### PR TITLE
fix: support array literals in IRR and MIRR

### DIFF
--- a/packages/sheets/src/formula/functions-financial.ts
+++ b/packages/sheets/src/formula/functions-financial.ts
@@ -12,6 +12,40 @@ import {
 } from './functions-helpers';
 import { parseDate, formatDate } from './functions-date';
 
+function getCashFlowValues(
+  expr: ParseTree,
+  visit: (tree: ParseTree) => EvalNode,
+  grid?: Grid,
+): number[] | ErrNode {
+  const node = visit(expr);
+  if (node.t === 'err') return node;
+
+  if (node.t === 'ref' && grid) {
+    const values: number[] = [];
+    for (const ref of toSrefs([node.v])) {
+      const cell = grid.get(ref);
+      const value = cell ? Number(cell.v) : 0;
+      if (isNaN(value)) return ErrNode.VALUE;
+      values.push(value);
+    }
+    return values;
+  }
+
+  if (node.t === 'arr') {
+    const values: number[] = [];
+    for (const row of node.v) {
+      for (const cell of row) {
+        const valueNode = NumberArgs.map(cell, grid);
+        if (valueNode.t === 'err') return valueNode;
+        values.push(valueNode.v);
+      }
+    }
+    return values;
+  }
+
+  return ErrNode.VALUE;
+}
+
 /**
  * PMT(rate, nper, pv, [fv], [type]) — calculates the periodic payment for a loan.
  */
@@ -432,15 +466,8 @@ export function irrFunc(
   const exprs = args.expr();
   if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
 
-  const values: number[] = [];
-  const refsResult = getRefsFromExpression(exprs[0], visit, grid);
-  if (refsResult.t === 'err') return refsResult;
-  for (const ref of refsResult.v) {
-    const cell = grid!.get(ref);
-    const v = cell ? Number(cell.v) : 0;
-    if (isNaN(v)) return ErrNode.VALUE;
-    values.push(v);
-  }
+  const values = getCashFlowValues(exprs[0], visit, grid);
+  if (!Array.isArray(values)) return values;
 
   let guess = 0.1;
   if (exprs.length === 2) {
@@ -841,20 +868,12 @@ export function mirrFunc(
   const exprs = args.expr();
   if (exprs.length !== 3) return ErrNode.NA;
 
-  const valuesResult = getRefsFromExpression(exprs[0], visit, grid);
-  if (valuesResult.t === 'err') return valuesResult;
+  const values = getCashFlowValues(exprs[0], visit, grid);
+  if (!Array.isArray(values)) return values;
   const financeRate = NumberArgs.map(visit(exprs[1]), grid);
   if (financeRate.t === 'err') return financeRate;
   const reinvestRate = NumberArgs.map(visit(exprs[2]), grid);
   if (reinvestRate.t === 'err') return reinvestRate;
-
-  const values: number[] = [];
-  for (const ref of valuesResult.v) {
-    const cell = grid!.get(ref);
-    const v = cell ? Number(cell.v) : 0;
-    if (isNaN(v)) return ErrNode.VALUE;
-    values.push(v);
-  }
 
   const n = values.length;
   if (n < 2) return ErrNode.VALUE;

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -1775,6 +1775,11 @@ describe('Formula', () => {
     expect(Number(result)).toBeCloseTo(0.1634, 2);
   });
 
+  it('should evaluate IRR with array literal cash flows', () => {
+    const result = evaluate('=IRR({-50000,15000,20000,25000,30000})');
+    expect(Number(result)).toBeCloseTo(0.2489, 4);
+  });
+
   it('should correctly evaluate DB function', () => {
     // DB(1000000, 100000, 6, 1, 7)
     const result = evaluate('=DB(1000000,100000,6,1,7)');
@@ -2087,6 +2092,11 @@ describe('Formula', () => {
     grid.set('A4', { v: '7000' } as Cell);
     const result = evaluate('=MIRR(A1:A4,0.1,0.12)', grid);
     expect(Number(result)).toBeGreaterThan(0);
+  });
+
+  it('should evaluate MIRR with array literal cash flows', () => {
+    const result = evaluate('=MIRR({-50000,15000,20000,25000,30000},0.1,0.12)');
+    expect(Number(result)).toBeCloseTo(0.2014, 4);
   });
 
   it('should correctly evaluate DOLLARDE function', () => {


### PR DESCRIPTION
## Summary

Fixes `IRR` and `MIRR` so array literal cashflow arguments are handled the same way as range-based cashflows.

## Changes

- Add shared cashflow extraction for range and array literal inputs
- Use it in `IRR` and `MIRR`
- Add regression coverage for array literal cashflows

fixes #232 

## Testing

- `git diff --check`
- `npm exec pnpm@10.5.2 -- --filter @wafflebase/sheets exec vitest --run test/formula/formula.test.ts`
- `npm exec pnpm@10.5.2 -- --filter @wafflebase/sheets typecheck`
- `npm exec pnpm@10.5.2 -- --filter @wafflebase/sheets test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- IRR and MIRR financial functions now accept array literals as direct inputs for cash flow values. Users can specify flow data directly within formulas using array syntax (e.g., `={-50000,15000,20000,25000,30000}`) without requiring separate cell references, streamlining financial calculations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/223)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->