### PR TITLE
Archive v0.3.2 release task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,13 +18,14 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| docx import export (2026-04-10) | [20260410-docx-import-export-todo.md](./active/20260410-docx-import-export-todo.md) | - |
 | intent preserving phase4 table cells (2026-04-03) | [20260403-intent-preserving-phase4-table-cells-todo.md](./active/20260403-intent-preserving-phase4-table-cells-todo.md) | - |
 | intent preserving phase5 undo redo (2026-04-03) | [20260403-intent-preserving-phase5-undo-redo-todo.md](./active/20260403-intent-preserving-phase5-undo-redo-todo.md) | - |
 | docs wordprocessor (2026-03-25) | [20260325-docs-wordprocessor-todo.md](./active/20260325-docs-wordprocessor-todo.md) | [20260325-docs-wordprocessor-lessons.md](./active/20260325-docs-wordprocessor-lessons.md) |
 
 ## Archive
 
-- Archived task count: 115
+- Archived task count: 118
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: intent preserving phase4 table cells (2026-04-03)
+Latest active task: docx import export (2026-04-10)

--- a/docs/tasks/archive/2026/04/20260411-release-v0.3.2-todo.md
+++ b/docs/tasks/archive/2026/04/20260411-release-v0.3.2-todo.md
@@ -77,16 +77,15 @@ All git commands run in **`/Users/hackerwins/Development/wafflebase/waffledocs`*
 - [x] Commit: `Bump version to v0.3.2` (subject only, matches v0.3.1 precedent)
 - [x] Open PR #115 `bump-v0.3.2` → `main`
       (pre-push hook ran `verify:self`, 6 lanes in 64.9s, all passed)
-- [ ] PR #115 merged to `main`
-- [ ] `git checkout main && git pull --ff-only` to get the merge commit
-- [ ] `git tag v0.3.2 <merge HEAD>` (lightweight, matches precedent)
-- [ ] `git push origin v0.3.2`
-- [ ] Create GitHub Release via `gh release create v0.3.2`
-      (see notes below) — this triggers
-      `.github/workflows/docker-publish.yml` which publishes
-      `yorkieteam/wafflebase:v0.3.2` and `:latest` for
-      `linux/amd64,linux/arm64`
-- [ ] Confirm docker-publish workflow run succeeds on Docker Hub
+- [x] PR #115 squash-merged to `main` as `39e782b9 Bump version to v0.3.2 (#115)`
+- [x] `git checkout main && git pull --ff-only` to get the merge commit
+- [x] `git tag v0.3.2 39e782b9` (lightweight, matches precedent)
+- [x] `git push origin v0.3.2`
+- [x] Create GitHub Release via `gh release create v0.3.2`
+      → https://github.com/wafflebase/wafflebase/releases/tag/v0.3.2
+- [x] `docker-publish.yml` release run succeeded (2m43s) —
+      `yorkieteam/wafflebase:v0.3.2` + `:latest` on Docker Hub
+      for `linux/amd64,linux/arm64`
 
 ### Release notes draft
 
@@ -114,40 +113,82 @@ All git commands run in **`/Users/hackerwins/Development/wafflebase/waffledocs`*
 ## Phase 3 — devops repo PR
 
 All git commands run in `/Users/hackerwins/Development/yorkie-team/devops`.
-Do not start Phase 3 until Phase 2 confirms the docker image is
-published.
 
-- [ ] `git checkout main && git pull --ff-only origin main`
-- [ ] `git checkout -b bump-wafflebase-v0.3.2`
-- [ ] Edit `k8s/wafflebase/deployment.yaml`:
-  - [ ] Replace all 6 occurrences of `0.3.0` / `v0.3.0` with `0.3.2` / `v0.3.2`
+> **Correction from earlier plan:** devops was at `v0.3.1`, not
+> `v0.3.0` — the initial observation was based on a stale local
+> clone of `devops/main`. The actual bump is therefore
+> `v0.3.1 → v0.3.2`. v0.3.1 was a routine image bump (PR #276 by
+> the user on 2026-04-05) with no env var changes — "no server
+> deployment needed" meant no new env vars or infrastructure, not
+> that the deployment was skipped.
+
+- [x] `git checkout main && git pull --ff-only origin main`
+- [x] `git checkout -b bump-wafflebase-v0.3.2`
+- [x] Edit `k8s/wafflebase/deployment.yaml`:
+  - [x] Replace all 6 occurrences of `0.3.1` → `0.3.2`
         (labels at L10, L14, L26, L27 + image tags at L38, L46)
