### PR TITLE
Preserve absolute reference ($) markers in formula operations

### DIFF
--- a/packages/sheet/src/model/coordinates.ts
+++ b/packages/sheet/src/model/coordinates.ts
@@ -1,4 +1,4 @@
-import { Ref, Range, Reference, Sref, Srng, Grid } from './types';
+import { ARef, Ref, Range, Reference, Sref, Srng, Grid } from './types';
 
 /**
  * `isIntersect` returns whether the given Ranges are intersected.
@@ -334,6 +334,39 @@ export function parseRef(ref: Sref): Ref {
   }
 
   return { r: row, c: col };
+}
+
+/**
+ * `parseARef` parses a string ref preserving absolute-reference `$` markers.
+ * e.g. "$A$1" → { r: 1, c: 1, absCol: true, absRow: true }
+ *      "A$1"  → { r: 1, c: 1, absRow: true }
+ *      "$A1"  → { r: 1, c: 1, absCol: true }
+ */
+export function parseARef(ref: Sref): ARef {
+  const absCol = ref.startsWith('$') || ref.includes('!$');
+  // Find the column-row boundary to detect row dollar sign.
+  // After optional leading '$' and column letters, check for '$' before digits.
+  const match = ref.match(/^(\$?)([A-Za-z]+)(\$?)(\d+)$/);
+  if (!match) {
+    throw new Error('Invalid Reference');
+  }
+  const absRow = match[3] === '$';
+  const parsed = parseRef(ref);
+  return {
+    ...parsed,
+    ...(absCol ? { absCol: true } : {}),
+    ...(absRow ? { absRow: true } : {}),
+  };
+}
+
+/**
+ * `toASref` converts an ARef back to a string ref, restoring `$` markers.
+ * e.g. { r: 1, c: 1, absCol: true, absRow: true } → "$A$1"
+ */
+export function toASref(ref: ARef): Sref {
+  const col = toColumnLabel(ref.c);
+  const row = String(ref.r);
+  return (ref.absCol ? '$' : '') + col + (ref.absRow ? '$' : '') + row;
 }
 
 /**

--- a/packages/sheet/src/model/shifting.ts
+++ b/packages/sheet/src/model/shifting.ts
@@ -1,6 +1,6 @@
 import { extractTokens } from '../formula/formula';
-import { parseRef, toSref } from './coordinates';
-import { Axis, Cell, Grid, Ref, Sref } from './types';
+import { parseARef, parseRef, toASref, toSref } from './coordinates';
+import { ARef, Axis, Cell, Grid, Ref, Sref } from './types';
 
 /**
  * `remapIndex` maps an old 1-based index to its new position after moving
@@ -77,15 +77,15 @@ export function moveFormula(
         result += text;
       } else if (text.includes(':')) {
         const [startStr, endStr] = text.split(':');
-        const startRef = parseRef(startStr.toUpperCase());
-        const endRef = parseRef(endStr.toUpperCase());
-        const newStart = moveRef(startRef, axis, src, count, dst);
-        const newEnd = moveRef(endRef, axis, src, count, dst);
-        result += toSref(newStart) + ':' + toSref(newEnd);
+        const startARef = parseARef(startStr.toUpperCase());
+        const endARef = parseARef(endStr.toUpperCase());
+        const newStart = moveRef(startARef, axis, src, count, dst);
+        const newEnd = moveRef(endARef, axis, src, count, dst);
+        result += toASref({ ...newStart, ...(startARef.absCol ? { absCol: true } : {}), ...(startARef.absRow ? { absRow: true } : {}) }) + ':' + toASref({ ...newEnd, ...(endARef.absCol ? { absCol: true } : {}), ...(endARef.absRow ? { absRow: true } : {}) });
       } else {
-        const ref = parseRef(text.toUpperCase());
-        const moved = moveRef(ref, axis, src, count, dst);
-        result += toSref(moved);
+        const aref = parseARef(text.toUpperCase());
+        const moved = moveRef(aref, axis, src, count, dst);
+        result += toASref({ ...moved, ...(aref.absCol ? { absCol: true } : {}), ...(aref.absRow ? { absRow: true } : {}) });
       }
     } else {
       result += token.text;
@@ -149,6 +149,18 @@ export function moveDimensionMap<T = number>(
 }
 
 /**
+ * `relocateARef` shifts an ARef by deltas, skipping absolute axes.
+ */
+function relocateARef(ref: ARef, deltaRow: number, deltaCol: number): ARef {
+  return {
+    r: ref.absRow ? ref.r : ref.r + deltaRow,
+    c: ref.absCol ? ref.c : ref.c + deltaCol,
+    ...(ref.absCol ? { absCol: true } : {}),
+    ...(ref.absRow ? { absRow: true } : {}),
+  };
+}
+
+/**
  * `relocateFormula` adjusts all cell references in a formula by the given
  * row and column deltas. Used when copy-pasting formulas to a new location.
  * Returns a formula with `#REF!` if any reference goes below row 1 or column 1.
@@ -169,22 +181,19 @@ export function relocateFormula(
         result += text;
       } else if (text.includes(':')) {
         const [startStr, endStr] = text.split(':');
-        const startRef = parseRef(startStr.toUpperCase());
-        const endRef = parseRef(endStr.toUpperCase());
-        const newStart = { r: startRef.r + deltaRow, c: startRef.c + deltaCol };
-        const newEnd = { r: endRef.r + deltaRow, c: endRef.c + deltaCol };
-        if (newStart.r < 1 || newStart.c < 1 || newEnd.r < 1 || newEnd.c < 1) {
+        const startRef = relocateARef(parseARef(startStr.toUpperCase()), deltaRow, deltaCol);
+        const endRef = relocateARef(parseARef(endStr.toUpperCase()), deltaRow, deltaCol);
+        if (startRef.r < 1 || startRef.c < 1 || endRef.r < 1 || endRef.c < 1) {
           result += '#REF!';
         } else {
-          result += toSref(newStart) + ':' + toSref(newEnd);
+          result += toASref(startRef) + ':' + toASref(endRef);
         }
       } else {
-        const ref = parseRef(text.toUpperCase());
-        const newRef = { r: ref.r + deltaRow, c: ref.c + deltaCol };
-        if (newRef.r < 1 || newRef.c < 1) {
+        const ref = relocateARef(parseARef(text.toUpperCase()), deltaRow, deltaCol);
+        if (ref.r < 1 || ref.c < 1) {
           result += '#REF!';
         } else {
-          result += toSref(newRef);
+          result += toASref(ref);
         }
       }
     } else {
@@ -193,6 +202,18 @@ export function relocateFormula(
   }
 
   return result;
+}
+
+/**
+ * `applyAbsMarkers` copies the absolute markers from an ARef onto a plain Sref.
+ */
+function applyAbsMarkers(aref: ARef, sref: Sref): Sref {
+  const parsed = parseRef(sref);
+  return toASref({
+    ...parsed,
+    ...(aref.absCol ? { absCol: true } : {}),
+    ...(aref.absRow ? { absRow: true } : {}),
+  });
 }
 
 /**
@@ -218,19 +239,22 @@ export function redirectFormula(
         result += text;
       } else if (text.includes(':')) {
         const [startStr, endStr] = text.split(':');
-        const startSref = toSref(parseRef(startStr.toUpperCase()));
-        const endSref = toSref(parseRef(endStr.toUpperCase()));
+        const startARef = parseARef(startStr.toUpperCase());
+        const endARef = parseARef(endStr.toUpperCase());
+        const startSref = toSref(startARef);
+        const endSref = toSref(endARef);
         const newStart = refMap.get(startSref);
         const newEnd = refMap.get(endSref);
         if (newStart && newEnd) {
-          result += newStart + ':' + newEnd;
+          result += applyAbsMarkers(startARef, newStart) + ':' + applyAbsMarkers(endARef, newEnd);
         } else {
           result += text;
         }
       } else {
-        const sref = toSref(parseRef(text.toUpperCase()));
+        const aref = parseARef(text.toUpperCase());
+        const sref = toSref(aref);
         const newSref = refMap.get(sref);
-        result += newSref ?? text;
+        result += newSref ? applyAbsMarkers(aref, newSref) : text;
       }
     } else {
       result += token.text;
@@ -292,9 +316,33 @@ export function shiftSref(
   index: number,
   count: number,
 ): Sref | null {
-  const ref = parseRef(sref);
+  const aref = parseARef(sref);
+  const shifted = shiftRef(aref, axis, index, count);
+  if (!shifted) return null;
+  return toASref({
+    ...shifted,
+    ...(aref.absCol ? { absCol: true } : {}),
+    ...(aref.absRow ? { absRow: true } : {}),
+  });
+}
+
+/**
+ * `shiftARef` shifts an ARef and preserves absolute markers.
+ * Insert/delete shifts even absolute refs (Excel behavior), but the `$` flags are kept.
+ */
+function shiftARef(
+  ref: ARef,
+  axis: Axis,
+  index: number,
+  count: number,
+): ARef | null {
   const shifted = shiftRef(ref, axis, index, count);
-  return shifted ? toSref(shifted) : null;
+  if (!shifted) return null;
+  return {
+    ...shifted,
+    ...(ref.absCol ? { absCol: true } : {}),
+    ...(ref.absRow ? { absRow: true } : {}),
+  };
 }
 
 /**
@@ -322,23 +370,20 @@ export function shiftFormula(
       } else if (text.includes(':')) {
         // Range reference: shift each endpoint
         const [startStr, endStr] = text.split(':');
-        const startRef = parseRef(startStr.toUpperCase());
-        const endRef = parseRef(endStr.toUpperCase());
-        const newStart = shiftRef(startRef, axis, index, count);
-        const newEnd = shiftRef(endRef, axis, index, count);
+        const newStart = shiftARef(parseARef(startStr.toUpperCase()), axis, index, count);
+        const newEnd = shiftARef(parseARef(endStr.toUpperCase()), axis, index, count);
         if (!newStart || !newEnd) {
           result += '#REF!';
         } else {
-          result += toSref(newStart) + ':' + toSref(newEnd);
+          result += toASref(newStart) + ':' + toASref(newEnd);
         }
       } else {
         // Single reference
-        const ref = parseRef(text.toUpperCase());
-        const shifted = shiftRef(ref, axis, index, count);
+        const shifted = shiftARef(parseARef(text.toUpperCase()), axis, index, count);
         if (!shifted) {
           result += '#REF!';
         } else {
-          result += toSref(shifted);
+          result += toASref(shifted);
         }
       }
     } else {

--- a/packages/sheet/src/model/types.ts
+++ b/packages/sheet/src/model/types.ts
@@ -34,6 +34,15 @@ export type Ref = {
 };
 
 /**
+ * ARef (Absolute-aware Ref) extends Ref with optional absolute-reference flags.
+ * Used during formula relocation to decide which axes should stay fixed.
+ */
+export type ARef = Ref & {
+  absCol?: boolean;
+  absRow?: boolean;
+};
+
+/**
  * Range type represents a range of cells in the sheet.
  */
 export type Range = [Ref, Ref];

