### PR TITLE
Add DOCX import and export for the docs editor

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,3 +16,19 @@ services:
     ports:
       - "8080:8080"
       - "8081:8081"
+
+  minio:
+    image: minio/minio
+    restart: always
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+
+volumes:
+  minio-data:

--- a/docs/design/docs/docs-docx-import-export.md
+++ b/docs/design/docs/docs-docx-import-export.md
@@ -1,0 +1,468 @@
+---
+title: docs-docx-import-export
+target-version: 0.3.0
+---
+
+# DOCX Import / Export
+
+## Summary
+
+Add the ability to import Microsoft Word (.docx) files into the Docs editor
+and export documents back to .docx format. This requires three prerequisite
+features that the Docs model does not yet support: inline images, image
+resource management (S3-compatible storage), and web font loading for Korean
+typefaces.
+
+## Goals
+
+- Import a .docx file and produce an editable `Document` (blocks, tables,
+  styles, images, headers/footers, page setup).
+- Export the current `Document` back to a valid .docx file that opens in
+  Word / Google Docs.
+- Support inline images backed by S3-compatible object storage.
+- Render Korean web fonts (Malgun Gothic, Batang, etc.) with a fallback chain.
+
+## Non-Goals
+
+- Round-trip fidelity (preserving every Word-specific attribute is not a goal).
+- Floating / anchored images — only inline images are in scope.
+- Nested tables — content is flattened to text on import.
+- Form controls, SmartArt, WordArt, embedded OLE objects.
+- Comments, track changes, footnotes/endnotes.
+- Real-time collaborative import (single-user import, then collaborate).
+
+---
+
+## Phase 1 — Prerequisite Features
+
+### 1.1 Inline Image Support
+
+#### Model Changes
+
+Add an `image` field to `InlineStyle` and introduce an `ImageData` type:
+
+```typescript
+// model/types.ts
+
+export interface ImageData {
+  src: string;         // URL to the image resource
+  width: number;       // Display width in pixels
+  height: number;      // Display height in pixels
+  alt?: string;        // Accessible alt text
+}
+
+export interface InlineStyle {
+  // ... existing fields ...
+  image?: ImageData;   // When set, this inline is an image, text is ignored
+}
+```
+
+An image inline is a single `Inline` element whose `text` is the Unicode
+Object Replacement Character (`\uFFFC`) and whose `style.image` carries the
+image metadata. This approach:
+
+- Keeps the `Block → Inline[]` hierarchy unchanged.
+- Images participate naturally in cursor navigation (offset +1 per image).
+- Selection, delete, copy/paste work with no structural changes.
+- Layout and rendering treat the image as a measured inline element.
+
+#### Layout Changes (`layout.ts`)
+
+During word-wrap, when an inline has `style.image`:
+
+1. Use `image.width` and `image.height` instead of `measureText`.
+2. The image inline is never word-broken — it stays as a single unit.
+3. If the image is wider than the content area, scale it down proportionally.
+
+#### Rendering Changes (`doc-canvas.ts`)
+
+1. Maintain an `ImageCache` (`Map<string, HTMLImageElement>`) to avoid
+   re-fetching on every repaint.
+2. When rendering an inline with `style.image`, call
+   `ctx.drawImage(cachedImg, x, y, width, height)`.
+3. Images load asynchronously — trigger a re-render when the `onload` fires.
+
+#### Editing Behavior
+
+| Action | Behavior |
+|--------|----------|
+| Cursor movement | Arrow keys skip over the image (offset +1) |
+| Backspace / Delete | Removes the image inline |
+| Selection | Image is part of the selection range |
+| Copy / Paste | Copies image URL; paste re-inserts the image inline |
+| Typing at image position | Text is inserted before/after the image |
+
+### 1.2 Image Resource Management
+
+#### Architecture
+
+```
+┌────────────┐     POST /images      ┌──────────────┐     PutObject     ┌──────────┐
+│  Frontend   │ ──────────────────►   │   Backend    │ ─────────────────► │  S3 /    │
+│  (upload)   │ ◄────────────────── │  ImageModule │ ◄───────────────── │  MinIO   │
+│             │    { url, id }      │              │    stored          │          │
+└────────────┘                      └──────────────┘                    └──────────┘
+```
+
+#### Backend — ImageModule
+
+New NestJS module at `packages/backend/src/image/`:
+
+```
+image/
+  image.module.ts        # Module definition, S3 client provider
+  image.controller.ts    # Upload / delete endpoints
+  image.service.ts       # S3 operations, URL generation
+  image.config.ts        # S3 configuration (bucket, region, endpoint)
+```
+
+**Endpoints:**
+
+| Method | Route | Auth | Description |
+|--------|-------|------|-------------|
+| `POST` | `/images` | JWT | Upload image (multipart), returns `{ id, url }` |
+| `GET` | `/images/:id` | Public | Redirect / proxy to S3 object |
+| `DELETE` | `/images/:id` | JWT | Delete image from storage |
+
+**S3 Configuration (env vars):**
+
+```env
+IMAGE_STORAGE_ENDPOINT=http://localhost:9000    # MinIO for dev
+IMAGE_STORAGE_BUCKET=wafflebase-images
+IMAGE_STORAGE_REGION=us-east-1
+IMAGE_STORAGE_ACCESS_KEY=minioadmin
+IMAGE_STORAGE_SECRET_KEY=minioadmin
+```
+
+**Upload Flow:**
+
+1. Frontend sends `multipart/form-data` with the image file.
+2. Backend validates: file type (png, jpg, gif, webp), max size (10 MB).
+3. Backend generates a UUID key, uploads to S3 with `PutObject`.
+4. Returns `{ id: "<uuid>", url: "/images/<uuid>" }`.
+
+**Dependencies:** `@aws-sdk/client-s3` for S3 operations.
+
+#### Frontend Integration
+
+- Image insert toolbar button opens a file picker.
+- On file select → `POST /images` → receive URL → insert image inline.
+- DOCX import extracts embedded images → uploads each → inserts URL refs.
+
+#### Development Environment
+
+Add MinIO to `docker-compose.yml`:
+
+```yaml
+minio:
+  image: minio/minio
+  ports:
+    - "9000:9000"
+    - "9001:9001"   # Console
+  environment:
+    MINIO_ROOT_USER: minioadmin
+    MINIO_ROOT_PASSWORD: minioadmin
+  command: server /data --console-address ":9001"
+  volumes:
+    - minio-data:/data
+```
+
+### 1.3 Web Font Loading
+
+#### Approach
+
+Use CSS `@font-face` with Google Fonts or self-hosted font files to load
+Korean typefaces on demand.
+
+**Font Mapping (DOCX → Web):**
+
+| DOCX Font Name | Web Font | Fallback Chain |
+|----------------|----------|----------------|
+| 맑은 고딕 | Malgun Gothic | `'Malgun Gothic', 'Noto Sans KR', sans-serif` |
+| 바탕 | Batang | `'Batang', 'Noto Serif KR', serif` |
+| HY헤드라인M | (no web equivalent) | `'Noto Sans KR', sans-serif` |
+| Arial | Arial | `'Arial', sans-serif` |
+| Tahoma | Tahoma | `'Tahoma', sans-serif` |
+
+#### Implementation
+
+1. **Font registry** in `packages/docs/src/view/fonts.ts`:
+   - Maps font family names to `@font-face` sources.
+   - Tracks load status per font (pending → loading → loaded → error).
+   - Triggers layout invalidation + re-render when a font finishes loading.
+
+2. **`document.fonts.load()`** — use the browser Font Loading API:
+   ```typescript
+   async function ensureFont(family: string): Promise<void> {
+     if (document.fonts.check(`12px "${family}"`)) return;
+     await document.fonts.load(`12px "${family}"`);
+     // Trigger re-layout
+   }
+   ```
+
+3. **measureText cache invalidation** — when a new font loads, clear cached
+   measurements for that font family (existing optimization infrastructure in
+   `docs-rendering-optimization`).
+
+---
+
+## Phase 2 — DOCX Import
+
+### 2.1 Architecture
+
+```
+┌──────────────┐    ArrayBuffer    ┌──────────────┐    Document    ┌──────────────┐
+│  File Input   │ ───────────────► │ DocxImporter  │ ────────────► │  DocStore     │
+│  (Frontend)   │                  │ (packages/    │               │  (editor)     │
+│               │                  │  docs)        │               │               │
+└──────────────┘                   └──────────────┘               └──────────────┘
+                                         │
+                                    POST /images
+                                         │
+                                         ▼
+                                   ┌──────────┐
+                                   │  Backend  │
+                                   │  (S3)     │
+                                   └──────────┘
+```
+
+Location: `packages/docs/src/import/docx-importer.ts`
+
+### 2.2 Parsing Pipeline
+
+```
+.docx (ZIP) ──► Extract XML + media ──► Parse document.xml ──►
+  Map paragraphs to Block[] ──► Map tables to table Block[] ──►
+  Upload images ──► Resolve styles ──► Assemble Document
+```
+
+**Steps:**
+
+1. **Unzip** the .docx using JSZip.
+2. **Parse `word/document.xml`** into an XML DOM.
+3. **Parse `word/styles.xml`** to resolve named styles (e.g., `"a3"` table style).
+4. **Parse `word/numbering.xml`** if lists exist.
+5. **Parse `word/_rels/document.xml.rels`** to map relationship IDs to media files.
+6. **Walk `<w:body>`** and convert each element:
+
+| OOXML Element | Docs Block Type |
+|---------------|-----------------|
+| `<w:p>` | `paragraph` (or `heading` / `list-item` based on style) |
+| `<w:tbl>` | `table` (top-level only) |
+| `<w:tbl>` inside `<w:tc>` | Flattened to text paragraphs |
+| `<w:drawing><wp:inline>` | Image inline within the parent paragraph |
+| `<w:sectPr>` | `PageSetup` |
+| `<w:headerReference>` | `HeaderFooter` (parse referenced header XML) |
+| `<w:footerReference>` | `HeaderFooter` (parse referenced footer XML) |
+
+7. **Upload extracted images** to the image service, replace embedded
+   references with URLs.
+
+### 2.3 Style Mapping
+
+#### Paragraph Properties (`<w:pPr>`)
+
+| OOXML Property | Docs BlockStyle Field |
+|----------------|-----------------------|
+| `<w:jc w:val="center">` | `alignment: 'center'` |
+| `<w:jc w:val="both">` | `alignment: 'justify'` |
+| `<w:spacing w:line="360">` | `lineHeight: 1.5` (line/240 = multiplier) |
+| `<w:spacing w:before="120">` | `marginTop` (twips → px: value / 20 × 96/72) |
+| `<w:spacing w:after="120">` | `marginBottom` (twips → px) |
+| `<w:ind w:firstLine="720">` | `textIndent` (twips → px) |
+| `<w:ind w:left="720">` | `marginLeft` (twips → px) |
+| `<w:pStyle w:val="1">` | `type: 'heading'`, map style ID to heading level |
+
+#### Run Properties (`<w:rPr>`)
+
+| OOXML Property | Docs InlineStyle Field |
+|----------------|------------------------|
+| `<w:b/>` | `bold: true` |
+| `<w:i/>` | `italic: true` |
+| `<w:u w:val="single"/>` | `underline: true` |
+| `<w:strike/>` | `strikethrough: true` |
+| `<w:sz w:val="24"/>` | `fontSize: 12` (half-points → points) |
+| `<w:rFonts w:ascii="Arial"/>` | `fontFamily: 'Arial'` |
+| `<w:color w:val="FF0000"/>` | `color: '#FF0000'` |
+| `<w:highlight w:val="yellow"/>` | `backgroundColor: '#FFFF00'` |
+| `<w:shd w:fill="FFFF00"/>` | `backgroundColor: '#FFFF00'` |
+| `<w:vertAlign w:val="superscript"/>` | `superscript: true` |
+
+#### Table Properties
+
+| OOXML Property | Docs Table Field |
+|----------------|------------------|
+| `<w:tblGrid><w:gridCol w:w="N"/>` | `columnWidths` (normalize to proportions) |
+| `<w:gridSpan w:val="2"/>` | `colSpan: 2` |
+| `<w:vMerge w:val="restart"/>` | `rowSpan` (count consecutive vMerge cells) |
+| `<w:vMerge/>` (continue) | `colSpan: 0` (covered cell) |
+| `<w:shd w:fill="E7E6E6"/>` | `style.backgroundColor: '#E7E6E6'` |
+| `<w:tcBorders>` | `style.borderTop/Right/Bottom/Left` |
+
+#### Page Setup (`<w:sectPr>`)
+
+| OOXML Property | Docs PageSetup Field |
+|----------------|----------------------|
+| `<w:pgSz w:w="11906" w:h="16838"/>` | A4 paper (twips → px at 96 DPI) |
+| `<w:pgMar w:top="1440" .../>` | `margins` (twips → px) |
+| `<w:pgSz w:orient="landscape"/>` | `orientation: 'landscape'` |
+
+**Unit Conversions:**
+
+```
+1 inch = 1440 twips = 914400 EMUs = 72 points = 96 CSS px
+twips → px: value × 96 / 1440
+EMUs → px: value × 96 / 914400
+half-points → points: value / 2
+```
+
+### 2.4 Image Import Flow
+
+1. Parse `word/_rels/document.xml.rels` to build `rId → filename` map.
+2. For each `<w:drawing>` with `<wp:inline>`:
+   a. Extract the relationship ID from `<a:blip r:embed="rId5"/>`.
+   b. Read the image bytes from the zip (`word/media/image5.png`).
+   c. Read `<wp:extent cx="..." cy="..."/>` for dimensions (EMUs → px).
+   d. Upload to image service → receive URL.
+   e. Create an inline with `text: '\uFFFC'` and `style.image: { src, width, height }`.
+
+### 2.5 Nested Table Handling
+
+When a `<w:tbl>` is encountered inside a `<w:tc>` (table cell):
+
+1. Recursively extract all text content from the nested table.
+2. Join cell texts with ` | ` separators, rows with newlines.
+3. Insert the result as paragraph blocks in the parent cell.
+
+### 2.6 Frontend Integration
+
+Add an "Import" option to the document creation UI:
+
+1. User clicks "Import DOCX" in the document list or editor toolbar.
+2. File picker opens, filtered to `.docx`.
+3. File is read as `ArrayBuffer` via `FileReader`.
+4. `DocxImporter.import(buffer, imageUploader)` is called:
+   - `imageUploader: (blob: Blob, filename: string) => Promise<string>` is
+     provided by the frontend to abstract the upload API call.
+5. Returns a `Document` object.
+6. A new document is created via the backend API, and the imported `Document`
+   is set as the initial content.
+
+### 2.7 Dependencies
+
+- **JSZip** (`jszip`) — .docx unzipping in the browser.
+- No XML parser library needed — use browser-native `DOMParser`.
+
+---
+
+## Phase 3 — DOCX Export
+
+### 3.1 Architecture
+
+```
+┌──────────────┐   Document    ┌──────────────┐    Blob     ┌──────────────┐
+│  DocStore     │ ────────────► │ DocxExporter  │ ──────────► │  Download    │
+│  (editor)     │              │ (packages/    │             │  (browser)   │
+│               │              │  docs)        │             │              │
+└──────────────┘               └──────────────┘             └──────────────┘
+                                     │
+                                GET /images/:id
+                                     │
+                                     ▼
+                               ┌──────────┐
+                               │  Fetch   │
+                               │  images  │
+                               └──────────┘
+```
+
+Location: `packages/docs/src/export/docx-exporter.ts`
+
+### 3.2 Generation Pipeline
+
+```
+Document ──► Build XML strings ──► Fetch images ──►
+  Package into ZIP ──► Generate Blob ──► Trigger download
+```
+
+**Steps:**
+
+1. **Generate `word/document.xml`** by walking `Document.blocks`:
+   - Each `paragraph` block → `<w:p>` with `<w:pPr>` and `<w:r>` runs.
+   - Each `table` block → `<w:tbl>` with rows, cells, merged cells.
+   - Each image inline → `<w:drawing><wp:inline>` with embedded relationship.
+2. **Generate `word/styles.xml`** with default styles and heading definitions.
+3. **Generate `word/header1.xml` / `word/footer1.xml`** from `Document.header`
+   and `Document.footer`.
+4. **Fetch image blobs** from their URLs and add to `word/media/`.
+5. **Generate `word/_rels/document.xml.rels`** with image and header/footer
+   relationships.
+6. **Generate `[Content_Types].xml`** registering all parts.
+7. **Package** all parts into a ZIP using JSZip.
+8. **Generate Blob** and trigger a browser download via `<a>` click.
+
+### 3.3 Style Mapping (Reverse of Import)
+
+The export maps Docs model properties back to OOXML XML attributes using the
+inverse of the tables in Section 2.3 (px → twips, points → half-points, etc.).
+
+### 3.4 Image Export Flow
+
+1. For each inline with `style.image`:
+   a. Fetch the image from `image.src` URL.
+   b. Determine the content type from the response.
+   c. Add the image bytes to `word/media/imageN.{ext}`.
+   d. Create a relationship entry `rIdN → media/imageN.{ext}`.
+   e. Generate `<w:drawing>` XML referencing `rIdN` with dimensions in EMUs.
+
+### 3.5 Frontend Integration
+
+- "Export as DOCX" button in the editor toolbar / file menu.
+- Click → `DocxExporter.export(document, imageFetcher)` → Blob → download.
+- `imageFetcher: (url: string) => Promise<Blob>` abstracts image fetching.
+
+### 3.6 Dependencies
+
+- **JSZip** (`jszip`) — packaging the .docx ZIP.
+- No additional libraries — XML is generated as template strings.
+
+---
+
+## File Structure
+
+```
+packages/docs/src/
+  model/
+    types.ts                    # + ImageData, image field on InlineStyle
+  import/
+    docx-importer.ts            # Main importer entry point
+    docx-parser.ts              # XML parsing utilities
+    docx-style-map.ts           # OOXML → Docs style conversion
+  export/
+    docx-exporter.ts            # Main exporter entry point
+    docx-builder.ts             # XML generation utilities
+    docx-style-map.ts           # Docs → OOXML style conversion
+  view/
+    fonts.ts                    # Font registry and loading
+
+packages/backend/src/
+  image/
+    image.module.ts
+    image.controller.ts
+    image.service.ts
+    image.config.ts
+
+docker-compose.yml              # + MinIO service
+```
+
+---
+
+## Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Complex OOXML edge cases (theme colors, inherited styles) | Start with direct property values; add theme resolution later if needed |
+| Large image files slowing import | Validate file size (10 MB limit per image); show progress indicator |
+| Korean fonts not available on user's system | Fallback to Noto Sans/Serif KR from Google Fonts |
+| Nested table content loss | Show a warning toast when nested tables are flattened to text |
+| Export fidelity — Word may render differently | Test with Word, Google Docs, LibreOffice; focus on structural correctness over pixel-perfect |
+| S3 credentials in dev environment | MinIO with default creds for local dev; real S3 for production |