-  - [ ] Append `IMAGE_STORAGE_*` env vars to the main container `env:`
-        block (5 entries: endpoint, bucket, region, access key, secret key)
-        using inline values (matches existing secret pattern in this file)
-- [ ] Commit:
-      ```
-      Bump up Wafflebase to v0.3.2
+  - [x] Append `IMAGE_STORAGE_*` env vars to the main container
+        `env:` block (5 entries: endpoint, bucket, region, access
+        key, secret key) using inline values (matches the existing
+        secret pattern in this file)
+- [x] Commit `Bump wafflebase to v0.3.2`
+- [x] `git push -u origin bump-wafflebase-v0.3.2`
+- [x] Opened `yorkie-team/devops#278`
+- [x] PR #278 merged to `main` as `485a6e7`
+- [x] ArgoCD synced the `wafflebase` app
+- [x] `kubectl -n wafflebase rollout status deploy/wafflebase` clean
+      (1 old replica terminated, new replica healthy)
+- [x] Pod logs show `Nest application successfully started +1071ms`
+      and `ImageController {/images}` POST/GET/DELETE routes mapped;
+      no `HeadBucket`/`CreateBucket` warnings from `ImageService`
+- [x] Endpoint reachability:
+      `/auth/me` → 401 (no cookie, expected),
+      `/` → 200,
+      `/images/<random-uuid>.png` → `NoSuchKey` (confirms S3
+      credentials and IAM policy work end-to-end — an
+      `AccessDenied` would indicate policy misconfiguration)
+- [x] Browser smoke test against https://wafflebase.io:
+  - [x] GitHub OAuth login works
+  - [x] Document list → **Import DOCX** menu imports a real
+        `form.docx` (1.2 MB, 46 tables, inline images) and
+        hands off to a new document
+  - [x] Inline images render in the body (end-to-end `/images`
+        upload + proxy path verified in the browser)
+  - [x] Export as DOCX round-trip produces a valid `.docx`
 
-      v0.3.2 adds DOCX import/export which adds a backend ImageModule
-      backed by S3. The service fails fast in production without the
-      IMAGE_STORAGE_* env vars, so provision the `wafflebase` bucket
-      in ap-northeast-2 and wire credentials into the deployment.
+### Smoke test outcome — 2 import bugs found (not release blockers)
 
-      v0.3.1 was an intentional tag-only checkpoint (no server
-      changes), so this bump jumps from v0.3.0 directly to v0.3.2.
-      ```
-- [ ] `git push -u origin bump-wafflebase-v0.3.2`
-- [ ] Open PR against `yorkie-team/devops#main` and request review
-- [ ] After merge, confirm ArgoCD syncs the `wafflebase` app
-- [ ] `kubectl -n wafflebase rollout status deploy/wafflebase`
-- [ ] `kubectl -n wafflebase logs deploy/wafflebase` — confirm
-      `ImageService` init does not warn on `HeadBucket`/`CreateBucket`
-- [ ] Smoke test on https://wafflebase.io:
-  - [ ] `/auth/me` still works
-  - [ ] Import a `.docx` with inline images via document list
-  - [ ] Export a document as `.docx` with inline images
-  - [ ] Round-trip a doc through import → export → re-import
+The end-to-end path (DOCX import → S3 upload → proxy → render →
+DOCX export) works. During visual inspection of `form.docx`, two
+preexisting bugs in the DOCX importer were found. Both are
+**import-path only** (no server/schema/infra impact), so v0.3.2
+is kept as released and the fixes will ship in v0.3.3.
+
+1. **`w:val="0"` is treated as ON for bold / italic / strikethrough.**
+   `docx-style-map.ts:21-23` checks only element presence. OOXML
+   uses `<w:b w:val="0"/>`, `<w:i w:val="0"/>`, `<w:strike w:val="0"/>`
+   to explicitly clear an inherited style. `form.docx` contains
+   509 + 509 + 513 such toggles, so the rendered document shows
+   unintended strikethrough (and bold / italic) across most runs.
+   The already-fixed underline (`<w:u w:val="none"/>`) and
+   highlight (`<w:highlight w:val="none"/>`) paths show the
+   correct pattern to follow.
+
+2. **`tbl.getElementsByTagNameNS('w:gridCol')` is recursive** and
+   picks up `w:gridCol` elements from every nested table inside
+   the outer `<w:tbl>`. The importer's row walk already uses
+   direct-child traversal for `<w:tr>` — the `gridCol` lookup is
+   an asymmetric survivor. In `form.docx` this inflates the
+   outer table's column count from e.g. 1 → 12 for the "별첨 n-k
+   인적사항" tables, which collapses the real column to ~8% of
+   the content width and stacks every row's text vertically in
+   a narrow strip. The contribution-guide table (table 5) is
+   unaffected — its narrow spacer columns are present in the
+   source `.docx` itself and Word renders the same layout.
+
+Follow-up task file for v0.3.3: see
+`docs/tasks/active/20260411-docx-import-bugs-todo.md` (to be
+created in the next step of the post-release workflow).
 
 ## Risks
 

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,15 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 115
+Total archived tasks: 118
 
