### PR TITLE
Prevent image duplication when splitting blocks near images

### DIFF
--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -68,6 +68,7 @@ export {
   applyInsertInline,
   applySplitBlock,
   applyMergeBlocks,
+  resolveOffsetForSplit,
 } from './store/block-helpers.js';
 export type { InlinePosition, InlineSegment } from './store/block-helpers.js';
 

--- a/packages/docs/src/store/block-helpers.ts
+++ b/packages/docs/src/store/block-helpers.ts
@@ -146,6 +146,24 @@ export function resolveStyleRange(
 }
 
 /**
+ * Like `resolveOffset` but treats an offset at the exact end of an
+ * image inline as belonging to the NEXT inline instead.  This prevents
+ * `splitLevel=2` from splitting through the image element.
+ */
+export function resolveOffsetForSplit(block: Block, offset: number): InlinePosition {
+  const result = resolveOffset(block, offset);
+  const inline = block.inlines[result.inlineIndex];
+  if (
+    inline?.style.image &&
+    result.charOffset === inline.text.length &&
+    result.inlineIndex + 1 < block.inlines.length
+  ) {
+    return { inlineIndex: result.inlineIndex + 1, charOffset: 0 };
+  }
+  return result;
+}
+
+/**
  * Get the inline style at a split point so empty sides preserve formatting.
  */
 function getSplitPointStyle(inlines: Inline[], offset: number): InlineStyle {

--- a/packages/docs/test/store/block-helpers.test.ts
+++ b/packages/docs/test/store/block-helpers.test.ts
@@ -1,7 +1,7 @@
 // packages/docs/test/store/block-helpers.test.ts
 import { describe, it, expect } from 'vitest';
-import { resolveOffset, resolveDeleteRange, applyInsertText, applyDeleteText, resolveStyleRange, applyInlineStyle, applySplitBlock, applyMergeBlocks } from '../../src/store/block-helpers.js';
-import type { Block } from '../../src/model/types.js';
+import { resolveOffset, resolveDeleteRange, applyInsertText, applyDeleteText, resolveStyleRange, applyInlineStyle, applySplitBlock, applyMergeBlocks, resolveOffsetForSplit } from '../../src/store/block-helpers.js';
+import type { Block, ImageData } from '../../src/model/types.js';
 import { DEFAULT_BLOCK_STYLE } from '../../src/model/types.js';
 
 function makeBlock(...inlines: Array<{ text: string; style?: Record<string, unknown> }>): Block {
@@ -266,6 +266,95 @@ describe('applySplitBlock', () => {
     expect(before.inlines[1]).toEqual({ text: 'C', style: { italic: true } });
     expect(after.inlines).toHaveLength(1);
     expect(after.inlines[0]).toEqual({ text: 'D', style: { italic: true } });
+  });
+});
+
+const IMG: ImageData = { src: 'https://example.com/img.jpg', width: 100, height: 100 };
+
+describe('resolveOffsetForSplit — image skip', () => {
+  it('returns same as resolveOffset for text inlines', () => {
+    const block = makeBlock({ text: 'Hello' });
+    expect(resolveOffsetForSplit(block, 3)).toEqual({ inlineIndex: 0, charOffset: 3 });
+  });
+
+  it('skips image inline when offset resolves to end of image', () => {
+    // "AB"(2) + image(1) + "CD"(2).
+    // offset=3 → resolveOffset maps to {1, 1} (end of image inline).
+    // resolveOffsetForSplit must skip to {2, 0} (start of "CD") so
+    // splitLevel=2 never splits through the image element.
+    const block = makeBlock(
+      { text: 'AB' },
+      { text: '\uFFFC', style: { image: IMG } },
+      { text: 'CD' },
+    );
+    expect(resolveOffset(block, 3)).toEqual({ inlineIndex: 1, charOffset: 1 });
+    expect(resolveOffsetForSplit(block, 3)).toEqual({ inlineIndex: 2, charOffset: 0 });
+  });
+
+  it('does not skip when offset resolves to text inline before image', () => {
+    // offset=2 → resolveOffset maps to {0, 2} (end of "AB"), not image.
+    const block = makeBlock(
+      { text: 'AB' },
+      { text: '\uFFFC', style: { image: IMG } },
+      { text: 'CD' },
+    );
+    expect(resolveOffsetForSplit(block, 2)).toEqual({ inlineIndex: 0, charOffset: 2 });
+  });
+
+  it('does not skip when image is last inline (no next inline to skip to)', () => {
+    const block = makeBlock(
+      { text: 'Hello' },
+      { text: '\uFFFC', style: { image: IMG } },
+    );
+    // offset=6 → {1, 1} on image, but no next inline
+    expect(resolveOffsetForSplit(block, 6)).toEqual({ inlineIndex: 1, charOffset: 1 });
+  });
+
+  it('does not skip for text inline after image', () => {
+    const block = makeBlock(
+      { text: '\uFFFC', style: { image: IMG } },
+      { text: 'Hello' },
+    );
+    // offset=3 → resolveOffset maps to {1, 2} (text inline, not image)
+    expect(resolveOffsetForSplit(block, 3)).toEqual({ inlineIndex: 1, charOffset: 2 });
+  });
+});
+
+describe('applySplitBlock — image boundary (cache path)', () => {
+  it('keeps image in before-block when offset is at image end', () => {
+    // offset=3 is at image inlineEnd. applySplitBlock uses (inlineEnd <= offset)
+    // which correctly puts the image in before-block.
+    const block = makeBlock(
+      { text: 'AB' },
+      { text: '\uFFFC', style: { image: IMG } },
+      { text: 'CD' },
+    );
+    const [before, after] = applySplitBlock(block, 3, 'b2', 'paragraph');
+
+    expect(before.inlines).toHaveLength(2);
+    expect(before.inlines[0].text).toBe('AB');
+    expect(before.inlines[1].text).toBe('\uFFFC');
+    expect(before.inlines[1].style.image).toEqual(IMG);
+
+    expect(after.inlines).toHaveLength(1);
+    expect(after.inlines[0].text).toBe('CD');
+    expect(after.inlines[0].style.image).toBeUndefined();
+  });
+
+  it('keeps image in before-block when image is at end of block', () => {
+    const block = makeBlock(
+      { text: 'Hello' },
+      { text: '\uFFFC', style: { image: IMG } },
+    );
+    const [before, after] = applySplitBlock(block, 6, 'b2', 'paragraph');
+
+    expect(before.inlines).toHaveLength(2);
+    expect(before.inlines[1].text).toBe('\uFFFC');
+    expect(before.inlines[1].style.image).toEqual(IMG);
+
+    expect(after.inlines).toHaveLength(1);
+    expect(after.inlines[0].text).toBe('');
+    expect(after.inlines[0].style.image).toBeUndefined();
   });
 });
 

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -756,6 +756,37 @@ export class YorkieDocStore implements DocStore {
     return { inlineIndex: Math.max(0, lastIdx), charOffset: lastLen };
   }
 
