### PR TITLE
Add Google Slides parity keyboard shortcuts

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -63,6 +63,7 @@ Presentation engine — slides, free-position elements, presentation mode, colla
 | [slides-themes-layouts-import.md](slides/slides-themes-layouts-import.md)             | Themes (4-tier) + 11 Google-Slides-parity layouts + PPTX best-effort import; 3-PR rollout plan      |
 | [slides-layout-change.md](slides/slides-layout-change.md)                             | Layout change UI — placeholder identity tracking, type-first matching, split-button + context menu  |
 | [slides-shapes.md](slides/slides-shapes.md)                                           | Shape library — 55 OOXML-aligned `ShapeKind` values, path-builder registry, `data.adjustments` storage, yellow-diamond drag handles, picker UX, phased roadmap to ~100-shape GS parity |
+| [slides-keyboard-shortcuts.md](slides/slides-keyboard-shortcuts.md)                   | Slides keyboard shortcuts — Google Slides parity pass, single catalog source, help modal, link popover wiring                                                                          |
 
 ## Common
 

--- a/docs/design/slides/slides-keyboard-shortcuts.md
+++ b/docs/design/slides/slides-keyboard-shortcuts.md
@@ -1,6 +1,6 @@
 ---
 title: slides-keyboard-shortcuts
-target-version: 0.2.0
+target-version: 0.4.1
 ---
 
 # Slides Keyboard Shortcuts — Google Slides Parity
@@ -177,75 +177,37 @@ Action: clear selection, `requestRender()`. Pure UI; no store write.
 
 ### Link popover wiring
 
-1. `docs/src/view/text-box-editor.ts` — add `onLinkRequest?: () =>
-   void` to `TextBoxEditorOptions`, set
-   `textEditor.onLinkRequest = opts.onLinkRequest` after construction.
-2. `slides/src/view/editor/text-box-editor.ts` — forward
-   `MountSlidesTextBoxOptions.onLinkRequest` to `initializeTextBox`.
-3. `SlidesEditor.enterEditMode` passes
-   `options.onLinkRequest` down to `mountSlidesTextBox`.
-4. Frontend (`slides-detail.tsx`) wires `onLinkRequest` to a small
-   floating input bound to the current text-box selection range.
-   (Same shape as the docs link popover — defer richer UX.)
-
-For v1, the popover is a minimal element ("URL: [____] [OK] [Cancel]")
-positioned near the caret. Without selection it inserts a new link;
-with a selection it wraps the run. Implementation reuses
-`getStyleAtCursor` / `toggleStyle` already on the text-editor.
+`Cmd+K` flows: docs `TextEditor.onLinkRequest` → docs `text-box-editor`
+forward → slides `text-box-editor` forward →
+`SlidesEditorOptions.onLinkRequest` → host shell. The slides side
+plumbs the callback through without owning the popover UI; a real
+popover requires extending `TextBoxEditorAPI` with `insertLink(url)`
+/ `getLinkAtCursor()` so the host can mutate the active text-box.
 
 ### Help modal
 
-`frontend/src/app/slides/slides-shortcuts-help.tsx`:
-
-- Centered, max-width modal with categories laid out vertically.
-- Closes on `Esc`, click outside, or the `×` button.
-- Content sourced from `SHORTCUTS` (imported from
-  `@wafflebase/slides`).
-- No search / filter in v1; the list is short enough to scan.
-
-The modal is the only new visible UI surface in this PR.
-
-### Testing
-
-Two layers:
-
-- **Unit (keyboard.test.ts).** One test per new rule, asserting:
-  - The keyRule mutation observed (selection state, store contents, or
-    callback invocation via `vi.fn()`).
-  - The editable-target gate (where applicable) — focus a `<textarea>`,
-    dispatch the key, assert no-op.
-  - Platform parity for `Mod` — exercise both `metaKey` and `ctrlKey`.
-
-- **Catalog test.** `shortcuts-catalog.test.ts` asserts catalog
-  invariants (every entry has non-empty keys, every category is one
-  of the expected values).
-
-The frontend wiring is exercised by existing slides smoke tests; the
-new help modal gets a focused jsdom test (open via callback, close via
-Esc).
+The host shell renders the modal from the `SHORTCUTS` catalog. It is
+the only path users have to discover the parity shortcuts, so its
+content must remain in lock-step with the catalog — see the
+"Catalog drift" risk below.
 
 ## Risks and Mitigation
 
 - **Catalog drift.** Catalog and keyRules are separate arrays. If a
   rule is added without a catalog entry, the help modal silently
-  omits it. Mitigation: include a developer-facing TODO comment in
-  the catalog and document the dual-edit in `slides.md`'s
-  Interactions table.
+  omits it. The catalog test asserts surface invariants (non-empty
+  keys, valid category), which catches typos but not deletions. The
+  dual-edit convention is documented in the `shortcuts-catalog.ts`
+  head comment.
 
 - **Tab-cycle ordering surprises.** Tab uses element-array order
   (current z-order). When the user reorders elements, Tab follows.
-  This matches Google Slides. Document in the design.
+  This matches Google Slides.
 
 - **Enter ambiguity.** Enter doubles as "enter edit mode on selected
   text element" and "submit dialogs / form inputs". The
   `isEditableTarget` gate handles form inputs; the rule no-ops when
   the selection isn't exactly one text element.
-
-- **Page Up / Page Down conflict with text scrolling.** Slides has
-  no scrolling content surface (slide thumbnails have their own
-  scroll, but its container isn't a textarea/input). The rule
-  invokes the editable-target gate so focused textareas keep their
-  default behaviour.
 
 - **Present-mode side effects.** `Cmd+Enter` while editing a text-box
   routes through the docs text-editor first, which binds it to
@@ -253,21 +215,5 @@ Esc).
   filtered at render but persists in the in-memory store and would
   be committed to the slide on blur. Mitigation: the present-mode
   keyRule respects the editable-target gate, so Cmd+Enter inside a
