### PR TITLE
Add slides presentation mode v1 (local-only fullscreen)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -64,6 +64,7 @@ Presentation engine — slides, free-position elements, presentation mode, colla
 | [slides-layout-change.md](slides/slides-layout-change.md)                             | Layout change UI — placeholder identity tracking, type-first matching, split-button + context menu  |
 | [slides-shapes.md](slides/slides-shapes.md)                                           | Shape library — 55 OOXML-aligned `ShapeKind` values, path-builder registry, `data.adjustments` storage, yellow-diamond drag handles, picker UX, phased roadmap to ~100-shape GS parity |
 | [slides-keyboard-shortcuts.md](slides/slides-keyboard-shortcuts.md)                   | Slides keyboard shortcuts — Google Slides parity pass, single catalog source, help modal, link popover wiring                                                                          |
+| [slides-presentation-mode.md](slides/slides-presentation-mode.md)                     | Slides presentation mode v1 — local-only fullscreen player, keyboard nav, click-to-advance, end screen, fullscreen-overlay fallback                                                    |
 
 ## Common
 

--- a/docs/design/slides/slides-presentation-mode.md
+++ b/docs/design/slides/slides-presentation-mode.md
@@ -215,6 +215,9 @@ layout chrome:
 Hotkey hints in the dropdown: `⌘↩` and `⌘⇧↩` (or Ctrl on non-Mac).
 The button is disabled when `store.read().slides.length === 0`.
 
+Icon library: `@tabler/icons-react` (`IconPlayerPlay`,
+`IconChevronDown`), matching the existing slides toolbar / chrome.
+
 The existing shortcuts (`Cmd/Ctrl+Enter`, `Cmd/Ctrl+Shift+Enter`)
 continue to work and are already documented in
 `docs/design/slides/slides-keyboard-shortcuts.md`.
@@ -235,11 +238,13 @@ Vitest + jsdom in `packages/slides/src/view/present/presenter.test.ts`:
 - `requestFullscreen` / `exitFullscreen` are mocked. A fallback path
   is exercised by making `requestFullscreen` reject.
 
-A small frontend test in
-`packages/frontend/src/app/slides/slides-presentation-mode.test.tsx`
-verifies that the shell mounts / unmounts cleanly and that an
-`onStartPresentation` call followed by `onExit` returns the editor
-to its prior state.
+No colocated React-shell test — the frontend package's test runner
+(Node `--test` + experimental strip-types) doesn't support JSX, and
+no existing slides React component is unit-tested. The presenter's
+50 unit tests in `packages/slides/src/view/present/presenter.test.ts`
+cover the framework-free half; the shell's mount / unmount lifecycle
+is exercised by the manual smoke in Task 10.2 of the implementation
+plan.
 
 No visual / browser test in this PR — fullscreen behavior is
 notoriously flaky in headless Chromium and the render path is the

--- a/docs/design/slides/slides-presentation-mode.md
+++ b/docs/design/slides/slides-presentation-mode.md
@@ -164,7 +164,7 @@ While the timer is dormant, `container.style.cursor = 'none'`. Any
 
 ### Fullscreen with overlay fallback
 