--- a/packages/sheet/test/sheet/shifting.test.ts
+++ b/packages/sheet/test/sheet/shifting.test.ts
@@ -6,6 +6,7 @@ import {
   shiftGrid,
   shiftDimensionMap,
   relocateFormula,
+  redirectFormula,
 } from '../../src/model/shifting';
 import { Grid } from '../../src/model/types';
 
@@ -269,6 +270,75 @@ describe('shiftDimensionMap', () => {
     const result = shiftDimensionMap(map, 2, 1);
 
     expect(result.size).toBe(0);
+  });
+});
+
+describe('absolute reference ($) support in relocateFormula', () => {
+  it('should not shift fully absolute ref ($A$1)', () => {
+    expect(relocateFormula('=$A$1+B1', 1, 1)).toBe('=$A$1+C2');
+  });
+
+  it('should fix column only ($A1)', () => {
+    expect(relocateFormula('=$A1+B1', 1, 1)).toBe('=$A2+C2');
+  });
+
+  it('should fix row only (A$1)', () => {
+    expect(relocateFormula('=A$1+B1', 1, 1)).toBe('=B$1+C2');
+  });
+
+  it('should handle mixed refs in one formula', () => {
+    expect(relocateFormula('=A$1+$B2', 1, 1)).toBe('=B$1+$B3');
+  });
+
+  it('should preserve $ in range references', () => {
+    expect(relocateFormula('=SUM($A$1:$B$3)', 2, 0)).toBe('=SUM($A$1:$B$3)');
+  });
+
+  it('should shift only relative parts of a range', () => {
+    expect(relocateFormula('=SUM($A1:B$3)', 1, 1)).toBe('=SUM($A2:C$3)');
+  });
+
+  it('should return #REF! when relative part goes below 1', () => {
+    expect(relocateFormula('=A$1', 0, -1)).toBe('=#REF!');
+  });
+
+  it('should be identity when delta is zero', () => {
+    expect(relocateFormula('=$A$1+$B2', 0, 0)).toBe('=$A$1+$B2');
+  });
+});
+
+describe('absolute reference ($) preservation in shiftFormula', () => {
+  it('should shift absolute refs on insert and preserve $ markers', () => {
+    expect(shiftFormula('=$A$1', 'row', 1, 1)).toBe('=$A$2');
+  });
+
+  it('should preserve mixed $ markers after row insert', () => {
+    expect(shiftFormula('=A$1+$B2', 'row', 1, 2)).toBe('=A$3+$B4');
+  });
+
+  it('should preserve $ markers after column insert', () => {
+    expect(shiftFormula('=$A1', 'column', 1, 1)).toBe('=$B1');
+  });
+
+  it('should preserve $ in range after insert', () => {
+    expect(shiftFormula('=SUM($A$1:$B$3)', 'row', 1, 1)).toBe('=SUM($A$2:$B$4)');
+  });
+});
+
+describe('absolute reference ($) preservation in redirectFormula', () => {
+  it('should preserve $ markers when redirecting single ref', () => {
+    const refMap = new Map([['A1', 'C1']]);
+    expect(redirectFormula('=$A$1', refMap)).toBe('=$C$1');
+  });
+
+  it('should preserve mixed $ markers when redirecting', () => {
+    const refMap = new Map([['A1', 'C3']]);
+    expect(redirectFormula('=$A1', refMap)).toBe('=$C3');
+  });
+
+  it('should preserve $ in range redirect', () => {
+    const refMap = new Map([['A1', 'C1'], ['B3', 'D3']]);
+    expect(redirectFormula('=SUM($A$1:B$3)', refMap)).toBe('=SUM($C$1:D$3)');
   });
 });
 


### PR DESCRIPTION
## Summary
Add ARef type and parseARef/toASref helpers to preserve $ flags through all formula rewriting paths (shift, relocate, redirect, move).

## Why
Previously, shifting, relocating, and redirecting formulas would strip the $ markers from cell references like $A$1, $A1, or A$1. This caused incorrect behavior when copy-pasting or inserting rows/columns in formulas that used absolute references.

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Strengthened absolute cell reference ($) handling in formulas, ensuring proper preservation when formulas are shifted, moved, or relocated across cells.
  * Enhanced support for various absolute reference patterns, including column-only and row-only absolute markers.

* **Tests**
  * Comprehensive test coverage added for absolute reference behavior, including cross-sheet operations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->