### PR TITLE
Add table copy-paste support in Docs editor

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -46,6 +46,7 @@ Word processor engine — rich text, tables, pagination, collaboration.
 | [docs-intent-preserving-edits.md](docs/docs-intent-preserving-edits.md)          | Intent-preserving Yorkie edits — character-level Tree editing, 5-phase migration                  |
 | [docs-wordprocessor-roadmap.md](docs/docs-wordprocessor-roadmap.md)              | Docs word processor roadmap — 6-phase plan for Google Docs parity                                 |
 | [docs-ruler.md](docs/docs-ruler.md)                                              | Docs ruler design                                                                                 |
+| [docs-table-copy-paste.md](docs/docs-table-copy-paste.md)                        | Docs table copy-paste — cell-range clipboard, whole-table block, external HTML table paste        |
 
 ## Common
 

--- a/docs/design/docs/docs-table-copy-paste.md
+++ b/docs/design/docs/docs-table-copy-paste.md
@@ -1,0 +1,134 @@
+---
+title: docs-table-copy-paste
+target-version: 0.3.5
+---
+
+# Docs Table Copy-Paste
+
+## Summary
+
+Enable copy-paste for tables in the Docs editor across three scenarios, implemented in phases:
+
+1. **Cell-to-cell** — copy a cell range within a table, paste into the same or another table
+2. **Whole-table block** — copy a region that includes table blocks, paste as new table blocks
+3. **External HTML tables** — paste tables from Google Docs, Sheets, or the web
+
+This document covers Phase 1 (cell-to-cell).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Copy a selected cell range and paste it into a target table, preserving cell content (blocks, inline styles)
+- Reuse existing `tableCellRange` selection and `getSelectedText()` for plain-text fallback
+- Keep changes minimal — extend existing clipboard infrastructure, don't rewrite it
+
+**Non-Goals:**
+- Auto-expanding the target table when pasted data exceeds bounds (clamp instead)
+- Copying/pasting cell merge (colSpan/rowSpan) attributes in Phase 1
+- External HTML table parsing (Phase 3)
+- Undo/redo integration beyond existing `saveSnapshot()` mechanism
+
+## Proposal Details
+
+### Clipboard Payload Extension
+
+Extend `ClipboardPayload` with an optional `tableCells` field:
+
+```typescript
+interface ClipboardPayload {
+  version: 1;
+  blocks: Block[];
+  tableCells?: TableCell[][]; // rows × cols, present when copying a cell range
+}
+```
+
+When `tableCells` is present, the payload represents a cell-range copy. When absent, it is a regular block copy. `blocks` remains `[]` for cell-range copies.
+
+**Files:** `clipboard.ts` — update `serializeBlocks()` and `deserializeBlocks()` to accept/return the optional `tableCells` field.
+
+### Copy Flow
+
+In `handleCopy` and `handleCut`, add a branch before the existing `getSelectedBlocks()` call:
+
+```
+if selection has tableCellRange:
+  1. Look up the table block by tableCellRange.blockId
+  2. Extract cells from start to end (inclusive) as TableCell[][]
+  3. Deep-clone each cell: regenerate block IDs, copy blocks/inlines/styles
+  4. Serialize with tableCells field → set as WAFFLEDOCS_MIME
+  5. Use existing getSelectedText() for text/plain (already tab/newline formatted)
+else:
+  existing block copy logic
+```
+
+**New method:** `getSelectedTableCells(): TableCell[][] | null` on `TextEditor`.
+
+### Paste Flow
+
+In `handlePaste`, after deserializing `WAFFLEDOCS_MIME`:
+
+```
+if payload has tableCells:
+  if cursor is inside a table cell:
+    1. Resolve current cell address (rowIndex, colIndex) via blockParentMap
+    2. For each source cell [r][c], compute target address: (rowIndex + r, colIndex + c)
+    3. Clamp to target table bounds — skip cells that exceed dimensions
+    4. Deep-clone source cell blocks (regenerate IDs)
+    5. Replace target cell's blocks via doc.updateCellBlocks()
+    6. Move cursor to the last pasted cell
+  else (cursor on normal block):
+    Create a new table block from tableCells and insert at cursor position
+else:
+  existing block paste logic
+```
+
+**New method:** `pasteTableCells(cells: TableCell[][])` on `TextEditor`.
+
+### Deep Clone Helper
+
+Both copy and paste need to regenerate block IDs inside cells to avoid ID collisions:
+
+```typescript
+function cloneTableCells(cells: TableCell[][]): TableCell[][] {
+  return cells.map(row =>
+    row.map(cell => ({
+      ...cell,
+      style: { ...cell.style },
+      blocks: cell.blocks.map(b => ({
+        ...b,
+        id: generateBlockId(),
+        inlines: b.inlines.map(il => ({ text: il.text, style: { ...il.style } })),
+        style: { ...b.style },
+      })),
+    }))
+  );
+}
+```
+
+### Changed Files
+
+| File | Change |
+|------|--------|
+| `clipboard.ts` | `ClipboardPayload.tableCells`, serialize/deserialize extension |
+| `text-editor.ts` | `handleCopy/Cut` cell-range branch, `getSelectedTableCells()`, `handlePaste` cell branch, `pasteTableCells()` |
+| `clipboard.test.ts` | Serialize/deserialize round-trip tests for tableCells |
+
+### Unchanged
+
+- `selection.ts` — existing `tableCellRange` and `getSelectedText()` reused as-is
+- `document.ts` — existing `updateCellBlocks()` reused
+- `types.ts` — existing `TableCell`, `TableCellRange`, `CellAddress` reused
+
+## Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Large cell ranges produce big clipboard payloads | JSON serialization is fast for typical table sizes (<1000 cells); defer optimization |
+| Block ID collisions after paste | Always regenerate IDs via `generateBlockId()` during clone |
+| Paste into merged cells may corrupt layout | Phase 1 skips colSpan/rowSpan — paste treats each cell independently |
+| Cut from table leaves empty cells vs. removing rows | Cut replaces cell content with empty blocks (like spreadsheet behavior), does not remove structural rows/columns |
+
+## Future Phases
+
+- **Phase 2:** Whole-table block copy — extend `getSelectedBlocks()` to include table blocks with `tableData`, extend `insertBlocks()` to handle `type === 'table'`
+- **Phase 3:** HTML table parsing — extend `parseHtmlToBlocks()` to handle `<table>/<tr>/<td>` elements, producing table blocks

