### PR TITLE
Fix unacceptable path error on empty paragraph text insertion

### DIFF
--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -1108,7 +1108,8 @@ export class YorkieDocStore implements DocStore {
       // If the block has no inline children (e.g. empty block left after
       // a split or concurrent edit), insert a new inline node with the text.
       if (!hasInlineChildren) {
-        const style = targetInline?.style ?? {};
+        const { image: _, ...style } = targetInline?.style ?? {};
+        void _;
         tree.editByPath(
           [...blockPath, 0],
           [...blockPath, 0],
@@ -1450,6 +1451,15 @@ export class YorkieDocStore implements DocStore {
           type: newBlockType,
           ...serializeBlockStyle(block.style),
         };
+        if (newBlockType === 'list-item' && block.listKind !== undefined) {
+          afterAttrs.listKind = block.listKind;
+          if (block.listLevel !== undefined) {
+            afterAttrs.listLevel = String(block.listLevel);
+          }
+        }
+        if (newBlockType === 'heading' && block.headingLevel !== undefined) {
+          afterAttrs.headingLevel = String(block.headingLevel);
+        }
         tree.editByPath(afterPath, afterPath, buildBlockNode({
           id: newBlockId,
           type: newBlockType,

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -1098,9 +1098,26 @@ export class YorkieDocStore implements DocStore {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
 
-      // Resolve offset from the actual Yorkie tree structure
       const treeRoot = tree.getRootTreeNode();
       const blockNode = this.getTreeBlockNode(treeRoot, blockPath);
+      const el = blockNode as ElementNode;
+      const hasInlineChildren = (el.children ?? []).some(
+        (c) => c.type === 'inline',
+      );
+
+      // If the block has no inline children (e.g. empty block left after
+      // a split or concurrent edit), insert a new inline node with the text.
+      if (!hasInlineChildren) {
+        const style = targetInline?.style ?? {};
+        tree.editByPath(
+          [...blockPath, 0],
+          [...blockPath, 0],
+          buildInlineNode({ text, style }),
+        );
+        return;
+      }
+
+      // Resolve offset from the actual Yorkie tree structure
       const { inlineIndex, charOffset } = this.resolveBlockNodeOffset(blockNode, offset);
 
       if (targetInline.style.image) {
@@ -1410,40 +1427,67 @@ export class YorkieDocStore implements DocStore {
       const tree = root.content;
       if (!tree || typeof tree.getRootTreeNode !== 'function') return;
 
-      // Resolve offset from the actual Yorkie tree, not the cache.
       const treeRoot = tree.getRootTreeNode();
       const blockNode = this.getTreeBlockNode(treeRoot, blockPath);
-      const { inlineIndex, charOffset } = this.resolveBlockNodeOffset(blockNode, offset);
-
-      // Native CRDT split: single atomic operation at splitLevel=2.
-      // splitLevel=2 because the text position is 2 levels below block:
-      //   doc → block → inline → text(charOffset)
-      // Two splits are needed: text→inline split + inline→block split.
-      tree.editByPath(
-        [...blockPath, inlineIndex, charOffset],
-        [...blockPath, inlineIndex, charOffset],
-        undefined,
-        2,
+      const el = blockNode as ElementNode;
+      const hasInlineChildren = (el.children ?? []).some(
+        (c) => c.type === 'inline',
       );
 
-      // The split duplicated all attributes. Update the "after" block.
       const afterPath = [...blockPath];
       afterPath[afterPath.length - 1] += 1;
-      const afterAttrs: Record<string, string> = {
-        id: newBlockId,
-        type: newBlockType,
-        ...serializeBlockStyle(block.style),
-      };
-      if (newBlockType === 'list-item' && block.listKind !== undefined) {
-        afterAttrs.listKind = block.listKind;
-        if (block.listLevel !== undefined) {
-          afterAttrs.listLevel = String(block.listLevel);
+
+      if (!hasInlineChildren) {
+        // Block has no inline children — can't use CRDT split.
+        // Ensure the current block has an inline, then insert a new block.
+        tree.editByPath(
+          [...blockPath, 0],
+          [...blockPath, 0],
+          buildInlineNode({ text: '', style: {} }),
+        );
+        const afterAttrs: Record<string, string> = {
+          id: newBlockId,
+          type: newBlockType,
+          ...serializeBlockStyle(block.style),
+        };
+        tree.editByPath(afterPath, afterPath, buildBlockNode({
+          id: newBlockId,
+          type: newBlockType,
+          inlines: [{ text: '', style: {} }],
+          style: block.style,
+        }));
+        tree.styleByPath(afterPath, afterAttrs);
+      } else {
+        // Resolve offset from the actual Yorkie tree, not the cache.
+        const { inlineIndex, charOffset } = this.resolveBlockNodeOffset(blockNode, offset);
+
+        // Native CRDT split: single atomic operation at splitLevel=2.
+        // splitLevel=2 because the text position is 2 levels below block:
+        //   doc → block → inline → text(charOffset)
+        // Two splits are needed: text→inline split + inline→block split.
+        tree.editByPath(
+          [...blockPath, inlineIndex, charOffset],
+          [...blockPath, inlineIndex, charOffset],
+          undefined,
+          2,
+        );
+
+        const afterAttrs: Record<string, string> = {
+          id: newBlockId,
+          type: newBlockType,
+          ...serializeBlockStyle(block.style),
+        };
+        if (newBlockType === 'list-item' && block.listKind !== undefined) {
+          afterAttrs.listKind = block.listKind;
+          if (block.listLevel !== undefined) {
+            afterAttrs.listLevel = String(block.listLevel);
+          }
         }
+        if (newBlockType === 'heading' && block.headingLevel !== undefined) {
+          afterAttrs.headingLevel = String(block.headingLevel);
+        }
+        tree.styleByPath(afterPath, afterAttrs);
       }
-      if (newBlockType === 'heading' && block.headingLevel !== undefined) {
-        afterAttrs.headingLevel = String(block.headingLevel);
-      }
-      tree.styleByPath(afterPath, afterAttrs);
     });
 
     // Update cache in-place using the pure-function result

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -380,6 +380,102 @@ describe('YorkieDocStore', () => {
       assert.equal(result.blocks[1].inlines[0].text, '');
     });
 
+    it('should allow insertText into the empty block created by split-at-end', () => {
+      const block = makeBlock('Hello');
+      store.setDocument({ blocks: [block] });
+      store.splitBlock(block.id, 5, 'new-id', 'paragraph');
+      const after = store.getDocument();
+      const emptyBlockId = after.blocks[1].id;
+      // This must not throw "unacceptable path"
+      store.insertText(emptyBlockId, 0, 'World');
+      const result = store.getDocument();
+      assert.equal(result.blocks[1].inlines[0].text, 'World');
+    });
+
+    it('should allow insertText after splitting an empty block (double Enter)', () => {
+      // Simulates: type "Hello" → Enter → Enter → type "World" in middle empty block
+      const block = makeBlock('Hello');
+      store.setDocument({ blocks: [block] });
+
+      // First Enter: split at end of "Hello"
+      store.splitBlock(block.id, 5, 'empty-block-1', 'paragraph');
+      const step1 = store.getDocument();
+      assert.equal(step1.blocks.length, 2);
+
+      // Second Enter: split the empty block at offset 0
+      store.splitBlock('empty-block-1', 0, 'empty-block-2', 'paragraph');
+      const step2 = store.getDocument();
+      assert.equal(step2.blocks.length, 3);
+
+      // Now try to insert text into the first empty block (block index 1)
+      // This must not throw "YorkieError: unacceptable path"
+      store.insertText('empty-block-1', 0, 'World');
+      const result = store.getDocument();
+      assert.equal(result.blocks[1].inlines[0].text, 'World');
+    });
+
+    it('should splitBlock on a block with no inline children in Yorkie tree', () => {
+      // A block with no inline children should be splittable (Enter key).
+      const blockId = 'orphan-block';
+      store.setDocument({
+        blocks: [
+          {
+            id: blockId,
+            type: 'paragraph',
+            inlines: [{ text: '', style: {} }],
+            style: { ...DEFAULT_BLOCK_STYLE },
+          },
+        ],
+      });
+
+      // Remove the inline child from the Yorkie tree
+      doc.update((root) => {
+        root.content.editByPath([0, 0], [0, 1]);
+      });
+
+      // This must not throw "YorkieError: unacceptable path"
+      store.splitBlock(blockId, 0, 'new-block', 'paragraph');
+      const result = store.getDocument();
+      assert.equal(result.blocks.length, 2);
+    });
+
+    it('should insertText into a block with no inline children in Yorkie tree', () => {
+      // Reproduce the production bug: a block exists in the Yorkie tree
+      // with no inline children (e.g. due to prior edits or GC).
+      const blockId = 'orphan-block';
+      // Set up a normal document first
+      store.setDocument({
+        blocks: [
+          {
+            id: blockId,
+            type: 'paragraph',
+            inlines: [{ text: '', style: {} }],
+            style: { ...DEFAULT_BLOCK_STYLE },
+          },
+        ],
+      });
+
+      // Now manually remove the inline child from the Yorkie tree
+      // to simulate the production state where a block has no inlines.
+      doc.update((root) => {
+        const tree = root.content;
+        // Remove the inline child at path [0, 0] to [0, 1]
+        tree.editByPath([0, 0], [0, 1]);
+      });
+
+      // Verify the Yorkie tree block has no inline children
+      const tree = doc.getRoot().content;
+      const treeRoot = tree.getRootTreeNode();
+      const blockNode = treeRoot.children[0];
+      const inlines = (blockNode.children || []).filter((c) => c.type === 'inline');
+      assert.equal(inlines.length, 0, 'block should have no inline children');
+
+      // This must not throw "YorkieError: unacceptable path"
+      store.insertText(blockId, 0, 'Hello');
+      const result = store.getDocument();
+      assert.equal(result.blocks[0].inlines[0].text, 'Hello');
+    });
+
     it('should preserve surrounding blocks', () => {
       const b1 = makeBlock('Before');
       const b2 = makeBlock('SplitMe');


### PR DESCRIPTION
## Summary
- Fix `YorkieError: unacceptable path` when inserting text or pressing Enter in an empty paragraph that has no inline children in the Yorkie tree
- Handle edge case in `insertText` and `splitBlock` where block node has zero inline children by creating inline node before editing

## Root Cause
A block in the Yorkie tree can end up with no inline children (exact cause still under investigation — see follow-up below). When `insertText` or `splitBlock` is called on such a block, `resolveBlockNodeOffset` returns `{inlineIndex: 0, charOffset: 0}` and `editByPath([...blockPath, 0, 0])` fails because the path doesn't exist.

**Confirmed in production** on `doc-07bdceb6-dd90-4d05-854c-dbb0b4a62f6a` (shared link `b08e15ab`):
```
Block[0]: <block><inline>안녕하세요.</inline></block>   ← OK
Block[1]: <block></block>                              ← NO INLINE CHILDREN
Block[2]: <block><inline>반갑습니다.</inline></block>   ← OK
```

## Fix
- **`insertText`**: When block has no inline children, insert a new `<inline>` node containing the text instead of editing at a nonexistent path
- **`splitBlock`**: When block has no inline children, restore an empty inline and insert a new block instead of using CRDT split (which requires an inline path)

## Follow-up
- Investigate how a block ends up with no inline children in the Yorkie tree (concurrent edits? GC? prior code version?)
- Document key: `doc-07bdceb6-dd90-4d05-854c-dbb0b4a62f6a`, MongoDB doc_id: `69e9ecaa6aeafa99f1b3748f`

## Test plan
- [x] `pnpm verify:fast` passes
- [x] New test: `should insertText into a block with no inline children in Yorkie tree` — reproduces the exact `YorkieError: unacceptable path`
- [x] New test: `should splitBlock on a block with no inline children in Yorkie tree`
- [x] New test: `should allow insertText into the empty block created by split-at-end`
- [x] New test: `should allow insertText after splitting an empty block (double Enter)`
- [x] All existing YorkieDocStore tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed text insertion errors occurring in certain document structures.
  - Resolved block splitting (Enter key) failures in edge case scenarios.
  - Improved overall editor stability and resilience during complex document operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->