-  text-box defers to the docs handler. Users press Esc first to
-  exit text edit, then Cmd+Enter to present. A cleaner fix (a docs
+  text-box defers to the docs handler. A cleaner fix (a docs
   text-box `disablePageBreak` option) is tracked as a follow-up.
-
-- **Catalog drift.** The shortcuts catalog and the keyRules array
-  are parallel declarations. If a rule lands without a catalog
-  entry, the help modal silently omits it. The catalog test asserts
-  surface invariants (every entry has non-empty keys, every category
-  is one of the expected values), which catches typos but not
-  deletions. Dual-edit convention is called out in
-  `shortcuts-catalog.ts` head comment.
-
-- **Categories expanded beyond original list.** The implementation
-  added `'Z-order'` and `'Nudge'` categories to the
-  `ShortcutCategory` union (originally `'Selection' | 'Slide' |
-  'Clipboard' | 'Format' | 'Present' | 'Help'`). This was a
-  pragmatic split to keep the help modal scannable; the catalog
-  is the source of truth.

--- a/docs/design/slides/slides-keyboard-shortcuts.md
+++ b/docs/design/slides/slides-keyboard-shortcuts.md
@@ -1,0 +1,234 @@
+---
+title: slides-keyboard-shortcuts
+target-version: 0.2.0
+---
+
+# Slides Keyboard Shortcuts — Google Slides Parity
+
+## Summary
+
+Extend the slides editor's keyboard support to cover the shortcuts a
+Google Slides user reaches for on the first day. The existing
+`view/editor/interactions/keyboard.ts` keyRule system already handles
+undo/redo, delete, nudge, clipboard, duplicate, and z-order. This pass
+adds selection, slide navigation, presentation start, link request,
+and a discoverable shortcuts-help modal.
+
+### Goals
+
+- Add the Google Slides parity shortcuts listed in the table below.
+- Keep the existing keyRule pattern: a single ordered array, optional
+  `isEditableTarget` gates, no global wrapper layer.
+- Single source of truth for shortcut metadata so the help modal and
+  documentation stay in sync with the runtime.
+
+### Non-Goals
+
+- **Group / Ungroup** (`Cmd+G` / `Cmd+Shift+G`). No group concept exists
+  in the slides model yet; introducing one is a separate design
+  involving model, CRDT, rendering, and selection-box changes.
+- **Find / replace** (`Cmd+F` / `Cmd+Shift+H`). Slides find/replace
+  spans every slide and needs its own UX (thumbnail jump, match
+  highlight, sequential search). Out of scope here.
+- **Customizing shortcuts.** The catalog is fixed in v1.
+
+## Proposal Details
+
+### Scope
+
+| Category | Shortcut | Behavior |
+|---|---|---|
+| Selection | `Cmd/Ctrl+A` | Select all elements on the current slide. |
+| Selection | `Esc` | Exit text edit → clear selection → otherwise no-op. |
+| Selection | `Tab` / `Shift+Tab` | Cycle next/previous element on the current slide. With nothing selected, selects the bottom-most (Tab) or top-most (Shift+Tab) element. |
+| Selection | `F2` / `Enter` | When exactly one text element is selected, enter text-edit mode. |
+| Slide | `Cmd/Ctrl+M` | Add a new slide after the current, using the current slide's layout, and switch to it. |
+| Slide | `Cmd/Ctrl+Shift+D` | Duplicate the current slide explicitly. (`Cmd+D` continues to duplicate selected elements; only falls back to slide-duplicate when nothing is selected.) |
+| Slide | `Page Up` / `Page Down` | Switch to previous / next slide. Boundary-safe. |
+| Present | `Cmd/Ctrl+Enter` | Start presentation from the current slide (via callback). |
+| Present | `Cmd/Ctrl+Shift+Enter` | Start presentation from the first slide. |
+| Clipboard | `Cmd/Ctrl+Shift+V` | While not editing text: same as `Cmd+V`. While editing text: handled by docs text-editor (plain-text paste). |
+| Text-box | `Cmd/Ctrl+K` | Open link insert popover (callback). Only fires while a text-box is in edit mode — docs `text-editor.ts` already binds the key; slides plumbs the callback through `text-box-editor.ts`. |
+| Discoverability | `Cmd/Ctrl+/` | Open the shortcuts-help modal (callback). Fires even while editing text. |
+
+### Architecture
+
+**Layer split:**
+
+| Concern | Owner |
+|---|---|
+| Selection-level shortcuts | `slides/src/view/editor/interactions/keyboard.ts` keyRules (existing pattern). |
+| Slide-level shortcuts (`Cmd+M`, `Page Up/Down`, …) | Same keyRules array. Uses `ctx.setCurrentSlide(id)` (new context entry) for slide switching. |
+| Present-mode start (`Cmd+Enter`) | keyRule fires `ctx.onStartPresentation?.('current' \| 'first')`. Frontend (`slides-detail.tsx`) wires the callback. |
+| Help modal (`Cmd+/`) | keyRule fires `ctx.onShowShortcutsHelp?.()`. Frontend mounts a modal that reads from the shortcuts catalog. |
+| Link request (`Cmd+K`) | Slides text-box wrapper forwards docs' `onLinkRequest` callback up to `SlidesEditorOptions.onLinkRequest`. Frontend mounts a small link popover. |
+| Catalog | New module `slides/src/view/editor/shortcuts-catalog.ts` exports `SHORTCUTS: ReadonlyArray<ShortcutEntry>`. The help modal renders from this list. |
+
+**Extended `KeyboardContext`** (in `interactions/keyboard.ts`):
+
+```ts
+export interface KeyboardContext {
+  store: SlidesStore;
+  selection: Selection;
+  currentSlideId(): string | undefined;
+  setCurrentSlide(id: string): void;            // new
+  enterEditMode?: (elementId: string) => void;  // new — for F2 / Enter
+  requestRender(): void;
+  onStartPresentation?: (from: 'current' | 'first') => void;
+  onShowShortcutsHelp?: () => void;
+  onLinkRequest?: () => void;                    // canvas-level (unused in v1, present for symmetry)
+}
+```
+
+`enterEditMode` exists on `SlidesEditor` as a private path used by
+`onDoubleClick`. We promote it to a method exposed to `KeyboardContext`
+so the F2 / Enter rules can invoke it without duplicating the
+text-box mount sequence.
+
+**`SlidesEditorOptions`** adds three optional callbacks:
+
+```ts
+export interface SlidesEditorOptions extends SlideRendererOptions {
+  // …existing fields…
+  onStartPresentation?: (from: 'current' | 'first') => void;
+  onShowShortcutsHelp?: () => void;
+  onLinkRequest?: () => void;
+}
+```
+
+All three are optional — frontend wiring is independent of the editor
+package, and unit tests don't need to provide them.
+
+**Editable-target gate.** Every selection-level rule keeps an
+`isEditableTarget(e.target)` guard so typing into a focused
+`<textarea>` (the text-box editor, the link popover input, the help
+modal search field) is not intercepted. Exceptions:
+
+- `Cmd+/` (help modal) bypasses the gate — help should always open.
+- `Cmd+Enter` / `Cmd+Shift+Enter` (start presentation) bypass the
+  gate — Google Slides treats this as a global shortcut.
+- `Cmd+K` (link) flows through the docs text-editor inside text-box
+  edit mode; no slides-level rule needed.
+
+### Catalog module
+
+`slides/src/view/editor/shortcuts-catalog.ts`:
+
+```ts
+export interface ShortcutEntry {
+  /** Category for grouping in the help modal. */
+  category: 'Selection' | 'Slide' | 'Clipboard' | 'Format' | 'Present' | 'Help';
+  /** Display label. Use `Cmd` for mac and `Ctrl` elsewhere — rendered
+   *  at runtime based on platform. */
+  keys: ReadonlyArray<string>;
+  /** Human description. */
+  description: string;
+}
+
+export const SHORTCUTS: ReadonlyArray<ShortcutEntry>;
+```
+
+The keys field carries a platform-neutral token like `'Mod+/'` or
+`'Page Up'`; the help modal renders it as `'⌘+/'` on mac and
+`'Ctrl+/'` elsewhere. Keeping the catalog declarative (not coupled to
+the keyRule match functions) trades one duplication risk (catalog
+drift) for clean rendering. A unit test asserts that every catalog
+entry has a corresponding keyRule (matched by description text in a
+test-only table — sufficient to catch deletions).
+
+### Esc semantics
+
+Existing behaviour: text-box editor binds Esc on its own textarea
+(calls `onCancel`, then blurs to commit). Context menu binds Esc to
+close.
+
+New: add a selection-level keyRule for Esc that fires only when
+
+- no editable target is focused,
+- no popover/context-menu open (those swallow it first via their own
+  capture listeners), and
+- the editor has a non-empty selection.
+
+Action: clear selection, `requestRender()`. Pure UI; no store write.
+
+### Link popover wiring
+
+1. `docs/src/view/text-box-editor.ts` — add `onLinkRequest?: () =>
+   void` to `TextBoxEditorOptions`, set
+   `textEditor.onLinkRequest = opts.onLinkRequest` after construction.
+2. `slides/src/view/editor/text-box-editor.ts` — forward
+   `MountSlidesTextBoxOptions.onLinkRequest` to `initializeTextBox`.
+3. `SlidesEditor.enterEditMode` passes
+   `options.onLinkRequest` down to `mountSlidesTextBox`.
+4. Frontend (`slides-detail.tsx`) wires `onLinkRequest` to a small
+   floating input bound to the current text-box selection range.
+   (Same shape as the docs link popover — defer richer UX.)
+
+For v1, the popover is a minimal element ("URL: [____] [OK] [Cancel]")
+positioned near the caret. Without selection it inserts a new link;
+with a selection it wraps the run. Implementation reuses
+`getStyleAtCursor` / `toggleStyle` already on the text-editor.
+
+### Help modal
+
+`frontend/src/app/slides/slides-shortcuts-help.tsx`:
+
+- Centered, max-width modal with categories laid out vertically.
+- Closes on `Esc`, click outside, or the `×` button.
+- Content sourced from `SHORTCUTS` (imported from
+  `@wafflebase/slides`).
+- No search / filter in v1; the list is short enough to scan.
+
+The modal is the only new visible UI surface in this PR.
+
+### Testing
+
+Two layers:
+
+- **Unit (keyboard.test.ts).** One test per new rule, asserting:
+  - The keyRule mutation observed (selection state, store contents, or
+    callback invocation via `vi.fn()`).
+  - The editable-target gate (where applicable) — focus a `<textarea>`,
+    dispatch the key, assert no-op.
+  - Platform parity for `Mod` — exercise both `metaKey` and `ctrlKey`.
+
+- **Catalog test.** `shortcuts-catalog.test.ts` asserts catalog
+  invariants (every entry has non-empty keys, every category is one
+  of the expected values).
+
+The frontend wiring is exercised by existing slides smoke tests; the
+new help modal gets a focused jsdom test (open via callback, close via
+Esc).
+
+## Risks and Mitigation
+
+- **Catalog drift.** Catalog and keyRules are separate arrays. If a
+  rule is added without a catalog entry, the help modal silently
+  omits it. Mitigation: include a developer-facing TODO comment in
+  the catalog and document the dual-edit in `slides.md`'s
+  Interactions table.
+
+- **Tab-cycle ordering surprises.** Tab uses element-array order
+  (current z-order). When the user reorders elements, Tab follows.
+  This matches Google Slides. Document in the design.
+
+- **Enter ambiguity.** Enter doubles as "enter edit mode on selected
+  text element" and "submit dialogs / form inputs". The
+  `isEditableTarget` gate handles form inputs; the rule no-ops when
+  the selection isn't exactly one text element.
+
+- **Page Up / Page Down conflict with text scrolling.** Slides has
+  no scrolling content surface (slide thumbnails have their own
+  scroll, but its container isn't a textarea/input). The rule
+  invokes the editable-target gate so focused textareas keep their
+  default behaviour.
+
+- **Present-mode side effects.** `Cmd+Enter` while editing a text-box
+  would today commit the text-box (Enter inserts newline; Cmd-Enter
+  is special). We bypass the editable-target gate for the present
+  shortcut, but the docs text-editor's own handler for
+  Cmd/Ctrl+Enter (which inserts a page break in docs) is **not
+  inherited** here — slides text-box doesn't expose page breaks. The
+  text-editor's `case 'Enter'` branch fires only when the key is
+  Enter and the `editContext` is 'body' (the default in slides);
+  we keep the slides keyRule but call `e.preventDefault()` first.

--- a/docs/design/slides/slides-keyboard-shortcuts.md
+++ b/docs/design/slides/slides-keyboard-shortcuts.md
@@ -102,22 +102,46 @@ package, and unit tests don't need to provide them.
 **Editable-target gate.** Every selection-level rule keeps an
 `isEditableTarget(e.target)` guard so typing into a focused
 `<textarea>` (the text-box editor, the link popover input, the help
-modal search field) is not intercepted. Exceptions:
+modal search field) is not intercepted. The gate also bails when the
+focused element is inside an interactive widget (`role="dialog"`,
+`role="menu"`, focused `<button>`, etc.) so the help modal's own Tab
+navigation doesn't get hijacked by the slides Tab-cycle rule.
+
+Exceptions:
 
 - `Cmd+/` (help modal) bypasses the gate — help should always open.
-- `Cmd+Enter` / `Cmd+Shift+Enter` (start presentation) bypass the
-  gate — Google Slides treats this as a global shortcut.
 - `Cmd+K` (link) flows through the docs text-editor inside text-box
   edit mode; no slides-level rule needed.
+- `Cmd+Enter` / `Cmd+Shift+Enter` (start presentation) **respect** the
+  gate. The original intent was to make them global like Google
+  Slides, but the docs text-editor binds Cmd+Enter to a `handlePageBreak`
+  op that writes a `page-break` block into the doc store (a docs-only
+  concept). Letting both fire produces stale page-break blocks in
+  slide text-element data. The pragmatic v1 behaviour: respect the
+  gate, document that the user can press Esc to exit text edit
+  before starting present mode. A clean fix is to expose a
+  `disablePageBreak` option on `TextBoxEditorOptions` (or skip
+  Cmd+Enter in the docs handler when `editContext` flags it as a
+  shim) — tracked as a follow-up.
 
 ### Catalog module
 
 `slides/src/view/editor/shortcuts-catalog.ts`:
 
 ```ts
+export type ShortcutCategory =
+  | 'Selection'
+  | 'Slide'
+  | 'Clipboard'
+  | 'Z-order'
+  | 'Nudge'
+  | 'Format'
+  | 'Present'
+  | 'Help';
+
 export interface ShortcutEntry {
   /** Category for grouping in the help modal. */
-  category: 'Selection' | 'Slide' | 'Clipboard' | 'Format' | 'Present' | 'Help';
+  category: ShortcutCategory;
   /** Display label. Use `Cmd` for mac and `Ctrl` elsewhere — rendered
    *  at runtime based on platform. */
   keys: ReadonlyArray<string>;
@@ -224,11 +248,26 @@ Esc).
   default behaviour.
 
 - **Present-mode side effects.** `Cmd+Enter` while editing a text-box
-  would today commit the text-box (Enter inserts newline; Cmd-Enter
-  is special). We bypass the editable-target gate for the present
-  shortcut, but the docs text-editor's own handler for
-  Cmd/Ctrl+Enter (which inserts a page break in docs) is **not
-  inherited** here — slides text-box doesn't expose page breaks. The
-  text-editor's `case 'Enter'` branch fires only when the key is
-  Enter and the `editContext` is 'body' (the default in slides);
-  we keep the slides keyRule but call `e.preventDefault()` first.
+  routes through the docs text-editor first, which binds it to
+  `handlePageBreak()` — inserts a `page-break` block. That block is
+  filtered at render but persists in the in-memory store and would
+  be committed to the slide on blur. Mitigation: the present-mode
+  keyRule respects the editable-target gate, so Cmd+Enter inside a
+  text-box defers to the docs handler. Users press Esc first to
+  exit text edit, then Cmd+Enter to present. A cleaner fix (a docs
+  text-box `disablePageBreak` option) is tracked as a follow-up.
+
+- **Catalog drift.** The shortcuts catalog and the keyRules array
+  are parallel declarations. If a rule lands without a catalog
+  entry, the help modal silently omits it. The catalog test asserts
+  surface invariants (every entry has non-empty keys, every category
+  is one of the expected values), which catches typos but not
+  deletions. Dual-edit convention is called out in
+  `shortcuts-catalog.ts` head comment.
+
+- **Categories expanded beyond original list.** The implementation
+  added `'Z-order'` and `'Nudge'` categories to the
+  `ShortcutCategory` union (originally `'Selection' | 'Slide' |
+  'Clipboard' | 'Format' | 'Present' | 'Help'`). This was a
+  pragmatic split to keep the help modal scannable; the catalog
+  is the source of truth.

--- a/docs/tasks/active/20260514-slides-keyboard-shortcuts-todo.md
+++ b/docs/tasks/active/20260514-slides-keyboard-shortcuts-todo.md
@@ -1,0 +1,84 @@
+# Slides Keyboard Shortcuts — Google Slides Parity
+
+**Goal:** Add the Google Slides parity shortcuts to the slides editor
+(selection / slide navigation / present-mode start / link / help
+modal). Group/Ungroup and Find/Replace are intentionally deferred.
+
+**Design doc:** [slides-keyboard-shortcuts.md](../../design/slides/slides-keyboard-shortcuts.md)
+
+---
+
+### Task 1: Shortcuts catalog
+
+**Files:**
+- New: `packages/slides/src/view/editor/shortcuts-catalog.ts`
+- New: `packages/slides/src/view/editor/shortcuts-catalog.test.ts`
+- Modify: `packages/slides/src/index.ts` (export catalog)
+
+- [ ] Add `ShortcutEntry` type and `SHORTCUTS` array covering all
+      shortcuts shipped here.
+- [ ] Add catalog invariant tests (non-empty keys, valid category).
+
+### Task 2: Extend `KeyboardContext` + add key rules
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/interactions/keyboard.ts`
+- Modify: `packages/slides/src/view/editor/editor.ts`
+- Modify: `packages/slides/src/view/editor/interactions/keyboard.test.ts`
+
+- [ ] Extend `KeyboardContext` with `setCurrentSlide`,
+      `enterEditMode`, `onStartPresentation`, `onShowShortcutsHelp`,
+      `onLinkRequest`.
+- [ ] Add rules: `Cmd+A`, `Esc` (clear selection), `Tab`/`Shift+Tab`,
+      `F2`/`Enter` (enter edit on text element), `Cmd+M` (new slide),
+      `Cmd+Shift+D` (duplicate slide explicit), `Page Up`/`Page Down`,
+      `Cmd+Enter` / `Cmd+Shift+Enter`, `Cmd+Shift+V`, `Cmd+/`.
+- [ ] Maintain ordering — Cmd+Shift+V rule must precede Cmd+V; F2/Enter
+      rule must precede other Enter handling.
+- [ ] Wire new ctx into `SlidesEditorImpl`. Promote `enterEditMode`
+      to a method usable by the keyRule via context.
+- [ ] Add `onStartPresentation` / `onShowShortcutsHelp` /
+      `onLinkRequest` to `SlidesEditorOptions`.
+- [ ] Tests per new rule, both Cmd and Ctrl variants where relevant.
+
+### Task 3: Link callback plumbing
+
+**Files:**
+- Modify: `packages/docs/src/view/text-box-editor.ts`
+      (`TextBoxEditorOptions.onLinkRequest`, wire to TextEditor)
+- Modify: `packages/slides/src/view/editor/text-box-editor.ts`
+      (`MountSlidesTextBoxOptions.onLinkRequest`, forward)
+- Modify: `packages/slides/src/view/editor/editor.ts` (pass through)
+
+- [ ] Add option to docs text-box editor, set on TextEditor instance.
+- [ ] Forward through slides wrapper.
+- [ ] Pass `options.onLinkRequest` from `enterEditMode`.
+- [ ] No new test for plumbing — covered by integration via frontend.
+
+### Task 4: Frontend wiring (help modal + present + link popover)
+
+**Files:**
+- New: `packages/frontend/src/app/slides/slides-shortcuts-help.tsx`
+- Modify: `packages/frontend/src/app/slides/slides-detail.tsx`
+      (wire callbacks, open present mode, open help modal,
+      mount link popover)
+
+- [ ] Help modal — renders `SHORTCUTS` categorized; closes on Esc /
+      click outside.
+- [ ] Wire `onShowShortcutsHelp` to mount help modal.
+- [ ] Wire `onStartPresentation` to existing present-mode entry path.
+- [ ] Wire `onLinkRequest` to a minimal link popover (text input +
+      apply button) anchored near the caret.
+
+### Task 5: Verify and commit
+
+- [ ] `pnpm verify:fast` — must pass.
+- [ ] Manual smoke: `pnpm dev`, exercise each new shortcut.
+- [ ] Commits one per logical chunk; each commit must run
+      `pnpm verify:fast` green.
+- [ ] Update `docs/design/README.md` with link to the new design doc.
+
+### Task 6: Archive
+
+- [ ] Capture lessons in `20260514-slides-keyboard-shortcuts-lessons.md`.
+- [ ] `pnpm tasks:archive && pnpm tasks:index`.

--- a/docs/tasks/active/20260514-slides-keyboard-shortcuts-todo.md
+++ b/docs/tasks/active/20260514-slides-keyboard-shortcuts-todo.md
@@ -15,9 +15,9 @@ modal). Group/Ungroup and Find/Replace are intentionally deferred.
 - New: `packages/slides/src/view/editor/shortcuts-catalog.test.ts`
 - Modify: `packages/slides/src/index.ts` (export catalog)
 
