### PR TITLE
Preserve absolute reference markers ($) in formula rewriting

### DIFF
--- a/packages/sheet/src/model/coordinates.ts
+++ b/packages/sheet/src/model/coordinates.ts
@@ -1,6 +1,12 @@
 import { Ref, Range, Reference, Sref, Srng, Grid } from './types';
 
 /**
+ * `AbsRef` extends `Ref` with flags indicating whether the column and/or row
+ * are absolute references (prefixed with `$` in A1 notation).
+ */
+export type AbsRef = Ref & { absCol: boolean; absRow: boolean };
+
+/**
  * `isIntersect` returns whether the given Ranges are intersected.
  */
 export function isIntersect(range1: Range, range2: Range): boolean {
@@ -334,6 +340,31 @@ export function parseRef(ref: Sref): Ref {
   }
 
   return { r: row, c: col };
+}
+
+/**
+ * `parseAbsRef` parses a string ref that may contain `$` markers for absolute
+ * references, returning an `AbsRef` with the position and absolute flags.
+ */
+export function parseAbsRef(ref: Sref): AbsRef {
+  // Detect $ positions before stripping
+  const absCol = ref.startsWith('$');
+  // Find $ before digits (row part)
+  const digitMatch = ref.search(/[0-9]/);
+  const absRow = digitMatch > 0 && ref[digitMatch - 1] === '$';
+
+  const parsed = parseRef(ref);
+  return { ...parsed, absCol, absRow };
+}
+
+/**
+ * `toAbsSref` converts an `AbsRef` back to a string ref, re-inserting `$`
+ * markers based on the absolute flags.
+ */
+export function toAbsSref(ref: AbsRef): Sref {
+  const col = toColumnLabel(ref.c);
+  const row = ref.r;
+  return (ref.absCol ? '$' : '') + col + (ref.absRow ? '$' : '') + row;
 }
 
 /**

--- a/packages/sheet/src/model/shifting.ts
+++ b/packages/sheet/src/model/shifting.ts
@@ -1,5 +1,5 @@
 import { extractTokens } from '../formula/formula';
-import { parseRef, toSref } from './coordinates';
+import { parseAbsRef, parseRef, toAbsSref, toSref } from './coordinates';
 import { Axis, Cell, Grid, Ref, Sref } from './types';
 
 /**
@@ -77,15 +77,18 @@ export function moveFormula(
         result += text;
       } else if (text.includes(':')) {
         const [startStr, endStr] = text.split(':');
-        const startRef = parseRef(startStr.toUpperCase());
-        const endRef = parseRef(endStr.toUpperCase());
-        const newStart = moveRef(startRef, axis, src, count, dst);
-        const newEnd = moveRef(endRef, axis, src, count, dst);
-        result += toSref(newStart) + ':' + toSref(newEnd);
+        const startAbs = parseAbsRef(startStr.toUpperCase());
+        const endAbs = parseAbsRef(endStr.toUpperCase());
+        const newStart = moveRef(startAbs, axis, src, count, dst);
+        const newEnd = moveRef(endAbs, axis, src, count, dst);
+        result +=
+          toAbsSref({ ...newStart, absCol: startAbs.absCol, absRow: startAbs.absRow }) +
+          ':' +
+          toAbsSref({ ...newEnd, absCol: endAbs.absCol, absRow: endAbs.absRow });
       } else {
-        const ref = parseRef(text.toUpperCase());
-        const moved = moveRef(ref, axis, src, count, dst);
-        result += toSref(moved);
+        const abs = parseAbsRef(text.toUpperCase());
+        const moved = moveRef(abs, axis, src, count, dst);
+        result += toAbsSref({ ...moved, absCol: abs.absCol, absRow: abs.absRow });
       }
     } else {
       result += token.text;
@@ -169,22 +172,34 @@ export function relocateFormula(
         result += text;
       } else if (text.includes(':')) {
         const [startStr, endStr] = text.split(':');
-        const startRef = parseRef(startStr.toUpperCase());
-        const endRef = parseRef(endStr.toUpperCase());
-        const newStart = { r: startRef.r + deltaRow, c: startRef.c + deltaCol };
-        const newEnd = { r: endRef.r + deltaRow, c: endRef.c + deltaCol };
+        const startAbs = parseAbsRef(startStr.toUpperCase());
+        const endAbs = parseAbsRef(endStr.toUpperCase());
+        const newStart = {
+          r: startAbs.r + (startAbs.absRow ? 0 : deltaRow),
+          c: startAbs.c + (startAbs.absCol ? 0 : deltaCol),
+        };
+        const newEnd = {
+          r: endAbs.r + (endAbs.absRow ? 0 : deltaRow),
+          c: endAbs.c + (endAbs.absCol ? 0 : deltaCol),
+        };
         if (newStart.r < 1 || newStart.c < 1 || newEnd.r < 1 || newEnd.c < 1) {
           result += '#REF!';
         } else {
-          result += toSref(newStart) + ':' + toSref(newEnd);
+          result +=
+            toAbsSref({ ...newStart, absCol: startAbs.absCol, absRow: startAbs.absRow }) +
+            ':' +
+            toAbsSref({ ...newEnd, absCol: endAbs.absCol, absRow: endAbs.absRow });
         }
       } else {
-        const ref = parseRef(text.toUpperCase());
-        const newRef = { r: ref.r + deltaRow, c: ref.c + deltaCol };
+        const abs = parseAbsRef(text.toUpperCase());
+        const newRef = {
+          r: abs.r + (abs.absRow ? 0 : deltaRow),
+          c: abs.c + (abs.absCol ? 0 : deltaCol),
+        };
         if (newRef.r < 1 || newRef.c < 1) {
           result += '#REF!';
         } else {
-          result += toSref(newRef);
+          result += toAbsSref({ ...newRef, absCol: abs.absCol, absRow: abs.absRow });
         }
       }
     } else {
@@ -218,19 +233,32 @@ export function redirectFormula(
         result += text;
       } else if (text.includes(':')) {
         const [startStr, endStr] = text.split(':');
+        const startAbs = parseAbsRef(startStr.toUpperCase());
+        const endAbs = parseAbsRef(endStr.toUpperCase());
         const startSref = toSref(parseRef(startStr.toUpperCase()));
         const endSref = toSref(parseRef(endStr.toUpperCase()));
         const newStart = refMap.get(startSref);
         const newEnd = refMap.get(endSref);
         if (newStart && newEnd) {
-          result += newStart + ':' + newEnd;
+          const newStartAbs = parseAbsRef(newStart);
+          const newEndAbs = parseAbsRef(newEnd);
+          result +=
+            toAbsSref({ ...newStartAbs, absCol: startAbs.absCol, absRow: startAbs.absRow }) +
+            ':' +
+            toAbsSref({ ...newEndAbs, absCol: endAbs.absCol, absRow: endAbs.absRow });
         } else {
           result += text;
         }
       } else {
+        const abs = parseAbsRef(text.toUpperCase());
         const sref = toSref(parseRef(text.toUpperCase()));
         const newSref = refMap.get(sref);
-        result += newSref ?? text;
+        if (newSref) {
+          const newAbs = parseAbsRef(newSref);
+          result += toAbsSref({ ...newAbs, absCol: abs.absCol, absRow: abs.absRow });
+        } else {
+          result += text;
+        }
       }
     } else {
       result += token.text;
@@ -322,23 +350,26 @@ export function shiftFormula(
       } else if (text.includes(':')) {
         // Range reference: shift each endpoint
         const [startStr, endStr] = text.split(':');
-        const startRef = parseRef(startStr.toUpperCase());
-        const endRef = parseRef(endStr.toUpperCase());
-        const newStart = shiftRef(startRef, axis, index, count);
-        const newEnd = shiftRef(endRef, axis, index, count);
+        const startAbs = parseAbsRef(startStr.toUpperCase());
+        const endAbs = parseAbsRef(endStr.toUpperCase());
+        const newStart = shiftRef(startAbs, axis, index, count);
+        const newEnd = shiftRef(endAbs, axis, index, count);
         if (!newStart || !newEnd) {
           result += '#REF!';
         } else {
-          result += toSref(newStart) + ':' + toSref(newEnd);
+          result +=
+            toAbsSref({ ...newStart, absCol: startAbs.absCol, absRow: startAbs.absRow }) +
+            ':' +
+            toAbsSref({ ...newEnd, absCol: endAbs.absCol, absRow: endAbs.absRow });
         }
       } else {
         // Single reference
-        const ref = parseRef(text.toUpperCase());
-        const shifted = shiftRef(ref, axis, index, count);
+        const abs = parseAbsRef(text.toUpperCase());
+        const shifted = shiftRef(abs, axis, index, count);
         if (!shifted) {
           result += '#REF!';
         } else {
-          result += toSref(shifted);
+          result += toAbsSref({ ...shifted, absCol: abs.absCol, absRow: abs.absRow });
         }
       }
     } else {

--- a/packages/sheet/test/sheet/shifting.test.ts
+++ b/packages/sheet/test/sheet/shifting.test.ts
@@ -6,8 +6,11 @@ import {
   shiftGrid,
   shiftDimensionMap,
   relocateFormula,
+  moveFormula,
+  redirectFormula,
 } from '../../src/model/shifting';
-import { Grid } from '../../src/model/types';
+import { parseAbsRef, toAbsSref } from '../../src/model/coordinates';
+import { Grid, Sref } from '../../src/model/types';
 
 describe('shiftRef', () => {
   describe('insert (count > 0)', () => {
@@ -269,6 +272,111 @@ describe('shiftDimensionMap', () => {
     const result = shiftDimensionMap(map, 2, 1);
 
     expect(result.size).toBe(0);
+  });
+});
+
+describe('parseAbsRef / toAbsSref', () => {
+  it('should round-trip A1 (no abs)', () => {
+    const abs = parseAbsRef('A1');
+    expect(abs).toEqual({ r: 1, c: 1, absCol: false, absRow: false });
+    expect(toAbsSref(abs)).toBe('A1');
+  });
+
+  it('should round-trip $A1 (abs col only)', () => {
+    const abs = parseAbsRef('$A1');
+    expect(abs).toEqual({ r: 1, c: 1, absCol: true, absRow: false });
+    expect(toAbsSref(abs)).toBe('$A1');
+  });
+
+  it('should round-trip A$1 (abs row only)', () => {
+    const abs = parseAbsRef('A$1');
+    expect(abs).toEqual({ r: 1, c: 1, absCol: false, absRow: true });
+    expect(toAbsSref(abs)).toBe('A$1');
+  });
+
+  it('should round-trip $A$1 (both abs)', () => {
+    const abs = parseAbsRef('$A$1');
+    expect(abs).toEqual({ r: 1, c: 1, absCol: true, absRow: true });
+    expect(toAbsSref(abs)).toBe('$A$1');
+  });
+
+  it('should handle multi-letter columns like $AB$10', () => {
+    const abs = parseAbsRef('$AB$10');
+    expect(abs.absCol).toBe(true);
+    expect(abs.absRow).toBe(true);
+    expect(abs.r).toBe(10);
+    expect(abs.c).toBe(28); // AB = 28
+    expect(toAbsSref(abs)).toBe('$AB$10');
+  });
+});
+
+describe('absolute refs in relocateFormula', () => {
+  it('should not shift absolute column', () => {
+    expect(relocateFormula('=$A1+B2', 0, 1)).toBe('=$A1+C2');
+  });
+
+  it('should not shift absolute row', () => {
+    expect(relocateFormula('=A$1+B2', 1, 0)).toBe('=A$1+B3');
+  });
+
+  it('should not shift fully absolute ref', () => {
+    expect(relocateFormula('=$A$1+B2', 2, 1)).toBe('=$A$1+C4');
+  });
+
+  it('should preserve abs markers in range refs', () => {
+    expect(relocateFormula('=SUM($A$1:B3)', 1, 1)).toBe('=SUM($A$1:C4)');
+  });
+
+  it('should preserve abs markers with zero delta', () => {
+    expect(relocateFormula('=$A$1', 0, 0)).toBe('=$A$1');
+  });
+});
+
+describe('absolute refs in shiftFormula', () => {
+  it('should preserve abs markers while shifting', () => {
+    // Insert row at 2: $A$1 stays at row 1 (before index), markers preserved
+    expect(shiftFormula('=$A$1+A2', 'row', 2, 1)).toBe('=$A$1+A3');
+  });
+
+  it('should shift absolute ref value on insert (Excel behavior)', () => {
+    // Insert row at 1: $A$1 shifts to $A$2 (value changes, markers stay)
+    expect(shiftFormula('=$A$1', 'row', 1, 1)).toBe('=$A$2');
+  });
+
+  it('should preserve mixed abs markers in range', () => {
+    expect(shiftFormula('=SUM($A2:B$5)', 'row', 2, 1)).toBe('=SUM($A3:B$6)');
+  });
+});
+
+describe('absolute refs in moveFormula', () => {
+  it('should preserve abs markers after move', () => {
+    expect(moveFormula('=$A$1', 'row', 1, 1, 3)).toBe('=$A$2');
+  });
+
+  it('should preserve mixed abs markers', () => {
+    // Moving row 1 (1 row) to before row 3: row 2 shifts backward to row 1
+    expect(moveFormula('=$A1+B$2', 'row', 1, 1, 3)).toBe('=$A2+B$1');
+  });
+});
+
+describe('absolute refs in redirectFormula', () => {
+  it('should preserve abs markers after redirect', () => {
+    const refMap = new Map<Sref, Sref>([['A1', 'B2']]);
+    expect(redirectFormula('=$A$1', refMap)).toBe('=$B$2');
+  });
+
+  it('should preserve mixed abs markers after redirect', () => {
+    // $A1 → redirect A1→C3: abs col flag preserved on new target C3 → $C3
+    const refMap = new Map<Sref, Sref>([['A1', 'C3']]);
+    expect(redirectFormula('=$A1', refMap)).toBe('=$C3');
+  });
+
+  it('should preserve abs markers in range redirect', () => {
+    const refMap = new Map<Sref, Sref>([
+      ['A1', 'B2'],
+      ['C3', 'D4'],
+    ]);
+    expect(redirectFormula('=$A$1:$C$3', refMap)).toBe('=$B$2:$D$4');
   });
 });
 

--- a/tasks/active/20260308-abs-ref-preserve-lessons.md
+++ b/tasks/active/20260308-abs-ref-preserve-lessons.md
@@ -1,0 +1,15 @@
+# Lessons: Preserve absolute reference markers ($)
+
+## Key decisions
+
+- `AbsRef` extends `Ref` with two booleans rather than a separate type to enable
+  easy pass-through to existing `moveRef`/`shiftRef` functions.
+- `parseAbsRef` detects `$` positions before stripping them (reuses `parseRef` internally).
+- `redirectFormula` keeps using `toSref(parseRef(...))` for map lookup keys (without `$`)
+  but preserves original abs flags when writing output.
+
+## Gotcha
+
+- `moveFormula` test: `remapIndex` can shift refs *between* src and dst, so a ref at
+  row 2 when moving row 1→3 shifts backward to row 1. Must trace through `remapIndex`
+  carefully when writing test expectations.

--- a/tasks/active/20260308-abs-ref-preserve-todo.md
+++ b/tasks/active/20260308-abs-ref-preserve-todo.md
@@ -1,0 +1,20 @@
+# Preserve absolute reference markers ($) during formula rewriting
+
+GitHub Issue: #24
+
+## Tasks
+
+- [x] Add `AbsRef` type and `parseAbsRef`/`toAbsSref` helpers in `coordinates.ts`
+- [x] Update `moveFormula` to preserve abs flags
+- [x] Update `shiftFormula` to preserve abs flags (shift value, keep markers)
+- [x] Update `relocateFormula` to skip delta for absolute dimensions
+- [x] Update `redirectFormula` to preserve abs flags through lookup
+- [x] Add tests for `parseAbsRef`/`toAbsSref` round-trip
+- [x] Add tests for all four formula rewrite functions with absolute refs
+- [x] `pnpm verify:fast` passes
+
+## Review
+
+All four formula rewrite functions now preserve `$` markers:
+- **relocateFormula**: absolute dimensions skip the delta (key semantic difference)
+- **shiftFormula/moveFormula/redirectFormula**: apply transforms normally but carry abs flags through


### PR DESCRIPTION
## Summary

- `parseRef()` was stripping `$` markers from cell references (e.g., `$A$1` → `A1`) and `toSref()` never re-added them, causing all four formula rewrite functions to lose absolute reference information
- Added `AbsRef` type with `absCol`/`absRow` flags, `parseAbsRef()`/`toAbsSref()` helpers in `coordinates.ts`
- Updated `moveFormula`, `shiftFormula`, `relocateFormula`, `redirectFormula` to preserve `$` markers through transforms
- In `relocateFormula` (copy/paste), absolute dimensions now skip the delta shift (`=$A$1` stays fixed)

Fixes #24

## Test plan

- [x] `parseAbsRef`/`toAbsSref` round-trip for all four combinations (`A1`, `$A1`, `A$1`, `$A$1`)
- [x] `relocateFormula`: absolute dimensions do not shift on copy/paste
- [x] `shiftFormula`: values shift but `$` markers are preserved (Excel behavior)
- [x] `moveFormula` / `redirectFormula`: transforms apply with abs flags carried through
- [x] `pnpm verify:fast` passes (979 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Absolute cell references (marked with $) are now properly preserved when formulas are moved, relocated, or shifted across the spreadsheet.

* **Tests**
  * Added comprehensive test coverage for absolute reference preservation in all formula relocation operations, including cross-sheet scenarios.

* **Documentation**
  * Added documentation outlining the design and implementation approach for preserving absolute reference markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->