### PR TITLE
Fix slides Delete key, multi-select drag, and shared Slides routing

### DIFF
--- a/harness.config.json
+++ b/harness.config.json
@@ -2,8 +2,8 @@
   "frontend": {
     "chunkBudgets": {
       "maxChunkKb": 710,
-      "maxChunkCount": 80,
-      "maxChunkCountReason": "Bumped from 70 → 80 in the Butter & Maple homepage redesign (Phase 9). Measured count is 71 chunks; the +9 buffer absorbs incremental primitives without an immediate re-bump.",
+      "maxChunkCount": 85,
+      "maxChunkCountReason": "Bumped from 80 → 85 when shared-document.tsx lazy-loaded SlidesView for slides share links — vite split SlidesView and its slide-renderer dependency into their own chunks (+2). Headroom (+2 over the measured 81) absorbs incremental primitives without an immediate re-bump. Prior bump: 70 → 80 in the Butter & Maple homepage redesign (Phase 9).",
       "overrides": [
         {
           "pattern": "^pending-imports-",

--- a/packages/frontend/src/api/share-links.ts
+++ b/packages/frontend/src/api/share-links.ts
@@ -15,7 +15,7 @@ export type ResolvedShareLink = {
   documentId: string;
   role: string;
   title: string;
-  type: "sheet" | "doc";
+  type: "sheet" | "doc" | "slides";
 };
 
 /**

--- a/packages/frontend/src/app/shared/shared-document.tsx
+++ b/packages/frontend/src/app/shared/shared-document.tsx
@@ -12,6 +12,7 @@ import {
   initialSpreadsheetDocument,
 } from "@/types/worksheet";
 import { initialDocsRoot, type YorkieDocsRoot } from "@/types/docs-document";
+import type { YorkieSlidesRoot } from "@/types/slides-document";
 import type { UserPresence as UserPresenceType } from "@/types/users";
 import { UserPresence } from "@/components/user-presence";
 import { DocsView, type EditorAPI } from "@/app/docs/docs-view";
@@ -27,6 +28,15 @@ type PeerJumpTarget = {
 const DataSourceView = lazy(() =>
   import("@/app/spreadsheet/datasource-view").then((module) => ({
     default: module.DataSourceView,
+  })),
+);
+
+// Slides editor + @wafflebase/slides bundle is heavy (see
+// `slides-detail-*` chunk override in harness.config.json). Lazy-load
+// it so non-slides share links don't pay the cost.
+const SlidesView = lazy(() =>
+  import("@/app/slides/slides-view").then((module) => ({
+    default: module.SlidesView,
   })),
 );
 
@@ -184,6 +194,36 @@ function SharedDocsLayout({ resolved }: { resolved: ResolvedShareLink }) {
   );
 }
 
+function SharedSlidesLayout({ resolved }: { resolved: ResolvedShareLink }) {
+  // `SlidesView` accepts `readOnly` for API parity with `DocsView` but
+  // currently treats it as a no-op (see slides-view.tsx — Phase 4a).
+  // The share-link role is forwarded so it lights up automatically when
+  // Phase 4b wires the read-only path. Until then, viewer-role shares
+  // see the "View only" badge but the editor is still interactive.
+  const readOnly = resolved.role === "viewer";
+
+  return (
+    <div className="flex h-screen w-full flex-col">
+      <header className="flex h-14 shrink-0 items-center justify-between border-b px-4">
+        <div className="flex items-center gap-2">
+          <h1 className="text-base font-medium">{resolved.title}</h1>
+          {readOnly && (
+            <span className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+              View only
+            </span>
+          )}
+        </div>
+        <UserPresence />
+      </header>
+      <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
+        <Suspense fallback={<Loader />}>
+          <SlidesView readOnly={readOnly} />
+        </Suspense>
+      </div>
+    </div>
+  );
+}
+
 function SharedDocumentInner({
   resolved,
 }: {
@@ -201,10 +241,16 @@ function SharedDocumentInner({
     photo: currentUser?.photo || "",
   };
 
-  const isDocs = resolved.type === "doc";
-  const docKey = isDocs
-    ? `doc-${resolved.documentId}`
-    : `sheet-${resolved.documentId}`;
+  // The Yorkie document key namespaces the three document types so a
+  // shared share-link routes the client to the same Yorkie document the
+  // owner is editing — `doc-{id}` / `slides-{id}` / `sheet-{id}` mirror
+  // the namespacing used by the per-type detail routes.
+  const docKey =
+    resolved.type === "doc"
+      ? `doc-${resolved.documentId}`
+      : resolved.type === "slides"
+      ? `slides-${resolved.documentId}`
+      : `sheet-${resolved.documentId}`;
 
   return (
     <YorkieProvider
@@ -212,7 +258,7 @@ function SharedDocumentInner({
       apiKey={import.meta.env.VITE_YORKIE_API_KEY}
       metadata={{ userID: presence.username }}
     >
-      {isDocs ? (
+      {resolved.type === "doc" ? (
         <DocumentProvider<YorkieDocsRoot>
           docKey={docKey}
           initialRoot={initialDocsRoot()}
@@ -220,6 +266,15 @@ function SharedDocumentInner({
           enableDevtools={import.meta.env.DEV}
         >
           <SharedDocsLayout resolved={resolved} />
+        </DocumentProvider>
+      ) : resolved.type === "slides" ? (
+        <DocumentProvider<Partial<YorkieSlidesRoot>>
+          docKey={docKey}
+          initialRoot={{}}
+          initialPresence={presence}
+          enableDevtools={import.meta.env.DEV}
+        >
+          <SharedSlidesLayout resolved={resolved} />
         </DocumentProvider>
       ) : (
         <DocumentProvider

--- a/packages/slides/src/view/editor/editor.test.ts
+++ b/packages/slides/src/view/editor/editor.test.ts
@@ -117,6 +117,43 @@ describe('initialize', () => {
     void elementId;
   });
 
+  it('clicking on an already-selected element preserves the multi-selection and drags all of them', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let aId = '';
+    let bId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      aId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 100, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+      bId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 400, y: 400, w: 100, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#0a0' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([aId, bId]);
+    // Click inside element `a` (no shift). Multi-selection should be
+    // preserved so the follow-up drag moves both elements.
+    dispatchMouseDown(canvas, 150, 150);
+    expect(editor.getSelection()).toEqual([aId, bId]);
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200, clientY: 180, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mouseup',   { clientX: 200, clientY: 180, bubbles: true }));
+    const elements = store.read().slides[0].elements;
+    const a = elements.find((el) => el.id === aId)!;
+    const b = elements.find((el) => el.id === bId)!;
+    // Both elements moved by approximately the same delta. Snap may
+    // tweak by ≤ 8 px, but the per-element delta is identical so the
+    // gap between a and b is preserved.
+    expect(b.frame.x - a.frame.x).toBe(300);
+    expect(b.frame.y - a.frame.y).toBe(300);
+    expect(a.frame.x).toBeGreaterThan(100);
+    expect(a.frame.y).toBeGreaterThan(100);
+  });
+
   it('dragging the e handle resizes the selected element', () => {
     const { canvas, overlay, store } = makeFixture();
     let elementId = '';

--- a/packages/slides/src/view/editor/interactions/keyboard.test.ts
+++ b/packages/slides/src/view/editor/interactions/keyboard.test.ts
@@ -113,6 +113,65 @@ describe('keyboard — undo/redo', () => {
   });
 });
 
+describe('keyboard — Delete / Backspace', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  it('Delete removes the selected element', () => {
+    const { editor: e, store, elementId } = makeFixture();
+    editor = e;
+    editor.setSelection([elementId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
+    expect(store.read().slides[0].elements).toHaveLength(0);
+    expect(editor.getSelection()).toEqual([]);
+  });
+
+  it('Backspace removes the selected element', () => {
+    const { editor: e, store, elementId } = makeFixture();
+    editor = e;
+    editor.setSelection([elementId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }));
+    expect(store.read().slides[0].elements).toHaveLength(0);
+  });
+
+  it('Delete with no selection is a no-op', () => {
+    const { editor: e, store } = makeFixture();
+    editor = e;
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
+    expect(store.read().slides[0].elements).toHaveLength(1);
+  });
+
+  it('Delete removes every element in a multi-selection in one undo entry', () => {
+    const { editor: e, store, elementId } = makeFixture();
+    editor = e;
+    let secondId = '';
+    store.batch(() => {
+      secondId = store.addElement(store.read().slides[0].id, {
+        type: 'shape',
+        frame: { x: 400, y: 400, w: 50, h: 50, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#0a0' } },
+      });
+    });
+    editor.setSelection([elementId, secondId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }));
+    expect(store.read().slides[0].elements).toHaveLength(0);
+    store.undo();
+    expect(store.read().slides[0].elements).toHaveLength(2);
+  });
+
+  it('Backspace inside a textarea does not delete elements', () => {
+    const { editor: e, store, elementId } = makeFixture();
+    editor = e;
+    editor.setSelection([elementId]);
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }));
+    expect(store.read().slides[0].elements).toHaveLength(1);
+    textarea.remove();
+  });
+});
+
 describe('keyboard — Cmd+D duplicate element', () => {
   let editor: SlidesEditor | null = null;
   beforeEach(() => { if (editor) { editor.detach(); editor = null; } });

--- a/packages/slides/src/view/editor/interactions/keyboard.ts
+++ b/packages/slides/src/view/editor/interactions/keyboard.ts
@@ -37,6 +37,28 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
       run: (e) => { e.preventDefault(); ctx.store.redo(); ctx.requestRender(); },
     },
 
+    // Delete / Backspace — remove selected elements. Skipped while the
+    // user is typing in a textarea/input/contenteditable so Backspace
+    // inside the inline text-box editor still deletes characters.
+    {
+      match: (e) =>
+        (e.key === 'Delete' || e.key === 'Backspace') &&
+        !isModPressed(e) &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        const ids = ctx.selection.get();
+        if (ids.length === 0) return;
+        const slide = currentSlide(ctx);
+        if (!slide) return;
+        e.preventDefault();
+        ctx.store.batch(() =>
+          ctx.store.removeElements(slide.id, [...ids]),
+        );
+        ctx.selection.clear();
+        ctx.requestRender();
+      },
+    },
+
     // Arrow nudge — only when something is selected and no modifier.
     ...(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'] as const).map(
       (key): KeyRule => ({
@@ -279,4 +301,12 @@ function tryDeserialize(json: string): ElementInit[] | null {
 
 function keyEquals(eventKey: string, target: string): boolean {
   return eventKey.toLowerCase() === target.toLowerCase();
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if ((target as HTMLElement).isContentEditable) return true;
+  return false;
 }

--- a/packages/slides/src/view/editor/interactions/select.test.ts
+++ b/packages/slides/src/view/editor/interactions/select.test.ts
@@ -44,4 +44,15 @@ describe('selectAt', () => {
   it('shift-click on empty canvas leaves selection unchanged', () => {
     expect(selectAt(slide, 500, 500, { shift: true }, ['a'])).toEqual(['a']);
   });
+
+  it('clicking an already-selected element preserves the multi-selection', () => {
+    // Without this, a no-shift click on one of several selected
+    // elements would collapse the selection to just the hit and the
+    // follow-up drag would only move that one element.
+    expect(selectAt(slide, 250, 250, {}, ['a', 'b'])).toEqual(['a', 'b']);
+  });
+
+  it('clicking a non-selected element while others are selected replaces selection', () => {
+    expect(selectAt(slide, 60, 60, {}, ['b'])).toEqual(['c']);
+  });
 });

--- a/packages/slides/src/view/editor/interactions/select.ts
+++ b/packages/slides/src/view/editor/interactions/select.ts
@@ -27,6 +27,11 @@ export function selectAt(
   }
 
   if (hit === null) return [];
+  // Preserve an existing multi-selection when the user clicks on an
+  // element that's already part of it. Without this guard, the no-shift
+  // click would collapse the selection to `[hit]` and a follow-up drag
+  // would only move the single clicked element instead of the group.
+  if (current.includes(hit)) return [...current];
   return [hit];
 }
 


### PR DESCRIPTION
## Summary

Three slides bugs reported in one session, fixed together because they share the same code paths:

1. **Delete/Backspace did nothing on a selected shape.** `packages/slides/src/view/editor/interactions/keyboard.ts` had no key rule for `Delete` or `Backspace` — the only Delete entry point was the right-click context menu. Added a rule that calls `store.removeElements` on the current selection. The rule skips when `e.target` is an `INPUT`/`TEXTAREA`/`SELECT` or `isContentEditable`, so Backspace inside the inline text-box editor still deletes characters.
2. **Clicking on one of several selected shapes collapsed the multi-selection.** `selectAt` in `packages/slides/src/view/editor/interactions/select.ts` returned `[hit]` on a no-shift click regardless of the current selection, so the follow-up `startDrag` (`editor.ts:716`) only moved the clicked element. Now `selectAt` preserves `current` when `current.includes(hit)`; replacement still happens for clicks on a non-selected element. Matches Google Slides / Keynote / Figma behavior.
3. **A shared Slides document opened as an empty Sheet.** `share-link.controller.ts:74` already passed the document's stored type (`"sheet" | "doc" | "slides"`) through to the resolver response, but `SharedDocumentInner` only special-cased `"doc"` — slides fell into the spreadsheet branch with a `sheet-{id}` Yorkie docKey. Extended `ResolvedShareLink.type` to include `"slides"`, added a `SharedSlidesLayout` that mounts `SlidesView` under a `slides-{id}` docKey (matching the standalone route at `slides-detail.tsx:220`).

## Known limitations

- **Read-only enforcement for slides is incomplete.** `SlidesView`'s `readOnly` prop is documented as a Phase 4b no-op (`slides-view.tsx:25-30`), so a `viewer`-role share link will see the "View only" badge but the editor remains interactive. The role is forwarded to `SlidesView` so it lights up automatically when 4b lands; called out with a comment in `SharedSlidesLayout`. This is a separate issue from the routing bug — pre-PR, viewers saw the wrong document entirely; post-PR, they at least see the right one.
- **Frontend chunk-count budget bumped 80 → 85.** Lazy-loading `SlidesView` in `shared-document.tsx` (so non-slides share links don't pay for the slides bundle) caused vite to split `slides-view` and its `slide-renderer` dependency into their own chunks (+2). Reasoned in `harness.config.json`.

## Test plan

- [x] `pnpm verify:self` — all 9 lanes pass (sheets/docs/slides build, verify:fast 226 + 1265 + 267 + 174 + 764, frontend build, chunk gate, backend build, cli build, entropy).
- [x] Added 8 unit tests covering the new behavior:
  - `select.test.ts` — click on already-selected element preserves multi-selection; click on non-selected element with multi-selection replaces.
  - `keyboard.test.ts` — Delete/Backspace remove selection (single + multi, single undo entry); Backspace inside textarea is a no-op; no-selection Delete is a no-op.
  - `editor.test.ts` — multi-select + click-on-selected + drag moves the whole group with identical per-element delta.
- [x] Manual smoke in `pnpm dev`: select shape + Delete, multi-select + drag, share a slides doc and open the link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)