### PR TITLE
Add CONTRIBUTING.md and surface Slides in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,212 @@
+# Contributing to Wafflebase
+
+Thanks for considering a contribution! Wafflebase is a web-based
+collaborative office suite (Sheets, Docs, Slides) built on Yorkie CRDTs
+and Canvas rendering. This guide describes how we accept changes, how
+the verification lanes work, and how AI coding agents fit into the
+workflow.
+
+## TL;DR
+
+- **Bug fix** → file an issue (or skip for trivial fixes) → branch from
+  `main` → `pnpm verify:fast` green → open a PR.
+- **Feature / non-trivial change** → write or update a design doc under
+  [`docs/design/`](docs/design/README.md) → create a task plan under
+  [`docs/tasks/active/`](docs/tasks/README.md) → implement → open a PR
+  that includes the design doc and the code.
+- **Docs / refactor** → straight to PR.
+
+All PRs target `main`. CI runs `verify:self` and `verify:integration`
+and posts a summary as a PR comment.
+
+## Before you start
+
+1. Search [open issues](https://github.com/wafflebase/wafflebase/issues)
+   and existing design docs to avoid duplicate work.
+2. For larger changes, open an issue or a discussion first so we can
+   align on scope before you spend time on code.
+3. By contributing, you agree your changes are licensed under the
+   project's [Apache License 2.0](LICENSE). A CLA is **not** required
+   today; we may introduce one in the future.
+
+## Contribution paths
+
+### Bug fixes
+
+1. File a bug using the [bug report template](.github/ISSUE_TEMPLATE/bug-report.md)
+   if one doesn't already exist. Include reproduction steps, expected vs.
+   actual behavior, and environment.
+2. Branch from `main`, fix the root cause (no temporary patches), and
+   add a regression test where it makes sense.
+3. Open a PR referencing the issue.
+
+### Features and non-trivial changes
+
+Wafflebase keeps design and execution in the repository:
+
+- **Architecture / data-model changes** belong in
+  `docs/design/<area>/<topic>.md`. See the
+  [Design Documents index](docs/design/README.md) and the
+  [template](docs/design/template.md). Update the existing doc when
+  evolving an area instead of creating parallel files.
+- **Per-task execution plans** belong in
+  `docs/tasks/active/YYYYMMDD-<slug>-todo.md`, with a paired
+  `…-lessons.md` capturing what surprised you (see
+  [`docs/tasks/README.md`](docs/tasks/README.md)).
+
+Design and code can ship in the **same PR**; we do not require a
+separate spec PR. For very large or controversial changes, open a
+design-only PR first to get architectural alignment before writing
+code.
+
+After the task is merged, archive it:
+
+```bash
+pnpm tasks:archive
+pnpm tasks:index
+```
+
+### Documentation, refactors, small chores
+
+Open a PR directly. Mention the motivation in the PR body.
+
+## Local development
+
+Setup, prerequisites, and the dev server are documented in the
+[root README](README.md#getting-started) and the
+[backend README](packages/backend/README.md). Don't duplicate them here
+— if those instructions are wrong, fix them at the source.
+
+## Verification gates
+
+We have three verification lanes; pick the one matching the scope of
+your change.
+
+| Command                          | When to run                                                      |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `pnpm verify:fast`               | Before every commit. Lint + unit tests; the pre-commit gate.     |
+| `pnpm verify:self`               | Before opening a PR. Adds full builds, chunk budgets, visual + entropy checks. |
+| `pnpm verify:integration:docker` | When touching backend, datasource, share-link, or Yorkie code paths. Spins up Postgres + Yorkie automatically. |
+
+CI re-runs `verify:self` and `verify:integration` on every PR and posts
+a per-lane summary comment. The two checkboxes in the PR template
+must be green (or the skip reason filled in) before review.
+
+## Commit messages
+
+- **Subject ≤ 70 chars**, sentence case, no trailing period. Describe
+  *what* changed.
+- **Blank line**, then a body wrapped at ~80 chars explaining *why*.
+- In a shell, use multiple `-m` flags or a `$'...'` literal for real
+  newlines — never `\n` inside a `"..."` quoted message.
+- Each commit should leave `pnpm verify:fast` green.
+
+Example:
+
+```text
+Remove the synced seq when detaching the document
+
+To collect garbage like CRDT tombstones left on the document, all
+the changes should be applied to other replicas before GC. For this,
+if the document is no longer used by this client, it should be
+detached.
+```
+
+## Pull Request workflow
+
+1. **Branch.** Cut a feature branch from up-to-date `main`.
+2. **Implement and self-verify.** `pnpm verify:fast` per commit;
+   `pnpm verify:self` (and `verify:integration:docker` where relevant)
+   before pushing.
+3. **Self review.** Run a code review skill over the full branch diff
+   before opening the PR — `/code-review`,
+   `superpowers:requesting-code-review`, or `/ultrareview`. Apply
+   blocking findings; note non-blocking ones in the PR body as known
+   limitations.
+4. **Rebase.** `git fetch && git rebase origin/main` to surface
+   conflicts before pushing.
+5. **Open the PR.** Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md).
+   - Title ≤ 70 chars.
+   - Body should answer *why* and include a test plan; attach
+     screenshots/recordings for UI changes.
+   - Tick the `verify:self` and `verify:integration` checkboxes once CI
+     reports green (or fill in the skip reason).
+6. **Merge.** Once CI is green and review is approved, capture lessons
+   in `*-lessons.md`, archive the task, and merge.
+
+We don't require a per-PR `CHANGELOG` entry — release notes are
+generated from merged PRs at release time
+(`gh release create --generate-notes`). See
+[MAINTAINING.md](MAINTAINING.md) for the release process.
+
+## Code review
+
+- Reply **inside the comment thread**, not at the top level of the PR,
+  so context stays attached:
+
+  ```bash
+  gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies \
+    -f body="reply text"
+  ```
+
+- Evaluate each finding technically. Push back with reasoning when a
+  suggestion is wrong; agree explicitly when it is right. Performative
+  agreement wastes everyone's time.
+- If `main` moved during review, rebase again before pushing fixes.
+
+## AI agent–assisted contributions
+
+Wafflebase is happy to accept work generated with help from coding
+agents (Claude Code, Codex, Cursor, etc.). The repository ships
+agent-facing instructions in [`CLAUDE.md`](CLAUDE.md) (also exposed as
+`AGENTS.md` via symlink) and [`.superpowers/`](.superpowers/) skills.
+
+Expectations:
+
+- A human contributor signs off on every PR, regardless of how the code
+  was produced. You are responsible for what you submit.
+- Follow the same workflow as a human contributor: design doc → task
+  plan → verify lanes → self review → PR.
+- Do not commit secrets, generated lockfile churn, or auto-formatter
+  drift unrelated to your change.
+- `/ultrareview` (multi-agent cloud review) is user-triggered and
+  billed; an agent cannot launch it for you. Use it on substantial
+  changes when you want a second opinion before merge.
+
+## Package-specific gotchas
+
+A few things bite first-time contributors:
+
+- **ANTLR generated files** in `packages/sheets/src/formula/` carry
+  `@ts-nocheck`. Do not hand-edit or "fix" types — regenerate with
+  `pnpm sheets build:formula` and commit the output.
+- **Store abstraction** — all spreadsheet behavior must go through the
+  `Store` interface, all document behavior through `DocStore`. Don't
+  reach around them with ad-hoc persistence.
+- **Integration / e2e tests** require `docker compose up -d` first
+  (Postgres + Yorkie). The `:docker` verify variant launches both for
+  you.
+- **Frontend chunk budgets** are enforced by `verify:self`. Defaults
+  live in `harness.config.json`; override locally with
+  `FRONTEND_CHUNK_LIMIT_KB` / `FRONTEND_CHUNK_COUNT_LIMIT` only when
+  intentionally landing larger bundles.
+
+## Reporting security issues
+
+Do **not** open a public issue for security vulnerabilities. Email the
+maintainers privately first; we will coordinate disclosure.
+
+## License
+
+Wafflebase is licensed under the [Apache License 2.0](LICENSE).
+Contributions are accepted under the same license. A Contributor
+License Agreement (CLA) is not required today and may be introduced
+later — we will announce ahead of time if that changes.
+
+## Further reading
+
+- [README.md](README.md) — project overview and setup
+- [docs/design/README.md](docs/design/README.md) — architecture and design docs
+- [docs/tasks/README.md](docs/tasks/README.md) — active and archived task plans
+- [MAINTAINING.md](MAINTAINING.md) — release and maintenance
+- [CLAUDE.md](CLAUDE.md) / `AGENTS.md` — agent-facing development conventions

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Wafflebase
 
-Wafflebase is a web-based collaborative spreadsheet and word processor. It
-bridges the gap between traditional spreadsheets and database tools, offering
-real-time collaboration and scalable performance for handling large datasets.
+Wafflebase is a web-based collaborative office suite — spreadsheets, word
+documents, and presentations. It offers real-time collaboration and scalable
+performance, and bridges the gap between traditional spreadsheets and database
+tools for handling large datasets.
 
 > **Status:** Early development. Core spreadsheet and document editing features
 > work, but the project is not yet production-ready. We are actively working on
@@ -32,6 +33,16 @@ real-time collaboration and scalable performance for handling large datasets.
 - **Block editing** — Paragraph-level operations with alignment and line
   height controls.
 
+### Slides
+
+- **Free-position canvas** — Place text boxes, shapes, and images anywhere
+  on a slide; reuses the Docs rich-text engine inside text boxes.
+- **Themes & layouts** — 5 built-in themes and 11 Google Slides–parity
+  layouts with placeholder identity tracking.
+- **Canvas + DOM editor** — Two-pane editor (slide list + main canvas) with
+  a DOM overlay for inline text editing.
+- **Import & export** — Best-effort PPTX import and PDF export.
+
 ### Shared
 
 - **Real-time collaboration** — Multi-user editing powered by
@@ -46,19 +57,21 @@ real-time collaboration and scalable performance for handling large datasets.
 | Frontend | React 19, Vite, TailwindCSS, Radix UI |
 | Sheets engine | Canvas rendering, ANTLR4 formula parser, Yorkie CRDT |
 | Docs engine | Canvas rendering, custom layout & pagination |
+| Slides engine | Canvas + DOM-overlay editor, theme/master/layout model, reuses Docs rich-text engine in text boxes |
 | Backend | NestJS, Prisma, PostgreSQL, GitHub OAuth + JWT |
 
 ## Project Structure
 
 - [packages/sheets/](packages/sheets/README.md) — Core spreadsheet engine (data model, formulas, Canvas rendering)
 - [packages/docs/](packages/docs/README.md) — Canvas-based document editor (rich text, inline formatting)
+- [packages/slides/](packages/slides/README.md) — Presentation engine (free-position elements, themes/layouts, Canvas + DOM overlay)
 - [packages/frontend/](packages/frontend/README.md) — React web app (pages, components, hooks)
 - [packages/backend/](packages/backend/README.md) — NestJS API server (auth, documents, data sources)
-- packages/cli/ — Command-line interface for Wafflebase API ([skills](packages/cli/skills/SKILL.md))
+- [packages/cli/](packages/cli/README.md) — Command-line interface for the Wafflebase API ([skills](packages/cli/skills/SKILL.md))
 - [packages/documentation/](packages/documentation/README.md) — VitePress documentation site (wafflebase.io/docs)
 
-The frontend depends on `@wafflebase/sheets` and `@wafflebase/docs` as
-workspace dependencies.
+The frontend depends on `@wafflebase/sheets`, `@wafflebase/docs`, and
+`@wafflebase/slides` as workspace dependencies.
 
 ## Getting Started
 
@@ -131,27 +144,14 @@ pnpm verify:integration:docker
 
 ## Contributing
 
-We welcome contributions! Check out open issues or propose new ideas.
-
-### Commit messages
-
-Commit messages should answer *what changed* and *why*:
-
-```
-Remove the synced seq when detaching the document
-
-To collect garbage like CRDT tombstones left on the document, all
-the changes should be applied to other replicas before GC. For this,
-if the document is no longer used by this client, it should be
-detached.
-```
-
-- Subject line: what changed, max 70 characters
-- Body: why, wrapped at 80 characters
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+full workflow — issue triage, design docs, verification lanes, commit
+conventions, and how AI coding agents fit in.
 
 ## Documentation
 
 - [docs/](docs/README.md) — design documents, architecture, and task tracking
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contributor workflow
 - [MAINTAINING.md](MAINTAINING.md) — release and maintenance procedures
 - [CLAUDE.md](CLAUDE.md) — agent instructions for AI-assisted development (also exposed as `AGENTS.md` via symlink)
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| add CONTRIBUTING.md (2026-05-10) | [20260510-contributing-md-todo.md](./active/20260510-contributing-md-todo.md) | - |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
 | slides package mvp (2026-05-05) | [20260505-slides-package-mvp-todo.md](./active/20260505-slides-package-mvp-todo.md) | [20260505-slides-package-mvp-lessons.md](./active/20260505-slides-package-mvp-lessons.md) |
 | undo destroys initial block (2026-05-05) | [20260505-undo-destroys-initial-block-todo.md](./active/20260505-undo-destroys-initial-block-todo.md) | - |
@@ -31,4 +32,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 161
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides themes layouts import (2026-05-07)
+Latest active task: add CONTRIBUTING.md (2026-05-10)

--- a/docs/tasks/active/20260510-contributing-md-todo.md
+++ b/docs/tasks/active/20260510-contributing-md-todo.md
@@ -1,0 +1,61 @@
+# Add CONTRIBUTING.md
+
+**Goal:** Author a top-level `CONTRIBUTING.md` that captures the agentic
+development workflow Wafflebase already uses, and trim the README's
+inline Contributing section to a pointer.
+
+**Scope:** Documentation only — no code changes.
+
+## Decisions (from owner, 2026-05-10)
+
+- **Spec/design PRs:** keep current style. Design lives in
+  `docs/design/<topic>.md`; per-task plans live in
+  `docs/tasks/active/YYYYMMDD-<slug>-todo.md`. Design and code can ship in
+  the same PR. Do NOT adopt warp's separate spec-PR flow.
+- **CLA:** none today. Mark as "planned, to be introduced later" — no
+  sign-off required for now.
+- **Changelog:** keep relying on GitHub auto-generated release notes
+  (`gh release create --generate-notes`). Do NOT require a per-PR
+  changelog entry.
+- **Reference:** loosely inspired by
+  https://github.com/warpdotdev/warp/blob/master/CONTRIBUTING.md, but
+  rewritten around our verify lanes, task docs, and superpowers/agent
+  workflow.
+
+## File map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `CONTRIBUTING.md` | Create | Full contributor workflow |
+| `README.md` | Modify | Replace inline Contributing section with link + 1-line commit hint |
+| `docs/tasks/README.md` | Modify | Add this task to the active index |
+
+## Plan
+
+- [ ] **Step 1:** Draft `CONTRIBUTING.md` with sections:
+  TL;DR, Before you start, Contribution paths (bug / feature / docs),
+  Local development (link), Verification gates, Commit messages,
+  Pull Request workflow, Code review, AI agent–assisted contributions,
+  Package-specific gotchas, License & CLA.
+- [ ] **Step 2:** Trim README's `## Contributing` section to a pointer at
+  `CONTRIBUTING.md`, keep the commit-message snippet OR move it fully
+  into `CONTRIBUTING.md` (decide while editing — pick whichever avoids
+  duplication).
+- [ ] **Step 3:** Update `docs/tasks/README.md` active table to include
+  this task.
+- [ ] **Step 4:** Run `pnpm verify:fast` (markdown-only change, but
+  required by repo policy).
+- [ ] **Step 5:** Owner review → commit → PR.
+
+## Verification
+
+`pnpm verify:fast` green.
+
+## Notes
+
+- Keep tone and structure aligned with existing repo docs (English,
+  concise, table-heavy).
+- Do NOT duplicate setup steps already in `README.md` and
+  `packages/backend/README.md` — link to them.
+- `AGENTS.md` is a symlink to `CLAUDE.md`; reference both names where
+  external readers might look.


### PR DESCRIPTION
## Summary

- New top-level `CONTRIBUTING.md` covering the agentic workflow already used in the repo: design docs in `docs/design/`, task plans in `docs/tasks/active/`, the three verify lanes, commit format, PR + review process, AI agent-assisted contributions, and package-specific gotchas (ANTLR, Store/DocStore, integration tests, chunk budgets).
- README's `## Contributing` trimmed to a one-line pointer; `Documentation` index now lists CONTRIBUTING.md.
- README updated to surface Slides: tagline now mentions all three editors, a `### Slides` block under Features, a `Slides engine` row in Tech Stack, and `packages/slides/` in Project Structure (also fixed `packages/cli/` to link its README and updated the workspace-deps line).
- Inspired loosely by warp's `CONTRIBUTING.md` but rewritten around our own conventions: no separate spec-PR flow, no per-PR CHANGELOG entry (release notes auto-generated), and a CLA marked as planned but not required today.

## Why

The README's Contributing section was a stub and the agentic workflow was only documented in `CLAUDE.md` / `AGENTS.md` — fine for AI agents, but a poor entry point for human contributors. CONTRIBUTING.md is the conventional landing page that GitHub also surfaces in the issue/PR sidebar.

Slides has shipped enough features to warrant top-level visibility in the README; previously a reader could miss that the package existed.

## Linked Issues

None.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

Local: `pnpm verify:fast` green (47 test files / 764 tests). Docs-only change, no code paths touched.

## Risk Assessment

- User-facing risk: none — markdown docs only.
- Data/security risk: none.
- Rollback plan: revert the single commit.

## Notes for Reviewers

- Tracking task: `docs/tasks/active/20260510-contributing-md-todo.md`.
- Decisions baked in (per owner): keep current style of putting design + code in one PR (no separate spec PR), keep auto-generated release notes (no per-PR CHANGELOG), CLA noted as planned but not required.
- `## Status` block in README still says "spreadsheet and document editing" — left as-is for now since Slides is still v1; happy to widen the wording in a follow-up if preferred.
- Follow-up work: none required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contribution guidelines with steps for bug fixes, features, and documentation contributions
  * Updated README describing Wafflebase as a web-based collaborative office suite
  * Added Slides feature documentation covering canvas editing, themes, and import/export capabilities
  * Expanded Tech Stack documentation with Slides engine and backend technology details
  * Enhanced contributor onboarding resources with workflow steps and verification expectations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/204)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->