### PR TITLE
Add intent-preserving cell span edits (Phase 6)

### DIFF
--- a/docs/design/docs/docs-intent-preserving-edits.md
+++ b/docs/design/docs/docs-intent-preserving-edits.md
@@ -123,7 +123,7 @@ divergence cannot be fully ruled out until these are resolved upstream.
 | 3 | Structural editing — split/merge (native CRDT, SDK 0.7.4) | ✅ Shipped |
 | 4 | Table cell internal edits (extend Phase 1–3) | ✅ Shipped |
 | 5 | Block/cell attribute edits (styleByPath) | ✅ Shipped |
-| 6 | Cell span attributes (styleByPath) | Planned |
+| 6 | Cell span attributes (styleByPath) | ✅ Shipped |
 | 7 | Table-level attributes (styleByPath on block) | Planned |
 | 8 | Cell structural edits (editByPath) | Planned |
 | 9 | Yorkie-native undo/redo (feature-flagged) | Planned |
@@ -186,11 +186,15 @@ All editing operations now route through intent-preserving store methods.
 Change `colSpan`/`rowSpan` attributes on cell nodes via `styleByPath`. Same
 pattern as Phase 5's `applyCellStyle`.
 
-| Call site | Trigger | Current method |
-|-----------|---------|----------------|
-| `deleteRow()` | rowSpan adjustment | `store.updateTableCell` |
-| `deleteColumn()` | colSpan adjustment | `store.updateTableCell` |
-| `splitCell()` | restore span on covered cells | `store.updateTableCell` |
+| Operation | Before | After |
+|-----------|--------|-------|
+| `deleteRow()` rowSpan adjust | `store.updateTableCell` (full cell replace) | `store.applyCellSpan` (styleByPath) |
+| `deleteColumn()` colSpan adjust | `store.updateTableCell` (full cell replace) | `store.applyCellSpan` (styleByPath) |
+| `splitCell()` top-left span clear | `store.updateTableCell` (full cell replace) | `store.applyCellSpan` (styleByPath) |
+
+`applyCellSpan` uses `styleByPath` to set span values and `removeStyleByPath`
+to clear them (value 1 = default = remove from tree). Covered cell block reset
+in `splitCell` still uses `updateTableCell` (Phase 8).
 
 ### Phase 7: Table-Level Attributes
 

--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -646,8 +646,8 @@ export class Doc {
         const cell = td.rows[r].cells[c];
         const rs = cell.rowSpan ?? 1;
         if (r + rs > rowIndex) {
-          cell.rowSpan = rs - 1;
-          this.store.updateTableCell(blockId, r, c, cell);
+          this.store.applyCellSpan(blockId, r, c, { rowSpan: rs - 1 });
+          cell.rowSpan = rs - 1 === 1 ? undefined : rs - 1;
         }
       }
     }
@@ -696,8 +696,8 @@ export class Doc {
         const cell = td.rows[ri].cells[c];
         const cs = cell.colSpan ?? 1;
         if (c + cs > colIndex) {
-          cell.colSpan = cs - 1;
-          this.store.updateTableCell(blockId, ri, c, cell);
+          this.store.applyCellSpan(blockId, ri, c, { colSpan: cs - 1 });
+          cell.colSpan = cs - 1 === 1 ? undefined : cs - 1;
         }
       }
     }
