### PR TITLE
Fix wrong vertical alignment with various height

### DIFF
--- a/packages/sheet/src/view/gridcanvas.ts
+++ b/packages/sheet/src/view/gridcanvas.ts
@@ -31,6 +31,7 @@ import {
   NoFreeze,
   FreezeHandleThickness,
   toBoundingRect,
+  getTextBlockHeight,
 } from './layout';
 
 type TextOverflowRenderData = {
@@ -1274,7 +1275,7 @@ export class GridCanvas {
 
       // Compute vertical alignment offset
       const vAlign = style?.va || 'top';
-      const totalTextHeight = lines.length * CellFontSize * CellLineHeight;
+      const totalTextHeight = getTextBlockHeight(lines.length);
       let baseY: number;
       if (vAlign === 'middle') {
         baseY = rect.top + (rect.height - totalTextHeight) / 2;

--- a/packages/sheet/src/view/layout.ts
+++ b/packages/sheet/src/view/layout.ts
@@ -42,6 +42,17 @@ export type Size = { width: number; height: number };
 export type BoundingRect = Position & Size;
 
 /**
+ * Calculates the height of a multi-line text block.
+ * @param lineCount The number of lines in the text block
+ * @returns The total height of the text block
+ */
+export function getTextBlockHeight(
+  lineCount: number
+): number {
+  return (lineCount - 1) * CellFontSize * CellLineHeight + CellFontSize;
+}
+
+/**
  * Calculates the bounding rectangle for a cell reference with scroll position
  * @param id The cell reference
  * @param scroll The scroll position

--- a/packages/sheet/src/view/worksheet.ts
+++ b/packages/sheet/src/view/worksheet.ts
@@ -29,7 +29,6 @@ import {
   DefaultCellHeight,
   RowHeaderWidth,
   CellFontSize,
-  CellLineHeight,
   CellPaddingY,
   BoundingRect,
   Position,
@@ -44,6 +43,7 @@ import {
   expandBoundingRect,
   toRef,
   toRefWithFreeze,
+  getTextBlockHeight,
 } from './layout';
 
 const ResizeEdgeThreshold = 6;
@@ -3277,7 +3277,7 @@ export class Worksheet {
 
     return Math.max(
       DefaultCellHeight,
-      Math.ceil(maxLines * CellFontSize * CellLineHeight + 2 * CellPaddingY),
+      Math.ceil(getTextBlockHeight(maxLines) + 2 * CellPaddingY),
     );
   }
 


### PR DESCRIPTION
## Summary
When change height of cell with vertical alignment, it aligns wrongly.
This change fixes to align correctly with any height of cell.

## Why

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared text-height calculation and applied it across cell rendering and autosizing for consistent multi-line measurements.
* **Bug Fixes**
  * Improved vertical alignment of multi-line text in cells—centered and bottom-aligned text now position correctly while single-line behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->