### PR TITLE
Extend outline borders across row/column insertion seam

### DIFF
--- a/docs/design/sheets/sheet-style.md
+++ b/docs/design/sheets/sheet-style.md
@@ -108,6 +108,21 @@ index mapping rules as cells:
 This keeps style behavior stable across structural edits while reducing patch
 count growth.
 
+Per-cell custom borders (`bt/bl/br/bb`) — produced by `setRangeBorders` — are
+stored on individual cells, not as range patches, so the range-expansion rule
+above does not apply to them directly. Instead, after a row/column insert, the
+sheet scans the two cells flanking the insertion seam in each populated
+column/row and writes the borders that were continuous across the seam onto
+the inserted cells:
+
+- row insert: shared `bl`/`br` between row `index-1` and row `index+count`
+  extends into every inserted row at that column
+- column insert: shared `bt`/`bb` between column `index-1` and column
+  `index+count` extends into every inserted column at that row
+
+The result matches Google Sheets: an outer border drawn around `A1:B2` stays
+unbroken when a row is inserted between rows 1 and 2.
+
 ## Copy/Paste
 
 Internal copy buffer includes clipped `rangeStyles` intersecting copied range.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -24,7 +24,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 141
+- Archived task count: 142
 - Archive index: [archive/README.md](./archive/README.md)
 
 Latest active task: docx table style followup (2026-04-12)

--- a/docs/tasks/archive/2026/04/20260428-border-outline-extension-todo.md
+++ b/docs/tasks/archive/2026/04/20260428-border-outline-extension-todo.md
@@ -1,0 +1,60 @@
+# Border outline extension on row/column insert
+
+**Status:** done
+**Scope:** `packages/sheets/src/model/worksheet/sheet.ts`,
+`packages/sheets/test/sheet/formatting.test.ts`
+
+## Goal
+
+Match Google Sheets behavior: when a row/column is inserted inside a
+range that already carries an outer border, the borders that run
+continuously across the insertion seam (left/right for row inserts,
+top/bottom for column inserts) extend into the new row/column so the
+outline stays visually unbroken.
+
+## Rule
+
+For a row insert at `index` with `count` rows:
+
+- For each column `c` where the cell at `(index-1, c)` and the cell at
+  `(index+count, c)` (after shift) both have `bl: true`, set
+  `bl: true` on every inserted cell `(i, c)` for `i ∈ [index, index+count-1]`.
+- Same with `br: true`.
+
+Symmetric for column insert at `index`:
+
+- For each row `r` where `(r, index-1)` and `(r, index+count)` share
+  `bt: true`, set `bt: true` on every inserted `(r, j)` for
+  `j ∈ [index, index+count-1]`. Same with `bb`.
+
+Borders are inherited only when **both adjacent cells** share the same
+truthy value — partial / asymmetric borders do not extend.
+
+## Implementation plan
+
+1. Add a private helper `extendBordersAcrossInsertion` on `Sheet` that
+   runs after `store.shiftCells` succeeds (only on inserts, count > 0).
+2. Identify candidate columns/rows: scan cells in the two seam
+   bands (above + below) that already carry the relevant border flags.
+3. For each candidate where both bands agree, apply `setStyle` on the
+   inserted cells inside the same store batch.
+4. Use `getStyle` (effective style) so that column/row/sheet-level
+   borders are honored, not just per-cell.
+
+## Verification
+
+- The two failing tests in `formatting.test.ts` should pass.
+- Existing border tests must keep passing (no regression on the
+  preset-application path).
+- `pnpm verify:fast`.
+
+## Result
+
+- Added `extendBordersAcrossInsertion` to `Sheet`, called inside the
+  existing post-shift batch in `shiftCells`.
+- Three tests added to `formatting.test.ts` (row insert, column
+  insert, insert-outside-range).
+- `pnpm verify:fast` passed: 1207 sheets + 622 docs + 107 backend + 60
+  other tests, exit 0.
+- `docs/design/sheets/sheet-style.md` updated with a paragraph on the
+  per-cell border seam-extension rule.

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,13 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 141
+Total archived tasks: 142
 
