### PR TITLE
Stop undo from destroying the docs initial block

### DIFF
--- a/docs/tasks/active/20260505-undo-destroys-initial-block-todo.md
+++ b/docs/tasks/active/20260505-undo-destroys-initial-block-todo.md
@@ -1,0 +1,79 @@
+# Undo destroys initial block
+
+**Created**: 2026-05-05
+
+## Problem
+
+Reproduction: open a freshly-created docs document, type "asdf",
+press Enter, type "asdf", press Enter, type "asdf", then press
+Cmd+Z enough times. The next keystroke crashes with:
+
+```
+document.ts:134 Uncaught Error: Block not found: block-1777984770574-0
+    at Doc.getBlock (document.ts:134:11)
+    at HTMLTextAreaElement.handleInput (text-editor.ts:331:35)
+```
+
+The block id has counter `0` — it is the very first `generateBlockId()`
+of the session, i.e. the document's initial block.
+
+## Root Cause
+
+`docs-view.tsx:ensureTree()` was responsible for installing the
+`yorkie.Tree` CRDT and the initial paragraph block. It did so via
+`doc.update(...)` after `client.attach()`. Because that update ran
+*after* attach, it landed on the document's undo stack.
+
+`YorkieDocStore.setDocument()` records `undoFloor =
+getUndoStackForTest().length` to prevent users from undoing past the
+initial document load. But `setDocument()` is only called from
+`editor.ts:388` when `getDocument().blocks.length === 0`. Once
+`ensureTree` had populated the Tree, the body already had one block,
+so `setDocument` was skipped and `undoFloor` stayed at 0.
+
+A long enough Cmd+Z sequence then unwound `ensureTree`'s update,
+removing the initial block from the Tree while the cursor was still
+holding its id. The next `handleInput` looked the block up via
+`getBlock` and threw.
+
+## Fix
+
+Two complementary changes:
+
+1. **Move Tree CRDT creation into `initialRoot`.**
+   `docs-detail.tsx` and `shared-document.tsx` now pass
+   `initialDocsRoot()` (returning `{ content: new Tree({...}) }`) to
+   `DocumentProvider`. yorkie-js-sdk PR #1238 (in 0.7.8) calls
+   `doc.clearHistory()` immediately after applying `initialRoot`, so
+   the setup is never on the undo stack. New docs no longer need
+   `ensureTree`'s fallback path.
+
+2. **Make legacy fallback safe and YorkieDocStore robust.**
+   - `ensureTree` calls `doc.clearHistory()` after its fallback
+     `doc.update`, mirroring what the SDK does for `initialRoot`.
+   - `YorkieDocStore` constructor records the current undo-stack
+     length as `undoFloor`. Anything already in the stack at
+     construction time (from `initialRoot`, `ensureTree`, or any
+     future setup) is not undoable — defense in depth.
+
+## Tasks
+
+- [x] Reproduce the bug (manual + regression test)
+- [x] Move initial Tree to `initialRoot` in docs-detail.tsx and shared-document.tsx
+- [x] Add `clearHistory()` to `ensureTree` fallback
+- [x] Initialize `undoFloor` in YorkieDocStore constructor
+- [x] Add regression test in yorkie-doc-store.test.ts
+- [x] `pnpm verify:fast` — all 741 tests pass
+- [ ] Manually verify in browser: new doc → "asdf"<Enter>"asdf"<Enter>"asdf"<Cmd+Z×N>typing → no crash
+- [ ] Commit, push, open PR
+
+## Notes
+
+- The earlier `validateCursorPosition()` patch on the
+  `fix-undo-cursor-validation` branch was a band-aid that could
+  not reach this scenario — when the Tree itself is unwound,
+  `doc.document.blocks` is empty and the helper has no first block
+  to fall back to. That branch is being abandoned.
+- The 0.7.8 SDK upgrade in #187 is unrelated to this bug but does
+  ship the `clearHistory()` API and the post-attach call that
+  this fix relies on.

--- a/packages/frontend/src/app/docs/docs-detail.tsx
+++ b/packages/frontend/src/app/docs/docs-detail.tsx
@@ -14,21 +14,12 @@ import { UserPresence } from "@/components/user-presence";
 import { usePresenceUpdater } from "@/hooks/use-presence-updater";
 import { IconFolder, IconSettings, IconDatabase } from "@tabler/icons-react";
 import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
-import type { YorkieDocsRoot } from "@/types/docs-document";
+import { initialDocsRoot, type YorkieDocsRoot } from "@/types/docs-document";
 import type { DocsPresence } from "@/types/users";
 import type { EditContext } from "@wafflebase/docs";
 import { DocsView, type EditorAPI, type JumpHandle } from "./docs-view";
 import { DocsFormattingToolbar } from "./docs-formatting-toolbar";
 
