### PR TITLE
Add nested table support for Docs editor

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -35,6 +35,7 @@ Word processor engine — rich text, tables, pagination, collaboration.
 | [docs-table-ui.md](docs/docs-table-ui.md)                                        | Docs table UI — grid picker, context menu, IME cell routing                                       |
 | [docs-table-crdt.md](docs/docs-table-crdt.md)                                    | Table CRDT collaboration — Tree node structure, container cells, concurrent editing               |
 | [docs-table-resize.md](docs/docs-table-resize.md)                                | Docs table resize — column/row border drag handles, guideline rendering                           |
+| [docs-nested-tables.md](docs/docs-nested-tables.md)                              | Nested tables — recursive nesting, layout, rendering, editing, CRDT synchronization               |
 | [docs-image-editing.md](docs/docs-image-editing.md)                              | Docs image editing — toolbar insert, selection handles, resize, rotation, crop, Image Options panel |
 | [docs-frontend-integration.md](docs/docs-frontend-integration.md)                | Docs frontend integration — document type field, list UI, routing, backend API changes            |
 | [docs-collaboration.md](docs/docs-collaboration.md)                              | Docs collaboration design                                                                         |

--- a/docs/design/docs/docs-nested-tables.md
+++ b/docs/design/docs/docs-nested-tables.md
@@ -1,0 +1,240 @@
+---
+title: docs-nested-tables
+target-version: v0.3.3
+---
+
+# Nested Tables
+
+## Summary
+
+Support recursively nested tables in the Docs editor. A table cell can contain
+another table, which in turn can contain another table, and so on. This enables
+.docx import/export fidelity (many real-world forms use nested tables) and lets
+users create nested tables directly in the editor.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Recursive nesting with no hard depth limit (UI naturally limits via minimum
+  cell width of 30 px)
+- Full feature parity inside nested tables: cell merge/split, row/column
+  insert/delete, resize, styling
+- Editor insertion: users can insert a table into a cell via the existing table
+  insertion UI
+- Real-time collaboration via Yorkie CRDT synchronization
+- .docx round-trip: import nested tables from .docx, export them back
+
+### Non-Goals
+
+- Cross-page splitting of nested rows (rows remain atomic across pages)
+- Repeating column headers on page break (future enhancement)
+- Drag-and-drop of tables between nesting levels
+
+## Proposal Details
+
+### 1. Data Model
+
+No type changes required. `TableCell.blocks: Block[]` already accepts any
+`Block`, and `Block` already has `type: 'table'` with a `tableData` field.
+
+**Changes:**
+
+- **Remove nested-table insertion guard** in `Document.insertTable()`. Currently
+  `insertTable` checks `BlockParentMap` and rejects insertion when the cursor is
+  inside a cell. Remove this check so that a table block is added to
+  `cell.blocks` like any other block.
+
+- **Recursive `BlockParentMap` construction.** When building the map, recurse
+  into cell blocks: if a block is a table, iterate its rows/cells and register
+  each inner block. Every `blockId` maps to its *direct* parent cell
+  (`BlockCellInfo`), regardless of nesting depth.
+
+- **Recursive `findBlock()`.** When searching for a block by ID, if it is not
+  found at the document level, search recursively through table cells. The
+  existing `BlockParentMap` lookup already provides O(1) access; the recursive
+  search is the fallback/construction path.
+
+**Invariants:**
+
+- All `blockId` values are globally unique.
+- `BlockParentMap[blockId]` always points to the *direct* parent cell.
+- A table block inside a cell is itself registered in the parent cell's map
+  entry.
+
+### 2. Layout Engine
+
+`computeTableLayout()` and `layoutCellBlocks()` become mutually recursive.
+
+**Changes:**
+
+- **`layoutCellBlocks()` handles `table` blocks.** When `block.type === 'table'`,
+  call `computeTableLayout()` recursively with `contentWidth = cellWidth - padding * 2`.
+  The returned `LayoutTable` is stored on a dedicated field.
+
+- **`LayoutLine` extension.** Add `nestedTable?: LayoutTable` to `LayoutLine`.
+  A table block produces a single `LayoutLine` whose height equals
+  `nestedTable.totalHeight`.
+
+- **`blockParentMap` merge.** Each recursive `computeTableLayout()` returns its
+  own `blockParentMap`. Merge all inner maps into the outermost map so that
+  global block lookup works.
+
+- **Inner table width.** The inner table receives the parent cell's content
+  width (cell pixel width minus padding on each side). This means deeper nesting
+  naturally produces narrower tables, and the 30 px minimum column width acts as
+  a practical depth limiter.
+
+**Call flow:**
+
+```
+computeTableLayout(outerTable, contentWidth)
+  layoutCellBlocks(cell.blocks, cellContentWidth)
+    block.type === 'table'
+      computeTableLayout(innerTable, cellContentWidth)   // recurse
+        layoutCellBlocks(innerCell.blocks, innerCellContentWidth)
+```
+
+### 3. Rendering
+
+`renderTableBackgrounds()` and `renderTableContent()` become recursive.
+
+**Changes:**
+
+- **Nested table rendering.** When iterating lines inside a cell, if a line has
+  `nestedTable`, call `renderTableBackgrounds()` then `renderTableContent()`
+  recursively with the line's (x, y) as the origin.
+
+- **Coordinate transform.** The inner table's rendering origin is computed as:
+  `x = cellX + padding`, `y = cellY + padding + lineYOffset`. All inner
+  coordinates are relative to this origin.
+
+- **Selection highlight.** When the cursor is inside a nested table, only that
+  table's cell selection is highlighted. `BlockParentMap` identifies which table
+  the cursor belongs to.
+
+- **Borders.** Each table renders its own borders independently. No
+  border-collapse interaction between outer and inner tables.
+
+**Unchanged:**
+
+- Pagination: rows (including those containing nested tables) remain atomic.
+- Border collapse logic: operates per-table, no cross-table collapse.
+
+### 4. Editing and Cursor/Navigation
+
+**Cursor context:**
+
+- `getCellInfo(blockId)` returns the direct parent cell from `BlockParentMap` —
+  works unchanged for nested tables.
+
+- **New `getTableContext(blockId)`** — walks up the `BlockParentMap` chain to
+  return the table hierarchy path: `[outermostTableId, ..., innermostTableId]`.
+  Used to identify the correct target table for structural operations.
+
+**Table insertion in cells:**
+
+- `insertTable()` inserts a table block into the current cell's `blocks` array
+  at the cursor's block position. Identical to inserting a paragraph, except the
+  block type is `'table'`.
+
+**Tab / arrow navigation:**
+
+- Tab moves between cells of the *direct parent* table only. If the cursor is
+  inside an inner table, Tab cycles through inner table cells.
+- Tab at the last cell of an inner table adds a new row to that inner table
+  (existing behavior, scoped to direct parent).
+- Arrow keys at an inner table boundary move the cursor to the next/previous
+  block in the outer cell.
+
+**Structural operations (insert row, delete column, merge, etc.):**
+
+- All operations use `getCellInfo()` to identify the direct parent table and
+  operate on it. No changes needed — operations are already table-scoped.
+
+**Context menu:**
+
+- Right-click inside a nested table shows row/column operations for that table.
+- "Delete table" deletes only the direct parent table (the inner table), not the
+  outer one.
+
+### 5. CRDT (Yorkie Tree) Synchronization
+
+Current Yorkie Tree structure:
+
+```
+<doc>
+  <p> ... </p>
+  <table>
+    <tr>
+      <td>            // container cell
+        <p> ... </p>
+      </td>
+    </tr>
+  </table>
+</doc>
+```
+
+**Extended structure with nesting:**
+
+```
+<doc>
+  <table>
+    <tr>
+      <td>
+        <p> ... </p>
+        <table>          // nested table inside <td>
+          <tr>
+            <td>
+              <p> ... </p>
+            </td>
+          </tr>
+        </table>
+        <p> ... </p>
+      </td>
+    </tr>
+  </table>
+</doc>
+```
+
+**Changes:**
+
+- **Allow `<table>` inside `<td>`.** Yorkie Tree supports arbitrary element
+  nesting, so no SDK changes are needed — just insert the `<table>` subtree
+  under the `<td>` node.
+
+- **`resolveTreePath(blockId): number[]` utility.** Converts a blockId to a
+  Yorkie Tree path by walking up the `BlockParentMap` hierarchy. For nested
+  tables, the path is deeper (e.g.,
+  `[tableIdx, rowIdx, colIdx, innerBlockIdx, innerRowIdx, ...]`).
+
+- **Granular operations path adjustment.** Existing Store methods
+  (`insertTableRow`, `deleteTableColumn`, `updateTableCell`, etc.) use tree
+  paths. For nested tables, `resolveTreePath` produces the correct deeper path.
+
+**Concurrent editing:**
+
+| Scenario | Resolution |
+|----------|-----------|
+| Two users edit different inner tables | No conflict (different subtrees) |
+| Two users edit the same inner cell | Text CRDT merge (existing behavior) |
+| User A deletes outer row, User B edits inner table in that row | Delete wins (Yorkie policy: edits to deleted subtrees are discarded) |
+| User A inserts row in outer table, User B inserts row in inner table | No conflict (different tables) |
+
+### 6. Pagination
+
+No changes. The existing rule applies recursively:
+
+- Rows are never split across pages.
+- A row containing a nested table is treated as a single atomic unit.
+- If a row (with its nested table) exceeds page height, it gets its own page.
+
+## Risks and Mitigation
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Path calculation complexity for Yorkie operations | High — wrong paths corrupt data | `resolveTreePath` utility with comprehensive unit tests; round-trip test that inserts/edits nested tables and verifies Yorkie state |
+| Performance with deep nesting | Medium — recursive layout/render | Minimum column width (30 px) naturally limits depth to ~4-5 levels; profile with stress test (3-level nesting, 10x10 tables) |
+| Coordinate math errors in rendering | Medium — visual glitches | Snapshot/visual regression tests for nested table rendering |
+| Undo/redo granularity | Low — snapshot-based undo already captures full state | No change needed, but verify undo works correctly across nesting levels |
+| .docx import/export | Medium — nested `<w:tbl>` mapping | Separate task; data model support is prerequisite |

--- a/docs/design/docs/docs-table-crdt.md
+++ b/docs/design/docs/docs-table-crdt.md
@@ -27,7 +27,9 @@ capabilities.
 
 ## Non-Goals
 
-- Nested tables (cells containing tables) — blocked at insertion time
+- ~~Nested tables (cells containing tables) — blocked at insertion time~~ —
+  **implemented**: nested tables are now supported; see
+  [docs-nested-tables.md](docs-nested-tables.md)
 - Cell-level images — deferred to future work
 - Yorkie-native undo/redo — remains snapshot-based (separate project)
 - Horizontal rules inside cells
@@ -326,11 +328,8 @@ sequentially within the cell bounds.
 | `paragraph` | Yes |
 | `list-item` | Yes |
 | `heading` | Yes |
-| `table` | **No** — blocked at insertion time |
+| `table` | **Yes** — nested tables are supported at any depth; `BlockParentMap` is recursive and CRDT path resolution handles arbitrarily nested `row → cell → block` chains. See [docs-nested-tables.md](docs-nested-tables.md). |
 | `horizontal-rule` | No |
-
-`insertTable` checks `BlockParentMap` — if the cursor is inside a cell,
-the insertion is rejected.
 
 ### Pagination
 

--- a/docs/design/docs/docs-tables.md
+++ b/docs/design/docs/docs-tables.md
@@ -28,7 +28,9 @@ borders.
 ## Non-Goals
 
 - Nested blocks inside cells (lists, headings, images) — deferred to future
