### PR TITLE
Migrate docs undo/redo to Yorkie-native history

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -37,6 +37,7 @@ Technical design documents for the Wafflebase project. These go deeper than pack
 | [docs-tables.md](docs-tables.md)                               | Docs tables — data model, cell merge, layout, rendering, extensibility path              |
 | [docs-table-ui.md](docs-table-ui.md)                           | Docs table UI — grid picker, context menu, IME cell routing                              |
 | [docs-table-crdt.md](docs-table-crdt.md)                       | Table CRDT collaboration — Tree node structure, container cells, concurrent editing       |
+| [docs-collaboration.md](docs-collaboration.md)                 | Docs collaboration — YorkieDocStore, tree structure, batched undo/redo                    |
 
 ## Template
 

--- a/docs/design/docs-collaboration.md
+++ b/docs/design/docs-collaboration.md
@@ -21,12 +21,12 @@ Yorkie's `Tree` CRDT. The docs editor currently uses an in-memory store
 - Collaborative inline styling (bold, italic, underline, fontSize, etc.)
 - Collaborative block styling (alignment, lineHeight, margins)
 - Extensible tree structure for future block types (tables, lists, images)
-- Local snapshot-based undo/redo as a first step
+- Local snapshot-based undo/redo as a first step (Phase 1)
+- Yorkie-native undo/redo via `doc.history.undo()/redo()` (Phase 2)
 
 ### Non-Goals
 
-- Presence / remote cursor display (follow-up work)
-- Yorkie-based undo/redo (future migration from local snapshots)
+- Presence / remote cursor display (follow-up work — done)
 - Offline editing with sync (out of scope)
 - Conflict resolution UI (Yorkie CRDT handles conflicts automatically)
 
@@ -209,27 +209,54 @@ The `onRemoteChange` callback triggers editor re-render. Since
 Stored as a JSON field (`pageSetup`) on the Yorkie document root, separate
 from the `content` tree. See the root schema above.
 
-#### Undo/Redo (Phase 1 — Local Snapshots)
+#### Undo/Redo
 
-The undo contract: **only explicit `snapshot()` calls create undo entries.**
-Individual `updateBlock()`/`insertBlock()`/`deleteBlock()` do NOT push to the
-undo stack. This applies to both `MemDocStore` and `YorkieDocStore`.
+##### Phase 1 — Local Snapshots (deprecated)
 
