### PR TITLE
Add dynamic spill arrays: MMULT, MINVERSE, MUNIT, TRANSPOSE

### DIFF
--- a/packages/frontend/src/app/spreadsheet/yorkie-store.ts
+++ b/packages/frontend/src/app/spreadsheet/yorkie-store.ts
@@ -207,10 +207,27 @@ export class YorkieStore implements Store {
       normalized.s = cell.s;
     }
 
+    if (cell.spillAnchor !== undefined) {
+      normalized.spillAnchor = cell.spillAnchor;
+    }
+    if (cell.spillRows !== undefined) {
+      normalized.spillRows = cell.spillRows;
+    }
+    if (cell.spillCols !== undefined) {
+      normalized.spillCols = cell.spillCols;
+    }
+    if (cell.spillBlocked !== undefined) {
+      normalized.spillBlocked = cell.spillBlocked;
+    }
+
     if (
       normalized.v === undefined &&
       normalized.f === undefined &&
-      normalized.s === undefined
+      normalized.s === undefined &&
+      normalized.spillAnchor === undefined &&
+      normalized.spillRows === undefined &&
+      normalized.spillCols === undefined &&
+      normalized.spillBlocked === undefined
     ) {
       return null;
     }

--- a/packages/sheets/src/formula/formula.ts
+++ b/packages/sheets/src/formula/formula.ts
@@ -446,6 +446,55 @@ export function findReferenceTokenAtCursor(
 }
 
 /**
+ * SpillResult carries a full 2-D string matrix for array-returning formulas
+ * (e.g. MMULT, MINVERSE). The calculator writes each element to adjacent cells.
+ */
+export type SpillResult = {
+  values: string[][];
+  rows: number;
+  cols: number;
+};
+
+function evalNodeToStr(node: EvalNode, grid?: Grid): string {
+  if (node.t === 'ref') {
+    if (isSrng(node.v)) return ErrValue.VALUE;
+    if (grid) return grid.get(node.v)?.v || '';
+  }
+  if (node.t === 'empty') return '0';
+  if (node.t === 'arr' || node.t === 'lambda') return ErrValue.VALUE;
+  if (node.t === 'err') return node.v;
+  if (node.t === 'bool') return node.v ? 'TRUE' : 'FALSE';
+  return node.v.toString();
+}
+
+/**
+ * `evaluateWithSpill` is like `evaluate` but returns a `SpillResult` instead
+ * of a string when the formula produces a 2-D array (e.g. MMULT, MINVERSE).
+ * The calculator is responsible for distributing spill cells.
+ */
+export function evaluateWithSpill(formula: string, grid?: Grid): string | SpillResult {
+  try {
+    const parsed = parseExpression(formula);
+    if (!parsed || hasSyntaxErrors(parsed)) return ErrValue.ERROR;
+
+    const evaluator = new Evaluator(grid);
+    const node = evaluator.visit(parsed.tree);
+
+    if (node.t === 'arr') {
+      return {
+        values: node.v.map((row) => row.map((cell) => evalNodeToStr(cell, grid))),
+        rows: node.rows,
+        cols: node.cols,
+      };
+    }
+
+    return evalNodeToStr(node, grid);
+  } catch {
+    return ErrValue.ERROR;
+  }
+}
+
+/**
  * `evaluate` returns the result of the expression.
  */
 export function evaluate(formula: string, grid?: Grid): string {

--- a/packages/sheets/src/formula/functions-lookup.ts
+++ b/packages/sheets/src/formula/functions-lookup.ts
@@ -1,6 +1,6 @@
 import { ParseTree } from 'antlr4ts/tree/ParseTree';
 import { FunctionContext } from '../../antlr/FormulaParser';
-import { EvalNode, ErrNode } from './formula';
+import { EvalNode, ErrNode, ArrNode, EmptyNode } from './formula';
 import { NumberArgs, BoolArgs } from './arguments';
 import { Grid } from '../model/core/types';
 import {
@@ -1000,7 +1000,7 @@ export function areasFunc(
 }
 
 /**
- * SORT(range, [sort_index], [sort_order]) — for single cell returns first sorted value.
+ * SORT(range, [sort_index], [sort_order]) — sorts a range; returns first sorted value (full spill not yet implemented).
  */
 export function sortFunc(
   ctx: FunctionContext,
@@ -1029,7 +1029,7 @@ export function sortFunc(
 
 /**
  * SORTBY(array, by_array, [sort_order], ...) — sorts range by another range.
- * Returns top-left value after sorting.
+ * Sorts range by another range; returns top-left value of the sorted result (full spill not yet implemented).
  */
 export function sortbyFunc(
   ctx: FunctionContext,
@@ -1082,7 +1082,7 @@ export function sortbyFunc(
 }
 
 /**
- * FLATTEN(range) — for single cell returns the first value.
+ * FLATTEN(range) — flattens a range to a 1-D column; returns first value (full spill not yet implemented).
  */
 export function flattenFunc(
   ctx: FunctionContext,
@@ -1101,7 +1101,8 @@ export function flattenFunc(
 }
 
 /**
- * TRANSPOSE(range) — for single cell returns the value itself.
+ * TRANSPOSE(range) — swaps rows and columns of a matrix, returning an ArrNode.
+ * Use INDEX to address individual elements; spill fills the full transposed matrix.
  */
 export function transposeFunc(
   ctx: FunctionContext,
@@ -1113,15 +1114,35 @@ export function transposeFunc(
   const exprs = args.expr();
   if (exprs.length !== 1) return ErrNode.NA;
 
-  const node = visit(exprs[0]);
-  if (node.t === 'err') return node;
-  if (node.t !== 'ref' || !grid) return node;
-  return firstCellValue(node, grid);
+  const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
+  if ('t' in m && m.t === 'err') return m;
+
+  const rows = m.t === 'arrmat' ? m.rowCount : m.v.rowCount;
+  const cols = m.t === 'arrmat' ? m.colCount : m.v.colCount;
+
+  const result: EvalNode[][] = [];
+  for (let c = 0; c < cols; c++) {
+    const row: EvalNode[] = [];
+    for (let r = 0; r < rows; r++) {
+      if (m.t === 'arrmat') {
+        row.push(m.values[r]?.[c] ?? ({ t: 'empty' } satisfies EmptyNode));
+      } else {
+        const cellVal = grid?.get(m.v.refs[r * cols + c])?.v;
+        if (!cellVal || cellVal === '') {
+          row.push({ t: 'empty' } satisfies EmptyNode);
+        } else {
+          const n = Number(cellVal);
+          row.push(isNaN(n) ? { t: 'str', v: cellVal } : { t: 'num', v: n });
+        }
+      }
+    }
+    result.push(row);
+  }
+  return { t: 'arr', v: result, rows: cols, cols: rows } satisfies ArrNode;
 }
 
 /**
- * FILTER(array, include, [if_empty]) — filters rows based on criteria.
- * Returns first matching row's first value for single-cell evaluation.
+ * FILTER(array, include, [if_empty]) — filters rows based on criteria; returns first matching value (full spill not yet implemented).
  */
 export function filterFunc(
   ctx: FunctionContext,
@@ -1162,7 +1183,7 @@ export function filterFunc(
 }
 
 /**
- * SEQUENCE(rows, [columns], [start], [step]) — returns start value for single cell.
+ * SEQUENCE(rows, [columns], [start], [step]) — generates a sequence; returns first value (full spill not yet implemented).
  */
 export function sequenceFunc(
   ctx: FunctionContext,
@@ -1190,7 +1211,7 @@ export function sequenceFunc(
 }
 
 /**
- * RANDARRAY([rows], [columns], [min], [max], [whole_number]) — returns random for single cell.
+ * RANDARRAY([rows], [columns], [min], [max], [whole_number]) — generates a random array; returns one value (full spill not yet implemented).
  */
 export function randarrayFunc(
   ctx: FunctionContext,
@@ -1225,8 +1246,7 @@ export function randarrayFunc(
 }
 
 /**
- * TOCOL(array, [ignore], [scan_by_column]) — flattens a range to a single column.
- * Returns all values as comma-separated string for single-cell evaluation.
+ * TOCOL(array, [ignore], [scan_by_column]) — flattens a range to a single column; returns values as comma-separated string (full spill not yet implemented).
  */
 export function tocolFunc(
   ctx: FunctionContext,
@@ -1280,8 +1300,7 @@ export function tocolFunc(
 }
 
 /**
- * TOROW(array, [ignore], [scan_by_column]) — flattens a range to a single row.
- * Identical to TOCOL in single-cell evaluation context.
+ * TOROW(array, [ignore], [scan_by_column]) — flattens a range to a single row; returns values as comma-separated string (full spill not yet implemented).
  */
 export function torowFunc(
   ctx: FunctionContext,
@@ -1292,8 +1311,7 @@ export function torowFunc(
 }
 
 /**
- * CHOOSEROWS(array, row_num1, [row_num2], ...) — returns specified rows.
- * Returns the value at the first chosen row, first column.
+ * CHOOSEROWS(array, row_num1, [row_num2], ...) — selects rows by index; returns first chosen row's first value (full spill not yet implemented).
  */
 export function chooserowsFunc(
   ctx: FunctionContext,
@@ -1323,8 +1341,7 @@ export function chooserowsFunc(
 }
 
 /**
- * CHOOSECOLS(array, col_num1, [col_num2], ...) — returns specified columns.
- * Returns the value at the first row, first chosen column.
+ * CHOOSECOLS(array, col_num1, [col_num2], ...) — selects columns by index; returns first row's first chosen value (full spill not yet implemented).
  */
 export function choosecolsFunc(
   ctx: FunctionContext,
@@ -1354,8 +1371,7 @@ export function choosecolsFunc(
 }
 
 /**
- * TAKE(array, rows, [columns]) — returns specified number of rows/columns from start/end.
- * Positive = from start, negative = from end.
+ * TAKE(array, rows, [columns]) — takes rows/cols from start (positive) or end (negative); returns top-left value (full spill not yet implemented).
  */
 export function takeFunc(
   ctx: FunctionContext,
@@ -1399,8 +1415,7 @@ export function takeFunc(
 }
 
 /**
- * DROP(array, rows, [columns]) — removes specified number of rows/columns.
- * Positive = from start, negative = from end.
+ * DROP(array, rows, [columns]) — drops rows/cols from start (positive) or end (negative); returns top-left value (full spill not yet implemented).
  */
 export function dropFunc(
   ctx: FunctionContext,
@@ -1441,8 +1456,7 @@ export function dropFunc(
 }
 
 /**
- * HSTACK(range1, range2, ...) — appends arrays horizontally.
- * Returns top-left value of first range.
+ * HSTACK(range1, range2, ...) — appends arrays horizontally; returns top-left value of first range (full spill not yet implemented).
  */
 export function hstackFunc(
   ctx: FunctionContext,
@@ -1465,8 +1479,7 @@ export function hstackFunc(
 }
 
 /**
- * VSTACK(range1, range2, ...) — appends arrays vertically.
- * Returns top-left value of first range.
+ * VSTACK(range1, range2, ...) — appends arrays vertically; returns top-left value of first range (full spill not yet implemented).
  */
 export function vstackFunc(
   ctx: FunctionContext,
@@ -1477,8 +1490,7 @@ export function vstackFunc(
 }
 
 /**
- * WRAPCOLS(vector, wrap_count, [pad_with]) — wraps a row/column into columns.
- * Returns first value.
+ * WRAPCOLS(vector, wrap_count, [pad_with]) — reshapes a vector into columns; returns first value (full spill not yet implemented).
  */
 export function wrapcolsFunc(
   ctx: FunctionContext,
@@ -1505,8 +1517,7 @@ export function wrapcolsFunc(
 }
 
 /**
- * WRAPROWS(vector, wrap_count, [pad_with]) — wraps a row/column into rows.
- * Returns first value.
+ * WRAPROWS(vector, wrap_count, [pad_with]) — reshapes a vector into rows; returns first value (full spill not yet implemented).
  */
 export function wraprowsFunc(
   ctx: FunctionContext,
@@ -1517,8 +1528,7 @@ export function wraprowsFunc(
 }
 
 /**
- * EXPAND(array, rows, [columns], [pad_with]) — expands array to specified dimensions.
- * Returns top-left value for single-cell evaluation.
+ * EXPAND(array, rows, [columns], [pad_with]) — expands array to given dimensions; returns top-left value (full spill not yet implemented).
  */
 export function expandFunc(
   ctx: FunctionContext,

--- a/packages/sheets/src/formula/functions-math.ts
+++ b/packages/sheets/src/formula/functions-math.ts
@@ -2251,16 +2251,29 @@ export function mdetermFunc(
   return { t: 'num', v: det(matrix) };
 }
 
-function getMatrixVal(m: MatrixResult, row: number, col: number, grid?: Grid): number {
+/**
+ * Reads one numeric value from a MatrixResult at (row, col).
+ * Handles both arrmat (computed/literal array) and matrix (cell-reference) sources.
+ * Returns the numeric value, 0 for empty/blank, or ErrNode for non-numeric / error elements.
+ */
+function getMatrixVal(m: MatrixResult, row: number, col: number, grid?: Grid): number | ErrNode {
   if (m.t === 'arrmat') {
     const node = m.values[row]?.[col];
-    if (!node || node.t === 'err') return 0;
+    if (!node || node.t === 'empty') return 0;
+    if (node.t === 'err') return node;
     if (node.t === 'num') return node.v;
-    if (node.t === 'str') { const n = Number(node.v); return isNaN(n) ? 0 : n; }
-    return 0;
+    if (node.t === 'bool') return node.v ? 1 : 0;
+    if (node.t === 'str') {
+      if (node.v === '') return 0;
+      const n = Number(node.v);
+      return isNaN(n) ? ErrNode.VALUE : n;
+    }
+    return ErrNode.VALUE;
   }
   const cellVal = grid?.get(m.v.refs[row * m.v.colCount + col])?.v;
-  return cellVal != null && cellVal !== '' ? Number(cellVal) : 0;
+  if (!cellVal || cellVal === '') return 0;
+  const n = Number(cellVal);
+  return isNaN(n) ? ErrNode.VALUE : n;
 }
 
 /**
@@ -2296,7 +2309,11 @@ export function mmultFunc(
     for (let j = 0; j < resultCols; j++) {
       let sum = 0;
       for (let k = 0; k < cols1; k++) {
-        sum += getMatrixVal(m1, i, k, grid) * getMatrixVal(m2, k, j, grid);
+        const v1 = getMatrixVal(m1, i, k, grid);
+        if (typeof v1 !== 'number') return v1;
+        const v2 = getMatrixVal(m2, k, j, grid);
+        if (typeof v2 !== 'number') return v2;
+        sum += v1 * v2;
       }
       arrRow.push({ t: 'num', v: sum });
     }
@@ -2331,7 +2348,9 @@ export function minverseFunc(
   for (let i = 0; i < n; i++) {
     const row: number[] = [];
     for (let j = 0; j < n; j++) {
-      row.push(getMatrixVal(m, i, j, grid));
+      const v = getMatrixVal(m, i, j, grid);
+      if (typeof v !== 'number') return v;
+      row.push(v);
     }
     for (let j = 0; j < n; j++) {
       row.push(i === j ? 1 : 0);
@@ -2380,8 +2399,8 @@ export function minverseFunc(
 }
 
 /**
- * MUNIT(dimension) — returns the identity matrix of size n×n.
- * Returns 1 (top-left element of identity matrix).
+ * MUNIT(dimension) — returns the identity matrix of size n×n as an ArrNode.
+ * Use INDEX to address individual elements; spill fills the full matrix automatically.
  */
 export function munitFunc(
   ctx: FunctionContext,
@@ -2394,9 +2413,17 @@ export function munitFunc(
   if (exprs.length !== 1) return ErrNode.NA;
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
-  if (n.v < 1) return ErrNode.VALUE;
-  // Top-left element of identity matrix is always 1
-  return { t: 'num', v: 1 };
+  const size = Math.floor(n.v);
+  if (size < 1) return ErrNode.VALUE;
+  const result: EvalNode[][] = [];
+  for (let i = 0; i < size; i++) {
+    const row: EvalNode[] = [];
+    for (let j = 0; j < size; j++) {
+      row.push({ t: 'num', v: i === j ? 1 : 0 });
+    }
+    result.push(row);
+  }
+  return { t: 'arr', v: result, rows: size, cols: size } satisfies ArrNode;
 }
 
 function roundHalfAwayFromZero(value: number): number {

--- a/packages/sheets/src/model/core/types.ts
+++ b/packages/sheets/src/model/core/types.ts
@@ -134,11 +134,20 @@ export type ConditionalFormatRule = {
 
 /**
  * Cell type represents a cell in the sheet.
+ *
+ * Spill fields support dynamic-array formulas (e.g. MMULT, MINVERSE):
+ *   - The anchor cell (the one with the formula) stores `spillRows`/`spillCols`
+ *     so the calculator knows how many ghost cells to clear on recalculation.
+ *   - Each ghost cell stores `spillAnchor` pointing back to the anchor's Sref.
  */
 export type Cell = {
   v?: string;
   f?: string;
   s?: CellStyle;
+  spillRows?: number;
+  spillCols?: number;
+  spillAnchor?: Sref;
+  spillBlocked?: boolean;
 };
 
 /**

--- a/packages/sheets/src/model/worksheet/calculator.ts
+++ b/packages/sheets/src/model/worksheet/calculator.ts
@@ -1,5 +1,5 @@
-import { ErrValue, evaluate, extractReferences } from '../../formula/formula';
-import { parseRef } from '../core/coordinates';
+import { ErrValue, evaluateWithSpill, SpillResult, extractReferences } from '../../formula/formula';
+import { parseRef, toSref } from '../core/coordinates';
 import { inferInput, applyInferredFormat } from './input';
 import { Sheet } from './sheet';
 import { CellStyle, Sref } from '../core/types';
@@ -62,9 +62,76 @@ export async function calculate(
       continue;
     }
 
+    // Clear ghost cells from a previous (unblocked) spill before re-evaluating.
+    // Only delete cells that are still THIS anchor's ghosts — skip any cell that
+    // has been overwritten with user data (spillAnchor would be absent).
+    if (cell.spillRows && cell.spillCols && !cell.spillBlocked) {
+      for (let dr = 0; dr < cell.spillRows; dr++) {
+        for (let dc = 0; dc < cell.spillCols; dc++) {
+          if (dr === 0 && dc === 0) continue;
+          const ghostRef = { r: ref.r + dr, c: ref.c + dc };
+          const ghostCell = await sheet.getCell(ghostRef);
+          if (ghostCell?.spillAnchor === sref) {
+            await sheet.deleteCell(ghostRef);
+          }
+        }
+      }
+    }
+
     const references = extractReferences(cell.f!);
     const grid = await sheet.fetchGridByReferences(references);
-    const value = evaluate(cell.f!, grid);
+    const result = evaluateWithSpill(cell.f!, grid);
+
+    if (typeof result !== 'string') {
+      const { values, rows, cols } = result as SpillResult;
+
+      // Check for spill conflicts: only user-entered data (no spillAnchor) blocks the spill.
+      // Ghost cells from any anchor are overwritten — they're virtual, not user data.
+      let blocker: Sref | null = null;
+      for (let dr = 0; dr < rows && !blocker; dr++) {
+        for (let dc = 0; dc < cols && !blocker; dc++) {
+          if (dr === 0 && dc === 0) continue;
+          const ghostSref = toSref({ r: ref.r + dr, c: ref.c + dc });
+          const existing = await sheet.getCell(parseRef(ghostSref));
+          if (existing && (existing.v || existing.f) && !existing.spillAnchor) {
+            blocker = ghostSref;
+          }
+        }
+      }
+
+      if (blocker !== null) {
+        // Record blocked state — ghost cells are NOT written; anchor shows #REF!
+        sheet.registerSpillBlocker(blocker, sref);
+        await sheet.setCell(ref, {
+          v: ErrValue.REF,
+          f: cell.f,
+          s: cell.s,
+          spillRows: rows,
+          spillCols: cols,
+          spillBlocked: true,
+        });
+        continue;
+      }
+
+      // No conflict — clear any previous blocked registration and write ghost cells.
+      sheet.clearSpillBlockers(sref);
+      const anchorValue = values[0]?.[0] ?? '';
+      const hasExplicitFormat = cell.s?.nf != null;
+      const style = hasExplicitFormat
+        ? cell.s
+        : applyInferredFormat(cell.s, inferInput(anchorValue));
+      await sheet.setCell(ref, { v: anchorValue, f: cell.f, s: style, spillRows: rows, spillCols: cols });
+      for (let dr = 0; dr < rows; dr++) {
+        for (let dc = 0; dc < cols; dc++) {
+          if (dr === 0 && dc === 0) continue;
+          const ghostRef = { r: ref.r + dr, c: ref.c + dc };
+          await sheet.setCell(ghostRef, { v: values[dr]?.[dc] ?? '', spillAnchor: sref });
+        }
+      }
+      continue;
+    }
+
+    const value = result;
     const hasExplicitFormat = cell.s?.nf != null;
     const style = hasExplicitFormat
       ? cell.s

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -973,14 +973,27 @@ export class Sheet {
       if (existing?.spillAnchor) return;
 
       // Clear ghost cells from any previous spill before overwriting the anchor.
-      if (existing?.spillRows && existing?.spillCols) {
-        this.clearSpillBlockers(toSref(target));
+      // Skip blocked anchors (no ghosts were ever written) and only delete cells
+      // still owned by THIS anchor — see calculator.ts cleanup contract.
+      if (
+        existing?.spillRows &&
+        existing?.spillCols &&
+        !existing.spillBlocked
+      ) {
+        const anchorSref = toSref(target);
+        this.clearSpillBlockers(anchorSref);
         for (let dr = 0; dr < existing.spillRows; dr++) {
           for (let dc = 0; dc < existing.spillCols; dc++) {
             if (dr === 0 && dc === 0) continue;
-            await this.store.delete({ r: target.r + dr, c: target.c + dc });
+            const ghostRef = { r: target.r + dr, c: target.c + dc };
+            const ghostCell = await this.store.get(ghostRef);
+            if (ghostCell?.spillAnchor === anchorSref) {
+              await this.store.delete(ghostRef);
+            }
           }
         }
+      } else if (existing?.spillBlocked) {
+        this.clearSpillBlockers(toSref(target));
       }
 
       const inferred = inferInput(value);
@@ -1046,14 +1059,22 @@ export class Sheet {
         const ref = parseRef(sref);
 
         // Anchor cell being deleted: clear all its ghost cells first.
-        if (cell.spillRows && cell.spillCols) {
+        // Skip blocked anchors (no ghosts were ever written) and only delete
+        // cells still owned by THIS anchor — see calculator.ts cleanup contract.
+        if (cell.spillRows && cell.spillCols && !cell.spillBlocked) {
           this.clearSpillBlockers(sref);
           for (let dr = 0; dr < cell.spillRows; dr++) {
             for (let dc = 0; dc < cell.spillCols; dc++) {
               if (dr === 0 && dc === 0) continue;
-              await this.store.delete({ r: ref.r + dr, c: ref.c + dc });
+              const ghostRef = { r: ref.r + dr, c: ref.c + dc };
+              const ghostCell = await this.store.get(ghostRef);
+              if (ghostCell?.spillAnchor === sref) {
+                await this.store.delete(ghostRef);
+              }
             }
           }
+        } else if (cell.spillBlocked) {
+          this.clearSpillBlockers(sref);
         }
 
         if (cell.s && Object.keys(cell.s).length > 0) {

--- a/packages/sheets/src/model/worksheet/sheet.ts
+++ b/packages/sheets/src/model/worksheet/sheet.ts
@@ -233,6 +233,12 @@ export class Sheet {
   private filterRange?: Range;
 
   /**
+   * Maps a blocker cell Sref → the spill anchor Sref it is blocking.
+   * Used to trigger anchor recalculation when a blocker is cleared.
+   */
+  private spillBlockers = new Map<Sref, Sref>();
+
+  /**
    * `filterColumns` stores column-specific criteria keyed by absolute column index.
    */
   private filterColumns: Map<number, FilterCondition> = new Map();
@@ -851,6 +857,41 @@ export class Sheet {
   }
 
   /**
+   * `deleteCell` removes a cell entirely (used to clear spill ghost cells).
+   */
+  async deleteCell(ref: Ref): Promise<void> {
+    await this.store.delete(ref);
+  }
+
+  /**
+   * Records that `blockerSref` is preventing the spill anchored at `anchorSref`.
+   * Called by the calculator when it detects a conflict.
+   */
+  registerSpillBlocker(blockerSref: Sref, anchorSref: Sref): void {
+    this.spillBlockers.set(blockerSref, anchorSref);
+  }
+
+  /**
+   * Removes all blocker registrations for the given anchor (called when spill
+   * succeeds or the anchor is deleted).
+   */
+  clearSpillBlockers(anchorSref: Sref): void {
+    for (const [blocker, anchor] of this.spillBlockers) {
+      if (anchor === anchorSref) this.spillBlockers.delete(blocker);
+    }
+  }
+
+  /**
+   * If `sref` was blocking a spill, returns the anchor that was waiting.
+   * Clears the registration so the next recalculation starts fresh.
+   */
+  private consumeSpillBlocker(sref: Sref): Sref | undefined {
+    const anchor = this.spillBlockers.get(sref);
+    if (anchor !== undefined) this.spillBlockers.delete(sref);
+    return anchor;
+  }
+
+  /**
    * `hasFormula` checks if the given row and column has a formula.
    */
   async hasFormula(ref: Ref): Promise<boolean> {
@@ -927,6 +968,21 @@ export class Sheet {
     try {
       // 01. Update the cell with normalized inferred value and style metadata.
       const existing = await this.store.get(target);
+
+      // Ghost cells are read-only — only the anchor (formula cell) may be edited.
+      if (existing?.spillAnchor) return;
+
+      // Clear ghost cells from any previous spill before overwriting the anchor.
+      if (existing?.spillRows && existing?.spillCols) {
+        this.clearSpillBlockers(toSref(target));
+        for (let dr = 0; dr < existing.spillRows; dr++) {
+          for (let dc = 0; dc < existing.spillCols; dc++) {
+            if (dr === 0 && dc === 0) continue;
+            await this.store.delete({ r: target.r + dr, c: target.c + dc });
+          }
+        }
+      }
+
       const inferred = inferInput(value);
       const style = applyInferredFormat(existing?.s, inferred);
       const base =
@@ -943,15 +999,21 @@ export class Sheet {
       }
 
       // 02. Update the dependencies.
-      const changedSrefs = this.expandChangedSrefsWithMergeAliases([
-        toSref(target),
-      ]);
+      const targetSref = toSref(target);
+      const changedSrefs = this.expandChangedSrefsWithMergeAliases([targetSref]);
       const dependantsMap = await this.store.buildDependantsMap(changedSrefs);
 
-      // 03. Calculate the cell and its dependencies.
+      // 03. If this cell was blocking a spill, include that anchor in recalculation.
+      const blockedAnchor = this.consumeSpillBlocker(targetSref);
+      if (blockedAnchor) {
+        changedSrefs.add(blockedAnchor);
+        dependantsMap.set(blockedAnchor, new Set());
+      }
+
+      // 04. Calculate the cell and its dependencies.
       await calculate(this, dependantsMap, changedSrefs);
 
-      // 04. Recompute active filter visibility if needed.
+      // 05. Recompute active filter visibility if needed.
       if (this.filterRange) {
         await this.recomputeFilterHiddenRows();
       }
@@ -975,8 +1037,25 @@ export class Sheet {
       const grid = await this.store.getGrid(range);
       const removeds = new Set<Sref>();
 
+      const unblockedAnchors = new Set<Sref>();
+
       for (const [sref, cell] of grid) {
+        // Ghost cells are read-only — skip silently.
+        if (cell.spillAnchor) continue;
+
         const ref = parseRef(sref);
+
+        // Anchor cell being deleted: clear all its ghost cells first.
+        if (cell.spillRows && cell.spillCols) {
+          this.clearSpillBlockers(sref);
+          for (let dr = 0; dr < cell.spillRows; dr++) {
+            for (let dc = 0; dc < cell.spillCols; dc++) {
+              if (dr === 0 && dc === 0) continue;
+              await this.store.delete({ r: ref.r + dr, c: ref.c + dc });
+            }
+          }
+        }
+
         if (cell.s && Object.keys(cell.s).length > 0) {
           // Preserve style, clear value and formula.
           await this.store.set(ref, { s: cell.s });
@@ -984,6 +1063,10 @@ export class Sheet {
           await this.store.delete(ref);
         }
         removeds.add(sref);
+
+        // If this cell was blocking a spill, queue the anchor for recalculation.
+        const blockedAnchor = this.consumeSpillBlocker(sref);
+        if (blockedAnchor) unblockedAnchors.add(blockedAnchor);
       }
 
       if (removeds.size === 0) {
@@ -992,6 +1075,13 @@ export class Sheet {
 
       const changedSrefs = this.expandChangedSrefsWithMergeAliases(removeds);
       const dependantsMap = await this.store.buildDependantsMap(changedSrefs);
+
+      // Include previously-blocked anchors so they can re-attempt the spill.
+      for (const anchor of unblockedAnchors) {
+        changedSrefs.add(anchor);
+        if (!dependantsMap.has(anchor)) dependantsMap.set(anchor, new Set());
+      }
+
       await calculate(this, dependantsMap, changedSrefs);
 
       if (this.filterRange) {
@@ -2011,6 +2101,8 @@ export class Sheet {
           for (let c = cutSourceRange[0].c; c <= cutSourceRange[1].c; c++) {
             const sref = toSref({ r, c });
             if (!grid.has(sref)) {
+              const sourceCell = await this.store.get({ r, c });
+              if (sourceCell?.spillAnchor) continue;
               await this.store.delete({ r, c });
             }
           }
@@ -2135,6 +2227,8 @@ export class Sheet {
         for (let c = srcMinC; c <= srcMaxC; c++) {
           const sref = toSref({ r, c });
           if (!movedGrid.has(sref)) {
+            const sourceCell = await this.store.get({ r, c });
+            if (sourceCell?.spillAnchor) continue;
             await this.store.delete({ r, c });
             changedSrefs.add(sref);
           }
@@ -2310,6 +2404,10 @@ export class Sheet {
 
           const normalizedDest = this.normalizeRefToAnchor(dest);
           const normalizedDestSref = toSref(normalizedDest);
+
+          // Ghost cells are read-only — skip autofill into spill positions.
+          const existingDest = await this.store.get(normalizedDest);
+          if (existingDest?.spillAnchor) continue;
 
           // Check if this line uses OLS trend
           const lineKey = isVertical ? c : r;

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -3126,6 +3126,91 @@ describe('Formula', () => {
     expect(evaluate('=CELL("address",B3)', grid)).toBe('$B$3');
   });
 
+  it('MUNIT returns full identity matrix as ArrNode', () => {
+    // 2×2 identity: [[1,0],[0,1]]
+    expect(evaluate('=INDEX(MUNIT(2),1,1)')).toBe('1');
+    expect(evaluate('=INDEX(MUNIT(2),1,2)')).toBe('0');
+    expect(evaluate('=INDEX(MUNIT(2),2,1)')).toBe('0');
+    expect(evaluate('=INDEX(MUNIT(2),2,2)')).toBe('1');
+    // 3×3 diagonal
+    expect(evaluate('=INDEX(MUNIT(3),1,1)')).toBe('1');
+    expect(evaluate('=INDEX(MUNIT(3),2,2)')).toBe('1');
+    expect(evaluate('=INDEX(MUNIT(3),3,3)')).toBe('1');
+    expect(evaluate('=INDEX(MUNIT(3),1,2)')).toBe('0');
+    expect(evaluate('=INDEX(MUNIT(3),2,1)')).toBe('0');
+    // 1×1 identity
+    expect(evaluate('=INDEX(MUNIT(1),1,1)')).toBe('1');
+    // non-integer is floored
+    expect(evaluate('=INDEX(MUNIT(2.9),1,1)')).toBe('1');
+    expect(evaluate('=INDEX(MUNIT(2.9),1,2)')).toBe('0');
+    // error cases
+    expect(evaluate('=MUNIT(0)')).toBe('#VALUE!');
+    expect(evaluate('=MUNIT(-1)')).toBe('#VALUE!');
+  });
+
+  it('MMULT(A, MUNIT(n)) equals A (identity property)', () => {
+    const grid = new Map<string, Cell>();
+    grid.set('A1', { v: '3' } as Cell); grid.set('B1', { v: '7' } as Cell);
+    grid.set('A2', { v: '1' } as Cell); grid.set('B2', { v: '5' } as Cell);
+    // A · I₂ = A
+    expect(evaluate('=INDEX(MMULT(A1:B2,MUNIT(2)),1,1)', grid)).toBe('3');
+    expect(evaluate('=INDEX(MMULT(A1:B2,MUNIT(2)),1,2)', grid)).toBe('7');
+    expect(evaluate('=INDEX(MMULT(A1:B2,MUNIT(2)),2,1)', grid)).toBe('1');
+    expect(evaluate('=INDEX(MMULT(A1:B2,MUNIT(2)),2,2)', grid)).toBe('5');
+  });
+
+  it('TRANSPOSE returns full transposed matrix as ArrNode', () => {
+    const grid = new Map<string, Cell>();
+    // [[1,2,3],[4,5,6]] → transposed → [[1,4],[2,5],[3,6]]
+    grid.set('A1', { v: '1' } as Cell); grid.set('B1', { v: '2' } as Cell); grid.set('C1', { v: '3' } as Cell);
+    grid.set('A2', { v: '4' } as Cell); grid.set('B2', { v: '5' } as Cell); grid.set('C2', { v: '6' } as Cell);
+    expect(evaluate('=INDEX(TRANSPOSE(A1:C2),1,1)', grid)).toBe('1');
+    expect(evaluate('=INDEX(TRANSPOSE(A1:C2),1,2)', grid)).toBe('4');
+    expect(evaluate('=INDEX(TRANSPOSE(A1:C2),2,1)', grid)).toBe('2');
+    expect(evaluate('=INDEX(TRANSPOSE(A1:C2),2,2)', grid)).toBe('5');
+    expect(evaluate('=INDEX(TRANSPOSE(A1:C2),3,1)', grid)).toBe('3');
+    expect(evaluate('=INDEX(TRANSPOSE(A1:C2),3,2)', grid)).toBe('6');
+    // array literal: TRANSPOSE({1,2;3,4}) → [[1,3],[2,4]]
+    expect(evaluate('=INDEX(TRANSPOSE({1,2;3,4}),1,1)')).toBe('1');
+    expect(evaluate('=INDEX(TRANSPOSE({1,2;3,4}),1,2)')).toBe('3');
+    expect(evaluate('=INDEX(TRANSPOSE({1,2;3,4}),2,1)')).toBe('2');
+    expect(evaluate('=INDEX(TRANSPOSE({1,2;3,4}),2,2)')).toBe('4');
+  });
+
+  it('TRANSPOSE handles single-row and single-column ranges', () => {
+    const grid = new Map<string, Cell>();
+    // Single row [1,2,3] → transposed to single column [[1],[2],[3]]
+    grid.set('A1', { v: '1' } as Cell); grid.set('B1', { v: '2' } as Cell); grid.set('C1', { v: '3' } as Cell);
+    expect(evaluate('=INDEX(TRANSPOSE(A1:C1),1,1)', grid)).toBe('1');
+    expect(evaluate('=INDEX(TRANSPOSE(A1:C1),2,1)', grid)).toBe('2');
+    expect(evaluate('=INDEX(TRANSPOSE(A1:C1),3,1)', grid)).toBe('3');
+    // Single column [[10],[20]] → transposed to single row [10,20]
+    grid.set('A2', { v: '10' } as Cell); grid.set('A3', { v: '20' } as Cell);
+    expect(evaluate('=INDEX(TRANSPOSE(A2:A3),1,1)', grid)).toBe('10');
+    expect(evaluate('=INDEX(TRANSPOSE(A2:A3),1,2)', grid)).toBe('20');
+  });
+
+  it('TRANSPOSE preserves text values', () => {
+    const grid = new Map<string, Cell>();
+    grid.set('A1', { v: 'hello' } as Cell); grid.set('B1', { v: 'world' } as Cell);
+    grid.set('A2', { v: '42' } as Cell);    grid.set('B2', { v: 'end' } as Cell);
+    // [[hello,world],[42,end]] → transposed → [[hello,42],[world,end]]
+    expect(evaluate('=INDEX(TRANSPOSE(A1:B2),1,1)', grid)).toBe('hello');
+    expect(evaluate('=INDEX(TRANSPOSE(A1:B2),1,2)', grid)).toBe('42');
+    expect(evaluate('=INDEX(TRANSPOSE(A1:B2),2,1)', grid)).toBe('world');
+    expect(evaluate('=INDEX(TRANSPOSE(A1:B2),2,2)', grid)).toBe('end');
+  });
+
+  it('TRANSPOSE(TRANSPOSE(A)) round-trips to the original', () => {
+    const grid = new Map<string, Cell>();
+    grid.set('A1', { v: '1' } as Cell); grid.set('B1', { v: '2' } as Cell);
+    grid.set('A2', { v: '3' } as Cell); grid.set('B2', { v: '4' } as Cell);
+    expect(evaluate('=INDEX(TRANSPOSE(TRANSPOSE(A1:B2)),1,1)', grid)).toBe('1');
+    expect(evaluate('=INDEX(TRANSPOSE(TRANSPOSE(A1:B2)),1,2)', grid)).toBe('2');
+    expect(evaluate('=INDEX(TRANSPOSE(TRANSPOSE(A1:B2)),2,1)', grid)).toBe('3');
+    expect(evaluate('=INDEX(TRANSPOSE(TRANSPOSE(A1:B2)),2,2)', grid)).toBe('4');
+  });
+
   it('should correctly evaluate MMULT function', () => {
     const grid = new Map<string, Cell>();
     // 2x2 matrix A: [[1,2],[3,4]]
@@ -3208,6 +3293,50 @@ describe('Formula', () => {
     expect(evaluate('=INDEX(MINVERSE(MMULT(A1:B2,C1:D2)),1,2)', grid)).toBe('0');
     expect(evaluate('=INDEX(MINVERSE(MMULT(A1:B2,C1:D2)),2,1)', grid)).toBe('0');
     expect(evaluate('=INDEX(MINVERSE(MMULT(A1:B2,C1:D2)),2,2)', grid)).toBe('0.5');
+  });
+
+  it('MMULT returns #VALUE! when a matrix element is non-numeric', () => {
+    const grid = new Map<string, Cell>();
+    grid.set('A1', { v: '1' } as Cell); grid.set('B1', { v: 'text' } as Cell);
+    grid.set('A2', { v: '3' } as Cell); grid.set('B2', { v: '4' } as Cell);
+    grid.set('C1', { v: '5' } as Cell); grid.set('D1', { v: '6' } as Cell);
+    grid.set('C2', { v: '7' } as Cell); grid.set('D2', { v: '8' } as Cell);
+    expect(evaluate('=MMULT(A1:B2,C1:D2)', grid)).toBe('#VALUE!');
+  });
+
+  it('MINVERSE returns #VALUE! when a matrix element is non-numeric', () => {
+    const grid = new Map<string, Cell>();
+    grid.set('A1', { v: '1' } as Cell); grid.set('B1', { v: 'text' } as Cell);
+    grid.set('A2', { v: '0' } as Cell); grid.set('B2', { v: '1' } as Cell);
+    expect(evaluate('=MINVERSE(A1:B2)', grid)).toBe('#VALUE!');
+  });
+
+  it('MMULT(MMULT with non-numeric)) propagates #VALUE! to outer call', () => {
+    const grid = new Map<string, Cell>();
+    // inner MMULT will get a non-numeric element → ArrNode with err element
+    // outer INDEX should surface #VALUE!
+    grid.set('A1', { v: '1' } as Cell); grid.set('B1', { v: 'bad' } as Cell);
+    grid.set('A2', { v: '3' } as Cell); grid.set('B2', { v: '4' } as Cell);
+    grid.set('C1', { v: '5' } as Cell); grid.set('D1', { v: '6' } as Cell);
+    grid.set('C2', { v: '7' } as Cell); grid.set('D2', { v: '8' } as Cell);
+    expect(evaluate('=INDEX(MMULT(MMULT(A1:B2,C1:D2),A1:B2),1,1)', grid)).toBe('#VALUE!');
+  });
+
+  it('MMULT returns #VALUE! when an array literal element is non-numeric text', () => {
+    // getMatrixVal arrmat path: string node with non-numeric value → #VALUE!
+    expect(evaluate('=MMULT({"text",2;3,4},{1,0;0,1})')).toBe('#VALUE!');
+    expect(evaluate('=MMULT({1,0;0,1},{"bad",0;0,1})')).toBe('#VALUE!');
+  });
+
+  it('MMULT coerces numeric strings in array literals', () => {
+    // getMatrixVal arrmat path: string node with numeric value → coerced to number
+    // {{"2","3"},{"4","5"}} · [[1,0],[0,1]] = same matrix → top-left is "2"
+    expect(evaluate('=MMULT({"2","0";"0","1"},{1,0;0,1})')).toBe('2');
+  });
+
+  it('MINVERSE returns #VALUE! when an array literal element is non-numeric text', () => {
+    // getMatrixVal arrmat path for MINVERSE
+    expect(evaluate('=MINVERSE({"text",0;0,1})')).toBe('#VALUE!');
   });
 
   it('should correctly evaluate XMATCH function', () => {

--- a/packages/sheets/test/sheet/calculation.test.ts
+++ b/packages/sheets/test/sheet/calculation.test.ts
@@ -169,6 +169,36 @@ describe('Sheet.Calcuation', () => {
     expect(await sheet.toDisplayString({ r: 5, c: 2 })).toBe('1');
   });
 
+  it('overwriting a blocked anchor preserves user data in the spill zone', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '0');
+    await sheet.setData({ r: 2, c: 1 }, '0'); await sheet.setData({ r: 2, c: 2 }, '1');
+    // Place a blocker that prevents the 2x2 spill at A4:B5.
+    await sheet.setData({ r: 5, c: 1 }, 'BLOCKER');
+    await sheet.setData({ r: 4, c: 1 }, '=MINVERSE(A1:B2)');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('#REF!');
+
+    // Overwrite the blocked anchor with a scalar — the blocker MUST survive
+    // because it is user data, not a ghost cell.
+    await sheet.setData({ r: 4, c: 1 }, '7');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('7');
+    expect(await sheet.toDisplayString({ r: 5, c: 1 })).toBe('BLOCKER');
+  });
+
+  it('clearing a blocked anchor preserves user data in the spill zone', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '0');
+    await sheet.setData({ r: 2, c: 1 }, '0'); await sheet.setData({ r: 2, c: 2 }, '1');
+    await sheet.setData({ r: 5, c: 1 }, 'BLOCKER');
+    await sheet.setData({ r: 4, c: 1 }, '=MINVERSE(A1:B2)');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('#REF!');
+
+    // Clearing the blocked anchor must NOT delete the user-entered blocker.
+    await sheet.setData({ r: 4, c: 1 }, '');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('');
+    expect(await sheet.toDisplayString({ r: 5, c: 1 })).toBe('BLOCKER');
+  });
+
   it('MUNIT spills identity matrix into adjacent cells', async () => {
     const sheet = new Sheet(new MemStore());
     // =MUNIT(3) at A1 should spill a 3×3 identity matrix

--- a/packages/sheets/test/sheet/calculation.test.ts
+++ b/packages/sheets/test/sheet/calculation.test.ts
@@ -68,6 +68,167 @@ describe('Sheet.Calcuation', () => {
     expect(await sheet.toDisplayString({ r: 1, c: 4 })).toBe('30');
   });
 
+  it('MMULT spills all elements into adjacent cells', async () => {
+    const sheet = new Sheet(new MemStore());
+    // A = [[1,2],[3,4]], B = [[5,6],[7,8]]
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '2');
+    await sheet.setData({ r: 2, c: 1 }, '3'); await sheet.setData({ r: 2, c: 2 }, '4');
+    await sheet.setData({ r: 1, c: 3 }, '5'); await sheet.setData({ r: 1, c: 4 }, '6');
+    await sheet.setData({ r: 2, c: 3 }, '7'); await sheet.setData({ r: 2, c: 4 }, '8');
+    // A×B = [[19,22],[43,50]]
+    await sheet.setData({ r: 4, c: 1 }, '=MMULT(A1:B2,C1:D2)');
+
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('19'); // [1,1] anchor
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe('22'); // [1,2] ghost
+    expect(await sheet.toDisplayString({ r: 5, c: 1 })).toBe('43'); // [2,1] ghost
+    expect(await sheet.toDisplayString({ r: 5, c: 2 })).toBe('50'); // [2,2] ghost
+  });
+
+  it('MINVERSE spills all elements into adjacent cells', async () => {
+    const sheet = new Sheet(new MemStore());
+    // [[2,1],[1,1]] — det=1, inverse = [[1,-1],[-1,2]]
+    await sheet.setData({ r: 1, c: 1 }, '2'); await sheet.setData({ r: 1, c: 2 }, '1');
+    await sheet.setData({ r: 2, c: 1 }, '1'); await sheet.setData({ r: 2, c: 2 }, '1');
+    await sheet.setData({ r: 4, c: 1 }, '=MINVERSE(A1:B2)');
+
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('1');
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe('-1');
+    expect(await sheet.toDisplayString({ r: 5, c: 1 })).toBe('-1');
+    expect(await sheet.toDisplayString({ r: 5, c: 2 })).toBe('2');
+  });
+
+  it('ghost cells are cleared when spill formula is overwritten with scalar', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '0');
+    await sheet.setData({ r: 2, c: 1 }, '0'); await sheet.setData({ r: 2, c: 2 }, '1');
+    // Identity inverse = identity
+    await sheet.setData({ r: 4, c: 1 }, '=MINVERSE(A1:B2)');
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe('0'); // ghost set
+
+    // Replace with scalar formula — ghost cells must be cleared
+    await sheet.setData({ r: 4, c: 1 }, '=SUM(A1:B2)');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('2');
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe(''); // ghost gone
+    expect(await sheet.toDisplayString({ r: 5, c: 1 })).toBe(''); // ghost gone
+    expect(await sheet.toDisplayString({ r: 5, c: 2 })).toBe(''); // ghost gone
+  });
+
+  it('ghost cells are read-only: setData on a ghost is silently ignored', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '0');
+    await sheet.setData({ r: 2, c: 1 }, '0'); await sheet.setData({ r: 2, c: 2 }, '1');
+    await sheet.setData({ r: 4, c: 1 }, '=MINVERSE(A1:B2)');
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe('0'); // ghost
+
+    // Attempt to overwrite a ghost cell — must be silently ignored.
+    await sheet.setData({ r: 4, c: 2 }, '999');
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe('0'); // still ghost value
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('1'); // anchor intact
+  });
+
+  it('deleting the anchor clears all ghost cells', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '0');
+    await sheet.setData({ r: 2, c: 1 }, '0'); await sheet.setData({ r: 2, c: 2 }, '1');
+    await sheet.setData({ r: 4, c: 1 }, '=MINVERSE(A1:B2)');
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe('0'); // ghost filled
+
+    // Delete the anchor by writing empty string.
+    await sheet.setData({ r: 4, c: 1 }, '');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe(''); // anchor gone
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe(''); // ghost cleared
+    expect(await sheet.toDisplayString({ r: 5, c: 1 })).toBe(''); // ghost cleared
+    expect(await sheet.toDisplayString({ r: 5, c: 2 })).toBe(''); // ghost cleared
+  });
+
+  it('spill is blocked and shows #REF! when range contains a non-empty cell', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '0');
+    await sheet.setData({ r: 2, c: 1 }, '0'); await sheet.setData({ r: 2, c: 2 }, '1');
+    // Place a blocker in the spill range before entering the formula.
+    await sheet.setData({ r: 5, c: 1 }, 'BLOCKER');
+    await sheet.setData({ r: 4, c: 1 }, '=MINVERSE(A1:B2)');
+
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('#REF!'); // blocked
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe('');      // ghost not written
+  });
+
+  it('spill auto-recovers when the blocking cell is cleared', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '0');
+    await sheet.setData({ r: 2, c: 1 }, '0'); await sheet.setData({ r: 2, c: 2 }, '1');
+    await sheet.setData({ r: 5, c: 1 }, 'BLOCKER');
+    await sheet.setData({ r: 4, c: 1 }, '=MINVERSE(A1:B2)');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('#REF!');
+
+    // Clear the blocker — spill should fill automatically.
+    await sheet.setData({ r: 5, c: 1 }, '');
+    expect(await sheet.toDisplayString({ r: 4, c: 1 })).toBe('1');
+    expect(await sheet.toDisplayString({ r: 4, c: 2 })).toBe('0');
+    expect(await sheet.toDisplayString({ r: 5, c: 1 })).toBe('0');
+    expect(await sheet.toDisplayString({ r: 5, c: 2 })).toBe('1');
+  });
+
+  it('MUNIT spills identity matrix into adjacent cells', async () => {
+    const sheet = new Sheet(new MemStore());
+    // =MUNIT(3) at A1 should spill a 3×3 identity matrix
+    await sheet.setData({ r: 1, c: 1 }, '=MUNIT(3)');
+
+    // Diagonal = 1, off-diagonal = 0
+    expect(await sheet.toDisplayString({ r: 1, c: 1 })).toBe('1'); // anchor [1,1]
+    expect(await sheet.toDisplayString({ r: 1, c: 2 })).toBe('0'); // [1,2] ghost
+    expect(await sheet.toDisplayString({ r: 1, c: 3 })).toBe('0'); // [1,3] ghost
+    expect(await sheet.toDisplayString({ r: 2, c: 1 })).toBe('0'); // [2,1] ghost
+    expect(await sheet.toDisplayString({ r: 2, c: 2 })).toBe('1'); // [2,2] ghost
+    expect(await sheet.toDisplayString({ r: 2, c: 3 })).toBe('0'); // [2,3] ghost
+    expect(await sheet.toDisplayString({ r: 3, c: 1 })).toBe('0'); // [3,1] ghost
+    expect(await sheet.toDisplayString({ r: 3, c: 2 })).toBe('0'); // [3,2] ghost
+    expect(await sheet.toDisplayString({ r: 3, c: 3 })).toBe('1'); // [3,3] ghost
+  });
+
+  it('MMULT(A, MUNIT(n)) spills a matrix equal to A', async () => {
+    const sheet = new Sheet(new MemStore());
+    // A = [[3,7],[1,5]]
+    await sheet.setData({ r: 1, c: 1 }, '3'); await sheet.setData({ r: 1, c: 2 }, '7');
+    await sheet.setData({ r: 2, c: 1 }, '1'); await sheet.setData({ r: 2, c: 2 }, '5');
+    // A · I₂ = A, spilled at D1
+    await sheet.setData({ r: 1, c: 4 }, '=MMULT(A1:B2,MUNIT(2))');
+
+    expect(await sheet.toDisplayString({ r: 1, c: 4 })).toBe('3');
+    expect(await sheet.toDisplayString({ r: 1, c: 5 })).toBe('7');
+    expect(await sheet.toDisplayString({ r: 2, c: 4 })).toBe('1');
+    expect(await sheet.toDisplayString({ r: 2, c: 5 })).toBe('5');
+  });
+
+  it('TRANSPOSE spills the transposed matrix into adjacent cells', async () => {
+    const sheet = new Sheet(new MemStore());
+    // Source: [[1,2,3],[4,5,6]] in A1:C2
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '2'); await sheet.setData({ r: 1, c: 3 }, '3');
+    await sheet.setData({ r: 2, c: 1 }, '4'); await sheet.setData({ r: 2, c: 2 }, '5'); await sheet.setData({ r: 2, c: 3 }, '6');
+    // =TRANSPOSE(A1:C2) at E1 → spills 3×2 transposed matrix
+    await sheet.setData({ r: 1, c: 5 }, '=TRANSPOSE(A1:C2)');
+
+    // Transposed: [[1,4],[2,5],[3,6]]
+    expect(await sheet.toDisplayString({ r: 1, c: 5 })).toBe('1'); // anchor [1,1]
+    expect(await sheet.toDisplayString({ r: 1, c: 6 })).toBe('4'); // [1,2] ghost
+    expect(await sheet.toDisplayString({ r: 2, c: 5 })).toBe('2'); // [2,1] ghost
+    expect(await sheet.toDisplayString({ r: 2, c: 6 })).toBe('5'); // [2,2] ghost
+    expect(await sheet.toDisplayString({ r: 3, c: 5 })).toBe('3'); // [3,1] ghost
+    expect(await sheet.toDisplayString({ r: 3, c: 6 })).toBe('6'); // [3,2] ghost
+  });
+
+  it('TRANSPOSE ghost cells are read-only', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '1'); await sheet.setData({ r: 1, c: 2 }, '2');
+    await sheet.setData({ r: 2, c: 1 }, '3'); await sheet.setData({ r: 2, c: 2 }, '4');
+    await sheet.setData({ r: 1, c: 4 }, '=TRANSPOSE(A1:B2)');
+
+    // Ghost at D2 = 2 (original B1)
+    expect(await sheet.toDisplayString({ r: 2, c: 4 })).toBe('2');
+    await sheet.setData({ r: 2, c: 4 }, '999');
+    expect(await sheet.toDisplayString({ r: 2, c: 4 })).toBe('2'); // still ghost
+  });
+
   it('should handle invalid value: range without array function', async () => {
     const sheet = new Sheet(new MemStore());
     await sheet.setData({ r: 1, c: 1 }, '1');


### PR DESCRIPTION
## Summary
All four matrix functions now return a full ArrNode that spills into adjacent cells (Google Sheets-style dynamic arrays). Includes:

- evaluateWithSpill() API so the calculator can detect array results and distribute them as ghost cells
- Ghost cell lifecycle: written on spill, cleared on re-eval, and read-only to all user edits (setData, removeData, cut/paste, move, autofill); anchor deletion also clears ghost cells
- #REF! on conflict with user-entered data; auto-recovery when the blocker is removed
- getMatrixVal helper reads from both range refs and arrmat literals, propagating #VALUE! for non-numeric elements — enables composition like MMULT(MMULT(...)), MINVERSE(MMULT(...)), MMULT(A, MUNIT(n))
- MUNIT builds the full n×n identity matrix (was: returning scalar 1)
- TRANSPOSE swaps rows and columns for range refs and array literals (was: returning only the top-left value)
- Fix yorkie-store normalizeCell to preserve spill fields so ghost cell guards work in the production Yorkie-backed store
- Clarify stub array functions (SORT, FLATTEN, FILTER, SEQUENCE, RANDARRAY, TOCOL/TOROW, HSTACK/VSTACK, WRAP*, CHOOSE*, TAKE, DROP, EXPAND) with explicit "full spill not yet implemented" notes

## Why

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Array-spilling formulas can populate multi-cell ranges, with transposed and identity matrix functions returning full matrices.
  * Spill behavior: spill ranges are written as anchor+read-only ghost cells; deleting an anchor clears its ghosts; conflicts block spills and automatically recover when cleared.
  * Edits/auto-fill now avoid overwriting spill ghost cells.

* **Bug Fixes**
  * Preserve spill metadata so spill-only cells aren’t dropped; matrix ops now surface value errors instead of silent coercion.

* **Tests**
  * Expanded tests covering spill behavior, matrix functions, error propagation, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->