### PR TITLE
Route table attrs through styleByPath (Phase 7)

### DIFF
--- a/docs/design/docs/docs-intent-preserving-edits.md
+++ b/docs/design/docs/docs-intent-preserving-edits.md
@@ -124,7 +124,7 @@ divergence cannot be fully ruled out until these are resolved upstream.
 | 4 | Table cell internal edits (extend Phase 1–3) | ✅ Shipped |
 | 5 | Block/cell attribute edits (styleByPath) | ✅ Shipped |
 | 6 | Cell span attributes (styleByPath) | ✅ Shipped |
-| 7 | Table-level attributes (styleByPath on block) | Planned |
+| 7 | Table-level attributes (styleByPath on block) | ✅ Shipped |
 | 8 | Cell structural edits (editByPath) | Planned |
 | 9 | Yorkie-native undo/redo (feature-flagged) | Planned |
 
@@ -196,20 +196,23 @@ pattern as Phase 5's `applyCellStyle`.
 to clear them (value 1 = default = remove from tree). Covered cell block reset
 in `splitCell` still uses `updateTableCell` (Phase 8).
 
-### Phase 7: Table-Level Attributes
+### Phase 7: Table-Level Attributes ✅
 
 Column widths and row heights are block-level attributes on the table node.
-Migrate `updateTableAttrs` to `styleByPath` on the block node.
+Migrated `updateTableAttrs` from `editByPath` (full block replacement) to
+`styleByPath` on the block node.
 
-| Call site | Trigger | Current method |
-|-----------|---------|----------------|
-| `insertRow()` | rowHeights update | `store.updateTableAttrs` |
-| `deleteRow()` | rowHeights update | `store.updateTableAttrs` |
-| `insertColumn()` | columnWidths update | `store.updateTableAttrs` |
-| `deleteColumn()` | columnWidths update | `store.updateTableAttrs` |
-| `setColumnWidth()` | single column resize | `store.updateTableAttrs` |
-| `setColumnWidthPair()` | adjacent column resize | `store.updateTableAttrs` |
-| `setRowHeight()` | row height resize | `store.updateTableAttrs` |
+| Before | After |
+|--------|-------|
+| `editByPath(tablePath, endPath, buildBlockNode(block))` | `styleByPath(tablePath, { cols, rowHeights })` |
+
+All 7 call sites (`insertRow`, `deleteRow`, `insertColumn`, `deleteColumn`,
+`setColumnWidth`, `resizeColumn`, `setRowHeight`) are routed through the
+same `updateTableAttrs` store method — no Doc-level changes needed.
+
+Attributes are serialized as comma-separated strings on the block node
+(`cols: "0.5,0.5"`, `rowHeights: "40,"`), matching the existing
+`buildBlockNode` format.
 
 ### Phase 8: Cell Structural Edits
 

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -1739,14 +1739,20 @@ export class YorkieDocStore implements DocStore {
     if (attrs.rowHeights !== undefined) {
       block.tableData!.rowHeights = attrs.rowHeights;
     }
+
+    const nodeAttrs: Record<string, string> = {
+      cols: attrs.cols.join(','),
+    };
+    if (attrs.rowHeights !== undefined) {
+      nodeAttrs.rowHeights = attrs.rowHeights.map(h => h ?? '').join(',');
+    }
+
     this.doc.update((root) => {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
-      // For the replace range, increment the last path segment by 1
-      const endPath = [...tablePath];
-      endPath[endPath.length - 1] += 1;
-      tree.editByPath(tablePath, endPath, buildBlockNode(block));
+      tree.styleByPath(tablePath, nodeAttrs);
     });
+
     this.cachedDoc = currentDoc;
     this.dirty = false;
   }

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -212,6 +212,17 @@ function buildInlineNode(inline: Inline): ElementNode {
   };
 }
 
