### PR TITLE
Add selectAll to Sheet

### DIFF
--- a/src/spreadsheet/worksheet.ts
+++ b/src/spreadsheet/worksheet.ts
@@ -332,9 +332,11 @@ export class Worksheet {
       move('left', e.shiftKey, e.metaKey);
     } else if (e.key === 'ArrowRight') {
       move('right', e.shiftKey, e.metaKey);
-    }
-
-    if (e.key === 'Tab') {
+    } else if (e.key === 'a' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      await this.sheet!.selectAll();
+      this.render();
+    } else if (e.key === 'Tab') {
       e.preventDefault();
 
       this.sheet!.moveInRange(0, e.shiftKey ? -1 : 1);

--- a/src/worksheet/coordinates.ts
+++ b/src/worksheet/coordinates.ts
@@ -77,6 +77,14 @@ export function isRangeInRange(inner: Range, outer: Range): boolean {
 }
 
 /**
+ * `isCollapsedRange` returns whether the given Range is collapsed.
+ */
+export function isCollapsedRange(range: Range): boolean {
+  const [from, to] = range;
+  return from.r === to.r && from.c === to.c;
+}
+
+/**
  * `toRange` returns the range of the given Refs.
  * @param ref1
  * @param ref2
@@ -100,6 +108,69 @@ export function toRange(ref1: Ref, ref2: Ref): Range {
  */
 export function cloneRange(range: Range): Range {
   return [cloneRef(range[0]), cloneRef(range[1])];
+}
+
+/**
+ * `isSameRange` returns whether the given Ranges are the same.
+ */
+export function isSameRange(range1: Range, range2: Range): boolean {
+  return isSameRef(range1[0], range2[0]) && isSameRef(range1[1], range2[1]);
+}
+
+/**
+ * `toBorderRanges` returns the border ranges of the given range.
+ */
+export function toBorderRanges(range: Range, dimension: Range): Array<Range> {
+  const borders: Array<Range> = [];
+
+  if (range[0].r > dimension[0].r) {
+    borders.push([
+      { r: range[0].r - 1, c: range[0].c },
+      { r: range[0].r - 1, c: range[1].c },
+    ]);
+  }
+
+  if (range[1].r < dimension[1].r) {
+    borders.push([
+      { r: range[1].r + 1, c: range[0].c },
+      { r: range[1].r + 1, c: range[1].c },
+    ]);
+  }
+
+  if (range[0].c > dimension[0].c) {
+    borders.push([
+      { r: range[0].r, c: range[0].c - 1 },
+      { r: range[1].r, c: range[0].c - 1 },
+    ]);
+  }
+
+  if (range[1].c < dimension[1].c) {
+    borders.push([
+      { r: range[0].r, c: range[1].c + 1 },
+      { r: range[1].r, c: range[1].c + 1 },
+    ]);
+  }
+
+  return borders;
+}
+
+/**
+ * `mergeRanges` merges the given ranges into one range.
+ */
+export function mergeRanges(rangeA: Range, rangeB: Range): Range {
+  const [fromA, toA] = rangeA;
+  const [fromB, toB] = rangeB;
+
+  return [
+    {
+      r: Math.min(fromA.r, fromB.r),
+      c: Math.min(fromA.c, fromB.c),
+    },
+    {
+      r: Math.max(toA.r, toB.r),
+      c: Math.max(toA.c, toB.c),
+    },
+  ];
 }
 
 /**

--- a/test/sheet/coordinates.test.ts
+++ b/test/sheet/coordinates.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { parseRef, parseRange, toSrefs } from '../../src/worksheet/coordinates';
+import {
+  parseRef,
+  parseRange,
+  toSrefs,
+  toBorderRanges,
+} from '../../src/worksheet/coordinates';
+import { Range } from '../../src/worksheet/types';
 
 describe('parseRef', () => {
   it('should parse the Sref and return the Ref', () => {
@@ -45,5 +51,52 @@ describe('toSrefs', () => {
     expect(srefs.next().value).toEqual('B1');
     expect(srefs.next().value).toEqual('A2');
     expect(srefs.next().value).toEqual('B2');
+  });
+});
+
+describe('toBorderRanges', () => {
+  it('should return the border ranges for the given range', () => {
+    const range: Range = [
+      { r: 2, c: 2 },
+      { r: 3, c: 3 },
+    ];
+
+    const dimension: Range = [
+      { r: 1, c: 1 },
+      { r: 4, c: 4 },
+    ];
+
+    expect(toBorderRanges(range, dimension)).toEqual([
+      [
+        { r: 1, c: 2 },
+        { r: 1, c: 3 },
+      ],
+      [
+        { r: 4, c: 2 },
+        { r: 4, c: 3 },
+      ],
+      [
+        { r: 2, c: 1 },
+        { r: 3, c: 1 },
+      ],
+      [
+        { r: 2, c: 4 },
+        { r: 3, c: 4 },
+      ],
+    ]);
+  });
+
+  it('should exclude the border ranges that are outside the dimension', () => {
+    const range: Range = [
+      { r: 1, c: 1 },
+      { r: 1, c: 1 },
+    ];
+
+    const dimension: Range = [
+      { r: 1, c: 1 },
+      { r: 1, c: 1 },
+    ];
+
+    expect(toBorderRanges(range, dimension)).toEqual([]);
   });
 });

--- a/test/sheet/sheet.test.ts
+++ b/test/sheet/sheet.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Sheet } from '../../src/worksheet/sheet';
 
-describe('Sheet', () => {
+describe('Sheet.Data', () => {
   it('should correctly set and get data', async () => {
     const sheet = new Sheet();
     await sheet.setData({ r: 1, c: 1 }, '10');
@@ -12,7 +12,9 @@ describe('Sheet', () => {
     expect(await sheet.toInputString({ r: 1, c: 2 })).toBe('20');
     expect(await sheet.toInputString({ r: 1, c: 3 })).toBe('30');
   });
+});
 
+describe('Sheet.Selection', () => {
   it('should update selection', () => {
     const sheet = new Sheet();
     sheet.selectStart({ r: 1, c: 1 });
@@ -69,4 +71,39 @@ describe('Sheet', () => {
     await sheet.moveToEdge('right');
     expect(sheet.getActiveCell()).toEqual({ r: 1, c: 6 });
   });
+});
+
+describe('Sheet.SelectAll', async () => {
+  const sheet = new Sheet();
+  await sheet.setData({ r: 2, c: 2 }, 'B2');
+  await sheet.setData({ r: 2, c: 3 }, 'C2');
+  await sheet.setData({ r: 3, c: 2 }, 'B3');
+  await sheet.setData({ r: 3, c: 3 }, 'C3');
+
+  const tests = [
+    {
+      msg: 'selection is outside of the content range',
+      start: { r: 1, c: 1 },
+      end: { r: 1, c: 1 },
+      expectedRange: sheet.dimensionRange,
+    },
+    {
+      msg: 'selection is on the top left corner of the content range',
+      start: { r: 2, c: 2 },
+      end: { r: 2, c: 2 },
+      expectedRange: [
+        { r: 2, c: 2 },
+        { r: 3, c: 3 },
+      ],
+    },
+  ];
+
+  for (const test of tests) {
+    it(test.msg, async () => {
+      await sheet.selectStart(test.start);
+      await sheet.selectEnd(test.end);
+      await sheet.selectAll();
+      expect(sheet.getRange()).toEqual(test.expectedRange);
+    });
+  }
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### What this PR does / why we need it?

Add selectAll to Sheet

### Any background context you want to provide?

### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a keyboard shortcut for selecting all items in the worksheet using the 'a' key with meta/control keys.
	- Added new functions to enhance range operations, including checking collapsed ranges and merging ranges.
	- Enhanced the `Sheet` class with methods for checking range contents, retrieving active cell, and selecting all cells.

- **Bug Fixes**
	- Improved handling of range selection and content checks to ensure accurate functionality.

- **Tests**
	- Added new test cases for validating range functions and selection logic in the `Sheet` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->