-```
+```typescript
 try {
   await container.requestFullscreen();
 } catch {

--- a/docs/design/slides/slides-presentation-mode.md
+++ b/docs/design/slides/slides-presentation-mode.md
@@ -1,0 +1,269 @@
+---
+title: slides-presentation-mode
+target-version: 0.4.2
+---
+
+# Slides Presentation Mode — v1 (local-only)
+
+## Summary
+
+Fill in the presentation-mode UI that `docs/design/slides/slides.md`
+Phase 5 has reserved a slot for. The editor already exposes a
+`onStartPresentation?: (from: 'current' | 'first') => void` callback,
+and `Cmd/Ctrl+Enter` / `Cmd/Ctrl+Shift+Enter` are wired through
+`view/editor/interactions/keyboard.ts` — they currently no-op because
+no handler is registered. This pass implements the handler and the
+underlying presenter.
+
+The presenter is **local-only**: it does not broadcast the active
+slide via Yorkie presence, and collaborators are not auto-snapped to
+the presenter's slide. Follow-along behavior, speaker-notes display,
+and the dual-screen presenter view stay in v2.
+
+### Goals
+
+- Full-screen one-slide-at-a-time rendering driven by the existing
+  `SlideRenderer`, with fit-to-screen sizing and a black letterbox.
+- Keyboard navigation: `→` / `Space` / `PageDown` / `n` advance,
+  `←` / `PageUp` / `Backspace` / `p` go back, `Home` / `End` jump,
+  `Esc` exits. All other keys are swallowed so accidental editor
+  shortcuts (e.g. `Cmd+Z`) cannot damage the deck while presenting.
+- Click-to-advance on the slide canvas.
+- A discoverable entry point: a "Present" split-button in the
+  slides header (main click = current slide, dropdown menu item =
+  from the beginning), in addition to the existing keyboard
+  shortcuts.
+- Cursor auto-hides after 3 s of no `mousemove`.
+- An "End of slideshow" black screen after the last slide; click or
+  `Esc` exits.
+- Fullscreen API failure (iframe sandbox, permission denied) falls
+  back to a fixed-position overlay covering the viewport — same UX,
+  no native fullscreen.
+- The presenter survives remote edits arriving over Yorkie: current
+  slide is tracked by **ID**, the React shell re-renders on every
+  store snapshot, and a deleted current slide jumps to the next
+  available one (or exits if the deck becomes empty).
+
+### Non-Goals
+
+- **Presence broadcast.** No `presentingSlideId` field on Yorkie
+  presence and no UI indicator for collaborators. Deferred to a
+  follow-up; `docs/design/slides/slides.md` Phase 5's "Presence shows
+  only the presenter's current slide so collaborators can follow
+  along" is downscoped to local-only for v1.
+- **Speaker notes display.** Notes are stored and edited via the
+  existing notes panel; rendering them in present mode (single-screen
+  overlay or dual-screen presenter view) is v2.
+- **Slide transitions.** Cuts only.
+- **Touch / swipe.** Presenting from mobile is out of scope; the
+  click-to-advance handler covers tap.
+- **Laser pointer, ink annotations, blackout (`B`) / whiteout (`W`)
+  keys.** Out of scope.
+- **Auto-play / timer / loop.** Out of scope.
+
+## Proposal Details
+
+### Code layout
+
+The presenter is split between a framework-free DOM module in the
+slides package and a thin React shell in the frontend, matching how
+`initializeEditor` is structured today.
+
+| File | Role |
+|---|---|
+| `packages/slides/src/view/present/presenter.ts` | Core: canvas creation, fit sizing, render, keyboard, cursor auto-hide, end screen, fullscreen-with-overlay fallback. No React, no Yorkie. |
+| `packages/slides/src/view/present/index.ts` | Re-export. |
+| `packages/slides/src/index.ts` | Add `export { startPresenter, type Presenter, type PresenterOptions } from './view/present';`. |
+| `packages/frontend/src/app/slides/slides-presentation-mode.tsx` | React shell. Mounts a portal `<div>`, calls `startPresenter`, forwards `store` snapshots into `presenter.setDocument(...)`, cleans up on unmount. |
+| `packages/frontend/src/app/slides/slides-view.tsx` | Wires `onStartPresentation` to local state (`presentingFrom: 'current' \| 'first' \| null`) and conditionally mounts `<SlidesPresentationMode />`. |
+| `packages/frontend/src/app/slides/slides-detail.tsx` | Adds the "Present" split-button to the header chrome. |
+
+### API surface (slides package)
+
+```ts
+export interface PresenterOptions {
+  /** The element that becomes fullscreen. The presenter mounts its
+   *  canvas as a child and restores the element's prior attributes
+   *  on dispose. */
+  container: HTMLElement;
+  /** Initial snapshot. Updated later via setDocument. */
+  doc: SlidesDocument;
+  /** Identify the starting slide by ID so concurrent structural
+   *  edits don't shift us. Pass the first slide's ID for
+   *  "from beginning". */
+  startSlideId: string;
+  /** Called when the user exits (Esc, end-screen click, or
+   *  native fullscreen exit via the browser chrome). */
+  onExit: () => void;
+}
+
+export interface Presenter {
+  /** Replace the document snapshot. The presenter re-renders the
+   *  current slide; if its ID disappears, jumps to the next slide
+   *  (or previous, if it was the last). If the deck becomes empty,
+   *  calls onExit. */
+  setDocument(doc: SlidesDocument): void;
+  /** Current slide id, or `null` while at the end-screen. */
+  getCurrentSlideId(): string | null;
+  /** True when the user has advanced past the last slide. */
+  isAtEndScreen(): boolean;
+  /** Tear down: remove canvas, listeners, exit fullscreen,
+   *  restore container. Safe to call from inside onExit. */
+  dispose(): void;
+}
+
+export function startPresenter(options: PresenterOptions): Presenter;
+```
+
+### Render path
+
+- One `<canvas>` inside `container`. Container background is `#000`
+  (letterbox); canvas is centered.
+- A `ResizeObserver` recomputes the fit:
+  `scale = min(viewportW / SLIDE_WIDTH, viewportH / SLIDE_HEIGHT)`
+  with `devicePixelRatio` applied to the backing store. Same math
+  as the editor's `computeFitSize`, lifted into a shared helper if
+  the duplication is meaningful (otherwise inline).
+- Re-render whenever the active slide changes or `setDocument` is
+  called. The renderer is the existing `SlideRenderer` — no DOM
+  overlay, no element handles.
+
+### Keyboard
+
+A single `keydown` listener installed at `document` level in the
+**capture phase** with `{ capture: true }`. It calls
+`stopImmediatePropagation()` for every key it observes (so the
+editor's keyRule layer cannot also fire) and `preventDefault()` on
+any key it does not consume.
+
+| Keys | Action |
+|---|---|
+| `→` `Space` `PageDown` `n` `N` | Next slide / end screen |
+| `←` `PageUp` `Backspace` `p` `P` | Previous slide |
+| `Home` | First slide |
+| `End` | Last slide |
+| `Esc` | Exit |
+| anything else | swallowed |
+
+Before entering present mode the host calls
+`document.activeElement?.blur()` so a focused contenteditable text
+box does not steal keystrokes inside the fullscreen element.
+
+### Click-to-advance
+
+A `click` listener on the canvas advances to the next slide (or
+shows the end screen). The end screen itself is a separate paint
+state of the same canvas — pure black with centered text — and any
+click while on it triggers `onExit`.
+
+### Cursor auto-hide
+
+A 3 s `setTimeout` armed on entry and re-armed on every `mousemove`.
+While the timer is dormant, `container.style.cursor = 'none'`. Any
+`mousemove` clears the style and restarts the timer.
+
+### Fullscreen with overlay fallback
+
+```
+try {
+  await container.requestFullscreen();
+} catch {
+  applyOverlayStyles(container);  // position: fixed; inset: 0; z-index: 9999
+}
+```
+
+The `fullscreenchange` event on `document` triggers `onExit` when
+the user leaves fullscreen via the browser chrome (Esc inside the
+browser's native handling). When we mounted with the overlay
+fallback there is no native handler — `Esc` from our keyboard
+listener is the only exit path.
+
+On `dispose`, exit fullscreen (or remove the overlay styles) and
+restore any prior inline styles on the container.
+
+### Remote-change handling
+
+The slides editor stays mounted under the presenter. Yorkie keeps
+flowing changes into the store. The React shell subscribes to the
+store and calls `presenter.setDocument(snapshot)` on every change.
+
+The presenter's `setDocument` logic:
+
+1. Look up the slide whose `id === currentSlideId`. If found,
+   re-render (theme/element edits are reflected).
+2. If not found (deleted by collaborator), pick the slide at the
+   same index in the new array. If the index is now out of bounds,
+   pick the last slide. Update `currentSlideId` and re-render.
+3. If `slides.length === 0`, call `onExit`. The shell surfaces a
+   toast ("Presentation ended").
+
+### Empty-deck entry guard
+
+`onStartPresentation` (the editor callback) is a no-op when
+`store.read().slides.length === 0`. `slides-view.tsx` already seeds a
+blank slide on first mount, so this is defensive only.
+
+### Entry-point UI
+
+A "Present" split-button in the slides header
+(`slides-detail.tsx`), placed to the right of the existing theme /
+layout chrome:
+
+- Main button click → `onStartPresentation('current')`.
+- Dropdown item "Present from beginning" → `onStartPresentation('first')`.
+
+Hotkey hints in the dropdown: `⌘↩` and `⌘⇧↩` (or Ctrl on non-Mac).
+The button is disabled when `store.read().slides.length === 0`.
+
+The existing shortcuts (`Cmd/Ctrl+Enter`, `Cmd/Ctrl+Shift+Enter`)
+continue to work and are already documented in
+`docs/design/slides/slides-keyboard-shortcuts.md`.
+
+### Testing
+
+Vitest + jsdom in `packages/slides/src/view/present/presenter.test.ts`:
+
+- Keyboard navigation maps each key to the expected next slide ID
+  (or end-screen state) on a fixture deck with three slides.
+- Boundary: `←` on the first slide is a no-op; `→` on the last slide
+  enters the end-screen state; a subsequent click invokes `onExit`.
+- `setDocument` with the current slide deleted jumps to the next
+  slide at the same index; with all slides deleted invokes `onExit`.
+- `dispose()` removes the canvas, the document-level keydown
+  listener, the `mousemove` listener, and the `fullscreenchange`
+  listener; exits fullscreen / removes overlay styles.
+- `requestFullscreen` / `exitFullscreen` are mocked. A fallback path
+  is exercised by making `requestFullscreen` reject.
+
+A small frontend test in
+`packages/frontend/src/app/slides/slides-presentation-mode.test.tsx`
+verifies that the shell mounts / unmounts cleanly and that an
+`onStartPresentation` call followed by `onExit` returns the editor
+to its prior state.
+
+No visual / browser test in this PR — fullscreen behavior is
+notoriously flaky in headless Chromium and the render path is the
+same `SlideRenderer` already covered by existing visual scenarios.
+Manual smoke before merge.
+
+### Risks and Mitigation
+
+- **Stale editor key handlers fire inside present mode.** The
+  capture-phase `keydown` listener with `stopImmediatePropagation`
+  is the primary mitigation; `document.activeElement?.blur()` on
+  entry is the secondary one for contenteditable focus theft.
+- **Fullscreen API restrictions on embed contexts.** The overlay
+  fallback gives identical visual behavior; the only loss is the
+  browser's native Esc handling, which our own `Esc` keybinding
+  already covers.
+- **Remote deletion of the current slide.** Tracking by ID plus the
+  index-preserving fallback gives a deterministic, non-jarring
+  outcome. The empty-deck case ends the presentation cleanly with
+  a toast.
+- **Double-mount / double-listener on hot reload.** `dispose` is
+  idempotent and restores container state; the React shell calls
+  it from `useEffect` cleanup.
+- **Scope creep toward "follow-along" presence.** Calling that out
+  explicitly in Non-Goals so a future PR adds it deliberately
+  (presence schema, snapshot subscriber, edit-lock UX), not as a
+  drive-by.

--- a/docs/design/slides/slides.md
+++ b/docs/design/slides/slides.md
@@ -537,17 +537,25 @@ when fewer than 3 elements are selected.
 
 ### Presentation mode
 
-Implemented in `view/present/presenter.ts` plus the React shell
-`presentation-mode.tsx`:
+See [slides-presentation-mode.md](./slides-presentation-mode.md) for
+the v1 design.
 
-- `requestFullscreen` on a single canvas, render only the current slide
-  via the same `slide-renderer` with `zoom = fit-to-screen`.
-- Keyboard navigation: ←/→, Space, Page Up/Down to step; Home/End to
-  jump; Esc to exit.
-- Editing UI is fully disabled. Presence shows only the presenter's
-  current slide so collaborators can follow along.
-- Speaker notes are written and stored in v1, but the dual-screen
-  presenter view that displays them ships in v2 (see Non-Goals).
+Shape at a glance:
+
+- `view/present/presenter.ts` (slides package, framework-free) +
+  `slides-presentation-mode.tsx` (frontend React shell).
+- `requestFullscreen` on a host element, single canvas re-using
+  `SlideRenderer` with fit-to-screen sizing; overlay fallback when
+  fullscreen is denied.
+- Keyboard navigation: ←/→, Space, PgUp/PgDn, Home/End, Esc. All
+  other keys are swallowed so editor shortcuts cannot fire.
+- Click-to-advance, cursor auto-hide after 3 s, end-of-slideshow
+  black screen.
+- Entry: a "Present" split-button in the slides header plus the
+  existing `Cmd/Ctrl+Enter` shortcuts.
+- **Local-only in v1**: no presence broadcast, no follow-along.
+  Speaker notes display and the dual-screen presenter view stay in
+  v2 (see Non-Goals).
 
 ### Error handling
 

--- a/docs/tasks/active/20260514-slides-keyboard-shortcuts-todo.md
+++ b/docs/tasks/active/20260514-slides-keyboard-shortcuts-todo.md
@@ -62,10 +62,12 @@ modal). Group/Ungroup and Find/Replace are intentionally deferred.
 - [x] Help modal renders `SHORTCUTS` categorized; closes via the
       Dialog primitive's Esc / overlay-click.
 - [x] Wire `onShowShortcutsHelp` to open the modal.
-- [ ] **Deferred:** `onStartPresentation` wiring. Present mode UI
-      isn't yet implemented in the slides package (`view/present/`
-      is documented in `slides.md` but the actual presenter doesn't
-      exist). Hook the callback in when that lands.
+- [x] **Wired in `feat/slides-presentation-mode`**: `view/present/`
+      now exists in the slides package, `SlidesView` forwards
+      `onStartPresentation`, and `SlidesLayout` routes the callback
+      to `handleStartPresentation` so the Cmd/Ctrl+Enter shortcuts
+      and the new Present split-button share the same entry path.
+      See `docs/tasks/active/20260514-slides-presentation-mode-todo.md`.
 - [ ] **Deferred:** Real `onLinkRequest` popover. Requires
       extending `TextBoxEditorAPI` with `insertLink(url)` /
       `getLinkAtCursor()` so a slides-side popover can actually

--- a/docs/tasks/active/20260514-slides-presentation-mode-todo.md
+++ b/docs/tasks/active/20260514-slides-presentation-mode-todo.md
@@ -548,7 +548,7 @@ primitives (check sibling files for the exact import paths).
 
 **Branch:** `feat/slides-presentation-mode` (off `main` @ `2c319e59`).
 
-**Commits (13, oldest → newest):**
+**Commits (15, oldest → newest):**
 
 1. `c9ce715f` Add slides presentation mode v1 design and plan
 2. `4e173dd5` Add slides presenter scaffold and navigation state
@@ -563,13 +563,16 @@ primitives (check sibling files for the exact import paths).
 11. `e2fce34b` Add slides presentation mode React shell
 12. `cc9dbc83` Forward onStartPresentation to the slides editor
 13. `ffa0df8e` Add Present split-button and presenting state to slides header
+14. `dc0c3275` Close out slides presentation mode task tracking
+15. `379636ae` Tighten presenter against fullscreen race and stale start id *(final cross-cutting fixup)*
 
 **Verification:** `pnpm verify:fast` green on the latest commit
-(47 test files, 764 tests). 50 unit tests in
+(47 test files, 764 tests). 52 unit tests in
 `packages/slides/src/view/present/presenter.test.ts` cover navigation,
 canvas mount, end-screen, keyboard, click, cursor auto-hide, fullscreen,
-overlay fallback, identity-gated fullscreenchange, remote-change
-handling, and dispose cleanup.
+overlay fallback, identity-gated fullscreenchange, dispose-during-pending-
+fullscreen race, stale-start-id fallback, remote-change handling, and
+dispose cleanup.
 
 **Outstanding (10.2 / 10.5 / 10.6 / 10.7):**
 

--- a/docs/tasks/active/20260514-slides-presentation-mode-todo.md
+++ b/docs/tasks/active/20260514-slides-presentation-mode-todo.md
@@ -546,4 +546,39 @@ primitives (check sibling files for the exact import paths).
 
 ## Status
 
-_Filled in as work progresses._
+**Branch:** `feat/slides-presentation-mode` (off `main` @ `2c319e59`).
+
+**Commits (13, oldest → newest):**
+
+1. `c9ce715f` Add slides presentation mode v1 design and plan
+2. `4e173dd5` Add slides presenter scaffold and navigation state
+3. `1e17df5b` Guard slides presenter against empty deck *(Task 1 fixup)*
+4. `ee045edf` Render slides on the presenter canvas
+5. `caefa99a` Guard presenter ResizeObserver and lift end-screen constants *(Task 2 fixup)*
+6. `e7501762` Wire presenter keyboard and click navigation
+7. `ef7155db` Add presenter fullscreen, overlay fallback, cursor auto-hide
+8. `bdc7df05` Identity-gate presenter fullscreenchange handler *(Task 4 fixup)*
+9. `6bc0920b` Handle remote doc changes in the presenter
+10. `06c24ecc` Tear down presenter cleanly and export from the package
+11. `e2fce34b` Add slides presentation mode React shell
+12. `cc9dbc83` Forward onStartPresentation to the slides editor
+13. `ffa0df8e` Add Present split-button and presenting state to slides header
+
+**Verification:** `pnpm verify:fast` green on the latest commit
+(47 test files, 764 tests). 50 unit tests in
+`packages/slides/src/view/present/presenter.test.ts` cover navigation,
+canvas mount, end-screen, keyboard, click, cursor auto-hide, fullscreen,
+overlay fallback, identity-gated fullscreenchange, remote-change
+handling, and dispose cleanup.
+
+**Outstanding (10.2 / 10.5 / 10.6 / 10.7):**
+
+- Manual browser smoke (`pnpm dev`) per the Task 10.2 checklist —
+  user-driven per the workflow.
+- Optional final cross-cutting code review (e.g. `/ultrareview`).
+- Lessons file (`20260514-slides-presentation-mode-lessons.md`).
+- Archive (`pnpm tasks:archive && pnpm tasks:index`).
+
+**Parked work**: Branch `wip/shape-insert-hover-preview` carries the
+unrelated shape-insert hover-preview + Escape-disarm changes that were
+sitting uncommitted on `main` at session start. Independent of this PR.

--- a/docs/tasks/active/20260514-slides-presentation-mode-todo.md
+++ b/docs/tasks/active/20260514-slides-presentation-mode-todo.md
@@ -1,0 +1,549 @@
+# Slides Presentation Mode — v1 (local-only)
+
+**Goal:** Implement the presentation-mode UI that `slides-view.tsx` has
+been waiting on (the `onStartPresentation` callback is intentionally
+unwired, with `Cmd/Ctrl+Enter` shortcuts already firing). Single-canvas
+fullscreen player, keyboard nav, click-to-advance, end screen,
+fullscreen-overlay fallback. Local-only — no presence broadcast.
+
+**Design doc:** [slides-presentation-mode.md](../../design/slides/slides-presentation-mode.md)
+
+**Architecture:** A framework-free `startPresenter(options) → Presenter`
+module in the slides package (matches `initializeEditor`'s shape) plus
+a thin React shell in the frontend. Slide identified by **ID**, not
+index, so concurrent Yorkie edits don't shift the presenter under the
+user.
+
+**Tech stack:** TS, Vitest + jsdom for unit tests, existing
+`SlideRenderer`, React 18 for the shell.
+
+---
+
+## Task 1 — Presenter skeleton + navigation state
+
+**Files:**
+
+- Create: `packages/slides/src/view/present/presenter.ts`
+- Create: `packages/slides/src/view/present/index.ts`
+- Create: `packages/slides/src/view/present/presenter.test.ts`
+
+Build the state machine and the public API; no DOM rendering yet.
+The presenter tracks `currentSlideId: string | null` and
+`atEndScreen: boolean`. Methods (initially private, exposed via the
+returned object): `next()`, `prev()`, `goToFirst()`, `goToLast()`,
+`setDocument(doc)`.
+
+- [ ] **1.1** Write failing tests for navigation on a 3-slide fixture
+  (`A`, `B`, `C`):
+  - `startPresenter` with `startSlideId: 'B'` puts current at `B`.
+  - `next()` from `A` → `B`; from `C` → `atEndScreen = true`; another
+    `next()` while at end-screen is a no-op (exit comes from a
+    separate `exit()` path, not from `next()` past end-screen).
+  - `prev()` from `B` → `A`; from `A` stays at `A`. From end-screen
+    state, `prev()` goes back to last slide and clears
+    `atEndScreen`.
+  - `goToFirst()` / `goToLast()` jump and clear `atEndScreen`.
+
+  Mock `container.requestFullscreen` to resolve (so the constructor
+  doesn't blow up in jsdom).
+
+- [ ] **1.2** Run tests, confirm they fail with "startPresenter is
+  not defined" / equivalent.
+- [ ] **1.3** Implement the minimum to pass — `PresenterOptions`,
+  `Presenter`, `startPresenter`. Internal `state` object with
+  `currentSlideId`, `atEndScreen`, `slides: readonly Slide[]`,
+  `doc: SlidesDocument`. Navigation methods mutate state; render is
+  a no-op stub at this point.
+
+  Important shape — tests will rely on this:
+
+  ```ts
+  export interface Presenter {
+    setDocument(doc: SlidesDocument): void;
+    dispose(): void;
+    // test-only helpers (also re-exported under a `__testing` namespace?):
+    // - getCurrentSlideId(): string | null
+    // - isAtEndScreen(): boolean
+  }
+  ```
+
+  Decision: expose `getCurrentSlideId()` and `isAtEndScreen()` on
+  the `Presenter` interface itself. They're cheap and useful for
+  the React shell (e.g., showing the slide number, though we
+  aren't doing that in v1).
+
+- [ ] **1.4** Run tests, confirm pass.
+- [ ] **1.5** Commit: `slides: add presenter scaffold and navigation state`.
+
+---
+
+## Task 2 — Canvas render integration
+
+**Files:**
+
+- Modify: `packages/slides/src/view/present/presenter.ts`
+- Modify: `packages/slides/src/view/present/presenter.test.ts`
+
+Mount a `<canvas>` into `container`, size it to a fit-to-viewport box
+(with `devicePixelRatio` baked into the backing store), and re-render
+through `SlideRenderer` on every navigation. Reuse the math from
+`slides-view.tsx`'s `computeFitSize` — copy it locally as a small
+private helper rather than touching the frontend file in this task.
+
+- [ ] **2.1** Add a failing test that verifies after `startPresenter`,
+  `container.querySelector('canvas')` is non-null and the canvas
+  `width`/`height` attributes reflect `dpr * fittedWidth/Height` for
+  a stubbed `window.innerWidth/innerHeight = 1280/720`.
+
+  Note: jsdom doesn't run `ResizeObserver`. Stub it:
+
+  ```ts
+  beforeEach(() => {
+    // jsdom lacks ResizeObserver
+    (globalThis as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+  ```
+
+- [ ] **2.2** Implement: in `startPresenter`, create canvas, append
+  to container, install a `ResizeObserver` on
+  `document.documentElement` that recomputes fit on resize.
+  Construct a `SlideRenderer(ctx, { hostWidth, hostHeight, dpr })`.
+  Add a private `paint()` that branches on state:
+  - `state.atEndScreen === true` → fill the canvas black and draw
+    centered white text "End of slideshow — click or press Esc to
+    exit" directly via the 2D context (no `SlideRenderer` involved).
+    Font: `${Math.round(hostHeight * 0.04)}px system-ui`.
+  - Otherwise → look up the current slide by ID and call
+    `renderer.render(slide, doc)`. Between slide switches call
+    `renderer.markDirty()` first — `SlideRenderer` is per-slide-state
+    and skips repaints without it.
+
+  Call `paint()` after every state change and after resize.
+
+- [ ] **2.3** Add a follow-up test that `next()` triggers an additional
+  call to a spied `renderer.render`. (Spy via vi.spyOn on
+  `SlideRenderer.prototype.render`.) Add a test that
+  `next()` from the last slide enters end-screen and that
+  `renderer.render` is NOT called for the end-screen paint (it's a
+  raw 2D fill).
+
+- [ ] **2.4** Container background: set `container.style.background =
+  '#000'` and `display: flex; align-items: center; justify-content:
+  center` so the canvas letterboxes naturally. Save prior inline
+  styles to restore on `dispose`.
+
+- [ ] **2.5** Run tests, pass.
+- [ ] **2.6** Commit: `slides: render slides on the presenter canvas`.
+
+---
+
+## Task 3 — Keyboard + click-to-advance
+
+**Files:**
+
+- Modify: `packages/slides/src/view/present/presenter.ts`
+- Modify: `packages/slides/src/view/present/presenter.test.ts`
+
+Install a capture-phase `keydown` listener on `document` and a `click`
+listener on the canvas. The keydown listener `stopImmediatePropagation`s
+every key (so editor key rules don't also fire) and `preventDefault`s
+anything it doesn't consume.
+
+- [ ] **3.1** Failing tests:
+  - Dispatching `keydown` for `'ArrowRight'`, `' '` (space),
+    `'PageDown'`, `'n'` advances. (One sub-test each, plus an
+    end-screen advance.)
+  - `'ArrowLeft'`, `'PageUp'`, `'Backspace'`, `'p'` go back.
+  - `'Home'` / `'End'` jump.
+  - `'Escape'` calls `onExit`.
+  - `'z'` (with Cmd) does nothing AND `stopImmediatePropagation` /
+    `preventDefault` are invoked — spy on the event. Use
+    `new KeyboardEvent('keydown', { key: 'z', metaKey: true })` and
+    `document.dispatchEvent(ev)`; check that `ev.defaultPrevented`
+    is `true`.
+  - Click on the canvas advances. Click on canvas while at
+    end-screen invokes `onExit`.
+
+- [ ] **3.2** Implement the listener. Use a single keydown handler
+  table — `KEY_ACTIONS: Record<string, (state) => void>` — to keep
+  the rule list compact. `Esc` → `options.onExit()` (caller decides
+  whether to call `dispose` from `onExit`).
+
+- [ ] **3.3** Pass.
+- [ ] **3.4** Commit: `slides: wire presenter keyboard and click navigation`.
+
+---
+
+## Task 4 — Cursor auto-hide + fullscreen with overlay fallback
+
+**Files:**
+
+- Modify: `packages/slides/src/view/present/presenter.ts`
+- Modify: `packages/slides/src/view/present/presenter.test.ts`
+
+Hide the cursor after 3 s of no `mousemove` and restore on
+`mousemove`. Call `container.requestFullscreen()` on entry; on
+rejection, apply `position: fixed; inset: 0; z-index: 9999`. Listen
+to `document.fullscreenchange` and call `onExit` when we leave
+fullscreen via the browser chrome.
+
+- [ ] **4.1** Failing tests (use `vi.useFakeTimers()`):
+  - `container.style.cursor === 'none'` after 3 s of no movement.
+  - `mousemove` clears `cursor` and re-arms.
+  - `requestFullscreen` is called on the container; when it rejects,
+    `container.style.position === 'fixed'` and `inset === '0px'`.
+  - `fullscreenchange` event with `document.fullscreenElement = null`
+    triggers `onExit`. (Stub via `Object.defineProperty` because
+    jsdom doesn't implement fullscreen.)
+
+- [ ] **4.2** Implement. Store the original inline style values
+  (`container.style.cssText`?) once at entry and restore on
+  `dispose`. Track `mountMode: 'fullscreen' | 'overlay'` so
+  `dispose` knows whether to call `exitFullscreen` or just remove
+  the overlay styles.
+
+- [ ] **4.3** Pass. Commit:
+  `slides: add presenter fullscreen with overlay fallback and cursor auto-hide`.
+
+---
+
+## Task 5 — Remote-change handling in setDocument
+
+**Files:**
+
+- Modify: `packages/slides/src/view/present/presenter.ts`
+- Modify: `packages/slides/src/view/present/presenter.test.ts`
+
+`setDocument(newDoc)` must:
+
+1. Re-bind `state.doc` and `state.slides`.
+2. If the current slide ID is still present, re-render (so theme /
+   element edits show up immediately).
+3. If it's gone, pick the slide at the same index in the new array;
+   if the index is now out-of-bounds, pick the last; update
+   `currentSlideId`.
+4. If `slides.length === 0`, call `onExit`.
+5. The `atEndScreen` state is preserved unless the deck shrinks below
+   the original-last-slide index, in which case it stays at
+   end-screen (`atEndScreen = true`) — the presentation is still
+   "over."
+
+- [ ] **5.1** Failing tests:
+  - Setting a doc where current slide still exists → no slide-id
+    change; render is called once with the new doc.
+  - Setting a doc where current slide is removed (was at index 1 of
+    `[A, B, C]`; new is `[A, C]`) → currentSlideId becomes the
+    slide now at index 1 (`C`).
+  - Removing all slides → `onExit` invoked.
+
+- [ ] **5.2** Implement. Pass. Commit:
+  `slides: handle remote doc changes in the presenter`.
+
+---
+
+## Task 6 — dispose() cleanup + public exports
+
+**Files:**
+
+- Modify: `packages/slides/src/view/present/presenter.ts`
+- Modify: `packages/slides/src/view/present/index.ts`
+- Modify: `packages/slides/src/view/present/presenter.test.ts`
+- Modify: `packages/slides/src/index.ts`
+
+Make sure `dispose()` is idempotent and tears down everything
+installed. **Order matters**: detach the `fullscreenchange` listener
+BEFORE calling `exitFullscreen`, otherwise our own teardown triggers
+the listener which calls `onExit` which loops back into `dispose`.
+
+- Set a `disposed = true` flag at the very top; bail out of further
+  cleanup if it was already set (idempotency).
+- Remove the `fullscreenchange` listener.
+- Remove the document-level keydown listener (capture-phase — must
+  pass `{ capture: true }` to `removeEventListener` to match the
+  registration).
+- Remove the canvas click listener.
+- Remove the `mousemove` listener.
+- Clear the cursor-hide timeout.
+- Disconnect the `ResizeObserver`.
+- If `mountMode === 'fullscreen'` AND `document.fullscreenElement`
+  is non-null, call `document.exitFullscreen()` wrapped in a
+  try/catch (it throws when not in fullscreen, e.g. user already
+  pressed Esc).
+- Remove the canvas from `container`.
+- Restore the container's `style.cssText` to its pre-entry value.
+
+- [ ] **6.1** Test: call `dispose()`, then verify
+  `container.children.length === 0`, container style restored,
+  subsequent `keydown` dispatches don't advance / don't crash, and a
+  second `dispose()` call is a no-op.
+
+- [ ] **6.2** Implement.
+
+- [ ] **6.3** Add `view/present/index.ts`:
+
+  ```ts
+  export {
+    startPresenter,
+    type Presenter,
+    type PresenterOptions,
+  } from './presenter';
+  ```
+
+  Append to `packages/slides/src/index.ts`:
+
+  ```ts
+  export {
+    startPresenter,
+    type Presenter,
+    type PresenterOptions,
+  } from './view/present';
+  ```
+
+- [ ] **6.4** Run `pnpm --filter @wafflebase/slides test` + `typecheck`
+  + `build` to make sure the new export survives the library build.
+
+- [ ] **6.5** Commit: `slides: ship presenter dispose and public exports`.
+
+---
+
+## Task 7 — React shell (slides-presentation-mode.tsx)
+
+**Files:**
+
+- Create: `packages/frontend/src/app/slides/slides-presentation-mode.tsx`
+- Create: `packages/frontend/src/app/slides/slides-presentation-mode.test.tsx`
+
+Thin React component that owns a portal `<div>` (mounted onto
+`document.body`), calls `startPresenter` on mount, forwards
+`store.onChange` snapshots into `presenter.setDocument`, and
+`dispose`s on unmount.
+
+Props:
+
+```ts
+interface SlidesPresentationModeProps {
+  store: YorkieSlidesStore;
+  startSlideId: string;
+  onExit: () => void;
+}
+```
+
+Implementation outline:
+
+```tsx
+export function SlidesPresentationMode(props: SlidesPresentationModeProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const presenterRef = useRef<Presenter | null>(null);
+
+  useEffect(() => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    hostRef.current = host;
+
+    // Drop editor focus so its contenteditable doesn't eat keystrokes.
+    (document.activeElement as HTMLElement | null)?.blur?.();
+
+    const presenter = startPresenter({
+      container: host,
+      doc: props.store.read(),
+      startSlideId: props.startSlideId,
+      onExit: () => {
+        props.onExit();
+      },
+    });
+    presenterRef.current = presenter;
+
+    const unsubscribe = props.store.onChange(() => {
+      presenter.setDocument(props.store.read());
+    });
+
+    return () => {
+      unsubscribe();
+      presenter.dispose();
+      host.remove();
+      presenterRef.current = null;
+      hostRef.current = null;
+    };
+  // Intentionally mount-only: store / startSlideId changes are not
+  // expected within a single presentation session. If they did
+  // change, we'd want to dispose + remount rather than reconfigure
+  // mid-flight.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+}
+```
+
+- [ ] **7.1** Failing test (`slides-presentation-mode.test.tsx`): mount
+  with a stub store (`onChange`, `read`), assert
+  `document.body.lastChild` is a `<div>` containing a `<canvas>`.
+  Unmount, assert the div is gone.
+
+- [ ] **7.2** Implement and pass.
+
+- [ ] **7.3** Commit: `slides: add presentation-mode react shell`.
+
+---
+
+## Task 8 — Wire `onStartPresentation` in slides-view.tsx
+
+**Files:**
+
+- Modify: `packages/frontend/src/app/slides/slides-view.tsx`
+
+`SlidesLayout` (the parent in `slides-detail.tsx`) owns the
+"presenting" state. `slides-view.tsx` forwards a prop down to the
+editor:
+
+```ts
+interface SlidesViewProps {
+  // ...existing
+  onStartPresentation?: (from: 'current' | 'first') => void;
+}
+```
+
+…and passes it into `initializeEditor`:
+
+```ts
+const editor = initializeEditor({
+  // ...
+  onStartPresentation: props.onStartPresentation,
+});
+```
+
+- [ ] **8.1** Update the prop type + thread it through to
+  `initializeEditor`. The comment block currently saying "Present
+  mode UI lands in a separate phase" needs to be deleted (it's now
+  landed).
+
+- [ ] **8.2** Run `pnpm --filter @wafflebase/frontend typecheck`.
+
+- [ ] **8.3** Commit: `slides: forward onStartPresentation to the editor`.
+
+---
+
+## Task 9 — Present split-button + state in slides-detail.tsx
+
+**Files:**
+
+- Modify: `packages/frontend/src/app/slides/slides-detail.tsx`
+
+Add the `presentingFrom: 'current' | 'first' | null` local state,
+the handler that sets it, and the conditional
+`<SlidesPresentationMode />` mount. Add a "Present" split-button into
+the `SiteHeader` children, next to `ShareDialog` and `UserPresence`.
+
+Split-button shape: a primary button ("Present") + a small chevron
+that opens a Radix dropdown menu with one item ("Present from
+beginning"). The primary button calls `handleStart('current')`, the
+menu item calls `handleStart('first')`. Disabled when
+`!store || store.read().slides.length === 0`.
+
+The starting slide ID:
+
+```ts
+function resolveStartSlideId(
+  store: YorkieSlidesStore,
+  from: 'current' | 'first',
+  editor: SlidesEditor | null,
+): string | undefined {
+  const slides = store.read().slides;
+  if (slides.length === 0) return undefined;
+  if (from === 'first') return slides[0].id;
+  return editor?.getCurrentSlideId() ?? slides[0].id;
+}
+```
+
+Mount conditionally:
+
+```tsx
+{presentingFrom && store && (
+  <SlidesPresentationMode
+    store={store}
+    startSlideId={resolveStartSlideId(store, presentingFrom, editor)!}
+    onExit={() => setPresentingFrom(null)}
+  />
+)}
+```
+
+The button uses Lucide `Play` icon + the existing
+`@/components/ui/button` + `@/components/ui/dropdown-menu`
+primitives (check sibling files for the exact import paths).
+
+- [ ] **9.1** Add a tiny `<PresentButton />` component inside
+  `slides-detail.tsx` (or extract to its own file
+  `slides-present-button.tsx` if it grows beyond ~30 lines).
+
+  Props: `{ disabled: boolean; onStart: (from: 'current' | 'first') => void }`.
+
+- [ ] **9.2** Wire the state + the conditional mount. The
+  `handleStart` function MUST early-return when
+  `!store || store.read().slides.length === 0` — this guards both
+  the button path and the `Cmd+Enter` shortcut path (the shortcut
+  goes through the editor's `onStartPresentation` callback, which
+  we wire to the same `handleStart`). The button's `disabled` is
+  cosmetic defense-in-depth; the handler guard is the real one.
+
+- [ ] **9.3** Verify the button is keyboard-accessible (Tab into it,
+  Enter fires "current", `ArrowDown` opens the menu). The existing
+  dropdown-menu primitive handles this — just make sure the button
+  isn't wrapped in something that swallows keys.
+
+- [ ] **9.4** Commit: `slides: add Present split-button to the slides header`.
+
+---
+
+## Task 10 — Verify + smoke + close out
+
+- [ ] **10.1** `pnpm verify:fast` — passes (Exit 0). If lint / unit
+  tests fail, fix and re-run before continuing.
+
+- [ ] **10.2** Manual smoke (`pnpm dev`):
+  1. Open a slides doc, create 3 slides with distinct titles.
+  2. Click the **Present** button → fullscreen, current slide
+     visible, letterboxed.
+  3. `→` advances. `←` goes back. `Space`/`PageDown` advance.
+     `Home`/`End` jump.
+  4. Click on the canvas → advances.
+  5. `→` past the last slide → black "End of slideshow" screen.
+     Click it → exits to editor.
+  6. Re-enter, hit `Esc` → exits cleanly.
+  7. Re-enter on slide 2, in another browser tab edit slide 2's
+     text → text updates in presenter.
+  8. Re-enter on slide 3, in another tab delete slide 3 → presenter
+     jumps to remaining last slide.
+  9. Click chevron → "Present from beginning" → starts at slide 1.
+  10. Move mouse, wait 3 s → cursor disappears. Move → reappears.
+
+  If any step regresses, fix before declaring done.
+
+- [ ] **10.3** Cross-check the slides-keyboard-shortcuts task doc
+  (`20260514-slides-keyboard-shortcuts-todo.md`) — Task 4 has a
+  "Deferred: onStartPresentation wiring" item that this PR closes.
+  Tick that box and add a back-reference.
+
+- [ ] **10.4** Update commit log into a single PR-ready summary in
+  a `## Status` section at the end of this file (mirror the
+  keyboard-shortcuts task doc's pattern).
+
+- [ ] **10.5** Self review the full branch diff via
+  `superpowers:requesting-code-review` or `/code-review` before
+  pushing. Address blocking findings; note non-blocking ones as
+  known limitations in the PR description.
+
+- [ ] **10.6** Capture lessons in
+  `20260514-slides-presentation-mode-lessons.md`.
+
+- [ ] **10.7** `pnpm tasks:archive && pnpm tasks:index`. Commit
+  the archived files and the README update.
+
+---
+
+## Status
+
+_Filled in as work progresses._

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -18,6 +18,8 @@ import type { Theme } from "@wafflebase/slides";
 import type { YorkieSlidesRoot } from "@/types/slides-document";
 import { SlidesView, type SlidesEditor } from "./slides-view";
 import { SlidesFormattingToolbar } from "./slides-formatting-toolbar";
+import { SlidesPresentationMode } from "./slides-presentation-mode";
+import { PresentButton } from "./slides-present-button";
 import { ThemePanel } from "./theme-panel";
 import type { YorkieSlidesStore } from "./yorkie-slides-store";
 
@@ -28,6 +30,26 @@ import type { YorkieSlidesStore } from "./yorkie-slides-store";
  */
 function initialSlidesRoot(): Partial<YorkieSlidesRoot> {
   return {};
+}
+
+/**
+ * Resolve the slide id where a fresh presentation session should start.
+ * `from === "first"` always returns the deck's first slide. `from ===
+ * "current"` prefers the editor's active slide, falling back to the
+ * first slide when the editor hasn't broadcast a selection yet (e.g.,
+ * the user hit Cmd+Enter before clicking anywhere). Returns undefined
+ * for an empty deck — the caller guards on that before mounting the
+ * presenter.
+ */
+function resolveStartSlideId(
+  store: YorkieSlidesStore,
+  from: "current" | "first",
+  editor: SlidesEditor | null,
+): string | undefined {
+  const slides = store.read().slides;
+  if (slides.length === 0) return undefined;
+  if (from === "first") return slides[0].id;
+  return editor?.getCurrentSlideId() ?? slides[0].id;
 }
 
 /**
@@ -45,6 +67,17 @@ function SlidesLayout({ documentId }: { documentId: string }) {
   // below — local applies notify after the batch commits, remote applies
   // notify on the Yorkie subscription.
   const [currentThemeId, setCurrentThemeId] = useState("default-light");
+  // `presentingFrom` is the present-mode state machine: null while
+  // editing, 'current' | 'first' while a session is mounted. Flipping
+  // to a non-null value mounts <SlidesPresentationMode>; the presenter's
+  // onExit flips it back to null.
+  const [presentingFrom, setPresentingFrom] = useState<
+    "current" | "first" | null
+  >(null);
+  // Mirror the deck size so the Present button can disable itself when
+  // the deck momentarily holds zero slides (before the editor seeds its
+  // initial slide). Re-evaluated on every store change.
+  const [slideCount, setSlideCount] = useState(0);
 
   useEffect(() => {
     if (!store) return;
@@ -53,6 +86,26 @@ function SlidesLayout({ documentId }: { documentId: string }) {
       setCurrentThemeId(store.read().meta.themeId);
     });
   }, [store]);
+
+  useEffect(() => {
+    if (!store) {
+      setSlideCount(0);
+      return;
+    }
+    setSlideCount(store.getSlideCount());
+    return store.onChange(() => {
+      setSlideCount(store.getSlideCount());
+    });
+  }, [store]);
+
+  const handleStartPresentation = useCallback(
+    (from: "current" | "first") => {
+      if (!store) return;
+      if (store.read().slides.length === 0) return;
+      setPresentingFrom(from);
+    },
+    [store],
+  );
 
   // Resolve the active Theme object — fed to the contextual color and
   // font pickers in the toolbar so their "Theme" rows match the deck.
@@ -156,6 +209,10 @@ function SlidesLayout({ documentId }: { documentId: string }) {
           onRename={handleRenameDocument}
         >
           <div className="flex items-center gap-2">
+            <PresentButton
+              disabled={!store || slideCount === 0}
+              onStart={handleStartPresentation}
+            />
             <ShareDialog documentId={documentId} />
             <UserPresence />
           </div>
@@ -172,6 +229,7 @@ function SlidesLayout({ documentId }: { documentId: string }) {
             <SlidesView
               onEditorReady={setEditor}
               onStoreReady={setStore}
+              onStartPresentation={handleStartPresentation}
               documentId={documentId}
             />
             {themePanelOpen && store && (
@@ -184,6 +242,13 @@ function SlidesLayout({ documentId }: { documentId: string }) {
           </div>
         </div>
       </SidebarInset>
+      {presentingFrom && store && (
+        <SlidesPresentationMode
+          store={store}
+          startSlideId={resolveStartSlideId(store, presentingFrom, editor)!}
+          onExit={() => setPresentingFrom(null)}
+        />
+      )}
     </SidebarProvider>
   );
 }

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -242,22 +242,39 @@ function SlidesLayout({ documentId }: { documentId: string }) {
           </div>
         </div>
       </SidebarInset>
-      {presentingFrom && store && (
-        <SlidesPresentationMode
-          store={store}
-          startSlideId={resolveStartSlideId(store, presentingFrom, editor)!}
-          onExit={() => {
-            // The presenter calls onExit for several reasons (Esc, end-
-            // screen click, native fullscreen exit, empty deck). We
-            // can't ask which — but if the deck is empty right now,
-            // the empty-deck branch of setDocument is what called us.
-            if (store.read().slides.length === 0) {
-              toast.info("Presentation ended (deck is empty)");
-            }
-            setPresentingFrom(null);
-          }}
-        />
-      )}
+      {presentingFrom &&
+        store &&
+        (() => {
+          // resolveStartSlideId returns undefined when the deck is
+          // empty. `presentingFrom` is gated on the empty-deck check
+          // in `handleStartPresentation`, but a remote peer can empty
+          // the deck between `setPresentingFrom(...)` and the next
+          // render — the conditional would otherwise reach here with
+          // an undefined start id. Guard explicitly instead of using
+          // a non-null assertion.
+          const startSlideId = resolveStartSlideId(
+            store,
+            presentingFrom,
+            editor,
+          );
+          if (!startSlideId) return null;
+          return (
+            <SlidesPresentationMode
+              store={store}
+              startSlideId={startSlideId}
+              onExit={() => {
+                // The presenter calls onExit for several reasons (Esc, end-
+                // screen click, native fullscreen exit, empty deck). We
+                // can't ask which — but if the deck is empty right now,
+                // the empty-deck branch of setDocument is what called us.
+                if (store.read().slides.length === 0) {
+                  toast.info("Presentation ended (deck is empty)");
+                }
+                setPresentingFrom(null);
+              }}
+            />
+          );
+        })()}
     </SidebarProvider>
   );
 }

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -246,7 +246,16 @@ function SlidesLayout({ documentId }: { documentId: string }) {
         <SlidesPresentationMode
           store={store}
           startSlideId={resolveStartSlideId(store, presentingFrom, editor)!}
-          onExit={() => setPresentingFrom(null)}
+          onExit={() => {
+            // The presenter calls onExit for several reasons (Esc, end-
+            // screen click, native fullscreen exit, empty deck). We
+            // can't ask which — but if the deck is empty right now,
+            // the empty-deck branch of setDocument is what called us.
+            if (store.read().slides.length === 0) {
+              toast.info("Presentation ended (deck is empty)");
+            }
+            setPresentingFrom(null);
+          }}
         />
       )}
     </SidebarProvider>

--- a/packages/frontend/src/app/slides/slides-present-button.tsx
+++ b/packages/frontend/src/app/slides/slides-present-button.tsx
@@ -1,0 +1,73 @@
+import { IconPlayerPlay, IconChevronDown } from "@tabler/icons-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+/**
+ * Split-button that enters present mode. Primary click starts from the
+ * editor's current slide; the chevron's dropdown offers "from beginning"
+ * (mirroring Google Slides). The two menu items also surface the
+ * keyboard shortcut hints — the corresponding bindings live in the
+ * editor and dispatch through the same `onStart` callback used here.
+ */
+interface PresentButtonProps {
+  disabled: boolean;
+  onStart: (from: "current" | "first") => void;
+}
+
+export function PresentButton({ disabled, onStart }: PresentButtonProps) {
+  const modKey =
+    typeof navigator !== "undefined" &&
+    navigator.platform.toLowerCase().includes("mac")
+      ? "⌘"
+      : "Ctrl";
+  return (
+    <div className="inline-flex items-center rounded-md border">
+      <button
+        type="button"
+        onClick={() => onStart("current")}
+        disabled={disabled}
+        aria-label="Present from current slide"
+        className="inline-flex h-8 items-center gap-1.5 rounded-l-md px-3 text-sm hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
+      >
+        <IconPlayerPlay size={16} />
+        <span>Present</span>
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            disabled={disabled}
+            aria-label="Present options"
+            className="inline-flex h-8 w-6 items-center justify-center rounded-r-md border-l hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
+          >
+            <IconChevronDown size={14} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onSelect={() => onStart("current")}
+          >
+            Present from current slide
+            <span className="ml-auto pl-4 text-xs text-muted-foreground">
+              {modKey}↵
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onSelect={() => onStart("first")}
+          >
+            Present from beginning
+            <span className="ml-auto pl-4 text-xs text-muted-foreground">
+              {modKey}⇧↵
+            </span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/slides/slides-presentation-mode.tsx
+++ b/packages/frontend/src/app/slides/slides-presentation-mode.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from "react";
+import { startPresenter, type Presenter } from "@wafflebase/slides";
+import type { YorkieSlidesStore } from "./yorkie-slides-store";
+
+interface SlidesPresentationModeProps {
+  store: YorkieSlidesStore;
+  startSlideId: string;
+  onExit: () => void;
+}
+
+/**
+ * Thin React wrapper that hosts the framework-free presenter from
+ * @wafflebase/slides. Creates a portal <div> on document.body, mounts
+ * the presenter, forwards every store snapshot into setDocument so the
+ * presenter reacts to remote edits, and disposes on unmount.
+ *
+ * The component renders no DOM of its own — the host <div> is created
+ * imperatively so its lifetime is decoupled from React's reconciliation
+ * (the presenter manipulates this element directly: appends a canvas,
+ * applies letterbox styles, requests fullscreen). Rendering null avoids
+ * confusing React strict-mode double-mounts with two host divs.
+ */
+export function SlidesPresentationMode(props: SlidesPresentationModeProps) {
+  const onExitRef = useRef(props.onExit);
+  onExitRef.current = props.onExit;
+
+  useEffect(() => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    // Drop editor focus so its contenteditable doesn't eat keystrokes
+    // inside the fullscreen element.
+    const active = document.activeElement;
+    if (active instanceof HTMLElement) active.blur();
+
+    let presenter: Presenter | null = null;
+    try {
+      presenter = startPresenter({
+        container: host,
+        doc: props.store.read(),
+        startSlideId: props.startSlideId,
+        onExit: () => onExitRef.current(),
+      });
+    } catch (e) {
+      // Defensive — startPresenter currently doesn't throw, but a
+      // future change could (e.g., an empty deck assertion). Surface
+      // it as a one-shot exit so the shell unmounts us.
+      host.remove();
+      onExitRef.current();
+      throw e;
+    }
+
+    const unsubscribe = props.store.onChange(() => {
+      presenter?.setDocument(props.store.read());
+    });
+
+    return () => {
+      unsubscribe();
+      presenter?.dispose();
+      host.remove();
+    };
+    // Intentionally mount-only: store + startSlideId changes are not
+    // expected within a single presentation session. The parent unmounts
+    // us when the session ends and remounts a fresh component when a
+    // new session starts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+}

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -38,6 +38,15 @@ interface SlidesViewProps {
    * own Yorkie store wrapper.
    */
   onStoreReady?: (store: YorkieSlidesStore | null) => void;
+  /**
+   * Invoked when the editor wants to enter present mode — currently
+   * driven by Cmd/Ctrl+Enter (from current slide) and Cmd/Ctrl+Shift+
+   * Enter (from the first slide). The parent shell owns the present
+   * mode UI (Task 7); this prop just routes the editor-level shortcut
+   * to it. Captured via a ref so a new callback identity from the
+   * parent doesn't remount the editor.
+   */
+  onStartPresentation?: (from: "current" | "first") => void;
 }
 
 // Logical slide aspect (1920×1080 = 16:9). The canvas is sized to fit
@@ -87,12 +96,24 @@ function computeFitSize(availWidth: number, availHeight: number): {
  * preload Noto KR via `document.fonts.load` the same way docs'
  * PDF exporter does.
  */
-export function SlidesView({ onEditorReady, onStoreReady }: SlidesViewProps) {
+export function SlidesView({
+  onEditorReady,
+  onStoreReady,
+  onStartPresentation,
+}: SlidesViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<SlidesEditor | null>(null);
   const [didMount, setDidMount] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const { doc, loading, error } = useDocument<YorkieSlidesRoot, SlidesPresence>();
+
+  // Capture the latest onStartPresentation in a ref so the editor's
+  // Cmd/Ctrl+Enter handler always calls the freshest callback, without
+  // adding the prop to the mount effect's deps (which would tear down
+  // and rebuild the editor whenever the parent re-renders with a new
+  // callback identity).
+  const onStartPresentationRef = useRef(onStartPresentation);
+  onStartPresentationRef.current = onStartPresentation;
 
   // Prevent double-initialization in React strict mode / dev HMR.
   useEffect(() => {
@@ -263,11 +284,11 @@ export function SlidesView({ onEditorReady, onStoreReady }: SlidesViewProps) {
       hostHeight: hostH,
       dpr,
       onShowShortcutsHelp: () => setHelpOpen(true),
-      // onStartPresentation / onLinkRequest are intentionally left
-      // unwired here. Present mode UI lands in a separate phase, and
-      // the link popover needs a richer TextBoxEditorAPI (insertLink /
-      // getLinkAtCursor) before it can drive the docs text-box.
-      // Cmd+Enter / Cmd+K no-op at the editor level until then.
+      onStartPresentation: (from) => onStartPresentationRef.current?.(from),
+      // onLinkRequest is still intentionally unwired — the link popover
+      // needs a richer TextBoxEditorAPI (insertLink / getLinkAtCursor)
+      // before it can drive the docs text-box. Cmd+K no-ops at the
+      // editor level until then.
     });
     editorRef.current = editor;
     onEditorReady?.(editor);

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -86,3 +86,10 @@ export { showLayoutPicker, type LayoutPickerOptions } from './view/editor/layout
 export { showContextMenu, dismiss as dismissContextMenu, type ContextMenuItem } from './view/editor/context-menu';
 export { MIME_TYPE as SLIDES_CLIPBOARD_MIME, serializeElements, deserializeElements } from './view/editor/interactions/clipboard';
 export { SHORTCUTS, formatCombo, type ShortcutEntry, type ShortcutCategory } from './view/editor/shortcuts-catalog';
+
+// View — Presenter (presentation mode)
+export {
+  startPresenter,
+  type Presenter,
+  type PresenterOptions,
+} from './view/present';

--- a/packages/slides/src/view/present/index.ts
+++ b/packages/slides/src/view/present/index.ts
@@ -1,0 +1,5 @@
+export {
+  startPresenter,
+  type Presenter,
+  type PresenterOptions,
+} from './presenter';

--- a/packages/slides/src/view/present/presenter.test.ts
+++ b/packages/slides/src/view/present/presenter.test.ts
@@ -1,0 +1,279 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemSlidesStore } from '../../store/memory';
+import type { SlidesDocument } from '../../model/presentation';
+import { startPresenter, type Presenter } from './presenter';
+
+interface TestHandle {
+  next: () => void;
+  prev: () => void;
+  goToFirst: () => void;
+  goToLast: () => void;
+}
+
+function testApi(presenter: Presenter): TestHandle {
+  return (presenter as unknown as { __test: TestHandle }).__test;
+}
+
+function makeDoc(): { doc: SlidesDocument; ids: [string, string, string] } {
+  const store = new MemSlidesStore();
+  let aId = '';
+  let bId = '';
+  let cId = '';
+  store.batch(() => {
+    aId = store.addSlide('blank');
+    bId = store.addSlide('blank');
+    cId = store.addSlide('blank');
+  });
+  return { doc: store.read(), ids: [aId, bId, cId] };
+}
+
+function makeContainer(): HTMLElement {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  return el;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  // jsdom lacks ResizeObserver.
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  // Make requestFullscreen resolve cleanly inside jsdom.
+  (HTMLElement.prototype as unknown as { requestFullscreen: () => Promise<void> })
+    .requestFullscreen = vi.fn().mockResolvedValue(undefined);
+});
+
+describe('startPresenter — initial state', () => {
+  it('starts at the requested slide id and not at end-screen', () => {
+    const { doc, ids } = makeDoc();
+    const [, bId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: bId,
+      onExit: vi.fn(),
+    });
+    try {
+      expect(presenter.getCurrentSlideId()).toBe(bId);
+      expect(presenter.isAtEndScreen()).toBe(false);
+    } finally {
+      presenter.dispose();
+    }
+  });
+});
+
+describe('startPresenter — next()', () => {
+  it('advances A → B', () => {
+    const { doc, ids } = makeDoc();
+    const [aId, bId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).next();
+      expect(presenter.getCurrentSlideId()).toBe(bId);
+      expect(presenter.isAtEndScreen()).toBe(false);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('next() from the last slide enters the end-screen', () => {
+    const { doc, ids } = makeDoc();
+    const [, , cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: cId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).next();
+      expect(presenter.isAtEndScreen()).toBe(true);
+      expect(presenter.getCurrentSlideId()).toBeNull();
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('next() while at end-screen is a no-op (no auto-exit)', () => {
+    const { doc, ids } = makeDoc();
+    const [, , cId] = ids;
+    const onExit = vi.fn();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: cId,
+      onExit,
+    });
+    try {
+      testApi(presenter).next();
+      expect(presenter.isAtEndScreen()).toBe(true);
+      testApi(presenter).next();
+      expect(presenter.isAtEndScreen()).toBe(true);
+      expect(presenter.getCurrentSlideId()).toBeNull();
+      expect(onExit).not.toHaveBeenCalled();
+    } finally {
+      presenter.dispose();
+    }
+  });
+});
+
+describe('startPresenter — prev()', () => {
+  it('goes B → A', () => {
+    const { doc, ids } = makeDoc();
+    const [aId, bId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: bId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).prev();
+      expect(presenter.getCurrentSlideId()).toBe(aId);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('stays at A when already at the first slide', () => {
+    const { doc, ids } = makeDoc();
+    const [aId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).prev();
+      expect(presenter.getCurrentSlideId()).toBe(aId);
+      expect(presenter.isAtEndScreen()).toBe(false);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('from end-screen returns to the last slide and clears the flag', () => {
+    const { doc, ids } = makeDoc();
+    const [, , cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: cId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).next(); // → end-screen
+      expect(presenter.isAtEndScreen()).toBe(true);
+      testApi(presenter).prev();
+      expect(presenter.isAtEndScreen()).toBe(false);
+      expect(presenter.getCurrentSlideId()).toBe(cId);
+    } finally {
+      presenter.dispose();
+    }
+  });
+});
+
+describe('startPresenter — goToFirst() / goToLast()', () => {
+  it('goToFirst jumps to the first slide', () => {
+    const { doc, ids } = makeDoc();
+    const [aId, , cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: cId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).goToFirst();
+      expect(presenter.getCurrentSlideId()).toBe(aId);
+      expect(presenter.isAtEndScreen()).toBe(false);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('goToLast jumps to the last slide', () => {
+    const { doc, ids } = makeDoc();
+    const [aId, , cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).goToLast();
+      expect(presenter.getCurrentSlideId()).toBe(cId);
+      expect(presenter.isAtEndScreen()).toBe(false);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('goToFirst clears the end-screen flag', () => {
+    const { doc, ids } = makeDoc();
+    const [aId, , cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: cId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).next(); // → end-screen
+      expect(presenter.isAtEndScreen()).toBe(true);
+      testApi(presenter).goToFirst();
+      expect(presenter.isAtEndScreen()).toBe(false);
+      expect(presenter.getCurrentSlideId()).toBe(aId);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('goToLast clears the end-screen flag', () => {
+    const { doc, ids } = makeDoc();
+    const [, , cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: cId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).next(); // → end-screen
+      expect(presenter.isAtEndScreen()).toBe(true);
+      testApi(presenter).goToLast();
+      expect(presenter.isAtEndScreen()).toBe(false);
+      expect(presenter.getCurrentSlideId()).toBe(cId);
+    } finally {
+      presenter.dispose();
+    }
+  });
+});
+
+describe('startPresenter — dispose()', () => {
+  it('is idempotent', () => {
+    const { doc, ids } = makeDoc();
+    const [aId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    expect(() => {
+      presenter.dispose();
+      presenter.dispose();
+    }).not.toThrow();
+  });
+});

--- a/packages/slides/src/view/present/presenter.test.ts
+++ b/packages/slides/src/view/present/presenter.test.ts
@@ -639,6 +639,13 @@ describe('startPresenter — cursor auto-hide', () => {
 });
 
 describe('startPresenter — fullscreen', () => {
+  afterEach(() => {
+    // Some tests below stub `document.fullscreenElement` with a
+    // configurable getter — clear it so later suites see jsdom's
+    // default and don't inherit a stale stub.
+    delete (document as unknown as { fullscreenElement?: unknown }).fullscreenElement;
+  });
+
   it('calls container.requestFullscreen on mount', () => {
     const req = vi
       .spyOn(HTMLElement.prototype, 'requestFullscreen')
@@ -703,7 +710,9 @@ describe('startPresenter — fullscreen', () => {
     });
     try {
       // Wait for the resolved requestFullscreen Promise to settle so
-      // mountMode remains 'fullscreen'.
+      // `enteredFullscreen` flips to `true` inside the `.then`
+      // continuation. Without this flush the handler would (correctly)
+      // ignore the dispatched event.
       await Promise.resolve();
       await Promise.resolve();
       document.dispatchEvent(new Event('fullscreenchange'));
@@ -730,6 +739,68 @@ describe('startPresenter — fullscreen', () => {
     });
     try {
       // Settle the rejected Promise so mountMode flips to 'overlay'.
+      // `enteredFullscreen` stays false since the `.then` never ran.
+      await Promise.resolve();
+      await Promise.resolve();
+      document.dispatchEvent(new Event('fullscreenchange'));
+      expect(onExit).not.toHaveBeenCalled();
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('fullscreenchange before requestFullscreen resolves does NOT trigger onExit', async () => {
+    // Pending forever — `enteredFullscreen` never flips to true. A
+    // stray fullscreenchange (e.g. some other element on the page
+    // exiting fullscreen while ours is still pending) must not be
+    // mistaken for our own exit.
+    (HTMLElement.prototype as unknown as { requestFullscreen: () => Promise<void> })
+      .requestFullscreen = vi.fn().mockReturnValue(new Promise<void>(() => {}));
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => null,
+    });
+    const onExit = vi.fn();
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: ids[0],
+      onExit,
+    });
+    try {
+      // Even after flushing, the pending Promise above never resolves,
+      // so `enteredFullscreen` remains false.
+      await Promise.resolve();
+      await Promise.resolve();
+      document.dispatchEvent(new Event('fullscreenchange'));
+      expect(onExit).not.toHaveBeenCalled();
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('fullscreenchange while our container is still the fullscreen element does NOT trigger onExit', async () => {
+    // Identity check: our container IS the fullscreen element. A
+    // fullscreenchange that leaves us as the fullscreen element (e.g.
+    // dispatched spuriously, or paired with a sibling transition that
+    // doesn't dethrone us) must not exit the presenter.
+    const onExit = vi.fn();
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => container,
+    });
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit,
+    });
+    try {
+      // Flush so `enteredFullscreen` becomes true via the resolved
+      // requestFullscreen Promise from the global beforeEach.
       await Promise.resolve();
       await Promise.resolve();
       document.dispatchEvent(new Event('fullscreenchange'));

--- a/packages/slides/src/view/present/presenter.test.ts
+++ b/packages/slides/src/view/present/presenter.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '../canvas/test-canvas-env';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemSlidesStore } from '../../store/memory';
 import type { SlidesDocument } from '../../model/presentation';
 import { SlideRenderer } from '../canvas/slide-renderer';
@@ -577,6 +577,163 @@ describe('startPresenter — click-to-advance', () => {
       const canvas = testApi(presenter).getCanvas();
       canvas.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       expect(onExit).toHaveBeenCalledOnce();
+    } finally {
+      presenter.dispose();
+    }
+  });
+});
+
+describe('startPresenter — cursor auto-hide', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('hides the cursor after 3 s of no mousemove', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    try {
+      // Initial timer is armed at mount; before the delay elapses
+      // the cursor must still be its default (empty inline style).
+      expect(container.style.cursor).toBe('');
+      vi.advanceTimersByTime(3_000);
+      expect(container.style.cursor).toBe('none');
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('mousemove restores the cursor and re-arms the hide timer', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    try {
+      vi.advanceTimersByTime(3_000);
+      expect(container.style.cursor).toBe('none');
+
+      container.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+      expect(container.style.cursor).toBe('');
+
+      vi.advanceTimersByTime(2_999);
+      expect(container.style.cursor).toBe('');
+
+      vi.advanceTimersByTime(1);
+      expect(container.style.cursor).toBe('none');
+    } finally {
+      presenter.dispose();
+    }
+  });
+});
+
+describe('startPresenter — fullscreen', () => {
+  it('calls container.requestFullscreen on mount', () => {
+    const req = vi
+      .spyOn(HTMLElement.prototype, 'requestFullscreen')
+      .mockResolvedValue(undefined);
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    try {
+      expect(req).toHaveBeenCalledTimes(1);
+      // requestFullscreen is invoked on the container element.
+      expect(req.mock.instances[0]).toBe(container);
+    } finally {
+      presenter.dispose();
+      req.mockRestore();
+    }
+  });
+
+  it('falls back to overlay styles when requestFullscreen rejects', async () => {
+    (HTMLElement.prototype as unknown as { requestFullscreen: () => Promise<void> })
+      .requestFullscreen = vi.fn().mockRejectedValue(new Error('denied'));
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    try {
+      // The .catch handler runs on the microtask queue; flush once for
+      // the resolved-promise hop, again for the .catch continuation.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(container.style.position).toBe('fixed');
+      expect(container.style.top).toBe('0px');
+      expect(container.style.left).toBe('0px');
+      expect(container.style.right).toBe('0px');
+      expect(container.style.bottom).toBe('0px');
+      expect(container.style.zIndex).toBe('9999');
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('fullscreenchange to null triggers onExit when mounted in fullscreen', async () => {
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => null,
+    });
+    const onExit = vi.fn();
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: ids[0],
+      onExit,
+    });
+    try {
+      // Wait for the resolved requestFullscreen Promise to settle so
+      // mountMode remains 'fullscreen'.
+      await Promise.resolve();
+      await Promise.resolve();
+      document.dispatchEvent(new Event('fullscreenchange'));
+      expect(onExit).toHaveBeenCalledTimes(1);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('fullscreenchange does NOT trigger onExit in overlay mode', async () => {
+    (HTMLElement.prototype as unknown as { requestFullscreen: () => Promise<void> })
+      .requestFullscreen = vi.fn().mockRejectedValue(new Error('denied'));
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => null,
+    });
+    const onExit = vi.fn();
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: ids[0],
+      onExit,
+    });
+    try {
+      // Settle the rejected Promise so mountMode flips to 'overlay'.
+      await Promise.resolve();
+      await Promise.resolve();
+      document.dispatchEvent(new Event('fullscreenchange'));
+      expect(onExit).not.toHaveBeenCalled();
     } finally {
       presenter.dispose();
     }

--- a/packages/slides/src/view/present/presenter.test.ts
+++ b/packages/slides/src/view/present/presenter.test.ts
@@ -401,6 +401,213 @@ describe('startPresenter — dispose()', () => {
   });
 });
 
+describe('dispose — cleanup', () => {
+  afterEach(() => {
+    delete (document as unknown as { fullscreenElement?: unknown }).fullscreenElement;
+  });
+
+  it('removes the canvas from the container', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    expect(container.querySelector('canvas')).not.toBeNull();
+    presenter.dispose();
+    expect(container.querySelector('canvas')).toBeNull();
+  });
+
+  it('restores container.style.cssText to its pre-mount snapshot', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    // Set inline styles BEFORE mount so dispose() can restore them.
+    container.style.background = 'red';
+    container.style.padding = '10px';
+    expect(container.style.background).toBe('red');
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    // Letterbox styles overwrote background while mounted.
+    expect(container.style.background).toBe('rgb(0, 0, 0)');
+    presenter.dispose();
+    expect(container.style.background).toBe('red');
+    expect(container.style.padding).toBe('10px');
+  });
+
+  it('removes the document keydown listener', () => {
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    expect(presenter.getCurrentSlideId()).toBe(ids[0]);
+    presenter.dispose();
+    // After dispose, ArrowRight on document must not change state.
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true }),
+    );
+    expect(presenter.getCurrentSlideId()).toBe(ids[0]);
+    expect(presenter.isAtEndScreen()).toBe(false);
+  });
+
+  it('removes the canvas click listener', () => {
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    const canvas = testApi(presenter).getCanvas();
+    presenter.dispose();
+    // The canvas reference is still around even after removal from
+    // the DOM — dispatch a click and confirm no state change.
+    canvas.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(presenter.getCurrentSlideId()).toBe(ids[0]);
+  });
+
+  it('disconnects the ResizeObserver', () => {
+    const observers: Array<{ disconnectCalled: boolean }> = [];
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      disconnectCalled = false;
+      constructor() {
+        observers.push(this);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {
+        this.disconnectCalled = true;
+      }
+    };
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    expect(observers.length).toBe(1);
+    expect(observers[0].disconnectCalled).toBe(false);
+    presenter.dispose();
+    expect(observers[0].disconnectCalled).toBe(true);
+  });
+
+  it('clears the cursor-hide timeout', () => {
+    vi.useFakeTimers();
+    try {
+      const { doc, ids } = makeDoc();
+      const container = makeContainer();
+      const presenter = startPresenter({
+        container,
+        doc,
+        startSlideId: ids[0],
+        onExit: vi.fn(),
+      });
+      // Dispose immediately, before the 3 s timer fires.
+      presenter.dispose();
+      vi.advanceTimersByTime(3_000);
+      // The cursor should never have been set to 'none'; the inline
+      // cssText was restored on dispose anyway, so the assertion is
+      // simply that nothing flipped to 'none' afterwards.
+      expect(container.style.cursor).not.toBe('none');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('removes the fullscreenchange listener', async () => {
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => null,
+    });
+    const onExit = vi.fn();
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: ids[0],
+      onExit,
+    });
+    // Let enteredFullscreen flip true so the handler would otherwise
+    // fire on a dispatched fullscreenchange.
+    await Promise.resolve();
+    await Promise.resolve();
+    presenter.dispose();
+    onExit.mockClear();
+    document.dispatchEvent(new Event('fullscreenchange'));
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('calls exitFullscreen when in fullscreen mode', async () => {
+    const container = makeContainer();
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get: () => container,
+    });
+    const exitSpy = vi.fn().mockResolvedValue(undefined);
+    (document as unknown as { exitFullscreen: () => Promise<void> }).exitFullscreen = exitSpy;
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    // Wait for the resolved requestFullscreen Promise to flip
+    // enteredFullscreen true.
+    await Promise.resolve();
+    await Promise.resolve();
+    presenter.dispose();
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call exitFullscreen when in overlay mode', async () => {
+    (HTMLElement.prototype as unknown as { requestFullscreen: () => Promise<void> })
+      .requestFullscreen = vi.fn().mockRejectedValue(new Error('denied'));
+    const exitSpy = vi.fn().mockResolvedValue(undefined);
+    (document as unknown as { exitFullscreen: () => Promise<void> }).exitFullscreen = exitSpy;
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    presenter.dispose();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: second dispose call is a no-op', () => {
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+    presenter.dispose();
+    const callsAfterFirst = removeSpy.mock.calls.length;
+    expect(() => presenter.dispose()).not.toThrow();
+    // Second dispose returns early — no further removeEventListener
+    // calls, canvas stays removed, container cssText stays restored.
+    expect(removeSpy.mock.calls.length).toBe(callsAfterFirst);
+    expect(container.querySelector('canvas')).toBeNull();
+    removeSpy.mockRestore();
+  });
+});
+
 interface KeyboardHandle {
   presenter: Presenter;
   ids: [string, string, string];

--- a/packages/slides/src/view/present/presenter.test.ts
+++ b/packages/slides/src/view/present/presenter.test.ts
@@ -810,3 +810,167 @@ describe('startPresenter — fullscreen', () => {
     }
   });
 });
+
+// Yorkie pushes store snapshots into the presenter via setDocument
+// while the presentation runs. These tests cover the four real-world
+// branches: unchanged deck (theme/element edits), current slide kept
+// despite structural edits, current slide deleted with the original
+// index either valid or out of bounds, and an empty deck triggering
+// onExit. The atEndScreen flag must survive any structural change
+// short of emptying the deck — the presentation is still "over".
+describe('startPresenter — setDocument remote changes', () => {
+  // Build a fresh 3-slide fixture and return a function that produces
+  // a new SlidesDocument with the specified slide ids removed. Uses
+  // MemSlidesStore so all mutations flow through the supported API.
+  function makeDocWithRemovals(): {
+    doc: SlidesDocument;
+    ids: [string, string, string];
+    store: MemSlidesStore;
+  } {
+    const store = new MemSlidesStore();
+    let aId = '';
+    let bId = '';
+    let cId = '';
+    store.batch(() => {
+      aId = store.addSlide('blank');
+      bId = store.addSlide('blank');
+      cId = store.addSlide('blank');
+    });
+    return { doc: store.read(), ids: [aId, bId, cId], store };
+  }
+
+  it('preserves currentSlideId and re-renders when the current slide still exists', () => {
+    const renderSpy = vi.spyOn(SlideRenderer.prototype, 'render');
+    const { doc, ids, store } = makeDocWithRemovals();
+    const [, bId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: bId,
+      onExit: vi.fn(),
+    });
+    try {
+      const callsBefore = renderSpy.mock.calls.length;
+      // Same deck snapshot, no structural change. Calls re-render.
+      presenter.setDocument(store.read());
+      expect(presenter.getCurrentSlideId()).toBe(bId);
+      expect(presenter.isAtEndScreen()).toBe(false);
+      expect(renderSpy.mock.calls.length).toBe(callsBefore + 1);
+    } finally {
+      presenter.dispose();
+      renderSpy.mockRestore();
+    }
+  });
+
+  it('jumps to the slide at the same index when the current slide is deleted', () => {
+    const { doc, ids, store } = makeDocWithRemovals();
+    const [, bId, cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: bId,
+      onExit: vi.fn(),
+    });
+    try {
+      // Remove B → new array is [A, C]; index 1 is now C.
+      store.batch(() => store.removeSlide(bId));
+      presenter.setDocument(store.read());
+      expect(presenter.getCurrentSlideId()).toBe(cId);
+      expect(presenter.isAtEndScreen()).toBe(false);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('falls back to the last slide when the deleted current slide index is out of bounds', () => {
+    const { doc, ids, store } = makeDocWithRemovals();
+    const [aId, bId, cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: cId,
+      onExit: vi.fn(),
+    });
+    try {
+      // Remove B and C → new array is [A]; index 2 is OOB → clamp to A.
+      store.batch(() => {
+        store.removeSlide(bId);
+        store.removeSlide(cId);
+      });
+      presenter.setDocument(store.read());
+      expect(presenter.getCurrentSlideId()).toBe(aId);
+      expect(presenter.isAtEndScreen()).toBe(false);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('calls onExit when the deck becomes empty', () => {
+    const { doc, ids, store } = makeDocWithRemovals();
+    const [aId, bId, cId] = ids;
+    const onExit = vi.fn();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit,
+    });
+    try {
+      store.batch(() => {
+        store.removeSlide(aId);
+        store.removeSlide(bId);
+        store.removeSlide(cId);
+      });
+      presenter.setDocument(store.read());
+      expect(onExit).toHaveBeenCalledOnce();
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('preserves end-screen state when the deck is unchanged', () => {
+    const { doc, ids, store } = makeDocWithRemovals();
+    const [, , cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: cId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).next(); // → end-screen
+      expect(presenter.isAtEndScreen()).toBe(true);
+      presenter.setDocument(store.read());
+      expect(presenter.isAtEndScreen()).toBe(true);
+      expect(presenter.getCurrentSlideId()).toBeNull();
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('preserves end-screen state even when slides shrink below the original tail', () => {
+    const { doc, ids, store } = makeDocWithRemovals();
+    const [, bId, cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: cId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).next(); // → end-screen
+      expect(presenter.isAtEndScreen()).toBe(true);
+      // Shrink the deck (C and B removed); only A remains. The
+      // presentation is still "over" — the end-screen survives.
+      store.batch(() => {
+        store.removeSlide(bId);
+        store.removeSlide(cId);
+      });
+      presenter.setDocument(store.read());
+      expect(presenter.isAtEndScreen()).toBe(true);
+      expect(presenter.getCurrentSlideId()).toBeNull();
+    } finally {
+      presenter.dispose();
+    }
+  });
+});

--- a/packages/slides/src/view/present/presenter.test.ts
+++ b/packages/slides/src/view/present/presenter.test.ts
@@ -276,4 +276,20 @@ describe('startPresenter — dispose()', () => {
       presenter.dispose();
     }).not.toThrow();
   });
+
+  it('navigation after dispose() is a no-op', () => {
+    const { doc, ids } = makeDoc();
+    const [aId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    presenter.dispose();
+    const before = presenter.getCurrentSlideId();
+    testApi(presenter).next();
+    expect(presenter.getCurrentSlideId()).toBe(before);
+    expect(presenter.isAtEndScreen()).toBe(false);
+  });
 });

--- a/packages/slides/src/view/present/presenter.test.ts
+++ b/packages/slides/src/view/present/presenter.test.ts
@@ -69,6 +69,23 @@ describe('startPresenter — initial state', () => {
     }
   });
 
+  it('throws when constructed with an empty deck', () => {
+    // The React shell guards on empty-deck before mounting the
+    // presenter, but startPresenter is public API and a CLI / test /
+    // embed caller could bypass that guard. Fail-fast rather than
+    // crashing on `slides[0].id` access below.
+    const emptyDoc = new MemSlidesStore().read();
+    expect(emptyDoc.slides.length).toBe(0);
+    expect(() =>
+      startPresenter({
+        container: makeContainer(),
+        doc: emptyDoc,
+        startSlideId: 'irrelevant',
+        onExit: vi.fn(),
+      }),
+    ).toThrow(/non-empty/);
+  });
+
   it('falls back to the first slide when startSlideId is not in the deck', () => {
     // A peer can delete the host's pending start slide between the
     // host computing the id and startPresenter mounting — without the
@@ -892,6 +909,38 @@ describe('startPresenter — fullscreen', () => {
     } finally {
       presenter.dispose();
       req.mockRestore();
+    }
+  });
+
+  it('falls back to overlay mode synchronously when requestFullscreen is unavailable', () => {
+    // Some embed contexts and very old browsers omit the Fullscreen
+    // API entirely. The optional-chained call protects only the call
+    // itself — chaining `.then` on the resulting `undefined` would
+    // throw TypeError. The explicit feature-detect handles it by
+    // dropping straight to overlay synchronously.
+    //
+    // The deletion is scoped to this test: the top-level beforeEach
+    // re-installs `requestFullscreen` on HTMLElement.prototype before
+    // every subsequent test, so we don't need to restore it here.
+    delete (HTMLElement.prototype as unknown as Record<string, unknown>)
+      .requestFullscreen;
+    const { doc, ids } = makeDoc();
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    try {
+      expect(container.style.position).toBe('fixed');
+      expect(container.style.top).toBe('0px');
+      expect(container.style.left).toBe('0px');
+      expect(container.style.right).toBe('0px');
+      expect(container.style.bottom).toBe('0px');
+      expect(container.style.zIndex).toBe('9999');
+    } finally {
+      presenter.dispose();
     }
   });
 

--- a/packages/slides/src/view/present/presenter.test.ts
+++ b/packages/slides/src/view/present/presenter.test.ts
@@ -400,3 +400,185 @@ describe('startPresenter — dispose()', () => {
     expect(presenter.isAtEndScreen()).toBe(false);
   });
 });
+
+interface KeyboardHandle {
+  presenter: Presenter;
+  ids: [string, string, string];
+  onExit: ReturnType<typeof vi.fn>;
+}
+
+function mountAt(slideIdx: 0 | 1 | 2): KeyboardHandle {
+  const { doc, ids } = makeDoc();
+  const onExit = vi.fn();
+  const presenter = startPresenter({
+    container: makeContainer(),
+    doc,
+    startSlideId: ids[slideIdx],
+    onExit,
+  });
+  return { presenter, ids, onExit };
+}
+
+function dispatchKey(key: string, extra: Partial<KeyboardEventInit> = {}): KeyboardEvent {
+  const ev = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...extra,
+  });
+  document.dispatchEvent(ev);
+  return ev;
+}
+
+describe('startPresenter — keyboard', () => {
+  it('ArrowRight, Space, PageDown, n, N each advance to the next slide', () => {
+    const keys = ['ArrowRight', ' ', 'PageDown', 'n', 'N'];
+    for (const key of keys) {
+      const { presenter, ids } = mountAt(0);
+      try {
+        dispatchKey(key);
+        expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+        expect(presenter.isAtEndScreen()).toBe(false);
+      } finally {
+        presenter.dispose();
+      }
+    }
+  });
+
+  it('ArrowLeft, PageUp, Backspace, p, P each move to the previous slide', () => {
+    const keys = ['ArrowLeft', 'PageUp', 'Backspace', 'p', 'P'];
+    for (const key of keys) {
+      const { presenter, ids } = mountAt(1);
+      try {
+        dispatchKey(key);
+        expect(presenter.getCurrentSlideId()).toBe(ids[0]);
+        expect(presenter.isAtEndScreen()).toBe(false);
+      } finally {
+        presenter.dispose();
+      }
+    }
+  });
+
+  it('Home jumps to the first slide; End jumps to the last', () => {
+    {
+      const { presenter, ids } = mountAt(2);
+      try {
+        dispatchKey('Home');
+        expect(presenter.getCurrentSlideId()).toBe(ids[0]);
+      } finally {
+        presenter.dispose();
+      }
+    }
+    {
+      const { presenter, ids } = mountAt(0);
+      try {
+        dispatchKey('End');
+        expect(presenter.getCurrentSlideId()).toBe(ids[2]);
+      } finally {
+        presenter.dispose();
+      }
+    }
+  });
+
+  it('Escape calls onExit (does not dispose)', () => {
+    const { presenter, ids, onExit } = mountAt(0);
+    try {
+      dispatchKey('Escape');
+      expect(onExit).toHaveBeenCalledOnce();
+      // Presenter is NOT disposed — the caller decides. State queries
+      // and navigation still work.
+      expect(presenter.getCurrentSlideId()).toBe(ids[0]);
+      testApi(presenter).next();
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('next() past the last slide enters the end-screen via ArrowRight', () => {
+    const { presenter, onExit } = mountAt(2);
+    try {
+      dispatchKey('ArrowRight');
+      expect(presenter.isAtEndScreen()).toBe(true);
+      // Pressing ArrowRight again at end-screen stays put; keyboard
+      // does not trigger onExit from the end-screen — click does.
+      dispatchKey('ArrowRight');
+      expect(presenter.isAtEndScreen()).toBe(true);
+      expect(onExit).not.toHaveBeenCalled();
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('Cmd+Z (or any unhandled key) is swallowed: preventDefault + stopImmediatePropagation', () => {
+    const { presenter } = mountAt(0);
+    try {
+      const ev = new KeyboardEvent('keydown', {
+        key: 'z',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const stopSpy = vi.spyOn(ev, 'stopImmediatePropagation');
+      document.dispatchEvent(ev);
+      expect(ev.defaultPrevented).toBe(true);
+      expect(stopSpy).toHaveBeenCalledOnce();
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('keydown listener is installed in capture phase', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    try {
+      const keydownCall = addSpy.mock.calls.find(
+        (args) => args[0] === 'keydown',
+      );
+      expect(keydownCall).toBeDefined();
+      const options = keydownCall![2];
+      expect(options).toBeDefined();
+      // Accept either `true` or `{ capture: true }`.
+      const captured =
+        options === true ||
+        (typeof options === 'object' && options !== null && (options as AddEventListenerOptions).capture === true);
+      expect(captured).toBe(true);
+    } finally {
+      presenter.dispose();
+      addSpy.mockRestore();
+    }
+  });
+});
+
+describe('startPresenter — click-to-advance', () => {
+  it('click on canvas advances to the next slide', () => {
+    const { presenter, ids } = mountAt(0);
+    try {
+      const canvas = testApi(presenter).getCanvas();
+      canvas.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(presenter.getCurrentSlideId()).toBe(ids[1]);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('click on canvas while at end-screen invokes onExit', () => {
+    const { presenter, onExit } = mountAt(2);
+    try {
+      testApi(presenter).next(); // → end-screen
+      expect(presenter.isAtEndScreen()).toBe(true);
+      expect(onExit).not.toHaveBeenCalled();
+      const canvas = testApi(presenter).getCanvas();
+      canvas.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(onExit).toHaveBeenCalledOnce();
+    } finally {
+      presenter.dispose();
+    }
+  });
+});

--- a/packages/slides/src/view/present/presenter.test.ts
+++ b/packages/slides/src/view/present/presenter.test.ts
@@ -68,6 +68,26 @@ describe('startPresenter — initial state', () => {
       presenter.dispose();
     }
   });
+
+  it('falls back to the first slide when startSlideId is not in the deck', () => {
+    // A peer can delete the host's pending start slide between the
+    // host computing the id and startPresenter mounting — without the
+    // fallback the presenter would mount on a phantom id.
+    const { doc, ids } = makeDoc();
+    const [aId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: 'not-a-real-id',
+      onExit: vi.fn(),
+    });
+    try {
+      expect(presenter.getCurrentSlideId()).toBe(aId);
+      expect(presenter.isAtEndScreen()).toBe(false);
+    } finally {
+      presenter.dispose();
+    }
+  });
 });
 
 describe('startPresenter — next()', () => {
@@ -1015,6 +1035,33 @@ describe('startPresenter — fullscreen', () => {
     } finally {
       presenter.dispose();
     }
+  });
+
+  it('dispose during pending requestFullscreen reverses the in-flight transition', async () => {
+    // Defer the requestFullscreen Promise so we can dispose mid-flight.
+    // Without the reversal, the browser still completes the fullscreen
+    // transition after we tear down — leaving the page in fullscreen
+    // with no canvas, no listeners, no way out except the browser's
+    // native Esc.
+    let resolveFullscreen!: () => void;
+    (HTMLElement.prototype as unknown as { requestFullscreen: () => Promise<void> })
+      .requestFullscreen = vi.fn().mockImplementation(
+        () => new Promise<void>((res) => { resolveFullscreen = res; }),
+      );
+    const exitSpy = vi.fn().mockResolvedValue(undefined);
+    (document as unknown as { exitFullscreen: () => Promise<void> }).exitFullscreen = exitSpy;
+    const { doc, ids } = makeDoc();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: ids[0],
+      onExit: vi.fn(),
+    });
+    presenter.dispose();          // dispose BEFORE the promise resolves
+    resolveFullscreen();          // browser completes the transition
+    await Promise.resolve();      // let the .then continuation run
+    await Promise.resolve();      // and its sub-continuation
+    expect(exitSpy).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/slides/src/view/present/presenter.test.ts
+++ b/packages/slides/src/view/present/presenter.test.ts
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
+import '../canvas/test-canvas-env';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemSlidesStore } from '../../store/memory';
 import type { SlidesDocument } from '../../model/presentation';
+import { SlideRenderer } from '../canvas/slide-renderer';
 import { startPresenter, type Presenter } from './presenter';
 
 interface TestHandle {
@@ -9,6 +11,8 @@ interface TestHandle {
   prev: () => void;
   goToFirst: () => void;
   goToLast: () => void;
+  getCanvas: () => HTMLCanvasElement;
+  getLastPaintKind: () => 'slide' | 'end' | null;
 }
 
 function testApi(presenter: Presenter): TestHandle {
@@ -257,6 +261,109 @@ describe('startPresenter — goToFirst() / goToLast()', () => {
       expect(presenter.getCurrentSlideId()).toBe(cId);
     } finally {
       presenter.dispose();
+    }
+  });
+});
+
+// jsdom's CanvasRenderingContext2D is a stub that doesn't actually
+// commit pixels, so we verify the end-screen branch via a
+// `lastPaintKind` side-effect exposed through `__test`. This tests
+// intent (which branch ran) rather than rendered output, and avoids
+// pulling in node-canvas for a single check.
+describe('startPresenter — canvas mount and paint', () => {
+  it('mounts a canvas into the container sized to dpr * fitted box', () => {
+    const { doc, ids } = makeDoc();
+    const [aId] = ids;
+    const container = makeContainer();
+    // jsdom defaults: window.innerWidth=1024, window.innerHeight=768.
+    // 1024 / (16/9) = 576 < 768 → width-binding fit.
+    expect(window.innerWidth).toBe(1024);
+    expect(window.innerHeight).toBe(768);
+    const dpr = window.devicePixelRatio || 1;
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    try {
+      const canvas = container.querySelector('canvas');
+      expect(canvas).not.toBeNull();
+      const expectedCssWidth = Math.round(1024);
+      const expectedCssHeight = Math.round(1024 / (16 / 9));
+      expect(canvas!.width).toBe(Math.round(expectedCssWidth * dpr));
+      expect(canvas!.height).toBe(Math.round(expectedCssHeight * dpr));
+      expect(canvas!.style.width).toBe(`${expectedCssWidth}px`);
+      expect(canvas!.style.height).toBe(`${expectedCssHeight}px`);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('letterbox styles applied to container on mount', () => {
+    const { doc, ids } = makeDoc();
+    const [aId] = ids;
+    const container = makeContainer();
+    const presenter = startPresenter({
+      container,
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    try {
+      // Black backdrop + flex centering so the canvas sits inside a
+      // letterbox when the viewport aspect differs from 16:9.
+      expect(container.style.background).toBe('rgb(0, 0, 0)');
+      expect(container.style.display).toBe('flex');
+      expect(container.style.alignItems).toBe('center');
+      expect(container.style.justifyContent).toBe('center');
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('next() triggers a fresh SlideRenderer.render call', () => {
+    const renderSpy = vi.spyOn(SlideRenderer.prototype, 'render');
+    const { doc, ids } = makeDoc();
+    const [aId, bId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    try {
+      const callsBefore = renderSpy.mock.calls.length;
+      testApi(presenter).next();
+      expect(renderSpy.mock.calls.length).toBe(callsBefore + 1);
+      const lastCall = renderSpy.mock.calls[renderSpy.mock.calls.length - 1];
+      expect((lastCall[0] as { id: string }).id).toBe(bId);
+    } finally {
+      presenter.dispose();
+      renderSpy.mockRestore();
+    }
+  });
+
+  it('end-screen state paints via the raw 2D context and does not call SlideRenderer.render', () => {
+    const renderSpy = vi.spyOn(SlideRenderer.prototype, 'render');
+    const { doc, ids } = makeDoc();
+    const [, , cId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: cId,
+      onExit: vi.fn(),
+    });
+    try {
+      // Mount paint on slide C consumed one call; baseline from here.
+      const callsBefore = renderSpy.mock.calls.length;
+      testApi(presenter).next(); // → end-screen
+      expect(presenter.isAtEndScreen()).toBe(true);
+      expect(renderSpy.mock.calls.length).toBe(callsBefore);
+      expect(testApi(presenter).getLastPaintKind()).toBe('end');
+    } finally {
+      presenter.dispose();
+      renderSpy.mockRestore();
     }
   });
 });

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -289,7 +289,15 @@ export function startPresenter(options: PresenterOptions): Presenter {
   // discard the Promise with `void` — the side effects (entering
   // fullscreen, or applying overlay on rejection) are sufficient. The
   // optional-call handles environments that lack the API entirely.
+  //
+  // `mountMode` drives overlay-vs-fullscreen styling for dispose() in
+  // Task 6. `enteredFullscreen` is a separate axis describing whether
+  // the browser-level fullscreen bridge is armed — it only flips true
+  // inside the `.then` of our own requestFullscreen, so a stray
+  // `fullscreenchange` before our Promise resolves, or one triggered
+  // by a sibling element exiting fullscreen, cannot misfire onExit.
   let mountMode: 'fullscreen' | 'overlay' = 'fullscreen';
+  let enteredFullscreen = false;
   function applyOverlayStyles(): void {
     container.style.position = 'fixed';
     container.style.top = '0';
@@ -298,22 +306,30 @@ export function startPresenter(options: PresenterOptions): Presenter {
     container.style.bottom = '0';
     container.style.zIndex = String(OVERLAY_Z_INDEX);
   }
-  void container.requestFullscreen?.().catch(() => {
+  void container.requestFullscreen?.().then(() => {
+    if (disposed) return;
+    enteredFullscreen = true;
+  }).catch(() => {
     if (disposed) return;
     mountMode = 'overlay';
     applyOverlayStyles();
   });
 
   // Bridge the browser's own Esc (which exits fullscreen without
-  // firing our keydown handler) back to options.onExit. Only relevant
-  // when we actually entered fullscreen — in overlay mode there's
-  // nothing to leave.
+  // firing our keydown handler) back to options.onExit. We gate on
+  // `enteredFullscreen` so events before our own requestFullscreen
+  // resolves are ignored, and on identity (`fullscreenElement ===
+  // container`) so a sibling element transitioning in or out of
+  // fullscreen does not exit the presenter. If our container is no
+  // longer the fullscreen element — whether the user left fullscreen
+  // entirely or some other element took over — the presenter is no
+  // longer driving fullscreen, so exit cleanly.
   function onFullscreenChange(): void {
     if (disposed) return;
-    if (mountMode !== 'fullscreen') return;
-    if (document.fullscreenElement === null) {
-      options.onExit();
-    }
+    if (!enteredFullscreen) return;
+    if (document.fullscreenElement === container) return;
+    enteredFullscreen = false;
+    options.onExit();
   }
   document.addEventListener('fullscreenchange', onFullscreenChange);
 
@@ -355,7 +371,7 @@ export function startPresenter(options: PresenterOptions): Presenter {
       goToLast,
       getCanvas: () => canvas,
       getLastPaintKind: () => lastPaintKind,
-      getResources: () => ({ canvas, ctx, prevCssText, resizeObserver }),
+      getResources: () => ({ canvas, ctx, prevCssText, resizeObserver, mountMode }),
     },
   });
 

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -64,12 +64,21 @@ function computeFitSize(availWidth: number, availHeight: number): {
 
 export function startPresenter(options: PresenterOptions): Presenter {
   const { container } = options;
+  // Fail-fast on an empty deck. The React shell's empty-deck guard
+  // (slides-detail.tsx) is the host-side gate, but `startPresenter`
+  // is public API — a future caller (CLI, test, embed) might bypass
+  // it. Without this throw we'd index into an empty `slides` array
+  // below and crash with an opaque `undefined.id`.
+  if (options.doc.slides.length === 0) {
+    throw new Error(
+      'startPresenter: doc.slides must be non-empty. The host is ' +
+        'responsible for guarding the empty-deck case before mounting.',
+    );
+  }
   // Validate startSlideId against the live doc. A peer can delete that
   // slide between the host computing the id and startPresenter
   // running; without this fallback, the presenter would mount on a
   // phantom id, paint() would no-op, and navigation would look broken.
-  // The host empty-deck guard (slides-detail.tsx) ensures `slides` is
-  // non-empty by the time we get here.
   const resolvedStartId = options.doc.slides.some(
     (s) => s.id === options.startSlideId,
   )
@@ -363,20 +372,30 @@ export function startPresenter(options: PresenterOptions): Presenter {
     container.style.bottom = '0';
     container.style.zIndex = String(OVERLAY_Z_INDEX);
   }
-  void container.requestFullscreen?.().then(() => {
-    if (disposed) {
-      // We tore down before the browser entered fullscreen. Reverse
-      // it — without this, the page sits in fullscreen with no canvas,
-      // no listeners, no way out except the browser's native Esc.
-      document.exitFullscreen?.().catch(() => { /* already exited */ });
-      return;
-    }
-    enteredFullscreen = true;
-  }).catch(() => {
-    if (disposed) return;
+  if (container.requestFullscreen) {
+    void container.requestFullscreen().then(() => {
+      if (disposed) {
+        // We tore down before the browser entered fullscreen. Reverse
+        // it — without this, the page sits in fullscreen with no canvas,
+        // no listeners, no way out except the browser's native Esc.
+        document.exitFullscreen?.().catch(() => { /* already exited */ });
+        return;
+      }
+      enteredFullscreen = true;
+    }).catch(() => {
+      if (disposed) return;
+      mountMode = 'overlay';
+      applyOverlayStyles();
+    });
+  } else {
+    // Environment lacks the Fullscreen API entirely (some embed
+    // contexts, very old browsers). Optional-chaining only protects
+    // the call itself — calling `.then` on the resulting `undefined`
+    // would throw TypeError. Feature-detect explicitly and skip
+    // directly to overlay mode.
     mountMode = 'overlay';
     applyOverlayStyles();
-  });
+  }
 
   // Bridge the browser's own Esc (which exits fullscreen without
   // firing our keydown handler) back to options.onExit. We gate on

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -1,0 +1,142 @@
+import type { Slide, SlidesDocument } from '../../model/presentation';
+
+/**
+ * Options for `startPresenter`. The presenter mounts a canvas inside
+ * `container`, listens for input, and tears everything down on
+ * `dispose`. v1 is local-only — no Yorkie presence broadcast.
+ */
+export interface PresenterOptions {
+  container: HTMLElement;
+  doc: SlidesDocument;
+  startSlideId: string;
+  onExit: () => void;
+}
+
+/**
+ * Public handle returned by `startPresenter`. The methods exposed
+ * here are the only ones safe to call from the React shell. Internal
+ * navigation methods (`next` / `prev` / `goToFirst` / `goToLast`)
+ * are not part of the public surface — they're driven by the
+ * presenter's own input handlers in later tasks.
+ */
+export interface Presenter {
+  setDocument(doc: SlidesDocument): void;
+  getCurrentSlideId(): string | null;
+  isAtEndScreen(): boolean;
+  dispose(): void;
+}
+
+interface PresenterState {
+  doc: SlidesDocument;
+  slides: readonly Slide[];
+  /** `null` only when `atEndScreen` is true. */
+  currentSlideId: string | null;
+  atEndScreen: boolean;
+}
+
+export function startPresenter(options: PresenterOptions): Presenter {
+  const state: PresenterState = {
+    doc: options.doc,
+    slides: options.doc.slides,
+    currentSlideId: options.startSlideId,
+    atEndScreen: false,
+  };
+
+  let disposed = false;
+
+  /**
+   * Render stub. Task 2 fills this in with the canvas + SlideRenderer
+   * integration. Task 1 only needs the state machine.
+   */
+  function paint(): void {
+    // no-op — render lands in Task 2.
+  }
+
+  function indexOfCurrent(): number {
+    if (state.currentSlideId === null) return -1;
+    return state.slides.findIndex((s) => s.id === state.currentSlideId);
+  }
+
+  function next(): void {
+    if (disposed) return;
+    if (state.atEndScreen) return;
+    const idx = indexOfCurrent();
+    if (idx < 0) return;
+    if (idx < state.slides.length - 1) {
+      state.currentSlideId = state.slides[idx + 1].id;
+    } else {
+      state.atEndScreen = true;
+      state.currentSlideId = null;
+    }
+    paint();
+  }
+
+  function prev(): void {
+    if (disposed) return;
+    if (state.atEndScreen) {
+      state.atEndScreen = false;
+      state.currentSlideId = state.slides[state.slides.length - 1].id;
+      paint();
+      return;
+    }
+    const idx = indexOfCurrent();
+    if (idx < 0) return;
+    const targetIdx = Math.max(0, idx - 1);
+    state.currentSlideId = state.slides[targetIdx].id;
+    paint();
+  }
+
+  function goToFirst(): void {
+    if (disposed) return;
+    state.currentSlideId = state.slides[0].id;
+    state.atEndScreen = false;
+    paint();
+  }
+
+  function goToLast(): void {
+    if (disposed) return;
+    state.currentSlideId = state.slides[state.slides.length - 1].id;
+    state.atEndScreen = false;
+    paint();
+  }
+
+  function setDocument(doc: SlidesDocument): void {
+    if (disposed) return;
+    // Task 5 will flesh this out with deletion / reindex logic.
+    state.doc = doc;
+    state.slides = doc.slides;
+    paint();
+  }
+
+  function getCurrentSlideId(): string | null {
+    return state.currentSlideId;
+  }
+
+  function isAtEndScreen(): boolean {
+    return state.atEndScreen;
+  }
+
+  function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    // Task 6 will tear down canvas, listeners, fullscreen, etc.
+  }
+
+  const presenter: Presenter = {
+    setDocument,
+    getCurrentSlideId,
+    isAtEndScreen,
+    dispose,
+  };
+
+  // Internal-only handle so unit tests can exercise navigation
+  // without going through DOM events. Not part of the public type;
+  // not enumerable. Later tasks (input wiring, remote-change tests)
+  // still want to drive navigation directly, so this stays.
+  Object.defineProperty(presenter, '__test', {
+    enumerable: false,
+    value: { next, prev, goToFirst, goToLast },
+  });
+
+  return presenter;
+}

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -1,4 +1,6 @@
 import type { Slide, SlidesDocument } from '../../model/presentation';
+import { SLIDE_HEIGHT, SLIDE_WIDTH } from '../../model/presentation';
+import { SlideRenderer } from '../canvas/slide-renderer';
 
 /**
  * Options for `startPresenter`. The presenter mounts a canvas inside
@@ -34,7 +36,25 @@ interface PresenterState {
   atEndScreen: boolean;
 }
 
+const SLIDE_ASPECT = SLIDE_WIDTH / SLIDE_HEIGHT;
+
+/**
+ * Pick the largest box that fits inside `availWidth × availHeight`
+ * while preserving the 16:9 slide aspect. Duplicated from
+ * `packages/frontend/src/app/slides/slides-view.tsx` on purpose — the
+ * slides package can't depend on the frontend, and the math is small.
+ */
+function computeFitSize(availWidth: number, availHeight: number): {
+  width: number;
+  height: number;
+} {
+  const widthFit = { width: availWidth, height: availWidth / SLIDE_ASPECT };
+  if (widthFit.height <= availHeight) return widthFit;
+  return { width: availHeight * SLIDE_ASPECT, height: availHeight };
+}
+
 export function startPresenter(options: PresenterOptions): Presenter {
+  const { container } = options;
   const state: PresenterState = {
     doc: options.doc,
     slides: options.doc.slides,
@@ -43,13 +63,89 @@ export function startPresenter(options: PresenterOptions): Presenter {
   };
 
   let disposed = false;
+  let lastPaintKind: 'slide' | 'end' | null = null;
 
-  /**
-   * Render stub. Task 2 fills this in with the canvas + SlideRenderer
-   * integration. Task 1 only needs the state machine.
-   */
+  // Remember the container's inline styles so Task 6's dispose() can
+  // restore them — the React shell hands us a host element it expects
+  // to look unchanged once presentation ends.
+  const prevCssText = container.style.cssText;
+
+  // Letterbox layout: black backdrop, center the canvas inside the
+  // container so non-16:9 viewports show black bars rather than
+  // stretching the slide.
+  container.style.background = '#000';
+  container.style.display = 'flex';
+  container.style.alignItems = 'center';
+  container.style.justifyContent = 'center';
+
+  const canvas = document.createElement('canvas');
+  container.appendChild(canvas);
+  const ctx = canvas.getContext('2d')!;
+  const dpr = window.devicePixelRatio || 1;
+
+  // SlideRenderer is bound to specific host dimensions, so it's
+  // rebuilt whenever the fit size changes. The constructor is cheap
+  // and ResizeObserver only fires on real size changes — not per
+  // frame — so re-instantiating here is fine.
+  let renderer = new SlideRenderer(ctx, {
+    hostWidth: 0,
+    hostHeight: 0,
+    dpr,
+  });
+
+  function applyFit(): void {
+    const fit = computeFitSize(window.innerWidth, window.innerHeight);
+    const cssWidth = Math.round(fit.width);
+    const cssHeight = Math.round(fit.height);
+    canvas.width = Math.round(fit.width * dpr);
+    canvas.height = Math.round(fit.height * dpr);
+    canvas.style.width = `${cssWidth}px`;
+    canvas.style.height = `${cssHeight}px`;
+    renderer = new SlideRenderer(ctx, {
+      hostWidth: cssWidth,
+      hostHeight: cssHeight,
+      dpr,
+    });
+    renderer.markDirty();
+    paint();
+  }
+
+  const resizeObserver = new ResizeObserver(() => applyFit());
+  resizeObserver.observe(document.documentElement);
+
   function paint(): void {
-    // no-op — render lands in Task 2.
+    if (disposed) return;
+    if (state.atEndScreen) {
+      paintEndScreen();
+      return;
+    }
+    const slide = state.slides.find((s) => s.id === state.currentSlideId);
+    if (!slide) return;
+    // SlideRenderer's dirty flag is per-slide-state, so it would skip
+    // the repaint after a slide switch without an explicit markDirty.
+    renderer.markDirty();
+    renderer.render(slide, state.doc);
+    lastPaintKind = 'slide';
+  }
+
+  function paintEndScreen(): void {
+    const hostWidth = canvas.width / dpr;
+    const hostHeight = canvas.height / dpr;
+    ctx.save();
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, hostWidth, hostHeight);
+    ctx.fillStyle = '#fff';
+    ctx.font = `${Math.round(hostHeight * 0.04)}px system-ui`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(
+      'End of slideshow — click or press Esc to exit',
+      hostWidth / 2,
+      hostHeight / 2,
+    );
+    ctx.restore();
+    lastPaintKind = 'end';
   }
 
   function indexOfCurrent(): number {
@@ -124,6 +220,9 @@ export function startPresenter(options: PresenterOptions): Presenter {
     // Task 6 will tear down canvas, listeners, fullscreen, etc.
   }
 
+  // Seed the initial paint after all closures are set up.
+  applyFit();
+
   const presenter: Presenter = {
     setDocument,
     getCurrentSlideId,
@@ -135,9 +234,23 @@ export function startPresenter(options: PresenterOptions): Presenter {
   // without going through DOM events. Not part of the public type;
   // not enumerable. Later tasks (input wiring, remote-change tests)
   // still want to drive navigation directly, so this stays.
+  //
+  // Also exposes:
+  //   - `getCanvas` so tests can inspect the mounted element.
+  //   - `getLastPaintKind` so tests can verify which paint branch ran
+  //     without depending on jsdom's stubbed canvas pixel state.
+  //   - `getResources` for Task 6's dispose teardown verification.
   Object.defineProperty(presenter, '__test', {
     enumerable: false,
-    value: { next, prev, goToFirst, goToLast },
+    value: {
+      next,
+      prev,
+      goToFirst,
+      goToLast,
+      getCanvas: () => canvas,
+      getLastPaintKind: () => lastPaintKind,
+      getResources: () => ({ canvas, ctx, prevCssText, resizeObserver }),
+    },
   });
 
   return presenter;

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -382,10 +382,36 @@ export function startPresenter(options: PresenterOptions): Presenter {
   function dispose(): void {
     if (disposed) return;
     disposed = true;
-    // Task 6 will tear down canvas, listeners (`onKeyDown` /
-    // `onCanvasClick` are held in closure above), fullscreen, etc.
-    // The `disposed` flag short-circuits all handlers so leaving the
-    // listeners installed until then is safe.
+
+    // Detach the fullscreenchange listener FIRST so the
+    // exitFullscreen() call below can't loop back into our handler
+    // → onExit → caller dispose → infinite recursion.
+    document.removeEventListener('fullscreenchange', onFullscreenChange);
+
+    // Capture-phase listener: the options object is part of the
+    // listener identity for removal. Without { capture: true } here
+    // removeEventListener is a silent no-op and the listener leaks.
+    document.removeEventListener('keydown', onKeyDown, { capture: true });
+    canvas.removeEventListener('click', onCanvasClick);
+    container.removeEventListener('mousemove', onMouseMove);
+
+    if (cursorHideTimer !== null) clearTimeout(cursorHideTimer);
+    resizeObserver?.disconnect();
+
+    // Exit fullscreen only if WE put the page there. exitFullscreen()
+    // throws when not currently in fullscreen, so the identity check
+    // plus try/catch guards against both browser-initiated exits and
+    // dispose-after-exit races.
+    if (enteredFullscreen && document.fullscreenElement === container) {
+      try {
+        void document.exitFullscreen();
+      } catch {
+        /* already exited */
+      }
+    }
+
+    canvas.remove();
+    container.style.cssText = prevCssText;
   }
 
   // Seed the initial paint after all closures are set up.

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -88,6 +88,7 @@ export function startPresenter(options: PresenterOptions): Presenter {
 
   function goToFirst(): void {
     if (disposed) return;
+    if (state.slides.length === 0) return;
     state.currentSlideId = state.slides[0].id;
     state.atEndScreen = false;
     paint();
@@ -95,6 +96,7 @@ export function startPresenter(options: PresenterOptions): Presenter {
 
   function goToLast(): void {
     if (disposed) return;
+    if (state.slides.length === 0) return;
     state.currentSlideId = state.slides[state.slides.length - 1].id;
     state.atEndScreen = false;
     paint();

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -219,10 +219,54 @@ export function startPresenter(options: PresenterOptions): Presenter {
     return state.atEndScreen;
   }
 
+  // Keyboard mapping: each entry corresponds to an `event.key` value
+  // that the presenter consumes. Anything not in this map is still
+  // swallowed (see `onKeyDown`) so editor shortcuts can't fire under
+  // the presenter — e.g. Cmd+Z must not undo the live deck.
+  const keyActions = new Map<string, () => void>([
+    ['ArrowRight', next],
+    [' ', next],
+    ['PageDown', next],
+    ['n', next],
+    ['N', next],
+    ['ArrowLeft', prev],
+    ['PageUp', prev],
+    ['Backspace', prev],
+    ['p', prev],
+    ['P', prev],
+    ['Home', goToFirst],
+    ['End', goToLast],
+    ['Escape', () => options.onExit()],
+  ]);
+
+  function onKeyDown(ev: KeyboardEvent): void {
+    if (disposed) return;
+    // Capture-phase + stopImmediatePropagation means editor key rules
+    // never see these events while the presenter is mounted.
+    ev.stopImmediatePropagation();
+    ev.preventDefault();
+    const action = keyActions.get(ev.key);
+    if (action) action();
+  }
+  document.addEventListener('keydown', onKeyDown, { capture: true });
+
+  function onCanvasClick(): void {
+    if (disposed) return;
+    if (state.atEndScreen) {
+      options.onExit();
+      return;
+    }
+    next();
+  }
+  canvas.addEventListener('click', onCanvasClick);
+
   function dispose(): void {
     if (disposed) return;
     disposed = true;
-    // Task 6 will tear down canvas, listeners, fullscreen, etc.
+    // Task 6 will tear down canvas, listeners (`onKeyDown` /
+    // `onCanvasClick` are held in closure above), fullscreen, etc.
+    // The `disposed` flag short-circuits all handlers so leaving the
+    // listeners installed until then is safe.
   }
 
   // Seed the initial paint after all closures are set up.

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -42,6 +42,10 @@ const SLIDE_ASPECT = SLIDE_WIDTH / SLIDE_HEIGHT;
 const END_SCREEN_FONT_RATIO = 0.04;
 /** User-visible end-screen copy. Single source for any future i18n pass. */
 const END_SCREEN_TEXT = 'End of slideshow — click or press Esc to exit';
+/** Milliseconds of mousemove inactivity before the cursor is hidden. */
+const CURSOR_HIDE_DELAY_MS = 3_000;
+/** z-index for the overlay fallback when fullscreen is unavailable. */
+const OVERLAY_Z_INDEX = 9999;
 
 /**
  * Pick the largest box that fits inside `availWidth × availHeight`
@@ -259,6 +263,59 @@ export function startPresenter(options: PresenterOptions): Presenter {
     next();
   }
   canvas.addEventListener('click', onCanvasClick);
+
+  // Cursor auto-hide: any `mousemove` restores the cursor and re-arms
+  // a single setTimeout. While the timer is dormant we set
+  // `cursor: 'none'` directly on the container so the canvas (which
+  // doesn't have its own cursor style) inherits it.
+  let cursorHideTimer: ReturnType<typeof setTimeout> | null = null;
+  function armCursorHide(): void {
+    if (cursorHideTimer !== null) clearTimeout(cursorHideTimer);
+    cursorHideTimer = setTimeout(() => {
+      if (disposed) return;
+      container.style.cursor = 'none';
+    }, CURSOR_HIDE_DELAY_MS);
+  }
+  function onMouseMove(): void {
+    if (disposed) return;
+    container.style.cursor = '';
+    armCursorHide();
+  }
+  container.addEventListener('mousemove', onMouseMove);
+  armCursorHide();
+
+  // Fullscreen + overlay fallback. `requestFullscreen` returns a
+  // Promise that rejects on iframe-sandbox / permission-denied. We
+  // discard the Promise with `void` — the side effects (entering
+  // fullscreen, or applying overlay on rejection) are sufficient. The
+  // optional-call handles environments that lack the API entirely.
+  let mountMode: 'fullscreen' | 'overlay' = 'fullscreen';
+  function applyOverlayStyles(): void {
+    container.style.position = 'fixed';
+    container.style.top = '0';
+    container.style.left = '0';
+    container.style.right = '0';
+    container.style.bottom = '0';
+    container.style.zIndex = String(OVERLAY_Z_INDEX);
+  }
+  void container.requestFullscreen?.().catch(() => {
+    if (disposed) return;
+    mountMode = 'overlay';
+    applyOverlayStyles();
+  });
+
+  // Bridge the browser's own Esc (which exits fullscreen without
+  // firing our keydown handler) back to options.onExit. Only relevant
+  // when we actually entered fullscreen — in overlay mode there's
+  // nothing to leave.
+  function onFullscreenChange(): void {
+    if (disposed) return;
+    if (mountMode !== 'fullscreen') return;
+    if (document.fullscreenElement === null) {
+      options.onExit();
+    }
+  }
+  document.addEventListener('fullscreenchange', onFullscreenChange);
 
   function dispose(): void {
     if (disposed) return;

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -64,10 +64,21 @@ function computeFitSize(availWidth: number, availHeight: number): {
 
 export function startPresenter(options: PresenterOptions): Presenter {
   const { container } = options;
+  // Validate startSlideId against the live doc. A peer can delete that
+  // slide between the host computing the id and startPresenter
+  // running; without this fallback, the presenter would mount on a
+  // phantom id, paint() would no-op, and navigation would look broken.
+  // The host empty-deck guard (slides-detail.tsx) ensures `slides` is
+  // non-empty by the time we get here.
+  const resolvedStartId = options.doc.slides.some(
+    (s) => s.id === options.startSlideId,
+  )
+    ? options.startSlideId
+    : options.doc.slides[0].id;
   const state: PresenterState = {
     doc: options.doc,
     slides: options.doc.slides,
-    currentSlideId: options.startSlideId,
+    currentSlideId: resolvedStartId,
     atEndScreen: false,
   };
 
@@ -353,7 +364,13 @@ export function startPresenter(options: PresenterOptions): Presenter {
     container.style.zIndex = String(OVERLAY_Z_INDEX);
   }
   void container.requestFullscreen?.().then(() => {
-    if (disposed) return;
+    if (disposed) {
+      // We tore down before the browser entered fullscreen. Reverse
+      // it — without this, the page sits in fullscreen with no canvas,
+      // no listeners, no way out except the browser's native Esc.
+      document.exitFullscreen?.().catch(() => { /* already exited */ });
+      return;
+    }
     enteredFullscreen = true;
   }).catch(() => {
     if (disposed) return;

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -38,6 +38,11 @@ interface PresenterState {
 
 const SLIDE_ASPECT = SLIDE_WIDTH / SLIDE_HEIGHT;
 
+/** End-screen font size as a fraction of the host canvas height. */
+const END_SCREEN_FONT_RATIO = 0.04;
+/** User-visible end-screen copy. Single source for any future i18n pass. */
+const END_SCREEN_TEXT = 'End of slideshow — click or press Esc to exit';
+
 /**
  * Pick the largest box that fits inside `availWidth × availHeight`
  * while preserving the 16:9 slide aspect. Duplicated from
@@ -110,8 +115,12 @@ export function startPresenter(options: PresenterOptions): Presenter {
     paint();
   }
 
-  const resizeObserver = new ResizeObserver(() => applyFit());
-  resizeObserver.observe(document.documentElement);
+  // observe documentElement as a viewport proxy — it works pre-fullscreen and post-overlay-fallback alike
+  let resizeObserver: ResizeObserver | null = null;
+  if (typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(() => applyFit());
+    resizeObserver.observe(document.documentElement);
+  }
 
   function paint(): void {
     if (disposed) return;
@@ -136,14 +145,10 @@ export function startPresenter(options: PresenterOptions): Presenter {
     ctx.fillStyle = '#000';
     ctx.fillRect(0, 0, hostWidth, hostHeight);
     ctx.fillStyle = '#fff';
-    ctx.font = `${Math.round(hostHeight * 0.04)}px system-ui`;
+    ctx.font = `${Math.round(hostHeight * END_SCREEN_FONT_RATIO)}px system-ui`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(
-      'End of slideshow — click or press Esc to exit',
-      hostWidth / 2,
-      hostHeight / 2,
-    );
+    ctx.fillText(END_SCREEN_TEXT, hostWidth / 2, hostHeight / 2);
     ctx.restore();
     lastPaintKind = 'end';
   }

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -209,9 +209,55 @@ export function startPresenter(options: PresenterOptions): Presenter {
 
   function setDocument(doc: SlidesDocument): void {
     if (disposed) return;
-    // Task 5 will flesh this out with deletion / reindex logic.
+    // Capture the old index BEFORE rebinding — the reindex fallback
+    // for a deleted current slide needs the position the user was on
+    // in the previous snapshot.
+    const oldSlides = state.slides;
+    const oldIndex =
+      state.currentSlideId === null
+        ? -1
+        : oldSlides.findIndex((s) => s.id === state.currentSlideId);
+
     state.doc = doc;
     state.slides = doc.slides;
+
+    // Empty deck → hand control back to the shell; it surfaces a
+    // toast and unmounts. Checked first so subsequent branches never
+    // index into an empty array.
+    if (state.slides.length === 0) {
+      options.onExit();
+      return;
+    }
+
+    // End-screen survives any structural change short of emptying the
+    // deck — the presentation is still "over". paint() re-paints the
+    // end-screen with no slide lookup, so this is safe regardless of
+    // what was removed.
+    if (state.atEndScreen) {
+      paint();
+      return;
+    }
+
+    // Same id still present — fast path. Avoids the reindex round-trip
+    // and prevents a spurious currentSlideId change on the common case
+    // of a theme or element edit on a slide that wasn't deleted.
+    const stillThere =
+      state.currentSlideId !== null &&
+      state.slides.some((s) => s.id === state.currentSlideId);
+    if (stillThere) {
+      paint();
+      return;
+    }
+
+    // Current slide is gone — fall back to the slide at the old
+    // index, clamped to the new tail. `oldIndex` is guaranteed >= 0
+    // here because `stillThere` was false and a null currentSlideId
+    // only occurs in the end-screen branch handled above.
+    const targetIndex = Math.min(
+      Math.max(0, oldIndex),
+      state.slides.length - 1,
+    );
+    state.currentSlideId = state.slides[targetIndex].id;
     paint();
   }
 


### PR DESCRIPTION
## Summary

- Implements the Phase 5 presentation mode that `docs/design/slides/slides.md`
  has reserved a slot for. Editor already exposes `onStartPresentation` and the
  `Cmd/Ctrl+Enter` shortcut keys are wired — this PR fills in the handler and
  the underlying presenter.
- New framework-free `startPresenter(options)` module in
  `packages/slides/src/view/present/` (~450 LOC, 52 unit tests) covering
  fullscreen, overlay fallback, keyboard nav, click-to-advance, end-screen,
  cursor auto-hide, identity-gated `fullscreenchange`, ID-tracked
  remote-change handling, and clean dispose.
- Thin React shell `SlidesPresentationMode` (portal-style, renders `null`)
  plus a `<PresentButton>` split-button in `SiteHeader` next to share /
  presence chrome. Cmd/Ctrl+Enter routes through the same handler as the
  button via a ref-wrapped `onStartPresentation` prop, so a fresh parent
  callback identity doesn't tear down the editor.
- **Local-only in v1**: no presence broadcast and collaborators are not
  auto-snapped to the presenter's slide. Speaker-notes display and dual-
  screen presenter view remain v2 per the design doc.

## Design

- `docs/design/slides/slides-presentation-mode.md` — full v1 spec.
- `docs/design/slides/slides.md` Phase 5 section now cross-references the
  new doc and is downscoped to local-only.

## Test plan

- [x] `pnpm verify:fast` green on every commit (47 test files, 764 tests).
- [x] 52 presenter unit tests in
      `packages/slides/src/view/present/presenter.test.ts` cover navigation,
      canvas mount, end-screen text, keyboard / click, cursor auto-hide,
      fullscreen, overlay fallback, identity-gated `fullscreenchange`,
      dispose-during-pending-fullscreen race, stale-`startSlideId` fallback,
      remote-change handling, and dispose cleanup.
- [ ] **Browser smoke** (`pnpm dev`):
  - [ ] Open slides doc with 3 slides → click **Present** → fullscreen,
        letterboxed, current slide visible.
  - [ ] Arrow keys / Space / PageDown / PageUp / Home / End all navigate.
        Click on canvas advances.
  - [ ] Past the last slide → black 'End of slideshow' screen → click or
        Esc exits to editor.
  - [ ] `Cmd+Enter` from a non-text-focused state starts present mode.
        `Cmd+Enter` while editing a text box does NOT enter (gated).
  - [ ] Dropdown 'Present from beginning' starts at slide 1.
  - [ ] Cursor disappears after ~3 s of no movement; reappears on move.
  - [ ] Native browser Esc / F11 exits cleanly (handler bridges
        `fullscreenchange` → `onExit`).
  - [ ] Open in two tabs: edit current slide in tab B → tab A re-renders.
        Delete current slide in tab B → tab A jumps to the slide at the
        same index (or last). Delete all slides → tab A exits with toast
        'Presentation ended (deck is empty)'.
  - [ ] Click Present then press Esc immediately (dispose-during-pending-
        fullscreen race): page should not be stuck in fullscreen.

## Notes

- Public API on `@wafflebase/slides`: `startPresenter`, `Presenter`,
  `PresenterOptions`.
- The branch closes the **Deferred: `onStartPresentation` wiring** TODO on
  `20260514-slides-keyboard-shortcuts-todo.md`.
- Implementation followed `docs/tasks/active/20260514-slides-presentation-mode-todo.md`
  task-by-task with per-task spec + code-quality reviews plus a final
  cross-cutting review; Status section at the bottom of that doc lists all
  16 commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Slides Presentation Mode with fullscreen support, keyboard navigation (arrow keys, page up/down, home/end, escape), and click-to-advance functionality.
  * Added "Present" split-button to start presentation from current or first slide.
  * Auto-hiding cursor during presentation and end-screen display.
  * Fallback overlay mode when fullscreen is unavailable.

* **Documentation**
  * Added design specifications for presentation mode features and implementation architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/240)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->