### PR TITLE
Refactor: extract shared frontend components to remove duplication

### DIFF
--- a/packages/backend/src/api/v1/cells.controller.ts
+++ b/packages/backend/src/api/v1/cells.controller.ts
@@ -36,11 +36,10 @@ export class ApiV1CellsController {
     documentId: string,
     workspaceId: string,
   ) {
-    const doc = await this.documentService.document({
+    await this.documentService.getDocumentOrThrow({
       id: documentId,
       workspaceId,
     });
-    if (!doc) throw new NotFoundException('Document not found');
   }
 
   @Get()

--- a/packages/backend/src/api/v1/documents.controller.ts
+++ b/packages/backend/src/api/v1/documents.controller.ts
@@ -3,7 +3,6 @@ import {
   Controller,
   Delete,
   Get,
-  NotFoundException,
   Param,
   Patch,
   Post,
@@ -46,12 +45,10 @@ export class ApiV1DocumentsController {
     @Param('workspaceId') workspaceId: string,
     @Param('documentId') documentId: string,
   ) {
-    const doc = await this.documentService.document({
+    return this.documentService.getDocumentOrThrow({
       id: documentId,
       workspaceId,
     });
-    if (!doc) throw new NotFoundException('Document not found');
-    return doc;
   }
 
   @Patch(':documentId')
@@ -60,11 +57,10 @@ export class ApiV1DocumentsController {
     @Param('documentId') documentId: string,
     @Body() body: { title?: string },
   ) {
-    const doc = await this.documentService.document({
+    await this.documentService.getDocumentOrThrow({
       id: documentId,
       workspaceId,
     });
-    if (!doc) throw new NotFoundException('Document not found');
     return this.documentService.updateDocument({
       where: { id: documentId },
       data: body,
@@ -76,11 +72,10 @@ export class ApiV1DocumentsController {
     @Param('workspaceId') workspaceId: string,
     @Param('documentId') documentId: string,
   ) {
-    const doc = await this.documentService.document({
+    await this.documentService.getDocumentOrThrow({
       id: documentId,
       workspaceId,
     });
-    if (!doc) throw new NotFoundException('Document not found');
     return this.documentService.deleteDocument({ id: documentId });
   }
 }

--- a/packages/backend/src/api/v1/images.controller.ts
+++ b/packages/backend/src/api/v1/images.controller.ts
@@ -16,10 +16,8 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { CombinedAuthGuard } from '../../api-key/combined-auth.guard';
 import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { ImageService } from '../../image/image.service';
+import { VALID_IMAGE_ID_PATTERN } from '../../image/image.constants';
 import type { Response, Request } from 'express';
-
-const VALID_ID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(png|jpe?g|gif|webp)$/i;
 
 @Controller('api/v1/workspaces/:workspaceId/images')
 @UseGuards(CombinedAuthGuard, WorkspaceScopeGuard)
@@ -81,7 +79,7 @@ export class ApiV1ImagesController {
     @Req() req: Request,
     @Res() res: Response,
   ): Promise<void> {
-    if (!VALID_ID_PATTERN.test(imageId)) {
+    if (!VALID_IMAGE_ID_PATTERN.test(imageId)) {
       throw new BadRequestException('Invalid image id');
     }
     try {
@@ -101,7 +99,7 @@ export class ApiV1ImagesController {
     @Param('imageId') imageId: string,
     @Req() req: Request,
   ): Promise<{ deleted: boolean }> {
-    if (!VALID_ID_PATTERN.test(imageId)) {
+    if (!VALID_IMAGE_ID_PATTERN.test(imageId)) {
       throw new BadRequestException('Invalid image id');
     }
     await this.imageService.delete(this.scopedKey(req, imageId));

--- a/packages/backend/src/api/v1/tabs.controller.ts
+++ b/packages/backend/src/api/v1/tabs.controller.ts
@@ -1,7 +1,6 @@
 import {
   Controller,
   Get,
-  NotFoundException,
   Param,
   UseGuards,
 } from '@nestjs/common';
@@ -23,11 +22,10 @@ export class ApiV1TabsController {
     @Param('workspaceId') workspaceId: string,
     @Param('documentId') documentId: string,
   ) {
-    const doc = await this.documentService.document({
+    await this.documentService.getDocumentOrThrow({
       id: documentId,
       workspaceId,
     });
-    if (!doc) throw new NotFoundException('Document not found');
 
     return this.yorkieService.withDocument(
       documentId,

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { Document, Prisma } from '@prisma/client';
 import { PrismaService } from 'src/database/prisma.service';
 
@@ -12,6 +12,14 @@ export class DocumentService {
     return this.prisma.document.findUnique({
       where: postWhereUniqueInput,
     });
+  }
+
+  async getDocumentOrThrow(
+    where: Prisma.DocumentWhereUniqueInput,
+  ): Promise<Document> {
+    const doc = await this.document(where);
+    if (!doc) throw new NotFoundException('Document not found');
+    return doc;
   }
 
   async documents(params: {

--- a/packages/backend/src/image/image.constants.ts
+++ b/packages/backend/src/image/image.constants.ts
@@ -1,0 +1,2 @@
+export const VALID_IMAGE_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(png|jpe?g|gif|webp)$/i;

--- a/packages/backend/src/image/image.controller.ts
+++ b/packages/backend/src/image/image.controller.ts
@@ -13,10 +13,8 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ImageService } from './image.service';
+import { VALID_IMAGE_ID_PATTERN } from './image.constants';
 import type { Response } from 'express';
-
-const VALID_ID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(png|jpe?g|gif|webp)$/i;
 
 @Controller('images')
 export class ImageController {
@@ -40,7 +38,7 @@ export class ImageController {
 
   @Get(':id')
   async get(@Param('id') id: string, @Res() res: Response): Promise<void> {
-    if (!VALID_ID_PATTERN.test(id)) {
+    if (!VALID_IMAGE_ID_PATTERN.test(id)) {
       throw new BadRequestException('Invalid image id');
     }
     const { body, contentType } = await this.imageService.getObject(id);
@@ -52,7 +50,7 @@ export class ImageController {
   @Delete(':id')
   @UseGuards(JwtAuthGuard)
   async delete(@Param('id') id: string): Promise<{ deleted: boolean }> {
-    if (!VALID_ID_PATTERN.test(id)) {
+    if (!VALID_IMAGE_ID_PATTERN.test(id)) {
       throw new BadRequestException('Invalid image id');
     }
     await this.imageService.delete(id);

--- a/packages/docs/src/view/pagination.ts
+++ b/packages/docs/src/view/pagination.ts
@@ -408,3 +408,27 @@ export function resolveClickTarget(
   }
   return 'body';
 }
+
+/**
+ * Find the first PageLine matching a given blockIndex and lineIndex.
+ * Returns the PageLine together with its pageIndex and absolute pageY,
+ * or undefined if no match is found.
+ */
+export function findPageLine(
+  paginatedLayout: PaginatedLayout,
+  blockIndex: number,
+  lineIndex: number,
+): { pageLine: PageLine; pageIndex: number; pageY: number } | undefined {
+  for (const page of paginatedLayout.pages) {
+    for (const pl of page.lines) {
+      if (pl.blockIndex === blockIndex && pl.lineIndex === lineIndex) {
+        return {
+          pageLine: pl,
+          pageIndex: page.pageIndex,
+          pageY: getPageYOffset(paginatedLayout, page.pageIndex),
+        };
+      }
+    }
+  }
+  return undefined;
+}

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -1,7 +1,7 @@
 import type { DocPosition, DocRange } from '../model/types.js';
 import { LIST_INDENT_PX } from '../model/types.js';
 import type { PaginatedLayout } from './pagination.js';
-import { findPageForPosition, getPageYOffset, getPageXOffset } from './pagination.js';
+import { findPageForPosition, findPageLine, getPageYOffset, getPageXOffset } from './pagination.js';
 import type { DocumentLayout } from './layout.js';
 import { buildFont, Theme } from './theme.js';
 import { computeMergedCellLineLayouts } from './table-renderer.js';
@@ -188,24 +188,12 @@ export function resolvePositionPixel(
         if (nestingPath.length === 1) {
           // Non-nested table cell — use the original cursor positioning
           // logic that finds the PageLine by ownerRow.
-          let pageLine: import('./pagination.js').PageLine | undefined;
-          let pageIndex = 0;
-          for (const page of paginatedLayout.pages) {
-            for (const pl of page.lines) {
-              if (pl.blockIndex === blockIndex && pl.lineIndex === ownerRow) {
-                pageLine = pl;
-                pageIndex = page.pageIndex;
-                break;
-              }
-            }
-            if (pageLine) break;
-          }
-          if (!pageLine) return undefined;
+          const found = findPageLine(paginatedLayout, blockIndex, ownerRow);
+          if (!found) return undefined;
 
-          const pageY = getPageYOffset(paginatedLayout, pageIndex);
           const cellX = tl.columnXOffsets[colIndex] + cellPadding;
           const cursorYOnPage =
-            pageY + pageLine.y + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]);
+            found.pageY + found.pageLine.y + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]);
 
           return {
             x: pageX + margins.left + cellX + cursorX,
@@ -217,23 +205,11 @@ export function resolvePositionPixel(
         // Nested table cell — find the PageLine for the outermost table's
         // row, then add accumulated Y offset from outer cells.
         const outerRowIndex = nestingPath[0].rowIndex;
-        let pageLine: import('./pagination.js').PageLine | undefined;
-        let pageIndex = 0;
-        for (const page of paginatedLayout.pages) {
-          for (const pl of page.lines) {
-            if (pl.blockIndex === blockIndex && pl.lineIndex === outerRowIndex) {
-              pageLine = pl;
-              pageIndex = page.pageIndex;
-              break;
-            }
-          }
-          if (pageLine) break;
-        }
-        if (!pageLine) return undefined;
+        const found = findPageLine(paginatedLayout, blockIndex, outerRowIndex);
+        if (!found) return undefined;
 
-        const pageY = getPageYOffset(paginatedLayout, pageIndex);
         const innerCellX = tl.columnXOffsets[colIndex] + cellPadding;
-        const innerCursorY = pageY + pageLine.y
+        const innerCursorY = found.pageY + found.pageLine.y
           + yOffsetInTable
           + tl.rowYOffsets[ownerRow]
           + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]);

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -562,9 +562,8 @@ function buildCellRangeRects(
   let baseY = 0;
   if (outerRowIndex >= 0) {
     const found = findPageLine(paginatedLayout, blockIndex, outerRowIndex);
-    if (found) {
-      baseY = found.pageY + found.pageLine.y + nestedYOffset;
-    }
+    if (!found) return [];
+    baseY = found.pageY + found.pageLine.y + nestedYOffset;
   }
 
   // Build a row → absolute Y map

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -2,7 +2,7 @@ import type { DocPosition, DocRange, TableCellRange, TableData, CellAddress } fr
 import { getBlockTextLength } from '../model/types.js';
 import type { DocumentLayout, LayoutLine } from './layout.js';
 import type { PaginatedLayout } from './pagination.js';
-import { findPageForPosition, getPageYOffset, getPageXOffset } from './pagination.js';
+import { findPageForPosition, findPageLine, getPageYOffset, getPageXOffset } from './pagination.js';
 import { resolvePositionPixel } from './peer-cursor.js';
 import { computeMergedCellLineLayouts } from './table-renderer.js';
 import { resolveNestedTableLayout } from './table-layout.js';
@@ -377,30 +377,16 @@ function buildRects(
     const isNested = resolved.outerRowIndex >= 0;
     const resolveLineAbsoluteY = (ownerRow: number, runLineY: number): number | undefined => {
       if (isNested) {
-        // For nested tables, find the outer row's page position and
-        // add the accumulated Y offset + inner row offset
         const outerRow = resolved.outerRowIndex;
-        for (const page of paginatedLayout.pages) {
-          for (const pl of page.lines) {
-            if (pl.blockIndex === blockIndex && pl.lineIndex === outerRow) {
-              const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
-              return pageY + pl.y + nestedYOff
-                + tl.rowYOffsets[ownerRow]
-                + (runLineY - tl.rowYOffsets[ownerRow]);
-            }
-          }
-        }
-        return undefined;
+        const found = findPageLine(paginatedLayout, blockIndex, outerRow);
+        if (!found) return undefined;
+        return found.pageY + found.pageLine.y + nestedYOff
+          + tl.rowYOffsets[ownerRow]
+          + (runLineY - tl.rowYOffsets[ownerRow]);
       }
-      for (const page of paginatedLayout.pages) {
-        for (const pl of page.lines) {
-          if (pl.blockIndex === blockIndex && pl.lineIndex === ownerRow) {
-            const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
-            return pageY + pl.y + (runLineY - tl.rowYOffsets[ownerRow]);
-          }
-        }
-      }
-      return undefined;
+      const found = findPageLine(paginatedLayout, blockIndex, ownerRow);
+      if (!found) return undefined;
+      return found.pageY + found.pageLine.y + (runLineY - tl.rowYOffsets[ownerRow]);
     };
 
     const cellRects: Array<{ x: number; y: number; width: number; height: number }> = [];
@@ -575,15 +561,9 @@ function buildCellRangeRects(
   // contains the nested table. For top-level tables, build the full row map.
   let baseY = 0;
   if (outerRowIndex >= 0) {
-    // Nested table — find the page line for the outer row
-    for (const page of paginatedLayout.pages) {
-      const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
-      for (const pl of page.lines) {
-        if (pl.blockIndex === blockIndex && pl.lineIndex === outerRowIndex) {
-          baseY = pageY + pl.y + nestedYOffset;
-          break;
-        }
-      }
+    const found = findPageLine(paginatedLayout, blockIndex, outerRowIndex);
+    if (found) {
+      baseY = found.pageY + found.pageLine.y + nestedYOffset;
     }
   }
 

--- a/packages/frontend/src/app/datasources/datasource-edit-dialog.tsx
+++ b/packages/frontend/src/app/datasources/datasource-edit-dialog.tsx
@@ -7,9 +7,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
+import { DataSourceFormFields } from "@/components/datasource-form-fields";
 import { updateDataSource, testDataSourceConnection } from "@/api/datasources";
 import { isAuthExpiredError } from "@/api/auth";
 import type { DataSource } from "@/types/datasource";
@@ -104,71 +102,24 @@ export function DataSourceEditDialog({
             Update the connection settings for this datasource.
           </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 py-2">
-          <div className="grid gap-2">
-            <Label htmlFor="edit-ds-name">Name</Label>
-            <Input
-              id="edit-ds-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          </div>
-          <div className="grid grid-cols-3 gap-2">
-            <div className="col-span-2 grid gap-2">
-              <Label htmlFor="edit-ds-host">Host</Label>
-              <Input
-                id="edit-ds-host"
-                value={host}
-                onChange={(e) => setHost(e.target.value)}
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="edit-ds-port">Port</Label>
-              <Input
-                id="edit-ds-port"
-                type="number"
-                value={port}
-                onChange={(e) => setPort(e.target.value)}
-              />
-            </div>
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="edit-ds-database">Database</Label>
-            <Input
-              id="edit-ds-database"
-              value={database}
-              onChange={(e) => setDatabase(e.target.value)}
-            />
-          </div>
-          <div className="grid grid-cols-2 gap-2">
-            <div className="grid gap-2">
-              <Label htmlFor="edit-ds-username">Username</Label>
-              <Input
-                id="edit-ds-username"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="edit-ds-password">Password</Label>
-              <Input
-                id="edit-ds-password"
-                type="password"
-                placeholder="Leave blank to keep current"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <Switch
-              id="edit-ds-ssl"
-              checked={sslEnabled}
-              onCheckedChange={setSslEnabled}
-            />
-            <Label htmlFor="edit-ds-ssl">Enable SSL</Label>
-          </div>
-        </div>
+        <DataSourceFormFields
+          idPrefix="edit-ds"
+          name={name}
+          host={host}
+          port={port}
+          database={database}
+          username={username}
+          password={password}
+          sslEnabled={sslEnabled}
+          passwordPlaceholder="Leave blank to keep current"
+          onNameChange={setName}
+          onHostChange={setHost}
+          onPortChange={setPort}
+          onDatabaseChange={setDatabase}
+          onUsernameChange={setUsername}
+          onPasswordChange={setPassword}
+          onSslEnabledChange={setSslEnabled}
+        />
         <div className="flex justify-between">
           <Button variant="outline" onClick={handleTest} disabled={testing}>
             {testing ? "Testing..." : "Test Connection"}

--- a/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
+++ b/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { TEXT_COLORS, BG_COLORS } from "@/components/formatting-colors";
+import { ColorPickerGrid } from "@/components/color-picker-grid";
 import {
   IconBold,
   IconItalic,
@@ -27,7 +28,6 @@ import {
   IconAlignJustified,
   IconTypography,
   IconHighlight,
-  IconDropletOff,
   IconArrowBackUp,
   IconArrowForwardUp,
   IconChevronDown,
@@ -380,14 +380,7 @@ export function DocsFormattingToolbar({ editor, editContext = 'body', documentTi
             <TooltipContent>Text color</TooltipContent>
           </Tooltip>
           <DropdownMenuContent className="w-auto p-2">
-            <button className="mb-2 flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted" onClick={() => handleTextColor("")}>
-              <IconDropletOff size={14} /> Reset
-            </button>
-            <div className="grid grid-cols-5 gap-1">
-              {TEXT_COLORS.map((color) => (
-                <button key={color} className="h-5 w-5 cursor-pointer rounded border border-border hover:scale-125 transition-transform" style={{ backgroundColor: color }} onClick={() => handleTextColor(color)} />
-              ))}
-            </div>
+            <ColorPickerGrid colors={TEXT_COLORS} onSelect={handleTextColor} onReset={() => handleTextColor("")} />
           </DropdownMenuContent>
         </DropdownMenu>
 
@@ -403,14 +396,7 @@ export function DocsFormattingToolbar({ editor, editContext = 'body', documentTi
             <TooltipContent>Highlight color</TooltipContent>
           </Tooltip>
           <DropdownMenuContent className="w-auto p-2">
-            <button className="mb-2 flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted" onClick={() => handleHighlightColor("")}>
-              <IconDropletOff size={14} /> Reset
-            </button>
-            <div className="grid grid-cols-5 gap-1">
-              {BG_COLORS.map((color) => (
-                <button key={color} className="h-5 w-5 cursor-pointer rounded border border-border hover:scale-125 transition-transform" style={{ backgroundColor: color }} onClick={() => handleHighlightColor(color)} />
-              ))}
-            </div>
+            <ColorPickerGrid colors={BG_COLORS} onSelect={handleHighlightColor} onReset={() => handleHighlightColor("")} />
           </DropdownMenuContent>
         </DropdownMenu>
 
@@ -603,23 +589,7 @@ export function DocsFormattingToolbar({ editor, editContext = 'body', documentTi
           <TooltipContent>Text color</TooltipContent>
         </Tooltip>
         <DropdownMenuContent className="w-auto p-2">
-          <button
-            className="mb-2 flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted"
-            onClick={() => handleTextColor("")}
-          >
-            <IconDropletOff size={14} />
-            Reset
-          </button>
-          <div className="grid grid-cols-5 gap-1">
-            {TEXT_COLORS.map((color) => (
-              <button
-                key={color}
-                className="h-5 w-5 cursor-pointer rounded border border-border hover:scale-125 transition-transform"
-                style={{ backgroundColor: color }}
-                onClick={() => handleTextColor(color)}
-              />
-            ))}
-          </div>
+          <ColorPickerGrid colors={TEXT_COLORS} onSelect={handleTextColor} onReset={() => handleTextColor("")} />
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -638,23 +608,7 @@ export function DocsFormattingToolbar({ editor, editContext = 'body', documentTi
           <TooltipContent>Highlight color</TooltipContent>
         </Tooltip>
         <DropdownMenuContent className="w-auto p-2">
-          <button
-            className="mb-2 flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted"
-            onClick={() => handleHighlightColor("")}
-          >
-            <IconDropletOff size={14} />
-            Reset
-          </button>
-          <div className="grid grid-cols-5 gap-1">
-            {BG_COLORS.map((color) => (
-              <button
-                key={color}
-                className="h-5 w-5 cursor-pointer rounded border border-border hover:scale-125 transition-transform"
-                style={{ backgroundColor: color }}
-                onClick={() => handleHighlightColor(color)}
-              />
-            ))}
-          </div>
+          <ColorPickerGrid colors={BG_COLORS} onSelect={handleHighlightColor} onReset={() => handleHighlightColor("")} />
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
+++ b/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
@@ -77,6 +77,42 @@ const isMac =
   /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
 const modKey = isMac ? "⌘" : "Ctrl";
 
+function AlignmentDropdown({ onAlign }: { onAlign: (alignment: "left" | "center" | "right" | "justify") => void }) {
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <button className="inline-flex h-7 cursor-pointer items-center justify-center gap-0 rounded-md px-1 text-sm hover:bg-muted" aria-label="Text alignment">
+              <IconAlignLeft size={16} />
+              <IconChevronDown size={12} className="ml-0.5 opacity-50" />
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Text alignment</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent className="w-[200px]">
+        <DropdownMenuItem className="flex items-center justify-between" onClick={() => onAlign("left")}>
+          <span className="flex items-center"><IconAlignLeft size={16} className="mr-2" />Left</span>
+          <span className="text-[11px] text-muted-foreground">{modKey}+⇧L</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="flex items-center justify-between" onClick={() => onAlign("center")}>
+          <span className="flex items-center"><IconAlignCenter size={16} className="mr-2" />Center</span>
+          <span className="text-[11px] text-muted-foreground">{modKey}+⇧E</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="flex items-center justify-between" onClick={() => onAlign("right")}>
+          <span className="flex items-center"><IconAlignRight size={16} className="mr-2" />Right</span>
+          <span className="text-[11px] text-muted-foreground">{modKey}+⇧R</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="flex items-center justify-between" onClick={() => onAlign("justify")}>
+          <span className="flex items-center"><IconAlignJustified size={16} className="mr-2" />Justify</span>
+          <span className="text-[11px] text-muted-foreground">{modKey}+⇧J</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function TableDropdown({ editor }: { editor: EditorAPI | null }) {
   const [open, setOpen] = useState(false);
   return (
@@ -403,37 +439,7 @@ export function DocsFormattingToolbar({ editor, editContext = 'body', documentTi
         <ToolbarSeparator />
 
         {/* ── Alignment ── */}
-        <DropdownMenu>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <button className="inline-flex h-7 cursor-pointer items-center justify-center gap-0 rounded-md px-1 text-sm hover:bg-muted" aria-label="Text alignment">
-                  <IconAlignLeft size={16} />
-                  <IconChevronDown size={12} className="ml-0.5 opacity-50" />
-                </button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent>Text alignment</TooltipContent>
-          </Tooltip>
-          <DropdownMenuContent className="w-[200px]">
-            <DropdownMenuItem className="flex items-center justify-between" onClick={() => handleAlign("left")}>
-              <span className="flex items-center"><IconAlignLeft size={16} className="mr-2" />Left</span>
-              <span className="text-[11px] text-muted-foreground">{modKey}+⇧L</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem className="flex items-center justify-between" onClick={() => handleAlign("center")}>
-              <span className="flex items-center"><IconAlignCenter size={16} className="mr-2" />Center</span>
-              <span className="text-[11px] text-muted-foreground">{modKey}+⇧E</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem className="flex items-center justify-between" onClick={() => handleAlign("right")}>
-              <span className="flex items-center"><IconAlignRight size={16} className="mr-2" />Right</span>
-              <span className="text-[11px] text-muted-foreground">{modKey}+⇧R</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem className="flex items-center justify-between" onClick={() => handleAlign("justify")}>
-              <span className="flex items-center"><IconAlignJustified size={16} className="mr-2" />Justify</span>
-              <span className="text-[11px] text-muted-foreground">{modKey}+⇧J</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <AlignmentDropdown onAlign={handleAlign} />
 
         <ToolbarSeparator />
 
@@ -637,40 +643,7 @@ export function DocsFormattingToolbar({ editor, editContext = 'body', documentTi
           <ToolbarSeparator />
 
           {/* ── Block Styles ── */}
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    className="inline-flex h-7 cursor-pointer items-center justify-center gap-0 rounded-md px-1 text-sm hover:bg-muted"
-                    aria-label="Text alignment"
-                  >
-                    <IconAlignLeft size={16} />
-                    <IconChevronDown size={12} className="ml-0.5 opacity-50" />
-                  </button>
-                </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent>Text alignment</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent className="w-[200px]">
-              <DropdownMenuItem className="flex items-center justify-between" onClick={() => handleAlign("left")}>
-                <span className="flex items-center"><IconAlignLeft size={16} className="mr-2" />Left</span>
-                <span className="text-[11px] text-muted-foreground">{modKey}+⇧L</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem className="flex items-center justify-between" onClick={() => handleAlign("center")}>
-                <span className="flex items-center"><IconAlignCenter size={16} className="mr-2" />Center</span>
-                <span className="text-[11px] text-muted-foreground">{modKey}+⇧E</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem className="flex items-center justify-between" onClick={() => handleAlign("right")}>
-                <span className="flex items-center"><IconAlignRight size={16} className="mr-2" />Right</span>
-                <span className="text-[11px] text-muted-foreground">{modKey}+⇧R</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem className="flex items-center justify-between" onClick={() => handleAlign("justify")}>
-                <span className="flex items-center"><IconAlignJustified size={16} className="mr-2" />Justify</span>
-                <span className="text-[11px] text-muted-foreground">{modKey}+⇧J</span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <AlignmentDropdown onAlign={handleAlign} />
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/packages/frontend/src/app/spreadsheet/charts/area-chart-renderer.tsx
+++ b/packages/frontend/src/app/spreadsheet/charts/area-chart-renderer.tsx
@@ -7,13 +7,13 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartDataset } from "../chart-utils";
-import { getLegendProps } from "./chart-registry";
+import { getLegendProps, type LegendPosition } from "./chart-registry";
 
 type Props = {
   dataset: ChartDataset;
   yAxisWidth: number;
   showGridlines: boolean;
-  legendPosition: "top" | "bottom" | "right" | "left" | "none";
+  legendPosition: LegendPosition;
   formatYAxisTick: (value: number | string) => string;
 };
 

--- a/packages/frontend/src/app/spreadsheet/charts/area-chart-renderer.tsx
+++ b/packages/frontend/src/app/spreadsheet/charts/area-chart-renderer.tsx
@@ -7,6 +7,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartDataset } from "../chart-utils";
+import { getLegendProps } from "./chart-registry";
 
 type Props = {
   dataset: ChartDataset;
@@ -39,19 +40,7 @@ export function AreaChartRenderer({
         />
         <ChartTooltip content={<ChartTooltipContent />} />
         {legendPosition !== "none" && (
-          <ChartLegend
-            content={<ChartLegendContent />}
-            verticalAlign={
-              legendPosition === "top" || legendPosition === "bottom"
-                ? legendPosition
-                : undefined
-            }
-            align={
-              legendPosition === "left" || legendPosition === "right"
-                ? legendPosition
-                : undefined
-            }
-          />
+          <ChartLegend content={<ChartLegendContent />} {...getLegendProps(legendPosition)} />
         )}
         {dataset.series.map((series) => (
           <Area

--- a/packages/frontend/src/app/spreadsheet/charts/bar-chart-renderer.tsx
+++ b/packages/frontend/src/app/spreadsheet/charts/bar-chart-renderer.tsx
@@ -7,13 +7,13 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartDataset } from "../chart-utils";
-import { getLegendProps } from "./chart-registry";
+import { getLegendProps, type LegendPosition } from "./chart-registry";
 
 type Props = {
   dataset: ChartDataset;
   yAxisWidth: number;
   showGridlines: boolean;
-  legendPosition: "top" | "bottom" | "right" | "left" | "none";
+  legendPosition: LegendPosition;
   formatYAxisTick: (value: number | string) => string;
 };
 

--- a/packages/frontend/src/app/spreadsheet/charts/bar-chart-renderer.tsx
+++ b/packages/frontend/src/app/spreadsheet/charts/bar-chart-renderer.tsx
@@ -7,6 +7,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartDataset } from "../chart-utils";
+import { getLegendProps } from "./chart-registry";
 
 type Props = {
   dataset: ChartDataset;
@@ -39,19 +40,7 @@ export function BarChartRenderer({
         />
         <ChartTooltip content={<ChartTooltipContent />} />
         {legendPosition !== "none" && (
-          <ChartLegend
-            content={<ChartLegendContent />}
-            verticalAlign={
-              legendPosition === "top" || legendPosition === "bottom"
-                ? legendPosition
-                : undefined
-            }
-            align={
-              legendPosition === "left" || legendPosition === "right"
-                ? legendPosition
-                : undefined
-            }
-          />
+          <ChartLegend content={<ChartLegendContent />} {...getLegendProps(legendPosition)} />
         )}
         {dataset.series.map((series) => (
           <Bar

--- a/packages/frontend/src/app/spreadsheet/charts/chart-registry.ts
+++ b/packages/frontend/src/app/spreadsheet/charts/chart-registry.ts
@@ -135,3 +135,18 @@ export function getChartEntry(type: ChartType): ChartRegistryEntry {
 export function getAllChartEntries(): ChartRegistryEntry[] {
   return [...registry.values()];
 }
+
+export type LegendPosition = ChartRendererProps["legendPosition"];
+
+export function getLegendProps(legendPosition: LegendPosition) {
+  return {
+    verticalAlign:
+      legendPosition === "top" || legendPosition === "bottom"
+        ? legendPosition
+        : undefined,
+    align:
+      legendPosition === "left" || legendPosition === "right"
+        ? legendPosition
+        : undefined,
+  } as const;
+}

--- a/packages/frontend/src/app/spreadsheet/charts/line-chart-renderer.tsx
+++ b/packages/frontend/src/app/spreadsheet/charts/line-chart-renderer.tsx
@@ -7,13 +7,13 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartDataset } from "../chart-utils";
-import { getLegendProps } from "./chart-registry";
+import { getLegendProps, type LegendPosition } from "./chart-registry";
 
 type Props = {
   dataset: ChartDataset;
   yAxisWidth: number;
   showGridlines: boolean;
-  legendPosition: "top" | "bottom" | "right" | "left" | "none";
+  legendPosition: LegendPosition;
   formatYAxisTick: (value: number | string) => string;
 };
 

--- a/packages/frontend/src/app/spreadsheet/charts/line-chart-renderer.tsx
+++ b/packages/frontend/src/app/spreadsheet/charts/line-chart-renderer.tsx
@@ -7,6 +7,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartDataset } from "../chart-utils";
+import { getLegendProps } from "./chart-registry";
 
 type Props = {
   dataset: ChartDataset;
@@ -39,19 +40,7 @@ export function LineChartRenderer({
         />
         <ChartTooltip content={<ChartTooltipContent />} />
         {legendPosition !== "none" && (
-          <ChartLegend
-            content={<ChartLegendContent />}
-            verticalAlign={
-              legendPosition === "top" || legendPosition === "bottom"
-                ? legendPosition
-                : undefined
-            }
-            align={
-              legendPosition === "left" || legendPosition === "right"
-                ? legendPosition
-                : undefined
-            }
-          />
+          <ChartLegend content={<ChartLegendContent />} {...getLegendProps(legendPosition)} />
         )}
         {dataset.series.map((series) => (
           <Line

--- a/packages/frontend/src/app/spreadsheet/charts/pie-chart-renderer.tsx
+++ b/packages/frontend/src/app/spreadsheet/charts/pie-chart-renderer.tsx
@@ -7,11 +7,11 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { PieDataset } from "../chart-utils";
-import { getLegendProps } from "./chart-registry";
+import { getLegendProps, type LegendPosition } from "./chart-registry";
 
 type Props = {
   dataset: PieDataset;
-  legendPosition: "top" | "bottom" | "right" | "left" | "none";
+  legendPosition: LegendPosition;
 };
 
 export function PieChartRenderer({ dataset, legendPosition }: Props) {

--- a/packages/frontend/src/app/spreadsheet/charts/pie-chart-renderer.tsx
+++ b/packages/frontend/src/app/spreadsheet/charts/pie-chart-renderer.tsx
@@ -7,6 +7,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { PieDataset } from "../chart-utils";
+import { getLegendProps } from "./chart-registry";
 
 type Props = {
   dataset: PieDataset;
@@ -24,19 +25,7 @@ export function PieChartRenderer({ dataset, legendPosition }: Props) {
       <PieChart>
         <ChartTooltip content={<ChartTooltipContent />} />
         {legendPosition !== "none" && (
-          <ChartLegend
-            content={<ChartLegendContent />}
-            verticalAlign={
-              legendPosition === "top" || legendPosition === "bottom"
-                ? legendPosition
-                : undefined
-            }
-            align={
-              legendPosition === "left" || legendPosition === "right"
-                ? legendPosition
-                : undefined
-            }
-          />
+          <ChartLegend content={<ChartLegendContent />} {...getLegendProps(legendPosition)} />
         )}
         <Pie
           data={dataset.entries}

--- a/packages/frontend/src/app/spreadsheet/charts/scatter-chart-renderer.tsx
+++ b/packages/frontend/src/app/spreadsheet/charts/scatter-chart-renderer.tsx
@@ -7,6 +7,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartDataset } from "../chart-utils";
+import { getLegendProps } from "./chart-registry";
 
 type Props = {
   dataset: ChartDataset;
@@ -46,19 +47,7 @@ export function ScatterChartRenderer({
         />
         <ChartTooltip content={<ChartTooltipContent />} />
         {legendPosition !== "none" && (
-          <ChartLegend
-            content={<ChartLegendContent />}
-            verticalAlign={
-              legendPosition === "top" || legendPosition === "bottom"
-                ? legendPosition
-                : undefined
-            }
-            align={
-              legendPosition === "left" || legendPosition === "right"
-                ? legendPosition
-                : undefined
-            }
-          />
+          <ChartLegend content={<ChartLegendContent />} {...getLegendProps(legendPosition)} />
         )}
         {dataset.series.map((series) => {
           const seriesData = dataset.rows.map((row) => ({

--- a/packages/frontend/src/app/spreadsheet/charts/scatter-chart-renderer.tsx
+++ b/packages/frontend/src/app/spreadsheet/charts/scatter-chart-renderer.tsx
@@ -7,13 +7,13 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import type { ChartDataset } from "../chart-utils";
-import { getLegendProps } from "./chart-registry";
+import { getLegendProps, type LegendPosition } from "./chart-registry";
 
 type Props = {
   dataset: ChartDataset;
   yAxisWidth: number;
   showGridlines: boolean;
-  legendPosition: "top" | "bottom" | "right" | "left" | "none";
+  legendPosition: LegendPosition;
   formatYAxisTick: (value: number | string) => string;
 };
 

--- a/packages/frontend/src/components/color-picker-grid.tsx
+++ b/packages/frontend/src/components/color-picker-grid.tsx
@@ -10,7 +10,9 @@ export function ColorPickerGrid({ colors, onSelect, onReset }: ColorPickerGridPr
   return (
     <>
       <button
+        type="button"
         className="mb-2 flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted"
+        aria-label="Reset color"
         onClick={onReset}
       >
         <IconDropletOff size={14} />
@@ -20,8 +22,11 @@ export function ColorPickerGrid({ colors, onSelect, onReset }: ColorPickerGridPr
         {colors.map((color) => (
           <button
             key={color}
+            type="button"
             className="h-5 w-5 cursor-pointer rounded border border-border hover:scale-125 transition-transform"
             style={{ backgroundColor: color }}
+            aria-label={`Select color ${color}`}
+            title={color}
             onClick={() => onSelect(color)}
           />
         ))}

--- a/packages/frontend/src/components/color-picker-grid.tsx
+++ b/packages/frontend/src/components/color-picker-grid.tsx
@@ -1,0 +1,31 @@
+import { IconDropletOff } from "@tabler/icons-react";
+
+interface ColorPickerGridProps {
+  colors: string[];
+  onSelect: (color: string) => void;
+  onReset: () => void;
+}
+
+export function ColorPickerGrid({ colors, onSelect, onReset }: ColorPickerGridProps) {
+  return (
+    <>
+      <button
+        className="mb-2 flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted"
+        onClick={onReset}
+      >
+        <IconDropletOff size={14} />
+        Reset
+      </button>
+      <div className="grid grid-cols-5 gap-1">
+        {colors.map((color) => (
+          <button
+            key={color}
+            className="h-5 w-5 cursor-pointer rounded border border-border hover:scale-125 transition-transform"
+            style={{ backgroundColor: color }}
+            onClick={() => onSelect(color)}
+          />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/packages/frontend/src/components/datasource-dialog.tsx
+++ b/packages/frontend/src/components/datasource-dialog.tsx
@@ -7,9 +7,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
+import { DataSourceFormFields } from "@/components/datasource-form-fields";
 import { testDataSourceConnection } from "@/api/datasources";
 import { createWorkspaceDataSource } from "@/api/workspaces";
 import { isAuthExpiredError } from "@/api/auth";
@@ -143,74 +141,23 @@ export function DataSourceDialog({
             Connect to an external PostgreSQL database.
           </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 py-2">
-          <div className="grid gap-2">
-            <Label htmlFor="ds-name">Name</Label>
-            <Input
-              id="ds-name"
-              placeholder="My Database"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          </div>
-          <div className="grid grid-cols-3 gap-2">
-            <div className="col-span-2 grid gap-2">
-              <Label htmlFor="ds-host">Host</Label>
-              <Input
-                id="ds-host"
-                placeholder="localhost"
-                value={host}
-                onChange={(e) => setHost(e.target.value)}
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="ds-port">Port</Label>
-              <Input
-                id="ds-port"
-                type="number"
-                value={port}
-                onChange={(e) => setPort(e.target.value)}
-              />
-            </div>
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="ds-database">Database</Label>
-            <Input
-              id="ds-database"
-              placeholder="mydb"
-              value={database}
-              onChange={(e) => setDatabase(e.target.value)}
-            />
-          </div>
-          <div className="grid grid-cols-2 gap-2">
-            <div className="grid gap-2">
-              <Label htmlFor="ds-username">Username</Label>
-              <Input
-                id="ds-username"
-                placeholder="postgres"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-              />
-            </div>
-            <div className="grid gap-2">
-              <Label htmlFor="ds-password">Password</Label>
-              <Input
-                id="ds-password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <Switch
-              id="ds-ssl"
-              checked={sslEnabled}
-              onCheckedChange={setSslEnabled}
-            />
-            <Label htmlFor="ds-ssl">Enable SSL</Label>
-          </div>
-        </div>
+        <DataSourceFormFields
+          idPrefix="ds"
+          name={name}
+          host={host}
+          port={port}
+          database={database}
+          username={username}
+          password={password}
+          sslEnabled={sslEnabled}
+          onNameChange={setName}
+          onHostChange={setHost}
+          onPortChange={setPort}
+          onDatabaseChange={setDatabase}
+          onUsernameChange={setUsername}
+          onPasswordChange={setPassword}
+          onSslEnabledChange={setSslEnabled}
+        />
         <div className="flex justify-between">
           <Button
             variant="outline"

--- a/packages/frontend/src/components/datasource-form-fields.tsx
+++ b/packages/frontend/src/components/datasource-form-fields.tsx
@@ -94,6 +94,7 @@ export function DataSourceFormFields({
           <Input
             id={`${idPrefix}-password`}
             type="password"
+            autoComplete="new-password"
             placeholder={passwordPlaceholder}
             value={password}
             onChange={(e) => onPasswordChange(e.target.value)}

--- a/packages/frontend/src/components/datasource-form-fields.tsx
+++ b/packages/frontend/src/components/datasource-form-fields.tsx
@@ -1,0 +1,113 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+interface DataSourceFormFieldsProps {
+  idPrefix: string;
+  name: string;
+  host: string;
+  port: string;
+  database: string;
+  username: string;
+  password: string;
+  sslEnabled: boolean;
+  passwordPlaceholder?: string;
+  onNameChange: (value: string) => void;
+  onHostChange: (value: string) => void;
+  onPortChange: (value: string) => void;
+  onDatabaseChange: (value: string) => void;
+  onUsernameChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onSslEnabledChange: (value: boolean) => void;
+}
+
+export function DataSourceFormFields({
+  idPrefix,
+  name,
+  host,
+  port,
+  database,
+  username,
+  password,
+  sslEnabled,
+  passwordPlaceholder,
+  onNameChange,
+  onHostChange,
+  onPortChange,
+  onDatabaseChange,
+  onUsernameChange,
+  onPasswordChange,
+  onSslEnabledChange,
+}: DataSourceFormFieldsProps) {
+  return (
+    <div className="grid gap-4 py-2">
+      <div className="grid gap-2">
+        <Label htmlFor={`${idPrefix}-name`}>Name</Label>
+        <Input
+          id={`${idPrefix}-name`}
+          placeholder="My Database"
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+        />
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        <div className="col-span-2 grid gap-2">
+          <Label htmlFor={`${idPrefix}-host`}>Host</Label>
+          <Input
+            id={`${idPrefix}-host`}
+            placeholder="localhost"
+            value={host}
+            onChange={(e) => onHostChange(e.target.value)}
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor={`${idPrefix}-port`}>Port</Label>
+          <Input
+            id={`${idPrefix}-port`}
+            type="number"
+            value={port}
+            onChange={(e) => onPortChange(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor={`${idPrefix}-database`}>Database</Label>
+        <Input
+          id={`${idPrefix}-database`}
+          placeholder="mydb"
+          value={database}
+          onChange={(e) => onDatabaseChange(e.target.value)}
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="grid gap-2">
+          <Label htmlFor={`${idPrefix}-username`}>Username</Label>
+          <Input
+            id={`${idPrefix}-username`}
+            placeholder="postgres"
+            value={username}
+            onChange={(e) => onUsernameChange(e.target.value)}
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor={`${idPrefix}-password`}>Password</Label>
+          <Input
+            id={`${idPrefix}-password`}
+            type="password"
+            placeholder={passwordPlaceholder}
+            value={password}
+            onChange={(e) => onPasswordChange(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Switch
+          id={`${idPrefix}-ssl`}
+          checked={sslEnabled}
+          onCheckedChange={onSslEnabledChange}
+        />
+        <Label htmlFor={`${idPrefix}-ssl`}>Enable SSL</Label>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/formatting-toolbar.tsx
+++ b/packages/frontend/src/components/formatting-toolbar.tsx
@@ -26,6 +26,7 @@ import {
   DropdownMenuShortcut,
 } from "@/components/ui/dropdown-menu";
 import { BG_COLORS, TEXT_COLORS } from "@/components/formatting-colors";
+import { ColorPickerGrid } from "@/components/color-picker-grid";
 import { useIsMobile } from "@/hooks/use-mobile";
 import {
   IconBold,
@@ -39,7 +40,6 @@ import {
   IconAlignBoxBottomCenter,
   IconTypography,
   IconDropletHalf2Filled,
-  IconDropletOff,
   IconArrowBackUp,
   IconArrowForwardUp,
   IconCurrencyDollar,
@@ -513,23 +513,7 @@ export function FormattingToolbar({
           <TooltipContent>Text color</TooltipContent>
         </Tooltip>
         <DropdownMenuContent className="w-auto p-2">
-          <button
-            className="mb-2 flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted"
-            onClick={handleResetTextColor}
-          >
-            <IconDropletOff size={14} />
-            Reset
-          </button>
-          <div className="grid grid-cols-5 gap-1">
-            {TEXT_COLORS.map((color) => (
-              <button
-                key={color}
-                className="h-5 w-5 cursor-pointer rounded border border-border hover:scale-125 transition-transform"
-                style={{ backgroundColor: color }}
-                onClick={() => handleTextColor(color)}
-              />
-            ))}
-          </div>
+          <ColorPickerGrid colors={TEXT_COLORS} onSelect={handleTextColor} onReset={handleResetTextColor} />
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -555,23 +539,7 @@ export function FormattingToolbar({
           <TooltipContent>Fill color</TooltipContent>
         </Tooltip>
         <DropdownMenuContent className="w-auto p-2">
-          <button
-            className="mb-2 flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted"
-            onClick={handleResetBgColor}
-          >
-            <IconDropletOff size={14} />
-            Reset
-          </button>
-          <div className="grid grid-cols-5 gap-1">
-            {BG_COLORS.map((color) => (
-              <button
-                key={color}
-                className="h-5 w-5 cursor-pointer rounded border border-border hover:scale-125 transition-transform"
-                style={{ backgroundColor: color }}
-                onClick={() => handleBgColor(color)}
-              />
-            ))}
-          </div>
+          <ColorPickerGrid colors={BG_COLORS} onSelect={handleBgColor} onReset={handleResetBgColor} />
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/packages/sheets/src/model/worksheet/conditional-format.ts
+++ b/packages/sheets/src/model/worksheet/conditional-format.ts
@@ -1,4 +1,4 @@
-import { inRange, toRange } from '../core/coordinates';
+import { cloneRange, inRange, toRange } from '../core/coordinates';
 import { remapIndex } from './shifting';
 import {
   Axis,
@@ -25,13 +25,6 @@ const ValueRequiredOperators = new Set<ConditionalFormatOperator>([
   'dateBefore',
   'dateAfter',
 ]);
-
-function cloneRange(range: Range): Range {
-  return [
-    { r: range[0].r, c: range[0].c },
-    { r: range[1].r, c: range[1].c },
-  ];
-}
 
 function isOperator(value: string): value is ConditionalFormatOperator {
   return ConditionalFormatOperators.has(value as ConditionalFormatOperator);
@@ -64,10 +57,6 @@ function normalizeText(value: unknown): string {
     }
   }
   return String(value);
-}
-
-function normalizeRange(range: Range): Range {
-  return toRange(range[0], range[1]);
 }
 
 function normalizeNumericValue(value: string | undefined): number | undefined {
@@ -229,7 +218,7 @@ export function normalizeConditionalFormatRule(
   if (!rawRanges || rawRanges.length === 0) {
     return undefined;
   }
-  const normalizedRanges = rawRanges.map((r) => normalizeRange(r));
+  const normalizedRanges = rawRanges.map((r) => toRange(r[0], r[1]));
 
   const normalized: ConditionalFormatRule = {
     id,

--- a/packages/sheets/src/model/worksheet/range-styles.ts
+++ b/packages/sheets/src/model/worksheet/range-styles.ts
@@ -1,3 +1,4 @@
+import { toRange } from '../core/coordinates';
 import { Axis, CellStyle, Range } from '../core/types';
 
 export type RangeStylePatch = {
@@ -55,23 +56,12 @@ export function mergeStylePatch(
   return next as CellStyle;
 }
 
-function normalizeRange(range: Range): Range {
-  const top = Math.min(range[0].r, range[1].r);
-  const left = Math.min(range[0].c, range[1].c);
-  const bottom = Math.max(range[0].r, range[1].r);
-  const right = Math.max(range[0].c, range[1].c);
-  return [
-    { r: top, c: left },
-    { r: bottom, c: right },
-  ];
-}
-
 /**
  * Creates a deep copy of a range-style patch with normalized coordinates.
  */
 export function cloneRangeStylePatch(patch: RangeStylePatch): RangeStylePatch {
   return {
-    range: normalizeRange(patch.range),
+    range: toRange(patch.range[0], patch.range[1]),
     style: { ...patch.style },
   };
 }
@@ -87,7 +77,7 @@ export function normalizeRangeStylePatch(
     return undefined;
   }
   return {
-    range: normalizeRange(patch.range),
+    range: toRange(patch.range[0], patch.range[1]),
     style,
   };
 }
@@ -440,7 +430,7 @@ export function clipRangeStylePatches(
   patches: RangeStylePatch[],
   clipRange: Range,
 ): RangeStylePatch[] {
-  const normalizedClip = normalizeRange(clipRange);
+  const normalizedClip = toRange(clipRange[0], clipRange[1]);
   const clipped: RangeStylePatch[] = [];
 
   for (const patch of patches) {
@@ -518,8 +508,8 @@ export function subtractRange(
   patch: RangeStylePatch,
   hole: Range,
 ): RangeStylePatch[] {
-  const p = normalizeRange(patch.range);
-  const h = normalizeRange(hole);
+  const p = toRange(patch.range[0], patch.range[1]);
+  const h = toRange(hole[0], hole[1]);
 
   // No intersection — return the patch unchanged.
   if (p[0].r > h[1].r || p[1].r < h[0].r || p[0].c > h[1].c || p[1].c < h[0].c) {


### PR DESCRIPTION
## Summary

- Extract `ColorPickerGrid` component — identical color grid + reset button pattern was duplicated 6 times across `formatting-toolbar.tsx` and `docs-formatting-toolbar.tsx`
- Extract `DataSourceFormFields` component — create and edit datasource dialogs had identical 7-input form layouts
- Extract `AlignmentDropdown` in docs toolbar — same 4-item alignment menu (Left/Center/Right/Justify with shortcuts) was duplicated in header/footer and body sections
- Extract `getLegendProps` helper — same legend position calculation was duplicated across all 5 chart renderers

Net result: **-103 lines** (252 added, 355 removed) across 12 files.

## Test plan

- [x] `pnpm verify:fast` passes (lint + all unit tests)
- [x] `pnpm verify:self` passes (includes builds)
- [x] Manual browser test: verify color pickers work in sheets and docs toolbars
- [x] Manual browser test: verify datasource create/edit dialogs work
- [x] Manual browser test: verify alignment dropdown in docs toolbar
- [x] Manual browser test: verify chart legend rendering for all chart types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added color picker component with grid-based color selection interface.
  * Added text alignment dropdown for improved formatting options.

* **Refactor**
  * Consolidated datasource form fields into reusable component.
  * Extracted and centralized chart legend positioning logic.
  * Improved error handling for document and image operations.
  * Unified image ID validation patterns across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->