-- [ ] Add `ShortcutEntry` type and `SHORTCUTS` array covering all
+- [x] Add `ShortcutEntry` type and `SHORTCUTS` array covering all
       shortcuts shipped here.
-- [ ] Add catalog invariant tests (non-empty keys, valid category).
+- [x] Add catalog invariant tests (non-empty keys, valid category).
 
 ### Task 2: Extend `KeyboardContext` + add key rules
 
@@ -26,59 +26,71 @@ modal). Group/Ungroup and Find/Replace are intentionally deferred.
 - Modify: `packages/slides/src/view/editor/editor.ts`
 - Modify: `packages/slides/src/view/editor/interactions/keyboard.test.ts`
 
-- [ ] Extend `KeyboardContext` with `setCurrentSlide`,
-      `enterEditMode`, `onStartPresentation`, `onShowShortcutsHelp`,
-      `onLinkRequest`.
-- [ ] Add rules: `Cmd+A`, `Esc` (clear selection), `Tab`/`Shift+Tab`,
-      `F2`/`Enter` (enter edit on text element), `Cmd+M` (new slide),
-      `Cmd+Shift+D` (duplicate slide explicit), `Page Up`/`Page Down`,
-      `Cmd+Enter` / `Cmd+Shift+Enter`, `Cmd+Shift+V`, `Cmd+/`.
-- [ ] Maintain ordering — Cmd+Shift+V rule must precede Cmd+V; F2/Enter
-      rule must precede other Enter handling.
-- [ ] Wire new ctx into `SlidesEditorImpl`. Promote `enterEditMode`
-      to a method usable by the keyRule via context.
-- [ ] Add `onStartPresentation` / `onShowShortcutsHelp` /
+- [x] Extend `KeyboardContext` with `setCurrentSlide`,
+      `enterEditMode`, `onStartPresentation`, `onShowShortcutsHelp`.
+      (`onLinkRequest` lives on `SlidesEditorOptions` only — the
+      slides-level keyRule is unnecessary because docs' text-editor
+      already binds Cmd+K inside text-box edit mode.)
+- [x] Add rules: `Cmd+A`, `Esc`, `Tab`/`Shift+Tab`, `F2`/`Enter`,
+      `Cmd+M`, `Cmd+Shift+D`, `Page Up`/`Page Down`,
+      `Cmd+Enter` / `Cmd+Shift+Enter`, `Cmd+/`. (Cmd+Shift+V already
+      matched by the existing `Cmd+V` rule since it doesn't gate on
+      shift; no new rule needed.)
+- [x] Wire new ctx into `SlidesEditorImpl`.
+- [x] Add `onStartPresentation` / `onShowShortcutsHelp` /
       `onLinkRequest` to `SlidesEditorOptions`.
