### PR TITLE
Wire imageFetcher through CLI docs export pipeline

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -6,6 +6,7 @@ import { printDryRun } from '../client/dry-run.js';
 import { parseContentFormat, runDocsContent } from '../docs/content.js';
 import { exportPdf } from '../docs/pdf-export.js';
 import { exportDocx } from '../docs/docx-export.js';
+import { createImageFetcher } from '../docs/image-fetcher.js';
 import { parsePageRange } from '../docs/page-range.js';
 import { writeBinary } from '../output/binary.js';
 import { runDocsImport } from '../docs/import.js';
@@ -259,6 +260,16 @@ export function registerDocsCommand(program: Command) {
         }
         const fetchedDoc = res.data;
 
+        // Image inlines reference URLs that PdfExporter and DocxExporter
+        // can't resolve on their own. The fetcher walks each unique
+        // `src`, GETs it (via `globalThis.fetch`), and hands back a
+        // Blob. Relative URLs (`/images/<id>`) resolve against the
+        // configured server base so the same doc round-trips between
+        // the editor (browser-relative) and the CLI.
+        const imageFetcher = createImageFetcher({
+          serverBase: getConfig(opts).server,
+        });
+
         let bytes: Uint8Array;
         if (format === 'pdf') {
           // Pagination uses the FontkitMeasurer's coarse Latin estimate
@@ -273,6 +284,7 @@ export function registerDocsCommand(program: Command) {
             // see `extractPages` in pdf-export.ts.
             const fullPdf = await exportPdf(fetchedDoc, {
               includeHeaderFooter: local.includeHeaderFooter,
+              imageFetcher,
             });
             const total = await pdfPageCount(fullPdf);
             pageRange = parsePageRange(local.pages, total);
@@ -282,10 +294,12 @@ export function registerDocsCommand(program: Command) {
             bytes = await exportPdf(fetchedDoc, {
               includeHeaderFooter: local.includeHeaderFooter,
               pages: pageRange,
+              imageFetcher,
             });
           } else {
             bytes = await exportPdf(fetchedDoc, {
               includeHeaderFooter: local.includeHeaderFooter,
+              imageFetcher,
             });
           }
         } else {
@@ -296,6 +310,7 @@ export function registerDocsCommand(program: Command) {
           }
           bytes = await exportDocx(fetchedDoc, {
             includeHeaderFooter: local.includeHeaderFooter,
+            imageFetcher,
           });
         }
 

--- a/packages/cli/src/docs/image-fetcher.ts
+++ b/packages/cli/src/docs/image-fetcher.ts
@@ -1,0 +1,57 @@
+import type { DocxImageFetcher } from '@wafflebase/docs';
+
+export interface ImageFetcherOptions {
+  /**
+   * Base URL of the Wafflebase API server. Used to resolve image
+   * inlines whose `src` is a server-relative path (`/images/<id>`).
+   * Absolute URLs (`http(s)://...`, `data:`, `blob:`, ...) pass through
+   * untouched so docs imported from external sources keep working.
+   */
+  serverBase: string;
+  /**
+   * Optional `fetch` override — kept as a seam for tests. Defaults to
+   * the global `fetch`. The signature matches the WHATWG fetch so a
+   * stub can be a plain async function without pulling DOM types in.
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+/**
+ * Resolve a possibly-relative image URL against the configured server
+ * base. Mirrors `resolveImageUrl` in
+ * `packages/frontend/src/app/docs/export-utils.ts` so the CLI and
+ * browser agree on what counts as "absolute". The shared rule: any URL
+ * that starts with a scheme (`http:`, `https:`, `data:`, `blob:`,
+ * `file:`, ...) is left alone; everything else gets prefixed.
+ */
+export function resolveImageUrl(url: string, serverBase: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return url;
+  const base = serverBase.replace(/\/$/, '');
+  if (!base) return url;
+  return `${base}${url.startsWith('/') ? url : `/${url}`}`;
+}
+
+/**
+ * Build an `ImageFetcher` for the CLI export pipelines. The fetcher
+ * downloads each unique image inline `src` once, returning a Blob the
+ * exporter can embed verbatim (PDF) or stream into the DOCX zip.
+ *
+ * Backend's `GET /images/:id` is publicly readable, so we don't attach
+ * an Authorization header — sending JWT cookies via the CLI isn't
+ * possible anyway. Relative URLs resolve against `serverBase`; absolute
+ * URLs (e.g., the canonical `https://api.wafflebase.io/images/...`
+ * surfaced by `imageFetcher required` errors) pass through.
+ */
+export function createImageFetcher(opts: ImageFetcherOptions): DocxImageFetcher {
+  const fetchImpl = opts.fetch ?? globalThis.fetch;
+  return async (url: string): Promise<Blob> => {
+    const resolved = resolveImageUrl(url, opts.serverBase);
+    const res = await fetchImpl(resolved);
+    if (!res.ok) {
+      throw new Error(
+        `Image fetch failed: ${res.status} ${res.statusText} for ${resolved}`,
+      );
+    }
+    return res.blob();
+  };
+}

--- a/packages/cli/src/docs/pdf-export.ts
+++ b/packages/cli/src/docs/pdf-export.ts
@@ -4,6 +4,7 @@ import {
   PdfFonts,
   scanFontsUsed,
   type Document,
+  type DocxImageFetcher,
   type FontUsage,
   type PdfFontKey,
   type PdfFontsOptions,
@@ -33,6 +34,15 @@ export interface CliPdfExportOptions {
    *  and to leave room for a future "strip header/footer" mode. */
   includeHeaderFooter?: boolean;
   fontSources?: PdfFontsOptions['sources'];
+  /** Resolve and download image inlines so they can be embedded in the
+   *  PDF. Required when the document contains image inlines —
+   *  `PdfExporter` throws otherwise to avoid silently dropping content.
+   *  The CLI command builds one via `createImageFetcher` from the
+   *  configured server base; tests inject a stub that returns
+   *  in-memory bytes. Typed as `DocxImageFetcher` (a structural
+   *  `(url) => Promise<Blob>` alias) since the bare `ImageFetcher`
+   *  symbol from `pdf-image-painter` isn't re-exported. */
+  imageFetcher?: DocxImageFetcher;
 }
 
 /**
@@ -57,7 +67,11 @@ export async function exportPdf(
   const measurer = new FontkitMeasurer();
   await preloadKoreanFonts(fonts, measurer, usage);
 
-  const blob = await PdfExporter.export(doc, { measurer, fonts });
+  const blob = await PdfExporter.export(doc, {
+    measurer,
+    fonts,
+    imageFetcher: opts.imageFetcher,
+  });
   const fullBytes = new Uint8Array(await blob.arrayBuffer());
 
   if (!opts.pages || opts.pages.pages.size === 0) {

--- a/packages/cli/test/docs-export.test.ts
+++ b/packages/cli/test/docs-export.test.ts
@@ -34,6 +34,38 @@ function paragraph(id: string, text: string, style: { fontFamily?: string } = {}
   };
 }
 
+/** Block that contains a single image inline with the given src. */
+function imageParagraph(id: string, src: string): Block {
+  return {
+    id,
+    type: 'paragraph',
+    inlines: [
+      // U+FFFC OBJECT REPLACEMENT CHARACTER is the model-level
+      // placeholder for an image inline; the exporter dispatches on
+      // `style.image` and ignores the character itself.
+      { text: '\uFFFC', style: { image: { src, width: 1, height: 1 } } },
+    ],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  };
+}
+
+/**
+ * Smallest valid PNG (1×1 transparent). pdf-lib `embedPng` parses the
+ * IHDR/IDAT/IEND chunks, so the exact byte sequence has to be a real
+ * PNG. Hex source: well-known minimal PNG.
+ */
+const PNG_1x1 = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41,
+  0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+  0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+  0x42, 0x60, 0x82,
+]);
+
 /** PDF starts with the bytes `%PDF-` (0x25 0x50 0x44 0x46 0x2D). */
 function looksLikePdf(bytes: Uint8Array): boolean {
   return (
@@ -86,6 +118,51 @@ describe('exportPdf', () => {
     expect(looksLikePdf(bytes)).toBe(true);
   }, 20000);
 
+  it('embeds image inlines via the supplied imageFetcher', async () => {
+    // Same doc as the regression test, but now we hand `exportPdf` a
+    // stub fetcher that returns a real 1×1 PNG. pdf-lib accepts the
+    // bytes via `embedPng`, so the call resolves to a valid PDF
+    // instead of throwing.
+    const calls: string[] = [];
+    const stubFetcher = async (url: string): Promise<Blob> => {
+      calls.push(url);
+      return new Blob([PNG_1x1], { type: 'image/png' });
+    };
+
+    const doc: Document = {
+      blocks: [
+        imageParagraph(
+          'p1',
+          'https://api.wafflebase.io/images/ff5cd97d-0627-4250-a947-05c422fe735f.png',
+        ),
+      ],
+    };
+    const bytes = await exportPdf(doc, { imageFetcher: stubFetcher });
+    expect(looksLikePdf(bytes)).toBe(true);
+    expect(calls).toEqual([
+      'https://api.wafflebase.io/images/ff5cd97d-0627-4250-a947-05c422fe735f.png',
+    ]);
+  }, 20000);
+
+  it('reproduces the original "imageFetcher required" error when no fetcher is supplied', async () => {
+    // Regression for the user-reported failure:
+    //   `wafflebase docs export <id> export.pdf`
+    //   → `imageFetcher required: document contains 1 image inline(s); first: ...`
+    // PdfExporter walks the doc up-front and refuses to silently drop
+    // image content when the caller forgot to wire a fetcher.
+    const doc: Document = {
+      blocks: [
+        imageParagraph(
+          'p1',
+          'https://api.wafflebase.io/images/ff5cd97d-0627-4250-a947-05c422fe735f.png',
+        ),
+      ],
+    };
+    await expect(exportPdf(doc)).rejects.toThrow(
+      /imageFetcher required: document contains 1 image inline\(s\); first: https:\/\/api\.wafflebase\.io\/images\/ff5cd97d-/,
+    );
+  }, 20000);
+
   it('extracts only the requested pages when --pages is supplied', async () => {
     // Build a doc large enough that pagination produces multiple pages
     // even with the FontkitMeasurer fallback.
@@ -119,6 +196,15 @@ describe('exportDocx', () => {
     const bytes = await exportDocx(doc);
     expect(bytes.length).toBeGreaterThan(0);
   });
+
+  // The DOCX "imageFetcher required" guard lives in `DocxExporter` and
+  // is exercised directly by the docs package's
+  // `docx-exporter.test.ts > should throw when image inline has no
+  // matching media entry`. We deliberately don't repeat it here: a
+  // failing `DocxExporter.export` invocation in the CLI's pure-Node
+  // env perturbs JSZip's Blob support state and surfaces a phantom
+  // `blob.arrayBuffer is not a function` in subsequent tests. Keep
+  // DOCX-with-images coverage in the jsdom-env docs suite.
 });
 
 describe('writeBinary', () => {

--- a/packages/cli/test/image-fetcher.test.ts
+++ b/packages/cli/test/image-fetcher.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createImageFetcher,
+  resolveImageUrl,
+} from '../src/docs/image-fetcher.js';
+
+describe('resolveImageUrl', () => {
+  it('passes absolute http(s) URLs through untouched', () => {
+    expect(
+      resolveImageUrl(
+        'https://api.wafflebase.io/images/abc',
+        'https://other.example',
+      ),
+    ).toBe('https://api.wafflebase.io/images/abc');
+    expect(
+      resolveImageUrl('http://localhost:3000/images/xyz', 'https://other'),
+    ).toBe('http://localhost:3000/images/xyz');
+  });
+
+  it('passes data:, blob:, and file: URLs through untouched', () => {
+    expect(resolveImageUrl('data:image/png;base64,AAA', 'https://x')).toBe(
+      'data:image/png;base64,AAA',
+    );
+    expect(resolveImageUrl('blob:https://x/abc', 'https://y')).toBe(
+      'blob:https://x/abc',
+    );
+  });
+
+  it('prefixes server-relative paths with the configured base', () => {
+    expect(resolveImageUrl('/images/abc', 'https://api.wafflebase.io')).toBe(
+      'https://api.wafflebase.io/images/abc',
+    );
+  });
+
+  it('strips a trailing slash from the base before joining', () => {
+    expect(resolveImageUrl('/images/abc', 'https://api.wafflebase.io/')).toBe(
+      'https://api.wafflebase.io/images/abc',
+    );
+  });
+
+  it('inserts a slash for relative paths that omit the leading "/"', () => {
+    expect(resolveImageUrl('images/abc', 'https://api.wafflebase.io')).toBe(
+      'https://api.wafflebase.io/images/abc',
+    );
+  });
+
+  it('returns the URL unchanged when serverBase is empty', () => {
+    expect(resolveImageUrl('/images/abc', '')).toBe('/images/abc');
+  });
+});
+
+describe('createImageFetcher', () => {
+  it('GETs the resolved URL via the injected fetch and returns the blob', async () => {
+    const calls: string[] = [];
+    const stubFetch: typeof globalThis.fetch = async (input) => {
+      calls.push(typeof input === 'string' ? input : (input as URL).toString());
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { 'Content-Type': 'image/png' },
+      });
+    };
+
+    const fetcher = createImageFetcher({
+      serverBase: 'https://api.wafflebase.io',
+      fetch: stubFetch,
+    });
+
+    const blob = await fetcher('/images/abc');
+    expect(calls).toEqual(['https://api.wafflebase.io/images/abc']);
+    expect(blob.type).toBe('image/png');
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+  });
+
+  it('passes absolute URLs through without prefixing the base', async () => {
+    const calls: string[] = [];
+    const stubFetch: typeof globalThis.fetch = async (input) => {
+      calls.push(typeof input === 'string' ? input : (input as URL).toString());
+      return new Response(new Uint8Array([0]), { status: 200 });
+    };
+
+    const fetcher = createImageFetcher({
+      serverBase: 'https://api.wafflebase.io',
+      fetch: stubFetch,
+    });
+
+    await fetcher('https://cdn.example.com/photo.jpg');
+    expect(calls).toEqual(['https://cdn.example.com/photo.jpg']);
+  });
+
+  it('throws a descriptive error on non-OK responses', async () => {
+    const stubFetch: typeof globalThis.fetch = async () =>
+      new Response('not found', { status: 404, statusText: 'Not Found' });
+
+    const fetcher = createImageFetcher({
+      serverBase: 'https://api.wafflebase.io',
+      fetch: stubFetch,
+    });
+
+    await expect(fetcher('/images/missing')).rejects.toThrow(
+      /Image fetch failed: 404 Not Found for https:\/\/api\.wafflebase\.io\/images\/missing/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `wafflebase docs export <id> <file>` failed for any document with an image inline because the CLI never built an `imageFetcher` to pass to `exportPdf` / `exportDocx`. The exporters intentionally throw `imageFetcher required: document contains N image inline(s); first: <url>` rather than silently dropping image content.
- Added `createImageFetcher({ serverBase })` (parallel to the frontend's `docsImageFetcher`): absolute URLs pass through, relative `/images/<id>` paths resolve against the configured server, public `GET /images/:id` so no auth header is needed.
- Plumbed the fetcher into `CliPdfExportOptions.imageFetcher` and the `docs export` action so both PDF and DOCX paths get one for free.

## Test plan

- [x] `pnpm verify:fast` (cli + docs + sheets — 2153 tests, all green)
- [x] New `image-fetcher.test.ts` covers URL resolution rules and fetch success/404 mapping with an injected fetch stub.
- [x] `docs-export.test.ts` regression test reproduces the original error message verbatim against a doc with an `https://api.wafflebase.io/images/<uuid>.png` inline.
- [x] `docs-export.test.ts` embed test exercises the full `exportPdf` pipeline with a 1×1 PNG stub fetcher and confirms the call resolves to a valid PDF (`%PDF-` header, fetcher invoked once with the absolute URL).
- [x] Manual smoke: `wafflebase docs export <id> out.pdf` against a workspace doc that contains one or more inline images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)