### PR TITLE
Link docs hierarchy from README and fix broken design references

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,12 @@ real-time collaboration and scalable performance for handling large datasets.
 
 ## Project Structure
 
-```
-packages/
-  sheets/          — Core spreadsheet engine (data model, formulas, Canvas rendering)
-  docs/            — Canvas-based document editor (rich text, inline formatting)
-  frontend/        — React web app (pages, components, hooks)
-  backend/         — NestJS API server (auth, documents, data sources)
-  cli/             — Command-line interface for Wafflebase API
-  documentation/   — VitePress documentation site (wafflebase.io/docs)
-```
+- [packages/sheets/](packages/sheets/README.md) — Core spreadsheet engine (data model, formulas, Canvas rendering)
+- [packages/docs/](packages/docs/README.md) — Canvas-based document editor (rich text, inline formatting)
+- [packages/frontend/](packages/frontend/README.md) — React web app (pages, components, hooks)
+- [packages/backend/](packages/backend/README.md) — NestJS API server (auth, documents, data sources)
+- packages/cli/ — Command-line interface for Wafflebase API ([skills](packages/cli/skills/SKILL.md))
+- [packages/documentation/](packages/documentation/README.md) — VitePress documentation site (wafflebase.io/docs)
 
 The frontend depends on `@wafflebase/sheets` and `@wafflebase/docs` as
 workspace dependencies.
@@ -151,6 +148,12 @@ detached.
 
 - Subject line: what changed, max 70 characters
 - Body: why, wrapped at 80 characters
+
+## Documentation
+
+- [docs/](docs/README.md) — design documents, architecture, and task tracking
+- [MAINTAINING.md](MAINTAINING.md) — release and maintenance procedures
+- [CLAUDE.md](CLAUDE.md) — agent instructions for AI-assisted development (also exposed as `AGENTS.md` via symlink)
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Project documentation for Wafflebase.
 
-| Directory              | Description                                                        |
-| ---------------------- | ------------------------------------------------------------------ |
-| [design/](design/)     | Architecture decisions, data models, and implementation details    |
-| [tasks/](tasks/)       | Task tracking — active work and archived task history              |
+| Directory                       | Description                                                        |
+| ------------------------------- | ------------------------------------------------------------------ |
+| [design/](design/README.md)     | Architecture decisions, data models, and implementation details    |
+| [tasks/](tasks/README.md)       | Task tracking — active work and archived task history              |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -39,6 +39,7 @@ Word processor engine — rich text, tables, pagination, collaboration.
 | [docs-table-resize.md](docs/docs-table-resize.md)                                | Docs table resize — column/row border drag handles, guideline rendering                           |
 | [docs-nested-tables.md](docs/docs-nested-tables.md)                              | Nested tables — recursive nesting, layout, rendering, editing, CRDT synchronization               |
 | [docs-image-editing.md](docs/docs-image-editing.md)                              | Docs image editing — toolbar insert, selection handles, resize, rotation, crop, Image Options panel |
+| [docs-docx-import-export.md](docs/docs-docx-import-export.md)                    | DOCX import/export — round-trip mapping between DOCX and the Docs data model                       |
 | [docs-frontend-integration.md](docs/docs-frontend-integration.md)                | Docs frontend integration — document type field, list UI, routing, backend API changes            |
 | [docs-collaboration.md](docs/docs-collaboration.md)                              | Docs collaboration design                                                                         |
 | [docs-remote-cursor.md](docs/docs-remote-cursor.md)                              | Docs remote cursor — peer cursor carets + name labels in collaborative docs editor                |
@@ -67,7 +68,7 @@ Infrastructure, frontend/backend, and cross-cutting concerns.
 
 ## Template
 
