### PR TITLE
Fix cell line overlap and page-split text bleed

### DIFF
--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -413,7 +413,11 @@ export function layoutBlock(
  * heights are computed identically.
  */
 export function assignLineHeights(lines: LayoutLine[], block: Block): void {
-  const lineHeightMultiplier = block.style.lineHeight ?? 1.5;
+  // Floor at 1.0: a sub-1.0 multiplier collapses the line below the font's
+  // own pixel height, so characters from adjacent lines overlap. The DOCX
+  // import path can plant such values when <w:spacing w:line="N"
+  // w:lineRule="exact|atLeast"/> is read as a 240ths-of-a-line multiplier.
+  const lineHeightMultiplier = Math.max(1, block.style.lineHeight ?? 1.5);
   let blockY = 0;
   for (const line of lines) {
     const maxFontSize = getLineMaxFontSizePx(line, block);

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -388,7 +388,13 @@ export function renderTableContent(
           ctx.fillStyle = style.color || Theme.defaultColor;
           ctx.textBaseline = 'alphabetic';
 
-          const baselineY = runLineY + line.height * 0.75;
+          // Centered-baseline formula, matching doc-canvas's body path and
+          // the list-marker path below. The old `runLineY + line.height *
+          // 0.75` leaked the glyph ~0.05 * fontSize above runLineY for
+          // tight line heights (lineHeight ≈ 1.0), so a line clipped
+          // exactly at its top — the case at a paginated row split —
+          // bled a sliver onto the previous page.
+          const baselineY = Math.round(runLineY + (line.height + fontSizePx * 0.8) / 2);
 
           // Text background highlight
           if (style.backgroundColor) {

--- a/packages/docs/test/view/table-layout.test.ts
+++ b/packages/docs/test/view/table-layout.test.ts
@@ -166,6 +166,23 @@ describe('computeTableLayout', () => {
     expect(tallHeight).toBeGreaterThan(baseHeight * 1.5);
   });
 
+  it('floors cell paragraph lineHeight at 1.0 to prevent overlap', () => {
+    // DOCX's <w:spacing w:line="N" w:lineRule="exact|atLeast"/> can land in
+    // block.style.lineHeight as a sub-1.0 multiplier (the import path
+    // unconditionally divides line by 240). Honoring it literally collapses
+    // each line below the font's natural height, causing characters from
+    // adjacent lines to overlap. Clamp to >= 1.0 so text stays legible.
+    const block = createTableBlock(1, 1);
+    const cellBlock = block.tableData!.rows[0].cells[0].blocks[0];
+    cellBlock.inlines = [{ text: 'X', style: { fontSize: 12 } }];
+    cellBlock.style = { ...DEFAULT_BLOCK_STYLE, lineHeight: 0.7 };
+    const result = computeTableLayout(block.tableData!, 'tbl', stubCtx(), 200);
+    const lineHeight = result.cells[0][0].lines[0].height;
+    // 12pt -> 16px. At lineHeight 0.7 the raw value is 11.2px (overlap);
+    // the floor lifts it back to at least the font's pixel height.
+    expect(lineHeight).toBeGreaterThanOrEqual(16);
+  });
+
   it('applies heading defaults to font size inside cell', () => {
     const baseBlock = createTableBlock(1, 1);
     baseBlock.tableData!.rows[0].cells[0].blocks[0].inlines = [{ text: 'Heading', style: {} }];


### PR DESCRIPTION
## Summary

Two rendering bugs that surfaced in DOCX-imported docs after #167 unified the cell paragraph layout with the body's `layoutBlock`. Both reproduce on the shared "지원서_양식" doc.

- **Cell line overlap.** Cells store `lineHeight: 0.7` for paragraphs imported from `<w:spacing w:line="168"/>` (docx-style-map divides by 240 unconditionally, ignoring `lineRule`). #167 made cells honor `block.style.lineHeight`; with 0.7, line height drops below the font's pixel height and characters crash into the line below. Floor the multiplier at 1.0 in `assignLineHeights`. The DOCX `lineRule` mishandling is the deeper data bug — left as a follow-up.
- **Page-split text bleed.** The cell text baseline used `runLineY + line.height * 0.75`. At tight line heights (≈ 1.0) that places the glyph ascent ~5% of `fontSize` above the line's declared top, so at a paginated row split the next page's first line bled a sliver into the previous page (and re-rendered fully on the next page). Switch to the centered baseline `(line.height + fontSize * 0.8) / 2`, matching the body path in `doc-canvas` and the list-marker path in the same file.

## Test plan

- [x] `pnpm verify:fast` (627/627 tests pass, lint/typecheck clean)
- [x] New regression test `floors cell paragraph lineHeight at 1.0 to prevent overlap`
- [x] Visual: shared "지원서_양식" doc — "참고사항" cell shows each bullet on its own line
- [x] Visual: page 1 / page 2 boundary — lines no longer split or double-draw across the boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)