### PR TITLE
Fix inverted sign in IPMT and PPMT

### DIFF
--- a/packages/sheets/src/formula/functions-financial.ts
+++ b/packages/sheets/src/formula/functions-financial.ts
@@ -263,7 +263,9 @@ export function ipmtFunc(
     balance += interest + (type === 0 ? pmt : (i > 1 ? pmt : 0));
   }
 
-  const ipmt = balance * rate.v;
+  // Excel cash-flow sign convention: interest is a cash flow paid/received
+  // by the borrower/lender, so its sign is opposite the outstanding balance.
+  const ipmt = -balance * rate.v;
   if (type === 1 && per.v === 1) return { t: 'num', v: 0 };
   return { t: 'num', v: ipmt };
 }
@@ -306,7 +308,7 @@ export function ppmtFunc(
 
   const pmt = computePmt(rate.v, nper.v, pv.v, fv, type);
 
-  // IPMT at this period
+  // IPMT at this period (Excel cash-flow sign convention: opposite of balance)
   let balance = pv.v;
   for (let i = 1; i < per.v; i++) {
     if (type === 1 && i === 1) {
@@ -316,7 +318,7 @@ export function ppmtFunc(
     balance += interest + (type === 0 ? pmt : (i > 1 ? pmt : 0));
   }
 
-  const ipmt = (type === 1 && per.v === 1) ? 0 : balance * rate.v;
+  const ipmt = (type === 1 && per.v === 1) ? 0 : -balance * rate.v;
   return { t: 'num', v: pmt - ipmt };
 }
 

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -1735,15 +1735,47 @@ describe('Formula', () => {
   });
 
   it('should correctly evaluate IPMT function', () => {
-    // IPMT(0.1/12, 1, 36, 8000) — interest in period 1 on $8000 loan at 10%
+    // IPMT(0.1/12, 1, 36, 8000) — interest in period 1 on $8000 loan at 10%.
+    // pv > 0 represents cash received now, so the interest portion of the
+    // payment is a cash outflow and is negative.
     const result = evaluate('=IPMT(0.1/12,1,36,8000)');
-    expect(Number(result)).toBeCloseTo(66.67, 1);
+    expect(Number(result)).toBeCloseTo(-66.67, 1);
+  });
+
+  it('should correctly evaluate IPMT function with negative pv', () => {
+    // Regression for wafflebase/wafflebase#216: IPMT sign was inverted.
+    // pv < 0 (you lent $300k) → period 1 interest is +1500 (cash received).
+    const result = evaluate('=IPMT(0.06/12,1,360,-300000)');
+    expect(Number(result)).toBeCloseTo(1500, 1);
   });
 
   it('should correctly evaluate PPMT function', () => {
-    // PPMT(0.1/12, 1, 36, 8000) — principal in period 1 on $8000 loan at 10%
+    // PPMT(0.1/12, 1, 36, 8000) — principal in period 1 on $8000 loan at 10%.
+    // PMT + (-IPMT_sign_corrected) should equal the principal cash flow.
     const result = evaluate('=PPMT(0.1/12,1,36,8000)');
-    expect(Number(result)).toBeCloseTo(-324.76, 0);
+    expect(Number(result)).toBeCloseTo(-191.47, 1);
+  });
+
+  it('should correctly evaluate PPMT function with negative pv', () => {
+    // Regression for wafflebase/wafflebase#216: PPMT was off by 2 * |IPMT|
+    // because the inverted IPMT sign was subtracted from PMT.
+    // PMT(0.06/12, 360, -300000) ≈ 1798.65, IPMT period 1 = 1500,
+    // so PPMT period 1 = 1798.65 - 1500 ≈ 298.65.
+    const result = evaluate('=PPMT(0.06/12,1,360,-300000)');
+    expect(Number(result)).toBeCloseTo(298.65, 1);
+  });
+
+  it('should preserve PMT = IPMT + PPMT identity', () => {
+    // The IPMT/PPMT split must always reconstruct PMT exactly. Test for both
+    // signs of pv so a future regression on either side surfaces here.
+    for (const pv of [8000, -300000]) {
+      const rate = pv > 0 ? 0.1 / 12 : 0.06 / 12;
+      const nper = pv > 0 ? 36 : 360;
+      const pmt = Number(evaluate(`=PMT(${rate},${nper},${pv})`));
+      const ipmt = Number(evaluate(`=IPMT(${rate},1,${nper},${pv})`));
+      const ppmt = Number(evaluate(`=PPMT(${rate},1,${nper},${pv})`));
+      expect(ipmt + ppmt).toBeCloseTo(pmt, 6);
+    }
   });
 
   it('should correctly evaluate SLN function', () => {


### PR DESCRIPTION
## Summary

Negates the periodic interest computed inside `ipmtFunc` and `ppmtFunc` so
IPMT/PPMT follow Excel's cash-flow sign convention.

- `packages/sheets/src/formula/functions-financial.ts`
  - `ipmtFunc`: return `-balance * rate` instead of `balance * rate`.
  - `ppmtFunc`: subtract `-balance * rate` from `pmt`, preserving the
    `PMT = IPMT + PPMT` identity. The type=1 / period=1 zero-interest
    special case still returns `0` (negating zero is still zero).
- `packages/sheets/test/formula/formula.test.ts`
  - Updated the two existing IPMT/PPMT unit tests, which had hard-coded the
    pre-fix (inverted) values.
  - Added regression tests for the issue's example
    (`IPMT(0.06/12, 1, 360, -300000) = 1500`,
    `PPMT(0.06/12, 1, 360, -300000) ≈ 298.65`).
  - Added an identity test that `IPMT + PPMT == PMT` for both signs of `pv`.

## Why

`=IPMT(0.06/12, 1, 360, -300000)` returns `-1500` today but should return
`+1500`: with `pv < 0` the present value represents cash paid out (a loan
*from* you), so the interest portion of each payment is cash flowing back
*to* you and is positive. The implementation was computing
`interest = balance * rate`, which carries the same sign as the outstanding
balance — i.e. an "accounting" sign rather than the cash-flow sign Excel
uses for `IPMT`, `PPMT`, and `PMT`.

The same inversion bleeds into `PPMT`, which computes `pmt - ipmt`. With
the wrong `ipmt`, the issue's case yields `1798.65 - (-1500) = 3298.65`
instead of `1798.65 - 1500 = 298.65`. Negating the internal `ipmt` value
fixes both functions with a single conceptual change and keeps the
`PMT = IPMT + PPMT` invariant.

The balance-amortization loop is left untouched: it uses the (signed)
`pmt` from `computePmt` plus the (signed) accounting interest, which
correctly walks the balance down regardless of the sign of `pv`. Only the
externally-returned interest is flipped.

## Linked Issues

Fixes #216

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): integration not touched (sheets formula
engine only); leaving the box for CI to confirm.

Locally:

- `pnpm verify:fast` — green.
- `pnpm sheets test` filtered to `IPMT|PPMT|preserve PMT` — 6 passed.

## Risk Assessment

- **User-facing risk:** Anyone who was depending on the previous
  (inverted) sign of `IPMT`/`PPMT` will see the sign flip. This is
  intentional — that behavior was the bug — but it is a behavior change
  for existing sheets that referenced these functions. `PMT` itself is
  unchanged.
- **Data/security risk:** None — pure computation in the formula engine,
  no I/O, persistence, or auth surface touched.
- **Rollback plan:** Single-commit revert; the change is two negations in
  `functions-financial.ts` plus the corresponding test updates.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): n/a — formula engine only.
- Follow-up work (if any): `cumipmtFunc`/`cumprincFunc` use the same
  `interest = balance * rate` accounting-sign convention internally, and
  their balance amortization is off as a result. Their existing tests only
  assert sign (`> 0` / `< 0`) so they still pass, but the actual
  cumulative magnitudes don't match Excel either. Intentionally kept out
  of this PR per the issue's "single minimal change" scope; happy to
  follow up in a separate PR if you'd like.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sign convention in financial payment formulas (IPMT, PPMT) for accurate interest and principal calculations.

* **Tests**
  * Expanded test coverage with new test cases and verification that payment components correctly reconstruct the total payment amount.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/219)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->