### PR TITLE
Fix staggered rowSpan merge rendering and arrow key navigation

### DIFF
--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -410,6 +410,45 @@ export function computeTableLayout(
     }
   }
 
+  // 5c. Grow rows that overflow due to merged-cell content redistribution.
+  // computeMergedCellLineLayouts (used at render time) pushes lines from
+  // shorter rows into later rows. When staggered merges make an
+  // intermediate row short, all content may pile into the last spanned
+  // row whose height was calculated without that extra load. Simulate
+  // the redistribution here and grow the receiving row as needed.
+  for (let r = 0; r < numRows; r++) {
+    for (let c = 0; c < numCols; c++) {
+      const cell = cells[r][c];
+      if (cell.merged) continue;
+      const rowSpan = rows[r].cells[c]?.rowSpan ?? 1;
+      if (rowSpan <= 1) continue;
+
+      const padding = rows[r].cells[c]?.style?.padding ?? DEFAULT_CELL_PADDING;
+      const spanEnd = Math.min(r + rowSpan, numRows);
+
+      // Simulate the line redistribution (mirrors computeMergedCellLineLayouts)
+      let curRow = r;
+      let yInRow = padding;
+
+      for (const line of cell.lines) {
+        if (
+          curRow + 1 < spanEnd &&
+          yInRow + line.height > rowHeights[curRow] - padding
+        ) {
+          curRow++;
+          yInRow = padding;
+        }
+        yInRow += line.height;
+      }
+
+      // Ensure the last receiving row has enough height
+      const needed = yInRow + padding;
+      if (needed > rowHeights[curRow]) {
+        rowHeights[curRow] = needed;
+      }
+    }
+  }
+
   // 6. Compute row Y offsets (cumulative sum)
   const rowYOffsets: number[] = [];
   let yOffset = 0;

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -439,12 +439,13 @@ export function computeTableLayout(
           yInRow = padding;
         }
         yInRow += line.height;
-      }
 
