### PR TITLE
Fix deleteText removing all inline children from a block

### DIFF
--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -1183,16 +1183,16 @@ export class YorkieDocStore implements DocStore {
         [...blockPath, treeEnd.inlineIndex, treeEnd.charOffset],
       );
 
-      // Remove any inlines that became empty after deletion
+      // Remove any inlines that became empty after deletion, but keep at least 1
       const updatedBlockNode = this.getTreeBlockNode(tree.getRootTreeNode(), blockPath) as ElementNode;
       const inlines = (updatedBlockNode.children ?? []).filter((c) => c.type === 'inline') as ElementNode[];
-      for (let i = inlines.length - 1; i >= 0; i--) {
-        if (inlines.length <= 1) break; // keep at least one
+      for (let i = inlines.length - 1; i >= 0 && inlines.length > 1; i--) {
         const textLen = (inlines[i].children ?? [])
           .filter((c): c is { type: 'text'; value: string } => c.type === 'text')
           .reduce((sum, t) => sum + t.value.length, 0);
         if (textLen === 0) {
           tree.editByPath([...blockPath, i], [...blockPath, i + 1]);
+          inlines.splice(i, 1);
         }
       }
     });

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -491,6 +491,60 @@ describe('YorkieDocStore', () => {
     });
   });
 
+  describe('deleteText', () => {
+    it('should keep at least one inline when deleting all text from a block with multiple empty inlines', () => {
+      // Reproduce the production bug (server_seq=630):
+      // 1. Block has 2 empty inlines (from split producing split fragments)
+      // 2. Text is inserted into the first inline
+      // 3. Text is deleted — cleanup loop should keep at least 1 inline
+      const b1 = makeBlock('Hello');
+      const b2 = makeBlock('World');
+      store.setDocument({ blocks: [b1, b2] });
+
+      // Split b1 at end → creates a new empty block between b1 and b2
+      const newBlockId = generateBlockId();
+      store.splitBlock(b1.id, 5, newBlockId, 'paragraph');
+
+      // Now manually add a second empty inline to simulate split fragments
+      // (production scenario: split on a block that already had an empty inline)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      doc.update((root: any) => {
+        const tree = root.content;
+        tree.editByPath([1, 1], [1, 1], {
+          type: 'inline',
+          attributes: {},
+          children: [],
+        });
+      });
+
+      // Verify the block now has 2 empty inlines in the Yorkie tree
+      const treeBefore = doc.getRoot().content;
+      const rootBefore = treeBefore.getRootTreeNode();
+      const blockBefore = rootBefore.children[1];
+      const inlinesBefore = (blockBefore.children || []).filter(
+        (c: { type: string }) => c.type === 'inline',
+      );
+      assert.equal(inlinesBefore.length, 2, 'block should have 2 empty inlines');
+
+      // Insert text into the block, then delete it
+      store.insertText(newBlockId, 0, 'X');
+      store.deleteText(newBlockId, 0, 1);
+
+      // The block must still have at least 1 inline child
+      const treeAfter = doc.getRoot().content;
+      const rootAfter = treeAfter.getRootTreeNode();
+      const blockAfter = rootAfter.children[1];
+      const inlinesAfter = (blockAfter.children || []).filter(
+        (c: { type: string }) => c.type === 'inline',
+      );
+      assert.equal(inlinesAfter.length, 1, `block should have exactly 1 inline, got ${inlinesAfter.length}`);
+
+      // getDocument should also work without errors
+      const result = store.getDocument();
+      assert.equal(result.blocks[1].inlines.length, 1);
+    });
+  });
+
   describe('mergeBlock', () => {
     it('should merge two adjacent blocks into one', () => {
       const b1 = makeBlock('Hello');


### PR DESCRIPTION
## Summary

- Fix stale array guard in `deleteText` cleanup loop that allowed removing all inline children from a block, leaving it in an invalid state
- The `inlines` snapshot array was never updated after each removal, so the `length` guard always checked the original count
- Apply the same `splice` pattern already used in `applyStyle` to keep the array in sync with the tree

## Root Cause

When a block has 2+ empty inlines after text deletion, the cleanup loop removes them one by one. The guard `if (inlines.length <= 1) break` checked the snapshot array length, which never decreased. With 2 empty inlines, both were removed, leaving the block with zero inline children. Subsequent `editByPath` calls on that block triggered `YorkieError: unacceptable path`.

Confirmed by replaying all 451 changes from the production document (`server_seq=630`).

## Test plan

- [x] New test: block with 2 empty inlines → insert text → delete text → verify exactly 1 inline remains
- [x] `pnpm verify:fast` passes (200 tests, 0 failures)
- [x] `pnpm verify:self` passes (full build + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text deletion handling when blocks contain multiple empty inline nodes to prevent unintended removal of required inline children.

* **Tests**
  * Added test coverage for text deletion scenarios with empty inline nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->