-## 2026/04 (27 tasks)
+## 2026/04 (28 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| border outline extension (2026-04-28) | [20260428-border-outline-extension-todo.md](./2026/04/20260428-border-outline-extension-todo.md) | - |
 | block attr intent preserving (2026-04-23) | [20260423-block-attr-intent-preserving-todo.md](./2026/04/20260423-block-attr-intent-preserving-todo.md) | [20260423-block-attr-intent-preserving-lessons.md](./2026/04/20260423-block-attr-intent-preserving-lessons.md) |
 | cell structural edits (2026-04-23) | [20260423-cell-structural-edits-todo.md](./2026/04/20260423-cell-structural-edits-todo.md) | [20260423-cell-structural-edits-lessons.md](./2026/04/20260423-cell-structural-edits-lessons.md) |
 | inline style tests (2026-04-23) | [20260423-inline-style-tests-todo.md](./20260423-inline-style-tests-todo.md) | - |

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -1092,6 +1092,12 @@ export class Sheet {
     // Batch the freeze pane adjustment and formula recalculation together
     this.store.beginBatch();
     try {
+      // Extend continuous outline borders into newly inserted rows/columns
+      // so an outer border that ran across the insertion seam stays unbroken.
+      if (count > 0) {
+        await this.extendBordersAcrossInsertion(axis, index, count);
+      }
+
       // Adjust freeze pane when inserting/deleting near the freeze boundary
       const frozen = axis === 'row' ? this.frozenRows : this.frozenCols;
       if (frozen > 0) {
@@ -1127,6 +1133,85 @@ export class Sheet {
       }
     } finally {
       this.store.endBatch();
+    }
+  }
+
+  /**
+   * `extendBordersAcrossInsertion` writes continuous outline borders into
+   * rows/columns just inserted by `shiftCells`. When both cells flanking
+   * the insertion seam share a vertical border (for row inserts) or a
+   * horizontal border (for column inserts), the inserted cells inherit
+   * that border so the outline does not break — matching the behavior of
+   * Google Sheets.
+   */
+  private async extendBordersAcrossInsertion(
+    axis: Axis,
+    index: number,
+    count: number,
+  ): Promise<void> {
+    if (count <= 0 || index <= 1) return;
+
+    // Border keys that span the insertion seam:
+    //   row insert -> vertical borders (bl, br) running through the seam
+    //   col insert -> horizontal borders (bt, bb) running through the seam
+    const keys: Array<'bt' | 'bb' | 'bl' | 'br'> =
+      axis === 'row' ? ['bl', 'br'] : ['bt', 'bb'];
+
+    // `cellsInRange` only iterates populated rows/cols, so an open-ended
+    // bound here just means "every populated cell on this seam line".
+    const upper = Number.MAX_SAFE_INTEGER;
+    const beforeRange: Range = axis === 'row'
+      ? [{ r: index - 1, c: 1 }, { r: index - 1, c: upper }]
+      : [{ r: 1, c: index - 1 }, { r: upper, c: index - 1 }];
+    const afterRange: Range = axis === 'row'
+      ? [{ r: index + count, c: 1 }, { r: index + count, c: upper }]
+      : [{ r: 1, c: index + count }, { r: upper, c: index + count }];
+
+    const before = await this.store.getGrid(beforeRange);
+    const after = await this.store.getGrid(afterRange);
+
+    const candidates = new Set<number>();
+    for (const sref of before.keys()) {
+      const ref = parseRef(sref);
+      candidates.add(axis === 'row' ? ref.c : ref.r);
+    }
+    for (const sref of after.keys()) {
+      const ref = parseRef(sref);
+      candidates.add(axis === 'row' ? ref.c : ref.r);
+    }
+
+    for (const other of candidates) {
+      const beforeRef: Ref = axis === 'row'
+        ? { r: index - 1, c: other }
+        : { r: other, c: index - 1 };
+      const afterRef: Ref = axis === 'row'
+        ? { r: index + count, c: other }
+        : { r: other, c: index + count };
+
+      const beforeStyle = await this.getStyle(beforeRef);
+      const afterStyle = await this.getStyle(afterRef);
+
+      const inheritedKeys = keys.filter(
+        (key) => beforeStyle?.[key] === true && afterStyle?.[key] === true,
+      );
+      if (inheritedKeys.length === 0) continue;
+
+      for (let i = 0; i < count; i++) {
+        const insertedRef: Ref = axis === 'row'
+          ? { r: index + i, c: other }
+          : { r: other, c: index + i };
+        const existing = await this.getStyle(insertedRef);
+
+        const patch: Partial<CellStyle> = {};
+        for (const key of inheritedKeys) {
+          if (existing?.[key] !== true) {
+            patch[key] = true;
+          }
+        }
+        if (Object.keys(patch).length > 0) {
+          await this.setStyle(insertedRef, patch);
+        }
+      }
     }
   }
 

--- a/packages/sheets/test/sheet/formatting.test.ts
+++ b/packages/sheets/test/sheet/formatting.test.ts
@@ -375,6 +375,134 @@ describe('Sheet.Formatting', () => {
     sheet.selectColumn(1);
     expect(await sheet.setRangeBorders('all')).toBe(false);
   });
+
+  // Google Sheets-like outline extension: when a row/column is inserted
+  // inside an outer-bordered range, borders that run continuously across
+  // the insertion seam are inherited by the new cells so the outline does
+  // not break.
+  it('should extend the left/right outline borders into a row inserted inside the range', async () => {
+    const sheet = new Sheet(new MemStore());
+    sheet.selectStart({ r: 1, c: 1 });
+    sheet.selectEnd({ r: 2, c: 2 });
+    await sheet.setRangeBorders('outer');
+
+    // Insert a row between row 1 and row 2.
+    await sheet.insertRows(2, 1);
+
+    // Original top row keeps its corner borders.
+    expect(await sheet.getStyle({ r: 1, c: 1 })).toEqual({
+      bt: true,
+      bl: true,
+      br: false,
+      bb: false,
+    });
+    expect(await sheet.getStyle({ r: 1, c: 2 })).toEqual({
+      bt: true,
+      bl: false,
+      br: true,
+      bb: false,
+    });
+
+    // New middle row inherits left edge in column 1 and right edge in column 2.
+    const newLeft = await sheet.getStyle({ r: 2, c: 1 });
+    const newRight = await sheet.getStyle({ r: 2, c: 2 });
+    expect(newLeft?.bl).toBe(true);
+    expect(newRight?.br).toBe(true);
+    // No spurious top/bottom borders inside the box.
+    expect(newLeft?.bt).not.toBe(true);
+    expect(newLeft?.bb).not.toBe(true);
+    expect(newRight?.bt).not.toBe(true);
+    expect(newRight?.bb).not.toBe(true);
+
+    // Original bottom row shifts to row 3 with its borders intact.
+    expect(await sheet.getStyle({ r: 3, c: 1 })).toEqual({
+      bt: false,
+      bl: true,
+      br: false,
+      bb: true,
+    });
+    expect(await sheet.getStyle({ r: 3, c: 2 })).toEqual({
+      bt: false,
+      bl: false,
+      br: true,
+      bb: true,
+    });
+  });
+
+  it('should extend the top/bottom outline borders into a column inserted inside the range', async () => {
+    const sheet = new Sheet(new MemStore());
+    sheet.selectStart({ r: 1, c: 1 });
+    sheet.selectEnd({ r: 2, c: 2 });
+    await sheet.setRangeBorders('outer');
+
+    // Insert a column between column A and column B.
+    await sheet.insertColumns(2, 1);
+
+    // Original left column keeps its borders.
+    expect(await sheet.getStyle({ r: 1, c: 1 })).toEqual({
+      bt: true,
+      bl: true,
+      br: false,
+      bb: false,
+    });
+    expect(await sheet.getStyle({ r: 2, c: 1 })).toEqual({
+      bt: false,
+      bl: true,
+      br: false,
+      bb: true,
+    });
+
+    // New middle column inherits top edge in row 1 and bottom edge in row 2.
+    const newTop = await sheet.getStyle({ r: 1, c: 2 });
+    const newBottom = await sheet.getStyle({ r: 2, c: 2 });
+    expect(newTop?.bt).toBe(true);
+    expect(newBottom?.bb).toBe(true);
+    expect(newTop?.bl).not.toBe(true);
+    expect(newTop?.br).not.toBe(true);
+    expect(newBottom?.bl).not.toBe(true);
+    expect(newBottom?.br).not.toBe(true);
+
+    // Original right column shifts to column C with its borders intact.
+    expect(await sheet.getStyle({ r: 1, c: 3 })).toEqual({
+      bt: true,
+      bl: false,
+      br: true,
+      bb: false,
+    });
+    expect(await sheet.getStyle({ r: 2, c: 3 })).toEqual({
+      bt: false,
+      bl: false,
+      br: true,
+      bb: true,
+    });
+  });
+
+  it('should not extend borders into rows inserted outside the bordered range', async () => {
+    const sheet = new Sheet(new MemStore());
+    sheet.selectStart({ r: 2, c: 2 });
+    sheet.selectEnd({ r: 3, c: 3 });
+    await sheet.setRangeBorders('outer');
+
+    // Insert a row above the bordered range — should NOT inherit borders.
+    await sheet.insertRows(1, 1);
+
+    expect(await sheet.getStyle({ r: 1, c: 2 })).toBeUndefined();
+    expect(await sheet.getStyle({ r: 1, c: 3 })).toBeUndefined();
+
+    // The bordered range shifts down intact.
+    expect(await sheet.getStyle({ r: 3, c: 2 })).toEqual({
+      bt: true,
+      bl: true,
+      br: false,
+      bb: false,
+    });
+    expect(await sheet.getStyle({ r: 4, c: 3 })).toEqual({
+      bt: false,
+      bl: false,
+      br: true,
+      bb: true,
+    });
+  });
 });
 
 describe('Sheet.ColumnRowSheetStyles', () => {


### PR DESCRIPTION
## Summary

- Per-cell custom borders (`bt/bl/br/bb`) did not extend into rows/columns inserted inside an outer-bordered range, so an outline drawn on `A1:B2` visibly broke when a row was inserted between rows 1 and 2.
- After the cell shift in `Sheet.shiftCells`, scan the two cells flanking the insertion seam in each populated column/row and copy borders that were continuous across the seam onto the inserted cells — matching Google Sheets behavior.
- Only populated rows/columns are scanned (via the cell index), so the extra work scales with data density, not sheet size.

## Test plan

- [x] `pnpm --filter @wafflebase/sheets test test/sheet/formatting.test.ts` — 3 new tests pass (row insert, column insert, insert outside range)
- [x] `pnpm --filter @wafflebase/sheets test` — 1207 sheets tests pass
- [x] `pnpm verify:fast` — sheets 1207 + docs 622 + backend 107 + 60 other, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Border styles now automatically propagate across newly inserted rows and columns to maintain seamless visual continuity, aligned with standard spreadsheet applications.

* **Tests**
  * Added new tests ensuring correct border continuity behavior when inserting rows and columns within bordered ranges.

* **Documentation**
  * Updated design documentation with border propagation specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->