### PR TITLE
Add merge/unmerge context menu and fix multi-page merged-cell rendering

### DIFF
--- a/docs/design/docs/docs-tables.md
+++ b/docs/design/docs/docs-tables.md
@@ -312,6 +312,70 @@ class Doc {
   covered cells is concatenated into the top-left cell.
 - `splitCell(cell)`: Reset `colSpan`/`rowSpan` to 1. Restore covered cells
   with default `inlines: [{ text: '', style: {} }]`.
+- The input range to `mergeCells` is assumed to be rectangular and to fully
+  contain any merged cells it touches. This invariant is enforced upstream
+  by [Cell Range Normalization](#cell-range-normalization), which expands
+  the user's drag selection so it never partially overlaps an existing
+  merged cell.
+
+## Cell Range Normalization
+
+`tableCellRange` is normalized in `selection.ts` whenever it changes (drag,
+shift+arrow, programmatic update). The normalizer is a fixed-point loop that
+expands the bounding rectangle until no merged cell crosses its boundary:
+
+1. Order `start`/`end` so that `rowStart ≤ rowEnd` and `colStart ≤ colEnd`.
+2. For every cell `(r, c)` inside the current bounding rect:
+   - If the cell is a merge **top-left** (`colSpan > 1` or `rowSpan > 1`)
+     and its span extends past `rowEnd`/`colEnd`, expand the bounding rect.
+   - If the cell is **covered** (`colSpan === 0`), walk back (←, ↑) to find
+     its merge top-left and expand the bounding rect to include that
+     position.
+3. Repeat step 2 until no expansion happens (typically 1–2 passes).
+
+`findMergeTopLeft(table, r, c)` is a small helper that scans backwards to
+locate the merge anchor for a covered cell. The current data model has no
+back-pointer; the scan is bounded by table size and is acceptable because
+tables are small.
+
+The normalized range is stored in `selection.range.tableCellRange`, so all
+downstream consumers (selection rendering, copy, batch cell-style apply,
+merge) see the expanded rectangle automatically. Drag-time hover highlights
+therefore preview the exact area that will be merged.
+
+## Cell Merge UX
+
+Merge and unmerge are exposed through a single context-menu slot whose
+label, icon, and enabled state follow the cursor and selection.
+
+| State | Trigger | Label | Enabled |
+|-------|---------|-------|---------|
+| `none` | In a single non-merged cell, no cell range | "Merge cells" | ❌ |
+| `canMerge` | Cell range with area ≥ 2 (post-normalization) | "Merge cells" | ✅ |
+| `canUnmerge` | Cursor in a merged cell, no cell range | "Unmerge cells" | ✅ |
+
+When the cursor is inside a merged cell **and** a cell range is also active,
+`canMerge` wins — the user's intent is to grow the existing merge into a
+larger one.
+
+The frontend reads this through a new editor API:
+
+```typescript
+type TableMergeContext =
+  | { state: 'none' }
+  | { state: 'canMerge'; tableBlockId: string; range: CellRange }
+  | { state: 'canUnmerge'; tableBlockId: string; cell: CellAddress };
+
+interface EditorAPI {
+  getTableMergeContext(): TableMergeContext;
+}
+```
+
+The context menu (`docs-table-context-menu.tsx`) calls
+`getTableMergeContext()` once when opening, caches the result for the
+lifetime of the popup, and renders a single slot whose label/icon/disabled
+state follow the table above. Out-of-scope for this iteration: keyboard
+shortcuts, top menu integration, floating table toolbar.
 
 ## Extensibility Path
 

--- a/docs/design/docs/docs-tables.md
+++ b/docs/design/docs/docs-tables.md
@@ -320,9 +320,9 @@ class Doc {
 
 ## Cell Range Normalization
 
-`tableCellRange` is normalized in `selection.ts` whenever it changes (drag,
-shift+arrow, programmatic update). The normalizer is a fixed-point loop that
-expands the bounding rectangle until no merged cell crosses its boundary:
+`expandCellRangeForMerges` in `selection.ts` is a fixed-point loop that
+grows a cell range's bounding rectangle until no merged cell crosses its
+boundary:
 
 1. Order `start`/`end` so that `rowStart ≤ rowEnd` and `colStart ≤ colEnd`.
 2. For every cell `(r, c)` inside the current bounding rect:
@@ -338,10 +338,19 @@ locate the merge anchor for a covered cell. The current data model has no
 back-pointer; the scan is bounded by table size and is acceptable because
 tables are small.
 
-The normalized range is stored in `selection.range.tableCellRange`, so all
-downstream consumers (selection rendering, copy, batch cell-style apply,
-merge) see the expanded rectangle automatically. Drag-time hover highlights
-therefore preview the exact area that will be merged.
+Normalization is applied in two places:
+
+- **Write-time** — the drag handler in `text-editor.ts` and the Shift+Arrow
+  cross-cell branch call `expandCellRangeForMerges` before storing the
+  range on the selection, so `selection.range.tableCellRange` already
+  contains the expanded rectangle. This is what drives the drag-time hover
+  highlight, which therefore previews the exact area that will be merged.
+- **Read-time** — `normalizeRange` in `selection.ts` re-applies the
+  expansion when a consumer reads the selection (rendering, copy, peer
+  cursor projection, `computeTableMergeContext`). This is a defensive pass
+  for programmatic writers: `Selection.setRange()` itself does not mutate
+  the supplied range, so callers that bypass the write-time handlers still
+  get a normalized view.
 
 ## Cell Merge UX
 

--- a/docs/tasks/active/20260411-docs-table-merge-ux-lessons.md
+++ b/docs/tasks/active/20260411-docs-table-merge-ux-lessons.md
@@ -75,24 +75,3 @@ Todo: [20260411-docs-table-merge-ux-todo.md](20260411-docs-table-merge-ux-todo.m
   not at `tableCellRange.end`. Otherwise the cursor disappears into a
   non-rendered cell block. Only the stored selection value needs to be
   expanded; the visual cursor target stays on the user's actual drop point.
-
-- **`@wafflebase/docs` is imported from `dist/`, not source.** The package's
-  `exports` field in `packages/docs/package.json` points at
-  `dist/wafflebase-document.es.js`. That means any change inside
-  `packages/docs/src/` is invisible to `pnpm dev` until you run
-  `pnpm --filter @wafflebase/docs build`. Adding a new method to `EditorAPI`
-  and only running `pnpm --filter @wafflebase/docs test` will make tests
-  pass but the dev frontend will still call the old dist, throwing
-  `editor.getTableMergeContext is not a function` silently inside a React
-  event handler — the menu opens but the new slot falls through to its
-  default state. Any plan that touches `packages/docs` *and* expects the
-  frontend to see it should include an explicit `pnpm --filter
-  @wafflebase/docs build` step before manual smoke testing.
-- **Expanded `TableCellRange.end` may land on a covered cell (`colSpan === 0`).**
-  `expandCellRangeForMerges` grows the bounding rect to fully contain any
-  merge, so the rect's bottom-right corner can be a covered position. When
-  using the expanded range to pick a cursor target, read the cell at the
-  *raw* hit-test result (e.g. `currentCA` from `resolveTableCellClick`),
-  not at `tableCellRange.end`. Otherwise the cursor disappears into a
-  non-rendered cell block. Only the stored selection value needs to be
-  expanded; the visual cursor target stays on the user's actual drop point.

--- a/docs/tasks/active/20260411-docs-table-merge-ux-lessons.md
+++ b/docs/tasks/active/20260411-docs-table-merge-ux-lessons.md
@@ -1,0 +1,31 @@
+# Docs Table Merge UX — Lessons
+
+Date: 2026-04-11
+Todo: [20260411-docs-table-merge-ux-todo.md](20260411-docs-table-merge-ux-todo.md)
+
+## Patterns to keep
+
+(Filled in as the work progresses.)
+
+## Mistakes to avoid
+
+- **`@wafflebase/docs` is imported from `dist/`, not source.** The package's
+  `exports` field in `packages/docs/package.json` points at
+  `dist/wafflebase-document.es.js`. That means any change inside
+  `packages/docs/src/` is invisible to `pnpm dev` until you run
+  `pnpm --filter @wafflebase/docs build`. Adding a new method to `EditorAPI`
+  and only running `pnpm --filter @wafflebase/docs test` will make tests
+  pass but the dev frontend will still call the old dist, throwing
+  `editor.getTableMergeContext is not a function` silently inside a React
+  event handler — the menu opens but the new slot falls through to its
+  default state. Any plan that touches `packages/docs` *and* expects the
+  frontend to see it should include an explicit `pnpm --filter
+  @wafflebase/docs build` step before manual smoke testing.
+- **Expanded `TableCellRange.end` may land on a covered cell (`colSpan === 0`).**
+  `expandCellRangeForMerges` grows the bounding rect to fully contain any
+  merge, so the rect's bottom-right corner can be a covered position. When
+  using the expanded range to pick a cursor target, read the cell at the
+  *raw* hit-test result (e.g. `currentCA` from `resolveTableCellClick`),
+  not at `tableCellRange.end`. Otherwise the cursor disappears into a
+  non-rendered cell block. Only the stored selection value needs to be
+  expanded; the visual cursor target stays on the user's actual drop point.

--- a/docs/tasks/active/20260411-docs-table-merge-ux-lessons.md
+++ b/docs/tasks/active/20260411-docs-table-merge-ux-lessons.md
@@ -5,9 +5,76 @@ Todo: [20260411-docs-table-merge-ux-todo.md](20260411-docs-table-merge-ux-todo.m
 
 ## Patterns to keep
 
-(Filled in as the work progresses.)
+- **A single source of truth for merged-cell line layout.** The renderer
+  (`renderTableContent`), the cursor (`resolvePositionPixel`), click-to-offset
+  (`resolveOffsetInCellAtXY`), cell-range highlight (`buildCellRangeRects`),
+  and cell-internal selection rects (`buildRects`) all call
+  `computeMergedCellLineLayouts`. When pagination math needs to change, we
+  change it in one place and the five consumers stay consistent. The helper
+  returns per-line `{ ownerRow, runLineY }` so every consumer can derive
+  both "which page does this belong to" and "what Y does it render at"
+  without duplicating the content-flow walk.
+- **Per-page render args carry both `pageStartRow` and `renderStartRow`.**
+  `renderStartRow` is swept back to the merged cell's top-left so the cell
+  gets visited for borders/background, while `pageStartRow` is the real
+  first row physically laid out on the current page. The cell renderer
+  filters lines by `pageStartRow` (so content draws once) but sizes the
+  border rect from `visibleStart = max(r, pageStartRow)` (so each page's
+  slice looks like a complete 4-sided cell).
 
 ## Mistakes to avoid
+
+- **`??` vs `||` for inline color strings.** Inline styles can store
+  `color: ''` (empty string) — `??` treats `''` as a real value and hands
+  it to `ctx.fillStyle`, which silently ignores invalid color strings and
+  keeps whatever fillStyle was already there. If the last thing drawn was
+  a selection highlight, table text renders in the selection color. Use
+  `||` so an empty string falls through to `Theme.defaultColor`, matching
+  what `renderRun` in `doc-canvas.ts` already does.
+- **Center-of-line ownership picks the wrong row when `rowHeights > lineHeight`.**
+  An early merged-cell pagination fix mapped each line to a row by checking
+  which row range its center Y fell into. With rows taller than lines
+  (e.g. 28-px rows × 20-px lines) two consecutive lines can share a row
+  range and the third line overflows into the same range, so lines 2 and
+  3 both got page 1 and line 3 straddled the break. Use a content-flow
+  walk: advance to the next row when the current row can't fit the next
+  line. That matches what users expect ("N lines in N rows → one per row")
+  and stays correct for non-uniform row heights.
+- **Cell-internal multi-line selection can't step by a single line height.**
+  The old `midY += startPixel.height` loop in `buildRects` assumed lines
+  flow on a single continuous Y axis within a cell. With per-row
+  distribution (merged cells split across pages) each line has an
+  independent rendered Y, so the middle-line strip ended up painting into
+  the empty space below the cell's first row on page 1. Iterate cell
+  lines from `startLineIdx` to `endLineIdx` and compute each line's Y via
+  `computeMergedCellLineLayouts`.
+- **Always run the per-page row filter in `resolveTableFromMouse`.** Mouse
+  hit-testing for a multi-page table cannot use one `tablePageY` — the
+  caller must walk each page's line band for the table and only resolve
+  inside the band the mouse is actually over. Returning `pageFirstRow` /
+  `pageLastRow` lets `detectTableBorder` skip row boundaries that belong
+  to another page, which stops the resize cursor from flashing in the
+  empty space below a merged cell's first row on page 1.
+- **`@wafflebase/docs` is imported from `dist/`, not source.** The package's
+  `exports` field in `packages/docs/package.json` points at
+  `dist/wafflebase-document.es.js`. That means any change inside
+  `packages/docs/src/` is invisible to `pnpm dev` until you run
+  `pnpm --filter @wafflebase/docs build`. Adding a new method to `EditorAPI`
+  and only running `pnpm --filter @wafflebase/docs test` will make tests
+  pass but the dev frontend will still call the old dist, throwing
+  `editor.getTableMergeContext is not a function` silently inside a React
+  event handler — the menu opens but the new slot falls through to its
+  default state. Any plan that touches `packages/docs` *and* expects the
+  frontend to see it should include an explicit `pnpm --filter
+  @wafflebase/docs build` step before manual smoke testing.
+- **Expanded `TableCellRange.end` may land on a covered cell (`colSpan === 0`).**
+  `expandCellRangeForMerges` grows the bounding rect to fully contain any
+  merge, so the rect's bottom-right corner can be a covered position. When
+  using the expanded range to pick a cursor target, read the cell at the
+  *raw* hit-test result (e.g. `currentCA` from `resolveTableCellClick`),
+  not at `tableCellRange.end`. Otherwise the cursor disappears into a
+  non-rendered cell block. Only the stored selection value needs to be
+  expanded; the visual cursor target stays on the user's actual drop point.
 
 - **`@wafflebase/docs` is imported from `dist/`, not source.** The package's
   `exports` field in `packages/docs/package.json` points at

--- a/docs/tasks/active/20260411-docs-table-merge-ux-todo.md
+++ b/docs/tasks/active/20260411-docs-table-merge-ux-todo.md
@@ -1,0 +1,1197 @@
+# Docs Table Merge UX Implementation Plan
+
+> **For agentic workers:** Use `superpowers:executing-plans` to implement
+> task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make table cell merge/unmerge a first-class context-menu action,
+with drag-time selection auto-expansion so users can preview the exact
+merge area before invoking it.
+
+**Architecture:** A pure helper in `selection.ts` expands a `TableCellRange`
+to a bounding rectangle that fully contains every merged cell it touches
+(fixed-point loop). The expansion is invoked at write-time by the drag and
+Shift+Arrow handlers, and at read-time by `normalizeRange` for safety
+(peer cursor renders, programmatic ranges). A new pure
+`computeTableMergeContext` function returns `'none' | 'canMerge' |
+'canUnmerge'` plus the data needed to act, and `EditorAPI.getTableMergeContext`
+exposes it. The frontend context menu reads this once on open and renders a
+single hybrid slot whose label/icon/disabled state follow the result.
+
+**Tech Stack:** TypeScript, Vitest, React (frontend menu), Tabler icons.
+
+**Design:** [docs-tables.md — Cell Range Normalization & Cell Merge UX](../../design/docs/docs-tables.md#cell-range-normalization)
+**Lessons:** [20260411-docs-table-merge-ux-lessons.md](20260411-docs-table-merge-ux-lessons.md)
+
+---
+
+## Conventions
+
+- Test runner: `pnpm test` (Vitest, runs in the `packages/docs` workspace).
+- Pre-commit gate: `pnpm verify:fast` (lint + unit tests).
+- Frequent commits: one commit per task (after the task's tests pass).
+- All file paths in this plan are relative to the worktree root
+  `.claude/worktrees/feature+header-footer/`.
+
+---
+
+## Task 1 — Pure helpers: `findMergeTopLeft` and `expandCellRangeForMerges`
+
+**Files:**
+- Modify: `packages/docs/src/view/selection.ts` (add helpers above existing
+  `normalizeCellRange`)
+- Create: `packages/docs/test/view/cell-range-expand.test.ts`
+
+These two helpers are pure functions over `TableData` and a
+`TableCellRange`. They have no dependency on layout, DOM, or
+`DocumentLayout`. Tests can construct `TableData` directly.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `packages/docs/test/view/cell-range-expand.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+  expandCellRangeForMerges,
+  findMergeTopLeft,
+} from '../../src/view/selection.js';
+import type { TableCell, TableData, TableCellRange } from '../../src/model/types.js';
+
+function plainCell(): TableCell {
+  return {
+    blocks: [{ id: 'b', type: 'paragraph', inlines: [{ text: '', style: {} }], style: {} as any }],
+    style: {},
+  };
+}
+
+function coveredCell(): TableCell {
+  return { ...plainCell(), colSpan: 0 };
+}
+
+function mergedTopLeft(rowSpan: number, colSpan: number): TableCell {
+  return { ...plainCell(), rowSpan, colSpan };
+}
+
+function makeTable(rows: number, cols: number, overrides: Record<string, TableCell> = {}): TableData {
+  const data: TableData = { rows: [], columnWidths: Array(cols).fill(1 / cols) };
+  for (let r = 0; r < rows; r++) {
+    const cells: TableCell[] = [];
+    for (let c = 0; c < cols; c++) {
+      cells.push(overrides[`${r},${c}`] ?? plainCell());
+    }
+    data.rows.push({ cells });
+  }
+  return data;
+}
+
+function rect(r1: number, c1: number, r2: number, c2: number): TableCellRange {
+  return { blockId: 't', start: { rowIndex: r1, colIndex: c1 }, end: { rowIndex: r2, colIndex: c2 } };
+}
+
+describe('findMergeTopLeft', () => {
+  it('returns the cell itself when it is a plain cell', () => {
+    const t = makeTable(3, 3);
+    expect(findMergeTopLeft(t, 1, 1)).toEqual({ rowIndex: 1, colIndex: 1 });
+  });
+
+  it('returns the cell itself when it is a merge top-left', () => {
+    const t = makeTable(3, 3, { '0,0': mergedTopLeft(2, 2), '0,1': coveredCell(), '1,0': coveredCell(), '1,1': coveredCell() });
+    expect(findMergeTopLeft(t, 0, 0)).toEqual({ rowIndex: 0, colIndex: 0 });
+  });
+
+  it('walks back from a covered cell to its top-left', () => {
+    const t = makeTable(3, 3, { '0,0': mergedTopLeft(2, 2), '0,1': coveredCell(), '1,0': coveredCell(), '1,1': coveredCell() });
+    expect(findMergeTopLeft(t, 1, 1)).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(findMergeTopLeft(t, 0, 1)).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(findMergeTopLeft(t, 1, 0)).toEqual({ rowIndex: 0, colIndex: 0 });
+  });
+});
+
+describe('expandCellRangeForMerges', () => {
+  it('returns input rect unchanged when no merges touched', () => {
+    const t = makeTable(3, 3);
+    const r = rect(0, 0, 1, 1);
+    expect(expandCellRangeForMerges(r, t)).toEqual(r);
+  });
+
+  it('expands when range partially overlaps a merge top-left', () => {
+    // (1,1) is a 2x2 merged top-left covering (1,1)..(2,2)
+    const t = makeTable(4, 4, {
+      '1,1': mergedTopLeft(2, 2), '1,2': coveredCell(), '2,1': coveredCell(), '2,2': coveredCell(),
+    });
+    // User selects (0,0)..(1,1) — overlaps merge top-left
+    const result = expandCellRangeForMerges(rect(0, 0, 1, 1), t);
+    expect(result.start).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(result.end).toEqual({ rowIndex: 2, colIndex: 2 });
+  });
+
+  it('walks back from a covered cell to include its top-left', () => {
+    const t = makeTable(4, 4, {
+      '1,1': mergedTopLeft(2, 2), '1,2': coveredCell(), '2,1': coveredCell(), '2,2': coveredCell(),
+    });
+    // User selects (2,2)..(3,3) — starts on a covered cell
+    const result = expandCellRangeForMerges(rect(2, 2, 3, 3), t);
+    expect(result.start).toEqual({ rowIndex: 1, colIndex: 1 });
+    expect(result.end).toEqual({ rowIndex: 3, colIndex: 3 });
+  });
+
+  it('chains expansion across multiple merges (fixed-point)', () => {
+    const t = makeTable(5, 5, {
+      // Merge A: (0,2)..(1,3)
+      '0,2': mergedTopLeft(2, 2), '0,3': coveredCell(),
+      '1,2': coveredCell(), '1,3': coveredCell(),
+      // Merge B: (1,0)..(2,1)
+      '1,0': mergedTopLeft(2, 2), '1,1': coveredCell(),
+      '2,0': coveredCell(), '2,1': coveredCell(),
+    });
+    // User picks (0,0)..(0,2): touches Merge A's top-left → expands to (0,0)..(1,3),
+    // which now contains Merge B's top-left → expands to (0,0)..(2,3).
+    const result = expandCellRangeForMerges(rect(0, 0, 0, 2), t);
+    expect(result.start).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(result.end).toEqual({ rowIndex: 2, colIndex: 3 });
+  });
+
+  it('handles a range whose start is greater than end (caller has not ordered)', () => {
+    const t = makeTable(3, 3);
+    const r = rect(2, 2, 0, 0);
+    const result = expandCellRangeForMerges(r, t);
+    expect(result.start).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(result.end).toEqual({ rowIndex: 2, colIndex: 2 });
+  });
+
+  it('preserves blockId', () => {
+    const t = makeTable(2, 2);
+    const r: TableCellRange = { blockId: 'my-table', start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 1, colIndex: 1 } };
+    expect(expandCellRangeForMerges(r, t).blockId).toBe('my-table');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pnpm --filter @wafflebase/docs test --run test/view/cell-range-expand.test.ts
+```
+
+Expected: failure with "expandCellRangeForMerges is not exported from
+'../../src/view/selection.js'" (or equivalent).
+
+- [ ] **Step 3: Implement the helpers in `selection.ts`**
+
+In `packages/docs/src/view/selection.ts`, immediately after the imports
+(before the `NormalizedRange` interface), add:
+
+```typescript
+import type { TableData, CellAddress } from '../model/types.js';
+```
+
+(The first import line currently imports from `'../model/types.js'`. Add
+`TableData` and `CellAddress` to that import — do not duplicate the import
+statement.)
+
+Then add the two helpers above the existing `normalizeCellRange`
+(currently at line 17):
+
+```typescript
+/**
+ * Walk back from `(r, c)` to the top-left of the merged cell that covers it.
+ * Returns `(r, c)` itself if the cell is plain or already a merge top-left.
+ *
+ * The data model has no back-pointer, so we scan upward and leftward looking
+ * for a cell whose `colSpan`/`rowSpan` reaches `(r, c)`. Tables are small in
+ * practice; the cost is bounded by the table area.
+ */
+export function findMergeTopLeft(table: TableData, r: number, c: number): CellAddress {
+  const cell = table.rows[r]?.cells[c];
+  if (!cell) return { rowIndex: r, colIndex: c };
+  if (cell.colSpan !== 0) return { rowIndex: r, colIndex: c };
+
+  for (let rr = r; rr >= 0; rr--) {
+    for (let cc = c; cc >= 0; cc--) {
+      const candidate = table.rows[rr]?.cells[cc];
+      if (!candidate) continue;
+      const span = candidate.colSpan ?? 1;
+      const rspan = candidate.rowSpan ?? 1;
+      if (span > 1 || rspan > 1) {
+        if (rr + rspan - 1 >= r && cc + span - 1 >= c) {
+          return { rowIndex: rr, colIndex: cc };
+        }
+      }
+    }
+  }
+  return { rowIndex: r, colIndex: c };
+}
+
+/**
+ * Expand a cell range to a bounding rectangle that fully contains every
+ * merged cell it touches. Runs a fixed-point loop because expanding for one
+ * merge can pull a previously-out-of-range merge into the rect.
+ *
+ * Caller may pass an unordered range — this helper orders start/end first.
+ */
+export function expandCellRangeForMerges(
+  cr: TableCellRange,
+  table: TableData,
+): TableCellRange {
+  let rowStart = Math.min(cr.start.rowIndex, cr.end.rowIndex);
+  let rowEnd = Math.max(cr.start.rowIndex, cr.end.rowIndex);
+  let colStart = Math.min(cr.start.colIndex, cr.end.colIndex);
+  let colEnd = Math.max(cr.start.colIndex, cr.end.colIndex);
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let r = rowStart; r <= rowEnd; r++) {
+      for (let c = colStart; c <= colEnd; c++) {
+        const cell = table.rows[r]?.cells[c];
+        if (!cell) continue;
+        const span = cell.colSpan ?? 1;
+        const rspan = cell.rowSpan ?? 1;
+
+        // Top-left of a merge whose span extends past current rect.
+        if (span > 1 || rspan > 1) {
+          const r2 = r + rspan - 1;
+          const c2 = c + span - 1;
+          if (r2 > rowEnd) { rowEnd = r2; changed = true; }
+          if (c2 > colEnd) { colEnd = c2; changed = true; }
+        }
+
+        // Covered cell whose top-left is outside current rect.
+        if (cell.colSpan === 0) {
+          const tl = findMergeTopLeft(table, r, c);
+          if (tl.rowIndex < rowStart) { rowStart = tl.rowIndex; changed = true; }
+          if (tl.colIndex < colStart) { colStart = tl.colIndex; changed = true; }
+        }
+      }
+    }
+  }
+
+  return {
+    blockId: cr.blockId,
+    start: { rowIndex: rowStart, colIndex: colStart },
+    end: { rowIndex: rowEnd, colIndex: colEnd },
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pnpm --filter @wafflebase/docs test --run test/view/cell-range-expand.test.ts
+```
+
+Expected: all 9 tests pass.
+
+- [ ] **Step 5: Run the full docs test suite to confirm nothing else broke**
+
+```bash
+pnpm --filter @wafflebase/docs test --run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/docs/src/view/selection.ts packages/docs/test/view/cell-range-expand.test.ts
+git commit -m "$(cat <<'EOF'
+Add cell range expansion helpers for merged-cell-aware selection
+
+Pure helpers in selection.ts: findMergeTopLeft walks back from a covered
+cell to its merge top-left, and expandCellRangeForMerges runs a fixed-point
+loop to grow a bounding rectangle until it fully contains every merged cell
+it touches. These will back the drag-time auto-expand of cell-range
+selections so users see the exact area that will be merged.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 — Wire `normalizeCellRange` to expand at read time
+
+**Files:**
+- Modify: `packages/docs/src/view/selection.ts:17` (`normalizeCellRange`)
+  and `packages/docs/src/view/selection.ts:25` (`normalizeRange` call site)
+
+`normalizeRange` already has access to `DocumentLayout`. We can look up the
+table block from there and pass its `tableData` into `normalizeCellRange`.
+This protects read paths (peer cursor rendering, programmatic ranges) even
+if the write-time path (Task 3) misses an edge case.
+
+- [ ] **Step 1: Write a regression test against `Selection.getNormalizedRange`**
+
+Append to `packages/docs/test/view/cell-range-expand.test.ts`:
+
+```typescript
+import { Selection } from '../../src/view/selection.js';
+import type { DocumentLayout, LayoutBlock } from '../../src/view/layout.js';
+
+describe('Selection.getNormalizedRange — cell range expansion at read time', () => {
+  it('expands a partially-overlapping cell range using layout TableData', () => {
+    // Build a minimal fake DocumentLayout with one table block
+    const t = makeTable(4, 4, {
+      '1,1': mergedTopLeft(2, 2), '1,2': coveredCell(),
+      '2,1': coveredCell(), '2,2': coveredCell(),
+    });
+    const tableBlock: any = {
+      id: 't', type: 'table', inlines: [], style: {},
+      tableData: t,
+    };
+    const lb: LayoutBlock = {
+      block: tableBlock,
+      lines: [],
+      width: 0, height: 0, top: 0,
+    } as unknown as LayoutBlock;
+    const layout: DocumentLayout = {
+      blocks: [lb],
+      blockParentMap: new Map(),
+    } as unknown as DocumentLayout;
+
+    const sel = new Selection();
+    sel.setRange({
+      anchor: { blockId: 'anchor', offset: 0 },
+      focus: { blockId: 'focus', offset: 0 },
+      tableCellRange: rect(0, 0, 1, 1),
+    });
+
+    const normalized = sel.getNormalizedRange(layout);
+    expect(normalized?.tableCellRange?.start).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(normalized?.tableCellRange?.end).toEqual({ rowIndex: 2, colIndex: 2 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @wafflebase/docs test --run test/view/cell-range-expand.test.ts
+```
+
+Expected: the new test fails — current `normalizeCellRange` only orders,
+does not expand.
+
+- [ ] **Step 3: Update `normalizeCellRange` and `normalizeRange`**
+
+In `packages/docs/src/view/selection.ts`, replace the existing
+`normalizeCellRange` (line 17) with:
+
+```typescript
+function normalizeCellRange(cr: TableCellRange, table?: TableData): TableCellRange {
+  const ordered: TableCellRange = {
+    blockId: cr.blockId,
+    start: {
+      rowIndex: Math.min(cr.start.rowIndex, cr.end.rowIndex),
+      colIndex: Math.min(cr.start.colIndex, cr.end.colIndex),
+    },
+    end: {
+      rowIndex: Math.max(cr.start.rowIndex, cr.end.rowIndex),
+      colIndex: Math.max(cr.start.colIndex, cr.end.colIndex),
+    },
+  };
+  return table ? expandCellRangeForMerges(ordered, table) : ordered;
+}
+```
+
+In the same file, update the cell-range branch of `normalizeRange`
+(currently lines 29–36):
+
+```typescript
+  // Cell-range mode: tableCellRange is set
+  if (range.tableCellRange) {
+    const lb = layout.blocks.find((b) => b.block.id === range.tableCellRange!.blockId);
+    const table = lb?.block.tableData;
+    return {
+      start: range.anchor,
+      end: range.focus,
+      tableCellRange: normalizeCellRange(range.tableCellRange, table),
+    };
+  }
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+pnpm --filter @wafflebase/docs test --run test/view/cell-range-expand.test.ts
+```
+
+Expected: all tests pass, including the new read-time test.
+
+- [ ] **Step 5: Run the full docs suite**
+
+```bash
+pnpm --filter @wafflebase/docs test --run
+```
+
+Expected: pass. If `table-selection.test.ts` or any other selection-related
+test fails, investigate before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/docs/src/view/selection.ts packages/docs/test/view/cell-range-expand.test.ts
+git commit -m "$(cat <<'EOF'
+Auto-expand cell ranges at read time using table data from layout
+
+normalizeCellRange now optionally takes TableData and runs the fixed-point
+expander before returning. normalizeRange looks the table up from layout
+and threads it through, so peer cursor rendering and programmatic ranges
+get the expanded rectangle even without a write-time normalization pass.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — Expand at write time in `text-editor.ts`
+
+**Files:**
+- Modify: `packages/docs/src/view/text-editor.ts:1156` (drag selection
+  cell-range branch) and `packages/docs/src/view/text-editor.ts:1820`
+  (Shift+arrow cross-cell branch).
+
+Read-time normalization (Task 2) handles correctness, but for the drag
+preview to actually show the expanded rectangle in real time, the value
+written to `selection.range.tableCellRange` must already be expanded.
+Otherwise the highlight reflects the raw drag rect on the cell-range path
+that bypasses `normalizeRange` (e.g. `applyTableCellStyle` reads
+`selection.range.tableCellRange` directly).
+
+- [ ] **Step 1: Add the import for the expander**
+
+At the top of `packages/docs/src/view/text-editor.ts`, find the existing
+import from `'./selection.js'`. If one exists, add `expandCellRangeForMerges`
+to it. Otherwise add a new import:
+
+```typescript
+import { expandCellRangeForMerges } from './selection.js';
+```
+
+(Check existing imports first to avoid duplicates.)
+
+- [ ] **Step 2: Expand the drag-selection cell-range write**
+
+Replace the cell-range branch around line 1156 in `updateDragSelection`:
+
+```typescript
+            } else if (currentCA) {
+              // Different cell — cell-range mode
+              const tableData = this.doc.getBlock(tableBlockId).tableData!;
+              tableCellRange = expandCellRangeForMerges(
+                {
+                  blockId: tableBlockId,
+                  start: anchorCA,
+                  end: currentCA,
+                },
+                tableData,
+              );
+              const targetCell = tableData.rows[tableCellRange.end.rowIndex]
+                .cells[tableCellRange.end.colIndex];
+              pos = {
+                blockId: targetCell.blocks[0].id,
+                offset: 0,
+              };
+            }
+```
+
+Note: `pos` (cursor target) now follows the expanded `end` instead of the
+raw `currentCA`, so the cursor lands on the bottom-right of the visible
+selection.
+
+- [ ] **Step 3: Expand the Shift+Arrow cell-range write**
+
+Find the second `tableCellRange:` write at line ~1820 (in the Shift+Arrow
+cross-cell branch). The current shape is:
+
+```typescript
+              tableCellRange: {
+                ...
+              },
+```
+
+Replace the inline literal with an `expandCellRangeForMerges` call. Read
+that block first to see exactly which fields are present, then wrap the
+literal:
+
+```typescript
+              tableCellRange: expandCellRangeForMerges(
+                {
+                  blockId: <tableBlockIdVar>,
+                  start: <startVar>,
+                  end: <endVar>,
+                },
+                this.doc.getBlock(<tableBlockIdVar>).tableData!,
+              ),
+```
+
+(Use the actual local-variable names from the surrounding code — do not
+guess. Read lines 1810–1830 first, identify the variables, then make the
+edit.)
+
+- [ ] **Step 4: Build the docs package to catch type errors**
+
+```bash
+pnpm --filter @wafflebase/docs build
+```
+
+Expected: clean build.
+
+- [ ] **Step 5: Run the docs test suite**
+
+```bash
+pnpm --filter @wafflebase/docs test --run
+```
+
+Expected: pass. If selection or table tests fail, investigate.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/docs/src/view/text-editor.ts
+git commit -m "$(cat <<'EOF'
+Expand cell ranges at write time so drag preview reflects merge bounds
+
+The drag-selection and Shift+Arrow cross-cell paths now run the cell range
+through expandCellRangeForMerges before storing it on the selection. The
+highlight is built from this stored value, so users see the exact area
+that will be merged before they open the context menu.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — `computeTableMergeContext` pure helper
+
+**Files:**
+- Create: `packages/docs/src/view/table-merge-context.ts`
+- Create: `packages/docs/test/view/table-merge-context.test.ts`
+
+A pure function that, given the doc, the cursor, and the current selection
+range, returns the state the menu needs. Pure = no DOM, no editor instance,
+trivially testable.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/docs/test/view/table-merge-context.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Doc } from '../../src/model/document.js';
+import { computeTableMergeContext } from '../../src/view/table-merge-context.js';
+import type { BlockCellInfo, CellAddress, DocPosition } from '../../src/model/types.js';
+
+function buildParentMap(doc: Doc, tableBlockId: string): Map<string, BlockCellInfo> {
+  const map = new Map<string, BlockCellInfo>();
+  const block = doc.getBlock(tableBlockId);
+  if (!block.tableData) return map;
+  for (let r = 0; r < block.tableData.rows.length; r++) {
+    for (let c = 0; c < block.tableData.rows[r].cells.length; c++) {
+      for (const b of block.tableData.rows[r].cells[c].blocks) {
+        map.set(b.id, { tableBlockId, rowIndex: r, colIndex: c });
+      }
+    }
+  }
+  return map;
+}
+
+function cellBlockId(doc: Doc, tableId: string, cell: CellAddress): string {
+  return doc.getBlock(tableId).tableData!.rows[cell.rowIndex].cells[cell.colIndex].blocks[0].id;
+}
+
+describe('computeTableMergeContext', () => {
+  let doc: Doc;
+  let tableId: string;
+  let parentMap: Map<string, BlockCellInfo>;
+
+  beforeEach(() => {
+    doc = Doc.create();
+    tableId = doc.insertTable(1, 3, 3);
+    parentMap = buildParentMap(doc, tableId);
+  });
+
+  it('returns none when cursor is not in a table', () => {
+    const pos: DocPosition = { blockId: doc.document.blocks[0].id, offset: 0 };
+    expect(computeTableMergeContext(doc, parentMap, pos, null)).toEqual({ state: 'none' });
+  });
+
+  it('returns none for a single-cell cursor with no selection', () => {
+    const pos: DocPosition = { blockId: cellBlockId(doc, tableId, { rowIndex: 0, colIndex: 0 }), offset: 0 };
+    expect(computeTableMergeContext(doc, parentMap, pos, null).state).toBe('none');
+  });
+
+  it('returns canMerge when a 2x2 cell range is active', () => {
+    const pos: DocPosition = { blockId: cellBlockId(doc, tableId, { rowIndex: 0, colIndex: 0 }), offset: 0 };
+    const ctx = computeTableMergeContext(doc, parentMap, pos, {
+      anchor: pos,
+      focus: pos,
+      tableCellRange: {
+        blockId: tableId,
+        start: { rowIndex: 0, colIndex: 0 },
+        end: { rowIndex: 1, colIndex: 1 },
+      },
+    });
+    expect(ctx.state).toBe('canMerge');
+    if (ctx.state === 'canMerge') {
+      expect(ctx.tableBlockId).toBe(tableId);
+      expect(ctx.range.start).toEqual({ rowIndex: 0, colIndex: 0 });
+      expect(ctx.range.end).toEqual({ rowIndex: 1, colIndex: 1 });
+    }
+  });
+
+  it('returns none when the range covers exactly one cell (area 1)', () => {
+    const pos: DocPosition = { blockId: cellBlockId(doc, tableId, { rowIndex: 0, colIndex: 0 }), offset: 0 };
+    const ctx = computeTableMergeContext(doc, parentMap, pos, {
+      anchor: pos,
+      focus: pos,
+      tableCellRange: {
+        blockId: tableId,
+        start: { rowIndex: 0, colIndex: 0 },
+        end: { rowIndex: 0, colIndex: 0 },
+      },
+    });
+    expect(ctx.state).toBe('none');
+  });
+
+  it('returns canUnmerge when cursor is inside an existing merged cell', () => {
+    doc.mergeCells(tableId, { start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 1, colIndex: 1 } });
+    parentMap = buildParentMap(doc, tableId);
+    const pos: DocPosition = { blockId: cellBlockId(doc, tableId, { rowIndex: 0, colIndex: 0 }), offset: 0 };
+    const ctx = computeTableMergeContext(doc, parentMap, pos, null);
+    expect(ctx.state).toBe('canUnmerge');
+    if (ctx.state === 'canUnmerge') {
+      expect(ctx.cell).toEqual({ rowIndex: 0, colIndex: 0 });
+      expect(ctx.tableBlockId).toBe(tableId);
+    }
+  });
+
+  it('canMerge wins when cursor is in a merged cell and a range is also active', () => {
+    doc.mergeCells(tableId, { start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 1, colIndex: 1 } });
+    parentMap = buildParentMap(doc, tableId);
+    const pos: DocPosition = { blockId: cellBlockId(doc, tableId, { rowIndex: 0, colIndex: 0 }), offset: 0 };
+    const ctx = computeTableMergeContext(doc, parentMap, pos, {
+      anchor: pos,
+      focus: pos,
+      tableCellRange: {
+        blockId: tableId,
+        start: { rowIndex: 0, colIndex: 0 },
+        end: { rowIndex: 0, colIndex: 2 },
+      },
+    });
+    expect(ctx.state).toBe('canMerge');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @wafflebase/docs test --run test/view/table-merge-context.test.ts
+```
+
+Expected: failure — module does not exist.
+
+- [ ] **Step 3: Implement `table-merge-context.ts`**
+
+Create `packages/docs/src/view/table-merge-context.ts`:
+
+```typescript
+import type { Doc } from '../model/document.js';
+import type {
+  BlockCellInfo,
+  CellAddress,
+  CellRange,
+  DocPosition,
+  DocRange,
+} from '../model/types.js';
+
+export type TableMergeContext =
+  | { state: 'none' }
+  | { state: 'canMerge'; tableBlockId: string; range: CellRange }
+  | { state: 'canUnmerge'; tableBlockId: string; cell: CellAddress };
+
+/**
+ * Decide which merge action (if any) the context menu should offer.
+ *
+ * Rules:
+ *  - Cursor outside a table → none.
+ *  - Active cell range covering ≥ 2 cells → canMerge (range from selection).
+ *    Wins over canUnmerge so a user can grow an existing merge.
+ *  - Cursor in a cell with `colSpan > 1` or `rowSpan > 1` → canUnmerge.
+ *  - Otherwise → none.
+ *
+ * Pure: no DOM, no editor reference. Reads only `doc`, the parent map, the
+ * cursor position, and the selection range.
+ */
+export function computeTableMergeContext(
+  doc: Doc,
+  blockParentMap: Map<string, BlockCellInfo>,
+  cursorPos: DocPosition,
+  selectionRange: DocRange | null,
+): TableMergeContext {
+  const cellInfo = blockParentMap.get(cursorPos.blockId);
+  if (!cellInfo) return { state: 'none' };
+
+  const tableBlockId = cellInfo.tableBlockId;
+  const cr = selectionRange?.tableCellRange;
+  if (cr && cr.blockId === tableBlockId) {
+    const rowSpan = Math.abs(cr.end.rowIndex - cr.start.rowIndex) + 1;
+    const colSpan = Math.abs(cr.end.colIndex - cr.start.colIndex) + 1;
+    if (rowSpan * colSpan >= 2) {
+      return {
+        state: 'canMerge',
+        tableBlockId,
+        range: {
+          start: {
+            rowIndex: Math.min(cr.start.rowIndex, cr.end.rowIndex),
+            colIndex: Math.min(cr.start.colIndex, cr.end.colIndex),
+          },
+          end: {
+            rowIndex: Math.max(cr.start.rowIndex, cr.end.rowIndex),
+            colIndex: Math.max(cr.start.colIndex, cr.end.colIndex),
+          },
+        },
+      };
+    }
+  }
+
+  const tableData = doc.getBlock(tableBlockId).tableData;
+  const cell = tableData?.rows[cellInfo.rowIndex]?.cells[cellInfo.colIndex];
+  if (cell && ((cell.colSpan ?? 1) > 1 || (cell.rowSpan ?? 1) > 1)) {
+    return {
+      state: 'canUnmerge',
+      tableBlockId,
+      cell: { rowIndex: cellInfo.rowIndex, colIndex: cellInfo.colIndex },
+    };
+  }
+
+  return { state: 'none' };
+}
+```
+
+- [ ] **Step 4: Run the new tests**
+
+```bash
+pnpm --filter @wafflebase/docs test --run test/view/table-merge-context.test.ts
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 5: Run the full docs suite**
+
+```bash
+pnpm --filter @wafflebase/docs test --run
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/docs/src/view/table-merge-context.ts packages/docs/test/view/table-merge-context.test.ts
+git commit -m "$(cat <<'EOF'
+Add computeTableMergeContext pure helper for menu state
+
+Returns 'none' | 'canMerge' | 'canUnmerge' plus the data the menu needs to
+act. Pure function over Doc, parent map, cursor, and selection range — no
+DOM, no editor reference, fully unit-testable. Range presence wins over
+canUnmerge so a user inside an existing merged cell can still grow the
+merge by selecting a wider range.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — Expose `getTableMergeContext` on `EditorAPI`
+
+**Files:**
+- Modify: `packages/docs/src/view/editor.ts:21` (`EditorAPI` interface) and
+  `packages/docs/src/view/editor.ts:293` (the `initialize` factory body)
+- Modify: `packages/docs/src/index.ts` (re-export `TableMergeContext`)
+
+- [ ] **Step 1: Add the type re-export**
+
+Open `packages/docs/src/index.ts`. Find the existing exports. Add:
+
+```typescript
+export type { TableMergeContext } from './view/table-merge-context.js';
+```
+
+If `index.ts` already re-exports types via `export type { ... } from './view/...'`,
+follow the existing pattern.
+
+- [ ] **Step 2: Add the API method to the `EditorAPI` interface**
+
+In `packages/docs/src/view/editor.ts`, add an import at the top:
+
+```typescript
+import { computeTableMergeContext, type TableMergeContext } from './table-merge-context.js';
+```
+
+In the `EditorAPI` interface (around line 87, near `mergeTableCells`), add:
+
+```typescript
+  /** Compute the merge/unmerge state for the menu (current cursor + selection) */
+  getTableMergeContext(): TableMergeContext;
+```
+
+- [ ] **Step 3: Implement the method in the factory return object**
+
+In the same file, find the section returning the EditorAPI object (the
+block containing `mergeTableCells: ...` at line 1359 and `splitTableCell: ...`
+at line 1372). Add a new entry directly after `splitTableCell`:
+
+```typescript
+    getTableMergeContext: () =>
+      computeTableMergeContext(doc, layout.blockParentMap, cursor.position, selection.range),
+```
+
+- [ ] **Step 4: Build to catch type errors**
+
+```bash
+pnpm --filter @wafflebase/docs build
+```
+
+Expected: clean build.
+
+- [ ] **Step 5: Run all docs tests**
+
+```bash
+pnpm --filter @wafflebase/docs test --run
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/docs/src/view/editor.ts packages/docs/src/index.ts
+git commit -m "$(cat <<'EOF'
+Expose getTableMergeContext on EditorAPI
+
+Thin wrapper around computeTableMergeContext that the frontend context menu
+calls when it opens, so the merge/unmerge slot can render the right label,
+icon, and enabled state without duplicating selection logic.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6 — Verify `Doc.mergeCells` handles a range that already contains a merge
+
+**Files:**
+- Modify: `packages/docs/test/model/table.test.ts` (add a regression test)
+- Possibly modify: `packages/docs/src/model/document.ts:669` (only if test fails)
+
+The current `mergeCells` algorithm assumes a rectangular range and iterates
+each cell, hoisting blocks to the top-left and marking the rest covered.
+Auto-expansion (Tasks 1–3) will routinely produce ranges that contain an
+already-merged cell. We need to verify the algorithm handles that, and add
+a regression test.
+
+- [ ] **Step 1: Write the regression test**
+
+Append to `packages/docs/test/model/table.test.ts` inside the existing
+`describe('mergeCells', ...)` block:
+
+```typescript
+    it('absorbs an existing merged cell when the new range contains it', () => {
+      const doc = Doc.create();
+      const tableId = doc.insertTable(0, 4, 4);
+      doc.setBlockParentMap(buildParentMap(doc, tableId));
+
+      // Pre-merge (1,1)..(2,2) with text "M"
+      const cellBlock11 = getCellBlock(doc, tableId, { rowIndex: 1, colIndex: 1 });
+      doc.insertText({ blockId: cellBlock11.id, offset: 0 }, 'M');
+      doc.mergeCells(tableId, { start: { rowIndex: 1, colIndex: 1 }, end: { rowIndex: 2, colIndex: 2 } });
+
+      // Add some text outside the merge
+      const cellBlock00 = getCellBlock(doc, tableId, { rowIndex: 0, colIndex: 0 });
+      doc.insertText({ blockId: cellBlock00.id, offset: 0 }, 'X');
+
+      // Now merge a 4x4 range containing the existing merge
+      doc.mergeCells(tableId, { start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 3, colIndex: 3 } });
+
+      const block = doc.getBlock(tableId);
+      const tl = block.tableData!.rows[0].cells[0];
+      expect(tl.colSpan).toBe(4);
+      expect(tl.rowSpan).toBe(4);
+
+      // The text from the inner merge should be preserved in the outer top-left
+      const allText = tl.blocks.flatMap(b => b.inlines).map(i => i.text).join('');
+      expect(allText).toContain('X');
+      expect(allText).toContain('M');
+
+      // Every other cell should be covered
+      for (let r = 0; r < 4; r++) {
+        for (let c = 0; c < 4; c++) {
+          if (r === 0 && c === 0) continue;
+          const cell = block.tableData!.rows[r].cells[c];
+          expect(cell.colSpan).toBe(0);
+        }
+      }
+    });
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+pnpm --filter @wafflebase/docs test --run test/model/table.test.ts
+```
+
+Expected outcome: most likely **passes** (the existing algorithm already
+handles this — see `document.ts:678`–`705`). If it fails, that is a real
+bug surfaced by the new test and must be fixed before continuing.
+
+- [ ] **Step 3: If the test passed, commit it as a regression guard**
+
+```bash
+git add packages/docs/test/model/table.test.ts
+git commit -m "$(cat <<'EOF'
+Add regression test for merging a range that contains an existing merge
+
+The auto-expansion path will routinely produce ranges that contain a
+pre-existing merged cell, so we lock in the current Doc.mergeCells
+behavior: outer top-left absorbs inner span and inner content, every
+other cell ends up covered.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If the test failed instead, fix `Doc.mergeCells` to handle the nested case,
+re-run the test until it passes, then commit the test + fix together with
+an explanatory message.
+
+---
+
+## Task 7 — Context menu UI: hybrid Merge/Unmerge slot
+
+**Files:**
+- Modify: `packages/frontend/src/app/docs/docs-table-context-menu.tsx`
+
+- [ ] **Step 1: Add the new icon and type imports**
+
+At the top of `packages/frontend/src/app/docs/docs-table-context-menu.tsx`,
+add `IconArrowsJoin` to the existing `@tabler/icons-react` import:
+
+```typescript
+import {
+  IconRowInsertTop,
+  IconRowInsertBottom,
+  IconColumnInsertLeft,
+  IconColumnInsertRight,
+  IconRowRemove,
+  IconColumnRemove,
+  IconArrowsJoin,
+  IconArrowsSplit,
+  IconDropletOff,
+  IconPalette,
+  IconTableOff,
+} from "@tabler/icons-react";
+```
+
+Add the type import next to the existing `EditorAPI` import:
+
+```typescript
+import type { EditorAPI, TableMergeContext } from "@wafflebase/docs";
+```
+
+- [ ] **Step 2: Cache the merge context in component state**
+
+Add a new state hook alongside the existing ones (after `useState<MenuPosition | null>`):
+
+```typescript
+  const [mergeCtx, setMergeCtx] = useState<TableMergeContext>({ state: 'none' });
+```
+
+In `handleContextMenu`, capture the merge context when the menu opens:
+
+```typescript
+  const handleContextMenu = useCallback(
+    (e: MouseEvent) => {
+      if (!editor?.isInTable()) return;
+      e.preventDefault();
+      setPosition({ x: e.clientX, y: e.clientY });
+      setMergeCtx(editor.getTableMergeContext());
+      setShowColors(false);
+    },
+    [editor],
+  );
+```
+
+- [ ] **Step 3: Replace the unconditional "Split cell" button with the hybrid slot**
+
+Find the existing block (around line 135–139):
+
+```tsx
+      <button className={item} onClick={act(() => editor.splitTableCell())}>
+        <IconArrowsSplit size={iconSize} className="text-muted-foreground" />
+        Split cell
+      </button>
+```
+
+Replace it with:
+
+```tsx
+      {/* Cell merge / unmerge — single hybrid slot */}
+      {mergeCtx.state === 'canUnmerge' ? (
+        <button className={item} onClick={act(() => editor.splitTableCell())}>
+          <IconArrowsSplit size={iconSize} className="text-muted-foreground" />
+          Unmerge cells
+        </button>
+      ) : (
+        <button
+          className={`${item} disabled:opacity-50 disabled:pointer-events-none`}
+          disabled={mergeCtx.state !== 'canMerge'}
+          onClick={
+            mergeCtx.state === 'canMerge'
+              ? act(() => editor.mergeTableCells(mergeCtx.range))
+              : undefined
+          }
+        >
+          <IconArrowsJoin size={iconSize} className="text-muted-foreground" />
+          Merge cells
+        </button>
+      )}
+```
+
+- [ ] **Step 4: Build the frontend to catch type errors**
+
+```bash
+pnpm --filter @wafflebase/frontend build
+```
+
+Expected: clean build. If `TableMergeContext` is not found, double-check
+Task 5 Step 1 (the `index.ts` re-export).
+
+- [ ] **Step 5: Lint**
+
+```bash
+pnpm --filter @wafflebase/frontend lint
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/src/app/docs/docs-table-context-menu.tsx
+git commit -m "$(cat <<'EOF'
+Show Merge/Unmerge as a single hybrid slot in the table context menu
+
+The Cell section of the table context menu now exposes one slot whose
+label, icon, and enabled state follow editor.getTableMergeContext().
+A single non-merged cell shows "Merge cells" disabled (discoverability),
+a 2+ cell range shows it enabled, and a merged cell shows "Unmerge cells".
+Replaces the previous Split-only entry, which was unreachable for users
+who never knew the merge API existed.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8 — Verification: `pnpm verify:fast` and manual smoke
+
+- [ ] **Step 1: Run the pre-commit gate**
+
+```bash
+pnpm verify:fast
+```
+
+Expected: pass. Investigate any failure before continuing.
+
+- [ ] **Step 2: Manual smoke test in dev**
+
+In a separate terminal:
+
+```bash
+docker compose up -d
+pnpm dev
+```
+
+Open the docs editor in a new doc and verify:
+
+1. Insert a 3×3 table.
+2. Drag-select cells (0,0)..(1,1) → right-click → "Merge cells" is
+   enabled → click → 2×2 merged cell with cursor inside.
+3. Right-click the merged cell → menu now shows "Unmerge cells" → click
+   → cells restored.
+4. Click a single non-merged cell → right-click → menu shows
+   "Merge cells" greyed out (disabled).
+5. With a 2×2 merged cell at (1,1)..(2,2), drag from (0,0) to (1,1).
+   The drag highlight should snap out to include the full merge —
+   visually covering (0,0)..(2,2) before the menu opens.
+6. Right-click and merge that expanded selection → result is a 3×3
+   merged cell.
+
+If any step misbehaves, capture the failure in the lessons file before
+fixing.
+
+- [ ] **Step 3: Stop dev**
+
+```bash
+# Ctrl+C the dev server when done
+docker compose down
+```
+
+---
+
+## Task 9 — Wrap up
+
+- [ ] **Step 1: Capture any non-obvious lessons**
+
+If the implementation surfaced surprises (corrections, near-misses,
+non-obvious gotchas), append them to
+`docs/tasks/active/20260411-docs-table-merge-ux-lessons.md` under
+"Patterns to keep" or "Mistakes to avoid".
+
+- [ ] **Step 2: Archive and reindex tasks**
+
+```bash
+pnpm tasks:archive && pnpm tasks:index
+```
+
+- [ ] **Step 3: Verify the worktree status is clean**
+
+```bash
+git status
+```
+
+Expected: clean working tree, all task work committed.
+
+---
+
+## Spec coverage check
+
+| Spec section | Implemented in |
+|---|---|
+| Cell range normalization (fixed-point) | Tasks 1–3 |
+| `findMergeTopLeft` helper | Task 1 |
+| Drag-time visual preview of expanded area | Task 3 |
+| Read-time normalization (peers, programmatic) | Task 2 |
+| `getTableMergeContext` API + states | Tasks 4–5 |
+| Hybrid context-menu slot (Merge/Unmerge) | Task 7 |
+| `Doc.mergeCells` handles nested merge | Task 6 |
+| Manual smoke test | Task 8 |
+| Wrap up + archive | Task 9 |
+
+## Review Notes
+
+(Filled in during/after implementation.)

--- a/docs/tasks/active/20260411-docs-table-merge-ux-todo.md
+++ b/docs/tasks/active/20260411-docs-table-merge-ux-todo.md
@@ -498,9 +498,13 @@ Replace the cell-range branch around line 1156 in `updateDragSelection`:
             }
 ```
 
-Note: `pos` (cursor target) now follows the expanded `end` instead of the
-raw `currentCA`, so the cursor lands on the bottom-right of the visible
-selection.
+Note: this initial draft of the step moved `pos` to the expanded `end`, but
+that lands the cursor on a covered cell (`colSpan === 0`) whenever the
+expansion extends rightward into a merge. The implemented code (see code
+review fix commit) keeps `pos` derived from the raw `currentCA`, which
+`resolveTableCellClick` guarantees is a visible top-left. The expanded
+range is still the one stored on `selection.range.tableCellRange` for
+highlighting — only the cursor target stays at the raw hit-test cell.
 
 - [ ] **Step 3: Expand the Shift+Arrow cell-range write**
 

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -72,6 +72,7 @@ export type { InlinePosition, InlineSegment } from './store/block-helpers.js';
 
 // View
 export { initialize, type EditorAPI } from './view/editor.js';
+export type { TableMergeContext } from './view/table-merge-context.js';
 export { computeLayout, computeListCounters } from './view/layout.js';
 export type {
   DocumentLayout,

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -98,6 +98,7 @@ interface TableRenderRange {
   layoutBlock: LayoutBlock;
   tableX: number;
   tableOriginY: number;
+  pageStartRow: number;
   renderStartRow: number;
   endRowIndex: number;
 }
@@ -120,9 +121,9 @@ function computeTableRangeForPageLine(
   layoutBlock: LayoutBlock,
   pl: PageLine,
   plIndex: number,
-): { renderStartRow: number; endRowIndex: number } {
-  const startRowIndex = pl.lineIndex;
-  let endRowIndex = startRowIndex + 1;
+): { pageStartRow: number; renderStartRow: number; endRowIndex: number } {
+  const pageStartRow = pl.lineIndex;
+  let endRowIndex = pageStartRow + 1;
   for (let k = plIndex + 1; k < page.lines.length; k++) {
     const nextPl = page.lines[k];
     if (nextPl.blockIndex === pl.blockIndex) {
@@ -131,20 +132,20 @@ function computeTableRangeForPageLine(
       break;
     }
   }
-  let renderStartRow = startRowIndex;
+  let renderStartRow = pageStartRow;
   const tableData = layoutBlock.block.tableData;
   if (tableData) {
-    for (let r = 0; r < startRowIndex; r++) {
+    for (let r = 0; r < pageStartRow; r++) {
       for (let c = 0; c < tableData.rows[r].cells.length; c++) {
         const cell = tableData.rows[r].cells[c];
         const rs = cell.rowSpan ?? 1;
-        if (rs > 1 && r + rs > startRowIndex) {
+        if (rs > 1 && r + rs > pageStartRow) {
           renderStartRow = Math.min(renderStartRow, r);
         }
       }
     }
   }
-  return { renderStartRow, endRowIndex };
+  return { pageStartRow, renderStartRow, endRowIndex };
 }
 
 /**
@@ -178,6 +179,7 @@ function collectTableRenderRanges(
       layoutBlock: lb,
       tableX: pageX + margins.left,
       tableOriginY,
+      pageStartRow: range.pageStartRow,
       renderStartRow: range.renderStartRow,
       endRowIndex: range.endRowIndex,
     });
@@ -535,6 +537,7 @@ export class DocCanvas {
                 tableOriginY,
                 range.renderStartRow,
                 range.endRowIndex,
+                range.pageStartRow,
               );
             }
             continue;

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -434,6 +434,7 @@ export class DocCanvas {
             tr.tableOriginY,
             tr.renderStartRow,
             tr.endRowIndex,
+            tr.pageStartRow,
           );
         }
       }

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -8,7 +8,7 @@ import { Cursor } from './cursor.js';
 import { Selection, computeSelectionRects } from './selection.js';
 import { TextEditor } from './text-editor.js';
 import { computeLayout, type DocumentLayout, type LayoutCache } from './layout.js';
-import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getHeaderYStart, getFooterYStart, type PaginatedLayout } from './pagination.js';
+import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getPageYOffset, getHeaderYStart, getFooterYStart, type PaginatedLayout } from './pagination.js';
 import type { DocPosition, HeaderFooter } from '../model/types.js';
 import { Ruler, RULER_SIZE } from './ruler.js';
 import { computeScaleFactor } from './scale.js';
@@ -764,13 +764,33 @@ export function initialize(
       ctx.restore();
     }
 
-    // Render rulers — target the page where the cursor is
-    const cursorBlock = doc.document.blocks.find(
-      (b) => b.id === cursor.position.blockId,
-    );
-    const cursorPageInfo = findPageForPosition(
-      paginatedLayout, cursor.position.blockId, cursor.position.offset, layout,
-    );
+    // Render rulers — target the page where the cursor is. For cells
+    // inside a table, the cursor's blockId is not a top-level block so
+    // findPageForPosition can't resolve it; fall back to the pixel
+    // position (which already knows which row and page the cursor lives
+    // on via resolvePositionPixel's per-row lookup).
+    const cursorCellInfo = layout.blockParentMap.get(cursor.position.blockId);
+    const cursorBlockId = cursorCellInfo
+      ? cursorCellInfo.tableBlockId
+      : cursor.position.blockId;
+    const cursorBlock = doc.document.blocks.find((b) => b.id === cursorBlockId);
+
+    let cursorPageIndex = 0;
+    if (cursorPixel) {
+      for (const page of paginatedLayout.pages) {
+        const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
+        if (cursorPixel.y >= pageY && cursorPixel.y < pageY + page.height) {
+          cursorPageIndex = page.pageIndex;
+          break;
+        }
+      }
+    } else {
+      const pageInfo = findPageForPosition(
+        paginatedLayout, cursor.position.blockId, cursor.position.offset, layout,
+      );
+      if (pageInfo) cursorPageIndex = pageInfo.pageIndex;
+    }
+
     if (scaleFactor >= 1) {
       ruler.render(
         paginatedLayout,
@@ -778,7 +798,7 @@ export function initialize(
         logicalCanvasWidth,
         canvasHeight,
         cursorBlock?.style ?? null,
-        cursorPageInfo?.pageIndex ?? 0,
+        cursorPageIndex,
       );
     }
   };

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -14,6 +14,7 @@ import { Ruler, RULER_SIZE } from './ruler.js';
 import { computeScaleFactor } from './scale.js';
 import { buildFont, setThemeMode, type ThemeMode } from './theme.js';
 import { type PeerCursor, resolvePositionPixel } from './peer-cursor.js';
+import { computeTableMergeContext, type TableMergeContext } from './table-merge-context.js';
 
 /**
  * Public API returned by initialize().
@@ -89,6 +90,8 @@ export interface EditorAPI {
   mergeTableCells(range: CellRange): void;
   /** Split the current cell */
   splitTableCell(): void;
+  /** Compute the merge/unmerge state for the menu (current cursor + selection) */
+  getTableMergeContext(): TableMergeContext;
   /** Apply style to current cell */
   applyTableCellStyle(style: Partial<CellStyle>): void;
   /** Delete the table the cursor is currently in */
@@ -1390,6 +1393,8 @@ export function initialize(
       invalidateLayout();
       render();
     },
+    getTableMergeContext: () =>
+      computeTableMergeContext(doc, layout.blockParentMap, cursor.position, selection.range),
     applyTableCellStyle: (style: Partial<CellStyle>) => {
       docStore.snapshot();
       // Cell-range selection: apply to all cells in range

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -50,34 +50,11 @@ export function resolvePositionPixel(
     const cell = tl.cells[rowIndex]?.[colIndex];
     if (!cell || cell.merged) return undefined;
 
-    const cellPadding = lb.block.tableData?.rows[rowIndex]?.cells[colIndex]?.style.padding ?? 4;
-
-    // Find which paginated page contains this row
-    const blockIndex = layout.blocks.indexOf(lb);
-    let pageLine: import('./pagination.js').PageLine | undefined;
-    let pageIndex = 0;
-    for (const page of paginatedLayout.pages) {
-      for (const pl of page.lines) {
-        if (pl.blockIndex === blockIndex && pl.lineIndex === rowIndex) {
-          pageLine = pl;
-          pageIndex = page.pageIndex;
-          break;
-        }
-      }
-      if (pageLine) break;
-    }
-    if (!pageLine) return undefined;
-
-    const pageX = getPageXOffset(paginatedLayout, canvasWidth);
-    const pageY = getPageYOffset(paginatedLayout, pageIndex);
-    const { margins } = paginatedLayout.pageSetup;
-
-    // Cell origin within table
-    const cellX = tl.columnXOffsets[colIndex] + cellPadding;
-    const cellY = tl.rowYOffsets[rowIndex] + cellPadding;
+    const cellData = lb.block.tableData?.rows[rowIndex]?.cells[colIndex];
+    const cellPadding = cellData?.style.padding ?? 4;
+    const rowSpan = cellData?.rowSpan ?? 1;
 
     // Determine which lines belong to the target cell block
-    const cellData = lb.block.tableData?.rows[rowIndex]?.cells[colIndex];
     const cbi = cellData ? cellData.blocks.findIndex((b) => b.id === position.blockId) : 0;
     const effectiveCbi = cbi >= 0 ? cbi : 0;
     const startLine = cell.blockBoundaries[effectiveCbi] ?? 0;
@@ -96,7 +73,6 @@ export function resolvePositionPixel(
         lineChars += run.text.length;
       }
       if (offsetRemaining <= lineChars) {
-        // Cursor is on this line
         lineHeight = line.height;
         cursorLineY = line.y;
         let chars = 0;
@@ -119,9 +95,59 @@ export function resolvePositionPixel(
       cursorLineY = line.y + line.height;
     }
 
+    // For a merged cell split across pages, find the row that actually
+    // owns the target line (based on its center Y in table-logical
+    // coordinates). The cursor must anchor to that row's PageLine so it
+    // renders on the page where the line is drawn, not on the cell's
+    // top-left page.
+    let ownerRow = rowIndex;
+    if (rowSpan > 1) {
+      const lineCenterInTable =
+        tl.rowYOffsets[rowIndex] + cellPadding + cursorLineY + lineHeight / 2;
+      for (let rr = rowIndex; rr < rowIndex + rowSpan && rr < tl.rowHeights.length; rr++) {
+        const top = tl.rowYOffsets[rr];
+        const bottom = top + tl.rowHeights[rr];
+        if (lineCenterInTable >= top && lineCenterInTable < bottom) {
+          ownerRow = rr;
+          break;
+        }
+      }
+      // Overflow past the spanned rows → clamp to last row.
+      const lastSpannedRow = Math.min(rowIndex + rowSpan - 1, tl.rowHeights.length - 1);
+      const lastRowBottom = tl.rowYOffsets[lastSpannedRow] + tl.rowHeights[lastSpannedRow];
+      if (ownerRow === rowIndex && lineCenterInTable >= lastRowBottom) {
+        ownerRow = lastSpannedRow;
+      }
+    }
+
+    // Find the PageLine for the owner row.
+    const blockIndex = layout.blocks.indexOf(lb);
+    let pageLine: import('./pagination.js').PageLine | undefined;
+    let pageIndex = 0;
+    for (const page of paginatedLayout.pages) {
+      for (const pl of page.lines) {
+        if (pl.blockIndex === blockIndex && pl.lineIndex === ownerRow) {
+          pageLine = pl;
+          pageIndex = page.pageIndex;
+          break;
+        }
+      }
+      if (pageLine) break;
+    }
+    if (!pageLine) return undefined;
+
+    const pageX = getPageXOffset(paginatedLayout, canvasWidth);
+    const pageY = getPageYOffset(paginatedLayout, pageIndex);
+    const { margins } = paginatedLayout.pageSetup;
+
+    const cellX = tl.columnXOffsets[colIndex] + cellPadding;
+    const lineVirtualY = tl.rowYOffsets[rowIndex] + cellPadding + cursorLineY;
+    const cursorYOnPage =
+      pageY + pageLine.y + (lineVirtualY - tl.rowYOffsets[ownerRow]);
+
     return {
       x: pageX + margins.left + cellX + cursorX,
-      y: pageY + pageLine.y - tl.rowYOffsets[rowIndex] + cellY + cursorLineY,
+      y: cursorYOnPage,
       height: lineHeight,
     };
   }

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -4,10 +4,7 @@ import type { PaginatedLayout } from './pagination.js';
 import { findPageForPosition, getPageYOffset, getPageXOffset } from './pagination.js';
 import type { DocumentLayout } from './layout.js';
 import { buildFont, Theme } from './theme.js';
-import {
-  computeMergedCellLineShift,
-  findMergedCellOwnerRow,
-} from './table-renderer.js';
+import { computeMergedCellLineLayouts } from './table-renderer.js';
 
 /**
  * Represents a remote peer's cursor for collaborative editing.
@@ -58,6 +55,18 @@ export function resolvePositionPixel(
     const cellPadding = cellData?.style.padding ?? 4;
     const rowSpan = cellData?.rowSpan ?? 1;
 
+    // Per-line layouts (distributes merged-cell lines across spanned
+    // rows). For rowSpan === 1 this collapses to the old
+    // `padding + line.y` positioning.
+    const lineLayouts = computeMergedCellLineLayouts(
+      cell.lines,
+      rowIndex,
+      rowSpan,
+      cellPadding,
+      tl.rowYOffsets,
+      tl.rowHeights,
+    );
+
     // Determine which lines belong to the target cell block
     const cbi = cellData ? cellData.blocks.findIndex((b) => b.id === position.blockId) : 0;
     const effectiveCbi = cbi >= 0 ? cbi : 0;
@@ -66,7 +75,7 @@ export function resolvePositionPixel(
 
     // Measure text offset within the target block's lines
     let cursorX = 0;
-    let cursorLineY = 0;
+    let targetLineIdx = -1;
     let lineHeight = tl.rowHeights[rowIndex] ?? 20;
     let offsetRemaining = position.offset;
 
@@ -77,8 +86,8 @@ export function resolvePositionPixel(
         lineChars += run.text.length;
       }
       if (offsetRemaining <= lineChars) {
+        targetLineIdx = li;
         lineHeight = line.height;
-        cursorLineY = line.y;
         let chars = 0;
         for (const run of line.runs) {
           if (offsetRemaining <= chars + run.text.length) {
@@ -96,26 +105,23 @@ export function resolvePositionPixel(
         break;
       }
       offsetRemaining -= lineChars;
-      cursorLineY = line.y + line.height;
     }
 
-    // For a merged cell split across pages, find the row that actually
-    // owns the target line (based on its center Y in table-logical
-    // coordinates). The cursor must anchor to that row's PageLine so it
-    // renders on the page where the line is drawn, not on the cell's
-    // top-left page.
-    const ownerRow =
-      rowSpan > 1
-        ? findMergedCellOwnerRow(
-            rowIndex,
-            rowSpan,
-            cellPadding,
-            cursorLineY,
-            lineHeight,
-            tl.rowYOffsets,
-            tl.rowHeights,
-          )
-        : rowIndex;
+    // Cursor past end-of-content: place at the tail of the last line in
+    // the target block so Arrow-End still resolves.
+    if (targetLineIdx < 0) {
+      targetLineIdx = Math.max(startLine, endLine - 1);
+      const tailLine = cell.lines[targetLineIdx];
+      if (tailLine) {
+        lineHeight = tailLine.height;
+        const lastRun = tailLine.runs[tailLine.runs.length - 1];
+        cursorX = lastRun ? lastRun.x + lastRun.width : 0;
+      }
+    }
+
+    const targetLayout = lineLayouts[targetLineIdx];
+    if (!targetLayout) return undefined;
+    const ownerRow = targetLayout.ownerRow;
 
     // Find the PageLine for the owner row.
     const blockIndex = layout.blocks.indexOf(lb);
@@ -133,50 +139,16 @@ export function resolvePositionPixel(
     }
     if (!pageLine) return undefined;
 
-    // Match the renderer's continuation-page shift so the cursor sits on
-    // the same pixel band as the text. Without this, merged-cell cursor
-    // positions on page 2+ stay anchored to the cell's virtual top-left
-    // row, even though the text has been shifted to give the continuation
-    // fresh top padding.
-    const ownerPage = paginatedLayout.pages[pageIndex];
-    let cellFirstRowOnPage = ownerRow;
-    for (const pl of ownerPage.lines) {
-      if (
-        pl.blockIndex === blockIndex &&
-        pl.lineIndex >= rowIndex &&
-        pl.lineIndex < rowIndex + rowSpan
-      ) {
-        cellFirstRowOnPage = pl.lineIndex;
-        break;
-      }
-    }
-    const lineYShift = computeMergedCellLineShift(
-      cell.lines,
-      rowIndex,
-      rowSpan,
-      cellPadding,
-      tl.rowYOffsets,
-      tl.rowHeights,
-      cellFirstRowOnPage,
-    );
-
     const pageX = getPageXOffset(paginatedLayout, canvasWidth);
     const pageY = getPageYOffset(paginatedLayout, pageIndex);
     const { margins } = paginatedLayout.pageSetup;
 
     const cellX = tl.columnXOffsets[colIndex] + cellPadding;
-    // Rendered line Y =
-    //   pageY + pageLine(ownerRow).y + (rowYOffsets[rowIndex] - rowYOffsets[ownerRow])
-    //   + cellPadding + cursorLineY + lineYShift
-    // This mirrors renderTableContent's (cellY + textYOffset + line.y + shift)
-    // once the page origin is factored in.
+    // targetLayout.runLineY is table-logical. The cursor's absolute Y
+    // on the owner row's page is pageY + pageLine.y + (runLineY -
+    // rowYOffsets[ownerRow]), i.e. the row-local offset of the line.
     const cursorYOnPage =
-      pageY +
-      pageLine.y +
-      (tl.rowYOffsets[rowIndex] - tl.rowYOffsets[ownerRow]) +
-      cellPadding +
-      cursorLineY +
-      lineYShift;
+      pageY + pageLine.y + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]);
 
     return {
       x: pageX + margins.left + cellX + cursorX,

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -4,6 +4,10 @@ import type { PaginatedLayout } from './pagination.js';
 import { findPageForPosition, getPageYOffset, getPageXOffset } from './pagination.js';
 import type { DocumentLayout } from './layout.js';
 import { buildFont, Theme } from './theme.js';
+import {
+  computeMergedCellLineShift,
+  findMergedCellOwnerRow,
+} from './table-renderer.js';
 
 /**
  * Represents a remote peer's cursor for collaborative editing.
@@ -100,25 +104,18 @@ export function resolvePositionPixel(
     // coordinates). The cursor must anchor to that row's PageLine so it
     // renders on the page where the line is drawn, not on the cell's
     // top-left page.
-    let ownerRow = rowIndex;
-    if (rowSpan > 1) {
-      const lineCenterInTable =
-        tl.rowYOffsets[rowIndex] + cellPadding + cursorLineY + lineHeight / 2;
-      for (let rr = rowIndex; rr < rowIndex + rowSpan && rr < tl.rowHeights.length; rr++) {
-        const top = tl.rowYOffsets[rr];
-        const bottom = top + tl.rowHeights[rr];
-        if (lineCenterInTable >= top && lineCenterInTable < bottom) {
-          ownerRow = rr;
-          break;
-        }
-      }
-      // Overflow past the spanned rows → clamp to last row.
-      const lastSpannedRow = Math.min(rowIndex + rowSpan - 1, tl.rowHeights.length - 1);
-      const lastRowBottom = tl.rowYOffsets[lastSpannedRow] + tl.rowHeights[lastSpannedRow];
-      if (ownerRow === rowIndex && lineCenterInTable >= lastRowBottom) {
-        ownerRow = lastSpannedRow;
-      }
-    }
+    const ownerRow =
+      rowSpan > 1
+        ? findMergedCellOwnerRow(
+            rowIndex,
+            rowSpan,
+            cellPadding,
+            cursorLineY,
+            lineHeight,
+            tl.rowYOffsets,
+            tl.rowHeights,
+          )
+        : rowIndex;
 
     // Find the PageLine for the owner row.
     const blockIndex = layout.blocks.indexOf(lb);
@@ -136,14 +133,50 @@ export function resolvePositionPixel(
     }
     if (!pageLine) return undefined;
 
+    // Match the renderer's continuation-page shift so the cursor sits on
+    // the same pixel band as the text. Without this, merged-cell cursor
+    // positions on page 2+ stay anchored to the cell's virtual top-left
+    // row, even though the text has been shifted to give the continuation
+    // fresh top padding.
+    const ownerPage = paginatedLayout.pages[pageIndex];
+    let cellFirstRowOnPage = ownerRow;
+    for (const pl of ownerPage.lines) {
+      if (
+        pl.blockIndex === blockIndex &&
+        pl.lineIndex >= rowIndex &&
+        pl.lineIndex < rowIndex + rowSpan
+      ) {
+        cellFirstRowOnPage = pl.lineIndex;
+        break;
+      }
+    }
+    const lineYShift = computeMergedCellLineShift(
+      cell.lines,
+      rowIndex,
+      rowSpan,
+      cellPadding,
+      tl.rowYOffsets,
+      tl.rowHeights,
+      cellFirstRowOnPage,
+    );
+
     const pageX = getPageXOffset(paginatedLayout, canvasWidth);
     const pageY = getPageYOffset(paginatedLayout, pageIndex);
     const { margins } = paginatedLayout.pageSetup;
 
     const cellX = tl.columnXOffsets[colIndex] + cellPadding;
-    const lineVirtualY = tl.rowYOffsets[rowIndex] + cellPadding + cursorLineY;
+    // Rendered line Y =
+    //   pageY + pageLine(ownerRow).y + (rowYOffsets[rowIndex] - rowYOffsets[ownerRow])
+    //   + cellPadding + cursorLineY + lineYShift
+    // This mirrors renderTableContent's (cellY + textYOffset + line.y + shift)
+    // once the page origin is factored in.
     const cursorYOnPage =
-      pageY + pageLine.y + (lineVirtualY - tl.rowYOffsets[ownerRow]);
+      pageY +
+      pageLine.y +
+      (tl.rowYOffsets[rowIndex] - tl.rowYOffsets[ownerRow]) +
+      cellPadding +
+      cursorLineY +
+      lineYShift;
 
     return {
       x: pageX + margins.left + cellX + cursorX,

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -4,6 +4,7 @@ import type { DocumentLayout, LayoutLine } from './layout.js';
 import type { PaginatedLayout } from './pagination.js';
 import { findPageForPosition, getPageYOffset, getPageXOffset } from './pagination.js';
 import { resolvePositionPixel } from './peer-cursor.js';
+import { computeMergedCellLineLayouts } from './table-renderer.js';
 import { buildFont, Theme } from './theme.js';
 
 // --- Free helpers (used by both Selection class and computeSelectionRects) ---
@@ -257,11 +258,16 @@ function buildRects(
       }];
     }
 
-    // Multi-line cell selection: find cell bounds for full-width lines
+    // Multi-line cell selection: walk the cell's lines from start to end
+    // and emit one rect per line. Each line's absolute Y is derived from
+    // computeMergedCellLineLayouts so per-row distribution (merged cells
+    // split across pages) stays consistent with the renderer. The old
+    // "advance midY by line height" path stepped linearly through the
+    // cell's Y axis and painted into the empty space below row 0 when a
+    // merged cell's line actually lived on the next page.
     const lb = layout.blocks.find((b) => b.block.id === startCellInfo.tableBlockId);
     const tl = lb?.layoutTable;
-    if (!tl) {
-      // Fallback: rect from start to end
+    if (!lb || !tl) {
       return [{
         x: startPixel.x,
         y: startPixel.y,
@@ -270,36 +276,96 @@ function buildRects(
       }];
     }
     const { rowIndex, colIndex } = startCellInfo;
-    const cellPadding = lb!.block.tableData?.rows[rowIndex]?.cells[colIndex]?.style.padding ?? 4;
-    const cellLeftX = startPixel.x - (startPixel.x - (getPageXOffset(paginatedLayout, canvasWidth) + paginatedLayout.pageSetup.margins.left + tl.columnXOffsets[colIndex] + cellPadding));
-    const cellRightX = getPageXOffset(paginatedLayout, canvasWidth) + paginatedLayout.pageSetup.margins.left + tl.columnXOffsets[colIndex] + tl.columnPixelWidths[colIndex] - cellPadding;
+    const layoutCell = tl.cells[rowIndex]?.[colIndex];
+    const cellData = lb.block.tableData?.rows[rowIndex]?.cells[colIndex];
+    if (!layoutCell || layoutCell.merged || !cellData) {
+      return [{
+        x: startPixel.x,
+        y: startPixel.y,
+        width: endPixel.x - startPixel.x,
+        height: endPixel.y + endPixel.height - startPixel.y,
+      }];
+    }
+    const cellPadding = cellData.style?.padding ?? 4;
+    const rowSpan = cellData.rowSpan ?? 1;
+
+    const pageXOffset = getPageXOffset(paginatedLayout, canvasWidth);
+    const { margins } = paginatedLayout.pageSetup;
+    const cellLeftX = pageXOffset + margins.left + tl.columnXOffsets[colIndex] + cellPadding;
+    const cellRightX =
+      pageXOffset + margins.left + tl.columnXOffsets[colIndex] + layoutCell.width - cellPadding;
+
+    // Locate the cell's block containing the start/end positions and the
+    // corresponding line indices within cell.lines.
+    const startCbi = cellData.blocks.findIndex((b) => b.id === start.blockId);
+    const endCbi = cellData.blocks.findIndex((b) => b.id === end.blockId);
+    const startCbiEff = startCbi >= 0 ? startCbi : 0;
+    const endCbiEff = endCbi >= 0 ? endCbi : 0;
+
+    const lineIdxForOffset = (cbiEff: number, offset: number): number => {
+      const lineStart = layoutCell.blockBoundaries[cbiEff] ?? 0;
+      const lineEnd =
+        layoutCell.blockBoundaries[cbiEff + 1] ?? layoutCell.lines.length;
+      let remaining = offset;
+      for (let li = lineStart; li < lineEnd; li++) {
+        let lineChars = 0;
+        for (const run of layoutCell.lines[li].runs) lineChars += run.text.length;
+        if (remaining <= lineChars) return li;
+        remaining -= lineChars;
+      }
+      return Math.max(lineStart, lineEnd - 1);
+    };
+
+    const startLineIdx = lineIdxForOffset(startCbiEff, start.offset);
+    const endLineIdx = lineIdxForOffset(endCbiEff, end.offset);
+
+    const lineLayouts = computeMergedCellLineLayouts(
+      layoutCell.lines,
+      rowIndex,
+      rowSpan,
+      cellPadding,
+      tl.rowYOffsets,
+      tl.rowHeights,
+    );
+
+    const blockIndex = layout.blocks.indexOf(lb);
+    const resolveLineAbsoluteY = (ownerRow: number, runLineY: number): number | undefined => {
+      for (const page of paginatedLayout.pages) {
+        for (const pl of page.lines) {
+          if (pl.blockIndex === blockIndex && pl.lineIndex === ownerRow) {
+            const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
+            return pageY + pl.y + (runLineY - tl.rowYOffsets[ownerRow]);
+          }
+        }
+      }
+      return undefined;
+    };
 
     const cellRects: Array<{ x: number; y: number; width: number; height: number }> = [];
-    // First line: from start to cell right edge
-    cellRects.push({
-      x: startPixel.x,
-      y: startPixel.y,
-      width: cellRightX - startPixel.x,
-      height: startPixel.height,
-    });
-    // Middle lines: full cell width
-    let midY = startPixel.y + startPixel.height;
-    while (midY < endPixel.y) {
-      cellRects.push({
-        x: cellLeftX,
-        y: midY,
-        width: cellRightX - cellLeftX,
-        height: startPixel.height, // approximate line height
-      });
-      midY += startPixel.height;
+    for (let li = startLineIdx; li <= endLineIdx; li++) {
+      const line = layoutCell.lines[li];
+      const ll = lineLayouts[li];
+      if (!ll) continue;
+      const lineY = resolveLineAbsoluteY(ll.ownerRow, ll.runLineY);
+      if (lineY === undefined) continue;
+
+      let lineX: number;
+      let lineWidth: number;
+      if (li === startLineIdx && li === endLineIdx) {
+        lineX = startPixel.x;
+        lineWidth = endPixel.x - startPixel.x;
+      } else if (li === startLineIdx) {
+        lineX = startPixel.x;
+        lineWidth = cellRightX - startPixel.x;
+      } else if (li === endLineIdx) {
+        lineX = cellLeftX;
+        lineWidth = endPixel.x - cellLeftX;
+      } else {
+        lineX = cellLeftX;
+        lineWidth = cellRightX - cellLeftX;
+      }
+      cellRects.push({ x: lineX, y: lineY, width: lineWidth, height: line.height });
     }
-    // Last line: from cell left edge to end
-    cellRects.push({
-      x: cellLeftX,
-      y: endPixel.y,
-      width: endPixel.x - cellLeftX,
-      height: endPixel.height,
-    });
     return cellRects;
   }
 

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -422,6 +422,11 @@ export function computeSelectionRects(
 
 /**
  * Build highlight rectangles for a cell-range selection.
+ *
+ * Row Y positions are read from the paginated layout (one `PageLine` per
+ * table row) so the highlight sits on the same pixel band as the rendered
+ * rows even when the table spans multiple pages. `tl.rowYOffsets` is a
+ * contiguous table-logical coordinate and cannot be used directly.
  */
 function buildCellRangeRects(
   cellRange: TableCellRange,
@@ -437,28 +442,23 @@ function buildCellRangeRects(
   const pageX = getPageXOffset(paginatedLayout, canvasWidth);
   const { margins } = paginatedLayout.pageSetup;
 
-  // Find the page Y offset for this table's first row
-  let tablePageY = 0;
-  let tableRowBaseY = 0;
-  let foundTablePage = false;
+  // Build a row → absolute Y map from the paginated layout.
+  const rowYMap = new Map<number, number>();
   for (const page of paginatedLayout.pages) {
+    const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
     for (const pl of page.lines) {
-      if (pl.blockIndex === blockIndex && pl.lineIndex === 0) {
-        tablePageY = getPageYOffset(paginatedLayout, page.pageIndex) + pl.y;
-        tableRowBaseY = tl.rowYOffsets[0];
-        foundTablePage = true;
-        break;
-      }
+      if (pl.blockIndex !== blockIndex) continue;
+      rowYMap.set(pl.lineIndex, pageY + pl.y);
     }
-    if (foundTablePage) break;
   }
-  const tableOriginY = tablePageY - tableRowBaseY;
 
   const { start, end } = cellRange;
   const rects: Array<{ x: number; y: number; width: number; height: number }> = [];
-
   const tableData = lb.block.tableData;
+
   for (let r = start.rowIndex; r <= end.rowIndex; r++) {
+    const rowAbsY = rowYMap.get(r);
+    if (rowAbsY === undefined) continue;
     for (let c = start.colIndex; c <= end.colIndex; c++) {
       const cell = tl.cells[r]?.[c];
       if (!cell || cell.merged) continue;
@@ -476,7 +476,7 @@ function buildCellRangeRects(
 
       rects.push({
         x: pageX + margins.left + tl.columnXOffsets[c],
-        y: tableOriginY + tl.rowYOffsets[r],
+        y: rowAbsY,
         width: cell.width,
         height,
       });

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -94,12 +94,19 @@ export function expandCellRangeForMerges(
   };
 }
 
-function normalizeCellRange(cr: TableCellRange): TableCellRange {
-  const minRow = Math.min(cr.start.rowIndex, cr.end.rowIndex);
-  const maxRow = Math.max(cr.start.rowIndex, cr.end.rowIndex);
-  const minCol = Math.min(cr.start.colIndex, cr.end.colIndex);
-  const maxCol = Math.max(cr.start.colIndex, cr.end.colIndex);
-  return { blockId: cr.blockId, start: { rowIndex: minRow, colIndex: minCol }, end: { rowIndex: maxRow, colIndex: maxCol } };
+function normalizeCellRange(cr: TableCellRange, table?: TableData): TableCellRange {
+  const ordered: TableCellRange = {
+    blockId: cr.blockId,
+    start: {
+      rowIndex: Math.min(cr.start.rowIndex, cr.end.rowIndex),
+      colIndex: Math.min(cr.start.colIndex, cr.end.colIndex),
+    },
+    end: {
+      rowIndex: Math.max(cr.start.rowIndex, cr.end.rowIndex),
+      colIndex: Math.max(cr.start.colIndex, cr.end.colIndex),
+    },
+  };
+  return table ? expandCellRangeForMerges(ordered, table) : ordered;
 }
 
 function normalizeRange(
@@ -108,10 +115,12 @@ function normalizeRange(
 ): NormalizedRange | null {
   // Cell-range mode: tableCellRange is set
   if (range.tableCellRange) {
+    const lb = layout.blocks.find((b) => b.block.id === range.tableCellRange!.blockId);
+    const table = lb?.block.tableData;
     return {
       start: range.anchor,
       end: range.focus,
-      tableCellRange: normalizeCellRange(range.tableCellRange),
+      tableCellRange: normalizeCellRange(range.tableCellRange, table),
     };
   }
 

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -457,15 +457,28 @@ function buildCellRangeRects(
   const { start, end } = cellRange;
   const rects: Array<{ x: number; y: number; width: number; height: number }> = [];
 
+  const tableData = lb.block.tableData;
   for (let r = start.rowIndex; r <= end.rowIndex; r++) {
     for (let c = start.colIndex; c <= end.colIndex; c++) {
       const cell = tl.cells[r]?.[c];
       if (!cell || cell.merged) continue;
+
+      // For merge top-left cells, the highlight must cover the full
+      // colSpan × rowSpan footprint, not just the anchor column/row.
+      // LayoutTableCell.width already sums spanned columns; for rows we
+      // sum rowHeights over the span explicitly.
+      const srcCell = tableData?.rows[r]?.cells[c];
+      const rowSpan = srcCell?.rowSpan ?? 1;
+      let height = 0;
+      for (let rr = r; rr < r + rowSpan && rr < tl.rowHeights.length; rr++) {
+        height += tl.rowHeights[rr];
+      }
+
       rects.push({
         x: pageX + margins.left + tl.columnXOffsets[c],
         y: tableOriginY + tl.rowYOffsets[r],
-        width: tl.columnPixelWidths[c],
-        height: tl.rowHeights[r],
+        width: cell.width,
+        height,
       });
     }
   }

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -457,29 +457,42 @@ function buildCellRangeRects(
   const tableData = lb.block.tableData;
 
   for (let r = start.rowIndex; r <= end.rowIndex; r++) {
-    const rowAbsY = rowYMap.get(r);
-    if (rowAbsY === undefined) continue;
     for (let c = start.colIndex; c <= end.colIndex; c++) {
       const cell = tl.cells[r]?.[c];
       if (!cell || cell.merged) continue;
 
-      // For merge top-left cells, the highlight must cover the full
-      // colSpan × rowSpan footprint, not just the anchor column/row.
-      // LayoutTableCell.width already sums spanned columns; for rows we
-      // sum rowHeights over the span explicitly.
+      // For merge top-left cells, highlight the full colSpan × rowSpan
+      // footprint. LayoutTableCell.width already sums spanned columns.
+      // Row coverage is split into one rect per contiguous page segment:
+      // when the next spanned row lives on a different page (its
+      // absolute Y is not the running segment's expected bottom), flush
+      // the current rect and start a new one anchored at the new row's
+      // page Y. This keeps merged-cell highlights aligned with the row
+      // bands on each page instead of bleeding into empty space below
+      // the first row.
       const srcCell = tableData?.rows[r]?.cells[c];
       const rowSpan = srcCell?.rowSpan ?? 1;
-      let height = 0;
-      for (let rr = r; rr < r + rowSpan && rr < tl.rowHeights.length; rr++) {
-        height += tl.rowHeights[rr];
-      }
+      const x = pageX + margins.left + tl.columnXOffsets[c];
+      const width = cell.width;
 
-      rects.push({
-        x: pageX + margins.left + tl.columnXOffsets[c],
-        y: rowAbsY,
-        width: cell.width,
-        height,
-      });
+      const spanEnd = Math.min(r + rowSpan, tl.rowHeights.length);
+      let segmentTop: number | undefined;
+      let segmentHeight = 0;
+      for (let rr = r; rr < spanEnd; rr++) {
+        const rrY = rowYMap.get(rr);
+        if (rrY === undefined) continue;
+        if (segmentTop === undefined) {
+          segmentTop = rrY;
+        } else if (Math.abs(rrY - (segmentTop + segmentHeight)) > 0.5) {
+          rects.push({ x, y: segmentTop, width, height: segmentHeight });
+          segmentTop = rrY;
+          segmentHeight = 0;
+        }
+        segmentHeight += tl.rowHeights[rr];
+      }
+      if (segmentTop !== undefined && segmentHeight > 0) {
+        rects.push({ x, y: segmentTop, width, height: segmentHeight });
+      }
     }
   }
   return rects;

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -302,7 +302,18 @@ function buildRects(
     const startCbiEff = startCbi >= 0 ? startCbi : 0;
     const endCbiEff = endCbi >= 0 ? endCbi : 0;
 
-    const lineIdxForOffset = (cbiEff: number, offset: number): number => {
+    // Find the cell-internal line index for a given offset. At a visual
+    // wrap boundary (offset === cumulative chars) forward affinity
+    // belongs to the next line (matching how `resolvePositionPixel` uses
+    // 'forward' for `start`), while backward affinity stays on the
+    // current line (matching `end`). Without this bias a wrapped cell
+    // selection can render an extra rect on the previous line or miss
+    // the first rect on the next one.
+    const lineIdxForOffset = (
+      cbiEff: number,
+      offset: number,
+      affinity: 'forward' | 'backward',
+    ): number => {
       const lineStart = layoutCell.blockBoundaries[cbiEff] ?? 0;
       const lineEnd =
         layoutCell.blockBoundaries[cbiEff + 1] ?? layoutCell.lines.length;
@@ -310,14 +321,24 @@ function buildRects(
       for (let li = lineStart; li < lineEnd; li++) {
         let lineChars = 0;
         for (const run of layoutCell.lines[li].runs) lineChars += run.text.length;
-        if (remaining <= lineChars) return li;
+        if (remaining <= lineChars) {
+          if (
+            affinity === 'forward' &&
+            remaining === lineChars &&
+            li < lineEnd - 1
+          ) {
+            remaining = 0;
+            continue;
+          }
+          return li;
+        }
         remaining -= lineChars;
       }
       return Math.max(lineStart, lineEnd - 1);
     };
 
-    const startLineIdx = lineIdxForOffset(startCbiEff, start.offset);
-    const endLineIdx = lineIdxForOffset(endCbiEff, end.offset);
+    const startLineIdx = lineIdxForOffset(startCbiEff, start.offset, 'forward');
+    const endLineIdx = lineIdxForOffset(endCbiEff, end.offset, 'backward');
 
     const lineLayouts = computeMergedCellLineLayouts(
       layoutCell.lines,

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -1,4 +1,4 @@
-import type { DocPosition, DocRange, TableCellRange } from '../model/types.js';
+import type { DocPosition, DocRange, TableCellRange, TableData, CellAddress } from '../model/types.js';
 import { getBlockTextLength } from '../model/types.js';
 import type { DocumentLayout, LayoutLine } from './layout.js';
 import type { PaginatedLayout } from './pagination.js';
@@ -12,6 +12,86 @@ export interface NormalizedRange {
   start: DocPosition;
   end: DocPosition;
   tableCellRange?: TableCellRange;
+}
+
+/**
+ * Walk back from `(r, c)` to the top-left of the merged cell that covers it.
+ * Returns `(r, c)` itself if the cell is plain or already a merge top-left.
+ *
+ * The data model has no back-pointer, so we scan upward and leftward looking
+ * for a cell whose `colSpan`/`rowSpan` reaches `(r, c)`. Tables are small in
+ * practice; the cost is bounded by the table area.
+ */
+export function findMergeTopLeft(table: TableData, r: number, c: number): CellAddress {
+  const cell = table.rows[r]?.cells[c];
+  if (!cell) return { rowIndex: r, colIndex: c };
+  if (cell.colSpan !== 0) return { rowIndex: r, colIndex: c };
+
+  for (let rr = r; rr >= 0; rr--) {
+    for (let cc = c; cc >= 0; cc--) {
+      const candidate = table.rows[rr]?.cells[cc];
+      if (!candidate) continue;
+      const span = candidate.colSpan ?? 1;
+      const rspan = candidate.rowSpan ?? 1;
+      if (span > 1 || rspan > 1) {
+        if (rr + rspan - 1 >= r && cc + span - 1 >= c) {
+          return { rowIndex: rr, colIndex: cc };
+        }
+      }
+    }
+  }
+  return { rowIndex: r, colIndex: c };
+}
+
+/**
+ * Expand a cell range to a bounding rectangle that fully contains every
+ * merged cell it touches. Runs a fixed-point loop because expanding for one
+ * merge can pull a previously-out-of-range merge into the rect.
+ *
+ * Caller may pass an unordered range — this helper orders start/end first.
+ */
+export function expandCellRangeForMerges(
+  cr: TableCellRange,
+  table: TableData,
+): TableCellRange {
+  let rowStart = Math.min(cr.start.rowIndex, cr.end.rowIndex);
+  let rowEnd = Math.max(cr.start.rowIndex, cr.end.rowIndex);
+  let colStart = Math.min(cr.start.colIndex, cr.end.colIndex);
+  let colEnd = Math.max(cr.start.colIndex, cr.end.colIndex);
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let r = rowStart; r <= rowEnd; r++) {
+      for (let c = colStart; c <= colEnd; c++) {
+        const cell = table.rows[r]?.cells[c];
+        if (!cell) continue;
+        const span = cell.colSpan ?? 1;
+        const rspan = cell.rowSpan ?? 1;
+
+        // Top-left of a merge whose span extends past current rect.
+        if (span > 1 || rspan > 1) {
+          const r2 = r + rspan - 1;
+          const c2 = c + span - 1;
+          if (r2 > rowEnd) { rowEnd = r2; changed = true; }
+          if (c2 > colEnd) { colEnd = c2; changed = true; }
+        }
+
+        // Covered cell whose top-left is outside current rect.
+        if (cell.colSpan === 0) {
+          const tl = findMergeTopLeft(table, r, c);
+          if (tl.rowIndex < rowStart) { rowStart = tl.rowIndex; changed = true; }
+          if (tl.colIndex < colStart) { colStart = tl.colIndex; changed = true; }
+        }
+      }
+    }
+  }
+
+  return {
+    blockId: cr.blockId,
+    start: { rowIndex: rowStart, colIndex: colStart },
+    end: { rowIndex: rowEnd, colIndex: colEnd },
+  };
 }
 
 function normalizeCellRange(cr: TableCellRange): TableCellRange {

--- a/packages/docs/src/view/table-merge-context.ts
+++ b/packages/docs/src/view/table-merge-context.ts
@@ -6,6 +6,7 @@ import type {
   DocPosition,
   DocRange,
 } from '../model/types.js';
+import { expandCellRangeForMerges } from './selection.js';
 
 export type TableMergeContext =
   | { state: 'none' }
@@ -17,10 +18,17 @@ export type TableMergeContext =
  *
  * Rules:
  *  - Cursor outside a table → none.
- *  - Active cell range covering ≥ 2 cells → canMerge (range from selection).
+ *  - Active cell range covering ≥ 2 cells → canMerge (range from selection,
+ *    expanded so any merged cell it touches is fully contained).
  *    Wins over canUnmerge so a user can grow an existing merge.
  *  - Cursor in a cell with `colSpan > 1` or `rowSpan > 1` → canUnmerge.
  *  - Otherwise → none.
+ *
+ * The selection range is expanded here as a defensive measure. The drag and
+ * Shift+Arrow handlers already call `expandCellRangeForMerges` at write
+ * time, but programmatic `Selection.setRange()` callers are not required
+ * to; this read-path expansion keeps the menu state consistent even when a
+ * raw range partially overlaps a merged cell.
  *
  * Pure: no DOM, no editor reference. Reads only `doc`, the parent map, the
  * cursor position, and the selection range.
@@ -35,29 +43,25 @@ export function computeTableMergeContext(
   if (!cellInfo) return { state: 'none' };
 
   const tableBlockId = cellInfo.tableBlockId;
+  const tableData = doc.getBlock(tableBlockId).tableData;
   const cr = selectionRange?.tableCellRange;
-  if (cr && cr.blockId === tableBlockId) {
-    const rowSpan = Math.abs(cr.end.rowIndex - cr.start.rowIndex) + 1;
-    const colSpan = Math.abs(cr.end.colIndex - cr.start.colIndex) + 1;
-    if (rowSpan * colSpan >= 2) {
+  if (cr && cr.blockId === tableBlockId && tableData) {
+    // Expand the range so any merged cell it touches is fully contained.
+    // `expandCellRangeForMerges` also orders start/end and skips over
+    // covered cells, so downstream consumers can treat the returned
+    // rectangle as canonical.
+    const expanded = expandCellRangeForMerges(cr, tableData);
+    const rows = expanded.end.rowIndex - expanded.start.rowIndex + 1;
+    const cols = expanded.end.colIndex - expanded.start.colIndex + 1;
+    if (rows * cols >= 2) {
       return {
         state: 'canMerge',
         tableBlockId,
-        range: {
-          start: {
-            rowIndex: Math.min(cr.start.rowIndex, cr.end.rowIndex),
-            colIndex: Math.min(cr.start.colIndex, cr.end.colIndex),
-          },
-          end: {
-            rowIndex: Math.max(cr.start.rowIndex, cr.end.rowIndex),
-            colIndex: Math.max(cr.start.colIndex, cr.end.colIndex),
-          },
-        },
+        range: { start: expanded.start, end: expanded.end },
       };
     }
   }
 
-  const tableData = doc.getBlock(tableBlockId).tableData;
   const cell = tableData?.rows[cellInfo.rowIndex]?.cells[cellInfo.colIndex];
   if (cell && ((cell.colSpan ?? 1) > 1 || (cell.rowSpan ?? 1) > 1)) {
     return {

--- a/packages/docs/src/view/table-merge-context.ts
+++ b/packages/docs/src/view/table-merge-context.ts
@@ -1,0 +1,71 @@
+import type { Doc } from '../model/document.js';
+import type {
+  BlockCellInfo,
+  CellAddress,
+  CellRange,
+  DocPosition,
+  DocRange,
+} from '../model/types.js';
+
+export type TableMergeContext =
+  | { state: 'none' }
+  | { state: 'canMerge'; tableBlockId: string; range: CellRange }
+  | { state: 'canUnmerge'; tableBlockId: string; cell: CellAddress };
+
+/**
+ * Decide which merge action (if any) the context menu should offer.
+ *
+ * Rules:
+ *  - Cursor outside a table → none.
+ *  - Active cell range covering ≥ 2 cells → canMerge (range from selection).
+ *    Wins over canUnmerge so a user can grow an existing merge.
+ *  - Cursor in a cell with `colSpan > 1` or `rowSpan > 1` → canUnmerge.
+ *  - Otherwise → none.
+ *
+ * Pure: no DOM, no editor reference. Reads only `doc`, the parent map, the
+ * cursor position, and the selection range.
+ */
+export function computeTableMergeContext(
+  doc: Doc,
+  blockParentMap: Map<string, BlockCellInfo>,
+  cursorPos: DocPosition,
+  selectionRange: DocRange | null,
+): TableMergeContext {
+  const cellInfo = blockParentMap.get(cursorPos.blockId);
+  if (!cellInfo) return { state: 'none' };
+
+  const tableBlockId = cellInfo.tableBlockId;
+  const cr = selectionRange?.tableCellRange;
+  if (cr && cr.blockId === tableBlockId) {
+    const rowSpan = Math.abs(cr.end.rowIndex - cr.start.rowIndex) + 1;
+    const colSpan = Math.abs(cr.end.colIndex - cr.start.colIndex) + 1;
+    if (rowSpan * colSpan >= 2) {
+      return {
+        state: 'canMerge',
+        tableBlockId,
+        range: {
+          start: {
+            rowIndex: Math.min(cr.start.rowIndex, cr.end.rowIndex),
+            colIndex: Math.min(cr.start.colIndex, cr.end.colIndex),
+          },
+          end: {
+            rowIndex: Math.max(cr.start.rowIndex, cr.end.rowIndex),
+            colIndex: Math.max(cr.start.colIndex, cr.end.colIndex),
+          },
+        },
+      };
+    }
+  }
+
+  const tableData = doc.getBlock(tableBlockId).tableData;
+  const cell = tableData?.rows[cellInfo.rowIndex]?.cells[cellInfo.colIndex];
+  if (cell && ((cell.colSpan ?? 1) > 1 || (cell.rowSpan ?? 1) > 1)) {
+    return {
+      state: 'canUnmerge',
+      tableBlockId,
+      cell: { rowIndex: cellInfo.rowIndex, colIndex: cellInfo.colIndex },
+    };
+  }
+
+  return { state: 'none' };
+}

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -40,6 +40,7 @@ export function renderTableBackgrounds(
   tableY: number,
   startRow = 0,
   endRow?: number,
+  pageStartRow?: number,
 ): void {
   const { rows } = tableData;
   const { cells, columnXOffsets, columnPixelWidths, rowYOffsets, rowHeights } = tableLayout;
@@ -47,6 +48,7 @@ export function renderTableBackgrounds(
   const numRows = cells.length;
   const numCols = columnPixelWidths.length;
   const rowEnd = endRow ?? numRows;
+  const pageStart = pageStartRow ?? startRow;
 
   for (let r = startRow; r < rowEnd; r++) {
     for (let c = 0; c < numCols; c++) {
@@ -59,22 +61,29 @@ export function renderTableBackgrounds(
       const colSpan = cell.colSpan ?? 1;
       const rowSpan = cell.rowSpan ?? 1;
 
+      // Clip the cell to the rows physically rendered on this page so a
+      // merged cell split across pages shows its background on each page
+      // as if it were a standalone cell.
+      const visibleStart = Math.max(r, pageStart);
+      const visibleEnd = Math.min(r + rowSpan, rowEnd, numRows);
+      if (visibleStart >= visibleEnd) continue;
+
       let cellWidth = 0;
       for (let s = 0; s < colSpan && c + s < numCols; s++) {
         cellWidth += columnPixelWidths[c + s];
       }
 
-      let cellHeight = 0;
-      for (let s = 0; s < rowSpan && r + s < numRows; s++) {
-        cellHeight += rowHeights[r + s];
+      let visibleHeight = 0;
+      for (let rr = visibleStart; rr < visibleEnd; rr++) {
+        visibleHeight += rowHeights[rr];
       }
 
       ctx.fillStyle = cell.style.backgroundColor;
       ctx.fillRect(
         tableX + columnXOffsets[c],
-        tableY + rowYOffsets[r],
+        tableY + rowYOffsets[visibleStart],
         cellWidth,
-        cellHeight,
+        visibleHeight,
       );
     }
   }
@@ -299,7 +308,9 @@ export function renderTableContent(
     }
   }
 
-  // 3. Borders
+  // 3. Borders. Clip each cell to the rows physically rendered on this
+  // page so a merged cell split by a page break draws a full 4-sided
+  // rectangle on each page instead of one half-open shape per page.
   for (let r = startRow; r < rowEnd; r++) {
     for (let c = 0; c < numCols; c++) {
       const layoutCell = cells[r][c];
@@ -311,25 +322,29 @@ export function renderTableContent(
       const colSpan = cell.colSpan ?? 1;
       const rowSpan = cell.rowSpan ?? 1;
 
+      const visibleStart = Math.max(r, pageStart);
+      const visibleEnd = Math.min(r + rowSpan, rowEnd, numRows);
+      if (visibleStart >= visibleEnd) continue;
+
       let cellWidth = 0;
       for (let s = 0; s < colSpan && c + s < numCols; s++) {
         cellWidth += columnPixelWidths[c + s];
       }
 
-      let cellHeight = 0;
-      for (let s = 0; s < rowSpan && r + s < numRows; s++) {
-        cellHeight += rowHeights[r + s];
+      let visibleHeight = 0;
+      for (let rr = visibleStart; rr < visibleEnd; rr++) {
+        visibleHeight += rowHeights[rr];
       }
 
       const x = tableX + columnXOffsets[c];
-      const y = tableY + rowYOffsets[r];
+      const y = tableY + rowYOffsets[visibleStart];
 
       // Use theme-aware default border color so borders adapt to dark mode
       const themeBorder: BorderStyle = { ...DEFAULT_BORDER_STYLE, color: Theme.defaultColor };
       drawBorder(ctx, cell.style?.borderTop ?? themeBorder, x, y, x + cellWidth, y);
-      drawBorder(ctx, cell.style?.borderBottom ?? themeBorder, x, y + cellHeight, x + cellWidth, y + cellHeight);
-      drawBorder(ctx, cell.style?.borderLeft ?? themeBorder, x, y, x, y + cellHeight);
-      drawBorder(ctx, cell.style?.borderRight ?? themeBorder, x + cellWidth, y, x + cellWidth, y + cellHeight);
+      drawBorder(ctx, cell.style?.borderBottom ?? themeBorder, x, y + visibleHeight, x + cellWidth, y + visibleHeight);
+      drawBorder(ctx, cell.style?.borderLeft ?? themeBorder, x, y, x, y + visibleHeight);
+      drawBorder(ctx, cell.style?.borderRight ?? themeBorder, x + cellWidth, y, x + cellWidth, y + visibleHeight);
     }
   }
 }

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -261,7 +261,7 @@ export function renderTableContent(
             style.bold,
             style.italic,
           );
-          ctx.fillStyle = style.color ?? Theme.defaultColor;
+          ctx.fillStyle = style.color || Theme.defaultColor;
           ctx.textBaseline = 'alphabetic';
 
           const runX = cellX + padding + run.x;
@@ -274,7 +274,7 @@ export function renderTableContent(
             ctx.fillStyle = style.backgroundColor;
             ctx.fillRect(runX, runLineY, run.width, line.height);
             ctx.restore();
-            ctx.fillStyle = style.color ?? Theme.defaultColor;
+            ctx.fillStyle = style.color || Theme.defaultColor;
           }
 
           ctx.fillText(run.text, runX, baselineY);
@@ -283,7 +283,7 @@ export function renderTableContent(
           if (style.underline) {
             const underlineY = baselineY + 2;
             ctx.beginPath();
-            ctx.strokeStyle = style.color ?? Theme.defaultColor;
+            ctx.strokeStyle = style.color || Theme.defaultColor;
             ctx.lineWidth = 1;
             ctx.moveTo(runX, underlineY);
             ctx.lineTo(runX + run.width, underlineY);
@@ -294,7 +294,7 @@ export function renderTableContent(
           if (style.strikethrough) {
             const strikeY = baselineY - fontSizePx * 0.25;
             ctx.beginPath();
-            ctx.strokeStyle = style.color ?? Theme.defaultColor;
+            ctx.strokeStyle = style.color || Theme.defaultColor;
             ctx.lineWidth = 1;
             ctx.moveTo(runX, strikeY);
             ctx.lineTo(runX + run.width, strikeY);
@@ -356,7 +356,7 @@ export function renderTableContent(
           const fontSizePx = ptToPx(fontSize);
           const baselineY = Math.round(markerLineY + (firstLine.height + fontSizePx * 0.8) / 2);
           ctx.font = buildFont(fontSize, cellBlock.inlines[0]?.style.fontFamily, false, false);
-          ctx.fillStyle = cellBlock.inlines[0]?.style.color ?? Theme.defaultColor;
+          ctx.fillStyle = cellBlock.inlines[0]?.style.color || Theme.defaultColor;
           ctx.fillText(marker, markerX, baselineY);
         }
       }

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -4,76 +4,59 @@ import { DEFAULT_BORDER_STYLE, LIST_INDENT_PX, UNORDERED_MARKERS } from '../mode
 import { Theme, buildFont, ptToPx } from './theme.js';
 
 /**
- * Find the row a single line of a merged cell visually belongs to, based
- * on its center Y in table-logical coordinates. Used by both the line
- * filter (skip lines that belong to another page) and the shift math
- * below (line up the first page-visible line with fresh top padding).
+ * Per-line placement for a merged cell: which spanned row the line
+ * belongs to and the line's absolute Y in table-logical coordinates.
  */
-export function findMergedCellOwnerRow(
-  cellTopRow: number,
-  rowSpan: number,
-  cellPadding: number,
-  lineY: number,
-  lineHeight: number,
-  rowYOffsets: number[],
-  rowHeights: number[],
-): number {
-  const numRows = rowYOffsets.length;
-  const spanEnd = Math.min(cellTopRow + rowSpan, numRows);
-  const lineCenter = rowYOffsets[cellTopRow] + cellPadding + lineY + lineHeight / 2;
-  for (let rr = cellTopRow; rr < spanEnd; rr++) {
-    const top = rowYOffsets[rr];
-    const bottom = top + rowHeights[rr];
-    if (lineCenter >= top && lineCenter < bottom) {
-      return rr;
-    }
-  }
-  // Overflow past the spanned rows → clamp to the last row.
-  return Math.min(cellTopRow + rowSpan - 1, numRows - 1);
+export interface MergedCellLineLayout {
+  ownerRow: number;
+  runLineY: number;
 }
 
 /**
- * Compute the Y shift that makes a merged cell's continuation on a new
- * page start with fresh top padding from the page's visible cell area.
+ * Distribute a merged cell's lines across the rows it spans, using a
+ * content-flow model: a line occupies the next free slot in the current
+ * row; if it does not fit, advance to the next row and start from that
+ * row's top padding. This lines up well with a user's expectation that
+ * N lines merged into N rows show one line per row, and cleanly answers
+ * "which page does this line belong to" even when `rowHeights` have slack
+ * (previously the center-in-range heuristic collapsed late lines into
+ * an earlier row whenever the rows were taller than the lines).
  *
- * Without the shift, lines keep their virtual Y anchored to the cell's
- * original top-left row, so a line that logically belongs to row 1 can
- * land flush against (or even above) row 1's top border when
- * `rowHeights[0]` is larger than the line height — i.e. when the merged
- * cell has slack space its content never actually uses.
- *
- * Returns 0 when no shift is needed (cell isn't a continuation on this
- * page, or no line on this page to anchor to).
+ * Returned positions are in table-logical Y (relative to the table's
+ * top-left). Callers add their page origin to draw or to anchor a cursor.
+ * For `rowSpan <= 1` the result matches the old `cellY + padding + line.y`
+ * formula so non-merged cells render unchanged.
  */
-export function computeMergedCellLineShift(
+export function computeMergedCellLineLayouts(
   cellLines: LayoutTableCell['lines'],
   cellTopRow: number,
   rowSpan: number,
   cellPadding: number,
   rowYOffsets: number[],
   rowHeights: number[],
-  cellFirstRowOnPage: number,
-): number {
-  if (rowSpan <= 1 || cellFirstRowOnPage <= cellTopRow) return 0;
+): MergedCellLineLayout[] {
+  const numRows = rowYOffsets.length;
+  const spanEnd = Math.min(cellTopRow + rowSpan, numRows);
+  const result: MergedCellLineLayout[] = [];
+  let currentRow = cellTopRow;
+  let yInRow = cellPadding;
 
   for (const line of cellLines) {
-    const owner = findMergedCellOwnerRow(
-      cellTopRow,
-      rowSpan,
-      cellPadding,
-      line.y,
-      line.height,
-      rowYOffsets,
-      rowHeights,
-    );
-    if (owner >= cellFirstRowOnPage) {
-      // Place this first-on-page line at (visible row top + padding):
-      // desiredRelY = rowYOffsets[cellFirstRowOnPage] + cellPadding
-      // originalRelY = rowYOffsets[cellTopRow] + cellPadding + line.y
-      return rowYOffsets[cellFirstRowOnPage] - rowYOffsets[cellTopRow] - line.y;
+    if (
+      rowSpan > 1 &&
+      currentRow + 1 < spanEnd &&
+      yInRow + line.height > rowHeights[currentRow] - cellPadding
+    ) {
+      currentRow++;
+      yInRow = cellPadding;
     }
+    result.push({
+      ownerRow: currentRow,
+      runLineY: rowYOffsets[currentRow] + yInRow,
+    });
+    yInRow += line.height;
   }
-  return 0;
+  return result;
 }
 
 /**
@@ -195,27 +178,6 @@ export function renderTableContent(
   const rowEnd = endRow ?? numRows;
   const pageStart = pageStartRow ?? startRow;
 
-  // Shortcut wrapper around findMergedCellOwnerRow bound to this layout.
-  // The `textYOffset` argument is kept so existing call sites do not need
-  // to know that the helper ignores it (it uses padding from the layout
-  // directly via the passed cellPadding in the underlying function).
-  const findOwnerRow = (
-    r: number,
-    rowSpan: number,
-    cellPadding: number,
-    lineYInCell: number,
-    lineHeight: number,
-  ): number =>
-    findMergedCellOwnerRow(
-      r,
-      rowSpan,
-      cellPadding,
-      lineYInCell,
-      lineHeight,
-      rowYOffsets,
-      rowHeights,
-    );
-
   // 2. Cell text
   for (let r = startRow; r < rowEnd; r++) {
     for (let c = 0; c < numCols; c++) {
@@ -261,27 +223,32 @@ export function renderTableContent(
         textYOffset = padding;
       }
 
-      // When a merged cell is split across pages, reset the text baseline
-      // for the continuation so the first line drawn on this page gets
-      // fresh top padding relative to the page's visible cell area,
-      // instead of inheriting the virtual offset from the cell's original
-      // top-left row (which can land lines flush against the page's top
-      // border when the first row is shorter than the merged content).
-      const lineYShift = computeMergedCellLineShift(
-        layoutCell.lines,
-        r,
-        rowSpan,
-        padding,
-        rowYOffsets,
-        rowHeights,
-        Math.max(r, pageStart),
-      );
+      // For merged cells, distribute lines across the spanned rows so
+      // each row gets its own top padding and content flows into the next
+      // row when one fills up. Non-merged cells keep the old text offset
+      // (which still honours vertical alignment).
+      const mergedLineLayouts =
+        rowSpan > 1
+          ? computeMergedCellLineLayouts(
+              layoutCell.lines,
+              r,
+              rowSpan,
+              padding,
+              rowYOffsets,
+              rowHeights,
+            )
+          : undefined;
 
       // Render each line's runs
-      for (const line of layoutCell.lines) {
-        if (rowSpan > 1) {
-          const ownerRow = findOwnerRow(r, rowSpan, padding, line.y, line.height);
-          if (ownerRow < pageStart || ownerRow >= rowEnd) continue;
+      for (let li = 0; li < layoutCell.lines.length; li++) {
+        const line = layoutCell.lines[li];
+        let lineAbsoluteY: number;
+        if (mergedLineLayouts) {
+          const ll = mergedLineLayouts[li];
+          if (ll.ownerRow < pageStart || ll.ownerRow >= rowEnd) continue;
+          lineAbsoluteY = tableY + ll.runLineY;
+        } else {
+          lineAbsoluteY = cellY + textYOffset + line.y;
         }
         for (const run of line.runs) {
           const style = run.inline.style;
@@ -298,7 +265,7 @@ export function renderTableContent(
           ctx.textBaseline = 'alphabetic';
 
           const runX = cellX + padding + run.x;
-          const runLineY = cellY + textYOffset + line.y + lineYShift;
+          const runLineY = lineAbsoluteY;
           const baselineY = runLineY + line.height * 0.75;
 
           // Text background highlight
@@ -367,15 +334,19 @@ export function renderTableContent(
           const firstLine = layoutCell.lines[firstLineIdx];
 
           // Keep the marker on whichever page actually renders the
-          // first line of this list-item block.
-          if (rowSpan > 1) {
-            const ownerRow = findOwnerRow(r, rowSpan, padding, firstLine.y, firstLine.height);
-            if (ownerRow < pageStart || ownerRow >= rowEnd) continue;
+          // first line of this list-item block, and anchor it to the
+          // same Y used by the text run above.
+          let markerLineY: number;
+          if (mergedLineLayouts) {
+            const ll = mergedLineLayouts[firstLineIdx];
+            if (ll.ownerRow < pageStart || ll.ownerRow >= rowEnd) continue;
+            markerLineY = tableY + ll.runLineY;
+          } else {
+            markerLineY = cellY + textYOffset + firstLine.y;
           }
 
           const markerIndent = LIST_INDENT_PX * level + LIST_INDENT_PX / 2 - 4;
           const markerX = cellX + padding + markerIndent;
-          const markerLineY = cellY + textYOffset + firstLine.y + lineYShift;
 
           const marker = cellBlock.listKind === 'unordered'
             ? UNORDERED_MARKERS[level % UNORDERED_MARKERS.length]

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -86,6 +86,14 @@ export function renderTableBackgrounds(
  * `renderTableBackgrounds` has already run for the same row range, and
  * that any selection highlight the editor wants under the text has
  * been drawn in between.
+ *
+ * `pageStartRow` is the first row physically laid out on the current
+ * page (normally equal to `startRow`). It differs only for merged cells
+ * that span a page break: the caller sweeps `startRow` back to the
+ * merge's top-left so the cell gets visited here, but only the lines
+ * whose vertical position lies within `[pageStartRow, endRow)` should
+ * actually be drawn. Without that filter, merged-cell text is rendered
+ * twice (once on each page) and lines near the break appear on both.
  */
 export function renderTableContent(
   ctx: CanvasRenderingContext2D,
@@ -95,6 +103,7 @@ export function renderTableContent(
   tableY: number,
   startRow = 0,
   endRow?: number,
+  pageStartRow?: number,
 ): void {
   const { rows } = tableData;
   const { cells, columnXOffsets, columnPixelWidths, rowYOffsets, rowHeights } = tableLayout;
@@ -102,6 +111,33 @@ export function renderTableContent(
   const numRows = cells.length;
   const numCols = columnPixelWidths.length;
   const rowEnd = endRow ?? numRows;
+  const pageStart = pageStartRow ?? startRow;
+
+  // Map a line to the row it visually belongs to. Used to filter lines
+  // of merged cells that cross a page break so each line is drawn on
+  // exactly one page.
+  const findOwnerRow = (
+    r: number,
+    rowSpan: number,
+    textYOffset: number,
+    lineYInCell: number,
+    lineHeight: number,
+  ): number => {
+    const lineCenterInTable =
+      rowYOffsets[r] + textYOffset + lineYInCell + lineHeight / 2;
+    for (let rr = r; rr < r + rowSpan && rr < numRows; rr++) {
+      const top = rowYOffsets[rr];
+      const bottom = top + rowHeights[rr];
+      if (lineCenterInTable >= top && lineCenterInTable < bottom) {
+        return rr;
+      }
+    }
+    // Line center falls past the spanned rows (overflow from a merged
+    // cell whose content is taller than its row budget). Attribute it
+    // to the last row of the span so it renders on the last page the
+    // cell touches.
+    return Math.min(r + rowSpan - 1, numRows - 1);
+  };
 
   // 2. Cell text
   for (let r = startRow; r < rowEnd; r++) {
@@ -115,6 +151,11 @@ export function renderTableContent(
       const padding = cell.style?.padding ?? 4;
       const colSpan = cell.colSpan ?? 1;
       const rowSpan = cell.rowSpan ?? 1;
+
+      // A non-merged cell on a swept-back row (r < pageStart) belongs to
+      // an earlier page — it was already rendered there, skip it here so
+      // the canvas state isn't wasted on clipped draws.
+      if (rowSpan === 1 && r < pageStart) continue;
 
       let cellWidth = 0;
       for (let s = 0; s < colSpan && c + s < numCols; s++) {
@@ -145,6 +186,10 @@ export function renderTableContent(
 
       // Render each line's runs
       for (const line of layoutCell.lines) {
+        if (rowSpan > 1) {
+          const ownerRow = findOwnerRow(r, rowSpan, textYOffset, line.y, line.height);
+          if (ownerRow < pageStart || ownerRow >= rowEnd) continue;
+        }
         for (const run of line.runs) {
           const style = run.inline.style;
           const fontSize = style.fontSize ?? Theme.defaultFontSize;
@@ -227,6 +272,13 @@ export function renderTableContent(
           const firstLineIdx = blockBoundaries[bi];
           if (firstLineIdx === undefined || firstLineIdx >= layoutCell.lines.length) continue;
           const firstLine = layoutCell.lines[firstLineIdx];
+
+          // Keep the marker on whichever page actually renders the
+          // first line of this list-item block.
+          if (rowSpan > 1) {
+            const ownerRow = findOwnerRow(r, rowSpan, textYOffset, firstLine.y, firstLine.height);
+            if (ownerRow < pageStart || ownerRow >= rowEnd) continue;
+          }
 
           const markerIndent = LIST_INDENT_PX * level + LIST_INDENT_PX / 2 - 4;
           const markerX = cellX + padding + markerIndent;

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -1,7 +1,80 @@
-import type { LayoutTable } from './table-layout.js';
+import type { LayoutTable, LayoutTableCell } from './table-layout.js';
 import type { TableData, BorderStyle } from '../model/types.js';
 import { DEFAULT_BORDER_STYLE, LIST_INDENT_PX, UNORDERED_MARKERS } from '../model/types.js';
 import { Theme, buildFont, ptToPx } from './theme.js';
+
+/**
+ * Find the row a single line of a merged cell visually belongs to, based
+ * on its center Y in table-logical coordinates. Used by both the line
+ * filter (skip lines that belong to another page) and the shift math
+ * below (line up the first page-visible line with fresh top padding).
+ */
+export function findMergedCellOwnerRow(
+  cellTopRow: number,
+  rowSpan: number,
+  cellPadding: number,
+  lineY: number,
+  lineHeight: number,
+  rowYOffsets: number[],
+  rowHeights: number[],
+): number {
+  const numRows = rowYOffsets.length;
+  const spanEnd = Math.min(cellTopRow + rowSpan, numRows);
+  const lineCenter = rowYOffsets[cellTopRow] + cellPadding + lineY + lineHeight / 2;
+  for (let rr = cellTopRow; rr < spanEnd; rr++) {
+    const top = rowYOffsets[rr];
+    const bottom = top + rowHeights[rr];
+    if (lineCenter >= top && lineCenter < bottom) {
+      return rr;
+    }
+  }
+  // Overflow past the spanned rows → clamp to the last row.
+  return Math.min(cellTopRow + rowSpan - 1, numRows - 1);
+}
+
+/**
+ * Compute the Y shift that makes a merged cell's continuation on a new
+ * page start with fresh top padding from the page's visible cell area.
+ *
+ * Without the shift, lines keep their virtual Y anchored to the cell's
+ * original top-left row, so a line that logically belongs to row 1 can
+ * land flush against (or even above) row 1's top border when
+ * `rowHeights[0]` is larger than the line height — i.e. when the merged
+ * cell has slack space its content never actually uses.
+ *
+ * Returns 0 when no shift is needed (cell isn't a continuation on this
+ * page, or no line on this page to anchor to).
+ */
+export function computeMergedCellLineShift(
+  cellLines: LayoutTableCell['lines'],
+  cellTopRow: number,
+  rowSpan: number,
+  cellPadding: number,
+  rowYOffsets: number[],
+  rowHeights: number[],
+  cellFirstRowOnPage: number,
+): number {
+  if (rowSpan <= 1 || cellFirstRowOnPage <= cellTopRow) return 0;
+
+  for (const line of cellLines) {
+    const owner = findMergedCellOwnerRow(
+      cellTopRow,
+      rowSpan,
+      cellPadding,
+      line.y,
+      line.height,
+      rowYOffsets,
+      rowHeights,
+    );
+    if (owner >= cellFirstRowOnPage) {
+      // Place this first-on-page line at (visible row top + padding):
+      // desiredRelY = rowYOffsets[cellFirstRowOnPage] + cellPadding
+      // originalRelY = rowYOffsets[cellTopRow] + cellPadding + line.y
+      return rowYOffsets[cellFirstRowOnPage] - rowYOffsets[cellTopRow] - line.y;
+    }
+  }
+  return 0;
+}
 
 /**
  * Render a table on the Canvas using pre-computed layout data.
@@ -122,31 +195,26 @@ export function renderTableContent(
   const rowEnd = endRow ?? numRows;
   const pageStart = pageStartRow ?? startRow;
 
-  // Map a line to the row it visually belongs to. Used to filter lines
-  // of merged cells that cross a page break so each line is drawn on
-  // exactly one page.
+  // Shortcut wrapper around findMergedCellOwnerRow bound to this layout.
+  // The `textYOffset` argument is kept so existing call sites do not need
+  // to know that the helper ignores it (it uses padding from the layout
+  // directly via the passed cellPadding in the underlying function).
   const findOwnerRow = (
     r: number,
     rowSpan: number,
-    textYOffset: number,
+    cellPadding: number,
     lineYInCell: number,
     lineHeight: number,
-  ): number => {
-    const lineCenterInTable =
-      rowYOffsets[r] + textYOffset + lineYInCell + lineHeight / 2;
-    for (let rr = r; rr < r + rowSpan && rr < numRows; rr++) {
-      const top = rowYOffsets[rr];
-      const bottom = top + rowHeights[rr];
-      if (lineCenterInTable >= top && lineCenterInTable < bottom) {
-        return rr;
-      }
-    }
-    // Line center falls past the spanned rows (overflow from a merged
-    // cell whose content is taller than its row budget). Attribute it
-    // to the last row of the span so it renders on the last page the
-    // cell touches.
-    return Math.min(r + rowSpan - 1, numRows - 1);
-  };
+  ): number =>
+    findMergedCellOwnerRow(
+      r,
+      rowSpan,
+      cellPadding,
+      lineYInCell,
+      lineHeight,
+      rowYOffsets,
+      rowHeights,
+    );
 
   // 2. Cell text
   for (let r = startRow; r < rowEnd; r++) {
@@ -193,10 +261,26 @@ export function renderTableContent(
         textYOffset = padding;
       }
 
+      // When a merged cell is split across pages, reset the text baseline
+      // for the continuation so the first line drawn on this page gets
+      // fresh top padding relative to the page's visible cell area,
+      // instead of inheriting the virtual offset from the cell's original
+      // top-left row (which can land lines flush against the page's top
+      // border when the first row is shorter than the merged content).
+      const lineYShift = computeMergedCellLineShift(
+        layoutCell.lines,
+        r,
+        rowSpan,
+        padding,
+        rowYOffsets,
+        rowHeights,
+        Math.max(r, pageStart),
+      );
+
       // Render each line's runs
       for (const line of layoutCell.lines) {
         if (rowSpan > 1) {
-          const ownerRow = findOwnerRow(r, rowSpan, textYOffset, line.y, line.height);
+          const ownerRow = findOwnerRow(r, rowSpan, padding, line.y, line.height);
           if (ownerRow < pageStart || ownerRow >= rowEnd) continue;
         }
         for (const run of line.runs) {
@@ -214,7 +298,7 @@ export function renderTableContent(
           ctx.textBaseline = 'alphabetic';
 
           const runX = cellX + padding + run.x;
-          const runLineY = cellY + textYOffset + line.y;
+          const runLineY = cellY + textYOffset + line.y + lineYShift;
           const baselineY = runLineY + line.height * 0.75;
 
           // Text background highlight
@@ -285,13 +369,13 @@ export function renderTableContent(
           // Keep the marker on whichever page actually renders the
           // first line of this list-item block.
           if (rowSpan > 1) {
-            const ownerRow = findOwnerRow(r, rowSpan, textYOffset, firstLine.y, firstLine.height);
+            const ownerRow = findOwnerRow(r, rowSpan, padding, firstLine.y, firstLine.height);
             if (ownerRow < pageStart || ownerRow >= rowEnd) continue;
           }
 
           const markerIndent = LIST_INDENT_PX * level + LIST_INDENT_PX / 2 - 4;
           const markerX = cellX + padding + markerIndent;
-          const markerLineY = cellY + textYOffset + firstLine.y;
+          const markerLineY = cellY + textYOffset + firstLine.y + lineYShift;
 
           const marker = cellBlock.listKind === 'unordered'
             ? UNORDERED_MARKERS[level % UNORDERED_MARKERS.length]

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -223,12 +223,16 @@ export function renderTableContent(
         textYOffset = padding;
       }
 
-      // For merged cells, distribute lines across the spanned rows so
-      // each row gets its own top padding and content flows into the next
-      // row when one fills up. Non-merged cells keep the old text offset
-      // (which still honours vertical alignment).
+      // For top-aligned merged cells, distribute lines across the
+      // spanned rows so each row gets its own top padding and content
+      // flows into the next row when one fills up. Non-merged cells, or
+      // merged cells with middle/bottom alignment, stay on the
+      // `textYOffset + line.y` path so the vertical alignment math in
+      // renderTableContent keeps working. (Pagination of middle/
+      // bottom-aligned merged cells is a pre-existing limitation — the
+      // semantics of "align-middle across two pages" is undefined.)
       const mergedLineLayouts =
-        rowSpan > 1
+        rowSpan > 1 && verticalAlign === 'top'
           ? computeMergedCellLineLayouts(
               layoutCell.lines,
               r,

--- a/packages/docs/src/view/table-resize.ts
+++ b/packages/docs/src/view/table-resize.ts
@@ -1,4 +1,6 @@
 import type { LayoutTable } from './table-layout.js';
+import type { TableData } from '../model/types.js';
+import { findMergeTopLeft } from './selection.js';
 
 const BORDER_THRESHOLD = 4;
 const MIN_COLUMN_WIDTH = 30;
@@ -19,19 +21,63 @@ export interface BorderDragState {
   maxPixel: number;
 }
 
+/**
+ * Return true if the two cell positions belong to the same merged cell.
+ * Plain cells have themselves as their own "top-left" so this also returns
+ * false for any two different plain cells.
+ */
+function cellsShareMerge(
+  table: TableData,
+  r1: number, c1: number,
+  r2: number, c2: number,
+): boolean {
+  const a = findMergeTopLeft(table, r1, c1);
+  const b = findMergeTopLeft(table, r2, c2);
+  return a.rowIndex === b.rowIndex && a.colIndex === b.colIndex;
+}
+
 export function detectTableBorder(
   layout: LayoutTable,
   localX: number,
   localY: number,
+  tableData?: TableData,
 ): BorderHit | null {
   const { columnXOffsets, columnPixelWidths, rowYOffsets, rowHeights } = layout;
   const numCols = columnPixelWidths.length;
   const numRows = rowHeights.length;
 
+  // Locate the row and column the cursor is currently over so we can tell
+  // whether a nearby border segment is swallowed by a merged cell.
+  let hoverRow = -1;
+  for (let r = 0; r < numRows; r++) {
+    const top = rowYOffsets[r];
+    const bottom = top + rowHeights[r];
+    if (localY >= top && localY <= bottom) {
+      hoverRow = r;
+      break;
+    }
+  }
+  let hoverCol = -1;
+  for (let c = 0; c < numCols; c++) {
+    const left = columnXOffsets[c];
+    const right = left + columnPixelWidths[c];
+    if (localX >= left && localX <= right) {
+      hoverCol = c;
+      break;
+    }
+  }
+
   // Check column borders (skip first left edge and last right edge)
   for (let c = 0; c < numCols - 1; c++) {
     const borderX = columnXOffsets[c] + columnPixelWidths[c];
     if (Math.abs(localX - borderX) <= BORDER_THRESHOLD) {
+      if (
+        tableData &&
+        hoverRow >= 0 &&
+        cellsShareMerge(tableData, hoverRow, c, hoverRow, c + 1)
+      ) {
+        continue;
+      }
       return { type: 'column', index: c };
     }
   }
@@ -40,6 +86,14 @@ export function detectTableBorder(
   for (let r = 0; r < numRows; r++) {
     const borderY = rowYOffsets[r] + rowHeights[r];
     if (Math.abs(localY - borderY) <= BORDER_THRESHOLD) {
+      if (
+        tableData &&
+        hoverCol >= 0 &&
+        r + 1 < numRows &&
+        cellsShareMerge(tableData, r, hoverCol, r + 1, hoverCol)
+      ) {
+        continue;
+      }
       return { type: 'row', index: r };
     }
   }

--- a/packages/docs/src/view/table-resize.ts
+++ b/packages/docs/src/view/table-resize.ts
@@ -41,15 +41,21 @@ export function detectTableBorder(
   localX: number,
   localY: number,
   tableData?: TableData,
+  pageFirstRow?: number,
+  pageLastRow?: number,
 ): BorderHit | null {
   const { columnXOffsets, columnPixelWidths, rowYOffsets, rowHeights } = layout;
   const numCols = columnPixelWidths.length;
   const numRows = rowHeights.length;
+  const firstRow = pageFirstRow ?? 0;
+  const lastRow = pageLastRow ?? numRows - 1;
 
   // Locate the row and column the cursor is currently over so we can tell
-  // whether a nearby border segment is swallowed by a merged cell.
+  // whether a nearby border segment is swallowed by a merged cell. Only
+  // consider rows physically on the current page so pagination gaps do
+  // not expose resize handles belonging to rows on another page.
   let hoverRow = -1;
-  for (let r = 0; r < numRows; r++) {
+  for (let r = firstRow; r <= lastRow; r++) {
     const top = rowYOffsets[r];
     const bottom = top + rowHeights[r];
     if (localY >= top && localY <= bottom) {
@@ -82,8 +88,8 @@ export function detectTableBorder(
     }
   }
 
-  // Check row borders (skip first top edge; include last bottom edge)
-  for (let r = 0; r < numRows; r++) {
+  // Check row borders — only for rows physically on this page.
+  for (let r = firstRow; r <= lastRow; r++) {
     const borderY = rowYOffsets[r] + rowHeights[r];
     if (Math.abs(localY - borderY) <= BORDER_THRESHOLD) {
       if (

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -13,6 +13,7 @@ import { detectUrlBeforeCursor, isSafeUrl } from './url-detect.js';
 import { findNextWordBoundary, findPrevWordBoundary, getWordRange } from './word-boundary.js';
 import { findVisualLine } from './visual-line.js';
 import { detectTableBorder, createDragState, type BorderDragState } from './table-resize.js';
+import { computeMergedCellLineLayouts } from './table-renderer.js';
 
 /**
  * Composition (IME) state tracker.
@@ -3132,30 +3133,46 @@ export class TextEditor {
     const pageX = getPageXOffset(paginatedLayout, this.getCanvasWidth());
     const dataCell = lb.block.tableData?.rows[cellAddr.rowIndex]?.cells[cellAddr.colIndex];
     const cellPadding = dataCell?.style.padding ?? 4;
+    const rowSpan = dataCell?.rowSpan ?? 1;
     const cellOriginX = pageX + margins.left + tl.columnXOffsets[cellAddr.colIndex] + cellPadding;
     const localX = logicalX - cellOriginX;
 
-    // Determine which line was clicked using Y coordinate
+    // Determine which line was clicked using Y coordinate. For merged
+    // cells each line lives on a different row (and possibly a
+    // different page), so we compute each line's absolute rendered Y
+    // via the same helper the renderer uses instead of relying on a
+    // single continuous cell Y axis.
     let targetLineIdx = cell.lines.length - 1; // default: last line
-    if (logicalY !== undefined) {
-      // Find the paginated row's page position to compute cell Y origin
+    if (logicalY !== undefined && cell.lines.length > 0) {
+      const lineLayouts = computeMergedCellLineLayouts(
+        cell.lines,
+        cellAddr.rowIndex,
+        rowSpan,
+        cellPadding,
+        tl.rowYOffsets,
+        tl.rowHeights,
+      );
       const blockIndex = layout.blocks.indexOf(lb);
-      let cellPageY = 0;
+
+      // Cache ownerRow → page Y + pl.y so we avoid an O(pages*lines)
+      // lookup per click.
+      const rowPageInfo = new Map<number, { pageY: number; plY: number }>();
       for (const page of paginatedLayout.pages) {
+        const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
         for (const pl of page.lines) {
-          if (pl.blockIndex === blockIndex && pl.lineIndex === cellAddr.rowIndex) {
-            const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
-            cellPageY = pageY + pl.y - tl.rowYOffsets[cellAddr.rowIndex] + cellPadding;
-            break;
-          }
+          if (pl.blockIndex !== blockIndex) continue;
+          rowPageInfo.set(pl.lineIndex, { pageY, plY: pl.y });
         }
-        if (cellPageY !== 0) break;
       }
 
-      const localY = logicalY - cellPageY;
       targetLineIdx = cell.lines.length - 1;
       for (let li = 0; li < cell.lines.length; li++) {
-        if (localY < cell.lines[li].y + cell.lines[li].height) {
+        const ll = lineLayouts[li];
+        const info = rowPageInfo.get(ll.ownerRow);
+        if (!info) continue;
+        const lineAbsY =
+          info.pageY + info.plY + (ll.runLineY - tl.rowYOffsets[ll.ownerRow]);
+        if (logicalY < lineAbsY + cell.lines[li].height) {
           targetLineIdx = li;
           break;
         }

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -724,6 +724,8 @@ export class TextEditor {
     layout: import('./table-layout.js').LayoutTable;
     tableOriginX: number;
     tableOriginY: number;
+    pageFirstRow: number;
+    pageLastRow: number;
   } | null {
     const rect = this.container.getBoundingClientRect();
     const s = this.getScaleFactor();
@@ -734,30 +736,50 @@ export class TextEditor {
     const paginatedLayout = this.getPaginatedLayout();
     const { margins } = paginatedLayout.pageSetup;
     const pageX = getPageXOffset(paginatedLayout, this.getCanvasWidth());
+    const tableOriginX = pageX + margins.left;
 
+    // Multi-page tables need per-page hit testing: a table splits into
+    // separate row bands across pages, so we can only map mouseY to a
+    // valid table-logical Y relative to the page the cursor is actually
+    // over. Walk each page's row bands for every table block and only
+    // resolve when mouseY falls inside one.
     for (const lb of layout.blocks) {
       if (lb.block.type !== 'table' || !lb.layoutTable) continue;
       const tl = lb.layoutTable;
       const blockIndex = layout.blocks.indexOf(lb);
 
-      let tablePageY = 0;
+      if (mouseX < tableOriginX || mouseX > tableOriginX + tl.totalWidth) continue;
+
       for (const page of paginatedLayout.pages) {
+        const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
+        let firstPl: import('./pagination.js').PageLine | undefined;
+        let lastPl: import('./pagination.js').PageLine | undefined;
         for (const pl of page.lines) {
-          if (pl.blockIndex === blockIndex && pl.lineIndex === 0) {
-            tablePageY = getPageYOffset(paginatedLayout, page.pageIndex) + pl.y;
-            break;
-          }
+          if (pl.blockIndex !== blockIndex) continue;
+          if (!firstPl) firstPl = pl;
+          lastPl = pl;
         }
-        if (tablePageY !== 0) break;
-      }
+        if (!firstPl || !lastPl) continue;
 
-      const tableOriginX = pageX + margins.left;
-      const tableOriginY = tablePageY;
-      const localX = mouseX - tableOriginX;
-      const localY = mouseY - tableOriginY;
+        const bandTop = pageY + firstPl.y;
+        const bandBottom = pageY + lastPl.y + lastPl.line.height;
+        if (mouseY < bandTop || mouseY > bandBottom) continue;
 
-      if (localX >= 0 && localX <= tl.totalWidth && localY >= 0 && localY <= tl.totalHeight) {
-        return { tableBlockId: lb.block.id, localX, localY, layout: tl, tableOriginX, tableOriginY };
+        // Convert mouseY to table-logical Y based on the first row in
+        // this band. The virtual tableOriginY is reconstructed so
+        // `localY = mouseY - tableOriginY` lands inside rowYOffsets of a
+        // row physically on this page.
+        const tableOriginY = bandTop - tl.rowYOffsets[firstPl.lineIndex];
+        return {
+          tableBlockId: lb.block.id,
+          localX: mouseX - tableOriginX,
+          localY: mouseY - tableOriginY,
+          layout: tl,
+          tableOriginX,
+          tableOriginY,
+          pageFirstRow: firstPl.lineIndex,
+          pageLastRow: lastPl.lineIndex,
+        };
       }
     }
     return null;
@@ -794,6 +816,8 @@ export class TextEditor {
         tableInfo.localX,
         tableInfo.localY,
         tableData,
+        tableInfo.pageFirstRow,
+        tableInfo.pageLastRow,
       );
       if (hit) {
         const pixel = hit.type === 'column'
@@ -1019,6 +1043,8 @@ export class TextEditor {
         tableInfo.localX,
         tableInfo.localY,
         tableData,
+        tableInfo.pageFirstRow,
+        tableInfo.pageLastRow,
       );
       if (hit) {
         this.setCanvasCursor(hit.type === 'column' ? 'col-resize' : 'row-resize');

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -788,7 +788,13 @@ export class TextEditor {
     // Check for border resize drag
     const tableInfo = this.resolveTableFromMouse(e);
     if (tableInfo) {
-      const hit = detectTableBorder(tableInfo.layout, tableInfo.localX, tableInfo.localY);
+      const tableData = this.doc.getBlock(tableInfo.tableBlockId).tableData;
+      const hit = detectTableBorder(
+        tableInfo.layout,
+        tableInfo.localX,
+        tableInfo.localY,
+        tableData,
+      );
       if (hit) {
         const pixel = hit.type === 'column'
           ? tableInfo.tableOriginX + tableInfo.layout.columnXOffsets[hit.index] + tableInfo.layout.columnPixelWidths[hit.index]
@@ -1028,7 +1034,13 @@ export class TextEditor {
     // Cursor style: check for border proximity
     const tableInfo = this.resolveTableFromMouse(e);
     if (tableInfo) {
-      const hit = detectTableBorder(tableInfo.layout, tableInfo.localX, tableInfo.localY);
+      const tableData = this.doc.getBlock(tableInfo.tableBlockId).tableData;
+      const hit = detectTableBorder(
+        tableInfo.layout,
+        tableInfo.localX,
+        tableInfo.localY,
+        tableData,
+      );
       if (hit) {
         this.setCanvasCursor(hit.type === 'column' ? 'col-resize' : 'row-resize');
       } else {

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -3,7 +3,7 @@ import { generateBlockId, getBlockText, getBlockTextLength, DEFAULT_BLOCK_STYLE,
 import { Doc, type EditContext } from '../model/document.js';
 import { serializeBlocks, deserializeBlocks, parseHtmlToBlocks, WAFFLEDOCS_MIME } from './clipboard.js';
 import { Cursor } from './cursor.js';
-import { Selection } from './selection.js';
+import { Selection, expandCellRangeForMerges } from './selection.js';
 import type { DocumentLayout } from './layout.js';
 import type { PaginatedLayout } from './pagination.js';
 import { paginatedPixelToPosition, findPageForPosition, getPageYOffset, getPageXOffset, getHeaderYStart, getFooterYStart, resolveClickTarget } from './pagination.js';
@@ -1162,12 +1162,21 @@ export class TextEditor {
               };
             } else if (currentCA) {
               // Different cell — cell-range mode
-              tableCellRange = {
-                blockId: tableBlockId,
-                start: anchorCA,
-                end: currentCA,
-              };
-              const targetCell = this.doc.getBlock(tableBlockId).tableData!.rows[currentCA.rowIndex].cells[currentCA.colIndex];
+              const tableData = this.doc.getBlock(tableBlockId).tableData!;
+              tableCellRange = expandCellRangeForMerges(
+                {
+                  blockId: tableBlockId,
+                  start: anchorCA,
+                  end: currentCA,
+                },
+                tableData,
+              );
+              // Cursor lands on the cell the user actually dragged to
+              // (resolveTableCellClick guarantees currentCA is a visible
+              // top-left, never a covered cell). The expanded range is for
+              // selection/highlighting only.
+              const targetCell = tableData.rows[currentCA.rowIndex]
+                .cells[currentCA.colIndex];
               pos = {
                 blockId: targetCell.blocks[0].id,
                 offset: 0,
@@ -1823,14 +1832,17 @@ export class TextEditor {
               anchorCI.tableBlockId === newPosCI.tableBlockId &&
               (anchorCI.rowIndex !== newPosCI.rowIndex ||
                anchorCI.colIndex !== newPosCI.colIndex)) {
-            // Cross-cell: use tableCellRange
+            // Cross-cell: use tableCellRange, expanded to cover any merges it touches
             this.selection.setRange({
               anchor, focus: newPos,
-              tableCellRange: {
-                blockId: anchorCI.tableBlockId,
-                start: { rowIndex: anchorCI.rowIndex, colIndex: anchorCI.colIndex },
-                end: { rowIndex: newPosCI.rowIndex, colIndex: newPosCI.colIndex },
-              },
+              tableCellRange: expandCellRangeForMerges(
+                {
+                  blockId: anchorCI.tableBlockId,
+                  start: { rowIndex: anchorCI.rowIndex, colIndex: anchorCI.colIndex },
+                  end: { rowIndex: newPosCI.rowIndex, colIndex: newPosCI.colIndex },
+                },
+                this.doc.getBlock(anchorCI.tableBlockId).tableData!,
+              ),
             });
           } else if (anchorCI && !newPosCI) {
             // Exiting table: block-range with anchor at table boundary

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -899,7 +899,6 @@ export class TextEditor {
     const clickedBlock = this.doc.document.blocks.find((b) => b.id === pos.blockId);
     if (clickedBlock?.type === 'table' && clickedBlock.tableData) {
       const layout = this.getLayout();
-      const paginatedLayout = this.getPaginatedLayout();
       const lb = layout.blocks.find((b) => b.block.id === pos.blockId);
       if (lb?.layoutTable) {
         const rect = this.container.getBoundingClientRect();
@@ -907,27 +906,7 @@ export class TextEditor {
         const mouseX = (e.clientX - rect.left + this.container.scrollLeft) / s;
         const mouseY = (e.clientY - rect.top - this.getCanvasOffsetTop()) / s + this.container.scrollTop / s;
 
-        // Find which page the table block is on to compute correct local coordinates
-        const blockIndex = layout.blocks.indexOf(lb);
-        const { margins } = paginatedLayout.pageSetup;
-        let tablePageY = 0;
-        let tablePageLineY = 0;
-        for (const page of paginatedLayout.pages) {
-          for (const pl of page.lines) {
-            if (pl.blockIndex === blockIndex && pl.lineIndex === 0) {
-              tablePageY = getPageYOffset(paginatedLayout, page.pageIndex);
-              tablePageLineY = pl.y;
-              break;
-            }
-          }
-          if (tablePageY > 0) break;
-        }
-
-        const pageX = getPageXOffset(paginatedLayout, this.getCanvasWidth());
-        const localX = mouseX - pageX - margins.left;
-        const localY = mouseY - tablePageY - tablePageLineY;
-
-        const cellAddr = this.resolveTableCellClick(pos.blockId, localX, localY);
+        const cellAddr = this.resolveTableCellClick(pos.blockId, mouseX, mouseY);
         if (cellAddr) {
           const tableBlock = this.doc.getBlock(pos.blockId);
           const cell = tableBlock.tableData!.rows[cellAddr.rowIndex].cells[cellAddr.colIndex];
@@ -1144,24 +1123,7 @@ export class TextEditor {
           const layout = this.getLayout();
           const lb = layout.blocks.find((b) => b.block.id === tableBlockId);
           if (lb?.layoutTable) {
-            const paginatedLayout = this.getPaginatedLayout();
-            const { margins } = paginatedLayout.pageSetup;
-            const pageX = getPageXOffset(paginatedLayout, this.getCanvasWidth());
-            // Find table page position for localX/Y
-            const blockIndex = layout.blocks.indexOf(lb);
-            let tablePageY = 0;
-            for (const page of paginatedLayout.pages) {
-              for (const pl of page.lines) {
-                if (pl.blockIndex === blockIndex && pl.lineIndex === 0) {
-                  tablePageY = getPageYOffset(paginatedLayout, page.pageIndex) + pl.y;
-                  break;
-                }
-              }
-              if (tablePageY !== 0) break;
-            }
-            const localX = x - pageX - margins.left;
-            const localY = (y + scrollY) - tablePageY;
-            const currentCA = this.resolveTableCellClick(tableBlockId, localX, localY);
+            const currentCA = this.resolveTableCellClick(tableBlockId, x, y + scrollY);
 
             if (currentCA &&
                 currentCA.rowIndex === anchorCA.rowIndex &&
@@ -3016,27 +2978,71 @@ export class TextEditor {
    * Resolve which table cell was clicked given coordinates local to the
    * table block's top-left corner.
    */
+  /**
+   * Resolve a mouse position (canvas-logical, scroll-adjusted coordinates)
+   * to the table cell under the cursor.
+   *
+   * Row resolution iterates the paginated layout's `PageLine`s instead of
+   * reading `tl.rowYOffsets` directly. Each row of a paginated table is
+   * recorded as a `PageLine` whose `lineIndex` is the row index and whose
+   * absolute Y we can reconstruct from `getPageYOffset` + `pl.y`. This is
+   * the only correct mapping when the table spans multiple pages — the
+   * table's own `rowYOffsets` are contiguous in table-logical space and
+   * do not account for the gap between pages.
+   */
   private resolveTableCellClick(
     blockId: string,
-    localX: number,
-    localY: number,
+    mouseX: number,
+    mouseY: number,
   ): CellAddress | undefined {
     const block = this.doc.document.blocks.find((b) => b.id === blockId);
     if (!block || block.type !== 'table' || !block.tableData) return undefined;
     const layout = this.getLayout();
+    const paginatedLayout = this.getPaginatedLayout();
     const lb = layout.blocks.find((b) => b.block.id === blockId);
     if (!lb?.layoutTable) return undefined;
     const tl = lb.layoutTable;
+    const blockIndex = layout.blocks.indexOf(lb);
 
-    // Find row
-    let rowIndex = tl.rowHeights.length - 1;
-    for (let r = 0; r < tl.rowYOffsets.length; r++) {
-      if (localY < tl.rowYOffsets[r] + tl.rowHeights[r]) {
-        rowIndex = r;
-        break;
+    // Find the row by walking the paginated layout's lines for this table.
+    let rowIndex = -1;
+    let firstRowTop = Number.POSITIVE_INFINITY;
+    let lastRowBottom = Number.NEGATIVE_INFINITY;
+    let lastRowIndex = -1;
+    outer: for (const page of paginatedLayout.pages) {
+      const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
+      for (const pl of page.lines) {
+        if (pl.blockIndex !== blockIndex) continue;
+        const top = pageY + pl.y;
+        const bottom = top + pl.line.height;
+        if (top < firstRowTop) firstRowTop = top;
+        if (bottom > lastRowBottom) {
+          lastRowBottom = bottom;
+          lastRowIndex = pl.lineIndex;
+        }
+        if (mouseY >= top && mouseY < bottom) {
+          rowIndex = pl.lineIndex;
+          break outer;
+        }
       }
     }
-    // Find column
+
+    // Click above/below the table: clamp to the nearest row so drags that
+    // leave the table vertically still land on a valid cell.
+    if (rowIndex < 0) {
+      if (mouseY < firstRowTop) {
+        rowIndex = 0;
+      } else if (lastRowIndex >= 0) {
+        rowIndex = lastRowIndex;
+      } else {
+        return undefined;
+      }
+    }
+
+    // Find the column using table-logical X.
+    const { margins } = paginatedLayout.pageSetup;
+    const pageX = getPageXOffset(paginatedLayout, this.getCanvasWidth());
+    const localX = mouseX - pageX - margins.left;
     let colIndex = tl.columnPixelWidths.length - 1;
     for (let c = 0; c < tl.columnXOffsets.length; c++) {
       if (localX < tl.columnXOffsets[c] + tl.columnPixelWidths[c]) {
@@ -3044,7 +3050,8 @@ export class TextEditor {
         break;
       }
     }
-    // Skip merged cells — find owner
+
+    // Resolve a covered cell to its merge top-left.
     const cell = block.tableData.rows[rowIndex]?.cells[colIndex];
     if (cell?.colSpan === 0) {
       for (let r = rowIndex; r >= 0; r--) {

--- a/packages/docs/test/model/table.test.ts
+++ b/packages/docs/test/model/table.test.ts
@@ -144,6 +144,43 @@ describe('Doc table operations', () => {
       expect(block.tableData!.rows[1].cells[0].colSpan).toBe(0);
       expect(block.tableData!.rows[1].cells[1].colSpan).toBe(0);
     });
+
+    it('absorbs an existing merged cell when the new range contains it', () => {
+      const doc = Doc.create();
+      const tableId = doc.insertTable(0, 4, 4);
+      doc.setBlockParentMap(buildParentMap(doc, tableId));
+
+      // Pre-merge (1,1)..(2,2) with text "M"
+      const cellBlock11 = getCellBlock(doc, tableId, { rowIndex: 1, colIndex: 1 });
+      doc.insertText({ blockId: cellBlock11.id, offset: 0 }, 'M');
+      doc.mergeCells(tableId, { start: { rowIndex: 1, colIndex: 1 }, end: { rowIndex: 2, colIndex: 2 } });
+
+      // Add some text outside the merge
+      const cellBlock00 = getCellBlock(doc, tableId, { rowIndex: 0, colIndex: 0 });
+      doc.insertText({ blockId: cellBlock00.id, offset: 0 }, 'X');
+
+      // Now merge a 4x4 range containing the existing merge
+      doc.mergeCells(tableId, { start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 3, colIndex: 3 } });
+
+      const block = doc.getBlock(tableId);
+      const tl = block.tableData!.rows[0].cells[0];
+      expect(tl.colSpan).toBe(4);
+      expect(tl.rowSpan).toBe(4);
+
+      // The text from the inner merge should be preserved in the outer top-left
+      const allText = tl.blocks.flatMap(b => b.inlines).map(i => i.text).join('');
+      expect(allText).toContain('X');
+      expect(allText).toContain('M');
+
+      // Every other cell should be covered
+      for (let r = 0; r < 4; r++) {
+        for (let c = 0; c < 4; c++) {
+          if (r === 0 && c === 0) continue;
+          const cell = block.tableData!.rows[r].cells[c];
+          expect(cell.colSpan).toBe(0);
+        }
+      }
+    });
   });
 
   describe('splitCell', () => {

--- a/packages/docs/test/view/cell-range-expand.test.ts
+++ b/packages/docs/test/view/cell-range-expand.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  expandCellRangeForMerges,
+  findMergeTopLeft,
+} from '../../src/view/selection.js';
+import type { TableCell, TableData, TableCellRange } from '../../src/model/types.js';
+
+function plainCell(): TableCell {
+  return {
+    blocks: [{ id: 'b', type: 'paragraph', inlines: [{ text: '', style: {} }], style: {} as any }],
+    style: {},
+  };
+}
+
+function coveredCell(): TableCell {
+  return { ...plainCell(), colSpan: 0 };
+}
+
+function mergedTopLeft(rowSpan: number, colSpan: number): TableCell {
+  return { ...plainCell(), rowSpan, colSpan };
+}
+
+function makeTable(rows: number, cols: number, overrides: Record<string, TableCell> = {}): TableData {
+  const data: TableData = { rows: [], columnWidths: Array(cols).fill(1 / cols) };
+  for (let r = 0; r < rows; r++) {
+    const cells: TableCell[] = [];
+    for (let c = 0; c < cols; c++) {
+      cells.push(overrides[`${r},${c}`] ?? plainCell());
+    }
+    data.rows.push({ cells });
+  }
+  return data;
+}
+
+function rect(r1: number, c1: number, r2: number, c2: number): TableCellRange {
+  return { blockId: 't', start: { rowIndex: r1, colIndex: c1 }, end: { rowIndex: r2, colIndex: c2 } };
+}
+
+describe('findMergeTopLeft', () => {
+  it('returns the cell itself when it is a plain cell', () => {
+    const t = makeTable(3, 3);
+    expect(findMergeTopLeft(t, 1, 1)).toEqual({ rowIndex: 1, colIndex: 1 });
+  });
+
+  it('returns the cell itself when it is a merge top-left', () => {
+    const t = makeTable(3, 3, { '0,0': mergedTopLeft(2, 2), '0,1': coveredCell(), '1,0': coveredCell(), '1,1': coveredCell() });
+    expect(findMergeTopLeft(t, 0, 0)).toEqual({ rowIndex: 0, colIndex: 0 });
+  });
+
+  it('walks back from a covered cell to its top-left', () => {
+    const t = makeTable(3, 3, { '0,0': mergedTopLeft(2, 2), '0,1': coveredCell(), '1,0': coveredCell(), '1,1': coveredCell() });
+    expect(findMergeTopLeft(t, 1, 1)).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(findMergeTopLeft(t, 0, 1)).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(findMergeTopLeft(t, 1, 0)).toEqual({ rowIndex: 0, colIndex: 0 });
+  });
+});
+
+describe('expandCellRangeForMerges', () => {
+  it('returns input rect unchanged when no merges touched', () => {
+    const t = makeTable(3, 3);
+    const r = rect(0, 0, 1, 1);
+    expect(expandCellRangeForMerges(r, t)).toEqual(r);
+  });
+
+  it('expands when range partially overlaps a merge top-left', () => {
+    // (1,1) is a 2x2 merged top-left covering (1,1)..(2,2)
+    const t = makeTable(4, 4, {
+      '1,1': mergedTopLeft(2, 2), '1,2': coveredCell(), '2,1': coveredCell(), '2,2': coveredCell(),
+    });
+    // User selects (0,0)..(1,1) — overlaps merge top-left
+    const result = expandCellRangeForMerges(rect(0, 0, 1, 1), t);
+    expect(result.start).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(result.end).toEqual({ rowIndex: 2, colIndex: 2 });
+  });
+
+  it('walks back from a covered cell to include its top-left', () => {
+    const t = makeTable(4, 4, {
+      '1,1': mergedTopLeft(2, 2), '1,2': coveredCell(), '2,1': coveredCell(), '2,2': coveredCell(),
+    });
+    // User selects (2,2)..(3,3) — starts on a covered cell
+    const result = expandCellRangeForMerges(rect(2, 2, 3, 3), t);
+    expect(result.start).toEqual({ rowIndex: 1, colIndex: 1 });
+    expect(result.end).toEqual({ rowIndex: 3, colIndex: 3 });
+  });
+
+  it('chains expansion across multiple merges (fixed-point)', () => {
+    const t = makeTable(5, 5, {
+      // Merge A: (0,2)..(1,3)
+      '0,2': mergedTopLeft(2, 2), '0,3': coveredCell(),
+      '1,2': coveredCell(), '1,3': coveredCell(),
+      // Merge B: (1,0)..(2,1)
+      '1,0': mergedTopLeft(2, 2), '1,1': coveredCell(),
+      '2,0': coveredCell(), '2,1': coveredCell(),
+    });
+    // User picks (0,0)..(0,2): touches Merge A's top-left → expands to (0,0)..(1,3),
+    // which now contains Merge B's top-left → expands to (0,0)..(2,3).
+    const result = expandCellRangeForMerges(rect(0, 0, 0, 2), t);
+    expect(result.start).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(result.end).toEqual({ rowIndex: 2, colIndex: 3 });
+  });
+
+  it('handles a range whose start is greater than end (caller has not ordered)', () => {
+    const t = makeTable(3, 3);
+    const r = rect(2, 2, 0, 0);
+    const result = expandCellRangeForMerges(r, t);
+    expect(result.start).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(result.end).toEqual({ rowIndex: 2, colIndex: 2 });
+  });
+
+  it('preserves blockId', () => {
+    const t = makeTable(2, 2);
+    const r: TableCellRange = { blockId: 'my-table', start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 1, colIndex: 1 } };
+    expect(expandCellRangeForMerges(r, t).blockId).toBe('my-table');
+  });
+});

--- a/packages/docs/test/view/cell-range-expand.test.ts
+++ b/packages/docs/test/view/cell-range-expand.test.ts
@@ -113,3 +113,40 @@ describe('expandCellRangeForMerges', () => {
     expect(expandCellRangeForMerges(r, t).blockId).toBe('my-table');
   });
 });
+
+import { Selection } from '../../src/view/selection.js';
+import type { DocumentLayout, LayoutBlock } from '../../src/view/layout.js';
+
+describe('Selection.getNormalizedRange — cell range expansion at read time', () => {
+  it('expands a partially-overlapping cell range using layout TableData', () => {
+    // Build a minimal fake DocumentLayout with one table block
+    const t = makeTable(4, 4, {
+      '1,1': mergedTopLeft(2, 2), '1,2': coveredCell(),
+      '2,1': coveredCell(), '2,2': coveredCell(),
+    });
+    const tableBlock: any = {
+      id: 't', type: 'table', inlines: [], style: {},
+      tableData: t,
+    };
+    const lb: LayoutBlock = {
+      block: tableBlock,
+      lines: [],
+      width: 0, height: 0, top: 0,
+    } as unknown as LayoutBlock;
+    const layout: DocumentLayout = {
+      blocks: [lb],
+      blockParentMap: new Map(),
+    } as unknown as DocumentLayout;
+
+    const sel = new Selection();
+    sel.setRange({
+      anchor: { blockId: 'anchor', offset: 0 },
+      focus: { blockId: 'focus', offset: 0 },
+      tableCellRange: rect(0, 0, 1, 1),
+    });
+
+    const normalized = sel.getNormalizedRange(layout);
+    expect(normalized?.tableCellRange?.start).toEqual({ rowIndex: 0, colIndex: 0 });
+    expect(normalized?.tableCellRange?.end).toEqual({ rowIndex: 2, colIndex: 2 });
+  });
+});

--- a/packages/docs/test/view/table-merge-context.test.ts
+++ b/packages/docs/test/view/table-merge-context.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Doc } from '../../src/model/document.js';
+import { computeTableMergeContext } from '../../src/view/table-merge-context.js';
+import type { BlockCellInfo, CellAddress, DocPosition } from '../../src/model/types.js';
+
+function buildParentMap(doc: Doc, tableBlockId: string): Map<string, BlockCellInfo> {
+  const map = new Map<string, BlockCellInfo>();
+  const block = doc.getBlock(tableBlockId);
+  if (!block.tableData) return map;
+  for (let r = 0; r < block.tableData.rows.length; r++) {
+    for (let c = 0; c < block.tableData.rows[r].cells.length; c++) {
+      for (const b of block.tableData.rows[r].cells[c].blocks) {
+        map.set(b.id, { tableBlockId, rowIndex: r, colIndex: c });
+      }
+    }
+  }
+  return map;
+}
+
+function cellBlockId(doc: Doc, tableId: string, cell: CellAddress): string {
+  return doc.getBlock(tableId).tableData!.rows[cell.rowIndex].cells[cell.colIndex].blocks[0].id;
+}
+
+describe('computeTableMergeContext', () => {
+  let doc: Doc;
+  let tableId: string;
+  let parentMap: Map<string, BlockCellInfo>;
+
+  beforeEach(() => {
+    doc = Doc.create();
+    tableId = doc.insertTable(1, 3, 3);
+    parentMap = buildParentMap(doc, tableId);
+  });
+
+  it('returns none when cursor is not in a table', () => {
+    const pos: DocPosition = { blockId: doc.document.blocks[0].id, offset: 0 };
+    expect(computeTableMergeContext(doc, parentMap, pos, null)).toEqual({ state: 'none' });
+  });
+
+  it('returns none for a single-cell cursor with no selection', () => {
+    const pos: DocPosition = { blockId: cellBlockId(doc, tableId, { rowIndex: 0, colIndex: 0 }), offset: 0 };
+    expect(computeTableMergeContext(doc, parentMap, pos, null).state).toBe('none');
+  });
+
+  it('returns canMerge when a 2x2 cell range is active', () => {
+    const pos: DocPosition = { blockId: cellBlockId(doc, tableId, { rowIndex: 0, colIndex: 0 }), offset: 0 };
+    const ctx = computeTableMergeContext(doc, parentMap, pos, {
+      anchor: pos,
+      focus: pos,
+      tableCellRange: {
+        blockId: tableId,
+        start: { rowIndex: 0, colIndex: 0 },
+        end: { rowIndex: 1, colIndex: 1 },
+      },
+    });
+    expect(ctx.state).toBe('canMerge');
+    if (ctx.state === 'canMerge') {
+      expect(ctx.tableBlockId).toBe(tableId);
+      expect(ctx.range.start).toEqual({ rowIndex: 0, colIndex: 0 });
+      expect(ctx.range.end).toEqual({ rowIndex: 1, colIndex: 1 });
+    }
+  });
+
+  it('returns none when the range covers exactly one cell (area 1)', () => {
+    const pos: DocPosition = { blockId: cellBlockId(doc, tableId, { rowIndex: 0, colIndex: 0 }), offset: 0 };
+    const ctx = computeTableMergeContext(doc, parentMap, pos, {
+      anchor: pos,
+      focus: pos,
+      tableCellRange: {
+        blockId: tableId,
+        start: { rowIndex: 0, colIndex: 0 },
+        end: { rowIndex: 0, colIndex: 0 },
+      },
+    });
+    expect(ctx.state).toBe('none');
+  });
+
+  it('returns canUnmerge when cursor is inside an existing merged cell', () => {
+    doc.mergeCells(tableId, { start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 1, colIndex: 1 } });
+    parentMap = buildParentMap(doc, tableId);
+    const pos: DocPosition = { blockId: cellBlockId(doc, tableId, { rowIndex: 0, colIndex: 0 }), offset: 0 };
+    const ctx = computeTableMergeContext(doc, parentMap, pos, null);
+    expect(ctx.state).toBe('canUnmerge');
+    if (ctx.state === 'canUnmerge') {
+      expect(ctx.cell).toEqual({ rowIndex: 0, colIndex: 0 });
+      expect(ctx.tableBlockId).toBe(tableId);
+    }
+  });
+
+  it('canMerge wins when cursor is in a merged cell and a range is also active', () => {
+    doc.mergeCells(tableId, { start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 1, colIndex: 1 } });
+    parentMap = buildParentMap(doc, tableId);
+    const pos: DocPosition = { blockId: cellBlockId(doc, tableId, { rowIndex: 0, colIndex: 0 }), offset: 0 };
+    const ctx = computeTableMergeContext(doc, parentMap, pos, {
+      anchor: pos,
+      focus: pos,
+      tableCellRange: {
+        blockId: tableId,
+        start: { rowIndex: 0, colIndex: 0 },
+        end: { rowIndex: 0, colIndex: 2 },
+      },
+    });
+    expect(ctx.state).toBe('canMerge');
+  });
+});

--- a/packages/frontend/src/app/docs/docs-table-context-menu.tsx
+++ b/packages/frontend/src/app/docs/docs-table-context-menu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { EditorAPI } from "@wafflebase/docs";
+import type { EditorAPI, TableMergeContext } from "@wafflebase/docs";
 import { BG_COLORS } from "@/components/formatting-colors";
 import {
   IconRowInsertTop,
@@ -8,6 +8,7 @@ import {
   IconColumnInsertRight,
   IconRowRemove,
   IconColumnRemove,
+  IconArrowsJoin,
   IconArrowsSplit,
   IconDropletOff,
   IconPalette,
@@ -36,6 +37,7 @@ export function DocsTableContextMenu({
 }: DocsTableContextMenuProps) {
   const [position, setPosition] = useState<MenuPosition | null>(null);
   const [showColors, setShowColors] = useState(false);
+  const [mergeCtx, setMergeCtx] = useState<TableMergeContext>({ state: 'none' });
   const menuRef = useRef<HTMLDivElement>(null);
 
   const handleContextMenu = useCallback(
@@ -43,6 +45,7 @@ export function DocsTableContextMenu({
       if (!editor?.isInTable()) return;
       e.preventDefault();
       setPosition({ x: e.clientX, y: e.clientY });
+      setMergeCtx(editor.getTableMergeContext());
       setShowColors(false);
     },
     [editor],
@@ -132,11 +135,26 @@ export function DocsTableContextMenu({
 
       <div className={sep} />
 
-      {/* Cell */}
-      <button className={item} onClick={act(() => editor.splitTableCell())}>
-        <IconArrowsSplit size={iconSize} className="text-muted-foreground" />
-        Split cell
-      </button>
+      {/* Cell merge / unmerge — single hybrid slot */}
+      {mergeCtx.state === 'canUnmerge' ? (
+        <button className={item} onClick={act(() => editor.splitTableCell())}>
+          <IconArrowsSplit size={iconSize} className="text-muted-foreground" />
+          Unmerge cells
+        </button>
+      ) : (
+        <button
+          className={`${item} disabled:opacity-50 disabled:pointer-events-none`}
+          disabled={mergeCtx.state !== 'canMerge'}
+          onClick={
+            mergeCtx.state === 'canMerge'
+              ? act(() => editor.mergeTableCells(mergeCtx.range))
+              : undefined
+          }
+        >
+          <IconArrowsJoin size={iconSize} className="text-muted-foreground" />
+          Merge cells
+        </button>
+      )}
       <button
         className={item}
         onClick={(e) => {

--- a/packages/frontend/src/app/docs/docs-table-context-menu.tsx
+++ b/packages/frontend/src/app/docs/docs-table-context-menu.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import type { EditorAPI, TableMergeContext } from "@wafflebase/docs";
 import { BG_COLORS } from "@/components/formatting-colors";
 import {
@@ -80,6 +86,29 @@ export function DocsTableContextMenu({
       document.removeEventListener("keydown", handleKey);
     };
   }, [position, close]);
+
+  // Keep the menu inside the viewport. Measures after render and shifts
+  // left/up if the menu would overflow the right/bottom edges. Re-runs
+  // when `showColors` toggles because that changes the menu's height.
+  useLayoutEffect(() => {
+    if (!position || !menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    const vpW = window.innerWidth;
+    const vpH = window.innerHeight;
+    const PAD = 4;
+
+    let x = position.x;
+    let y = position.y;
+    if (x + rect.width + PAD > vpW) {
+      x = Math.max(PAD, vpW - rect.width - PAD);
+    }
+    if (y + rect.height + PAD > vpH) {
+      y = Math.max(PAD, vpH - rect.height - PAD);
+    }
+    if (x !== position.x || y !== position.y) {
+      setPosition({ x, y });
+    }
+  }, [position, showColors]);
 
   if (!position || !editor) return null;
 

--- a/packages/frontend/src/app/docs/docs-table-context-menu.tsx
+++ b/packages/frontend/src/app/docs/docs-table-context-menu.tsx
@@ -90,20 +90,27 @@ export function DocsTableContextMenu({
   // Keep the menu inside the viewport. Measures after render and shifts
   // left/up if the menu would overflow the right/bottom edges. Re-runs
   // when `showColors` toggles because that changes the menu's height.
+  //
+  // Uses offsetWidth/offsetHeight (not getBoundingClientRect) because the
+  // menu has a zoom-in CSS animation — during the animation the bounding
+  // rect reports the scaled size, which would leave the bottom clipped
+  // after the animation finishes.
   useLayoutEffect(() => {
-    if (!position || !menuRef.current) return;
-    const rect = menuRef.current.getBoundingClientRect();
+    const el = menuRef.current;
+    if (!position || !el) return;
+    const width = el.offsetWidth;
+    const height = el.offsetHeight;
     const vpW = window.innerWidth;
     const vpH = window.innerHeight;
-    const PAD = 4;
+    const PAD = 8;
 
     let x = position.x;
     let y = position.y;
-    if (x + rect.width + PAD > vpW) {
-      x = Math.max(PAD, vpW - rect.width - PAD);
+    if (x + width + PAD > vpW) {
+      x = Math.max(PAD, vpW - width - PAD);
     }
-    if (y + rect.height + PAD > vpH) {
-      y = Math.max(PAD, vpH - rect.height - PAD);
+    if (y + height + PAD > vpH) {
+      y = Math.max(PAD, vpH - height - PAD);
     }
     if (x !== position.x || y !== position.y) {
       setPosition({ x, y });


### PR DESCRIPTION
## Summary

- Expose merge/unmerge as a first-class table context-menu action with
  drag-time auto-expansion over existing merged cells.
- Make the docs editor handle merged cells that span a page break
  correctly for rendering, cursor, click, selection highlight, and
  ruler. Every consumer now calls a shared `computeMergedCellLineLayouts`
  helper so pagination math stays consistent.
- A handful of unrelated but related bugs that surfaced while testing:
  context menu clipping near the viewport edge, resize cursor flashing
  on borders inside a merged cell, and a `??` vs `||` color fallback
  that made table text on page 2 pick up the stale selection fillStyle.

## What the context menu does now

- New hybrid slot in `docs-table-context-menu.tsx`: shows "Merge cells"
  (enabled when a ≥ 2-cell range is active, disabled for a single
  cell) or "Unmerge cells" when the cursor is inside an existing merge.
  Range presence wins, so users can grow an existing merge by
  selecting a larger range.
- `Doc.mergeCells` / `Doc.splitCell` were already in place; this PR adds
  the UI entry point and a pure `computeTableMergeContext` helper that
  the frontend calls once per menu open.
- `expandCellRangeForMerges` runs a fixed-point walk over any merged
  cell the drag selection touches, so the highlight previews the exact
  area that will be merged before the user opens the menu. This
  expansion is applied at both write time (drag/Shift+Arrow) and read
  time (peer cursors, programmatic ranges) via `normalizeCellRange`.

## Merged cells across page breaks

When a merged cell's `rowSpan` crosses a page break, every part of the
editor needs to agree on which row each line belongs to and where that
row lives on each page. The PR introduces `computeMergedCellLineLayouts`
in `table-renderer.ts` and uses it everywhere:

| Concern | Before | After |
|---|---|---|
| Text rendering | Lines drawn twice (once per page) with canvas clip, producing duplicates near the break | Per-line owner row filters + shift so each line draws once with fresh top padding on its page |
| Borders / background | One rect anchored to row 0, half-clipped per page | Rect sized to the rows physically on the current page — each slice is a complete 4-sided cell |
| Cursor placement | Anchored to the cell's top-left row's PageLine; Arrow Down on page 1 landed in the empty space below row 0 | Finds the target line's owner row via the same helper and anchors to that row's PageLine |
| Click → offset | Single `cellPageY` from row 0; clicking "2" on page 2 selected "3" | Each line's absolute Y is reconstructed from its owner row's PageLine |
| Click → cell | `localY = mouseY - row 0 Y` for all pages; second-page clicks always fell through to the last row | Per-page row band in `resolveTableFromMouse`; rows only hit-test for the page the cursor is over |
| Cell-range highlight | One big rect extending past row 0's bottom into empty space | Split into per-page segments by walking the rowYMap |
| Cell-internal selection | `midY += lineHeight` loop painted middle lines into empty space on page 1 | Iterate `cell.lines[startIdx..endIdx]`, position each via line layouts |
| Resize cursor | Fires on row boundaries even when both sides share a merge or the border is on another page | `detectTableBorder` takes `pageFirstRow`/`pageLastRow` and `tableData` so merge-swallowed or off-page borders are skipped |
| Ruler target page | `findPageForPosition` returned undefined for cell-internal block IDs, ruler always drew on page 1 | Use `cursorPixel.y` to pick the page; also resolves the block style through the parent map |

## Other fixes

- **Context menu viewport clamp** (`docs-table-context-menu.tsx`): uses
  `useLayoutEffect` + `offsetWidth`/`offsetHeight` so the clamp isn't
  thrown off by the `animate-in zoom-in-95` CSS transform. Bumped the
  viewport padding to 8 px.
- **Resize cursor over merged cells** (`table-resize.ts`): the
  merge-swallowed border detection now takes the page's visible row
  range so hover areas on pages where the row isn't laid out don't
  trigger `row-resize`.
- **Cell-range highlight width for horizontal merges**
  (`selection.ts`): uses `LayoutTableCell.width` (which already sums
  spanned columns) instead of a single column's pixel width.
- **`??` → `||` for inline text color** (`table-renderer.ts`): empty
  color strings now fall through to `Theme.defaultColor`, matching
  `doc-canvas.ts`'s `renderRun`. Previously page 2's table text
  inherited the stale selection fillStyle.

## Design + plan

- Design: \`docs/design/docs/docs-tables.md\` — new "Cell Range
  Normalization" and "Cell Merge UX" sections describe the shared
  helper, hybrid slot, and expansion loop.
- Task files: \`docs/tasks/active/20260411-docs-table-merge-ux-todo.md\`
  and \`20260411-docs-table-merge-ux-lessons.md\`. Lessons captures the
  pagination follow-ups, the `??` vs `||` pitfall, and the dist-import
  boundary that burned the first manual smoke test.

## Test plan

- \`pnpm verify:fast\` — 490/490 docs tests passing, lint + architecture
  checks clean.
- Manual smoke in dev (multi-page 3×3 table with first column 3-row merge,
  content \`1\\n2\\n3\`):
  - [x] Drag cells → "Merge cells" enabled, merges correctly.
  - [x] Right-click a merged cell → "Unmerge cells", restores cells.
  - [x] Single non-merged cell right-click → "Merge cells" disabled.
  - [x] Drag range touching an existing merge → highlight auto-expands
        to cover the full merge before the menu opens.
  - [x] 1+2 row split across pages → page 1 shows "1", page 2 shows
        "2\\n3" as a complete cell with top padding.
  - [x] 2+1 row split → page 1 shows "1\\n2", page 2 shows "3".
  - [x] Click on page 2 cell → ruler updates to page 2.
  - [x] Click after "2" in page 2's merged cell → cursor lands after
        "2", not after "3".
  - [x] Hover empty space below row 0 on page 1 → no resize cursor.
  - [x] Hover inside a merged cell's centre → no resize cursor.
  - [x] Context menu at the bottom of the viewport → clamped so
        "Delete table" and its padding are visible.
  - [x] Cell-internal Cmd+A + cell-range selection across the page
        break → highlights only the text, no empty-space bleed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merge/Unmerge combined action added to the table context menu.

* **Improvements**
  * More accurate selection, cursor, rendering and hover previews for merged cells across paginated pages; selection highlights and copy behavior better reflect merged boundaries.

* **Documentation**
  * Added design/spec, UX lessons, and a multi-step implementation plan for table merge behavior.

* **Tests**
  * New tests covering merge behavior and cell-range expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->