-/**
- * Initial Yorkie document root for a new docs document.
- * Note: Tree CRDT must be created via `new yorkie.Tree()` inside
- * doc.update(), so we only provide an empty root here. DocsView
- * initializes the Tree when it detects `content` is missing.
- */
-function initialDocsRoot(): Partial<YorkieDocsRoot> {
-  return {};
-}
 
 /**
  * DocsLayout provides the sidebar + header chrome around the docs editor,

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -25,8 +25,16 @@ export interface JumpHandle {
 
 /**
  * Ensure the Yorkie document has a Tree CRDT for content.
- * Tree must be created via `new Tree()` inside doc.update();
- * it cannot be passed as a plain object through initialRoot.
+ *
+ * New docs receive the Tree via `client.attach({ initialRoot })`
+ * (see `initialDocsRoot()`), and yorkie-js-sdk PR #1238 clears the
+ * undo stack right after — so the setup is not undoable.
+ *
+ * This helper is a fallback for legacy docs whose Tree was never
+ * persisted. After creating the Tree we call `clearHistory()` so
+ * the setup is similarly absent from the undo stack; otherwise a
+ * long enough Cmd+Z sequence could unwind the Tree creation and
+ * destroy the initial block, crashing the editor.
  */
 function ensureTree(doc: ReturnType<typeof useDocument<YorkieDocsRoot>>["doc"]): boolean {
   if (!doc) return false;
@@ -63,6 +71,7 @@ function ensureTree(doc: ReturnType<typeof useDocument<YorkieDocsRoot>>["doc"]):
       ],
     });
   });
