### PR TITLE
fix: support IRR and MIRR array literals

### DIFF
--- a/packages/sheets/src/formula/functions-financial.ts
+++ b/packages/sheets/src/formula/functions-financial.ts
@@ -432,15 +432,8 @@ export function irrFunc(
   const exprs = args.expr();
   if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
 
-  const values: number[] = [];
-  const refsResult = getRefsFromExpression(exprs[0], visit, grid);
-  if (refsResult.t === 'err') return refsResult;
-  for (const ref of refsResult.v) {
-    const cell = grid!.get(ref);
-    const v = cell ? Number(cell.v) : 0;
-    if (isNaN(v)) return ErrNode.VALUE;
-    values.push(v);
-  }
+  const values = collectCashFlowValues(exprs[0], visit, grid);
+  if (values.t === 'err') return values;
 
   let guess = 0.1;
   if (exprs.length === 2) {
@@ -454,10 +447,10 @@ export function irrFunc(
   for (let iter = 0; iter < 100; iter++) {
     let npv = 0;
     let dnpv = 0;
-    for (let i = 0; i < values.length; i++) {
+    for (let i = 0; i < values.v.length; i++) {
       const denom = Math.pow(1 + rate, i);
-      npv += values[i] / denom;
-      dnpv -= i * values[i] / Math.pow(1 + rate, i + 1);
+      npv += values.v[i] / denom;
+      dnpv -= i * values.v[i] / Math.pow(1 + rate, i + 1);
     }
     if (Math.abs(dnpv) < 1e-15) return ErrNode.VALUE;
     const newRate = rate - npv / dnpv;
@@ -841,22 +834,14 @@ export function mirrFunc(
   const exprs = args.expr();
   if (exprs.length !== 3) return ErrNode.NA;
 
-  const valuesResult = getRefsFromExpression(exprs[0], visit, grid);
-  if (valuesResult.t === 'err') return valuesResult;
+  const values = collectCashFlowValues(exprs[0], visit, grid);
+  if (values.t === 'err') return values;
   const financeRate = NumberArgs.map(visit(exprs[1]), grid);
   if (financeRate.t === 'err') return financeRate;
   const reinvestRate = NumberArgs.map(visit(exprs[2]), grid);
   if (reinvestRate.t === 'err') return reinvestRate;
 
-  const values: number[] = [];
-  for (const ref of valuesResult.v) {
-    const cell = grid!.get(ref);
-    const v = cell ? Number(cell.v) : 0;
-    if (isNaN(v)) return ErrNode.VALUE;
-    values.push(v);
-  }
-
-  const n = values.length;
+  const n = values.v.length;
   if (n < 2) return ErrNode.VALUE;
 
   // PV of negative cash flows (costs) discounted at finance rate
@@ -865,15 +850,61 @@ export function mirrFunc(
   let fvPos = 0;
 
   for (let i = 0; i < n; i++) {
-    if (values[i] < 0) {
-      pvNeg += values[i] / Math.pow(1 + financeRate.v, i);
+    if (values.v[i] < 0) {
+      pvNeg += values.v[i] / Math.pow(1 + financeRate.v, i);
     } else {
-      fvPos += values[i] * Math.pow(1 + reinvestRate.v, n - 1 - i);
+      fvPos += values.v[i] * Math.pow(1 + reinvestRate.v, n - 1 - i);
     }
   }
 
   if (pvNeg === 0) return ErrNode.DIV0;
   return { t: 'num', v: Math.pow(-fvPos / pvNeg, 1 / (n - 1)) - 1 };
+}
+
+function collectCashFlowValues(
+  expr: ParseTree,
+  visit: (tree: ParseTree) => EvalNode,
+  grid?: Grid,
+): { t: 'values'; v: number[] } | ErrNode {
+  const node = visit(expr);
+  if (node.t === 'err') return node;
+
+  const values: number[] = [];
+  if (node.t === 'arr') {
+    for (const row of node.v) {
+      for (const cell of row) {
+        const value = cashFlowNodeToNumber(cell);
+        if (value.t === 'err') return value;
+        values.push(value.v);
+      }
+    }
+    return { t: 'values', v: values };
+  }
+
+  if (node.t !== 'ref' || !grid) {
+    return ErrNode.VALUE;
+  }
+
+  for (const ref of toSrefs([node.v])) {
+    const value = cashFlowStringToNumber(grid.get(ref)?.v);
+    if (value.t === 'err') return value;
+    values.push(value.v);
+  }
+  return { t: 'values', v: values };
+}
+
+function cashFlowNodeToNumber(node: EvalNode): { t: 'num'; v: number } | ErrNode {
+  if (node.t === 'err') return node;
+  if (node.t === 'num') return node;
+  if (node.t === 'bool') return { t: 'num', v: node.v ? 1 : 0 };
+  if (node.t === 'str') return cashFlowStringToNumber(node.v);
+  if (node.t === 'empty') return { t: 'num', v: 0 };
+  return ErrNode.VALUE;
+}
+
+function cashFlowStringToNumber(value?: string): { t: 'num'; v: number } | ErrNode {
+  const num = Number(value ?? 0);
+  return isNaN(num) ? ErrNode.VALUE : { t: 'num', v: num };
 }
 
 /**

--- a/packages/sheets/src/formula/functions-financial.ts
+++ b/packages/sheets/src/formula/functions-financial.ts
@@ -861,6 +861,9 @@ export function mirrFunc(
   return { t: 'num', v: Math.pow(-fvPos / pvNeg, 1 / (n - 1)) - 1 };
 }
 
+/**
+ * Collects cash-flow inputs from either an evaluated array literal or a reference range.
+ */
 function collectCashFlowValues(
   expr: ParseTree,
   visit: (tree: ParseTree) => EvalNode,
@@ -893,6 +896,9 @@ function collectCashFlowValues(
   return { t: 'values', v: values };
 }
 
+/**
+ * Coerces array-literal cells using the same numeric rules as referenced cells.
+ */
 function cashFlowNodeToNumber(node: EvalNode): { t: 'num'; v: number } | ErrNode {
   if (node.t === 'err') return node;
   if (node.t === 'num') return node;
@@ -902,6 +908,9 @@ function cashFlowNodeToNumber(node: EvalNode): { t: 'num'; v: number } | ErrNode
   return ErrNode.VALUE;
 }
 
+/**
+ * Coerces a referenced cash-flow cell, treating blank and missing cells as zero.
+ */
 function cashFlowStringToNumber(value?: string): { t: 'num'; v: number } | ErrNode {
   const num = Number(value ?? 0);
   return isNaN(num) ? ErrNode.VALUE : { t: 'num', v: num };

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -1775,6 +1775,11 @@ describe('Formula', () => {
     expect(Number(result)).toBeCloseTo(0.1634, 2);
   });
 
+  it('should correctly evaluate IRR with array literals', () => {
+    const result = evaluate('=IRR({-50000,15000,20000,25000,30000})');
+    expect(Number(result)).toBeCloseTo(0.2489, 3);
+  });
+
   it('should correctly evaluate DB function', () => {
     // DB(1000000, 100000, 6, 1, 7)
     const result = evaluate('=DB(1000000,100000,6,1,7)');
@@ -2087,6 +2092,11 @@ describe('Formula', () => {
     grid.set('A4', { v: '7000' } as Cell);
     const result = evaluate('=MIRR(A1:A4,0.1,0.12)', grid);
     expect(Number(result)).toBeGreaterThan(0);
+  });
+
+  it('should correctly evaluate MIRR with array literals', () => {
+    const result = evaluate('=MIRR({-50000,15000,20000,25000,30000},0.1,0.12)');
+    expect(Number(result)).toBeCloseTo(0.2014, 3);
   });
 
   it('should correctly evaluate DOLLARDE function', () => {

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -1780,6 +1780,15 @@ describe('Formula', () => {
     expect(Number(result)).toBeCloseTo(0.2489, 3);
   });
 
+  it('should coerce IRR array literal cash-flow values consistently', () => {
+    expect(Number(evaluate('=IRR({"-10000","3000","4200","6800"})'))).toBeCloseTo(
+      0.1634,
+      2,
+    );
+    expect(evaluate('=IRR({"not-a-number",3000})')).toBe('#VALUE!');
+    expect(evaluate('=IRR(1)')).toBe('#VALUE!');
+  });
+
   it('should correctly evaluate DB function', () => {
     // DB(1000000, 100000, 6, 1, 7)
     const result = evaluate('=DB(1000000,100000,6,1,7)');
@@ -2097,6 +2106,21 @@ describe('Formula', () => {
   it('should correctly evaluate MIRR with array literals', () => {
     const result = evaluate('=MIRR({-50000,15000,20000,25000,30000},0.1,0.12)');
     expect(Number(result)).toBeCloseTo(0.2014, 3);
+  });
+
+  it('should coerce MIRR array literal and range cash-flow values consistently', () => {
+    expect(Number(evaluate('=MIRR({-10000,"5000",TRUE},0.1,0.12)'))).toBeCloseTo(
+      -0.2516,
+      3,
+    );
+    expect(evaluate('=MIRR({1000,2000},0.1,0.12)')).toBe('#DIV/0!');
+    expect(evaluate('=MIRR({-1000},0.1,0.12)')).toBe('#VALUE!');
+
+    const grid: Grid = new Map<string, Cell>();
+    grid.set('A1', { v: '-10000' } as Cell);
+    grid.set('A3', { v: '12000' } as Cell);
+    const result = evaluate('=MIRR(A1:A3,0.1,0.12)', grid);
+    expect(Number(result)).toBeCloseTo(0.0954, 3);
   });
 
   it('should correctly evaluate DOLLARDE function', () => {


### PR DESCRIPTION
## Summary
- allow `IRR` and `MIRR` to read cash flows from array literals as well as cell ranges
- share cash-flow coercion for range and array inputs while preserving `#VALUE!` on non-numeric values
- add regression coverage for `IRR({ ... })`, `MIRR({ ... }, finance_rate, reinvest_rate)`, numeric-string cash flows, missing range cells, and invalid/no-negative cash-flow cases
- document the shared cash-flow helpers to reduce review noise around docstring coverage

Fixes #217

## Verification
- `pnpm --filter @wafflebase/sheets test -- test/formula/formula.test.ts` (488 tests passed)
- `pnpm --filter @wafflebase/sheets typecheck`
- `pnpm --filter @wafflebase/sheets test` (58 files / 1267 tests passed, prior full run before extra coverage)
- `git diff --check -- packages/sheets/src/formula/functions-financial.ts packages/sheets/test/formula/formula.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `IRR` and `MIRR` financial functions to better handle array literal inputs and error propagation.

* **Tests**
  * Added test coverage for `IRR` and `MIRR` functions with array literal cash flow inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/232)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->