### PR TITLE
Forward slides editor scale to docs text-box click math

### DIFF
--- a/docs/tasks/active/20260517-slides-textbox-click-scale-lessons.md
+++ b/docs/tasks/active/20260517-slides-textbox-click-scale-lessons.md
@@ -1,0 +1,55 @@
+# Lessons — Slides text-box click scale bug
+
+## Where to look when a click in a Canvas-based editor "lands far from
+## where the user clicked"
+
+The first instinct is to look at the hit-test math (`findPositionAtPixel`),
+but in practice the regression is almost always at a **layer boundary**
+where one side reasons in host pixels and the other in logical pixels.
+For Canvas-rendered surfaces, the candidates are:
+
+1. The shim that converts pointer coords (`getScaleFactor`,
+   `getCanvasOffsetTop`, `container.getBoundingClientRect`) into
+   layout-local coords.
+2. The render-side scale (`ctx.scale(dpr * scale, ...)`) — but this
+   only affects drawing, not clicks.
+3. The container's CSS transform (`transform: scale(...)`).
+
+The hit-test code itself (`findPositionAtPixel`) is straightforward —
+if `localX` and `run.x` are in the same coordinate space, alignment
+already "just works" via `applyAlignment` mutating `run.x` directly.
+
+User symptom: caret jumps to offset 0 on click. Symptom is most visible
+on **center/right-aligned** text because the rendered glyphs sit far
+from the layout origin, so an undersized `localX` drops into the
+`localX < firstRun.x` branch and snaps to line start.
+
+## Tests at scale=1 won't catch scale-propagation bugs
+
+`packages/slides/test/view/editor/text-box-editor.test.ts` ran all
+scenarios at `hostWidth: 1920` (= slide width), which makes
+`scale = 1` and silently dodges the entire class of bug. **Any shim
+that takes a `scale` should be exercised at scale ≠ 1 in tests.**
+
+## jsdom rAF flush timing
+
+The docs text-box's `requestRender` uses `requestAnimationFrame`. jsdom
+polyfills rAF via setTimeout, but `setTimeout(0)` is sometimes too tight
+to flush a render cycle plus the cursor-blink scheduling that runs
+after `cursor.moveTo`. Use `setTimeout(16)` (one frame) for assertions
+that depend on a callback firing from inside `renderNow`.
+
+**Why:** the docs paint pipeline batches via `requestAnimationFrame`,
+and `cursor.moveTo` re-arms the blink interval before the paint
+deduper releases — both go through the same scheduler.
+**How to apply:** any test that mounts a docs/slides editor in jsdom
+and asserts on cursor-position callbacks should await ~16 ms (one
+frame), not 0 ms, after dispatching the input event.
+
+## Workspace dist must be rebuilt for cross-package typecheck
+
+`packages/slides/tsconfig.json` consumes `@wafflebase/docs` types from
+the package's published `dist/*.d.ts`. The vite test alias points to
+source for runtime but TypeScript still reads dist. Adding a new field
+to `TextBoxEditorOptions` requires `pnpm --filter @wafflebase/docs build`
+before `pnpm verify:fast` will succeed on the slides typecheck step.

