### PR TITLE
Fix to get accurate result when reversed range in formula

### DIFF
--- a/packages/sheets/src/formula/functions-helpers.ts
+++ b/packages/sheets/src/formula/functions-helpers.ts
@@ -107,10 +107,14 @@ export function getReferenceMatrixFromExpression(
       prefix = `${sheetName}!`;
     }
 
-    const [from, to] = parseRange(localRange);
+    const [a, b] = parseRange(localRange);
+    const minR = Math.min(a.r, b.r);
+    const maxR = Math.max(a.r, b.r);
+    const minC = Math.min(a.c, b.c);
+    const maxC = Math.max(a.c, b.c);
     const refs: string[] = [];
-    for (let row = from.r; row <= to.r; row++) {
-      for (let col = from.c; col <= to.c; col++) {
+    for (let row = minR; row <= maxR; row++) {
+      for (let col = minC; col <= maxC; col++) {
         refs.push(`${prefix}${toSref({ r: row, c: col })}`);
       }
     }
@@ -119,8 +123,8 @@ export function getReferenceMatrixFromExpression(
       t: 'matrix',
       v: {
         refs,
-        rowCount: to.r - from.r + 1,
-        colCount: to.c - from.c + 1,
+        rowCount: maxR - minR + 1,
+        colCount: maxC - minC + 1,
       },
     };
   } catch {

--- a/packages/sheets/src/model/core/coordinates.ts
+++ b/packages/sheets/src/model/core/coordinates.ts
@@ -30,10 +30,14 @@ export function rangeOf(grid: Grid): Range {
  * `toRefs` generates Refs from the given Range.
  */
 export function* toRefs(range: Range): Generator<Ref> {
-  const [from, to] = range;
+  const [a, b] = range;
+  const minR = Math.min(a.r, b.r);
+  const maxR = Math.max(a.r, b.r);
+  const minC = Math.min(a.c, b.c);
+  const maxC = Math.max(a.c, b.c);
 
-  for (let row = from.r; row <= to.r; row++) {
-    for (let col = from.c; col <= to.c; col++) {
+  for (let row = minR; row <= maxR; row++) {
+    for (let col = minC; col <= maxC; col++) {
       yield { r: row, c: col };
     }
   }

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -189,6 +189,30 @@ describe('Formula', () => {
     expect(evaluate('=SUM(true,false,true)')).toBe('2');
   });
 
+  it('should handle reversed ranges (e.g. F6:A1)', () => {
+    const grid: Grid = new Map<string, Cell>();
+    grid.set('A1', { v: '1' });
+    grid.set('A2', { v: '2' });
+    grid.set('A3', { v: '3' });
+    grid.set('B1', { v: '4' });
+    grid.set('B2', { v: '5' });
+    grid.set('B3', { v: '6' });
+    grid.set('C1', { v: '7' });
+    grid.set('C2', { v: '8' });
+    grid.set('C3', { v: '9' });
+
+    expect(evaluate('=SUM(A1:C3)', grid)).toBe('45');
+    expect(evaluate('=SUM(A3:C1)', grid)).toBe('45');
+    expect(evaluate('=SUM(C1:A3)', grid)).toBe('45');
+    expect(evaluate('=SUM(C3:A1)', grid)).toBe('45');
+    expect(evaluate('=SUM(A3:A1)', grid)).toBe('6');
+    expect(evaluate('=SUM(B$3:B$1)', grid)).toBe('15');
+    expect(evaluate('=SUM($C$3:$A$1)', grid)).toBe('45');
+
+    expect(evaluate('=COUNT(C3:A1)', grid)).toBe('9');
+    expect(evaluate('=AVERAGE(C3:A1)', grid)).toBe('5');
+  });
+
   it('should correctly evaluate ABS function', () => {
     expect(evaluate('=ABS(-5)')).toBe('5');
     expect(evaluate('=ABS(5)')).toBe('5');


### PR DESCRIPTION
## Summary
Fix to iterate min to max range in cells when order is reversed.
e.g. A3:C1 -> for A to C, for 1 to 3

## Why
`=SUM(A3:C1)` returns 0 even A1 ~ C3 has positive sum.
It must be same with result `=SUM(A1:C3)`

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spreadsheet range handling to correctly process ranges with reversed endpoints. Formulas like SUM, COUNT, and AVERAGE now produce consistent results regardless of range direction (e.g., C3:A1 and A1:C3 yield identical outcomes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->