--- a/docs/design/docs/docs-table-copy-paste.md
+++ b/docs/design/docs/docs-table-copy-paste.md
@@ -44,7 +44,7 @@ interface ClipboardPayload {
 
 When `tableCells` is present, the payload represents a cell-range copy. When absent, it is a regular block copy. `blocks` remains `[]` for cell-range copies.
 
-**Files:** `clipboard.ts` — update `serializeBlocks()` and `deserializeBlocks()` to accept/return the optional `tableCells` field.
+**Files:** `clipboard.ts` — add new `serializeClipboard()` and `deserializeClipboard()` functions that handle the optional `tableCells` field (existing `serializeBlocks`/`deserializeBlocks` kept for backward compatibility).
 
 ### Copy Flow
 
@@ -74,7 +74,7 @@ if payload has tableCells:
     2. For each source cell [r][c], compute target address: (rowIndex + r, colIndex + c)
     3. Clamp to target table bounds — skip cells that exceed dimensions
     4. Deep-clone source cell blocks (regenerate IDs)
-    5. Replace target cell's blocks via doc.updateCellBlocks()
+    5. Replace target cell's blocks via doc.updateBlockDirect()
     6. Move cursor to the last pasted cell
   else (cursor on normal block):
     Create a new table block from tableCells and insert at cursor position

--- a/docs/tasks/active/20260419-table-copy-paste-lessons.md
+++ b/docs/tasks/active/20260419-table-copy-paste-lessons.md
@@ -1,0 +1,24 @@
+# Table Copy-Paste — Lessons
+
+## Root Cause: tableData lost during block clone
+
+`getSelectedBlocks()` cloned blocks without preserving `tableData`, causing
+tables to silently disappear on paste. The fix: deep-clone `tableData` (rows,
+cells, block IDs) during block extraction.
+
+**Why:** The clone code was written for paragraph/heading/list blocks (which
+only have `inlines`). Table blocks store their content in `tableData`, not
+`inlines`, so the existing clone missed it entirely.
+
+## Debugging approach
+
+- Adding console.log to the copy/paste pipeline traced the data flow end-to-end
+- Programmatic ClipboardEvent dispatch via Puppeteer confirmed `insertBlocks`
+  worked but `requestRender()` was blocked by a debug log error
+- Inspecting the serialized clipboard payload revealed `type: "table"` blocks
+  with no `tableData` — pinpointing `getSelectedBlocks()` as the source
+
+## Follow-ups
+
+- Phase 2: whole-table block copy (extend `insertBlocks` for `type === 'table'`)
+- Phase 3: HTML table parsing (`parseHtmlToBlocks` for `<table>/<tr>/<td>`)

--- a/docs/tasks/active/20260419-table-copy-paste-todo.md
+++ b/docs/tasks/active/20260419-table-copy-paste-todo.md
@@ -1,0 +1,533 @@
+# Table Copy-Paste (Phase 1: Cell-to-Cell) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable copy-paste of table cell ranges within and between tables in the Docs editor.
+
+**Architecture:** Extend `ClipboardPayload` with optional `tableCells: TableCell[][]` field. Add cell-range extraction in copy, cell-range writing in paste. Reuse existing `tableCellRange` selection, `store.updateTableCell()`, and `getSelectedText()`.
+
+**Tech Stack:** TypeScript, Vitest (jsdom), existing Docs model/view layer.
+
+**Design doc:** `docs/design/docs/docs-table-copy-paste.md`
+
+---
+
+### Task 1: Extend clipboard serialization for table cells
+
+**Files:**
+- Modify: `packages/docs/src/view/clipboard.ts:3-21`
+- Test: `packages/docs/test/view/clipboard.test.ts`
+
+- [ ] **Step 1: Write failing test for tableCells round-trip**
+
+In `packages/docs/test/view/clipboard.test.ts`, add to the `clipboard JSON serialization` describe block:
+
+```typescript
+it('should round-trip tableCells payload', () => {
+  const cells: TableCell[][] = [
+    [
+      {
+        blocks: [{
+          id: 'c1',
+          type: 'paragraph' as const,
+          inlines: [{ text: 'A1', style: { bold: true } }],
+          style: { alignment: 'left' as const, lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 },
+        }],
+        style: { padding: 4 },
+      },
+      {
+        blocks: [{
+          id: 'c2',
+          type: 'paragraph' as const,
+          inlines: [{ text: 'B1', style: {} }],
+          style: { alignment: 'left' as const, lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 },
+        }],
+        style: { padding: 4 },
+      },
+    ],
+  ];
+  const json = serializeClipboard({ blocks: [], tableCells: cells });
+  const result = deserializeClipboard(json);
+  expect(result.tableCells).toBeDefined();
+  expect(result.tableCells).toHaveLength(1);
+  expect(result.tableCells![0]).toHaveLength(2);
+  expect(result.tableCells![0][0].blocks[0].inlines[0].text).toBe('A1');
+  expect(result.tableCells![0][0].blocks[0].inlines[0].style.bold).toBe(true);
+  expect(result.tableCells![0][1].blocks[0].inlines[0].text).toBe('B1');
+});
+
+it('should return empty tableCells when absent in payload', () => {
+  const json = serializeClipboard({ blocks: [] });
+  const result = deserializeClipboard(json);
+  expect(result.tableCells).toBeUndefined();
+});
+```
+
+Add the `TableCell` import at the top of the test file:
+
+```typescript
+import type { TableCell } from '../../src/model/types.js';
+```
+
+And update the existing import to include the new functions:
+
+```typescript
+import { serializeClipboard, deserializeClipboard, serializeBlocks, deserializeBlocks, parseHtmlToInlines } from '../../src/view/clipboard.js';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && npx vitest run test/view/clipboard.test.ts`
+Expected: FAIL — `serializeClipboard` and `deserializeClipboard` not exported.
+
+- [ ] **Step 3: Implement serialization changes**
+
+In `packages/docs/src/view/clipboard.ts`, update the `ClipboardPayload` interface and add new functions:
+
+```typescript
+import type { Block, BlockType, Inline, InlineStyle, HeadingLevel, TableCell } from '../model/types.js';
+```
+
+Update the interface:
+
+```typescript
+interface ClipboardPayload {
+  version: 1;
+  blocks: Block[];
+  tableCells?: TableCell[][];
+}
+```
+
+Add new serialize/deserialize functions after the existing ones (keep old ones for backward compat):
+
+```typescript
+export interface ClipboardData {
+  blocks: Block[];
+  tableCells?: TableCell[][];
+}
+
+export function serializeClipboard(data: ClipboardData): string {
+  const payload: ClipboardPayload = { version: 1, blocks: data.blocks };
+  if (data.tableCells) {
+    payload.tableCells = data.tableCells;
+  }
+  return JSON.stringify(payload);
+}
+
+export function deserializeClipboard(json: string): ClipboardData {
+  try {
+    const payload = JSON.parse(json) as Partial<ClipboardPayload>;
+    if (payload.version !== 1) return { blocks: [] };
+    return {
+      blocks: Array.isArray(payload.blocks) ? payload.blocks : [],
+      tableCells: Array.isArray(payload.tableCells) ? payload.tableCells : undefined,
+    };
+  } catch {
+    return { blocks: [] };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && npx vitest run test/view/clipboard.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/view/clipboard.ts packages/docs/test/view/clipboard.test.ts
+git commit -m "Add clipboard serialization support for table cells"
+```
+
+---
+
+### Task 2: Add cloneTableCells helper
+
+**Files:**
+- Modify: `packages/docs/src/view/clipboard.ts`
+- Test: `packages/docs/test/view/clipboard.test.ts`
+
+- [ ] **Step 1: Write failing test for cloneTableCells**
+
+In `packages/docs/test/view/clipboard.test.ts`, add a new describe block:
+
+```typescript
+import { cloneTableCells } from '../../src/view/clipboard.js';
+
+describe('cloneTableCells', () => {
+  it('should deep clone cells with new block IDs', () => {
+    const cells: TableCell[][] = [
+      [
+        {
+          blocks: [{
+            id: 'original-id',
+            type: 'paragraph' as const,
+            inlines: [{ text: 'hello', style: { bold: true } }],
+            style: { alignment: 'left' as const, lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 },
+          }],
+          style: { padding: 4 },
+        },
+      ],
+    ];
+    const cloned = cloneTableCells(cells);
+
+    // Different block ID
+    expect(cloned[0][0].blocks[0].id).not.toBe('original-id');
+    // Same content
+    expect(cloned[0][0].blocks[0].inlines[0].text).toBe('hello');
+    expect(cloned[0][0].blocks[0].inlines[0].style.bold).toBe(true);
+    // Deep clone — mutating original does not affect clone
+    cells[0][0].blocks[0].inlines[0].text = 'mutated';
+    expect(cloned[0][0].blocks[0].inlines[0].text).toBe('hello');
+  });
+
+  it('should clone cell style independently', () => {
+    const cells: TableCell[][] = [
+      [{
+        blocks: [{
+          id: 'b1',
+          type: 'paragraph' as const,
+          inlines: [{ text: '', style: {} }],
+          style: { alignment: 'left' as const, lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 },
+        }],
+        style: { padding: 8 },
+      }],
+    ];
+    const cloned = cloneTableCells(cells);
+    cells[0][0].style.padding = 99;
+    expect(cloned[0][0].style.padding).toBe(8);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && npx vitest run test/view/clipboard.test.ts`
+Expected: FAIL — `cloneTableCells` not exported.
+
+- [ ] **Step 3: Implement cloneTableCells**
+
+In `packages/docs/src/view/clipboard.ts`, add:
+
+```typescript
+export function cloneTableCells(cells: TableCell[][]): TableCell[][] {
+  return cells.map(row =>
+    row.map(cell => ({
+      style: { ...cell.style },
+      ...(cell.colSpan != null ? { colSpan: cell.colSpan } : {}),
+      ...(cell.rowSpan != null ? { rowSpan: cell.rowSpan } : {}),
+      blocks: cell.blocks.map(b => ({
+        ...b,
+        id: generateBlockId(),
+        inlines: b.inlines.map(il => ({ text: il.text, style: { ...il.style } })),
+        style: { ...b.style },
+      })),
+    }))
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && npx vitest run test/view/clipboard.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/view/clipboard.ts packages/docs/test/view/clipboard.test.ts
+git commit -m "Add cloneTableCells deep-clone helper for clipboard"
+```
+
+---
+
+### Task 3: Implement copy for table cell ranges
+
+**Files:**
+- Modify: `packages/docs/src/view/text-editor.ts:696-715`
+
+- [ ] **Step 1: Add getSelectedTableCells method**
+
+In `packages/docs/src/view/text-editor.ts`, add the following method near `getSelectedBlocks()` (around line 2553):
+
+```typescript
+/**
+ * Extract selected table cells as a 2D array when a tableCellRange is active.
+ */
+private getSelectedTableCells(): TableCell[][] | null {
+  const layout = this.getLayout();
+  const normalized = this.selection.getNormalizedRange(layout);
+  if (!normalized?.tableCellRange) return null;
+
+  const cr = normalized.tableCellRange;
+  const lb = layout.blocks.find((b) => b.block.id === cr.blockId);
+  if (!lb?.block.tableData) return null;
+
+  const td = lb.block.tableData;
+  const rows: TableCell[][] = [];
+  for (let r = cr.start.rowIndex; r <= cr.end.rowIndex; r++) {
+    const row: TableCell[] = [];
+    for (let c = cr.start.colIndex; c <= cr.end.colIndex; c++) {
+      const cell = td.rows[r]?.cells[c];
+      if (cell) {
+        row.push(cell);
+      }
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+```
+
+- [ ] **Step 2: Update handleCopy to handle cell ranges**
+
+Replace `handleCopy` at line 696:
+
+```typescript
+private handleCopy = (e: ClipboardEvent): void => {
+  if (!this.selection.hasSelection()) return;
+  e.preventDefault();
+
+  const tableCells = this.getSelectedTableCells();
+  if (tableCells) {
+    const cloned = cloneTableCells(tableCells);
+    const json = serializeClipboard({ blocks: [], tableCells: cloned });
+    e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
+    e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+    return;
+  }
+
+  const selectedBlocks = this.getSelectedBlocks();
+  const json = serializeClipboard({ blocks: selectedBlocks });
+  e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
+  e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+};
+```
+
+- [ ] **Step 3: Update handleCut to handle cell ranges**
+
+Replace `handleCut` at line 705:
+
+```typescript
+private handleCut = (e: ClipboardEvent): void => {
+  if (!this.selection.hasSelection()) return;
+  e.preventDefault();
+
+  const tableCells = this.getSelectedTableCells();
+  if (tableCells) {
+    const cloned = cloneTableCells(tableCells);
+    const json = serializeClipboard({ blocks: [], tableCells: cloned });
+    e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
+    e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+    this.saveSnapshot();
+    this.deleteSelection();
+    this.requestRender();
+    return;
+  }
+
+  const selectedBlocks = this.getSelectedBlocks();
+  const json = serializeClipboard({ blocks: selectedBlocks });
+  e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
+  e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+  this.saveSnapshot();
+  this.deleteSelection();
+  this.requestRender();
+};
+```
+
+- [ ] **Step 4: Update imports in text-editor.ts**
+
+At the top of `text-editor.ts`, update the clipboard import:
+
+```typescript
+import { serializeClipboard, deserializeClipboard, cloneTableCells, parseHtmlToBlocks, WAFFLEDOCS_MIME } from './clipboard.js';
+```
+
+Remove the old `serializeBlocks` and `deserializeBlocks` imports.
+
+- [ ] **Step 5: Update handlePaste to use deserializeClipboard**
+
+In `handlePaste` at line 737, update the deserialization:
+
+```typescript
+const json = e.clipboardData?.getData(WAFFLEDOCS_MIME);
+if (json) {
+  const data = deserializeClipboard(json);
+  if (data.tableCells && data.tableCells.length > 0) {
+    this.saveSnapshot();
+    this.deleteSelection();
+    this.pasteTableCells(data.tableCells);
+    this.selection.setRange(null);
+    this.requestRender();
+    return;
+  }
+  if (data.blocks.length > 0) {
+    this.saveSnapshot();
+    this.deleteSelection();
+    this.insertBlocks(data.blocks);
+    this.selection.setRange(null);
+    this.requestRender();
+    return;
+  }
+}
+```
+
+- [ ] **Step 6: Run lint to verify no compile errors**
+
+Run: `cd packages/docs && npx tsc --noEmit`
+Expected: PASS (ignore if `pasteTableCells` not yet defined — add stub next step)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/docs/src/view/text-editor.ts
+git commit -m "Add table cell range copy/cut support in clipboard handlers"
+```
+
+---
+
+### Task 4: Implement paste for table cell ranges
+
+**Files:**
+- Modify: `packages/docs/src/view/text-editor.ts`
+
+- [ ] **Step 1: Add pasteTableCells method**
+
+In `packages/docs/src/view/text-editor.ts`, add after `insertBlocks()` (around line 2711):
+
+```typescript
+/**
+ * Paste table cells into the current table at the cursor position.
+ * If cursor is not in a table, creates a new table block from the cells.
+ */
+private pasteTableCells(cells: TableCell[][]): void {
+  if (cells.length === 0) return;
+
+  const layout = this.getLayout();
+  const pos = this.cursor.position;
+  const cellInfo = layout.blockParentMap.get(pos.blockId);
+
+  if (!cellInfo) {
+    // Cursor not in a table — insert a new table block from the cells
+    const rows = cells.length;
+    const cols = Math.max(...cells.map(r => r.length));
+    const tableBlock = createTableBlock(rows, cols);
+    const td = tableBlock.tableData!;
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cells[r].length; c++) {
+        const cloned = cloneTableCells([[cells[r][c]]])[0][0];
+        td.rows[r].cells[c] = cloned;
+      }
+    }
+    const blockIdx = this.doc.getBlockIndex(pos.blockId);
+    this.doc.insertBlockAt(blockIdx + 1, tableBlock);
+    this.invalidateLayout();
+    const firstCellBlock = td.rows[0].cells[0].blocks[0];
+    this.cursor.moveTo({ blockId: firstCellBlock.id, offset: 0 }, 'before');
+    return;
+  }
+
+  // Cursor is in a table — paste cells starting from current cell position
+  const tableBlockId = cellInfo.tableBlockId;
+  const tableBlock = this.doc.getBlock(tableBlockId);
+  const td = tableBlock.tableData;
+  if (!td) return;
+
+  const startRow = cellInfo.rowIndex;
+  const startCol = cellInfo.colIndex;
+
+  for (let r = 0; r < cells.length; r++) {
+    const targetRow = startRow + r;
+    if (targetRow >= td.rows.length) break; // clamp
+
+    for (let c = 0; c < cells[r].length; c++) {
+      const targetCol = startCol + c;
+      if (targetCol >= td.rows[targetRow].cells.length) continue; // clamp
+
+      const cloned = cloneTableCells([[cells[r][c]]])[0][0];
+      td.rows[targetRow].cells[targetCol] = cloned;
+      this.doc.store.updateTableCell(tableBlockId, targetRow, targetCol, cloned);
+    }
+  }
+
+  this.invalidateLayout();
+  // Move cursor to the last pasted cell's first block
+  const lastRow = Math.min(startRow + cells.length - 1, td.rows.length - 1);
+  const lastCol = Math.min(startCol + cells[cells.length - 1].length - 1, td.rows[lastRow].cells.length - 1);
+  const lastCell = td.rows[lastRow].cells[lastCol];
+  if (lastCell?.blocks[0]) {
+    this.cursor.moveTo({ blockId: lastCell.blocks[0].id, offset: 0 }, 'before');
+  }
+}
+```
+
+- [ ] **Step 2: Add createTableBlock import**
+
+Ensure `text-editor.ts` imports `createTableBlock` from the model:
+
+```typescript
+import { ..., createTableBlock } from '../model/types.js';
+```
+
+- [ ] **Step 3: Verify store access pattern**
+
+Check if `this.doc.store` is accessible. If the store is private, use `this.doc.updateTableCell()` instead. Look at how existing code calls `store.updateTableCell`:
+
+The document model's existing pattern (seen in `document.ts:823`) is `this.store.updateTableCell(blockId, r, c, cell)`. Since `pasteTableCells` lives in `text-editor.ts` which has `this.doc` (a `Document` instance), we need to check if `Document` exposes a method we can use.
+
+If `Document` doesn't expose `updateTableCell` directly, add a thin wrapper to `document.ts`:
+
+```typescript
+updateTableCell(tableBlockId: string, rowIndex: number, colIndex: number, cell: TableCell): void {
+  this.store.updateTableCell(tableBlockId, rowIndex, colIndex, cell);
+  this.refresh();
+}
+```
+
+Then in `pasteTableCells`, replace `this.doc.store.updateTableCell(...)` with `this.doc.updateTableCell(...)` and remove `this.invalidateLayout()` since `refresh()` handles it.
+
+- [ ] **Step 4: Run type check**
+
+Run: `cd packages/docs && npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/docs/src/view/text-editor.ts packages/docs/src/model/document.ts
+git commit -m "Add table cell paste support with clamp-to-bounds"
+```
+
+---
+
+### Task 5: Verify and run full test suite
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run clipboard tests**
+
+Run: `cd packages/docs && npx vitest run test/view/clipboard.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 2: Run full docs package tests**
+
+Run: `pnpm test`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run verify:fast**
+
+Run: `pnpm verify:fast`
+Expected: PASS — lint + unit tests clean
+
+- [ ] **Step 4: Manual smoke test (if dev server available)**
+
+1. Start dev server: `pnpm dev`
+2. Create a new doc, insert a table (3x3)
+3. Type text in several cells
+4. Select a 2x2 cell range → Ctrl+C
+5. Click a different cell → Ctrl+V
+6. Verify: cells pasted correctly at target position
+7. Select cells → Ctrl+X → verify cells cleared
+8. Paste into a different table → verify cross-table paste works
+9. Paste when cursor is on a normal paragraph → verify new table created