@@ -783,11 +783,12 @@ export class Doc {
     const rowSpan = target.rowSpan ?? 1;
     const colSpan = target.colSpan ?? 1;
 
-    // Clear merge on top-left
+    // Clear merge on top-left via intent-preserving span update
     delete target.colSpan;
     delete target.rowSpan;
+    this.store.applyCellSpan(blockId, cell.rowIndex, cell.colIndex, { colSpan: 1, rowSpan: 1 });
 
-    // Restore covered cells
+    // Restore covered cells (block reset + span clear)
     for (let r = cell.rowIndex; r < cell.rowIndex + rowSpan; r++) {
       for (let c = cell.colIndex; c < cell.colIndex + colSpan; c++) {
         if (r === cell.rowIndex && c === cell.colIndex) continue;
@@ -795,12 +796,7 @@ export class Doc {
         delete covered.colSpan;
         delete covered.rowSpan;
         covered.blocks = [{ id: generateBlockId(), type: 'paragraph', inlines: [{ text: '', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }];
-      }
-    }
-
-    for (let r = cell.rowIndex; r < cell.rowIndex + rowSpan; r++) {
-      for (let c = cell.colIndex; c < cell.colIndex + colSpan; c++) {
-        this.store.updateTableCell(blockId, r, c, td.rows[r].cells[c]);
+        this.store.updateTableCell(blockId, r, c, covered);
       }
     }
     this.refresh();

--- a/packages/docs/src/store/memory.ts
+++ b/packages/docs/src/store/memory.ts
@@ -235,6 +235,20 @@ export class MemDocStore implements DocStore {
     cell.style = { ...cell.style, ...style };
   }
 
+  applyCellSpan(
+    tableBlockId: string, rowIndex: number, colIndex: number,
+    span: { colSpan?: number; rowSpan?: number },
+  ): void {
+    const block = this.findBlock(tableBlockId);
+    const cell = block.tableData!.rows[rowIndex].cells[colIndex];
+    if (span.colSpan !== undefined) {
+      cell.colSpan = span.colSpan === 1 ? undefined : span.colSpan;
+    }
+    if (span.rowSpan !== undefined) {
+      cell.rowSpan = span.rowSpan === 1 ? undefined : span.rowSpan;
+    }
+  }
+
   insertImageInline(blockId: string, offset: number, inline: Inline): void {
     const { blocks, index } = this.findBlockInAnyArray(blockId);
     blocks[index] = applyInsertInline(blocks[index], offset, inline);

--- a/packages/docs/src/store/store.ts
+++ b/packages/docs/src/store/store.ts
@@ -88,6 +88,13 @@ export interface DocStore {
     tableBlockId: string, rowIndex: number, colIndex: number,
     style: Partial<CellStyle>,
   ): void;
+  /** Update colSpan/rowSpan on a cell node via styleByPath.
+   *  Value of 1 (default) removes the attribute from the tree.
+   *  Only specified properties are changed; omitted ones are untouched. */
+  applyCellSpan(
+    tableBlockId: string, rowIndex: number, colIndex: number,
+    span: { colSpan?: number; rowSpan?: number },
+  ): void;
   /** Insert an image inline at a block-level character offset. */
   insertImageInline(blockId: string, offset: number, inline: Inline): void;
 }

--- a/packages/docs/test/model/table.test.ts
+++ b/packages/docs/test/model/table.test.ts
@@ -92,6 +92,35 @@ describe('Doc table operations', () => {
       doc.deleteRow(tableId, 1);
       expect(doc.getBlock(tableId).tableData!.rows).toHaveLength(2);
     });
+
+    it('should decrement rowSpan when deleting a row spanned by a cell above', () => {
+      const doc = Doc.create();
+      const tableId = doc.insertTable(0, 3, 2);
+      // Merge rows 0-1 in column 0
+      doc.mergeCells(tableId, { start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 1, colIndex: 0 } });
+      const block = doc.getBlock(tableId);
+      expect(block.tableData!.rows[0].cells[0].rowSpan).toBe(2);
+
+      // Delete row 1 — rowSpan should shrink to 1 (removed)
+      doc.deleteRow(tableId, 1);
+      const after = doc.getBlock(tableId);
+      expect(after.tableData!.rows).toHaveLength(2);
+      expect(after.tableData!.rows[0].cells[0].rowSpan).toBeUndefined();
+    });
+
+    it('should decrement rowSpan from 3 to 2 when deleting a middle spanned row', () => {
+      const doc = Doc.create();
+      const tableId = doc.insertTable(0, 4, 2);
+      // Merge rows 0-2 in column 0 (rowSpan=3)
+      doc.mergeCells(tableId, { start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 2, colIndex: 0 } });
+      expect(doc.getBlock(tableId).tableData!.rows[0].cells[0].rowSpan).toBe(3);
+
+      // Delete row 1 — rowSpan should shrink to 2
+      doc.deleteRow(tableId, 1);
+      const after = doc.getBlock(tableId);
+      expect(after.tableData!.rows).toHaveLength(3);
+      expect(after.tableData!.rows[0].cells[0].rowSpan).toBe(2);
+    });
   });
 
   describe('insertColumn', () => {
@@ -117,6 +146,34 @@ describe('Doc table operations', () => {
       expect(block.tableData!.rows[0].cells).toHaveLength(2);
       const sum = block.tableData!.columnWidths.reduce((a, b) => a + b, 0);
       expect(sum).toBeCloseTo(1.0);
+    });
+
+    it('should decrement colSpan when deleting a column spanned by a cell to the left', () => {
+      const doc = Doc.create();
+      const tableId = doc.insertTable(0, 2, 3);
+      // Merge columns 0-1 in row 0
+      doc.mergeCells(tableId, { start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 0, colIndex: 1 } });
+      expect(doc.getBlock(tableId).tableData!.rows[0].cells[0].colSpan).toBe(2);
+
+      // Delete column 1 — colSpan should shrink to 1 (removed)
+      doc.deleteColumn(tableId, 1);
+      const after = doc.getBlock(tableId);
+      expect(after.tableData!.columnWidths).toHaveLength(2);
+      expect(after.tableData!.rows[0].cells[0].colSpan).toBeUndefined();
+    });
+
+    it('should decrement colSpan from 3 to 2 when deleting a middle spanned column', () => {
+      const doc = Doc.create();
+      const tableId = doc.insertTable(0, 2, 4);
+      // Merge columns 0-2 in row 0 (colSpan=3)
+      doc.mergeCells(tableId, { start: { rowIndex: 0, colIndex: 0 }, end: { rowIndex: 0, colIndex: 2 } });
+      expect(doc.getBlock(tableId).tableData!.rows[0].cells[0].colSpan).toBe(3);
+
+      // Delete column 1 — colSpan should shrink to 2
+      doc.deleteColumn(tableId, 1);
+      const after = doc.getBlock(tableId);
+      expect(after.tableData!.columnWidths).toHaveLength(3);
+      expect(after.tableData!.rows[0].cells[0].colSpan).toBe(2);
     });
   });
 

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -1678,6 +1678,59 @@ export class YorkieDocStore implements DocStore {
     this.dirty = false;
   }
 
