### PR TITLE
Add PPTX best-effort import to slides (parser + UI)

### DIFF
--- a/docs/design/slides/slides-themes-layouts-import.md
+++ b/docs/design/slides/slides-themes-layouts-import.md
@@ -380,11 +380,82 @@ flattened, M groups expanded, K shapes simplified."
 
 #### EMU and slide size
 
-PPTX uses EMU (914 400 EMU = 1 inch). Our logical canvas is 1920×1080
-px, which corresponds to a 13.333" × 7.5" slide at 144 dpi (matches
-PPTX 16:9 widescreen exactly: 12 192 000 × 6 858 000 EMU). Conversion:
-`px = emu * 1920 / 12192000`. PPTX decks with non-16:9 sizes are
-imported at the closest fit and a toast warns of the aspect change.
+PPTX uses EMU (914 400 EMU = 1 inch). Our logical canvas is fixed at
+1920×1080 px (16:9), defined as `SLIDE_WIDTH` / `SLIDE_HEIGHT` constants
+in `packages/slides/src/model/presentation.ts`. The deck's own
+`<p:sldSz cx cy>` is read at parse time and used to derive the scale:
+`px_x = emu * 1920 / cx`, `px_y = emu * 1080 / cy`. Both common 16:9
+PPTX sizes (standard 9 144 000 × 5 143 500 EMU = 10″×5.625″, and
+widescreen 12 192 000 × 6 858 000 EMU = 13.333″×7.5″) map without
+aspect distortion. Decks with non-16:9 aspect are imported scaled to
+fit and a toast warns of the aspect change.
+
+#### Yorkie 캐즘 deck — re-validated gap (2026-05-15)
+
+After v0.4.0 shipped the 117-kind shape registry, first-class
+connectors, 11 built-in layouts, and 4-tier theming, the benchmark deck
+was re-inventoried against the actual current model. The gap is
+significantly smaller than the original mapping table assumed.
+
+**Inventory (36 slides, 16:9 standard 10″×5.625″, NOT widescreen):**
+
+| OOXML element | Count | Notes |
+|---|---|---|
+| `<p:sp>` (shapes, all `prstGeom`, 0 `custGeom`) | 218 | 13 distinct kinds: rect, roundRect, ellipse, rtTriangle, chevron, blockArc, uturnArrow, flowChartOffpageConnector, rightArrowCallout, leftBracket, homePlate, donut, can — **all 13 already in `ShapeKind`** |
+| `<p:pic>` | 63 | 25 unique media files (png/jpg/gif); 1 `srcRect` (crop), rest plain stretch |
+| `<p:cxnSp>` | 51 | `curvedConnector2`(28) + `straightConnector1`(20) + `curvedConnector3`(3); `stCxn`/`endCxn` shape-anchored; 38 triangle arrowheads |
+| `<p:grpSp>` | 48 | max nesting depth = 1 |
+| `<p:graphicFrame><a:tbl>` | 7 | ~3×3, 0 cell merges |
+| Animations / transitions / charts / SmartArt | 0 | none — all explicitly out of scope |
+| `<a:highlight>` (text bg highlight) | 136 | **most frequent custom text effect in this deck** |
+| `<a:hlinkClick>` (text hyperlink) | 31 | external URLs |
+| `<a:normAutofit fontScale=...>` | many | shrink-to-fit on title boxes |
+| `<a:outerShdw>` | 7 | drop shadow on shapes |
+| Slide-level `<p:bg>` overrides | 4 | rest inherit master |
+| Layouts referenced | tx(23), secHead(7), body(5), title(1) | all map to existing 11 built-ins |
+| Theme | custom 12-color palette (`accent1=#058DC7` ...) | imported as a new `Theme` |
+| Embedded fonts | Roboto, Roboto Thin/Medium, Nanum Gothic (14 `.fntdata`) | dropped, Noto Sans KR fallback |
+| Notes | Korean text on nearly every slide | map to `Slide.notes` |
+
+**Verified model support (file:line evidence in
+`docs/tasks/active/`):**
+
+| Feature in deck | Model has it? | Mapping |
+|---|---|---|
+| 13 distinct `prstGeom` kinds | ✅ all 13 in `ShapeKind` (`packages/slides/src/model/element.ts`) | direct preset → `kind` |
+| `<a:highlight>` text bg | ✅ `Inline.style.backgroundColor` (`packages/docs/src/model/types.ts:123`) | direct |
+| `<a:hlinkClick>` on text | ✅ `Inline.style.href` (`packages/docs/src/model/types.ts:126`) | resolve via slide `_rels` |
+| `<a:schemeClr>` / `<a:srgbClr>` | ✅ `ThemeColor { kind: 'role' \| 'srgb' }` | direct |
+| Connectors with shape anchors | ✅ `ConnectorElement` endpoint (`packages/slides/src/model/connector.ts`) | `stCxn id/idx` → `attached` endpoint |
+| `curvedConnector2/3` | ✅ routing `'curved'` | direct |
+| `straightConnector1` | ✅ routing `'straight'` | direct |
+| Triangle arrowheads | ✅ 8 arrowhead kinds | direct |
+| Slide-level background | ✅ `Slide.background` | direct |
+| `<a:normAutofit>` (shrink-to-fit) | ❌ `TextElement.data` has only `blocks` — no autoFit field | **lossy:** pre-apply `fontScale` to each run's stored `fontSize` at parse time; the original is approximated, no live re-fit. Acceptable: shrink-to-fit only affects display, not content. |
+| `<a:outerShdw>` shape effects | ❌ `ShapeElement.data` has only `{kind, adjustments, fill, stroke}` | **drop**, 7 cases only; toast counts |
+| Slide canvas size flexibility | ❌ `SLIDE_WIDTH/HEIGHT` are module constants in `presentation.ts:50-51`; `SlidesDocument` has no `canvasSize` field | **rescale** EMU→px using deck's own `<p:sldSz>` so geometry preserves at the deck's aspect; if aspect ≠ 16:9, fit + toast warning |
+
+**Net result:** of the original mapping table's ⚠️/❌ rows, only 3
+real model gaps remain for this deck (autoFit, shape shadow, dynamic
+canvas size) — and all 3 have acceptable lossy fallbacks. The 117-kind
+registry and first-class connectors absorb what the original v1 plan
+called out as "shape placeholder" fallbacks. **No new model fields are
+required to import this deck.**
+
+**Revised PR2 scope adjustments:**
+
+1. PR2 mapping table row "other `prst` → placeholder rect" is now
+   stale. Replace with: "any `prst` whose name matches a registered
+   `ShapeKind` → that `ShapeKind`; unknown `prst` (rare) →
+   `rect` + toast." All 13 kinds in this deck hit the supported path.
+2. PR2 mapping table row "roundRect → new shape kind" is stale —
+   `roundRect` ships in v0.4.0. Drop the "new" note.
+3. Add explicit rows for highlight, hyperlink, autoFit (lossy), and
+   shape shadow (dropped). Include their counts in the post-import
+   toast: "Imported with N tables flattened, M groups expanded, K
+   shadows dropped, L text boxes pre-scaled."
+4. Coordinate scaling reads `<p:sldSz>` per deck rather than hardcoding
+   widescreen EMU.
 
 #### UI / CLI surface
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,10 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| pptx import (2026-05-15) | [20260515-pptx-import-todo.md](./active/20260515-pptx-import-todo.md) | [20260515-pptx-import-lessons.md](./active/20260515-pptx-import-lessons.md) |
+| slides connectors pr1 (2026-05-15) | [20260515-slides-connectors-pr1-todo.md](./active/20260515-slides-connectors-pr1-todo.md) | [20260515-slides-connectors-pr1-lessons.md](./active/20260515-slides-connectors-pr1-lessons.md) |
 | slides keyboard shortcuts (2026-05-14) | [20260514-slides-keyboard-shortcuts-todo.md](./active/20260514-slides-keyboard-shortcuts-todo.md) | - |
+| slides presentation mode (2026-05-14) | [20260514-slides-presentation-mode-todo.md](./active/20260514-slides-presentation-mode-todo.md) | - |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
 | slides package mvp (2026-05-05) | [20260505-slides-package-mvp-todo.md](./active/20260505-slides-package-mvp-todo.md) | [20260505-slides-package-mvp-lessons.md](./active/20260505-slides-package-mvp-lessons.md) |
 | pdf export followup (2026-05-01) | [20260501-pdf-export-followup-todo.md](./active/20260501-pdf-export-followup-todo.md) | - |
@@ -31,4 +34,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 175
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides keyboard shortcuts (2026-05-14)
+Latest active task: pptx import (2026-05-15)

--- a/docs/tasks/active/20260515-pptx-import-lessons.md
+++ b/docs/tasks/active/20260515-pptx-import-lessons.md
@@ -1,0 +1,88 @@
+# PPTX Import — Lessons
+
+**Created**: 2026-05-15
+
+Lessons captured while shipping PPTX best-effort import (PR2 of
+`slides-themes-layouts-import.md`). Benchmark deck is the 36-slide
+Yorkie 캐즘 file.
+
+Filled in during implementation as patterns emerge. Headings below are
+placeholders for the topics most likely to need notes — drop or rename
+as the work plays out.
+
+## Parser
+
+## EMU and slide-size scaling
+
+## Connector forward references
+
+## `<a:normAutofit>` fidelity
+
+## Image upload + concurrency
+
+## Yorkie write of the parsed document
+
+## Test fixtures (synthetic vs. real `.pptx`)
+
+## CLI parity with `docs import`
+
+## Shared OOXML library — follow-up candidates
+
+Decision (2026-05-15): keep slides PPTX parsing self-contained for PR2;
+revisit extraction after both DOCX (docs) and PPTX (slides) are in
+production. YAGNI + we want to see the two implementations side-by-side
+before committing to an interface.
+
+Concrete extract candidates once PR2 ships:
+
+- `parseRels` / `resolveRelsTarget` — slides version is ~1:1 with docs's
+  `parseRelationships`. Move to `@wafflebase/ooxml` or a docs subpath.
+- EMU constants (914400 / inch, 12700 / pt) — currently in `docs/units.ts`
+  and (forthcoming) `slides/geometry.ts`.
+- `<a:srgbClr>` / `<a:schemeClr>` / `<a:tint>` / `<a:shade>` parsing —
+  pure DrawingML; identical across both formats.
+- `<a:blip r:embed>` image upload glue.
+
+## Scaffold deferred-utilities
+
+Task 1's planned `geometry.ts` / `color.ts` / `font.ts` modules moved to
+Task 2 (their first consumers — theme/master parsing). Writing them
+eagerly in Task 1 would have produced empty stubs.
+
+## Benchmark dry-run (2026-05-15, post-Task 4)
+
+Ran the 36-slide Yorkie 캐즘 deck through `importPptx` once Tasks 1–4
+landed. Output matched the static analysis to within 1–2 elements:
+
+| Metric | Static analysis | Runtime |
+|---|---|---|
+| Slides | 36 | 36 |
+| Images (`<p:pic>` refs) | 63 | 63 |
+| Connectors (`<p:cxnSp>`) | 51 | 51 |
+| Groups (`<p:grpSp>`, depth 1) | 48 | 48 flattened |
+| Tables (`<p:graphicFrame>`) | 7 | 7 flattened |
+| Unknown prsts (rightArrowCallout / leftBracket / homePlate) | 3 | 3 → rect fallback |
+| Total elements imported | n/a | 480 (text 208, shape 158, connector 51, image 63) |
+| Notes coverage | every slide | 36/36 |
+
+Two small discrepancies for later investigation: `outerShdw` was counted
+at 7 in static analysis but the runtime dropped only 5 (likely the
+other 2 are nested in master/layout, not slide). The original
+`<p:sldLayout type="body">` (5 slide refs) maps to `one-column-text`
+but only 3 layout types showed up in `Set(slides[*].layoutId)`. Worth a
+follow-up trace.
+
+**Action item:** the dry-run was driven by an ad-hoc node script that
+polyfilled `DOMParser` via `@xmldom/xmldom`. Once Task 6 lands, the CLI
+runs the same code path natively — no need for a checked-in fixture
+script.
+
+## dist/ staleness when running scripts manually
+
+`node /tmp/script.mjs` against `packages/slides/dist/node.js` returns
+**old** behavior if you forgot to `pnpm slides build` after editing
+sources. Symptom in our case: `report.groupsFlattened` stayed at 0
+even though Task 4's group flattener was wired correctly — the dist
+just hadn't been rebuilt. **Always `pnpm slides build` before invoking
+the published entry from external scripts.** Test runs (vitest) read
+sources directly and don't hit this trap.