--- a/packages/docs/src/view/clipboard.ts
+++ b/packages/docs/src/view/clipboard.ts
@@ -1,9 +1,10 @@
-import type { Block, BlockType, Inline, InlineStyle, HeadingLevel } from '../model/types.js';
+import type { Block, BlockType, Inline, InlineStyle, HeadingLevel, TableCell } from '../model/types.js';
 import { generateBlockId, DEFAULT_BLOCK_STYLE, inlineStylesEqual } from '../model/types.js';
 
 interface ClipboardPayload {
   version: 1;
   blocks: Block[];
+  tableCells?: TableCell[][];
 }
 
 export function serializeBlocks(blocks: Block[]): string {
@@ -18,6 +19,32 @@ export function deserializeBlocks(json: string): Block[] {
     return payload.blocks as Block[];
   } catch {
     return [];
+  }
+}
+
+export interface ClipboardData {
+  blocks: Block[];
+  tableCells?: TableCell[][];
+}
+
+export function serializeClipboard(data: ClipboardData): string {
+  const payload: ClipboardPayload = { version: 1, blocks: data.blocks };
+  if (data.tableCells) {
+    payload.tableCells = data.tableCells;
+  }
+  return JSON.stringify(payload);
+}
+
+export function deserializeClipboard(json: string): ClipboardData {
+  try {
+    const payload = JSON.parse(json) as Partial<ClipboardPayload>;
+    if (payload.version !== 1) return { blocks: [] };
+    return {
+      blocks: Array.isArray(payload.blocks) ? payload.blocks : [],
+      tableCells: Array.isArray(payload.tableCells) ? payload.tableCells : undefined,
+    };
+  } catch {
+    return { blocks: [] };
   }
 }
 

