### PR TITLE
Add image insertion with S3-compatible asset storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ The frontend depends on `@wafflebase/sheet` as a workspace dependency.
 
 ```bash
 pnpm install                # Install all dependencies
-docker compose up -d        # Start PostgreSQL + Yorkie server
+docker compose up -d        # Start PostgreSQL + Yorkie + MinIO
 pnpm dev                    # Start frontend (:5173) + backend (:3000)
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ pnpm run test
 
 #### Running
 
-Wafflebase depends on [Yorkie](https://yorkie.dev) and [Postgres](https://www.postgresql.org/). You can run them locally using Docker.
+Wafflebase depends on [Yorkie](https://yorkie.dev),
+[Postgres](https://www.postgresql.org/), and
+[MinIO](https://min.io/) (S3-compatible object storage for image uploads).
+You can run them locally using Docker.
 
 ```bash
 docker compose up -d

--- a/design/frontend.md
+++ b/design/frontend.md
@@ -110,10 +110,15 @@ It also exposes `Insert chart`, which creates a floating chart object from the
 current cell selection. Floating chart cards include a top-right context menu
 (`Edit chart`, `Delete chart`) and open a right-side chart editor panel for
 configuring chart type, data range, X-axis column, and visible series columns.
+It also exposes `Insert image`, which uploads an image file through the backend
+asset API and creates a floating image card anchored to the selected cell.
+Floating image cards include a top-right context menu (`Edit image`,
+`Delete image`) and open a right-side image editor panel for title, alt text,
+display fit mode, and replacement upload.
 Chart series colors are derived from theme tokens (`primary` with tonal
 variants), so they stay visually consistent across light and dark mode.
-Chart overlay/editor UI is lazy-loaded, and chart overlay render-version
-tracking is enabled only when the current tab actually has charts.
+Chart/image overlay and editor UI is lazy-loaded, and overlay render-version
+tracking is enabled only when the current tab actually has floating objects.
 
 A `didMount` ref guards against React 19 StrictMode double-mounting in
 development.
@@ -149,6 +154,20 @@ type SheetChart = {
   offsetY: number;       // px offset from anchor cell top
   width: number;         // px
   height: number;        // px
+};
+
+type SheetImage = {
+  id: string;
+  title?: string;
+  alt?: string;
+  key: string;           // object-storage key (resolved via backend API)
+  contentType: string;   // e.g. "image/png"
+  anchor: Sref;          // top-left anchor cell in current sheet
+  offsetX: number;       // px offset from anchor cell left
+  offsetY: number;       // px offset from anchor cell top
+  width: number;         // px
+  height: number;        // px
+  fit: 'cover' | 'contain';
 };
 
 type WorksheetFilterState = {
@@ -206,6 +225,7 @@ type Worksheet = {
   merges?: { [anchor: Sref]: { rs: number; cs: number } };
   filter?: WorksheetFilterState;
   charts?: { [id: string]: SheetChart };
+  images?: { [id: string]: SheetImage };
   frozenRows: number;
   frozenCols: number;
 };
@@ -219,13 +239,13 @@ type SpreadsheetDocument = {
 
 Tab metadata and sheet data are synced via Yorkie. Datasource query results
 are fetched from the backend on demand and displayed using `ReadOnlyStore`.
-Chart objects are stored in each worksheet and rendered as floating DOM cards
-above the sheet canvas. Chart geometry and editor fields are updated through
-`doc.update()` so chart edits are collaborative in real time. Rendering is
-clipped to the unfrozen scrollable quadrant, so charts are hidden underneath
-frozen rows/columns. Chart anchor layout also uses scrollable-quadrant
-coordinates, so charts continue moving with scroll even if their anchor refs
-fall inside frozen rows/columns.
+Chart and image objects are stored in each worksheet and rendered as floating
+DOM cards above the sheet canvas. Object geometry and editor fields are
+updated through `doc.update()` so floating-object edits are collaborative in
+real time. Rendering is clipped to the unfrozen scrollable quadrant, so
+floating objects are hidden underneath frozen rows/columns. Anchor layout also
+uses scrollable-quadrant coordinates, so objects continue moving with scroll
+even if their anchor refs fall inside frozen rows/columns.
 
 **Migration:** Old documents (flat `Worksheet` format with `root.sheet`) are
 automatically migrated to the new `SpreadsheetDocument` structure on load,
@@ -247,8 +267,8 @@ all reads/writes to `root.sheets[tabId]`. Each store method maps to a Yorkie
 | `setGrid(grid)` | Batch write to `root.sheet` |
 | `getGrid(range)` | Use CellIndex to iterate only populated cells in range |
 | `findEdge(ref, direction, dimension)` | Delegate to `findEdgeWithIndex` using CellIndex |
-| `shiftCells(axis, index, count)` | Remap sheet refs/formulas in place (delete removed keys, upsert remapped keys); also remap chart anchors and conditional-format ranges |
-| `moveCells(axis, src, count, dst)` | Remap sheet refs/formulas in place (delete removed keys, upsert remapped keys); also remap chart anchors and conditional-format ranges |
+| `shiftCells(axis, index, count)` | Remap sheet refs/formulas in place (delete removed keys, upsert remapped keys); also remap chart/image anchors and conditional-format ranges |
+| `moveCells(axis, src, count, dst)` | Remap sheet refs/formulas in place (delete removed keys, upsert remapped keys); also remap chart/image anchors and conditional-format ranges |
 | `setDimensionSize(axis, index, size)` | Write to `root.rowHeights` or `root.colWidths` |
 | `getDimensionSizes(axis)` | Read from `root.rowHeights` or `root.colWidths` |
 | `addRangeStyle(patch)` | Append to `root.sheets[tabId].rangeStyles` |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,3 +17,18 @@ services:
     ports:
       - "8080:8080"
       - "8081:8081"
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+
+volumes:
+  minio-data:

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { AuthModule } from './auth/auth.module';
 import { DocumentModule } from './document/document.module';
 import { ShareLinkModule } from './share-link/share-link.module';
 import { DataSourceModule } from './datasource/datasource.module';
+import { AssetModule } from './asset/asset.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { DataSourceModule } from './datasource/datasource.module';
     DocumentModule,
     ShareLinkModule,
     DataSourceModule,
+    AssetModule,
   ],
   controllers: [],
   providers: [],

--- a/packages/backend/src/asset/asset.controller.ts
+++ b/packages/backend/src/asset/asset.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Res,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Response } from 'express';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { AssetService, ImageUploadFile } from './asset.service';
+
+const MAX_IMAGE_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+@Controller('assets')
+export class AssetController {
+  constructor(private readonly assetService: AssetService) {}
+
+  @Post('images')
+  @UseGuards(JwtAuthGuard)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: {
+        fileSize: MAX_IMAGE_UPLOAD_BYTES,
+      },
+    }),
+  )
+  async uploadImage(@UploadedFile() file: ImageUploadFile) {
+    return this.assetService.uploadImage(file);
+  }
+
+  @Get('images/:key')
+  async getImage(@Param('key') key: string, @Res() res: Response): Promise<void> {
+    const image = await this.assetService.getImage(key);
+    res.setHeader('Content-Type', image.contentType);
+    res.setHeader('Cache-Control', image.cacheControl);
+    if (image.contentLength !== undefined) {
+      res.setHeader('Content-Length', String(image.contentLength));
+    }
+    image.body.pipe(res);
+  }
+}

