### PR TITLE
Use axis ID based selection for collaborative cursor tracking

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -21,6 +21,7 @@ Spreadsheet engine — data model, formulas, rendering, collaboration.
 | [collaboration.md](sheets/collaboration.md)                          | Yorkie collaboration — worksheet storage, structural concurrency, and test strategy              |
 | [datasource.md](sheets/datasource.md)                                | External PostgreSQL datasources, multi-tab documents, SQL editor, ReadOnlyStore                    |
 | [peer-cursor-labels.md](sheets/peer-cursor-labels.md)               | Peer cursor name labels — transient username tags on collaborative sheet cursors                  |
+| [axis-id-selection.md](sheets/axis-id-selection.md)                  | Axis ID based selection & presence — stable selection across remote structural edits              |
 
 ## Docs
 

--- a/docs/design/sheets/axis-id-selection.md
+++ b/docs/design/sheets/axis-id-selection.md
@@ -85,7 +85,7 @@ type UserPresence = {
 Axis ID ↔ visual coordinate conversion happens **only at the Store boundary**.
 The Sheet engine keeps using `Ref` internally.
 
-```
+```text
 Presence (axis ID)  ←→  Conversion Layer  ←→  Sheet Engine (Ref)  →  Canvas
 ```
 
@@ -103,7 +103,7 @@ Four conversion functions, placed in a new module
 
 #### Local selection → Presence
 
-```
+```text
 User clicks cell / drags range
   → Sheet.setActiveCell(ref)  &  Sheet.setRanges(ranges)
   → Store.updateSelection(
@@ -115,7 +115,7 @@ User clicks cell / drags range
 
 #### Remote structural edit → Local selection correction
 
-```
+```text
 Remote peer inserts row at index 3
   → Yorkie syncs: rowOrder changes (new ID spliced in)
   → reloadDimensions() called
@@ -128,7 +128,7 @@ Remote peer inserts row at index 3
 
 #### Peer cursor rendering
 
-```
+```text
 Peer presence received
   → SelectionPresence { activeCell: CellAnchor, ranges: RangeAnchor[] }
   → anchorToRef(activeCell, rowOrder, colOrder) → Ref

--- a/docs/design/sheets/axis-id-selection.md
+++ b/docs/design/sheets/axis-id-selection.md
@@ -1,0 +1,227 @@
+---
+title: axis-id-selection
+target-version: 0.3.3
+---
+
+# Axis ID Based Selection & Presence
+
+## Summary
+
+Replace coordinate-based selection (`Ref: {r, c}`, `Sref: "A5"`) in Yorkie
+presence with stable axis ID references (`CellAnchor: {rowId, colId}`). When
+remote peers insert or delete rows/columns, `rowOrder`/`colOrder` shift but
+axis IDs stay the same, so every client's selection automatically tracks the
+correct cell without any shift-correction logic.
+
+## Goals
+
+- Selection follows the intended cell across remote structural edits (row/column
+  insert, delete, move) without explicit shift logic.
+- Peer cursors show both active cell (border) and selected ranges (translucent
+  background), Google Sheets style.
+- Multi-range selection (Ctrl+click) is shared via presence.
+- Entire-row / entire-column selection is represented uniformly within the range
+  structure (no separate `selectionType` flag in presence).
+
+## Non-Goals
+
+- Changing how Sheet engine internals work — the engine continues to use `Ref`
+  for cell access, rendering, and formula evaluation.
+- Modifying cell data storage — cells are already keyed by axis IDs.
+
+## Proposal Details
+
+### New Types
+
+```typescript
+/**
+ * Stable cell reference using axis IDs instead of visual coordinates.
+ */
+type CellAnchor = {
+  rowId: string; // e.g. "r3k9a"
+  colId: string; // e.g. "cmfvz"
+};
+
+/**
+ * Stable range reference. A null field means "all" on that axis:
+ * - colId null → entire-row selection
+ * - rowId null → entire-column selection
+ * - both null  → select-all
+ */
+type RangeAnchor = {
+  startRowId: string | null;
+  startColId: string | null;
+  endRowId: string | null;
+  endColId: string | null;
+};
+
+/**
+ * Full selection state stored in Yorkie presence.
+ */
+type SelectionPresence = {
+  activeCell: CellAnchor;
+  ranges: RangeAnchor[]; // multi-select (Ctrl+click)
+};
+```
+
+### Presence Schema Change
+
+```typescript
+// Before
+type UserPresence = {
+  activeCell?: Sref;        // "A5"
+  activeTabId?: string;
+} & User;
+
+// After
+type UserPresence = {
+  selection?: SelectionPresence;
+  activeTabId?: string;
+} & User;
+```
+
+### Coordinate Conversion Layer
+
+Axis ID ↔ visual coordinate conversion happens **only at the Store boundary**.
+The Sheet engine keeps using `Ref` internally.
+
+```
+Presence (axis ID)  ←→  Conversion Layer  ←→  Sheet Engine (Ref)  →  Canvas
+```
+
+Four conversion functions, placed in a new module
+`packages/sheets/src/model/workbook/anchor-conversion.ts`:
+
+| Function | Input | Output | Description |
+|----------|-------|--------|-------------|
+| `anchorToRef` | `CellAnchor, rowOrder, colOrder` | `Ref \| null` | axis ID → visual position. Returns null if axis ID was deleted. |
+| `refToAnchor` | `Ref, rowOrder, colOrder` | `CellAnchor` | visual position → axis ID |
+| `rangeAnchorToRange` | `RangeAnchor, rowOrder, colOrder` | `Range \| null` | range conversion. null fields → 1 / max dimension. Returns null if both endpoints deleted. |
+| `rangeToRangeAnchor` | `Range, rowOrder, colOrder, selectionType` | `RangeAnchor` | range → anchor. Entire-row/col → null on the "all" axis. |
+
+### Data Flow
+
+#### Local selection → Presence
+
+```
+User clicks cell / drags range
+  → Sheet.setActiveCell(ref)  &  Sheet.setRanges(ranges)
+  → Store.updateSelection(
+      refToAnchor(activeCell),
+      ranges.map(r => rangeToRangeAnchor(r))
+    )
+  → Yorkie presence.set({ selection: { activeCell, ranges } })
+```
+
+#### Remote structural edit → Local selection correction
+
+```
+Remote peer inserts row at index 3
+  → Yorkie syncs: rowOrder changes (new ID spliced in)
+  → reloadDimensions() called
+  → Stored CellAnchor unchanged (still "r3k9a")
+  → anchorToRef("r3k9a", newRowOrder) → new Ref (e.g. {r:5} instead of {r:4})
+  → Sheet.activeCell = new Ref
+  → No explicit shift logic needed — the axis ID's position in rowOrder IS the
+    new coordinate
+```
+
+#### Peer cursor rendering
+
+```
+Peer presence received
+  → SelectionPresence { activeCell: CellAnchor, ranges: RangeAnchor[] }
+  → anchorToRef(activeCell, rowOrder, colOrder) → Ref
+  → rangeAnchorToRange(range, rowOrder, colOrder) → Range
+  → Render: active cell = colored border + name label
+  → Render: ranges = translucent background fill in peer color
+  → If axis ID not in rowOrder/colOrder → skip rendering (deleted)
+```
+
+### Deleted Axis ID Handling
+
+When a remote peer deletes a row/column that the local user has selected:
+
+1. `anchorToRef(anchor, rowOrder, colOrder)` returns `null`.
+2. Find the **previous visual index** of the deleted axis ID. Since the ID is
+   no longer in `rowOrder`, use a cached previous-order snapshot or track the
+   deletion index from the remote change event.
+3. Clamp to `Math.min(prevIndex, rowOrder.length)` to find the nearest valid
+   row.
+4. Update `activeCell` to the new axis ID at that clamped index.
+5. Push updated presence.
+
+For ranges, each endpoint is resolved independently. If an endpoint's axis ID
+is deleted, it snaps to the nearest valid position. If both endpoints are
+deleted, the range is dropped from the selection.
+
+### Sheet Engine Changes
+
+The Sheet class keeps `activeCell: Ref` and `ranges: Ranges` as-is. Changes:
+
+- **New field**: `private activeCellAnchor: CellAnchor` — the authoritative
+  selection stored as axis IDs. On every remote sync, this is re-resolved to
+  `Ref` via `anchorToRef()`.
+- **New field**: `private rangeAnchors: RangeAnchor[]` — same pattern for
+  ranges.
+- **setActiveCell(ref)**: updates both `this.activeCell` (Ref) and
+  `this.activeCellAnchor` (CellAnchor). Calls `store.updateSelection()`.
+- **Remove shift logic** in `shiftCells()` (lines 1105-1143 of sheet.ts): the
+  activeCell/range shift block becomes unnecessary because the anchor's position
+  is derived from `rowOrder` on every read.
+- **reloadDimensions()**: after reloading row/col order from store, re-resolve
+  `activeCellAnchor → activeCell` and `rangeAnchors → ranges`. This is where
+  the automatic correction happens.
+
+### Store Interface Changes
+
+```typescript
+interface Store {
+  // Replace updateActiveCell
+  updateSelection(activeCell: CellAnchor, ranges: RangeAnchor[]): void;
+
+  // Replace getPresences return type
+  getPresences(): Array<{
+    clientID: string;
+    presence: {
+      selection?: SelectionPresence;
+      username?: string;
+    };
+  }>;
+
+  // Expose axis orders for conversion
+  getRowOrder(): string[];
+  getColOrder(): string[];
+}
+```
+
+### Overlay Rendering Changes
+
+`overlay.ts` currently renders peer cursors as single-cell borders. Changes:
+
+- Accept `SelectionPresence` instead of `Sref` for each peer.
+- For `activeCell`: convert `CellAnchor → Ref`, draw colored border + name
+  label (existing logic, just different input).
+- For each `range` in `ranges`: convert `RangeAnchor → Range`, fill the range
+  area with the peer's color at ~10% opacity.
+- Skip peers whose `activeCell` axis ID is not found in current row/col order.
+
+### Migration / Backward Compatibility
+
+During rollout, peers may run old code that sets `activeCell: Sref` in presence
+instead of the new `selection: SelectionPresence`.
+
+- The new presence subscriber checks for both formats.
+- If `activeCell` is a string (old format), parse it as `Sref → Ref` directly
+  (existing behavior).
+- If `selection` exists (new format), use the axis ID conversion path.
+- Once all clients are updated, the old `activeCell` field can be removed.
+
+## Risks and Mitigation
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Presence payload size with many ranges | Increased sync traffic | Cap `ranges` array to a reasonable limit (e.g. 32). Multi-select beyond that is rare. |
+| `indexOf` on `rowOrder` for every render | O(n) per lookup on large sheets | Build a `Map<string, number>` index from `rowOrder` on change, not on every render. Already done for cell lookups in `getWorksheetEntries`. |
+| Deleted axis ID detection requires previous state | Complexity in tracking deletions | Cache previous `rowOrder` snapshot on each remote sync. Diff is cheap (array comparison). |
+| Mixed old/new client presence during rollout | Rendering glitches | Dual-format presence parsing with fallback. |

--- a/docs/design/sheets/axis-id-selection.md
+++ b/docs/design/sheets/axis-id-selection.md
@@ -143,17 +143,13 @@ Peer presence received
 When a remote peer deletes a row/column that the local user has selected:
 
 1. `anchorToRef(anchor, rowOrder, colOrder)` returns `null`.
-2. Find the **previous visual index** of the deleted axis ID. Since the ID is
-   no longer in `rowOrder`, use a cached previous-order snapshot or track the
-   deletion index from the remote change event.
-3. Clamp to `Math.min(prevIndex, rowOrder.length)` to find the nearest valid
-   row.
-4. Update `activeCell` to the new axis ID at that clamped index.
-5. Push updated presence.
+2. Active cell falls back to `{ r: 1, c: 1 }` and a new anchor is created
+   from that position.
+3. Repaired selection is republished to presence.
 
-For ranges, each endpoint is resolved independently. If an endpoint's axis ID
-is deleted, it snaps to the nearest valid position. If both endpoints are
-deleted, the range is dropped from the selection.
+For ranges, each endpoint is resolved independently. If one endpoint's axis ID
+is deleted, it snaps to the surviving endpoint. If both endpoints are deleted,
+the range is dropped from the selection.
 
 ### Sheet Engine Changes
 
@@ -192,6 +188,9 @@ interface Store {
   // Expose axis orders for conversion
   getRowOrder(): string[];
   getColOrder(): string[];
+
+  // Extend axis orders to cover selection range
+  ensureAxisOrder(minRows: number, minCols: number): void;
 }
 ```
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| axis id selection (2026-04-14) | [20260414-axis-id-selection-todo.md](./active/20260414-axis-id-selection-todo.md) | - |
+| random axis id (2026-04-13) | [20260413-random-axis-id-todo.md](./active/20260413-random-axis-id-todo.md) | - |
 | docs image editing (2026-04-12) | [20260412-docs-image-editing-todo.md](./active/20260412-docs-image-editing-todo.md) | [20260412-docs-image-editing-lessons.md](./active/20260412-docs-image-editing-lessons.md) |
 | docx table style followup (2026-04-12) | [20260412-docx-table-style-followup-todo.md](./active/20260412-docx-table-style-followup-todo.md) | - |
 | intent preserving phase4 table cells (2026-04-03) | [20260403-intent-preserving-phase4-table-cells-todo.md](./active/20260403-intent-preserving-phase4-table-cells-todo.md) | - |
@@ -29,4 +31,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 126
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: docs image editing (2026-04-12)
+Latest active task: axis id selection (2026-04-14)

--- a/docs/tasks/active/20260414-axis-id-selection-todo.md
+++ b/docs/tasks/active/20260414-axis-id-selection-todo.md
@@ -1,0 +1,1117 @@
+# Axis ID Based Selection & Presence — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace coordinate-based selection with stable axis ID references in Yorkie presence so selections automatically track cells across remote structural edits.
+
+**Architecture:** New `CellAnchor`/`RangeAnchor` types represent selection via axis IDs. A conversion layer at the Store boundary translates between axis IDs and visual `Ref` coordinates. The Sheet engine keeps `Ref` internally; presence stores axis IDs. Peer cursors render both active cell borders and range backgrounds.
+
+**Tech Stack:** TypeScript, Vitest, Yorkie CRDT presence
+
+---
+
+### Task 1: Anchor Types and Conversion Functions
+
+**Files:**
+- Create: `packages/sheets/src/model/workbook/anchor-conversion.ts`
+- Create: `packages/sheets/test/workbook/anchor-conversion.test.ts`
+
+- [ ] **Step 1: Write failing tests for `anchorToRef`**
+
+```typescript
+// packages/sheets/test/workbook/anchor-conversion.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  anchorToRef,
+  refToAnchor,
+  rangeAnchorToRange,
+  rangeToRangeAnchor,
+} from '../../src/model/workbook/anchor-conversion';
+import type { CellAnchor, RangeAnchor } from '../../src/model/workbook/anchor-conversion';
+
+describe('anchorToRef', () => {
+  const rowOrder = ['r1', 'r2', 'r3', 'r4', 'r5'];
+  const colOrder = ['c1', 'c2', 'c3'];
+
+  it('converts axis IDs to visual position', () => {
+    const anchor: CellAnchor = { rowId: 'r3', colId: 'c2' };
+    expect(anchorToRef(anchor, rowOrder, colOrder)).toEqual({ r: 3, c: 2 });
+  });
+
+  it('returns null when rowId is not in rowOrder (deleted)', () => {
+    const anchor: CellAnchor = { rowId: 'rDeleted', colId: 'c1' };
+    expect(anchorToRef(anchor, rowOrder, colOrder)).toBeNull();
+  });
+
+  it('returns null when colId is not in colOrder (deleted)', () => {
+    const anchor: CellAnchor = { rowId: 'r1', colId: 'cDeleted' };
+    expect(anchorToRef(anchor, rowOrder, colOrder)).toBeNull();
+  });
+
+  it('reflects position change after row insertion', () => {
+    const anchor: CellAnchor = { rowId: 'r3', colId: 'c1' };
+    // Before insertion: r3 is at index 2 → Ref {r:3}
+    expect(anchorToRef(anchor, rowOrder, colOrder)).toEqual({ r: 3, c: 1 });
+    // After inserting a new row before r3:
+    const newRowOrder = ['r1', 'r2', 'rNew', 'r3', 'r4', 'r5'];
+    expect(anchorToRef(anchor, newRowOrder, colOrder)).toEqual({ r: 4, c: 1 });
+  });
+});
+```
+
+- [ ] **Step 2: Write failing tests for `refToAnchor`**
+
+```typescript
+// append to the same test file
+describe('refToAnchor', () => {
+  const rowOrder = ['r1', 'r2', 'r3'];
+  const colOrder = ['c1', 'c2', 'c3'];
+
+  it('converts visual position to axis IDs', () => {
+    expect(refToAnchor({ r: 2, c: 3 }, rowOrder, colOrder)).toEqual({
+      rowId: 'r2',
+      colId: 'c3',
+    });
+  });
+
+  it('returns null for out-of-bounds ref', () => {
+    expect(refToAnchor({ r: 10, c: 1 }, rowOrder, colOrder)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Write failing tests for `rangeAnchorToRange` and `rangeToRangeAnchor`**
+
+```typescript
+// append to the same test file
+describe('rangeAnchorToRange', () => {
+  const rowOrder = ['r1', 'r2', 'r3', 'r4'];
+  const colOrder = ['c1', 'c2', 'c3'];
+
+  it('converts a normal range', () => {
+    const anchor: RangeAnchor = {
+      startRowId: 'r2', startColId: 'c1',
+      endRowId: 'r4', endColId: 'c3',
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toEqual([
+      { r: 2, c: 1 },
+      { r: 4, c: 3 },
+    ]);
+  });
+
+  it('entire-row selection (null colIds)', () => {
+    const anchor: RangeAnchor = {
+      startRowId: 'r2', startColId: null,
+      endRowId: 'r3', endColId: null,
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toEqual([
+      { r: 2, c: 1 },
+      { r: 3, c: colOrder.length },
+    ]);
+  });
+
+  it('entire-column selection (null rowIds)', () => {
+    const anchor: RangeAnchor = {
+      startRowId: null, startColId: 'c2',
+      endRowId: null, endColId: 'c2',
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toEqual([
+      { r: 1, c: 2 },
+      { r: rowOrder.length, c: 2 },
+    ]);
+  });
+
+  it('select-all (all null)', () => {
+    const anchor: RangeAnchor = {
+      startRowId: null, startColId: null,
+      endRowId: null, endColId: null,
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toEqual([
+      { r: 1, c: 1 },
+      { r: rowOrder.length, c: colOrder.length },
+    ]);
+  });
+
+  it('returns null when both start and end axis IDs are deleted', () => {
+    const anchor: RangeAnchor = {
+      startRowId: 'rGone', startColId: 'c1',
+      endRowId: 'rAlsoGone', endColId: 'c2',
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toBeNull();
+  });
+});
+
+describe('rangeToRangeAnchor', () => {
+  const rowOrder = ['r1', 'r2', 'r3', 'r4'];
+  const colOrder = ['c1', 'c2', 'c3'];
+
+  it('converts a normal range to anchor', () => {
+    const anchor = rangeToRangeAnchor(
+      [{ r: 2, c: 1 }, { r: 4, c: 3 }],
+      rowOrder, colOrder, 'cell',
+    );
+    expect(anchor).toEqual({
+      startRowId: 'r2', startColId: 'c1',
+      endRowId: 'r4', endColId: 'c3',
+    });
+  });
+
+  it('encodes entire-row selection with null colIds', () => {
+    const anchor = rangeToRangeAnchor(
+      [{ r: 2, c: 1 }, { r: 3, c: colOrder.length }],
+      rowOrder, colOrder, 'row',
+    );
+    expect(anchor).toEqual({
+      startRowId: 'r2', startColId: null,
+      endRowId: 'r3', endColId: null,
+    });
+  });
+
+  it('encodes entire-column selection with null rowIds', () => {
+    const anchor = rangeToRangeAnchor(
+      [{ r: 1, c: 2 }, { r: rowOrder.length, c: 2 }],
+      rowOrder, colOrder, 'column',
+    );
+    expect(anchor).toEqual({
+      startRowId: null, startColId: 'c2',
+      endRowId: null, endColId: 'c2',
+    });
+  });
+
+  it('encodes select-all with all nulls', () => {
+    const anchor = rangeToRangeAnchor(
+      [{ r: 1, c: 1 }, { r: rowOrder.length, c: colOrder.length }],
+      rowOrder, colOrder, 'all',
+    );
+    expect(anchor).toEqual({
+      startRowId: null, startColId: null,
+      endRowId: null, endColId: null,
+    });
+  });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `pnpm --filter @wafflebase/sheets exec vitest run test/workbook/anchor-conversion.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 5: Implement anchor-conversion module**
+
+```typescript
+// packages/sheets/src/model/workbook/anchor-conversion.ts
+import type { Range, Ref, SelectionType } from '../core/types';
+
+/**
+ * Stable cell reference using axis IDs instead of visual coordinates.
+ */
+export type CellAnchor = {
+  rowId: string;
+  colId: string;
+};
+
+/**
+ * Stable range reference. A null field means "all" on that axis:
+ * - colId null → entire-row selection
+ * - rowId null → entire-column selection
+ * - both null  → select-all
+ */
+export type RangeAnchor = {
+  startRowId: string | null;
+  startColId: string | null;
+  endRowId: string | null;
+  endColId: string | null;
+};
+
+/**
+ * Full selection state stored in Yorkie presence.
+ */
+export type SelectionPresence = {
+  activeCell: CellAnchor;
+  ranges: RangeAnchor[];
+};
+
+/**
+ * Convert a CellAnchor to a visual Ref using current axis ordering.
+ * Returns null if the axis ID has been deleted (not found in order).
+ */
+export function anchorToRef(
+  anchor: CellAnchor,
+  rowOrder: string[],
+  colOrder: string[],
+): Ref | null {
+  const r = rowOrder.indexOf(anchor.rowId);
+  const c = colOrder.indexOf(anchor.colId);
+  if (r === -1 || c === -1) return null;
+  return { r: r + 1, c: c + 1 };
+}
+
+/**
+ * Convert a visual Ref to a CellAnchor using current axis ordering.
+ * Returns null if the ref is out of bounds.
+ */
+export function refToAnchor(
+  ref: Ref,
+  rowOrder: string[],
+  colOrder: string[],
+): CellAnchor | null {
+  const rowId = rowOrder[ref.r - 1];
+  const colId = colOrder[ref.c - 1];
+  if (!rowId || !colId) return null;
+  return { rowId, colId };
+}
+
+/**
+ * Convert a RangeAnchor to a visual Range.
+ * null axis fields expand to 1 (start) or max dimension (end).
+ * Returns null if both row endpoints are deleted or both col endpoints are deleted.
+ */
+export function rangeAnchorToRange(
+  anchor: RangeAnchor,
+  rowOrder: string[],
+  colOrder: string[],
+): Range | null {
+  const startR = anchor.startRowId
+    ? rowOrder.indexOf(anchor.startRowId) + 1
+    : 1;
+  const startC = anchor.startColId
+    ? colOrder.indexOf(anchor.startColId) + 1
+    : 1;
+  const endR = anchor.endRowId
+    ? rowOrder.indexOf(anchor.endRowId) + 1
+    : rowOrder.length;
+  const endC = anchor.endColId
+    ? colOrder.indexOf(anchor.endColId) + 1
+    : colOrder.length;
+
+  // indexOf returns -1 → +1 = 0 means deleted
+  if (
+    (anchor.startRowId && startR === 0) &&
+    (anchor.endRowId && endR === 0)
+  ) return null;
+  if (
+    (anchor.startColId && startC === 0) &&
+    (anchor.endColId && endC === 0)
+  ) return null;
+
+  return [
+    { r: Math.max(1, startR), c: Math.max(1, startC) },
+    { r: Math.max(1, endR), c: Math.max(1, endC) },
+  ];
+}
+
+/**
+ * Convert a visual Range to a RangeAnchor.
+ * selectionType determines which axes get null (entire-row/column/all).
+ */
+export function rangeToRangeAnchor(
+  range: Range,
+  rowOrder: string[],
+  colOrder: string[],
+  selectionType: SelectionType,
+): RangeAnchor {
+  const [start, end] = range;
+  const useRow = selectionType !== 'column' && selectionType !== 'all';
+  const useCol = selectionType !== 'row' && selectionType !== 'all';
+
+  return {
+    startRowId: useRow ? (rowOrder[start.r - 1] ?? null) : null,
+    startColId: useCol ? (colOrder[start.c - 1] ?? null) : null,
+    endRowId: useRow ? (rowOrder[end.r - 1] ?? null) : null,
+    endColId: useCol ? (colOrder[end.c - 1] ?? null) : null,
+  };
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm --filter @wafflebase/sheets exec vitest run test/workbook/anchor-conversion.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 7: Export new types from sheets package**
+
+Add to `packages/sheets/src/index.ts`:
+
+```typescript
+import type { CellAnchor, RangeAnchor, SelectionPresence } from './model/workbook/anchor-conversion';
+// ... in the export block:
+export { type CellAnchor, type RangeAnchor, type SelectionPresence };
+export { anchorToRef, refToAnchor, rangeAnchorToRange, rangeToRangeAnchor } from './model/workbook/anchor-conversion';
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/sheets/src/model/workbook/anchor-conversion.ts \
+       packages/sheets/test/workbook/anchor-conversion.test.ts \
+       packages/sheets/src/index.ts
+git commit -m "Add anchor conversion layer for axis ID based selection
+
+CellAnchor/RangeAnchor types reference cells by stable axis IDs.
+Conversion functions translate between axis IDs and visual Ref
+coordinates at the Store boundary."
+```
+
+---
+
+### Task 2: Store Interface — Replace `updateActiveCell` with `updateSelection`
+
+**Files:**
+- Modify: `packages/sheets/src/store/store.ts:76,208`
+- Modify: `packages/sheets/src/store/memory.ts:297-302,318-323`
+- Modify: `packages/sheets/src/store/readonly.ts:140-149`
+
+- [ ] **Step 1: Update Store interface**
+
+In `packages/sheets/src/store/store.ts`, replace:
+
+```typescript
+// Line 73-76: change getPresences signature
+/**
+ * `getPresences` method gets the user presences.
+ */
+getPresences(): Array<{
+  clientID: string;
+  presence: { activeCell: string; username?: string };
+}>;
+```
+
+with:
+
+```typescript
+/**
+ * `getPresences` method gets the user presences with axis-ID-based selection.
+ */
+getPresences(): Array<{
+  clientID: string;
+  presence: {
+    selection?: SelectionPresence;
+    activeCell?: string; // legacy fallback
+    username?: string;
+  };
+}>;
+```
+
+And replace:
+
+```typescript
+// Line 205-208: change updateActiveCell to updateSelection
+/**
+ * `updateActiveCell` method updates the active cell of the current user.
+ */
+updateActiveCell(activeCell: Ref): void;
+```
+
+with:
+
+```typescript
+/**
+ * `updateSelection` updates the selection of the current user in presence.
+ */
+updateSelection(
+  activeCell: CellAnchor,
+  ranges: RangeAnchor[],
+): void;
+
+/**
+ * `getRowOrder` returns the current row axis ID ordering.
+ */
+getRowOrder(): string[];
+
+/**
+ * `getColOrder` returns the current column axis ID ordering.
+ */
+getColOrder(): string[];
+```
+
+Add the imports at the top of `store.ts`:
+
+```typescript
+import type { CellAnchor, RangeAnchor, SelectionPresence } from '../model/workbook/anchor-conversion';
+```
+
+- [ ] **Step 2: Update MemStore**
+
+In `packages/sheets/src/store/memory.ts`, replace `getPresences` and `updateActiveCell`:
+
+```typescript
+getPresences(): Array<{
+  clientID: string;
+  presence: {
+    selection?: SelectionPresence;
+    activeCell?: string;
+    username?: string;
+  };
+}> {
+  return [];
+}
+
+updateSelection(_activeCell: CellAnchor, _ranges: RangeAnchor[]): void {
+  // No-op for memory store
+}
+
+getRowOrder(): string[] {
+  return [];
+}
+
+getColOrder(): string[] {
+  return [];
+}
+```
+
+Add import: `import type { CellAnchor, RangeAnchor, SelectionPresence } from '../model/workbook/anchor-conversion';`
+
+- [ ] **Step 3: Update ReadOnlyStore**
+
+In `packages/sheets/src/store/readonly.ts`, apply the same changes as MemStore — replace `getPresences` and `updateActiveCell` with the new signatures and no-op implementations.
+
+Add import: `import type { CellAnchor, RangeAnchor, SelectionPresence } from '../model/workbook/anchor-conversion';`
+
+- [ ] **Step 4: Verify typecheck passes**
+
+Run: `pnpm sheets typecheck`
+Expected: FAIL — Sheet class and YorkieStore still use old signatures. That is expected; they will be updated in Tasks 3 and 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sheets/src/store/store.ts \
+       packages/sheets/src/store/memory.ts \
+       packages/sheets/src/store/readonly.ts
+git commit -m "Update Store interface for axis ID based selection
+
+Replace updateActiveCell(Ref) with updateSelection(CellAnchor, RangeAnchor[]).
+Add getRowOrder/getColOrder for axis order access.
+Update getPresences to include SelectionPresence."
+```
+
+---
+
+### Task 3: Sheet Engine — Anchor-Based Selection State
+
+**Files:**
+- Modify: `packages/sheets/src/model/worksheet/sheet.ts`
+
+- [ ] **Step 1: Add anchor fields and update setActiveCell**
+
+In `packages/sheets/src/model/worksheet/sheet.ts`, add imports:
+
+```typescript
+import {
+  type CellAnchor,
+  type RangeAnchor,
+  refToAnchor,
+  anchorToRef,
+  rangeToRangeAnchor,
+  rangeAnchorToRange,
+} from '../workbook/anchor-conversion';
+```
+
+After the existing `private ranges: Ranges = [];` (line 157), add:
+
+```typescript
+/**
+ * `activeCellAnchor` is the authoritative selection as axis IDs.
+ * On remote sync, re-resolved to `activeCell` (Ref) via anchorToRef().
+ */
+private activeCellAnchor: CellAnchor | null = null;
+
+/**
+ * `rangeAnchors` are the authoritative range selections as axis IDs.
+ */
+private rangeAnchors: RangeAnchor[] = [];
+```
+
+Replace `setActiveCell` (lines 2609-2613):
+
+```typescript
+public setActiveCell(ref: Ref): void {
+  const anchor = this.normalizeRefToAnchor(ref);
+  this.activeCell = anchor;
+
+  const cellAnchor = refToAnchor(anchor, this.store.getRowOrder(), this.store.getColOrder());
+  if (cellAnchor) {
+    this.activeCellAnchor = cellAnchor;
+  }
+
+  this.syncSelectionToPresence();
+}
+```
+
+- [ ] **Step 2: Add `syncSelectionToPresence` helper and update selection methods**
+
+Add a private helper method:
+
+```typescript
+private syncSelectionToPresence(): void {
+  if (!this.activeCellAnchor) return;
+  const rowOrder = this.store.getRowOrder();
+  const colOrder = this.store.getColOrder();
+  const rangeAnchors = this.ranges.map((range) =>
+    rangeToRangeAnchor(range, rowOrder, colOrder, this.selectionType),
+  );
+  this.rangeAnchors = rangeAnchors;
+  this.store.updateSelection(this.activeCellAnchor, rangeAnchors);
+}
+```
+
+Update `selectRow` (lines 2666-2674) — replace `this.store.updateActiveCell(this.activeCell)` with `this.syncSelectionToPresence()`.
+
+Update `selectColumn` (lines 2679-2687) — same replacement.
+
+Update `selectAllCells` (lines 2718-2723) — same replacement.
+
+Update any other method that calls `this.store.updateActiveCell(...)` — replace with `this.syncSelectionToPresence()`. Search for all occurrences of `store.updateActiveCell` in `sheet.ts`.
+
+- [ ] **Step 3: Add `resolveAnchorsToRefs` for remote sync**
+
+Add a public method that `reloadDimensions` flow can call:
+
+```typescript
+/**
+ * Re-resolve axis-ID-based anchors to visual Refs after rowOrder/colOrder change.
+ * Called on remote structural edits to correct selection position.
+ */
+public resolveAnchorsToRefs(): void {
+  if (!this.activeCellAnchor) return;
+  const rowOrder = this.store.getRowOrder();
+  const colOrder = this.store.getColOrder();
+
+  const newRef = anchorToRef(this.activeCellAnchor, rowOrder, colOrder);
+  if (newRef) {
+    this.activeCell = this.normalizeRefToAnchor(newRef);
+  } else {
+    // Axis ID was deleted — snap to nearest valid position
+    this.handleDeletedAnchor(rowOrder, colOrder);
+  }
+
+  // Re-resolve ranges
+  const newRanges: Range[] = [];
+  for (const anchor of this.rangeAnchors) {
+    const range = rangeAnchorToRange(anchor, rowOrder, colOrder);
+    if (range) {
+      newRanges.push(range);
+    }
+  }
+  this.ranges = newRanges;
+}
+
+private handleDeletedAnchor(rowOrder: string[], colOrder: string[]): void {
+  // Fallback: place activeCell at row 1, col 1 and update anchor
+  const fallbackRef: Ref = { r: 1, c: 1 };
+  this.activeCell = fallbackRef;
+  const newAnchor = refToAnchor(fallbackRef, rowOrder, colOrder);
+  if (newAnchor) {
+    this.activeCellAnchor = newAnchor;
+    this.syncSelectionToPresence();
+  }
+}
+```
+
+Note: The `handleDeletedAnchor` uses a simple fallback to {r:1, c:1}. A smarter approach (snapping to the nearest row) requires caching previous rowOrder, which can be added as a follow-up refinement. The simple fallback is correct and safe.
+
+- [ ] **Step 4: Remove activeCell shift logic from `shiftCells`**
+
+In `shiftCells()` (lines 1105-1144), replace the entire activeCell shift block:
+
+```typescript
+// Adjust activeCell if it's at or beyond the insertion/deletion point
+const value = axis === 'row' ? this.activeCell.r : this.activeCell.c;
+if (count > 0 && value >= index) {
+  // ... all the shift logic ...
+}
+this.activeCell = this.normalizeRefToAnchor(this.activeCell);
+```
+
+with:
+
+```typescript
+// ActiveCell adjustment is handled by resolveAnchorsToRefs() via axis IDs.
+// For local edits, re-resolve immediately since rowOrder has already changed.
+this.resolveAnchorsToRefs();
+```
+
+- [ ] **Step 5: Update `getPresences` return type**
+
+In `sheet.ts`, update the `getPresences` method (lines 2635-2640):
+
+```typescript
+getPresences(): Array<{
+  clientID: string;
+  presence: {
+    selection?: SelectionPresence;
+    activeCell?: string;
+    username?: string;
+  };
+}> {
+  return this.store.getPresences();
+}
+```
+
+Add import: `import type { SelectionPresence } from '../workbook/anchor-conversion';`
+
+- [ ] **Step 6: Verify typecheck passes**
+
+Run: `pnpm sheets typecheck`
+Expected: FAIL — YorkieStore not yet updated (Task 4). MemStore/ReadOnlyStore should be fine.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sheets/src/model/worksheet/sheet.ts
+git commit -m "Add anchor-based selection state to Sheet engine
+
+Sheet maintains CellAnchor/RangeAnchor alongside Ref-based fields.
+resolveAnchorsToRefs() re-resolves on remote sync.
+Remove manual activeCell shift logic from shiftCells()."
+```
+
+---
+
+### Task 4: YorkieStore — Implement `updateSelection` and Axis Order Access
+
+**Files:**
+- Modify: `packages/frontend/src/app/spreadsheet/yorkie-store.ts:602-612`
+- Modify: `packages/frontend/src/types/users.ts`
+
+- [ ] **Step 1: Update UserPresence type**
+
+In `packages/frontend/src/types/users.ts`:
+
+```typescript
+import type { Sref, SelectionPresence } from "@wafflebase/sheets";
+
+export type User = {
+  id: number;
+  authProvider: string;
+  username: string;
+  email: string;
+  photo: string;
+};
+
+export type UserPresence = {
+  selection?: SelectionPresence;
+  activeCell?: Sref; // legacy fallback for mixed-version peers
+  activeTabId?: string;
+} & User;
+```
+
+- [ ] **Step 2: Update YorkieStore methods**
+
+In `packages/frontend/src/app/spreadsheet/yorkie-store.ts`, add imports:
+
+```typescript
+import type { CellAnchor, RangeAnchor } from "@wafflebase/sheets";
+```
+
+Replace `updateActiveCell` (lines 602-606):
+
+```typescript
+updateSelection(activeCell: CellAnchor, ranges: RangeAnchor[]) {
+  this.doc.update((_, p) => {
+    p.set({
+      selection: { activeCell, ranges },
+      activeTabId: this.tabId,
+    });
+  });
+}
+```
+
+Add `getRowOrder` and `getColOrder`:
+
+```typescript
+getRowOrder(): string[] {
+  const ws = this.getSheet();
+  return ws.rowOrder ? [...ws.rowOrder] : [];
+}
+
+getColOrder(): string[] {
+  const ws = this.getSheet();
+  return ws.colOrder ? [...ws.colOrder] : [];
+}
+```
+
+- [ ] **Step 3: Verify full typecheck passes**
+
+Run: `pnpm sheets typecheck && pnpm --filter @wafflebase/frontend exec tsc --noEmit`
+Expected: PASS (all implementations now match the interface)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/frontend/src/app/spreadsheet/yorkie-store.ts \
+       packages/frontend/src/types/users.ts
+git commit -m "Implement updateSelection and axis order access in YorkieStore
+
+YorkieStore writes SelectionPresence to Yorkie presence.
+UserPresence type includes both new selection and legacy activeCell
+fields for backward compatibility."
+```
+
+---
+
+### Task 5: Remote Sync — Re-resolve Anchors on Structural Change
+
+**Files:**
+- Modify: `packages/sheets/src/view/worksheet.ts:4175-4190`
+- Modify: `packages/frontend/src/app/spreadsheet/sheet-view.tsx:640-664`
+
+- [ ] **Step 1: Add `resolveAnchorsToRefs` call in `reloadDimensions`**
+
+In `packages/sheets/src/view/worksheet.ts`, update `reloadDimensions()` (lines 4175-4190):
+
+```typescript
+public async reloadDimensions() {
+  await this.sheet!.loadDimensions();
+  await this.sheet!.loadStyles();
+  await this.sheet!.loadMerges();
+  await this.sheet!.loadFreezePane();
+  await this.sheet!.loadFilterState();
+  await this.sheet!.loadHiddenState();
+  await this.sheet!.loadPivotDefinition();
+
+  // Re-resolve axis-ID-based selection after structural changes
+  this.sheet!.resolveAnchorsToRefs();
+
+  this.hiddenRows.clear();
+  this.hiddenRowSizeBackup.clear();
+  this.hiddenColumns.clear();
+  this.hiddenColSizeBackup.clear();
+  this.syncHiddenRowsFromSheet();
+  this.syncHiddenColumnsFromSheet();
+  this.updateFreezeState();
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `pnpm sheets typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/sheets/src/view/worksheet.ts
+git commit -m "Re-resolve selection anchors on remote structural changes
+
+reloadDimensions() calls resolveAnchorsToRefs() so activeCell
+automatically tracks its axis ID after remote row/col inserts."
+```
+
+---
+
+### Task 6: Overlay — Render Peer Selection Ranges
+
+**Files:**
+- Modify: `packages/sheets/src/view/overlay.ts:135-165,602-656`
+- Modify: `packages/sheets/src/view/worksheet.ts:4509-4541`
+
+- [ ] **Step 1: Update overlay `render()` signature for new presence type**
+
+In `packages/sheets/src/view/overlay.ts`, update the `peerPresences` parameter type in `render()` (line 138) and `renderPeerCursorsSimple()` (line 605):
+
+Change the presence type from:
+
+```typescript
+Array<{ clientID: string; presence: { activeCell: string; username?: string } }>
+```
+
+to:
+
+```typescript
+Array<{
+  clientID: string;
+  presence: {
+    selection?: SelectionPresence;
+    activeCell?: string;
+    username?: string;
+  };
+}>
+```
+
+Add imports at the top of `overlay.ts`:
+
+```typescript
+import type { SelectionPresence } from '../model/workbook/anchor-conversion';
+import { anchorToRef, rangeAnchorToRange } from '../model/workbook/anchor-conversion';
+```
+
+- [ ] **Step 2: Update `renderPeerCursorsSimple` to handle both formats and render ranges**
+
+Replace the body of `renderPeerCursorsSimple` (lines 614-656):
+
+```typescript
+private renderPeerCursorsSimple(
+  ctx: CanvasRenderingContext2D,
+  port: BoundingRect,
+  peerPresences: Array<{
+    clientID: string;
+    presence: {
+      selection?: SelectionPresence;
+      activeCell?: string;
+      username?: string;
+    };
+  }>,
+  scroll: { left: number; top: number },
+  rowDim?: DimensionIndex,
+  colDim?: DimensionIndex,
+  mergeData?: {
+    anchors: Map<string, MergeSpan>;
+    coverToAnchor: Map<string, string>;
+  },
+  visiblePeerLabels?: Set<string>,
+  rowOrder?: string[],
+  colOrder?: string[],
+): void {
+  const cellPeers = new Map<string, Array<{ clientID: string; username: string; rect: BoundingRect }>>();
+
+  for (const { clientID, presence } of peerPresences) {
+    let peerActiveCell: Ref | null = null;
+    let peerRanges: Range[] = [];
+
+    if (presence.selection && rowOrder && colOrder) {
+      // New format: axis ID based
+      peerActiveCell = anchorToRef(presence.selection.activeCell, rowOrder, colOrder);
+      for (const rangeAnchor of presence.selection.ranges) {
+        const range = rangeAnchorToRange(rangeAnchor, rowOrder, colOrder);
+        if (range) peerRanges.push(range);
+      }
+    } else if (presence.activeCell) {
+      // Legacy format: Sref string
+      peerActiveCell = parseRef(presence.activeCell);
+    }
+
+    if (!peerActiveCell) continue;
+
+    const peerColor = getPeerCursorColor(this.theme, clientID);
+
+    // Draw range backgrounds
+    for (const range of peerRanges) {
+      this.renderPeerRangeBackground(ctx, range, peerColor, scroll, rowDim, colDim);
+    }
+
+    // Draw active cell border
+    const rect = this.toCellRect(peerActiveCell, scroll, rowDim, colDim, mergeData);
+    if (rect.left >= -rect.width && rect.left < port.width &&
+        rect.top >= -rect.height && rect.top < port.height) {
+      ctx.strokeStyle = peerColor;
+      ctx.lineWidth = 2;
+      ctx.strokeRect(rect.left, rect.top, rect.width, rect.height);
+
+      if (visiblePeerLabels?.has(clientID) && presence.username) {
+        const key = peerActiveCell.r + ',' + peerActiveCell.c;
+        if (!cellPeers.has(key)) {
+          cellPeers.set(key, []);
+        }
+        cellPeers.get(key)!.push({ clientID, username: presence.username, rect });
+      }
+    }
+  }
+
+  // Draw labels grouped by cell, stacked in stable clientID order.
+  for (const peers of cellPeers.values()) {
+    peers.sort((a, b) => a.clientID.localeCompare(b.clientID));
+    for (let i = 0; i < peers.length; i++) {
+      const { clientID, username, rect } = peers[i];
+      const peerColor = getPeerCursorColor(this.theme, clientID);
+      drawPeerLabel(ctx, username, peerColor, rect, port, i);
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Add `renderPeerRangeBackground` helper**
+
+Add after `renderPeerCursorsSimple`:
+
+```typescript
+private renderPeerRangeBackground(
+  ctx: CanvasRenderingContext2D,
+  range: Range,
+  color: string,
+  scroll: { left: number; top: number },
+  rowDim?: DimensionIndex,
+  colDim?: DimensionIndex,
+): void {
+  const startRect = this.toCellRect(range[0], scroll, rowDim, colDim);
+  const endRect = this.toCellRect(range[1], scroll, rowDim, colDim);
+  const x = startRect.left;
+  const y = startRect.top;
+  const w = endRect.left + endRect.width - startRect.left;
+  const h = endRect.top + endRect.height - startRect.top;
+
+  ctx.save();
+  ctx.fillStyle = color;
+  ctx.globalAlpha = 0.1;
+  ctx.fillRect(x, y, w, h);
+  ctx.restore();
+}
+```
+
+- [ ] **Step 4: Pass rowOrder/colOrder through render() → renderPeerCursorsSimple()**
+
+Add `rowOrder?: string[]` and `colOrder?: string[]` parameters to the `render()` method signature (after `cellDragMovePreview`):
+
+```typescript
+rowOrder?: string[],
+colOrder?: string[],
+```
+
+Pass them through to `renderPeerCursorsSimple()` call inside `render()`.
+
+- [ ] **Step 5: Update worksheet.ts `renderOverlay` to pass rowOrder/colOrder**
+
+In `packages/sheets/src/view/worksheet.ts` `renderOverlay()` method (lines 4509-4541), add the new arguments:
+
+```typescript
+public renderOverlay() {
+  this.updatePeerLabelVisibility();
+  this.overlay.render(
+    this.viewport,
+    this.scroll,
+    this.sheet!.getActiveCell(),
+    this.sheet!.getPresences(),
+    this.sheet!.getRanges(),
+    this.rowDim,
+    this.colDim,
+    this.resizeHover,
+    this.resizeDragging,
+    this.sheet!.getSelectionType(),
+    this.dragMove
+      ? { axis: this.dragMove.axis, dropIndex: this.dragMove.dropIndex }
+      : null,
+    this.formulaRanges,
+    this.freezeState,
+    this.freezeDrag,
+    this.sheet!.getCopyRange(),
+    this.sheet!.isCutMode(),
+    this.autofillPreview,
+    this.shouldShowAutofillHandle(),
+    this.sheet!.getMerges(),
+    this.sheet!.getFilterRange(),
+    this.zoom,
+    this.showMobileHandles,
+    this._searchResults.length > 0 ? this._searchResults : undefined,
+    this._searchCurrentIndex >= 0 ? this._searchCurrentIndex : undefined,
+    this.getVisiblePeerLabels(),
+    this.cellDragMovePreview,
+    this.sheet!.getStore().getRowOrder(),
+    this.sheet!.getStore().getColOrder(),
+  );
+}
+```
+
+Note: This requires `Sheet.getStore()` to be accessible. If it's not public, add a public getter:
+
+```typescript
+// In sheet.ts, add:
+public getStore(): Store {
+  return this.store;
+}
+```
+
+- [ ] **Step 6: Verify typecheck and tests pass**
+
+Run: `pnpm verify:fast`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sheets/src/view/overlay.ts \
+       packages/sheets/src/view/worksheet.ts \
+       packages/sheets/src/model/worksheet/sheet.ts
+git commit -m "Render peer selection ranges with translucent background
+
+Overlay handles both axis-ID-based and legacy Sref-based peer
+presences. Peer ranges are drawn with 10% opacity fill.
+Active cell keeps colored border + name label."
+```
+
+---
+
+### Task 7: Initialize Anchors on Sheet Load
+
+**Files:**
+- Modify: `packages/sheets/src/model/worksheet/sheet.ts`
+
+- [ ] **Step 1: Initialize `activeCellAnchor` when sheet loads**
+
+Find the Sheet constructor or initialization method where `activeCell` is first set. After `this.activeCell = { r: 1, c: 1 }` (or wherever the default is set), add anchor initialization.
+
+In the constructor or `init()`-like method, after active cell is established:
+
+```typescript
+// Initialize anchor from the default activeCell
+const rowOrder = this.store.getRowOrder();
+const colOrder = this.store.getColOrder();
+if (rowOrder.length > 0 && colOrder.length > 0) {
+  this.activeCellAnchor = refToAnchor(this.activeCell, rowOrder, colOrder);
+}
+```
+
+- [ ] **Step 2: Verify tests pass**
+
+Run: `pnpm verify:fast`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/sheets/src/model/worksheet/sheet.ts
+git commit -m "Initialize selection anchors on sheet load
+
+Ensures activeCellAnchor is set from the start so
+resolveAnchorsToRefs works on the first remote change."
+```
+
+---
+
+### Task 8: Verify End-to-End and Clean Up
+
+**Files:**
+- Modify: `docs/design/sheets/axis-id-selection.md` (if needed)
+- Modify: `docs/tasks/active/20260414-axis-id-selection-todo.md`
+
+- [ ] **Step 1: Run full verification**
+
+Run: `pnpm verify:fast`
+Expected: ALL PASS
+
+- [ ] **Step 2: Run typecheck across all packages**
+
+Run: `pnpm sheets typecheck && pnpm --filter @wafflebase/frontend exec tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Search for leftover `updateActiveCell` references**
+
+Search for any remaining `updateActiveCell` calls in the codebase that haven't been updated. These would be compile errors but verify none are hidden:
+
+```bash
+grep -r "updateActiveCell" packages/ --include="*.ts" --include="*.tsx"
+```
+
+Expected: No matches (all replaced with `updateSelection` or `syncSelectionToPresence`)
+
+- [ ] **Step 4: Manual testing checklist**
+
+1. Open sheet in two browser tabs (ClientA, ClientB)
+2. ClientA selects cell D4
+3. ClientB inserts a row at row 2
+4. Verify: ClientA's selection moves to D5
+5. ClientB deletes row 3
+6. Verify: ClientA's selection adjusts correctly
+7. ClientA selects range B2:D5, verify ClientB sees translucent range overlay
+8. ClientA selects entire row 3, verify ClientB sees full-row highlight
+9. Both clients select different cells — verify both peer cursors visible with labels
+
+- [ ] **Step 5: Final commit with task completion**
+
+```bash
+pnpm tasks:archive && pnpm tasks:index
+git add docs/
+git commit -m "Complete axis ID based selection implementation
+
+Verified end-to-end: remote structural edits preserve selection,
+peer ranges render correctly, backward compatibility works."
+```

--- a/packages/frontend/src/app/spreadsheet/yorkie-store.ts
+++ b/packages/frontend/src/app/spreadsheet/yorkie-store.ts
@@ -10,6 +10,7 @@ import {
   getWorksheetEntries,
   getWorksheetKeys,
   createWorksheetAxisId,
+  anchorToRef,
   isCrossSheetRef,
   cloneConditionalFormatRule,
   normalizeConditionalFormatRule,
@@ -603,9 +604,12 @@ export class YorkieStore implements Store {
   }
 
   updateSelection(activeCell: CellAnchor, ranges: RangeAnchor[]) {
+    // Also emit legacy activeCell string for user-presence.tsx jump feature
+    const ref = anchorToRef(activeCell, this.getRowOrder(), this.getColOrder());
     this.doc.update((_, p) => {
       p.set({
         selection: { activeCell, ranges },
+        activeCell: ref ? toSref(ref) : undefined,
         activeTabId: this.tabId,
       });
     });
@@ -625,6 +629,8 @@ export class YorkieStore implements Store {
     this.doc.update((root) => {
       const ws = root.sheets[this.tabId];
       if (!ws) return;
+      ws.rowOrder ??= [];
+      ws.colOrder ??= [];
       const rowPrefix = "r";
       const colPrefix = "c";
       while (ws.rowOrder.length < minRows) {

--- a/packages/frontend/src/app/spreadsheet/yorkie-store.ts
+++ b/packages/frontend/src/app/spreadsheet/yorkie-store.ts
@@ -9,6 +9,7 @@ import {
   getWorksheetCell,
   getWorksheetEntries,
   getWorksheetKeys,
+  createWorksheetAxisId,
   isCrossSheetRef,
   cloneConditionalFormatRule,
   normalizeConditionalFormatRule,
@@ -618,6 +619,21 @@ export class YorkieStore implements Store {
   getColOrder(): string[] {
     const ws = this.getSheet();
     return ws.colOrder ? [...ws.colOrder] : [];
+  }
+
+  ensureAxisOrder(minRows: number, minCols: number): void {
+    this.doc.update((root) => {
+      const ws = root.sheets[this.tabId];
+      if (!ws) return;
+      const rowPrefix = "r";
+      const colPrefix = "c";
+      while (ws.rowOrder.length < minRows) {
+        ws.rowOrder.push(createWorksheetAxisId(rowPrefix));
+      }
+      while (ws.colOrder.length < minCols) {
+        ws.colOrder.push(createWorksheetAxisId(colPrefix));
+      }
+    });
   }
 
   getPresences(): Array<{ clientID: string; presence: UserPresence }> {

--- a/packages/frontend/src/app/spreadsheet/yorkie-store.ts
+++ b/packages/frontend/src/app/spreadsheet/yorkie-store.ts
@@ -601,12 +601,6 @@ export class YorkieStore implements Store {
     return result;
   }
 
-  updateActiveCell(activeCell: Ref) {
-    this.doc.update((_, p) => {
-      p.set({ activeCell: toSref(activeCell), activeTabId: this.tabId });
-    });
-  }
-
   updateSelection(activeCell: CellAnchor, ranges: RangeAnchor[]) {
     this.doc.update((_, p) => {
       p.set({

--- a/packages/frontend/src/app/spreadsheet/yorkie-store.ts
+++ b/packages/frontend/src/app/spreadsheet/yorkie-store.ts
@@ -22,6 +22,8 @@ import type {
   Grid,
   Cell,
   CellStyle,
+  CellAnchor,
+  RangeAnchor,
   FilterCondition,
   FilterState,
   HiddenState,
@@ -603,6 +605,25 @@ export class YorkieStore implements Store {
     this.doc.update((_, p) => {
       p.set({ activeCell: toSref(activeCell), activeTabId: this.tabId });
     });
+  }
+
+  updateSelection(activeCell: CellAnchor, ranges: RangeAnchor[]) {
+    this.doc.update((_, p) => {
+      p.set({
+        selection: { activeCell, ranges },
+        activeTabId: this.tabId,
+      });
+    });
+  }
+
+  getRowOrder(): string[] {
+    const ws = this.getSheet();
+    return ws.rowOrder ? [...ws.rowOrder] : [];
+  }
+
+  getColOrder(): string[] {
+    const ws = this.getSheet();
+    return ws.colOrder ? [...ws.colOrder] : [];
   }
 
   getPresences(): Array<{ clientID: string; presence: UserPresence }> {

--- a/packages/frontend/src/types/users.ts
+++ b/packages/frontend/src/types/users.ts
@@ -1,4 +1,4 @@
-import type { Sref } from "@wafflebase/sheets";
+import type { Sref, SelectionPresence } from "@wafflebase/sheets";
 
 export type User = {
   id: number;
@@ -9,7 +9,8 @@ export type User = {
 };
 
 export type UserPresence = {
-  activeCell?: Sref;
+  selection?: SelectionPresence;
+  activeCell?: Sref; // legacy fallback for mixed-version peers
   activeTabId?: string;
 } & User;
 

--- a/packages/sheets/src/index.ts
+++ b/packages/sheets/src/index.ts
@@ -132,6 +132,15 @@ import {
   createWorksheetCellKey,
   parseWorksheetCellKey,
 } from './model/workbook/worksheet-record';
+import {
+  type CellAnchor,
+  type RangeAnchor,
+  type SelectionPresence,
+  anchorToRef,
+  refToAnchor,
+  rangeAnchorToRange,
+  rangeToRangeAnchor,
+} from './model/workbook/anchor-conversion';
 import { calculatePivot, materialize } from './model/pivot/index';
 import { parseSourceData } from './model/pivot/parse';
 import { parseRange } from './model/core/coordinates';
@@ -235,6 +244,10 @@ export {
   createSpreadsheetDocument,
   initialSpreadsheetDocument,
   getPeerCursorColor,
+  anchorToRef,
+  refToAnchor,
+  rangeAnchorToRange,
+  rangeToRangeAnchor,
 };
 
 export type {
@@ -289,4 +302,7 @@ export type {
   SheetKind,
   TabMeta,
   SpreadsheetDocument,
+  CellAnchor,
+  RangeAnchor,
+  SelectionPresence,
 };

--- a/packages/sheets/src/model/workbook/anchor-conversion.ts
+++ b/packages/sheets/src/model/workbook/anchor-conversion.ts
@@ -43,11 +43,14 @@ export function rangeAnchorToRange(
   anchor: RangeAnchor,
   rowOrder: string[],
   colOrder: string[],
+  dimension?: { rows: number; columns: number },
 ): Range | null {
+  const maxRows = dimension?.rows ?? rowOrder.length;
+  const maxCols = dimension?.columns ?? colOrder.length;
   const startR = anchor.startRowId ? rowOrder.indexOf(anchor.startRowId) + 1 : 1;
   const startC = anchor.startColId ? colOrder.indexOf(anchor.startColId) + 1 : 1;
-  const endR = anchor.endRowId ? rowOrder.indexOf(anchor.endRowId) + 1 : rowOrder.length;
-  const endC = anchor.endColId ? colOrder.indexOf(anchor.endColId) + 1 : colOrder.length;
+  const endR = anchor.endRowId ? rowOrder.indexOf(anchor.endRowId) + 1 : maxRows;
+  const endC = anchor.endColId ? colOrder.indexOf(anchor.endColId) + 1 : maxCols;
 
   // indexOf returns -1 → +1 = 0 means deleted
   if (anchor.startRowId && startR === 0 && anchor.endRowId && endR === 0) return null;

--- a/packages/sheets/src/model/workbook/anchor-conversion.ts
+++ b/packages/sheets/src/model/workbook/anchor-conversion.ts
@@ -1,0 +1,78 @@
+import type { Range, Ref, SelectionType } from '../core/types';
+
+export type CellAnchor = {
+  rowId: string;
+  colId: string;
+};
+
+export type RangeAnchor = {
+  startRowId: string | null;
+  startColId: string | null;
+  endRowId: string | null;
+  endColId: string | null;
+};
+
+export type SelectionPresence = {
+  activeCell: CellAnchor;
+  ranges: RangeAnchor[];
+};
+
+export function anchorToRef(
+  anchor: CellAnchor,
+  rowOrder: string[],
+  colOrder: string[],
+): Ref | null {
+  const r = rowOrder.indexOf(anchor.rowId);
+  const c = colOrder.indexOf(anchor.colId);
+  if (r === -1 || c === -1) return null;
+  return { r: r + 1, c: c + 1 };
+}
+
+export function refToAnchor(
+  ref: Ref,
+  rowOrder: string[],
+  colOrder: string[],
+): CellAnchor | null {
+  const rowId = rowOrder[ref.r - 1];
+  const colId = colOrder[ref.c - 1];
+  if (!rowId || !colId) return null;
+  return { rowId, colId };
+}
+
+export function rangeAnchorToRange(
+  anchor: RangeAnchor,
+  rowOrder: string[],
+  colOrder: string[],
+): Range | null {
+  const startR = anchor.startRowId ? rowOrder.indexOf(anchor.startRowId) + 1 : 1;
+  const startC = anchor.startColId ? colOrder.indexOf(anchor.startColId) + 1 : 1;
+  const endR = anchor.endRowId ? rowOrder.indexOf(anchor.endRowId) + 1 : rowOrder.length;
+  const endC = anchor.endColId ? colOrder.indexOf(anchor.endColId) + 1 : colOrder.length;
+
+  // indexOf returns -1 → +1 = 0 means deleted
+  if (anchor.startRowId && startR === 0 && anchor.endRowId && endR === 0) return null;
+  if (anchor.startColId && startC === 0 && anchor.endColId && endC === 0) return null;
+
+  return [
+    { r: Math.max(1, startR), c: Math.max(1, startC) },
+    { r: Math.max(1, endR), c: Math.max(1, endC) },
+  ];
+}
+
+export function rangeToRangeAnchor(
+  range: Range,
+  rowOrder: string[],
+  colOrder: string[],
+  selectionType: SelectionType,
+): RangeAnchor {
+  const [start, end] = range;
+  const useRow = selectionType !== 'column' && selectionType !== 'all';
+  const useCol = selectionType !== 'row' && selectionType !== 'all';
+
+  return {
+    startRowId: useRow ? (rowOrder[start.r - 1] ?? null) : null,
+    startColId: useCol ? (colOrder[start.c - 1] ?? null) : null,
+    endRowId: useRow ? (rowOrder[end.r - 1] ?? null) : null,
+    endColId: useCol ? (colOrder[end.c - 1] ?? null) : null,
+  };
+}

--- a/packages/sheets/src/model/workbook/anchor-conversion.ts
+++ b/packages/sheets/src/model/workbook/anchor-conversion.ts
@@ -72,6 +72,12 @@ export function rangeToRangeAnchor(
   const useRow = selectionType !== 'column' && selectionType !== 'all';
   const useCol = selectionType !== 'row' && selectionType !== 'all';
 
+  // When an index exceeds the axis order length (e.g. selecting column E
+  // when only A-B have data), use null to mean "extends to end of sheet".
+  // This is intentional: row/col selection with selectionType 'row'/'column'
+  // already sets the other axis to null, but for the selected axis we also
+  // need to handle the case where the visual grid is larger than the CRDT
+  // axis order.
   return {
     startRowId: useRow ? (rowOrder[start.r - 1] ?? null) : null,
     startColId: useCol ? (colOrder[start.c - 1] ?? null) : null,

--- a/packages/sheets/src/model/workbook/anchor-conversion.ts
+++ b/packages/sheets/src/model/workbook/anchor-conversion.ts
@@ -56,9 +56,24 @@ export function rangeAnchorToRange(
   if (anchor.startRowId && startR === 0 && anchor.endRowId && endR === 0) return null;
   if (anchor.startColId && startC === 0 && anchor.endColId && endC === 0) return null;
 
+  // When one endpoint is deleted, snap it to the surviving endpoint
+  let finalStartR = startR;
+  let finalStartC = startC;
+  let finalEndR = endR;
+  let finalEndC = endC;
+  if (anchor.startRowId && finalStartR === 0) finalStartR = finalEndR;
+  if (anchor.endRowId && finalEndR === 0) finalEndR = finalStartR;
+  if (anchor.startColId && finalStartC === 0) finalStartC = finalEndC;
+  if (anchor.endColId && finalEndC === 0) finalEndC = finalStartC;
+
+  const r1 = Math.max(1, Math.min(finalStartR, finalEndR));
+  const c1 = Math.max(1, Math.min(finalStartC, finalEndC));
+  const r2 = Math.max(1, Math.max(finalStartR, finalEndR));
+  const c2 = Math.max(1, Math.max(finalStartC, finalEndC));
+
   return [
-    { r: Math.max(1, startR), c: Math.max(1, startC) },
-    { r: Math.max(1, endR), c: Math.max(1, endC) },
+    { r: r1, c: c1 },
+    { r: r2, c: c2 },
   ];
 }
 

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -98,6 +98,14 @@ import {
   isNumericValue,
 } from './clipboard';
 import {
+  type CellAnchor,
+  type RangeAnchor,
+  refToAnchor,
+  anchorToRef,
+  rangeToRangeAnchor,
+  rangeAnchorToRange,
+} from '../workbook/anchor-conversion';
+import {
   hasCellContent,
   isEmptyCell,
   compactCell,
@@ -155,6 +163,9 @@ export class Sheet {
    * An empty array means no range is selected (only activeCell).
    */
   private ranges: Ranges = [];
+
+  private activeCellAnchor: CellAnchor | null = null;
+  private rangeAnchors: RangeAnchor[] = [];
 
   /**
    * `selectionType` indicates whether whole rows/columns or individual cells are selected.
@@ -1102,46 +1113,9 @@ export class Sheet {
     this.shiftFilterState(axis, index, count);
     this.shiftUserHiddenState(axis, index, count);
 
-    // Adjust activeCell if it's at or beyond the insertion/deletion point
-    const value = axis === 'row' ? this.activeCell.r : this.activeCell.c;
-    if (count > 0 && value >= index) {
-      // Insert: shift active cell forward
-      if (axis === 'row') {
-        this.activeCell = {
-          r: this.activeCell.r + count,
-          c: this.activeCell.c,
-        };
-      } else {
-        this.activeCell = {
-          r: this.activeCell.r,
-          c: this.activeCell.c + count,
-        };
-      }
-    } else if (count < 0) {
-      const absCount = Math.abs(count);
-      if (value >= index && value < index + absCount) {
-        // Active cell was in deleted zone, move to index (or 1 if index < 1)
-        if (axis === 'row') {
-          this.activeCell = { r: Math.max(1, index), c: this.activeCell.c };
-        } else {
-          this.activeCell = { r: this.activeCell.r, c: Math.max(1, index) };
-        }
-      } else if (value >= index + absCount) {
-        // Active cell is after deleted zone, shift back
-        if (axis === 'row') {
-          this.activeCell = {
-            r: this.activeCell.r + count,
-            c: this.activeCell.c,
-          };
-        } else {
-          this.activeCell = {
-            r: this.activeCell.r,
-            c: this.activeCell.c + count,
-          };
-        }
-      }
-    }
-    this.activeCell = this.normalizeRefToAnchor(this.activeCell);
+    // ActiveCell adjustment is handled by resolveAnchorsToRefs() via axis IDs.
+    // For local edits, re-resolve immediately since rowOrder has already changed.
+    this.resolveAnchorsToRefs();
 
     // Batch the freeze pane adjustment and formula recalculation together
     this.store.beginBatch();
@@ -2027,7 +2001,9 @@ export class Sheet {
         { r: minR, c: minC },
         { r: maxR, c: maxC },
       ]];
-      this.store.updateActiveCell(this.activeCell);
+      const cellAnchor = refToAnchor(this.activeCell, this.store.getRowOrder(), this.store.getColOrder());
+      if (cellAnchor) this.activeCellAnchor = cellAnchor;
+      this.syncSelectionToPresence();
     }
   }
 
@@ -2135,7 +2111,9 @@ export class Sheet {
     this.selectionType = 'cell';
     this.activeCell = destStart;
     this.ranges = [[destStart, destEnd]];
-    this.store.updateActiveCell(this.activeCell);
+    const cellAnchor = refToAnchor(this.activeCell, this.store.getRowOrder(), this.store.getColOrder());
+    if (cellAnchor) this.activeCellAnchor = cellAnchor;
+    this.syncSelectionToPresence();
   }
 
   /**
@@ -2596,6 +2574,17 @@ export class Sheet {
     this.crossSheetFormulaSrefs = null;
   }
 
+  private syncSelectionToPresence(): void {
+    if (!this.activeCellAnchor) return;
+    const rowOrder = this.store.getRowOrder();
+    const colOrder = this.store.getColOrder();
+    const rangeAnchors = this.ranges.map((range) =>
+      rangeToRangeAnchor(range, rowOrder, colOrder, this.selectionType),
+    );
+    this.rangeAnchors = rangeAnchors;
+    this.store.updateSelection(this.activeCellAnchor, rangeAnchors);
+  }
+
   /**
    * `getActiveCell` returns the currently selected cell.
    */
@@ -2609,7 +2598,13 @@ export class Sheet {
   public setActiveCell(ref: Ref): void {
     const anchor = this.normalizeRefToAnchor(ref);
     this.activeCell = anchor;
-    this.store.updateActiveCell(anchor);
+
+    const cellAnchor = refToAnchor(anchor, this.store.getRowOrder(), this.store.getColOrder());
+    if (cellAnchor) {
+      this.activeCellAnchor = cellAnchor;
+    }
+
+    this.syncSelectionToPresence();
   }
 
   /**
@@ -2674,7 +2669,9 @@ export class Sheet {
       { r: row, c: 1 },
       { r: row, c: this.dimension.columns },
     ]];
-    this.store.updateActiveCell(this.activeCell);
+    const cellAnchor = refToAnchor(this.activeCell, this.store.getRowOrder(), this.store.getColOrder());
+    if (cellAnchor) this.activeCellAnchor = cellAnchor;
+    this.syncSelectionToPresence();
   }
 
   /**
@@ -2687,7 +2684,9 @@ export class Sheet {
       { r: 1, c: col },
       { r: this.dimension.rows, c: col },
     ]];
-    this.store.updateActiveCell(this.activeCell);
+    const cellAnchor = refToAnchor(this.activeCell, this.store.getRowOrder(), this.store.getColOrder());
+    if (cellAnchor) this.activeCellAnchor = cellAnchor;
+    this.syncSelectionToPresence();
   }
 
   /**
@@ -2723,7 +2722,9 @@ export class Sheet {
     this.selectionType = 'all';
     this.activeCell = { r: 1, c: 1 };
     this.ranges = [cloneRange(this.dimensionRange)];
-    this.store.updateActiveCell(this.activeCell);
+    const cellAnchor = refToAnchor(this.activeCell, this.store.getRowOrder(), this.store.getColOrder());
+    if (cellAnchor) this.activeCellAnchor = cellAnchor;
+    this.syncSelectionToPresence();
   }
 
   /**
@@ -3124,7 +3125,9 @@ export class Sheet {
     this.selectionType = 'cell';
     const anchor = this.normalizeRefToAnchor(ref);
     this.activeCell = anchor;
-    this.store.updateActiveCell(anchor);
+    const cellAnchor = refToAnchor(anchor, this.store.getRowOrder(), this.store.getColOrder());
+    if (cellAnchor) this.activeCellAnchor = cellAnchor;
+    this.syncSelectionToPresence();
     // Append a new collapsed range for the new selection start
     this.ranges.push([anchor, anchor]);
   }
@@ -3773,7 +3776,9 @@ export class Sheet {
         } else {
           this.ranges = [result.affectedRange];
         }
-        this.store.updateActiveCell(this.activeCell);
+        const cellAnchor = refToAnchor(this.activeCell, this.store.getRowOrder(), this.store.getColOrder());
+        if (cellAnchor) this.activeCellAnchor = cellAnchor;
+        this.syncSelectionToPresence();
       }
 
       this.ensureActiveCellVisibleAfterHiding();
@@ -3805,7 +3810,9 @@ export class Sheet {
         } else {
           this.ranges = [result.affectedRange];
         }
-        this.store.updateActiveCell(this.activeCell);
+        const cellAnchor = refToAnchor(this.activeCell, this.store.getRowOrder(), this.store.getColOrder());
+        if (cellAnchor) this.activeCellAnchor = cellAnchor;
+        this.syncSelectionToPresence();
       }
 
       this.ensureActiveCellVisibleAfterHiding();
@@ -3967,5 +3974,38 @@ export class Sheet {
 
     results.sort((a, b) => a.r !== b.r ? a.r - b.r : a.c - b.c);
     return results;
+  }
+
+  public resolveAnchorsToRefs(): void {
+    if (!this.activeCellAnchor) return;
+    const rowOrder = this.store.getRowOrder();
+    const colOrder = this.store.getColOrder();
+
+    const newRef = anchorToRef(this.activeCellAnchor, rowOrder, colOrder);
+    if (newRef) {
+      this.activeCell = this.normalizeRefToAnchor(newRef);
+    } else {
+      // Axis ID was deleted — snap to {r:1, c:1}
+      this.activeCell = { r: 1, c: 1 };
+      const newAnchor = refToAnchor(this.activeCell, rowOrder, colOrder);
+      if (newAnchor) {
+        this.activeCellAnchor = newAnchor;
+        this.syncSelectionToPresence();
+      }
+    }
+
+    // Re-resolve ranges
+    const newRanges: Range[] = [];
+    for (const anchor of this.rangeAnchors) {
+      const range = rangeAnchorToRange(anchor, rowOrder, colOrder);
+      if (range) {
+        newRanges.push(range);
+      }
+    }
+    this.ranges = newRanges;
+  }
+
+  public getStore(): Store {
+    return this.store;
   }
 }

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -2581,8 +2581,6 @@ export class Sheet {
   }
 
   private syncSelectionToPresence(): void {
-    if (!this.activeCellAnchor) return;
-
     // Ensure axis orders cover the activeCell and the non-null axes of
     // the selection.  For column selection only cols need extending (not
     // all 100 rows); for row selection only rows.
@@ -2606,11 +2604,12 @@ export class Sheet {
     const rowOrder = this.store.getRowOrder();
     const colOrder = this.store.getColOrder();
 
-    // Re-resolve activeCell anchor after potential axis extension
+    // Resolve activeCell anchor (bootstrap on first call or after axis extension)
     const freshAnchor = refToAnchor(this.activeCell, rowOrder, colOrder);
     if (freshAnchor) {
       this.activeCellAnchor = freshAnchor;
     }
+    if (!this.activeCellAnchor) return;
 
     const rangeAnchors = this.ranges.map((range) =>
       rangeToRangeAnchor(range, rowOrder, colOrder, this.selectionType),

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -2350,6 +2350,7 @@ export class Sheet {
 
     this.selectionType = 'cell';
     this.ranges = [fillRange];
+    this.syncSelectionToPresence();
     return true;
   }
 
@@ -2733,6 +2734,7 @@ export class Sheet {
       { r: minRow, c: 1 },
       { r: maxRow, c: this.dimension.columns },
     ]];
+    this.syncSelectionToPresence();
   }
 
   /**
@@ -2746,6 +2748,7 @@ export class Sheet {
       { r: 1, c: minCol },
       { r: this.dimension.rows, c: maxCol },
     ]];
+    this.syncSelectionToPresence();
   }
 
   /**
@@ -3240,10 +3243,12 @@ export class Sheet {
 
     if (isSameRange(prev, curr)) {
       this.ranges = [cloneRange(this.dimensionRange)];
+      this.syncSelectionToPresence();
       return;
     }
 
     this.ranges = [curr];
+    this.syncSelectionToPresence();
   }
 
   /**
@@ -3423,6 +3428,7 @@ export class Sheet {
     }
 
     this.ranges = [this.expandRangeToMergedBoundaries(range)];
+    this.syncSelectionToPresence();
     return true;
   }
 
@@ -3709,8 +3715,11 @@ export class Sheet {
     }
 
     this.selectionType = 'cell';
-    this.setActiveCell(anchor);
+    this.activeCell = this.normalizeRefToAnchor(anchor);
+    const cellAnchor = refToAnchor(this.activeCell, this.store.getRowOrder(), this.store.getColOrder());
+    if (cellAnchor) this.activeCellAnchor = cellAnchor;
     this.ranges = [toMergeRange(anchor, span)];
+    this.syncSelectionToPresence();
     return true;
   }
 
@@ -3749,6 +3758,7 @@ export class Sheet {
 
     this.selectionType = 'cell';
     this.ranges = [];
+    this.syncSelectionToPresence();
     return true;
   }
 

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -3161,9 +3161,9 @@ export class Sheet {
     this.activeCell = anchor;
     const cellAnchor = refToAnchor(anchor, this.store.getRowOrder(), this.store.getColOrder());
     if (cellAnchor) this.activeCellAnchor = cellAnchor;
-    this.syncSelectionToPresence();
-    // Append a new collapsed range for the new selection start
+    // Append the new collapsed range before syncing so peers see it
     this.ranges.push([anchor, anchor]);
+    this.syncSelectionToPresence();
   }
 
   /**
@@ -4028,11 +4028,10 @@ export class Sheet {
       const newAnchor = refToAnchor(this.activeCell, rowOrder, colOrder);
       if (newAnchor) {
         this.activeCellAnchor = newAnchor;
-        this.syncSelectionToPresence();
       }
     }
 
-    // Re-resolve ranges
+    // Re-resolve ranges before syncing so peers get the repaired state
     const newRanges: Range[] = [];
     for (const anchor of this.rangeAnchors) {
       const range = rangeAnchorToRange(anchor, rowOrder, colOrder, this.dimension);
@@ -4041,6 +4040,11 @@ export class Sheet {
       }
     }
     this.ranges = newRanges;
+
+    // Republish repaired selection if activeCell was deleted
+    if (!newRef) {
+      this.syncSelectionToPresence();
+    }
   }
 
   public getStore(): Store {

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -2634,7 +2634,11 @@ export class Sheet {
    */
   getPresences(): Array<{
     clientID: string;
-    presence: { activeCell: string; username?: string };
+    presence: {
+      selection?: import('../workbook/anchor-conversion').SelectionPresence;
+      activeCell?: string;
+      username?: string;
+    };
   }> {
     return this.store.getPresences();
   }

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -4003,7 +4003,7 @@ export class Sheet {
     // Re-resolve ranges
     const newRanges: Range[] = [];
     for (const anchor of this.rangeAnchors) {
-      const range = rangeAnchorToRange(anchor, rowOrder, colOrder);
+      const range = rangeAnchorToRange(anchor, rowOrder, colOrder, this.dimension);
       if (range) {
         newRanges.push(range);
       }

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -3109,8 +3109,8 @@ export class Sheet {
     }
 
     this.selectionType = 'cell';
-    this.setActiveCell(this.normalizeRefToAnchor(ref));
     this.ranges = [];
+    this.setActiveCell(this.normalizeRefToAnchor(ref));
   }
 
   /**
@@ -3154,11 +3154,13 @@ export class Sheet {
 
     if (isSameRef(anchor, target)) {
       this.ranges[this.ranges.length - 1] = [anchor, anchor];
+      this.syncSelectionToPresence();
       return;
     }
 
     this.ranges[this.ranges.length - 1] =
       this.expandRangeToMergedBoundaries(toRange(anchor, target));
+    this.syncSelectionToPresence();
   }
 
   /**
@@ -3172,12 +3174,14 @@ export class Sheet {
     const target = this.normalizeRefToAnchor(ref);
     if (isSameRef(this.activeCell, target)) {
       this.ranges = [];
+      this.syncSelectionToPresence();
       return;
     }
 
     this.ranges = [this.expandRangeToMergedBoundaries(
       toRange(this.activeCell, target),
     )];
+    this.syncSelectionToPresence();
   }
 
   /**

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -2582,8 +2582,36 @@ export class Sheet {
 
   private syncSelectionToPresence(): void {
     if (!this.activeCellAnchor) return;
+
+    // Ensure axis orders cover the activeCell and the non-null axes of
+    // the selection.  For column selection only cols need extending (not
+    // all 100 rows); for row selection only rows.
+    const minRow = this.activeCell.r;
+    const minCol = this.activeCell.c;
+    let maxRow = minRow;
+    let maxCol = minCol;
+    const isRow = this.selectionType === 'row';
+    const isCol = this.selectionType === 'column';
+    const isAll = this.selectionType === 'all';
+    for (const [start, end] of this.ranges) {
+      if (!isCol && !isAll) {
+        maxRow = Math.max(maxRow, start.r, end.r);
+      }
+      if (!isRow && !isAll) {
+        maxCol = Math.max(maxCol, start.c, end.c);
+      }
+    }
+    this.store.ensureAxisOrder(maxRow, maxCol);
+
     const rowOrder = this.store.getRowOrder();
     const colOrder = this.store.getColOrder();
+
+    // Re-resolve activeCell anchor after potential axis extension
+    const freshAnchor = refToAnchor(this.activeCell, rowOrder, colOrder);
+    if (freshAnchor) {
+      this.activeCellAnchor = freshAnchor;
+    }
+
     const rangeAnchors = this.ranges.map((range) =>
       rangeToRangeAnchor(range, rowOrder, colOrder, this.selectionType),
     );

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -301,6 +301,12 @@ export class Sheet {
     this.store = store;
     this.dimension = { ...Dimensions };
     this.activeCell = { r: 1, c: 1 };
+    // Initialize anchor from the default activeCell
+    const rowOrder = this.store.getRowOrder();
+    const colOrder = this.store.getColOrder();
+    if (rowOrder.length > 0 && colOrder.length > 0) {
+      this.activeCellAnchor = refToAnchor(this.activeCell, rowOrder, colOrder);
+    }
   }
 
   /**

--- a/packages/sheets/src/store/memory.ts
+++ b/packages/sheets/src/store/memory.ts
@@ -331,6 +331,10 @@ export class MemStore implements Store {
     return [];
   }
 
+  ensureAxisOrder(_minRows: number, _minCols: number): void {
+    // No-op for memory store
+  }
+
   async setColumnStyle(col: number, style: CellStyle): Promise<void> {
     this.colStyles.set(col, style);
   }

--- a/packages/sheets/src/store/memory.ts
+++ b/packages/sheets/src/store/memory.ts
@@ -319,15 +319,6 @@ export class MemStore implements Store {
     return new Map(axis === 'row' ? this.rowHeights : this.colWidths);
   }
 
-  /**
-   * `updateActiveCell` method updates the active cell of the current user.
-   * For MemStore, this is a no-op since it's not connected to real-time collaboration.
-   * @deprecated Use `updateSelection` instead.
-   */
-  updateActiveCell(_: Ref): void {
-    // No-op for memory store
-  }
-
   updateSelection(_activeCell: CellAnchor, _ranges: RangeAnchor[]): void {
     // No-op for memory store
   }

--- a/packages/sheets/src/store/memory.ts
+++ b/packages/sheets/src/store/memory.ts
@@ -40,6 +40,7 @@ import {
   Direction,
   FilterState,
 } from '../model/core/types';
+import type { CellAnchor, RangeAnchor, SelectionPresence } from '../model/workbook/anchor-conversion';
 import { CellIndex } from './cell-index';
 import { findEdgeWithIndex } from './find-edge';
 import { Store } from './store';
@@ -296,7 +297,11 @@ export class MemStore implements Store {
    */
   getPresences(): Array<{
     clientID: string;
-    presence: { activeCell: string; username?: string };
+    presence: {
+      selection?: SelectionPresence;
+      activeCell?: string;
+      username?: string;
+    };
   }> {
     return [];
   }
@@ -317,9 +322,22 @@ export class MemStore implements Store {
   /**
    * `updateActiveCell` method updates the active cell of the current user.
    * For MemStore, this is a no-op since it's not connected to real-time collaboration.
+   * @deprecated Use `updateSelection` instead.
    */
   updateActiveCell(_: Ref): void {
     // No-op for memory store
+  }
+
+  updateSelection(_activeCell: CellAnchor, _ranges: RangeAnchor[]): void {
+    // No-op for memory store
+  }
+
+  getRowOrder(): string[] {
+    return [];
+  }
+
+  getColOrder(): string[] {
+    return [];
   }
 
   async setColumnStyle(col: number, style: CellStyle): Promise<void> {

--- a/packages/sheets/src/store/readonly.ts
+++ b/packages/sheets/src/store/readonly.ts
@@ -161,6 +161,10 @@ export class ReadOnlyStore implements Store {
     return [];
   }
 
+  ensureAxisOrder(_minRows: number, _minCols: number): void {
+    // no-op
+  }
+
   async setDimensionSize(
     _axis: Axis,
     _index: number,

--- a/packages/sheets/src/store/readonly.ts
+++ b/packages/sheets/src/store/readonly.ts
@@ -149,13 +149,6 @@ export class ReadOnlyStore implements Store {
     return [];
   }
 
-  /**
-   * @deprecated Use `updateSelection` instead.
-   */
-  updateActiveCell(_ref: Ref): void {
-    // no-op
-  }
-
   updateSelection(_activeCell: CellAnchor, _ranges: RangeAnchor[]): void {
     // no-op
   }

--- a/packages/sheets/src/store/readonly.ts
+++ b/packages/sheets/src/store/readonly.ts
@@ -14,6 +14,7 @@ import {
   Sref,
   Direction,
 } from '../model/core/types';
+import type { CellAnchor, RangeAnchor, SelectionPresence } from '../model/workbook/anchor-conversion';
 import { RangeStylePatch } from '../model/worksheet/range-styles';
 import { CellIndex } from './cell-index';
 import { findEdgeWithIndex } from './find-edge';
@@ -139,13 +140,32 @@ export class ReadOnlyStore implements Store {
 
   getPresences(): Array<{
     clientID: string;
-    presence: { activeCell: string; username?: string };
+    presence: {
+      selection?: SelectionPresence;
+      activeCell?: string;
+      username?: string;
+    };
   }> {
     return [];
   }
 
+  /**
+   * @deprecated Use `updateSelection` instead.
+   */
   updateActiveCell(_ref: Ref): void {
     // no-op
+  }
+
+  updateSelection(_activeCell: CellAnchor, _ranges: RangeAnchor[]): void {
+    // no-op
+  }
+
+  getRowOrder(): string[] {
+    return [];
+  }
+
+  getColOrder(): string[] {
+    return [];
   }
 
   async setDimensionSize(

--- a/packages/sheets/src/store/store.ts
+++ b/packages/sheets/src/store/store.ts
@@ -13,6 +13,7 @@ import {
   Sref,
   Direction,
 } from '../model/core/types';
+import type { CellAnchor, RangeAnchor, SelectionPresence } from '../model/workbook/anchor-conversion';
 import { RangeStylePatch } from '../model/worksheet/range-styles';
 
 /**
@@ -73,7 +74,14 @@ export interface Store {
   /**
    * `getPresences` method gets the user presences.
    */
-  getPresences(): Array<{ clientID: string; presence: { activeCell: string; username?: string } }>;
+  getPresences(): Array<{
+    clientID: string;
+    presence: {
+      selection?: SelectionPresence;
+      activeCell?: string; // legacy fallback
+      username?: string;
+    };
+  }>;
 
   /**
    * `shiftCells` method shifts cells along the given axis.
@@ -203,9 +211,25 @@ export interface Store {
   getPivotDefinition(): Promise<PivotTableDefinition | undefined>;
 
   /**
+   * @deprecated Use `updateSelection` instead. Will be removed after migration.
    * `updateActiveCell` method updates the active cell of the current user.
    */
   updateActiveCell(activeCell: Ref): void;
+
+  /**
+   * `updateSelection` updates the selection of the current user in presence.
+   */
+  updateSelection(activeCell: CellAnchor, ranges: RangeAnchor[]): void;
+
+  /**
+   * `getRowOrder` returns the current row axis ID ordering.
+   */
+  getRowOrder(): string[];
+
+  /**
+   * `getColOrder` returns the current column axis ID ordering.
+   */
+  getColOrder(): string[];
 
   /**
    * `setFreezePane` method sets the freeze pane position.

--- a/packages/sheets/src/store/store.ts
+++ b/packages/sheets/src/store/store.ts
@@ -226,6 +226,12 @@ export interface Store {
   getColOrder(): string[];
 
   /**
+   * `ensureAxisOrder` ensures the row/col axis orders have at least the
+   * given number of entries, creating new axis IDs if needed.
+   */
+  ensureAxisOrder(minRows: number, minCols: number): void;
+
+  /**
    * `setFreezePane` method sets the freeze pane position.
    */
   setFreezePane(frozenRows: number, frozenCols: number): Promise<void>;

--- a/packages/sheets/src/store/store.ts
+++ b/packages/sheets/src/store/store.ts
@@ -211,12 +211,6 @@ export interface Store {
   getPivotDefinition(): Promise<PivotTableDefinition | undefined>;
 
   /**
-   * @deprecated Use `updateSelection` instead. Will be removed after migration.
-   * `updateActiveCell` method updates the active cell of the current user.
-   */
-  updateActiveCell(activeCell: Ref): void;
-
-  /**
    * `updateSelection` updates the selection of the current user in presence.
    */
   updateSelection(activeCell: CellAnchor, ranges: RangeAnchor[]): void;

--- a/packages/sheets/src/view/overlay.ts
+++ b/packages/sheets/src/view/overlay.ts
@@ -138,7 +138,7 @@ export class Overlay {
     activeCell: Ref,
     peerPresences: Array<{
       clientID: string;
-      presence: { activeCell: string; username?: string };
+      presence: { activeCell?: string; username?: string };
     }>,
     ranges?: Ranges,
     rowDim?: DimensionIndex,
@@ -602,7 +602,7 @@ export class Overlay {
   private renderPeerCursorsSimple(
     ctx: CanvasRenderingContext2D,
     port: BoundingRect,
-    peerPresences: Array<{ clientID: string; presence: { activeCell: string; username?: string } }>,
+    peerPresences: Array<{ clientID: string; presence: { activeCell?: string; username?: string } }>,
     scroll: { left: number; top: number },
     rowDim?: DimensionIndex,
     colDim?: DimensionIndex,

--- a/packages/sheets/src/view/overlay.ts
+++ b/packages/sheets/src/view/overlay.ts
@@ -170,6 +170,7 @@ export class Overlay {
     cellDragMovePreview?: Range,
     rowOrder?: string[],
     colOrder?: string[],
+    sheetDimension?: { rows: number; columns: number },
   ) {
     this.canvas.width = 0;
     this.canvas.height = 0;
@@ -229,6 +230,7 @@ export class Overlay {
         visiblePeerLabels,
         rowOrder,
         colOrder,
+        sheetDimension,
       );
       this.renderFilterRangeSimple(ctx, filterRange, scroll, rowDim, colDim);
       this.renderFormulaRangesSimple(ctx, formulaRanges, scroll, rowDim, colDim);
@@ -251,7 +253,7 @@ export class Overlay {
         if (presence.selection && rowOrder && colOrder) {
           peerRef = anchorToRef(presence.selection.activeCell, rowOrder, colOrder);
           for (const rangeAnchor of presence.selection.ranges) {
-            const range = rangeAnchorToRange(rangeAnchor, rowOrder, colOrder);
+            const range = rangeAnchorToRange(rangeAnchor, rowOrder, colOrder, sheetDimension);
             if (range) peerRanges.push(range);
           }
         } else if (presence.activeCell) {
@@ -649,6 +651,7 @@ export class Overlay {
     visiblePeerLabels?: Set<string>,
     rowOrder?: string[],
     colOrder?: string[],
+    sheetDimension?: { rows: number; columns: number },
   ): void {
     const cellPeers = new Map<string, Array<{ clientID: string; username: string; rect: BoundingRect }>>();
 
@@ -660,7 +663,7 @@ export class Overlay {
         // New format: axis ID based
         peerActiveCell = anchorToRef(presence.selection.activeCell, rowOrder, colOrder);
         for (const rangeAnchor of presence.selection.ranges) {
-          const range = rangeAnchorToRange(rangeAnchor, rowOrder, colOrder);
+          const range = rangeAnchorToRange(rangeAnchor, rowOrder, colOrder, sheetDimension);
           if (range) peerRanges.push(range);
         }
       } else if (presence.activeCell) {

--- a/packages/sheets/src/view/overlay.ts
+++ b/packages/sheets/src/view/overlay.ts
@@ -1,4 +1,6 @@
 import { MergeSpan, Ref, Range, Ranges, SelectionType } from '../model/core/types';
+import type { SelectionPresence } from '../model/workbook/anchor-conversion';
+import { anchorToRef, rangeAnchorToRange } from '../model/workbook/anchor-conversion';
 import { DimensionIndex } from '../model/worksheet/dimensions';
 import { parseRef, toSref, isSameRange } from '../model/core/coordinates';
 import { Theme, ThemeKey, getThemeColor, getPeerCursorColor, getFormulaRangeColor } from './theme';
@@ -138,7 +140,11 @@ export class Overlay {
     activeCell: Ref,
     peerPresences: Array<{
       clientID: string;
-      presence: { activeCell?: string; username?: string };
+      presence: {
+        selection?: SelectionPresence;
+        activeCell?: string;
+        username?: string;
+      };
     }>,
     ranges?: Ranges,
     rowDim?: DimensionIndex,
@@ -162,6 +168,8 @@ export class Overlay {
     searchCurrentIndex?: number,
     visiblePeerLabels?: Set<string>,
     cellDragMovePreview?: Range,
+    rowOrder?: string[],
+    colOrder?: string[],
   ) {
     this.canvas.width = 0;
     this.canvas.height = 0;
@@ -219,6 +227,8 @@ export class Overlay {
         colDim,
         mergeData,
         visiblePeerLabels,
+        rowOrder,
+        colOrder,
       );
       this.renderFilterRangeSimple(ctx, filterRange, scroll, rowDim, colDim);
       this.renderFormulaRangesSimple(ctx, formulaRanges, scroll, rowDim, colDim);
@@ -235,8 +245,20 @@ export class Overlay {
 
       // Render peer cursors per quadrant
       for (const { clientID, presence } of peerPresences) {
-        if (!presence.activeCell) continue;
-        const peerRef = parseRef(presence.activeCell);
+        let peerRef: Ref | null = null;
+        let peerRanges: Range[] = [];
+
+        if (presence.selection && rowOrder && colOrder) {
+          peerRef = anchorToRef(presence.selection.activeCell, rowOrder, colOrder);
+          for (const rangeAnchor of presence.selection.ranges) {
+            const range = rangeAnchorToRange(rangeAnchor, rowOrder, colOrder);
+            if (range) peerRanges.push(range);
+          }
+        } else if (presence.activeCell) {
+          peerRef = parseRef(presence.activeCell);
+        }
+
+        if (!peerRef) continue;
         const peerColor = getPeerCursorColor(this.theme, clientID);
 
         for (const q of quadrants) {
@@ -245,9 +267,16 @@ export class Overlay {
           ctx.rect(q.x, q.y, q.width, q.height);
           ctx.clip();
 
+          const qScroll = { left: q.scrollLeft, top: q.scrollTop };
+
+          // Draw range backgrounds
+          for (const range of peerRanges) {
+            this.renderPeerRangeBackground(ctx, range, peerColor, qScroll, rowDim, colDim);
+          }
+
           const rect = this.toCellRect(
             peerRef,
-            { left: q.scrollLeft, top: q.scrollTop },
+            qScroll,
             rowDim,
             colDim,
             mergeData,
@@ -602,7 +631,14 @@ export class Overlay {
   private renderPeerCursorsSimple(
     ctx: CanvasRenderingContext2D,
     port: BoundingRect,
-    peerPresences: Array<{ clientID: string; presence: { activeCell?: string; username?: string } }>,
+    peerPresences: Array<{
+      clientID: string;
+      presence: {
+        selection?: SelectionPresence;
+        activeCell?: string;
+        username?: string;
+      };
+    }>,
     scroll: { left: number; top: number },
     rowDim?: DimensionIndex,
     colDim?: DimensionIndex,
@@ -611,31 +647,46 @@ export class Overlay {
       coverToAnchor: Map<string, string>;
     },
     visiblePeerLabels?: Set<string>,
+    rowOrder?: string[],
+    colOrder?: string[],
   ): void {
-    // Map from cell sref -> peers that need labels drawn there (for stacking).
     const cellPeers = new Map<string, Array<{ clientID: string; username: string; rect: BoundingRect }>>();
 
     for (const { clientID, presence } of peerPresences) {
-      if (!presence.activeCell) continue;
+      let peerActiveCell: Ref | null = null;
+      let peerRanges: Range[] = [];
 
-      const peerActiveCell = parseRef(presence.activeCell);
-      const rect = this.toCellRect(
-        peerActiveCell,
-        scroll,
-        rowDim,
-        colDim,
-        mergeData,
-      );
+      if (presence.selection && rowOrder && colOrder) {
+        // New format: axis ID based
+        peerActiveCell = anchorToRef(presence.selection.activeCell, rowOrder, colOrder);
+        for (const rangeAnchor of presence.selection.ranges) {
+          const range = rangeAnchorToRange(rangeAnchor, rowOrder, colOrder);
+          if (range) peerRanges.push(range);
+        }
+      } else if (presence.activeCell) {
+        // Legacy format: Sref string
+        peerActiveCell = parseRef(presence.activeCell);
+      }
 
+      if (!peerActiveCell) continue;
+
+      const peerColor = getPeerCursorColor(this.theme, clientID);
+
+      // Draw range backgrounds
+      for (const range of peerRanges) {
+        this.renderPeerRangeBackground(ctx, range, peerColor, scroll, rowDim, colDim);
+      }
+
+      // Draw active cell border
+      const rect = this.toCellRect(peerActiveCell, scroll, rowDim, colDim, mergeData);
       if (rect.left >= -rect.width && rect.left < port.width &&
           rect.top >= -rect.height && rect.top < port.height) {
-        const peerColor = getPeerCursorColor(this.theme, clientID);
         ctx.strokeStyle = peerColor;
         ctx.lineWidth = 2;
         ctx.strokeRect(rect.left, rect.top, rect.width, rect.height);
 
         if (visiblePeerLabels?.has(clientID) && presence.username) {
-          const key = presence.activeCell;
+          const key = peerActiveCell.r + ',' + peerActiveCell.c;
           if (!cellPeers.has(key)) {
             cellPeers.set(key, []);
           }
@@ -653,6 +704,28 @@ export class Overlay {
         drawPeerLabel(ctx, username, peerColor, rect, port, i);
       }
     }
+  }
+
+  private renderPeerRangeBackground(
+    ctx: CanvasRenderingContext2D,
+    range: Range,
+    color: string,
+    scroll: { left: number; top: number },
+    rowDim?: DimensionIndex,
+    colDim?: DimensionIndex,
+  ): void {
+    const startRect = this.toCellRect(range[0], scroll, rowDim, colDim);
+    const endRect = this.toCellRect(range[1], scroll, rowDim, colDim);
+    const x = startRect.left;
+    const y = startRect.top;
+    const w = endRect.left + endRect.width - startRect.left;
+    const h = endRect.top + endRect.height - startRect.top;
+
+    ctx.save();
+    ctx.fillStyle = color;
+    ctx.globalAlpha = 0.1;
+    ctx.fillRect(x, y, w, h);
+    ctx.restore();
   }
 
   private renderFilterRangeSimple(

--- a/packages/sheets/src/view/worksheet.ts
+++ b/packages/sheets/src/view/worksheet.ts
@@ -4543,6 +4543,7 @@ export class Worksheet {
       this.cellDragMovePreview,
       this.sheet!.getStore().getRowOrder(),
       this.sheet!.getStore().getColOrder(),
+      this.sheet!.getDimension(),
     );
   }
 

--- a/packages/sheets/src/view/worksheet.ts
+++ b/packages/sheets/src/view/worksheet.ts
@@ -4180,6 +4180,10 @@ export class Worksheet {
     await this.sheet!.loadFilterState();
     await this.sheet!.loadHiddenState();
     await this.sheet!.loadPivotDefinition();
+
+    // Re-resolve axis-ID-based selection after structural changes
+    this.sheet!.resolveAnchorsToRefs();
+
     this.hiddenRows.clear();
     this.hiddenRowSizeBackup.clear();
     this.hiddenColumns.clear();

--- a/packages/sheets/src/view/worksheet.ts
+++ b/packages/sheets/src/view/worksheet.ts
@@ -4191,6 +4191,10 @@ export class Worksheet {
     this.syncHiddenRowsFromSheet();
     this.syncHiddenColumnsFromSheet();
     this.updateFreezeState();
+
+    // Reposition the input cell after structural changes so it follows
+    // the active cell to its new visual location.
+    this.updateCellInputPosition();
   }
 
   /**

--- a/packages/sheets/src/view/worksheet.ts
+++ b/packages/sheets/src/view/worksheet.ts
@@ -4460,12 +4460,16 @@ export class Worksheet {
     const currentPeerIDs = new Set<string>();
 
     for (const { clientID, presence } of presences) {
-      if (!presence.activeCell) continue;
+      // Derive a stable key from either the new selection or legacy activeCell
+      const cellKey = presence.selection
+        ? `${presence.selection.activeCell.rowId}|${presence.selection.activeCell.colId}`
+        : presence.activeCell;
+      if (!cellKey) continue;
       currentPeerIDs.add(clientID);
 
       const prev = this.prevPeerActiveCells.get(clientID);
-      if (prev !== presence.activeCell) {
-        this.prevPeerActiveCells.set(clientID, presence.activeCell);
+      if (prev !== cellKey) {
+        this.prevPeerActiveCells.set(clientID, cellKey);
 
         const existingTimer = this.peerLabelTimers.get(clientID);
         if (existingTimer != null) {

--- a/packages/sheets/src/view/worksheet.ts
+++ b/packages/sheets/src/view/worksheet.ts
@@ -4541,6 +4541,8 @@ export class Worksheet {
       this._searchCurrentIndex >= 0 ? this._searchCurrentIndex : undefined,
       this.getVisiblePeerLabels(),
       this.cellDragMovePreview,
+      this.sheet!.getStore().getRowOrder(),
+      this.sheet!.getStore().getColOrder(),
     );
   }
 

--- a/packages/sheets/src/view/worksheet.ts
+++ b/packages/sheets/src/view/worksheet.ts
@@ -5,6 +5,7 @@ import {
   isReferenceInsertPosition,
   findReferenceTokenAtCursor,
 } from '../formula/formula';
+import { anchorToRef } from '../model/workbook/anchor-conversion';
 import { DimensionIndex } from '../model/worksheet/dimensions';
 import { Sheet } from '../model/worksheet/sheet';
 import { Theme, getThemeColor } from './theme';
@@ -2534,16 +2535,18 @@ export class Worksheet {
       const mouseRow = this.toRowFromMouse(hoverY);
       const mouseCol = this.toColFromMouse(hoverX);
       const presences = this.sheet!.getPresences();
+      const rowOrder = this.sheet!.getStore().getRowOrder();
+      const colOrder = this.sheet!.getStore().getColOrder();
       for (const { clientID, presence } of presences) {
-        if (!presence.activeCell) continue;
-        try {
-          const ref = parseRef(presence.activeCell);
-          if (ref.r === mouseRow && ref.c === mouseCol) {
-            newHoveredPeer = clientID;
-            break;
-          }
-        } catch {
-          // Skip peers with invalid activeCell references
+        let ref: { r: number; c: number } | null = null;
+        if (presence.selection) {
+          ref = anchorToRef(presence.selection.activeCell, rowOrder, colOrder);
+        } else if (presence.activeCell) {
+          try { ref = parseRef(presence.activeCell); } catch { /* skip */ }
+        }
+        if (ref && ref.r === mouseRow && ref.c === mouseCol) {
+          newHoveredPeer = clientID;
+          break;
         }
       }
     }

--- a/packages/sheets/test/workbook/anchor-conversion.test.ts
+++ b/packages/sheets/test/workbook/anchor-conversion.test.ts
@@ -138,6 +138,34 @@ describe('rangeAnchorToRange', () => {
     };
     expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toBeNull();
   });
+
+  it('uses visual dimension for null fields when provided', () => {
+    const dimension = { rows: 100, columns: 26 };
+    const anchor: RangeAnchor = {
+      startRowId: 'r2',
+      startColId: null,
+      endRowId: 'r3',
+      endColId: null,
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder, dimension)).toEqual([
+      { r: 2, c: 1 },
+      { r: 3, c: 26 },
+    ]);
+  });
+
+  it('uses visual dimension for select-all when provided', () => {
+    const dimension = { rows: 100, columns: 26 };
+    const anchor: RangeAnchor = {
+      startRowId: null,
+      startColId: null,
+      endRowId: null,
+      endColId: null,
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder, dimension)).toEqual([
+      { r: 1, c: 1 },
+      { r: 100, c: 26 },
+    ]);
+  });
 });
 
 describe('rangeToRangeAnchor', () => {

--- a/packages/sheets/test/workbook/anchor-conversion.test.ts
+++ b/packages/sheets/test/workbook/anchor-conversion.test.ts
@@ -139,6 +139,34 @@ describe('rangeAnchorToRange', () => {
     expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toBeNull();
   });
 
+  it('snaps deleted start endpoint to surviving end endpoint', () => {
+    const anchor: RangeAnchor = {
+      startRowId: 'deleted',
+      startColId: 'c1',
+      endRowId: 'r3',
+      endColId: 'c3',
+    };
+    const result = rangeAnchorToRange(anchor, rowOrder, colOrder);
+    expect(result).toEqual([
+      { r: 3, c: 1 },
+      { r: 3, c: 3 },
+    ]);
+  });
+
+  it('snaps deleted end endpoint to surviving start endpoint', () => {
+    const anchor: RangeAnchor = {
+      startRowId: 'r2',
+      startColId: 'c1',
+      endRowId: 'r2',
+      endColId: 'deleted',
+    };
+    const result = rangeAnchorToRange(anchor, rowOrder, colOrder);
+    expect(result).toEqual([
+      { r: 2, c: 1 },
+      { r: 2, c: 1 },
+    ]);
+  });
+
   it('uses visual dimension for null fields when provided', () => {
     const dimension = { rows: 100, columns: 26 };
     const anchor: RangeAnchor = {
@@ -209,6 +237,18 @@ describe('rangeToRangeAnchor', () => {
       startRowId: null,
       startColId: null,
       endRowId: null,
+      endColId: null,
+    });
+  });
+
+  it('uses null when index exceeds axis order length', () => {
+    // colOrder has 4 entries (c1-c4), selecting column 6 is out of bounds
+    const range: Range = [{ r: 2, c: 6 }, { r: 4, c: 6 }];
+    const result = rangeToRangeAnchor(range, rowOrder, colOrder, 'cell');
+    expect(result).toEqual({
+      startRowId: 'r2',
+      startColId: null,
+      endRowId: 'r4',
       endColId: null,
     });
   });

--- a/packages/sheets/test/workbook/anchor-conversion.test.ts
+++ b/packages/sheets/test/workbook/anchor-conversion.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import {
+  anchorToRef,
+  refToAnchor,
+  rangeAnchorToRange,
+  rangeToRangeAnchor,
+} from '../../src/model/workbook/anchor-conversion';
+import type {
+  CellAnchor,
+  RangeAnchor,
+} from '../../src/model/workbook/anchor-conversion';
+import type { Range } from '../../src/model/core/types';
+
+const rowOrder = ['r1', 'r2', 'r3', 'r4', 'r5'];
+const colOrder = ['c1', 'c2', 'c3', 'c4'];
+
+describe('anchorToRef', () => {
+  it('converts axis IDs to visual position', () => {
+    const anchor: CellAnchor = { rowId: 'r2', colId: 'c3' };
+    expect(anchorToRef(anchor, rowOrder, colOrder)).toEqual({ r: 2, c: 3 });
+  });
+
+  it('returns null when rowId is deleted', () => {
+    const anchor: CellAnchor = { rowId: 'deleted', colId: 'c1' };
+    expect(anchorToRef(anchor, rowOrder, colOrder)).toBeNull();
+  });
+
+  it('returns null when colId is deleted', () => {
+    const anchor: CellAnchor = { rowId: 'r1', colId: 'deleted' };
+    expect(anchorToRef(anchor, rowOrder, colOrder)).toBeNull();
+  });
+
+  it('reflects position change after row insertion', () => {
+    const anchor: CellAnchor = { rowId: 'r3', colId: 'c2' };
+    // Before insertion: r3 is at index 2 → r=3
+    expect(anchorToRef(anchor, rowOrder, colOrder)).toEqual({ r: 3, c: 2 });
+
+    // After inserting a row before r3
+    const newRowOrder = ['r1', 'r2', 'rNew', 'r3', 'r4', 'r5'];
+    expect(anchorToRef(anchor, newRowOrder, colOrder)).toEqual({ r: 4, c: 2 });
+  });
+});
+
+describe('refToAnchor', () => {
+  it('converts visual position to axis IDs', () => {
+    expect(refToAnchor({ r: 1, c: 1 }, rowOrder, colOrder)).toEqual({
+      rowId: 'r1',
+      colId: 'c1',
+    });
+    expect(refToAnchor({ r: 5, c: 4 }, rowOrder, colOrder)).toEqual({
+      rowId: 'r5',
+      colId: 'c4',
+    });
+  });
+
+  it('returns null for out-of-bounds row', () => {
+    expect(refToAnchor({ r: 6, c: 1 }, rowOrder, colOrder)).toBeNull();
+  });
+
+  it('returns null for out-of-bounds column', () => {
+    expect(refToAnchor({ r: 1, c: 5 }, rowOrder, colOrder)).toBeNull();
+  });
+
+  it('returns null for zero index', () => {
+    expect(refToAnchor({ r: 0, c: 1 }, rowOrder, colOrder)).toBeNull();
+  });
+});
+
+describe('rangeAnchorToRange', () => {
+  it('converts a normal range', () => {
+    const anchor: RangeAnchor = {
+      startRowId: 'r2',
+      startColId: 'c1',
+      endRowId: 'r4',
+      endColId: 'c3',
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toEqual([
+      { r: 2, c: 1 },
+      { r: 4, c: 3 },
+    ]);
+  });
+
+  it('handles entire-row selection (null colIds)', () => {
+    const anchor: RangeAnchor = {
+      startRowId: 'r2',
+      startColId: null,
+      endRowId: 'r4',
+      endColId: null,
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toEqual([
+      { r: 2, c: 1 },
+      { r: 4, c: 4 },
+    ]);
+  });
+
+  it('handles entire-column selection (null rowIds)', () => {
+    const anchor: RangeAnchor = {
+      startRowId: null,
+      startColId: 'c2',
+      endRowId: null,
+      endColId: 'c3',
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toEqual([
+      { r: 1, c: 2 },
+      { r: 5, c: 3 },
+    ]);
+  });
+
+  it('handles select-all (all null)', () => {
+    const anchor: RangeAnchor = {
+      startRowId: null,
+      startColId: null,
+      endRowId: null,
+      endColId: null,
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toEqual([
+      { r: 1, c: 1 },
+      { r: 5, c: 4 },
+    ]);
+  });
+
+  it('returns null when both row endpoints are deleted', () => {
+    const anchor: RangeAnchor = {
+      startRowId: 'deleted1',
+      startColId: 'c1',
+      endRowId: 'deleted2',
+      endColId: 'c3',
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toBeNull();
+  });
+
+  it('returns null when both col endpoints are deleted', () => {
+    const anchor: RangeAnchor = {
+      startRowId: 'r1',
+      startColId: 'deleted1',
+      endRowId: 'r3',
+      endColId: 'deleted2',
+    };
+    expect(rangeAnchorToRange(anchor, rowOrder, colOrder)).toBeNull();
+  });
+});
+
+describe('rangeToRangeAnchor', () => {
+  it('converts a normal cell range', () => {
+    const range: Range = [{ r: 2, c: 1 }, { r: 4, c: 3 }];
+    const result = rangeToRangeAnchor(range, rowOrder, colOrder, 'cell');
+    expect(result).toEqual({
+      startRowId: 'r2',
+      startColId: 'c1',
+      endRowId: 'r4',
+      endColId: 'c3',
+    });
+  });
+
+  it('stores null colIds for row selection type', () => {
+    const range: Range = [{ r: 2, c: 1 }, { r: 4, c: 4 }];
+    const result = rangeToRangeAnchor(range, rowOrder, colOrder, 'row');
+    expect(result).toEqual({
+      startRowId: 'r2',
+      startColId: null,
+      endRowId: 'r4',
+      endColId: null,
+    });
+  });
+
+  it('stores null rowIds for column selection type', () => {
+    const range: Range = [{ r: 1, c: 2 }, { r: 5, c: 3 }];
+    const result = rangeToRangeAnchor(range, rowOrder, colOrder, 'column');
+    expect(result).toEqual({
+      startRowId: null,
+      startColId: 'c2',
+      endRowId: null,
+      endColId: 'c3',
+    });
+  });
+
+  it('stores all null for select-all type', () => {
+    const range: Range = [{ r: 1, c: 1 }, { r: 5, c: 4 }];
+    const result = rangeToRangeAnchor(range, rowOrder, colOrder, 'all');
+    expect(result).toEqual({
+      startRowId: null,
+      startColId: null,
+      endRowId: null,
+      endColId: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replace coordinate-based selection (`Ref`, `Sref`) in Yorkie presence with stable axis ID references (`CellAnchor`, `RangeAnchor`) so selections automatically track cells across remote row/column inserts and deletes
- Render peer selection ranges with translucent background (Google Sheets style)
- Share multi-range selection (Ctrl+click) via presence
- Fix peer name labels and hover detection for the new presence format
- Reposition input cell when remote structural changes shift the grid

## Key changes

**New types & conversion layer** (`anchor-conversion.ts`):
- `CellAnchor { rowId, colId }` — stable cell reference using axis IDs
- `RangeAnchor` — stable range reference, null fields = entire row/column/all
- `anchorToRef` / `refToAnchor` — convert between axis IDs and visual `Ref`

**Store interface**:
- `updateActiveCell(Ref)` → `updateSelection(CellAnchor, RangeAnchor[])`
- Added `getRowOrder()`, `getColOrder()`, `ensureAxisOrder()`

**Sheet engine**:
- `activeCellAnchor` / `rangeAnchors` as authoritative selection state
- `resolveAnchorsToRefs()` re-maps anchors after remote structural changes
- Removed manual activeCell shift logic from `shiftCells()`

**Overlay**:
- Peer ranges drawn with 10% opacity background fill
- Dual-format support (axis-ID + legacy Sref) for backward compatibility

## Test plan

- [x] Unit tests for anchor conversion (18 tests)
- [x] `pnpm verify:fast` passes
- [x] Manual: two browser tabs, insert row above peer's selection → cursor follows
- [x] Manual: select range via drag → peer sees range immediately
- [x] Manual: select entire row/column → peer sees full-width/height highlight
- [x] Manual: hover peer cursor → name label appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Axis-ID based selection/presence for stable active-cell and multi-range selections across structural edits.
  * Peer rendering shows active-cell borders and translucent range backgrounds; overlay supports anchor-based presences and legacy fallback.
  * Store/sheet APIs expose axis order and selection-aware presence for smoother sync and migration.

* **Documentation**
  * Added design spec and step-by-step migration task for anchor-based selection.

* **Tests**
  * Added unit tests for anchor↔visual conversions and range behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->