### PR TITLE
Fix OFFSET height and width handling

### DIFF
--- a/packages/sheets/src/formula/functions-lookup.ts
+++ b/packages/sheets/src/formula/functions-lookup.ts
@@ -10,6 +10,7 @@ import {
   parseRange,
   parseRef,
   toColumnLabel,
+  toSrng,
 } from '../model/core/coordinates';
 import {
   toStr,
@@ -716,8 +717,25 @@ export function offsetFunc(
     return ErrNode.REF;
   }
 
-  // For single cell OFFSET (no height/width or 1x1)
+  const heightNode = exprs[3] ? NumberArgs.map(visit(exprs[3]), grid) : { t: 'num' as const, v: 1 };
+  if (heightNode.t === 'err') return heightNode;
+  const widthNode = exprs[4] ? NumberArgs.map(visit(exprs[4]), grid) : { t: 'num' as const, v: 1 };
+  if (widthNode.t === 'err') return widthNode;
+
+  const height = Math.trunc(heightNode.v);
+  const width = Math.trunc(widthNode.v);
+  if (height < 1 || width < 1) {
+    return ErrNode.REF;
+  }
+
+  const endRow = newRow + height - 1;
+  const endCol = newCol + width - 1;
   const newRef = `${toColumnLabel(newCol)}${newRow}`;
+  const endRef = `${toColumnLabel(endCol)}${endRow}`;
+  if (height > 1 || width > 1) {
+    return { t: 'ref', v: toSrng([parseRef(newRef), parseRef(endRef)]) };
+  }
+
   const cellVal = grid.get(newRef)?.v || '';
   const num = Number(cellVal);
   if (cellVal !== '' && !isNaN(num)) {

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -1586,6 +1586,10 @@ describe('Formula', () => {
     expect(evaluate('=OFFSET(A1,1,1)', grid)).toBe('40');
     // OFFSET(A1, 0, 1) = B1 = 20
     expect(evaluate('=OFFSET(A1,0,1)', grid)).toBe('20');
+    expect(evaluate('=SUM(OFFSET(A1,0,0,2,1))', grid)).toBe('40');
+    expect(evaluate('=SUM(OFFSET(A1,0,0,2,2))', grid)).toBe('100');
+    expect(evaluate('=OFFSET(A1,-1,0)', grid)).toBe('#REF!');
+    expect(evaluate('=OFFSET(A1,0,0,0,1)', grid)).toBe('#REF!');
   });
 
   it('should correctly evaluate ISEVEN and ISODD functions', () => {


### PR DESCRIPTION
## Summary
- make `OFFSET` return a range when height/width are provided
- return `#REF!` for non-positive height/width
- add regression coverage for `SUM(OFFSET(...))` ranges

Fixes #213

## Verification
- `pnpm sheets test -- formula.test.ts --runInBand`
- `pnpm sheets typecheck`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the OFFSET formula to properly support height and width parameters, enabling it to return range references for multi-cell selections.
  * Fixed OFFSET to correctly handle invalid dimensions and out-of-bounds references by returning appropriate error values.

* **Tests**
  * Added test coverage for OFFSET function behavior with various parameter combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/234)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->