### PR TITLE
Preserve slides thumbnail scroll + add arrow key navigation

### DIFF
--- a/docs/tasks/active/20260517-slides-thumbnail-scroll-arrow-todo.md
+++ b/docs/tasks/active/20260517-slides-thumbnail-scroll-arrow-todo.md
@@ -1,0 +1,70 @@
+# Slides Thumbnail — Preserve Scroll + Arrow Key Navigation
+
+**Goal:** Fix the thumbnail panel scroll position resetting to the top
+on every click, and add ArrowUp/ArrowDown keyboard navigation when the
+panel is focused.
+
+---
+
+### Background
+
+`packages/slides/src/view/editor/thumbnail-panel.ts`'s `render()` wipes
+the panel with `container.innerHTML = ''` and rebuilds every thumbnail.
+While the children are gone the scrollable ancestor's `scrollHeight`
+collapses, the browser clamps `scrollTop` to 0, and the just-appended
+children paint at the top. Every click triggers `render()` (via the
+`onSelectionChange` subscription **plus** an explicit force-render in
+the click handler), so the user constantly snaps back to slide 1.
+
+Arrow keys are reserved for element nudging on the canvas
+(`keyboard.ts:97-124`). Slide navigation already exists for
+PageUp/PageDown but the thumbnail panel itself isn't focusable and has
+no keydown listener.
+
+### Task 1 — Preserve scroll position across `render()`
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/thumbnail-panel.ts`
+- Modify: `packages/slides/test/view/editor/thumbnail-panel.test.ts`
+
+- [ ] Walk up from `container` to find the scrollable ancestor
+      (`overflowY: auto | scroll`).
+- [ ] Capture its `scrollTop` before `innerHTML = ''`; restore after
+      all thumbnails are re-appended.
+- [ ] Subscribe to `editor.onCurrentSlideChange` instead of
+      `onSelectionChange` — element selection changes don't affect
+      thumbnail content and trigger redundant renders. Drop the
+      force-render in the click handler now that the subscription
+      catches the .current highlight update.
+- [ ] Test: after scrolling the panel and clicking a thumbnail, the
+      scroll position is preserved.
+
+### Task 2 — Arrow key navigation on the thumbnail panel
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/thumbnail-panel.ts`
+- Modify: `packages/slides/test/view/editor/thumbnail-panel.test.ts`
+
+- [ ] Make `container` keyboard-focusable (`tabIndex = 0`,
+      `outline: none` so no visible focus ring on the host).
+- [ ] On plain click of a thumbnail, focus the container with
+      `{ preventScroll: true }` so subsequent arrow keys route here.
+- [ ] Add a keydown listener on `container`: ArrowUp / ArrowDown moves
+      to prev / next slide via `editor.setCurrentSlide` (clamped at
+      ends, `preventDefault` on actual moves to stop the scrollable
+      parent from page-scrolling).
+- [ ] After moving, `scrollIntoView({ block: 'nearest' })` on the new
+      current thumb so off-screen targets become visible.
+- [ ] Tests: ArrowDown advances current slide; ArrowUp reverses;
+      clamps at both ends.
+
+### Task 3 — Verify + commit
+
+- [ ] `pnpm verify:fast` clean.
+- [ ] Manual smoke: `pnpm dev`, open a slides doc with 10+ slides,
+      scroll, click, then arrow-key navigate.
+- [ ] Capture lessons in `*-lessons.md`, archive.
+
+### Review
+
+(Populated after merge.)

--- a/packages/slides/src/view/editor/shortcuts-catalog.ts
+++ b/packages/slides/src/view/editor/shortcuts-catalog.ts
@@ -52,6 +52,7 @@ export const SHORTCUTS: ReadonlyArray<ShortcutEntry> = [
   { category: 'Slide', keys: ['Mod+Shift+D'],     description: 'Duplicate the current slide' },
   { category: 'Slide', keys: ['Mod+D'],           description: 'Duplicate selected elements (or current slide if none)' },
   { category: 'Slide', keys: ['Page Up', 'Page Down'], description: 'Go to previous / next slide' },
+  { category: 'Slide', keys: ['Arrow ↑', 'Arrow ↓'],   description: 'Go to previous / next slide (thumbnail panel focused)' },
 
   // Clipboard ------------------------------------------------------------
   { category: 'Clipboard', keys: ['Mod+C'],       description: 'Copy selected elements' },

--- a/packages/slides/src/view/editor/thumbnail-panel.ts
+++ b/packages/slides/src/view/editor/thumbnail-panel.ts
@@ -178,7 +178,27 @@ export function mountThumbnailPanel(
     ];
   };
 