--- a/packages/docs/src/view/clipboard.ts
+++ b/packages/docs/src/view/clipboard.ts
@@ -48,6 +48,22 @@ export function deserializeClipboard(json: string): ClipboardData {
   }
 }
 
+export function cloneTableCells(cells: TableCell[][]): TableCell[][] {
+  return cells.map(row =>
+    row.map(cell => ({
+      style: { ...cell.style },
+      ...(cell.colSpan != null ? { colSpan: cell.colSpan } : {}),
+      ...(cell.rowSpan != null ? { rowSpan: cell.rowSpan } : {}),
+      blocks: cell.blocks.map(b => ({
+        ...b,
+        id: generateBlockId(),
+        inlines: b.inlines.map(il => ({ text: il.text, style: { ...il.style } })),
+        style: { ...b.style },
+      })),
+    }))
+  );
+}
+
 export const WAFFLEDOCS_MIME = 'application/x-waffledocs';
 
 /**

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -2604,6 +2604,25 @@ export class TextEditor {
       if (block.headingLevel !== undefined) cloned.headingLevel = block.headingLevel;
       if (block.listKind !== undefined) cloned.listKind = block.listKind;
       if (block.listLevel !== undefined) cloned.listLevel = block.listLevel;
+      if (block.tableData) {
+        cloned.tableData = {
+          columnWidths: [...block.tableData.columnWidths],
+          ...(block.tableData.rowHeights ? { rowHeights: [...block.tableData.rowHeights] } : {}),
+          rows: block.tableData.rows.map(row => ({
+            cells: row.cells.map(cell => ({
+              style: { ...cell.style },
+              ...(cell.colSpan != null ? { colSpan: cell.colSpan } : {}),
+              ...(cell.rowSpan != null ? { rowSpan: cell.rowSpan } : {}),
+              blocks: cell.blocks.map(b => ({
+                ...b,
+                id: generateBlockId(),
+                inlines: b.inlines.map(il => ({ text: il.text, style: { ...il.style } })),
+                style: { ...b.style },
+              })),
+            })),
+          })),
+        };
+      }
       result.push(cloned);
     }
 
@@ -2702,7 +2721,6 @@ export class TextEditor {
     // If cursor is on a non-editable block, split to create a text block first
     this.ensureEditableBlock();
     const pos = this.cursor.position;
-
     if (blocks.length === 1) {
       // Single block: merge pasted inlines into the current block at cursor
       const pastedInlines = blocks[0].inlines;

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -2793,6 +2793,9 @@ export class TextEditor {
   private pasteTableCells(cells: TableCell[][]): void {
     if (cells.length === 0) return;
 
+    // Table paste is only supported in the body context
+    if (this.editContext !== 'body') return;
+
     const layout = this.getLayout();
     const pos = this.cursor.position;
     const cellInfo = layout.blockParentMap.get(pos.blockId);
@@ -2800,7 +2803,7 @@ export class TextEditor {
     if (!cellInfo) {
       // Cursor not in a table — insert a new table block from the cells
       const rows = cells.length;
-      const cols = Math.max(...cells.map(r => r.length));
+      const cols = Math.max(1, ...cells.map(r => r.length));
       const tableBlock = createTableBlock(rows, cols);
       const td = tableBlock.tableData!;
       for (let r = 0; r < rows; r++) {
@@ -2836,14 +2839,14 @@ export class TextEditor {
 
         const cloned = cloneTableCells([[cells[r][c]]])[0][0];
         td.rows[targetRow].cells[targetCol] = cloned;
-        this.doc.updateBlockDirect(tableBlockId, tableBlock);
       }
     }
+    this.doc.updateBlockDirect(tableBlockId, tableBlock);
 
     this.invalidateLayout();
     // Move cursor to the last pasted cell's first block
     const lastRow = Math.min(startRow + cells.length - 1, td.rows.length - 1);
-    const lastColIdx = cells.length > 0 ? cells[cells.length - 1].length - 1 : 0;
+    const lastColIdx = Math.max(0, cells[cells.length - 1].length - 1);
     const lastCol = Math.min(startCol + lastColIdx, td.rows[lastRow].cells.length - 1);
     const lastCell = td.rows[lastRow].cells[lastCol];
     if (lastCell?.blocks[0]) {

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1,7 +1,7 @@
-import type { Block, BlockCellInfo, CellAddress, DocPosition, DocRange, Inline, InlineStyle, HeadingLevel } from '../model/types.js';
-import { generateBlockId, getBlockText, getBlockTextLength, DEFAULT_BLOCK_STYLE, createBlock } from '../model/types.js';
+import type { Block, BlockCellInfo, CellAddress, DocPosition, DocRange, Inline, InlineStyle, HeadingLevel, TableCell } from '../model/types.js';
+import { generateBlockId, getBlockText, getBlockTextLength, DEFAULT_BLOCK_STYLE, createBlock, createTableBlock } from '../model/types.js';
 import { Doc, type EditContext } from '../model/document.js';
-import { serializeBlocks, deserializeBlocks, parseHtmlToBlocks, WAFFLEDOCS_MIME } from './clipboard.js';
+import { serializeClipboard, deserializeClipboard, cloneTableCells, parseHtmlToBlocks, WAFFLEDOCS_MIME } from './clipboard.js';
 import { Cursor } from './cursor.js';
 import { Selection, expandCellRangeForMerges } from './selection.js';
 import type { DocumentLayout } from './layout.js';
@@ -696,8 +696,18 @@ export class TextEditor {
   private handleCopy = (e: ClipboardEvent): void => {
     if (!this.selection.hasSelection()) return;
     e.preventDefault();
+
+    const tableCells = this.getSelectedTableCells();
+    if (tableCells) {
+      const cloned = cloneTableCells(tableCells);
+      const json = serializeClipboard({ blocks: [], tableCells: cloned });
+      e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
+      e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+      return;
+    }
+
     const selectedBlocks = this.getSelectedBlocks();
-    const json = serializeBlocks(selectedBlocks);
+    const json = serializeClipboard({ blocks: selectedBlocks });
     e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
     e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
   };
@@ -705,8 +715,21 @@ export class TextEditor {
   private handleCut = (e: ClipboardEvent): void => {
     if (!this.selection.hasSelection()) return;
     e.preventDefault();
+
+    const tableCells = this.getSelectedTableCells();
+    if (tableCells) {
+      const cloned = cloneTableCells(tableCells);
+      const json = serializeClipboard({ blocks: [], tableCells: cloned });
+      e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
+      e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
+      this.saveSnapshot();
+      this.deleteSelection();
+      this.requestRender();
+      return;
+    }
+
     const selectedBlocks = this.getSelectedBlocks();
-    const json = serializeBlocks(selectedBlocks);
+    const json = serializeClipboard({ blocks: selectedBlocks });
     e.clipboardData?.setData(WAFFLEDOCS_MIME, json);
     e.clipboardData?.setData('text/plain', this.selection.getSelectedText(this.getLayout()));
     this.saveSnapshot();
@@ -736,11 +759,19 @@ export class TextEditor {
     // Try rich internal paste first
     const json = e.clipboardData?.getData(WAFFLEDOCS_MIME);
     if (json) {
-      const blocks = deserializeBlocks(json);
-      if (blocks.length > 0) {
+      const data = deserializeClipboard(json);
+      if (data.tableCells && data.tableCells.length > 0) {
         this.saveSnapshot();
         this.deleteSelection();
-        this.insertBlocks(blocks);
+        this.pasteTableCells(data.tableCells);
+        this.selection.setRange(null);
+        this.requestRender();
+        return;
+      }
+      if (data.blocks.length > 0) {
+        this.saveSnapshot();
+        this.deleteSelection();
+        this.insertBlocks(data.blocks);
         this.selection.setRange(null);
         this.requestRender();
         return;
@@ -2511,6 +2542,33 @@ export class TextEditor {
   }
 
   /**
+   * Extract selected table cells as a 2D array when a tableCellRange is active.
+   */
+  private getSelectedTableCells(): TableCell[][] | null {
+    const layout = this.getLayout();
+    const normalized = this.selection.getNormalizedRange(layout);
+    if (!normalized?.tableCellRange) return null;
+
+    const cr = normalized.tableCellRange;
+    const lb = layout.blocks.find((b) => b.block.id === cr.blockId);
+    if (!lb?.block.tableData) return null;
+
+    const td = lb.block.tableData;
+    const rows: TableCell[][] = [];
+    for (let r = cr.start.rowIndex; r <= cr.end.rowIndex; r++) {
+      const row: TableCell[] = [];
+      for (let c = cr.start.colIndex; c <= cr.end.colIndex; c++) {
+        const cell = td.rows[r]?.cells[c];
+        if (cell) {
+          row.push(cell);
+        }
+      }
+      rows.push(row);
+    }
+    return rows;
+  }
+
+  /**
    * Extract the selected blocks with formatting, trimming the first and last
    * block to the selection boundaries. Block IDs are regenerated.
    */
