### PR TITLE
Fix formula tokenizer corrupting text with emoji characters

### DIFF
--- a/packages/sheets/src/formula/formula.ts
+++ b/packages/sheets/src/formula/formula.ts
@@ -242,14 +242,40 @@ export function extractReferences(formula: string): Set<Reference> {
 }
 
 /**
+ * `codePointToUtf16Offsets` builds a mapping from code-point index to UTF-16
+ * index.  `offsets[i]` is the UTF-16 position of the i-th code point.
+ * `offsets[codePointCount]` equals `str.length` (a sentinel past the end).
+ *
+ * ANTLR4-ts `CharStreams.fromString` uses Unicode code points for token
+ * indices, while JavaScript string methods use UTF-16 code units.  Characters
+ * outside the BMP (e.g. emoji) are 1 code point but 2 UTF-16 code units,
+ * causing the two index systems to diverge.
+ */
+function codePointToUtf16Offsets(str: string): number[] {
+  const offsets: number[] = [];
+  let u16 = 0;
+  for (const ch of str) {
+    offsets.push(u16);
+    u16 += ch.length; // 1 for BMP, 2 for supplementary
+  }
+  offsets.push(u16); // sentinel
+  return offsets;
+}
+
+/**
  * `extractTokens` returns tokens in the expression.
  */
 export function extractTokens(formula: string): Array<Token> {
-  const stream = CharStreams.fromString(formula.slice(1));
+  const body = formula.slice(1); // skip '='
+  const stream = CharStreams.fromString(body);
   const lexer = new FormulaLexer(stream);
   const tokenStream = new CommonTokenStream(lexer);
   lexer.removeErrorListeners();
   tokenStream.fill();
+
+  // ANTLR token indices are code-point based; JS slice is UTF-16 based.
+  // Build a mapping so gap-filling and returned start/stop use UTF-16.
+  const cpOff = codePointToUtf16Offsets(body);
 
   const tokens: Array<Token> = [];
   for (const token of tokenStream.getTokens()) {
@@ -259,8 +285,8 @@ export function extractTokens(formula: string): Array<Token> {
 
     tokens.push({
       type: lexer.vocabulary.getSymbolicName(token.type) || 'STRING',
-      start: token.startIndex,
-      stop: token.stopIndex,
+      start: cpOff[token.startIndex],
+      stop: cpOff[token.stopIndex + 1] - 1,
       text: token.text!,
     });
   }
@@ -274,14 +300,14 @@ export function extractTokens(formula: string): Array<Token> {
         type: 'STRING',
         start: 0,
         stop: token.start - 1,
-        text: formula.slice(1, token.start + 1),
+        text: body.slice(0, token.start),
       });
     } else if (currToken && currToken.stop + 1 !== token.start) {
       filledTokens.push({
         type: 'STRING',
         start: currToken.stop + 1,
         stop: token.start - 1,
-        text: formula.slice(currToken.stop + 2, token.start + 1),
+        text: body.slice(currToken.stop + 1, token.start),
       });
     }
     filledTokens.push(token);
@@ -289,12 +315,12 @@ export function extractTokens(formula: string): Array<Token> {
     currToken = token;
   }
 
