### PR TITLE
Cycle autocomplete hint highlight through repeating arg tail

### DIFF
--- a/packages/sheets/src/formula/function-catalog.ts
+++ b/packages/sheets/src/formula/function-catalog.ts
@@ -138,9 +138,8 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
       { name: 'expression' },
       { name: 'case1' },
       { name: 'value1' },
-      { name: 'case2', optional: true, repeating: true },
+      { name: 'case2_or_default', optional: true, repeating: true },
       { name: 'value2', optional: true, repeating: true },
-      { name: 'default', optional: true },
     ],
   },
   {
@@ -3020,15 +3019,17 @@ export function findFunction(name: string): FunctionInfo | undefined {
 }
 
 /**
- * `formatSignature` renders a function signature like `SUM(number1, [number2], ...)`.
+ * `formatSignature` renders a function signature like `SUM(number1, [number2, ...])`.
+ * A `repeating` arg yields `name, ...` inside its (possibly optional) brackets,
+ * so each variadic slot is presented as one optional repeating placeholder.
  */
 export function formatSignature(info: FunctionInfo): string {
   const args = info.args.map((a) => {
-    let s = a.optional ? `[${a.name}]` : a.name;
+    let s = a.name;
     if (a.repeating) {
       s += ', ...';
     }
-    return s;
+    return a.optional ? `[${s}]` : s;
   });
   return `${info.name}(${args.join(', ')})`;
 }

--- a/packages/sheets/src/view/autocomplete.ts
+++ b/packages/sheets/src/view/autocomplete.ts
@@ -3,7 +3,6 @@ import {
   FunctionInfo,
   searchFunctions,
   findFunction,
-  formatSignature,
 } from '../formula/function-catalog';
 
 /**
@@ -277,13 +276,31 @@ export class FormulaAutocomplete {
     const row = document.createElement('div');
     row.style.padding = '6px 10px';
     row.style.color = textColor;
-    row.style.whiteSpace = 'nowrap';
+    row.style.whiteSpace = 'normal';
 
-    // Build: FUNC_NAME( arg1, [arg2], ... ) with the current arg highlighted
+    // Build: FUNC_NAME(arg1, [arg2, ...]) with the current arg highlighted
     const nameSpan = document.createElement('span');
     nameSpan.style.fontWeight = '600';
     nameSpan.textContent = info.name + '(';
     row.appendChild(nameSpan);
+
+    let activeIdx = -1;
+    if (info.args.length > 0) {
+      const lastIdx = info.args.length - 1;
+      let repStart = lastIdx;
+      while (
+        repStart > 0 &&
+        info.args[lastIdx].repeating &&
+        info.args[repStart - 1].repeating
+      ) {
+        repStart--;
+      }
+      const repLen = info.args.length - repStart;
+      activeIdx =
+        argIndex < info.args.length || !info.args[lastIdx].repeating
+          ? Math.min(argIndex, lastIdx)
+          : repStart + ((argIndex - repStart) % repLen);
+    }
 
     for (let i = 0; i < info.args.length; i++) {
       if (i > 0) {
@@ -291,17 +308,16 @@ export class FormulaAutocomplete {
       }
 
       const arg = info.args[i];
-      let label = arg.optional ? `[${arg.name}]` : arg.name;
+      let label = arg.name;
       if (arg.repeating) {
         label += ', ...';
       }
+      if (arg.optional) {
+        label = `[${label}]`;
+      }
 
       const argSpan = document.createElement('span');
-      // Highlight the current argument, or clamp to the last repeating arg
-      const isActive =
-        i === argIndex ||
-        (i === info.args.length - 1 && arg.repeating && argIndex >= i);
-      if (isActive) {
+      if (i === activeIdx) {
         argSpan.style.fontWeight = '700';
         argSpan.style.color = activeCellColor;
       }
@@ -317,7 +333,7 @@ export class FormulaAutocomplete {
     descEl.style.opacity = '0.7';
     descEl.style.color = textColor;
     descEl.style.padding = '2px 10px 4px';
-    descEl.textContent = formatSignature(info) + ' — ' + info.description;
+    descEl.textContent = info.description;
 
     this.container.appendChild(row);
     this.container.appendChild(descEl);

--- a/packages/sheets/test/formula/function-catalog.test.ts
+++ b/packages/sheets/test/formula/function-catalog.test.ts
@@ -435,7 +435,7 @@ describe('FunctionCatalog', () => {
   describe('formatSignature', () => {
     it('should format SUM signature', () => {
       const info = findFunction('SUM')!;
-      expect(formatSignature(info)).toBe('SUM(number1, [number2], ...)');
+      expect(formatSignature(info)).toBe('SUM(number1, [number2, ...])');
     });
 
     it('should format IF signature', () => {
@@ -465,14 +465,14 @@ describe('FunctionCatalog', () => {
     it('should format TEXTJOIN signature', () => {
       const info = findFunction('TEXTJOIN')!;
       expect(formatSignature(info)).toBe(
-        'TEXTJOIN(delimiter, ignore_empty, text1, [text2], ...)',
+        'TEXTJOIN(delimiter, ignore_empty, text1, [text2, ...])',
       );
     });
 
     it('should format SUMIFS signature', () => {
       const info = findFunction('SUMIFS')!;
       expect(formatSignature(info)).toBe(
-        'SUMIFS(sum_range, criteria_range1, criterion1, [criteria_range2], ..., [criterion2], ...)',
+        'SUMIFS(sum_range, criteria_range1, criterion1, [criteria_range2, ...], [criterion2, ...])',
       );
     });
 


### PR DESCRIPTION
## Summary
The formula autocomplete hint had three issues that compounded on multi-arg-pair functions like MINIFS / SUMIFS / SWITCH:

1. `[name], ...` instead of `[name, ...]` — the brackets enclosed only the name, leaving `, ...` outside, which read as a separate arg.
2. Highlight clamped to the very last arg once the cursor passed it, so a user typing the 5th, 6th, 7th MINIFS argument still saw `criterion2` highlighted instead of cycling cr2 / c2 / cr2 / c2.
3. The description row below the signature re-rendered `formatSignature(info) + ' — ' + description`, duplicating the already-rendered signature.

Fix the label by enclosing the `, ...` inside the optional brackets, both in renderHint and in formatSignature for consistency. Find the contiguous trailing block of repeating args and modulo argIndex into it so each slot in the repeating tail re-highlights as the user types past the catalog's last formal argument. Drop the signature prefix from the description row so only the highlighted signature shows.

Also fix SWITCH's catalog entry: it had
`[case2 repeating, value2 repeating, default optional]`, breaking the trailing-contiguous-repeating invariant the new cycling relies on. Excel/Sheets semantics treat the last optional as living in the first slot of the trailing pair (a `case_or_default`), so rename case2 to `case2_or_default` and drop the separate default arg.

## Why

## Linked Issues

Fixes #

## Author checklist

- [X] I searched existing issues and PRs and confirmed this is not a duplicate.
- [X] I read every line of this diff and can explain why each change is necessary.
- [X] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [X] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced formula autocomplete hints with improved formatting for function signatures and parameters.
  * Optional repeating parameters now display with consistent bracket notation (e.g., `[parameter, ...]`) for better clarity and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/242)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->