-- [ ] Tests per new rule, both Cmd and Ctrl variants where relevant.
+- [x] Tests per new rule, Cmd variants only (Ctrl parity is covered
+      by `isModPressed` and the existing Ctrl+Z tests).
 
 ### Task 3: Link callback plumbing
 
 **Files:**
 - Modify: `packages/docs/src/view/text-box-editor.ts`
-      (`TextBoxEditorOptions.onLinkRequest`, wire to TextEditor)
 - Modify: `packages/slides/src/view/editor/text-box-editor.ts`
-      (`MountSlidesTextBoxOptions.onLinkRequest`, forward)
-- Modify: `packages/slides/src/view/editor/editor.ts` (pass through)
+- Modify: `packages/slides/src/view/editor/editor.ts`
 
-- [ ] Add option to docs text-box editor, set on TextEditor instance.
-- [ ] Forward through slides wrapper.
-- [ ] Pass `options.onLinkRequest` from `enterEditMode`.
-- [ ] No new test for plumbing — covered by integration via frontend.
+- [x] Add option to docs text-box editor, set on TextEditor instance.
+- [x] Forward through slides wrapper.
+- [x] Pass `options.onLinkRequest` from `enterEditMode`.
 
-### Task 4: Frontend wiring (help modal + present + link popover)
+### Task 4: Frontend wiring
 
 **Files:**
 - New: `packages/frontend/src/app/slides/slides-shortcuts-help.tsx`
-- Modify: `packages/frontend/src/app/slides/slides-detail.tsx`
-      (wire callbacks, open present mode, open help modal,
-      mount link popover)
+- Modify: `packages/frontend/src/app/slides/slides-view.tsx`
 
-- [ ] Help modal — renders `SHORTCUTS` categorized; closes on Esc /
-      click outside.
-- [ ] Wire `onShowShortcutsHelp` to mount help modal.
-- [ ] Wire `onStartPresentation` to existing present-mode entry path.
-- [ ] Wire `onLinkRequest` to a minimal link popover (text input +
-      apply button) anchored near the caret.
+- [x] Help modal renders `SHORTCUTS` categorized; closes via the
+      Dialog primitive's Esc / overlay-click.
+- [x] Wire `onShowShortcutsHelp` to open the modal.
+- [ ] **Deferred:** `onStartPresentation` wiring. Present mode UI
+      isn't yet implemented in the slides package (`view/present/`
+      is documented in `slides.md` but the actual presenter doesn't
+      exist). Hook the callback in when that lands.
+- [ ] **Deferred:** Real `onLinkRequest` popover. Requires
+      extending `TextBoxEditorAPI` with `insertLink(url)` /
+      `getLinkAtCursor()` so a slides-side popover can actually
+      mutate the active text-box. The keyboard plumbing is in place
+      (Cmd+K fires through docs text-editor → onLinkRequest), but
+      no host wiring → currently a no-op while editing text. Track
+      as a follow-up.
 
 ### Task 5: Verify and commit
 
-- [ ] `pnpm verify:fast` — must pass.
-- [ ] Manual smoke: `pnpm dev`, exercise each new shortcut.
-- [ ] Commits one per logical chunk; each commit must run
-      `pnpm verify:fast` green.
-- [ ] Update `docs/design/README.md` with link to the new design doc.
+- [x] `pnpm verify:fast` — passes (Exit 0).
+- [ ] Manual smoke: `pnpm dev`, exercise each new shortcut (browser
+      smoke before merge per user workflow).
+- [x] Commits one per logical chunk; each commit `verify:fast` green.
+- [x] Update `docs/design/README.md` with link to the new design doc.
 
 ### Task 6: Archive
 
 - [ ] Capture lessons in `20260514-slides-keyboard-shortcuts-lessons.md`.
 - [ ] `pnpm tasks:archive && pnpm tasks:index`.
+
+## Status
+
+- **Commits on branch `feat/slides-keyboard-shortcuts`:**
+  - `Add Google Slides parity keyboard shortcuts in the editor`
+  - `Wire slides shortcuts help modal on Cmd+/`
+- **Next steps:** manual browser smoke; review; PR (after rebase on
+  main).

--- a/packages/docs/src/view/text-box-editor.ts
+++ b/packages/docs/src/view/text-box-editor.ts
@@ -96,6 +96,15 @@ export interface TextBoxEditorOptions {
    * Defaults to 1 (no HiDPI scaling) if omitted.
    */
   dpr?: number;
+
+  /**
+   * Called when the user presses Cmd/Ctrl+K inside the text-box. The
+   * host typically opens a link popover anchored near the caret. The
+   * shim wires this through to the underlying `TextEditor`'s
+   * `onLinkRequest` field — same shape as the docs editor's public
+   * `onLinkRequest(cb)` API.
+   */
+  onLinkRequest?: () => void;
 }
 
 export interface TextBoxEditorAPI {
@@ -329,6 +338,9 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
     },
   );
   textEditor.setCursorTarget(canvas);
+  if (opts.onLinkRequest) {
+    textEditor.onLinkRequest = opts.onLinkRequest;
+  }
 
   // Track focus so the cursor only paints + blinks while the textarea
   // owns focus (the standard caret behaviour).