+  // Walk up to the closest scrollable ancestor so we can capture and
+  // restore its scrollTop across the innerHTML wipe. Without this the
+  // browser clamps scrollTop to 0 the instant the wiped children leave
+  // scrollHeight smaller than the current scroll offset — every click
+  // would otherwise snap the panel back to the first slide.
+  const findScrollParent = (
+    el: HTMLElement | null,
+  ): HTMLElement | null => {
+    for (let n: HTMLElement | null = el; n; n = n.parentElement) {
+      const overflowY =
+        typeof getComputedStyle === 'function'
+          ? getComputedStyle(n).overflowY
+          : n.style.overflowY;
+      if (overflowY === 'auto' || overflowY === 'scroll') return n;
+    }
+    return null;
+  };
+
   const render = (): void => {
+    const scrollParent = findScrollParent(container);
+    const savedScrollTop = scrollParent?.scrollTop ?? 0;
     container.innerHTML = '';
     const dims = computeThumbDims(container.clientWidth);
     // Read DPR per render so a window dragged between Retina and a
@@ -244,11 +264,11 @@ export function mountThumbnailPanel(
           return;
         }
         selectedSlideIds = [slide.id];
+        // Focus the panel so subsequent ArrowUp/ArrowDown navigate
+        // slides. preventScroll avoids the browser auto-scrolling the
+        // panel to the focused element — we manage scroll explicitly.
+        container.focus({ preventScroll: true });
         editor.setCurrentSlide(slide.id);
-        // setCurrentSlide may not fire onSelectionChange (when element
-        // selection was already empty). Force a re-render so the
-        // .current highlight updates.
-        render();
       });
 
       // HTML5 drag-and-drop reorder. jsdom only partially implements
@@ -294,12 +314,48 @@ export function mountThumbnailPanel(
 
       container.appendChild(item);
     }
+    if (scrollParent) scrollParent.scrollTop = savedScrollTop;
   };
 
-  // Re-render when the editor's selection changes — this is a cheap
-  // proxy for many editor mutations (selection clear on slide switch,
-  // etc.) and the thumbnail draw is fast.
-  const off = editor.onSelectionChange(() => render());
+  // Re-render whenever the editor's current slide changes — this is
+  // the only state the panel reflects (the `.current` highlight). The
+  // panel used to subscribe to onSelectionChange as a proxy, but that
+  // fired on every element click on the canvas, causing wasted renders
+  // and (with the old non-scroll-preserving render) a snap-to-top each
+  // time selection cleared.
+  const off = editor.onCurrentSlideChange(() => render());
+
+  // Make the panel a keyboard-focusable host so ArrowUp/Down navigate
+  // slides when the user clicks a thumbnail or tabs in. No visible
+  // focus ring on the container itself — the `.current` thumb already
+  // shows where we are.
+  if (!container.hasAttribute('tabindex')) container.tabIndex = 0;
+  container.style.outline = 'none';
+  container.addEventListener('keydown', (e) => {
+    if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    const slides = store.read().slides;
+    if (slides.length === 0) return;
+    const currentId = editor.getCurrentSlideId();
+    const idx = slides.findIndex((s) => s.id === currentId);
+    if (idx === -1) return;
+    const nextIdx =
+      e.key === 'ArrowUp'
+        ? Math.max(0, idx - 1)
+        : Math.min(slides.length - 1, idx + 1);
+    if (nextIdx === idx) return;
+    e.preventDefault();
+    selectedSlideIds = [slides[nextIdx].id];
+    editor.setCurrentSlide(slides[nextIdx].id);
+    // The onCurrentSlideChange listener has already re-rendered, so
+    // the new thumb element exists. Scroll it into view if off-screen.
+    // scrollIntoView is missing from jsdom; the optional-chain guard
+    // keeps unit tests happy.
+    const newItem = container.querySelector<HTMLDivElement>(
+      `[data-slide-id="${slides[nextIdx].id}"]`,
+    );
+    newItem?.scrollIntoView?.({ block: 'nearest' });
+  });
 
   // Re-render when the panel's host element changes width (user drags
   // the column resizer in slides-view.tsx). Skip the no-op tick where

