### PR TITLE
Preserve heading/title style when splitting blocks

### DIFF
--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -296,6 +296,11 @@ export class Doc {
     let newType: BlockType = 'paragraph';
     if (block.type === 'list-item') {
       newType = 'list-item';
+    } else if (
+      (block.type === 'title' || block.type === 'subtitle' || block.type === 'heading') &&
+      offset < blockText.length
+    ) {
+      newType = block.type;
     }
 
     const newBlockId = generateBlockId();

--- a/packages/docs/src/store/block-helpers.ts
+++ b/packages/docs/src/store/block-helpers.ts
@@ -201,7 +201,9 @@ export function applySplitBlock(
 
   // Remove block-specific attrs from after block
   delete after.tableData;
-  delete after.headingLevel;
+  if (newBlockType !== 'heading') {
+    delete after.headingLevel;
+  }
   // Preserve list attrs when the new block is also a list-item
   if (newBlockType !== 'list-item') {
     delete after.listKind;

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -556,10 +556,20 @@ function getLineMaxFontSizePx(line: LayoutLine, block: Block): number {
     if (size > max) max = size;
   }
   if (max > 0) return max;
-  if (block.inlines.length > 0 && block.inlines[0].style.fontSize) {
-    return ptToPx(block.inlines[0].style.fontSize);
+
+  // For empty lines, resolve font size from block type defaults
+  let fallbackSize: number | undefined;
+  if (block.type === 'title') {
+    fallbackSize = TITLE_DEFAULTS.fontSize;
+  } else if (block.type === 'subtitle') {
+    fallbackSize = SUBTITLE_DEFAULTS.fontSize;
+  } else if (block.type === 'heading' && block.headingLevel) {
+    fallbackSize = getHeadingDefaults(block.headingLevel as HeadingLevel).fontSize;
   }
-  return ptToPx(Theme.defaultFontSize);
+  if (block.inlines.length > 0 && block.inlines[0].style.fontSize) {
+    fallbackSize = block.inlines[0].style.fontSize;
+  }
+  return ptToPx(fallbackSize ?? Theme.defaultFontSize);
 }
 
 /**

--- a/packages/docs/test/model/document.test.ts
+++ b/packages/docs/test/model/document.test.ts
@@ -296,7 +296,7 @@ describe('Doc', () => {
   });
 
   describe('splitBlock — type-aware', () => {
-    it('should create paragraph when splitting a heading', () => {
+    it('should create paragraph when splitting a heading at end', () => {
       const doc = Doc.create();
       const blockId = doc.document.blocks[0].id;
       doc.setBlockType(blockId, 'heading', { headingLevel: 1 });
@@ -304,6 +304,59 @@ describe('Doc', () => {
       doc.splitBlock(blockId, 5);
       expect(doc.document.blocks[0].type).toBe('heading');
       expect(doc.document.blocks[1].type).toBe('paragraph');
+    });
+
+    it('should preserve heading style when splitting in the middle', () => {
+      const doc = Doc.create();
+      const blockId = doc.document.blocks[0].id;
+      doc.setBlockType(blockId, 'heading', { headingLevel: 1 });
+      doc.insertText({ blockId, offset: 0 }, 'Hello');
+      doc.splitBlock(blockId, 3);
+      expect(doc.document.blocks[0].type).toBe('heading');
+      expect(doc.document.blocks[0].headingLevel).toBe(1);
+      expect(doc.document.blocks[1].type).toBe('heading');
+      expect(doc.document.blocks[1].headingLevel).toBe(1);
+    });
+
+    it('should preserve heading style when splitting at the beginning', () => {
+      const doc = Doc.create();
+      const blockId = doc.document.blocks[0].id;
+      doc.setBlockType(blockId, 'heading', { headingLevel: 2 });
+      doc.insertText({ blockId, offset: 0 }, 'Hello');
+      doc.splitBlock(blockId, 0);
+      expect(doc.document.blocks[0].type).toBe('heading');
+      expect(doc.document.blocks[1].type).toBe('heading');
+      expect(doc.document.blocks[1].headingLevel).toBe(2);
+    });
+
+    it('should preserve title style when splitting at the beginning', () => {
+      const doc = Doc.create();
+      const blockId = doc.document.blocks[0].id;
+      doc.setBlockType(blockId, 'title');
+      doc.insertText({ blockId, offset: 0 }, 'abcd');
+      doc.splitBlock(blockId, 0);
+      expect(doc.document.blocks[0].type).toBe('title');
+      expect(doc.document.blocks[1].type).toBe('title');
+    });
+
+    it('should reset to paragraph when splitting title at the end', () => {
+      const doc = Doc.create();
+      const blockId = doc.document.blocks[0].id;
+      doc.setBlockType(blockId, 'title');
+      doc.insertText({ blockId, offset: 0 }, 'abcd');
+      doc.splitBlock(blockId, 4);
+      expect(doc.document.blocks[0].type).toBe('title');
+      expect(doc.document.blocks[1].type).toBe('paragraph');
+    });
+
+    it('should preserve subtitle style when splitting in the middle', () => {
+      const doc = Doc.create();
+      const blockId = doc.document.blocks[0].id;
+      doc.setBlockType(blockId, 'subtitle');
+      doc.insertText({ blockId, offset: 0 }, 'Sub');
+      doc.splitBlock(blockId, 1);
+      expect(doc.document.blocks[0].type).toBe('subtitle');
+      expect(doc.document.blocks[1].type).toBe('subtitle');
     });
 
     it('should inherit list type when splitting list-item with content', () => {

--- a/packages/docs/test/view/layout.test.ts
+++ b/packages/docs/test/view/layout.test.ts
@@ -39,6 +39,35 @@ describe('heading layout', () => {
   });
 });
 
+describe('empty block height', () => {
+  it('should give empty title block the same line height as a title with text', () => {
+    const emptyTitle = createBlock('title');
+    emptyTitle.inlines = [{ text: '', style: {} }];
+    const fullTitle = createBlock('title');
+    fullTitle.inlines = [{ text: 'Hello', style: {} }];
+    const { layout } = computeLayout([emptyTitle, fullTitle], mockCtx(), 600);
+    expect(layout.blocks[0].height).toBe(layout.blocks[1].height);
+  });
+
+  it('should give empty heading block the same line height as a heading with text', () => {
+    const emptyH1 = createBlock('heading', { headingLevel: 1 });
+    emptyH1.inlines = [{ text: '', style: {} }];
+    const fullH1 = createBlock('heading', { headingLevel: 1 });
+    fullH1.inlines = [{ text: 'Hello', style: {} }];
+    const { layout } = computeLayout([emptyH1, fullH1], mockCtx(), 600);
+    expect(layout.blocks[0].height).toBe(layout.blocks[1].height);
+  });
+
+  it('should give empty subtitle block the same line height as a subtitle with text', () => {
+    const emptySub = createBlock('subtitle');
+    emptySub.inlines = [{ text: '', style: {} }];
+    const fullSub = createBlock('subtitle');
+    fullSub.inlines = [{ text: 'Hello', style: {} }];
+    const { layout } = computeLayout([emptySub, fullSub], mockCtx(), 600);
+    expect(layout.blocks[0].height).toBe(layout.blocks[1].height);
+  });
+});
+
 describe('list-item layout', () => {
   it('should offset text by list indent', () => {
     const block = createBlock('list-item', { listKind: 'unordered', listLevel: 0 });

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -525,6 +525,38 @@ export class YorkieDocStore implements DocStore {
   }
 
   /**
+   * Resolve a block-level character offset into the Yorkie tree's actual
+   * inline structure. The cached document may have merged adjacent same-style
+   * inlines (normalizeInlines) that remain separate nodes in the Yorkie tree,
+   * so paths computed from the cache can be invalid.
+   */
+  private resolveTreeOffset(
+    treeRoot: TreeNode,
+    treeBlockIdx: number,
+    offset: number,
+  ): { inlineIndex: number; charOffset: number } {
+    const blockNode = (treeRoot as ElementNode).children![treeBlockIdx] as ElementNode;
+    const inlineChildren = (blockNode.children ?? []).filter(
+      (c): c is ElementNode => c.type === 'inline',
+    );
+    let remaining = offset;
+    for (let i = 0; i < inlineChildren.length; i++) {
+      const textLen = (inlineChildren[i].children ?? [])
+        .filter((c): c is { type: 'text'; value: string } => c.type === 'text')
+        .reduce((sum, t) => sum + t.value.length, 0);
+      if (remaining <= textLen) {
+        return { inlineIndex: i, charOffset: remaining };
+      }
+      remaining -= textLen;
+    }
+    const lastIdx = inlineChildren.length - 1;
+    const lastLen = (inlineChildren[lastIdx]?.children ?? [])
+      .filter((c): c is { type: 'text'; value: string } => c.type === 'text')
+      .reduce((sum, t) => sum + t.value.length, 0);
+    return { inlineIndex: Math.max(0, lastIdx), charOffset: lastLen };
+  }
+
+  /**
    * Check if a block lives in header or footer.
    */
   private findHeaderFooterBlock(blockId: string, doc: Document): { region: 'header' | 'footer'; blocks: Block[]; index: number } | null {
@@ -587,30 +619,30 @@ export class YorkieDocStore implements DocStore {
     if (blockIdx === -1) throw new Error(`Block not found: ${blockId}`);
     const block = currentDoc.blocks[blockIdx];
 
-    const { inlineIndex, charOffset } = resolveOffset(block, offset);
     const off = this.bodyTreeOffset(currentDoc);
-    const targetInline = block.inlines[inlineIndex];
+    // Use cache-based resolveOffset for image detection only
+    const cacheResolved = resolveOffset(block, offset);
+    const targetInline = block.inlines[cacheResolved.inlineIndex];
 
     this.doc.update((root) => {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
 
+      // Resolve offset from the actual Yorkie tree structure
+      const treeRoot = tree.getRootTreeNode();
+      const { inlineIndex, charOffset } = this.resolveTreeOffset(treeRoot, blockIdx + off, offset);
+
       if (targetInline.style.image) {
-        // Image inlines must not absorb regular text. Insert a new
-        // inline node adjacent to the image node instead of putting
-        // text inside it.
         const { image: _, ...plainStyle } = targetInline.style;
         void _;
         const newNode = buildInlineNode({ text, style: plainStyle });
         if (charOffset === 0) {
-          // Before image: insert new inline before the image node
           tree.editByPath(
             [blockIdx + off, inlineIndex],
             [blockIdx + off, inlineIndex],
             newNode,
           );
         } else {
-          // After image: insert new inline after the image node
           tree.editByPath(
             [blockIdx + off, inlineIndex + 1],
             [blockIdx + off, inlineIndex + 1],
@@ -665,19 +697,28 @@ export class YorkieDocStore implements DocStore {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
 
-      // 1. Character-level deletes (reverse order to preserve indices)
-      for (let i = segments.length - 1; i >= 0; i--) {
-        const seg = segments[i];
-        tree.editByPath(
-          [blockIdx + off, seg.inlineIndex, seg.charFrom],
-          [blockIdx + off, seg.inlineIndex, seg.charTo],
-        );
-      }
+      // Resolve delete segments from the actual Yorkie tree structure
+      const treeRoot = tree.getRootTreeNode();
+      const treeStart = this.resolveTreeOffset(treeRoot, blockIdx + off, offset);
+      const treeEnd = this.resolveTreeOffset(treeRoot, blockIdx + off, offset + length);
 
-      // 2. Remove empty inline nodes (reverse order to preserve indices)
-      for (let i = emptyInlineIndices.length - 1; i >= 0; i--) {
-        const idx = emptyInlineIndices[i];
-        tree.editByPath([blockIdx + off, idx], [blockIdx + off, idx + 1]);
+      // Single-range delete on the Yorkie tree
+      tree.editByPath(
+        [blockIdx + off, treeStart.inlineIndex, treeStart.charOffset],
+        [blockIdx + off, treeEnd.inlineIndex, treeEnd.charOffset],
+      );
+
+      // Remove any inlines that became empty after deletion
+      const blockNode = ((tree.getRootTreeNode() as ElementNode).children![blockIdx + off]) as ElementNode;
+      const inlines = (blockNode.children ?? []).filter((c) => c.type === 'inline') as ElementNode[];
+      for (let i = inlines.length - 1; i >= 0; i--) {
+        if (inlines.length <= 1) break; // keep at least one
+        const textLen = (inlines[i].children ?? [])
+          .filter((c): c is { type: 'text'; value: string } => c.type === 'text')
+          .reduce((sum, t) => sum + t.value.length, 0);
+        if (textLen === 0) {
+          tree.editByPath([blockIdx + off, i], [blockIdx + off, i + 1]);
+        }
       }
     });
 
@@ -790,13 +831,15 @@ export class YorkieDocStore implements DocStore {
       throw new Error(`splitBlock does not support ${block.type} blocks`);
     }
 
-    // Resolve block-level character offset to inline-level path
-    const { inlineIndex, charOffset } = resolveOffset(block, offset);
     const off = this.bodyTreeOffset(currentDoc);
 
     this.doc.update((root) => {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
+
+      // Resolve offset from the actual Yorkie tree, not the cache.
+      const treeRoot = tree.getRootTreeNode();
+      const { inlineIndex, charOffset } = this.resolveTreeOffset(treeRoot, blockIdx + off, offset);
 
       // Native CRDT split: single atomic operation at splitLevel=2.
       // splitLevel=2 because the text position is 2 levels below block:
@@ -820,6 +863,9 @@ export class YorkieDocStore implements DocStore {
         if (block.listLevel !== undefined) {
           afterAttrs.listLevel = String(block.listLevel);
         }
+      }
+      if (newBlockType === 'heading' && block.headingLevel !== undefined) {
+        afterAttrs.headingLevel = String(block.headingLevel);
       }
       tree.styleByPath([blockIdx + off + 1], afterAttrs);
     });


### PR DESCRIPTION
## Summary
- **Paragraph style preservation**: Splitting Title/Heading/Subtitle blocks at the beginning or middle now preserves the style on both halves (Google Docs behavior). Splitting at the end resets the new block to paragraph.
- **Empty block height fix**: Empty Title/Heading/Subtitle blocks now render with correct line height based on their block type font size instead of falling back to default 11pt.
- **Yorkie tree path resolution**: `editByPath` paths are now computed from the actual Yorkie tree inline structure instead of the cache, preventing `unacceptable path` errors when `normalizeInlines` merges inlines that remain separate in the Yorkie tree after split/merge operations.

## Test plan
- [x] Unit tests for split style preservation (6 new tests in `document.test.ts`)
- [x] Unit tests for empty block height (3 new tests in `layout.test.ts`)
- [x] All existing tests pass (`pnpm verify:fast` + frontend tests)
- [x] Manual smoke test: Title block split at beginning/middle/end
- [x] Manual smoke test: consecutive Enter presses with merge (backspace) cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed block type and formatting preservation when editing and splitting headings, titles, and subtitles
- Improved font sizing accuracy for empty styled blocks
- Enhanced text editing reliability and consistency when inserting, deleting, and splitting content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->