--- a/packages/frontend/src/app/slides/slides-shortcuts-help.tsx
+++ b/packages/frontend/src/app/slides/slides-shortcuts-help.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from "react";
+import {
+  SHORTCUTS,
+  formatCombo,
+  type ShortcutCategory,
+  type ShortcutEntry,
+} from "@wafflebase/slides";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface SlidesShortcutsHelpProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const CATEGORY_ORDER: ReadonlyArray<ShortcutCategory> = [
+  "Selection",
+  "Slide",
+  "Nudge",
+  "Clipboard",
+  "Z-order",
+  "Format",
+  "Present",
+  "Help",
+];
+
+function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+}
+
+export function SlidesShortcutsHelp({
+  open,
+  onOpenChange,
+}: SlidesShortcutsHelpProps) {
+  const isMac = useMemo(() => isMacPlatform(), []);
+  const grouped = useMemo(() => groupByCategory(SHORTCUTS), []);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+        </DialogHeader>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6 mt-2">
+          {CATEGORY_ORDER.map((category) => {
+            const entries = grouped.get(category);
+            if (!entries || entries.length === 0) return null;
+            return (
+              <section key={category}>
+                <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                  {category}
+                </h3>
+                <ul className="space-y-1">
+                  {entries.map((entry, idx) => (
+                    <li
+                      key={`${category}-${idx}`}
+                      className="flex items-start justify-between gap-3 text-sm"
+                    >
+                      <span className="flex-1 leading-snug">
+                        {entry.description}
+                      </span>
+                      <span className="flex flex-wrap gap-1 shrink-0">
+                        {entry.keys.map((combo, k) => (
+                          <kbd
+                            key={k}
+                            className="px-1.5 py-0.5 rounded border bg-muted text-xs font-mono whitespace-nowrap"
+                          >
+                            {formatCombo(combo, isMac)}
+                          </kbd>
+                        ))}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function groupByCategory(
+  entries: ReadonlyArray<ShortcutEntry>,
+): Map<ShortcutCategory, ShortcutEntry[]> {
+  const map = new Map<ShortcutCategory, ShortcutEntry[]>();
+  for (const entry of entries) {
+    const list = map.get(entry.category);
+    if (list) {
+      list.push(entry);
+    } else {
+      map.set(entry.category, [entry]);
+    }
+  }
+  return map;
+}

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -10,6 +10,7 @@ import { useDocument } from "@yorkie-js/react";
 import { Loader } from "@/components/loader";
 import type { YorkieSlidesRoot } from "@/types/slides-document";
 import type { SlidesPresence } from "@/types/users";
+import { SlidesShortcutsHelp } from "./slides-shortcuts-help";
 import { YorkieSlidesStore, ensureSlidesRoot } from "./yorkie-slides-store";
 
 export type { SlidesEditor } from "@wafflebase/slides";
@@ -90,6 +91,7 @@ export function SlidesView({ onEditorReady, onStoreReady }: SlidesViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<SlidesEditor | null>(null);
   const [didMount, setDidMount] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
   const { doc, loading, error } = useDocument<YorkieSlidesRoot, SlidesPresence>();
 
   // Prevent double-initialization in React strict mode / dev HMR.
@@ -260,6 +262,12 @@ export function SlidesView({ onEditorReady, onStoreReady }: SlidesViewProps) {
       hostWidth: hostW,
       hostHeight: hostH,
       dpr,
+      onShowShortcutsHelp: () => setHelpOpen(true),
+      // onStartPresentation / onLinkRequest are intentionally left
+      // unwired here. Present mode UI lands in a separate phase, and
+      // the link popover needs a richer TextBoxEditorAPI (insertLink /
+      // getLinkAtCursor) before it can drive the docs text-box.
+      // Cmd+Enter / Cmd+K no-op at the editor level until then.
     });
     editorRef.current = editor;
     onEditorReady?.(editor);
@@ -441,7 +449,12 @@ export function SlidesView({ onEditorReady, onStoreReady }: SlidesViewProps) {
     );
   }
 
-  return <div ref={containerRef} className="relative flex-1 w-full min-h-0" />;
+  return (
+    <>
+      <div ref={containerRef} className="relative flex-1 w-full min-h-0" />
+      <SlidesShortcutsHelp open={helpOpen} onOpenChange={setHelpOpen} />
+    </>
+  );
 }
 
 export default SlidesView;

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -85,3 +85,4 @@ export { mountNotesPanel } from './view/editor/notes-panel';
 export { showLayoutPicker, type LayoutPickerOptions } from './view/editor/layout-picker';
 export { showContextMenu, dismiss as dismissContextMenu, type ContextMenuItem } from './view/editor/context-menu';
 export { MIME_TYPE as SLIDES_CLIPBOARD_MIME, serializeElements, deserializeElements } from './view/editor/interactions/clipboard';
+export { SHORTCUTS, formatCombo, type ShortcutEntry, type ShortcutCategory } from './view/editor/shortcuts-catalog';

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -50,6 +50,26 @@ export interface SlidesEditorOptions extends SlideRendererOptions {
    * functional Canvas 2D context).
    */
   mountTextBox?: typeof mountSlidesTextBox;
+  /**
+   * Host hook for `Cmd+Enter` / `Cmd+Shift+Enter`. The editor doesn't
+   * own present mode — the surrounding shell does — so we fire this
+   * callback and let the host route to its existing presentation
+   * entry path. `from` is `'current'` for `Cmd+Enter` and `'first'`
+   * for `Cmd+Shift+Enter`. No-op when omitted.
+   */
+  onStartPresentation?: (from: 'current' | 'first') => void;
+  /**
+   * Host hook for `Cmd+/`. Opens the shortcuts-help modal. The keyRule
+   * bypasses the editable-target gate so help opens even while
+   * editing text. No-op when omitted.
+   */
+  onShowShortcutsHelp?: () => void;
+  /**
+   * Host hook for `Cmd+K` inside text-box edit mode. Forwarded down
+   * to the docs text-box editor; fired by docs/text-editor when the
+   * user requests link insertion. No-op when omitted.
+   */
+  onLinkRequest?: () => void;
 }
 
 export interface SlidesEditor {
@@ -194,7 +214,12 @@ class SlidesEditorImpl implements SlidesEditor {
       store: this.options.store,
       selection: this.selection,
       currentSlideId: () => this.getCurrentSlideId(),
+      setCurrentSlide: (id: string) => this.setCurrentSlide(id),
+      enterEditMode: (slideId: string, elementId: string) =>
+        this.enterEditMode(slideId, elementId),
       requestRender: () => this.requestRender(),
+      onStartPresentation: this.options.onStartPresentation,
+      onShowShortcutsHelp: this.options.onShowShortcutsHelp,
     });
     this.attachInteractions();
   }
@@ -666,6 +691,7 @@ class SlidesEditorImpl implements SlidesEditor {
       frame: element.frame,
       scale: this.scale(),
       blocks,
+      onLinkRequest: this.options.onLinkRequest,
       onCommit: (next) => {
         // Persist via withTextElement and exit edit mode. We snapshot
         // the slide id at enter-time because the user could have

--- a/packages/slides/src/view/editor/interactions/keyboard.test.ts
+++ b/packages/slides/src/view/editor/interactions/keyboard.test.ts
@@ -402,6 +402,38 @@ describe('keyboard — F2 / Enter enters text edit', () => {
   });
 });
 
+describe('keyboard — interactive-widget gate', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  it('Tab inside a focused dialog does not cycle slide selection', () => {
+    const { editor: e, elementId } = makeFixture();
+    editor = e;
+    editor.setSelection([elementId]);
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    const button = document.createElement('button');
+    dialog.appendChild(button);
+    document.body.appendChild(dialog);
+    button.focus();
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(editor.getSelection()).toEqual([elementId]);
+    dialog.remove();
+  });
+
+  it('Enter on a focused button does not enter text-edit mode', () => {
+    const { editor: e, elementId } = makeFixture();
+    editor = e;
+    editor.setSelection([elementId]);
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    button.focus();
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(editor.getEditingElementId()).toBe(null);
+    button.remove();
+  });
+});
+
 describe('keyboard — Cmd+M new slide', () => {
   let editor: SlidesEditor | null = null;
   beforeEach(() => { if (editor) { editor.detach(); editor = null; } });

--- a/packages/slides/src/view/editor/interactions/keyboard.test.ts
+++ b/packages/slides/src/view/editor/interactions/keyboard.test.ts
@@ -219,6 +219,331 @@ describe('keyboard — z-order shortcuts', () => {
   });
 });
 
+describe('keyboard — Cmd+A select all', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  it('selects every element on the current slide', () => {
+    const { editor: e, store, elementId } = makeFixture();
+    editor = e;
+    const slideId = store.read().slides[0].id;
+    let secondId = '';
+    store.batch(() => {
+      secondId = store.addElement(slideId, {
+        type: 'shape',
+        frame: { x: 0, y: 0, w: 50, h: 50, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#0a0' } },
+      });
+    });
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', metaKey: true, bubbles: true }));
+    expect(editor.getSelection()).toEqual([elementId, secondId]);
+  });
+
+  it('is a no-op when target is a textarea', () => {
+    const { editor: e } = makeFixture();
+    editor = e;
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', metaKey: true, bubbles: true }));
+    expect(editor.getSelection()).toEqual([]);
+    textarea.remove();
+  });
+});
+
+describe('keyboard — Esc', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  it('clears selection when something is selected', () => {
+    const { editor: e, elementId } = makeFixture();
+    editor = e;
+    editor.setSelection([elementId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(editor.getSelection()).toEqual([]);
+  });
+
+  it('is a no-op when nothing is selected', () => {
+    const { editor: e } = makeFixture();
+    editor = e;
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(editor.getSelection()).toEqual([]);
+  });
+});
+
+describe('keyboard — Tab cycle', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  function fixtureWithTwoElements() {
+    const fx = makeFixture();
+    let secondId = '';
+    fx.store.batch(() => {
+      secondId = fx.store.addElement(fx.store.read().slides[0].id, {
+        type: 'shape',
+        frame: { x: 0, y: 0, w: 50, h: 50, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#0a0' } },
+      });
+    });
+    return { ...fx, secondId };
+  }
+
+  it('with empty selection Tab picks the first element', () => {
+    const { editor: e, elementId } = fixtureWithTwoElements();
+    editor = e;
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(editor.getSelection()).toEqual([elementId]);
+  });
+
+  it('with empty selection Shift+Tab picks the last element', () => {
+    const { editor: e, secondId } = fixtureWithTwoElements();
+    editor = e;
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }));
+    expect(editor.getSelection()).toEqual([secondId]);
+  });
+
+  it('Tab advances and wraps', () => {
+    const { editor: e, elementId, secondId } = fixtureWithTwoElements();
+    editor = e;
+    editor.setSelection([elementId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(editor.getSelection()).toEqual([secondId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    expect(editor.getSelection()).toEqual([elementId]);
+  });
+
+  it('Shift+Tab moves backward and wraps', () => {
+    const { editor: e, elementId, secondId } = fixtureWithTwoElements();
+    editor = e;
+    editor.setSelection([elementId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true }));
+    expect(editor.getSelection()).toEqual([secondId]);
+  });
+});
+
+describe('keyboard — F2 / Enter enters text edit', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  function fixtureWithTextElement() {
+    document.body.innerHTML = '';
+    const canvas = document.createElement('canvas');
+    canvas.width = 960; canvas.height = 540;
+    const overlay = document.createElement('div');
+    document.body.appendChild(canvas);
+    document.body.appendChild(overlay);
+    const store = new MemSlidesStore();
+    let textId = '';
+    store.batch(() => {
+      const sid = store.addSlide('blank');
+      textId = store.addElement(sid, {
+        type: 'text',
+        frame: { x: 0, y: 0, w: 200, h: 80, rotation: 0 },
+        data: { blocks: [] },
+      });
+    });
+    // Mount fixture uses a fake text-box mount so jsdom isn't asked to
+    // drive the real docs text editor.
+    const mountedSpy = vi.fn();
+    const fakeMount = ((opts: { overlay: HTMLDivElement }) => {
+      mountedSpy();
+      const container = document.createElement('div');
+      opts.overlay.appendChild(container);
+      return {
+        isEditing: () => true,
+        focus: () => undefined,
+        detach: () => container.remove(),
+        commit: () => undefined,
+        container,
+      };
+    }) as unknown as Parameters<typeof initialize>[0]['mountTextBox'];
+    const ed = initialize({
+      canvas, overlay, store, hostWidth: 960, hostHeight: 540, dpr: 1,
+      mountTextBox: fakeMount,
+    });
+    trackedEditors.push(ed);
+    return { editor: ed, store, textId, mountedSpy };
+  }
+
+  it('F2 mounts the text-box editor on the selected text element', () => {
+    const { editor: e, textId, mountedSpy } = fixtureWithTextElement();
+    editor = e;
+    editor.setSelection([textId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'F2', bubbles: true }));
+    expect(mountedSpy).toHaveBeenCalledTimes(1);
+    expect(editor.getEditingElementId()).toBe(textId);
+  });
+
+  it('Enter mounts the text-box editor on the selected text element', () => {
+    const { editor: e, textId, mountedSpy } = fixtureWithTextElement();
+    editor = e;
+    editor.setSelection([textId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(mountedSpy).toHaveBeenCalledTimes(1);
+    expect(editor.getEditingElementId()).toBe(textId);
+  });
+
+  it('does not enter edit mode for non-text elements', () => {
+    const { editor: e, store, mountedSpy } = fixtureWithTextElement();
+    editor = e;
+    // The non-text element from makeFixture style — add a shape and select it instead.
+    let shapeId = '';
+    store.batch(() => {
+      shapeId = store.addElement(store.read().slides[0].id, {
+        type: 'shape',
+        frame: { x: 300, y: 100, w: 100, h: 60, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor.setSelection([shapeId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(mountedSpy).not.toHaveBeenCalled();
+    expect(editor.getEditingElementId()).toBe(null);
+  });
+});
+
+describe('keyboard — Cmd+M new slide', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  it('inserts after the current slide and switches to it', () => {
+    const { editor: e, store } = makeFixture();
+    editor = e;
+    const startId = store.read().slides[0].id;
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', metaKey: true, bubbles: true }));
+    const slides = store.read().slides;
+    expect(slides).toHaveLength(2);
+    expect(slides[0].id).toBe(startId);
+    expect(editor.getCurrentSlideId()).toBe(slides[1].id);
+  });
+
+  it('reuses the current slide\'s layout', () => {
+    const { editor: e, store } = makeFixture();
+    editor = e;
+    const layoutId = store.read().slides[0].layoutId;
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', metaKey: true, bubbles: true }));
+    expect(store.read().slides[1].layoutId).toBe(layoutId);
+  });
+});
+
+describe('keyboard — Cmd+Shift+D duplicate slide', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  it('duplicates the current slide even when an element is selected', () => {
+    const { editor: e, store, elementId } = makeFixture();
+    editor = e;
+    editor.setSelection([elementId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'd', metaKey: true, shiftKey: true, bubbles: true }));
+    expect(store.read().slides).toHaveLength(2);
+  });
+});
+
+describe('keyboard — Page Up / Page Down', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  function fixtureWithTwoSlides() {
+    const fx = makeFixture();
+    fx.store.batch(() => fx.store.addSlide('blank'));
+    return fx;
+  }
+
+  it('Page Down advances to next slide', () => {
+    const { editor: e, store } = fixtureWithTwoSlides();
+    editor = e;
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageDown', bubbles: true }));
+    expect(editor.getCurrentSlideId()).toBe(store.read().slides[1].id);
+  });
+
+  it('Page Up returns to previous slide', () => {
+    const { editor: e, store } = fixtureWithTwoSlides();
+    editor = e;
+    editor.setCurrentSlide(store.read().slides[1].id);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true }));
+    expect(editor.getCurrentSlideId()).toBe(store.read().slides[0].id);
+  });
+
+  it('is a no-op at boundaries', () => {
+    const { editor: e, store } = fixtureWithTwoSlides();
+    editor = e;
+    const firstId = store.read().slides[0].id;
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true }));
+    expect(editor.getCurrentSlideId()).toBe(firstId);
+  });
+});
+
+describe('keyboard — Present mode shortcuts', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  it('Cmd+Enter fires onStartPresentation with current', () => {
+    document.body.innerHTML = '';
+    const canvas = document.createElement('canvas');
+    canvas.width = 960; canvas.height = 540;
+    const overlay = document.createElement('div');
+    document.body.appendChild(canvas);
+    document.body.appendChild(overlay);
+    const store = new MemSlidesStore();
+    store.batch(() => store.addSlide('blank'));
+    const onStartPresentation = vi.fn();
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 960, hostHeight: 540, dpr: 1,
+      onStartPresentation,
+    });
+    trackedEditors.push(editor);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true }));
+    expect(onStartPresentation).toHaveBeenCalledWith('current');
+  });
+
+  it('Cmd+Shift+Enter fires onStartPresentation with first', () => {
+    document.body.innerHTML = '';
+    const canvas = document.createElement('canvas');
+    canvas.width = 960; canvas.height = 540;
+    const overlay = document.createElement('div');
+    document.body.appendChild(canvas);
+    document.body.appendChild(overlay);
+    const store = new MemSlidesStore();
+    store.batch(() => store.addSlide('blank'));
+    const onStartPresentation = vi.fn();
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 960, hostHeight: 540, dpr: 1,
+      onStartPresentation,
+    });
+    trackedEditors.push(editor);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, shiftKey: true, bubbles: true }));
+    expect(onStartPresentation).toHaveBeenCalledWith('first');
+  });
+});
+
+describe('keyboard — Cmd+/ shortcuts help', () => {
+  let editor: SlidesEditor | null = null;
+  beforeEach(() => { if (editor) { editor.detach(); editor = null; } });
+
+  it('fires onShowShortcutsHelp even while a textarea is focused', () => {
+    document.body.innerHTML = '';
+    const canvas = document.createElement('canvas');
+    canvas.width = 960; canvas.height = 540;
+    const overlay = document.createElement('div');
+    document.body.appendChild(canvas);
+    document.body.appendChild(overlay);
+    const store = new MemSlidesStore();
+    store.batch(() => store.addSlide('blank'));
+    const onShowShortcutsHelp = vi.fn();
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 960, hostHeight: 540, dpr: 1,
+      onShowShortcutsHelp,
+    });
+    trackedEditors.push(editor);
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: '/', metaKey: true, bubbles: true }));
+    expect(onShowShortcutsHelp).toHaveBeenCalled();
+    textarea.remove();
+  });
+});
+
 describe('keyboard — Cmd+C copy', () => {
   let editor: SlidesEditor | null = null;
   let originalClipboard: unknown;

--- a/packages/slides/src/view/editor/interactions/keyboard.ts
+++ b/packages/slides/src/view/editor/interactions/keyboard.ts
@@ -12,7 +12,14 @@ export interface KeyboardContext {
   store: SlidesStore;
   selection: Selection;
   currentSlideId(): string | undefined;
+  /** Switch to the given slide. Used by Page Up / Page Down and Cmd+M. */
+  setCurrentSlide(id: string): void;
+  /** Enter text-edit mode on the given element. Used by F2 / Enter. */
+  enterEditMode(slideId: string, elementId: string): void;
   requestRender(): void;
+  /** Optional callbacks wired by the host shell. No-op if absent. */
+  onStartPresentation?: (from: 'current' | 'first') => void;
+  onShowShortcutsHelp?: () => void;
 }
 
 const NUDGE = 1;
@@ -210,6 +217,215 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
             ctx.store.reorderElement(slideId, id, target);
           }
         });
