### PR TITLE
slides: add read-only mobile view (<768px)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -69,6 +69,7 @@ Presentation engine — slides, free-position elements, presentation mode, colla
 | [slides-connectors.md](slides/slides-connectors.md)                                   | Slides connectors — endpoint-driven Line/Arrow/Elbow/Curved with per-shape connection sites, auto routing, snap-on-draw UX, 3-PR rollout                                              |
 | [slides-toolbar-redesign.md](slides/slides-toolbar-redesign.md)                       | Slides toolbar redesign — single morphing toolbar (Idle / Object / Text-editing) replacing the always-on layout, Arrange dropdown consolidating align/distribute/order/rotate, shared text-formatting components |
 | [slides-text-engine-audit.md](slides/slides-text-engine-audit.md)                     | Spike audit (Phase 5 prep) — docs RichText reuse plan: extract `paintLayout`/`findPositionAtPixel`/`initializeTextBox`, no fork                                                                              |
+| [slides-mobile-view.md](slides/slides-mobile-view.md)                                 | Mobile view (read-only) — viewport-768 branch in SlidesView, dedicated MobileSlidesView reusing SlideRenderer, swipe nav, Present entry, no editor mount                                                    |
 
 ## Common
 

--- a/docs/design/slides/slides-mobile-view.md
+++ b/docs/design/slides/slides-mobile-view.md
@@ -1,0 +1,260 @@
+---
+title: slides-mobile-view
+target-version: 0.4.3
+---
+
+# Slides Mobile View
+
+## Summary
+
+Add a read-only mobile experience to the slides package. When the
+viewport is narrower than 768px, the slide deck mounts as a dedicated
+`MobileSlidesView` component — a thin header (back / title / Present),
+a single full-width canvas showing the current slide, and a footer
+indicator (`2 / 12`). Slide navigation is left/right swipe plus small
+arrow buttons. Editing is not exposed on mobile in this phase; the
+editor module is not mounted, so read-only is enforced by construction
+rather than by feature flags.
+
+This is the slides equivalent of `docs-mobile-zoom-to-fit.md`, but the
+implementation is simpler: the slides canvas already paints into a
+fit-sized box (`computeFitSize` in `slides-view.tsx`), so no
+`ctx.scale` plumbing is needed — the existing `SlideRenderer` from
+`packages/slides/src/view/canvas/slide-renderer.ts` is reused directly.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Slide decks are readable and navigable on phones (≤ 767px viewport).
+- Read-only is enforced by not mounting the editor — no mutation
+  pathway exists from the mobile component.
+- Present mode (`packages/slides/src/view/present`) is reachable in
+  one tap from the mobile header, using the existing fullscreen
+  overlay fallback already shipped for browsers that block the
+  Fullscreen API.
+- Crossing the 768px breakpoint at runtime (window resize, device
+  rotation) swaps cleanly between desktop and mobile mounts without
+  losing the active Yorkie attachment.
+- No regression to the desktop editor — the desktop code path is
+  unchanged.
+
+### Non-Goals
+
+- Mobile editing (text edit, slide reorder, theme change). Tracked
+  as phase (B) — light edit — separately. Locking is done by
+  omission (the editor module isn't mounted), not by a `readOnly`
+  flag on the editor.
+- Pinch-to-zoom. The canvas already fits the viewport width; zooming
+  for fine inspection is deferred.
+- Speaker-notes panel on mobile. Notes are not surfaced in this
+  phase; reuse on mobile waits for phase (B) or a notes-aware
+  presenter view.
+- Per-tablet treatment. iPads in landscape and portrait (≥ 768px)
+  remain on the desktop UI. Touch interaction in the desktop editor
+  on tablets is out of scope here.
+- Shared-link read-only flow (`sharing.md`). The mobile viewer is a
+  natural building block for that flow, but wiring viewer roles to
+  share tokens is a separate task.
+- URL-stateful slide index. The current slide id is component-local;
+  reload returns to the first slide. Persisting the position in the
+  URL is deferred.
+
+## Proposal Details
+
+### Detection and branching
+
+`SlidesView` (`packages/frontend/src/app/slides/slides-view.tsx`)
+branches at the top of its render based on the existing
+`useIsMobile()` hook (`packages/frontend/src/hooks/use-mobile.ts`),
+which already tracks `(max-width: 767px)`:
+
+```tsx
+const isMobile = useIsMobile();
+if (isMobile) {
+  return <MobileSlidesView documentId={documentId} ... />;
+}
+// existing desktop editor mount path, unchanged
+```
+
+When the viewport crosses 768px at runtime, React unmounts one tree
+and mounts the other. The desktop editor's existing mount-time
+`useEffect` cleanup tears down the RAF tick, thumbnail panel, notes
+panel, editor instance, and style tag. The Yorkie `useDocument`
+attachment lives on the surrounding `DocumentProvider`, so the
+document stays attached across the swap.
+
+### MobileSlidesView component
+
+New file: `packages/frontend/src/app/slides/mobile-slides-view.tsx`.
+
+**DOM structure** (built as JSX, unlike the desktop view which
+hand-builds DOM for the vanilla editor):
+
+```
+<div class="mobile-slides">
+  <header>
+    <button aria-label="Back to deck list">‹</button>
+    <h1 class="truncate">{title}</h1>
+    <button aria-label="Start presentation">▶</button>
+  </header>
+  <div ref={canvasHostRef} class="canvas-host">
+    <canvas />
+  </div>
+  <footer>
+    <button aria-label="Previous slide">‹</button>
+    <span>{index + 1} / {slides.length}</span>
+    <button aria-label="Next slide">›</button>
+  </footer>
+</div>
+```
+
+The outer container uses `100dvh` (dynamic viewport height) with a
+`100vh` fallback so the iOS Safari address-bar collapse/expand does
+not visually shift the canvas. Header is `≈ 44px`, footer `≈ 28px`,
+`canvas-host` is `flex: 1`.
+
+**Yorkie data flow**:
+
+- `useDocument<YorkieSlidesRoot, SlidesPresence>()` provides the
+  document handle, same as the desktop view.
+- `ensureSlidesRoot(doc)` is called once on mount — this is the only
+  write path the mobile component touches, and it is a no-op when
+  the document is already populated. It exists so a user who lands
+  on a freshly created (empty) deck on mobile still sees a usable
+  shell.
+- The deck's slides, theme, and meta are read from the Yorkie root
+  into React state. A `doc.subscribe((e) => ...)` listener triggers
+  a re-snapshot on `remote-change` events; this mirrors the pattern
+  used by `yorkie-slides-store.ts` and avoids a heavier
+  `YorkieSlidesStore` instance, which the mobile view does not
+  need. No writes are issued.
+
+**Canvas rendering**:
+
+- A single `SlideRenderer` instance is created on mount
+  (`packages/slides/src/view/canvas/slide-renderer.ts`, imported
+  directly from `@wafflebase/slides`).
+- A `ResizeObserver` on `canvasHostRef` tracks the available width
+  and height; `computeFitSize` (existing 16:9 width-binding helper)
+  computes the logical canvas size. DPR scaling is applied the same
+  way the desktop and presenter renderers do it — backing store at
+  `size × dpr`, CSS at `size`.
+- Re-render is triggered when (a) slides array changes, (b)
+  `currentSlideId` changes, (c) `canvasHostRef`'s box changes. There
+  is no per-frame RAF tick; the slide is static between events.
+
+The `computeFitSize` math is currently duplicated in
+`slides-view.tsx` and `view/present/presenter.ts` — both copies are
+identical and the slides package README already notes this is
+intentional duplication to keep the package free of frontend
+dependencies. The mobile view continues the pattern (a third copy of
+~10 lines is cheaper than introducing a shared utility module).
+
+### Navigation
+
+**Current slide state**: `useState<string>(slides[0]?.id ?? '')`, kept
+in sync with the slides array (if the current slide is removed by a
+collaborator, falls back to `slides[0]?.id ?? ''`).
+
+**Prev/next**: thin helpers that look up the current index and clamp
+at the array ends.
+
+```typescript
+function nextSlide() {
+  const i = slides.findIndex((s) => s.id === currentSlideId);
+  if (i < 0 || i >= slides.length - 1) return;
+  setCurrentSlideId(slides[i + 1].id);
+}
+```
+
+**Swipe gesture**: a `usePointerSwipe` hook on `canvasHostRef`
+listens for `pointerdown` / `pointermove` / `pointerup`.
+
+- `start` captures `(x, y, time)`.
+- On `pointermove`, once `|dx| > 10px`, classify as horizontal if
+  `|dx| > |dy|`, else cancel. Once classified as horizontal, set
+  `touch-action: none` and call `preventDefault` to suppress the iOS
+  swipe-back gesture (where the browser allows it — edge-anchored
+  system gestures cannot be intercepted).
+- On `pointerup`, if `|dx| > 50px` and elapsed time `< 600ms`, fire
+  `dx < 0 ? nextSlide() : prevSlide()`.
+- A single tap (no movement) is a no-op. This is intentional —
+  read-only means no edit affordance.
+
+**Footer arrow buttons** are an explicit, accessible fallback for
+screen readers and any environment where the pointer events do not
+classify cleanly.
+
+**Present button**: invokes the same `onStartPresentation('current')`
+callback that the desktop view uses. The outer route shell
+(`packages/frontend/src/app/slides/...`) already owns presentation
+mode and the fullscreen-overlay fallback; the mobile view is just
+another trigger.
+
+### Read-only enforcement
+
+Read-only is a property of construction, not configuration:
+
+| Mutation source on desktop                | Why mobile cannot trigger it                       |
+| ----------------------------------------- | -------------------------------------------------- |
+| Toolbar buttons                           | Not mounted                                        |
+| Keymap shortcuts                          | Not mounted                                        |
+| Drag handles / adjustment diamonds        | Not mounted                                        |
+| Double-tap / dblclick to enter text-edit  | No handler attached                                |
+| Yorkie `doc.update()` from editor         | Editor is not instantiated                         |
+| Shape picker / theme panel / notes panel  | Not mounted                                        |
+
+The only write that *can* happen from `MobileSlidesView` is
+`ensureSlidesRoot(doc)`, which is a no-op on populated decks and a
+one-shot scaffold on empty ones. That tradeoff is acceptable: an
+empty deck has nothing to protect.
+
+### Loader / error states
+
+The mobile view reuses the existing `<Loader />` component during
+`useDocument`'s `loading` state and the existing `toast` for errors.
+This matches `SlidesView`'s current treatment and keeps the
+component small.
+
+### File change summary
+
+| File                                                            | Changes                                                                                              |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `packages/frontend/src/app/slides/slides-view.tsx`              | Add `useIsMobile()` branch at the top of render; delegate to `MobileSlidesView` when true.           |
+| `packages/frontend/src/app/slides/mobile-slides-view.tsx` (new) | Component described above: header, canvas, footer, swipe hook, ResizeObserver, SlideRenderer mount.  |
+| `packages/frontend/src/hooks/use-pointer-swipe.ts` (new)        | Small hook (`~50 lines`) encapsulating the pointer classification described above. Unit-testable.    |
+| `packages/slides/src/index.ts`                                  | No change — `SlideRenderer` is already exported.                                                     |
+
+No changes to the slides package model, store, view editor, or
+presenter modules. No changes to the backend.
+
+### Testing
+
+- **Unit (frontend)**: `use-pointer-swipe.ts` — gesture classification
+  thresholds (horizontal vs vertical, time cap, dead-zone). Pure
+  function over synthetic pointer events.
+- **Unit (slides)**: existing `SlideRenderer` tests cover correct
+  rendering; no new tests needed for renderer reuse.
+- **Component (frontend)**: `MobileSlidesView` mount renders the
+  header, footer, and a canvas; clicking the footer next button
+  advances the slide index by 1; the back and present buttons fire
+  their respective callbacks.
+- **Visual (`pnpm verify:browser:docker`)**: new fixtures at 360×640,
+  390×844, and 430×932 viewports verify header + canvas + footer
+  layout and that the first slide paints.
+- **Manual smoke**: `pnpm dev` → DevTools mobile emulation; verify
+  swipe navigation, Present button (fullscreen overlay fallback on
+  iOS), and clean transition when toggling between mobile (375px)
+  and desktop (1024px) emulated widths.
+
+## Risks and Mitigation
+
+| Risk                                                                                                                  | Mitigation                                                                                                                              |
+| --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Two `computeFitSize` copies (desktop, presenter) become three.                                                        | Accepted; the math is ~10 lines and the slides package must stay frontend-agnostic. Revisit if a fourth caller appears.                  |
+| Pointer-event classification misfires on Android Chrome where horizontal scroll containers compete for the gesture.   | The mobile view has no scrollable ancestors inside the canvas host; outer container is `overflow: hidden`. Footer arrows are the fallback. |
+| iOS system swipe-back at the screen edge cannot be prevented.                                                         | Documented limitation. Users who initiate near the edge will navigate away; this is consistent with every other mobile web app.          |
+| `useDocument`'s remote change causes the current slide to be removed mid-view.                                        | Fall back to the first slide if `currentSlideId` is not found in the new slides array. No user-visible error.                            |
+| Adding a hard mobile/desktop branch in `SlidesView` makes future feature flags awkward (e.g., a `viewerOnly` prop).   | The branch is one `if`. When `viewerOnly` lands (for shared-link viewers), it ORs with `isMobile` to pick the same mobile component.   |
+| Memory/perf: `SlideRenderer` re-runs on every resize during window drag.                                              | Wrap the resize handler in `requestAnimationFrame` coalescing; same pattern used by presenter.ts.                                       |

--- a/docs/design/slides/slides-mobile-view.md
+++ b/docs/design/slides/slides-mobile-view.md
@@ -91,7 +91,7 @@ New file: `packages/frontend/src/app/slides/mobile-slides-view.tsx`.
 **DOM structure** (built as JSX, unlike the desktop view which
 hand-builds DOM for the vanilla editor):
 
-```
+```html
 <div class="mobile-slides">
   <header>
     <button aria-label="Back to deck list">‹</button>

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
-| docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | - |
+| pptx unsupported shapes (2026-05-17) | [20260517-pptx-unsupported-shapes-todo.md](./active/20260517-pptx-unsupported-shapes-todo.md) | - |
+| slides mobile view (2026-05-17) | [20260517-slides-mobile-view-todo.md](./active/20260517-slides-mobile-view-todo.md) | [20260517-slides-mobile-view-lessons.md](./active/20260517-slides-mobile-view-lessons.md) |
 | slides connectors pr1 (2026-05-15) | [20260515-slides-connectors-pr1-todo.md](./active/20260515-slides-connectors-pr1-todo.md) | [20260515-slides-connectors-pr1-lessons.md](./active/20260515-slides-connectors-pr1-lessons.md) |
 | slides keyboard shortcuts (2026-05-14) | [20260514-slides-keyboard-shortcuts-todo.md](./active/20260514-slides-keyboard-shortcuts-todo.md) | - |
 | slides presentation mode (2026-05-14) | [20260514-slides-presentation-mode-todo.md](./active/20260514-slides-presentation-mode-todo.md) | - |
@@ -30,7 +31,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 184
+- Archived task count: 181
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: docs comments followup (2026-05-17)
+Latest active task: pptx unsupported shapes (2026-05-17)

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,8 +18,9 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
-| pptx unsupported shapes (2026-05-17) | [20260517-pptx-unsupported-shapes-todo.md](./active/20260517-pptx-unsupported-shapes-todo.md) | - |
+| docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | - |
 | slides mobile view (2026-05-17) | [20260517-slides-mobile-view-todo.md](./active/20260517-slides-mobile-view-todo.md) | [20260517-slides-mobile-view-lessons.md](./active/20260517-slides-mobile-view-lessons.md) |
+| slides textbox click scale (2026-05-17) | [20260517-slides-textbox-click-scale-todo.md](./active/20260517-slides-textbox-click-scale-todo.md) | [20260517-slides-textbox-click-scale-lessons.md](./active/20260517-slides-textbox-click-scale-lessons.md) |
 | slides connectors pr1 (2026-05-15) | [20260515-slides-connectors-pr1-todo.md](./active/20260515-slides-connectors-pr1-todo.md) | [20260515-slides-connectors-pr1-lessons.md](./active/20260515-slides-connectors-pr1-lessons.md) |
 | slides keyboard shortcuts (2026-05-14) | [20260514-slides-keyboard-shortcuts-todo.md](./active/20260514-slides-keyboard-shortcuts-todo.md) | - |
 | slides presentation mode (2026-05-14) | [20260514-slides-presentation-mode-todo.md](./active/20260514-slides-presentation-mode-todo.md) | - |
@@ -31,7 +32,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 181
+- Archived task count: 184
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: pptx unsupported shapes (2026-05-17)
+Latest active task: docs comments followup (2026-05-17)

--- a/docs/tasks/active/20260517-slides-mobile-view-lessons.md
+++ b/docs/tasks/active/20260517-slides-mobile-view-lessons.md
@@ -24,4 +24,36 @@ rebaselines, etc.
 
 ## Observations during implementation
 
-_(Fill in as work proceeds.)_
+- **Frontend tests use `node:test`, not Vitest.** The original plan
+  wrote Vitest-style tests (`vi.mock`, `renderHook`, `@testing-library/
+  react`). These would have failed at load: the runner is Node's
+  native runner, and `tests/resolve-hooks.mjs` stubs every `.tsx`
+  file under `src/` to no-op exports so React components cannot be
+  rendered in unit tests at all. The pattern in this repo is to
+  extract pure logic into `*-helpers.ts` and test that; UI behavior
+  is left to Playwright (visual/interaction). The hook was reshaped
+  into `attachPointerSwipe` (pure DOM, fully unit-tested against a
+  fake element) + `usePointerSwipe` (thin React wrapper, unverified
+  in unit tests — covered by manual smoke).
+
+- **The mobile branch had to move up to `slides-detail.tsx`, not
+  `slides-view.tsx`.** The plan placed `useIsMobile` inside
+  `SlidesView`, but `SlidesLayout` (in `slides-detail.tsx`) mounts
+  the desktop sidebar, site header, toolbar, theme panel, and
+  `SlidesView` together. Branching inside `SlidesView` would leave
+  all that desktop chrome above a tiny mobile canvas. The fix:
+  branch at the top of `SlidesLayout` and extract the existing body
+  into `DesktopSlidesLayout`. This is also the only way to preserve
+  React's rules-of-hooks across the breakpoint swap.
+
+- **Visual baseline scenario for the mobile chrome deferred.** The
+  visual-harness pattern (`harness/visual/slides-scenarios.tsx`)
+  renders scenarios as plain React with in-memory `SlidesDocument`
+  data — it has no Yorkie wiring. `MobileSlidesView` is tightly
+  coupled to `useDocument` (for the doc handle, presence, and
+  remote-change subscription), so adding a scenario would require
+  either decoupling the component into a presentational shell
+  (moderate refactor) or building a `DocumentProvider` mock for the
+  harness (new infra). For a static header/footer chrome around an
+  already-tested `SlideRenderer`, the cost outweighs the regression
+  coverage. Tracked as a possible follow-up.

--- a/docs/tasks/active/20260517-slides-mobile-view-lessons.md
+++ b/docs/tasks/active/20260517-slides-mobile-view-lessons.md
@@ -1,0 +1,27 @@
+# Slides Mobile View — Lessons
+
+Companion to
+[`20260517-slides-mobile-view-todo.md`](./20260517-slides-mobile-view-todo.md).
+Capture anything surprising encountered during implementation —
+edges in the existing slides/Yorkie surface, pointer-event quirks
+on real devices, ResizeObserver timing issues, Playwright snapshot
+rebaselines, etc.
+
+## Notable decisions made during brainstorming
+
+- **No `readOnly` flag on the editor.** Read-only is enforced by not
+  mounting the editor module at all on mobile, instead of plumbing a
+  flag through toolbar, keymap, handles, etc. Keeps the desktop
+  code path untouched and gives future shared-link viewers a ready
+  building block.
+- **`computeFitSize` is duplicated three places now** (desktop
+  `slides-view.tsx`, `presenter.ts`, `mobile-slides-view.tsx`).
+  Accepted — the slides package must stay frontend-agnostic and the
+  math is ~10 lines. Revisit if a fourth caller appears.
+- **iOS edge swipe-back cannot be intercepted.** Documented as a
+  limitation; footer arrow buttons are the screen-reader and
+  fallback affordance.
+
+## Observations during implementation
+
+_(Fill in as work proceeds.)_

--- a/docs/tasks/active/20260517-slides-mobile-view-todo.md
+++ b/docs/tasks/active/20260517-slides-mobile-view-todo.md
@@ -1,0 +1,1109 @@
+# Slides Mobile View — read-only viewport-768 branch
+
+**Goal:** Add a mobile (`< 768px` viewport) view of the slides editor
+that mounts a dedicated read-only component — header, single canvas,
+swipe + footer-arrow navigation, Present button — instead of the
+desktop editor. Read-only by construction (the editor module is not
+mounted on mobile).
+
+**Design doc:** [slides-mobile-view.md](../../design/slides/slides-mobile-view.md)
+
+**Architecture:** `SlidesView` branches at the top of render based on
+the existing `useIsMobile()` hook. The new `MobileSlidesView`
+component reuses `SlideRenderer` (already exported from
+`@wafflebase/slides`) directly — same pattern as
+`view/present/presenter.ts`. A small `usePointerSwipe` hook
+encapsulates the horizontal-swipe gesture.
+
+**Tech stack:** React 18, TypeScript, Vitest + jsdom for unit tests,
+existing Yorkie `useDocument`, existing `SlideRenderer`.
+
+---
+
+## Task 1 — `usePointerSwipe` hook
+
+**Files:**
+
+- Create: `packages/frontend/src/hooks/use-pointer-swipe.ts`
+- Create: `packages/frontend/src/hooks/use-pointer-swipe.test.tsx`
+
+Isolated pointer-gesture classifier. Pure-ish (state lives in refs);
+TDD-able with synthetic `PointerEvent`s in jsdom.
+
+**Public shape:**
+
+```ts
+export interface PointerSwipeOptions {
+  onSwipeLeft: () => void;   // dx < 0
+  onSwipeRight: () => void;  // dx > 0
+  /** Minimum |dx| before a swipe fires. Default 50. */
+  thresholdPx?: number;
+  /** Max elapsed ms for a swipe. Default 600. */
+  maxDurationMs?: number;
+  /** |dx| where horizontal intent is locked. Default 10. */
+  classifyAtPx?: number;
+}
+
+export function usePointerSwipe(
+  ref: React.RefObject<HTMLElement | null>,
+  options: PointerSwipeOptions,
+): void;
+```
+
+Classification rules:
+
+1. On `pointerdown`, record `(x, y, time)`.
+2. On `pointermove`, if not yet classified:
+   - If `|dx| > classifyAtPx` and `|dx| > |dy|` → lock horizontal,
+     call `event.preventDefault()`.
+   - Else if `|dy| > classifyAtPx` and `|dy| >= |dx|` → cancel
+     (vertical scroll intent).
+3. On `pointerup` (only if classified horizontal):
+   - If `elapsed < maxDurationMs` and `|dx| >= thresholdPx`:
+     `dx < 0 ? onSwipeLeft() : onSwipeRight()`.
+4. `pointercancel` cancels.
+
+`pointerdown` calls `event.currentTarget.setPointerCapture(pointerId)`
+so move/up events don't get lost if the pointer leaves the element.
+
+- [ ] **1.1** Write failing tests covering:
+
+  ```tsx
+  import { renderHook } from '@testing-library/react';
+  import { usePointerSwipe } from './use-pointer-swipe';
+
+  function makeRef(el: HTMLElement) {
+    return { current: el } as React.RefObject<HTMLElement>;
+  }
+
+  function fire(
+    el: HTMLElement,
+    type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+    x: number,
+    y: number,
+  ) {
+    const ev = new PointerEvent(type, {
+      clientX: x,
+      clientY: y,
+      pointerId: 1,
+      bubbles: true,
+      cancelable: true,
+    });
+    el.dispatchEvent(ev);
+    return ev;
+  }
+
+  test('left swipe past threshold fires onSwipeLeft', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const left = vi.fn();
+    const right = vi.fn();
+    renderHook(() =>
+      usePointerSwipe(makeRef(el), { onSwipeLeft: left, onSwipeRight: right }),
+    );
+    fire(el, 'pointerdown', 200, 100);
+    fire(el, 'pointermove', 120, 100); // dx = -80, locks horizontal
+    fire(el, 'pointerup', 120, 100);
+    expect(left).toHaveBeenCalledTimes(1);
+    expect(right).not.toHaveBeenCalled();
+  });
+
+  test('right swipe past threshold fires onSwipeRight', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const left = vi.fn();
+    const right = vi.fn();
+    renderHook(() =>
+      usePointerSwipe(makeRef(el), { onSwipeLeft: left, onSwipeRight: right }),
+    );
+    fire(el, 'pointerdown', 100, 100);
+    fire(el, 'pointermove', 200, 100);
+    fire(el, 'pointerup', 200, 100);
+    expect(right).toHaveBeenCalledTimes(1);
+    expect(left).not.toHaveBeenCalled();
+  });
+
+  test('vertical movement cancels classification', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const left = vi.fn();
+    const right = vi.fn();
+    renderHook(() =>
+      usePointerSwipe(makeRef(el), { onSwipeLeft: left, onSwipeRight: right }),
+    );
+    fire(el, 'pointerdown', 100, 100);
+    fire(el, 'pointermove', 105, 200); // dy >> dx
+    fire(el, 'pointerup', 200, 100);   // dx large here but classification was vertical
+    expect(left).not.toHaveBeenCalled();
+    expect(right).not.toHaveBeenCalled();
+  });
+
+  test('below threshold does nothing', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const left = vi.fn();
+    const right = vi.fn();
+    renderHook(() =>
+      usePointerSwipe(makeRef(el), { onSwipeLeft: left, onSwipeRight: right }),
+    );
+    fire(el, 'pointerdown', 100, 100);
+    fire(el, 'pointermove', 130, 100); // dx 30, classifies horizontal
+    fire(el, 'pointerup', 130, 100);   // but below 50px threshold
+    expect(left).not.toHaveBeenCalled();
+    expect(right).not.toHaveBeenCalled();
+  });
+
+  test('too slow (> maxDurationMs) does not fire', () => {
+    vi.useFakeTimers();
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const left = vi.fn();
+    renderHook(() =>
+      usePointerSwipe(makeRef(el), {
+        onSwipeLeft: left,
+        onSwipeRight: vi.fn(),
+        maxDurationMs: 600,
+      }),
+    );
+    fire(el, 'pointerdown', 200, 100);
+    fire(el, 'pointermove', 120, 100);
+    vi.advanceTimersByTime(700);
+    fire(el, 'pointerup', 120, 100);
+    expect(left).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  test('pointercancel mid-gesture aborts', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const left = vi.fn();
+    renderHook(() =>
+      usePointerSwipe(makeRef(el), { onSwipeLeft: left, onSwipeRight: vi.fn() }),
+    );
+    fire(el, 'pointerdown', 200, 100);
+    fire(el, 'pointermove', 120, 100);
+    fire(el, 'pointercancel', 120, 100);
+    fire(el, 'pointerup', 120, 100);
+    expect(left).not.toHaveBeenCalled();
+  });
+  ```
+
+  Note: `setPointerCapture` may not exist on jsdom elements — stub
+  it via `Object.defineProperty(el, 'setPointerCapture', { value: vi.fn() })`
+  in the test setup, or in the hook itself check `'setPointerCapture' in el`
+  before calling. Production browsers always have it.
+
+- [ ] **1.2** Run tests, confirm they fail with "usePointerSwipe is not defined":
+
+  ```bash
+  pnpm --filter @wafflebase/frontend test packages/frontend/src/hooks/use-pointer-swipe.test.tsx
+  ```
+
+- [ ] **1.3** Implement the hook:
+
+  ```ts
+  import { useEffect } from 'react';
+
+  export interface PointerSwipeOptions {
+    onSwipeLeft: () => void;
+    onSwipeRight: () => void;
+    thresholdPx?: number;
+    maxDurationMs?: number;
+    classifyAtPx?: number;
+  }
+
+  type Phase = 'idle' | 'pending' | 'horizontal' | 'cancelled';
+
+  interface GestureState {
+    phase: Phase;
+    startX: number;
+    startY: number;
+    startTime: number;
+    pointerId: number | null;
+  }
+
+  export function usePointerSwipe(
+    ref: React.RefObject<HTMLElement | null>,
+    options: PointerSwipeOptions,
+  ): void {
+    useEffect(() => {
+      const el = ref.current;
+      if (!el) return;
+
+      const threshold = options.thresholdPx ?? 50;
+      const maxDuration = options.maxDurationMs ?? 600;
+      const classifyAt = options.classifyAtPx ?? 10;
+
+      const state: GestureState = {
+        phase: 'idle',
+        startX: 0,
+        startY: 0,
+        startTime: 0,
+        pointerId: null,
+      };
+
+      const onDown = (e: PointerEvent) => {
+        state.phase = 'pending';
+        state.startX = e.clientX;
+        state.startY = e.clientY;
+        state.startTime = performance.now();
+        state.pointerId = e.pointerId;
+        if ('setPointerCapture' in el) {
+          try {
+            (el as Element).setPointerCapture(e.pointerId);
+          } catch {
+            // jsdom or browsers refusing capture — ignore.
+          }
+        }
+      };
+
+      const onMove = (e: PointerEvent) => {
+        if (state.phase === 'idle' || state.phase === 'cancelled') return;
+        if (state.pointerId !== e.pointerId) return;
+        const dx = e.clientX - state.startX;
+        const dy = e.clientY - state.startY;
+        if (state.phase === 'pending') {
+          if (Math.abs(dx) > classifyAt && Math.abs(dx) > Math.abs(dy)) {
+            state.phase = 'horizontal';
+            e.preventDefault();
+          } else if (Math.abs(dy) > classifyAt && Math.abs(dy) >= Math.abs(dx)) {
+            state.phase = 'cancelled';
+          }
+        } else if (state.phase === 'horizontal') {
+          e.preventDefault();
+        }
+      };
+
+      const onUp = (e: PointerEvent) => {
+        if (state.pointerId !== e.pointerId) return;
+        const wasHorizontal = state.phase === 'horizontal';
+        state.phase = 'idle';
+        if (!wasHorizontal) return;
+        const dx = e.clientX - state.startX;
+        const elapsed = performance.now() - state.startTime;
+        if (elapsed > maxDuration) return;
+        if (Math.abs(dx) < threshold) return;
+        if (dx < 0) options.onSwipeLeft();
+        else options.onSwipeRight();
+      };
+
+      const onCancel = (e: PointerEvent) => {
+        if (state.pointerId !== e.pointerId) return;
+        state.phase = 'cancelled';
+      };
+
+      el.addEventListener('pointerdown', onDown);
+      el.addEventListener('pointermove', onMove);
+      el.addEventListener('pointerup', onUp);
+      el.addEventListener('pointercancel', onCancel);
+
+      return () => {
+        el.removeEventListener('pointerdown', onDown);
+        el.removeEventListener('pointermove', onMove);
+        el.removeEventListener('pointerup', onUp);
+        el.removeEventListener('pointercancel', onCancel);
+      };
+    }, [ref, options]);
+  }
+  ```
+
+- [ ] **1.4** Run tests, confirm pass.
+
+- [ ] **1.5** Run `pnpm verify:fast` to confirm lint + unit tests are green.
+
+- [ ] **1.6** Commit:
+
+  ```bash
+  git add packages/frontend/src/hooks/use-pointer-swipe.ts \
+    packages/frontend/src/hooks/use-pointer-swipe.test.tsx
+  git commit -m "$(cat <<'EOF'
+  frontend: add usePointerSwipe hook for mobile slide nav
+
+  Encapsulates horizontal swipe classification so the upcoming
+  mobile slides view can hand off all gesture logic to a single
+  unit-tested hook. Locks intent once |dx| > 10px to suppress iOS
+  swipe-back, falls back to no-op below a 50px / 600ms threshold,
+  and uses pointer capture so move/up don't get lost if the pointer
+  leaves the element mid-gesture.
+  EOF
+  )"
+  ```
+
+---
+
+## Task 2 — `MobileSlidesView` scaffold (no canvas yet)
+
+**Files:**
+
+- Create: `packages/frontend/src/app/slides/mobile-slides-view.tsx`
+- Create: `packages/frontend/src/app/slides/mobile-slides-view.test.tsx`
+
+Render the header, footer, and an empty `canvas-host` div. Read the
+Yorkie root, track `currentSlideId`, wire prev/next buttons and the
+swipe hook. No canvas painting yet — verifying the React shell in
+isolation first.
+
+- [ ] **2.1** Write failing test:
+
+  ```tsx
+  import { describe, it, expect, vi } from 'vitest';
+  import { render, fireEvent, screen } from '@testing-library/react';
+  import { MobileSlidesView } from './mobile-slides-view';
+
+  // Mock @yorkie-js/react useDocument with a fake doc that has 3 slides.
+  vi.mock('@yorkie-js/react', () => ({
+    useDocument: () => ({
+      doc: makeFakeDoc(['s1', 's2', 's3']),
+      loading: false,
+      error: null,
+    }),
+  }));
+
+  // Mock SlideRenderer so jsdom doesn't try to use canvas APIs.
+  vi.mock('@wafflebase/slides', async (importOriginal) => {
+    const mod = await importOriginal<typeof import('@wafflebase/slides')>();
+    return {
+      ...mod,
+      SlideRenderer: vi.fn().mockImplementation(() => ({
+        render: vi.fn(),
+        markDirty: vi.fn(),
+      })),
+    };
+  });
+
+  function makeFakeDoc(ids: string[]) {
+    const slides = ids.map((id) => ({
+      id,
+      background: { type: 'solid', color: '#fff' },
+      elements: [],
+      notes: [],
+    }));
+    return {
+      getRoot: () => ({
+        meta: { title: 'Test Deck', themeId: 'default-light', masterId: 'default' },
+        slides,
+        themes: [],
+        masters: [],
+        layouts: [],
+      }),
+      subscribe: () => () => {},
+      update: vi.fn(),
+    };
+  }
+
+  describe('MobileSlidesView', () => {
+    it('renders title from yorkie meta', () => {
+      render(<MobileSlidesView documentId="d" />);
+      expect(screen.getByText('Test Deck')).toBeInTheDocument();
+    });
+
+    it('shows 1 / N indicator on mount', () => {
+      render(<MobileSlidesView documentId="d" />);
+      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    });
+
+    it('next button advances the indicator', () => {
+      render(<MobileSlidesView documentId="d" />);
+      fireEvent.click(screen.getByLabelText('Next slide'));
+      expect(screen.getByText('2 / 3')).toBeInTheDocument();
+    });
+
+    it('next at last slide is a no-op', () => {
+      render(<MobileSlidesView documentId="d" />);
+      fireEvent.click(screen.getByLabelText('Next slide'));
+      fireEvent.click(screen.getByLabelText('Next slide'));
+      fireEvent.click(screen.getByLabelText('Next slide')); // already at 3
+      expect(screen.getByText('3 / 3')).toBeInTheDocument();
+    });
+
+    it('prev at first slide is a no-op', () => {
+      render(<MobileSlidesView documentId="d" />);
+      fireEvent.click(screen.getByLabelText('Previous slide'));
+      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    });
+
+    it('present button invokes onStartPresentation', () => {
+      const onStart = vi.fn();
+      render(<MobileSlidesView documentId="d" onStartPresentation={onStart} />);
+      fireEvent.click(screen.getByLabelText('Start presentation'));
+      expect(onStart).toHaveBeenCalledWith('current');
+    });
+
+    it('back button invokes navigateBack callback', () => {
+      const onBack = vi.fn();
+      render(<MobileSlidesView documentId="d" onBack={onBack} />);
+      fireEvent.click(screen.getByLabelText('Back to deck list'));
+      expect(onBack).toHaveBeenCalled();
+    });
+  });
+  ```
+
+- [ ] **2.2** Run, confirm fail with "MobileSlidesView is not defined":
+
+  ```bash
+  pnpm --filter @wafflebase/frontend test packages/frontend/src/app/slides/mobile-slides-view.test.tsx
+  ```
+
+- [ ] **2.3** Implement the scaffold:
+
+  ```tsx
+  import { useDocument } from '@yorkie-js/react';
+  import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+  import { useNavigate } from 'react-router-dom';
+  import { Loader } from '@/components/loader';
+  import { usePointerSwipe } from '@/hooks/use-pointer-swipe';
+  import type { YorkieSlidesRoot } from '@/types/slides-document';
+  import type { SlidesPresence } from '@/types/users';
+  import { ensureSlidesRoot } from './yorkie-slides-store';
+
+  interface MobileSlidesViewProps {
+    documentId?: string;
+    onStartPresentation?: (from: 'current' | 'first') => void;
+    /** Optional override for the back action; defaults to navigate('/slides'). */
+    onBack?: () => void;
+  }
+
+  /**
+   * Read-only mobile slide viewer mounted by `SlidesView` when the
+   * viewport is below 768px. Does not mount the slides editor —
+   * read-only is enforced by construction. Reuses `SlideRenderer`
+   * directly via the slides package's public API (Task 3).
+   */
+  export function MobileSlidesView({
+    documentId: _documentId,
+    onStartPresentation,
+    onBack,
+  }: MobileSlidesViewProps) {
+    const navigate = useNavigate();
+    const { doc, loading, error } = useDocument<YorkieSlidesRoot, SlidesPresence>();
+
+    // Snapshot the root into React state. The Yorkie subscription
+    // (Task 3) will refresh this on remote-change.
+    const [snapshot, setSnapshot] = useState<{
+      title: string;
+      slideIds: string[];
+    }>({ title: '', slideIds: [] });
+
+    useEffect(() => {
+      if (!doc) return;
+      ensureSlidesRoot(doc);
+      const root = doc.getRoot();
+      setSnapshot({
+        title: root.meta?.title ?? 'Untitled',
+        slideIds: (root.slides ?? []).map((s) => s.id),
+      });
+    }, [doc]);
+
+    const [currentSlideId, setCurrentSlideId] = useState<string>('');
+    useEffect(() => {
+      if (snapshot.slideIds.length === 0) {
+        setCurrentSlideId('');
+        return;
+      }
+      // If the current slide was removed by a peer, fall back to first.
+      setCurrentSlideId((id) =>
+        snapshot.slideIds.includes(id) ? id : snapshot.slideIds[0],
+      );
+    }, [snapshot.slideIds]);
+
+    const currentIndex = useMemo(
+      () => snapshot.slideIds.indexOf(currentSlideId),
+      [snapshot.slideIds, currentSlideId],
+    );
+
+    const nextSlide = useCallback(() => {
+      if (currentIndex < 0 || currentIndex >= snapshot.slideIds.length - 1) return;
+      setCurrentSlideId(snapshot.slideIds[currentIndex + 1]);
+    }, [currentIndex, snapshot.slideIds]);
+
+    const prevSlide = useCallback(() => {
+      if (currentIndex <= 0) return;
+      setCurrentSlideId(snapshot.slideIds[currentIndex - 1]);
+    }, [currentIndex, snapshot.slideIds]);
+
+    const canvasHostRef = useRef<HTMLDivElement>(null);
+    usePointerSwipe(canvasHostRef, {
+      onSwipeLeft: nextSlide,
+      onSwipeRight: prevSlide,
+    });
+
+    const handleBack = useCallback(() => {
+      if (onBack) onBack();
+      else navigate('/slides');
+    }, [onBack, navigate]);
+
+    const handlePresent = useCallback(() => {
+      onStartPresentation?.('current');
+    }, [onStartPresentation]);
+
+    if (loading) return <Loader />;
+    if (error) return <div role="alert">Failed to load deck.</div>;
+
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100dvh',
+          maxHeight: '100vh',
+          overflow: 'hidden',
+        }}
+      >
+        <header
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            height: 44,
+            padding: '0 8px',
+            gap: 8,
+            borderBottom: '1px solid var(--border, #e5e7eb)',
+            flexShrink: 0,
+          }}
+        >
+          <button
+            type="button"
+            aria-label="Back to deck list"
+            onClick={handleBack}
+            style={{ width: 36, height: 36 }}
+          >
+            ‹
+          </button>
+          <h1
+            style={{
+              flex: 1,
+              fontSize: 16,
+              fontWeight: 500,
+              margin: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {snapshot.title}
+          </h1>
+          <button
+            type="button"
+            aria-label="Start presentation"
+            onClick={handlePresent}
+            disabled={snapshot.slideIds.length === 0}
+            style={{ width: 36, height: 36 }}
+          >
+            ▶
+          </button>
+        </header>
+
+        <div
+          ref={canvasHostRef}
+          style={{
+            flex: 1,
+            minHeight: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: '#000',
+            touchAction: 'pan-y',
+          }}
+        >
+          {/* Canvas mounts here in Task 3 */}
+        </div>
+
+        <footer
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 16,
+            height: 28,
+            fontSize: 13,
+            flexShrink: 0,
+            borderTop: '1px solid var(--border, #e5e7eb)',
+          }}
+        >
+          <button
+            type="button"
+            aria-label="Previous slide"
+            onClick={prevSlide}
+            disabled={currentIndex <= 0}
+            style={{ minWidth: 32 }}
+          >
+            ‹
+          </button>
+          <span>
+            {Math.max(currentIndex + 1, 0)} / {snapshot.slideIds.length}
+          </span>
+          <button
+            type="button"
+            aria-label="Next slide"
+            onClick={nextSlide}
+            disabled={currentIndex >= snapshot.slideIds.length - 1}
+            style={{ minWidth: 32 }}
+          >
+            ›
+          </button>
+        </footer>
+      </div>
+    );
+  }
+  ```
+
+- [ ] **2.4** Run tests, confirm pass.
+
+- [ ] **2.5** Run `pnpm verify:fast`.
+
+- [ ] **2.6** Commit:
+
+  ```bash
+  git add packages/frontend/src/app/slides/mobile-slides-view.tsx \
+    packages/frontend/src/app/slides/mobile-slides-view.test.tsx
+  git commit -m "$(cat <<'EOF'
+  frontend: scaffold MobileSlidesView (header, nav, no canvas yet)
+
+  Renders the header (back / title / Present), footer indicator,
+  and prev/next handlers driven by both arrow buttons and the swipe
+  hook from the previous commit. Yorkie subscription and the actual
+  SlideRenderer canvas land in the next commit so this one keeps the
+  React shell reviewable in isolation.
+  EOF
+  )"
+  ```
+
+---
+
+## Task 3 — Canvas integration (SlideRenderer + ResizeObserver + remote-change)
+
+**Files:**
+
+- Modify: `packages/frontend/src/app/slides/mobile-slides-view.tsx`
+
+Wire the canvas. On mount, create a `<canvas>` inside `canvasHostRef`,
+attach a `SlideRenderer`, observe size changes with `ResizeObserver`,
+and re-render whenever (a) the slide list changes, (b)
+`currentSlideId` changes, or (c) the host resizes. Subscribe to
+`doc` for `remote-change` events to refresh the snapshot.
+
+- [ ] **3.1** Add a snapshot-refresh helper and a `doc.subscribe`
+  effect that calls it on `remote-change`:
+
+  ```tsx
+  useEffect(() => {
+    if (!doc) return;
+    const refresh = () => {
+      const root = doc.getRoot();
+      setSnapshot({
+        title: root.meta?.title ?? 'Untitled',
+        slideIds: (root.slides ?? []).map((s) => s.id),
+      });
+    };
+    const unsub = doc.subscribe((e) => {
+      if (e.type === 'remote-change') refresh();
+    });
+    return () => unsub();
+  }, [doc]);
+  ```
+
+  Note: the existing mount effect already calls `ensureSlidesRoot`
+  and seeds the initial snapshot. Keep it; this new effect is the
+  per-remote-change refresher only.
+
+- [ ] **3.2** Replace the `{/* Canvas mounts here */}` comment with a
+  `<canvas ref={canvasRef} />` and add the renderer effect:
+
+  ```tsx
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rendererRef = useRef<{
+    renderer: SlideRenderer;
+    cssWidth: number;
+    cssHeight: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const host = canvasHostRef.current;
+    if (!canvas || !host || !doc) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+
+    const SLIDE_ASPECT = 16 / 9;
+    function computeFit(availW: number, availH: number) {
+      const wFit = { w: availW, h: availW / SLIDE_ASPECT };
+      if (wFit.h <= availH) return wFit;
+      return { w: availH * SLIDE_ASPECT, h: availH };
+    }
+
+    function paint() {
+      const root = doc.getRoot();
+      const slides = root.slides ?? [];
+      const slide = slides.find((s) => s.id === currentSlideId);
+      if (!slide || !rendererRef.current) return;
+      // Cast: Yorkie root is structurally compatible with the
+      // SlidesDocument the renderer wants. See yorkie-slides-store.ts
+      // for the same cast.
+      rendererRef.current.renderer.markDirty();
+      rendererRef.current.renderer.render(slide, root as unknown as SlidesDocument);
+    }
+
+    function applyFit() {
+      const rect = host.getBoundingClientRect();
+      const fit = computeFit(rect.width, rect.height);
+      const cssW = Math.round(fit.w);
+      const cssH = Math.round(fit.h);
+      canvas.width = Math.round(cssW * dpr);
+      canvas.height = Math.round(cssH * dpr);
+      canvas.style.width = `${cssW}px`;
+      canvas.style.height = `${cssH}px`;
+      rendererRef.current = {
+        renderer: new SlideRenderer(ctx, {
+          hostWidth: cssW,
+          hostHeight: cssH,
+          dpr,
+        }),
+        cssWidth: cssW,
+        cssHeight: cssH,
+      };
+      paint();
+    }
+
+    let rafScheduled = false;
+    const ro = new ResizeObserver(() => {
+      if (rafScheduled) return;
+      rafScheduled = true;
+      requestAnimationFrame(() => {
+        rafScheduled = false;
+        applyFit();
+      });
+    });
+    ro.observe(host);
+    applyFit(); // initial paint
+
+    return () => {
+      ro.disconnect();
+      rendererRef.current = null;
+    };
+  }, [doc, currentSlideId]);
+  ```
+
+  Imports to add at the top of the file:
+
+  ```ts
+  import { SlideRenderer } from '@wafflebase/slides';
+  import type { SlidesDocument } from '@wafflebase/slides';
+  ```
+
+- [ ] **3.3** Verify `SlidesDocument` is exported from
+  `@wafflebase/slides`. If not, export it from
+  `packages/slides/src/index.ts` in the same commit:
+
+  ```bash
+  grep -n "SlidesDocument\|export.*type" packages/slides/src/index.ts | head -5
+  ```
+
+  If missing, add: `export type { Slide, SlidesDocument } from './model/presentation';`
+  (it's likely already exported — confirm before committing).
+
+- [ ] **3.4** Run the existing `MobileSlidesView` tests. Because they
+  mock `SlideRenderer`, they should still pass without modification.
+  If a test now needs a `canvas` element in the DOM, add a
+  `HTMLCanvasElement.prototype.getContext = vi.fn(() => ({} as any))`
+  stub at the top of the test file.
+
+- [ ] **3.5** Run `pnpm verify:fast`.
+
+- [ ] **3.6** Manual smoke (don't skip this — visual regressions on
+  Canvas don't show up in unit tests):
+
+  ```bash
+  pnpm dev
+  ```
+
+  Open Chrome DevTools → toggle device toolbar → iPhone 14 Pro
+  (393×852). Navigate to a slide deck. Verify:
+
+  - Header shows back, title, Present button.
+  - Canvas paints the first slide and fits the visible area
+    without scrollbars.
+  - Footer shows `1 / N`.
+  - Tap Next button: slide changes, footer updates.
+  - Swipe left on the canvas: slide advances.
+  - Swipe right: slide goes back.
+  - Rotate device emulation (landscape): canvas resizes, no layout
+    break.
+  - Toggle out of mobile emulation (desktop 1280px): desktop editor
+    mounts (this will only work after Task 4).
+
+- [ ] **3.7** Commit:
+
+  ```bash
+  git add packages/frontend/src/app/slides/mobile-slides-view.tsx
+  # plus packages/slides/src/index.ts if SlidesDocument needed exporting
+  git commit -m "$(cat <<'EOF'
+  frontend: paint slides on mobile via SlideRenderer
+
+  Wires a single SlideRenderer to MobileSlidesView's canvas, with a
+  ResizeObserver-driven fit (RAF-coalesced so window-drag doesn't
+  spam re-instantiation) and a Yorkie remote-change subscription
+  that re-snapshots title and slide-id list. Re-uses the same
+  computeFitSize math as slides-view.tsx / presenter.ts —
+  intentional ~10-line duplicate per the design doc.
+  EOF
+  )"
+  ```
+
+---
+
+## Task 4 — `SlidesView` branch on `useIsMobile`
+
+**Files:**
+
+- Modify: `packages/frontend/src/app/slides/slides-view.tsx`
+
+Top-of-render branch. The desktop path is left intact; only the
+entry point changes.
+
+- [ ] **4.1** At the top of `slides-view.tsx`, add the import:
+
+  ```tsx
+  import { useIsMobile } from '@/hooks/use-mobile';
+  import { MobileSlidesView } from './mobile-slides-view';
+  ```
+
+- [ ] **4.2** In the `SlidesView` function, after `useDocument` and
+  before the existing mount `useEffect`, branch:
+
+  ```tsx
+  const isMobile = useIsMobile();
+  if (isMobile) {
+    return (
+      <MobileSlidesView
+        documentId={documentId}
+        onStartPresentation={onStartPresentation}
+      />
+    );
+  }
+  ```
+
+  Place the branch AFTER `useDocument` and `useIsMobile` calls but
+  BEFORE any other hooks — React requires consistent hook order
+  across renders. Since `useDocument` and `useIsMobile` are always
+  called, and the branch returns before any other hook, this is
+  safe. (The existing desktop hooks below the branch only run when
+  `!isMobile`, but they'll still get called consistently on every
+  desktop render. Confirm by running the dev server and resizing
+  across the breakpoint — no "rendered fewer hooks than expected"
+  warning should appear.)
+
+- [ ] **4.3** Add a test verifying the branch (in a new file or
+  appended to an existing slides-view test if one exists):
+
+  ```tsx
+  import { vi, describe, it, expect } from 'vitest';
+  import { render, screen } from '@testing-library/react';
+  import { SlidesView } from './slides-view';
+
+  vi.mock('@/hooks/use-mobile', () => ({
+    useIsMobile: vi.fn(),
+  }));
+  vi.mock('@yorkie-js/react', () => ({
+    useDocument: () => ({
+      doc: { getRoot: () => ({ meta: { title: 'T' }, slides: [] }), subscribe: () => () => {} },
+      loading: false,
+      error: null,
+    }),
+  }));
+  vi.mock('./mobile-slides-view', () => ({
+    MobileSlidesView: () => <div data-testid="mobile-view" />,
+  }));
+
+  import { useIsMobile } from '@/hooks/use-mobile';
+
+  describe('SlidesView mobile branch', () => {
+    it('mounts MobileSlidesView when isMobile is true', () => {
+      (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      render(<SlidesView />);
+      expect(screen.getByTestId('mobile-view')).toBeInTheDocument();
+    });
+  });
+  ```
+
+  Path: `packages/frontend/src/app/slides/slides-view.test.tsx` (new
+  if absent; just append the `describe` block if present).
+
+- [ ] **4.4** Run tests + verify:fast.
+
+- [ ] **4.5** Manual smoke: `pnpm dev`, resize browser window across
+  the 768px boundary. Confirm:
+
+  - At < 768px: mobile view renders (header / canvas / footer).
+  - At ≥ 768px: existing desktop editor renders.
+  - Resizing across the boundary unmounts one, mounts the other
+    cleanly; no console errors; Yorkie remains attached (look at
+    Network tab — no extra Yorkie attach/detach).
+
+- [ ] **4.6** Commit:
+
+  ```bash
+  git add packages/frontend/src/app/slides/slides-view.tsx \
+    packages/frontend/src/app/slides/slides-view.test.tsx
+  git commit -m "$(cat <<'EOF'
+  frontend: branch SlidesView to MobileSlidesView under 768px
+
+  Adds a one-line useIsMobile branch at the top of SlidesView's
+  render. The desktop mount path is unchanged. Crossing the
+  breakpoint at runtime swaps mounts without re-attaching the
+  Yorkie document (DocumentProvider lives above SlidesView).
+  EOF
+  )"
+  ```
+
+---
+
+## Task 5 — Visual / mobile-viewport browser tests
+
+**Files:**
+
+- Create: a new fixture under `packages/frontend/tests/visual/` or
+  equivalent, depending on where existing slides visual tests live.
+  Confirm by running:
+
+  ```bash
+  find packages/frontend/tests -name "*slides*" -type f 2>/dev/null | head -5
+  find . -name "playwright*" -type f -not -path "*/node_modules/*" 2>/dev/null | head -5
+  ```
+
+- [ ] **5.1** Locate the existing slides visual test (likely a
+  Playwright spec since the project uses `pnpm verify:browser:docker`).
+  Read it to learn the fixture pattern.
+
+- [ ] **5.2** Add a new spec — `slides-mobile-view.spec.ts` (next to
+  the existing slides spec) — that:
+
+  - Sets viewport to 390×844 (iPhone 14).
+  - Navigates to a known seeded slide deck (use the same seed the
+    existing visual test uses).
+  - Asserts the header `Back to deck list`, `Start presentation`,
+    and the indicator `1 /` text are present.
+  - Takes a snapshot of the page (full-page).
+  - Sets viewport to 360×640 and re-snapshots.
+  - Clicks the `Next slide` aria-label and asserts the indicator
+    increments.
+
+  Use the same `await page.locator` and snapshot APIs as the existing
+  spec — don't introduce a new framework.
+
+- [ ] **5.3** Run `pnpm verify:browser:docker` locally. First-run
+  snapshots will be written — review the generated images to confirm
+  the layout looks right, then commit them.
+
+- [ ] **5.4** Commit:
+
+  ```bash
+  git add packages/frontend/tests/  # adjust to actual path
+  git commit -m "$(cat <<'EOF'
+  frontend: add mobile-viewport visual test for slides
+
+  Snapshots the MobileSlidesView layout at 390x844 and 360x640
+  and verifies the Next slide arrow advances the indicator. Runs
+  in pnpm verify:browser:docker alongside the existing slides
+  visual fixture.
+  EOF
+  )"
+  ```
+
+---
+
+## Task 6 — Final verification and PR
+
+- [ ] **6.1** Pull latest main and rebase:
+
+  ```bash
+  git fetch origin
+  git rebase origin/main
+  ```
+
+  Resolve any conflicts.
+
+- [ ] **6.2** Run the full pre-merge check:
+
+  ```bash
+  pnpm verify:fast
+  pnpm verify:self
+  pnpm verify:browser:docker
+  ```
+
+- [ ] **6.3** Manual smoke pass one more time:
+
+  - `pnpm dev`
+  - DevTools mobile emulation: iPhone 14 Pro, iPhone SE (375×667),
+    Pixel 7 (412×915).
+  - Verify: header sizing, swipe left/right, tap Present →
+    fullscreen presentation works (or overlay fallback fires),
+    cross-breakpoint resize works.
+  - Verify desktop is unchanged: open a deck on a wide window,
+    confirm editor still mounts and behaves identically to main.
+
+- [ ] **6.4** Self-review (don't skip — CLAUDE.md mandates a
+  dispatched review before pushing). Run:
+
+  ```bash
+  /code-review
+  ```
+
+  or invoke the `superpowers:requesting-code-review` skill over the
+  full branch diff. Apply blocking findings; record non-blocking
+  as known limitations in the lessons file.
+
+- [ ] **6.5** Update lessons file
+  (`docs/tasks/active/20260517-slides-mobile-view-lessons.md`)
+  with anything surprising encountered during implementation —
+  Yorkie subscribe quirks, jsdom canvas stubs, ResizeObserver
+  timing, Playwright snapshot rebaselines, etc.
+
+- [ ] **6.6** Archive and reindex tasks:
+
+  ```bash
+  pnpm tasks:archive
+  pnpm tasks:index
+  ```
+
+- [ ] **6.7** Push and open PR:
+
+  ```bash
+  git push -u origin slides-mobile-view
+  gh pr create --title "slides: add read-only mobile view (<768px)" --body "$(cat <<'EOF'
+  ## Summary
+
+  - New `MobileSlidesView` component mounted by `SlidesView` when
+    the viewport is under 768px. Read-only by construction (no
+    editor module is mounted).
+  - Header (back / title / Present), single full-width canvas via
+    `SlideRenderer` reuse, footer indicator, and left/right swipe
+    navigation through a new `usePointerSwipe` hook.
+  - Design doc: `docs/design/slides/slides-mobile-view.md`.
+
+  ## Test plan
+
+  - [ ] `pnpm verify:fast` green
+  - [ ] `pnpm verify:browser:docker` green (with new mobile fixture)
+  - [ ] Manual: mobile emulation at 360, 390, 430 viewport widths
+  - [ ] Manual: cross-breakpoint resize swaps mounts cleanly
+  - [ ] Manual: Present button enters presentation (fullscreen or
+        overlay fallback on iOS)
+  - [ ] Manual: desktop editor unchanged at >=768px
+  EOF
+  )"
+  ```
+
+---
+
+## Self-review checklist (run before pushing)
+
+- [ ] All tasks above are checked off
+- [ ] No `console.log` left in production code
+- [ ] No mutation paths from `MobileSlidesView` to Yorkie except
+  `ensureSlidesRoot` (which is idempotent)
+- [ ] `useIsMobile` branch is placed where hook ordering stays
+  consistent
+- [ ] Existing desktop editor flow is byte-for-byte identical to
+  `main` (diff `slides-view.tsx` — the only change should be the
+  added imports and the early-return branch)

--- a/packages/frontend/src/app/slides/mobile-slides-view.tsx
+++ b/packages/frontend/src/app/slides/mobile-slides-view.tsx
@@ -7,6 +7,12 @@ import {
   useState,
 } from "react";
 import { useNavigate } from "react-router-dom";
+import {
+  SLIDE_HEIGHT,
+  SLIDE_WIDTH,
+  SlideRenderer,
+  type SlidesDocument,
+} from "@wafflebase/slides";
 import { Loader } from "@/components/loader";
 import { usePointerSwipe } from "@/hooks/use-pointer-swipe";
 import type { YorkieSlidesRoot } from "@/types/slides-document";
@@ -16,6 +22,23 @@ import {
   YorkieSlidesStore,
   ensureSlidesRoot,
 } from "./yorkie-slides-store";
+
+const SLIDE_ASPECT = SLIDE_WIDTH / SLIDE_HEIGHT;
+
+/**
+ * Picks the largest 16:9 box that fits inside the available area.
+ * Duplicated from `view/present/presenter.ts` and `slides-view.tsx`
+ * on purpose — the slides package can't depend on the frontend, and
+ * the math is small (see slides-mobile-view design doc).
+ */
+function computeFitSize(
+  availWidth: number,
+  availHeight: number,
+): { width: number; height: number } {
+  const widthFit = { width: availWidth, height: availWidth / SLIDE_ASPECT };
+  if (widthFit.height <= availHeight) return widthFit;
+  return { width: availHeight * SLIDE_ASPECT, height: availHeight };
+}
 
 interface MobileSlidesViewProps {
   documentId: string;
@@ -109,11 +132,82 @@ export function MobileSlidesView({
   }, [currentIndex, snapshot.slideIds]);
 
   const canvasHostRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
   const swipeOptions = useMemo(
     () => ({ onSwipeLeft: nextSlide, onSwipeRight: prevSlide }),
     [nextSlide, prevSlide],
   );
   usePointerSwipe(canvasHostRef, swipeOptions);
+
+  // Canvas painting. A single SlideRenderer is bound to the current
+  // host size; on resize it's rebuilt (cheap constructor) inside a
+  // RAF-coalesced ResizeObserver callback so window drags don't spam
+  // re-instantiation. Repaint is triggered by changes to the current
+  // slide id or by the store's onChange (covers remote peer edits).
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const host = canvasHostRef.current;
+    if (!canvas || !host || !store) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+
+    let renderer: SlideRenderer | null = null;
+    let lastDoc: SlidesDocument = store.read();
+
+    function paint() {
+      if (!renderer) return;
+      const slide = lastDoc.slides.find((s) => s.id === currentSlideId);
+      if (!slide) return;
+      renderer.markDirty();
+      renderer.render(slide, lastDoc);
+    }
+
+    function applyFit() {
+      const rect = host!.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return;
+      const fit = computeFitSize(rect.width, rect.height);
+      const cssW = Math.round(fit.width);
+      const cssH = Math.round(fit.height);
+      canvas!.width = Math.round(cssW * dpr);
+      canvas!.height = Math.round(cssH * dpr);
+      canvas!.style.width = `${cssW}px`;
+      canvas!.style.height = `${cssH}px`;
+      renderer = new SlideRenderer(ctx!, {
+        hostWidth: cssW,
+        hostHeight: cssH,
+        dpr,
+      });
+      paint();
+    }
+
+    let rafScheduled = false;
+    const ro = new ResizeObserver(() => {
+      if (rafScheduled) return;
+      rafScheduled = true;
+      requestAnimationFrame(() => {
+        rafScheduled = false;
+        applyFit();
+      });
+    });
+    ro.observe(host);
+    applyFit();
+
+    // Pick up peer edits (remote-change → store.onChange) and apply
+    // them to the next paint. Local writes never originate from this
+    // mobile view, but onChange fires for them too on the desktop
+    // editor side — harmless duplicate refresh.
+    const unsubscribe = store.onChange(() => {
+      lastDoc = store.read();
+      paint();
+    });
+
+    return () => {
+      ro.disconnect();
+      unsubscribe();
+      renderer = null;
+    };
+  }, [store, currentSlideId]);
 
   const handleBack = useCallback(() => {
     if (onBack) onBack();
@@ -220,7 +314,10 @@ export function MobileSlidesView({
           touchAction: "pan-y",
         }}
       >
-        {/* Canvas mounts here in Task 3. */}
+        <canvas
+          ref={canvasRef}
+          aria-label={`Slide ${Math.max(currentIndex + 1, 0)} of ${snapshot.slideIds.length}`}
+        />
       </div>
 
       <footer

--- a/packages/frontend/src/app/slides/mobile-slides-view.tsx
+++ b/packages/frontend/src/app/slides/mobile-slides-view.tsx
@@ -53,11 +53,9 @@ interface MobileSlidesViewProps {
  * `slides-detail.tsx`'s `SlidesLayout` when `useIsMobile()` is true,
  * replacing the full desktop chrome (sidebar / site header / toolbar
  * / SlidesView). The editor module is intentionally not mounted —
- * read-only is enforced by construction.
- *
- * The canvas painting wiring lands in the next commit. This commit
- * builds out the React shell, navigation state, swipe gesture, and
- * Present-mode launch so the structure is reviewable on its own.
+ * read-only is enforced by construction. Slide painting reuses
+ * `SlideRenderer` directly the same way `view/present/presenter.ts`
+ * does, so the canvas pipeline stays in one place.
  */
 export function MobileSlidesView({
   title,

--- a/packages/frontend/src/app/slides/mobile-slides-view.tsx
+++ b/packages/frontend/src/app/slides/mobile-slides-view.tsx
@@ -1,0 +1,287 @@
+import { useDocument } from "@yorkie-js/react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useNavigate } from "react-router-dom";
+import { Loader } from "@/components/loader";
+import { usePointerSwipe } from "@/hooks/use-pointer-swipe";
+import type { YorkieSlidesRoot } from "@/types/slides-document";
+import type { SlidesPresence } from "@/types/users";
+import { SlidesPresentationMode } from "./slides-presentation-mode";
+import {
+  YorkieSlidesStore,
+  ensureSlidesRoot,
+} from "./yorkie-slides-store";
+
+interface MobileSlidesViewProps {
+  documentId: string;
+  /** Page title from the Documents API. Falls back to Yorkie meta title. */
+  title?: string;
+  /** Override the back action; defaults to `navigate(-1)`. */
+  onBack?: () => void;
+}
+
+/**
+ * Read-only mobile shell for the slides editor. Mounted by
+ * `slides-detail.tsx`'s `SlidesLayout` when `useIsMobile()` is true,
+ * replacing the full desktop chrome (sidebar / site header / toolbar
+ * / SlidesView). The editor module is intentionally not mounted —
+ * read-only is enforced by construction.
+ *
+ * The canvas painting wiring lands in the next commit. This commit
+ * builds out the React shell, navigation state, swipe gesture, and
+ * Present-mode launch so the structure is reviewable on its own.
+ */
+export function MobileSlidesView({
+  title,
+  onBack,
+}: MobileSlidesViewProps) {
+  const navigate = useNavigate();
+  const { doc, loading, error } = useDocument<
+    YorkieSlidesRoot,
+    SlidesPresence
+  >();
+
+  // Build the store once per `doc`. We keep the store around so the
+  // Present button can hand it to `<SlidesPresentationMode>` without
+  // re-wrapping on every render. Disposed in cleanup.
+  const [store, setStore] = useState<YorkieSlidesStore | null>(null);
+  useEffect(() => {
+    if (!doc) return;
+    ensureSlidesRoot(doc);
+    const s = new YorkieSlidesStore(doc);
+    setStore(s);
+    return () => {
+      s.dispose();
+      setStore(null);
+    };
+  }, [doc]);
+
+  // Snapshot of the parts of the deck the mobile shell renders.
+  // Refreshed whenever the store fires `onChange` (covers local writes
+  // — though we don't issue any here — and remote peer edits).
+  const [snapshot, setSnapshot] = useState<{
+    title: string;
+    slideIds: string[];
+  }>({ title: title ?? "", slideIds: [] });
+
+  useEffect(() => {
+    if (!store) return;
+    const refresh = () => {
+      const r = store.read();
+      setSnapshot({
+        title: title ?? r.meta?.title ?? "Untitled",
+        slideIds: r.slides.map((s) => s.id),
+      });
+    };
+    refresh();
+    return store.onChange(refresh);
+  }, [store, title]);
+
+  const [currentSlideId, setCurrentSlideId] = useState<string>("");
+  useEffect(() => {
+    if (snapshot.slideIds.length === 0) {
+      setCurrentSlideId("");
+      return;
+    }
+    setCurrentSlideId((id) =>
+      snapshot.slideIds.includes(id) ? id : snapshot.slideIds[0],
+    );
+  }, [snapshot.slideIds]);
+
+  const currentIndex = useMemo(
+    () => snapshot.slideIds.indexOf(currentSlideId),
+    [snapshot.slideIds, currentSlideId],
+  );
+
+  const nextSlide = useCallback(() => {
+    if (currentIndex < 0 || currentIndex >= snapshot.slideIds.length - 1) return;
+    setCurrentSlideId(snapshot.slideIds[currentIndex + 1]);
+  }, [currentIndex, snapshot.slideIds]);
+
+  const prevSlide = useCallback(() => {
+    if (currentIndex <= 0) return;
+    setCurrentSlideId(snapshot.slideIds[currentIndex - 1]);
+  }, [currentIndex, snapshot.slideIds]);
+
+  const canvasHostRef = useRef<HTMLDivElement>(null);
+  const swipeOptions = useMemo(
+    () => ({ onSwipeLeft: nextSlide, onSwipeRight: prevSlide }),
+    [nextSlide, prevSlide],
+  );
+  usePointerSwipe(canvasHostRef, swipeOptions);
+
+  const handleBack = useCallback(() => {
+    if (onBack) onBack();
+    else navigate(-1);
+  }, [onBack, navigate]);
+
+  const [presentingFrom, setPresentingFrom] = useState<"current" | null>(null);
+  const handlePresent = useCallback(() => {
+    if (!store || store.read().slides.length === 0) return;
+    setPresentingFrom("current");
+  }, [store]);
+
+  const presentationStartSlideId =
+    presentingFrom && currentSlideId ? currentSlideId : undefined;
+
+  if (loading) return <Loader />;
+  if (error) {
+    return (
+      <div role="alert" style={{ padding: 16 }}>
+        Failed to load deck.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100dvh",
+        maxHeight: "100vh",
+        overflow: "hidden",
+        background: "#fff",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          height: 44,
+          padding: "0 8px",
+          gap: 8,
+          borderBottom: "1px solid #e5e7eb",
+          flexShrink: 0,
+          background: "#fff",
+        }}
+      >
+        <button
+          type="button"
+          aria-label="Back to deck list"
+          onClick={handleBack}
+          style={{
+            width: 36,
+            height: 36,
+            fontSize: 22,
+            background: "transparent",
+            border: 0,
+            cursor: "pointer",
+          }}
+        >
+          ‹
+        </button>
+        <h1
+          style={{
+            flex: 1,
+            fontSize: 16,
+            fontWeight: 500,
+            margin: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {snapshot.title || "Untitled"}
+        </h1>
+        <button
+          type="button"
+          aria-label="Start presentation"
+          onClick={handlePresent}
+          disabled={snapshot.slideIds.length === 0}
+          style={{
+            width: 36,
+            height: 36,
+            fontSize: 16,
+            background: "transparent",
+            border: 0,
+            cursor: snapshot.slideIds.length === 0 ? "not-allowed" : "pointer",
+            opacity: snapshot.slideIds.length === 0 ? 0.4 : 1,
+          }}
+        >
+          ▶
+        </button>
+      </header>
+
+      <div
+        ref={canvasHostRef}
+        style={{
+          flex: 1,
+          minHeight: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#000",
+          touchAction: "pan-y",
+        }}
+      >
+        {/* Canvas mounts here in Task 3. */}
+      </div>
+
+      <footer
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 16,
+          height: 28,
+          fontSize: 13,
+          flexShrink: 0,
+          borderTop: "1px solid #e5e7eb",
+          background: "#fff",
+        }}
+      >
+        <button
+          type="button"
+          aria-label="Previous slide"
+          onClick={prevSlide}
+          disabled={currentIndex <= 0}
+          style={{
+            minWidth: 32,
+            background: "transparent",
+            border: 0,
+            cursor: currentIndex <= 0 ? "not-allowed" : "pointer",
+            opacity: currentIndex <= 0 ? 0.4 : 1,
+          }}
+        >
+          ‹
+        </button>
+        <span>
+          {Math.max(currentIndex + 1, 0)} / {snapshot.slideIds.length}
+        </span>
+        <button
+          type="button"
+          aria-label="Next slide"
+          onClick={nextSlide}
+          disabled={currentIndex >= snapshot.slideIds.length - 1}
+          style={{
+            minWidth: 32,
+            background: "transparent",
+            border: 0,
+            cursor:
+              currentIndex >= snapshot.slideIds.length - 1
+                ? "not-allowed"
+                : "pointer",
+            opacity:
+              currentIndex >= snapshot.slideIds.length - 1 ? 0.4 : 1,
+          }}
+        >
+          ›
+        </button>
+      </footer>
+
+      {presentingFrom && store && presentationStartSlideId && (
+        <SlidesPresentationMode
+          store={store}
+          startSlideId={presentationStartSlideId}
+          onExit={() => setPresentingFrom(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -74,7 +74,11 @@ function SlidesLayout({ documentId }: { documentId: string }) {
   const isMobile = useIsMobile();
   const navigate = useNavigate();
 
-  const { data: documentData, isError: isDocumentError } = useQuery({
+  const {
+    data: documentData,
+    isError: isDocumentError,
+    isLoading: isDocumentLoading,
+  } = useQuery({
     queryKey: ["document", documentId],
     queryFn: () => fetchDocument(documentId),
     retry: false,
@@ -101,6 +105,18 @@ function SlidesLayout({ documentId }: { documentId: string }) {
       });
     }
   }, [isDocumentError, navigate, fallbackSlug]);
+
+  // Gate the mount on the document existence check. Without this gate
+  // both branches would mount during the loading window, kicking off
+  // a Yorkie attach for the requested id before the backend has had
+  // a chance to confirm the user is allowed to read it — a peer who
+  // already had the deck open would briefly leak its contents
+  // through the Yorkie subscription. Holding both branches behind
+  // the loader closes that window; the error branch returns null
+  // because the useEffect above is already racing toward the
+  // redirect.
+  if (isDocumentLoading) return <Loader />;
+  if (isDocumentError) return null;
 
   if (isMobile) {
     return (

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -58,14 +58,58 @@ function resolveStartSlideId(
 
 /**
  * SlidesLayout — dispatches between the desktop chrome and the
- * read-only mobile shell based on viewport width. The mobile branch
- * intentionally skips the desktop sidebar, site header, toolbar, and
- * SlidesView so a <768px viewport gets the entire vertical space for
- * the slide canvas (see docs/design/slides/slides-mobile-view.md).
+ * read-only mobile shell based on viewport width, and owns the
+ * shared document-not-found / permission guard that both branches
+ * rely on. Hoisting the metadata fetch up here keeps mobile from
+ * silently attaching to a Yorkie doc for an id the backend has
+ * already rejected (without this, navigating to /p/<bad-id> on
+ * mobile would create an empty deck instead of redirecting away).
+ *
+ * The mobile branch intentionally skips the desktop sidebar, site
+ * header, toolbar, and SlidesView so a <768px viewport gets the
+ * entire vertical space for the slide canvas (see
+ * docs/design/slides/slides-mobile-view.md).
  */
 function SlidesLayout({ documentId }: { documentId: string }) {
   const isMobile = useIsMobile();
-  if (isMobile) return <MobileSlidesView documentId={documentId} />;
+  const navigate = useNavigate();
+
+  const { data: documentData, isError: isDocumentError } = useQuery({
+    queryKey: ["document", documentId],
+    queryFn: () => fetchDocument(documentId),
+    retry: false,
+  });
+
+  const { data: workspaces = [] } = useQuery<Workspace[]>({
+    queryKey: ["workspaces"],
+    queryFn: fetchWorkspaces,
+  });
+
+  // Resolve the fallback workspace slug for the redirect target, so
+  // a not-found redirect lands the user back on their workspace's
+  // document list rather than the global /documents page when
+  // possible.
+  const fallbackSlug =
+    workspaces.find((w) => w.id === documentData?.workspaceId)?.slug ??
+    workspaces[0]?.slug;
+
+  useEffect(() => {
+    if (isDocumentError) {
+      toast.error("Document not found");
+      navigate(fallbackSlug ? `/w/${fallbackSlug}` : "/documents", {
+        replace: true,
+      });
+    }
+  }, [isDocumentError, navigate, fallbackSlug]);
+
+  if (isMobile) {
+    return (
+      <MobileSlidesView
+        documentId={documentId}
+        title={documentData?.title}
+      />
+    );
+  }
   return <DesktopSlidesLayout documentId={documentId} />;
 }
 
@@ -146,7 +190,11 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
-  const { data: documentData, isError: isDocumentError } = useQuery({
+  // The not-found / permission redirect lives in `SlidesLayout` (the
+  // parent) so the mobile branch enforces the same guard. The query
+  // call below reuses react-query's cache — same key as the parent's
+  // — so no second network request is issued.
+  const { data: documentData } = useQuery({
     queryKey: ["document", documentId],
     queryFn: () => fetchDocument(documentId),
     retry: false,
@@ -167,16 +215,6 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
     (w) => w.id === documentData?.workspaceId,
   );
   const workspaceSlug = currentWorkspace?.slug;
-  const fallbackSlug = workspaceSlug ?? workspaces[0]?.slug;
-
-  useEffect(() => {
-    if (isDocumentError) {
-      toast.error("Document not found");
-      navigate(fallbackSlug ? `/w/${fallbackSlug}` : "/documents", {
-        replace: true,
-      });
-    }
-  }, [isDocumentError, navigate, fallbackSlug]);
 
   const items = useMemo(() => {
     const wsRoot = workspaceSlug ? `/w/${workspaceSlug}` : "/documents";

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -14,8 +14,10 @@ import { UserPresence } from "@/components/user-presence";
 import { usePresenceUpdater } from "@/hooks/use-presence-updater";
 import { IconFolder, IconSettings, IconDatabase } from "@tabler/icons-react";
 import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
+import { useIsMobile } from "@/hooks/use-mobile";
 import type { Theme } from "@wafflebase/slides";
 import type { YorkieSlidesRoot } from "@/types/slides-document";
+import { MobileSlidesView } from "./mobile-slides-view";
 import { SlidesView, type SlidesEditor } from "./slides-view";
 import { SlidesToolbar } from "./toolbar";
 import { SlidesPresentationMode } from "./slides-presentation-mode";
@@ -55,11 +57,24 @@ function resolveStartSlideId(
 }
 
 /**
- * SlidesLayout — sidebar + header chrome around the slides editor.
+ * SlidesLayout — dispatches between the desktop chrome and the
+ * read-only mobile shell based on viewport width. The mobile branch
+ * intentionally skips the desktop sidebar, site header, toolbar, and
+ * SlidesView so a <768px viewport gets the entire vertical space for
+ * the slide canvas (see docs/design/slides/slides-mobile-view.md).
+ */
+function SlidesLayout({ documentId }: { documentId: string }) {
+  const isMobile = useIsMobile();
+  if (isMobile) return <MobileSlidesView documentId={documentId} />;
+  return <DesktopSlidesLayout documentId={documentId} />;
+}
+
+/**
+ * DesktopSlidesLayout — sidebar + header chrome around the slides editor.
  * Mirrors `DocsLayout` so the three document types share a single
  * visual language.
  */
-function SlidesLayout({ documentId }: { documentId: string }) {
+function DesktopSlidesLayout({ documentId }: { documentId: string }) {
   usePresenceUpdater();
   const [editor, setEditor] = useState<SlidesEditor | null>(null);
   const [store, setStore] = useState<YorkieSlidesStore | null>(null);

--- a/packages/frontend/src/hooks/use-pointer-swipe.ts
+++ b/packages/frontend/src/hooks/use-pointer-swipe.ts
@@ -1,0 +1,132 @@
+import { useEffect, type RefObject } from "react";
+
+/** Minimum |dx| in px before a swipe fires. */
+const DEFAULT_THRESHOLD_PX = 50;
+/** Maximum time (ms) between pointerdown and pointerup for the gesture to
+ * still register — guards against slow drags being mistaken for swipes. */
+const DEFAULT_MAX_DURATION_MS = 600;
+/** |dx| at which the gesture commits to horizontal mode and starts
+ * suppressing the browser's default (e.g. iOS swipe-back). */
+const DEFAULT_CLASSIFY_AT_PX = 10;
+
+export interface PointerSwipeOptions {
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+  thresholdPx?: number;
+  maxDurationMs?: number;
+  classifyAtPx?: number;
+}
+
+type Phase = "idle" | "pending" | "horizontal" | "cancelled";
+
+/**
+ * DOM-only attach helper. Wires `pointerdown` / `pointermove` /
+ * `pointerup` / `pointercancel` on `el` and fires `onSwipeLeft` /
+ * `onSwipeRight` when a left/right swipe past `thresholdPx` finishes
+ * inside `maxDurationMs`. Once the gesture is classified as horizontal
+ * (`|dx| > classifyAtPx` and `|dx| > |dy|`), subsequent `pointermove`
+ * events call `preventDefault` so the browser does not start a
+ * competing scroll or history-back swipe.
+ *
+ * Exposed separately from `usePointerSwipe` so the gesture logic can
+ * be unit-tested without a React renderer — the frontend test runner
+ * is Node's native runner and stubs `.tsx` files, so component-level
+ * tests on a React hook are not possible here.
+ *
+ * Returns the cleanup function the caller should invoke on teardown.
+ */
+export function attachPointerSwipe(
+  el: HTMLElement,
+  options: PointerSwipeOptions,
+): () => void {
+  const threshold = options.thresholdPx ?? DEFAULT_THRESHOLD_PX;
+  const maxDuration = options.maxDurationMs ?? DEFAULT_MAX_DURATION_MS;
+  const classifyAt = options.classifyAtPx ?? DEFAULT_CLASSIFY_AT_PX;
+
+  let phase: Phase = "idle";
+  let startX = 0;
+  let startY = 0;
+  let startTime = 0;
+  let pointerId: number | null = null;
+
+  const onDown = (e: PointerEvent) => {
+    phase = "pending";
+    startX = e.clientX;
+    startY = e.clientY;
+    startTime = e.timeStamp;
+    pointerId = e.pointerId;
+    if (typeof el.setPointerCapture === "function") {
+      try {
+        el.setPointerCapture(e.pointerId);
+      } catch {
+        // Some environments (jsdom, or pointers that don't allow capture)
+        // throw — safe to ignore; the gesture still works through bubbled
+        // events.
+      }
+    }
+  };
+
+  const onMove = (e: PointerEvent) => {
+    if (phase === "idle" || phase === "cancelled") return;
+    if (pointerId !== null && e.pointerId !== pointerId) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    if (phase === "pending") {
+      if (Math.abs(dx) > classifyAt && Math.abs(dx) > Math.abs(dy)) {
+        phase = "horizontal";
+        if (e.cancelable) e.preventDefault();
+      } else if (Math.abs(dy) > classifyAt && Math.abs(dy) >= Math.abs(dx)) {
+        phase = "cancelled";
+      }
+    } else if (phase === "horizontal") {
+      if (e.cancelable) e.preventDefault();
+    }
+  };
+
+  const onUp = (e: PointerEvent) => {
+    if (pointerId !== null && e.pointerId !== pointerId) return;
+    const wasHorizontal = phase === "horizontal";
+    phase = "idle";
+    pointerId = null;
+    if (!wasHorizontal) return;
+    const dx = e.clientX - startX;
+    const elapsed = e.timeStamp - startTime;
+    if (elapsed > maxDuration) return;
+    if (Math.abs(dx) < threshold) return;
+    if (dx < 0) options.onSwipeLeft();
+    else options.onSwipeRight();
+  };
+
+  const onCancel = (e: PointerEvent) => {
+    if (pointerId !== null && e.pointerId !== pointerId) return;
+    phase = "cancelled";
+    pointerId = null;
+  };
+
+  el.addEventListener("pointerdown", onDown);
+  el.addEventListener("pointermove", onMove);
+  el.addEventListener("pointerup", onUp);
+  el.addEventListener("pointercancel", onCancel);
+
+  return () => {
+    el.removeEventListener("pointerdown", onDown);
+    el.removeEventListener("pointermove", onMove);
+    el.removeEventListener("pointerup", onUp);
+    el.removeEventListener("pointercancel", onCancel);
+  };
+}
+
+/**
+ * React wrapper around `attachPointerSwipe`. Mounts the gesture
+ * listeners on `ref.current` when present.
+ */
+export function usePointerSwipe(
+  ref: RefObject<HTMLElement | null>,
+  options: PointerSwipeOptions,
+): void {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    return attachPointerSwipe(el, options);
+  }, [ref, options]);
+}

--- a/packages/frontend/src/hooks/use-pointer-swipe.ts
+++ b/packages/frontend/src/hooks/use-pointer-swipe.ts
@@ -50,6 +50,13 @@ export function attachPointerSwipe(
   let pointerId: number | null = null;
 
   const onDown = (e: PointerEvent) => {
+    // Ignore additional pointerdowns while we're tracking another
+    // pointer. Without this, a second finger landing mid-swipe would
+    // overwrite the first finger's start coordinates and pointerId,
+    // turning the in-flight gesture into nonsense. `pointerId` is
+    // cleared on pointerup / pointercancel, so a fresh gesture
+    // starts cleanly after either path.
+    if (pointerId !== null) return;
     phase = "pending";
     startX = e.clientX;
     startY = e.clientY;

--- a/packages/frontend/tests/hooks/use-pointer-swipe.test.ts
+++ b/packages/frontend/tests/hooks/use-pointer-swipe.test.ts
@@ -1,0 +1,229 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { attachPointerSwipe } from "../../src/hooks/use-pointer-swipe.ts";
+
+/**
+ * `attachPointerSwipe` is the pure-DOM core of the `usePointerSwipe`
+ * React hook. We test it directly against a fake element so we can
+ * skip JSDOM and React entirely — the frontend test runner is
+ * `node:test`, not Vitest, and `.tsx` files are stubbed to no-op by
+ * the resolve hook. Mirrors the pattern used by `shape-picker.test.ts`
+ * (extract pure logic, test that, leave the JSX/UI for Playwright).
+ */
+
+type Handler = (e: unknown) => void;
+
+interface FakeElement {
+  addEventListener(type: string, fn: Handler): void;
+  removeEventListener(type: string, fn: Handler): void;
+  setPointerCapture(): void;
+  __handlers: Map<string, Set<Handler>>;
+  __fire(type: string, event: PointerLikeEvent): void;
+}
+
+interface PointerLikeEvent {
+  pointerId: number;
+  clientX: number;
+  clientY: number;
+  timeStamp: number;
+  cancelable?: boolean;
+  preventDefault?: () => void;
+}
+
+function makeFakeEl(): FakeElement {
+  const handlers = new Map<string, Set<Handler>>();
+  return {
+    __handlers: handlers,
+    addEventListener(type, fn) {
+      let set = handlers.get(type);
+      if (!set) {
+        set = new Set();
+        handlers.set(type, set);
+      }
+      set.add(fn);
+    },
+    removeEventListener(type, fn) {
+      handlers.get(type)?.delete(fn);
+    },
+    setPointerCapture() {
+      // no-op
+    },
+    __fire(type, event) {
+      const set = handlers.get(type);
+      if (!set) return;
+      // Coerce to PointerEvent shape; the attach helper only reads a
+      // handful of fields, and the cast keeps the test types honest.
+      for (const fn of set) fn(event);
+    },
+  };
+}
+
+function ev(
+  type: "down" | "move" | "up" | "cancel",
+  x: number,
+  y: number,
+  timeStamp: number,
+): PointerLikeEvent {
+  const preventDefault = () => {};
+  return {
+    pointerId: 1,
+    clientX: x,
+    clientY: y,
+    timeStamp,
+    cancelable: true,
+    preventDefault,
+  };
+}
+
+test("attachPointerSwipe — left swipe past threshold fires onSwipeLeft", () => {
+  const el = makeFakeEl();
+  let left = 0;
+  let right = 0;
+  const cleanup = attachPointerSwipe(el as unknown as HTMLElement, {
+    onSwipeLeft: () => left++,
+    onSwipeRight: () => right++,
+  });
+
+  el.__fire("pointerdown", ev("down", 200, 100, 0));
+  el.__fire("pointermove", ev("move", 120, 100, 50)); // dx = -80, locks horizontal
+  el.__fire("pointerup", ev("up", 120, 100, 100));
+
+  assert.equal(left, 1);
+  assert.equal(right, 0);
+  cleanup();
+});
+
+test("attachPointerSwipe — right swipe past threshold fires onSwipeRight", () => {
+  const el = makeFakeEl();
+  let left = 0;
+  let right = 0;
+  const cleanup = attachPointerSwipe(el as unknown as HTMLElement, {
+    onSwipeLeft: () => left++,
+    onSwipeRight: () => right++,
+  });
+
+  el.__fire("pointerdown", ev("down", 100, 100, 0));
+  el.__fire("pointermove", ev("move", 200, 100, 50));
+  el.__fire("pointerup", ev("up", 200, 100, 100));
+
+  assert.equal(left, 0);
+  assert.equal(right, 1);
+  cleanup();
+});
+
+test("attachPointerSwipe — vertical movement cancels classification", () => {
+  const el = makeFakeEl();
+  let fired = 0;
+  const cleanup = attachPointerSwipe(el as unknown as HTMLElement, {
+    onSwipeLeft: () => fired++,
+    onSwipeRight: () => fired++,
+  });
+
+  el.__fire("pointerdown", ev("down", 100, 100, 0));
+  el.__fire("pointermove", ev("move", 105, 200, 50)); // |dy|=100 >> |dx|=5
+  el.__fire("pointerup", ev("up", 200, 100, 100));    // dx now large but already cancelled
+
+  assert.equal(fired, 0);
+  cleanup();
+});
+
+test("attachPointerSwipe — horizontal travel below threshold does not fire", () => {
+  const el = makeFakeEl();
+  let fired = 0;
+  const cleanup = attachPointerSwipe(el as unknown as HTMLElement, {
+    onSwipeLeft: () => fired++,
+    onSwipeRight: () => fired++,
+  });
+
+  el.__fire("pointerdown", ev("down", 100, 100, 0));
+  el.__fire("pointermove", ev("move", 130, 100, 50)); // dx=30 → locks horizontal
+  el.__fire("pointerup", ev("up", 130, 100, 100));    // |dx|=30 < default 50px threshold
+
+  assert.equal(fired, 0);
+  cleanup();
+});
+
+test("attachPointerSwipe — gesture over maxDurationMs is ignored", () => {
+  const el = makeFakeEl();
+  let left = 0;
+  const cleanup = attachPointerSwipe(el as unknown as HTMLElement, {
+    onSwipeLeft: () => left++,
+    onSwipeRight: () => {},
+    maxDurationMs: 600,
+  });
+
+  el.__fire("pointerdown", ev("down", 200, 100, 0));
+  el.__fire("pointermove", ev("move", 120, 100, 100));
+  el.__fire("pointerup", ev("up", 120, 100, 1000)); // elapsed 1000 > 600
+
+  assert.equal(left, 0);
+  cleanup();
+});
+
+test("attachPointerSwipe — pointercancel mid-gesture aborts", () => {
+  const el = makeFakeEl();
+  let left = 0;
+  const cleanup = attachPointerSwipe(el as unknown as HTMLElement, {
+    onSwipeLeft: () => left++,
+    onSwipeRight: () => {},
+  });
+
+  el.__fire("pointerdown", ev("down", 200, 100, 0));
+  el.__fire("pointermove", ev("move", 120, 100, 50));
+  el.__fire("pointercancel", ev("cancel", 120, 100, 60));
+  el.__fire("pointerup", ev("up", 120, 100, 100));
+
+  assert.equal(left, 0);
+  cleanup();
+});
+
+test("attachPointerSwipe — cleanup removes listeners", () => {
+  const el = makeFakeEl();
+  let fired = 0;
+  const cleanup = attachPointerSwipe(el as unknown as HTMLElement, {
+    onSwipeLeft: () => fired++,
+    onSwipeRight: () => fired++,
+  });
+
+  cleanup();
+  // Both downs and ups should now be no-ops; firing should not throw or
+  // invoke the callbacks.
+  el.__fire("pointerdown", ev("down", 200, 100, 0));
+  el.__fire("pointermove", ev("move", 120, 100, 50));
+  el.__fire("pointerup", ev("up", 120, 100, 100));
+
+  assert.equal(fired, 0);
+  // Listener sets should be empty after cleanup.
+  for (const set of el.__handlers.values()) {
+    assert.equal(set.size, 0);
+  }
+});
+
+test("attachPointerSwipe — events from a different pointerId are ignored mid-gesture", () => {
+  const el = makeFakeEl();
+  let fired = 0;
+  const cleanup = attachPointerSwipe(el as unknown as HTMLElement, {
+    onSwipeLeft: () => fired++,
+    onSwipeRight: () => fired++,
+  });
+
+  // First pointer starts a horizontal gesture.
+  el.__fire("pointerdown", ev("down", 200, 100, 0));
+  el.__fire("pointermove", ev("move", 120, 100, 50));
+  // A different pointer's up should NOT close out the gesture.
+  el.__fire("pointerup", {
+    pointerId: 99,
+    clientX: 50,
+    clientY: 100,
+    timeStamp: 100,
+    cancelable: true,
+    preventDefault: () => {},
+  });
+  assert.equal(fired, 0, "second pointer must not close the first's gesture");
+
+  // The real pointer's up should still fire.
+  el.__fire("pointerup", ev("up", 120, 100, 110));
+  assert.equal(fired, 1);
+
+  cleanup();
+});

--- a/packages/frontend/tests/hooks/use-pointer-swipe.test.ts
+++ b/packages/frontend/tests/hooks/use-pointer-swipe.test.ts
@@ -227,3 +227,59 @@ test("attachPointerSwipe — events from a different pointerId are ignored mid-g
 
   cleanup();
 });
+
+test("attachPointerSwipe — second pointerdown mid-gesture is ignored", () => {
+  // Without the active-pointer guard in onDown, a second finger
+  // landing mid-swipe would overwrite startX/startY/pointerId and
+  // the first finger's gesture would silently turn into the second
+  // finger's half-formed gesture on release.
+  const el = makeFakeEl();
+  let left = 0;
+  const cleanup = attachPointerSwipe(el as unknown as HTMLElement, {
+    onSwipeLeft: () => left++,
+    onSwipeRight: () => {},
+  });
+
+  el.__fire("pointerdown", ev("down", 200, 100, 0));
+  // Second pointer lands mid-gesture — must be ignored and must NOT
+  // reset the tracked start coordinates. If the guard regresses, the
+  // start would jump to (50, 100) and the pointer-1 move/up would no
+  // longer compute a left-swipe.
+  el.__fire("pointerdown", {
+    pointerId: 2,
+    clientX: 50,
+    clientY: 100,
+    timeStamp: 30,
+    cancelable: true,
+    preventDefault: () => {},
+  });
+  el.__fire("pointermove", ev("move", 120, 100, 50)); // pointer 1, dx = -80
+  el.__fire("pointerup", ev("up", 120, 100, 100));
+
+  assert.equal(left, 1);
+  cleanup();
+});
+
+test("attachPointerSwipe — a fresh pointerdown is accepted after pointercancel", () => {
+  // pointercancel must leave the hook ready for the next gesture.
+  // Without this, a single browser-cancelled swipe would dead-lock
+  // the element until the user navigates away.
+  const el = makeFakeEl();
+  let left = 0;
+  const cleanup = attachPointerSwipe(el as unknown as HTMLElement, {
+    onSwipeLeft: () => left++,
+    onSwipeRight: () => {},
+  });
+
+  el.__fire("pointerdown", ev("down", 200, 100, 0));
+  el.__fire("pointermove", ev("move", 120, 100, 50));
+  el.__fire("pointercancel", ev("cancel", 120, 100, 60));
+
+  // New gesture — must be accepted, not swallowed by leftover state.
+  el.__fire("pointerdown", ev("down", 300, 100, 200));
+  el.__fire("pointermove", ev("move", 220, 100, 250));
+  el.__fire("pointerup", ev("up", 220, 100, 300));
+
+  assert.equal(left, 1);
+  cleanup();
+});


### PR DESCRIPTION
## Summary

- Adds a dedicated read-only `MobileSlidesView` shell — thin header (back / title / Present), full-width slide canvas, footer indicator, and left/right swipe nav — mounted by `SlidesLayout` when `useIsMobile()` is true.
- Editor module is intentionally not mounted on mobile, so read-only is enforced by construction rather than by a feature flag. `SlideRenderer` is reused directly the same way `view/present/presenter.ts` does.
- Adds a `usePointerSwipe` / `attachPointerSwipe` pair; the pure-DOM core is unit-tested against a fake element (the frontend test runner is `node:test` and stubs `.tsx`, so the React wrapper itself is covered only by manual smoke).
- Design doc: [`docs/design/slides/slides-mobile-view.md`](docs/design/slides/slides-mobile-view.md). Implementation lessons (plan deviations) captured in [`docs/tasks/active/20260517-slides-mobile-view-lessons.md`](docs/tasks/active/20260517-slides-mobile-view-lessons.md).

## Test plan

- [x] `pnpm verify:fast` green (792 tests)
- [x] `pnpm verify:self` green (sheets/docs/slides/frontend/backend/cli builds + entropy)
- [x] Manual smoke: mobile emulation at 360, 390, 430 viewport widths — header / canvas / footer layout, swipe navigation, Present button (fullscreen API + iOS overlay fallback), back nav
- [x] Manual smoke: cross-breakpoint resize at the 768px boundary swaps the two layouts cleanly without losing the Yorkie attachment or remounting `DocumentProvider`
- [x] Manual smoke: desktop editor at ≥768px is byte-for-byte identical to main (no regression to the existing slide editor path)

## Known limitations

- Visual baseline scenario for the mobile chrome is deferred — the visual harness has no Yorkie wiring and `MobileSlidesView` is tightly coupled to `useDocument`. Detail in the lessons file.
- iOS edge-anchored swipe-back gestures cannot be intercepted (system constraint); footer arrow buttons are the documented fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile-optimized read-only slides viewer with swipe gesture navigation for devices under 768px.
  * Enabled presentation mode on mobile devices.
  * Mobile UI includes header navigation, footer controls, and intuitive touch gestures.

* **Documentation**
  * Added implementation specifications and design guidelines for mobile slides experience.

* **Tests**
  * Added gesture detection and navigation test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->