-## 2026/04 (1 tasks)
+## 2026/04 (4 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| release v0.3.2 (2026-04-11) | [20260411-release-v0.3.2-todo.md](./2026/04/20260411-release-v0.3.2-todo.md) | - |
+| header footer (2026-04-08) | [20260408-header-footer-todo.md](./2026/04/20260408-header-footer-todo.md) | - |
+| page break (2026-04-08) | [20260408-page-break-todo.md](./2026/04/20260408-page-break-todo.md) | - |
 | intent preserving phase1 3 (2026-04-02) | [20260402-intent-preserving-phase1-3-todo.md](./2026/04/20260402-intent-preserving-phase1-3-todo.md) | [20260402-intent-preserving-phase1-3-lessons.md](./2026/04/20260402-intent-preserving-phase1-3-lessons.md) |
 
 ## 2026/03 (77 tasks)


### PR DESCRIPTION
## Summary

Marks the v0.3.2 release task as complete and moves it to
`docs/tasks/archive/2026/04/`. The release is fully live:

- **wafflebase#115** — version bump to v0.3.2 merged
- **Tag v0.3.2** and GitHub release published
- **`yorkieteam/wafflebase:v0.3.2`** + `:latest` on Docker Hub
- **yorkie-team/devops#278** — image bump + `IMAGE_STORAGE_*`
  env vars merged, ArgoCD synced, rollout clean
- **AWS** — S3 bucket `wafflebase` in `ap-northeast-2` + scoped
  IAM user `wafflebase` provisioned

End-to-end DOCX import/export against a real-world `form.docx`
(1.2 MB, 46 tables, inline images) works: the new S3-backed
image pipeline is verified from upload through proxy render.

## Two import-only bugs found during smoke test (not blockers)

Keeping v0.3.2 as released. Follow-up fixes will ship in v0.3.3.

1. **`w:val="0"` treated as ON for bold / italic / strikethrough**
   — `docx-style-map.ts:21-23` checks only element presence.
   `form.docx` contains 509 + 509 + 513 such explicit "off"
   toggles, so most text renders with unintended strikethrough.

2. **`tbl.getElementsByTagNameNS('w:gridCol')` is recursive** and
   picks up nested tables' grid columns. The importer's row
   walk already uses direct-child traversal for `<w:tr>`; the
   `gridCol` lookup is an asymmetric survivor. In `form.docx`
   this inflates outer table column counts from e.g. 1 → 12
   for the "별첨" tables, collapsing real columns to ~8% of
   the content width.

Both are import-path only (no server / schema / infra impact).

## Test plan

- [x] `pnpm verify:fast` passes locally (pre-commit hook)
- [x] `pnpm verify:self` passes via pre-push hook
- [x] `pnpm tasks:archive` moved the todo and regenerated both
      `docs/tasks/README.md` and `docs/tasks/archive/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Identified two minor DOCX import issues during testing (tracked for next release)

* **Documentation**
  * Updated release v0.3.2 completion and deployment documentation
  * Verified DOCX import/export functionality through testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->