+        ctx.requestRender();
+      },
+    },
+
+    // --- Parity pass: selection / slide / present / help ---
+
+    // Cmd+/ — show shortcuts help. Bypasses the editable-target gate so
+    // the help modal opens even while typing in a text-box.
+    {
+      match: (e) => keyEquals(e.key, '/') && isModPressed(e),
+      run: (e) => {
+        if (!ctx.onShowShortcutsHelp) return;
+        e.preventDefault();
+        ctx.onShowShortcutsHelp();
+      },
+    },
+
+    // Cmd+Shift+Enter — present from first slide. Must precede the
+    // Cmd+Enter rule so the shift variant doesn't get swallowed.
+    {
+      match: (e) =>
+        e.key === 'Enter' &&
+        isModPressed(e) &&
+        e.shiftKey &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        if (!ctx.onStartPresentation) return;
+        e.preventDefault();
+        ctx.onStartPresentation('first');
+      },
+    },
+    // Cmd+Enter — present from current slide. Gated by editable target
+    // because docs text-editor binds Cmd+Enter to a page-break op which
+    // isn't meaningful in slides text-boxes; user can Esc out first.
+    {
+      match: (e) =>
+        e.key === 'Enter' &&
+        isModPressed(e) &&
+        !e.shiftKey &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        if (!ctx.onStartPresentation) return;
+        e.preventDefault();
+        ctx.onStartPresentation('current');
+      },
+    },
+
+    // Cmd+A — select all elements on the current slide.
+    {
+      match: (e) =>
+        keyEquals(e.key, 'a') &&
+        isModPressed(e) &&
+        !e.shiftKey &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        const slide = currentSlide(ctx);
+        if (!slide || slide.elements.length === 0) return;
+        e.preventDefault();
+        ctx.selection.set(slide.elements.map((el) => el.id));
+        ctx.requestRender();
+      },
+    },
+
+    // Cmd+M — add a new slide after the current, using the current
+    // slide's layout, and switch to it.
+    {
+      match: (e) =>
+        keyEquals(e.key, 'm') &&
+        isModPressed(e) &&
+        !e.shiftKey &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        const slide = currentSlide(ctx);
+        if (!slide) return;
+        e.preventDefault();
+        const slides = ctx.store.read().slides;
+        const currentIdx = slides.findIndex((s) => s.id === slide.id);
+        let newId = '';
+        ctx.store.batch(() => {
+          newId = ctx.store.addSlide(slide.layoutId, currentIdx + 1);
+        });
+        if (newId) ctx.setCurrentSlide(newId);
+        ctx.requestRender();
+      },
+    },
+
+    // Cmd+Shift+D — duplicate the current slide explicitly. Distinct
+    // from Cmd+D, which duplicates the selected element(s) and only
+    // falls back to slide-duplicate when nothing is selected.
+    {
+      match: (e) =>
+        keyEquals(e.key, 'd') &&
+        isModPressed(e) &&
+        e.shiftKey &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        const slide = currentSlide(ctx);
+        if (!slide) return;
+        e.preventDefault();
+        ctx.store.batch(() => ctx.store.duplicateSlide(slide.id));
+        ctx.requestRender();
+      },
+    },
+
+    // Page Up / Page Down — switch to previous / next slide. Gated by
+    // editable target so PgUp/PgDn inside a focused textarea retains
+    // its default behaviour (caret movement).
+    {
+      match: (e) =>
+        (e.key === 'PageUp' || e.key === 'PageDown') &&
+        !isModPressed(e) &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        const slides = ctx.store.read().slides;
+        if (slides.length === 0) return;
+        const currentId = ctx.currentSlideId();
+        const currentIdx = slides.findIndex((s) => s.id === currentId);
+        if (currentIdx === -1) return;
+        const targetIdx =
+          e.key === 'PageUp'
+            ? Math.max(0, currentIdx - 1)
+            : Math.min(slides.length - 1, currentIdx + 1);
+        if (targetIdx === currentIdx) return;
+        e.preventDefault();
+        ctx.setCurrentSlide(slides[targetIdx].id);
+      },
+    },
+
+    // Tab / Shift+Tab — cycle next / previous element on the current
+    // slide. Empty selection: Tab picks the first element, Shift+Tab
+    // picks the last (matches Google Slides).
+    {
+      match: (e) =>
+        e.key === 'Tab' &&
+        !isModPressed(e) &&
+        !e.altKey &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        const slide = currentSlide(ctx);
+        if (!slide || slide.elements.length === 0) return;
+        e.preventDefault();
+        const direction: 'next' | 'prev' = e.shiftKey ? 'prev' : 'next';
+        const selected = ctx.selection.get();
+        const len = slide.elements.length;
+        let nextIdx: number;
+        if (selected.length === 0) {
+          nextIdx = direction === 'next' ? 0 : len - 1;
+        } else {
+          // Anchor on the last element in selection (in array order)
+          // so repeated Tab walks forward through the slide.
+          let anchor = -1;
+          for (let i = len - 1; i >= 0; i--) {
+            if (selected.includes(slide.elements[i].id)) {
+              anchor = i;
+              break;
+            }
+          }
+          if (anchor === -1) {
+            nextIdx = direction === 'next' ? 0 : len - 1;
+          } else {
+            const step = direction === 'next' ? 1 : -1;
+            nextIdx = (anchor + step + len) % len;
+          }
+        }
+        ctx.selection.set([slide.elements[nextIdx].id]);
+        ctx.requestRender();
+      },
+    },
+
+    // F2 / Enter — enter text-edit mode on the selected text element.
+    // Only fires when:
+    //   - exactly one element is selected,
+    //   - that element is type 'text',
+    //   - the focused target isn't an editable input (so Enter still
+    //     submits dialogs and the text-box editor's own Enter keeps
+    //     inserting newlines).
+    {
+      match: (e) =>
+        (e.key === 'F2' || e.key === 'Enter') &&
+        !isModPressed(e) &&
+        !e.shiftKey &&
+        !e.altKey &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        const slide = currentSlide(ctx);
+        if (!slide) return;
+        const selected = ctx.selection.get();
+        if (selected.length !== 1) return;
+        const element = slide.elements.find((el) => el.id === selected[0]);
+        if (!element || element.type !== 'text') return;
+        e.preventDefault();
+        ctx.enterEditMode(slide.id, element.id);
+      },
+    },
+
+    // Esc — clear selection when something is selected and no
+    // editable target is focused. Text-box Esc is handled by the
+    // text-box editor's own capture-phase listener (which stops
+    // propagation before reaching this rule). Popover/context-menu
+    // Esc is also captured at their layer.
+    {
+      match: (e) =>
+        e.key === 'Escape' &&
+        !isModPressed(e) &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        if (ctx.selection.get().length === 0) return;
+        e.preventDefault();
+        ctx.selection.clear();
         ctx.requestRender();
       },
     },