--- a/docs/tasks/active/20260517-slides-textbox-click-scale-todo.md
+++ b/docs/tasks/active/20260517-slides-textbox-click-scale-todo.md
@@ -1,0 +1,46 @@
+# Slides text-box click position wrong at scale ≠ 1
+
+## Problem
+
+Clicking inside a slides text-box places the caret at the wrong position
+when the editor is rendered at any scale other than 1 (i.e. essentially
+every real session, since `scale = hostWidth / SLIDE_WIDTH`). The
+symptom is especially obvious on center / right aligned paragraphs:
+clicking on visually rendered text makes the caret jump to offset 0 of
+the block.
+
+## Root Cause
+
+`packages/docs/src/view/text-box-editor.ts` mounts the docs `TextEditor`
+with `getScaleFactor = () => 1`. The slides text-box container is
+sized in **host pixels** (`frame.w * scale`) but the layout is computed
+in **logical pixels** (`contentWidth = frame.w`).
+`TextEditor.getPositionFromMouse` does `x = (clientX - rect.left) / s`,
+so with `s = 1` the click coords come out in host pixels and are
+compared against logical-pixel `run.x` values that include the
+alignment offset. Clicks on the visible text land left of `firstRun.x`
+→ snap to `offset 0`.
+
+`findPositionAtPixel` itself handles alignment correctly — the bug is
+strictly in the coord-space conversion at the shim boundary.
+
+## Plan
+
+- [x] Reproduce with a failing unit test
+- [x] Add `scale` to `TextBoxEditorOptions`, plumb through to the
+      `TextEditor` `getScaleFactor` shim
+- [x] Update `mountSlidesTextBox` to forward `opts.scale`
+- [x] Add scale != 1 case to slides text-box-editor test
+- [x] `pnpm verify:fast` green
+- [x] Commit
+
+## Notes
+
+- The shim already accounts for HiDPI via `dpr` (which is
+  `browser_dpr * scale`); that path only affects the canvas bitmap,
+  not the pointer math.
+- `getCanvasOffsetTop` returns `-Theme.pageGap` (pure logical pixels),
+  so once `getScaleFactor` returns the real scale, the y-axis math
+  works out automatically: `(clientY - rect.top - (-pageGap)) / scale`
+  = logical y + pageGap, which is what `paginatedPixelToPosition`
+  expects for the shim's single page at pageIndex 0.

--- a/docs/tasks/active/20260517-slides-textbox-click-scale-todo.md
+++ b/docs/tasks/active/20260517-slides-textbox-click-scale-todo.md
@@ -39,8 +39,30 @@ strictly in the coord-space conversion at the shim boundary.
 - The shim already accounts for HiDPI via `dpr` (which is
   `browser_dpr * scale`); that path only affects the canvas bitmap,
   not the pointer math.
-- `getCanvasOffsetTop` returns `-Theme.pageGap` (pure logical pixels),
+- ~~`getCanvasOffsetTop` returns `-Theme.pageGap` (pure logical pixels),
   so once `getScaleFactor` returns the real scale, the y-axis math
-  works out automatically: `(clientY - rect.top - (-pageGap)) / scale`
-  = logical y + pageGap, which is what `paginatedPixelToPosition`
-  expects for the shim's single page at pageIndex 0.
+  works out automatically~~ **Wrong** — see follow-up below.
+
+## Follow-up: Y-axis sibling of the same bug
+
+User report after the first fix landed: x lands correctly but y is
+still off; clicking paragraph N puts the caret in paragraph N+1 at
+scale ≠ 1.
+
+Root cause: `TextEditor.getPositionFromMouse` computes
+`(clientY - rect.top - canvasOffsetTop) / scale`. The `clientY -
+rect.top` term is in HOST pixels, so `canvasOffsetTop` has to be in
+host pixels too — but the shim returned the raw logical `-Theme.pageGap`.
+At scale ≠ 1 every click y picked up an extra
+`(1 - scale) * pageGap / scale` logical pixels of bias. At
+scale = 0.5 that's an extra 40 px, enough to skip ~2 paragraphs.
+
+Fix: `getCanvasOffsetTop: () => -Theme.pageGap * scale`. At scale = 1
+this is a no-op (matching the prior behaviour), so the docs full-doc
+factory and the existing slides-text-box smoke tests are unaffected.
+
+Regression test added: `y-axis: a click on a specific paragraph lands
+in that paragraph at scale != 1` in
+`packages/slides/test/view/editor/text-box-click-scale.test.ts` —
+4 paragraphs, click at host y = 15 at scale = 0.5 must land in `p2`;
+pre-fix it lands in `p3`.

--- a/packages/docs/src/view/text-box-editor.ts
+++ b/packages/docs/src/view/text-box-editor.ts
@@ -394,9 +394,13 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
   //     logical-pixel space as `run.x`. Slides passes the live zoom
   //     here; full-document docs callers pass 1 (their container's CSS
   //     size already matches contentWidth).
