### PR TITLE
Add ROMAN relaxation rules 0-4 and validate ARABIC by round-trip

### DIFF
--- a/packages/sheets/src/formula/functions-math.ts
+++ b/packages/sheets/src/formula/functions-math.ts
@@ -1853,6 +1853,45 @@ export function randbetweenFunc(
   return { t: 'num', v: Math.floor(Math.random() * (high - low + 1)) + low };
 }
 
+// Lookup tables for ROMAN/ARABIC — each entry is [value, symbol], sorted descending.
+// Rule 0: classic strict notation (I-V/X, X-L/C, C-D/M only).
+// Rule 1–4: progressively allow additional subtractive pairs.
+const ROMAN_TABLES: ReadonlyArray<ReadonlyArray<readonly [number, string]>> = [
+  [ // Rule 0
+    [1000, 'M'],  [900, 'CM'], [500, 'D'],  [400, 'CD'],
+    [100,  'C'],  [90,  'XC'], [50,  'L'],  [40,  'XL'],
+    [10,   'X'],  [9,   'IX'], [5,   'V'],  [4,   'IV'],  [1, 'I'],
+  ],
+  [ // Rule 1: additionally V-L=45, V-C=95, L-D=450, L-M=950.
+    [1000, 'M'],  [950, 'LM'], [900, 'CM'],
+    [500,  'D'],  [450, 'LD'], [400, 'CD'],
+    [100,  'C'],  [95,  'VC'], [90,  'XC'],
+    [50,   'L'],  [45,  'VL'], [40,  'XL'],
+    [10,   'X'],  [9,   'IX'], [5,    'V'], [4,   'IV'], [1, 'I'],
+  ],
+  [ // Rule 2: additionally I-L=49, I-C=99, X-D=490, X-M=990.
+    [1000, 'M'],  [990, 'XM'], [950, 'LM'], [900, 'CM'],
+    [500,  'D'],  [490, 'XD'], [450, 'LD'], [400, 'CD'],
+    [100,  'C'],  [99,  'IC'], [95,  'VC'], [90,  'XC'],
+    [50,   'L'],  [49,  'IL'], [45,  'VL'], [40,  'XL'],
+    [10,   'X'],  [9,   'IX'], [5,    'V'], [4,   'IV'], [1, 'I'],
+  ],
+  [ // Rule 3: additionally V-D=495, V-M=995.
+    [1000, 'M'],  [995, 'VM'], [990, 'XM'], [950, 'LM'], [900, 'CM'],
+    [500,  'D'],  [495, 'VD'], [490, 'XD'], [450, 'LD'], [400, 'CD'],
+    [100,  'C'],  [99,  'IC'], [95,  'VC'], [90,  'XC'],
+    [50,   'L'],  [49,  'IL'], [45,  'VL'], [40,  'XL'],
+    [10,   'X'],  [9,   'IX'], [5,    'V'], [4,   'IV'], [1, 'I'],
+  ],
+  [ // Rule 4: additionally I-D=499, I-M=999.
+    [1000, 'M'],  [999, 'IM'], [995, 'VM'], [990, 'XM'], [950, 'LM'], [900, 'CM'],
+    [500,  'D'],  [499, 'ID'], [495, 'VD'], [490, 'XD'], [450, 'LD'], [400, 'CD'],
+    [100,  'C'],  [99,  'IC'], [95,  'VC'], [90,  'XC'],
+    [50,   'L'],  [49,  'IL'], [45,  'VL'], [40,  'XL'],
+    [10,   'X'],  [9,   'IX'], [5,    'V'], [4,   'IV'], [1, 'I'],
+  ],
+];
+
 /**
  * ARABIC(roman_numeral) — converts Roman numeral text to a number.
  */
