### PR TITLE
Refresh expired CLI session instead of dropping to none auth

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -25,7 +25,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 155
+- Archived task count: 156
 - Archive index: [archive/README.md](./archive/README.md)
 
 Latest active task: pdf export followup (2026-05-01)

--- a/docs/tasks/archive/2026/05/20260505-cli-expired-session-404-todo.md
+++ b/docs/tasks/archive/2026/05/20260505-cli-expired-session-404-todo.md
@@ -1,0 +1,75 @@
+---
+title: Fix CLI 404 when access token is expired
+date: 2026-05-05
+status: completed
+---
+
+# Fix CLI 404 when access token is expired
+
+## Problem
+
+`wafflebase docs list` (and any other CLI subcommand) returns
+
+```
+{ "error": { "code": "ERROR", "message": "HTTP 404" } }
+```
+
+once the session's access token has expired, even though a valid refresh
+token is sitting in `~/.wafflebase/session.json`.
+
+## Root cause
+
+`packages/cli/src/config/config.ts:104` only adopts the saved session when
+`!isSessionExpired(session)`. If the access token is past its `expiresAt`,
+the JWT branch is skipped, the function falls through to `authMode: 'none'`,
+and `session.activeWorkspace` is dropped. The HTTP client then constructs
+
+```
+GET https://api.wafflebase.io/api/v1/workspaces//documents
+```
+
+with an empty workspace segment, which the backend rejects with a 404.
+
+`HttpClient.refreshSession` already knows how to swap the access token for
+a fresh one on a 401, but it only fires when `authMode === 'jwt'` and a
+refresh token is present — exactly the state `resolveConfig` refuses to
+hand it.
+
+## Plan
+
+- [x] Add a failing test in `packages/cli/test/config.test.ts` covering the
+      "expired access token but valid refresh token" case: `resolveConfig`
+      must return `authMode: 'jwt'`, the session's `accessToken` /
+      `refreshToken`, and `session.activeWorkspace`.
+- [x] In `resolveConfig`, drop the `!isSessionExpired(session)` gate so a
+      session with both tokens always selects JWT auth. Let the HTTP client
+      handle the actual expiration via its existing 401 → refresh → retry
+      path.
+- [x] Manually verify with the real CLI: forced
+      `~/.wafflebase/session.json` `expiresAt` into the past, confirmed
+      installed CLI returned `HTTP 404`, then ran the patched CLI from
+      source (`pnpm --filter @wafflebase/cli dev docs list`) and it
+      auto-refreshed the access token and returned the document list.
+- [x] Run `pnpm -w run verify:fast` — exit 0.
+
+## Notes
+
+- The `wafflebase status` command still uses `isSessionExpired` to decide
+  whether to print "valid" / "expired"; that's a UX hint and is fine — we
+  only want to stop *config resolution* from giving up early.
+- `SESSION_EXPIRED` error path in `HttpClient.request` already covers the
+  "refresh token also dead" scenario, so users still get a clear
+  "run `wafflebase login`" message when both tokens are gone.
+
+## Review
+
+Single-file behavior change in `packages/cli/src/config/config.ts`: stop
+gating session adoption on `!isSessionExpired`. The HTTP client's existing
+401 → refresh path now actually runs in the scenario it was designed for
+(expired access token, live refresh token), and the active workspace from
+the session is no longer dropped — which was the proximate cause of the
+malformed `/api/v1/workspaces//documents` URL and the resulting 404.
+
+Test coverage added: a regression case in `packages/cli/test/config.test.ts`
+asserts that an expired-access-token session still resolves to
+`authMode: 'jwt'` with the session workspace and both tokens intact.

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,13 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 155
+Total archived tasks: 156
 
