### PR TITLE
Fix decimal increase/decrease buttons to work with plain format

### DIFF
--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -34,6 +34,7 @@ import {
   Range,
   Ranges,
   Direction,
+  NumberFormat,
   SelectionType,
 } from '../core/types';
 import {
@@ -3714,6 +3715,34 @@ export class Sheet {
   async getActiveDecimalPlaces(): Promise<number> {
     const style = await this.getStyle(this.activeCell);
     return style?.dp ?? 2;
+  }
+
+  /**
+   * `getActiveDecimalState` returns the decimal places and number format
+   * of the active cell. When the cell has plain format and no explicit dp,
+   * the decimal places are inferred from the stored value string so that
+   * the first increase/decrease starts from the visible precision.
+   */
+  async getActiveDecimalState(): Promise<{ dp: number; nf?: NumberFormat }> {
+    const style = await this.getStyle(this.activeCell);
+    // If dp is explicitly set in the style, use it.
+    if (style?.dp !== undefined) {
+      return { dp: style.dp, nf: style?.nf };
+    }
+    // For plain format (or no format), infer dp from the stored value.
+    if (!style?.nf || style.nf === 'plain') {
+      const cell = await this.store.get(
+        this.normalizeRefToAnchor(this.activeCell),
+      );
+      if (cell?.v) {
+        const dotIndex = cell.v.indexOf('.');
+        if (dotIndex >= 0) {
+          return { dp: cell.v.length - dotIndex - 1, nf: style?.nf };
+        }
+      }
+      return { dp: 0, nf: style?.nf };
+    }
+    return { dp: 2, nf: style?.nf };
   }
 
   /**

--- a/packages/sheets/src/view/spreadsheet.ts
+++ b/packages/sheets/src/view/spreadsheet.ts
@@ -416,8 +416,12 @@ export class Spreadsheet {
    */
   public async increaseDecimals() {
     if (!this.sheet || this._readOnly) return;
-    const dp = await this.sheet.getActiveDecimalPlaces();
-    await this.sheet.setRangeStyle({ dp: dp + 1 });
+    const { dp, nf } = await this.sheet.getActiveDecimalState();
+    const patch: Partial<CellStyle> = { dp: dp + 1 };
+    if (!nf || nf === 'plain') {
+      patch.nf = 'number';
+    }
+    await this.sheet.setRangeStyle(patch);
     this.worksheet.render();
     this.notifySelectionChange();
   }
@@ -427,8 +431,12 @@ export class Spreadsheet {
    */
   public async decreaseDecimals() {
     if (!this.sheet || this._readOnly) return;
-    const dp = await this.sheet.getActiveDecimalPlaces();
-    await this.sheet.setRangeStyle({ dp: Math.max(0, dp - 1) });
+    const { dp, nf } = await this.sheet.getActiveDecimalState();
+    const patch: Partial<CellStyle> = { dp: Math.max(0, dp - 1) };
+    if (!nf || nf === 'plain') {
+      patch.nf = 'number';
+    }
+    await this.sheet.setRangeStyle(patch);
     this.worksheet.render();
     this.notifySelectionChange();
   }


### PR DESCRIPTION
## Summary
The decimal buttons had no visible effect because they only set dp without changing nf from plain. Now they auto-promote nf to number, and infer the starting dp from the stored value's actual decimal places instead of defaulting to 2.

## Why
Previously decimal increase/decrease places button doesn't work with number.

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced decimal place adjustment to preserve number formatting state in spreadsheets, ensuring consistent formatting behavior when increasing or decreasing decimal precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->