### PR TITLE
Redirect to document list when accessing a deleted document

### DIFF
--- a/packages/frontend/src/app/docs/docs-detail.tsx
+++ b/packages/frontend/src/app/docs/docs-detail.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { fetchMe } from "@/api/auth";
 import { fetchDocument, renameDocument } from "@/api/documents";
+import { toast } from "sonner";
 import { Loader } from "@/components/loader";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
@@ -55,9 +56,13 @@ function DocsLayout({ documentId }: { documentId: string }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
-  const { data: documentData } = useQuery({
+  const {
+    data: documentData,
+    isError: isDocumentError,
+  } = useQuery({
     queryKey: ["document", documentId],
     queryFn: () => fetchDocument(documentId),
+    retry: false,
   });
 
   useEffect(() => {
@@ -75,6 +80,15 @@ function DocsLayout({ documentId }: { documentId: string }) {
     (w) => w.id === documentData?.workspaceId,
   );
   const workspaceSlug = currentWorkspace?.slug;
+
+  useEffect(() => {
+    if (isDocumentError) {
+      toast.error("Document not found");
+      navigate(workspaceSlug ? `/w/${workspaceSlug}` : "/documents", {
+        replace: true,
+      });
+    }
+  }, [isDocumentError, navigate, workspaceSlug]);
 
   const items = useMemo(() => {
     if (workspaceSlug) {

--- a/packages/frontend/src/app/docs/docs-detail.tsx
+++ b/packages/frontend/src/app/docs/docs-detail.tsx
@@ -81,14 +81,16 @@ function DocsLayout({ documentId }: { documentId: string }) {
   );
   const workspaceSlug = currentWorkspace?.slug;
 
+  const fallbackSlug = workspaceSlug ?? workspaces[0]?.slug;
+
   useEffect(() => {
     if (isDocumentError) {
       toast.error("Document not found");
-      navigate(workspaceSlug ? `/w/${workspaceSlug}` : "/documents", {
+      navigate(fallbackSlug ? `/w/${fallbackSlug}` : "/documents", {
         replace: true,
       });
     }
-  }, [isDocumentError, navigate, workspaceSlug]);
+  }, [isDocumentError, navigate, fallbackSlug]);
 
   const items = useMemo(() => {
     if (workspaceSlug) {

--- a/packages/frontend/src/app/documents/document-detail.tsx
+++ b/packages/frontend/src/app/documents/document-detail.tsx
@@ -98,9 +98,13 @@ function DocumentLayout({ documentId }: { documentId: string }) {
 
   const navigate = useNavigate();
 
-  const { data: documentData } = useQuery({
+  const {
+    data: documentData,
+    isError: isDocumentError,
+  } = useQuery({
     queryKey: ["document", documentId],
     queryFn: () => fetchDocument(documentId),
+    retry: false,
   });
 
   useEffect(() => {
@@ -118,6 +122,15 @@ function DocumentLayout({ documentId }: { documentId: string }) {
     (w) => w.id === documentData?.workspaceId,
   );
   const workspaceSlug = currentWorkspace?.slug;
+
+  useEffect(() => {
+    if (isDocumentError) {
+      toast.error("Document not found");
+      navigate(workspaceSlug ? `/w/${workspaceSlug}` : "/documents", {
+        replace: true,
+      });
+    }
+  }, [isDocumentError, navigate, workspaceSlug]);
 
   const items = useMemo(() => {
     if (workspaceSlug) {

--- a/packages/frontend/src/app/documents/document-detail.tsx
+++ b/packages/frontend/src/app/documents/document-detail.tsx
@@ -123,14 +123,16 @@ function DocumentLayout({ documentId }: { documentId: string }) {
   );
   const workspaceSlug = currentWorkspace?.slug;
 
+  const fallbackSlug = workspaceSlug ?? workspaces[0]?.slug;
+
   useEffect(() => {
     if (isDocumentError) {
       toast.error("Document not found");
-      navigate(workspaceSlug ? `/w/${workspaceSlug}` : "/documents", {
+      navigate(fallbackSlug ? `/w/${fallbackSlug}` : "/documents", {
         replace: true,
       });
     }
-  }, [isDocumentError, navigate, workspaceSlug]);
+  }, [isDocumentError, navigate, fallbackSlug]);
 
   const items = useMemo(() => {
     if (workspaceSlug) {


### PR DESCRIPTION
## Summary
- When a deleted document was accessed via URL, the page rendered without workspace context because the document fetch failed silently
- Clicking "Documents" in that state showed all documents across all workspaces (no workspace filter)
- Added error handling to the document query: on fetch failure, shows a toast and redirects to the workspace document list

## Test plan
- [x] Delete a document, then access its URL directly — should redirect to document list with "Document not found" toast
- [x] Verify normal document access still works as expected
- [x] Verify sidebar "Documents" link points to the correct workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for document loading with notifications when documents cannot be found
  * Added automatic redirection to the workspace or documents page when document access fails, preventing users from being stuck on error states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->