-  migration (see [Extensibility Path](#extensibility-path))
+  migration (see [Extensibility Path](#extensibility-path)) — **Note:** nested
+  tables inside cells are now supported (see
+  [docs-nested-tables.md](docs-nested-tables.md))
 - Column resize via drag handle — future enhancement
 - Table of contents auto-generation from table content
 - CSV/spreadsheet import into tables
@@ -441,7 +443,8 @@ capabilities.
 ### Trigger Criteria for Migration
 
 - User requests for lists or headings inside table cells
-- Need for nested tables (e.g., complex form layouts)
+- ~~Need for nested tables (e.g., complex form layouts)~~ — **implemented**:
+  nested tables are now supported; see [docs-nested-tables.md](docs-nested-tables.md)
 - Phase 6 work (multi-column, footnotes) that benefits from recursive
   Block structure
 

--- a/docs/tasks/active/20260413-nested-tables-todo.md
+++ b/docs/tasks/active/20260413-nested-tables-todo.md
@@ -1,0 +1,1085 @@
+# Nested Tables Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Support recursively nested tables in the Docs editor — a table cell can contain another table.
+
+**Architecture:** Remove the insertion guard, make `layoutCellBlocks()` and `computeTableLayout()` mutually recursive, extend rendering to recurse into nested tables, and build `BlockParentMap` recursively so all existing cell operations (merge, split, navigate) work at any nesting depth. CRDT sync via `resolveTreePath()` utility.
+
+**Tech Stack:** TypeScript, Vitest, Canvas 2D, Yorkie CRDT Tree
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `packages/docs/src/view/table-layout.ts:183-232` | `layoutCellBlocks()` — handle `block.type === 'table'` via recursive `computeTableLayout()` |
+| Modify | `packages/docs/src/view/table-layout.ts:350-360` | `computeTableLayout()` — recursive `blockParentMap` construction |
+| Modify | `packages/docs/src/view/layout.ts:81-86` | `LayoutLine` — add `nestedTable?: LayoutTable` field |
+| Modify | `packages/docs/src/view/table-renderer.ts:260-358` | `renderTableContent()` — recurse when line has `nestedTable` |
+| Modify | `packages/docs/src/view/table-renderer.ts:93-148` | `renderTableBackgrounds()` — recurse for nested tables |
+| Modify | `packages/docs/src/view/editor.ts:1849-1873` | `insertTable()` — support insertion inside cells |
+| Modify | `packages/docs/src/view/editor.ts:1874-1889` | `deleteTable()` — handle nested table deletion |
+| Modify | `packages/docs/src/model/document.ts:121-167` | `getBlock()`/`findBlock()` — recursive cell search for deeply nested blocks |
+| Modify | `packages/docs/src/view/text-editor.ts:3290-3380` | `moveToNextCell()`/`moveToPrevCell()` — already scoped to direct parent; verify with nested tables |
+| Create | `packages/docs/test/model/nested-table.test.ts` | Unit tests for nested table data model operations |
+| Create | `packages/docs/test/view/nested-table-layout.test.ts` | Unit tests for nested table layout computation |
+
+---
+
+### Task 1: Data Model — Recursive BlockParentMap
+
+Enable `BlockParentMap` to register blocks inside nested tables and make `getBlock()`/`findBlock()` find them.
+
+**Files:**
+- Modify: `packages/docs/src/view/table-layout.ts:350-360`
+- Modify: `packages/docs/src/model/document.ts:121-167`
+- Create: `packages/docs/test/model/nested-table.test.ts`
+
+- [ ] **Step 1: Write failing test — nested table block lookup**
+
+Create `packages/docs/test/model/nested-table.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { Doc } from '../../src/model/document.js';
+import type { BlockCellInfo } from '../../src/model/types.js';
+import { createTableBlock } from '../../src/model/types.js';
+
+/**
+ * Build a recursive BlockParentMap that registers blocks
+ * inside nested tables (mirrors what computeTableLayout will do).
+ */
+function buildParentMapRecursive(
+  doc: Doc,
+  tableBlockId: string,
+): Map<string, BlockCellInfo> {
+  const map = new Map<string, BlockCellInfo>();
+  const block = doc.getBlock(tableBlockId);
+  if (!block.tableData) return map;
+  for (let r = 0; r < block.tableData.rows.length; r++) {
+    for (let c = 0; c < block.tableData.rows[r].cells.length; c++) {
+      const cell = block.tableData.rows[r].cells[c];
+      for (const b of cell.blocks) {
+        map.set(b.id, { tableBlockId, rowIndex: r, colIndex: c });
+        // Recurse into nested tables
+        if (b.type === 'table' && b.tableData) {
+          for (let ir = 0; ir < b.tableData.rows.length; ir++) {
+            for (let ic = 0; ic < b.tableData.rows[ir].cells.length; ic++) {
+              const innerCell = b.tableData.rows[ir].cells[ic];
+              for (const ib of innerCell.blocks) {
+                map.set(ib.id, { tableBlockId: b.id, rowIndex: ir, colIndex: ic });
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return map;
+}
+
+describe('Nested table data model', () => {
+  it('should find a block inside a nested table via getBlock()', () => {
+    const doc = Doc.create();
+    // Insert outer table
+    const outerTableId = doc.insertTable(0, 2, 2);
+
+    // Manually insert an inner table into cell (0,0)
+    const outerBlock = doc.getBlock(outerTableId);
+    const cell00 = outerBlock.tableData!.rows[0].cells[0];
+    const innerTable = createTableBlock(2, 2);
+    cell00.blocks.push(innerTable);
+    doc.store.updateTableCell(outerTableId, 0, 0, cell00);
+
+    // Build and set the recursive parent map
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+
+    // The inner table block itself should be found in outer cell (0,0)
+    const foundInnerTable = doc.getBlock(innerTable.id);
+    expect(foundInnerTable.id).toBe(innerTable.id);
+    expect(foundInnerTable.type).toBe('table');
+
+    // A block inside the inner table should be found
+    const innerCellBlock = innerTable.tableData!.rows[0].cells[0].blocks[0];
+    const foundInnerBlock = doc.getBlock(innerCellBlock.id);
+    expect(foundInnerBlock.id).toBe(innerCellBlock.id);
+  });
+
+  it('BlockParentMap should map inner blocks to their direct parent table', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const cell00 = outerBlock.tableData!.rows[0].cells[0];
+    const innerTable = createTableBlock(2, 2);
+    cell00.blocks.push(innerTable);
+    doc.store.updateTableCell(outerTableId, 0, 0, cell00);
+
+    const map = buildParentMapRecursive(doc, outerTableId);
+
+    // Inner table block → outer cell (0,0)
+    const innerTableInfo = map.get(innerTable.id);
+    expect(innerTableInfo?.tableBlockId).toBe(outerTableId);
+    expect(innerTableInfo?.rowIndex).toBe(0);
+    expect(innerTableInfo?.colIndex).toBe(0);
+
+    // Inner cell's paragraph → inner table cell (0,0)
+    const innerParagraph = innerTable.tableData!.rows[0].cells[0].blocks[0];
+    const innerParagraphInfo = map.get(innerParagraph.id);
+    expect(innerParagraphInfo?.tableBlockId).toBe(innerTable.id);
+    expect(innerParagraphInfo?.rowIndex).toBe(0);
+    expect(innerParagraphInfo?.colIndex).toBe(0);
+  });
+
+  it('should insert and retrieve text in a nested table cell', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const cell00 = outerBlock.tableData!.rows[0].cells[0];
+    const innerTable = createTableBlock(2, 2);
+    cell00.blocks.push(innerTable);
+    doc.store.updateTableCell(outerTableId, 0, 0, cell00);
+
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+
+    const innerCellBlock = innerTable.tableData!.rows[0].cells[0].blocks[0];
+    doc.insertText({ blockId: innerCellBlock.id, offset: 0 }, 'Nested!');
+    const found = doc.getBlock(innerCellBlock.id);
+    expect(found.inlines.map(i => i.text).join('')).toBe('Nested!');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && npx vitest run test/model/nested-table.test.ts`
+Expected: FAIL — `getBlock()` cannot find blocks inside nested tables because `BlockParentMap` only maps one level and `getBlock()` only searches top-level table blocks.
+
+- [ ] **Step 3: Make getBlock()/findBlock() support nested tables**
+
+The current `getBlock()` at `document.ts:131-139` looks up `cellInfo.tableBlockId` only in `this._document.blocks` (top-level). For nested tables, the parent table is itself inside a cell. Change the lookup to be recursive:
+
+In `packages/docs/src/model/document.ts`, replace the cell-search section in both `getBlock()` (lines 131-139) and `findBlock()` (lines 156-163) with a recursive helper:
+
+```typescript
+// Add this private method to the Doc class:
+private findBlockInCells(blockId: string): Block | undefined {
+  const cellInfo = this._blockParentMap.get(blockId);
+  if (!cellInfo) return undefined;
+
+  // The parent table might itself be nested — find it recursively
+  let tableBlock: Block | undefined;
+  // First check top-level blocks
+  tableBlock = this._document.blocks.find((b) => b.id === cellInfo.tableBlockId);
+  // Then check header/footer
+  if (!tableBlock) {
+    tableBlock = this._document.header?.blocks.find((b) => b.id === cellInfo.tableBlockId);
+  }
+  if (!tableBlock) {
+    tableBlock = this._document.footer?.blocks.find((b) => b.id === cellInfo.tableBlockId);
+  }
+  // If still not found, the parent table is itself inside a cell — recurse
+  if (!tableBlock) {
+    tableBlock = this.findBlockInCells(cellInfo.tableBlockId);
+  }
+
+  if (tableBlock?.tableData) {
+    const cell = tableBlock.tableData.rows[cellInfo.rowIndex]?.cells[cellInfo.colIndex];
+    return cell?.blocks.find((b) => b.id === blockId);
+  }
+  return undefined;
+}
+```
+
+Then update `getBlock()`:
+
+```typescript
+getBlock(blockId: string): Block {
+  const block = this._document.blocks.find((b) => b.id === blockId);
+  if (block) return block;
+
+  const hBlock = this._document.header?.blocks.find((b) => b.id === blockId);
+  if (hBlock) return hBlock;
+  const fBlock = this._document.footer?.blocks.find((b) => b.id === blockId);
+  if (fBlock) return fBlock;
+
+  const found = this.findBlockInCells(blockId);
+  if (found) return found;
+
+  throw new Error(`Block not found: ${blockId}`);
+}
+```
+
+And `findBlock()`:
+
+```typescript
+findBlock(blockId: string): Block | undefined {
+  const block = this._document.blocks.find((b) => b.id === blockId);
+  if (block) return block;
+
+  const hBlock = this._document.header?.blocks.find((b) => b.id === blockId);
+  if (hBlock) return hBlock;
+  const fBlock = this._document.footer?.blocks.find((b) => b.id === blockId);
+  if (fBlock) return fBlock;
+
+  return this.findBlockInCells(blockId);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && npx vitest run test/model/nested-table.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `pnpm verify:fast`
+Expected: All existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/docs/src/model/document.ts packages/docs/test/model/nested-table.test.ts
+git commit -m 'Support recursive block lookup for nested tables
+
+getBlock()/findBlock() now walk the BlockParentMap chain to find
+blocks inside arbitrarily nested table cells.'
+```
+
+---
+
+### Task 2: Layout Engine — Recursive Cell Layout
+
+Make `layoutCellBlocks()` handle `block.type === 'table'` by calling `computeTableLayout()` recursively, and merge inner `blockParentMap` entries into the outer map.
+
+**Files:**
+- Modify: `packages/docs/src/view/layout.ts:81-86` (LayoutLine type)
+- Modify: `packages/docs/src/view/table-layout.ts:183-232` (layoutCellBlocks)
+- Modify: `packages/docs/src/view/table-layout.ts:237-376` (computeTableLayout — blockParentMap merge)
+- Create: `packages/docs/test/view/nested-table-layout.test.ts`
+
+- [ ] **Step 1: Write failing test — nested table layout**
+
+Create `packages/docs/test/view/nested-table-layout.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { computeTableLayout } from '../../src/view/table-layout.js';
+import { createTableBlock, createTableCell } from '../../src/model/types.js';
+import type { TableData } from '../../src/model/types.js';
+
+function stubCtx(): CanvasRenderingContext2D {
+  return {
+    measureText: (text: string) => ({ width: text.length * 8 }),
+    font: '',
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function makeNestedTableData(): { outer: TableData; innerBlockId: string } {
+  // Create a 2x2 outer table, with a 2x2 inner table in cell (0,0)
+  const innerTable = createTableBlock(2, 2);
+  const outerCell00 = createTableCell();
+  outerCell00.blocks.push(innerTable);
+
+  const outerCell01 = createTableCell();
+  const outerCell10 = createTableCell();
+  const outerCell11 = createTableCell();
+
+  const outer: TableData = {
+    rows: [
+      { cells: [outerCell00, outerCell01] },
+      { cells: [outerCell10, outerCell11] },
+    ],
+    columnWidths: [0.5, 0.5],
+  };
+
+  return { outer, innerBlockId: innerTable.id };
+}
+
+describe('Nested table layout', () => {
+  it('should compute layout for a table containing a nested table', () => {
+    const { outer, innerBlockId } = makeNestedTableData();
+    const ctx = stubCtx();
+    const layout = computeTableLayout(outer, 'outer-table', ctx, 400);
+
+    // Cell (0,0) should be taller than cell (0,1) due to the nested table
+    expect(layout.cells[0][0].height).toBeGreaterThan(layout.cells[0][1].height);
+
+    // The blockParentMap should contain entries from the inner table
+    const innerTableInfo = layout.blockParentMap.get(innerBlockId);
+    expect(innerTableInfo).toBeDefined();
+    expect(innerTableInfo!.tableBlockId).toBe('outer-table');
+    expect(innerTableInfo!.rowIndex).toBe(0);
+    expect(innerTableInfo!.colIndex).toBe(0);
+  });
+
+  it('should include inner table cell blocks in blockParentMap', () => {
+    const { outer } = makeNestedTableData();
+    const innerTable = outer.rows[0].cells[0].blocks[1]; // index 1 = nested table
+    const innerCellBlockId = innerTable.tableData!.rows[0].cells[0].blocks[0].id;
+
+    const ctx = stubCtx();
+    const layout = computeTableLayout(outer, 'outer-table', ctx, 400);
+
+    const info = layout.blockParentMap.get(innerCellBlockId);
+    expect(info).toBeDefined();
+    expect(info!.tableBlockId).toBe(innerTable.id);
+  });
+
+  it('should produce a LayoutLine with nestedTable for the table block', () => {
+    const { outer } = makeNestedTableData();
+    const ctx = stubCtx();
+    const layout = computeTableLayout(outer, 'outer-table', ctx, 400);
+
+    // Cell (0,0) has 2 blocks: default paragraph + nested table.
+    // The nested table block should produce a line with nestedTable set.
+    const cell00 = layout.cells[0][0];
+    const hasNestedTableLine = cell00.lines.some(
+      (line) => (line as any).nestedTable !== undefined,
+    );
+    expect(hasNestedTableLine).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && npx vitest run test/view/nested-table-layout.test.ts`
+Expected: FAIL — `layoutCellBlocks()` doesn't handle table blocks, so nested table height is 0 and no `nestedTable` field exists on `LayoutLine`.
+
+- [ ] **Step 3: Add nestedTable field to LayoutLine**
+
+In `packages/docs/src/view/layout.ts`, add the import and field:
+
+```typescript
+// Add import at top of file
+import type { LayoutTable } from './table-layout.js';
+
+// Extend LayoutLine interface (lines 81-86)
+export interface LayoutLine {
+  runs: LayoutRun[];
+  y: number;
+  height: number;
+  width: number;
+  nestedTable?: LayoutTable;
+}
+```
+
+- [ ] **Step 4: Make layoutCellBlocks() handle table blocks recursively**
+
+In `packages/docs/src/view/table-layout.ts`, modify `layoutCellBlocks()` (around line 199-221). The function needs access to the outer `tableBlockId` and an accumulator for the merged `blockParentMap`. Change the function signature and add the table block handling:
+
+First, update `computeTableLayout()` to pass `tableBlockId` and a shared `blockParentMap` accumulator to `layoutCellBlocks()`:
+
+```typescript
+// In computeTableLayout(), replace the layoutCellBlocks call (around line 282):
+const { lines, blockBoundaries } = layoutCellBlocks(
+  cell?.blocks ?? [], ctx, innerWidth, tableBlockId, r, c, blockParentMap,
+);
+```
+
+Then update `layoutCellBlocks()`:
+
+```typescript
+function layoutCellBlocks(
+  blocks: Block[],
+  ctx: CanvasRenderingContext2D,
+  maxWidth: number,
+  parentTableBlockId?: string,
+  parentRow?: number,
+  parentCol?: number,
+  parentMap?: Map<string, BlockCellInfo>,
+): { lines: LayoutLine[]; blockBoundaries: number[] } {
+  if (blocks.length === 0) {
+    const defaultHeight = ptToPx(Theme.defaultFontSize) * 1.5;
+    return {
+      lines: [{ runs: [], y: 0, height: defaultHeight, width: 0 }],
+      blockBoundaries: [0],
+    };
+  }
+
+  const allLines: LayoutLine[] = [];
+  const blockBoundaries: number[] = [];
+
+  for (const block of blocks) {
+    blockBoundaries.push(allLines.length);
+
+    // Handle nested table blocks
+    if (block.type === 'table' && block.tableData) {
+      const nestedLayout = computeTableLayout(
+        block.tableData, block.id, ctx, maxWidth,
+      );
+      // Merge inner blockParentMap into outer
+      if (parentMap) {
+        for (const [k, v] of nestedLayout.blockParentMap) {
+          parentMap.set(k, v);
+        }
+      }
+      const tableLine: LayoutLine = {
+        runs: [],
+        y: 0,
+        height: nestedLayout.totalHeight,
+        width: nestedLayout.totalWidth,
+        nestedTable: nestedLayout,
+      };
+      allLines.push(tableLine);
+      continue;
+    }
+
+    // Existing logic for text blocks
+    const listIndent = block.type === 'list-item'
+      ? LIST_INDENT_PX * ((block.listLevel ?? 0) + 1)
+      : 0;
+    const effectiveWidth = maxWidth - listIndent;
+    const blockLines = layoutCellInlines(block.inlines, ctx, effectiveWidth);
+    const alignment = block.style?.alignment ?? 'left';
+    for (let li = 0; li < blockLines.length; li++) {
+      applyAlignment(blockLines[li], effectiveWidth, alignment, li === blockLines.length - 1);
+    }
+    if (listIndent > 0) {
+      for (const line of blockLines) {
+        for (const run of line.runs) {
+          run.x += listIndent;
+        }
+        line.width += listIndent;
+      }
+    }
+    allLines.push(...blockLines);
+  }
+
+  // Recalculate cumulative y offsets
+  let y = 0;
+  for (const line of allLines) {
+    line.y = y;
+    y += line.height;
+  }
+
+  return { lines: allLines, blockBoundaries };
+}
+```
+
+And in `computeTableLayout()`, update the `blockParentMap` construction (around line 350-360) to also pass the map to `layoutCellBlocks` and ensure it's initialized before the cell layout loop:
+
+```typescript
+// Move blockParentMap initialization to BEFORE the cell layout loop (before line 258)
+const blockParentMap = new Map<string, BlockCellInfo>();
+
+// In the cell layout loop, pass blockParentMap:
+const { lines, blockBoundaries } = layoutCellBlocks(
+  cell?.blocks ?? [], ctx, innerWidth, tableBlockId, r, c, blockParentMap,
+);
+
+// Keep the existing blockParentMap construction (lines 350-360) to register
+// direct children. The nested maps are already merged via layoutCellBlocks.
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd packages/docs && npx vitest run test/view/nested-table-layout.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `pnpm verify:fast`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/docs/src/view/layout.ts packages/docs/src/view/table-layout.ts packages/docs/test/view/nested-table-layout.test.ts
+git commit -m 'Add recursive layout for nested tables
+
+layoutCellBlocks() now calls computeTableLayout() when it encounters
+a table block, producing a LayoutLine with nestedTable. Inner
+blockParentMap entries are merged into the outer map.'
+```
+
+---
+
+### Task 3: Rendering — Recursive Table Rendering
+
+Make `renderTableContent()` and `renderTableBackgrounds()` recurse when a line has `nestedTable`.
+
+**Files:**
+- Modify: `packages/docs/src/view/table-renderer.ts:93-148` (renderTableBackgrounds)
+- Modify: `packages/docs/src/view/table-renderer.ts:260-358` (renderTableContent, per-line loop)
+
+- [ ] **Step 1: Add nested table rendering in renderTableContent()**
+
+In `packages/docs/src/view/table-renderer.ts`, inside the per-line loop (around line 260), add a check before the run loop:
+
+```typescript
+// Inside the per-line loop, before `for (const run of line.runs)`:
+for (let li = 0; li < layoutCell.lines.length; li++) {
+  const line = layoutCell.lines[li];
+  let lineAbsoluteY: number;
+  if (mergedLineLayouts) {
+    const ll = mergedLineLayouts[li];
+    if (ll.ownerRow < pageStart || ll.ownerRow >= rowEnd) continue;
+    lineAbsoluteY = tableY + ll.runLineY;
+  } else {
+    lineAbsoluteY = cellY + textYOffset + line.y;
+  }
+
+  // Render nested table if this line contains one
+  if (line.nestedTable) {
+    const nestedX = cellX + padding;
+    const nestedY = lineAbsoluteY;
+    const innerTableData = cell.blocks.find(
+      (b) => b.type === 'table' && b.tableData,
+    );
+    if (innerTableData?.tableData) {
+      renderTableBackgrounds(
+        ctx, innerTableData.tableData, line.nestedTable,
+        nestedX, nestedY,
+      );
+      renderTableContent(
+        ctx, innerTableData.tableData, line.nestedTable,
+        nestedX, nestedY,
+        0, undefined, undefined,
+        requestRender, dragImageRun, selectionRects, focused,
+      );
+    }
+    continue;
+  }
+
+  // Existing run rendering loop...
+  for (const run of line.runs) {
+    // ...existing code
+  }
+}
+```
+
+Note: The above approach of `cell.blocks.find()` is fragile when multiple nested tables exist. A more robust approach: track block index via `blockBoundaries`. For each line at index `li`, find which block it belongs to using `blockBoundaries`, then use `cell.blocks[blockIndex]`. Adjust accordingly:
+
+```typescript
+// Before the line loop, compute a helper to map line index → block index:
+// (blockBoundaries[bi] is the first line of block bi)
+function getBlockIndexForLine(blockBoundaries: number[], lineIndex: number): number {
+  for (let bi = blockBoundaries.length - 1; bi >= 0; bi--) {
+    if (lineIndex >= blockBoundaries[bi]) return bi;
+  }
+  return 0;
+}
+
+// Then in the nested table check:
+if (line.nestedTable) {
+  const blockIndex = getBlockIndexForLine(layoutCell.blockBoundaries, li);
+  const nestedBlock = cell.blocks[blockIndex];
+  if (nestedBlock?.tableData) {
+    const nestedX = cellX + padding;
+    const nestedY = lineAbsoluteY;
+    renderTableBackgrounds(
+      ctx, nestedBlock.tableData, line.nestedTable,
+      nestedX, nestedY,
+    );
+    renderTableContent(
+      ctx, nestedBlock.tableData, line.nestedTable,
+      nestedX, nestedY,
+      0, undefined, undefined,
+      requestRender, dragImageRun, selectionRects, focused,
+    );
+  }
+  continue;
+}
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `pnpm verify:fast`
+Expected: All tests pass. (Rendering tests may not cover nested tables yet, but no regressions.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/docs/src/view/table-renderer.ts
+git commit -m 'Add recursive rendering for nested tables
+
+renderTableContent() now detects lines with nestedTable and
+recursively calls renderTableBackgrounds() + renderTableContent()
+to draw inner tables within cells.'
+```
+
+---
+
+### Task 4: Editor — Allow Table Insertion Inside Cells
+
+Modify the editor's `insertTable()` to work when the cursor is inside a table cell, inserting a nested table block into that cell's blocks array.
+
+**Files:**
+- Modify: `packages/docs/src/view/editor.ts:1849-1873`
+- Modify: `packages/docs/src/model/document.ts` (add `insertTableInCell()`)
+
+- [ ] **Step 1: Write failing test — insert table inside cell**
+
+Add to `packages/docs/test/model/nested-table.test.ts`:
+
+```typescript
+describe('insertTableInCell', () => {
+  it('should insert a nested table into a cell', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const cellBlock = outerBlock.tableData!.rows[0].cells[0].blocks[0];
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+
+    const innerTableId = doc.insertTableInCell(cellBlock.id, 2, 2);
+
+    const cell = doc.getBlock(outerTableId).tableData!.rows[0].cells[0];
+    expect(cell.blocks).toHaveLength(2);
+    const innerBlock = cell.blocks.find((b) => b.id === innerTableId);
+    expect(innerBlock).toBeDefined();
+    expect(innerBlock!.type).toBe('table');
+    expect(innerBlock!.tableData!.rows).toHaveLength(2);
+    expect(innerBlock!.tableData!.rows[0].cells).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && npx vitest run test/model/nested-table.test.ts`
+Expected: FAIL — `insertTableInCell` doesn't exist.
+
+- [ ] **Step 3: Add insertTableInCell() to Doc**
+
+In `packages/docs/src/model/document.ts`, add after the existing `insertTable()` method:
+
+```typescript
+/**
+ * Insert a table block into the cell containing `blockId`.
+ * The new table is inserted after the block at `blockId`.
+ * Returns the new table block's ID.
+ */
+insertTableInCell(blockId: string, rows: number, cols: number): string {
+  const cellInfo = this._blockParentMap.get(blockId);
+  if (!cellInfo) {
+    throw new Error(`Block ${blockId} is not inside a table cell`);
+  }
+  const tableBlock = this.getBlock(cellInfo.tableBlockId);
+  const cell = tableBlock.tableData!.rows[cellInfo.rowIndex].cells[cellInfo.colIndex];
+  const blockIndex = cell.blocks.findIndex((b) => b.id === blockId);
+
+  const newTable = createTableBlock(rows, cols);
+  cell.blocks.splice(blockIndex + 1, 0, newTable);
+  this.store.updateTableCell(
+    cellInfo.tableBlockId, cellInfo.rowIndex, cellInfo.colIndex, cell,
+  );
+  this.refresh();
+  return newTable.id;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && npx vitest run test/model/nested-table.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Update editor insertTable() to handle cell context**
+
+In `packages/docs/src/view/editor.ts`, modify the `insertTable` method (lines 1849-1873):
+
+```typescript
+insertTable: (rows: number, cols: number) => {
+  docStore.snapshot();
+  const pos = cursor.position;
+  const cellInfo = layout.blockParentMap.get(pos.blockId);
+
+  if (cellInfo) {
+    // Cursor is inside a table cell — insert nested table
+    const innerTableId = doc.insertTableInCell(pos.blockId, rows, cols);
+    const innerBlock = doc.getBlock(innerTableId);
+    const firstCellBlock = innerBlock.tableData!.rows[0].cells[0].blocks[0];
+    cursor.moveTo({ blockId: firstCellBlock.id, offset: 0 });
+    invalidateLayout();
+    render();
+    return;
+  }
+
+  // Top-level table insertion (existing logic)
+  const block = doc.getBlock(pos.blockId);
+  const blockLen = getBlockTextLength(block);
+  if (pos.offset > 0 && pos.offset < blockLen) {
+    doc.splitBlock(pos.blockId, pos.offset);
+  }
+  const blockIndex = doc.getBlockIndex(pos.blockId);
+  const tableId = doc.insertTable(blockIndex + 1, rows, cols);
+  const tableIndex = doc.getBlockIndex(tableId);
+  doc.ensureBlockAfter(tableIndex);
+  const tableBlock = doc.getBlock(tableId);
+  const firstCellBlock = tableBlock.tableData!.rows[0].cells[0].blocks[0];
+  cursor.moveTo({ blockId: firstCellBlock.id, offset: 0 });
+  invalidateLayout();
+  render();
+},
+```
+
+- [ ] **Step 6: Update deleteTable() to handle nested tables**
+
+In `packages/docs/src/view/editor.ts`, modify `deleteTable` (lines 1874-1889):
+
+```typescript
+deleteTable: () => {
+  const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
+  if (!cellInfo) return;
+  const tableBlockId = cellInfo.tableBlockId;
+  docStore.snapshot();
+
+  // Check if this table is itself nested inside a cell
+  const parentCellInfo = layout.blockParentMap.get(tableBlockId);
+  if (parentCellInfo) {
+    // Nested table — remove it from the parent cell's blocks
+    const parentTableBlock = doc.getBlock(parentCellInfo.tableBlockId);
+    const parentCell = parentTableBlock.tableData!.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];
+    const idx = parentCell.blocks.findIndex((b) => b.id === tableBlockId);
+    if (idx !== -1) {
+      parentCell.blocks.splice(idx, 1);
+      // Ensure cell has at least one block
+      if (parentCell.blocks.length === 0) {
+        parentCell.blocks.push({
+          id: generateBlockId(),
+          type: 'paragraph',
+          inlines: [{ text: '', style: {} }],
+          style: { ...DEFAULT_BLOCK_STYLE },
+        });
+      }
+      doc.store.updateTableCell(
+        parentCellInfo.tableBlockId, parentCellInfo.rowIndex, parentCellInfo.colIndex, parentCell,
+      );
+      cursor.moveTo({ blockId: parentCell.blocks[0].id, offset: 0 });
+    }
+  } else {
+    // Top-level table — existing logic
+    const blockIndex = doc.getBlockIndex(tableBlockId);
+    doc.deleteBlock(tableBlockId);
+    const blocks = doc.document.blocks;
+    if (blocks.length > 0) {
+      const newIndex = Math.min(blockIndex, blocks.length - 1);
+      cursor.moveTo({ blockId: blocks[newIndex].id, offset: 0 });
+    }
+  }
+  invalidateLayout();
+  render();
+},
+```
+
+Note: You'll need to import `generateBlockId` and `DEFAULT_BLOCK_STYLE` at the top of editor.ts if not already imported.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `pnpm verify:fast`
+Expected: All tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/docs/src/model/document.ts packages/docs/src/view/editor.ts packages/docs/test/model/nested-table.test.ts
+git commit -m 'Allow table insertion and deletion inside cells
+
+insertTableInCell() adds a table block to a cell. The editor
+insertTable() detects cell context and delegates. deleteTable()
+handles nested table removal from parent cells.'
+```
+
+---
+
+### Task 5: Navigation — Verify and Fix Cell Navigation for Nested Tables
+
+Verify that Tab/arrow navigation works correctly when the cursor is inside a nested table. The existing `moveToNextCell()`/`moveToPrevCell()` use `getCellInfo()` which returns the direct parent table — this should work, but needs verification and edge case handling.
+
+**Files:**
+- Modify: `packages/docs/src/view/text-editor.ts:3290-3380` (if needed)
+- Modify: `packages/docs/test/model/nested-table.test.ts` (add navigation tests)
+
+- [ ] **Step 1: Write test for navigation context in nested tables**
+
+Add to `packages/docs/test/model/nested-table.test.ts`:
+
+```typescript
+describe('Nested table navigation context', () => {
+  it('getCellInfo should return inner table cell for inner block', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const cell00 = outerBlock.tableData!.rows[0].cells[0];
+    const innerTable = createTableBlock(2, 2);
+    cell00.blocks.push(innerTable);
+    doc.store.updateTableCell(outerTableId, 0, 0, cell00);
+
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+
+    // Inner cell (1,1) paragraph
+    const innerCellBlock = innerTable.tableData!.rows[1].cells[1].blocks[0];
+    const info = map.get(innerCellBlock.id);
+    expect(info).toBeDefined();
+    expect(info!.tableBlockId).toBe(innerTable.id);
+    expect(info!.rowIndex).toBe(1);
+    expect(info!.colIndex).toBe(1);
+  });
+
+  it('getCellInfo for inner table block itself should return outer cell', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const cell00 = outerBlock.tableData!.rows[0].cells[0];
+    const innerTable = createTableBlock(2, 2);
+    cell00.blocks.push(innerTable);
+    doc.store.updateTableCell(outerTableId, 0, 0, cell00);
+
+    const map = buildParentMapRecursive(doc, outerTableId);
+
+    const info = map.get(innerTable.id);
+    expect(info).toBeDefined();
+    expect(info!.tableBlockId).toBe(outerTableId);
+    expect(info!.rowIndex).toBe(0);
+    expect(info!.colIndex).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd packages/docs && npx vitest run test/model/nested-table.test.ts`
+Expected: PASS — `BlockParentMap` already maps inner blocks to direct parent table. `moveToNextCell()` and `moveToPrevCell()` in text-editor.ts use `getCellInfo()` which reads from `blockParentMap`, so they will navigate within the inner table. No code changes needed if tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/docs/test/model/nested-table.test.ts
+git commit -m 'Add navigation context tests for nested tables
+
+Verify that BlockParentMap correctly maps inner table cell blocks
+to their direct parent table for scoped navigation.'
+```
+
+---
+
+### Task 6: CRDT — resolveTreePath() for Nested Tables
+
+Add a `resolveTreePath()` utility that converts a blockId to a Yorkie Tree path, supporting arbitrarily nested tables.
+
+**Files:**
+- Modify: `packages/docs/src/store/yorkie.ts` (or create utility)
+- Tests inline with the Yorkie store tests
+
+This task depends on the existing YorkieDocStore implementation. The key change is:
+
+- [ ] **Step 1: Identify current Yorkie path resolution**
+
+Read `packages/docs/src/store/yorkie.ts` to understand how table operations currently map to tree paths.
+
+- [ ] **Step 2: Add resolveTreePath() utility**
+
+The utility walks up the `BlockParentMap` chain from a blockId to build the full Yorkie Tree path:
+
+```typescript
+/**
+ * Resolve a block's Yorkie Tree path by walking up the BlockParentMap chain.
+ * For a block inside a nested table, this produces a path like:
+ *   [outerTableIdx, trIdx, tdIdx, innerTableBlockIdx, innerTrIdx, innerTdIdx, blockIdx]
+ */
+export function resolveTreePath(
+  blockId: string,
+  blockParentMap: Map<string, BlockCellInfo>,
+  doc: Doc,
+): number[] {
+  const cellInfo = blockParentMap.get(blockId);
+  if (!cellInfo) {
+    // Top-level block — return its document-level index
+    return [doc.getBlockIndex(blockId)];
+  }
+
+  // Build path from innermost to outermost
+  const segments: number[] = [];
+
+  // Find block index within its cell
+  const tableBlock = doc.getBlock(cellInfo.tableBlockId);
+  const cell = tableBlock.tableData!.rows[cellInfo.rowIndex].cells[cellInfo.colIndex];
+  const blockIndex = cell.blocks.findIndex((b) => b.id === blockId);
+  segments.unshift(blockIndex); // block within <td>
+  segments.unshift(cellInfo.colIndex); // <td> index
+  segments.unshift(cellInfo.rowIndex); // <tr> index
+
+  // Now resolve the table block itself (may be nested)
+  const parentPath = resolveTreePath(cellInfo.tableBlockId, blockParentMap, doc);
+  return [...parentPath, ...segments];
+}
+```
+
+- [ ] **Step 3: Update Yorkie store table operations to use resolveTreePath()**
+
+Existing granular operations (`insertTableRow`, `updateTableCell`, etc.) in the Yorkie store should use `resolveTreePath()` to compute the correct path for nested tables instead of assuming a flat document structure.
+
+- [ ] **Step 4: Write tests for path resolution**
+
+Test that `resolveTreePath()` returns the correct path for:
+- A block in a top-level table cell
+- A block in a nested table cell
+- A block in a 2-level nested table cell
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `pnpm verify:fast`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/docs/src/store/
+git commit -m 'Add resolveTreePath() for nested table CRDT paths
+
+Walks BlockParentMap chain to build Yorkie Tree paths for blocks
+at any nesting depth.'
+```
+
+---
+
+### Task 7: Integration Testing & Edge Cases
+
+End-to-end verification of nested tables across the full pipeline.
+
+**Files:**
+- Modify: `packages/docs/test/model/nested-table.test.ts`
+
+- [ ] **Step 1: Add integration tests**
+
+```typescript
+describe('Nested table integration', () => {
+  it('should support row/column operations on inner table', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const cell00 = outerBlock.tableData!.rows[0].cells[0];
+    const innerTable = createTableBlock(2, 2);
+    cell00.blocks.push(innerTable);
+    doc.store.updateTableCell(outerTableId, 0, 0, cell00);
+
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+
+    // Insert row in inner table
+    doc.insertRow(innerTable.id, 1);
+    const updatedInner = doc.getBlock(innerTable.id);
+    expect(updatedInner.tableData!.rows).toHaveLength(3);
+
+    // Insert column in inner table
+    doc.insertColumn(innerTable.id, 1);
+    expect(updatedInner.tableData!.columnWidths).toHaveLength(3);
+  });
+
+  it('should support merge/split in inner table', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const cell00 = outerBlock.tableData!.rows[0].cells[0];
+    const innerTable = createTableBlock(3, 3);
+    cell00.blocks.push(innerTable);
+    doc.store.updateTableCell(outerTableId, 0, 0, cell00);
+
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+
+    // Merge cells in inner table
+    const range: CellRange = {
+      start: { rowIndex: 0, colIndex: 0 },
+      end: { rowIndex: 1, colIndex: 1 },
+    };
+    doc.mergeCells(innerTable.id, range);
+    const updatedInner = doc.getBlock(innerTable.id);
+    expect(updatedInner.tableData!.rows[0].cells[0].colSpan).toBe(2);
+    expect(updatedInner.tableData!.rows[0].cells[0].rowSpan).toBe(2);
+
+    // Split
+    doc.splitCell(innerTable.id, { rowIndex: 0, colIndex: 0 });
+    const afterSplit = doc.getBlock(innerTable.id);
+    expect(afterSplit.tableData!.rows[0].cells[0].colSpan).toBeUndefined();
+  });
+
+  it('should support text editing in deeply nested table (2 levels)', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const cell00 = outerBlock.tableData!.rows[0].cells[0];
+
+    // Level 1: inner table in outer cell (0,0)
+    const innerTable = createTableBlock(2, 2);
+    cell00.blocks.push(innerTable);
+    doc.store.updateTableCell(outerTableId, 0, 0, cell00);
+
+    // Level 2: innermost table in inner cell (0,0)
+    const innerCell00 = innerTable.tableData!.rows[0].cells[0];
+    const innermostTable = createTableBlock(2, 2);
+    innerCell00.blocks.push(innermostTable);
+    // Update the outer cell which contains the modified inner table
+    doc.store.updateTableCell(outerTableId, 0, 0, cell00);
+
+    // Build recursive map (must handle 3 levels)
+    const map = buildParentMapRecursive(doc, outerTableId);
+    // Extend map for level 2
+    for (let r = 0; r < innermostTable.tableData!.rows.length; r++) {
+      for (let c = 0; c < innermostTable.tableData!.rows[r].cells.length; c++) {
+        for (const b of innermostTable.tableData!.rows[r].cells[c].blocks) {
+          map.set(b.id, { tableBlockId: innermostTable.id, rowIndex: r, colIndex: c });
+        }
+      }
+    }
+    doc.setBlockParentMap(map);
+
+    // Insert text in innermost cell
+    const innermostBlock = innermostTable.tableData!.rows[0].cells[0].blocks[0];
+    doc.insertText({ blockId: innermostBlock.id, offset: 0 }, 'Deep!');
+    const found = doc.getBlock(innermostBlock.id);
+    expect(found.inlines.map(i => i.text).join('')).toBe('Deep!');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd packages/docs && npx vitest run test/model/nested-table.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pnpm verify:fast`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/docs/test/model/nested-table.test.ts
+git commit -m 'Add integration tests for nested table operations
+
+Tests row/column insert, merge/split, and 2-level deep text editing
+inside nested tables.'
+```
+
+---
+
+### Task 8: Update Design Docs
+
+Update the existing table design docs to reflect nested table support.
+
+**Files:**
+- Modify: `docs/design/docs/docs-tables.md` — add nested tables to the phase plan
+- Already created: `docs/design/docs/docs-nested-tables.md`
+
+- [ ] **Step 1: Update docs-tables.md phase plan**
+
+Add a note in the extensibility/phase section that nested tables are now supported.
+
+- [ ] **Step 2: Update docs-table-crdt.md**
+
+Remove or update the "table type NOT allowed in cell" constraint to reflect the new capability.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/
+git commit -m 'Update design docs to reflect nested table support'
+```

--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -128,15 +128,8 @@ export class Doc {
     const fBlock = this._document.footer?.blocks.find((b) => b.id === blockId);
     if (fBlock) return fBlock;
 
-    const cellInfo = this._blockParentMap.get(blockId);
-    if (cellInfo) {
-      const tableBlock = this._document.blocks.find((b) => b.id === cellInfo.tableBlockId);
-      if (tableBlock?.tableData) {
-        const cell = tableBlock.tableData.rows[cellInfo.rowIndex]?.cells[cellInfo.colIndex];
-        const found = cell?.blocks.find((b) => b.id === blockId);
-        if (found) return found;
-      }
-    }
+    const cellBlock = this.findBlockInCells(blockId);
+    if (cellBlock) return cellBlock;
 
     throw new Error(`Block not found: ${blockId}`);
   }
@@ -153,16 +146,34 @@ export class Doc {
     const fBlock = this._document.footer?.blocks.find((b) => b.id === blockId);
     if (fBlock) return fBlock;
 
+    return this.findBlockInCells(blockId);
+  }
+
+  /**
+   * Recursively search for a block inside table cells using the BlockParentMap chain.
+   * Handles nested tables where the parent table is itself inside another table cell.
+   */
+  private findBlockInCells(blockId: string): Block | undefined {
     const cellInfo = this._blockParentMap.get(blockId);
-    if (cellInfo) {
-      const tableBlock = this._document.blocks.find((b) => b.id === cellInfo.tableBlockId);
-      if (tableBlock?.tableData) {
-        const cell = tableBlock.tableData.rows[cellInfo.rowIndex]?.cells[cellInfo.colIndex];
-        const found = cell?.blocks.find((b) => b.id === blockId);
-        if (found) return found;
-      }
+    if (!cellInfo) return undefined;
+
+    // Find the parent table block — it may be top-level, in header/footer, or nested
+    let tableBlock: Block | undefined;
+    tableBlock = this._document.blocks.find((b) => b.id === cellInfo.tableBlockId);
+    if (!tableBlock) {
+      tableBlock = this._document.header?.blocks.find((b) => b.id === cellInfo.tableBlockId);
+    }
+    if (!tableBlock) {
+      tableBlock = this._document.footer?.blocks.find((b) => b.id === cellInfo.tableBlockId);
+    }
+    if (!tableBlock) {
+      tableBlock = this.findBlockInCells(cellInfo.tableBlockId);
     }
 
+    if (tableBlock?.tableData) {
+      const cell = tableBlock.tableData.rows[cellInfo.rowIndex]?.cells[cellInfo.colIndex];
+      return cell?.blocks.find((b) => b.id === blockId);
+    }
     return undefined;
   }
 
@@ -180,7 +191,7 @@ export class Doc {
   getParentTableBlock(blockId: string): Block | undefined {
     const cellInfo = this._blockParentMap.get(blockId);
     if (!cellInfo) return undefined;
-    return this._document.blocks.find((b) => b.id === cellInfo.tableBlockId);
+    return this.findBlock(cellInfo.tableBlockId);
   }
 
   /**
@@ -855,7 +866,9 @@ export class Doc {
   private updateBlockInStore(blockId: string, block: Block): void {
     const cellInfo = this._blockParentMap.get(blockId);
     if (cellInfo) {
-      const tableBlock = this._document.blocks.find((b) => b.id === cellInfo.tableBlockId);
+      // Find the direct parent table block (may itself be nested)
+      const tableBlock = this.findBlock(cellInfo.tableBlockId);
+
       if (tableBlock) {
         const cell = tableBlock.tableData!.rows[cellInfo.rowIndex].cells[cellInfo.colIndex];
         // Replace the block within the cell with the updated one (handles pure-function callers)
@@ -863,11 +876,24 @@ export class Doc {
         if (blockIndex !== -1) {
           cell.blocks[blockIndex] = block;
         }
-        this.store.updateTableCell(cellInfo.tableBlockId, cellInfo.rowIndex, cellInfo.colIndex, cell);
+
+        // Walk up to find the root-level table for store persistence
+        const rootTableId = this.findRootTableId(cellInfo.tableBlockId);
+        const rootBlock = this.getBlock(rootTableId);
+        this.store.updateBlock(rootTableId, rootBlock);
       }
     } else {
       this.store.updateBlock(blockId, block);
     }
+  }
+
+  /**
+   * Walk up the BlockParentMap chain to find the root-level (top-level) table ID.
+   */
+  private findRootTableId(tableBlockId: string): string {
+    const parentInfo = this._blockParentMap.get(tableBlockId);
+    if (!parentInfo) return tableBlockId;
+    return this.findRootTableId(parentInfo.tableBlockId);
   }
 
   /**

--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -590,6 +590,57 @@ export class Doc {
   }
 
   /**
+   * Insert a table block into the cell containing `blockId`.
+   * The new table is inserted after the block at `blockId`.
+   * Returns the new table block's ID.
+   */
+  insertTableInCell(blockId: string, rows: number, cols: number): string {
+    const cellInfo = this._blockParentMap.get(blockId);
+    if (!cellInfo) {
+      throw new Error(`Block ${blockId} is not inside a table cell`);
+    }
+    const tableBlock = this.getBlock(cellInfo.tableBlockId);
+    const cell = tableBlock.tableData!.rows[cellInfo.rowIndex].cells[cellInfo.colIndex];
+    const blockIndex = cell.blocks.findIndex((b) => b.id === blockId);
+
+    const newTable = createTableBlock(rows, cols);
+    cell.blocks.splice(blockIndex + 1, 0, newTable);
+    this.store.updateTableCell(
+      cellInfo.tableBlockId, cellInfo.rowIndex, cellInfo.colIndex, cell,
+    );
+    this.refresh();
+    return newTable.id;
+  }
+
+  /**
+   * Delete a nested table from its parent cell.
+   * Ensures the cell retains at least one empty block.
+   * Returns the ID of the block the cursor should move to.
+   */
+  deleteTableInCell(tableBlockId: string): string {
+    const parentCellInfo = this._blockParentMap.get(tableBlockId);
+    if (!parentCellInfo) {
+      throw new Error(`Block ${tableBlockId} is not inside a table cell`);
+    }
+    const parentTableBlock = this.getBlock(parentCellInfo.tableBlockId);
+    const parentCell = parentTableBlock.tableData!.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];
+    const idx = parentCell.blocks.findIndex((b) => b.id === tableBlockId);
+    if (idx !== -1) {
+      parentCell.blocks.splice(idx, 1);
+    }
+    // Ensure cell still has at least one block
+    if (parentCell.blocks.length === 0) {
+      const emptyBlock = createTableCell().blocks[0];
+      parentCell.blocks.push(emptyBlock);
+    }
+    this.store.updateTableCell(
+      parentCellInfo.tableBlockId, parentCellInfo.rowIndex, parentCellInfo.colIndex, parentCell,
+    );
+    this.refresh();
+    return parentCell.blocks[0].id;
+  }
+
+  /**
    * Ensure a non-table block exists after the given block index.
    * If the block at `blockIndex` is the last block (or followed only by
    * another table), an empty paragraph is appended after it.

--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -592,9 +592,11 @@ export class Doc {
   /**
    * Insert a table block into the cell containing `blockId`.
    * The new table is inserted after the block at `blockId`.
-   * Returns the new table block's ID.
+   * Returns the new table block (not just the ID) so callers can access
+   * its tableData without a getBlock() lookup — the BlockParentMap has
+   * not been rebuilt yet at this point.
    */
-  insertTableInCell(blockId: string, rows: number, cols: number): string {
+  insertTableInCell(blockId: string, rows: number, cols: number): Block {
     const cellInfo = this._blockParentMap.get(blockId);
     if (!cellInfo) {
       throw new Error(`Block ${blockId} is not inside a table cell`);
@@ -609,7 +611,7 @@ export class Doc {
       cellInfo.tableBlockId, cellInfo.rowIndex, cellInfo.colIndex, cell,
     );
     this.refresh();
-    return newTable.id;
+    return newTable;
   }
 
   /**

--- a/packages/docs/src/store/memory.ts
+++ b/packages/docs/src/store/memory.ts
@@ -213,7 +213,37 @@ export class MemDocStore implements DocStore {
       const fIdx = this.doc.footer.blocks.findIndex((b) => b.id === id);
       if (fIdx !== -1) return { blocks: this.doc.footer.blocks, index: fIdx };
     }
+    // Recursively search inside table cells (supports nested tables)
+    const nested = this.findBlockInTableCells(id, this.doc.blocks);
+    if (nested) return nested;
+    if (this.doc.header) {
+      const hNested = this.findBlockInTableCells(id, this.doc.header.blocks);
+      if (hNested) return hNested;
+    }
+    if (this.doc.footer) {
+      const fNested = this.findBlockInTableCells(id, this.doc.footer.blocks);
+      if (fNested) return fNested;
+    }
     throw new Error(`Block not found: ${id}`);
+  }
+
+  private findBlockInTableCells(
+    id: string,
+    blocks: Block[],
+  ): { blocks: Block[]; index: number } | undefined {
+    for (const block of blocks) {
+      if (!block.tableData) continue;
+      for (const row of block.tableData.rows) {
+        for (const cell of row.cells) {
+          const idx = cell.blocks.findIndex((b) => b.id === id);
+          if (idx !== -1) return { blocks: cell.blocks, index: idx };
+          // Recurse into nested tables
+          const nested = this.findBlockInTableCells(id, cell.blocks);
+          if (nested) return nested;
+        }
+      }
+    }
+    return undefined;
   }
 
   private pushUndo(): void {

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1849,6 +1849,20 @@ export function initialize(
     insertTable: (rows: number, cols: number) => {
       docStore.snapshot();
       const pos = cursor.position;
+      const cellInfo = layout.blockParentMap.get(pos.blockId);
+
+      if (cellInfo) {
+        // Cursor is inside a table cell — insert nested table
+        const innerTableId = doc.insertTableInCell(pos.blockId, rows, cols);
+        const innerBlock = doc.getBlock(innerTableId);
+        const firstCellBlock = innerBlock.tableData!.rows[0].cells[0].blocks[0];
+        cursor.moveTo({ blockId: firstCellBlock.id, offset: 0 });
+        invalidateLayout();
+        render();
+        return;
+      }
+
+      // Top-level table insertion (existing logic)
       const block = doc.getBlock(pos.blockId);
       const blockLen = getBlockTextLength(block);
 
@@ -1874,15 +1888,25 @@ export function initialize(
     deleteTable: () => {
       const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
-      const blockId = cellInfo.tableBlockId;
-      const blockIndex = doc.getBlockIndex(blockId);
+      const tableBlockId = cellInfo.tableBlockId;
       docStore.snapshot();
-      doc.deleteBlock(blockId);
-      // Move cursor to nearest block
-      const blocks = doc.document.blocks;
-      if (blocks.length > 0) {
-        const newIndex = Math.min(blockIndex, blocks.length - 1);
-        cursor.moveTo({ blockId: blocks[newIndex].id, offset: 0 });
+
+      // Check if this table is itself nested inside a cell
+      const parentCellInfo = layout.blockParentMap.get(tableBlockId);
+      if (parentCellInfo) {
+        // Nested table — remove from parent cell's blocks
+        const cursorBlockId = doc.deleteTableInCell(tableBlockId);
+        cursor.moveTo({ blockId: cursorBlockId, offset: 0 });
+      } else {
+        // Top-level table (existing logic)
+        const blockIndex = doc.getBlockIndex(tableBlockId);
+        doc.deleteBlock(tableBlockId);
+        // Move cursor to nearest block
+        const blocks = doc.document.blocks;
+        if (blocks.length > 0) {
+          const newIndex = Math.min(blockIndex, blocks.length - 1);
+          cursor.moveTo({ blockId: blocks[newIndex].id, offset: 0 });
+        }
       }
       invalidateLayout();
       render();

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1853,8 +1853,7 @@ export function initialize(
 
       if (cellInfo) {
         // Cursor is inside a table cell — insert nested table
-        const innerTableId = doc.insertTableInCell(pos.blockId, rows, cols);
-        const innerBlock = doc.getBlock(innerTableId);
+        const innerBlock = doc.insertTableInCell(pos.blockId, rows, cols);
         const firstCellBlock = innerBlock.tableData!.rows[0].cells[0].blocks[0];
         cursor.moveTo({ blockId: firstCellBlock.id, offset: 0 });
         invalidateLayout();

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -15,6 +15,7 @@ import { computeScaleFactor } from './scale.js';
 import { buildFont, setThemeMode, type ThemeMode } from './theme.js';
 import { type PeerCursor, resolvePositionPixel } from './peer-cursor.js';
 import { computeTableMergeContext, type TableMergeContext } from './table-merge-context.js';
+import { resolveNestedTableLayout } from './table-layout.js';
 import {
   collectImageRects,
   findImageAtPoint,
@@ -877,12 +878,12 @@ export function initialize(
       const dragOffset = imageResizeDrag.offset;
       const cellInfo = layout.blockParentMap.get(dragBlockId);
       if (cellInfo) {
-        const tableBlock = layout.blocks.find(
-          (b) => b.block.id === cellInfo.tableBlockId,
-        );
+        // Use resolveNestedTableLayout to find the correct LayoutTable
+        // for both top-level and nested table cells.
+        const resolved = resolveNestedTableLayout(cellInfo.tableBlockId, layout);
         const layoutCell =
-          tableBlock?.layoutTable?.cells[cellInfo.rowIndex]?.[cellInfo.colIndex];
-        const cellData = tableBlock?.block.tableData?.rows[cellInfo.rowIndex]
+          resolved?.layoutTable.cells[cellInfo.rowIndex]?.[cellInfo.colIndex];
+        const cellData = resolved?.dataBlock.tableData?.rows[cellInfo.rowIndex]
           ?.cells[cellInfo.colIndex];
         if (layoutCell && cellData) {
           const boundaries = layoutCell.blockBoundaries;

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1853,6 +1853,14 @@ export function initialize(
       const cellInfo = layout.blockParentMap.get(pos.blockId);
 
       if (cellInfo) {
+        // Split the current block at the cursor so trailing text moves
+        // below the new table (matches the top-level insertion flow).
+        const cellBlock = doc.getBlock(pos.blockId);
+        const cellBlockLen = getBlockTextLength(cellBlock);
+        if (pos.offset > 0 && pos.offset < cellBlockLen) {
+          doc.splitBlock(pos.blockId, pos.offset);
+        }
+
         // Cursor is inside a table cell — insert nested table
         const innerBlock = doc.insertTableInCell(pos.blockId, rows, cols);
         const firstCellBlock = innerBlock.tableData!.rows[0].cells[0].blocks[0];

--- a/packages/docs/src/view/image-selection-overlay.ts
+++ b/packages/docs/src/view/image-selection-overlay.ts
@@ -353,6 +353,17 @@ function collectTableCellImageRects(
       if (!innerBlock) break;
 
       const line = layoutCell.lines[li];
+
+      // Recurse into nested tables
+      if (line.nestedTable && innerBlock?.type === 'table' && innerBlock.tableData) {
+        collectNestedTableImageRects(
+          innerBlock.tableData, line.nestedTable,
+          cellX + padding, cellY + padding + line.y,
+          out,
+        );
+        continue;
+      }
+
       for (const run of line.runs) {
         if (run.inline.style.image) {
           const drawHeight = run.imageHeight ?? line.height;
@@ -369,6 +380,73 @@ function collectTableCellImageRects(
     // lint would complain about the unused `cell.colSpan ?? 1` read
     // above without this explicit touch.
     void colSpan;
+  }
+}
+
+/**
+ * Recursively collect image rects from a nested table.
+ * Mirrors the coordinate math from `renderTableContent` for nested tables.
+ */
+function collectNestedTableImageRects(
+  tableData: import('../model/types.js').TableData,
+  layoutTable: import('./table-layout.js').LayoutTable,
+  tableX: number,
+  tableY: number,
+  out: Map<string, ImageRect>,
+): void {
+  for (let r = 0; r < layoutTable.cells.length; r++) {
+    for (let c = 0; c < layoutTable.cells[r].length; c++) {
+      const layoutCell = layoutTable.cells[r][c];
+      if (layoutCell.merged) continue;
+      const cell = tableData.rows[r]?.cells[c];
+      if (!cell) continue;
+      const rowSpan = cell.rowSpan ?? 1;
+      if (rowSpan > 1) continue;
+      const verticalAlign = cell.style?.verticalAlign ?? 'top';
+      if (verticalAlign !== 'top') continue;
+
+      const padding = cell.style?.padding ?? 4;
+      const cellX = tableX + layoutTable.columnXOffsets[c];
+      const cellY = tableY + layoutTable.rowYOffsets[r];
+
+      const boundaries = layoutCell.blockBoundaries;
+      let currentBlockIdx = 0;
+      let offsetInBlock = 0;
+      for (let li = 0; li < layoutCell.lines.length; li++) {
+        while (
+          currentBlockIdx + 1 < boundaries.length &&
+          boundaries[currentBlockIdx + 1] <= li
+        ) {
+          currentBlockIdx++;
+          offsetInBlock = 0;
+        }
+        const innerBlock = cell.blocks[currentBlockIdx];
+        if (!innerBlock) break;
+
+        const line = layoutCell.lines[li];
+
+        // Recurse into deeper nested tables
+        if (line.nestedTable && innerBlock.type === 'table' && innerBlock.tableData) {
+          collectNestedTableImageRects(
+            innerBlock.tableData, line.nestedTable,
+            cellX + padding, cellY + padding + line.y,
+            out,
+          );
+          continue;
+        }
+
+        for (const run of line.runs) {
+          if (run.inline.style.image) {
+            const drawHeight = run.imageHeight ?? line.height;
+            const x = cellX + padding + run.x;
+            const y = cellY + padding + line.y + line.height - drawHeight;
+            const key = `${innerBlock.id}:${offsetInBlock}`;
+            out.set(key, { x, y, width: run.width, height: drawHeight });
+          }
+          offsetInBlock += run.charEnd - run.charStart;
+        }
+      }
+    }
   }
 }
 

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -83,6 +83,7 @@ export interface LayoutLine {
   y: number;
   height: number;
   width: number;
+  nestedTable?: LayoutTable;
 }
 
 /**

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -172,12 +172,42 @@ export function resolvePositionPixel(
         if (!targetLayout) return undefined;
         const ownerRow = targetLayout.ownerRow;
 
-        // Find the PageLine for the outermost table's owner row.
-        // For nested tables, the paginated layout only tracks top-level rows.
-        // We need to find the row of the outermost table that contains this
-        // nested content, using the first segment of the nesting path.
-        const outerRowIndex = nestingPath[0].rowIndex;
         const blockIndex = layout.blocks.indexOf(lb);
+        const pageX = getPageXOffset(paginatedLayout, canvasWidth);
+        const { margins } = paginatedLayout.pageSetup;
+
+        if (nestingPath.length === 1) {
+          // Non-nested table cell — use the original cursor positioning
+          // logic that finds the PageLine by ownerRow.
+          let pageLine: import('./pagination.js').PageLine | undefined;
+          let pageIndex = 0;
+          for (const page of paginatedLayout.pages) {
+            for (const pl of page.lines) {
+              if (pl.blockIndex === blockIndex && pl.lineIndex === ownerRow) {
+                pageLine = pl;
+                pageIndex = page.pageIndex;
+                break;
+              }
+            }
+            if (pageLine) break;
+          }
+          if (!pageLine) return undefined;
+
+          const pageY = getPageYOffset(paginatedLayout, pageIndex);
+          const cellX = tl.columnXOffsets[colIndex] + cellPadding;
+          const cursorYOnPage =
+            pageY + pageLine.y + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]);
+
+          return {
+            x: pageX + margins.left + cellX + cursorX,
+            y: cursorYOnPage,
+            height: lineHeight,
+          };
+        }
+
+        // Nested table cell — find the PageLine for the outermost table's
+        // row, then add accumulated Y offset from outer cells.
+        const outerRowIndex = nestingPath[0].rowIndex;
         let pageLine: import('./pagination.js').PageLine | undefined;
         let pageIndex = 0;
         for (const page of paginatedLayout.pages) {
@@ -192,17 +222,12 @@ export function resolvePositionPixel(
         }
         if (!pageLine) return undefined;
 
-        const pageX = getPageXOffset(paginatedLayout, canvasWidth);
         const pageY = getPageYOffset(paginatedLayout, pageIndex);
-        const { margins } = paginatedLayout.pageSetup;
-
         const innerCellX = tl.columnXOffsets[colIndex] + cellPadding;
-        // For nested tables: Y = page base + pageLine offset +
-        // accumulated Y offset from outer cells + inner row Y + inner line Y
         const innerCursorY = pageY + pageLine.y
           + yOffsetInTable
-          + (targetLayout.runLineY - tl.rowYOffsets[ownerRow])
-          + tl.rowYOffsets[ownerRow];
+          + tl.rowYOffsets[ownerRow]
+          + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]);
 
         return {
           x: pageX + margins.left + xOffset + innerCellX + cursorX,

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -44,121 +44,174 @@ export function resolvePositionPixel(
   // --- Table cell cursor ---
   const cellInfo = layout.blockParentMap.get(position.blockId);
   if (cellInfo) {
-    const lb = layout.blocks.find((b) => b.block.id === cellInfo.tableBlockId);
+    // Walk up the blockParentMap chain to find the top-level table and
+    // collect the nesting path: [{tableBlockId, rowIndex, colIndex}, ...]
+    // from outermost to innermost.
+    const nestingPath: Array<{ tableBlockId: string; rowIndex: number; colIndex: number }> = [];
+    nestingPath.push(cellInfo);
+    let currentTableId = cellInfo.tableBlockId;
+    while (true) {
+      const parentInfo = layout.blockParentMap.get(currentTableId);
+      if (!parentInfo) break; // currentTableId is a top-level block
+      nestingPath.unshift(parentInfo);
+      currentTableId = parentInfo.tableBlockId;
+    }
+
+    // currentTableId is now the top-level table block ID
+    const lb = layout.blocks.find((b) => b.block.id === currentTableId);
     if (!lb?.layoutTable) return undefined;
-    const tl = lb.layoutTable;
-    const { rowIndex, colIndex } = cellInfo;
-    const cell = tl.cells[rowIndex]?.[colIndex];
-    if (!cell || cell.merged) return undefined;
 
-    const cellData = lb.block.tableData?.rows[rowIndex]?.cells[colIndex];
-    const cellPadding = cellData?.style.padding ?? 4;
-    const rowSpan = cellData?.rowSpan ?? 1;
+    // Navigate down through nested LayoutTables to find the target cell
+    let tl = lb.layoutTable;
+    let xOffset = 0;
+    let yOffsetInTable = 0;
+    let dataBlock = lb.block;
 
-    // Per-line layouts (distributes merged-cell lines across spanned
-    // rows). For rowSpan === 1 this collapses to the old
-    // `padding + line.y` positioning.
-    const lineLayouts = computeMergedCellLineLayouts(
-      cell.lines,
-      rowIndex,
-      rowSpan,
-      cellPadding,
-      tl.rowYOffsets,
-      tl.rowHeights,
-    );
+    for (let ni = 0; ni < nestingPath.length; ni++) {
+      const seg = nestingPath[ni];
+      const { rowIndex, colIndex } = seg;
+      const cell = tl.cells[rowIndex]?.[colIndex];
+      if (!cell || cell.merged) return undefined;
 
-    // Determine which lines belong to the target cell block
-    const cbi = cellData ? cellData.blocks.findIndex((b) => b.id === position.blockId) : 0;
-    const effectiveCbi = cbi >= 0 ? cbi : 0;
-    const startLine = cell.blockBoundaries[effectiveCbi] ?? 0;
-    const endLine = cell.blockBoundaries[effectiveCbi + 1] ?? cell.lines.length;
+      const cellData = dataBlock.tableData?.rows[rowIndex]?.cells[colIndex];
+      const cellPadding = cellData?.style.padding ?? 4;
 
-    // Measure text offset within the target block's lines
-    let cursorX = 0;
-    let targetLineIdx = -1;
-    let lineHeight = tl.rowHeights[rowIndex] ?? 20;
-    let offsetRemaining = position.offset;
+      if (ni < nestingPath.length - 1) {
+        // Intermediate nesting level — find the nested table line and
+        // accumulate coordinate offsets.
+        const nextTableId = nestingPath[ni + 1].tableBlockId;
+        let nestedTableLine: import('./layout.js').LayoutLine | undefined;
+        let nestedLineIdx = -1;
+        for (let li = 0; li < cell.lines.length; li++) {
+          if (cell.lines[li].nestedTable) {
+            // Find the block index for this line
+            let blockIdx = 0;
+            for (let bi = cell.blockBoundaries.length - 1; bi >= 0; bi--) {
+              if (li >= cell.blockBoundaries[bi]) { blockIdx = bi; break; }
+            }
+            if (cellData?.blocks[blockIdx]?.id === nextTableId) {
+              nestedTableLine = cell.lines[li];
+              nestedLineIdx = li;
+              break;
+            }
+          }
+        }
+        if (!nestedTableLine?.nestedTable || nestedLineIdx < 0) return undefined;
 
-    for (let li = startLine; li < endLine; li++) {
-      const line = cell.lines[li];
-      let lineChars = 0;
-      for (const run of line.runs) {
-        lineChars += run.text.length;
-      }
-      if (offsetRemaining <= lineChars) {
-        targetLineIdx = li;
-        lineHeight = line.height;
-        let chars = 0;
-        for (const run of line.runs) {
-          if (offsetRemaining <= chars + run.text.length) {
-            const localOff = offsetRemaining - chars;
-            if (run.imageHeight !== undefined) {
-              cursorX = run.x + (localOff > 0 ? run.width : 0);
-            } else {
-              const textBefore = run.text.slice(0, localOff);
-              ctx.font = buildFont(
-                run.inline.style.fontSize, run.inline.style.fontFamily,
-                run.inline.style.bold, run.inline.style.italic,
-              );
-              cursorX = run.x + ctx.measureText(textBefore).width;
+        // Accumulate X offset: cell origin + padding
+        xOffset += tl.columnXOffsets[colIndex] + cellPadding;
+        // Accumulate Y offset: row Y + cell padding + line Y within cell
+        yOffsetInTable += tl.rowYOffsets[rowIndex] + cellPadding + nestedTableLine.y;
+
+        // Descend into the nested table
+        const nextBlock = cellData?.blocks.find((b) => b.id === nextTableId);
+        if (!nextBlock?.tableData) return undefined;
+        tl = nestedTableLine.nestedTable;
+        dataBlock = nextBlock;
+      } else {
+        // Innermost level — resolve cursor position in this cell
+        const rowSpan = cellData?.rowSpan ?? 1;
+        const lineLayouts = computeMergedCellLineLayouts(
+          cell.lines, rowIndex, rowSpan, cellPadding,
+          tl.rowYOffsets, tl.rowHeights,
+        );
+
+        const cbi = cellData ? cellData.blocks.findIndex((b) => b.id === position.blockId) : 0;
+        const effectiveCbi = cbi >= 0 ? cbi : 0;
+        const startLine = cell.blockBoundaries[effectiveCbi] ?? 0;
+        const endLine = cell.blockBoundaries[effectiveCbi + 1] ?? cell.lines.length;
+
+        let cursorX = 0;
+        let targetLineIdx = -1;
+        let lineHeight = tl.rowHeights[rowIndex] ?? 20;
+        let offsetRemaining = position.offset;
+
+        for (let li = startLine; li < endLine; li++) {
+          const line = cell.lines[li];
+          let lineChars = 0;
+          for (const run of line.runs) {
+            lineChars += run.text.length;
+          }
+          if (offsetRemaining <= lineChars) {
+            targetLineIdx = li;
+            lineHeight = line.height;
+            let chars = 0;
+            for (const run of line.runs) {
+              if (offsetRemaining <= chars + run.text.length) {
+                const localOff = offsetRemaining - chars;
+                if (run.imageHeight !== undefined) {
+                  cursorX = run.x + (localOff > 0 ? run.width : 0);
+                } else {
+                  const textBefore = run.text.slice(0, localOff);
+                  ctx.font = buildFont(
+                    run.inline.style.fontSize, run.inline.style.fontFamily,
+                    run.inline.style.bold, run.inline.style.italic,
+                  );
+                  cursorX = run.x + ctx.measureText(textBefore).width;
+                }
+                break;
+              }
+              chars += run.text.length;
             }
             break;
           }
-          chars += run.text.length;
+          offsetRemaining -= lineChars;
         }
-        break;
-      }
-      offsetRemaining -= lineChars;
-    }
 
-    // Cursor past end-of-content: place at the tail of the last line in
-    // the target block so Arrow-End still resolves.
-    if (targetLineIdx < 0) {
-      targetLineIdx = Math.max(startLine, endLine - 1);
-      const tailLine = cell.lines[targetLineIdx];
-      if (tailLine) {
-        lineHeight = tailLine.height;
-        const lastRun = tailLine.runs[tailLine.runs.length - 1];
-        cursorX = lastRun ? lastRun.x + lastRun.width : 0;
-      }
-    }
-
-    const targetLayout = lineLayouts[targetLineIdx];
-    if (!targetLayout) return undefined;
-    const ownerRow = targetLayout.ownerRow;
-
-    // Find the PageLine for the owner row.
-    const blockIndex = layout.blocks.indexOf(lb);
-    let pageLine: import('./pagination.js').PageLine | undefined;
-    let pageIndex = 0;
-    for (const page of paginatedLayout.pages) {
-      for (const pl of page.lines) {
-        if (pl.blockIndex === blockIndex && pl.lineIndex === ownerRow) {
-          pageLine = pl;
-          pageIndex = page.pageIndex;
-          break;
+        if (targetLineIdx < 0) {
+          targetLineIdx = Math.max(startLine, endLine - 1);
+          const tailLine = cell.lines[targetLineIdx];
+          if (tailLine) {
+            lineHeight = tailLine.height;
+            const lastRun = tailLine.runs[tailLine.runs.length - 1];
+            cursorX = lastRun ? lastRun.x + lastRun.width : 0;
+          }
         }
+
+        const targetLayout = lineLayouts[targetLineIdx];
+        if (!targetLayout) return undefined;
+        const ownerRow = targetLayout.ownerRow;
+
+        // Find the PageLine for the outermost table's owner row.
+        // For nested tables, the paginated layout only tracks top-level rows.
+        // We need to find the row of the outermost table that contains this
+        // nested content, using the first segment of the nesting path.
+        const outerRowIndex = nestingPath[0].rowIndex;
+        const blockIndex = layout.blocks.indexOf(lb);
+        let pageLine: import('./pagination.js').PageLine | undefined;
+        let pageIndex = 0;
+        for (const page of paginatedLayout.pages) {
+          for (const pl of page.lines) {
+            if (pl.blockIndex === blockIndex && pl.lineIndex === outerRowIndex) {
+              pageLine = pl;
+              pageIndex = page.pageIndex;
+              break;
+            }
+          }
+          if (pageLine) break;
+        }
+        if (!pageLine) return undefined;
+
+        const pageX = getPageXOffset(paginatedLayout, canvasWidth);
+        const pageY = getPageYOffset(paginatedLayout, pageIndex);
+        const { margins } = paginatedLayout.pageSetup;
+
+        const innerCellX = tl.columnXOffsets[colIndex] + cellPadding;
+        // For nested tables: Y = page base + pageLine offset +
+        // accumulated Y offset from outer cells + inner row Y + inner line Y
+        const innerCursorY = pageY + pageLine.y
+          + yOffsetInTable
+          + (targetLayout.runLineY - tl.rowYOffsets[ownerRow])
+          + tl.rowYOffsets[ownerRow];
+
+        return {
+          x: pageX + margins.left + xOffset + innerCellX + cursorX,
+          y: innerCursorY,
+          height: lineHeight,
+        };
       }
-      if (pageLine) break;
     }
-    if (!pageLine) return undefined;
-
-    const pageX = getPageXOffset(paginatedLayout, canvasWidth);
-    const pageY = getPageYOffset(paginatedLayout, pageIndex);
-    const { margins } = paginatedLayout.pageSetup;
-
-    const cellX = tl.columnXOffsets[colIndex] + cellPadding;
-    // targetLayout.runLineY is table-logical. The cursor's absolute Y
-    // on the owner row's page is pageY + pageLine.y + (runLineY -
-    // rowYOffsets[ownerRow]), i.e. the row-local offset of the line.
-    const cursorYOnPage =
-      pageY + pageLine.y + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]);
-
-    return {
-      x: pageX + margins.left + cellX + cursorX,
-      y: cursorYOnPage,
-      height: lineHeight,
-    };
+    return undefined;
   }
 
   // --- Regular (non-table) cursor ---

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -133,6 +133,15 @@ export function resolvePositionPixel(
             lineChars += run.text.length;
           }
           if (offsetRemaining <= lineChars) {
+            // At a wrap boundary, forward affinity belongs to the next line
+            if (
+              lineAffinity === 'forward' &&
+              offsetRemaining === lineChars &&
+              li < endLine - 1
+            ) {
+              offsetRemaining = 0;
+              continue;
+            }
             targetLineIdx = li;
             lineHeight = line.height;
             let chars = 0;

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -284,30 +284,21 @@ function buildRects(
     // "advance midY by line height" path stepped linearly through the
     // cell's Y axis and painted into the empty space below row 0 when a
     // merged cell's line actually lived on the next page.
-    const lb = layout.blocks.find((b) => b.block.id === startCellInfo.tableBlockId);
-    const tl = lb?.layoutTable;
-    if (!lb || !tl) {
-      // Nested table cell — the direct parent table is not a top-level
-      // layout block. Use pixel coordinates from resolvePositionPixel
-      // (which already handles nested tables) for selection rects.
-      if (startPixel.y === endPixel.y) {
-        return [{
-          x: startPixel.x,
-          y: startPixel.y,
-          width: endPixel.x - startPixel.x,
-          height: startPixel.height,
-        }];
-      }
+    // Resolve the table that owns this cell — may be top-level or nested
+    const resolved = resolveNestedTableLayout(startCellInfo.tableBlockId, layout);
+    const lb = resolved ? layout.blocks[resolved.lb.blockIndex] : undefined;
+    const tl = resolved?.layoutTable;
+    if (!lb || !tl || !resolved) {
       return [{
-        x: Math.min(startPixel.x, endPixel.x),
+        x: startPixel.x,
         y: startPixel.y,
-        width: Math.max(startPixel.x, endPixel.x) - Math.min(startPixel.x, endPixel.x),
+        width: endPixel.x - startPixel.x,
         height: endPixel.y + endPixel.height - startPixel.y,
       }];
     }
     const { rowIndex, colIndex } = startCellInfo;
     const layoutCell = tl.cells[rowIndex]?.[colIndex];
-    const cellData = lb.block.tableData?.rows[rowIndex]?.cells[colIndex];
+    const cellData = resolved.dataBlock.tableData?.rows[rowIndex]?.cells[colIndex];
     if (!layoutCell || layoutCell.merged || !cellData) {
       return [{
         x: startPixel.x,
@@ -321,9 +312,10 @@ function buildRects(
 
     const pageXOffset = getPageXOffset(paginatedLayout, canvasWidth);
     const { margins } = paginatedLayout.pageSetup;
-    const cellLeftX = pageXOffset + margins.left + tl.columnXOffsets[colIndex] + cellPadding;
+    const nestedXOff = resolved.xOffset;
+    const cellLeftX = pageXOffset + margins.left + nestedXOff + tl.columnXOffsets[colIndex] + cellPadding;
     const cellRightX =
-      pageXOffset + margins.left + tl.columnXOffsets[colIndex] + layoutCell.width - cellPadding;
+      pageXOffset + margins.left + nestedXOff + tl.columnXOffsets[colIndex] + layoutCell.width - cellPadding;
 
     // Locate the cell's block containing the start/end positions and the
     // corresponding line indices within cell.lines.
@@ -379,8 +371,26 @@ function buildRects(
       tl.rowHeights,
     );
 
-    const blockIndex = layout.blocks.indexOf(lb);
+    const blockIndex = resolved.lb.blockIndex;
+    const nestedYOff = resolved.yOffset;
+    const isNested = resolved.outerRowIndex >= 0;
     const resolveLineAbsoluteY = (ownerRow: number, runLineY: number): number | undefined => {
+      if (isNested) {
+        // For nested tables, find the outer row's page position and
+        // add the accumulated Y offset + inner row offset
+        const outerRow = resolved.outerRowIndex;
+        for (const page of paginatedLayout.pages) {
+          for (const pl of page.lines) {
+            if (pl.blockIndex === blockIndex && pl.lineIndex === outerRow) {
+              const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
+              return pageY + pl.y + nestedYOff
+                + tl.rowYOffsets[ownerRow]
+                + (runLineY - tl.rowYOffsets[ownerRow]);
+            }
+          }
+        }
+        return undefined;
+      }
       for (const page of paginatedLayout.pages) {
         for (const pl of page.lines) {
           if (pl.blockIndex === blockIndex && pl.lineIndex === ownerRow) {

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -131,12 +131,22 @@ function normalizeRange(
   const focusCellInfo = layout.blockParentMap.get(range.focus.blockId);
 
 
-  const anchorIdx = layout.blocks.findIndex(
-    (lb) => lb.block.id === (anchorCellInfo?.tableBlockId ?? range.anchor.blockId),
-  );
-  const focusIdx = layout.blocks.findIndex(
-    (lb) => lb.block.id === (focusCellInfo?.tableBlockId ?? range.focus.blockId),
-  );
+  // For nested tables, walk up the blockParentMap chain to find the
+  // outermost table ID that exists in layout.blocks.
+  let anchorTopId = anchorCellInfo?.tableBlockId ?? range.anchor.blockId;
+  while (anchorTopId && layout.blocks.findIndex((lb) => lb.block.id === anchorTopId) === -1) {
+    const parentInfo = layout.blockParentMap.get(anchorTopId);
+    if (!parentInfo) break;
+    anchorTopId = parentInfo.tableBlockId;
+  }
+  let focusTopId = focusCellInfo?.tableBlockId ?? range.focus.blockId;
+  while (focusTopId && layout.blocks.findIndex((lb) => lb.block.id === focusTopId) === -1) {
+    const parentInfo = layout.blockParentMap.get(focusTopId);
+    if (!parentInfo) break;
+    focusTopId = parentInfo.tableBlockId;
+  }
+  const anchorIdx = layout.blocks.findIndex((lb) => lb.block.id === anchorTopId);
+  const focusIdx = layout.blocks.findIndex((lb) => lb.block.id === focusTopId);
   if (anchorIdx === -1 || focusIdx === -1) return null;
   if (anchorCellInfo || focusCellInfo) {
     // Both must be in the same cell for a valid selection
@@ -249,9 +259,11 @@ function buildRects(
   // Cell-internal selection
   const startCellInfo = layout.blockParentMap.get(start.blockId);
   const endCellInfo = layout.blockParentMap.get(end.blockId);
+
   if (startCellInfo && endCellInfo) {
     const startPixel = resolvePositionPixel(start, 'forward', paginatedLayout, layout, ctx, canvasWidth);
     const endPixel = resolvePositionPixel(end, 'backward', paginatedLayout, layout, ctx, canvasWidth);
+
     if (!startPixel || !endPixel) return [];
 
     if (startPixel.y === endPixel.y) {

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -274,10 +274,21 @@ function buildRects(
     const lb = layout.blocks.find((b) => b.block.id === startCellInfo.tableBlockId);
     const tl = lb?.layoutTable;
     if (!lb || !tl) {
+      // Nested table cell — the direct parent table is not a top-level
+      // layout block. Use pixel coordinates from resolvePositionPixel
+      // (which already handles nested tables) for selection rects.
+      if (startPixel.y === endPixel.y) {
+        return [{
+          x: startPixel.x,
+          y: startPixel.y,
+          width: endPixel.x - startPixel.x,
+          height: startPixel.height,
+        }];
+      }
       return [{
-        x: startPixel.x,
+        x: Math.min(startPixel.x, endPixel.x),
         y: startPixel.y,
-        width: endPixel.x - startPixel.x,
+        width: Math.max(startPixel.x, endPixel.x) - Math.min(startPixel.x, endPixel.x),
         height: endPixel.y + endPixel.height - startPixel.y,
       }];
     }

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -155,9 +155,10 @@ function normalizeRange(
         anchorCellInfo.tableBlockId === focusCellInfo.tableBlockId &&
         anchorCellInfo.rowIndex === focusCellInfo.rowIndex &&
         anchorCellInfo.colIndex === focusCellInfo.colIndex) {
-      // Find cell block indices for ordering
-      const tableBlock = layout.blocks.find((b) => b.block.id === anchorCellInfo.tableBlockId);
-      const cell = tableBlock?.block.tableData?.rows[anchorCellInfo.rowIndex]?.cells[anchorCellInfo.colIndex];
+      // Find cell block indices for ordering — use resolveNestedTableLayout
+      // so nested table cells are found correctly.
+      const resolvedTable = resolveNestedTableLayout(anchorCellInfo.tableBlockId, layout);
+      const cell = resolvedTable?.dataBlock.tableData?.rows[anchorCellInfo.rowIndex]?.cells[anchorCellInfo.colIndex];
       const aCbi = cell ? cell.blocks.findIndex((b) => b.id === range.anchor.blockId) : 0;
       const fCbi = cell ? cell.blocks.findIndex((b) => b.id === range.focus.blockId) : 0;
       if (aCbi < fCbi || (aCbi === fCbi && range.anchor.offset <= range.focus.offset)) {

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -5,6 +5,7 @@ import type { PaginatedLayout } from './pagination.js';
 import { findPageForPosition, getPageYOffset, getPageXOffset } from './pagination.js';
 import { resolvePositionPixel } from './peer-cursor.js';
 import { computeMergedCellLineLayouts } from './table-renderer.js';
+import { resolveNestedTableLayout } from './table-layout.js';
 import { buildFont, Theme } from './theme.js';
 
 // --- Free helpers (used by both Selection class and computeSelectionRects) ---
@@ -550,45 +551,62 @@ function buildCellRangeRects(
   layout: DocumentLayout,
   canvasWidth: number,
 ): Array<{ x: number; y: number; width: number; height: number }> {
-  const lb = layout.blocks.find((b) => b.block.id === cellRange.blockId);
-  if (!lb?.layoutTable) return [];
-  const tl = lb.layoutTable;
+  // Resolve the table — may be top-level or nested
+  const resolved = resolveNestedTableLayout(cellRange.blockId, layout);
+  if (!resolved) return [];
+  const { lb, layoutTable: tl, dataBlock, xOffset: nestedXOffset, yOffset: nestedYOffset, outerRowIndex } = resolved;
 
-  const blockIndex = layout.blocks.indexOf(lb);
+  const blockIndex = lb.blockIndex;
   const pageX = getPageXOffset(paginatedLayout, canvasWidth);
   const { margins } = paginatedLayout.pageSetup;
 
-  // Build a row → absolute Y map from the paginated layout.
+  // For nested tables, we need the absolute Y of the outermost row that
+  // contains the nested table. For top-level tables, build the full row map.
+  let baseY = 0;
+  if (outerRowIndex >= 0) {
+    // Nested table — find the page line for the outer row
+    for (const page of paginatedLayout.pages) {
+      const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
+      for (const pl of page.lines) {
+        if (pl.blockIndex === blockIndex && pl.lineIndex === outerRowIndex) {
+          baseY = pageY + pl.y + nestedYOffset;
+          break;
+        }
+      }
+    }
+  }
+
+  // Build a row → absolute Y map
   const rowYMap = new Map<number, number>();
-  for (const page of paginatedLayout.pages) {
-    const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
-    for (const pl of page.lines) {
-      if (pl.blockIndex !== blockIndex) continue;
-      rowYMap.set(pl.lineIndex, pageY + pl.y);
+  if (outerRowIndex >= 0) {
+    // Nested: compute Y for each inner row from baseY + inner rowYOffsets
+    for (let r = 0; r < tl.rowYOffsets.length; r++) {
+      rowYMap.set(r, baseY + tl.rowYOffsets[r]);
+    }
+  } else {
+    // Top-level: use paginated layout
+    for (const page of paginatedLayout.pages) {
+      const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
+      for (const pl of page.lines) {
+        if (pl.blockIndex !== blockIndex) continue;
+        rowYMap.set(pl.lineIndex, pageY + pl.y);
+      }
     }
   }
 
   const { start, end } = cellRange;
   const rects: Array<{ x: number; y: number; width: number; height: number }> = [];
-  const tableData = lb.block.tableData;
+  const tableData = dataBlock.tableData;
+  const xBase = pageX + margins.left + nestedXOffset;
 
   for (let r = start.rowIndex; r <= end.rowIndex; r++) {
     for (let c = start.colIndex; c <= end.colIndex; c++) {
       const cell = tl.cells[r]?.[c];
       if (!cell || cell.merged) continue;
 
-      // For merge top-left cells, highlight the full colSpan × rowSpan
-      // footprint. LayoutTableCell.width already sums spanned columns.
-      // Row coverage is split into one rect per contiguous page segment:
-      // when the next spanned row lives on a different page (its
-      // absolute Y is not the running segment's expected bottom), flush
-      // the current rect and start a new one anchored at the new row's
-      // page Y. This keeps merged-cell highlights aligned with the row
-      // bands on each page instead of bleeding into empty space below
-      // the first row.
       const srcCell = tableData?.rows[r]?.cells[c];
       const rowSpan = srcCell?.rowSpan ?? 1;
-      const x = pageX + margins.left + tl.columnXOffsets[c];
+      const x = xBase + tl.columnXOffsets[c];
       const width = cell.width;
 
       const spanEnd = Math.min(r + rowSpan, tl.rowHeights.length);

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -399,3 +399,118 @@ export function computeTableLayout(
     blockParentMap,
   };
 }
+
+/**
+ * Result of resolving a nested table's layout context.
+ */
+export interface ResolvedNestedTable {
+  /** The top-level LayoutBlock containing this table. */
+  lb: { block: Block; layoutTable: LayoutTable; blockIndex: number };
+  /** The LayoutTable for the target table (may be the top-level or inner). */
+  layoutTable: LayoutTable;
+  /** The data Block for the target table. */
+  dataBlock: Block;
+  /** Accumulated X offset from the top-level table origin. */
+  xOffset: number;
+  /** Accumulated Y offset from the top-level table origin (table-logical). */
+  yOffset: number;
+  /** The row index of the outermost nesting level (for paginated Y lookup). */
+  outerRowIndex: number;
+}
+
+/**
+ * Resolve a (possibly nested) table block ID to its LayoutTable and
+ * accumulated coordinate offsets from the top-level layout block.
+ *
+ * For a top-level table, xOffset and yOffset are 0.
+ * For nested tables, they accumulate cell padding and line offsets at each level.
+ */
+export function resolveNestedTableLayout(
+  tableBlockId: string,
+  layout: { blocks: Array<{ block: Block; layoutTable?: LayoutTable }>; blockParentMap: Map<string, BlockCellInfo> },
+): ResolvedNestedTable | undefined {
+  // Walk up to find the top-level table
+  let topTableId = tableBlockId;
+  while (true) {
+    const parentInfo = layout.blockParentMap.get(topTableId);
+    if (!parentInfo) break;
+    topTableId = parentInfo.tableBlockId;
+  }
+
+  const lbIdx = layout.blocks.findIndex((b) => b.block.id === topTableId);
+  const lb = layout.blocks[lbIdx];
+  if (!lb?.layoutTable) return undefined;
+
+  // If the target is the top-level table itself, return directly
+  if (topTableId === tableBlockId) {
+    return {
+      lb: { block: lb.block, layoutTable: lb.layoutTable, blockIndex: lbIdx },
+      layoutTable: lb.layoutTable,
+      dataBlock: lb.block,
+      xOffset: 0,
+      yOffset: 0,
+      outerRowIndex: -1, // not applicable for top-level
+    };
+  }
+
+  // Build the nesting path from outermost to target table
+  const path: BlockCellInfo[] = [];
+  let cur = tableBlockId;
+  while (cur !== topTableId) {
+    const info = layout.blockParentMap.get(cur);
+    if (!info) return undefined;
+    path.unshift(info);
+    cur = info.tableBlockId;
+  }
+
+  let tl = lb.layoutTable;
+  let dataBlock = lb.block;
+  let xOffset = 0;
+  let yOffset = 0;
+
+  for (const seg of path) {
+    const { rowIndex, colIndex } = seg;
+    const cell = tl.cells[rowIndex]?.[colIndex];
+    if (!cell || cell.merged) return undefined;
+
+    const cellData = dataBlock.tableData?.rows[rowIndex]?.cells[colIndex];
+    const cellPadding = cellData?.style.padding ?? 4;
+
+    // Find the nested table line for this segment's target
+    const targetId = seg === path[path.length - 1]
+      ? tableBlockId
+      : path[path.indexOf(seg) + 1].tableBlockId;
+
+    let nestedLine: LayoutLine | undefined;
+    for (let li = 0; li < cell.lines.length; li++) {
+      if (cell.lines[li].nestedTable) {
+        let bi = 0;
+        for (let b = cell.blockBoundaries.length - 1; b >= 0; b--) {
+          if (li >= cell.blockBoundaries[b]) { bi = b; break; }
+        }
+        if (cellData?.blocks[bi]?.id === targetId) {
+          nestedLine = cell.lines[li];
+          break;
+        }
+      }
+    }
+    if (!nestedLine?.nestedTable) return undefined;
+
+    xOffset += tl.columnXOffsets[colIndex] + cellPadding;
+    yOffset += tl.rowYOffsets[rowIndex] + cellPadding + nestedLine.y;
+
+    const nextBlock = cellData?.blocks.find((b) => b.id === targetId);
+    if (!nextBlock?.tableData) return undefined;
+    tl = nestedLine.nestedTable;
+    dataBlock = nextBlock;
+  }
+
+  return {
+    lb: { block: lb.block, layoutTable: lb.layoutTable, blockIndex: lbIdx },
+    layoutTable: tl,
+    dataBlock,
+    xOffset,
+    yOffset,
+    outerRowIndex: path[0].rowIndex,
+  };
+}

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -184,6 +184,7 @@ function layoutCellBlocks(
   blocks: Block[],
   ctx: CanvasRenderingContext2D,
   maxWidth: number,
+  blockParentMap?: Map<string, BlockCellInfo>,
 ): { lines: LayoutLine[]; blockBoundaries: number[] } {
   if (blocks.length === 0) {
     const defaultHeight = ptToPx(Theme.defaultFontSize) * 1.5;
@@ -198,6 +199,29 @@ function layoutCellBlocks(
 
   for (const block of blocks) {
     blockBoundaries.push(allLines.length);
+
+    // Handle nested table blocks
+    if (block.type === 'table' && block.tableData) {
+      const nestedLayout = computeTableLayout(
+        block.tableData, block.id, ctx, maxWidth,
+      );
+      // Merge inner blockParentMap into outer
+      if (blockParentMap) {
+        for (const [k, v] of nestedLayout.blockParentMap) {
+          blockParentMap.set(k, v);
+        }
+      }
+      const tableLine: LayoutLine = {
+        runs: [],
+        y: 0,
+        height: nestedLayout.totalHeight,
+        width: nestedLayout.totalWidth,
+        nestedTable: nestedLayout,
+      };
+      allLines.push(tableLine);
+      continue;
+    }
+
     // Reserve space for list marker indent
     const listIndent = block.type === 'list-item'
       ? LIST_INDENT_PX * ((block.listLevel ?? 0) + 1)
@@ -256,6 +280,7 @@ export function computeTableLayout(
   }
 
   // 3. Layout each cell
+  const blockParentMap = new Map<string, BlockCellInfo>();
   const cells: LayoutTableCell[][] = [];
   for (let r = 0; r < numRows; r++) {
     const row = rows[r];
@@ -279,7 +304,7 @@ export function computeTableLayout(
       const padding = cell?.style?.padding ?? DEFAULT_CELL_PADDING;
       const innerWidth = Math.max(cellWidth - padding * 2, 0);
 
-      const { lines, blockBoundaries } = layoutCellBlocks(cell?.blocks ?? [], ctx, innerWidth);
+      const { lines, blockBoundaries } = layoutCellBlocks(cell?.blocks ?? [], ctx, innerWidth, blockParentMap);
       const cellHeight = lines.reduce((sum, l) => sum + l.height, 0) + padding * 2;
 
       cellRow.push({ lines, blockBoundaries, width: cellWidth, height: cellHeight, merged: false });
@@ -347,8 +372,8 @@ export function computeTableLayout(
     yOffset += rowHeights[r];
   }
 
-  // 7. Build BlockParentMap
-  const blockParentMap = new Map<string, BlockCellInfo>();
+  // 7. Register direct-child blocks in BlockParentMap
+  // (nested table blocks are already merged by layoutCellBlocks)
   for (let r = 0; r < numRows; r++) {
     for (let c = 0; c < numCols; c++) {
       const cell = rows[r]?.cells[c];

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -127,6 +127,51 @@ function layoutCellInlines(
         flushCurrentLine(fontSizePx);
       }
 
+      // Character-level break: if a single word is wider than maxWidth,
+      // split it into chunks that fit. This prevents text from
+      // overflowing cell boundaries (matches Google Docs behavior).
+      if (wordWidth > maxWidth && maxWidth > 0) {
+        let remaining = word;
+        let remainCharPos = charPos;
+        while (remaining.length > 0) {
+          // Find how many characters fit in the remaining line width
+          const availWidth = maxWidth - lineWidth;
+          let fitLen = 0;
+          let fitWidth = 0;
+          for (let ci = 1; ci <= remaining.length; ci++) {
+            const w = cachedMeasureText(ctx, remaining.slice(0, ci), font);
+            if (w > availWidth && fitLen > 0) break;
+            fitLen = ci;
+            fitWidth = w;
+          }
+          // At least one character per chunk to avoid infinite loop
+          if (fitLen === 0) {
+            fitLen = 1;
+            fitWidth = cachedMeasureText(ctx, remaining.slice(0, 1), font);
+          }
+          const chunk = remaining.slice(0, fitLen);
+          currentRuns.push({
+            inline,
+            text: chunk,
+            x: lineWidth,
+            width: fitWidth,
+            inlineIndex: i,
+            charStart: remainCharPos,
+            charEnd: remainCharPos + chunk.length,
+            charOffsets: computeCharOffsets(ctx, chunk, font),
+          });
+          lineWidth += fitWidth;
+          if (fontSizePx > lineMaxFontSize) lineMaxFontSize = fontSizePx;
+          remainCharPos += chunk.length;
+          remaining = remaining.slice(fitLen);
+          if (remaining.length > 0) {
+            flushCurrentLine(fontSizePx);
+          }
+        }
+        charPos = remainCharPos;
+        continue;
+      }
+
       currentRuns.push({
         inline,
         text: word,

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -3,6 +3,7 @@ import { LIST_INDENT_PX } from '../model/types.js';
 import type { LayoutLine } from './layout.js';
 import { cachedMeasureText, applyAlignment, computeCharOffsets } from './layout.js';
 import { buildFont, ptToPx, Theme } from './theme.js';
+import { computeMergedCellLineLayouts } from './table-renderer.js';
 
 export interface LayoutTableCell {
   lines: LayoutLine[];
@@ -527,6 +528,7 @@ export function resolveNestedTableLayout(
       : path[path.indexOf(seg) + 1].tableBlockId;
 
     let nestedLine: LayoutLine | undefined;
+    let nestedLineIdx = -1;
     for (let li = 0; li < cell.lines.length; li++) {
       if (cell.lines[li].nestedTable) {
         let bi = 0;
@@ -535,14 +537,24 @@ export function resolveNestedTableLayout(
         }
         if (cellData?.blocks[bi]?.id === targetId) {
           nestedLine = cell.lines[li];
+          nestedLineIdx = li;
           break;
         }
       }
     }
-    if (!nestedLine?.nestedTable) return undefined;
+    if (!nestedLine?.nestedTable || nestedLineIdx < 0) return undefined;
+
+    // Use computeMergedCellLineLayouts for accurate Y positioning that
+    // accounts for merged-row redistribution and vertical alignment.
+    const rowSpan = cellData?.rowSpan ?? 1;
+    const lineLayouts = computeMergedCellLineLayouts(
+      cell.lines, rowIndex, rowSpan, cellPadding,
+      tl.rowYOffsets, tl.rowHeights,
+    );
+    const ll = lineLayouts[nestedLineIdx];
 
     xOffset += tl.columnXOffsets[colIndex] + cellPadding;
-    yOffset += tl.rowYOffsets[rowIndex] + cellPadding + nestedLine.y;
+    yOffset += ll ? ll.runLineY : (tl.rowYOffsets[rowIndex] + cellPadding + nestedLine.y);
 
     const nextBlock = cellData?.blocks.find((b) => b.id === targetId);
     if (!nextBlock?.tableData) return undefined;

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -267,6 +267,26 @@ export function renderTableContent(
         } else {
           lineAbsoluteY = cellY + textYOffset + line.y;
         }
+        // Render nested table if this line contains one
+        if (line.nestedTable) {
+          const blockIndex = getBlockIndexForLine(layoutCell.blockBoundaries, li);
+          const nestedBlock = cell.blocks[blockIndex];
+          if (nestedBlock?.tableData) {
+            const nestedX = cellX + padding;
+            const nestedY = lineAbsoluteY;
+            renderTableBackgrounds(
+              ctx, nestedBlock.tableData, line.nestedTable,
+              nestedX, nestedY,
+            );
+            renderTableContent(
+              ctx, nestedBlock.tableData, line.nestedTable,
+              nestedX, nestedY,
+              0, undefined, undefined,
+              requestRender, dragImageRun, selectionRects, focused,
+            );
+          }
+          continue;
+        }
         for (const run of line.runs) {
           // Drag-lift: skip the image currently being resized so the
           // editor's separate shadow pass can draw it at the preview
@@ -457,6 +477,18 @@ export function renderTableContent(
       drawBorder(ctx, cell.style?.borderRight ?? themeBorder, x + cellWidth, y, x + cellWidth, y + visibleHeight);
     }
   }
+}
+
+/**
+ * Return the block index that owns the given line index, using the
+ * pre-computed `blockBoundaries` array (each entry is the first line
+ * index of the corresponding block).
+ */
+function getBlockIndexForLine(blockBoundaries: number[], lineIndex: number): number {
+  for (let bi = blockBoundaries.length - 1; bi >= 0; bi--) {
+    if (lineIndex >= blockBoundaries[bi]) return bi;
+  }
+  return 0;
 }
 
 /**

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -3261,6 +3261,141 @@ export class TextEditor {
     // Resolve X within the target line
     const ctx = this.getCtx();
     const targetLine = cell.lines[targetLineIdx];
+
+    // Handle nested table: resolve click into the inner table
+    if (targetLine?.nestedTable) {
+      const innerLayout = targetLine.nestedTable;
+      const innerBlock = dataBlock.tableData!.rows[cellAddr.rowIndex].cells[cellAddr.colIndex].blocks[currentBlockIndex];
+      if (innerBlock?.tableData) {
+        // Find inner column from local X within the inner table
+        const innerLocalX = localX;
+        let innerCol = innerLayout.columnPixelWidths.length - 1;
+        for (let c = 0; c < innerLayout.columnXOffsets.length; c++) {
+          if (innerLocalX < innerLayout.columnXOffsets[c] + innerLayout.columnPixelWidths[c]) {
+            innerCol = c;
+            break;
+          }
+        }
+
+        // Find inner row from Y within the inner table
+        let innerRow = innerLayout.rowHeights.length - 1;
+        let innerTableAbsY = 0;
+        if (logicalY !== undefined) {
+          // Compute the inner table's absolute Y origin
+          const lineLayouts = computeMergedCellLineLayouts(
+            cell.lines, cellAddr.rowIndex, dataCell?.rowSpan ?? 1,
+            cellPadding, tl.rowYOffsets, tl.rowHeights,
+          );
+          const ll = lineLayouts[targetLineIdx];
+          const blockIndex = layout.blocks.indexOf(lb);
+          for (const page of paginatedLayout.pages) {
+            const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
+            for (const pl of page.lines) {
+              if (pl.blockIndex === blockIndex && pl.lineIndex === ll.ownerRow) {
+                innerTableAbsY = pageY + pl.y + (ll.runLineY - tl.rowYOffsets[ll.ownerRow]);
+                break;
+              }
+            }
+          }
+          const innerLocalY = logicalY - innerTableAbsY;
+          for (let r = 0; r < innerLayout.rowYOffsets.length; r++) {
+            if (innerLocalY < innerLayout.rowYOffsets[r] + innerLayout.rowHeights[r]) {
+              innerRow = r;
+              break;
+            }
+          }
+        }
+
+        // Resolve merged cells in inner table
+        const innerDataCell = innerBlock.tableData.rows[innerRow]?.cells[innerCol];
+        if (innerDataCell?.colSpan === 0) {
+          for (let r = innerRow; r >= 0; r--) {
+            for (let c = innerCol; c >= 0; c--) {
+              const cand = innerBlock.tableData.rows[r]?.cells[c];
+              if (cand && cand.colSpan !== 0) {
+                const cs = cand.colSpan ?? 1;
+                const rs = cand.rowSpan ?? 1;
+                if (r + rs > innerRow && c + cs > innerCol) {
+                  innerRow = r;
+                  innerCol = c;
+                  break;
+                }
+              }
+            }
+          }
+        }
+
+        // Resolve offset within the inner table cell directly using its layout
+        const innerCellLayout = innerLayout.cells[innerRow]?.[innerCol];
+        const innerCellData = innerBlock.tableData.rows[innerRow]?.cells[innerCol];
+        if (innerCellLayout && innerCellData && !innerCellLayout.merged) {
+          const innerCellPadding = innerCellData.style.padding ?? 4;
+          const innerCellX = innerLayout.columnXOffsets[innerCol] + innerCellPadding;
+          const innerCellLocalX = innerLocalX - innerCellX;
+
+          // Find target line in inner cell
+          let innerLineIdx = innerCellLayout.lines.length - 1;
+          if (logicalY !== undefined) {
+            const innerCellAbsY = innerTableAbsY + innerLayout.rowYOffsets[innerRow] + innerCellPadding;
+            const innerCellRelY = logicalY - innerCellAbsY;
+            for (let li = 0; li < innerCellLayout.lines.length; li++) {
+              const line = innerCellLayout.lines[li];
+              if (innerCellRelY < line.y + line.height) {
+                innerLineIdx = li;
+                break;
+              }
+            }
+          }
+
+          // Check for further nesting (recursive)
+          const innerTargetLine = innerCellLayout.lines[innerLineIdx];
+          if (innerTargetLine?.nestedTable) {
+            // For deeper nesting, fall through to first block of inner cell
+            return { blockId: innerCellData.blocks[0].id, offset: 0 };
+          }
+
+          // Find block index within inner cell
+          let innerBlockIdx = 0;
+          for (let bi = 0; bi < innerCellLayout.blockBoundaries.length; bi++) {
+            const nextBound = innerCellLayout.blockBoundaries[bi + 1] ?? innerCellLayout.lines.length;
+            if (innerLineIdx < nextBound) {
+              innerBlockIdx = bi;
+              break;
+            }
+          }
+
+          // Find character offset
+          let innerOffset = 0;
+          const innerBlockStart = innerCellLayout.blockBoundaries[innerBlockIdx] ?? 0;
+          for (let li = innerBlockStart; li < innerLineIdx; li++) {
+            for (const run of innerCellLayout.lines[li].runs) {
+              innerOffset += run.text.length;
+            }
+          }
+
+          if (innerTargetLine) {
+            for (const run of innerTargetLine.runs) {
+              ctx.font = buildFont(
+                run.inline.style.fontSize, run.inline.style.fontFamily,
+                run.inline.style.bold, run.inline.style.italic,
+              );
+              for (let i = 0; i <= run.text.length; i++) {
+                const w = ctx.measureText(run.text.slice(0, i)).width + run.x;
+                if (w >= innerCellLocalX) {
+                  return { blockId: innerCellData.blocks[innerBlockIdx].id, offset: innerOffset + i };
+                }
+              }
+              innerOffset += run.text.length;
+            }
+          }
+          return { blockId: innerCellData.blocks[innerBlockIdx].id, offset: innerOffset };
+        }
+
+        // Fallback: first block of inner cell
+        return { blockId: innerBlock.tableData.rows[innerRow].cells[innerCol].blocks[0].id, offset: 0 };
+      }
+    }
+
     if (targetLine) {
       for (const run of targetLine.runs) {
         ctx.font = buildFont(

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -978,6 +978,7 @@ export class TextEditor {
 
     // Table cell click detection: resolve which cell was clicked
     const clickedBlock = this.doc.document.blocks.find((b) => b.id === pos.blockId);
+
     if (clickedBlock?.type === 'table' && clickedBlock.tableData) {
       const layout = this.getLayout();
       const lb = layout.blocks.find((b) => b.block.id === pos.blockId);
@@ -1031,6 +1032,7 @@ export class TextEditor {
             // Single click — resolve character offset from mouse position
             const resolved = this.resolveOffsetInCell(pos.blockId, cellAddr, e);
             const cellPos: DocPosition = { blockId: resolved.blockId, offset: resolved.offset };
+
             this.cursor.moveTo(cellPos);
             // Set anchor for drag selection (same as non-cell single click)
             this.selection.setRange({ anchor: cellPos, focus: cellPos });
@@ -1203,6 +1205,7 @@ export class TextEditor {
       let tableCellRange: DocRange['tableCellRange'] = undefined;
 
       const anchorCellInfo = this.getCellInfo(anchor.blockId);
+
       if (anchorCellInfo) {
         const tableBlockId = anchorCellInfo.tableBlockId;
 
@@ -1217,6 +1220,7 @@ export class TextEditor {
         }
 
         // Check if mouse is still in the same table (or its outermost ancestor)
+
         if (result.blockId === tableBlockId || result.blockId === outermostTableId) {
           // For nested tables, use the outermost table for coordinate
           // resolution since resolveTableCellClick only works with
@@ -1234,6 +1238,7 @@ export class TextEditor {
               // Check if resolved position is in the same cell as the anchor
               const resolvedCellInfo = layout.blockParentMap.get(resolved.blockId);
               const anchorTableId = anchorCellInfo.tableBlockId;
+
               if (resolvedCellInfo &&
                   resolvedCellInfo.tableBlockId === anchorTableId &&
                   resolvedCellInfo.rowIndex === anchorCellInfo.rowIndex &&

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -2306,6 +2306,21 @@ export class TextEditor {
   }
 
   /**
+   * Get the last cursor position in a cell, entering nested tables if the
+   * last block is a table.
+   */
+  private lastPositionInCell(cell: import('../model/types.js').TableCell): DocPosition {
+    let lastBlock = cell.blocks[cell.blocks.length - 1];
+    while (lastBlock.type === 'table' && lastBlock.tableData) {
+      const td = lastBlock.tableData;
+      const lastRow = td.rows[td.rows.length - 1];
+      const lastCell = lastRow.cells[lastRow.cells.length - 1];
+      lastBlock = lastCell.blocks[lastCell.blocks.length - 1];
+    }
+    return { blockId: lastBlock.id, offset: getBlockTextLength(lastBlock) };
+  }
+
+  /**
    * Walk up the blockParentMap chain from a (possibly nested) block to find
    * its cell address within a specific outer table.
    */
@@ -3115,8 +3130,7 @@ export class TextEditor {
     for (let c = cellInfo.colIndex - 1; c >= 0; c--) {
       const cell = td.rows[cellInfo.rowIndex]?.cells[c];
       if (cell && cell.colSpan !== 0) {
-        const lastBlock = cell.blocks[cell.blocks.length - 1];
-        return { blockId: lastBlock.id, offset: getBlockTextLength(lastBlock) };
+        return this.lastPositionInCell(cell);
       }
     }
     // Try previous rows
@@ -3124,8 +3138,7 @@ export class TextEditor {
       for (let c = td.columnWidths.length - 1; c >= 0; c--) {
         const cell = td.rows[r]?.cells[c];
         if (cell && cell.colSpan !== 0) {
-          const lastBlock = cell.blocks[cell.blocks.length - 1];
-          return { blockId: lastBlock.id, offset: getBlockTextLength(lastBlock) };
+          return this.lastPositionInCell(cell);
         }
       }
     }
@@ -3681,8 +3694,7 @@ export class TextEditor {
     for (let c = colIndex - 1; c >= 0; c--) {
       const cell = td.rows[rowIndex]?.cells[c];
       if (cell && cell.colSpan !== 0) {
-        const lastBlock = cell.blocks[cell.blocks.length - 1];
-        this.cursor.moveTo({ blockId: lastBlock.id, offset: getBlockTextLength(lastBlock) });
+        this.cursor.moveTo(this.lastPositionInCell(cell));
         return true;
       }
     }
@@ -3691,8 +3703,7 @@ export class TextEditor {
       for (let c = td.columnWidths.length - 1; c >= 0; c--) {
         const cell = td.rows[r]?.cells[c];
         if (cell && cell.colSpan !== 0) {
-          const lastBlock = cell.blocks[cell.blocks.length - 1];
-          this.cursor.moveTo({ blockId: lastBlock.id, offset: getBlockTextLength(lastBlock) });
+          this.cursor.moveTo(this.lastPositionInCell(cell));
           return true;
         }
       }

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1204,46 +1204,66 @@ export class TextEditor {
 
       const anchorCellInfo = this.getCellInfo(anchor.blockId);
       if (anchorCellInfo) {
-        const anchorCA: CellAddress = { rowIndex: anchorCellInfo.rowIndex, colIndex: anchorCellInfo.colIndex };
         const tableBlockId = anchorCellInfo.tableBlockId;
 
-        // Check if mouse is still in the same table
-        if (result.blockId === tableBlockId) {
-          const layout = this.getLayout();
-          const lb = layout.blocks.find((b) => b.block.id === tableBlockId);
-          if (lb?.layoutTable) {
-            const currentCA = this.resolveTableCellClick(tableBlockId, x, y + scrollY);
+        // Walk up the nesting chain to find the outermost table ID.
+        // For nested tables, result.blockId is always the top-level table,
+        // but tableBlockId may be an inner table.
+        let outermostTableId = tableBlockId;
+        while (true) {
+          const parentInfo = this.getLayout().blockParentMap.get(outermostTableId);
+          if (!parentInfo) break;
+          outermostTableId = parentInfo.tableBlockId;
+        }
 
-            if (currentCA &&
-                currentCA.rowIndex === anchorCA.rowIndex &&
-                currentCA.colIndex === anchorCA.colIndex) {
-              // Same cell — text selection mode
-              const resolved = this.resolveOffsetInCellAtXY(tableBlockId, anchorCA, x, y + scrollY);
-              pos = {
-                blockId: resolved.blockId,
-                offset: resolved.offset,
-              };
-            } else if (currentCA) {
-              // Different cell — cell-range mode
-              const tableData = this.doc.getBlock(tableBlockId).tableData!;
-              tableCellRange = expandCellRangeForMerges(
-                {
-                  blockId: tableBlockId,
-                  start: anchorCA,
-                  end: currentCA,
-                },
-                tableData,
-              );
-              // Cursor lands on the cell the user actually dragged to
-              // (resolveTableCellClick guarantees currentCA is a visible
-              // top-left, never a covered cell). The expanded range is for
-              // selection/highlighting only.
-              const targetCell = tableData.rows[currentCA.rowIndex]
-                .cells[currentCA.colIndex];
-              pos = {
-                blockId: targetCell.blocks[0].id,
-                offset: 0,
-              };
+        // Check if mouse is still in the same table (or its outermost ancestor)
+        if (result.blockId === tableBlockId || result.blockId === outermostTableId) {
+          // For nested tables, use the outermost table for coordinate
+          // resolution since resolveTableCellClick only works with
+          // top-level table blocks.
+          const resolveTableId = outermostTableId;
+          const layout = this.getLayout();
+          const lb = layout.blocks.find((b) => b.block.id === resolveTableId);
+          if (lb?.layoutTable) {
+            const outerCA = this.resolveTableCellClick(resolveTableId, x, y + scrollY);
+
+            if (outerCA) {
+              // Resolve the full position (handles nested tables internally)
+              const resolved = this.resolveOffsetInCellAtXY(resolveTableId, outerCA, x, y + scrollY);
+
+              // Check if resolved position is in the same cell as the anchor
+              const resolvedCellInfo = layout.blockParentMap.get(resolved.blockId);
+              const anchorTableId = anchorCellInfo.tableBlockId;
+              if (resolvedCellInfo &&
+                  resolvedCellInfo.tableBlockId === anchorTableId &&
+                  resolvedCellInfo.rowIndex === anchorCellInfo.rowIndex &&
+                  resolvedCellInfo.colIndex === anchorCellInfo.colIndex) {
+                // Same cell — text selection mode
+                pos = {
+                  blockId: resolved.blockId,
+                  offset: resolved.offset,
+                };
+              } else {
+                // Different cell — cell-range mode within the outermost table
+                const outerAnchorCA = this.findOuterCellAddress(anchor.blockId, resolveTableId);
+                if (outerAnchorCA) {
+                  const tableData = this.doc.getBlock(resolveTableId).tableData!;
+                  tableCellRange = expandCellRangeForMerges(
+                    {
+                      blockId: resolveTableId,
+                      start: outerAnchorCA,
+                      end: outerCA,
+                    },
+                    tableData,
+                  );
+                  const targetCell = tableData.rows[outerCA.rowIndex]
+                    .cells[outerCA.colIndex];
+                  pos = {
+                    blockId: targetCell.blocks[0].id,
+                    offset: 0,
+                  };
+                }
+              }
             }
           }
         } else {
@@ -2186,6 +2206,23 @@ export class TextEditor {
 
   private getCellInfo(blockId: string): BlockCellInfo | undefined {
     return this.getLayout().blockParentMap.get(blockId);
+  }
+
+  /**
+   * Walk up the blockParentMap chain from a (possibly nested) block to find
+   * its cell address within a specific outer table.
+   */
+  private findOuterCellAddress(blockId: string, outerTableId: string): CellAddress | undefined {
+    const map = this.getLayout().blockParentMap;
+    let currentId = blockId;
+    while (true) {
+      const info = map.get(currentId);
+      if (!info) return undefined;
+      if (info.tableBlockId === outerTableId) {
+        return { rowIndex: info.rowIndex, colIndex: info.colIndex };
+      }
+      currentId = info.tableBlockId;
+    }
   }
 
   // --- Helpers ---

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1853,28 +1853,75 @@ export class TextEditor {
         const cell = tableBlock.tableData!.rows[arrowCellInfo.rowIndex].cells[arrowCellInfo.colIndex];
         const blockIdx = cell.blocks.findIndex(b => b.id === pos.blockId);
         if (blockIdx > 0) {
-          // Move to previous block within the same cell
           const prevBlock = cell.blocks[blockIdx - 1];
-          const prevLen = getBlockTextLength(prevBlock);
-          newPos = {
-            blockId: prevBlock.id,
-            offset: Math.min(pos.offset, prevLen),
-          };
+          // If previous block is a nested table, enter its last row
+          if (prevBlock.type === 'table' && prevBlock.tableData) {
+            const td = prevBlock.tableData;
+            const lastRow = td.rows.length - 1;
+            const lastCell = td.rows[lastRow].cells[arrowCellInfo.colIndex < td.columnWidths.length ? arrowCellInfo.colIndex : 0];
+            const lastCellBlock = lastCell.blocks[lastCell.blocks.length - 1];
+            newPos = {
+              blockId: lastCellBlock.id,
+              offset: Math.min(pos.offset, getBlockTextLength(lastCellBlock)),
+            };
+          } else {
+            newPos = {
+              blockId: prevBlock.id,
+              offset: Math.min(pos.offset, getBlockTextLength(prevBlock)),
+            };
+          }
         } else {
           // At first block — move to cell above or exit table
           if (arrowCellInfo.rowIndex > 0) {
             const aboveCell = tableBlock.tableData!.rows[arrowCellInfo.rowIndex - 1].cells[arrowCellInfo.colIndex];
             const lastBlock = aboveCell.blocks[aboveCell.blocks.length - 1];
-            const lastBlockLen = getBlockTextLength(lastBlock);
-            newPos = {
-              blockId: lastBlock.id,
-              offset: Math.min(pos.offset, lastBlockLen),
-            };
+            // If last block is a nested table, enter it
+            if (lastBlock.type === 'table' && lastBlock.tableData) {
+              const td = lastBlock.tableData;
+              const lastRow = td.rows.length - 1;
+              const col = Math.min(arrowCellInfo.colIndex, td.columnWidths.length - 1);
+              const innerCell = td.rows[lastRow].cells[col];
+              const innerBlock = innerCell.blocks[innerCell.blocks.length - 1];
+              newPos = {
+                blockId: innerBlock.id,
+                offset: Math.min(pos.offset, getBlockTextLength(innerBlock)),
+              };
+            } else {
+              newPos = {
+                blockId: lastBlock.id,
+                offset: Math.min(pos.offset, getBlockTextLength(lastBlock)),
+              };
+            }
           } else {
-            const blockIndex = this.doc.getBlockIndex(tableBlockId);
-            if (blockIndex > 0) {
-              const prevBlock = this.doc.document.blocks[blockIndex - 1];
-              newPos = { blockId: prevBlock.id, offset: getBlockTextLength(prevBlock) };
+            // Exit table upward
+            const parentCellInfo = this.getLayout().blockParentMap.get(tableBlockId);
+            if (parentCellInfo) {
+              // Nested table — move to the block before this table in parent cell
+              const parentTable = this.doc.getBlock(parentCellInfo.tableBlockId);
+              const parentCell = parentTable.tableData!.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];
+              const idx = parentCell.blocks.findIndex(b => b.id === tableBlockId);
+              if (idx > 0) {
+                const prevBlock = parentCell.blocks[idx - 1];
+                newPos = { blockId: prevBlock.id, offset: getBlockTextLength(prevBlock) };
+              } else if (parentCellInfo.rowIndex > 0) {
+                // Move to the cell above in the outer table
+                const aboveCell = parentTable.tableData!.rows[parentCellInfo.rowIndex - 1].cells[parentCellInfo.colIndex];
+                const lastBlock = aboveCell.blocks[aboveCell.blocks.length - 1];
+                newPos = { blockId: lastBlock.id, offset: getBlockTextLength(lastBlock) };
+              } else {
+                // Exit outer table
+                const outerIdx = this.doc.getBlockIndex(parentCellInfo.tableBlockId);
+                if (outerIdx > 0) {
+                  const prevBlock = this.doc.document.blocks[outerIdx - 1];
+                  newPos = { blockId: prevBlock.id, offset: getBlockTextLength(prevBlock) };
+                }
+              }
+            } else {
+              const blockIndex = this.doc.getBlockIndex(tableBlockId);
+              if (blockIndex > 0) {
+                const prevBlock = this.doc.document.blocks[blockIndex - 1];
+                newPos = { blockId: prevBlock.id, offset: getBlockTextLength(prevBlock) };
+              }
             }
           }
         }
@@ -1883,27 +1930,72 @@ export class TextEditor {
         const cell = tableBlock.tableData!.rows[arrowCellInfo.rowIndex].cells[arrowCellInfo.colIndex];
         const blockIdx = cell.blocks.findIndex(b => b.id === pos.blockId);
         if (blockIdx < cell.blocks.length - 1) {
-          // Move to next block within the same cell
           const nextBlock = cell.blocks[blockIdx + 1];
-          const nextLen = getBlockTextLength(nextBlock);
-          newPos = {
-            blockId: nextBlock.id,
-            offset: Math.min(pos.offset, nextLen),
-          };
+          // If next block is a nested table, enter its first row
+          if (nextBlock.type === 'table' && nextBlock.tableData) {
+            const td = nextBlock.tableData;
+            const col = Math.min(arrowCellInfo.colIndex, td.columnWidths.length - 1);
+            const firstCellBlock = td.rows[0].cells[col].blocks[0];
+            newPos = {
+              blockId: firstCellBlock.id,
+              offset: Math.min(pos.offset, getBlockTextLength(firstCellBlock)),
+            };
+          } else {
+            newPos = {
+              blockId: nextBlock.id,
+              offset: Math.min(pos.offset, getBlockTextLength(nextBlock)),
+            };
+          }
         } else {
           // At last block — move to cell below or exit table
           const td = tableBlock.tableData!;
           if (arrowCellInfo.rowIndex < td.rows.length - 1) {
             const belowCell = td.rows[arrowCellInfo.rowIndex + 1].cells[arrowCellInfo.colIndex];
             const firstBlock = belowCell.blocks[0];
-            newPos = {
-              blockId: firstBlock.id,
-              offset: Math.min(pos.offset, getBlockTextLength(firstBlock)),
-            };
+            // If first block is a nested table, enter it
+            if (firstBlock.type === 'table' && firstBlock.tableData) {
+              const innerTd = firstBlock.tableData;
+              const col = Math.min(arrowCellInfo.colIndex, innerTd.columnWidths.length - 1);
+              const innerBlock = innerTd.rows[0].cells[col].blocks[0];
+              newPos = {
+                blockId: innerBlock.id,
+                offset: Math.min(pos.offset, getBlockTextLength(innerBlock)),
+              };
+            } else {
+              newPos = {
+                blockId: firstBlock.id,
+                offset: Math.min(pos.offset, getBlockTextLength(firstBlock)),
+              };
+            }
           } else {
-            const blockIndex = this.doc.getBlockIndex(tableBlockId);
-            const nextId = this.doc.ensureBlockAfter(blockIndex);
-            newPos = { blockId: nextId, offset: 0 };
+            // Exit table downward
+            const parentCellInfo = this.getLayout().blockParentMap.get(tableBlockId);
+            if (parentCellInfo) {
+              // Nested table — move to the block after this table in parent cell
+              const parentTable = this.doc.getBlock(parentCellInfo.tableBlockId);
+              const parentCell = parentTable.tableData!.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];
+              const idx = parentCell.blocks.findIndex(b => b.id === tableBlockId);
+              if (idx + 1 < parentCell.blocks.length) {
+                const nextBlock = parentCell.blocks[idx + 1];
+                newPos = { blockId: nextBlock.id, offset: 0 };
+              } else {
+                // No more blocks — move to cell below in outer table
+                const outerTd = parentTable.tableData!;
+                if (parentCellInfo.rowIndex < outerTd.rows.length - 1) {
+                  const belowCell = outerTd.rows[parentCellInfo.rowIndex + 1].cells[parentCellInfo.colIndex];
+                  newPos = { blockId: belowCell.blocks[0].id, offset: 0 };
+                } else {
+                  // Exit outer table
+                  const outerIdx = this.doc.getBlockIndex(parentCellInfo.tableBlockId);
+                  const nextId = this.doc.ensureBlockAfter(outerIdx);
+                  newPos = { blockId: nextId, offset: 0 };
+                }
+              }
+            } else {
+              const blockIndex = this.doc.getBlockIndex(tableBlockId);
+              const nextId = this.doc.ensureBlockAfter(blockIndex);
+              newPos = { blockId: nextId, offset: 0 };
+            }
           }
         }
       }
@@ -2944,6 +3036,19 @@ export class TextEditor {
   }
 
   private getPositionBeforeTable(tableBlockId: string): DocPosition | undefined {
+    // For nested tables, find the previous block in the parent cell
+    const parentCellInfo = this.getLayout().blockParentMap.get(tableBlockId);
+    if (parentCellInfo) {
+      const parentTable = this.doc.getBlock(parentCellInfo.tableBlockId);
+      const parentCell = parentTable.tableData!.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];
+      const idx = parentCell.blocks.findIndex(b => b.id === tableBlockId);
+      if (idx > 0) {
+        const prev = parentCell.blocks[idx - 1];
+        return { blockId: prev.id, offset: getBlockTextLength(prev) };
+      }
+      // No block before — use getPrevCellLastPosition on parent table
+      return this.getPrevCellLastPosition(parentCellInfo);
+    }
     const idx = this.doc.getBlockIndex(tableBlockId);
     if (idx > 0) {
       const prev = this.doc.document.blocks[idx - 1];
@@ -2953,6 +3058,18 @@ export class TextEditor {
   }
 
   private getPositionAfterTable(tableBlockId: string): DocPosition | undefined {
+    // For nested tables, find the next block in the parent cell
+    const parentCellInfo = this.getLayout().blockParentMap.get(tableBlockId);
+    if (parentCellInfo) {
+      const parentTable = this.doc.getBlock(parentCellInfo.tableBlockId);
+      const parentCell = parentTable.tableData!.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];
+      const idx = parentCell.blocks.findIndex(b => b.id === tableBlockId);
+      if (idx + 1 < parentCell.blocks.length) {
+        return { blockId: parentCell.blocks[idx + 1].id, offset: 0 };
+      }
+      // No block after — use getNextCellFirstPosition on parent table
+      return this.getNextCellFirstPosition(parentCellInfo);
+    }
     const idx = this.doc.getBlockIndex(tableBlockId);
     const blocks = this.doc.document.blocks;
     if (idx < blocks.length - 1) {

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1248,8 +1248,28 @@ export class TextEditor {
                   blockId: resolved.blockId,
                   offset: resolved.offset,
                 };
+              } else if (resolvedCellInfo &&
+                  resolvedCellInfo.tableBlockId === anchorTableId) {
+                // Different cell in the SAME table (e.g., inner table
+                // cell-range selection) — use that table for cell-range mode
+                const innerTableData = this.doc.getBlock(anchorTableId).tableData!;
+                tableCellRange = expandCellRangeForMerges(
+                  {
+                    blockId: anchorTableId,
+                    start: { rowIndex: anchorCellInfo.rowIndex, colIndex: anchorCellInfo.colIndex },
+                    end: { rowIndex: resolvedCellInfo.rowIndex, colIndex: resolvedCellInfo.colIndex },
+                  },
+                  innerTableData,
+                );
+                const targetCell = innerTableData.rows[resolvedCellInfo.rowIndex]
+                  .cells[resolvedCellInfo.colIndex];
+                pos = {
+                  blockId: targetCell.blocks[0].id,
+                  offset: 0,
+                };
               } else {
-                // Different cell — cell-range mode within the outermost table
+                // Different cell in different tables or outer table —
+                // cell-range mode within the outermost table
                 const outerAnchorCA = this.findOuterCellAddress(anchor.blockId, resolveTableId);
                 if (outerAnchorCA) {
                   const tableData = this.doc.getBlock(resolveTableId).tableData!;

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -3519,7 +3519,27 @@ export class TextEditor {
       this.cursor.moveTo({ blockId: newCell.blocks[0].id, offset: 0 });
       return true;
     }
-    // ArrowRight: exit table — move to the block after the table
+    // Exit table — move to the block after the table.
+    // If this is a nested table, move to the next block in the parent cell
+    // or to the next cell in the outer table.
+    const parentCellInfo = this.getLayout().blockParentMap.get(tableBlockId);
+    if (parentCellInfo) {
+      // Nested table — find the next block in the parent cell
+      const parentTable = this.doc.getBlock(parentCellInfo.tableBlockId);
+      const parentCell = parentTable.tableData!.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];
+      const idx = parentCell.blocks.findIndex(b => b.id === tableBlockId);
+      if (idx + 1 < parentCell.blocks.length) {
+        const nextBlock = parentCell.blocks[idx + 1];
+        this.cursor.moveTo({ blockId: nextBlock.id, offset: 0 });
+        return true;
+      }
+      // No more blocks in parent cell — navigate to the next cell in the
+      // outer table. Temporarily place the cursor on the first block of
+      // the parent cell so getCellInfo resolves to the outer table context.
+      this.cursor.moveTo({ blockId: parentCell.blocks[0].id, offset: 0 });
+      return this.moveToNextCell(addRowAtEnd);
+    }
+    // Top-level table — move to the block after the table
     const blockIndex = this.doc.getBlockIndex(tableBlockId);
     const nextId = this.doc.ensureBlockAfter(blockIndex);
     this.cursor.moveTo({ blockId: nextId, offset: 0 });
@@ -3560,7 +3580,25 @@ export class TextEditor {
         }
       }
     }
-    // At first cell — exit table, move to the block before the table
+    // At first cell — exit table.
+    // If nested, move to the previous block in the parent cell or
+    // to the previous cell in the outer table.
+    const parentCellInfo = this.getLayout().blockParentMap.get(tableBlockId);
+    if (parentCellInfo) {
+      const parentTable = this.doc.getBlock(parentCellInfo.tableBlockId);
+      const parentCell = parentTable.tableData!.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];
+      const idx = parentCell.blocks.findIndex(b => b.id === tableBlockId);
+      if (idx > 0) {
+        const prevBlock = parentCell.blocks[idx - 1];
+        this.cursor.moveTo({ blockId: prevBlock.id, offset: getBlockTextLength(prevBlock) });
+        return true;
+      }
+      // No blocks before this table in parent cell — navigate to previous
+      // cell in the outer table.
+      this.cursor.moveTo({ blockId: parentCell.blocks[0].id, offset: 0 });
+      return this.moveToPrevCell();
+    }
+    // Top-level table — move to the block before the table
     const blockIndex = this.doc.getBlockIndex(tableBlockId);
     if (blockIndex > 0) {
       const prevBlock = this.doc.document.blocks[blockIndex - 1];

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -2646,6 +2646,15 @@ export class TextEditor {
       const blockIdx = cell.blocks.findIndex(b => b.id === pos.blockId);
       if (blockIdx > 0) {
         const prevBlock = cell.blocks[blockIdx - 1];
+        // If previous block is a nested table, enter its last cell
+        if (prevBlock.type === 'table' && prevBlock.tableData) {
+          const td = prevBlock.tableData;
+          const lastRow = td.rows.length - 1;
+          const lastCol = td.columnWidths.length - 1;
+          const lastCell = td.rows[lastRow].cells[lastCol];
+          const lastCellBlock = lastCell.blocks[lastCell.blocks.length - 1];
+          return { blockId: lastCellBlock.id, offset: getBlockTextLength(lastCellBlock) };
+        }
         return { blockId: prevBlock.id, offset: getBlockTextLength(prevBlock) };
       }
       return pos; // Clamp at cell start
@@ -2684,7 +2693,12 @@ export class TextEditor {
       const tableCell = tableBlock.tableData!.rows[cellInfo.rowIndex].cells[cellInfo.colIndex];
       const blockIdx = tableCell.blocks.findIndex(b => b.id === pos.blockId);
       if (blockIdx + 1 < tableCell.blocks.length) {
-        return { blockId: tableCell.blocks[blockIdx + 1].id, offset: 0 };
+        const nextBlock = tableCell.blocks[blockIdx + 1];
+        // If next block is a nested table, enter its first cell
+        if (nextBlock.type === 'table' && nextBlock.tableData) {
+          return { blockId: nextBlock.tableData.rows[0].cells[0].blocks[0].id, offset: 0 };
+        }
+        return { blockId: nextBlock.id, offset: 0 };
       }
       return pos; // Clamp at cell end
     }

--- a/packages/docs/test/model/nested-table.test.ts
+++ b/packages/docs/test/model/nested-table.test.ts
@@ -92,15 +92,14 @@ describe('Nested table block lookup', () => {
     const map = buildParentMapRecursive(doc, outerTableId);
     doc.setBlockParentMap(map);
 
-    const innerTableId = doc.insertTableInCell(cellBlock.id, 2, 2);
+    const innerBlock = doc.insertTableInCell(cellBlock.id, 2, 2);
 
     const cell = doc.getBlock(outerTableId).tableData!.rows[0].cells[0];
     expect(cell.blocks).toHaveLength(2);
-    const innerBlock = cell.blocks.find((b) => b.id === innerTableId);
-    expect(innerBlock).toBeDefined();
-    expect(innerBlock!.type).toBe('table');
-    expect(innerBlock!.tableData!.rows).toHaveLength(2);
-    expect(innerBlock!.tableData!.rows[0].cells).toHaveLength(2);
+    expect(cell.blocks.find((b) => b.id === innerBlock.id)).toBeDefined();
+    expect(innerBlock.type).toBe('table');
+    expect(innerBlock.tableData!.rows).toHaveLength(2);
+    expect(innerBlock.tableData!.rows[0].cells).toHaveLength(2);
   });
 
   it('should insert and retrieve text in a nested table cell', () => {
@@ -165,20 +164,20 @@ describe('Nested table integration', () => {
     const cellBlock = outerBlock.tableData!.rows[0].cells[0].blocks[0];
     const map = buildParentMapRecursive(doc, outerTableId);
     doc.setBlockParentMap(map);
-    const innerTableId = doc.insertTableInCell(cellBlock.id, 2, 2);
+    const innerTable = doc.insertTableInCell(cellBlock.id, 2, 2);
 
     // Rebuild the parent map to include the inner table's blocks
     const map2 = buildParentMapRecursive(doc, outerTableId);
     doc.setBlockParentMap(map2);
 
     // Insert row in inner table
-    doc.insertRow(innerTableId, 1);
-    const updatedInner = doc.getBlock(innerTableId);
+    doc.insertRow(innerTable.id, 1);
+    const updatedInner = doc.getBlock(innerTable.id);
     expect(updatedInner.tableData!.rows).toHaveLength(3);
 
     // Insert column in inner table
-    doc.insertColumn(innerTableId, 1);
-    expect(doc.getBlock(innerTableId).tableData!.columnWidths).toHaveLength(3);
+    doc.insertColumn(innerTable.id, 1);
+    expect(doc.getBlock(innerTable.id).tableData!.columnWidths).toHaveLength(3);
   });
 
   it('should support merge/split in inner table', () => {
@@ -190,7 +189,7 @@ describe('Nested table integration', () => {
     const cellBlock = outerBlock.tableData!.rows[0].cells[0].blocks[0];
     const map = buildParentMapRecursive(doc, outerTableId);
     doc.setBlockParentMap(map);
-    const innerTableId = doc.insertTableInCell(cellBlock.id, 3, 3);
+    const innerTable = doc.insertTableInCell(cellBlock.id, 3, 3);
 
     // Rebuild the parent map
     const map2 = buildParentMapRecursive(doc, outerTableId);
@@ -201,14 +200,14 @@ describe('Nested table integration', () => {
       start: { rowIndex: 0, colIndex: 0 },
       end: { rowIndex: 1, colIndex: 1 },
     };
-    doc.mergeCells(innerTableId, mergeRange);
-    const updatedInner = doc.getBlock(innerTableId);
+    doc.mergeCells(innerTable.id, mergeRange);
+    const updatedInner = doc.getBlock(innerTable.id);
     expect(updatedInner.tableData!.rows[0].cells[0].colSpan).toBe(2);
     expect(updatedInner.tableData!.rows[0].cells[0].rowSpan).toBe(2);
 
     // Split the merged cell
-    doc.splitCell(innerTableId, { rowIndex: 0, colIndex: 0 });
-    const afterSplit = doc.getBlock(innerTableId);
+    doc.splitCell(innerTable.id, { rowIndex: 0, colIndex: 0 });
+    const afterSplit = doc.getBlock(innerTable.id);
     expect(afterSplit.tableData!.rows[0].cells[0].colSpan).toBeUndefined();
   });
 
@@ -221,24 +220,22 @@ describe('Nested table integration', () => {
     const outerCellBlock = outerBlock.tableData!.rows[0].cells[0].blocks[0];
     const map = buildParentMapRecursive(doc, outerTableId);
     doc.setBlockParentMap(map);
-    const innerTableId = doc.insertTableInCell(outerCellBlock.id, 2, 2);
+    const innerTable = doc.insertTableInCell(outerCellBlock.id, 2, 2);
 
     // Rebuild map to include inner table's blocks
     const map2 = buildParentMapRecursive(doc, outerTableId);
     doc.setBlockParentMap(map2);
 
     // Insert innermost table into inner cell (0,0)
-    const innerBlock = doc.getBlock(innerTableId);
-    const innerCellBlock = innerBlock.tableData!.rows[0].cells[0].blocks[0];
-    const innermostTableId = doc.insertTableInCell(innerCellBlock.id, 2, 2);
+    const innerCellBlock = innerTable.tableData!.rows[0].cells[0].blocks[0];
+    const innermostTable = doc.insertTableInCell(innerCellBlock.id, 2, 2);
 
     // Rebuild map again to include innermost table's blocks
     const map3 = buildParentMapRecursive(doc, outerTableId);
     doc.setBlockParentMap(map3);
 
     // Insert text in innermost cell (0,0)
-    const innermostBlock = doc.getBlock(innermostTableId);
-    const innermostCellBlock = innermostBlock.tableData!.rows[0].cells[0].blocks[0];
+    const innermostCellBlock = innermostTable.tableData!.rows[0].cells[0].blocks[0];
     doc.insertText({ blockId: innermostCellBlock.id, offset: 0 }, 'Deep!');
     const found = doc.getBlock(innermostCellBlock.id);
     expect(found.inlines.map((i) => i.text).join('')).toBe('Deep!');

--- a/packages/docs/test/model/nested-table.test.ts
+++ b/packages/docs/test/model/nested-table.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { Doc } from '../../src/model/document.js';
+import type { BlockCellInfo, TableData } from '../../src/model/types.js';
+import { createTableBlock } from '../../src/model/types.js';
+
+/**
+ * Build a BlockParentMap that recursively walks nested tables,
+ * so inner blocks map to their direct parent table.
+ */
+function buildParentMapRecursive(
+  doc: Doc,
+  tableBlockId: string,
+): Map<string, BlockCellInfo> {
+  const map = new Map<string, BlockCellInfo>();
+  function walk(tblId: string, tableData: TableData) {
+    for (let r = 0; r < tableData.rows.length; r++) {
+      for (let c = 0; c < tableData.rows[r].cells.length; c++) {
+        const cell = tableData.rows[r].cells[c];
+        for (const b of cell.blocks) {
+          map.set(b.id, { tableBlockId: tblId, rowIndex: r, colIndex: c });
+          if (b.type === 'table' && b.tableData) {
+            walk(b.id, b.tableData);
+          }
+        }
+      }
+    }
+  }
+  const block = doc.getBlock(tableBlockId);
+  if (block.tableData) walk(tableBlockId, block.tableData);
+  return map;
+}
+
+describe('Nested table block lookup', () => {
+  /**
+   * Helper: create a doc with a top-level table and nest an inner table
+   * inside cell (0,0) of the outer table.
+   * Returns { doc, outerTableId, innerTableId }.
+   */
+  function createNestedTableDoc() {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+
+    // Manually place an inner table into cell (0,0) of the outer table
+    const outerBlock = doc.getBlock(outerTableId);
+    const innerTable = createTableBlock(2, 2);
+    outerBlock.tableData!.rows[0].cells[0].blocks.push(innerTable);
+
+    // Build recursive parent map
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+
+    return { doc, outerTableId, innerTableId: innerTable.id };
+  }
+
+  it('should find a block inside a nested table via getBlock()', () => {
+    const { doc, innerTableId } = createNestedTableDoc();
+
+    // Get a block inside the inner table's cell (0,0)
+    const innerTable = doc.getBlock(innerTableId);
+    expect(innerTable.type).toBe('table');
+    expect(innerTable.tableData).toBeDefined();
+
+    const innerCellBlock = innerTable.tableData!.rows[0].cells[0].blocks[0];
+    const found = doc.getBlock(innerCellBlock.id);
+    expect(found).toBeDefined();
+    expect(found.id).toBe(innerCellBlock.id);
+  });
+
+  it('should map inner blocks to their direct parent table in BlockParentMap', () => {
+    const { doc, outerTableId, innerTableId } = createNestedTableDoc();
+    const map = doc.blockParentMap;
+
+    // The inner table block itself should map to the outer table
+    const innerTableInfo = map.get(innerTableId);
+    expect(innerTableInfo).toBeDefined();
+    expect(innerTableInfo!.tableBlockId).toBe(outerTableId);
+
+    // A block inside the inner table should map to the inner table
+    const innerTable = doc.getBlock(innerTableId);
+    const innerCellBlock = innerTable.tableData!.rows[0].cells[0].blocks[0];
+    const innerCellInfo = map.get(innerCellBlock.id);
+    expect(innerCellInfo).toBeDefined();
+    expect(innerCellInfo!.tableBlockId).toBe(innerTableId);
+  });
+
+  it('should insert and retrieve text in a nested table cell', () => {
+    const { doc, innerTableId } = createNestedTableDoc();
+
+    const innerTable = doc.getBlock(innerTableId);
+    const innerCellBlock = innerTable.tableData!.rows[0].cells[0].blocks[0];
+
+    doc.insertText({ blockId: innerCellBlock.id, offset: 0 }, 'Nested');
+
+    // Re-fetch after mutation and verify
+    const updated = doc.getBlock(innerCellBlock.id);
+    const text = updated.inlines.map((i) => i.text).join('');
+    expect(text).toBe('Nested');
+  });
+});

--- a/packages/docs/test/model/nested-table.test.ts
+++ b/packages/docs/test/model/nested-table.test.ts
@@ -83,6 +83,25 @@ describe('Nested table block lookup', () => {
     expect(innerCellInfo!.tableBlockId).toBe(innerTableId);
   });
 
+  it('should insert a nested table into a cell via insertTableInCell', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const cellBlock = outerBlock.tableData!.rows[0].cells[0].blocks[0];
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+
+    const innerTableId = doc.insertTableInCell(cellBlock.id, 2, 2);
+
+    const cell = doc.getBlock(outerTableId).tableData!.rows[0].cells[0];
+    expect(cell.blocks).toHaveLength(2);
+    const innerBlock = cell.blocks.find((b) => b.id === innerTableId);
+    expect(innerBlock).toBeDefined();
+    expect(innerBlock!.type).toBe('table');
+    expect(innerBlock!.tableData!.rows).toHaveLength(2);
+    expect(innerBlock!.tableData!.rows[0].cells).toHaveLength(2);
+  });
+
   it('should insert and retrieve text in a nested table cell', () => {
     const { doc, innerTableId } = createNestedTableDoc();
 

--- a/packages/docs/test/model/nested-table.test.ts
+++ b/packages/docs/test/model/nested-table.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { Doc } from '../../src/model/document.js';
 import type { BlockCellInfo, TableData } from '../../src/model/types.js';
 import { createTableBlock } from '../../src/model/types.js';
+import type { CellRange } from '../../src/model/types.js';
 
 /**
  * Build a BlockParentMap that recursively walks nested tables,
@@ -151,5 +152,95 @@ describe('Nested table navigation context', () => {
     expect(info!.tableBlockId).toBe(outerTableId);
     expect(info!.rowIndex).toBe(0);
     expect(info!.colIndex).toBe(0);
+  });
+});
+
+describe('Nested table integration', () => {
+  it('should support row/column operations on inner table', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+
+    // Insert inner table into cell (0,0) of outer table via insertTableInCell
+    const outerBlock = doc.getBlock(outerTableId);
+    const cellBlock = outerBlock.tableData!.rows[0].cells[0].blocks[0];
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+    const innerTableId = doc.insertTableInCell(cellBlock.id, 2, 2);
+
+    // Rebuild the parent map to include the inner table's blocks
+    const map2 = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map2);
+
+    // Insert row in inner table
+    doc.insertRow(innerTableId, 1);
+    const updatedInner = doc.getBlock(innerTableId);
+    expect(updatedInner.tableData!.rows).toHaveLength(3);
+
+    // Insert column in inner table
+    doc.insertColumn(innerTableId, 1);
+    expect(doc.getBlock(innerTableId).tableData!.columnWidths).toHaveLength(3);
+  });
+
+  it('should support merge/split in inner table', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+
+    // Insert inner 3x3 table into cell (0,0) of outer table
+    const outerBlock = doc.getBlock(outerTableId);
+    const cellBlock = outerBlock.tableData!.rows[0].cells[0].blocks[0];
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+    const innerTableId = doc.insertTableInCell(cellBlock.id, 3, 3);
+
+    // Rebuild the parent map
+    const map2 = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map2);
+
+    // Merge cells (0,0)-(1,1) in inner table
+    const mergeRange: CellRange = {
+      start: { rowIndex: 0, colIndex: 0 },
+      end: { rowIndex: 1, colIndex: 1 },
+    };
+    doc.mergeCells(innerTableId, mergeRange);
+    const updatedInner = doc.getBlock(innerTableId);
+    expect(updatedInner.tableData!.rows[0].cells[0].colSpan).toBe(2);
+    expect(updatedInner.tableData!.rows[0].cells[0].rowSpan).toBe(2);
+
+    // Split the merged cell
+    doc.splitCell(innerTableId, { rowIndex: 0, colIndex: 0 });
+    const afterSplit = doc.getBlock(innerTableId);
+    expect(afterSplit.tableData!.rows[0].cells[0].colSpan).toBeUndefined();
+  });
+
+  it('should support text editing in deeply nested table (2 levels)', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+
+    // Insert inner table into outer cell (0,0)
+    const outerBlock = doc.getBlock(outerTableId);
+    const outerCellBlock = outerBlock.tableData!.rows[0].cells[0].blocks[0];
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+    const innerTableId = doc.insertTableInCell(outerCellBlock.id, 2, 2);
+
+    // Rebuild map to include inner table's blocks
+    const map2 = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map2);
+
+    // Insert innermost table into inner cell (0,0)
+    const innerBlock = doc.getBlock(innerTableId);
+    const innerCellBlock = innerBlock.tableData!.rows[0].cells[0].blocks[0];
+    const innermostTableId = doc.insertTableInCell(innerCellBlock.id, 2, 2);
+
+    // Rebuild map again to include innermost table's blocks
+    const map3 = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map3);
+
+    // Insert text in innermost cell (0,0)
+    const innermostBlock = doc.getBlock(innermostTableId);
+    const innermostCellBlock = innermostBlock.tableData!.rows[0].cells[0].blocks[0];
+    doc.insertText({ blockId: innermostCellBlock.id, offset: 0 }, 'Deep!');
+    const found = doc.getBlock(innermostCellBlock.id);
+    expect(found.inlines.map((i) => i.text).join('')).toBe('Deep!');
   });
 });

--- a/packages/docs/test/model/nested-table.test.ts
+++ b/packages/docs/test/model/nested-table.test.ts
@@ -116,3 +116,40 @@ describe('Nested table block lookup', () => {
     expect(text).toBe('Nested');
   });
 });
+
+describe('Nested table navigation context', () => {
+  it('getCellInfo should return inner table cell for inner block', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const innerTable = createTableBlock(2, 2);
+    outerBlock.tableData!.rows[0].cells[0].blocks.push(innerTable);
+
+    const map = buildParentMapRecursive(doc, outerTableId);
+    doc.setBlockParentMap(map);
+
+    // Inner cell (1,1) paragraph
+    const innerCellBlock = innerTable.tableData!.rows[1].cells[1].blocks[0];
+    const info = map.get(innerCellBlock.id);
+    expect(info).toBeDefined();
+    expect(info!.tableBlockId).toBe(innerTable.id);
+    expect(info!.rowIndex).toBe(1);
+    expect(info!.colIndex).toBe(1);
+  });
+
+  it('getCellInfo for inner table block itself should return outer cell', () => {
+    const doc = Doc.create();
+    const outerTableId = doc.insertTable(0, 2, 2);
+    const outerBlock = doc.getBlock(outerTableId);
+    const innerTable = createTableBlock(2, 2);
+    outerBlock.tableData!.rows[0].cells[0].blocks.push(innerTable);
+
+    const map = buildParentMapRecursive(doc, outerTableId);
+
+    const info = map.get(innerTable.id);
+    expect(info).toBeDefined();
+    expect(info!.tableBlockId).toBe(outerTableId);
+    expect(info!.rowIndex).toBe(0);
+    expect(info!.colIndex).toBe(0);
+  });
+});

--- a/packages/docs/test/view/nested-table-layout.test.ts
+++ b/packages/docs/test/view/nested-table-layout.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { computeTableLayout } from '../../src/view/table-layout.js';
+import { createTableBlock, createTableCell } from '../../src/model/types.js';
+import type { TableData } from '../../src/model/types.js';
+
+function stubCtx(): CanvasRenderingContext2D {
+  return {
+    measureText: (text: string) => ({ width: text.length * 8 }),
+    font: '',
+  } as unknown as CanvasRenderingContext2D;
+}
+
+function makeNestedTableData(): { outer: TableData; innerBlockId: string } {
+  const innerTable = createTableBlock(2, 2);
+  const outerCell00 = createTableCell();
+  outerCell00.blocks.push(innerTable);
+  const outerCell01 = createTableCell();
+  const outerCell10 = createTableCell();
+  const outerCell11 = createTableCell();
+  const outer: TableData = {
+    rows: [
+      { cells: [outerCell00, outerCell01] },
+      { cells: [outerCell10, outerCell11] },
+    ],
+    columnWidths: [0.5, 0.5],
+  };
+  return { outer, innerBlockId: innerTable.id };
+}
+
+describe('Nested table layout', () => {
+  it('should compute layout for a table containing a nested table', () => {
+    const { outer, innerBlockId } = makeNestedTableData();
+    const ctx = stubCtx();
+    const layout = computeTableLayout(outer, 'outer-table', ctx, 400);
+    // Cell (0,0) should be taller than cell (0,1) due to the nested table
+    expect(layout.cells[0][0].height).toBeGreaterThan(layout.cells[0][1].height);
+    // The inner table block should be in blockParentMap
+    const innerTableInfo = layout.blockParentMap.get(innerBlockId);
+    expect(innerTableInfo).toBeDefined();
+    expect(innerTableInfo!.tableBlockId).toBe('outer-table');
+    expect(innerTableInfo!.rowIndex).toBe(0);
+    expect(innerTableInfo!.colIndex).toBe(0);
+  });
+
+  it('should include inner table cell blocks in blockParentMap', () => {
+    const { outer } = makeNestedTableData();
+    const innerTable = outer.rows[0].cells[0].blocks[1]; // index 1 = nested table
+    const innerCellBlockId = innerTable.tableData!.rows[0].cells[0].blocks[0].id;
+    const ctx = stubCtx();
+    const layout = computeTableLayout(outer, 'outer-table', ctx, 400);
+    const info = layout.blockParentMap.get(innerCellBlockId);
+    expect(info).toBeDefined();
+    expect(info!.tableBlockId).toBe(innerTable.id);
+  });
+
+  it('should produce a LayoutLine with nestedTable for the table block', () => {
+    const { outer } = makeNestedTableData();
+    const ctx = stubCtx();
+    const layout = computeTableLayout(outer, 'outer-table', ctx, 400);
+    const cell00 = layout.cells[0][0];
+    const hasNestedTableLine = cell00.lines.some((line) => line.nestedTable !== undefined);
+    expect(hasNestedTableLine).toBe(true);
+  });
+});

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -878,47 +878,126 @@ export class YorkieDocStore implements DocStore {
   // Table granular updates
   // -----------------------------------------------------------------------
 
+  /**
+   * Resolve a table block's tree path. For top-level tables, returns a
+   * single-element array with the tree-adjusted index. For nested tables
+   * (inside a cell), returns the full path segments through the tree
+   * hierarchy: [parentTableIdx, rowIdx, cellIdx, blockIdx, ...].
+   */
+  private resolveTableTreePath(tableBlockId: string): number[] {
+    const currentDoc = this.getDocument();
+
+    // Check if it's a top-level block
+    const bodyIdx = currentDoc.blocks.findIndex((b) => b.id === tableBlockId);
+    if (bodyIdx !== -1) {
+      return [bodyIdx + this.bodyTreeOffset(currentDoc)];
+    }
+
+    // Nested table — recursively search through the document structure
+    function findInBlocks(blocks: Block[], targetId: string, basePath: number[]): number[] | null {
+      for (let i = 0; i < blocks.length; i++) {
+        const block = blocks[i];
+        if (block.id === targetId) {
+          return [...basePath, i];
+        }
+        if (block.type === 'table' && block.tableData) {
+          for (let r = 0; r < block.tableData.rows.length; r++) {
+            for (let c = 0; c < block.tableData.rows[r].cells.length; c++) {
+              const cell = block.tableData.rows[r].cells[c];
+              const result = findInBlocks(cell.blocks, targetId, [...basePath, i, r, c]);
+              if (result) return result;
+            }
+          }
+        }
+      }
+      return null;
+    }
+
+    const offset = this.bodyTreeOffset(currentDoc);
+    const path = findInBlocks(currentDoc.blocks, tableBlockId, []);
+
+    if (!path) {
+      throw new Error(`Table block not found: ${tableBlockId}`);
+    }
+
+    // Add the body tree offset to the first segment
+    path[0] += offset;
+    return path;
+  }
+
   /** Returns body array index and tree-adjusted index for a table block. */
   private findTableIndex(tableBlockId: string): { bodyIdx: number; treeIdx: number } {
-    const currentDoc = this.getDocument();
-    const index = currentDoc.blocks.findIndex((b) => b.id === tableBlockId);
-    if (index === -1) throw new Error(`Table block not found: ${tableBlockId}`);
-    return { bodyIdx: index, treeIdx: index + this.bodyTreeOffset(currentDoc) };
+    const path = this.resolveTableTreePath(tableBlockId);
+    if (path.length === 1) {
+      const currentDoc = this.getDocument();
+      return { bodyIdx: path[0] - this.bodyTreeOffset(currentDoc), treeIdx: path[0] };
+    }
+    throw new Error(
+      `Cannot use findTableIndex for nested table ${tableBlockId}; use resolveTableTreePath instead`,
+    );
+  }
+
+  /**
+   * Resolve the table Block from the cached document using the tree path
+   * returned by resolveTableTreePath(). For top-level tables, this indexes
+   * into `doc.blocks`. For nested tables, it walks through the table
+   * hierarchy (row → cell → blocks).
+   */
+  private resolveTableBlock(treePath: number[], doc: Document): Block {
+    const offset = this.bodyTreeOffset(doc);
+    const bodyIdx = treePath[0] - offset;
+    let block = doc.blocks[bodyIdx];
+    // Walk deeper for nested tables: path segments after the first are
+    // [rowIdx, colIdx, blockIdx] triplets leading to the target block.
+    for (let i = 1; i < treePath.length; i += 3) {
+      const r = treePath[i];
+      const c = treePath[i + 1];
+      const b = treePath[i + 2];
+      block = block.tableData!.rows[r].cells[c].blocks[b];
+    }
+    return block;
   }
 
   insertTableRow(tableBlockId: string, atIndex: number, row: TableRow): void {
-    const { bodyIdx, treeIdx } = this.findTableIndex(tableBlockId);
+    const tablePath = this.resolveTableTreePath(tableBlockId);
     const rowNode = buildRowNode(row);
     this.doc.update((root) => {
-      root.content.editByPath([treeIdx, atIndex], [treeIdx, atIndex], rowNode);
+      root.content.editByPath([...tablePath, atIndex], [...tablePath, atIndex], rowNode);
     });
     const currentDoc = this.getDocument();
-    currentDoc.blocks[bodyIdx].tableData!.rows.splice(atIndex, 0, row);
+    const block = this.resolveTableBlock(tablePath, currentDoc);
+    block.tableData!.rows.splice(atIndex, 0, row);
     this.cachedDoc = currentDoc;
     this.dirty = false;
   }
 
   deleteTableRow(tableBlockId: string, rowIndex: number): void {
-    const { treeIdx, bodyIdx } = this.findTableIndex(tableBlockId);
+    const tablePath = this.resolveTableTreePath(tableBlockId);
     this.doc.update((root) => {
-      root.content.editByPath([treeIdx, rowIndex], [treeIdx, rowIndex + 1]);
+      root.content.editByPath([...tablePath, rowIndex], [...tablePath, rowIndex + 1]);
     });
     const currentDoc = this.getDocument();
-    currentDoc.blocks[bodyIdx].tableData!.rows.splice(rowIndex, 1);
+    const block = this.resolveTableBlock(tablePath, currentDoc);
+    block.tableData!.rows.splice(rowIndex, 1);
     this.cachedDoc = currentDoc;
     this.dirty = false;
   }
 
   insertTableColumn(tableBlockId: string, atIndex: number, cells: TableCell[]): void {
-    const { bodyIdx, treeIdx } = this.findTableIndex(tableBlockId);
+    const tablePath = this.resolveTableTreePath(tableBlockId);
     this.doc.update((root) => {
       const tree = root.content;
       for (let r = 0; r < cells.length; r++) {
-        tree.editByPath([treeIdx, r, atIndex], [treeIdx, r, atIndex], buildCellNode(cells[r]));
+        tree.editByPath(
+          [...tablePath, r, atIndex],
+          [...tablePath, r, atIndex],
+          buildCellNode(cells[r]),
+        );
       }
     });
     const currentDoc = this.getDocument();
-    const td = currentDoc.blocks[bodyIdx].tableData!;
+    const block = this.resolveTableBlock(tablePath, currentDoc);
+    const td = block.tableData!;
     td.rows.forEach((row, i) => {
       row.cells.splice(atIndex, 0, cells[i]);
     });
@@ -927,16 +1006,17 @@ export class YorkieDocStore implements DocStore {
   }
 
   deleteTableColumn(tableBlockId: string, colIndex: number): void {
-    const { bodyIdx, treeIdx } = this.findTableIndex(tableBlockId);
+    const tablePath = this.resolveTableTreePath(tableBlockId);
     const currentDoc = this.getDocument();
-    const rowCount = currentDoc.blocks[bodyIdx].tableData!.rows.length;
+    const block = this.resolveTableBlock(tablePath, currentDoc);
+    const rowCount = block.tableData!.rows.length;
     this.doc.update((root) => {
       const tree = root.content;
       for (let r = 0; r < rowCount; r++) {
-        tree.editByPath([treeIdx, r, colIndex], [treeIdx, r, colIndex + 1]);
+        tree.editByPath([...tablePath, r, colIndex], [...tablePath, r, colIndex + 1]);
       }
     });
-    currentDoc.blocks[bodyIdx].tableData!.rows.forEach((row) => {
+    block.tableData!.rows.forEach((row) => {
       row.cells.splice(colIndex, 1);
     });
     this.cachedDoc = currentDoc;
@@ -946,25 +1026,26 @@ export class YorkieDocStore implements DocStore {
   updateTableCell(
     tableBlockId: string, rowIndex: number, colIndex: number, cell: TableCell,
   ): void {
-    const { bodyIdx, treeIdx } = this.findTableIndex(tableBlockId);
+    const tablePath = this.resolveTableTreePath(tableBlockId);
     const cellNode = buildCellNode(cell);
     this.doc.update((root) => {
       root.content.editByPath(
-        [treeIdx, rowIndex, colIndex],
-        [treeIdx, rowIndex, colIndex + 1],
+        [...tablePath, rowIndex, colIndex],
+        [...tablePath, rowIndex, colIndex + 1],
         cellNode,
       );
     });
     const currentDoc = this.getDocument();
-    currentDoc.blocks[bodyIdx].tableData!.rows[rowIndex].cells[colIndex] = cell;
+    const block = this.resolveTableBlock(tablePath, currentDoc);
+    block.tableData!.rows[rowIndex].cells[colIndex] = cell;
     this.cachedDoc = currentDoc;
     this.dirty = false;
   }
 
   updateTableAttrs(tableBlockId: string, attrs: { cols: number[]; rowHeights?: (number | undefined)[] }): void {
-    const { bodyIdx, treeIdx } = this.findTableIndex(tableBlockId);
+    const tablePath = this.resolveTableTreePath(tableBlockId);
     const currentDoc = this.getDocument();
-    const block = currentDoc.blocks[bodyIdx];
+    const block = this.resolveTableBlock(tablePath, currentDoc);
     block.tableData!.columnWidths = attrs.cols;
     if (attrs.rowHeights !== undefined) {
       block.tableData!.rowHeights = attrs.rowHeights;
@@ -972,7 +1053,10 @@ export class YorkieDocStore implements DocStore {
     this.doc.update((root) => {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
-      tree.editByPath([treeIdx], [treeIdx + 1], buildBlockNode(block));
+      // For the replace range, increment the last path segment by 1
+      const endPath = [...tablePath];
+      endPath[endPath.length - 1] += 1;
+      tree.editByPath(tablePath, endPath, buildBlockNode(block));
     });
     this.cachedDoc = currentDoc;
     this.dirty = false;


### PR DESCRIPTION
## Summary

- Add recursive table nesting in the Docs editor — cells can contain tables at any depth
- Full editing support: click, cursor, selection, arrow navigation, Tab navigation, image resize
- Character-level word break prevents text overflow in narrow cells
- CRDT path resolution for Yorkie real-time collaboration with nested tables
- Design doc, unit tests, and integration tests included

## Changes (15 files, +1607/-279)

**Core engine (data model, layout, rendering):**
- `document.ts` — recursive `getBlock()`/`findBlock()`, `insertTableInCell()`, `deleteTableInCell()`
- `table-layout.ts` — recursive `layoutCellBlocks()`, `resolveNestedTableLayout()` helper, character-level word break
- `table-renderer.ts` — recursive rendering for nested table content/backgrounds
- `layout.ts` — `LayoutLine.nestedTable` field
- `memory.ts` — recursive block lookup in `MemDocStore`

**Interaction (click, cursor, selection, navigation):**
- `text-editor.ts` — mouse click resolution, drag selection, arrow key navigation (all 4 directions), cell exit/entry for nested tables
- `peer-cursor.ts` — cursor pixel position via nesting chain walk
- `selection.ts` — selection normalization, line-by-line selection rects, cell-range highlight for nested tables
- `image-selection-overlay.ts` — image rect collection for nested cells
- `editor.ts` — insert/delete table in cells, image resize drag lookup

**CRDT & design:**
- `yorkie-doc-store.ts` — `resolveTableTreePath()` for nested table Yorkie Tree paths
- Design docs updated (`docs-tables.md`, `docs-table-crdt.md`, `docs-nested-tables.md`)

## Test plan
- [x] Insert table inside a table cell via toolbar
- [x] Click inside nested table cells — cursor appears at correct position
- [x] Drag selection within nested cell — line-by-line highlight
- [x] Double-click word selection in nested cell
- [x] Arrow keys (all 4 directions) navigate into/out of nested tables
- [x] Tab key cycles through inner table cells, then exits to outer table
- [x] Cell-range selection (drag across inner cells) highlights inner cells only
- [x] Image in nested cell — click shows resize handles
- [x] Long word in narrow nested cell — wraps at character boundary
- [x] Undo/redo works after nested table operations
- [x] `pnpm verify:fast` passes (558 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Docs editor now supports inserting tables within table cells—create nested tables at any depth.
  * Full editing, navigation, and rendering for nested tables with seamless synchronization.

* **Tests**
  * Added comprehensive test coverage for nested table operations and layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->