### PR TITLE
Delete unavailable link in harness-engineering.md

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -367,4 +367,3 @@ Harness v1 is complete when all are true:
 
 - [OpenAI: Harness engineering — leveraging Codex in an agent-first world](https://openai.com/index/harness-engineering/)
 - [Martin Fowler: Harness Engineering](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html)
-- [Mitchell Hashimoto: Harness, not AGENTS.md](https://mitchellh.com/writing/agents-harness-not-agents-md)


### PR DESCRIPTION
## Summary
Delete unavailable reference link in `harness-engineering.md`

## Why
https://mitchellh.com/writing/agents-harness-not-agents-md is not available. It seems article is just deleted.

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated reference documentation by removing an outdated reference entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->