-## 2026/05 (10 tasks)
+## 2026/05 (11 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| cli expired session 404 (2026-05-05) | [20260505-cli-expired-session-404-todo.md](./2026/05/20260505-cli-expired-session-404-todo.md) | - |
 | release 0.3.7 (2026-05-04) | [20260504-release-0.3.7-todo.md](./2026/05/20260504-release-0.3.7-todo.md) | - |
 | cmd arrow axis extension (2026-05-03) | [20260503-cmd-arrow-axis-extension-todo.md](./2026/05/20260503-cmd-arrow-axis-extension-todo.md) | [20260503-cmd-arrow-axis-extension-lessons.md](./2026/05/20260503-cmd-arrow-axis-extension-lessons.md) |
 | docs paragraph bg selection (2026-05-03) | [20260503-docs-paragraph-bg-selection-todo.md](./2026/05/20260503-docs-paragraph-bg-selection-todo.md) | - |

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -2,7 +2,7 @@ import { readFileSync, existsSync, mkdirSync, copyFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { parse as parseYaml } from 'yaml';
-import { loadSession, isSessionExpired } from './session.js';
+import { loadSession } from './session.js';
 
 export const DEFAULT_SERVER = 'https://api.wafflebase.io';
 
@@ -67,7 +67,10 @@ export function getConfigPath(): string {
  *
  * Auth resolution order:
  * 1. Flag/env `--api-key` or `WAFFLEBASE_API_KEY` → API key auth
- * 2. Session `~/.wafflebase/session.json` exists and token valid → JWT auth
+ * 2. Session `~/.wafflebase/session.json` with both tokens → JWT auth
+ *    (the access token may already be past its `expiresAt`; the HTTP
+ *    client refreshes it on the first 401 and falls back to a clear
+ *    SESSION_EXPIRED error when the refresh token is also dead)
  * 3. Config profile `api-key` → API key auth
  * 4. None → empty (commands will fail)
  */
@@ -99,9 +102,14 @@ export function resolveConfig(flags: {
     };
   }
 
-  // Step 2: Try session
+  // Step 2: Try session — accept it whenever both tokens are present.
+  // Gating on `isSessionExpired` here would silently drop the session
+  // (and its `activeWorkspace`) the moment the access token expired,
+  // turning every command into a `/workspaces//...` 404. Letting the
+  // HTTP client see the expired access token + refresh token lets its
+  // 401 → refresh → retry path do its job.
   const session = loadSession();
-  if (session && !isSessionExpired(session)) {
+  if (session && session.accessToken && session.refreshToken) {
     return {
       server:
         flags.server ??

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { resolveConfig, getConfigPath, migrateConfigIfNeeded, DEFAULT_SERVER } from '../src/config/config.js';
+import type { Session } from '../src/config/session.js';
 
 describe('resolveConfig', () => {
   const origEnv = { ...process.env };
@@ -54,6 +55,60 @@ describe('resolveConfig', () => {
 
     expect(config.server).toBe('https://env.example.com');
     expect(config.apiKey).toBe('wfb_env');
+  });
+
+  describe('session-backed JWT auth', () => {
+    let tmpDir: string;
+    let sessionPath: string;
+
+    function writeSessionFile(overrides: Partial<Session>): void {
+      const session: Session = {
+        server: 'https://api.example.com',
+        user: { id: 1, username: 'u', email: 'u@example.com', photo: null },
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+        activeWorkspace: 'ws-from-session',
+        workspaces: [{ id: 'ws-from-session', name: 'WS' }],
+        ...overrides,
+      };
+      mkdirSync(tmpDir, { recursive: true });
+      writeFileSync(sessionPath, JSON.stringify(session), 'utf-8');
+    }
+
+    beforeEach(() => {
+      tmpDir = join(tmpdir(), `wfb-config-session-${Date.now()}-${Math.random()}`);
+      sessionPath = join(tmpDir, 'session.json');
+      process.env.WAFFLEBASE_CONFIG = join(tmpDir, 'config.yaml');
+      process.env.WAFFLEBASE_SESSION = sessionPath;
+    });
+
+    afterEach(() => {
+      if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('uses session JWT auth when access token is still valid', () => {
+      writeSessionFile({ expiresAt: new Date(Date.now() + 3600_000).toISOString() });
+      const config = resolveConfig({});
+      expect(config.authMode).toBe('jwt');
+      expect(config.workspace).toBe('ws-from-session');
+      expect(config.accessToken).toBe('access-token');
+      expect(config.refreshToken).toBe('refresh-token');
+    });
+
+    // Regression: when the access token is expired but a refresh token is
+    // present, resolveConfig must still pick JWT auth and surface the
+    // session's active workspace. Otherwise the HTTP client builds
+    // `/api/v1/workspaces//documents` (empty segment) and the backend
+    // returns 404, making expired sessions look like missing routes.
+    it('keeps JWT auth and workspace when access token is expired but refresh token exists', () => {
+      writeSessionFile({ expiresAt: new Date(Date.now() - 60_000).toISOString() });
+      const config = resolveConfig({});
+      expect(config.authMode).toBe('jwt');
+      expect(config.workspace).toBe('ws-from-session');
+      expect(config.accessToken).toBe('access-token');
+      expect(config.refreshToken).toBe('refresh-token');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes `wafflebase docs list` (and other CLI subcommands) returning `HTTP 404` once the session's access token expires, even when a valid refresh token is sitting in `~/.wafflebase/session.json`.
- Root cause: `resolveConfig` in `packages/cli/src/config/config.ts` only adopted the saved session when `!isSessionExpired(session)`. With an expired access token it fell through to `authMode: 'none'` and **dropped `session.activeWorkspace`**, so the HTTP client built `GET /api/v1/workspaces//documents` (empty segment) and the backend rejected it with a 404. The HttpClient's existing 401 → refresh → retry path requires `authMode === 'jwt'`, so it was effectively dead code in exactly the scenario it was designed for.
- Fix: adopt the session whenever both `accessToken` and `refreshToken` are present. The HttpClient now actually gets to refresh the access token on 401; if the refresh token is also dead, the existing `SESSION_EXPIRED` path still surfaces a clear "run `wafflebase login`" message.
- `wafflebase status` keeps using `isSessionExpired` for its "valid" / "expired" UX hint — only config resolution is changed.

## Test plan

- [x] `pnpm --filter @wafflebase/cli test` — new regression case in `packages/cli/test/config.test.ts` fails before the fix, passes after.
- [x] Manual repro: forced `~/.wafflebase/session.json` `expiresAt` into the past, ran the installed CLI → `HTTP 404`. Then ran the patched CLI from source (`pnpm --filter @wafflebase/cli dev docs list`) → auto-refresh fired, document list returned, `expiresAt` rotated forward.
- [x] `pnpm -w run verify:fast` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved CLI HTTP 404 errors that occurred when session access tokens expired despite having a valid refresh token. The CLI now properly handles automatic token refresh before retrying requests.

* **Tests**
  * Added test coverage for session authentication scenarios with expired and valid access tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->