### PR TITLE
Improve mobile UX for homepage demo and sheet editing

### DIFF
--- a/packages/frontend/src/app/home/demo-section.tsx
+++ b/packages/frontend/src/app/home/demo-section.tsx
@@ -30,7 +30,7 @@ export function DemoSection() {
           <div className="size-2.5 rounded-full bg-[#FEBC2E]" />
           <div className="size-2.5 rounded-full bg-[#28C840]" />
         </div>
-        <div className="w-full aspect-video relative">
+        <div className="w-full aspect-[4/3] md:aspect-video relative">
           {!loaded && (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-muted gap-3">
               <div className="size-6 border-2 border-muted-foreground/30 border-t-muted-foreground rounded-full animate-spin" />

--- a/packages/frontend/src/components/mobile-edit-panel.tsx
+++ b/packages/frontend/src/components/mobile-edit-panel.tsx
@@ -38,7 +38,7 @@ export function MobileEditPanel({
   useEffect(() => {
     const el = textareaRef.current;
     if (el) {
-      el.focus();
+      el.focus({ preventScroll: true });
       el.setSelectionRange(0, el.value.length);
       autoGrow();
     }
@@ -63,7 +63,7 @@ export function MobileEditPanel({
       className="fixed inset-x-0 z-50 border-t bg-background px-2 py-1.5 shadow-lg"
       style={{
         bottom: keyboardOffset,
-        paddingBottom: `max(env(safe-area-inset-bottom, 0px), 6px)`,
+        paddingBottom: keyboardOffset > 0 ? 6 : `max(env(safe-area-inset-bottom, 0px), 6px)`,
       }}
     >
       <div className="flex items-start gap-2">

--- a/packages/sheet/src/view/spreadsheet.ts
+++ b/packages/sheet/src/view/spreadsheet.ts
@@ -199,6 +199,7 @@ export class Spreadsheet {
     if (!this.sheet || this._readOnly) return;
     const ref = this.sheet.getActiveCell();
     await this.sheet.setData(ref, value);
+    await this.worksheet.autoResizeActiveRow();
     this.worksheet.render();
     this.notifySelectionChange();
   }

--- a/packages/sheet/src/view/worksheet.ts
+++ b/packages/sheet/src/view/worksheet.ts
@@ -382,6 +382,15 @@ export class Worksheet {
     this.primeCellInputForSelection();
   }
 
+  /**
+   * `autoResizeActiveRow` auto-resizes the active cell's row to fit content.
+   * Used by external editors (e.g. mobile edit panel) after committing a value.
+   */
+  public async autoResizeActiveRow(): Promise<void> {
+    if (!this.sheet) return;
+    await this.autoResizeRow(this.sheet.getActiveCell().r);
+  }
+
   public cleanup() {
     if (this.pendingRenderFrame !== null) {
       cancelAnimationFrame(this.pendingRenderFrame);
@@ -4520,7 +4529,7 @@ export class Worksheet {
       layout.height,
       layout.maxWidth,
       layout.maxHeight,
-      !!this.mobileEditCallback,
+      !!this.mobileEditCallback || this.showMobileHandles,
     );
     this.cellInput.setCellPositionHint(undefined);
   }


### PR DESCRIPTION
## Summary
- Use 4:3 aspect ratio on mobile for homepage demo section (taller preview on small screens)
- Fix keyboard popup on sheet tab switch by using `showMobileHandles` flag (set at construction) instead of relying on `mobileEditCallback` (set after init)
- Use `focus({ preventScroll: true })` to prevent iOS Safari from shifting the viewport when the mobile edit panel opens
- Skip safe-area bottom padding when keyboard is visible to reduce gap between edit panel and keyboard
- Auto-resize row height on mobile after multiline cell edit via `commitExternalEdit`

## Test plan
- [x] `pnpm verify:fast` passes (lint + all unit tests)
- [x] iPhone simulator: verify homepage demo section has taller aspect ratio
- [x] iPhone simulator: verify tab switching does not trigger keyboard
- [x] iPhone simulator: verify cell editing does not shift viewport upward
- [x] iPhone simulator: verify multiline input auto-resizes row height

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed unintended page scrolling when focusing the mobile edit panel.

* **Improvements**
  * Demo container aspect ratio now responsive across screen sizes.
  * Mobile edit panel padding dynamically adjusts based on keyboard visibility.
  * Spreadsheet rows auto-resize when external edits are committed.
  * Mobile editing handles now properly enabled during cell input operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->