### PR TITLE
Fix table row splitting: click, cursor, selection, and rendering

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -47,6 +47,7 @@ Word processor engine — rich text, tables, pagination, collaboration.
 | [docs-wordprocessor-roadmap.md](docs/docs-wordprocessor-roadmap.md)              | Docs word processor roadmap — 6-phase plan for Google Docs parity                                 |
 | [docs-ruler.md](docs/docs-ruler.md)                                              | Docs ruler design                                                                                 |
 | [docs-table-copy-paste.md](docs/docs-table-copy-paste.md)                        | Docs table copy-paste — cell-range clipboard, whole-table block, external HTML table paste        |
+| [docs-table-row-splitting.md](docs/docs-table-row-splitting.md)                  | Table row splitting — split tall table rows across pages, recursive nested table support          |
 
 ## Common
 

--- a/docs/design/docs/docs-pagination.md
+++ b/docs/design/docs/docs-pagination.md
@@ -395,6 +395,51 @@ Reuses the `horizontal-rule` non-editable pattern in `document.ts`:
 Block type attribute `'page-break'` stored in the Yorkie Tree node, following
 the existing pattern for `horizontal-rule` and `table`.
 
+## Table Row Splitting
+
+See [docs-table-row-splitting.md](docs-table-row-splitting.md) for the full
+design.
+
+### Motivation
+
+The original pagination treats table rows as atomic — a row is never split
+across pages. This causes two problems when a row is tall (e.g. contains a
+nested table, long text, or images):
+
+1. The row is pushed to the next page, leaving large blank space on the
+   previous page.
+2. If the row exceeds page height, its content is clipped.
+
+### Summary of Changes to Pagination
+
+- `paginateLayout()` gains row-splitting logic: when a table row does not fit
+  on the current page, the paginator walks each cell's content lines to find a
+  safe split height (between atomic units — text lines or images).
+- `PageLine` gains optional `rowSplitOffset` and `rowSplitHeight` fields. A
+  split row produces two or more `PageLine` entries (one per page fragment)
+  sharing the same `blockIndex + lineIndex`.
+- Nested tables are handled recursively — a nested table row can itself be
+  split, and its partial height feeds into the parent cell's split calculation.
+- rowSpan/colSpan merged cells that straddle a split are rendered on both pages,
+  with content clipped to each fragment's height.
+
+### Atomic Units
+
+| Unit | Splittable? |
+|------|-------------|
+| Text line | No |
+| Image block | No |
+| Table row | Yes — between text lines / blocks inside cells |
+| Nested-table row | Yes — recursively |
+
+### Rendering
+
+Each page fragment of a split row renders with:
+- Clipped cell content (translated by `rowSplitOffset`)
+- Full cell borders on both fragment top and bottom
+- Cell background fill for the visible area only
+- Recursive rendering for nested table fragments
+
 ## Risks and Mitigation
 
 | Risk | Mitigation |
@@ -403,3 +448,5 @@ the existing pattern for `horizontal-rule` and `table`.
 | Existing tests break from signature change | Update `computeLayout` call sites in tests to pass `contentWidth` |
 | Coordinate mapping bugs at page boundaries | Comprehensive tests for clicks on margins, gaps, and page edges |
 | Future header/footer integration | `LayoutPage` structure is extensible; header/footer regions can be added to page model |
+| Row splitting correctness with merges | Start with simple cases; add merge-specific tests |
+| Deep nesting performance | Cache split results per row; only recompute dirty rows |

--- a/docs/design/docs/docs-pagination.md
+++ b/docs/design/docs/docs-pagination.md
@@ -420,8 +420,9 @@ nested table, long text, or images):
   sharing the same `blockIndex + lineIndex`.
 - Nested tables are handled recursively — a nested table row can itself be
   split, and its partial height feeds into the parent cell's split calculation.
-- rowSpan/colSpan merged cells that straddle a split are rendered on both pages,
-  with content clipped to each fragment's height.
+- rowSpan/colSpan merged cells are not yet split-aware — they render correctly
+  only when the merge owner row is on the same page. Full merged-cell splitting
+  is a planned future enhancement.
 
 ### Atomic Units
 

--- a/docs/design/docs/docs-table-row-splitting.md
+++ b/docs/design/docs/docs-table-row-splitting.md
@@ -1,0 +1,182 @@
+---
+title: docs-table-row-splitting
+target-version: 0.4.0
+---
+
+# Table Row Splitting Across Pages
+
+## Summary
+
+Allow table rows to split across page boundaries so that tall rows
+(especially those containing nested tables or long text) render
+continuously instead of jumping to the next page and leaving blank
+space.
+
+## Goals
+
+- Split table rows at page boundaries when a row does not fit on the
+  current page.
+- Recurse into nested tables — rows inside a nested table follow the
+  same splitting rules.
+- Handle rowSpan/colSpan merged cells that straddle a page split.
+- Re-draw cell borders and backgrounds on each page fragment so that
+  every page looks visually complete.
+- Preserve cursor placement, arrow-key navigation, text selection, and
+  scroll-into-view across split rows.
+
+## Non-Goals
+
+- Splitting a single text line across pages (a text line is atomic).
+- Splitting an image block across pages (an image is atomic; if it
+  exceeds page height it gets its own page).
+- Rebalancing content between pages to minimise whitespace (standard
+  "keep-with-next" / "widow-orphan" logic is out of scope).
+
+## Atomic Units
+
+| Unit | Splittable? |
+|------|-------------|
+| Text line (one visual line of text) | No |
+| Image block | No |
+| Table row | Yes — between text lines / blocks inside cells |
+| Nested-table row | Yes — recursively |
+
+A split point is always *between* two atomic units inside a cell, never
+in the middle of one.
+
+## Proposal Details
+
+### 1. Layout / Pagination Layer
+
+File: `packages/docs/src/view/pagination.ts`
+
+#### 1.1 Split-point calculation
+
+When a table row does not fit in the remaining page space:
+
+1. Compute `availableHeight` = remaining space on the current page.
+2. For each cell in the row, walk its content lines (text lines,
+   image blocks, nested-table rows) and find the last line whose
+   cumulative height ≤ `availableHeight`.
+3. Take the **minimum** across all cells — that is the safe split
+   height where every cell can break without cutting an atomic unit.
+4. If the minimum is 0 (no line fits), push the entire row to the next
+   page (current behaviour).
+
+#### 1.2 Nested-table recursion
+
+When a cell line is a nested table row, apply the same split algorithm
+recursively. The nested table row may itself split, producing a partial
+height that feeds back into the parent cell's line-walk.
+
+#### 1.3 rowSpan handling
+
+A rowSpan cell spans multiple logical rows. When a page break falls
+inside the span:
+
+- The cell's content is split at the same `splitHeight` as the row that
+  triggers the break.
+- On the next page the cell continues rendering from the split point,
+  with its remaining rowSpan rows.
+
+#### 1.4 Data model extension — `PageLine`
+
+Add optional fields to `PageLine`:
+
+```ts
+interface PageLine {
+  // ... existing fields ...
+
+  /** For split table rows: vertical offset into the row where this
+      page fragment starts (0 for the first fragment). */
+  rowSplitOffset?: number;
+
+  /** For split table rows: height of this fragment on this page. */
+  rowSplitHeight?: number;
+}
+```
+
+The paginator emits two (or more) `PageLine` entries for the same
+`blockIndex + lineIndex` when a row is split — one per page, each with
+its own `rowSplitOffset` / `rowSplitHeight`.
+
+### 2. Rendering Layer
+
+Files: `packages/docs/src/view/doc-canvas.ts`,
+       `packages/docs/src/view/table-renderer.ts`
+
+#### 2.1 Clipped cell rendering
+
+When painting a split row fragment:
+
+1. Save canvas state, set a clip rect to the fragment's height.
+2. Translate the cell content up by `rowSplitOffset` so the correct
+   slice of content is visible.
+3. Render text lines / images / nested tables as normal — the clip rect
+   hides out-of-bounds content.
+4. Restore canvas state.
+
+#### 2.2 Border re-drawing
+
+For every page that contains a row fragment:
+
+- **Top of fragment**: draw the cell's top border (even if this is a
+  continuation from the previous page).
+- **Bottom of fragment**: draw the cell's bottom border (even if the
+  row continues on the next page).
+
+This gives each page a visually complete table appearance.
+
+#### 2.3 Background fill
+
+Fill the cell background colour for the visible fragment area only,
+before rendering cell content.
+
+#### 2.4 Nested-table fragments
+
+When a cell contains a nested table that is itself split, the cell
+renderer delegates to the table renderer recursively.  Each nested
+fragment follows the same clip + translate + border rules.
+
+### 3. Interaction Layer
+
+Files: `packages/docs/src/view/text-editor.ts`,
+       `packages/docs/src/view/pagination.ts` (pixel ↔ position)
+
+#### 3.1 Pixel → position (`paginatedPixelToPosition`)
+
+Extend to account for `rowSplitOffset`. When a click lands on a split
+row fragment, add the fragment's `rowSplitOffset` to the local Y before
+resolving to a text position inside the cell.
+
+#### 3.2 Position → pixel (`findPageForPosition` / `getPixelForPosition`)
+
+When the cursor is inside a split row, determine which page fragment
+contains the cursor's line, then compute the pixel Y relative to that
+page.
+
+#### 3.3 Arrow-key navigation
+
+`moveVertical` already handles page-boundary crossings.  Split rows
+add one new case: the cursor is at the last visible line of a fragment
+and presses Down — it should move to the first line of the next
+fragment (same row, next page) rather than to the next row.
+
+#### 3.4 Selection rendering
+
+`renderSelection` clips selection highlight rectangles to the current
+page's fragment bounds, the same way cell content is clipped.
+
+#### 3.5 Scroll into view
+
+When the cursor moves into a split row fragment on a different page,
+`scrollIntoView` targets that page's Y offset.
+
+## Risks and Mitigation
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Performance — split calculation for deeply nested tables | Slow layout on large docs | Cache split results per row; only recompute dirty rows |
+| Correctness — rowSpan cells with complex merges | Visual glitches at split boundaries | Start with simple cases; add merge-specific tests |
+| Complexity — recursive split + render + interaction | Large diff, hard to review | Implement in phases: pagination → rendering → interaction |
+| Regression — existing non-split table rendering | Broken tables | Existing tests must keep passing; split logic is additive |