+  doc.clearHistory();
 
   return true;
 }

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -451,6 +451,12 @@ export class YorkieDocStore implements DocStore {
 
   constructor(doc: YorkieDocument<YorkieDocsRoot>) {
     this.doc = doc;
+    // Whatever already exists in the doc when this store is constructed
+    // (e.g. content set via client.attach({ initialRoot }), or a legacy
+    // ensureTree() doc.update) is treated as the initial state. Users
+    // must not be able to undo past it — doing so would destroy blocks
+    // the cursor still references.
+    this.undoFloor = this.doc.getUndoStackForTest().length;
 
     // Invalidate cache on remote changes
     doc.subscribe((event) => {

--- a/packages/frontend/src/app/shared/shared-document.tsx
+++ b/packages/frontend/src/app/shared/shared-document.tsx
@@ -11,7 +11,7 @@ import {
   TabMeta,
   initialSpreadsheetDocument,
 } from "@/types/worksheet";
-import type { YorkieDocsRoot } from "@/types/docs-document";
+import { initialDocsRoot, type YorkieDocsRoot } from "@/types/docs-document";
 import type { UserPresence as UserPresenceType } from "@/types/users";
 import { UserPresence } from "@/components/user-presence";
 import { DocsView, type EditorAPI } from "@/app/docs/docs-view";
@@ -215,7 +215,7 @@ function SharedDocumentInner({
       {isDocs ? (
         <DocumentProvider<YorkieDocsRoot>
           docKey={docKey}
-          initialRoot={{}}
+          initialRoot={initialDocsRoot()}
           initialPresence={presence}
           enableDevtools={import.meta.env.DEV}
         >

--- a/packages/frontend/src/types/docs-document.ts
+++ b/packages/frontend/src/types/docs-document.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@yorkie-js/sdk';
+import { Tree } from '@yorkie-js/sdk';
 
 /**
  * Yorkie document root for the docs (rich-text) editor.
@@ -14,3 +14,38 @@ export type YorkieDocsRoot = {
     margins: { top: number; bottom: number; left: number; right: number };
   };
 };
+
+/**
+ * Initial Yorkie document root for a new docs document.
+ *
+ * The Tree CRDT is created here so that `client.attach({ initialRoot })`
+ * runs the setup inside the SDK and clears the undo stack right after
+ * (yorkie-js-sdk PR #1238). If we instead call `doc.update` after
+ * attach to populate the Tree, the setup ends up on the undo stack —
+ * a long enough Cmd+Z sequence then unwinds it and destroys the
+ * initial block, crashing `text-editor.handleInput` with "Block not
+ * found".
+ */
+export function initialDocsRoot(): Partial<YorkieDocsRoot> {
+  return {
+    content: new Tree({
+      type: 'doc',
+      children: [
+        {
+          type: 'block',
+          attributes: {
+            id: `block-${Date.now()}-0`,
+            type: 'paragraph',
+            alignment: 'left',
+            lineHeight: '1.5',
+            marginTop: '0',
+            marginBottom: '8',
+            textIndent: '0',
+            marginLeft: '0',
+          },
+          children: [{ type: 'inline', children: [] }],
+        },
+      ],
+    }),
+  };
+}

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -362,6 +362,69 @@ describe('YorkieDocStore', () => {
       const restored = store.getPresenceCursorPos();
       assert.deepEqual(restored, { blockId: block.id, offset: 5 });
     });
+
+    // Regression: ensureTree() in docs-view.tsx populates the Tree with an
+    // initial block via doc.update() *before* YorkieDocStore is constructed.
+    // When the doc already has blocks, editor.ts skips its setDocument
+    // fallback, so undoFloor would stay at 0. Repeated undo could then
+    // unwind ensureTree's update and destroy the initial block — leaving
+    // the cursor pointing at a non-existent block id and crashing
+    // text-editor.ts:handleInput with "Block not found".
+    it('repeated undo cannot remove blocks present at construction', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const seededDoc: any = new yorkie.Document<any>(`seed-${Date.now()}-${Math.random()}`);
+      const initialId = `block-${Date.now()}-init`;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      seededDoc.update((root: any) => {
+        root.content = new yorkie.Tree({
+          type: 'doc',
+          children: [
+            {
+              type: 'block',
+              attributes: {
+                id: initialId,
+                type: 'paragraph',
+                alignment: 'left',
+                lineHeight: '1.5',
+                marginTop: '0',
+                marginBottom: '8',
+                textIndent: '0',
+                marginLeft: '0',
+              },
+              children: [{ type: 'inline', children: [] }],
+            },
+          ],
+        });
+      });
+
+      const seededStore = new YorkieDocStore(seededDoc);
+      assert.equal(seededStore.getDocument().blocks[0].id, initialId);
+
+      // Simulate user typing "asdf" then Enter then "asdf" then Enter then "asdf",
+      // matching the reported reproduction.
+      seededStore.insertText(initialId, 0, 'asdf');
+      const id2 = `block-${Date.now()}-2`;
+      seededStore.splitBlock(initialId, 4, id2, 'paragraph');
+      seededStore.insertText(id2, 0, 'asdf');
+      const id3 = `block-${Date.now()}-3`;
+      seededStore.splitBlock(id2, 4, id3, 'paragraph');
+      seededStore.insertText(id3, 0, 'asdf');
+
+      // Undo until the store says we cannot undo any further.
+      let safety = 100;
+      while (seededStore.canUndo() && safety-- > 0) {
+        seededStore.undo();
+      }
+
+      // The initial block must still be reachable. Without the fix, the
+      // ensureTree-style update is reachable via undo and the initial block
+      // is destroyed.
+      const blocks = seededStore.getDocument().blocks;
+      assert.ok(
+        blocks.some((b) => b.id === initialId),
+        `initial block ${initialId} must survive repeated undo, got ${JSON.stringify(blocks.map((b) => b.id))}`,
+      );
+    });
   });
 
   describe('caching', () => {


### PR DESCRIPTION
## Repro

Open a new docs document, type \`asdf\`, Enter, \`asdf\`, Enter, \`asdf\`, then Cmd+Z enough times. The next keystroke crashes:

\`\`\`
document.ts:134 Uncaught Error: Block not found: block-<...>-0
    at Doc.getBlock (document.ts:134:11)
    at HTMLTextAreaElement.handleInput (text-editor.ts:331:35)
\`\`\`

## Root Cause

\`docs-view.ensureTree()\` was creating the \`yorkie.Tree\` and the initial paragraph block via \`doc.update()\` *after* \`client.attach()\`, so the setup landed on the undo stack. \`YorkieDocStore.setDocument()\` does record an \`undoFloor\`, but it is only called when the body is empty; \`ensureTree\` had already populated the body, so \`setDocument\` was skipped and \`undoFloor\` stayed at 0. A long enough Cmd+Z sequence then unwound \`ensureTree\`'s update and removed the initial block while the cursor still held its id.

## Fix

1. **Move Tree CRDT creation into \`initialRoot\`**.
   \`docs-detail.tsx\` and \`shared-document.tsx\` pass \`initialDocsRoot()\` (returning \`{ content: new Tree({...}) }\`) to \`DocumentProvider\`. yorkie-js-sdk PR #1238 (in 0.7.8) calls \`doc.clearHistory()\` immediately after applying \`initialRoot\`, so the setup is never on the undo stack for new docs.
2. **Make the legacy \`ensureTree\` fallback safe**.
   Calls \`doc.clearHistory()\` after the fallback \`doc.update\`, mirroring what the SDK does for \`initialRoot\`.
3. **Defense in depth in \`YorkieDocStore\`**.
   Constructor records the current undo-stack length as \`undoFloor\` so anything already in the stack at construction time is not undoable.

## Test plan

- [x] \`pnpm verify:fast\` — 741 / 741 tests pass
- [x] New regression test in \`yorkie-doc-store.test.ts\` (\`repeated undo cannot remove blocks present at construction\`) — fails on main with \`got []\`, passes with this PR
- [x] Manually verify in browser: new doc → type/Enter sequence → many Cmd+Z → typing — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where extensive undo operations (Cmd+Z) would remove the document's initial block, causing subsequent crashes. The initial document structure is now protected from being undone.

* **Tests**
  * Added regression test to prevent undo from removing foundational document blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->