### PR TITLE
Fix cut-paste deleting pasted values when ranges overlap

### DIFF
--- a/packages/frontend/tests/app/spreadsheet/yorkie-cut-paste.test.ts
+++ b/packages/frontend/tests/app/spreadsheet/yorkie-cut-paste.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseRef, toSref } from "@wafflebase/sheet";
+import { createSingleUserYorkie } from "../../helpers/single-user-yorkie.ts";
+
+const shouldRun = Boolean(process.env.YORKIE_RPC_ADDR);
+
+/**
+ * Simulates the cut-paste batch sequence at the store level:
+ *   1. beginBatch
+ *   2. setGrid (paste destination values)
+ *   3. delete source cells that don't overlap destination
+ *   4. endBatch
+ */
+
+test(
+  "YorkieStore batch: cut A1 paste A2 (no overlap) preserves pasted value",
+  { skip: !shouldRun },
+  async () => {
+    const ctx = await createSingleUserYorkie("cut-paste-no-overlap");
+    try {
+      const { store } = ctx;
+
+      // Seed: A1=1, A2=2
+      await store.set(parseRef("A1"), { v: "1" });
+      await store.set(parseRef("A2"), { v: "2" });
+
+      // Simulate cut A1 → paste A2
+      store.beginBatch();
+      await store.setGrid(new Map([[toSref(parseRef("A2")), { v: "1" }]]));
+      await store.delete(parseRef("A1"));
+      store.endBatch();
+
+      const a2 = await store.get(parseRef("A2"));
+      const a1 = await store.get(parseRef("A1"));
+      assert.equal(a2?.v, "1", "A2 should have pasted value 1");
+      assert.equal(a1, undefined, "A1 should be cleared");
+    } finally {
+      await ctx.cleanup();
+    }
+  },
+);
+
+test(
+  "YorkieStore batch: cut A1:A2 paste A2 (overlapping) preserves pasted values",
+  { skip: !shouldRun },
+  async () => {
+    const ctx = await createSingleUserYorkie("cut-paste-overlap");
+    try {
+      const { store } = ctx;
+
+      // Seed: A1=1, A2=2, A3=3
+      await store.set(parseRef("A1"), { v: "1" });
+      await store.set(parseRef("A2"), { v: "2" });
+      await store.set(parseRef("A3"), { v: "3" });
+
+      // Simulate cut A1:A2 → paste starting at A2 (destination A2:A3)
+      const pasteGrid = new Map([
+        [toSref(parseRef("A2")), { v: "1" }],
+        [toSref(parseRef("A3")), { v: "2" }],
+      ]);
+
+      store.beginBatch();
+      await store.setGrid(pasteGrid);
+      // Only delete source cells NOT in paste destination (A1 only)
+      // A2 is in both source and destination — must NOT be deleted
+      await store.delete(parseRef("A1"));
+      store.endBatch();
+
+      const a1 = await store.get(parseRef("A1"));
+      const a2 = await store.get(parseRef("A2"));
+      const a3 = await store.get(parseRef("A3"));
+      assert.equal(a1, undefined, "A1 should be cleared");
+      assert.equal(a2?.v, "1", "A2 should have value from A1");
+      assert.equal(a3?.v, "2", "A3 should have value from A2");
+    } finally {
+      await ctx.cleanup();
+    }
+  },
+);

