### PR TITLE
Coerce boolean arrays in SUMPRODUCT

### DIFF
--- a/packages/sheets/src/formula/formula.ts
+++ b/packages/sheets/src/formula/formula.ts
@@ -481,7 +481,7 @@ export function evaluateWithSpill(formula: string, grid?: Grid): string | SpillR
     const evaluator = new Evaluator(grid);
     const node = evaluator.visit(parsed.tree);
 
-    if (node.t === 'arr') {
+    if (node.t === 'arr' && node.spill !== false) {
       return {
         values: node.v.map((row) => row.map((cell) => evalNodeToStr(cell, grid))),
         rows: node.rows,
@@ -629,7 +629,7 @@ export const ErrNode = {
 
 export type RefNode = { t: 'ref'; v: Reference };
 export type EmptyNode = { t: 'empty' };
-export type ArrNode = { t: 'arr'; v: EvalNode[][]; rows: number; cols: number };
+export type ArrNode = { t: 'arr'; v: EvalNode[][]; rows: number; cols: number; spill?: boolean };
 export type LambdaNode = {
   t: 'lambda';
   params: string[];
@@ -894,7 +894,7 @@ class Evaluator implements FormulaVisitor<EvalNode> {
       result.push(resultRow);
     }
 
-    return { t: 'arr', v: result, rows, cols };
+    return { t: 'arr', v: result, rows, cols, spill: false };
   }
 
   private comparisonArrayBinary(leftRaw: EvalNode, rightRaw: EvalNode, op: number): EvalNode | null {
@@ -928,7 +928,7 @@ class Evaluator implements FormulaVisitor<EvalNode> {
       result.push(resultRow);
     }
 
-    return { t: 'arr', v: result, rows, cols };
+    return { t: 'arr', v: result, rows, cols, spill: false };
   }
 
   private toMatrixArray(node: EvalNode): MatrixArray | ErrNode | null {

--- a/packages/sheets/src/formula/formula.ts
+++ b/packages/sheets/src/formula/formula.ts
@@ -489,6 +489,12 @@ export function evaluateWithSpill(formula: string, grid?: Grid): string | SpillR
       };
     }
 
+    if (node.t === 'arr' && node.scalarSafe) {
+      const topLeft = node.v[0]?.[0];
+      if (!topLeft || topLeft.t === 'empty') return '0';
+      return evalNodeToStr(topLeft, grid);
+    }
+
     return evalNodeToStr(node, grid);
   } catch {
     return ErrValue.ERROR;
@@ -629,7 +635,14 @@ export const ErrNode = {
 
 export type RefNode = { t: 'ref'; v: Reference };
 export type EmptyNode = { t: 'empty' };
-export type ArrNode = { t: 'arr'; v: EvalNode[][]; rows: number; cols: number; spill?: boolean };
+export type ArrNode = {
+  t: 'arr';
+  v: EvalNode[][];
+  rows: number;
+  cols: number;
+  spill?: boolean;
+  scalarSafe?: boolean;
+};
 export type LambdaNode = {
   t: 'lambda';
   params: string[];
@@ -654,6 +667,7 @@ type MatrixArray = {
   values: EvalNode[][];
   rows: number;
   cols: number;
+  scalarSafe: boolean;
 };
 
 /**
@@ -854,6 +868,7 @@ class Evaluator implements FormulaVisitor<EvalNode> {
   }
 
   private numericArrayBinary(leftRaw: EvalNode, rightRaw: EvalNode, op: number): EvalNode | null {
+    // Scalar-vs-matrix operations broadcast the scalar; matrix-vs-matrix requires exact shape.
     const leftMatrix = this.toMatrixArray(leftRaw);
     if (leftMatrix && 't' in leftMatrix) return leftMatrix;
     const rightMatrix = this.toMatrixArray(rightRaw);
@@ -894,10 +909,15 @@ class Evaluator implements FormulaVisitor<EvalNode> {
       result.push(resultRow);
     }
 
-    return { t: 'arr', v: result, rows, cols, spill: false };
+    const scalarSafe =
+      (!leftMatrix || leftMatrix.scalarSafe) &&
+      (!rightMatrix || rightMatrix.scalarSafe);
+
+    return { t: 'arr', v: result, rows, cols, spill: false, scalarSafe };
   }
 
   private comparisonArrayBinary(leftRaw: EvalNode, rightRaw: EvalNode, op: number): EvalNode | null {
+    // Array literals can carry ref nodes, so matrix cells are resolved before scalar comparison.
     const leftMatrix = this.toMatrixArray(leftRaw);
     if (leftMatrix && 't' in leftMatrix) return leftMatrix;
     const rightMatrix = this.toMatrixArray(rightRaw);
@@ -919,8 +939,18 @@ class Evaluator implements FormulaVisitor<EvalNode> {
     for (let row = 0; row < rows; row++) {
       const resultRow: EvalNode[] = [];
       for (let col = 0; col < cols; col++) {
-        const leftNode = leftMatrix ? leftMatrix.values[row]?.[col] ?? { t: 'empty' } : leftScalar!;
-        const rightNode = rightMatrix ? rightMatrix.values[row]?.[col] ?? { t: 'empty' } : rightScalar!;
+        const rawLeft = leftMatrix
+          ? leftMatrix.values[row]?.[col] ?? { t: 'empty' }
+          : leftScalar!;
+        const leftNode = rawLeft.t === 'ref' ? this.resolveValue(rawLeft) : rawLeft;
+        if (leftNode.t === 'err') return leftNode;
+
+        const rawRight = rightMatrix
+          ? rightMatrix.values[row]?.[col] ?? { t: 'empty' }
+          : rightScalar!;
+        const rightNode = rawRight.t === 'ref' ? this.resolveValue(rawRight) : rawRight;
+        if (rightNode.t === 'err') return rightNode;
+
         const compared = this.compareValues(leftNode, rightNode, op);
         if (compared.t === 'err') return compared;
         resultRow.push(compared);
@@ -928,12 +958,22 @@ class Evaluator implements FormulaVisitor<EvalNode> {
       result.push(resultRow);
     }
 
-    return { t: 'arr', v: result, rows, cols, spill: false };
+    const scalarSafe =
+      (!leftMatrix || leftMatrix.scalarSafe) &&
+      (!rightMatrix || rightMatrix.scalarSafe);
+
+    return { t: 'arr', v: result, rows, cols, spill: false, scalarSafe };
   }
 
   private toMatrixArray(node: EvalNode): MatrixArray | ErrNode | null {
+    // Ranges are materialized to cell values; array literals keep their existing shape.
     if (node.t === 'arr') {
-      return { values: node.v, rows: node.rows, cols: node.cols };
+      return {
+        values: node.v,
+        rows: node.rows,
+        cols: node.cols,
+        scalarSafe: node.scalarSafe === true,
+      };
     }
 
     if (node.t !== 'ref' || !this.grid || !isSrng(node.v)) {
@@ -959,7 +999,7 @@ class Evaluator implements FormulaVisitor<EvalNode> {
         values.push(resultRow);
       }
 
-      return { values, rows, cols };
+      return { values, rows, cols, scalarSafe: false };
     } catch {
       return ErrNode.VALUE;
     }
@@ -1019,7 +1059,7 @@ class Evaluator implements FormulaVisitor<EvalNode> {
       rows.push(cells);
     }
     const cols = rows.reduce((max, r) => Math.max(max, r.length), 0);
-    return { t: 'arr', v: rows, rows: rows.length, cols };
+    return { t: 'arr', v: rows, rows: rows.length, cols, scalarSafe: true };
   }
 
   visitIdentifier(ctx: IdentifierContext): EvalNode {

--- a/packages/sheets/src/formula/formula.ts
+++ b/packages/sheets/src/formula/formula.ts
@@ -30,6 +30,7 @@ import {
   parseRef,
   parseRange,
   isCrossSheetRef,
+  toSrefs,
 } from '../model/core/coordinates';
 
 /**
@@ -649,6 +650,12 @@ export type EvalNode =
   | ArrNode
   | LambdaNode;
 
+type MatrixArray = {
+  values: EvalNode[][];
+  rows: number;
+  cols: number;
+};
+
 /**
  * `Evaluator` class evaluates the formula. The grammar of the formula is defined in
  * `antlr/Formula.g4` file.
@@ -731,12 +738,17 @@ class Evaluator implements FormulaVisitor<EvalNode> {
   }
 
   visitAddSub(ctx: AddSubContext): EvalNode {
-    const left = NumberArgs.map(this.visit(ctx.expr(0)), this.grid);
+    const leftRaw = this.visit(ctx.expr(0));
+    const rightRaw = this.visit(ctx.expr(1));
+    const matrixResult = this.numericArrayBinary(leftRaw, rightRaw, ctx._op.type);
+    if (matrixResult) return matrixResult;
+
+    const left = NumberArgs.map(leftRaw, this.grid);
     if (left.t === 'err') {
       return left;
     }
 
-    const right = NumberArgs.map(this.visit(ctx.expr(1)), this.grid);
+    const right = NumberArgs.map(rightRaw, this.grid);
     if (right.t === 'err') {
       return right;
     }
@@ -749,12 +761,17 @@ class Evaluator implements FormulaVisitor<EvalNode> {
   }
 
   visitMulDiv(ctx: MulDivContext): EvalNode {
-    const left = NumberArgs.map(this.visit(ctx.expr(0)), this.grid);
+    const leftRaw = this.visit(ctx.expr(0));
+    const rightRaw = this.visit(ctx.expr(1));
+    const matrixResult = this.numericArrayBinary(leftRaw, rightRaw, ctx._op.type);
+    if (matrixResult) return matrixResult;
+
+    const left = NumberArgs.map(leftRaw, this.grid);
     if (left.t === 'err') {
       return left;
     }
 
-    const right = NumberArgs.map(this.visit(ctx.expr(1)), this.grid);
+    const right = NumberArgs.map(rightRaw, this.grid);
     if (right.t === 'err') {
       return right;
     }
@@ -785,18 +802,25 @@ class Evaluator implements FormulaVisitor<EvalNode> {
   }
 
   visitComparison(ctx: ComparisonContext): EvalNode {
-    const left = this.resolveValue(this.visit(ctx.expr(0)));
+    const leftRaw = this.visit(ctx.expr(0));
+    const rightRaw = this.visit(ctx.expr(1));
+    const matrixResult = this.comparisonArrayBinary(leftRaw, rightRaw, ctx._op.type);
+    if (matrixResult) return matrixResult;
+
+    const left = this.resolveValue(leftRaw);
     if (left.t === 'err') {
       return left;
     }
 
-    const right = this.resolveValue(this.visit(ctx.expr(1)));
+    const right = this.resolveValue(rightRaw);
     if (right.t === 'err') {
       return right;
     }
 
-    const op = ctx._op.type;
+    return this.compareValues(left, right, ctx._op.type);
+  }
 
+  private compareValues(left: EvalNode, right: EvalNode, op: number): EvalNode {
     // Different types: EQ→false, NEQ→true, order: num < str < bool
     if (left.t !== right.t) {
       if (op === FormulaParser.EQ) return { t: 'bool', v: false };
@@ -827,6 +851,118 @@ class Evaluator implements FormulaVisitor<EvalNode> {
     const lv = (left as NumNode).v;
     const rv = (right as NumNode).v;
     return this.compareBool(op, lv < rv ? -1 : lv > rv ? 1 : 0);
+  }
+
+  private numericArrayBinary(leftRaw: EvalNode, rightRaw: EvalNode, op: number): EvalNode | null {
+    const leftMatrix = this.toMatrixArray(leftRaw);
+    if (leftMatrix && 't' in leftMatrix) return leftMatrix;
+    const rightMatrix = this.toMatrixArray(rightRaw);
+    if (rightMatrix && 't' in rightMatrix) return rightMatrix;
+    if (!leftMatrix && !rightMatrix) return null;
+
+    const rows = leftMatrix?.rows ?? rightMatrix!.rows;
+    const cols = leftMatrix?.cols ?? rightMatrix!.cols;
+    if (leftMatrix && rightMatrix && (leftMatrix.rows !== rightMatrix.rows || leftMatrix.cols !== rightMatrix.cols)) {
+      return ErrNode.VALUE;
+    }
+
+    const leftScalar = leftMatrix ? null : NumberArgs.map(leftRaw, this.grid);
+    if (leftScalar?.t === 'err') return leftScalar;
+    const rightScalar = rightMatrix ? null : NumberArgs.map(rightRaw, this.grid);
+    if (rightScalar?.t === 'err') return rightScalar;
+
+    const result: EvalNode[][] = [];
+    for (let row = 0; row < rows; row++) {
+      const resultRow: EvalNode[] = [];
+      for (let col = 0; col < cols; col++) {
+        const leftNode = leftMatrix ? NumberArgs.map(leftMatrix.values[row]?.[col] ?? { t: 'empty' }, this.grid) : leftScalar!;
+        if (leftNode.t === 'err') return leftNode;
+        const rightNode = rightMatrix ? NumberArgs.map(rightMatrix.values[row]?.[col] ?? { t: 'empty' }, this.grid) : rightScalar!;
+        if (rightNode.t === 'err') return rightNode;
+
+        if (op === FormulaParser.ADD) {
+          resultRow.push({ t: 'num', v: leftNode.v + rightNode.v });
+        } else if (op === FormulaParser.SUB) {
+          resultRow.push({ t: 'num', v: leftNode.v - rightNode.v });
+        } else if (op === FormulaParser.MUL) {
+          resultRow.push({ t: 'num', v: leftNode.v * rightNode.v });
+        } else {
+          if (rightNode.v === 0) return ErrNode.DIV0;
+          resultRow.push({ t: 'num', v: leftNode.v / rightNode.v });
+        }
+      }
+      result.push(resultRow);
+    }
+
+    return { t: 'arr', v: result, rows, cols };
+  }
+
+  private comparisonArrayBinary(leftRaw: EvalNode, rightRaw: EvalNode, op: number): EvalNode | null {
+    const leftMatrix = this.toMatrixArray(leftRaw);
+    if (leftMatrix && 't' in leftMatrix) return leftMatrix;
+    const rightMatrix = this.toMatrixArray(rightRaw);
+    if (rightMatrix && 't' in rightMatrix) return rightMatrix;
+    if (!leftMatrix && !rightMatrix) return null;
+
+    const rows = leftMatrix?.rows ?? rightMatrix!.rows;
+    const cols = leftMatrix?.cols ?? rightMatrix!.cols;
+    if (leftMatrix && rightMatrix && (leftMatrix.rows !== rightMatrix.rows || leftMatrix.cols !== rightMatrix.cols)) {
+      return ErrNode.VALUE;
+    }
+
+    const leftScalar = leftMatrix ? null : this.resolveValue(leftRaw);
+    if (leftScalar?.t === 'err') return leftScalar;
+    const rightScalar = rightMatrix ? null : this.resolveValue(rightRaw);
+    if (rightScalar?.t === 'err') return rightScalar;
+
+    const result: EvalNode[][] = [];
+    for (let row = 0; row < rows; row++) {
+      const resultRow: EvalNode[] = [];
+      for (let col = 0; col < cols; col++) {
+        const leftNode = leftMatrix ? leftMatrix.values[row]?.[col] ?? { t: 'empty' } : leftScalar!;
+        const rightNode = rightMatrix ? rightMatrix.values[row]?.[col] ?? { t: 'empty' } : rightScalar!;
+        const compared = this.compareValues(leftNode, rightNode, op);
+        if (compared.t === 'err') return compared;
+        resultRow.push(compared);
+      }
+      result.push(resultRow);
+    }
+
+    return { t: 'arr', v: result, rows, cols };
+  }
+
+  private toMatrixArray(node: EvalNode): MatrixArray | ErrNode | null {
+    if (node.t === 'arr') {
+      return { values: node.v, rows: node.rows, cols: node.cols };
+    }
+
+    if (node.t !== 'ref' || !this.grid || !isSrng(node.v)) {
+      return null;
+    }
+
+    try {
+      const [start, end] = parseRange(node.v);
+      const rows = Math.abs(end.r - start.r) + 1;
+      const cols = Math.abs(end.c - start.c) + 1;
+      const refs = Array.from(toSrefs([node.v]));
+      const values: EvalNode[][] = [];
+
+      for (let row = 0; row < rows; row++) {
+        const resultRow: EvalNode[] = [];
+        for (let col = 0; col < cols; col++) {
+          const ref = refs[row * cols + col];
+          if (!ref) return ErrNode.VALUE;
+          const value = this.resolveValue({ t: 'ref', v: ref });
+          if (value.t === 'err') return value;
+          resultRow.push(value);
+        }
+        values.push(resultRow);
+      }
+
+      return { values, rows, cols };
+    } catch {
+      return ErrNode.VALUE;
+    }
   }
 
   private resolveValue(node: EvalNode): EvalNode {

--- a/packages/sheets/src/formula/functions-math.ts
+++ b/packages/sheets/src/formula/functions-math.ts
@@ -1769,15 +1769,22 @@ export function sumproductFunc(
 
   const arrays: number[][] = [];
   for (const expr of exprs) {
-    const refs = getRefsFromExpression(expr, visit, grid);
-    if (refs.t === 'err') {
-      return refs;
+    const matrix = getReferenceMatrixFromExpression(expr, visit, grid);
+    if ('t' in matrix && matrix.t === 'err') {
+      return matrix;
     }
 
+    const rows = matrix.t === 'arrmat' ? matrix.rowCount : matrix.v.rowCount;
+    const cols = matrix.t === 'arrmat' ? matrix.colCount : matrix.v.colCount;
     const values: number[] = [];
-    for (const ref of refs.v) {
-      const cellVal = grid?.get(ref)?.v || '';
-      values.push(cellVal !== '' && !isNaN(Number(cellVal)) ? Number(cellVal) : 0);
+    for (let row = 0; row < rows; row++) {
+      for (let col = 0; col < cols; col++) {
+        const value = getMatrixVal(matrix, row, col, grid);
+        if (typeof value !== 'number') {
+          return value;
+        }
+        values.push(value);
+      }
     }
     arrays.push(values);
   }

--- a/packages/sheets/src/formula/functions-math.ts
+++ b/packages/sheets/src/formula/functions-math.ts
@@ -1768,6 +1768,8 @@ export function sumproductFunc(
   }
 
   const arrays: number[][] = [];
+  let expectedRows: number | undefined;
+  let expectedCols: number | undefined;
   for (const expr of exprs) {
     const matrix = getReferenceMatrixFromExpression(expr, visit, grid);
     if ('t' in matrix && matrix.t === 'err') {
@@ -1776,6 +1778,15 @@ export function sumproductFunc(
 
     const rows = matrix.t === 'arrmat' ? matrix.rowCount : matrix.v.rowCount;
     const cols = matrix.t === 'arrmat' ? matrix.colCount : matrix.v.colCount;
+    if (
+      expectedRows !== undefined &&
+      (rows !== expectedRows || cols !== expectedCols)
+    ) {
+      return ErrNode.VALUE;
+    }
+    expectedRows ??= rows;
+    expectedCols ??= cols;
+
     const values: number[] = [];
     for (let row = 0; row < rows; row++) {
       for (let col = 0; col < cols; col++) {

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -132,6 +132,10 @@ describe('Formula', () => {
     expect(evaluate('=SUMPRODUCT((A1:A3="North")*B1:B3)', grid)).toBe('40');
   });
 
+  it('should reject SUMPRODUCT arrays with different shapes', () => {
+    expect(evaluate('=SUMPRODUCT({1,2,3,4},{1,2;3,4})')).toBe('#VALUE!');
+  });
+
   it('should use array literals in arithmetic', () => {
     expect(evaluate('={1,2,3}+10')).toBe('11');
   });

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -120,6 +120,18 @@ describe('Formula', () => {
     expect(evaluate('=COUNT({1,2,3})')).toBe('3');
   });
 
+  it('should use boolean array products with SUMPRODUCT', () => {
+    const grid: Grid = new Map<string, Cell>();
+    grid.set('A1', { v: 'North' } as Cell);
+    grid.set('A2', { v: 'South' } as Cell);
+    grid.set('A3', { v: 'North' } as Cell);
+    grid.set('B1', { v: '10' } as Cell);
+    grid.set('B2', { v: '20' } as Cell);
+    grid.set('B3', { v: '30' } as Cell);
+
+    expect(evaluate('=SUMPRODUCT((A1:A3="North")*B1:B3)', grid)).toBe('40');
+  });
+
   it('should use array literals in arithmetic', () => {
     expect(evaluate('={1,2,3}+10')).toBe('11');
   });

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   evaluate,
+  evaluateWithSpill,
   extractReferences,
   extractTokens,
   isReferenceInsertPosition,
@@ -130,6 +131,26 @@ describe('Formula', () => {
     grid.set('B3', { v: '30' } as Cell);
 
     expect(evaluate('=SUMPRODUCT((A1:A3="North")*B1:B3)', grid)).toBe('40');
+  });
+
+  it('should compare array literal cell references by value', () => {
+    const grid: Grid = new Map<string, Cell>();
+    grid.set('A1', { v: '5' } as Cell);
+    grid.set('B1', { v: '10' } as Cell);
+
+    expect(evaluate('={A1,B1}=10', grid)).toBe('FALSE');
+    expect(evaluateWithSpill('={A1,B1}=10', grid)).toBe('FALSE');
+    expect(evaluate('=SUMPRODUCT({A1,B1}=10,{1,1})', grid)).toBe('1');
+  });
+
+  it('should use array literal reference comparisons with SUMPRODUCT', () => {
+    const grid: Grid = new Map<string, Cell>();
+    grid.set('A1', { v: 'North' } as Cell);
+    grid.set('A2', { v: 'South' } as Cell);
+    grid.set('B1', { v: '10' } as Cell);
+    grid.set('B2', { v: '20' } as Cell);
+
+    expect(evaluate('=SUMPRODUCT(({A1,A2}="North")*{B1,B2})', grid)).toBe('10');
   });
 
   it('should reject SUMPRODUCT arrays with different shapes', () => {

--- a/packages/sheets/test/sheet/calculation.test.ts
+++ b/packages/sheets/test/sheet/calculation.test.ts
@@ -270,4 +270,13 @@ describe('Sheet.Calcuation', () => {
     await sheet.setData({ r: 1, c: 4 }, '=A1:B1+A1:B1');
     expect(await sheet.toDisplayString({ r: 1, c: 4 })).toBe('#VALUE!');
   });
+
+  it('should compare array literal references without spilling', async () => {
+    const sheet = new Sheet(new MemStore());
+    await sheet.setData({ r: 1, c: 1 }, '5');
+    await sheet.setData({ r: 1, c: 2 }, '10');
+    await sheet.setData({ r: 1, c: 3 }, '={A1,B1}=10');
+
+    expect(await sheet.toDisplayString({ r: 1, c: 3 })).toBe('FALSE');
+  });
 });


### PR DESCRIPTION
Summary:
- Evaluate range comparisons as arrays so expressions like `A1:A3=North` produce boolean arrays.
- Support element-wise arithmetic when either side is an array or range.
- Let `SUMPRODUCT` consume computed arrays and coerce booleans to `0`/`1` through the existing matrix value path.
- Add regression coverage for the reported filtered SUMPRODUCT formula.

Test plan:
- `git diff --check`
- Attempted `pnpm install --frozen-lockfile --ignore-scripts`, but pnpm is unavailable in this Codex shell.

Closes #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Element-wise array arithmetic (+, -, *, /) across 2‑D ranges with per-cell division-by-zero reporting.
  * Array-aware comparisons producing element-wise boolean/matrix results.
  * SUMPRODUCT now accepts computed arrays, enforces matching dimensions, and propagates non-numeric errors instead of coercing them to zero.

* **Tests**
  * Added coverage for boolean-array arithmetic and SUMPRODUCT dimension-mismatch handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/199)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->