### PR TITLE
Fix to get proper result when whitespace inside of formula

### DIFF
--- a/packages/sheets/src/view/cellinput.ts
+++ b/packages/sheets/src/view/cellinput.ts
@@ -196,7 +196,7 @@ export class CellInput {
   }
 
   public getValue(): string {
-    return this.input.innerText;
+    return this.input.innerText.replace(/\u00a0/g, ' ');
   }
 
   public setValue(value: string): void {

--- a/packages/sheets/src/view/formulabar.ts
+++ b/packages/sheets/src/view/formulabar.ts
@@ -132,7 +132,7 @@ export class FormulaBar {
   }
 
   public getValue(): string {
-    return this.formulaInput.innerText;
+    return this.formulaInput.innerText.replace(/\u00a0/g, ' ');
   }
 
   public setValue(value: string) {


### PR DESCRIPTION
## Summary
Fix to replace `\u00a0` as whitespace character.

## Why
`=SUM(1, 2)` or `=ABS( -5)` gets error because whitespace `' '` is `\u00a0` as input.

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cell input now normalizes non-breaking spaces to regular spaces, preventing invisible spacing issues when entering or editing cell values.
  * Formula bar now normalizes non-breaking spaces to regular spaces, ensuring consistent formula text retrieval and reducing spacing-related inconsistencies when editing or evaluating expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->