### PR TITLE
Add design note: local caret anchoring (issue #237)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -46,6 +46,7 @@ Word processor engine — rich text, tables, pagination, collaboration.
 | [docs-comments.md](docs/docs-comments.md)                                        | Docs comments — text-range threads, CRDT-stable posRange anchors, orphan preservation, shared frontend module |
 | [docs-font-controls.md](docs/docs-font-controls.md)                              | Docs font controls — curated family picker (14 fonts), Google-Docs-style size input, line spacing, clear formatting, shared text-formatting components |
 | [docs-pending-inline-style.md](docs/docs-pending-inline-style.md)                | Pending inline style at a collapsed caret — stored marks for toolbar toggles, IME-aware, view-local            |
+| [docs-local-caret-anchoring.md](docs/docs-local-caret-anchoring.md)              | Local caret anchoring — Yorkie Tree-anchored caret/selection, resolves to DocPosition at render time (issue #237) |
 
 ## Slides
 

--- a/docs/design/docs/docs-local-caret-anchoring.md
+++ b/docs/design/docs/docs-local-caret-anchoring.md
@@ -79,7 +79,8 @@ The Yorkie-backed frontend integration should own the anchored representation:
 ```ts
 type AnchoredDocPosition = {
   region: 'body' | 'header' | 'footer';
-  yorkiePosition: unknown;
+  yorkiePosition: TreePos;
+  lineAffinity?: 'forward' | 'backward';
 };
 
 type AnchoredDocRange = {
@@ -89,10 +90,19 @@ type AnchoredDocRange = {
 };
 ```
 
-The concrete `yorkiePosition` type should be selected from the Yorkie SDK Tree
-position APIs used by the collaboration layer. The important boundary is that
-Yorkie-specific state does not leak into the core docs model unless
-implementation proves that the boundary is too expensive or ambiguous.
+The concrete anchor is Yorkie's Tree position type. Convert a collapsed caret
+or range endpoint with `tree.indexRangeToPosRange([index, index])`, and resolve
+it with `tree.posRangeToIndexRange(posRange)`. A caret is a collapsed range, so
+`AnchoredDocRange` maps 1:1 to two endpoint anchors. Yorkie-specific state
+does not leak into the core docs model; `packages/docs` still receives only
+resolved `DocPosition` values.
+
+Headers, body, and footers all live in the same `root.content` Tree as sibling
+top-level containers. Header and footer blocks are wrapped by top-level
+`type: 'header' | 'footer'` nodes, while body blocks are direct top-level
+block nodes. `indexRangeToPosRange` therefore handles all three regions
+uniformly. The `region` tag is retained only so fallback stays region-local
+when the anchor target is deleted.
 
 ### Data Flow
 
@@ -108,6 +118,10 @@ Remote document change arrives
   -> editor cursor and selection are updated
   -> render cache is invalidated and repaint happens
 ```
+
+The anchor is canonical. A resolved `DocPosition` is a cache derived from the
+current Tree snapshot and is invalidated on remote change. `pendingCursorPos`
+continues to store absolute offsets for undo/redo presence history for now.
 
 ### Converting DocPosition To An Anchor
 
@@ -147,9 +161,21 @@ After remote insert at start: Hi Hello wo|rld
 
 ### Remote Insert At The Same Boundary
 
-Use Yorkie Tree position semantics for tie-breaking. The implementation should
-document whether the local caret resolves before or after the concurrently
-inserted remote text at the same boundary.
+Use Yorkie Tree position semantics for tie-breaking, then apply the local
+affinity rule before fallback. The local caret uses right affinity for the
+user's own insert so typing advances the caret after inserted text. Remote
+inserts at the same boundary use left affinity so the local caret stays before
+the remotely inserted text, matching Google Docs behavior.
+
+```text
+User B anchor: He|llo
+User A inserts "y" at the same boundary
+Resolved for B: He|yllo
+```
+
+Tests must assert this same-boundary affinity. If the Yorkie SDK's
+`posRangeToIndexRange` semantics differ, the frontend wrapper normalizes the
+resolved `DocPosition` to this rule.
 
 ### Remote Delete Before Caret
 
@@ -168,11 +194,25 @@ If a remote edit splits a block before or at the local caret, the anchor should
 resolve into the correct resulting block according to Yorkie Tree semantics.
 The resolved `blockId` may change.
 
+Today's `splitBlock` implementation uses `delete + insert` rather than Yorkie's
+native `splitLevel=2`, so a Yorkie Tree position pointing into the deleted
+"after" portion cannot be preserved across the split. Resolution falls through
+the deterministic fallback ladder to the surviving original block clamped to
+its new end. Switching to native `splitLevel=2` is tracked in *Known
+Follow-Ups* and would let the anchor land in the new block at the logical
+offset without a fallback.
+
 ### Block Merge
 
 If a remote edit merges two blocks and the caret was in the removed block, the
 anchor should resolve into the surviving merged block at the corresponding
 logical offset.
+
+Today's `mergeBlock` also uses `delete + clone-insert`, so a Yorkie Tree
+position pointing into the deleted block cannot follow the merge through CRDT
+semantics. Resolution falls back to "end of the previous region block" via the
+fallback ladder; the logical offset within the merged content is not
+preserved. Native CRDT-preserving merge is tracked in *Known Follow-Ups*.
 
 ### Headers And Footers
 
@@ -204,25 +244,24 @@ land at the same position:
 5. First editable body block.
 
 Determinism matters because non-deterministic fallback would diverge selection
-state between clients during concurrent edits. The order above is illustrative
-and should be confirmed during implementation against the concrete Yorkie Tree
-semantics.
+state between clients during concurrent edits. Same-boundary affinity is
+applied first; if the Yorkie position no longer resolves to a usable block, the
+fallback ladder above is the canonical order. During implementation, verify
+and pin the exact SDK behavior for a `TreePos` whose node was deleted.
 
 ### IME Composition
 
 The local caret anchor is captured before composition starts and should remain
 tied to the composition start boundary until `compositionend`.
 
-The current editor updates the model during composition by replacing the
-previous composing text at `composition.startPosition`, then normalizes the
-final text again on `compositionend`. This design should anchor
-`composition.startPosition` itself, so a remote edit before the composing text
-does not leave composition commits targeting the old absolute offset.
-
-If a remote edit lands mid-composition, resolve the composition-start anchor
-before the next composition replacement or final commit. The visible composing
-text may shift on screen with the anchor, but it should not be committed at a
-stale absolute offset.
+The text editor anchors `composition.startPosition` itself: on
+`compositionstart` it notifies the collaboration layer with the current cursor
+position, which captures a Yorkie Tree anchor; on `compositionend` it clears
+the anchor. When a remote change arrives mid-composition, the anchor is
+resolved and the text editor's cached `composition.startPosition` is replaced
+with the new resolved `DocPosition` before the next composing-text replacement
+or final commit. The visible composing text may shift on screen with the
+anchor, but it is never committed at a stale absolute offset.
 
 ## Testing Strategy
 
@@ -230,6 +269,8 @@ stale absolute offset.
 
 - Convert a body `DocPosition` to an anchor and back with no document changes.
 - Remote insert before caret shifts the resolved offset right.
+- Remote insert at the same boundary resolves with left affinity for remote
+  text.
 - Remote insert after caret leaves the resolved offset unchanged.
 - Remote delete before caret shifts the resolved offset left.
 - Remote delete covering caret clamps to a valid nearby boundary.
@@ -238,6 +279,10 @@ stale absolute offset.
 - Header and footer anchors preserve region identity.
 - Table-cell anchors resolve through nested table paths.
 - Selection anchoring resolves both `anchor` and `focus` correctly.
+- The composition start anchor resolves to a shifted `DocPosition` after
+  remote text is inserted before it, and is cleared on `compositionend`.
+- The fallback ladder lands at the end of the previous region block when the
+  anchor's block is deleted.
 
 ### Integration Tests
 
@@ -245,8 +290,11 @@ stale absolute offset.
 - User B places the caret in the middle of a paragraph.
 - User A inserts text before User B's caret.
 - User B's caret remains attached to the same logical character boundary.
+- User B creates a non-collapsed selection in a paragraph, User A inserts and
+  deletes upstream text, and both `anchor` and `focus` resolve correctly.
 - Repeat the same scenario for a table-cell paragraph.
-- Repeat the same scenario for a header or footer paragraph.
+- Repeat the same scenario in a header paragraph.
+- Repeat the same scenario in a footer paragraph.
 
 ## Rollout Plan
 
@@ -267,6 +315,14 @@ behavior under concurrent remote edits. It is intentionally out of scope for
 this note so the first change stays focused on live caret and selection, but
 it is a natural follow-up that can reuse the same anchor representation.
 
+`splitBlock` and `mergeBlock` use `delete + insert` against the Yorkie Tree
+rather than the SDK's native `splitLevel`. As a result, an anchor whose target
+text is removed by a remote split or merge cannot follow through Yorkie CRDT
+semantics and falls through the deterministic fallback ladder. Moving these
+operations to native split/merge would let the anchor preserve its logical
+offset across remote structural edits; this requires also restoring undo/redo
+behavior previously documented as broken under `splitLevel=2`.
+
 ## Risks and Mitigation
 
 | Risk | Mitigation |
@@ -281,9 +337,6 @@ it is a natural follow-up that can reuse the same anchor representation.
 
 ## Open Questions
 
-- Which concrete Yorkie SDK Tree position type should local anchors store?
-- What affinity should the local caret use when remote text is inserted at the
-  exact same boundary?
 - Should remote peer cursor presence eventually use the same anchored
   representation, or remain resolved display data?
 - Should fallback after a deleted block prefer visual proximity, document order,

--- a/docs/design/docs/docs-local-caret-anchoring.md
+++ b/docs/design/docs/docs-local-caret-anchoring.md
@@ -1,0 +1,290 @@
+---
+title: docs-local-caret-anchoring
+target-version: 0.4.1
+---
+
+# Docs Local Caret Anchoring
+
+## Summary
+
+Keep the local caret and text selection attached to the user's intended
+logical text position when remote collaborators edit the same document.
+
+Today the docs editor stores the local caret as an absolute
+`{ blockId, offset }`. In collaborative mode, remote document changes invalidate
+the render cache, but they do not transform that local offset. If another user
+inserts text before the local caret in the same block, the caret keeps the same
+numeric offset and ends up pointing to a different character.
+
+The proposed fix is to anchor the local caret and selection to Yorkie Tree
+positions in the frontend collaboration layer, then resolve those anchors back
+to `{ blockId, offset }` only when the editor needs to render or operate on the
+current document snapshot.
+
+## Background
+
+Issue #237 reported that when User A inserts text before User B's caret within
+the same paragraph, User B's caret stays at the same absolute offset instead of
+shifting with the logical text position. The expected behavior matches editors
+like Google Docs and Notion: the caret should remain attached to the character
+boundary it originally represented.
+
+The maintainer confirmed this is a bug, not intentional behavior. The current
+local caret uses `DocPosition` from `packages/docs/src/model/types.ts`, while
+remote changes in `packages/frontend/src/app/docs/yorkie-doc-store.ts`
+invalidate render state without transforming the stored local offset.
+
+The maintainer also pointed to the preferred direction: anchor the caret to a
+Yorkie Tree position, then resolve back to `DocPosition` at render time. This
+is similar to the position-preserving approach needed for collaborative cursor
+state, but this note focuses on the local caret and selection first. Because
+the change touches headers, footers, tables, and selection paths, this note
+records the expected edge-case behavior before implementation.
+
+## Goals
+
+- Preserve local caret intent across remote inserts, deletes, splits, and
+  merges.
+- Preserve non-collapsed text selection intent by anchoring both range
+  endpoints.
+- Support body blocks, header blocks, footer blocks, and table-cell blocks.
+- Avoid ad-hoc offset transformation logic in response to remote operations.
+- Keep Yorkie-specific anchor state in the frontend collaboration layer where
+  possible.
+
+## Non-Goals
+
+- Redesigning `DocPosition` throughout `packages/docs`.
+- Changing the visual caret rendering behavior.
+- Replacing remote peer cursor presence in this change.
+- Implementing collaborative undo/redo.
+- Adding off-screen cursor indicators or new cursor UI.
+
+## Proposal Details
+
+### API Boundary
+
+`packages/docs` should continue to use resolved `DocPosition` values for
+editing, layout, hit-testing, and rendering:
+
+```ts
+interface DocPosition {
+  blockId: string;
+  offset: number;
+}
+```
+
+The Yorkie-backed frontend integration should own the anchored representation:
+
+```ts
+type AnchoredDocPosition = {
+  region: 'body' | 'header' | 'footer';
+  yorkiePosition: unknown;
+};
+
+type AnchoredDocRange = {
+  anchor: AnchoredDocPosition;
+  focus: AnchoredDocPosition;
+  tableCellRange?: TableCellRange;
+};
+```
+
+The concrete `yorkiePosition` type should be selected from the Yorkie SDK Tree
+position APIs used by the collaboration layer. The important boundary is that
+Yorkie-specific state does not leak into the core docs model unless
+implementation proves that the boundary is too expensive or ambiguous.
+
+### Data Flow
+
+```text
+Local cursor or selection changes
+  -> editor emits DocPosition / DocRange
+  -> YorkieDocStore converts endpoints to Yorkie Tree anchors
+  -> frontend stores the anchored local caret/range
+
+Remote document change arrives
+  -> YorkieDocStore refreshes the cached document
+  -> frontend resolves anchored caret/range to current DocPosition / DocRange
+  -> editor cursor and selection are updated
+  -> render cache is invalidated and repaint happens
+```
+
+### Converting DocPosition To An Anchor
+
+1. Resolve `blockId` to the current Yorkie Tree path using existing recursive
+   block path helpers.
+2. Preserve the resolved region: `body`, `header`, or `footer`.
+3. Walk the block's inline/text children to map the concatenated block offset
+   to a Yorkie Tree text boundary.
+4. Store the resulting Yorkie Tree position as the local anchor.
+
+For a non-collapsed selection, apply the same conversion to both `anchor` and
+`focus`.
+
+### Resolving An Anchor To DocPosition
+
+1. Resolve the Yorkie Tree position against the current Tree.
+2. Find the containing block node.
+3. Read the block id from the block node attributes.
+4. Convert the resolved text boundary back to a concatenated inline offset.
+5. Clamp to a valid nearby position if the exact boundary was deleted.
+
+The resolved position is then passed back into the existing editor APIs as
+`DocPosition`.
+
+## Edge Cases
+
+### Remote Insert Before Caret
+
+If a remote user inserts text before the local caret in the same block, the
+resolved `DocPosition` should shift right so the caret stays attached to the
+same logical text boundary.
+
+```text
+Before: Hello wo|rld
+After remote insert at start: Hi Hello wo|rld
+```
+
+### Remote Insert At The Same Boundary
+
+Use Yorkie Tree position semantics for tie-breaking. The implementation should
+document whether the local caret resolves before or after the concurrently
+inserted remote text at the same boundary.
+
+### Remote Delete Before Caret
+
+If remote text before the local caret is deleted, the resolved offset should
+shift left while preserving the same logical boundary.
+
+### Remote Delete Covering Caret
+
+If the text around the local caret is deleted, resolve to the nearest valid
+surviving boundary. Prefer the same block when it still exists. If the block was
+removed, move to the nearest valid neighboring editable block.
+
+### Block Split
+
+If a remote edit splits a block before or at the local caret, the anchor should
+resolve into the correct resulting block according to Yorkie Tree semantics.
+The resolved `blockId` may change.
+
+### Block Merge
+
+If a remote edit merges two blocks and the caret was in the removed block, the
+anchor should resolve into the surviving merged block at the corresponding
+logical offset.
+
+### Headers And Footers
+
+Anchors must preserve region identity. Header and footer blocks are not body
+blocks, even though they reuse the same `Block` and `Inline` model. Resolution
+should not search the wrong region if ids collide or if layout traversal order
+changes.
+
+### Tables
+
+Table-cell blocks are nested inside table nodes. Anchor conversion should use
+the existing recursive block path resolution so cell-internal text positions
+behave like body text positions.
+
+Text selection endpoints inside table cells should be anchored individually.
+`tableCellRange` remains selection metadata for table-cell range selection mode
+and should not replace endpoint anchoring for normal text selections.
+
+### Invalid Or Missing Anchor
+
+If an anchor cannot be resolved because its target content no longer exists,
+fall back along a deterministic ladder so two clients in the same remote race
+land at the same position:
+
+1. Same block, clamp to the nearest surviving offset using left affinity.
+2. End of the previous block in the same region.
+3. Start of the next block in the same region.
+4. First editable block in the same region (`body`, `header`, or `footer`).
+5. First editable body block.
+
+Determinism matters because non-deterministic fallback would diverge selection
+state between clients during concurrent edits. The order above is illustrative
+and should be confirmed during implementation against the concrete Yorkie Tree
+semantics.
+
+### IME Composition
+
+The local caret anchor is captured before composition starts and should remain
+tied to the composition start boundary until `compositionend`.
+
+The current editor updates the model during composition by replacing the
+previous composing text at `composition.startPosition`, then normalizes the
+final text again on `compositionend`. This design should anchor
+`composition.startPosition` itself, so a remote edit before the composing text
+does not leave composition commits targeting the old absolute offset.
+
+If a remote edit lands mid-composition, resolve the composition-start anchor
+before the next composition replacement or final commit. The visible composing
+text may shift on screen with the anchor, but it should not be committed at a
+stale absolute offset.
+
+## Testing Strategy
+
+### Unit Tests
+
+- Convert a body `DocPosition` to an anchor and back with no document changes.
+- Remote insert before caret shifts the resolved offset right.
+- Remote insert after caret leaves the resolved offset unchanged.
+- Remote delete before caret shifts the resolved offset left.
+- Remote delete covering caret clamps to a valid nearby boundary.
+- Remote block split resolves into the correct resulting block.
+- Remote block merge resolves into the surviving merged block.
+- Header and footer anchors preserve region identity.
+- Table-cell anchors resolve through nested table paths.
+- Selection anchoring resolves both `anchor` and `focus` correctly.
+
+### Integration Tests
+
+- Two clients open the same document.
+- User B places the caret in the middle of a paragraph.
+- User A inserts text before User B's caret.
+- User B's caret remains attached to the same logical character boundary.
+- Repeat the same scenario for a table-cell paragraph.
+- Repeat the same scenario for a header or footer paragraph.
+
+## Rollout Plan
+
+1. Add local anchor conversion helpers in the Yorkie-backed docs integration.
+2. Store a local caret anchor whenever the editor cursor changes.
+3. Resolve and restore the local caret after remote document changes.
+4. Extend the same mechanism to non-collapsed text selections.
+5. Add tests for body text first, then tables, headers, and footers.
+6. Revisit remote peer cursor presence separately if the same anchor strategy
+   should be shared later.
+
+## Known Follow-Ups
+
+The undo/redo cursor snapshot in
+`packages/frontend/src/app/docs/yorkie-doc-store.ts` (`pendingCursorPos`) is
+also stored as an absolute `{ blockId, offset }` and has the same drift
+behavior under concurrent remote edits. It is intentionally out of scope for
+this note so the first change stays focused on live caret and selection, but
+it is a natural follow-up that can reuse the same anchor representation.
+
+## Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Yorkie Tree position semantics for affinity or deleted nodes differ from this note's assumptions | Keep all anchor conversion in the frontend collaboration layer (one file) so the gap can be narrowed without touching the docs model |
+| Anchor lifecycle is unclear if the chosen Yorkie SDK type has attach/detach semantics | Centralize anchor ownership in the cursor/selection state owner and document whether the concrete anchor type needs cleanup |
+| Anchor resolution runs on every render and becomes a hot path | Resolve lazily: only after a remote change is observed, or before a cursor read; local edits update the resolved position in lockstep with the mutation |
+| Fallback for missing anchors diverges between clients | Use the deterministic ladder described under "Invalid Or Missing Anchor"; covered by integration tests with two clients in the same race |
+| Header, footer, or table-cell region becomes invalid (disabled, removed) | Region is captured at anchor creation; if the region is gone, resolution returns no result and the fallback ladder applies |
+| Region identity is lost when block ids are reused or layout traversal order changes | Region tag is part of the anchor itself, not inferred from block id lookup at resolve time |
+| Local edits race with anchor resolution and produce a transient wrong caret position | Resolve before the next render and before any command reads the caret; never expose a stale anchored value to commands |
+
+## Open Questions
+
+- Which concrete Yorkie SDK Tree position type should local anchors store?
+- What affinity should the local caret use when remote text is inserted at the
+  exact same boundary?
+- Should remote peer cursor presence eventually use the same anchored
+  representation, or remain resolved display data?
+- Should fallback after a deleted block prefer visual proximity, document order,
+  or region-local order?

--- a/docs/tasks/active/20260519-docs-local-caret-anchoring-lessons.md
+++ b/docs/tasks/active/20260519-docs-local-caret-anchoring-lessons.md
@@ -1,0 +1,29 @@
+# Docs Local Caret Anchoring Lessons
+
+## Lessons
+
+- Yorkie's `pathToIndex` plus `indexRangeToPosRange` can anchor collapsed
+  caret positions across body, header, footer, and table-cell text because all
+  regions share the same `root.content` Tree.
+- `pendingCursorPos` should remain separate from local caret anchors for now:
+  it is undo/redo presence history, while the anchor is the canonical remote
+  change cursor state.
+- Yorkie's `CRDTTreePos` is `(parentID, leftSiblingID)`, which already gives
+  the design's required "left affinity for remote inserts at the same
+  boundary" behavior. A normalization wrapper is unnecessary as long as
+  `tree.indexRangeToPosRange([n, n])` is used for the anchor.
+- `splitBlock` and `mergeBlock` currently use `delete + insert` against the
+  Yorkie Tree. Anchors that target deleted text cannot follow these
+  operations through CRDT semantics, so the fallback ladder takes over.
+  Switching to native `splitLevel=2` would preserve the logical offset but
+  requires also addressing the previously documented undo/redo regression.
+- The IME composition start position lives in `packages/docs`'s `TextEditor`.
+  Bridging it through the collaboration layer needed three small hooks:
+  `onCompositionStart`/`onCompositionEnd` callbacks for capture/clear, and
+  `updateCompositionStartPosition` for replay after a remote-resolved anchor.
+- Capturing the region's top-level block index in the anchor lets the
+  fallback ladder pick "end of the previous region block" / "start of the
+  next region block" deterministically when the anchored block is gone.
+- The frontend integration test script currently depends on `tsx`, which is
+  not available in this workspace even through `npx -y`; unit coverage and
+  TypeScript checks still validate the new anchor helpers locally.

--- a/docs/tasks/active/20260519-docs-local-caret-anchoring-todo.md
+++ b/docs/tasks/active/20260519-docs-local-caret-anchoring-todo.md
@@ -1,0 +1,32 @@
+# Docs Local Caret Anchoring
+
+## Goal
+
+Implement the local caret and text-selection anchoring design from
+`docs/design/docs/docs-local-caret-anchoring.md` in the Yorkie docs store.
+
+## Plan
+
+- [x] Read PR feedback, the design note, and the existing Yorkie docs store flow.
+- [x] Pin the design doc to the concrete Yorkie Tree position APIs and affinity rules.
+- [x] Add local caret/range anchor conversion and resolution in `YorkieDocStore`.
+- [x] Preserve current undo/redo cursor history behavior through `pendingCursorPos`.
+- [x] Add focused unit coverage for body/header/footer/table anchors.
+- [x] Add two-client integration coverage for caret and non-collapsed selection drift.
+- [x] Expand the fallback ladder to cover previous/next region block per design.
+- [x] Anchor `composition.startPosition` through the store so IME survives remote edits.
+- [x] Add missing unit tests: round-trip, insert-after, same-boundary affinity,
+      delete-before, delete-covering, split fallback, merge fallback,
+      composition resolve/clear, fallback ladder.
+- [x] Add header/footer two-client integration coverage.
+- [x] Update design doc: pin Yorkie APIs, affinity rule, data-flow invariant,
+      IME anchoring, fallback ladder, split/merge known limitations, open questions cleanup.
+- [x] Run targeted docs store tests and `pnpm verify:fast`.
+
+## Notes
+
+- Keep Yorkie-specific anchor state inside `packages/frontend`.
+- `pendingCursorPos` remains an absolute-offset history mechanism for now.
+- `splitBlock` / `mergeBlock` use `delete + insert` rather than Yorkie's native
+  `splitLevel=2`, so anchors that target deleted text fall through the
+  deterministic ladder. Native split/merge is tracked as a follow-up.

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -11,7 +11,7 @@ import { computeLayout, resolveInlineFont, type DocumentLayout, type LayoutCache
 import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getPageYOffset, getHeaderYStart, getFooterYStart, paginatedPixelToPosition, type PaginatedLayout } from './pagination.js';
 import { CanvasTextMeasurer } from './canvas-measurer.js';
 import type { TextMeasurer } from './measurer.js';
-import type { DocPosition, HeaderFooter } from '../model/types.js';
+import type { DocPosition, DocRange, HeaderFooter } from '../model/types.js';
 import { findMarkerAt, type CommentMarker, type HighlightRect } from './comment-markers.js';
 import { Ruler, RULER_SIZE } from './ruler/index.js';
 import { computeScaleFactor } from './scale.js';
@@ -105,6 +105,8 @@ export interface EditorAPI {
    * the cursor itself has not moved.
    */
   onCursorMove(cb: (pos: { blockId: string; offset: number }, selection?: { anchor: { blockId: string; offset: number }; focus: { blockId: string; offset: number }; tableCellRange?: { blockId: string; start: { rowIndex: number; colIndex: number }; end: { rowIndex: number; colIndex: number } } } | null) => void): () => void;
+  /** Restore local cursor and selection after collaborative anchor resolution. */
+  restoreLocalCursor(cursorPos: DocPosition | null, range?: DocRange | null): void;
   /** Get last-computed peer cursor pixel positions (for hover hit-testing) */
   getPeerCursorPixels(): Array<{ clientID: string; x: number; y: number; height: number }>;
   /** Get the block type at the cursor position */
@@ -2672,6 +2674,16 @@ export function initialize(
     },
     focus: () => textEditor?.focus(),
     validateCursorPosition,
+    restoreLocalCursor: (cursorPos, range) => {
+      if (cursorPos && doc.findBlock(cursorPos.blockId)) {
+        const block = doc.getBlock(cursorPos.blockId);
+        cursor.moveTo({
+          blockId: cursorPos.blockId,
+          offset: Math.min(cursorPos.offset, getBlockTextLength(block)),
+        });
+      }
+      selection.setRange(range ?? null);
+    },
     resetAfterDocumentReplace: () => {
       pending.clear();
       doc.refresh();

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -107,6 +107,19 @@ export interface EditorAPI {
   onCursorMove(cb: (pos: { blockId: string; offset: number }, selection?: { anchor: { blockId: string; offset: number }; focus: { blockId: string; offset: number }; tableCellRange?: { blockId: string; start: { rowIndex: number; colIndex: number }; end: { rowIndex: number; colIndex: number } } } | null) => void): () => void;
   /** Restore local cursor and selection after collaborative anchor resolution. */
   restoreLocalCursor(cursorPos: DocPosition | null, range?: DocRange | null): void;
+  /** Register a callback fired when an IME composition session starts. */
+  onCompositionStart(cb: (startPos: DocPosition) => void): void;
+  /** Register a callback fired when an IME composition session ends. */
+  onCompositionEnd(cb: () => void): void;
+  /**
+   * Update the cached IME composition start position. Called by the
+   * collaboration layer after a remote change has been resolved against
+   * the composition anchor so the next composing-text replacement targets
+   * the correct offset instead of a stale absolute one.
+   */
+  updateCompositionStartPosition(pos: DocPosition): void;
+  /** Whether an IME composition session is currently active. */
+  isComposing(): boolean;
   /** Get last-computed peer cursor pixel positions (for hover hit-testing) */
   getPeerCursorPixels(): Array<{ clientID: string; x: number; y: number; height: number }>;
   /** Get the block type at the cursor position */
@@ -2684,6 +2697,12 @@ export function initialize(
       }
       selection.setRange(range ?? null);
     },
+    onCompositionStart: (cb) => textEditor?.onCompositionStart(cb),
+    onCompositionEnd: (cb) => textEditor?.onCompositionEnd(cb),
+    updateCompositionStartPosition: (pos) => {
+      textEditor?.setCompositionStartPosition(pos);
+    },
+    isComposing: () => textEditor?.isComposing() ?? false,
     resetAfterDocumentReplace: () => {
       pending.clear();
       doc.refresh();

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -169,6 +169,12 @@ export class TextEditor {
   /** Callback invoked when edit context changes (body/header/footer). */
   private editContextChangeCallback?: (context: EditContext) => void;
 
+  /** Listeners notified when an IME composition session starts. */
+  private compositionStartListeners: Array<(startPos: DocPosition) => void> = [];
+
+  /** Listeners notified when an IME composition session ends. */
+  private compositionEndListeners: Array<() => void> = [];
+
   /**
    * Optional cursor-style target. When set, `setCanvasCursor` writes the
    * CSS cursor on this element directly. When unset, the editor falls
@@ -204,6 +210,28 @@ export class TextEditor {
 
   onEditContextChange(cb: (context: EditContext) => void): void {
     this.editContextChangeCallback = cb;
+  }
+
+  onCompositionStart(cb: (startPos: DocPosition) => void): void {
+    this.compositionStartListeners.push(cb);
+  }
+
+  onCompositionEnd(cb: () => void): void {
+    this.compositionEndListeners.push(cb);
+  }
+
+  /**
+   * Replace the cached composition start position. The collaboration layer
+   * calls this after a remote change so that subsequent composition input
+   * lands at the resolved (drift-corrected) offset.
+   */
+  setCompositionStartPosition(pos: DocPosition): void {
+    if (!this.composition.active) return;
+    this.composition.startPosition = { ...pos };
+  }
+
+  isComposing(): boolean {
+    return this.composition.active;
   }
 
   /**
@@ -361,11 +389,13 @@ export class TextEditor {
     this.ignoreInputUntilNextTick = false;
     this.saveSnapshot();
     this.deleteSelection();
+    const startPosition: DocPosition = { ...this.cursor.position };
     this.composition = {
       active: true,
-      startPosition: { ...this.cursor.position },
+      startPosition,
       currentLength: 0,
     };
+    for (const cb of this.compositionStartListeners) cb({ ...startPosition });
   };
 
   private handleCompositionEnd = (e: CompositionEvent): void => {
@@ -393,6 +423,7 @@ export class TextEditor {
 
     this.composition.active = false;
     this.composition.currentLength = 0;
+    for (const cb of this.compositionEndListeners) cb();
     this.requestRender();
 
     // Ignore ALL input events fired synchronously after compositionend.

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -353,7 +353,12 @@ export function DocsView({
     // refresh() updates the Doc's cached document from the store, then
     // render() repaints the canvas with the latest content.
     store.onRemoteChange = () => {
+      const resolvedLocalCursor = store.resolveAnchoredLocalCursor();
       editor.getDoc().refresh();
+      editor.restoreLocalCursor(
+        resolvedLocalCursor.cursor,
+        resolvedLocalCursor.selection,
+      );
       editor.validateCursorPosition();
       editor.render();
     };

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -362,6 +362,10 @@ export function DocsView({
       if (resolvedLocalCursor.compositionStart && editor.isComposing()) {
         editor.updateCompositionStartPosition(resolvedLocalCursor.compositionStart);
       }
+      store.publishResolvedLocalCursor({
+        cursor: resolvedLocalCursor.cursor,
+        selection: resolvedLocalCursor.selection,
+      });
       editor.validateCursorPosition();
       editor.render();
     };

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -359,9 +359,19 @@ export function DocsView({
         resolvedLocalCursor.cursor,
         resolvedLocalCursor.selection,
       );
+      if (resolvedLocalCursor.compositionStart && editor.isComposing()) {
+        editor.updateCompositionStartPosition(resolvedLocalCursor.compositionStart);
+      }
       editor.validateCursorPosition();
       editor.render();
     };
+
+    editor.onCompositionStart((startPos) => {
+      store.setCompositionStart(startPos);
+    });
+    editor.onCompositionEnd(() => {
+      store.setCompositionStart(null);
+    });
 
     const unsubPresence = doc.subscribe("others", () => {
       handlePresenceChange();

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -56,8 +56,11 @@ type AnchoredDocRange = {
 };
 
 // Enable with: localStorage.setItem('DOCS_DEBUG', '1')
-const isDebug = () =>
-  typeof localStorage !== 'undefined' && localStorage.getItem('DOCS_DEBUG') === '1';
+const isDebug = () => {
+  if (typeof localStorage === 'undefined') return false;
+  if (typeof localStorage.getItem !== 'function') return false;
+  return localStorage.getItem('DOCS_DEBUG') === '1';
+};
 
 /** Summarize a block's inline text for debug logging. */
 function describeBlock(block: Block): string {

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -497,6 +497,7 @@ export class YorkieDocStore implements DocStore {
   private pendingCursorPos: { blockId: string; offset: number } | null = null;
   private localCursorAnchor: AnchoredDocPosition | null = null;
   private localSelectionAnchor: AnchoredDocRange | null = null;
+  private compositionStartAnchor: AnchoredDocPosition | null = null;
   /** Undo stack depth after setDocument — users cannot undo past this point. */
   private undoFloor = 0;
 
@@ -1024,7 +1025,11 @@ export class YorkieDocStore implements DocStore {
     return { blockId: anchor.blockId, offset: 0 };
   }
 
-  resolveAnchoredLocalCursor(): { cursor: DocPosition | null; selection: DocRange | null } {
+  resolveAnchoredLocalCursor(): {
+    cursor: DocPosition | null;
+    selection: DocRange | null;
+    compositionStart: DocPosition | null;
+  } {
     const cursor = this.localCursorAnchor
       ? this.resolveAnchoredDocPosition(this.localCursorAnchor)
       : null;
@@ -1034,6 +1039,9 @@ export class YorkieDocStore implements DocStore {
           focus: this.resolveAnchoredDocPosition(this.localSelectionAnchor.focus),
           tableCellRange: this.localSelectionAnchor.tableCellRange,
         }
+      : null;
+    const compositionStart = this.compositionStartAnchor
+      ? this.resolveAnchoredDocPosition(this.compositionStartAnchor)
       : null;
 
     if (cursor || selection) {
@@ -1045,7 +1053,16 @@ export class YorkieDocStore implements DocStore {
       });
     }
 
-    return { cursor, selection };
+    return { cursor, selection, compositionStart };
+  }
+
+  /**
+   * Capture or clear the IME composition start anchor. Pass null on
+   * compositionend so subsequent remote changes do not resolve a stale
+   * composition anchor.
+   */
+  setCompositionStart(pos: DocPosition | null): void {
+    this.compositionStartAnchor = pos ? this.anchorDocPosition(pos, 'backward') : null;
   }
 
   /**

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -18,6 +18,8 @@ import type {
   TableCell,
   CellStyle,
   BorderStyle,
+  DocPosition,
+  DocRange,
 } from '@wafflebase/docs';
 import {
   resolvePageSetup,
@@ -33,6 +35,25 @@ import {
 } from '@wafflebase/docs';
 import type { YorkieDocsRoot } from '@/types/docs-document';
 import type { DocsPresence } from '@/types/users';
+
+type DocRegion = 'body' | 'header' | 'footer';
+type TreePosRange = ReturnType<YorkieDocsRoot['content']['indexRangeToPosRange']>;
+
+type AnchoredDocPosition = {
+  region: DocRegion;
+  blockId: string;
+  offset: number;
+  /** Index of the top-level region block that contained the caret at anchor time. */
+  regionTopIndex: number;
+  yorkiePosition: TreePosRange;
+  lineAffinity?: 'forward' | 'backward';
+};
+
+type AnchoredDocRange = {
+  anchor: AnchoredDocPosition;
+  focus: AnchoredDocPosition;
+  tableCellRange?: DocRange['tableCellRange'];
+};
 
 // Enable with: localStorage.setItem('DOCS_DEBUG', '1')
 const isDebug = () =>
@@ -474,6 +495,8 @@ export class YorkieDocStore implements DocStore {
   private cachedDoc: Document | null = null;
   private dirty = true;
   private pendingCursorPos: { blockId: string; offset: number } | null = null;
+  private localCursorAnchor: AnchoredDocPosition | null = null;
+  private localSelectionAnchor: AnchoredDocRange | null = null;
   /** Undo stack depth after setDocument — users cannot undo past this point. */
   private undoFloor = 0;
 
@@ -803,6 +826,226 @@ export class YorkieDocStore implements DocStore {
       .filter((c): c is { type: 'text'; value: string } => c.type === 'text')
       .reduce((sum, t) => sum + t.value.length, 0);
     return { inlineIndex: Math.max(0, lastIdx), charOffset: lastLen };
+  }
+
+  private blockTextLength(block: Block): number {
+    return block.inlines.reduce((sum, inline) => sum + inline.text.length, 0);
+  }
+
+  private anchorDocPosition(
+    pos: DocPosition,
+    lineAffinity: 'forward' | 'backward' = 'backward',
+  ): AnchoredDocPosition | null {
+    const root = this.doc.getRoot();
+    const tree = root.content;
+    if (!tree || typeof tree.getRootTreeNode !== 'function') return null;
+
+    const currentDoc = this.getDocument();
+    const { path: blockPath, region } = this.resolveBlockTreePath(pos.blockId, currentDoc);
+    const block = this.getBlockByRegion(currentDoc, blockPath, region);
+    const blockNode = this.getTreeBlockNode(tree.getRootTreeNode(), blockPath);
+    const clampedOffset = Math.max(0, Math.min(pos.offset, this.blockTextLength(block)));
+    const { inlineIndex, charOffset } = this.resolveBlockNodeOffset(blockNode, clampedOffset);
+    const index = tree.pathToIndex([...blockPath, inlineIndex, charOffset]);
+    const regionTopIndex = this.topLevelRegionIndex(currentDoc, region, pos.blockId);
+
+    return {
+      region,
+      blockId: pos.blockId,
+      offset: clampedOffset,
+      regionTopIndex,
+      yorkiePosition: tree.indexRangeToPosRange([index, index]),
+      lineAffinity,
+    };
+  }
+
+  private topLevelRegionIndex(
+    currentDoc: Document,
+    region: DocRegion,
+    blockId: string,
+  ): number {
+    const topBlocks = this.regionBlocksFor(currentDoc, region);
+    for (let i = 0; i < topBlocks.length; i++) {
+      if (topBlocks[i].id === blockId) return i;
+      if (topBlocks[i].type === 'table' && this.findBlockInTable(topBlocks[i], blockId)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private anchorDocRange(selection: DocRange | null | undefined): AnchoredDocRange | null {
+    if (!selection) return null;
+    const anchor = this.anchorDocPosition(selection.anchor, 'backward');
+    const focus = this.anchorDocPosition(selection.focus, 'backward');
+    if (!anchor || !focus) return null;
+    return {
+      anchor,
+      focus,
+      tableCellRange: selection.tableCellRange,
+    };
+  }
+
+  private treeNodeAtPath(treeRoot: TreeNode, path: number[]): TreeNode | undefined {
+    let node: TreeNode | undefined = treeRoot;
+    for (const idx of path) {
+      node = ((node as ElementNode | undefined)?.children ?? [])[idx];
+      if (!node) return undefined;
+    }
+    return node;
+  }
+
+  private findContainingBlockPath(treeRoot: TreeNode, path: number[]): number[] | null {
+    for (let len = path.length; len >= 0; len--) {
+      const candidate = path.slice(0, len);
+      const node = this.treeNodeAtPath(treeRoot, candidate);
+      if (node?.type !== 'block') continue;
+      const attrs = ((node as ElementNode).attributes ?? {}) as Record<string, string>;
+      if (attrs.id) return candidate;
+    }
+    return null;
+  }
+
+  private blockOffsetFromPath(blockNode: TreeNode, pathInBlock: number[]): number {
+    const el = blockNode as ElementNode;
+    const inlineChildren = (el.children ?? []).filter(
+      (c): c is ElementNode => c.type === 'inline',
+    );
+    const inlineIndex = Math.max(0, Math.min(pathInBlock[0] ?? 0, inlineChildren.length - 1));
+    const charOffset = Math.max(0, pathInBlock[1] ?? 0);
+    let offset = 0;
+    for (let i = 0; i < inlineIndex; i++) {
+      offset += (inlineChildren[i].children ?? [])
+        .filter((c): c is { type: 'text'; value: string } => c.type === 'text')
+        .reduce((sum, text) => sum + text.value.length, 0);
+    }
+    const inlineLength = (inlineChildren[inlineIndex]?.children ?? [])
+      .filter((c): c is { type: 'text'; value: string } => c.type === 'text')
+      .reduce((sum, text) => sum + text.value.length, 0);
+    return offset + Math.min(charOffset, inlineLength);
+  }
+
+  private resolveAnchoredDocPosition(anchor: AnchoredDocPosition): DocPosition {
+    const root = this.doc.getRoot();
+    const tree = root.content;
+    if (!tree || typeof tree.getRootTreeNode !== 'function') {
+      return { blockId: anchor.blockId, offset: anchor.offset };
+    }
+
+    try {
+      const [index] = tree.posRangeToIndexRange(anchor.yorkiePosition);
+      const path = tree.indexToPath(index);
+      const treeRoot = tree.getRootTreeNode();
+      const blockPath = this.findContainingBlockPath(treeRoot, path);
+      if (!blockPath) return this.fallbackAnchoredDocPosition(anchor);
+
+      const blockNode = this.getTreeBlockNode(treeRoot, blockPath);
+      const attrs = ((blockNode as ElementNode).attributes ?? {}) as Record<string, string>;
+      const blockId = attrs.id;
+      if (!blockId) return this.fallbackAnchoredDocPosition(anchor);
+      return {
+        blockId,
+        offset: this.blockOffsetFromPath(blockNode, path.slice(blockPath.length)),
+      };
+    } catch {
+      return this.fallbackAnchoredDocPosition(anchor);
+    }
+  }
+
+  private regionBlocksFor(currentDoc: Document, region: DocRegion): Block[] {
+    if (region === 'header') return currentDoc.header?.blocks ?? [];
+    if (region === 'footer') return currentDoc.footer?.blocks ?? [];
+    return currentDoc.blocks;
+  }
+
+  private firstEditableTopBlock(blocks: Block[]): Block | null {
+    for (const block of blocks) {
+      if (block.inlines.length > 0) return block;
+      if (block.type === 'table') return block;
+    }
+    return blocks[0] ?? null;
+  }
+
+  private endOfTopBlock(block: Block): DocPosition {
+    if (block.type === 'table' && block.tableData) {
+      const rows = block.tableData.rows;
+      const lastRow = rows[rows.length - 1];
+      const lastCell = lastRow?.cells[lastRow.cells.length - 1];
+      const lastInner = lastCell?.blocks[lastCell.blocks.length - 1];
+      if (lastInner) {
+        return { blockId: lastInner.id, offset: this.blockTextLength(lastInner) };
+      }
+    }
+    return { blockId: block.id, offset: this.blockTextLength(block) };
+  }
+
+  private startOfTopBlock(block: Block): DocPosition {
+    if (block.type === 'table' && block.tableData) {
+      const firstCell = block.tableData.rows[0]?.cells[0];
+      const firstInner = firstCell?.blocks[0];
+      if (firstInner) {
+        return { blockId: firstInner.id, offset: 0 };
+      }
+    }
+    return { blockId: block.id, offset: 0 };
+  }
+
+  private fallbackAnchoredDocPosition(anchor: AnchoredDocPosition): DocPosition {
+    const currentDoc = this.getDocument();
+    const sameBlock = this.getBlock(anchor.blockId);
+    if (sameBlock) {
+      return {
+        blockId: anchor.blockId,
+        offset: Math.min(anchor.offset, this.blockTextLength(sameBlock)),
+      };
+    }
+
+    const regionTop = this.regionBlocksFor(currentDoc, anchor.region);
+    if (anchor.regionTopIndex >= 0) {
+      const previousTop = regionTop[anchor.regionTopIndex - 1];
+      if (previousTop) {
+        return this.endOfTopBlock(previousTop);
+      }
+      const nextTop = regionTop[anchor.regionTopIndex];
+      if (nextTop) {
+        return this.startOfTopBlock(nextTop);
+      }
+    }
+
+    const regionFallback = this.firstEditableTopBlock(regionTop);
+    if (regionFallback) {
+      return this.startOfTopBlock(regionFallback);
+    }
+
+    const bodyFallback = this.firstEditableTopBlock(currentDoc.blocks);
+    if (bodyFallback) {
+      return this.startOfTopBlock(bodyFallback);
+    }
+    return { blockId: anchor.blockId, offset: 0 };
+  }
+
+  resolveAnchoredLocalCursor(): { cursor: DocPosition | null; selection: DocRange | null } {
+    const cursor = this.localCursorAnchor
+      ? this.resolveAnchoredDocPosition(this.localCursorAnchor)
+      : null;
+    const selection = this.localSelectionAnchor
+      ? {
+          anchor: this.resolveAnchoredDocPosition(this.localSelectionAnchor.anchor),
+          focus: this.resolveAnchoredDocPosition(this.localSelectionAnchor.focus),
+          tableCellRange: this.localSelectionAnchor.tableCellRange,
+        }
+      : null;
+
+    if (cursor || selection) {
+      this.doc.update((_, p) => {
+        p.set({
+          activeCursorPos: cursor ?? undefined,
+          activeSelection: selection ?? undefined,
+        } as Partial<DocsPresence>);
+      });
+    }
+
+    return { cursor, selection };
   }
 
   /**
@@ -2351,6 +2594,8 @@ export class YorkieDocStore implements DocStore {
       };
     } | null,
   ): void {
+    this.localCursorAnchor = pos ? this.anchorDocPosition(pos, 'backward') : null;
+    this.localSelectionAnchor = this.anchorDocRange(selection ?? null);
     this.doc.update((_, p) => {
       p.set({
         activeCursorPos: pos ?? undefined,

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -1028,6 +1028,12 @@ export class YorkieDocStore implements DocStore {
     return { blockId: anchor.blockId, offset: 0 };
   }
 
+  /**
+   * Pure read: resolve the locally anchored caret / selection /
+   * composition-start back to {@link DocPosition}. Does not touch
+   * presence. Call {@link publishResolvedLocalCursor} after pushing the
+   * resolved values into the editor when the broadcast is desired.
+   */
   resolveAnchoredLocalCursor(): {
     cursor: DocPosition | null;
     selection: DocRange | null;
@@ -1046,17 +1052,26 @@ export class YorkieDocStore implements DocStore {
     const compositionStart = this.compositionStartAnchor
       ? this.resolveAnchoredDocPosition(this.compositionStartAnchor)
       : null;
-
-    if (cursor || selection) {
-      this.doc.update((_, p) => {
-        p.set({
-          activeCursorPos: cursor ?? undefined,
-          activeSelection: selection ?? undefined,
-        } as Partial<DocsPresence>);
-      });
-    }
-
     return { cursor, selection, compositionStart };
+  }
+
+  /**
+   * Broadcast a previously resolved caret / selection to peers via
+   * Yorkie presence. Split out from {@link resolveAnchoredLocalCursor}
+   * so the resolve path stays a pure read and callers opt into the
+   * side effect explicitly.
+   */
+  publishResolvedLocalCursor(resolved: {
+    cursor: DocPosition | null;
+    selection: DocRange | null;
+  }): void {
+    if (!resolved.cursor && !resolved.selection) return;
+    this.doc.update((_, p) => {
+      p.set({
+        activeCursorPos: resolved.cursor ?? undefined,
+        activeSelection: resolved.selection ?? undefined,
+      } as Partial<DocsPresence>);
+    });
   }
 
   /**

--- a/packages/frontend/tests/app/docs/yorkie-doc-store-concurrent.integration.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store-concurrent.integration.ts
@@ -421,6 +421,124 @@ describe('YorkieDocStore concurrent inline styling', { skip: !shouldRun }, () =>
   });
 });
 
+describe('YorkieDocStore local caret anchoring', { skip: !shouldRun }, () => {
+  it('keeps User B caret anchored when User A inserts upstream text', async () => {
+    const block = makeBlock('HelloWorld');
+    const ctx = await createTwoUserDocs('caret-anchor-insert', [block]);
+    try {
+      ctx.storeB.updateCursorPos({ blockId: block.id, offset: 5 });
+
+      ctx.storeA.insertText(block.id, 0, 'Hey ');
+      await ctx.sync();
+
+      const resolved = ctx.storeB.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 9 });
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('keeps both User B selection endpoints anchored across upstream edits', async () => {
+    const block = makeBlock('HelloWorld');
+    const ctx = await createTwoUserDocs('selection-anchor-insert-delete', [block]);
+    try {
+      ctx.storeB.updateCursorPos(
+        { blockId: block.id, offset: 8 },
+        {
+          anchor: { blockId: block.id, offset: 2 },
+          focus: { blockId: block.id, offset: 8 },
+        },
+      );
+
+      ctx.storeA.insertText(block.id, 0, 'Hey ');
+      ctx.storeA.deleteText(block.id, 4, 1);
+      await ctx.sync();
+
+      const resolved = ctx.storeB.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.selection, {
+        anchor: { blockId: block.id, offset: 5 },
+        focus: { blockId: block.id, offset: 11 },
+        tableCellRange: undefined,
+      });
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('keeps table-cell selection endpoints anchored across upstream edits', async () => {
+    const tableBlock = createTableBlock(2, 2);
+    const cellBlock = tableBlock.tableData!.rows[0].cells[0].blocks[0];
+    cellBlock.inlines = [{ text: 'HelloWorld', style: {} }];
+
+    const ctx = await createTwoUserDocs('selection-anchor-table-cell', [tableBlock]);
+    try {
+      ctx.storeB.updateCursorPos(
+        { blockId: cellBlock.id, offset: 8 },
+        {
+          anchor: { blockId: cellBlock.id, offset: 2 },
+          focus: { blockId: cellBlock.id, offset: 8 },
+        },
+      );
+
+      ctx.storeA.insertText(cellBlock.id, 0, 'Hey ');
+      ctx.storeA.deleteText(cellBlock.id, 4, 1);
+      await ctx.sync();
+
+      const resolved = ctx.storeB.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.selection, {
+        anchor: { blockId: cellBlock.id, offset: 5 },
+        focus: { blockId: cellBlock.id, offset: 11 },
+        tableCellRange: undefined,
+      });
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('keeps a header caret anchored across upstream edits', async () => {
+    const bodyBlock = makeBlock('Body');
+    const headerBlock = makeBlock('HeaderText');
+    const ctx = await createTwoUserDocs(
+      'caret-anchor-header',
+      [bodyBlock],
+      { blocks: [headerBlock], marginFromEdge: 48 },
+    );
+    try {
+      ctx.storeB.updateCursorPos({ blockId: headerBlock.id, offset: 6 });
+
+      ctx.storeA.insertText(headerBlock.id, 0, 'Top ');
+      await ctx.sync();
+
+      const resolved = ctx.storeB.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: headerBlock.id, offset: 10 });
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('keeps a footer caret anchored across upstream edits', async () => {
+    const bodyBlock = makeBlock('Body');
+    const footerBlock = makeBlock('FooterText');
+    const ctx = await createTwoUserDocs(
+      'caret-anchor-footer',
+      [bodyBlock],
+      undefined,
+      { blocks: [footerBlock], marginFromEdge: 48 },
+    );
+    try {
+      ctx.storeB.updateCursorPos({ blockId: footerBlock.id, offset: 6 });
+
+      ctx.storeA.insertText(footerBlock.id, 0, 'Low ');
+      await ctx.sync();
+
+      const resolved = ctx.storeB.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: footerBlock.id, offset: 10 });
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Table cell concurrent editing
 // ---------------------------------------------------------------------------

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -1584,6 +1584,28 @@ describe('YorkieDocStore', () => {
       assert.equal(resolved.cursor!.blockId, first.id);
       assert.equal(resolved.cursor!.offset, 5);
     });
+
+    it('resolves the composition start anchor after upstream text shifts', () => {
+      const block = makeBlock('HelloWorld');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 5 });
+      store.setCompositionStart({ blockId: block.id, offset: 5 });
+
+      store.insertText(block.id, 0, 'Hey ');
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.compositionStart, { blockId: block.id, offset: 9 });
+    });
+
+    it('clears the composition anchor when composition ends', () => {
+      const block = makeBlock('HelloWorld');
+      store.setDocument({ blocks: [block] });
+      store.setCompositionStart({ blockId: block.id, offset: 4 });
+      store.setCompositionStart(null);
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.equal(resolved.compositionStart, null);
+    });
   });
 
   describe('setBlockType', () => {

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -1403,6 +1403,189 @@ describe('YorkieDocStore', () => {
     });
   });
 
+  describe('local caret anchoring', () => {
+    it('resolves a body caret after upstream text is inserted', () => {
+      const block = makeBlock('HelloWorld');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 5 });
+
+      store.insertText(block.id, 0, 'Hey ');
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 9 });
+    });
+
+    it('resolves a non-collapsed selection after upstream text is inserted', () => {
+      const block = makeBlock('HelloWorld');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos(
+        { blockId: block.id, offset: 8 },
+        {
+          anchor: { blockId: block.id, offset: 2 },
+          focus: { blockId: block.id, offset: 8 },
+        },
+      );
+
+      store.insertText(block.id, 0, 'Hey ');
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.selection, {
+        anchor: { blockId: block.id, offset: 6 },
+        focus: { blockId: block.id, offset: 12 },
+        tableCellRange: undefined,
+      });
+    });
+
+    it('resolves a header caret independently from body blocks', () => {
+      const headerBlock = makeBlock('HeaderText');
+      const bodyBlock = makeBlock('BodyText');
+      store.setDocument({
+        header: { blocks: [headerBlock], marginFromEdge: 48 },
+        blocks: [bodyBlock],
+      });
+      store.updateCursorPos({ blockId: headerBlock.id, offset: 6 });
+
+      store.insertText(headerBlock.id, 0, 'Top ');
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: headerBlock.id, offset: 10 });
+    });
+
+    it('resolves a footer caret independently from body blocks', () => {
+      const bodyBlock = makeBlock('BodyText');
+      const footerBlock = makeBlock('FooterText');
+      store.setDocument({
+        blocks: [bodyBlock],
+        footer: { blocks: [footerBlock], marginFromEdge: 48 },
+      });
+      store.updateCursorPos({ blockId: footerBlock.id, offset: 6 });
+
+      store.insertText(footerBlock.id, 0, 'Low ');
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: footerBlock.id, offset: 10 });
+    });
+
+    it('resolves a table-cell caret through nested tree paths', () => {
+      const { tableBlock, cellBlockId } = makeTableWithText();
+      store.setDocument({ blocks: [tableBlock] });
+      store.updateCursorPos({ blockId: cellBlockId, offset: 2 });
+
+      store.insertText(cellBlockId, 0, 'Yo ');
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: cellBlockId, offset: 5 });
+    });
+
+    it('round-trips a body DocPosition when nothing changes', () => {
+      const block = makeBlock('HelloWorld');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 4 });
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 4 });
+    });
+
+    it('leaves the resolved caret unchanged when text is inserted after it', () => {
+      const block = makeBlock('HelloWorld');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 5 });
+
+      store.insertText(block.id, 7, 'XYZ');
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 5 });
+    });
+
+    it('keeps the local caret before text inserted at the same boundary', () => {
+      const block = makeBlock('HelloWorld');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 5 });
+
+      // Simulate a remote insert exactly at the anchored boundary.
+      store.insertText(block.id, 5, 'X');
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 5 });
+    });
+
+    it('shifts the resolved caret left when upstream text is deleted', () => {
+      const block = makeBlock('HelloWorld');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 8 });
+
+      store.deleteText(block.id, 1, 3);
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 5 });
+    });
+
+    it('clamps the resolved caret when the surrounding text is deleted', () => {
+      const block = makeBlock('HelloWorld');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 5 });
+
+      store.deleteText(block.id, 2, 6);
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.equal(resolved.cursor!.blockId, block.id);
+      const remaining = store.getBlock(block.id)!;
+      const length = remaining.inlines.reduce((s, i) => s + i.text.length, 0);
+      assert.ok(
+        resolved.cursor!.offset >= 0 && resolved.cursor!.offset <= length,
+        `caret offset ${resolved.cursor!.offset} out of [0,${length}]`,
+      );
+    });
+
+    it('clamps to the surviving original block after a split deletes the anchored text', () => {
+      // splitBlock uses delete+insert (not native Yorkie splitLevel=2) so an
+      // anchor pointing into the deleted "after" portion no longer resolves
+      // through CRDT semantics. Fallback clamps to the end of the surviving
+      // original block, which keeps the caret visible without a crash.
+      const block = makeBlock('HelloWorld');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 7 });
+
+      const newBlockId = generateBlockId();
+      store.splitBlock(block.id, 5, newBlockId, 'paragraph');
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.equal(resolved.cursor!.blockId, block.id);
+      assert.equal(resolved.cursor!.offset, 5);
+    });
+
+    it('falls back into the surviving region block after a merge removes the anchored block', () => {
+      // mergeBlock also uses delete+insert, so an anchor inside the deleted
+      // block falls through the deterministic ladder to the previous region
+      // block's end. The logical offset is not preserved through the merge.
+      const first = makeBlock('Hello');
+      const second = makeBlock('World');
+      store.setDocument({ blocks: [first, second] });
+      store.updateCursorPos({ blockId: second.id, offset: 3 });
+
+      store.mergeBlock(first.id, second.id);
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.equal(resolved.cursor!.blockId, first.id);
+      const merged = store.getBlock(first.id)!;
+      const mergedLength = merged.inlines.reduce((s, i) => s + i.text.length, 0);
+      assert.equal(resolved.cursor!.offset, mergedLength);
+    });
+
+    it('falls back to the end of the previous region block when the anchor block is deleted', () => {
+      const first = makeBlock('Hello');
+      const second = makeBlock('World');
+      store.setDocument({ blocks: [first, second] });
+      store.updateCursorPos({ blockId: second.id, offset: 2 });
+
+      store.deleteBlock(second.id);
+
+      const resolved = store.resolveAnchoredLocalCursor();
+      assert.equal(resolved.cursor!.blockId, first.id);
+      assert.equal(resolved.cursor!.offset, 5);
+    });
+  });
+
   describe('setBlockType', () => {
     it('should change block type to heading', () => {
       const block = makeBlock('Hello');

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -1412,7 +1412,7 @@ describe('YorkieDocStore', () => {
       store.insertText(block.id, 0, 'Hey ');
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 9 });
+      expect(resolved.cursor).toEqual({ blockId: block.id, offset: 9 });
     });
 
     it('resolves a non-collapsed selection after upstream text is inserted', () => {
@@ -1429,7 +1429,7 @@ describe('YorkieDocStore', () => {
       store.insertText(block.id, 0, 'Hey ');
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.deepEqual(resolved.selection, {
+      expect(resolved.selection).toEqual({
         anchor: { blockId: block.id, offset: 6 },
         focus: { blockId: block.id, offset: 12 },
         tableCellRange: undefined,
@@ -1448,7 +1448,7 @@ describe('YorkieDocStore', () => {
       store.insertText(headerBlock.id, 0, 'Top ');
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.deepEqual(resolved.cursor, { blockId: headerBlock.id, offset: 10 });
+      expect(resolved.cursor).toEqual({ blockId: headerBlock.id, offset: 10 });
     });
 
     it('resolves a footer caret independently from body blocks', () => {
@@ -1463,7 +1463,7 @@ describe('YorkieDocStore', () => {
       store.insertText(footerBlock.id, 0, 'Low ');
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.deepEqual(resolved.cursor, { blockId: footerBlock.id, offset: 10 });
+      expect(resolved.cursor).toEqual({ blockId: footerBlock.id, offset: 10 });
     });
 
     it('resolves a table-cell caret through nested tree paths', () => {
@@ -1474,7 +1474,7 @@ describe('YorkieDocStore', () => {
       store.insertText(cellBlockId, 0, 'Yo ');
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.deepEqual(resolved.cursor, { blockId: cellBlockId, offset: 5 });
+      expect(resolved.cursor).toEqual({ blockId: cellBlockId, offset: 5 });
     });
 
     it('round-trips a body DocPosition when nothing changes', () => {
@@ -1483,7 +1483,7 @@ describe('YorkieDocStore', () => {
       store.updateCursorPos({ blockId: block.id, offset: 4 });
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 4 });
+      expect(resolved.cursor).toEqual({ blockId: block.id, offset: 4 });
     });
 
     it('leaves the resolved caret unchanged when text is inserted after it', () => {
@@ -1494,7 +1494,7 @@ describe('YorkieDocStore', () => {
       store.insertText(block.id, 7, 'XYZ');
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 5 });
+      expect(resolved.cursor).toEqual({ blockId: block.id, offset: 5 });
     });
 
     it('keeps the local caret before text inserted at the same boundary', () => {
@@ -1506,7 +1506,7 @@ describe('YorkieDocStore', () => {
       store.insertText(block.id, 5, 'X');
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 5 });
+      expect(resolved.cursor).toEqual({ blockId: block.id, offset: 5 });
     });
 
     it('shifts the resolved caret left when upstream text is deleted', () => {
@@ -1517,7 +1517,7 @@ describe('YorkieDocStore', () => {
       store.deleteText(block.id, 1, 3);
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.deepEqual(resolved.cursor, { blockId: block.id, offset: 5 });
+      expect(resolved.cursor).toEqual({ blockId: block.id, offset: 5 });
     });
 
     it('clamps the resolved caret when the surrounding text is deleted', () => {
@@ -1528,13 +1528,11 @@ describe('YorkieDocStore', () => {
       store.deleteText(block.id, 2, 6);
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.equal(resolved.cursor!.blockId, block.id);
+      expect(resolved.cursor!.blockId).toBe(block.id);
       const remaining = store.getBlock(block.id)!;
       const length = remaining.inlines.reduce((s, i) => s + i.text.length, 0);
-      assert.ok(
-        resolved.cursor!.offset >= 0 && resolved.cursor!.offset <= length,
-        `caret offset ${resolved.cursor!.offset} out of [0,${length}]`,
-      );
+      expect(resolved.cursor!.offset).toBeGreaterThanOrEqual(0);
+      expect(resolved.cursor!.offset).toBeLessThanOrEqual(length);
     });
 
     it('clamps to the surviving original block after a split deletes the anchored text', () => {
@@ -1550,8 +1548,8 @@ describe('YorkieDocStore', () => {
       store.splitBlock(block.id, 5, newBlockId, 'paragraph');
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.equal(resolved.cursor!.blockId, block.id);
-      assert.equal(resolved.cursor!.offset, 5);
+      expect(resolved.cursor!.blockId).toBe(block.id);
+      expect(resolved.cursor!.offset).toBe(5);
     });
 
     it('falls back into the surviving region block after a merge removes the anchored block', () => {
@@ -1566,10 +1564,10 @@ describe('YorkieDocStore', () => {
       store.mergeBlock(first.id, second.id);
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.equal(resolved.cursor!.blockId, first.id);
+      expect(resolved.cursor!.blockId).toBe(first.id);
       const merged = store.getBlock(first.id)!;
       const mergedLength = merged.inlines.reduce((s, i) => s + i.text.length, 0);
-      assert.equal(resolved.cursor!.offset, mergedLength);
+      expect(resolved.cursor!.offset).toBe(mergedLength);
     });
 
     it('falls back to the end of the previous region block when the anchor block is deleted', () => {
@@ -1581,8 +1579,8 @@ describe('YorkieDocStore', () => {
       store.deleteBlock(second.id);
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.equal(resolved.cursor!.blockId, first.id);
-      assert.equal(resolved.cursor!.offset, 5);
+      expect(resolved.cursor!.blockId).toBe(first.id);
+      expect(resolved.cursor!.offset).toBe(5);
     });
 
     it('resolves the composition start anchor after upstream text shifts', () => {
@@ -1594,7 +1592,7 @@ describe('YorkieDocStore', () => {
       store.insertText(block.id, 0, 'Hey ');
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.deepEqual(resolved.compositionStart, { blockId: block.id, offset: 9 });
+      expect(resolved.compositionStart).toEqual({ blockId: block.id, offset: 9 });
     });
 
     it('clears the composition anchor when composition ends', () => {
@@ -1604,7 +1602,7 @@ describe('YorkieDocStore', () => {
       store.setCompositionStart(null);
 
       const resolved = store.resolveAnchoredLocalCursor();
-      assert.equal(resolved.compositionStart, null);
+      expect(resolved.compositionStart).toBeNull();
     });
   });
 

--- a/packages/frontend/tests/helpers/two-user-docs-yorkie.ts
+++ b/packages/frontend/tests/helpers/two-user-docs-yorkie.ts
@@ -2,7 +2,7 @@ import yorkie from '@yorkie-js/sdk';
 import { YorkieDocStore } from '@/app/docs/yorkie-doc-store.ts';
 import type { YorkieDocsRoot } from '@/types/docs-document.ts';
 import { generateBlockId, DEFAULT_BLOCK_STYLE } from '@wafflebase/docs';
-import type { Block } from '@wafflebase/docs';
+import type { Block, HeaderFooter } from '@wafflebase/docs';
 
 type YorkieClient = {
   activate(): Promise<void>;
@@ -77,6 +77,8 @@ export interface TwoUserDocsContext {
 export async function createTwoUserDocs(
   testName: string,
   initialBlocks: Block[],
+  initialHeader?: HeaderFooter,
+  initialFooter?: HeaderFooter,
 ): Promise<TwoUserDocsContext> {
   const slug = testName.replace(/[^a-z0-9]+/gi, '-').toLowerCase();
   const docKey = `docs-concurrent-${slug}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -107,7 +109,11 @@ export async function createTwoUserDocs(
     });
 
     const storeA = new YorkieDocStore(docA as never);
-    storeA.setDocument({ blocks: initialBlocks });
+    storeA.setDocument({
+      blocks: initialBlocks,
+      header: initialHeader,
+      footer: initialFooter,
+    });
 
     // Mirror production document creation (see `initialDocsRoot`): the
     // comments map is created once at bootstrap so concurrent first-inserts


### PR DESCRIPTION
The local caret in the docs editor is stored as an absolute
`{ blockId, offset }`. When a remote peer edits the same block, the
render cache is invalidated but the local offset is not transformed, so
the caret ends up pointing at the wrong character (issue #237).

This PR lands both the design note and its implementation: local
cursor, non-collapsed selection endpoints, and the IME composition
start position are anchored to Yorkie Tree positions in the frontend
collaboration layer and resolved back to `DocPosition` only at render
time.

## Summary

- Design note `docs/design/docs/docs-local-caret-anchoring.md` pins the
  Yorkie API (`indexRangeToPosRange` / `posRangeToIndexRange`), makes
  the same-boundary affinity rule normative, documents the deterministic
  fallback ladder, and records `splitBlock` / `mergeBlock` as a known
  limitation (current `delete + insert` implementation cannot preserve
  `TreePos` through deleted content; native `splitLevel` is a
  follow-up).
- `YorkieDocStore` captures `AnchoredDocPosition` / `AnchoredDocRange`
  on cursor change, resolves both on every remote document change, and
  walks a five-step fallback (same block → previous region block end →
  next region block start → first editable region block → first
  editable body block) when the anchor's block was removed.
- `TextEditor` emits `onCompositionStart` / `onCompositionEnd`; the
  collaboration layer captures a composition anchor and pushes the
  drift-corrected start position back through
  `EditorAPI.updateCompositionStartPosition` so IME commits never land
  at a stale absolute offset.
- Yorkie-specific anchor state is kept inside `packages/frontend`;
  `packages/docs` still receives only resolved `DocPosition` values.

## Why

The maintainer confirmed in #237 that the absolute-offset drift is a
bug and pointed at anchoring through Yorkie Tree positions. The review
on this PR also asked for two doc updates that are now reflected in the
note: pin the concrete API surface and make the affinity rule
normative. The implementation lands here rather than in a follow-up
because the maintainer asked to keep design and implementation in the
same PR.

## Linked Issues

Fixes #237.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅

Local `pnpm verify:fast` runs green on each of the three commits in
this branch.

## Risk Assessment

- User-facing risk: Behavior change in the docs collaborative caret —
  before this PR, a remote insert before the local caret left the caret
  pointing at the wrong character; after, the caret follows the
  intended logical boundary. The change is scoped to docs and does not
  touch sheets/slides.
- Data/security risk: None. No schema or storage changes.
- Rollback plan: Revert the three commits in this branch. The store
  API additions (`resolveAnchoredLocalCursor`, `setCompositionStart`)
  and `EditorAPI` additions (`restoreLocalCursor`, composition hooks)
  are net-new and not depended on by callers outside this PR.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): N/A — the visible
  behavior change is "the caret no longer drifts under concurrent
  remote inserts" and is exercised by the two-client integration tests
  rather than by a screenshot.
- Follow-up work: `splitBlock` / `mergeBlock` use `delete + insert`
  against the Yorkie Tree rather than native `splitLevel=2`. Anchors
  whose target text is removed by a remote split or merge therefore go
  through the deterministic fallback ladder instead of preserving the
  logical offset through CRDT semantics. Switching to native
  split/merge is tracked in *Known Follow-Ups* and would also need to
  restore the undo/redo regression previously documented under
  `splitLevel=2`.
- AI assistance: Drafted with help from Claude Code across both the
  design note and the implementation (anchor data flow, fallback
  ladder, IME wiring, tests, doc updates). I reviewed every line and
  own the technical choices — happy to defend or revise any of them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented local caret and selection anchoring for collaborative documents, automatically preserving cursor position during remote changes.
  * Added IME composition lifecycle support for improved text input handling.

* **Documentation**
  * Added design documentation outlining the caret anchoring strategy.
  * Added task tracking for implementation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->