### PR TITLE
Sync non-cell remote changes (styles, dimensions, etc.)

### DIFF
--- a/packages/frontend/src/app/spreadsheet/remote-change-utils.ts
+++ b/packages/frontend/src/app/spreadsheet/remote-change-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Pattern matching Yorkie operation paths that require cross-sheet formula
+ * recalculation: cell data, merge definitions, and tab name changes.
+ */
+const cellChangePattern =
+  /^\$\.sheets\.[^.]+\.(cells|merges)|^\$\.tabs\.[^.]+\.name/;
+
+/**
+ * Determine whether a set of remote-change operations includes changes that
+ * require cross-sheet formula recalculation.
+ *
+ * Cell/merge/tab-name changes need recalc + render; everything else (styles,
+ * dimensions, charts, filters, etc.) only needs reload + render.
+ *
+ * When operations are missing (`undefined`), we conservatively assume recalc
+ * is needed.
+ */
+export function needsRecalc(
+  operations: Array<{ path?: string }> | undefined,
+): boolean {
+  if (!operations) return true;
+  return operations.some(
+    (op) => op.path != null && cellChangePattern.test(op.path),
+  );
+}

--- a/packages/frontend/src/app/spreadsheet/sheet-view.tsx
+++ b/packages/frontend/src/app/spreadsheet/sheet-view.tsx
@@ -25,6 +25,7 @@ import { useTheme } from "@/components/theme-provider";
 import { useDocument } from "@yorkie-js/react";
 import { SheetChart, SpreadsheetDocument } from "@/types/worksheet";
 import { YorkieStore } from "./yorkie-store";
+import { needsRecalc } from "./remote-change-utils";
 import { UserPresence } from "@/types/users";
 import { useMobileSheetGestures } from "@/hooks/use-mobile-sheet-gestures";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -634,7 +635,7 @@ export function SheetView({
         }),
       );
 
