### PR TITLE
Tighten CONTRIBUTING and PR template against unread AI PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,13 @@
 
 Fixes #
 
+## Author checklist
+
+- [ ] I searched existing issues and PRs and confirmed this is not a duplicate.
+- [ ] I read every line of this diff and can explain why each change is necessary.
+- [ ] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
+- [ ] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.
+
 ## Verification
 
 CI automatically posts a verification summary comment on this PR with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,19 @@ and posts a summary as a PR comment.
 
 ## Before you start
 
-1. Search [open issues](https://github.com/wafflebase/wafflebase/issues)
-   and existing design docs to avoid duplicate work.
-2. For larger changes, open an issue or a discussion first so we can
+1. Search [open issues](https://github.com/wafflebase/wafflebase/issues),
+   open PRs, and existing design docs for related work. If a PR is
+   already open for the issue you wanted to tackle, leave a comment
+   there instead of opening a parallel PR — maintainers will close
+   later duplicates with a pointer to the earlier one.
+2. **Claim the issue before you start.** Leave a comment on the issue
+   saying you'll take it; a maintainer will assign you. If you go
+   silent for more than 3 days, we may un-assign so someone else can
+   pick it up. This keeps multiple contributors from racing on the
+   same fix.
+3. For larger changes, open an issue or a discussion first so we can
    align on scope before you spend time on code.
-3. By contributing, you agree your changes are licensed under the
+4. By contributing, you agree your changes are licensed under the
    project's [Apache License 2.0](LICENSE). A CLA is **not** required
    today; we may introduce one in the future.
 
@@ -153,6 +161,10 @@ generated from merged PRs at release time
   suggestion is wrong; agree explicitly when it is right. Performative
   agreement wastes everyone's time.
 - If `main` moved during review, rebase again before pushing fixes.
+- **Stalled reviews.** If actionable review feedback goes unaddressed
+  for more than 7 days, a maintainer may close the PR to keep the
+  queue clean. Reopen it whenever you address the feedback — there is
+  no penalty for re-opening, only for ignoring.
 
 ## AI agent–assisted contributions
 
@@ -163,8 +175,20 @@ agent-facing instructions in [`CLAUDE.md`](CLAUDE.md) (also exposed as
 
 Expectations:
 
-- A human contributor signs off on every PR, regardless of how the code
-  was produced. You are responsible for what you submit.
+- **You sign off on every line.** Before opening the PR, read the entire
+  diff. You should be able to answer "why X instead of Y" for each
+  change. "The AI wrote it that way" is not an acceptable response to
+  review feedback — fix it, or counter with a concrete technical
+  reason.
+- **Match existing conventions.** Coding agents tend to regress to
+  generic patterns and ignore project-local idioms. Before submitting,
+  compare your changes against nearby code in the same package and
+  reconcile mismatches. If a reviewer flags a convention break, fix it
+  rather than re-prompting the agent until it sounds confident.
+- **CI green ≠ done.** Run the change locally and exercise the affected
+  feature, especially for UI work. Tests are not your reviewer.
+- **Disclose AI assistance** in the PR body so reviewers know where to
+  focus extra attention.
 - Follow the same workflow as a human contributor: design doc → task
   plan → verify lanes → self review → PR.
 - Do not commit secrets, generated lockfile churn, or auto-formatter


### PR DESCRIPTION
## Summary

- Add an **Author checklist** to the PR template covering duplicate search, line-by-line understanding, convention match, and AI disclosure.
- Strengthen the **AI agent–assisted contributions** section in `CONTRIBUTING.md`: explicit sign-off, convention matching, "CI green ≠ done", and AI disclosure — with concrete language that "the AI wrote it that way" is not a valid response to review feedback.
- Document **issue claim cadence** (3-day un-assign on silent claims) and **stalled review cadence** (7-day PR close, free re-open).

## Why

Maintainers have seen recurring patterns that aren't well-served by the current docs:

- AI-generated PRs that regress to generic patterns and break package-local conventions.
- Contributors who don't engage with review comments, leaving PRs to rot.
- Multiple PRs racing on the same issue when one is already in flight.

The previous wording ("a human contributor signs off on every PR") is true but toothless — it didn't give maintainers anything concrete to point at when pushing back or closing a stalled PR. This change makes the expectations enforceable and the close/un-assign cadence predictable, so maintainer time isn't spent re-litigating norms case by case.

## Test plan

- [x] `pnpm verify:fast` green locally
- [x] Markdown renders correctly (Author checklist, numbered list renumbering in "Before you start", new bullets in AI section and Code review)
- [x] PR template renders as expected on this very PR (self-check after creation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added author checklist to pull request template with requirements for duplicate-issue verification, comprehensive diff review, code convention compliance confirmation, and tool usage disclosure
  * Enhanced contribution guidelines with detailed pre-submission verification steps, explicit code convention matching expectations, clarification that CI passing is insufficient, and stalled submission closure policies

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/221)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->