### PR TITLE
Add external table paste support (HTML and markdown)

### DIFF
--- a/docs/design/docs/docs-table-copy-paste.md
+++ b/docs/design/docs/docs-table-copy-paste.md
@@ -13,7 +13,7 @@ Enable copy-paste for tables in the Docs editor across three scenarios, implemen
 2. **Whole-table block** — copy a region that includes table blocks, paste as new table blocks
 3. **External HTML tables** — paste tables from Google Docs, Sheets, or the web
 
-This document covers Phase 1 (cell-to-cell).
+This document covers Phase 1 (cell-to-cell) and Phase 3 (external table paste).
 
 ## Goals / Non-Goals
 
@@ -128,7 +128,85 @@ function cloneTableCells(cells: TableCell[][]): TableCell[][] {
 | Paste into merged cells may corrupt layout | Phase 1 skips colSpan/rowSpan — paste treats each cell independently |
 | Cut from table leaves empty cells vs. removing rows | Cut replaces cell content with empty blocks (like spreadsheet behavior), does not remove structural rows/columns |
 
+## Phase 3: External Table Paste
+
+### Summary
+
+Parse external table content from two sources — HTML `<table>` elements and
+markdown table syntax — into `TableCell[][]`, then reuse the existing
+`pasteTableCells()` method to insert them.
+
+### Goals
+
+- Paste HTML tables from Google Docs, Sheets, web browsers, etc.
+- Paste markdown tables (`| col | col |` syntax) from text editors, GitHub, etc.
+- Preserve inline formatting from HTML table cells (bold, italic, links, etc.)
+- Reuse existing `pasteTableCells()` — no new insertion logic needed
+
+### Non-Goals
+
+- Parsing mixed content (table + paragraphs) as a table — only pure-table HTML triggers table paste
+- colSpan/rowSpan from external HTML (Phase 1 already defers this)
+- Markdown cell formatting (bold `**text**`, etc.) — cells are plain text
+
+### New Functions in `clipboard.ts`
+
+#### `parseHtmlTableToTableCells(html: string): TableCell[][] | null`
+
+1. Parse HTML with `DOMParser`, find the first `<table>` element
+2. If no `<table>` found or the HTML contains significant non-table content, return `null`
+3. Walk `<tr>` rows, then `<td>`/`<th>` cells within each row
+4. For each cell, reuse the existing inline-walk logic to produce `Inline[]`
+   with formatting (bold, italic, color, links, etc.)
+5. Wrap each cell's inlines in a single paragraph `Block` inside a `TableCell`
+6. Return the 2D `TableCell[][]` array
+
+#### `parseMarkdownTableToTableCells(text: string): TableCell[][] | null`
+
+1. Split text into lines, trim each line
+2. Validate markdown table structure:
+   - At least 2 lines (header + separator)
+   - Lines start and/or contain `|` delimiters
+   - Second line matches separator pattern (`---`, `:---:`, etc.)
+3. Skip the separator line, parse remaining lines by splitting on `|`
+4. Each cell becomes a `TableCell` with a single paragraph block containing
+   plain-text inline
+5. Return the 2D `TableCell[][]` array, or `null` if not a valid markdown table
+
+### `handlePaste` Flow Change
+
+```
+1. Image file         → existing handler
+2. WAFFLEDOCS_MIME    → existing handler
+3. text/html (no shift):
+   a. parseHtmlTableToTableCells(html)
+      → if non-null: saveSnapshot → deleteSelection → pasteTableCells() → return
+   b. parseHtmlToBlocks(html)
+      → existing block paste
+4. text/plain:
+   a. parseMarkdownTableToTableCells(text)
+      → if non-null: saveSnapshot → deleteSelection → pasteTableCells() → return
+   b. insertPlainText(text)
+      → existing plain-text paste
+```
+
+### Changed Files
+
+| File | Change |
+|------|--------|
+| `clipboard.ts` | Add `parseHtmlTableToTableCells()`, `parseMarkdownTableToTableCells()` |
+| `text-editor.ts` | Update `handlePaste` to try table parsers before existing fallbacks |
+| `clipboard.test.ts` | Tests for both parsers: basic tables, formatting, edge cases, rejection |
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| HTML with mixed table + paragraph content | Return `null` from table parser — fall through to existing `parseHtmlToBlocks` |
+| Malformed markdown tables (ragged columns) | Pad short rows with empty cells to match the widest row |
+| Google Sheets pastes `<table>` with heavy inline styles | `resolveInlineCSS()` already handles common CSS properties |
+| Plain text that looks like a markdown table but isn't | Require separator line (`---`) as a mandatory signal |
+
 ## Future Phases
 
 - **Phase 2:** Whole-table block copy — extend `getSelectedBlocks()` to include table blocks with `tableData`, extend `insertBlocks()` to handle `type === 'table'`
-- **Phase 3:** HTML table parsing — extend `parseHtmlToBlocks()` to handle `<table>/<tr>/<td>` elements, producing table blocks

--- a/docs/design/docs/docs-table-copy-paste.md
+++ b/docs/design/docs/docs-table-copy-paste.md
@@ -145,67 +145,84 @@ markdown table syntax — into `TableCell[][]`, then reuse the existing
 
 ### Non-Goals
 
-- Parsing mixed content (table + paragraphs) as a table — only pure-table HTML triggers table paste
 - colSpan/rowSpan from external HTML (Phase 1 already defers this)
 - Markdown cell formatting (bold `**text**`, etc.) — cells are plain text
 
 ### New Functions in `clipboard.ts`
 
+#### `parseHtmlTableElement(tableEl: Element): Block | null` (private)
+
+Converts a single `<table>` DOM element into a table `Block`. Used by
+`parseHtmlToBlocks` when it encounters a `<table>` tag inline, and by
+`parseHtmlTableToTableCells` for pure-table clipboard content.
+
+Uses scoped `:scope >` selectors to avoid matching `<tr>` from nested tables.
+
 #### `parseHtmlTableToTableCells(html: string): TableCell[][] | null`
 
-1. Parse HTML with `DOMParser`, find the first `<table>` element
-2. If no `<table>` found or the HTML contains significant non-table content, return `null`
-3. Walk `<tr>` rows, then `<td>`/`<th>` cells within each row
-4. For each cell, reuse the existing inline-walk logic to produce `Inline[]`
-   with formatting (bold, italic, color, links, etc.)
-5. Wrap each cell's inlines in a single paragraph `Block` inside a `TableCell`
-6. Return the 2D `TableCell[][]` array
+For pure-table HTML (no surrounding paragraphs). Returns `TableCell[][]` for
+use with `pasteTableCells()` (enables cell-by-cell paste into existing tables).
 
 #### `parseMarkdownTableToTableCells(text: string): TableCell[][] | null`
 
-1. Split text into lines, trim each line
-2. Validate markdown table structure:
-   - At least 2 lines (header + separator)
-   - Lines start and/or contain `|` delimiters
-   - Second line matches separator pattern (`---`, `:---:`, etc.)
-3. Skip the separator line, parse remaining lines by splitting on `|`
-4. Each cell becomes a `TableCell` with a single paragraph block containing
-   plain-text inline
-5. Return the 2D `TableCell[][]` array, or `null` if not a valid markdown table
+For pure markdown tables (no surrounding text). Same cell-by-cell paste path.
 
-### `handlePaste` Flow Change
+#### `parseMarkdownWithTables(text: string): Block[] | null`
+
+For mixed markdown content (text + tables). Detects markdown table regions
+within the text and returns `Block[]` where table regions become table blocks
+and text regions become paragraph blocks. Pads first/last with empty paragraphs
+if they are table blocks (required by `insertBlocks` merge semantics).
+
+#### `parseHtmlToBlocks` — enhanced with `<table>` handling
+
+The existing `parseHtmlToBlocks` now handles `<table>` tags inline via
+`parseHtmlTableElement()`. This is the primary path for pasting rendered
+markdown from sources like Claude chat, which provide both `text/html` and
+`text/plain` on the clipboard.
+
+Also skips whitespace-only text nodes between block-level siblings
+(e.g. `\n` between `<li>` tags) to avoid spurious empty paragraphs.
+
+### `handlePaste` Flow
 
 ```
 1. Image file         → existing handler
 2. WAFFLEDOCS_MIME    → existing handler
 3. text/html (no shift):
    a. parseHtmlTableToTableCells(html)
-      → if non-null: saveSnapshot → deleteSelection → pasteTableCells() → return
+      → pure table: pasteTableCells() (cell-by-cell into existing table)
    b. parseHtmlToBlocks(html)
-      → existing block paste
-4. text/plain:
+      → mixed content: tables become table blocks inline, text becomes paragraphs
+4. text/plain (no shift):
    a. parseMarkdownTableToTableCells(text)
-      → if non-null: saveSnapshot → deleteSelection → pasteTableCells() → return
-   b. insertPlainText(text)
-      → existing plain-text paste
+      → pure table: pasteTableCells()
+   b. parseMarkdownWithTables(text)
+      → mixed: tables + paragraphs via insertBlocks()
+   c. insertPlainText(text)
+      → fallback plain text
 ```
+
+Shift+paste bypasses all table parsers (HTML and markdown) and forces plain text.
 
 ### Changed Files
 
 | File | Change |
 |------|--------|
-| `clipboard.ts` | Add `parseHtmlTableToTableCells()`, `parseMarkdownTableToTableCells()` |
-| `text-editor.ts` | Update `handlePaste` to try table parsers before existing fallbacks |
-| `clipboard.test.ts` | Tests for both parsers: basic tables, formatting, edge cases, rejection |
+| `clipboard.ts` | `parseHtmlTableElement()`, `parseHtmlTableToTableCells()`, `parseMarkdownTableToTableCells()`, `parseMarkdownWithTables()`, `collectInlines()`, `parentHasBlockChild()`, `<table>` handling in `parseHtmlToBlocks` |
+| `text-editor.ts` | `handlePaste` flow with table parsers, single-table-block handling in `insertBlocks` |
+| `clipboard.test.ts` | Tests for all parsers including mixed HTML/markdown, whitespace, nested tables |
 
 ### Risks and Mitigation
 
 | Risk | Mitigation |
 |------|------------|
-| HTML with mixed table + paragraph content | Return `null` from table parser — fall through to existing `parseHtmlToBlocks` |
+| Nested tables in HTML | Scoped `:scope >` selectors prevent inner table rows leaking into outer table |
+| Mixed HTML (table + paragraphs) | `parseHtmlToBlocks` handles `<table>` inline; `parseHtmlTableToTableCells` returns null for mixed content |
 | Malformed markdown tables (ragged columns) | Pad short rows with empty cells to match the widest row |
 | Google Sheets pastes `<table>` with heavy inline styles | `resolveInlineCSS()` already handles common CSS properties |
 | Plain text that looks like a markdown table but isn't | Require separator line (`---`) as a mandatory signal |
+| Table block as first/last in insertBlocks | Auto-pad with empty paragraphs to prevent merge corruption |
 
 ## Future Phases
 

--- a/packages/docs/src/view/clipboard.ts
+++ b/packages/docs/src/view/clipboard.ts
@@ -175,6 +175,19 @@ function resolveInlineCSS(el: Element, style: InlineStyle): void {
 }
 
 /**
+ * Check whether an element has any child element that is a block-level tag.
+ * Used to distinguish insignificant whitespace (between block siblings)
+ * from meaningful whitespace (between inline siblings like `<b>` and `<i>`).
+ */
+function parentHasBlockChild(parent: Element | null): boolean {
+  if (!parent) return false;
+  for (const child of Array.from(parent.children)) {
+    if (BLOCK_TAGS.has(child.tagName.toLowerCase())) return true;
+  }
+  return false;
+}
+
+/**
  * Parse an HTML string into an array of Block objects, preserving both
  * inline formatting and block-level semantics (headings, list items, etc.).
  */
@@ -199,6 +212,12 @@ export function parseHtmlToBlocks(html: string): Block[] {
     if (node.nodeType === Node.TEXT_NODE) {
       const text = node.textContent ?? '';
       if (text.length > 0) {
+        // Skip whitespace-only text nodes between block-level elements
+        // (e.g. "\n" between <li> tags inside <ul>). These are insignificant
+        // in HTML but would otherwise produce empty paragraph blocks.
+        if (/^\s+$/.test(text) && parentHasBlockChild(node.parentElement)) {
+          return;
+        }
         currentInlines.push({ text, style: { ...inherited } });
       }
       return;
@@ -219,6 +238,16 @@ export function parseHtmlToBlocks(html: string): Block[] {
     if (tag === 'ul' || tag === 'ol') {
       for (const child of Array.from(node.childNodes)) {
         walk(child, inherited);
+      }
+      return;
+    }
+
+    // <table> → flush current content, then emit a table block
+    if (tag === 'table') {
+      flushBlock();
+      const tableBlock = parseHtmlTableElement(el);
+      if (tableBlock) {
+        blocks.push(tableBlock);
       }
       return;
     }
@@ -269,6 +298,15 @@ export function parseHtmlToBlocks(html: string): Block[] {
   // Flush any remaining inline content
   if (currentInlines.length > 0) {
     blocks.push(makeBlock(currentInlines, currentMeta));
+  }
+
+  // insertBlocks merges the first and last blocks with surrounding text.
+  // Table blocks cannot be merged, so pad with empty paragraphs if needed.
+  if (blocks.length > 0 && blocks[0].type === 'table') {
+    blocks.unshift(makeBlock([]));
+  }
+  if (blocks.length > 0 && blocks[blocks.length - 1].type === 'table') {
+    blocks.push(makeBlock([]));
   }
 
   return blocks;
@@ -356,6 +394,52 @@ function makeCellFromInlines(inlines: Inline[], cellStyle?: Partial<CellStyle>):
     }],
     style: { padding: 4, ...cellStyle },
   };
+}
+
+/**
+ * Convert a `<table>` DOM element into a table Block.
+ * Returns null if the table has no rows.
+ */
+function parseHtmlTableElement(tableEl: Element): Block | null {
+  const rows: TableCell[][] = [];
+  const trs = tableEl.querySelectorAll('tr');
+
+  for (const tr of Array.from(trs)) {
+    const cells: TableCell[] = [];
+    const tds = tr.querySelectorAll(':scope > td, :scope > th');
+
+    for (const td of Array.from(tds)) {
+      const inlines = collectInlines(td, {});
+      const cellStyle: Partial<CellStyle> = {};
+      if (td instanceof HTMLElement && td.style.backgroundColor) {
+        cellStyle.backgroundColor = td.style.backgroundColor;
+      }
+      cells.push(makeCellFromInlines(inlines, cellStyle));
+    }
+
+    if (cells.length > 0) {
+      rows.push(cells);
+    }
+  }
+
+  if (rows.length === 0) return null;
+
+  // Pad short rows
+  const maxCols = Math.max(...rows.map(r => r.length));
+  for (const row of rows) {
+    while (row.length < maxCols) {
+      row.push(makeCellFromInlines([], {}));
+    }
+  }
+
+  const block = createTableBlock(rows.length, maxCols);
+  const td = block.tableData!;
+  for (let r = 0; r < rows.length; r++) {
+    for (let c = 0; c < rows[r].length; c++) {
+      td.rows[r].cells[c] = rows[r][c];
+    }
+  }
+  return block;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/docs/src/view/clipboard.ts
+++ b/packages/docs/src/view/clipboard.ts
@@ -402,7 +402,9 @@ function makeCellFromInlines(inlines: Inline[], cellStyle?: Partial<CellStyle>):
  */
 function parseHtmlTableElement(tableEl: Element): Block | null {
   const rows: TableCell[][] = [];
-  const trs = tableEl.querySelectorAll('tr');
+  const trs = tableEl.querySelectorAll(
+    ':scope > tr, :scope > thead > tr, :scope > tbody > tr, :scope > tfoot > tr',
+  );
 
   for (const tr of Array.from(trs)) {
     const cells: TableCell[] = [];
@@ -480,7 +482,9 @@ export function parseHtmlTableToTableCells(html: string): TableCell[][] | null {
   }
 
   const rows: TableCell[][] = [];
-  const trs = table.querySelectorAll('tr');
+  const trs = table.querySelectorAll(
+    ':scope > tr, :scope > thead > tr, :scope > tbody > tr, :scope > tfoot > tr',
+  );
 
   for (const tr of Array.from(trs)) {
     const cells: TableCell[] = [];

--- a/packages/docs/src/view/clipboard.ts
+++ b/packages/docs/src/view/clipboard.ts
@@ -1,4 +1,4 @@
-import type { Block, BlockType, Inline, InlineStyle, HeadingLevel, TableCell } from '../model/types.js';
+import type { Block, BlockType, Inline, InlineStyle, HeadingLevel, TableCell, CellStyle } from '../model/types.js';
 import { generateBlockId, DEFAULT_BLOCK_STYLE, inlineStylesEqual } from '../model/types.js';
 
 interface ClipboardPayload {
@@ -281,4 +281,214 @@ export function parseHtmlToBlocks(html: string): Block[] {
 export function parseHtmlToInlines(html: string): Inline[] {
   const blocks = parseHtmlToBlocks(html);
   return blocks.flatMap((b) => b.inlines);
+}
+
+// ---------------------------------------------------------------------------
+// Inline extraction helper (reused by table parsers)
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk an HTML element's children and collect formatted Inline runs.
+ * Reuses the same tag/CSS resolution logic as parseHtmlToBlocks.
+ */
+function collectInlines(root: Node, inherited: InlineStyle): Inline[] {
+  const inlines: Inline[] = [];
+
+  function walk(node: Node, style: InlineStyle): void {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent ?? '';
+      if (text.length > 0) {
+        inlines.push({ text, style: { ...style } });
+      }
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+    const el = node as Element;
+    const tag = el.tagName.toLowerCase();
+
+    // Skip table structural tags — we only want inline content
+    if (tag === 'table' || tag === 'thead' || tag === 'tbody' || tag === 'tfoot' || tag === 'tr' || tag === 'td' || tag === 'th') {
+      for (const child of Array.from(node.childNodes)) {
+        walk(child, style);
+      }
+      return;
+    }
+
+    if (tag === 'br') {
+      inlines.push({ text: '\n', style: { ...style } });
+      return;
+    }
+
+    const childStyle: InlineStyle = { ...style };
+    const tagStyle = TAG_STYLE_MAP[tag];
+    if (tagStyle) {
+      Object.assign(childStyle, tagStyle);
+    }
+    if (tag === 'a') {
+      const href = el.getAttribute('href');
+      if (href) {
+        childStyle.href = href;
+      }
+    }
+    resolveInlineCSS(el, childStyle);
+
+    for (const child of Array.from(node.childNodes)) {
+      walk(child, childStyle);
+    }
+  }
+
+  walk(root, inherited);
+  return mergeInlines(inlines);
+}
+
+/**
+ * Build a TableCell from an array of Inlines.
+ */
+function makeCellFromInlines(inlines: Inline[], cellStyle?: Partial<CellStyle>): TableCell {
+  const merged = mergeInlines(inlines);
+  return {
+    blocks: [{
+      id: generateBlockId(),
+      type: 'paragraph',
+      inlines: merged.length > 0 ? merged : [{ text: '', style: {} }],
+      style: { ...DEFAULT_BLOCK_STYLE },
+    }],
+    style: { padding: 4, ...cellStyle },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTML table paste
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an HTML string and extract the first `<table>` as TableCell[][].
+ * Returns null if the HTML does not contain a table or contains significant
+ * non-table content (mixed content falls through to parseHtmlToBlocks).
+ */
+export function parseHtmlTableToTableCells(html: string): TableCell[][] | null {
+  if (!html) return null;
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+
+  const table = doc.querySelector('table');
+  if (!table) return null;
+
+  // Check for significant non-table content — if there are block-level
+  // elements outside the table, fall through to block parsing instead.
+  for (const child of Array.from(doc.body.childNodes)) {
+    if (child === table) continue;
+    if (child.nodeType === Node.ELEMENT_NODE) {
+      const tag = (child as Element).tagName.toLowerCase();
+      // Allow wrapper elements that just contain the table (e.g. Google Sheets
+      // wraps tables in <meta>/<style> tags)
+      if (tag !== 'meta' && tag !== 'style' && tag !== 'br' && tag !== 'colgroup') {
+        // There's meaningful non-table content — abort
+        const text = (child as Element).textContent?.trim() ?? '';
+        if (text.length > 0) return null;
+      }
+    } else if (child.nodeType === Node.TEXT_NODE) {
+      const text = child.textContent?.trim() ?? '';
+      if (text.length > 0) return null;
+    }
+  }
+
+  const rows: TableCell[][] = [];
+  const trs = table.querySelectorAll('tr');
+
+  for (const tr of Array.from(trs)) {
+    const cells: TableCell[] = [];
+    const tds = tr.querySelectorAll(':scope > td, :scope > th');
+
+    for (const td of Array.from(tds)) {
+      const inlines = collectInlines(td, {});
+      const cellStyle: Partial<CellStyle> = {};
+      if (td instanceof HTMLElement && td.style.backgroundColor) {
+        cellStyle.backgroundColor = td.style.backgroundColor;
+      }
+      cells.push(makeCellFromInlines(inlines, cellStyle));
+    }
+
+    if (cells.length > 0) {
+      rows.push(cells);
+    }
+  }
+
+  if (rows.length === 0) return null;
+
+  // Pad short rows to the maximum column count
+  const maxCols = Math.max(...rows.map(r => r.length));
+  for (const row of rows) {
+    while (row.length < maxCols) {
+      row.push(makeCellFromInlines([], {}));
+    }
+  }
+
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown table paste
+// ---------------------------------------------------------------------------
+
+/** Match a markdown table separator line: `| --- | :---: | ---: |` etc. */
+const MD_SEPARATOR_RE = /^\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$/;
+
+/**
+ * Parse a plain-text markdown table into TableCell[][].
+ * Returns null if the text is not a valid markdown table.
+ *
+ * Supported format:
+ * ```
+ * | Header 1 | Header 2 |
+ * | -------- | -------- |
+ * | Cell 1   | Cell 2   |
+ * ```
+ */
+export function parseMarkdownTableToTableCells(text: string): TableCell[][] | null {
+  if (!text) return null;
+
+  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+  if (lines.length < 2) return null;
+
+  // The second line must be a separator
+  if (!MD_SEPARATOR_RE.test(lines[1])) return null;
+
+  // The first line must contain at least one pipe
+  if (!lines[0].includes('|')) return null;
+
+  const parseRow = (line: string): string[] => {
+    // Strip leading/trailing pipes
+    let trimmed = line;
+    if (trimmed.startsWith('|')) trimmed = trimmed.slice(1);
+    if (trimmed.endsWith('|')) trimmed = trimmed.slice(0, -1);
+    return trimmed.split('|').map(cell => cell.trim());
+  };
+
+  const rows: TableCell[][] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    // Skip separator line
+    if (i === 1) continue;
+
+    const cellTexts = parseRow(lines[i]);
+    rows.push(cellTexts.map(t => makeCellFromInlines(
+      t.length > 0 ? [{ text: t, style: {} }] : [],
+      {},
+    )));
+  }
+
+  if (rows.length === 0) return null;
+
+  // Pad short rows
+  const maxCols = Math.max(...rows.map(r => r.length));
+  for (const row of rows) {
+    while (row.length < maxCols) {
+      row.push(makeCellFromInlines([], {}));
+    }
+  }
+
+  return rows;
 }

--- a/packages/docs/src/view/clipboard.ts
+++ b/packages/docs/src/view/clipboard.ts
@@ -1,5 +1,5 @@
 import type { Block, BlockType, Inline, InlineStyle, HeadingLevel, TableCell, CellStyle } from '../model/types.js';
-import { generateBlockId, DEFAULT_BLOCK_STYLE, inlineStylesEqual } from '../model/types.js';
+import { generateBlockId, DEFAULT_BLOCK_STYLE, inlineStylesEqual, createTableBlock } from '../model/types.js';
 
 interface ClipboardPayload {
   version: 1;
@@ -437,15 +437,49 @@ export function parseHtmlTableToTableCells(html: string): TableCell[][] | null {
 const MD_SEPARATOR_RE = /^\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$/;
 
 /**
+ * Parse a single row of pipe-delimited cells into trimmed strings.
+ */
+function parseMdRow(line: string): string[] {
+  let trimmed = line;
+  if (trimmed.startsWith('|')) trimmed = trimmed.slice(1);
+  if (trimmed.endsWith('|')) trimmed = trimmed.slice(0, -1);
+  return trimmed.split('|').map(cell => cell.trim());
+}
+
+/**
+ * Convert parsed cell strings into a padded TableCell[][] and wrap in a
+ * table Block.
+ */
+function buildTableBlockFromRows(rowTexts: string[][]): Block {
+  const maxCols = Math.max(1, ...rowTexts.map(r => r.length));
+  const cells: TableCell[][] = rowTexts.map(row => {
+    const tableCells = row.map(t => makeCellFromInlines(
+      t.length > 0 ? [{ text: t, style: {} }] : [],
+      {},
+    ));
+    // Pad short rows
+    while (tableCells.length < maxCols) {
+      tableCells.push(makeCellFromInlines([], {}));
+    }
+    return tableCells;
+  });
+
+  const block = createTableBlock(cells.length, maxCols);
+  const td = block.tableData!;
+  for (let r = 0; r < cells.length; r++) {
+    for (let c = 0; c < cells[r].length; c++) {
+      td.rows[r].cells[c] = cells[r][c];
+    }
+  }
+  return block;
+}
+
+/**
  * Parse a plain-text markdown table into TableCell[][].
  * Returns null if the text is not a valid markdown table.
  *
- * Supported format:
- * ```
- * | Header 1 | Header 2 |
- * | -------- | -------- |
- * | Cell 1   | Cell 2   |
- * ```
+ * Only succeeds when the **entire** text is a single markdown table.
+ * For mixed text+table content, use `parseMarkdownWithTables()`.
  */
 export function parseMarkdownTableToTableCells(text: string): TableCell[][] | null {
   if (!text) return null;
@@ -453,27 +487,14 @@ export function parseMarkdownTableToTableCells(text: string): TableCell[][] | nu
   const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0);
   if (lines.length < 2) return null;
 
-  // The second line must be a separator
   if (!MD_SEPARATOR_RE.test(lines[1])) return null;
-
-  // The first line must contain at least one pipe
   if (!lines[0].includes('|')) return null;
-
-  const parseRow = (line: string): string[] => {
-    // Strip leading/trailing pipes
-    let trimmed = line;
-    if (trimmed.startsWith('|')) trimmed = trimmed.slice(1);
-    if (trimmed.endsWith('|')) trimmed = trimmed.slice(0, -1);
-    return trimmed.split('|').map(cell => cell.trim());
-  };
 
   const rows: TableCell[][] = [];
 
   for (let i = 0; i < lines.length; i++) {
-    // Skip separator line
-    if (i === 1) continue;
-
-    const cellTexts = parseRow(lines[i]);
+    if (i === 1) continue; // skip separator
+    const cellTexts = parseMdRow(lines[i]);
     rows.push(cellTexts.map(t => makeCellFromInlines(
       t.length > 0 ? [{ text: t, style: {} }] : [],
       {},
@@ -482,7 +503,6 @@ export function parseMarkdownTableToTableCells(text: string): TableCell[][] | nu
 
   if (rows.length === 0) return null;
 
-  // Pad short rows
   const maxCols = Math.max(...rows.map(r => r.length));
   for (const row of rows) {
     while (row.length < maxCols) {
@@ -491,4 +511,64 @@ export function parseMarkdownTableToTableCells(text: string): TableCell[][] | nu
   }
 
   return rows;
+}
+
+/**
+ * Parse plain text that may contain markdown tables interspersed with
+ * regular text.  Returns a Block[] where table regions become table blocks
+ * and text regions become paragraph blocks.
+ *
+ * Returns null if no markdown table is found (caller should fall through
+ * to plain-text paste).
+ */
+export function parseMarkdownWithTables(text: string): Block[] | null {
+  if (!text) return null;
+
+  const lines = text.split('\n');
+  const blocks: Block[] = [];
+  let i = 0;
+  let foundTable = false;
+
+  while (i < lines.length) {
+    // Detect markdown table: current line has `|` and next line is separator
+    if (
+      i + 1 < lines.length &&
+      lines[i].includes('|') &&
+      MD_SEPARATOR_RE.test(lines[i + 1].trim())
+    ) {
+      foundTable = true;
+      const rowTexts: string[][] = [parseMdRow(lines[i].trim())]; // header
+      i += 2; // skip header + separator
+
+      // Collect data rows — lines containing `|`
+      while (i < lines.length && lines[i].trim().includes('|')) {
+        rowTexts.push(parseMdRow(lines[i].trim()));
+        i++;
+      }
+
+      blocks.push(buildTableBlockFromRows(rowTexts));
+    } else {
+      const line = lines[i];
+      if (line.trim().length > 0) {
+        blocks.push(makeBlock([{ text: line, style: {} }]));
+      } else if (blocks.length > 0) {
+        // Preserve blank lines between content as empty paragraphs
+        blocks.push(makeBlock([]));
+      }
+      i++;
+    }
+  }
+
+  if (!foundTable) return null;
+
+  // insertBlocks merges the first and last blocks with surrounding text.
+  // Table blocks cannot be merged, so pad with empty paragraphs if needed.
+  if (blocks.length > 0 && blocks[0].type === 'table') {
+    blocks.unshift(makeBlock([]));
+  }
+  if (blocks.length > 0 && blocks[blocks.length - 1].type === 'table') {
+    blocks.push(makeBlock([]));
+  }
+
+  return blocks;
 }

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1,7 +1,7 @@
 import type { Block, BlockCellInfo, CellAddress, DocPosition, DocRange, Inline, InlineStyle, HeadingLevel, TableCell } from '../model/types.js';
 import { generateBlockId, getBlockText, getBlockTextLength, DEFAULT_BLOCK_STYLE, createBlock, createTableBlock } from '../model/types.js';
 import { Doc, type EditContext } from '../model/document.js';
-import { serializeClipboard, deserializeClipboard, cloneTableCells, parseHtmlToBlocks, parseHtmlTableToTableCells, parseMarkdownTableToTableCells, WAFFLEDOCS_MIME } from './clipboard.js';
+import { serializeClipboard, deserializeClipboard, cloneTableCells, parseHtmlToBlocks, parseHtmlTableToTableCells, parseMarkdownTableToTableCells, parseMarkdownWithTables, WAFFLEDOCS_MIME } from './clipboard.js';
 import { Cursor } from './cursor.js';
 import { Selection, expandCellRangeForMerges, findMergeTopLeft } from './selection.js';
 import type { DocumentLayout } from './layout.js';
@@ -822,12 +822,23 @@ export class TextEditor {
     const text = e.clipboardData?.getData('text/plain');
     if (!text) return;
 
-    // Try markdown table
+    // Try pure markdown table (enables cell-by-cell paste into existing tables)
     const mdTableCells = parseMarkdownTableToTableCells(text);
     if (mdTableCells) {
       this.saveSnapshot();
       this.deleteSelection();
       this.pasteTableCells(mdTableCells);
+      this.selection.setRange(null);
+      this.requestRender();
+      return;
+    }
+
+    // Try mixed markdown with tables (e.g. full document with tables)
+    const mdBlocks = parseMarkdownWithTables(text);
+    if (mdBlocks) {
+      this.saveSnapshot();
+      this.deleteSelection();
+      this.insertBlocks(mdBlocks);
       this.selection.setRange(null);
       this.requestRender();
       return;

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -822,26 +822,29 @@ export class TextEditor {
     const text = e.clipboardData?.getData('text/plain');
     if (!text) return;
 
-    // Try pure markdown table (enables cell-by-cell paste into existing tables)
-    const mdTableCells = parseMarkdownTableToTableCells(text);
-    if (mdTableCells) {
-      this.saveSnapshot();
-      this.deleteSelection();
-      this.pasteTableCells(mdTableCells);
-      this.selection.setRange(null);
-      this.requestRender();
-      return;
-    }
+    // Try markdown table parsers (skip when shift is held — force plain-text)
+    if (!this.shiftHeld) {
+      // Try pure markdown table (enables cell-by-cell paste into existing tables)
+      const mdTableCells = parseMarkdownTableToTableCells(text);
+      if (mdTableCells) {
+        this.saveSnapshot();
+        this.deleteSelection();
+        this.pasteTableCells(mdTableCells);
+        this.selection.setRange(null);
+        this.requestRender();
+        return;
+      }
 
-    // Try mixed markdown with tables (e.g. full document with tables)
-    const mdBlocks = parseMarkdownWithTables(text);
-    if (mdBlocks) {
-      this.saveSnapshot();
-      this.deleteSelection();
-      this.insertBlocks(mdBlocks);
-      this.selection.setRange(null);
-      this.requestRender();
-      return;
+      // Try mixed markdown with tables (e.g. full document with tables)
+      const mdBlocks = parseMarkdownWithTables(text);
+      if (mdBlocks) {
+        this.saveSnapshot();
+        this.deleteSelection();
+        this.insertBlocks(mdBlocks);
+        this.selection.setRange(null);
+        this.requestRender();
+        return;
+      }
     }
 
     this.saveSnapshot();

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -2991,7 +2991,17 @@ export class TextEditor {
     // If cursor is on a non-editable block, split to create a text block first
     this.ensureEditableBlock();
     const pos = this.cursor.position;
-    if (blocks.length === 1) {
+    if (blocks.length === 1 && blocks[0].type === 'table') {
+      // Single table block: insert as a new block (cannot merge into current)
+      this.invalidateLayout();
+      const blockIdx = this.doc.getBlockIndex(pos.blockId);
+      const newBlock: Block = { ...blocks[0], id: generateBlockId() };
+      this.doc.insertBlockAt(blockIdx + 1, newBlock);
+      const firstCellBlock = newBlock.tableData?.rows[0]?.cells[0]?.blocks[0];
+      if (firstCellBlock) {
+        this.cursor.moveTo({ blockId: firstCellBlock.id, offset: 0 }, 'forward');
+      }
+    } else if (blocks.length === 1) {
       // Single block: merge pasted inlines into the current block at cursor
       const pastedInlines = blocks[0].inlines;
       const pastedTextLen = pastedInlines.reduce((sum, il) => sum + il.text.length, 0);

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1,7 +1,7 @@
 import type { Block, BlockCellInfo, CellAddress, DocPosition, DocRange, Inline, InlineStyle, HeadingLevel, TableCell } from '../model/types.js';
 import { generateBlockId, getBlockText, getBlockTextLength, DEFAULT_BLOCK_STYLE, createBlock, createTableBlock } from '../model/types.js';
 import { Doc, type EditContext } from '../model/document.js';
-import { serializeClipboard, deserializeClipboard, cloneTableCells, parseHtmlToBlocks, WAFFLEDOCS_MIME } from './clipboard.js';
+import { serializeClipboard, deserializeClipboard, cloneTableCells, parseHtmlToBlocks, parseHtmlTableToTableCells, parseMarkdownTableToTableCells, WAFFLEDOCS_MIME } from './clipboard.js';
 import { Cursor } from './cursor.js';
 import { Selection, expandCellRangeForMerges, findMergeTopLeft } from './selection.js';
 import type { DocumentLayout } from './layout.js';
@@ -795,6 +795,17 @@ export class TextEditor {
     if (!this.shiftHeld) {
       const html = e.clipboardData?.getData('text/html');
       if (html) {
+        // Try HTML table first
+        const tableCells = parseHtmlTableToTableCells(html);
+        if (tableCells) {
+          this.saveSnapshot();
+          this.deleteSelection();
+          this.pasteTableCells(tableCells);
+          this.selection.setRange(null);
+          this.requestRender();
+          return;
+        }
+
         const blocks = parseHtmlToBlocks(html);
         if (blocks.length > 0) {
           this.saveSnapshot();
@@ -810,6 +821,17 @@ export class TextEditor {
     // Fall through to plain text handling
     const text = e.clipboardData?.getData('text/plain');
     if (!text) return;
+
+    // Try markdown table
+    const mdTableCells = parseMarkdownTableToTableCells(text);
+    if (mdTableCells) {
+      this.saveSnapshot();
+      this.deleteSelection();
+      this.pasteTableCells(mdTableCells);
+      this.selection.setRange(null);
+      this.requestRender();
+      return;
+    }
 
     this.saveSnapshot();
     this.deleteSelection();

--- a/packages/docs/test/view/clipboard.test.ts
+++ b/packages/docs/test/view/clipboard.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
 import type { TableCell } from '../../src/model/types.js';
-import { serializeClipboard, deserializeClipboard, cloneTableCells, serializeBlocks, deserializeBlocks, parseHtmlToInlines, parseHtmlTableToTableCells, parseMarkdownTableToTableCells, parseMarkdownWithTables } from '../../src/view/clipboard.js';
+import { serializeClipboard, deserializeClipboard, cloneTableCells, serializeBlocks, deserializeBlocks, parseHtmlToInlines, parseHtmlToBlocks, parseHtmlTableToTableCells, parseMarkdownTableToTableCells, parseMarkdownWithTables } from '../../src/view/clipboard.js';
 
 describe('clipboard JSON serialization', () => {
   it('should round-trip blocks with formatting', () => {
@@ -249,6 +249,24 @@ describe('HTML paste parsing', () => {
     expect(inlines).toHaveLength(1);
     expect(inlines[0].text).toBe('hello world');
   });
+
+  it('should not insert empty paragraphs between list items', () => {
+    const blocks = parseHtmlToBlocks('<ul>\n<li>Item 1</li>\n<li>Item 2</li>\n</ul>');
+    // Should produce exactly 2 list-item blocks, no empty paragraphs between them
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe('list-item');
+    expect(blocks[0].inlines[0].text).toBe('Item 1');
+    expect(blocks[1].type).toBe('list-item');
+    expect(blocks[1].inlines[0].text).toBe('Item 2');
+  });
+
+  it('should preserve spaces between inline elements', () => {
+    const inlines = parseHtmlToInlines('<b>hello</b> <i>world</i>');
+    expect(inlines).toHaveLength(3);
+    expect(inlines[0].text).toBe('hello');
+    expect(inlines[1].text).toBe(' ');
+    expect(inlines[2].text).toBe('world');
+  });
 });
 
 describe('cloneTableCells', () => {
@@ -379,6 +397,53 @@ describe('parseHtmlTableToTableCells', () => {
     expect(cells).not.toBeNull();
     expect(cells![0][0].blocks[0].inlines[0].style.href).toBe('https://example.com');
     expect(cells![0][0].blocks[0].inlines[0].text).toBe('link');
+  });
+});
+
+describe('parseHtmlToBlocks with tables', () => {
+  it('should convert inline <table> to table block in mixed HTML', () => {
+    const html = '<p>Before</p><table><tr><td>A</td><td>B</td></tr><tr><td>1</td><td>2</td></tr></table><p>After</p>';
+    const blocks = parseHtmlToBlocks(html);
+    const tableBlock = blocks.find(b => b.type === 'table');
+    expect(tableBlock).toBeDefined();
+    expect(tableBlock!.tableData).toBeDefined();
+    expect(tableBlock!.tableData!.rows).toHaveLength(2);
+    expect(tableBlock!.tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('A');
+    expect(tableBlock!.tableData!.rows[1].cells[1].blocks[0].inlines[0].text).toBe('2');
+
+    // Text blocks should also exist
+    const textBlocks = blocks.filter(b => b.type === 'paragraph' && b.inlines[0].text.length > 0);
+    const texts = textBlocks.map(b => b.inlines[0].text);
+    expect(texts).toContain('Before');
+    expect(texts).toContain('After');
+  });
+
+  it('should handle multiple tables in mixed HTML', () => {
+    const html = '<p>Intro</p><table><tr><td>T1</td></tr></table><p>Middle</p><table><tr><td>T2</td></tr></table>';
+    const blocks = parseHtmlToBlocks(html);
+    const tables = blocks.filter(b => b.type === 'table');
+    expect(tables).toHaveLength(2);
+    expect(tables[0].tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('T1');
+    expect(tables[1].tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('T2');
+  });
+
+  it('should preserve inline formatting inside table cells', () => {
+    const html = '<table><tr><td><strong>bold</strong> text</td></tr></table>';
+    const blocks = parseHtmlToBlocks(html);
+    const tableBlock = blocks.find(b => b.type === 'table');
+    expect(tableBlock).toBeDefined();
+    const inlines = tableBlock!.tableData!.rows[0].cells[0].blocks[0].inlines;
+    expect(inlines[0].style.bold).toBe(true);
+    expect(inlines[0].text).toBe('bold');
+    expect(inlines[1].text).toBe(' text');
+  });
+
+  it('should handle thead/tbody wrappers in mixed HTML', () => {
+    const html = '<h1>Title</h1><table><thead><tr><th>H</th></tr></thead><tbody><tr><td>D</td></tr></tbody></table>';
+    const blocks = parseHtmlToBlocks(html);
+    const tableBlock = blocks.find(b => b.type === 'table');
+    expect(tableBlock).toBeDefined();
+    expect(tableBlock!.tableData!.rows).toHaveLength(2);
   });
 });
 

--- a/packages/docs/test/view/clipboard.test.ts
+++ b/packages/docs/test/view/clipboard.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
 import type { TableCell } from '../../src/model/types.js';
-import { serializeClipboard, deserializeClipboard, cloneTableCells, serializeBlocks, deserializeBlocks, parseHtmlToInlines } from '../../src/view/clipboard.js';
+import { serializeClipboard, deserializeClipboard, cloneTableCells, serializeBlocks, deserializeBlocks, parseHtmlToInlines, parseHtmlTableToTableCells, parseMarkdownTableToTableCells } from '../../src/view/clipboard.js';
 
 describe('clipboard JSON serialization', () => {
   it('should round-trip blocks with formatting', () => {
@@ -293,5 +293,161 @@ describe('cloneTableCells', () => {
     const cloned = cloneTableCells(cells);
     cells[0][0].style.padding = 99;
     expect(cloned[0][0].style.padding).toBe(8);
+  });
+});
+
+describe('parseHtmlTableToTableCells', () => {
+  it('should parse a simple HTML table', () => {
+    const html = '<table><tr><td>A1</td><td>B1</td></tr><tr><td>A2</td><td>B2</td></tr></table>';
+    const cells = parseHtmlTableToTableCells(html);
+    expect(cells).not.toBeNull();
+    expect(cells).toHaveLength(2);
+    expect(cells![0]).toHaveLength(2);
+    expect(cells![0][0].blocks[0].inlines[0].text).toBe('A1');
+    expect(cells![0][1].blocks[0].inlines[0].text).toBe('B1');
+    expect(cells![1][0].blocks[0].inlines[0].text).toBe('A2');
+    expect(cells![1][1].blocks[0].inlines[0].text).toBe('B2');
+  });
+
+  it('should preserve inline formatting in cells', () => {
+    const html = '<table><tr><td><b>bold</b></td><td><i>italic</i></td></tr></table>';
+    const cells = parseHtmlTableToTableCells(html);
+    expect(cells).not.toBeNull();
+    expect(cells![0][0].blocks[0].inlines[0].style.bold).toBe(true);
+    expect(cells![0][1].blocks[0].inlines[0].style.italic).toBe(true);
+  });
+
+  it('should handle th elements', () => {
+    const html = '<table><tr><th>Header</th></tr><tr><td>Data</td></tr></table>';
+    const cells = parseHtmlTableToTableCells(html);
+    expect(cells).not.toBeNull();
+    expect(cells).toHaveLength(2);
+    expect(cells![0][0].blocks[0].inlines[0].text).toBe('Header');
+    expect(cells![1][0].blocks[0].inlines[0].text).toBe('Data');
+  });
+
+  it('should handle thead/tbody wrappers', () => {
+    const html = '<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>D</td></tr></tbody></table>';
+    const cells = parseHtmlTableToTableCells(html);
+    expect(cells).not.toBeNull();
+    expect(cells).toHaveLength(2);
+    expect(cells![0][0].blocks[0].inlines[0].text).toBe('H');
+    expect(cells![1][0].blocks[0].inlines[0].text).toBe('D');
+  });
+
+  it('should pad ragged rows', () => {
+    const html = '<table><tr><td>A</td><td>B</td><td>C</td></tr><tr><td>D</td></tr></table>';
+    const cells = parseHtmlTableToTableCells(html);
+    expect(cells).not.toBeNull();
+    expect(cells![0]).toHaveLength(3);
+    expect(cells![1]).toHaveLength(3);
+    expect(cells![1][1].blocks[0].inlines[0].text).toBe('');
+  });
+
+  it('should return null for non-table HTML', () => {
+    const html = '<p>Just a paragraph</p>';
+    expect(parseHtmlTableToTableCells(html)).toBeNull();
+  });
+
+  it('should return null for mixed table + paragraph content', () => {
+    const html = '<p>Some text</p><table><tr><td>A</td></tr></table>';
+    expect(parseHtmlTableToTableCells(html)).toBeNull();
+  });
+
+  it('should return null for empty string', () => {
+    expect(parseHtmlTableToTableCells('')).toBeNull();
+  });
+
+  it('should allow meta/style tags alongside table (Google Sheets)', () => {
+    const html = '<meta charset="utf-8"><style>td{}</style><table><tr><td>A</td></tr></table>';
+    const cells = parseHtmlTableToTableCells(html);
+    expect(cells).not.toBeNull();
+    expect(cells![0][0].blocks[0].inlines[0].text).toBe('A');
+  });
+
+  it('should handle empty cells', () => {
+    const html = '<table><tr><td></td><td>B</td></tr></table>';
+    const cells = parseHtmlTableToTableCells(html);
+    expect(cells).not.toBeNull();
+    expect(cells![0][0].blocks[0].inlines[0].text).toBe('');
+    expect(cells![0][1].blocks[0].inlines[0].text).toBe('B');
+  });
+
+  it('should handle links in cells', () => {
+    const html = '<table><tr><td><a href="https://example.com">link</a></td></tr></table>';
+    const cells = parseHtmlTableToTableCells(html);
+    expect(cells).not.toBeNull();
+    expect(cells![0][0].blocks[0].inlines[0].style.href).toBe('https://example.com');
+    expect(cells![0][0].blocks[0].inlines[0].text).toBe('link');
+  });
+});
+
+describe('parseMarkdownTableToTableCells', () => {
+  it('should parse a simple markdown table', () => {
+    const text = '| A | B |\n| --- | --- |\n| 1 | 2 |';
+    const cells = parseMarkdownTableToTableCells(text);
+    expect(cells).not.toBeNull();
+    expect(cells).toHaveLength(2); // header + 1 data row
+    expect(cells![0][0].blocks[0].inlines[0].text).toBe('A');
+    expect(cells![0][1].blocks[0].inlines[0].text).toBe('B');
+    expect(cells![1][0].blocks[0].inlines[0].text).toBe('1');
+    expect(cells![1][1].blocks[0].inlines[0].text).toBe('2');
+  });
+
+  it('should handle multiple data rows', () => {
+    const text = '| H1 | H2 |\n| --- | --- |\n| A | B |\n| C | D |';
+    const cells = parseMarkdownTableToTableCells(text);
+    expect(cells).not.toBeNull();
+    expect(cells).toHaveLength(3);
+    expect(cells![2][0].blocks[0].inlines[0].text).toBe('C');
+    expect(cells![2][1].blocks[0].inlines[0].text).toBe('D');
+  });
+
+  it('should handle alignment separators', () => {
+    const text = '| L | C | R |\n| :--- | :---: | ---: |\n| a | b | c |';
+    const cells = parseMarkdownTableToTableCells(text);
+    expect(cells).not.toBeNull();
+    expect(cells).toHaveLength(2);
+  });
+
+  it('should pad ragged rows', () => {
+    const text = '| A | B | C |\n| --- | --- | --- |\n| 1 |';
+    const cells = parseMarkdownTableToTableCells(text);
+    expect(cells).not.toBeNull();
+    expect(cells![1]).toHaveLength(3);
+    expect(cells![1][1].blocks[0].inlines[0].text).toBe('');
+  });
+
+  it('should return null for non-table text', () => {
+    expect(parseMarkdownTableToTableCells('Just some text')).toBeNull();
+  });
+
+  it('should return null for text without separator line', () => {
+    expect(parseMarkdownTableToTableCells('| A | B |\n| C | D |')).toBeNull();
+  });
+
+  it('should return null for empty string', () => {
+    expect(parseMarkdownTableToTableCells('')).toBeNull();
+  });
+
+  it('should return null for single line', () => {
+    expect(parseMarkdownTableToTableCells('| A | B |')).toBeNull();
+  });
+
+  it('should handle tables without leading/trailing pipes', () => {
+    const text = 'A | B\n--- | ---\n1 | 2';
+    const cells = parseMarkdownTableToTableCells(text);
+    expect(cells).not.toBeNull();
+    expect(cells![0][0].blocks[0].inlines[0].text).toBe('A');
+    expect(cells![1][1].blocks[0].inlines[0].text).toBe('2');
+  });
+
+  it('should handle empty cells in markdown', () => {
+    const text = '| A | |\n| --- | --- |\n| | B |';
+    const cells = parseMarkdownTableToTableCells(text);
+    expect(cells).not.toBeNull();
+    expect(cells![0][1].blocks[0].inlines[0].text).toBe('');
+    expect(cells![1][0].blocks[0].inlines[0].text).toBe('');
+    expect(cells![1][1].blocks[0].inlines[0].text).toBe('B');
   });
 });

--- a/packages/docs/test/view/clipboard.test.ts
+++ b/packages/docs/test/view/clipboard.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
 import type { TableCell } from '../../src/model/types.js';
-import { serializeClipboard, deserializeClipboard, cloneTableCells, serializeBlocks, deserializeBlocks, parseHtmlToInlines, parseHtmlTableToTableCells, parseMarkdownTableToTableCells } from '../../src/view/clipboard.js';
+import { serializeClipboard, deserializeClipboard, cloneTableCells, serializeBlocks, deserializeBlocks, parseHtmlToInlines, parseHtmlTableToTableCells, parseMarkdownTableToTableCells, parseMarkdownWithTables } from '../../src/view/clipboard.js';
 
 describe('clipboard JSON serialization', () => {
   it('should round-trip blocks with formatting', () => {
@@ -449,5 +449,85 @@ describe('parseMarkdownTableToTableCells', () => {
     expect(cells![0][1].blocks[0].inlines[0].text).toBe('');
     expect(cells![1][0].blocks[0].inlines[0].text).toBe('');
     expect(cells![1][1].blocks[0].inlines[0].text).toBe('B');
+  });
+});
+
+describe('parseMarkdownWithTables', () => {
+  it('should parse mixed text and table', () => {
+    const text = 'Some intro text\n\n| A | B |\n| --- | --- |\n| 1 | 2 |\n\nSome outro text';
+    const blocks = parseMarkdownWithTables(text);
+    expect(blocks).not.toBeNull();
+
+    // Find the table block
+    const tableBlock = blocks!.find(b => b.type === 'table');
+    expect(tableBlock).toBeDefined();
+    expect(tableBlock!.tableData).toBeDefined();
+    expect(tableBlock!.tableData!.rows).toHaveLength(2);
+    expect(tableBlock!.tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('A');
+    expect(tableBlock!.tableData!.rows[1].cells[1].blocks[0].inlines[0].text).toBe('2');
+
+    // Text blocks should exist
+    const textBlocks = blocks!.filter(b => b.type === 'paragraph' && b.inlines[0].text.length > 0);
+    const texts = textBlocks.map(b => b.inlines[0].text);
+    expect(texts).toContain('Some intro text');
+    expect(texts).toContain('Some outro text');
+  });
+
+  it('should handle multiple tables in text', () => {
+    const text = 'Before\n\n| A | B |\n| --- | --- |\n| 1 | 2 |\n\nMiddle\n\n| C | D |\n| --- | --- |\n| 3 | 4 |\n\nAfter';
+    const blocks = parseMarkdownWithTables(text);
+    expect(blocks).not.toBeNull();
+
+    const tables = blocks!.filter(b => b.type === 'table');
+    expect(tables).toHaveLength(2);
+    expect(tables[0].tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('A');
+    expect(tables[1].tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('C');
+  });
+
+  it('should return null when no tables present', () => {
+    const text = 'Just some plain text\nWith multiple lines';
+    expect(parseMarkdownWithTables(text)).toBeNull();
+  });
+
+  it('should pad with empty paragraph when table is first', () => {
+    const text = '| A | B |\n| --- | --- |\n| 1 | 2 |\n\nAfter text';
+    const blocks = parseMarkdownWithTables(text);
+    expect(blocks).not.toBeNull();
+    // First block should be an empty paragraph (padding for insertBlocks)
+    expect(blocks![0].type).toBe('paragraph');
+    expect(blocks![0].inlines[0].text).toBe('');
+  });
+
+  it('should pad with empty paragraph when table is last', () => {
+    const text = 'Before text\n\n| A | B |\n| --- | --- |\n| 1 | 2 |';
+    const blocks = parseMarkdownWithTables(text);
+    expect(blocks).not.toBeNull();
+    const last = blocks![blocks!.length - 1];
+    expect(last.type).toBe('paragraph');
+    expect(last.inlines[0].text).toBe('');
+  });
+
+  it('should return null for empty string', () => {
+    expect(parseMarkdownWithTables('')).toBeNull();
+  });
+
+  it('should handle table at start and end of text', () => {
+    const text = '| A |\n| --- |\n| 1 |\n\n| B |\n| --- |\n| 2 |';
+    const blocks = parseMarkdownWithTables(text);
+    expect(blocks).not.toBeNull();
+    const tables = blocks!.filter(b => b.type === 'table');
+    expect(tables).toHaveLength(2);
+    // Should be padded at start and end
+    expect(blocks![0].type).toBe('paragraph');
+    expect(blocks![blocks!.length - 1].type).toBe('paragraph');
+  });
+
+  it('should preserve blank lines as empty paragraphs', () => {
+    const text = 'Line 1\n\nLine 2\n\n| A |\n| --- |\n| 1 |';
+    const blocks = parseMarkdownWithTables(text);
+    expect(blocks).not.toBeNull();
+    // Should have paragraphs for text and empty lines
+    const nonTableBlocks = blocks!.filter(b => b.type !== 'table');
+    expect(nonTableBlocks.length).toBeGreaterThanOrEqual(3);
   });
 });


### PR DESCRIPTION
## Summary

- Add `parseHtmlTableToTableCells()` to convert pasted HTML `<table>` elements (from Google Docs, Sheets, web browsers) into doc table blocks
- Add `parseMarkdownTableToTableCells()` to convert pasted markdown table syntax (`| col | col |`) into doc table blocks
- Update `handlePaste` flow to try table parsers before existing fallbacks
- Update Phase 3 section in `docs-table-copy-paste.md` design doc

This implements Phase 3 of the docs table copy-paste design.

## Test plan

- [x] Paste an HTML table from Google Sheets → should create a table block
- [x] Paste an HTML table from a web page → should create a table block with inline formatting preserved
- [x] Paste a markdown table (header + separator + rows) → should create a table block
- [x] Paste mixed HTML (paragraph + table) → should fall through to block paste, not table
- [x] Paste plain text that is not a markdown table → should insert as plain text
- [x] Paste a markdown table into an existing table cell → should fill cells from cursor position
- [x] Shift+paste HTML table → should insert as plain text (shift forces plain text)
- [x] 21 unit tests added for both parsers (edge cases, formatting, ragged rows, rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now paste tables from external HTML and markdown sources directly into the editor with automatic format detection and proper structure preservation.

* **Documentation**
  * Updated design documentation to describe external table paste behavior and parsing specifications.

* **Tests**
  * Added comprehensive test coverage for table parsing from multiple formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->