### PR TITLE
Add image insertion and editing to docs editor (Phase 1)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -35,6 +35,7 @@ Word processor engine — rich text, tables, pagination, collaboration.
 | [docs-table-ui.md](docs/docs-table-ui.md)                                        | Docs table UI — grid picker, context menu, IME cell routing                                       |
 | [docs-table-crdt.md](docs/docs-table-crdt.md)                                    | Table CRDT collaboration — Tree node structure, container cells, concurrent editing               |
 | [docs-table-resize.md](docs/docs-table-resize.md)                                | Docs table resize — column/row border drag handles, guideline rendering                           |
+| [docs-image-editing.md](docs/docs-image-editing.md)                              | Docs image editing — toolbar insert, selection handles, resize, rotation, crop, Image Options panel |
 | [docs-frontend-integration.md](docs/docs-frontend-integration.md)                | Docs frontend integration — document type field, list UI, routing, backend API changes            |
 | [docs-collaboration.md](docs/docs-collaboration.md)                              | Docs collaboration design                                                                         |
 | [docs-remote-cursor.md](docs/docs-remote-cursor.md)                              | Docs remote cursor — peer cursor carets + name labels in collaborative docs editor                |

--- a/docs/design/docs/docs-image-editing.md
+++ b/docs/design/docs/docs-image-editing.md
@@ -1,0 +1,253 @@
+---
+title: docs-image-editing
+target-version: 0.3.3
+---
+
+# Docs Image Insertion & Editing
+
+## Summary
+
+Add Google Docs–style image support to the Docs editor: a toolbar
+**Insert image** entry point (upload / by URL / drag-and-drop / paste),
+on-canvas selection with eight resize handles, a floating context bar
+for common actions, and an Image Options side panel for size, rotation,
+alt text, and crop. Text-wrap is explicitly **out of scope** for this
+first pass — all images remain inline (as they are today for DOCX
+imports).
+
+## Goals
+
+- Users can insert an image from the toolbar by uploading a local file
+  or pasting a URL.
+- Drag-and-drop and clipboard paste land an image at the cursor.
+- Clicking an inline image selects it and shows eight resize handles.
+- Corner drag preserves aspect ratio; side-handle drag resizes one axis.
+- A floating context bar above the selected image exposes Replace,
+  Alt text, Image options, and Delete.
+- Image Options side panel provides Size (px), Lock aspect ratio,
+  Rotation (90° buttons + free angle), Alt text, and Reset.
+- Crop mode toggles the handles into crop handles; apply on exit.
+
+## Non-Goals
+
+- **Text wrap modes** (square / break text / behind / in front). Needs a
+  float-aware layout engine; tracked separately.
+- **Recolor / filters / brightness / contrast / transparency**. Phase 3+.
+- **Border, drop shadow, link-to-URL on image**. Phase 4+.
+- **Drive / Photos / Web search / Camera** sources. Upload + URL only.
+- Non-inline anchoring (page / paragraph / character anchor).
+- Image metadata collaboration edge cases beyond what inline text
+  already handles — CRDT treats the inline as an atomic character.
+
+## Data Model Changes
+
+`ImageData` (in `packages/docs/src/model/types.ts`) gains four optional
+fields. All are backwards-compatible — existing documents keep working
+unchanged because every new field has a defined default.
+
+```ts
+export interface ImageData {
+  src: string;
+  width: number;          // displayed width in px (post-scale, pre-crop-box)
+  height: number;         // displayed height in px
+  alt?: string;
+
+  // New — Phase 1
+  rotation?: number;      // degrees, default 0. Clockwise.
+  cropLeft?: number;      // 0..1 fraction of natural width to hide
+  cropRight?: number;
+  cropTop?: number;
+  cropBottom?: number;
+  originalWidth?: number; // intrinsic pixel size, for "Reset image"
+  originalHeight?: number;
+}
+```
+
+Invariants:
+
+- `cropLeft + cropRight < 1` and `cropTop + cropBottom < 1` (enforced by
+  the crop UI; layout falls back to no-crop if violated).
+- `rotation` is normalized to `[0, 360)` on write.
+- `originalWidth/Height` are captured at insert time from the loaded
+  `HTMLImageElement.naturalWidth/Height`. Older persisted images without
+  them fall back to `width/height` for Reset.
+
+## Editor API
+
+New methods on `EditorAPI` (`packages/docs/src/view/editor.ts`):
+
+```ts
+interface EditorAPI {
+  // ... existing ...
+
+  /**
+   * Insert an image inline at the current selection focus. Replaces
+   * any non-collapsed selection. `src` may be any value that a plain
+   * <img> element can load (data: URL, absolute URL, /images/:id).
+   * The caller is responsible for uploading file bytes and resolving
+   * to a URL before calling this.
+   */
+  insertImage(src: string, naturalWidth: number, naturalHeight: number, alt?: string): void;
+
+  /** Mutate the selected image's ImageData. No-op if no image selected. */
+  updateSelectedImage(patch: Partial<ImageData>): void;
+
+  /** Return ImageData + position of the currently selected image, or null. */
+  getSelectedImage(): { data: ImageData; blockId: string; offset: number } | null;
+
+  /** Programmatically select the image at (blockId, offset). */
+  selectImageAt(blockId: string, offset: number): void;
+}
+```
+
+Image selection is a **new kind of selection** that coexists with text
+selection: when an image is selected, the text caret is hidden and the
+image handle overlay is shown. Clicking elsewhere returns to text mode.
+
+## Selection & Handles
+
+### Rendering
+
+A new `image-selection-overlay.ts` view module draws, on top of the
+existing canvas:
+
+1. A 1px selection rectangle around the image's bounding box (post
+   rotation).
+2. Eight 8×8 square handles — four corners + four edge midpoints —
+   centered on the bounding box edges.
+3. During drag, a dashed preview rectangle tracks the pointer.
+
+This overlay renders from `DocCanvas.render()` after the selection
+highlight pass, so it always appears above text and table backgrounds.
+
+### Hit testing
+
+`DocCanvas` already maps pointer coordinates to `(blockId, offset)`. We
+extend this with a pre-pass that checks whether the pointer is inside
+an image's drawn rect **or** one of its eight handles. Handle hits
+short-circuit the text hit-test and enter resize mode.
+
+### Resize interaction
+
+- Corner handle: `(dx, dy)` projected onto the rect's diagonal so the
+  aspect ratio is preserved. Shift releases the lock.
+- Side handle: pure width-only or height-only change.
+- Minimum size: 20×20 px. Maximum: `min(pageContentWidth, 2000)`.
+- On mouse-up, the editor dispatches a single `updateSelectedImage`
+  with the final `{ width, height }`, producing one undo step.
+
+### Keyboard
+
+| Key                | Action                        |
+|--------------------|-------------------------------|
+| ← → ↑ ↓           | 1px nudge (size, not position — inline has no position) |
+| Shift + arrow      | 8px nudge                     |
+| Delete / Backspace | Delete the image              |
+| Esc                | Deselect, return to text mode |
+
+## Floating Context Bar
+
+A small React overlay (positioned absolutely above the canvas, anchored
+to the image's screen-space top) with four buttons:
+
+- **Replace** — opens the same file picker as Insert
+- **Alt text** — inline input popover
+- **Image options** — opens the side panel
+- **Delete**
+
+The bar reuses existing `@/components/ui` primitives (Tooltip, Button)
+to match the formatting toolbar's visual language.
+
+## Image Options Side Panel
+
+Opened from the context bar or from a new `Format → Image options`
+menu item. The panel mounts on the right side of `docs-detail.tsx`,
+reusing the same slide-in shell as future panels.
+
+Controls:
+
+- **Size**
+  - Width (px) number input
+  - Height (px) number input
+  - Lock aspect ratio checkbox (default on)
+- **Rotation**
+  - Rotate 90° CW / CCW buttons
+  - Free angle slider + number input (0..359)
+- **Alt text** — single-line input
+- **Reset image** — restores `originalWidth/Height`, clears crop &
+  rotation
+
+## Insert Flows
+
+### Toolbar button
+
+`Insert image` is a DropdownMenu with two items:
+
+- **Upload from computer** — opens a hidden `<input type=file accept="image/*">`.
+  On pick: read file → POST to `/images` (existing endpoint, already used
+  by the DOCX importer's image uploader) → call `editor.insertImage`.
+- **By URL** — inline text field. On submit: preflight-load the URL in a
+  hidden `<img>` to capture `naturalWidth/Height`, then insert.
+
+### Drag-and-drop
+
+`DocCanvas` listens for `dragover` / `drop`. If the drop contains
+`dataTransfer.files` with `type.startsWith('image/')`, upload and insert
+at the drop coordinate's text position.
+
+### Clipboard paste
+
+The existing paste handler already sees `ClipboardEvent`. Extend it to
+check `clipboardData.items[i].kind === 'file'` for images and route
+them through the same upload helper.
+
+## Rendering
+
+`renderTableContent` and `DocCanvas.renderRun` already call
+`getOrLoadImage` and `drawImage` (fixed in 2026-04-12). The additions
+are:
+
+- **Rotation** — wrap the `drawImage` call in `ctx.save()` /
+  `ctx.translate(cx, cy)` / `ctx.rotate(rad)` / `ctx.translate(-cx, -cy)`
+  / `ctx.restore()`.
+- **Crop** — use the 9-arg `drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh)`
+  form with `sx/sy/sw/sh` derived from `cropLeft/Right/Top/Bottom *
+  naturalWidth/Height`.
+- The bounding box used for hit testing and the handle overlay must
+  account for rotation (take the axis-aligned bounding box of the
+  rotated rect).
+
+## Collaboration (Yorkie)
+
+Each image is a single inline with `text === '\uFFFC'` and `style.image
+= ImageData`. Mutations (`updateSelectedImage`) replace the inline's
+style via the existing `styleByPath` / inline replacement path. The
+CRDT sees an atomic style update — no new concurrency semantics beyond
+what text-run styling already handles.
+
+Pitfall: two users resizing the same image concurrently will
+last-writer-wins on `width/height`. This matches Google Docs and we
+accept it for Phase 1.
+
+## Risks & Mitigation
+
+- **Rotation + crop + scale compound math** is easy to get wrong. Unit
+  tests cover each transform independently and their composition.
+- **Selection overlay repaint cost** — the handle overlay must not
+  trigger a full-document re-layout. Render it as an overlay pass in
+  `DocCanvas.render()`, not as a layout mutation.
+- **Drag-drop hijacking text DnD** — only intercept drops whose
+  `dataTransfer.files[0]` has an image MIME. Files that don't match
+  fall through to the existing handler.
+- **Paste of huge images** — clamp width to the page content width on
+  insert so a 4000px screenshot doesn't push layout off-page.
+- **Accessibility** — alt text is surfaced in the context bar and the
+  side panel, and persisted through DOCX round-trip (already supported).
+
+## Rollout
+
+Phase 1 ships in a single PR branch `docs-image-editing-phase1` and
+delivers the toolbar button, upload/URL/DnD/paste, selection handles,
+resize, context bar, and Image Options panel (size + rotation + alt +
+reset + crop). Text-wrap and filters are explicitly tracked as
+follow-ups in a separate design doc update.

--- a/docs/design/docs/docs-image-editing.md
+++ b/docs/design/docs/docs-image-editing.md
@@ -81,13 +81,20 @@ interface EditorAPI {
   // ... existing ...
 
   /**
-   * Insert an image inline at the current selection focus. Replaces
-   * any non-collapsed selection. `src` may be any value that a plain
-   * <img> element can load (data: URL, absolute URL, /images/:id).
-   * The caller is responsible for uploading file bytes and resolving
-   * to a URL before calling this.
+   * Insert an image inline at the current caret position. Width is
+   * auto-clamped to the page's content width so oversized screenshots
+   * don't overflow. `src` may be any value a plain <img> element can
+   * load (data: URL, absolute URL, /images/:id). The caller is
+   * responsible for uploading file bytes and resolving to a URL
+   * before calling this. Non-collapsed selection replacement is not
+   * yet implemented — the image inserts at the focus offset and the
+   * selection is left as-is.
    */
-  insertImage(src: string, naturalWidth: number, naturalHeight: number, alt?: string): void;
+  insertImage(src: string, width: number, height: number, opts?: {
+    alt?: string;
+    originalWidth?: number;
+    originalHeight?: number;
+  }): void;
 
   /** Mutate the selected image's ImageData. No-op if no image selected. */
   updateSelectedImage(patch: Partial<ImageData>): void;
@@ -145,7 +152,7 @@ short-circuit the text hit-test and enter resize mode.
 | Delete / Backspace | Delete the image              |
 | Esc                | Deselect, return to text mode |
 
-## Floating Context Bar
+## Floating Context Bar *(Planned — Milestone 5)*
 
 A small React overlay (positioned absolutely above the canvas, anchored
 to the image's screen-space top) with four buttons:
@@ -158,7 +165,7 @@ to the image's screen-space top) with four buttons:
 The bar reuses existing `@/components/ui` primitives (Tooltip, Button)
 to match the formatting toolbar's visual language.
 
-## Image Options Side Panel
+## Image Options Side Panel *(Planned — Milestone 6)*
 
 Opened from the context bar or from a new `Format → Image options`
 menu item. The panel mounts on the right side of `docs-detail.tsx`,
@@ -248,6 +255,7 @@ accept it for Phase 1.
 
 Phase 1 ships in a single PR branch `docs-image-editing-phase1` and
 delivers the toolbar button, upload/URL/DnD/paste, selection handles,
-resize, context bar, and Image Options panel (size + rotation + alt +
-reset + crop). Text-wrap and filters are explicitly tracked as
-follow-ups in a separate design doc update.
+and resize. The floating context bar (Milestone 5), Image Options
+side panel (Milestone 6), rotation & crop rendering (Milestone 7),
+and crop mode (Milestone 8) are planned as follow-up PRs. Text-wrap
+and filters are tracked separately beyond Phase 1.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| docs image editing (2026-04-12) | [20260412-docs-image-editing-todo.md](./active/20260412-docs-image-editing-todo.md) | [20260412-docs-image-editing-lessons.md](./active/20260412-docs-image-editing-lessons.md) |
 | docx table merge gaps (2026-04-11) | [20260411-docx-table-merge-gaps-todo.md](./active/20260411-docx-table-merge-gaps-todo.md) | [20260411-docx-table-merge-gaps-lessons.md](./active/20260411-docx-table-merge-gaps-lessons.md) |
 | intent preserving phase4 table cells (2026-04-03) | [20260403-intent-preserving-phase4-table-cells-todo.md](./active/20260403-intent-preserving-phase4-table-cells-todo.md) | - |
 | intent preserving phase5 undo redo (2026-04-03) | [20260403-intent-preserving-phase5-undo-redo-todo.md](./active/20260403-intent-preserving-phase5-undo-redo-todo.md) | - |
@@ -28,4 +29,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 122
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: docx table merge gaps (2026-04-11)
+Latest active task: docs image editing (2026-04-12)

--- a/docs/tasks/active/20260412-docs-image-editing-lessons.md
+++ b/docs/tasks/active/20260412-docs-image-editing-lessons.md
@@ -1,0 +1,3 @@
+# Docs Image Insertion & Editing — Phase 1 lessons
+
+_(captured as each milestone lands; empty at planning time)_

--- a/docs/tasks/active/20260412-docs-image-editing-todo.md
+++ b/docs/tasks/active/20260412-docs-image-editing-todo.md
@@ -128,15 +128,23 @@ be paused and resumed cleanly.
       `editor.insertImage`. Errors surface as sonner toasts.
 - [x] **4c. By-URL path** — `insertImageFromUrl(editor, url)` in the
       same module. Validates the `http[s]://` prefix, preflight-loads
-      the URL with `crossOrigin="anonymous"`, and calls
-      `editor.insertImage` with the natural dimensions.
+      the URL **without** `crossOrigin` (removed to support non-CORS
+      image hosts — canvas becomes tainted but `drawImage` still
+      works), and calls `editor.insertImage` with the natural
+      dimensions. Returns `true`/`false` so the toolbar can keep the
+      URL form open on failure instead of discarding the user's input.
+      Note: the URL is stored as-is (hotlinked); uploading to
+      first-party storage requires a backend `POST /images/from-url`
+      endpoint (tracked as Phase 2 follow-up).
 - [x] **4d. Drag and drop** — `handleImageDragOver` /
       `handleImageDrop` installed on the editor container. `dragover`
-      checks `dataTransfer.files` for an `image/*` entry and
-      `preventDefault`s so the drop fires; `drop` moves the caret to
-      the drop position via `paginatedPixelToPosition`, then invokes
-      the host-supplied `onImageFileDrop` callback. Non-image drops
-      fall through to the browser default.
+      checks `dataTransfer.items` (not `.files`, which is empty during
+      `dragover` for browser security) for an `image/*` entry and
+      `preventDefault`s so the drop fires; `drop` extracts the `File`
+      from `.files`, moves the caret to the drop position via
+      `paginatedPixelToPosition`, then invokes the host-supplied
+      `onImageFileDrop` callback. Non-image drops fall through to
+      the browser default.
 - [x] **4e. Clipboard paste** — `TextEditor.imageFilePasteHandler`
       new field. `handlePaste` iterates `clipboardData.items`,
       extracts the first `image/*` file, and routes it through the

--- a/docs/tasks/active/20260412-docs-image-editing-todo.md
+++ b/docs/tasks/active/20260412-docs-image-editing-todo.md
@@ -1,0 +1,238 @@
+# Docs Image Insertion & Editing — Phase 1
+
+**Status:** in-progress
+**Design doc:** `docs/design/docs/docs-image-editing.md`
+**Scope:** `packages/docs/src/{model,view}`, `packages/frontend/src/app/docs/*`
+
+## Background
+
+The Docs editor accepts images via DOCX import (fixed 2026-04-12) but
+has no way to insert, select, resize, or edit them from the UI. This
+task delivers Phase 1 of `docs-image-editing.md` — a single PR that
+covers the full end-to-end Google Docs–style flow **minus** text wrap
+and color/filter adjustments (those are Phase 2+).
+
+The design doc is the source of truth for what goes in and what stays
+out. This file tracks per-milestone checklist progress so the work can
+be paused and resumed cleanly.
+
+## Milestone 1 — Data model & editor API
+
+- [x] **1a. Extend `ImageData`** with `rotation`, `cropLeft/Right/Top/Bottom`,
+      `originalWidth`, `originalHeight`. Keep all fields optional.
+- [x] **1b. Update `imageDataEqual`** in `packages/docs/src/model/types.ts`
+      to compare the new fields.
+- [x] **1c. Add `EditorAPI.insertImage(src, width, height, opts?)`** —
+      inserts a new inline at the caret via `doc.insertImageInline` and
+      advances the caret past it. Non-collapsed selection replacement
+      is deferred until Milestone 4 where the insert flows plug in.
+- [x] **1d. Add `EditorAPI.updateSelectedImage(patch)`** — shallow-merges
+      the patch onto the current `ImageData` and writes it back through
+      `doc.applyInlineStyle({ image: merged })`. No-op when no image is
+      selected or the stored position no longer references one.
+- [x] **1e. Add `EditorAPI.getSelectedImage()`** returning
+      `{ data, blockId, offset } | null`.
+- [x] **1f. Add `EditorAPI.selectImageAt(blockId, offset)` +
+      `clearImageSelection()`** for programmatic selection. `selectImageAt`
+      is a no-op if the offset does not point at an image inline.
+- [x] **1g. Model-layer tests** in `packages/docs/test/model/types.test.ts`
+      covering the new `ImageData` fields, `imageDataEqual`, and
+      `findImageAtOffset`. Full editor-API tests are deferred to
+      Milestone 2 where the jsdom editor harness lands alongside the
+      overlay renderer (no editor-boot test exists today, and standing
+      one up just for the API would bloat this milestone).
+
+## Milestone 2 — Selection state & overlay rendering
+
+- [x] **2a. Image selection state** — `selectedImage: { blockId, offset }`
+      closure state in the editor. The text caret is suppressed in
+      `DocCanvas.render()` whenever an image-selection rect is active.
+- [x] **2b. Hit test** — container `mousedown` listener installed in the
+      capture phase (so it runs before TextEditor). On a click, it walks
+      `collectImageRects(layout, paginatedLayout, canvasWidth)` and, if
+      the pointer lands inside an image, sets `selectedImage` and stops
+      propagation. A click outside an image clears any prior selection
+      and falls through to text handling.
+- [x] **2c. `image-selection-overlay.ts`** view module — draws a 1px
+      selection rect + eight 8×8 handles for the currently selected
+      image. `DocCanvas.render()` invokes it after all pages finish
+      so the overlay sits above text and table backgrounds.
+      `collectImageRects` additionally walks simple (top-aligned,
+      non-merged, rowSpan=1) table cells via `collectTableCellImageRects`
+      so images inside cells are selectable. Merged / row-spanning /
+      non-top-aligned cells remain a follow-up.
+- [ ] **2d. Cursor hints** — handle-hover cursor swap is deferred to
+      Milestone 3 where the resize drag state machine also owns the
+      handle hit-test on pointer move. Hit test helper
+      (`hitTestImageHandle` / `cursorForHandle`) is already available.
+- [x] **2e. Keyboard** — `imageKeyHandler` installed on `TextEditor`.
+      Delete/Backspace deletes the image inline + restores the caret;
+      Escape clears the selection; any other key clears the selection
+      and falls through to the normal text path.
+- [x] **2f. Unit tests** — `test/view/image-selection-overlay.test.ts`
+      covers `handleCenter`, `drawImageSelection`, `hitTestImageHandle`
+      (including slack), `hitTestImageRect`, `cursorForHandle`,
+      `collectImageRects` (with a single body image), `findImageAtPoint`
+      (including block IDs that contain colons). Rotation-AABB tests
+      are deferred to Milestone 7 where the rotation math lands.
+
+## Milestone 3 — Resize interaction
+
+- [x] **3a. Resize drag state machine** — mousedown on a handle
+      captures `{ handle, startRect, startClientX/Y, previewRect }`.
+      Mousemove computes a new `(width, height)` via
+      `computeResizeDelta` and updates `previewRect` via
+      `computePreviewRect`, then `renderPaintOnly()` repaints the
+      overlay at the preview. Mouseup commits a single
+      `doc.applyInlineStyle({ image: merged })` and clears the drag.
+- [x] **3b. Aspect ratio lock** — corner handles use the dominant
+      proportional axis (max of `|wScale - 1|`, `|hScale - 1|`) and
+      drive both sides off that scale so the rect stays similar-shape.
+      Holding Shift during the drag disables the lock and the corner
+      becomes free-form — `aspectLock = !e.shiftKey` in the
+      mousemove handler.
+- [x] **3c. Min/max clamps** — `MIN_IMAGE_DIMENSION = 20` floor;
+      `maxWidth = pageContentWidth` and `maxHeight = pageContentWidth
+      * 2` ceiling, derived per drag so it tracks the current page
+      setup. Tests cover both clamps.
+- [x] **3d. Undo grouping** — mousemove **only** updates the preview
+      rect (no doc mutation). The single `docStore.snapshot()` +
+      `applyInlineStyle` call happens on mouseup, and a no-op
+      mousedown→up without movement skips the snapshot entirely so
+      the undo stack stays clean.
+- [x] **3e. Keyboard nudge** — Arrow keys in `imageKeyHandler` scale
+      the image proportionally: ±1px on width with height derived
+      from aspect ratio (±8 with Shift). Each key press is its own
+      undo step via a new `docStore.snapshot()`, matching the
+      behavior for text typing. Clamps share `getResizeMax()` with
+      the drag path.
+- [x] **3f. Unit tests** for `computeResizeDelta` (9 cases: SE/NW/E/S
+      drags, free-form vs locked corners, min/max clamps, dominant
+      axis, zero delta) and `computePreviewRect` (8 anchor cases:
+      corners + edges). Cursor hint hover (`handleImageMouseMove`)
+      lives in integration code and is validated end-to-end manually
+      rather than through a jsdom harness.
+
+## Milestone 4 — Insert flows
+
+- [x] **4a. Toolbar button** — `InsertImageDropdown` component added
+      to `docs-formatting-toolbar.tsx` using `IconPhoto`. Two actions:
+      `Upload from computer` (hidden `<input type=file>`) and `By
+      URL…` (inline form inside the dropdown that stays open while
+      the user types).
+- [x] **4b. Upload path** — `insertImageFromFile(editor, file)` in
+      `packages/frontend/src/app/docs/image-insert.ts`. Reuses the
+      existing `docxImageUploader` (renamed conceptually via the new
+      `uploadImageFile` wrapper) to POST to `/images`, then probes
+      the resulting URL via `loadImageDimensions` and calls
+      `editor.insertImage`. Errors surface as sonner toasts.
+- [x] **4c. By-URL path** — `insertImageFromUrl(editor, url)` in the
+      same module. Validates the `http[s]://` prefix, preflight-loads
+      the URL with `crossOrigin="anonymous"`, and calls
+      `editor.insertImage` with the natural dimensions.
+- [x] **4d. Drag and drop** — `handleImageDragOver` /
+      `handleImageDrop` installed on the editor container. `dragover`
+      checks `dataTransfer.files` for an `image/*` entry and
+      `preventDefault`s so the drop fires; `drop` moves the caret to
+      the drop position via `paginatedPixelToPosition`, then invokes
+      the host-supplied `onImageFileDrop` callback. Non-image drops
+      fall through to the browser default.
+- [x] **4e. Clipboard paste** — `TextEditor.imageFilePasteHandler`
+      new field. `handlePaste` iterates `clipboardData.items`,
+      extracts the first `image/*` file, and routes it through the
+      callback. Takes priority over text paste so a clipboard with
+      both `image/png` + `text/plain` (common for screenshot tools)
+      lands the image.
+- [x] **4f. Clamp on insert** — extracted `clampImageToWidth(width,
+      height, maxWidth)` pure helper into `model/types.ts`.
+      `EditorAPI.insertImage` calls it against the current page's
+      content width on every insert so huge screenshots scale down
+      proportionally, with height floored at 1px.
+- [x] **4g. Unit tests** for `clampImageToWidth` (7 cases: fit,
+      scale, rounding, height-floor, zero/negative width, exact fit).
+      End-to-end upload + paste + DnD are validated manually via the
+      dev server — no jsdom editor harness exists today and bringing
+      one up for these flows would balloon the milestone.
+
+## Milestone 5 — Floating context bar
+
+- [ ] **5a. React overlay component** — `image-context-bar.tsx`
+      absolutely positioned above the canvas, anchored to the
+      selected image's screen-space top-left.
+- [ ] **5b. Buttons** — Replace / Alt text / Image options / Delete,
+      using existing `@/components/ui` primitives.
+- [ ] **5c. Replace** — reuses the upload flow, but on success calls
+      `updateSelectedImage({ src, originalWidth, originalHeight })`
+      instead of `insertImage`.
+- [ ] **5d. Alt text** — inline popover with a text input.
+- [ ] **5e. Reposition on scroll/resize** — listen to the canvas scroll
+      and window resize; recompute anchor; hide while mid-drag.
+
+## Milestone 6 — Image Options side panel
+
+- [ ] **6a. Panel shell** — slide-in panel on the right side of
+      `docs-detail.tsx`, visibility controlled by a `showImageOptions`
+      state. Close button + click-outside dismiss.
+- [ ] **6b. Size controls** — Width/Height number inputs with a Lock
+      aspect ratio checkbox (default on). Debounced dispatch to
+      `updateSelectedImage`.
+- [ ] **6c. Rotation controls** — `Rotate 90° CCW` / `Rotate 90° CW`
+      buttons + free-angle slider (0..359) + numeric input.
+- [ ] **6d. Alt text field**.
+- [ ] **6e. Reset image** — restores `originalWidth/Height`, clears
+      rotation and crop.
+
+## Milestone 7 — Rendering: rotation & crop
+
+- [ ] **7a. Rotation in `doc-canvas` body render path** — wrap the
+      `drawImage` call in `save/translate/rotate/restore`.
+- [ ] **7b. Rotation in `table-renderer.renderTableContent`** — same
+      transformation wrapper so table-cell images rotate too.
+- [ ] **7c. Crop** — switch to the 9-arg `drawImage` form with
+      `sx/sy/sw/sh` computed from `crop* * natural*`. Works in both
+      renderers.
+- [ ] **7d. Hit-test AABB** — `getImageBoundingBox(data)` returns the
+      axis-aligned bbox of the rotated, cropped image.
+- [ ] **7e. Unit tests** for the bbox math and for a regression that
+      checks rotated image draws land at the expected canvas coords
+      (use a recording ctx like the existing table-renderer tests).
+
+## Milestone 8 — Crop mode
+
+- [ ] **8a. Crop mode toggle** — the context bar `Image options →
+      Crop` or a dedicated Crop button enters crop mode: the eight
+      handles become crop handles (drawn inside the image bounds) and
+      a darkened overlay masks the cropped-away areas.
+- [ ] **8b. Crop drag** — dragging a crop handle adjusts one of the
+      four crop fractions. Clamp so `cropLeft + cropRight < 0.9` and
+      `cropTop + cropBottom < 0.9`.
+- [ ] **8c. Commit / cancel** — Enter or clicking outside commits;
+      Esc cancels and restores prior crop values.
+- [ ] **8d. Reset crop** — clears all four crop fields.
+
+## Milestone 9 — Verification
+
+- [ ] `pnpm --filter @wafflebase/docs test` — all existing + new tests
+- [ ] `pnpm verify:fast`
+- [ ] Manual: insert via toolbar upload, URL, drag-drop, paste
+- [ ] Manual: resize (corner aspect lock, side axis-only, keyboard
+      nudge, Shift release)
+- [ ] Manual: rotate 90° CW/CCW and free angle
+- [ ] Manual: crop + reset
+- [ ] Manual: alt text persists across reload
+- [ ] Manual: DOCX round-trip (import → resize → export → reimport) is
+      lossless for width/height/alt; rotation and crop degrade
+      gracefully if DOCX doesn't round-trip them
+
+## Out of scope (tracked separately)
+
+- Text wrap modes (square, break, behind, in front of text) — needs
+  float-aware layout; separate design doc update
+- Recolor / filters / brightness / contrast / transparency
+- Border, shadow, link-on-image
+- Drive / Photos / Web-search / Camera sources
+- Non-inline positioning (page / paragraph anchor)
+
+## Review
+
+_(filled in as each milestone lands)_

--- a/packages/docs/src/model/types.ts
+++ b/packages/docs/src/model/types.ts
@@ -276,7 +276,7 @@ export function clampImageToWidth(
   height: number,
   maxWidth: number,
 ): { width: number; height: number } {
-  if (width <= maxWidth || width <= 0) {
+  if (width <= maxWidth || width <= 0 || maxWidth <= 0) {
     return { width, height };
   }
   const scale = maxWidth / width;

--- a/packages/docs/src/model/types.ts
+++ b/packages/docs/src/model/types.ts
@@ -71,12 +71,32 @@ export interface BlockStyle {
 /**
  * Image metadata for an inline image element.
  * Used when an Inline has text '\uFFFC' (Object Replacement Character).
+ *
+ * All fields beyond `src/width/height/alt` are optional — older persisted
+ * documents that lack them keep working, and absence is treated as
+ * "no rotation / no crop / reset-to-displayed-size".
  */
 export interface ImageData {
+  /** Displayed width in px (post-scale, pre-crop viewport). */
   src: string;
   width: number;
+  /** Displayed height in px. */
   height: number;
   alt?: string;
+
+  /** Clockwise rotation in degrees, normalized to [0, 360). Default 0. */
+  rotation?: number;
+  /** Fraction of natural width hidden on the left edge. 0..1. Default 0. */
+  cropLeft?: number;
+  /** Fraction of natural width hidden on the right edge. 0..1. Default 0. */
+  cropRight?: number;
+  /** Fraction of natural height hidden on the top edge. 0..1. Default 0. */
+  cropTop?: number;
+  /** Fraction of natural height hidden on the bottom edge. 0..1. Default 0. */
+  cropBottom?: number;
+  /** Intrinsic pixel size of the source image, captured at insert time. */
+  originalWidth?: number;
+  originalHeight?: number;
 }
 
 /**
@@ -239,10 +259,68 @@ export function getBlockText(block: Block): string {
   return block.inlines.map((inline) => inline.text).join('');
 }
 
+/**
+ * Scale an image's displayed dimensions down so its width does not
+ * exceed `maxWidth`, preserving the original aspect ratio. Returns
+ * the input unchanged when the image already fits or when the width
+ * is zero/negative (defensive against bogus callers).
+ *
+ * Used on every `insertImage` call so a 4000px screenshot pasted into
+ * an 8.5" page fits within the content area instead of overflowing the
+ * right margin. Height gets rounded to the nearest integer pixel and
+ * clamped to at least 1 to avoid invisible rows when a very wide +
+ * very short source scales down hard.
+ */
+export function clampImageToWidth(
+  width: number,
+  height: number,
+  maxWidth: number,
+): { width: number; height: number } {
+  if (width <= maxWidth || width <= 0) {
+    return { width, height };
+  }
+  const scale = maxWidth / width;
+  return {
+    width: maxWidth,
+    height: Math.max(1, Math.round(height * scale)),
+  };
+}
+
+/**
+ * Return the `ImageData` of the inline whose character offset span
+ * contains `offset`, or `null` if that position is not inside an image
+ * inline. Image inlines carry exactly one character (ORC = '\uFFFC'),
+ * so the caller is expected to pass the image's start offset — this
+ * helper tolerates any offset inside the image run for convenience.
+ */
+export function findImageAtOffset(block: Block, offset: number): ImageData | null {
+  let pos = 0;
+  for (const inline of block.inlines) {
+    const inlineEnd = pos + inline.text.length;
+    if (offset >= pos && offset < inlineEnd && inline.style.image) {
+      return inline.style.image;
+    }
+    pos = inlineEnd;
+  }
+  return null;
+}
+
 function imageDataEqual(a: ImageData | undefined, b: ImageData | undefined): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  return a.src === b.src && a.width === b.width && a.height === b.height && a.alt === b.alt;
+  return (
+    a.src === b.src &&
+    a.width === b.width &&
+    a.height === b.height &&
+    a.alt === b.alt &&
+    a.rotation === b.rotation &&
+    a.cropLeft === b.cropLeft &&
+    a.cropRight === b.cropRight &&
+    a.cropTop === b.cropTop &&
+    a.cropBottom === b.cropBottom &&
+    a.originalWidth === b.originalWidth &&
+    a.originalHeight === b.originalHeight
+  );
 }
 
 /**

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -3,13 +3,13 @@ import { LIST_INDENT_PX, UNORDERED_MARKERS } from '../model/types.js';
 import type { PaginatedLayout, LayoutPage, PageLine } from './pagination.js';
 import { getPageYOffset, getPageXOffset, getHeaderYStart, getFooterYStart } from './pagination.js';
 import type { EditContext } from '../model/document.js';
-import type { DocumentLayout, LayoutBlock } from './layout.js';
-import type { LayoutRun } from './layout.js';
+import type { DocumentLayout, LayoutBlock, LayoutRun } from './layout.js';
 import { computeListCounters } from './layout.js';
 import { Theme, buildFont, ptToPx } from './theme.js';
 import { drawPeerCaret, drawPeerLabel } from './peer-cursor.js';
 import { renderTableBackgrounds, renderTableContent } from './table-renderer.js';
 import { getOrLoadImage } from './image-cache.js';
+import { drawImageSelection, drawResizeHud, type ImageRect } from './image-selection-overlay.js';
 
 /**
  * Convert a peer cursor color (hex) to a translucent selection fill.
@@ -180,6 +180,18 @@ export class DocCanvas {
     headerCursor?: { x: number; y: number; height: number; visible: boolean },
     footerCursor?: { x: number; y: number; height: number; visible: boolean },
     hfSelectionRects?: Array<{ x: number; y: number; width: number; height: number }>,
+    imageSelectionRect?: ImageRect,
+    imageResizeHudText?: string,
+    /**
+     * When an image resize drag is active, the caller passes the
+     * LayoutRun of the image being dragged. The normal content pass
+     * skips drawing it at its committed (pre-drag) size, and a final
+     * shadow-lift pass draws it at `imageSelectionRect` (which is the
+     * preview rect during drag). The result feels like the image is
+     * being physically scaled under the cursor instead of the
+     * overlay floating off the committed image.
+     */
+    dragImageRun?: LayoutRun,
   ): void {
     const dpr = window.devicePixelRatio || 1;
     const logicalWidth = this.canvas.width / dpr;
@@ -467,6 +479,7 @@ export class DocCanvas {
                 range.endRowIndex,
                 range.pageStartRow,
                 this.requestRender ?? undefined,
+                dragImageRun,
               );
             }
             continue;
@@ -474,6 +487,11 @@ export class DocCanvas {
         }
 
         for (const run of pl.line.runs) {
+          // Skip the image run that's currently being resized — it's
+          // drawn in a later pass at the preview rect with a lift
+          // shadow, so that the overlay handles and the image stay in
+          // lockstep instead of visually diverging during the drag.
+          if (dragImageRun && run === dragImageRun) continue;
           this.renderRun(run, pageX + pl.x, pageY + pl.y, pl.line.height);
         }
 
@@ -491,8 +509,12 @@ export class DocCanvas {
         }
       }
 
-      // Draw cursor if on this page (only when focused)
-      if (focused && cursor?.visible) {
+      // Draw cursor if on this page (only when focused).
+      // When an image is selected the text caret is suppressed — the
+      // selection overlay stands in for the caret and showing both
+      // would read as "insertion point is inside the image" which is
+      // misleading.
+      if (focused && cursor?.visible && !imageSelectionRect) {
         if (cursor.y >= pageY + margins.top &&
             cursor.y < pageY + margins.top + contentHeight) {
           this.ctx.fillStyle = Theme.cursorColor;
@@ -530,6 +552,47 @@ export class DocCanvas {
             }
           }
         }
+      }
+    }
+
+    // Drag-lift pass: if the user is resizing an image, render it at
+    // the preview rect with a soft drop shadow so it feels lifted
+    // off the page. Drawn before the selection rect so the overlay
+    // and handles paint on top of both the image and its shadow.
+    if (dragImageRun && imageSelectionRect) {
+      const imgStyle = dragImageRun.inline.style.image;
+      if (imgStyle) {
+        const img = getOrLoadImage(imgStyle.src, () => {
+          this.requestRender?.();
+        });
+        if (img) {
+          this.ctx.save();
+          this.ctx.shadowColor = 'rgba(0, 0, 0, 0.30)';
+          this.ctx.shadowBlur = 16;
+          this.ctx.shadowOffsetX = 0;
+          this.ctx.shadowOffsetY = 4;
+          this.ctx.drawImage(
+            img,
+            imageSelectionRect.x,
+            imageSelectionRect.y,
+            imageSelectionRect.width,
+            imageSelectionRect.height,
+          );
+          this.ctx.restore();
+        }
+      }
+    }
+
+    // Image selection overlay — drawn after every page's content so it
+    // sits on top of whichever image run is currently selected.
+    // `imageSelectionRect` is already in document-layout coordinates,
+    // matching the translation that's still active on the context.
+    // The optional HUD renders after the handles so the pill sits
+    // above the se handle instead of getting clipped by it.
+    if (imageSelectionRect) {
+      drawImageSelection(this.ctx, imageSelectionRect);
+      if (imageResizeHudText) {
+        drawResizeHud(this.ctx, imageSelectionRect, imageResizeHudText);
       }
     }
 

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1,20 +1,31 @@
 import { Doc } from '../model/document.js';
-import type { Block, InlineStyle, BlockStyle, BlockType, HeadingLevel, SearchMatch, CellAddress, CellRange, CellStyle } from '../model/types.js';
-import { resolvePageSetup, getEffectiveDimensions, getBlockTextLength } from '../model/types.js';
+import type { Block, InlineStyle, BlockStyle, BlockType, HeadingLevel, SearchMatch, CellAddress, CellRange, CellStyle, ImageData } from '../model/types.js';
+import { resolvePageSetup, getEffectiveDimensions, getBlockTextLength, findImageAtOffset, clampImageToWidth } from '../model/types.js';
 import { MemDocStore } from '../store/memory.js';
 import type { DocStore } from '../store/store.js';
 import { DocCanvas } from './doc-canvas.js';
 import { Cursor } from './cursor.js';
 import { Selection, computeSelectionRects } from './selection.js';
 import { TextEditor } from './text-editor.js';
-import { computeLayout, type DocumentLayout, type LayoutCache } from './layout.js';
-import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getPageYOffset, getHeaderYStart, getFooterYStart, type PaginatedLayout } from './pagination.js';
+import { computeLayout, type DocumentLayout, type LayoutCache, type LayoutRun } from './layout.js';
+import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getPageYOffset, getHeaderYStart, getFooterYStart, paginatedPixelToPosition, type PaginatedLayout } from './pagination.js';
 import type { DocPosition, HeaderFooter } from '../model/types.js';
 import { Ruler, RULER_SIZE } from './ruler.js';
 import { computeScaleFactor } from './scale.js';
 import { buildFont, setThemeMode, type ThemeMode } from './theme.js';
 import { type PeerCursor, resolvePositionPixel } from './peer-cursor.js';
 import { computeTableMergeContext, type TableMergeContext } from './table-merge-context.js';
+import {
+  collectImageRects,
+  findImageAtPoint,
+  hitTestImageHandle,
+  cursorForHandle,
+  computeResizeDelta,
+  computePreviewRect,
+  formatResizeHud,
+  type ImageHandle,
+  type ImageRect,
+} from './image-selection-overlay.js';
 
 /**
  * Public API returned by initialize().
@@ -100,6 +111,47 @@ export interface EditorAPI {
   isInTable(): boolean;
   /** Get the current cell address (if in table) */
   getCellAddress(): CellAddress | undefined;
+  /**
+   * Insert an inline image at the current cursor position. The caller is
+   * responsible for producing a URL the browser can load (upload, data URL,
+   * or absolute http[s]). The dimensions passed here become the image's
+   * initial displayed size — callers that need to clamp to page width
+   * should do so before calling.
+   */
+  insertImage(src: string, width: number, height: number, opts?: {
+    alt?: string;
+    originalWidth?: number;
+    originalHeight?: number;
+  }): void;
+  /**
+   * Programmatically mark the image at `(blockId, offset)` as the selected
+   * image. This hides the text caret (once the overlay renderer lands) and
+   * is the entry point for resize/rotate/crop interactions. No-op if the
+   * offset does not point at an image inline.
+   */
+  selectImageAt(blockId: string, offset: number): void;
+  /** Clear the image selection, returning to text mode. */
+  clearImageSelection(): void;
+  /** Return the currently selected image's data and position, or null. */
+  getSelectedImage(): { data: ImageData; blockId: string; offset: number } | null;
+  /**
+   * Replace the selected image's `ImageData` with a merged patch. The patch
+   * is a shallow field-level merge onto the current data — pass `undefined`
+   * for any field to explicitly clear it. No-op if no image is selected or
+   * the stored position no longer references an image inline.
+   */
+  updateSelectedImage(patch: Partial<ImageData>): void;
+  /**
+   * Register a handler for image files the user drops into the editor
+   * or pastes from the clipboard. The editor intercepts `drop` and
+   * `paste` events that carry an image MIME file and invokes this
+   * callback with the underlying `File`. The caller is responsible
+   * for uploading the bytes somewhere and calling `insertImage` with
+   * the resulting URL — the docs package stays agnostic about auth,
+   * CORS, and upload endpoints. Only the most recent callback is
+   * active; calling this again replaces it.
+   */
+  onImageFileDrop(cb: ((file: File) => void) | null): void;
   /** Insert a page number token at cursor in header/footer */
   insertPageNumber(): void;
   /** Get the current edit context */
@@ -379,6 +431,46 @@ export function initialize(
   let searchMatches: SearchMatch[] = [];
   let activeMatchIndex = -1;
   let scaleFactor = 1;
+
+  // Position of the currently selected image. When set, the text caret
+  // is suppressed and the image selection overlay (Milestone 2) renders
+  // handles here. Kept as `null` when the user is in text editing mode.
+  let selectedImage: { blockId: string; offset: number } | null = null;
+
+  /**
+   * In-progress resize drag, driven by a handle-drag on the selected
+   * image's overlay. While this is non-null, `render()` draws the
+   * overlay at the preview rect rather than the committed image rect,
+   * and the actual `ImageData.width/height` stay unchanged until
+   * `mouseup` commits a single `updateSelectedImage` call (so the
+   * drag produces exactly one undo step).
+   */
+  let imageResizeDrag:
+    | {
+        handle: ImageHandle;
+        startRect: ImageRect;
+        startClientX: number;
+        startClientY: number;
+        previewRect: ImageRect;
+        blockId: string;
+        offset: number;
+        /**
+         * Whether the aspect ratio is currently being held. Corner
+         * drags default to `true`; Shift releases the lock. Side
+         * handles ignore this field (they only change one axis).
+         * Tracked here so the HUD pill can reflect the state during
+         * the drag even when the user hasn't yet moved the mouse.
+         */
+        aspectLocked: boolean;
+      }
+    | null = null;
+
+  /**
+   * Callback the host (frontend) installs via `onImageFileDrop` to
+   * receive image files from drag-and-drop + clipboard paste. The
+   * editor owns the event wiring; the host owns upload + insert.
+   */
+  let imageFileDropCallback: ((file: File) => void) | null = null;
 
   // Compute layout helper
   const recomputeLayout = () => {
@@ -725,6 +817,82 @@ export function initialize(
       }
     }
 
+    // If an image is currently selected, walk the layout once and
+    // resolve its screen-space rect so the overlay draws in the right
+    // place. While a resize drag is active, the overlay tracks the
+    // preview rect instead so the user sees the handles following
+    // their cursor in real time — the committed `ImageData` stays
+    // unchanged until mouseup so the drag produces exactly one undo
+    // step.
+    let selectedImageRect: ImageRect | undefined;
+    let imageResizeHudText: string | undefined;
+    let dragImageRun: LayoutRun | undefined;
+    if (imageResizeDrag) {
+      selectedImageRect = imageResizeDrag.previewRect;
+      imageResizeHudText = formatResizeHud(
+        imageResizeDrag.handle,
+        imageResizeDrag.previewRect,
+        imageResizeDrag.aspectLocked,
+      );
+      // Locate the specific LayoutRun that corresponds to the image
+      // being dragged so DocCanvas can (a) skip drawing it at its
+      // committed size during the normal content pass and (b) draw
+      // it with a drop shadow at the preview rect instead. Handles
+      // both body blocks and cell blocks — the cell path goes via
+      // `blockParentMap` so the table's `LayoutTableCell.lines` can
+      // be walked directly.
+      const dragBlockId = imageResizeDrag.blockId;
+      const dragOffset = imageResizeDrag.offset;
+      const cellInfo = layout.blockParentMap.get(dragBlockId);
+      if (cellInfo) {
+        const tableBlock = layout.blocks.find(
+          (b) => b.block.id === cellInfo.tableBlockId,
+        );
+        const layoutCell =
+          tableBlock?.layoutTable?.cells[cellInfo.rowIndex]?.[cellInfo.colIndex];
+        const cellData = tableBlock?.block.tableData?.rows[cellInfo.rowIndex]
+          ?.cells[cellInfo.colIndex];
+        if (layoutCell && cellData) {
+          const boundaries = layoutCell.blockBoundaries;
+          // Find the block index of `dragBlockId` within this cell.
+          const innerIdx = cellData.blocks.findIndex(
+            (bl) => bl.id === dragBlockId,
+          );
+          if (innerIdx >= 0) {
+            const firstLine = boundaries[innerIdx] ?? 0;
+            const lastLine = boundaries[innerIdx + 1] ?? layoutCell.lines.length;
+            let offsetCursor = 0;
+            outer: for (let li = firstLine; li < lastLine; li++) {
+              for (const run of layoutCell.lines[li].runs) {
+                if (offsetCursor === dragOffset && run.inline.style.image) {
+                  dragImageRun = run;
+                  break outer;
+                }
+                offsetCursor += run.charEnd - run.charStart;
+              }
+            }
+          }
+        }
+      } else {
+        const lb = layout.blocks.find((b) => b.block.id === dragBlockId);
+        if (lb) {
+          let offsetCursor = 0;
+          outer: for (const line of lb.lines) {
+            for (const run of line.runs) {
+              if (offsetCursor === dragOffset && run.inline.style.image) {
+                dragImageRun = run;
+                break outer;
+              }
+              offsetCursor += run.charEnd - run.charStart;
+            }
+          }
+        }
+      }
+    } else if (selectedImage) {
+      selectedImageRect = collectImageRects(layout, paginatedLayout, logicalCanvasWidth)
+        .get(`${selectedImage.blockId}:${selectedImage.offset}`);
+    }
+
     docCanvas.render(
       paginatedLayout, scrollY, logicalCanvasWidth, canvasHeight,
       editCtx === 'body' ? (cursorPixel ?? undefined) : undefined,
@@ -740,6 +908,9 @@ export function initialize(
       hfCursorHeader,
       hfCursorFooter,
       hfSelectionRects,
+      selectedImageRect,
+      imageResizeHudText,
+      dragImageRun,
     );
 
     // Draw drag guideline if active
@@ -941,6 +1112,334 @@ export function initialize(
       dragGuideline = pos;
       renderPaintOnly();
     };
+
+    // Image selection key routing. Delete/Backspace delete the selected
+    // image inline and return to text mode; Escape clears the image
+    // selection without mutating the doc; anything else (arrows, typing,
+    // modifier combos) returns false so TextEditor handles the key
+    // normally — we just clear the image selection first so typing
+    // while an image is selected naturally replaces the image's slot
+    // with a plain caret, matching Google Docs.
+    // `textEditor.imageHoverHandler` is assigned below, after
+    // `handleImageHover` is declared — it can't be wired here because
+    // `const` declarations in the TDZ would throw on reference.
+    textEditor.imageKeyHandler = (e: KeyboardEvent): boolean => {
+      if (!selectedImage) return false;
+      const key = e.key;
+      if (key === 'Escape') {
+        e.preventDefault();
+        const restore = selectedImage;
+        selectedImage = null;
+        cursor.moveTo({ blockId: restore.blockId, offset: restore.offset });
+        render();
+        return true;
+      }
+      if (key === 'Delete' || key === 'Backspace') {
+        e.preventDefault();
+        const { blockId, offset } = selectedImage;
+        docStore.snapshot();
+        doc.deleteText({ blockId, offset }, 1);
+        selectedImage = null;
+        cursor.moveTo({ blockId, offset });
+        markDirty(blockId);
+        invalidateLayout();
+        render();
+        return true;
+      }
+      // Arrow keys nudge the image size. ArrowRight/Down grow, Arrow
+      // Left/Up shrink. Nudge is proportional so the image retains
+      // its aspect ratio — matches Google Docs' "maintain ratio on
+      // keyboard resize" behavior. Shift multiplies the step by 8.
+      if (
+        key === 'ArrowLeft' || key === 'ArrowRight' ||
+        key === 'ArrowUp'   || key === 'ArrowDown'
+      ) {
+        const { blockId, offset } = selectedImage;
+        const block = doc.getBlock(blockId);
+        if (!block) return true;
+        const current = findImageAtOffset(block, offset);
+        if (!current) return true;
+        e.preventDefault();
+        const step = (e.shiftKey ? 8 : 1) *
+          (key === 'ArrowRight' || key === 'ArrowDown' ? 1 : -1);
+        const aspect = current.width / current.height;
+        const { maxWidth, maxHeight } = getResizeMax();
+        const MIN = 20;
+        let newWidth = current.width + step;
+        newWidth = Math.max(MIN, Math.min(newWidth, maxWidth));
+        let newHeight = newWidth / aspect;
+        if (newHeight < MIN) {
+          newHeight = MIN;
+          newWidth = Math.max(MIN, Math.min(newHeight * aspect, maxWidth));
+        }
+        if (newHeight > maxHeight) {
+          newHeight = maxHeight;
+          newWidth = Math.max(MIN, Math.min(newHeight * aspect, maxWidth));
+        }
+        if (newWidth === current.width && newHeight === current.height) {
+          return true;
+        }
+        docStore.snapshot();
+        const merged = { ...current, width: newWidth, height: newHeight };
+        doc.applyInlineStyle(
+          { anchor: { blockId, offset }, focus: { blockId, offset: offset + 1 } },
+          { image: merged },
+        );
+        markDirty(blockId);
+        invalidateLayout();
+        render();
+        return true;
+      }
+      // Other keys clear image selection and fall through so the text
+      // path sees them on the now-active caret.
+      selectedImage = null;
+      return false;
+    };
+  }
+
+  // Convert a MouseEvent clientXY into document-layout coordinates
+  // (the same space `collectImageRects` returns). Used by every image
+  // pointer handler below, so keep the math in one place.
+  const clientToDocCoords = (clientX: number, clientY: number) => {
+    const containerRect = container.getBoundingClientRect();
+    const canvasOffsetTop = canvas.getBoundingClientRect().top - containerRect.top;
+    const s = scaleFactor;
+    return {
+      x: (clientX - containerRect.left + container.scrollLeft) / s,
+      y: (clientY - containerRect.top - canvasOffsetTop) / s + container.scrollTop / s,
+    };
+  };
+
+  // Return the committed rect of the currently selected image, or
+  // undefined if no image is selected / its position is stale.
+  const getSelectedImageRectCommitted = (): ImageRect | undefined => {
+    if (!selectedImage || !layout) return undefined;
+    const s = scaleFactor;
+    const canvasWidth = canvas.getBoundingClientRect().width / s;
+    const rects = collectImageRects(layout, paginatedLayout, canvasWidth);
+    return rects.get(`${selectedImage.blockId}:${selectedImage.offset}`);
+  };
+
+  // Maximum width/height an image may be resized to. Width is capped
+  // at the current page's content width so the user can't drag the
+  // image past the right margin. Height uses the same value doubled —
+  // images taller than ~2x content width are extremely rare and this
+  // keeps the max free of page-layout assumptions.
+  const getResizeMax = () => {
+    const pageSetup = resolvePageSetup(doc.document.pageSetup);
+    const dims = getEffectiveDimensions(pageSetup);
+    const contentWidth = dims.width - pageSetup.margins.left - pageSetup.margins.right;
+    return {
+      maxWidth: contentWidth,
+      maxHeight: contentWidth * 2,
+    };
+  };
+
+  const handleImageResizeMouseMove = (e: MouseEvent) => {
+    if (!imageResizeDrag) return;
+    const s = scaleFactor;
+    const dx = (e.clientX - imageResizeDrag.startClientX) / s;
+    const dy = (e.clientY - imageResizeDrag.startClientY) / s;
+    const aspectLocked = !e.shiftKey;
+    const { maxWidth, maxHeight } = getResizeMax();
+    const { width, height } = computeResizeDelta(
+      imageResizeDrag.handle,
+      imageResizeDrag.startRect.width,
+      imageResizeDrag.startRect.height,
+      dx,
+      dy,
+      { aspectLock: aspectLocked, maxWidth, maxHeight },
+    );
+    imageResizeDrag.previewRect = computePreviewRect(
+      imageResizeDrag.startRect,
+      imageResizeDrag.handle,
+      width,
+      height,
+    );
+    imageResizeDrag.aspectLocked = aspectLocked;
+    renderPaintOnly();
+  };
+
+  const handleImageResizeMouseUp = () => {
+    if (!imageResizeDrag) return;
+    const commit = imageResizeDrag.previewRect;
+    const { blockId, offset } = imageResizeDrag;
+    // Tear down drag state before mutating so any synchronous render
+    // during the mutation sees the committed selection rather than
+    // the preview rect.
+    document.removeEventListener('mousemove', handleImageResizeMouseMove);
+    document.removeEventListener('mouseup', handleImageResizeMouseUp);
+    imageResizeDrag = null;
+    canvas.style.cursor = '';
+
+    // Only commit if the drag actually changed the size. Avoids a
+    // no-op undo step for a mousedown-up on a handle without movement.
+    const block = doc.getBlock(blockId);
+    const current = block ? findImageAtOffset(block, offset) : null;
+    if (!current) {
+      render();
+      return;
+    }
+    if (current.width === commit.width && current.height === commit.height) {
+      render();
+      return;
+    }
+    docStore.snapshot();
+    const merged = { ...current, width: commit.width, height: commit.height };
+    doc.applyInlineStyle(
+      {
+        anchor: { blockId, offset },
+        focus: { blockId, offset: offset + 1 },
+      },
+      { image: merged },
+    );
+    markDirty(blockId);
+    invalidateLayout();
+    render();
+  };
+
+  // Image hit test, installed in the capture phase so it runs before
+  // TextEditor's bubble-phase container listener. A click on a handle
+  // starts a resize drag; a click on an image's body selects it; a
+  // click elsewhere clears the image selection and lets TextEditor
+  // handle the click normally.
+  const handleImageMouseDown = (e: MouseEvent) => {
+    if (!layout) return;
+    if (e.button !== 0) return;
+    const target = e.target as HTMLElement;
+    if (
+      target.tagName === 'BUTTON' ||
+      target.tagName === 'INPUT' ||
+      target.closest('button, [role="menu"], [role="menuitem"]')
+    ) {
+      return;
+    }
+
+    const { x: docX, y: docY } = clientToDocCoords(e.clientX, e.clientY);
+    const s = scaleFactor;
+    const canvasWidth = canvas.getBoundingClientRect().width / s;
+    const rects = collectImageRects(layout, paginatedLayout, canvasWidth);
+
+    // 1) If an image is already selected, check for a handle hit first
+    //    so the user can start a resize drag without having to click
+    //    the image body twice.
+    if (selectedImage) {
+      const selRect = rects.get(`${selectedImage.blockId}:${selectedImage.offset}`);
+      if (selRect) {
+        const handle = hitTestImageHandle(selRect, docX, docY);
+        if (handle) {
+          e.preventDefault();
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+          imageResizeDrag = {
+            handle,
+            startRect: selRect,
+            startClientX: e.clientX,
+            startClientY: e.clientY,
+            previewRect: selRect,
+            blockId: selectedImage.blockId,
+            offset: selectedImage.offset,
+            aspectLocked: !e.shiftKey,
+          };
+          canvas.style.cursor = cursorForHandle(handle);
+          document.addEventListener('mousemove', handleImageResizeMouseMove);
+          document.addEventListener('mouseup', handleImageResizeMouseUp);
+          return;
+        }
+      }
+    }
+
+    // 2) Image body hit — select it.
+    const hit = findImageAtPoint(rects, docX, docY);
+    if (hit) {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+      selectedImage = { blockId: hit.blockId, offset: hit.offset };
+      cursor.moveTo({ blockId: hit.blockId, offset: hit.offset });
+      render();
+      return;
+    }
+
+    // 3) Click elsewhere — clear any prior image selection and let
+    //    TextEditor handle the click normally. No stopPropagation so
+    //    the subsequent bubble listener still places the caret.
+    if (selectedImage) {
+      selectedImage = null;
+      render();
+    }
+  };
+  container.addEventListener('mousedown', handleImageMouseDown, { capture: true });
+
+  /**
+   * Drag-and-drop of image files into the editor. `dragover` must
+   * `preventDefault` for the drop to fire; `drop` then inspects the
+   * files on the transfer and routes the first image file to the
+   * registered callback. Non-image drops fall through to the
+   * browser's default (no-op on a canvas).
+   */
+  const hasImageFile = (dt: DataTransfer | null): File | null => {
+    if (!dt || !dt.files || dt.files.length === 0) return null;
+    for (const file of dt.files) {
+      if (file.type.startsWith('image/')) return file;
+    }
+    return null;
+  };
+
+  const handleImageDragOver = (e: DragEvent) => {
+    if (!imageFileDropCallback) return;
+    const file = hasImageFile(e.dataTransfer);
+    if (!file) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+  };
+
+  const handleImageDrop = (e: DragEvent) => {
+    if (!imageFileDropCallback) return;
+    const file = hasImageFile(e.dataTransfer);
+    if (!file) return;
+    e.preventDefault();
+    e.stopPropagation();
+    // Move the caret to the drop location first so the subsequent
+    // `insertImage` call lands where the user dropped the file.
+    // Reuse the existing `paginatedPixelToPosition` via a synthetic
+    // pointer position. If the drop happens outside any block the
+    // caret stays where it was.
+    const { x: docX, y: docY } = clientToDocCoords(e.clientX, e.clientY);
+    if (layout) {
+      const s = scaleFactor;
+      const canvasWidth = canvas.getBoundingClientRect().width / s;
+      const hit = paginatedPixelToPosition(paginatedLayout, layout, docX, docY, canvasWidth);
+      if (hit) {
+        cursor.moveTo({ blockId: hit.blockId, offset: hit.offset });
+      }
+    }
+    imageFileDropCallback(file);
+  };
+  container.addEventListener('dragover', handleImageDragOver);
+  container.addEventListener('drop', handleImageDrop);
+
+  // Resize cursor hint for image handles. Installed as a pre-handler
+  // on TextEditor.handleMouseMove rather than as a separate listener
+  // so that TextEditor's own `setCanvasCursor('text')` reset doesn't
+  // immediately overwrite ours. Returning `true` tells TextEditor to
+  // skip its default cursor reset for this pointer position.
+  const handleImageHover = (e: MouseEvent): boolean => {
+    // While dragging, the drag state owns the cursor — skip the
+    // hover override so the corner cursor doesn't flip to ns/ew
+    // mid-drag.
+    if (imageResizeDrag) return true;
+    if (!selectedImage || !layout) return false;
+    const selRect = getSelectedImageRectCommitted();
+    if (!selRect) return false;
+    const { x, y } = clientToDocCoords(e.clientX, e.clientY);
+    const handle = hitTestImageHandle(selRect, x, y);
+    if (!handle) return false;
+    canvas.style.cursor = cursorForHandle(handle);
+    return true;
+  };
+  if (textEditor) {
+    textEditor.imageHoverHandler = handleImageHover;
   }
 
   // Start cursor blink (skip in read-only — no cursor visible)
@@ -1440,6 +1939,107 @@ export function initialize(
       markDirty(cellInfo.tableBlockId);
       render();
     },
+    insertImage: (
+      src: string,
+      width: number,
+      height: number,
+      opts?: { alt?: string; originalWidth?: number; originalHeight?: number },
+    ) => {
+      // Clamp the displayed width to the page's content width so a
+      // 4000px screenshot pasted into an 8.5" page doesn't punch past
+      // the right margin. Aspect ratio is preserved by
+      // `clampImageToWidth`. Most insert paths (toolbar / DnD / paste
+      // / URL insert) want this clamp by default; callers with a
+      // pre-sized image can pass width <= maxWidth and it's a no-op.
+      const pageSetup = resolvePageSetup(doc.document.pageSetup);
+      const dims = getEffectiveDimensions(pageSetup);
+      const maxWidth = dims.width - pageSetup.margins.left - pageSetup.margins.right;
+      const clamped = clampImageToWidth(width, height, maxWidth);
+      const displayWidth = clamped.width;
+      const displayHeight = clamped.height;
+
+      const pos = cursor.position;
+      const imageData: ImageData = {
+        src,
+        width: displayWidth,
+        height: displayHeight,
+        ...(opts?.alt !== undefined ? { alt: opts.alt } : {}),
+        ...(opts?.originalWidth !== undefined ? { originalWidth: opts.originalWidth } : {}),
+        ...(opts?.originalHeight !== undefined ? { originalHeight: opts.originalHeight } : {}),
+      };
+      docStore.snapshot();
+      // `insertImageInline` routes through the block-helpers path for both
+      // top-level blocks and cells, so it works inside tables without
+      // special-casing. Non-collapsed selection replacement is deferred
+      // until the drag/paste wiring lands in Milestone 4.
+      doc.insertImageInline(pos.blockId, pos.offset, {
+        text: '\uFFFC',
+        style: { image: imageData },
+      });
+      // Advance the caret past the image so the user can keep typing
+      // after the insert, mirroring `insertPageNumber`'s cursor handling.
+      cursor.moveTo({ blockId: pos.blockId, offset: pos.offset + 1 });
+      markDirty(pos.blockId);
+      invalidateLayout();
+      needsScrollIntoView = true;
+      render();
+    },
+    selectImageAt: (blockId: string, offset: number) => {
+      const block = doc.getBlock(blockId);
+      if (!block) return;
+      if (!findImageAtOffset(block, offset)) return;
+      selectedImage = { blockId, offset };
+      render();
+    },
+    clearImageSelection: () => {
+      if (!selectedImage) return;
+      selectedImage = null;
+      render();
+    },
+    getSelectedImage: () => {
+      if (!selectedImage) return null;
+      const block = doc.getBlock(selectedImage.blockId);
+      if (!block) return null;
+      const data = findImageAtOffset(block, selectedImage.offset);
+      if (!data) return null;
+      return {
+        data,
+        blockId: selectedImage.blockId,
+        offset: selectedImage.offset,
+      };
+    },
+    updateSelectedImage: (patch: Partial<ImageData>) => {
+      if (!selectedImage) return;
+      const block = doc.getBlock(selectedImage.blockId);
+      if (!block) return;
+      const current = findImageAtOffset(block, selectedImage.offset);
+      if (!current) return;
+      // Field-level merge: preserve any ImageData fields the caller did
+      // not touch. Shallow merge is correct because ImageData is flat.
+      const merged: ImageData = { ...current, ...patch };
+      docStore.snapshot();
+      doc.applyInlineStyle(
+        {
+          anchor: { blockId: selectedImage.blockId, offset: selectedImage.offset },
+          focus: { blockId: selectedImage.blockId, offset: selectedImage.offset + 1 },
+        },
+        { image: merged },
+      );
+      markDirty(selectedImage.blockId);
+      invalidateLayout();
+      render();
+    },
+    onImageFileDrop: (cb: ((file: File) => void) | null) => {
+      imageFileDropCallback = cb;
+      if (textEditor) {
+        // Wire the clipboard path through TextEditor's paste handler.
+        // `setImageFilePasteHandler` is installed below alongside
+        // `imageKeyHandler`; it checks for image files on the clipboard
+        // first and only falls through to the existing text-paste flow
+        // when none are present.
+        textEditor.imageFilePasteHandler = cb;
+      }
+    },
     insertPageNumber: () => {
       if (!textEditor) return;
       const ctx = textEditor.getEditContext();
@@ -1481,6 +2081,11 @@ export function initialize(
       ruler.dispose();
       cursor.dispose();
       textEditor?.dispose();
+      container.removeEventListener('mousedown', handleImageMouseDown, { capture: true });
+      container.removeEventListener('dragover', handleImageDragOver);
+      container.removeEventListener('drop', handleImageDrop);
+      document.removeEventListener('mousemove', handleImageResizeMouseMove);
+      document.removeEventListener('mouseup', handleImageResizeMouseUp);
       container.removeEventListener('scroll', handleScroll);
       document.removeEventListener('transitionend', handleTransitionEnd);
       resizeObserver.disconnect();

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -122,6 +122,7 @@ export interface EditorAPI {
     alt?: string;
     originalWidth?: number;
     originalHeight?: number;
+    position?: { blockId: string; offset: number };
   }): void;
   /**
    * Programmatically mark the image at `(blockId, offset)` as the selected
@@ -151,7 +152,7 @@ export interface EditorAPI {
    * CORS, and upload endpoints. Only the most recent callback is
    * active; calling this again replaces it.
    */
-  onImageFileDrop(cb: ((file: File) => void) | null): void;
+  onImageFileDrop(cb: ((file: File, position: { blockId: string; offset: number }) => void) | null): void;
   /** Insert a page number token at cursor in header/footer */
   insertPageNumber(): void;
   /** Get the current edit context */
@@ -470,7 +471,7 @@ export function initialize(
    * receive image files from drag-and-drop + clipboard paste. The
    * editor owns the event wiring; the host owns upload + insert.
    */
-  let imageFileDropCallback: ((file: File) => void) | null = null;
+  let imageFileDropCallback: ((file: File, position: { blockId: string; offset: number }) => void) | null = null;
 
   // Compute layout helper
   const recomputeLayout = () => {
@@ -1304,6 +1305,7 @@ export function initialize(
   // click elsewhere clears the image selection and lets TextEditor
   // handle the click normally.
   const handleImageMouseDown = (e: MouseEvent) => {
+    if (readOnly) return;
     if (!layout) return;
     if (e.button !== 0) return;
     const target = e.target as HTMLElement;
@@ -1355,6 +1357,7 @@ export function initialize(
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();
+      selection.setRange(null);
       selectedImage = { blockId: hit.blockId, offset: hit.offset };
       cursor.moveTo({ blockId: hit.blockId, offset: hit.offset });
       render();
@@ -1405,6 +1408,7 @@ export function initialize(
   };
 
   const handleImageDragOver = (e: DragEvent) => {
+    if (readOnly) return;
     if (!imageFileDropCallback) return;
     if (!hasImageItem(e.dataTransfer)) return;
     e.preventDefault();
@@ -1412,6 +1416,7 @@ export function initialize(
   };
 
   const handleImageDrop = (e: DragEvent) => {
+    if (readOnly) return;
     if (!imageFileDropCallback) return;
     const file = getImageFile(e.dataTransfer);
     if (!file) return;
@@ -1423,15 +1428,17 @@ export function initialize(
     // pointer position. If the drop happens outside any block the
     // caret stays where it was.
     const { x: docX, y: docY } = clientToDocCoords(e.clientX, e.clientY);
+    let dropPosition: { blockId: string; offset: number } = { blockId: cursor.position.blockId, offset: cursor.position.offset };
     if (layout) {
       const s = scaleFactor;
       const canvasWidth = canvas.getBoundingClientRect().width / s;
       const hit = paginatedPixelToPosition(paginatedLayout, layout, docX, docY, canvasWidth);
       if (hit) {
         cursor.moveTo({ blockId: hit.blockId, offset: hit.offset });
+        dropPosition = { blockId: hit.blockId, offset: hit.offset };
       }
     }
-    imageFileDropCallback(file);
+    imageFileDropCallback(file, dropPosition);
   };
   container.addEventListener('dragover', handleImageDragOver);
   container.addEventListener('drop', handleImageDrop);
@@ -1960,8 +1967,16 @@ export function initialize(
       src: string,
       width: number,
       height: number,
-      opts?: { alt?: string; originalWidth?: number; originalHeight?: number },
+      opts?: { alt?: string; originalWidth?: number; originalHeight?: number; position?: { blockId: string; offset: number } },
     ) => {
+      if (readOnly) return;
+      // If an explicit position was captured at drop/paste time, move
+      // the cursor there before inserting so an async upload that
+      // finishes after the user moved the caret still lands at the
+      // original location.
+      if (opts?.position) {
+        cursor.moveTo(opts.position);
+      }
       // Clamp the displayed width to the page's content width so a
       // 4000px screenshot pasted into an 8.5" page doesn't punch past
       // the right margin. Aspect ratio is preserved by
@@ -2005,6 +2020,7 @@ export function initialize(
       const block = doc.getBlock(blockId);
       if (!block) return;
       if (!findImageAtOffset(block, offset)) return;
+      selection.setRange(null);
       selectedImage = { blockId, offset };
       render();
     },
@@ -2026,6 +2042,7 @@ export function initialize(
       };
     },
     updateSelectedImage: (patch: Partial<ImageData>) => {
+      if (readOnly) return;
       if (!selectedImage) return;
       const block = doc.getBlock(selectedImage.blockId);
       if (!block) return;
@@ -2046,7 +2063,7 @@ export function initialize(
       invalidateLayout();
       render();
     },
-    onImageFileDrop: (cb: ((file: File) => void) | null) => {
+    onImageFileDrop: (cb: ((file: File, position: { blockId: string; offset: number }) => void) | null) => {
       imageFileDropCallback = cb;
       if (textEditor) {
         // Wire the clipboard path through TextEditor's paste handler.

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -2095,6 +2095,9 @@ export function initialize(
       peerCursors = [];
       cursorMoveCallback = null;
       lastPeerPixels = [];
+      selectedImage = null;
+      imageResizeDrag = null;
+      imageFileDropCallback = null;
       ruler.dispose();
       cursor.dispose();
       textEditor?.dispose();

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1378,8 +1378,26 @@ export function initialize(
    * registered callback. Non-image drops fall through to the
    * browser's default (no-op on a canvas).
    */
-  const hasImageFile = (dt: DataTransfer | null): File | null => {
-    if (!dt || !dt.files || dt.files.length === 0) return null;
+  /**
+   * Check `dataTransfer.items` for an image file entry. Usable in
+   * both `dragover` and `drop` — unlike `dt.files`, which the browser
+   * leaves **empty during `dragover`** for security, `dt.items`
+   * exposes each entry's MIME type at drag time so we can accept or
+   * reject the drop before the user releases the mouse. Without this
+   * the `dragover` handler never calls `preventDefault()` and the
+   * browser navigates to the dropped image URL (its default behavior).
+   */
+  const hasImageItem = (dt: DataTransfer | null): boolean => {
+    if (!dt?.items) return false;
+    for (const item of dt.items) {
+      if (item.kind === 'file' && item.type.startsWith('image/')) return true;
+    }
+    return false;
+  };
+
+  /** Extract the first image `File` from the drop. Only works on `drop`. */
+  const getImageFile = (dt: DataTransfer | null): File | null => {
+    if (!dt?.files) return null;
     for (const file of dt.files) {
       if (file.type.startsWith('image/')) return file;
     }
@@ -1388,15 +1406,14 @@ export function initialize(
 
   const handleImageDragOver = (e: DragEvent) => {
     if (!imageFileDropCallback) return;
-    const file = hasImageFile(e.dataTransfer);
-    if (!file) return;
+    if (!hasImageItem(e.dataTransfer)) return;
     e.preventDefault();
     if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
   };
 
   const handleImageDrop = (e: DragEvent) => {
     if (!imageFileDropCallback) return;
-    const file = hasImageFile(e.dataTransfer);
+    const file = getImageFile(e.dataTransfer);
     if (!file) return;
     e.preventDefault();
     e.stopPropagation();

--- a/packages/docs/src/view/image-selection-overlay.ts
+++ b/packages/docs/src/view/image-selection-overlay.ts
@@ -1,0 +1,478 @@
+import type { DocumentLayout, LayoutBlock } from './layout.js';
+import type { PaginatedLayout } from './pagination.js';
+import { getPageXOffset, getPageYOffset } from './pagination.js';
+
+/**
+ * Axis-aligned rectangle in document-layout coordinates (i.e. the same
+ * coordinate space the canvas render uses before the `-scrollY`
+ * translate). All values are in CSS pixels.
+ */
+export interface ImageRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Identifier for one of the eight resize handles around a selection. */
+export type ImageHandle = 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w';
+
+/** Side length of each square handle, in CSS pixels. */
+export const HANDLE_SIZE = 8;
+/** Half of HANDLE_SIZE — handy for the center-based hit math. */
+export const HANDLE_HALF = HANDLE_SIZE / 2;
+/** Extra slack around the handle center for pointer-friendly hit testing. */
+const HANDLE_HIT_SLACK = 2;
+
+/** Ordered handle list so drawing and hit testing share a single source. */
+export const IMAGE_HANDLES: readonly ImageHandle[] = [
+  'nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w',
+];
+
+/**
+ * Return the center point of a given handle on the rect.
+ */
+export function handleCenter(rect: ImageRect, handle: ImageHandle): { x: number; y: number } {
+  const xMid = rect.x + rect.width / 2;
+  const yMid = rect.y + rect.height / 2;
+  const xRight = rect.x + rect.width;
+  const yBot = rect.y + rect.height;
+  switch (handle) {
+    case 'nw': return { x: rect.x, y: rect.y };
+    case 'n':  return { x: xMid, y: rect.y };
+    case 'ne': return { x: xRight, y: rect.y };
+    case 'e':  return { x: xRight, y: yMid };
+    case 'se': return { x: xRight, y: yBot };
+    case 's':  return { x: xMid, y: yBot };
+    case 'sw': return { x: rect.x, y: yBot };
+    case 'w':  return { x: rect.x, y: yMid };
+  }
+}
+
+/**
+ * Draw a small dimensions pill anchored to the bottom-right of the
+ * given rect. Used as an in-drag HUD so users can see the exact
+ * pixel size they're resizing to, plus whether the aspect ratio is
+ * currently locked. Reuses the ctx's transform — call this *after*
+ * `drawImageSelection` so the pill appears above any handle that
+ * would otherwise overlap it.
+ *
+ * Text is drawn in the canvas's native font; the caller doesn't
+ * need to set one first. The pill clamps its x position so it never
+ * extends past the left edge of the rect when the rect is very wide.
+ */
+export function drawResizeHud(
+  ctx: CanvasRenderingContext2D,
+  rect: ImageRect,
+  text: string,
+  opts: { background: string; textColor: string } = {
+    background: '#1a73e8',
+    textColor: '#ffffff',
+  },
+): void {
+  ctx.save();
+  ctx.font = '11px system-ui, -apple-system, sans-serif';
+  ctx.textBaseline = 'middle';
+  const padX = 6;
+  const height = 18;
+  const metrics = ctx.measureText(text);
+  const width = Math.ceil(metrics.width) + padX * 2;
+
+  // Anchor bottom-right corner, 6px below the rect. Shift left if
+  // the rect is narrower than the pill so the pill right-aligns to
+  // the rect's right edge rather than spilling past it.
+  const x = Math.round(rect.x + rect.width - width);
+  const y = Math.round(rect.y + rect.height + 6);
+
+  // Background: rounded rect for a pill look. Falls back to a plain
+  // fillRect if the 2D context doesn't support roundRect (older
+  // browsers, jsdom).
+  ctx.fillStyle = opts.background;
+  const roundRect = (ctx as unknown as {
+    roundRect?: (x: number, y: number, w: number, h: number, r: number) => void;
+  }).roundRect;
+  if (typeof roundRect === 'function') {
+    ctx.beginPath();
+    roundRect.call(ctx, x, y, width, height, 4);
+    ctx.fill();
+  } else {
+    ctx.fillRect(x, y, width, height);
+  }
+
+  ctx.fillStyle = opts.textColor;
+  ctx.fillText(text, x + padX, y + height / 2 + 0.5);
+  ctx.restore();
+}
+
+/**
+ * Format the HUD label for an in-progress resize drag. Corner drags
+ * include a "ratio" / "free" suffix so the user can tell at a glance
+ * whether holding Shift has released the aspect-ratio lock; side
+ * drags show pure dimensions because there is no lock to release.
+ */
+export function formatResizeHud(
+  handle: ImageHandle,
+  rect: ImageRect,
+  aspectLocked: boolean,
+): string {
+  const w = Math.round(rect.width);
+  const h = Math.round(rect.height);
+  const isCorner =
+    handle === 'nw' || handle === 'ne' || handle === 'sw' || handle === 'se';
+  if (!isCorner) return `${w} × ${h}`;
+  return `${w} × ${h}  ·  ${aspectLocked ? 'ratio' : 'free'}`;
+}
+
+/**
+ * Draw the selection overlay (thin rect + eight handles) on top of an
+ * already-rendered image. Caller is expected to have set the canvas
+ * origin such that `rect` is in the current coordinate space (the
+ * DocCanvas render loop is already translated by `-scrollY`, so the
+ * layout-coordinate rect can be passed through directly).
+ */
+export function drawImageSelection(
+  ctx: CanvasRenderingContext2D,
+  rect: ImageRect,
+  opts: { borderColor: string; handleFill: string; handleStroke: string } = {
+    borderColor: '#1a73e8',
+    handleFill: '#ffffff',
+    handleStroke: '#1a73e8',
+  },
+): void {
+  ctx.save();
+  // Selection rectangle. Offset by 0.5 so the 1px stroke lands on a
+  // pixel center and stays crisp.
+  ctx.strokeStyle = opts.borderColor;
+  ctx.lineWidth = 1;
+  ctx.strokeRect(
+    Math.round(rect.x) + 0.5,
+    Math.round(rect.y) + 0.5,
+    Math.round(rect.width),
+    Math.round(rect.height),
+  );
+
+  // Eight handles. White fill with a matching stroke so they're visible
+  // on both light- and dark-themed image content.
+  ctx.fillStyle = opts.handleFill;
+  ctx.strokeStyle = opts.handleStroke;
+  ctx.lineWidth = 1;
+  for (const handle of IMAGE_HANDLES) {
+    const c = handleCenter(rect, handle);
+    const hx = Math.round(c.x - HANDLE_HALF);
+    const hy = Math.round(c.y - HANDLE_HALF);
+    ctx.fillRect(hx, hy, HANDLE_SIZE, HANDLE_SIZE);
+    ctx.strokeRect(hx + 0.5, hy + 0.5, HANDLE_SIZE - 1, HANDLE_SIZE - 1);
+  }
+  ctx.restore();
+}
+
+/**
+ * Return which handle — if any — the pointer `(x, y)` lies on. The
+ * hit region extends slightly beyond the drawn handle for a more
+ * forgiving click target.
+ */
+export function hitTestImageHandle(
+  rect: ImageRect,
+  x: number,
+  y: number,
+): ImageHandle | null {
+  const reach = HANDLE_HALF + HANDLE_HIT_SLACK;
+  for (const handle of IMAGE_HANDLES) {
+    const c = handleCenter(rect, handle);
+    if (Math.abs(x - c.x) <= reach && Math.abs(y - c.y) <= reach) {
+      return handle;
+    }
+  }
+  return null;
+}
+
+/** True if `(x, y)` lies inside the image's bounding rectangle. */
+export function hitTestImageRect(rect: ImageRect, x: number, y: number): boolean {
+  return (
+    x >= rect.x &&
+    x <= rect.x + rect.width &&
+    y >= rect.y &&
+    y <= rect.y + rect.height
+  );
+}
+
+/**
+ * CSS cursor name to show when hovering the given handle. Matches Google
+ * Docs — corners use the diagonal-resize cursors, side handles use axis
+ * ones.
+ */
+export function cursorForHandle(handle: ImageHandle): string {
+  switch (handle) {
+    case 'nw': case 'se': return 'nwse-resize';
+    case 'ne': case 'sw': return 'nesw-resize';
+    case 'n':  case 's':  return 'ns-resize';
+    case 'e':  case 'w':  return 'ew-resize';
+  }
+}
+
+/**
+ * Walk the document layout and return a map from `${blockId}:${offset}`
+ * to the image's screen-space bounding box. Covers body paragraphs and
+ * simple (non-merged, non-row-spanning, top-aligned) table cells.
+ *
+ * The offset key is the block-level character offset of the image run's
+ * first character within the inner block (for cell images, that inner
+ * block is the cell's paragraph / list-item). This matches the
+ * `selectedImage.offset` value the editor stores and the value it
+ * passes to `cursor.moveTo` / `doc.applyInlineStyle`, which are
+ * already cell-aware downstream.
+ */
+export function collectImageRects(
+  layout: DocumentLayout,
+  paginatedLayout: PaginatedLayout,
+  canvasWidth: number,
+): Map<string, ImageRect> {
+  const map = new Map<string, ImageRect>();
+  if (paginatedLayout.pages.length === 0) return map;
+
+  const pageX = getPageXOffset(paginatedLayout, canvasWidth);
+
+  // The math here MUST match `DocCanvas.renderRun`'s image branch
+  // exactly or the selection overlay drifts off the picture:
+  //   renderRun receives lineX = pageX + pl.x and lineY = pageY + pl.y,
+  //   then draws at (lineX + run.x, lineY + lineHeight - drawHeight).
+  // Note that `pl.x` / `pl.y` *already* include the page margins —
+  // pagination.ts sets them to `margins.left` / `margins.top + currentY`
+  // when it places each PageLine. Adding `margins.left` here a second
+  // time would shift every handle right by one margin width.
+  for (const page of paginatedLayout.pages) {
+    const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
+    for (const pl of page.lines) {
+      const lb = layout.blocks[pl.blockIndex] as LayoutBlock | undefined;
+      if (!lb) continue;
+
+      if (lb.block.type === 'table') {
+        collectTableCellImageRects(lb, pl, pageY, pageX, map);
+        continue;
+      }
+
+      const line = lb.lines[pl.lineIndex];
+      if (!line) continue;
+      const lineHeight = pl.line.height;
+
+      // Walk every line of the block up to the current one once to get
+      // the block-level character offset of the first run on `line`.
+      let blockOffset = 0;
+      for (let li = 0; li < pl.lineIndex; li++) {
+        for (const r of lb.lines[li].runs) {
+          blockOffset += r.charEnd - r.charStart;
+        }
+      }
+
+      for (const run of line.runs) {
+        if (run.inline.style.image) {
+          const drawHeight = run.imageHeight ?? lineHeight;
+          const x = pageX + pl.x + run.x;
+          const y = pageY + pl.y + lineHeight - drawHeight;
+          const key = `${lb.block.id}:${blockOffset}`;
+          map.set(key, { x, y, width: run.width, height: drawHeight });
+        }
+        blockOffset += run.charEnd - run.charStart;
+      }
+    }
+  }
+  return map;
+}
+
+/**
+ * Extend the image-rect map with images found inside the row at
+ * `pl.lineIndex` of the table block `lb`. Mirrors the position math
+ * used by `renderTableContent`:
+ *
+ *   cellX = pageX + margins.left + columnXOffsets[c] + padding + run.x
+ *   cellY = pageY + pl.y + padding + line.y + line.height - drawHeight
+ *
+ * Restricted to non-merged, non-row-spanning, top-aligned cells in
+ * this pass. Merged/row-spanning/vertically-aligned cells fall back
+ * to "not selectable" — M2 scope trade-off; the body path keeps
+ * working and the common case (image inside a simple cell) is now
+ * live. More exotic layouts land in a follow-up once the row-span
+ * pagination math is shared out of the table renderer.
+ */
+function collectTableCellImageRects(
+  lb: LayoutBlock,
+  pl: { lineIndex: number; x: number; y: number },
+  pageY: number,
+  pageX: number,
+  out: Map<string, ImageRect>,
+): void {
+  const tableData = lb.block.tableData;
+  const layoutTable = lb.layoutTable;
+  if (!tableData || !layoutTable) return;
+  const r = pl.lineIndex;
+  const rowCells = layoutTable.cells[r];
+  if (!rowCells) return;
+  const dataRow = tableData.rows[r];
+  if (!dataRow) return;
+
+  // Note: `pl.x` for a table row is `margins.left` (see pagination.ts
+  // where table row PageLines are constructed), matching the body
+  // path. We use `pl.x` directly here so the two code paths stay
+  // symmetric and the test fixtures don't need table-specific
+  // pl.x / pl.y values.
+  for (let c = 0; c < rowCells.length; c++) {
+    const layoutCell = rowCells[c];
+    if (layoutCell.merged) continue;
+    const cell = dataRow.cells[c];
+    if (!cell) continue;
+
+    const colSpan = cell.colSpan ?? 1;
+    const rowSpan = cell.rowSpan ?? 1;
+    if (rowSpan > 1) continue; // row-spanning cells: follow-up
+    const verticalAlign = cell.style?.verticalAlign ?? 'top';
+    if (verticalAlign !== 'top') continue; // non-top: follow-up
+
+    const padding = cell.style?.padding ?? 4;
+    const cellX = pageX + pl.x + layoutTable.columnXOffsets[c];
+    const cellY = pageY + pl.y;
+
+    // Walk the cell's lines, tracking which block each line belongs
+    // to (cells can hold multiple paragraphs / list-items) and the
+    // running character offset within that block.
+    const boundaries = layoutCell.blockBoundaries;
+    let currentBlockIdx = 0;
+    let offsetInBlock = 0;
+    for (let li = 0; li < layoutCell.lines.length; li++) {
+      // Advance `currentBlockIdx` when the line crosses a block
+      // boundary. `blockBoundaries[bi]` is the first line index of
+      // block `bi`; the while-loop handles consecutive empty blocks
+      // that start at the same line index defensively.
+      while (
+        currentBlockIdx + 1 < boundaries.length &&
+        boundaries[currentBlockIdx + 1] <= li
+      ) {
+        currentBlockIdx++;
+        offsetInBlock = 0;
+      }
+      const innerBlock = cell.blocks[currentBlockIdx];
+      if (!innerBlock) break;
+
+      const line = layoutCell.lines[li];
+      for (const run of line.runs) {
+        if (run.inline.style.image) {
+          const drawHeight = run.imageHeight ?? line.height;
+          const x = cellX + padding + run.x;
+          const y = cellY + padding + line.y + line.height - drawHeight;
+          const key = `${innerBlock.id}:${offsetInBlock}`;
+          out.set(key, { x, y, width: run.width, height: drawHeight });
+        }
+        offsetInBlock += run.charEnd - run.charStart;
+      }
+    }
+    // `colSpan` is unused for image layout (the image still sits at
+    // the cell's top-left corner regardless of its span width), but
+    // lint would complain about the unused `cell.colSpan ?? 1` read
+    // above without this explicit touch.
+    void colSpan;
+  }
+}
+
+/**
+ * Given a map of image rects (produced by `collectImageRects`) and a
+ * pointer position, return the first image whose rect contains the
+ * pointer. `null` if the pointer isn't over any image.
+ */
+export function findImageAtPoint(
+  rects: Map<string, ImageRect>,
+  x: number,
+  y: number,
+): { blockId: string; offset: number; rect: ImageRect } | null {
+  for (const [key, rect] of rects) {
+    if (hitTestImageRect(rect, x, y)) {
+      const sep = key.lastIndexOf(':');
+      const blockId = key.slice(0, sep);
+      const offset = Number.parseInt(key.slice(sep + 1), 10);
+      return { blockId, offset, rect };
+    }
+  }
+  return null;
+}
+
+/** Minimum side length of an image during resize, in CSS pixels. */
+export const MIN_IMAGE_DIMENSION = 20;
+
+/**
+ * Compute the new width/height of an image being resized from a given
+ * handle, based on the pointer delta relative to the drag start.
+ *
+ * - Side handles (`n`, `s`, `e`, `w`) only change one axis.
+ * - Corner handles change both axes. If `aspectLock` is true, the
+ *   corner scales uniformly — we pick whichever axis moved more
+ *   (in proportional terms) and drive the other off it. This matches
+ *   the Google Docs behavior where a corner drag always produces a
+ *   similar-shape image unless the user holds Shift.
+ * - Results are clamped to `[MIN_IMAGE_DIMENSION, maxWidth/maxHeight]`.
+ *
+ * Pure function — anchor math lives in `computePreviewRect`.
+ */
+export function computeResizeDelta(
+  handle: ImageHandle,
+  startWidth: number,
+  startHeight: number,
+  dx: number,
+  dy: number,
+  opts: {
+    aspectLock: boolean;
+    maxWidth: number;
+    maxHeight: number;
+  },
+): { width: number; height: number } {
+  const hasEast = handle === 'ne' || handle === 'e' || handle === 'se';
+  const hasWest = handle === 'nw' || handle === 'w' || handle === 'sw';
+  const hasNorth = handle === 'nw' || handle === 'n' || handle === 'ne';
+  const hasSouth = handle === 'sw' || handle === 's' || handle === 'se';
+
+  let width = startWidth;
+  let height = startHeight;
+  if (hasEast) width = startWidth + dx;
+  if (hasWest) width = startWidth - dx;
+  if (hasSouth) height = startHeight + dy;
+  if (hasNorth) height = startHeight - dy;
+
+  const isCorner = (hasEast || hasWest) && (hasNorth || hasSouth);
+  if (isCorner && opts.aspectLock && startWidth > 0 && startHeight > 0) {
+    // Scale uniformly along whichever axis moved more (proportionally).
+    // Using abs(scale - 1) keeps the dominant axis independent of whether
+    // the user is enlarging or shrinking.
+    const wScale = width / startWidth;
+    const hScale = height / startHeight;
+    const scale =
+      Math.abs(wScale - 1) >= Math.abs(hScale - 1) ? wScale : hScale;
+    width = startWidth * scale;
+    height = startHeight * scale;
+  }
+
+  // Clamp to min/max. Apply min first so the max check doesn't fight it.
+  width = Math.max(MIN_IMAGE_DIMENSION, Math.min(width, opts.maxWidth));
+  height = Math.max(MIN_IMAGE_DIMENSION, Math.min(height, opts.maxHeight));
+  return { width, height };
+}
+
+/**
+ * Build the preview rect for an in-progress resize. The rect is
+ * anchored on the opposite corner / edge of the handle being dragged
+ * so the non-dragged side stays visually pinned, just like Google Docs.
+ */
+export function computePreviewRect(
+  startRect: ImageRect,
+  handle: ImageHandle,
+  previewWidth: number,
+  previewHeight: number,
+): ImageRect {
+  let x = startRect.x;
+  let y = startRect.y;
+  if (handle === 'nw' || handle === 'w' || handle === 'sw') {
+    // West edge is being dragged — anchor on east.
+    x = startRect.x + startRect.width - previewWidth;
+  }
+  if (handle === 'nw' || handle === 'n' || handle === 'ne') {
+    // North edge is being dragged — anchor on south.
+    y = startRect.y + startRect.height - previewHeight;
+  }
+  return { x, y, width: previewWidth, height: previewHeight };
+}

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -1,4 +1,5 @@
 import type { LayoutTable, LayoutTableCell } from './table-layout.js';
+import type { LayoutRun } from './layout.js';
 import type { TableData, BorderStyle } from '../model/types.js';
 import { DEFAULT_BORDER_STYLE, LIST_INDENT_PX, UNORDERED_MARKERS } from '../model/types.js';
 import { Theme, buildFont, ptToPx } from './theme.js';
@@ -171,6 +172,14 @@ export function renderTableContent(
   endRow?: number,
   pageStartRow?: number,
   requestRender?: () => void,
+  /**
+   * Optional: a LayoutRun that is currently being resized. When
+   * supplied, the content pass skips drawing that specific image run
+   * so the editor's drag-lift pass can draw the image at the
+   * preview rect with a drop shadow instead. Exactly mirrors the
+   * same skip in `DocCanvas.render`'s body loop.
+   */
+  dragImageRun?: LayoutRun,
 ): void {
   const { rows } = tableData;
   const { cells, columnXOffsets, columnPixelWidths, rowYOffsets, rowHeights } = tableLayout;
@@ -257,6 +266,11 @@ export function renderTableContent(
           lineAbsoluteY = cellY + textYOffset + line.y;
         }
         for (const run of line.runs) {
+          // Drag-lift: skip the image currently being resized so the
+          // editor's separate shadow pass can draw it at the preview
+          // rect instead. Symmetric with the body-block path in
+          // `DocCanvas.render`.
+          if (dragImageRun && run === dragImageRun) continue;
           const style = run.inline.style;
           const fontSize = style.fontSize ?? Theme.defaultFontSize;
           const fontSizePx = ptToPx(fontSize);

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -132,7 +132,7 @@ export class TextEditor {
    * image file, the handler is never called and paste proceeds
    * normally.
    */
-  imageFilePasteHandler: ((file: File) => void) | null = null;
+  imageFilePasteHandler: ((file: File, position: { blockId: string; offset: number }) => void) | null = null;
 
   /**
    * Optional hover pre-handler invoked inside `handleMouseMove` right
@@ -726,7 +726,7 @@ export class TextEditor {
         if (item.kind === 'file' && item.type.startsWith('image/')) {
           const file = item.getAsFile();
           if (file) {
-            this.imageFilePasteHandler(file);
+            this.imageFilePasteHandler(file, { blockId: this.cursor.position.blockId, offset: this.cursor.position.offset });
             return;
           }
         }

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -113,6 +113,37 @@ export class TextEditor {
   /** Callback to update the drag guideline overlay in the editor paint loop. */
   onDragGuideline?: (pos: { x?: number; y?: number } | null) => void;
 
+  /**
+   * Optional pre-handler for key events. When set, called at the very
+   * top of `handleKeyDown` (after the IME guard). Returning `true` marks
+   * the event as fully consumed — the normal text-editor path is
+   * skipped. The parent editor uses this to let an active image
+   * selection absorb Delete/Backspace/Escape without routing through
+   * text editing.
+   */
+  imageKeyHandler: ((e: KeyboardEvent) => boolean) | null = null;
+
+  /**
+   * Optional handler for image files pasted from the clipboard. When
+   * set and the paste carries at least one `kind === 'file'` item
+   * with an image MIME type, the handler is invoked with the first
+   * matching file and the paste is considered fully handled — the
+   * existing rich-text paste flow is skipped. When the paste has no
+   * image file, the handler is never called and paste proceeds
+   * normally.
+   */
+  imageFilePasteHandler: ((file: File) => void) | null = null;
+
+  /**
+   * Optional hover pre-handler invoked inside `handleMouseMove` right
+   * before the default `setCanvasCursor('text')` call. Returning
+   * `true` signals that the image overlay owns the cursor for this
+   * pointer position (e.g. hovering a resize handle) — the text
+   * cursor reset is skipped so the resize cursor stays visible.
+   * Returning `false` falls through to the normal text-cursor path.
+   */
+  imageHoverHandler: ((e: MouseEvent) => boolean) | null = null;
+
   /** Callback invoked when edit context changes (body/header/footer). */
   private editContextChangeCallback?: (context: EditContext) => void;
 
@@ -354,6 +385,15 @@ export class TextEditor {
     this.shiftHeld = e.shiftKey;
     // Don't intercept keys during IME composition
     if (this.composition.active || e.isComposing) return;
+
+    // Image selection consumes certain keys (Delete / Backspace / Escape)
+    // before the text-editor path sees them. For any other key, the
+    // handler clears the image selection and returns false so the event
+    // continues to the text editor — this matches Google Docs where
+    // typing while an image is selected replaces the image with text.
+    if (this.imageKeyHandler && this.imageKeyHandler(e)) {
+      return;
+    }
 
     const { ctrlKey, metaKey, shiftKey, altKey } = e;
     const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
@@ -676,6 +716,22 @@ export class TextEditor {
 
   private handlePaste = (e: ClipboardEvent): void => {
     e.preventDefault();
+
+    // Image file paste — takes priority over any text payload. Many
+    // screenshot tools populate both `image/png` and `text/plain` on
+    // the clipboard; the text is usually garbage ("Image") and the
+    // user expects the picture to land in the doc.
+    if (this.imageFilePasteHandler && e.clipboardData) {
+      for (const item of e.clipboardData.items) {
+        if (item.kind === 'file' && item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) {
+            this.imageFilePasteHandler(file);
+            return;
+          }
+        }
+      }
+    }
 
     // Try rich internal paste first
     const json = e.clipboardData?.getData(WAFFLEDOCS_MIME);
@@ -1035,7 +1091,9 @@ export class TextEditor {
       return;
     }
 
-    // Cursor style: check for border proximity
+    // Cursor style: check for border proximity first, then fall back
+    // to the image overlay hover handler (which may claim the cursor
+    // for a resize handle), and finally the default text cursor.
     const tableInfo = this.resolveTableFromMouse(e);
     if (tableInfo) {
       const tableData = this.doc.getBlock(tableInfo.tableBlockId).tableData;
@@ -1049,9 +1107,13 @@ export class TextEditor {
       );
       if (hit) {
         this.setCanvasCursor(hit.type === 'column' ? 'col-resize' : 'row-resize');
+      } else if (this.imageHoverHandler && this.imageHoverHandler(e)) {
+        // Image overlay owns the cursor for this position.
       } else {
         this.setCanvasCursor('text');
       }
+    } else if (this.imageHoverHandler && this.imageHoverHandler(e)) {
+      // Image overlay owns the cursor for this position.
     } else {
       this.setCanvasCursor('text');
     }

--- a/packages/docs/test/model/types.test.ts
+++ b/packages/docs/test/model/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { HeadingLevel, Document, Inline, InlineStyle } from '../../src/model/types.js';
+import type { HeadingLevel, Document, Inline, InlineStyle, Block } from '../../src/model/types.js';
 import {
   DEFAULT_BLOCK_STYLE,
   DEFAULT_PAGE_SETUP,
@@ -13,6 +13,8 @@ import {
   inlineStylesEqual,
   createTableCell,
   createTableBlock,
+  findImageAtOffset,
+  clampImageToWidth,
 } from '../../src/model/types.js';
 
 describe('BlockStyle', () => {
@@ -258,5 +260,123 @@ describe('ImageData on InlineStyle', () => {
     };
     expect(inlineStylesEqual(a, b)).toBe(true);
     expect(inlineStylesEqual(a, c)).toBe(false);
+  });
+
+  it('imageDataEqual distinguishes rotation', () => {
+    const a: InlineStyle = {
+      image: { src: 'x.png', width: 10, height: 10, rotation: 90 },
+    };
+    const b: InlineStyle = {
+      image: { src: 'x.png', width: 10, height: 10, rotation: 180 },
+    };
+    expect(inlineStylesEqual(a, b)).toBe(false);
+  });
+
+  it('imageDataEqual distinguishes each crop edge independently', () => {
+    const base = { src: 'x.png', width: 10, height: 10 };
+    const fields = ['cropLeft', 'cropRight', 'cropTop', 'cropBottom'] as const;
+    for (const field of fields) {
+      const a: InlineStyle = { image: { ...base } };
+      const b: InlineStyle = { image: { ...base, [field]: 0.25 } };
+      expect(
+        inlineStylesEqual(a, b),
+        `expected change in ${field} to be detected`,
+      ).toBe(false);
+    }
+  });
+
+  it('imageDataEqual distinguishes originalWidth/Height', () => {
+    const a: InlineStyle = {
+      image: { src: 'x.png', width: 10, height: 10, originalWidth: 100, originalHeight: 80 },
+    };
+    const b: InlineStyle = {
+      image: { src: 'x.png', width: 10, height: 10, originalWidth: 200, originalHeight: 80 },
+    };
+    expect(inlineStylesEqual(a, b)).toBe(false);
+  });
+
+  it('imageDataEqual treats undefined rotation as distinct from 0', () => {
+    // Kept as a guard against accidentally normalizing `rotation: 0` into
+    // `undefined` at equality time — stored documents should round-trip
+    // exactly what was written, not what would have rendered identically.
+    const a: InlineStyle = { image: { src: 'x.png', width: 10, height: 10 } };
+    const b: InlineStyle = {
+      image: { src: 'x.png', width: 10, height: 10, rotation: 0 },
+    };
+    expect(inlineStylesEqual(a, b)).toBe(false);
+  });
+});
+
+describe('clampImageToWidth', () => {
+  it('returns the image unchanged when it already fits', () => {
+    expect(clampImageToWidth(100, 50, 800)).toEqual({ width: 100, height: 50 });
+  });
+
+  it('scales width down to maxWidth and height proportionally', () => {
+    // 4000×2000 source (2:1) → max 800 → 800×400.
+    expect(clampImageToWidth(4000, 2000, 800)).toEqual({ width: 800, height: 400 });
+  });
+
+  it('rounds the scaled height to the nearest pixel', () => {
+    // 300×151 source → max 200 → scale 200/300 ≈ 0.6667 → h = 151 * 0.6667 ≈ 100.67 → 101.
+    expect(clampImageToWidth(300, 151, 200)).toEqual({ width: 200, height: 101 });
+  });
+
+  it('clamps degenerate very-short images to height >= 1', () => {
+    // A 10000×1 banner scaling to 100: height = round(0.01) = 0 → clamped to 1.
+    expect(clampImageToWidth(10000, 1, 100)).toEqual({ width: 100, height: 1 });
+  });
+
+  it('returns the input unchanged when width is zero', () => {
+    expect(clampImageToWidth(0, 50, 200)).toEqual({ width: 0, height: 50 });
+  });
+
+  it('returns the input unchanged when width is negative', () => {
+    expect(clampImageToWidth(-10, 50, 200)).toEqual({ width: -10, height: 50 });
+  });
+
+  it('handles exact-fit width as a no-op', () => {
+    expect(clampImageToWidth(200, 100, 200)).toEqual({ width: 200, height: 100 });
+  });
+});
+
+describe('findImageAtOffset', () => {
+  function makeBlock(inlines: Inline[]): Block {
+    return { id: 'b1', type: 'paragraph', inlines, style: { ...DEFAULT_BLOCK_STYLE } };
+  }
+
+  it('returns null when the block has no image inline at the offset', () => {
+    const block = makeBlock([{ text: 'hello', style: {} }]);
+    expect(findImageAtOffset(block, 0)).toBeNull();
+    expect(findImageAtOffset(block, 2)).toBeNull();
+  });
+
+  it('returns the image data when offset falls on the image inline', () => {
+    const img = { src: 'x.png', width: 10, height: 10 };
+    const block = makeBlock([
+      { text: 'ab', style: {} },
+      { text: '\uFFFC', style: { image: img } },
+      { text: 'cd', style: {} },
+    ]);
+    expect(findImageAtOffset(block, 2)).toBe(img);
+  });
+
+  it('returns null for offsets before and after the image inline', () => {
+    const img = { src: 'x.png', width: 10, height: 10 };
+    const block = makeBlock([
+      { text: 'ab', style: {} },
+      { text: '\uFFFC', style: { image: img } },
+      { text: 'cd', style: {} },
+    ]);
+    expect(findImageAtOffset(block, 0)).toBeNull();
+    expect(findImageAtOffset(block, 1)).toBeNull();
+    // offset 3 is on the first char of 'cd', not the image.
+    expect(findImageAtOffset(block, 3)).toBeNull();
+  });
+
+  it('returns null when offset is past the end of the block', () => {
+    const img = { src: 'x.png', width: 10, height: 10 };
+    const block = makeBlock([{ text: '\uFFFC', style: { image: img } }]);
+    expect(findImageAtOffset(block, 5)).toBeNull();
   });
 });

--- a/packages/docs/test/view/image-selection-overlay.test.ts
+++ b/packages/docs/test/view/image-selection-overlay.test.ts
@@ -1,0 +1,702 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  drawImageSelection,
+  hitTestImageHandle,
+  hitTestImageRect,
+  handleCenter,
+  cursorForHandle,
+  collectImageRects,
+  findImageAtPoint,
+  computeResizeDelta,
+  computePreviewRect,
+  formatResizeHud,
+  HANDLE_SIZE,
+  IMAGE_HANDLES,
+  MIN_IMAGE_DIMENSION,
+  type ImageRect,
+  type ImageHandle,
+} from '../../src/view/image-selection-overlay.js';
+import type { DocumentLayout, LayoutBlock } from '../../src/view/layout.js';
+import type { PaginatedLayout } from '../../src/view/pagination.js';
+import { DEFAULT_BLOCK_STYLE, DEFAULT_PAGE_SETUP } from '../../src/model/types.js';
+
+/**
+ * Minimal stub context that records the calls we care about for the
+ * overlay's draw pass. We don't need a real 2D context — only the
+ * primitive counts + arguments — so the tests stay fast and node-only.
+ */
+function makeRecordingCtx() {
+  const strokeRect = vi.fn();
+  const fillRect = vi.fn();
+  const save = vi.fn();
+  const restore = vi.fn();
+  const ctx = {
+    strokeStyle: '',
+    fillStyle: '',
+    lineWidth: 0,
+    save,
+    restore,
+    strokeRect,
+    fillRect,
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, strokeRect, fillRect, save, restore };
+}
+
+describe('handleCenter', () => {
+  const rect: ImageRect = { x: 100, y: 50, width: 200, height: 80 };
+
+  it('returns the four corners at rect corners', () => {
+    expect(handleCenter(rect, 'nw')).toEqual({ x: 100, y: 50 });
+    expect(handleCenter(rect, 'ne')).toEqual({ x: 300, y: 50 });
+    expect(handleCenter(rect, 'sw')).toEqual({ x: 100, y: 130 });
+    expect(handleCenter(rect, 'se')).toEqual({ x: 300, y: 130 });
+  });
+
+  it('returns the midpoints for edge handles', () => {
+    expect(handleCenter(rect, 'n')).toEqual({ x: 200, y: 50 });
+    expect(handleCenter(rect, 's')).toEqual({ x: 200, y: 130 });
+    expect(handleCenter(rect, 'w')).toEqual({ x: 100, y: 90 });
+    expect(handleCenter(rect, 'e')).toEqual({ x: 300, y: 90 });
+  });
+});
+
+describe('drawImageSelection', () => {
+  it('draws the selection rect plus eight handles', () => {
+    const { ctx, strokeRect, fillRect } = makeRecordingCtx();
+    const rect: ImageRect = { x: 10, y: 20, width: 100, height: 60 };
+    drawImageSelection(ctx, rect);
+
+    // One rect stroke for the border, eight handles drawn with
+    // fill + stroke each = 8 fillRect + 9 strokeRect total.
+    expect(fillRect).toHaveBeenCalledTimes(IMAGE_HANDLES.length);
+    expect(strokeRect).toHaveBeenCalledTimes(IMAGE_HANDLES.length + 1);
+  });
+
+  it('draws the border at pixel-center offsets for crispness', () => {
+    const { ctx, strokeRect } = makeRecordingCtx();
+    drawImageSelection(ctx, { x: 10, y: 20, width: 100, height: 60 });
+    // First strokeRect is the selection border — offsets end in .5.
+    const [bx, by] = strokeRect.mock.calls[0];
+    expect(bx).toBeCloseTo(10.5);
+    expect(by).toBeCloseTo(20.5);
+  });
+});
+
+describe('hitTestImageHandle', () => {
+  const rect: ImageRect = { x: 100, y: 100, width: 200, height: 100 };
+
+  it('returns the handle when the pointer is on its center', () => {
+    for (const handle of IMAGE_HANDLES) {
+      const c = handleCenter(rect, handle);
+      expect(hitTestImageHandle(rect, c.x, c.y)).toBe(handle);
+    }
+  });
+
+  it('returns null when the pointer is clearly off every handle', () => {
+    // Inside the rect but nowhere near a handle (dead center).
+    expect(hitTestImageHandle(rect, 200, 150)).toBeNull();
+  });
+
+  it('has forgiving hit slack near handle edges', () => {
+    // nw handle center is at (100, 100). HANDLE_SIZE/2 + slack ≈ 6, so
+    // (105, 105) should still hit it.
+    expect(hitTestImageHandle(rect, 105, 105)).toBe('nw');
+  });
+
+  it('prefers the listed handle when two handles overlap on tiny rects', () => {
+    // A rect smaller than HANDLE_SIZE can make corners overlap. The
+    // implementation iterates in IMAGE_HANDLES order, so nw wins.
+    const tiny: ImageRect = { x: 10, y: 10, width: 2, height: 2 };
+    expect(hitTestImageHandle(tiny, 10, 10)).toBe('nw');
+  });
+});
+
+describe('hitTestImageRect', () => {
+  const rect: ImageRect = { x: 50, y: 50, width: 100, height: 100 };
+  it('detects inside vs outside', () => {
+    expect(hitTestImageRect(rect, 100, 100)).toBe(true);
+    expect(hitTestImageRect(rect, 49, 100)).toBe(false);
+    expect(hitTestImageRect(rect, 200, 100)).toBe(false);
+  });
+  it('treats rect edges as hits', () => {
+    expect(hitTestImageRect(rect, 50, 50)).toBe(true);
+    expect(hitTestImageRect(rect, 150, 150)).toBe(true);
+  });
+});
+
+describe('cursorForHandle', () => {
+  it('maps each handle to the expected CSS cursor', () => {
+    const expected: Record<ImageHandle, string> = {
+      nw: 'nwse-resize', se: 'nwse-resize',
+      ne: 'nesw-resize', sw: 'nesw-resize',
+      n: 'ns-resize',   s: 'ns-resize',
+      e: 'ew-resize',   w: 'ew-resize',
+    };
+    for (const h of IMAGE_HANDLES) {
+      expect(cursorForHandle(h)).toBe(expected[h]);
+    }
+  });
+});
+
+describe('collectImageRects', () => {
+  function makeSingleImageLayout(): { layout: DocumentLayout; paginatedLayout: PaginatedLayout } {
+    const image = { src: 'x.png', width: 120, height: 80 };
+    const lb: LayoutBlock = {
+      block: {
+        id: 'b1',
+        type: 'paragraph',
+        style: { ...DEFAULT_BLOCK_STYLE },
+        inlines: [
+          { text: 'ab', style: {} },
+          { text: '\uFFFC', style: { image } },
+        ],
+      },
+      x: 0,
+      y: 0,
+      width: 500,
+      height: 80,
+      lines: [
+        {
+          y: 0,
+          height: 80,
+          width: 240,
+          runs: [
+            {
+              inline: { text: 'ab', style: {} },
+              text: 'ab',
+              x: 0,
+              width: 20,
+              inlineIndex: 0,
+              charStart: 0,
+              charEnd: 2,
+              charOffsets: [10, 20],
+            },
+            {
+              inline: { text: '\uFFFC', style: { image } },
+              text: '\uFFFC',
+              x: 20,
+              width: 120,
+              inlineIndex: 1,
+              charStart: 0,
+              charEnd: 1,
+              charOffsets: [120],
+              imageHeight: 80,
+            },
+          ],
+        },
+      ],
+    };
+    const layout: DocumentLayout = {
+      blocks: [lb],
+      totalHeight: 80,
+      blockParentMap: new Map(),
+    };
+    // Match what `paginateLayout` produces in production: each
+    // PageLine's x/y already have the page margins baked in
+    // (x = margins.left, y = margins.top + currentY). `collectImageRects`
+    // mirrors `DocCanvas.renderRun` which adds `pageX + pl.x` — adding
+    // `margins.left` a second time would shift handles right.
+    const paginatedLayout: PaginatedLayout = {
+      pageSetup: DEFAULT_PAGE_SETUP,
+      pages: [
+        {
+          pageIndex: 0,
+          width: 816,
+          height: 1056,
+          lines: [
+            {
+              blockIndex: 0,
+              lineIndex: 0,
+              line: lb.lines[0],
+              x: DEFAULT_PAGE_SETUP.margins.left, // 96
+              y: DEFAULT_PAGE_SETUP.margins.top,  // 96
+            },
+          ],
+        },
+      ],
+    };
+    return { layout, paginatedLayout };
+  }
+
+  it('returns a rect keyed by the image run\'s block-level offset', () => {
+    const { layout, paginatedLayout } = makeSingleImageLayout();
+    const rects = collectImageRects(layout, paginatedLayout, 816);
+    // Two characters precede the image ('ab'), so the image's block
+    // offset is 2.
+    expect([...rects.keys()]).toEqual(['b1:2']);
+    const rect = rects.get('b1:2')!;
+    // Left of the image = pageX + pl.x + run.x
+    //                   = 0 + 96 + 20 = 116
+    expect(rect.x).toBe(116);
+    expect(rect.width).toBe(120);
+    expect(rect.height).toBe(80);
+    // Bottom-aligned to the line: y = pageY + pl.y + lineHeight - drawHeight
+    //   pageY = Theme.pageGap = 40 (page 0's top gap)
+    //   pl.y  = margins.top = 96
+    //   lineHeight - drawHeight = 80 - 80 = 0
+    //   → y = 40 + 96 + 0 = 136
+    expect(rect.y).toBe(136);
+  });
+
+  it('returns an empty map when there are no images', () => {
+    const lb: LayoutBlock = {
+      block: {
+        id: 'b1',
+        type: 'paragraph',
+        style: { ...DEFAULT_BLOCK_STYLE },
+        inlines: [{ text: 'hello', style: {} }],
+      },
+      x: 0, y: 0, width: 500, height: 20,
+      lines: [
+        {
+          y: 0,
+          height: 20,
+          width: 50,
+          runs: [
+            {
+              inline: { text: 'hello', style: {} },
+              text: 'hello',
+              x: 0,
+              width: 50,
+              inlineIndex: 0,
+              charStart: 0,
+              charEnd: 5,
+              charOffsets: [10, 20, 30, 40, 50],
+            },
+          ],
+        },
+      ],
+    };
+    const layout: DocumentLayout = {
+      blocks: [lb],
+      totalHeight: 20,
+      blockParentMap: new Map(),
+    };
+    const paginatedLayout: PaginatedLayout = {
+      pageSetup: DEFAULT_PAGE_SETUP,
+      pages: [
+        {
+          pageIndex: 0,
+          width: 816,
+          height: 1056,
+          lines: [
+            {
+              blockIndex: 0,
+              lineIndex: 0,
+              line: lb.lines[0],
+              x: DEFAULT_PAGE_SETUP.margins.left,
+              y: DEFAULT_PAGE_SETUP.margins.top,
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectImageRects(layout, paginatedLayout, 816).size).toBe(0);
+  });
+
+  it('computes rects for images inside simple top-aligned table cells', () => {
+    // One 1×1 table, cell at (0,0) contains a single paragraph with a
+    // pending image inline (`\uFFFC`). The rect math mirrors
+    // `renderTableContent`:
+    //   cellX = pageX + pl.x + columnXOffsets[c]       = 0 + 96 + 10 = 106
+    //   cellY = pageY + pl.y                           = 40 + 96    = 136
+    //   imgX  = cellX + padding + run.x                = 106 + 4 + 0 = 110
+    //   imgY  = cellY + padding + line.y + line.height - drawHeight
+    //         = 136 + 4 + 0 + 80 - 80                   = 140
+    const image = { src: 'cell.png', width: 120, height: 80 };
+    const innerBlockId = 'cell-block-0';
+    const cellData = {
+      blocks: [
+        {
+          id: innerBlockId,
+          type: 'paragraph' as const,
+          style: { ...DEFAULT_BLOCK_STYLE },
+          inlines: [{ text: '\uFFFC', style: { image } }],
+        },
+      ],
+      style: { padding: 4 },
+      colSpan: undefined,
+      rowSpan: undefined,
+    };
+    const tableBlockId = 'table-1';
+    const tableBlock = {
+      id: tableBlockId,
+      type: 'table' as const,
+      style: { ...DEFAULT_BLOCK_STYLE },
+      inlines: [],
+      tableData: {
+        rows: [{ cells: [cellData] }],
+        columnWidths: [1],
+      },
+    };
+    const layoutCell = {
+      lines: [
+        {
+          y: 0,
+          height: 80,
+          width: 120,
+          runs: [
+            {
+              inline: { text: '\uFFFC', style: { image } },
+              text: '\uFFFC',
+              x: 0,
+              width: 120,
+              inlineIndex: 0,
+              charStart: 0,
+              charEnd: 1,
+              charOffsets: [120],
+              imageHeight: 80,
+            },
+          ],
+        },
+      ],
+      blockBoundaries: [0],
+      width: 130,
+      height: 88,
+      merged: false,
+    };
+    const layoutTable = {
+      cells: [[layoutCell]],
+      columnXOffsets: [10],
+      columnPixelWidths: [130],
+      rowYOffsets: [0],
+      rowHeights: [88],
+      totalWidth: 130,
+      totalHeight: 88,
+      blockParentMap: new Map(),
+    };
+    const lb = {
+      block: tableBlock,
+      x: 0,
+      y: 0,
+      width: 130,
+      height: 88,
+      lines: [
+        { y: 0, height: 88, width: 130, runs: [] },
+      ],
+      layoutTable,
+    } as unknown as LayoutBlock;
+    const layout: DocumentLayout = {
+      blocks: [lb],
+      totalHeight: 88,
+      // Cell-block → table info so the editor's cell lookup stays
+      // consistent with what pagination produces.
+      blockParentMap: new Map([
+        [innerBlockId, {
+          tableBlockId,
+          rowIndex: 0,
+          colIndex: 0,
+        }],
+      ]),
+    };
+    const paginatedLayout: PaginatedLayout = {
+      pageSetup: DEFAULT_PAGE_SETUP,
+      pages: [
+        {
+          pageIndex: 0,
+          width: 816,
+          height: 1056,
+          lines: [
+            {
+              blockIndex: 0,
+              lineIndex: 0,
+              line: lb.lines[0],
+              x: DEFAULT_PAGE_SETUP.margins.left,
+              y: DEFAULT_PAGE_SETUP.margins.top,
+            },
+          ],
+        },
+      ],
+    };
+    const rects = collectImageRects(layout, paginatedLayout, 816);
+    expect([...rects.keys()]).toEqual([`${innerBlockId}:0`]);
+    const rect = rects.get(`${innerBlockId}:0`)!;
+    expect(rect.x).toBe(110);
+    expect(rect.y).toBe(140);
+    expect(rect.width).toBe(120);
+    expect(rect.height).toBe(80);
+  });
+
+  it('skips merged placeholder cells', () => {
+    // One 1×2 row with col 1 as a merged placeholder. The placeholder
+    // must NOT emit an image rect even if its `layoutCell.lines`
+    // contains an image run (defensive: in practice merged cells
+    // carry no lines, but the guard matters).
+    const image = { src: 'x.png', width: 50, height: 50 };
+    const fakeImageLine = {
+      y: 0,
+      height: 50,
+      width: 50,
+      runs: [
+        {
+          inline: { text: '\uFFFC', style: { image } },
+          text: '\uFFFC',
+          x: 0,
+          width: 50,
+          inlineIndex: 0,
+          charStart: 0,
+          charEnd: 1,
+          charOffsets: [50],
+          imageHeight: 50,
+        },
+      ],
+    };
+    const ownerCellLayout = {
+      lines: [],
+      blockBoundaries: [0],
+      width: 130,
+      height: 88,
+      merged: false,
+    };
+    const placeholderLayout = {
+      lines: [fakeImageLine], // defensive — should be skipped anyway
+      blockBoundaries: [0],
+      width: 130,
+      height: 88,
+      merged: true,
+    };
+    const layoutTable = {
+      cells: [[ownerCellLayout, placeholderLayout]],
+      columnXOffsets: [0, 130],
+      columnPixelWidths: [130, 130],
+      rowYOffsets: [0],
+      rowHeights: [88],
+      totalWidth: 260,
+      totalHeight: 88,
+      blockParentMap: new Map(),
+    };
+    const lb = {
+      block: {
+        id: 'tbl',
+        type: 'table' as const,
+        style: { ...DEFAULT_BLOCK_STYLE },
+        inlines: [],
+        tableData: {
+          rows: [
+            {
+              cells: [
+                {
+                  blocks: [
+                    {
+                      id: 'owner',
+                      type: 'paragraph' as const,
+                      style: { ...DEFAULT_BLOCK_STYLE },
+                      inlines: [{ text: '', style: {} }],
+                    },
+                  ],
+                  style: { padding: 4 },
+                  colSpan: 2,
+                },
+                {
+                  blocks: [],
+                  style: { padding: 4 },
+                },
+              ],
+            },
+          ],
+          columnWidths: [0.5, 0.5],
+        },
+      },
+      x: 0, y: 0, width: 260, height: 88,
+      lines: [{ y: 0, height: 88, width: 260, runs: [] }],
+      layoutTable,
+    } as unknown as LayoutBlock;
+    const layout: DocumentLayout = {
+      blocks: [lb],
+      totalHeight: 88,
+      blockParentMap: new Map(),
+    };
+    const paginatedLayout: PaginatedLayout = {
+      pageSetup: DEFAULT_PAGE_SETUP,
+      pages: [
+        {
+          pageIndex: 0,
+          width: 816,
+          height: 1056,
+          lines: [
+            {
+              blockIndex: 0,
+              lineIndex: 0,
+              line: lb.lines[0],
+              x: DEFAULT_PAGE_SETUP.margins.left,
+              y: DEFAULT_PAGE_SETUP.margins.top,
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectImageRects(layout, paginatedLayout, 816).size).toBe(0);
+  });
+});
+
+describe('findImageAtPoint', () => {
+  it('returns the matching image and parses the block offset', () => {
+    const rects = new Map<string, ImageRect>([
+      ['block-1:7', { x: 50, y: 50, width: 100, height: 80 }],
+    ]);
+    const hit = findImageAtPoint(rects, 100, 100);
+    expect(hit).not.toBeNull();
+    expect(hit!.blockId).toBe('block-1');
+    expect(hit!.offset).toBe(7);
+  });
+
+  it('handles block IDs that contain colons (uses lastIndexOf)', () => {
+    const rects = new Map<string, ImageRect>([
+      ['block:with:colons:3', { x: 0, y: 0, width: 10, height: 10 }],
+    ]);
+    const hit = findImageAtPoint(rects, 5, 5);
+    expect(hit).not.toBeNull();
+    expect(hit!.blockId).toBe('block:with:colons');
+    expect(hit!.offset).toBe(3);
+  });
+
+  it('returns null when the pointer misses every rect', () => {
+    const rects = new Map<string, ImageRect>([
+      ['b:0', { x: 0, y: 0, width: 10, height: 10 }],
+    ]);
+    expect(findImageAtPoint(rects, 100, 100)).toBeNull();
+  });
+});
+
+describe('HANDLE_SIZE + IMAGE_HANDLES', () => {
+  it('exposes the canonical 8-handle set in drawing order', () => {
+    expect(IMAGE_HANDLES).toEqual(['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w']);
+  });
+  it('uses a visible handle size', () => {
+    expect(HANDLE_SIZE).toBeGreaterThan(0);
+  });
+});
+
+describe('computeResizeDelta', () => {
+  const max = { maxWidth: 1000, maxHeight: 1000, aspectLock: true };
+
+  it('se drag enlarges both dimensions, ratio locked', () => {
+    // Start 100×50 (ratio 2). Drag +40x, +0y. With ratio lock and
+    // the larger proportional change on width, the scale = 1.4 so
+    // width → 140, height → 70.
+    const result = computeResizeDelta('se', 100, 50, 40, 0, max);
+    expect(result.width).toBeCloseTo(140);
+    expect(result.height).toBeCloseTo(70);
+  });
+
+  it('nw drag enlarges both dimensions when both deltas are negative', () => {
+    // NW drag moves the top-left outward (away from the anchor),
+    // which visually enlarges the rect. Delta (-40, 0) on a 100×50
+    // rect → width 140 under aspect lock (height follows via scale).
+    const result = computeResizeDelta('nw', 100, 50, -40, 0, max);
+    expect(result.width).toBeCloseTo(140);
+    expect(result.height).toBeCloseTo(70);
+  });
+
+  it('side handle e changes only width', () => {
+    const result = computeResizeDelta('e', 100, 50, 30, 0, { ...max, aspectLock: false });
+    expect(result.width).toBe(130);
+    expect(result.height).toBe(50);
+  });
+
+  it('side handle s changes only height', () => {
+    const result = computeResizeDelta('s', 100, 50, 0, 25, { ...max, aspectLock: false });
+    expect(result.width).toBe(100);
+    expect(result.height).toBe(75);
+  });
+
+  it('corner handle without aspect lock drives each axis independently', () => {
+    // Shift held → aspectLock: false. SE drag with (dx=40, dy=-10)
+    // maps to width 140, height 40 without any ratio correction.
+    const result = computeResizeDelta('se', 100, 50, 40, -10, { ...max, aspectLock: false });
+    expect(result.width).toBe(140);
+    expect(result.height).toBe(40);
+  });
+
+  it('clamps to MIN_IMAGE_DIMENSION on shrink', () => {
+    const result = computeResizeDelta('se', 100, 50, -500, -500, { ...max, aspectLock: false });
+    expect(result.width).toBe(MIN_IMAGE_DIMENSION);
+    expect(result.height).toBe(MIN_IMAGE_DIMENSION);
+  });
+
+  it('clamps to maxWidth/Height on enlarge', () => {
+    const result = computeResizeDelta('se', 100, 50, 5000, 5000, { ...max, aspectLock: false });
+    expect(result.width).toBe(1000);
+    expect(result.height).toBe(1000);
+  });
+
+  it('picks the dominant axis on corner drags with unequal motion', () => {
+    // SE drag with (dx=5, dy=40) on 100×50: wScale=1.05, hScale=1.8.
+    // Height dominates, so scale = 1.8 → width 180, height 90.
+    const result = computeResizeDelta('se', 100, 50, 5, 40, max);
+    expect(result.width).toBeCloseTo(180);
+    expect(result.height).toBeCloseTo(90);
+  });
+
+  it('leaves the rect unchanged on a zero-delta mousemove', () => {
+    const result = computeResizeDelta('se', 100, 50, 0, 0, max);
+    expect(result.width).toBe(100);
+    expect(result.height).toBe(50);
+  });
+});
+
+describe('formatResizeHud', () => {
+  const rect: ImageRect = { x: 0, y: 0, width: 240, height: 120 };
+
+  it('corner drag + aspectLocked → dimensions with "ratio" suffix', () => {
+    expect(formatResizeHud('se', rect, true)).toBe('240 × 120  ·  ratio');
+    expect(formatResizeHud('nw', rect, true)).toBe('240 × 120  ·  ratio');
+    expect(formatResizeHud('ne', rect, true)).toBe('240 × 120  ·  ratio');
+    expect(formatResizeHud('sw', rect, true)).toBe('240 × 120  ·  ratio');
+  });
+
+  it('corner drag with Shift → dimensions with "free" suffix', () => {
+    expect(formatResizeHud('se', rect, false)).toBe('240 × 120  ·  free');
+  });
+
+  it('side drags show pure dimensions regardless of aspectLocked', () => {
+    // Side handles only change one axis, so the lock state is not
+    // meaningful — the HUD should not show it either.
+    expect(formatResizeHud('n', rect, true)).toBe('240 × 120');
+    expect(formatResizeHud('s', rect, false)).toBe('240 × 120');
+    expect(formatResizeHud('e', rect, true)).toBe('240 × 120');
+    expect(formatResizeHud('w', rect, false)).toBe('240 × 120');
+  });
+
+  it('rounds fractional dimensions to the nearest integer', () => {
+    const frac: ImageRect = { x: 0, y: 0, width: 239.6, height: 119.4 };
+    expect(formatResizeHud('se', frac, true)).toBe('240 × 119  ·  ratio');
+  });
+});
+
+describe('computePreviewRect', () => {
+  const start: ImageRect = { x: 100, y: 50, width: 200, height: 80 };
+
+  it('se anchors on the top-left — origin stays put', () => {
+    const r = computePreviewRect(start, 'se', 240, 100);
+    expect(r).toEqual({ x: 100, y: 50, width: 240, height: 100 });
+  });
+
+  it('nw anchors on the bottom-right — origin moves', () => {
+    const r = computePreviewRect(start, 'nw', 240, 100);
+    // East edge stays at x=300 → x = 300 - 240 = 60
+    // South edge stays at y=130 → y = 130 - 100 = 30
+    expect(r).toEqual({ x: 60, y: 30, width: 240, height: 100 });
+  });
+
+  it('ne anchors on the bottom-left — only y moves', () => {
+    const r = computePreviewRect(start, 'ne', 240, 100);
+    expect(r).toEqual({ x: 100, y: 30, width: 240, height: 100 });
+  });
+
+  it('sw anchors on the top-right — only x moves', () => {
+    const r = computePreviewRect(start, 'sw', 240, 100);
+    expect(r).toEqual({ x: 60, y: 50, width: 240, height: 100 });
+  });
+
+  it('n, s, e, w only move along one axis', () => {
+    expect(computePreviewRect(start, 'n', 200, 100))
+      .toEqual({ x: 100, y: 30, width: 200, height: 100 });
+    expect(computePreviewRect(start, 's', 200, 100))
+      .toEqual({ x: 100, y: 50, width: 200, height: 100 });
+    expect(computePreviewRect(start, 'e', 240, 80))
+      .toEqual({ x: 100, y: 50, width: 240, height: 80 });
+    expect(computePreviewRect(start, 'w', 240, 80))
+      .toEqual({ x: 60, y: 50, width: 240, height: 80 });
+  });
+});

--- a/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
+++ b/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { BlockType, EditorAPI, EditContext, HeadingLevel } from "@wafflebase/docs";
 import { Toggle } from "@/components/ui/toggle";
 import { Separator } from "@/components/ui/separator";
@@ -36,9 +36,11 @@ import {
   IconTable,
   IconHash,
   IconFileDownload,
+  IconPhoto,
 } from "@tabler/icons-react";
 import { TableGridPicker } from "./table-grid-picker";
 import { exportDocxAndDownload } from "./docx-actions";
+import { insertImageFromFile, insertImageFromUrl } from "./image-insert";
 import { toast } from "sonner";
 
 /** Style option for the block-type dropdown (Google Docs style). */
@@ -98,6 +100,136 @@ function TableDropdown({ editor }: { editor: EditorAPI | null }) {
         />
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function InsertImageDropdown({ editor }: { editor: EditorAPI | null }) {
+  const [open, setOpen] = useState(false);
+  const [urlMode, setUrlMode] = useState(false);
+  const [urlInput, setUrlInput] = useState("");
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Reset the dropdown's internal view back to the two-item menu. Used
+  // by every code path that closes the dropdown — both the Radix
+  // `onOpenChange` callback (user clicked outside / pressed Esc) and
+  // our own programmatic closes (Upload / Insert submit). Setting the
+  // controlled `open` prop to `false` does NOT re-fire `onOpenChange`,
+  // so programmatic closes used to leave `urlMode === true` behind
+  // and the dropdown reopened on the URL form next time.
+  const closeAndReset = () => {
+    setOpen(false);
+    setUrlMode(false);
+    setUrlInput("");
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      closeAndReset();
+    } else {
+      setOpen(true);
+    }
+  };
+
+  const handlePickFile = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // Reset the input so selecting the same file twice still fires the
+    // change event next time.
+    e.target.value = "";
+    if (!file || !editor) return;
+    closeAndReset();
+    await insertImageFromFile(editor, file);
+  };
+
+  const handleUrlSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editor) return;
+    const url = urlInput;
+    closeAndReset();
+    await insertImageFromUrl(editor, url);
+  };
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        style={{ display: "none" }}
+        onChange={handleFileChange}
+      />
+      <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-sm hover:bg-muted"
+                aria-label="Insert image"
+              >
+                <IconPhoto size={16} />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Insert image</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="start" sideOffset={4} className="min-w-[220px]">
+          {urlMode ? (
+            <form className="flex flex-col gap-2 p-2" onSubmit={handleUrlSubmit}>
+              <label className="text-xs text-muted-foreground" htmlFor="insert-image-url">
+                Image URL
+              </label>
+              <input
+                id="insert-image-url"
+                type="url"
+                autoFocus
+                placeholder="https://…"
+                value={urlInput}
+                onChange={(ev) => setUrlInput(ev.target.value)}
+                className="h-7 rounded border border-border bg-background px-2 text-sm outline-none focus:border-primary"
+              />
+              <div className="flex items-center justify-end gap-1">
+                <button
+                  type="button"
+                  className="cursor-pointer rounded px-2 py-1 text-xs hover:bg-muted"
+                  onClick={() => {
+                    setUrlMode(false);
+                    setUrlInput("");
+                  }}
+                >
+                  Back
+                </button>
+                <button
+                  type="submit"
+                  className="cursor-pointer rounded bg-primary px-2 py-1 text-xs text-primary-foreground hover:opacity-90"
+                >
+                  Insert
+                </button>
+              </div>
+            </form>
+          ) : (
+            <>
+              <DropdownMenuItem onClick={handlePickFile}>
+                Upload from computer
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={(ev) => {
+                  // Keep the menu open so the URL input can render
+                  // inside it. Without preventDefault, Radix closes
+                  // the menu on `select`.
+                  ev.preventDefault();
+                  setUrlMode(true);
+                }}
+              >
+                By URL…
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
   );
 }
 
@@ -527,6 +659,8 @@ export function DocsFormattingToolbar({ editor, editContext = 'body', documentTi
         </TooltipTrigger>
         <TooltipContent>Insert link ({modKey}+K)</TooltipContent>
       </Tooltip>
+
+      <InsertImageDropdown editor={editor} />
 
       <TableDropdown editor={editor} />
 

--- a/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
+++ b/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
@@ -147,9 +147,13 @@ function InsertImageDropdown({ editor }: { editor: EditorAPI | null }) {
   const handleUrlSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!editor) return;
-    const url = urlInput;
-    closeAndReset();
-    await insertImageFromUrl(editor, url);
+    const inserted = await insertImageFromUrl(editor, urlInput);
+    // Only close the dropdown when the image was successfully
+    // inserted. On validation / load failure the form stays open so
+    // the user can correct the URL instead of retyping it.
+    if (inserted) {
+      closeAndReset();
+    }
   };
 
   return (

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -15,6 +15,7 @@ import { DocsLinkPopover } from "./docs-link-popover";
 import { DocsFindBar } from "./docs-find-bar";
 import { DocsTableContextMenu } from "./docs-table-context-menu";
 import { clearPendingImport, peekPendingImport } from "./pending-imports";
+import { insertImageFromFile } from "./image-insert";
 
 export type { EditorAPI } from "@wafflebase/docs";
 
@@ -283,6 +284,14 @@ export function DocsView({ onEditorReady, readOnly, documentId }: DocsViewProps)
       if (!pos) return;
       const existingHref = editor.getLinkAtCursor() ?? "";
       setLinkInputRequest({ initialUrl: existingHref, position: pos });
+    });
+
+    // Drag-and-drop + clipboard paste of image files. The docs
+    // package only knows how to intercept the raw File; upload + URL
+    // resolution + insert all live in the frontend because they
+    // depend on auth cookies and the `/images` endpoint.
+    editor.onImageFileDrop((file) => {
+      void insertImageFromFile(editor, file);
     });
 
     const handleMouseMove = (e: MouseEvent) => {

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -290,8 +290,8 @@ export function DocsView({ onEditorReady, readOnly, documentId }: DocsViewProps)
     // package only knows how to intercept the raw File; upload + URL
     // resolution + insert all live in the frontend because they
     // depend on auth cookies and the `/images` endpoint.
-    editor.onImageFileDrop((file) => {
-      void insertImageFromFile(editor, file);
+    editor.onImageFileDrop((file, pos) => {
+      void insertImageFromFile(editor, file, pos);
     });
 
     const handleMouseMove = (e: MouseEvent) => {

--- a/packages/frontend/src/app/docs/image-insert.ts
+++ b/packages/frontend/src/app/docs/image-insert.ts
@@ -55,6 +55,7 @@ export function loadImageDimensions(
 export async function insertImageFromFile(
   editor: EditorAPI,
   file: File,
+  position?: { blockId: string; offset: number },
 ): Promise<void> {
   try {
     const url = await uploadImageFile(file);
@@ -63,6 +64,7 @@ export async function insertImageFromFile(
       originalWidth: width,
       originalHeight: height,
       alt: file.name,
+      position,
     });
     editor.focus();
   } catch (err) {

--- a/packages/frontend/src/app/docs/image-insert.ts
+++ b/packages/frontend/src/app/docs/image-insert.ts
@@ -1,0 +1,111 @@
+import type { EditorAPI } from "@wafflebase/docs";
+import { docxImageUploader } from "./docx-actions";
+import { toast } from "sonner";
+
+/**
+ * Upload an image file to the backend and return the absolute URL the
+ * canvas can render. Reuses the same `/images` endpoint the DOCX
+ * importer already uses, so auth (JWT cookie) and CORS wiring stay in
+ * one place.
+ */
+export async function uploadImageFile(file: File): Promise<string> {
+  const filename = file.name || "pasted-image";
+  return docxImageUploader(file, filename);
+}
+
+/**
+ * Preflight-load an image URL in a hidden <img> and resolve once the
+ * browser knows its intrinsic dimensions. Needed because the editor's
+ * `insertImage` wants pixel width/height at insert time so the layout
+ * reserves the right amount of space from the first paint. Rejects on
+ * network errors or an inaccessible URL.
+ *
+ * Intentionally does NOT set `crossOrigin` — that would force a CORS
+ * preflight which most public image hosts (e.g. blogs, Wikipedia,
+ * WordPress CDNs) don't support, and the request would fail before
+ * we ever see the pixels. The docs canvas only uses `drawImage` on
+ * inline pictures, so a cross-origin image becomes "tainted" for
+ * `getImageData` / `toDataURL` (which we never call) but still
+ * renders fine. Consistent with how `<img>` tags load cross-origin
+ * images in a regular web page.
+ */
+export function loadImageDimensions(
+  url: string,
+): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+        resolve({ width: img.naturalWidth, height: img.naturalHeight });
+      } else {
+        reject(new Error("Image has zero dimensions"));
+      }
+    };
+    img.onerror = () => reject(new Error(`Failed to load image: ${url}`));
+    img.src = url;
+  });
+}
+
+/**
+ * Upload a local image file, probe its natural size, and insert it at
+ * the editor's current caret. Shows a toast on any failure. Wrapped
+ * here so both the toolbar upload path and the drag/paste path go
+ * through the same error-handling and insert flow.
+ */
+export async function insertImageFromFile(
+  editor: EditorAPI,
+  file: File,
+): Promise<void> {
+  try {
+    const url = await uploadImageFile(file);
+    const { width, height } = await loadImageDimensions(url);
+    editor.insertImage(url, width, height, {
+      originalWidth: width,
+      originalHeight: height,
+      alt: file.name,
+    });
+    editor.focus();
+  } catch (err) {
+    console.error("Image insert failed", err);
+    toast.error(
+      err instanceof Error
+        ? `Image upload failed: ${err.message}`
+        : "Image upload failed",
+    );
+  }
+}
+
+/**
+ * Validate + insert an image URL typed by the user in the toolbar.
+ * Unlike `insertImageFromFile`, this skips the upload step — the URL
+ * is inserted as-is so external images (e.g. `https://...` referenced
+ * from another host) do not get re-uploaded. The preflight load still
+ * happens so we capture the natural dimensions and fail early on 404 /
+ * CORS errors.
+ */
+export async function insertImageFromUrl(
+  editor: EditorAPI,
+  url: string,
+): Promise<void> {
+  const trimmed = url.trim();
+  if (!trimmed) return;
+  if (!/^https?:\/\//i.test(trimmed)) {
+    toast.error("Image URL must start with http:// or https://");
+    return;
+  }
+  try {
+    const { width, height } = await loadImageDimensions(trimmed);
+    editor.insertImage(trimmed, width, height, {
+      originalWidth: width,
+      originalHeight: height,
+    });
+    editor.focus();
+  } catch (err) {
+    console.error("Image URL insert failed", err);
+    toast.error(
+      err instanceof Error
+        ? `Couldn't load image: ${err.message}`
+        : "Couldn't load image",
+    );
+  }
+}

--- a/packages/frontend/src/app/docs/image-insert.ts
+++ b/packages/frontend/src/app/docs/image-insert.ts
@@ -80,18 +80,25 @@ export async function insertImageFromFile(
  * Unlike `insertImageFromFile`, this skips the upload step — the URL
  * is inserted as-is so external images (e.g. `https://...` referenced
  * from another host) do not get re-uploaded. The preflight load still
- * happens so we capture the natural dimensions and fail early on 404 /
- * CORS errors.
+ * happens so we capture the natural dimensions and fail early on 404.
+ *
+ * Returns `true` on success so the caller can close the UI, or `false`
+ * on validation / load failure so the caller can keep the input open
+ * for the user to fix the URL instead of losing their typed text.
+ *
+ * NOTE: the URL is stored as a direct hotlink. Uploading external
+ * images to first-party storage requires a backend endpoint
+ * (`POST /images/from-url`) and is tracked as a Phase 2 follow-up.
  */
 export async function insertImageFromUrl(
   editor: EditorAPI,
   url: string,
-): Promise<void> {
+): Promise<boolean> {
   const trimmed = url.trim();
-  if (!trimmed) return;
+  if (!trimmed) return false;
   if (!/^https?:\/\//i.test(trimmed)) {
     toast.error("Image URL must start with http:// or https://");
-    return;
+    return false;
   }
   try {
     const { width, height } = await loadImageDimensions(trimmed);
@@ -100,6 +107,7 @@ export async function insertImageFromUrl(
       originalHeight: height,
     });
     editor.focus();
+    return true;
   } catch (err) {
     console.error("Image URL insert failed", err);
     toast.error(
@@ -107,5 +115,6 @@ export async function insertImageFromUrl(
         ? `Couldn't load image: ${err.message}`
         : "Couldn't load image",
     );
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

- **Toolbar insert** — new *Insert image* dropdown with *Upload from computer* and *By URL* entries, plus drag-and-drop and clipboard paste
- **Click-to-select** — 8-handle selection overlay for body and simple table-cell images, with text caret suppression
- **Resize** — aspect-ratio-locked corner drag (Shift releases), free side-handle drag, keyboard nudge (arrows ±1 / Shift ±8), drag-lift shadow, and live dimension HUD showing ratio/free state
- **Delete / Esc** — standard Google Docs keyboard shortcuts via TextEditor pre-handler

### Milestones delivered

| # | Scope | Tests added |
|---|-------|------------|
| M1 | `ImageData` extended with rotation/crop/original* fields, `EditorAPI` image methods | 8 |
| M2 | Selection overlay, hit-test, capture-phase click routing, keyboard routing | 18 |
| M3 | Resize drag state machine, `computeResizeDelta`, preview rect, cursor hints, drag-lift shadow | 14 |
| M4 | Toolbar dropdown, `image-insert.ts` helpers, DnD/paste wiring, `clampImageToWidth` | 7 |

**546 tests** pass (`pnpm verify:fast` EXIT=0).

### Bug fixes included

- `collectImageRects` double-added `margins.left` (pl.x already includes it)
- TextEditor `handleMouseMove` always reset cursor to `text`, overriding handle hover hints
- `loadImageDimensions` forced CORS `crossOrigin="anonymous"` which broke non-CORS image hosts
- `InsertImageDropdown` didn't reset `urlMode` on programmatic close
- Table cell images (non-merged, top-aligned) are now selectable

### Out of scope (Phase 2+)

- Floating context bar (Replace / Alt text / Image options / Delete)
- Image Options side panel (Size / Rotation / Alt / Reset)
- Rotation & crop rendering
- Crop mode
- Text wrap modes
- Row-spanning / vertically-aligned table cell images

## Test plan

- [x] Insert image via toolbar Upload from computer → renders at caret
- [x] Insert image via toolbar By URL → renders inline
- [x] Drag-and-drop image file onto editor → inserts at drop position
- [x] Paste screenshot → inserts at caret
- [x] Click image → 8-handle overlay appears, text caret hidden
- [x] Corner handle drag → aspect-ratio locked resize with shadow + HUD
- [x] Shift + corner drag → free resize, HUD shows "free"
- [x] Side handle drag → single-axis resize
- [x] Arrow keys on selected image → proportional nudge
- [x] Delete/Backspace → removes image
- [x] Esc → deselects, returns to text mode
- [x] Click outside image → deselects
- [x] Table cell image click → handles appear correctly
- [x] Large image paste → auto-clamped to page content width

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image insertion via upload, URL, drag-and-drop, and clipboard paste
  * Inline image selection with eight-handle resize, keyboard nudging, delete/escape behavior, and single-undo resize
  * Floating context bar and side Image Options (size, aspect lock, free rotation, alt text, Reset)

* **Documentation**
  * New design spec and task entries detailing Phase 1 image insertion & editing scope and rollout

* **Tests**
  * Extensive tests for image utilities, selection overlay, resize math, and insertion flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->