### PR TITLE
Fix overflow text disappearing on horizontal scroll

### DIFF
--- a/packages/sheets/src/view/gridcanvas.ts
+++ b/packages/sheets/src/view/gridcanvas.ts
@@ -482,11 +482,14 @@ export class GridCanvas {
       return resolved;
     };
 
+    // Extend the overflow detection range to the left so that text from
+    // off-screen cells that overflows into the visible area is still drawn.
+    const overflowColStart = Math.max(1, colStart - 20);
     const overflowData = this.buildTextOverflowRenderData(
       ctx,
       rowStart,
       rowEnd,
-      colStart,
+      overflowColStart,
       colEnd,
       grid,
       colDim,
@@ -568,6 +571,32 @@ export class GridCanvas {
         mergeSpan,
         overflowEndCol,
       );
+    }
+
+    // Pass 3b: Render text from off-screen overflow anchors whose text
+    // spills into the visible viewport. These cells are outside the normal
+    // renderRefs range, so they need an extra draw pass.
+    if (overflowData) {
+      for (const [sref, endCol] of overflowData.anchorToEndCol) {
+        const ref = parseRef(sref);
+        if (ref.c < colStart && endCol >= colStart) {
+          const cell = grid?.get(sref);
+          const effectiveStyle = resolveCellStyle(ref.r, ref.c, cell);
+          this.renderCellContent(
+            ctx,
+            ref,
+            cell,
+            scroll,
+            rowDim,
+            colDim,
+            effectiveStyle,
+            grid,
+            colEnd,
+            undefined,
+            endCol,
+          );
+        }
+      }
     }
 
     // Pass 4: Render filter dropdown buttons inside filter header row cells.


### PR DESCRIPTION
## Summary
- When a cell contains long text that overflows into adjacent cells, scrolling right until the source cell leaves the viewport caused the overflowed text to vanish
- Extended overflow detection range 20 columns to the left of the viewport in `buildTextOverflowRenderData`
- Added supplementary render pass (3b) that draws text from off-screen anchor cells whose overflow reaches into the visible area

## Test plan
- [x] Enter long text in A1 that overflows into B1, C1
- [x] Scroll right until A1 is off-screen — verify overflowed text in B1/C1 still renders
- [x] Test with freeze panes active (frozen columns + horizontal scroll)
- [x] Verify `pnpm verify:fast` passes (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text overflow detection to identify overflow scenarios earlier in the rendering process.
  * Enhanced rendering of text that extends beyond cell boundaries, especially when originating from cells outside the currently visible area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->