--- a/docs/tasks/active/20260410-docx-import-export-todo.md
+++ b/docs/tasks/active/20260410-docx-import-export-todo.md
@@ -1,0 +1,2599 @@
+# DOCX Import / Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Import .docx files into the Docs editor and export documents back to .docx format.
+
+**Architecture:** Three-phase approach — first add prerequisite features (inline images with S3 storage, web font loading), then build DOCX import (JSZip + DOMParser in the browser), then DOCX export (XML generation + JSZip packaging). All conversion logic lives in `packages/docs/src/import/` and `packages/docs/src/export/`, keeping it isomorphic and close to the model types.
+
+**Tech Stack:** JSZip (zip/unzip), DOMParser (XML parsing), @aws-sdk/client-s3 (image storage), MinIO (dev S3), NestJS (image API), Canvas 2D (image rendering)
+
+**Spec:** `docs/design/docs/docs-docx-import-export.md`
+
+---
+
+## Phase 1 — Prerequisite Features
+
+### Task 1: Add ImageData type and image field to InlineStyle
+
+**Files:**
+- Modify: `packages/docs/src/model/types.ts`
+- Test: `packages/docs/test/model/types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/docs/test/model/types.test.ts`:
+
+```typescript
+describe('ImageData on InlineStyle', () => {
+  it('should allow creating an inline with image data', () => {
+    const inline: Inline = {
+      text: '\uFFFC',
+      style: {
+        image: {
+          src: 'https://example.com/image.png',
+          width: 200,
+          height: 150,
+          alt: 'Test image',
+        },
+      },
+    };
+    expect(inline.style.image).toBeDefined();
+    expect(inline.style.image!.src).toBe('https://example.com/image.png');
+    expect(inline.style.image!.width).toBe(200);
+    expect(inline.style.image!.height).toBe(150);
+    expect(inline.style.image!.alt).toBe('Test image');
+  });
+
+  it('should compare inline styles with image data', () => {
+    const a: InlineStyle = {
+      image: { src: 'a.png', width: 100, height: 100 },
+    };
+    const b: InlineStyle = {
+      image: { src: 'a.png', width: 100, height: 100 },
+    };
+    const c: InlineStyle = {
+      image: { src: 'b.png', width: 100, height: 100 },
+    };
+    expect(inlineStylesEqual(a, b)).toBe(true);
+    expect(inlineStylesEqual(a, c)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm test -- --run test/model/types.test.ts`
+Expected: FAIL — `image` property does not exist on `InlineStyle`
+
+- [ ] **Step 3: Add ImageData type and image field**
+
+In `packages/docs/src/model/types.ts`, add after the `InlineStyle` interface:
+
+```typescript
+/**
+ * Image data for inline image elements.
+ */
+export interface ImageData {
+  src: string;
+  width: number;
+  height: number;
+  alt?: string;
+}
+```
+
+Add `image` field to `InlineStyle`:
+
+```typescript
+export interface InlineStyle {
+  // ... existing fields ...
+  pageNumber?: boolean;
+  image?: ImageData;
+}
+```
+
+Update `inlineStylesEqual` to compare `image`:
+
+```typescript
+export function inlineStylesEqual(a: InlineStyle, b: InlineStyle): boolean {
+  return (
+    a.bold === b.bold &&
+    a.italic === b.italic &&
+    a.underline === b.underline &&
+    a.strikethrough === b.strikethrough &&
+    a.fontSize === b.fontSize &&
+    a.fontFamily === b.fontFamily &&
+    a.color === b.color &&
+    a.backgroundColor === b.backgroundColor &&
+    a.superscript === b.superscript &&
+    a.subscript === b.subscript &&
+    a.href === b.href &&
+    a.pageNumber === b.pageNumber &&
+    imageDataEqual(a.image, b.image)
+  );
+}
+
+function imageDataEqual(a: ImageData | undefined, b: ImageData | undefined): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.src === b.src && a.width === b.width && a.height === b.height && a.alt === b.alt;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm test -- --run test/model/types.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run full typecheck**
+
+Run: `cd packages/docs && pnpm typecheck`
+Expected: PASS — no existing code breaks
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/docs/src/model/types.ts packages/docs/test/model/types.test.ts
+git commit -m "Add ImageData type and image field to InlineStyle"
+```
+
+---
+
+### Task 2: Add image inline support to Doc model
+
+**Files:**
+- Modify: `packages/docs/src/model/document.ts`
+- Test: `packages/docs/test/model/document.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/docs/test/model/document.test.ts`:
+
+```typescript
+describe('image inlines', () => {
+  it('should insert an image inline into a block', () => {
+    const doc = Doc.create();
+    const blockId = doc.document.blocks[0].id;
+    doc.insertText({ blockId, offset: 0 }, 'Hello');
+
+    const imageInline: Inline = {
+      text: '\uFFFC',
+      style: {
+        image: { src: '/images/test.png', width: 200, height: 100 },
+      },
+    };
+    doc.insertImageInline(blockId, 5, imageInline);
+
+    const block = doc.document.blocks[0];
+    expect(getBlockText(block)).toBe('Hello\uFFFC');
+    expect(block.inlines[block.inlines.length - 1].style.image?.src).toBe('/images/test.png');
+  });
+
+  it('should delete an image inline with backspace', () => {
+    const doc = Doc.create();
+    const blockId = doc.document.blocks[0].id;
+    const imageInline: Inline = {
+      text: '\uFFFC',
+      style: {
+        image: { src: '/images/test.png', width: 200, height: 100 },
+      },
+    };
+    doc.insertImageInline(blockId, 0, imageInline);
+    expect(getBlockText(doc.document.blocks[0])).toBe('\uFFFC');
+
+    doc.deleteText({ blockId, offset: 0 }, 1);
+    expect(getBlockText(doc.document.blocks[0])).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm test -- --run test/model/document.test.ts`
+Expected: FAIL — `insertImageInline` does not exist on `Doc`
+
+- [ ] **Step 3: Implement insertImageInline on Doc**
+
+Add to `packages/docs/src/model/document.ts`:
+
+```typescript
+/**
+ * Insert an image inline at the given offset within a block.
+ * The image inline uses \uFFFC as its text character.
+ */
+insertImageInline(blockId: string, offset: number, imageInline: Inline): void {
+  this.store.snapshot();
+  const block = this.getBlock(blockId);
+  const cloned = cloneBlock(block);
+
+  // Split inlines at offset, insert the image inline in between
+  const before: Inline[] = [];
+  const after: Inline[] = [];
+  let remaining = offset;
+  for (const inline of cloned.inlines) {
+    if (remaining >= inline.text.length) {
+      before.push(inline);
+      remaining -= inline.text.length;
+    } else if (remaining > 0) {
+      before.push({ text: inline.text.slice(0, remaining), style: { ...inline.style } });
+      after.push({ text: inline.text.slice(remaining), style: { ...inline.style } });
+      remaining = 0;
+    } else {
+      after.push(inline);
+    }
+  }
+
+  cloned.inlines = [...before, imageInline, ...after];
+  this.store.updateBlock(blockId, cloned);
+  this.refresh();
+}
+```
+
+Import `cloneBlock` from `../store/block-helpers.js` and `Inline` from `../model/types.js` if not already imported.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm test -- --run test/model/document.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/model/document.ts packages/docs/test/model/document.test.ts
+git commit -m "Add insertImageInline method to Doc model"
+```
+
+---
+
+### Task 3: Add image inline support to Yorkie serialization
+
+**Files:**
+- Modify: `packages/frontend/src/app/docs/yorkie-doc-store.ts`
+
+- [ ] **Step 1: Add image serialization to serializeInlineStyle**
+
+In the `serializeInlineStyle` function, add:
+
+```typescript
+if (style.image) {
+  attrs['image.src'] = style.image.src;
+  attrs['image.width'] = String(style.image.width);
+  attrs['image.height'] = String(style.image.height);
+  if (style.image.alt) attrs['image.alt'] = style.image.alt;
+}
+```
+
+- [ ] **Step 2: Add image deserialization to parseInlineStyle**
+
+In the `parseInlineStyle` function, add:
+
+```typescript
+if ('image.src' in attrs) {
+  style.image = {
+    src: attrs['image.src'],
+    width: Number(attrs['image.width']),
+    height: Number(attrs['image.height']),
+    alt: attrs['image.alt'] || undefined,
+  };
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm frontend typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/frontend/src/app/docs/yorkie-doc-store.ts
+git commit -m "Add image data serialization to Yorkie doc store"
+```
+
+---
+
+### Task 4: Add image rendering to layout and canvas
+
+**Files:**
+- Modify: `packages/docs/src/view/layout.ts`
+- Modify: `packages/docs/src/view/doc-canvas.ts`
+- Modify: `packages/docs/src/view/editor.ts`
+
+This task modifies the view layer which uses Canvas 2D and doesn't have unit-testable functions for image rendering (requires a browser DOM). It will be verified via manual testing and the existing visual test infrastructure.
+
+- [ ] **Step 1: Add image measurement to layout.ts**
+
+In the word-wrap logic inside `computeLayout` (or the inline measurement function), add image handling before `measureText`:
+
+```typescript
+// When computing run width for an inline:
+if (inline.style.image) {
+  const img = inline.style.image;
+  const maxWidth = contentWidth; // available width in the line
+  const scale = img.width > maxWidth ? maxWidth / img.width : 1;
+  const displayWidth = img.width * scale;
+  const displayHeight = img.height * scale;
+  // Treat as a single unbreakable run with these dimensions
+  // Set run.width = displayWidth, line.height = max(line.height, displayHeight)
+}
+```
+
+The exact insertion point depends on the word-wrap loop structure. The key principle: an image inline produces a single `LayoutRun` that cannot be word-broken, with width and height taken from `image.width`/`image.height` (scaled down if wider than content area).
+
+- [ ] **Step 2: Add ImageCache and image drawing to doc-canvas.ts**
+
+Add at module level in `doc-canvas.ts`:
+
+```typescript
+const imageCache = new Map<string, HTMLImageElement>();
+
+function getOrLoadImage(
+  src: string,
+  onLoad: () => void,
+): HTMLImageElement | null {
+  const cached = imageCache.get(src);
+  if (cached && cached.complete) return cached;
+  if (!cached) {
+    const img = new Image();
+    img.onload = onLoad;
+    img.src = src;
+    imageCache.set(src, img);
+  }
+  return null;
+}
+```
+
+In the run rendering loop (where `ctx.fillText` is called), add before the text draw:
+
+```typescript
+if (run.inline.style.image) {
+  const img = getOrLoadImage(run.inline.style.image.src, () => {
+    // Trigger re-render when image loads
+    this.render(/* pass current args */);
+  });
+  if (img) {
+    ctx.drawImage(img, run.x + pageXOffset, run.y + lineY, run.width, lineHeight);
+  }
+  continue; // Skip text rendering for image runs
+}
+```
+
+- [ ] **Step 3: Wire re-render callback in editor.ts**
+
+Ensure the editor's render method is accessible for the image onload callback. The `DocCanvas` already has access to the render pipeline through the editor. Store a `requestRender` callback that the canvas can invoke.
+
+- [ ] **Step 4: Run typecheck and verify**
+
+Run: `cd packages/docs && pnpm typecheck`
+Expected: PASS
+
+Run: `pnpm verify:fast`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/view/layout.ts packages/docs/src/view/doc-canvas.ts packages/docs/src/view/editor.ts
+git commit -m "Add image inline rendering to layout and canvas"
+```
+
+---
+
+### Task 5: Add MinIO to docker-compose and create ImageModule backend
+
+**Files:**
+- Modify: `docker-compose.yaml`
+- Create: `packages/backend/src/image/image.module.ts`
+- Create: `packages/backend/src/image/image.service.ts`
+- Create: `packages/backend/src/image/image.controller.ts`
+- Create: `packages/backend/src/image/image.config.ts`
+- Modify: `packages/backend/src/app.module.ts`
+- Test: `packages/backend/test/image.service.spec.ts`
+
+- [ ] **Step 1: Add MinIO service to docker-compose.yaml**
+
+Append to `docker-compose.yaml`:
+
+```yaml
+  minio:
+    image: minio/minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+
+volumes:
+  minio-data:
+```
+
+- [ ] **Step 2: Create image.config.ts**
+
+Create `packages/backend/src/image/image.config.ts`:
+
+```typescript
+import { registerAs } from '@nestjs/config';
+
+export const imageConfig = registerAs('image', () => ({
+  endpoint: process.env.IMAGE_STORAGE_ENDPOINT || 'http://localhost:9000',
+  bucket: process.env.IMAGE_STORAGE_BUCKET || 'wafflebase-images',
+  region: process.env.IMAGE_STORAGE_REGION || 'us-east-1',
+  accessKey: process.env.IMAGE_STORAGE_ACCESS_KEY || 'minioadmin',
+  secretKey: process.env.IMAGE_STORAGE_SECRET_KEY || 'minioadmin',
+  maxFileSizeBytes: 10 * 1024 * 1024, // 10 MB
+  allowedMimeTypes: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'],
+}));
+```
+
+- [ ] **Step 3: Create image.service.ts**
+
+Create `packages/backend/src/image/image.service.ts`:
+
+```typescript
+import { Injectable, BadRequestException, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  CreateBucketCommand,
+  HeadBucketCommand,
+} from '@aws-sdk/client-s3';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class ImageService implements OnModuleInit {
+  private s3: S3Client;
+  private bucket: string;
+  private maxFileSize: number;
+  private allowedMimeTypes: string[];
+
+  constructor(private config: ConfigService) {
+    const endpoint = this.config.get<string>('image.endpoint')!;
+    const region = this.config.get<string>('image.region')!;
+    const accessKey = this.config.get<string>('image.accessKey')!;
+    const secretKey = this.config.get<string>('image.secretKey')!;
+    this.bucket = this.config.get<string>('image.bucket')!;
+    this.maxFileSize = this.config.get<number>('image.maxFileSizeBytes')!;
+    this.allowedMimeTypes = this.config.get<string[]>('image.allowedMimeTypes')!;
+
+    this.s3 = new S3Client({
+      endpoint,
+      region,
+      credentials: { accessKeyId: accessKey, secretAccessKey: secretKey },
+      forcePathStyle: true, // Required for MinIO
+    });
+  }
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.s3.send(new HeadBucketCommand({ Bucket: this.bucket }));
+    } catch {
+      await this.s3.send(new CreateBucketCommand({ Bucket: this.bucket }));
+    }
+  }
+
+  async upload(
+    file: Buffer,
+    mimeType: string,
+    originalName: string,
+  ): Promise<{ id: string; url: string }> {
+    if (!this.allowedMimeTypes.includes(mimeType)) {
+      throw new BadRequestException(`Unsupported file type: ${mimeType}`);
+    }
+    if (file.length > this.maxFileSize) {
+      throw new BadRequestException(`File too large (max ${this.maxFileSize / 1024 / 1024} MB)`);
+    }
+
+    const ext = originalName.split('.').pop() || 'bin';
+    const id = randomUUID();
+    const key = `${id}.${ext}`;
+
+    await this.s3.send(new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: key,
+      Body: file,
+      ContentType: mimeType,
+    }));
+
+    return { id: key, url: `/images/${key}` };
+  }
+
+  async getObject(id: string): Promise<{ body: ReadableStream; contentType: string }> {
+    const response = await this.s3.send(new GetObjectCommand({
+      Bucket: this.bucket,
+      Key: id,
+    }));
+    return {
+      body: response.Body as unknown as ReadableStream,
+      contentType: response.ContentType || 'application/octet-stream',
+    };
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.s3.send(new DeleteObjectCommand({
+      Bucket: this.bucket,
+      Key: id,
+    }));
+  }
+}
+```
+
+- [ ] **Step 4: Create image.controller.ts**
+
+Create `packages/backend/src/image/image.controller.ts`:
+
+```typescript
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Param,
+  Res,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ImageService } from './image.service';
+import type { Response } from 'express';
+
+@Controller('images')
+export class ImageController {
+  constructor(private readonly imageService: ImageService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @UseInterceptors(FileInterceptor('file'))
+  async upload(
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<{ id: string; url: string }> {
+    return this.imageService.upload(
+      file.buffer,
+      file.mimetype,
+      file.originalname,
+    );
+  }
+
+  @Get(':id')
+  async get(
+    @Param('id') id: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const { body, contentType } = await this.imageService.getObject(id);
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    const reader = (body as any).getReader();
+    const pump = async () => {
+      const { done, value } = await reader.read();
+      if (done) { res.end(); return; }
+      res.write(value);
+      await pump();
+    };
+    await pump();
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  async delete(@Param('id') id: string): Promise<{ deleted: boolean }> {
+    await this.imageService.delete(id);
+    return { deleted: true };
+  }
+}
+```
+
+- [ ] **Step 5: Create image.module.ts**
+
+Create `packages/backend/src/image/image.module.ts`:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ImageController } from './image.controller';
+import { ImageService } from './image.service';
+import { imageConfig } from './image.config';
+
+@Module({
+  imports: [ConfigModule.forFeature(imageConfig)],
+  controllers: [ImageController],
+  providers: [ImageService],
+  exports: [ImageService],
+})
+export class ImageModule {}
+```
+
+- [ ] **Step 6: Register ImageModule in AppModule**
+
+In `packages/backend/src/app.module.ts`, add import and register:
+
+```typescript
+import { ImageModule } from './image/image.module';
+
+@Module({
+  imports: [
+    // ... existing imports ...
+    ImageModule,
+  ],
+})
+export class AppModule {}
+```
+
+- [ ] **Step 7: Install @aws-sdk/client-s3 dependency**
+
+Run: `cd packages/backend && pnpm add @aws-sdk/client-s3`
+
+- [ ] **Step 8: Run backend typecheck and tests**
+
+Run: `pnpm backend test`
+Expected: PASS (existing tests still pass)
+
+Run: `pnpm verify:fast`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docker-compose.yaml packages/backend/src/image/ packages/backend/src/app.module.ts packages/backend/package.json pnpm-lock.yaml
+git commit -m $'Add ImageModule with S3-compatible storage backend\n\nMinIO for dev environment, configurable S3 endpoint for production.\nSupports upload, serve, and delete of image resources.'
+```
+
+---
+
+### Task 6: Add font registry and web font loading
+
+**Files:**
+- Create: `packages/docs/src/view/fonts.ts`
+- Test: `packages/docs/test/view/fonts.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/docs/test/view/fonts.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { FontRegistry, resolveFontFamily } from '../../src/view/fonts.js';
+
+describe('FontRegistry', () => {
+  it('should resolve known Korean font to fallback chain', () => {
+    expect(resolveFontFamily('맑은 고딕')).toBe("'Malgun Gothic', 'Noto Sans KR', sans-serif");
+  });
+
+  it('should resolve HY헤드라인M to Noto Sans KR fallback', () => {
+    expect(resolveFontFamily('HY헤드라인M')).toBe("'Noto Sans KR', sans-serif");
+  });
+
+  it('should return standard fonts as-is with fallback', () => {
+    expect(resolveFontFamily('Arial')).toBe("'Arial', sans-serif");
+  });
+
+  it('should return unknown fonts with generic fallback', () => {
+    expect(resolveFontFamily('SomeRandomFont')).toBe("'SomeRandomFont', sans-serif");
+  });
+
+  it('should resolve 바탕 to serif chain', () => {
+    expect(resolveFontFamily('바탕')).toBe("'Batang', 'Noto Serif KR', serif");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm test -- --run test/view/fonts.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement font registry**
+
+Create `packages/docs/src/view/fonts.ts`:
+
+```typescript
+/**
+ * Font registry — maps font family names to web-safe fallback chains
+ * and handles on-demand font loading via the CSS Font Loading API.
+ */
+
+const FONT_MAP: Record<string, string> = {
+  '맑은 고딕': "'Malgun Gothic', 'Noto Sans KR', sans-serif",
+  'Malgun Gothic': "'Malgun Gothic', 'Noto Sans KR', sans-serif",
+  '바탕': "'Batang', 'Noto Serif KR', serif",
+  'Batang': "'Batang', 'Noto Serif KR', serif",
+  'HY헤드라인M': "'Noto Sans KR', sans-serif",
+  'Arial': "'Arial', sans-serif",
+  'Tahoma': "'Tahoma', sans-serif",
+};
+
+const SERIF_FONTS = new Set(['바탕', 'Batang', 'Noto Serif KR', 'Times New Roman', 'Georgia']);
+
+/**
+ * Resolve a font family name to a CSS fallback chain string.
+ */
+export function resolveFontFamily(family: string): string {
+  const mapped = FONT_MAP[family];
+  if (mapped) return mapped;
+
+  const generic = SERIF_FONTS.has(family) ? 'serif' : 'sans-serif';
+  return `'${family}', ${generic}`;
+}
+
+type FontStatus = 'pending' | 'loading' | 'loaded' | 'error';
+
+/**
+ * FontRegistry manages on-demand web font loading and notifies
+ * listeners when fonts finish loading (to trigger re-layout).
+ */
+export class FontRegistry {
+  private status = new Map<string, FontStatus>();
+  private listeners: Array<() => void> = [];
+
+  /**
+   * Register a callback to be called when any font finishes loading.
+   */
+  onFontLoaded(cb: () => void): void {
+    this.listeners.push(cb);
+  }
+
+  /**
+   * Ensure a font is loaded. If not yet loaded, triggers async loading
+   * and calls listeners when done.
+   */
+  async ensureFont(family: string): Promise<void> {
+    if (typeof document === 'undefined') return; // SSR guard
+    const key = family;
+    const current = this.status.get(key);
+    if (current === 'loaded' || current === 'loading') return;
+
+    if (document.fonts.check(`12px "${family}"`)) {
+      this.status.set(key, 'loaded');
+      return;
+    }
+
+    this.status.set(key, 'loading');
+    try {
+      await document.fonts.load(`12px "${family}"`);
+      this.status.set(key, 'loaded');
+      this.listeners.forEach((cb) => cb());
+    } catch {
+      this.status.set(key, 'error');
+    }
+  }
+
+  getFontStatus(family: string): FontStatus {
+    return this.status.get(family) ?? 'pending';
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm test -- --run test/view/fonts.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/view/fonts.ts packages/docs/test/view/fonts.test.ts
+git commit -m "Add font registry with Korean font fallback chains"
+```
+
+---
+
+## Phase 2 — DOCX Import
+
+### Task 7: Add unit conversion utilities
+
+**Files:**
+- Create: `packages/docs/src/import/units.ts`
+- Test: `packages/docs/test/import/units.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/docs/test/import/units.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { twipsToPx, emusToPx, halfPointsToPoints, pxToTwips, pxToEmus, pointsToHalfPoints } from '../../src/import/units.js';
+
+describe('OOXML unit conversions', () => {
+  it('should convert twips to px', () => {
+    expect(twipsToPx(1440)).toBeCloseTo(96, 1);    // 1 inch
+    expect(twipsToPx(720)).toBeCloseTo(48, 1);      // 0.5 inch
+  });
+
+  it('should convert EMUs to px', () => {
+    expect(emusToPx(914400)).toBeCloseTo(96, 1);    // 1 inch
+    expect(emusToPx(457200)).toBeCloseTo(48, 1);     // 0.5 inch
+  });
+
+  it('should convert half-points to points', () => {
+    expect(halfPointsToPoints(24)).toBe(12);
+    expect(halfPointsToPoints(30)).toBe(15);
+  });
+
+  it('should convert px to twips (reverse)', () => {
+    expect(pxToTwips(96)).toBeCloseTo(1440, 1);
+  });
+
+  it('should convert px to EMUs (reverse)', () => {
+    expect(pxToEmus(96)).toBeCloseTo(914400, 1);
+  });
+
+  it('should convert points to half-points (reverse)', () => {
+    expect(pointsToHalfPoints(12)).toBe(24);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm test -- --run test/import/units.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement unit conversions**
+
+Create `packages/docs/src/import/units.ts`:
+
+```typescript
+/**
+ * OOXML ↔ CSS px unit conversions.
+ *
+ * 1 inch = 1440 twips = 914400 EMUs = 72 points = 96 CSS px
+ */
+
+/** Twips (1/1440 inch) → CSS pixels (1/96 inch). */
+export function twipsToPx(twips: number): number {
+  return twips * 96 / 1440;
+}
+
+/** CSS pixels → twips. */
+export function pxToTwips(px: number): number {
+  return px * 1440 / 96;
+}
+
+/** EMUs (1/914400 inch) → CSS pixels. */
+export function emusToPx(emus: number): number {
+  return emus * 96 / 914400;
+}
+
+/** CSS pixels → EMUs. */
+export function pxToEmus(px: number): number {
+  return px * 914400 / 96;
+}
+
+/** OOXML half-points → points. */
+export function halfPointsToPoints(halfPts: number): number {
+  return halfPts / 2;
+}
+
+/** Points → OOXML half-points. */
+export function pointsToHalfPoints(pts: number): number {
+  return pts * 2;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm test -- --run test/import/units.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/import/units.ts packages/docs/test/import/units.test.ts
+git commit -m "Add OOXML unit conversion utilities"
+```
+
+---
+
+### Task 8: Implement DOCX style mapping (OOXML → Docs model)
+
+**Files:**
+- Create: `packages/docs/src/import/docx-style-map.ts`
+- Test: `packages/docs/test/import/docx-style-map.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/docs/test/import/docx-style-map.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { mapRunProperties, mapParagraphProperties, mapTableCellProperties, mapHighlightColor } from '../../src/import/docx-style-map.js';
+
+describe('mapRunProperties', () => {
+  it('should map bold', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:b/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.bold).toBe(true);
+  });
+
+  it('should map font size from half-points', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:sz w:val="24"/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.fontSize).toBe(12);
+  });
+
+  it('should map font family', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:rFonts w:ascii="Arial"/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.fontFamily).toBe('Arial');
+  });
+
+  it('should map text color', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:color w:val="FF0000"/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.color).toBe('#FF0000');
+  });
+
+  it('should map underline, italic, strikethrough', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:i/><w:u w:val="single"/><w:strike/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.italic).toBe(true);
+    expect(style.underline).toBe(true);
+    expect(style.strikethrough).toBe(true);
+  });
+
+  it('should map superscript', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:vertAlign w:val="superscript"/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.superscript).toBe(true);
+  });
+});
+
+describe('mapParagraphProperties', () => {
+  it('should map center alignment', () => {
+    const xml = '<w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:jc w:val="center"/></w:pPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = mapParagraphProperties(el);
+    expect(result.blockStyle.alignment).toBe('center');
+  });
+
+  it('should map "both" to justify', () => {
+    const xml = '<w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:jc w:val="both"/></w:pPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = mapParagraphProperties(el);
+    expect(result.blockStyle.alignment).toBe('justify');
+  });
+
+  it('should map spacing to marginTop and marginBottom', () => {
+    const xml = '<w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:spacing w:before="120" w:after="240"/></w:pPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = mapParagraphProperties(el);
+    expect(result.blockStyle.marginTop).toBeCloseTo(8, 0);
+    expect(result.blockStyle.marginBottom).toBeCloseTo(16, 0);
+  });
+});
+
+describe('mapHighlightColor', () => {
+  it('should map named highlight colors', () => {
+    expect(mapHighlightColor('yellow')).toBe('#FFFF00');
+    expect(mapHighlightColor('red')).toBe('#FF0000');
+    expect(mapHighlightColor('green')).toBe('#00FF00');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm test -- --run test/import/docx-style-map.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement style mapping**
+
+Create `packages/docs/src/import/docx-style-map.ts`:
+
+```typescript
+import type { InlineStyle, BlockStyle } from '../model/types.js';
+import { DEFAULT_BLOCK_STYLE } from '../model/types.js';
+import { twipsToPx, halfPointsToPoints } from './units.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function getW(el: Element, localName: string): Element | null {
+  return el.getElementsByTagNameNS(W, localName)[0] ?? null;
+}
+
+function getWAttr(el: Element, attr: string): string | null {
+  return el.getAttributeNS(W, attr) || el.getAttribute(`w:${attr}`);
+}
+
+/**
+ * Map <w:rPr> element to InlineStyle.
+ */
+export function mapRunProperties(rPr: Element): InlineStyle {
+  const style: InlineStyle = {};
+
+  if (getW(rPr, 'b')) style.bold = true;
+  if (getW(rPr, 'i')) style.italic = true;
+  if (getW(rPr, 'strike')) style.strikethrough = true;
+
+  const u = getW(rPr, 'u');
+  if (u) {
+    const val = getWAttr(u, 'val');
+    if (val && val !== 'none') style.underline = true;
+  }
+
+  const sz = getW(rPr, 'sz');
+  if (sz) {
+    const val = getWAttr(sz, 'val');
+    if (val) style.fontSize = halfPointsToPoints(parseInt(val, 10));
+  }
+
+  const rFonts = getW(rPr, 'rFonts');
+  if (rFonts) {
+    const font = getWAttr(rFonts, 'ascii') || getWAttr(rFonts, 'eastAsia') || getWAttr(rFonts, 'hAnsi');
+    if (font) style.fontFamily = font;
+  }
+
+  const color = getW(rPr, 'color');
+  if (color) {
+    const val = getWAttr(color, 'val');
+    if (val && val !== 'auto') style.color = `#${val}`;
+  }
+
+  const highlight = getW(rPr, 'highlight');
+  if (highlight) {
+    const val = getWAttr(highlight, 'val');
+    if (val) style.backgroundColor = mapHighlightColor(val);
+  }
+
+  const shd = getW(rPr, 'shd');
+  if (shd && !style.backgroundColor) {
+    const fill = getWAttr(shd, 'fill');
+    if (fill && fill !== 'auto') style.backgroundColor = `#${fill}`;
+  }
+
+  const vertAlign = getW(rPr, 'vertAlign');
+  if (vertAlign) {
+    const val = getWAttr(vertAlign, 'val');
+    if (val === 'superscript') style.superscript = true;
+    if (val === 'subscript') style.subscript = true;
+  }
+
+  return style;
+}
+
+/**
+ * Map <w:pPr> element to block style + block type metadata.
+ */
+export function mapParagraphProperties(pPr: Element): {
+  blockStyle: BlockStyle;
+  headingLevel?: number;
+  blockType?: string;
+} {
+  const blockStyle: BlockStyle = { ...DEFAULT_BLOCK_STYLE };
+  let headingLevel: number | undefined;
+  let blockType: string | undefined;
+
+  const jc = getW(pPr, 'jc');
+  if (jc) {
+    const val = getWAttr(jc, 'val');
+    if (val === 'center') blockStyle.alignment = 'center';
+    else if (val === 'right') blockStyle.alignment = 'right';
+    else if (val === 'both') blockStyle.alignment = 'justify';
+    else blockStyle.alignment = 'left';
+  }
+
+  const spacing = getW(pPr, 'spacing');
+  if (spacing) {
+    const before = getWAttr(spacing, 'before');
+    if (before) blockStyle.marginTop = twipsToPx(parseInt(before, 10));
+    const after = getWAttr(spacing, 'after');
+    if (after) blockStyle.marginBottom = twipsToPx(parseInt(after, 10));
+    const line = getWAttr(spacing, 'line');
+    if (line) {
+      const lineVal = parseInt(line, 10);
+      // line value of 240 = single spacing (1.0)
+      if (lineVal > 0) blockStyle.lineHeight = lineVal / 240;
+    }
+  }
+
+  const ind = getW(pPr, 'ind');
+  if (ind) {
+    const firstLine = getWAttr(ind, 'firstLine');
+    if (firstLine) blockStyle.textIndent = twipsToPx(parseInt(firstLine, 10));
+    const left = getWAttr(ind, 'left');
+    if (left) blockStyle.marginLeft = twipsToPx(parseInt(left, 10));
+  }
+
+  const pStyle = getW(pPr, 'pStyle');
+  if (pStyle) {
+    const val = getWAttr(pStyle, 'val');
+    if (val) {
+      // Common heading style IDs
+      const headingMatch = val.match(/^(?:Heading|heading)(\d)$/);
+      if (headingMatch) {
+        headingLevel = parseInt(headingMatch[1], 10);
+        blockType = 'heading';
+      }
+      // Korean style IDs are sometimes just numbers
+      if (/^\d$/.test(val)) {
+        headingLevel = parseInt(val, 10);
+        blockType = 'heading';
+      }
+    }
+  }
+
+  return { blockStyle, headingLevel, blockType };
+}
+
+/**
+ * Map <w:tcPr> to cell background and border styles.
+ */
+export function mapTableCellProperties(tcPr: Element): {
+  backgroundColor?: string;
+  borderTop?: { width: number; color: string; style: 'solid' | 'none' };
+  borderBottom?: { width: number; color: string; style: 'solid' | 'none' };
+  borderLeft?: { width: number; color: string; style: 'solid' | 'none' };
+  borderRight?: { width: number; color: string; style: 'solid' | 'none' };
+  colSpan?: number;
+  vMerge?: 'restart' | 'continue';
+} {
+  const result: ReturnType<typeof mapTableCellProperties> = {};
+
+  const shd = getW(tcPr, 'shd');
+  if (shd) {
+    const fill = getWAttr(shd, 'fill');
+    if (fill && fill !== 'auto') result.backgroundColor = `#${fill}`;
+  }
+
+  const gridSpan = getW(tcPr, 'gridSpan');
+  if (gridSpan) {
+    const val = getWAttr(gridSpan, 'val');
+    if (val) result.colSpan = parseInt(val, 10);
+  }
+
+  const vMerge = getW(tcPr, 'vMerge');
+  if (vMerge) {
+    const val = getWAttr(vMerge, 'val');
+    result.vMerge = val === 'restart' ? 'restart' : 'continue';
+  }
+
+  const tcBorders = getW(tcPr, 'tcBorders');
+  if (tcBorders) {
+    for (const side of ['top', 'bottom', 'left', 'right'] as const) {
+      const borderEl = getW(tcBorders, side);
+      if (borderEl) {
+        const sz = getWAttr(borderEl, 'sz');
+        const color = getWAttr(borderEl, 'color');
+        const val = getWAttr(borderEl, 'val');
+        const key = `border${side.charAt(0).toUpperCase() + side.slice(1)}` as const;
+        result[key] = {
+          width: sz ? parseInt(sz, 10) / 8 : 1, // eighths of a point → px approximation
+          color: color && color !== 'auto' ? `#${color}` : '#000000',
+          style: val === 'none' || val === 'nil' ? 'none' : 'solid',
+        };
+      }
+    }
+  }
+
+  return result;
+}
+
+const HIGHLIGHT_COLORS: Record<string, string> = {
+  yellow: '#FFFF00',
+  green: '#00FF00',
+  cyan: '#00FFFF',
+  magenta: '#FF00FF',
+  blue: '#0000FF',
+  red: '#FF0000',
+  darkBlue: '#00008B',
+  darkCyan: '#008B8B',
+  darkGreen: '#006400',
+  darkMagenta: '#8B008B',
+  darkRed: '#8B0000',
+  darkYellow: '#808000',
+  darkGray: '#A9A9A9',
+  lightGray: '#D3D3D3',
+  black: '#000000',
+  white: '#FFFFFF',
+};
+
+export function mapHighlightColor(name: string): string {
+  return HIGHLIGHT_COLORS[name] ?? '#FFFF00';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm test -- --run test/import/docx-style-map.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/import/docx-style-map.ts packages/docs/test/import/docx-style-map.test.ts
+git commit -m "Add DOCX-to-Docs style mapping functions"
+```
+
+---
+
+### Task 9: Implement DOCX XML parser utilities
+
+**Files:**
+- Create: `packages/docs/src/import/docx-parser.ts`
+- Test: `packages/docs/test/import/docx-parser.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/docs/test/import/docx-parser.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { parseRelationships, parseParagraph, parsePageSetup } from '../../src/import/docx-parser.js';
+
+describe('parseRelationships', () => {
+  it('should parse document.xml.rels into rId → target map', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+      <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>
+    </Relationships>`;
+    const rels = parseRelationships(xml);
+    expect(rels.get('rId1')).toEqual({ target: 'media/image1.png', type: 'image' });
+    expect(rels.get('rId2')).toEqual({ target: 'header1.xml', type: 'header' });
+  });
+});
+
+describe('parseParagraph', () => {
+  it('should extract text runs from a paragraph', () => {
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:r><w:t>Hello</w:t></w:r>
+      <w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve"> World</w:t></w:r>
+    </w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines).toHaveLength(2);
+    expect(result.inlines[0].text).toBe('Hello');
+    expect(result.inlines[0].style.bold).toBeUndefined();
+    expect(result.inlines[1].text).toBe(' World');
+    expect(result.inlines[1].style.bold).toBe(true);
+  });
+
+  it('should handle empty paragraphs', () => {
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines).toHaveLength(1);
+    expect(result.inlines[0].text).toBe('');
+  });
+});
+
+describe('parsePageSetup', () => {
+  it('should parse sectPr into PageSetup', () => {
+    const xml = `<w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:pgSz w:w="11906" w:h="16838"/>
+      <w:pgMar w:top="1440" w:right="1080" w:bottom="1440" w:left="1080"/>
+    </w:sectPr>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const setup = parsePageSetup(el);
+    // A4 paper: 11906 twips wide ≈ 794 px
+    expect(setup.paperSize.width).toBeCloseTo(794, 0);
+    expect(setup.paperSize.height).toBeCloseTo(1123, 0);
+    expect(setup.margins.top).toBeCloseTo(96, 0);
+    expect(setup.margins.left).toBeCloseTo(72, 0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm test -- --run test/import/docx-parser.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement parser utilities**
+
+Create `packages/docs/src/import/docx-parser.ts`:
+
+```typescript
+import type { Inline, InlineStyle, BlockStyle, Block, PageSetup, PageMargins, PaperSize } from '../model/types.js';
+import { DEFAULT_BLOCK_STYLE, generateBlockId } from '../model/types.js';
+import { mapRunProperties, mapParagraphProperties } from './docx-style-map.js';
+import { twipsToPx } from './units.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const RELS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+export interface RelEntry {
+  target: string;
+  type: string;
+}
+
+/**
+ * Parse a .rels XML file into a Map of relationship ID → target + type.
+ */
+export function parseRelationships(xml: string): Map<string, RelEntry> {
+  const doc = new DOMParser().parseFromString(xml, 'text/xml');
+  const rels = new Map<string, RelEntry>();
+  const elements = doc.getElementsByTagNameNS(RELS, 'Relationship');
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i];
+    const id = el.getAttribute('Id') || '';
+    const target = el.getAttribute('Target') || '';
+    const fullType = el.getAttribute('Type') || '';
+    // Extract short type from the full URI
+    const type = fullType.split('/').pop() || '';
+    rels.set(id, { target, type });
+  }
+  return rels;
+}
+
+/**
+ * Parse a <w:p> element into inlines and block metadata.
+ */
+export function parseParagraph(pEl: Element): {
+  inlines: Inline[];
+  blockStyle: BlockStyle;
+  blockType: string;
+  headingLevel?: number;
+  imageRefs: Array<{ rId: string; cx: number; cy: number }>;
+} {
+  let blockStyle: BlockStyle = { ...DEFAULT_BLOCK_STYLE };
+  let blockType = 'paragraph';
+  let headingLevel: number | undefined;
+  const imageRefs: Array<{ rId: string; cx: number; cy: number }> = [];
+
+  const pPr = pEl.getElementsByTagNameNS(W, 'pPr')[0];
+  if (pPr) {
+    const mapped = mapParagraphProperties(pPr);
+    blockStyle = mapped.blockStyle;
+    if (mapped.blockType) blockType = mapped.blockType;
+    if (mapped.headingLevel) headingLevel = mapped.headingLevel;
+  }
+
+  const inlines: Inline[] = [];
+  const runs = pEl.getElementsByTagNameNS(W, 'r');
+  for (let i = 0; i < runs.length; i++) {
+    const r = runs[i];
+    // Check if this run is a direct child (not inside a nested element like hyperlink)
+    // by verifying its parent is either the paragraph or a hyperlink
+    if (r.parentElement !== pEl && r.parentElement?.localName !== 'hyperlink') {
+      // Skip runs inside nested structures we don't handle
+    }
+
+    let style: InlineStyle = {};
+    const rPr = r.getElementsByTagNameNS(W, 'rPr')[0];
+    if (rPr) {
+      style = mapRunProperties(rPr);
+    }
+
+    // Check for drawing (image)
+    const drawing = r.getElementsByTagNameNS(W, 'drawing')[0];
+    if (drawing) {
+      const inlineDrawing = drawing.getElementsByTagNameNS(WP, 'inline')[0];
+      if (inlineDrawing) {
+        const extent = inlineDrawing.getElementsByTagNameNS(WP, 'extent')[0];
+        const cx = extent ? parseInt(extent.getAttribute('cx') || '0', 10) : 0;
+        const cy = extent ? parseInt(extent.getAttribute('cy') || '0', 10) : 0;
+
+        const blip = inlineDrawing.getElementsByTagNameNS(A, 'blip')[0];
+        const rId = blip?.getAttributeNS(R_NS, 'embed') || blip?.getAttribute('r:embed') || '';
+
+        if (rId) {
+          imageRefs.push({ rId, cx, cy });
+          // Placeholder — the importer will fill in the actual URL after upload
+          inlines.push({
+            text: '\uFFFC',
+            style: { ...style, image: { src: `__pending__:${rId}`, width: 0, height: 0 } },
+          });
+        }
+      }
+      continue;
+    }
+
+    // Regular text
+    const textEls = r.getElementsByTagNameNS(W, 't');
+    let text = '';
+    for (let j = 0; j < textEls.length; j++) {
+      text += textEls[j].textContent || '';
+    }
+
+    // Tab and break elements
+    const tabs = r.getElementsByTagNameNS(W, 'tab');
+    if (tabs.length > 0) text += '\t';
+    const brs = r.getElementsByTagNameNS(W, 'br');
+    if (brs.length > 0) text += '\n';
+
+    if (text) {
+      inlines.push({ text, style });
+    }
+  }
+
+  // Ensure at least one inline (empty paragraphs)
+  if (inlines.length === 0) {
+    inlines.push({ text: '', style: {} });
+  }
+
+  return { inlines, blockStyle, blockType, headingLevel, imageRefs };
+}
+
+/**
+ * Parse <w:sectPr> into PageSetup.
+ */
+export function parsePageSetup(sectPr: Element): PageSetup {
+  const pgSz = sectPr.getElementsByTagNameNS(W, 'pgSz')[0];
+  const pgMar = sectPr.getElementsByTagNameNS(W, 'pgMar')[0];
+
+  let width = 816; // Letter default
+  let height = 1056;
+  let orientation: 'portrait' | 'landscape' = 'portrait';
+
+  if (pgSz) {
+    const w = pgSz.getAttributeNS(W, 'w') || pgSz.getAttribute('w:w');
+    const h = pgSz.getAttributeNS(W, 'h') || pgSz.getAttribute('w:h');
+    const orient = pgSz.getAttributeNS(W, 'orient') || pgSz.getAttribute('w:orient');
+    if (w) width = Math.round(twipsToPx(parseInt(w, 10)));
+    if (h) height = Math.round(twipsToPx(parseInt(h, 10)));
+    if (orient === 'landscape') orientation = 'landscape';
+  }
+
+  const margins: PageMargins = { top: 96, bottom: 96, left: 96, right: 96 };
+  if (pgMar) {
+    const getMargin = (name: string) => {
+      const val = pgMar.getAttributeNS(W, name) || pgMar.getAttribute(`w:${name}`);
+      return val ? Math.round(twipsToPx(parseInt(val, 10))) : undefined;
+    };
+    const t = getMargin('top');     if (t !== undefined) margins.top = t;
+    const b = getMargin('bottom');  if (b !== undefined) margins.bottom = b;
+    const l = getMargin('left');    if (l !== undefined) margins.left = l;
+    const r = getMargin('right');   if (r !== undefined) margins.right = r;
+  }
+
+  const paperSize: PaperSize = { name: 'Custom', width, height };
+
+  return { paperSize, orientation, margins };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm test -- --run test/import/docx-parser.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/import/docx-parser.ts packages/docs/test/import/docx-parser.test.ts
+git commit -m "Add DOCX XML parser utilities for paragraphs, rels, and page setup"
+```
+
+---
+
+### Task 10: Implement DocxImporter main entry point
+
+**Files:**
+- Create: `packages/docs/src/import/docx-importer.ts`
+- Test: `packages/docs/test/import/docx-importer.test.ts`
+- Dependencies: `jszip` (add to packages/docs)
+
+- [ ] **Step 1: Install JSZip**
+
+Run: `cd packages/docs && pnpm add jszip`
+
+- [ ] **Step 2: Write the failing test**
+
+Create `packages/docs/test/import/docx-importer.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { DocxImporter } from '../../src/import/docx-importer.js';
+import JSZip from 'jszip';
+
+/**
+ * Helper to create a minimal .docx zip in memory.
+ */
+async function createMinimalDocx(bodyXml: string): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  const docXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <w:body>${bodyXml}</w:body>
+    </w:document>`;
+  zip.file('word/document.xml', docXml);
+  zip.file('word/_rels/document.xml.rels', `<?xml version="1.0" encoding="UTF-8"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    </Relationships>`);
+  zip.file('[Content_Types].xml', `<?xml version="1.0" encoding="UTF-8"?>
+    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    </Types>`);
+  return zip.generateAsync({ type: 'arraybuffer' });
+}
+
+describe('DocxImporter', () => {
+  it('should import a simple paragraph', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:p><w:r><w:t>Hello World</w:t></w:r></w:p>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks).toHaveLength(1);
+    expect(doc.blocks[0].type).toBe('paragraph');
+    expect(doc.blocks[0].inlines[0].text).toBe('Hello World');
+  });
+
+  it('should import multiple paragraphs', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:p><w:r><w:t>First</w:t></w:r></w:p>
+      <w:p><w:r><w:t>Second</w:t></w:r></w:p>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks).toHaveLength(2);
+    expect(doc.blocks[0].inlines[0].text).toBe('First');
+    expect(doc.blocks[1].inlines[0].text).toBe('Second');
+  });
+
+  it('should import styled text runs', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:p>
+        <w:r><w:t>Normal </w:t></w:r>
+        <w:r><w:rPr><w:b/></w:rPr><w:t>Bold</w:t></w:r>
+      </w:p>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks[0].inlines).toHaveLength(2);
+    expect(doc.blocks[0].inlines[1].style.bold).toBe(true);
+  });
+
+  it('should import a simple table', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:tbl>
+        <w:tblGrid><w:gridCol w:w="4000"/><w:gridCol w:w="4000"/></w:tblGrid>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>A1</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>B1</w:t></w:r></w:p></w:tc>
+        </w:tr>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>A2</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>B2</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks).toHaveLength(1);
+    expect(doc.blocks[0].type).toBe('table');
+    expect(doc.blocks[0].tableData!.rows).toHaveLength(2);
+    expect(doc.blocks[0].tableData!.rows[0].cells).toHaveLength(2);
+    expect(doc.blocks[0].tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('A1');
+  });
+
+  it('should import page setup from sectPr', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:p><w:r><w:t>Content</w:t></w:r></w:p>
+      <w:sectPr>
+        <w:pgSz w:w="11906" w:h="16838"/>
+        <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/>
+      </w:sectPr>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.pageSetup).toBeDefined();
+    expect(doc.pageSetup!.paperSize.width).toBeCloseTo(794, 0);
+    expect(doc.pageSetup!.margins.top).toBeCloseTo(96, 0);
+  });
+
+  it('should flatten nested tables to text', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:tbl>
+        <w:tblGrid><w:gridCol w:w="8000"/></w:tblGrid>
+        <w:tr>
+          <w:tc>
+            <w:tbl>
+              <w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>
+              <w:tr><w:tc><w:p><w:r><w:t>Nested</w:t></w:r></w:p></w:tc></w:tr>
+            </w:tbl>
+          </w:tc>
+        </w:tr>
+      </w:tbl>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks[0].type).toBe('table');
+    // Nested table is flattened — cell should contain a paragraph with "Nested"
+    const cellBlocks = doc.blocks[0].tableData!.rows[0].cells[0].blocks;
+    const allText = cellBlocks.map(b => b.inlines.map(i => i.text).join('')).join('');
+    expect(allText).toContain('Nested');
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm test -- --run test/import/docx-importer.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 4: Implement DocxImporter**
+
+Create `packages/docs/src/import/docx-importer.ts`:
+
+```typescript
+import JSZip from 'jszip';
+import type { Document, Block, Inline, TableData, TableRow, TableCell, HeaderFooter } from '../model/types.js';
+import { generateBlockId, DEFAULT_BLOCK_STYLE, DEFAULT_CELL_STYLE, DEFAULT_HEADER_MARGIN_FROM_EDGE } from '../model/types.js';
+import { parseRelationships, parseParagraph, parsePageSetup, type RelEntry } from './docx-parser.js';
+import { mapTableCellProperties } from './docx-style-map.js';
+import { emusToPx, twipsToPx } from './units.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+
+export type ImageUploader = (blob: Blob, filename: string) => Promise<string>;
+
+export class DocxImporter {
+  /**
+   * Import a .docx ArrayBuffer into a Document.
+   *
+   * @param buffer - The .docx file as an ArrayBuffer.
+   * @param imageUploader - Optional callback to upload images. If not provided,
+   *   images are skipped.
+   */
+  static async import(
+    buffer: ArrayBuffer,
+    imageUploader?: ImageUploader,
+  ): Promise<Document> {
+    const zip = await JSZip.loadAsync(buffer);
+
+    // Parse relationships
+    const relsXml = await zip.file('word/_rels/document.xml.rels')?.async('string');
+    const rels = relsXml ? parseRelationships(relsXml) : new Map<string, RelEntry>();
+
+    // Parse document.xml
+    const docXml = await zip.file('word/document.xml')?.async('string');
+    if (!docXml) throw new Error('Invalid .docx: missing word/document.xml');
+    const xmlDoc = new DOMParser().parseFromString(docXml, 'text/xml');
+    const body = xmlDoc.getElementsByTagNameNS(W, 'body')[0];
+    if (!body) throw new Error('Invalid .docx: missing w:body');
+
+    // Upload images
+    const imageUrls = new Map<string, { src: string; width: number; height: number }>();
+    if (imageUploader) {
+      await DocxImporter.uploadImages(zip, rels, imageUploader, imageUrls);
+    }
+
+    // Walk body children
+    const blocks: Block[] = [];
+    let pageSetup = undefined;
+    for (let i = 0; i < body.childNodes.length; i++) {
+      const node = body.childNodes[i];
+      if (node.nodeType !== 1) continue;
+      const el = node as Element;
+      if (el.localName === 'p') {
+        blocks.push(DocxImporter.convertParagraph(el, imageUrls));
+      } else if (el.localName === 'tbl') {
+        blocks.push(DocxImporter.convertTable(el, imageUrls, false));
+      } else if (el.localName === 'sectPr') {
+        pageSetup = parsePageSetup(el);
+      }
+    }
+
+    // Parse headers and footers
+    const header = await DocxImporter.parseHeaderFooter(zip, rels, 'header', imageUrls);
+    const footer = await DocxImporter.parseHeaderFooter(zip, rels, 'footer', imageUrls);
+
+    return { blocks, pageSetup, header, footer };
+  }
+
+  private static convertParagraph(
+    pEl: Element,
+    imageUrls: Map<string, { src: string; width: number; height: number }>,
+  ): Block {
+    const { inlines, blockStyle, blockType, headingLevel } = parseParagraph(pEl);
+
+    // Resolve pending image references
+    const resolvedInlines = inlines.map((inline) => {
+      if (inline.style.image?.src.startsWith('__pending__:')) {
+        const rId = inline.style.image.src.replace('__pending__:', '');
+        const img = imageUrls.get(rId);
+        if (img) {
+          return {
+            text: inline.text,
+            style: { ...inline.style, image: img },
+          };
+        }
+      }
+      return inline;
+    });
+
+    const block: Block = {
+      id: generateBlockId(),
+      type: blockType as Block['type'],
+      inlines: resolvedInlines,
+      style: blockStyle,
+    };
+    if (headingLevel) block.headingLevel = headingLevel as Block['headingLevel'];
+    return block;
+  }
+
+  private static convertTable(
+    tblEl: Element,
+    imageUrls: Map<string, { src: string; width: number; height: number }>,
+    isNested: boolean,
+  ): Block {
+    // If nested, flatten to a paragraph with text content
+    if (isNested) {
+      const texts: string[] = [];
+      const trs = tblEl.getElementsByTagNameNS(W, 'tr');
+      for (let r = 0; r < trs.length; r++) {
+        const rowTexts: string[] = [];
+        const tcs = trs[r].getElementsByTagNameNS(W, 'tc');
+        for (let c = 0; c < tcs.length; c++) {
+          const cellText = DocxImporter.extractText(tcs[c]);
+          rowTexts.push(cellText);
+        }
+        texts.push(rowTexts.join(' | '));
+      }
+      return {
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [{ text: texts.join('\n'), style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      };
+    }
+
+    // Parse grid columns for widths
+    const gridCols = tblEl.getElementsByTagNameNS(W, 'gridCol');
+    const colWidthsRaw: number[] = [];
+    for (let i = 0; i < gridCols.length; i++) {
+      const w = gridCols[i].getAttributeNS(W, 'w') || gridCols[i].getAttribute('w:w');
+      colWidthsRaw.push(w ? parseInt(w, 10) : 1);
+    }
+    const totalWidth = colWidthsRaw.reduce((a, b) => a + b, 0) || 1;
+    const columnWidths = colWidthsRaw.map((w) => w / totalWidth);
+
+    // Parse rows — only direct child <w:tr> elements
+    const rows: TableRow[] = [];
+    const vMergeTracker: Map<number, { startRow: number; count: number }> = new Map();
+
+    for (let i = 0; i < tblEl.childNodes.length; i++) {
+      const node = tblEl.childNodes[i];
+      if (node.nodeType !== 1 || (node as Element).localName !== 'tr') continue;
+      const trEl = node as Element;
+
+      const cells: TableCell[] = [];
+      let colIdx = 0;
+      for (let j = 0; j < trEl.childNodes.length; j++) {
+        const tcNode = trEl.childNodes[j];
+        if (tcNode.nodeType !== 1 || (tcNode as Element).localName !== 'tc') continue;
+        const tcEl = tcNode as Element;
+
+        // Parse cell properties
+        const tcPr = tcEl.getElementsByTagNameNS(W, 'tcPr')[0];
+        let colSpan = 1;
+        let vMerge: 'restart' | 'continue' | undefined;
+        let cellProps: ReturnType<typeof mapTableCellProperties> = {};
+        if (tcPr) {
+          cellProps = mapTableCellProperties(tcPr);
+          if (cellProps.colSpan) colSpan = cellProps.colSpan;
+          vMerge = cellProps.vMerge;
+        }
+
+        // Handle vertical merge tracking
+        if (vMerge === 'restart') {
+          vMergeTracker.set(colIdx, { startRow: rows.length, count: 1 });
+        } else if (vMerge === 'continue') {
+          const tracker = vMergeTracker.get(colIdx);
+          if (tracker) tracker.count++;
+          // Mark as covered cell
+          cells.push({
+            blocks: [{ id: generateBlockId(), type: 'paragraph', inlines: [{ text: '', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }],
+            style: { ...DEFAULT_CELL_STYLE },
+            colSpan: 0, // Covered
+          });
+          colIdx += colSpan;
+          continue;
+        }
+
+        // Parse cell content blocks
+        const cellBlocks: Block[] = [];
+        for (let k = 0; k < tcEl.childNodes.length; k++) {
+          const childNode = tcEl.childNodes[k];
+          if (childNode.nodeType !== 1) continue;
+          const childEl = childNode as Element;
+          if (childEl.localName === 'p') {
+            cellBlocks.push(DocxImporter.convertParagraph(childEl, imageUrls));
+          } else if (childEl.localName === 'tbl') {
+            // Nested table → flatten to text
+            cellBlocks.push(DocxImporter.convertTable(childEl, imageUrls, true));
+          }
+        }
+        if (cellBlocks.length === 0) {
+          cellBlocks.push({
+            id: generateBlockId(),
+            type: 'paragraph',
+            inlines: [{ text: '', style: {} }],
+            style: { ...DEFAULT_BLOCK_STYLE },
+          });
+        }
+
+        cells.push({
+          blocks: cellBlocks,
+          style: {
+            ...DEFAULT_CELL_STYLE,
+            backgroundColor: cellProps.backgroundColor,
+            borderTop: cellProps.borderTop,
+            borderBottom: cellProps.borderBottom,
+            borderLeft: cellProps.borderLeft,
+            borderRight: cellProps.borderRight,
+          },
+          colSpan: colSpan > 1 ? colSpan : undefined,
+        });
+        colIdx += colSpan;
+      }
+      rows.push({ cells });
+    }
+
+    // Resolve vMerge rowSpan values
+    for (const [colIdx, tracker] of vMergeTracker) {
+      if (tracker.count > 1 && rows[tracker.startRow]) {
+        const cell = rows[tracker.startRow].cells[colIdx];
+        if (cell) cell.rowSpan = tracker.count;
+      }
+    }
+
+    const tableData: TableData = { rows, columnWidths };
+
+    return {
+      id: generateBlockId(),
+      type: 'table',
+      inlines: [],
+      style: { ...DEFAULT_BLOCK_STYLE },
+      tableData,
+    };
+  }
+
+  private static extractText(el: Element): string {
+    const texts: string[] = [];
+    const tEls = el.getElementsByTagNameNS(W, 't');
+    for (let i = 0; i < tEls.length; i++) {
+      texts.push(tEls[i].textContent || '');
+    }
+    return texts.join('');
+  }
+
+  private static async uploadImages(
+    zip: JSZip,
+    rels: Map<string, RelEntry>,
+    uploader: ImageUploader,
+    imageUrls: Map<string, { src: string; width: number; height: number }>,
+  ): Promise<void> {
+    for (const [rId, rel] of rels) {
+      if (rel.type !== 'image') continue;
+      const path = `word/${rel.target}`;
+      const file = zip.file(path);
+      if (!file) continue;
+
+      const data = await file.async('blob');
+      const ext = rel.target.split('.').pop() || 'png';
+      const filename = `${rId}.${ext}`;
+      const url = await uploader(data, filename);
+
+      // We'll set dimensions later when resolving
+      imageUrls.set(rId, { src: url, width: 0, height: 0 });
+    }
+  }
+
+  private static async parseHeaderFooter(
+    zip: JSZip,
+    rels: Map<string, RelEntry>,
+    type: 'header' | 'footer',
+    imageUrls: Map<string, { src: string; width: number; height: number }>,
+  ): Promise<HeaderFooter | undefined> {
+    // Find the default (type 2, "default") header/footer relationship
+    let targetFile: string | undefined;
+    for (const [, rel] of rels) {
+      if (rel.type === type) {
+        targetFile = rel.target;
+        break;
+      }
+    }
+    if (!targetFile) return undefined;
+
+    const xml = await zip.file(`word/${targetFile}`)?.async('string');
+    if (!xml) return undefined;
+
+    const xmlDoc = new DOMParser().parseFromString(xml, 'text/xml');
+    const rootTag = type === 'header' ? 'hdr' : 'ftr';
+    const root = xmlDoc.getElementsByTagNameNS(W, rootTag)[0];
+    if (!root) return undefined;
+
+    const blocks: Block[] = [];
+    for (let i = 0; i < root.childNodes.length; i++) {
+      const node = root.childNodes[i];
+      if (node.nodeType !== 1) continue;
+      const el = node as Element;
+      if (el.localName === 'p') {
+        blocks.push(DocxImporter.convertParagraph(el, imageUrls));
+      }
+    }
+
+    if (blocks.length === 0) return undefined;
+
+    return { blocks, marginFromEdge: DEFAULT_HEADER_MARGIN_FROM_EDGE };
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm test -- --run test/import/docx-importer.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `pnpm verify:fast`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/docs/src/import/ packages/docs/test/import/ packages/docs/package.json pnpm-lock.yaml
+git commit -m $'Implement DocxImporter for .docx to Document conversion\n\nSupports paragraphs, styled text, tables with cell merge,\npage setup, headers/footers, and nested table flattening.\nImages are uploaded via a pluggable callback.'
+```
+
+---
+
+## Phase 3 — DOCX Export
+
+### Task 11: Implement DOCX export style mapping (Docs → OOXML)
+
+**Files:**
+- Create: `packages/docs/src/export/docx-style-map.ts`
+- Test: `packages/docs/test/export/docx-style-map.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/docs/test/export/docx-style-map.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { buildRunPropertiesXml, buildParagraphPropertiesXml } from '../../src/export/docx-style-map.js';
+
+describe('buildRunPropertiesXml', () => {
+  it('should generate bold tag', () => {
+    const xml = buildRunPropertiesXml({ bold: true });
+    expect(xml).toContain('<w:b/>');
+  });
+
+  it('should generate font size in half-points', () => {
+    const xml = buildRunPropertiesXml({ fontSize: 12 });
+    expect(xml).toContain('<w:sz w:val="24"/>');
+    expect(xml).toContain('<w:szCs w:val="24"/>');
+  });
+
+  it('should generate font family', () => {
+    const xml = buildRunPropertiesXml({ fontFamily: 'Arial' });
+    expect(xml).toContain('w:ascii="Arial"');
+  });
+
+  it('should generate color', () => {
+    const xml = buildRunPropertiesXml({ color: '#FF0000' });
+    expect(xml).toContain('<w:color w:val="FF0000"/>');
+  });
+
+  it('should return empty string for empty style', () => {
+    const xml = buildRunPropertiesXml({});
+    expect(xml).toBe('');
+  });
+});
+
+describe('buildParagraphPropertiesXml', () => {
+  it('should generate center alignment', () => {
+    const xml = buildParagraphPropertiesXml({ alignment: 'center', lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 });
+    expect(xml).toContain('<w:jc w:val="center"/>');
+  });
+
+  it('should generate justify as "both"', () => {
+    const xml = buildParagraphPropertiesXml({ alignment: 'justify', lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 });
+    expect(xml).toContain('<w:jc w:val="both"/>');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm test -- --run test/export/docx-style-map.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement export style mapping**
+
+Create `packages/docs/src/export/docx-style-map.ts`:
+
+```typescript
+import type { InlineStyle, BlockStyle } from '../model/types.js';
+import { pointsToHalfPoints, pxToTwips } from '../import/units.js';
+
+/**
+ * Build <w:rPr>...</w:rPr> XML from InlineStyle.
+ * Returns empty string if no properties to set.
+ */
+export function buildRunPropertiesXml(style: InlineStyle): string {
+  const parts: string[] = [];
+
+  if (style.fontFamily) {
+    parts.push(`<w:rFonts w:ascii="${style.fontFamily}" w:hAnsi="${style.fontFamily}" w:eastAsia="${style.fontFamily}"/>`);
+  }
+  if (style.bold) parts.push('<w:b/>');
+  if (style.italic) parts.push('<w:i/>');
+  if (style.underline) parts.push('<w:u w:val="single"/>');
+  if (style.strikethrough) parts.push('<w:strike/>');
+  if (style.fontSize) {
+    const hp = pointsToHalfPoints(style.fontSize);
+    parts.push(`<w:sz w:val="${hp}"/>`);
+    parts.push(`<w:szCs w:val="${hp}"/>`);
+  }
+  if (style.color) {
+    const hex = style.color.replace('#', '');
+    parts.push(`<w:color w:val="${hex}"/>`);
+  }
+  if (style.backgroundColor) {
+    const hex = style.backgroundColor.replace('#', '');
+    parts.push(`<w:shd w:val="clear" w:color="auto" w:fill="${hex}"/>`);
+  }
+  if (style.superscript) parts.push('<w:vertAlign w:val="superscript"/>');
+  if (style.subscript) parts.push('<w:vertAlign w:val="subscript"/>');
+
+  if (parts.length === 0) return '';
+  return `<w:rPr>${parts.join('')}</w:rPr>`;
+}
+
+/**
+ * Build <w:pPr>...</w:pPr> XML from BlockStyle.
+ */
+export function buildParagraphPropertiesXml(
+  style: BlockStyle,
+  headingLevel?: number,
+): string {
+  const parts: string[] = [];
+
+  if (headingLevel) {
+    parts.push(`<w:pStyle w:val="Heading${headingLevel}"/>`);
+  }
+
+  const align = style.alignment === 'justify' ? 'both' : style.alignment;
+  if (align !== 'left') {
+    parts.push(`<w:jc w:val="${align}"/>`);
+  }
+
+  const spacingParts: string[] = [];
+  if (style.marginTop > 0) spacingParts.push(`w:before="${Math.round(pxToTwips(style.marginTop))}"`);
+  if (style.marginBottom > 0) spacingParts.push(`w:after="${Math.round(pxToTwips(style.marginBottom))}"`);
+  if (style.lineHeight !== 1.5) spacingParts.push(`w:line="${Math.round(style.lineHeight * 240)}"`);
+  if (spacingParts.length > 0) parts.push(`<w:spacing ${spacingParts.join(' ')}/>`);
+
+  const indParts: string[] = [];
+  if (style.textIndent > 0) indParts.push(`w:firstLine="${Math.round(pxToTwips(style.textIndent))}"`);
+  if (style.marginLeft > 0) indParts.push(`w:left="${Math.round(pxToTwips(style.marginLeft))}"`);
+  if (indParts.length > 0) parts.push(`<w:ind ${indParts.join(' ')}/>`);
+
+  if (parts.length === 0) return '';
+  return `<w:pPr>${parts.join('')}</w:pPr>`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm test -- --run test/export/docx-style-map.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/export/docx-style-map.ts packages/docs/test/export/docx-style-map.test.ts
+git commit -m "Add Docs-to-OOXML style mapping for export"
+```
+
+---
+
+### Task 12: Implement DocxExporter
+
+**Files:**
+- Create: `packages/docs/src/export/docx-exporter.ts`
+- Create: `packages/docs/src/export/docx-templates.ts`
+- Test: `packages/docs/test/export/docx-exporter.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/docs/test/export/docx-exporter.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { DocxExporter } from '../../src/export/docx-exporter.js';
+import { DocxImporter } from '../../src/import/docx-importer.js';
+import type { Document } from '../../src/model/types.js';
+import { DEFAULT_BLOCK_STYLE, DEFAULT_PAGE_SETUP, generateBlockId } from '../../src/model/types.js';
+
+describe('DocxExporter', () => {
+  it('should export a simple paragraph and re-import it', async () => {
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [{ text: 'Hello World', style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+
+    const blob = await DocxExporter.export(doc);
+    expect(blob.size).toBeGreaterThan(0);
+
+    // Re-import and verify round-trip
+    const buffer = await blob.arrayBuffer();
+    const reimported = await DocxImporter.import(buffer);
+    expect(reimported.blocks).toHaveLength(1);
+    expect(reimported.blocks[0].inlines[0].text).toBe('Hello World');
+  });
+
+  it('should export styled text', async () => {
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [
+          { text: 'Normal ', style: {} },
+          { text: 'Bold', style: { bold: true } },
+        ],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+
+    const blob = await DocxExporter.export(doc);
+    const buffer = await blob.arrayBuffer();
+    const reimported = await DocxImporter.import(buffer);
+    expect(reimported.blocks[0].inlines).toHaveLength(2);
+    expect(reimported.blocks[0].inlines[1].style.bold).toBe(true);
+  });
+
+  it('should export a table', async () => {
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'table',
+        inlines: [],
+        style: { ...DEFAULT_BLOCK_STYLE },
+        tableData: {
+          rows: [{
+            cells: [
+              { blocks: [{ id: generateBlockId(), type: 'paragraph', inlines: [{ text: 'A1', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }], style: {} },
+              { blocks: [{ id: generateBlockId(), type: 'paragraph', inlines: [{ text: 'B1', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }], style: {} },
+            ],
+          }],
+          columnWidths: [0.5, 0.5],
+        },
+      }],
+    };
+
+    const blob = await DocxExporter.export(doc);
+    const buffer = await blob.arrayBuffer();
+    const reimported = await DocxImporter.import(buffer);
+    expect(reimported.blocks[0].type).toBe('table');
+    expect(reimported.blocks[0].tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('A1');
+  });
+
+  it('should produce a valid .docx zip', async () => {
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [{ text: 'Test', style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+
+    const blob = await DocxExporter.export(doc);
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    expect(zip.file('word/document.xml')).not.toBeNull();
+    expect(zip.file('[Content_Types].xml')).not.toBeNull();
+    expect(zip.file('_rels/.rels')).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm test -- --run test/export/docx-exporter.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create XML template strings**
+
+Create `packages/docs/src/export/docx-templates.ts`:
+
+```typescript
+/**
+ * Static OOXML boilerplate templates for .docx export.
+ */
+
+export const CONTENT_TYPES = (extras: string) => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Default Extension="jpg" ContentType="image/jpeg"/>
+  <Default Extension="jpeg" ContentType="image/jpeg"/>
+  <Default Extension="gif" ContentType="image/gif"/>
+  <Default Extension="webp" ContentType="image/webp"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+${extras}</Types>`;
+
+export const ROOT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+export const STYLES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:styleId="Normal" w:default="1">
+    <w:name w:val="Normal"/>
+    <w:rPr><w:rFonts w:ascii="Arial" w:hAnsi="Arial"/><w:sz w:val="22"/></w:rPr>
+  </w:style>
+</w:styles>`;
+
+export const DOC_RELS = (extras: string) => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+${extras}</Relationships>`;
+```
+
+- [ ] **Step 4: Implement DocxExporter**
+
+Create `packages/docs/src/export/docx-exporter.ts`:
+
+```typescript
+import JSZip from 'jszip';
+import type { Document, Block, Inline, TableData, PageSetup, HeaderFooter } from '../model/types.js';
+import { DEFAULT_PAGE_SETUP } from '../model/types.js';
+import { buildRunPropertiesXml, buildParagraphPropertiesXml } from './docx-style-map.js';
+import { pxToTwips, pxToEmus, pointsToHalfPoints } from '../import/units.js';
+import { CONTENT_TYPES, ROOT_RELS, STYLES, DOC_RELS } from './docx-templates.js';
+
+export type ImageFetcher = (url: string) => Promise<Blob>;
+
+export class DocxExporter {
+  /**
+   * Export a Document to a .docx Blob.
+   */
+  static async export(
+    doc: Document,
+    imageFetcher?: ImageFetcher,
+  ): Promise<Blob> {
+    const zip = new JSZip();
+    const imageEntries: Array<{ rId: string; path: string; ext: string }> = [];
+    let rIdCounter = 10; // Start after reserved IDs
+
+    // Collect and fetch images
+    if (imageFetcher) {
+      for (const block of doc.blocks) {
+        await DocxExporter.collectImages(block, imageFetcher, zip, imageEntries, () => `rId${rIdCounter++}`);
+      }
+    }
+
+    // Build header/footer
+    const hfRels: string[] = [];
+    const hfContentTypes: string[] = [];
+    let headerRId: string | undefined;
+    let footerRId: string | undefined;
+
+    if (doc.header && doc.header.blocks.length > 0) {
+      headerRId = `rId${rIdCounter++}`;
+      const headerXml = DocxExporter.buildHeaderFooterXml(doc.header, 'header');
+      zip.file('word/header1.xml', headerXml);
+      hfRels.push(`  <Relationship Id="${headerRId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>`);
+      hfContentTypes.push(`  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>`);
+    }
+    if (doc.footer && doc.footer.blocks.length > 0) {
+      footerRId = `rId${rIdCounter++}`;
+      const footerXml = DocxExporter.buildHeaderFooterXml(doc.footer, 'footer');
+      zip.file('word/footer1.xml', footerXml);
+      hfRels.push(`  <Relationship Id="${footerRId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer" Target="footer1.xml"/>`);
+      hfContentTypes.push(`  <Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>`);
+    }
+
+    // Build document.xml
+    const bodyXml = doc.blocks.map((b) => DocxExporter.blockToXml(b, imageEntries)).join('\n');
+    const sectPr = DocxExporter.buildSectPrXml(doc.pageSetup ?? DEFAULT_PAGE_SETUP, headerRId, footerRId);
+    const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+            xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+            xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+  <w:body>
+${bodyXml}
+    ${sectPr}
+  </w:body>
+</w:document>`;
+
+    zip.file('word/document.xml', documentXml);
+    zip.file('word/styles.xml', STYLES);
+
+    // Relationships
+    const imageRels = imageEntries.map((e) =>
+      `  <Relationship Id="${e.rId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="${e.path}"/>`
+    );
+    zip.file('word/_rels/document.xml.rels', DOC_RELS([...imageRels, ...hfRels].join('\n')));
+    zip.file('_rels/.rels', ROOT_RELS);
+    zip.file('[Content_Types].xml', CONTENT_TYPES(hfContentTypes.join('\n')));
+
+    return zip.generateAsync({ type: 'blob', mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
+  }
+
+  private static blockToXml(
+    block: Block,
+    imageEntries: Array<{ rId: string; path: string; ext: string }>,
+  ): string {
+    if (block.type === 'table' && block.tableData) {
+      return DocxExporter.tableToXml(block.tableData, imageEntries);
+    }
+    if (block.type === 'page-break') {
+      return `    <w:p><w:r><w:br w:type="page"/></w:r></w:p>`;
+    }
+    if (block.type === 'horizontal-rule') {
+      return `    <w:p><w:pPr><w:pBdr><w:bottom w:val="single" w:sz="6" w:space="1" w:color="auto"/></w:pBdr></w:pPr></w:p>`;
+    }
+
+    const pPr = buildParagraphPropertiesXml(
+      block.style,
+      block.type === 'heading' ? block.headingLevel : undefined,
+    );
+    const runs = block.inlines.map((inline) => DocxExporter.inlineToXml(inline, imageEntries)).join('');
+    return `    <w:p>${pPr}${runs}</w:p>`;
+  }
+
+  private static inlineToXml(
+    inline: Inline,
+    imageEntries: Array<{ rId: string; path: string; ext: string }>,
+  ): string {
+    // Image inline
+    if (inline.style.image) {
+      const entry = imageEntries.find((e) => e.rId && inline.style.image?.src.includes(e.path.replace('media/', '')));
+      if (entry) {
+        const cx = pxToEmus(inline.style.image.width);
+        const cy = pxToEmus(inline.style.image.height);
+        return `<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">
+          <wp:extent cx="${Math.round(cx)}" cy="${Math.round(cy)}"/>
+          <wp:docPr id="1" name="Image"/>
+          <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+            <pic:pic><pic:nvPicPr><pic:cNvPr id="1" name="Image"/><pic:cNvPicPr/></pic:nvPicPr>
+            <pic:blipFill><a:blip r:embed="${entry.rId}"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>
+            <pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${Math.round(cx)}" cy="${Math.round(cy)}"/></a:xfrm>
+            <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr></pic:pic>
+          </a:graphicData></a:graphic></wp:inline></w:drawing></w:r>`;
+      }
+    }
+
+    // Regular text run
+    const rPr = buildRunPropertiesXml(inline.style);
+    const escapedText = inline.text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    return `<w:r>${rPr}<w:t xml:space="preserve">${escapedText}</w:t></w:r>`;
+  }
+
+  private static tableToXml(
+    tableData: TableData,
+    imageEntries: Array<{ rId: string; path: string; ext: string }>,
+  ): string {
+    // Compute grid col widths in twips (assume total page width ~9000 twips)
+    const totalTwips = 9000;
+    const gridCols = tableData.columnWidths
+      .map((w) => `<w:gridCol w:w="${Math.round(w * totalTwips)}"/>`)
+      .join('');
+
+    const rows = tableData.rows.map((row) => {
+      const cells = row.cells.map((cell) => {
+        if (cell.colSpan === 0) {
+          // Covered cell (vMerge continue)
+          return `<w:tc><w:tcPr><w:vMerge/></w:tcPr><w:p/></w:tc>`;
+        }
+
+        const tcPrParts: string[] = [];
+        if (cell.colSpan && cell.colSpan > 1) tcPrParts.push(`<w:gridSpan w:val="${cell.colSpan}"/>`);
+        if (cell.rowSpan && cell.rowSpan > 1) tcPrParts.push(`<w:vMerge w:val="restart"/>`);
+        if (cell.style.backgroundColor) {
+          const hex = cell.style.backgroundColor.replace('#', '');
+          tcPrParts.push(`<w:shd w:val="clear" w:color="auto" w:fill="${hex}"/>`);
+        }
+        const tcPr = tcPrParts.length > 0 ? `<w:tcPr>${tcPrParts.join('')}</w:tcPr>` : '';
+
+        const cellContent = cell.blocks
+          .map((b) => DocxExporter.blockToXml(b, imageEntries))
+          .join('');
+        return `<w:tc>${tcPr}${cellContent || '<w:p/>'}</w:tc>`;
+      }).join('');
+      return `<w:tr>${cells}</w:tr>`;
+    }).join('');
+
+    return `    <w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr><w:tblGrid>${gridCols}</w:tblGrid>${rows}</w:tbl>`;
+  }
+
+  private static buildSectPrXml(
+    setup: PageSetup,
+    headerRId?: string,
+    footerRId?: string,
+  ): string {
+    const w = Math.round(pxToTwips(setup.paperSize.width));
+    const h = Math.round(pxToTwips(setup.paperSize.height));
+    const orient = setup.orientation === 'landscape' ? ' w:orient="landscape"' : '';
+    const pgSz = `<w:pgSz w:w="${w}" w:h="${h}"${orient}/>`;
+    const pgMar = `<w:pgMar w:top="${Math.round(pxToTwips(setup.margins.top))}" w:right="${Math.round(pxToTwips(setup.margins.right))}" w:bottom="${Math.round(pxToTwips(setup.margins.bottom))}" w:left="${Math.round(pxToTwips(setup.margins.left))}" w:header="720" w:footer="720"/>`;
+
+    const refs: string[] = [];
+    if (headerRId) refs.push(`<w:headerReference w:type="default" r:id="${headerRId}"/>`);
+    if (footerRId) refs.push(`<w:footerReference w:type="default" r:id="${footerRId}"/>`);
+
+    return `<w:sectPr>${refs.join('')}${pgSz}${pgMar}</w:sectPr>`;
+  }
+
+  private static buildHeaderFooterXml(hf: HeaderFooter, type: 'header' | 'footer'): string {
+    const tag = type === 'header' ? 'hdr' : 'ftr';
+    const blocks = hf.blocks.map((b) => DocxExporter.blockToXml(b, [])).join('\n');
+    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:${tag} xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+${blocks}
+</w:${tag}>`;
+  }
+
+  private static async collectImages(
+    block: Block,
+    fetcher: ImageFetcher,
+    zip: JSZip,
+    entries: Array<{ rId: string; path: string; ext: string }>,
+    nextRId: () => string,
+  ): Promise<void> {
+    for (const inline of block.inlines) {
+      if (inline.style.image) {
+        const blob = await fetcher(inline.style.image.src);
+        const ext = inline.style.image.src.split('.').pop() || 'png';
+        const rId = nextRId();
+        const path = `media/image_${rId}.${ext}`;
+        zip.file(`word/${path}`, blob);
+        entries.push({ rId, path, ext });
+      }
+    }
+    // Also check table cells
+    if (block.tableData) {
+      for (const row of block.tableData.rows) {
+        for (const cell of row.cells) {
+          for (const cellBlock of cell.blocks) {
+            await DocxExporter.collectImages(cellBlock, fetcher, zip, entries, nextRId);
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm test -- --run test/export/docx-exporter.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `pnpm verify:fast`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/docs/src/export/ packages/docs/test/export/
+git commit -m $'Implement DocxExporter for Document to .docx conversion\n\nSupports paragraphs, styled text, tables with cell merge,\npage setup, headers/footers, page breaks, and image embedding.'
+```
+
+---
+
+## Phase 4 — Frontend Integration
+
+### Task 13: Add Import DOCX button to frontend
+
+**Files:**
+- Modify: `packages/frontend/src/app/docs/docs-formatting-toolbar.tsx` (or appropriate toolbar/menu file)
+- Modify: `packages/frontend/src/app/docs/docs-detail.tsx`
+
+This task wires the DocxImporter into the frontend UI. The exact component locations depend on the current toolbar structure.
+
+- [ ] **Step 1: Add import handler function**
+
+Create an import handler that:
+1. Opens a file picker filtered to `.docx`
+2. Reads the file as `ArrayBuffer`
+3. Calls `DocxImporter.import(buffer, imageUploader)`
+4. Creates a new document via the backend API
+5. Sets the imported Document as content via `store.setDocument()`
+6. Navigates to the new document
+
+```typescript
+async function handleImportDocx() {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.docx';
+  input.onchange = async () => {
+    const file = input.files?.[0];
+    if (!file) return;
+    const buffer = await file.arrayBuffer();
+
+    const imageUploader = async (blob: Blob, filename: string): Promise<string> => {
+      const formData = new FormData();
+      formData.append('file', blob, filename);
+      const res = await fetch('/images', { method: 'POST', body: formData });
+      const { url } = await res.json();
+      return url;
+    };
+
+    const doc = await DocxImporter.import(buffer, imageUploader);
+    // Create document and load content
+    // ... (depends on existing document creation flow)
+  };
+  input.click();
+}
+```
+
+- [ ] **Step 2: Add export handler function**
+
+```typescript
+async function handleExportDocx(store: DocStore) {
+  const doc = store.getDocument();
+  const imageFetcher = async (url: string): Promise<Blob> => {
+    const res = await fetch(url);
+    return res.blob();
+  };
+  const blob = await DocxExporter.export(doc, imageFetcher);
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'document.docx';
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+```
+
+- [ ] **Step 3: Add UI buttons**
+
+Add "Import DOCX" and "Export as DOCX" buttons to the appropriate toolbar or menu. Follow existing button patterns in the codebase.
+
+- [ ] **Step 4: Run typecheck and verify**
+
+Run: `pnpm verify:fast`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/app/docs/
+git commit -m "Add Import DOCX and Export as DOCX buttons to docs editor"
+```
+
+---
+
+## Summary
+
+| Task | Phase | Description |
+|------|-------|-------------|
+| 1 | 1 | ImageData type + InlineStyle.image field |
+| 2 | 1 | Doc.insertImageInline method |
+| 3 | 1 | Yorkie image serialization |
+| 4 | 1 | Canvas image layout + rendering |
+| 5 | 1 | MinIO + ImageModule backend |
+| 6 | 1 | Font registry + web font loading |
+| 7 | 2 | Unit conversion utilities |
+| 8 | 2 | DOCX → Docs style mapping |
+| 9 | 2 | DOCX XML parser utilities |
+| 10 | 2 | DocxImporter main entry point |
+| 11 | 3 | Docs → OOXML style mapping |
+| 12 | 3 | DocxExporter main entry point |
+| 13 | 4 | Frontend import/export buttons |

--- a/docs/tasks/active/20260410-docx-import-export-todo.md
+++ b/docs/tasks/active/20260410-docx-import-export-todo.md
@@ -2508,7 +2508,7 @@ git commit -m $'Implement DocxExporter for Document to .docx conversion\n\nSuppo
 
 This task wires the DocxImporter into the frontend UI. The exact component locations depend on the current toolbar structure.
 
-- [ ] **Step 1: Add import handler function**
+- [x] **Step 1: Add import handler function**
 
 Create an import handler that:
 1. Opens a file picker filtered to `.docx`
@@ -2544,7 +2544,7 @@ async function handleImportDocx() {
 }
 ```
 
-- [ ] **Step 2: Add export handler function**
+- [x] **Step 2: Add export handler function**
 
 ```typescript
 async function handleExportDocx(store: DocStore) {
@@ -2562,16 +2562,16 @@ async function handleExportDocx(store: DocStore) {
 }
 ```
 
-- [ ] **Step 3: Add UI buttons**
+- [x] **Step 3: Add UI buttons**
 
 Add "Import DOCX" and "Export as DOCX" buttons to the appropriate toolbar or menu. Follow existing button patterns in the codebase.
 
-- [ ] **Step 4: Run typecheck and verify**
+- [x] **Step 4: Run typecheck and verify**
 
 Run: `pnpm verify:fast`
 Expected: PASS
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/frontend/src/app/docs/

--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
   "ignore": [
-    "scripts/**"
+    "scripts/**",
+    ".claude/**"
   ],
   "workspaces": {
     "packages/sheets": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,6 +26,7 @@
     "migrate:yorkie:cf-ranges": "tsx scripts/migrate-yorkie-cf-ranges.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1028.0",
     "@nestjs/common": "^11.1.0",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.0",
@@ -74,11 +75,11 @@
     "prisma": "^6.6.0",
     "source-map-support": "^0.5.21",
     "supertest": "^7.2.0",
-    "tsx": "^4.19.0",
     "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.20.0"
   },
@@ -101,7 +102,10 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "coverageReporters": ["text", "lcov"],
+    "coverageReporters": [
+      "text",
+      "lcov"
+    ],
     "testEnvironment": "node"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -62,6 +62,7 @@
     "@types/express-session": "^1.18.1",
     "@types/jest": "^29.5.14",
     "@types/ms": "^2.1.0",
+    "@types/multer": "^2.1.0",
     "@types/node": "^22.10.7",
     "@types/passport-jwt": "^4.0.1",
     "@types/pg": "^8.16.0",

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { WorkspaceModule } from './workspace/workspace.module';
 import { ApiKeyModule } from './api-key/api-key.module';
 import { YorkieModule } from './yorkie/yorkie.module';
 import { ApiV1Module } from './api/v1/api-v1.module';
+import { ImageModule } from './image/image.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { ApiV1Module } from './api/v1/api-v1.module';
     ApiKeyModule,
     YorkieModule,
     ApiV1Module,
+    ImageModule,
   ],
   controllers: [],
   providers: [],

--- a/packages/backend/src/image/image.config.ts
+++ b/packages/backend/src/image/image.config.ts
@@ -1,11 +1,17 @@
 import { registerAs } from '@nestjs/config';
 
+// MinIO defaults are only applied when NODE_ENV is not 'production'. In
+// production the fallbacks are empty strings so that misconfiguration fails
+// fast on bucket access instead of silently authenticating with predictable
+// credentials.
+const isDev = process.env.NODE_ENV !== 'production';
+
 export const imageConfig = registerAs('image', () => ({
-  endpoint: process.env.IMAGE_STORAGE_ENDPOINT || 'http://localhost:9000',
-  bucket: process.env.IMAGE_STORAGE_BUCKET || 'wafflebase-images',
-  region: process.env.IMAGE_STORAGE_REGION || 'us-east-1',
-  accessKey: process.env.IMAGE_STORAGE_ACCESS_KEY || 'minioadmin',
-  secretKey: process.env.IMAGE_STORAGE_SECRET_KEY || 'minioadmin',
+  endpoint: process.env.IMAGE_STORAGE_ENDPOINT || (isDev ? 'http://localhost:9000' : ''),
+  bucket: process.env.IMAGE_STORAGE_BUCKET || (isDev ? 'wafflebase-images' : ''),
+  region: process.env.IMAGE_STORAGE_REGION || (isDev ? 'us-east-1' : ''),
+  accessKey: process.env.IMAGE_STORAGE_ACCESS_KEY || (isDev ? 'minioadmin' : ''),
+  secretKey: process.env.IMAGE_STORAGE_SECRET_KEY || (isDev ? 'minioadmin' : ''),
   maxFileSizeBytes: 10 * 1024 * 1024, // 10 MB
   allowedMimeTypes: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'],
 }));

--- a/packages/backend/src/image/image.config.ts
+++ b/packages/backend/src/image/image.config.ts
@@ -1,0 +1,11 @@
+import { registerAs } from '@nestjs/config';
+
+export const imageConfig = registerAs('image', () => ({
+  endpoint: process.env.IMAGE_STORAGE_ENDPOINT || 'http://localhost:9000',
+  bucket: process.env.IMAGE_STORAGE_BUCKET || 'wafflebase-images',
+  region: process.env.IMAGE_STORAGE_REGION || 'us-east-1',
+  accessKey: process.env.IMAGE_STORAGE_ACCESS_KEY || 'minioadmin',
+  secretKey: process.env.IMAGE_STORAGE_SECRET_KEY || 'minioadmin',
+  maxFileSizeBytes: 10 * 1024 * 1024, // 10 MB
+  allowedMimeTypes: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'],
+}));

--- a/packages/backend/src/image/image.controller.ts
+++ b/packages/backend/src/image/image.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Param,
+  Res,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ImageService } from './image.service';
+import type { Response } from 'express';
+
+@Controller('images')
+export class ImageController {
+  constructor(private readonly imageService: ImageService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @UseInterceptors(FileInterceptor('file'))
+  async upload(
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<{ id: string; url: string }> {
+    if (!file) {
+      throw new BadRequestException('No file uploaded');
+    }
+    return this.imageService.upload(
+      file.buffer,
+      file.mimetype,
+      file.originalname,
+    );
+  }
+
+  @Get(':id')
+  async get(@Param('id') id: string, @Res() res: Response): Promise<void> {
+    const { body, contentType } = await this.imageService.getObject(id);
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    res.end(Buffer.from(body));
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  async delete(@Param('id') id: string): Promise<{ deleted: boolean }> {
+    await this.imageService.delete(id);
+    return { deleted: true };
+  }
+}

--- a/packages/backend/src/image/image.controller.ts
+++ b/packages/backend/src/image/image.controller.ts
@@ -15,6 +15,9 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ImageService } from './image.service';
 import type { Response } from 'express';
 
+const VALID_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(png|jpe?g|gif|webp)$/i;
+
 @Controller('images')
 export class ImageController {
   constructor(private readonly imageService: ImageService) {}
@@ -37,6 +40,9 @@ export class ImageController {
 
   @Get(':id')
   async get(@Param('id') id: string, @Res() res: Response): Promise<void> {
+    if (!VALID_ID_PATTERN.test(id)) {
+      throw new BadRequestException('Invalid image id');
+    }
     const { body, contentType } = await this.imageService.getObject(id);
     res.setHeader('Content-Type', contentType);
     res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
@@ -46,6 +52,9 @@ export class ImageController {
   @Delete(':id')
   @UseGuards(JwtAuthGuard)
   async delete(@Param('id') id: string): Promise<{ deleted: boolean }> {
+    if (!VALID_ID_PATTERN.test(id)) {
+      throw new BadRequestException('Invalid image id');
+    }
     await this.imageService.delete(id);
     return { deleted: true };
   }

--- a/packages/backend/src/image/image.module.ts
+++ b/packages/backend/src/image/image.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ImageController } from './image.controller';
+import { ImageService } from './image.service';
+import { imageConfig } from './image.config';
+
+@Module({
+  imports: [ConfigModule.forFeature(imageConfig)],
+  controllers: [ImageController],
+  providers: [ImageService],
+  exports: [ImageService],
+})
+export class ImageModule {}

--- a/packages/backend/src/image/image.service.ts
+++ b/packages/backend/src/image/image.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, BadRequestException, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  CreateBucketCommand,
+  HeadBucketCommand,
+} from '@aws-sdk/client-s3';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class ImageService implements OnModuleInit {
+  private s3: S3Client;
+  private bucket: string;
+  private maxFileSize: number;
+  private allowedMimeTypes: string[];
+
+  constructor(private config: ConfigService) {
+    const endpoint = this.config.get<string>('image.endpoint')!;
+    const region = this.config.get<string>('image.region')!;
+    const accessKey = this.config.get<string>('image.accessKey')!;
+    const secretKey = this.config.get<string>('image.secretKey')!;
+    this.bucket = this.config.get<string>('image.bucket')!;
+    this.maxFileSize = this.config.get<number>('image.maxFileSizeBytes')!;
+    this.allowedMimeTypes = this.config.get<string[]>('image.allowedMimeTypes')!;
+
+    this.s3 = new S3Client({
+      endpoint,
+      region,
+      credentials: { accessKeyId: accessKey, secretAccessKey: secretKey },
+      forcePathStyle: true, // Required for MinIO
+    });
+  }
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.s3.send(new HeadBucketCommand({ Bucket: this.bucket }));
+    } catch {
+      try {
+        await this.s3.send(new CreateBucketCommand({ Bucket: this.bucket }));
+      } catch (err) {
+        // Bucket creation may fail during tests or when storage is unreachable.
+        // Log and continue so the module can still boot.
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[ImageService] Failed to ensure bucket "${this.bucket}":`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+  }
+
+  async upload(
+    file: Buffer,
+    mimeType: string,
+    originalName: string,
+  ): Promise<{ id: string; url: string }> {
+    if (!this.allowedMimeTypes.includes(mimeType)) {
+      throw new BadRequestException(`Unsupported file type: ${mimeType}`);
+    }
+    if (file.length > this.maxFileSize) {
+      throw new BadRequestException(
+        `File too large (max ${this.maxFileSize / 1024 / 1024} MB)`,
+      );
+    }
+
+    const ext = originalName.split('.').pop() || 'bin';
+    const id = randomUUID();
+    const key = `${id}.${ext}`;
+
+    await this.s3.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: file,
+        ContentType: mimeType,
+      }),
+    );
+
+    return { id: key, url: `/images/${key}` };
+  }
+
+  async getObject(
+    id: string,
+  ): Promise<{ body: Uint8Array; contentType: string }> {
+    const response = await this.s3.send(
+      new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: id,
+      }),
+    );
+    const body = response.Body
+      ? await (response.Body as { transformToByteArray: () => Promise<Uint8Array> }).transformToByteArray()
+      : new Uint8Array();
+    return {
+      body,
+      contentType: response.ContentType || 'application/octet-stream',
+    };
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.s3.send(
+      new DeleteObjectCommand({
+        Bucket: this.bucket,
+        Key: id,
+      }),
+    );
+  }
+}

--- a/packages/backend/src/image/image.service.ts
+++ b/packages/backend/src/image/image.service.ts
@@ -10,6 +10,20 @@ import {
 } from '@aws-sdk/client-s3';
 import { randomUUID } from 'crypto';
 
+/**
+ * Map from validated MIME type → canonical storage extension. Deriving the
+ * extension from the MIME type (rather than the client-provided filename)
+ * ensures that the object key matches its true content, so retrieval
+ * validation (`VALID_ID_PATTERN`) does not reject correctly uploaded files
+ * when the client sent a mismatched filename (e.g. `foo.bmp` for a PNG).
+ */
+const MIME_TO_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
 @Injectable()
 export class ImageService implements OnModuleInit {
   private s3: S3Client;
@@ -55,7 +69,7 @@ export class ImageService implements OnModuleInit {
   async upload(
     file: Buffer,
     mimeType: string,
-    originalName: string,
+    _originalName: string,
   ): Promise<{ id: string; url: string }> {
     if (!this.allowedMimeTypes.includes(mimeType)) {
       throw new BadRequestException(`Unsupported file type: ${mimeType}`);
@@ -66,7 +80,14 @@ export class ImageService implements OnModuleInit {
       );
     }
 
-    const ext = originalName.split('.').pop() || 'bin';
+    // Derive the stored extension from the validated MIME type rather than
+    // the client-provided filename. A PNG sent as `foo.bmp` would otherwise
+    // be stored with a `.bmp` suffix and later fail ID-pattern validation
+    // on retrieval.
+    const ext = MIME_TO_EXT[mimeType];
+    if (!ext) {
+      throw new BadRequestException(`Unsupported file type: ${mimeType}`);
+    }
     const id = randomUUID();
     const key = `${id}.${ext}`;
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -34,5 +34,8 @@
     "vite": "^6.4.1",
     "vite-plugin-dts": "^4.5.3",
     "vitest": "^3.1.1"
+  },
+  "dependencies": {
+    "jszip": "^3.10.1"
   }
 }

--- a/packages/docs/src/export/docx-exporter.ts
+++ b/packages/docs/src/export/docx-exporter.ts
@@ -117,12 +117,12 @@ ${bodyXml}
         const cx = pxToEmus(inline.style.image.width);
         const cy = pxToEmus(inline.style.image.height);
         return `<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">
-          <wp:extent cx="${Math.round(cx)}" cy="${Math.round(cy)}"/>
+          <wp:extent cx="${cx}" cy="${cy}"/>
           <wp:docPr id="1" name="Image"/>
           <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
             <pic:pic><pic:nvPicPr><pic:cNvPr id="1" name="Image"/><pic:cNvPicPr/></pic:nvPicPr>
             <pic:blipFill><a:blip r:embed="${entry.rId}"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>
-            <pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${Math.round(cx)}" cy="${Math.round(cy)}"/></a:xfrm>
+            <pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${cx}" cy="${cy}"/></a:xfrm>
             <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr></pic:pic>
           </a:graphicData></a:graphic></wp:inline></w:drawing></w:r>`;
       }
@@ -179,11 +179,11 @@ ${bodyXml}
     headerRId?: string,
     footerRId?: string,
   ): string {
-    const w = Math.round(pxToTwips(setup.paperSize.width));
-    const h = Math.round(pxToTwips(setup.paperSize.height));
+    const w = pxToTwips(setup.paperSize.width);
+    const h = pxToTwips(setup.paperSize.height);
     const orient = setup.orientation === 'landscape' ? ' w:orient="landscape"' : '';
     const pgSz = `<w:pgSz w:w="${w}" w:h="${h}"${orient}/>`;
-    const pgMar = `<w:pgMar w:top="${Math.round(pxToTwips(setup.margins.top))}" w:right="${Math.round(pxToTwips(setup.margins.right))}" w:bottom="${Math.round(pxToTwips(setup.margins.bottom))}" w:left="${Math.round(pxToTwips(setup.margins.left))}" w:header="720" w:footer="720"/>`;
+    const pgMar = `<w:pgMar w:top="${pxToTwips(setup.margins.top)}" w:right="${pxToTwips(setup.margins.right)}" w:bottom="${pxToTwips(setup.margins.bottom)}" w:left="${pxToTwips(setup.margins.left)}" w:header="720" w:footer="720"/>`;
 
     const refs: string[] = [];
     if (headerRId) refs.push(`<w:headerReference w:type="default" r:id="${headerRId}"/>`);

--- a/packages/docs/src/export/docx-exporter.ts
+++ b/packages/docs/src/export/docx-exporter.ts
@@ -9,9 +9,27 @@ export type ImageFetcher = (url: string) => Promise<Blob>;
 
 type ImageEntry = { rId: string; path: string; ext: string; src: string };
 
+const MIME_TO_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/bmp': 'bmp',
+};
+
+function deriveExt(blob: Blob): string {
+  const mime = blob.type.toLowerCase();
+  return MIME_TO_EXT[mime] || 'bin';
+}
+
 export class DocxExporter {
   /**
    * Export a Document to a .docx Blob.
+   *
+   * @param doc - The document to export.
+   * @param imageFetcher - Required when the document contains image inlines.
+   *   Called once per unique image src to fetch the raw image Blob. If omitted
+   *   and the document contains image inlines, export will throw.
    */
   static async export(
     doc: Document,
@@ -150,10 +168,15 @@ ${bodyXml}
     // Image inline
     if (inline.style.image) {
       const entry = imageEntries.find((e) => e.src === inline.style.image!.src);
-      if (entry) {
-        const cx = pxToEmus(inline.style.image.width);
-        const cy = pxToEmus(inline.style.image.height);
-        return `<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">
+      if (!entry) {
+        throw new Error(
+          `DOCX export: image inline references ${inline.style.image.src} but no matching media entry was collected. ` +
+          `Did you forget to pass an imageFetcher to DocxExporter.export()?`,
+        );
+      }
+      const cx = pxToEmus(inline.style.image.width);
+      const cy = pxToEmus(inline.style.image.height);
+      return `<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">
           <wp:extent cx="${cx}" cy="${cy}"/>
           <wp:docPr id="1" name="Image"/>
           <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
@@ -162,7 +185,6 @@ ${bodyXml}
             <pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${cx}" cy="${cy}"/></a:xfrm>
             <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr></pic:pic>
           </a:graphicData></a:graphic></wp:inline></w:drawing></w:r>`;
-      }
     }
 
     // Regular text run
@@ -281,7 +303,7 @@ ${rels}
         // Skip if this src was already fetched for the same part (dedupe).
         if (entries.some((e) => e.src === src)) continue;
         const blob = await fetcher(src);
-        const ext = (src.split('.').pop() || 'png').toLowerCase().split('?')[0];
+        const ext = deriveExt(blob);
         const rId = nextRId();
         const path = nextMediaName(ext);
         zip.file(`word/${path}`, blob);

--- a/packages/docs/src/export/docx-exporter.ts
+++ b/packages/docs/src/export/docx-exporter.ts
@@ -18,39 +18,80 @@ export class DocxExporter {
     imageFetcher?: ImageFetcher,
   ): Promise<Blob> {
     const zip = new JSZip();
-    const imageEntries: ImageEntry[] = [];
-    let rIdCounter = 10; // Start after reserved IDs
+    // rIds are scoped per .rels file in OOXML, so give each part its own
+    // counter and entry list. Header and footer images live in separate
+    // `.rels` documents from the main document's image relationships.
+    // The media filename counter is shared across parts so that header
+    // and footer media do not collide with main-document media in the
+    // `word/media/` directory.
+    const docImageEntries: ImageEntry[] = [];
+    const headerImageEntries: ImageEntry[] = [];
+    const footerImageEntries: ImageEntry[] = [];
+    const makeCounter = () => {
+      let n = 10; // Start after reserved IDs
+      return () => `rId${n++}`;
+    };
+    const nextDocRId = makeCounter();
+    const nextHeaderRId = makeCounter();
+    const nextFooterRId = makeCounter();
+    let mediaSeq = 0;
+    const nextMediaName = (ext: string) => `media/image_${++mediaSeq}.${ext}`;
 
-    // Collect and fetch images
+    // Collect and fetch images referenced from the main document body.
     if (imageFetcher) {
       for (const block of doc.blocks) {
-        await DocxExporter.collectImages(block, imageFetcher, zip, imageEntries, () => `rId${rIdCounter++}`);
+        await DocxExporter.collectImages(block, imageFetcher, zip, docImageEntries, nextDocRId, nextMediaName);
       }
     }
 
-    // Build header/footer
-    const hfRels: string[] = [];
+    // Build header/footer. Each part's rels file uses rIds for the
+    // header/footer parts as well as any image relationships referenced
+    // from within that part.
     const hfContentTypes: string[] = [];
     let headerRId: string | undefined;
     let footerRId: string | undefined;
 
     if (doc.header && doc.header.blocks.length > 0) {
-      headerRId = `rId${rIdCounter++}`;
-      const headerXml = DocxExporter.buildHeaderFooterXml(doc.header, 'header');
+      headerRId = nextDocRId();
+      if (imageFetcher) {
+        for (const block of doc.header.blocks) {
+          await DocxExporter.collectImages(block, imageFetcher, zip, headerImageEntries, nextHeaderRId, nextMediaName);
+        }
+      }
+      const headerXml = DocxExporter.buildHeaderFooterXml(doc.header, 'header', headerImageEntries);
       zip.file('word/header1.xml', headerXml);
-      hfRels.push(`  <Relationship Id="${headerRId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>`);
+      zip.file('word/_rels/header1.xml.rels', DocxExporter.buildPartRelsXml(headerImageEntries));
       hfContentTypes.push(`  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>`);
     }
     if (doc.footer && doc.footer.blocks.length > 0) {
-      footerRId = `rId${rIdCounter++}`;
-      const footerXml = DocxExporter.buildHeaderFooterXml(doc.footer, 'footer');
+      footerRId = nextDocRId();
+      if (imageFetcher) {
+        for (const block of doc.footer.blocks) {
+          await DocxExporter.collectImages(block, imageFetcher, zip, footerImageEntries, nextFooterRId, nextMediaName);
+        }
+      }
+      const footerXml = DocxExporter.buildHeaderFooterXml(doc.footer, 'footer', footerImageEntries);
       zip.file('word/footer1.xml', footerXml);
-      hfRels.push(`  <Relationship Id="${footerRId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer" Target="footer1.xml"/>`);
+      zip.file('word/_rels/footer1.xml.rels', DocxExporter.buildPartRelsXml(footerImageEntries));
       hfContentTypes.push(`  <Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>`);
     }
 
+    // Assemble document.xml.rels: image relationships for the main body
+    // plus any header/footer part relationships (header/footer image
+    // rels live in their own .rels files, not here).
+    const docRels: string[] = [];
+    for (const e of docImageEntries) {
+      docRels.push(`  <Relationship Id="${e.rId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="${e.path}"/>`);
+    }
+    if (headerRId) {
+      docRels.push(`  <Relationship Id="${headerRId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>`);
+    }
+    if (footerRId) {
+      docRels.push(`  <Relationship Id="${footerRId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer" Target="footer1.xml"/>`);
+    }
+
     // Build document.xml
-    const bodyXml = doc.blocks.map((b) => DocxExporter.blockToXml(b, imageEntries)).join('\n');
+    const bodyXml = doc.blocks.map((b) => DocxExporter.blockToXml(b, docImageEntries)).join('\n');
     const sectPr = DocxExporter.buildSectPrXml(doc.pageSetup ?? DEFAULT_PAGE_SETUP, headerRId, footerRId);
     const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
@@ -67,11 +108,7 @@ ${bodyXml}
     zip.file('word/document.xml', documentXml);
     zip.file('word/styles.xml', STYLES);
 
-    // Relationships
-    const imageRels = imageEntries.map((e) =>
-      `  <Relationship Id="${e.rId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="${e.path}"/>`
-    );
-    zip.file('word/_rels/document.xml.rels', DOC_RELS([...imageRels, ...hfRels].join('\n')));
+    zip.file('word/_rels/document.xml.rels', DOC_RELS(docRels.join('\n')));
     zip.file('_rels/.rels', ROOT_RELS);
     zip.file('[Content_Types].xml', CONTENT_TYPES(hfContentTypes.join('\n')));
 
@@ -192,14 +229,42 @@ ${bodyXml}
     return `<w:sectPr>${refs.join('')}${pgSz}${pgMar}</w:sectPr>`;
   }
 
-  private static buildHeaderFooterXml(hf: HeaderFooter, type: 'header' | 'footer'): string {
+  private static buildHeaderFooterXml(
+    hf: HeaderFooter,
+    type: 'header' | 'footer',
+    imageEntries: ImageEntry[],
+  ): string {
     const tag = type === 'header' ? 'hdr' : 'ftr';
-    const blocks = hf.blocks.map((b) => DocxExporter.blockToXml(b, [])).join('\n');
+    const blocks = hf.blocks.map((b) => DocxExporter.blockToXml(b, imageEntries)).join('\n');
+    // Include the drawing-related namespaces so that any embedded
+    // <w:drawing> emitted by inlineToXml resolves correctly.
     return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:${tag} xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
-          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+          xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+          xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
 ${blocks}
 </w:${tag}>`;
+  }
+
+  /**
+   * Build a part-scoped .rels file containing the given image
+   * relationships. Used for `word/_rels/header1.xml.rels` and
+   * `word/_rels/footer1.xml.rels` so that images referenced from header
+   * or footer parts resolve correctly when opened in Word.
+   */
+  private static buildPartRelsXml(imageEntries: ImageEntry[]): string {
+    const rels = imageEntries
+      .map(
+        (e) =>
+          `  <Relationship Id="${e.rId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="${e.path}"/>`,
+      )
+      .join('\n');
+    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+${rels}
+</Relationships>`;
   }
 
   private static async collectImages(
@@ -208,16 +273,17 @@ ${blocks}
     zip: JSZip,
     entries: ImageEntry[],
     nextRId: () => string,
+    nextMediaName: (ext: string) => string,
   ): Promise<void> {
     for (const inline of block.inlines) {
       if (inline.style.image) {
         const src = inline.style.image.src;
-        // Skip if this src was already fetched (dedupe).
+        // Skip if this src was already fetched for the same part (dedupe).
         if (entries.some((e) => e.src === src)) continue;
         const blob = await fetcher(src);
         const ext = (src.split('.').pop() || 'png').toLowerCase().split('?')[0];
         const rId = nextRId();
-        const path = `media/image_${rId}.${ext}`;
+        const path = nextMediaName(ext);
         zip.file(`word/${path}`, blob);
         entries.push({ rId, path, ext, src });
       }
@@ -227,7 +293,7 @@ ${blocks}
       for (const row of block.tableData.rows) {
         for (const cell of row.cells) {
           for (const cellBlock of cell.blocks) {
-            await DocxExporter.collectImages(cellBlock, fetcher, zip, entries, nextRId);
+            await DocxExporter.collectImages(cellBlock, fetcher, zip, entries, nextRId, nextMediaName);
           }
         }
       }

--- a/packages/docs/src/export/docx-exporter.ts
+++ b/packages/docs/src/export/docx-exporter.ts
@@ -1,0 +1,236 @@
+import JSZip from 'jszip';
+import type { Document, Block, Inline, TableData, PageSetup, HeaderFooter } from '../model/types.js';
+import { DEFAULT_PAGE_SETUP } from '../model/types.js';
+import { buildRunPropertiesXml, buildParagraphPropertiesXml } from './docx-style-map.js';
+import { pxToTwips, pxToEmus } from '../import/units.js';
+import { CONTENT_TYPES, ROOT_RELS, STYLES, DOC_RELS } from './docx-templates.js';
+
+export type ImageFetcher = (url: string) => Promise<Blob>;
+
+type ImageEntry = { rId: string; path: string; ext: string; src: string };
+
+export class DocxExporter {
+  /**
+   * Export a Document to a .docx Blob.
+   */
+  static async export(
+    doc: Document,
+    imageFetcher?: ImageFetcher,
+  ): Promise<Blob> {
+    const zip = new JSZip();
+    const imageEntries: ImageEntry[] = [];
+    let rIdCounter = 10; // Start after reserved IDs
+
+    // Collect and fetch images
+    if (imageFetcher) {
+      for (const block of doc.blocks) {
+        await DocxExporter.collectImages(block, imageFetcher, zip, imageEntries, () => `rId${rIdCounter++}`);
+      }
+    }
+
+    // Build header/footer
+    const hfRels: string[] = [];
+    const hfContentTypes: string[] = [];
+    let headerRId: string | undefined;
+    let footerRId: string | undefined;
+
+    if (doc.header && doc.header.blocks.length > 0) {
+      headerRId = `rId${rIdCounter++}`;
+      const headerXml = DocxExporter.buildHeaderFooterXml(doc.header, 'header');
+      zip.file('word/header1.xml', headerXml);
+      hfRels.push(`  <Relationship Id="${headerRId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>`);
+      hfContentTypes.push(`  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>`);
+    }
+    if (doc.footer && doc.footer.blocks.length > 0) {
+      footerRId = `rId${rIdCounter++}`;
+      const footerXml = DocxExporter.buildHeaderFooterXml(doc.footer, 'footer');
+      zip.file('word/footer1.xml', footerXml);
+      hfRels.push(`  <Relationship Id="${footerRId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer" Target="footer1.xml"/>`);
+      hfContentTypes.push(`  <Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>`);
+    }
+
+    // Build document.xml
+    const bodyXml = doc.blocks.map((b) => DocxExporter.blockToXml(b, imageEntries)).join('\n');
+    const sectPr = DocxExporter.buildSectPrXml(doc.pageSetup ?? DEFAULT_PAGE_SETUP, headerRId, footerRId);
+    const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+            xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+            xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+  <w:body>
+${bodyXml}
+    ${sectPr}
+  </w:body>
+</w:document>`;
+
+    zip.file('word/document.xml', documentXml);
+    zip.file('word/styles.xml', STYLES);
+
+    // Relationships
+    const imageRels = imageEntries.map((e) =>
+      `  <Relationship Id="${e.rId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="${e.path}"/>`
+    );
+    zip.file('word/_rels/document.xml.rels', DOC_RELS([...imageRels, ...hfRels].join('\n')));
+    zip.file('_rels/.rels', ROOT_RELS);
+    zip.file('[Content_Types].xml', CONTENT_TYPES(hfContentTypes.join('\n')));
+
+    // Generate as an ArrayBuffer first, then wrap in a Blob. This avoids
+    // environment-specific issues where a JSZip-produced Blob may not
+    // implement Blob.prototype.arrayBuffer (notably in jsdom).
+    const buffer = await zip.generateAsync({ type: 'arraybuffer' });
+    return new Blob([buffer], {
+      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    });
+  }
+
+  private static blockToXml(
+    block: Block,
+    imageEntries: ImageEntry[],
+  ): string {
+    if (block.type === 'table' && block.tableData) {
+      return DocxExporter.tableToXml(block.tableData, imageEntries);
+    }
+    if (block.type === 'page-break') {
+      return `    <w:p><w:r><w:br w:type="page"/></w:r></w:p>`;
+    }
+    if (block.type === 'horizontal-rule') {
+      return `    <w:p><w:pPr><w:pBdr><w:bottom w:val="single" w:sz="6" w:space="1" w:color="auto"/></w:pBdr></w:pPr></w:p>`;
+    }
+
+    const pPr = buildParagraphPropertiesXml(
+      block.style,
+      block.type === 'heading' ? block.headingLevel : undefined,
+    );
+    const runs = block.inlines.map((inline) => DocxExporter.inlineToXml(inline, imageEntries)).join('');
+    return `    <w:p>${pPr}${runs}</w:p>`;
+  }
+
+  private static inlineToXml(
+    inline: Inline,
+    imageEntries: ImageEntry[],
+  ): string {
+    // Image inline
+    if (inline.style.image) {
+      const entry = imageEntries.find((e) => e.src === inline.style.image!.src);
+      if (entry) {
+        const cx = pxToEmus(inline.style.image.width);
+        const cy = pxToEmus(inline.style.image.height);
+        return `<w:r><w:drawing><wp:inline distT="0" distB="0" distL="0" distR="0">
+          <wp:extent cx="${Math.round(cx)}" cy="${Math.round(cy)}"/>
+          <wp:docPr id="1" name="Image"/>
+          <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+            <pic:pic><pic:nvPicPr><pic:cNvPr id="1" name="Image"/><pic:cNvPicPr/></pic:nvPicPr>
+            <pic:blipFill><a:blip r:embed="${entry.rId}"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>
+            <pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="${Math.round(cx)}" cy="${Math.round(cy)}"/></a:xfrm>
+            <a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr></pic:pic>
+          </a:graphicData></a:graphic></wp:inline></w:drawing></w:r>`;
+      }
+    }
+
+    // Regular text run
+    const rPr = buildRunPropertiesXml(inline.style);
+    const escapedText = inline.text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    return `<w:r>${rPr}<w:t xml:space="preserve">${escapedText}</w:t></w:r>`;
+  }
+
+  private static tableToXml(
+    tableData: TableData,
+    imageEntries: ImageEntry[],
+  ): string {
+    // Compute grid col widths in twips (assume total page width ~9000 twips)
+    const totalTwips = 9000;
+    const gridCols = tableData.columnWidths
+      .map((w) => `<w:gridCol w:w="${Math.round(w * totalTwips)}"/>`)
+      .join('');
+
+    const rows = tableData.rows.map((row) => {
+      const cells = row.cells.map((cell) => {
+        if (cell.colSpan === 0) {
+          // Covered cell (vMerge continue)
+          return `<w:tc><w:tcPr><w:vMerge/></w:tcPr><w:p/></w:tc>`;
+        }
+
+        const tcPrParts: string[] = [];
+        if (cell.colSpan && cell.colSpan > 1) tcPrParts.push(`<w:gridSpan w:val="${cell.colSpan}"/>`);
+        if (cell.rowSpan && cell.rowSpan > 1) tcPrParts.push(`<w:vMerge w:val="restart"/>`);
+        if (cell.style.backgroundColor) {
+          const hex = cell.style.backgroundColor.replace('#', '');
+          tcPrParts.push(`<w:shd w:val="clear" w:color="auto" w:fill="${hex}"/>`);
+        }
+        const tcPr = tcPrParts.length > 0 ? `<w:tcPr>${tcPrParts.join('')}</w:tcPr>` : '';
+
+        const cellContent = cell.blocks
+          .map((b) => DocxExporter.blockToXml(b, imageEntries))
+          .join('');
+        return `<w:tc>${tcPr}${cellContent || '<w:p/>'}</w:tc>`;
+      }).join('');
+      return `<w:tr>${cells}</w:tr>`;
+    }).join('');
+
+    return `    <w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr><w:tblGrid>${gridCols}</w:tblGrid>${rows}</w:tbl>`;
+  }
+
+  private static buildSectPrXml(
+    setup: PageSetup,
+    headerRId?: string,
+    footerRId?: string,
+  ): string {
+    const w = Math.round(pxToTwips(setup.paperSize.width));
+    const h = Math.round(pxToTwips(setup.paperSize.height));
+    const orient = setup.orientation === 'landscape' ? ' w:orient="landscape"' : '';
+    const pgSz = `<w:pgSz w:w="${w}" w:h="${h}"${orient}/>`;
+    const pgMar = `<w:pgMar w:top="${Math.round(pxToTwips(setup.margins.top))}" w:right="${Math.round(pxToTwips(setup.margins.right))}" w:bottom="${Math.round(pxToTwips(setup.margins.bottom))}" w:left="${Math.round(pxToTwips(setup.margins.left))}" w:header="720" w:footer="720"/>`;
+
+    const refs: string[] = [];
+    if (headerRId) refs.push(`<w:headerReference w:type="default" r:id="${headerRId}"/>`);
+    if (footerRId) refs.push(`<w:footerReference w:type="default" r:id="${footerRId}"/>`);
+
+    return `<w:sectPr>${refs.join('')}${pgSz}${pgMar}</w:sectPr>`;
+  }
+
+  private static buildHeaderFooterXml(hf: HeaderFooter, type: 'header' | 'footer'): string {
+    const tag = type === 'header' ? 'hdr' : 'ftr';
+    const blocks = hf.blocks.map((b) => DocxExporter.blockToXml(b, [])).join('\n');
+    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:${tag} xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+${blocks}
+</w:${tag}>`;
+  }
+
+  private static async collectImages(
+    block: Block,
+    fetcher: ImageFetcher,
+    zip: JSZip,
+    entries: ImageEntry[],
+    nextRId: () => string,
+  ): Promise<void> {
+    for (const inline of block.inlines) {
+      if (inline.style.image) {
+        const src = inline.style.image.src;
+        // Skip if this src was already fetched (dedupe).
+        if (entries.some((e) => e.src === src)) continue;
+        const blob = await fetcher(src);
+        const ext = (src.split('.').pop() || 'png').toLowerCase().split('?')[0];
+        const rId = nextRId();
+        const path = `media/image_${rId}.${ext}`;
+        zip.file(`word/${path}`, blob);
+        entries.push({ rId, path, ext, src });
+      }
+    }
+    // Also check table cells
+    if (block.tableData) {
+      for (const row of block.tableData.rows) {
+        for (const cell of row.cells) {
+          for (const cellBlock of cell.blocks) {
+            await DocxExporter.collectImages(cellBlock, fetcher, zip, entries, nextRId);
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/docs/src/export/docx-style-map.ts
+++ b/packages/docs/src/export/docx-style-map.ts
@@ -54,14 +54,14 @@ export function buildParagraphPropertiesXml(
   }
 
   const spacingParts: string[] = [];
-  if (style.marginTop > 0) spacingParts.push(`w:before="${Math.round(pxToTwips(style.marginTop))}"`);
-  if (style.marginBottom > 0) spacingParts.push(`w:after="${Math.round(pxToTwips(style.marginBottom))}"`);
+  if (style.marginTop > 0) spacingParts.push(`w:before="${pxToTwips(style.marginTop)}"`);
+  if (style.marginBottom > 0) spacingParts.push(`w:after="${pxToTwips(style.marginBottom)}"`);
   if (style.lineHeight !== 1.5) spacingParts.push(`w:line="${Math.round(style.lineHeight * 240)}"`);
   if (spacingParts.length > 0) parts.push(`<w:spacing ${spacingParts.join(' ')}/>`);
 
   const indParts: string[] = [];
-  if (style.textIndent > 0) indParts.push(`w:firstLine="${Math.round(pxToTwips(style.textIndent))}"`);
-  if (style.marginLeft > 0) indParts.push(`w:left="${Math.round(pxToTwips(style.marginLeft))}"`);
+  if (style.textIndent > 0) indParts.push(`w:firstLine="${pxToTwips(style.textIndent)}"`);
+  if (style.marginLeft > 0) indParts.push(`w:left="${pxToTwips(style.marginLeft)}"`);
   if (indParts.length > 0) parts.push(`<w:ind ${indParts.join(' ')}/>`);
 
   if (parts.length === 0) return '';

--- a/packages/docs/src/export/docx-style-map.ts
+++ b/packages/docs/src/export/docx-style-map.ts
@@ -1,0 +1,69 @@
+import type { InlineStyle, BlockStyle } from '../model/types.js';
+import { pointsToHalfPoints, pxToTwips } from '../import/units.js';
+
+/**
+ * Build <w:rPr>...</w:rPr> XML from InlineStyle.
+ * Returns empty string if no properties to set.
+ */
+export function buildRunPropertiesXml(style: InlineStyle): string {
+  const parts: string[] = [];
+
+  if (style.fontFamily) {
+    parts.push(`<w:rFonts w:ascii="${style.fontFamily}" w:hAnsi="${style.fontFamily}" w:eastAsia="${style.fontFamily}"/>`);
+  }
+  if (style.bold) parts.push('<w:b/>');
+  if (style.italic) parts.push('<w:i/>');
+  if (style.underline) parts.push('<w:u w:val="single"/>');
+  if (style.strikethrough) parts.push('<w:strike/>');
+  if (style.fontSize) {
+    const hp = pointsToHalfPoints(style.fontSize);
+    parts.push(`<w:sz w:val="${hp}"/>`);
+    parts.push(`<w:szCs w:val="${hp}"/>`);
+  }
+  if (style.color) {
+    const hex = style.color.replace('#', '');
+    parts.push(`<w:color w:val="${hex}"/>`);
+  }
+  if (style.backgroundColor) {
+    const hex = style.backgroundColor.replace('#', '');
+    parts.push(`<w:shd w:val="clear" w:color="auto" w:fill="${hex}"/>`);
+  }
+  if (style.superscript) parts.push('<w:vertAlign w:val="superscript"/>');
+  if (style.subscript) parts.push('<w:vertAlign w:val="subscript"/>');
+
+  if (parts.length === 0) return '';
+  return `<w:rPr>${parts.join('')}</w:rPr>`;
+}
+
+/**
+ * Build <w:pPr>...</w:pPr> XML from BlockStyle.
+ */
+export function buildParagraphPropertiesXml(
+  style: BlockStyle,
+  headingLevel?: number,
+): string {
+  const parts: string[] = [];
+
+  if (headingLevel) {
+    parts.push(`<w:pStyle w:val="Heading${headingLevel}"/>`);
+  }
+
+  const align = style.alignment === 'justify' ? 'both' : style.alignment;
+  if (align !== 'left') {
+    parts.push(`<w:jc w:val="${align}"/>`);
+  }
+
+  const spacingParts: string[] = [];
+  if (style.marginTop > 0) spacingParts.push(`w:before="${Math.round(pxToTwips(style.marginTop))}"`);
+  if (style.marginBottom > 0) spacingParts.push(`w:after="${Math.round(pxToTwips(style.marginBottom))}"`);
+  if (style.lineHeight !== 1.5) spacingParts.push(`w:line="${Math.round(style.lineHeight * 240)}"`);
+  if (spacingParts.length > 0) parts.push(`<w:spacing ${spacingParts.join(' ')}/>`);
+
+  const indParts: string[] = [];
+  if (style.textIndent > 0) indParts.push(`w:firstLine="${Math.round(pxToTwips(style.textIndent))}"`);
+  if (style.marginLeft > 0) indParts.push(`w:left="${Math.round(pxToTwips(style.marginLeft))}"`);
+  if (indParts.length > 0) parts.push(`<w:ind ${indParts.join(' ')}/>`);
+
+  if (parts.length === 0) return '';
+  return `<w:pPr>${parts.join('')}</w:pPr>`;
+}

--- a/packages/docs/src/export/docx-templates.ts
+++ b/packages/docs/src/export/docx-templates.ts
@@ -1,0 +1,34 @@
+/**
+ * Static OOXML boilerplate templates for .docx export.
+ */
+
+export const CONTENT_TYPES = (extras: string) => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Default Extension="jpg" ContentType="image/jpeg"/>
+  <Default Extension="jpeg" ContentType="image/jpeg"/>
+  <Default Extension="gif" ContentType="image/gif"/>
+  <Default Extension="webp" ContentType="image/webp"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+${extras}</Types>`;
+
+export const ROOT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+export const STYLES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:styleId="Normal" w:default="1">
+    <w:name w:val="Normal"/>
+    <w:rPr><w:rFonts w:ascii="Arial" w:hAnsi="Arial"/><w:sz w:val="22"/></w:rPr>
+  </w:style>
+</w:styles>`;
+
+export const DOC_RELS = (extras: string) => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+${extras}</Relationships>`;

--- a/packages/docs/src/export/docx-templates.ts
+++ b/packages/docs/src/export/docx-templates.ts
@@ -11,6 +11,8 @@ export const CONTENT_TYPES = (extras: string) => `<?xml version="1.0" encoding="
   <Default Extension="jpeg" ContentType="image/jpeg"/>
   <Default Extension="gif" ContentType="image/gif"/>
   <Default Extension="webp" ContentType="image/webp"/>
+  <Default Extension="bmp" ContentType="image/bmp"/>
+  <Default Extension="bin" ContentType="application/octet-stream"/>
   <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
   <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
 ${extras}</Types>`;

--- a/packages/docs/src/import/docx-importer.ts
+++ b/packages/docs/src/import/docx-importer.ts
@@ -3,6 +3,7 @@ import type { Document, Block, TableData, TableRow, TableCell, HeaderFooter, Pag
 import { generateBlockId, DEFAULT_BLOCK_STYLE, DEFAULT_CELL_STYLE, DEFAULT_HEADER_MARGIN_FROM_EDGE } from '../model/types.js';
 import { parseRelationships, parseParagraph, parsePageSetup, type RelEntry } from './docx-parser.js';
 import { mapTableCellProperties } from './docx-style-map.js';
+import { emusToPx } from './units.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -68,17 +69,26 @@ export class DocxImporter {
     pEl: Element,
     imageUrls: Map<string, ResolvedImage>,
   ): Block {
-    const { inlines, blockStyle, blockType, headingLevel } = parseParagraph(pEl);
+    const { inlines, blockStyle, blockType, headingLevel, imageRefs } = parseParagraph(pEl);
 
-    // Resolve pending image references
+    // Resolve pending image references. Each pending placeholder inline is
+    // matched in order against imageRefs from the same paragraph so that the
+    // EMU extent parsed from <w:drawing> is preserved as CSS pixel dimensions.
+    let refIdx = 0;
     const resolvedInlines = inlines.map((inline) => {
       if (inline.style.image?.src.startsWith('__pending__:')) {
         const rId = inline.style.image.src.replace('__pending__:', '');
-        const img = imageUrls.get(rId);
-        if (img) {
+        const uploaded = imageUrls.get(rId);
+        const ref = imageRefs[refIdx++];
+        if (uploaded) {
+          const width = ref && ref.cx > 0 ? Math.round(emusToPx(ref.cx)) : uploaded.width;
+          const height = ref && ref.cy > 0 ? Math.round(emusToPx(ref.cy)) : uploaded.height;
           return {
             text: inline.text,
-            style: { ...inline.style, image: img },
+            style: {
+              ...inline.style,
+              image: { src: uploaded.src, width, height },
+            },
           };
         }
       }
@@ -100,16 +110,20 @@ export class DocxImporter {
     imageUrls: Map<string, ResolvedImage>,
     isNested: boolean,
   ): Block {
-    // If nested, flatten to a paragraph with text content
+    // If nested, flatten to a paragraph with text content. Walk only direct
+    // child <w:tr> / <w:tc> so that deeply nested tables don't bleed their
+    // rows/cells into the outer flattened text.
     if (isNested) {
       const texts: string[] = [];
-      const trs = tblEl.getElementsByTagNameNS(W, 'tr');
-      for (let r = 0; r < trs.length; r++) {
+      for (let i = 0; i < tblEl.childNodes.length; i++) {
+        const trNode = tblEl.childNodes[i];
+        if (trNode.nodeType !== 1 || (trNode as Element).localName !== 'tr') continue;
+        const trEl = trNode as Element;
         const rowTexts: string[] = [];
-        const tcs = trs[r].getElementsByTagNameNS(W, 'tc');
-        for (let c = 0; c < tcs.length; c++) {
-          const cellText = DocxImporter.extractText(tcs[c]);
-          rowTexts.push(cellText);
+        for (let j = 0; j < trEl.childNodes.length; j++) {
+          const tcNode = trEl.childNodes[j];
+          if (tcNode.nodeType !== 1 || (tcNode as Element).localName !== 'tc') continue;
+          rowTexts.push(DocxImporter.extractText(tcNode as Element));
         }
         texts.push(rowTexts.join(' | '));
       }
@@ -133,7 +147,21 @@ export class DocxImporter {
 
     // Parse rows — only direct child <w:tr> elements
     const rows: TableRow[] = [];
+    // Track the currently-open vMerge group per column. Each group is
+    // resolved (its rowSpan written) either when the column starts a new
+    // group or at the end after all rows are walked. This handles multiple
+    // stacked vMerge groups in the same column without overwriting earlier
+    // trackers.
     const vMergeTracker: Map<number, { startRow: number; count: number }> = new Map();
+    const resolveVMergeGroup = (
+      colIdx: number,
+      tracker: { startRow: number; count: number },
+    ) => {
+      if (tracker.count > 1 && rows[tracker.startRow]) {
+        const cell = rows[tracker.startRow].cells[colIdx];
+        if (cell) cell.rowSpan = tracker.count;
+      }
+    };
 
     for (let i = 0; i < tblEl.childNodes.length; i++) {
       const node = tblEl.childNodes[i];
@@ -160,6 +188,10 @@ export class DocxImporter {
 
         // Handle vertical merge tracking
         if (vMerge === 'restart') {
+          // If a previous group is still open for this column, close it
+          // before starting a new one.
+          const existing = vMergeTracker.get(colIdx);
+          if (existing) resolveVMergeGroup(colIdx, existing);
           vMergeTracker.set(colIdx, { startRow: rows.length, count: 1 });
         } else if (vMerge === 'continue') {
           const tracker = vMergeTracker.get(colIdx);
@@ -213,12 +245,9 @@ export class DocxImporter {
       rows.push({ cells });
     }
 
-    // Resolve vMerge rowSpan values
+    // Resolve any still-open vMerge groups at end of table.
     for (const [colIdx, tracker] of vMergeTracker) {
-      if (tracker.count > 1 && rows[tracker.startRow]) {
-        const cell = rows[tracker.startRow].cells[colIdx];
-        if (cell) cell.rowSpan = tracker.count;
-      }
+      resolveVMergeGroup(colIdx, tracker);
     }
 
     const tableData: TableData = { rows, columnWidths };
@@ -258,7 +287,8 @@ export class DocxImporter {
       const filename = `${rId}.${ext}`;
       const url = await uploader(data, filename);
 
-      // We'll set dimensions later when resolving
+      // Dimensions are filled per-reference in convertParagraph using the
+      // <wp:extent> cx/cy values returned by parseParagraph.
       imageUrls.set(rId, { src: url, width: 0, height: 0 });
     }
   }

--- a/packages/docs/src/import/docx-importer.ts
+++ b/packages/docs/src/import/docx-importer.ts
@@ -1,15 +1,28 @@
 import JSZip from 'jszip';
-import type { Document, Block, TableData, TableRow, TableCell, HeaderFooter, PageSetup } from '../model/types.js';
+import type { Document, Block, Inline, TableData, TableRow, TableCell, HeaderFooter, PageSetup } from '../model/types.js';
 import { generateBlockId, DEFAULT_BLOCK_STYLE, DEFAULT_CELL_STYLE, DEFAULT_HEADER_MARGIN_FROM_EDGE } from '../model/types.js';
 import { parseRelationships, parseParagraph, parsePageSetup, type RelEntry } from './docx-parser.js';
 import { mapTableCellProperties } from './docx-style-map.js';
 import { emusToPx } from './units.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
 
 export type ImageUploader = (blob: Blob, filename: string) => Promise<string>;
 
 type ResolvedImage = { src: string; width: number; height: number };
+
+/**
+ * Directory for a .rels file. Relationship targets are resolved relative to
+ * the parent directory of the file the rels belong to:
+ *   - word/_rels/document.xml.rels → word/
+ *   - word/_rels/header1.xml.rels  → word/
+ * Pre-computing this makes it easier to read image bytes from the zip.
+ */
+function relsDirFor(partPath: string): string {
+  const idx = partPath.lastIndexOf('/');
+  return idx >= 0 ? partPath.slice(0, idx + 1) : '';
+}
 
 export class DocxImporter {
   /**
@@ -25,7 +38,7 @@ export class DocxImporter {
   ): Promise<Document> {
     const zip = await JSZip.loadAsync(buffer);
 
-    // Parse relationships
+    // Parse document.xml.rels (scoped to the document part).
     const relsXml = await zip.file('word/_rels/document.xml.rels')?.async('string');
     const rels = relsXml ? parseRelationships(relsXml) : new Map<string, RelEntry>();
 
@@ -36,15 +49,17 @@ export class DocxImporter {
     const body = xmlDoc.getElementsByTagNameNS(W, 'body')[0];
     if (!body) throw new Error('Invalid .docx: missing w:body');
 
-    // Upload images
+    // Upload images referenced from the document part. Image rIds are
+    // scoped per rels file, so header/footer parts keep their own maps.
     const imageUrls = new Map<string, ResolvedImage>();
     if (imageUploader) {
-      await DocxImporter.uploadImages(zip, rels, imageUploader, imageUrls);
+      await DocxImporter.uploadImages(zip, rels, 'word/', imageUploader, imageUrls);
     }
 
     // Walk body children
     const blocks: Block[] = [];
     let pageSetup: PageSetup | undefined;
+    let sectPrEl: Element | undefined;
     for (let i = 0; i < body.childNodes.length; i++) {
       const node = body.childNodes[i];
       if (node.nodeType !== 1) continue;
@@ -55,14 +70,61 @@ export class DocxImporter {
         blocks.push(DocxImporter.convertTable(el, imageUrls, false));
       } else if (el.localName === 'sectPr') {
         pageSetup = parsePageSetup(el);
+        sectPrEl = el;
       }
     }
 
-    // Parse headers and footers
-    const header = await DocxImporter.parseHeaderFooter(zip, rels, 'header', imageUrls);
-    const footer = await DocxImporter.parseHeaderFooter(zip, rels, 'footer', imageUrls);
+    // Resolve the active header/footer parts via the sectPr references
+    // rather than picking the first matching rel in iteration order.
+    const headerTarget = sectPrEl
+      ? DocxImporter.resolveHeaderFooterTarget(sectPrEl, rels, 'header')
+      : undefined;
+    const footerTarget = sectPrEl
+      ? DocxImporter.resolveHeaderFooterTarget(sectPrEl, rels, 'footer')
+      : undefined;
+
+    const header = await DocxImporter.parseHeaderFooter(
+      zip, 'header', headerTarget, imageUploader,
+    );
+    const footer = await DocxImporter.parseHeaderFooter(
+      zip, 'footer', footerTarget, imageUploader,
+    );
 
     return { blocks, pageSetup, header, footer };
+  }
+
+  /**
+   * Look up the default header/footer part target referenced from a
+   * <w:sectPr>. Prefers w:type="default", then falls back to the first
+   * reference of the requested kind. Returns the zip-relative target path
+   * (e.g. "word/header1.xml") or undefined when none is referenced.
+   */
+  private static resolveHeaderFooterTarget(
+    sectPr: Element,
+    rels: Map<string, RelEntry>,
+    type: 'header' | 'footer',
+  ): string | undefined {
+    const refTag = type === 'header' ? 'headerReference' : 'footerReference';
+    const refs = sectPr.getElementsByTagNameNS(W, refTag);
+    if (refs.length === 0) return undefined;
+
+    const pickRef = (): Element | undefined => {
+      for (let i = 0; i < refs.length; i++) {
+        const ref = refs[i];
+        const t = ref.getAttributeNS(W, 'type') || ref.getAttribute('w:type');
+        if (t === 'default') return ref;
+      }
+      return refs[0];
+    };
+
+    const ref = pickRef();
+    if (!ref) return undefined;
+    const rId = ref.getAttributeNS(R_NS, 'id') || ref.getAttribute('r:id');
+    if (!rId) return undefined;
+    const rel = rels.get(rId);
+    if (!rel || rel.type !== type) return undefined;
+    // document.xml's rels are scoped to word/, so header1.xml lives at word/header1.xml.
+    return `word/${rel.target}`;
   }
 
   private static convertParagraph(
@@ -74,8 +136,12 @@ export class DocxImporter {
     // Resolve pending image references. Each pending placeholder inline is
     // matched in order against imageRefs from the same paragraph so that the
     // EMU extent parsed from <w:drawing> is preserved as CSS pixel dimensions.
+    // Unresolved placeholders (e.g. when no uploader was supplied or when
+    // the image belongs to a rels file we didn't walk) are dropped to avoid
+    // leaving `__pending__:*` sources in the returned document.
     let refIdx = 0;
-    const resolvedInlines = inlines.map((inline) => {
+    const resolvedInlines: Inline[] = [];
+    for (const inline of inlines) {
       if (inline.style.image?.src.startsWith('__pending__:')) {
         const rId = inline.style.image.src.replace('__pending__:', '');
         const uploaded = imageUrls.get(rId);
@@ -83,18 +149,25 @@ export class DocxImporter {
         if (uploaded) {
           const width = ref && ref.cx > 0 ? Math.round(emusToPx(ref.cx)) : uploaded.width;
           const height = ref && ref.cy > 0 ? Math.round(emusToPx(ref.cy)) : uploaded.height;
-          return {
+          resolvedInlines.push({
             text: inline.text,
             style: {
               ...inline.style,
               image: { src: uploaded.src, width, height },
             },
-          };
+          });
         }
+        // else: drop the pending inline (no uploader or rId not in scope).
+        continue;
       }
-      return inline;
-    });
+      resolvedInlines.push(inline);
+    }
 
+    // Ensure the paragraph always has at least one inline so downstream
+    // layout/rendering can assume a non-empty inlines array.
+    if (resolvedInlines.length === 0) {
+      resolvedInlines.push({ text: '', style: {} });
+    }
     const block: Block = {
       id: generateBlockId(),
       type: blockType as Block['type'],
@@ -270,15 +343,26 @@ export class DocxImporter {
     return texts.join('');
   }
 
+  /**
+   * Walk the image relationships of a single .rels file and upload each
+   * referenced image via the caller-supplied uploader. Image relationship
+   * targets are resolved relative to the parent directory of the owning
+   * part (e.g. word/_rels/header1.xml.rels → word/media/image1.png).
+   *
+   * imageUrls is a map scoped to the same rels file because OOXML rIds
+   * are only unique within a given .rels document; collisions between
+   * document.xml.rels and header1.xml.rels are legal.
+   */
   private static async uploadImages(
     zip: JSZip,
     rels: Map<string, RelEntry>,
+    baseDir: string,
     uploader: ImageUploader,
     imageUrls: Map<string, ResolvedImage>,
   ): Promise<void> {
     for (const [rId, rel] of rels) {
       if (rel.type !== 'image') continue;
-      const path = `word/${rel.target}`;
+      const path = `${baseDir}${rel.target}`;
       const file = zip.file(path);
       if (!file) continue;
 
@@ -293,24 +377,41 @@ export class DocxImporter {
     }
   }
 
+  /**
+   * Parse a specific header/footer part and return its blocks. The caller
+   * resolves the part path from the active <w:sectPr> so that real Word
+   * documents — which may have multiple unused header/footer rels — land
+   * on the actual referenced part rather than the first match in
+   * iteration order.
+   *
+   * This also parses the part-local .rels file and uploads any images
+   * referenced from the header/footer into a scoped imageUrls map so that
+   * rId collisions with document.xml.rels do not bleed across parts.
+   */
   private static async parseHeaderFooter(
     zip: JSZip,
-    rels: Map<string, RelEntry>,
     type: 'header' | 'footer',
-    imageUrls: Map<string, ResolvedImage>,
+    targetFile: string | undefined,
+    imageUploader: ImageUploader | undefined,
   ): Promise<HeaderFooter | undefined> {
-    // Find the default (type 2, "default") header/footer relationship
-    let targetFile: string | undefined;
-    for (const [, rel] of rels) {
-      if (rel.type === type) {
-        targetFile = rel.target;
-        break;
-      }
-    }
     if (!targetFile) return undefined;
 
-    const xml = await zip.file(`word/${targetFile}`)?.async('string');
+    const xml = await zip.file(targetFile)?.async('string');
     if (!xml) return undefined;
+
+    // Load the part-scoped rels file and upload any referenced images.
+    // Example: targetFile = "word/header1.xml" →
+    //          relsPath   = "word/_rels/header1.xml.rels"
+    const baseDir = relsDirFor(targetFile);
+    const partFilename = targetFile.slice(baseDir.length);
+    const relsPath = `${baseDir}_rels/${partFilename}.rels`;
+    const relsXml = await zip.file(relsPath)?.async('string');
+    const partRels = relsXml ? parseRelationships(relsXml) : new Map<string, RelEntry>();
+
+    const partImageUrls = new Map<string, ResolvedImage>();
+    if (imageUploader) {
+      await DocxImporter.uploadImages(zip, partRels, baseDir, imageUploader, partImageUrls);
+    }
 
     const xmlDoc = new DOMParser().parseFromString(xml, 'text/xml');
     const rootTag = type === 'header' ? 'hdr' : 'ftr';
@@ -323,7 +424,7 @@ export class DocxImporter {
       if (node.nodeType !== 1) continue;
       const el = node as Element;
       if (el.localName === 'p') {
-        blocks.push(DocxImporter.convertParagraph(el, imageUrls));
+        blocks.push(DocxImporter.convertParagraph(el, partImageUrls));
       }
     }
 

--- a/packages/docs/src/import/docx-importer.ts
+++ b/packages/docs/src/import/docx-importer.ts
@@ -1,0 +1,304 @@
+import JSZip from 'jszip';
+import type { Document, Block, TableData, TableRow, TableCell, HeaderFooter, PageSetup } from '../model/types.js';
+import { generateBlockId, DEFAULT_BLOCK_STYLE, DEFAULT_CELL_STYLE, DEFAULT_HEADER_MARGIN_FROM_EDGE } from '../model/types.js';
+import { parseRelationships, parseParagraph, parsePageSetup, type RelEntry } from './docx-parser.js';
+import { mapTableCellProperties } from './docx-style-map.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+export type ImageUploader = (blob: Blob, filename: string) => Promise<string>;
+
+type ResolvedImage = { src: string; width: number; height: number };
+
+export class DocxImporter {
+  /**
+   * Import a .docx ArrayBuffer into a Document.
+   *
+   * @param buffer - The .docx file as an ArrayBuffer.
+   * @param imageUploader - Optional callback to upload images. If not provided,
+   *   images are skipped.
+   */
+  static async import(
+    buffer: ArrayBuffer,
+    imageUploader?: ImageUploader,
+  ): Promise<Document> {
+    const zip = await JSZip.loadAsync(buffer);
+
+    // Parse relationships
+    const relsXml = await zip.file('word/_rels/document.xml.rels')?.async('string');
+    const rels = relsXml ? parseRelationships(relsXml) : new Map<string, RelEntry>();
+
+    // Parse document.xml
+    const docXml = await zip.file('word/document.xml')?.async('string');
+    if (!docXml) throw new Error('Invalid .docx: missing word/document.xml');
+    const xmlDoc = new DOMParser().parseFromString(docXml, 'text/xml');
+    const body = xmlDoc.getElementsByTagNameNS(W, 'body')[0];
+    if (!body) throw new Error('Invalid .docx: missing w:body');
+
+    // Upload images
+    const imageUrls = new Map<string, ResolvedImage>();
+    if (imageUploader) {
+      await DocxImporter.uploadImages(zip, rels, imageUploader, imageUrls);
+    }
+
+    // Walk body children
+    const blocks: Block[] = [];
+    let pageSetup: PageSetup | undefined;
+    for (let i = 0; i < body.childNodes.length; i++) {
+      const node = body.childNodes[i];
+      if (node.nodeType !== 1) continue;
+      const el = node as Element;
+      if (el.localName === 'p') {
+        blocks.push(DocxImporter.convertParagraph(el, imageUrls));
+      } else if (el.localName === 'tbl') {
+        blocks.push(DocxImporter.convertTable(el, imageUrls, false));
+      } else if (el.localName === 'sectPr') {
+        pageSetup = parsePageSetup(el);
+      }
+    }
+
+    // Parse headers and footers
+    const header = await DocxImporter.parseHeaderFooter(zip, rels, 'header', imageUrls);
+    const footer = await DocxImporter.parseHeaderFooter(zip, rels, 'footer', imageUrls);
+
+    return { blocks, pageSetup, header, footer };
+  }
+
+  private static convertParagraph(
+    pEl: Element,
+    imageUrls: Map<string, ResolvedImage>,
+  ): Block {
+    const { inlines, blockStyle, blockType, headingLevel } = parseParagraph(pEl);
+
+    // Resolve pending image references
+    const resolvedInlines = inlines.map((inline) => {
+      if (inline.style.image?.src.startsWith('__pending__:')) {
+        const rId = inline.style.image.src.replace('__pending__:', '');
+        const img = imageUrls.get(rId);
+        if (img) {
+          return {
+            text: inline.text,
+            style: { ...inline.style, image: img },
+          };
+        }
+      }
+      return inline;
+    });
+
+    const block: Block = {
+      id: generateBlockId(),
+      type: blockType as Block['type'],
+      inlines: resolvedInlines,
+      style: blockStyle,
+    };
+    if (headingLevel) block.headingLevel = headingLevel as Block['headingLevel'];
+    return block;
+  }
+
+  private static convertTable(
+    tblEl: Element,
+    imageUrls: Map<string, ResolvedImage>,
+    isNested: boolean,
+  ): Block {
+    // If nested, flatten to a paragraph with text content
+    if (isNested) {
+      const texts: string[] = [];
+      const trs = tblEl.getElementsByTagNameNS(W, 'tr');
+      for (let r = 0; r < trs.length; r++) {
+        const rowTexts: string[] = [];
+        const tcs = trs[r].getElementsByTagNameNS(W, 'tc');
+        for (let c = 0; c < tcs.length; c++) {
+          const cellText = DocxImporter.extractText(tcs[c]);
+          rowTexts.push(cellText);
+        }
+        texts.push(rowTexts.join(' | '));
+      }
+      return {
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [{ text: texts.join('\n'), style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      };
+    }
+
+    // Parse grid columns for widths
+    const gridCols = tblEl.getElementsByTagNameNS(W, 'gridCol');
+    const colWidthsRaw: number[] = [];
+    for (let i = 0; i < gridCols.length; i++) {
+      const w = gridCols[i].getAttributeNS(W, 'w') || gridCols[i].getAttribute('w:w');
+      colWidthsRaw.push(w ? parseInt(w, 10) : 1);
+    }
+    const totalWidth = colWidthsRaw.reduce((a, b) => a + b, 0) || 1;
+    const columnWidths = colWidthsRaw.map((w) => w / totalWidth);
+
+    // Parse rows — only direct child <w:tr> elements
+    const rows: TableRow[] = [];
+    const vMergeTracker: Map<number, { startRow: number; count: number }> = new Map();
+
+    for (let i = 0; i < tblEl.childNodes.length; i++) {
+      const node = tblEl.childNodes[i];
+      if (node.nodeType !== 1 || (node as Element).localName !== 'tr') continue;
+      const trEl = node as Element;
+
+      const cells: TableCell[] = [];
+      let colIdx = 0;
+      for (let j = 0; j < trEl.childNodes.length; j++) {
+        const tcNode = trEl.childNodes[j];
+        if (tcNode.nodeType !== 1 || (tcNode as Element).localName !== 'tc') continue;
+        const tcEl = tcNode as Element;
+
+        // Parse cell properties
+        const tcPr = tcEl.getElementsByTagNameNS(W, 'tcPr')[0];
+        let colSpan = 1;
+        let vMerge: 'restart' | 'continue' | undefined;
+        let cellProps: ReturnType<typeof mapTableCellProperties> = {};
+        if (tcPr) {
+          cellProps = mapTableCellProperties(tcPr);
+          if (cellProps.colSpan) colSpan = cellProps.colSpan;
+          vMerge = cellProps.vMerge;
+        }
+
+        // Handle vertical merge tracking
+        if (vMerge === 'restart') {
+          vMergeTracker.set(colIdx, { startRow: rows.length, count: 1 });
+        } else if (vMerge === 'continue') {
+          const tracker = vMergeTracker.get(colIdx);
+          if (tracker) tracker.count++;
+          // Mark as covered cell
+          cells.push({
+            blocks: [{ id: generateBlockId(), type: 'paragraph', inlines: [{ text: '', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }],
+            style: { ...DEFAULT_CELL_STYLE },
+            colSpan: 0, // Covered
+          });
+          colIdx += colSpan;
+          continue;
+        }
+
+        // Parse cell content blocks
+        const cellBlocks: Block[] = [];
+        for (let k = 0; k < tcEl.childNodes.length; k++) {
+          const childNode = tcEl.childNodes[k];
+          if (childNode.nodeType !== 1) continue;
+          const childEl = childNode as Element;
+          if (childEl.localName === 'p') {
+            cellBlocks.push(DocxImporter.convertParagraph(childEl, imageUrls));
+          } else if (childEl.localName === 'tbl') {
+            // Nested table → flatten to text
+            cellBlocks.push(DocxImporter.convertTable(childEl, imageUrls, true));
+          }
+        }
+        if (cellBlocks.length === 0) {
+          cellBlocks.push({
+            id: generateBlockId(),
+            type: 'paragraph',
+            inlines: [{ text: '', style: {} }],
+            style: { ...DEFAULT_BLOCK_STYLE },
+          });
+        }
+
+        cells.push({
+          blocks: cellBlocks,
+          style: {
+            ...DEFAULT_CELL_STYLE,
+            backgroundColor: cellProps.backgroundColor,
+            borderTop: cellProps.borderTop,
+            borderBottom: cellProps.borderBottom,
+            borderLeft: cellProps.borderLeft,
+            borderRight: cellProps.borderRight,
+          },
+          colSpan: colSpan > 1 ? colSpan : undefined,
+        });
+        colIdx += colSpan;
+      }
+      rows.push({ cells });
+    }
+
+    // Resolve vMerge rowSpan values
+    for (const [colIdx, tracker] of vMergeTracker) {
+      if (tracker.count > 1 && rows[tracker.startRow]) {
+        const cell = rows[tracker.startRow].cells[colIdx];
+        if (cell) cell.rowSpan = tracker.count;
+      }
+    }
+
+    const tableData: TableData = { rows, columnWidths };
+
+    return {
+      id: generateBlockId(),
+      type: 'table',
+      inlines: [],
+      style: { ...DEFAULT_BLOCK_STYLE },
+      tableData,
+    };
+  }
+
+  private static extractText(el: Element): string {
+    const texts: string[] = [];
+    const tEls = el.getElementsByTagNameNS(W, 't');
+    for (let i = 0; i < tEls.length; i++) {
+      texts.push(tEls[i].textContent || '');
+    }
+    return texts.join('');
+  }
+
+  private static async uploadImages(
+    zip: JSZip,
+    rels: Map<string, RelEntry>,
+    uploader: ImageUploader,
+    imageUrls: Map<string, ResolvedImage>,
+  ): Promise<void> {
+    for (const [rId, rel] of rels) {
+      if (rel.type !== 'image') continue;
+      const path = `word/${rel.target}`;
+      const file = zip.file(path);
+      if (!file) continue;
+
+      const data = await file.async('blob');
+      const ext = rel.target.split('.').pop() || 'png';
+      const filename = `${rId}.${ext}`;
+      const url = await uploader(data, filename);
+
+      // We'll set dimensions later when resolving
+      imageUrls.set(rId, { src: url, width: 0, height: 0 });
+    }
+  }
+
+  private static async parseHeaderFooter(
+    zip: JSZip,
+    rels: Map<string, RelEntry>,
+    type: 'header' | 'footer',
+    imageUrls: Map<string, ResolvedImage>,
+  ): Promise<HeaderFooter | undefined> {
+    // Find the default (type 2, "default") header/footer relationship
+    let targetFile: string | undefined;
+    for (const [, rel] of rels) {
+      if (rel.type === type) {
+        targetFile = rel.target;
+        break;
+      }
+    }
+    if (!targetFile) return undefined;
+
+    const xml = await zip.file(`word/${targetFile}`)?.async('string');
+    if (!xml) return undefined;
+
+    const xmlDoc = new DOMParser().parseFromString(xml, 'text/xml');
+    const rootTag = type === 'header' ? 'hdr' : 'ftr';
+    const root = xmlDoc.getElementsByTagNameNS(W, rootTag)[0];
+    if (!root) return undefined;
+
+    const blocks: Block[] = [];
+    for (let i = 0; i < root.childNodes.length; i++) {
+      const node = root.childNodes[i];
+      if (node.nodeType !== 1) continue;
+      const el = node as Element;
+      if (el.localName === 'p') {
+        blocks.push(DocxImporter.convertParagraph(el, imageUrls));
+      }
+    }
+
+    if (blocks.length === 0) return undefined;
+
+    return { blocks, marginFromEdge: DEFAULT_HEADER_MARGIN_FROM_EDGE };
+  }
+}

--- a/packages/docs/src/import/docx-parser.ts
+++ b/packages/docs/src/import/docx-parser.ts
@@ -60,10 +60,11 @@ export function parseParagraph(pEl: Element): {
   const runs = pEl.getElementsByTagNameNS(W, 'r');
   for (let i = 0; i < runs.length; i++) {
     const r = runs[i];
-    // Check if this run is a direct child (not inside a nested element like hyperlink)
-    // by verifying its parent is either the paragraph or a hyperlink
+    // Skip runs that are not a direct child of the paragraph or a hyperlink.
+    // Without this guard, runs inside nested structures we don't handle
+    // (e.g. w:sdt) leak into the surrounding paragraph's inline list.
     if (r.parentElement !== pEl && r.parentElement?.localName !== 'hyperlink') {
-      // Skip runs inside nested structures we don't handle
+      continue;
     }
 
     let style: InlineStyle = {};
@@ -96,18 +97,24 @@ export function parseParagraph(pEl: Element): {
       continue;
     }
 
-    // Regular text
-    const textEls = r.getElementsByTagNameNS(W, 't');
+    // Walk direct children in document order so that a run like
+    // "A<w:tab/>B<w:br/>C" produces "A\tB\nC" rather than collapsing all
+    // text into "ABC\t\n".
     let text = '';
-    for (let j = 0; j < textEls.length; j++) {
-      text += textEls[j].textContent || '';
+    for (let j = 0; j < r.childNodes.length; j++) {
+      const child = r.childNodes[j];
+      if (child.nodeType !== 1) continue;
+      const childEl = child as Element;
+      if (childEl.namespaceURI !== W) continue;
+      const local = childEl.localName;
+      if (local === 't') {
+        text += childEl.textContent || '';
+      } else if (local === 'tab') {
+        text += '\t';
+      } else if (local === 'br') {
+        text += '\n';
+      }
     }
-
-    // Tab and break elements
-    const tabs = r.getElementsByTagNameNS(W, 'tab');
-    if (tabs.length > 0) text += '\t';
-    const brs = r.getElementsByTagNameNS(W, 'br');
-    if (brs.length > 0) text += '\n';
 
     if (text) {
       inlines.push({ text, style });

--- a/packages/docs/src/import/docx-parser.ts
+++ b/packages/docs/src/import/docx-parser.ts
@@ -1,0 +1,160 @@
+import type { Inline, InlineStyle, BlockStyle, PageSetup, PageMargins, PaperSize } from '../model/types.js';
+import { DEFAULT_BLOCK_STYLE } from '../model/types.js';
+import { mapRunProperties, mapParagraphProperties } from './docx-style-map.js';
+import { twipsToPx } from './units.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const RELS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+export interface RelEntry {
+  target: string;
+  type: string;
+}
+
+/**
+ * Parse a .rels XML file into a Map of relationship ID → target + type.
+ */
+export function parseRelationships(xml: string): Map<string, RelEntry> {
+  const doc = new DOMParser().parseFromString(xml, 'text/xml');
+  const rels = new Map<string, RelEntry>();
+  const elements = doc.getElementsByTagNameNS(RELS, 'Relationship');
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i];
+    const id = el.getAttribute('Id') || '';
+    const target = el.getAttribute('Target') || '';
+    const fullType = el.getAttribute('Type') || '';
+    // Extract short type from the full URI
+    const type = fullType.split('/').pop() || '';
+    rels.set(id, { target, type });
+  }
+  return rels;
+}
+
+/**
+ * Parse a <w:p> element into inlines and block metadata.
+ */
+export function parseParagraph(pEl: Element): {
+  inlines: Inline[];
+  blockStyle: BlockStyle;
+  blockType: string;
+  headingLevel?: number;
+  imageRefs: Array<{ rId: string; cx: number; cy: number }>;
+} {
+  let blockStyle: BlockStyle = { ...DEFAULT_BLOCK_STYLE };
+  let blockType = 'paragraph';
+  let headingLevel: number | undefined;
+  const imageRefs: Array<{ rId: string; cx: number; cy: number }> = [];
+
+  const pPr = pEl.getElementsByTagNameNS(W, 'pPr')[0];
+  if (pPr) {
+    const mapped = mapParagraphProperties(pPr);
+    blockStyle = mapped.blockStyle;
+    if (mapped.blockType) blockType = mapped.blockType;
+    if (mapped.headingLevel) headingLevel = mapped.headingLevel;
+  }
+
+  const inlines: Inline[] = [];
+  const runs = pEl.getElementsByTagNameNS(W, 'r');
+  for (let i = 0; i < runs.length; i++) {
+    const r = runs[i];
+    // Check if this run is a direct child (not inside a nested element like hyperlink)
+    // by verifying its parent is either the paragraph or a hyperlink
+    if (r.parentElement !== pEl && r.parentElement?.localName !== 'hyperlink') {
+      // Skip runs inside nested structures we don't handle
+    }
+
+    let style: InlineStyle = {};
+    const rPr = r.getElementsByTagNameNS(W, 'rPr')[0];
+    if (rPr) {
+      style = mapRunProperties(rPr);
+    }
+
+    // Check for drawing (image)
+    const drawing = r.getElementsByTagNameNS(W, 'drawing')[0];
+    if (drawing) {
+      const inlineDrawing = drawing.getElementsByTagNameNS(WP, 'inline')[0];
+      if (inlineDrawing) {
+        const extent = inlineDrawing.getElementsByTagNameNS(WP, 'extent')[0];
+        const cx = extent ? parseInt(extent.getAttribute('cx') || '0', 10) : 0;
+        const cy = extent ? parseInt(extent.getAttribute('cy') || '0', 10) : 0;
+
+        const blip = inlineDrawing.getElementsByTagNameNS(A, 'blip')[0];
+        const rId = blip?.getAttributeNS(R_NS, 'embed') || blip?.getAttribute('r:embed') || '';
+
+        if (rId) {
+          imageRefs.push({ rId, cx, cy });
+          // Placeholder — the importer will fill in the actual URL after upload
+          inlines.push({
+            text: '\uFFFC',
+            style: { ...style, image: { src: `__pending__:${rId}`, width: 0, height: 0 } },
+          });
+        }
+      }
+      continue;
+    }
+
+    // Regular text
+    const textEls = r.getElementsByTagNameNS(W, 't');
+    let text = '';
+    for (let j = 0; j < textEls.length; j++) {
+      text += textEls[j].textContent || '';
+    }
+
+    // Tab and break elements
+    const tabs = r.getElementsByTagNameNS(W, 'tab');
+    if (tabs.length > 0) text += '\t';
+    const brs = r.getElementsByTagNameNS(W, 'br');
+    if (brs.length > 0) text += '\n';
+
+    if (text) {
+      inlines.push({ text, style });
+    }
+  }
+
+  // Ensure at least one inline (empty paragraphs)
+  if (inlines.length === 0) {
+    inlines.push({ text: '', style: {} });
+  }
+
+  return { inlines, blockStyle, blockType, headingLevel, imageRefs };
+}
+
+/**
+ * Parse <w:sectPr> into PageSetup.
+ */
+export function parsePageSetup(sectPr: Element): PageSetup {
+  const pgSz = sectPr.getElementsByTagNameNS(W, 'pgSz')[0];
+  const pgMar = sectPr.getElementsByTagNameNS(W, 'pgMar')[0];
+
+  let width = 816; // Letter default
+  let height = 1056;
+  let orientation: 'portrait' | 'landscape' = 'portrait';
+
+  if (pgSz) {
+    const w = pgSz.getAttributeNS(W, 'w') || pgSz.getAttribute('w:w');
+    const h = pgSz.getAttributeNS(W, 'h') || pgSz.getAttribute('w:h');
+    const orient = pgSz.getAttributeNS(W, 'orient') || pgSz.getAttribute('w:orient');
+    if (w) width = Math.round(twipsToPx(parseInt(w, 10)));
+    if (h) height = Math.round(twipsToPx(parseInt(h, 10)));
+    if (orient === 'landscape') orientation = 'landscape';
+  }
+
+  const margins: PageMargins = { top: 96, bottom: 96, left: 96, right: 96 };
+  if (pgMar) {
+    const getMargin = (name: string) => {
+      const val = pgMar.getAttributeNS(W, name) || pgMar.getAttribute(`w:${name}`);
+      return val ? Math.round(twipsToPx(parseInt(val, 10))) : undefined;
+    };
+    const t = getMargin('top');     if (t !== undefined) margins.top = t;
+    const b = getMargin('bottom');  if (b !== undefined) margins.bottom = b;
+    const l = getMargin('left');    if (l !== undefined) margins.left = l;
+    const r = getMargin('right');   if (r !== undefined) margins.right = r;
+  }
+
+  const paperSize: PaperSize = { name: 'Custom', width, height };
+
+  return { paperSize, orientation, margins };
+}

--- a/packages/docs/src/import/docx-style-map.ts
+++ b/packages/docs/src/import/docx-style-map.ts
@@ -1,0 +1,214 @@
+import type { InlineStyle, BlockStyle } from '../model/types.js';
+import { DEFAULT_BLOCK_STYLE } from '../model/types.js';
+import { twipsToPx, halfPointsToPoints } from './units.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function getW(el: Element, localName: string): Element | null {
+  return el.getElementsByTagNameNS(W, localName)[0] ?? null;
+}
+
+function getWAttr(el: Element, attr: string): string | null {
+  return el.getAttributeNS(W, attr) || el.getAttribute(`w:${attr}`);
+}
+
+/**
+ * Map <w:rPr> element to InlineStyle.
+ */
+export function mapRunProperties(rPr: Element): InlineStyle {
+  const style: InlineStyle = {};
+
+  if (getW(rPr, 'b')) style.bold = true;
+  if (getW(rPr, 'i')) style.italic = true;
+  if (getW(rPr, 'strike')) style.strikethrough = true;
+
+  const u = getW(rPr, 'u');
+  if (u) {
+    const val = getWAttr(u, 'val');
+    if (val && val !== 'none') style.underline = true;
+  }
+
+  const sz = getW(rPr, 'sz');
+  if (sz) {
+    const val = getWAttr(sz, 'val');
+    if (val) style.fontSize = halfPointsToPoints(parseInt(val, 10));
+  }
+
+  const rFonts = getW(rPr, 'rFonts');
+  if (rFonts) {
+    const font = getWAttr(rFonts, 'ascii') || getWAttr(rFonts, 'eastAsia') || getWAttr(rFonts, 'hAnsi');
+    if (font) style.fontFamily = font;
+  }
+
+  const color = getW(rPr, 'color');
+  if (color) {
+    const val = getWAttr(color, 'val');
+    if (val && val !== 'auto') style.color = `#${val}`;
+  }
+
+  const highlight = getW(rPr, 'highlight');
+  if (highlight) {
+    const val = getWAttr(highlight, 'val');
+    if (val) style.backgroundColor = mapHighlightColor(val);
+  }
+
+  const shd = getW(rPr, 'shd');
+  if (shd && !style.backgroundColor) {
+    const fill = getWAttr(shd, 'fill');
+    if (fill && fill !== 'auto') style.backgroundColor = `#${fill}`;
+  }
+
+  const vertAlign = getW(rPr, 'vertAlign');
+  if (vertAlign) {
+    const val = getWAttr(vertAlign, 'val');
+    if (val === 'superscript') style.superscript = true;
+    if (val === 'subscript') style.subscript = true;
+  }
+
+  return style;
+}
+
+/**
+ * Map <w:pPr> element to block style + block type metadata.
+ */
+export function mapParagraphProperties(pPr: Element): {
+  blockStyle: BlockStyle;
+  headingLevel?: number;
+  blockType?: string;
+} {
+  const blockStyle: BlockStyle = { ...DEFAULT_BLOCK_STYLE };
+  let headingLevel: number | undefined;
+  let blockType: string | undefined;
+
+  const jc = getW(pPr, 'jc');
+  if (jc) {
+    const val = getWAttr(jc, 'val');
+    if (val === 'center') blockStyle.alignment = 'center';
+    else if (val === 'right') blockStyle.alignment = 'right';
+    else if (val === 'both') blockStyle.alignment = 'justify';
+    else blockStyle.alignment = 'left';
+  }
+
+  const spacing = getW(pPr, 'spacing');
+  if (spacing) {
+    const before = getWAttr(spacing, 'before');
+    if (before) blockStyle.marginTop = twipsToPx(parseInt(before, 10));
+    const after = getWAttr(spacing, 'after');
+    if (after) blockStyle.marginBottom = twipsToPx(parseInt(after, 10));
+    const line = getWAttr(spacing, 'line');
+    if (line) {
+      const lineVal = parseInt(line, 10);
+      // line value of 240 = single spacing (1.0)
+      if (lineVal > 0) blockStyle.lineHeight = lineVal / 240;
+    }
+  }
+
+  const ind = getW(pPr, 'ind');
+  if (ind) {
+    const firstLine = getWAttr(ind, 'firstLine');
+    if (firstLine) blockStyle.textIndent = twipsToPx(parseInt(firstLine, 10));
+    const left = getWAttr(ind, 'left');
+    if (left) blockStyle.marginLeft = twipsToPx(parseInt(left, 10));
+  }
+
+  const pStyle = getW(pPr, 'pStyle');
+  if (pStyle) {
+    const val = getWAttr(pStyle, 'val');
+    if (val) {
+      // Common heading style IDs
+      const headingMatch = val.match(/^(?:Heading|heading)(\d)$/);
+      if (headingMatch) {
+        headingLevel = parseInt(headingMatch[1], 10);
+        blockType = 'heading';
+      }
+      // Korean style IDs are sometimes just numbers
+      if (/^\d$/.test(val)) {
+        headingLevel = parseInt(val, 10);
+        blockType = 'heading';
+      }
+    }
+  }
+
+  return { blockStyle, headingLevel, blockType };
+}
+
+/**
+ * Map <w:tcPr> to cell background and border styles.
+ */
+export function mapTableCellProperties(tcPr: Element): {
+  backgroundColor?: string;
+  borderTop?: { width: number; color: string; style: 'solid' | 'none' };
+  borderBottom?: { width: number; color: string; style: 'solid' | 'none' };
+  borderLeft?: { width: number; color: string; style: 'solid' | 'none' };
+  borderRight?: { width: number; color: string; style: 'solid' | 'none' };
+  colSpan?: number;
+  vMerge?: 'restart' | 'continue';
+} {
+  const result: ReturnType<typeof mapTableCellProperties> = {};
+
+  const shd = getW(tcPr, 'shd');
+  if (shd) {
+    const fill = getWAttr(shd, 'fill');
+    if (fill && fill !== 'auto') result.backgroundColor = `#${fill}`;
+  }
+
+  const gridSpan = getW(tcPr, 'gridSpan');
+  if (gridSpan) {
+    const val = getWAttr(gridSpan, 'val');
+    if (val) result.colSpan = parseInt(val, 10);
+  }
+
+  const vMerge = getW(tcPr, 'vMerge');
+  if (vMerge) {
+    const val = getWAttr(vMerge, 'val');
+    result.vMerge = val === 'restart' ? 'restart' : 'continue';
+  }
+
+  const tcBorders = getW(tcPr, 'tcBorders');
+  if (tcBorders) {
+    const sides = [
+      ['top', 'borderTop'],
+      ['bottom', 'borderBottom'],
+      ['left', 'borderLeft'],
+      ['right', 'borderRight'],
+    ] as const;
+    for (const [side, key] of sides) {
+      const borderEl = getW(tcBorders, side);
+      if (borderEl) {
+        const sz = getWAttr(borderEl, 'sz');
+        const color = getWAttr(borderEl, 'color');
+        const val = getWAttr(borderEl, 'val');
+        result[key] = {
+          width: sz ? parseInt(sz, 10) / 8 : 1, // eighths of a point → px approximation
+          color: color && color !== 'auto' ? `#${color}` : '#000000',
+          style: val === 'none' || val === 'nil' ? 'none' : 'solid',
+        };
+      }
+    }
+  }
+
+  return result;
+}
+
+const HIGHLIGHT_COLORS: Record<string, string> = {
+  yellow: '#FFFF00',
+  green: '#00FF00',
+  cyan: '#00FFFF',
+  magenta: '#FF00FF',
+  blue: '#0000FF',
+  red: '#FF0000',
+  darkBlue: '#00008B',
+  darkCyan: '#008B8B',
+  darkGreen: '#006400',
+  darkMagenta: '#8B008B',
+  darkRed: '#8B0000',
+  darkYellow: '#808000',
+  darkGray: '#A9A9A9',
+  lightGray: '#D3D3D3',
+  black: '#000000',
+  white: '#FFFFFF',
+};
+
+export function mapHighlightColor(name: string): string {
+  return HIGHLIGHT_COLORS[name] ?? '#FFFF00';
+}

--- a/packages/docs/src/import/docx-style-map.ts
+++ b/packages/docs/src/import/docx-style-map.ts
@@ -24,8 +24,11 @@ export function mapRunProperties(rPr: Element): InlineStyle {
 
   const u = getW(rPr, 'u');
   if (u) {
+    // A bare <w:u/> without a w:val attribute is valid OOXML and means
+    // "underline enabled" (defaults to single). Only the explicit "none"
+    // value should suppress the underline.
     const val = getWAttr(u, 'val');
-    if (val && val !== 'none') style.underline = true;
+    if (val !== 'none') style.underline = true;
   }
 
   const sz = getW(rPr, 'sz');
@@ -49,7 +52,9 @@ export function mapRunProperties(rPr: Element): InlineStyle {
   const highlight = getW(rPr, 'highlight');
   if (highlight) {
     const val = getWAttr(highlight, 'val');
-    if (val) style.backgroundColor = mapHighlightColor(val);
+    // Skip "none" so that the mapHighlightColor fallback does not
+    // incorrectly apply yellow to explicitly cleared highlights.
+    if (val && val !== 'none') style.backgroundColor = mapHighlightColor(val);
   }
 
   const shd = getW(rPr, 'shd');

--- a/packages/docs/src/import/units.ts
+++ b/packages/docs/src/import/units.ts
@@ -1,0 +1,35 @@
+/**
+ * OOXML ↔ CSS px unit conversions.
+ *
+ * 1 inch = 1440 twips = 914400 EMUs = 72 points = 96 CSS px
+ */
+
+/** Twips (1/1440 inch) → CSS pixels (1/96 inch). */
+export function twipsToPx(twips: number): number {
+  return twips * 96 / 1440;
+}
+
+/** CSS pixels → twips. */
+export function pxToTwips(px: number): number {
+  return px * 1440 / 96;
+}
+
+/** EMUs (1/914400 inch) → CSS pixels. */
+export function emusToPx(emus: number): number {
+  return emus * 96 / 914400;
+}
+
+/** CSS pixels → EMUs. */
+export function pxToEmus(px: number): number {
+  return px * 914400 / 96;
+}
+
+/** OOXML half-points → points. */
+export function halfPointsToPoints(halfPts: number): number {
+  return halfPts / 2;
+}
+
+/** Points → OOXML half-points. */
+export function pointsToHalfPoints(pts: number): number {
+  return pts * 2;
+}

--- a/packages/docs/src/import/units.ts
+++ b/packages/docs/src/import/units.ts
@@ -9,9 +9,11 @@ export function twipsToPx(twips: number): number {
   return twips * 96 / 1440;
 }
 
-/** CSS pixels → twips. */
+/**
+ * CSS pixels → twips. Rounded because OOXML attributes expect integer values.
+ */
 export function pxToTwips(px: number): number {
-  return px * 1440 / 96;
+  return Math.round(px * 1440 / 96);
 }
 
 /** EMUs (1/914400 inch) → CSS pixels. */
@@ -19,9 +21,12 @@ export function emusToPx(emus: number): number {
   return emus * 96 / 914400;
 }
 
-/** CSS pixels → EMUs. */
+/**
+ * CSS pixels → EMUs. Rounded because OOXML drawing extents expect integer
+ * EMU values.
+ */
 export function pxToEmus(px: number): number {
-  return px * 914400 / 96;
+  return Math.round(px * 914400 / 96);
 }
 
 /** OOXML half-points → points. */
@@ -29,7 +34,10 @@ export function halfPointsToPoints(halfPts: number): number {
   return halfPts / 2;
 }
 
-/** Points → OOXML half-points. */
+/**
+ * Points → OOXML half-points. Rounded because OOXML size attributes expect
+ * integer half-point values.
+ */
 export function pointsToHalfPoints(pts: number): number {
-  return pts * 2;
+  return Math.round(pts * 2);
 }

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -7,6 +7,7 @@ export type {
   Inline,
   BlockStyle,
   InlineStyle,
+  ImageData,
   DocPosition,
   DocRange,
   PageSetup,

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -110,3 +110,9 @@ export type { SearchMatch, SearchOptions } from './model/types.js';
 export { isSafeUrl, normalizeLinkUrl } from './view/url-detect.js';
 export { computeScaleFactor, MOBILE_PADDING } from './view/scale.js';
 export type { LayoutTable, LayoutTableCell } from './view/table-layout.js';
+
+// Import / Export (DOCX)
+export { DocxImporter } from './import/docx-importer.js';
+export type { ImageUploader } from './import/docx-importer.js';
+export { DocxExporter } from './export/docx-exporter.js';
+export type { ImageFetcher } from './export/docx-exporter.js';

--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -28,7 +28,7 @@ import {
 } from './types.js';
 import { MemDocStore } from '../store/memory.js';
 import type { DocStore } from '../store/store.js';
-import { applyDeleteText, cloneBlock } from '../store/block-helpers.js';
+import { applyDeleteText, applyInsertInline } from '../store/block-helpers.js';
 
 /**
  * The current editing context for header/footer routing.
@@ -184,27 +184,8 @@ export class Doc {
   insertImageInline(blockId: string, offset: number, imageInline: Inline): void {
     this.store.snapshot();
     const block = this.getBlock(blockId);
-    const cloned = cloneBlock(block);
-
-    // Split inlines at offset, insert the image inline in between
-    const before: Inline[] = [];
-    const after: Inline[] = [];
-    let remaining = offset;
-    for (const inline of cloned.inlines) {
-      if (remaining >= inline.text.length) {
-        before.push(inline);
-        remaining -= inline.text.length;
-      } else if (remaining > 0) {
-        before.push({ text: inline.text.slice(0, remaining), style: { ...inline.style } });
-        after.push({ text: inline.text.slice(remaining), style: { ...inline.style } });
-        remaining = 0;
-      } else {
-        after.push(inline);
-      }
-    }
-
-    cloned.inlines = [...before, imageInline, ...after];
-    this.store.updateBlock(blockId, cloned);
+    const updated = applyInsertInline(block, offset, imageInline);
+    this.updateBlockInStore(blockId, updated);
     this.refresh();
   }
 
@@ -851,6 +832,11 @@ export class Doc {
       const tableBlock = this._document.blocks.find((b) => b.id === cellInfo.tableBlockId);
       if (tableBlock) {
         const cell = tableBlock.tableData!.rows[cellInfo.rowIndex].cells[cellInfo.colIndex];
+        // Replace the block within the cell with the updated one (handles pure-function callers)
+        const blockIndex = cell.blocks.findIndex((b) => b.id === blockId);
+        if (blockIndex !== -1) {
+          cell.blocks[blockIndex] = block;
+        }
         this.store.updateTableCell(cellInfo.tableBlockId, cellInfo.rowIndex, cellInfo.colIndex, cell);
       }
     } else {

--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -28,7 +28,7 @@ import {
 } from './types.js';
 import { MemDocStore } from '../store/memory.js';
 import type { DocStore } from '../store/store.js';
-import { applyDeleteText } from '../store/block-helpers.js';
+import { applyDeleteText, cloneBlock } from '../store/block-helpers.js';
 
 /**
  * The current editing context for header/footer routing.
@@ -174,6 +174,37 @@ export class Doc {
     } else {
       this.store.insertText(pos.blockId, pos.offset, text);
     }
+    this.refresh();
+  }
+
+  /**
+   * Insert an image inline at the given offset within a block.
+   * The image inline uses \uFFFC as its text character.
+   */
+  insertImageInline(blockId: string, offset: number, imageInline: Inline): void {
+    this.store.snapshot();
+    const block = this.getBlock(blockId);
+    const cloned = cloneBlock(block);
+
+    // Split inlines at offset, insert the image inline in between
+    const before: Inline[] = [];
+    const after: Inline[] = [];
+    let remaining = offset;
+    for (const inline of cloned.inlines) {
+      if (remaining >= inline.text.length) {
+        before.push(inline);
+        remaining -= inline.text.length;
+      } else if (remaining > 0) {
+        before.push({ text: inline.text.slice(0, remaining), style: { ...inline.style } });
+        after.push({ text: inline.text.slice(remaining), style: { ...inline.style } });
+        remaining = 0;
+      } else {
+        after.push(inline);
+      }
+    }
+
+    cloned.inlines = [...before, imageInline, ...after];
+    this.store.updateBlock(blockId, cloned);
     this.refresh();
   }
 

--- a/packages/docs/src/model/types.ts
+++ b/packages/docs/src/model/types.ts
@@ -69,6 +69,17 @@ export interface BlockStyle {
 }
 
 /**
+ * Image metadata for an inline image element.
+ * Used when an Inline has text '\uFFFC' (Object Replacement Character).
+ */
+export interface ImageData {
+  src: string;
+  width: number;
+  height: number;
+  alt?: string;
+}
+
+/**
  * Character-level formatting applied to an Inline.
  * All properties are optional; undefined means "inherit default".
  */
@@ -85,6 +96,7 @@ export interface InlineStyle {
   subscript?: boolean;
   href?: string;
   pageNumber?: boolean;
+  image?: ImageData;
 }
 
 /**
@@ -227,6 +239,12 @@ export function getBlockText(block: Block): string {
   return block.inlines.map((inline) => inline.text).join('');
 }
 
+function imageDataEqual(a: ImageData | undefined, b: ImageData | undefined): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.src === b.src && a.width === b.width && a.height === b.height && a.alt === b.alt;
+}
+
 /**
  * Check if two inline styles are equal.
  */
@@ -243,7 +261,8 @@ export function inlineStylesEqual(a: InlineStyle, b: InlineStyle): boolean {
     a.superscript === b.superscript &&
     a.subscript === b.subscript &&
     a.href === b.href &&
-    a.pageNumber === b.pageNumber
+    a.pageNumber === b.pageNumber &&
+    imageDataEqual(a.image, b.image)
   );
 }
 

--- a/packages/docs/src/store/block-helpers.ts
+++ b/packages/docs/src/store/block-helpers.ts
@@ -205,6 +205,34 @@ export function applyMergeBlocks(block: Block, nextBlock: Block): Block {
 }
 
 /**
+ * Insert an inline element at a block-level character offset.
+ * Splits inlines at offset, inserts the new inline in between,
+ * and normalizes the result. Returns a new Block (pure function).
+ */
+export function applyInsertInline(block: Block, offset: number, inline: Inline): Block {
+  const newBlock = cloneBlock(block);
+  const before: Inline[] = [];
+  const after: Inline[] = [];
+  let remaining = offset;
+
+  for (const existing of newBlock.inlines) {
+    if (remaining >= existing.text.length) {
+      before.push(existing);
+      remaining -= existing.text.length;
+    } else if (remaining > 0) {
+      before.push({ text: existing.text.slice(0, remaining), style: { ...existing.style } });
+      after.push({ text: existing.text.slice(remaining), style: { ...existing.style } });
+      remaining = 0;
+    } else {
+      after.push(existing);
+    }
+  }
+
+  newBlock.inlines = normalizeInlines([...before, { ...inline }, ...after]);
+  return newBlock;
+}
+
+/**
  * Apply inline style to a range within a block. Returns new Block.
  * Splits inlines as needed and normalizes the result.
  */

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -18,9 +18,21 @@ import { renderTable } from './table-renderer.js';
 const imageCache = new Map<string, HTMLImageElement>();
 
 /**
+ * Callbacks waiting on in-flight image loads, keyed by src. When an image
+ * load kicks off from one DocCanvas render, any subsequent call from a
+ * different DocCanvas instance (or the same instance on a re-render)
+ * subscribes here so that every interested caller gets notified when the
+ * load resolves. Without this, the second caller's onLoad would be
+ * silently dropped and its canvas would never repaint with the image.
+ */
+const pendingImageCallbacks = new Map<string, Set<() => void>>();
+
+/**
  * Return a loaded HTMLImageElement for the given src, or null if it is
  * still loading. On first encounter, kicks off an async load and invokes
  * `onLoad` once the image is ready so the caller can trigger a re-render.
+ * When the image is already loading from a previous call, the caller is
+ * subscribed to the in-flight load so its onLoad still fires.
  */
 function getOrLoadImage(
   src: string,
@@ -28,16 +40,47 @@ function getOrLoadImage(
 ): HTMLImageElement | null {
   const cached = imageCache.get(src);
   if (cached) {
-    return cached.complete && cached.naturalWidth > 0 ? cached : null;
+    if (cached.complete && cached.naturalWidth > 0) return cached;
+    // Still loading (or failed with naturalWidth === 0). Subscribe only
+    // while the image is not yet complete so that in-flight loads notify
+    // every waiting callback.
+    if (!cached.complete) {
+      let callbacks = pendingImageCallbacks.get(src);
+      if (!callbacks) {
+        callbacks = new Set();
+        pendingImageCallbacks.set(src, callbacks);
+      }
+      callbacks.add(onLoad);
+    }
+    return null;
   }
+
   const img = new Image();
-  img.onload = onLoad;
+  imageCache.set(src, img);
+  const callbacks = new Set<() => void>([onLoad]);
+  pendingImageCallbacks.set(src, callbacks);
+
+  img.onload = () => {
+    const waiting = pendingImageCallbacks.get(src);
+    pendingImageCallbacks.delete(src);
+    if (waiting) {
+      for (const cb of waiting) {
+        try {
+          cb();
+        } catch {
+          // Ignore listener errors so that one failing subscriber does
+          // not block notifications for the rest.
+        }
+      }
+    }
+  };
   img.onerror = () => {
     // Broken image is now cached; subsequent draws will skip it via the
-    // `naturalWidth > 0` guard above. No re-render needed.
+    // `naturalWidth > 0` guard above. Drop any pending callbacks so they
+    // are not retained forever.
+    pendingImageCallbacks.delete(src);
   };
   img.src = src;
-  imageCache.set(src, img);
   return null;
 }
 

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -11,6 +11,34 @@ import { drawPeerCaret, drawPeerLabel } from './peer-cursor.js';
 import { renderTable } from './table-renderer.js';
 
 /**
+ * Shared cache of loaded inline images, keyed by src URL. Populated lazily
+ * on first render and reused across all DocCanvas instances so that
+ * navigating between documents does not re-fetch images.
+ */
+const imageCache = new Map<string, HTMLImageElement>();
+
+/**
+ * Return a loaded HTMLImageElement for the given src, or null if it is
+ * still loading. On first encounter, kicks off an async load and invokes
+ * `onLoad` once the image is ready so the caller can trigger a re-render.
+ */
+function getOrLoadImage(
+  src: string,
+  onLoad: () => void,
+): HTMLImageElement | null {
+  const cached = imageCache.get(src);
+  if (cached) {
+    return cached.complete && cached.naturalWidth > 0 ? cached : null;
+  }
+  const img = new Image();
+  img.onload = onLoad;
+  img.onerror = onLoad;
+  img.src = src;
+  imageCache.set(src, img);
+  return null;
+}
+
+/**
  * Convert a peer cursor color (hex) to a translucent selection fill.
  */
 function peerColorToSelectionColor(hex: string): string {
@@ -27,6 +55,12 @@ function peerColorToSelectionColor(hex: string): string {
 export class DocCanvas {
   private canvas: HTMLCanvasElement;
   private ctx: CanvasRenderingContext2D;
+  /**
+   * Optional re-render trigger invoked after async resources (e.g. inline
+   * images) finish loading. Set by the owning editor via
+   * {@link setRequestRender}. Null while not wired (tests, headless use).
+   */
+  private requestRender: (() => void) | null = null;
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas;
@@ -37,6 +71,14 @@ export class DocCanvas {
 
   getContext(): CanvasRenderingContext2D {
     return this.ctx;
+  }
+
+  /**
+   * Register a callback used to trigger a re-render when asynchronous
+   * resources (currently inline images) finish loading.
+   */
+  setRequestRender(cb: () => void): void {
+    this.requestRender = cb;
   }
 
   /**
@@ -452,6 +494,25 @@ export class DocCanvas {
     lineHeight: number,
   ): void {
     const style = run.inline.style;
+
+    // Image inlines are rendered via drawImage, not fillText. The run's
+    // width/imageHeight were set by layoutBlock (scaled to fit if needed);
+    // we align the image to the line's baseline area.
+    if (style.image) {
+      const x = Math.round(lineX + run.x);
+      const drawHeight = run.imageHeight ?? lineHeight;
+      // Bottom-align the image so it sits on the text baseline row.
+      const y = Math.round(lineY + lineHeight - drawHeight);
+      const img = getOrLoadImage(style.image.src, () => {
+        // Trigger a re-render when the image finishes loading.
+        this.requestRender?.();
+      });
+      if (img) {
+        this.ctx.drawImage(img, x, y, run.width, drawHeight);
+      }
+      return;
+    }
+
     const originalFontSizePx = ptToPx(style.fontSize ?? Theme.defaultFontSize);
 
     // Superscript/subscript: reduce font size to 60% and shift baseline

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -32,7 +32,10 @@ function getOrLoadImage(
   }
   const img = new Image();
   img.onload = onLoad;
-  img.onerror = onLoad;
+  img.onerror = () => {
+    // Broken image is now cached; subsequent draws will skip it via the
+    // `naturalWidth > 0` guard above. No re-render needed.
+  };
   img.src = src;
   imageCache.set(src, img);
   return null;

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -785,6 +785,11 @@ export function initialize(
     paint();
   };
 
+  // Allow the canvas to request a paint-only re-render once async resources
+  // (inline images) finish loading. Layout already reserved space using the
+  // known image dimensions, so no relayout is needed.
+  docCanvas.setRequestRender(() => renderPaintOnly());
+
   // Wire ruler callbacks
   ruler.onMarginChange((margins) => {
     docStore.snapshot();

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -105,6 +105,12 @@ export interface EditorAPI {
   onEditContextChange(cb: (context: 'body' | 'header' | 'footer') => void): void;
   /** Focus the editor */
   focus(): void;
+  /**
+   * Reset editor state after the underlying document was replaced externally
+   * (e.g. via `store.setDocument()`). Refreshes the cached document, resets
+   * the cursor to the first block, invalidates layout caches, and repaints.
+   */
+  resetAfterDocumentReplace(): void;
   /** Clean up */
   dispose(): void;
 }
@@ -1431,6 +1437,18 @@ export function initialize(
       textEditor?.onEditContextChange(cb);
     },
     focus: () => textEditor?.focus(),
+    resetAfterDocumentReplace: () => {
+      doc.refresh();
+      textEditor?.setEditContext('body');
+      layoutCache = undefined;
+      const firstBlock = doc.document.blocks[0];
+      if (firstBlock) {
+        cursor.moveTo({ blockId: firstBlock.id, offset: 0 });
+      }
+      selection.setRange(null);
+      needsScrollIntoView = true;
+      render();
+    },
     dispose: () => {
       peerCursors = [];
       cursorMoveCallback = null;

--- a/packages/docs/src/view/fonts.ts
+++ b/packages/docs/src/view/fonts.ts
@@ -16,6 +16,15 @@ const FONT_MAP: Record<string, string> = {
 const SERIF_FONTS = new Set(['바탕', 'Batang', 'Noto Serif KR', 'Times New Roman', 'Georgia']);
 
 /**
+ * Escape a font family name for use in a CSS single-quoted string.
+ * The CSS spec requires backslashes and single quotes to be escaped.
+ */
+function escapeFontFamily(family: string): string {
+  // Escape backslashes first, then single quotes.
+  return family.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+/**
  * Resolve a font family name to a CSS fallback chain string.
  */
 export function resolveFontFamily(family: string): string {
@@ -23,7 +32,7 @@ export function resolveFontFamily(family: string): string {
   if (mapped) return mapped;
 
   const generic = SERIF_FONTS.has(family) ? 'serif' : 'sans-serif';
-  return `'${family}', ${generic}`;
+  return `'${escapeFontFamily(family)}', ${generic}`;
 }
 
 type FontStatus = 'pending' | 'loading' | 'loaded' | 'error';
@@ -53,14 +62,17 @@ export class FontRegistry {
     const current = this.status.get(key);
     if (current === 'loaded' || current === 'loading') return;
 
-    if (document.fonts.check(`12px "${family}"`)) {
+    // Use JSON.stringify to produce a correctly quoted font name for the
+    // Font Loading API, handling embedded quotes and special characters.
+    const fontSpec = `12px ${JSON.stringify(family)}`;
+    if (document.fonts.check(fontSpec)) {
       this.status.set(key, 'loaded');
       return;
     }
 
     this.status.set(key, 'loading');
     try {
-      await document.fonts.load(`12px "${family}"`);
+      await document.fonts.load(fontSpec);
       this.status.set(key, 'loaded');
     } catch {
       this.status.set(key, 'error');

--- a/packages/docs/src/view/fonts.ts
+++ b/packages/docs/src/view/fonts.ts
@@ -1,0 +1,74 @@
+/**
+ * Font registry — maps font family names to web-safe fallback chains
+ * and handles on-demand font loading via the CSS Font Loading API.
+ */
+
+const FONT_MAP: Record<string, string> = {
+  '맑은 고딕': "'Malgun Gothic', 'Noto Sans KR', sans-serif",
+  'Malgun Gothic': "'Malgun Gothic', 'Noto Sans KR', sans-serif",
+  '바탕': "'Batang', 'Noto Serif KR', serif",
+  'Batang': "'Batang', 'Noto Serif KR', serif",
+  'HY헤드라인M': "'Noto Sans KR', sans-serif",
+  'Arial': "'Arial', sans-serif",
+  'Tahoma': "'Tahoma', sans-serif",
+};
+
+const SERIF_FONTS = new Set(['바탕', 'Batang', 'Noto Serif KR', 'Times New Roman', 'Georgia']);
+
+/**
+ * Resolve a font family name to a CSS fallback chain string.
+ */
+export function resolveFontFamily(family: string): string {
+  const mapped = FONT_MAP[family];
+  if (mapped) return mapped;
+
+  const generic = SERIF_FONTS.has(family) ? 'serif' : 'sans-serif';
+  return `'${family}', ${generic}`;
+}
+
+type FontStatus = 'pending' | 'loading' | 'loaded' | 'error';
+
+/**
+ * FontRegistry manages on-demand web font loading and notifies
+ * listeners when fonts finish loading (to trigger re-layout).
+ */
+export class FontRegistry {
+  private status = new Map<string, FontStatus>();
+  private listeners: Array<() => void> = [];
+
+  /**
+   * Register a callback to be called when any font finishes loading.
+   */
+  onFontLoaded(cb: () => void): void {
+    this.listeners.push(cb);
+  }
+
+  /**
+   * Ensure a font is loaded. If not yet loaded, triggers async loading
+   * and calls listeners when done.
+   */
+  async ensureFont(family: string): Promise<void> {
+    if (typeof document === 'undefined') return; // SSR guard
+    const key = family;
+    const current = this.status.get(key);
+    if (current === 'loaded' || current === 'loading') return;
+
+    if (document.fonts.check(`12px "${family}"`)) {
+      this.status.set(key, 'loaded');
+      return;
+    }
+
+    this.status.set(key, 'loading');
+    try {
+      await document.fonts.load(`12px "${family}"`);
+      this.status.set(key, 'loaded');
+      this.listeners.forEach((cb) => cb());
+    } catch {
+      this.status.set(key, 'error');
+    }
+  }
+
+  getFontStatus(family: string): FontStatus {
+    return this.status.get(family) ?? 'pending';
+  }
+}

--- a/packages/docs/src/view/fonts.ts
+++ b/packages/docs/src/view/fonts.ts
@@ -62,9 +62,22 @@ export class FontRegistry {
     try {
       await document.fonts.load(`12px "${family}"`);
       this.status.set(key, 'loaded');
-      this.listeners.forEach((cb) => cb());
     } catch {
       this.status.set(key, 'error');
+      return;
+    }
+
+    // Listeners are invoked after the status is settled so that a
+    // listener throwing cannot flip the font into 'error' via the
+    // surrounding catch block. Each callback is wrapped individually so
+    // one failing subscriber does not block notifications for the rest.
+    for (const cb of this.listeners) {
+      try {
+        cb();
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('FontRegistry listener threw:', e);
+      }
     }
   }
 

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -68,6 +68,11 @@ export interface LayoutRun {
   charEnd: number;
   /** Cumulative pixel widths: charOffsets[i] = width of text.slice(0, i+1). Length === text.length. */
   charOffsets: number[];
+  /**
+   * For image inlines, the pixel height of the (possibly scaled) image.
+   * Line height must grow to accommodate this. Undefined for text runs.
+   */
+  imageHeight?: number;
 }
 
 /**
@@ -122,6 +127,12 @@ interface MeasuredSegment {
   charStart: number;
   charEnd: number;
   font: string;
+  /**
+   * Intrinsic image dimensions for image inlines. When present, this segment
+   * is treated as unbreakable and rendered as an image run. Width is the
+   * intrinsic pixel width (pre-scale); rendering may scale down to fit.
+   */
+  image?: { width: number; height: number };
 }
 
 /**
@@ -200,7 +211,14 @@ export function computeLayout(
       let blockY = 0;
       for (const line of lines) {
         const maxFontSize = getLineMaxFontSizePx(line, effectiveBlock);
-        const lineHeight = lineHeightMultiplier * maxFontSize;
+        let lineHeight = lineHeightMultiplier * maxFontSize;
+        // Any image runs on this line force the line height to accommodate
+        // the tallest image.
+        for (const run of line.runs) {
+          if (run.imageHeight !== undefined && run.imageHeight > lineHeight) {
+            lineHeight = run.imageHeight;
+          }
+        }
         line.y = blockY;
         line.height = lineHeight;
         blockY += lineHeight;
@@ -293,6 +311,36 @@ function layoutBlock(
   };
 
   for (const seg of segments) {
+    // Image segments are unbreakable. Scale down to fit the effective line
+    // width if necessary, then emit a single run carrying the image height.
+    if (seg.image) {
+      let displayWidth = seg.image.width;
+      let displayHeight = seg.image.height;
+      if (effectiveWidth > 0 && displayWidth > effectiveWidth) {
+        const scale = effectiveWidth / displayWidth;
+        displayWidth = effectiveWidth;
+        displayHeight = seg.image.height * scale;
+      }
+      // Wrap to next line if the scaled image won't fit next to existing runs.
+      if (lineWidth + displayWidth > effectiveWidth && currentRuns.length > 0) {
+        flushLine();
+      }
+      currentRuns.push({
+        inline: inlines[seg.inlineIndex],
+        text: seg.text,
+        x: lineStartX + lineWidth,
+        width: displayWidth,
+        inlineIndex: seg.inlineIndex,
+        charStart: seg.charStart,
+        charEnd: seg.charEnd,
+        // Single-character placeholder: charOffsets has one entry equal to width.
+        charOffsets: seg.text.length > 0 ? [displayWidth] : [],
+        imageHeight: displayHeight,
+      });
+      lineWidth += displayWidth;
+      continue;
+    }
+
     // If adding this segment exceeds effective width and line is not empty,
     // wrap to next line
     if (lineWidth + seg.width > effectiveWidth && currentRuns.length > 0) {
@@ -394,6 +442,25 @@ function measureSegments(
       inline.style.bold,
       inline.style.italic,
     );
+
+    // Image inlines are a single unbreakable segment spanning the entire
+    // inline text (the Object Replacement Character placeholder). Width
+    // comes from the image metadata rather than text measurement; any
+    // scale-to-fit is applied later in layoutBlock.
+    if (inline.style.image) {
+      const image = inline.style.image;
+      segments.push({
+        text: inline.text,
+        style: inline.style,
+        width: image.width,
+        inlineIndex: i,
+        charStart: 0,
+        charEnd: inline.text.length,
+        font,
+        image: { width: image.width, height: image.height },
+      });
+      continue;
+    }
 
     // Split on word boundaries (keep spaces attached to preceding word)
     const words = splitWords(inline.text);

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -51,6 +51,25 @@ function layoutCellInlines(
   let currentRuns: LayoutLine['runs'] = [];
   let lineWidth = 0;
   let lineMaxFontSize = 0;
+  // Tallest image on the current line, in pixels. Tracked separately from
+  // lineMaxFontSize so it is not multiplied by the 1.5 text line-height
+  // factor — the final line height is max(textHeight, imageHeight).
+  let lineMaxImageHeight = 0;
+
+  const flushCurrentLine = (fallbackFontSizePx: number) => {
+    const textLineHeight = (lineMaxFontSize || fallbackFontSizePx) * 1.5;
+    const lineHeight = Math.max(textLineHeight, lineMaxImageHeight);
+    lines.push({
+      runs: currentRuns,
+      y: 0,
+      height: lineHeight,
+      width: lineWidth,
+    });
+    currentRuns = [];
+    lineWidth = 0;
+    lineMaxFontSize = 0;
+    lineMaxImageHeight = 0;
+  };
 
   for (let i = 0; i < inlines.length; i++) {
     const inline = inlines[i];
@@ -63,6 +82,39 @@ function layoutCellInlines(
       inline.style.italic,
     );
 
+    // Image inlines are a single unbreakable run. Scale down to fit the
+    // cell width if necessary, and force line height to accommodate the
+    // image. Mirrors the image path in layoutBlock / measureSegments.
+    if (inline.style.image) {
+      const image = inline.style.image;
+      let displayWidth = image.width;
+      let displayHeight = image.height;
+      if (maxWidth > 0 && displayWidth > maxWidth) {
+        const scale = maxWidth / displayWidth;
+        displayWidth = maxWidth;
+        displayHeight = image.height * scale;
+      }
+      // Wrap to next line if the scaled image won't fit next to existing runs.
+      if (lineWidth + displayWidth > maxWidth && currentRuns.length > 0) {
+        flushCurrentLine(fontSizePx);
+      }
+      currentRuns.push({
+        inline,
+        text: inline.text,
+        x: lineWidth,
+        width: displayWidth,
+        inlineIndex: i,
+        charStart: 0,
+        charEnd: inline.text.length,
+        // Single-character placeholder: charOffsets has one entry equal to width.
+        charOffsets: inline.text.length > 0 ? [displayWidth] : [],
+        imageHeight: displayHeight,
+      });
+      lineWidth += displayWidth;
+      if (displayHeight > lineMaxImageHeight) lineMaxImageHeight = displayHeight;
+      continue;
+    }
+
     // Split text into words (keep trailing spaces with preceding word)
     const words = splitWords(inline.text);
     let charPos = 0;
@@ -72,16 +124,7 @@ function layoutCellInlines(
 
       // Wrap if adding this word exceeds maxWidth and line is not empty
       if (lineWidth + wordWidth > maxWidth && currentRuns.length > 0) {
-        const lineHeight = (lineMaxFontSize || fontSizePx) * 1.5;
-        lines.push({
-          runs: currentRuns,
-          y: 0,
-          height: lineHeight,
-          width: lineWidth,
-        });
-        currentRuns = [];
-        lineWidth = 0;
-        lineMaxFontSize = 0;
+        flushCurrentLine(fontSizePx);
       }
 
       currentRuns.push({
@@ -102,14 +145,7 @@ function layoutCellInlines(
 
   // Flush remaining runs
   if (currentRuns.length > 0) {
-    const defaultFontSizePx = ptToPx(Theme.defaultFontSize);
-    const lineHeight = (lineMaxFontSize || defaultFontSizePx) * 1.5;
-    lines.push({
-      runs: currentRuns,
-      y: 0,
-      height: lineHeight,
-      width: lineWidth,
-    });
+    flushCurrentLine(ptToPx(Theme.defaultFontSize));
   }
 
   // Set cumulative y offsets

--- a/packages/docs/test/export/docx-exporter.test.ts
+++ b/packages/docs/test/export/docx-exporter.test.ts
@@ -103,6 +103,58 @@ describe('DocxExporter', () => {
     expect(zip.file('_rels/.rels')).not.toBeNull();
   });
 
+  it('should throw when image inline has no matching media entry (no imageFetcher)', async () => {
+    // Issue 1: When a document contains an image inline but no imageFetcher is
+    // provided (so no media entries are collected), the exporter must throw a
+    // descriptive error rather than silently falling through to a text run.
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [
+          { text: '\uFFFC', style: { image: { src: 'https://example.com/photo.jpg', width: 100, height: 80 } } },
+        ],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+
+    await expect(DocxExporter.export(doc)).rejects.toThrow(
+      'DOCX export: image inline references https://example.com/photo.jpg but no matching media entry was collected.',
+    );
+  });
+
+  it('should derive media extension from blob MIME type, not URL', async () => {
+    // Issue 2: Extension must come from blob.type so that JPEG bytes served
+    // under a .png URL (or an extensionless URL) are packaged correctly.
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [
+          // URL has no extension — previously would fall back to 'png'
+          { text: '\uFFFC', style: { image: { src: 'https://cdn.example.com/images/abcdef', width: 100, height: 80 } } },
+        ],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+
+    // Return a JPEG blob despite the URL having no extension
+    const fetcher = async (_url: string): Promise<Blob> =>
+      new Blob([new Uint8Array([0xff, 0xd8, 0xff, 0xe0])], { type: 'image/jpeg' });
+
+    const blob = await DocxExporter.export(doc, fetcher);
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+
+    // The media file should be stored as .jpg, not .png or 'abcdef'
+    const mediaFiles: string[] = [];
+    zip.forEach((path, entry) => {
+      if (path.startsWith('word/media/') && !entry.dir) mediaFiles.push(path);
+    });
+    expect(mediaFiles).toHaveLength(1);
+    expect(mediaFiles[0]).toMatch(/\.jpg$/);
+  });
+
   it('should package header/footer images with part-scoped rels', async () => {
     // Header/footer blocks with image inlines must be accompanied by
     // media files in the zip AND their own part-scoped .rels files

--- a/packages/docs/test/export/docx-exporter.test.ts
+++ b/packages/docs/test/export/docx-exporter.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { DocxExporter } from '../../src/export/docx-exporter.js';
+import { DocxImporter } from '../../src/import/docx-importer.js';
+import type { Document } from '../../src/model/types.js';
+import { DEFAULT_BLOCK_STYLE, generateBlockId } from '../../src/model/types.js';
+
+// jsdom's Blob shim lacks arrayBuffer(); polyfill via FileReader.
+if (typeof Blob.prototype.arrayBuffer !== 'function') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (Blob.prototype as any).arrayBuffer = function arrayBuffer(this: Blob): Promise<ArrayBuffer> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as ArrayBuffer);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsArrayBuffer(this);
+    });
+  };
+}
+
+describe('DocxExporter', () => {
+  it('should export a simple paragraph and re-import it', async () => {
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [{ text: 'Hello World', style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+
+    const blob = await DocxExporter.export(doc);
+    expect(blob.size).toBeGreaterThan(0);
+
+    // Re-import and verify round-trip
+    const buffer = await blob.arrayBuffer();
+    const reimported = await DocxImporter.import(buffer);
+    expect(reimported.blocks).toHaveLength(1);
+    expect(reimported.blocks[0].inlines[0].text).toBe('Hello World');
+  });
+
+  it('should export styled text', async () => {
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [
+          { text: 'Normal ', style: {} },
+          { text: 'Bold', style: { bold: true } },
+        ],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+
+    const blob = await DocxExporter.export(doc);
+    const buffer = await blob.arrayBuffer();
+    const reimported = await DocxImporter.import(buffer);
+    expect(reimported.blocks[0].inlines).toHaveLength(2);
+    expect(reimported.blocks[0].inlines[1].style.bold).toBe(true);
+  });
+
+  it('should export a table', async () => {
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'table',
+        inlines: [],
+        style: { ...DEFAULT_BLOCK_STYLE },
+        tableData: {
+          rows: [{
+            cells: [
+              { blocks: [{ id: generateBlockId(), type: 'paragraph', inlines: [{ text: 'A1', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }], style: {} },
+              { blocks: [{ id: generateBlockId(), type: 'paragraph', inlines: [{ text: 'B1', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }], style: {} },
+            ],
+          }],
+          columnWidths: [0.5, 0.5],
+        },
+      }],
+    };
+
+    const blob = await DocxExporter.export(doc);
+    const buffer = await blob.arrayBuffer();
+    const reimported = await DocxImporter.import(buffer);
+    expect(reimported.blocks[0].type).toBe('table');
+    expect(reimported.blocks[0].tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('A1');
+  });
+
+  it('should produce a valid .docx zip', async () => {
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [{ text: 'Test', style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+
+    const blob = await DocxExporter.export(doc);
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    expect(zip.file('word/document.xml')).not.toBeNull();
+    expect(zip.file('[Content_Types].xml')).not.toBeNull();
+    expect(zip.file('_rels/.rels')).not.toBeNull();
+  });
+});

--- a/packages/docs/test/export/docx-exporter.test.ts
+++ b/packages/docs/test/export/docx-exporter.test.ts
@@ -102,4 +102,78 @@ describe('DocxExporter', () => {
     expect(zip.file('[Content_Types].xml')).not.toBeNull();
     expect(zip.file('_rels/.rels')).not.toBeNull();
   });
+
+  it('should package header/footer images with part-scoped rels', async () => {
+    // Header/footer blocks with image inlines must be accompanied by
+    // media files in the zip AND their own part-scoped .rels files
+    // (word/_rels/header1.xml.rels, word/_rels/footer1.xml.rels).
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [{ text: 'Body', style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+      header: {
+        blocks: [{
+          id: generateBlockId(),
+          type: 'paragraph',
+          inlines: [
+            { text: '\uFFFC', style: { image: { src: 'https://example.com/logo.png', width: 80, height: 20 } } },
+          ],
+          style: { ...DEFAULT_BLOCK_STYLE },
+        }],
+        marginFromEdge: 48,
+      },
+      footer: {
+        blocks: [{
+          id: generateBlockId(),
+          type: 'paragraph',
+          inlines: [
+            { text: '\uFFFC', style: { image: { src: 'https://example.com/stamp.png', width: 40, height: 40 } } },
+          ],
+          style: { ...DEFAULT_BLOCK_STYLE },
+        }],
+        marginFromEdge: 48,
+      },
+    };
+
+    const fetches: string[] = [];
+    const fakeFetcher = async (url: string): Promise<Blob> => {
+      fetches.push(url);
+      return new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' });
+    };
+
+    const blob = await DocxExporter.export(doc, fakeFetcher);
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+
+    // Both header and footer images should be fetched and packaged.
+    expect(fetches).toContain('https://example.com/logo.png');
+    expect(fetches).toContain('https://example.com/stamp.png');
+
+    // Header and footer rels files must exist and reference image relationships.
+    const headerRels = await zip.file('word/_rels/header1.xml.rels')?.async('string');
+    const footerRels = await zip.file('word/_rels/footer1.xml.rels')?.async('string');
+    expect(headerRels).toBeDefined();
+    expect(footerRels).toBeDefined();
+    expect(headerRels!).toContain('relationships/image');
+    expect(footerRels!).toContain('relationships/image');
+
+    // Header xml should reference the image via a:blip r:embed.
+    const headerXml = await zip.file('word/header1.xml')?.async('string');
+    const footerXml = await zip.file('word/footer1.xml')?.async('string');
+    expect(headerXml!).toContain('a:blip');
+    expect(footerXml!).toContain('a:blip');
+
+    // Media files from header and footer should not collide in word/media/.
+    const mediaFiles: string[] = [];
+    zip.forEach((path, entry) => {
+      if (path.startsWith('word/media/') && !entry.dir) {
+        mediaFiles.push(path);
+      }
+    });
+    expect(mediaFiles.length).toBe(2);
+    expect(new Set(mediaFiles).size).toBe(2);
+  });
 });

--- a/packages/docs/test/export/docx-style-map.test.ts
+++ b/packages/docs/test/export/docx-style-map.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { buildRunPropertiesXml, buildParagraphPropertiesXml } from '../../src/export/docx-style-map.js';
+
+describe('buildRunPropertiesXml', () => {
+  it('should generate bold tag', () => {
+    const xml = buildRunPropertiesXml({ bold: true });
+    expect(xml).toContain('<w:b/>');
+  });
+
+  it('should generate font size in half-points', () => {
+    const xml = buildRunPropertiesXml({ fontSize: 12 });
+    expect(xml).toContain('<w:sz w:val="24"/>');
+    expect(xml).toContain('<w:szCs w:val="24"/>');
+  });
+
+  it('should generate font family', () => {
+    const xml = buildRunPropertiesXml({ fontFamily: 'Arial' });
+    expect(xml).toContain('w:ascii="Arial"');
+  });
+
+  it('should generate color', () => {
+    const xml = buildRunPropertiesXml({ color: '#FF0000' });
+    expect(xml).toContain('<w:color w:val="FF0000"/>');
+  });
+
+  it('should return empty string for empty style', () => {
+    const xml = buildRunPropertiesXml({});
+    expect(xml).toBe('');
+  });
+});
+
+describe('buildParagraphPropertiesXml', () => {
+  it('should generate center alignment', () => {
+    const xml = buildParagraphPropertiesXml({ alignment: 'center', lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 });
+    expect(xml).toContain('<w:jc w:val="center"/>');
+  });
+
+  it('should generate justify as "both"', () => {
+    const xml = buildParagraphPropertiesXml({ alignment: 'justify', lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 });
+    expect(xml).toContain('<w:jc w:val="both"/>');
+  });
+});

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -3,25 +3,45 @@ import { describe, it, expect } from 'vitest';
 import { DocxImporter } from '../../src/import/docx-importer.js';
 import JSZip from 'jszip';
 
+interface DocxOptions {
+  relsXml?: string;
+  extraFiles?: Record<string, Uint8Array | string>;
+}
+
 /**
  * Helper to create a minimal .docx zip in memory.
  */
-async function createMinimalDocx(bodyXml: string): Promise<ArrayBuffer> {
+async function createMinimalDocx(
+  bodyXml: string,
+  options: DocxOptions = {},
+): Promise<ArrayBuffer> {
   const zip = new JSZip();
   const docXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
-                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
       <w:body>${bodyXml}</w:body>
     </w:document>`;
   zip.file('word/document.xml', docXml);
-  zip.file('word/_rels/document.xml.rels', `<?xml version="1.0" encoding="UTF-8"?>
+  zip.file(
+    'word/_rels/document.xml.rels',
+    options.relsXml ??
+      `<?xml version="1.0" encoding="UTF-8"?>
     <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-    </Relationships>`);
+    </Relationships>`,
+  );
   zip.file('[Content_Types].xml', `<?xml version="1.0" encoding="UTF-8"?>
     <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
       <Default Extension="xml" ContentType="application/xml"/>
       <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+      <Default Extension="png" ContentType="image/png"/>
     </Types>`);
+  if (options.extraFiles) {
+    for (const [path, content] of Object.entries(options.extraFiles)) {
+      zip.file(path, content);
+    }
+  }
   return zip.generateAsync({ type: 'arraybuffer' });
 }
 
@@ -93,6 +113,136 @@ describe('DocxImporter', () => {
     expect(doc.pageSetup).toBeDefined();
     expect(doc.pageSetup!.paperSize.width).toBeCloseTo(794, 0);
     expect(doc.pageSetup!.margins.top).toBeCloseTo(96, 0);
+  });
+
+  it('should import image with dimensions from w:drawing extent', async () => {
+    // 1 inch x 0.5 inch in EMU (914400 EMU per inch). At 96 DPI → 96 x 48 CSS px.
+    const drawingXml = `
+      <w:r>
+        <w:drawing>
+          <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+            <wp:extent cx="914400" cy="457200"/>
+            <wp:docPr id="1" name="Picture 1"/>
+            <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                  <pic:blipFill>
+                    <a:blip xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:embed="rId5"/>
+                  </pic:blipFill>
+                </pic:pic>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>`;
+    const relsXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+      </Relationships>`;
+    // Minimal 1x1 PNG bytes (transparent) — content doesn't matter for the test.
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+      0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
+      0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+      0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+    const buffer = await createMinimalDocx(
+      `<w:p>${drawingXml}</w:p>`,
+      {
+        relsXml,
+        extraFiles: { 'word/media/image1.png': pngBytes },
+      },
+    );
+    const doc = await DocxImporter.import(buffer, async () => 'https://example.com/image1.png');
+    const inline = doc.blocks[0].inlines.find((i) => !!i.style.image);
+    expect(inline).toBeDefined();
+    expect(inline!.style.image!.src).toBe('https://example.com/image1.png');
+    expect(inline!.style.image!.width).toBe(96);
+    expect(inline!.style.image!.height).toBe(48);
+  });
+
+  it('should resolve stacked vMerge groups in the same column', async () => {
+    // Column 0: rows 0-1 merged, row 2 standalone, rows 3-4 merged.
+    const buffer = await createMinimalDocx(`
+      <w:tbl>
+        <w:tblGrid><w:gridCol w:w="4000"/><w:gridCol w:w="4000"/></w:tblGrid>
+        <w:tr>
+          <w:tc><w:tcPr><w:vMerge w:val="restart"/></w:tcPr><w:p><w:r><w:t>Group1Top</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>R0C1</w:t></w:r></w:p></w:tc>
+        </w:tr>
+        <w:tr>
+          <w:tc><w:tcPr><w:vMerge/></w:tcPr><w:p/></w:tc>
+          <w:tc><w:p><w:r><w:t>R1C1</w:t></w:r></w:p></w:tc>
+        </w:tr>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>Standalone</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>R2C1</w:t></w:r></w:p></w:tc>
+        </w:tr>
+        <w:tr>
+          <w:tc><w:tcPr><w:vMerge w:val="restart"/></w:tcPr><w:p><w:r><w:t>Group2Top</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>R3C1</w:t></w:r></w:p></w:tc>
+        </w:tr>
+        <w:tr>
+          <w:tc><w:tcPr><w:vMerge/></w:tcPr><w:p/></w:tc>
+          <w:tc><w:p><w:r><w:t>R4C1</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    const table = doc.blocks[0];
+    expect(table.type).toBe('table');
+    const rows = table.tableData!.rows;
+    expect(rows).toHaveLength(5);
+
+    // First group anchor at row 0, col 0 should have rowSpan 2.
+    const group1Top = rows[0].cells[0];
+    expect(group1Top.rowSpan).toBe(2);
+    expect(group1Top.blocks[0].inlines[0].text).toBe('Group1Top');
+
+    // Row 2 col 0 is a normal standalone cell, no rowSpan.
+    expect(rows[2].cells[0].rowSpan).toBeUndefined();
+    expect(rows[2].cells[0].blocks[0].inlines[0].text).toBe('Standalone');
+
+    // Second group anchor at row 3, col 0 should have rowSpan 2.
+    const group2Top = rows[3].cells[0];
+    expect(group2Top.rowSpan).toBe(2);
+    expect(group2Top.blocks[0].inlines[0].text).toBe('Group2Top');
+  });
+
+  it('should not duplicate content when flattening deeply nested tables', async () => {
+    // Outer table with a nested table that itself contains another nested
+    // table. The flattened outer cell should contain "DEEP" exactly once.
+    const buffer = await createMinimalDocx(`
+      <w:tbl>
+        <w:tblGrid><w:gridCol w:w="8000"/></w:tblGrid>
+        <w:tr>
+          <w:tc>
+            <w:tbl>
+              <w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>
+              <w:tr>
+                <w:tc>
+                  <w:tbl>
+                    <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>
+                    <w:tr><w:tc><w:p><w:r><w:t>DEEP</w:t></w:r></w:p></w:tc></w:tr>
+                  </w:tbl>
+                </w:tc>
+              </w:tr>
+            </w:tbl>
+          </w:tc>
+        </w:tr>
+      </w:tbl>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    const table = doc.blocks[0];
+    expect(table.type).toBe('table');
+    const cellBlocks = table.tableData!.rows[0].cells[0].blocks;
+    const allText = cellBlocks.map((b) => b.inlines.map((i) => i.text).join('')).join('\n');
+    // "DEEP" should appear exactly once even though the inner flatten code
+    // used to recurse via getElementsByTagNameNS.
+    const occurrences = allText.split('DEEP').length - 1;
+    expect(occurrences).toBe(1);
   });
 
   it('should flatten nested tables to text', async () => {

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -245,6 +245,155 @@ describe('DocxImporter', () => {
     expect(occurrences).toBe(1);
   });
 
+  it('should drop pending image inlines when no uploader is supplied', async () => {
+    // Parser inserts a pending placeholder for every <w:drawing>. Without
+    // an uploader, convertParagraph must drop it instead of leaving an
+    // `__pending__:*` src in the final document.
+    const drawingXml = `
+      <w:r>
+        <w:drawing>
+          <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+            <wp:extent cx="914400" cy="457200"/>
+            <wp:docPr id="1" name="Picture 1"/>
+            <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                  <pic:blipFill>
+                    <a:blip xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:embed="rId5"/>
+                  </pic:blipFill>
+                </pic:pic>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>`;
+    const buffer = await createMinimalDocx(
+      `<w:p>${drawingXml}<w:r><w:t>Fallback</w:t></w:r></w:p>`,
+    );
+    // Intentionally omit the imageUploader argument.
+    const doc = await DocxImporter.import(buffer);
+    for (const inline of doc.blocks[0].inlines) {
+      expect(inline.style.image?.src?.startsWith('__pending__')).toBeFalsy();
+    }
+    const allText = doc.blocks[0].inlines.map((i) => i.text).join('');
+    expect(allText).toContain('Fallback');
+  });
+
+  it('should pick the default header referenced from sectPr, not first rel', async () => {
+    // Two header relationships exist in the rels map; only header2 is
+    // referenced from the sectPr as the default. The importer must pick
+    // header2 rather than the first rel in iteration order.
+    const relsXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId10" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>
+        <Relationship Id="rId11" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header2.xml"/>
+      </Relationships>`;
+    const header1Xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:p><w:r><w:t>First header (unused)</w:t></w:r></w:p>
+      </w:hdr>`;
+    const header2Xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:p><w:r><w:t>Active header</w:t></w:r></w:p>
+      </w:hdr>`;
+    const buffer = await createMinimalDocx(
+      `<w:p><w:r><w:t>Body</w:t></w:r></w:p>
+       <w:sectPr xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+         <w:headerReference w:type="default" r:id="rId11"/>
+         <w:pgSz w:w="11906" w:h="16838"/>
+         <w:pgMar w:top="1440" w:right="1080" w:bottom="1440" w:left="1080"/>
+       </w:sectPr>`,
+      {
+        relsXml,
+        extraFiles: {
+          'word/header1.xml': header1Xml,
+          'word/header2.xml': header2Xml,
+        },
+      },
+    );
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.header).toBeDefined();
+    const headerText = doc.header!.blocks
+      .map((b) => b.inlines.map((i) => i.text).join(''))
+      .join('');
+    expect(headerText).toBe('Active header');
+  });
+
+  it('should upload images referenced only from a header .rels file', async () => {
+    // Image rId "rId3" belongs to header1.xml.rels and has no counterpart
+    // in document.xml.rels. Without per-part rels walking, the header
+    // image would resolve to a __pending__:* src. With the fix, the
+    // uploader is called with the header-local image.
+    const relsXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId20" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>
+      </Relationships>`;
+    const header1Rels = `<?xml version="1.0" encoding="UTF-8"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/header-image.png"/>
+      </Relationships>`;
+    const header1Xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+             xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <w:p>
+          <w:r>
+            <w:drawing>
+              <wp:inline>
+                <wp:extent cx="914400" cy="457200"/>
+                <wp:docPr id="1" name="Picture 1"/>
+                <a:graphic>
+                  <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                    <pic:pic>
+                      <pic:blipFill><a:blip r:embed="rId3"/></pic:blipFill>
+                    </pic:pic>
+                  </a:graphicData>
+                </a:graphic>
+              </wp:inline>
+            </w:drawing>
+          </w:r>
+        </w:p>
+      </w:hdr>`;
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+      0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
+      0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+      0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+    const buffer = await createMinimalDocx(
+      `<w:p><w:r><w:t>Body</w:t></w:r></w:p>
+       <w:sectPr xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+         <w:headerReference w:type="default" r:id="rId20"/>
+         <w:pgSz w:w="11906" w:h="16838"/>
+         <w:pgMar w:top="1440" w:right="1080" w:bottom="1440" w:left="1080"/>
+       </w:sectPr>`,
+      {
+        relsXml,
+        extraFiles: {
+          'word/header1.xml': header1Xml,
+          'word/_rels/header1.xml.rels': header1Rels,
+          'word/media/header-image.png': pngBytes,
+        },
+      },
+    );
+    const uploaded: string[] = [];
+    const doc = await DocxImporter.import(buffer, async (_blob, filename) => {
+      uploaded.push(filename);
+      return `https://example.com/${filename}`;
+    });
+    expect(uploaded.length).toBe(1);
+    expect(doc.header).toBeDefined();
+    const headerBlock = doc.header!.blocks[0];
+    const headerInline = headerBlock.inlines.find((i) => !!i.style.image);
+    expect(headerInline).toBeDefined();
+    expect(headerInline!.style.image!.src).toContain('https://example.com/');
+    expect(headerInline!.style.image!.src.startsWith('__pending__')).toBe(false);
+  });
+
   it('should flatten nested tables to text', async () => {
     const buffer = await createMinimalDocx(`
       <w:tbl>

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { DocxImporter } from '../../src/import/docx-importer.js';
+import JSZip from 'jszip';
+
+/**
+ * Helper to create a minimal .docx zip in memory.
+ */
+async function createMinimalDocx(bodyXml: string): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  const docXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+      <w:body>${bodyXml}</w:body>
+    </w:document>`;
+  zip.file('word/document.xml', docXml);
+  zip.file('word/_rels/document.xml.rels', `<?xml version="1.0" encoding="UTF-8"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    </Relationships>`);
+  zip.file('[Content_Types].xml', `<?xml version="1.0" encoding="UTF-8"?>
+    <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+      <Default Extension="xml" ContentType="application/xml"/>
+      <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    </Types>`);
+  return zip.generateAsync({ type: 'arraybuffer' });
+}
+
+describe('DocxImporter', () => {
+  it('should import a simple paragraph', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:p><w:r><w:t>Hello World</w:t></w:r></w:p>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks).toHaveLength(1);
+    expect(doc.blocks[0].type).toBe('paragraph');
+    expect(doc.blocks[0].inlines[0].text).toBe('Hello World');
+  });
+
+  it('should import multiple paragraphs', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:p><w:r><w:t>First</w:t></w:r></w:p>
+      <w:p><w:r><w:t>Second</w:t></w:r></w:p>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks).toHaveLength(2);
+    expect(doc.blocks[0].inlines[0].text).toBe('First');
+    expect(doc.blocks[1].inlines[0].text).toBe('Second');
+  });
+
+  it('should import styled text runs', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:p>
+        <w:r><w:t>Normal </w:t></w:r>
+        <w:r><w:rPr><w:b/></w:rPr><w:t>Bold</w:t></w:r>
+      </w:p>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks[0].inlines).toHaveLength(2);
+    expect(doc.blocks[0].inlines[1].style.bold).toBe(true);
+  });
+
+  it('should import a simple table', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:tbl>
+        <w:tblGrid><w:gridCol w:w="4000"/><w:gridCol w:w="4000"/></w:tblGrid>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>A1</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>B1</w:t></w:r></w:p></w:tc>
+        </w:tr>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>A2</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>B2</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks).toHaveLength(1);
+    expect(doc.blocks[0].type).toBe('table');
+    expect(doc.blocks[0].tableData!.rows).toHaveLength(2);
+    expect(doc.blocks[0].tableData!.rows[0].cells).toHaveLength(2);
+    expect(doc.blocks[0].tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('A1');
+  });
+
+  it('should import page setup from sectPr', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:p><w:r><w:t>Content</w:t></w:r></w:p>
+      <w:sectPr>
+        <w:pgSz w:w="11906" w:h="16838"/>
+        <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/>
+      </w:sectPr>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.pageSetup).toBeDefined();
+    expect(doc.pageSetup!.paperSize.width).toBeCloseTo(794, 0);
+    expect(doc.pageSetup!.margins.top).toBeCloseTo(96, 0);
+  });
+
+  it('should flatten nested tables to text', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:tbl>
+        <w:tblGrid><w:gridCol w:w="8000"/></w:tblGrid>
+        <w:tr>
+          <w:tc>
+            <w:tbl>
+              <w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>
+              <w:tr><w:tc><w:p><w:r><w:t>Nested</w:t></w:r></w:p></w:tc></w:tr>
+            </w:tbl>
+          </w:tc>
+        </w:tr>
+      </w:tbl>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks[0].type).toBe('table');
+    // Nested table is flattened — cell should contain a paragraph with "Nested"
+    const cellBlocks = doc.blocks[0].tableData!.rows[0].cells[0].blocks;
+    const allText = cellBlocks.map(b => b.inlines.map(i => i.text).join('')).join('');
+    expect(allText).toContain('Nested');
+  });
+});

--- a/packages/docs/test/import/docx-parser.test.ts
+++ b/packages/docs/test/import/docx-parser.test.ts
@@ -37,6 +37,37 @@ describe('parseParagraph', () => {
     expect(result.inlines).toHaveLength(1);
     expect(result.inlines[0].text).toBe('');
   });
+
+  it('should preserve document order of text, tabs, and breaks within a run', () => {
+    // Regression: previously the parser appended all tabs/breaks after all
+    // text, turning "A<w:tab/>B<w:br/>C" into "ABC\t\n" instead of "A\tB\nC".
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:r>
+        <w:t>A</w:t><w:tab/><w:t>B</w:t><w:br/><w:t>C</w:t>
+      </w:r>
+    </w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines).toHaveLength(1);
+    expect(result.inlines[0].text).toBe('A\tB\nC');
+  });
+
+  it('should skip runs nested inside structures like w:sdt', () => {
+    // A run whose parent is neither the paragraph nor a hyperlink must be
+    // skipped so it does not leak into the inline list of the outer
+    // paragraph. Without the guard, nested w:sdt content bled through.
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:r><w:t>Outer</w:t></w:r>
+      <w:sdt>
+        <w:sdtContent>
+          <w:r><w:t>Nested</w:t></w:r>
+        </w:sdtContent>
+      </w:sdt>
+    </w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines.map((i) => i.text)).toEqual(['Outer']);
+  });
 });
 
 describe('parsePageSetup', () => {

--- a/packages/docs/test/import/docx-parser.test.ts
+++ b/packages/docs/test/import/docx-parser.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { parseRelationships, parseParagraph, parsePageSetup } from '../../src/import/docx-parser.js';
+
+describe('parseRelationships', () => {
+  it('should parse document.xml.rels into rId → target map', () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+      <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>
+    </Relationships>`;
+    const rels = parseRelationships(xml);
+    expect(rels.get('rId1')).toEqual({ target: 'media/image1.png', type: 'image' });
+    expect(rels.get('rId2')).toEqual({ target: 'header1.xml', type: 'header' });
+  });
+});
+
+describe('parseParagraph', () => {
+  it('should extract text runs from a paragraph', () => {
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:r><w:t>Hello</w:t></w:r>
+      <w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve"> World</w:t></w:r>
+    </w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines).toHaveLength(2);
+    expect(result.inlines[0].text).toBe('Hello');
+    expect(result.inlines[0].style.bold).toBeUndefined();
+    expect(result.inlines[1].text).toBe(' World');
+    expect(result.inlines[1].style.bold).toBe(true);
+  });
+
+  it('should handle empty paragraphs', () => {
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines).toHaveLength(1);
+    expect(result.inlines[0].text).toBe('');
+  });
+});
+
+describe('parsePageSetup', () => {
+  it('should parse sectPr into PageSetup', () => {
+    const xml = `<w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:pgSz w:w="11906" w:h="16838"/>
+      <w:pgMar w:top="1440" w:right="1080" w:bottom="1440" w:left="1080"/>
+    </w:sectPr>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const setup = parsePageSetup(el);
+    // A4 paper: 11906 twips wide ≈ 794 px
+    expect(setup.paperSize.width).toBeCloseTo(794, 0);
+    expect(setup.paperSize.height).toBeCloseTo(1123, 0);
+    expect(setup.margins.top).toBeCloseTo(96, 0);
+    expect(setup.margins.left).toBeCloseTo(72, 0);
+  });
+});

--- a/packages/docs/test/import/docx-style-map.test.ts
+++ b/packages/docs/test/import/docx-style-map.test.ts
@@ -46,6 +46,30 @@ describe('mapRunProperties', () => {
     const style = mapRunProperties(el);
     expect(style.superscript).toBe(true);
   });
+
+  it('should enable underline for bare <w:u/> without w:val', () => {
+    // A bare <w:u/> is valid OOXML shorthand for "underline enabled".
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:u/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.underline).toBe(true);
+  });
+
+  it('should leave underline unset for <w:u w:val="none"/>', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:u w:val="none"/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.underline).toBeUndefined();
+  });
+
+  it('should not apply yellow highlight for <w:highlight w:val="none"/>', () => {
+    // Regression: mapHighlightColor falls back to yellow for unknown names,
+    // so "none" must short-circuit before the lookup.
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:highlight w:val="none"/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.backgroundColor).toBeUndefined();
+  });
 });
 
 describe('mapParagraphProperties', () => {

--- a/packages/docs/test/import/docx-style-map.test.ts
+++ b/packages/docs/test/import/docx-style-map.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { mapRunProperties, mapParagraphProperties, mapTableCellProperties, mapHighlightColor } from '../../src/import/docx-style-map.js';
+
+describe('mapRunProperties', () => {
+  it('should map bold', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:b/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.bold).toBe(true);
+  });
+
+  it('should map font size from half-points', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:sz w:val="24"/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.fontSize).toBe(12);
+  });
+
+  it('should map font family', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:rFonts w:ascii="Arial"/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.fontFamily).toBe('Arial');
+  });
+
+  it('should map text color', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:color w:val="FF0000"/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.color).toBe('#FF0000');
+  });
+
+  it('should map underline, italic, strikethrough', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:i/><w:u w:val="single"/><w:strike/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.italic).toBe(true);
+    expect(style.underline).toBe(true);
+    expect(style.strikethrough).toBe(true);
+  });
+
+  it('should map superscript', () => {
+    const xml = '<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:vertAlign w:val="superscript"/></w:rPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const style = mapRunProperties(el);
+    expect(style.superscript).toBe(true);
+  });
+});
+
+describe('mapParagraphProperties', () => {
+  it('should map center alignment', () => {
+    const xml = '<w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:jc w:val="center"/></w:pPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = mapParagraphProperties(el);
+    expect(result.blockStyle.alignment).toBe('center');
+  });
+
+  it('should map "both" to justify', () => {
+    const xml = '<w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:jc w:val="both"/></w:pPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = mapParagraphProperties(el);
+    expect(result.blockStyle.alignment).toBe('justify');
+  });
+
+  it('should map spacing to marginTop and marginBottom', () => {
+    const xml = '<w:pPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:spacing w:before="120" w:after="240"/></w:pPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = mapParagraphProperties(el);
+    expect(result.blockStyle.marginTop).toBeCloseTo(8, 0);
+    expect(result.blockStyle.marginBottom).toBeCloseTo(16, 0);
+  });
+});
+
+describe('mapTableCellProperties', () => {
+  it('should map background fill, gridSpan, and vMerge', () => {
+    const xml = '<w:tcPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:shd w:fill="DDEEFF"/><w:gridSpan w:val="2"/><w:vMerge w:val="restart"/></w:tcPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = mapTableCellProperties(el);
+    expect(result.backgroundColor).toBe('#DDEEFF');
+    expect(result.colSpan).toBe(2);
+    expect(result.vMerge).toBe('restart');
+  });
+
+  it('should map tcBorders to per-side border styles', () => {
+    const xml = '<w:tcPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:tcBorders><w:top w:sz="8" w:color="000000" w:val="single"/><w:bottom w:val="none"/></w:tcBorders></w:tcPr>';
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = mapTableCellProperties(el);
+    expect(result.borderTop?.color).toBe('#000000');
+    expect(result.borderTop?.style).toBe('solid');
+    expect(result.borderBottom?.style).toBe('none');
+  });
+});
+
+describe('mapHighlightColor', () => {
+  it('should map named highlight colors', () => {
+    expect(mapHighlightColor('yellow')).toBe('#FFFF00');
+    expect(mapHighlightColor('red')).toBe('#FF0000');
+    expect(mapHighlightColor('green')).toBe('#00FF00');
+  });
+});

--- a/packages/docs/test/import/units.test.ts
+++ b/packages/docs/test/import/units.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { twipsToPx, emusToPx, halfPointsToPoints, pxToTwips, pxToEmus, pointsToHalfPoints } from '../../src/import/units.js';
+
+describe('OOXML unit conversions', () => {
+  it('should convert twips to px', () => {
+    expect(twipsToPx(1440)).toBeCloseTo(96, 1);    // 1 inch
+    expect(twipsToPx(720)).toBeCloseTo(48, 1);      // 0.5 inch
+  });
+
+  it('should convert EMUs to px', () => {
+    expect(emusToPx(914400)).toBeCloseTo(96, 1);    // 1 inch
+    expect(emusToPx(457200)).toBeCloseTo(48, 1);     // 0.5 inch
+  });
+
+  it('should convert half-points to points', () => {
+    expect(halfPointsToPoints(24)).toBe(12);
+    expect(halfPointsToPoints(30)).toBe(15);
+  });
+
+  it('should convert px to twips (reverse)', () => {
+    expect(pxToTwips(96)).toBeCloseTo(1440, 1);
+  });
+
+  it('should convert px to EMUs (reverse)', () => {
+    expect(pxToEmus(96)).toBeCloseTo(914400, 1);
+  });
+
+  it('should convert points to half-points (reverse)', () => {
+    expect(pointsToHalfPoints(12)).toBe(24);
+  });
+});

--- a/packages/docs/test/import/units.test.ts
+++ b/packages/docs/test/import/units.test.ts
@@ -18,14 +18,27 @@ describe('OOXML unit conversions', () => {
   });
 
   it('should convert px to twips (reverse)', () => {
-    expect(pxToTwips(96)).toBeCloseTo(1440, 1);
+    expect(pxToTwips(96)).toBe(1440);
   });
 
   it('should convert px to EMUs (reverse)', () => {
-    expect(pxToEmus(96)).toBeCloseTo(914400, 1);
+    expect(pxToEmus(96)).toBe(914400);
   });
 
   it('should convert points to half-points (reverse)', () => {
     expect(pointsToHalfPoints(12)).toBe(24);
+  });
+
+  it('should round reverse conversions to integers for OOXML', () => {
+    // Non-integer inputs previously produced fractional values, which are
+    // invalid for OOXML attributes that must be whole numbers.
+    expect(pxToTwips(100)).toBe(Math.round(100 * 1440 / 96));
+    expect(Number.isInteger(pxToTwips(100))).toBe(true);
+
+    expect(pxToEmus(100)).toBe(Math.round(100 * 914400 / 96));
+    expect(Number.isInteger(pxToEmus(100))).toBe(true);
+
+    expect(pointsToHalfPoints(10.25)).toBe(21);
+    expect(Number.isInteger(pointsToHalfPoints(10.25))).toBe(true);
   });
 });

--- a/packages/docs/test/model/document.test.ts
+++ b/packages/docs/test/model/document.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Doc } from '../../src/model/document.js';
-import { createEmptyBlock, getBlockText } from '../../src/model/types.js';
+import { type Inline, createEmptyBlock, getBlockText } from '../../src/model/types.js';
 import { MemDocStore } from '../../src/store/memory.js';
 
 describe('Doc', () => {
@@ -653,5 +653,41 @@ describe('Doc editContext', () => {
     expect(newPos.blockId).toBe(b1.id);
     expect(newPos.offset).toBe(1);
     expect(doc.document.header!.blocks).toHaveLength(1);
+  });
+});
+
+describe('image inlines', () => {
+  it('should insert an image inline into a block', () => {
+    const doc = Doc.create();
+    const blockId = doc.document.blocks[0].id;
+    doc.insertText({ blockId, offset: 0 }, 'Hello');
+
+    const imageInline: Inline = {
+      text: '\uFFFC',
+      style: {
+        image: { src: '/images/test.png', width: 200, height: 100 },
+      },
+    };
+    doc.insertImageInline(blockId, 5, imageInline);
+
+    const block = doc.document.blocks[0];
+    expect(getBlockText(block)).toBe('Hello\uFFFC');
+    expect(block.inlines[block.inlines.length - 1].style.image?.src).toBe('/images/test.png');
+  });
+
+  it('should delete an image inline with backspace', () => {
+    const doc = Doc.create();
+    const blockId = doc.document.blocks[0].id;
+    const imageInline: Inline = {
+      text: '\uFFFC',
+      style: {
+        image: { src: '/images/test.png', width: 200, height: 100 },
+      },
+    };
+    doc.insertImageInline(blockId, 0, imageInline);
+    expect(getBlockText(doc.document.blocks[0])).toBe('\uFFFC');
+
+    doc.deleteText({ blockId, offset: 0 }, 1);
+    expect(getBlockText(doc.document.blocks[0])).toBe('');
   });
 });

--- a/packages/docs/test/model/document.test.ts
+++ b/packages/docs/test/model/document.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { Doc } from '../../src/model/document.js';
-import { type Inline, createEmptyBlock, getBlockText } from '../../src/model/types.js';
+import { type BlockCellInfo, type Inline, createEmptyBlock, getBlockText } from '../../src/model/types.js';
 import { MemDocStore } from '../../src/store/memory.js';
+
+function buildParentMap(doc: Doc, tableBlockId: string): Map<string, BlockCellInfo> {
+  const map = new Map<string, BlockCellInfo>();
+  const block = doc.getBlock(tableBlockId);
+  if (!block.tableData) return map;
+  for (let r = 0; r < block.tableData.rows.length; r++) {
+    for (let c = 0; c < block.tableData.rows[r].cells.length; c++) {
+      const cell = block.tableData.rows[r].cells[c];
+      for (const b of cell.blocks) {
+        map.set(b.id, { tableBlockId, rowIndex: r, colIndex: c });
+      }
+    }
+  }
+  return map;
+}
 
 describe('Doc', () => {
   describe('create', () => {
@@ -689,5 +704,45 @@ describe('image inlines', () => {
 
     doc.deleteText({ blockId, offset: 0 }, 1);
     expect(getBlockText(doc.document.blocks[0])).toBe('');
+  });
+
+  it('should insert an image inline in the middle of a block', () => {
+    const doc = Doc.create();
+    const blockId = doc.document.blocks[0].id;
+    doc.insertText({ blockId, offset: 0 }, 'Hello');
+
+    const imageInline: Inline = {
+      text: '\uFFFC',
+      style: {
+        image: { src: '/images/test.png', width: 200, height: 100 },
+      },
+    };
+    doc.insertImageInline(blockId, 2, imageInline);
+
+    const block = doc.document.blocks[0];
+    expect(getBlockText(block)).toBe('He\uFFFCllo');
+    // Verify inline structure: 'He' | image | 'llo'
+    const imageIdx = block.inlines.findIndex(i => i.style.image);
+    expect(imageIdx).toBeGreaterThan(0);
+    expect(imageIdx).toBeLessThan(block.inlines.length - 1);
+  });
+
+  it('should insert an image inline into a table cell block', () => {
+    const doc = Doc.create();
+    const tableBlockId = doc.insertTable(1, 2, 2);
+    doc.setBlockParentMap(buildParentMap(doc, tableBlockId));
+    const tableBlock = doc.getBlock(tableBlockId);
+    const cellBlockId = tableBlock.tableData!.rows[0].cells[0].blocks[0].id;
+
+    const imageInline: Inline = {
+      text: '\uFFFC',
+      style: {
+        image: { src: '/images/cell.png', width: 100, height: 50 },
+      },
+    };
+    doc.insertImageInline(cellBlockId, 0, imageInline);
+
+    const cellBlock = doc.getBlock(cellBlockId);
+    expect(cellBlock.inlines.some(i => i.style.image?.src === '/images/cell.png')).toBe(true);
   });
 });

--- a/packages/docs/test/model/types.test.ts
+++ b/packages/docs/test/model/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { HeadingLevel, Document, Inline } from '../../src/model/types.js';
+import type { HeadingLevel, Document, Inline, InlineStyle } from '../../src/model/types.js';
 import {
   DEFAULT_BLOCK_STYLE,
   DEFAULT_PAGE_SETUP,
@@ -223,5 +223,40 @@ describe('HeaderFooter', () => {
     const doc: Document = { blocks: [createEmptyBlock()] };
     expect(doc.header).toBeUndefined();
     expect(doc.footer).toBeUndefined();
+  });
+});
+
+describe('ImageData on InlineStyle', () => {
+  it('should allow creating an inline with image data', () => {
+    const inline: Inline = {
+      text: '\uFFFC',
+      style: {
+        image: {
+          src: 'https://example.com/image.png',
+          width: 200,
+          height: 150,
+          alt: 'Test image',
+        },
+      },
+    };
+    expect(inline.style.image).toBeDefined();
+    expect(inline.style.image!.src).toBe('https://example.com/image.png');
+    expect(inline.style.image!.width).toBe(200);
+    expect(inline.style.image!.height).toBe(150);
+    expect(inline.style.image!.alt).toBe('Test image');
+  });
+
+  it('should compare inline styles with image data', () => {
+    const a: InlineStyle = {
+      image: { src: 'a.png', width: 100, height: 100 },
+    };
+    const b: InlineStyle = {
+      image: { src: 'a.png', width: 100, height: 100 },
+    };
+    const c: InlineStyle = {
+      image: { src: 'b.png', width: 100, height: 100 },
+    };
+    expect(inlineStylesEqual(a, b)).toBe(true);
+    expect(inlineStylesEqual(a, c)).toBe(false);
   });
 });

--- a/packages/docs/test/view/fonts.test.ts
+++ b/packages/docs/test/view/fonts.test.ts
@@ -26,4 +26,20 @@ describe('FontRegistry', () => {
     const registry = new FontRegistry();
     expect(registry.getFontStatus('Arial')).toBe('pending');
   });
+
+  it('should escape single quotes in unknown font family names', () => {
+    // Issue 3: A font name containing a single quote (e.g. from a DOCX file)
+    // must produce valid CSS — the quote must be escaped so it does not break
+    // out of the surrounding single-quoted string.
+    const result = resolveFontFamily("O'Connor Sans");
+    expect(result).toBe("'O\\'Connor Sans', sans-serif");
+    // Ensure the raw string is valid: it must not contain an unescaped ' that
+    // would terminate the CSS quoted string prematurely.
+    expect(result.indexOf("'O'")).toBe(-1);
+  });
+
+  it('should escape backslashes in unknown font family names', () => {
+    const result = resolveFontFamily('Font\\Name');
+    expect(result).toBe("'Font\\\\Name', sans-serif");
+  });
 });

--- a/packages/docs/test/view/fonts.test.ts
+++ b/packages/docs/test/view/fonts.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { FontRegistry, resolveFontFamily } from '../../src/view/fonts.js';
+
+describe('FontRegistry', () => {
+  it('should resolve known Korean font to fallback chain', () => {
+    expect(resolveFontFamily('맑은 고딕')).toBe("'Malgun Gothic', 'Noto Sans KR', sans-serif");
+  });
+
+  it('should resolve HY헤드라인M to Noto Sans KR fallback', () => {
+    expect(resolveFontFamily('HY헤드라인M')).toBe("'Noto Sans KR', sans-serif");
+  });
+
+  it('should return standard fonts as-is with fallback', () => {
+    expect(resolveFontFamily('Arial')).toBe("'Arial', sans-serif");
+  });
+
+  it('should return unknown fonts with generic fallback', () => {
+    expect(resolveFontFamily('SomeRandomFont')).toBe("'SomeRandomFont', sans-serif");
+  });
+
+  it('should resolve 바탕 to serif chain', () => {
+    expect(resolveFontFamily('바탕')).toBe("'Batang', 'Noto Serif KR', serif");
+  });
+
+  it('FontRegistry should report pending status for unknown font', () => {
+    const registry = new FontRegistry();
+    expect(registry.getFontStatus('Arial')).toBe('pending');
+  });
+});

--- a/packages/frontend/src/app/docs/docs-detail.tsx
+++ b/packages/frontend/src/app/docs/docs-detail.tsx
@@ -141,8 +141,12 @@ function DocsLayout({ documentId }: { documentId: string }) {
           </div>
         </SiteHeader>
         <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
-          <DocsFormattingToolbar editor={editor} editContext={editContext} />
-          <DocsView onEditorReady={setEditor} />
+          <DocsFormattingToolbar
+            editor={editor}
+            editContext={editContext}
+            documentTitle={documentData?.title}
+          />
+          <DocsView onEditorReady={setEditor} documentId={documentId} />
         </div>
       </SidebarInset>
     </SidebarProvider>

--- a/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
+++ b/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
@@ -35,8 +35,11 @@ import {
   IconLink,
   IconTable,
   IconHash,
+  IconFileDownload,
 } from "@tabler/icons-react";
 import { TableGridPicker } from "./table-grid-picker";
+import { exportDocxAndDownload } from "./docx-actions";
+import { toast } from "sonner";
 
 /** Style option for the block-type dropdown (Google Docs style). */
 interface StyleOption {
@@ -101,9 +104,28 @@ function TableDropdown({ editor }: { editor: EditorAPI | null }) {
 interface DocsFormattingToolbarProps {
   editor: EditorAPI | null;
   editContext?: EditContext;
+  documentTitle?: string;
 }
 
-export function DocsFormattingToolbar({ editor, editContext = 'body' }: DocsFormattingToolbarProps) {
+export function DocsFormattingToolbar({ editor, editContext = 'body', documentTitle }: DocsFormattingToolbarProps) {
+  const [exporting, setExporting] = useState(false);
+
+  const handleExportDocx = useCallback(async () => {
+    if (!editor || exporting) return;
+    setExporting(true);
+    try {
+      const doc = editor.getStore().getDocument();
+      await exportDocxAndDownload(doc, documentTitle ?? "document");
+    } catch (err) {
+      console.error("DOCX export failed", err);
+      toast.error(
+        err instanceof Error ? `Export failed: ${err.message}` : "Export failed",
+      );
+    } finally {
+      setExporting(false);
+    }
+  }, [editor, documentTitle, exporting]);
+
   const handleUndo = useCallback(() => editor?.undo(), [editor]);
   const handleRedo = useCallback(() => editor?.redo(), [editor]);
 
@@ -596,6 +618,23 @@ export function DocsFormattingToolbar({ editor, editContext = 'body' }: DocsForm
           </button>
         </TooltipTrigger>
         <TooltipContent>Increase indent ({modKey}+])</TooltipContent>
+      </Tooltip>
+
+      <Separator orientation="vertical" className="mx-1 h-6" />
+
+      {/* ── Export DOCX ── */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-sm hover:bg-muted disabled:opacity-50"
+            onClick={handleExportDocx}
+            disabled={!editor || exporting}
+            aria-label="Export as DOCX"
+          >
+            <IconFileDownload size={16} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Export as DOCX</TooltipContent>
       </Tooltip>
 
     </div>

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -207,14 +207,16 @@ export function DocsView({ onEditorReady, readOnly, documentId }: DocsViewProps)
     onEditorReady?.(editor);
 
     // If a DOCX import was staged for this document before navigation,
-    // apply it now that the store and editor are ready.
+    // apply it now that the store and editor are ready. The editor's
+    // cursor currently points to the initial empty-doc block id which
+    // no longer exists after setDocument; resetAfterDocumentReplace
+    // resets the cursor, clears the selection, and invalidates layout.
     if (documentId) {
       const pending = takePendingImport(documentId);
       if (pending) {
         try {
           store.setDocument(pending);
-          editor.getDoc().refresh();
-          editor.render();
+          editor.resetAfterDocumentReplace();
         } catch (err) {
           console.error("Failed to apply pending DOCX import", err);
         }

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -14,7 +14,7 @@ import { YorkieDocStore } from "./yorkie-doc-store";
 import { DocsLinkPopover } from "./docs-link-popover";
 import { DocsFindBar } from "./docs-find-bar";
 import { DocsTableContextMenu } from "./docs-table-context-menu";
-import { takePendingImport } from "./pending-imports";
+import { clearPendingImport, peekPendingImport } from "./pending-imports";
 
 export type { EditorAPI } from "@wafflebase/docs";
 
@@ -211,12 +211,17 @@ export function DocsView({ onEditorReady, readOnly, documentId }: DocsViewProps)
     // cursor currently points to the initial empty-doc block id which
     // no longer exists after setDocument; resetAfterDocumentReplace
     // resets the cursor, clears the selection, and invalidates layout.
+    //
+    // Peek (rather than take) the pending entry so that a failing apply
+    // leaves the import in the registry. It will be retried on the next
+    // mount (e.g. after an HMR reload) instead of being silently lost.
     if (documentId) {
-      const pending = takePendingImport(documentId);
+      const pending = peekPendingImport(documentId);
       if (pending) {
         try {
           store.setDocument(pending);
           editor.resetAfterDocumentReplace();
+          clearPendingImport(documentId);
         } catch (err) {
           console.error("Failed to apply pending DOCX import", err);
         }

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -14,6 +14,7 @@ import { YorkieDocStore } from "./yorkie-doc-store";
 import { DocsLinkPopover } from "./docs-link-popover";
 import { DocsFindBar } from "./docs-find-bar";
 import { DocsTableContextMenu } from "./docs-table-context-menu";
+import { takePendingImport } from "./pending-imports";
 
 export type { EditorAPI } from "@wafflebase/docs";
 
@@ -68,6 +69,13 @@ const HOVER_RADIUS = 10;
 interface DocsViewProps {
   onEditorReady?: (editor: EditorAPI | null) => void;
   readOnly?: boolean;
+  /**
+   * Optional document id used to consume any pending DOCX import that
+   * was staged before navigation (see `pending-imports.ts`). When set,
+   * the imported `Document` is applied via `store.setDocument()` once
+   * the editor finishes mounting.
+   */
+  documentId?: string;
 }
 
 /**
@@ -77,7 +85,7 @@ interface DocsViewProps {
  * It also subscribes to presence changes for peer cursors with label visibility
  * and hover detection.
  */
-export function DocsView({ onEditorReady, readOnly }: DocsViewProps) {
+export function DocsView({ onEditorReady, readOnly, documentId }: DocsViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<EditorAPI | null>(null);
   const storeRef = useRef<YorkieDocStore | null>(null);
@@ -197,6 +205,21 @@ export function DocsView({ onEditorReady, readOnly }: DocsViewProps) {
     editorRef.current = editor;
     setMountedEditor(editor);
     onEditorReady?.(editor);
+
+    // If a DOCX import was staged for this document before navigation,
+    // apply it now that the store and editor are ready.
+    if (documentId) {
+      const pending = takePendingImport(documentId);
+      if (pending) {
+        try {
+          store.setDocument(pending);
+          editor.getDoc().refresh();
+          editor.render();
+        } catch (err) {
+          console.error("Failed to apply pending DOCX import", err);
+        }
+      }
+    }
 
     if (import.meta.env.DEV) {
       (window as Record<string, unknown>).__docsEditor = editor;

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -220,10 +220,16 @@ export function DocsView({ onEditorReady, readOnly, documentId }: DocsViewProps)
       if (pending) {
         try {
           store.setDocument(pending);
-          editor.resetAfterDocumentReplace();
+          // setDocument succeeded; the document is now persisted. Clear pending
+          // immediately so a subsequent reset failure doesn't cause re-apply.
           clearPendingImport(documentId);
+          editor.resetAfterDocumentReplace();
         } catch (err) {
           console.error("Failed to apply pending DOCX import", err);
+          // If setDocument itself threw, pending is still in peek state and
+          // will be retried on next mount. If reset threw, it was already
+          // cleared above — just the editor state is stale, which the user
+          // can recover from with a reload.
         }
       }
     }

--- a/packages/frontend/src/app/docs/docx-actions.ts
+++ b/packages/frontend/src/app/docs/docx-actions.ts
@@ -1,0 +1,140 @@
+import {
+  DocxImporter,
+  DocxExporter,
+  type Document as DocsDocument,
+  type ImageUploader,
+  type ImageFetcher,
+} from "@wafflebase/docs";
+import { fetchWithAuth } from "@/api/auth";
+
+const BACKEND_BASE = import.meta.env.VITE_BACKEND_API_URL ?? "";
+
+/**
+ * Resolve a possibly-relative image URL (e.g. "/images/<id>") against the
+ * backend base URL so the browser can fetch it from a different origin /
+ * port than the frontend.
+ */
+function resolveImageUrl(url: string): string {
+  if (/^https?:\/\//i.test(url)) return url;
+  if (!BACKEND_BASE) return url;
+  return `${BACKEND_BASE.replace(/\/$/, "")}${url.startsWith("/") ? url : `/${url}`}`;
+}
+
+/**
+ * Image uploader passed into DocxImporter — uploads each embedded image
+ * found inside a .docx file to the backend ImageModule and returns an
+ * absolute URL the docs canvas can render.
+ */
+export const docxImageUploader: ImageUploader = async (
+  blob: Blob,
+  filename: string,
+): Promise<string> => {
+  const formData = new FormData();
+  formData.append("file", blob, filename);
+  const res = await fetchWithAuth(`${BACKEND_BASE}/images`, {
+    method: "POST",
+    body: formData,
+  });
+  if (!res.ok) {
+    throw new Error(`Image upload failed: ${res.status} ${res.statusText}`);
+  }
+  const { url } = (await res.json()) as { id: string; url: string };
+  return resolveImageUrl(url);
+};
+
+/**
+ * Image fetcher passed into DocxExporter — downloads images referenced by
+ * the document so they can be embedded into the .docx zip.
+ */
+export const docxImageFetcher: ImageFetcher = async (
+  url: string,
+): Promise<Blob> => {
+  const resolved = resolveImageUrl(url);
+  // Use credentials so JWT cookies are sent for backend-hosted images.
+  const res = await fetch(resolved, { credentials: "include" });
+  if (!res.ok) {
+    throw new Error(`Image fetch failed: ${res.status} ${res.statusText}`);
+  }
+  return res.blob();
+};
+
+/**
+ * Open a native file picker for .docx files and parse the selected file
+ * into a Docs `Document`. Returns `null` if the user cancels the picker.
+ */
+export async function pickAndImportDocx(): Promise<{
+  doc: DocsDocument;
+  fileName: string;
+} | null> {
+  const file = await pickFile(".docx");
+  if (!file) return null;
+  const buffer = await file.arrayBuffer();
+  const doc = await DocxImporter.import(buffer, docxImageUploader);
+  return { doc, fileName: file.name };
+}
+
+/**
+ * Export the given Document as a .docx file and trigger a browser
+ * download.
+ */
+export async function exportDocxAndDownload(
+  doc: DocsDocument,
+  title: string,
+): Promise<void> {
+  const blob = await DocxExporter.export(doc, docxImageFetcher);
+  const safeTitle = (title || "document").replace(/[\\/:*?"<>|]+/g, "_").trim();
+  const filename = safeTitle.toLowerCase().endsWith(".docx")
+    ? safeTitle
+    : `${safeTitle}.docx`;
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  // Defer revocation so Safari has a chance to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/**
+ * Open a native file picker and resolve to the selected file (or null
+ * if the user cancels). The hidden input is appended to the DOM so it
+ * works reliably across browsers.
+ */
+function pickFile(accept: string): Promise<File | null> {
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = accept;
+    input.style.display = "none";
+    let settled = false;
+
+    input.onchange = () => {
+      settled = true;
+      const file = input.files?.[0] ?? null;
+      cleanup();
+      resolve(file);
+    };
+
+    // Detect cancel via window focus (no perfect way, but acceptable).
+    const onFocus = () => {
+      window.removeEventListener("focus", onFocus);
+      setTimeout(() => {
+        if (!settled) {
+          cleanup();
+          resolve(null);
+        }
+      }, 300);
+    };
+    window.addEventListener("focus", onFocus);
+
+    const cleanup = () => {
+      if (input.parentNode) input.parentNode.removeChild(input);
+    };
+
+    document.body.appendChild(input);
+    input.click();
+  });
+}

--- a/packages/frontend/src/app/docs/pending-imports.ts
+++ b/packages/frontend/src/app/docs/pending-imports.ts
@@ -1,0 +1,30 @@
+import type { Document as DocsDocument } from "@wafflebase/docs";
+
+/**
+ * Module-level registry for pending DOCX imports.
+ *
+ * When the user imports a .docx from the document list, the flow is:
+ *   1. Parse the .docx into a Docs `Document`.
+ *   2. Create an empty backend document.
+ *   3. Stash the parsed `Document` here, keyed by the new document's id.
+ *   4. Navigate to `/d/:id`.
+ *   5. After the editor mounts and the Yorkie Tree is initialized,
+ *      the editor pulls the pending `Document` from this registry and
+ *      applies it via `store.setDocument()`.
+ *
+ * A simple in-memory Map is sufficient — the import lives only for the
+ * short window between navigation and editor mount within the same SPA
+ * session. If the user reloads, the import is lost (acceptable trade-off
+ * vs. persisting large documents in localStorage).
+ */
+const pendingImports = new Map<string, DocsDocument>();
+
+export function setPendingImport(docId: string, doc: DocsDocument): void {
+  pendingImports.set(docId, doc);
+}
+
+export function takePendingImport(docId: string): DocsDocument | undefined {
+  const doc = pendingImports.get(docId);
+  if (doc) pendingImports.delete(docId);
+  return doc;
+}

--- a/packages/frontend/src/app/docs/pending-imports.ts
+++ b/packages/frontend/src/app/docs/pending-imports.ts
@@ -23,8 +23,24 @@ export function setPendingImport(docId: string, doc: DocsDocument): void {
   pendingImports.set(docId, doc);
 }
 
+/**
+ * Read a pending import without consuming it. Callers should prefer this
+ * over `takePendingImport` when the apply step can fail, so the entry
+ * can be retried (or explicitly dropped) after the failure is handled.
+ */
+export function peekPendingImport(docId: string): DocsDocument | undefined {
+  return pendingImports.get(docId);
+}
+
 export function takePendingImport(docId: string): DocsDocument | undefined {
   const doc = pendingImports.get(docId);
   if (doc) pendingImports.delete(docId);
   return doc;
+}
+
+/**
+ * Explicitly drop a pending import after it has been successfully applied.
+ */
+export function clearPendingImport(docId: string): void {
+  pendingImports.delete(docId);
 }

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -10,6 +10,7 @@ import type {
   Inline,
   BlockStyle,
   InlineStyle,
+  ImageData,
   PageSetup,
   HeaderFooter,
   TableRow,
@@ -59,6 +60,14 @@ function serializeInlineStyle(style: InlineStyle): Record<string, string> {
   if (style.backgroundColor !== undefined) attrs.backgroundColor = style.backgroundColor;
   if (style.href !== undefined) attrs.href = style.href;
   setIfDefined(attrs, 'pageNumber', style.pageNumber);
+  if (style.image !== undefined) {
+    attrs['image.src'] = style.image.src;
+    attrs['image.width'] = String(style.image.width);
+    attrs['image.height'] = String(style.image.height);
+    if (style.image.alt !== undefined) {
+      attrs['image.alt'] = style.image.alt;
+    }
+  }
   return attrs;
 }
 
@@ -77,6 +86,17 @@ function parseInlineStyle(attrs: Record<string, string> | undefined): InlineStyl
   if ('backgroundColor' in attrs) style.backgroundColor = attrs.backgroundColor;
   if (attrs.href !== undefined) style.href = attrs.href;
   if (attrs.pageNumber !== undefined) style.pageNumber = attrs.pageNumber === 'true';
+  if ('image.src' in attrs) {
+    const image: ImageData = {
+      src: attrs['image.src'],
+      width: Number(attrs['image.width']),
+      height: Number(attrs['image.height']),
+    };
+    if ('image.alt' in attrs) {
+      image.alt = attrs['image.alt'];
+    }
+    style.image = image;
+  }
   return style;
 }
 

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -87,15 +87,27 @@ function parseInlineStyle(attrs: Record<string, string> | undefined): InlineStyl
   if (attrs.href !== undefined) style.href = attrs.href;
   if (attrs.pageNumber !== undefined) style.pageNumber = attrs.pageNumber === 'true';
   if ('image.src' in attrs) {
-    const image: ImageData = {
-      src: attrs['image.src'],
-      width: Number(attrs['image.width']),
-      height: Number(attrs['image.height']),
-    };
-    if ('image.alt' in attrs) {
-      image.alt = attrs['image.alt'];
+    // Guard against NaN / non-positive sizes from missing or malformed
+    // attributes so that invalid image data is dropped instead of being
+    // materialised into the in-memory document (and persisted back).
+    const width = Number(attrs['image.width']);
+    const height = Number(attrs['image.height']);
+    if (
+      Number.isFinite(width) &&
+      Number.isFinite(height) &&
+      width > 0 &&
+      height > 0
+    ) {
+      const image: ImageData = {
+        src: attrs['image.src'],
+        width,
+        height,
+      };
+      if ('image.alt' in attrs) {
+        image.alt = attrs['image.alt'];
+      }
+      style.image = image;
     }
-    style.image = image;
   }
   return style;
 }

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -16,6 +16,7 @@ import {
 import { formatDistanceToNow } from "date-fns";
 import { toast } from "sonner";
 import {
+  FileDown,
   FileText,
   FolderOutput,
   MoreHorizontal,
@@ -70,6 +71,8 @@ import {
   fetchWorkspaces,
   type Workspace,
 } from "@/api/workspaces";
+import { pickAndImportDocx } from "@/app/docs/docx-actions";
+import { setPendingImport } from "@/app/docs/pending-imports";
 
 function getDocumentPath(doc: { id: number | string; type?: DocumentType }) {
   return doc.type === "doc" ? `/d/${doc.id}` : `/s/${doc.id}`;
@@ -209,6 +212,33 @@ export function DocumentList({
     onSuccess: (doc) => navigate(getDocumentPath(doc)),
   });
 
+  const [importing, setImporting] = useState(false);
+
+  const handleImportDocx = async () => {
+    if (importing) return;
+    setImporting(true);
+    try {
+      const result = await pickAndImportDocx();
+      if (!result) return;
+
+      const title = result.fileName.replace(/\.docx$/i, "") || "Imported Document";
+      const created = workspaceId
+        ? await createWorkspaceDocument(workspaceId, { title, type: "doc" })
+        : await createDocument({ title, type: "doc" });
+
+      setPendingImport(String(created.id), result.doc);
+      toast.success(`Imported "${title}"`);
+      navigate(getDocumentPath(created));
+    } catch (err) {
+      console.error("DOCX import failed", err);
+      toast.error(
+        err instanceof Error ? `Import failed: ${err.message}` : "Import failed",
+      );
+    } finally {
+      setImporting(false);
+    }
+  };
+
   const deleteDocumentMutation = useMutation({
     mutationFn: async (id: string) => await deleteDocument(id),
     onSuccess: () => {
@@ -319,6 +349,13 @@ export function DocumentList({
               <FileText className="mr-2 h-4 w-4 text-blue-500" />
               New Document
             </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={importing}
+              onClick={handleImportDocx}
+            >
+              <FileDown className="mr-2 h-4 w-4 text-blue-500" />
+              Import DOCX
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
@@ -403,6 +440,13 @@ export function DocumentList({
                         >
                           <FileText className="mr-2 h-4 w-4 text-blue-500" />
                           New Document
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          disabled={importing}
+                          onClick={handleImportDocx}
+                        >
+                          <FileDown className="mr-2 h-4 w-4 text-blue-500" />
+                          Import DOCX
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       '@types/ms':
         specifier: ^2.1.0
         version: 2.1.0
+      '@types/multer':
+        specifier: ^2.1.0
+        version: 2.1.0
       '@types/node':
         specifier: ^22.10.7
         version: 22.14.1
@@ -3701,6 +3704,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/multer@2.1.0':
+    resolution: {integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==}
 
   '@types/node@22.14.1':
     resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
@@ -11347,6 +11353,10 @@ snapshots:
   '@types/mime@1.3.5': {}
 
   '@types/ms@2.1.0': {}
+
+  '@types/multer@2.1.0':
+    dependencies:
+      '@types/express': 5.0.1
 
   '@types/node@22.14.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,10 @@ importers:
         version: 3.1.1(@types/node@25.4.0)(jiti@2.6.1)(jsdom@28.0.0(@noble/hashes@1.8.0))(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/docs:
+    dependencies:
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 3.1.1
@@ -5484,6 +5488,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -5625,6 +5632,9 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -5868,6 +5878,9 @@ packages:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -5903,6 +5916,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-darwin-arm64@1.29.2:
     resolution: {integrity: sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==}
@@ -6377,6 +6393,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   papaparse@5.5.2:
     resolution: {integrity: sha512-PZXg8UuAc4PcVwLosEEDYjPyfWnTEhOrUfdv+3Bx+NuAb+5NhDmXzg5fHWmdCh1mP5p7JAZfFr3IMQfcntNAdA==}
 
@@ -6618,6 +6637,9 @@ packages:
       typescript:
         optional: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -6743,6 +6765,9 @@ packages:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -6856,6 +6881,9 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -6928,6 +6956,9 @@ packages:
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -7082,6 +7113,9 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -13348,6 +13382,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -13456,6 +13492,8 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -13916,6 +13954,13 @@ snapshots:
       ms: 2.1.3
       semver: 7.7.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -13960,6 +14005,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-darwin-arm64@1.29.2:
     optional: true
@@ -14409,6 +14458,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   papaparse@5.5.2: {}
 
   parent-module@1.0.1:
@@ -14618,6 +14669,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  process-nextick-args@2.0.1: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -14731,6 +14784,16 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
@@ -14870,6 +14933,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-regex-test@1.1.0:
@@ -14956,6 +15021,8 @@ snapshots:
       get-intrinsic: 1.3.0
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -15110,6 +15177,10 @@ snapshots:
       emoji-regex: 10.4.0
       get-east-asian-width: 1.3.0
       strip-ansi: 7.1.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
 
   packages/backend:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1028.0
+        version: 3.1028.0
       '@nestjs/common':
         specifier: ^11.1.0
         version: 11.1.14(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -595,6 +598,165 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1028.0':
+    resolution: {integrity: sha512-KL8PREFJxyWXUjMQR6Krq/OjZ5qbcV1QFjtA7Q7oMW5XaFO9YoSBtBxQeeXO4um6vYSmRVYVDTvEKZDcNbyeXw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.27':
+    resolution: {integrity: sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.6':
+    resolution: {integrity: sha512-NMbiqKdruhwwgI6nzBVe2jWMkXjaoQz2YOs3rFX+2F3gGyrJDkDPwMpV/RsTFeq2vAQ055wZNtOXFK4NYSkM8g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.25':
+    resolution: {integrity: sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.27':
+    resolution: {integrity: sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.29':
+    resolution: {integrity: sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.29':
+    resolution: {integrity: sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.30':
+    resolution: {integrity: sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.25':
+    resolution: {integrity: sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.29':
+    resolution: {integrity: sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.29':
+    resolution: {integrity: sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.9':
+    resolution: {integrity: sha512-COToYKgquDyligbcAep7ygs48RK+mwe/IYprq4+TSrVFzNOYmzWvHf6werpnKV5VYpRiwdn+Wa5ZXkPqLVwcTg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.9':
+    resolution: {integrity: sha512-V/FNCjFxnh4VGu+HdSiW4Yg5GELihA1MIDSAdsEPvuayXBVmr0Jaa6jdLAZLH38KYXl/vVjri9DQJWnTAujHEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.7':
+    resolution: {integrity: sha512-uU4/ch2CLHB8Phu1oTKnnQ4e8Ujqi49zEnQYBhWYT53zfFvtJCdGsaOoypBr8Fm/pmCBssRmGoIQ4sixgdLP9w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.9':
+    resolution: {integrity: sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.9':
+    resolution: {integrity: sha512-TyfOi2XNdOZpNKeTJwRUsVAGa+14nkyMb2VVGG+eDgcWG/ed6+NUo72N3hT6QJioxym80NSinErD+LBRF0Ir1w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.9':
+    resolution: {integrity: sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.10':
+    resolution: {integrity: sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.28':
+    resolution: {integrity: sha512-qJHcJQH9UNPUrnPlRtCozKjtqAaypQ5IgQxTNoPsVYIQeuwNIA8Rwt3NvGij1vCDYDfCmZaPLpnJEHlZXeFqmg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.9':
+    resolution: {integrity: sha512-wSA2BR7L0CyBNDJeSrleIIzC+DzL93YNTdfU0KPGLiocK6YsRv1nPAzPF+BFSdcs0Qa5ku5Kcf4KvQcWwKGenQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.29':
+    resolution: {integrity: sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.996.19':
+    resolution: {integrity: sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.11':
+    resolution: {integrity: sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.16':
+    resolution: {integrity: sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1026.0':
+    resolution: {integrity: sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.7':
+    resolution: {integrity: sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.6':
+    resolution: {integrity: sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.9':
+    resolution: {integrity: sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==}
+
+  '@aws-sdk/util-user-agent-node@3.973.15':
+    resolution: {integrity: sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.17':
+    resolution: {integrity: sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -2976,6 +3138,218 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.14':
+    resolution: {integrity: sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.14':
+    resolution: {integrity: sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.13':
+    resolution: {integrity: sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.13':
+    resolution: {integrity: sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.13':
+    resolution: {integrity: sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.13':
+    resolution: {integrity: sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.13':
+    resolution: {integrity: sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.13':
+    resolution: {integrity: sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.16':
+    resolution: {integrity: sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.2.14':
+    resolution: {integrity: sha512-rtQ5es8r/5v4rav7q5QTsfx9CtCyzrz/g7ZZZBH2xtMmd6G/KQrLOWfSHTvFOUPlVy59RQvxeBYJaLRoybMEyA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.13':
+    resolution: {integrity: sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.2.13':
+    resolution: {integrity: sha512-WdQ7HwUjINXETeh6dqUeob1UHIYx8kAn9PSp1HhM2WWegiZBYVy2WXIs1lB07SZLan/udys9SBnQGt9MQbDpdg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.13':
+    resolution: {integrity: sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.2.13':
+    resolution: {integrity: sha512-cNm7I9NXolFxtS20ojROddOEpSAeI1Obq6pd1Kj5HtHws3s9Fkk8DdHDfQSs5KuxCewZuVK6UqrJnfJmiMzDuQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.13':
+    resolution: {integrity: sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.29':
+    resolution: {integrity: sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.5.1':
+    resolution: {integrity: sha512-/zY+Gp7Qj2D2hVm3irkCyONER7E9MiX3cUUm/k2ZmhkzZkrPgwVS4aJ5NriZUEN/M0D1hhjrgjUmX04HhRwdWA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.17':
+    resolution: {integrity: sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.13':
+    resolution: {integrity: sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.13':
+    resolution: {integrity: sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.5.2':
+    resolution: {integrity: sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.13':
+    resolution: {integrity: sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.13':
+    resolution: {integrity: sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.13':
+    resolution: {integrity: sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.13':
+    resolution: {integrity: sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.13':
+    resolution: {integrity: sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.8':
+    resolution: {integrity: sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.13':
+    resolution: {integrity: sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.9':
+    resolution: {integrity: sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.0':
+    resolution: {integrity: sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.13':
+    resolution: {integrity: sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.45':
+    resolution: {integrity: sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.49':
+    resolution: {integrity: sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.3.4':
+    resolution: {integrity: sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.13':
+    resolution: {integrity: sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.3.1':
+    resolution: {integrity: sha512-FwmicpgWOkP5kZUjN3y+3JIom8NLGqSAJBeoIgK0rIToI817TEBHCrd0A2qGeKQlgDeP+Jzn4i0H/NLAXGy9uQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.22':
+    resolution: {integrity: sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.2.15':
+    resolution: {integrity: sha512-oUt9o7n8hBv3BL56sLSneL0XeigZSuem0Hr78JaoK33D9oKieyCvVP8eTSe3j7g2mm/S1DvzxKieG7JEWNJUNg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+
   '@swc/cli@0.7.3':
     resolution: {integrity: sha512-rnVXNnlURjdOuPaBIwZ3TmBA44BF/eP0j154LanlgPEYfau74ige7cpKlKkZr1IBqMOG99lAnYNxQipDWA3hdg==}
     engines: {node: '>= 16.14.0'}
@@ -3944,6 +4318,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -4772,6 +5149,13 @@ packages:
 
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
+  fast-xml-builder@1.1.4:
+    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -6041,6 +6425,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -6735,6 +7123,9 @@ packages:
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
     engines: {node: '>=14.16'}
+
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
@@ -7621,6 +8012,450 @@ snapshots:
       lru-cache: 11.2.6
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.7
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1028.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/credential-provider-node': 3.972.30
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.9
+      '@aws-sdk/middleware-expect-continue': 3.972.9
+      '@aws-sdk/middleware-flexible-checksums': 3.974.7
+      '@aws-sdk/middleware-host-header': 3.972.9
+      '@aws-sdk/middleware-location-constraint': 3.972.9
+      '@aws-sdk/middleware-logger': 3.972.9
+      '@aws-sdk/middleware-recursion-detection': 3.972.10
+      '@aws-sdk/middleware-sdk-s3': 3.972.28
+      '@aws-sdk/middleware-ssec': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.29
+      '@aws-sdk/region-config-resolver': 3.972.11
+      '@aws-sdk/signature-v4-multi-region': 3.996.16
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-endpoints': 3.996.6
+      '@aws-sdk/util-user-agent-browser': 3.972.9
+      '@aws-sdk/util-user-agent-node': 3.973.15
+      '@smithy/config-resolver': 4.4.14
+      '@smithy/core': 3.23.14
+      '@smithy/eventstream-serde-browser': 4.2.13
+      '@smithy/eventstream-serde-config-resolver': 4.3.13
+      '@smithy/eventstream-serde-node': 4.2.13
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/hash-blob-browser': 4.2.14
+      '@smithy/hash-node': 4.2.13
+      '@smithy/hash-stream-node': 4.2.13
+      '@smithy/invalid-dependency': 4.2.13
+      '@smithy/md5-js': 4.2.13
+      '@smithy/middleware-content-length': 4.2.13
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/middleware-retry': 4.5.1
+      '@smithy/middleware-serde': 4.2.17
+      '@smithy/middleware-stack': 4.2.13
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.45
+      '@smithy/util-defaults-mode-node': 4.2.49
+      '@smithy/util-endpoints': 3.3.4
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-retry': 4.3.1
+      '@smithy/util-stream': 4.5.22
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.2.15
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/xml-builder': 3.972.17
+      '@smithy/core': 3.23.14
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/property-provider': 4.2.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/signature-v4': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.6':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.25':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.27':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/types': 3.973.7
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/property-provider': 4.2.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/util-stream': 4.5.22
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/credential-provider-env': 3.972.25
+      '@aws-sdk/credential-provider-http': 3.972.27
+      '@aws-sdk/credential-provider-login': 3.972.29
+      '@aws-sdk/credential-provider-process': 3.972.25
+      '@aws-sdk/credential-provider-sso': 3.972.29
+      '@aws-sdk/credential-provider-web-identity': 3.972.29
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/types': 3.973.7
+      '@smithy/credential-provider-imds': 4.2.13
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.30':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.25
+      '@aws-sdk/credential-provider-http': 3.972.27
+      '@aws-sdk/credential-provider-ini': 3.972.29
+      '@aws-sdk/credential-provider-process': 3.972.25
+      '@aws-sdk/credential-provider-sso': 3.972.29
+      '@aws-sdk/credential-provider-web-identity': 3.972.29
+      '@aws-sdk/types': 3.973.7
+      '@smithy/credential-provider-imds': 4.2.13
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.25':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/token-providers': 3.1026.0
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.7':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/crc64-nvme': 3.972.6
+      '@aws-sdk/types': 3.973.7
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-stream': 4.5.22
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.28':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.14
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/signature-v4': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-stream': 4.5.22
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-endpoints': 3.996.6
+      '@smithy/core': 3.23.14
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-retry': 4.3.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.996.19':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/middleware-host-header': 3.972.9
+      '@aws-sdk/middleware-logger': 3.972.9
+      '@aws-sdk/middleware-recursion-detection': 3.972.10
+      '@aws-sdk/middleware-user-agent': 3.972.29
+      '@aws-sdk/region-config-resolver': 3.972.11
+      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/util-endpoints': 3.996.6
+      '@aws-sdk/util-user-agent-browser': 3.972.9
+      '@aws-sdk/util-user-agent-node': 3.973.15
+      '@smithy/config-resolver': 4.4.14
+      '@smithy/core': 3.23.14
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/hash-node': 4.2.13
+      '@smithy/invalid-dependency': 4.2.13
+      '@smithy/middleware-content-length': 4.2.13
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/middleware-retry': 4.5.1
+      '@smithy/middleware-serde': 4.2.17
+      '@smithy/middleware-stack': 4.2.13
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.45
+      '@smithy/util-defaults-mode-node': 4.2.49
+      '@smithy/util-endpoints': 3.3.4
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-retry': 4.3.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/config-resolver': 4.4.14
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.16':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.28
+      '@aws-sdk/types': 3.973.7
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/signature-v4': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1026.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/nested-clients': 3.996.19
+      '@aws-sdk/types': 3.973.7
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.7':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.6':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-endpoints': 3.3.4
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.7
+      '@smithy/types': 4.14.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.15':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.29
+      '@aws-sdk/types': 3.973.7
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.17':
+    dependencies:
+      '@smithy/types': 4.14.0
+      fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -9819,6 +10654,339 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    dependencies:
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.3.4
+      '@smithy/util-middleware': 4.2.13
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-stream': 4.5.22
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.13':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/property-provider': 4.2.13
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.13':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.0
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.13':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.13':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.13':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.16':
+    dependencies:
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.2.14':
+    dependencies:
+      '@smithy/chunked-blob-reader': 5.2.2
+      '@smithy/chunked-blob-reader-native': 4.2.3
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.13':
+    dependencies:
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.29':
+    dependencies:
+      '@smithy/core': 3.23.14
+      '@smithy/middleware-serde': 4.2.17
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      '@smithy/url-parser': 4.2.13
+      '@smithy/util-middleware': 4.2.13
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.5.1':
+    dependencies:
+      '@smithy/core': 3.23.14
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/service-error-classification': 4.2.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-retry': 4.3.1
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.17':
+    dependencies:
+      '@smithy/core': 3.23.14
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.13':
+    dependencies:
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.5.2':
+    dependencies:
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/querystring-builder': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+
+  '@smithy/shared-ini-file-loader@4.4.8':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.13':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.9':
+    dependencies:
+      '@smithy/core': 3.23.14
+      '@smithy/middleware-endpoint': 4.4.29
+      '@smithy/middleware-stack': 4.2.13
+      '@smithy/protocol-http': 5.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-stream': 4.5.22
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.13':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.45':
+    dependencies:
+      '@smithy/property-provider': 4.2.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.49':
+    dependencies:
+      '@smithy/config-resolver': 4.4.14
+      '@smithy/credential-provider-imds': 4.2.13
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/property-provider': 4.2.13
+      '@smithy/smithy-client': 4.12.9
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.3.4':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.1':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.22':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.16
+      '@smithy/node-http-handler': 4.5.2
+      '@smithy/types': 4.14.0
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.2.15':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@swc/cli@0.7.3(@swc/core@1.11.20)(chokidar@4.0.3)':
     dependencies:
       '@swc/core': 1.11.20
@@ -10933,6 +12101,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bowser@2.14.1: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -11801,6 +12971,16 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.0.6: {}
+
+  fast-xml-builder@1.1.4:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.5.8:
+    dependencies:
+      fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   fastq@1.19.1:
     dependencies:
@@ -13281,6 +14461,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -13962,6 +15144,8 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.3: {}
+
+  strnum@2.2.3: {}
 
   strtok3@10.3.4:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds bidirectional Microsoft Word (.docx) import and export to the docs editor, including inline images, tables with cell merge, page setup, and headers/footers.
- Introduces the prerequisite features needed to represent real-world .docx content: inline image support in the model/layout/canvas, an S3-compatible image service backed by MinIO in dev, and a Korean web-font registry with fallback chains.
- Converts at the model layer: DocxImporter reads a .docx into a `Document`, DocxExporter writes a `Document` back to a .docx Blob. Frontend wires both into the document list "New" dropdown and the body toolbar.

## Design and Plan

- Design: `docs/design/docs/docs-docx-import-export.md`
- Implementation plan: `docs/tasks/active/20260410-docx-import-export-todo.md`

## What's Included

**Phase 1 — Prerequisites**
- `ImageData` type on `InlineStyle`; `Doc.insertImageInline` via a new `applyInsertInline` helper in `block-helpers.ts`; Yorkie image serialization
- Image measurement/rendering in `layout.ts`, `doc-canvas.ts`, and `table-layout.ts` with a shared image cache and async-load re-render
- `ImageModule` NestJS backend with S3/MinIO storage, JWT-authed upload/delete, public serve with UUID-format validation, bucket auto-create
- Font registry with fallback chains for Korean typefaces (맑은 고딕, 바탕, HY헤드라인M) and the browser Font Loading API

**Phase 2 — DOCX Import**
- Unit conversions (twips/EMU/half-points ↔ CSS px)
- OOXML → Docs style mapping (run, paragraph, table cell, highlight)
- XML parser utilities (relationships, paragraphs, page setup)
- `DocxImporter.import(buffer, imageUploader?)` — handles paragraphs, styled runs, tables with `gridSpan`/`vMerge`, nested-table flattening to text, page setup, headers/footers, and image upload hand-off

**Phase 3 — DOCX Export**
- Docs → OOXML style mapping
- OOXML templates for content types, rels, and styles
- `DocxExporter.export(doc, imageFetcher?)` — builds document.xml, header1.xml, footer1.xml, relationships, and packages to a Blob via JSZip. Round-trip tested against the importer.

**Phase 4 — Frontend integration**
- "Import DOCX" item in the New dropdown (document list + empty state) that parses the file, uploads embedded images to the image service, creates a new document, and hands off the parsed Document via an in-memory pending-imports map
- "Export as DOCX" toolbar button in the body formatting toolbar
- `EditorAPI.resetAfterDocumentReplace()` to fix a stale-cursor crash after `store.setDocument()` applies the imported content

**Infrastructure**
- MinIO service added to `docker-compose.yaml` (ports 9000/9001, `minio-data` volume)
- `@types/multer` dev dep so the image controller typechecks under watch mode
- Knip config excludes `.claude/**` so dead-code scans don't trip over sibling git worktrees

## Intentional Non-Goals

- Floating / anchored images — only inline images are supported
- Nested tables — content is flattened to text on import (documented in design)
- Form controls, SmartArt, comments, track changes, footnotes
- Pixel-perfect round-trip fidelity with Word — structural correctness first

## Test plan

- [x] `pnpm verify:fast` — 434 tests across 28 test files pass
- [x] `pnpm verify:self` — all build, lint, typecheck, chunk, and entropy lanes pass
- [x] Unit tests for `ImageData` type, `insertImageInline` (including table-cell path), OOXML unit conversions, OOXML ↔ Docs style mapping, XML parsers, DocxImporter (including image dimensions, stacked vMerge groups, deeply nested table de-duplication), DocxExporter round-trips, font fallback chains
- [ ] Manual: `docker compose up -d` (with MinIO), `pnpm dev`, import the target form.docx via the document list "New" dropdown and verify layout, tables, page setup, and embedded images render
- [ ] Manual: export a doc with text formatting, tables, and images, open it in Word / Google Docs / LibreOffice

## Follow-Ups

Tracked from code review; not in scope for this PR:
- Bounded LRU eviction for the canvas image cache
- Baseline-aligned image placement (currently bottom-aligned)
- Import progress toast / loading state
- Backend `IMAGE_STORAGE_*` env vars documented in `packages/backend/README.md`
- Images inside tables pass through a parallel code path in `table-layout.ts`; consider hoisting `measureSegments` into a shared helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DOCX import/export (preserves formatting, tables, headers/footers)
  * Inline image support: insert, upload, render, and automatic scaling
  * Image service integration for uploading and serving images (local dev storage enabled)
  * UI: "Import DOCX" and "Export as DOCX" flows with direct download
  * Pending import/resume: imported documents can be applied after navigation
  * Korean web font loading for improved typography and rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->