-  //   - getCanvasOffsetTop: -Theme.pageGap so pointer math compensates
-  //     for getPageYOffset(0) === Theme.pageGap, landing localY = 0 at
-  //     the canvas top edge.
+  //   - getCanvasOffsetTop: -Theme.pageGap * scale. TextEditor computes
+  //     `(clientY - rect.top - canvasOffsetTop) / scale`, so the offset
+  //     lives in HOST pixels — using a raw logical pageGap inflates the
+  //     y by an extra `(1 - scale) * pageGap / scale` per click. With
+  //     the scale factor, clicking the canvas top resolves to logical
+  //     `pageGap` (= page-0 top in paginatedPixelToPosition's coord
+  //     space) at any zoom.
   const textEditor = new TextEditor(
     container,
     doc,
@@ -407,7 +411,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
     () => measurer,
     () => contentWidth,
     () => scale,
-    () => -Theme.pageGap,
+    () => -Theme.pageGap * scale,
     requestRender,
     () => docStore.snapshot(),
     () => {

--- a/packages/docs/src/view/text-box-editor.ts
+++ b/packages/docs/src/view/text-box-editor.ts
@@ -95,6 +95,17 @@ export interface TextBoxEditorOptions {
   dpr?: number;
 
   /**
+   * Host-pixels-per-logical-pixel for the surrounding viewport. Slides
+   * sizes the text-box container in host pixels (`frame * scale`) but
+   * the layout is computed in logical pixels (`contentWidth`); the
+   * editor's pointer math divides `(clientX - rect.left)` by this value
+   * so click coords land in the same coordinate space as `run.x` (which
+   * includes alignment offsets). When the container's CSS size already
+   * matches `contentWidth` / `contentHeight`, omit this (defaults to 1).
+   */
+  scale?: number;
+
+  /**
    * Called when the user presses Cmd/Ctrl+K inside the text-box. The
    * host typically opens a link popover anchored near the caret. The
    * shim wires this through to the underlying `TextEditor`'s
@@ -241,6 +252,7 @@ function buildShimPaginatedLayout(
 export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI {
   const { container, canvas, contentWidth, contentHeight } = opts;
   const dpr = opts.dpr ?? 1;
+  const scale = opts.scale ?? 1;
 
   // Seed an in-memory store with the supplied blocks. Empty input gets
   // a single empty paragraph so cursor placement and the very first
@@ -377,7 +389,11 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
   // `initialize` constructs, except every page-aware getter is replaced
   // with a shim:
   //   - getCanvasWidth: contentWidth (so pageX = 0 in pagination math)
-  //   - getScaleFactor: 1 (slides handles scale via CSS transform)
+  //   - getScaleFactor: opts.scale (host pixels per logical pixel) so
+  //     `(clientX - rect.left) / s` converts clicks back into the same
+  //     logical-pixel space as `run.x`. Slides passes the live zoom
+  //     here; full-document docs callers pass 1 (their container's CSS
+  //     size already matches contentWidth).
   //   - getCanvasOffsetTop: -Theme.pageGap so pointer math compensates
   //     for getPageYOffset(0) === Theme.pageGap, landing localY = 0 at
   //     the canvas top edge.
@@ -390,7 +406,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
     () => paginatedLayout,
     () => measurer,
     () => contentWidth,
-    () => 1,
+    () => scale,
     () => -Theme.pageGap,
     requestRender,
     () => docStore.snapshot(),

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1028,6 +1028,13 @@ class SlidesEditorImpl implements SlidesEditor {
     const { x, y } = this.clientToLogical(e.clientX, e.clientY);
     const hit = topmostUnderPoint(slide, x, y);
     if (hit === null) return;
+    // The text-box editor's container lives inside the overlay, so a
+    // dblclick *inside* the active editor bubbles up here. Re-entering
+    // edit mode on the same element would commit + remount the
+    // text-box, resetting the docs cursor to offset 0 and wiping the
+    // word selection the inner TextEditor's second mousedown just
+    // made. Bail out and let the inner editor own the dblclick.
+    if (hit === this.editingElementId) return;
     const element = slide.elements.find((el) => el.id === hit);
     if (!element || element.type !== 'text') return;
     e.preventDefault();

--- a/packages/slides/src/view/editor/text-box-editor.ts
+++ b/packages/slides/src/view/editor/text-box-editor.ts
@@ -171,6 +171,13 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
     contentWidth: frame.w,
     contentHeight: frame.h,
     dpr: dpr * scale,
+    // The container CSS size is `frame * scale` host pixels but
+    // `contentWidth/Height` are in logical pixels — pass `scale` so the
+    // docs editor's pointer math divides clicks back into the logical
+    // coord space `run.x` lives in. Without this, clicks at scale != 1
+    // land at offset 0 (especially visible with center/right alignment
+    // because `localX < firstRun.x` snaps to the start of the line).
+    scale,
     onCommit: handleCommit,
     onCancel: handleCancel,
     onLinkRequest,

--- a/packages/slides/test/view/editor/text-box-click-scale.test.ts
+++ b/packages/slides/test/view/editor/text-box-click-scale.test.ts
@@ -124,9 +124,10 @@ describe('mountSlidesTextBox click positioning at scale != 1', () => {
     // Long left-aligned line so click-x and offset-N are distinguishable
     // with vs. without the fix. Text is 20 chars × 8 px = 160 logical wide;
     // visible (at scale 0.5) at host x ∈ [0, 80]. A click at host x = 40
-    // (≈midpoint of visible text) maps to logical x = 80 → ~offset 10.
-    // With the bug, logical x = 40 → ~offset 5 — so the assertion
-    // `offset > 7` cleanly fails pre-fix and passes post-fix.
+    // (≈midpoint of visible text) maps to logical x = 80 → offset 10
+    // post-fix; with the bug, logical x = 40 → offset 5. The post-fix
+    // assertion below is `toBe(10)`, which is far enough from 5 to be
+    // a clean pre-fix failure.
     const SCALE = 0.5;
     const FRAME = { x: 0, y: 0, w: 400, h: 100, rotation: 0 };
 

--- a/packages/slides/test/view/editor/text-box-click-scale.test.ts
+++ b/packages/slides/test/view/editor/text-box-click-scale.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import type { Block } from '@wafflebase/docs';
+import { mountSlidesTextBox } from '../../../src/view/editor/text-box-editor';
+
+/**
+ * Regression: clicks inside a slides text-box landed at offset 0 of the
+ * block whenever the editor was rendered at a scale ≠ 1 (i.e. every
+ * real session — `scale = hostWidth / SLIDE_WIDTH`). The bug was
+ * especially visible on right- and center-aligned paragraphs because
+ * the visible glyphs sit far from the layout origin, so the (un-scaled)
+ * click x dropped into the `localX < firstRun.x` branch of
+ * `findPositionAtPixel` and snapped to the start of the line.
+ *
+ * The fix wires `opts.scale` through `initializeTextBox` to the docs
+ * `TextEditor`'s `getScaleFactor` shim. Without it, the docs editor
+ * divides `(clientX - rect.left)` by `1` instead of `scale`, mixing
+ * host and logical coordinates.
+ */
+function flushRaf(): Promise<void> {
+  // Drain rAF/microtask queues that the docs text-box editor uses for
+  // paint scheduling. jsdom polyfills rAF via setTimeout, so a few
+  // sequential macrotask flushes are enough.
+  return new Promise((resolve) => setTimeout(resolve, 16));
+}
+
+function rightAlignedBlock(text: string): Block {
+  return {
+    id: 'b1',
+    type: 'paragraph',
+    inlines: [{ text, style: {} }],
+    style: { alignment: 'right' },
+  } as Block;
+}
+
+function mockBoundingRect(el: HTMLElement, width: number, height: number): void {
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    left: 0,
+    top: 0,
+    right: width,
+    bottom: height,
+    width,
+    height,
+    x: 0,
+    y: 0,
+    toJSON: (): string => '',
+  } as DOMRect);
+}
+
+describe('mountSlidesTextBox click positioning at scale != 1', () => {
+  let overlay: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    overlay = document.createElement('div');
+    overlay.style.position = 'absolute';
+    document.body.appendChild(overlay);
+  });
+
+  it('right-aligned text: a click on the visible glyphs lands inside the text (not offset 0)', async () => {
+    const SCALE = 0.5;
+    const FRAME = { x: 0, y: 0, w: 400, h: 100, rotation: 0 };
+
+    let lastCursor: { blockId: string; offset: number } | null = null;
+    const tb = mountSlidesTextBox({
+      overlay,
+      frame: FRAME,
+      scale: SCALE,
+      blocks: [rightAlignedBlock('XXXXXXXX')],
+      onCommit: (): void => {},
+      onCancel: (): void => {},
+    });
+    tb.onCursorMove((pos): void => {
+      lastCursor = { blockId: pos.blockId, offset: pos.offset };
+    });
+    tb.focus();
+    await flushRaf();
+
+    // Container is sized in host pixels (frame * scale). The docs editor
+    // computes `(clientX - rect.left) / scale` to recover logical x.
+    mockBoundingRect(tb.container, FRAME.w * SCALE, FRAME.h * SCALE);
+
+    // FakeCanvas measureText returns text.length * 8 logical px, so
+    // right-aligned "XXXXXXXX" (width = 64) sits at logical x ∈ [336, 400].
+    // In host pixels (scale=0.5), the visible text spans x ∈ [168, 200].
+    // A click at host x=195 should map to logical x=390 → near end of text.
+    // Without the fix, host x=195 → logical x=195 → < firstRun.x=336 →
+    // snaps to offset 0.
+    tb.container.dispatchEvent(
+      new MouseEvent('mousedown', {
+        clientX: 195,
+        clientY: 25,
+        button: 0,
+        bubbles: true,
+      }),
+    );
+    tb.container.dispatchEvent(
+      new MouseEvent('mouseup', {
+        clientX: 195,
+        clientY: 25,
+        button: 0,
+        bubbles: true,
+      }),
+    );
+
+    await flushRaf();
+    await flushRaf();
+
+    expect(lastCursor).not.toBeNull();
+    // Bug repro: offset would be 0. Fixed: offset is near 8 (end of text).
+    expect(lastCursor!.offset).toBeGreaterThan(0);
+
+    tb.detach();
+  });
+
+  it('left-aligned text: a click on the visible glyphs hits the correct offset at scale != 1', async () => {
+    // Long left-aligned line so click-x and offset-N are distinguishable
+    // with vs. without the fix. Text is 20 chars × 8 px = 160 logical wide;
+    // visible (at scale 0.5) at host x ∈ [0, 80]. A click at host x = 40
+    // (≈midpoint of visible text) maps to logical x = 80 → ~offset 10.
+    // With the bug, logical x = 40 → ~offset 5 — so the assertion
+    // `offset > 7` cleanly fails pre-fix and passes post-fix.
+    const SCALE = 0.5;
+    const FRAME = { x: 0, y: 0, w: 400, h: 100, rotation: 0 };
+
+    let lastCursor: { blockId: string; offset: number } | null = null;
+    const tb = mountSlidesTextBox({
+      overlay,
+      frame: FRAME,
+      scale: SCALE,
+      blocks: [
+        {
+          id: 'b1',
+          type: 'paragraph',
+          inlines: [{ text: 'A'.repeat(20), style: {} }],
+          style: {},
+        } as Block,
+      ],
+      onCommit: (): void => {},
+      onCancel: (): void => {},
+    });
+    tb.onCursorMove((pos): void => {
+      lastCursor = { blockId: pos.blockId, offset: pos.offset };
+    });
+    tb.focus();
+    await flushRaf();
+
+    mockBoundingRect(tb.container, FRAME.w * SCALE, FRAME.h * SCALE);
+
+    tb.container.dispatchEvent(
+      new MouseEvent('mousedown', {
+        clientX: 40,
+        clientY: 25,
+        button: 0,
+        bubbles: true,
+      }),
+    );
+
+    await flushRaf();
+    await flushRaf();
+
+    expect(lastCursor).not.toBeNull();
+    expect(lastCursor!.offset).toBeGreaterThan(7);
+
+    tb.detach();
+  });
+});

