### PR TITLE
Fix arrow key crashes and add table row splitting across pages

### DIFF
--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1612,7 +1612,10 @@ export function initialize(
     },
     getPeerCursorPixels: () => lastPeerPixels,
     getBlockType() {
-      const block = doc.getBlock(cursor.position.blockId);
+      const block = doc.findBlock(cursor.position.blockId);
+      if (!block) {
+        return { type: 'paragraph' as BlockType };
+      }
       return {
         type: block.type,
         headingLevel: block.headingLevel,

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -395,6 +395,19 @@ export class TextEditor {
       return;
     }
 
+    // Guard: if the cursor references a block that no longer exists
+    // (e.g. deleted by a remote collaborator), reset to the first block.
+    if (!this.doc.findBlock(this.cursor.position.blockId)) {
+      const blocks = this.doc.getContextBlocks();
+      if (blocks.length > 0) {
+        this.cursor.moveTo({ blockId: blocks[0].id, offset: 0 });
+        this.selection.setRange(null);
+        this.invalidateLayout();
+        this.requestRender();
+      }
+      return;
+    }
+
     const { ctrlKey, metaKey, shiftKey, altKey } = e;
     const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
     const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
@@ -1840,6 +1853,21 @@ export class TextEditor {
     shiftKey: boolean,
     wordMod = false,
   ): void {
+    try {
+      this.handleArrowInner(direction, shiftKey, wordMod);
+    } catch {
+      // Stale blockParentMap data (e.g. table rows removed by remote edit).
+      // Rebuild layout so the next keypress has fresh data.
+      this.invalidateLayout();
+      this.requestRender();
+    }
+  }
+
+  private handleArrowInner(
+    direction: 'left' | 'right' | 'up' | 'down',
+    shiftKey: boolean,
+    wordMod = false,
+  ): void {
     const pos = this.cursor.position;
 
     // Table cell arrow key handling: keep cursor within cell boundaries
@@ -3179,9 +3207,27 @@ export class TextEditor {
           const crossPageResult = paginatedPixelToPosition(
             paginatedLayout, layout, pixel.x, targetY, canvasWidth,
           );
-          if (crossPageResult) {
+          if (crossPageResult
+              && !(crossPageResult.blockId === pos.blockId && crossPageResult.offset === pos.offset)) {
             this.cursor.lineAffinity = crossPageResult.lineAffinity;
             return crossPageResult;
+          }
+          // Cross-page pixel lookup returned the same position (e.g. the
+          // adjacent page only contains a tall table block). Fall back to
+          // the block on that page line and enter the table if applicable.
+          const fallbackBlock = layout.blocks[targetLine.blockIndex]?.block;
+          if (fallbackBlock?.type === 'table' && fallbackBlock.tableData) {
+            const td = fallbackBlock.tableData;
+            if (direction === -1) {
+              const lastRow = td.rows.length - 1;
+              const lastCol = td.columnWidths.length - 1;
+              const lastCell = td.rows[lastRow].cells[lastCol];
+              const lastCellBlock = lastCell.blocks[lastCell.blocks.length - 1];
+              return { blockId: lastCellBlock.id, offset: Math.min(pos.offset, getBlockTextLength(lastCellBlock)) };
+            } else {
+              const firstCellBlock = td.rows[0].cells[0].blocks[0];
+              return { blockId: firstCellBlock.id, offset: Math.min(pos.offset, getBlockTextLength(firstCellBlock)) };
+            }
           }
           return pos;
         }


### PR DESCRIPTION
## Summary

Two major improvements to the Docs editor:

### 1. Arrow Key Navigation Crash Fix
- Fix "Block not found" crash when pressing Arrow Up/Down/Right in shared documents where blocks may be deleted by remote collaborators
- Fix cursor getting stuck at page boundaries when the adjacent page contains only a tall table block
- Fix toolbar render crash when `getBlockType()` references a deleted block

### 2. Table Row Splitting Across Pages
- **Split tall table rows at page boundaries** so content renders continuously instead of leaving blank space or clipping
- Rows are split at safe points between text lines and images (atomic units are never cut)
- Short header cells don't constrain the split height — only cells with overflowing content limit where the split occurs
- Recursive support for nested tables — rows inside nested tables can also split
- Cell backgrounds and borders render correctly on each page fragment
- Image selection handles position correctly on split row fragments
- Arrow key navigation works across split row boundaries

## Changes

| File | Change |
|------|--------|
| `editor.ts` | `getBlockType()` uses non-throwing `findBlock()` |
| `text-editor.ts` | Stale cursor guard, `handleArrow` try-catch, `moveVertical` cross-page table entry |
| `pagination.ts` | `PageLine.rowSplitOffset/Height`, row splitting logic in `paginateLayout`, coordinate mapping update |
| `table-layout.ts` | `findRowSplitHeight()` with nested table recursion |
| `doc-canvas.ts` | Split fragment rendering pipeline, dedup fix |
| `table-renderer.ts` | Clip-based split fragment rendering |
| `image-selection-overlay.ts` | Split-aware image rect collection |

## Test plan

- [x] `pnpm verify:fast` — 576 tests pass
- [x] Browser: Arrow navigation top→bottom→top — 0 errors
- [x] Browser: "프로젝트 개요" row splits across pages, no blank space
- [x] Browser: Image selection handles position correctly on split fragments
- [x] Browser: No duplicate content rendering at split boundaries
- [x] Browser: No visual artifacts (extra vertical lines) at split boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)