### PR TITLE
Show row resize guideline and keep scroll on page 2

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -24,7 +24,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 145
+- Archived task count: 146
 - Archive index: [archive/README.md](./archive/README.md)
 
 Latest active task: docx table style followup (2026-04-12)

--- a/docs/tasks/active/20260501-table-resize-row-split-lessons.md
+++ b/docs/tasks/active/20260501-table-resize-row-split-lessons.md
@@ -1,0 +1,47 @@
+---
+title: Lessons — table resize handle missing on split-continuation page
+date: 2026-05-01
+---
+
+# Lessons
+
+## Renderer/resolver coordinate formulas must share a helper
+
+The bug was a duplicated formula. `DocCanvas` had:
+
+```ts
+const tableOriginY = pageY + pl.y - rowYOffsets[pl.lineIndex] - splitOffset;
+```
+
+while `TextEditor.resolveTableFromMouse` had:
+
+```ts
+const tableOriginY = bandTop - tl.rowYOffsets[firstPl.lineIndex];
+```
+
+Both names match (`tableOriginY`) but the resolver silently dropped the
+`- splitOffset` term. As long as a row never split across pages the
+two formulas agreed, so the divergence stayed invisible until split
+rows shipped (#170 area). The lesson: **whenever two paths must land on
+the same screen pixel — renderer and hit-test, in this case — extract
+the math into a single named helper and call it from both sides.**
+
+## Symptom asymmetry is a strong locator
+
+User reported: column resize works, row resize does not. The shared
+codepath is `detectTableBorder`, which uses `localX` for column hits
+and `localY` for row hits. An asymmetry between two sibling code
+branches that share most of their input is almost always a hint that
+ONE of the inputs is wrong. Tracing back from `localY` led directly to
+`tableOriginY` and the missing offset. **When two parallel features
+share a function and only one breaks, suspect the input that only that
+branch uses.**
+
+## Treat hit-area "tightness" as a separate concern
+
+While fixing `tableOriginY`, I also tightened `bandBottom` to use
+`rowSplitHeight` instead of the full `line.height`. This wasn't the
+root cause of the reported bug, but it was a latent issue in the same
+function: a split fragment ending at a page break would have its hit
+area extend beyond the page break into empty space. Fixing it in the
+same change avoids leaving a known-stale calculation behind.

--- a/docs/tasks/active/20260501-table-resize-row-split-todo.md
+++ b/docs/tasks/active/20260501-table-resize-row-split-todo.md
@@ -1,0 +1,88 @@
+---
+title: Table row resize handle missing on page 2 — drag guideline off-screen
+date: 2026-05-01
+status: in_progress
+---
+
+# Row resize drag guideline does not appear when scrolled to page 2
+
+## Symptom
+
+On a multi-page document, scrolling to page 2 and starting a row
+resize drag (`row-resize` cursor) on a table cell border:
+
+- Cursor changes to `row-resize` correctly.
+- Drag is accepted (mousedown starts the drag, applies on mouseup).
+- **But the blue dashed guideline that should appear under the cursor
+  during drag is invisible.**
+- Column drag guideline (vertical) stays visible.
+
+## Root cause
+
+`editor.ts` draws the drag guideline AFTER `docCanvas.render()` returns.
+`render()` does its drawing inside `ctx.save()` / `ctx.restore()` with
+a `translate(0, -scrollY)` and a `scale(scaleFactor, scaleFactor)`
+applied. After it restores, the canvas context is back to identity.
+
+But `dragGuideline.x` / `dragGuideline.y` are in **unscaled document
+coordinates** (set by `TextEditor.handleMouseMove` from `mouseY` =
+`(e.clientY - rect.top - canvasOffsetTop) / s + scrollTop / s`). The
+guideline draw used these directly as canvas pixel coords:
+
+```ts
+ctx.moveTo(0, dragGuideline.y);
+ctx.lineTo(canvasWidth, dragGuideline.y);
+```
+
+When scrolled to page 2 with `scrollTop ≈ 1118`, `dragGuideline.y`
+becomes ~1605 (absolute doc coord). Drawing at canvas pixel y=1605
+falls way below the visible canvas area (~787 pixels tall), so the
+horizontal line is rendered off-screen.
+
+The vertical (column) guideline accidentally works because
+`scrollLeft` is almost always 0 in this app — drawing at canvas pixel
+x = `dragGuideline.x` happens to land at the right viewport position.
+With horizontal scroll it would break the same way.
+
+## Fix
+
+In `editor.ts` guideline draw, convert the unscaled doc coords to
+canvas pixel coords by subtracting the scroll and applying the scale:
+
+```ts
+const x = (dragGuideline.x - container.scrollLeft / scaleFactor) * scaleFactor;
+const y = (dragGuideline.y - scrollY) * scaleFactor;
+```
+
+`scrollY` is already in scope (`container.scrollTop / scaleFactor`).
+
+## Bonus refactor in same change
+
+While investigating, I also extracted a shared
+`getTableOriginYForPageLine(pageY, pl, rowYOffsets)` helper in
+`pagination.ts` so `DocCanvas` (renderer) and `TextEditor`
+(`resolveTableFromMouse`, hit-test) compute the same virtual table
+origin. The previous resolver formula dropped the `rowSplitOffset`
+term that the renderer used, so on a page where the table starts
+with a split-row continuation the row-border hit area was offset by
+the page-1 fragment height. This was a real latent bug; even if it
+wasn't the user's primary complaint, the refactor prevents the two
+formulas from drifting apart again.
+
+## Tasks
+
+- [x] Reproduce the missing guideline via puppeteer drag simulation
+      on the user's shared URL (page 2 row drag → no guideline)
+- [x] Identify root cause: editor.ts guideline draw uses unscaled
+      doc coords as canvas pixel coords
+- [x] Apply fix: convert to canvas pixels by subtracting scroll and
+      scaling
+- [x] Verify guideline visible on row drag at page 2 via puppeteer
+- [x] Verify column guideline still visible (no regression)
+- [x] Keep helper extraction (`getTableOriginYForPageLine`) — fixes
+      latent split-row hit-test bug
+- [ ] Investigate follow-up: cell resize on page 2 with cursor on
+      page 1 scrolls back to page 1
+- [ ] Run `pnpm verify:fast`
+- [ ] Move work to a worktree + feature branch (per user request)
+- [ ] Archive task and update index

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,13 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 145
+Total archived tasks: 146
 
-## 2026/05 (1 tasks)
+## 2026/05 (2 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| table resize row split (2026-05-01) | [20260501-table-resize-row-split-todo.md](./2026/05/20260501-table-resize-row-split-todo.md) | [20260501-table-resize-row-split-lessons.md](./2026/05/20260501-table-resize-row-split-lessons.md) |
 | table split followup rows (2026-05-01) | [20260501-table-split-followup-rows-todo.md](./2026/05/20260501-table-split-followup-rows-todo.md) | - |
 
 ## 2026/04 (30 tasks)

--- a/knip.json
+++ b/knip.json
@@ -10,6 +10,10 @@
       "project": ["src/**/*.ts", "test/**/*.ts"],
       "ignoreBinaries": ["scripts/fix-antlr-ts.sh"]
     },