-      const runCrossSheetRecalc = () => {
+      const runRemoteSync = (needsRecalc: boolean) => {
         if (cancelled || !sheet) return;
         if (recalcInFlight) {
           recalcPending = true;
@@ -646,22 +647,25 @@ export function SheetView({
           .reloadDimensions()
           .then(() => {
             if (cancelled || !sheet) return;
-            return sheet.recalculateCrossSheetFormulas();
+            if (needsRecalc) {
+              return sheet.recalculateCrossSheetFormulas();
+            }
+            sheet.render();
           })
           .finally(() => {
             recalcInFlight = false;
             if (recalcPending) {
               recalcPending = false;
-              queueMicrotask(runCrossSheetRecalc);
+              queueMicrotask(() => runRemoteSync(needsRecalc));
             }
           });
       };
 
-      const scheduleCrossSheetRecalc = () => {
+      const scheduleRemoteSync = (needsRecalc: boolean) => {
         if (cancelled || recalcFrame !== null) return;
         recalcFrame = requestAnimationFrame(() => {
           recalcFrame = null;
-          runCrossSheetRecalc();
+          runRemoteSync(needsRecalc);
         });
       };
 
@@ -758,31 +762,19 @@ export function SheetView({
 
       // Recalculate cross-sheet formulas on initial load (tab switch)
       // so that any changes made in other sheets are reflected immediately.
-      runCrossSheetRecalc();
+      runRemoteSync(true);
 
-      // Trigger cross-sheet recalc only when remote changes include cell
-      // data modifications. Non-cell changes (styles, dimensions, presence)
-      // don't affect formula values and can be skipped.
+      // Re-render on any remote change. Cell/merge/tab-name changes also
+      // trigger cross-sheet formula recalculation; all other changes
+      // (styles, dimensions, charts, filters, etc.) only reload state and
+      // re-render without the expensive recalc pass.
       unsubs.push(
         doc.subscribe((e) => {
           if (e.type !== "remote-change") return;
           const ops = (
             e as { value?: { operations?: Array<{ path?: string }> } }
           ).value?.operations;
-          if (!ops) {
-            scheduleCrossSheetRecalc();
-            return;
-          }
-          const hasCellChange = ops.some((op) => {
-            if (!op.path) return false;
-            return (
-              /^\$\.sheets\.[^.]+\.(cells|merges)/.test(op.path) ||
-              /^\$\.tabs\.[^.]+\.name/.test(op.path)
-            );
-          });
-          if (hasCellChange) {
-            scheduleCrossSheetRecalc();
-          }
+          scheduleRemoteSync(needsRecalc(ops));
         }),
       );
       unsubs.push(doc.subscribe("presence", scheduleOverlayRender));

--- a/packages/frontend/tests/app/spreadsheet/remote-change-utils.test.ts
+++ b/packages/frontend/tests/app/spreadsheet/remote-change-utils.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { needsRecalc } from "../../../src/app/spreadsheet/remote-change-utils.ts";
+
+// ---------------------------------------------------------------------------
+// needsRecalc — paths that require cross-sheet formula recalculation
+// ---------------------------------------------------------------------------
+
+test("returns true when operations are undefined (conservative)", () => {
+  assert.equal(needsRecalc(undefined), true);
+});
+
+test("returns true for cell data changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.cells.1.2" }];
+  assert.equal(needsRecalc(ops), true);
+});
+
+test("returns true for merge changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.merges.0" }];
+  assert.equal(needsRecalc(ops), true);
+});
+
+test("returns true for tab name changes", () => {
+  const ops = [{ path: "$.tabs.tab-1.name" }];
+  assert.equal(needsRecalc(ops), true);
+});
+
+test("returns true when cell change is mixed with style changes", () => {
+  const ops = [
+    { path: "$.sheets.tab-1.rangeStyles.0" },
+    { path: "$.sheets.tab-1.cells.1.1" },
+  ];
+  assert.equal(needsRecalc(ops), true);
+});
+
+// ---------------------------------------------------------------------------
+// needsRecalc — paths that only need reload + render (no recalc)
+// ---------------------------------------------------------------------------
+
+test("returns false for rangeStyles changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.rangeStyles.0" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for colStyles changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.colStyles.3" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for rowStyles changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.rowStyles.5" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for sheetStyle changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.sheetStyle" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for rowHeights changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.rowHeights.10" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for colWidths changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.colWidths.4" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for conditionalFormats changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.conditionalFormats.0" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for filter changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.filter" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for hiddenRows changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.hiddenRows.0" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for hiddenColumns changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.hiddenColumns.2" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for frozenRows changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.frozenRows" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for frozenCols changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.frozenCols" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for chart changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.charts.chart-1" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for rowOrder changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.rowOrder.0" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for colOrder changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.colOrder.0" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for tabOrder changes", () => {
+  const ops = [{ path: "$.tabOrder.0" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for pivotTable changes", () => {
+  const ops = [{ path: "$.sheets.tab-1.pivotTable" }];
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for empty operations array", () => {
+  assert.equal(needsRecalc([]), false);
+});
+
+test("returns false when all ops have no path", () => {
+  const ops = [{ path: undefined }, {}] as Array<{ path?: string }>;
+  assert.equal(needsRecalc(ops), false);
+});
+
+test("returns false for multiple non-cell changes", () => {
+  const ops = [
+    { path: "$.sheets.tab-1.rangeStyles.0" },
+    { path: "$.sheets.tab-1.colWidths.3" },
+    { path: "$.sheets.tab-1.rowHeights.5" },
+  ];
+  assert.equal(needsRecalc(ops), false);
+});

--- a/packages/frontend/tests/app/spreadsheet/yorkie-cross-sheet.integration.ts
+++ b/packages/frontend/tests/app/spreadsheet/yorkie-cross-sheet.integration.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { parseRef } from "@wafflebase/sheet";
 import { setupCrossSheetEnv } from "../../helpers/cross-sheet-yorkie.ts";
+import { needsRecalc } from "../../../src/app/spreadsheet/remote-change-utils.ts";
 
 const shouldRun = Boolean(process.env.YORKIE_RPC_ADDR);
 
@@ -127,6 +128,108 @@ test("remote-change event includes cell path for data edits", { skip: !shouldRun
       true,
       `Expected cell path in: ${JSON.stringify(cellPaths)}`,
     );
+  } finally {
+    await env.cleanup();
+  }
+});
+
+test("remote-change event for style edit does not need recalc", { skip: !shouldRun }, async () => {
+  const env = await setupCrossSheetEnv("style-event-path");
+  try {
+    const events: Array<{
+      type: string;
+      operations?: Array<{ path?: string }>;
+    }> = [];
+    env.subscribeA((e: unknown) => {
+      const evt = e as {
+        type: string;
+        value?: { operations?: Array<{ path?: string }> };
+      };
+      if (evt.type === "remote-change") {
+        events.push({
+          type: evt.type,
+          operations: evt.value?.operations,
+        });
+      }
+    });
+
+    // ClientB applies a range style (background color) to Sheet2
+    await env.storeB2.addRangeStyle({
+      startRef: parseRef("A1"),
+      endRef: parseRef("B3"),
+      style: { bgColor: "#ff0000" },
+    });
+    await env.sync();
+
+    // Verify remote-change events contain rangeStyles path, not cells
+    const allPaths = events.flatMap((e) =>
+      (e.operations ?? []).map((op) => op.path).filter(Boolean),
+    );
+    const hasStylePath = allPaths.some((p) =>
+      /^\$\.sheets\.[^.]+\.rangeStyles/.test(p!),
+    );
+    assert.equal(
+      hasStylePath,
+      true,
+      `Expected rangeStyles path in: ${JSON.stringify(allPaths)}`,
+    );
+
+    // The style-only operations should NOT require formula recalculation
+    for (const e of events) {
+      assert.equal(
+        needsRecalc(e.operations),
+        false,
+        `Style-only event should not need recalc: ${JSON.stringify(e.operations?.map((op) => op.path))}`,
+      );
+    }
+  } finally {
+    await env.cleanup();
+  }
+});
+
+test("remote-change event for dimension edit does not need recalc", { skip: !shouldRun }, async () => {
+  const env = await setupCrossSheetEnv("dimension-event-path");
+  try {
+    const events: Array<{
+      type: string;
+      operations?: Array<{ path?: string }>;
+    }> = [];
+    env.subscribeA((e: unknown) => {
+      const evt = e as {
+        type: string;
+        value?: { operations?: Array<{ path?: string }> };
+      };
+      if (evt.type === "remote-change") {
+        events.push({
+          type: evt.type,
+          operations: evt.value?.operations,
+        });
+      }
+    });
+
+    // ClientB changes a column width in Sheet2
+    await env.storeB2.setDimensionSize("col", 2, 200);
+    await env.sync();
+
+    const allPaths = events.flatMap((e) =>
+      (e.operations ?? []).map((op) => op.path).filter(Boolean),
+    );
+    const hasDimPath = allPaths.some((p) =>
+      /^\$\.sheets\.[^.]+\.colWidths/.test(p!),
+    );
+    assert.equal(
+      hasDimPath,
+      true,
+      `Expected colWidths path in: ${JSON.stringify(allPaths)}`,
+    );
+
+    for (const e of events) {
+      assert.equal(
+        needsRecalc(e.operations),
+        false,
+        `Dimension-only event should not need recalc: ${JSON.stringify(e.operations?.map((op) => op.path))}`,
+      );
+    }
   } finally {
     await env.cleanup();
   }


### PR DESCRIPTION
## Summary
- Fix: remote style/layout/chart/filter changes from collaborators were not rendered until page refresh
- Now all `remote-change` events trigger `reloadDimensions()` + `render()`
- Cell/merge/tab-name changes additionally run cross-sheet formula recalculation; non-cell changes skip the expensive recalc pass
- Extract `needsRecalc()` into `remote-change-utils.ts` for testability

## Test plan
- [x] 25 unit tests covering all known Yorkie operation paths (recalc vs render-only classification)
- [x] 2 integration tests for style and dimension change events (require Yorkie server)
- [x] `pnpm verify:fast` passes
- [x] Manual: User1 changes cell background color → User2 sees it immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized remote change handling in collaborative spreadsheets with selective formula recalculation based on operation types.

* **Tests**
  * Added comprehensive test coverage for remote change detection, including cell modifications, style changes, and dimension edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->