### PR TITLE
Prevent long titles from pushing presence off mobile header

### DIFF
--- a/packages/frontend/src/components/site-header.tsx
+++ b/packages/frontend/src/components/site-header.tsx
@@ -42,16 +42,16 @@ export function SiteHeader({
   return (
     <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
       <div className="flex w-full items-center justify-between gap-1 px-4 lg:gap-2 lg:px-6 min-h-[3.5rem]">
-        <div className="flex items-center gap-1 lg:gap-2">
-          <SidebarTrigger className="-ml-1" />
+        <div className="flex min-w-0 flex-1 items-center gap-1 lg:gap-2">
+          <SidebarTrigger className="-ml-1 shrink-0" />
           <Separator
             orientation="vertical"
-            className="mx-2 data-[orientation=vertical]:h-4"
+            className="mx-2 shrink-0 data-[orientation=vertical]:h-4"
           />
           {editing ? (
             <input
               ref={inputRef}
-              className="text-base font-medium bg-transparent border-b border-primary px-1 min-w-[120px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+              className="text-base font-medium bg-transparent border-b border-primary px-1 min-w-0 flex-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
               value={editValue}
               aria-label="Document title"
               onChange={(e) => setEditValue(e.target.value)}
@@ -66,7 +66,7 @@ export function SiteHeader({
             />
           ) : (
             <h1
-              className={`text-base font-medium ${editable ? "cursor-pointer hover:bg-muted/50 px-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" : ""}`}
+              className={`text-base font-medium truncate min-w-0 ${editable ? "cursor-pointer hover:bg-muted/50 px-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" : ""}`}
               onClick={() => {
                 if (editable) setEditing(true);
               }}
@@ -86,7 +86,7 @@ export function SiteHeader({
         </div>
 
         {/* Always reserve space for children to prevent layout shift */}
-        <div className="flex items-center min-w-0">{children}</div>
+        <div className="flex shrink-0 items-center">{children}</div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- On mobile, long document titles in `SiteHeader` caused horizontal scrolling and pushed the right-side presence/avatar group off-screen.
- The left flex section lacked `min-w-0`, so the title grew unchecked and overflowed; the children container had `min-w-0` (could shrink) instead of `shrink-0` (stay pinned).
- Apply `min-w-0 flex-1` to the title section, `truncate` the `h1`, and pin children with `shrink-0` so presence indicators stay visible at any title length.

## Test plan
- [x] \`pnpm verify:fast\` passes (lint + 686 unit tests)
- [x] Open a Docs document with a long title on a narrow viewport — title truncates with ellipsis, no horizontal scroll, avatars remain visible
- [x] Same check on the spreadsheet page (uses the same `SiteHeader`)
- [x] Click title to rename — input shrinks to fit available space without overflowing
- [x] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined site header layout to improve text truncation and element sizing, ensuring better visual consistency and proper spacing across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->