### PR TITLE
Fix Yorkie proxy ownKeys duplicate entries crash

### DIFF
--- a/packages/frontend/src/app/spreadsheet/yorkie-store.ts
+++ b/packages/frontend/src/app/spreadsheet/yorkie-store.ts
@@ -15,6 +15,7 @@ import {
   cloneRangeStylePatch,
   normalizeRangeStylePatch,
   writeWorksheetCell,
+  safeWorksheetRecordEntries,
 } from "@wafflebase/sheet";
 import type {
   Store,
@@ -591,7 +592,7 @@ export class YorkieStore implements Store {
     const obj = axis === "row" ? ws.rowHeights : ws.colWidths;
     const result = new Map<number, number>();
     if (obj) {
-      for (const [key, value] of Object.entries(obj)) {
+      for (const [key, value] of safeWorksheetRecordEntries(obj)) {
         result.set(Number(key), value);
       }
     }
@@ -635,7 +636,7 @@ export class YorkieStore implements Store {
     const ws = this.getSheet();
     const result = new Map<number, CellStyle>();
     if (ws.colStyles) {
-      for (const [key, value] of Object.entries(ws.colStyles)) {
+      for (const [key, value] of safeWorksheetRecordEntries(ws.colStyles)) {
         result.set(Number(key), value);
       }
     }
@@ -667,7 +668,7 @@ export class YorkieStore implements Store {
     const ws = this.getSheet();
     const result = new Map<number, CellStyle>();
     if (ws.rowStyles) {
-      for (const [key, value] of Object.entries(ws.rowStyles)) {
+      for (const [key, value] of safeWorksheetRecordEntries(ws.rowStyles)) {
         result.set(Number(key), value);
       }
     }
@@ -857,7 +858,7 @@ export class YorkieStore implements Store {
     const ws = this.getSheet();
     const result = new Map<Sref, MergeSpan>();
     if (!ws.merges) return result;
-    for (const [sref, span] of Object.entries(ws.merges)) {
+    for (const [sref, span] of safeWorksheetRecordEntries(ws.merges)) {
       result.set(sref, { ...span });
     }
     return result;
@@ -1060,7 +1061,7 @@ export class YorkieStore implements Store {
 
     const beforeCellKeys = new Set(this.worksheetKeys(this.getSheet()));
     const beforeMerges = new Map<Sref, MergeSpan>(
-      Object.entries(this.getSheet().merges || {}) as Array<[Sref, MergeSpan]>,
+      safeWorksheetRecordEntries(this.getSheet().merges) as Array<[Sref, MergeSpan]>,
     );
     this.doc.history.undo();
     this.dirty = true;
@@ -1074,7 +1075,7 @@ export class YorkieStore implements Store {
 
     const beforeCellKeys = new Set(this.worksheetKeys(this.getSheet()));
     const beforeMerges = new Map<Sref, MergeSpan>(
-      Object.entries(this.getSheet().merges || {}) as Array<[Sref, MergeSpan]>,
+      safeWorksheetRecordEntries(this.getSheet().merges) as Array<[Sref, MergeSpan]>,
     );
     this.doc.history.redo();
     this.dirty = true;
@@ -1092,7 +1093,7 @@ export class YorkieStore implements Store {
   ): Range | undefined {
     const afterKeys = new Set(this.worksheetKeys(this.getSheet()));
     const afterMerges = new Map<Sref, MergeSpan>(
-      Object.entries(this.getSheet().merges || {}) as Array<[Sref, MergeSpan]>,
+      safeWorksheetRecordEntries(this.getSheet().merges) as Array<[Sref, MergeSpan]>,
     );
 
     // Find all changed srefs (added, removed, or modified)

--- a/packages/frontend/src/app/spreadsheet/yorkie-worksheet-structure.ts
+++ b/packages/frontend/src/app/spreadsheet/yorkie-worksheet-structure.ts
@@ -12,6 +12,9 @@ import {
   shiftFormula,
   shiftMergeMap,
   shiftRangeStylePatches,
+  safeWorksheetRecordEntries,
+  safeWorksheetRecordKeys,
+  safeWorksheetRecordValues,
   shiftSref,
   toSref,
   writeWorksheetCell,
@@ -31,7 +34,7 @@ type NormalizeCell = (cell: Cell) => Cell | null;
 
 function toIndexedMap<T>(record: Record<string, T>): Map<number, T> {
   return new Map(
-    Object.entries(record).map(([key, value]) => [Number(key), value]),
+    safeWorksheetRecordEntries(record).map(([key, value]) => [Number(key), value]),
   );
 }
 
@@ -39,7 +42,7 @@ function replaceIndexedRecord<T>(
   record: Record<string, T>,
   next: Map<number, T>,
 ): void {
-  for (const key of Object.keys(record)) {
+  for (const key of safeWorksheetRecordKeys(record)) {
     delete record[key];
   }
 
@@ -83,7 +86,7 @@ function shiftChartAnchors(
     return;
   }
 
-  for (const chart of Object.values(charts as Record<string, SheetChart>)) {
+  for (const chart of safeWorksheetRecordValues(charts as Record<string, SheetChart>)) {
     const shiftedAnchor = shiftSref(chart.anchor, axis, index, count);
     if (shiftedAnchor) {
       chart.anchor = shiftedAnchor;
@@ -112,7 +115,7 @@ function moveChartAnchors(
     return;
   }
 
-  for (const chart of Object.values(charts as Record<string, SheetChart>)) {
+  for (const chart of safeWorksheetRecordValues(charts as Record<string, SheetChart>)) {
     const nextAnchor = moveRef(
       parseRef(chart.anchor),
       axis,
@@ -171,7 +174,7 @@ export function applyYorkieWorksheetShift(options: {
   replaceMerges(
     ws,
     shiftMergeMap(
-      new Map(Object.entries(ws.merges || {}) as Array<[Sref, MergeSpan]>),
+      new Map(safeWorksheetRecordEntries(ws.merges) as Array<[Sref, MergeSpan]>),
       axis,
       index,
       count,
@@ -232,7 +235,7 @@ export function applyYorkieWorksheetMove(options: {
   replaceMerges(
     ws,
     moveMergeMap(
-      new Map(Object.entries(ws.merges || {}) as Array<[Sref, MergeSpan]>),
+      new Map(safeWorksheetRecordEntries(ws.merges) as Array<[Sref, MergeSpan]>),
       axis,
       srcIndex,
       count,

--- a/packages/sheet/src/index.ts
+++ b/packages/sheet/src/index.ts
@@ -126,6 +126,7 @@ import {
 import {
   safeWorksheetRecordKeys,
   safeWorksheetRecordEntries,
+  safeWorksheetRecordValues,
   createWorksheetAxisId,
   createWorksheetCellKey,
   parseWorksheetCellKey,
@@ -219,6 +220,7 @@ export {
   replaceWorksheetCells,
   safeWorksheetRecordKeys,
   safeWorksheetRecordEntries,
+  safeWorksheetRecordValues,
   createWorksheetAxisId,
   createWorksheetCellKey,
   parseWorksheetCellKey,

--- a/packages/sheet/src/model/workbook/worksheet-record.ts
+++ b/packages/sheet/src/model/workbook/worksheet-record.ts
@@ -60,6 +60,20 @@ export function safeWorksheetRecordEntries<T>(
   }
 }
 
+export function safeWorksheetRecordValues<T>(obj?: Record<string, T>): T[] {
+  if (!obj) {
+    return [];
+  }
+  try {
+    return Object.values(obj);
+  } catch (error) {
+    if (isDuplicateOwnKeysError(error)) {
+      return Object.values(snapshotRecord(obj));
+    }
+    throw error;
+  }
+}
+
 export function createWorksheetAxisId(prefix: 'r' | 'c', index: number): string {
   return `${prefix}${index}`;
 }


### PR DESCRIPTION
## Summary
- Replace all unsafe `Object.entries/keys/values` calls on Yorkie CRDT proxy objects with `safeWorksheetRecord*` utilities
- Add new `safeWorksheetRecordValues` utility for chart iteration
- Fixes `TypeError: 'ownKeys' on proxy: trap returned duplicate entries` crash when loading sheets with concurrent edits

## Root Cause
Yorkie CRDT proxy's `ownKeys` trap can return duplicate keys when concurrent operations cause timestamp reversal in `ElementRHT.set()`. This makes `Object.entries()` throw a TypeError per JavaScript's Proxy invariants.

The codebase already had `safeWorksheetRecordEntries` and `safeWorksheetRecordKeys` utilities that catch this error and fall back to a snapshot copy, but 14 callsites were not using them.

## Changes
- **worksheet-record.ts**: Add `safeWorksheetRecordValues` utility
- **yorkie-store.ts**: Replace 7 unsafe `Object.entries()` calls (dimensions, styles, merges, undo/redo)
- **yorkie-worksheet-structure.ts**: Replace 6 unsafe calls (indexed maps, chart anchors, merges)

## Test plan
- [x] `pnpm verify:fast` passes
- [ ] Load the affected sheet URL and verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spreadsheet stability by enhancing worksheet record handling to prevent iteration-related failures when working with dimensions, styles, and merge configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->