### PR TITLE
Add to support cell drag-move feature

### DIFF
--- a/docs/design/sheet.md
+++ b/docs/design/sheet.md
@@ -99,6 +99,15 @@ all cell, selection, and navigation operations.
   recalculated from all changed destination refs. With freeze panes, the handle
   is hidden (and non-interactive) when the selection is in the unfrozen
   scrollable quadrant but the handle position would fall under frozen panes.
+- **Cell drag-move** — hovering near the edges of a selected cell or range
+  (excluding the bottom-right autofill handle corner) shows a `move` cursor.
+  Dragging from the edge moves the entire selection to the drop position.
+  Unlike copy-paste, formula text is preserved as-is (e.g. `=SUM(A10:I10)`
+  stays `=SUM(A10:I10)` after the move), matching Google Sheets behavior.
+  Other cells that referenced the moved cells are redirected to the new
+  positions. Range styles are translated to the destination and the source
+  area is cleared. The overlay renders a dashed preview rectangle at the
+  prospective drop location during the drag.
 - **Filtering** — `createFilterFromSelection`, `setColumnFilter`, and
   `clearFilter` persist filter metadata and compute hidden row indices.
   If the selection is header-only (single row), filter creation auto-expands
@@ -437,7 +446,8 @@ draws:
   - Live width/height tooltip during drag (includes multi-selection count)
   - `requestAnimationFrame`-coalesced worksheet rendering so scroll/resize
     bursts collapse to one frame and stale async grid fetch results are dropped
-- Move drop indicator (bold blue line at drop position during drag-to-move)
+- Move drop indicator (bold blue line at drop position during row/column drag-to-move)
+- Cell drag-move (dashed rectangle with translucent fill at drop target)
 
 ### DimensionIndex
 

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -2029,6 +2029,113 @@ export class Sheet {
   }
 
   /**
+   * `moveRangeTo` moves a rectangular cell range to a new position.
+   * Unlike copy-paste, drag-move preserves formula text as-is (Google Sheets
+   * behavior). For example, `=SUM(A10:I10)` stays `=SUM(A10:I10)` after move.
+   * Other cells that referenced the moved cells are redirected to the new
+   * positions.
+   */
+  async moveRangeTo(sourceRange: Range, destStart: Ref): Promise<void> {
+    if (this.pivotDefinition) return;
+    this.invalidateCrossSheetCache();
+
+    const srcMinR = Math.min(sourceRange[0].r, sourceRange[1].r);
+    const srcMinC = Math.min(sourceRange[0].c, sourceRange[1].c);
+    const srcMaxR = Math.max(sourceRange[0].r, sourceRange[1].r);
+    const srcMaxC = Math.max(sourceRange[0].c, sourceRange[1].c);
+    const normalizedSource: Range = [
+      { r: srcMinR, c: srcMinC },
+      { r: srcMaxR, c: srcMaxC },
+    ];
+
+    const deltaRow = destStart.r - srcMinR;
+    const deltaCol = destStart.c - srcMinC;
+
+    // No-op if destination is same as source
+    if (deltaRow === 0 && deltaCol === 0) return;
+
+    const grid = await this.fetchGrid(normalizedSource);
+
+    // Build destination grid preserving formula text as-is (no relocation).
+    // Only cell positions change; formula references within the cell stay intact.
+    const movedGrid: Grid = new Map();
+    for (const [sref, cell] of grid) {
+      const ref = parseRef(sref);
+      const newRef = { r: ref.r + deltaRow, c: ref.c + deltaCol };
+      const newSref = toSref(newRef);
+      movedGrid.set(newSref, { ...cell });
+    }
+
+    const cutRefMap = buildCutRefMap(normalizedSource, deltaRow, deltaCol);
+    const sourceStyles = clipRangeStylePatches(this.rangeStyles, normalizedSource);
+
+    this.store.beginBatch();
+    try {
+      // Write moved cells to destination
+      await this.setGrid(movedGrid);
+
+      // Remove source range styles before adding destination styles
+      this.subtractRangeFromStyles(normalizedSource);
+
+      // Add translated style patches at destination
+      const translatedStyles = translateRangeStylePatches(
+        sourceStyles,
+        deltaRow,
+        deltaCol,
+      );
+      for (const patch of translatedStyles) {
+        await this.addRangeStylePatch(patch.range, patch.style);
+        await this.applyStylePatchToExistingCells(patch.range, patch.style);
+      }
+
+      // Recalculate formulas for all changed cells
+      const changedSrefs = new Set<Sref>();
+      for (const [sref] of movedGrid) {
+        changedSrefs.add(sref);
+      }
+
+      // Clear source cells that don't overlap with destination
+      for (let r = srcMinR; r <= srcMaxR; r++) {
+        for (let c = srcMinC; c <= srcMaxC; c++) {
+          const sref = toSref({ r, c });
+          if (!movedGrid.has(sref)) {
+            await this.store.delete({ r, c });
+            changedSrefs.add(sref);
+          }
+        }
+      }
+
+      await this.store.setRangeStyles(this.rangeStyles);
+
+      // Redirect formula references that pointed to moved cells
+      await this.redirectFormulasForCut(cutRefMap);
+
+      // Recalculate dependants
+      if (changedSrefs.size > 0) {
+        const expanded = this.expandChangedSrefsWithMergeAliases(changedSrefs);
+        const dependantsMap = await this.store.buildDependantsMap(expanded);
+        await calculate(this, dependantsMap, expanded);
+      }
+
+      if (this.filterRange) {
+        await this.recomputeFilterHiddenRows();
+      }
+    } finally {
+      this.store.endBatch();
+    }
+
+    // Select the destination range
+    const destEnd: Ref = {
+      r: destStart.r + (srcMaxR - srcMinR),
+      c: destStart.c + (srcMaxC - srcMinC),
+    };
+    this.selectionType = 'cell';
+    this.activeCell = destStart;
+    this.ranges = [[destStart, destEnd]];
+    this.store.updateActiveCell(this.activeCell);
+  }
+
+  /**
    * `subtractRangeFromStyles` subtracts a range from all style patches,
    * keeping the portions that fall outside the given range.
    */