+function serializeTableAttrs(
+  cols: number[],
+  rowHeights?: (number | undefined)[],
+): Record<string, string> {
+  const attrs: Record<string, string> = { cols: cols.join(',') };
+  if (rowHeights && rowHeights.length > 0) {
+    attrs.rowHeights = rowHeights.map(h => h ?? '').join(',');
+  }
+  return attrs;
+}
+
 function buildBlockNode(block: Block): ElementNode {
   // Table block: children are row → cell → block nodes
   if (block.type === 'table' && block.tableData) {
@@ -220,10 +231,7 @@ function buildBlockNode(block: Block): ElementNode {
       attributes: {
         id: block.id,
         type: 'table',
-        cols: block.tableData.columnWidths.join(','),
-        ...(block.tableData.rowHeights && block.tableData.rowHeights.length > 0
-          ? { rowHeights: block.tableData.rowHeights.map(h => h ?? '').join(',') }
-          : {}),
+        ...serializeTableAttrs(block.tableData.columnWidths, block.tableData.rowHeights),
         ...serializeBlockStyle(block.style),
       },
       children: block.tableData.rows.map(buildRowNode),
@@ -1740,12 +1748,11 @@ export class YorkieDocStore implements DocStore {
       block.tableData!.rowHeights = attrs.rowHeights;
     }
 
-    const nodeAttrs: Record<string, string> = {
-      cols: attrs.cols.join(','),
-    };
-    if (attrs.rowHeights !== undefined) {
-      nodeAttrs.rowHeights = attrs.rowHeights.map(h => h ?? '').join(',');
-    }
+    // styleByPath merges attributes — it never removes existing keys.
+    // No call site currently transitions rowHeights from set → unset,
+    // so removeStyleByPath is not needed here. If that changes, add:
+    //   tree.removeStyleByPath(tablePath, endPath, ['rowHeights']);
+    const nodeAttrs = serializeTableAttrs(attrs.cols, attrs.rowHeights);
 
     this.doc.update((root) => {
       const tree = root.content;

--- a/packages/frontend/tests/app/docs/yorkie-doc-store-concurrent.integration.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store-concurrent.integration.ts
@@ -680,4 +680,71 @@ describe('YorkieDocStore concurrent table cell edits', { skip: !shouldRun }, () 
       await ctx.cleanup();
     }
   });
+
+  // -------------------------------------------------------------------------
+  // Concurrent updateTableAttrs + text insert (Phase 7)
+  // -------------------------------------------------------------------------
+
+  it('concurrent updateTableAttrs and text insert should both be preserved', async () => {
+    const table = createTableBlock(2, 2);
+    const cellBlock = table.tableData!.rows[0].cells[0].blocks[0];
+    cellBlock.inlines = [{ text: 'Hello', style: {} }];
+    const ctx = await createTwoUserDocs('table-attrs-text', [table]);
+    try {
+      // Client A: resize columns
+      ctx.storeA.updateTableAttrs(table.id, { cols: [0.7, 0.3] });
+
+      // Client B: insert text in a cell
+      ctx.storeB.insertText(cellBlock.id, 5, ' World');
+
+      await ctx.sync();
+
+      const docA = ctx.storeA.getDocument();
+      const docB = ctx.storeB.getDocument();
+
+      // Column widths should converge
+      assert.deepEqual(docA.blocks[0].tableData!.columnWidths, [0.7, 0.3]);
+      assert.deepEqual(docB.blocks[0].tableData!.columnWidths, [0.7, 0.3]);
+
+      // Text should be preserved
+      const textA = docA.blocks[0].tableData!.rows[0].cells[0].blocks[0].inlines[0].text;
+      const textB = docB.blocks[0].tableData!.rows[0].cells[0].blocks[0].inlines[0].text;
+      assert.equal(textA, 'Hello World');
+      assert.equal(textB, 'Hello World');
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('concurrent updateTableAttrs with rowHeights and applyCellStyle should both be preserved', async () => {
+    const table = createTableBlock(2, 2);
+    const ctx = await createTwoUserDocs('table-attrs-style', [table]);
+    try {
+      // Client A: set row heights
+      ctx.storeA.updateTableAttrs(table.id, {
+        cols: [0.5, 0.5],
+        rowHeights: [40, undefined],
+      });
+
+      // Client B: apply cell background
+      ctx.storeB.applyCellStyle(table.id, 0, 0, { backgroundColor: '#ff0000' });
+
+      await ctx.sync();
+
+      const docA = ctx.storeA.getDocument();
+      const docB = ctx.storeB.getDocument();
+
+      // Row heights should converge
+      assert.deepEqual(docA.blocks[0].tableData!.rowHeights, [40, undefined]);
+      assert.deepEqual(docB.blocks[0].tableData!.rowHeights, [40, undefined]);
+
+      // Cell style should be preserved
+      const cellStyleA = docA.blocks[0].tableData!.rows[0].cells[0].style;
+      const cellStyleB = docB.blocks[0].tableData!.rows[0].cells[0].style;
+      assert.equal(cellStyleA?.backgroundColor, '#ff0000');
+      assert.equal(cellStyleB?.backgroundColor, '#ff0000');
+    } finally {
+      await ctx.cleanup();
+    }
+  });
 });

--- a/packages/frontend/tests/app/docs/yorkie-doc-store-concurrent.integration.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store-concurrent.integration.ts
@@ -747,4 +747,43 @@ describe('YorkieDocStore concurrent table cell edits', { skip: !shouldRun }, () 
       await ctx.cleanup();
     }
   });
+
+  it('concurrent updateTableAttrs from two clients should merge attributes', async () => {
+    const table = createTableBlock(2, 2);
+    const ctx = await createTwoUserDocs('table-attrs-attrs', [table]);
+    try {
+      // Client A: resize columns
+      ctx.storeA.updateTableAttrs(table.id, { cols: [0.6, 0.4] });
+
+      // Client B: set row heights (cols unchanged)
+      ctx.storeB.updateTableAttrs(table.id, {
+        cols: [0.5, 0.5],
+        rowHeights: [30, 50],
+      });
+
+      await ctx.sync();
+
+      const docA = ctx.storeA.getDocument();
+      const docB = ctx.storeB.getDocument();
+
+      // Both clients should converge (LWW on each attribute key)
+      assert.deepEqual(
+        docA.blocks[0].tableData!.columnWidths,
+        docB.blocks[0].tableData!.columnWidths,
+        'Column widths should converge',
+      );
+      assert.deepEqual(
+        docA.blocks[0].tableData!.rowHeights,
+        docB.blocks[0].tableData!.rowHeights,
+        'Row heights should converge',
+      );
+      // rowHeights should be present (set by Client B)
+      assert.ok(
+        docA.blocks[0].tableData!.rowHeights,
+        'rowHeights should exist after merge',
+      );
+    } finally {
+      await ctx.cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Migrate `updateTableAttrs` from `editByPath` (full block replacement) to `styleByPath` (attribute-only update), preserving concurrent cell edits when column widths or row heights are modified
- Extract shared `serializeTableAttrs` helper to eliminate duplication between `buildBlockNode` and `updateTableAttrs`
- Add 3 concurrent integration tests (attrs+text, attrs+cellStyle, attrs+attrs)
- Mark Phase 7 as shipped in design doc

## Test plan
- [x] `pnpm verify:fast` passes (580 docs + 152 frontend tests)
- [ ] `pnpm verify:full` with Yorkie server — concurrent integration tests
- [ ] Manual: resize columns/rows while another user edits cell text

🤖 Generated with [Claude Code](https://claude.com/claude-code)