@@ -1868,21 +1907,39 @@ export function arabicFunc(
   const node = visit(exprs[0]);
   const strResult = toStr(node, grid);
   if (strResult.t === 'err') return strResult;
+
+  if (strResult.v === '') return { t: 'num', v: 0 };
+  if (!/^-?[MDCLXVI]*$/i.test(strResult.v)) return ErrNode.VALUE;
+
   const text = strResult.v.toUpperCase();
+  const negative = text[0] === '-';
+  const body = negative ? text.slice(1) : text;
 
   const romanValues: Record<string, number> = { I: 1, V: 5, X: 10, L: 50, C: 100, D: 500, M: 1000 };
+
   let result = 0;
-  for (let i = 0; i < text.length; i++) {
-    const current = romanValues[text[i]];
-    const next = i + 1 < text.length ? romanValues[text[i + 1]] : 0;
-    if (current === undefined) return ErrNode.VALUE;
-    if (current < next) {
-      result -= current;
-    } else {
-      result += current;
-    }
+  for (let i = 0; i < body.length; i++) {
+    const current = romanValues[body[i]];
+    const next = i + 1 < body.length ? romanValues[body[i + 1]] : 0;
+    result += current < next ? -current : current;
   }
-  return { t: 'num', v: result };
+
+  const value = negative ? -result : result;
+  if (Math.abs(value) > 3999) return ErrNode.VALUE;
+
+  // Validate by round-trip: input must be the canonical form for some rule 0–4.
+  const abs = Math.abs(value);
+  const valid = ROMAN_TABLES.some(table => {
+    let s = '';
+    let rem = abs;
+    for (const [v, sym] of table) {
+      while (rem >= v) { s += sym; rem -= v; }
+    }
+    return s === body;
+  });
+  if (!valid) return ErrNode.VALUE;
+
+  return { t: 'num', v: value };
 }
 
 /**
@@ -1904,13 +1961,20 @@ export function romanFunc(
   if (num < 0 || num > 3999) return ErrNode.VALUE;
   if (num === 0) return { t: 'str', v: '' };
 
-  const values = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1];
-  const symbols = ['M', 'CM', 'D', 'CD', 'C', 'XC', 'L', 'XL', 'X', 'IX', 'V', 'IV', 'I'];
+  let rule = 0;
+  if (exprs.length === 2) {
+    const ruleNode = NumberArgs.map(visit(exprs[1]), grid);
+    if (ruleNode.t === 'err') return ruleNode;
+    rule = Math.trunc(ruleNode.v);
+    if (rule < 0 || rule > 4) return ErrNode.VALUE;
+  }
+
+  const table = ROMAN_TABLES[rule];
   let result = '';
-  for (let i = 0; i < values.length; i++) {
-    while (num >= values[i]) {
-      result += symbols[i];
-      num -= values[i];
+  for (const [value, symbol] of table) {
+    while (num >= value) {
+      result += symbol;
+      num -= value;
     }
   }
   return { t: 'str', v: result };

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -1953,12 +1953,64 @@ describe('Formula', () => {
     expect(evaluate('=ARABIC("XIV")')).toBe('14');
     expect(evaluate('=ARABIC("MCMXCIX")')).toBe('1999');
     expect(evaluate('=ARABIC("IV")')).toBe('4');
+    // lowercase input
+    expect(evaluate('=ARABIC("xiv")')).toBe('14');
+    // empty string → 0
+    expect(evaluate('=ARABIC("")')).toBe('0');
+    // negative prefix
+    expect(evaluate('=ARABIC("-XIV")')).toBe('-14');
+    expect(evaluate('=ARABIC("-MCMXCIX")')).toBe('-1999');
+    expect(evaluate('=ARABIC("-I")')).toBe('-1');
+    // minus sign only → 0
+    expect(evaluate('=ARABIC("-")')).toBe('0');
+    // invalid character → #VALUE!
+    expect(evaluate('=ARABIC("XIVZ")')).toBe('#VALUE!');
+    // non-canonical forms → #VALUE! (round-trip check: must match ROMAN(n, rule) for some rule 0–4)
+    expect(evaluate('=ARABIC("VV")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("VVV")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("LL")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("LLL")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("DD")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("DDD")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("IIII")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("XXXX")')).toBe('#VALUE!');
+    // M can repeat but result must be ≤ 3999
+    expect(evaluate('=ARABIC("MMMCMXCIX")')).toBe('3999');
+    expect(evaluate('=ARABIC("MMMM")')).toBe('#VALUE!');
+    // subtractive pair must be exactly one prefix char before one target char
+    expect(evaluate('=ARABIC("IIV")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("IIIV")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("IIX")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("XXL")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("ILL")')).toBe('#VALUE!');
+    expect(evaluate('=ARABIC("XDD")')).toBe('#VALUE!');
+    // rule-4 relaxed subtractive pairs
+    expect(evaluate('=ARABIC("ID")')).toBe('499');
+    expect(evaluate('=ARABIC("IM")')).toBe('999');
+    expect(evaluate('=ARABIC("VD")')).toBe('495');
+    expect(evaluate('=ARABIC("VM")')).toBe('995');
+    expect(evaluate('=ARABIC("XD")')).toBe('490');
+    expect(evaluate('=ARABIC("IL")')).toBe('49');
   });
 
   it('should correctly evaluate ROMAN function', () => {
+    // rule 0 (default)
     expect(evaluate('=ROMAN(14)')).toBe('XIV');
     expect(evaluate('=ROMAN(1999)')).toBe('MCMXCIX');
     expect(evaluate('=ROMAN(4)')).toBe('IV');
+    expect(evaluate('=ROMAN(499,0)')).toBe('CDXCIX');
+    // rule 1
+    expect(evaluate('=ROMAN(499,1)')).toBe('LDVLIV');
+    // rule 2
+    expect(evaluate('=ROMAN(499,2)')).toBe('XDIX');
+    // rule 3
+    expect(evaluate('=ROMAN(499,3)')).toBe('VDIV');
+    // rule 4
+    expect(evaluate('=ROMAN(499,4)')).toBe('ID');
+    expect(evaluate('=ROMAN(999,4)')).toBe('IM');
+    // edge cases
+    expect(evaluate('=ROMAN(0)')).toBe('');
+    expect(evaluate('=ROMAN(3999)')).toBe('MMMCMXCIX');
   });
 
   it('should correctly evaluate MULTINOMIAL function', () => {


### PR DESCRIPTION
## Summary
ROMAN now accepts an optional second parameter (0–4) enabling progressively relaxed subtractive pairs (rule 4 adds ID=499, IM=999).

ARABIC validation is rewritten as a round-trip check: the input must equal the canonical ROMAN(n, rule) output for some rule 0–4, which cleanly rejects non-canonical forms like ILL, ILXL, ILX without ad-hoc structural checks.

## Why

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* ROMAN function now accepts an optional rule parameter to select from different Roman numeral representation formats.

## Bug Fixes
* ARABIC function now validates input format and rejects malformed Roman numerals with improved error handling.
* ARABIC function now correctly processes edge cases, including empty inputs and negative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->