### PR TITLE
Fix crash when remote peer deletes all content in docs editor

### DIFF
--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -142,6 +142,31 @@ export class Doc {
   }
 
   /**
+   * Find a block by ID, returning undefined if not found (non-throwing variant of getBlock).
+   */
+  findBlock(blockId: string): Block | undefined {
+    const block = this._document.blocks.find((b) => b.id === blockId);
+    if (block) return block;
+
+    const hBlock = this._document.header?.blocks.find((b) => b.id === blockId);
+    if (hBlock) return hBlock;
+    const fBlock = this._document.footer?.blocks.find((b) => b.id === blockId);
+    if (fBlock) return fBlock;
+
+    const cellInfo = this._blockParentMap.get(blockId);
+    if (cellInfo) {
+      const tableBlock = this._document.blocks.find((b) => b.id === cellInfo.tableBlockId);
+      if (tableBlock?.tableData) {
+        const cell = tableBlock.tableData.rows[cellInfo.rowIndex]?.cells[cellInfo.colIndex];
+        const found = cell?.blocks.find((b) => b.id === blockId);
+        if (found) return found;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
    * Find block index by ID within the current context. Returns -1 if not found.
    */
   getBlockIndex(blockId: string): number {

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -162,6 +162,11 @@ export interface EditorAPI {
   /** Focus the editor */
   focus(): void;
   /**
+   * Ensure the cursor points to a block that still exists after a remote
+   * change may have deleted the block it was on.
+   */
+  validateCursorPosition(): void;
+  /**
    * Reset editor state after the underlying document was replaced externally
    * (e.g. via `store.setDocument()`). Refreshes the cached document, resets
    * the cursor to the first block, invalidates layout caches, and repaints.
@@ -396,6 +401,20 @@ export function initialize(
   let dirtyBlockIds: Set<string> | undefined;
   let needsScrollIntoView = false;
   let focused = !readOnly;
+
+  /**
+   * Ensure the cursor points to a block that still exists in the document.
+   * After a remote change deletes the block the cursor is on, relocate it
+   * to the first block so subsequent reads don't throw.
+   */
+  const validateCursorPosition = (): void => {
+    if (doc.findBlock(cursor.position.blockId)) return;
+    const firstBlock = doc.getContextBlocks()[0] ?? doc.document.blocks[0];
+    if (firstBlock) {
+      cursor.moveTo({ blockId: firstBlock.id, offset: 0 });
+      selection.setRange(null);
+    }
+  };
 
   /** Apply inline style to all blocks in all cells within a cell range. */
   function applyStyleToCellRange(
@@ -2096,6 +2115,7 @@ export function initialize(
       textEditor?.onEditContextChange(cb);
     },
     focus: () => textEditor?.focus(),
+    validateCursorPosition,
     resetAfterDocumentReplace: () => {
       doc.refresh();
       textEditor?.setEditContext('body');

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -244,6 +244,7 @@ export function DocsView({ onEditorReady, readOnly, documentId }: DocsViewProps)
     // render() repaints the canvas with the latest content.
     store.onRemoteChange = () => {
       editor.getDoc().refresh();
+      editor.validateCursorPosition();
       editor.render();
     };
 


### PR DESCRIPTION
## Summary

- Fix "Block not found" error when a remote client selects all and deletes in a collaborative docs session
- Add `Doc.findBlock()` (non-throwing block lookup) and `EditorAPI.validateCursorPosition()` to relocate a stale cursor after remote changes remove the block it references
- Call `validateCursorPosition()` in the `onRemoteChange` handler between `refresh()` and `render()`

## Test plan

- [x] Open the same document in two browser tabs
- [x] In tab B, select all (Ctrl/Cmd+A) and delete
- [x] Verify tab A does not throw "Block not found" and gracefully shows the updated (empty) document
- [x] Verify normal collaborative editing still works after the deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)