+    "packages/docs": {
+      "entry": ["src/index.ts", "test/**/*.test.ts", "scripts/*.mjs"],
+      "project": ["src/**/*.ts", "test/**/*.ts"]
+    },
     "packages/frontend": {
       "entry": ["src/main.tsx", "tests/**/*.test.ts"],
       "project": ["src/**/*.{ts,tsx}", "tests/**/*.test.ts"]

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -1,7 +1,7 @@
 import type { Block } from '../model/types.js';
 import { LIST_INDENT_PX, UNORDERED_MARKERS } from '../model/types.js';
 import type { PaginatedLayout, LayoutPage } from './pagination.js';
-import { getPageYOffset, getPageXOffset, getHeaderYStart, getFooterYStart } from './pagination.js';
+import { getPageYOffset, getPageXOffset, getHeaderYStart, getFooterYStart, getTableOriginYForPageLine } from './pagination.js';
 import type { EditContext } from '../model/document.js';
 import type { DocumentLayout, LayoutBlock, LayoutRun } from './layout.js';
 import { computeListCounters } from './layout.js';
@@ -81,8 +81,7 @@ export function collectTableRenderRanges(
       continue;
     }
     const range = computeTableRangeForPageLine(page, lb, pl, plIndex);
-    const splitOffset = pl.rowSplitOffset ?? 0;
-    const tableOriginY = pageY + pl.y - lb.layoutTable.rowYOffsets[pl.lineIndex] - splitOffset;
+    const tableOriginY = getTableOriginYForPageLine(pageY, pl, lb.layoutTable.rowYOffsets);
     ranges.push({
       layoutBlock: lb,
       tableX: pageX + margins.left,
@@ -451,8 +450,7 @@ export class DocCanvas {
             // lockstep.
             if (shouldStartTableRender(page, plIndex)) {
               const range = computeTableRangeForPageLine(page, lb, pl, plIndex);
-              const splitOffset = pl.rowSplitOffset ?? 0;
-              const tableOriginY = pageY + pl.y - lb.layoutTable.rowYOffsets[pl.lineIndex] - splitOffset;
+              const tableOriginY = getTableOriginYForPageLine(pageY, pl, lb.layoutTable.rowYOffsets);
               renderTableContent(
                 this.ctx,
                 lb.block.tableData,

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -946,23 +946,32 @@ export function initialize(
       dragImageRun,
     );
 
-    // Draw drag guideline if active
+    // Draw drag guideline if active. Guideline coords are in unscaled
+    // document space, but this draws after `docCanvas.render()` has
+    // already restored the canvas context to identity. Convert to canvas
+    // pixels manually so the line stays under the cursor regardless of
+    // scroll or zoom; otherwise vertical scroll on page 2+ pushes the
+    // horizontal (row) guideline off-screen — only the column guideline
+    // ever appeared because horizontal scroll happens to be zero.
     if (dragGuideline) {
       const ctx = docCanvas.getContext();
+      const scrollX = container.scrollLeft / scaleFactor;
       ctx.save();
       ctx.setLineDash([4, 4]);
       ctx.strokeStyle = '#4285F4';
       ctx.lineWidth = 1;
       if (dragGuideline.x != null) {
+        const x = (dragGuideline.x - scrollX) * scaleFactor;
         ctx.beginPath();
-        ctx.moveTo(dragGuideline.x, 0);
-        ctx.lineTo(dragGuideline.x, canvasHeight);
+        ctx.moveTo(x, 0);
+        ctx.lineTo(x, canvasHeight);
         ctx.stroke();
       }
       if (dragGuideline.y != null) {
+        const y = (dragGuideline.y - scrollY) * scaleFactor;
         ctx.beginPath();
-        ctx.moveTo(0, dragGuideline.y);
-        ctx.lineTo(canvasWidth, dragGuideline.y);
+        ctx.moveTo(0, y);
+        ctx.lineTo(canvasWidth, y);
         ctx.stroke();
       }
       ctx.restore();
@@ -1177,6 +1186,10 @@ export function initialize(
       dragGuideline = pos;
       renderPaintOnly();
     };
+    // Layout-only re-render that does NOT scroll the cursor into view.
+    // Used by table border resize so resizing on page 2 with the caret
+    // on page 1 doesn't snap the viewport back to page 1.
+    textEditor.requestRenderNoCursorScroll = render;
 
     // Image selection key routing. Delete/Backspace delete the selected
     // image inline and return to text mode; Escape clears the image

--- a/packages/docs/src/view/pagination.ts
+++ b/packages/docs/src/view/pagination.ts
@@ -185,6 +185,34 @@ export function getPageYOffset(
 }
 
 /**
+ * Reconstruct the canvas Y where the table's logical row 0 would sit
+ * for rendering or hit-testing on the page that contains `pl`.
+ *
+ * For a non-split row the math is just `pageY + pl.y - rowYOffsets[lineIndex]`;
+ * for a split-fragment continuation we additionally subtract
+ * `rowSplitOffset` so the fragment lines up with where the row was
+ * already drawn on the previous page. Renderer and resolver share this
+ * helper so they cannot drift apart on split fragments.
+ */
+export function getTableOriginYForPageLine(
+  pageY: number,
+  pl: PageLine,
+  rowYOffsets: number[],
+): number {
+  if (pl.lineIndex < 0 || pl.lineIndex >= rowYOffsets.length) {
+    // An out-of-bounds lineIndex would silently yield NaN and corrupt
+    // every downstream coordinate (renderer + hit-test). Fail loudly
+    // so a future split-rendering bug surfaces immediately instead of
+    // turning into invisible widgets or off-by-N misclicks.
+    throw new RangeError(
+      `getTableOriginYForPageLine: lineIndex ${pl.lineIndex} out of bounds (rowYOffsets length ${rowYOffsets.length})`,
+    );
+  }
+  const splitOffset = pl.rowSplitOffset ?? 0;
+  return pageY + pl.y - rowYOffsets[pl.lineIndex] - splitOffset;
+}
+
+/**
  * Get the total scrollable height of the paginated document.
  */
 export function getTotalHeight(paginatedLayout: PaginatedLayout): number {

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -6,7 +6,7 @@ import { Cursor } from './cursor.js';
 import { Selection, expandCellRangeForMerges, findMergeTopLeft } from './selection.js';
 import type { DocumentLayout } from './layout.js';
 import type { PaginatedLayout } from './pagination.js';
-import { paginatedPixelToPosition, findPageForPosition, getPageYOffset, getPageXOffset, getHeaderYStart, getFooterYStart, resolveClickTarget } from './pagination.js';
+import { paginatedPixelToPosition, findPageForPosition, getPageYOffset, getPageXOffset, getHeaderYStart, getFooterYStart, getTableOriginYForPageLine, resolveClickTarget } from './pagination.js';
 import { buildFont } from './theme.js';
 import { HangulAssembler, isJamo, type HangulResult } from './hangul.js';
 import { detectUrlBeforeCursor, isSafeUrl } from './url-detect.js';
@@ -93,6 +93,20 @@ export class TextEditor {
   private getScaleFactor: () => number;
   private getCanvasOffsetTop: () => number;
   private requestRender: () => void;
+  /**
+   * Render variant for layout-only changes that do NOT move the caret
+   * (e.g. table border resize). The default `requestRender` pulls the
+   * cursor into view, which causes the viewport to jump back to the
+   * cursor's page when the user resizes a row on a different page than
+   * where the caret lives.
+   *
+   * IMPORTANT: hosts MUST wire this. The fallback to `requestRender`
+   * exists only so the editor still functions if the wiring is missed
+   * during refactors — but it silently re-introduces the page-snap
+   * bug. Treat unset as a wiring error and add the assignment in
+   * `editor.ts`.
+   */
+  requestRenderNoCursorScroll?: () => void;
   private saveSnapshot: () => void;
   private undoAction: () => void;
   private redoAction: () => void;
@@ -898,15 +912,23 @@ export class TextEditor {
         }
         if (!firstPl || !lastPl) continue;
 
+        // bandTop/bandBottom must hug the actually rendered area on
+        // this page. When the last PageLine is a split fragment that
+        // continues onto the next page, use rowSplitHeight (the
+        // fragment's painted height) instead of line.height (the full
+        // logical row height) so the hit area stops at the page break
+        // rather than spilling into the next page.
         const bandTop = pageY + firstPl.y;
-        const bandBottom = pageY + lastPl.y + lastPl.line.height;
+        const lastHeight = lastPl.rowSplitHeight ?? lastPl.line.height;
+        const bandBottom = pageY + lastPl.y + lastHeight;
         if (mouseY < bandTop || mouseY > bandBottom) continue;
 
-        // Convert mouseY to table-logical Y based on the first row in
-        // this band. The virtual tableOriginY is reconstructed so
-        // `localY = mouseY - tableOriginY` lands inside rowYOffsets of a
-        // row physically on this page.
-        const tableOriginY = bandTop - tl.rowYOffsets[firstPl.lineIndex];
+        // Reconstruct the virtual tableOriginY using the same formula
+        // as the renderer. For a split-fragment continuation as the
+        // first PageLine on the page, this subtracts rowSplitOffset so
+        // localY = mouseY - tableOriginY lines up with rowYOffsets[r]
+        // for rows actually drawn on this page.
+        const tableOriginY = getTableOriginYForPageLine(pageY, firstPl, tl.rowYOffsets);
         return {
           tableBlockId: lb.block.id,
           localX: mouseX - tableOriginX,
@@ -1261,7 +1283,10 @@ export class TextEditor {
     }
 
     this.markDirty(drag.tableBlockId);
-    this.requestRender();
+    // Resize doesn't move the caret, so don't pull the viewport back
+    // to where the cursor lives. Fall back to the regular render if
+    // the host hasn't wired the no-scroll variant.
+    (this.requestRenderNoCursorScroll ?? this.requestRender)();
   }
 
   private updateDragSelection(clientX: number, clientY: number): void {

--- a/packages/docs/test/view/table-origin-y.test.ts
+++ b/packages/docs/test/view/table-origin-y.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { computeLayout } from '../../src/view/layout.js';
+import {
+  paginateLayout,
+  getPageYOffset,
+  getTableOriginYForPageLine,
+} from '../../src/view/pagination.js';
+import {
+  createTableBlock,
+  DEFAULT_PAGE_SETUP,
+  getEffectiveDimensions,
+  DEFAULT_BLOCK_STYLE,
+} from '../../src/model/types.js';
+
+function stubCtx(): CanvasRenderingContext2D {
+  return {
+    font: '',
+    measureText: (text: string) => ({ width: text.length * 7 }),
+  } as unknown as CanvasRenderingContext2D;
+}
+
+/**
+ * Regression: when a table row splits across pages and the
+ * continuation fragment lands as the first PageLine on the next page,
+ * `getTableOriginYForPageLine` must return the SAME virtual table
+ * origin for the split fragment and for any non-split follow-up row of
+ * the same table on that page. Otherwise hit-testing for row resize
+ * handles drifts away from where the renderer actually drew the rows.
+ */
+describe('getTableOriginYForPageLine', () => {
+  it('agrees across split fragment and follow-up rows on the same page', () => {
+    const setup = DEFAULT_PAGE_SETUP;
+    const { width } = getEffectiveDimensions(setup);
+    const contentWidth = width - setup.margins.left - setup.margins.right;
+
+    // 3-row table: row 0 is tall (forces split across pages 1 and 2),
+    // rows 1 and 2 are short and land on page 2 right after the
+    // continuation fragment of row 0.
+    const tableBlock = createTableBlock(3, 1);
+    const td = tableBlock.tableData!;
+    const r0Cell = td.rows[0].cells[0];
+    r0Cell.blocks = [];
+    for (let i = 0; i < 60; i++) {
+      r0Cell.blocks.push({
+        id: `r0p${i}`,
+        type: 'paragraph',
+        inlines: [{ text: `Row0 paragraph ${i} with text content`, style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      });
+    }
+    td.rows[1].cells[0].blocks[0].inlines = [{ text: 'Row 1', style: {} }];
+    td.rows[2].cells[0].blocks[0].inlines = [{ text: 'Row 2', style: {} }];
+
+    const ctx = stubCtx();
+    const { layout } = computeLayout([tableBlock], ctx, contentWidth);
+    const paginated = paginateLayout(layout, setup);
+
+    // Locate the page that holds the continuation fragment.
+    const pageIndex = paginated.pages.findIndex((p) =>
+      p.lines.some((pl) => pl.rowSplitOffset !== undefined && pl.rowSplitOffset > 0),
+    );
+    expect(pageIndex).toBeGreaterThan(0);
+
+    const page = paginated.pages[pageIndex];
+    const pageY = getPageYOffset(paginated, pageIndex);
+    const lb = layout.blocks[0];
+    expect(lb.layoutTable).toBeDefined();
+    const rowYOffsets = lb.layoutTable!.rowYOffsets;
+
+    // The first PL on this page must be the row-0 continuation, with
+    // a non-zero rowSplitOffset.
+    const firstPl = page.lines[0];
+    expect(firstPl.lineIndex).toBe(0);
+    expect(firstPl.rowSplitOffset).toBeDefined();
+    expect(firstPl.rowSplitOffset!).toBeGreaterThan(0);
+
+    // Find a follow-up non-split PageLine for row 1 on the same page.
+    const row1Pl = page.lines.find(
+      (pl) => pl.lineIndex === 1 && pl.rowSplitOffset === undefined,
+    );
+    expect(row1Pl).toBeDefined();
+
+    const originFromSplit = getTableOriginYForPageLine(pageY, firstPl, rowYOffsets);
+    const originFromRow1 = getTableOriginYForPageLine(pageY, row1Pl!, rowYOffsets);
+
+    // Same physical table → same virtual origin.
+    expect(originFromSplit).toBe(originFromRow1);
+  });
+
+  it('matches the simple formula for a non-split first PageLine', () => {
+    const setup = DEFAULT_PAGE_SETUP;
+    const { width } = getEffectiveDimensions(setup);
+    const contentWidth = width - setup.margins.left - setup.margins.right;
+
+    const tableBlock = createTableBlock(2, 1);
+    const td = tableBlock.tableData!;
+    td.rows[0].cells[0].blocks[0].inlines = [{ text: 'A', style: {} }];
+    td.rows[1].cells[0].blocks[0].inlines = [{ text: 'B', style: {} }];
+
+    const ctx = stubCtx();
+    const { layout } = computeLayout([tableBlock], ctx, contentWidth);
+    const paginated = paginateLayout(layout, setup);
+
+    const pageY = getPageYOffset(paginated, 0);
+    const pl = paginated.pages[0].lines[0];
+    const rowYOffsets = layout.blocks[0].layoutTable!.rowYOffsets;
+
+    expect(getTableOriginYForPageLine(pageY, pl, rowYOffsets)).toBe(
+      pageY + pl.y - rowYOffsets[pl.lineIndex],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Row resize drag guideline now appears on the page where the cursor is, not off-screen, when the document is scrolled past page 1.
- Resizing a row on page 2 with the caret on page 1 no longer snaps the viewport back to page 1.
- Defensive refactor: renderer and hit-test share `getTableOriginYForPageLine`, so the row-border hit area can no longer drift away from the painted border on a split-row continuation page.

## Root causes

**Guideline off-screen (`editor.ts`):** The drag-guideline draw runs after `docCanvas.render()` has restored the canvas context to identity, but `dragGuideline.x/y` are in unscaled document coordinates. Drawing at canvas pixel y = absolute_doc_y placed the horizontal line below the visible viewport when scrolled (e.g. `scrollTop ≈ 1118` → line drawn at y = 1605, canvas height ~787). The vertical (column) guideline accidentally worked because `scrollLeft` is normally 0. Convert to canvas pixels with `(coord - scroll) * scaleFactor` for both axes — also correct under mobile zoom-to-fit.

**Viewport snap on resize (`editor.ts` + `text-editor.ts`):** `applyBorderDrag` requested a render through the path that always sets `needsScrollIntoView = true`, so the next paint scrolled the cursor (still on page 1) into view. Added `requestRenderNoCursorScroll` for layout-only changes that don't move the caret.

**Latent split-row hit-test bug (`pagination.ts` + `doc-canvas.ts` + `text-editor.ts`):** The renderer used `pageY + pl.y - rowYOffsets[lineIndex] - rowSplitOffset` to position a continuation fragment, but the resolver used `bandTop - rowYOffsets[firstPl.lineIndex]` (no `rowSplitOffset`). On a page that starts with a row-split continuation, the resolver's virtual table origin diverged from the renderer's by the page-1 fragment height, so row-border hit-testing missed every row by that offset. Extracted `getTableOriginYForPageLine(pageY, pl, rowYOffsets)` so both paths share the same formula. The helper bounds-checks `lineIndex` so any future split-rendering regression fails loudly instead of silently producing NaN coordinates.

**Pre-push harness fix (`knip.json`):** With docs registered in knip workspaces, knip used `main`/`module` from `packages/docs/package.json` (which point at `dist/`) as its only entry roots — so once docs was built, knip flagged `scripts/verify-ime-browser.mjs` as unused dead code and broke `verify:entropy` in the pre-push harness. Add a `packages/docs` workspace block matching the sheets pattern.

## Test plan

- [x] `pnpm verify:fast` (684/684 tests pass)
- [x] `pnpm verify:entropy` passes after building docs
- [x] Puppeteer reproduction of guideline bug on the user's shared doc:
  - row resize drag at page 2 → blue dashed horizontal guideline visible under cursor (was invisible)
  - column resize drag → vertical guideline still visible (no regression)
  - resize row on page 2 with caret on page 1 → viewport stays at `scrollTop=1118` (was snapping back to 0)
- [x] New `table-origin-y.test.ts` regression: helper returns the same virtual origin for the split fragment and follow-up rows on the same page; reverting the `rowSplitOffset` term in the helper makes this test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)