### PR TITLE
Fix body block cache index offset when header exists

### DIFF
--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -892,6 +892,25 @@ export class YorkieDocStore implements DocStore {
   }
 
   /**
+   * Resolve the local array index for a block within its containing
+   * Block[] (doc.blocks, header.blocks, footer.blocks, or cell.blocks).
+   *
+   * For cell-internal blocks the last path segment is already relative
+   * to the cell's blocks array.  For top-level blocks we need
+   * `getRegionBlocks().topIndex` which adjusts for the header tree
+   * offset in the body region.
+   */
+  private localBlockIndex(
+    doc: Document,
+    blockPath: number[],
+    region: 'header' | 'body' | 'footer',
+  ): number {
+    return this.isCellBlockPath(blockPath, region)
+      ? blockPath[blockPath.length - 1]
+      : this.getRegionBlocks(doc, blockPath, region).topIndex;
+  }
+
+  /**
    * Extract the cell sub-path from a full block path.
    * For body: [tableTreeIdx, r, c, b, ...] → [r, c, b, ...]
    * For header/footer: [regionIdx, tableIdx, r, c, b, ...] → [r, c, b, ...]
@@ -1394,9 +1413,7 @@ export class YorkieDocStore implements DocStore {
 
     // Update cache in-place
     const blocksArray = this.getBlocksArrayForPath(currentDoc, siblingPath, region);
-    const localIdx = this.isCellBlockPath(siblingPath, region)
-      ? siblingPath[siblingPath.length - 1]
-      : this.getRegionBlocks(currentDoc, siblingPath, region).topIndex;
+    const localIdx = this.localBlockIndex(currentDoc, siblingPath, region);
     blocksArray.splice(localIdx + 1, 0, block);
     this.cachedDoc = currentDoc;
     this.dirty = false;
@@ -1417,7 +1434,7 @@ export class YorkieDocStore implements DocStore {
 
     // Update cache in-place
     const blocksArray = this.getBlocksArrayForPath(currentDoc, blockPath, region);
-    const localIdx = blockPath[blockPath.length - 1];
+    const localIdx = this.localBlockIndex(currentDoc, blockPath, region);
     blocksArray.splice(localIdx, 1);
     this.cachedDoc = currentDoc;
     this.dirty = false;
@@ -1535,7 +1552,7 @@ export class YorkieDocStore implements DocStore {
     // Update cache in-place using the pure-function result
     const [before, after] = applySplitBlock(block, offset, newBlockId, newBlockType);
     const blocksArray = this.getBlocksArrayForPath(currentDoc, blockPath, region);
-    const localIdx = blockPath[blockPath.length - 1];
+    const localIdx = this.localBlockIndex(currentDoc, blockPath, region);
     blocksArray[localIdx] = before;
     blocksArray.splice(localIdx + 1, 0, after);
     this.cachedDoc = currentDoc;
@@ -1590,8 +1607,8 @@ export class YorkieDocStore implements DocStore {
 
     // Update cache in-place
     const blocksArray = this.getBlocksArrayForPath(currentDoc, blockPath, region);
-    const localIdx = blockPath[blockPath.length - 1];
-    const nextLocalIdx = nextPath[nextPath.length - 1];
+    const localIdx = this.localBlockIndex(currentDoc, blockPath, region);
+    const nextLocalIdx = this.localBlockIndex(currentDoc, nextPath, nextRegion);
     blocksArray[localIdx] = merged;
     blocksArray.splice(nextLocalIdx, 1);
     this.cachedDoc = currentDoc;

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import yorkie from '@yorkie-js/sdk';
 import { YorkieDocStore } from '../../../src/app/docs/yorkie-doc-store.ts';
 import { generateBlockId, DEFAULT_BLOCK_STYLE, createTableBlock, createTableCell } from '@wafflebase/docs';
-import type { Block, TableRow, TableCell as TCell } from '@wafflebase/docs';
+import type { Block, Inline, TableRow, TableCell as TCell } from '@wafflebase/docs';
 
 function makeBlock(text: string, style?: Partial<Block['style']>): Block {
   return {
@@ -803,6 +803,53 @@ describe('YorkieDocStore', () => {
       assert.equal(result.blocks[1].inlines[0].style.bold, true);
       assert.equal(result.blocks[1].inlines[0].style.italic, true);
       assert.equal(result.blocks[1].inlines[0].style.fontSize, 18);
+    });
+  });
+
+  describe('cache index with header offset', () => {
+    it('splitBlock should not duplicate body content when header exists', () => {
+      // When a header is present, tree path [1] maps to body blocks[0].
+      // The cache update must use the body-relative index, not the tree path.
+      const header = makeBlock('Header');
+      const body = makeBlock('asdf');
+      const trailing = makeBlock('');
+      store.setDocument({ blocks: [body, trailing] });
+      store.setHeader({ blocks: [header], marginFromEdge: 48 });
+
+      store.splitBlock(body.id, 4, 'new-id', 'paragraph');
+      const result = store.getDocument();
+      assert.equal(result.blocks.length, 3);
+      const text0 = result.blocks[0].inlines.map((i: Inline) => i.text).join('');
+      const text1 = result.blocks[1].inlines.map((i: Inline) => i.text).join('');
+      assert.equal(text0, 'asdf', 'First body block should keep "asdf"');
+      assert.equal(text1, '', 'New block should be empty, not duplicated');
+    });
+
+    it('mergeBlock should merge correct body blocks when header exists', () => {
+      const header = makeBlock('Header');
+      const b1 = makeBlock('Hello');
+      const b2 = makeBlock('World');
+      store.setDocument({ blocks: [b1, b2] });
+      store.setHeader({ blocks: [header], marginFromEdge: 48 });
+
+      store.mergeBlock(b1.id, b2.id);
+      const result = store.getDocument();
+      assert.equal(result.blocks.length, 1);
+      const text = result.blocks[0].inlines.map((i: Inline) => i.text).join('');
+      assert.equal(text, 'HelloWorld');
+    });
+
+    it('deleteBlock should delete correct body block when header exists', () => {
+      const header = makeBlock('Header');
+      const b1 = makeBlock('Keep');
+      const b2 = makeBlock('Delete');
+      store.setDocument({ blocks: [b1, b2] });
+      store.setHeader({ blocks: [header], marginFromEdge: 48 });
+
+      store.deleteBlock(b2.id);
+      const result = store.getDocument();
+      assert.equal(result.blocks.length, 1);
+      assert.equal(result.blocks[0].inlines[0].text, 'Keep');
     });
   });
 


### PR DESCRIPTION
## Summary
- When a header element is present, tree path index for body blocks is offset by 1. The cache update in `splitBlock`, `mergeBlock`, and `deleteBlock` used the raw tree path index as the array index into `doc.blocks`, causing off-by-one writes — the split overwrote the wrong block and duplicated content (e.g. "asdf\nasdf" instead of "asdf\n").
- Extract `localBlockIndex()` helper that resolves the correct body-relative index via `getRegionBlocks().topIndex`, and apply it to all four cache-update sites.

## Test plan
- [x] Added tests for splitBlock, mergeBlock, deleteBlock with header present
- [x] All 106 existing YorkieDocStore tests pass
- [x] Full `verify:fast` + `verify:self` pass (pre-push hook)
- [x] Manual verification on production document (wafflebase.io)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of document block operations (split, merge, delete) with complex document structures.

* **Tests**
  * Added comprehensive test coverage for block cache correctness in various document scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->