### PR TITLE
Keep slide canvas outline visible across themes and viewports

### DIFF
--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -207,6 +207,11 @@ export function SlidesView({ onEditorReady, onStoreReady }: SlidesViewProps) {
     canvas.style.width = `${hostW}px`;
     canvas.style.height = `${hostH}px`;
     canvas.style.background = "#fff";
+    // 1px ring so the slide edge stays visible when the slide background
+    // (theme-driven, white by default) matches the surrounding inset's
+    // bg-background. Without this, the slide blends into the chrome
+    // entirely below `md:` (where `SidebarInset` drops its own card frame).
+    canvas.style.boxShadow = "0 0 0 1px var(--border)";
     canvasWrap.appendChild(canvas);
 
     const overlay = document.createElement("div");

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -207,11 +207,17 @@ export function SlidesView({ onEditorReady, onStoreReady }: SlidesViewProps) {
     canvas.style.width = `${hostW}px`;
     canvas.style.height = `${hostH}px`;
     canvas.style.background = "#fff";
-    // 1px ring so the slide edge stays visible when the slide background
-    // (theme-driven, white by default) matches the surrounding inset's
-    // bg-background. Without this, the slide blends into the chrome
-    // entirely below `md:` (where `SidebarInset` drops its own card frame).
-    canvas.style.boxShadow = "0 0 0 1px var(--border)";
+    // Slide elevation: 1px hairline + soft drop shadow so the slide edge
+    // stays visible when its background matches the surrounding inset's
+    // `bg-background` — happens in two pairings: default-light (white slide
+    // on white bg) and dark mode + Simple Dark (dark slide on dark bg).
+    // Hairline is mixed from `--foreground` so it inverts with the theme
+    // (dark on light, light on dark) and reads on both. The drop shadow
+    // is a black rgba — it adds depth in light mode and quietly fades in
+    // dark mode where the hairline carries the edge.
+    canvas.style.boxShadow =
+      "0 0 0 1px color-mix(in srgb, var(--foreground) 25%, transparent)," +
+      " 0 4px 12px rgba(0, 0, 0, 0.08)";
     canvasWrap.appendChild(canvas);
 
     const overlay = document.createElement("div");

--- a/packages/slides/src/view/canvas/slide-renderer.test.ts
+++ b/packages/slides/src/view/canvas/slide-renderer.test.ts
@@ -43,24 +43,25 @@ function makeRenderer(): { renderer: SlideRenderer; ctx: ReturnType<typeof creat
 }
 
 describe('SlideRenderer.render', () => {
-  it('clears the canvas, fills the background, and is a no-op on the second call when nothing is dirty', () => {
+  it('fills the background once and is a no-op on the second call when nothing is dirty', () => {
     const { renderer, ctx } = makeRenderer();
     renderer.render(blankSlide(), DOC);
-    expect(ctx.clearRect).toHaveBeenCalledTimes(1);
-    expect(ctx.fillRect).toHaveBeenCalled(); // background fill
+    // The full-canvas background fillRect doubles as the clear step; we
+    // no longer call clearRect because fillRect overwrites everything.
+    expect(ctx.fillRect).toHaveBeenCalledTimes(1);
 
-    const before = ctx.clearRect.mock.calls.length;
+    const before = ctx.fillRect.mock.calls.length;
     renderer.render(blankSlide(), DOC);
-    expect(ctx.clearRect.mock.calls.length).toBe(before); // no second clear
+    expect(ctx.fillRect.mock.calls.length).toBe(before); // no second paint
   });
 
   it('repaints after markDirty()', () => {
     const { renderer, ctx } = makeRenderer();
     renderer.render(blankSlide(), DOC);
-    const before = ctx.clearRect.mock.calls.length;
+    const before = ctx.fillRect.mock.calls.length;
     renderer.markDirty();
     renderer.render(blankSlide(), DOC);
-    expect(ctx.clearRect.mock.calls.length).toBe(before + 1);
+    expect(ctx.fillRect.mock.calls.length).toBe(before + 1);
   });
 
   it('iterates elements in array order (z-order) — last element paints on top', () => {
@@ -117,9 +118,9 @@ describe('SlideRenderer.render', () => {
   it('forceRender paints even when not dirty', () => {
     const { renderer, ctx } = makeRenderer();
     renderer.render(blankSlide(), DOC);        // dirty → false
-    const before = ctx.clearRect.mock.calls.length;
+    const before = ctx.fillRect.mock.calls.length;
     renderer.forceRender(blankSlide(), DOC);
-    expect(ctx.clearRect.mock.calls.length).toBe(before + 1);
+    expect(ctx.fillRect.mock.calls.length).toBe(before + 1);
   });
 
   it('resolves a role-bound background through the theme', () => {

--- a/packages/slides/src/view/canvas/slide-renderer.ts
+++ b/packages/slides/src/view/canvas/slide-renderer.ts
@@ -95,18 +95,28 @@ export function drawSlide(
   const scaleY = (hostHeight / SLIDE_HEIGHT) * dpr;
   const scale = Math.min(scaleX, scaleY);
 
-  // Reset to identity, clear, then re-establish the world scale so
-  // the content paints at the correct host pixel size regardless of
-  // any leftover transforms from a previous render.
+  // Reset to identity, paint the slide background across the FULL canvas
+  // (not just the logical 1920×1080 region), then re-establish the world
+  // scale so element content paints at the correct host pixel size.
+  //
+  // Filling the full canvas — rather than `fillRect(0, 0, SLIDE_W, SLIDE_H)`
+  // after the scale transform — hides 1–2 px aspect-ratio rounding gaps on
+  // the right/bottom edges. Without this, host dimensions whose ratio drifts
+  // from SLIDE_WIDTH:SLIDE_HEIGHT (rounding from `computeFitSize` →
+  // `Math.round`) leave a transparent strip that reveals the canvas's CSS
+  // `background` underneath. That strip reads white in light mode and reads
+  // as a flashing white edge in dark mode + Simple Dark, where the slide
+  // background is `#202124` but the canvas backdrop stays `#fff`.
   ctx.setTransform(1, 0, 0, 1, 0, 0);
-  ctx.clearRect(0, 0, hostWidth * dpr, hostHeight * dpr);
+  ctx.fillStyle = resolveColor(slide.background.fill, theme);
+  ctx.fillRect(0, 0, hostWidth * dpr, hostHeight * dpr);
   ctx.scale(scale, scale);
 
-  // Background fill — image-fill backgrounds are v2.
-  ctx.fillStyle = resolveColor(slide.background.fill, theme);
-  ctx.fillRect(0, 0, SLIDE_WIDTH, SLIDE_HEIGHT);
-
-  // Iterate elements in array order = z-order, last is front.
+  // Iterate elements in array order = z-order, last is front. Image-fill
+  // backgrounds are v2 — when they land, paint the image inside the
+  // logical 1920×1080 region *after* this full-canvas color fill so the
+  // image still represents the slide and the surrounding strip stays
+  // background-color.
   for (const element of slide.elements) {
     drawElement(ctx, element, doc, theme, onAssetLoad);
   }

--- a/packages/slides/src/view/canvas/thumbnail.test.ts
+++ b/packages/slides/src/view/canvas/thumbnail.test.ts
@@ -39,7 +39,6 @@ describe('renderThumbnail', () => {
   it('paints the slide at the requested host size', () => {
     const ctx = createCtxSpy();
     renderThumbnail(asCtx(ctx), blankSlide('s1'), DOC, { hostWidth: 192, hostHeight: 108, dpr: 1 });
-    expect(ctx.clearRect).toHaveBeenCalled();
     expect(ctx.fillRect).toHaveBeenCalled();
     // Scale = 192 / 1920 = 0.1
     expect(ctx.scale).toHaveBeenCalledWith(0.1, 0.1);


### PR DESCRIPTION
## Summary

- The slide canvas had no border or shadow of its own; it relied on `SidebarInset`'s `md:` card chrome for visual separation, so on `< md` viewports the slide blended into the white inset and disappeared entirely.
- The same blending showed up in **dark mode + Simple Dark**, plus a viewport-dependent **white edge on the right/bottom** that flickered as the window resized. Root cause: `drawSlide` painted the slide background only across the logical 1920×1080 region, and `Math.round` on `hostWidth`/`hostHeight` left a 1–2 px aspect-ratio gap. That gap revealed the canvas's hardcoded `background: #fff`, which read as a white strip on dark slides.
- Add a theme-aware hairline (`color-mix(in srgb, var(--foreground) 25%, transparent)`) plus a soft drop shadow on the canvas, and fill the renderer's background across the full canvas in identity transform so the rounding gap inherits the slide color.

## Test plan

- [ ] Light mode + Simple Light: dark hairline + soft shadow visible against the inset
- [ ] Light mode + Simple Dark: dark slide visible, no white strip on right/bottom
- [ ] Dark mode + Simple Light: white slide visible against dark inset
- [ ] Dark mode + Simple Dark: light hairline reads on dark slide; no white edge at any viewport size
- [ ] Resize across the `md:` (768px) breakpoint — outline stays stable
- [x] `pnpm verify:fast` green (764 frontend + 692 slides tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)