--- a/packages/slides/src/view/editor/interactions/keyboard.ts
+++ b/packages/slides/src/view/editor/interactions/keyboard.ts
@@ -224,9 +224,14 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
     // --- Parity pass: selection / slide / present / help ---
 
     // Cmd+/ — show shortcuts help. Bypasses the editable-target gate so
-    // the help modal opens even while typing in a text-box.
+    // the help modal opens even while typing in a text-box. Matches
+    // only when a host handler is wired so an unhandled Cmd+/ falls
+    // through to the browser default.
     {
-      match: (e) => keyEquals(e.key, '/') && isModPressed(e),
+      match: (e) =>
+        keyEquals(e.key, '/') &&
+        isModPressed(e) &&
+        ctx.onShowShortcutsHelp !== undefined,
       run: (e) => {
         if (!ctx.onShowShortcutsHelp) return;
         e.preventDefault();
@@ -236,27 +241,32 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
 
     // Cmd+Shift+Enter — present from first slide. Must precede the
     // Cmd+Enter rule so the shift variant doesn't get swallowed.
+    // Both rules are gated by the editable-target check: docs
+    // text-editor binds Cmd+Enter to a page-break op (a docs-only
+    // concept) which would corrupt slide text-element data if it ran
+    // inside a slides text-box. Users can press Esc to exit text edit
+    // before starting present mode. See design doc "Esc semantics"
+    // and the "Cmd+Enter implementation deviation" note.
     {
       match: (e) =>
         e.key === 'Enter' &&
         isModPressed(e) &&
         e.shiftKey &&
-        !isEditableTarget(e.target),
+        !isEditableTarget(e.target) &&
+        ctx.onStartPresentation !== undefined,
       run: (e) => {
         if (!ctx.onStartPresentation) return;
         e.preventDefault();
         ctx.onStartPresentation('first');
       },
     },
-    // Cmd+Enter — present from current slide. Gated by editable target
-    // because docs text-editor binds Cmd+Enter to a page-break op which
-    // isn't meaningful in slides text-boxes; user can Esc out first.
     {
       match: (e) =>
         e.key === 'Enter' &&
         isModPressed(e) &&
         !e.shiftKey &&
-        !isEditableTarget(e.target),
+        !isEditableTarget(e.target) &&
+        ctx.onStartPresentation !== undefined,
       run: (e) => {
         if (!ctx.onStartPresentation) return;
         e.preventDefault();
@@ -524,5 +534,18 @@ function isEditableTarget(target: EventTarget | null): boolean {
   const tag = target.tagName;
   if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
   if ((target as HTMLElement).isContentEditable) return true;
+  // Also gate against interactive widgets (dialogs, dropdowns, focused
+  // buttons). Without this, Tab inside the shortcuts-help dialog would
+  // be hijacked by the slides Tab-cycle rule, and Enter on a focused
+  // toolbar button would enter text-edit mode instead of activating
+  // the button. We treat any of these as "not the slide canvas" and
+  // let the default browser/widget handling run.
+  if (tag === 'BUTTON') return true;
+  if (target.closest('[role="dialog"], [role="menu"], [role="listbox"], [role="combobox"], [role="tree"], [role="grid"]')) {
+    return true;
+  }
+  if (target.matches('[role="button"], [role="menuitem"], [role="option"], [role="tab"]')) {
+    return true;
+  }
   return false;
 }

--- a/packages/slides/src/view/editor/shortcuts-catalog.test.ts
+++ b/packages/slides/src/view/editor/shortcuts-catalog.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { SHORTCUTS, formatCombo } from './shortcuts-catalog';
+
+describe('shortcuts catalog', () => {
+  it('every entry has at least one key combo', () => {
+    for (const entry of SHORTCUTS) {
+      expect(entry.keys.length).toBeGreaterThan(0);
+      for (const combo of entry.keys) {
+        expect(combo).not.toBe('');
+      }
+    }
+  });
+
+  it('every entry has a non-empty description', () => {
+    for (const entry of SHORTCUTS) {
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every entry uses a known category', () => {
+    const allowed = new Set([
+      'Selection', 'Slide', 'Clipboard', 'Z-order', 'Nudge',
+      'Format', 'Present', 'Help',
+    ]);
+    for (const entry of SHORTCUTS) {
+      expect(allowed.has(entry.category)).toBe(true);
+    }
+  });
+
+  it('covers the high-visibility shortcuts shipped in this pass', () => {
+    const descriptions = SHORTCUTS.map((s) => s.description.toLowerCase());
+    expect(descriptions.some((d) => d.includes('select all'))).toBe(true);
+    expect(descriptions.some((d) => d.includes('cycle'))).toBe(true);
+    expect(descriptions.some((d) => d.includes('add a new slide'))).toBe(true);
+    expect(descriptions.some((d) => d.includes('previous / next slide'))).toBe(true);
+    expect(descriptions.some((d) => d.includes('start presentation from the current'))).toBe(true);
+    expect(descriptions.some((d) => d.includes('keyboard shortcuts'))).toBe(true);
+  });
+});
+
+describe('formatCombo', () => {
+  it('rewrites Mod to ⌘ on mac and Ctrl elsewhere', () => {
+    expect(formatCombo('Mod+A', true)).toBe('⌘A');
+    expect(formatCombo('Mod+A', false)).toBe('Ctrl+A');
+  });
+
+  it('preserves named keys', () => {
+    expect(formatCombo('Page Up', true)).toBe('Page Up');
+    expect(formatCombo('Esc', false)).toBe('Esc');
+  });
+
+  it('combines modifiers correctly', () => {
+    expect(formatCombo('Mod+Shift+D', true)).toBe('⌘⇧D');
+    expect(formatCombo('Mod+Shift+D', false)).toBe('Ctrl+Shift+D');
+  });
+});

--- a/packages/slides/src/view/editor/shortcuts-catalog.ts
+++ b/packages/slides/src/view/editor/shortcuts-catalog.ts
@@ -1,0 +1,101 @@
+/**
+ * Single source of truth for the keyboard shortcuts shipped by the
+ * slides editor. The runtime keyRule registrations live in
+ * `interactions/keyboard.ts`; this catalog drives the help modal and
+ * any user-facing reference docs.
+ *
+ * Keep this list in sync with `buildKeyRules` whenever you add or
+ * remove a rule. There is no automated assertion that every rule has
+ * a catalog entry (the rules are predicate-based, not symbolic), so
+ * dual-edit is the convention.
+ *
+ * Keys use platform-neutral tokens:
+ *   - `Mod`        — Cmd on macOS, Ctrl elsewhere
+ *   - `Shift`, `Alt`
+ *   - Named keys (`Enter`, `Tab`, `Esc`, `Page Up`, `Arrow ↑`, …)
+ *   - Printable letters in upper case (`A`, `M`, `D`, …)
+ *
+ * A combo is a `+`-joined string; multiple alternative combos are
+ * an array of strings.
+ */
+
+export type ShortcutCategory =
+  | 'Selection'
+  | 'Slide'
+  | 'Clipboard'
+  | 'Z-order'
+  | 'Nudge'
+  | 'Format'
+  | 'Present'
+  | 'Help';
+
+export interface ShortcutEntry {
+  category: ShortcutCategory;
+  keys: ReadonlyArray<string>;
+  description: string;
+}
+
+export const SHORTCUTS: ReadonlyArray<ShortcutEntry> = [
+  // Selection ------------------------------------------------------------
+  { category: 'Selection', keys: ['Mod+A'],            description: 'Select all elements on the current slide' },
+  { category: 'Selection', keys: ['Esc'],              description: 'Exit text edit, then clear selection' },
+  { category: 'Selection', keys: ['Tab', 'Shift+Tab'], description: 'Cycle next / previous element' },
+  { category: 'Selection', keys: ['F2', 'Enter'],      description: 'Enter text edit on the selected text element' },
+  { category: 'Selection', keys: ['Delete', 'Backspace'], description: 'Delete selected elements' },
+
+  // Nudge ----------------------------------------------------------------
+  { category: 'Nudge', keys: ['Arrow ←/→/↑/↓'],         description: 'Move selection 1 px' },
+  { category: 'Nudge', keys: ['Shift + Arrow'],          description: 'Move selection 10 px' },
+
+  // Slide ----------------------------------------------------------------
+  { category: 'Slide', keys: ['Mod+M'],           description: 'Add a new slide after the current' },
+  { category: 'Slide', keys: ['Mod+Shift+D'],     description: 'Duplicate the current slide' },
+  { category: 'Slide', keys: ['Mod+D'],           description: 'Duplicate selected elements (or current slide if none)' },
+  { category: 'Slide', keys: ['Page Up', 'Page Down'], description: 'Go to previous / next slide' },
+
+  // Clipboard ------------------------------------------------------------
+  { category: 'Clipboard', keys: ['Mod+C'],       description: 'Copy selected elements' },
+  { category: 'Clipboard', keys: ['Mod+X'],       description: 'Cut selected elements' },
+  { category: 'Clipboard', keys: ['Mod+V'],       description: 'Paste' },
+  { category: 'Clipboard', keys: ['Mod+Shift+V'], description: 'Paste (when editing text: plain text)' },
+
+  // Z-order --------------------------------------------------------------
+  { category: 'Z-order', keys: ['Mod+↑', 'Mod+↓'],             description: 'Bring forward / send backward' },
+  { category: 'Z-order', keys: ['Mod+Shift+↑', 'Mod+Shift+↓'], description: 'Bring to front / send to back' },
+
+  // Format (text-box edit mode) ------------------------------------------
+  { category: 'Format', keys: ['Mod+B'],       description: 'Bold (when editing text)' },
+  { category: 'Format', keys: ['Mod+I'],       description: 'Italic (when editing text)' },
+  { category: 'Format', keys: ['Mod+U'],       description: 'Underline (when editing text)' },
+  { category: 'Format', keys: ['Mod+K'],       description: 'Insert link (when editing text)' },
+  { category: 'Format', keys: ['Mod+\\'],      description: 'Clear formatting (when editing text)' },
+  { category: 'Format', keys: ['Mod+Shift+L', 'Mod+Shift+E', 'Mod+Shift+R'], description: 'Align left / center / right (when editing text)' },
+
+  // Present --------------------------------------------------------------
+  { category: 'Present', keys: ['Mod+Enter'],       description: 'Start presentation from the current slide' },
+  { category: 'Present', keys: ['Mod+Shift+Enter'], description: 'Start presentation from the first slide' },
+
+  // History --------------------------------------------------------------
+  { category: 'Help', keys: ['Mod+Z'],          description: 'Undo' },
+  { category: 'Help', keys: ['Mod+Shift+Z'],    description: 'Redo' },
+  { category: 'Help', keys: ['Mod+/'],          description: 'Show keyboard shortcuts' },
+];
+
+/**
+ * Render a combo string for display, rewriting `Mod` to the
+ * platform-correct symbol. Pass `isMac` explicitly so the function
+ * stays pure / testable.
+ */
+export function formatCombo(combo: string, isMac: boolean): string {
+  const mod = isMac ? '⌘' : 'Ctrl';
+  return combo
+    .split('+')
+    .map((part) => part.trim())
+    .map((part) => {
+      if (part === 'Mod') return mod;
+      if (part === 'Shift') return isMac ? '⇧' : 'Shift';
+      if (part === 'Alt') return isMac ? '⌥' : 'Alt';
+      return part;
+    })
+    .join(isMac ? '' : '+');
+}

--- a/packages/slides/src/view/editor/text-box-editor.ts
+++ b/packages/slides/src/view/editor/text-box-editor.ts
@@ -41,6 +41,12 @@ export interface MountSlidesTextBoxOptions {
   onCommit: (blocks: Block[]) => void;
   /** Called when Escape is pressed (BEFORE onCommit fires via the blur path). */
   onCancel: () => void;
+  /**
+   * Called when the user presses Cmd/Ctrl+K. The slides shell opens a
+   * link popover anchored near the caret. Forwarded straight through
+   * to the docs text-box, which wires it to the inner `TextEditor`.
+   */
+  onLinkRequest?: () => void;
 }
 
 export interface SlidesTextBoxEditor {
@@ -68,7 +74,7 @@ export interface SlidesTextBoxEditor {
 }
 
 export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextBoxEditor {
-  const { overlay, frame, scale, blocks, onCommit, onCancel } = opts;
+  const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest } = opts;
 
   // Container positioned over the element frame in host-pixel space.
   const container = document.createElement('div');
@@ -142,6 +148,7 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
     dpr: dpr * scale,
     onCommit: handleCommit,
     onCancel: handleCancel,
+    onLinkRequest,
   });
 
   return {


### PR DESCRIPTION
## Summary

Add the Google Slides parity keyboard shortcuts the slides editor was missing — selection (`Cmd+A`, `Esc`, `Tab`/`Shift+Tab`, `F2`/`Enter`), slide navigation (`Cmd+M`, `Cmd+Shift+D`, `Page Up`/`Page Down`), present-mode entry (`Cmd+Enter`, `Cmd+Shift+Enter`), and a `Cmd+/` shortcuts-help modal.

- New keyRules land in the existing `interactions/keyboard.ts` array; `SlidesEditorOptions` gains three optional host callbacks (`onStartPresentation`, `onShowShortcutsHelp`, `onLinkRequest`).
- `shortcuts-catalog.ts` is the single source of truth for shortcut metadata; the help modal renders directly from it.
- `Cmd+K` (link) is plumbed end-to-end through `docs/text-box-editor` → slides text-box → `SlidesEditor`. The host wiring for a real link popover is deferred (requires expanding `TextBoxEditorAPI` with `insertLink`/`getLinkAtCursor`).
- Present-mode wiring is also deferred — present UI isn't implemented in the slides package yet.

Design: [`docs/design/slides/slides-keyboard-shortcuts.md`](../blob/feat/slides-keyboard-shortcuts/docs/design/slides/slides-keyboard-shortcuts.md). Task: [`docs/tasks/active/20260514-slides-keyboard-shortcuts-todo.md`](../blob/feat/slides-keyboard-shortcuts/docs/tasks/active/20260514-slides-keyboard-shortcuts-todo.md).

Group/Ungroup and Find/Replace are explicitly out of scope (no group concept in the model; find/replace needs a deck-wide UX).

## Test plan

- [x] `pnpm verify:fast` — green
- [x] 15 new unit tests in `keyboard.test.ts` (Cmd+A, Esc, Tab/Shift+Tab, F2/Enter, Cmd+M, Cmd+Shift+D, Page Up/Down, present callbacks, Cmd+/, interactive-widget gate)
- [x] 7 new tests in `shortcuts-catalog.test.ts` (invariants + `formatCombo`)
- [ ] Manual browser smoke:
  - Cmd+/ opens the help modal with all shortcuts grouped by category
  - Tab/Enter inside the help modal use default focus behaviour (not hijacked by slides Tab-cycle / enter-edit rules)
  - Cmd+A selects every element on the current slide
  - Tab cycles through elements; Shift+Tab cycles backward; wraps
  - F2 / Enter on a single text-element selection enters edit mode
  - Cmd+M adds a new slide and switches to it
  - Cmd+Shift+D duplicates the current slide even when elements are selected
  - Page Up / Page Down navigate slides; no-op at boundaries
  - Esc clears selection; doesn't interfere with text-box edit or open dialogs
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcuts for the slides editor, including selection (Cmd+A, Tab, Escape), slide navigation (Page Up/Down, Cmd+M to add slide, Cmd+Shift+D to duplicate), text editing (Enter/F2), presentation mode (Cmd+Enter), and link insertion (Cmd+K).
  * Added shortcuts help modal accessible via Cmd+/ to view all available keyboard shortcuts.

* **Documentation**
  * Added design documentation for keyboard shortcuts parity implementation.
  * Added task documentation for the keyboard shortcuts feature rollout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/238)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->