### PR TITLE
Support TEXT digit placeholders

### DIFF
--- a/packages/sheets/src/formula/functions-text.ts
+++ b/packages/sheets/src/formula/functions-text.ts
@@ -718,32 +718,81 @@ export function textFunc(
     return fmt;
   }
 
-  const format = fmt.v;
-  const value = num.v;
+  return { t: 'str', v: formatNumberWithPlaceholders(num.v, fmt.v) };
+}
 
-  // Percentage formats
-  if (format.endsWith('%')) {
-    const decimalPart = format.slice(0, -1);
-    const decimals = (decimalPart.split('.')[1] || '').length;
-    return { t: 'str', v: (value * 100).toFixed(decimals) + '%' };
+function formatNumberWithPlaceholders(value: number, format: string): string {
+  const isPercent = format.endsWith('%');
+  const numericFormat = isPercent ? format.slice(0, -1) : format;
+  const scaledValue = isPercent ? value * 100 : value;
+  const [integerFormat, decimalFormat = ''] = numericFormat.split('.');
+  const decimalPlaceholders = decimalFormat.match(/[0#]/g)?.length ?? 0;
+  const roundingFactor = 10 ** decimalPlaceholders;
+  const rounded = (
+    Math.round(Math.abs(scaledValue) * roundingFactor) / roundingFactor
+  ).toFixed(decimalPlaceholders);
+  const [roundedInteger, roundedDecimal = ''] = rounded.split('.');
+  const integerResult = formatIntegerPlaceholders(roundedInteger, integerFormat);
+  const decimalResult = formatDecimalPlaceholders(roundedDecimal, decimalFormat);
+  const sign = scaledValue < 0 ? '-' : '';
+
+  return `${sign}${integerResult}${decimalResult}${isPercent ? '%' : ''}`;
+}
+
+function formatIntegerPlaceholders(digits: string, format: string): string {
+  const firstPlaceholder = format.search(/[0#]/);
+  const lastPlaceholder = Math.max(format.lastIndexOf('0'), format.lastIndexOf('#'));
+  if (firstPlaceholder === -1 || lastPlaceholder === -1) {
+    return digits;
   }
 
-  // Comma-separated formats
-  if (format.includes(',')) {
-    const decimals = (format.split('.')[1] || '').replace(/[^0#]/g, '').length;
-    const parts = value.toFixed(decimals).split('.');
-    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    return { t: 'str', v: parts.join('.') };
+  const prefix = format.slice(0, firstPlaceholder).replace(/,/g, '');
+  const suffix = format.slice(lastPlaceholder + 1).replace(/,/g, '');
+  const placeholderSection = format.slice(firstPlaceholder, lastPlaceholder + 1);
+  const hasGrouping = placeholderSection.includes(',');
+  const placeholders = placeholderSection.replace(/[^0#]/g, '');
+  const requiredDigits = [...placeholders].filter((ch) => ch === '0').length;
+  const paddedDigits = digits.padStart(requiredDigits, '0');
+  const formattedDigits = hasGrouping
+    ? paddedDigits.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    : paddedDigits;
+
+  return `${prefix}${formattedDigits}${suffix}`;
+}
+
+function formatDecimalPlaceholders(digits: string, format: string): string {
+  if (!format) {
+    return '';
   }
 
-  // Fixed decimal formats
-  if (format.includes('.')) {
-    const decimals = (format.split('.')[1] || '').length;
-    return { t: 'str', v: value.toFixed(decimals) };
+  const chars: string[] = [];
+  let digitIndex = 0;
+
+  for (const ch of format) {
+    if (ch !== '0' && ch !== '#') {
+      chars.push(ch);
+      continue;
+    }
+
+    const digit = digits[digitIndex++] ?? '0';
+    if (ch === '0' || digit !== '0' || hasNonZeroDigit(digits, digitIndex)) {
+      chars.push(digit);
+    }
   }
 
-  // Integer format
-  return { t: 'str', v: value.toFixed(0) };
+  while (chars.length > 0 && chars[chars.length - 1] === '0') {
+    const formatIndex = chars.length - 1;
+    if (format[formatIndex] === '0') {
+      break;
+    }
+    chars.pop();
+  }
+
+  return chars.length === 0 ? '' : `.${chars.join('')}`;
+}
+
+function hasNonZeroDigit(digits: string, start: number): boolean {
+  return [...digits.slice(start)].some((digit) => digit !== '0');
 }
 
 /**

--- a/packages/sheets/src/formula/functions-text.ts
+++ b/packages/sheets/src/formula/functions-text.ts
@@ -754,10 +754,34 @@ function formatIntegerPlaceholders(digits: string, format: string): string {
   const requiredDigits = [...placeholders].filter((ch) => ch === '0').length;
   const paddedDigits = digits.padStart(requiredDigits, '0');
   const formattedDigits = hasGrouping
-    ? paddedDigits.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    ? applyIntegerGrouping(paddedDigits, placeholderSection)
     : paddedDigits;
 
   return `${prefix}${formattedDigits}${suffix}`;
+}
+
+function applyIntegerGrouping(digits: string, placeholderSection: string): string {
+  const groupSizes = placeholderSection
+    .split(',')
+    .map((token) => token.replace(/[^0#]/g, '').length)
+    .filter((size) => size > 0);
+
+  if (groupSizes.length <= 1) {
+    return digits;
+  }
+
+  const groups: string[] = [];
+  let remainingDigits = digits;
+  let groupIndex = groupSizes.length - 1;
+
+  while (remainingDigits.length > 0) {
+    const groupSize = groupSizes[Math.max(groupIndex, 0)];
+    groups.unshift(remainingDigits.slice(-groupSize));
+    remainingDigits = remainingDigits.slice(0, -groupSize);
+    groupIndex--;
+  }
+
+  return groups.join(',');
 }
 
 function formatDecimalPlaceholders(digits: string, format: string): string {
@@ -767,6 +791,7 @@ function formatDecimalPlaceholders(digits: string, format: string): string {
 
   const chars: string[] = [];
   let digitIndex = 0;
+  let emittedDigit = false;
 
   for (const ch of format) {
     if (ch !== '0' && ch !== '#') {
@@ -777,6 +802,7 @@ function formatDecimalPlaceholders(digits: string, format: string): string {
     const digit = digits[digitIndex++] ?? '0';
     if (ch === '0' || digit !== '0' || hasNonZeroDigit(digits, digitIndex)) {
       chars.push(digit);
+      emittedDigit = true;
     }
   }
 
@@ -788,7 +814,11 @@ function formatDecimalPlaceholders(digits: string, format: string): string {
     chars.pop();
   }
 
-  return chars.length === 0 ? '' : `.${chars.join('')}`;
+  if (chars.length === 0) {
+    return '';
+  }
+
+  return emittedDigit ? `.${chars.join('')}` : chars.join('');
 }
 
 function hasNonZeroDigit(digits: string, start: number): boolean {

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -1024,6 +1024,9 @@ describe('Formula', () => {
     expect(evaluate('=TEXT(12.3,"###.##")')).toBe('12.3');
     expect(evaluate('=TEXT(12.3,"$###.##")')).toBe('$12.3');
     expect(evaluate('=TEXT(1234567,"000,000,000")')).toBe('001,234,567');
+    expect(evaluate('=TEXT(1234567,"00,00,000")')).toBe('12,34,567');
+    expect(evaluate('=TEXT(12,"0.#kg")')).toBe('12kg');
+    expect(evaluate('=TEXT(12.3,"0.#kg")')).toBe('12.3kg');
     expect(evaluate('=TEXT(12.305,"00.00")')).toBe('12.31');
   });
 

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -1017,6 +1017,14 @@ describe('Formula', () => {
     expect(evaluate('=TEXT(0.75,"0%")')).toBe('75%');
     expect(evaluate('=TEXT(3.14159,"0.00")')).toBe('3.14');
     expect(evaluate('=TEXT(42,"0")')).toBe('42');
+    expect(evaluate('=TEXT(42,"00000")')).toBe('00042');
+    expect(evaluate('=TEXT(-42,"00000")')).toBe('-00042');
+    expect(evaluate('=TEXT(12.3,"000.00")')).toBe('012.30');
+    expect(evaluate('=TEXT(42,"##000")')).toBe('042');
+    expect(evaluate('=TEXT(12.3,"###.##")')).toBe('12.3');
+    expect(evaluate('=TEXT(12.3,"$###.##")')).toBe('$12.3');
+    expect(evaluate('=TEXT(1234567,"000,000,000")')).toBe('001,234,567');
+    expect(evaluate('=TEXT(12.305,"00.00")')).toBe('12.31');
   });
 
   it('should correctly evaluate CHAR function', () => {


### PR DESCRIPTION
## What?

Implements the `TEXT()` digit-placeholder behavior requested in #195 for numeric formats using `0` and `#`.

The formatter now pads required integer placeholders, preserves optional `#` behavior for fractional trailing zeroes, supports grouped integer placeholders, keeps prefix/suffix text such as currency symbols, and applies the same path to percent formats. I also added coverage for the repro cases around zero-padded integers, mixed `#`/`0`, grouped masks, optional decimals, and rounding.

## Why?

Previously `TEXT(42,"00000")` returned `"42"` instead of `"00042"`, and optional masks such as `"###.##"` kept forced trailing zeroes. These cases are common spreadsheet formatting patterns and are called out directly in the issue.

Verification:
- `pnpm --filter @wafflebase/sheets test -- formula.test.ts`
- `pnpm --filter @wafflebase/sheets typecheck`
- `git diff --check`

fixes #195 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced TEXT function formatting with improved support for zero-padding, thousands grouping, decimal precision trimming, and currency prefixes.

* **Tests**
  * Expanded test coverage for TEXT function formatting patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/236)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->