+  applyCellSpan(
+    tableBlockId: string, rowIndex: number, colIndex: number,
+    span: { colSpan?: number; rowSpan?: number },
+  ): void {
+    const tablePath = this.resolveTableTreePath(tableBlockId);
+    const currentDoc = this.getDocument();
+    const block = this.resolveTableBlock(tablePath, currentDoc);
+    const cell = block.tableData!.rows[rowIndex].cells[colIndex];
+
+    const cellPath = [...tablePath, rowIndex, colIndex];
+    const attrsToSet: Record<string, string> = {};
+    const attrsToRemove: string[] = [];
+
+    if (span.colSpan !== undefined) {
+      if (span.colSpan !== 1) {
+        attrsToSet.colSpan = String(span.colSpan);
+      } else {
+        attrsToRemove.push('colSpan');
+      }
+    }
+    if (span.rowSpan !== undefined) {
+      if (span.rowSpan !== 1) {
+        attrsToSet.rowSpan = String(span.rowSpan);
+      } else {
+        attrsToRemove.push('rowSpan');
+      }
+    }
+
+    this.doc.update((root) => {
+      const tree = root.content;
+      if (!tree || typeof tree.getRootTreeNode !== 'function') return;
+      if (Object.keys(attrsToSet).length > 0) {
+        tree.styleByPath(cellPath, attrsToSet);
+      }
+      if (attrsToRemove.length > 0) {
+        const endPath = [...cellPath];
+        endPath[endPath.length - 1] += 1;
+        tree.removeStyleByPath(cellPath, endPath, attrsToRemove);
+      }
+    });
+
+    // Update cache after Yorkie update succeeds
+    if (span.colSpan !== undefined) {
+      cell.colSpan = span.colSpan === 1 ? undefined : span.colSpan;
+    }
+    if (span.rowSpan !== undefined) {
+      cell.rowSpan = span.rowSpan === 1 ? undefined : span.rowSpan;
+    }
+
+    this.cachedDoc = currentDoc;
+    this.dirty = false;
+  }
+
   updateTableAttrs(tableBlockId: string, attrs: { cols: number[]; rowHeights?: (number | undefined)[] }): void {
     const tablePath = this.resolveTableTreePath(tableBlockId);
     const currentDoc = this.getDocument();

--- a/packages/frontend/tests/app/docs/yorkie-doc-store-concurrent.integration.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store-concurrent.integration.ts
@@ -587,6 +587,70 @@ describe('YorkieDocStore concurrent table cell edits', { skip: !shouldRun }, () 
     }
   });
 
