### PR TITLE
Fix CLI version to read from package.json dynamically

### DIFF
--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -1,7 +1,11 @@
+import { createRequire } from 'node:module';
 import { Command } from 'commander';
 import { resolveConfig, type CliConfig } from '../config/config.js';
 import { HttpClient } from '../client/http-client.js';
 import type { OutputFormat } from '../output/formatter.js';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../../package.json') as { version: string };
 
 export interface GlobalOpts {
   server?: string;
@@ -38,7 +42,7 @@ export function createProgram(): Command {
   program
     .name('wafflebase')
     .description('CLI for Wafflebase spreadsheet API')
-    .version('0.1.0')
+    .version(version)
     .option('--server <url>', 'Server URL')
     .option('--api-key <key>', 'API key')
     .option('--workspace <id>', 'Workspace ID')

--- a/packages/cli/test/version.test.ts
+++ b/packages/cli/test/version.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { createProgram } from '../src/commands/root.js';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as { version: string };
+
+describe('version', () => {
+  it('should match package.json version', () => {
+    const program = createProgram();
+    expect(program.version()).toBe(pkg.version);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace hardcoded `.version('0.1.0')` in CLI root command with dynamic read from `package.json`
- `wafflebase --version` was reporting 0.1.0 after the 0.2.0 release because the version string in `root.ts` was not updated
- Add regression test asserting CLI program version matches `package.json`

## Test plan
- [x] `pnpm verify:fast` passes
- [x] `node dist/bin.js --version` outputs `0.2.0`
- [x] New `version.test.ts` verifies version matches package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI version display to dynamically retrieve the correct version from package metadata instead of using a hardcoded value.

* **Tests**
  * Added test coverage to verify CLI version consistency with package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->