@@ -2707,6 +2765,71 @@ export class TextEditor {
 
       const newPos = { blockId: tailBlockId, offset: lastPastedTextLen };
       this.cursor.moveTo(newPos, this.getWrapAffinity(newPos));
+    }
+  }
+
+  /**
+   * Paste table cells into the current table at the cursor position.
+   * If cursor is not in a table, creates a new table block from the cells.
+   */
+  private pasteTableCells(cells: TableCell[][]): void {
+    if (cells.length === 0) return;
+
+    const layout = this.getLayout();
+    const pos = this.cursor.position;
+    const cellInfo = layout.blockParentMap.get(pos.blockId);
+
+    if (!cellInfo) {
+      // Cursor not in a table — insert a new table block from the cells
+      const rows = cells.length;
+      const cols = Math.max(...cells.map(r => r.length));
+      const tableBlock = createTableBlock(rows, cols);
+      const td = tableBlock.tableData!;
+      for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cells[r].length; c++) {
+          const cloned = cloneTableCells([[cells[r][c]]])[0][0];
+          td.rows[r].cells[c] = cloned;
+        }
+      }
+      const blockIdx = this.doc.getBlockIndex(pos.blockId);
+      this.doc.insertBlockAt(blockIdx + 1, tableBlock);
+      this.invalidateLayout();
+      const firstCellBlock = td.rows[0].cells[0].blocks[0];
+      this.cursor.moveTo({ blockId: firstCellBlock.id, offset: 0 }, 'forward');
+      return;
+    }
+
+    // Cursor is in a table — paste cells starting from current cell position
+    const tableBlockId = cellInfo.tableBlockId;
+    const tableBlock = this.doc.getBlock(tableBlockId);
+    const td = tableBlock.tableData;
+    if (!td) return;
+
+    const startRow = cellInfo.rowIndex;
+    const startCol = cellInfo.colIndex;
+
+    for (let r = 0; r < cells.length; r++) {
+      const targetRow = startRow + r;
+      if (targetRow >= td.rows.length) break; // clamp
+
+      for (let c = 0; c < cells[r].length; c++) {
+        const targetCol = startCol + c;
+        if (targetCol >= td.rows[targetRow].cells.length) continue; // clamp
+
+        const cloned = cloneTableCells([[cells[r][c]]])[0][0];
+        td.rows[targetRow].cells[targetCol] = cloned;
+        this.doc.updateBlockDirect(tableBlockId, tableBlock);
+      }
+    }
+
+    this.invalidateLayout();
+    // Move cursor to the last pasted cell's first block
+    const lastRow = Math.min(startRow + cells.length - 1, td.rows.length - 1);
+    const lastColIdx = cells.length > 0 ? cells[cells.length - 1].length - 1 : 0;
+    const lastCol = Math.min(startCol + lastColIdx, td.rows[lastRow].cells.length - 1);
+    const lastCell = td.rows[lastRow].cells[lastCol];
+    if (lastCell?.blocks[0]) {
+      this.cursor.moveTo({ blockId: lastCell.blocks[0].id, offset: 0 }, 'forward');
     }
   }
 

