### PR TITLE
Pin docs table grid picker selection at MAX_SIZE on overshoot

### DIFF
--- a/docs/design/docs/docs-table-ui.md
+++ b/docs/design/docs/docs-table-ui.md
@@ -28,10 +28,10 @@ exist in the EditorAPI — this work connects them to the user interface.
 
 ### Component: `TableGridPicker`
 
-A 10x10 grid of small squares rendered inside a Radix `DropdownMenuContent`.
-Mouse hover highlights the selected region (top-left to hovered cell).
-Bottom label shows dimensions (e.g., "3 x 4"). Click calls
-`onSelect(rows, cols)`.
+A grid of small squares (up to 10x10, expanding from 5x5) rendered inside a
+Radix `DropdownMenuContent`. Mouse hover highlights the selected region
+(top-left to hovered cell). Bottom label shows dimensions (e.g., "3 x 4").
+Click calls `onSelect(rows, cols)`.
 
 ```typescript
 interface TableGridPickerProps {
@@ -44,6 +44,8 @@ interface TableGridPickerProps {
 - Hover: cells from (0,0) to (hoverRow, hoverCol) highlighted in blue
 - Click: fires `onSelect(hoverRow + 1, hoverCol + 1)`, closes dropdown
 - Label below grid: "3 x 4" or "Insert table" when no hover
+- Pointer exiting past the right/bottom edge while at the maximum pins the
+  selection to 10x10 instead of resetting (prevents overshoot snap-back)
 
 **Integration in `DocsFormattingToolbar`:**
 - New table icon button (`IconTable` from `@tabler/icons-react`) after the

--- a/packages/frontend/src/app/docs/table-grid-picker.tsx
+++ b/packages/frontend/src/app/docs/table-grid-picker.tsx
@@ -58,7 +58,18 @@ export function TableGridPicker({ onSelect }: TableGridPickerProps) {
     [resolveCell, onSelect],
   );
 
-  const handleMouseLeave = useCallback(() => {
+  const handleMouseLeave = useCallback((e: React.MouseEvent) => {
+    const grid = gridRef.current;
+    if (grid) {
+      const rect = grid.getBoundingClientRect();
+      const exitedRight = e.clientX >= rect.right;
+      const exitedBottom = e.clientY >= rect.bottom;
+      if (exitedRight || exitedBottom) {
+        setHoverCol((prev) => (exitedRight ? MAX_SIZE - 1 : prev));
+        setHoverRow((prev) => (exitedBottom ? MAX_SIZE - 1 : prev));
+        return;
+      }
+    }
     setHoverRow(-1);
     setHoverCol(-1);
   }, []);


### PR DESCRIPTION
## Summary
Previously, when the user dragged the table-insert grid picker out past the right or bottom edge, the hover state reset to (-1, -1) and the highlighted region collapsed back to the empty state. This made it impossible to land on the maximum 10x10 selection reliably — a slight overshoot would force the user to re-enter and stop precisely on the last cell.

Now the mouseLeave handler checks the exit edge: if the pointer leaves past the right/bottom of the grid, hover is pinned to the MAX_SIZE-1 boundary on that axis instead of being reset. Leaving via the top or left still resets, since that direction has no selection-overshoot risk.

## Why

## Linked Issues

Fixes #

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table grid picker now maintains selection at maximum size (10x10) when pointer exits to the right or bottom edge, preventing unintended state resets.

* **Documentation**
  * Updated table UI design documentation with refined grid picker specifications, table cell context menu design, and IME composition event routing details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/203)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->