### PR TITLE
fix(sheets): collapse internal whitespace in TRIM()

### DIFF
--- a/packages/sheets/src/formula/functions-text.ts
+++ b/packages/sheets/src/formula/functions-text.ts
@@ -14,7 +14,8 @@ import {
 
 /**
  * `trimFunc` is the implementation of the TRIM function.
- * TRIM(text) — removes leading and trailing whitespace.
+ * TRIM(text) — removes leading and trailing whitespace and collapses
+ * runs of internal whitespace to a single space.
  */
 export function trimFunc(
   ctx: FunctionContext,
@@ -34,7 +35,7 @@ export function trimFunc(
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') return str;
 
-  return { t: 'str', v: str.v.trim() };
+  return { t: 'str', v: str.v.replace(/\s+/g, ' ').trim() };
 }
 
 /**

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -599,6 +599,10 @@ describe('Formula', () => {
     expect(evaluate('=TRIM("  hello  ")')).toBe('hello');
     expect(evaluate('=TRIM("hello")')).toBe('hello');
     expect(evaluate('=TRIM("  spaces  ")')).toBe('spaces');
+    // Collapse runs of internal whitespace to a single space.
+    expect(evaluate('=TRIM("  hello   world  ")')).toBe('hello world');
+    expect(evaluate('=TRIM("a    b")')).toBe('a b');
+    expect(evaluate('=TRIM("   ")')).toBe('');
   });
 
   it('should correctly evaluate LEN function', () => {


### PR DESCRIPTION
## Summary

`TRIM(text)` now strips leading/trailing whitespace **and** collapses
runs of internal whitespace to a single space, matching Excel / Google
Sheets semantics.

```ts
// Before
return { t: 'str', v: str.v.trim() };

// After
return { t: 'str', v: str.v.replace(/\s+/g, ' ').trim() };
```

## Why

Before this fix only the leading/trailing strip was performed, so
internal runs of whitespace survived intact:

| Formula | Expected | Actual (before) |
| --- | --- | --- |
| `=TRIM("  hello   world  ")` | `"hello world"` | `"hello   world"` |

That diverges from how every other spreadsheet engine (Excel, Google
Sheets, LibreOffice Calc) defines `TRIM`, and trips users who rely on
`TRIM` to normalize copy-pasted or scraped text before comparison /
concatenation.

## Linked Issues

Fixes #212

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Locally:

- `pnpm sheets typecheck` — clean
- `pnpm sheets test` — all 1265 sheets tests pass (including 3 new regression cases for `TRIM`)

Skip reason (if applicable): n/a

## Risk Assessment

- User-facing risk: very low — the change only widens what `TRIM` removes; any pre-existing formula relying on `TRIM` preserving internal whitespace runs was already not portable to Excel/Sheets and would have been an unintentional dependency on the buggy behavior.
- Data/security risk: none — pure formula evaluation, no I/O, no persistence change.
- Rollback plan: revert the single one-line change in `functions-text.ts` (and the corresponding test additions).

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): none — formula engine only.
- Follow-up work (if any): none required for this issue. If maintainers want to match Excel's stricter behavior (only collapse `\u0020` and leave `\t`, `\n`, etc. untouched), that could be a follow-up; the current implementation matches the project's existing convention of using JS `String.prototype.trim()` (which already touches all whitespace, not just spaces).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TRIM function now collapses multiple consecutive spaces within text to single spaces, in addition to removing leading and trailing whitespace.

* **Tests**
  * Added test cases to verify improved whitespace handling in TRIM function.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/218)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->