--- a/docs/tasks/active/20260419-table-row-splitting-todo.md
+++ b/docs/tasks/active/20260419-table-row-splitting-todo.md
@@ -1,0 +1,940 @@
+# Table Row Splitting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split tall table rows across page boundaries so content renders continuously instead of leaving blank space or clipping.
+
+**Architecture:** Extend `paginateLayout()` to detect rows that exceed remaining page space and compute a split height based on cell content lines. Each split produces two `PageLine` entries (one per page) with `rowSplitOffset`/`rowSplitHeight` metadata. The renderer clips cell content to the fragment bounds and re-draws borders on each page. Coordinate mapping and navigation are updated to handle the split fragments.
+
+**Tech Stack:** TypeScript, Canvas 2D, Vitest
+
+**Spec:** `docs/design/docs/docs-table-row-splitting.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `packages/docs/src/view/pagination.ts` | Modify | Row split calculation, `PageLine` extension, split `PageLine` emission |
+| `packages/docs/src/view/table-layout.ts` | Modify | Export cell content line heights for split calculation |
+| `packages/docs/src/view/doc-canvas.ts` | Modify | Pass split metadata to table renderer, adjust `tableOriginY` |
+| `packages/docs/src/view/table-renderer.ts` | Modify | Clip cell content by split offset/height, re-draw borders |
+| `packages/docs/src/view/text-editor.ts` | Modify | Arrow navigation across split row fragments |
+| `packages/docs/test/view/pagination.test.ts` | Modify | Add row-splitting test cases |
+| `packages/docs/test/view/table-row-split.test.ts` | Create | Dedicated split rendering and interaction tests |
+
+---
+
+### Task 1: Extend `PageLine` with split metadata
+
+**Files:**
+- Modify: `packages/docs/src/view/pagination.ts:7-13`
+
+- [ ] **Step 1: Add `rowSplitOffset` and `rowSplitHeight` to `PageLine`**
+
+In `packages/docs/src/view/pagination.ts`, extend the `PageLine` interface:
+
+```typescript
+export interface PageLine {
+  blockIndex: number;
+  lineIndex: number;
+  line: LayoutLine;
+  x: number;
+  y: number;
+
+  /** For split table rows: vertical offset into the row where this
+      page fragment starts (0 for the first fragment). */
+  rowSplitOffset?: number;
+
+  /** For split table rows: height of this fragment on this page.
+      When undefined the full row height is used. */
+  rowSplitHeight?: number;
+}
+```
+
+- [ ] **Step 2: Verify existing tests still pass**
+
+Run: `cd packages/docs && pnpm vitest run test/view/pagination.test.ts`
+Expected: All existing tests pass (no behaviour change yet).
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/docs/src/view/pagination.ts
+git commit -m "Add rowSplitOffset/rowSplitHeight fields to PageLine"
+```
+
+---
+
+### Task 2: Export cell content line heights from table layout
+
+The paginator needs to know the cumulative content heights inside each
+cell so it can find a safe split point. Add a helper that returns line
+heights for a given row.
+
+**Files:**
+- Modify: `packages/docs/src/view/table-layout.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `packages/docs/test/view/table-row-split.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { computeTableLayout, getCellContentBreakpoints } from '../../src/view/table-layout.js';
+import type { TableData } from '../../src/model/types.js';
+import { createMockContext } from '../helpers.js';
+
+describe('getCellContentBreakpoints', () => {
+  it('returns cumulative line heights for a single-cell row', () => {
+    // Build a simple 1×1 table with 3 text lines
+    const tableData: TableData = {
+      columnWidths: [1],
+      rows: [{
+        cells: [{
+          blocks: [{ id: 'b1', type: 'paragraph', inlines: [
+            { text: 'Line 1' },
+            { text: 'Line 2' },
+            { text: 'Line 3' },
+          ], style: {} }],
+          colSpan: 1, rowSpan: 1,
+        }],
+      }],
+    };
+    const ctx = createMockContext();
+    const layout = computeTableLayout(tableData, 'tbl', ctx, 200);
+    const breakpoints = getCellContentBreakpoints(layout, 0);
+
+    // breakpoints should be an array of cumulative heights for each
+    // atomic unit (text line) across all cells in the row
+    expect(breakpoints.length).toBeGreaterThan(0);
+    // Each entry is the cumulative height at which a break is safe
+    for (let i = 1; i < breakpoints.length; i++) {
+      expect(breakpoints[i]).toBeGreaterThan(breakpoints[i - 1]);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm vitest run test/view/table-row-split.test.ts`
+Expected: FAIL — `getCellContentBreakpoints` not exported.
+
+- [ ] **Step 3: Implement `getCellContentBreakpoints`**
+
+In `packages/docs/src/view/table-layout.ts`, add after `computeTableLayout`:
+
+```typescript
+/**
+ * Return sorted array of safe vertical break positions within a table row.
+ * Each value is a cumulative height (relative to the row top) at which
+ * all cells in the row have an atomic-unit boundary (text line or image end).
+ * The paginator can split the row at any of these heights.
+ */
+export function getCellContentBreakpoints(
+  layout: LayoutTable,
+  rowIndex: number,
+): number[] {
+  const padding = DEFAULT_CELL_PADDING;
+  const cells = layout.cells[rowIndex];
+  if (!cells || cells.length === 0) return [];
+
+  // Collect per-cell breakpoint sets
+  const perCell: Set<number>[] = [];
+  for (let c = 0; c < cells.length; c++) {
+    const cell = cells[c];
+    if (cell.merged) continue; // skip covered cells
+    const breaks = new Set<number>();
+    let y = padding;
+    for (const line of cell.lines) {
+      y += line.height;
+      breaks.add(y);
+    }
+    perCell.push(breaks);
+  }
+
+  if (perCell.length === 0) return [];
+
+  // Intersect: only keep heights where ALL non-merged cells have a break
+  const first = perCell[0];
+  const common: number[] = [];
+  for (const h of first) {
+    if (perCell.every(s => s.has(h))) {
+      common.push(h);
+    }
+  }
+  common.sort((a, b) => a - b);
+  return common;
+}
+```
+
+Note: intersection is the strict version. If no common breakpoints exist
+(cells have different line heights), the row cannot be split and stays
+atomic. A later refinement can use "closest safe height per cell" instead
+of strict intersection.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm vitest run test/view/table-row-split.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/docs/src/view/table-layout.ts packages/docs/test/view/table-row-split.test.ts
+git commit -m "Add getCellContentBreakpoints for row split calculation"
+```
+
+---
+
+### Task 3: Split rows in `paginateLayout()`
+
+Replace the atomic row placement (lines 63–83) with logic that attempts
+to split a row when it doesn't fit.
+
+**Files:**
+- Modify: `packages/docs/src/view/pagination.ts:63-83`
+- Test: `packages/docs/test/view/table-row-split.test.ts`
+
+- [ ] **Step 1: Write failing test for row splitting**
+
+Add to `packages/docs/test/view/table-row-split.test.ts`:
+
+```typescript
+import { paginateLayout } from '../../src/view/pagination.js';
+import { computeLayout } from '../../src/view/layout.js';
+import type { Block } from '../../src/model/types.js';
+import { resolvePageSetup, getEffectiveDimensions } from '../../src/view/pagination.js';
+
+describe('paginateLayout — row splitting', () => {
+  it('splits a tall table row across two pages', () => {
+    // Create a table block with one row whose cell content is taller
+    // than the page content area
+    const tableBlock: Block = {
+      id: 'table1',
+      type: 'table',
+      inlines: [],
+      style: {},
+      tableData: {
+        columnWidths: [1],
+        rows: [{
+          cells: [{
+            blocks: Array.from({ length: 40 }, (_, i) => ({
+              id: `p${i}`,
+              type: 'paragraph' as const,
+              inlines: [{ text: `Line ${i}` }],
+              style: {},
+            })),
+            colSpan: 1,
+            rowSpan: 1,
+          }],
+        }],
+      },
+    };
+    const ctx = createMockContext();
+    const pageSetup = resolvePageSetup(undefined);
+    const dims = getEffectiveDimensions(pageSetup);
+    const contentWidth = dims.width - pageSetup.margins.left - pageSetup.margins.right;
+    const layout = computeLayout([tableBlock], ctx, contentWidth).layout;
+    const paginated = paginateLayout(layout, pageSetup);
+
+    // The table should span at least 2 pages
+    expect(paginated.pages.length).toBeGreaterThanOrEqual(2);
+
+    // First page should have a PageLine with rowSplitOffset = 0
+    const firstPageTableLines = paginated.pages[0].lines.filter(
+      l => l.rowSplitHeight !== undefined
+    );
+    expect(firstPageTableLines.length).toBe(1);
+    expect(firstPageTableLines[0].rowSplitOffset).toBe(0);
+
+    // Second page should have a PageLine with rowSplitOffset > 0
+    const secondPageTableLines = paginated.pages[1].lines.filter(
+      l => l.rowSplitOffset !== undefined
+    );
+    expect(secondPageTableLines.length).toBe(1);
+    expect(secondPageTableLines[0].rowSplitOffset).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm vitest run test/view/table-row-split.test.ts`
+Expected: FAIL — row is not split, only 1 page or row pushed to page 2 whole.
+
+- [ ] **Step 3: Implement row splitting in `paginateLayout()`**
+
+In `packages/docs/src/view/pagination.ts`, replace the table row loop
+(lines 63–83) with split-aware logic:
+
+```typescript
+// Inside paginateLayout(), replace the table row handling section:
+import { getCellContentBreakpoints } from './table-layout.js';
+
+// ... inside the table block branch (lb.layoutTable exists):
+const tl = lb.layoutTable!;
+for (let ri = 0; ri < tl.rowHeights.length; ri++) {
+  const rowHeight = tl.rowHeights[ri];
+
+  // Row fits on current page — no split needed
+  if (currentY + rowHeight <= contentHeight || isPageTop) {
+    currentPage.lines.push({
+      blockIndex: bi,
+      lineIndex: ri,
+      line: { runs: [], y: tl.rowYOffsets[ri], height: rowHeight, width: availableWidth },
+      x: margins.left,
+      y: margins.top + currentY,
+    });
+    currentY += rowHeight;
+    isPageTop = false;
+    continue;
+  }
+
+  // Row doesn't fit — try to split
+  const availableForRow = contentHeight - currentY;
+  const breakpoints = getCellContentBreakpoints(tl, ri);
+
+  // Find the largest breakpoint that fits in available space
+  let splitHeight = 0;
+  for (const bp of breakpoints) {
+    if (bp <= availableForRow) {
+      splitHeight = bp;
+    } else {
+      break;
+    }
+  }
+
+  if (splitHeight <= 0) {
+    // No safe split point fits — push entire row to next page
+    startNewPage();
+    currentPage.lines.push({
+      blockIndex: bi,
+      lineIndex: ri,
+      line: { runs: [], y: tl.rowYOffsets[ri], height: rowHeight, width: availableWidth },
+      x: margins.left,
+      y: margins.top + currentY,
+    });
+    currentY += rowHeight;
+    isPageTop = false;
+    continue;
+  }
+
+  // Emit first fragment on current page
+  currentPage.lines.push({
+    blockIndex: bi,
+    lineIndex: ri,
+    line: { runs: [], y: tl.rowYOffsets[ri], height: rowHeight, width: availableWidth },
+    x: margins.left,
+    y: margins.top + currentY,
+    rowSplitOffset: 0,
+    rowSplitHeight: splitHeight,
+  });
+
+  // Continue emitting fragments on subsequent pages
+  let consumed = splitHeight;
+  while (consumed < rowHeight) {
+    startNewPage();
+    const remaining = rowHeight - consumed;
+    const pageAvailable = contentHeight;
+
+    // Find next split point within this page
+    let fragmentHeight = remaining; // default: rest fits on this page
+    if (remaining > pageAvailable) {
+      // Need another split
+      fragmentHeight = 0;
+      for (const bp of breakpoints) {
+        if (bp > consumed && bp - consumed <= pageAvailable) {
+          fragmentHeight = bp - consumed;
+        }
+      }
+      if (fragmentHeight <= 0) {
+        // No split point fits — give entire page to this fragment
+        fragmentHeight = Math.min(remaining, pageAvailable);
+      }
+    }
+
+    currentPage.lines.push({
+      blockIndex: bi,
+      lineIndex: ri,
+      line: { runs: [], y: tl.rowYOffsets[ri], height: rowHeight, width: availableWidth },
+      x: margins.left,
+      y: margins.top + currentY,
+      rowSplitOffset: consumed,
+      rowSplitHeight: fragmentHeight,
+    });
+    consumed += fragmentHeight;
+    currentY += fragmentHeight;
+    isPageTop = false;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/docs && pnpm vitest run test/view/table-row-split.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run all existing pagination tests**
+
+Run: `cd packages/docs && pnpm vitest run test/view/pagination.test.ts`
+Expected: All existing tests PASS (non-split rows unchanged).
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/docs/src/view/pagination.ts packages/docs/test/view/table-row-split.test.ts
+git commit -m "Split tall table rows across pages in paginateLayout"
+```
+
+---
+
+### Task 4: Render split row fragments
+
+Update the table rendering pipeline to clip cell content and re-draw
+borders for each page fragment.
+
+**Files:**
+- Modify: `packages/docs/src/view/doc-canvas.ts:83-115` (collectTableRenderRanges)
+- Modify: `packages/docs/src/view/table-renderer.ts:165-480` (renderTableContent)
+- Test: `packages/docs/test/view/table-row-split.test.ts`
+
+- [ ] **Step 1: Update `collectTableRenderRanges` to carry split metadata**
+
+In `packages/docs/src/view/doc-canvas.ts`, extend `TableRenderRange`:
+
+```typescript
+interface TableRenderRange {
+  layoutBlock: LayoutBlock;
+  tableX: number;
+  tableOriginY: number;
+  pageStartRow: number;
+  renderStartRow: number;
+  endRowIndex: number;
+  /** When the row is split, the vertical offset into the row. */
+  rowSplitOffset?: number;
+  /** When the row is split, the height of this fragment. */
+  rowSplitHeight?: number;
+}
+```
+
+In `collectTableRenderRanges()`, pass through split fields from `PageLine`:
+
+```typescript
+// After computing range, add:
+range.rowSplitOffset = pl.rowSplitOffset;
+range.rowSplitHeight = pl.rowSplitHeight;
+```
+
+And adjust `tableOriginY` for split fragments:
+
+```typescript
+// When rowSplitOffset is set, the origin needs adjustment
+const rowY = lb.layoutTable!.rowYOffsets[pl.lineIndex];
+const splitOffset = pl.rowSplitOffset ?? 0;
+range.tableOriginY = pageY + pl.y - rowY - splitOffset;
+// This way (tableOriginY + rowY + splitOffset) == (pageY + pl.y)
+// i.e. the visible content starts at pl.y on the page
+```
+
+- [ ] **Step 2: Update `renderTableContent` to clip split fragments**
+
+In `packages/docs/src/view/table-renderer.ts`, `renderTableContent()`:
+
+Add parameters for split info and apply clipping:
+
+```typescript
+export function renderTableContent(
+  ctx: CanvasRenderingContext2D,
+  tableData: TableData,
+  layout: LayoutTable,
+  tableX: number,
+  tableY: number,
+  startRow: number,
+  endRow: number,
+  pageStartRow: number,
+  // ... existing params ...
+  rowSplitOffset?: number,
+  rowSplitHeight?: number,
+): void {
+  // When rendering a split fragment, clip to the fragment bounds
+  const isSplit = rowSplitOffset !== undefined && rowSplitHeight !== undefined;
+  if (isSplit) {
+    const splitRow = startRow; // the row being split
+    const clipY = tableY + layout.rowYOffsets[splitRow] + rowSplitOffset;
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(tableX, clipY, layout.totalWidth, rowSplitHeight);
+    ctx.clip();
+  }
+
+  // ... existing rendering logic unchanged ...
+
+  if (isSplit) {
+    ctx.restore();
+  }
+}
+```
+
+- [ ] **Step 3: Re-draw borders on fragment boundaries**
+
+After the clip-restore in `renderTableContent`, draw fragment borders:
+
+```typescript
+if (isSplit) {
+  ctx.restore();
+
+  // Draw top border of fragment
+  const splitRow = startRow;
+  const fragTop = tableY + layout.rowYOffsets[splitRow] + rowSplitOffset;
+  const fragBottom = fragTop + rowSplitHeight;
+
+  ctx.strokeStyle = '#000';
+  ctx.lineWidth = 1;
+
+  // Top border
+  ctx.beginPath();
+  ctx.moveTo(tableX, fragTop);
+  ctx.lineTo(tableX + layout.totalWidth, fragTop);
+  ctx.stroke();
+
+  // Bottom border
+  ctx.beginPath();
+  ctx.moveTo(tableX, fragBottom);
+  ctx.lineTo(tableX + layout.totalWidth, fragBottom);
+  ctx.stroke();
+
+  // Vertical cell borders within fragment
+  for (const xOff of layout.columnXOffsets) {
+    ctx.beginPath();
+    ctx.moveTo(tableX + xOff, fragTop);
+    ctx.lineTo(tableX + xOff, fragBottom);
+    ctx.stroke();
+  }
+  // Right edge
+  ctx.beginPath();
+  ctx.moveTo(tableX + layout.totalWidth, fragTop);
+  ctx.lineTo(tableX + layout.totalWidth, fragBottom);
+  ctx.stroke();
+}
+```
+
+- [ ] **Step 4: Update `renderTableBackgrounds` similarly**
+
+Apply the same clip logic for cell backgrounds in split fragments.
+
+- [ ] **Step 5: Wire split metadata through `DocCanvas.render()`**
+
+In `doc-canvas.ts`, pass `rowSplitOffset`/`rowSplitHeight` from
+`TableRenderRange` to `renderTableContent()` and `renderTableBackgrounds()`.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cd packages/docs && pnpm vitest run`
+Expected: All tests pass.
+
+- [ ] **Step 7: Manual browser test**
+
+Open the shared document, scroll to the "프로젝트 개요" area. Verify:
+- The tall row is split across pages
+- Cell borders appear on both pages
+- Cell content is clipped correctly (no bleed)
+- No blank space on the previous page
+
+- [ ] **Step 8: Commit**
+
+```
+git add packages/docs/src/view/doc-canvas.ts packages/docs/src/view/table-renderer.ts
+git commit -m "Render split table row fragments with clipping and borders"
+```
+
+---
+
+### Task 5: Update coordinate mapping for split rows
+
+`paginatedPixelToPosition` and `findPageForPosition` must handle split
+row fragments so that clicks and cursor placement work correctly.
+
+**Files:**
+- Modify: `packages/docs/src/view/pagination.ts` (paginatedPixelToPosition, findPageForPosition)
+
+- [ ] **Step 1: Update `paginatedPixelToPosition`**
+
+When a click lands on a split row fragment, the local Y within the cell
+must account for `rowSplitOffset`. In `paginatedPixelToPosition()`:
+
+```typescript
+// After finding the target PageLine (targetPL), check for split:
+if (targetPL.rowSplitOffset !== undefined) {
+  // Adjust localY to account for the split offset
+  // The cell content visible on this page starts at rowSplitOffset
+  // So the effective Y within the cell = localY relative to fragment top + rowSplitOffset
+}
+```
+
+The existing logic resolves to a blockIndex + lineIndex. For split rows,
+the lineIndex is the same row — the difference is which portion of the
+cell content is visible. The character offset calculation happens inside
+the cell content lines, which are addressed by the table renderer.
+
+For now, clicks on split rows can resolve to the row's block position.
+Precise within-cell click resolution is handled by the table cell click
+path in `text-editor.ts`.
+
+- [ ] **Step 2: Update `findPageForPosition`**
+
+When a cursor is inside a split row, `findPageForPosition` must return
+the correct page fragment. Currently it matches `blockIndex + lineIndex`:
+
+```typescript
+for (const page of paginatedLayout.pages) {
+  for (const pl of page.lines) {
+    if (pl.blockIndex === blockIndex && pl.lineIndex === targetLineIndex) {
+      return { pageIndex: page.pageIndex, pageLine: pl };
+    }
+  }
+}
+```
+
+With split rows, multiple PageLines share the same blockIndex + lineIndex.
+We need to check which fragment contains the cursor's Y position:
+
+```typescript
+// For table blocks with split rows, check if the cursor's cell-local Y
+// falls within this fragment's [rowSplitOffset, rowSplitOffset + rowSplitHeight)
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd packages/docs && pnpm vitest run`
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```
+git add packages/docs/src/view/pagination.ts
+git commit -m "Update coordinate mapping for split table row fragments"
+```
+
+---
+
+### Task 6: Arrow navigation across split row boundaries
+
+Update `moveVertical` in `text-editor.ts` so that Arrow Up/Down
+crosses split row fragment boundaries correctly.
+
+**Files:**
+- Modify: `packages/docs/src/view/text-editor.ts` (moveVertical)
+
+- [ ] **Step 1: Handle split row in moveVertical page boundary logic**
+
+The existing cross-page logic in `moveVertical` (line ~3195) already
+handles page boundary jumps. Split rows add one case: the cursor is at
+the last visible line of a fragment and presses Down — it should move to
+the first visible line of the next fragment (same row, next page).
+
+This is naturally handled by `paginatedPixelToPosition` if the coordinate
+mapping is correct (Task 5). The target Y calculation lands on the next
+page's fragment, and the position resolver returns the correct offset.
+
+Verify this works by testing in the browser. If additional logic is
+needed, add a check in `moveVertical`:
+
+```typescript
+// After computing crossPageResult, if it lands on the same row
+// with a different rowSplitOffset, accept it as a valid move.
+```
+
+- [ ] **Step 2: Browser test**
+
+Place cursor at the last line of a split row fragment. Press Arrow Down.
+Verify cursor moves to the first line of the next fragment (next page).
+Press Arrow Up from there — verify it returns to the previous fragment.
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/docs/src/view/text-editor.ts
+git commit -m "Handle arrow navigation across split row fragments"
+```
+
+---
+
+### Task 7: Recursive nested table splitting
+
+Extend `getCellContentBreakpoints` to recurse into nested tables,
+and verify the full pipeline handles nested table row splitting.
+
+**Files:**
+- Modify: `packages/docs/src/view/table-layout.ts` (getCellContentBreakpoints)
+- Test: `packages/docs/test/view/table-row-split.test.ts`
+
+- [ ] **Step 1: Write failing test for nested table splitting**
+
+```typescript
+describe('nested table row splitting', () => {
+  it('splits a row containing a nested table across pages', () => {
+    // Create a table with one row containing a nested table
+    // The nested table has many rows that exceed page height
+    const nestedTable: Block = {
+      id: 'nested',
+      type: 'table',
+      inlines: [],
+      style: {},
+      tableData: {
+        columnWidths: [1],
+        rows: Array.from({ length: 30 }, (_, i) => ({
+          cells: [{
+            blocks: [{ id: `np${i}`, type: 'paragraph' as const, inlines: [{ text: `Nested ${i}` }], style: {} }],
+            colSpan: 1, rowSpan: 1,
+          }],
+        })),
+      },
+    };
+
+    const outerTable: Block = {
+      id: 'outer',
+      type: 'table',
+      inlines: [],
+      style: {},
+      tableData: {
+        columnWidths: [1],
+        rows: [{
+          cells: [{
+            blocks: [nestedTable],
+            colSpan: 1, rowSpan: 1,
+          }],
+        }],
+      },
+    };
+
+    const ctx = createMockContext();
+    const pageSetup = resolvePageSetup(undefined);
+    const dims = getEffectiveDimensions(pageSetup);
+    const contentWidth = dims.width - pageSetup.margins.left - pageSetup.margins.right;
+    const layout = computeLayout([outerTable], ctx, contentWidth).layout;
+    const paginated = paginateLayout(layout, pageSetup);
+
+    // Should span multiple pages
+    expect(paginated.pages.length).toBeGreaterThanOrEqual(2);
+    // Each page should have content (no empty pages)
+    for (const page of paginated.pages) {
+      expect(page.lines.length).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/docs && pnpm vitest run test/view/table-row-split.test.ts`
+Expected: FAIL — nested table row not split (breakpoints don't recurse).
+
+- [ ] **Step 3: Update `getCellContentBreakpoints` for recursion**
+
+When a cell line has `nestedTable`, recurse into the nested table's
+rows to produce breakpoints:
+
+```typescript
+export function getCellContentBreakpoints(
+  layout: LayoutTable,
+  rowIndex: number,
+): number[] {
+  const padding = DEFAULT_CELL_PADDING;
+  const cells = layout.cells[rowIndex];
+  if (!cells || cells.length === 0) return [];
+
+  const perCell: number[][] = [];
+  for (let c = 0; c < cells.length; c++) {
+    const cell = cells[c];
+    if (cell.merged) continue;
+    const breaks: number[] = [];
+    let y = padding;
+    for (const line of cell.lines) {
+      if (line.nestedTable) {
+        // Recurse: each nested row boundary is a breakpoint
+        const nt = line.nestedTable;
+        for (let nr = 0; nr < nt.rowHeights.length; nr++) {
+          // Recursively get breakpoints within the nested row
+          const nestedBPs = getCellContentBreakpoints(nt, nr);
+          for (const nbp of nestedBPs) {
+            breaks.push(y + nt.rowYOffsets[nr] + nbp);
+          }
+          // The end of each nested row is also a breakpoint
+          y_end = y + nt.rowYOffsets[nr] + nt.rowHeights[nr];
+          breaks.push(y_end);
+        }
+        y += line.height;
+      } else {
+        y += line.height;
+        breaks.push(y);
+      }
+    }
+    perCell.push(breaks);
+  }
+
+  if (perCell.length === 0) return [];
+
+  // Use union of all breakpoints (not strict intersection) for flexibility
+  // then filter to heights where splitting is safe for all cells
+  const allBreaks = new Set<number>();
+  for (const cellBreaks of perCell) {
+    for (const b of cellBreaks) allBreaks.add(b);
+  }
+  const sorted = [...allBreaks].sort((a, b) => a - b);
+
+  // For each candidate, verify it doesn't cut an atomic unit in any cell
+  return sorted.filter(h => {
+    return perCell.every(cellBreaks => {
+      // h must be at or between breakpoints of this cell
+      return cellBreaks.some(cb => cb >= h) || h >= cellBreaks[cellBreaks.length - 1];
+    });
+  });
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd packages/docs && pnpm vitest run test/view/table-row-split.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `pnpm verify:fast`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/docs/src/view/table-layout.ts packages/docs/test/view/table-row-split.test.ts
+git commit -m "Recurse into nested tables for row split breakpoints"
+```
+
+---
+
+### Task 8: rowSpan cell splitting
+
+Handle merged cells (rowSpan > 1) that straddle a page split.
+
+**Files:**
+- Modify: `packages/docs/src/view/pagination.ts`
+- Modify: `packages/docs/src/view/table-renderer.ts`
+- Test: `packages/docs/test/view/table-row-split.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+describe('rowSpan cell splitting', () => {
+  it('splits a row with rowSpan cells across pages', () => {
+    // Create a 2-column table where column 1 has rowSpan=2
+    // and enough content to exceed page height
+    const tableBlock: Block = {
+      id: 'merged-table',
+      type: 'table',
+      inlines: [],
+      style: {},
+      tableData: {
+        columnWidths: [0.5, 0.5],
+        rows: [
+          {
+            cells: [
+              {
+                blocks: Array.from({ length: 40 }, (_, i) => ({
+                  id: `m${i}`, type: 'paragraph' as const,
+                  inlines: [{ text: `Merged line ${i}` }], style: {},
+                })),
+                colSpan: 1, rowSpan: 2,
+              },
+              {
+                blocks: [{ id: 'r0c1', type: 'paragraph' as const, inlines: [{ text: 'Row 0 Col 1' }], style: {} }],
+                colSpan: 1, rowSpan: 1,
+              },
+            ],
+          },
+          {
+            cells: [
+              { blocks: [], colSpan: 0, rowSpan: 0 }, // covered by merge
+              {
+                blocks: [{ id: 'r1c1', type: 'paragraph' as const, inlines: [{ text: 'Row 1 Col 1' }], style: {} }],
+                colSpan: 1, rowSpan: 1,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const ctx = createMockContext();
+    const pageSetup = resolvePageSetup(undefined);
+    const dims = getEffectiveDimensions(pageSetup);
+    const contentWidth = dims.width - pageSetup.margins.left - pageSetup.margins.right;
+    const layout = computeLayout([tableBlock], ctx, contentWidth).layout;
+    const paginated = paginateLayout(layout, pageSetup);
+
+    expect(paginated.pages.length).toBeGreaterThanOrEqual(2);
+  });
+});
+```
+
+- [ ] **Step 2: Implement rowSpan-aware breakpoint calculation**
+
+In `getCellContentBreakpoints`, when computing breakpoints for a row,
+include rowSpan cells that START in earlier rows but extend through this
+row. Their content is distributed via `computeMergedCellLineLayouts`
+and must be accounted for in the breakpoint calculation.
+
+- [ ] **Step 3: Update renderer for merged cell fragments**
+
+The existing `computeMergedCellLineLayouts()` in `table-renderer.ts`
+already handles distributing merged cell content across rows. For split
+rows, the renderer uses the same logic — the clip rect ensures only
+the visible portion of the merged cell is shown on each page.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd packages/docs && pnpm vitest run test/view/table-row-split.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/docs/src/view/pagination.ts packages/docs/src/view/table-layout.ts packages/docs/src/view/table-renderer.ts packages/docs/test/view/table-row-split.test.ts
+git commit -m "Handle rowSpan cells in table row splitting"
+```
+
+---
+
+### Task 9: End-to-end browser verification and cleanup
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: `pnpm verify:fast`**
+
+Run: `pnpm verify:fast`
+Expected: All pass.
+
+- [ ] **Step 2: Browser test — shared document**
+
+Open `http://localhost:5173/shared/50832333-3bc2-4eff-abd1-adb45fcc582c`
+and verify:
+- "프로젝트 소개" → "프로젝트 개요" transition: row splits across pages,
+  no large blank space, content not clipped
+- "별첨1-4" area: tall nested tables split correctly
+- Arrow Up/Down across split boundaries works
+- Click in split row places cursor correctly
+- Selection across split boundary renders on both pages
+
+- [ ] **Step 3: Remove any debug logging**
+
+Search for and remove any `console.log` statements added during
+development.
+
+- [ ] **Step 4: Final commit**
+
+```
+git add -A
+git commit -m "Table row splitting: end-to-end verification and cleanup"
+```

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -28,6 +28,8 @@ interface TableRenderRange {
   pageStartRow: number;
   renderStartRow: number;
   endRowIndex: number;
+  rowSplitOffset?: number;
+  rowSplitHeight?: number;
 }
 
 /**
@@ -94,14 +96,16 @@ function collectTableRenderRanges(
     // range computation sweeps forward from there, so subsequent rows
     // of the same block are handled by the sweep.
     if (plIndex > 0 && page.lines[plIndex - 1]?.blockIndex === pl.blockIndex) {
-      continue;
+      // Allow split fragments through — each needs its own render range
+      if (pl.rowSplitOffset === undefined) continue;
     }
     const lb = layout.blocks[pl.blockIndex];
     if (!lb || lb.block.type !== 'table' || !lb.layoutTable || !lb.block.tableData) {
       continue;
     }
     const range = computeTableRangeForPageLine(page, lb, pl, plIndex);
-    const tableOriginY = pageY + pl.y - lb.layoutTable.rowYOffsets[pl.lineIndex];
+    const splitOffset = pl.rowSplitOffset ?? 0;
+    const tableOriginY = pageY + pl.y - lb.layoutTable.rowYOffsets[pl.lineIndex] - splitOffset;
     ranges.push({
       layoutBlock: lb,
       tableX: pageX + margins.left,
@@ -109,6 +113,8 @@ function collectTableRenderRanges(
       pageStartRow: range.pageStartRow,
       renderStartRow: range.renderStartRow,
       endRowIndex: range.endRowIndex,
+      rowSplitOffset: pl.rowSplitOffset,
+      rowSplitHeight: pl.rowSplitHeight,
     });
   }
   return ranges;
@@ -374,6 +380,8 @@ export class DocCanvas {
             tr.renderStartRow,
             tr.endRowIndex,
             tr.pageStartRow,
+            tr.rowSplitOffset,
+            tr.rowSplitHeight,
           );
         }
       }
@@ -462,13 +470,12 @@ export class DocCanvas {
           const lb = layout.blocks[pl.blockIndex];
           if (lb && lb.block.type === 'table' && lb.layoutTable && lb.block.tableData) {
             // Only render on the first row PageLine of this table block,
-            // so we touch each table once per page. The row range was
-            // already computed in the background pre-pass — recompute it
-            // here instead of threading the data through so both passes
-            // keep their logic self-contained and readable.
-            if (plIndex === 0 || page.lines[plIndex - 1]?.blockIndex !== pl.blockIndex) {
+            // so we touch each table once per page. Split fragments (with
+            // rowSplitOffset) must not be deduped — each gets its own pass.
+            if (plIndex === 0 || page.lines[plIndex - 1]?.blockIndex !== pl.blockIndex || pl.rowSplitOffset !== undefined) {
               const range = computeTableRangeForPageLine(page, lb, pl, plIndex);
-              const tableOriginY = pageY + pl.y - lb.layoutTable.rowYOffsets[pl.lineIndex];
+              const splitOffset = pl.rowSplitOffset ?? 0;
+              const tableOriginY = pageY + pl.y - lb.layoutTable.rowYOffsets[pl.lineIndex] - splitOffset;
               renderTableContent(
                 this.ctx,
                 lb.block.tableData,
@@ -482,6 +489,8 @@ export class DocCanvas {
                 dragImageRun,
                 selectionRects,
                 focused,
+                pl.rowSplitOffset,
+                pl.rowSplitHeight,
               );
             }
             continue;

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -56,6 +56,8 @@ function computeTableRangeForPageLine(
   for (let k = plIndex + 1; k < page.lines.length; k++) {
     const nextPl = page.lines[k];
     if (nextPl.blockIndex === pl.blockIndex) {
+      // Stop before split fragments — they get their own render pass
+      if (nextPl.rowSplitOffset !== undefined) break;
       endRowIndex = nextPl.lineIndex + 1;
     } else {
       break;

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -53,14 +53,19 @@ function computeTableRangeForPageLine(
 ): { pageStartRow: number; renderStartRow: number; endRowIndex: number } {
   const pageStartRow = pl.lineIndex;
   let endRowIndex = pageStartRow + 1;
-  for (let k = plIndex + 1; k < page.lines.length; k++) {
-    const nextPl = page.lines[k];
-    if (nextPl.blockIndex === pl.blockIndex) {
-      // Stop before split fragments — they get their own render pass
-      if (nextPl.rowSplitOffset !== undefined) break;
-      endRowIndex = nextPl.lineIndex + 1;
-    } else {
-      break;
+  // Split fragments render only their own row — don't extend to
+  // subsequent rows, which would incorrectly include them in the
+  // clipped split pass.
+  if (pl.rowSplitOffset === undefined) {
+    for (let k = plIndex + 1; k < page.lines.length; k++) {
+      const nextPl = page.lines[k];
+      if (nextPl.blockIndex === pl.blockIndex) {
+        // Stop before split fragments — they get their own render pass
+        if (nextPl.rowSplitOffset !== undefined) break;
+        endRowIndex = nextPl.lineIndex + 1;
+      } else {
+        break;
+      }
     }
   }
   let renderStartRow = pageStartRow;

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1612,7 +1612,10 @@ export function initialize(
     },
     getPeerCursorPixels: () => lastPeerPixels,
     getBlockType() {
-      const block = doc.getBlock(cursor.position.blockId);
+      const block = doc.findBlock(cursor.position.blockId);
+      if (!block) {
+        return { type: 'paragraph' as BlockType };
+      }
       return {
         type: block.type,
         headingLevel: block.headingLevel,

--- a/packages/docs/src/view/image-selection-overlay.ts
+++ b/packages/docs/src/view/image-selection-overlay.ts
@@ -247,7 +247,7 @@ export function collectImageRects(
       if (!lb) continue;
 
       if (lb.block.type === 'table') {
-        collectTableCellImageRects(lb, pl, pageY, pageX, map);
+        collectTableCellImageRects(lb, pl, pageY, pageX, map, pl.rowSplitOffset, pl.rowSplitHeight);
         continue;
       }
 
@@ -300,6 +300,8 @@ function collectTableCellImageRects(
   pageY: number,
   pageX: number,
   out: Map<string, ImageRect>,
+  rowSplitOffset?: number,
+  rowSplitHeight?: number,
 ): void {
   const tableData = lb.block.tableData;
   const layoutTable = lb.layoutTable;
@@ -310,11 +312,9 @@ function collectTableCellImageRects(
   const dataRow = tableData.rows[r];
   if (!dataRow) return;
 
-  // Note: `pl.x` for a table row is `margins.left` (see pagination.ts
-  // where table row PageLines are constructed), matching the body
-  // path. We use `pl.x` directly here so the two code paths stay
-  // symmetric and the test fixtures don't need table-specific
-  // pl.x / pl.y values.
+  const splitOffset = rowSplitOffset ?? 0;
+  const isSplit = rowSplitOffset !== undefined && rowSplitHeight !== undefined;
+
   for (let c = 0; c < rowCells.length; c++) {
     const layoutCell = rowCells[c];
     if (layoutCell.merged) continue;
@@ -329,7 +329,8 @@ function collectTableCellImageRects(
 
     const padding = cell.style?.padding ?? 4;
     const cellX = pageX + pl.x + layoutTable.columnXOffsets[c];
-    const cellY = pageY + pl.y;
+    // For split fragments, shift up by splitOffset to match rendering
+    const cellY = pageY + pl.y - splitOffset;
 
     // Walk the cell's lines, tracking which block each line belongs
     // to (cells can hold multiple paragraphs / list-items) and the
@@ -369,6 +370,17 @@ function collectTableCellImageRects(
           const drawHeight = run.imageHeight ?? line.height;
           const x = cellX + padding + run.x;
           const y = cellY + padding + line.y + line.height - drawHeight;
+
+          // For split fragments, skip images outside the visible range
+          if (isSplit) {
+            const imgTop = padding + line.y + line.height - drawHeight;
+            const imgBottom = imgTop + drawHeight;
+            if (imgBottom <= splitOffset || imgTop >= splitOffset + rowSplitHeight!) {
+              offsetInBlock += run.charEnd - run.charStart;
+              continue;
+            }
+          }
+
           const key = `${innerBlock.id}:${offsetInBlock}`;
           out.set(key, { x, y, width: run.width, height: drawHeight });
         }

--- a/packages/docs/src/view/pagination.ts
+++ b/packages/docs/src/view/pagination.ts
@@ -271,15 +271,26 @@ export function findPageForPosition(
     targetLineIndex = li;
   }
 
+  // For non-table blocks, return the first matching PageLine.
+  // For table rows that split across pages, multiple PageLines share the same
+  // blockIndex + lineIndex; return the last fragment so the cursor lands on the
+  // most-recently-visible portion of the row (continuation pages).
+  const isTableBlock = lb.block.type === 'table';
+  let result: { pageIndex: number; pageLine: PageLine } | undefined;
+
   for (const page of paginatedLayout.pages) {
     for (const pl of page.lines) {
       if (pl.blockIndex === blockIndex && pl.lineIndex === targetLineIndex) {
-        return { pageIndex: page.pageIndex, pageLine: pl };
+        if (!isTableBlock) {
+          return { pageIndex: page.pageIndex, pageLine: pl };
+        }
+        // For table blocks, keep scanning to find the last fragment.
+        result = { pageIndex: page.pageIndex, pageLine: pl };
       }
     }
   }
 
-  return undefined;
+  return result;
 }
 
 /**

--- a/packages/docs/src/view/pagination.ts
+++ b/packages/docs/src/view/pagination.ts
@@ -10,6 +10,14 @@ export interface PageLine {
   line: LayoutLine;
   x: number;
   y: number;
+
+  /** For split table rows: vertical offset into the row where this
+      page fragment starts (0 for the first fragment). */
+  rowSplitOffset?: number;
+
+  /** For split table rows: height of this fragment on this page.
+      When undefined the full row height is used. */
+  rowSplitHeight?: number;
 }
 
 export interface LayoutPage {

--- a/packages/docs/src/view/pagination.ts
+++ b/packages/docs/src/view/pagination.ts
@@ -2,7 +2,7 @@ import type { PageSetup } from '../model/types.js';
 import { getEffectiveDimensions } from '../model/types.js';
 import type { EditContext } from '../model/document.js';
 import type { DocumentLayout, LayoutLine, LayoutRun } from './layout.js';
-import { getCellContentBreakpoints } from './table-layout.js';
+import { findRowSplitHeight } from './table-layout.js';
 import { Theme } from './theme.js';
 
 export interface PageLine {
@@ -75,40 +75,8 @@ export function paginateLayout(
         const rowHeight = tl.rowHeights[ri];
         const rowLine = { runs: [] as LayoutRun[], y: tl.rowYOffsets[ri], height: rowHeight, width: availableWidth };
 
-        // Row fits on current page — no split needed
-        if (currentY + rowHeight <= contentHeight || isPageTop) {
-          // If row exceeds page even when at page top, try to split it
-          if (isPageTop && currentY + rowHeight > contentHeight) {
-            const breakpoints = getCellContentBreakpoints(tl, ri);
-            if (breakpoints.length > 0) {
-              let consumed = 0;
-              while (consumed < rowHeight) {
-                if (consumed > 0) startNewPage();
-                const remaining = rowHeight - consumed;
-                const pageAvail = contentHeight - currentY;
-                let fragHeight = remaining;
-                if (remaining > pageAvail) {
-                  fragHeight = 0;
-                  for (const bp of breakpoints) {
-                    if (bp > consumed && bp - consumed <= pageAvail) {
-                      fragHeight = bp - consumed;
-                    }
-                  }
-                  if (fragHeight <= 0) fragHeight = Math.min(remaining, pageAvail);
-                }
-                currentLines.push({
-                  blockIndex: bi, lineIndex: ri, line: rowLine,
-                  x: margins.left, y: margins.top + currentY,
-                  rowSplitOffset: consumed, rowSplitHeight: fragHeight,
-                });
-                consumed += fragHeight;
-                currentY += fragHeight;
-                isPageTop = false;
-              }
-              continue;
-            }
-          }
-          // No split needed or not possible — place whole row
+        // Row fits on current page — place whole row
+        if (currentY + rowHeight <= contentHeight) {
           currentLines.push({
             blockIndex: bi, lineIndex: ri, line: rowLine,
             x: margins.left, y: margins.top + currentY,
@@ -120,55 +88,34 @@ export function paginateLayout(
 
         // Row doesn't fit — try to split
         const availableForRow = contentHeight - currentY;
-        const breakpoints = getCellContentBreakpoints(tl, ri);
+        const splitHeight = availableForRow > 0
+          ? findRowSplitHeight(tl, ri, availableForRow)
+          : 0;
 
-        let splitHeight = 0;
-        for (const bp of breakpoints) {
-          if (bp <= availableForRow) splitHeight = bp;
-          else break;
-        }
-
-        if (splitHeight <= 0) {
-          // No safe split point — push entire row to next page
+        if (splitHeight <= 0 && !isPageTop) {
+          // No safe split point on this page — push to next page
           startNewPage();
-          currentLines.push({
-            blockIndex: bi, lineIndex: ri, line: rowLine,
-            x: margins.left, y: margins.top + currentY,
-          });
-          currentY += rowHeight;
-          isPageTop = false;
-          continue;
         }
 
-        // Emit first fragment
-        currentLines.push({
-          blockIndex: bi, lineIndex: ri, line: rowLine,
-          x: margins.left, y: margins.top + currentY,
-          rowSplitOffset: 0, rowSplitHeight: splitHeight,
-        });
-        let consumed = splitHeight;
-        currentY += splitHeight;
-        isPageTop = false;
-
-        // Continue on subsequent pages
+        // Emit fragments across pages
+        let consumed = 0;
         while (consumed < rowHeight) {
-          startNewPage();
+          if (consumed > 0) startNewPage();
           const remaining = rowHeight - consumed;
-          const pageAvail = contentHeight;
+          const pageAvail = contentHeight - currentY;
+
           let fragHeight = remaining;
-          if (remaining > pageAvail) {
-            fragHeight = 0;
-            for (const bp of breakpoints) {
-              if (bp > consumed && bp - consumed <= pageAvail) {
-                fragHeight = bp - consumed;
-              }
-            }
-            if (fragHeight <= 0) fragHeight = Math.min(remaining, pageAvail);
+          if (remaining > pageAvail && pageAvail > 0) {
+            const sh = findRowSplitHeight(tl, ri, consumed + pageAvail);
+            fragHeight = sh > consumed ? sh - consumed : Math.min(remaining, pageAvail);
           }
+          if (fragHeight <= 0) fragHeight = Math.min(remaining, contentHeight);
+
+          const needsSplit = consumed > 0 || fragHeight < rowHeight;
           currentLines.push({
             blockIndex: bi, lineIndex: ri, line: rowLine,
             x: margins.left, y: margins.top + currentY,
-            rowSplitOffset: consumed, rowSplitHeight: fragHeight,
+            ...(needsSplit ? { rowSplitOffset: consumed, rowSplitHeight: fragHeight } : {}),
           });
           consumed += fragHeight;
           currentY += fragHeight;

--- a/packages/docs/src/view/pagination.ts
+++ b/packages/docs/src/view/pagination.ts
@@ -1,7 +1,8 @@
 import type { PageSetup } from '../model/types.js';
 import { getEffectiveDimensions } from '../model/types.js';
 import type { EditContext } from '../model/document.js';
-import type { DocumentLayout, LayoutLine } from './layout.js';
+import type { DocumentLayout, LayoutLine, LayoutRun } from './layout.js';
+import { getCellContentBreakpoints } from './table-layout.js';
 import { Theme } from './theme.js';
 
 export interface PageLine {
@@ -72,18 +73,107 @@ export function paginateLayout(
       const tl = lb.layoutTable;
       for (let ri = 0; ri < tl.rowHeights.length; ri++) {
         const rowHeight = tl.rowHeights[ri];
-        if (currentY + rowHeight > contentHeight && !isPageTop) {
-          startNewPage();
+        const rowLine = { runs: [] as LayoutRun[], y: tl.rowYOffsets[ri], height: rowHeight, width: availableWidth };
+
+        // Row fits on current page — no split needed
+        if (currentY + rowHeight <= contentHeight || isPageTop) {
+          // If row exceeds page even when at page top, try to split it
+          if (isPageTop && currentY + rowHeight > contentHeight) {
+            const breakpoints = getCellContentBreakpoints(tl, ri);
+            if (breakpoints.length > 0) {
+              let consumed = 0;
+              while (consumed < rowHeight) {
+                if (consumed > 0) startNewPage();
+                const remaining = rowHeight - consumed;
+                const pageAvail = contentHeight - currentY;
+                let fragHeight = remaining;
+                if (remaining > pageAvail) {
+                  fragHeight = 0;
+                  for (const bp of breakpoints) {
+                    if (bp > consumed && bp - consumed <= pageAvail) {
+                      fragHeight = bp - consumed;
+                    }
+                  }
+                  if (fragHeight <= 0) fragHeight = Math.min(remaining, pageAvail);
+                }
+                currentLines.push({
+                  blockIndex: bi, lineIndex: ri, line: rowLine,
+                  x: margins.left, y: margins.top + currentY,
+                  rowSplitOffset: consumed, rowSplitHeight: fragHeight,
+                });
+                consumed += fragHeight;
+                currentY += fragHeight;
+                isPageTop = false;
+              }
+              continue;
+            }
+          }
+          // No split needed or not possible — place whole row
+          currentLines.push({
+            blockIndex: bi, lineIndex: ri, line: rowLine,
+            x: margins.left, y: margins.top + currentY,
+          });
+          currentY += rowHeight;
+          isPageTop = false;
+          continue;
         }
+
+        // Row doesn't fit — try to split
+        const availableForRow = contentHeight - currentY;
+        const breakpoints = getCellContentBreakpoints(tl, ri);
+
+        let splitHeight = 0;
+        for (const bp of breakpoints) {
+          if (bp <= availableForRow) splitHeight = bp;
+          else break;
+        }
+
+        if (splitHeight <= 0) {
+          // No safe split point — push entire row to next page
+          startNewPage();
+          currentLines.push({
+            blockIndex: bi, lineIndex: ri, line: rowLine,
+            x: margins.left, y: margins.top + currentY,
+          });
+          currentY += rowHeight;
+          isPageTop = false;
+          continue;
+        }
+
+        // Emit first fragment
         currentLines.push({
-          blockIndex: bi,
-          lineIndex: ri,
-          line: { runs: [], y: tl.rowYOffsets[ri], height: rowHeight, width: availableWidth },
-          x: margins.left,
-          y: margins.top + currentY,
+          blockIndex: bi, lineIndex: ri, line: rowLine,
+          x: margins.left, y: margins.top + currentY,
+          rowSplitOffset: 0, rowSplitHeight: splitHeight,
         });
-        currentY += rowHeight;
+        let consumed = splitHeight;
+        currentY += splitHeight;
         isPageTop = false;
+
+        // Continue on subsequent pages
+        while (consumed < rowHeight) {
+          startNewPage();
+          const remaining = rowHeight - consumed;
+          const pageAvail = contentHeight;
+          let fragHeight = remaining;
+          if (remaining > pageAvail) {
+            fragHeight = 0;
+            for (const bp of breakpoints) {
+              if (bp > consumed && bp - consumed <= pageAvail) {
+                fragHeight = bp - consumed;
+              }
+            }
+            if (fragHeight <= 0) fragHeight = Math.min(remaining, pageAvail);
+          }
+          currentLines.push({
+            blockIndex: bi, lineIndex: ri, line: rowLine,
+            x: margins.left, y: margins.top + currentY,
+            rowSplitOffset: consumed, rowSplitHeight: fragHeight,
+          });
+          consumed += fragHeight;
+          currentY += fragHeight;
+          isPageTop = false;
+        }
       }
 
       if (tl.rowHeights.length > 0) {

--- a/packages/docs/src/view/pagination.ts
+++ b/packages/docs/src/view/pagination.ts
@@ -88,8 +88,9 @@ export function paginateLayout(
 
         // Row doesn't fit — try to split
         const availableForRow = contentHeight - currentY;
+        const td = lb.block.tableData;
         const splitHeight = availableForRow > 0
-          ? findRowSplitHeight(tl, ri, availableForRow)
+          ? findRowSplitHeight(tl, ri, availableForRow, td ?? undefined)
           : 0;
 
         if (splitHeight <= 0 && !isPageTop) {
@@ -106,7 +107,7 @@ export function paginateLayout(
 
           let fragHeight = remaining;
           if (remaining > pageAvail && pageAvail > 0) {
-            const sh = findRowSplitHeight(tl, ri, consumed + pageAvail);
+            const sh = findRowSplitHeight(tl, ri, consumed + pageAvail, td ?? undefined);
             fragHeight = sh > consumed ? sh - consumed : Math.min(remaining, pageAvail);
           }
           if (fragHeight <= 0) fragHeight = Math.min(remaining, contentHeight);

--- a/packages/docs/src/view/pagination.ts
+++ b/packages/docs/src/view/pagination.ts
@@ -329,13 +329,18 @@ export function paginatedPixelToPosition(
   const localY = py - pageTop;
   const localX = px - pageX - margins.left;
 
-  // Find the target line on this page by Y
+  // Find the target line on this page by Y.
+  // For split table rows, use rowSplitHeight so a tiny first-fragment
+  // doesn't claim the space that belongs to the next line below it.
   let targetPL = targetPage.lines[0];
   for (const pl of targetPage.lines) {
+    const visibleHeight = pl.rowSplitHeight ?? pl.line.height;
+    if (localY >= pl.y && localY < pl.y + visibleHeight) {
+      targetPL = pl;
+      break;
+    }
     if (localY >= pl.y) {
       targetPL = pl;
-    } else {
-      break;
     }
   }
 

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -187,25 +187,45 @@ export function resolvePositionPixel(
 
         if (nestingPath.length === 1) {
           // Non-nested table cell — use the original cursor positioning
-          // logic that finds the PageLine by ownerRow.
+          // logic that finds the PageLine by ownerRow. For split rows,
+          // pick the fragment whose visible range contains the line.
           let pageLine: import('./pagination.js').PageLine | undefined;
           let pageIndex = 0;
+          const lineInRow = targetLayout.runLineY - tl.rowYOffsets[ownerRow];
           for (const page of paginatedLayout.pages) {
             for (const pl of page.lines) {
               if (pl.blockIndex === blockIndex && pl.lineIndex === ownerRow) {
+                if (pl.rowSplitHeight === undefined) {
+                  // Non-split row — use directly
+                  pageLine = pl;
+                  pageIndex = page.pageIndex;
+                  break;
+                }
+                // Split row — check if line falls within this fragment
+                const splitOff = pl.rowSplitOffset ?? 0;
+                if (lineInRow >= splitOff && lineInRow < splitOff + pl.rowSplitHeight) {
+                  pageLine = pl;
+                  pageIndex = page.pageIndex;
+                  break;
+                }
+                // Fallback to last seen
                 pageLine = pl;
                 pageIndex = page.pageIndex;
-                break;
               }
             }
-            if (pageLine) break;
+            if (pageLine && pageLine.rowSplitHeight === undefined) break;
+            if (pageLine && pageLine.rowSplitOffset !== undefined) {
+              const splitOff = pageLine.rowSplitOffset ?? 0;
+              if (lineInRow >= splitOff && lineInRow < splitOff + (pageLine.rowSplitHeight ?? Infinity)) break;
+            }
           }
           if (!pageLine) return undefined;
 
           const pageY = getPageYOffset(paginatedLayout, pageIndex);
+          const splitOffset = pageLine.rowSplitOffset ?? 0;
           const cellX = tl.columnXOffsets[colIndex] + cellPadding;
           const cursorYOnPage =
-            pageY + pageLine.y + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]);
+            pageY + pageLine.y + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]) - splitOffset;
 
           return {
             x: pageX + margins.left + cellX + cursorX,
@@ -215,28 +235,42 @@ export function resolvePositionPixel(
         }
 
         // Nested table cell — find the PageLine for the outermost table's
-        // row, then add accumulated Y offset from outer cells.
+        // row, then add accumulated Y offset from outer cells. For split
+        // rows, pick the fragment whose range contains the cursor's Y.
         const outerRowIndex = nestingPath[0].rowIndex;
+        const cursorInRow = yOffsetInTable + targetLayout.runLineY;
         let pageLine: import('./pagination.js').PageLine | undefined;
         let pageIndex = 0;
         for (const page of paginatedLayout.pages) {
           for (const pl of page.lines) {
             if (pl.blockIndex === blockIndex && pl.lineIndex === outerRowIndex) {
+              if (pl.rowSplitHeight === undefined) {
+                pageLine = pl;
+                pageIndex = page.pageIndex;
+                break;
+              }
+              const splitOff = pl.rowSplitOffset ?? 0;
+              if (cursorInRow >= splitOff && cursorInRow < splitOff + pl.rowSplitHeight) {
+                pageLine = pl;
+                pageIndex = page.pageIndex;
+                break;
+              }
               pageLine = pl;
               pageIndex = page.pageIndex;
-              break;
             }
           }
           if (pageLine) break;
         }
         if (!pageLine) return undefined;
 
+        const nestedSplitOffset = pageLine.rowSplitOffset ?? 0;
         const pageY = getPageYOffset(paginatedLayout, pageIndex);
         const innerCellX = tl.columnXOffsets[colIndex] + cellPadding;
         const innerCursorY = pageY + pageLine.y
           + yOffsetInTable
           + tl.rowYOffsets[ownerRow]
-          + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]);
+          + (targetLayout.runLineY - tl.rowYOffsets[ownerRow])
+          - nestedSplitOffset;
 
         return {
           x: pageX + margins.left + xOffset + innerCellX + cursorX,

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -1,10 +1,70 @@
 import type { DocPosition, DocRange } from '../model/types.js';
 import { LIST_INDENT_PX } from '../model/types.js';
-import type { PaginatedLayout } from './pagination.js';
+import type { PageLine, PaginatedLayout } from './pagination.js';
 import { findPageForPosition, getPageYOffset, getPageXOffset } from './pagination.js';
 import type { DocumentLayout } from './layout.js';
 import { buildFont, Theme } from './theme.js';
 import { computeMergedCellLineLayouts } from './table-renderer.js';
+
+/**
+ * Find the split fragment (PageLine) that should render a cursor at
+ * `cursorInRow` pixels from the top of the outer table row.
+ *
+ * For non-split rows the first matching PageLine is returned immediately.
+ * For split rows the fragment whose [splitOffset, splitOffset+splitHeight)
+ * range contains `cursorInRow` is preferred. When `lineEndInRow` is
+ * supplied (nested tables), a straddling match is also accepted — this
+ * handles the case where the cursor's precise Y is in the first fragment
+ * but the enclosing nested-table line extends into a later fragment.
+ */
+function findSplitFragment(
+  paginatedLayout: PaginatedLayout,
+  blockIndex: number,
+  rowIndex: number,
+  cursorInRow: number,
+  lineEndInRow?: number,
+): { pageLine: PageLine; pageIndex: number } | undefined {
+  let pageLine: PageLine | undefined;
+  let pageIndex = 0;
+
+  for (const page of paginatedLayout.pages) {
+    for (const pl of page.lines) {
+      if (pl.blockIndex !== blockIndex || pl.lineIndex !== rowIndex) continue;
+
+      if (pl.rowSplitHeight === undefined) {
+        return { pageLine: pl, pageIndex: page.pageIndex };
+      }
+
+      const splitOff = pl.rowSplitOffset ?? 0;
+      const splitEnd = splitOff + pl.rowSplitHeight;
+
+      if (cursorInRow >= splitOff && cursorInRow < splitEnd) {
+        return { pageLine: pl, pageIndex: page.pageIndex };
+      }
+
+      // Straddling: cursor Y is before this fragment but the enclosing
+      // nested-table line extends into it.
+      if (lineEndInRow !== undefined
+          && cursorInRow < splitOff
+          && lineEndInRow > splitOff) {
+        return { pageLine: pl, pageIndex: page.pageIndex };
+      }
+
+      // Fallback — keep the last seen fragment so we don't return
+      // undefined when the cursor is past all fragments.
+      pageLine = pl;
+      pageIndex = page.pageIndex;
+    }
+
+    if (!pageLine) continue;
+    if (pageLine.rowSplitHeight === undefined) break;
+    const off = pageLine.rowSplitOffset ?? 0;
+    if (cursorInRow >= off && cursorInRow < off + (pageLine.rowSplitHeight ?? Infinity)) break;
+    if (lineEndInRow !== undefined && cursorInRow < off && lineEndInRow > off) break;
+  }
+
+  return pageLine ? { pageLine, pageIndex } : undefined;
+}
 
 /**
  * Represents a remote peer's cursor for collaborative editing.
@@ -186,91 +246,64 @@ export function resolvePositionPixel(
         const { margins } = paginatedLayout.pageSetup;
 
         if (nestingPath.length === 1) {
-          // Non-nested table cell — use the original cursor positioning
-          // logic that finds the PageLine by ownerRow. For split rows,
-          // pick the fragment whose visible range contains the line.
-          let pageLine: import('./pagination.js').PageLine | undefined;
-          let pageIndex = 0;
+          // Non-nested table cell
           const lineInRow = targetLayout.runLineY - tl.rowYOffsets[ownerRow];
-          for (const page of paginatedLayout.pages) {
-            for (const pl of page.lines) {
-              if (pl.blockIndex === blockIndex && pl.lineIndex === ownerRow) {
-                if (pl.rowSplitHeight === undefined) {
-                  // Non-split row — use directly
-                  pageLine = pl;
-                  pageIndex = page.pageIndex;
-                  break;
-                }
-                // Split row — check if line falls within this fragment
-                const splitOff = pl.rowSplitOffset ?? 0;
-                if (lineInRow >= splitOff && lineInRow < splitOff + pl.rowSplitHeight) {
-                  pageLine = pl;
-                  pageIndex = page.pageIndex;
-                  break;
-                }
-                // Fallback to last seen
-                pageLine = pl;
-                pageIndex = page.pageIndex;
-              }
-            }
-            if (pageLine && pageLine.rowSplitHeight === undefined) break;
-            if (pageLine && pageLine.rowSplitOffset !== undefined) {
-              const splitOff = pageLine.rowSplitOffset ?? 0;
-              if (lineInRow >= splitOff && lineInRow < splitOff + (pageLine.rowSplitHeight ?? Infinity)) break;
-            }
-          }
-          if (!pageLine) return undefined;
+          const found = findSplitFragment(paginatedLayout, blockIndex, ownerRow, lineInRow);
+          if (!found) return undefined;
 
-          const pageY = getPageYOffset(paginatedLayout, pageIndex);
-          const splitOffset = pageLine.rowSplitOffset ?? 0;
+          const pageY = getPageYOffset(paginatedLayout, found.pageIndex);
+          const splitOffset = found.pageLine.rowSplitOffset ?? 0;
           const cellX = tl.columnXOffsets[colIndex] + cellPadding;
-          const cursorYOnPage =
-            pageY + pageLine.y + (targetLayout.runLineY - tl.rowYOffsets[ownerRow]) - splitOffset;
 
           return {
             x: pageX + margins.left + cellX + cursorX,
-            y: cursorYOnPage,
+            y: pageY + found.pageLine.y + lineInRow - splitOffset,
             height: lineHeight,
           };
         }
 
-        // Nested table cell — find the PageLine for the outermost table's
-        // row, then add accumulated Y offset from outer cells. For split
-        // rows, pick the fragment whose range contains the cursor's Y.
+        // Nested table cell — accumulated Y offset places the cursor
+        // within the outermost row. For split rows that straddle the
+        // boundary, pass the enclosing cell line's end Y so that the
+        // straddling match can pick the continuation fragment.
         const outerRowIndex = nestingPath[0].rowIndex;
         const cursorInRow = yOffsetInTable + targetLayout.runLineY;
-        let pageLine: import('./pagination.js').PageLine | undefined;
-        let pageIndex = 0;
-        for (const page of paginatedLayout.pages) {
-          for (const pl of page.lines) {
-            if (pl.blockIndex === blockIndex && pl.lineIndex === outerRowIndex) {
-              if (pl.rowSplitHeight === undefined) {
-                pageLine = pl;
-                pageIndex = page.pageIndex;
+
+        // Compute lineEndInRow: end Y of the outermost cell line that
+        // contains the nested-table chain.
+        let lineEndInRow: number | undefined;
+        if (nestingPath.length > 1) {
+          const outerSeg = nestingPath[0];
+          const outerCell = lb.layoutTable.cells[outerSeg.rowIndex]?.[outerSeg.colIndex];
+          const outerCellData = lb.block.tableData?.rows[outerSeg.rowIndex]?.cells[outerSeg.colIndex];
+          if (outerCell && outerCellData) {
+            const nextTableId = nestingPath[1].tableBlockId;
+            for (let li = 0; li < outerCell.lines.length; li++) {
+              if (!outerCell.lines[li].nestedTable) continue;
+              let bIdx = 0;
+              for (let bi = outerCell.blockBoundaries.length - 1; bi >= 0; bi--) {
+                if (li >= outerCell.blockBoundaries[bi]) { bIdx = bi; break; }
+              }
+              if (outerCellData.blocks[bIdx]?.id === nextTableId) {
+                lineEndInRow = yOffsetInTable + outerCell.lines[li].height;
                 break;
               }
-              const splitOff = pl.rowSplitOffset ?? 0;
-              if (cursorInRow >= splitOff && cursorInRow < splitOff + pl.rowSplitHeight) {
-                pageLine = pl;
-                pageIndex = page.pageIndex;
-                break;
-              }
-              pageLine = pl;
-              pageIndex = page.pageIndex;
             }
           }
-          if (pageLine) break;
         }
-        if (!pageLine) return undefined;
 
-        const nestedSplitOffset = pageLine.rowSplitOffset ?? 0;
-        const pageY = getPageYOffset(paginatedLayout, pageIndex);
+        const found = findSplitFragment(
+          paginatedLayout, blockIndex, outerRowIndex, cursorInRow, lineEndInRow,
+        );
+        if (!found) return undefined;
+
+        const nestedSplitOffset = found.pageLine.rowSplitOffset ?? 0;
+        const pageY = getPageYOffset(paginatedLayout, found.pageIndex);
         const innerCellX = tl.columnXOffsets[colIndex] + cellPadding;
-        const innerCursorY = pageY + pageLine.y
-          + yOffsetInTable
-          + tl.rowYOffsets[ownerRow]
-          + (targetLayout.runLineY - tl.rowYOffsets[ownerRow])
-          - nestedSplitOffset;
+        // Clamp cursor Y to the fragment top. When a nested table
+        // straddles the split boundary the raw Y can be above the page.
+        const rawCursorY = pageY + found.pageLine.y + cursorInRow - nestedSplitOffset;
+        const innerCursorY = Math.max(rawCursorY, pageY + found.pageLine.y);
 
         return {
           x: pageX + margins.left + xOffset + innerCellX + cursorX,

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -266,8 +266,11 @@ export function resolvePositionPixel(
         // within the outermost row. For split rows that straddle the
         // boundary, pass the enclosing cell line's end Y so that the
         // straddling match can pick the continuation fragment.
+        // Subtract the outer row's Y offset so cursorInRow is row-local
+        // (matching the row-local splitOffset/splitHeight in PageLine).
         const outerRowIndex = nestingPath[0].rowIndex;
-        const cursorInRow = yOffsetInTable + targetLayout.runLineY;
+        const outerRowTop = lb.layoutTable.rowYOffsets[outerRowIndex] ?? 0;
+        const cursorInRow = yOffsetInTable + targetLayout.runLineY - outerRowTop;
 
         // Compute lineEndInRow: end Y of the outermost cell line that
         // contains the nested-table chain.
@@ -285,7 +288,7 @@ export function resolvePositionPixel(
                 if (li >= outerCell.blockBoundaries[bi]) { bIdx = bi; break; }
               }
               if (outerCellData.blocks[bIdx]?.id === nextTableId) {
-                lineEndInRow = yOffsetInTable + outerCell.lines[li].height;
+                lineEndInRow = yOffsetInTable + outerCell.lines[li].height - outerRowTop;
                 break;
               }
             }

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -392,15 +392,29 @@ function buildRects(
         }
         return undefined;
       }
+      // For split rows, multiple PageLines share the same blockIndex +
+      // lineIndex. Pick the fragment whose visible range contains runLineY
+      // (relative to the row top).
+      let bestResult: number | undefined;
       for (const page of paginatedLayout.pages) {
         for (const pl of page.lines) {
           if (pl.blockIndex === blockIndex && pl.lineIndex === ownerRow) {
             const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
-            return pageY + pl.y + (runLineY - tl.rowYOffsets[ownerRow]);
+            const splitOffset = pl.rowSplitOffset ?? 0;
+            const absY = pageY + pl.y + (runLineY - tl.rowYOffsets[ownerRow]) - splitOffset;
+            if (pl.rowSplitHeight === undefined) {
+              return absY; // non-split row
+            }
+            // Check if this line falls within this fragment's range
+            const lineInRow = runLineY - tl.rowYOffsets[ownerRow];
+            if (lineInRow >= splitOffset && lineInRow < splitOffset + pl.rowSplitHeight) {
+              return absY;
+            }
+            bestResult = absY; // fallback to last
           }
         }
       }
-      return undefined;
+      return bestResult;
     };
 
     const cellRects: Array<{ x: number; y: number; width: number; height: number }> = [];

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -587,34 +587,59 @@ function buildCellRangeRects(
 
   // For nested tables, we need the absolute Y of the outermost row that
   // contains the nested table. For top-level tables, build the full row map.
-  let baseY = 0;
+  // Build a row → absolute Y fragments list. For split rows, multiple
+  // fragments share the same lineIndex; each gets its own entry so the
+  // selection highlight appears on every page the row spans.
+  const rowFrags = new Map<number, Array<{ y: number; height: number }>>();
   if (outerRowIndex >= 0) {
-    // Nested table — find the page line for the outer row
+    // Nested table inside a (possibly split) outer row.
+    // Collect all outer-row fragments so inner rows that fall on
+    // different pages each get their own rect.
+    const outerFragments: Array<{ pageY: number; plY: number; splitOff: number; splitH: number }> = [];
     for (const page of paginatedLayout.pages) {
-      const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
+      const pY = getPageYOffset(paginatedLayout, page.pageIndex);
       for (const pl of page.lines) {
         if (pl.blockIndex === blockIndex && pl.lineIndex === outerRowIndex) {
-          baseY = pageY + pl.y + nestedYOffset;
-          break;
+          outerFragments.push({
+            pageY: pY,
+            plY: pl.y,
+            splitOff: pl.rowSplitOffset ?? 0,
+            splitH: pl.rowSplitHeight ?? pl.line.height,
+          });
         }
       }
     }
-  }
 
-  // Build a row → absolute Y map
-  const rowYMap = new Map<number, number>();
-  if (outerRowIndex >= 0) {
-    // Nested: compute Y for each inner row from baseY + inner rowYOffsets
     for (let r = 0; r < tl.rowYOffsets.length; r++) {
-      rowYMap.set(r, baseY + tl.rowYOffsets[r]);
+      const innerRowTop = nestedYOffset + tl.rowYOffsets[r];
+      const innerRowH = tl.rowHeights[r];
+      const entries: Array<{ y: number; height: number }> = [];
+
+      for (const frag of outerFragments) {
+        const fragEnd = frag.splitOff + frag.splitH;
+        // Check if this inner row overlaps the fragment's visible range
+        if (innerRowTop + innerRowH <= frag.splitOff || innerRowTop >= fragEnd) continue;
+        // Clamp the visible portion to the fragment bounds
+        const visTop = Math.max(innerRowTop, frag.splitOff);
+        const visBot = Math.min(innerRowTop + innerRowH, fragEnd);
+        const y = frag.pageY + frag.plY + (visTop - frag.splitOff);
+        entries.push({ y, height: visBot - visTop });
+      }
+
+      if (entries.length > 0) {
+        rowFrags.set(r, entries);
+      }
     }
   } else {
-    // Top-level: use paginated layout
+    // Top-level: use paginated layout (split rows produce multiple entries)
     for (const page of paginatedLayout.pages) {
       const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
       for (const pl of page.lines) {
         if (pl.blockIndex !== blockIndex) continue;
-        rowYMap.set(pl.lineIndex, pageY + pl.y);
+        const visibleHeight = pl.rowSplitHeight ?? tl.rowHeights[pl.lineIndex];
+        const entries = rowFrags.get(pl.lineIndex) ?? [];
+        entries.push({ y: pageY + pl.y, height: visibleHeight });
+        rowFrags.set(pl.lineIndex, entries);
       }
     }
   }
@@ -634,23 +659,13 @@ function buildCellRangeRects(
       const x = xBase + tl.columnXOffsets[c];
       const width = cell.width;
 
-      const spanEnd = Math.min(r + rowSpan, tl.rowHeights.length);
-      let segmentTop: number | undefined;
-      let segmentHeight = 0;
-      for (let rr = r; rr < spanEnd; rr++) {
-        const rrY = rowYMap.get(rr);
-        if (rrY === undefined) continue;
-        if (segmentTop === undefined) {
-          segmentTop = rrY;
-        } else if (Math.abs(rrY - (segmentTop + segmentHeight)) > 0.5) {
-          rects.push({ x, y: segmentTop, width, height: segmentHeight });
-          segmentTop = rrY;
-          segmentHeight = 0;
+      // Collect all visible fragments for the spanned rows
+      for (let rr = r; rr < Math.min(r + rowSpan, tl.rowHeights.length); rr++) {
+        const frags = rowFrags.get(rr);
+        if (!frags) continue;
+        for (const frag of frags) {
+          rects.push({ x, y: frag.y, width, height: frag.height });
         }
-        segmentHeight += tl.rowHeights[rr];
-      }
-      if (segmentTop !== undefined && segmentHeight > 0) {
-        rects.push({ x, y: segmentTop, width, height: segmentHeight });
       }
     }
   }

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -638,18 +638,25 @@ export function findRowSplitHeight(
     if (cell.merged) continue;
     hasCells = true;
 
-    // Find largest breakpoint <= availableHeight for this cell
+    // Find largest breakpoint <= availableHeight for this cell.
+    // If all content fits, this cell imposes no constraint on split height.
     let bestBp = 0;
     let y = padding;
+    let allFit = true;
     for (const line of cell.lines) {
       y += line.height;
       if (y <= availableHeight) {
         bestBp = y;
       } else {
+        allFit = false;
         break;
       }
     }
-    minSafe = Math.min(minSafe, bestBp);
+    if (!allFit) {
+      minSafe = Math.min(minSafe, bestBp);
+    }
+    // When allFit, this cell's content ends before availableHeight,
+    // so splitting at any height >= bestBp is safe — no constraint.
   }
 
   return hasCells ? minSafe : 0;

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -638,42 +638,41 @@ export function findRowSplitHeight(
     if (cell.merged) continue;
     hasCells = true;
 
-    // Find largest breakpoint <= availableHeight for this cell.
-    // If all content fits, this cell imposes no constraint on split height.
+    // Use the layout engine's actual line.y values (which include any
+    // block margins and spacing) instead of re-summing heights manually.
+    // Breakpoints are at padding + line.y + line.height for each line.
     let bestBp = 0;
-    let y = padding;
     let allFit = true;
     for (const line of cell.lines) {
+      const lineEnd = padding + line.y + line.height;
       if (line.nestedTable) {
         // Recurse into nested table: each row boundary is a breakpoint
         const nt = line.nestedTable;
+        const ntBase = padding + line.y; // Y of nested table top within row
         for (let nr = 0; nr < nt.rowHeights.length; nr++) {
-          const rowEnd = y + nt.rowYOffsets[nr] + nt.rowHeights[nr];
+          const rowEnd = ntBase + nt.rowYOffsets[nr] + nt.rowHeights[nr];
           if (rowEnd <= availableHeight) {
             bestBp = rowEnd;
           } else {
-            // Try splitting within this nested row
-            const nestedAvail = availableHeight - y - nt.rowYOffsets[nr];
+            const nestedAvail = availableHeight - ntBase - nt.rowYOffsets[nr];
             if (nestedAvail > 0) {
               const innerSplit = findRowSplitHeight(nt, nr, nestedAvail);
               if (innerSplit > 0) {
-                bestBp = y + nt.rowYOffsets[nr] + innerSplit;
+                bestBp = ntBase + nt.rowYOffsets[nr] + innerSplit;
               }
             }
             allFit = false;
             break;
           }
         }
-        if (allFit) y += line.height;
       } else {
-        y += line.height;
-        if (y <= availableHeight) {
-          bestBp = y;
+        if (lineEnd <= availableHeight) {
+          bestBp = lineEnd;
         } else {
           allFit = false;
-          break;
         }
       }
+      if (!allFit) break;
     }
     if (!allFit) {
       minSafe = Math.min(minSafe, bestBp);

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -644,12 +644,35 @@ export function findRowSplitHeight(
     let y = padding;
     let allFit = true;
     for (const line of cell.lines) {
-      y += line.height;
-      if (y <= availableHeight) {
-        bestBp = y;
+      if (line.nestedTable) {
+        // Recurse into nested table: each row boundary is a breakpoint
+        const nt = line.nestedTable;
+        for (let nr = 0; nr < nt.rowHeights.length; nr++) {
+          const rowEnd = y + nt.rowYOffsets[nr] + nt.rowHeights[nr];
+          if (rowEnd <= availableHeight) {
+            bestBp = rowEnd;
+          } else {
+            // Try splitting within this nested row
+            const nestedAvail = availableHeight - y - nt.rowYOffsets[nr];
+            if (nestedAvail > 0) {
+              const innerSplit = findRowSplitHeight(nt, nr, nestedAvail);
+              if (innerSplit > 0) {
+                bestBp = y + nt.rowYOffsets[nr] + innerSplit;
+              }
+            }
+            allFit = false;
+            break;
+          }
+        }
+        if (allFit) y += line.height;
       } else {
-        allFit = false;
-        break;
+        y += line.height;
+        if (y <= availableHeight) {
+          bestBp = y;
+        } else {
+          allFit = false;
+          break;
+        }
       }
     }
     if (!allFit) {

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -611,3 +611,45 @@ export function resolveNestedTableLayout(
     outerRowIndex: path[0].rowIndex,
   };
 }
+
+/**
+ * Return sorted array of safe vertical break positions within a table row.
+ * Each value is a cumulative height (relative to the row top) at which
+ * all cells in the row have an atomic-unit boundary (text line or image end).
+ * The paginator can split the row at any of these heights.
+ */
+export function getCellContentBreakpoints(
+  layout: LayoutTable,
+  rowIndex: number,
+): number[] {
+  const padding = DEFAULT_CELL_PADDING;
+  const cells = layout.cells[rowIndex];
+  if (!cells || cells.length === 0) return [];
+
+  // Collect per-cell breakpoint sets
+  const perCell: Set<number>[] = [];
+  for (let c = 0; c < cells.length; c++) {
+    const cell = cells[c];
+    if (cell.merged) continue; // skip covered cells
+    const breaks = new Set<number>();
+    let y = padding;
+    for (const line of cell.lines) {
+      y += line.height;
+      breaks.add(y);
+    }
+    perCell.push(breaks);
+  }
+
+  if (perCell.length === 0) return [];
+
+  // Intersect: only keep heights where ALL non-merged cells have a break
+  const first = perCell[0];
+  const common: number[] = [];
+  for (const h of first) {
+    if (perCell.every(s => s.has(h))) {
+      common.push(h);
+    }
+  }
+  common.sort((a, b) => a - b);
+  return common;
+}

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -613,43 +613,44 @@ export function resolveNestedTableLayout(
 }
 
 /**
- * Return sorted array of safe vertical break positions within a table row.
- * Each value is a cumulative height (relative to the row top) at which
- * all cells in the row have an atomic-unit boundary (text line or image end).
- * The paginator can split the row at any of these heights.
+ * Find the maximum safe split height for a table row given the available space.
+ * Returns 0 if no safe split is possible (row stays atomic).
+ *
+ * A split at height H is safe when, for every non-merged cell in the row,
+ * H falls exactly at a line boundary (never mid-line). Because different
+ * cells have different line heights, the function clamps to each cell's
+ * largest breakpoint <= availableHeight and returns the minimum across cells.
  */
-export function getCellContentBreakpoints(
+export function findRowSplitHeight(
   layout: LayoutTable,
   rowIndex: number,
-): number[] {
+  availableHeight: number,
+): number {
   const padding = DEFAULT_CELL_PADDING;
   const cells = layout.cells[rowIndex];
-  if (!cells || cells.length === 0) return [];
+  if (!cells || cells.length === 0) return 0;
 
-  // Collect per-cell breakpoint sets
-  const perCell: Set<number>[] = [];
+  let minSafe = availableHeight;
+  let hasCells = false;
+
   for (let c = 0; c < cells.length; c++) {
     const cell = cells[c];
-    if (cell.merged) continue; // skip covered cells
-    const breaks = new Set<number>();
+    if (cell.merged) continue;
+    hasCells = true;
+
+    // Find largest breakpoint <= availableHeight for this cell
+    let bestBp = 0;
     let y = padding;
     for (const line of cell.lines) {
       y += line.height;
-      breaks.add(y);
+      if (y <= availableHeight) {
+        bestBp = y;
+      } else {
+        break;
+      }
     }
-    perCell.push(breaks);
+    minSafe = Math.min(minSafe, bestBp);
   }
 
-  if (perCell.length === 0) return [];
-
-  // Intersect: only keep heights where ALL non-merged cells have a break
-  const first = perCell[0];
-  const common: number[] = [];
-  for (const h of first) {
-    if (perCell.every(s => s.has(h))) {
-      common.push(h);
-    }
-  }
-  common.sort((a, b) => a - b);
-  return common;
+  return hasCells ? minSafe : 0;
 }

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -625,8 +625,8 @@ export function findRowSplitHeight(
   layout: LayoutTable,
   rowIndex: number,
   availableHeight: number,
+  tableData?: import('../model/types.js').TableData,
 ): number {
-  const padding = DEFAULT_CELL_PADDING;
   const cells = layout.cells[rowIndex];
   if (!cells || cells.length === 0) return 0;
 
@@ -637,6 +637,8 @@ export function findRowSplitHeight(
     const cell = cells[c];
     if (cell.merged) continue;
     hasCells = true;
+
+    const padding = tableData?.rows[rowIndex]?.cells[c]?.style?.padding ?? DEFAULT_CELL_PADDING;
 
     // Use the layout engine's actual line.y values (which include any
     // block margins and spacing) instead of re-summing heights manually.

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -99,6 +99,8 @@ export function renderTableBackgrounds(
   startRow = 0,
   endRow?: number,
   pageStartRow?: number,
+  rowSplitOffset?: number,
+  rowSplitHeight?: number,
 ): void {
   const { rows } = tableData;
   const { cells, columnXOffsets, columnPixelWidths, rowYOffsets, rowHeights } = tableLayout;
@@ -107,6 +109,15 @@ export function renderTableBackgrounds(
   const numCols = columnPixelWidths.length;
   const rowEnd = endRow ?? numRows;
   const pageStart = pageStartRow ?? startRow;
+
+  const isSplit = rowSplitOffset !== undefined && rowSplitHeight !== undefined;
+  if (isSplit) {
+    const clipY = tableY + rowYOffsets[pageStart] + rowSplitOffset;
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(tableX, clipY, tableLayout.totalWidth, rowSplitHeight);
+    ctx.clip();
+  }
 
   for (let r = startRow; r < rowEnd; r++) {
     for (let c = 0; c < numCols; c++) {
@@ -145,6 +156,10 @@ export function renderTableBackgrounds(
       );
     }
   }
+
+  if (isSplit) {
+    ctx.restore();
+  }
 }
 
 /**
@@ -182,6 +197,8 @@ export function renderTableContent(
   dragImageRun?: LayoutRun,
   selectionRects?: Array<{ x: number; y: number; width: number; height: number }>,
   focused?: boolean,
+  rowSplitOffset?: number,
+  rowSplitHeight?: number,
 ): void {
   const { rows } = tableData;
   const { cells, columnXOffsets, columnPixelWidths, rowYOffsets, rowHeights } = tableLayout;
@@ -190,6 +207,15 @@ export function renderTableContent(
   const numCols = columnPixelWidths.length;
   const rowEnd = endRow ?? numRows;
   const pageStart = pageStartRow ?? startRow;
+
+  const isSplit = rowSplitOffset !== undefined && rowSplitHeight !== undefined;
+  if (isSplit) {
+    const clipY = tableY + rowYOffsets[pageStart] + rowSplitOffset;
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(tableX, clipY, tableLayout.totalWidth, rowSplitHeight);
+    ctx.clip();
+  }
 
   // 2. Cell text
   for (let r = startRow; r < rowEnd; r++) {
@@ -476,6 +502,32 @@ export function renderTableContent(
       drawBorder(ctx, cell.style?.borderLeft ?? themeBorder, x, y, x, y + visibleHeight);
       drawBorder(ctx, cell.style?.borderRight ?? themeBorder, x + cellWidth, y, x + cellWidth, y + visibleHeight);
     }
+  }
+
+  if (isSplit) {
+    ctx.restore();
+    // Re-draw borders on fragment boundaries so each split piece has
+    // a clean rectangular outline.
+    const fragTop = tableY + rowYOffsets[pageStart] + rowSplitOffset;
+    const fragBottom = fragTop + rowSplitHeight;
+    ctx.save();
+    ctx.strokeStyle = Theme.defaultColor;
+    ctx.lineWidth = 1;
+    // Top and bottom borders
+    ctx.beginPath();
+    ctx.moveTo(tableX, fragTop);
+    ctx.lineTo(tableX + tableLayout.totalWidth, fragTop);
+    ctx.moveTo(tableX, fragBottom);
+    ctx.lineTo(tableX + tableLayout.totalWidth, fragBottom);
+    // Vertical cell borders
+    for (const xOff of columnXOffsets) {
+      ctx.moveTo(tableX + xOff, fragTop);
+      ctx.lineTo(tableX + xOff, fragBottom);
+    }
+    ctx.moveTo(tableX + tableLayout.totalWidth, fragTop);
+    ctx.lineTo(tableX + tableLayout.totalWidth, fragBottom);
+    ctx.stroke();
+    ctx.restore();
   }
 }
 

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -506,28 +506,6 @@ export function renderTableContent(
 
   if (isSplit) {
     ctx.restore();
-    // Re-draw borders on fragment boundaries so each split piece has
-    // a clean rectangular outline.
-    const fragTop = tableY + rowYOffsets[pageStart] + rowSplitOffset;
-    const fragBottom = fragTop + rowSplitHeight;
-    ctx.save();
-    ctx.strokeStyle = Theme.defaultColor;
-    ctx.lineWidth = 1;
-    // Top and bottom borders
-    ctx.beginPath();
-    ctx.moveTo(tableX, fragTop);
-    ctx.lineTo(tableX + tableLayout.totalWidth, fragTop);
-    ctx.moveTo(tableX, fragBottom);
-    ctx.lineTo(tableX + tableLayout.totalWidth, fragBottom);
-    // Vertical cell borders
-    for (const xOff of columnXOffsets) {
-      ctx.moveTo(tableX + xOff, fragTop);
-      ctx.lineTo(tableX + xOff, fragBottom);
-    }
-    ctx.moveTo(tableX + tableLayout.totalWidth, fragTop);
-    ctx.lineTo(tableX + tableLayout.totalWidth, fragBottom);
-    ctx.stroke();
-    ctx.restore();
   }
 }
 

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -125,10 +125,11 @@ export function renderTableBackgrounds(
       if (layoutCell.merged) continue;
 
       const cell = rows[r]?.cells[c];
-      if (!cell?.style?.backgroundColor) continue;
+      if (!cell) continue;
 
       const colSpan = cell.colSpan ?? 1;
       const rowSpan = cell.rowSpan ?? 1;
+      const padding = cell.style?.padding ?? 4;
 
       // Clip the cell to the rows physically rendered on this page so a
       // merged cell split across pages shows its background on each page
@@ -147,13 +148,34 @@ export function renderTableBackgrounds(
         visibleHeight += rowHeights[rr];
       }
 
-      ctx.fillStyle = cell.style.backgroundColor;
-      ctx.fillRect(
-        tableX + columnXOffsets[c],
-        tableY + rowYOffsets[visibleStart],
-        cellWidth,
-        visibleHeight,
-      );
+      // Draw this cell's own background
+      if (cell.style?.backgroundColor) {
+        ctx.fillStyle = cell.style.backgroundColor;
+        ctx.fillRect(
+          tableX + columnXOffsets[c],
+          tableY + rowYOffsets[visibleStart],
+          cellWidth,
+          visibleHeight,
+        );
+      }
+
+      // Recurse into nested tables so their backgrounds are also drawn
+      // in the first pass, before the selection highlight layer.
+      const cellX = tableX + columnXOffsets[c];
+      const cellY = tableY + rowYOffsets[r];
+      const textYOffset = padding; // nested tables use top alignment
+      for (let li = 0; li < layoutCell.lines.length; li++) {
+        const line = layoutCell.lines[li];
+        if (!line.nestedTable) continue;
+        const blockIndex = getBlockIndexForLine(layoutCell.blockBoundaries, li);
+        const nestedBlock = cell.blocks[blockIndex];
+        if (nestedBlock?.tableData) {
+          renderTableBackgrounds(
+            ctx, nestedBlock.tableData, line.nestedTable,
+            cellX + padding, cellY + textYOffset + line.y,
+          );
+        }
+      }
     }
   }
 
@@ -293,17 +315,16 @@ export function renderTableContent(
         } else {
           lineAbsoluteY = cellY + textYOffset + line.y;
         }
-        // Render nested table if this line contains one
+        // Render nested table if this line contains one.
+        // Backgrounds were already drawn in the first pass
+        // (renderTableBackgrounds recurses into nested tables)
+        // so only the content pass is needed here.
         if (line.nestedTable) {
           const blockIndex = getBlockIndexForLine(layoutCell.blockBoundaries, li);
           const nestedBlock = cell.blocks[blockIndex];
           if (nestedBlock?.tableData) {
             const nestedX = cellX + padding;
             const nestedY = lineAbsoluteY;
-            renderTableBackgrounds(
-              ctx, nestedBlock.tableData, line.nestedTable,
-              nestedX, nestedY,
-            );
             renderTableContent(
               ctx, nestedBlock.tableData, line.nestedTable,
               nestedX, nestedY,

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -3616,7 +3616,8 @@ export class TextEditor {
       for (const pl of page.lines) {
         if (pl.blockIndex !== blockIndex) continue;
         const top = pageY + pl.y;
-        const bottom = top + pl.line.height;
+        const visibleHeight = pl.rowSplitHeight ?? pl.line.height;
+        const bottom = top + visibleHeight;
         if (top < firstRowTop) firstRowTop = top;
         if (bottom > lastRowBottom) {
           lastRowBottom = bottom;

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -395,6 +395,19 @@ export class TextEditor {
       return;
     }
 
+    // Guard: if the cursor references a block that no longer exists
+    // (e.g. deleted by a remote collaborator), reset to the first block.
+    if (!this.doc.findBlock(this.cursor.position.blockId)) {
+      const blocks = this.doc.getContextBlocks();
+      if (blocks.length > 0) {
+        this.cursor.moveTo({ blockId: blocks[0].id, offset: 0 });
+        this.selection.setRange(null);
+        this.invalidateLayout();
+        this.requestRender();
+      }
+      return;
+    }
+
     const { ctrlKey, metaKey, shiftKey, altKey } = e;
     const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
     const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
@@ -1840,6 +1853,21 @@ export class TextEditor {
     shiftKey: boolean,
     wordMod = false,
   ): void {
+    try {
+      this.handleArrowInner(direction, shiftKey, wordMod);
+    } catch {
+      // Stale blockParentMap data (e.g. table rows removed by remote edit).
+      // Rebuild layout so the next keypress has fresh data.
+      this.invalidateLayout();
+      this.requestRender();
+    }
+  }
+
+  private handleArrowInner(
+    direction: 'left' | 'right' | 'up' | 'down',
+    shiftKey: boolean,
+    wordMod = false,
+  ): void {
     const pos = this.cursor.position;
 
     // Table cell arrow key handling: keep cursor within cell boundaries
@@ -3179,9 +3207,27 @@ export class TextEditor {
           const crossPageResult = paginatedPixelToPosition(
             paginatedLayout, layout, pixel.x, targetY, canvasWidth,
           );
-          if (crossPageResult) {
+          if (crossPageResult
+              && !(crossPageResult.blockId === pos.blockId && crossPageResult.offset === pos.offset)) {
             this.cursor.lineAffinity = crossPageResult.lineAffinity;
             return crossPageResult;
+          }
+          // Cross-page pixel lookup returned the same position (e.g. the
+          // adjacent page only contains a tall table block). Fall back to
+          // the block on that page line and enter the table if applicable.
+          const fallbackBlock = layout.blocks[targetLine.blockIndex]?.block;
+          if (fallbackBlock?.type === 'table' && fallbackBlock.tableData) {
+            const td = fallbackBlock.tableData;
+            if (direction === -1) {
+              const lastRow = td.rows.length - 1;
+              const lastCol = td.columnWidths.length - 1;
+              const lastCell = td.rows[lastRow].cells[lastCol];
+              const lastCellBlock = lastCell.blocks[lastCell.blocks.length - 1];
+              return { blockId: lastCellBlock.id, offset: Math.min(pos.offset, getBlockTextLength(lastCellBlock)) };
+            } else {
+              const firstCellBlock = td.rows[0].cells[0].blocks[0];
+              return { blockId: firstCellBlock.id, offset: Math.min(pos.offset, getBlockTextLength(firstCellBlock)) };
+            }
           }
           return pos;
         }

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1929,9 +1929,7 @@ export class TextEditor {
       } else if (direction === 'up') {
         const tableBlock = this.doc.getBlock(tableBlockId);
         const cell = tableBlock.tableData!.rows[arrowCellInfo.rowIndex].cells[arrowCellInfo.colIndex];
-        const tl = this.doc.getParentTableBlock(pos.blockId)
-          ? undefined
-          : this.getLayout().blocks.find(b => b.block.id === tableBlockId)?.layoutTable;
+        const tl = this.getLayout().blocks.find(b => b.block.id === tableBlockId)?.layoutTable;
         const layoutCell = tl?.cells[arrowCellInfo.rowIndex]?.[arrowCellInfo.colIndex];
 
         // Try line-by-line navigation within the cell first

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -3635,13 +3635,25 @@ export class TextEditor {
       const blockIndex = layout.blocks.indexOf(lb);
 
       // Cache ownerRow → page Y + pl.y so we avoid an O(pages*lines)
-      // lookup per click.
-      const rowPageInfo = new Map<number, { pageY: number; plY: number }>();
+      // lookup per click. For split rows, prefer the fragment whose
+      // visible range contains the click Y (multiple PageLines share
+      // the same lineIndex).
+      const rowPageInfo = new Map<number, { pageY: number; plY: number; splitOffset: number }>();
       for (const page of paginatedLayout.pages) {
         const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
         for (const pl of page.lines) {
           if (pl.blockIndex !== blockIndex) continue;
-          rowPageInfo.set(pl.lineIndex, { pageY, plY: pl.y });
+          const existing = rowPageInfo.get(pl.lineIndex);
+          if (!existing) {
+            rowPageInfo.set(pl.lineIndex, { pageY, plY: pl.y, splitOffset: pl.rowSplitOffset ?? 0 });
+          } else if (logicalY !== undefined && pl.rowSplitOffset !== undefined) {
+            // Split fragment: use the one whose page contains the click
+            const fragTop = pageY + pl.y;
+            const fragBottom = fragTop + (pl.rowSplitHeight ?? pl.line.height);
+            if (logicalY >= fragTop && logicalY < fragBottom) {
+              rowPageInfo.set(pl.lineIndex, { pageY, plY: pl.y, splitOffset: pl.rowSplitOffset });
+            }
+          }
         }
       }
 
@@ -3651,7 +3663,7 @@ export class TextEditor {
         const info = rowPageInfo.get(ll.ownerRow);
         if (!info) continue;
         const lineAbsY =
-          info.pageY + info.plY + (ll.runLineY - tl.rowYOffsets[ll.ownerRow]);
+          info.pageY + info.plY + (ll.runLineY - tl.rowYOffsets[ll.ownerRow]) - info.splitOffset;
         if (logicalY < lineAbsY + cell.lines[li].height) {
           targetLineIdx = li;
           break;

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1927,9 +1927,24 @@ export class TextEditor {
           }
         }
       } else if (direction === 'up') {
-        // Find previous block in the same cell
         const tableBlock = this.doc.getBlock(tableBlockId);
         const cell = tableBlock.tableData!.rows[arrowCellInfo.rowIndex].cells[arrowCellInfo.colIndex];
+        const tl = this.doc.getParentTableBlock(pos.blockId)
+          ? undefined
+          : this.getLayout().blocks.find(b => b.block.id === tableBlockId)?.layoutTable;
+        const layoutCell = tl?.cells[arrowCellInfo.rowIndex]?.[arrowCellInfo.colIndex];
+
+        // Try line-by-line navigation within the cell first
+        if (layoutCell && !layoutCell.merged) {
+          const prevLine = this.moveCellLine(pos, layoutCell, cell, -1);
+          if (prevLine) {
+            newPos = prevLine;
+            // Skip the block-level fallback below
+          }
+        }
+
+        if (!newPos) {
+        // Fall back to block/cell navigation
         const blockIdx = cell.blocks.findIndex(b => b.id === pos.blockId);
         if (blockIdx > 0) {
           const prevBlock = cell.blocks[blockIdx - 1];
@@ -2015,9 +2030,22 @@ export class TextEditor {
             }
           }
         }
+        } // end if (!newPos)
       } else if (direction === 'down') {
         const tableBlock = this.doc.getBlock(tableBlockId);
         const cell = tableBlock.tableData!.rows[arrowCellInfo.rowIndex].cells[arrowCellInfo.colIndex];
+        const tl2 = this.getLayout().blocks.find(b => b.block.id === tableBlockId)?.layoutTable;
+        const layoutCell2 = tl2?.cells[arrowCellInfo.rowIndex]?.[arrowCellInfo.colIndex];
+
+        // Try line-by-line navigation within the cell first
+        if (layoutCell2 && !layoutCell2.merged) {
+          const nextLine = this.moveCellLine(pos, layoutCell2, cell, 1);
+          if (nextLine) {
+            newPos = nextLine;
+          }
+        }
+
+        if (!newPos) {
         const blockIdx = cell.blocks.findIndex(b => b.id === pos.blockId);
         if (blockIdx < cell.blocks.length - 1) {
           const nextBlock = cell.blocks[blockIdx + 1];
@@ -2101,6 +2129,7 @@ export class TextEditor {
             }
           }
         }
+        } // end if (!newPos) for down
       }
 
       if (newPos) {
@@ -2406,6 +2435,74 @@ export class TextEditor {
 
   private getCellInfo(blockId: string): BlockCellInfo | undefined {
     return this.getLayout().blockParentMap.get(blockId);
+  }
+
+  /**
+   * Move the cursor one visual line up (direction=-1) or down (direction=1)
+   * within a table cell. Returns undefined if already at the first/last line
+   * of the cell, so the caller can fall back to block/cell navigation.
+   */
+  private moveCellLine(
+    pos: DocPosition,
+    layoutCell: import('./table-layout.js').LayoutTableCell,
+    cell: import('../model/types.js').TableCell,
+    direction: -1 | 1,
+  ): DocPosition | undefined {
+    // Find which cell line the cursor is on
+    const blockIdx = cell.blocks.findIndex(b => b.id === pos.blockId);
+    if (blockIdx < 0) return undefined;
+
+    const lineStart = layoutCell.blockBoundaries[blockIdx] ?? 0;
+    const lineEnd = layoutCell.blockBoundaries[blockIdx + 1] ?? layoutCell.lines.length;
+
+    // Find the current line within this block
+    let remaining = pos.offset;
+    let currentLine = lineStart;
+    for (let li = lineStart; li < lineEnd; li++) {
+      let lineChars = 0;
+      for (const run of layoutCell.lines[li].runs) lineChars += run.text.length;
+      if (remaining <= lineChars) {
+        currentLine = li;
+        break;
+      }
+      remaining -= lineChars;
+      currentLine = li;
+    }
+
+    const targetLine = currentLine + direction;
+
+    // Check bounds: can we move within the cell's lines?
+    if (targetLine < 0 || targetLine >= layoutCell.lines.length) return undefined;
+
+    // If the target line is in a different block, compute the new position
+    // within that block.
+    let targetBlockIdx = blockIdx;
+    for (let bi = layoutCell.blockBoundaries.length - 1; bi >= 0; bi--) {
+      if (targetLine >= (layoutCell.blockBoundaries[bi] ?? 0)) {
+        targetBlockIdx = bi;
+        break;
+      }
+    }
+    const targetBlock = cell.blocks[targetBlockIdx];
+    if (!targetBlock) return undefined;
+
+    // Skip nested table lines — fall back to block navigation
+    if (layoutCell.lines[targetLine].nestedTable) return undefined;
+
+    // Compute character offset: count chars from target block start to
+    // target line, then clamp the cursor's column position to the line length.
+    const targetLineStart = layoutCell.blockBoundaries[targetBlockIdx] ?? 0;
+    let charsBeforeTargetLine = 0;
+    for (let li = targetLineStart; li < targetLine; li++) {
+      for (const run of layoutCell.lines[li].runs) charsBeforeTargetLine += run.text.length;
+    }
+    let targetLineChars = 0;
+    for (const run of layoutCell.lines[targetLine].runs) targetLineChars += run.text.length;
+
+    // `remaining` is the cursor's column position within the current line
+    const offset = charsBeforeTargetLine + Math.min(remaining, targetLineChars);
+
+    return { blockId: targetBlock.id, offset };
   }
 
   /**

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -2460,14 +2460,22 @@ export class TextEditor {
     const lineStart = layoutCell.blockBoundaries[blockIdx] ?? 0;
     const lineEnd = layoutCell.blockBoundaries[blockIdx + 1] ?? layoutCell.lines.length;
 
-    // Find the current line within this block
+    // Find the current line within this block, respecting lineAffinity
+    // so that at a wrap boundary the cursor stays on the correct visual line.
     let remaining = pos.offset;
     let currentLine = lineStart;
     for (let li = lineStart; li < lineEnd; li++) {
       let lineChars = 0;
       for (const run of layoutCell.lines[li].runs) lineChars += run.text.length;
-      if (remaining <= lineChars) {
+      if (remaining < lineChars || (remaining === lineChars && li === lineEnd - 1)) {
         currentLine = li;
+        break;
+      }
+      // At a wrap boundary with forward affinity, the cursor belongs to
+      // the next line — keep iterating.
+      if (remaining === lineChars && this.cursor.lineAffinity === 'forward' && li < lineEnd - 1) {
+        remaining = 0;
+        currentLine = li + 1;
         break;
       }
       remaining -= lineChars;

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1035,7 +1035,14 @@ export class TextEditor {
         const cellAddr = this.resolveTableCellClick(pos.blockId, mouseX, mouseY);
         if (cellAddr) {
           const tableBlock = this.doc.getBlock(pos.blockId);
-          const cell = tableBlock.tableData!.rows[cellAddr.rowIndex].cells[cellAddr.colIndex];
+          const cellRow = tableBlock.tableData?.rows[cellAddr.rowIndex];
+          if (!cellRow) {
+            this.cursor.moveTo(pos);
+            this.selection.setRange(null);
+            this.requestRender();
+            return;
+          }
+          const cell = cellRow.cells[cellAddr.colIndex];
 
           if (this.clickCount === 3) {
             // Triple-click: select all text in the clicked cell block
@@ -2658,8 +2665,33 @@ export class TextEditor {
     } else {
       // Multi-block structural change — force full layout recompute
       this.invalidateLayout();
-      // Delete from start to end of first block
+
+      // Check if entire document is selected (all blocks from first to last,
+      // at offset 0 and end). Replace with a single empty paragraph.
+      const blocks = this.doc.document.blocks;
       const firstBlock = this.doc.getBlock(start.blockId);
+      const lastBlock = this.doc.getBlock(end.blockId);
+      const isFullSelection = startBlockIdx === 0
+        && endBlockIdx === blocks.length - 1
+        && start.offset === 0
+        && end.offset === getBlockTextLength(lastBlock);
+
+      if (isFullSelection) {
+        // Replace everything with a single empty paragraph
+        const emptyBlock = createBlock();
+        this.doc.insertBlockAt(0, emptyBlock);
+        // Remove all original blocks (now shifted to indices 1..length-1)
+        const remaining = this.doc.document.blocks.length;
+        for (let i = remaining - 1; i > 0; i--) {
+          this.doc.deleteBlockByIndex(i);
+        }
+        this.cursor.moveTo({ blockId: emptyBlock.id, offset: 0 });
+        this.selection.setRange(null);
+        this.requestRender();
+        return true;
+      }
+
+      // Delete from start to end of first block
       const firstLen = getBlockTextLength(firstBlock);
       if (start.offset < firstLen) {
         this.doc.deleteText(start, firstLen - start.offset);
@@ -3599,6 +3631,7 @@ export class TextEditor {
   ): CellAddress | undefined {
     const block = this.doc.document.blocks.find((b) => b.id === blockId);
     if (!block || block.type !== 'table' || !block.tableData) return undefined;
+    if (block.tableData.rows.length === 0) return undefined;
     const layout = this.getLayout();
     const paginatedLayout = this.getPaginatedLayout();
     const lb = layout.blocks.find((b) => b.block.id === blockId);
@@ -3734,20 +3767,20 @@ export class TextEditor {
       // lookup per click. For split rows, prefer the fragment whose
       // visible range contains the click Y (multiple PageLines share
       // the same lineIndex).
-      const rowPageInfo = new Map<number, { pageY: number; plY: number; splitOffset: number }>();
+      const rowPageInfo = new Map<number, { pageY: number; plY: number; splitOffset: number; splitHeight: number | undefined }>();
       for (const page of paginatedLayout.pages) {
         const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
         for (const pl of page.lines) {
           if (pl.blockIndex !== blockIndex) continue;
           const existing = rowPageInfo.get(pl.lineIndex);
           if (!existing) {
-            rowPageInfo.set(pl.lineIndex, { pageY, plY: pl.y, splitOffset: pl.rowSplitOffset ?? 0 });
+            rowPageInfo.set(pl.lineIndex, { pageY, plY: pl.y, splitOffset: pl.rowSplitOffset ?? 0, splitHeight: pl.rowSplitHeight });
           } else if (logicalY !== undefined && pl.rowSplitOffset !== undefined) {
             // Split fragment: use the one whose page contains the click
             const fragTop = pageY + pl.y;
             const fragBottom = fragTop + (pl.rowSplitHeight ?? pl.line.height);
             if (logicalY >= fragTop && logicalY < fragBottom) {
-              rowPageInfo.set(pl.lineIndex, { pageY, plY: pl.y, splitOffset: pl.rowSplitOffset });
+              rowPageInfo.set(pl.lineIndex, { pageY, plY: pl.y, splitOffset: pl.rowSplitOffset, splitHeight: pl.rowSplitHeight });
             }
           }
         }
@@ -3763,6 +3796,30 @@ export class TextEditor {
         if (logicalY < lineAbsY + cell.lines[li].height) {
           targetLineIdx = li;
           break;
+        }
+      }
+
+      // Clamp to visible lines in the clicked fragment. When the loop
+      // falls through (click below all visible lines in a split fragment),
+      // targetLineIdx defaults to the last cell line which may be on a
+      // different page. Restrict it to lines within the fragment bounds.
+      const clickedRowInfo = rowPageInfo.get(lineLayouts[targetLineIdx]?.ownerRow ?? cellAddr.rowIndex);
+      if (clickedRowInfo?.splitHeight !== undefined) {
+        const splitEnd = clickedRowInfo.splitOffset + clickedRowInfo.splitHeight;
+        const lineInRow = lineLayouts[targetLineIdx]
+          ? lineLayouts[targetLineIdx].runLineY - tl.rowYOffsets[lineLayouts[targetLineIdx].ownerRow]
+          : 0;
+        if (lineInRow >= splitEnd || lineInRow + cell.lines[targetLineIdx]?.height <= clickedRowInfo.splitOffset) {
+          // Target line is outside the visible fragment — find the last visible line
+          let lastVisible = 0;
+          for (let li = 0; li < cell.lines.length; li++) {
+            const ll = lineLayouts[li];
+            const inRow = ll.runLineY - tl.rowYOffsets[ll.ownerRow];
+            if (inRow >= clickedRowInfo.splitOffset && inRow < splitEnd) {
+              lastVisible = li;
+            }
+          }
+          targetLineIdx = lastVisible;
         }
       }
     }
@@ -3809,19 +3866,28 @@ export class TextEditor {
         let innerRow = innerLayout.rowHeights.length - 1;
         let innerTableAbsY = 0;
         if (logicalY !== undefined) {
-          // Compute the inner table's absolute Y origin
+          // Compute the inner table's absolute Y origin, accounting for
+          // split rows by picking the fragment that contains the click Y.
           const lineLayouts = computeMergedCellLineLayouts(
             cell.lines, cellAddr.rowIndex, dataCell?.rowSpan ?? 1,
             cellPadding, tl.rowYOffsets, tl.rowHeights,
           );
           const ll = lineLayouts[targetLineIdx];
           const blockIndex = layout.blocks.indexOf(lb);
-          for (const page of paginatedLayout.pages) {
+          findInnerTableY: for (const page of paginatedLayout.pages) {
             const pageY = getPageYOffset(paginatedLayout, page.pageIndex);
             for (const pl of page.lines) {
               if (pl.blockIndex === blockIndex && pl.lineIndex === ll.ownerRow) {
-                innerTableAbsY = pageY + pl.y + (ll.runLineY - tl.rowYOffsets[ll.ownerRow]);
-                break;
+                const splitOff = pl.rowSplitOffset ?? 0;
+                innerTableAbsY = pageY + pl.y + (ll.runLineY - tl.rowYOffsets[ll.ownerRow]) - splitOff;
+                // For split rows, check if the click falls within this fragment
+                if (pl.rowSplitHeight !== undefined) {
+                  const fragTop = pageY + pl.y;
+                  const fragBottom = fragTop + pl.rowSplitHeight;
+                  if (logicalY >= fragTop && logicalY < fragBottom) break findInnerTableY;
+                  continue; // try next fragment
+                }
+                break findInnerTableY;
               }
             }
           }
@@ -3878,8 +3944,16 @@ export class TextEditor {
           // Check for further nesting (recursive)
           const innerTargetLine = innerCellLayout.lines[innerLineIdx];
           if (innerTargetLine?.nestedTable) {
-            // For deeper nesting, fall through to first block of inner cell
-            return { blockId: innerCellData.blocks[0].id, offset: 0 };
+            // For deeper nesting, resolve to the block that owns this line
+            let deepBlockIdx = 0;
+            for (let bi = 0; bi < innerCellLayout.blockBoundaries.length; bi++) {
+              const nextBound = innerCellLayout.blockBoundaries[bi + 1] ?? innerCellLayout.lines.length;
+              if (innerLineIdx < nextBound) {
+                deepBlockIdx = bi;
+                break;
+              }
+            }
+            return { blockId: innerCellData.blocks[deepBlockIdx]?.id ?? innerCellData.blocks[0].id, offset: 0 };
           }
 
           // Find block index within inner cell

--- a/packages/docs/test/view/table-row-split.test.ts
+++ b/packages/docs/test/view/table-row-split.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { computeTableLayout, getCellContentBreakpoints } from '../../src/view/table-layout.js';
-import { createTableBlock } from '../../src/model/types.js';
+import { createTableBlock, DEFAULT_PAGE_SETUP, getEffectiveDimensions } from '../../src/model/types.js';
+import { computeLayout } from '../../src/view/layout.js';
+import { paginateLayout } from '../../src/view/pagination.js';
 
 function stubCtx(): CanvasRenderingContext2D {
   return {
@@ -70,5 +72,63 @@ describe('getCellContentBreakpoints', () => {
     const breakpoints = getCellContentBreakpoints(layout, 0);
     // Should still return breakpoints from the single non-merged cell
     expect(Array.isArray(breakpoints)).toBe(true);
+  });
+});
+
+describe('paginateLayout — row splitting', () => {
+  function stubCtxWide(): CanvasRenderingContext2D {
+    return {
+      font: '',
+      measureText: (text: string) => ({ width: text.length * 7 }),
+    } as unknown as CanvasRenderingContext2D;
+  }
+
+  it('splits a tall single-row table across pages', () => {
+    // DEFAULT_PAGE_SETUP: 1056px tall, 96px top/bottom margins → 864px content height
+    const setup = DEFAULT_PAGE_SETUP;
+    const { width, height: pageHeight } = getEffectiveDimensions(setup);
+    const contentHeight = pageHeight - setup.margins.top - setup.margins.bottom;
+    const contentWidth = width - setup.margins.left - setup.margins.right;
+
+    // Build a 1×1 table whose single cell has enough paragraph blocks to
+    // exceed one page's content height (each paragraph ~24px → need > 36 paragraphs)
+    const tableBlock = createTableBlock(1, 1);
+    const td = tableBlock.tableData!;
+    const cell = td.rows[0].cells[0];
+
+    // Add 40 paragraph blocks (each will produce ~24px lines at 7px/char width)
+    cell.blocks = [];
+    for (let i = 0; i < 40; i++) {
+      cell.blocks.push({
+        id: `p${i}`,
+        type: 'paragraph',
+        inlines: [{ text: `Paragraph line number ${i} with some text content`, style: {} }],
+        style: { alignment: 'left', lineHeight: 1.5, marginTop: 0, marginBottom: 8, textIndent: 0, marginLeft: 0 },
+      });
+    }
+
+    const ctx = stubCtxWide();
+    const { layout } = computeLayout([tableBlock], ctx, contentWidth);
+    const result = paginateLayout(layout, setup);
+
+    // Should span at least 2 pages due to tall row
+    expect(result.pages.length).toBeGreaterThanOrEqual(2);
+
+    // First page must have at least one PageLine for the row with rowSplitOffset === 0
+    const firstPageLines = result.pages[0].lines.filter(
+      (pl) => pl.rowSplitOffset !== undefined,
+    );
+    expect(firstPageLines.length).toBeGreaterThan(0);
+    const firstFragment = firstPageLines[0];
+    expect(firstFragment.rowSplitOffset).toBe(0);
+    expect(firstFragment.rowSplitHeight).toBeDefined();
+    expect(firstFragment.rowSplitHeight).toBeGreaterThan(0);
+    expect(firstFragment.rowSplitHeight).toBeLessThanOrEqual(contentHeight);
+
+    // Second page must have a PageLine for the same row with rowSplitOffset > 0
+    const secondPageLines = result.pages[1].lines.filter(
+      (pl) => pl.rowSplitOffset !== undefined && pl.rowSplitOffset > 0,
+    );
+    expect(secondPageLines.length).toBeGreaterThan(0);
   });
 });

--- a/packages/docs/test/view/table-row-split.test.ts
+++ b/packages/docs/test/view/table-row-split.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeTableLayout, getCellContentBreakpoints } from '../../src/view/table-layout.js';
+import { computeTableLayout, findRowSplitHeight } from '../../src/view/table-layout.js';
 import { createTableBlock, DEFAULT_PAGE_SETUP, getEffectiveDimensions } from '../../src/model/types.js';
 import { computeLayout } from '../../src/view/layout.js';
 import { paginateLayout } from '../../src/view/pagination.js';
@@ -11,8 +11,8 @@ function stubCtx(): CanvasRenderingContext2D {
   } as unknown as CanvasRenderingContext2D;
 }
 
-describe('getCellContentBreakpoints', () => {
-  it('returns cumulative line heights for a single-cell row', () => {
+describe('findRowSplitHeight', () => {
+  it('returns safe split height for a single-cell row', () => {
     const block = createTableBlock(1, 1);
     const td = block.tableData!;
     td.rows[0].cells[0].blocks[0].inlines = [
@@ -21,57 +21,44 @@ describe('getCellContentBreakpoints', () => {
     ];
     const ctx = stubCtx();
     const layout = computeTableLayout(td, 'tbl', ctx, 200);
-    const breakpoints = getCellContentBreakpoints(layout, 0);
+    const splitH = findRowSplitHeight(layout, 0, 100);
 
-    expect(breakpoints.length).toBeGreaterThan(0);
-    for (let i = 1; i < breakpoints.length; i++) {
-      expect(breakpoints[i]).toBeGreaterThan(breakpoints[i - 1]);
-    }
+    // Should find a split point within available height
+    expect(splitH).toBeGreaterThan(0);
+    expect(splitH).toBeLessThanOrEqual(100);
   });
 
-  it('returns empty array for out-of-bounds row index', () => {
+  it('returns 0 for out-of-bounds row index', () => {
     const block = createTableBlock(1, 1);
     const td = block.tableData!;
     td.rows[0].cells[0].blocks[0].inlines = [{ text: 'hello', style: {} }];
     const ctx = stubCtx();
     const layout = computeTableLayout(td, 'tbl', ctx, 200);
-    expect(getCellContentBreakpoints(layout, 5)).toEqual([]);
+    expect(findRowSplitHeight(layout, 5, 100)).toBe(0);
   });
 
-  it('returns only common breakpoints across multiple columns', () => {
-    // Two-column table: left cell has 1 line, right cell has 2 lines
-    // Only the height after the first line of both cells can be a shared breakpoint
+  it('handles multi-column rows with different line heights', () => {
     const block = createTableBlock(1, 2);
     const td = block.tableData!;
-    // Left cell: single short text (likely 1 line)
     td.rows[0].cells[0].blocks[0].inlines = [{ text: 'A', style: {} }];
-    // Right cell: same short text (same height → same break)
     td.rows[0].cells[1].blocks[0].inlines = [{ text: 'B', style: {} }];
     const ctx = stubCtx();
     const layout = computeTableLayout(td, 'tbl', ctx, 200);
-    const breakpoints = getCellContentBreakpoints(layout, 0);
+    const splitH = findRowSplitHeight(layout, 0, 100);
 
-    // All breakpoints must be strictly ascending
-    for (let i = 1; i < breakpoints.length; i++) {
-      expect(breakpoints[i]).toBeGreaterThan(breakpoints[i - 1]);
-    }
+    // Should return a safe height (min of per-cell breakpoints)
+    expect(splitH).toBeGreaterThanOrEqual(0);
   });
 
-  it('returns empty array for merged cells row with no non-merged cells', () => {
-    const block = createTableBlock(1, 2);
+  it('returns 0 when no line fits in available height', () => {
+    const block = createTableBlock(1, 1);
     const td = block.tableData!;
-    // Simulate a covered cell scenario by marking both as merged is not
-    // directly possible with just colSpan=0, but we can test with a
-    // row that has no content if cells are set to merged pattern.
-    td.rows[0].cells[0].colSpan = 2;
-    td.rows[0].cells[1].colSpan = 0;
-    td.rows[0].cells[1].blocks = [];
+    td.rows[0].cells[0].blocks[0].inlines = [{ text: 'hello', style: {} }];
     const ctx = stubCtx();
     const layout = computeTableLayout(td, 'tbl', ctx, 200);
-    // Row 0 has 1 non-merged cell (col 0 with colSpan=2) and 1 merged (col 1)
-    const breakpoints = getCellContentBreakpoints(layout, 0);
-    // Should still return breakpoints from the single non-merged cell
-    expect(Array.isArray(breakpoints)).toBe(true);
+    // Available height smaller than padding + first line
+    const splitH = findRowSplitHeight(layout, 0, 1);
+    expect(splitH).toBe(0);
   });
 });
 

--- a/packages/docs/test/view/table-row-split.test.ts
+++ b/packages/docs/test/view/table-row-split.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { computeTableLayout, getCellContentBreakpoints } from '../../src/view/table-layout.js';
+import { createTableBlock } from '../../src/model/types.js';
+
+function stubCtx(): CanvasRenderingContext2D {
+  return {
+    font: '',
+    measureText: (text: string) => ({ width: text.length * 7 }),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+describe('getCellContentBreakpoints', () => {
+  it('returns cumulative line heights for a single-cell row', () => {
+    const block = createTableBlock(1, 1);
+    const td = block.tableData!;
+    td.rows[0].cells[0].blocks[0].inlines = [
+      { text: 'Line 1 text here', style: {} },
+      { text: ' and more text', style: {} },
+    ];
+    const ctx = stubCtx();
+    const layout = computeTableLayout(td, 'tbl', ctx, 200);
+    const breakpoints = getCellContentBreakpoints(layout, 0);
+
+    expect(breakpoints.length).toBeGreaterThan(0);
+    for (let i = 1; i < breakpoints.length; i++) {
+      expect(breakpoints[i]).toBeGreaterThan(breakpoints[i - 1]);
+    }
+  });
+
+  it('returns empty array for out-of-bounds row index', () => {
+    const block = createTableBlock(1, 1);
+    const td = block.tableData!;
+    td.rows[0].cells[0].blocks[0].inlines = [{ text: 'hello', style: {} }];
+    const ctx = stubCtx();
+    const layout = computeTableLayout(td, 'tbl', ctx, 200);
+    expect(getCellContentBreakpoints(layout, 5)).toEqual([]);
+  });
+
+  it('returns only common breakpoints across multiple columns', () => {
+    // Two-column table: left cell has 1 line, right cell has 2 lines
+    // Only the height after the first line of both cells can be a shared breakpoint
+    const block = createTableBlock(1, 2);
+    const td = block.tableData!;
+    // Left cell: single short text (likely 1 line)
+    td.rows[0].cells[0].blocks[0].inlines = [{ text: 'A', style: {} }];
+    // Right cell: same short text (same height → same break)
+    td.rows[0].cells[1].blocks[0].inlines = [{ text: 'B', style: {} }];
+    const ctx = stubCtx();
+    const layout = computeTableLayout(td, 'tbl', ctx, 200);
+    const breakpoints = getCellContentBreakpoints(layout, 0);
+
+    // All breakpoints must be strictly ascending
+    for (let i = 1; i < breakpoints.length; i++) {
+      expect(breakpoints[i]).toBeGreaterThan(breakpoints[i - 1]);
+    }
+  });
+
+  it('returns empty array for merged cells row with no non-merged cells', () => {
+    const block = createTableBlock(1, 2);
+    const td = block.tableData!;
+    // Simulate a covered cell scenario by marking both as merged is not
+    // directly possible with just colSpan=0, but we can test with a
+    // row that has no content if cells are set to merged pattern.
+    td.rows[0].cells[0].colSpan = 2;
+    td.rows[0].cells[1].colSpan = 0;
+    td.rows[0].cells[1].blocks = [];
+    const ctx = stubCtx();
+    const layout = computeTableLayout(td, 'tbl', ctx, 200);
+    // Row 0 has 1 non-merged cell (col 0 with colSpan=2) and 1 merged (col 1)
+    const breakpoints = getCellContentBreakpoints(layout, 0);
+    // Should still return breakpoints from the single non-merged cell
+    expect(Array.isArray(breakpoints)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Split tall table rows across page boundaries so content renders continuously
- Fix click resolution, cursor placement, and cell selection for split rows with nested tables
- Fix nested table background rendering order so selection highlights remain visible
- Fix Cmd+A delete leaving empty table shells instead of empty paragraphs

## Key changes

**Row splitting** (`pagination.ts`, `table-layout.ts`, `table-renderer.ts`, `doc-canvas.ts`):
- Extend `PageLine` with `rowSplitOffset`/`rowSplitHeight` metadata
- Detect rows exceeding page space and compute safe split heights
- Render split fragments with clipping and re-drawn borders per page

**Click resolution** (`text-editor.ts`):
- Use labeled break (`break findInnerTableY`) so nested table Y computation stops at the correct fragment
- Account for split offset in nested table inner row resolution
- Clamp target line to visible fragment bounds
- Return correct block for deeper nesting instead of always `blocks[0]`
- Guard against empty tables (rows=0) in click handling

**Cursor rendering** (`peer-cursor.ts`):
- Extract `findSplitFragment` helper for fragment selection
- Add straddling match for nested tables crossing split boundaries
- Clamp cursor Y to fragment top when straddling produces negative offset

**Selection highlighting** (`selection.ts`, `table-renderer.ts`):
- Recurse into nested tables during background pass so backgrounds don't cover selection highlights
- Support split row fragments in cell-range rects for both top-level and nested tables

**Other** (`text-editor.ts`):
- Cmd+A delete replaces everything with empty paragraph (not empty table shell)
- Line-by-line arrow navigation in table cells

## Test plan

- [ ] Open a document with tall table rows that span page boundaries
- [ ] Verify rows split across pages without blank space or clipping
- [ ] Click on cells in split row fragments — cursor appears on correct page
- [ ] Click on nested table cells within split rows — cursor appears at clicked position
- [ ] Select cells in nested tables on both pages — selection highlight visible on both
- [ ] Arrow Up/Down across split row boundaries moves cursor correctly
- [ ] Cmd+A then Delete produces empty paragraph, not empty table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tables can now split across page boundaries, allowing tall rows to span multiple pages instead of forcing oversized pages.
  * Enhanced cursor navigation and text selection for split table rows across page fragments.

* **Tests**
  * Added comprehensive test coverage for table row splitting during pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->