--- a/packages/frontend/tests/helpers/single-user-yorkie.ts
+++ b/packages/frontend/tests/helpers/single-user-yorkie.ts
@@ -1,0 +1,63 @@
+import yorkie from "@yorkie-js/sdk";
+import { YorkieStore } from "@/app/spreadsheet/yorkie-store";
+import { initialSpreadsheetDocument } from "@/types/worksheet";
+
+type YorkieClient = {
+  activate(): Promise<void>;
+  deactivate(): Promise<void>;
+  attach(doc: object, options?: object): Promise<object>;
+  detach(doc: object): Promise<object>;
+};
+
+const { Client, Document, SyncMode } = yorkie as {
+  Client: new (options?: Record<string, unknown>) => YorkieClient;
+  Document: new (key: string) => object;
+  SyncMode: { Manual: unknown };
+};
+
+function cloneInitialDocument() {
+  return JSON.parse(JSON.stringify(initialSpreadsheetDocument()));
+}
+
+export interface SingleUserContext {
+  store: YorkieStore;
+  cleanup(): Promise<void>;
+}
+
+/**
+ * Creates a single-user Yorkie-backed store for integration testing.
+ * Requires a running Yorkie server (YORKIE_RPC_ADDR).
+ */
+export async function createSingleUserYorkie(
+  testName: string,
+): Promise<SingleUserContext> {
+  const slug = testName.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+  const docKey = `single-${slug}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const client = new Client({
+    key: `single-user-${slug}`,
+    rpcAddr: process.env.YORKIE_RPC_ADDR ?? "http://localhost:8080",
+    apiKey: process.env.YORKIE_API_KEY,
+    syncLoopDuration: 10,
+    retrySyncLoopDelay: 10,
+    reconnectStreamDelay: 10,
+  });
+
+  const doc = new Document(docKey);
+
+  await client.activate();
+  await client.attach(doc, {
+    initialRoot: cloneInitialDocument(),
+    syncMode: SyncMode.Manual,
+  });
+
+  const store = new YorkieStore(doc as never, "tab-1");
+
+  return {
+    store,
+    async cleanup() {
+      await client.detach(doc).catch(() => {});
+      await client.deactivate().catch(() => {});
+    },
+  };
+}

--- a/packages/sheet/src/model/worksheet/sheet.ts
+++ b/packages/sheet/src/model/worksheet/sheet.ts
@@ -1958,9 +1958,18 @@ export class Sheet {
         await calculate(this, dependantsMap, expanded);
       }
 
-      // Cut-paste: clear source cells, remove source styles, redirect references
+      // Cut-paste: clear source cells, remove source styles, redirect references.
+      // Only delete source cells that don't overlap with the pasted destination
+      // to avoid erasing values that were just written by setGrid above.
       if (isCut && cutSourceRange && cutRefMap) {
-        await this.store.deleteRange(cutSourceRange);
+        for (let r = cutSourceRange[0].r; r <= cutSourceRange[1].r; r++) {
+          for (let c = cutSourceRange[0].c; c <= cutSourceRange[1].c; c++) {
+            const sref = toSref({ r, c });
+            if (!grid.has(sref)) {
+              await this.store.delete({ r, c });
+            }
+          }
+        }
         this.removeRangeStylesOverlapping(cutSourceRange);
         await this.store.setRangeStyles(this.rangeStyles);
         await this.redirectFormulasForCut(cutRefMap);

--- a/packages/sheet/test/sheet/clipboard.test.ts
+++ b/packages/sheet/test/sheet/clipboard.test.ts
@@ -492,4 +492,45 @@ describe('Sheet.cut & paste', () => {
     // Source still has value (copy, not cut)
     expect(await sheet.toDisplayString({ r: 1, c: 1 })).toBe('10');
   });
+
+  it('should overwrite existing cell when cut-pasting onto it', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1');
+    await sheet.setData({ r: 2, c: 1 }, '2');
+
+    // Cut A1
+    sheet.selectStart({ r: 1, c: 1 });
+    const { text } = await sheet.cut();
+
+    // Paste to A2 (which already has value '2')
+    sheet.selectStart({ r: 2, c: 1 });
+    await sheet.paste({ text });
+
+    // A2 should have the cut value
+    expect(await sheet.toDisplayString({ r: 2, c: 1 })).toBe('1');
+    // A1 should be cleared
+    expect(await sheet.toDisplayString({ r: 1, c: 1 })).toBe('');
+  });
+
+  it('should handle cut-paste with overlapping source and destination (shift down by 1)', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1');
+    await sheet.setData({ r: 2, c: 1 }, '2');
+    await sheet.setData({ r: 3, c: 1 }, '3');
+
+    // Cut A1:A2 (values 1,2)
+    sheet.selectStart({ r: 1, c: 1 });
+    sheet.selectEnd({ r: 2, c: 1 });
+    const { text } = await sheet.cut();
+
+    // Paste to A2 (destination A2:A3 overlaps source A1:A2 at A2)
+    sheet.selectStart({ r: 2, c: 1 });
+    await sheet.paste({ text });
+
+    // A2 should have value 1 (from A1), A3 should have value 2 (from A2)
+    expect(await sheet.toDisplayString({ r: 2, c: 1 })).toBe('1');
+    expect(await sheet.toDisplayString({ r: 3, c: 1 })).toBe('2');
+    // A1 should be cleared (was part of cut source, not part of destination)
+    expect(await sheet.toDisplayString({ r: 1, c: 1 })).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- Fix `paste()` in `sheet.ts` to skip deleting source cells that overlap with the paste destination, preventing pasted values from being erased during cut-paste operations
- Add sheet-level unit tests for cut-paste onto existing cells and overlapping source/destination ranges
- Add YorkieStore-level integration tests verifying batch overlay correctness for cut-paste scenarios

## Root Cause
`deleteRange(cutSourceRange)` in `paste()` deleted ALL cells in the cut source range, including cells that overlap with the paste destination and were just written by `setGrid()`. For example, cutting A1:A2 and pasting to A2:A3 would write A2 and A3, then delete A1 and A2 — erasing the just-pasted A2 value.

## Fix
Replace `deleteRange(cutSourceRange)` with per-cell deletion that checks `!grid.has(sref)` before deleting, preserving cells that are part of the paste destination.

## Test plan
- [x] `pnpm verify:fast` passes
- [x] `pnpm verify:self` passes (pre-push hook)
- [x] Sheet unit tests: cut-paste onto existing cell, overlapping source/destination
- [x] YorkieStore integration tests: no-overlap and overlapping cut-paste batches (requires Yorkie server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cut-paste operations to correctly preserve overlapping cell values when the destination range overlaps with the source range. Previously, data could be lost during these operations; now values are properly relocated and the source cells are appropriately cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->