--- a/packages/docs/test/view/clipboard.test.ts
+++ b/packages/docs/test/view/clipboard.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
-import { serializeBlocks, deserializeBlocks, parseHtmlToInlines } from '../../src/view/clipboard.js';
+import type { TableCell } from '../../src/model/types.js';
+import { serializeClipboard, deserializeClipboard, serializeBlocks, deserializeBlocks, parseHtmlToInlines } from '../../src/view/clipboard.js';
 
 describe('clipboard JSON serialization', () => {
   it('should round-trip blocks with formatting', () => {
@@ -83,6 +84,45 @@ describe('clipboard JSON serialization', () => {
     const parsed = deserializeBlocks(serializeBlocks(blocks));
     expect(parsed[0].listKind).toBe('ordered');
     expect(parsed[0].listLevel).toBe(1);
+  });
+
+  it('should round-trip tableCells payload', () => {
+    const cells: TableCell[][] = [
+      [
+        {
+          blocks: [{
+            id: 'c1',
+            type: 'paragraph' as const,
+            inlines: [{ text: 'A1', style: { bold: true } }],
+            style: { alignment: 'left' as const, lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 },
+          }],
+          style: { padding: 4 },
+        },
+        {
+          blocks: [{
+            id: 'c2',
+            type: 'paragraph' as const,
+            inlines: [{ text: 'B1', style: {} }],
+            style: { alignment: 'left' as const, lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 },
+          }],
+          style: { padding: 4 },
+        },
+      ],
+    ];
+    const json = serializeClipboard({ blocks: [], tableCells: cells });
+    const result = deserializeClipboard(json);
+    expect(result.tableCells).toBeDefined();
+    expect(result.tableCells).toHaveLength(1);
+    expect(result.tableCells![0]).toHaveLength(2);
+    expect(result.tableCells![0][0].blocks[0].inlines[0].text).toBe('A1');
+    expect(result.tableCells![0][0].blocks[0].inlines[0].style.bold).toBe(true);
+    expect(result.tableCells![0][1].blocks[0].inlines[0].text).toBe('B1');
+  });
+
+  it('should return empty tableCells when absent in payload', () => {
+    const json = serializeClipboard({ blocks: [] });
+    const result = deserializeClipboard(json);
+    expect(result.tableCells).toBeUndefined();
   });
 
   it('should preserve inline style properties', () => {

--- a/packages/docs/test/view/clipboard.test.ts
+++ b/packages/docs/test/view/clipboard.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
 import type { TableCell } from '../../src/model/types.js';
-import { serializeClipboard, deserializeClipboard, serializeBlocks, deserializeBlocks, parseHtmlToInlines } from '../../src/view/clipboard.js';
+import { serializeClipboard, deserializeClipboard, cloneTableCells, serializeBlocks, deserializeBlocks, parseHtmlToInlines } from '../../src/view/clipboard.js';
 
 describe('clipboard JSON serialization', () => {
   it('should round-trip blocks with formatting', () => {
@@ -248,5 +248,50 @@ describe('HTML paste parsing', () => {
     const inlines = parseHtmlToInlines('<span>hello </span><span>world</span>');
     expect(inlines).toHaveLength(1);
     expect(inlines[0].text).toBe('hello world');
+  });
+});
+
+describe('cloneTableCells', () => {
+  it('should deep clone cells with new block IDs', () => {
+    const cells: TableCell[][] = [
+      [
+        {
+          blocks: [{
+            id: 'original-id',
+            type: 'paragraph' as const,
+            inlines: [{ text: 'hello', style: { bold: true } }],
+            style: { alignment: 'left' as const, lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 },
+          }],
+          style: { padding: 4 },
+        },
+      ],
+    ];
+    const cloned = cloneTableCells(cells);
+
+    // Different block ID
+    expect(cloned[0][0].blocks[0].id).not.toBe('original-id');
+    // Same content
+    expect(cloned[0][0].blocks[0].inlines[0].text).toBe('hello');
+    expect(cloned[0][0].blocks[0].inlines[0].style.bold).toBe(true);
+    // Deep clone — mutating original does not affect clone
+    cells[0][0].blocks[0].inlines[0].text = 'mutated';
+    expect(cloned[0][0].blocks[0].inlines[0].text).toBe('hello');
+  });
+
+  it('should clone cell style independently', () => {
+    const cells: TableCell[][] = [
+      [{
+        blocks: [{
+          id: 'b1',
+          type: 'paragraph' as const,
+          inlines: [{ text: '', style: {} }],
+          style: { alignment: 'left' as const, lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 },
+        }],
+        style: { padding: 8 },
+      }],
+    ];
+    const cloned = cloneTableCells(cells);
+    cells[0][0].style.padding = 99;
+    expect(cloned[0][0].style.padding).toBe(8);
   });
 });


### PR DESCRIPTION
## Summary

- Add clipboard serialization for table cell ranges (`TableCell[][]`) with deep clone helper
- Enable cell-range copy/cut/paste within and between tables (Phase 1)
- Fix pre-existing bug: `getSelectedBlocks()` now preserves `tableData` when copying blocks that span table boundaries
- Update `handleCopy`/`handleCut`/`handlePaste` to support both cell-range and whole-block table operations

## Details

**Cell-range copy-paste (new):** When a `tableCellRange` selection is active, cells are serialized as `TableCell[][]` in the clipboard payload. Pasting into a table overwrites cells from the cursor position (clamped to table bounds). Pasting outside a table creates a new table block.

**Block-level table copy (bugfix):** `getSelectedBlocks()` was cloning table blocks without `tableData`, causing tables to silently disappear on paste. Now deep-clones the full table structure including rows, cells, and nested block IDs.

## Test plan

- [x] Clipboard serialization round-trip tests (24 pass)
- [x] `cloneTableCells` deep-clone tests (2 pass)
- [x] Full docs test suite (570/570 pass)
- [x] Manual: select cell range → Ctrl+C → click different cell → Ctrl+V
- [x] Manual: select all (with table) → Ctrl+C → Ctrl+V → table preserved
- [x] Manual: Ctrl+X on cell range → cells cleared
- [x] Puppeteer verification of table data preservation through copy-paste cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added table cell copy and paste functionality to Docs editor. Users can now copy and paste individual cells or ranges within tables. Pasted content can populate existing tables or create new table blocks with formatting and content preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->