### PR TITLE
Fix image inline bugs in docs editor

### DIFF
--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -28,7 +28,7 @@ import {
 } from './types.js';
 import { MemDocStore } from '../store/memory.js';
 import type { DocStore } from '../store/store.js';
-import { applyDeleteText, applyInsertInline } from '../store/block-helpers.js';
+import { applyDeleteText, applyInsertInline, applyInsertText } from '../store/block-helpers.js';
 
 /**
  * The current editing context for header/footer routing.
@@ -162,18 +162,9 @@ export class Doc {
    * Insert text at a document position.
    */
   insertText(pos: DocPosition, text: string): void {
-    const cellInfo = this._blockParentMap.get(pos.blockId);
-    if (cellInfo) {
-      // Table cell path — keep existing behavior for now (Phase 4)
-      const block = this.getBlock(pos.blockId);
-      const { inlineIndex, charOffset } = this.resolveOffset(block, pos.offset);
-      const inline = block.inlines[inlineIndex];
-      inline.text =
-        inline.text.slice(0, charOffset) + text + inline.text.slice(charOffset);
-      this.updateBlockInStore(pos.blockId, block);
-    } else {
-      this.store.insertText(pos.blockId, pos.offset, text);
-    }
+    const block = this.getBlock(pos.blockId);
+    const updated = applyInsertText(block, pos.offset, text);
+    this.updateBlockInStore(pos.blockId, updated);
     this.refresh();
   }
 
