### PR TITLE
Fix DOCX image import and render images inside table cells

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -25,7 +25,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 121
+- Archived task count: 122
 - Archive index: [archive/README.md](./archive/README.md)
 
 Latest active task: docx table merge gaps (2026-04-11)

--- a/docs/tasks/archive/2026/04/20260412-docx-image-import-render-lessons.md
+++ b/docs/tasks/archive/2026/04/20260412-docx-image-import-render-lessons.md
@@ -1,0 +1,61 @@
+# Lessons — DOCX image import + table-cell image render
+
+Date: 2026-04-12
+
+## 1. JSZip blobs carry no MIME type
+
+`jszip.file(path).async('blob')` returns a `Blob` with `type === ''`.
+When such a blob is appended to `FormData` and POSTed, multipart
+`Content-Type` defaults to `application/octet-stream` — which the backend
+image allowlist rejects outright. Any producer code that forwards a JSZip
+blob to an upload endpoint must repackage it with a concrete MIME derived
+from a trusted source (here: the `.rels` target extension inside the
+`.docx`).
+
+**Apply when**: touching any code that reads media out of a zip-based
+container (`.docx`, `.xlsx`, `.odt`, `.epub`, `.zip` attachments) and
+hands it off to anything that sniffs Content-Type.
+
+## 2. Two rendering paths means two image branches
+
+`doc-canvas.renderRun()` had a proper `if (style.image)` branch that
+called `drawImage`, but `table-renderer.renderTableContent()` — a parallel
+code path for the *same* layout run type — did not. Image inlines were
+silently painted as the ORC placeholder glyph (`\uFFFC`). Tests on the
+body path were green, the regression was invisible until a real `.docx`
+with an in-table image showed up.
+
+**Apply when**: adding a new inline style (image, embed, chart, equation,
+sticker) to the doc model. Grep for every place that iterates
+`line.runs` and branches on `run.inline.style.*` — there are currently
+**two** such loops (body + table). Either consolidate them, or patch both
+at once and add a regression test that exercises the style inside a
+table cell.
+
+## 3. Module-local caches silently fork behavior
+
+`getOrLoadImage` + `imageCache` started as a `doc-canvas.ts` module-local
+helper. That was fine when only one file drew images; as soon as a second
+renderer needed it, "just duplicate the helper" would have produced two
+disjoint caches and double the network load. Extracting it to
+`view/image-cache.ts` before wiring the second caller kept the cache
+coherent.
+
+**Apply when**: a module-level singleton (cache, registry, pool) is about
+to be referenced by a second file. Move it to a shared module *first*,
+then import from both sites. Don't let the "quick copy" tempt you.
+
+## 4. Puppeteer scroll-by-guessing is fine for one-off verification
+
+For this bug I needed to eyeball three images deep inside a 36-block,
+20-row-table document. Rather than wiring an API to ask the editor "what
+scrollTop shows block[5] row 15?", I dumped `doc.blocks[i].type` + the
+first-column labels of the target table, inferred the right region, and
+scrolled the viewport in 400-800px steps. Total time ~2 min — much faster
+than instrumenting the layout.
+
+**Apply when**: you need to visually verify a render bug in a long doc.
+Dump the high-level structure first (block types, row labels, block[i]
+offsets if available), use that to steer the scroll, and take
+screenshots at each candidate position. Don't invest in a "find block in
+layout" helper unless you'll reuse it.

--- a/docs/tasks/archive/2026/04/20260412-docx-image-import-render-todo.md
+++ b/docs/tasks/archive/2026/04/20260412-docx-image-import-render-todo.md
@@ -8,7 +8,7 @@ Two distinct bugs surfaced while importing `~/Downloads/form2.docx` on the
 local dev server:
 
 1. **HTTP 400 from `/images` on every embedded image.**