--- a/packages/slides/test/view/editor/text-box-click-scale.test.ts
+++ b/packages/slides/test/view/editor/text-box-click-scale.test.ts
@@ -19,9 +19,10 @@ import { mountSlidesTextBox } from '../../../src/view/editor/text-box-editor';
  * host and logical coordinates.
  */
 function flushRaf(): Promise<void> {
-  // Drain rAF/microtask queues that the docs text-box editor uses for
-  // paint scheduling. jsdom polyfills rAF via setTimeout, so a few
-  // sequential macrotask flushes are enough.
+  // Wait one frame so the docs text-box editor's rAF-scheduled
+  // renderNow (and the cursor-blink restart that piggybacks on it)
+  // actually fires. jsdom polyfills rAF via setTimeout; `setTimeout(0)`
+  // is too tight to drain both.
   return new Promise((resolve) => setTimeout(resolve, 16));
 }
 
@@ -108,8 +109,13 @@ describe('mountSlidesTextBox click positioning at scale != 1', () => {
     await flushRaf();
 
     expect(lastCursor).not.toBeNull();
-    // Bug repro: offset would be 0. Fixed: offset is near 8 (end of text).
-    expect(lastCursor!.offset).toBeGreaterThan(0);
+    // Pre-fix: offset == 0 (snap to line start because logical click x
+    // fell before firstRun.x). Post-fix: logical x = 195/0.5 = 390;
+    // right-aligned "XXXXXXXX" runs from logical 336 to 400, so the
+    // localRunX = 54 sits ~6 px before the 7th boundary at 56 — snap
+    // to offset 7. A tight equality catches scale-direction inversions
+    // (e.g. `1/scale`) which would push the offset elsewhere.
+    expect(lastCursor!.offset).toBe(7);
 
     tb.detach();
   });