+  it('concurrent applyCellSpan and text insert in same cell should both be preserved', async () => {
+    const table = createTableBlock(2, 2);
+    const cellBlock = table.tableData!.rows[0].cells[0].blocks[0];
+    cellBlock.inlines = [{ text: 'SpanText', style: {} }];
+    const ctx = await createTwoUserDocs('cellspan-and-insert', [table]);
+    try {
+      // Client A: set colSpan on cell (merge scenario)
+      ctx.storeA.applyCellSpan(table.id, 0, 0, { colSpan: 2 });
+
+      // Client B: insert text in cell
+      ctx.storeB.insertText(cellBlock.id, 4, 'YY');
+
+      await ctx.sync();
+
+      const docA = ctx.storeA.getDocument();
+      const docB = ctx.storeB.getDocument();
+
+      // Span should be preserved
+      const cellA = docA.blocks[0].tableData!.rows[0].cells[0];
+      const cellB = docB.blocks[0].tableData!.rows[0].cells[0];
+      assert.equal(cellA.colSpan, 2, 'A: colSpan should be 2');
+      assert.equal(cellB.colSpan, 2, 'B: colSpan should be 2');
+
+      // Text should be preserved
+      const textA = cellA.blocks.flatMap((b) => b.inlines.map((i) => i.text)).join('');
+      const textB = cellB.blocks.flatMap((b) => b.inlines.map((i) => i.text)).join('');
+      assert.equal(textA, textB, 'Text should converge');
+      assert.ok(textA.includes('YY'), `Inserted text "YY" should be preserved, got "${textA}"`);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('concurrent applyCellSpan removal and applyCellStyle should both be preserved', async () => {
+    const table = createTableBlock(2, 2);
+    // Pre-set a span
+    table.tableData!.rows[0].cells[0].colSpan = 2;
+    const ctx = await createTwoUserDocs('cellspan-remove-and-style', [table]);
+    try {
+      // Client A: remove colSpan (split cell scenario)
+      ctx.storeA.applyCellSpan(table.id, 0, 0, { colSpan: 1 });
+
+      // Client B: apply cell background
+      ctx.storeB.applyCellStyle(table.id, 0, 0, { backgroundColor: '#00ff00' });
+
+      await ctx.sync();
+
+      const docA = ctx.storeA.getDocument();
+      const docB = ctx.storeB.getDocument();
+
+      // colSpan should be removed on both
+      const cellA = docA.blocks[0].tableData!.rows[0].cells[0];
+      const cellB = docB.blocks[0].tableData!.rows[0].cells[0];
+      assert.equal(cellA.colSpan, undefined, 'A: colSpan should be removed');
+      assert.equal(cellB.colSpan, undefined, 'B: colSpan should be removed');
+
+      // Style should be preserved
+      assert.equal(cellA.style.backgroundColor, '#00ff00', 'A: bg should be green');
+      assert.equal(cellB.style.backgroundColor, '#00ff00', 'B: bg should be green');
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
   it('concurrent split in cell and text insert in same cell should converge', async () => {
     const table = createTableBlock(1, 1);
     const cellBlock = table.tableData!.rows[0].cells[0].blocks[0];

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -995,6 +995,109 @@ describe('YorkieDocStore', () => {
     });
   });
 
+  describe('applyCellSpan', () => {
+    it('should set colSpan on a cell', () => {
+      const tableBlock = createTableBlock(2, 3);
+      store.setDocument({ blocks: [tableBlock] });
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 2 });
+      const doc = store.getDocument();
+      const cell = doc.blocks[0].tableData!.rows[0].cells[0];
+      assert.equal(cell.colSpan, 2);
+    });
+
+    it('should set rowSpan on a cell', () => {
+      const tableBlock = createTableBlock(3, 2);
+      store.setDocument({ blocks: [tableBlock] });
+      store.applyCellSpan(tableBlock.id, 0, 0, { rowSpan: 3 });
+      const doc = store.getDocument();
+      assert.equal(doc.blocks[0].tableData!.rows[0].cells[0].rowSpan, 3);
+    });
+
+    it('should set both colSpan and rowSpan', () => {
+      const tableBlock = createTableBlock(3, 3);
+      store.setDocument({ blocks: [tableBlock] });
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 2, rowSpan: 2 });
+      const doc = store.getDocument();
+      const cell = doc.blocks[0].tableData!.rows[0].cells[0];
+      assert.equal(cell.colSpan, 2);
+      assert.equal(cell.rowSpan, 2);
+    });
+
+    it('should remove colSpan when set to 1 (default)', () => {
+      const tableBlock = createTableBlock(2, 3);
+      store.setDocument({ blocks: [tableBlock] });
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 3 });
+      assert.equal(store.getDocument().blocks[0].tableData!.rows[0].cells[0].colSpan, 3);
+      // Setting to 1 removes it (default)
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 1 });
+      const doc = store.getDocument();
+      assert.equal(doc.blocks[0].tableData!.rows[0].cells[0].colSpan, undefined);
+    });
+
+    it('should remove rowSpan when set to 1 (default)', () => {
+      const tableBlock = createTableBlock(3, 2);
+      store.setDocument({ blocks: [tableBlock] });
+      store.applyCellSpan(tableBlock.id, 0, 0, { rowSpan: 2 });
+      assert.equal(store.getDocument().blocks[0].tableData!.rows[0].cells[0].rowSpan, 2);
+      store.applyCellSpan(tableBlock.id, 0, 0, { rowSpan: 1 });
+      const doc = store.getDocument();
+      assert.equal(doc.blocks[0].tableData!.rows[0].cells[0].rowSpan, undefined);
+    });
+
+    it('should set colSpan=0 for covered cells', () => {
+      const tableBlock = createTableBlock(2, 2);
+      store.setDocument({ blocks: [tableBlock] });
+      store.applyCellSpan(tableBlock.id, 0, 1, { colSpan: 0 });
+      const doc = store.getDocument();
+      assert.equal(doc.blocks[0].tableData!.rows[0].cells[1].colSpan, 0);
+    });
+
+    it('should not affect other cell properties', () => {
+      const tableBlock = createTableBlock(2, 2);
+      store.setDocument({ blocks: [tableBlock] });
+      store.applyCellStyle(tableBlock.id, 0, 0, { backgroundColor: '#ff0000' });
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 2 });
+      const doc = store.getDocument();
+      const cell = doc.blocks[0].tableData!.rows[0].cells[0];
+      assert.equal(cell.colSpan, 2);
+      assert.equal(cell.style.backgroundColor, '#ff0000');
+    });
+
+    it('should only update specified span property', () => {
+      const tableBlock = createTableBlock(3, 3);
+      store.setDocument({ blocks: [tableBlock] });
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 2, rowSpan: 3 });
+      // Update only rowSpan, colSpan should remain
+      store.applyCellSpan(tableBlock.id, 0, 0, { rowSpan: 2 });
+      const doc = store.getDocument();
+      const cell = doc.blocks[0].tableData!.rows[0].cells[0];
+      assert.equal(cell.colSpan, 2);
+      assert.equal(cell.rowSpan, 2);
+    });
+
+    it('should clear both spans (splitCell scenario)', () => {
+      const tableBlock = createTableBlock(3, 3);
+      store.setDocument({ blocks: [tableBlock] });
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 2, rowSpan: 2 });
+      // Simulate splitCell: clear both spans
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 1, rowSpan: 1 });
+      const doc = store.getDocument();
+      const cell = doc.blocks[0].tableData!.rows[0].cells[0];
+      assert.equal(cell.colSpan, undefined);
+      assert.equal(cell.rowSpan, undefined);
+    });
+
+    it('should decrement rowSpan (deleteRow scenario)', () => {
+      const tableBlock = createTableBlock(3, 2);
+      store.setDocument({ blocks: [tableBlock] });
+      store.applyCellSpan(tableBlock.id, 0, 0, { rowSpan: 3 });
+      // Simulate deleteRow: decrement rowSpan
+      store.applyCellSpan(tableBlock.id, 0, 0, { rowSpan: 2 });
+      const doc = store.getDocument();
+      assert.equal(doc.blocks[0].tableData!.rows[0].cells[0].rowSpan, 2);
+    });
+  });
+
   describe('insertImageInline', () => {
     it('should insert an image inline at offset', () => {
       const block = makeBlock('Hello');

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -1098,6 +1098,110 @@ describe('YorkieDocStore', () => {
     });
   });
 
+  describe('deleteRow with spanning cells', () => {
+    it('should decrement rowSpan when deleting a row spanned by a cell above', () => {
+      const tableBlock = createTableBlock(3, 2);
+      store.setDocument({ blocks: [tableBlock] });
+      // Set rowSpan=2 on cell (0,0) — spans rows 0-1
+      store.applyCellSpan(tableBlock.id, 0, 0, { rowSpan: 2 });
+      // Mark cell (1,0) as covered
+      store.applyCellSpan(tableBlock.id, 1, 0, { colSpan: 0 });
+
+      // Delete row 1 — rowSpan should shrink to 1 (removed)
+      // Simulate Doc.deleteRow: adjust spans then delete row
+      store.applyCellSpan(tableBlock.id, 0, 0, { rowSpan: 1 });
+      store.deleteTableRow(tableBlock.id, 1);
+
+      const doc = store.getDocument();
+      const td = doc.blocks[0].tableData!;
+      assert.equal(td.rows.length, 2);
+      assert.equal(td.rows[0].cells[0].rowSpan, undefined);
+    });
+
+    it('should decrement rowSpan from 3 to 2 when deleting a middle spanned row', () => {
+      const tableBlock = createTableBlock(4, 2);
+      store.setDocument({ blocks: [tableBlock] });
+      // Set rowSpan=3 on cell (0,0) — spans rows 0-2
+      store.applyCellSpan(tableBlock.id, 0, 0, { rowSpan: 3 });
+
+      // Delete row 1 — rowSpan should shrink to 2
+      store.applyCellSpan(tableBlock.id, 0, 0, { rowSpan: 2 });
+      store.deleteTableRow(tableBlock.id, 1);
+
+      const doc = store.getDocument();
+      assert.equal(doc.blocks[0].tableData!.rows.length, 3);
+      assert.equal(doc.blocks[0].tableData!.rows[0].cells[0].rowSpan, 2);
+    });
+  });
+
+  describe('deleteColumn with spanning cells', () => {
+    it('should decrement colSpan when deleting a column spanned by a cell to the left', () => {
+      const tableBlock = createTableBlock(2, 3);
+      store.setDocument({ blocks: [tableBlock] });
+      // Set colSpan=2 on cell (0,0) — spans cols 0-1
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 2 });
+      store.applyCellSpan(tableBlock.id, 0, 1, { colSpan: 0 });
+
+      // Delete col 1 — colSpan should shrink to 1 (removed)
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 1 });
+      store.deleteTableColumn(tableBlock.id, 1);
+
+      const doc = store.getDocument();
+      const td = doc.blocks[0].tableData!;
+      assert.equal(td.rows[0].cells.length, 2);
+      assert.equal(td.rows[0].cells[0].colSpan, undefined);
+    });
+
+    it('should decrement colSpan from 3 to 2 when deleting a middle spanned column', () => {
+      const tableBlock = createTableBlock(2, 4);
+      store.setDocument({ blocks: [tableBlock] });
+      // Set colSpan=3 on cell (0,0) — spans cols 0-2
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 3 });
+
+      // Delete col 1 — colSpan should shrink to 2
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 2 });
+      store.deleteTableColumn(tableBlock.id, 1);
+
+      const doc = store.getDocument();
+      assert.equal(doc.blocks[0].tableData!.rows[0].cells.length, 3);
+      assert.equal(doc.blocks[0].tableData!.rows[0].cells[0].colSpan, 2);
+    });
+  });
+
+  describe('splitCell via applyCellSpan', () => {
+    it('should clear spans on top-left cell and restore covered cells', () => {
+      const tableBlock = createTableBlock(3, 3);
+      store.setDocument({ blocks: [tableBlock] });
+
+      // Simulate merge: set colSpan=2, rowSpan=2 on top-left, mark covered cells
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 2, rowSpan: 2 });
+      store.applyCellSpan(tableBlock.id, 0, 1, { colSpan: 0 });
+      store.applyCellSpan(tableBlock.id, 1, 0, { colSpan: 0 });
+      store.applyCellSpan(tableBlock.id, 1, 1, { colSpan: 0 });
+
+      // Verify merge state
+      const merged = store.getDocument();
+      assert.equal(merged.blocks[0].tableData!.rows[0].cells[0].colSpan, 2);
+      assert.equal(merged.blocks[0].tableData!.rows[0].cells[0].rowSpan, 2);
+      assert.equal(merged.blocks[0].tableData!.rows[0].cells[1].colSpan, 0);
+
+      // Simulate splitCell: clear spans on all cells
+      store.applyCellSpan(tableBlock.id, 0, 0, { colSpan: 1, rowSpan: 1 });
+      store.applyCellSpan(tableBlock.id, 0, 1, { colSpan: 1 });
+      store.applyCellSpan(tableBlock.id, 1, 0, { colSpan: 1 });
+      store.applyCellSpan(tableBlock.id, 1, 1, { colSpan: 1 });
+
+      // All cells should have no span attributes
+      const doc = store.getDocument();
+      const td = doc.blocks[0].tableData!;
+      assert.equal(td.rows[0].cells[0].colSpan, undefined);
+      assert.equal(td.rows[0].cells[0].rowSpan, undefined);
+      assert.equal(td.rows[0].cells[1].colSpan, undefined);
+      assert.equal(td.rows[1].cells[0].colSpan, undefined);
+      assert.equal(td.rows[1].cells[1].colSpan, undefined);
+    });
+  });
+
   describe('insertImageInline', () => {
     it('should insert an image inline at offset', () => {
       const block = makeBlock('Hello');


### PR DESCRIPTION
## Summary
- Add `applyCellSpan` to DocStore interface using Yorkie `styleByPath`/`removeStyleByPath` instead of full cell replacement via `updateTableCell`
- Update `deleteRow`/`deleteColumn` to use `applyCellSpan` for span adjustments
- Update `splitCell` to use `applyCellSpan` for top-left cell span clearing (covered cell block reset remains `updateTableCell` for Phase 8)

## Test plan
- [x] 10 unit tests for `applyCellSpan` (set/remove colSpan/rowSpan, covered cells, isolation, split/delete scenarios)
- [x] 2 concurrent integration tests (span + text insert, span removal + cell style)
- [x] `pnpm verify:fast` passes
- [ ] Manual test: merge cells, delete row/column with spanning cells, split merged cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)