### PR TITLE
Migrate API URL to api.wafflebase.io

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import { parse as parseYaml } from 'yaml';
 import { loadSession, isSessionExpired } from './session.js';
 
-export const DEFAULT_SERVER = 'https://wafflebase-api.yorkie.dev';
+export const DEFAULT_SERVER = 'https://api.wafflebase.io';
 
 export interface CliConfig {
   server: string;

--- a/packages/cli/src/schema/registry.ts
+++ b/packages/cli/src/schema/registry.ts
@@ -22,7 +22,7 @@ const registry: CommandSchema[] = [
     description: 'Authenticate via GitHub OAuth in the browser',
     safety: 'write',
     parameters: {
-      '--server': { type: 'string', required: false, description: 'Server URL', default: 'https://wafflebase-api.yorkie.dev' },
+      '--server': { type: 'string', required: false, description: 'Server URL', default: 'https://api.wafflebase.io' },
     },
     response: { user: 'string', workspace: 'string' },
   },

--- a/packages/docs/developers/cli.md
+++ b/packages/docs/developers/cli.md
@@ -97,7 +97,7 @@ export WAFFLEBASE_WORKSPACE=your-workspace-id
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--server <url>` | Server URL | `https://wafflebase-api.yorkie.dev` |
+| `--server <url>` | Server URL | `https://api.wafflebase.io` |
 | `--api-key <key>` | API key | — |
 | `--workspace <id>` | Workspace ID | — |
 | `--profile <name>` | Config profile | `default` |

--- a/packages/frontend/.env.production
+++ b/packages/frontend/.env.production
@@ -1,4 +1,4 @@
 VITE_FRONTEND_BASENAME=/
-VITE_BACKEND_API_URL=https://wafflebase-api.yorkie.dev
+VITE_BACKEND_API_URL=https://api.wafflebase.io
 VITE_YORKIE_RPC_ADDR=https://api.yorkie.dev
 VITE_YORKIE_API_KEY=fbuqYRxotajGGzb3kUD6aX


### PR DESCRIPTION
## Summary
- Update default API URL from `wafflebase-api.yorkie.dev` to `api.wafflebase.io`
- Changes frontend `.env.production`, CLI default server, CLI schema registry, and CLI docs

## Related
- Companion PR in yorkie-team/devops for ingress + deployment changes

## Test plan
- [ ] Verify `pnpm verify:fast` passes (done locally)
- [ ] After devops PR is merged and ACM cert is issued, verify `https://api.wafflebase.io` serves the API
- [ ] Verify OAuth login flow works end-to-end
- [ ] Update GitHub OAuth App callback URL to `https://api.wafflebase.io/auth/github/callback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default API server endpoint across the CLI and frontend to point to the new api.wafflebase.io domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->