### PR TITLE
Work around editByPath merge failure after split

### DIFF
--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -1590,13 +1590,37 @@ export class YorkieDocStore implements DocStore {
       // number of inline nodes than the cache (e.g. split fragments).
       const treeRoot = tree.getRootTreeNode();
       const blockNode = this.getTreeBlockNode(treeRoot, blockPath) as ElementNode;
+      const nextBlockNode = this.getTreeBlockNode(treeRoot, nextPath) as ElementNode;
       const treeInlineCount = (blockNode.children ?? []).filter(
         (c) => c.type === 'inline',
       ).length;
-      // Delete the boundary between the two blocks. This range starts just
-      // past the last inline of the first block and ends just before the
-      // first inline of the next block, causing Yorkie Tree to merge them.
-      tree.editByPath([...blockPath, treeInlineCount], [...nextPath, 0]);
+
+      // Workaround for yorkie-js-sdk Phase 3 Range Narrowing bug:
+      // A single cross-boundary editByPath fails on blocks created by
+      // splitLevel>=2 because the insNextID chain causes the collection
+      // range to be narrowed to empty. Instead, decompose into two
+      // same-parent operations: (1) delete the next block, (2) insert
+      // its inline children at the end of the first block.
+      const parentPath = blockPath.slice(0, -1);
+      const inlineChildren = (nextBlockNode.children ?? []).filter(
+        (c): c is ElementNode => c.type === 'inline',
+      );
+
+      // Step 1: Delete the next block element (same-parent edit).
+      tree.editByPath(nextPath, [...parentPath, nextLastIdx + 1]);
+
+      // Step 2: Insert the next block's inlines at the end of the first
+      // block. Deep-clone nodes so Yorkie creates fresh CRDT nodes.
+      if (inlineChildren.length > 0) {
+        const cloned = inlineChildren.map((n) =>
+          JSON.parse(JSON.stringify(n)) as TreeNode,
+        );
+        tree.editBulkByPath(
+          [...blockPath, treeInlineCount],
+          [...blockPath, treeInlineCount],
+          cloned,
+        );
+      }
     });
 
     const merged = applyMergeBlocks(firstBlock, nextBlock);


### PR DESCRIPTION
## Summary

- Fix backspace not merging blocks in docs editor when the blocks were created by Enter (splitLevel>=2)
- Decompose the single cross-boundary `editByPath` into two same-parent operations to avoid the SDK's Phase 3 Range Narrowing bug

## Problem

When pressing Enter in a paragraph (e.g., "as|df" → "as" + "df"), the split creates CRDT nodes linked via `insNextID`. A subsequent backspace calling `editByPath([blockPath, inlineCount], [nextPath, 0])` fails silently because the SDK's Range Narrowing follows the `insNextID` chain and narrows the collection range to empty.

## Fix

Replace the single cross-boundary edit with two same-parent operations:
1. **Delete** the next block element: `editByPath(nextPath, [parentPath, nextIdx+1])`
2. **Insert** its inline children at the end of the first block: `editBulkByPath(...)`

Both operations stay within the same parent element, avoiding the Range Narrowing code path.

Related SDK issue: yorkie-team/yorkie-js-sdk#1237

## Test plan

- [x] `pnpm verify:fast` passes (all 622 docs + 1204 sheets + 167 frontend tests)
- [x] "split then merge round-trip" test continues to pass
- [x] Manual test: type "asdf", press Enter after "as", press Backspace → should merge back to "asdf"
- [x] Manual test with styled text (bold "as" + normal "df") → merge preserves styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block merging to handle complex document structures more reliably. The merge operation now uses an optimized two-step process that separately handles the deletion and reinsertion of block content, ensuring better stability when working with nested block elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->