### PR TITLE
Bump version to v0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wafflebase",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "description": "Super Simple Spreadsheet",
   "scripts": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wafflebase/backend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "",
   "private": true,
   "license": "Apache-2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wafflebase/cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "CLI for Wafflebase spreadsheet API",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wafflebase/docs",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "Apache-2.0",
   "description": "Canvas-based document editor for Wafflebase",
   "type": "module",

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wafflebase/documentation",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vitepress dev --port 5174 --no-open",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wafflebase/frontend",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/sheets/package.json
+++ b/packages/sheets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wafflebase/sheets",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "Apache-2.0",
   "description": "Frontend for Wafflebase",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump all 7 `package.json` versions from `0.3.2` → `0.3.3`

## What's in v0.3.3

### Docs (word processor)
- Nested tables — recursive nesting in editor and DOCX import (#128, #129)
- Image insertion & editing Phase 1 (#121); inline image bug fixes (#123)
- Table merge/unmerge context menu + multi-page rendering (#119)
- Native Yorkie Tree split/merge for concurrent convergence (#126)
- Fix crash when remote peer deletes all content (#124)
- Fix cursor escape when table is last block (#125)
- Fix DOCX image import and table cell rendering (#120)
- Harden DOCX table merge import (#118)
- Fix four DOCX / rendering bugs from v0.3.2 smoke test (#117)

### Sheets (spreadsheet)
- Axis ID based selection for collaborative cursor tracking (#130)
- Random axis IDs to prevent duplicate row/col IDs (#127)

### UI
- Full-app design review polish (#122)