-Note: The current `MemDocStore` pushes undo on every mutation method. This
-will be fixed to match the `snapshot()`-only contract so that both stores
-behave identically.
+- **`snapshot()`** — Deep-clones the current document state and pushes to
+  a local undo stack. `undo()` replaces the entire tree with the snapshot
+  via `writeFullDocument()`.
+- **Limitation**: `writeFullDocument()` deletes all tree nodes and reinserts
+  from the snapshot. During concurrent editing, this causes duplicate block
+  IDs when Yorkie's CRDT merge preserves both old and new tree nodes
+  (see issue #97).
 
-- **`snapshot()`** — Calls `getDocument()` to deep-clone the current state
-  and pushes it onto a local undo stack.
-- **`undo()`** — Pops from the undo stack, pushes current state to redo
-  stack, and replaces the entire tree content with the snapshot.
-- **`redo()`** — Reverse of undo.
+##### Phase 2 — Yorkie-Native Undo/Redo (current)
 
-**Limitation**: In Phase 1, undo restores a full document snapshot. During
-concurrent editing, this can overwrite other users' changes. This is
-acceptable as a known limitation; undo is scoped to single-user scenarios
-until Phase 2 migrates to `doc.history.undo()/redo()` for operation-level
-undo that respects concurrent edits.
+Migrated from snapshot-based undo to Yorkie's operation-level undo via
+`doc.history.undo()/redo()`. This eliminates the `writeFullDocument()`
+nuke-and-replace pattern that caused concurrent editing bugs.
+
+**Batching**: `snapshot()` is replaced by `beginBatch()/endBatch()`. All
+store mutations between `beginBatch()` and `endBatch()` are buffered and
+flushed as a single `doc.update()` call, producing one undo unit. This
+ensures compound user actions (Enter = split block, Backspace = merge blocks,
+paste = insert multiple blocks) undo atomically.
+
+Batching is reference-counted to support nesting: `Doc.splitBlock()` wraps
+its two store calls in `beginBatch/endBatch`, and the caller in `TextEditor`
+can wrap a larger sequence (e.g., delete selection + split) in an outer batch.
+Only the outermost `endBatch()` flushes to `doc.update()`.
+
+```
+TextEditor: beginBatch()          ← outer batch (depth=1)
+  Doc.splitBlock():
+    store.beginBatch()            ← nested (depth=2, no-op)
+    store.updateBlock(...)        ← buffered
+    store.insertBlock(...)        ← buffered
+    store.endBatch()              ← depth=1, not flushed yet
+TextEditor: endBatch()            ← depth=0 → single doc.update()
+```
+
+**YorkieDocStore undo/redo**:
+- `undo()`: calls `this.doc.history.undo()`
+- `redo()`: calls `this.doc.history.redo()`
+- `canUndo()`: calls `this.doc.history.canUndo()`
+- `canRedo()`: calls `this.doc.history.canRedo()`
+
+**MemDocStore**: continues to use snapshot-based undo/redo for tests.
+`beginBatch()` pushes a snapshot at depth=1; `endBatch()` is a no-op
+since mutations are applied directly.
 
 ### Data Flow
 
@@ -298,6 +325,6 @@ is determined by Yorkie's merge semantics.
 |------|------------|
 | `getDocument()` tree traversal cost on large docs | Dirty-flag cache; only re-traverse on actual changes. Incremental layout (dirty block tracking) already minimizes downstream cost. |
 | `getBlock(id)` O(n) scan per call on hot path | `Map<string, TreeNode>` index rebuilt on dirty; O(1) lookup. |
-| Local snapshot undo overwrites concurrent users' changes | Known Phase 1 limitation; undo restricted to single-user until Phase 2 migrates to Yorkie operation-level history. |
+| Local snapshot undo overwrites concurrent users' changes | Resolved in Phase 2: Yorkie-native undo via `doc.history.undo()` eliminates `writeFullDocument()`. |
 | `yorkie.Tree` API constraints (edit by path vs index) | Prototype key operations early to validate API fit. |
 | Doc refactoring breaks existing tests | MemDocStore preserves identical behavior; tests update constructor only. |

--- a/docs/tasks/active/20260331-docs-yorkie-undo-lessons.md
+++ b/docs/tasks/active/20260331-docs-yorkie-undo-lessons.md
@@ -1,0 +1,5 @@
+# Docs Yorkie-Native Undo/Redo — Lessons
+
+## Lessons Learned
+
+(To be populated during implementation)

--- a/docs/tasks/active/20260331-docs-yorkie-undo-todo.md
+++ b/docs/tasks/active/20260331-docs-yorkie-undo-todo.md
@@ -1,0 +1,44 @@
+# Docs Yorkie-Native Undo/Redo
+
+Design doc: [docs-collaboration.md](../../design/docs-collaboration.md)
+Issue: [#97](https://github.com/wafflebase/wafflebase/issues/97)
+
+## Problem
+
+Snapshot-based undo calls `writeFullDocument()` which deletes all tree nodes
+and reinserts from a snapshot. During concurrent editing, Yorkie's CRDT merge
+can preserve both old and new tree nodes, producing duplicate block IDs.
+Clicking a block then jumps to the wrong position because `.find()` returns
+the first match.
+
+## Solution
+
+Migrate to `doc.history.undo()/redo()` with ref-counted `beginBatch/endBatch`
+to ensure compound user actions undo atomically.
+
+## Steps
+
+- [x] 1. DocStore interface: replace `snapshot()` with `beginBatch()/endBatch()`
+- [x] 2. MemDocStore: implement ref-counted batching (snapshot on outer beginBatch)
+- [x] 3. YorkieDocStore: implement batch buffering (buffer ops, flush in endBatch)
+- [x] 4. YorkieDocStore: switch undo/redo to `doc.history.undo()/redo()`
+- [x] 5. YorkieDocStore: remove `undoStack`, `redoStack` (writeFullDocument kept for setDocument only)
+- [x] 6. Doc: wrap compound methods in beginBatch/endBatch
+      - splitBlock, mergeBlocks, deleteRow, insertColumn, deleteColumn
+- [x] 7. editor.ts: convert 21 `docStore.snapshot()` → beginBatch/endBatch pairs
+- [x] 8. text-editor.ts: replace `saveSnapshot` callback with beginBatch/endBatch
+      - Constructor signature change
+      - Convert 27 saveSnapshot call sites
+- [x] 9. Run `pnpm verify:fast` — all tests pass (280/280)
+- [ ] 10. Manual test: concurrent editing + undo → no duplicate block IDs
+
+## Files
+
+| File | Changes |
+|------|---------|
+| `packages/docs/src/store/store.ts` | Interface: remove snapshot, add beginBatch/endBatch |
+| `packages/docs/src/store/memory.ts` | Ref-counted batch + snapshot-based undo |
+| `packages/frontend/src/app/docs/yorkie-doc-store.ts` | Batch buffer + doc.history.undo |
+| `packages/docs/src/model/document.ts` | Wrap compound ops in batch |
+| `packages/docs/src/view/editor.ts` | snapshot → beginBatch/endBatch |
+| `packages/docs/src/view/text-editor.ts` | saveSnapshot → beginBatch/endBatch |

--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -258,8 +258,10 @@ export class Doc {
       ...extra,
     };
 
+    this.store.beginBatch();
     this.store.updateBlock(blockId, block);
     this.store.insertBlock(blockIndex + 1, newBlock);
+    this.store.endBatch();
     this.refresh();
     return newBlock.id;
   }
@@ -291,8 +293,10 @@ export class Doc {
     block.inlines = [...block.inlines, ...nextBlock.inlines];
     this.normalizeInlines(block);
 
+    this.store.beginBatch();
     this.store.updateBlock(blockId, block);
     this.store.deleteBlock(nextBlockId);
+    this.store.endBatch();
     this.refresh();
   }
 
@@ -574,6 +578,7 @@ export class Doc {
     const td = block.tableData!;
     if (td.rows.length <= 1) return; // Prevent 0-row table
 
+    this.store.beginBatch();
     // Adjust rowSpan for cells above that span into the deleted row
     for (let r = 0; r < rowIndex; r++) {
       for (let c = 0; c < td.rows[r].cells.length; c++) {
@@ -587,6 +592,7 @@ export class Doc {
     }
     td.rows.splice(rowIndex, 1);
     this.store.deleteTableRow(blockId, rowIndex);
+    this.store.endBatch();
     this.refresh();
   }
 
@@ -606,8 +612,10 @@ export class Doc {
       row.cells.splice(atIndex, 0, createTableCell());
     }
     const newCells = td.rows.map((row) => row.cells[atIndex]);
+    this.store.beginBatch();
     this.store.insertTableColumn(blockId, atIndex, newCells);
     this.store.updateTableAttrs(blockId, { cols: td.columnWidths });
+    this.store.endBatch();
     this.refresh();
   }
 
@@ -620,6 +628,7 @@ export class Doc {
     const td = block.tableData!;
     if (td.columnWidths.length <= 1) return; // Prevent 0-column table
 
+    this.store.beginBatch();
     // Adjust colSpan for cells left of the deleted column that span into it
     for (let ri = 0; ri < td.rows.length; ri++) {
       for (let c = 0; c < colIndex; c++) {
@@ -642,6 +651,7 @@ export class Doc {
     }
     this.store.deleteTableColumn(blockId, colIndex);
     this.store.updateTableAttrs(blockId, { cols: td.columnWidths });
+    this.store.endBatch();
     this.refresh();
   }
 

--- a/packages/docs/src/store/memory.ts
+++ b/packages/docs/src/store/memory.ts
@@ -20,6 +20,7 @@ export class MemDocStore implements DocStore {
   private doc: Document;
   private undoStack: Document[] = [];
   private redoStack: Document[] = [];
+  private batchDepth = 0;
 
   constructor(doc?: Document) {
     this.doc = doc ? cloneDocument(doc) : { blocks: [] };
@@ -93,9 +94,18 @@ export class MemDocStore implements DocStore {
     return this.redoStack.length > 0;
   }
 
-  snapshot(): void {
-    this.pushUndo();
-    this.redoStack = [];
+  beginBatch(): void {
+    this.batchDepth++;
+    if (this.batchDepth === 1) {
+      this.pushUndo();
+      this.redoStack = [];
+    }
+  }
+
+  endBatch(): void {
+    if (this.batchDepth > 0) {
+      this.batchDepth--;
+    }
   }
 
   insertTableRow(tableBlockId: string, atIndex: number, row: TableRow): void {

--- a/packages/docs/src/store/store.ts
+++ b/packages/docs/src/store/store.ts
@@ -25,8 +25,14 @@ export interface DocStore {
   deleteBlockByIndex(index: number): void;
   getPageSetup(): PageSetup;
   setPageSetup(setup: PageSetup): void;
-  /** Save current state to the undo stack before a group of mutations. */
-  snapshot(): void;
+  /**
+   * Begin a batch of mutations. All store calls between beginBatch() and
+   * endBatch() form a single undo unit. Calls are ref-counted so compound
+   * operations (e.g. splitBlock) can nest safely.
+   */
+  beginBatch(): void;
+  /** End a batch. The outermost endBatch() commits the batch as one undo unit. */
+  endBatch(): void;
   undo(): void;
   redo(): void;
   canUndo(): boolean;

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -533,19 +533,21 @@ export function initialize(
 
   // Wire ruler callbacks
   ruler.onMarginChange((margins) => {
-    docStore.snapshot();
+    docStore.beginBatch();
     const setup = resolvePageSetup(doc.document.pageSetup);
     setup.margins = { ...margins };
     docStore.setPageSetup(setup);
     doc.refresh();
     layoutCache = undefined;
+    docStore.endBatch();
     render();
   });
 
   ruler.onIndentChange((style) => {
-    docStore.snapshot();
+    docStore.beginBatch();
     doc.applyBlockStyle(cursor.position.blockId, style);
     markDirty(cursor.position.blockId);
+    docStore.endBatch();
     render();
   });
 
@@ -636,7 +638,8 @@ export function initialize(
     () => scaleFactor,
     () => canvas.getBoundingClientRect().top - container.getBoundingClientRect().top,
     renderWithScroll,
-    () => docStore.snapshot(),
+    () => docStore.beginBatch(),
+    () => docStore.endBatch(),
     undoFn,
     redoFn,
     markDirty,
@@ -719,13 +722,14 @@ export function initialize(
     },
     applyStyle: (style: Partial<InlineStyle>) => {
       if (selection.hasSelection() && selection.range) {
-        docStore.snapshot();
+        docStore.beginBatch();
         const range = selection.range;
 
         // Cell-range mode: apply to all cells in range
         if (range.tableCellRange) {
           applyStyleToCellRange(range.tableCellRange, style);
           markDirty(range.tableCellRange.blockId);
+          docStore.endBatch();
           render();
           return;
         }
@@ -750,14 +754,16 @@ export function initialize(
             }
           }
         }
+        docStore.endBatch();
         render();
       }
     },
     applyBlockStyle: (style: Partial<BlockStyle>) => {
-      docStore.snapshot();
+      docStore.beginBatch();
       forEachBlockInSelection((block) => {
         doc.applyBlockStyle(block.id, style);
       });
+      docStore.endBatch();
       render();
     },
     undo: undoFn,
@@ -785,13 +791,14 @@ export function initialize(
       };
     },
     setBlockType(type: BlockType, opts?: { headingLevel?: HeadingLevel; listKind?: 'ordered' | 'unordered'; listLevel?: number }) {
-      docStore.snapshot();
+      docStore.beginBatch();
       doc.setBlockType(cursor.position.blockId, type, opts);
       invalidateLayout();
+      docStore.endBatch();
       render();
     },
     toggleList(kind: 'ordered' | 'unordered') {
-      docStore.snapshot();
+      docStore.beginBatch();
       forEachBlockInSelection((block) => {
         if (block.type === 'list-item' && block.listKind === kind) {
           doc.setBlockType(block.id, 'paragraph');
@@ -803,12 +810,13 @@ export function initialize(
         }
       });
       invalidateLayout();
+      docStore.endBatch();
       render();
     },
     indent() {
       const MAX_LIST_LEVEL = 8;
       const INDENT_STEP = 36;
-      docStore.snapshot();
+      docStore.beginBatch();
       forEachBlockInSelection((block) => {
         if (block.type === 'list-item') {
           const currentLevel = block.listLevel ?? 0;
@@ -823,11 +831,12 @@ export function initialize(
           });
         }
       });
+      docStore.endBatch();
       render();
     },
     outdent() {
       const INDENT_STEP = 36;
-      docStore.snapshot();
+      docStore.beginBatch();
       forEachBlockInSelection((block) => {
         if (block.type === 'list-item') {
           const currentLevel = block.listLevel ?? 0;
@@ -844,11 +853,12 @@ export function initialize(
           });
         }
       });
+      docStore.endBatch();
       render();
     },
     insertLink: (url: string) => {
       if (selection.hasSelection() && selection.range) {
-        docStore.snapshot();
+        docStore.beginBatch();
         const range = selection.range;
 
         doc.applyInlineStyle(range, { href: url });
@@ -861,9 +871,10 @@ export function initialize(
             markDirty(doc.document.blocks[i].id);
           }
         }
+        docStore.endBatch();
         render();
       } else {
-        docStore.snapshot();
+        docStore.beginBatch();
         const pos = cursor.position;
 
         doc.insertText(pos, url);
@@ -875,6 +886,7 @@ export function initialize(
         cursor.moveTo({ blockId: pos.blockId, offset: pos.offset + url.length });
         markDirty(pos.blockId);
         needsScrollIntoView = true;
+        docStore.endBatch();
         render();
       }
     },
@@ -901,7 +913,7 @@ export function initialize(
       let hi = cursorInlineIdx;
       while (hi < inlines.length - 1 && inlines[hi + 1].style.href === href) hi++;
 
-      docStore.snapshot();
+      docStore.beginBatch();
       const range = {
         anchor: { blockId: block.id, offset: offsets[lo] },
         focus: { blockId: block.id, offset: offsets[hi + 1] },
@@ -910,6 +922,7 @@ export function initialize(
       // Mark the containing block (or table block for cell blocks) as dirty
       const cellInfo = layout.blockParentMap.get(block.id);
       markDirty(cellInfo ? cellInfo.tableBlockId : block.id);
+      docStore.endBatch();
       render();
     },
     getLinkAtCursor: (): string | undefined => {
@@ -1012,13 +1025,14 @@ export function initialize(
       render();
     },
     insertTable: (rows: number, cols: number) => {
-      docStore.snapshot();
+      docStore.beginBatch();
       const blockIndex = doc.getBlockIndex(cursor.position.blockId);
       const tableId = doc.insertTable(blockIndex + 1, rows, cols);
       const tableBlock = doc.getBlock(tableId);
       const firstCellBlock = tableBlock.tableData!.rows[0].cells[0].blocks[0];
       cursor.moveTo({ blockId: firstCellBlock.id, offset: 0 });
       invalidateLayout();
+      docStore.endBatch();
       render();
     },
     deleteTable: () => {
@@ -1026,7 +1040,7 @@ export function initialize(
       if (!cellInfo) return;
       const blockId = cellInfo.tableBlockId;
       const blockIndex = doc.getBlockIndex(blockId);
-      docStore.snapshot();
+      docStore.beginBatch();
       doc.deleteBlock(blockId);
       // Move cursor to nearest block
       const blocks = doc.document.blocks;
@@ -1035,6 +1049,7 @@ export function initialize(
         cursor.moveTo({ blockId: blocks[newIndex].id, offset: 0 });
       }
       invalidateLayout();
+      docStore.endBatch();
       render();
     },
     isInTable: () => layout.blockParentMap.has(cursor.position.blockId),
@@ -1046,16 +1061,17 @@ export function initialize(
     insertTableRow: (above: boolean) => {
       const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
-      docStore.snapshot();
+      docStore.beginBatch();
       const idx = above ? cellInfo.rowIndex : cellInfo.rowIndex + 1;
       doc.insertRow(cellInfo.tableBlockId, idx);
       invalidateLayout();
+      docStore.endBatch();
       render();
     },
     deleteTableRow: () => {
       const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
-      docStore.snapshot();
+      docStore.beginBatch();
       const tableBlockId = cellInfo.tableBlockId;
       doc.deleteRow(tableBlockId, cellInfo.rowIndex);
       // Re-home cursor if the deleted row was the last one
@@ -1066,21 +1082,23 @@ export function initialize(
         cursor.moveTo({ blockId: newCellBlock.id, offset: 0 });
       }
       invalidateLayout();
+      docStore.endBatch();
       render();
     },
     insertTableColumn: (left: boolean) => {
       const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
-      docStore.snapshot();
+      docStore.beginBatch();
       const idx = left ? cellInfo.colIndex : cellInfo.colIndex + 1;
       doc.insertColumn(cellInfo.tableBlockId, idx);
       invalidateLayout();
+      docStore.endBatch();
       render();
     },
     deleteTableColumn: () => {
       const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
-      docStore.snapshot();
+      docStore.beginBatch();
       const tableBlockId = cellInfo.tableBlockId;
       doc.deleteColumn(tableBlockId, cellInfo.colIndex);
       // Re-home cursor if the deleted column was the last one
@@ -1091,12 +1109,13 @@ export function initialize(
         cursor.moveTo({ blockId: newCellBlock.id, offset: 0 });
       }
       invalidateLayout();
+      docStore.endBatch();
       render();
     },
     mergeTableCells: (range: CellRange) => {
       const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
-      docStore.snapshot();
+      docStore.beginBatch();
       const tableBlockId = cellInfo.tableBlockId;
       doc.mergeCells(tableBlockId, range);
       // Move cursor to top-left cell of merged range
@@ -1104,18 +1123,20 @@ export function initialize(
       const topLeftBlock = td.rows[range.start.rowIndex].cells[range.start.colIndex].blocks[0];
       cursor.moveTo({ blockId: topLeftBlock.id, offset: 0 });
       invalidateLayout();
+      docStore.endBatch();
       render();
     },
     splitTableCell: () => {
       const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
-      docStore.snapshot();
+      docStore.beginBatch();
       doc.splitCell(cellInfo.tableBlockId, { rowIndex: cellInfo.rowIndex, colIndex: cellInfo.colIndex });
       invalidateLayout();
+      docStore.endBatch();
       render();
     },
     applyTableCellStyle: (style: Partial<CellStyle>) => {
-      docStore.snapshot();
+      docStore.beginBatch();
       // Cell-range selection: apply to all cells in range
       if (selection.range?.tableCellRange) {
         const cr = selection.range.tableCellRange;
@@ -1129,6 +1150,7 @@ export function initialize(
           }
         }
         markDirty(cr.blockId);
+        docStore.endBatch();
         render();
         return;
       }
@@ -1137,6 +1159,7 @@ export function initialize(
       if (!cellInfo) return;
       doc.applyCellStyle(cellInfo.tableBlockId, { rowIndex: cellInfo.rowIndex, colIndex: cellInfo.colIndex }, style);
       markDirty(cellInfo.tableBlockId);
+      docStore.endBatch();
       render();
     },
     focus: () => textEditor?.focus(),

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -354,9 +354,13 @@ export class TextEditor {
       }
     }
 
-    // Non-typing keys close the typing batch so subsequent undo/redo
-    // operations don't interfere with the typing undo unit.
-    this.flushTypingBatch();
+    // Printable characters (single char, no Ctrl/Cmd) are handled by
+    // handleInput and share the typing batch — don't flush here.
+    // All other keys (Backspace, Enter, arrows, shortcuts) flush.
+    const isTypingKey = key.length === 1 && !mod && !ctrlKey && !metaKey && !altKey;
+    if (!isTypingKey) {
+      this.flushTypingBatch();
+    }
 
     switch (key) {
       case 'Backspace':

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -75,6 +75,16 @@ export class TextEditor {
   /** Track shift key state for paste handler (ClipboardEvent lacks shiftKey). */
   private shiftHeld = false;
 
+  /**
+   * Typing debounce: consecutive keystrokes share a single batch so that
+   * Yorkie records them as one undo unit. The batch stays open while the
+   * user keeps typing and is flushed after TYPING_BATCH_MS of inactivity
+   * or when a non-typing action occurs.
+   */
+  private static readonly TYPING_BATCH_MS = 300;
+  private typingBatchOpen = false;
+  private typingBatchTimer: ReturnType<typeof setTimeout> | null = null;
+
   private container: HTMLElement;
   private doc: Doc;
   private cursor: Cursor;
@@ -281,7 +291,33 @@ export class TextEditor {
     // Non-jamo input: flush any pending Hangul composition first
     this.flushHangul();
 
-    this.beginBatch();
+    // Space triggers auto-convert / auto-link which are distinct actions,
+    // so flush the typing batch and start a fresh one.
+    if (data === ' ') {
+      this.flushTypingBatch();
+      this.beginBatch();
+      this.deleteSelection();
+      const blockId = this.cursor.position.blockId;
+      this.doc.insertText(this.cursor.position, data);
+      const newPos = {
+        blockId: this.cursor.position.blockId,
+        offset: this.cursor.position.offset + data.length,
+      };
+      this.markDirty(blockId);
+      if (this.tryAutoConvert(blockId)) {
+        this.endBatch();
+        this.requestRender();
+        return;
+      }
+      this.tryAutoLinkBeforeCursor(blockId, newPos.offset - 1);
+      this.endBatch();
+      this.cursor.moveTo(newPos, this.getWrapAffinity(newPos));
+      this.requestRender();
+      return;
+    }
+
+    // Regular typing: group consecutive keystrokes into one undo unit.
+    this.ensureTypingBatch();
     this.deleteSelection();
     const blockId = this.cursor.position.blockId;
 
@@ -291,18 +327,8 @@ export class TextEditor {
       offset: this.cursor.position.offset + data.length,
     };
     this.markDirty(blockId);
-    // Markdown-style auto-conversion: check after each space
-    if (data === ' ' && this.tryAutoConvert(blockId)) {
-      this.endBatch();
-      this.requestRender();
-      return;
-    }
-    // URL auto-detection: after typing a space, check if the preceding token
-    // is a URL and convert it to a hyperlink.
-    if (data === ' ') {
-      this.tryAutoLinkBeforeCursor(blockId, newPos.offset - 1);
-    }
-    this.endBatch();
+    // Don't endBatch here — the typing batch stays open until the
+    // debounce timer fires or a non-typing action flushes it.
     this.cursor.moveTo(newPos, this.getWrapAffinity(newPos));
     this.requestRender();
   };
@@ -327,6 +353,10 @@ export class TextEditor {
         this.flushHangul();
       }
     }
+
+    // Non-typing keys close the typing batch so subsequent undo/redo
+    // operations don't interfere with the typing undo unit.
+    this.flushTypingBatch();
 
     switch (key) {
       case 'Backspace':
@@ -595,6 +625,7 @@ export class TextEditor {
   };
 
   private handleCopy = (e: ClipboardEvent): void => {
+    this.flushTypingBatch();
     if (!this.selection.hasSelection()) return;
     e.preventDefault();
     const selectedBlocks = this.getSelectedBlocks();
@@ -604,6 +635,7 @@ export class TextEditor {
   };
 
   private handleCut = (e: ClipboardEvent): void => {
+    this.flushTypingBatch();
     if (!this.selection.hasSelection()) return;
     e.preventDefault();
     const selectedBlocks = this.getSelectedBlocks();
@@ -617,6 +649,7 @@ export class TextEditor {
   };
 
   private handlePaste = (e: ClipboardEvent): void => {
+    this.flushTypingBatch();
     e.preventDefault();
 
     // Try rich internal paste first
@@ -664,6 +697,7 @@ export class TextEditor {
   };
 
   private handleMouseDown = (e: MouseEvent): void => {
+    this.flushTypingBatch();
     if (e.target === this.textarea) return;
 
     // Ignore clicks on non-canvas UI elements (e.g. context menu buttons)
@@ -2930,6 +2964,41 @@ export class TextEditor {
   }
 
   /**
+   * Ensure a typing batch is open. Consecutive keystrokes share a single
+   * batch so Yorkie records them as one undo unit. The batch auto-closes
+   * after TYPING_BATCH_MS of inactivity.
+   */
+  private ensureTypingBatch(): void {
+    if (this.typingBatchTimer !== null) {
+      clearTimeout(this.typingBatchTimer);
+      this.typingBatchTimer = null;
+    }
+    if (!this.typingBatchOpen) {
+      this.beginBatch();
+      this.typingBatchOpen = true;
+    }
+    this.typingBatchTimer = setTimeout(() => {
+      this.flushTypingBatch();
+    }, TextEditor.TYPING_BATCH_MS);
+  }
+
+  /**
+   * Close the typing batch if one is open. Called when a non-typing
+   * action occurs (Enter, Backspace, paste, style change, etc.) or
+   * after the debounce timeout.
+   */
+  private flushTypingBatch(): void {
+    if (this.typingBatchTimer !== null) {
+      clearTimeout(this.typingBatchTimer);
+      this.typingBatchTimer = null;
+    }
+    if (this.typingBatchOpen) {
+      this.typingBatchOpen = false;
+      this.endBatch();
+    }
+  }
+
+  /**
    * Move the hidden textarea to the cursor's screen position so the
    * browser doesn't scroll the container to bring the textarea into view.
    * The textarea uses position:fixed, so coordinates are viewport-relative.
@@ -3020,6 +3089,7 @@ export class TextEditor {
   }
 
   dispose(): void {
+    this.flushTypingBatch();
     this.textarea.removeEventListener('input', this.handleInput);
     this.textarea.removeEventListener('keydown', this.handleKeyDown);
     this.textarea.removeEventListener('compositionstart', this.handleCompositionStart);

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -86,7 +86,8 @@ export class TextEditor {
   private getScaleFactor: () => number;
   private getCanvasOffsetTop: () => number;
   private requestRender: () => void;
-  private saveSnapshot: () => void;
+  private beginBatch: () => void;
+  private endBatch: () => void;
   private undoAction: () => void;
   private redoAction: () => void;
   private markDirty: (blockId: string) => void;
@@ -113,7 +114,8 @@ export class TextEditor {
     getScaleFactor: () => number,
     getCanvasOffsetTop: () => number,
     requestRender: () => void,
-    saveSnapshot: () => void,
+    beginBatch: () => void,
+    endBatch: () => void,
     undoAction: () => void,
     redoAction: () => void,
     markDirty: (blockId: string) => void,
@@ -130,7 +132,8 @@ export class TextEditor {
     this.getScaleFactor = getScaleFactor;
     this.getCanvasOffsetTop = getCanvasOffsetTop;
     this.requestRender = requestRender;
-    this.saveSnapshot = saveSnapshot;
+    this.beginBatch = beginBatch;
+    this.endBatch = endBatch;
     this.undoAction = undoAction;
     this.redoAction = redoAction;
     this.markDirty = markDirty;
@@ -178,8 +181,9 @@ export class TextEditor {
     // Cancel any pending post-compositionend ignore — a new composition is
     // starting (e.g. syllable boundary in Korean: compositionend → compositionstart).
     this.ignoreInputUntilNextTick = false;
-    this.saveSnapshot();
+    this.beginBatch();
     this.deleteSelection();
+    this.endBatch();
     this.composition = {
       active: true,
       startPosition: { ...this.cursor.position },
@@ -277,7 +281,7 @@ export class TextEditor {
     // Non-jamo input: flush any pending Hangul composition first
     this.flushHangul();
 
-    this.saveSnapshot();
+    this.beginBatch();
     this.deleteSelection();
     const blockId = this.cursor.position.blockId;
 
@@ -289,6 +293,7 @@ export class TextEditor {
     this.markDirty(blockId);
     // Markdown-style auto-conversion: check after each space
     if (data === ' ' && this.tryAutoConvert(blockId)) {
+      this.endBatch();
       this.requestRender();
       return;
     }
@@ -297,6 +302,7 @@ export class TextEditor {
     if (data === ' ') {
       this.tryAutoLinkBeforeCursor(blockId, newPos.offset - 1);
     }
+    this.endBatch();
     this.cursor.moveTo(newPos, this.getWrapAffinity(newPos));
     this.requestRender();
   };
@@ -489,8 +495,9 @@ export class TextEditor {
       case '0':
         if (mod && altKey) {
           e.preventDefault();
-          this.saveSnapshot();
+          this.beginBatch();
           this.doc.setBlockType(this.cursor.position.blockId, 'paragraph');
+          this.endBatch();
           this.invalidateLayout();
           this.requestRender();
         }
@@ -548,8 +555,9 @@ export class TextEditor {
         if (mod && altKey) {
           e.preventDefault();
           if (this.styleBuffer && this.selection.hasSelection() && this.selection.range) {
-            this.saveSnapshot();
+            this.beginBatch();
             this.doc.applyInlineStyle(this.selection.range, this.styleBuffer);
+            this.endBatch();
             const startIdx = this.doc.getBlockIndex(this.selection.range.anchor.blockId);
             const endIdx = this.doc.getBlockIndex(this.selection.range.focus.blockId);
             if (startIdx >= 0 && endIdx >= 0) {
@@ -570,7 +578,7 @@ export class TextEditor {
       case '1': case '2': case '3': case '4': case '5': case '6':
         if (mod && altKey) {
           e.preventDefault();
-          this.saveSnapshot();
+          this.beginBatch();
           const level = Number(key) as HeadingLevel;
           const block = this.doc.getBlock(this.cursor.position.blockId);
           if (block && block.type === 'heading' && block.headingLevel === level) {
@@ -578,6 +586,7 @@ export class TextEditor {
           } else if (block) {
             this.doc.setBlockType(block.id, 'heading', { headingLevel: level });
           }
+          this.endBatch();
           this.invalidateLayout();
           this.requestRender();
         }
@@ -601,8 +610,9 @@ export class TextEditor {
     const json = serializeBlocks(selectedBlocks);
     e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
     e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
-    this.saveSnapshot();
+    this.beginBatch();
     this.deleteSelection();
+    this.endBatch();
     this.requestRender();
   };
 
@@ -614,9 +624,10 @@ export class TextEditor {
     if (json) {
       const blocks = deserializeBlocks(json);
       if (blocks.length > 0) {
-        this.saveSnapshot();
+        this.beginBatch();
         this.deleteSelection();
         this.insertBlocks(blocks);
+        this.endBatch();
         this.selection.setRange(null);
         this.requestRender();
         return;
@@ -629,9 +640,10 @@ export class TextEditor {
       if (html) {
         const blocks = parseHtmlToBlocks(html);
         if (blocks.length > 0) {
-          this.saveSnapshot();
+          this.beginBatch();
           this.deleteSelection();
           this.insertBlocks(blocks);
+          this.endBatch();
           this.selection.setRange(null);
           this.requestRender();
           return;
@@ -643,9 +655,10 @@ export class TextEditor {
     const text = e.clipboardData?.getData('text/plain');
     if (!text) return;
 
-    this.saveSnapshot();
+    this.beginBatch();
     this.deleteSelection();
     this.insertPlainText(text);
+    this.endBatch();
     this.selection.setRange(null);
     this.requestRender();
   };
@@ -960,8 +973,11 @@ export class TextEditor {
   // --- Text operations ---
 
   private handleBackspace(): void {
-    this.saveSnapshot();
-    if (this.deleteSelection()) return;
+    this.beginBatch();
+    if (this.deleteSelection()) {
+      this.endBatch();
+      return;
+    }
 
     // Table cell backspace: delete within cell block, merge blocks, or no-op
     const bsCellInfo = this.getCellInfo(this.cursor.position.blockId);
@@ -969,6 +985,7 @@ export class TextEditor {
       const pos = this.cursor.position;
       if (pos.offset > 0) {
         this.doc.deleteText({ blockId: pos.blockId, offset: pos.offset - 1 }, 1);
+        this.endBatch();
         this.cursor.moveTo({
           blockId: pos.blockId,
           offset: pos.offset - 1,
@@ -983,12 +1000,14 @@ export class TextEditor {
           const prevBlock = cell.blocks[blockIdx - 1];
           const prevLen = getBlockTextLength(prevBlock);
           this.doc.mergeBlocks(prevBlock.id, pos.blockId);
+          this.endBatch();
           this.cursor.moveTo({
             blockId: prevBlock.id,
             offset: prevLen,
           });
           this.invalidateLayout();
         } else {
+          this.endBatch();
           return; // At start of first block in cell — no-op
         }
       }
@@ -1003,6 +1022,7 @@ export class TextEditor {
       this.invalidateLayout();
     }
     const newPos = this.doc.deleteBackward(this.cursor.position);
+    this.endBatch();
     if (isInBlock) {
       this.markDirty(blockId);
     }
@@ -1011,8 +1031,11 @@ export class TextEditor {
   }
 
   private handleDelete(): void {
-    this.saveSnapshot();
-    if (this.deleteSelection()) return;
+    this.beginBatch();
+    if (this.deleteSelection()) {
+      this.endBatch();
+      return;
+    }
 
     // Table cell delete: delete within cell block, merge blocks, or no-op
     const delCellInfo = this.getCellInfo(this.cursor.position.blockId);
@@ -1031,9 +1054,11 @@ export class TextEditor {
           this.doc.mergeBlocks(pos.blockId, nextBlock.id);
           this.invalidateLayout();
         } else {
+          this.endBatch();
           return; // At end of last block in cell — no-op
         }
       }
+      this.endBatch();
       this.markDirty(delCellInfo.tableBlockId);
       this.requestRender();
       return;
@@ -1053,33 +1078,45 @@ export class TextEditor {
         this.doc.mergeBlocks(this.cursor.position.blockId, nextBlock.id);
       }
     }
+    this.endBatch();
     this.requestRender();
   }
 
   private handleWordBackspace(): void {
-    this.saveSnapshot();
-    if (this.deleteSelection()) return;
+    this.beginBatch();
+    if (this.deleteSelection()) {
+      this.endBatch();
+      return;
+    }
     const pos = this.cursor.position;
     if (pos.offset > 0) {
       const text = getBlockText(this.doc.getBlock(pos.blockId));
       const boundary = findPrevWordBoundary(text, pos.offset);
       const count = pos.offset - boundary;
       this.doc.deleteText({ blockId: pos.blockId, offset: boundary }, count);
+      this.endBatch();
       this.cursor.moveTo({ blockId: pos.blockId, offset: boundary });
       this.markDirty(pos.blockId);
     } else {
       // At start of block — merge with previous (same as normal backspace)
-      if (this.doc.getBlockIndex(pos.blockId) === 0) return;
+      if (this.doc.getBlockIndex(pos.blockId) === 0) {
+        this.endBatch();
+        return;
+      }
       this.invalidateLayout();
       const newPos = this.doc.deleteBackward(pos);
+      this.endBatch();
       this.cursor.moveTo(newPos);
     }
     this.requestRender();
   }
 
   private handleWordDelete(): void {
-    this.saveSnapshot();
-    if (this.deleteSelection()) return;
+    this.beginBatch();
+    if (this.deleteSelection()) {
+      this.endBatch();
+      return;
+    }
     const pos = this.cursor.position;
     const block = this.doc.getBlock(pos.blockId);
     const len = getBlockTextLength(block);
@@ -1097,6 +1134,7 @@ export class TextEditor {
         this.doc.mergeBlocks(pos.blockId, this.doc.document.blocks[idx + 1].id);
       }
     }
+    this.endBatch();
     this.requestRender();
   }
 
@@ -1104,10 +1142,11 @@ export class TextEditor {
     // In a table cell: split block within cell
     const enterCellInfo = this.getCellInfo(this.cursor.position.blockId);
     if (enterCellInfo) {
-      this.saveSnapshot();
+      this.beginBatch();
       this.deleteSelection();
       const pos = this.cursor.position;
       const newBlockId = this.doc.splitBlock(pos.blockId, pos.offset);
+      this.endBatch();
       this.cursor.moveTo({
         blockId: newBlockId,
         offset: 0,
@@ -1119,7 +1158,7 @@ export class TextEditor {
       return;
     }
 
-    this.saveSnapshot();
+    this.beginBatch();
     this.deleteSelection();
     this.invalidateLayout();
 
@@ -1130,6 +1169,7 @@ export class TextEditor {
       this.doc.deleteText({ blockId: enterPos.blockId, offset: 0 }, 3);
       this.doc.setBlockType(enterPos.blockId, 'horizontal-rule');
       const newId = this.doc.splitBlock(enterPos.blockId, 0);
+      this.endBatch();
       this.cursor.moveTo({ blockId: newId, offset: 0 });
       this.selection.setRange(null);
       this.requestRender();
@@ -1140,6 +1180,7 @@ export class TextEditor {
     const pos = this.cursor.position;
     this.tryAutoLinkBeforeCursor(pos.blockId, pos.offset);
     const newBlockId = this.doc.splitBlock(pos.blockId, pos.offset);
+    this.endBatch();
 
     if (newBlockId === pos.blockId) {
       // Block was converted in-place (e.g., empty list → paragraph)
@@ -1167,28 +1208,33 @@ export class TextEditor {
     const block = this.doc.getBlock(this.cursor.position.blockId);
     if (block.type !== 'list-item') return;
 
-    this.saveSnapshot();
+    this.beginBatch();
     const currentLevel = block.listLevel ?? 0;
     const newLevel = shift ? Math.max(0, currentLevel - 1) : Math.min(8, currentLevel + 1);
-    if (newLevel === currentLevel) return;
+    if (newLevel === currentLevel) {
+      this.endBatch();
+      return;
+    }
 
     this.doc.setBlockType(block.id, 'list-item', {
       listKind: block.listKind,
       listLevel: newLevel,
     });
+    this.endBatch();
     this.invalidateLayout();
     this.requestRender();
   }
 
   private handleAlign(alignment: 'left' | 'center' | 'right' | 'justify'): void {
-    this.saveSnapshot();
+    this.beginBatch();
     this.doc.applyBlockStyle(this.cursor.position.blockId, { alignment });
+    this.endBatch();
     this.invalidateLayout();
     this.requestRender();
   }
 
   private toggleList(kind: 'ordered' | 'unordered'): void {
-    this.saveSnapshot();
+    this.beginBatch();
     {
       const block = this.doc.getBlock(this.cursor.position.blockId);
       if (block.type === 'list-item' && block.listKind === kind) {
@@ -1200,6 +1246,7 @@ export class TextEditor {
         });
       }
     }
+    this.endBatch();
     this.invalidateLayout();
     this.requestRender();
   }
@@ -1207,7 +1254,7 @@ export class TextEditor {
   private handleIndent(): void {
     const MAX_LIST_LEVEL = 8;
     const INDENT_STEP = 36;
-    this.saveSnapshot();
+    this.beginBatch();
     this.forEachBlockInSelection((block) => {
       if (block.type === 'list-item') {
         const currentLevel = block.listLevel ?? 0;
@@ -1222,13 +1269,14 @@ export class TextEditor {
         });
       }
     });
+    this.endBatch();
     this.invalidateLayout();
     this.requestRender();
   }
 
   private handleOutdent(): void {
     const INDENT_STEP = 36;
-    this.saveSnapshot();
+    this.beginBatch();
     this.forEachBlockInSelection((block) => {
       if (block.type === 'list-item') {
         const currentLevel = block.listLevel ?? 0;
@@ -1245,6 +1293,7 @@ export class TextEditor {
         });
       }
     });
+    this.endBatch();
     this.invalidateLayout();
     this.requestRender();
   }
@@ -1636,24 +1685,33 @@ export class TextEditor {
   }
 
   private handleLineBackspace(): void {
-    this.saveSnapshot();
-    if (this.deleteSelection()) return;
+    this.beginBatch();
+    if (this.deleteSelection()) {
+      this.endBatch();
+      return;
+    }
     const pos = this.cursor.position;
     const lineStart = this.getVisualLineStart(pos);
     if (lineStart.offset < pos.offset) {
       const count = pos.offset - lineStart.offset;
       this.doc.deleteText(lineStart, count);
+      this.endBatch();
       this.cursor.moveTo(lineStart);
       this.markDirty(pos.blockId);
     } else if (pos.offset > 0) {
       // Cursor is at visual line start but not block start — delete to block start
       this.doc.deleteText({ blockId: pos.blockId, offset: 0 }, pos.offset);
+      this.endBatch();
       this.cursor.moveTo({ blockId: pos.blockId, offset: 0 });
       this.markDirty(pos.blockId);
     } else {
-      if (this.doc.getBlockIndex(pos.blockId) === 0) return;
+      if (this.doc.getBlockIndex(pos.blockId) === 0) {
+        this.endBatch();
+        return;
+      }
       this.invalidateLayout();
       const newPos = this.doc.deleteBackward(pos);
+      this.endBatch();
       this.cursor.moveTo(newPos);
     }
     this.requestRender();
@@ -1680,7 +1738,7 @@ export class TextEditor {
 
   private clearFormatting(): void {
     if (!this.selection.hasSelection() || !this.selection.range) return;
-    this.saveSnapshot();
+    this.beginBatch();
     const range = this.selection.range;
     const clearStyle: Partial<InlineStyle> = {
       bold: undefined,
@@ -1693,6 +1751,7 @@ export class TextEditor {
     };
 
     this.doc.applyInlineStyle(range, clearStyle);
+    this.endBatch();
     const startIdx = this.doc.getBlockIndex(range.anchor.blockId);
     const endIdx = this.doc.getBlockIndex(range.focus.blockId);
     if (startIdx < 0 || endIdx < 0) {
@@ -1965,9 +2024,10 @@ export class TextEditor {
     try {
       const text = await navigator.clipboard.readText();
       if (!text) return;
-      this.saveSnapshot();
+      this.beginBatch();
       this.deleteSelection();
       this.insertPlainText(text);
+      this.endBatch();
       this.selection.setRange(null);
       this.requestRender();
     } catch {
@@ -2702,9 +2762,10 @@ export class TextEditor {
     // At last cell
     if (addRowAtEnd) {
       // Tab: insert a new row and move to it
-      this.saveSnapshot();
+      this.beginBatch();
       const newRowIndex = td.rows.length;
       this.doc.insertRow(tableBlockId, newRowIndex);
+      this.endBatch();
       this.invalidateLayout();
       // After insertRow, re-fetch the block to get the new row's cell blocks
       const updatedBlock = this.doc.getBlock(tableBlockId);
@@ -2832,8 +2893,10 @@ export class TextEditor {
     }
 
     if (result.composing) {
+      let batchStarted = false;
       if (this.hangulComposingLength === 0 && !result.commit) {
-        this.saveSnapshot();
+        this.beginBatch();
+        batchStarted = true;
         this.deleteSelection();
         this.hangulStartPos = { ...this.cursor.position };
       }
@@ -2842,6 +2905,9 @@ export class TextEditor {
       }
       this.doc.insertText(this.hangulStartPos, result.composing);
       this.hangulComposingLength = result.composing.length;
+      if (batchStarted) {
+        this.endBatch();
+      }
     } else {
       this.hangulComposingLength = 0;
     }

--- a/packages/docs/test/store/memory.test.ts
+++ b/packages/docs/test/store/memory.test.ts
@@ -106,12 +106,13 @@ describe('MemDocStore', () => {
       expect(store.canUndo()).toBe(false);
     });
 
-    it('snapshot + replaceDocument enables correct undo', () => {
+    it('batch + replaceDocument enables correct undo', () => {
       const block = makeBlock('Hello');
       const store = new MemDocStore({ blocks: [block] });
 
-      store.snapshot();
+      store.beginBatch();
       store.replaceDocument({ blocks: [makeBlock('Edited')] });
+      store.endBatch();
       expect(store.getDocument().blocks[0].inlines[0].text).toBe('Edited');
 
       store.undo();
@@ -127,9 +128,10 @@ describe('MemDocStore', () => {
 
     it('setPageSetup updates and supports undo', () => {
       const store = new MemDocStore();
-      store.snapshot();
+      store.beginBatch();
       const a4Setup = { ...DEFAULT_PAGE_SETUP, paperSize: PAPER_SIZES.A4 };
       store.setPageSetup(a4Setup);
+      store.endBatch();
       expect(store.getPageSetup().paperSize).toEqual(PAPER_SIZES.A4);
 
       store.undo();
@@ -138,11 +140,12 @@ describe('MemDocStore', () => {
   });
 
   describe('undo/redo', () => {
-    it('should undo a setDocument when preceded by snapshot', () => {
+    it('should undo a setDocument when preceded by beginBatch', () => {
       const block = makeBlock('Hello');
       const store = new MemDocStore({ blocks: [block] });
-      store.snapshot();
+      store.beginBatch();
       store.setDocument({ blocks: [] });
+      store.endBatch();
       expect(store.getDocument().blocks).toHaveLength(0);
 
       store.undo();
@@ -153,24 +156,27 @@ describe('MemDocStore', () => {
     it('should redo after undo', () => {
       const block = makeBlock('Hello');
       const store = new MemDocStore({ blocks: [block] });
-      store.snapshot();
+      store.beginBatch();
       store.setDocument({ blocks: [] });
+      store.endBatch();
       store.undo();
       store.redo();
       expect(store.getDocument().blocks).toHaveLength(0);
     });
 
-    it('should clear redo stack on new snapshot', () => {
+    it('should clear redo stack on new batch', () => {
       const block = makeBlock('Hello');
       const store = new MemDocStore({ blocks: [block] });
-      store.snapshot();
+      store.beginBatch();
       store.setDocument({ blocks: [] });
+      store.endBatch();
       store.undo();
       expect(store.canRedo()).toBe(true);
 
-      store.snapshot();
+      store.beginBatch();
       const newBlock = makeBlock('New');
       store.insertBlock(0, newBlock);
+      store.endBatch();
       expect(store.canRedo()).toBe(false);
     });
 
@@ -179,8 +185,9 @@ describe('MemDocStore', () => {
       expect(store.canUndo()).toBe(false);
       expect(store.canRedo()).toBe(false);
 
-      store.snapshot();
+      store.beginBatch();
       store.setDocument({ blocks: [makeBlock('A')] });
+      store.endBatch();
       expect(store.canUndo()).toBe(true);
       expect(store.canRedo()).toBe(false);
 
@@ -189,39 +196,42 @@ describe('MemDocStore', () => {
       expect(store.canRedo()).toBe(true);
     });
 
-    it('should undo insertBlock when preceded by snapshot', () => {
+    it('should undo insertBlock when preceded by beginBatch', () => {
       const store = new MemDocStore();
-      store.snapshot();
+      store.beginBatch();
       store.insertBlock(0, makeBlock('Hello'));
+      store.endBatch();
       expect(store.getDocument().blocks).toHaveLength(1);
 
       store.undo();
       expect(store.getDocument().blocks).toHaveLength(0);
     });
 
-    it('should undo deleteBlock when preceded by snapshot', () => {
+    it('should undo deleteBlock when preceded by beginBatch', () => {
       const block = makeBlock('Hello');
       const store = new MemDocStore({ blocks: [block] });
-      store.snapshot();
+      store.beginBatch();
       store.deleteBlock(block.id);
+      store.endBatch();
       expect(store.getDocument().blocks).toHaveLength(0);
 
       store.undo();
       expect(store.getDocument().blocks).toHaveLength(1);
     });
 
-    it('should undo updateBlock when preceded by snapshot', () => {
+    it('should undo updateBlock when preceded by beginBatch', () => {
       const block = makeBlock('Hello');
       const store = new MemDocStore({ blocks: [block] });
-      store.snapshot();
+      store.beginBatch();
       store.updateBlock(block.id, { ...block, inlines: [{ text: 'World', style: {} }] });
+      store.endBatch();
       expect(store.getBlock(block.id)?.inlines[0].text).toBe('World');
 
       store.undo();
       expect(store.getBlock(block.id)?.inlines[0].text).toBe('Hello');
     });
 
-    it('mutation without snapshot is not undoable', () => {
+    it('mutation without beginBatch is not undoable', () => {
       const block = makeBlock('Hello');
       const store = new MemDocStore({ blocks: [block] });
       store.updateBlock(block.id, { ...block, inlines: [{ text: 'World', style: {} }] });

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -58,6 +58,10 @@ function ensureTree(doc: ReturnType<typeof useDocument<YorkieDocsRoot>>["doc"]):
     });
   });
 
+  // Clear undo history so the initial tree creation is not undoable.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (doc as any).clearHistory?.();
+
   return true;
 }
 

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -333,9 +333,10 @@ export class YorkieDocStore implements DocStore {
   private cachedDoc: Document | null = null;
   private dirty = true;
 
-  // Local snapshot-based undo/redo (Phase 1)
-  private undoStack: Document[] = [];
-  private redoStack: Document[] = [];
+  // Batch buffering for atomic undo units
+  private batchDepth = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private batchOps: Array<(root: any) => void> | null = null;
 
   /**
    * Optional callback invoked when a remote change is detected.
@@ -424,10 +425,11 @@ export class YorkieDocStore implements DocStore {
       throw new Error(`Block not found: ${id}`);
     }
 
-    this.doc.update((root) => {
+    const node = buildBlockNode(block);
+    this.execTreeOp((root) => {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
-      tree.editByPath([index], [index + 1], buildBlockNode(block));
+      tree.editByPath([index], [index + 1], node);
     });
     // Update cache in-place instead of clearing
     currentDoc.blocks[index] = block;
@@ -436,10 +438,11 @@ export class YorkieDocStore implements DocStore {
   }
 
   insertBlock(index: number, block: Block): void {
-    this.doc.update((root) => {
+    const node = buildBlockNode(block);
+    this.execTreeOp((root) => {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
-      tree.editByPath([index], [index], buildBlockNode(block));
+      tree.editByPath([index], [index], node);
     });
     // Update cache in-place
     const currentDoc = this.getDocument();
@@ -458,7 +461,7 @@ export class YorkieDocStore implements DocStore {
   }
 
   deleteBlockByIndex(index: number): void {
-    this.doc.update((root) => {
+    this.execTreeOp((root) => {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
       const treeRoot = tree.getRootTreeNode();
@@ -489,7 +492,7 @@ export class YorkieDocStore implements DocStore {
   insertTableRow(tableBlockId: string, atIndex: number, row: TableRow): void {
     const tIdx = this.findTableIndex(tableBlockId);
     const rowNode = buildRowNode(row);
-    this.doc.update((root) => {
+    this.execTreeOp((root) => {
       root.content.editByPath([tIdx, atIndex], [tIdx, atIndex], rowNode);
     });
     const currentDoc = this.getDocument();
@@ -500,7 +503,7 @@ export class YorkieDocStore implements DocStore {
 
   deleteTableRow(tableBlockId: string, rowIndex: number): void {
     const tIdx = this.findTableIndex(tableBlockId);
-    this.doc.update((root) => {
+    this.execTreeOp((root) => {
       root.content.editByPath([tIdx, rowIndex], [tIdx, rowIndex + 1]);
     });
     const currentDoc = this.getDocument();
@@ -511,10 +514,11 @@ export class YorkieDocStore implements DocStore {
 
   insertTableColumn(tableBlockId: string, atIndex: number, cells: TableCell[]): void {
     const tIdx = this.findTableIndex(tableBlockId);
-    this.doc.update((root) => {
+    const cellNodes = cells.map(buildCellNode);
+    this.execTreeOp((root) => {
       const tree = root.content;
-      for (let r = 0; r < cells.length; r++) {
-        tree.editByPath([tIdx, r, atIndex], [tIdx, r, atIndex], buildCellNode(cells[r]));
+      for (let r = 0; r < cellNodes.length; r++) {
+        tree.editByPath([tIdx, r, atIndex], [tIdx, r, atIndex], cellNodes[r]);
       }
     });
     const currentDoc = this.getDocument();
@@ -530,7 +534,7 @@ export class YorkieDocStore implements DocStore {
     const tIdx = this.findTableIndex(tableBlockId);
     const currentDoc = this.getDocument();
     const rowCount = currentDoc.blocks[tIdx].tableData!.rows.length;
-    this.doc.update((root) => {
+    this.execTreeOp((root) => {
       const tree = root.content;
       for (let r = 0; r < rowCount; r++) {
         tree.editByPath([tIdx, r, colIndex], [tIdx, r, colIndex + 1]);
@@ -548,7 +552,7 @@ export class YorkieDocStore implements DocStore {
   ): void {
     const tIdx = this.findTableIndex(tableBlockId);
     const cellNode = buildCellNode(cell);
-    this.doc.update((root) => {
+    this.execTreeOp((root) => {
       root.content.editByPath(
         [tIdx, rowIndex, colIndex],
         [tIdx, rowIndex, colIndex + 1],
@@ -566,15 +570,16 @@ export class YorkieDocStore implements DocStore {
     const currentDoc = this.getDocument();
     const block = currentDoc.blocks[tIdx];
     block.tableData!.columnWidths = attrs.cols;
-    this.doc.update((root) => {
-      root.content.editByPath([tIdx], [tIdx + 1], buildBlockNode(block));
+    const node = buildBlockNode(block);
+    this.execTreeOp((root) => {
+      root.content.editByPath([tIdx], [tIdx + 1], node);
     });
     this.cachedDoc = currentDoc;
     this.dirty = false;
   }
 
   setPageSetup(setup: PageSetup): void {
-    this.doc.update((root) => {
+    this.execTreeOp((root) => {
       root.pageSetup = {
         paperSize: { ...setup.paperSize },
         orientation: setup.orientation,
@@ -586,50 +591,73 @@ export class YorkieDocStore implements DocStore {
   }
 
   // -----------------------------------------------------------------------
-  // Undo / Redo (local snapshot stack — Phase 1)
+  // Batch + Undo / Redo (Yorkie-native via doc.history)
   // -----------------------------------------------------------------------
 
-  snapshot(): void {
-    const current = this.getDocument();
-    this.undoStack.push(cloneDocument(current));
-    this.redoStack = [];
+  beginBatch(): void {
+    this.batchDepth++;
+    if (this.batchDepth === 1) {
+      this.batchOps = [];
+    }
+  }
+
+  endBatch(): void {
+    if (this.batchDepth <= 0) return;
+    this.batchDepth--;
+    if (this.batchDepth === 0) {
+      const ops = this.batchOps;
+      this.batchOps = null;
+      if (!ops || ops.length === 0) return;
+      this.doc.update((root) => {
+        for (const op of ops) {
+          op(root);
+        }
+      });
+    }
   }
 
   undo(): void {
     if (!this.canUndo()) return;
-    const current = this.getDocument();
-    this.redoStack.push(cloneDocument(current));
-    const previous = this.undoStack.pop()!;
-    this.writeFullDocument(previous);
+    this.doc.history.undo();
     this.dirty = true;
     this.cachedDoc = null;
   }
 
   redo(): void {
     if (!this.canRedo()) return;
-    const current = this.getDocument();
-    this.undoStack.push(cloneDocument(current));
-    const next = this.redoStack.pop()!;
-    this.writeFullDocument(next);
+    this.doc.history.redo();
     this.dirty = true;
     this.cachedDoc = null;
   }
 
   canUndo(): boolean {
-    return this.undoStack.length > 0;
+    return this.doc.history.canUndo();
   }
 
   canRedo(): boolean {
-    return this.redoStack.length > 0;
+    return this.doc.history.canRedo();
   }
 
   // -----------------------------------------------------------------------
-  // Internal: write a full document to the Yorkie tree
+  // Internal helpers
   // -----------------------------------------------------------------------
 
   /**
+   * Execute a tree operation. If batching, buffer the op; otherwise run
+   * it immediately inside doc.update().
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private execTreeOp(op: (root: any) => void): void {
+    if (this.batchOps) {
+      this.batchOps.push(op);
+    } else {
+      this.doc.update((root) => op(root));
+    }
+  }
+
+  /**
    * Replace the entire tree content with the given document.
-   * This deletes all existing blocks and inserts new ones.
+   * Used only for initial document setup (setDocument), NOT for undo.
    */
   private writeFullDocument(document: Document): void {
     this.doc.update((root) => {

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -336,7 +336,7 @@ export class YorkieDocStore implements DocStore {
   // Batch buffering for atomic undo units
   private batchDepth = 0;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private batchOps: Array<(root: any) => void> | null = null;
+  private batchOps: Array<{ key: string; op: (root: any) => void }> | null = null;
 
   /**
    * Optional callback invoked when a remote change is detected.
@@ -430,7 +430,7 @@ export class YorkieDocStore implements DocStore {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
       tree.editByPath([index], [index + 1], node);
-    });
+    }, `update:${id}`);
     // Update cache in-place instead of clearing
     currentDoc.blocks[index] = block;
     this.cachedDoc = currentDoc;
@@ -609,7 +609,7 @@ export class YorkieDocStore implements DocStore {
       this.batchOps = null;
       if (!ops || ops.length === 0) return;
       this.doc.update((root) => {
-        for (const op of ops) {
+        for (const { op } of ops) {
           op(root);
         }
       });
@@ -645,11 +645,28 @@ export class YorkieDocStore implements DocStore {
   /**
    * Execute a tree operation. If batching, buffer the op; otherwise run
    * it immediately inside doc.update().
+   *
+   * @param op - The tree operation lambda
+   * @param key - Optional dedup key. When provided, if the last buffered
+   *   op has the same key, it is replaced instead of appended. This
+   *   prevents multiple editByPath calls for the same block within a
+   *   single batch (which causes reverseOp CRDT position conflicts).
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private execTreeOp(op: (root: any) => void): void {
+  private execTreeOp(op: (root: any) => void, key?: string): void {
     if (this.batchOps) {
-      this.batchOps.push(op);
+      // Dedup: if the last op targets the same block, replace it.
+      // Consecutive updateBlock calls on the same block only need the
+      // final state — intermediate replacements are redundant and cause
+      // reverseOp conflicts during undo.
+      if (key && this.batchOps.length > 0) {
+        const last = this.batchOps[this.batchOps.length - 1];
+        if (last.key === key) {
+          last.op = op;
+          return;
+        }
+      }
+      this.batchOps.push({ key: key ?? '', op });
     } else {
       this.doc.update((root) => op(root));
     }

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -408,6 +408,12 @@ export class YorkieDocStore implements DocStore {
     // (e.g., stale documents whose content field was a plain object).
     this.cachedDoc = cloneDocument(doc);
     this.dirty = false;
+
+    // Clear undo history so the document initialization (writeFullDocument)
+    // is not undoable. Without this, the first undo after typing would
+    // attempt to reverse the initial tree setup, causing CRDT position errors.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (this.doc as any).clearHistory?.();
   }
 
   replaceDocument(doc: Document): void {

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -177,11 +177,12 @@ describe('YorkieDocStore', () => {
   });
 
   describe('undo/redo', () => {
-    it('should undo after snapshot', () => {
+    it('should undo after batch', () => {
       const block = makeBlock('Hello');
       store.setDocument({ blocks: [block] });
-      store.snapshot();
+      store.beginBatch();
       store.updateBlock(block.id, { ...block, inlines: [{ text: 'World', style: {} }] });
+      store.endBatch();
       assert.equal(store.getBlock(block.id)?.inlines[0].text, 'World');
       store.undo();
       assert.equal(store.getBlock(block.id)?.inlines[0].text, 'Hello');
@@ -190,28 +191,34 @@ describe('YorkieDocStore', () => {
     it('should redo after undo', () => {
       const block = makeBlock('Hello');
       store.setDocument({ blocks: [block] });
-      store.snapshot();
+      store.beginBatch();
       store.updateBlock(block.id, { ...block, inlines: [{ text: 'World', style: {} }] });
+      store.endBatch();
       store.undo();
       store.redo();
       assert.equal(store.getBlock(block.id)?.inlines[0].text, 'World');
     });
 
-    it('mutation without snapshot is not undoable', () => {
+    it('mutation without batch is still undoable via Yorkie history', () => {
       const block = makeBlock('Hello');
       store.setDocument({ blocks: [block] });
       store.updateBlock(block.id, { ...block, inlines: [{ text: 'World', style: {} }] });
-      assert.equal(store.canUndo(), false);
+      // Yorkie-native undo tracks all doc.update() calls, so even
+      // unbatched mutations are undoable.
+      assert.equal(store.canUndo(), true);
     });
 
-    it('should clear redo stack on new snapshot', () => {
+    it('should clear redo stack on new mutation', () => {
       const block = makeBlock('Hello');
       store.setDocument({ blocks: [block] });
-      store.snapshot();
+      store.beginBatch();
       store.updateBlock(block.id, { ...block, inlines: [{ text: 'World', style: {} }] });
+      store.endBatch();
       store.undo();
       assert.equal(store.canRedo(), true);
-      store.snapshot();
+      store.beginBatch();
+      store.updateBlock(block.id, { ...block, inlines: [{ text: 'Again', style: {} }] });
+      store.endBatch();
       assert.equal(store.canRedo(), false);
     });
   });

--- a/packages/frontend/tests/app/docs/yorkie-docs-undo.integration.ts
+++ b/packages/frontend/tests/app/docs/yorkie-docs-undo.integration.ts
@@ -1,0 +1,447 @@
+/**
+ * Integration tests for docs undo/redo with Yorkie Tree CRDT.
+ *
+ * Tests two-client concurrent editing scenarios to verify that
+ * undo/redo operations don't corrupt the document (no duplicate
+ * block IDs, no CRDT position errors).
+ *
+ * Requires a running Yorkie server:
+ *   YORKIE_RPC_ADDR=http://localhost:8080 pnpm frontend test:integration
+ */
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createTwoUserDocs,
+  makeBlock,
+  getBlockText,
+  getAllBlockTexts,
+  type TwoUserDocsContext,
+} from "../../helpers/two-user-docs-yorkie.ts";
+
+const shouldRun = Boolean(process.env.YORKIE_RPC_ADDR);
+
+describe("Docs Undo/Redo Integration", { skip: !shouldRun }, () => {
+  let ctx: TwoUserDocsContext;
+
+  afterEach(async () => {
+    if (ctx) await ctx.cleanup();
+  });
+
+  // -----------------------------------------------------------------------
+  // 1. Single-client undo/redo basics
+  // -----------------------------------------------------------------------
+
+  it("single client: type then undo restores original", async () => {
+    ctx = await createTwoUserDocs("single-type-undo", [makeBlock("init")]);
+
+    const { storeA } = ctx;
+    const doc = storeA.getDocument();
+    const blockId = doc.blocks[0].id;
+
+    // Type "Hello" via batch
+    storeA.beginBatch();
+    storeA.updateBlock(blockId, {
+      ...doc.blocks[0],
+      inlines: [{ text: "Hello", style: {} }],
+    });
+    storeA.endBatch();
+
+    assert.equal(getBlockText(storeA, 0), "Hello");
+
+    storeA.undo();
+    assert.equal(getBlockText(storeA, 0), "init");
+
+    storeA.redo();
+    assert.equal(getBlockText(storeA, 0), "Hello");
+  });
+
+  it("single client: multiple undos", async () => {
+    ctx = await createTwoUserDocs("multi-undo", [makeBlock("")]);
+
+    const { storeA } = ctx;
+
+    // Batch 1: type "a"
+    const doc1 = storeA.getDocument();
+    storeA.beginBatch();
+    storeA.updateBlock(doc1.blocks[0].id, {
+      ...doc1.blocks[0],
+      inlines: [{ text: "a", style: {} }],
+    });
+    storeA.endBatch();
+
+    // Batch 2: type "ab"
+    const doc2 = storeA.getDocument();
+    storeA.beginBatch();
+    storeA.updateBlock(doc2.blocks[0].id, {
+      ...doc2.blocks[0],
+      inlines: [{ text: "ab", style: {} }],
+    });
+    storeA.endBatch();
+
+    // Batch 3: type "abc"
+    const doc3 = storeA.getDocument();
+    storeA.beginBatch();
+    storeA.updateBlock(doc3.blocks[0].id, {
+      ...doc3.blocks[0],
+      inlines: [{ text: "abc", style: {} }],
+    });
+    storeA.endBatch();
+
+    assert.equal(getBlockText(storeA, 0), "abc");
+
+    storeA.undo();
+    assert.equal(getBlockText(storeA, 0), "ab");
+
+    storeA.undo();
+    assert.equal(getBlockText(storeA, 0), "a");
+
+    storeA.undo();
+    assert.equal(getBlockText(storeA, 0), "");
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Compound operations: split/merge as single undo unit
+  // -----------------------------------------------------------------------
+
+  it("single client: split block undoes in one step", async () => {
+    ctx = await createTwoUserDocs("split-undo", [makeBlock("HelloWorld")]);
+
+    const { storeA } = ctx;
+    const doc = storeA.getDocument();
+    const blockId = doc.blocks[0].id;
+
+    // Split at offset 5: "Hello" | "World"
+    storeA.beginBatch();
+    storeA.updateBlock(blockId, {
+      ...doc.blocks[0],
+      inlines: [{ text: "Hello", style: {} }],
+    });
+    storeA.insertBlock(1, makeBlock("World"));
+    storeA.endBatch();
+
+    assert.equal(storeA.getDocument().blocks.length, 2);
+    assert.equal(getBlockText(storeA, 0), "Hello");
+    assert.equal(getBlockText(storeA, 1), "World");
+
+    // Single undo should restore both blocks
+    storeA.undo();
+    assert.equal(storeA.getDocument().blocks.length, 1);
+    assert.equal(getBlockText(storeA, 0), "HelloWorld");
+  });
+
+  it("single client: merge blocks undoes in one step", async () => {
+    ctx = await createTwoUserDocs("merge-undo", [
+      makeBlock("Hello"),
+      makeBlock("World"),
+    ]);
+
+    const { storeA } = ctx;
+    const doc = storeA.getDocument();
+
+    // Merge: "Hello" + "World" → "HelloWorld"
+    storeA.beginBatch();
+    storeA.updateBlock(doc.blocks[0].id, {
+      ...doc.blocks[0],
+      inlines: [{ text: "HelloWorld", style: {} }],
+    });
+    storeA.deleteBlock(doc.blocks[1].id);
+    storeA.endBatch();
+
+    assert.equal(storeA.getDocument().blocks.length, 1);
+    assert.equal(getBlockText(storeA, 0), "HelloWorld");
+
+    // Single undo should restore both blocks
+    storeA.undo();
+    assert.equal(storeA.getDocument().blocks.length, 2);
+    assert.equal(getBlockText(storeA, 0), "Hello");
+    assert.equal(getBlockText(storeA, 1), "World");
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Two-client concurrent editing + undo
+  // -----------------------------------------------------------------------
+
+  it("two clients: A edits block 0, B edits block 1, both undo", async () => {
+    ctx = await createTwoUserDocs("two-client-diff-blocks", [
+      makeBlock("para1"),
+      makeBlock("para2"),
+    ]);
+
+    const { storeA, storeB, sync } = ctx;
+
+    // Sync initial state
+    await sync();
+
+    const docA = storeA.getDocument();
+    const docB = storeB.getDocument();
+
+    // A edits block 0: "para1" → "abcd"
+    storeA.beginBatch();
+    storeA.updateBlock(docA.blocks[0].id, {
+      ...docA.blocks[0],
+      inlines: [{ text: "abcd", style: {} }],
+    });
+    storeA.endBatch();
+
+    // B edits block 1: "para2" → "qwer"
+    storeB.beginBatch();
+    storeB.updateBlock(docB.blocks[1].id, {
+      ...docB.blocks[1],
+      inlines: [{ text: "qwer", style: {} }],
+    });
+    storeB.endBatch();
+
+    // Sync changes
+    await sync();
+
+    // Both should see the merged result
+    assert.deepEqual(getAllBlockTexts(storeA), ["abcd", "qwer"]);
+    assert.deepEqual(getAllBlockTexts(storeB), ["abcd", "qwer"]);
+
+    // A undoes → block 0 back to "para1", block 1 stays "qwer"
+    storeA.undo();
+    await sync();
+
+    assert.deepEqual(getAllBlockTexts(storeA), ["para1", "qwer"]);
+    assert.deepEqual(getAllBlockTexts(storeB), ["para1", "qwer"]);
+
+    // B undoes → block 1 back to "para2"
+    storeB.undo();
+    await sync();
+
+    assert.deepEqual(getAllBlockTexts(storeA), ["para1", "para2"]);
+    assert.deepEqual(getAllBlockTexts(storeB), ["para1", "para2"]);
+  });
+
+  it("two clients: A edits block 0, B edits block 1, A undoes then redoes", async () => {
+    ctx = await createTwoUserDocs("two-client-undo-redo", [
+      makeBlock("para1"),
+      makeBlock("para2"),
+    ]);
+
+    const { storeA, storeB, sync } = ctx;
+    await sync();
+
+    const docA = storeA.getDocument();
+    const docB = storeB.getDocument();
+
+    // A: "para1" → "AAAA"
+    storeA.beginBatch();
+    storeA.updateBlock(docA.blocks[0].id, {
+      ...docA.blocks[0],
+      inlines: [{ text: "AAAA", style: {} }],
+    });
+    storeA.endBatch();
+
+    // B: "para2" → "BBBB"
+    storeB.beginBatch();
+    storeB.updateBlock(docB.blocks[1].id, {
+      ...docB.blocks[1],
+      inlines: [{ text: "BBBB", style: {} }],
+    });
+    storeB.endBatch();
+
+    await sync();
+    assert.deepEqual(getAllBlockTexts(storeA), ["AAAA", "BBBB"]);
+
+    // A undoes
+    storeA.undo();
+    await sync();
+    assert.deepEqual(getAllBlockTexts(storeA), ["para1", "BBBB"]);
+    assert.deepEqual(getAllBlockTexts(storeB), ["para1", "BBBB"]);
+
+    // A redoes
+    storeA.redo();
+    await sync();
+    assert.deepEqual(getAllBlockTexts(storeA), ["AAAA", "BBBB"]);
+    assert.deepEqual(getAllBlockTexts(storeB), ["AAAA", "BBBB"]);
+  });
+
+  it("two clients: alternating undo — A undoes, then B undoes", async () => {
+    ctx = await createTwoUserDocs("alternating-undo", [
+      makeBlock("original1"),
+      makeBlock("original2"),
+    ]);
+
+    const { storeA, storeB, sync } = ctx;
+    await sync();
+
+    const docA = storeA.getDocument();
+    const docB = storeB.getDocument();
+
+    // A edits block 0
+    storeA.beginBatch();
+    storeA.updateBlock(docA.blocks[0].id, {
+      ...docA.blocks[0],
+      inlines: [{ text: "editA", style: {} }],
+    });
+    storeA.endBatch();
+
+    await sync();
+
+    // B edits block 1
+    storeB.beginBatch();
+    storeB.updateBlock(docB.blocks[1].id, {
+      ...docB.blocks[1],
+      inlines: [{ text: "editB", style: {} }],
+    });
+    storeB.endBatch();
+
+    await sync();
+    assert.deepEqual(getAllBlockTexts(storeA), ["editA", "editB"]);
+
+    // A undoes its edit
+    storeA.undo();
+    await sync();
+    assert.deepEqual(getAllBlockTexts(storeA), ["original1", "editB"]);
+    assert.deepEqual(getAllBlockTexts(storeB), ["original1", "editB"]);
+
+    // B undoes its edit
+    storeB.undo();
+    await sync();
+    assert.deepEqual(getAllBlockTexts(storeA), ["original1", "original2"]);
+    assert.deepEqual(getAllBlockTexts(storeB), ["original1", "original2"]);
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. No duplicate block IDs after undo
+  // -----------------------------------------------------------------------
+
+  it("no duplicate block IDs after concurrent edit + undo", async () => {
+    ctx = await createTwoUserDocs("no-dup-ids", [
+      makeBlock("first"),
+      makeBlock("second"),
+    ]);
+
+    const { storeA, storeB, sync } = ctx;
+    await sync();
+
+    const docA = storeA.getDocument();
+
+    // A edits block 0
+    storeA.beginBatch();
+    storeA.updateBlock(docA.blocks[0].id, {
+      ...docA.blocks[0],
+      inlines: [{ text: "changed", style: {} }],
+    });
+    storeA.endBatch();
+
+    // B also edits (different block)
+    const docB = storeB.getDocument();
+    storeB.beginBatch();
+    storeB.updateBlock(docB.blocks[1].id, {
+      ...docB.blocks[1],
+      inlines: [{ text: "also changed", style: {} }],
+    });
+    storeB.endBatch();
+
+    await sync();
+
+    // A undoes
+    storeA.undo();
+    await sync();
+
+    // Check no duplicate IDs on either client
+    for (const store of [storeA, storeB]) {
+      const doc = store.getDocument();
+      const ids = doc.blocks.map((b) => b.id);
+      const unique = new Set(ids);
+      assert.equal(
+        ids.length,
+        unique.size,
+        `Duplicate block IDs found: ${JSON.stringify(ids)}`,
+      );
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. Block insertion + undo convergence
+  // -----------------------------------------------------------------------
+
+  it("two clients: A inserts block, B edits existing, A undoes", async () => {
+    ctx = await createTwoUserDocs("insert-and-edit", [makeBlock("original")]);
+
+    const { storeA, storeB, sync } = ctx;
+    await sync();
+
+    // A inserts a new block
+    storeA.beginBatch();
+    storeA.insertBlock(1, makeBlock("inserted by A"));
+    storeA.endBatch();
+
+    // B edits the existing block
+    const docB = storeB.getDocument();
+    storeB.beginBatch();
+    storeB.updateBlock(docB.blocks[0].id, {
+      ...docB.blocks[0],
+      inlines: [{ text: "edited by B", style: {} }],
+    });
+    storeB.endBatch();
+
+    await sync();
+
+    // A undoes the insertion
+    storeA.undo();
+    await sync();
+
+    // Both should converge: B's edit preserved, A's insertion gone
+    const textsA = getAllBlockTexts(storeA);
+    const textsB = getAllBlockTexts(storeB);
+    assert.deepEqual(textsA, textsB, "Clients should converge after undo");
+    assert.ok(
+      textsA.includes("edited by B"),
+      "B's edit should be preserved",
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. Multiple undo/redo cycles
+  // -----------------------------------------------------------------------
+
+  it("single client: undo → redo → undo cycle", async () => {
+    ctx = await createTwoUserDocs("undo-redo-cycle", [makeBlock("start")]);
+
+    const { storeA } = ctx;
+    const doc = storeA.getDocument();
+    const blockId = doc.blocks[0].id;
+
+    // Edit 1
+    storeA.beginBatch();
+    storeA.updateBlock(blockId, {
+      ...doc.blocks[0],
+      inlines: [{ text: "step1", style: {} }],
+    });
+    storeA.endBatch();
+
+    // Edit 2
+    const doc2 = storeA.getDocument();
+    storeA.beginBatch();
+    storeA.updateBlock(doc2.blocks[0].id, {
+      ...doc2.blocks[0],
+      inlines: [{ text: "step2", style: {} }],
+    });
+    storeA.endBatch();
+
+    assert.equal(getBlockText(storeA, 0), "step2");
+
+    // Undo → step1
+    storeA.undo();
+    assert.equal(getBlockText(storeA, 0), "step1");
+
+    // Redo → step2
+    storeA.redo();
+    assert.equal(getBlockText(storeA, 0), "step2");
+
+    // Undo → step1
+    storeA.undo();
+    assert.equal(getBlockText(storeA, 0), "step1");
+
+    // Undo → start
+    storeA.undo();
+    assert.equal(getBlockText(storeA, 0), "start");
+
+    // Redo → step1
+    storeA.redo();
+    assert.equal(getBlockText(storeA, 0), "step1");
+  });
+});

--- a/packages/frontend/tests/app/docs/yorkie-docs-undo.integration.ts
+++ b/packages/frontend/tests/app/docs/yorkie-docs-undo.integration.ts
@@ -444,4 +444,157 @@ describe("Docs Undo/Redo Integration", { skip: !shouldRun }, () => {
     storeA.redo();
     assert.equal(getBlockText(storeA, 0), "step1");
   });
+
+  // -----------------------------------------------------------------------
+  // 7. Realistic typing pattern: multiple updateBlock in single batch
+  //    (simulates UI typing debounce where each keystroke replaces the
+  //     entire block within one open batch)
+  // -----------------------------------------------------------------------
+
+  it("single client: batched sequential block replacements (typing pattern) + undo", async () => {
+    ctx = await createTwoUserDocs("batched-typing", [makeBlock("")]);
+
+    const { storeA } = ctx;
+    const doc = storeA.getDocument();
+    const blockId = doc.blocks[0].id;
+
+    // Simulate typing "abcd" with debounce: one batch, 4 updateBlock calls
+    // This is what actually happens in the UI when the user types quickly.
+    storeA.beginBatch();
+
+    // Keystroke 'a': replace block with "a"
+    const d1 = storeA.getDocument();
+    storeA.updateBlock(blockId, {
+      ...d1.blocks[0],
+      inlines: [{ text: "a", style: {} }],
+    });
+
+    // Keystroke 'b': replace block with "ab"
+    const d2 = storeA.getDocument();
+    storeA.updateBlock(d2.blocks[0].id, {
+      ...d2.blocks[0],
+      inlines: [{ text: "ab", style: {} }],
+    });
+
+    // Keystroke 'c': replace block with "abc"
+    const d3 = storeA.getDocument();
+    storeA.updateBlock(d3.blocks[0].id, {
+      ...d3.blocks[0],
+      inlines: [{ text: "abc", style: {} }],
+    });
+
+    // Keystroke 'd': replace block with "abcd"
+    const d4 = storeA.getDocument();
+    storeA.updateBlock(d4.blocks[0].id, {
+      ...d4.blocks[0],
+      inlines: [{ text: "abcd", style: {} }],
+    });
+
+    storeA.endBatch();
+
+    assert.equal(getBlockText(storeA, 0), "abcd");
+
+    // Single undo should revert the entire typing batch
+    storeA.undo();
+    assert.equal(getBlockText(storeA, 0), "");
+  });
+
+  it("single client: two batched typing sessions + undo each", async () => {
+    ctx = await createTwoUserDocs("two-batched-typing", [makeBlock("")]);
+
+    const { storeA } = ctx;
+    const doc = storeA.getDocument();
+    const blockId = doc.blocks[0].id;
+
+    // Session 1: type "ab" (2 updateBlock in one batch)
+    storeA.beginBatch();
+    const s1d1 = storeA.getDocument();
+    storeA.updateBlock(blockId, {
+      ...s1d1.blocks[0],
+      inlines: [{ text: "a", style: {} }],
+    });
+    const s1d2 = storeA.getDocument();
+    storeA.updateBlock(s1d2.blocks[0].id, {
+      ...s1d2.blocks[0],
+      inlines: [{ text: "ab", style: {} }],
+    });
+    storeA.endBatch();
+
+    assert.equal(getBlockText(storeA, 0), "ab");
+
+    // Session 2: type "cd" → "abcd" (2 more updateBlock in another batch)
+    storeA.beginBatch();
+    const s2d1 = storeA.getDocument();
+    storeA.updateBlock(s2d1.blocks[0].id, {
+      ...s2d1.blocks[0],
+      inlines: [{ text: "abc", style: {} }],
+    });
+    const s2d2 = storeA.getDocument();
+    storeA.updateBlock(s2d2.blocks[0].id, {
+      ...s2d2.blocks[0],
+      inlines: [{ text: "abcd", style: {} }],
+    });
+    storeA.endBatch();
+
+    assert.equal(getBlockText(storeA, 0), "abcd");
+
+    // First undo: revert session 2 → "ab"
+    storeA.undo();
+    assert.equal(getBlockText(storeA, 0), "ab");
+
+    // Second undo: revert session 1 → ""
+    storeA.undo();
+    assert.equal(getBlockText(storeA, 0), "");
+  });
+
+  it("two clients: A types in batch, B types in batch, both undo", async () => {
+    ctx = await createTwoUserDocs("two-client-batched-typing", [
+      makeBlock(""),
+      makeBlock(""),
+    ]);
+
+    const { storeA, storeB, sync } = ctx;
+    await sync();
+
+    const docA = storeA.getDocument();
+    const docB = storeB.getDocument();
+
+    // A types "abcd" in block 0 (batched sequential replacements)
+    storeA.beginBatch();
+    for (const text of ["a", "ab", "abc", "abcd"]) {
+      const d = storeA.getDocument();
+      storeA.updateBlock(docA.blocks[0].id, {
+        ...d.blocks[0],
+        inlines: [{ text, style: {} }],
+      });
+    }
+    storeA.endBatch();
+
+    // B types "qwer" in block 1 (batched sequential replacements)
+    storeB.beginBatch();
+    for (const text of ["q", "qw", "qwe", "qwer"]) {
+      const d = storeB.getDocument();
+      storeB.updateBlock(docB.blocks[1].id, {
+        ...d.blocks[1],
+        inlines: [{ text, style: {} }],
+      });
+    }
+    storeB.endBatch();
+
+    await sync();
+    assert.deepEqual(getAllBlockTexts(storeA), ["abcd", "qwer"]);
+    assert.deepEqual(getAllBlockTexts(storeB), ["abcd", "qwer"]);
+
+    // A undoes
+    storeA.undo();
+    await sync();
+    assert.deepEqual(getAllBlockTexts(storeA), ["", "qwer"]);
+    assert.deepEqual(getAllBlockTexts(storeB), ["", "qwer"]);
+
+    // B undoes
+    storeB.undo();
+    await sync();
+    assert.deepEqual(getAllBlockTexts(storeA), ["", ""]);
+    assert.deepEqual(getAllBlockTexts(storeB), ["", ""]);
+  });
 });

--- a/packages/frontend/tests/helpers/two-user-docs-yorkie.ts
+++ b/packages/frontend/tests/helpers/two-user-docs-yorkie.ts
@@ -1,0 +1,130 @@
+import yorkie from "@yorkie-js/sdk";
+import { YorkieDocStore } from "@/app/docs/yorkie-doc-store.ts";
+import type { YorkieDocsRoot } from "@/types/docs-document.ts";
+import {
+  generateBlockId,
+  DEFAULT_BLOCK_STYLE,
+} from "@wafflebase/docs";
+import type { Block } from "@wafflebase/docs";
+
+type YorkieClient = {
+  activate(): Promise<void>;
+  deactivate(): Promise<void>;
+  attach(doc: object, options?: object): Promise<object>;
+  detach(doc: object): Promise<object>;
+  sync(doc: object): Promise<object[]>;
+};
+
+const { Client, Document, SyncMode } = yorkie as {
+  Client: new (options?: Record<string, unknown>) => YorkieClient;
+  Document: new (key: string) => object;
+  SyncMode: { Manual: unknown };
+};
+
+export function makeBlock(text: string): Block {
+  return {
+    id: generateBlockId(),
+    type: "paragraph",
+    inlines: [{ text, style: {} }],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  };
+}
+
+function createClient(key: string): YorkieClient {
+  return new Client({
+    key,
+    rpcAddr: process.env.YORKIE_RPC_ADDR ?? "http://localhost:8080",
+    apiKey: process.env.YORKIE_API_KEY,
+    syncLoopDuration: 10,
+    retrySyncLoopDelay: 10,
+    reconnectStreamDelay: 10,
+  });
+}
+
+export interface TwoUserDocsContext {
+  storeA: YorkieDocStore;
+  storeB: YorkieDocStore;
+  /** Sync both clients (4 rounds for convergence). */
+  sync(): Promise<void>;
+  cleanup(): Promise<void>;
+}
+
+/**
+ * Creates a two-user Yorkie-backed docs environment for integration testing.
+ * Both clients attach to the same document.
+ *
+ * @param testName - Unique test name for document key generation
+ * @param initialBlocks - Blocks to seed the document with (via clientA)
+ */
+export async function createTwoUserDocs(
+  testName: string,
+  initialBlocks?: Block[],
+): Promise<TwoUserDocsContext> {
+  const slug = testName.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+  const docKey = `docs-${slug}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const clientA = createClient(`docs-a-${slug}`);
+  const clientB = createClient(`docs-b-${slug}`);
+  const docA = new Document(docKey) as ReturnType<typeof yorkie.Document<YorkieDocsRoot>>;
+  const docB = new Document(docKey) as ReturnType<typeof yorkie.Document<YorkieDocsRoot>>;
+
+  await clientA.activate();
+  await clientB.activate();
+
+  // Client A creates the document with initial tree
+  await clientA.attach(docA, { syncMode: SyncMode.Manual });
+  const storeA = new YorkieDocStore(docA as never);
+
+  // Seed initial content
+  if (initialBlocks && initialBlocks.length > 0) {
+    storeA.setDocument({ blocks: initialBlocks });
+  } else {
+    storeA.setDocument({ blocks: [makeBlock("")] });
+  }
+
+  // Sync so Client B sees the initial state
+  await clientA.sync(docA);
+
+  await clientB.attach(docB, { syncMode: SyncMode.Manual });
+  await clientB.sync(docB);
+
+  const storeB = new YorkieDocStore(docB as never);
+
+  async function sync(): Promise<void> {
+    for (let round = 0; round < 4; round++) {
+      await clientA.sync(docA);
+      await clientB.sync(docB);
+    }
+  }
+
+  async function cleanup(): Promise<void> {
+    await Promise.allSettled([
+      clientA.detach(docA),
+      clientB.detach(docB),
+    ]);
+    await Promise.allSettled([
+      clientA.deactivate(),
+      clientB.deactivate(),
+    ]);
+  }
+
+  return { storeA, storeB, sync, cleanup };
+}
+
+/**
+ * Get the text of a specific block by index from a store.
+ */
+export function getBlockText(store: YorkieDocStore, blockIndex: number): string {
+  const doc = store.getDocument();
+  const block = doc.blocks[blockIndex];
+  if (!block) return "";
+  return block.inlines.map((i) => i.text).join("");
+}
+
+/**
+ * Get all block texts from a store as an array.
+ */
+export function getAllBlockTexts(store: YorkieDocStore): string[] {
+  const doc = store.getDocument();
+  return doc.blocks.map((b) => b.inlines.map((i) => i.text).join(""));
+}


### PR DESCRIPTION
## Summary

- Replace snapshot-based undo/redo with Yorkie's `doc.history.undo()/redo()` in the docs editor
- Add ref-counted `beginBatch()/endBatch()` to `DocStore` interface to ensure compound operations (split block, merge blocks, paste, table ops) undo atomically as a single unit
- Eliminate `writeFullDocument()` from the undo path, which caused duplicate block IDs during concurrent editing (fixes #97)

## Test plan

- [x] `pnpm verify:fast` — all 280 docs tests + frontend tests pass
- [ ] Manual test: two browsers editing same doc, one user undoes → no duplicate block IDs
- [ ] Manual test: Enter (split) → Undo restores in one step
- [ ] Manual test: Backspace (merge) → Undo restores in one step
- [ ] Manual test: Paste multi-block → Undo restores in one step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed undo/redo edge cases from concurrent edits and prevented the initial document setup from being undoable.

* **New Features**
  * Compound actions (split/merge, paste, table edits) undo/redo atomically via batching.
  * Typing groups keystrokes into debounce-controlled batches for intuitive undos.
  * Undo/redo now uses native Yorkie history for collaborative correctness.

* **Documentation**
  * Added design and task docs describing the batching and undo/redo plan.

* **Tests**
  * Added integration and updated unit tests to validate batched undo/redo and multi-client scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->