-   ```
+   ```text
    Unsupported file type: application/octet-stream
    ```
 2. **Images imported via the pending-import path were missing from the

--- a/docs/tasks/archive/2026/04/20260412-docx-image-import-render-todo.md
+++ b/docs/tasks/archive/2026/04/20260412-docx-image-import-render-todo.md
@@ -1,0 +1,94 @@
+# DOCX import: image upload 400 + images not rendering in table cells
+
+Date: 2026-04-12
+
+## Problem
+
+Two distinct bugs surfaced while importing `~/Downloads/form2.docx` on the
+local dev server:
+
+1. **HTTP 400 from `/images` on every embedded image.**
+   ```
+   Unsupported file type: application/octet-stream
+   ```
+2. **Images imported via the pending-import path were missing from the
+   editor.** Text flowed as if the images were there, but the picture slots
+   were blank.
+
+Both reproduce with any `.docx` that contains inline images inside a table —
+`form2.docx` has three PNGs nested deep in a single cell of its main
+"신청 프로젝트 정보" table.
+
+## Root causes
+
+### 1. JSZip blob has no MIME type
+
+`DocxImporter.uploadImages()` extracted image bytes via
+`jszip.file(path).async('blob')`. JSZip produces a `Blob` with `type === ''`,
+so when the frontend `docxImageUploader` posts it via `FormData`, the
+multipart `Content-Type` defaults to `application/octet-stream`.
+`ImageService.upload()` only accepts `image/png|jpeg|gif|webp` and rejects
+the upload with `BadRequestException` → HTTP 400.
+
+Confirmed end-to-end with a direct `curl` against `/images` using a local
+session cookie — `type=application/octet-stream` returns 400, `type=image/png`
+returns 201.
+
+### 2. Table renderer had no image branch
+
+`renderTableContent()` in `packages/docs/src/view/table-renderer.ts` walked
+every run in a cell line and unconditionally called
+`ctx.fillText(run.text, …)`. Image inlines carry `run.text === '\uFFFC'`
+(Object Replacement Character) plus `run.imageHeight`, so the picture was
+never drawn — only the ORC placeholder was painted. The body paragraph
+renderer in `doc-canvas.ts:648` already handled this via `drawImage`; the
+table renderer was simply missing the mirror branch.
+
+`getOrLoadImage` / `imageCache` / `pendingImageCallbacks` lived as
+module-locals inside `doc-canvas.ts`, so the table renderer had no way to
+share the cache even if it had tried.
+
+## Fix
+
+### Image upload
+
+`packages/docs/src/import/docx-importer.ts`
+- Add an `EXT_TO_IMAGE_MIME` map (`png → image/png`, `jpg|jpeg → image/jpeg`,
+  `gif → image/gif`, `webp → image/webp`).
+- In `uploadImages()`, wrap the raw JSZip blob with
+  `new Blob([raw], { type: mime })` when the extension is recognised; fall
+  through to the raw blob otherwise so unknown parts keep surfacing the
+  backend error instead of silently sending a bad MIME.
+
+### Image rendering in table cells
+
+`packages/docs/src/view/image-cache.ts` **(new)**
+- Extracted shared `getOrLoadImage`, `imageCache`, `pendingImageCallbacks`
+  from `doc-canvas.ts` so both renderers share a single load cache.
+
+`packages/docs/src/view/doc-canvas.ts`
+- Import `getOrLoadImage` from the shared module (remove the private copy).
+- Pass `this.requestRender ?? undefined` into `renderTableContent`.
+
+`packages/docs/src/view/table-renderer.ts`
+- Accept a `requestRender?: () => void` parameter on `renderTableContent`.
+- Add an image branch at the top of the per-run loop: bottom-align the
+  (possibly scaled) image to the line and call `ctx.drawImage`, mirroring
+  the body path in `doc-canvas.ts`.
+
+## Tests
+
+- `packages/docs/test/import/docx-importer.test.ts` — asserts the uploader
+  receives a `Blob` with `type === 'image/png'` and the correct filename.
+- `packages/docs/test/view/table-renderer.test.ts` — asserts an image run
+  is never drawn via `fillText(ORC)` and that `drawImage` is never called
+  while the image is still loading (entry point for the cache).
+
+## Verification
+
+- [x] `pnpm --filter @wafflebase/docs test` (491 → 493, two new cases)
+- [x] `pnpm verify:fast` → PASS
+- [x] Manual end-to-end against `form2.docx` on local dev server:
+  - 3 PNGs upload with `type="image/png"` → HTTP 201
+  - Yorkie architecture diagram, CodePair screenshot, and Wafflebase demo
+    all render in their table cell at the correct size/position.

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,13 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 121
+Total archived tasks: 122
 
-## 2026/04 (7 tasks)
+## 2026/04 (8 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| docx image import render (2026-04-12) | [20260412-docx-image-import-render-todo.md](./2026/04/20260412-docx-image-import-render-todo.md) | [20260412-docx-image-import-render-lessons.md](./2026/04/20260412-docx-image-import-render-lessons.md) |
 | docs table merge ux (2026-04-11) | [20260411-docs-table-merge-ux-todo.md](./2026/04/20260411-docs-table-merge-ux-todo.md) | [20260411-docs-table-merge-ux-lessons.md](./2026/04/20260411-docs-table-merge-ux-lessons.md) |
 | release v0.3.2 (2026-04-11) | [20260411-release-v0.3.2-todo.md](./2026/04/20260411-release-v0.3.2-todo.md) | - |
 | v0.3.2 smoke test fixes (2026-04-11) | [20260411-v0.3.2-smoke-test-fixes-todo.md](./2026/04/20260411-v0.3.2-smoke-test-fixes-todo.md) | [20260411-v0.3.2-smoke-test-fixes-lessons.md](./2026/04/20260411-v0.3.2-smoke-test-fixes-lessons.md) |

--- a/packages/docs/src/import/docx-importer.ts
+++ b/packages/docs/src/import/docx-importer.ts
@@ -8,6 +8,19 @@ import { emusToPx } from './units.js';
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
 
+/**
+ * MIME types the backend image endpoint accepts, keyed by the lowercase
+ * file extension recorded in a .docx .rels target. Used by `uploadImages`
+ * to repackage JSZip's untyped blob before posting to `/images`.
+ */
+const EXT_TO_IMAGE_MIME: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+};
+
 export type ImageUploader = (blob: Blob, filename: string) => Promise<string>;
 
 type ResolvedImage = { src: string; width: number; height: number };
@@ -511,8 +524,15 @@ export class DocxImporter {
       const file = zip.file(path);
       if (!file) continue;
 
-      const data = await file.async('blob');
-      const ext = rel.target.split('.').pop() || 'png';
+      // JSZip returns a Blob with an empty `type`. When posted via FormData
+      // the multipart Content-Type defaults to application/octet-stream,
+      // which the backend image endpoint rejects with 400. Repackage the
+      // bytes with a MIME derived from the .rels target extension so the
+      // upload carries a concrete image/* type.
+      const raw = await file.async('blob');
+      const ext = (rel.target.split('.').pop() || 'png').toLowerCase();
+      const mime = EXT_TO_IMAGE_MIME[ext];
+      const data = mime ? new Blob([raw], { type: mime }) : raw;
       const filename = `${rId}.${ext}`;
       const url = await uploader(data, filename);
 

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -9,80 +9,7 @@ import { computeListCounters } from './layout.js';
 import { Theme, buildFont, ptToPx } from './theme.js';
 import { drawPeerCaret, drawPeerLabel } from './peer-cursor.js';
 import { renderTableBackgrounds, renderTableContent } from './table-renderer.js';
-
-/**
- * Shared cache of loaded inline images, keyed by src URL. Populated lazily
- * on first render and reused across all DocCanvas instances so that
- * navigating between documents does not re-fetch images.
- */
-const imageCache = new Map<string, HTMLImageElement>();
-
-/**
- * Callbacks waiting on in-flight image loads, keyed by src. When an image
- * load kicks off from one DocCanvas render, any subsequent call from a
- * different DocCanvas instance (or the same instance on a re-render)
- * subscribes here so that every interested caller gets notified when the
- * load resolves. Without this, the second caller's onLoad would be
- * silently dropped and its canvas would never repaint with the image.
- */
-const pendingImageCallbacks = new Map<string, Set<() => void>>();
-
-/**
- * Return a loaded HTMLImageElement for the given src, or null if it is
- * still loading. On first encounter, kicks off an async load and invokes
- * `onLoad` once the image is ready so the caller can trigger a re-render.
- * When the image is already loading from a previous call, the caller is
- * subscribed to the in-flight load so its onLoad still fires.
- */
-function getOrLoadImage(
-  src: string,
-  onLoad: () => void,
-): HTMLImageElement | null {
-  const cached = imageCache.get(src);
-  if (cached) {
-    if (cached.complete && cached.naturalWidth > 0) return cached;
-    // Still loading (or failed with naturalWidth === 0). Subscribe only
-    // while the image is not yet complete so that in-flight loads notify
-    // every waiting callback.
-    if (!cached.complete) {
-      let callbacks = pendingImageCallbacks.get(src);
-      if (!callbacks) {
-        callbacks = new Set();
-        pendingImageCallbacks.set(src, callbacks);
-      }
-      callbacks.add(onLoad);
-    }
-    return null;
-  }
-
-  const img = new Image();
-  imageCache.set(src, img);
-  const callbacks = new Set<() => void>([onLoad]);
-  pendingImageCallbacks.set(src, callbacks);
-
-  img.onload = () => {
-    const waiting = pendingImageCallbacks.get(src);
-    pendingImageCallbacks.delete(src);
-    if (waiting) {
-      for (const cb of waiting) {
-        try {
-          cb();
-        } catch {
-          // Ignore listener errors so that one failing subscriber does
-          // not block notifications for the rest.
-        }
-      }
-    }
-  };
-  img.onerror = () => {
-    // Broken image is now cached; subsequent draws will skip it via the
-    // `naturalWidth > 0` guard above. Drop any pending callbacks so they
-    // are not retained forever.
-    pendingImageCallbacks.delete(src);
-  };
-  img.src = src;
-  return null;
-}
+import { getOrLoadImage } from './image-cache.js';
 
 /**
  * Convert a peer cursor color (hex) to a translucent selection fill.
@@ -539,6 +466,7 @@ export class DocCanvas {
                 range.renderStartRow,
                 range.endRowIndex,
                 range.pageStartRow,
+                this.requestRender ?? undefined,
               );
             }
             continue;

--- a/packages/docs/src/view/image-cache.ts
+++ b/packages/docs/src/view/image-cache.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared cache of loaded inline images for the Canvas renderer. Populated
+ * lazily on first render and reused across every DocCanvas / table-renderer
+ * invocation so switching documents or scrolling does not re-fetch images.
+ */
+const imageCache = new Map<string, HTMLImageElement>();
+
+/**
+ * Callbacks waiting on in-flight image loads, keyed by src. When an image
+ * load kicks off from one render, any subsequent call from another render
+ * path (body renderer, table renderer, a second DocCanvas instance)
+ * subscribes here so every interested caller gets notified when the load
+ * resolves. Without this, later callers' onLoad would be silently dropped
+ * and their canvas would never repaint with the image.
+ */
+const pendingImageCallbacks = new Map<string, Set<() => void>>();
+
+/**
+ * Return a loaded HTMLImageElement for the given src, or null if it is
+ * still loading. On first encounter, kicks off an async load and invokes
+ * `onLoad` once the image is ready so the caller can trigger a re-render.
+ * When the image is already loading from a previous call, the caller is
+ * subscribed to the in-flight load so its onLoad still fires.
+ */
+export function getOrLoadImage(
+  src: string,
+  onLoad: () => void,
+): HTMLImageElement | null {
+  const cached = imageCache.get(src);
+  if (cached) {
+    if (cached.complete && cached.naturalWidth > 0) return cached;
+    // Still loading (or failed with naturalWidth === 0). Subscribe only
+    // while the image is not yet complete so that in-flight loads notify
+    // every waiting callback.
+    if (!cached.complete) {
+      let callbacks = pendingImageCallbacks.get(src);
+      if (!callbacks) {
+        callbacks = new Set();
+        pendingImageCallbacks.set(src, callbacks);
+      }
+      callbacks.add(onLoad);
+    }
+    return null;
+  }
+
+  const img = new Image();
+  imageCache.set(src, img);
+  const callbacks = new Set<() => void>([onLoad]);
+  pendingImageCallbacks.set(src, callbacks);
+
+  img.onload = () => {
+    const waiting = pendingImageCallbacks.get(src);
+    pendingImageCallbacks.delete(src);
+    if (waiting) {
+      for (const cb of waiting) {
+        try {
+          cb();
+        } catch {
+          // Ignore listener errors so that one failing subscriber does
+          // not block notifications for the rest.
+        }
+      }
+    }
+  };
+  img.onerror = () => {
+    // Broken image is now cached; subsequent draws will skip it via the
+    // `naturalWidth > 0` guard above. Drop any pending callbacks so they
+    // are not retained forever.
+    pendingImageCallbacks.delete(src);
+  };
+  img.src = src;
+  return null;
+}

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -2,6 +2,7 @@ import type { LayoutTable, LayoutTableCell } from './table-layout.js';
 import type { TableData, BorderStyle } from '../model/types.js';
 import { DEFAULT_BORDER_STYLE, LIST_INDENT_PX, UNORDERED_MARKERS } from '../model/types.js';
 import { Theme, buildFont, ptToPx } from './theme.js';
+import { getOrLoadImage } from './image-cache.js';
 
 /**
  * Per-line placement for a merged cell: which spanned row the line
@@ -169,6 +170,7 @@ export function renderTableContent(
   startRow = 0,
   endRow?: number,
   pageStartRow?: number,
+  requestRender?: () => void,
 ): void {
   const { rows } = tableData;
   const { cells, columnXOffsets, columnPixelWidths, rowYOffsets, rowHeights } = tableLayout;
@@ -259,6 +261,27 @@ export function renderTableContent(
           const fontSize = style.fontSize ?? Theme.defaultFontSize;
           const fontSizePx = ptToPx(fontSize);
 
+          const runX = cellX + padding + run.x;
+          const runLineY = lineAbsoluteY;
+
+          // Image inlines carry the Object Replacement Character (￼) in
+          // `run.text`; drawing them via fillText would paint that glyph
+          // instead of the picture. Mirror the image path used for body
+          // paragraphs in doc-canvas: bottom-align the (possibly scaled)
+          // image to the line and call drawImage once it finishes loading.
+          if (style.image) {
+            const drawHeight = run.imageHeight ?? line.height;
+            const imgX = Math.round(runX);
+            const imgY = Math.round(runLineY + line.height - drawHeight);
+            const img = getOrLoadImage(style.image.src, () => {
+              requestRender?.();
+            });
+            if (img) {
+              ctx.drawImage(img, imgX, imgY, run.width, drawHeight);
+            }
+            continue;
+          }
+
           ctx.font = buildFont(
             style.fontSize,
             style.fontFamily,
@@ -268,8 +291,6 @@ export function renderTableContent(
           ctx.fillStyle = style.color || Theme.defaultColor;
           ctx.textBaseline = 'alphabetic';
 
-          const runX = cellX + padding + run.x;
-          const runLineY = lineAbsoluteY;
           const baselineY = runLineY + line.height * 0.75;
 
           // Text background highlight

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -571,6 +571,60 @@ describe('DocxImporter', () => {
     expect(inline!.style.image!.height).toBe(48);
   });
 
+  it('should pass a typed image Blob to the uploader', async () => {
+    // Regression for DOCX import failing with 400 from /images because the
+    // Blob returned by JSZip has an empty `type`, which FormData then sends
+    // as application/octet-stream. The importer must repackage the bytes
+    // with a MIME derived from the .rels target extension.
+    const drawingXml = `
+      <w:r>
+        <w:drawing>
+          <wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+            <wp:extent cx="914400" cy="457200"/>
+            <wp:docPr id="1" name="Picture 1"/>
+            <a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                  <pic:blipFill>
+                    <a:blip xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:embed="rId5"/>
+                  </pic:blipFill>
+                </pic:pic>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </w:r>`;
+    const relsXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+      </Relationships>`;
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+      0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
+      0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+      0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+    const buffer = await createMinimalDocx(
+      `<w:p>${drawingXml}</w:p>`,
+      {
+        relsXml,
+        extraFiles: { 'word/media/image1.png': pngBytes },
+      },
+    );
+
+    const seen: Array<{ type: string; filename: string }> = [];
+    await DocxImporter.import(buffer, async (blob, filename) => {
+      seen.push({ type: blob.type, filename });
+      return 'https://example.com/image1.png';
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].type).toBe('image/png');
+    expect(seen[0].filename).toBe('rId5.png');
+  });
+
   it('should resolve stacked vMerge groups in the same column', async () => {
     // Column 0: rows 0-1 merged, row 2 standalone, rows 3-4 merged.
     const buffer = await createMinimalDocx(`

--- a/packages/docs/test/view/table-renderer.test.ts
+++ b/packages/docs/test/view/table-renderer.test.ts
@@ -252,10 +252,13 @@ describe('renderTableContent image inlines', () => {
     }
   });
 
-  it('invokes requestRender once while the image is still loading', () => {
-    // Under jsdom the image never finishes loading synchronously, so
-    // drawImage stays uncalled and the renderer schedules a re-render so
-    // the canvas can repaint once the Image fires onload.
+  it('does not synchronously draw or call requestRender while the image is loading', () => {
+    // Under jsdom the image never finishes loading during the render
+    // call, so drawImage stays uncalled and requestRender is only
+    // invoked later from the Image's onload. Synchronously during the
+    // renderTableContent call, neither should fire — and the absence of
+    // a fillText(ORC) call in the test above guarantees the image
+    // branch was actually taken rather than falling through to text.
     const { ctx, drawImage } = makeRecordingCtx();
     const { tableData, layout } = makeImageCellTable();
     const requestRender = vi.fn();
@@ -270,10 +273,8 @@ describe('renderTableContent image inlines', () => {
       undefined,
       requestRender,
     );
-    // The image never loads in this environment, so drawImage must stay
-    // at zero — but the cache must have been consulted, which is the
-    // entry point that replaces the buggy fillText path.
     expect(drawImage).not.toHaveBeenCalled();
+    expect(requestRender).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/docs/test/view/table-renderer.test.ts
+++ b/packages/docs/test/view/table-renderer.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -23,10 +24,12 @@ function makeRecordingCtx(): {
   fillRect: ReturnType<typeof vi.fn>;
   fillText: ReturnType<typeof vi.fn>;
   stroke: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
 } {
   const fillRect = vi.fn();
   const fillText = vi.fn();
   const stroke = vi.fn();
+  const drawImage = vi.fn();
   const ctx = {
     font: '',
     fillStyle: '',
@@ -43,8 +46,9 @@ function makeRecordingCtx(): {
     fillRect,
     fillText,
     stroke,
+    drawImage,
   } as unknown as CanvasRenderingContext2D;
-  return { ctx, fillRect, fillText, stroke };
+  return { ctx, fillRect, fillText, stroke, drawImage };
 }
 
 function makeTable(): { tableData: TableData; layout: LayoutTable } {
@@ -160,6 +164,116 @@ describe('renderTableContent', () => {
     // backgrounds would also be fillRects — this test uses plain runs
     // without backgrounds, so fillRect should stay at zero.
     expect(fillRect).not.toHaveBeenCalled();
+  });
+});
+
+describe('renderTableContent image inlines', () => {
+  // Regression: inline image runs inside a table cell were rendered with
+  // fillText(run.text) where `run.text` is the Object Replacement Character
+  // (U+FFFC), so the picture was never painted — only a blank placeholder
+  // glyph. Body paragraphs in doc-canvas handled this via drawImage; the
+  // table renderer must do the same.
+  const ORC = '\uFFFC';
+
+  function makeImageCellTable(): { tableData: TableData; layout: LayoutTable } {
+    const imageStyle = {
+      image: { src: 'https://example.invalid/cell-image.png', width: 60, height: 20 },
+    };
+    const tableData: TableData = {
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [
+                {
+                  id: 'b1',
+                  type: 'paragraph',
+                  inlines: [{ text: ORC, style: imageStyle }],
+                  style: { ...DEFAULT_BLOCK_STYLE },
+                },
+              ],
+              style: { ...DEFAULT_CELL_STYLE },
+            },
+          ],
+        },
+      ],
+      columnWidths: [1],
+    };
+    const layout: LayoutTable = {
+      cells: [
+        [
+          {
+            lines: [
+              {
+                y: 0,
+                height: 20,
+                width: 60,
+                runs: [
+                  {
+                    inline: { text: ORC, style: imageStyle },
+                    text: ORC,
+                    x: 0,
+                    width: 60,
+                    inlineIndex: 0,
+                    charStart: 0,
+                    charEnd: 1,
+                    charOffsets: [60],
+                    imageHeight: 20,
+                  },
+                ],
+              },
+            ],
+            blockBoundaries: [0],
+            width: 60,
+            height: 20,
+            merged: false,
+          },
+        ],
+      ],
+      columnXOffsets: [0],
+      columnPixelWidths: [80],
+      rowYOffsets: [0],
+      rowHeights: [28],
+      totalWidth: 80,
+      totalHeight: 28,
+      blockParentMap: new Map(),
+    };
+    return { tableData, layout };
+  }
+
+  it('never calls fillText with the ORC placeholder for image runs', () => {
+    const { ctx, fillText } = makeRecordingCtx();
+    const { tableData, layout } = makeImageCellTable();
+    renderTableContent(ctx, tableData, layout, 0, 0);
+    // The regression: before the fix, this was exactly one fillText(ORC)
+    // call per image inline.
+    for (const call of fillText.mock.calls) {
+      expect(call[0]).not.toBe(ORC);
+    }
+  });
+
+  it('invokes requestRender once while the image is still loading', () => {
+    // Under jsdom the image never finishes loading synchronously, so
+    // drawImage stays uncalled and the renderer schedules a re-render so
+    // the canvas can repaint once the Image fires onload.
+    const { ctx, drawImage } = makeRecordingCtx();
+    const { tableData, layout } = makeImageCellTable();
+    const requestRender = vi.fn();
+    renderTableContent(
+      ctx,
+      tableData,
+      layout,
+      0,
+      0,
+      undefined,
+      undefined,
+      undefined,
+      requestRender,
+    );
+    // The image never loads in this environment, so drawImage must stay
+    // at zero — but the cache must have been consulted, which is the
+    // entry point that replaces the buggy fillText path.
+    expect(drawImage).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Importing a `.docx` with embedded images hit two separate bugs that together made image-bearing files unusable in the docs editor. `~/Downloads/form2.docx` reproduced both on the local dev server — three PNGs nested inside the main "신청 프로젝트 정보" table were invisible after import.

- **HTTP 400 from `/images` on every embedded image.** `DocxImporter.uploadImages()` handed JSZip's untyped `Blob` (type `''`) straight to the uploader. `FormData` then sent the multipart part as `application/octet-stream`, which `ImageService.upload()` rejects against its `png/jpeg/gif/webp` allowlist. The importer now repackages the bytes with a MIME derived from the `.rels` target extension before calling the uploader.
- **Images inside table cells never rendered.** `renderTableContent()` unconditionally called `fillText(run.text)` on every run — including image runs whose `run.text` is the Object Replacement Character (`\uFFFC`). The body path in `doc-canvas` handled this via `drawImage`; the table path was simply missing the mirror branch. Extracted the shared `imageCache` / `getOrLoadImage` into `packages/docs/src/view/image-cache.ts` so both renderers share a single load cache, and taught `renderTableContent` to bottom-align image runs and call `drawImage`, scheduling a repaint via `requestRender` once the load resolves.

## Test plan

- [x] `pnpm --filter @wafflebase/docs test` — 491 → 493 (two new regression cases)
- [x] `pnpm verify:fast`
- [x] Manual end-to-end against `form2.docx` on local dev server:
  - 3 PNGs upload with `type="image/png"` → HTTP 201
  - Yorkie architecture diagram, CodePair README screenshot, and Wafflebase demo all render inside the correct cell at the correct size/position.

## Regression tests

- `packages/docs/test/import/docx-importer.test.ts` — asserts the uploader receives a `Blob` with `type === 'image/png'` and the correct filename.
- `packages/docs/test/view/table-renderer.test.ts` — asserts an image run is never drawn via `fillText(ORC)` and that `drawImage` is never called while the image is still loading (entry point for the cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved DOCX image import so uploaded images carry proper image MIME types.

* **Bug Fixes**
  * Table-cell images now render instead of placeholder glyphs.
  * Image caching unified to prevent duplicate loads and inconsistent renderer behavior.

* **Documentation**
  * Added lessons and a TODO guide capturing findings and verification steps for DOCX image import and rendering.

* **Tests**
  * Added regression tests covering importer MIME handling and table-image rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->