### PR TITLE
Constrain autofill to a single axis (vertical or horizontal)

### DIFF
--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -84,7 +84,8 @@ React and the `@wafflebase/sheets` engine:
 5. Fill handle drag is handled inside `Worksheet`/`Overlay`: the bottom-right
    handle on a cell selection (or merged active cell bounds when no explicit
    range exists) shows a crosshair cursor, previews the expanded fill range
-   with a dashed border, and commits `Sheet.autofill(...)` on mouseup.
+   (constrained to a single axis — vertical or horizontal) with a dashed
+   border, and commits `Sheet.autofill(...)` on mouseup.
 6. On mobile viewports, `useMobileSheetGestures` adds one-finger drag panning
    (`spreadsheet.panBy(...)`) and double-tap-to-edit
    (`spreadsheet.handleMobileDoubleTap(...)`) on the canvas container.

--- a/docs/design/sheet.md
+++ b/docs/design/sheet.md
@@ -94,11 +94,14 @@ all cell, selection, and navigation operations.
   (including plain-value pastes). External pastes (TSV/HTML) run through the
   same conservative input inference as `setData` before persistence.
 - **Autofill (fill handle)** — dragging the selection handle repeats the source
-  pattern across the expanded range. Formula cells are relocated per target
-  offset (same reference-shift semantics as internal paste), then dependants are
-  recalculated from all changed destination refs. With freeze panes, the handle
-  is hidden (and non-interactive) when the selection is in the unfrozen
-  scrollable quadrant but the handle position would fall under frozen panes.
+  pattern across the expanded range. The fill is constrained to a single axis
+  (vertical or horizontal) based on whichever direction the drag extends
+  furthest from the source edge; ties favour vertical. Formula cells are
+  relocated per target offset (same reference-shift semantics as internal
+  paste), then dependants are recalculated from all changed destination refs.
+  With freeze panes, the handle is hidden (and non-interactive) when the
+  selection is in the unfrozen scrollable quadrant but the handle position
+  would fall under frozen panes.
 - **Cell drag-move** — hovering near the edges of a selected cell or range
   (excluding the bottom-right autofill handle corner) shows a `move` cursor.
   Dragging from the edge moves the entire selection to the drop position.

--- a/packages/sheets/src/model/worksheet/clipboard.ts
+++ b/packages/sheets/src/model/worksheet/clipboard.ts
@@ -53,8 +53,10 @@ export function buildCutRefMap(
 }
 
 /**
- * `computeAutofillRange` returns the expanded fill range, or undefined
- * when `target` is inside the source range.
+ * `computeAutofillRange` returns the expanded fill range constrained to a
+ * single axis (vertical or horizontal), or undefined when `target` is inside
+ * the source range.  The dominant axis is the one where the target is
+ * furthest from the source edge; ties favour vertical.
  */
 export function computeAutofillRange(
   sourceRange: Range,
@@ -63,7 +65,24 @@ export function computeAutofillRange(
   if (inRange(target, sourceRange)) {
     return undefined;
   }
-  return mergeRanges(sourceRange, [target, target]);
+
+  const distUp = Math.max(0, sourceRange[0].r - target.r);
+  const distDown = Math.max(0, target.r - sourceRange[1].r);
+  const distLeft = Math.max(0, sourceRange[0].c - target.c);
+  const distRight = Math.max(0, target.c - sourceRange[1].c);
+
+  const verticalDist = Math.max(distUp, distDown);
+  const horizontalDist = Math.max(distLeft, distRight);
+
+  if (verticalDist >= horizontalDist) {
+    // Constrain to vertical: keep source columns, extend rows to target
+    const clampedTarget: Ref = { r: target.r, c: sourceRange[1].c };
+    return mergeRanges(sourceRange, [clampedTarget, clampedTarget]);
+  } else {
+    // Constrain to horizontal: keep source rows, extend columns to target
+    const clampedTarget: Ref = { r: sourceRange[1].r, c: target.c };
+    return mergeRanges(sourceRange, [clampedTarget, clampedTarget]);
+  }
 }
 
 /**

--- a/packages/sheets/test/sheet/autofill.test.ts
+++ b/packages/sheets/test/sheet/autofill.test.ts
@@ -20,7 +20,7 @@ describe('Sheet.autofill', () => {
     ]);
   });
 
-  it('tiles a multi-cell pattern across a larger range', async () => {
+  it('tiles a multi-cell pattern vertically (single-axis)', async () => {
     const sheet = new Sheet(new MemStore());
     await sheet.setData({ r: 1, c: 1 }, '1');
     await sheet.setData({ r: 1, c: 2 }, '2');
@@ -29,13 +29,29 @@ describe('Sheet.autofill', () => {
 
     sheet.selectStart({ r: 1, c: 1 });
     sheet.selectEnd({ r: 2, c: 2 });
-    const changed = await sheet.autofill({ r: 4, c: 3 });
+    const changed = await sheet.autofill({ r: 4, c: 2 });
 
     expect(changed).toBe(true);
+    // Pattern tiles: rows 3-4 repeat rows 1-2
     expect(await sheet.toDisplayString({ r: 3, c: 1 })).toBe('1');
-    expect(await sheet.toDisplayString({ r: 3, c: 3 })).toBe('1');
+    expect(await sheet.toDisplayString({ r: 3, c: 2 })).toBe('2');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('3');
     expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe('4');
-    expect(await sheet.toDisplayString({ r: 4, c: 3 })).toBe('3');
+  });
+
+  it('constrains autofill to single axis (vertical wins on tie)', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, 'a');
+
+    sheet.selectStart({ r: 1, c: 1 });
+    // Diagonal target: row extends by 2, col extends by 1 → vertical wins
+    const changed = await sheet.autofill({ r: 3, c: 2 });
+
+    expect(changed).toBe(true);
+    // Vertical fill only: cols stay at 1
+    expect(await sheet.toDisplayString({ r: 2, c: 1 })).toBe('a');
+    expect(await sheet.toDisplayString({ r: 3, c: 1 })).toBe('a');
+    expect(await sheet.toDisplayString({ r: 2, c: 2 })).toBe('');
   });
 
   it('relocates formulas during autofill', async () => {


### PR DESCRIPTION
## Summary
Previously computeAutofillRange created a bounding box that could extend in both row and column directions simultaneously.  Now the target is clamped to the dominant axis — whichever direction the drag extends furthest from the source edge — matching Google Sheets behaviour. 

## Why
Both google sheet and excel supports to autofill vertical or horizontal.
This change will handle number-autofill case easily (future work). It does not just fill repeatly, based on Ordinary Least Squares(OLS).

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated frontend and sheet design documentation to clarify autofill behavior constraints.

* **Bug Fixes**
  * Modified autofill (fill-handle) to expand along a single axis (vertical or horizontal) based on drag direction distance, with vertical preferred on ties.

* **Tests**
  * Updated autofill test cases to validate single-axis expansion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->