### PR TITLE
Import nested tables from .docx as actual table blocks

### DIFF
--- a/packages/docs/src/import/docx-importer.ts
+++ b/packages/docs/src/import/docx-importer.ts
@@ -99,7 +99,7 @@ export class DocxImporter {
       if (el.localName === 'p') {
         blocks.push(DocxImporter.convertParagraph(el, imageUrls));
       } else if (el.localName === 'tbl') {
-        blocks.push(DocxImporter.convertTable(el, imageUrls, false));
+        blocks.push(DocxImporter.convertTable(el, imageUrls));
       } else if (el.localName === 'sectPr') {
         pageSetup = parsePageSetup(el);
         sectPrEl = el;
@@ -213,33 +213,7 @@ export class DocxImporter {
   private static convertTable(
     tblEl: Element,
     imageUrls: Map<string, ResolvedImage>,
-    isNested: boolean,
   ): Block {
-    // If nested, flatten to a paragraph with text content. Walk only direct
-    // child <w:tr> / <w:tc> so that deeply nested tables don't bleed their
-    // rows/cells into the outer flattened text.
-    if (isNested) {
-      const texts: string[] = [];
-      for (let i = 0; i < tblEl.childNodes.length; i++) {
-        const trNode = tblEl.childNodes[i];
-        if (trNode.nodeType !== 1 || (trNode as Element).localName !== 'tr') continue;
-        const trEl = trNode as Element;
-        const rowTexts: string[] = [];
-        for (let j = 0; j < trEl.childNodes.length; j++) {
-          const tcNode = trEl.childNodes[j];
-          if (tcNode.nodeType !== 1 || (tcNode as Element).localName !== 'tc') continue;
-          rowTexts.push(DocxImporter.extractText(tcNode as Element));
-        }
-        texts.push(rowTexts.join(' | '));
-      }
-      return {
-        id: generateBlockId(),
-        type: 'paragraph',
-        inlines: [{ text: texts.join('\n'), style: {} }],
-        style: { ...DEFAULT_BLOCK_STYLE },
-      };
-    }
-
     // Parse grid columns for widths. The walk is direct-child only:
     // getElementsByTagNameNS recurses into nested tables, which used to
     // inflate the outer column count with the nested grids (a 1-col
@@ -395,8 +369,7 @@ export class DocxImporter {
           if (childEl.localName === 'p') {
             cellBlocks.push(DocxImporter.convertParagraph(childEl, imageUrls));
           } else if (childEl.localName === 'tbl') {
-            // Nested table → flatten to text
-            cellBlocks.push(DocxImporter.convertTable(childEl, imageUrls, true));
+            cellBlocks.push(DocxImporter.convertTable(childEl, imageUrls));
           }
         }
         if (cellBlocks.length === 0) {
@@ -490,15 +463,6 @@ export class DocxImporter {
       }
     }
     return null;
-  }
-
-  private static extractText(el: Element): string {
-    const texts: string[] = [];
-    const tEls = el.getElementsByTagNameNS(W, 't');
-    for (let i = 0; i < tEls.length; i++) {
-      texts.push(tEls[i].textContent || '');
-    }
-    return texts.join('');
   }
 
   /**

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -673,9 +673,9 @@ describe('DocxImporter', () => {
     expect(group2Top.blocks[0].inlines[0].text).toBe('Group2Top');
   });
 
-  it('should not duplicate content when flattening deeply nested tables', async () => {
+  it('should import deeply nested tables preserving structure', async () => {
     // Outer table with a nested table that itself contains another nested
-    // table. The flattened outer cell should contain "DEEP" exactly once.
+    // table. Each level should be a real table block.
     const buffer = await createMinimalDocx(`
       <w:tbl>
         <w:tblGrid><w:gridCol w:w="8000"/></w:tblGrid>
@@ -697,14 +697,19 @@ describe('DocxImporter', () => {
       </w:tbl>
     `);
     const doc = await DocxImporter.import(buffer);
-    const table = doc.blocks[0];
-    expect(table.type).toBe('table');
-    const cellBlocks = table.tableData!.rows[0].cells[0].blocks;
-    const allText = cellBlocks.map((b) => b.inlines.map((i) => i.text).join('')).join('\n');
-    // "DEEP" should appear exactly once even though the inner flatten code
-    // used to recurse via getElementsByTagNameNS.
-    const occurrences = allText.split('DEEP').length - 1;
-    expect(occurrences).toBe(1);
+    const outerTable = doc.blocks[0];
+    expect(outerTable.type).toBe('table');
+    // Level 1: nested table inside outer cell
+    const level1Blocks = outerTable.tableData!.rows[0].cells[0].blocks;
+    const midTable = level1Blocks.find(b => b.type === 'table');
+    expect(midTable).toBeDefined();
+    // Level 2: nested table inside mid-level cell
+    const level2Blocks = midTable!.tableData!.rows[0].cells[0].blocks;
+    const innerTable = level2Blocks.find(b => b.type === 'table');
+    expect(innerTable).toBeDefined();
+    // Innermost cell contains "DEEP"
+    const deepText = innerTable!.tableData!.rows[0].cells[0].blocks[0].inlines[0].text;
+    expect(deepText).toBe('DEEP');
   });
 
   it('should drop pending image inlines when no uploader is supplied', async () => {
@@ -856,7 +861,7 @@ describe('DocxImporter', () => {
     expect(headerInline!.style.image!.src.startsWith('__pending__')).toBe(false);
   });
 
-  it('should flatten nested tables to text', async () => {
+  it('should import nested tables as actual table blocks', async () => {
     const buffer = await createMinimalDocx(`
       <w:tbl>
         <w:tblGrid><w:gridCol w:w="8000"/></w:tblGrid>
@@ -872,9 +877,13 @@ describe('DocxImporter', () => {
     `);
     const doc = await DocxImporter.import(buffer);
     expect(doc.blocks[0].type).toBe('table');
-    // Nested table is flattened — cell should contain a paragraph with "Nested"
+    // Nested table should be a table block inside the outer cell
     const cellBlocks = doc.blocks[0].tableData!.rows[0].cells[0].blocks;
-    const allText = cellBlocks.map(b => b.inlines.map(i => i.text).join('')).join('');
-    expect(allText).toContain('Nested');
+    const nestedTable = cellBlocks.find(b => b.type === 'table');
+    expect(nestedTable).toBeDefined();
+    expect(nestedTable!.tableData).toBeDefined();
+    expect(nestedTable!.tableData!.rows).toHaveLength(1);
+    const innerText = nestedTable!.tableData!.rows[0].cells[0].blocks[0].inlines[0].text;
+    expect(innerText).toBe('Nested');
   });
 });


### PR DESCRIPTION
## Summary
- Remove the `isNested` flattening logic in `DocxImporter.convertTable()` that converted nested `<w:tbl>` elements to plain text paragraphs
- Nested tables are now imported as real table blocks, preserving full document structure at any depth
- Remove unused `extractText()` helper that was only used for flattening
- Update tests to verify nested table structure is preserved

## Test plan
- [x] `pnpm verify:fast` passes
- [x] Import `~/Downloads/form.docx` and verify nested tables render correctly
- [x] Export document with nested tables and re-import to verify round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)