-Design documents use YAML frontmatter and follow this structure:
+New design documents should be based on [template.md](template.md). YAML frontmatter and structure:
 
 ```markdown
 ---

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -4,8 +4,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Layout
 
-- Active tasks: `docs/tasks/active/`
-- Archived tasks: `docs/tasks/archive/YYYY/MM/`
+- [Active tasks](active/README.md) — `docs/tasks/active/`
+- [Archived tasks](archive/README.md) — `docs/tasks/archive/YYYY/MM/`
 - Regenerate indexes: `pnpm tasks:index`
 - Archive completed tasks: `pnpm tasks:archive`
 

--- a/docs/tasks/active/20260325-docs-wordprocessor-lessons.md
+++ b/docs/tasks/active/20260325-docs-wordprocessor-lessons.md
@@ -1,6 +1,6 @@
 # Docs Word Processor — Lessons
 
-Design doc: [docs-wordprocessor-roadmap.md](../../design/docs-wordprocessor-roadmap.md)
+Design doc: [docs-wordprocessor-roadmap.md](../../design/docs/docs-wordprocessor-roadmap.md)
 
 ## Lessons
 

--- a/docs/tasks/active/20260325-docs-wordprocessor-todo.md
+++ b/docs/tasks/active/20260325-docs-wordprocessor-todo.md
@@ -1,6 +1,6 @@
 # Docs Word Processor Roadmap — Task Tracking
 
-Design doc: [docs-wordprocessor-roadmap.md](../../design/docs-wordprocessor-roadmap.md)
+Design doc: [docs-wordprocessor-roadmap.md](../../design/docs/docs-wordprocessor-roadmap.md)
 
 ## Phase 1: Block Type Extensions ✅
 

--- a/docs/tasks/archive/2026/04/20260408-header-footer-todo.md
+++ b/docs/tasks/archive/2026/04/20260408-header-footer-todo.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** TypeScript, Canvas 2D API, Vitest
 
-**Design doc:** [docs-header-footer.md](../../design/docs/docs-header-footer.md)
+**Design doc:** [docs-header-footer.md](../../../../design/docs/docs-header-footer.md)
 
 ---
 

--- a/docs/tasks/archive/2026/04/20260411-docs-table-merge-ux-todo.md
+++ b/docs/tasks/archive/2026/04/20260411-docs-table-merge-ux-todo.md
@@ -19,7 +19,7 @@ single hybrid slot whose label/icon/disabled state follow the result.
 
 **Tech Stack:** TypeScript, Vitest, React (frontend menu), Tabler icons.
 
-**Design:** [docs-tables.md — Cell Range Normalization & Cell Merge UX](../../design/docs/docs-tables.md#cell-range-normalization)
+**Design:** [docs-tables.md — Cell Range Normalization & Cell Merge UX](../../../../design/docs/docs-tables.md#cell-range-normalization)
 **Lessons:** [20260411-docs-table-merge-ux-lessons.md](20260411-docs-table-merge-ux-lessons.md)
 
 ---

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -122,6 +122,11 @@ Total archived tasks: 141
 | workspace delete (2026-03-01) | [20260301-workspace-delete-todo.md](./2026/03/20260301-workspace-delete-todo.md) | [20260301-workspace-delete-lessons.md](./2026/03/20260301-workspace-delete-lessons.md) |
 | workspace ui improvements (2026-03-01) | [20260301-workspace-ui-improvements-todo.md](./2026/03/20260301-workspace-ui-improvements-todo.md) | [20260301-workspace-ui-improvements-lessons.md](./2026/03/20260301-workspace-ui-improvements-lessons.md) |
 
+### Pre-todo plans (legacy `-plan` naming)
+
+- [docs-site (2026-03-14)](./2026/03/20260314-docs-site-plan.md) — VitePress documentation site implementation plan
+- [docs-arrow-pixel-accuracy (2026-03-25)](./2026/03/20260325-docs-arrow-pixel-accuracy-plan.md) — Arrow Up/Down pixel accuracy implementation plan
+
 ## 2026/02 (37 tasks)
 
 | Task | Todo | Lessons |

--- a/packages/documentation/README.md
+++ b/packages/documentation/README.md
@@ -1,6 +1,6 @@
 # @wafflebase/documentation
 
-VitePress-based documentation site for Wafflebase. Serves user guides and developer documentation at the `/docs/` subpath.
+VitePress-based documentation site for Wafflebase. Serves user guides and developer documentation at the `/docs/` subpath. The site root is [`index.md`](index.md), which redirects to the Getting Started guide.
 
 ## Content
 


### PR DESCRIPTION
## Summary

- Convert the Project Structure code block in \`README.md\` to a markdown list so all six package READMEs become reachable from the entry point. Add a Documentation section linking \`docs/\`, \`MAINTAINING.md\`, and \`CLAUDE.md\` (also exposed as \`AGENTS.md\` via symlink).
- Fix \`docs/README.md\` so \`design/\` and \`tasks/\` point at the README.md inside each subdirectory (the previous \`(design/)\` and \`(tasks/)\` targets lacked a \`.md\` extension and were skipped by link checkers).
- Add \`docs-docx-import-export.md\` and \`template.md\` to \`docs/design/README.md\` so they are reachable from the design index.
- Link \`active/README.md\` and \`archive/README.md\` from \`docs/tasks/README.md\` (they were referenced inline by code-style paths previously).
- Add the two pre-todo \`-plan.md\` files (\`docs-site\`, \`docs-arrow-pixel-accuracy\`) to \`docs/tasks/archive/README.md\` under a legacy plans subsection.
- Link \`index.md\` from \`packages/documentation/README.md\` so the VitePress landing redirect is reachable.
- Fix four broken design references in tasks. The relative paths needed one or two more parent hops to reach \`docs/design/\`:
  - \`archive/2026/04/20260411-docs-table-merge-ux-todo.md\`: \`../../design/...\` → \`../../../../design/...\`
  - \`archive/2026/04/20260408-header-footer-todo.md\`: same fix
  - \`active/20260325-docs-wordprocessor-todo.md\`: \`../../design/docs-wordprocessor-roadmap.md\` → \`../../design/docs/docs-wordprocessor-roadmap.md\`
  - \`active/20260325-docs-wordprocessor-lessons.md\`: same fix

Found via the link connectivity check script being added to second-brain ([yorkie-team/second-brain#34](https://github.com/yorkie-team/second-brain/pull/34)).

Before this change, 319 \`.md\` files in this repo had no incoming link from the README graph. After, only the \`.github/\` issue/PR templates and the \`AGENTS.md → CLAUDE.md\` symlink remain (both are by design).

## Test plan

- [x] Verified the corrected design paths resolve to existing files
- [x] Verified the new Documentation/Project Structure links resolve
- [ ] Reviewer to spot-check the new and updated index sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized main README's Project Structure section with linked navigation to package documentation and new Documentation section surfacing design, architecture, and task tracking resources.
  * Enhanced docs navigation with clickable task category links (Active and Archived tasks).
  * Added DOCX import/export design documentation reference.
  * Improved internal documentation cross-references and file path consistency across task and design documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->