--- a/packages/sheets/src/view/overlay.ts
+++ b/packages/sheets/src/view/overlay.ts
@@ -161,6 +161,7 @@ export class Overlay {
     searchResults?: Ref[],
     searchCurrentIndex?: number,
     visiblePeerLabels?: Set<string>,
+    cellDragMovePreview?: Range,
   ) {
     this.canvas.width = 0;
     this.canvas.height = 0;
@@ -446,6 +447,11 @@ export class Overlay {
     // Render drag-move drop indicator (same for freeze/no-freeze)
     if (dragMove && colDim && rowDim) {
       this.renderDragMoveIndicator(ctx, port, scroll, dragMove, rowDim, colDim, freeze);
+    }
+
+    // Render cell drag-move preview rectangle
+    if (cellDragMovePreview) {
+      this.renderCellDragMovePreview(ctx, cellDragMovePreview, scroll, rowDim, colDim, freeze);
     }
 
     // Render freeze drag preview line
@@ -1007,6 +1013,29 @@ export class Overlay {
     ctx.setLineDash([4, 2]);
     ctx.strokeRect(rect.left, rect.top, rect.width, rect.height);
     ctx.setLineDash([]);
+  }
+
+  private renderCellDragMovePreview(
+    ctx: CanvasRenderingContext2D,
+    previewRange: Range,
+    scroll: { left: number; top: number },
+    rowDim?: DimensionIndex,
+    colDim?: DimensionIndex,
+    freeze: FreezeState = NoFreeze,
+  ): void {
+    const rect = this.toRangeRect(previewRange, scroll, rowDim, colDim, freeze);
+    if (!rect) return;
+    ctx.strokeStyle = this.getThemeColor('dropIndicatorColor');
+    ctx.lineWidth = 2;
+    ctx.setLineDash([4, 3]);
+    ctx.strokeRect(rect.left, rect.top, rect.width, rect.height);
+    ctx.setLineDash([]);
+
+    // Semi-transparent fill to indicate drop target
+    ctx.fillStyle = this.getThemeColor('dropIndicatorColor');
+    ctx.globalAlpha = 0.08;
+    ctx.fillRect(rect.left, rect.top, rect.width, rect.height);
+    ctx.globalAlpha = 1;
   }
 
   private renderAutofillHandle(

--- a/packages/sheets/src/view/worksheet.ts
+++ b/packages/sheets/src/view/worksheet.ts
@@ -54,6 +54,7 @@ const AutoScrollMinSpeed = 300;
 const AutoScrollMaxSpeed = 1800;
 const AutofillHandleSize = 8;
 const AutofillHandleHitPadding = 4;
+const CellEdgeHitThreshold = 2;
 const FilterPanelMaxVisibleValues = 200;
 const CellInputPinnedMargin = 8;
 
@@ -152,6 +153,7 @@ export class Worksheet {
   private freezeDrag: { axis: 'row' | 'column'; targetIndex: number } | null =
     null;
   private autofillPreview: Range | undefined;
+  private cellDragMovePreview: Range | undefined;
   private onRenderCallback?: () => void;
   private readOnly: boolean;
   private hideAutofillHandle: boolean;
@@ -2291,6 +2293,50 @@ export class Worksheet {
     );
   }
 
+  /**
+   * `detectCellEdge` returns true when the pointer is over the border of the
+   * selected cell/range, excluding the bottom-right corner (autofill handle).
+   */
+  private detectCellEdge(x: number, y: number): boolean {
+    if (this.readOnly) return false;
+    if (!this.sheet || this.sheet.getSelectionType() !== 'cell') return false;
+
+    const range = this.sheet.getRangeOrActiveCell();
+    const rect = this.getAutofillSelectionRect(range);
+    if (!rect) return false;
+
+    const t = CellEdgeHitThreshold;
+    const left = rect.left;
+    const top = rect.top;
+    const right = rect.left + rect.width;
+    const bottom = rect.top + rect.height;
+
+    // Check if mouse is within the edge band of the selection rectangle
+    const nearLeft = x >= left - t && x <= left + t;
+    const nearRight = x >= right - t && x <= right + t;
+    const nearTop = y >= top - t && y <= top + t;
+    const nearBottom = y >= bottom - t && y <= bottom + t;
+
+    const withinHorizontalBand = x >= left - t && x <= right + t;
+    const withinVerticalBand = y >= top - t && y <= bottom + t;
+
+    const onEdge =
+      (nearTop && withinHorizontalBand) ||
+      (nearBottom && withinHorizontalBand) ||
+      (nearLeft && withinVerticalBand) ||
+      (nearRight && withinVerticalBand);
+
+    if (!onEdge) return false;
+
+    // Exclude the bottom-right corner (autofill handle area)
+    const handleSize = AutofillHandleSize + AutofillHandleHitPadding;
+    if (x >= right - handleSize && y >= bottom - handleSize) {
+      return false;
+    }
+
+    return true;
+  }
+
   private shouldShowAutofillHandle(): boolean {
     if (this.hideAutofillHandle) return false;
     if (this.readOnly) return false;
@@ -2425,6 +2471,16 @@ export class Worksheet {
     } else {
       if (this.detectAutofillHandle(e.offsetX, e.offsetY)) {
         scrollContainer.style.cursor = 'crosshair';
+        this.setFilterButtonHoverCol(null);
+        if (changed) {
+          this.renderOverlay();
+        }
+        return;
+      }
+
+      // Check if hovering over cell selection edge → show move cursor
+      if (this.detectCellEdge(e.offsetX, e.offsetY)) {
+        scrollContainer.style.cursor = 'move';
         this.setFilterButtonHoverCol(null);
         if (changed) {
           this.renderOverlay();
@@ -2925,6 +2981,13 @@ export class Worksheet {
       return;
     }
 
+    if (this.detectCellEdge(e.offsetX, e.offsetY)) {
+      e.preventDefault();
+      await this.finishEditing();
+      this.startCellDragMove(e);
+      return;
+    }
+
     if (this.detectAutofillHandle(e.offsetX, e.offsetY)) {
       e.preventDefault();
       await this.finishEditing();
@@ -3164,6 +3227,136 @@ export class Worksheet {
         stopAutoScroll();
         this.endNativeSelectionBlock();
         this.autofillPreview = undefined;
+        if (this.sheet) {
+          this.renderOverlay();
+        }
+      },
+    });
+  }
+
+  /**
+   * `startCellDragMove` begins a drag-to-move operation for the selected cell range.
+   * Dragging from the edge of a cell selection moves the cell data to the drop location.
+   */
+  private startCellDragMove(startEvent: MouseEvent): void {
+    const scrollContainer = this.gridContainer.getScrollContainer();
+    scrollContainer.style.cursor = 'move';
+
+    const sourceRange = this.sheet!.getRangeOrActiveCell();
+    const srcRows = Math.abs(sourceRange[1].r - sourceRange[0].r) + 1;
+    const srcCols = Math.abs(sourceRange[1].c - sourceRange[0].c) + 1;
+
+    let lastClientX = startEvent.clientX;
+    let lastClientY = startEvent.clientY;
+    let frameId: number | null = null;
+    let lastFrameTime: number | null = null;
+
+    const updatePreview = () => {
+      const { x, y } = this.clampClientPointToViewport(lastClientX, lastClientY);
+      const target = this.toRefFromMouse(x, y);
+      // The preview range is the destination rectangle with the same dimensions
+      const endRef: Ref = { r: target.r + srcRows - 1, c: target.c + srcCols - 1 };
+      this.cellDragMovePreview = [target, endRef];
+      this.renderOverlay();
+    };
+
+    const stopAutoScroll = () => {
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+        frameId = null;
+      }
+      lastFrameTime = null;
+    };
+
+    const stepAutoScroll = (now: number) => {
+      const port = this.viewport;
+      const velocityX = this.getAutoScrollVelocity(
+        lastClientX,
+        port.left,
+        port.left + port.width,
+      );
+      const velocityY = this.getAutoScrollVelocity(
+        lastClientY,
+        port.top,
+        port.top + port.height,
+      );
+
+      if (velocityX === 0 && velocityY === 0) {
+        frameId = null;
+        lastFrameTime = null;
+        return;
+      }
+
+      const dt = Math.min(
+        50,
+        lastFrameTime === null ? 16 : now - lastFrameTime,
+      );
+      lastFrameTime = now;
+      this.gridContainer.scrollBy((velocityX * dt) / 1000, (velocityY * dt) / 1000);
+      updatePreview();
+      frameId = requestAnimationFrame(stepAutoScroll);
+    };
+
+    const startAutoScroll = () => {
+      if (frameId === null) {
+        frameId = requestAnimationFrame(stepAutoScroll);
+      }
+    };
+
+    const onMove = (e: MouseEvent) => {
+      lastClientX = e.clientX;
+      lastClientY = e.clientY;
+      updatePreview();
+
+      const port = this.viewport;
+      const velocityX = this.getAutoScrollVelocity(
+        lastClientX,
+        port.left,
+        port.left + port.width,
+      );
+      const velocityY = this.getAutoScrollVelocity(
+        lastClientY,
+        port.top,
+        port.top + port.height,
+      );
+      if (velocityX === 0 && velocityY === 0) {
+        stopAutoScroll();
+      } else {
+        startAutoScroll();
+      }
+    };
+
+    this.beginNativeSelectionBlock();
+    updatePreview();
+    this.startMouseDragSession({
+      onMove,
+      onComplete: () => {
+        const { x, y } = this.clampClientPointToViewport(lastClientX, lastClientY);
+        const target = this.toRefFromMouse(x, y);
+        const sheet = this.sheet!;
+
+        // No-op if dropped back on itself
+        const sr = sourceRange;
+        const minR = Math.min(sr[0].r, sr[1].r);
+        const minC = Math.min(sr[0].c, sr[1].c);
+        if (target.r === minR && target.c === minC) {
+          this.cellDragMovePreview = undefined;
+          this.renderOverlay();
+          return;
+        }
+
+        void (async () => {
+          await sheet.moveRangeTo(sourceRange, target);
+          this.cellDragMovePreview = undefined;
+          if (!this.sheet) return;
+          this.render();
+        })();
+      },
+      onCleanup: () => {
+        scrollContainer.style.cursor = '';
+        stopAutoScroll();
+        this.endNativeSelectionBlock();
+        this.cellDragMovePreview = undefined;
         if (this.sheet) {
           this.renderOverlay();
         }
@@ -4343,6 +4536,7 @@ export class Worksheet {
       this._searchResults.length > 0 ? this._searchResults : undefined,
       this._searchCurrentIndex >= 0 ? this._searchCurrentIndex : undefined,
       this.getVisiblePeerLabels(),
+      this.cellDragMovePreview,
     );
   }
 


### PR DESCRIPTION
## Summary
When pointer is on selected cell range border (except right-bottom, it's for expand cell), data can be moved to other cell by drag-and-drop.

## Why
This feature also supported on google sheet.

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cell drag-move functionality: select and drag cells to relocate them to a new location.
  * Cursor changes to "move" when hovering over selected cell edges (excluding autofill corner).
  * Visual dashed preview rectangle displays destination during drag.
  * Formulas in moved cells preserve their text; formulas referencing moved cells auto-update.
  * Cell styles and content transfer to destination; source area clears.

* **Documentation**
  * Updated design specification with cell drag-move interaction details and overlay legend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->