-  if (currToken && currToken.stop + 2 < formula.length) {
+  if (currToken && currToken.stop + 1 < body.length) {
     filledTokens.push({
       type: 'STRING',
       start: currToken.stop + 1,
-      stop: formula.length - 1,
-      text: formula.slice(currToken.stop + 2),
+      stop: body.length - 1,
+      text: body.slice(currToken.stop + 1),
     });
   }
 

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -3365,7 +3365,7 @@ describe('Formula.extractTokens', () => {
 
     expect(extractTokens('=A1:')).toEqual([
       { type: 'REFERENCE', start: 0, stop: 1, text: 'A1' },
-      { type: 'STRING', start: 2, stop: 3, text: ':' },
+      { type: 'STRING', start: 2, stop: 2, text: ':' },
     ]);
 
     expect(extractTokens('=AA1+AB2')).toEqual([
@@ -3386,6 +3386,46 @@ describe('Formula.extractTokens', () => {
       { type: 'STRING', start: 7, stop: 7, text: '(' },
       { type: 'NUM', start: 8, stop: 8, text: '1' },
       { type: 'STRING', start: 9, stop: 9, text: ')' },
+    ]);
+
+    // Emoji characters (supplementary code points) must produce correct
+    // token text AND UTF-16 start/stop positions.
+    // Formula: =IF(A1>0,"🔴 Bad","🟢 OK")
+    //  body:    I F ( A 1 > 0 , " 🔴    B  a  d  "  ,  "  🟢     O  K  "  )
+    //  UTF-16:  0 1 2 3 4 5 6 7 8 9,10 11 12 13 14 15 16 17 18,19 20 21 22 23 24
+    //  (🔴 = U+1F534, 2 UTF-16 code units at positions 9-10)
+    //  (🟢 = U+1F7E2, 2 UTF-16 code units at positions 18-19)
+    expect(extractTokens('=IF(A1>0,"🔴 Bad","🟢 OK")')).toEqual([
+      { type: 'FUNCNAME', start: 0, stop: 1, text: 'IF' },
+      { type: 'STRING', start: 2, stop: 2, text: '(' },
+      { type: 'REFERENCE', start: 3, stop: 4, text: 'A1' },
+      { type: 'GT', start: 5, stop: 5, text: '>' },
+      { type: 'NUM', start: 6, stop: 6, text: '0' },
+      { type: 'STRING', start: 7, stop: 7, text: ',' },
+      // "🔴 Bad" — 🔴 is 2 UTF-16 units, so the string token spans 8..15
+      { type: 'STRING', start: 8, stop: 15, text: '"🔴 Bad"' },
+      { type: 'STRING', start: 16, stop: 16, text: ',' },
+      // "🟢 OK" — 🟢 is 2 UTF-16 units, so the string token spans 17..23
+      { type: 'STRING', start: 17, stop: 23, text: '"🟢 OK"' },
+      { type: 'STRING', start: 24, stop: 24, text: ')' },
+    ]);
+
+    // Multi-emoji formula reconstructs losslessly
+    const emojiFormula =
+      '=IF(A1>0,"🔴 Over Budget",IF(A1>0,"🟢 OK"))';
+    const emojiTokens = extractTokens(emojiFormula);
+    const reconstructed = '=' + emojiTokens.map((t) => t.text).join('');
+    expect(reconstructed).toBe(emojiFormula);
+
+    // Token after multiple emoji has correct UTF-16 offset
+    // "=1+"🔴🟡"+2" — two emoji in a string, then NUM token after
+    expect(extractTokens('=1+"🔴🟡"+2')).toEqual([
+      { type: 'NUM', start: 0, stop: 0, text: '1' },
+      { type: 'ADD', start: 1, stop: 1, text: '+' },
+      // "🔴🟡" — each emoji is 2 UTF-16 units → string is 6 UTF-16 units
+      { type: 'STRING', start: 2, stop: 7, text: '"🔴🟡"' },
+      { type: 'ADD', start: 8, stop: 8, text: '+' },
+      { type: 'NUM', start: 9, stop: 9, text: '2' },
     ]);
   });
 


### PR DESCRIPTION
## Summary
ANTLR4-ts CharStreams.fromString() uses Unicode code points for token indices, but JavaScript String.slice() uses UTF-16 code units. Emoji like 🔴 (U+1F534) are 1 code point but 2 UTF-16 code units, so the offset divergence grew with each emoji in the formula.
build a code-point → UTF-16 offset map and convert all ANTLR indices to UTF-16 space before slicing or storing in Token.start/stop.

## Why
pasting `=IF(H24>0.9,"🔴 Over Budget",IF(H24>0.7,"🟡 At Risk","🟢 On Track"))` produced extra `"))` appended at the end, and backspace inserted more ")) instead of deleting — because extractTokens() gap-filling used ANTLR code-point indices with JS slice(), producing corrupted token text that the syntax highlighter then wrote back into the contenteditable input.

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unicode character handling in formula parsing to correctly process emoji and other multi-byte characters.

* **Tests**
  * Added test coverage for emoji support in formulas, including validation of token positioning and formula reconstruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->