@@ -161,7 +167,10 @@ describe('mountSlidesTextBox click positioning at scale != 1', () => {
     await flushRaf();
 
     expect(lastCursor).not.toBeNull();
-    expect(lastCursor!.offset).toBeGreaterThan(7);
+    // Pre-fix: logical x ≈ 40 → offset ≈ 5 (mid-text wrong position).
+    // Post-fix: logical x ≈ 80 → offset === 10. Equality catches
+    // scale-direction inversions and partial-scale-propagation regressions.
+    expect(lastCursor!.offset).toBe(10);
 
     tb.detach();
   });

--- a/packages/slides/test/view/editor/text-box-click-scale.test.ts
+++ b/packages/slides/test/view/editor/text-box-click-scale.test.ts
@@ -175,4 +175,61 @@ describe('mountSlidesTextBox click positioning at scale != 1', () => {
 
     tb.detach();
   });
+
+  it('y-axis: a click on a specific paragraph lands in that paragraph at scale != 1', async () => {
+    // Y-axis sibling of the x-axis bug: TextEditor's pointer math does
+    // `(clientY - rect.top - canvasOffsetTop) / scale`. The shim hands
+    // back `canvasOffsetTop = -Theme.pageGap` (logical pixels) where
+    // host pixels are required, so every click y is inflated by an
+    // extra `(1 - scale) * pageGap / scale` logical pixels — at
+    // scale = 0.5 that's an extra 40 px, enough to skip 2-3 paragraphs
+    // and route the caret to the wrong block. User-visible symptom:
+    // clicking paragraph 2 lands the caret in paragraph 3.
+    const SCALE = 0.5;
+    const FRAME = { x: 0, y: 0, w: 400, h: 400, rotation: 0 };
+
+    let lastCursor: { blockId: string; offset: number } | null = null;
+    const tb = mountSlidesTextBox({
+      overlay,
+      frame: FRAME,
+      scale: SCALE,
+      blocks: [
+        { id: 'p1', type: 'paragraph', inlines: [{ text: 'first', style: {} }], style: {} },
+        { id: 'p2', type: 'paragraph', inlines: [{ text: 'second', style: {} }], style: {} },
+        { id: 'p3', type: 'paragraph', inlines: [{ text: 'third', style: {} }], style: {} },
+        { id: 'p4', type: 'paragraph', inlines: [{ text: 'fourth', style: {} }], style: {} },
+      ] as Block[],
+      onCommit: (): void => {},
+      onCancel: (): void => {},
+    });
+    tb.onCursorMove((pos): void => {
+      lastCursor = { blockId: pos.blockId, offset: pos.offset };
+    });
+    tb.focus();
+    await flushRaf();
+
+    mockBoundingRect(tb.container, FRAME.w * SCALE, FRAME.h * SCALE);
+
+    // Click at host y = 15. Post-fix logical y = 30 → middle of p2.
+    // Pre-fix logical y = (15 + 40) / 0.5 = 110 — far past p4 — but the
+    // paginated wrapper clamps "past last line on page" to the nearest
+    // line, which empirically lands on p3 (one paragraph too far). The
+    // user-visible symptom matches: clicking p2 puts the caret in p3.
+    tb.container.dispatchEvent(
+      new MouseEvent('mousedown', {
+        clientX: 10,
+        clientY: 15,
+        button: 0,
+        bubbles: true,
+      }),
+    );
+
+    await flushRaf();
+    await flushRaf();
+
+    expect(lastCursor).not.toBeNull();
+    expect(lastCursor!.blockId).toBe('p2');
+
+    tb.detach();
+  });
 });