@@ -193,16 +184,9 @@ export class Doc {
    * Delete `length` characters forward from position.
    */
   deleteText(pos: DocPosition, length: number): void {
-    const cellInfo = this._blockParentMap.get(pos.blockId);
-    if (cellInfo) {
-      // Table cell path — use shared helper for correct cross-inline deletion
-      const block = this.getBlock(pos.blockId);
-      const updated = applyDeleteText(block, pos.offset, length);
-      block.inlines = updated.inlines;
-      this.updateBlockInStore(pos.blockId, block);
-    } else {
-      this.store.deleteText(pos.blockId, pos.offset, length);
-    }
+    const block = this.getBlock(pos.blockId);
+    const updated = applyDeleteText(block, pos.offset, length);
+    this.updateBlockInStore(pos.blockId, updated);
     this.refresh();
   }
 

--- a/packages/docs/src/store/block-helpers.ts
+++ b/packages/docs/src/store/block-helpers.ts
@@ -90,6 +90,22 @@ export function applyInsertText(block: Block, offset: number, text: string): Blo
   const newBlock = cloneBlock(block);
   const { inlineIndex, charOffset } = resolveOffset(newBlock, offset);
   const inline = newBlock.inlines[inlineIndex];
+
+  // Image inlines must not absorb regular text — split at the insertion
+  // point and place the new text in its own inline without image style.
+  if (inline.style.image) {
+    const { image: _img, ...plainStyle } = inline.style;
+    const before = inline.text.slice(0, charOffset);
+    const after = inline.text.slice(charOffset);
+    const spliced: Inline[] = [];
+    if (before.length > 0) spliced.push({ text: before, style: { ...inline.style } });
+    spliced.push({ text, style: plainStyle });
+    if (after.length > 0) spliced.push({ text: after, style: { ...inline.style } });
+    newBlock.inlines.splice(inlineIndex, 1, ...spliced);
+    newBlock.inlines = normalizeInlines(newBlock.inlines);
+    return newBlock;
+  }
+
   inline.text =
     inline.text.slice(0, charOffset) + text + inline.text.slice(charOffset);
   return newBlock;
@@ -134,7 +150,8 @@ export function resolveStyleRange(
  */
 function getSplitPointStyle(inlines: Inline[], offset: number): InlineStyle {
   const { inlineIndex } = resolveOffset({ inlines } as Block, offset);
-  return { ...inlines[inlineIndex].style };
+  const { image: _image, ...rest } = inlines[inlineIndex].style;
+  return rest;
 }
 
 /**

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -480,6 +480,8 @@ export class DocCanvas {
                 range.pageStartRow,
                 this.requestRender ?? undefined,
                 dragImageRun,
+                selectionRects,
+                focused,
               );
             }
             continue;
@@ -493,6 +495,26 @@ export class DocCanvas {
           // lockstep instead of visually diverging during the drag.
           if (dragImageRun && run === dragImageRun) continue;
           this.renderRun(run, pageX + pl.x, pageY + pl.y, pl.line.height);
+
+          // Image runs are opaque and cover the selection highlight
+          // drawn earlier. Re-draw a semi-transparent overlay on top
+          // of the image when it intersects the selection, so that
+          // selected images show a visible blue tint.
+          if (run.inline.style.image && selectionRects) {
+            const ix = Math.round(pageX + pl.x + run.x);
+            const drawH = run.imageHeight ?? pl.line.height;
+            const iy = Math.round(pageY + pl.y + pl.line.height - drawH);
+            const iw = run.width;
+            const ih = drawH;
+            for (const sr of selectionRects) {
+              if (sr.x < ix + iw && sr.x + sr.width > ix &&
+                  sr.y < iy + ih && sr.y + sr.height > iy) {
+                this.ctx.fillStyle = focused ? Theme.selectionColor : Theme.selectionColorInactive;
+                this.ctx.fillRect(ix, iy, iw, ih);
+                break;
+              }
+            }
+          }
         }
 
         // Render list markers on the first line of each list-item block

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -207,12 +207,16 @@ function computeHFCursorPixel(
       for (const run of line.runs) {
         if (offsetRemaining <= chars + run.text.length) {
           const localOff = offsetRemaining - chars;
-          const textBefore = run.text.slice(0, localOff);
-          ctx.font = buildFont(
-            run.inline.style.fontSize, run.inline.style.fontFamily,
-            run.inline.style.bold, run.inline.style.italic,
-          );
-          cursorX = run.x + ctx.measureText(textBefore).width;
+          if (run.imageHeight !== undefined) {
+            cursorX = run.x + (localOff > 0 ? run.width : 0);
+          } else {
+            const textBefore = run.text.slice(0, localOff);
+            ctx.font = buildFont(
+              run.inline.style.fontSize, run.inline.style.fontFamily,
+              run.inline.style.bold, run.inline.style.italic,
+            );
+            cursorX = run.x + ctx.measureText(textBefore).width;
+          }
           break;
         }
         chars += run.text.length;
@@ -305,13 +309,21 @@ function computeHFSelectionRects(
           const runLen = run.text.length;
           if (chars + runLen > lineSelStart && x0 === 0 && lineSelStart > 0) {
             const localOff = lineSelStart - chars;
-            ctx.font = buildFont(run.inline.style.fontSize, run.inline.style.fontFamily, run.inline.style.bold, run.inline.style.italic);
-            x0 = run.x + ctx.measureText(run.text.slice(0, localOff)).width;
+            if (run.imageHeight !== undefined) {
+              x0 = run.x + (localOff > 0 ? run.width : 0);
+            } else {
+              ctx.font = buildFont(run.inline.style.fontSize, run.inline.style.fontFamily, run.inline.style.bold, run.inline.style.italic);
+              x0 = run.x + ctx.measureText(run.text.slice(0, localOff)).width;
+            }
           }
           if (chars + runLen >= lineSelEnd) {
             const localOff = lineSelEnd - chars;
-            ctx.font = buildFont(run.inline.style.fontSize, run.inline.style.fontFamily, run.inline.style.bold, run.inline.style.italic);
-            x1 = run.x + ctx.measureText(run.text.slice(0, localOff)).width;
+            if (run.imageHeight !== undefined) {
+              x1 = run.x + (localOff > 0 ? run.width : 0);
+            } else {
+              ctx.font = buildFont(run.inline.style.fontSize, run.inline.style.fontFamily, run.inline.style.bold, run.inline.style.italic);
+              x1 = run.x + ctx.measureText(run.text.slice(0, localOff)).width;
+            }
             break;
           }
           chars += runLen;
@@ -1147,47 +1159,29 @@ export function initialize(
         render();
         return true;
       }
-      // Arrow keys nudge the image size. ArrowRight/Down grow, Arrow
-      // Left/Up shrink. Nudge is proportional so the image retains
-      // its aspect ratio — matches Google Docs' "maintain ratio on
-      // keyboard resize" behavior. Shift multiplies the step by 8.
+      // Arrow keys deselect the image and move the cursor, matching
+      // Google Docs behavior. Left places the caret before the image,
+      // Right places it after. Shift+Arrow clears the image selection
+      // and falls through to TextEditor so it can extend the text
+      // selection normally.
       if (
         key === 'ArrowLeft' || key === 'ArrowRight' ||
         key === 'ArrowUp'   || key === 'ArrowDown'
       ) {
         const { blockId, offset } = selectedImage;
-        const block = doc.getBlock(blockId);
-        if (!block) return true;
-        const current = findImageAtOffset(block, offset);
-        if (!current) return true;
+        selectedImage = null;
+        if (e.shiftKey || key === 'ArrowUp' || key === 'ArrowDown') {
+          // Fall through to TextEditor for Shift+Arrow selection
+          // and Up/Down vertical navigation
+          render();
+          return false;
+        }
         e.preventDefault();
-        const step = (e.shiftKey ? 8 : 1) *
-          (key === 'ArrowRight' || key === 'ArrowDown' ? 1 : -1);
-        const aspect = current.width / current.height;
-        const { maxWidth, maxHeight } = getResizeMax();
-        const MIN = 20;
-        let newWidth = current.width + step;
-        newWidth = Math.max(MIN, Math.min(newWidth, maxWidth));
-        let newHeight = newWidth / aspect;
-        if (newHeight < MIN) {
-          newHeight = MIN;
-          newWidth = Math.max(MIN, Math.min(newHeight * aspect, maxWidth));
+        if (key === 'ArrowRight') {
+          cursor.moveTo({ blockId, offset: offset + 1 });
+        } else if (key === 'ArrowLeft') {
+          cursor.moveTo({ blockId, offset });
         }
-        if (newHeight > maxHeight) {
-          newHeight = maxHeight;
-          newWidth = Math.max(MIN, Math.min(newHeight * aspect, maxWidth));
-        }
-        if (newWidth === current.width && newHeight === current.height) {
-          return true;
-        }
-        docStore.snapshot();
-        const merged = { ...current, width: newWidth, height: newHeight };
-        doc.applyInlineStyle(
-          { anchor: { blockId, offset }, focus: { blockId, offset: offset + 1 } },
-          { image: merged },
-        );
-        markDirty(blockId);
-        invalidateLayout();
         render();
         return true;
       }

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -92,12 +92,16 @@ export function resolvePositionPixel(
         for (const run of line.runs) {
           if (offsetRemaining <= chars + run.text.length) {
             const localOff = offsetRemaining - chars;
-            const textBefore = run.text.slice(0, localOff);
-            ctx.font = buildFont(
-              run.inline.style.fontSize, run.inline.style.fontFamily,
-              run.inline.style.bold, run.inline.style.italic,
-            );
-            cursorX = run.x + ctx.measureText(textBefore).width;
+            if (run.imageHeight !== undefined) {
+              cursorX = run.x + (localOff > 0 ? run.width : 0);
+            } else {
+              const textBefore = run.text.slice(0, localOff);
+              ctx.font = buildFont(
+                run.inline.style.fontSize, run.inline.style.fontFamily,
+                run.inline.style.bold, run.inline.style.italic,
+              );
+              cursorX = run.x + ctx.measureText(textBefore).width;
+            }
             break;
           }
           chars += run.text.length;
@@ -183,16 +187,23 @@ export function resolvePositionPixel(
     const runLength = run.charEnd - run.charStart;
     if (lineOffset >= charCount && lineOffset <= charCount + runLength) {
       const localOffset = lineOffset - charCount;
-      const textBefore = run.text.slice(0, localOffset);
-      const isSuperOrSub = run.inline.style.superscript || run.inline.style.subscript;
-      const measureFontSize = isSuperOrSub
-        ? (run.inline.style.fontSize ?? Theme.defaultFontSize) * 0.6
-        : run.inline.style.fontSize;
-      ctx.font = buildFont(
-        measureFontSize, run.inline.style.fontFamily,
-        run.inline.style.bold, run.inline.style.italic,
-      );
-      const x = pageX + pageLine.x + run.x + ctx.measureText(textBefore).width;
+      let xOffset: number;
+      if (run.imageHeight !== undefined) {
+        // Image run: use display width, not measureText of the placeholder char
+        xOffset = localOffset > 0 ? run.width : 0;
+      } else {
+        const textBefore = run.text.slice(0, localOffset);
+        const isSuperOrSub = run.inline.style.superscript || run.inline.style.subscript;
+        const measureFontSize = isSuperOrSub
+          ? (run.inline.style.fontSize ?? Theme.defaultFontSize) * 0.6
+          : run.inline.style.fontSize;
+        ctx.font = buildFont(
+          measureFontSize, run.inline.style.fontFamily,
+          run.inline.style.bold, run.inline.style.italic,
+        );
+        xOffset = ctx.measureText(textBefore).width;
+      }
+      const x = pageX + pageLine.x + run.x + xOffset;
       return { x, y: pageY + pageLine.y, height: pageLine.line.height };
     }
     charCount += runLength;

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -196,15 +196,21 @@ function positionToPagePixel(
     const runLength = run.charEnd - run.charStart;
     if (lineOffset >= charCount && lineOffset <= charCount + runLength) {
       const localOff = lineOffset - charCount;
-      const isSuperOrSub = run.inline.style.superscript || run.inline.style.subscript;
-      const measureFontSize = isSuperOrSub
-        ? (run.inline.style.fontSize ?? Theme.defaultFontSize) * 0.6
-        : run.inline.style.fontSize;
-      ctx.font = buildFont(
-        measureFontSize, run.inline.style.fontFamily,
-        run.inline.style.bold, run.inline.style.italic,
-      );
-      const x = pageX + pageLine.x + run.x + ctx.measureText(run.text.slice(0, localOff)).width;
+      let xOffset: number;
+      if (run.imageHeight !== undefined) {
+        xOffset = localOff > 0 ? run.width : 0;
+      } else {
+        const isSuperOrSub = run.inline.style.superscript || run.inline.style.subscript;
+        const measureFontSize = isSuperOrSub
+          ? (run.inline.style.fontSize ?? Theme.defaultFontSize) * 0.6
+          : run.inline.style.fontSize;
+        ctx.font = buildFont(
+          measureFontSize, run.inline.style.fontFamily,
+          run.inline.style.bold, run.inline.style.italic,
+        );
+        xOffset = ctx.measureText(run.text.slice(0, localOff)).width;
+      }
+      const x = pageX + pageLine.x + run.x + xOffset;
       return { x, y: pageY + pageLine.y, height: pageLine.line.height };
     }
     charCount += runLength;

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -180,6 +180,8 @@ export function renderTableContent(
    * same skip in `DocCanvas.render`'s body loop.
    */
   dragImageRun?: LayoutRun,
+  selectionRects?: Array<{ x: number; y: number; width: number; height: number }>,
+  focused?: boolean,
 ): void {
   const { rows } = tableData;
   const { cells, columnXOffsets, columnPixelWidths, rowYOffsets, rowHeights } = tableLayout;
@@ -292,6 +294,20 @@ export function renderTableContent(
             });
             if (img) {
               ctx.drawImage(img, imgX, imgY, run.width, drawHeight);
+            }
+            // Re-draw selection overlay on top of the opaque image,
+            // mirroring the body path in DocCanvas.render.
+            if (selectionRects) {
+              const iw = run.width;
+              const ih = drawHeight;
+              for (const sr of selectionRects) {
+                if (sr.x < imgX + iw && sr.x + sr.width > imgX &&
+                    sr.y < imgY + ih && sr.y + sr.height > imgY) {
+                  ctx.fillStyle = focused ? Theme.selectionColor : Theme.selectionColorInactive;
+                  ctx.fillRect(imgX, imgY, iw, ih);
+                  break;
+                }
+              }
             }
             continue;
           }

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -589,15 +589,41 @@ export class YorkieDocStore implements DocStore {
 
     const { inlineIndex, charOffset } = resolveOffset(block, offset);
     const off = this.bodyTreeOffset(currentDoc);
+    const targetInline = block.inlines[inlineIndex];
 
     this.doc.update((root) => {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
-      tree.editByPath(
-        [blockIdx + off, inlineIndex, charOffset],
-        [blockIdx + off, inlineIndex, charOffset],
-        { type: 'text', value: text },
-      );
+
+      if (targetInline.style.image) {
+        // Image inlines must not absorb regular text. Insert a new
+        // inline node adjacent to the image node instead of putting
+        // text inside it.
+        const { image: _, ...plainStyle } = targetInline.style;
+        void _;
+        const newNode = buildInlineNode({ text, style: plainStyle });
+        if (charOffset === 0) {
+          // Before image: insert new inline before the image node
+          tree.editByPath(
+            [blockIdx + off, inlineIndex],
+            [blockIdx + off, inlineIndex],
+            newNode,
+          );
+        } else {
+          // After image: insert new inline after the image node
+          tree.editByPath(
+            [blockIdx + off, inlineIndex + 1],
+            [blockIdx + off, inlineIndex + 1],
+            newNode,
+          );
+        }
+      } else {
+        tree.editByPath(
+          [blockIdx + off, inlineIndex, charOffset],
+          [blockIdx + off, inlineIndex, charOffset],
+          { type: 'text', value: text },
+        );
+      }
     });
 
     // Update cache in-place (same pattern as updateBlock)


### PR DESCRIPTION
## Summary

- **Enter key duplicating images**: `getSplitPointStyle` copied image data to empty split sides; now strips `image` from inherited style
- **Text invisible next to images**: `applyInsertText` merged text into image-styled inlines; now splits into separate inlines
- **Arrow keys resized instead of navigating**: Image key handler used arrows for resize; now deselects and moves cursor (Shift+Arrow extends selection)
- **Cursor stuck at image left edge**: Cursor/selection pixel calculation used `measureText('\uFFFC')` ≈ 0px; now uses `run.width` for image runs
- **No selection highlight on images**: Added semi-transparent blue overlay on top of opaque images in both body and table cell renderers
- **Yorkie tree corruption**: Yorkie store inserted text into image tree nodes; now creates adjacent inline nodes
- **Body vs table cell duplication**: Unified `insertText`/`deleteText` in `document.ts` to use `applyInsertText`/`applyDeleteText` via `updateBlockInStore`, removing the body-vs-table-cell branching

## Test plan

- [x] Insert image in docs editor, press Enter — image should not duplicate
- [x] Type text before and after an image — text should be visible
- [x] Click image, press ArrowRight/Left — cursor moves to image edges
- [x] Shift+Arrow to select across image — blue highlight visible on image
- [x] Same operations inside a table cell
- [x] Ctrl+A to select all, Delete — image should be deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images now display selection highlights when selected in documents.

* **Bug Fixes**
  * Fixed text insertion behavior when editing content adjacent to images.
  * Arrow keys now move the cursor around images instead of resizing them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->