### PR TITLE
Use per-request Yorkie client to avoid concurrent attach conflicts

### DIFF
--- a/packages/backend/src/yorkie/yorkie.service.spec.ts
+++ b/packages/backend/src/yorkie/yorkie.service.spec.ts
@@ -84,16 +84,48 @@ describe('YorkieService', () => {
       expect(mockDeactivate).toHaveBeenCalled();
     });
 
+    it('deactivates even if attach throws', async () => {
+      mockAttach.mockRejectedValueOnce(new Error('attach failed'));
+      const callback = jest.fn();
+
+      await expect(service.withDocument('doc-1', callback)).rejects.toThrow(
+        'attach failed',
+      );
+      expect(callback).not.toHaveBeenCalled();
+      expect(mockDeactivate).toHaveBeenCalled();
+    });
+
+    it('deactivates even if detach throws', async () => {
+      mockDetach.mockRejectedValueOnce(new Error('detach failed'));
+      const callback = jest.fn().mockReturnValue('ok');
+
+      await expect(service.withDocument('doc-1', callback)).rejects.toThrow(
+        'detach failed',
+      );
+      expect(mockDeactivate).toHaveBeenCalled();
+    });
+
     it('concurrent calls to the same document should not conflict', async () => {
-      // Simulate slow callbacks so both requests overlap
-      const slow = () =>
-        new Promise<string>((resolve) => setTimeout(() => resolve('a'), 50));
+      // Use a deferred barrier for deterministic overlap control
+      let releaseBarrier: () => void;
+      const barrier = new Promise<void>((resolve) => {
+        releaseBarrier = resolve;
+      });
+
+      const slow = async () => {
+        await barrier;
+        return 'a';
+      };
       const fast = () => Promise.resolve('b');
 
-      const results = await Promise.all([
+      const promise = Promise.all([
         service.withDocument('doc-1', slow),
         service.withDocument('doc-1', fast),
       ]);
+
+      // Release the barrier after both calls have started
+      releaseBarrier!();
+      const results = await promise;
 
       expect(results).toEqual(['a', 'b']);
       // Each call should use its own client (activate called twice)

--- a/packages/backend/src/yorkie/yorkie.service.ts
+++ b/packages/backend/src/yorkie/yorkie.service.ts
@@ -23,18 +23,25 @@ export class YorkieService {
       rpcAddr: this.rpcAddr,
       apiKey: this.apiKey,
     });
-    await client.activate();
     const doc = new yorkie.Document<SpreadsheetDocument>(
       `sheet-${documentId}`,
     );
-    await client.attach(doc, { syncMode: SyncMode.Manual });
+    let attached = false;
     try {
+      await client.activate();
+      await client.attach(doc, { syncMode: SyncMode.Manual });
+      attached = true;
       const result = await callback(doc);
       await client.sync(doc);
       return result;
     } finally {
-      await client.detach(doc);
-      await client.deactivate();
+      try {
+        if (attached) {
+          await client.detach(doc);
+        }
+      } finally {
+        await client.deactivate();
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Single shared Yorkie client caused `ErrConflictOnUpdate` (gRPC FAILED_PRECONDITION) when concurrent API requests attached the same document
- Each `withDocument()` call now creates, activates, and deactivates its own Yorkie client for full request isolation
- Added concurrent-call test that reproduces the original failure

## Test plan
- [x] `pnpm verify:fast` passes (102 backend tests, 1029 sheet tests, 59 CLI tests)
- [x] Deploy to staging and verify `wafflebase tab list <doc-id>` returns tabs
- [x] Verify concurrent CLI requests to the same document don't conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering multiple failure scenarios to ensure cleanup always occurs.
  * Added concurrent-operation test to confirm simultaneous document requests don't conflict.

* **Refactor**
  * Changed to per-operation resource initialization for document workflows.
  * Improved lifecycle handling so resources are reliably deactivated after success or error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->