--- a/packages/slides/test/view/editor/text-box-editor.test.ts
+++ b/packages/slides/test/view/editor/text-box-editor.test.ts
@@ -171,6 +171,36 @@ describe('slides text-box editor wiring', () => {
     expect(current()!.isEditing()).toBe(true);
   });
 
+  it('double-click inside an already-editing text element does NOT remount', () => {
+    // Regression: dblclick inside an edited text-box was bubbling to the
+    // slides overlay listener, which called enterEditMode on the same
+    // element. enterEditMode short-circuits "already editing" via
+    // exitEditMode('commit') → mountTextBox again, which resets the
+    // docs cursor to offset 0 and wipes any word selection the inner
+    // TextEditor just made on the second mousedown. The slides editor
+    // should ignore dblclicks whose hit-target IS the editing element
+    // and let the docs TextEditor own word selection.
+    const { canvas, overlay, store } = makeFixture();
+    addTextElement(store);
+    let mountCount = 0;
+    const inner = makeMockMount();
+    const mount = (opts: MountSlidesTextBoxOptions): SlidesTextBoxEditor => {
+      mountCount++;
+      return inner.mount(opts);
+    };
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: mount,
+    });
+    dispatchDblClick(canvas, 200, 200);
+    expect(mountCount).toBe(1);
+    // Dispatch a second dblclick at the same point. The hit-target is
+    // still the editing element — slides editor must NOT remount.
+    dispatchDblClick(canvas, 220, 200);
+    expect(mountCount).toBe(1);
+  });
+
   it('double-click on a non-text element does not enter edit mode', () => {
     const { canvas, overlay, store } = makeFixture();
     const slideId = store.read().slides[0].id;


### PR DESCRIPTION
## Summary

- Slides text-box containers are sized in host pixels (`frame * scale`) but the text layout is computed in logical pixels (`contentWidth = frame.w`). The docs `TextEditor.getPositionFromMouse` divides click x by `getScaleFactor()` to recover logical coords, but `initializeTextBox` hard-coded that getter to `() => 1` — so at any scale ≠ 1 (every real session, since `scale = hostWidth / SLIDE_WIDTH`) clicks stayed in host pixels and were compared against `run.x` values in logical pixels (which include the alignment offset from `applyAlignment`). The mismatch dropped clicks into the `localX < firstRun.x` branch of `findPositionAtPixel`, snapping the caret to offset 0 — especially obvious on center- and right-aligned paragraphs whose runs sit far from the layout origin.
- Add a `scale?: number` option to `TextBoxEditorOptions` (defaults to 1 → no change for the full-document docs editor), wire it into the `TextEditor`'s `getScaleFactor` shim, and forward `opts.scale` from `mountSlidesTextBox`.
- Add a regression test that mounts the real `mountSlidesTextBox` at `scale=0.5` and verifies clicks on visually rendered glyphs (right- and left-aligned) hit exact post-snap offsets — failing pre-fix on both, passing post-fix.

## Test plan

- [x] `pnpm verify:fast` green
- [x] New unit test fails without the fix, passes with it (verified by toggling `() => scale` back to `() => 1`)
- [x] Existing slides text-box wiring tests untouched
- [ ] Manual smoke: enter edit mode on a right-aligned text box in `pnpm dev`, click visible glyphs, caret lands at clicked character (not start of block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for specifying editor scale so clicks map correctly when zoom ≠ 1.

* **Bug Fixes**
  * Fixed caret placement when clicking in slide text boxes at non-default zoom levels (x and y axis corrections).

* **Tests**
  * Added regression tests covering click-to-cursor mapping at scale ≠ 1 (left/right alignment and vertical navigation).

* **Documentation**
  * Added troubleshooting and testing guidance for text-box click/scale regressions, including debugging tips and frame-timing advice.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->