### PR TITLE
Add shared docs toolbar and read-only mode

### DIFF
--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -67,6 +67,7 @@ export function initialize(
   container: HTMLElement,
   store?: DocStore,
   theme?: ThemeMode,
+  readOnly?: boolean,
 ): EditorAPI {
   if (theme) {
     setThemeMode(theme);
@@ -87,7 +88,7 @@ export function initialize(
   canvas.style.display = 'block';
   canvas.style.position = 'sticky';
   canvas.style.top = '0';
-  canvas.style.cursor = 'text';
+  canvas.style.cursor = readOnly ? 'default' : 'text';
   container.style.position = 'relative';
   container.appendChild(canvas);
 
@@ -97,7 +98,7 @@ export function initialize(
   container.appendChild(spacer);
 
   const docCanvas = new DocCanvas(canvas);
-  const ruler = new Ruler(container, canvas);
+  const ruler = new Ruler(container, canvas, readOnly);
   const cursor = new Cursor(doc.document.blocks[0].id);
   const selection = new Selection();
   let layout: DocumentLayout = { blocks: [], totalHeight: 0 };
@@ -105,7 +106,7 @@ export function initialize(
   let layoutCache: LayoutCache | undefined;
   let dirtyBlockIds: Set<string> | undefined;
   let needsScrollIntoView = false;
-  let focused = true;
+  let focused = !readOnly;
   let dragGuideline: { x?: number; y?: number } | null = null;
   let peerCursors: PeerCursor[] = [];
   let cursorMoveCallback: ((pos: { blockId: string; offset: number }, selection?: { anchor: { blockId: string; offset: number }; focus: { blockId: string; offset: number } } | null) => void) | null = null;
@@ -193,7 +194,7 @@ export function initialize(
       const containerRect = container.getBoundingClientRect();
       const screenX = containerRect.left + cursorPixel.x;
       const screenY = containerRect.top + (cursorPixel.y - scrollY);
-      textEditor.updateTextareaPosition(screenX, screenY);
+      textEditor?.updateTextareaPosition(screenX, screenY);
     }
 
     const selectionRects = selection.getSelectionRects(
@@ -392,7 +393,7 @@ export function initialize(
     cursorMoveCallback?.(cursor.position, selRange);
   };
 
-  const textEditor = new TextEditor(
+  const textEditor = readOnly ? null : new TextEditor(
     container,
     doc,
     cursor,
@@ -414,8 +415,10 @@ export function initialize(
     invalidateLayout,
   );
 
-  // Start cursor blink
-  cursor.startBlink(renderPaintOnly);
+  // Start cursor blink (skip in read-only — no cursor visible)
+  if (!readOnly) {
+    cursor.startBlink(renderPaintOnly);
+  }
 
   // Enable scroll BEFORE the initial render so the container stays
   // flex-constrained instead of growing to match content height.
@@ -453,10 +456,10 @@ export function initialize(
     cursor.stopBlink();
     render();
   };
-  textEditor.onFocusChange(handleFocus, handleBlur);
-
-  // Focus
-  textEditor.focus();
+  if (textEditor) {
+    textEditor.onFocusChange(handleFocus, handleBlur);
+    textEditor.focus();
+  }
 
   return {
     render,
@@ -607,14 +610,14 @@ export function initialize(
       markDirty(block.id);
       render();
     },
-    focus: () => textEditor.focus(),
+    focus: () => textEditor?.focus(),
     dispose: () => {
       peerCursors = [];
       cursorMoveCallback = null;
       lastPeerPixels = [];
       ruler.dispose();
       cursor.dispose();
-      textEditor.dispose();
+      textEditor?.dispose();
       container.removeEventListener('scroll', handleScroll);
       document.removeEventListener('transitionend', handleTransitionEnd);
       resizeObserver.disconnect();

--- a/packages/docs/src/view/ruler.ts
+++ b/packages/docs/src/view/ruler.ts
@@ -74,7 +74,7 @@ export class Ruler {
   // Event handler references for cleanup
   private boundHandlers: Array<[EventTarget, string, EventListener]> = [];
 
-  constructor(container: HTMLElement, docCanvas: HTMLCanvasElement) {
+  constructor(container: HTMLElement, docCanvas: HTMLCanvasElement, readOnly?: boolean) {
     const doc = typeof document !== 'undefined' ? document : null;
 
     // Corner element: collapses into hRuler's space via negative margin
@@ -117,7 +117,7 @@ export class Ruler {
     this.unit = detectUnit(typeof navigator !== 'undefined' ? navigator?.language : undefined);
     this.grid = getGridConfig(this.unit);
 
-    if (typeof document !== 'undefined') {
+    if (typeof document !== 'undefined' && !readOnly) {
       this.addMouseHandlers();
     }
   }

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -64,6 +64,7 @@ const HOVER_RADIUS = 10;
 
 interface DocsViewProps {
   onEditorReady?: (editor: EditorAPI | null) => void;
+  readOnly?: boolean;
 }
 
 /**
@@ -73,7 +74,7 @@ interface DocsViewProps {
  * It also subscribes to presence changes for peer cursors with label visibility
  * and hover detection.
  */
-export function DocsView({ onEditorReady }: DocsViewProps) {
+export function DocsView({ onEditorReady, readOnly }: DocsViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<EditorAPI | null>(null);
   const storeRef = useRef<YorkieDocStore | null>(null);
@@ -182,7 +183,7 @@ export function DocsView({ onEditorReady }: DocsViewProps) {
     const store = new YorkieDocStore(doc);
     storeRef.current = store;
     const theme = (resolvedTheme === "dark" ? "dark" : "light") as ThemeMode;
-    const editor: EditorAPI = initialize(container, store, theme);
+    const editor: EditorAPI = initialize(container, store, theme, readOnly);
     editorRef.current = editor;
     onEditorReady?.(editor);
 

--- a/packages/frontend/src/app/shared/shared-document.tsx
+++ b/packages/frontend/src/app/shared/shared-document.tsx
@@ -14,7 +14,8 @@ import {
 import type { YorkieDocsRoot } from "@/types/docs-document";
 import type { UserPresence as UserPresenceType } from "@/types/users";
 import { UserPresence } from "@/components/user-presence";
-import { DocsView } from "@/app/docs/docs-view";
+import { DocsView, type EditorAPI } from "@/app/docs/docs-view";
+import { DocsFormattingToolbar } from "@/app/docs/docs-formatting-toolbar";
 import { IconDatabase, IconTable } from "@tabler/icons-react";
 
 type PeerJumpTarget = {
@@ -141,8 +142,8 @@ function SharedDocumentLayout({
 }
 
 function SharedDocsLayout({ resolved }: { resolved: ResolvedShareLink }) {
-  // TODO: pass readOnly to DocsView once the docs editor supports read-only mode
   const readOnly = resolved.role === "viewer";
+  const [editor, setEditor] = useState<EditorAPI | null>(null);
 
   return (
     <div className="flex h-screen w-full flex-col">
@@ -158,7 +159,8 @@ function SharedDocsLayout({ resolved }: { resolved: ResolvedShareLink }) {
         <UserPresence />
       </header>
       <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
-        <DocsView />
+        {!readOnly && <DocsFormattingToolbar editor={editor} />}
+        <DocsView onEditorReady={setEditor} readOnly={readOnly} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add formatting toolbar to shared docs for editor-role users (was completely missing)
- Implement read-only mode for viewer-role users in the docs editor:
  - No cursor focus or text input (TextEditor not created)
  - No ruler drag interactions (mouse handlers skipped)
  - Canvas cursor shows `default` instead of `text`

## Test plan
- [x] Open a shared doc link with editor role → toolbar should appear and be functional
- [x] Open a shared doc link with viewer role → no toolbar, no cursor, no ruler dragging
- [x] Verify authenticated docs editor (`/d/:id`) still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only editor mode support. Editors now adapt their behavior based on user permissions, disabling editing interactions and the formatting toolbar for viewers while maintaining full functionality for authorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->