--- a/packages/backend/src/asset/asset.module.ts
+++ b/packages/backend/src/asset/asset.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AssetController } from './asset.controller';
+import { AssetService } from './asset.service';
+
+@Module({
+  controllers: [AssetController],
+  providers: [AssetService],
+  exports: [AssetService],
+})
+export class AssetModule {}

--- a/packages/backend/src/asset/asset.service.spec.ts
+++ b/packages/backend/src/asset/asset.service.spec.ts
@@ -1,0 +1,105 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AssetService, ImageUploadFile } from './asset.service';
+
+describe('AssetService', () => {
+  let fetchMock: jest.Mock;
+
+  const config = new ConfigService({
+    ASSET_STORAGE_BUCKET: 'wafflebase-assets-test',
+    ASSET_STORAGE_REGION: 'us-east-1',
+    ASSET_STORAGE_ENDPOINT: 'http://localhost:9000',
+    ASSET_STORAGE_FORCE_PATH_STYLE: 'true',
+    ASSET_STORAGE_ACCESS_KEY: 'minioadmin',
+    ASSET_STORAGE_SECRET_KEY: 'minioadmin',
+  });
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    (global as unknown as { fetch: jest.Mock }).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rejects unsupported image mime types', async () => {
+    const service = new AssetService(config);
+
+    await expect(
+      service.uploadImage({
+        mimetype: 'application/pdf',
+        size: 12,
+        buffer: Buffer.from('test'),
+      } as ImageUploadFile),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('uploads allowed image types to object storage', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 200 }));
+    const service = new AssetService(config);
+
+    const uploaded = await service.uploadImage({
+      mimetype: 'image/png',
+      size: 128,
+      buffer: Buffer.from('png-data'),
+    } as ImageUploadFile);
+
+    expect(uploaded.contentType).toBe('image/png');
+    expect(uploaded.size).toBe(128);
+    expect(uploaded.key).toMatch(/^[0-9a-f-]+\.png$/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [
+      URL | string,
+      RequestInit,
+    ];
+    expect(String(requestUrl)).toContain('wafflebase-assets-test');
+    expect(requestInit.method).toBe('PUT');
+  });
+
+  it('throws not found when object does not exist', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 404 }));
+    const service = new AssetService(config);
+
+    await expect(service.getImage('missing.png')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('returns object stream metadata', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('hello', {
+        status: 200,
+        headers: {
+          'content-type': 'image/webp',
+          'cache-control': 'public, max-age=60',
+          'content-length': '5',
+        },
+      }),
+    );
+
+    const service = new AssetService(config);
+    const result = await service.getImage('demo.webp');
+    const chunks: Buffer[] = [];
+    for await (const chunk of result.body) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+
+    expect(result.contentType).toBe('image/webp');
+    expect(result.cacheControl).toBe('public, max-age=60');
+    expect(result.contentLength).toBe(5);
+    expect(Buffer.concat(chunks).toString('utf8')).toBe('hello');
+  });
+
+  it('rejects invalid object keys', async () => {
+    const service = new AssetService(config);
+
+    await expect(service.getImage('../invalid-key')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/asset/asset.service.ts
+++ b/packages/backend/src/asset/asset.service.ts
@@ -1,0 +1,450 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash, createHmac, randomUUID } from 'crypto';
+import { Readable } from 'stream';
+
+const MAX_IMAGE_UPLOAD_BYTES = 10 * 1024 * 1024;
+const DEFAULT_BUCKET_NAME = 'wafflebase-assets';
+const DEFAULT_REGION = 'us-east-1';
+const IMAGE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+const ASSET_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const IMAGE_MIME_TO_EXTENSION: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'image/avif': '.avif',
+};
+const EMPTY_PAYLOAD_HASH = sha256Hex('');
+
+type RequestTarget = {
+  url: URL;
+  host: string;
+  canonicalUri: string;
+};
+
+export type UploadedImageAsset = {
+  key: string;
+  contentType: string;
+  size: number;
+};
+
+export type ImageUploadFile = {
+  mimetype: string;
+  size: number;
+  buffer: Buffer;
+  originalname?: string;
+};
+
+export type StoredImageObject = {
+  body: Readable;
+  contentType: string;
+  cacheControl: string;
+  contentLength?: number;
+};
+
+@Injectable()
+export class AssetService implements OnModuleInit {
+  private readonly logger = new Logger(AssetService.name);
+  private readonly bucket: string;
+  private readonly region: string;
+  private readonly endpoint: URL | null;
+  private readonly forcePathStyle: boolean;
+  private readonly accessKeyId: string;
+  private readonly secretAccessKey: string;
+  private readonly sessionToken?: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.bucket =
+      this.configService.get<string>('ASSET_STORAGE_BUCKET') ||
+      DEFAULT_BUCKET_NAME;
+    this.region =
+      this.configService.get<string>('ASSET_STORAGE_REGION') || DEFAULT_REGION;
+
+    const endpoint = this.configService.get<string>('ASSET_STORAGE_ENDPOINT');
+    this.endpoint = endpoint ? new URL(endpoint) : null;
+
+    const forcePathStyleFromEnv = this.getBooleanEnv(
+      'ASSET_STORAGE_FORCE_PATH_STYLE',
+    );
+    this.forcePathStyle =
+      forcePathStyleFromEnv !== undefined
+        ? forcePathStyleFromEnv
+        : this.endpoint !== null;
+
+    const accessKeyId = this.configService.get<string>('ASSET_STORAGE_ACCESS_KEY');
+    const secretAccessKey = this.configService.get<string>(
+      'ASSET_STORAGE_SECRET_KEY',
+    );
+    if (!accessKeyId || !secretAccessKey) {
+      throw new Error(
+        'ASSET_STORAGE_ACCESS_KEY and ASSET_STORAGE_SECRET_KEY are required',
+      );
+    }
+
+    this.accessKeyId = accessKeyId;
+    this.secretAccessKey = secretAccessKey;
+    this.sessionToken =
+      this.configService.get<string>('ASSET_STORAGE_SESSION_TOKEN') || undefined;
+  }
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.ensureBucketExists();
+    } catch (error) {
+      this.logger.warn(
+        'Skipping asset bucket verification during startup. Upload attempts may fail until storage is reachable.',
+      );
+      this.logger.debug((error as Error).message);
+    }
+  }
+
+  async uploadImage(file: ImageUploadFile): Promise<UploadedImageAsset> {
+    if (!file) {
+      throw new BadRequestException('Image file is required');
+    }
+
+    if (!this.isAllowedImageMimeType(file.mimetype)) {
+      throw new BadRequestException(
+        'Only JPEG, PNG, GIF, WEBP, and AVIF images are supported',
+      );
+    }
+
+    if (file.size <= 0) {
+      throw new BadRequestException('Image file is empty');
+    }
+
+    if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
+      throw new BadRequestException('Image must be 10MB or smaller');
+    }
+
+    if (!file.buffer) {
+      throw new InternalServerErrorException('Image buffer was not provided');
+    }
+
+    const key = this.buildImageKey(file.mimetype);
+
+    const response = await this.sendSignedRequest({
+      method: 'PUT',
+      key,
+      body: file.buffer,
+      contentType: file.mimetype,
+      cacheControl: IMAGE_CACHE_CONTROL,
+    });
+
+    if (response.status !== 200) {
+      const detail = await safeReadText(response);
+      this.logger.error(`Failed to upload image: ${response.status} ${detail}`);
+      throw new InternalServerErrorException('Failed to upload image');
+    }
+
+    return {
+      key,
+      contentType: file.mimetype,
+      size: file.size,
+    };
+  }
+
+  async getImage(key: string): Promise<StoredImageObject> {
+    if (!ASSET_KEY_PATTERN.test(key)) {
+      throw new BadRequestException('Invalid asset key');
+    }
+
+    const response = await this.sendSignedRequest({
+      method: 'GET',
+      key,
+    });
+
+    if (response.status === 404) {
+      throw new NotFoundException('Image not found');
+    }
+
+    if (response.status !== 200) {
+      const detail = await safeReadText(response);
+      this.logger.error(`Failed to fetch image: ${response.status} ${detail}`);
+      throw new InternalServerErrorException('Failed to fetch image');
+    }
+
+    const bytes = Buffer.from(await response.arrayBuffer());
+    const contentLengthHeader = response.headers.get('content-length');
+    const parsedLength = contentLengthHeader
+      ? Number(contentLengthHeader)
+      : undefined;
+
+    return {
+      body: Readable.from(bytes),
+      contentType:
+        response.headers.get('content-type') || 'application/octet-stream',
+      cacheControl:
+        response.headers.get('cache-control') || IMAGE_CACHE_CONTROL,
+      contentLength:
+        parsedLength !== undefined && Number.isFinite(parsedLength)
+          ? parsedLength
+          : undefined,
+    };
+  }
+
+  private async ensureBucketExists(): Promise<void> {
+    const headResponse = await this.sendSignedRequest({
+      method: 'HEAD',
+      key: null,
+    });
+
+    if (headResponse.status === 200) {
+      return;
+    }
+
+    if (headResponse.status !== 404) {
+      const detail = await safeReadText(headResponse);
+      this.logger.warn(
+        `Could not verify bucket "${this.bucket}" (${headResponse.status} ${detail}). Upload attempts may fail.`,
+      );
+      return;
+    }
+
+    const createResponse = await this.sendSignedRequest({
+      method: 'PUT',
+      key: null,
+      body:
+        this.region === DEFAULT_REGION
+          ? undefined
+          : buildCreateBucketXml(this.region),
+      contentType: 'application/xml',
+    });
+
+    if (createResponse.status >= 200 && createResponse.status < 300) {
+      this.logger.log(`Created asset bucket "${this.bucket}"`);
+      return;
+    }
+
+    if (createResponse.status === 409) {
+      return;
+    }
+
+    const detail = await safeReadText(createResponse);
+    this.logger.warn(
+      `Failed to create asset bucket "${this.bucket}" (${createResponse.status} ${detail}). Upload attempts may fail.`,
+    );
+  }
+
+  private async sendSignedRequest({
+    method,
+    key,
+    body,
+    contentType,
+    cacheControl,
+  }: {
+    method: 'GET' | 'PUT' | 'HEAD';
+    key: string | null;
+    body?: Buffer | string;
+    contentType?: string;
+    cacheControl?: string;
+  }): Promise<Response> {
+    const target = this.buildRequestTarget(key);
+    const payloadHash = body === undefined ? EMPTY_PAYLOAD_HASH : sha256Hex(body);
+
+    const signed = this.buildSignedHeaders({
+      method,
+      target,
+      payloadHash,
+      contentType,
+      cacheControl,
+    });
+
+    try {
+      return await fetch(target.url, {
+        method,
+        headers: signed,
+        body,
+      });
+    } catch (error) {
+      this.logger.error('Asset storage request failed', error as Error);
+      throw new InternalServerErrorException('Asset storage request failed');
+    }
+  }
+
+  private buildRequestTarget(key: string | null): RequestTarget {
+    if (this.endpoint) {
+      const baseHost = this.endpoint.host;
+      const host = this.forcePathStyle
+        ? baseHost
+        : `${this.bucket}.${baseHost}`;
+      const pathParts = this.forcePathStyle ? [this.bucket] : [];
+      if (key) {
+        pathParts.push(key);
+      }
+      const canonicalUri = buildCanonicalUri(pathParts);
+      const url = new URL(canonicalUri, `${this.endpoint.protocol}//${host}`);
+      return { url, host, canonicalUri };
+    }
+
+    const baseHost =
+      this.region === DEFAULT_REGION
+        ? 's3.amazonaws.com'
+        : `s3.${this.region}.amazonaws.com`;
+    const host = this.forcePathStyle ? baseHost : `${this.bucket}.${baseHost}`;
+    const pathParts = this.forcePathStyle ? [this.bucket] : [];
+    if (key) {
+      pathParts.push(key);
+    }
+    const canonicalUri = buildCanonicalUri(pathParts);
+    const url = new URL(`https://${host}${canonicalUri}`);
+    return { url, host, canonicalUri };
+  }
+
+  private buildSignedHeaders({
+    method,
+    target,
+    payloadHash,
+    contentType,
+    cacheControl,
+  }: {
+    method: 'GET' | 'PUT' | 'HEAD';
+    target: RequestTarget;
+    payloadHash: string;
+    contentType?: string;
+    cacheControl?: string;
+  }): Record<string, string> {
+    const now = new Date();
+    const amzDate = formatAmzDate(now);
+    const dateStamp = formatDateStamp(now);
+    const scope = `${dateStamp}/${this.region}/s3/aws4_request`;
+
+    const canonicalHeaders: Record<string, string> = {
+      host: target.host,
+      'x-amz-content-sha256': payloadHash,
+      'x-amz-date': amzDate,
+    };
+
+    if (contentType) {
+      canonicalHeaders['content-type'] = contentType;
+    }
+
+    if (cacheControl) {
+      canonicalHeaders['cache-control'] = cacheControl;
+    }
+
+    if (this.sessionToken) {
+      canonicalHeaders['x-amz-security-token'] = this.sessionToken;
+    }
+
+    const sortedHeaderNames = Object.keys(canonicalHeaders).sort();
+    const canonicalHeaderString = sortedHeaderNames
+      .map((name) => `${name}:${canonicalHeaders[name].trim()}\n`)
+      .join('');
+    const signedHeaders = sortedHeaderNames.join(';');
+
+    const canonicalRequest = [
+      method,
+      target.canonicalUri,
+      '',
+      canonicalHeaderString,
+      signedHeaders,
+      payloadHash,
+    ].join('\n');
+
+    const stringToSign = [
+      'AWS4-HMAC-SHA256',
+      amzDate,
+      scope,
+      sha256Hex(canonicalRequest),
+    ].join('\n');
+
+    const signingKey = this.getSigningKey(dateStamp);
+    const signature = hmacHex(signingKey, stringToSign);
+
+    return {
+      ...canonicalHeaders,
+      Authorization: `AWS4-HMAC-SHA256 Credential=${this.accessKeyId}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    };
+  }
+
+  private getSigningKey(dateStamp: string): Buffer {
+    const kDate = hmacBuffer(`AWS4${this.secretAccessKey}`, dateStamp);
+    const kRegion = hmacBuffer(kDate, this.region);
+    const kService = hmacBuffer(kRegion, 's3');
+    return hmacBuffer(kService, 'aws4_request');
+  }
+
+  private buildImageKey(mimeType: string): string {
+    const extension = IMAGE_MIME_TO_EXTENSION[mimeType] || '.bin';
+    return `${randomUUID()}${extension}`;
+  }
+
+  private isAllowedImageMimeType(mimeType: string): boolean {
+    return IMAGE_MIME_TO_EXTENSION[mimeType] !== undefined;
+  }
+
+  private getBooleanEnv(name: string): boolean | undefined {
+    const raw = this.configService.get<string>(name);
+    if (raw === undefined || raw === '') {
+      return undefined;
+    }
+    return raw.trim().toLowerCase() === 'true';
+  }
+}
+
+function buildCanonicalUri(parts: string[]): string {
+  const encoded = parts.map((part) =>
+    part
+      .split('/')
+      .map((segment) => encodeRfc3986(segment))
+      .join('/'),
+  );
+  return `/${encoded.join('/')}`;
+}
+
+function encodeRfc3986(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function formatAmzDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+  return `${year}${month}${day}T${hours}${minutes}${seconds}Z`;
+}
+
+function formatDateStamp(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}${month}${day}`;
+}
+
+function sha256Hex(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hmacBuffer(key: string | Buffer, value: string): Buffer {
+  return createHmac('sha256', key).update(value).digest();
+}
+
+function hmacHex(key: string | Buffer, value: string): string {
+  return createHmac('sha256', key).update(value).digest('hex');
+}
+
+function buildCreateBucketXml(region: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?><CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LocationConstraint>${region}</LocationConstraint></CreateBucketConfiguration>`;
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -32,7 +32,7 @@ VITE_YORKIE_API_KEY=              # Yorkie server API key
 ```bash
 # From the monorepo root:
 pnpm install
-docker compose up -d          # Start PostgreSQL + Yorkie
+docker compose up -d          # Start PostgreSQL + Yorkie + MinIO
 pnpm dev                      # Starts frontend (:5173) + backend (:3000)
 
 # Or run the frontend only:
@@ -72,7 +72,8 @@ src/
 │   └── settings/page.tsx     # Settings page
 ├── api/
 │   ├── auth.ts               # fetchMe(), logout(), fetchWithAuth()
-│   └── documents.ts          # CRUD operations for documents
+│   ├── documents.ts          # CRUD operations for documents
+│   └── image-assets.ts       # Image upload API
 ├── components/
 │   ├── ui/                   # Radix UI + Tailwind components (23 components)
 │   ├── app-sidebar.tsx       # Navigation sidebar
@@ -105,6 +106,13 @@ src/
 ### Real-time Collaboration
 
 The `YorkieStore` class implements the `Store` interface from `@wafflebase/sheet`, persisting all cell data, row heights, and column widths to a Yorkie CRDT document. Changes sync automatically across all connected clients.
+
+### Floating Objects
+
+`SheetView` supports floating chart cards and floating image cards above the
+canvas grid. Images are uploaded through the backend (`/assets/images`) and
+stored in object storage (S3-compatible), while chart/image position and size
+are synced through Yorkie so all collaborators see the same layout.
 
 ### Presence
 

--- a/packages/frontend/src/api/image-assets.ts
+++ b/packages/frontend/src/api/image-assets.ts
@@ -1,0 +1,37 @@
+import { fetchWithAuth } from "./auth";
+
+export type UploadedImageAsset = {
+  key: string;
+  contentType: string;
+  size: number;
+};
+
+/**
+ * Uploads an image file to the backend object storage.
+ */
+export async function uploadImageAsset(file: File): Promise<UploadedImageAsset> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await fetchWithAuth(
+    `${import.meta.env.VITE_BACKEND_API_URL}/assets/images`,
+    {
+      method: "POST",
+      body: formData,
+    },
+  );
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    const message =
+      payload &&
+      typeof payload === "object" &&
+      "message" in payload &&
+      typeof payload.message === "string"
+        ? payload.message
+        : "Failed to upload image";
+    throw new Error(message);
+  }
+
+  return response.json();
+}

--- a/packages/frontend/src/app/documents/document-detail.tsx
+++ b/packages/frontend/src/app/documents/document-detail.tsx
@@ -113,6 +113,7 @@ function migrateDocument(
         conditionalFormats: [],
         merges: (r as Record<string, unknown>).merges || {},
         charts: {},
+        images: {},
         frozenRows: r.frozenRows || 0,
         frozenCols: r.frozenCols || 0,
       },
@@ -237,6 +238,7 @@ function DocumentLayout({ documentId }: { documentId: string }) {
         conditionalFormats: [],
         merges: {},
         charts: {},
+        images: {},
         frozenRows: 0,
         frozenCols: 0,
       } as Worksheet;

--- a/packages/frontend/src/app/spreadsheet/image-editor-panel.tsx
+++ b/packages/frontend/src/app/spreadsheet/image-editor-panel.tsx
@@ -1,0 +1,170 @@
+import { ChangeEvent, useRef, useState } from "react";
+import { toast } from "sonner";
+import { IconPhoto, IconUpload, IconX } from "@tabler/icons-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SheetImage } from "@/types/worksheet";
+
+type ImageEditorPanelProps = {
+  image: SheetImage | undefined;
+  open: boolean;
+  onClose: () => void;
+  onUpdateImage: (imageId: string, patch: Partial<SheetImage>) => void;
+  onReplaceImage: (imageId: string, file: File) => Promise<void>;
+};
+
+/**
+ * Renders the ImageEditorPanel component.
+ */
+export function ImageEditorPanel({
+  image,
+  open,
+  onClose,
+  onUpdateImage,
+  onReplaceImage,
+}: ImageEditorPanelProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  if (!open || !image) {
+    return null;
+  }
+
+  const handleClickReplace = () => {
+    if (uploading) return;
+    fileInputRef.current?.click();
+  };
+
+  const handleReplaceChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const nextFile = event.target.files?.[0];
+    event.target.value = "";
+    if (!nextFile) return;
+
+    if (!nextFile.type.startsWith("image/")) {
+      toast.error("Select a valid image file.");
+      return;
+    }
+
+    setUploading(true);
+    try {
+      await onReplaceImage(image.id, nextFile);
+      toast.success("Image replaced.");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to replace image.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <aside className="absolute inset-y-0 right-0 z-20 flex w-80 flex-col overflow-hidden border-l bg-background shadow-lg">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <IconPhoto size={16} className="text-primary" />
+            <p className="text-sm font-semibold">Image editor</p>
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            Key: {image.key}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+          onClick={onClose}
+          aria-label="Close image editor"
+        >
+          <IconX size={16} />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain p-4 pb-6">
+        <section className="space-y-2">
+          <Label htmlFor="image-title">Image title</Label>
+          <Input
+            id="image-title"
+            value={image.title || ""}
+            onChange={(event) =>
+              onUpdateImage(image.id, {
+                title: event.target.value,
+              })
+            }
+            placeholder="Image"
+          />
+        </section>
+
+        <Separator />
+
+        <section className="space-y-2">
+          <Label htmlFor="image-alt-text">Alt text</Label>
+          <Input
+            id="image-alt-text"
+            value={image.alt || ""}
+            onChange={(event) =>
+              onUpdateImage(image.id, {
+                alt: event.target.value,
+              })
+            }
+            placeholder="Describe the image"
+          />
+        </section>
+
+        <Separator />
+
+        <section className="space-y-2">
+          <Label htmlFor="image-fit-mode">Fit mode</Label>
+          <Select
+            value={image.fit}
+            onValueChange={(value) => {
+              onUpdateImage(image.id, {
+                fit: value as SheetImage["fit"],
+              });
+            }}
+          >
+            <SelectTrigger id="image-fit-mode" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="cover">Fill frame (cover)</SelectItem>
+              <SelectItem value="contain">Fit inside (contain)</SelectItem>
+            </SelectContent>
+          </Select>
+        </section>
+
+        <Separator />
+
+        <section className="space-y-2">
+          <Label>Image file</Label>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(event) => {
+              void handleReplaceChange(event);
+            }}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={handleClickReplace}
+            disabled={uploading}
+          >
+            <IconUpload size={14} className="mr-2" />
+            {uploading ? "Uploading..." : "Replace image"}
+          </Button>
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/packages/frontend/src/app/spreadsheet/image-object-layer.tsx
+++ b/packages/frontend/src/app/spreadsheet/image-object-layer.tsx
@@ -1,0 +1,370 @@
+import {
+  type PointerEvent as ReactPointerEvent,
+  useEffect,
+  useState,
+} from "react";
+import { parseRef, Spreadsheet } from "@wafflebase/sheet";
+import { SheetImage, SpreadsheetDocument } from "@/types/worksheet";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  IconDotsVertical,
+  IconPencil,
+  IconPhoto,
+  IconTrash,
+} from "@tabler/icons-react";
+
+type ImageObjectLayerProps = {
+  spreadsheet: Spreadsheet | undefined;
+  root: SpreadsheetDocument;
+  tabId: string;
+  readOnly: boolean;
+  selectedImageId: string | null;
+  onSelectImage: (imageId: string) => void;
+  onRequestEditImage: (imageId: string) => void;
+  onDeleteImage: (imageId: string) => void;
+  onUpdateImage: (imageId: string, patch: Partial<SheetImage>) => void;
+  renderVersion: number;
+};
+
+type DraftLayout = {
+  offsetX: number;
+  offsetY: number;
+  width: number;
+  height: number;
+};
+
+type DragState = {
+  imageId: string;
+  mode: "move" | "resize";
+  startX: number;
+  startY: number;
+  startOffsetX: number;
+  startOffsetY: number;
+  startWidth: number;
+  startHeight: number;
+};
+
+const MIN_IMAGE_WIDTH = 160;
+const MIN_IMAGE_HEIGHT = 120;
+
+/**
+ * Renders the ImageObjectLayer component.
+ */
+export function ImageObjectLayer({
+  spreadsheet,
+  root,
+  tabId,
+  readOnly,
+  selectedImageId,
+  onSelectImage,
+  onRequestEditImage,
+  onDeleteImage,
+  onUpdateImage,
+  renderVersion,
+}: ImageObjectLayerProps) {
+  const [dragState, setDragState] = useState<DragState | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, DraftLayout>>({});
+
+  const images = Object.values(root.sheets[tabId]?.images || {});
+
+  useEffect(() => {
+    if (!dragState || readOnly) return;
+
+    let latestX = dragState.startX;
+    let latestY = dragState.startY;
+
+    const toDraft = (clientX: number, clientY: number): DraftLayout => {
+      const deltaX = clientX - dragState.startX;
+      const deltaY = clientY - dragState.startY;
+
+      if (dragState.mode === "move") {
+        return {
+          offsetX: dragState.startOffsetX + deltaX,
+          offsetY: dragState.startOffsetY + deltaY,
+          width: dragState.startWidth,
+          height: dragState.startHeight,
+        };
+      }
+
+      return {
+        offsetX: dragState.startOffsetX,
+        offsetY: dragState.startOffsetY,
+        width: Math.max(MIN_IMAGE_WIDTH, dragState.startWidth + deltaX),
+        height: Math.max(MIN_IMAGE_HEIGHT, dragState.startHeight + deltaY),
+      };
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      latestX = event.clientX;
+      latestY = event.clientY;
+      const nextDraft = toDraft(latestX, latestY);
+      setDrafts((prev) => ({
+        ...prev,
+        [dragState.imageId]: nextDraft,
+      }));
+    };
+
+    const onPointerUp = () => {
+      const nextDraft = toDraft(latestX, latestY);
+      onUpdateImage(dragState.imageId, nextDraft);
+      setDrafts((prev) => {
+        const remaining = { ...prev };
+        delete remaining[dragState.imageId];
+        return remaining;
+      });
+      setDragState(null);
+    };
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+    };
+  }, [dragState, onUpdateImage, readOnly]);
+
+  if (!spreadsheet || images.length === 0) {
+    return null;
+  }
+
+  const viewport = spreadsheet.getGridViewportRect();
+  const scrollableViewport = spreadsheet.getScrollableGridViewportRect();
+  const clipLeft = Math.max(0, scrollableViewport.left - viewport.left);
+  const clipTop = Math.max(0, scrollableViewport.top - viewport.top);
+  const clipWidth = Math.max(0, scrollableViewport.width);
+  const clipHeight = Math.max(0, scrollableViewport.height);
+
+  if (clipWidth === 0 || clipHeight === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="absolute pointer-events-none overflow-hidden"
+      data-render-version={renderVersion}
+      style={{
+        left: viewport.left,
+        top: viewport.top,
+        width: viewport.width,
+        height: viewport.height,
+        zIndex: 6,
+      }}
+    >
+      <div
+        className="absolute pointer-events-none overflow-hidden"
+        style={{
+          left: clipLeft,
+          top: clipTop,
+          width: clipWidth,
+          height: clipHeight,
+        }}
+      >
+        <div
+          className="relative h-full w-full pointer-events-none"
+          style={{
+            left: -clipLeft,
+            top: -clipTop,
+            width: viewport.width,
+            height: viewport.height,
+          }}
+        >
+          {images.map((image) => {
+            const layout = drafts[image.id] || {
+              offsetX: image.offsetX,
+              offsetY: image.offsetY,
+              width: image.width,
+              height: image.height,
+            };
+            return (
+              <ImageObject
+                key={image.id}
+                image={image}
+                spreadsheet={spreadsheet}
+                selected={selectedImageId === image.id}
+                readOnly={readOnly}
+                layout={layout}
+                onSelect={() => onSelectImage(image.id)}
+                onRequestEdit={() => onRequestEditImage(image.id)}
+                onDelete={() => onDeleteImage(image.id)}
+                onMoveStart={(event) => {
+                  onSelectImage(image.id);
+                  setDragState({
+                    imageId: image.id,
+                    mode: "move",
+                    startX: event.clientX,
+                    startY: event.clientY,
+                    startOffsetX: layout.offsetX,
+                    startOffsetY: layout.offsetY,
+                    startWidth: layout.width,
+                    startHeight: layout.height,
+                  });
+                }}
+                onResizeStart={(event) => {
+                  onSelectImage(image.id);
+                  setDragState({
+                    imageId: image.id,
+                    mode: "resize",
+                    startX: event.clientX,
+                    startY: event.clientY,
+                    startOffsetX: layout.offsetX,
+                    startOffsetY: layout.offsetY,
+                    startWidth: layout.width,
+                    startHeight: layout.height,
+                  });
+                }}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ImageObject({
+  image,
+  spreadsheet,
+  selected,
+  readOnly,
+  layout,
+  onSelect,
+  onRequestEdit,
+  onDelete,
+  onMoveStart,
+  onResizeStart,
+}: {
+  image: SheetImage;
+  spreadsheet: Spreadsheet;
+  selected: boolean;
+  readOnly: boolean;
+  layout: DraftLayout;
+  onSelect: () => void;
+  onRequestEdit: () => void;
+  onDelete: () => void;
+  onMoveStart: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  onResizeStart: (event: ReactPointerEvent<HTMLDivElement>) => void;
+}) {
+  const [loadFailed, setLoadFailed] = useState(false);
+  const imageUrl = `${import.meta.env.VITE_BACKEND_API_URL}/assets/images/${encodeURIComponent(image.key)}`;
+  useEffect(() => {
+    setLoadFailed(false);
+  }, [imageUrl]);
+
+  let anchorRect;
+  try {
+    anchorRect = spreadsheet.getCellRectInScrollableViewport(parseRef(image.anchor));
+  } catch {
+    return null;
+  }
+  const left = anchorRect.left + layout.offsetX;
+  const top = anchorRect.top + layout.offsetY;
+  const fitMode = image.fit === "contain" ? "contain" : "cover";
+
+  return (
+    <div
+      className="pointer-events-auto absolute flex flex-col rounded-md border bg-background shadow-md"
+      style={{
+        left,
+        top,
+        width: layout.width,
+        height: layout.height,
+        borderColor: selected ? "var(--color-primary)" : undefined,
+      }}
+      onPointerDown={(event) => {
+        event.stopPropagation();
+        onSelect();
+      }}
+    >
+      <div className="flex shrink-0 items-center justify-between border-b px-2 py-1 text-xs font-medium">
+        <div
+          className={`min-w-0 flex-1 ${readOnly ? "" : "cursor-move"}`}
+          onPointerDown={(event) => {
+            if (readOnly) return;
+            event.preventDefault();
+            event.stopPropagation();
+            onMoveStart(event);
+          }}
+        >
+          <span className="truncate">{image.title || "Image"}</span>
+        </div>
+        {!readOnly && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="ml-1 inline-flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+                onPointerDown={(event) => {
+                  event.stopPropagation();
+                }}
+                onClick={(event) => {
+                  event.stopPropagation();
+                }}
+                aria-label="Open image menu"
+              >
+                <IconDotsVertical size={14} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              onPointerDown={(event) => {
+                event.stopPropagation();
+              }}
+            >
+              <DropdownMenuItem
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRequestEdit();
+                }}
+              >
+                <IconPencil size={14} />
+                Edit image
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                variant="destructive"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDelete();
+                }}
+              >
+                <IconTrash size={14} />
+                Delete image
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+      <div className="relative min-h-0 flex-1 bg-muted/30">
+        {loadFailed ? (
+          <div className="flex h-full w-full items-center justify-center gap-2 text-xs text-muted-foreground">
+            <IconPhoto size={16} />
+            Failed to load image
+          </div>
+        ) : (
+          <img
+            src={imageUrl}
+            alt={image.alt || image.title || "Sheet image"}
+            className="h-full w-full select-none"
+            style={{ objectFit: fitMode }}
+            draggable={false}
+            onError={() => setLoadFailed(true)}
+          />
+        )}
+        {!readOnly && selected && (
+          <div
+            className="absolute bottom-0 right-0 h-3 w-3 cursor-se-resize rounded-tl border-l border-t bg-background"
+            onPointerDown={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onResizeStart(event);
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/formatting-toolbar.tsx
+++ b/packages/frontend/src/components/formatting-toolbar.tsx
@@ -53,6 +53,7 @@ import {
   IconFilter,
   IconMathFunction,
   IconChartBar,
+  IconPhoto,
   IconBorderAll,
   IconBorderOuter,
   IconBorderInner,
@@ -94,6 +95,7 @@ const modKey = isMac ? "⌘" : "Ctrl";
 interface FormattingToolbarProps {
   spreadsheet: Spreadsheet | undefined;
   onInsertChart?: () => void;
+  onInsertImage?: () => void;
   onOpenConditionalFormat?: () => void;
   onTogglePaintFormat?: () => void;
   paintFormatActive?: boolean;
@@ -105,6 +107,7 @@ interface FormattingToolbarProps {
 export function FormattingToolbar({
   spreadsheet,
   onInsertChart,
+  onInsertImage,
   onOpenConditionalFormat,
   onTogglePaintFormat,
   paintFormatActive = false,
@@ -196,6 +199,10 @@ export function FormattingToolbar({
   const handleInsertChart = useCallback(() => {
     onInsertChart?.();
   }, [onInsertChart]);
+
+  const handleInsertImage = useCallback(() => {
+    onInsertImage?.();
+  }, [onInsertImage]);
 
   const handleOpenConditionalFormat = useCallback(() => {
     onOpenConditionalFormat?.();
@@ -724,6 +731,18 @@ export function FormattingToolbar({
           <Tooltip>
             <TooltipTrigger asChild>
               <button
+                className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-[11px] font-semibold hover:bg-muted"
+                onClick={handleInsertImage}
+              >
+                <IconPhoto size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Insert image</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
                 className="inline-flex h-7 cursor-pointer items-center justify-center rounded-md px-2 text-[10px] font-semibold tracking-wide hover:bg-muted"
                 onClick={handleOpenConditionalFormat}
               >
@@ -856,6 +875,10 @@ export function FormattingToolbar({
               <DropdownMenuItem onClick={handleInsertChart}>
                 <IconChartBar size={16} className="mr-2" />
                 Insert chart
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleInsertImage}>
+                <IconPhoto size={16} className="mr-2" />
+                Insert image
               </DropdownMenuItem>
               <DropdownMenuItem onClick={handleTogglePaintFormat}>
                 <IconPaint size={16} className="mr-2" />

--- a/packages/frontend/src/types/worksheet.ts
+++ b/packages/frontend/src/types/worksheet.ts
@@ -25,6 +25,22 @@ export type SheetChart = {
   height: number;
 };
 
+export type ImageFit = "cover" | "contain";
+
+export type SheetImage = {
+  id: string;
+  title?: string;
+  alt?: string;
+  key: string;
+  contentType: string;
+  anchor: Sref;
+  offsetX: number;
+  offsetY: number;
+  width: number;
+  height: number;
+  fit: ImageFit;
+};
+
 export type WorksheetFilterState = {
   startRow: number;
   endRow: number;
@@ -61,6 +77,9 @@ export type Worksheet = {
   filter?: WorksheetFilterState;
   charts?: {
     [id: string]: SheetChart;
+  };
+  images?: {
+    [id: string]: SheetImage;
   };
   frozenRows: number;
   frozenCols: number;
@@ -103,6 +122,7 @@ export const initialSpreadsheetDocument: SpreadsheetDocument = {
       conditionalFormats: [],
       merges: {},
       charts: {},
+      images: {},
       frozenRows: 0,
       frozenCols: 0,
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### What this PR does / why we need it?

Image insertion needed to match the chart-style floating object workflow and keep object edits collaborative through Yorkie.

This adds floating image cards with editor controls, backend image upload/stream endpoints, MinIO-based local dev setup, and updated docs for S3-compatible configuration in production.

### Any background context you want to provide?

### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Image asset upload and retrieval with S3-compatible object storage integration.
  * Image editing panel with metadata management and positioning controls.
  * Image object support within spreadsheets with interactive resizing and layout synchronization.

* **Documentation**
  * Updated development setup to include MinIO container alongside existing services.
  * Added asset storage configuration and API documentation.

* **Tests**
  * Added comprehensive test coverage for image asset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->