--- a/docs/tasks/active/20260515-pptx-import-todo.md
+++ b/docs/tasks/active/20260515-pptx-import-todo.md
@@ -1,0 +1,196 @@
+# PPTX Import (PR2 of slides-themes-layouts-import)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Created**: 2026-05-15
+
+**Goal:** Ship best-effort PPTX import so a user can drag a `.pptx` onto the deck list (or run `slides import file.pptx` from the CLI) and start editing. Benchmark is the 36-slide Yorkie 캐즘 deck.
+
+**Architecture:** Pure-TypeScript, client-side parser under `packages/slides/src/import/pptx/`. Reuses `jszip` (already in `@wafflebase/docs` for DOCX import) and `@xmldom/xmldom` (already in `@wafflebase/cli`). Maps OOXML theme/master/layout/slide → `SlidesDocument`. Images go through the existing workspace `/images` upload API. No new backend endpoints.
+
+**Spec:** `docs/design/slides/slides-themes-layouts-import.md` (PR2 section + "Yorkie 캐즘 deck — re-validated gap (2026-05-15)" subsection)
+
+**Tech Stack:** TypeScript, Vitest (slides), node:test (frontend), jszip, @xmldom/xmldom, NestJS (backend, only for the e2e gate).
+
+**Re-validated reality (delta from spec written before v0.4.0):**
+
+- 117 `ShapeKind` registered — all 13 `prstGeom` kinds used by the benchmark map directly. No "placeholder rect" fallback for these.
+- First-class `ConnectorElement` with `stCxn`/`endCxn`-style attached endpoints — `curvedConnector2/3` + `straightConnector1` map directly.
+- 4-tier theming (Theme/Master/Layout/Slide) and 11 built-in layouts already shipped.
+- `Inline.style.backgroundColor` (`<a:highlight>` ✅) and `Inline.style.href` (`<a:hlinkClick>` ✅) already exist in `@wafflebase/docs`.
+- Real model gaps confirmed lossy-acceptable: `<a:normAutofit>` (pre-scale fontSize), `<a:outerShdw>` (drop), slide canvas (1920×1080 hardcoded — rescale EMU→px from deck's `<p:sldSz>`).
+
+**Why mostly TDD:** Each parser is a pure `(xmlNode) → DomainObject` function — small XML fixtures, deterministic outputs. End-to-end uses the benchmark deck through `MemSlidesStore`.
+
+---
+
+## File Map
+
+| File | Role |
+|------|------|
+| `packages/slides/src/import/pptx/index.ts` | New: `importPptx(buffer): Promise<SlidesDocument>` public entry |
+| `packages/slides/src/import/pptx/unzip.ts` | New: jszip wrapper, returns `Map<path, Uint8Array \| string>` |
+| `packages/slides/src/import/pptx/xml.ts` | New: xmldom wrapper, namespace-tolerant element traversal helpers |
+| `packages/slides/src/import/pptx/rels.ts` | New: parse `*.rels` into `Map<id, { type, target }>` |
+| `packages/slides/src/import/pptx/geometry.ts` | New: EMU↔px (deck-size driven), rotation degrees→radians, prst→`ShapeKind` lookup |
+| `packages/slides/src/import/pptx/color.ts` | New: schemeClr/srgbClr/sysClr/prstClr + tint/shade → `ThemeColor` |
+| `packages/slides/src/import/pptx/font.ts` | New: typeface resolution + Korean (Noto Sans KR) fallback |
+| `packages/slides/src/import/pptx/theme.ts` | New: `<a:theme>` → `Theme` (ColorScheme + FontScheme) |
+| `packages/slides/src/import/pptx/master.ts` | New: `<p:sldMaster>` → `Master` + placeholder styles |
+| `packages/slides/src/import/pptx/layout.ts` | New: `<p:sldLayout>` → `Layout`; classify type (`title`/`secHead`/`tx`/`body`/`titleOnly`/`blank`/…) and map to nearest built-in layout id |
+| `packages/slides/src/import/pptx/slide.ts` | New: `<p:sld>` + its rels → `Slide` (background + elements + notes) |
+| `packages/slides/src/import/pptx/shape.ts` | New: dispatcher for `<p:sp>` / `<p:pic>` / `<p:cxnSp>` / `<p:grpSp>` / `<p:graphicFrame>` |
+| `packages/slides/src/import/pptx/text.ts` | New: `<p:txBody>` → `Block[]`; handles `<a:r>` (runs), `<a:p>` (paragraphs), `<a:pPr>` (alignment, bullet, indent, line-spacing), `<a:rPr>` (bold, underline, size, font, color, **highlight**, **hyperlink**), `<a:br>`, `<a:normAutofit>` pre-scale |
+| `packages/slides/src/import/pptx/group.ts` | New: flatten `<p:grpSp>` — compose `chOff/chExt`+ `off/ext` group transform into each child's frame |
+| `packages/slides/src/import/pptx/table.ts` | New: `<a:tbl>` → matrix of `TextElement` + border `ShapeElement` per cell |
+| `packages/slides/src/import/pptx/image.ts` | New: `<p:pic>` → upload bytes via injected `uploadImage(bytes, mime) → src` callback, produce `ImageElement` |
+| `packages/slides/src/import/pptx/report.ts` | New: `ImportReport` — counts of flattened groups, tables, dropped shadows, pre-scaled text boxes, unknown shapes |
+| `packages/slides/src/import/pptx/__fixtures__/` | New: small per-parser XML fixtures + a tiny synthetic `.pptx` |
+| `packages/slides/src/index.ts` + `node.ts` | Re-export `importPptx` and `ImportReport` |
+| `packages/frontend/src/app/decks/import-pptx-button.tsx` | New: `<ImportPptxButton />` — file input + drag-drop zone; calls `importPptx`, creates a deck via existing REST, populates Yorkie doc |
+| `packages/frontend/src/app/decks/deck-list-page.tsx` | Wire `<ImportPptxButton />` next to "+ New Deck"; drop zone overlay on the page |
+| `packages/frontend/src/types/slides-document.ts` | Verify Yorkie schema can absorb output (no new fields expected; lint if drift) |
+| `packages/cli/src/commands/slides/import.ts` | New: `slides import <file.pptx> [--workspace <id>] [--title <name>]` |
+| `packages/cli/src/commands/slides/index.ts` | Register `import` subcommand |
+| `packages/backend/test/slides-pptx-import.e2e-spec.ts` | New: end-to-end CLI import of the 36-slide benchmark, gated by `RUN_DB_INTEGRATION_TESTS` + `RUN_YORKIE_INTEGRATION_TESTS` |
+| `packages/frontend/tests/app/slides/pptx-import.test.ts` | New: small `.pptx` fixture → `MemSlidesStore` → assert slide count, element counts, content hashes |
+| `docs/design/slides/slides-themes-layouts-import.md` | Update mapping-table stale rows (already done in PR2 design refresh) |
+| `docs/tasks/active/20260515-pptx-import-lessons.md` | Capture lessons during implementation |
+
+---
+
+## Task 1 — `feat(slides): pptx unzip + xml parser scaffold`
+
+**Files:** `packages/slides/src/import/pptx/{unzip,xml,rels,geometry,color,font,report,index}.ts`, `__fixtures__/minimal.pptx`
+
+Set up the I/O surface and the shared utilities every later parser uses. After this task `importPptx(buffer)` returns an empty `SlidesDocument` for a minimal valid `.pptx` (one blank slide).
+
+- [ ] **Step 1.** Add `jszip` and `@xmldom/xmldom` to `packages/slides/package.json` (devDeps via `pnpm add -D --filter @wafflebase/slides ...`); confirm both are already top-level deps in their existing homes (no version duplication).
+- [ ] **Step 2.** `unzip.ts`: `unzipPptx(buffer: ArrayBuffer): Promise<PptxArchive>` returning `{ readText(path), readBytes(path), list(prefix) }`. Tests: load `__fixtures__/minimal.pptx`, list `ppt/slides/*.xml`.
+- [ ] **Step 3.** `xml.ts`: `parseXml(text): Document` + helpers `child(el, localName, namespace?)`, `children(...)`, `attr(el, name)`, `text(el)`. Namespace-tolerant: match on `localName` to survive `p:`/`a:`/`r:` prefixes. Tests: parse a tiny snippet with mixed namespaces.
+- [ ] **Step 4.** `rels.ts`: `parseRels(text): Map<id, { type, target }>`. Tests: small `.rels` fixture with image, hyperlink, and slideLayout entries.
+- [ ] **Step 5.** `geometry.ts`: export `emuToPxScale(sldSzCx, sldSzCy) → { sx, sy }`; `emuToFrame(off, ext, scale)`; `rotEmuToRad(rot)`; `prstToShapeKind(prst): ShapeKind | null` (covers the 13 kinds used by the benchmark — verify with `Object.keys(PATH_BUILDERS)`). Tests cover both standard (9144000×5143500) and widescreen (12192000×6858000) decks.
+- [ ] **Step 6.** `color.ts`: `parseColor(node, theme?): ThemeColor` — handles `<a:schemeClr val>` → `{kind:'role', role}`, `<a:srgbClr val>` → `{kind:'srgb', value}`, `<a:sysClr lastClr>` → `{kind:'srgb'}`, `<a:prstClr val>` → preset color table lookup. Preserve `<a:tint>`/`<a:shade>` as numbers on the resulting `ThemeColor`. Tests for each variant.
+- [ ] **Step 7.** `font.ts`: `parseTypeface(latin, ea, cs): ThemeFont`. If Hangul characters appear in the run text *and* no `ea` typeface, suggest 'Noto Sans KR' fallback. Tests use a tiny Korean sample.
+- [ ] **Step 8.** `report.ts`: `class ImportReport` with counters (`tablesFlattened`, `groupsFlattened`, `shadowsDropped`, `textBoxesPreScaled`, `unknownShapes`, `skippedImages`) and `summary(): string`. Tests are trivial.
+- [ ] **Step 9.** `index.ts`: `importPptx(buffer, opts: { uploadImage }): Promise<{ document: SlidesDocument; report: ImportReport }>` — scaffold only, returns an empty `SlidesDocument` keyed to a fresh theme/master/layout and reads `<p:sldSz>` for the scale. Test: minimal `.pptx` round-trips to a one-slide deck.
+- [ ] **Step 10.** Synthesise `__fixtures__/minimal.pptx` via a tiny generator script (Node, runs in tests only). Commit the generator + the resulting `.pptx`.
+- [ ] **Step 11.** Re-export `importPptx` from `packages/slides/src/index.ts` and `node.ts`. Confirm both `pnpm slides build` and `pnpm verify:fast` are green.
+
+---
+
+## Task 2 — `feat(slides): pptx theme/master/layout parsers`
+
+**Files:** `theme.ts`, `master.ts`, `layout.ts`
+
+After this task: a deck's own visual identity (custom palette, fonts, layouts) is imported as a *new* `Theme` + `Master` + `Layout[]`. `SlidesDocument.meta.themeId/masterId` point at the imported pair.
+
+- [ ] **Step 1.** `theme.ts`: walk `<a:clrScheme>` → 12-slot `ColorScheme`; `<a:fontScheme>` (`majorFont/minorFont`'s `latin typeface`) → `FontScheme`. Test against the benchmark's theme1.xml — confirm `accent1` resolves to `#058DC7`.
+- [ ] **Step 2.** `master.ts`: parse `<p:sldMaster>`'s `<p:bg>` → `Background`; walk placeholder shapes to derive `placeholderStyles` (title, body) using `parseTypeface` + `parseColor`. Test on a master fixture.
+- [ ] **Step 3.** `layout.ts`: parse `<p:sldLayout>`'s `type` attribute and map to built-in `Layout.id`:
+  - `title` → `title-slide`
+  - `secHead` → `section-header`
+  - `tx` / `obj` → `title-body`
+  - `body` → `one-column-text`
+  - `titleOnly` → `title-only`
+  - `twoColTx` → `title-two-columns`
+  - `blank` → `blank`
+  - everything else → `title-body` with a `report.unknownLayoutType` count
+- [ ] **Step 4.** Parse layout placeholders (their `<p:ph type idx>`) into `PlaceholderSpec[]`. Layout `background?` overrides only when `<p:bg>` is present on the layout itself.
+- [ ] **Step 5.** Wire all three into `importPptx`: read `ppt/theme/theme1.xml`, `ppt/slideMasters/slideMaster1.xml`, `ppt/slideLayouts/*.xml`. Populate `document.themes`, `document.masters`, `document.layouts`. Test: the benchmark deck produces exactly 11 imported layouts (or however many it ships).
+- [ ] **Step 6.** Run `pnpm verify:fast`.
+
+---
+
+## Task 3 — `feat(slides): pptx slide + shape parsers (text, image, basic shapes, connectors)`
+
+**Files:** `slide.ts`, `shape.ts`, `text.ts`, `image.ts`
+
+This is the big one. After this task: text boxes, images, basic shapes, and connectors round-trip with high fidelity.
+
+- [ ] **Step 1.** `slide.ts`: parse `<p:sld>` — walk `<p:spTree>` and dispatch each child to `shape.ts`. Read sibling rels file for image and hyperlink resolution.
+- [ ] **Step 2.** Slide-level background: respect `<p:bg>` on the slide; otherwise `slide.background = undefined` (inherit). Confirm 4 benchmark slides report a non-inherited background.
+- [ ] **Step 3.** Notes: read `notesSlideN.xml` via rels, parse its `<p:txBody>` runs into a `Block[]` for `Slide.notes`.
+- [ ] **Step 4.** `shape.ts` — text box (`<p:sp txBox="1">` or `<p:sp>` with `<p:txBody>` containing visible runs): build `TextElement` via `text.ts`.
+- [ ] **Step 5.** `shape.ts` — non-text shape: `prstToShapeKind` → `ShapeElement`. Parse `<a:avLst><a:gd>` into `adjustments` (preserve OOXML thousandths). Parse `<p:spPr>`'s `<a:solidFill>` and `<a:ln>` into `fill` + `stroke`. Drop `<a:outerShdw>` and bump `report.shadowsDropped`. Unknown `prst` → fallback `rect` and bump `report.unknownShapes`.
+- [ ] **Step 6.** `image.ts`: `<p:pic>` — resolve `<a:blip r:embed>` via rels to a media path, read bytes, call injected `uploadImage(bytes, mime)`. Build `ImageElement`. Honor `<a:srcRect l t r b>` as `crop` (the 1 case in the benchmark). Honor `<a:alphaModFix amt>` — store in element as appropriate (skip if model doesn't support, but defer alpha to v2 if needed).
+- [ ] **Step 7.** Connectors (`<p:cxnSp>`): `prstGeom` `straightConnector1` → routing `'straight'`; `curvedConnector2/3` → `'curved'`; anything else with elbow-y geometry → `'elbow'`. `stCxn id idx`/`endCxn id idx` → `attached` endpoint (use the shape's id mapping built during the same pass). Arrowheads `<a:headEnd>`/`<a:tailEnd>` `type` → `'triangle'`/`'open-triangle'`/`'diamond'`/`'circle'`. Test against the benchmark slide that has 4 connectors.
+- [ ] **Step 8.** `text.ts` — paragraphs and runs:
+  - `<a:p>` → docs `Block`. `<a:pPr algn="">` → alignment. `<a:pPr lvl indent marL>` → indent. `<a:lnSpc>` → lineHeight. `<a:buChar char>` / `<a:buAutoNum type>` / `<a:buNone>` → list style on the block. `<a:br/>` → soft break.
+  - `<a:r><a:rPr.../><a:t>...</a:t></a:r>` → docs `Inline`. `rPr@b="1"` → bold; `rPr@u="sng"` → underline; `rPr@sz` → fontSize (PPTX hundredths-of-pt → our pt); `<a:latin typeface>` / `<a:ea typeface>` → fontFamily via `font.ts`. `<a:solidFill>` (inside rPr) → color. **`<a:highlight>` → `Inline.style.backgroundColor`.** **`<a:hlinkClick r:id>` → `Inline.style.href` resolved via rels.**
+  - `<a:bodyPr><a:normAutofit fontScale=>` → pre-multiply every run's `fontSize` by `fontScale/100000`; bump `report.textBoxesPreScaled`. Note in `lessons.md` if the visual diff exceeds tolerance.
+- [ ] **Step 9.** Element ids: assign deterministic ids during parse (e.g. `slide${idx}-el${nvSpPr.cNvPr@id}`) so connectors can resolve `stCxn id` to the right element. Build a per-slide `Map<number, string>` to translate.
+- [ ] **Step 10.** Fixtures: per-shape XML fixtures under `__fixtures__/` for every distinct `prst` kind in the benchmark (rect, roundRect, ellipse, rtTriangle, chevron, blockArc, uturnArrow, flowChartOffpageConnector, rightArrowCallout, leftBracket, homePlate, donut, can) + 3 connector variants + 1 text-with-highlight-and-hyperlink + 1 cropped image.
+- [ ] **Step 11.** `pnpm verify:fast`.
+
+---
+
+## Task 4 — `feat(slides): pptx fallbacks (group flatten, table flatten, unknown shape)`
+
+**Files:** `group.ts`, `table.ts`, plus extensions to `shape.ts`
+
+- [ ] **Step 1.** `group.ts`: `flattenGroup(grpSp, parentScale, parentOff)`. Compose group `<a:xfrm off="X Y" ext="W H" chOff="x y" chExt="w h">` into each child's frame using the affine formula `child_off_world = parent_off + (child_off_local - chOff) * (ext / chExt)`. Recursive on nested groups (depth 1 in the benchmark, but support arbitrary). Bump `report.groupsFlattened` per group.
+- [ ] **Step 2.** `table.ts`: walk `<a:tbl>` rows and cells. Compute each cell's world frame from `<a:tblGrid><a:gridCol w>` widths and `<a:tr h>` heights against the graphicFrame's `<p:xfrm off ext>`. For each cell: produce a borderless `ShapeElement` (kind `'rect'`, no fill or transparent) with the cell's borders applied as a 4-stroke synthesis — or, if border-strokes-per-side aren't supported in our model, a single stroke with the dominant color and a `report.tableBordersApproximated` count. Inside the cell, place a `TextElement` from `<a:txBody>`. Bump `report.tablesFlattened`. Cell merges (`<a:gridSpan>`/`<a:rowSpan>`/`<a:hMerge>`/`<a:vMerge>`) — benchmark has 0; emit a `report.tableMergesIgnored` for future decks.
+- [ ] **Step 3.** Wire group + table into `shape.ts` dispatcher.
+- [ ] **Step 4.** Pre-flight sanity test on the benchmark: 36 slides parsed; 218 shapes + 51 connectors + 63 images appear in `document.slides[*].elements`; 48 groups counted in report.groupsFlattened; 7 tables in report.tablesFlattened. (Element totals may differ slightly because tables explode to N text + N border shapes.)
+- [ ] **Step 5.** `pnpm verify:fast`.
+
+---
+
+## Task 5 — `feat(frontend): import-pptx UI (button + drag-drop)`
+
+**Files:** `packages/frontend/src/app/decks/import-pptx-button.tsx`, `deck-list-page.tsx`, sibling tests
+
+- [ ] **Step 1.** `<ImportPptxButton />` — a button next to "+ New Deck" labeled "↑ Import .pptx". `<input type="file" accept=".pptx" />` hidden; clicking the button triggers it.
+- [ ] **Step 2.** On file selected: read as `ArrayBuffer`, show a progress modal ("Importing… 0/36 slides"), invoke `importPptx(buffer, { uploadImage })`. `uploadImage` is bound to the existing workspace `POST /api/v1/workspaces/:wid/images` endpoint.
+- [ ] **Step 3.** On success: create a new deck via the existing `POST /documents` REST endpoint with `type='slides'` and an empty doc; then attach to Yorkie, push the parsed `SlidesDocument`, and navigate to `/slides/:id`. Show a toast with `report.summary()`.
+- [ ] **Step 4.** Drag-and-drop: a full-page invisible drop zone on `deck-list-page.tsx`; when a `.pptx` is dragged, show a translucent "Drop to import" overlay. Drop → same flow as step 2.
+- [ ] **Step 5.** Error handling: parser exceptions, image upload failures, and Yorkie attach failures all surface a user-visible error toast and *do not* leave a half-populated deck (delete the placeholder document on failure).
+- [ ] **Step 6.** Tests in `packages/frontend/tests/app/slides/pptx-import.test.ts` — small `.pptx` fixture → assert deck created, slide count, image count, content text hashes per slide.
+- [ ] **Step 7.** `pnpm verify:fast` + manual smoke with the benchmark deck in `pnpm dev`.
+
+---
+
+## Task 6 — `feat(cli): slides import command`
+
+**Files:** `packages/cli/src/commands/slides/import.ts`, `packages/cli/src/commands/slides/index.ts`, backend e2e
+
+- [ ] **Step 1.** Mirror the existing `docs import` command shape (read it first). Signature: `wafflebase slides import <file.pptx> [--workspace <id>] [--title <name>]`. Title defaults to the file basename.
+- [ ] **Step 2.** Wire to the slides parser: read the file, call `importPptx(buffer, { uploadImage })`. `uploadImage` uses the CLI's existing API client.
+- [ ] **Step 3.** Create deck via REST (`POST /api/v1/workspaces/:wid/documents` with `type='slides'`), attach to Yorkie, write `SlidesDocument`, print the import report (slide count, image count, fallback counts).
+- [ ] **Step 4.** Register the subcommand in `slides/index.ts`.
+- [ ] **Step 5.** `packages/backend/test/slides-pptx-import.e2e-spec.ts`: gated by both `RUN_DB_INTEGRATION_TESTS=true` and `RUN_YORKIE_INTEGRATION_TESTS=true`. Reads the benchmark `.pptx` from a fixtures directory (copied in during setup; do not commit the actual user file — commit a sanitised variant or instruct CI to skip if missing). Asserts: 36 slides, image count, per-slide text-content SHA matches a checked-in expectations JSON.
+- [ ] **Step 6.** `pnpm verify:integration:docker` locally; ensure CI's `verify-integration` job picks up the test.
+- [ ] **Step 7.** `pnpm verify:fast` final.
+
+---
+
+## Out of scope (PR3 or v2)
+
+- Theme builder UI (PR3 of design doc).
+- PPTX *export* (v2).
+- Animations / transitions (v2).
+- Embedded font loading (`.fntdata` decryption).
+- SmartArt / charts inside PPTX (none in benchmark).
+- Group elements as first-class kind (flatten is the v1 strategy).
+- Multi-master decks (benchmark uses 1; assume 1 in v1, log if more).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| `<p:cxnSp>` connector `stCxn id` references a shape that hasn't been parsed yet (forward reference). | Two-pass per slide: build id map first, then resolve endpoints. |
+| `<a:normAutofit fontScale=>` pre-scale gives wrong size if text reflows differently in our renderer. | Acceptable for v1; toast count. Lessons file should capture observed magnitude of mismatch. |
+| Table border-per-side semantics don't map to our single-stroke `ShapeStroke`. | Use dominant border color; report `tableBordersApproximated`. Revisit when docs-tables ships. |
+| Image upload concurrency starves the importer or backend. | Batch uploads at 5 concurrent; per-image failure → placeholder + count in report. |
+| Aspect ratio ≠ 16:9. | Fit-by-width, center vertically; toast warning. Benchmark is 16:9 so this path is not exercised by primary fixture. |
+| Bundle size — `jszip` + `@xmldom/xmldom` together (~150 KB gzipped). | Code-split the importer behind dynamic `import()` from the deck list page. Frontend chunk-gate must stay green. |
+
+## Acceptance
+
+- 36-slide Yorkie 캐즘 deck imports in <30 s (cold).
+- Slide count = 36; image count = 25 unique media (63 references); connector count = 51; element-type histogram within ±5% of expectations (tables explode).
+- `report.summary()` printed at end of import, contains all six counters.
+- Two-user Yorkie integration test (lighter, in `packages/frontend/tests/app/slides/`) confirms the imported deck replicates between peers without divergence.
+- Visual smoke: manually compare the first 5 slides side-by-side against the original PPT in PowerPoint or Google Slides; no missing elements; text content hashes match.
+- `pnpm verify:fast` + `pnpm verify:integration` + `pnpm verify:browser:docker` all green.

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -74,6 +74,8 @@ import {
 } from "@/api/workspaces";
 import { pickAndImportDocx } from "@/app/docs/docx-actions";
 import { setPendingImport } from "@/app/docs/pending-imports";
+import { pickAndImportPptx } from "@/app/slides/pptx-actions";
+import { setPendingImport as setPendingPptxImport } from "@/app/slides/pending-imports";
 
 function getDocumentPath(doc: { id: number | string; type?: DocumentType }) {
   switch (doc.type) {
@@ -250,6 +252,38 @@ export function DocumentList({
     }
   };
 
+  const handleImportPptx = async () => {
+    if (importing) return;
+    setImporting(true);
+    try {
+      const result = await pickAndImportPptx();
+      if (!result) return;
+
+      const title =
+        result.fileName.replace(/\.pptx$/i, "") || "Imported Presentation";
+      const created = workspaceId
+        ? await createWorkspaceDocument(workspaceId, { title, type: "slides" })
+        : await createDocument({ title, type: "slides" });
+
+      // Stash for SlidesView to consume on mount.
+      setPendingPptxImport(String(created.id), result.document);
+      const summary = result.report.summary();
+      toast.success(
+        summary === "Imported with no fallbacks."
+          ? `Imported "${title}"`
+          : `Imported "${title}" — ${summary}`,
+      );
+      navigate(getDocumentPath(created));
+    } catch (err) {
+      console.error("PPTX import failed", err);
+      toast.error(
+        err instanceof Error ? `Import failed: ${err.message}` : "Import failed",
+      );
+    } finally {
+      setImporting(false);
+    }
+  };
+
   const deleteDocumentMutation = useMutation({
     mutationFn: async (id: string) => await deleteDocument(id),
     onSuccess: () => {
@@ -377,6 +411,13 @@ export function DocumentList({
             >
               <FileDown className="mr-2 h-4 w-4 text-blue-500" />
               Import DOCX
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={importing}
+              onClick={handleImportPptx}
+            >
+              <FileDown className="mr-2 h-4 w-4 text-orange-500" />
+              Import PPTX
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/packages/frontend/src/app/slides/pending-imports.ts
+++ b/packages/frontend/src/app/slides/pending-imports.ts
@@ -1,0 +1,36 @@
+import type { SlidesDocument } from "@wafflebase/slides";
+
+/**
+ * Module-level registry for pending PPTX imports — mirrors the docs
+ * package's `docs/pending-imports.ts`.
+ *
+ * Flow:
+ *   1. User picks a .pptx from the document list; `importPptx` parses
+ *      it client-side and uploads embedded images to /images.
+ *   2. The list creates a new backend slides document (empty).
+ *   3. The parsed `SlidesDocument` is stashed here by the new doc id.
+ *   4. Navigation to `/p/:id` mounts `SlidesView`.
+ *   5. Before `ensureSlidesRoot` runs, the view consumes the pending
+ *      entry and pushes the imported deck onto the Yorkie root.
+ *
+ * A reload between steps 4 and 5 loses the in-memory entry — the
+ * trade-off is no large objects in localStorage.
+ */
+const pendingImports = new Map<string, SlidesDocument>();
+
+export function setPendingImport(docId: string, doc: SlidesDocument): void {
+  pendingImports.set(docId, doc);
+}
+
+/**
+ * Read a pending entry without consuming it. The caller takes it only
+ * after a successful apply so a partial failure can be retried on the
+ * next mount.
+ */
+export function peekPendingImport(docId: string): SlidesDocument | undefined {
+  return pendingImports.get(docId);
+}
+
+export function clearPendingImport(docId: string): void {
+  pendingImports.delete(docId);
+}

--- a/packages/frontend/src/app/slides/pptx-actions.ts
+++ b/packages/frontend/src/app/slides/pptx-actions.ts
@@ -1,0 +1,51 @@
+import {
+  importPptx,
+  type ImportReport,
+  type SlidesDocument,
+  type UploadImage,
+} from "@wafflebase/slides";
+import { docsImageUploader } from "../docs/export-utils";
+import { pickFile } from "../docs/export-utils";
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/bmp": "bmp",
+};
+
+/**
+ * Bridge the slides importer's bytes+mime signature onto the shared
+ * /images upload endpoint, which expects a `Blob` + filename. Reuses
+ * `docsImageUploader` so PPTX images land in the same workspace bucket
+ * as DOCX images.
+ */
+const slidesImageUploader: UploadImage = async (
+  bytes: Uint8Array,
+  mime: string,
+): Promise<string> => {
+  const ext = MIME_TO_EXT[mime] ?? "bin";
+  const blob = new Blob([bytes], { type: mime });
+  return docsImageUploader(blob, `image.${ext}`);
+};
+
+/**
+ * Open the file picker for .pptx and parse the chosen archive. Returns
+ * `null` if the user cancels. Throws on a malformed archive or a
+ * failed image upload — the caller surfaces a toast and aborts the
+ * document-creation flow.
+ */
+export async function pickAndImportPptx(): Promise<{
+  document: SlidesDocument;
+  report: ImportReport;
+  fileName: string;
+} | null> {
+  const file = await pickFile(".pptx");
+  if (!file) return null;
+  const buffer = await file.arrayBuffer();
+  const { document, report } = await importPptx(buffer, {
+    uploadImage: slidesImageUploader,
+  });
+  return { document, report, fileName: file.name };
+}

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -7,6 +7,7 @@ import {
 } from "@wafflebase/slides";
 import { useEffect, useRef, useState } from "react";
 import { useDocument } from "@yorkie-js/react";
+import { toast } from "sonner";
 import { Loader } from "@/components/loader";
 import type { YorkieSlidesRoot } from "@/types/slides-document";
 import type { SlidesPresence } from "@/types/users";
@@ -150,6 +151,11 @@ export function SlidesView({
           clearPendingImport(documentId);
         } catch (err) {
           console.error("Failed to apply pending PPTX import", err);
+          toast.error(
+            err instanceof Error
+              ? `Failed to load imported deck: ${err.message}`
+              : "Failed to load imported deck.",
+          );
         }
       }
     }

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -11,6 +11,7 @@ import { Loader } from "@/components/loader";
 import type { YorkieSlidesRoot } from "@/types/slides-document";
 import type { SlidesPresence } from "@/types/users";
 import { SlidesShortcutsHelp } from "./slides-shortcuts-help";
+import { clearPendingImport, peekPendingImport } from "./pending-imports";
 import { YorkieSlidesStore, ensureSlidesRoot } from "./yorkie-slides-store";
 
 export type { SlidesEditor } from "@wafflebase/slides";
@@ -97,6 +98,7 @@ function computeFitSize(availWidth: number, availHeight: number): {
  * PDF exporter does.
  */
 export function SlidesView({
+  documentId,
   onEditorReady,
   onStoreReady,
   onStartPresentation,
@@ -124,6 +126,33 @@ export function SlidesView({
     if (!didMount || !doc) return;
     const container = containerRef.current;
     if (!container) return;
+
+    // Consume any PPTX import staged for this document by the deck list
+    // BEFORE ensureSlidesRoot runs. Pushing the imported deck into the
+    // Yorkie root preempts the empty-deck initializer (which only fires
+    // when `root.meta` is null). We peek-then-clear so a thrown update
+    // leaves the entry in place for the next mount to retry.
+    if (documentId) {
+      const pending = peekPendingImport(documentId);
+      if (pending) {
+        try {
+          doc.update((r) => {
+            r.meta = {
+              title: pending.meta.title,
+              themeId: pending.meta.themeId,
+              masterId: pending.meta.masterId,
+            };
+            r.themes = pending.themes;
+            r.masters = pending.masters;
+            r.layouts = pending.layouts as unknown as YorkieSlidesRoot["layouts"];
+            r.slides = pending.slides as unknown as YorkieSlidesRoot["slides"];
+          });
+          clearPendingImport(documentId);
+        } catch (err) {
+          console.error("Failed to apply pending PPTX import", err);
+        }
+      }
+    }
 
     ensureSlidesRoot(doc);
 

--- a/packages/slides/package.json
+++ b/packages/slides/package.json
@@ -10,10 +10,22 @@
   "types": "dist/wafflebase-slides.es.d.ts",
   "exports": {
     ".": {
+      "node": {
+        "types": "./dist/node.d.ts",
+        "import": "./dist/node.js",
+        "require": "./dist/node.cjs",
+        "default": "./dist/node.js"
+      },
       "types": "./dist/wafflebase-slides.es.d.ts",
       "import": "./dist/wafflebase-slides.es.js",
       "require": "./dist/wafflebase-slides.cjs",
       "default": "./dist/wafflebase-slides.es.js"
+    },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "import": "./dist/node.js",
+      "require": "./dist/node.cjs",
+      "default": "./dist/node.js"
     }
   },
   "scripts": {
@@ -25,7 +37,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@wafflebase/docs": "workspace:*"
+    "@wafflebase/docs": "workspace:*",
+    "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.1.1",

--- a/packages/slides/src/import/pptx/__fixtures__/build-minimal-pptx.ts
+++ b/packages/slides/src/import/pptx/__fixtures__/build-minimal-pptx.ts
@@ -1,0 +1,131 @@
+import JSZip from 'jszip';
+
+/**
+ * Build a minimal valid .pptx in-memory: 1 blank slide, 1 layout, 1
+ * master, 1 theme, standard 16:9 widescreen size. Used by importer
+ * unit tests so a real .pptx binary doesn't need to be checked in.
+ *
+ * The XML is hand-rolled and intentionally terse — just enough for the
+ * importer to read.
+ */
+export async function buildMinimalPptx(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+
+  zip.file('[Content_Types].xml', CONTENT_TYPES);
+  zip.file('_rels/.rels', ROOT_RELS);
+  zip.file('ppt/presentation.xml', PRESENTATION);
+  zip.file('ppt/_rels/presentation.xml.rels', PRESENTATION_RELS);
+  zip.file('ppt/theme/theme1.xml', THEME);
+  zip.file('ppt/slideMasters/slideMaster1.xml', SLIDE_MASTER);
+  zip.file('ppt/slideMasters/_rels/slideMaster1.xml.rels', SLIDE_MASTER_RELS);
+  zip.file('ppt/slideLayouts/slideLayout1.xml', SLIDE_LAYOUT);
+  zip.file('ppt/slideLayouts/_rels/slideLayout1.xml.rels', SLIDE_LAYOUT_RELS);
+  zip.file('ppt/slides/slide1.xml', SLIDE);
+  zip.file('ppt/slides/_rels/slide1.xml.rels', SLIDE_RELS);
+
+  return zip.generateAsync({ type: 'arraybuffer' });
+}
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+  <Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+  <Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>
+  <Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>
+  <Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+</Types>`;
+
+const ROOT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>`;
+
+const PRESENTATION = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>
+  <p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>
+  <p:sldSz cx="12192000" cy="6858000"/>
+  <p:notesSz cx="6858000" cy="9144000"/>
+</p:presentation>`;
+
+const PRESENTATION_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>
+</Relationships>`;
+
+const THEME = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office">
+  <a:themeElements>
+    <a:clrScheme name="Office">
+      <a:dk1><a:srgbClr val="000000"/></a:dk1>
+      <a:lt1><a:srgbClr val="FFFFFF"/></a:lt1>
+      <a:dk2><a:srgbClr val="44546A"/></a:dk2>
+      <a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>
+      <a:accent1><a:srgbClr val="4472C4"/></a:accent1>
+      <a:accent2><a:srgbClr val="ED7D31"/></a:accent2>
+      <a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>
+      <a:accent4><a:srgbClr val="FFC000"/></a:accent4>
+      <a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>
+      <a:accent6><a:srgbClr val="70AD47"/></a:accent6>
+      <a:hlink><a:srgbClr val="0563C1"/></a:hlink>
+      <a:folHlink><a:srgbClr val="954F72"/></a:folHlink>
+    </a:clrScheme>
+    <a:fontScheme name="Office">
+      <a:majorFont><a:latin typeface="Calibri Light"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont>
+      <a:minorFont><a:latin typeface="Calibri"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont>
+    </a:fontScheme>
+    <a:fmtScheme name="Office"/>
+  </a:themeElements>
+</a:theme>`;
+
+const SLIDE_MASTER = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:bg><p:bgPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></p:bgPr></p:bg>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>
+    </p:spTree>
+  </p:cSld>
+  <p:sldLayoutIdLst><p:sldLayoutId id="2147483649" r:id="rId1"/></p:sldLayoutIdLst>
+</p:sldMaster>`;
+
+const SLIDE_MASTER_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="../theme/theme1.xml"/>
+</Relationships>`;
+
+const SLIDE_LAYOUT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" type="blank">
+  <p:cSld name="Blank">
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>
+    </p:spTree>
+  </p:cSld>
+</p:sldLayout>`;
+
+const SLIDE_LAYOUT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>
+</Relationships>`;
+
+const SLIDE = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
+const SLIDE_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+</Relationships>`;

--- a/packages/slides/src/import/pptx/color.test.ts
+++ b/packages/slides/src/import/pptx/color.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseXml } from './xml';
+import { parseColorElement, parseColorFromContainer, parseHexInContainer } from './color';
+
+function colorEl(xml: string): Element {
+  return parseXml(`<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">${xml}</root>`).documentElement.firstElementChild!;
+}
+
+describe('parseColorElement', () => {
+  it('maps srgbClr to a normalized hex sRGB', () => {
+    expect(parseColorElement(colorEl(`<a:srgbClr val="058dc7"/>`))).toEqual({
+      kind: 'srgb',
+      value: '#058DC7',
+    });
+  });
+
+  it('maps schemeClr aliases to ColorRole keys', () => {
+    expect(parseColorElement(colorEl(`<a:schemeClr val="accent1"/>`))).toEqual({
+      kind: 'role',
+      role: 'accent1',
+    });
+    expect(parseColorElement(colorEl(`<a:schemeClr val="bg1"/>`))).toEqual({
+      kind: 'role',
+      role: 'background',
+    });
+    expect(parseColorElement(colorEl(`<a:schemeClr val="tx2"/>`))).toEqual({
+      kind: 'role',
+      role: 'textSecondary',
+    });
+    expect(parseColorElement(colorEl(`<a:schemeClr val="folHlink"/>`))).toEqual({
+      kind: 'role',
+      role: 'visitedHyperlink',
+    });
+  });
+
+  it('preserves tint and shade modifiers on role colors', () => {
+    expect(
+      parseColorElement(colorEl(`<a:schemeClr val="accent2"><a:tint val="50000"/></a:schemeClr>`)),
+    ).toEqual({ kind: 'role', role: 'accent2', tint: 50000 });
+    expect(
+      parseColorElement(colorEl(`<a:schemeClr val="accent2"><a:shade val="25000"/></a:schemeClr>`)),
+    ).toEqual({ kind: 'role', role: 'accent2', shade: 25000 });
+  });
+
+  it('falls back through sysClr.lastClr and prstClr', () => {
+    expect(parseColorElement(colorEl(`<a:sysClr val="windowText" lastClr="2B2B2B"/>`))).toEqual({
+      kind: 'srgb',
+      value: '#2B2B2B',
+    });
+    expect(parseColorElement(colorEl(`<a:prstClr val="red"/>`))).toEqual({
+      kind: 'srgb',
+      value: '#FF0000',
+    });
+    expect(parseColorElement(colorEl(`<a:prstClr val="someUnknownColor"/>`))).toEqual({
+      kind: 'srgb',
+      value: '#000000',
+    });
+  });
+
+  it('returns undefined for unknown scheme tokens', () => {
+    // phClr is a placeholder-color reference that has no fixed mapping.
+    expect(parseColorElement(colorEl(`<a:schemeClr val="phClr"/>`))).toBeUndefined();
+  });
+});
+
+describe('parseColorFromContainer', () => {
+  it('finds the first color child of a fill container', () => {
+    const fill = parseXml(
+      `<a:solidFill xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:srgbClr val="ABCDEF"/></a:solidFill>`,
+    ).documentElement;
+    expect(parseColorFromContainer(fill)).toEqual({ kind: 'srgb', value: '#ABCDEF' });
+  });
+
+  it('returns undefined when no color child is present', () => {
+    const fill = parseXml(
+      `<a:noFill xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"/>`,
+    ).documentElement;
+    expect(parseColorFromContainer(fill)).toBeUndefined();
+  });
+});
+
+describe('parseHexInContainer', () => {
+  it('returns just the hex string for ColorScheme slot population', () => {
+    const slot = parseXml(
+      `<a:accent1 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:srgbClr val="058dc7"/></a:accent1>`,
+    ).documentElement;
+    expect(parseHexInContainer(slot)).toBe('#058DC7');
+  });
+
+  it('falls through sysClr.lastClr then prstClr', () => {
+    const a = parseXml(
+      `<a:dk1 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:sysClr val="windowText" lastClr="222222"/></a:dk1>`,
+    ).documentElement;
+    expect(parseHexInContainer(a)).toBe('#222222');
+  });
+});

--- a/packages/slides/src/import/pptx/color.test.ts
+++ b/packages/slides/src/import/pptx/color.test.ts
@@ -62,6 +62,25 @@ describe('parseColorElement', () => {
     // phClr is a placeholder-color reference that has no fixed mapping.
     expect(parseColorElement(colorEl(`<a:schemeClr val="phClr"/>`))).toBeUndefined();
   });
+
+  it('routes schemeClr through clrMap (benchmark bg2/tx2 swap)', () => {
+    const clrMap = new Map<string, string>([['bg2', 'dk2'], ['tx2', 'lt2']]);
+    // With the swap, slide-level `bg2` resolves to dk2 = textSecondary.
+    expect(parseColorElement(colorEl(`<a:schemeClr val="bg2"/>`), clrMap)).toEqual({
+      kind: 'role',
+      role: 'textSecondary',
+    });
+    // And `tx2` resolves to lt2 = backgroundAlt.
+    expect(parseColorElement(colorEl(`<a:schemeClr val="tx2"/>`), clrMap)).toEqual({
+      kind: 'role',
+      role: 'backgroundAlt',
+    });
+    // Identity entries fall through unchanged.
+    expect(parseColorElement(colorEl(`<a:schemeClr val="accent1"/>`), clrMap)).toEqual({
+      kind: 'role',
+      role: 'accent1',
+    });
+  });
 });
 
 describe('parseColorFromContainer', () => {

--- a/packages/slides/src/import/pptx/color.ts
+++ b/packages/slides/src/import/pptx/color.ts
@@ -1,0 +1,142 @@
+import type { ColorRole, ThemeColor } from '../../model/theme';
+import { attr, attrInt, child, children } from './xml';
+
+/**
+ * Map OOXML `<a:schemeClr val>` tokens to our `ColorRole` keys.
+ *
+ * OOXML exposes both the original PowerPoint role names (dk1/lt1) and
+ * the WordprocessingML-style aliases (tx1/bg1). The clrMap on a master
+ * may swap these, but in practice the identity mapping is overwhelmingly
+ * what we see; the PR2 scope treats them as synonyms.
+ */
+const SCHEME_TO_ROLE: Record<string, ColorRole> = {
+  dk1: 'text',
+  tx1: 'text',
+  lt1: 'background',
+  bg1: 'background',
+  dk2: 'textSecondary',
+  tx2: 'textSecondary',
+  lt2: 'backgroundAlt',
+  bg2: 'backgroundAlt',
+  accent1: 'accent1',
+  accent2: 'accent2',
+  accent3: 'accent3',
+  accent4: 'accent4',
+  accent5: 'accent5',
+  accent6: 'accent6',
+  hlink: 'hyperlink',
+  folHlink: 'visitedHyperlink',
+};
+
+/**
+ * Minimal preset-color table covering the few values that show up in
+ * real decks. Unknown names fall back to black with no further
+ * complaint; PowerPoint exporters almost always emit `<a:srgbClr>` so
+ * this path is rare in practice.
+ */
+const PRESET_COLORS: Record<string, string> = {
+  black: '000000',
+  white: 'FFFFFF',
+  red: 'FF0000',
+  green: '008000',
+  blue: '0000FF',
+  yellow: 'FFFF00',
+  gray: '808080',
+  grey: '808080',
+  cyan: '00FFFF',
+  magenta: 'FF00FF',
+};
+
+/**
+ * Parse a color child container (e.g. `<a:solidFill>`, `<a:lnRef>`,
+ * `<a:fgClr>`) — DrawingML wraps the actual color in `<a:srgbClr>` /
+ * `<a:schemeClr>` / `<a:sysClr>` / `<a:prstClr>`, optionally with
+ * `<a:tint>` / `<a:shade>` modifiers.
+ *
+ * Returns `undefined` when no recognised color child is present.
+ */
+export function parseColorFromContainer(container: Element): ThemeColor | undefined {
+  for (let i = 0; i < container.childNodes.length; i++) {
+    const n = container.childNodes[i];
+    if (n.nodeType !== 1) continue;
+    const el = n as Element;
+    const color = parseColorElement(el);
+    if (color) return color;
+  }
+  return undefined;
+}
+
+/** Parse a single `<a:srgbClr>` / `<a:schemeClr>` / `<a:sysClr>` / `<a:prstClr>` element. */
+export function parseColorElement(el: Element): ThemeColor | undefined {
+  switch (el.localName) {
+    case 'srgbClr': {
+      const val = attr(el, 'val');
+      if (!val) return undefined;
+      return applyModifiers({ kind: 'srgb', value: normalizeHex(val) }, el);
+    }
+    case 'schemeClr': {
+      const val = attr(el, 'val');
+      if (!val) return undefined;
+      const role = SCHEME_TO_ROLE[val];
+      if (!role) return undefined; // unknown scheme token (e.g. phClr in placeholders)
+      return applyModifiers({ kind: 'role', role }, el);
+    }
+    case 'sysClr': {
+      // PowerPoint stores the last-resolved sRGB in `lastClr`; that's
+      // the only reliable value at parse time (the system color itself
+      // is by definition variable).
+      const lastClr = attr(el, 'lastClr');
+      if (!lastClr) return undefined;
+      return applyModifiers({ kind: 'srgb', value: normalizeHex(lastClr) }, el);
+    }
+    case 'prstClr': {
+      const val = attr(el, 'val');
+      if (!val) return undefined;
+      const hex = PRESET_COLORS[val.toLowerCase()] ?? '000000';
+      return applyModifiers({ kind: 'srgb', value: normalizeHex(hex) }, el);
+    }
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Resolve a `<a:srgbClr val>` child on a container element to a plain
+ * hex string. Used by `theme.ts` to populate the 12 ColorScheme slots,
+ * each of which is just a hex string in our model.
+ */
+export function parseHexInContainer(container: Element): string | undefined {
+  const srgb = child(container, 'srgbClr');
+  if (srgb) {
+    const val = attr(srgb, 'val');
+    if (val) return normalizeHex(val);
+  }
+  const sys = child(container, 'sysClr');
+  if (sys) {
+    const last = attr(sys, 'lastClr');
+    if (last) return normalizeHex(last);
+  }
+  const prst = child(container, 'prstClr');
+  if (prst) {
+    const val = attr(prst, 'val');
+    if (val) return normalizeHex(PRESET_COLORS[val.toLowerCase()] ?? '000000');
+  }
+  return undefined;
+}
+
+function applyModifiers(base: ThemeColor, el: Element): ThemeColor {
+  if (base.kind !== 'role') return base;
+  let tint: number | undefined;
+  let shade: number | undefined;
+  const tEl = children(el, 'tint')[0];
+  if (tEl) tint = attrInt(tEl, 'val');
+  const sEl = children(el, 'shade')[0];
+  if (sEl) shade = attrInt(sEl, 'val');
+  if (tint == null && shade == null) return base;
+  return { ...base, tint, shade };
+}
+
+function normalizeHex(hex: string): string {
+  const h = hex.startsWith('#') ? hex.slice(1) : hex;
+  return '#' + h.toUpperCase();
+}

--- a/packages/slides/src/import/pptx/color.ts
+++ b/packages/slides/src/import/pptx/color.ts
@@ -2,6 +2,17 @@ import type { ColorRole, ThemeColor } from '../../model/theme';
 import { attr, attrInt, child, children } from './xml';
 
 /**
+ * OOXML `<p:clrMap>` translation table: logical scheme name (e.g.
+ * `bg1`, `tx2`) → actual scheme slot name (e.g. `lt1`, `dk2`). The
+ * benchmark deck swaps `bg2` and `tx2` from their identity defaults,
+ * so a slide that references `bg2` should resolve to `dk2`, not `lt2`.
+ *
+ * An empty/missing map is the identity mapping (every key maps to
+ * itself).
+ */
+export type ClrMap = Map<string, string>;
+
+/**
  * Map OOXML `<a:schemeClr val>` tokens to our `ColorRole` keys.
  *
  * OOXML exposes both the original PowerPoint role names (dk1/lt1) and
@@ -53,21 +64,30 @@ const PRESET_COLORS: Record<string, string> = {
  * `<a:schemeClr>` / `<a:sysClr>` / `<a:prstClr>`, optionally with
  * `<a:tint>` / `<a:shade>` modifiers.
  *
+ * `clrMap`, when provided, translates logical scheme names through
+ * the master's `<p:clrMap>` before looking them up in `SCHEME_TO_ROLE`.
+ *
  * Returns `undefined` when no recognised color child is present.
  */
-export function parseColorFromContainer(container: Element): ThemeColor | undefined {
+export function parseColorFromContainer(
+  container: Element,
+  clrMap?: ClrMap,
+): ThemeColor | undefined {
   for (let i = 0; i < container.childNodes.length; i++) {
     const n = container.childNodes[i];
     if (n.nodeType !== 1) continue;
     const el = n as Element;
-    const color = parseColorElement(el);
+    const color = parseColorElement(el, clrMap);
     if (color) return color;
   }
   return undefined;
 }
 
 /** Parse a single `<a:srgbClr>` / `<a:schemeClr>` / `<a:sysClr>` / `<a:prstClr>` element. */
-export function parseColorElement(el: Element): ThemeColor | undefined {
+export function parseColorElement(
+  el: Element,
+  clrMap?: ClrMap,
+): ThemeColor | undefined {
   switch (el.localName) {
     case 'srgbClr': {
       const val = attr(el, 'val');
@@ -77,7 +97,8 @@ export function parseColorElement(el: Element): ThemeColor | undefined {
     case 'schemeClr': {
       const val = attr(el, 'val');
       if (!val) return undefined;
-      const role = SCHEME_TO_ROLE[val];
+      const mapped = clrMap?.get(val) ?? val;
+      const role = SCHEME_TO_ROLE[mapped];
       if (!role) return undefined; // unknown scheme token (e.g. phClr in placeholders)
       return applyModifiers({ kind: 'role', role }, el);
     }

--- a/packages/slides/src/import/pptx/font.test.ts
+++ b/packages/slides/src/import/pptx/font.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseXml } from './xml';
+import { containsHangul, parsePrimaryTypeface } from './font';
+
+function fontEl(xml: string): Element {
+  return parseXml(`<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">${xml}</root>`).documentElement.firstElementChild!;
+}
+
+describe('parsePrimaryTypeface', () => {
+  it('returns the Latin face on majorFont/minorFont containers', () => {
+    expect(
+      parsePrimaryTypeface(
+        fontEl(`<a:majorFont><a:latin typeface="Calibri Light"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont>`),
+      ),
+    ).toBe('Calibri Light');
+  });
+
+  it('returns undefined when typeface is empty string (inherit)', () => {
+    expect(
+      parsePrimaryTypeface(fontEl(`<a:majorFont><a:latin typeface=""/></a:majorFont>`)),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when latin child is missing', () => {
+    expect(parsePrimaryTypeface(fontEl(`<a:minorFont/>`))).toBeUndefined();
+  });
+});
+
+describe('containsHangul', () => {
+  it('detects Hangul syllables', () => {
+    expect(containsHangul('안녕하세요')).toBe(true);
+    expect(containsHangul('hello 안')).toBe(true);
+  });
+
+  it('returns false for Latin / CJK Han', () => {
+    expect(containsHangul('Hello')).toBe(false);
+    expect(containsHangul('中文')).toBe(false);
+    expect(containsHangul('')).toBe(false);
+  });
+});

--- a/packages/slides/src/import/pptx/font.ts
+++ b/packages/slides/src/import/pptx/font.ts
@@ -1,0 +1,35 @@
+import { attr, child } from './xml';
+
+/**
+ * Pull the primary typeface from a `<a:majorFont>` / `<a:minorFont>` /
+ * `<a:rPr>` container. We use the Latin face as the primary `family` —
+ * our `FontScheme` and `ThemeFont` slots hold a single string and East
+ * Asian / complex-script disambiguation is handled at render time by
+ * the font registry (Noto Sans KR for Hangul, etc.).
+ *
+ * Returns `undefined` if no `<a:latin typeface>` is set. The placeholder
+ * value `typeface=""` is treated as "no override" — that's how OOXML
+ * exporters represent "inherit" inside `<a:minorFont>` aliases.
+ */
+export function parsePrimaryTypeface(container: Element): string | undefined {
+  const latin = child(container, 'latin');
+  if (!latin) return undefined;
+  const face = attr(latin, 'typeface');
+  if (!face) return undefined;
+  return face.length > 0 ? face : undefined;
+}
+
+/** Returns true if any character in the string is in a Hangul block. */
+export function containsHangul(text: string): boolean {
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (
+      (code >= 0xac00 && code <= 0xd7a3) || // Hangul syllables
+      (code >= 0x1100 && code <= 0x11ff) || // Hangul Jamo
+      (code >= 0x3130 && code <= 0x318f) // Hangul Compatibility Jamo
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/slides/src/import/pptx/font.ts
+++ b/packages/slides/src/import/pptx/font.ts
@@ -15,8 +15,11 @@ export function parsePrimaryTypeface(container: Element): string | undefined {
   const latin = child(container, 'latin');
   if (!latin) return undefined;
   const face = attr(latin, 'typeface');
-  if (!face) return undefined;
-  return face.length > 0 ? face : undefined;
+  if (face == null) return undefined;
+  // Treat whitespace-only typefaces the same as the empty string —
+  // they're an "inherit" sentinel, not a real font family name.
+  const trimmed = face.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 /** Returns true if any character in the string is in a Hangul block. */
@@ -26,7 +29,9 @@ export function containsHangul(text: string): boolean {
     if (
       (code >= 0xac00 && code <= 0xd7a3) || // Hangul syllables
       (code >= 0x1100 && code <= 0x11ff) || // Hangul Jamo
-      (code >= 0x3130 && code <= 0x318f) // Hangul Compatibility Jamo
+      (code >= 0x3130 && code <= 0x318f) || // Hangul Compatibility Jamo
+      (code >= 0xa960 && code <= 0xa97f) || // Hangul Jamo Extended-A
+      (code >= 0xd7b0 && code <= 0xd7ff) // Hangul Jamo Extended-B
     ) {
       return true;
     }

--- a/packages/slides/src/import/pptx/geometry.test.ts
+++ b/packages/slides/src/import/pptx/geometry.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_WIDESCREEN_EMU,
+  EMU_PER_INCH,
+  emuScale,
+  parseXfrm,
+  prstToShapeKind,
+  rotEmuToRad,
+} from './geometry';
+import { parseXml } from './xml';
+
+describe('emuScale', () => {
+  it('scales widescreen to 1920×1080 exactly', () => {
+    const s = emuScale(DEFAULT_WIDESCREEN_EMU);
+    expect(s.sx).toBeCloseTo(1920 / DEFAULT_WIDESCREEN_EMU.cx, 12);
+    expect(s.sy).toBeCloseTo(1080 / DEFAULT_WIDESCREEN_EMU.cy, 12);
+    // Sanity: widescreen aspect ratio matches our canvas.
+    expect(s.sx).toBeCloseTo(s.sy, 12);
+  });
+
+  it('scales 10″×5.625″ standard 16:9 (Yorkie 캐즘 deck) without distortion', () => {
+    const s = emuScale({ cx: 9_144_000, cy: 5_143_500 });
+    // Both axes share the same scale → no aspect distortion.
+    expect(s.sx).toBeCloseTo(s.sy, 6);
+    // Logical canvas width should land exactly at 1920 px.
+    expect(9_144_000 * s.sx).toBeCloseTo(1920, 6);
+    expect(5_143_500 * s.sy).toBeCloseTo(1080, 6);
+  });
+});
+
+describe('rotEmuToRad', () => {
+  it('converts OOXML 60000ths-of-degree to radians', () => {
+    expect(rotEmuToRad(0)).toBe(0);
+    expect(rotEmuToRad(5_400_000)).toBeCloseTo(Math.PI / 2, 9); // 90°
+    expect(rotEmuToRad(-5_400_000)).toBeCloseTo(-Math.PI / 2, 9);
+    expect(rotEmuToRad(10_800_000)).toBeCloseTo(Math.PI, 9); // 180°
+  });
+});
+
+describe('parseXfrm', () => {
+  it('reads off/ext/rot through the scale', () => {
+    const xml = `<a:xfrm xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" rot="5400000"><a:off x="914400" y="457200"/><a:ext cx="1828800" cy="914400"/></a:xfrm>`;
+    const xfrm = parseXml(xml).documentElement;
+    const s = emuScale(DEFAULT_WIDESCREEN_EMU);
+    const frame = parseXfrm(xfrm, s);
+    expect(frame.x).toBeCloseTo(914_400 * s.sx, 6);
+    expect(frame.y).toBeCloseTo(457_200 * s.sy, 6);
+    expect(frame.w).toBeCloseTo(1_828_800 * s.sx, 6);
+    expect(frame.h).toBeCloseTo(914_400 * s.sy, 6);
+    expect(frame.rotation).toBeCloseTo(Math.PI / 2, 9);
+  });
+
+  it('returns the zero frame when xfrm is missing', () => {
+    expect(parseXfrm(undefined, emuScale(DEFAULT_WIDESCREEN_EMU))).toEqual({
+      x: 0,
+      y: 0,
+      w: 0,
+      h: 0,
+      rotation: 0,
+    });
+  });
+});
+
+describe('prstToShapeKind', () => {
+  it('passes through registered shape kinds', () => {
+    for (const prst of [
+      'rect',
+      'roundRect',
+      'ellipse',
+      'rtTriangle',
+      'chevron',
+      'blockArc',
+      'uturnArrow',
+      'flowChartOffpageConnector',
+      'donut',
+      'can',
+    ]) {
+      expect(prstToShapeKind(prst)).toBe(prst);
+    }
+  });
+
+  it('returns undefined for unknown / unmapped names', () => {
+    // Yorkie 캐즘 deck has 3 of these — caller falls back to rect.
+    expect(prstToShapeKind('rightArrowCallout')).toBeUndefined();
+    expect(prstToShapeKind('leftBracket')).toBeUndefined();
+    expect(prstToShapeKind('homePlate')).toBeUndefined();
+    expect(prstToShapeKind('totallyMadeUp')).toBeUndefined();
+  });
+});
+
+describe('constants', () => {
+  it('exposes the EMU-per-inch invariant', () => {
+    expect(EMU_PER_INCH).toBe(914_400);
+  });
+});

--- a/packages/slides/src/import/pptx/geometry.test.ts
+++ b/packages/slides/src/import/pptx/geometry.test.ts
@@ -27,6 +27,17 @@ describe('emuScale', () => {
     expect(9_144_000 * s.sx).toBeCloseTo(1920, 6);
     expect(5_143_500 * s.sy).toBeCloseTo(1080, 6);
   });
+
+  it('falls back to widescreen defaults for invalid dimensions', () => {
+    const widescreen = emuScale(DEFAULT_WIDESCREEN_EMU);
+    expect(emuScale({ cx: 0, cy: 0 })).toEqual(widescreen);
+    expect(emuScale({ cx: -1, cy: 100 })).toEqual({ sx: widescreen.sx, sy: 1080 / 100 });
+    expect(emuScale({ cx: Number.NaN, cy: Number.NaN })).toEqual(widescreen);
+    expect(emuScale({ cx: Number.POSITIVE_INFINITY, cy: 100 })).toEqual({
+      sx: widescreen.sx,
+      sy: 1080 / 100,
+    });
+  });
 });
 
 describe('rotEmuToRad', () => {

--- a/packages/slides/src/import/pptx/geometry.ts
+++ b/packages/slides/src/import/pptx/geometry.ts
@@ -1,0 +1,65 @@
+import type { Frame } from '../../model/element';
+import type { ShapeKind } from '../../model/element';
+import { PATH_BUILDERS } from '../../view/canvas/shapes';
+import { attrInt, child } from './xml';
+
+/** EMU per inch — fundamental OOXML constant. */
+export const EMU_PER_INCH = 914_400;
+/** Default 16:9 widescreen size in EMU. Used as fallback when sldSz is missing. */
+export const DEFAULT_WIDESCREEN_EMU = { cx: 12_192_000, cy: 6_858_000 } as const;
+
+/** Per-axis EMU→px scale derived from the deck's `<p:sldSz>` and our 1920×1080 canvas. */
+export interface EmuScale {
+  sx: number;
+  sy: number;
+}
+
+export function emuScale(slideSizeEmu: { cx: number; cy: number }): EmuScale {
+  return {
+    sx: 1920 / slideSizeEmu.cx,
+    sy: 1080 / slideSizeEmu.cy,
+  };
+}
+
+/** OOXML rotation is in 60000ths of a degree (`rot="5400000"` = 90°). */
+export function rotEmuToRad(rot: number): number {
+  return (rot / 60_000) * (Math.PI / 180);
+}
+
+/**
+ * Build a `Frame` from a `<a:xfrm>` element using the per-axis scale.
+ * Returns the zero frame when no geometry is present — the caller can
+ * inherit from a placeholder or report it.
+ */
+export function parseXfrm(xfrm: Element | undefined, scale: EmuScale): Frame {
+  if (!xfrm) return { x: 0, y: 0, w: 0, h: 0, rotation: 0 };
+  const off = child(xfrm, 'off');
+  const ext = child(xfrm, 'ext');
+  const x = off ? (attrInt(off, 'x') ?? 0) : 0;
+  const y = off ? (attrInt(off, 'y') ?? 0) : 0;
+  const cx = ext ? (attrInt(ext, 'cx') ?? 0) : 0;
+  const cy = ext ? (attrInt(ext, 'cy') ?? 0) : 0;
+  const rot = attrInt(xfrm, 'rot') ?? 0;
+  return {
+    x: x * scale.sx,
+    y: y * scale.sy,
+    w: cx * scale.sx,
+    h: cy * scale.sy,
+    rotation: rot ? rotEmuToRad(rot) : 0,
+  };
+}
+
+/**
+ * Look up an OOXML preset-geometry name in the registered `ShapeKind`
+ * set. Most prst names are identical to our kind ids — when they are,
+ * the cast is valid because the strings match.
+ *
+ * Returns `undefined` for unknown names (rare custom OOXML prsts, or
+ * connector prsts handled by `<p:cxnSp>` dispatch). Callers fall back
+ * to `rect` and bump `report.unknownShapes`.
+ */
+export function prstToShapeKind(prst: string): ShapeKind | undefined {
+  const candidate = prst as ShapeKind;
+  if (PATH_BUILDERS.has(candidate)) return candidate;
+  return undefined;
+}

--- a/packages/slides/src/import/pptx/geometry.ts
+++ b/packages/slides/src/import/pptx/geometry.ts
@@ -15,15 +15,37 @@ export interface EmuScale {
 }
 
 export function emuScale(slideSizeEmu: { cx: number; cy: number }): EmuScale {
-  return {
-    sx: 1920 / slideSizeEmu.cx,
-    sy: 1080 / slideSizeEmu.cy,
-  };
+  // Defensively guard against a deck whose `<p:sldSz>` is missing,
+  // zero, or NaN. Without this, every frame multiplies by Infinity /
+  // NaN and the entire import is unrecoverable. Fall through to the
+  // widescreen default so the slides still render.
+  const cx =
+    Number.isFinite(slideSizeEmu.cx) && slideSizeEmu.cx > 0
+      ? slideSizeEmu.cx
+      : DEFAULT_WIDESCREEN_EMU.cx;
+  const cy =
+    Number.isFinite(slideSizeEmu.cy) && slideSizeEmu.cy > 0
+      ? slideSizeEmu.cy
+      : DEFAULT_WIDESCREEN_EMU.cy;
+  return { sx: 1920 / cx, sy: 1080 / cy };
 }
 
 /** OOXML rotation is in 60000ths of a degree (`rot="5400000"` = 90°). */
 export function rotEmuToRad(rot: number): number {
   return (rot / 60_000) * (Math.PI / 180);
+}
+
+/**
+ * Convert an EMU stroke width to px using the deck's own scale.
+ *
+ * Frames are scaled per-axis (`sx`, `sy`), but stroke width is a single
+ * scalar — we use the mean of the two scales so a flipped or non-16:9
+ * deck still produces a stroke that's proportional to the rendered
+ * frame rather than the 96-dpi default the importer used to assume.
+ */
+export function emuToStrokePx(emuWidth: number, scale: EmuScale): number {
+  if (!Number.isFinite(emuWidth) || emuWidth < 0) return 0;
+  return emuWidth * ((scale.sx + scale.sy) / 2);
 }
 
 /**

--- a/packages/slides/src/import/pptx/group.test.ts
+++ b/packages/slides/src/import/pptx/group.test.ts
@@ -79,4 +79,37 @@ describe('composeGroupTransform + applyGroupTransform', () => {
     const t = composeGroupTransform(IDENTITY_TRANSFORM, grp, SCALE);
     expect(t).toBe(IDENTITY_TRANSFORM);
   });
+
+  it('rotates child centers around the group pivot when rot ≠ 0', () => {
+    // Group centered at world (1000, 1000), 200×200 in raw EMU,
+    // rotated 90° (`rot=5400000`). chOff/chExt identity → localScale 1.
+    const grp = grpSp(`<p:grpSp>
+      <p:grpSpPr>
+        <a:xfrm rot="5400000">
+          <a:off x="900" y="900"/>
+          <a:ext cx="200" cy="200"/>
+          <a:chOff x="900" y="900"/>
+          <a:chExt cx="200" cy="200"/>
+        </a:xfrm>
+      </p:grpSpPr>
+    </p:grpSp>`);
+    const t = composeGroupTransform(IDENTITY_TRANSFORM, grp, SCALE);
+
+    // A child sitting at the right edge of the group (center at the
+    // east point) should after a +90° rotation land at the south point.
+    const child = {
+      x: 1050 * SCALE.sx - 10,
+      y: 1000 * SCALE.sy - 10,
+      w: 20,
+      h: 20,
+      rotation: 0,
+    };
+    const world = applyGroupTransform(child, t);
+
+    const expectedCenterX = 1000 * SCALE.sx;
+    const expectedCenterY = 1050 * SCALE.sy;
+    expect(world.x + world.w / 2).toBeCloseTo(expectedCenterX, 6);
+    expect(world.y + world.h / 2).toBeCloseTo(expectedCenterY, 6);
+    expect(world.rotation).toBeCloseTo(Math.PI / 2, 9);
+  });
 });

--- a/packages/slides/src/import/pptx/group.test.ts
+++ b/packages/slides/src/import/pptx/group.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  IDENTITY_TRANSFORM,
+  applyGroupTransform,
+  composeGroupTransform,
+} from './group';
+import { DEFAULT_WIDESCREEN_EMU, emuScale } from './geometry';
+import { parseXml } from './xml';
+
+const SCALE = emuScale(DEFAULT_WIDESCREEN_EMU);
+
+function grpSp(xml: string): Element {
+  return parseXml(
+    `<root xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">${xml}</root>`,
+  ).documentElement.firstElementChild!;
+}
+
+describe('composeGroupTransform + applyGroupTransform', () => {
+  it('translates children when chOff matches a non-zero local origin', () => {
+    // Group at world (300, 400), 600 wide × 200 tall.
+    // Local space starts at (100, 100), extent 600×200 → no scale change.
+    // A child at local (200, 100) should land at world (400, 400).
+    const grp = grpSp(`<p:grpSp>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="2400000" y="3200000"/>
+          <a:ext cx="4800000" cy="1600000"/>
+          <a:chOff x="800000" y="800000"/>
+          <a:chExt cx="4800000" cy="1600000"/>
+        </a:xfrm>
+      </p:grpSpPr>
+    </p:grpSp>`);
+    const t = composeGroupTransform(IDENTITY_TRANSFORM, grp, SCALE);
+    const local = {
+      x: 1_600_000 * SCALE.sx,
+      y: 800_000 * SCALE.sy,
+      w: 800_000 * SCALE.sx,
+      h: 400_000 * SCALE.sy,
+      rotation: 0,
+    };
+    const world = applyGroupTransform(local, t);
+    expect(world.x).toBeCloseTo(3_200_000 * SCALE.sx, 6);
+    expect(world.y).toBeCloseTo(3_200_000 * SCALE.sy, 6);
+    expect(world.w).toBeCloseTo(800_000 * SCALE.sx, 6);
+    expect(world.h).toBeCloseTo(400_000 * SCALE.sy, 6);
+  });
+
+  it('rescales when chExt differs from ext', () => {
+    // Group at world (0,0), 1000×1000 px-EMU.
+    // Local space 0..2000 → child halves in world.
+    const grp = grpSp(`<p:grpSp>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="1000000" cy="1000000"/>
+          <a:chOff x="0" y="0"/>
+          <a:chExt cx="2000000" cy="2000000"/>
+        </a:xfrm>
+      </p:grpSpPr>
+    </p:grpSp>`);
+    const t = composeGroupTransform(IDENTITY_TRANSFORM, grp, SCALE);
+    const local = {
+      x: 1_000_000 * SCALE.sx,
+      y: 500_000 * SCALE.sy,
+      w: 400_000 * SCALE.sx,
+      h: 400_000 * SCALE.sy,
+      rotation: 0,
+    };
+    const world = applyGroupTransform(local, t);
+    expect(world.x).toBeCloseTo(500_000 * SCALE.sx, 6);
+    expect(world.y).toBeCloseTo(250_000 * SCALE.sy, 6);
+    expect(world.w).toBeCloseTo(200_000 * SCALE.sx, 6);
+    expect(world.h).toBeCloseTo(200_000 * SCALE.sy, 6);
+  });
+
+  it('returns the parent transform when the group has no xfrm', () => {
+    const grp = grpSp(`<p:grpSp><p:grpSpPr/></p:grpSp>`);
+    const t = composeGroupTransform(IDENTITY_TRANSFORM, grp, SCALE);
+    expect(t).toBe(IDENTITY_TRANSFORM);
+  });
+});

--- a/packages/slides/src/import/pptx/group.test.ts
+++ b/packages/slides/src/import/pptx/group.test.ts
@@ -18,9 +18,6 @@ function grpSp(xml: string): Element {
 
 describe('composeGroupTransform + applyGroupTransform', () => {
   it('translates children when chOff matches a non-zero local origin', () => {
-    // Group at world (300, 400), 600 wide × 200 tall.
-    // Local space starts at (100, 100), extent 600×200 → no scale change.
-    // A child at local (200, 100) should land at world (400, 400).
     const grp = grpSp(`<p:grpSp>
       <p:grpSpPr>
         <a:xfrm>
@@ -47,8 +44,6 @@ describe('composeGroupTransform + applyGroupTransform', () => {
   });
 
   it('rescales when chExt differs from ext', () => {
-    // Group at world (0,0), 1000×1000 px-EMU.
-    // Local space 0..2000 → child halves in world.
     const grp = grpSp(`<p:grpSp>
       <p:grpSpPr>
         <a:xfrm>
@@ -81,8 +76,7 @@ describe('composeGroupTransform + applyGroupTransform', () => {
   });
 
   it('rotates child centers around the group pivot when rot ≠ 0', () => {
-    // Group centered at world (1000, 1000), 200×200 in raw EMU,
-    // rotated 90° (`rot=5400000`). chOff/chExt identity → localScale 1.
+    // Group centered at world (1000, 1000), 200×200 raw EMU, rotated 90°.
     const grp = grpSp(`<p:grpSp>
       <p:grpSpPr>
         <a:xfrm rot="5400000">
@@ -95,8 +89,6 @@ describe('composeGroupTransform + applyGroupTransform', () => {
     </p:grpSp>`);
     const t = composeGroupTransform(IDENTITY_TRANSFORM, grp, SCALE);
 
-    // A child sitting at the right edge of the group (center at the
-    // east point) should after a +90° rotation land at the south point.
     const child = {
       x: 1050 * SCALE.sx - 10,
       y: 1000 * SCALE.sy - 10,
@@ -106,10 +98,59 @@ describe('composeGroupTransform + applyGroupTransform', () => {
     };
     const world = applyGroupTransform(child, t);
 
-    const expectedCenterX = 1000 * SCALE.sx;
-    const expectedCenterY = 1050 * SCALE.sy;
-    expect(world.x + world.w / 2).toBeCloseTo(expectedCenterX, 6);
-    expect(world.y + world.h / 2).toBeCloseTo(expectedCenterY, 6);
+    expect(world.x + world.w / 2).toBeCloseTo(1000 * SCALE.sx, 6);
+    expect(world.y + world.h / 2).toBeCloseTo(1050 * SCALE.sy, 6);
     expect(world.rotation).toBeCloseTo(Math.PI / 2, 9);
+  });
+
+  it('composes nested rotated groups via full matrix multiplication', () => {
+    // Outer group rotated 90° around (1000, 1000):
+    //   any local point (lx, ly) → (1000 + (1000 - ly), 1000 + (lx - 1000))
+    //   i.e. (2000 - ly, lx)
+    // Inner group sits at (1100, 1000) (east of the outer's pivot),
+    // rotated by another 90°. After outer rotation, the inner's center
+    // lands at world (1000, 1100) → south of the outer pivot.
+    // Then the inner's 90° spins its own children around that location.
+    const outer = grpSp(`<p:grpSp>
+      <p:grpSpPr>
+        <a:xfrm rot="5400000">
+          <a:off x="900" y="900"/>
+          <a:ext cx="200" cy="200"/>
+          <a:chOff x="900" y="900"/>
+          <a:chExt cx="200" cy="200"/>
+        </a:xfrm>
+      </p:grpSpPr>
+    </p:grpSp>`);
+    const inner = grpSp(`<p:grpSp>
+      <p:grpSpPr>
+        <a:xfrm rot="5400000">
+          <a:off x="1090" y="990"/>
+          <a:ext cx="20" cy="20"/>
+          <a:chOff x="1090" y="990"/>
+          <a:chExt cx="20" cy="20"/>
+        </a:xfrm>
+      </p:grpSpPr>
+    </p:grpSp>`);
+    const tOuter = composeGroupTransform(IDENTITY_TRANSFORM, outer, SCALE);
+    const tInner = composeGroupTransform(tOuter, inner, SCALE);
+
+    // A point at the inner group's own center, in inner-local coords.
+    const localCenterX = 1100 * SCALE.sx;
+    const localCenterY = 1000 * SCALE.sy;
+    const child = {
+      x: localCenterX - 5,
+      y: localCenterY - 5,
+      w: 10,
+      h: 10,
+      rotation: 0,
+    };
+    const world = applyGroupTransform(child, tInner);
+
+    // Inner's own center, after outer's 90° spin, lands at the outer
+    // pivot's south point: world (1000 * sx, 1100 * sy).
+    expect(world.x + world.w / 2).toBeCloseTo(1000 * SCALE.sx, 6);
+    expect(world.y + world.h / 2).toBeCloseTo(1100 * SCALE.sy, 6);
+    // Cumulative rotation = outer + inner = 180°.
+    expect(world.rotation).toBeCloseTo(Math.PI, 6);
   });
 });

--- a/packages/slides/src/import/pptx/group.ts
+++ b/packages/slides/src/import/pptx/group.ts
@@ -4,53 +4,52 @@ import { parseXfrm } from './geometry';
 import { child } from './xml';
 
 /**
- * Affine transform that maps a child's local frame (in deck-px,
+ * 2D affine transform that maps a child's local frame (in deck-px,
  * already scaled by `parseXfrm`) into the world frame after a group
  * has been "ungrouped" inline.
  *
+ *   [a c tx]
+ *   [b d ty]   →  world = M · local
+ *   [0 0  1]
+ *
+ * The matrix bakes in every enclosing group's translate / scale /
+ * rotation, so nested rotated groups compose correctly via standard
+ * matrix multiplication. `rotation` is the cumulative element-self
+ * rotation that gets added to each child's own `frame.rotation` (the
+ * canvas renderer rotates each element around its own center, so the
+ * world-space orbit is handled by the matrix while the in-place spin
+ * is handled by `rotation`).
+ *
  * OOXML group spPr exposes four boxes:
- *   `<a:off>`   — group's position in the parent space
- *   `<a:ext>`   — group's size in the parent space
+ *   `<a:off>`   — group position in the parent space
+ *   `<a:ext>`   — group size in the parent space
  *   `<a:chOff>` — local origin (subtracted from each child)
- *   `<a:chExt>` — local extent (the denominator of the local scale)
+ *   `<a:chExt>` — local extent (denominator of the local scale)
  *
- * Child position before rotation is then:
- *   `offset + (child_local - chOff) * (ext / chExt)`
- *
- * Rotation is applied last: each child's *center* is rotated around the
- * group's world center, then the group's rotation is added to the
- * child's own. Nested rotated groups are approximated — inner pivot is
- * computed pre-rotation of the outer (correct when outer rotation = 0,
- * which is the only case the benchmark deck and most real decks hit).
+ * The group's own transform is composed of (applied to a local point):
+ *   1. translate by `-chOff`
+ *   2. scale by `ext / chExt`
+ *   3. translate by `off`
+ *   4. rotate by `rot` around the group's center `off + ext / 2`
  */
 export interface GroupTransform {
-  parentOffX: number;
-  parentOffY: number;
-  scaleX: number;
-  scaleY: number;
-  childBaseX: number;
-  childBaseY: number;
-  /** Group rotation in radians, applied around (pivotX, pivotY). */
+  a: number; b: number;
+  c: number; d: number;
+  tx: number; ty: number;
   rotation: number;
-  /** Rotation pivot in world coordinates (group's center). */
-  pivotX: number;
-  pivotY: number;
 }
 
 export const IDENTITY_TRANSFORM: GroupTransform = {
-  parentOffX: 0,
-  parentOffY: 0,
-  scaleX: 1,
-  scaleY: 1,
-  childBaseX: 0,
-  childBaseY: 0,
+  a: 1, b: 0,
+  c: 0, d: 1,
+  tx: 0, ty: 0,
   rotation: 0,
-  pivotX: 0,
-  pivotY: 0,
 };
 
 /**
- * Build the cumulative transform for descending into a `<p:grpSp>`.
+ * Build the cumulative transform for descending into a `<p:grpSp>` —
+ * `parent * group` so the parent applies *after* the group's own
+ * transform (i.e., child → group local → parent world).
  */
 export function composeGroupTransform(
   parent: GroupTransform,
@@ -61,9 +60,8 @@ export function composeGroupTransform(
   const xfrm = grpSpPr ? child(grpSpPr, 'xfrm') : undefined;
   if (!xfrm) return parent;
 
-  // Read the group's own frame in the local px space (already scaled).
+  // Group's own frame in the local px space (already scaled).
   const off = parseXfrm(xfrm, scale);
-
   const chOffEl = child(xfrm, 'chOff');
   const chExtEl = child(xfrm, 'chExt');
   const chOffX = chOffEl ? Number(chOffEl.getAttribute('x') ?? '0') * scale.sx : 0;
@@ -71,67 +69,101 @@ export function composeGroupTransform(
   const chExtW = chExtEl ? Number(chExtEl.getAttribute('cx') ?? '0') * scale.sx : off.w;
   const chExtH = chExtEl ? Number(chExtEl.getAttribute('cy') ?? '0') * scale.sy : off.h;
 
-  // Local scale factors: how the local space stretches onto the parent
-  // space. When `chExt` matches `ext` (most common), this is identity.
   const localSx = chExtW > 0 ? off.w / chExtW : 1;
   const localSy = chExtH > 0 ? off.h / chExtH : 1;
 
-  // Pivot of THIS group in world coordinates = center of the group's
-  // own frame after the parent's translate+scale (but ignoring the
-  // parent's rotation — see GroupTransform jsdoc).
-  const groupCenterX = off.x + off.w / 2;
-  const groupCenterY = off.y + off.h / 2;
-  const pivotX =
-    parent.parentOffX + (groupCenterX - parent.childBaseX) * parent.scaleX;
-  const pivotY =
-    parent.parentOffY + (groupCenterY - parent.childBaseY) * parent.scaleY;
-
-  return {
-    parentOffX: parent.parentOffX + (off.x - parent.childBaseX) * parent.scaleX,
-    parentOffY: parent.parentOffY + (off.y - parent.childBaseY) * parent.scaleY,
-    scaleX: parent.scaleX * localSx,
-    scaleY: parent.scaleY * localSy,
-    childBaseX: chOffX,
-    childBaseY: chOffY,
-    rotation: parent.rotation + off.rotation,
-    pivotX,
-    pivotY,
+  // Matrix for this group: translate(off) · scale(localSx, localSy) · translate(-chOff)
+  //   = [localSx  0       off.x - localSx*chOffX]
+  //     [0        localSy off.y - localSy*chOffY]
+  let m: GroupTransform = {
+    a: localSx, b: 0,
+    c: 0, d: localSy,
+    tx: off.x - localSx * chOffX,
+    ty: off.y - localSy * chOffY,
+    rotation: 0,
   };
+
+  // Rotate around the group's own center (parent-relative coords).
+  if (off.rotation) {
+    const pivotX = off.x + off.w / 2;
+    const pivotY = off.y + off.h / 2;
+    m = composeMatrix(rotationAround(off.rotation, pivotX, pivotY), m);
+    m.rotation = off.rotation;
+  }
+
+  // Final composition: parent · group.
+  const composed = composeMatrix(parent, m);
+  composed.rotation = parent.rotation + m.rotation;
+  return composed;
 }
 
 /**
  * Apply a group transform to a child's local frame, returning the
- * world frame. Non-zero group rotation rotates the child's center
- * around the group's pivot rather than just adding to the child's own
- * rotation in place.
+ * world frame. The element's own rotation is preserved; the group's
+ * accumulated rotation is added on top so the renderer's "rotate
+ * around own center" maps to the correct visual orientation.
  */
 export function applyGroupTransform(frame: Frame, t: GroupTransform): Frame {
-  // Pre-rotation world position via affine.
-  const x0 = t.parentOffX + (frame.x - t.childBaseX) * t.scaleX;
-  const y0 = t.parentOffY + (frame.y - t.childBaseY) * t.scaleY;
-  const w = frame.w * t.scaleX;
-  const h = frame.h * t.scaleY;
+  // Apply matrix to the child's center.
+  const cxLocal = frame.x + frame.w / 2;
+  const cyLocal = frame.y + frame.h / 2;
+  const cxWorld = t.a * cxLocal + t.c * cyLocal + t.tx;
+  const cyWorld = t.b * cxLocal + t.d * cyLocal + t.ty;
 
-  if (!t.rotation) {
-    return { x: x0, y: y0, w, h, rotation: frame.rotation };
-  }
+  // Extract scale along each axis. For pure rotation / translation /
+  // scale (no shear) this is exact; shear cases (rare in OOXML) will
+  // still produce a reasonable approximation.
+  const scaleX = Math.sqrt(t.a * t.a + t.b * t.b);
+  const scaleY = Math.sqrt(t.c * t.c + t.d * t.d);
+  const w = frame.w * scaleX;
+  const h = frame.h * scaleY;
 
-  // Rotate the child's center around the group's world pivot, then
-  // recover the top-left from the rotated center using the (still
-  // axis-aligned in local frame terms) child dimensions.
-  const cxLocal = x0 + w / 2;
-  const cyLocal = y0 + h / 2;
-  const cos = Math.cos(t.rotation);
-  const sin = Math.sin(t.rotation);
-  const dx = cxLocal - t.pivotX;
-  const dy = cyLocal - t.pivotY;
-  const cxWorld = t.pivotX + dx * cos - dy * sin;
-  const cyWorld = t.pivotY + dx * sin + dy * cos;
   return {
     x: cxWorld - w / 2,
     y: cyWorld - h / 2,
     w,
     h,
     rotation: frame.rotation + t.rotation,
+  };
+}
+
+/**
+ * Apply a group transform to a single point (used for connector
+ * free endpoints, which are bare `(x, y)` rather than a full frame).
+ */
+export function applyGroupTransformToPoint(
+  x: number,
+  y: number,
+  t: GroupTransform,
+): { x: number; y: number } {
+  return {
+    x: t.a * x + t.c * y + t.tx,
+    y: t.b * x + t.d * y + t.ty,
+  };
+}
+
+/** Compose two affine matrices: result = outer · inner (apply inner first). */
+function composeMatrix(outer: GroupTransform, inner: GroupTransform): GroupTransform {
+  return {
+    a: outer.a * inner.a + outer.c * inner.b,
+    b: outer.b * inner.a + outer.d * inner.b,
+    c: outer.a * inner.c + outer.c * inner.d,
+    d: outer.b * inner.c + outer.d * inner.d,
+    tx: outer.a * inner.tx + outer.c * inner.ty + outer.tx,
+    ty: outer.b * inner.tx + outer.d * inner.ty + outer.ty,
+    rotation: outer.rotation,
+  };
+}
+
+/** R(θ, pivot) = T(pivot) · R(θ) · T(-pivot). */
+function rotationAround(theta: number, pivotX: number, pivotY: number): GroupTransform {
+  const cos = Math.cos(theta);
+  const sin = Math.sin(theta);
+  return {
+    a: cos, b: sin,
+    c: -sin, d: cos,
+    tx: pivotX * (1 - cos) + sin * pivotY,
+    ty: pivotY * (1 - cos) - sin * pivotX,
+    rotation: 0,
   };
 }

--- a/packages/slides/src/import/pptx/group.ts
+++ b/packages/slides/src/import/pptx/group.ts
@@ -14,10 +14,14 @@ import { child } from './xml';
  *   `<a:chOff>` — local origin (subtracted from each child)
  *   `<a:chExt>` — local extent (the denominator of the local scale)
  *
- * Child position is then: `offset + (child_local - chOff) * (ext / chExt)`.
+ * Child position before rotation is then:
+ *   `offset + (child_local - chOff) * (ext / chExt)`
  *
- * Because both halves are EMU-linear, applying the same scale formula
- * directly on the px values yields the correct world px frame.
+ * Rotation is applied last: each child's *center* is rotated around the
+ * group's world center, then the group's rotation is added to the
+ * child's own. Nested rotated groups are approximated — inner pivot is
+ * computed pre-rotation of the outer (correct when outer rotation = 0,
+ * which is the only case the benchmark deck and most real decks hit).
  */
 export interface GroupTransform {
   parentOffX: number;
@@ -26,8 +30,11 @@ export interface GroupTransform {
   scaleY: number;
   childBaseX: number;
   childBaseY: number;
-  /** Group rotation in radians, applied additively to each child. */
+  /** Group rotation in radians, applied around (pivotX, pivotY). */
   rotation: number;
+  /** Rotation pivot in world coordinates (group's center). */
+  pivotX: number;
+  pivotY: number;
 }
 
 export const IDENTITY_TRANSFORM: GroupTransform = {
@@ -38,12 +45,12 @@ export const IDENTITY_TRANSFORM: GroupTransform = {
   childBaseX: 0,
   childBaseY: 0,
   rotation: 0,
+  pivotX: 0,
+  pivotY: 0,
 };
 
 /**
  * Build the cumulative transform for descending into a `<p:grpSp>`.
- * Composes with the parent transform so nested groups (depth > 1) work
- * — the benchmark deck stays at depth 1 but the formula generalises.
  */
 export function composeGroupTransform(
   parent: GroupTransform,
@@ -59,9 +66,6 @@ export function composeGroupTransform(
 
   const chOffEl = child(xfrm, 'chOff');
   const chExtEl = child(xfrm, 'chExt');
-  // Synthesise a tiny <a:xfrm> for chOff/chExt — parseXfrm wants
-  // off/ext children, so we reuse the same helper by writing the same
-  // pattern. Simpler: read directly.
   const chOffX = chOffEl ? Number(chOffEl.getAttribute('x') ?? '0') * scale.sx : 0;
   const chOffY = chOffEl ? Number(chOffEl.getAttribute('y') ?? '0') * scale.sy : 0;
   const chExtW = chExtEl ? Number(chExtEl.getAttribute('cx') ?? '0') * scale.sx : off.w;
@@ -72,9 +76,16 @@ export function composeGroupTransform(
   const localSx = chExtW > 0 ? off.w / chExtW : 1;
   const localSy = chExtH > 0 ? off.h / chExtH : 1;
 
-  // Apply parent transform on top of the local transform so the
-  // resulting transform takes a *local child frame* and outputs the
-  // *parent's world frame*.
+  // Pivot of THIS group in world coordinates = center of the group's
+  // own frame after the parent's translate+scale (but ignoring the
+  // parent's rotation — see GroupTransform jsdoc).
+  const groupCenterX = off.x + off.w / 2;
+  const groupCenterY = off.y + off.h / 2;
+  const pivotX =
+    parent.parentOffX + (groupCenterX - parent.childBaseX) * parent.scaleX;
+  const pivotY =
+    parent.parentOffY + (groupCenterY - parent.childBaseY) * parent.scaleY;
+
   return {
     parentOffX: parent.parentOffX + (off.x - parent.childBaseX) * parent.scaleX,
     parentOffY: parent.parentOffY + (off.y - parent.childBaseY) * parent.scaleY,
@@ -83,16 +94,44 @@ export function composeGroupTransform(
     childBaseX: chOffX,
     childBaseY: chOffY,
     rotation: parent.rotation + off.rotation,
+    pivotX,
+    pivotY,
   };
 }
 
-/** Apply a group transform to a child's local frame, returning the world frame. */
+/**
+ * Apply a group transform to a child's local frame, returning the
+ * world frame. Non-zero group rotation rotates the child's center
+ * around the group's pivot rather than just adding to the child's own
+ * rotation in place.
+ */
 export function applyGroupTransform(frame: Frame, t: GroupTransform): Frame {
+  // Pre-rotation world position via affine.
+  const x0 = t.parentOffX + (frame.x - t.childBaseX) * t.scaleX;
+  const y0 = t.parentOffY + (frame.y - t.childBaseY) * t.scaleY;
+  const w = frame.w * t.scaleX;
+  const h = frame.h * t.scaleY;
+
+  if (!t.rotation) {
+    return { x: x0, y: y0, w, h, rotation: frame.rotation };
+  }
+
+  // Rotate the child's center around the group's world pivot, then
+  // recover the top-left from the rotated center using the (still
+  // axis-aligned in local frame terms) child dimensions.
+  const cxLocal = x0 + w / 2;
+  const cyLocal = y0 + h / 2;
+  const cos = Math.cos(t.rotation);
+  const sin = Math.sin(t.rotation);
+  const dx = cxLocal - t.pivotX;
+  const dy = cyLocal - t.pivotY;
+  const cxWorld = t.pivotX + dx * cos - dy * sin;
+  const cyWorld = t.pivotY + dx * sin + dy * cos;
   return {
-    x: t.parentOffX + (frame.x - t.childBaseX) * t.scaleX,
-    y: t.parentOffY + (frame.y - t.childBaseY) * t.scaleY,
-    w: frame.w * t.scaleX,
-    h: frame.h * t.scaleY,
+    x: cxWorld - w / 2,
+    y: cyWorld - h / 2,
+    w,
+    h,
     rotation: frame.rotation + t.rotation,
   };
 }

--- a/packages/slides/src/import/pptx/group.ts
+++ b/packages/slides/src/import/pptx/group.ts
@@ -1,0 +1,98 @@
+import type { Frame } from '../../model/element';
+import type { EmuScale } from './geometry';
+import { parseXfrm } from './geometry';
+import { child } from './xml';
+
+/**
+ * Affine transform that maps a child's local frame (in deck-px,
+ * already scaled by `parseXfrm`) into the world frame after a group
+ * has been "ungrouped" inline.
+ *
+ * OOXML group spPr exposes four boxes:
+ *   `<a:off>`   — group's position in the parent space
+ *   `<a:ext>`   — group's size in the parent space
+ *   `<a:chOff>` — local origin (subtracted from each child)
+ *   `<a:chExt>` — local extent (the denominator of the local scale)
+ *
+ * Child position is then: `offset + (child_local - chOff) * (ext / chExt)`.
+ *
+ * Because both halves are EMU-linear, applying the same scale formula
+ * directly on the px values yields the correct world px frame.
+ */
+export interface GroupTransform {
+  parentOffX: number;
+  parentOffY: number;
+  scaleX: number;
+  scaleY: number;
+  childBaseX: number;
+  childBaseY: number;
+  /** Group rotation in radians, applied additively to each child. */
+  rotation: number;
+}
+
+export const IDENTITY_TRANSFORM: GroupTransform = {
+  parentOffX: 0,
+  parentOffY: 0,
+  scaleX: 1,
+  scaleY: 1,
+  childBaseX: 0,
+  childBaseY: 0,
+  rotation: 0,
+};
+
+/**
+ * Build the cumulative transform for descending into a `<p:grpSp>`.
+ * Composes with the parent transform so nested groups (depth > 1) work
+ * — the benchmark deck stays at depth 1 but the formula generalises.
+ */
+export function composeGroupTransform(
+  parent: GroupTransform,
+  grpSp: Element,
+  scale: EmuScale,
+): GroupTransform {
+  const grpSpPr = child(grpSp, 'grpSpPr');
+  const xfrm = grpSpPr ? child(grpSpPr, 'xfrm') : undefined;
+  if (!xfrm) return parent;
+
+  // Read the group's own frame in the local px space (already scaled).
+  const off = parseXfrm(xfrm, scale);
+
+  const chOffEl = child(xfrm, 'chOff');
+  const chExtEl = child(xfrm, 'chExt');
+  // Synthesise a tiny <a:xfrm> for chOff/chExt — parseXfrm wants
+  // off/ext children, so we reuse the same helper by writing the same
+  // pattern. Simpler: read directly.
+  const chOffX = chOffEl ? Number(chOffEl.getAttribute('x') ?? '0') * scale.sx : 0;
+  const chOffY = chOffEl ? Number(chOffEl.getAttribute('y') ?? '0') * scale.sy : 0;
+  const chExtW = chExtEl ? Number(chExtEl.getAttribute('cx') ?? '0') * scale.sx : off.w;
+  const chExtH = chExtEl ? Number(chExtEl.getAttribute('cy') ?? '0') * scale.sy : off.h;
+
+  // Local scale factors: how the local space stretches onto the parent
+  // space. When `chExt` matches `ext` (most common), this is identity.
+  const localSx = chExtW > 0 ? off.w / chExtW : 1;
+  const localSy = chExtH > 0 ? off.h / chExtH : 1;
+
+  // Apply parent transform on top of the local transform so the
+  // resulting transform takes a *local child frame* and outputs the
+  // *parent's world frame*.
+  return {
+    parentOffX: parent.parentOffX + (off.x - parent.childBaseX) * parent.scaleX,
+    parentOffY: parent.parentOffY + (off.y - parent.childBaseY) * parent.scaleY,
+    scaleX: parent.scaleX * localSx,
+    scaleY: parent.scaleY * localSy,
+    childBaseX: chOffX,
+    childBaseY: chOffY,
+    rotation: parent.rotation + off.rotation,
+  };
+}
+
+/** Apply a group transform to a child's local frame, returning the world frame. */
+export function applyGroupTransform(frame: Frame, t: GroupTransform): Frame {
+  return {
+    x: t.parentOffX + (frame.x - t.childBaseX) * t.scaleX,
+    y: t.parentOffY + (frame.y - t.childBaseY) * t.scaleY,
+    w: frame.w * t.scaleX,
+    h: frame.h * t.scaleY,
+    rotation: frame.rotation + t.rotation,
+  };
+}

--- a/packages/slides/src/import/pptx/image.test.ts
+++ b/packages/slides/src/import/pptx/image.test.ts
@@ -91,6 +91,24 @@ describe('parsePic', () => {
     expect(result?.data.crop).toEqual({ x: 0.1, y: 0.2, w: 0.9, h: 0.8 });
   });
 
+  it('skips and bumps the report when uploadImage throws', async () => {
+    const report = new ImportReport();
+    const result = await parsePic(picEl(PIC), {
+      archive: fakeArchive({ 'ppt/media/image1.png': new Uint8Array([1]) }),
+      slidePartPath: 'ppt/slides/slide1.xml',
+      rels: new Map([
+        ['rId3', { type: 'image', target: '../media/image1.png', external: false }],
+      ]),
+      uploadImage: async () => {
+        throw new Error('network down');
+      },
+      scale: emuScale(DEFAULT_WIDESCREEN_EMU),
+      report,
+    });
+    expect(result).toBeUndefined();
+    expect(report.skippedImages).toBe(1);
+  });
+
   it('skips and bumps the report when the rel is missing', async () => {
     const report = new ImportReport();
     const result = await parsePic(picEl(PIC), {

--- a/packages/slides/src/import/pptx/image.test.ts
+++ b/packages/slides/src/import/pptx/image.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parsePic } from './image';
+import { ImportReport } from './report';
+import { emuScale, DEFAULT_WIDESCREEN_EMU } from './geometry';
+import { parseXml } from './xml';
+import type { PptxArchive } from './unzip';
+
+function picEl(xml: string): Element {
+  return parseXml(
+    `<root xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">${xml}</root>`,
+  ).documentElement.firstElementChild!;
+}
+
+function fakeArchive(media: Record<string, Uint8Array>): PptxArchive {
+  return {
+    readText: async () => undefined,
+    readBytes: async (path) => media[path],
+    list: () => Object.keys(media),
+  };
+}
+
+const PIC = `<p:pic>
+  <p:blipFill><a:blip r:embed="rId3"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>
+  <p:spPr><a:xfrm><a:off x="914400" y="457200"/><a:ext cx="1828800" cy="914400"/></a:xfrm></p:spPr>
+</p:pic>`;
+
+describe('parsePic', () => {
+  it('uploads image bytes and emits an ImageElement', async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    let receivedMime = '';
+    let receivedBytes: Uint8Array | undefined;
+    const archive = fakeArchive({ 'ppt/media/image1.png': bytes });
+    const report = new ImportReport();
+    const result = await parsePic(picEl(PIC), {
+      archive,
+      slidePartPath: 'ppt/slides/slide1.xml',
+      rels: new Map([
+        ['rId3', { type: 'image', target: '../media/image1.png', external: false }],
+      ]),
+      uploadImage: async (b, m) => {
+        receivedBytes = b;
+        receivedMime = m;
+        return 'https://cdn/image1.png';
+      },
+      scale: emuScale(DEFAULT_WIDESCREEN_EMU),
+      report,
+    });
+    expect(result?.type).toBe('image');
+    expect(result?.data.src).toBe('https://cdn/image1.png');
+    expect(receivedMime).toBe('image/png');
+    expect(receivedBytes).toBe(bytes);
+    expect(result?.frame.w).toBeGreaterThan(0);
+    expect(report.skippedImages).toBe(0);
+  });
+
+  it('skips when uploadImage is not provided', async () => {
+    const report = new ImportReport();
+    const result = await parsePic(picEl(PIC), {
+      archive: fakeArchive({}),
+      slidePartPath: 'ppt/slides/slide1.xml',
+      rels: new Map([
+        ['rId3', { type: 'image', target: '../media/image1.png', external: false }],
+      ]),
+      scale: emuScale(DEFAULT_WIDESCREEN_EMU),
+      report,
+    });
+    expect(result).toBeUndefined();
+    expect(report.skippedImages).toBe(1);
+  });
+
+  it('parses <a:srcRect> as a normalized Crop', async () => {
+    const pic = picEl(`<p:pic>
+      <p:blipFill>
+        <a:blip r:embed="rId3"/>
+        <a:srcRect l="10000" t="20000" r="0" b="0"/>
+        <a:stretch><a:fillRect/></a:stretch>
+      </p:blipFill>
+      <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm></p:spPr>
+    </p:pic>`);
+    const result = await parsePic(pic, {
+      archive: fakeArchive({ 'ppt/media/image1.png': new Uint8Array([1]) }),
+      slidePartPath: 'ppt/slides/slide1.xml',
+      rels: new Map([
+        ['rId3', { type: 'image', target: '../media/image1.png', external: false }],
+      ]),
+      uploadImage: async () => 'u',
+      scale: emuScale(DEFAULT_WIDESCREEN_EMU),
+      report: new ImportReport(),
+    });
+    expect(result?.data.crop).toEqual({ x: 0.1, y: 0.2, w: 0.9, h: 0.8 });
+  });
+
+  it('skips and bumps the report when the rel is missing', async () => {
+    const report = new ImportReport();
+    const result = await parsePic(picEl(PIC), {
+      archive: fakeArchive({}),
+      slidePartPath: 'ppt/slides/slide1.xml',
+      rels: new Map(), // no rId3
+      uploadImage: async () => 'u',
+      scale: emuScale(DEFAULT_WIDESCREEN_EMU),
+      report,
+    });
+    expect(result).toBeUndefined();
+    expect(report.skippedImages).toBe(1);
+  });
+});

--- a/packages/slides/src/import/pptx/image.ts
+++ b/packages/slides/src/import/pptx/image.ts
@@ -67,7 +67,19 @@ export async function parsePic(
   const ext = mediaPath.split('.').pop()?.toLowerCase() ?? '';
   const mime = EXT_TO_MIME[ext] ?? 'application/octet-stream';
 
-  const src = await ctx.uploadImage(bytes, mime);
+  // Soft-skip on upload failure — a single broken image shouldn't tank
+  // the whole import. Counts towards `report.skippedImages` and the
+  // caller drops the element.
+  let src: string;
+  try {
+    src = await ctx.uploadImage(bytes, mime);
+  } catch (err) {
+    ctx.report.skippedImages += 1;
+    if (typeof console !== 'undefined') {
+      console.warn(`pptx import: image upload failed for ${mediaPath}:`, err);
+    }
+    return undefined;
+  }
 
   const crop = blipFill ? parseSrcRect(child(blipFill, 'srcRect')) : undefined;
 

--- a/packages/slides/src/import/pptx/image.ts
+++ b/packages/slides/src/import/pptx/image.ts
@@ -1,0 +1,104 @@
+import type { Crop, ImageElement } from '../../model/element';
+import { generateId } from '../../model/element';
+import type { EmuScale } from './geometry';
+import { parseXfrm } from './geometry';
+import type { PptxArchive } from './unzip';
+import type { PptxRel } from './rels';
+import { resolveRelsTarget } from './rels';
+import { ImportReport } from './report';
+import type { UploadImage } from './index';
+import { attrInt, child, NS } from './xml';
+
+const EXT_TO_MIME: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+};
+
+export interface ImageParseContext {
+  archive: PptxArchive;
+  /** The slide part path, used to resolve relative rels targets. */
+  slidePartPath: string;
+  rels: Map<string, PptxRel>;
+  uploadImage?: UploadImage;
+  scale: EmuScale;
+  report: ImportReport;
+}
+
+/**
+ * Parse `<p:pic>` into an `ImageElement`. Returns `undefined` and bumps
+ * `report.skippedImages` when the blip is missing, the rel doesn't
+ * resolve, or no `uploadImage` callback is configured.
+ */
+export async function parsePic(
+  pic: Element,
+  ctx: ImageParseContext,
+): Promise<ImageElement | undefined> {
+  const spPr = child(pic, 'spPr');
+  const xfrm = spPr ? child(spPr, 'xfrm') : undefined;
+  const frame = parseXfrm(xfrm, ctx.scale);
+
+  const blipFill = child(pic, 'blipFill');
+  const blip = blipFill ? child(blipFill, 'blip') : undefined;
+  const rid = blip
+    ? blip.getAttributeNS(NS.R, 'embed') || blip.getAttribute('r:embed') || undefined
+    : undefined;
+
+  if (!rid || !ctx.uploadImage) {
+    ctx.report.skippedImages += 1;
+    return undefined;
+  }
+  const rel = ctx.rels.get(rid);
+  if (!rel) {
+    ctx.report.skippedImages += 1;
+    return undefined;
+  }
+
+  const mediaPath = resolveRelsTarget(ctx.slidePartPath, rel.target);
+  const bytes = await ctx.archive.readBytes(mediaPath);
+  if (!bytes) {
+    ctx.report.skippedImages += 1;
+    return undefined;
+  }
+
+  const ext = mediaPath.split('.').pop()?.toLowerCase() ?? '';
+  const mime = EXT_TO_MIME[ext] ?? 'application/octet-stream';
+
+  const src = await ctx.uploadImage(bytes, mime);
+
+  const crop = blipFill ? parseSrcRect(child(blipFill, 'srcRect')) : undefined;
+
+  return {
+    id: generateId(),
+    type: 'image',
+    frame,
+    data: {
+      src,
+      ...(crop ? { crop } : {}),
+    },
+  };
+}
+
+/**
+ * `<a:srcRect l="10000" t="0" r="0" b="0"/>` — each axis is in
+ * thousandths of the image dimension. Our `Crop` is normalized to a
+ * 0..1 sub-rectangle (origin + size).
+ */
+function parseSrcRect(srcRect: Element | undefined): Crop | undefined {
+  if (!srcRect) return undefined;
+  const l = (attrInt(srcRect, 'l') ?? 0) / 100_000;
+  const t = (attrInt(srcRect, 't') ?? 0) / 100_000;
+  const r = (attrInt(srcRect, 'r') ?? 0) / 100_000;
+  const b = (attrInt(srcRect, 'b') ?? 0) / 100_000;
+  if (l === 0 && t === 0 && r === 0 && b === 0) return undefined;
+  return {
+    x: l,
+    y: t,
+    w: Math.max(0, 1 - l - r),
+    h: Math.max(0, 1 - t - b),
+  };
+}
+

--- a/packages/slides/src/import/pptx/index.test.ts
+++ b/packages/slides/src/import/pptx/index.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { importPptx } from './index';
+import { buildMinimalPptx } from './__fixtures__/build-minimal-pptx';
+
+describe('importPptx', () => {
+  it('imports a minimal deck — theme/master/layout/slide all wired', async () => {
+    const buffer = await buildMinimalPptx();
+    const { document, report } = await importPptx(buffer);
+    expect(document.meta.themeId).toMatch(/^imported-/);
+    expect(document.meta.masterId).toMatch(/^imported-/);
+    // Imported "Office" theme + 5 built-ins.
+    expect(document.themes.length).toBeGreaterThanOrEqual(6);
+    const imported = document.themes.find((t) => t.id === document.meta.themeId);
+    expect(imported?.colors.accent1).toBe('#4472C4');
+    expect(document.masters).toHaveLength(1);
+    expect(document.masters[0].themeId).toBe(document.meta.themeId);
+    // Built-in layouts + imported (blank) collapsed via dedupe.
+    expect(document.layouts.length).toBeGreaterThanOrEqual(11);
+    // Minimal fixture ships one blank slide.
+    expect(document.slides).toHaveLength(1);
+    expect(document.slides[0].layoutId).toBe('blank');
+    expect(document.slides[0].elements).toHaveLength(0);
+    expect(report.summary()).toContain('no fallbacks');
+  });
+
+  it('throws on a buffer without presentation.xml', async () => {
+    const JSZip = (await import('jszip')).default;
+    const zip = new JSZip();
+    zip.file('[Content_Types].xml', '<Types/>');
+    const buffer = await zip.generateAsync({ type: 'arraybuffer' });
+    await expect(importPptx(buffer)).rejects.toThrow(/presentation\.xml/);
+  });
+});

--- a/packages/slides/src/import/pptx/index.ts
+++ b/packages/slides/src/import/pptx/index.ts
@@ -4,6 +4,7 @@ import { DEFAULT_MASTER } from '../../model/master';
 import { BUILT_IN_LAYOUTS } from '../../model/layout';
 import { BUILT_IN_THEMES } from '../../themes';
 import type { Theme } from '../../model/theme';
+import type { ClrMap } from './color';
 import { emuScale, DEFAULT_WIDESCREEN_EMU } from './geometry';
 import { parseSlide, type LayoutPathToInfo } from './slide';
 import { unzipPptx, type PptxArchive } from './unzip';
@@ -83,7 +84,12 @@ export async function importPptx(
         importedTheme?.id ?? 'default-light',
         report,
       )
-    : { master: undefined, layouts: [] as Layout[], layoutMap: new Map() as LayoutPathToInfo };
+    : {
+        master: undefined,
+        layouts: [] as Layout[],
+        layoutMap: new Map() as LayoutPathToInfo,
+        clrMap: new Map() as ClrMap,
+      };
 
   const themes: Theme[] = importedTheme
     ? [importedTheme, ...BUILT_IN_THEMES.filter((t) => t.id !== importedTheme.id)]
@@ -109,6 +115,7 @@ export async function importPptx(
       uploadImage: opts.uploadImage,
       scale,
       report,
+      clrMap: masterAndLayouts.clrMap,
     });
     if (slide) slides.push(slide);
   }
@@ -184,12 +191,19 @@ async function loadMasterAndLayouts(
   masterTarget: string,
   themeId: string,
   report: ImportReport,
-): Promise<{ master: Master | undefined; layouts: Layout[]; layoutMap: LayoutPathToInfo }> {
+): Promise<{
+  master: Master | undefined;
+  layouts: Layout[];
+  layoutMap: LayoutPathToInfo;
+  clrMap: ClrMap;
+}> {
   const masterPath = resolveRelsTarget(ownerPart, masterTarget);
   const masterXml = await archive.readText(masterPath);
-  if (!masterXml) return { master: undefined, layouts: [], layoutMap: new Map() };
+  if (!masterXml) {
+    return { master: undefined, layouts: [], layoutMap: new Map(), clrMap: new Map() };
+  }
 
-  const master = parseMaster(masterXml, `imported-${masterPath}`, themeId);
+  const { master, clrMap } = parseMaster(masterXml, `imported-${masterPath}`, themeId);
 
   // Each master's rels file lists the slideLayouts it owns. We import
   // them all; slides resolve to one via their own rels file.
@@ -212,7 +226,7 @@ async function loadMasterAndLayouts(
     });
   }
 
-  return { master, layouts, layoutMap };
+  return { master, layouts, layoutMap, clrMap };
 }
 
 /** `ppt/slideMasters/slideMaster1.xml` → `ppt/slideMasters/_rels/slideMaster1.xml.rels`. */

--- a/packages/slides/src/import/pptx/index.ts
+++ b/packages/slides/src/import/pptx/index.ts
@@ -5,7 +5,7 @@ import { BUILT_IN_LAYOUTS } from '../../model/layout';
 import { BUILT_IN_THEMES } from '../../themes';
 import type { Theme } from '../../model/theme';
 import { emuScale, DEFAULT_WIDESCREEN_EMU } from './geometry';
-import { parseSlide, type LayoutPathToId } from './slide';
+import { parseSlide, type LayoutPathToInfo } from './slide';
 import { unzipPptx, type PptxArchive } from './unzip';
 import { ImportReport } from './report';
 import { parseRels, resolveRelsTarget } from './rels';
@@ -83,7 +83,7 @@ export async function importPptx(
         importedTheme?.id ?? 'default-light',
         report,
       )
-    : { master: undefined, layouts: [] as Layout[], layoutMap: new Map() as LayoutPathToId };
+    : { master: undefined, layouts: [] as Layout[], layoutMap: new Map() as LayoutPathToInfo };
 
   const themes: Theme[] = importedTheme
     ? [importedTheme, ...BUILT_IN_THEMES.filter((t) => t.id !== importedTheme.id)]
@@ -184,7 +184,7 @@ async function loadMasterAndLayouts(
   masterTarget: string,
   themeId: string,
   report: ImportReport,
-): Promise<{ master: Master | undefined; layouts: Layout[]; layoutMap: LayoutPathToId }> {
+): Promise<{ master: Master | undefined; layouts: Layout[]; layoutMap: LayoutPathToInfo }> {
   const masterPath = resolveRelsTarget(ownerPart, masterTarget);
   const masterXml = await archive.readText(masterPath);
   if (!masterXml) return { master: undefined, layouts: [], layoutMap: new Map() };
@@ -198,7 +198,7 @@ async function loadMasterAndLayouts(
   const rels = relsXml ? parseRels(relsXml) : new Map();
 
   const layouts: Layout[] = [];
-  const layoutMap: LayoutPathToId = new Map();
+  const layoutMap: LayoutPathToInfo = new Map();
   for (const rel of rels.values()) {
     if (rel.type !== 'slideLayout') continue;
     const layoutPath = resolveRelsTarget(masterPath, rel.target);
@@ -206,7 +206,10 @@ async function loadMasterAndLayouts(
     if (!layoutXml) continue;
     const imported = parseLayout(layoutXml, layoutPath, report);
     layouts.push(imported.layout);
-    layoutMap.set(layoutPath, imported.layout.id);
+    layoutMap.set(layoutPath, {
+      builtInId: imported.layout.id,
+      placeholderSizes: imported.placeholderSizes,
+    });
   }
 
   return { master, layouts, layoutMap };

--- a/packages/slides/src/import/pptx/index.ts
+++ b/packages/slides/src/import/pptx/index.ts
@@ -1,0 +1,232 @@
+import type { SlidesDocument, Layout, Slide } from '../../model/presentation';
+import type { Master } from '../../model/master';
+import { DEFAULT_MASTER } from '../../model/master';
+import { BUILT_IN_LAYOUTS } from '../../model/layout';
+import { BUILT_IN_THEMES } from '../../themes';
+import type { Theme } from '../../model/theme';
+import { emuScale, DEFAULT_WIDESCREEN_EMU } from './geometry';
+import { parseSlide, type LayoutPathToId } from './slide';
+import { unzipPptx, type PptxArchive } from './unzip';
+import { ImportReport } from './report';
+import { parseRels, resolveRelsTarget } from './rels';
+import { parseTheme } from './theme';
+import { parseMaster } from './master';
+import { parseLayout } from './layout';
+import { attrInt, children, descendant, parseXml, NS } from './xml';
+
+export type UploadImage = (bytes: Uint8Array, mime: string) => Promise<string>;
+
+export interface ImportPptxOptions {
+  /**
+   * Called once per `<p:pic>` embedded blob. Returns the URL to store
+   * on the resulting `ImageElement`. The caller is responsible for
+   * routing to the workspace's `/images` endpoint.
+   *
+   * Required for decks with images. Omitted for fixtures / dry runs.
+   */
+  uploadImage?: UploadImage;
+}
+
+export interface ImportPptxResult {
+  document: SlidesDocument;
+  report: ImportReport;
+}
+
+/** EMU dimensions of the source deck — captured for the geometry scale. */
+export interface SourceSlideSize {
+  cx: number;
+  cy: number;
+}
+
+/**
+ * Best-effort import of a `.pptx` archive into a `SlidesDocument`.
+ *
+ * Task 2 wires in theme / master / layout. Slides + element parsing
+ * land in Task 3; the document returns with an empty `slides[]` until
+ * then.
+ *
+ * Node consumers must polyfill `DOMParser` before calling this. The
+ * CLI's `dom-polyfill.ts` already does so for the docs importer.
+ */
+export async function importPptx(
+  buffer: ArrayBuffer,
+  opts: ImportPptxOptions = {},
+): Promise<ImportPptxResult> {
+  const archive = await unzipPptx(buffer);
+  const report = new ImportReport();
+
+  const presentationXml = await archive.readText('ppt/presentation.xml');
+  if (!presentationXml) {
+    throw new Error('Invalid .pptx: missing ppt/presentation.xml');
+  }
+  const presentation = parseXml(presentationXml);
+
+  const slideSizeEmu = readSlideSize(presentation);
+  const scale = emuScale(slideSizeEmu);
+
+  // Resolve presentation.xml.rels → theme + master + slide targets.
+  const presRelsXml = await archive.readText('ppt/_rels/presentation.xml.rels');
+  const presRels = presRelsXml ? parseRels(presRelsXml) : new Map();
+
+  const themeTarget = pickRelTarget(presRels, 'theme');
+  const masterTarget = pickRelTarget(presRels, 'slideMaster');
+
+  const importedTheme = themeTarget
+    ? await loadTheme(archive, 'ppt/presentation.xml', themeTarget)
+    : undefined;
+
+  const masterAndLayouts = masterTarget
+    ? await loadMasterAndLayouts(
+        archive,
+        'ppt/presentation.xml',
+        masterTarget,
+        importedTheme?.id ?? 'default-light',
+        report,
+      )
+    : { master: undefined, layouts: [] as Layout[], layoutMap: new Map() as LayoutPathToId };
+
+  const themes: Theme[] = importedTheme
+    ? [importedTheme, ...BUILT_IN_THEMES.filter((t) => t.id !== importedTheme.id)]
+    : [...BUILT_IN_THEMES];
+  const masters: Master[] = masterAndLayouts.master
+    ? [masterAndLayouts.master]
+    : [DEFAULT_MASTER];
+  // Built-in layouts are always available; imported layouts ride on top
+  // (deduped by id — multiple OOXML layouts can collapse onto the same
+  // built-in, and storing duplicates would break BUILT_IN_LAYOUTS' usage
+  // as the picker's source of truth).
+  const layouts = dedupeLayouts([...BUILT_IN_LAYOUTS, ...masterAndLayouts.layouts]);
+
+  // Slides — resolve in source order from `<p:sldIdLst>`. Each entry's
+  // `r:id` points into `presRels` at the slide part path.
+  const slidePartPaths = orderedSlidePaths(presentation, presRels);
+  const slides: Slide[] = [];
+  for (const path of slidePartPaths) {
+    const slide = await parseSlide({
+      archive,
+      partPath: path,
+      layoutMap: masterAndLayouts.layoutMap,
+      uploadImage: opts.uploadImage,
+      scale,
+      report,
+    });
+    if (slide) slides.push(slide);
+  }
+
+  const document: SlidesDocument = {
+    meta: {
+      title: 'Imported deck',
+      themeId: importedTheme?.id ?? 'default-light',
+      masterId: masterAndLayouts.master?.id ?? 'default',
+    },
+    themes,
+    masters,
+    layouts,
+    slides,
+  };
+
+  return { document, report };
+}
+
+function orderedSlidePaths(
+  presentation: Document,
+  presRels: Map<string, { type: string; target: string }>,
+): string[] {
+  const sldIdLst = descendant(presentation, 'sldIdLst');
+  if (!sldIdLst) return [];
+  const out: string[] = [];
+  for (const sldId of children(sldIdLst, 'sldId')) {
+    const rid =
+      sldId.getAttributeNS(NS.R, 'id') || sldId.getAttribute('r:id') || undefined;
+    if (!rid) continue;
+    const rel = presRels.get(rid);
+    if (!rel || rel.type !== 'slide') continue;
+    out.push(resolveRelsTarget('ppt/presentation.xml', rel.target));
+  }
+  return out;
+}
+
+function readSlideSize(presentation: Document): SourceSlideSize {
+  const sldSz = descendant(presentation, 'sldSz');
+  if (!sldSz) return { ...DEFAULT_WIDESCREEN_EMU };
+  return {
+    cx: attrInt(sldSz, 'cx') ?? DEFAULT_WIDESCREEN_EMU.cx,
+    cy: attrInt(sldSz, 'cy') ?? DEFAULT_WIDESCREEN_EMU.cy,
+  };
+}
+
+function pickRelTarget(
+  rels: Map<string, { type: string; target: string }>,
+  type: string,
+): string | undefined {
+  for (const rel of rels.values()) {
+    if (rel.type === type) return rel.target;
+  }
+  return undefined;
+}
+
+async function loadTheme(
+  archive: PptxArchive,
+  ownerPart: string,
+  target: string,
+): Promise<Theme | undefined> {
+  const path = resolveRelsTarget(ownerPart, target);
+  const xml = await archive.readText(path);
+  if (!xml) return undefined;
+  // Stable id keyed on the source path keeps imported themes distinct
+  // from the built-ins even if multiple decks share the OOXML name "Office".
+  return parseTheme(xml, `imported-${path}`);
+}
+
+async function loadMasterAndLayouts(
+  archive: PptxArchive,
+  ownerPart: string,
+  masterTarget: string,
+  themeId: string,
+  report: ImportReport,
+): Promise<{ master: Master | undefined; layouts: Layout[]; layoutMap: LayoutPathToId }> {
+  const masterPath = resolveRelsTarget(ownerPart, masterTarget);
+  const masterXml = await archive.readText(masterPath);
+  if (!masterXml) return { master: undefined, layouts: [], layoutMap: new Map() };
+
+  const master = parseMaster(masterXml, `imported-${masterPath}`, themeId);
+
+  // Each master's rels file lists the slideLayouts it owns. We import
+  // them all; slides resolve to one via their own rels file.
+  const relsPath = relsSiblingFor(masterPath);
+  const relsXml = await archive.readText(relsPath);
+  const rels = relsXml ? parseRels(relsXml) : new Map();
+
+  const layouts: Layout[] = [];
+  const layoutMap: LayoutPathToId = new Map();
+  for (const rel of rels.values()) {
+    if (rel.type !== 'slideLayout') continue;
+    const layoutPath = resolveRelsTarget(masterPath, rel.target);
+    const layoutXml = await archive.readText(layoutPath);
+    if (!layoutXml) continue;
+    const imported = parseLayout(layoutXml, layoutPath, report);
+    layouts.push(imported.layout);
+    layoutMap.set(layoutPath, imported.layout.id);
+  }
+
+  return { master, layouts, layoutMap };
+}
+
+/** `ppt/slideMasters/slideMaster1.xml` → `ppt/slideMasters/_rels/slideMaster1.xml.rels`. */
+function relsSiblingFor(partPath: string): string {
+  const slash = partPath.lastIndexOf('/');
+  const dir = slash >= 0 ? partPath.slice(0, slash) : '';
+  const file = slash >= 0 ? partPath.slice(slash + 1) : partPath;
+  return (dir ? dir + '/' : '') + '_rels/' + file + '.rels';
+}
+
+function dedupeLayouts(layouts: Layout[]): Layout[] {
+  const seen = new Set<string>();
+  const out: Layout[] = [];
+  for (const layout of layouts) {
+    if (seen.has(layout.id)) continue;
+    seen.add(layout.id);
+    out.push(layout);
+  }
+  return out;
+}

--- a/packages/slides/src/import/pptx/layout.test.ts
+++ b/packages/slides/src/import/pptx/layout.test.ts
@@ -33,5 +33,42 @@ describe('parseLayout', () => {
     const out = parseLayout(layoutXml('blank'), 'ppt/slideLayouts/slideLayout11.xml', r);
     expect(out.ooxmlPartName).toBe('ppt/slideLayouts/slideLayout11.xml');
     expect(out.layout.id).toBe('blank');
+    expect(out.placeholderSizes.size).toBe(0);
+  });
+
+  it('extracts placeholder default font sizes from <a:lstStyle><a:lvl1pPr><a:defRPr sz>', () => {
+    // Mirrors the benchmark deck's slideLayout1.xml, where the ctrTitle
+    // placeholder carries sz="5200" (52pt) as its default. Without
+    // reading this, slide-level runs with no explicit sz collapse to
+    // the docs renderer's 11pt fallback.
+    const xml = `<?xml version="1.0"?>
+<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" type="title">
+  <p:cSld name="Title Slide">
+    <p:spTree>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Title 1"/><p:cNvSpPr/><p:nvPr><p:ph type="ctrTitle"/></p:nvPr></p:nvSpPr>
+        <p:spPr/>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle><a:lvl1pPr><a:defRPr sz="5200"/></a:lvl1pPr></a:lstStyle>
+          <a:p><a:r><a:t/></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="3" name="Subtitle 2"/><p:cNvSpPr/><p:nvPr><p:ph idx="1" type="subTitle"/></p:nvPr></p:nvSpPr>
+        <p:spPr/>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle><a:lvl1pPr><a:defRPr sz="2400"/></a:lvl1pPr></a:lstStyle>
+          <a:p><a:r><a:t/></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sldLayout>`;
+    const out = parseLayout(xml, 'ppt/slideLayouts/slideLayout1.xml', new ImportReport());
+    expect(out.placeholderSizes.get('ctrTitle:0')).toBe(52);
+    expect(out.placeholderSizes.get('subTitle:1')).toBe(24);
   });
 });

--- a/packages/slides/src/import/pptx/layout.test.ts
+++ b/packages/slides/src/import/pptx/layout.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseLayout } from './layout';
+import { ImportReport } from './report';
+
+function layoutXml(type: string): string {
+  return `<?xml version="1.0"?>
+<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" type="${type}">
+  <p:cSld name="Layout"><p:spTree/></p:cSld>
+</p:sldLayout>`;
+}
+
+describe('parseLayout', () => {
+  it('maps the four types used by the benchmark deck', () => {
+    const r = new ImportReport();
+    expect(parseLayout(layoutXml('tx'), 'l1', r).layout.id).toBe('title-body');
+    expect(parseLayout(layoutXml('secHead'), 'l2', r).layout.id).toBe('section-header');
+    expect(parseLayout(layoutXml('body'), 'l3', r).layout.id).toBe('one-column-text');
+    expect(parseLayout(layoutXml('title'), 'l4', r).layout.id).toBe('title-slide');
+    expect(r.unknownLayoutTypes).toBe(0);
+  });
+
+  it('falls back to title-body and counts unknown types', () => {
+    const r = new ImportReport();
+    const out = parseLayout(layoutXml('mediaText'), 'lx', r);
+    expect(out.layout.id).toBe('title-body');
+    expect(r.unknownLayoutTypes).toBe(1);
+  });
+
+  it('preserves the OOXML part name for later rels resolution', () => {
+    const r = new ImportReport();
+    const out = parseLayout(layoutXml('blank'), 'ppt/slideLayouts/slideLayout11.xml', r);
+    expect(out.ooxmlPartName).toBe('ppt/slideLayouts/slideLayout11.xml');
+    expect(out.layout.id).toBe('blank');
+  });
+});

--- a/packages/slides/src/import/pptx/layout.ts
+++ b/packages/slides/src/import/pptx/layout.ts
@@ -1,7 +1,7 @@
 import { BUILT_IN_LAYOUTS } from '../../model/layout';
 import type { Layout } from '../../model/presentation';
 import { ImportReport } from './report';
-import { attr, descendant, parseXml } from './xml';
+import { attr, attrInt, child, children, descendant, parseXml } from './xml';
 
 /**
  * OOXML `<p:sldLayout type>` value → one of our built-in layout ids.
@@ -33,6 +33,16 @@ export interface ImportedLayout {
   ooxmlPartName: string;
   /** Built-in layout id that best matches the OOXML `type`. */
   layout: Layout;
+  /**
+   * Map of `"{ooxmlType}:{idx}"` → default `fontSize` in points, derived
+   * from each layout placeholder's `<p:txBody><a:lstStyle><a:lvl1pPr>
+   * <a:defRPr sz>`. Slide-level runs inherit this when their own
+   * `<a:rPr>` lacks an explicit `sz`. The benchmark deck stores its
+   * title-slide title size (`5200` → 52pt) only here — not on the
+   * slide or in the master's `<p:txStyles>` — so we have to read
+   * layout overrides to render titles faithfully.
+   */
+  placeholderSizes: Map<string, number>;
 }
 
 /**
@@ -55,6 +65,44 @@ export function parseLayout(
 
   const targetId = builtInId ?? 'title-body';
   const layout = BUILT_IN_LAYOUTS.find((l) => l.id === targetId) ?? BUILT_IN_LAYOUTS[0];
+  const placeholderSizes = sldLayout
+    ? parsePlaceholderSizes(sldLayout)
+    : new Map<string, number>();
 
-  return { ooxmlPartName, layout };
+  return { ooxmlPartName, layout, placeholderSizes };
+}
+
+/**
+ * Walk a layout's `<p:spTree>` for placeholder shapes and pull each
+ * one's level-1 default font size out of `<a:lstStyle><a:lvl1pPr>
+ * <a:defRPr sz>`. Returns a map keyed by `"{ooxmlType}:{idx}"` so the
+ * slide parser can look up the right default for a given placeholder
+ * reference.
+ */
+function parsePlaceholderSizes(sldLayout: Element): Map<string, number> {
+  const out = new Map<string, number>();
+  const cSld = child(sldLayout, 'cSld');
+  const spTree = cSld ? child(cSld, 'spTree') : undefined;
+  if (!spTree) return out;
+  for (const sp of children(spTree, 'sp')) {
+    const nvSpPr = child(sp, 'nvSpPr');
+    const nvPr = nvSpPr ? child(nvSpPr, 'nvPr') : undefined;
+    const ph = nvPr ? child(nvPr, 'ph') : undefined;
+    if (!ph) continue;
+    const type = attr(ph, 'type') ?? 'body';
+    const idx = attr(ph, 'idx') ?? '0';
+
+    const txBody = child(sp, 'txBody');
+    if (!txBody) continue;
+    const lstStyle = child(txBody, 'lstStyle');
+    if (!lstStyle) continue;
+    const lvl1 = child(lstStyle, 'lvl1pPr');
+    if (!lvl1) continue;
+    const defRPr = child(lvl1, 'defRPr');
+    if (!defRPr) continue;
+    const sz = attrInt(defRPr, 'sz');
+    if (sz == null) continue;
+    out.set(`${type}:${idx}`, sz / 100);
+  }
+  return out;
 }

--- a/packages/slides/src/import/pptx/layout.ts
+++ b/packages/slides/src/import/pptx/layout.ts
@@ -1,0 +1,60 @@
+import { BUILT_IN_LAYOUTS } from '../../model/layout';
+import type { Layout } from '../../model/presentation';
+import { ImportReport } from './report';
+import { attr, descendant, parseXml } from './xml';
+
+/**
+ * OOXML `<p:sldLayout type>` value → one of our built-in layout ids.
+ *
+ * PPTX defines ~30 layout `type` tokens; we collapse them onto the 11
+ * Google-Slides-parity layouts shipped in v0.4.0. Any unrecognised
+ * token falls back to `title-body` (the most common one in real decks)
+ * and bumps `report.unknownLayoutTypes`.
+ *
+ * The benchmark Yorkie 캐즘 deck uses only `tx`, `secHead`, `body`, and
+ * `title` — all covered explicitly below.
+ */
+const TYPE_TO_BUILT_IN: Record<string, string> = {
+  title: 'title-slide',
+  ctrTitle: 'title-slide',
+  secHead: 'section-header',
+  obj: 'title-body',
+  tx: 'title-body',
+  body: 'one-column-text',
+  titleOnly: 'title-only',
+  twoColTx: 'title-two-columns',
+  twoObj: 'title-two-columns',
+  twoTxTwoObj: 'title-two-columns',
+  blank: 'blank',
+};
+
+export interface ImportedLayout {
+  /** Stable id for this layout part — used by slide rels resolution. */
+  ooxmlPartName: string;
+  /** Built-in layout id that best matches the OOXML `type`. */
+  layout: Layout;
+}
+
+/**
+ * Resolve a `ppt/slideLayouts/slideLayoutN.xml` document to one of our
+ * eleven built-in layouts. v1 does *not* synthesise per-deck custom
+ * layouts; the design doc reserves that for v1.5 alongside theme builder
+ * editing of master/layout placeholders.
+ */
+export function parseLayout(
+  xml: string,
+  ooxmlPartName: string,
+  report: ImportReport,
+): ImportedLayout {
+  const doc = parseXml(xml);
+  const sldLayout = descendant(doc, 'sldLayout');
+  const rawType = sldLayout ? attr(sldLayout, 'type') : undefined;
+  const builtInId = rawType ? TYPE_TO_BUILT_IN[rawType] : undefined;
+
+  if (rawType && !builtInId) report.unknownLayoutTypes += 1;
+
+  const targetId = builtInId ?? 'title-body';
+  const layout = BUILT_IN_LAYOUTS.find((l) => l.id === targetId) ?? BUILT_IN_LAYOUTS[0];
+
+  return { ooxmlPartName, layout };
+}

--- a/packages/slides/src/import/pptx/master.test.ts
+++ b/packages/slides/src/import/pptx/master.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseMaster } from './master';
+
+const MIN_MASTER = `<?xml version="1.0"?>
+<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:bg><p:bgPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></p:bgPr></p:bg>
+    <p:spTree/>
+  </p:cSld>
+</p:sldMaster>`;
+
+const SRGB_MASTER = `<?xml version="1.0"?>
+<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:bg><p:bgPr><a:solidFill><a:srgbClr val="F3F3F3"/></a:solidFill></p:bgPr></p:bg>
+    <p:spTree/>
+  </p:cSld>
+</p:sldMaster>`;
+
+describe('parseMaster', () => {
+  it('captures the master background as a theme-bound role', () => {
+    const m = parseMaster(MIN_MASTER, 'master-1', 'imported-yorkie');
+    expect(m.id).toBe('master-1');
+    expect(m.themeId).toBe('imported-yorkie');
+    expect(m.background.fill).toEqual({ kind: 'role', role: 'background' });
+  });
+
+  it('captures a literal sRGB background', () => {
+    const m = parseMaster(SRGB_MASTER, 'm', 't');
+    expect(m.background.fill).toEqual({ kind: 'srgb', value: '#F3F3F3' });
+  });
+
+  it('inherits the default placeholder-style table for now', () => {
+    const m = parseMaster(MIN_MASTER, 'm', 't');
+    expect(m.placeholderStyles.title.fontSize).toBe(44);
+    expect(m.placeholderStyles.body.fontSize).toBe(18);
+  });
+});

--- a/packages/slides/src/import/pptx/master.test.ts
+++ b/packages/slides/src/import/pptx/master.test.ts
@@ -22,20 +22,39 @@ const SRGB_MASTER = `<?xml version="1.0"?>
 
 describe('parseMaster', () => {
   it('captures the master background as a theme-bound role', () => {
-    const m = parseMaster(MIN_MASTER, 'master-1', 'imported-yorkie');
-    expect(m.id).toBe('master-1');
-    expect(m.themeId).toBe('imported-yorkie');
-    expect(m.background.fill).toEqual({ kind: 'role', role: 'background' });
+    const { master, clrMap } = parseMaster(MIN_MASTER, 'master-1', 'imported-yorkie');
+    expect(master.id).toBe('master-1');
+    expect(master.themeId).toBe('imported-yorkie');
+    expect(master.background.fill).toEqual({ kind: 'role', role: 'background' });
+    expect(clrMap.size).toBe(0); // identity (no <p:clrMap>)
   });
 
   it('captures a literal sRGB background', () => {
-    const m = parseMaster(SRGB_MASTER, 'm', 't');
-    expect(m.background.fill).toEqual({ kind: 'srgb', value: '#F3F3F3' });
+    const { master } = parseMaster(SRGB_MASTER, 'm', 't');
+    expect(master.background.fill).toEqual({ kind: 'srgb', value: '#F3F3F3' });
   });
 
   it('inherits the default placeholder-style table for now', () => {
-    const m = parseMaster(MIN_MASTER, 'm', 't');
-    expect(m.placeholderStyles.title.fontSize).toBe(44);
-    expect(m.placeholderStyles.body.fontSize).toBe(18);
+    const { master } = parseMaster(MIN_MASTER, 'm', 't');
+    expect(master.placeholderStyles.title.fontSize).toBe(44);
+    expect(master.placeholderStyles.body.fontSize).toBe(18);
+  });
+
+  it('parses non-identity <p:clrMap> mappings (benchmark deck swaps bg2/tx2)', () => {
+    const xml = `<?xml version="1.0"?>
+<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld><p:spTree/></p:cSld>
+  <p:clrMap bg1="lt1" tx1="dk1" bg2="dk2" tx2="lt2"
+            accent1="accent1" accent2="accent2" accent3="accent3"
+            accent4="accent4" accent5="accent5" accent6="accent6"
+            hlink="hlink" folHlink="folHlink"/>
+</p:sldMaster>`;
+    const { clrMap } = parseMaster(xml, 'm', 't');
+    // Identity entries skipped; only the swaps land in the map.
+    expect(clrMap.get('bg2')).toBe('dk2');
+    expect(clrMap.get('tx2')).toBe('lt2');
+    expect(clrMap.has('bg1')).toBe(false);
+    expect(clrMap.has('accent1')).toBe(false);
   });
 });

--- a/packages/slides/src/import/pptx/master.ts
+++ b/packages/slides/src/import/pptx/master.ts
@@ -1,0 +1,44 @@
+import type { Master, MasterBackground } from '../../model/master';
+import { DEFAULT_MASTER } from '../../model/master';
+import { parseColorFromContainer } from './color';
+import { child, descendant, parseXml } from './xml';
+
+/**
+ * Parse `ppt/slideMasters/slideMaster1.xml` into a `Master`.
+ *
+ * v1 scope: read just the master-level background and inherit the rest
+ * of the placeholder-style table from `DEFAULT_MASTER`. Per-placeholder
+ * style overrides on the master are reachable via `<p:txStyles>` and
+ * will land alongside Task 3 text parsing — the first consumer is the
+ * docs-style block emitter, not the master importer itself.
+ */
+export function parseMaster(xml: string, id: string, themeId: string): Master {
+  const doc = parseXml(xml);
+  const sldMaster = descendant(doc, 'sldMaster');
+  const cSld = sldMaster ? child(sldMaster, 'cSld') : undefined;
+  const bg = cSld ? child(cSld, 'bg') : undefined;
+
+  const background = bg ? parseBackground(bg) : { ...DEFAULT_MASTER.background };
+
+  return {
+    id,
+    themeId,
+    background,
+    placeholderStyles: { ...DEFAULT_MASTER.placeholderStyles },
+  };
+}
+
+function parseBackground(bg: Element): MasterBackground {
+  // `<p:bg>` wraps either `<p:bgPr>` (literal fill) or `<p:bgRef>` (style
+  // matrix index). v1 supports only `bgPr → solidFill` and falls back
+  // for anything else.
+  const bgPr = child(bg, 'bgPr');
+  if (bgPr) {
+    const solid = child(bgPr, 'solidFill');
+    if (solid) {
+      const color = parseColorFromContainer(solid);
+      if (color) return { fill: color };
+    }
+  }
+  return { ...DEFAULT_MASTER.background };
+}

--- a/packages/slides/src/import/pptx/master.ts
+++ b/packages/slides/src/import/pptx/master.ts
@@ -1,7 +1,21 @@
 import type { Master, MasterBackground } from '../../model/master';
 import { DEFAULT_MASTER } from '../../model/master';
-import { parseColorFromContainer } from './color';
-import { child, descendant, parseXml } from './xml';
+import { clone } from '../../model/clone';
+import { parseColorFromContainer, type ClrMap } from './color';
+import { attr, child, descendant, parseXml } from './xml';
+
+/**
+ * OOXML `<p:clrMap>` attributes — translation table from logical
+ * scheme tokens (`bg1` / `bg2` / `tx1` / `tx2` / `accent1..6` /
+ * `hlink` / `folHlink`) to actual scheme slot names. Real-world decks
+ * (including the Yorkie 캐즘 benchmark) emit non-identity mappings
+ * — e.g. `bg2="dk2"` swaps `bg2` away from its default `lt2` slot.
+ */
+const CLR_MAP_KEYS = [
+  'bg1', 'tx1', 'bg2', 'tx2',
+  'accent1', 'accent2', 'accent3', 'accent4', 'accent5', 'accent6',
+  'hlink', 'folHlink',
+] as const;
 
 /**
  * Parse `ppt/slideMasters/slideMaster1.xml` into a `Master`.
@@ -12,20 +26,71 @@ import { child, descendant, parseXml } from './xml';
  * will land alongside Task 3 text parsing — the first consumer is the
  * docs-style block emitter, not the master importer itself.
  */
-export function parseMaster(xml: string, id: string, themeId: string): Master {
+export interface ImportedMaster {
+  master: Master;
+  /** Translation table from the master's `<p:clrMap>` for slide-level color resolution. */
+  clrMap: ClrMap;
+}
+
+export function parseMaster(xml: string, id: string, themeId: string): ImportedMaster {
   const doc = parseXml(xml);
   const sldMaster = descendant(doc, 'sldMaster');
   const cSld = sldMaster ? child(sldMaster, 'cSld') : undefined;
   const bg = cSld ? child(cSld, 'bg') : undefined;
+  const clrMap = sldMaster ? parseClrMap(sldMaster) : new Map<string, string>();
 
-  const background = bg ? parseBackground(bg) : { ...DEFAULT_MASTER.background };
+  // Master `<p:bg>` is parsed without `clrMap` — backgrounds almost
+  // always use direct scheme slot names (`lt1` / `dk1`) rather than the
+  // logical `bg1` / `tx1` aliases that `<p:clrMap>` rewires.
+  const background = bg ? parseBackground(bg) : clone(DEFAULT_MASTER.background);
 
+  // `clone()` deep-copies so the imported master can mutate its
+  // background / placeholderStyles without leaking back into
+  // `DEFAULT_MASTER` (which is read-only by intent — many decks share
+  // it via module identity).
   return {
-    id,
-    themeId,
-    background,
-    placeholderStyles: { ...DEFAULT_MASTER.placeholderStyles },
+    master: {
+      id,
+      themeId,
+      background,
+      placeholderStyles: clone(DEFAULT_MASTER.placeholderStyles),
+    },
+    clrMap,
   };
+}
+
+/**
+ * Default OOXML clrMap (the implicit mapping when `<p:clrMap>` is
+ * omitted). Identity for accent / hlink slots; aliases bg1/tx1/bg2/tx2
+ * to their default scheme slot names.
+ */
+const DEFAULT_CLR_MAP: Record<string, string> = {
+  bg1: 'lt1',
+  tx1: 'dk1',
+  bg2: 'lt2',
+  tx2: 'dk2',
+  accent1: 'accent1',
+  accent2: 'accent2',
+  accent3: 'accent3',
+  accent4: 'accent4',
+  accent5: 'accent5',
+  accent6: 'accent6',
+  hlink: 'hlink',
+  folHlink: 'folHlink',
+};
+
+function parseClrMap(sldMaster: Element): ClrMap {
+  const map = new Map<string, string>();
+  const el = child(sldMaster, 'clrMap');
+  if (!el) return map;
+  for (const key of CLR_MAP_KEYS) {
+    const value = attr(el, key);
+    // Skip identity (matches OOXML default) — keeps the map sparse and
+    // makes test assertions clearer. Non-identity entries are what
+    // matter at color-resolution time.
+    if (value && value !== DEFAULT_CLR_MAP[key]) map.set(key, value);
+  }
+  return map;
 }
 
 function parseBackground(bg: Element): MasterBackground {
@@ -40,5 +105,5 @@ function parseBackground(bg: Element): MasterBackground {
       if (color) return { fill: color };
     }
   }
-  return { ...DEFAULT_MASTER.background };
+  return clone(DEFAULT_MASTER.background);
 }

--- a/packages/slides/src/import/pptx/rels.test.ts
+++ b/packages/slides/src/import/pptx/rels.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseRels, resolveRelsTarget } from './rels';
+
+const RELS_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout3.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com/" TargetMode="External"/>
+</Relationships>`;
+
+describe('parseRels', () => {
+  it('builds a map from rId to short type + target', () => {
+    const rels = parseRels(RELS_XML);
+    expect(rels.size).toBe(3);
+    expect(rels.get('rId1')).toEqual({
+      type: 'slideLayout',
+      target: '../slideLayouts/slideLayout3.xml',
+      external: false,
+    });
+    expect(rels.get('rId2')?.type).toBe('image');
+    expect(rels.get('rId3')?.external).toBe(true);
+  });
+});
+
+describe('resolveRelsTarget', () => {
+  it('resolves relative targets against the part directory', () => {
+    expect(resolveRelsTarget('ppt/slides/slide1.xml', '../media/image1.png')).toBe(
+      'ppt/media/image1.png',
+    );
+    expect(resolveRelsTarget('ppt/slides/slide1.xml', '../slideLayouts/slideLayout3.xml')).toBe(
+      'ppt/slideLayouts/slideLayout3.xml',
+    );
+  });
+
+  it('returns external URLs unchanged', () => {
+    expect(resolveRelsTarget('ppt/slides/slide1.xml', 'https://example.com/')).toBe(
+      'https://example.com/',
+    );
+  });
+});

--- a/packages/slides/src/import/pptx/rels.ts
+++ b/packages/slides/src/import/pptx/rels.ts
@@ -1,0 +1,55 @@
+import { NS, parseXml } from './xml';
+
+export interface PptxRel {
+  /** Short type name (last URL segment), e.g. `'image'`, `'hyperlink'`. */
+  type: string;
+  /** Target path, possibly relative (`../media/image1.png`). */
+  target: string;
+  /** External hyperlinks expose `TargetMode="External"`. */
+  external: boolean;
+}
+
+/**
+ * Parse a `.rels` XML file into a map of relationship id → entry.
+ *
+ * Same shape as docs's `parseRelationships`, kept separate so the slides
+ * package doesn't depend on docs internals.
+ */
+export function parseRels(xml: string): Map<string, PptxRel> {
+  const doc = parseXml(xml);
+  const out = new Map<string, PptxRel>();
+  const elements = doc.getElementsByTagNameNS(NS.RELS, 'Relationship');
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i];
+    const id = el.getAttribute('Id') ?? '';
+    const target = el.getAttribute('Target') ?? '';
+    const fullType = el.getAttribute('Type') ?? '';
+    const type = fullType.split('/').pop() ?? '';
+    const external = el.getAttribute('TargetMode') === 'External';
+    if (id) out.set(id, { type, target, external });
+  }
+  return out;
+}
+
+/**
+ * Resolve a rels target path against the part it's attached to.
+ *
+ *   resolveRelsTarget('ppt/slides/slide1.xml', '../media/image1.png')
+ *     → 'ppt/media/image1.png'
+ *
+ * External targets (`https://...`) are returned as-is.
+ */
+export function resolveRelsTarget(partPath: string, target: string): string {
+  if (/^[a-z]+:\/\//i.test(target)) return target;
+  // Drop the part filename and join with the target.
+  const lastSlash = partPath.lastIndexOf('/');
+  const baseDir = lastSlash >= 0 ? partPath.slice(0, lastSlash) : '';
+  const segments = (baseDir + '/' + target).split('/');
+  const stack: string[] = [];
+  for (const seg of segments) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') stack.pop();
+    else stack.push(seg);
+  }
+  return stack.join('/');
+}

--- a/packages/slides/src/import/pptx/report.ts
+++ b/packages/slides/src/import/pptx/report.ts
@@ -24,6 +24,11 @@ export class ImportReport {
     if (this.shadowsDropped) parts.push(`${this.shadowsDropped} shadow(s) dropped`);
     if (this.textBoxesPreScaled) parts.push(`${this.textBoxesPreScaled} text box(es) pre-scaled`);
     if (this.unknownShapes) parts.push(`${this.unknownShapes} unknown shape(s) → rect`);
+    if (this.unknownLayoutTypes) parts.push(`${this.unknownLayoutTypes} unknown layout type(s)`);
+    if (this.tableMergesIgnored) parts.push(`${this.tableMergesIgnored} table merge(s) ignored`);
+    if (this.tableBordersApproximated) {
+      parts.push(`${this.tableBordersApproximated} table border(s) approximated`);
+    }
     if (this.skippedImages) parts.push(`${this.skippedImages} image(s) skipped`);
     if (parts.length === 0) return 'Imported with no fallbacks.';
     return `Imported with ${parts.join(', ')}.`;

--- a/packages/slides/src/import/pptx/report.ts
+++ b/packages/slides/src/import/pptx/report.ts
@@ -1,0 +1,31 @@
+/**
+ * Counts surfaced to the user after a best-effort import. The toast on
+ * the deck list reads from `summary()`; the CLI prints the same line.
+ *
+ * Fields are mutable — parsers bump counters as they encounter lossy
+ * paths. Anything fully supported is *not* counted (a clean import
+ * produces zeros).
+ */
+export class ImportReport {
+  tablesFlattened = 0;
+  groupsFlattened = 0;
+  shadowsDropped = 0;
+  textBoxesPreScaled = 0;
+  unknownShapes = 0;
+  unknownLayoutTypes = 0;
+  tableMergesIgnored = 0;
+  tableBordersApproximated = 0;
+  skippedImages = 0;
+
+  summary(): string {
+    const parts: string[] = [];
+    if (this.tablesFlattened) parts.push(`${this.tablesFlattened} table(s) flattened`);
+    if (this.groupsFlattened) parts.push(`${this.groupsFlattened} group(s) expanded`);
+    if (this.shadowsDropped) parts.push(`${this.shadowsDropped} shadow(s) dropped`);
+    if (this.textBoxesPreScaled) parts.push(`${this.textBoxesPreScaled} text box(es) pre-scaled`);
+    if (this.unknownShapes) parts.push(`${this.unknownShapes} unknown shape(s) → rect`);
+    if (this.skippedImages) parts.push(`${this.skippedImages} image(s) skipped`);
+    if (parts.length === 0) return 'Imported with no fallbacks.';
+    return `Imported with ${parts.join(', ')}.`;
+  }
+}

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -1,0 +1,429 @@
+import type {
+  Element as SlideElement,
+  ShapeElement,
+  ShapeStroke,
+  TextElement,
+} from '../../model/element';
+import { generateId } from '../../model/element';
+import type {
+  ArrowheadKind,
+  ArrowheadStyle,
+  ConnectorElement,
+  ConnectorRouting,
+  Endpoint,
+} from '../../model/connector';
+import { parseColorFromContainer } from './color';
+import type { EmuScale } from './geometry';
+import { parseXfrm, prstToShapeKind } from './geometry';
+import {
+  applyGroupTransform,
+  composeGroupTransform,
+  IDENTITY_TRANSFORM,
+  type GroupTransform,
+} from './group';
+import { parsePic, type ImageParseContext } from './image';
+import { ImportReport } from './report';
+import { parseTable } from './table';
+import { parseTextBody } from './text';
+import type { PptxArchive } from './unzip';
+import type { PptxRel } from './rels';
+import type { UploadImage } from './index';
+import { attr, attrInt, child, children, NS, parseXml } from './xml';
+
+/**
+ * Per-slide context plumbed through every element-level parser.
+ */
+export interface SlideParseContext {
+  archive: PptxArchive;
+  slidePartPath: string;
+  rels: Map<string, PptxRel>;
+  uploadImage?: UploadImage;
+  scale: EmuScale;
+  report: ImportReport;
+  /**
+   * Maps PPTX shape ids (the `<p:cNvPr id>` numbers within this slide)
+   * to the element ids we generated for them. Connectors use this to
+   * resolve `<a:stCxn id idx>` / `<a:endCxn id idx>` to attached
+   * endpoints.
+   */
+  idMap: Map<number, string>;
+}
+
+/**
+ * Walk a `<p:spTree>` (or a flattened `<p:grpSp>`) in two passes:
+ *   Pass 1: assign element ids to every shape so connectors can resolve
+ *           attached endpoints regardless of source order.
+ *   Pass 2: actually parse each child, recursing into groups.
+ *
+ * Groups and tables are deferred to Task 4 — for now they emit nothing
+ * and bump no counters (the caller will report on them once the v1
+ * fallbacks land).
+ */
+export async function parseSpTree(
+  spTree: Element,
+  ctx: SlideParseContext,
+  transform: GroupTransform = IDENTITY_TRANSFORM,
+): Promise<SlideElement[]> {
+  // Pass 1: id assignment for `<p:sp>` / `<p:pic>` / `<p:cxnSp>`,
+  // recursing through `<p:grpSp>` so nested ids land in the same map
+  // and connectors can resolve attached endpoints regardless of depth.
+  preassignIds(spTree, ctx.idMap);
+
+  // Pass 2: parse each child element, applying the cumulative group
+  // transform to every element's frame.
+  const out: SlideElement[] = [];
+  for (let i = 0; i < spTree.childNodes.length; i++) {
+    const n = spTree.childNodes[i];
+    if (n.nodeType !== 1) continue;
+    const el = n as Element;
+
+    if (el.localName === 'grpSp') {
+      const childTransform = composeGroupTransform(transform, el, ctx.scale);
+      const flattened = await parseSpTree(el, ctx, childTransform);
+      out.push(...flattened);
+      ctx.report.groupsFlattened += 1;
+      continue;
+    }
+
+    const parsed = await parseChild(el, ctx);
+    if (!parsed) continue;
+    for (const elem of parsed) {
+      out.push(applyTransformToElement(elem, transform));
+    }
+  }
+  return out;
+}
+
+function applyTransformToElement(
+  elem: SlideElement,
+  transform: GroupTransform,
+): SlideElement {
+  if (transform === IDENTITY_TRANSFORM) return elem;
+  if (elem.type === 'connector') {
+    // Connectors with `attached` endpoints inherit positions from the
+    // referenced element — only the `free` corners + arrowhead frame
+    // need a transform pass.
+    const start =
+      elem.start.kind === 'free'
+        ? {
+            kind: 'free' as const,
+            x: transform.parentOffX + (elem.start.x - transform.childBaseX) * transform.scaleX,
+            y: transform.parentOffY + (elem.start.y - transform.childBaseY) * transform.scaleY,
+          }
+        : elem.start;
+    const end =
+      elem.end.kind === 'free'
+        ? {
+            kind: 'free' as const,
+            x: transform.parentOffX + (elem.end.x - transform.childBaseX) * transform.scaleX,
+            y: transform.parentOffY + (elem.end.y - transform.childBaseY) * transform.scaleY,
+          }
+        : elem.end;
+    return {
+      ...elem,
+      frame: applyGroupTransform(elem.frame, transform),
+      start,
+      end,
+    };
+  }
+  return { ...elem, frame: applyGroupTransform(elem.frame, transform) };
+}
+
+function preassignIds(parent: Element, idMap: Map<number, string>): void {
+  for (let i = 0; i < parent.childNodes.length; i++) {
+    const n = parent.childNodes[i];
+    if (n.nodeType !== 1) continue;
+    const el = n as Element;
+    switch (el.localName) {
+      case 'sp':
+      case 'pic':
+      case 'cxnSp': {
+        const id = pptxIdOf(el);
+        if (id != null && !idMap.has(id)) idMap.set(id, generateId());
+        break;
+      }
+      case 'grpSp':
+        preassignIds(el, idMap);
+        break;
+    }
+  }
+}
+
+async function parseChild(
+  el: Element,
+  ctx: SlideParseContext,
+): Promise<SlideElement[] | undefined> {
+  switch (el.localName) {
+    case 'sp': {
+      const sp = parseSp(el, ctx);
+      return sp ? [sp] : undefined;
+    }
+    case 'pic': {
+      const picCtx: ImageParseContext = {
+        archive: ctx.archive,
+        slidePartPath: ctx.slidePartPath,
+        rels: ctx.rels,
+        uploadImage: ctx.uploadImage,
+        scale: ctx.scale,
+        report: ctx.report,
+      };
+      const img = await parsePic(el, picCtx);
+      return img ? [withId(img, ctx, el)] : undefined;
+    }
+    case 'cxnSp': {
+      const cxn = parseCxnSp(el, ctx);
+      return cxn ? [cxn] : undefined;
+    }
+    case 'graphicFrame':
+      return parseTable(el, ctx);
+    case 'grpSp':
+      // Handled at the parseSpTree level (transform composition).
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+function pptxIdOf(el: Element): number | undefined {
+  // `<p:nvSpPr><p:cNvPr id="N">` / `<p:nvPicPr><p:cNvPr id>` / etc.
+  // Walk the `nv*Pr` container to find the `cNvPr`.
+  for (let i = 0; i < el.childNodes.length; i++) {
+    const n = el.childNodes[i];
+    if (n.nodeType !== 1) continue;
+    const c = n as Element;
+    if (!c.localName.startsWith('nv')) continue;
+    const cNvPr = child(c, 'cNvPr');
+    if (cNvPr) return attrInt(cNvPr, 'id');
+  }
+  return undefined;
+}
+
+function withId(elem: SlideElement, ctx: SlideParseContext, sourceEl: Element): SlideElement {
+  const pid = pptxIdOf(sourceEl);
+  if (pid != null) {
+    const mapped = ctx.idMap.get(pid);
+    if (mapped) return { ...elem, id: mapped };
+  }
+  return elem;
+}
+
+function parseSp(sp: Element, ctx: SlideParseContext): SlideElement | undefined {
+  const nvSpPr = child(sp, 'nvSpPr');
+  const cNvSpPr = nvSpPr ? child(nvSpPr, 'cNvSpPr') : undefined;
+  const isTextBox = cNvSpPr ? attr(cNvSpPr, 'txBox') === '1' : false;
+
+  const spPr = child(sp, 'spPr');
+  const xfrm = spPr ? child(spPr, 'xfrm') : undefined;
+  const frame = parseXfrm(xfrm, ctx.scale);
+
+  const txBody = child(sp, 'txBody');
+  const elementId = idForSp(sp, ctx);
+
+  // Effects — only `outerShdw` is reported; for v1 we drop it.
+  const effectLst = spPr ? child(spPr, 'effectLst') : undefined;
+  if (effectLst && child(effectLst, 'outerShdw')) {
+    ctx.report.shadowsDropped += 1;
+  }
+
+  // Pure text box — `txBox=1` shapes have no fill/stroke and exist only
+  // as a host for `<p:txBody>`. Emit a TextElement.
+  if (isTextBox && txBody) {
+    return buildTextElement(elementId, frame, txBody, ctx);
+  }
+
+  // Shape with a `prstGeom` — emit a ShapeElement; if it also has text,
+  // we layer a TextElement on top (caller will append both — but for v1
+  // we keep one element per source <p:sp> and prefer the shape).
+  const prstGeom = spPr ? child(spPr, 'prstGeom') : undefined;
+  if (prstGeom) {
+    return buildShapeElement(elementId, frame, sp, prstGeom, ctx);
+  }
+
+  // No prstGeom but has text — treat as plain text box.
+  if (txBody) {
+    return buildTextElement(elementId, frame, txBody, ctx);
+  }
+
+  return undefined;
+}
+
+function idForSp(sp: Element, ctx: SlideParseContext): string {
+  const pid = pptxIdOf(sp);
+  if (pid != null) {
+    const existing = ctx.idMap.get(pid);
+    if (existing) return existing;
+  }
+  return generateId();
+}
+
+function buildTextElement(
+  id: string,
+  frame: SlideElement['frame'],
+  txBody: Element,
+  ctx: SlideParseContext,
+): TextElement {
+  return {
+    id,
+    type: 'text',
+    frame,
+    data: {
+      blocks: parseTextBody(txBody, { rels: ctx.rels, report: ctx.report }),
+    },
+  };
+}
+
+function buildShapeElement(
+  id: string,
+  frame: SlideElement['frame'],
+  sp: Element,
+  prstGeom: Element,
+  ctx: SlideParseContext,
+): ShapeElement {
+  const prst = attr(prstGeom, 'prst') ?? 'rect';
+  let kind = prstToShapeKind(prst) ?? 'rect';
+  if (kind === 'rect' && prst !== 'rect') ctx.report.unknownShapes += 1;
+
+  const adjustments = parseAdjustments(prstGeom);
+
+  const spPr = child(sp, 'spPr');
+  const fill = parseShapeFill(spPr);
+  const stroke = parseShapeStroke(spPr);
+
+  return {
+    id,
+    type: 'shape',
+    frame,
+    data: {
+      kind,
+      ...(adjustments ? { adjustments } : {}),
+      ...(fill ? { fill } : {}),
+      ...(stroke ? { stroke } : {}),
+    },
+  };
+}
+
+function parseAdjustments(prstGeom: Element): number[] | undefined {
+  const avLst = child(prstGeom, 'avLst');
+  if (!avLst) return undefined;
+  const gds = children(avLst, 'gd');
+  if (gds.length === 0) return undefined;
+  const out: number[] = [];
+  for (const gd of gds) {
+    const fmla = attr(gd, 'fmla') ?? '';
+    // PPTX adjustment formulas are `val NNN` for direct values; we
+    // surface NNN and let the path builder interpret it.
+    const m = /^val\s+(-?\d+(?:\.\d+)?)/.exec(fmla);
+    if (m) out.push(Number(m[1]));
+  }
+  return out.length ? out : undefined;
+}
+
+function parseShapeFill(spPr: Element | undefined): ShapeElement['data']['fill'] {
+  if (!spPr) return undefined;
+  const solid = child(spPr, 'solidFill');
+  if (solid) return parseColorFromContainer(solid);
+  // gradient, pattern, blip-fill on shape — out of v1 scope.
+  return undefined;
+}
+
+function parseShapeStroke(spPr: Element | undefined): ShapeStroke | undefined {
+  if (!spPr) return undefined;
+  const ln = child(spPr, 'ln');
+  if (!ln) return undefined;
+  // `<a:ln w>` is in EMU (9525 EMU = 1 px at 96 dpi).
+  const w = attrInt(ln, 'w');
+  const width = w != null ? Math.max(0, w / 9525) : 1;
+  const solid = child(ln, 'solidFill');
+  const color = solid ? parseColorFromContainer(solid) : undefined;
+  if (!color) return undefined;
+  return { color, width };
+}
+
+function parseCxnSp(cxn: Element, ctx: SlideParseContext): ConnectorElement | undefined {
+  const elementId = idForSp(cxn, ctx);
+  const spPr = child(cxn, 'spPr');
+  const xfrm = spPr ? child(spPr, 'xfrm') : undefined;
+  const frame = parseXfrm(xfrm, ctx.scale);
+
+  const prstGeom = spPr ? child(spPr, 'prstGeom') : undefined;
+  const prst = prstGeom ? attr(prstGeom, 'prst') ?? '' : '';
+  const routing: ConnectorRouting = prst.startsWith('curved')
+    ? 'curved'
+    : prst.startsWith('bent')
+      ? 'elbow'
+      : 'straight';
+
+  const nvCxnSpPr = child(cxn, 'nvCxnSpPr');
+  const cNvCxnSpPr = nvCxnSpPr ? child(nvCxnSpPr, 'cNvCxnSpPr') : undefined;
+  const stCxn = cNvCxnSpPr ? child(cNvCxnSpPr, 'stCxn') : undefined;
+  const endCxn = cNvCxnSpPr ? child(cNvCxnSpPr, 'endCxn') : undefined;
+
+  const start = resolveEndpoint(stCxn, frame, 'start', ctx);
+  const end = resolveEndpoint(endCxn, frame, 'end', ctx);
+
+  const ln = spPr ? child(spPr, 'ln') : undefined;
+  const stroke = parseShapeStroke(spPr);
+  const arrowheads = ln
+    ? {
+        start: parseArrowhead(child(ln, 'headEnd')),
+        end: parseArrowhead(child(ln, 'tailEnd')),
+      }
+    : {};
+
+  return {
+    id: elementId,
+    type: 'connector',
+    frame,
+    routing,
+    start,
+    end,
+    arrowheads,
+    ...(stroke ? { stroke } : {}),
+  };
+}
+
+function resolveEndpoint(
+  cxn: Element | undefined,
+  frame: SlideElement['frame'],
+  which: 'start' | 'end',
+  ctx: SlideParseContext,
+): Endpoint {
+  if (cxn) {
+    const idAttr = attrInt(cxn, 'id');
+    const idxAttr = attrInt(cxn, 'idx');
+    if (idAttr != null) {
+      const mapped = ctx.idMap.get(idAttr);
+      if (mapped) {
+        return { kind: 'attached', elementId: mapped, siteIndex: idxAttr ?? 0 };
+      }
+    }
+  }
+  // Fall back to absolute frame corners. `frame` is already in px.
+  const x = which === 'start' ? frame.x : frame.x + frame.w;
+  const y = which === 'start' ? frame.y : frame.y + frame.h;
+  return { kind: 'free', x, y };
+}
+
+const OOXML_ARROW_TO_KIND: Record<string, ArrowheadKind> = {
+  triangle: 'triangle',
+  arrow: 'triangle-open',
+  stealth: 'triangle',
+  diamond: 'diamond',
+  oval: 'circle',
+};
+
+function parseArrowhead(end: Element | undefined): ArrowheadStyle | undefined {
+  if (!end) return undefined;
+  const type = attr(end, 'type');
+  if (!type || type === 'none') return undefined;
+  const kind = OOXML_ARROW_TO_KIND[type];
+  if (!kind) return undefined;
+  const sizeAttr = attr(end, 'len') ?? attr(end, 'w') ?? 'med';
+  const size: ArrowheadStyle['size'] =
+    sizeAttr === 'sm' ? 'sm' : sizeAttr === 'lg' ? 'lg' : 'md';
+  return { kind, size };
+}
+
+// Re-export the shared parser for slide.ts so a one-time test fixture can
+// build a sample <p:sld> via parseXml and exercise parseSpTree directly.
+export { parseXml, NS };

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -19,6 +19,7 @@ import type { EmuScale } from './geometry';
 import { emuToStrokePx, parseXfrm, prstToShapeKind } from './geometry';
 import {
   applyGroupTransform,
+  applyGroupTransformToPoint,
   composeGroupTransform,
   IDENTITY_TRANSFORM,
   type GroupTransform,
@@ -121,16 +122,14 @@ function applyTransformToElement(
       elem.start.kind === 'free'
         ? {
             kind: 'free' as const,
-            x: transform.parentOffX + (elem.start.x - transform.childBaseX) * transform.scaleX,
-            y: transform.parentOffY + (elem.start.y - transform.childBaseY) * transform.scaleY,
+            ...applyGroupTransformToPoint(elem.start.x, elem.start.y, transform),
           }
         : elem.start;
     const end =
       elem.end.kind === 'free'
         ? {
             kind: 'free' as const,
-            x: transform.parentOffX + (elem.end.x - transform.childBaseX) * transform.scaleX,
-            y: transform.parentOffY + (elem.end.y - transform.childBaseY) * transform.scaleY,
+            ...applyGroupTransformToPoint(elem.end.x, elem.end.y, transform),
           }
         : elem.end;
     return {

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -1,5 +1,7 @@
 import type {
   Element as SlideElement,
+  PlaceholderRef,
+  PlaceholderType,
   ShapeElement,
   ShapeStroke,
   TextElement,
@@ -47,6 +49,12 @@ export interface SlideParseContext {
    * endpoints.
    */
   idMap: Map<number, string>;
+  /**
+   * Default font sizes per layout placeholder, keyed by `"{ooxmlType}:{idx}"`.
+   * Slide-level runs whose `<a:rPr>` lacks an explicit `sz` inherit from
+   * here when the parent shape has a matching `<p:ph>` reference.
+   */
+  placeholderSizes: Map<string, number>;
 }
 
 /**
@@ -218,6 +226,9 @@ function parseSp(sp: Element, ctx: SlideParseContext): SlideElement | undefined 
 
   const txBody = child(sp, 'txBody');
   const elementId = idForSp(sp, ctx);
+  const placeholderInfo = readPlaceholderInfo(nvSpPr);
+  const placeholderRef = placeholderInfo?.ref;
+  const layoutSizeKey = placeholderInfo?.ooxmlKey;
 
   // Effects — only `outerShdw` is reported; for v1 we drop it.
   const effectLst = spPr ? child(spPr, 'effectLst') : undefined;
@@ -228,7 +239,7 @@ function parseSp(sp: Element, ctx: SlideParseContext): SlideElement | undefined 
   // Pure text box — `txBox=1` shapes have no fill/stroke and exist only
   // as a host for `<p:txBody>`. Emit a TextElement.
   if (isTextBox && txBody) {
-    return buildTextElement(elementId, frame, txBody, ctx);
+    return buildTextElement(elementId, frame, txBody, ctx, placeholderRef, layoutSizeKey);
   }
 
   // Shape with a `prstGeom` — emit a ShapeElement; if it also has text,
@@ -241,10 +252,57 @@ function parseSp(sp: Element, ctx: SlideParseContext): SlideElement | undefined 
 
   // No prstGeom but has text — treat as plain text box.
   if (txBody) {
-    return buildTextElement(elementId, frame, txBody, ctx);
+    return buildTextElement(elementId, frame, txBody, ctx, placeholderRef, layoutSizeKey);
   }
 
   return undefined;
+}
+
+/**
+ * OOXML `<p:ph type>` → our `PlaceholderType`. Tokens we don't model
+ * (`ftr`, `sldNum`, `hdr`, `dt`, `pic`, `chart`, `media`, ...) return
+ * `undefined`, leaving the element with no `placeholderRef`.
+ */
+const OOXML_PH_TO_TYPE: Record<string, PlaceholderType> = {
+  title: 'title',
+  ctrTitle: 'title',
+  subTitle: 'subtitle',
+  body: 'body',
+};
+
+/**
+ * Heuristic default font sizes by placeholder role, in points. OOXML
+ * lets the master/layout placeholder style chain set these per-deck —
+ * faithful inheritance is v1.5 work. Until then, these defaults match
+ * Google Slides' built-in template sizes for the common roles so title
+ * runs don't render at the docs renderer's 11 pt fallback.
+ */
+const PLACEHOLDER_DEFAULT_FONT_SIZE: Record<PlaceholderType, number> = {
+  title: 36,
+  subtitle: 24,
+  body: 18,
+  caption: 14,
+  'big-number': 96,
+};
+
+function readPlaceholderInfo(
+  nvSpPr: Element | undefined,
+): { ref: PlaceholderRef | undefined; ooxmlKey: string } | undefined {
+  if (!nvSpPr) return undefined;
+  const nvPr = child(nvSpPr, 'nvPr');
+  if (!nvPr) return undefined;
+  const ph = child(nvPr, 'ph');
+  if (!ph) return undefined;
+  const rawType = attr(ph, 'type') ?? 'body';
+  const idxStr = attr(ph, 'idx') ?? '0';
+  const ooxmlKey = `${rawType}:${idxStr}`;
+  const type = OOXML_PH_TO_TYPE[rawType];
+  let ref: PlaceholderRef | undefined;
+  if (type) {
+    const index = Number(idxStr);
+    ref = { type, index: Number.isFinite(index) ? index : 0 };
+  }
+  return { ref, ooxmlKey };
 }
 
 function idForSp(sp: Element, ctx: SlideParseContext): string {
@@ -261,13 +319,28 @@ function buildTextElement(
   frame: SlideElement['frame'],
   txBody: Element,
   ctx: SlideParseContext,
+  placeholderRef: PlaceholderRef | undefined,
+  layoutSizeKey: string | undefined,
 ): TextElement {
+  // Inheritance order: layout placeholder default (parsed from the
+  // imported deck) → hardcoded per-type fallback for placeholders we
+  // recognise → leave undefined (docs renderer default).
+  const layoutSize = layoutSizeKey ? ctx.placeholderSizes.get(layoutSizeKey) : undefined;
+  const fallbackSize = placeholderRef
+    ? PLACEHOLDER_DEFAULT_FONT_SIZE[placeholderRef.type]
+    : undefined;
+  const defaultFontSize = layoutSize ?? fallbackSize;
   return {
     id,
     type: 'text',
     frame,
+    ...(placeholderRef ? { placeholderRef } : {}),
     data: {
-      blocks: parseTextBody(txBody, { rels: ctx.rels, report: ctx.report }),
+      blocks: parseTextBody(txBody, {
+        rels: ctx.rels,
+        report: ctx.report,
+        defaultFontSize,
+      }),
     },
   };
 }

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -14,9 +14,9 @@ import type {
   ConnectorRouting,
   Endpoint,
 } from '../../model/connector';
-import { parseColorFromContainer } from './color';
+import { parseColorFromContainer, type ClrMap } from './color';
 import type { EmuScale } from './geometry';
-import { parseXfrm, prstToShapeKind } from './geometry';
+import { emuToStrokePx, parseXfrm, prstToShapeKind } from './geometry';
 import {
   applyGroupTransform,
   composeGroupTransform,
@@ -55,6 +55,12 @@ export interface SlideParseContext {
    * here when the parent shape has a matching `<p:ph>` reference.
    */
   placeholderSizes: Map<string, number>;
+  /**
+   * Master-level `<p:clrMap>` — applied when resolving slide-level
+   * `<a:schemeClr>` lookups so logical names like `bg2` route through
+   * the master's translation table.
+   */
+  clrMap: ClrMap;
 }
 
 /**
@@ -163,8 +169,8 @@ async function parseChild(
 ): Promise<SlideElement[] | undefined> {
   switch (el.localName) {
     case 'sp': {
-      const sp = parseSp(el, ctx);
-      return sp ? [sp] : undefined;
+      const sps = parseSp(el, ctx);
+      return sps.length > 0 ? sps : undefined;
     }
     case 'pic': {
       const picCtx: ImageParseContext = {
@@ -215,7 +221,7 @@ function withId(elem: SlideElement, ctx: SlideParseContext, sourceEl: Element): 
   return elem;
 }
 
-function parseSp(sp: Element, ctx: SlideParseContext): SlideElement | undefined {
+function parseSp(sp: Element, ctx: SlideParseContext): SlideElement[] {
   const nvSpPr = child(sp, 'nvSpPr');
   const cNvSpPr = nvSpPr ? child(nvSpPr, 'cNvSpPr') : undefined;
   const isTextBox = cNvSpPr ? attr(cNvSpPr, 'txBox') === '1' : false;
@@ -225,6 +231,7 @@ function parseSp(sp: Element, ctx: SlideParseContext): SlideElement | undefined 
   const frame = parseXfrm(xfrm, ctx.scale);
 
   const txBody = child(sp, 'txBody');
+  const hasText = !!txBody && hasVisibleText(txBody);
   const elementId = idForSp(sp, ctx);
   const placeholderInfo = readPlaceholderInfo(nvSpPr);
   const placeholderRef = placeholderInfo?.ref;
@@ -237,25 +244,51 @@ function parseSp(sp: Element, ctx: SlideParseContext): SlideElement | undefined 
   }
 
   // Pure text box — `txBox=1` shapes have no fill/stroke and exist only
-  // as a host for `<p:txBody>`. Emit a TextElement.
+  // as a host for `<p:txBody>`.
   if (isTextBox && txBody) {
-    return buildTextElement(elementId, frame, txBody, ctx, placeholderRef, layoutSizeKey);
+    return [buildTextElement(elementId, frame, txBody, ctx, placeholderRef, layoutSizeKey)];
   }
 
-  // Shape with a `prstGeom` — emit a ShapeElement; if it also has text,
-  // we layer a TextElement on top (caller will append both — but for v1
-  // we keep one element per source <p:sp> and prefer the shape).
+  // Shape with `prstGeom` — emit the shape, then layer a coincident
+  // TextElement on top when the shape also carries visible text (the
+  // "labelled rect / callout" pattern, ubiquitous in PowerPoint).
   const prstGeom = spPr ? child(spPr, 'prstGeom') : undefined;
   if (prstGeom) {
-    return buildShapeElement(elementId, frame, sp, prstGeom, ctx);
+    const shape = buildShapeElement(elementId, frame, sp, prstGeom, ctx);
+    if (!hasText) return [shape];
+    const text = buildTextElement(
+      generateId(),
+      frame,
+      txBody!,
+      ctx,
+      placeholderRef,
+      layoutSizeKey,
+    );
+    return [shape, text];
   }
 
   // No prstGeom but has text — treat as plain text box.
   if (txBody) {
-    return buildTextElement(elementId, frame, txBody, ctx, placeholderRef, layoutSizeKey);
+    return [buildTextElement(elementId, frame, txBody, ctx, placeholderRef, layoutSizeKey)];
   }
 
-  return undefined;
+  return [];
+}
+
+/**
+ * Returns true when `<p:txBody>` contains at least one non-empty
+ * `<a:t>`. PowerPoint emits empty `<a:p><a:endParaRPr/></a:p>` on every
+ * shape regardless of whether the user typed anything, and we don't
+ * want to layer a blank text element on top of every plain rectangle.
+ */
+function hasVisibleText(txBody: Element): boolean {
+  const ts = txBody.getElementsByTagName('*');
+  for (let i = 0; i < ts.length; i++) {
+    const el = ts[i];
+    if (el.localName !== 't') continue;
+    if ((el.textContent ?? '').length > 0) return true;
+  }
+  return false;
 }
 
 /**
@@ -340,6 +373,7 @@ function buildTextElement(
         rels: ctx.rels,
         report: ctx.report,
         defaultFontSize,
+        clrMap: ctx.clrMap,
       }),
     },
   };
@@ -359,8 +393,8 @@ function buildShapeElement(
   const adjustments = parseAdjustments(prstGeom);
 
   const spPr = child(sp, 'spPr');
-  const fill = parseShapeFill(spPr);
-  const stroke = parseShapeStroke(spPr);
+  const fill = parseShapeFill(spPr, ctx);
+  const stroke = parseShapeStroke(spPr, ctx);
 
   return {
     id,
@@ -391,23 +425,31 @@ function parseAdjustments(prstGeom: Element): number[] | undefined {
   return out.length ? out : undefined;
 }
 
-function parseShapeFill(spPr: Element | undefined): ShapeElement['data']['fill'] {
+function parseShapeFill(
+  spPr: Element | undefined,
+  ctx: SlideParseContext,
+): ShapeElement['data']['fill'] {
   if (!spPr) return undefined;
   const solid = child(spPr, 'solidFill');
-  if (solid) return parseColorFromContainer(solid);
+  if (solid) return parseColorFromContainer(solid, ctx.clrMap);
   // gradient, pattern, blip-fill on shape — out of v1 scope.
   return undefined;
 }
 
-function parseShapeStroke(spPr: Element | undefined): ShapeStroke | undefined {
+function parseShapeStroke(
+  spPr: Element | undefined,
+  ctx: SlideParseContext,
+): ShapeStroke | undefined {
   if (!spPr) return undefined;
   const ln = child(spPr, 'ln');
   if (!ln) return undefined;
-  // `<a:ln w>` is in EMU (9525 EMU = 1 px at 96 dpi).
+  // `<a:ln w>` is in EMU. Scale with the deck rather than a fixed
+  // 96 dpi so strokes stay proportional to scaled frame coordinates
+  // for both standard 16:9 (10″×5.625″) and widescreen decks.
   const w = attrInt(ln, 'w');
-  const width = w != null ? Math.max(0, w / 9525) : 1;
+  const width = w != null ? emuToStrokePx(w, ctx.scale) : 1;
   const solid = child(ln, 'solidFill');
-  const color = solid ? parseColorFromContainer(solid) : undefined;
+  const color = solid ? parseColorFromContainer(solid, ctx.clrMap) : undefined;
   if (!color) return undefined;
   return { color, width };
 }
@@ -417,6 +459,8 @@ function parseCxnSp(cxn: Element, ctx: SlideParseContext): ConnectorElement | un
   const spPr = child(cxn, 'spPr');
   const xfrm = spPr ? child(spPr, 'xfrm') : undefined;
   const frame = parseXfrm(xfrm, ctx.scale);
+  const flipH = xfrm ? attr(xfrm, 'flipH') === '1' : false;
+  const flipV = xfrm ? attr(xfrm, 'flipV') === '1' : false;
 
   const prstGeom = spPr ? child(spPr, 'prstGeom') : undefined;
   const prst = prstGeom ? attr(prstGeom, 'prst') ?? '' : '';
@@ -431,11 +475,11 @@ function parseCxnSp(cxn: Element, ctx: SlideParseContext): ConnectorElement | un
   const stCxn = cNvCxnSpPr ? child(cNvCxnSpPr, 'stCxn') : undefined;
   const endCxn = cNvCxnSpPr ? child(cNvCxnSpPr, 'endCxn') : undefined;
 
-  const start = resolveEndpoint(stCxn, frame, 'start', ctx);
-  const end = resolveEndpoint(endCxn, frame, 'end', ctx);
+  const start = resolveEndpoint(stCxn, frame, 'start', ctx, flipH, flipV);
+  const end = resolveEndpoint(endCxn, frame, 'end', ctx, flipH, flipV);
 
   const ln = spPr ? child(spPr, 'ln') : undefined;
-  const stroke = parseShapeStroke(spPr);
+  const stroke = parseShapeStroke(spPr, ctx);
   const arrowheads = ln
     ? {
         start: parseArrowhead(child(ln, 'headEnd')),
@@ -460,6 +504,8 @@ function resolveEndpoint(
   frame: SlideElement['frame'],
   which: 'start' | 'end',
   ctx: SlideParseContext,
+  flipH: boolean,
+  flipV: boolean,
 ): Endpoint {
   if (cxn) {
     const idAttr = attrInt(cxn, 'id');
@@ -471,9 +517,14 @@ function resolveEndpoint(
       }
     }
   }
-  // Fall back to absolute frame corners. `frame` is already in px.
-  const x = which === 'start' ? frame.x : frame.x + frame.w;
-  const y = which === 'start' ? frame.y : frame.y + frame.h;
+  // Fall back to absolute frame corners. The default `straightConnector1`
+  // routes (x,y) → (x+w, y+h). `flipH`/`flipV` swap the active corner
+  // on each axis independently — e.g. a `flipH` connector starts at
+  // top-right and ends at bottom-left.
+  const startHorizontal = (which === 'start') !== flipH;
+  const startVertical = (which === 'start') !== flipV;
+  const x = startHorizontal ? frame.x : frame.x + frame.w;
+  const y = startVertical ? frame.y : frame.y + frame.h;
   return { kind: 'free', x, y };
 }
 

--- a/packages/slides/src/import/pptx/slide.ts
+++ b/packages/slides/src/import/pptx/slide.ts
@@ -1,6 +1,7 @@
 import type { Block } from '@wafflebase/docs';
 import type { Background, Slide } from '../../model/presentation';
 import { DEFAULT_BACKGROUND } from '../../model/presentation';
+import { clone } from '../../model/clone';
 import { parseColorFromContainer, type ClrMap } from './color';
 import { type EmuScale } from './geometry';
 import { parseRels, resolveRelsTarget, type PptxRel } from './rels';
@@ -9,7 +10,7 @@ import { parseSpTree, type SlideParseContext } from './shape';
 import { parseTextBody } from './text';
 import type { PptxArchive } from './unzip';
 import type { UploadImage } from './index';
-import { child, descendant, parseXml } from './xml';
+import { attr, child, descendant, parseXml } from './xml';
 
 /** Per-layout resolution data: built-in id + placeholder default sizes. */
 export interface LayoutResolution {
@@ -56,7 +57,7 @@ export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undef
   const bgEl = cSld ? child(cSld, 'bg') : undefined;
   const background = bgEl
     ? parseSlideBackground(bgEl, opts.clrMap)
-    : { ...DEFAULT_BACKGROUND };
+    : clone(DEFAULT_BACKGROUND);
 
   const spTree = cSld ? child(cSld, 'spTree') : undefined;
   const ctx: SlideParseContext = {
@@ -106,7 +107,7 @@ function parseSlideBackground(bgEl: Element, clrMap: ClrMap): Background {
       if (color) return { fill: color };
     }
   }
-  return { ...DEFAULT_BACKGROUND };
+  return clone(DEFAULT_BACKGROUND);
 }
 
 async function parseNotes(
@@ -129,13 +130,18 @@ async function parseNotes(
   if (!notesXml) return [];
 
   const notesDoc = parseXml(notesXml);
-  // `<p:notes><p:cSld><p:spTree>` holds the notes placeholders; we read
-  // the body placeholder's <p:txBody>.
+  // `<p:notes><p:cSld><p:spTree>` holds the notes placeholders. A
+  // notes slide typically contains several shapes — slide image,
+  // body placeholder, slide number, header/footer/date — and only
+  // `<p:ph type="body">` carries the speaker notes content.
   const spTree = descendant(notesDoc, 'spTree');
   if (!spTree) return [];
 
-  // Find the first `<p:sp>` whose `<p:nvSpPr><p:nvPr><p:ph type="body">`.
-  // For v1 we take the largest text body content from the notes spTree.
+  // First pass: look for the body placeholder specifically (PowerPoint
+  // emits `<p:ph type="body">` for the notes text host).
+  let bodyTxBody: Element | undefined;
+  let fallbackTxBody: Element | undefined;
+  let fallbackLength = 0;
   for (let i = 0; i < spTree.childNodes.length; i++) {
     const n = spTree.childNodes[i];
     if (n.nodeType !== 1) continue;
@@ -143,9 +149,29 @@ async function parseNotes(
     if (el.localName !== 'sp') continue;
     const txBody = child(el, 'txBody');
     if (!txBody) continue;
-    return parseTextBody(txBody, { report });
+
+    const nvSpPr = child(el, 'nvSpPr');
+    const nvPr = nvSpPr ? child(nvSpPr, 'nvPr') : undefined;
+    const ph = nvPr ? child(nvPr, 'ph') : undefined;
+    const phType = ph ? attr(ph, 'type') : undefined;
+    if (phType === 'body') {
+      bodyTxBody = txBody;
+      break;
+    }
+    // Track the longest non-placeholder txBody as a fallback in case
+    // the deck omits the body placeholder type entirely.
+    if (!ph || (phType !== 'sldNum' && phType !== 'hdr' && phType !== 'dt')) {
+      const len = (txBody.textContent ?? '').length;
+      if (len > fallbackLength) {
+        fallbackTxBody = txBody;
+        fallbackLength = len;
+      }
+    }
   }
-  return [];
+
+  const chosen = bodyTxBody ?? fallbackTxBody;
+  if (!chosen) return [];
+  return parseTextBody(chosen, { report });
 }
 
 function relsSiblingFor(partPath: string): string {

--- a/packages/slides/src/import/pptx/slide.ts
+++ b/packages/slides/src/import/pptx/slide.ts
@@ -1,7 +1,7 @@
 import type { Block } from '@wafflebase/docs';
 import type { Background, Slide } from '../../model/presentation';
 import { DEFAULT_BACKGROUND } from '../../model/presentation';
-import { parseColorFromContainer } from './color';
+import { parseColorFromContainer, type ClrMap } from './color';
 import { type EmuScale } from './geometry';
 import { parseRels, resolveRelsTarget, type PptxRel } from './rels';
 import { ImportReport } from './report';
@@ -30,6 +30,8 @@ export interface ParseSlideOptions {
   uploadImage?: UploadImage;
   scale: EmuScale;
   report: ImportReport;
+  /** Master-level color map; identity for decks without `<p:clrMap>`. */
+  clrMap: ClrMap;
 }
 
 export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undefined> {
@@ -52,7 +54,9 @@ export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undef
   // from the master. v1 records an override only when present.
   const cSld = child(slideEl, 'cSld');
   const bgEl = cSld ? child(cSld, 'bg') : undefined;
-  const background = bgEl ? parseSlideBackground(bgEl) : { ...DEFAULT_BACKGROUND };
+  const background = bgEl
+    ? parseSlideBackground(bgEl, opts.clrMap)
+    : { ...DEFAULT_BACKGROUND };
 
   const spTree = cSld ? child(cSld, 'spTree') : undefined;
   const ctx: SlideParseContext = {
@@ -64,6 +68,7 @@ export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undef
     report: opts.report,
     idMap: new Map(),
     placeholderSizes,
+    clrMap: opts.clrMap,
   };
   const elements = spTree ? await parseSpTree(spTree, ctx) : [];
 
@@ -92,12 +97,12 @@ function pickLayoutInfo(
   return undefined;
 }
 
-function parseSlideBackground(bgEl: Element): Background {
+function parseSlideBackground(bgEl: Element, clrMap: ClrMap): Background {
   const bgPr = child(bgEl, 'bgPr');
   if (bgPr) {
     const solid = child(bgPr, 'solidFill');
     if (solid) {
-      const color = parseColorFromContainer(solid);
+      const color = parseColorFromContainer(solid, clrMap);
       if (color) return { fill: color };
     }
   }

--- a/packages/slides/src/import/pptx/slide.ts
+++ b/packages/slides/src/import/pptx/slide.ts
@@ -1,0 +1,141 @@
+import type { Block } from '@wafflebase/docs';
+import type { Background, Slide } from '../../model/presentation';
+import { DEFAULT_BACKGROUND } from '../../model/presentation';
+import { parseColorFromContainer } from './color';
+import { type EmuScale } from './geometry';
+import { parseRels, resolveRelsTarget, type PptxRel } from './rels';
+import { ImportReport } from './report';
+import { parseSpTree, type SlideParseContext } from './shape';
+import { parseTextBody } from './text';
+import type { PptxArchive } from './unzip';
+import type { UploadImage } from './index';
+import { child, descendant, parseXml } from './xml';
+
+/** Maps from imported OOXML layout part path → the built-in layout id we chose. */
+export type LayoutPathToId = Map<string, string>;
+
+export interface ParseSlideOptions {
+  archive: PptxArchive;
+  /** e.g. `'ppt/slides/slide1.xml'` */
+  partPath: string;
+  /** Pre-built mapping for resolving each slide's layout rel to a built-in layout id. */
+  layoutMap: LayoutPathToId;
+  uploadImage?: UploadImage;
+  scale: EmuScale;
+  report: ImportReport;
+}
+
+export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undefined> {
+  const xml = await opts.archive.readText(opts.partPath);
+  if (!xml) return undefined;
+  const doc = parseXml(xml);
+  const slideEl = descendant(doc, 'sld');
+  if (!slideEl) return undefined;
+
+  const relsPath = relsSiblingFor(opts.partPath);
+  const relsXml = await opts.archive.readText(relsPath);
+  const rels = relsXml ? parseRels(relsXml) : new Map<string, PptxRel>();
+
+  // Resolve the layout — slide picks its layout via `slideLayout` rel.
+  const layoutId = pickLayoutId(rels, opts.partPath, opts.layoutMap) ?? 'title-body';
+
+  // Background may be on the slide's `<p:cSld>` (override) or inherited
+  // from the master. v1 records an override only when present.
+  const cSld = child(slideEl, 'cSld');
+  const bgEl = cSld ? child(cSld, 'bg') : undefined;
+  const background = bgEl ? parseSlideBackground(bgEl) : { ...DEFAULT_BACKGROUND };
+
+  const spTree = cSld ? child(cSld, 'spTree') : undefined;
+  const ctx: SlideParseContext = {
+    archive: opts.archive,
+    slidePartPath: opts.partPath,
+    rels,
+    uploadImage: opts.uploadImage,
+    scale: opts.scale,
+    report: opts.report,
+    idMap: new Map(),
+  };
+  const elements = spTree ? await parseSpTree(spTree, ctx) : [];
+
+  const notes = await parseNotes(opts.archive, opts.partPath, rels, opts.report);
+
+  return {
+    id: opts.partPath, // stable id keyed on source part path
+    layoutId,
+    background,
+    elements,
+    notes,
+  };
+}
+
+function pickLayoutId(
+  rels: Map<string, PptxRel>,
+  slidePart: string,
+  layoutMap: LayoutPathToId,
+): string | undefined {
+  for (const rel of rels.values()) {
+    if (rel.type !== 'slideLayout') continue;
+    const path = resolveRelsTarget(slidePart, rel.target);
+    const mapped = layoutMap.get(path);
+    if (mapped) return mapped;
+  }
+  return undefined;
+}
+
+function parseSlideBackground(bgEl: Element): Background {
+  const bgPr = child(bgEl, 'bgPr');
+  if (bgPr) {
+    const solid = child(bgPr, 'solidFill');
+    if (solid) {
+      const color = parseColorFromContainer(solid);
+      if (color) return { fill: color };
+    }
+  }
+  return { ...DEFAULT_BACKGROUND };
+}
+
+async function parseNotes(
+  archive: PptxArchive,
+  slidePart: string,
+  rels: Map<string, PptxRel>,
+  report: ImportReport,
+): Promise<Block[]> {
+  let notesTarget: string | undefined;
+  for (const rel of rels.values()) {
+    if (rel.type === 'notesSlide') {
+      notesTarget = rel.target;
+      break;
+    }
+  }
+  if (!notesTarget) return [];
+
+  const notesPath = resolveRelsTarget(slidePart, notesTarget);
+  const notesXml = await archive.readText(notesPath);
+  if (!notesXml) return [];
+
+  const notesDoc = parseXml(notesXml);
+  // `<p:notes><p:cSld><p:spTree>` holds the notes placeholders; we read
+  // the body placeholder's <p:txBody>.
+  const spTree = descendant(notesDoc, 'spTree');
+  if (!spTree) return [];
+
+  // Find the first `<p:sp>` whose `<p:nvSpPr><p:nvPr><p:ph type="body">`.
+  // For v1 we take the largest text body content from the notes spTree.
+  for (let i = 0; i < spTree.childNodes.length; i++) {
+    const n = spTree.childNodes[i];
+    if (n.nodeType !== 1) continue;
+    const el = n as Element;
+    if (el.localName !== 'sp') continue;
+    const txBody = child(el, 'txBody');
+    if (!txBody) continue;
+    return parseTextBody(txBody, { report });
+  }
+  return [];
+}
+
+function relsSiblingFor(partPath: string): string {
+  const slash = partPath.lastIndexOf('/');
+  const dir = slash >= 0 ? partPath.slice(0, slash) : '';
+  const file = slash >= 0 ? partPath.slice(slash + 1) : partPath;
+  return (dir ? dir + '/' : '') + '_rels/' + file + '.rels';
+}

--- a/packages/slides/src/import/pptx/slide.ts
+++ b/packages/slides/src/import/pptx/slide.ts
@@ -11,15 +11,22 @@ import type { PptxArchive } from './unzip';
 import type { UploadImage } from './index';
 import { child, descendant, parseXml } from './xml';
 
-/** Maps from imported OOXML layout part path → the built-in layout id we chose. */
-export type LayoutPathToId = Map<string, string>;
+/** Per-layout resolution data: built-in id + placeholder default sizes. */
+export interface LayoutResolution {
+  builtInId: string;
+  /** Map of `"{ooxmlType}:{idx}"` → default fontSize in points. */
+  placeholderSizes: Map<string, number>;
+}
+
+/** Maps from imported OOXML layout part path → resolution data. */
+export type LayoutPathToInfo = Map<string, LayoutResolution>;
 
 export interface ParseSlideOptions {
   archive: PptxArchive;
   /** e.g. `'ppt/slides/slide1.xml'` */
   partPath: string;
   /** Pre-built mapping for resolving each slide's layout rel to a built-in layout id. */
-  layoutMap: LayoutPathToId;
+  layoutMap: LayoutPathToInfo;
   uploadImage?: UploadImage;
   scale: EmuScale;
   report: ImportReport;
@@ -37,7 +44,9 @@ export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undef
   const rels = relsXml ? parseRels(relsXml) : new Map<string, PptxRel>();
 
   // Resolve the layout — slide picks its layout via `slideLayout` rel.
-  const layoutId = pickLayoutId(rels, opts.partPath, opts.layoutMap) ?? 'title-body';
+  const layoutInfo = pickLayoutInfo(rels, opts.partPath, opts.layoutMap);
+  const layoutId = layoutInfo?.builtInId ?? 'title-body';
+  const placeholderSizes = layoutInfo?.placeholderSizes ?? new Map<string, number>();
 
   // Background may be on the slide's `<p:cSld>` (override) or inherited
   // from the master. v1 records an override only when present.
@@ -54,6 +63,7 @@ export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undef
     scale: opts.scale,
     report: opts.report,
     idMap: new Map(),
+    placeholderSizes,
   };
   const elements = spTree ? await parseSpTree(spTree, ctx) : [];
 
@@ -68,11 +78,11 @@ export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undef
   };
 }
 
-function pickLayoutId(
+function pickLayoutInfo(
   rels: Map<string, PptxRel>,
   slidePart: string,
-  layoutMap: LayoutPathToId,
-): string | undefined {
+  layoutMap: LayoutPathToInfo,
+): LayoutResolution | undefined {
   for (const rel of rels.values()) {
     if (rel.type !== 'slideLayout') continue;
     const path = resolveRelsTarget(slidePart, rel.target);

--- a/packages/slides/src/import/pptx/table.test.ts
+++ b/packages/slides/src/import/pptx/table.test.ts
@@ -24,6 +24,7 @@ function ctx(report = new ImportReport()): SlideParseContext {
     report,
     idMap: new Map(),
     placeholderSizes: new Map(),
+    clrMap: new Map(),
   };
 }
 
@@ -87,6 +88,9 @@ describe('parseTable', () => {
     </p:graphicFrame>`;
     const report = new ImportReport();
     parseTable(frame(xml), ctx(report));
-    expect(report.tableMergesIgnored).toBe(2); // one gridSpan + one hMerge
+    // gridSpan=2 on the owning cell counts once; the cell it covers is
+    // skipped via column-index advance, so the matching `hMerge=1`
+    // placeholder is no longer double-counted.
+    expect(report.tableMergesIgnored).toBe(1);
   });
 });

--- a/packages/slides/src/import/pptx/table.test.ts
+++ b/packages/slides/src/import/pptx/table.test.ts
@@ -23,6 +23,7 @@ function ctx(report = new ImportReport()): SlideParseContext {
     scale: SCALE,
     report,
     idMap: new Map(),
+    placeholderSizes: new Map(),
   };
 }
 

--- a/packages/slides/src/import/pptx/table.test.ts
+++ b/packages/slides/src/import/pptx/table.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseTable } from './table';
+import { ImportReport } from './report';
+import { DEFAULT_WIDESCREEN_EMU, emuScale } from './geometry';
+import { parseXml } from './xml';
+import type { SlideParseContext } from './shape';
+import type { ShapeElement, TextElement } from '../../model/element';
+
+const SCALE = emuScale(DEFAULT_WIDESCREEN_EMU);
+
+function frame(xml: string): Element {
+  return parseXml(
+    `<root xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">${xml}</root>`,
+  ).documentElement.firstElementChild!;
+}
+
+function ctx(report = new ImportReport()): SlideParseContext {
+  return {
+    archive: { readText: async () => undefined, readBytes: async () => undefined, list: () => [] },
+    slidePartPath: 'ppt/slides/slide1.xml',
+    rels: new Map(),
+    scale: SCALE,
+    report,
+    idMap: new Map(),
+  };
+}
+
+const SMALL_TABLE = `<p:graphicFrame>
+  <p:xfrm><a:off x="1000000" y="2000000"/><a:ext cx="3000000" cy="2000000"/></p:xfrm>
+  <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
+    <a:tbl>
+      <a:tblGrid>
+        <a:gridCol w="1000000"/><a:gridCol w="2000000"/>
+      </a:tblGrid>
+      <a:tr h="1000000">
+        <a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:t>A1</a:t></a:r></a:p></a:txBody>
+              <a:tcPr><a:lnL w="9525"><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:lnL></a:tcPr></a:tc>
+        <a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:t>B1</a:t></a:r></a:p></a:txBody></a:tc>
+      </a:tr>
+      <a:tr h="1000000">
+        <a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:t>A2</a:t></a:r></a:p></a:txBody></a:tc>
+        <a:tc><a:txBody><a:bodyPr/><a:p><a:r><a:t>B2</a:t></a:r></a:p></a:txBody></a:tc>
+      </a:tr>
+    </a:tbl>
+  </a:graphicData></a:graphic>
+</p:graphicFrame>`;
+
+describe('parseTable', () => {
+  it('flattens a 2×2 table into cell text + a border on at least one cell', () => {
+    const report = new ImportReport();
+    const out = parseTable(frame(SMALL_TABLE), ctx(report));
+    const texts = out.filter((e) => e.type === 'text') as TextElement[];
+    const borders = out.filter((e) => e.type === 'shape') as ShapeElement[];
+    expect(texts).toHaveLength(4);
+    expect(texts.map((t) => t.data.blocks[0].inlines[0].text)).toEqual(['A1', 'B1', 'A2', 'B2']);
+    expect(borders.length).toBeGreaterThanOrEqual(1);
+    expect(report.tablesFlattened).toBe(1);
+    expect(report.tableBordersApproximated).toBeGreaterThanOrEqual(1);
+  });
+
+  it('positions cells using cumulative col/row widths from the grid', () => {
+    const out = parseTable(frame(SMALL_TABLE), ctx());
+    const texts = out.filter((e) => e.type === 'text') as TextElement[];
+    // A1 at top-left of the table.
+    expect(texts[0].frame.x).toBeCloseTo(1_000_000 * SCALE.sx, 6);
+    expect(texts[0].frame.y).toBeCloseTo(2_000_000 * SCALE.sy, 6);
+    // B1 to the right by 1000000 EMU.
+    expect(texts[1].frame.x).toBeCloseTo(2_000_000 * SCALE.sx, 6);
+    // A2 below row 1.
+    expect(texts[2].frame.y).toBeCloseTo(3_000_000 * SCALE.sy, 6);
+  });
+
+  it('counts merges via gridSpan/rowSpan/vMerge', () => {
+    const xml = `<p:graphicFrame>
+      <p:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="2000000"/></p:xfrm>
+      <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
+        <a:tbl>
+          <a:tblGrid><a:gridCol w="1000000"/><a:gridCol w="1000000"/></a:tblGrid>
+          <a:tr h="1000000">
+            <a:tc gridSpan="2"><a:txBody><a:bodyPr/><a:p><a:r><a:t>spans</a:t></a:r></a:p></a:txBody></a:tc>
+            <a:tc hMerge="1"><a:txBody><a:bodyPr/><a:p/></a:txBody></a:tc>
+          </a:tr>
+        </a:tbl>
+      </a:graphicData></a:graphic>
+    </p:graphicFrame>`;
+    const report = new ImportReport();
+    parseTable(frame(xml), ctx(report));
+    expect(report.tableMergesIgnored).toBe(2); // one gridSpan + one hMerge
+  });
+});

--- a/packages/slides/src/import/pptx/table.ts
+++ b/packages/slides/src/import/pptx/table.ts
@@ -1,0 +1,130 @@
+import type { Element as SlideElement, Frame, ShapeElement, TextElement } from '../../model/element';
+import { generateId } from '../../model/element';
+import { parseColorFromContainer } from './color';
+import { parseXfrm } from './geometry';
+import type { SlideParseContext } from './shape';
+import { parseTextBody } from './text';
+import { attr, attrInt, child, children, descendant } from './xml';
+
+/**
+ * Flatten `<p:graphicFrame><a:tbl>` into a matrix of TextElements (one
+ * per cell) overlaid on a borderless rect per cell to carry the cell's
+ * stroke. Cells with `<a:gridSpan>` / `<a:rowSpan>` are reported but
+ * not specially merged in v1 — the benchmark deck has zero merges, and
+ * a true merge requires `colSpan/rowSpan` semantics that our generic
+ * shape rect can't express. Merge placeholders (`<a:hMerge>` /
+ * `<a:vMerge>`) are simply dropped.
+ *
+ * Returns an array of slide elements in painting order:
+ *   - first: cell border rect (so text paints on top)
+ *   - then: cell text body
+ */
+export function parseTable(
+  graphicFrame: Element,
+  ctx: SlideParseContext,
+): SlideElement[] {
+  const xfrm = child(graphicFrame, 'xfrm');
+  const tableFrame = parseXfrm(xfrm, ctx.scale);
+
+  const tbl = descendant(graphicFrame, 'tbl');
+  if (!tbl) return [];
+
+  const gridCols = children(child(tbl, 'tblGrid') ?? tbl, 'gridCol');
+  const colWidthsPx = gridCols.map((g) => (attrInt(g, 'w') ?? 0) * ctx.scale.sx);
+
+  const rows = children(tbl, 'tr');
+  const rowHeightsPx = rows.map((r) => (attrInt(r, 'h') ?? 0) * ctx.scale.sy);
+
+  const out: SlideElement[] = [];
+
+  let y = tableFrame.y;
+  for (let r = 0; r < rows.length; r++) {
+    const rowEl = rows[r];
+    const rowHeight = rowHeightsPx[r] || 0;
+    let x = tableFrame.x;
+    const cells = children(rowEl, 'tc');
+    for (let c = 0; c < cells.length; c++) {
+      const cell = cells[c];
+      const colWidth = colWidthsPx[c] || 0;
+
+      // Track merge artifacts; we don't honor them but counting tells
+      // the user when a deck would benefit from real table support.
+      if (attr(cell, 'hMerge') || attr(cell, 'vMerge')) {
+        ctx.report.tableMergesIgnored += 1;
+        x += colWidth;
+        continue;
+      }
+      const colSpan = attrInt(cell, 'gridSpan');
+      const rowSpan = attrInt(cell, 'rowSpan');
+      if ((colSpan && colSpan > 1) || (rowSpan && rowSpan > 1)) {
+        ctx.report.tableMergesIgnored += 1;
+      }
+
+      const cellFrame: Frame = {
+        x,
+        y,
+        w: colWidth * (colSpan ?? 1),
+        h: rowHeight * (rowSpan ?? 1),
+        rotation: 0,
+      };
+
+      const border = buildCellBorder(cellFrame, cell, ctx);
+      if (border) out.push(border);
+
+      const txBody = child(cell, 'txBody');
+      if (txBody) {
+        const txt: TextElement = {
+          id: generateId(),
+          type: 'text',
+          frame: cellFrame,
+          data: { blocks: parseTextBody(txBody, { rels: ctx.rels, report: ctx.report }) },
+        };
+        out.push(txt);
+      }
+
+      x += colWidth;
+    }
+    y += rowHeight;
+  }
+
+  ctx.report.tablesFlattened += 1;
+  return out;
+}
+
+/**
+ * Synthesise a single transparent rect with the dominant cell border as
+ * its stroke. PPTX cells expose four separate borders (`lnL`/`lnR`/
+ * `lnT`/`lnB`), but our `ShapeStroke` is uniform per element. Pick the
+ * first border with a real color and report the approximation.
+ */
+function buildCellBorder(
+  frame: Frame,
+  cell: Element,
+  ctx: SlideParseContext,
+): ShapeElement | undefined {
+  const tcPr = child(cell, 'tcPr');
+  if (!tcPr) return undefined;
+  for (const tag of ['lnL', 'lnR', 'lnT', 'lnB'] as const) {
+    const ln = child(tcPr, tag);
+    if (!ln) continue;
+    const solid = child(ln, 'solidFill');
+    if (!solid) continue;
+    const color = parseColorFromContainer(solid);
+    if (!color) continue;
+    // EMU width → px width (~9525 EMU = 1 px at 96 dpi).
+    const wEmu = attrInt(ln, 'w');
+    const width = wEmu != null ? Math.max(0, wEmu / 9525) : 1;
+    // Bump approximation counter once per cell, not per border.
+    ctx.report.tableBordersApproximated += 1;
+    return {
+      id: generateId(),
+      type: 'shape',
+      frame,
+      data: {
+        kind: 'rect',
+        stroke: { color, width },
+      },
+    };
+  }
+  return undefined;
+}

--- a/packages/slides/src/import/pptx/table.ts
+++ b/packages/slides/src/import/pptx/table.ts
@@ -1,7 +1,7 @@
 import type { Element as SlideElement, Frame, ShapeElement, TextElement } from '../../model/element';
 import { generateId } from '../../model/element';
 import { parseColorFromContainer } from './color';
-import { parseXfrm } from './geometry';
+import { emuToStrokePx, parseXfrm } from './geometry';
 import type { SlideParseContext } from './shape';
 import { parseTextBody } from './text';
 import { attr, attrInt, child, children, descendant } from './xml';
@@ -77,12 +77,25 @@ export function parseTable(
           id: generateId(),
           type: 'text',
           frame: cellFrame,
-          data: { blocks: parseTextBody(txBody, { rels: ctx.rels, report: ctx.report }) },
+          data: {
+            blocks: parseTextBody(txBody, {
+              rels: ctx.rels,
+              report: ctx.report,
+              clrMap: ctx.clrMap,
+            }),
+          },
         };
         out.push(txt);
       }
 
-      x += colWidth;
+      // Advance by the effective horizontal span so the next `<a:tc>`
+      // (typically a column-merge placeholder) lands at the right
+      // column index even if PPTX omits the corresponding `hMerge`.
+      const span = colSpan && colSpan > 1 ? colSpan : 1;
+      let stepW = 0;
+      for (let s = 0; s < span; s++) stepW += colWidthsPx[c + s] || 0;
+      x += stepW;
+      c += span - 1;
     }
     y += rowHeight;
   }
@@ -109,11 +122,12 @@ function buildCellBorder(
     if (!ln) continue;
     const solid = child(ln, 'solidFill');
     if (!solid) continue;
-    const color = parseColorFromContainer(solid);
+    const color = parseColorFromContainer(solid, ctx.clrMap);
     if (!color) continue;
-    // EMU width → px width (~9525 EMU = 1 px at 96 dpi).
+    // Scale EMU stroke width with the deck so cell borders stay
+    // proportional to the rendered cell rect.
     const wEmu = attrInt(ln, 'w');
-    const width = wEmu != null ? Math.max(0, wEmu / 9525) : 1;
+    const width = wEmu != null ? emuToStrokePx(wEmu, ctx.scale) : 1;
     // Bump approximation counter once per cell, not per border.
     ctx.report.tableBordersApproximated += 1;
     return {

--- a/packages/slides/src/import/pptx/text.test.ts
+++ b/packages/slides/src/import/pptx/text.test.ts
@@ -55,6 +55,27 @@ describe('parseTextBody — runs', () => {
     expect(inline.style.href).toBe('https://yorkie.dev/');
   });
 
+  it('drops unsafe schemes and internal-slide rels', () => {
+    const xssTxt = txBody(`<a:txBody><a:bodyPr/><a:p><a:r>
+      <a:rPr><a:hlinkClick xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rId1"/></a:rPr>
+      <a:t>click</a:t>
+    </a:r></a:p></a:txBody>`);
+    const internalTxt = txBody(`<a:txBody><a:bodyPr/><a:p><a:r>
+      <a:rPr><a:hlinkClick xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rId2"/></a:rPr>
+      <a:t>jump</a:t>
+    </a:r></a:p></a:txBody>`);
+    const rels = new Map<string, PptxRel>([
+      ['rId1', { type: 'hyperlink', target: 'javascript:alert(1)', external: true }],
+      ['rId2', { type: 'slide', target: 'slide3.xml', external: false }],
+    ]);
+    expect(
+      parseTextBody(xssTxt, { rels, report: new ImportReport() })[0].inlines[0].style.href,
+    ).toBeUndefined();
+    expect(
+      parseTextBody(internalTxt, { rels, report: new ImportReport() })[0].inlines[0].style.href,
+    ).toBeUndefined();
+  });
+
   it('falls back to Noto Sans KR when typeface is missing but Hangul is present', () => {
     const t = txBody(`<a:txBody><a:bodyPr/><a:p><a:r><a:t>안녕</a:t></a:r></a:p></a:txBody>`);
     const inline = parseTextBody(t, { report: new ImportReport() })[0].inlines[0];

--- a/packages/slides/src/import/pptx/text.test.ts
+++ b/packages/slides/src/import/pptx/text.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseTextBody } from './text';
+import { ImportReport } from './report';
+import { parseXml } from './xml';
+import type { PptxRel } from './rels';
+
+function txBody(xml: string): Element {
+  return parseXml(
+    `<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">${xml}</root>`,
+  ).documentElement.firstElementChild!;
+}
+
+describe('parseTextBody — runs', () => {
+  it('captures bold, underline, font size, font family, color', () => {
+    const t = txBody(`<a:txBody>
+      <a:bodyPr/>
+      <a:p>
+        <a:r>
+          <a:rPr b="1" u="sng" sz="1800"><a:latin typeface="Roboto"/><a:solidFill><a:srgbClr val="FF9900"/></a:solidFill></a:rPr>
+          <a:t>Hi</a:t>
+        </a:r>
+      </a:p>
+    </a:txBody>`);
+    const ctx = { report: new ImportReport() };
+    const blocks = parseTextBody(t, ctx);
+    expect(blocks).toHaveLength(1);
+    const inline = blocks[0].inlines[0];
+    expect(inline.text).toBe('Hi');
+    expect(inline.style.bold).toBe(true);
+    expect(inline.style.underline).toBe(true);
+    expect(inline.style.fontSize).toBe(18);
+    expect(inline.style.fontFamily).toBe('Roboto');
+    expect(inline.style.color).toEqual({ kind: 'srgb', value: '#FF9900' });
+  });
+
+  it('captures <a:highlight> as backgroundColor', () => {
+    const t = txBody(`<a:txBody>
+      <a:bodyPr/>
+      <a:p><a:r><a:rPr sz="800"><a:highlight><a:schemeClr val="lt1"/></a:highlight></a:rPr><a:t>marker</a:t></a:r></a:p>
+    </a:txBody>`);
+    const inline = parseTextBody(t, { report: new ImportReport() })[0].inlines[0];
+    expect(inline.style.backgroundColor).toEqual({ kind: 'role', role: 'background' });
+  });
+
+  it('resolves hyperlink rids via the per-slide rels map', () => {
+    const rels = new Map<string, PptxRel>([
+      ['rId7', { type: 'hyperlink', target: 'https://yorkie.dev/', external: true }],
+    ]);
+    const t = txBody(`<a:txBody>
+      <a:bodyPr/>
+      <a:p><a:r><a:rPr><a:hlinkClick xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rId7"/></a:rPr><a:t>yorkie</a:t></a:r></a:p>
+    </a:txBody>`);
+    const inline = parseTextBody(t, { rels, report: new ImportReport() })[0].inlines[0];
+    expect(inline.style.href).toBe('https://yorkie.dev/');
+  });
+
+  it('falls back to Noto Sans KR when typeface is missing but Hangul is present', () => {
+    const t = txBody(`<a:txBody><a:bodyPr/><a:p><a:r><a:t>안녕</a:t></a:r></a:p></a:txBody>`);
+    const inline = parseTextBody(t, { report: new ImportReport() })[0].inlines[0];
+    expect(inline.style.fontFamily).toBe('Noto Sans KR');
+  });
+
+  it('does not override an explicit Korean-capable typeface', () => {
+    const t = txBody(`<a:txBody><a:bodyPr/><a:p><a:r><a:rPr><a:latin typeface="Nanum Gothic"/></a:rPr><a:t>안녕</a:t></a:r></a:p></a:txBody>`);
+    const inline = parseTextBody(t, { report: new ImportReport() })[0].inlines[0];
+    expect(inline.style.fontFamily).toBe('Nanum Gothic');
+  });
+});
+
+describe('parseTextBody — paragraphs', () => {
+  it('captures alignment + line spacing + indent', () => {
+    const t = txBody(`<a:txBody>
+      <a:bodyPr/>
+      <a:p>
+        <a:pPr algn="ctr" marL="457200" indent="-457200">
+          <a:lnSpc><a:spcPct val="120000"/></a:lnSpc>
+          <a:buNone/>
+        </a:pPr>
+        <a:r><a:t>x</a:t></a:r>
+      </a:p>
+    </a:txBody>`);
+    const block = parseTextBody(t, { report: new ImportReport() })[0];
+    expect(block.type).toBe('paragraph');
+    expect(block.style.alignment).toBe('center');
+    expect(block.style.lineHeight).toBeCloseTo(1.2, 6);
+    expect(block.style.marginLeft).toBe(48); // 457200 / 9525
+    expect(block.style.textIndent).toBe(-48);
+  });
+
+  it('classifies bulleted and numbered paragraphs as list-items', () => {
+    const t = txBody(`<a:txBody>
+      <a:bodyPr/>
+      <a:p><a:pPr lvl="0"><a:buChar char="•"/></a:pPr><a:r><a:t>a</a:t></a:r></a:p>
+      <a:p><a:pPr lvl="1"><a:buAutoNum type="arabicPeriod"/></a:pPr><a:r><a:t>b</a:t></a:r></a:p>
+      <a:p><a:pPr><a:buNone/></a:pPr><a:r><a:t>c</a:t></a:r></a:p>
+    </a:txBody>`);
+    const blocks = parseTextBody(t, { report: new ImportReport() });
+    expect(blocks[0].type).toBe('list-item');
+    expect(blocks[0].listKind).toBe('unordered');
+    expect(blocks[0].listLevel).toBe(0);
+    expect(blocks[1].type).toBe('list-item');
+    expect(blocks[1].listKind).toBe('ordered');
+    expect(blocks[1].listLevel).toBe(1);
+    expect(blocks[2].type).toBe('paragraph');
+  });
+
+  it('preserves empty paragraphs with placeholder inline so layout never NaNs', () => {
+    const t = txBody(`<a:txBody><a:bodyPr/><a:p/></a:txBody>`);
+    const blocks = parseTextBody(t, { report: new ImportReport() });
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].inlines).toHaveLength(1);
+    expect(blocks[0].inlines[0].text).toBe('');
+  });
+
+  it('lifts <a:br> into a soft line break in the same block', () => {
+    const t = txBody(`<a:txBody><a:bodyPr/><a:p>
+      <a:r><a:rPr sz="1000"/><a:t>line1</a:t></a:r>
+      <a:br/>
+      <a:r><a:rPr sz="1000"/><a:t>line2</a:t></a:r>
+    </a:p></a:txBody>`);
+    const blocks = parseTextBody(t, { report: new ImportReport() });
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].inlines.map((i) => i.text)).toEqual(['line1', '\n', 'line2']);
+  });
+});
+
+describe('parseTextBody — normAutofit pre-scale', () => {
+  it('multiplies fontSize by fontScale/100000 and bumps the report', () => {
+    const t = txBody(`<a:txBody>
+      <a:bodyPr><a:normAutofit fontScale="90000"/></a:bodyPr>
+      <a:p><a:r><a:rPr sz="2000"/><a:t>big</a:t></a:r></a:p>
+    </a:txBody>`);
+    const report = new ImportReport();
+    const blocks = parseTextBody(t, { report });
+    expect(blocks[0].inlines[0].style.fontSize).toBeCloseTo(18, 6); // 20pt * 0.9
+    expect(report.textBoxesPreScaled).toBe(1);
+  });
+
+  it('does NOT bump the report when fontScale is 100000 (no shrink)', () => {
+    const t = txBody(`<a:txBody>
+      <a:bodyPr><a:normAutofit fontScale="100000"/></a:bodyPr>
+      <a:p><a:r><a:rPr sz="2000"/><a:t>same</a:t></a:r></a:p>
+    </a:txBody>`);
+    const report = new ImportReport();
+    parseTextBody(t, { report });
+    expect(report.textBoxesPreScaled).toBe(0);
+  });
+});

--- a/packages/slides/src/import/pptx/text.ts
+++ b/packages/slides/src/import/pptx/text.ts
@@ -14,6 +14,14 @@ export interface TextParseContext {
   /** Slide-scoped rels — used to look up `<a:hlinkClick r:id="rIdN">` targets. */
   rels?: Map<string, PptxRel>;
   report: ImportReport;
+  /**
+   * Fallback `fontSize` (in points) applied to any `<a:r>` whose `<a:rPr>`
+   * lacks an `sz` attribute. OOXML inherits these from the master/layout
+   * placeholder style chain; for the v1 importer we use a single hint
+   * derived from the parent shape's `<p:ph type>` so title runs don't
+   * collapse to the docs default of 11 pt.
+   */
+  defaultFontSize?: number;
 }
 
 /**
@@ -145,6 +153,12 @@ function parseRun(
   const rPr = child(r, 'rPr');
   const style: InlineStyle = {};
 
+  // Apply placeholder-derived default first so an explicit `sz` below
+  // can override it.
+  if (ctx.defaultFontSize != null) {
+    style.fontSize = ctx.defaultFontSize * fontScale;
+  }
+
   if (rPr) {
     if (attr(rPr, 'b') === '1') style.bold = true;
     if (attr(rPr, 'i') === '1') style.italic = true;
@@ -161,7 +175,7 @@ function parseRun(
     }
 
     const sz = attrInt(rPr, 'sz');
-    if (sz != null) style.fontSize = (sz / 100) * fontScale; // sz is hundredths of pt
+    if (sz != null) style.fontSize = (sz / 100) * fontScale;
 
     // Font family — Latin face wins. East Asian fallback kicks in at
     // run text inspection time below.

--- a/packages/slides/src/import/pptx/text.ts
+++ b/packages/slides/src/import/pptx/text.ts
@@ -1,6 +1,6 @@
 import type { Block, BlockStyle, Inline, InlineStyle } from '@wafflebase/docs';
 import { DEFAULT_BLOCK_STYLE, generateBlockId } from '@wafflebase/docs';
-import { parseColorFromContainer } from './color';
+import { parseColorFromContainer, type ClrMap } from './color';
 import { containsHangul, parsePrimaryTypeface } from './font';
 import { ImportReport } from './report';
 import type { PptxRel } from './rels';
@@ -22,6 +22,8 @@ export interface TextParseContext {
    * collapse to the docs default of 11 pt.
    */
   defaultFontSize?: number;
+  /** Master-level `<p:clrMap>` translation table for `<a:schemeClr>` lookups. */
+  clrMap?: ClrMap;
 }
 
 /**
@@ -184,14 +186,14 @@ function parseRun(
 
     const solidFill = child(rPr, 'solidFill');
     if (solidFill) {
-      const color = parseColorFromContainer(solidFill);
+      const color = parseColorFromContainer(solidFill, ctx.clrMap);
       if (color) style.color = color;
     }
 
     // Text highlight (`<a:highlight>` — a:solidFill-like container).
     const highlight = child(rPr, 'highlight');
     if (highlight) {
-      const bg = parseColorFromContainer(highlight);
+      const bg = parseColorFromContainer(highlight, ctx.clrMap);
       if (bg) style.backgroundColor = bg;
     }
 
@@ -203,7 +205,13 @@ function parseRun(
       const rid =
         hlink.getAttributeNS(NS.R, 'id') || hlink.getAttribute('r:id') || undefined;
       const rel = rid ? ctx.rels?.get(rid) : undefined;
-      if (rel?.target) style.href = rel.target;
+      // Only forward *external* http/https links. Internal slide-jump
+      // rels (e.g. `Type=".../slide" Target="slide3.xml"`) are not
+      // representable in docs `Inline.style.href`, and untrusted PPTX
+      // can embed `javascript:` / `data:` schemes as an XSS vector.
+      if (rel?.external && rel.target && isSafeHref(rel.target)) {
+        style.href = rel.target;
+      }
     }
   }
 
@@ -216,6 +224,21 @@ function parseRun(
   }
 
   return { text, style };
+}
+
+/**
+ * Allowlist of URL schemes safe to forward as `Inline.style.href`.
+ * Everything else (javascript:, data:, vbscript:, file:, ...) is
+ * dropped — PPTX is an untrusted format and the docs renderer turns
+ * any non-empty `href` into a click target.
+ */
+function isSafeHref(target: string): boolean {
+  // Relative or protocol-relative URLs are safe (they resolve under
+  // the host's own origin).
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(target)) return true;
+  if (/^mailto:/i.test(target)) return true;
+  if (/^https?:/i.test(target)) return true;
+  return false;
 }
 
 function emptyBlock(): Block {

--- a/packages/slides/src/import/pptx/text.ts
+++ b/packages/slides/src/import/pptx/text.ts
@@ -1,0 +1,214 @@
+import type { Block, BlockStyle, Inline, InlineStyle } from '@wafflebase/docs';
+import { DEFAULT_BLOCK_STYLE, generateBlockId } from '@wafflebase/docs';
+import { parseColorFromContainer } from './color';
+import { containsHangul, parsePrimaryTypeface } from './font';
+import { ImportReport } from './report';
+import type { PptxRel } from './rels';
+import { attr, attrInt, child, children, NS, textOf } from './xml';
+
+/**
+ * Per-slide context the text parser needs to resolve hyperlink relationships
+ * and report autofit pre-scaling globally.
+ */
+export interface TextParseContext {
+  /** Slide-scoped rels — used to look up `<a:hlinkClick r:id="rIdN">` targets. */
+  rels?: Map<string, PptxRel>;
+  report: ImportReport;
+}
+
+/**
+ * Parse `<p:txBody>` into a docs `Block[]`.
+ *
+ * Honors `<a:bodyPr><a:normAutofit fontScale=...>`: each run's `fontSize`
+ * is pre-multiplied by `fontScale / 100000` so the rendered output
+ * approximates the source. This is lossy (we don't auto-re-fit on
+ * resize), but acceptable for v1 — see the design doc's "re-validated
+ * gap" section.
+ */
+export function parseTextBody(txBody: Element, ctx: TextParseContext): Block[] {
+  let fontScale = 1;
+  const bodyPr = child(txBody, 'bodyPr');
+  if (bodyPr) {
+    const autofit = child(bodyPr, 'normAutofit');
+    if (autofit) {
+      const raw = attrInt(autofit, 'fontScale');
+      if (raw != null && raw > 0 && raw !== 100_000) {
+        fontScale = raw / 100_000;
+        ctx.report.textBoxesPreScaled += 1;
+      }
+    }
+  }
+
+  const paragraphs = children(txBody, 'p');
+  if (paragraphs.length === 0) return [emptyBlock()];
+
+  return paragraphs.map((p) => parseParagraph(p, fontScale, ctx));
+}
+
+function parseParagraph(
+  p: Element,
+  fontScale: number,
+  ctx: TextParseContext,
+): Block {
+  const pPr = child(p, 'pPr');
+  const { style, list } = parseParagraphProperties(pPr);
+
+  const inlines: Inline[] = [];
+  for (let i = 0; i < p.childNodes.length; i++) {
+    const n = p.childNodes[i];
+    if (n.nodeType !== 1) continue;
+    const el = n as Element;
+    if (el.localName === 'r') inlines.push(parseRun(el, fontScale, ctx));
+    else if (el.localName === 'br') inlines.push({ text: '\n', style: {} });
+    else if (el.localName === 'fld') {
+      // `<a:fld>` is a field (slide number, date, …). v1 dumps the
+      // pre-rendered text and ignores the field semantics.
+      const t = child(el, 't');
+      if (t) inlines.push(parseRun(el, fontScale, ctx, textOf(t)));
+    }
+  }
+
+  // Empty paragraphs need a placeholder inline so layout doesn't NaN —
+  // docs's `computeLayout` requires at least one inline per block.
+  if (inlines.length === 0) inlines.push({ text: '', style: {} });
+
+  const block: Block = {
+    id: generateBlockId(),
+    type: list ? 'list-item' : 'paragraph',
+    inlines,
+    style,
+  };
+  if (list) {
+    block.listKind = list.kind;
+    block.listLevel = list.level;
+  }
+  return block;
+}
+
+/** PPTX bullet config extracted from `<a:pPr>`. */
+interface ListInfo {
+  kind: 'ordered' | 'unordered';
+  level: number;
+}
+
+function parseParagraphProperties(pPr: Element | undefined): {
+  style: BlockStyle;
+  list: ListInfo | undefined;
+} {
+  const style: BlockStyle = { ...DEFAULT_BLOCK_STYLE };
+  if (!pPr) return { style, list: undefined };
+
+  const algn = attr(pPr, 'algn');
+  if (algn === 'ctr') style.alignment = 'center';
+  else if (algn === 'r') style.alignment = 'right';
+  else if (algn === 'just') style.alignment = 'justify';
+  else if (algn === 'l') style.alignment = 'left';
+
+  // Line spacing — PPTX exposes either percentage (1000ths) or absolute pts.
+  const lnSpc = child(pPr, 'lnSpc');
+  if (lnSpc) {
+    const pct = child(lnSpc, 'spcPct');
+    if (pct) {
+      const v = attrInt(pct, 'val');
+      if (v != null) style.lineHeight = v / 100_000;
+    }
+    // spcPts (absolute points) is rare; ignore for v1 — design doc says
+    // docs's lineHeight is a ratio, not an absolute, so the closest
+    // faithful translation is keeping the default 1.5.
+  }
+
+  // Indent / left margin — PPTX values are in EMU; docs values are px.
+  // We don't have the slide scale at parse time, so we approximate with
+  // the EMU→px ratio at 96 dpi (914400 EMU/in ÷ 96 px/in = 9525 EMU/px).
+  // Sufficient for outline indentation; precise placement is bounded by
+  // the text box anyway.
+  const marL = attrInt(pPr, 'marL');
+  if (marL != null) style.marginLeft = Math.round(marL / 9525);
+  const indent = attrInt(pPr, 'indent');
+  if (indent != null) style.textIndent = Math.round(indent / 9525);
+
+  let list: ListInfo | undefined;
+  const lvl = attrInt(pPr, 'lvl') ?? 0;
+  if (child(pPr, 'buAutoNum')) list = { kind: 'ordered', level: lvl };
+  else if (child(pPr, 'buChar')) list = { kind: 'unordered', level: lvl };
+  // `<a:buNone/>` and absence both mean "no list" — leave list undefined.
+
+  return { style, list };
+}
+
+function parseRun(
+  r: Element,
+  fontScale: number,
+  ctx: TextParseContext,
+  textOverride?: string,
+): Inline {
+  const rPr = child(r, 'rPr');
+  const style: InlineStyle = {};
+
+  if (rPr) {
+    if (attr(rPr, 'b') === '1') style.bold = true;
+    if (attr(rPr, 'i') === '1') style.italic = true;
+    const u = attr(rPr, 'u');
+    if (u && u !== 'none') style.underline = true;
+    if (attr(rPr, 'strike') === 'sngStrike' || attr(rPr, 'strike') === 'dblStrike') {
+      style.strikethrough = true;
+    }
+    // baseline -> super/subscript. PPTX stores as 1000ths of a percent.
+    const baseline = attrInt(rPr, 'baseline');
+    if (baseline != null) {
+      if (baseline > 0) style.superscript = true;
+      else if (baseline < 0) style.subscript = true;
+    }
+
+    const sz = attrInt(rPr, 'sz');
+    if (sz != null) style.fontSize = (sz / 100) * fontScale; // sz is hundredths of pt
+
+    // Font family — Latin face wins. East Asian fallback kicks in at
+    // run text inspection time below.
+    const face = parsePrimaryTypeface(rPr);
+    if (face) style.fontFamily = face;
+
+    const solidFill = child(rPr, 'solidFill');
+    if (solidFill) {
+      const color = parseColorFromContainer(solidFill);
+      if (color) style.color = color;
+    }
+
+    // Text highlight (`<a:highlight>` — a:solidFill-like container).
+    const highlight = child(rPr, 'highlight');
+    if (highlight) {
+      const bg = parseColorFromContainer(highlight);
+      if (bg) style.backgroundColor = bg;
+    }
+
+    // Hyperlink — `r:id` is namespaced; some DOMParsers expose it
+    // through `getAttributeNS`, others only via the literal `r:id` form.
+    // Try both.
+    const hlink = child(rPr, 'hlinkClick');
+    if (hlink) {
+      const rid =
+        hlink.getAttributeNS(NS.R, 'id') || hlink.getAttribute('r:id') || undefined;
+      const rel = rid ? ctx.rels?.get(rid) : undefined;
+      if (rel?.target) style.href = rel.target;
+    }
+  }
+
+  const text = textOverride ?? textOf(child(r, 't') ?? r);
+
+  // Korean-script fallback — only when the explicit Latin face is one of
+  // the well-known Latin-only fonts that we know don't render Hangul.
+  if (!style.fontFamily && containsHangul(text)) {
+    style.fontFamily = 'Noto Sans KR';
+  }
+
+  return { text, style };
+}
+
+function emptyBlock(): Block {
+  return {
+    id: generateBlockId(),
+    type: 'paragraph',
+    inlines: [{ text: '', style: {} }],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  };
+}

--- a/packages/slides/src/import/pptx/theme.test.ts
+++ b/packages/slides/src/import/pptx/theme.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseTheme } from './theme';
+
+const YORKIE_THEME_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Yorkie">
+  <a:themeElements>
+    <a:clrScheme name="Yorkie">
+      <a:dk1><a:srgbClr val="000000"/></a:dk1>
+      <a:lt1><a:srgbClr val="FFFFFF"/></a:lt1>
+      <a:dk2><a:srgbClr val="158158"/></a:dk2>
+      <a:lt2><a:srgbClr val="F3F3F3"/></a:lt2>
+      <a:accent1><a:srgbClr val="058DC7"/></a:accent1>
+      <a:accent2><a:srgbClr val="50B432"/></a:accent2>
+      <a:accent3><a:srgbClr val="ED561B"/></a:accent3>
+      <a:accent4><a:srgbClr val="EDEF00"/></a:accent4>
+      <a:accent5><a:srgbClr val="24CBE5"/></a:accent5>
+      <a:accent6><a:srgbClr val="64E572"/></a:accent6>
+      <a:hlink><a:srgbClr val="2200CC"/></a:hlink>
+      <a:folHlink><a:srgbClr val="551A8B"/></a:folHlink>
+    </a:clrScheme>
+    <a:fontScheme name="Yorkie">
+      <a:majorFont><a:latin typeface="Roboto"/></a:majorFont>
+      <a:minorFont><a:latin typeface="Roboto"/></a:minorFont>
+    </a:fontScheme>
+    <a:fmtScheme name="Office"/>
+  </a:themeElements>
+</a:theme>`;
+
+describe('parseTheme', () => {
+  it('extracts the Yorkie 캐즘 deck palette + Roboto', () => {
+    const theme = parseTheme(YORKIE_THEME_XML, 'imported-yorkie');
+    expect(theme.id).toBe('imported-yorkie');
+    expect(theme.name).toBe('Yorkie');
+    expect(theme.colors.accent1).toBe('#058DC7');
+    expect(theme.colors.accent6).toBe('#64E572');
+    expect(theme.colors.text).toBe('#000000');
+    expect(theme.colors.background).toBe('#FFFFFF');
+    expect(theme.colors.textSecondary).toBe('#158158');
+    expect(theme.colors.hyperlink).toBe('#2200CC');
+    expect(theme.colors.visitedHyperlink).toBe('#551A8B');
+    expect(theme.fonts).toEqual({ heading: 'Roboto', body: 'Roboto' });
+  });
+
+  it('falls back to default-light values when slots are missing', () => {
+    const empty = `<?xml version="1.0"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:themeElements/></a:theme>`;
+    const theme = parseTheme(empty, 'empty');
+    expect(theme.colors.accent1).toBe('#1A73E8'); // default-light accent1
+    expect(theme.fonts.heading).toBe('Inter');
+  });
+
+  it('keeps default fonts when only Latin face is blank (inherit)', () => {
+    const xml = `<?xml version="1.0"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Blank Fonts"><a:themeElements>
+  <a:clrScheme name="X"/>
+  <a:fontScheme name="X"><a:majorFont><a:latin typeface=""/></a:majorFont><a:minorFont><a:latin typeface=""/></a:minorFont></a:fontScheme>
+</a:themeElements></a:theme>`;
+    const theme = parseTheme(xml, 't');
+    expect(theme.fonts).toEqual({ heading: 'Inter', body: 'Inter' });
+  });
+});

--- a/packages/slides/src/import/pptx/theme.ts
+++ b/packages/slides/src/import/pptx/theme.ts
@@ -1,0 +1,83 @@
+import type { ColorRole, ColorScheme, FontScheme, Theme } from '../../model/theme';
+import { parseHexInContainer } from './color';
+import { parsePrimaryTypeface } from './font';
+import { attr, child, descendant, parseXml } from './xml';
+
+/**
+ * OOXML `<a:clrScheme>` slot name → our `ColorScheme` key. The 12 slots
+ * are positional; we read them by element name to be order-agnostic.
+ */
+const SCHEME_SLOTS: Array<[string, ColorRole]> = [
+  ['dk1', 'text'],
+  ['lt1', 'background'],
+  ['dk2', 'textSecondary'],
+  ['lt2', 'backgroundAlt'],
+  ['accent1', 'accent1'],
+  ['accent2', 'accent2'],
+  ['accent3', 'accent3'],
+  ['accent4', 'accent4'],
+  ['accent5', 'accent5'],
+  ['accent6', 'accent6'],
+  ['hlink', 'hyperlink'],
+  ['folHlink', 'visitedHyperlink'],
+];
+
+/** Fallback when a theme slot is missing — uses `default-light` values. */
+const FALLBACK_COLORS: ColorScheme = {
+  text: '#202124',
+  background: '#FFFFFF',
+  textSecondary: '#5F6368',
+  backgroundAlt: '#F1F3F4',
+  accent1: '#1A73E8',
+  accent2: '#34A853',
+  accent3: '#FBBC04',
+  accent4: '#EA4335',
+  accent5: '#673AB7',
+  accent6: '#FF6D01',
+  hyperlink: '#1A73E8',
+  visitedHyperlink: '#7B1FA2',
+};
+
+const FALLBACK_FONTS: FontScheme = { heading: 'Inter', body: 'Inter' };
+
+/**
+ * Parse a `ppt/theme/themeN.xml` into a `Theme`.
+ *
+ * Slot resolution is lossy but predictable: when a slot is missing or
+ * uses an unresolved `<a:schemeClr>` reference, we fall back to the
+ * matching `default-light` value rather than failing the import.
+ */
+export function parseTheme(xml: string, id: string): Theme {
+  const doc = parseXml(xml);
+  const themeEl = descendant(doc, 'theme');
+  const elements = themeEl ? child(themeEl, 'themeElements') : undefined;
+  const clrScheme = elements ? child(elements, 'clrScheme') : undefined;
+  const fontScheme = elements ? child(elements, 'fontScheme') : undefined;
+
+  return {
+    id,
+    name: (themeEl && attr(themeEl, 'name')) || id,
+    colors: clrScheme ? parseColorScheme(clrScheme) : { ...FALLBACK_COLORS },
+    fonts: fontScheme ? parseFontScheme(fontScheme) : { ...FALLBACK_FONTS },
+  };
+}
+
+function parseColorScheme(scheme: Element): ColorScheme {
+  const out: ColorScheme = { ...FALLBACK_COLORS };
+  for (const [ooxmlSlot, role] of SCHEME_SLOTS) {
+    const slot = child(scheme, ooxmlSlot);
+    if (!slot) continue;
+    const hex = parseHexInContainer(slot);
+    if (hex) out[role] = hex;
+  }
+  return out;
+}
+
+function parseFontScheme(scheme: Element): FontScheme {
+  const major = child(scheme, 'majorFont');
+  const minor = child(scheme, 'minorFont');
+  return {
+    heading: (major && parsePrimaryTypeface(major)) || FALLBACK_FONTS.heading,
+    body: (minor && parsePrimaryTypeface(minor)) || FALLBACK_FONTS.body,
+  };
+}

--- a/packages/slides/src/import/pptx/unzip.test.ts
+++ b/packages/slides/src/import/pptx/unzip.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import { unzipPptx } from './unzip';
+import { buildMinimalPptx } from './__fixtures__/build-minimal-pptx';
+
+describe('unzipPptx', () => {
+  it('reads text parts from a minimal pptx', async () => {
+    const buffer = await buildMinimalPptx();
+    const archive = await unzipPptx(buffer);
+    const xml = await archive.readText('ppt/presentation.xml');
+    expect(xml).toBeDefined();
+    expect(xml).toContain('<p:presentation');
+  });
+
+  it('returns undefined for missing entries', async () => {
+    const buffer = await buildMinimalPptx();
+    const archive = await unzipPptx(buffer);
+    expect(await archive.readText('ppt/slides/slide99.xml')).toBeUndefined();
+    expect(await archive.readBytes('ppt/media/missing.png')).toBeUndefined();
+  });
+
+  it('lists entries by prefix', async () => {
+    const buffer = await buildMinimalPptx();
+    const archive = await unzipPptx(buffer);
+    const slides = archive.list('ppt/slides/');
+    expect(slides).toContain('ppt/slides/slide1.xml');
+    const layouts = archive.list('ppt/slideLayouts/');
+    expect(layouts).toContain('ppt/slideLayouts/slideLayout1.xml');
+  });
+
+  it('rejects a non-OOXML archive', async () => {
+    const zip = new JSZip();
+    zip.file('hello.txt', 'world');
+    const buffer = await zip.generateAsync({ type: 'arraybuffer' });
+    await expect(unzipPptx(buffer)).rejects.toThrow(/Content_Types/);
+  });
+
+  it('rejects an unzip failure', async () => {
+    const buffer = new Uint8Array([1, 2, 3, 4]).buffer;
+    await expect(unzipPptx(buffer)).rejects.toThrow(/Invalid \.pptx/);
+  });
+});

--- a/packages/slides/src/import/pptx/unzip.ts
+++ b/packages/slides/src/import/pptx/unzip.ts
@@ -1,0 +1,52 @@
+import JSZip from 'jszip';
+
+/**
+ * A read-only view over an unzipped .pptx archive.
+ *
+ * Mirrors the access patterns we need throughout the importer:
+ *   - `readText(path)` for XML parts
+ *   - `readBytes(path)` for media (uploaded via the host's image API)
+ *   - `list(prefix)` for enumerating slides / layouts / media
+ *
+ * Returns `undefined` for missing entries rather than throwing — callers
+ * decide whether absence is fatal (e.g., `ppt/presentation.xml`) or
+ * tolerable (e.g., a slide rels file with no images).
+ */
+export interface PptxArchive {
+  readText(path: string): Promise<string | undefined>;
+  readBytes(path: string): Promise<Uint8Array | undefined>;
+  list(prefix: string): string[];
+}
+
+export async function unzipPptx(buffer: ArrayBuffer): Promise<PptxArchive> {
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(buffer);
+  } catch (err) {
+    throw new Error(
+      `Invalid .pptx: failed to unzip (${(err as Error).message})`,
+    );
+  }
+
+  // Minimal sanity check — a valid PPTX always has `[Content_Types].xml`.
+  if (!zip.file('[Content_Types].xml')) {
+    throw new Error(
+      'Invalid .pptx: missing [Content_Types].xml (not an OOXML package)',
+    );
+  }
+
+  return {
+    async readText(path) {
+      return zip.file(path)?.async('string');
+    },
+    async readBytes(path) {
+      const data = await zip.file(path)?.async('uint8array');
+      return data;
+    },
+    list(prefix) {
+      return Object.keys(zip.files).filter(
+        (name) => name.startsWith(prefix) && !zip.files[name].dir,
+      );
+    },
+  };
+}

--- a/packages/slides/src/import/pptx/xml.test.ts
+++ b/packages/slides/src/import/pptx/xml.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { attr, attrInt, child, children, descendant, parseXml, textOf, NS } from './xml';
+
+const SAMPLE = `<?xml version="1.0"?>
+<root xmlns:p="${NS.P}" xmlns:a="${NS.A}">
+  <p:wrap>
+    <a:run sz="1200">Hello</a:run>
+    <a:run sz="abc">World</a:run>
+    <a:run>!</a:run>
+  </p:wrap>
+  <p:other/>
+</root>`;
+
+describe('xml helpers', () => {
+  it('throws on malformed input', () => {
+    expect(() => parseXml('<a><b>')).toThrow(/Invalid XML/);
+  });
+
+  it('matches children by localName ignoring prefix', () => {
+    const doc = parseXml(SAMPLE);
+    const root = doc.documentElement;
+    const wrap = child(root, 'wrap');
+    expect(wrap).toBeDefined();
+    const runs = children(wrap!, 'run');
+    expect(runs).toHaveLength(3);
+    expect(textOf(runs[0])).toBe('Hello');
+  });
+
+  it('finds a descendant deep in the tree', () => {
+    const doc = parseXml(SAMPLE);
+    const run = descendant(doc, 'run');
+    expect(run).toBeDefined();
+    expect(textOf(run!)).toBe('Hello');
+  });
+
+  it('reads attributes safely', () => {
+    const doc = parseXml(SAMPLE);
+    const run = descendant(doc, 'run')!;
+    expect(attr(run, 'sz')).toBe('1200');
+    expect(attr(run, 'missing')).toBeUndefined();
+    expect(attrInt(run, 'sz')).toBe(1200);
+
+    const runs = children(child(doc.documentElement, 'wrap')!, 'run');
+    expect(attrInt(runs[1], 'sz')).toBeUndefined();
+    expect(attrInt(runs[2], 'sz')).toBeUndefined();
+  });
+});

--- a/packages/slides/src/import/pptx/xml.ts
+++ b/packages/slides/src/import/pptx/xml.ts
@@ -1,0 +1,91 @@
+/**
+ * Thin DOMParser facade + namespace-tolerant traversal helpers.
+ *
+ * PPTX XML uses several namespaces (`p:`, `a:`, `r:` plus a handful of
+ * extension namespaces). Rather than threading the namespace URI through
+ * every lookup, this module matches on `localName` so callers don't have
+ * to distinguish between `p:sp` and `sp` etc.
+ *
+ * Node consumers (the CLI) must polyfill `DOMParser` before calling into
+ * the importer — `@wafflebase/cli`'s `dom-polyfill.ts` already does this
+ * as a side-effect import for the docs importer.
+ */
+
+export const NS = {
+  /** PresentationML — `p:` */
+  P: 'http://schemas.openxmlformats.org/presentationml/2006/main',
+  /** DrawingML — `a:` */
+  A: 'http://schemas.openxmlformats.org/drawingml/2006/main',
+  /** Relationships (per-part) — `r:` */
+  R: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+  /** Relationships (package-level `.rels` files) */
+  RELS: 'http://schemas.openxmlformats.org/package/2006/relationships',
+} as const;
+
+export function parseXml(text: string): Document {
+  const doc = new DOMParser().parseFromString(text, 'text/xml');
+  // DOMParser emits a `<parsererror>` element rather than throwing.
+  // Surface it as an Error so callers don't proceed with a junk tree.
+  const err = doc.getElementsByTagName('parsererror')[0];
+  if (err) {
+    throw new Error(`Invalid XML: ${err.textContent ?? 'unknown parse error'}`);
+  }
+  return doc;
+}
+
+/** First child element with matching `localName`, or `undefined`. */
+export function child(parent: Element | Document, localName: string): Element | undefined {
+  const root: ParentNode = parent;
+  const nodes = root.childNodes;
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i];
+    if (n.nodeType === 1 && (n as Element).localName === localName) {
+      return n as Element;
+    }
+  }
+  return undefined;
+}
+
+/** Every direct child element with matching `localName`. */
+export function children(parent: Element | Document, localName: string): Element[] {
+  const out: Element[] = [];
+  const nodes = parent.childNodes;
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i];
+    if (n.nodeType === 1 && (n as Element).localName === localName) {
+      out.push(n as Element);
+    }
+  }
+  return out;
+}
+
+/**
+ * First descendant element with matching `localName`. Useful for reading
+ * a single deeply-nested attribute (e.g. `<p:sldSz>` inside the root).
+ */
+export function descendant(parent: Element | Document, localName: string): Element | undefined {
+  // Document and Element both expose `getElementsByTagName` (`*` matches any).
+  // We then filter by `localName` to stay namespace-agnostic.
+  const all = (parent as Element | Document).getElementsByTagName('*');
+  for (let i = 0; i < all.length; i++) {
+    if (all[i].localName === localName) return all[i];
+  }
+  return undefined;
+}
+
+export function attr(el: Element, name: string): string | undefined {
+  const v = el.getAttribute(name);
+  return v === null ? undefined : v;
+}
+
+/** Parse an int attribute; returns `undefined` if missing or not a number. */
+export function attrInt(el: Element, name: string): number | undefined {
+  const v = el.getAttribute(name);
+  if (v === null) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function textOf(el: Element): string {
+  return el.textContent ?? '';
+}

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -1,3 +1,14 @@
+// PPTX import — best-effort. Browser usage relies on the host's
+// `DOMParser`; Node consumers should import from `@wafflebase/slides/node`
+// instead so the dual-entry build can keep the polyfill story explicit.
+export { importPptx } from './import/pptx';
+export type {
+  ImportPptxOptions,
+  ImportPptxResult,
+  UploadImage,
+} from './import/pptx';
+export { ImportReport } from './import/pptx/report';
+
 // Model
 export type {
   Background,

--- a/packages/slides/src/node.ts
+++ b/packages/slides/src/node.ts
@@ -73,3 +73,15 @@ export {
   ADJUSTMENT_HANDLES,
 } from './view/canvas/shapes';
 export type { PathBuilder, AdjustmentSpec, FrameSize, AdjustmentHandle } from './view/canvas/shapes/builder';
+
+// PPTX import — best-effort. Reaches for `DOMParser` at runtime, so
+// Node consumers (the CLI) must install a polyfill before calling. The
+// CLI's `dom-polyfill.ts` already does this as a side-effect import for
+// the docs DOCX importer; the same polyfill covers slides.
+export { importPptx } from './import/pptx';
+export type {
+  ImportPptxOptions,
+  ImportPptxResult,
+  UploadImage,
+} from './import/pptx';
+export { ImportReport } from './import/pptx/report';

--- a/packages/slides/vite.build.ts
+++ b/packages/slides/vite.build.ts
@@ -4,11 +4,22 @@ import dts from 'vite-plugin-dts';
 export default defineConfig({
   build: {
     lib: {
-      entry: 'src/index.ts',
-      name: 'wafflebase-slides',
+      // Multiple entry points so the published package can expose both:
+      //   - `.`      (full editor; browser-only)
+      //   - `./node` (data-model + DOM-free importers — backend/CLI/SSR safe)
+      entry: {
+        'wafflebase-slides.es': 'src/index.ts',
+        node: 'src/node.ts',
+      },
       formats: ['es', 'cjs'],
-      fileName: (format) =>
-        format === 'cjs' ? 'wafflebase-slides.cjs' : 'wafflebase-slides.es.js',
+      fileName: (format, entryName) => {
+        if (entryName === 'node') {
+          return format === 'cjs' ? 'node.cjs' : 'node.js';
+        }
+        return format === 'cjs'
+          ? 'wafflebase-slides.cjs'
+          : 'wafflebase-slides.es.js';
+      },
     },
   },
   plugins: [dts({ rollupTypes: true })],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,9 @@ importers:
       '@wafflebase/docs':
         specifier: workspace:*
         version: link:../docs
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^3.1.1


### PR DESCRIPTION
## Summary

- New PPTX parser at `packages/slides/src/import/pptx/` reuses jszip (shared with the DOCX importer) and the host's `DOMParser` (Node consumers polyfill via `@xmldom/xmldom`, same convention as docs). Adds a `./node` subpath build so CLI/backend can import without pulling in the editor.
- Maps OOXML theme/master/layout/slide onto the v0.4 slides model — 13 prst shape kinds land directly on the existing 117-kind registry, `<p:cxnSp>` straight/curved connectors map to first-class `ConnectorElement` with attached endpoints via per-slide id map, `<p:grpSp>` groups flatten through composed affine transforms, `<p:graphicFrame>` tables flatten to cell text + uniform-stroke border rects, `<a:highlight>` / `<a:hlinkClick>` land on the docs `Inline.style.backgroundColor` / `href` that already exist. Lossy fallbacks (`<a:normAutofit>` pre-scale, `<a:outerShdw>` drop) are counted in an `ImportReport`.
- Frontend deck list gains an "Import PPTX" item next to "Import DOCX". Picks the file, parses client-side, uploads embedded images through the existing workspace `/images` endpoint, stashes the parsed deck in a slides-side pending-import registry, and pushes it into the Yorkie root before `ensureSlidesRoot` runs.
- Font-size inheritance reads each layout placeholder's `<a:lstStyle><a:lvl1pPr><a:defRPr sz>` so title runs whose `<a:rPr>` lacks `sz` get the layout default (e.g. 52pt) instead of collapsing to 11pt.

## Validation

Benchmark deck (`Yorkie, 캐즘 뛰어넘기.pptx`, 36 slides) imports through the deck list UI with all counts matching the source: 480 elements (text 208, shape 158, connector 51, image 63), 48 groups flattened, 7 tables flattened, 3 unknown prsts folded to rect, slide-1 title renders at 52pt.

## Out of scope (follow-up PR)

- CLI `wafflebase slides import` — requires a parallel backend `slides-content` controller + writer (see `docs/tasks/active/20260515-pptx-import-todo.md` Task 6).
- Backend e2e for the CLI flow.
- Master `<p:txStyles>` inheritance for placeholders that aren't covered by their layout's `<a:lstStyle>` (v1.5).

## Test plan

- [x] `pnpm verify:fast` green on each commit
- [x] `pnpm slides test` — 209 files / 926 tests pass (67 new under `import/pptx/`)
- [x] `pnpm slides build` produces dual-entry artifacts (`dist/wafflebase-slides.es.js` + `dist/node.js`)
- [x] `pnpm frontend build` produces clean chunks, no chunk-gate regression
- [x] Manual smoke (reporter): import benchmark deck through the deck list UI, confirm 36 slides + title font size matches the source
- [x] Reviewer manual smoke: import any PPTX through the deck list dropdown; confirm toast reports the right counts and the deck opens
- [x] Reviewer: check the design doc's new "re-validated gap" subsection in `docs/design/slides/slides-themes-layouts-import.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import PPTX files to create Slides documents from PowerPoint, available as "Import PPTX" in the New menu.
  * Preserves text, shapes, images, connectors, tables, themes, and layout ordering with graceful fallbacks; uploads embedded images and shows an import summary toast.

* **Improvements**
  * Accurate slide sizing/scaling to a 1920×1080 canvas with fit behavior for differing aspect ratios; improved color/font/highlight handling and clearer fallback reporting.

* **Documentation**
  * Updated import design notes and task/lessons pages capturing scope, gaps, and next steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/243)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->