--- a/packages/slides/src/view/editor/thumbnail-panel.ts
+++ b/packages/slides/src/view/editor/thumbnail-panel.ts
@@ -334,6 +334,13 @@ export function mountThumbnailPanel(
   container.addEventListener('keydown', (e) => {
     if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
     if (e.metaKey || e.ctrlKey || e.altKey) return;
+    // Defer to the canvas element-nudge rule (interactions/keyboard.ts)
+    // when the user has a canvas selection. After clicking a thumbnail
+    // the panel container keeps focus (canvas isn't focusable, so
+    // selecting an element on the canvas doesn't move focus away), and
+    // without this gate ArrowUp/Down would steal the user's nudge —
+    // switching slides AND clearing their selection.
+    if (editor.getSelection().length > 0) return;
     const slides = store.read().slides;
     if (slides.length === 0) return;
     const currentId = editor.getCurrentSlideId();

--- a/packages/slides/test/view/editor/thumbnail-panel.test.ts
+++ b/packages/slides/test/view/editor/thumbnail-panel.test.ts
@@ -69,7 +69,7 @@ describe('mountThumbnailPanel', () => {
     expect(handle.getSelectedSlideIds()).toEqual([]);
   });
 
-  it('dispose detaches editor selection subscription', () => {
+  it('dispose detaches editor current-slide subscription', () => {
     const { panel, store, editor } = makeFixture();
     const handle = mountThumbnailPanel(panel, store, editor);
     expect(() => handle.dispose()).not.toThrow();
@@ -166,19 +166,82 @@ describe('mountThumbnailPanel — arrow key navigation', () => {
     expect(editor.getCurrentSlideId()).toBe(slideIds[slideIds.length - 1]);
   });
 
-  it('ignores arrow keys with modifier (Cmd/Ctrl/Alt) so existing shortcuts pass through', () => {
+  it('panel handler is a no-op when a modifier key (Cmd/Ctrl/Alt) is held', () => {
+    // Modifier+arrow combinations are owned by other key rules (e.g.
+    // Cmd+Arrow z-order in interactions/keyboard.ts). The panel must
+    // bail so those keep working when the panel happens to have focus.
     const { panel, store, editor } = makeFixture();
     mountThumbnailPanel(panel, store, editor);
     const slideIds = store.read().slides.map((s) => s.id);
-    panel.dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: 'ArrowDown',
-        metaKey: true,
-        bubbles: true,
-        cancelable: true,
-      }),
-    );
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    panel.dispatchEvent(event);
     expect(editor.getCurrentSlideId()).toBe(slideIds[0]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('panel handler defers to the canvas nudge rule when an element is selected', () => {
+    // Clicking a thumbnail focuses the panel; clicking a canvas element
+    // afterwards leaves focus on the panel (the canvas isn't focusable).
+    // ArrowUp/Down would then steal the user's element-nudge — we must
+    // bail when getSelection() is non-empty so the document-level rule
+    // can run.
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor);
+    const slideIds = store.read().slides.map((s) => s.id);
+    // Add an element so we have something to "select".
+    let elementId = '';
+    store.batch(() => {
+      elementId = store.addElement(slideIds[0], {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor.setSelection([elementId]);
+    // Dispatch on `panel` (target=panel). The panel listener fires
+    // first (and must bail); the bubble to `document` reaches the
+    // editor's keyRules where the canvas-nudge rule matches.
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      bubbles: true,
+      cancelable: true,
+    });
+    panel.dispatchEvent(event);
+
+    // Panel handler bailed → current slide unchanged, selection
+    // preserved. The element-nudge rule consumed the event downstream.
+    expect(editor.getCurrentSlideId()).toBe(slideIds[0]);
+    expect(editor.getSelection()).toEqual([elementId]);
+    const movedY = store.read().slides[0].elements[0].frame.y;
+    expect(movedY).toBeGreaterThan(100);
+  });
+
+  it('ArrowDown calls preventDefault on a successful move (blocks default page scroll)', () => {
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor);
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      bubbles: true,
+      cancelable: true,
+    });
+    panel.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('clicking a thumbnail focuses the panel so subsequent arrow keys route here', () => {
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor);
+    const slideIds = store.read().slides.map((s) => s.id);
+    const second = panel.querySelector<HTMLDivElement>(
+      `[data-slide-id="${slideIds[1]}"]`,
+    )!;
+    second.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(document.activeElement).toBe(panel);
   });
 
   it('panel is keyboard-focusable (tabIndex=0)', () => {

--- a/packages/slides/test/view/editor/thumbnail-panel.test.ts
+++ b/packages/slides/test/view/editor/thumbnail-panel.test.ts
@@ -76,6 +76,118 @@ describe('mountThumbnailPanel', () => {
   });
 });
 
+describe('mountThumbnailPanel — scroll preservation across re-render', () => {
+  it('restores parent scrollTop after innerHTML wipe (simulated browser clamp)', () => {
+    const { panel, store, editor } = makeFixture();
+    // Wrap the panel in a scrollable host so findScrollParent (overflowY=auto)
+    // picks it up. Mirrors the slides-view layout.
+    panel.remove();
+    const scrollable = document.createElement('div');
+    scrollable.style.overflowY = 'auto';
+    scrollable.appendChild(panel);
+    document.body.appendChild(scrollable);
+    mountThumbnailPanel(panel, store, editor);
+
+    // jsdom doesn't compute layout, so scrollTop isn't clamped automatically.
+    // Simulate the real-browser clamp synchronously: the moment innerHTML is
+    // wiped, slam scrollTop to 0 — what Chrome does when scrollHeight briefly
+    // drops below the current scroll offset. The panel must capture scrollTop
+    // BEFORE the wipe and restore it AFTER appending children.
+    let scrollTopVal = 250;
+    Object.defineProperty(scrollable, 'scrollTop', {
+      get: () => scrollTopVal,
+      set: (v: number) => { scrollTopVal = v; },
+      configurable: true,
+    });
+    const innerHTMLDesc = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      'innerHTML',
+    )!;
+    Object.defineProperty(panel, 'innerHTML', {
+      get() { return innerHTMLDesc.get!.call(this); },
+      set(value: string) {
+        innerHTMLDesc.set!.call(this, value);
+        if (value === '') scrollTopVal = 0; // simulated clamp
+      },
+      configurable: true,
+    });
+
+    // Click a different thumbnail — triggers render().
+    const slideIds = store.read().slides.map((s) => s.id);
+    const second = panel.querySelector<HTMLDivElement>(
+      `[data-slide-id="${slideIds[1]}"]`,
+    )!;
+    second.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+    expect(scrollable.scrollTop).toBe(250);
+  });
+});
+
+describe('mountThumbnailPanel — arrow key navigation', () => {
+  function keydown(target: HTMLElement, key: string) {
+    target.dispatchEvent(
+      new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }),
+    );
+  }
+
+  it('ArrowDown advances to the next slide', () => {
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor);
+    const slideIds = store.read().slides.map((s) => s.id);
+    expect(editor.getCurrentSlideId()).toBe(slideIds[0]);
+    keydown(panel, 'ArrowDown');
+    expect(editor.getCurrentSlideId()).toBe(slideIds[1]);
+  });
+
+  it('ArrowUp reverses to the previous slide', () => {
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor);
+    const slideIds = store.read().slides.map((s) => s.id);
+    editor.setCurrentSlide(slideIds[1]);
+    keydown(panel, 'ArrowUp');
+    expect(editor.getCurrentSlideId()).toBe(slideIds[0]);
+  });
+
+  it('ArrowUp on the first slide is a no-op', () => {
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor);
+    const slideIds = store.read().slides.map((s) => s.id);
+    expect(editor.getCurrentSlideId()).toBe(slideIds[0]);
+    keydown(panel, 'ArrowUp');
+    expect(editor.getCurrentSlideId()).toBe(slideIds[0]);
+  });
+
+  it('ArrowDown on the last slide is a no-op', () => {
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor);
+    const slideIds = store.read().slides.map((s) => s.id);
+    editor.setCurrentSlide(slideIds[slideIds.length - 1]);
+    keydown(panel, 'ArrowDown');
+    expect(editor.getCurrentSlideId()).toBe(slideIds[slideIds.length - 1]);
+  });
+
+  it('ignores arrow keys with modifier (Cmd/Ctrl/Alt) so existing shortcuts pass through', () => {
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor);
+    const slideIds = store.read().slides.map((s) => s.id);
+    panel.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowDown',
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(editor.getCurrentSlideId()).toBe(slideIds[0]);
+  });
+
+  it('panel is keyboard-focusable (tabIndex=0)', () => {
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor);
+    expect(panel.tabIndex).toBe(0);
+  });
+});
+
 describe('mountThumbnailPanel — responsive sizing + DPR', () => {
   it('thumbnail outer box scales to the container width with 16:9 inner', () => {
     const { panel, store, editor } = makeFixture();


### PR DESCRIPTION
## Summary

- Fix thumbnail panel snapping to top on every click — capture and restore the scrollable ancestor's `scrollTop` across `render()`'s `innerHTML` wipe (the browser clamps `scrollTop` to 0 when `scrollHeight` transiently collapses).
- Swap `onSelectionChange` → `onCurrentSlideChange` subscription so the panel doesn't re-render on every canvas element click, and drop the now-redundant force-`render()` in the click handler.
- Add ArrowUp/ArrowDown navigation: `tabIndex=0` on the container, focus the panel on thumbnail click (`preventScroll: true`), keydown handler navigates prev/next slide with `scrollIntoView({block:'nearest'})` for off-screen targets.
- Defer to the canvas element-nudge rule when `editor.getSelection()` is non-empty — after a thumbnail click the panel keeps focus (canvas isn't focusable), so without this gate ArrowUp/Down would steal the user's nudge intent.
- List the new shortcut in the catalog so it appears in the help modal.

## Test plan

- [x] `pnpm verify:fast`
- [x] New unit tests: scroll preservation across the wipe (simulated browser clamp), Arrow navigation in both directions, end clamps, modifier-key bail (no slide change, `defaultPrevented` stays false), canvas-selection bail (element nudges, current slide unchanged), click→focus path, `preventDefault` on successful move
- [ ] Manual smoke: `pnpm dev`, open a slides doc with 10+ slides — scroll, click, then arrow-key navigate; click a canvas element and confirm ArrowUp/Down nudges it instead of switching slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)