### PR TITLE
Validate function arity at evaluator dispatch via catalog

### DIFF
--- a/packages/sheets/src/formula/formula.ts
+++ b/packages/sheets/src/formula/formula.ts
@@ -23,6 +23,7 @@ import {
   UnarySignContext,
 } from '../../antlr/FormulaParser';
 import { FunctionMap } from './functions';
+import { findFunction, isValidArity } from './function-catalog';
 import { Grid, Range, Reference } from '../model/core/types';
 import { NumberArgs, StringArgs } from './arguments';
 import {
@@ -692,6 +693,12 @@ class Evaluator implements FormulaVisitor<EvalNode> {
     if (name === 'LAMBDA') return this.evalLambda(ctx);
 
     if (FunctionMap.has(name)) {
+      const info = findFunction(name);
+      if (info) {
+        const argsCtx = ctx.args();
+        const argCount = argsCtx ? argsCtx.expr().length : 0;
+        if (!isValidArity(info, argCount)) return ErrNode.NA;
+      }
       const func = FunctionMap.get(name)!;
       return func(ctx, this.visit, this.grid);
     }

--- a/packages/sheets/src/formula/function-catalog.ts
+++ b/packages/sheets/src/formula/function-catalog.ts
@@ -34,352 +34,7 @@ export type FunctionInfo = {
   args: FunctionArg[];
 };
 
-/**
- * FunctionCatalog lists all built-in functions with metadata for autocomplete.
- */
-const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
-  {
-    name: 'SUM',
-    description: 'Returns the sum of a series of numbers',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'ABS',
-    description: 'Returns the absolute value of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'ROUND',
-    description: 'Rounds a number to a certain number of decimal places',
-    args: [{ name: 'value' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'ROUNDUP',
-    description: 'Rounds a number away from zero',
-    args: [{ name: 'value' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'ROUNDDOWN',
-    description: 'Rounds a number toward zero',
-    args: [{ name: 'value' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'INT',
-    description: 'Rounds a number down to the nearest integer',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'MOD',
-    description: 'Returns the remainder after division',
-    args: [{ name: 'dividend' }, { name: 'divisor' }],
-  },
-  {
-    name: 'SQRT',
-    description: 'Returns the positive square root of a number',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'POWER',
-    description: 'Returns a number raised to a power',
-    args: [{ name: 'base' }, { name: 'exponent' }],
-  },
-  {
-    name: 'PRODUCT',
-    description: 'Multiplies a series of numbers',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'MEDIAN',
-    description: 'Returns the middle number in a series',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'RAND',
-    description: 'Returns a random number between 0 and 1',
-    args: [],
-  },
-  {
-    name: 'RANDBETWEEN',
-    description: 'Returns a random integer between two values',
-    args: [{ name: 'low' }, { name: 'high' }],
-  },
-  {
-    name: 'IF',
-    description: 'Returns one value if true and another if false',
-    args: [
-      { name: 'condition' },
-      { name: 'value_if_true' },
-      { name: 'value_if_false', optional: true },
-    ],
-  },
-  {
-    name: 'IFS',
-    description: 'Returns the first value whose condition is true',
-    args: [
-      { name: 'condition1' },
-      { name: 'value1' },
-      { name: 'condition2', optional: true, repeating: true },
-      { name: 'value2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'SWITCH',
-    description: 'Matches an expression against case/value pairs',
-    args: [
-      { name: 'expression' },
-      { name: 'case1' },
-      { name: 'value1' },
-      { name: 'case2_or_default', optional: true, repeating: true },
-      { name: 'value2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'AND',
-    description: 'Returns TRUE if all arguments are true',
-    args: [
-      { name: 'logical1' },
-      { name: 'logical2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'OR',
-    description: 'Returns TRUE if any argument is true',
-    args: [
-      { name: 'logical1' },
-      { name: 'logical2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'NOT',
-    description: 'Returns the opposite of a logical value',
-    args: [{ name: 'logical' }],
-  },
-  {
-    name: 'AVERAGE',
-    description: 'Returns the average of a series of numbers',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'MIN',
-    description: 'Returns the smallest value in a set of numbers',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'MAX',
-    description: 'Returns the largest value in a set of numbers',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'COUNT',
-    description: 'Counts the number of numeric values',
-    args: [
-      { name: 'value1' },
-      { name: 'value2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'COUNTA',
-    description: 'Counts the number of non-empty values',
-    args: [
-      { name: 'value1' },
-      { name: 'value2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'COUNTBLANK',
-    description: 'Counts empty cells',
-    args: [
-      { name: 'value1' },
-      { name: 'value2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'COUNTIF',
-    description: 'Counts values in a range that meet a criterion',
-    args: [{ name: 'range' }, { name: 'criterion' }],
-  },
-  {
-    name: 'SUMIF',
-    description: 'Sums values in a range that meet a criterion',
-    args: [
-      { name: 'range' },
-      { name: 'criterion' },
-      { name: 'sum_range', optional: true },
-    ],
-  },
-  {
-    name: 'COUNTIFS',
-    description: 'Counts values that meet multiple criteria',
-    args: [
-      { name: 'criteria_range1' },
-      { name: 'criterion1' },
-      { name: 'criteria_range2', optional: true, repeating: true },
-      { name: 'criterion2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'SUMIFS',
-    description: 'Sums values that meet multiple criteria',
-    args: [
-      { name: 'sum_range' },
-      { name: 'criteria_range1' },
-      { name: 'criterion1' },
-      { name: 'criteria_range2', optional: true, repeating: true },
-      { name: 'criterion2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'MATCH',
-    description: 'Returns the position of an item in a one-dimensional range',
-    args: [
-      { name: 'search_key' },
-      { name: 'range' },
-      { name: 'search_type', optional: true },
-    ],
-  },
-  {
-    name: 'INDEX',
-    description: 'Returns the value at a given row and column of a range',
-    args: [
-      { name: 'reference' },
-      { name: 'row', optional: true },
-      { name: 'column', optional: true },
-    ],
-  },
-  {
-    name: 'VLOOKUP',
-    description: 'Looks up a value in the first column of a range',
-    args: [
-      { name: 'search_key' },
-      { name: 'range' },
-      { name: 'index' },
-      { name: 'is_sorted', optional: true },
-    ],
-  },
-  {
-    name: 'HLOOKUP',
-    description: 'Looks up a value in the first row of a range',
-    args: [
-      { name: 'search_key' },
-      { name: 'range' },
-      { name: 'index' },
-      { name: 'is_sorted', optional: true },
-    ],
-  },
-  {
-    name: 'TRIM',
-    description: 'Removes leading and trailing whitespace from text',
-    args: [{ name: 'text' }],
-  },
-  {
-    name: 'LEN',
-    description: 'Returns the number of characters in a text string',
-    args: [{ name: 'text' }],
-  },
-  {
-    name: 'LEFT',
-    description: 'Returns the leftmost characters from a text string',
-    args: [{ name: 'text' }, { name: 'num_chars', optional: true }],
-  },
-  {
-    name: 'RIGHT',
-    description: 'Returns the rightmost characters from a text string',
-    args: [{ name: 'text' }, { name: 'num_chars', optional: true }],
-  },
-  {
-    name: 'MID',
-    description: 'Returns characters from the middle of a text string',
-    args: [{ name: 'text' }, { name: 'start_num' }, { name: 'num_chars' }],
-  },
-  {
-    name: 'CONCATENATE',
-    description: 'Joins two or more text strings into one',
-    args: [
-      { name: 'text1' },
-      { name: 'text2' },
-      { name: 'text3', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'CONCAT',
-    description: 'Joins text values into one string',
-    args: [
-      { name: 'text1' },
-      { name: 'text2' },
-      { name: 'text3', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'FIND',
-    description: 'Finds one text value inside another (case-sensitive)',
-    args: [
-      { name: 'search_for' },
-      { name: 'text_to_search' },
-      { name: 'starting_at', optional: true },
-    ],
-  },
-  {
-    name: 'SEARCH',
-    description: 'Finds one text value inside another (case-insensitive)',
-    args: [
-      { name: 'search_for' },
-      { name: 'text_to_search' },
-      { name: 'starting_at', optional: true },
-    ],
-  },
-  {
-    name: 'TEXTJOIN',
-    description: 'Joins text values with a delimiter',
-    args: [
-      { name: 'delimiter' },
-      { name: 'ignore_empty' },
-      { name: 'text1' },
-      { name: 'text2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'LOWER',
-    description: 'Converts text to lowercase',
-    args: [{ name: 'text' }],
-  },
-  {
-    name: 'UPPER',
-    description: 'Converts text to uppercase',
-    args: [{ name: 'text' }],
-  },
-  {
-    name: 'PROPER',
-    description: 'Capitalizes each word in text',
-    args: [{ name: 'text' }],
-  },
-  {
-    name: 'SUBSTITUTE',
-    description: 'Replaces existing text with new text in a string',
-    args: [
-      { name: 'text' },
-      { name: 'search_for' },
-      { name: 'replace_with' },
-      { name: 'occurrence', optional: true },
-    ],
-  },
+const dateCatalog: Array<Omit<FunctionInfo, 'category'>> = [
   {
     name: 'TODAY',
     description: 'Returns the current date',
@@ -393,792 +48,575 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
   {
     name: 'DATE',
     description: 'Returns a date from year, month, and day values',
-    args: [{ name: 'year' }, { name: 'month' }, { name: 'day' }],
+    args: [
+      { name: 'year' },
+      { name: 'month' },
+      { name: 'day' },
+    ],
   },
   {
     name: 'TIME',
     description: 'Returns a time from hour, minute, and second values',
-    args: [{ name: 'hour' }, { name: 'minute' }, { name: 'second' }],
+    args: [
+      { name: 'hour' },
+      { name: 'minute' },
+      { name: 'second' },
+    ],
   },
   {
     name: 'DAYS',
     description: 'Returns the number of days between two dates',
-    args: [{ name: 'end_date' }, { name: 'start_date' }],
+    args: [
+      { name: 'end_date' },
+      { name: 'start_date' },
+    ],
   },
   {
     name: 'YEAR',
     description: 'Returns the year from a date',
-    args: [{ name: 'date' }],
+    args: [
+      { name: 'date' },
+    ],
   },
   {
     name: 'MONTH',
     description: 'Returns the month from a date (1-12)',
-    args: [{ name: 'date' }],
+    args: [
+      { name: 'date' },
+    ],
   },
   {
     name: 'DAY',
     description: 'Returns the day of the month from a date (1-31)',
-    args: [{ name: 'date' }],
+    args: [
+      { name: 'date' },
+    ],
   },
   {
     name: 'HOUR',
     description: 'Returns the hour from a date/time (0-23)',
-    args: [{ name: 'time' }],
+    args: [
+      { name: 'time' },
+    ],
   },
   {
     name: 'MINUTE',
     description: 'Returns the minute from a date/time (0-59)',
-    args: [{ name: 'time' }],
+    args: [
+      { name: 'time' },
+    ],
   },
   {
     name: 'SECOND',
     description: 'Returns the second from a date/time (0-59)',
-    args: [{ name: 'time' }],
+    args: [
+      { name: 'time' },
+    ],
   },
   {
     name: 'WEEKDAY',
     description: 'Returns day of the week as a number',
-    args: [{ name: 'date' }, { name: 'type', optional: true }],
-  },
-  {
-    name: 'ISBLANK',
-    description: 'Checks whether a value is blank',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ISNUMBER',
-    description: 'Checks whether a value is a number',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ISTEXT',
-    description: 'Checks whether a value is text',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ISERROR',
-    description: 'Checks whether a value is any error',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ISERR',
-    description: 'Checks whether a value is an error except #N/A',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ISNA',
-    description: 'Checks whether a value is the #N/A error',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ISLOGICAL',
-    description: 'Checks whether a value is boolean',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ISNONTEXT',
-    description: 'Checks whether a value is not text',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'TRUE',
-    description: 'Returns the boolean value TRUE',
-    args: [],
-  },
-  {
-    name: 'FALSE',
-    description: 'Returns the boolean value FALSE',
-    args: [],
-  },
-  {
-    name: 'IFERROR',
-    description: 'Returns a value if no error, otherwise returns an alternate value',
-    args: [{ name: 'value' }, { name: 'value_if_error' }],
-  },
-  {
-    name: 'IFNA',
-    description: 'Returns a value if no #N/A error, otherwise returns an alternate value',
-    args: [{ name: 'value' }, { name: 'value_if_na' }],
-  },
-  {
-    name: 'PI',
-    description: 'Returns the value of Pi',
-    args: [],
-  },
-  {
-    name: 'SIGN',
-    description: 'Returns the sign of a number (-1, 0, or 1)',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'EVEN',
-    description: 'Rounds a number up to the nearest even integer',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'ODD',
-    description: 'Rounds a number up to the nearest odd integer',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'EXP',
-    description: 'Returns Euler\'s number raised to a power',
-    args: [{ name: 'exponent' }],
-  },
-  {
-    name: 'LN',
-    description: 'Returns the natural logarithm of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'LOG',
-    description: 'Returns the logarithm of a number given a base',
-    args: [{ name: 'number' }, { name: 'base', optional: true }],
-  },
-  {
-    name: 'SIN',
-    description: 'Returns the sine of an angle in radians',
-    args: [{ name: 'angle' }],
-  },
-  {
-    name: 'COS',
-    description: 'Returns the cosine of an angle in radians',
-    args: [{ name: 'angle' }],
-  },
-  {
-    name: 'TAN',
-    description: 'Returns the tangent of an angle in radians',
-    args: [{ name: 'angle' }],
-  },
-  {
-    name: 'ASIN',
-    description: 'Returns the inverse sine of a value in radians',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ACOS',
-    description: 'Returns the inverse cosine of a value in radians',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ATAN',
-    description: 'Returns the inverse tangent of a value in radians',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ATAN2',
-    description: 'Returns the angle between the x-axis and a point',
-    args: [{ name: 'x' }, { name: 'y' }],
-  },
-  {
-    name: 'DEGREES',
-    description: 'Converts an angle from radians to degrees',
-    args: [{ name: 'angle' }],
-  },
-  {
-    name: 'RADIANS',
-    description: 'Converts an angle from degrees to radians',
-    args: [{ name: 'angle' }],
-  },
-  {
-    name: 'CEILING',
-    description: 'Rounds a number up to the nearest multiple of significance',
-    args: [{ name: 'number' }, { name: 'significance', optional: true }],
-  },
-  {
-    name: 'FLOOR',
-    description: 'Rounds a number down to the nearest multiple of significance',
-    args: [{ name: 'number' }, { name: 'significance', optional: true }],
-  },
-  {
-    name: 'TRUNC',
-    description: 'Truncates a number to a given number of decimal places',
-    args: [{ name: 'number' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'MROUND',
-    description: 'Rounds a number to the nearest specified multiple',
-    args: [{ name: 'number' }, { name: 'multiple' }],
-  },
-  {
-    name: 'EXACT',
-    description: 'Tests whether two strings are identical (case-sensitive)',
-    args: [{ name: 'text1' }, { name: 'text2' }],
-  },
-  {
-    name: 'REPLACE',
-    description: 'Replaces part of a text string with a different text string',
-    args: [{ name: 'old_text' }, { name: 'start_num' }, { name: 'num_chars' }, { name: 'new_text' }],
-  },
-  {
-    name: 'REPT',
-    description: 'Repeats text a given number of times',
-    args: [{ name: 'text' }, { name: 'number_times' }],
-  },
-  {
-    name: 'T',
-    description: 'Returns the text referred to by value',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'VALUE',
-    description: 'Converts a text string that represents a number to a number',
-    args: [{ name: 'text' }],
-  },
-  {
-    name: 'TEXT',
-    description: 'Formats a number and converts it to text',
-    args: [{ name: 'number' }, { name: 'format' }],
-  },
-  {
-    name: 'CHAR',
-    description: 'Returns the character specified by the code number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'CODE',
-    description: 'Returns a numeric code for the first character in a text string',
-    args: [{ name: 'text' }],
-  },
-  {
-    name: 'AVERAGEIF',
-    description: 'Returns the average of a range that meets a criterion',
     args: [
-      { name: 'criteria_range' },
-      { name: 'criterion' },
-      { name: 'average_range', optional: true },
+      { name: 'date' },
+      { name: 'type', optional: true },
     ],
-  },
-  {
-    name: 'AVERAGEIFS',
-    description: 'Returns the average of a range that meets multiple criteria',
-    args: [
-      { name: 'average_range' },
-      { name: 'criteria_range1' },
-      { name: 'criterion1' },
-      { name: 'criteria_range2', optional: true, repeating: true },
-      { name: 'criterion2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'LARGE',
-    description: 'Returns the nth largest value in a data set',
-    args: [{ name: 'data' }, { name: 'n' }],
-  },
-  {
-    name: 'SMALL',
-    description: 'Returns the nth smallest value in a data set',
-    args: [{ name: 'data' }, { name: 'n' }],
-  },
-  {
-    name: 'N',
-    description: 'Converts a value to a number',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'SUMPRODUCT',
-    description: 'Multiplies corresponding components and returns the sum',
-    args: [
-      { name: 'array1' },
-      { name: 'array2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'GCD',
-    description: 'Returns the greatest common divisor',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'LCM',
-    description: 'Returns the least common multiple',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'COMBIN',
-    description: 'Returns the number of combinations for a given number of items',
-    args: [{ name: 'n' }, { name: 'k' }],
-  },
-  {
-    name: 'FACT',
-    description: 'Returns the factorial of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'QUOTIENT',
-    description: 'Returns the integer portion of a division',
-    args: [{ name: 'numerator' }, { name: 'denominator' }],
-  },
-  {
-    name: 'XOR',
-    description: 'Returns TRUE if an odd number of arguments are TRUE',
-    args: [
-      { name: 'logical1' },
-      { name: 'logical2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'CHOOSE',
-    description: 'Returns a value from a list based on index',
-    args: [
-      { name: 'index' },
-      { name: 'value1' },
-      { name: 'value2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'TYPE',
-    description: 'Returns a number indicating the data type of a value',
-    args: [{ name: 'value' }],
   },
   {
     name: 'EDATE',
     description: 'Returns a date a specified number of months before or after another date',
-    args: [{ name: 'start_date' }, { name: 'months' }],
+    args: [
+      { name: 'start_date' },
+      { name: 'months' },
+    ],
   },
   {
     name: 'EOMONTH',
     description: 'Returns the last day of the month a specified number of months away',
-    args: [{ name: 'start_date' }, { name: 'months' }],
+    args: [
+      { name: 'start_date' },
+      { name: 'months' },
+    ],
   },
   {
     name: 'NETWORKDAYS',
     description: 'Returns the number of net working days between two dates',
-    args: [{ name: 'start_date' }, { name: 'end_date' }, { name: 'holidays', optional: true }],
+    args: [
+      { name: 'start_date' },
+      { name: 'end_date' },
+      { name: 'holidays', optional: true },
+    ],
   },
   {
     name: 'DATEVALUE',
     description: 'Converts a date string to a date value',
-    args: [{ name: 'date_string' }],
+    args: [
+      { name: 'date_string' },
+    ],
   },
   {
     name: 'TIMEVALUE',
     description: 'Returns the fraction of the day a time represents',
-    args: [{ name: 'time_string' }],
+    args: [
+      { name: 'time_string' },
+    ],
   },
   {
     name: 'DATEDIF',
     description: 'Calculates the number of days, months, or years between two dates',
-    args: [{ name: 'start_date' }, { name: 'end_date' }, { name: 'unit' }],
-  },
-  {
-    name: 'ROW',
-    description: 'Returns the row number of a reference',
-    args: [{ name: 'reference', optional: true }],
-  },
-  {
-    name: 'COLUMN',
-    description: 'Returns the column number of a reference',
-    args: [{ name: 'reference', optional: true }],
-  },
-  {
-    name: 'ROWS',
-    description: 'Returns the number of rows in a range',
-    args: [{ name: 'range' }],
-  },
-  {
-    name: 'COLUMNS',
-    description: 'Returns the number of columns in a range',
-    args: [{ name: 'range' }],
-  },
-  {
-    name: 'ADDRESS',
-    description: 'Returns a cell reference as text given row and column numbers',
     args: [
-      { name: 'row' },
-      { name: 'column' },
-      { name: 'abs_num', optional: true },
-      { name: 'a1', optional: true },
+      { name: 'start_date' },
+      { name: 'end_date' },
+      { name: 'unit' },
     ],
-  },
-  {
-    name: 'HYPERLINK',
-    description: 'Creates a hyperlink in a cell',
-    args: [{ name: 'url' }, { name: 'link_label', optional: true }],
-  },
-  {
-    name: 'MINIFS',
-    description: 'Returns the minimum value in a range that meets multiple criteria',
-    args: [
-      { name: 'min_range' },
-      { name: 'criteria_range1' },
-      { name: 'criterion1' },
-      { name: 'criteria_range2', optional: true, repeating: true },
-      { name: 'criterion2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'MAXIFS',
-    description: 'Returns the maximum value in a range that meets multiple criteria',
-    args: [
-      { name: 'max_range' },
-      { name: 'criteria_range1' },
-      { name: 'criterion1' },
-      { name: 'criteria_range2', optional: true, repeating: true },
-      { name: 'criterion2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'RANK',
-    description: 'Returns the rank of a value within a data set',
-    args: [
-      { name: 'value' },
-      { name: 'data' },
-      { name: 'order', optional: true },
-    ],
-  },
-  {
-    name: 'PERCENTILE',
-    description: 'Returns the k-th percentile of a data set',
-    args: [{ name: 'data' }, { name: 'k' }],
-  },
-  {
-    name: 'CLEAN',
-    description: 'Removes all non-printable characters from text',
-    args: [{ name: 'text' }],
-  },
-  {
-    name: 'NUMBERVALUE',
-    description: 'Converts text to a number in a locale-independent way',
-    args: [
-      { name: 'text' },
-      { name: 'decimal_separator', optional: true },
-      { name: 'group_separator', optional: true },
-    ],
-  },
-  {
-    name: 'STDEV',
-    description: 'Returns the sample standard deviation',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'STDEVP',
-    description: 'Returns the population standard deviation',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'VAR',
-    description: 'Returns the sample variance',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'VARP',
-    description: 'Returns the population variance',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'MODE',
-    description: 'Returns the most frequently occurring value',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'SUMSQ',
-    description: 'Returns the sum of the squares of the arguments',
-    args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'NA',
-    description: 'Returns the #N/A error value',
-    args: [],
-  },
-  {
-    name: 'QUARTILE',
-    description: 'Returns the quartile of a data set',
-    args: [{ name: 'data' }, { name: 'quart' }],
-  },
-  {
-    name: 'COUNTUNIQUE',
-    description: 'Counts the number of unique values in a list',
-    args: [
-      { name: 'value1' },
-      { name: 'value2', optional: true, repeating: true },
-    ],
-  },
-  {
-    name: 'FIXED',
-    description: 'Formats a number with a fixed number of decimal places',
-    args: [
-      { name: 'number' },
-      { name: 'decimals', optional: true },
-      { name: 'no_commas', optional: true },
-    ],
-  },
-  {
-    name: 'DOLLAR',
-    description: 'Formats a number as currency with a dollar sign',
-    args: [{ name: 'number' }, { name: 'decimals', optional: true }],
   },
   {
     name: 'WEEKNUM',
     description: 'Returns the week number of the year',
-    args: [{ name: 'date' }, { name: 'type', optional: true }],
+    args: [
+      { name: 'date' },
+      { name: 'type', optional: true },
+    ],
   },
   {
     name: 'ISOWEEKNUM',
     description: 'Returns the ISO week number of the year',
-    args: [{ name: 'date' }],
+    args: [
+      { name: 'date' },
+    ],
   },
   {
     name: 'WORKDAY',
     description: 'Returns a date that is a specified number of working days away',
-    args: [{ name: 'start_date' }, { name: 'days' }, { name: 'holidays', optional: true }],
+    args: [
+      { name: 'start_date' },
+      { name: 'days' },
+      { name: 'holidays', optional: true },
+    ],
   },
   {
     name: 'YEARFRAC',
     description: 'Returns the fraction of the year between two dates',
-    args: [{ name: 'start_date' }, { name: 'end_date' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'LOOKUP',
-    description: 'Searches a sorted range for a key',
     args: [
-      { name: 'search_key' },
-      { name: 'search_range' },
-      { name: 'result_range', optional: true },
+      { name: 'start_date' },
+      { name: 'end_date' },
+      { name: 'basis', optional: true },
     ],
   },
   {
-    name: 'INDIRECT',
-    description: 'Returns the reference specified by a text string',
-    args: [{ name: 'cell_reference' }, { name: 'is_A1_notation', optional: true }],
-  },
-  {
-    name: 'ERROR.TYPE',
-    description: 'Returns a number corresponding to the error type',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ISDATE',
-    description: 'Checks whether a value is a date',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'SPLIT',
-    description: 'Splits text around a delimiter',
+    name: 'DAYS360',
+    description: 'Returns the number of days between two dates using 360-day year',
     args: [
-      { name: 'text' },
-      { name: 'delimiter' },
-      { name: 'split_by_each', optional: true },
-      { name: 'remove_empty', optional: true },
+      { name: 'start_date' },
+      { name: 'end_date' },
+      { name: 'method', optional: true },
     ],
   },
   {
-    name: 'JOIN',
-    description: 'Joins values with a delimiter',
+    name: 'WORKDAY.INTL',
+    description: 'Returns a date that is a specified number of workdays with custom weekends',
     args: [
-      { name: 'delimiter' },
-      { name: 'value1' },
-      { name: 'value2', optional: true, repeating: true },
+      { name: 'start_date' },
+      { name: 'days' },
+      { name: 'weekend', optional: true },
+      { name: 'holidays', optional: true },
     ],
   },
   {
-    name: 'REGEXMATCH',
-    description: 'Returns whether text matches a regular expression',
-    args: [{ name: 'text' }, { name: 'regular_expression' }],
-  },
-  {
-    name: 'FORECAST',
-    description: 'Predicts a y-value for a given x using linear regression',
-    args: [{ name: 'x' }, { name: 'known_ys' }, { name: 'known_xs' }],
-  },
-  {
-    name: 'SLOPE',
-    description: 'Returns the slope of the linear regression line',
-    args: [{ name: 'known_ys' }, { name: 'known_xs' }],
-  },
-  {
-    name: 'INTERCEPT',
-    description: 'Returns the y-intercept of the linear regression line',
-    args: [{ name: 'known_ys' }, { name: 'known_xs' }],
-  },
-  {
-    name: 'CORREL',
-    description: 'Returns the Pearson correlation coefficient',
-    args: [{ name: 'data_y' }, { name: 'data_x' }],
-  },
-  {
-    name: 'XLOOKUP',
-    description: 'Searches a range for a match and returns a corresponding item',
+    name: 'NETWORKDAYS.INTL',
+    description: 'Returns the number of working days between two dates with custom weekends',
     args: [
-      { name: 'search_key' },
-      { name: 'lookup_range' },
-      { name: 'return_range' },
-      { name: 'if_not_found', optional: true },
-      { name: 'match_mode', optional: true },
-      { name: 'search_mode', optional: true },
+      { name: 'start_date' },
+      { name: 'end_date' },
+      { name: 'weekend', optional: true },
+      { name: 'holidays', optional: true },
     ],
   },
+];
+
+const engineeringCatalog: Array<Omit<FunctionInfo, 'category'>> = [
   {
-    name: 'OFFSET',
-    description: 'Returns a reference offset from a starting reference',
-    args: [
-      { name: 'reference' },
-      { name: 'rows' },
-      { name: 'cols' },
-      { name: 'height', optional: true },
-      { name: 'width', optional: true },
-    ],
-  },
-  {
-    name: 'ISEVEN',
-    description: 'Checks whether a number is even',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'ISODD',
-    description: 'Checks whether a number is odd',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'FACTDOUBLE',
-    description: 'Returns the double factorial of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'BASE',
-    description: 'Converts a number to text in another base',
-    args: [{ name: 'number' }, { name: 'base' }, { name: 'min_length', optional: true }],
-  },
-  {
-    name: 'DECIMAL',
-    description: 'Converts text from another base to a decimal number',
-    args: [{ name: 'text' }, { name: 'base' }],
-  },
-  {
-    name: 'SQRTPI',
-    description: 'Returns the square root of number * PI',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'SINH',
-    description: 'Returns the hyperbolic sine of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'COSH',
-    description: 'Returns the hyperbolic cosine of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'TANH',
-    description: 'Returns the hyperbolic tangent of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'ASINH',
-    description: 'Returns the inverse hyperbolic sine of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'ACOSH',
-    description: 'Returns the inverse hyperbolic cosine of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'ATANH',
-    description: 'Returns the inverse hyperbolic tangent of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'COT',
-    description: 'Returns the cotangent of an angle in radians',
-    args: [{ name: 'angle' }],
-  },
-  {
-    name: 'CSC',
-    description: 'Returns the cosecant of an angle in radians',
-    args: [{ name: 'angle' }],
-  },
-  {
-    name: 'SEC',
-    description: 'Returns the secant of an angle in radians',
-    args: [{ name: 'angle' }],
-  },
-  {
-    name: 'REGEXEXTRACT',
-    description: 'Extracts matching substrings using a regular expression',
-    args: [{ name: 'text' }, { name: 'regular_expression' }],
-  },
-  {
-    name: 'REGEXREPLACE',
-    description: 'Replaces text matching a regular expression',
-    args: [{ name: 'text' }, { name: 'regular_expression' }, { name: 'replacement' }],
-  },
-  {
-    name: 'UNICODE',
-    description: 'Returns the Unicode code point of the first character',
-    args: [{ name: 'text' }],
-  },
-  {
-    name: 'UNICHAR',
-    description: 'Returns the Unicode character for a code point',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'GEOMEAN',
-    description: 'Returns the geometric mean',
+    name: 'DELTA',
+    description: 'Tests whether two values are equal',
     args: [
       { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
+      { name: 'number2', optional: true },
     ],
   },
   {
-    name: 'HARMEAN',
-    description: 'Returns the harmonic mean',
+    name: 'GESTEP',
+    description: 'Tests whether a number is greater than or equal to a step value',
+    args: [
+      { name: 'number' },
+      { name: 'step', optional: true },
+    ],
+  },
+  {
+    name: 'ERF',
+    description: 'Returns the error function',
+    args: [
+      { name: 'lower_limit' },
+      { name: 'upper_limit', optional: true },
+    ],
+  },
+  {
+    name: 'ERFC',
+    description: 'Returns the complementary error function',
+    args: [
+      { name: 'x' },
+    ],
+  },
+  {
+    name: 'CONVERT',
+    description: 'Converts a number from one measurement unit to another',
+    args: [
+      { name: 'number' },
+      { name: 'from_unit' },
+      { name: 'to_unit' },
+    ],
+  },
+  {
+    name: 'BITAND',
+    description: 'Returns the bitwise AND of two numbers',
     args: [
       { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
+      { name: 'number2' },
     ],
   },
   {
-    name: 'AVEDEV',
-    description: 'Returns the average absolute deviation from the mean',
+    name: 'BITOR',
+    description: 'Returns the bitwise OR of two numbers',
     args: [
       { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
+      { name: 'number2' },
     ],
   },
   {
-    name: 'DEVSQ',
-    description: 'Returns the sum of squared deviations from the mean',
+    name: 'BITXOR',
+    description: 'Returns the bitwise XOR of two numbers',
     args: [
       { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
+      { name: 'number2' },
     ],
   },
   {
-    name: 'TRIMMEAN',
-    description: 'Returns the mean of the interior portion of a data set',
-    args: [{ name: 'data' }, { name: 'percent' }],
+    name: 'BITLSHIFT',
+    description: 'Shifts a number left by a specified number of bits',
+    args: [
+      { name: 'number' },
+      { name: 'shift_amount' },
+    ],
   },
   {
-    name: 'PERMUT',
-    description: 'Returns the number of permutations for a given number of objects',
-    args: [{ name: 'n' }, { name: 'k' }],
+    name: 'BITRSHIFT',
+    description: 'Shifts a number right by a specified number of bits',
+    args: [
+      { name: 'number' },
+      { name: 'shift_amount' },
+    ],
   },
+  {
+    name: 'HEX2DEC',
+    description: 'Converts a hexadecimal number to decimal',
+    args: [
+      { name: 'hex_string' },
+    ],
+  },
+  {
+    name: 'DEC2HEX',
+    description: 'Converts a decimal number to hexadecimal',
+    args: [
+      { name: 'number' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'BIN2DEC',
+    description: 'Converts a binary number to decimal',
+    args: [
+      { name: 'bin_string' },
+    ],
+  },
+  {
+    name: 'DEC2BIN',
+    description: 'Converts a decimal number to binary',
+    args: [
+      { name: 'number' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'OCT2DEC',
+    description: 'Converts an octal number to decimal',
+    args: [
+      { name: 'oct_string' },
+    ],
+  },
+  {
+    name: 'DEC2OCT',
+    description: 'Converts a decimal number to octal',
+    args: [
+      { name: 'number' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'COMPLEX',
+    description: 'Creates a complex number from real and imaginary parts',
+    args: [
+      { name: 'real' },
+      { name: 'imaginary' },
+      { name: 'suffix', optional: true },
+    ],
+  },
+  {
+    name: 'IMREAL',
+    description: 'Returns the real part of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMAGINARY',
+    description: 'Returns the imaginary part of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMABS',
+    description: 'Returns the absolute value (modulus) of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMSUM',
+    description: 'Returns the sum of complex numbers',
+    args: [
+      { name: 'complex1' },
+      { name: 'complex2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'IMSUB',
+    description: 'Returns the difference of two complex numbers',
+    args: [
+      { name: 'complex1' },
+      { name: 'complex2' },
+    ],
+  },
+  {
+    name: 'IMPRODUCT',
+    description: 'Returns the product of complex numbers',
+    args: [
+      { name: 'complex1' },
+      { name: 'complex2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'IMDIV',
+    description: 'Returns the quotient of two complex numbers',
+    args: [
+      { name: 'complex1' },
+      { name: 'complex2' },
+    ],
+  },
+  {
+    name: 'IMCONJUGATE',
+    description: 'Returns the complex conjugate of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMARGUMENT',
+    description: 'Returns the argument (angle) of a complex number in radians',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMPOWER',
+    description: 'Returns a complex number raised to a power',
+    args: [
+      { name: 'complex_number' },
+      { name: 'power' },
+    ],
+  },
+  {
+    name: 'IMSQRT',
+    description: 'Returns the square root of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMEXP',
+    description: 'Returns e raised to a complex power',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMLN',
+    description: 'Returns the natural logarithm of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMLOG2',
+    description: 'Returns the base-2 logarithm of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMLOG10',
+    description: 'Returns the base-10 logarithm of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMSIN',
+    description: 'Returns the sine of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMCOS',
+    description: 'Returns the cosine of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMTAN',
+    description: 'Returns the tangent of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMSINH',
+    description: 'Returns the hyperbolic sine of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMCOSH',
+    description: 'Returns the hyperbolic cosine of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMSEC',
+    description: 'Returns the secant of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMCSC',
+    description: 'Returns the cosecant of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'IMCOT',
+    description: 'Returns the cotangent of a complex number',
+    args: [
+      { name: 'complex_number' },
+    ],
+  },
+  {
+    name: 'HEX2BIN',
+    description: 'Converts a hexadecimal number to binary',
+    args: [
+      { name: 'hex_string' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'HEX2OCT',
+    description: 'Converts a hexadecimal number to octal',
+    args: [
+      { name: 'hex_string' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'BIN2HEX',
+    description: 'Converts a binary number to hexadecimal',
+    args: [
+      { name: 'bin_string' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'BIN2OCT',
+    description: 'Converts a binary number to octal',
+    args: [
+      { name: 'bin_string' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'OCT2HEX',
+    description: 'Converts an octal number to hexadecimal',
+    args: [
+      { name: 'oct_string' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'OCT2BIN',
+    description: 'Converts an octal number to binary',
+    args: [
+      { name: 'oct_string' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'BESSELJ',
+    description: 'Returns the Bessel function of the first kind Jn(x)',
+    args: [
+      { name: 'x' },
+      { name: 'n' },
+    ],
+  },
+  {
+    name: 'BESSELY',
+    description: 'Returns the Bessel function of the second kind Yn(x)',
+    args: [
+      { name: 'x' },
+      { name: 'n' },
+    ],
+  },
+  {
+    name: 'BESSELI',
+    description: 'Returns the modified Bessel function of the first kind In(x)',
+    args: [
+      { name: 'x' },
+      { name: 'n' },
+    ],
+  },
+  {
+    name: 'BESSELK',
+    description: 'Returns the modified Bessel function of the second kind Kn(x)',
+    args: [
+      { name: 'x' },
+      { name: 'n' },
+    ],
+  },
+];
+
+const financialCatalog: Array<Omit<FunctionInfo, 'category'>> = [
   {
     name: 'PMT',
     description: 'Returns the periodic payment for an annuity',
@@ -1259,12 +697,19 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
   {
     name: 'SLN',
     description: 'Returns the straight-line depreciation of an asset',
-    args: [{ name: 'cost' }, { name: 'salvage' }, { name: 'life' }],
+    args: [
+      { name: 'cost' },
+      { name: 'salvage' },
+      { name: 'life' },
+    ],
   },
   {
     name: 'EFFECT',
     description: 'Returns the effective annual interest rate',
-    args: [{ name: 'nominal_rate' }, { name: 'periods_per_year' }],
+    args: [
+      { name: 'nominal_rate' },
+      { name: 'periods_per_year' },
+    ],
   },
   {
     name: 'RATE',
@@ -1281,7 +726,10 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
   {
     name: 'IRR',
     description: 'Returns the internal rate of return for a series of cash flows',
-    args: [{ name: 'values' }, { name: 'guess', optional: true }],
+    args: [
+      { name: 'values' },
+      { name: 'guess', optional: true },
+    ],
   },
   {
     name: 'DB',
@@ -1308,7 +756,10 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
   {
     name: 'NOMINAL',
     description: 'Returns the nominal annual interest rate',
-    args: [{ name: 'effective_rate' }, { name: 'periods_per_year' }],
+    args: [
+      { name: 'effective_rate' },
+      { name: 'periods_per_year' },
+    ],
   },
   {
     name: 'CUMIPMT',
@@ -1332,6 +783,1921 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
       { name: 'start_period' },
       { name: 'end_period' },
       { name: 'type' },
+    ],
+  },
+  {
+    name: 'XNPV',
+    description: 'Returns net present value for irregular cash flows',
+    args: [
+      { name: 'rate' },
+      { name: 'values' },
+      { name: 'dates' },
+    ],
+  },
+  {
+    name: 'XIRR',
+    description: 'Returns internal rate of return for irregular cash flows',
+    args: [
+      { name: 'values' },
+      { name: 'dates' },
+      { name: 'guess', optional: true },
+    ],
+  },
+  {
+    name: 'SYD',
+    description: 'Returns the sum-of-years-digits depreciation',
+    args: [
+      { name: 'cost' },
+      { name: 'salvage' },
+      { name: 'life' },
+      { name: 'period' },
+    ],
+  },
+  {
+    name: 'MIRR',
+    description: 'Returns the modified internal rate of return',
+    args: [
+      { name: 'values' },
+      { name: 'finance_rate' },
+      { name: 'reinvest_rate' },
+    ],
+  },
+  {
+    name: 'TBILLEQ',
+    description: 'Returns the bond-equivalent yield for a T-bill',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'discount' },
+    ],
+  },
+  {
+    name: 'TBILLPRICE',
+    description: 'Returns the price per $100 for a T-bill',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'discount' },
+    ],
+  },
+  {
+    name: 'TBILLYIELD',
+    description: 'Returns the yield for a T-bill',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'price' },
+    ],
+  },
+  {
+    name: 'DOLLARDE',
+    description: 'Converts a fractional dollar price to a decimal price',
+    args: [
+      { name: 'fractional_dollar' },
+      { name: 'fraction' },
+    ],
+  },
+  {
+    name: 'DOLLARFR',
+    description: 'Converts a decimal dollar price to a fractional price',
+    args: [
+      { name: 'decimal_dollar' },
+      { name: 'fraction' },
+    ],
+  },
+  {
+    name: 'ACCRINT',
+    description: 'Returns the accrued interest for a security that pays periodic interest',
+    args: [
+      { name: 'issue' },
+      { name: 'first_interest' },
+      { name: 'settlement' },
+      { name: 'rate' },
+      { name: 'par' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'ACCRINTM',
+    description: 'Returns the accrued interest for a security that pays at maturity',
+    args: [
+      { name: 'issue' },
+      { name: 'settlement' },
+      { name: 'rate' },
+      { name: 'par' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'COUPDAYBS',
+    description: 'Returns the number of days from the coupon period start to settlement',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'COUPDAYS',
+    description: 'Returns the number of days in the coupon period containing settlement',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'COUPDAYSNC',
+    description: 'Returns the number of days from settlement to the next coupon date',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'COUPNCD',
+    description: 'Returns the next coupon date after settlement',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'COUPNUM',
+    description: 'Returns the number of coupons between settlement and maturity',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'COUPPCD',
+    description: 'Returns the previous coupon date before settlement',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'DISC',
+    description: 'Returns the discount rate for a security',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'price' },
+      { name: 'redemption' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'PRICEDISC',
+    description: 'Returns the price of a discounted security',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'discount' },
+      { name: 'redemption' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'YIELDDISC',
+    description: 'Returns the annual yield for a discounted security',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'price' },
+      { name: 'redemption' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'DURATION',
+    description: 'Returns the Macaulay duration of a security',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'coupon' },
+      { name: 'yield' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'MDURATION',
+    description: 'Returns the modified Macaulay duration of a security',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'coupon' },
+      { name: 'yield' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'RECEIVED',
+    description: 'Returns the amount received at maturity for a fully invested security',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'investment' },
+      { name: 'discount' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'INTRATE',
+    description: 'Returns the interest rate for a fully invested security',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'investment' },
+      { name: 'redemption' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'PRICE',
+    description: 'Returns the price per $100 face value of a coupon-paying security',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'rate' },
+      { name: 'yield' },
+      { name: 'redemption' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'YIELD',
+    description: 'Returns the yield on a coupon-paying security',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'rate' },
+      { name: 'price' },
+      { name: 'redemption' },
+      { name: 'frequency' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'PRICEMAT',
+    description: 'Returns the price of a security that pays at maturity',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'issue' },
+      { name: 'rate' },
+      { name: 'yield' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'YIELDMAT',
+    description: 'Returns the yield of a security that pays at maturity',
+    args: [
+      { name: 'settlement' },
+      { name: 'maturity' },
+      { name: 'issue' },
+      { name: 'rate' },
+      { name: 'price' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'AMORLINC',
+    description: 'Returns the depreciation for each accounting period (French linear)',
+    args: [
+      { name: 'cost' },
+      { name: 'purchase_date' },
+      { name: 'first_period' },
+      { name: 'salvage' },
+      { name: 'period' },
+      { name: 'rate' },
+      { name: 'basis', optional: true },
+    ],
+  },
+  {
+    name: 'ISPMT',
+    description: 'Returns the interest paid during a specific period of a loan',
+    args: [
+      { name: 'rate' },
+      { name: 'period' },
+      { name: 'nper' },
+      { name: 'pv' },
+    ],
+  },
+  {
+    name: 'FVSCHEDULE',
+    description: 'Returns the future value of a principal after applying a schedule of rates',
+    args: [
+      { name: 'principal' },
+      { name: 'schedule' },
+    ],
+  },
+  {
+    name: 'PDURATION',
+    description: 'Returns the number of periods for an investment to reach a specified value',
+    args: [
+      { name: 'rate' },
+      { name: 'pv' },
+      { name: 'fv' },
+    ],
+  },
+  {
+    name: 'RRI',
+    description: 'Returns the equivalent interest rate for the growth of an investment',
+    args: [
+      { name: 'nper' },
+      { name: 'pv' },
+      { name: 'fv' },
+    ],
+  },
+];
+
+const infoCatalog: Array<Omit<FunctionInfo, 'category'>> = [
+  {
+    name: 'ISBLANK',
+    description: 'Checks whether a value is blank',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ISNUMBER',
+    description: 'Checks whether a value is a number',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ISTEXT',
+    description: 'Checks whether a value is text',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ISERROR',
+    description: 'Checks whether a value is any error',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ISERR',
+    description: 'Checks whether a value is an error except #N/A',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ISNA',
+    description: 'Checks whether a value is the #N/A error',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ISLOGICAL',
+    description: 'Checks whether a value is boolean',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ISNONTEXT',
+    description: 'Checks whether a value is not text',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'N',
+    description: 'Converts a value to a number',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'TYPE',
+    description: 'Returns a number indicating the data type of a value',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'NA',
+    description: 'Returns the #N/A error value',
+    args: [],
+  },
+  {
+    name: 'ERROR.TYPE',
+    description: 'Returns a number corresponding to the error type',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ISDATE',
+    description: 'Checks whether a value is a date',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ISURL',
+    description: 'Returns TRUE if a value is a valid URL',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ISFORMULA',
+    description: 'Returns TRUE if a cell contains a formula',
+    args: [
+      { name: 'cell' },
+    ],
+  },
+  {
+    name: 'FORMULATEXT',
+    description: 'Returns the formula of a cell as a string',
+    args: [
+      { name: 'cell' },
+    ],
+  },
+  {
+    name: 'ISREF',
+    description: 'Returns TRUE if the value is a reference',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'SHEET',
+    description: 'Returns the sheet number of a reference',
+    args: [
+      { name: 'value', optional: true },
+    ],
+  },
+  {
+    name: 'SHEETS',
+    description: 'Returns the number of sheets in a reference',
+    args: [
+      { name: 'reference', optional: true },
+    ],
+  },
+  {
+    name: 'AREAS',
+    description: 'Returns the number of areas in a reference',
+    args: [
+      { name: 'reference' },
+    ],
+  },
+  {
+    name: 'CELL',
+    description: 'Returns information about a cell',
+    args: [
+      { name: 'info_type' },
+      { name: 'reference', optional: true },
+    ],
+  },
+];
+
+const logicalCatalog: Array<Omit<FunctionInfo, 'category'>> = [
+  {
+    name: 'IF',
+    description: 'Returns one value if true and another if false',
+    args: [
+      { name: 'condition' },
+      { name: 'value_if_true' },
+      { name: 'value_if_false', optional: true },
+    ],
+  },
+  {
+    name: 'IFS',
+    description: 'Returns the first value whose condition is true',
+    args: [
+      { name: 'condition1' },
+      { name: 'value1' },
+      { name: 'condition2', optional: true, repeating: true },
+      { name: 'value2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'SWITCH',
+    description: 'Matches an expression against case/value pairs',
+    args: [
+      { name: 'expression' },
+      { name: 'case1' },
+      { name: 'value1' },
+      { name: 'case2_or_default', optional: true, repeating: true },
+      { name: 'value2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'AND',
+    description: 'Returns TRUE if all arguments are true',
+    args: [
+      { name: 'logical1' },
+      { name: 'logical2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'OR',
+    description: 'Returns TRUE if any argument is true',
+    args: [
+      { name: 'logical1' },
+      { name: 'logical2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'NOT',
+    description: 'Returns the opposite of a logical value',
+    args: [
+      { name: 'logical' },
+    ],
+  },
+  {
+    name: 'TRUE',
+    description: 'Returns the boolean value TRUE',
+    args: [],
+  },
+  {
+    name: 'FALSE',
+    description: 'Returns the boolean value FALSE',
+    args: [],
+  },
+  {
+    name: 'IFERROR',
+    description: 'Returns a value if no error, otherwise returns an alternate value',
+    args: [
+      { name: 'value' },
+      { name: 'value_if_error' },
+    ],
+  },
+  {
+    name: 'IFNA',
+    description: 'Returns a value if no #N/A error, otherwise returns an alternate value',
+    args: [
+      { name: 'value' },
+      { name: 'value_if_na' },
+    ],
+  },
+  {
+    name: 'XOR',
+    description: 'Returns TRUE if an odd number of arguments are TRUE',
+    args: [
+      { name: 'logical1' },
+      { name: 'logical2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'CHOOSE',
+    description: 'Returns a value from a list based on index',
+    args: [
+      { name: 'index' },
+      { name: 'value1' },
+      { name: 'value2', optional: true, repeating: true },
+    ],
+  },
+];
+
+const lookupCatalog: Array<Omit<FunctionInfo, 'category'>> = [
+  {
+    name: 'MATCH',
+    description: 'Returns the position of an item in a one-dimensional range',
+    args: [
+      { name: 'search_key' },
+      { name: 'range' },
+      { name: 'search_type', optional: true },
+    ],
+  },
+  {
+    name: 'INDEX',
+    description: 'Returns the value at a given row and column of a range',
+    args: [
+      { name: 'reference' },
+      { name: 'row', optional: true },
+      { name: 'column', optional: true },
+    ],
+  },
+  {
+    name: 'VLOOKUP',
+    description: 'Looks up a value in the first column of a range',
+    args: [
+      { name: 'search_key' },
+      { name: 'range' },
+      { name: 'index' },
+      { name: 'is_sorted', optional: true },
+    ],
+  },
+  {
+    name: 'HLOOKUP',
+    description: 'Looks up a value in the first row of a range',
+    args: [
+      { name: 'search_key' },
+      { name: 'range' },
+      { name: 'index' },
+      { name: 'is_sorted', optional: true },
+    ],
+  },
+  {
+    name: 'ROW',
+    description: 'Returns the row number of a reference',
+    args: [
+      { name: 'reference', optional: true },
+    ],
+  },
+  {
+    name: 'COLUMN',
+    description: 'Returns the column number of a reference',
+    args: [
+      { name: 'reference', optional: true },
+    ],
+  },
+  {
+    name: 'ROWS',
+    description: 'Returns the number of rows in a range',
+    args: [
+      { name: 'range' },
+    ],
+  },
+  {
+    name: 'COLUMNS',
+    description: 'Returns the number of columns in a range',
+    args: [
+      { name: 'range' },
+    ],
+  },
+  {
+    name: 'ADDRESS',
+    description: 'Returns a cell reference as text given row and column numbers',
+    args: [
+      { name: 'row' },
+      { name: 'column' },
+      { name: 'abs_num', optional: true },
+      { name: 'a1', optional: true },
+    ],
+  },
+  {
+    name: 'HYPERLINK',
+    description: 'Creates a hyperlink in a cell',
+    args: [
+      { name: 'url' },
+      { name: 'link_label', optional: true },
+    ],
+  },
+  {
+    name: 'LOOKUP',
+    description: 'Searches a sorted range for a key',
+    args: [
+      { name: 'search_key' },
+      { name: 'search_range' },
+      { name: 'result_range', optional: true },
+    ],
+  },
+  {
+    name: 'INDIRECT',
+    description: 'Returns the reference specified by a text string',
+    args: [
+      { name: 'cell_reference' },
+      { name: 'is_A1_notation', optional: true },
+    ],
+  },
+  {
+    name: 'XLOOKUP',
+    description: 'Searches a range for a match and returns a corresponding item',
+    args: [
+      { name: 'search_key' },
+      { name: 'lookup_range' },
+      { name: 'return_range' },
+      { name: 'if_not_found', optional: true },
+      { name: 'match_mode', optional: true },
+      { name: 'search_mode', optional: true },
+    ],
+  },
+  {
+    name: 'OFFSET',
+    description: 'Returns a reference offset from a starting reference',
+    args: [
+      { name: 'reference' },
+      { name: 'rows' },
+      { name: 'cols' },
+      { name: 'height', optional: true },
+      { name: 'width', optional: true },
+    ],
+  },
+  {
+    name: 'SORT',
+    description: 'Sorts a range of data',
+    args: [
+      { name: 'range' },
+      { name: 'sort_index', optional: true },
+      { name: 'sort_order', optional: true },
+    ],
+  },
+  {
+    name: 'FLATTEN',
+    description: 'Flattens a range into a single column',
+    args: [
+      { name: 'range' },
+    ],
+  },
+  {
+    name: 'TRANSPOSE',
+    description: 'Transposes the rows and columns of a range',
+    args: [
+      { name: 'range' },
+    ],
+  },
+  {
+    name: 'XMATCH',
+    description: 'Returns the relative position of a value in an array',
+    args: [
+      { name: 'lookup_value' },
+      { name: 'lookup_array' },
+      { name: 'match_mode', optional: true },
+      { name: 'search_mode', optional: true },
+    ],
+  },
+  {
+    name: 'TOCOL',
+    description: 'Transforms an array into a single column',
+    args: [
+      { name: 'array' },
+      { name: 'ignore', optional: true },
+      { name: 'scan_by_column', optional: true },
+    ],
+  },
+  {
+    name: 'TOROW',
+    description: 'Transforms an array into a single row',
+    args: [
+      { name: 'array' },
+      { name: 'ignore', optional: true },
+      { name: 'scan_by_column', optional: true },
+    ],
+  },
+  {
+    name: 'CHOOSEROWS',
+    description: 'Returns specified rows from an array',
+    args: [
+      { name: 'array' },
+      { name: 'row_num1' },
+      { name: 'row_num2', optional: true },
+    ],
+  },
+  {
+    name: 'CHOOSECOLS',
+    description: 'Returns specified columns from an array',
+    args: [
+      { name: 'array' },
+      { name: 'col_num1' },
+      { name: 'col_num2', optional: true },
+    ],
+  },
+  {
+    name: 'TAKE',
+    description: 'Returns rows or columns from the start or end of an array',
+    args: [
+      { name: 'array' },
+      { name: 'rows' },
+      { name: 'columns', optional: true },
+    ],
+  },
+  {
+    name: 'DROP',
+    description: 'Removes rows or columns from the start or end of an array',
+    args: [
+      { name: 'array' },
+      { name: 'rows' },
+      { name: 'columns', optional: true },
+    ],
+  },
+  {
+    name: 'HSTACK',
+    description: 'Appends arrays horizontally',
+    args: [
+      { name: 'range1' },
+      { name: 'range2', optional: true },
+    ],
+  },
+  {
+    name: 'VSTACK',
+    description: 'Appends arrays vertically',
+    args: [
+      { name: 'range1' },
+      { name: 'range2', optional: true },
+    ],
+  },
+  {
+    name: 'SORTBY',
+    description: 'Sorts a range by another range',
+    args: [
+      { name: 'array' },
+      { name: 'by_array' },
+      { name: 'sort_order', optional: true },
+    ],
+  },
+  {
+    name: 'WRAPCOLS',
+    description: 'Wraps a row or column of values into columns',
+    args: [
+      { name: 'vector' },
+      { name: 'wrap_count' },
+      { name: 'pad_with', optional: true },
+    ],
+  },
+  {
+    name: 'WRAPROWS',
+    description: 'Wraps a row or column of values into rows',
+    args: [
+      { name: 'vector' },
+      { name: 'wrap_count' },
+      { name: 'pad_with', optional: true },
+    ],
+  },
+  {
+    name: 'FILTER',
+    description: 'Filters an array based on a boolean array',
+    args: [
+      { name: 'array' },
+      { name: 'include' },
+      { name: 'if_empty', optional: true },
+    ],
+  },
+  {
+    name: 'EXPAND',
+    description: 'Expands an array to specified dimensions',
+    args: [
+      { name: 'array' },
+      { name: 'rows' },
+      { name: 'columns', optional: true },
+      { name: 'pad_with', optional: true },
+    ],
+  },
+];
+
+const mathCatalog: Array<Omit<FunctionInfo, 'category'>> = [
+  {
+    name: 'SUM',
+    description: 'Returns the sum of a series of numbers',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'ABS',
+    description: 'Returns the absolute value of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'ROUND',
+    description: 'Rounds a number to a certain number of decimal places',
+    args: [
+      { name: 'value' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'ROUNDUP',
+    description: 'Rounds a number away from zero',
+    args: [
+      { name: 'value' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'ROUNDDOWN',
+    description: 'Rounds a number toward zero',
+    args: [
+      { name: 'value' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'INT',
+    description: 'Rounds a number down to the nearest integer',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'MOD',
+    description: 'Returns the remainder after division',
+    args: [
+      { name: 'dividend' },
+      { name: 'divisor' },
+    ],
+  },
+  {
+    name: 'SQRT',
+    description: 'Returns the positive square root of a number',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'POWER',
+    description: 'Returns a number raised to a power',
+    args: [
+      { name: 'base' },
+      { name: 'exponent' },
+    ],
+  },
+  {
+    name: 'PRODUCT',
+    description: 'Multiplies a series of numbers',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'RAND',
+    description: 'Returns a random number between 0 and 1',
+    args: [],
+  },
+  {
+    name: 'RANDBETWEEN',
+    description: 'Returns a random integer between two values',
+    args: [
+      { name: 'low' },
+      { name: 'high' },
+    ],
+  },
+  {
+    name: 'COUNTBLANK',
+    description: 'Counts empty cells',
+    args: [
+      { name: 'value1' },
+      { name: 'value2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'COUNTIF',
+    description: 'Counts values in a range that meet a criterion',
+    args: [
+      { name: 'range' },
+      { name: 'criterion' },
+    ],
+  },
+  {
+    name: 'SUMIF',
+    description: 'Sums values in a range that meet a criterion',
+    args: [
+      { name: 'range' },
+      { name: 'criterion' },
+      { name: 'sum_range', optional: true },
+    ],
+  },
+  {
+    name: 'COUNTIFS',
+    description: 'Counts values that meet multiple criteria',
+    args: [
+      { name: 'criteria_range1' },
+      { name: 'criterion1' },
+      { name: 'criteria_range2', optional: true, repeating: true },
+      { name: 'criterion2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'SUMIFS',
+    description: 'Sums values that meet multiple criteria',
+    args: [
+      { name: 'sum_range' },
+      { name: 'criteria_range1' },
+      { name: 'criterion1' },
+      { name: 'criteria_range2', optional: true, repeating: true },
+      { name: 'criterion2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'PI',
+    description: 'Returns the value of Pi',
+    args: [],
+  },
+  {
+    name: 'SIGN',
+    description: 'Returns the sign of a number (-1, 0, or 1)',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'EVEN',
+    description: 'Rounds a number up to the nearest even integer',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'ODD',
+    description: 'Rounds a number up to the nearest odd integer',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'EXP',
+    description: 'Returns Euler\'s number raised to a power',
+    args: [
+      { name: 'exponent' },
+    ],
+  },
+  {
+    name: 'LN',
+    description: 'Returns the natural logarithm of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'LOG',
+    description: 'Returns the logarithm of a number given a base',
+    args: [
+      { name: 'number' },
+      { name: 'base', optional: true },
+    ],
+  },
+  {
+    name: 'SIN',
+    description: 'Returns the sine of an angle in radians',
+    args: [
+      { name: 'angle' },
+    ],
+  },
+  {
+    name: 'COS',
+    description: 'Returns the cosine of an angle in radians',
+    args: [
+      { name: 'angle' },
+    ],
+  },
+  {
+    name: 'TAN',
+    description: 'Returns the tangent of an angle in radians',
+    args: [
+      { name: 'angle' },
+    ],
+  },
+  {
+    name: 'ASIN',
+    description: 'Returns the inverse sine of a value in radians',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ACOS',
+    description: 'Returns the inverse cosine of a value in radians',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ATAN',
+    description: 'Returns the inverse tangent of a value in radians',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'ATAN2',
+    description: 'Returns the angle between the x-axis and a point',
+    args: [
+      { name: 'x' },
+      { name: 'y' },
+    ],
+  },
+  {
+    name: 'DEGREES',
+    description: 'Converts an angle from radians to degrees',
+    args: [
+      { name: 'angle' },
+    ],
+  },
+  {
+    name: 'RADIANS',
+    description: 'Converts an angle from degrees to radians',
+    args: [
+      { name: 'angle' },
+    ],
+  },
+  {
+    name: 'CEILING',
+    description: 'Rounds a number up to the nearest multiple of significance',
+    args: [
+      { name: 'number' },
+      { name: 'significance', optional: true },
+    ],
+  },
+  {
+    name: 'FLOOR',
+    description: 'Rounds a number down to the nearest multiple of significance',
+    args: [
+      { name: 'number' },
+      { name: 'significance', optional: true },
+    ],
+  },
+  {
+    name: 'TRUNC',
+    description: 'Truncates a number to a given number of decimal places',
+    args: [
+      { name: 'number' },
+      { name: 'places', optional: true },
+    ],
+  },
+  {
+    name: 'MROUND',
+    description: 'Rounds a number to the nearest specified multiple',
+    args: [
+      { name: 'number' },
+      { name: 'multiple' },
+    ],
+  },
+  {
+    name: 'SUMPRODUCT',
+    description: 'Multiplies corresponding components and returns the sum',
+    args: [
+      { name: 'array1' },
+      { name: 'array2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'GCD',
+    description: 'Returns the greatest common divisor',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'LCM',
+    description: 'Returns the least common multiple',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'COMBIN',
+    description: 'Returns the number of combinations for a given number of items',
+    args: [
+      { name: 'n' },
+      { name: 'k' },
+    ],
+  },
+  {
+    name: 'FACT',
+    description: 'Returns the factorial of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'QUOTIENT',
+    description: 'Returns the integer portion of a division',
+    args: [
+      { name: 'numerator' },
+      { name: 'denominator' },
+    ],
+  },
+  {
+    name: 'SUMSQ',
+    description: 'Returns the sum of the squares of the arguments',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'ISEVEN',
+    description: 'Checks whether a number is even',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'ISODD',
+    description: 'Checks whether a number is odd',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'FACTDOUBLE',
+    description: 'Returns the double factorial of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'BASE',
+    description: 'Converts a number to text in another base',
+    args: [
+      { name: 'number' },
+      { name: 'base' },
+      { name: 'min_length', optional: true },
+    ],
+  },
+  {
+    name: 'DECIMAL',
+    description: 'Converts text from another base to a decimal number',
+    args: [
+      { name: 'text' },
+      { name: 'base' },
+    ],
+  },
+  {
+    name: 'SQRTPI',
+    description: 'Returns the square root of number * PI',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'SINH',
+    description: 'Returns the hyperbolic sine of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'COSH',
+    description: 'Returns the hyperbolic cosine of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'TANH',
+    description: 'Returns the hyperbolic tangent of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'ASINH',
+    description: 'Returns the inverse hyperbolic sine of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'ACOSH',
+    description: 'Returns the inverse hyperbolic cosine of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'ATANH',
+    description: 'Returns the inverse hyperbolic tangent of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'COT',
+    description: 'Returns the cotangent of an angle in radians',
+    args: [
+      { name: 'angle' },
+    ],
+  },
+  {
+    name: 'CSC',
+    description: 'Returns the cosecant of an angle in radians',
+    args: [
+      { name: 'angle' },
+    ],
+  },
+  {
+    name: 'SEC',
+    description: 'Returns the secant of an angle in radians',
+    args: [
+      { name: 'angle' },
+    ],
+  },
+  {
+    name: 'ARABIC',
+    description: 'Converts a Roman numeral to a number',
+    args: [
+      { name: 'roman_numeral' },
+    ],
+  },
+  {
+    name: 'ROMAN',
+    description: 'Converts a number to Roman numeral text',
+    args: [
+      { name: 'number' },
+      { name: 'form', optional: true },
+    ],
+  },
+  {
+    name: 'MULTINOMIAL',
+    description: 'Returns the multinomial coefficient',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'SERIESSUM',
+    description: 'Returns the sum of a power series',
+    args: [
+      { name: 'x' },
+      { name: 'n' },
+      { name: 'm' },
+      { name: 'coefficients' },
+    ],
+  },
+  {
+    name: 'CEILING.MATH',
+    description: 'Rounds a number up to the nearest integer or multiple of significance',
+    args: [
+      { name: 'number' },
+      { name: 'significance', optional: true },
+      { name: 'mode', optional: true },
+    ],
+  },
+  {
+    name: 'FLOOR.MATH',
+    description: 'Rounds a number down to the nearest integer or multiple of significance',
+    args: [
+      { name: 'number' },
+      { name: 'significance', optional: true },
+      { name: 'mode', optional: true },
+    ],
+  },
+  {
+    name: 'CEILING.PRECISE',
+    description: 'Rounds a number up to the nearest multiple of significance, ignoring sign',
+    args: [
+      { name: 'number' },
+      { name: 'significance', optional: true },
+    ],
+  },
+  {
+    name: 'FLOOR.PRECISE',
+    description: 'Rounds a number down to the nearest multiple of significance, ignoring sign',
+    args: [
+      { name: 'number' },
+      { name: 'significance', optional: true },
+    ],
+  },
+  {
+    name: 'SUMX2MY2',
+    description: 'Returns the sum of differences of squares of corresponding values',
+    args: [
+      { name: 'array_x' },
+      { name: 'array_y' },
+    ],
+  },
+  {
+    name: 'SUMX2PY2',
+    description: 'Returns the sum of sums of squares of corresponding values',
+    args: [
+      { name: 'array_x' },
+      { name: 'array_y' },
+    ],
+  },
+  {
+    name: 'SUMXMY2',
+    description: 'Returns the sum of squares of differences of corresponding values',
+    args: [
+      { name: 'array_x' },
+      { name: 'array_y' },
+    ],
+  },
+  {
+    name: 'SEQUENCE',
+    description: 'Generates a sequence of numbers',
+    args: [
+      { name: 'rows' },
+      { name: 'columns', optional: true },
+      { name: 'start', optional: true },
+      { name: 'step', optional: true },
+    ],
+  },
+  {
+    name: 'RANDARRAY',
+    description: 'Generates an array of random numbers',
+    args: [
+      { name: 'rows', optional: true },
+      { name: 'columns', optional: true },
+      { name: 'min', optional: true },
+      { name: 'max', optional: true },
+      { name: 'whole_number', optional: true },
+    ],
+  },
+  {
+    name: 'SUBTOTAL',
+    description: 'Returns a subtotal using a specified aggregate function',
+    args: [
+      { name: 'function_num' },
+      { name: 'ref1' },
+      { name: 'ref2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'MDETERM',
+    description: 'Returns the determinant of a square matrix',
+    args: [
+      { name: 'square_matrix' },
+    ],
+  },
+  {
+    name: 'COMBINA',
+    description: 'Returns the number of combinations with repetition',
+    args: [
+      { name: 'n' },
+      { name: 'k' },
+    ],
+  },
+  {
+    name: 'MMULT',
+    description: 'Returns the matrix product of two arrays',
+    args: [
+      { name: 'array1' },
+      { name: 'array2' },
+    ],
+  },
+  {
+    name: 'MINVERSE',
+    description: 'Returns the inverse matrix of a square array',
+    args: [
+      { name: 'array' },
+    ],
+  },
+  {
+    name: 'ISO.CEILING',
+    description: 'Rounds a number up to the nearest integer or multiple of significance',
+    args: [
+      { name: 'number' },
+      { name: 'significance', optional: true },
+    ],
+  },
+  {
+    name: 'SECH',
+    description: 'Returns the hyperbolic secant of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'CSCH',
+    description: 'Returns the hyperbolic cosecant of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'COTH',
+    description: 'Returns the hyperbolic cotangent of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'ACOT',
+    description: 'Returns the arccotangent of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'ACOTH',
+    description: 'Returns the inverse hyperbolic cotangent of a number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'MUNIT',
+    description: 'Returns the identity matrix of the specified dimension',
+    args: [
+      { name: 'dimension' },
+    ],
+  },
+];
+
+const operatorCatalog: Array<Omit<FunctionInfo, 'category'>> = [
+  {
+    name: 'CONCAT',
+    description: 'Joins text values into one string',
+    args: [
+      { name: 'text1' },
+      { name: 'text2' },
+      { name: 'text3', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'UNIQUE',
+    description: 'Returns unique values from a range',
+    args: [
+      { name: 'range' },
+    ],
+  },
+  {
+    name: 'ADD',
+    description: 'Returns the sum of two numbers',
+    args: [
+      { name: 'value1' },
+      { name: 'value2' },
+    ],
+  },
+  {
+    name: 'MINUS',
+    description: 'Returns the difference of two numbers',
+    args: [
+      { name: 'value1' },
+      { name: 'value2' },
+    ],
+  },
+  {
+    name: 'MULTIPLY',
+    description: 'Returns the product of two numbers',
+    args: [
+      { name: 'factor1' },
+      { name: 'factor2' },
+    ],
+  },
+  {
+    name: 'DIVIDE',
+    description: 'Returns the result of dividing one number by another',
+    args: [
+      { name: 'dividend' },
+      { name: 'divisor' },
+    ],
+  },
+  {
+    name: 'POW',
+    description: 'Returns the result of raising a number to a power',
+    args: [
+      { name: 'base' },
+      { name: 'exponent' },
+    ],
+  },
+  {
+    name: 'UMINUS',
+    description: 'Returns the negation of a number',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'UPLUS',
+    description: 'Returns the unary positive of a number',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'UNARY_PERCENT',
+    description: 'Returns a value interpreted as a percentage',
+    args: [
+      { name: 'percentage' },
+    ],
+  },
+  {
+    name: 'EQ',
+    description: 'Returns TRUE if two values are equal',
+    args: [
+      { name: 'value1' },
+      { name: 'value2' },
+    ],
+  },
+  {
+    name: 'NE',
+    description: 'Returns TRUE if two values are not equal',
+    args: [
+      { name: 'value1' },
+      { name: 'value2' },
+    ],
+  },
+  {
+    name: 'LT',
+    description: 'Returns TRUE if the first value is less than the second',
+    args: [
+      { name: 'value1' },
+      { name: 'value2' },
+    ],
+  },
+  {
+    name: 'LTE',
+    description: 'Returns TRUE if the first value is less than or equal to the second',
+    args: [
+      { name: 'value1' },
+      { name: 'value2' },
+    ],
+  },
+  {
+    name: 'GT',
+    description: 'Returns TRUE if the first value is greater than the second',
+    args: [
+      { name: 'value1' },
+      { name: 'value2' },
+    ],
+  },
+  {
+    name: 'GTE',
+    description: 'Returns TRUE if the first value is greater than or equal to the second',
+    args: [
+      { name: 'value1' },
+      { name: 'value2' },
+    ],
+  },
+  {
+    name: 'ISBETWEEN',
+    description: 'Returns TRUE if a value is between two values (inclusive by default)',
+    args: [
+      { name: 'value_to_compare' },
+      { name: 'lower_value' },
+      { name: 'upper_value' },
+      { name: 'lower_value_is_inclusive', optional: true },
+      { name: 'upper_value_is_inclusive', optional: true },
+    ],
+  },
+];
+
+const statisticalCatalog: Array<Omit<FunctionInfo, 'category'>> = [
+  {
+    name: 'MEDIAN',
+    description: 'Returns the middle number in a series',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'AVERAGE',
+    description: 'Returns the average of a series of numbers',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'MIN',
+    description: 'Returns the smallest value in a set of numbers',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'MAX',
+    description: 'Returns the largest value in a set of numbers',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'COUNT',
+    description: 'Counts the number of numeric values',
+    args: [
+      { name: 'value1' },
+      { name: 'value2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'COUNTA',
+    description: 'Counts the number of non-empty values',
+    args: [
+      { name: 'value1' },
+      { name: 'value2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'AVERAGEIF',
+    description: 'Returns the average of a range that meets a criterion',
+    args: [
+      { name: 'criteria_range' },
+      { name: 'criterion' },
+      { name: 'average_range', optional: true },
+    ],
+  },
+  {
+    name: 'AVERAGEIFS',
+    description: 'Returns the average of a range that meets multiple criteria',
+    args: [
+      { name: 'average_range' },
+      { name: 'criteria_range1' },
+      { name: 'criterion1' },
+      { name: 'criteria_range2', optional: true, repeating: true },
+      { name: 'criterion2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'LARGE',
+    description: 'Returns the nth largest value in a data set',
+    args: [
+      { name: 'data' },
+      { name: 'n' },
+    ],
+  },
+  {
+    name: 'SMALL',
+    description: 'Returns the nth smallest value in a data set',
+    args: [
+      { name: 'data' },
+      { name: 'n' },
+    ],
+  },
+  {
+    name: 'MINIFS',
+    description: 'Returns the minimum value in a range that meets multiple criteria',
+    args: [
+      { name: 'min_range' },
+      { name: 'criteria_range1' },
+      { name: 'criterion1' },
+      { name: 'criteria_range2', optional: true, repeating: true },
+      { name: 'criterion2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'MAXIFS',
+    description: 'Returns the maximum value in a range that meets multiple criteria',
+    args: [
+      { name: 'max_range' },
+      { name: 'criteria_range1' },
+      { name: 'criterion1' },
+      { name: 'criteria_range2', optional: true, repeating: true },
+      { name: 'criterion2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'RANK',
+    description: 'Returns the rank of a value within a data set',
+    args: [
+      { name: 'value' },
+      { name: 'data' },
+      { name: 'order', optional: true },
+    ],
+  },
+  {
+    name: 'PERCENTILE',
+    description: 'Returns the k-th percentile of a data set',
+    args: [
+      { name: 'data' },
+      { name: 'k' },
+    ],
+  },
+  {
+    name: 'STDEV',
+    description: 'Returns the sample standard deviation',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'STDEVP',
+    description: 'Returns the population standard deviation',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'VAR',
+    description: 'Returns the sample variance',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'VARP',
+    description: 'Returns the population variance',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'MODE',
+    description: 'Returns the most frequently occurring value',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'QUARTILE',
+    description: 'Returns the quartile of a data set',
+    args: [
+      { name: 'data' },
+      { name: 'quart' },
+    ],
+  },
+  {
+    name: 'COUNTUNIQUE',
+    description: 'Counts the number of unique values in a list',
+    args: [
+      { name: 'value1' },
+      { name: 'value2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'FORECAST',
+    description: 'Predicts a y-value for a given x using linear regression',
+    args: [
+      { name: 'x' },
+      { name: 'known_ys' },
+      { name: 'known_xs' },
+    ],
+  },
+  {
+    name: 'SLOPE',
+    description: 'Returns the slope of the linear regression line',
+    args: [
+      { name: 'known_ys' },
+      { name: 'known_xs' },
+    ],
+  },
+  {
+    name: 'INTERCEPT',
+    description: 'Returns the y-intercept of the linear regression line',
+    args: [
+      { name: 'known_ys' },
+      { name: 'known_xs' },
+    ],
+  },
+  {
+    name: 'CORREL',
+    description: 'Returns the Pearson correlation coefficient',
+    args: [
+      { name: 'data_y' },
+      { name: 'data_x' },
+    ],
+  },
+  {
+    name: 'GEOMEAN',
+    description: 'Returns the geometric mean',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'HARMEAN',
+    description: 'Returns the harmonic mean',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'AVEDEV',
+    description: 'Returns the average absolute deviation from the mean',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'DEVSQ',
+    description: 'Returns the sum of squared deviations from the mean',
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'TRIMMEAN',
+    description: 'Returns the mean of the interior portion of a data set',
+    args: [
+      { name: 'data' },
+      { name: 'percent' },
+    ],
+  },
+  {
+    name: 'PERMUT',
+    description: 'Returns the number of permutations for a given number of objects',
+    args: [
+      { name: 'n' },
+      { name: 'k' },
     ],
   },
   {
@@ -1361,97 +2727,167 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
   {
     name: 'FISHER',
     description: 'Returns the Fisher transformation',
-    args: [{ name: 'x' }],
+    args: [
+      { name: 'x' },
+    ],
   },
   {
     name: 'FISHERINV',
     description: 'Returns the inverse Fisher transformation',
-    args: [{ name: 'y' }],
+    args: [
+      { name: 'y' },
+    ],
   },
   {
     name: 'GAMMA',
     description: 'Returns the gamma function value',
-    args: [{ name: 'number' }],
+    args: [
+      { name: 'number' },
+    ],
   },
   {
     name: 'GAMMALN',
     description: 'Returns the natural log of the gamma function',
-    args: [{ name: 'number' }],
+    args: [
+      { name: 'number' },
+    ],
   },
   {
     name: 'NORMDIST',
     description: 'Returns the normal distribution',
-    args: [{ name: 'x' }, { name: 'mean' }, { name: 'stdev' }, { name: 'cumulative' }],
+    args: [
+      { name: 'x' },
+      { name: 'mean' },
+      { name: 'stdev' },
+      { name: 'cumulative' },
+    ],
   },
   {
     name: 'NORMINV',
     description: 'Returns the inverse of the normal distribution',
-    args: [{ name: 'probability' }, { name: 'mean' }, { name: 'stdev' }],
+    args: [
+      { name: 'probability' },
+      { name: 'mean' },
+      { name: 'stdev' },
+    ],
   },
   {
     name: 'LOGNORMAL.DIST',
     description: 'Returns the lognormal distribution',
-    args: [{ name: 'x' }, { name: 'mean' }, { name: 'stdev' }, { name: 'cumulative' }],
+    args: [
+      { name: 'x' },
+      { name: 'mean' },
+      { name: 'stdev' },
+      { name: 'cumulative' },
+    ],
   },
   {
     name: 'LOGNORMAL.INV',
     description: 'Returns the inverse of the lognormal distribution',
-    args: [{ name: 'probability' }, { name: 'mean' }, { name: 'stdev' }],
+    args: [
+      { name: 'probability' },
+      { name: 'mean' },
+      { name: 'stdev' },
+    ],
   },
   {
     name: 'STANDARDIZE',
     description: 'Returns a normalized value (z-score)',
-    args: [{ name: 'x' }, { name: 'mean' }, { name: 'stdev' }],
+    args: [
+      { name: 'x' },
+      { name: 'mean' },
+      { name: 'stdev' },
+    ],
   },
   {
     name: 'WEIBULL.DIST',
     description: 'Returns the Weibull distribution',
-    args: [{ name: 'x' }, { name: 'alpha' }, { name: 'beta' }, { name: 'cumulative' }],
+    args: [
+      { name: 'x' },
+      { name: 'alpha' },
+      { name: 'beta' },
+      { name: 'cumulative' },
+    ],
   },
   {
     name: 'POISSON.DIST',
     description: 'Returns the Poisson distribution',
-    args: [{ name: 'x' }, { name: 'mean' }, { name: 'cumulative' }],
+    args: [
+      { name: 'x' },
+      { name: 'mean' },
+      { name: 'cumulative' },
+    ],
   },
   {
     name: 'BINOM.DIST',
     description: 'Returns the binomial distribution probability',
-    args: [{ name: 'successes' }, { name: 'trials' }, { name: 'probability' }, { name: 'cumulative' }],
+    args: [
+      { name: 'successes' },
+      { name: 'trials' },
+      { name: 'probability' },
+      { name: 'cumulative' },
+    ],
   },
   {
     name: 'EXPON.DIST',
     description: 'Returns the exponential distribution',
-    args: [{ name: 'x' }, { name: 'lambda' }, { name: 'cumulative' }],
+    args: [
+      { name: 'x' },
+      { name: 'lambda' },
+      { name: 'cumulative' },
+    ],
   },
   {
     name: 'CONFIDENCE.NORM',
     description: 'Returns the confidence interval using normal distribution',
-    args: [{ name: 'alpha' }, { name: 'stdev' }, { name: 'size' }],
+    args: [
+      { name: 'alpha' },
+      { name: 'stdev' },
+      { name: 'size' },
+    ],
   },
   {
     name: 'CONFIDENCE.T',
     description: 'Returns the confidence interval using t-distribution',
-    args: [{ name: 'alpha' }, { name: 'stdev' }, { name: 'size' }],
+    args: [
+      { name: 'alpha' },
+      { name: 'stdev' },
+      { name: 'size' },
+    ],
   },
   {
     name: 'CHISQ.DIST',
     description: 'Returns the chi-squared distribution',
-    args: [{ name: 'x' }, { name: 'degrees_freedom' }, { name: 'cumulative' }],
+    args: [
+      { name: 'x' },
+      { name: 'degrees_freedom' },
+      { name: 'cumulative' },
+    ],
   },
   {
     name: 'CHISQ.INV',
     description: 'Returns the inverse of the chi-squared distribution',
-    args: [{ name: 'probability' }, { name: 'degrees_freedom' }],
+    args: [
+      { name: 'probability' },
+      { name: 'degrees_freedom' },
+    ],
   },
   {
     name: 'T.DIST',
     description: 'Returns the Student t-distribution',
-    args: [{ name: 'x' }, { name: 'degrees_freedom' }, { name: 'cumulative' }],
+    args: [
+      { name: 'x' },
+      { name: 'degrees_freedom' },
+      { name: 'cumulative' },
+    ],
   },
   {
     name: 'T.INV',
     description: 'Returns the inverse of the Student t-distribution',
-    args: [{ name: 'probability' }, { name: 'degrees_freedom' }],
+    args: [
+      { name: 'probability' },
+      { name: 'degrees_freedom' },
+    ],
   },
   {
     name: 'HYPGEOM.DIST',
@@ -1467,188 +2903,60 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
   {
     name: 'NEGBINOM.DIST',
     description: 'Returns the negative binomial distribution',
-    args: [{ name: 'failures' }, { name: 'successes' }, { name: 'probability' }, { name: 'cumulative' }],
-  },
-  {
-    name: 'ARABIC',
-    description: 'Converts a Roman numeral to a number',
-    args: [{ name: 'roman_numeral' }],
-  },
-  {
-    name: 'ROMAN',
-    description: 'Converts a number to Roman numeral text',
-    args: [{ name: 'number' }, { name: 'form', optional: true }],
-  },
-  {
-    name: 'MULTINOMIAL',
-    description: 'Returns the multinomial coefficient',
     args: [
-      { name: 'number1' },
-      { name: 'number2', optional: true, repeating: true },
+      { name: 'failures' },
+      { name: 'successes' },
+      { name: 'probability' },
+      { name: 'cumulative' },
     ],
-  },
-  {
-    name: 'SERIESSUM',
-    description: 'Returns the sum of a power series',
-    args: [{ name: 'x' }, { name: 'n' }, { name: 'm' }, { name: 'coefficients' }],
-  },
-  {
-    name: 'DELTA',
-    description: 'Tests whether two values are equal',
-    args: [{ name: 'number1' }, { name: 'number2', optional: true }],
-  },
-  {
-    name: 'GESTEP',
-    description: 'Tests whether a number is greater than or equal to a step value',
-    args: [{ name: 'number' }, { name: 'step', optional: true }],
-  },
-  {
-    name: 'ERF',
-    description: 'Returns the error function',
-    args: [{ name: 'lower_limit' }, { name: 'upper_limit', optional: true }],
-  },
-  {
-    name: 'ERFC',
-    description: 'Returns the complementary error function',
-    args: [{ name: 'x' }],
-  },
-  {
-    name: 'XNPV',
-    description: 'Returns net present value for irregular cash flows',
-    args: [{ name: 'rate' }, { name: 'values' }, { name: 'dates' }],
-  },
-  {
-    name: 'XIRR',
-    description: 'Returns internal rate of return for irregular cash flows',
-    args: [{ name: 'values' }, { name: 'dates' }, { name: 'guess', optional: true }],
-  },
-  {
-    name: 'SYD',
-    description: 'Returns the sum-of-years-digits depreciation',
-    args: [{ name: 'cost' }, { name: 'salvage' }, { name: 'life' }, { name: 'period' }],
-  },
-  {
-    name: 'MIRR',
-    description: 'Returns the modified internal rate of return',
-    args: [{ name: 'values' }, { name: 'finance_rate' }, { name: 'reinvest_rate' }],
-  },
-  {
-    name: 'TBILLEQ',
-    description: 'Returns the bond-equivalent yield for a T-bill',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'discount' }],
-  },
-  {
-    name: 'TBILLPRICE',
-    description: 'Returns the price per $100 for a T-bill',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'discount' }],
-  },
-  {
-    name: 'TBILLYIELD',
-    description: 'Returns the yield for a T-bill',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'price' }],
-  },
-  {
-    name: 'DOLLARDE',
-    description: 'Converts a fractional dollar price to a decimal price',
-    args: [{ name: 'fractional_dollar' }, { name: 'fraction' }],
-  },
-  {
-    name: 'DOLLARFR',
-    description: 'Converts a decimal dollar price to a fractional price',
-    args: [{ name: 'decimal_dollar' }, { name: 'fraction' }],
-  },
-  {
-    name: 'ENCODEURL',
-    description: 'Encodes a string for use in a URL',
-    args: [{ name: 'text' }],
-  },
-  {
-    name: 'ISURL',
-    description: 'Returns TRUE if a value is a valid URL',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'ISFORMULA',
-    description: 'Returns TRUE if a cell contains a formula',
-    args: [{ name: 'cell' }],
-  },
-  {
-    name: 'FORMULATEXT',
-    description: 'Returns the formula of a cell as a string',
-    args: [{ name: 'cell' }],
-  },
-  {
-    name: 'CEILING.MATH',
-    description: 'Rounds a number up to the nearest integer or multiple of significance',
-    args: [
-      { name: 'number' },
-      { name: 'significance', optional: true },
-      { name: 'mode', optional: true },
-    ],
-  },
-  {
-    name: 'FLOOR.MATH',
-    description: 'Rounds a number down to the nearest integer or multiple of significance',
-    args: [
-      { name: 'number' },
-      { name: 'significance', optional: true },
-      { name: 'mode', optional: true },
-    ],
-  },
-  {
-    name: 'CEILING.PRECISE',
-    description: 'Rounds a number up to the nearest multiple of significance, ignoring sign',
-    args: [{ name: 'number' }, { name: 'significance', optional: true }],
-  },
-  {
-    name: 'FLOOR.PRECISE',
-    description: 'Rounds a number down to the nearest multiple of significance, ignoring sign',
-    args: [{ name: 'number' }, { name: 'significance', optional: true }],
   },
   {
     name: 'COVAR',
     description: 'Returns the population covariance of two datasets',
-    args: [{ name: 'data_y' }, { name: 'data_x' }],
+    args: [
+      { name: 'data_y' },
+      { name: 'data_x' },
+    ],
   },
   {
     name: 'COVARIANCE.S',
     description: 'Returns the sample covariance of two datasets',
-    args: [{ name: 'data_y' }, { name: 'data_x' }],
+    args: [
+      { name: 'data_y' },
+      { name: 'data_x' },
+    ],
   },
   {
     name: 'RSQ',
     description: 'Returns the R-squared value of a linear regression',
-    args: [{ name: 'known_ys' }, { name: 'known_xs' }],
+    args: [
+      { name: 'known_ys' },
+      { name: 'known_xs' },
+    ],
   },
   {
     name: 'STEYX',
     description: 'Returns the standard error of the predicted y-value in a regression',
-    args: [{ name: 'known_ys' }, { name: 'known_xs' }],
-  },
-  {
-    name: 'SUMX2MY2',
-    description: 'Returns the sum of differences of squares of corresponding values',
-    args: [{ name: 'array_x' }, { name: 'array_y' }],
-  },
-  {
-    name: 'SUMX2PY2',
-    description: 'Returns the sum of sums of squares of corresponding values',
-    args: [{ name: 'array_x' }, { name: 'array_y' }],
-  },
-  {
-    name: 'SUMXMY2',
-    description: 'Returns the sum of squares of differences of corresponding values',
-    args: [{ name: 'array_x' }, { name: 'array_y' }],
+    args: [
+      { name: 'known_ys' },
+      { name: 'known_xs' },
+    ],
   },
   {
     name: 'PERCENTILE.EXC',
     description: 'Returns the k-th percentile of values using exclusive interpolation',
-    args: [{ name: 'data' }, { name: 'k' }],
+    args: [
+      { name: 'data' },
+      { name: 'k' },
+    ],
   },
   {
     name: 'QUARTILE.EXC',
     description: 'Returns the exclusive quartile of a dataset',
-    args: [{ name: 'data' }, { name: 'quart' }],
+    args: [
+      { name: 'data' },
+      { name: 'quart' },
+    ],
   },
   {
     name: 'RANK.AVG',
@@ -1732,32 +3040,51 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
   {
     name: 'GAMMA.INV',
     description: 'Returns the inverse of the gamma cumulative distribution',
-    args: [{ name: 'probability' }, { name: 'alpha' }, { name: 'beta' }],
+    args: [
+      { name: 'probability' },
+      { name: 'alpha' },
+      { name: 'beta' },
+    ],
   },
   {
     name: 'CHISQ.DIST.RT',
     description: 'Returns the right-tailed chi-squared distribution probability',
-    args: [{ name: 'x' }, { name: 'degrees_freedom' }],
+    args: [
+      { name: 'x' },
+      { name: 'degrees_freedom' },
+    ],
   },
   {
     name: 'CHISQ.INV.RT',
     description: 'Returns the inverse right-tailed chi-squared distribution',
-    args: [{ name: 'probability' }, { name: 'degrees_freedom' }],
+    args: [
+      { name: 'probability' },
+      { name: 'degrees_freedom' },
+    ],
   },
   {
     name: 'T.DIST.RT',
     description: 'Returns the right-tailed Student t-distribution',
-    args: [{ name: 'x' }, { name: 'degrees_freedom' }],
+    args: [
+      { name: 'x' },
+      { name: 'degrees_freedom' },
+    ],
   },
   {
     name: 'T.DIST.2T',
     description: 'Returns the two-tailed Student t-distribution',
-    args: [{ name: 'x' }, { name: 'degrees_freedom' }],
+    args: [
+      { name: 'x' },
+      { name: 'degrees_freedom' },
+    ],
   },
   {
     name: 'T.INV.2T',
     description: 'Returns the inverse two-tailed Student t-distribution',
-    args: [{ name: 'probability' }, { name: 'degrees_freedom' }],
+    args: [
+      { name: 'probability' },
+      { name: 'degrees_freedom' },
+    ],
   },
   {
     name: 'F.DIST.RT',
@@ -1780,118 +3107,25 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
   {
     name: 'BINOM.INV',
     description: 'Returns the smallest value for which the cumulative binomial distribution is >= alpha',
-    args: [{ name: 'trials' }, { name: 'probability_s' }, { name: 'alpha' }],
-  },
-  {
-    name: 'TEXTBEFORE',
-    description: 'Returns text before a specified delimiter',
     args: [
-      { name: 'text' },
-      { name: 'delimiter' },
-      { name: 'instance_num', optional: true },
+      { name: 'trials' },
+      { name: 'probability_s' },
+      { name: 'alpha' },
     ],
-  },
-  {
-    name: 'TEXTAFTER',
-    description: 'Returns text after a specified delimiter',
-    args: [
-      { name: 'text' },
-      { name: 'delimiter' },
-      { name: 'instance_num', optional: true },
-    ],
-  },
-  {
-    name: 'VALUETOTEXT',
-    description: 'Converts a value to text',
-    args: [{ name: 'value' }, { name: 'format', optional: true }],
-  },
-  {
-    name: 'SEQUENCE',
-    description: 'Generates a sequence of numbers',
-    args: [
-      { name: 'rows' },
-      { name: 'columns', optional: true },
-      { name: 'start', optional: true },
-      { name: 'step', optional: true },
-    ],
-  },
-  {
-    name: 'RANDARRAY',
-    description: 'Generates an array of random numbers',
-    args: [
-      { name: 'rows', optional: true },
-      { name: 'columns', optional: true },
-      { name: 'min', optional: true },
-      { name: 'max', optional: true },
-      { name: 'whole_number', optional: true },
-    ],
-  },
-  {
-    name: 'SORT',
-    description: 'Sorts a range of data',
-    args: [
-      { name: 'range' },
-      { name: 'sort_index', optional: true },
-      { name: 'sort_order', optional: true },
-    ],
-  },
-  {
-    name: 'UNIQUE',
-    description: 'Returns unique values from a range',
-    args: [{ name: 'range' }],
-  },
-  { name: 'ADD', description: 'Returns the sum of two numbers', args: [{ name: 'value1' }, { name: 'value2' }] },
-  { name: 'MINUS', description: 'Returns the difference of two numbers', args: [{ name: 'value1' }, { name: 'value2' }] },
-  { name: 'MULTIPLY', description: 'Returns the product of two numbers', args: [{ name: 'factor1' }, { name: 'factor2' }] },
-  { name: 'DIVIDE', description: 'Returns the result of dividing one number by another', args: [{ name: 'dividend' }, { name: 'divisor' }] },
-  { name: 'POW', description: 'Returns the result of raising a number to a power', args: [{ name: 'base' }, { name: 'exponent' }] },
-  { name: 'UMINUS', description: 'Returns the negation of a number', args: [{ name: 'value' }] },
-  { name: 'UPLUS', description: 'Returns the unary positive of a number', args: [{ name: 'value' }] },
-  { name: 'UNARY_PERCENT', description: 'Returns a value interpreted as a percentage', args: [{ name: 'percentage' }] },
-  { name: 'EQ', description: 'Returns TRUE if two values are equal', args: [{ name: 'value1' }, { name: 'value2' }] },
-  { name: 'NE', description: 'Returns TRUE if two values are not equal', args: [{ name: 'value1' }, { name: 'value2' }] },
-  { name: 'LT', description: 'Returns TRUE if the first value is less than the second', args: [{ name: 'value1' }, { name: 'value2' }] },
-  { name: 'LTE', description: 'Returns TRUE if the first value is less than or equal to the second', args: [{ name: 'value1' }, { name: 'value2' }] },
-  { name: 'GT', description: 'Returns TRUE if the first value is greater than the second', args: [{ name: 'value1' }, { name: 'value2' }] },
-  { name: 'GTE', description: 'Returns TRUE if the first value is greater than or equal to the second', args: [{ name: 'value1' }, { name: 'value2' }] },
-  {
-    name: 'ISBETWEEN',
-    description: 'Returns TRUE if a value is between two values (inclusive by default)',
-    args: [
-      { name: 'value_to_compare' },
-      { name: 'lower_value' },
-      { name: 'upper_value' },
-      { name: 'lower_value_is_inclusive', optional: true },
-      { name: 'upper_value_is_inclusive', optional: true },
-    ],
-  },
-  {
-    name: 'FLATTEN',
-    description: 'Flattens a range into a single column',
-    args: [{ name: 'range' }],
-  },
-  {
-    name: 'TRANSPOSE',
-    description: 'Transposes the rows and columns of a range',
-    args: [{ name: 'range' }],
   },
   {
     name: 'NORM.S.DIST',
     description: 'Returns the standard normal distribution probability',
-    args: [{ name: 'z' }, { name: 'cumulative' }],
+    args: [
+      { name: 'z' },
+      { name: 'cumulative' },
+    ],
   },
   {
     name: 'NORM.S.INV',
     description: 'Returns the inverse of the standard normal distribution',
-    args: [{ name: 'probability' }],
-  },
-  {
-    name: 'SUBTOTAL',
-    description: 'Returns a subtotal using a specified aggregate function',
     args: [
-      { name: 'function_num' },
-      { name: 'ref1' },
-      { name: 'ref2', optional: true, repeating: true },
+      { name: 'probability' },
     ],
   },
   {
@@ -1927,26 +3161,6 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
     ],
   },
   {
-    name: 'ISREF',
-    description: 'Returns TRUE if the value is a reference',
-    args: [{ name: 'value' }],
-  },
-  {
-    name: 'SHEET',
-    description: 'Returns the sheet number of a reference',
-    args: [{ name: 'value', optional: true }],
-  },
-  {
-    name: 'SHEETS',
-    description: 'Returns the number of sheets in a reference',
-    args: [{ name: 'reference', optional: true }],
-  },
-  {
-    name: 'MDETERM',
-    description: 'Returns the determinant of a square matrix',
-    args: [{ name: 'square_matrix' }],
-  },
-  {
     name: 'PROB',
     description: 'Returns the probability of values in a range between two limits',
     args: [
@@ -1957,1038 +3171,712 @@ const FunctionCatalogEntries: Array<Omit<FunctionInfo, 'category'>> = [
     ],
   },
   {
-    name: 'CONVERT',
-    description: 'Converts a number from one measurement unit to another',
-    args: [{ name: 'number' }, { name: 'from_unit' }, { name: 'to_unit' }],
-  },
-  {
-    name: 'BITAND',
-    description: 'Returns the bitwise AND of two numbers',
-    args: [{ name: 'number1' }, { name: 'number2' }],
-  },
-  {
-    name: 'BITOR',
-    description: 'Returns the bitwise OR of two numbers',
-    args: [{ name: 'number1' }, { name: 'number2' }],
-  },
-  {
-    name: 'BITXOR',
-    description: 'Returns the bitwise XOR of two numbers',
-    args: [{ name: 'number1' }, { name: 'number2' }],
-  },
-  {
-    name: 'BITLSHIFT',
-    description: 'Shifts a number left by a specified number of bits',
-    args: [{ name: 'number' }, { name: 'shift_amount' }],
-  },
-  {
-    name: 'BITRSHIFT',
-    description: 'Shifts a number right by a specified number of bits',
-    args: [{ name: 'number' }, { name: 'shift_amount' }],
-  },
-  {
-    name: 'HEX2DEC',
-    description: 'Converts a hexadecimal number to decimal',
-    args: [{ name: 'hex_string' }],
-  },
-  {
-    name: 'DEC2HEX',
-    description: 'Converts a decimal number to hexadecimal',
-    args: [{ name: 'number' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'BIN2DEC',
-    description: 'Converts a binary number to decimal',
-    args: [{ name: 'bin_string' }],
-  },
-  {
-    name: 'DEC2BIN',
-    description: 'Converts a decimal number to binary',
-    args: [{ name: 'number' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'OCT2DEC',
-    description: 'Converts an octal number to decimal',
-    args: [{ name: 'oct_string' }],
-  },
-  {
-    name: 'DEC2OCT',
-    description: 'Converts a decimal number to octal',
-    args: [{ name: 'number' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'COMPLEX',
-    description: 'Creates a complex number from real and imaginary parts',
-    args: [{ name: 'real' }, { name: 'imaginary' }, { name: 'suffix', optional: true }],
-  },
-  {
-    name: 'IMREAL',
-    description: 'Returns the real part of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMAGINARY',
-    description: 'Returns the imaginary part of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMABS',
-    description: 'Returns the absolute value (modulus) of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMSUM',
-    description: 'Returns the sum of complex numbers',
-    args: [{ name: 'complex1' }, { name: 'complex2', optional: true, repeating: true }],
-  },
-  {
-    name: 'IMSUB',
-    description: 'Returns the difference of two complex numbers',
-    args: [{ name: 'complex1' }, { name: 'complex2' }],
-  },
-  {
-    name: 'IMPRODUCT',
-    description: 'Returns the product of complex numbers',
-    args: [{ name: 'complex1' }, { name: 'complex2', optional: true, repeating: true }],
-  },
-  {
-    name: 'IMDIV',
-    description: 'Returns the quotient of two complex numbers',
-    args: [{ name: 'complex1' }, { name: 'complex2' }],
-  },
-  {
-    name: 'IMCONJUGATE',
-    description: 'Returns the complex conjugate of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMARGUMENT',
-    description: 'Returns the argument (angle) of a complex number in radians',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMPOWER',
-    description: 'Returns a complex number raised to a power',
-    args: [{ name: 'complex_number' }, { name: 'power' }],
-  },
-  {
-    name: 'IMSQRT',
-    description: 'Returns the square root of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMEXP',
-    description: 'Returns e raised to a complex power',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMLN',
-    description: 'Returns the natural logarithm of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMLOG2',
-    description: 'Returns the base-2 logarithm of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMLOG10',
-    description: 'Returns the base-10 logarithm of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMSIN',
-    description: 'Returns the sine of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMCOS',
-    description: 'Returns the cosine of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMTAN',
-    description: 'Returns the tangent of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMSINH',
-    description: 'Returns the hyperbolic sine of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMCOSH',
-    description: 'Returns the hyperbolic cosine of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMSEC',
-    description: 'Returns the secant of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMCSC',
-    description: 'Returns the cosecant of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'IMCOT',
-    description: 'Returns the cotangent of a complex number',
-    args: [{ name: 'complex_number' }],
-  },
-  {
-    name: 'HEX2BIN',
-    description: 'Converts a hexadecimal number to binary',
-    args: [{ name: 'hex_string' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'HEX2OCT',
-    description: 'Converts a hexadecimal number to octal',
-    args: [{ name: 'hex_string' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'BIN2HEX',
-    description: 'Converts a binary number to hexadecimal',
-    args: [{ name: 'bin_string' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'BIN2OCT',
-    description: 'Converts a binary number to octal',
-    args: [{ name: 'bin_string' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'OCT2HEX',
-    description: 'Converts an octal number to hexadecimal',
-    args: [{ name: 'oct_string' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'OCT2BIN',
-    description: 'Converts an octal number to binary',
-    args: [{ name: 'oct_string' }, { name: 'places', optional: true }],
-  },
-  {
-    name: 'BESSELJ',
-    description: 'Returns the Bessel function of the first kind Jn(x)',
-    args: [{ name: 'x' }, { name: 'n' }],
-  },
-  {
-    name: 'BESSELY',
-    description: 'Returns the Bessel function of the second kind Yn(x)',
-    args: [{ name: 'x' }, { name: 'n' }],
-  },
-  {
-    name: 'BESSELI',
-    description: 'Returns the modified Bessel function of the first kind In(x)',
-    args: [{ name: 'x' }, { name: 'n' }],
-  },
-  {
-    name: 'BESSELK',
-    description: 'Returns the modified Bessel function of the second kind Kn(x)',
-    args: [{ name: 'x' }, { name: 'n' }],
-  },
-  {
-    name: 'ACCRINT',
-    description: 'Returns the accrued interest for a security that pays periodic interest',
-    args: [{ name: 'issue' }, { name: 'first_interest' }, { name: 'settlement' }, { name: 'rate' }, { name: 'par' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'ACCRINTM',
-    description: 'Returns the accrued interest for a security that pays at maturity',
-    args: [{ name: 'issue' }, { name: 'settlement' }, { name: 'rate' }, { name: 'par' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'COUPDAYBS',
-    description: 'Returns the number of days from the coupon period start to settlement',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'COUPDAYS',
-    description: 'Returns the number of days in the coupon period containing settlement',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'COUPDAYSNC',
-    description: 'Returns the number of days from settlement to the next coupon date',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'COUPNCD',
-    description: 'Returns the next coupon date after settlement',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'COUPNUM',
-    description: 'Returns the number of coupons between settlement and maturity',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'COUPPCD',
-    description: 'Returns the previous coupon date before settlement',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'DISC',
-    description: 'Returns the discount rate for a security',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'price' }, { name: 'redemption' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'PRICEDISC',
-    description: 'Returns the price of a discounted security',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'discount' }, { name: 'redemption' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'YIELDDISC',
-    description: 'Returns the annual yield for a discounted security',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'price' }, { name: 'redemption' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'DURATION',
-    description: 'Returns the Macaulay duration of a security',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'coupon' }, { name: 'yield' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'MDURATION',
-    description: 'Returns the modified Macaulay duration of a security',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'coupon' }, { name: 'yield' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'RECEIVED',
-    description: 'Returns the amount received at maturity for a fully invested security',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'investment' }, { name: 'discount' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'INTRATE',
-    description: 'Returns the interest rate for a fully invested security',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'investment' }, { name: 'redemption' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'PRICE',
-    description: 'Returns the price per $100 face value of a coupon-paying security',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'rate' }, { name: 'yield' }, { name: 'redemption' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'YIELD',
-    description: 'Returns the yield on a coupon-paying security',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'rate' }, { name: 'price' }, { name: 'redemption' }, { name: 'frequency' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'PRICEMAT',
-    description: 'Returns the price of a security that pays at maturity',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'issue' }, { name: 'rate' }, { name: 'yield' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'YIELDMAT',
-    description: 'Returns the yield of a security that pays at maturity',
-    args: [{ name: 'settlement' }, { name: 'maturity' }, { name: 'issue' }, { name: 'rate' }, { name: 'price' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'AMORLINC',
-    description: 'Returns the depreciation for each accounting period (French linear)',
-    args: [{ name: 'cost' }, { name: 'purchase_date' }, { name: 'first_period' }, { name: 'salvage' }, { name: 'period' }, { name: 'rate' }, { name: 'basis', optional: true }],
-  },
-  {
-    name: 'ISPMT',
-    description: 'Returns the interest paid during a specific period of a loan',
-    args: [{ name: 'rate' }, { name: 'period' }, { name: 'nper' }, { name: 'pv' }],
-  },
-  {
-    name: 'FVSCHEDULE',
-    description: 'Returns the future value of a principal after applying a schedule of rates',
-    args: [{ name: 'principal' }, { name: 'schedule' }],
-  },
-  {
-    name: 'PDURATION',
-    description: 'Returns the number of periods for an investment to reach a specified value',
-    args: [{ name: 'rate' }, { name: 'pv' }, { name: 'fv' }],
-  },
-  {
-    name: 'RRI',
-    description: 'Returns the equivalent interest rate for the growth of an investment',
-    args: [{ name: 'nper' }, { name: 'pv' }, { name: 'fv' }],
-  },
-  {
-    name: 'DSUM',
-    description: 'Sums values in a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DCOUNT',
-    description: 'Counts numeric values in a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DCOUNTA',
-    description: 'Counts non-empty values in a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DAVERAGE',
-    description: 'Averages values in a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DMAX',
-    description: 'Returns the maximum value in a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DMIN',
-    description: 'Returns the minimum value in a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DPRODUCT',
-    description: 'Returns the product of values in a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DGET',
-    description: 'Returns a single value from a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DSTDEV',
-    description: 'Returns the sample standard deviation of a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DSTDEVP',
-    description: 'Returns the population standard deviation of a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DVAR',
-    description: 'Returns the sample variance of a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
-    name: 'DVARP',
-    description: 'Returns the population variance of a database field matching criteria',
-    args: [{ name: 'database' }, { name: 'field' }, { name: 'criteria' }],
-  },
-  {
     name: 'GROWTH',
     description: 'Calculates predicted exponential growth using existing data',
-    args: [{ name: 'known_y' }, { name: 'known_x', optional: true }, { name: 'new_x', optional: true }],
+    args: [
+      { name: 'known_y' },
+      { name: 'known_x', optional: true },
+      { name: 'new_x', optional: true },
+    ],
   },
   {
     name: 'TREND',
     description: 'Calculates predicted linear trend values using least squares regression',
-    args: [{ name: 'known_y' }, { name: 'known_x', optional: true }, { name: 'new_x', optional: true }],
+    args: [
+      { name: 'known_y' },
+      { name: 'known_x', optional: true },
+      { name: 'new_x', optional: true },
+    ],
   },
   {
     name: 'LINEST',
     description: 'Returns the slope of the linear regression line',
-    args: [{ name: 'known_y' }, { name: 'known_x', optional: true }],
+    args: [
+      { name: 'known_y' },
+      { name: 'known_x', optional: true },
+    ],
   },
   {
     name: 'LOGEST',
     description: 'Returns the growth rate of an exponential regression',
-    args: [{ name: 'known_y' }, { name: 'known_x', optional: true }],
+    args: [
+      { name: 'known_y' },
+      { name: 'known_x', optional: true },
+    ],
   },
   {
     name: 'FREQUENCY',
     description: 'Calculates how often values occur within a range of bins',
-    args: [{ name: 'data_array' }, { name: 'bins_array' }],
+    args: [
+      { name: 'data_array' },
+      { name: 'bins_array' },
+    ],
   },
   {
     name: 'MODE.MULT',
     description: 'Returns the most frequently occurring values in a dataset',
-    args: [{ name: 'number1' }, { name: 'number2', optional: true, repeating: true }],
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
   },
   {
     name: 'AGGREGATE',
     description: 'Returns an aggregate calculation, ignoring errors and hidden rows',
-    args: [{ name: 'function_num' }, { name: 'options' }, { name: 'ref1' }, { name: 'ref2', optional: true, repeating: true }],
-  },
-  {
-    name: 'COMBINA',
-    description: 'Returns the number of combinations with repetition',
-    args: [{ name: 'n' }, { name: 'k' }],
+    args: [
+      { name: 'function_num' },
+      { name: 'options' },
+      { name: 'ref1' },
+      { name: 'ref2', optional: true, repeating: true },
+    ],
   },
   {
     name: 'PERMUTATIONA',
     description: 'Returns the number of permutations with repetition',
-    args: [{ name: 'n' }, { name: 'k' }],
+    args: [
+      { name: 'n' },
+      { name: 'k' },
+    ],
   },
   {
     name: 'T.TEST',
     description: 'Returns the probability associated with a Student t-test',
-    args: [{ name: 'range1' }, { name: 'range2' }, { name: 'tails' }, { name: 'type' }],
+    args: [
+      { name: 'range1' },
+      { name: 'range2' },
+      { name: 'tails' },
+      { name: 'type' },
+    ],
   },
   {
     name: 'Z.TEST',
     description: 'Returns the one-tailed p-value of a z-test',
-    args: [{ name: 'range' }, { name: 'value' }, { name: 'sigma', optional: true }],
-  },
-  {
-    name: 'AREAS',
-    description: 'Returns the number of areas in a reference',
-    args: [{ name: 'reference' }],
-  },
-  {
-    name: 'CELL',
-    description: 'Returns information about a cell',
-    args: [{ name: 'info_type' }, { name: 'reference', optional: true }],
-  },
-  {
-    name: 'MMULT',
-    description: 'Returns the matrix product of two arrays',
-    args: [{ name: 'array1' }, { name: 'array2' }],
-  },
-  {
-    name: 'MINVERSE',
-    description: 'Returns the inverse matrix of a square array',
-    args: [{ name: 'array' }],
-  },
-  {
-    name: 'XMATCH',
-    description: 'Returns the relative position of a value in an array',
-    args: [{ name: 'lookup_value' }, { name: 'lookup_array' }, { name: 'match_mode', optional: true }, { name: 'search_mode', optional: true }],
-  },
-  {
-    name: 'TOCOL',
-    description: 'Transforms an array into a single column',
-    args: [{ name: 'array' }, { name: 'ignore', optional: true }, { name: 'scan_by_column', optional: true }],
-  },
-  {
-    name: 'TOROW',
-    description: 'Transforms an array into a single row',
-    args: [{ name: 'array' }, { name: 'ignore', optional: true }, { name: 'scan_by_column', optional: true }],
-  },
-  {
-    name: 'TEXTSPLIT',
-    description: 'Splits text by delimiter into parts',
-    args: [{ name: 'text' }, { name: 'col_delimiter' }, { name: 'row_delimiter', optional: true }, { name: 'ignore_empty', optional: true }],
-  },
-  {
-    name: 'CHOOSEROWS',
-    description: 'Returns specified rows from an array',
-    args: [{ name: 'array' }, { name: 'row_num1' }, { name: 'row_num2', optional: true }],
-  },
-  {
-    name: 'CHOOSECOLS',
-    description: 'Returns specified columns from an array',
-    args: [{ name: 'array' }, { name: 'col_num1' }, { name: 'col_num2', optional: true }],
-  },
-  {
-    name: 'TAKE',
-    description: 'Returns rows or columns from the start or end of an array',
-    args: [{ name: 'array' }, { name: 'rows' }, { name: 'columns', optional: true }],
-  },
-  {
-    name: 'DROP',
-    description: 'Removes rows or columns from the start or end of an array',
-    args: [{ name: 'array' }, { name: 'rows' }, { name: 'columns', optional: true }],
-  },
-  {
-    name: 'HSTACK',
-    description: 'Appends arrays horizontally',
-    args: [{ name: 'range1' }, { name: 'range2', optional: true }],
-  },
-  {
-    name: 'VSTACK',
-    description: 'Appends arrays vertically',
-    args: [{ name: 'range1' }, { name: 'range2', optional: true }],
-  },
-  {
-    name: 'SORTBY',
-    description: 'Sorts a range by another range',
-    args: [{ name: 'array' }, { name: 'by_array' }, { name: 'sort_order', optional: true }],
-  },
-  {
-    name: 'WRAPCOLS',
-    description: 'Wraps a row or column of values into columns',
-    args: [{ name: 'vector' }, { name: 'wrap_count' }, { name: 'pad_with', optional: true }],
-  },
-  {
-    name: 'WRAPROWS',
-    description: 'Wraps a row or column of values into rows',
-    args: [{ name: 'vector' }, { name: 'wrap_count' }, { name: 'pad_with', optional: true }],
+    args: [
+      { name: 'range' },
+      { name: 'value' },
+      { name: 'sigma', optional: true },
+    ],
   },
   {
     name: 'GAUSS',
     description: 'Returns the probability between 0 and z standard deviations',
-    args: [{ name: 'z' }],
+    args: [
+      { name: 'z' },
+    ],
   },
   {
     name: 'PHI',
     description: 'Returns the value of the standard normal density function',
-    args: [{ name: 'x' }],
+    args: [
+      { name: 'x' },
+    ],
   },
   {
     name: 'STDEVA',
     description: 'Standard deviation of a sample, including text and logical values',
-    args: [{ name: 'value1' }, { name: 'value2', optional: true }],
+    args: [
+      { name: 'value1' },
+      { name: 'value2', optional: true },
+    ],
   },
   {
     name: 'STDEVPA',
     description: 'Standard deviation of a population, including text and logical values',
-    args: [{ name: 'value1' }, { name: 'value2', optional: true }],
+    args: [
+      { name: 'value1' },
+      { name: 'value2', optional: true },
+    ],
   },
   {
     name: 'SKEW.P',
     description: 'Returns the population skewness of a distribution',
-    args: [{ name: 'number1' }, { name: 'number2', optional: true }],
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true },
+    ],
   },
   {
     name: 'CHISQ.TEST',
     description: 'Returns the chi-squared test for independence',
-    args: [{ name: 'actual_range' }, { name: 'expected_range' }],
+    args: [
+      { name: 'actual_range' },
+      { name: 'expected_range' },
+    ],
   },
   {
     name: 'F.TEST',
     description: 'Returns the result of an F-test',
-    args: [{ name: 'array1' }, { name: 'array2' }],
-  },
-  {
-    name: 'ISO.CEILING',
-    description: 'Rounds a number up to the nearest integer or multiple of significance',
-    args: [{ name: 'number' }, { name: 'significance', optional: true }],
-  },
-  {
-    name: 'FILTER',
-    description: 'Filters an array based on a boolean array',
-    args: [{ name: 'array' }, { name: 'include' }, { name: 'if_empty', optional: true }],
-  },
-  {
-    name: 'SECH',
-    description: 'Returns the hyperbolic secant of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'CSCH',
-    description: 'Returns the hyperbolic cosecant of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'COTH',
-    description: 'Returns the hyperbolic cotangent of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'ACOT',
-    description: 'Returns the arccotangent of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'ACOTH',
-    description: 'Returns the inverse hyperbolic cotangent of a number',
-    args: [{ name: 'number' }],
-  },
-  {
-    name: 'DAYS360',
-    description: 'Returns the number of days between two dates using 360-day year',
-    args: [{ name: 'start_date' }, { name: 'end_date' }, { name: 'method', optional: true }],
-  },
-  {
-    name: 'WORKDAY.INTL',
-    description: 'Returns a date that is a specified number of workdays with custom weekends',
-    args: [{ name: 'start_date' }, { name: 'days' }, { name: 'weekend', optional: true }, { name: 'holidays', optional: true }],
-  },
-  {
-    name: 'NETWORKDAYS.INTL',
-    description: 'Returns the number of working days between two dates with custom weekends',
-    args: [{ name: 'start_date' }, { name: 'end_date' }, { name: 'weekend', optional: true }, { name: 'holidays', optional: true }],
-  },
-  {
-    name: 'EXPAND',
-    description: 'Expands an array to specified dimensions',
-    args: [{ name: 'array' }, { name: 'rows' }, { name: 'columns', optional: true }, { name: 'pad_with', optional: true }],
-  },
-  {
-    name: 'MUNIT',
-    description: 'Returns the identity matrix of the specified dimension',
-    args: [{ name: 'dimension' }],
+    args: [
+      { name: 'array1' },
+      { name: 'array2' },
+    ],
   },
   {
     name: 'BINOM.DIST.RANGE',
     description: 'Returns the probability of a trial result using a binomial distribution',
-    args: [{ name: 'trials' }, { name: 'probability_s' }, { name: 'number_s' }, { name: 'number_s2', optional: true }],
+    args: [
+      { name: 'trials' },
+      { name: 'probability_s' },
+      { name: 'number_s' },
+      { name: 'number_s2', optional: true },
+    ],
   },
   {
     name: 'STDEV.S',
     description: 'Returns the sample standard deviation (alias for STDEV)',
-    args: [{ name: 'number1' }, { name: 'number2', optional: true, repeating: true }],
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
   },
   {
     name: 'STDEV.P',
     description: 'Returns the population standard deviation (alias for STDEVP)',
-    args: [{ name: 'number1' }, { name: 'number2', optional: true, repeating: true }],
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
   },
   {
     name: 'VAR.S',
     description: 'Returns the sample variance (alias for VAR)',
-    args: [{ name: 'number1' }, { name: 'number2', optional: true, repeating: true }],
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
   },
   {
     name: 'VAR.P',
     description: 'Returns the population variance (alias for VARP)',
-    args: [{ name: 'number1' }, { name: 'number2', optional: true, repeating: true }],
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
   },
   {
     name: 'MODE.SNGL',
     description: 'Returns the most frequently occurring value (alias for MODE)',
-    args: [{ name: 'number1' }, { name: 'number2', optional: true, repeating: true }],
+    args: [
+      { name: 'number1' },
+      { name: 'number2', optional: true, repeating: true },
+    ],
   },
   {
     name: 'NORM.DIST',
     description: 'Returns the normal distribution (alias for NORMDIST)',
-    args: [{ name: 'x' }, { name: 'mean' }, { name: 'stdev' }, { name: 'cumulative' }],
+    args: [
+      { name: 'x' },
+      { name: 'mean' },
+      { name: 'stdev' },
+      { name: 'cumulative' },
+    ],
   },
   {
     name: 'NORM.INV',
     description: 'Returns the inverse of the normal distribution (alias for NORMINV)',
-    args: [{ name: 'probability' }, { name: 'mean' }, { name: 'stdev' }],
+    args: [
+      { name: 'probability' },
+      { name: 'mean' },
+      { name: 'stdev' },
+    ],
   },
   {
     name: 'QUARTILE.INC',
     description: 'Returns the quartile of a data set (alias for QUARTILE)',
-    args: [{ name: 'data' }, { name: 'quart' }],
+    args: [
+      { name: 'data' },
+      { name: 'quart' },
+    ],
   },
   {
     name: 'PERCENTILE.INC',
     description: 'Returns the k-th percentile of a data set (alias for PERCENTILE)',
-    args: [{ name: 'data' }, { name: 'k' }],
+    args: [
+      { name: 'data' },
+      { name: 'k' },
+    ],
   },
   {
     name: 'RANK.EQ',
     description: 'Returns the rank of a value within a data set (alias for RANK)',
-    args: [{ name: 'value' }, { name: 'data' }, { name: 'order', optional: true }],
+    args: [
+      { name: 'value' },
+      { name: 'data' },
+      { name: 'order', optional: true },
+    ],
   },
   {
     name: 'PERCENTRANK.INC',
     description: 'Returns the percentage rank of a value in a dataset (alias for PERCENTRANK)',
-    args: [{ name: 'data' }, { name: 'x' }, { name: 'significance', optional: true }],
+    args: [
+      { name: 'data' },
+      { name: 'x' },
+      { name: 'significance', optional: true },
+    ],
   },
   {
     name: 'COVARIANCE.P',
     description: 'Returns the population covariance of two datasets (alias for COVAR)',
-    args: [{ name: 'data_y' }, { name: 'data_x' }],
+    args: [
+      { name: 'data_y' },
+      { name: 'data_x' },
+    ],
   },
   {
     name: 'FORECAST.LINEAR',
     description: 'Predicts a y-value for a given x using linear regression (alias for FORECAST)',
-    args: [{ name: 'x' }, { name: 'known_ys' }, { name: 'known_xs' }],
+    args: [
+      { name: 'x' },
+      { name: 'known_ys' },
+      { name: 'known_xs' },
+    ],
   },
 ];
 
-const FunctionNamesByCategory: Partial<Record<FunctionCategory, ReadonlySet<string>>> = {
-  Date: new Set([
-    'TODAY',
-    'NOW',
-    'DATE',
-    'TIME',
-    'DAYS',
-    'YEAR',
-    'MONTH',
-    'DAY',
-    'HOUR',
-    'MINUTE',
-    'SECOND',
-    'WEEKDAY',
-    'EDATE',
-    'EOMONTH',
-    'NETWORKDAYS',
-    'DATEVALUE',
-    'TIMEVALUE',
-    'DATEDIF',
-    'WEEKNUM',
-    'ISOWEEKNUM',
-    'WORKDAY',
-    'YEARFRAC',
-    'DAYS360',
-    'WORKDAY.INTL',
-    'NETWORKDAYS.INTL',
-  ]),
-  Engineering: new Set(['DELTA', 'GESTEP', 'ERF', 'ERFC', 'CONVERT', 'BITAND', 'BITOR', 'BITXOR', 'BITLSHIFT', 'BITRSHIFT', 'HEX2DEC', 'DEC2HEX', 'BIN2DEC', 'DEC2BIN', 'OCT2DEC', 'DEC2OCT', 'COMPLEX', 'IMREAL', 'IMAGINARY', 'IMABS', 'IMSUM', 'IMSUB', 'IMPRODUCT', 'IMDIV', 'IMCONJUGATE', 'IMARGUMENT', 'IMPOWER', 'IMSQRT', 'IMEXP', 'IMLN', 'IMLOG2', 'IMLOG10', 'IMSIN', 'IMCOS', 'IMTAN', 'IMSINH', 'IMCOSH', 'IMSEC', 'IMCSC', 'IMCOT', 'HEX2BIN', 'HEX2OCT', 'BIN2HEX', 'BIN2OCT', 'OCT2HEX', 'OCT2BIN', 'BESSELJ', 'BESSELY', 'BESSELI', 'BESSELK']),
-  Financial: new Set(['PMT', 'FV', 'PV', 'NPV', 'NPER', 'IPMT', 'PPMT', 'SLN', 'EFFECT', 'RATE', 'IRR', 'DB', 'DDB', 'NOMINAL', 'CUMIPMT', 'CUMPRINC', 'XNPV', 'XIRR', 'SYD', 'MIRR', 'TBILLEQ', 'TBILLPRICE', 'TBILLYIELD', 'DOLLARDE', 'DOLLARFR', 'ACCRINT', 'ACCRINTM', 'COUPDAYBS', 'COUPDAYS', 'COUPDAYSNC', 'COUPNCD', 'COUPNUM', 'COUPPCD', 'DISC', 'PRICEDISC', 'YIELDDISC', 'DURATION', 'MDURATION', 'RECEIVED', 'INTRATE', 'PRICE', 'YIELD', 'PRICEMAT', 'YIELDMAT', 'AMORLINC', 'ISPMT', 'FVSCHEDULE', 'PDURATION', 'RRI']),
-  Info: new Set([
-    'ISBLANK',
-    'ISNUMBER',
-    'ISTEXT',
-    'ISERROR',
-    'ISERR',
-    'ISNA',
-    'ISLOGICAL',
-    'ISNONTEXT',
-    'ISURL',
-    'ISFORMULA',
-    'FORMULATEXT',
-    'ISREF',
-    'SHEET',
-    'SHEETS',
-    'N',
-    'TYPE',
-    'NA',
-    'ERROR.TYPE',
-    'ISDATE',
-    'AREAS',
-    'CELL',
-  ]),
-  Logical: new Set(['IF', 'IFS', 'SWITCH', 'AND', 'OR', 'NOT', 'IFERROR', 'IFNA', 'XOR', 'CHOOSE', 'TRUE', 'FALSE']),
-  Lookup: new Set(['MATCH', 'INDEX', 'VLOOKUP', 'HLOOKUP', 'ROW', 'COLUMN', 'ROWS', 'COLUMNS', 'ADDRESS', 'HYPERLINK', 'LOOKUP', 'INDIRECT', 'XLOOKUP', 'OFFSET', 'SORT', 'FLATTEN', 'TRANSPOSE', 'XMATCH', 'TOCOL', 'TOROW', 'CHOOSEROWS', 'CHOOSECOLS', 'TAKE', 'DROP', 'HSTACK', 'VSTACK', 'SORTBY', 'WRAPCOLS', 'WRAPROWS', 'FILTER', 'EXPAND']),
-  Operator: new Set(['ADD', 'MINUS', 'MULTIPLY', 'DIVIDE', 'POW', 'UMINUS', 'UPLUS', 'UNARY_PERCENT', 'EQ', 'NE', 'LT', 'LTE', 'GT', 'GTE', 'ISBETWEEN', 'CONCAT', 'UNIQUE']),
-  Math: new Set([
-    'SUM',
-    'ABS',
-    'ROUND',
-    'ROUNDUP',
-    'ROUNDDOWN',
-    'INT',
-    'MOD',
-    'SQRT',
-    'POWER',
-    'PRODUCT',
-    'RAND',
-    'RANDBETWEEN',
-    'COUNTBLANK',
-    'COUNTIF',
-    'SUMIF',
-    'COUNTIFS',
-    'SUMIFS',
-    'PI',
-    'SIGN',
-    'EVEN',
-    'ODD',
-    'EXP',
-    'LN',
-    'LOG',
-    'SIN',
-    'COS',
-    'TAN',
-    'ASIN',
-    'ACOS',
-    'ATAN',
-    'ATAN2',
-    'DEGREES',
-    'RADIANS',
-    'CEILING',
-    'FLOOR',
-    'TRUNC',
-    'MROUND',
-    'SUMPRODUCT',
-    'GCD',
-    'LCM',
-    'COMBIN',
-    'FACT',
-    'QUOTIENT',
-    'SUMSQ',
-    'ISEVEN',
-    'ISODD',
-    'FACTDOUBLE',
-    'BASE',
-    'DECIMAL',
-    'SQRTPI',
-    'SINH',
-    'COSH',
-    'TANH',
-    'ASINH',
-    'ACOSH',
-    'ATANH',
-    'COT',
-    'CSC',
-    'SEC',
-    'ARABIC',
-    'ROMAN',
-    'MULTINOMIAL',
-    'SERIESSUM',
-    'CEILING.MATH',
-    'FLOOR.MATH',
-    'CEILING.PRECISE',
-    'FLOOR.PRECISE',
-    'SUMX2MY2',
-    'SUMX2PY2',
-    'SUMXMY2',
-    'SEQUENCE',
-    'RANDARRAY',
-    'SUBTOTAL',
-    'MDETERM',
-    'COMBINA',
-    'MMULT',
-    'MINVERSE',
-    'ISO.CEILING',
-    'SECH',
-    'CSCH',
-    'COTH',
-    'ACOT',
-    'ACOTH',
-    'MUNIT',
-  ]),
-  Statistical: new Set([
-    'AVERAGE',
-    'MIN',
-    'MAX',
-    'COUNT',
-    'COUNTA',
-    'MEDIAN',
-    'AVERAGEIF',
-    'AVERAGEIFS',
-    'LARGE',
-    'SMALL',
-    'MINIFS',
-    'MAXIFS',
-    'RANK',
-    'PERCENTILE',
-    'STDEV',
-    'STDEVP',
-    'VAR',
-    'VARP',
-    'MODE',
-    'QUARTILE',
-    'COUNTUNIQUE',
-    'FORECAST',
-    'SLOPE',
-    'INTERCEPT',
-    'CORREL',
-    'GEOMEAN',
-    'HARMEAN',
-    'AVEDEV',
-    'DEVSQ',
-    'TRIMMEAN',
-    'PERMUT',
-    'AVERAGEA',
-    'MINA',
-    'MAXA',
-    'FISHER',
-    'FISHERINV',
-    'GAMMA',
-    'GAMMALN',
-    'NORMDIST',
-    'NORMINV',
-    'LOGNORMAL.DIST',
-    'LOGNORMAL.INV',
-    'STANDARDIZE',
-    'WEIBULL.DIST',
-    'POISSON.DIST',
-    'BINOM.DIST',
-    'EXPON.DIST',
-    'CONFIDENCE.NORM',
-    'CONFIDENCE.T',
-    'CHISQ.DIST',
-    'CHISQ.INV',
-    'T.DIST',
-    'T.INV',
-    'HYPGEOM.DIST',
-    'NEGBINOM.DIST',
-    'COVAR',
-    'COVARIANCE.S',
-    'RSQ',
-    'STEYX',
-    'PERCENTILE.EXC',
-    'QUARTILE.EXC',
-    'RANK.AVG',
-    'PERCENTRANK',
-    'PERCENTRANK.EXC',
-    'BETA.DIST',
-    'BETA.INV',
-    'F.DIST',
-    'F.INV',
-    'GAMMA.DIST',
-    'GAMMA.INV',
-    'CHISQ.DIST.RT',
-    'CHISQ.INV.RT',
-    'T.DIST.RT',
-    'T.DIST.2T',
-    'T.INV.2T',
-    'F.DIST.RT',
-    'F.INV.RT',
-    'BINOM.INV',
-    'NORM.S.DIST',
-    'NORM.S.INV',
-    'VARA',
-    'VARPA',
-    'SKEW',
-    'KURT',
-    'PROB',
-    'GROWTH',
-    'TREND',
-    'LINEST',
-    'LOGEST',
-    'FREQUENCY',
-    'MODE.MULT',
-    'AGGREGATE',
-    'T.TEST',
-    'Z.TEST',
-    'PERMUTATIONA',
-    'GAUSS',
-    'PHI',
-    'STDEVA',
-    'STDEVPA',
-    'SKEW.P',
-    'CHISQ.TEST',
-    'F.TEST',
-    'BINOM.DIST.RANGE',
-    'STDEV.S',
-    'STDEV.P',
-    'VAR.S',
-    'VAR.P',
-    'MODE.SNGL',
-    'NORM.DIST',
-    'NORM.INV',
-    'QUARTILE.INC',
-    'PERCENTILE.INC',
-    'RANK.EQ',
-    'PERCENTRANK.INC',
-    'COVARIANCE.P',
-    'FORECAST.LINEAR',
-  ]),
-  Text: new Set([
-    'TRIM',
-    'LEN',
-    'LEFT',
-    'RIGHT',
-    'MID',
-    'CONCATENATE',
-    'FIND',
-    'SEARCH',
-    'TEXTJOIN',
-    'LOWER',
-    'UPPER',
-    'PROPER',
-    'SUBSTITUTE',
-    'EXACT',
-    'REPLACE',
-    'REPT',
-    'T',
-    'VALUE',
-    'TEXT',
-    'CHAR',
-    'CODE',
-    'CLEAN',
-    'NUMBERVALUE',
-    'FIXED',
-    'DOLLAR',
-    'SPLIT',
-    'JOIN',
-    'REGEXMATCH',
-    'REGEXEXTRACT',
-    'REGEXREPLACE',
-    'UNICODE',
-    'UNICHAR',
-    'ENCODEURL',
-    'TEXTBEFORE',
-    'TEXTAFTER',
-    'VALUETOTEXT',
-    'TEXTSPLIT',
-  ]),
-  Database: new Set(['DSUM', 'DCOUNT', 'DCOUNTA', 'DAVERAGE', 'DMAX', 'DMIN', 'DPRODUCT', 'DGET', 'DSTDEV', 'DSTDEVP', 'DVAR', 'DVARP']),
+const textCatalog: Array<Omit<FunctionInfo, 'category'>> = [
+  {
+    name: 'TRIM',
+    description: 'Removes leading and trailing whitespace from text',
+    args: [
+      { name: 'text' },
+    ],
+  },
+  {
+    name: 'LEN',
+    description: 'Returns the number of characters in a text string',
+    args: [
+      { name: 'text' },
+    ],
+  },
+  {
+    name: 'LEFT',
+    description: 'Returns the leftmost characters from a text string',
+    args: [
+      { name: 'text' },
+      { name: 'num_chars', optional: true },
+    ],
+  },
+  {
+    name: 'RIGHT',
+    description: 'Returns the rightmost characters from a text string',
+    args: [
+      { name: 'text' },
+      { name: 'num_chars', optional: true },
+    ],
+  },
+  {
+    name: 'MID',
+    description: 'Returns characters from the middle of a text string',
+    args: [
+      { name: 'text' },
+      { name: 'start_num' },
+      { name: 'num_chars' },
+    ],
+  },
+  {
+    name: 'CONCATENATE',
+    description: 'Joins two or more text strings into one',
+    args: [
+      { name: 'text1' },
+      { name: 'text2' },
+      { name: 'text3', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'FIND',
+    description: 'Finds one text value inside another (case-sensitive)',
+    args: [
+      { name: 'search_for' },
+      { name: 'text_to_search' },
+      { name: 'starting_at', optional: true },
+    ],
+  },
+  {
+    name: 'SEARCH',
+    description: 'Finds one text value inside another (case-insensitive)',
+    args: [
+      { name: 'search_for' },
+      { name: 'text_to_search' },
+      { name: 'starting_at', optional: true },
+    ],
+  },
+  {
+    name: 'TEXTJOIN',
+    description: 'Joins text values with a delimiter',
+    args: [
+      { name: 'delimiter' },
+      { name: 'ignore_empty' },
+      { name: 'text1' },
+      { name: 'text2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'LOWER',
+    description: 'Converts text to lowercase',
+    args: [
+      { name: 'text' },
+    ],
+  },
+  {
+    name: 'UPPER',
+    description: 'Converts text to uppercase',
+    args: [
+      { name: 'text' },
+    ],
+  },
+  {
+    name: 'PROPER',
+    description: 'Capitalizes each word in text',
+    args: [
+      { name: 'text' },
+    ],
+  },
+  {
+    name: 'SUBSTITUTE',
+    description: 'Replaces existing text with new text in a string',
+    args: [
+      { name: 'text' },
+      { name: 'search_for' },
+      { name: 'replace_with' },
+      { name: 'occurrence', optional: true },
+    ],
+  },
+  {
+    name: 'EXACT',
+    description: 'Tests whether two strings are identical (case-sensitive)',
+    args: [
+      { name: 'text1' },
+      { name: 'text2' },
+    ],
+  },
+  {
+    name: 'REPLACE',
+    description: 'Replaces part of a text string with a different text string',
+    args: [
+      { name: 'old_text' },
+      { name: 'start_num' },
+      { name: 'num_chars' },
+      { name: 'new_text' },
+    ],
+  },
+  {
+    name: 'REPT',
+    description: 'Repeats text a given number of times',
+    args: [
+      { name: 'text' },
+      { name: 'number_times' },
+    ],
+  },
+  {
+    name: 'T',
+    description: 'Returns the text referred to by value',
+    args: [
+      { name: 'value' },
+    ],
+  },
+  {
+    name: 'VALUE',
+    description: 'Converts a text string that represents a number to a number',
+    args: [
+      { name: 'text' },
+    ],
+  },
+  {
+    name: 'TEXT',
+    description: 'Formats a number and converts it to text',
+    args: [
+      { name: 'number' },
+      { name: 'format' },
+    ],
+  },
+  {
+    name: 'CHAR',
+    description: 'Returns the character specified by the code number',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'CODE',
+    description: 'Returns a numeric code for the first character in a text string',
+    args: [
+      { name: 'text' },
+    ],
+  },
+  {
+    name: 'CLEAN',
+    description: 'Removes all non-printable characters from text',
+    args: [
+      { name: 'text' },
+    ],
+  },
+  {
+    name: 'NUMBERVALUE',
+    description: 'Converts text to a number in a locale-independent way',
+    args: [
+      { name: 'text' },
+      { name: 'decimal_separator', optional: true },
+      { name: 'group_separator', optional: true },
+    ],
+  },
+  {
+    name: 'FIXED',
+    description: 'Formats a number with a fixed number of decimal places',
+    args: [
+      { name: 'number' },
+      { name: 'decimals', optional: true },
+      { name: 'no_commas', optional: true },
+    ],
+  },
+  {
+    name: 'DOLLAR',
+    description: 'Formats a number as currency with a dollar sign',
+    args: [
+      { name: 'number' },
+      { name: 'decimals', optional: true },
+    ],
+  },
+  {
+    name: 'SPLIT',
+    description: 'Splits text around a delimiter',
+    args: [
+      { name: 'text' },
+      { name: 'delimiter' },
+      { name: 'split_by_each', optional: true },
+      { name: 'remove_empty', optional: true },
+    ],
+  },
+  {
+    name: 'JOIN',
+    description: 'Joins values with a delimiter',
+    args: [
+      { name: 'delimiter' },
+      { name: 'value1' },
+      { name: 'value2', optional: true, repeating: true },
+    ],
+  },
+  {
+    name: 'REGEXMATCH',
+    description: 'Returns whether text matches a regular expression',
+    args: [
+      { name: 'text' },
+      { name: 'regular_expression' },
+    ],
+  },
+  {
+    name: 'REGEXEXTRACT',
+    description: 'Extracts matching substrings using a regular expression',
+    args: [
+      { name: 'text' },
+      { name: 'regular_expression' },
+    ],
+  },
+  {
+    name: 'REGEXREPLACE',
+    description: 'Replaces text matching a regular expression',
+    args: [
+      { name: 'text' },
+      { name: 'regular_expression' },
+      { name: 'replacement' },
+    ],
+  },
+  {
+    name: 'UNICODE',
+    description: 'Returns the Unicode code point of the first character',
+    args: [
+      { name: 'text' },
+    ],
+  },
+  {
+    name: 'UNICHAR',
+    description: 'Returns the Unicode character for a code point',
+    args: [
+      { name: 'number' },
+    ],
+  },
+  {
+    name: 'ENCODEURL',
+    description: 'Encodes a string for use in a URL',
+    args: [
+      { name: 'text' },
+    ],
+  },
+  {
+    name: 'TEXTBEFORE',
+    description: 'Returns text before a specified delimiter',
+    args: [
+      { name: 'text' },
+      { name: 'delimiter' },
+      { name: 'instance_num', optional: true },
+    ],
+  },
+  {
+    name: 'TEXTAFTER',
+    description: 'Returns text after a specified delimiter',
+    args: [
+      { name: 'text' },
+      { name: 'delimiter' },
+      { name: 'instance_num', optional: true },
+    ],
+  },
+  {
+    name: 'VALUETOTEXT',
+    description: 'Converts a value to text',
+    args: [
+      { name: 'value' },
+      { name: 'format', optional: true },
+    ],
+  },
+  {
+    name: 'TEXTSPLIT',
+    description: 'Splits text by delimiter into parts',
+    args: [
+      { name: 'text' },
+      { name: 'col_delimiter' },
+      { name: 'row_delimiter', optional: true },
+      { name: 'ignore_empty', optional: true },
+    ],
+  },
+];
+
+const databaseCatalog: Array<Omit<FunctionInfo, 'category'>> = [
+  {
+    name: 'DSUM',
+    description: 'Sums values in a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DCOUNT',
+    description: 'Counts numeric values in a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DCOUNTA',
+    description: 'Counts non-empty values in a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DAVERAGE',
+    description: 'Averages values in a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DMAX',
+    description: 'Returns the maximum value in a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DMIN',
+    description: 'Returns the minimum value in a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DPRODUCT',
+    description: 'Returns the product of values in a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DGET',
+    description: 'Returns a single value from a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DSTDEV',
+    description: 'Returns the sample standard deviation of a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DSTDEVP',
+    description: 'Returns the population standard deviation of a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DVAR',
+    description: 'Returns the sample variance of a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+  {
+    name: 'DVARP',
+    description: 'Returns the population variance of a database field matching criteria',
+    args: [
+      { name: 'database' },
+      { name: 'field' },
+      { name: 'criteria' },
+    ],
+  },
+];
+
+/**
+ * FunctionCatalog lists all built-in functions with metadata for autocomplete.
+ */
+const FunctionCatalogEntries: Partial<
+  Record<FunctionCategory, Array<Omit<FunctionInfo, 'category'>>>
+> = {
+  Date: dateCatalog,
+  Engineering: engineeringCatalog,
+  Financial: financialCatalog,
+  Info: infoCatalog,
+  Logical: logicalCatalog,
+  Lookup: lookupCatalog,
+  Math: mathCatalog,
+  Operator: operatorCatalog,
+  Statistical: statisticalCatalog,
+  Text: textCatalog,
+  Database: databaseCatalog,
 };
 
-function resolveFunctionCategory(name: string): FunctionCategory {
-  for (const category of SheetsFunctionCategoryOrder) {
-    if (FunctionNamesByCategory[category]?.has(name)) {
-      return category;
-    }
-  }
 
-  throw new Error(`Missing Sheets category for function: ${name}`);
-}
-
-export const FunctionCatalog: FunctionInfo[] = FunctionCatalogEntries.map((info) => ({
-  ...info,
-  category: resolveFunctionCategory(info.name),
-}));
+export const FunctionCatalog: FunctionInfo[] = SheetsFunctionCategoryOrder.flatMap(
+  (category) =>
+    (FunctionCatalogEntries[category] ?? []).map((info) => ({
+      ...info,
+      category,
+    })),
+);
 
 /**
  * Lists categories in display order for the provided function set.
@@ -3016,6 +3904,46 @@ export function searchFunctions(prefix: string): FunctionInfo[] {
 export function findFunction(name: string): FunctionInfo | undefined {
   const upper = name.toUpperCase();
   return FunctionCatalog.find((f) => f.name === upper);
+}
+
+/**
+ * `Arity` describes the legal argument-count window of a function. `max` is
+ * `Infinity` when any tail is repeating. `step` is the count of contiguous
+ * trailing repeating args (1 for SUM, 2 for SUMIFS-style pairs) — extra
+ * args beyond `min` must arrive in multiples of `step`.
+ */
+export type Arity = {
+  min: number;
+  max: number;
+  step: number;
+};
+
+/**
+ * `getArity` derives the arity directly from the function's `args`
+ * definition so there is no second source of truth to drift from.
+ */
+export function getArity(info: FunctionInfo): Arity {
+  const args = info.args;
+  const min = args.filter((a) => !a.optional).length;
+  let trailingRepeating = 0;
+  for (let i = args.length - 1; i >= 0 && args[i].repeating; i--) {
+    trailingRepeating++;
+  }
+  const max = trailingRepeating > 0 ? Infinity : args.length;
+  const step = trailingRepeating;
+  return { min, max, step };
+}
+
+/**
+ * `isValidArity` returns true when `argCount` is in the function's
+ * declared min/max window. We deliberately ignore `step` here: some
+ * variadic tails (SWITCH's `[case_or_default, value, ...]`) allow a
+ * trailing lone arg, so an even/odd parity check would be too strict.
+ * Functions that need pairwise validation enforce it themselves.
+ */
+export function isValidArity(info: FunctionInfo, argCount: number): boolean {
+  const { min, max } = getArity(info);
+  return argCount >= min && argCount <= max;
 }
 
 /**

--- a/packages/sheets/src/formula/functions-database.ts
+++ b/packages/sheets/src/formula/functions-database.ts
@@ -199,10 +199,7 @@ function extractDatabaseValues(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): { values: number[]; strValues: string[] } | EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   // Parse database range
   const dbNode = visit(exprs[0]);

--- a/packages/sheets/src/formula/functions-date.ts
+++ b/packages/sheets/src/formula/functions-date.ts
@@ -15,15 +15,10 @@ import {
  * TODAY() — returns the current date as YYYY-MM-DD.
  */
 export function todayFunc(
-  ctx: FunctionContext,
+  _ctx: FunctionContext,
   _visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (args && args.expr().length > 0) {
-    return ErrNode.NA;
-  }
-
   return { t: 'str', v: formatDate(new Date()) };
 }
 
@@ -32,15 +27,10 @@ export function todayFunc(
  * NOW() — returns the current date and time as YYYY-MM-DD HH:MM:SS.
  */
 export function nowFunc(
-  ctx: FunctionContext,
+  _ctx: FunctionContext,
   _visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (args && args.expr().length > 0) {
-    return ErrNode.NA;
-  }
-
   const now = new Date();
   return { t: 'str', v: `${formatDate(now)} ${formatTime(now)}` };
 }
@@ -54,15 +44,7 @@ export function dateFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const yearNode = NumberArgs.map(visit(exprs[0]), grid);
   if (yearNode.t === 'err') {
@@ -96,15 +78,7 @@ export function timeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const hourNode = NumberArgs.map(visit(exprs[0]), grid);
   if (hourNode.t === 'err') {
@@ -138,15 +112,7 @@ export function daysFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const endDate = parseDate(visit(exprs[0]), grid);
   if (!(endDate instanceof Date)) {
@@ -182,15 +148,7 @@ export function yearFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDate(visit(exprs[0]), grid);
   if (!(date instanceof Date)) return date;
@@ -207,15 +165,7 @@ export function monthFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDate(visit(exprs[0]), grid);
   if (!(date instanceof Date)) return date;
@@ -232,15 +182,7 @@ export function dayFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDate(visit(exprs[0]), grid);
   if (!(date instanceof Date)) return date;
@@ -257,15 +199,7 @@ export function hourFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDateTime(visit(exprs[0]), grid);
   if (!(date instanceof Date)) {
@@ -284,15 +218,7 @@ export function minuteFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDateTime(visit(exprs[0]), grid);
   if (!(date instanceof Date)) {
@@ -311,15 +237,7 @@ export function secondFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDateTime(visit(exprs[0]), grid);
   if (!(date instanceof Date)) {
@@ -338,15 +256,7 @@ export function weekdayFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDate(visit(exprs[0]), grid);
   if (!(date instanceof Date)) {
@@ -384,15 +294,7 @@ export function edateFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDate(visit(exprs[0]), grid);
   if (!(date instanceof Date)) {
@@ -417,15 +319,7 @@ export function eomonthFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDate(visit(exprs[0]), grid);
   if (!(date instanceof Date)) {
@@ -452,15 +346,7 @@ export function networkdaysFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const startDate = parseDate(visit(exprs[0]), grid);
   if (!(startDate instanceof Date)) {
@@ -498,10 +384,7 @@ export function networkdaysintlFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const startDate = parseDate(visit(exprs[0]), grid);
   if ('t' in startDate) return startDate;
@@ -553,15 +436,7 @@ export function datevalueFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDate(visit(exprs[0]), grid);
   if (!(date instanceof Date)) {
@@ -579,15 +454,7 @@ export function timevalueFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDateTime(visit(exprs[0]), grid);
   if (!(date instanceof Date)) {
@@ -611,15 +478,7 @@ export function datedifFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const startDate = parseDate(visit(exprs[0]), grid);
   if (!(startDate instanceof Date)) {
@@ -714,15 +573,7 @@ export function weeknumFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDate(visit(exprs[0]), grid);
   if (!(date instanceof Date)) {
@@ -757,15 +608,7 @@ export function isoweeknumFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const date = parseDate(visit(exprs[0]), grid);
   if (!(date instanceof Date)) {
@@ -789,15 +632,7 @@ export function workdayFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const startDate = parseDate(visit(exprs[0]), grid);
   if (!(startDate instanceof Date)) {
@@ -852,10 +687,7 @@ export function workdayintlFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const startDate = parseDate(visit(exprs[0]), grid);
   if ('t' in startDate) return startDate;
@@ -911,15 +743,7 @@ export function yearfracFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const startDate = parseDate(visit(exprs[0]), grid);
   if (!(startDate instanceof Date)) {
@@ -1013,10 +837,7 @@ export function days360Func(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const startDate = parseDate(visit(exprs[0]), grid);
   if ('t' in startDate) return startDate;

--- a/packages/sheets/src/formula/functions-engineering.ts
+++ b/packages/sheets/src/formula/functions-engineering.ts
@@ -16,10 +16,7 @@ export function deltaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const n1 = NumberArgs.map(visit(exprs[0]), grid);
   if (n1.t === 'err') return n1;
@@ -42,10 +39,7 @@ export function gestepFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
@@ -68,10 +62,7 @@ export function erfFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const lower = NumberArgs.map(visit(exprs[0]), grid);
   if (lower.t === 'err') return lower;
@@ -93,10 +84,7 @@ export function erfcFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -112,10 +100,7 @@ export function convertFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const numNode = NumberArgs.map(visit(exprs[0]), grid);
   if (numNode.t === 'err') return numNode;
@@ -219,10 +204,7 @@ export function bitandFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const a = NumberArgs.map(visit(exprs[0]), grid);
   if (a.t === 'err') return a;
   const b = NumberArgs.map(visit(exprs[1]), grid);
@@ -239,10 +221,7 @@ export function bitorFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const a = NumberArgs.map(visit(exprs[0]), grid);
   if (a.t === 'err') return a;
   const b = NumberArgs.map(visit(exprs[1]), grid);
@@ -259,10 +238,7 @@ export function bitxorFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const a = NumberArgs.map(visit(exprs[0]), grid);
   if (a.t === 'err') return a;
   const b = NumberArgs.map(visit(exprs[1]), grid);
@@ -279,10 +255,7 @@ export function bitlshiftFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const a = NumberArgs.map(visit(exprs[0]), grid);
   if (a.t === 'err') return a;
   const b = NumberArgs.map(visit(exprs[1]), grid);
@@ -299,10 +272,7 @@ export function bitrshiftFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const a = NumberArgs.map(visit(exprs[0]), grid);
   if (a.t === 'err') return a;
   const b = NumberArgs.map(visit(exprs[1]), grid);
@@ -319,10 +289,7 @@ export function hex2decFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const hex = s.v.trim();
@@ -343,10 +310,7 @@ export function dec2hexFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   let val = Math.trunc(num.v);
@@ -377,10 +341,7 @@ export function bin2decFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const bin = s.v.trim();
@@ -401,10 +362,7 @@ export function dec2binFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   let val = Math.trunc(num.v);
@@ -435,10 +393,7 @@ export function oct2decFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const oct = s.v.trim();
@@ -459,10 +414,7 @@ export function dec2octFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   let val = Math.trunc(num.v);
@@ -493,10 +445,7 @@ export function hex2binFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const dec = parseInt(s.v, 16);
@@ -520,10 +469,7 @@ export function hex2octFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const dec = parseInt(s.v, 16);
@@ -547,10 +493,7 @@ export function bin2hexFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const dec = parseInt(s.v, 2);
@@ -574,10 +517,7 @@ export function bin2octFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const dec = parseInt(s.v, 2);
@@ -601,10 +541,7 @@ export function oct2hexFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const dec = parseInt(s.v, 8);
@@ -628,10 +565,7 @@ export function oct2binFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const dec = parseInt(s.v, 8);
@@ -655,10 +589,7 @@ export function complexFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const re = NumberArgs.map(visit(exprs[0]), grid);
   if (re.t === 'err') return re;
   const im = NumberArgs.map(visit(exprs[1]), grid);
@@ -692,10 +623,7 @@ export function imrealFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const c = parseComplex(s.v);
@@ -711,10 +639,7 @@ export function imaginaryFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const c = parseComplex(s.v);
@@ -730,10 +655,7 @@ export function imabsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const c = parseComplex(s.v);
@@ -749,10 +671,7 @@ export function imsumFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   let re = 0, im = 0;
   for (const expr of exprs) {
     const s = toStr(visit(expr), grid);
@@ -773,10 +692,7 @@ export function imsubFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s1 = toStr(visit(exprs[0]), grid);
   if (s1.t === 'err') return s1;
   const c1 = parseComplex(s1.v);
@@ -796,10 +712,7 @@ export function improductFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   let re = 1, im = 0;
   for (const expr of exprs) {
     const s = toStr(visit(expr), grid);
@@ -822,10 +735,7 @@ export function imdivFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s1 = toStr(visit(exprs[0]), grid);
   if (s1.t === 'err') return s1;
   const c1 = parseComplex(s1.v);
@@ -876,10 +786,7 @@ export function impowerFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const c = parseComplex(s.v);
@@ -1152,10 +1059,7 @@ export function besseljFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
   const n = NumberArgs.map(visit(exprs[1]), grid);
@@ -1173,10 +1077,7 @@ export function besselyFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
   const n = NumberArgs.map(visit(exprs[1]), grid);
@@ -1195,10 +1096,7 @@ export function besseliFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
   const n = NumberArgs.map(visit(exprs[1]), grid);
@@ -1216,10 +1114,7 @@ export function besselkFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
   const n = NumberArgs.map(visit(exprs[1]), grid);
@@ -1286,10 +1181,7 @@ function parseComplexArg(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): { re: number; im: number } | EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const s = toStr(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
   const c = parseComplex(s.v);

--- a/packages/sheets/src/formula/functions-financial.ts
+++ b/packages/sheets/src/formula/functions-financial.ts
@@ -54,10 +54,7 @@ export function pmtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
@@ -91,10 +88,7 @@ export function fvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
@@ -133,10 +127,7 @@ export function pvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
@@ -175,10 +166,7 @@ export function npvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
@@ -214,10 +202,7 @@ export function nperFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
@@ -257,10 +242,7 @@ export function ipmtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
@@ -312,10 +294,7 @@ export function ppmtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
@@ -364,10 +343,7 @@ export function slnFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const cost = NumberArgs.map(visit(exprs[0]), grid);
   if (cost.t === 'err') return cost;
   const salvage = NumberArgs.map(visit(exprs[1]), grid);
@@ -386,10 +362,7 @@ export function effectFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const nominal = NumberArgs.map(visit(exprs[0]), grid);
   if (nominal.t === 'err') return nominal;
   const periods = NumberArgs.map(visit(exprs[1]), grid);
@@ -407,10 +380,7 @@ export function rateFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const nper = NumberArgs.map(visit(exprs[0]), grid);
   if (nper.t === 'err') return nper;
@@ -463,10 +433,7 @@ export function irrFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const values = getCashFlowValues(exprs[0], visit, grid);
   if (!Array.isArray(values)) return values;
@@ -504,10 +471,7 @@ export function dbFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const cost = NumberArgs.map(visit(exprs[0]), grid);
   if (cost.t === 'err') return cost;
@@ -557,10 +521,7 @@ export function ddbFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const cost = NumberArgs.map(visit(exprs[0]), grid);
   if (cost.t === 'err') return cost;
@@ -606,10 +567,7 @@ export function nominalFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const effectiveRate = NumberArgs.map(visit(exprs[0]), grid);
   if (effectiveRate.t === 'err') return effectiveRate;
   const periods = NumberArgs.map(visit(exprs[1]), grid);
@@ -627,10 +585,7 @@ export function cumipmtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
@@ -675,10 +630,7 @@ export function cumprincFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
@@ -723,10 +675,7 @@ export function xnpvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
@@ -772,10 +721,7 @@ export function xirrFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const valuesResult = getRefsFromExpression(exprs[0], visit, grid);
   if (valuesResult.t === 'err') return valuesResult;
@@ -835,10 +781,7 @@ export function sydFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const cost = NumberArgs.map(visit(exprs[0]), grid);
   if (cost.t === 'err') return cost;
@@ -865,10 +808,7 @@ export function mirrFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const values = getCashFlowValues(exprs[0], visit, grid);
   if (!Array.isArray(values)) return values;
@@ -905,10 +845,7 @@ export function tbilleqFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const settlementNode = visit(exprs[0]);
   const maturityNode = visit(exprs[1]);
@@ -937,10 +874,7 @@ export function tbillpriceFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const settlementNode = visit(exprs[0]);
   const maturityNode = visit(exprs[1]);
@@ -969,10 +903,7 @@ export function tbillyieldFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const settlementNode = visit(exprs[0]);
   const maturityNode = visit(exprs[1]);
@@ -1001,10 +932,7 @@ export function dollardeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const dollar = NumberArgs.map(visit(exprs[0]), grid);
   if (dollar.t === 'err') return dollar;
@@ -1027,10 +955,7 @@ export function dollarfrFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const dollar = NumberArgs.map(visit(exprs[0]), grid);
   if (dollar.t === 'err') return dollar;
@@ -1054,10 +979,7 @@ export function accrintFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 6 || exprs.length > 7) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const issue = parseDate(visit(exprs[0]), grid);
   if (!(issue instanceof Date)) return issue;
   // first_interest is ignored in simplified calculation
@@ -1084,10 +1006,7 @@ export function accrintmFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const issue = parseDate(visit(exprs[0]), grid);
   if (!(issue instanceof Date)) return issue;
   const settlement = parseDate(visit(exprs[1]), grid);
@@ -1111,10 +1030,7 @@ export function coupdaybsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1135,10 +1051,7 @@ export function coupdaysFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1161,10 +1074,7 @@ export function coupdaysncFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1185,10 +1095,7 @@ export function coupncdFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1208,10 +1115,7 @@ export function coupnumFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1238,10 +1142,7 @@ export function couppcdFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1261,10 +1162,7 @@ export function discFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1289,10 +1187,7 @@ export function pricediscFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1316,10 +1211,7 @@ export function yielddiscFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1344,10 +1236,7 @@ export function durationFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 5 || exprs.length > 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1388,10 +1277,7 @@ export function mdurationFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 5 || exprs.length > 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1431,10 +1317,7 @@ export function receivedFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1460,10 +1343,7 @@ export function intrateFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1488,10 +1368,7 @@ export function priceFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 6 || exprs.length > 7) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1537,10 +1414,7 @@ export function yieldBondFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 6 || exprs.length > 7) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1597,10 +1471,7 @@ export function pricematFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 5 || exprs.length > 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1631,10 +1502,7 @@ export function yieldmatFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 5 || exprs.length > 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const settlement = parseDate(visit(exprs[0]), grid);
   if (!(settlement instanceof Date)) return settlement;
   const maturity = parseDate(visit(exprs[1]), grid);
@@ -1666,10 +1534,7 @@ export function amorlincFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 6 || exprs.length > 7) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const cost = NumberArgs.map(visit(exprs[0]), grid);
   if (cost.t === 'err') return cost;
   const purchaseDate = parseDate(visit(exprs[1]), grid);
@@ -1709,10 +1574,7 @@ export function ispmtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
   const per = NumberArgs.map(visit(exprs[1]), grid);
@@ -1732,10 +1594,7 @@ export function fvscheduleFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const principal = NumberArgs.map(visit(exprs[0]), grid);
   if (principal.t === 'err') return principal;
   const scheduleNode = visit(exprs[1]);
@@ -1766,10 +1625,7 @@ export function pdurationFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const rate = NumberArgs.map(visit(exprs[0]), grid);
   if (rate.t === 'err') return rate;
   const pv = NumberArgs.map(visit(exprs[1]), grid);
@@ -1788,10 +1644,7 @@ export function rriFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const nper = NumberArgs.map(visit(exprs[0]), grid);
   if (nper.t === 'err') return nper;
   const pv = NumberArgs.map(visit(exprs[1]), grid);

--- a/packages/sheets/src/formula/functions-helpers.ts
+++ b/packages/sheets/src/formula/functions-helpers.ts
@@ -330,4 +330,3 @@ export function wildcardToRegex(pattern: string): string {
 
   return regex;
 }
-

--- a/packages/sheets/src/formula/functions-info.ts
+++ b/packages/sheets/src/formula/functions-info.ts
@@ -22,15 +22,7 @@ export function isblankFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -56,15 +48,7 @@ export function isnumberFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -98,15 +82,7 @@ export function istextFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -142,15 +118,7 @@ export function iserrorFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = visit(exprs[0]);
   return { t: 'bool', v: value.t === 'err' };
@@ -165,15 +133,7 @@ export function iserrFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = visit(exprs[0]);
   return { t: 'bool', v: value.t === 'err' && value.v !== ErrValue.NA };
@@ -188,15 +148,7 @@ export function isnaFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = visit(exprs[0]);
   return { t: 'bool', v: value.t === 'err' && value.v === ErrValue.NA };
@@ -211,15 +163,7 @@ export function islogicalFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -249,15 +193,7 @@ export function isnontextFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -295,10 +231,7 @@ export function isevenFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   return { t: 'bool', v: Math.trunc(num.v) % 2 === 0 };
@@ -312,10 +245,7 @@ export function isoddFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   return { t: 'bool', v: Math.trunc(num.v) % 2 !== 0 };
@@ -329,15 +259,7 @@ export function isdateFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -365,10 +287,7 @@ export function isurlFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   const s = toStr(node, grid);
@@ -386,10 +305,7 @@ export function isformulaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t !== 'ref' || !grid) return { t: 'bool', v: false };
@@ -407,10 +323,7 @@ export function isrefFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   return { t: 'bool', v: node.t === 'ref' };
@@ -424,15 +337,7 @@ export function nFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -463,15 +368,10 @@ export function nFunc(
  * NA() — returns the #N/A error value.
  */
 export function naFunc(
-  ctx: FunctionContext,
+  _ctx: FunctionContext,
   _visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (args && args.expr().length > 0) {
-    return ErrNode.NA;
-  }
-
   return ErrNode.NA;
 }
 
@@ -484,15 +384,7 @@ export function typeFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   switch (node.t) {
@@ -522,15 +414,7 @@ export function errortypeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   const errValue = resolveErrValue(node, grid);
@@ -562,10 +446,7 @@ export function formulatextFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t !== 'ref' || !grid) return ErrNode.NA;
@@ -585,10 +466,7 @@ export function cellInfoFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const infoType = toStr(visit(exprs[0]), grid);
   if (infoType.t === 'err') return infoType;
   const typeStr = infoType.v.toLowerCase();

--- a/packages/sheets/src/formula/functions-logical.ts
+++ b/packages/sheets/src/formula/functions-logical.ts
@@ -16,15 +16,7 @@ export function ifFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const condition = BoolArgs.map(visit(exprs[0]), grid);
   if (condition.t === 'err') {
@@ -52,15 +44,7 @@ export function ifsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length % 2 !== 0) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   for (let i = 0; i < exprs.length; i += 2) {
     const condition = BoolArgs.map(visit(exprs[i]), grid);
@@ -85,15 +69,7 @@ export function switchFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const expression = toStr(visit(exprs[0]), grid);
   if (expression.t === 'err') {
@@ -131,12 +107,7 @@ export function andFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  for (const node of BoolArgs.iterate(args, visit, grid)) {
+  for (const node of BoolArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -158,12 +129,7 @@ export function orFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  for (const node of BoolArgs.iterate(args, visit, grid)) {
+  for (const node of BoolArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -185,15 +151,7 @@ export function notFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = BoolArgs.map(visit(exprs[0]), grid);
   if (value.t === 'err') {
@@ -211,13 +169,8 @@ export function xorFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let trueCount = 0;
-  for (const node of BoolArgs.iterate(args, visit, grid)) {
+  for (const node of BoolArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -237,15 +190,7 @@ export function chooseFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const indexNode = NumberArgs.map(visit(exprs[0]), grid);
   if (indexNode.t === 'err') {
@@ -269,15 +214,7 @@ export function iferrorFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = visit(exprs[0]);
   if (value.t === 'err') {
@@ -296,15 +233,7 @@ export function ifnaFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = visit(exprs[0]);
   if (value.t === 'err' && value.v === ErrValue.NA) {

--- a/packages/sheets/src/formula/functions-lookup.ts
+++ b/packages/sheets/src/formula/functions-lookup.ts
@@ -35,15 +35,7 @@ export function matchFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const lookup = lookupValueFromNode(visit(exprs[0]), grid);
   if (isFormulaError(lookup)) {
@@ -124,15 +116,7 @@ export function indexFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const mat: MatrixResult | ErrNode = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if (mat.t === 'err') return mat;
@@ -179,15 +163,7 @@ export function vlookupFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const lookup = lookupValueFromNode(visit(exprs[0]), grid);
   if (isFormulaError(lookup)) {
@@ -271,15 +247,7 @@ export function hlookupFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const lookup = lookupValueFromNode(visit(exprs[0]), grid);
   if (isFormulaError(lookup)) {
@@ -362,15 +330,7 @@ export function xlookupFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 6) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const keyNode = visit(exprs[0]);
   if (keyNode.t === 'err') {
@@ -479,10 +439,7 @@ export function xmatchFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const keyNode = visit(exprs[0]);
   if (keyNode.t === 'err') return keyNode;
@@ -573,15 +530,7 @@ export function lookupFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const keyNode = visit(exprs[0]);
   if (keyNode.t === 'err') {
@@ -640,15 +589,7 @@ export function indirectFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') {
@@ -680,15 +621,7 @@ export function offsetFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 5) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const refNode = visit(exprs[0]);
   if (refNode.t === 'err') {
@@ -752,15 +685,9 @@ export function rowFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args || args.expr().length === 0) {
-    return ErrNode.NA;
-  }
+  const args = ctx.args()!;
 
   const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -792,15 +719,9 @@ export function columnFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args || args.expr().length === 0) {
-    return ErrNode.NA;
-  }
+  const args = ctx.args()!;
 
   const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -832,15 +753,7 @@ export function rowsFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -875,15 +788,7 @@ export function columnsFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -918,15 +823,7 @@ export function addressFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 4) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rowNode = NumberArgs.map(visit(exprs[0]), grid);
   if (rowNode.t === 'err') {
@@ -976,15 +873,7 @@ export function hyperlinkFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const url = toStr(visit(exprs[0]), grid);
   if (url.t === 'err') {
@@ -1007,13 +896,9 @@ export function hyperlinkFunc(
  * Simplified: always returns 1 for a single reference.
  */
 export function areasFunc(
-  ctx: FunctionContext,
+  _ctx: FunctionContext,
   _visit: (tree: ParseTree) => EvalNode,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
   return { t: 'num', v: 1 };
 }
 
@@ -1025,10 +910,7 @@ export function sortFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const vals = collectNumericValues(exprs[0], visit, grid);
   if (!Array.isArray(vals)) return vals;
@@ -1054,10 +936,7 @@ export function sortbyFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -1107,10 +986,7 @@ export function flattenFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') return node;
@@ -1127,10 +1003,7 @@ export function transposeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -1167,10 +1040,7 @@ export function filterFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -1208,10 +1078,7 @@ export function sequenceFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const rowsNode = NumberArgs.map(visit(exprs[0]), grid);
   if (rowsNode.t === 'err') return rowsNode;
@@ -1236,9 +1103,8 @@ export function randarrayFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
+  const args = ctx.args()!;
   const exprs = args ? args.expr() : [];
-  if (exprs.length > 5) return ErrNode.NA;
 
   let min = 0, max = 1, whole = false;
   if (exprs.length >= 3) {
@@ -1271,10 +1137,7 @@ export function tocolFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -1336,10 +1199,7 @@ export function chooserowsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -1366,10 +1226,7 @@ export function choosecolsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -1396,10 +1253,7 @@ export function takeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -1440,10 +1294,7 @@ export function dropFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -1481,10 +1332,7 @@ export function hstackFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -1515,10 +1363,7 @@ export function wrapcolsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -1553,10 +1398,7 @@ export function expandFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;

--- a/packages/sheets/src/formula/functions-math.ts
+++ b/packages/sheets/src/formula/functions-math.ts
@@ -18,20 +18,15 @@ import {
 import { gammaLanczos } from './functions-statistical';
 
 /**
- * `sum` is the implementation of the SUM function.
+ * `sumFunc` is the implementation of the SUM function.
  */
-export function sum(
+export function sumFunc(
   ctx: FunctionContext,
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args()!;
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let value = 0;
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -54,15 +49,7 @@ export function absFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -81,15 +68,7 @@ export function roundFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = NumberArgs.map(visit(exprs[0]), grid);
   if (value.t === 'err') {
@@ -115,15 +94,7 @@ export function roundUpFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = NumberArgs.map(visit(exprs[0]), grid);
   if (value.t === 'err') {
@@ -150,15 +121,7 @@ export function roundDownFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = NumberArgs.map(visit(exprs[0]), grid);
   if (value.t === 'err') {
@@ -185,15 +148,7 @@ export function intFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = NumberArgs.map(visit(exprs[0]), grid);
   if (value.t === 'err') {
@@ -212,15 +167,7 @@ export function modFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const dividend = NumberArgs.map(visit(exprs[0]), grid);
   if (dividend.t === 'err') {
@@ -248,15 +195,7 @@ export function sqrtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = NumberArgs.map(visit(exprs[0]), grid);
   if (value.t === 'err') {
@@ -278,15 +217,7 @@ export function powerFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const base = NumberArgs.map(visit(exprs[0]), grid);
   if (base.t === 'err') {
@@ -315,13 +246,8 @@ export function productFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let value = 1;
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -335,15 +261,10 @@ export function productFunc(
  * PI() — returns the value of π.
  */
 export function piFunc(
-  ctx: FunctionContext,
+  _ctx: FunctionContext,
   _visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (args && args.expr().length > 0) {
-    return ErrNode.NA;
-  }
-
   return { t: 'num', v: Math.PI };
 }
 
@@ -355,15 +276,7 @@ export function signFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -381,15 +294,7 @@ export function evenFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -414,15 +319,7 @@ export function oddFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -448,15 +345,7 @@ export function expFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -474,15 +363,7 @@ export function lnFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -503,15 +384,7 @@ export function logFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -547,15 +420,7 @@ export function sinFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -573,15 +438,7 @@ export function cosFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -599,15 +456,7 @@ export function tanFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -625,15 +474,7 @@ export function asinFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -654,15 +495,7 @@ export function acosFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -683,15 +516,7 @@ export function atanFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -709,15 +534,7 @@ export function atan2Func(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') {
@@ -744,15 +561,7 @@ export function degreesFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -770,15 +579,7 @@ export function radiansFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -796,15 +597,7 @@ export function ceilingFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -839,15 +632,7 @@ export function floorFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -882,15 +667,7 @@ export function truncFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -918,15 +695,7 @@ export function mroundFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -958,10 +727,7 @@ export function ceilingmathFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
@@ -998,10 +764,7 @@ export function floormathFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
@@ -1037,10 +800,7 @@ export function ceilingpreciseFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
@@ -1064,10 +824,7 @@ export function floorpreciseFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
@@ -1092,10 +849,7 @@ export function isoceilingFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
@@ -1119,13 +873,8 @@ export function gcdFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let result = 0;
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -1147,14 +896,9 @@ export function lcmFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let result = 1;
   let hasValue = false;
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -1184,15 +928,7 @@ export function combinFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const nNode = NumberArgs.map(visit(exprs[0]), grid);
   if (nNode.t === 'err') {
@@ -1227,10 +963,7 @@ export function combinaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   const k = NumberArgs.map(visit(exprs[1]), grid);
@@ -1255,15 +988,7 @@ export function factFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -1291,10 +1016,7 @@ export function factdoubleFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   const n = Math.trunc(num.v);
@@ -1315,15 +1037,7 @@ export function quotientFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const numerator = NumberArgs.map(visit(exprs[0]), grid);
   if (numerator.t === 'err') {
@@ -1350,10 +1064,7 @@ export function baseFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   const base = NumberArgs.map(visit(exprs[1]), grid);
@@ -1377,10 +1088,7 @@ export function decimalFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') return str;
   const base = NumberArgs.map(visit(exprs[1]), grid);
@@ -1408,10 +1116,7 @@ export function sqrtpiFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   if (num.v < 0) return ErrNode.NUM;
@@ -1426,10 +1131,7 @@ export function sinhFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   return { t: 'num', v: Math.sinh(num.v) };
@@ -1443,10 +1145,7 @@ export function coshFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   return { t: 'num', v: Math.cosh(num.v) };
@@ -1460,10 +1159,7 @@ export function tanhFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   return { t: 'num', v: Math.tanh(num.v) };
@@ -1477,10 +1173,7 @@ export function asinhFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   return { t: 'num', v: Math.asinh(num.v) };
@@ -1494,10 +1187,7 @@ export function acoshFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   if (num.v < 1) return ErrNode.NUM;
@@ -1512,10 +1202,7 @@ export function atanhFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   if (num.v <= -1 || num.v >= 1) return ErrNode.NUM;
@@ -1530,10 +1217,7 @@ export function cotFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   const tan = Math.tan(num.v);
@@ -1549,10 +1233,7 @@ export function cscFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   const sin = Math.sin(num.v);
@@ -1568,10 +1249,7 @@ export function secFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   const cos = Math.cos(num.v);
@@ -1587,10 +1265,7 @@ export function sechFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   return { t: 'num', v: 1 / Math.cosh(n.v) };
@@ -1604,10 +1279,7 @@ export function cschFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   if (n.v === 0) return ErrNode.DIV0;
@@ -1622,10 +1294,7 @@ export function cothFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   if (n.v === 0) return ErrNode.DIV0;
@@ -1640,10 +1309,7 @@ export function acotFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   return { t: 'num', v: Math.atan(1 / n.v) };
@@ -1657,10 +1323,7 @@ export function acothFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   if (Math.abs(n.v) <= 1) return ErrNode.NUM;
@@ -1675,12 +1338,10 @@ export function multinomialFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
 
   let sum = 0;
   let denomProduct = 1;
-  for (const expr of args.expr()) {
+  for (const expr of ctx.args()!.expr()) {
     const n = NumberArgs.map(visit(expr), grid);
     if (n.t === 'err') return n;
     const val = Math.trunc(n.v);
@@ -1699,10 +1360,7 @@ export function seriessumFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -1733,13 +1391,8 @@ export function sumsqFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let total = 0;
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -1757,15 +1410,7 @@ export function sumproductFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const arrays: number[][] = [];
   for (const expr of exprs) {
@@ -1804,15 +1449,10 @@ export function sumproductFunc(
  * RAND() — returns a random number in [0, 1).
  */
 export function randFunc(
-  ctx: FunctionContext,
+  _ctx: FunctionContext,
   _visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (args && args.expr().length > 0) {
-    return ErrNode.NA;
-  }
-
   return { t: 'num', v: Math.random() };
 }
 
@@ -1825,15 +1465,7 @@ export function randbetweenFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const lowNode = NumberArgs.map(visit(exprs[0]), grid);
   if (lowNode.t === 'err') {
@@ -1901,10 +1533,7 @@ export function arabicFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const node = visit(exprs[0]);
   const strResult = toStr(node, grid);
   if (strResult.t === 'err') return strResult;
@@ -1951,10 +1580,7 @@ export function romanFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
@@ -1989,10 +1615,7 @@ export function permutFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const nNode = NumberArgs.map(visit(exprs[0]), grid);
   if (nNode.t === 'err') return nNode;
   const kNode = NumberArgs.map(visit(exprs[1]), grid);
@@ -2015,10 +1638,7 @@ export function permutationaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   const k = NumberArgs.map(visit(exprs[1]), grid);
@@ -2037,10 +1657,7 @@ export function subtotalFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const fnNode = NumberArgs.map(visit(exprs[0]), grid);
   if (fnNode.t === 'err') return fnNode;
@@ -2120,10 +1737,7 @@ export function aggregateFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const funcNum = NumberArgs.map(visit(exprs[0]), grid);
   if (funcNum.t === 'err') return funcNum;
   // Skip options (exprs[1])
@@ -2193,10 +1807,7 @@ export function mdetermFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') return node;
@@ -2285,10 +1896,7 @@ export function mmultFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m1 = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m1 && m1.t === 'err') return m1;
@@ -2331,10 +1939,7 @@ export function minverseFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const m = getReferenceMatrixFromExpression(exprs[0], visit, grid);
   if ('t' in m && m.t === 'err') return m;
@@ -2407,10 +2012,7 @@ export function munitFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   const size = Math.floor(n.v);
@@ -2468,10 +2070,7 @@ export function log10Func(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   if (n.v <= 0) return ErrNode.VALUE;
@@ -2479,7 +2078,7 @@ export function log10Func(
 }
 
 export const mathEntries: [string, (...args: any[]) => EvalNode][] = [
-  ['SUM', sum],
+  ['SUM', sumFunc],
   ['ABS', absFunc],
   ['ROUND', roundFunc],
   ['ROUNDUP', roundUpFunc],

--- a/packages/sheets/src/formula/functions-operator.ts
+++ b/packages/sheets/src/formula/functions-operator.ts
@@ -60,10 +60,7 @@ function twoArgs(
   ctx: FunctionContext,
   visit: (tree: ParseTree) => EvalNode,
 ): [EvalNode, EvalNode] | ErrNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   return [visit(exprs[0]), visit(exprs[1])];
 }
 
@@ -72,10 +69,7 @@ function oneArg(
   ctx: FunctionContext,
   visit: (tree: ParseTree) => EvalNode,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   return visit(exprs[0]);
 }
 
@@ -240,10 +234,7 @@ export function isbetweenFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const value = resolveScalar(visit(exprs[0]), grid);
   const lower = resolveScalar(visit(exprs[1]), grid);
@@ -282,10 +273,7 @@ export function concatFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   let result = '';
   for (const expr of exprs) {
@@ -301,10 +289,7 @@ export function uniqueFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') return node;

--- a/packages/sheets/src/formula/functions-statistical.ts
+++ b/packages/sheets/src/formula/functions-statistical.ts
@@ -18,22 +18,17 @@ import {
 } from './functions-helpers';
 
 /**
- * `average` is the implementation of the AVERAGE function.
+ * `averageFunc` is the implementation of the AVERAGE function.
  * AVERAGE(number1, [number2], ...) — returns the arithmetic mean.
  */
-export function average(
+export function averageFunc(
   ctx: FunctionContext,
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args()!;
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let sum = 0;
   let count = 0;
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -57,13 +52,8 @@ export function medianFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   const values: number[] = [];
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -92,13 +82,8 @@ export function minFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args()!;
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let result = Infinity;
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -119,13 +104,8 @@ export function maxFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args()!;
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let result = -Infinity;
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -146,13 +126,8 @@ export function countFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args()!;
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let count = 0;
-  for (const expr of args.expr()) {
+  for (const expr of ctx.args()!.expr()) {
     const node = visit(expr);
     if (node.t === 'num') {
       count++;
@@ -196,13 +171,8 @@ export function countaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args()!;
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let count = 0;
-  for (const expr of args.expr()) {
+  for (const expr of ctx.args()!.expr()) {
     const node = visit(expr);
     if (node.t === 'num' || node.t === 'bool') {
       count++;
@@ -239,13 +209,8 @@ export function countblankFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args()!;
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   let count = 0;
-  for (const expr of args.expr()) {
+  for (const expr of ctx.args()!.expr()) {
     const node = visit(expr);
 
     if (node.t === 'str') {
@@ -287,15 +252,7 @@ export function countifFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const refs = getRefsFromExpression(exprs[0], visit, grid);
   if (refs.t === 'err') {
@@ -327,15 +284,7 @@ export function sumifFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const criteriaRefs = getRefsFromExpression(exprs[0], visit, grid);
   if (criteriaRefs.t === 'err') {
@@ -382,15 +331,7 @@ export function countifsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length % 2 !== 0) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const ranges: string[][] = [];
   const criteria: ParsedCriterion[] = [];
@@ -441,15 +382,7 @@ export function sumifsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3 || (exprs.length - 1) % 2 !== 0) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const sumRefs = getRefsFromExpression(exprs[0], visit, grid);
   if (sumRefs.t === 'err') {
@@ -503,15 +436,7 @@ export function averageifFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const criteriaRefs = getRefsFromExpression(exprs[0], visit, grid);
   if (criteriaRefs.t === 'err') {
@@ -566,15 +491,7 @@ export function averageifsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3 || (exprs.length - 1) % 2 !== 0) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const avgRefs = getRefsFromExpression(exprs[0], visit, grid);
   if (avgRefs.t === 'err') {
@@ -638,15 +555,7 @@ export function largeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const values: number[] = [];
   const dataNode = visit(exprs[0]);
@@ -686,15 +595,7 @@ export function smallFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const values: number[] = [];
   const dataNode = visit(exprs[0]);
@@ -734,13 +635,8 @@ export function stdevFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   const values: number[] = [];
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -764,13 +660,8 @@ export function stdevpFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   const values: number[] = [];
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -794,13 +685,8 @@ export function varFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   const values: number[] = [];
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -824,13 +710,8 @@ export function varpFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   const values: number[] = [];
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -854,13 +735,8 @@ export function modeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   const values: number[] = [];
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') {
       return node;
     }
@@ -901,10 +777,7 @@ export function modemultFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const nums: number[] = [];
   for (const expr of exprs) {
     const result = collectNumericValues(expr, visit, grid);
@@ -933,15 +806,7 @@ export function quartileFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const values: number[] = [];
   const dataNode = visit(exprs[0]);
@@ -992,10 +857,7 @@ export function quartileexcFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const vals = collectNumericValues(exprs[0], visit, grid);
   if (!Array.isArray(vals)) return vals;
@@ -1024,13 +886,8 @@ export function countuniqueFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
   const unique = new Set<string>();
-  const exprs = args.expr();
+  const exprs = ctx.args()?.expr() ?? [];
   for (const expr of exprs) {
     const node = visit(expr);
     if (node.t === 'err') {
@@ -1064,15 +921,7 @@ export function rankFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const valueNode = NumberArgs.map(visit(exprs[0]), grid);
   if (valueNode.t === 'err') {
@@ -1129,10 +978,7 @@ export function rankavgFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const valueNode = NumberArgs.map(visit(exprs[0]), grid);
   if (valueNode.t === 'err') return valueNode;
@@ -1168,15 +1014,7 @@ export function percentileFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const values: number[] = [];
   const dataNode = visit(exprs[0]);
@@ -1227,10 +1065,7 @@ export function percentileexcFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const vals = collectNumericValues(exprs[0], visit, grid);
   if (!Array.isArray(vals)) return vals;
@@ -1258,10 +1093,7 @@ export function percentrankFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const vals = collectNumericValues(exprs[0], visit, grid);
   if (!Array.isArray(vals)) return vals;
@@ -1313,10 +1145,7 @@ export function percentrankexcFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const vals = collectNumericValues(exprs[0], visit, grid);
   if (!Array.isArray(vals)) return vals;
@@ -1364,10 +1193,7 @@ export function trimmeanFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const dataNode = visit(exprs[0]);
   if (dataNode.t === 'err') return dataNode;
@@ -1406,10 +1232,8 @@ export function geomeanFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
   const values: number[] = [];
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') return node;
     if (node.v <= 0) return ErrNode.VALUE;
     values.push(node.v);
@@ -1427,10 +1251,8 @@ export function harmeanFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
   const values: number[] = [];
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') return node;
     if (node.v <= 0) return ErrNode.VALUE;
     values.push(node.v);
@@ -1448,10 +1270,8 @@ export function avedevFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
   const values: number[] = [];
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') return node;
     values.push(node.v);
   }
@@ -1469,10 +1289,8 @@ export function devsqFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
   const values: number[] = [];
-  for (const node of NumberArgs.iterate(args, visit, grid)) {
+  for (const node of NumberArgs.iterate(ctx.args()!, visit, grid)) {
     if (node.t === 'err') return node;
     values.push(node.v);
   }
@@ -1489,12 +1307,10 @@ export function averageaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
 
   let sum = 0;
   let count = 0;
-  for (const expr of args.expr()) {
+  for (const expr of ctx.args()!.expr()) {
     const node = visit(expr);
     if (node.t === 'err') return node;
     if (node.t === 'ref' && grid) {
@@ -1529,12 +1345,10 @@ export function minaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
 
   let min = Infinity;
   let hasValue = false;
-  for (const expr of args.expr()) {
+  for (const expr of ctx.args()!.expr()) {
     const node = visit(expr);
     if (node.t === 'err') return node;
     if (node.t === 'ref' && grid) {
@@ -1571,12 +1385,10 @@ export function maxaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
 
   let max = -Infinity;
   let hasValue = false;
-  for (const expr of args.expr()) {
+  for (const expr of ctx.args()!.expr()) {
     const node = visit(expr);
     if (node.t === 'err') return node;
     if (node.t === 'ref' && grid) {
@@ -1613,15 +1425,7 @@ export function minifsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3 || (exprs.length - 1) % 2 !== 0) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const minRefs = getRefsFromExpression(exprs[0], visit, grid);
   if (minRefs.t === 'err') {
@@ -1683,15 +1487,7 @@ export function maxifsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3 || (exprs.length - 1) % 2 !== 0) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const maxRefs = getRefsFromExpression(exprs[0], visit, grid);
   if (maxRefs.t === 'err') {
@@ -1753,10 +1549,7 @@ export function fisherFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
   if (x.v <= -1 || x.v >= 1) return ErrNode.VALUE;
@@ -1771,10 +1564,7 @@ export function fisherinvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const y = NumberArgs.map(visit(exprs[0]), grid);
   if (y.t === 'err') return y;
   const e2y = Math.exp(2 * y.v);
@@ -1789,10 +1579,7 @@ export function gammaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   if (n.v <= 0 && Number.isInteger(n.v)) return ErrNode.VALUE;
@@ -1807,10 +1594,7 @@ export function gammalnFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const n = NumberArgs.map(visit(exprs[0]), grid);
   if (n.t === 'err') return n;
   if (n.v <= 0) return ErrNode.VALUE;
@@ -1825,10 +1609,7 @@ export function normdistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -1856,10 +1637,7 @@ export function norminvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const p = NumberArgs.map(visit(exprs[0]), grid);
   if (p.t === 'err') return p;
@@ -1880,10 +1658,7 @@ export function normsdistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const z = NumberArgs.map(visit(exprs[0]), grid);
   if (z.t === 'err') return z;
@@ -1904,10 +1679,7 @@ export function normsinvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const p = NumberArgs.map(visit(exprs[0]), grid);
   if (p.t === 'err') return p;
@@ -1924,10 +1696,7 @@ export function lognormdistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -1955,10 +1724,7 @@ export function lognorminvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const p = NumberArgs.map(visit(exprs[0]), grid);
   if (p.t === 'err') return p;
@@ -1979,10 +1745,7 @@ export function standardizeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -2003,10 +1766,7 @@ export function weibulldistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -2033,10 +1793,7 @@ export function poissondistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -2068,10 +1825,7 @@ export function binomdistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const s = NumberArgs.map(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
@@ -2113,10 +1867,7 @@ export function binomdistrangeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const trials = NumberArgs.map(visit(exprs[0]), grid);
   if (trials.t === 'err') return trials;
@@ -2157,10 +1908,7 @@ export function biominvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const nNode = NumberArgs.map(visit(exprs[0]), grid);
   if (nNode.t === 'err') return nNode;
@@ -2194,10 +1942,7 @@ export function expondistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -2222,10 +1967,7 @@ export function confidencenormFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const alpha = NumberArgs.map(visit(exprs[0]), grid);
   if (alpha.t === 'err') return alpha;
@@ -2250,10 +1992,7 @@ export function confidencetFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const alpha = NumberArgs.map(visit(exprs[0]), grid);
   if (alpha.t === 'err') return alpha;
@@ -2283,10 +2022,7 @@ export function chisqdistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -2317,10 +2053,7 @@ export function chisqinvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const p = NumberArgs.map(visit(exprs[0]), grid);
   if (p.t === 'err') return p;
@@ -2355,10 +2088,7 @@ export function chisqdistrtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -2378,10 +2108,7 @@ export function chisqinvrtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const p = NumberArgs.map(visit(exprs[0]), grid);
   if (p.t === 'err') return p;
@@ -2416,10 +2143,7 @@ export function chisqtestFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
@@ -2451,10 +2175,7 @@ export function tdistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -2490,10 +2211,7 @@ export function tinvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const p = NumberArgs.map(visit(exprs[0]), grid);
   if (p.t === 'err') return p;
@@ -2512,10 +2230,7 @@ export function tdistrtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -2539,10 +2254,7 @@ export function tdist2tFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
@@ -2565,10 +2277,7 @@ export function tinv2tFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const p = NumberArgs.map(visit(exprs[0]), grid);
   if (p.t === 'err') return p;
@@ -2590,10 +2299,7 @@ export function ttestFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
   const arr1 = result.ys;
@@ -2627,10 +2333,7 @@ export function fdistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const xNode = NumberArgs.map(visit(exprs[0]), grid);
   if (xNode.t === 'err') return xNode;
@@ -2668,10 +2371,7 @@ export function finvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const pNode = NumberArgs.map(visit(exprs[0]), grid);
   if (pNode.t === 'err') return pNode;
@@ -2715,10 +2415,7 @@ export function fdistrtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const xNode = NumberArgs.map(visit(exprs[0]), grid);
   if (xNode.t === 'err') return xNode;
@@ -2744,10 +2441,7 @@ export function finvrtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const pNode = NumberArgs.map(visit(exprs[0]), grid);
   if (pNode.t === 'err') return pNode;
@@ -2788,10 +2482,7 @@ export function ftestFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
@@ -2824,10 +2515,7 @@ export function hypgeomdistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const s = NumberArgs.map(visit(exprs[0]), grid);
   if (s.t === 'err') return s;
@@ -2876,10 +2564,7 @@ export function negbinomdistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const f = NumberArgs.map(visit(exprs[0]), grid);
   if (f.t === 'err') return f;
@@ -2920,10 +2605,7 @@ export function betadistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 4 || exprs.length > 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const xNode = NumberArgs.map(visit(exprs[0]), grid);
   if (xNode.t === 'err') return xNode;
@@ -2971,10 +2653,7 @@ export function betainvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 5) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const pNode = NumberArgs.map(visit(exprs[0]), grid);
   if (pNode.t === 'err') return pNode;
@@ -3024,10 +2703,7 @@ export function gammadistFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const xNode = NumberArgs.map(visit(exprs[0]), grid);
   if (xNode.t === 'err') return xNode;
@@ -3059,10 +2735,7 @@ export function gammainvFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const pNode = NumberArgs.map(visit(exprs[0]), grid);
   if (pNode.t === 'err') return pNode;
@@ -3099,10 +2772,7 @@ export function ztestFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const dataResult = collectNumericValues(exprs[0], visit, grid);
   if (!Array.isArray(dataResult)) return dataResult;
   if (dataResult.length === 0) return ErrNode.VALUE;
@@ -3132,15 +2802,7 @@ export function forecastFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const xNode = NumberArgs.map(visit(exprs[0]), grid);
   if (xNode.t === 'err') {
@@ -3162,15 +2824,7 @@ export function slopeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const data = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in data) return data;
@@ -3187,15 +2841,7 @@ export function interceptFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const data = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in data) return data;
@@ -3212,15 +2858,7 @@ export function correlFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const data = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in data) return data;
@@ -3256,10 +2894,7 @@ export function covarFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
@@ -3279,10 +2914,7 @@ export function covarsFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
@@ -3303,10 +2935,7 @@ export function rsqFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
@@ -3331,10 +2960,7 @@ export function steyxFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
@@ -3360,10 +2986,7 @@ export function sumx2my2Func(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
@@ -3385,10 +3008,7 @@ export function sumx2py2Func(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
@@ -3409,10 +3029,7 @@ export function sumxmy2Func(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
@@ -3434,10 +3051,7 @@ export function probFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const result = extractPairedArrays(exprs[0], exprs[1], visit, grid);
   if ('t' in result) return result;
@@ -3478,10 +3092,7 @@ export function growthFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const result = extractPairedArrays(exprs[0], exprs.length >= 2 ? exprs[1] : undefined, visit, grid);
   if ('t' in result) return result;
   // result.ys = known_y (first arg), result.xs = known_x (second arg)
@@ -3511,10 +3122,7 @@ export function trendFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const result = extractPairedArrays(exprs[0], exprs.length >= 2 ? exprs[1] : undefined, visit, grid);
   if ('t' in result) return result;
   const knownY = result.ys;
@@ -3540,10 +3148,7 @@ export function linestFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const result = extractPairedArrays(exprs[0], exprs.length >= 2 ? exprs[1] : undefined, visit, grid);
   if ('t' in result) return result;
   const knownY = result.ys;
@@ -3563,10 +3168,7 @@ export function logestFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const result = extractPairedArrays(exprs[0], exprs.length >= 2 ? exprs[1] : undefined, visit, grid);
   if ('t' in result) return result;
   const knownY = result.ys;
@@ -3588,10 +3190,7 @@ export function frequencyFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const dataResult = collectNumericValues(exprs[0], visit, grid);
   if (!Array.isArray(dataResult)) return dataResult;
   const binsResult = collectNumericValues(exprs[1], visit, grid);
@@ -3623,10 +3222,7 @@ export function varaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length === 0) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const values: number[] = [];
   for (const expr of exprs) {
@@ -3661,10 +3257,7 @@ export function varpaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length === 0) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const values: number[] = [];
   for (const expr of exprs) {
@@ -3699,10 +3292,7 @@ export function skewFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length === 0) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const values: number[] = [];
   for (const expr of exprs) {
@@ -3734,9 +3324,7 @@ export function skewpFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
+  const exprs = ctx.args()?.expr() ?? [];
   const values: number[] = [];
   for (const expr of exprs) {
     const result = collectNumericValues(expr, visit, grid);
@@ -3760,10 +3348,7 @@ export function kurtFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length === 0) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const values: number[] = [];
   for (const expr of exprs) {
@@ -3797,9 +3382,7 @@ export function stdevaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
+  const exprs = ctx.args()?.expr() ?? [];
   const values: number[] = [];
   for (const expr of exprs) {
     const node = visit(expr);
@@ -3835,9 +3418,7 @@ export function stdevpaFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
+  const exprs = ctx.args()?.expr() ?? [];
   const values: number[] = [];
   for (const expr of exprs) {
     const node = visit(expr);
@@ -3874,10 +3455,7 @@ export function gaussFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const z = NumberArgs.map(visit(exprs[0]), grid);
   if (z.t === 'err') return z;
   return { t: 'num', v: normCdf(z.v) - 0.5 };
@@ -3891,10 +3469,7 @@ export function phiFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const x = NumberArgs.map(visit(exprs[0]), grid);
   if (x.t === 'err') return x;
   return { t: 'num', v: normPdf(x.v) };
@@ -4270,7 +3845,7 @@ function binomPmf(n: number, k: number, p: number): number {
 }
 
 export const statisticalEntries: [string, (...args: any[]) => EvalNode][] = [
-  ['AVERAGE', average],
+  ['AVERAGE', averageFunc],
   ['MEDIAN', medianFunc],
   ['MIN', minFunc],
   ['MAX', maxFunc],

--- a/packages/sheets/src/formula/functions-text.ts
+++ b/packages/sheets/src/formula/functions-text.ts
@@ -21,15 +21,7 @@ export function trimFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') return str;
@@ -46,15 +38,7 @@ export function lenFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') return str;
@@ -71,15 +55,7 @@ export function leftFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') return str;
@@ -103,15 +79,7 @@ export function rightFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') return str;
@@ -135,15 +103,7 @@ export function midFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') return str;
@@ -167,15 +127,7 @@ export function concatenateFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   let result = '';
   for (const expr of exprs) {
@@ -196,15 +148,7 @@ export function findFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const searchFor = toStr(visit(exprs[0]), grid);
   if (searchFor.t === 'err') {
@@ -242,15 +186,7 @@ export function searchFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const searchFor = toStr(visit(exprs[0]), grid);
   if (searchFor.t === 'err') {
@@ -291,15 +227,7 @@ export function textjoinFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const delimiter = toStr(visit(exprs[0]), grid);
   if (delimiter.t === 'err') {
@@ -351,15 +279,7 @@ export function lowerFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') {
@@ -378,15 +298,7 @@ export function upperFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') {
@@ -405,15 +317,7 @@ export function properFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') {
@@ -436,15 +340,7 @@ export function substituteFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 3 || exprs.length > 4) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const text = toStr(visit(exprs[0]), grid);
   if (text.t === 'err') {
@@ -508,15 +404,7 @@ export function exactFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const a = toStr(visit(exprs[0]), grid);
   if (a.t === 'err') {
@@ -539,15 +427,7 @@ export function replaceFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 4) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const oldText = toStr(visit(exprs[0]), grid);
   if (oldText.t === 'err') {
@@ -587,15 +467,7 @@ export function reptFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const text = toStr(visit(exprs[0]), grid);
   if (text.t === 'err') {
@@ -623,15 +495,7 @@ export function tFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') {
@@ -665,15 +529,7 @@ export function valueFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') {
@@ -698,15 +554,7 @@ export function textFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -833,15 +681,7 @@ export function charFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -864,15 +704,7 @@ export function codeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') {
@@ -894,15 +726,7 @@ export function cleanFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 1) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') {
@@ -922,15 +746,7 @@ export function numbervalueFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') {
@@ -988,15 +804,7 @@ export function fixedFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 3) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -1046,15 +854,7 @@ export function dollarFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') {
@@ -1096,15 +896,7 @@ export function splitFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 4) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const text = toStr(visit(exprs[0]), grid);
   if (text.t === 'err') {
@@ -1159,15 +951,7 @@ export function joinFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length < 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const delimiter = toStr(visit(exprs[0]), grid);
   if (delimiter.t === 'err') {
@@ -1205,15 +989,7 @@ export function regexmatchFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) {
-    return ErrNode.NA;
-  }
-
-  const exprs = args.expr();
-  if (exprs.length !== 2) {
-    return ErrNode.NA;
-  }
+  const exprs = ctx.args()?.expr() ?? [];
 
   const text = toStr(visit(exprs[0]), grid);
   if (text.t === 'err') {
@@ -1241,10 +1017,7 @@ export function regexextractFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const text = toStr(visit(exprs[0]), grid);
   if (text.t === 'err') return text;
   const pattern = toStr(visit(exprs[1]), grid);
@@ -1266,10 +1039,7 @@ export function regexreplaceFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const text = toStr(visit(exprs[0]), grid);
   if (text.t === 'err') return text;
   const pattern = toStr(visit(exprs[1]), grid);
@@ -1291,10 +1061,7 @@ export function unicodeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const str = toStr(visit(exprs[0]), grid);
   if (str.t === 'err') return str;
   if (str.v.length === 0) return ErrNode.VALUE;
@@ -1309,10 +1076,7 @@ export function unicharFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
   const num = NumberArgs.map(visit(exprs[0]), grid);
   if (num.t === 'err') return num;
   const code = Math.trunc(num.v);
@@ -1332,10 +1096,7 @@ export function encodeurlFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length !== 1) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   const s = toStr(node, grid);
@@ -1351,10 +1112,7 @@ export function textbeforeFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const textNode = toStr(visit(exprs[0]), grid);
   if (textNode.t === 'err') return textNode;
@@ -1398,10 +1156,7 @@ export function textafterFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 3) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const textNode = toStr(visit(exprs[0]), grid);
   if (textNode.t === 'err') return textNode;
@@ -1445,10 +1200,7 @@ export function valuetotextFunc(
   visit: (tree: ParseTree) => EvalNode,
   grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 1 || exprs.length > 2) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
   if (node.t === 'err') return node;
@@ -1477,10 +1229,7 @@ export function textsplitFunc(
   visit: (tree: ParseTree) => EvalNode,
   _grid?: Grid,
 ): EvalNode {
-  const args = ctx.args();
-  if (!args) return ErrNode.NA;
-  const exprs = args.expr();
-  if (exprs.length < 2 || exprs.length > 6) return ErrNode.NA;
+  const exprs = ctx.args()?.expr() ?? [];
 
   const textNode = visit(exprs[0]);
   const text = textNode.t === 'str' ? textNode.v : textNode.t === 'num' ? String(textNode.v) : '';


### PR DESCRIPTION
## Summary
Every built-in opened with the same four-line boilerplate — pull args out, null-check, count exprs, range-check — and returned `#N/A` on mismatch. The catalog already knows each function's parameter shape, so move the count check upstream into `visitFunction` and derive the arity from `args` (min = required count, max = Infinity when any tail is repeating). Built-ins now just call `ctx.args()?.expr() ?? []` and trust that the dispatcher has already rejected illegal counts.

`step` is derived but not enforced at the dispatch gate: variadic tails like SWITCH's `[case_or_default, value, ...]` allow a lone trailing default, so a strict parity check would be too aggressive.

Inline `category` directly on each catalog entry, group entries by category in a `Partial<Record<FunctionCategory, ...>>`, and extract each category's array to its own top-level const (`dateCatalog`, `mathCatalog`, …). `FunctionCatalog` flattens the named consts back to a flat `FunctionInfo[]` with `category` re-attached from the map key. This drops `FunctionNamesByCategory` and `resolveFunctionCategory` — a second source of truth that drifted silently from runtime entries.

Also normalize every entry to the canonical multi-line shape so single-line operator entries like `GTE` and `LT` read the same as the rest, and rename `sum` / `average` to `sumFunc` / `averageFunc` to match the rest of the impl convention.

Net: 11 functions-*.ts files lose ~940 lines of boilerplate, no catalog/runtime drift surface, and zero-arg functions like RAND no longer special-case the "no args at all" path inside each impl.

## Why

## Linked Issues

Fixes #

## Author checklist

- [X] I searched existing issues and PRs and confirmed this is not a duplicate.
- [X] I read every line of this diff and can explain why each change is necessary.
- [X] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [X] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Formula functions now properly validate argument counts and return `#NA` errors when invalid arity is detected, ensuring consistent behavior across all formulas.
  * Improved error handling for edge cases involving missing or malformed function arguments, providing more predictable results.

* **Improvements**
  * Enhanced formula evaluation consistency and reliability through unified argument validation patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->