+  /**
+   * Like resolveBlockNodeOffset but skips image inlines to prevent
+   * splitLevel=2 from splitting through an image element.
+   * When the resolved inline has image attributes, we move to the
+   * start of the next inline so the image stays in the "before" block.
+   */
+  private resolveBlockNodeOffsetForSplit(
+    blockNode: TreeNode,
+    offset: number,
+  ): { inlineIndex: number; charOffset: number } {
+    const result = this.resolveBlockNodeOffset(blockNode, offset);
+    const el = blockNode as ElementNode;
+    const inlineChildren = (el.children ?? []).filter(
+      (c): c is ElementNode => c.type === 'inline',
+    );
+    const resolved = inlineChildren[result.inlineIndex];
+    const hasImage = resolved?.attributes && Object.keys(resolved.attributes).some(
+      (k) => k.startsWith('image.'),
+    );
+    const textLen = (resolved?.children ?? [])
+      .filter((c): c is { type: 'text'; value: string } => c.type === 'text')
+      .reduce((sum, t) => sum + t.value.length, 0);
+    // Only skip when charOffset equals textLen (the end-of-image boundary
+    // caused by resolveOffset's <= semantics).  charOffset < textLen means
+    // the cursor is before the image and should not be moved.
+    if (hasImage && result.charOffset === textLen && result.inlineIndex + 1 < inlineChildren.length) {
+      return { inlineIndex: result.inlineIndex + 1, charOffset: 0 };
+    }
+    return result;
+  }
+
   /** Log the Yorkie Tree state at a given block path for debugging. */
   private logTreeState(op: string, blockPath: number[]): void {
     try {
@@ -1469,7 +1500,8 @@ export class YorkieDocStore implements DocStore {
         tree.styleByPath(afterPath, afterAttrs);
       } else {
         // Resolve offset from the actual Yorkie tree, not the cache.
-        const { inlineIndex, charOffset } = this.resolveBlockNodeOffset(blockNode, offset);
+        // Use the split-aware resolver to skip image inlines.
+        const { inlineIndex, charOffset } = this.resolveBlockNodeOffsetForSplit(blockNode, offset);
 
         // Native CRDT split: single atomic operation at splitLevel=2.
         // splitLevel=2 because the text position is 2 levels below block:


### PR DESCRIPTION
## Summary

- Fix image duplication bug when pressing Enter near an image inline in the docs editor
- Yorkie Tree's `SplitElement` deep-copies all attributes to split siblings — for image inlines this creates ghost duplicates with `image.*` attributes but no text content
- Add split-aware offset resolvers that skip image inlines at the end boundary, redirecting `splitLevel=2` to the next inline

## Root Cause

`resolveOffset` uses `<=` boundary semantics, so offsets at an image inline's end still resolve to that image inline. When `splitLevel=2` splits through an image element, Yorkie's `SplitElement` `DeepCopy()`s all attributes (including `image.*`) to the empty split sibling, creating a ghost image.

## Changes

| File | Change |
|------|--------|
| `packages/docs/src/store/block-helpers.ts` | Add `resolveOffsetForSplit()` — skips image inline at end boundary |
| `packages/docs/src/index.ts` | Export new function |
| `packages/frontend/.../yorkie-doc-store.ts` | Add `resolveBlockNodeOffsetForSplit()` — Yorkie Tree node equivalent |
| `packages/docs/test/store/block-helpers.test.ts` | 7 test cases for image split handling |

## Test plan

- [x] `pnpm verify:fast` passes (all 587 docs tests + 162 frontend tests + 107 backend tests)
- [x] `resolveOffsetForSplit` correctly skips image inline when `charOffset === textLen`
- [x] `resolveOffsetForSplit` does NOT skip for text inlines or when image is last inline
- [x] Cache path (`applySplitBlock`) correctly handles image boundaries without adjustment
- [ ] Manual test: insert image in wafflebase doc, press Enter near image — no duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document splitting behavior at image boundaries, ensuring images remain correctly positioned in the before block when splitting occurs at image edges, preventing split operations from crossing image elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->