-      // Ensure the last receiving row has enough height
-      const needed = yInRow + padding;
-      if (needed > rowHeights[curRow]) {
-        rowHeights[curRow] = needed;
+        // Ensure every receiving row has enough height for the content
+        // already assigned to it (not just the last row).
+        const needed = yInRow + padding;
+        if (needed > rowHeights[curRow]) {
+          rowHeights[curRow] = needed;
+        }
       }
     }
   }

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -3,7 +3,7 @@ import { generateBlockId, getBlockText, getBlockTextLength, DEFAULT_BLOCK_STYLE,
 import { Doc, type EditContext } from '../model/document.js';
 import { serializeBlocks, deserializeBlocks, parseHtmlToBlocks, WAFFLEDOCS_MIME } from './clipboard.js';
 import { Cursor } from './cursor.js';
-import { Selection, expandCellRangeForMerges } from './selection.js';
+import { Selection, expandCellRangeForMerges, findMergeTopLeft } from './selection.js';
 import type { DocumentLayout } from './layout.js';
 import type { PaginatedLayout } from './pagination.js';
 import { paginatedPixelToPosition, findPageForPosition, getPageYOffset, getPageXOffset, getHeaderYStart, getFooterYStart, resolveClickTarget } from './pagination.js';
@@ -1893,7 +1893,13 @@ export class TextEditor {
         } else {
           // At first block — move to cell above or exit table
           if (arrowCellInfo.rowIndex > 0) {
-            const aboveCell = tableBlock.tableData!.rows[arrowCellInfo.rowIndex - 1].cells[arrowCellInfo.colIndex];
+            const aboveRow = arrowCellInfo.rowIndex - 1;
+            let aboveCell = tableBlock.tableData!.rows[aboveRow].cells[arrowCellInfo.colIndex];
+            // Resolve covered cell to its merge top-left
+            if (aboveCell?.colSpan === 0) {
+              const tl = findMergeTopLeft(tableBlock.tableData!, aboveRow, arrowCellInfo.colIndex);
+              aboveCell = tableBlock.tableData!.rows[tl.rowIndex].cells[tl.colIndex];
+            }
             const lastBlock = aboveCell.blocks[aboveCell.blocks.length - 1];
             // If last block is a nested table, enter it
             if (lastBlock.type === 'table' && lastBlock.tableData) {
@@ -1925,7 +1931,12 @@ export class TextEditor {
                 newPos = { blockId: prevBlock.id, offset: getBlockTextLength(prevBlock) };
               } else if (parentCellInfo.rowIndex > 0) {
                 // Move to the cell above in the outer table
-                const aboveCell = parentTable.tableData!.rows[parentCellInfo.rowIndex - 1].cells[parentCellInfo.colIndex];
+                const aboveRow = parentCellInfo.rowIndex - 1;
+                let aboveCell = parentTable.tableData!.rows[aboveRow].cells[parentCellInfo.colIndex];
+                if (aboveCell?.colSpan === 0) {
+                  const tl = findMergeTopLeft(parentTable.tableData!, aboveRow, parentCellInfo.colIndex);
+                  aboveCell = parentTable.tableData!.rows[tl.rowIndex].cells[tl.colIndex];
+                }
                 const lastBlock = aboveCell.blocks[aboveCell.blocks.length - 1];
                 newPos = { blockId: lastBlock.id, offset: getBlockTextLength(lastBlock) };
               } else {
@@ -1969,8 +1980,15 @@ export class TextEditor {
         } else {
           // At last block — move to cell below or exit table
           const td = tableBlock.tableData!;
-          if (arrowCellInfo.rowIndex < td.rows.length - 1) {
-            const belowCell = td.rows[arrowCellInfo.rowIndex + 1].cells[arrowCellInfo.colIndex];
+          const currentCell = td.rows[arrowCellInfo.rowIndex].cells[arrowCellInfo.colIndex];
+          const nextRow = arrowCellInfo.rowIndex + (currentCell.rowSpan ?? 1);
+          if (nextRow < td.rows.length) {
+            let belowCell = td.rows[nextRow].cells[arrowCellInfo.colIndex];
+            // Resolve covered cell to its merge top-left
+            if (belowCell?.colSpan === 0) {
+              const tl = findMergeTopLeft(td, nextRow, arrowCellInfo.colIndex);
+              belowCell = td.rows[tl.rowIndex].cells[tl.colIndex];
+            }
             const firstBlock = belowCell.blocks[0];
             // If first block is a nested table, enter it
             if (firstBlock.type === 'table' && firstBlock.tableData) {
@@ -2001,8 +2019,14 @@ export class TextEditor {
               } else {
                 // No more blocks — move to cell below in outer table
                 const outerTd = parentTable.tableData!;
-                if (parentCellInfo.rowIndex < outerTd.rows.length - 1) {
-                  const belowCell = outerTd.rows[parentCellInfo.rowIndex + 1].cells[parentCellInfo.colIndex];
+                const outerCell = outerTd.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];
+                const outerNextRow = parentCellInfo.rowIndex + (outerCell.rowSpan ?? 1);
+                if (outerNextRow < outerTd.rows.length) {
+                  let belowCell = outerTd.rows[outerNextRow].cells[parentCellInfo.colIndex];
+                  if (belowCell?.colSpan === 0) {
+                    const tl = findMergeTopLeft(outerTd, outerNextRow, parentCellInfo.colIndex);
+                    belowCell = outerTd.rows[tl.rowIndex].cells[tl.colIndex];
+                  }
                   newPos = { blockId: belowCell.blocks[0].id, offset: 0 };
                 } else {
                   // Exit outer table

--- a/packages/docs/test/view/table-layout.test.ts
+++ b/packages/docs/test/view/table-layout.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { computeTableLayout } from '../../src/view/table-layout.js';
+import { computeMergedCellLineLayouts } from '../../src/view/table-renderer.js';
 import { createTableBlock, DEFAULT_BLOCK_STYLE } from '../../src/model/types.js';
 
 function stubCtx(): CanvasRenderingContext2D {
@@ -105,13 +106,24 @@ describe('computeTableLayout', () => {
 
     const result = computeTableLayout(td, 'test-table', stubCtx(), 300);
 
-    // The merged cells in row 1 each have 2 lines. Row 1 must be tall
-    // enough so that content is not pushed entirely into row 2, or row 2
-    // must grow to accommodate redistributed content. Either way, the
-    // total height must contain all content.
-    const totalContentPerMergedCell = result.cells[1][0].height;
-    const spannedHeight = result.rowHeights[1] + result.rowHeights[2];
-    expect(spannedHeight).toBeGreaterThanOrEqual(totalContentPerMergedCell);
+    // Every redistributed line must fit within its owner row.
+    const mergedCell = result.cells[1][0];
+    const padding = td.rows[1].cells[0].style?.padding ?? 4;
+    const lineLayouts = computeMergedCellLineLayouts(
+      mergedCell.lines,
+      1,
+      td.rows[1].cells[0].rowSpan ?? 1,
+      padding,
+      result.rowYOffsets,
+      result.rowHeights,
+    );
+
+    for (let i = 0; i < mergedCell.lines.length; i++) {
+      const { ownerRow, runLineY } = lineLayouts[i];
+      const lineBottom =
+        runLineY - result.rowYOffsets[ownerRow] + mergedCell.lines[i].height + padding;
+      expect(lineBottom).toBeLessThanOrEqual(result.rowHeights[ownerRow]);
+    }
 
     // totalHeight must equal sum of all row heights
     const sumRowHeights = result.rowHeights.reduce((s, h) => s + h, 0);

--- a/packages/docs/test/view/table-layout.test.ts
+++ b/packages/docs/test/view/table-layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { computeTableLayout } from '../../src/view/table-layout.js';
-import { createTableBlock } from '../../src/model/types.js';
+import { createTableBlock, DEFAULT_BLOCK_STYLE } from '../../src/model/types.js';
 
 function stubCtx(): CanvasRenderingContext2D {
   return {
@@ -63,5 +63,58 @@ describe('computeTableLayout', () => {
     const result = computeTableLayout(block.tableData!, 'test-table', stubCtx(), 50); // narrow width forces wrapping
     // Row height should be content-based, not 5px
     expect(result.rowHeights[0]).toBeGreaterThan(5);
+  });
+
+  it('should grow rows when staggered rowSpan merges redistribute content', () => {
+    // 3x3 table with staggered merges:
+    //   Col 0: normal row 0, merged rows 1-2
+    //   Col 1: merged rows 0-1, normal row 2
+    //   Col 2: normal row 0, merged rows 1-2
+    const block = createTableBlock(3, 3);
+    const td = block.tableData!;
+
+    // (0,1): rowSpan=2, two blocks
+    td.rows[0].cells[1].rowSpan = 2;
+    td.rows[0].cells[1].blocks = [
+      { id: 'b1', type: 'paragraph', inlines: [{ text: '1x2', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } },
+      { id: 'b2', type: 'paragraph', inlines: [{ text: '2x2', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } },
+    ];
+    // (1,1): covered
+    td.rows[1].cells[1].colSpan = 0;
+    td.rows[1].cells[1].blocks = [{ id: 'b3', type: 'paragraph', inlines: [{ text: '', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }];
+
+    // (1,0): rowSpan=2, two blocks
+    td.rows[1].cells[0].rowSpan = 2;
+    td.rows[1].cells[0].blocks = [
+      { id: 'b4', type: 'paragraph', inlines: [{ text: '2x1', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } },
+      { id: 'b5', type: 'paragraph', inlines: [{ text: '3x1', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } },
+    ];
+    // (2,0): covered
+    td.rows[2].cells[0].colSpan = 0;
+    td.rows[2].cells[0].blocks = [{ id: 'b6', type: 'paragraph', inlines: [{ text: '', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }];
+
+    // (1,2): rowSpan=2, two blocks
+    td.rows[1].cells[2].rowSpan = 2;
+    td.rows[1].cells[2].blocks = [
+      { id: 'b7', type: 'paragraph', inlines: [{ text: '2x3', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } },
+      { id: 'b8', type: 'paragraph', inlines: [{ text: '3x3', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } },
+    ];
+    // (2,2): covered
+    td.rows[2].cells[2].colSpan = 0;
+    td.rows[2].cells[2].blocks = [{ id: 'b9', type: 'paragraph', inlines: [{ text: '', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }];
+
+    const result = computeTableLayout(td, 'test-table', stubCtx(), 300);
+
+    // The merged cells in row 1 each have 2 lines. Row 1 must be tall
+    // enough so that content is not pushed entirely into row 2, or row 2
+    // must grow to accommodate redistributed content. Either way, the
+    // total height must contain all content.
+    const totalContentPerMergedCell = result.cells[1][0].height;
+    const spannedHeight = result.rowHeights[1] + result.rowHeights[2];
+    expect(spannedHeight).toBeGreaterThanOrEqual(totalContentPerMergedCell);
+
+    // totalHeight must equal sum of all row heights
+    const sumRowHeights = result.rowHeights.reduce((s, h) => s + h, 0);
+    expect(result.totalHeight).toBe(sumRowHeights);
   });
 });


### PR DESCRIPTION
## Summary

- Fix table content overflowing past borders when columns have staggered rowSpan merges (e.g., col 0 merges rows 1-2 while col 1 merges rows 0-1)
- Fix crash ("Block not found") when pressing arrow up/down in merged table cells — cursor was navigating to covered placeholder cells whose blocks aren't in blockParentMap

## Details

**Row height overflow (table-layout.ts):** `computeMergedCellLineLayouts` redistributes lines from shorter rows into later rows at render time, but the layout engine did not account for this. Added Phase 5c to simulate the redistribution during layout and grow the receiving row as needed.

**Arrow key crash (text-editor.ts):** Arrow down used `rowIndex + 1` which lands on a covered cell inside the current merge span. Fixed by using `rowIndex + rowSpan` to skip past the merge. Arrow up now resolves covered cells via `findMergeTopLeft`. Applied to both direct and nested-table-exit navigation paths (4 locations).

## Test plan

- [x] `pnpm verify:fast` passes (567 docs tests, all green)
- [x] New test: staggered rowSpan merge row height grows to contain content
- [x] Manual: create 3×3 table, stagger rowSpan merges across columns, verify no content outside borders
- [x] Manual: arrow up/down in merged cells navigates correctly without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed table row height calculations to properly account for merged cells and prevent vertical overflow issues.
* Improved vertical navigation within tables to correctly identify destination cells when moving up or down, especially with merged cells present.

## Tests
* Added test coverage for table layout behavior with merged cells to validate height calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->