### PR TITLE
Import slide and master blipFill backgrounds from PPTX

### DIFF
--- a/docs/tasks/active/20260517-pptx-image-background-lessons.md
+++ b/docs/tasks/active/20260517-pptx-image-background-lessons.md
@@ -1,0 +1,63 @@
+# PPTX image-background import — lessons
+
+## What worked
+
+- **Inspecting the source XML before patching the importer.** The deck's
+  `<p:bg><p:bgPr><a:blipFill r:embed="rId3"><a:stretch/></a:blipFill></p:bgPr></p:bg>`
+  immediately revealed the gap. Reading the importer first ("which fill
+  types does `parseSlideBackground` recognise?") confirmed `solidFill`
+  was the only branch.
+
+- **Reusing `image.ts`'s blip pipeline.** Splitting `parsePic` into
+  `parseBlipFill` (returns `{ src, opacity?, crop? }`) + a thin
+  `parsePic` wrapper kept `<p:pic>` and `<p:bgPr>` paths sharing a
+  single rels-resolve + upload-with-soft-fail + alphaModFix/srcRect
+  implementation. Without this, the background path would have
+  diverged on edge cases (alphaModFix range clamping, upload-failure
+  reporting) within a release.
+
+- **Drying ImageRef.** `ImageRef = { src, w, h }` was unused. Replacing
+  it with `BackgroundImage = { src, opacity?, crop? }` (matching
+  `ImageElement.data`) eliminated the `w`/`h` puzzle for stretched
+  backgrounds and aligned the renderer paths.
+
+## Pitfalls
+
+- **`parseMaster` going async.** The master importer was the last
+  fully-synchronous unit in the import pipeline. Awaiting an upload
+  for a master-level background means `parseMaster` and its caller
+  `loadMasterAndLayouts` both shifted. Future master parsing (texture
+  fills, embedded fonts) should expect async too.
+
+- **Pre-loading rels before `parseMaster`.** Master rels were loaded
+  *after* `parseMaster` originally because nothing in the master
+  needed them. With image backgrounds the rels feed both the master's
+  own `<p:bg>` and the slideLayouts loop, so the order had to flip.
+
+- **Test-env image loading.** jsdom's `<img>` never auto-completes, so
+  the renderer test had to stub `Image` with a microtask-completing
+  fake (mirroring `image-renderer.test.ts`). Forgetting this leaves
+  `ctx.drawImage` permanently uncalled and the test silently passes
+  with the wrong assertion.
+
+## Open follow-ups (intentionally out of scope)
+
+- **`<p:bgRef>` theme background style references.** Many PowerPoint
+  decks (vs. Google Slides exports) use bgRef pointing into the theme's
+  `<a:bgFillStyleLst>`. Adding this would resolve the index, look up
+  the referenced fill, and route through either the solid or blip
+  parser as appropriate.
+
+- **`<a:gradFill>` / `<a:pattFill>` backgrounds.** Distinct data shape;
+  would need a `BackgroundGradient` / `BackgroundPattern` field on
+  `Background` and matching renderer paths.
+
+- **`<a:tile>` fill mode.** OOXML's `<a:blipFill>` can carry either
+  `<a:stretch>` (default, what we render) or `<a:tile>` (repeat). The
+  OSSCA deck and most real-world decks use stretch; tile is rare.
+
+- **Upload deduplication.** Every slide in the OSSCA deck references
+  the same blip via `rId3`. The current import calls `uploadImage`
+  once per slide for the same bytes — 22 uploads for one image. A
+  hash-keyed dedupe cache in `ImageParseContext` would cut this to
+  one upload + 21 cache hits without changing the import surface.

--- a/docs/tasks/active/20260517-pptx-image-background-todo.md
+++ b/docs/tasks/active/20260517-pptx-image-background-todo.md
@@ -1,0 +1,114 @@
+# PPTX import — image (blipFill) backgrounds
+
+## Problem
+
+Importing `11. 2026 OSSCA_참여형_Project Guide_Yorkie.pptx` produces
+slides with no visible background. The deck uses an image background on
+every slide (`<p:bg><p:bgPr><a:blipFill r:embed="rId3">…<a:stretch/></a:blipFill></p:bgPr></p:bg>`),
+but the current importer only recognises `<a:solidFill>` inside
+`<p:bgPr>` and falls back to the theme's role-based background color.
+The result is a flat white slide with the foreground shapes adrift on it.
+
+Confirmed in `packages/slides/src/import/pptx/slide.ts:101-111` and
+`packages/slides/src/import/pptx/master.ts:96-109`. The data model
+already declares `Background.image?: ImageRef`, but nothing populates
+or paints it (`packages/slides/src/view/canvas/slide-renderer.ts:128-132`
+explicitly says "Image-fill backgrounds are v2").
+
+## Scope
+
+In:
+
+- Slide-level `<p:bg><p:bgPr><a:blipFill>` parsing and rendering.
+- Master-level `<p:bg><p:bgPr><a:blipFill>` parsing and rendering
+  (inherits to slides without an explicit `<p:bg>`).
+- `<a:stretch>` fill mode (OOXML default, used by the OSSCA deck).
+  Implemented as "paint scaled to the logical 1920×1080 region".
+- Per-blip `<a:alphaModFix>` opacity and `<a:srcRect>` crop, reusing
+  the existing helpers from `import/pptx/image.ts`.
+
+Out (defer to a follow-up):
+
+- `<p:bgRef>` — theme background-style matrix references.
+- `<a:gradFill>` / `<a:pattFill>` background fills.
+- `<a:tile>` fill mode.
+- Layout-level background overrides (`Layout.background` is already
+  declared but the importer never sets it).
+
+## Plan
+
+1. **Data model**
+   - `Background.image` and `MasterBackground.image` switch from the
+     unused `ImageRef = { src, w, h }` to a slimmer `BackgroundImage =
+     { src; opacity?; crop? }` that matches what the renderer needs
+     and mirrors `ImageElement['data']`. `ImageRef` had no live
+     producers, so this is a pure widening for new producers.
+   - Update the `clone` helper and the re-export surface
+     (`slides/src/index.ts`, `slides/src/node.ts`).
+
+2. **Slide importer (`import/pptx/slide.ts`)**
+   - `parseSlideBackground` gains the importer's archive / rels /
+     uploadImage / report so it can resolve a `blipFill`. Refactor
+     `image.ts` to expose a `parseBlip(blipEl, ctx)` helper that
+     returns `{ src; opacity?; crop? }` so both `parsePic` and the
+     background path share one code path.
+   - When `<p:bgPr><a:blipFill>` is present, populate
+     `background.image`. `background.fill` keeps the existing
+     solid-color fallback (theme role) so transparent PNGs still get
+     a sensible canvas underneath them.
+   - When upload fails, fall through to the color-only path and bump
+     `report.skippedImages` — never throw.
+
+3. **Master importer (`import/pptx/master.ts`)**
+   - Thread the same context into `parseBackground`. `parseMaster`
+     becomes async (uploads can be async); update `parseMaster`'s
+     callers in `index.ts`.
+
+4. **Slide renderer (`view/canvas/slide-renderer.ts`)**
+   - After the existing full-canvas color fill, if
+     `slide.background.image` (or the inherited master image) is set,
+     paint it inside the scaled 1920×1080 region via
+     `drawImage(ctx, { w: 1920, h: 1080 }, image, onAssetLoad)`. The
+     color stays underneath so transparent backgrounds still read
+     correctly and the off-aspect strip remains the canvas color.
+
+5. **Tests**
+   - `import/pptx/slide.test.ts`: blipFill → populates
+     `background.image.src`, copies opacity/crop, falls back when no
+     `uploadImage` is configured.
+   - `import/pptx/master.test.ts`: blipFill on master.
+   - `view/canvas/slide-renderer.test.ts`: image background calls
+     `ctx.drawImage` once at slide-local 0,0 with size 1920×1080.
+   - `pnpm verify:fast` green.
+   - Manual: re-import the OSSCA deck against a local dev server and
+     visually confirm backgrounds appear.
+
+## Risks / open questions
+
+- **Async master parse**: `parseMaster` is currently synchronous and
+  pure. Going async is contained (only its index.ts caller) but worth
+  the touch.
+- **Caching across slides**: every slide in the OSSCA deck references
+  the same `rId3` blip → same bytes → same `uploadImage(bytes, mime)`
+  call. `image.getOrLoadImage` keys by `src`, so once the URL repeats
+  we share the cached `HTMLImageElement`. We just need to make sure
+  the `uploadImage` callback is idempotent or that the importer
+  short-circuits identical blob hashes; the current callback in
+  `frontend/src/app/slides/pptx-actions.ts` uploads each call, so the
+  same image gets uploaded N times. Not a correctness bug — only a
+  bandwidth/storage waste — and outside this task's scope. Note it in
+  the lessons file so we can revisit.
+- **Yorkie schema**: `Background` is part of the slides Yorkie schema.
+  Adding `image?: BackgroundImage` is a forward-compatible addition;
+  removing `ImageRef`'s `w`/`h` only matters if any persisted doc has
+  populated it — none do, since the renderer never read it and the
+  importer never set it.
+
+## Verification
+
+- `pnpm --filter @wafflebase/slides test` (unit tests).
+- `pnpm verify:fast` (lint + unit).
+- Manual import of `11. 2026 OSSCA_참여형_Project Guide_Yorkie.pptx`
+  against `pnpm dev`; confirm each slide shows its image background.
+- Spot-check `Yorkie, 캐즘 뛰어넘기.pptx` (existing benchmark deck) to
+  ensure we haven't regressed solid-color backgrounds.

--- a/packages/frontend/src/types/slides-document.ts
+++ b/packages/frontend/src/types/slides-document.ts
@@ -51,7 +51,11 @@ export interface YorkieSlide {
    */
   background: {
     fill?: ThemeColor;
-    image?: { src: string; w: number; h: number };
+    image?: {
+      src: string;
+      opacity?: number;
+      crop?: { x: number; y: number; w: number; h: number };
+    };
   };
   elements: YorkieElement[];
   notes: Block[];

--- a/packages/slides/src/import/pptx/image.ts
+++ b/packages/slides/src/import/pptx/image.ts
@@ -29,19 +29,26 @@ export interface ImageParseContext {
 }
 
 /**
- * Parse `<p:pic>` into an `ImageElement`. Returns `undefined` and bumps
- * `report.skippedImages` when the blip is missing, the rel doesn't
- * resolve, or no `uploadImage` callback is configured.
+ * Resolved `<a:blipFill>` data, shared by `<p:pic>` (foreground image)
+ * and `<p:bgPr>` (slide / master background) parsing.
  */
-export async function parsePic(
-  pic: Element,
-  ctx: ImageParseContext,
-): Promise<ImageElement | undefined> {
-  const spPr = child(pic, 'spPr');
-  const xfrm = spPr ? child(spPr, 'xfrm') : undefined;
-  const frame = parseXfrm(xfrm, ctx.scale);
+export type ParsedBlip = {
+  src: string;
+  opacity?: number;
+  crop?: Crop;
+};
 
-  const blipFill = child(pic, 'blipFill');
+/**
+ * Resolve `<a:blipFill>` → uploaded src + optional opacity/crop.
+ * Returns `undefined` and bumps `report.skippedImages` when the blip
+ * is missing, the rel doesn't resolve, or no `uploadImage` callback
+ * is configured. Soft-fails on upload errors (logs and counts skip)
+ * so a single broken image cannot tank the whole import.
+ */
+export async function parseBlipFill(
+  blipFill: Element | undefined,
+  ctx: ImageParseContext,
+): Promise<ParsedBlip | undefined> {
   const blip = blipFill ? child(blipFill, 'blip') : undefined;
   const rid = blip
     ? blip.getAttributeNS(NS.R, 'embed') || blip.getAttribute('r:embed') || undefined
@@ -67,9 +74,6 @@ export async function parsePic(
   const ext = mediaPath.split('.').pop()?.toLowerCase() ?? '';
   const mime = EXT_TO_MIME[ext] ?? 'application/octet-stream';
 
-  // Soft-skip on upload failure — a single broken image shouldn't tank
-  // the whole import. Counts towards `report.skippedImages` and the
-  // caller drops the element.
   let src: string;
   try {
     src = await ctx.uploadImage(bytes, mime);
@@ -83,16 +87,35 @@ export async function parsePic(
 
   const crop = blipFill ? parseSrcRect(child(blipFill, 'srcRect')) : undefined;
   const opacity = blip ? parseAlphaModFix(child(blip, 'alphaModFix')) : undefined;
+  return {
+    src,
+    ...(crop ? { crop } : {}),
+    ...(opacity !== undefined ? { opacity } : {}),
+  };
+}
+
+/**
+ * Parse `<p:pic>` into an `ImageElement`. Returns `undefined` and bumps
+ * `report.skippedImages` when the blip is missing, the rel doesn't
+ * resolve, or no `uploadImage` callback is configured.
+ */
+export async function parsePic(
+  pic: Element,
+  ctx: ImageParseContext,
+): Promise<ImageElement | undefined> {
+  const spPr = child(pic, 'spPr');
+  const xfrm = spPr ? child(spPr, 'xfrm') : undefined;
+  const frame = parseXfrm(xfrm, ctx.scale);
+
+  const blipFill = child(pic, 'blipFill');
+  const blip = await parseBlipFill(blipFill, ctx);
+  if (!blip) return undefined;
 
   return {
     id: generateId(),
     type: 'image',
     frame,
-    data: {
-      src,
-      ...(crop ? { crop } : {}),
-      ...(opacity !== undefined ? { opacity } : {}),
-    },
+    data: blip,
   };
 }
 

--- a/packages/slides/src/import/pptx/index.ts
+++ b/packages/slides/src/import/pptx/index.ts
@@ -14,6 +14,7 @@ import { parseTheme } from './theme';
 import { parseMaster } from './master';
 import { parseLayout } from './layout';
 import { attrInt, children, descendant, parseXml, NS } from './xml';
+import type { ImageParseContext } from './image';
 
 export type UploadImage = (bytes: Uint8Array, mime: string) => Promise<string>;
 
@@ -83,6 +84,8 @@ export async function importPptx(
         masterTarget,
         importedTheme?.id ?? 'default-light',
         report,
+        opts.uploadImage,
+        scale,
       )
     : {
         master: undefined,
@@ -191,6 +194,8 @@ async function loadMasterAndLayouts(
   masterTarget: string,
   themeId: string,
   report: ImportReport,
+  uploadImage: UploadImage | undefined,
+  scale: ReturnType<typeof emuScale>,
 ): Promise<{
   master: Master | undefined;
   layouts: Layout[];
@@ -203,13 +208,28 @@ async function loadMasterAndLayouts(
     return { master: undefined, layouts: [], layoutMap: new Map(), clrMap: new Map() };
   }
 
-  const { master, clrMap } = parseMaster(masterXml, `imported-${masterPath}`, themeId);
-
   // Each master's rels file lists the slideLayouts it owns. We import
-  // them all; slides resolve to one via their own rels file.
+  // them all; slides resolve to one via their own rels file. Loaded
+  // before `parseMaster` so the same `rels` map can resolve any
+  // master-level blipFill background.
   const relsPath = relsSiblingFor(masterPath);
   const relsXml = await archive.readText(relsPath);
   const rels = relsXml ? parseRels(relsXml) : new Map();
+
+  const masterImageCtx: ImageParseContext = {
+    archive,
+    slidePartPath: masterPath,
+    rels,
+    uploadImage,
+    scale,
+    report,
+  };
+  const { master, clrMap } = await parseMaster(
+    masterXml,
+    `imported-${masterPath}`,
+    themeId,
+    masterImageCtx,
+  );
 
   const layouts: Layout[] = [];
   const layoutMap: LayoutPathToInfo = new Map();

--- a/packages/slides/src/import/pptx/master.ts
+++ b/packages/slides/src/import/pptx/master.ts
@@ -2,6 +2,7 @@ import type { Master, MasterBackground } from '../../model/master';
 import { DEFAULT_MASTER } from '../../model/master';
 import { clone } from '../../model/clone';
 import { parseColorFromContainer, type ClrMap } from './color';
+import { parseBlipFill, type ImageParseContext } from './image';
 import { attr, child, descendant, parseXml } from './xml';
 
 /**
@@ -32,7 +33,12 @@ export interface ImportedMaster {
   clrMap: ClrMap;
 }
 
-export function parseMaster(xml: string, id: string, themeId: string): ImportedMaster {
+export async function parseMaster(
+  xml: string,
+  id: string,
+  themeId: string,
+  imageCtx: ImageParseContext,
+): Promise<ImportedMaster> {
   const doc = parseXml(xml);
   const sldMaster = descendant(doc, 'sldMaster');
   const cSld = sldMaster ? child(sldMaster, 'cSld') : undefined;
@@ -42,7 +48,9 @@ export function parseMaster(xml: string, id: string, themeId: string): ImportedM
   // Master `<p:bg>` is parsed without `clrMap` — backgrounds almost
   // always use direct scheme slot names (`lt1` / `dk1`) rather than the
   // logical `bg1` / `tx1` aliases that `<p:clrMap>` rewires.
-  const background = bg ? parseBackground(bg) : clone(DEFAULT_MASTER.background);
+  const background = bg
+    ? await parseBackground(bg, imageCtx)
+    : clone(DEFAULT_MASTER.background);
 
   // `clone()` deep-copies so the imported master can mutate its
   // background / placeholderStyles without leaking back into
@@ -93,12 +101,22 @@ function parseClrMap(sldMaster: Element): ClrMap {
   return map;
 }
 
-function parseBackground(bg: Element): MasterBackground {
+async function parseBackground(
+  bg: Element,
+  imageCtx: ImageParseContext,
+): Promise<MasterBackground> {
   // `<p:bg>` wraps either `<p:bgPr>` (literal fill) or `<p:bgRef>` (style
-  // matrix index). v1 supports only `bgPr → solidFill` and falls back
-  // for anything else.
+  // matrix index). v2 adds blipFill alongside solidFill; bgRef is still
+  // unhandled and falls through to the default.
   const bgPr = child(bg, 'bgPr');
   if (bgPr) {
+    const blipFill = child(bgPr, 'blipFill');
+    if (blipFill) {
+      const blip = await parseBlipFill(blipFill, imageCtx);
+      if (blip) {
+        return { fill: clone(DEFAULT_MASTER.background).fill, image: blip };
+      }
+    }
     const solid = child(bgPr, 'solidFill');
     if (solid) {
       const color = parseColorFromContainer(solid);

--- a/packages/slides/src/import/pptx/slide.ts
+++ b/packages/slides/src/import/pptx/slide.ts
@@ -4,6 +4,7 @@ import { DEFAULT_BACKGROUND } from '../../model/presentation';
 import { clone } from '../../model/clone';
 import { parseColorFromContainer, type ClrMap } from './color';
 import { type EmuScale } from './geometry';
+import { parseBlipFill, type ImageParseContext } from './image';
 import { parseRels, resolveRelsTarget, type PptxRel } from './rels';
 import { ImportReport } from './report';
 import { parseSpTree, type SlideParseContext } from './shape';
@@ -55,8 +56,16 @@ export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undef
   // from the master. v1 records an override only when present.
   const cSld = child(slideEl, 'cSld');
   const bgEl = cSld ? child(cSld, 'bg') : undefined;
+  const imageCtx: ImageParseContext = {
+    archive: opts.archive,
+    slidePartPath: opts.partPath,
+    rels,
+    uploadImage: opts.uploadImage,
+    scale: opts.scale,
+    report: opts.report,
+  };
   const background = bgEl
-    ? parseSlideBackground(bgEl, opts.clrMap)
+    ? await parseSlideBackground(bgEl, opts.clrMap, imageCtx)
     : clone(DEFAULT_BACKGROUND);
 
   const spTree = cSld ? child(cSld, 'spTree') : undefined;
@@ -98,9 +107,26 @@ function pickLayoutInfo(
   return undefined;
 }
 
-function parseSlideBackground(bgEl: Element, clrMap: ClrMap): Background {
+async function parseSlideBackground(
+  bgEl: Element,
+  clrMap: ClrMap,
+  imageCtx: ImageParseContext,
+): Promise<Background> {
   const bgPr = child(bgEl, 'bgPr');
   if (bgPr) {
+    // blipFill (image background) — populate `image` alongside the
+    // theme-role fill so transparent regions of the image still show
+    // a sensible color underneath, and so an upload failure doesn't
+    // leave us with a missing background entirely.
+    const blipFill = child(bgPr, 'blipFill');
+    if (blipFill) {
+      const blip = await parseBlipFill(blipFill, imageCtx);
+      if (blip) {
+        return { fill: clone(DEFAULT_BACKGROUND).fill, image: blip };
+      }
+      // Upload failed / blip unresolved — fall through so the slide
+      // still gets the theme background instead of nothing.
+    }
     const solid = child(bgPr, 'solidFill');
     if (solid) {
       const color = parseColorFromContainer(solid, clrMap);

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -12,6 +12,7 @@ export { ImportReport } from './import/pptx/report';
 // Model
 export type {
   Background,
+  BackgroundImage,
   Layout,
   Meta,
   PlaceholderSpec,
@@ -30,7 +31,12 @@ export type {
   ThemeFont,
 } from './model/theme';
 export { resolveColor, resolveFont } from './model/theme';
-export type { Master, PlaceholderStyle, MasterBackground } from './model/master';
+export type {
+  Master,
+  PlaceholderStyle,
+  MasterBackground,
+  MasterBackgroundImage,
+} from './model/master';
 export { DEFAULT_MASTER } from './model/master';
 export { seedPlaceholderBlocks } from './model/placeholder-blocks';
 
@@ -42,7 +48,6 @@ export type {
   ElementType,
   Frame,
   ImageElement,
-  ImageRef,
   PlaceholderRef,
   PlaceholderType,
   ShapeElement,

--- a/packages/slides/src/model/element.ts
+++ b/packages/slides/src/model/element.ts
@@ -21,13 +21,6 @@ export type Frame = {
   flipV?: boolean;
 };
 
-export type ImageRef = {
-  src: string;
-  /** Natural pixel dimensions, used to constrain crop and aspect. */
-  w: number;
-  h: number;
-};
-
 /** Crop rectangle in image-relative coordinates (0..1 on each axis). */
 export type Crop = { x: number; y: number; w: number; h: number };
 

--- a/packages/slides/src/model/master.ts
+++ b/packages/slides/src/model/master.ts
@@ -1,3 +1,4 @@
+import type { Crop } from './element';
 import type { ColorRole, FontRole, ThemeColor } from './theme';
 
 export type PlaceholderStyle = {
@@ -8,8 +9,17 @@ export type PlaceholderStyle = {
   lineHeight: number;
 };
 
+/** Same shape as `BackgroundImage` in `presentation.ts`; kept inline
+ *  here to avoid a circular dependency between master and presentation. */
+export type MasterBackgroundImage = {
+  src: string;
+  opacity?: number;
+  crop?: Crop;
+};
+
 export type MasterBackground = {
   fill: ThemeColor;
+  image?: MasterBackgroundImage;
 };
 
 export type Master = {

--- a/packages/slides/src/model/presentation.ts
+++ b/packages/slides/src/model/presentation.ts
@@ -1,11 +1,25 @@
 import type { Block } from '@wafflebase/docs';
-import type { Element, ElementInit, ImageRef, PlaceholderType } from './element';
+import type { Crop, Element, ElementInit, PlaceholderType } from './element';
 import type { Theme, ThemeColor } from './theme';
 import type { Master } from './master';
 
+/**
+ * Image fill behind a slide. Painted inside the logical 1920×1080
+ * region after `fill`; transparent regions of the image reveal the
+ * solid color underneath. Stretch mode only — there is no tile/repeat
+ * variant yet.
+ */
+export type BackgroundImage = {
+  src: string;
+  /** `[0, 1]`. Imported from OOXML `<a:blip><a:alphaModFix>`. */
+  opacity?: number;
+  /** `<a:srcRect>` sub-rectangle of the source image, in 0..1 coords. */
+  crop?: Crop;
+};
+
 export type Background = {
   fill: ThemeColor;
-  image?: ImageRef;
+  image?: BackgroundImage;
 };
 
 export type Slide = {

--- a/packages/slides/src/node.ts
+++ b/packages/slides/src/node.ts
@@ -25,6 +25,7 @@
 
 export type {
   Background,
+  BackgroundImage,
   Layout,
   Meta,
   PlaceholderSpec,
@@ -34,7 +35,7 @@ export type {
 export { DEFAULT_BACKGROUND, SLIDE_HEIGHT, SLIDE_WIDTH } from './model/presentation';
 
 export type { ColorScheme, FontScheme, Theme, ThemeColor, ThemeFont } from './model/theme';
-export type { Master, MasterBackground } from './model/master';
+export type { Master, MasterBackground, MasterBackgroundImage } from './model/master';
 
 export type {
   Crop,
@@ -44,7 +45,6 @@ export type {
   ElementType,
   Frame,
   ImageElement,
-  ImageRef,
   ShapeElement,
   ShapeKind,
   ShapeStroke,

--- a/packages/slides/src/view/canvas/slide-renderer.ts
+++ b/packages/slides/src/view/canvas/slide-renderer.ts
@@ -1,8 +1,9 @@
 import type { Element } from '../../model/element';
-import type { Slide, SlidesDocument } from '../../model/presentation';
+import type { BackgroundImage, Slide, SlidesDocument } from '../../model/presentation';
 import { SLIDE_HEIGHT, SLIDE_WIDTH } from '../../model/presentation';
 import { resolveColor } from '../../model/theme';
 import { drawElement } from './element-renderer';
+import { drawImage } from './image-renderer';
 import { getActiveTheme } from './render-context';
 
 /** Global alpha applied to the hover-ghost element so the user can see
@@ -125,11 +126,18 @@ export function drawSlide(
   ctx.fillRect(0, 0, hostWidth * dpr, hostHeight * dpr);
   ctx.scale(scale, scale);
 
-  // Iterate elements in array order = z-order, last is front. Image-fill
-  // backgrounds are v2 — when they land, paint the image inside the
-  // logical 1920×1080 region *after* this full-canvas color fill so the
-  // image still represents the slide and the surrounding strip stays
-  // background-color.
+  // Image-fill background (PPTX `<p:bg><p:bgPr><a:blipFill>`). Painted
+  // *after* the full-canvas color fill so the surrounding strip stays
+  // background-color and transparent regions of the image still show
+  // the color underneath. Stretch to the logical 1920×1080 region
+  // because that's what OOXML `<a:stretch><a:fillRect/></a:stretch>`
+  // means; tile mode is a v3 problem.
+  const bgImage = pickBackgroundImage(slide, doc);
+  if (bgImage) {
+    drawImage(ctx, { w: SLIDE_WIDTH, h: SLIDE_HEIGHT }, bgImage, onAssetLoad);
+  }
+
+  // Iterate elements in array order = z-order, last is front.
   // Element lookup is consumed by the connector renderer to resolve
   // attached endpoints. Built once per slide-render so each connector
   // doesn't rebuild it.
@@ -151,4 +159,18 @@ export function drawSlide(
     drawElement(ctx, ghost, doc, theme, onAssetLoad, elementsLookup);
     ctx.restore();
   }
+}
+
+/**
+ * Slide-level image background takes precedence; otherwise inherit
+ * from the deck's master so master-only image decks still render.
+ * Returns `undefined` when neither is set.
+ */
+function pickBackgroundImage(
+  slide: Slide,
+  doc: SlidesDocument,
+): BackgroundImage | undefined {
+  if (slide.background.image) return slide.background.image;
+  const master = doc.masters.find((m) => m.id === doc.meta.masterId);
+  return master?.background.image;
 }

--- a/packages/slides/test/import/pptx/master.test.ts
+++ b/packages/slides/test/import/pptx/master.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import { parseMaster } from '../../../src/import/pptx/master';
+import type { ImageParseContext } from '../../../src/import/pptx/image';
+import { ImportReport } from '../../../src/import/pptx/report';
 
 const MIN_MASTER = `<?xml version="1.0"?>
 <p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
@@ -20,27 +22,108 @@ const SRGB_MASTER = `<?xml version="1.0"?>
   </p:cSld>
 </p:sldMaster>`;
 
+const stubImageCtx = (): ImageParseContext => ({
+  archive: {
+    readText: async () => undefined,
+    readBytes: async () => undefined,
+    list: () => [],
+  },
+  slidePartPath: 'ppt/slideMasters/slideMaster1.xml',
+  rels: new Map(),
+  uploadImage: undefined,
+  scale: { sx: 1, sy: 1 },
+  report: new ImportReport(),
+});
+
 describe('parseMaster', () => {
-  it('captures the master background as a theme-bound role', () => {
-    const { master, clrMap } = parseMaster(MIN_MASTER, 'master-1', 'imported-yorkie');
+  it('captures the master background as a theme-bound role', async () => {
+    const { master, clrMap } = await parseMaster(
+      MIN_MASTER,
+      'master-1',
+      'imported-yorkie',
+      stubImageCtx(),
+    );
     expect(master.id).toBe('master-1');
     expect(master.themeId).toBe('imported-yorkie');
     expect(master.background.fill).toEqual({ kind: 'role', role: 'background' });
     expect(clrMap.size).toBe(0); // identity (no <p:clrMap>)
   });
 
-  it('captures a literal sRGB background', () => {
-    const { master } = parseMaster(SRGB_MASTER, 'm', 't');
+  it('captures a literal sRGB background', async () => {
+    const { master } = await parseMaster(SRGB_MASTER, 'm', 't', stubImageCtx());
     expect(master.background.fill).toEqual({ kind: 'srgb', value: '#F3F3F3' });
   });
 
-  it('inherits the default placeholder-style table for now', () => {
-    const { master } = parseMaster(MIN_MASTER, 'm', 't');
+  it('inherits the default placeholder-style table for now', async () => {
+    const { master } = await parseMaster(MIN_MASTER, 'm', 't', stubImageCtx());
     expect(master.placeholderStyles.title.fontSize).toBe(44);
     expect(master.placeholderStyles.body.fontSize).toBe(18);
   });
 
-  it('parses non-identity <p:clrMap> mappings (benchmark deck swaps bg2/tx2)', () => {
+  it('populates background.image from a master-level blipFill', async () => {
+    const xml = `<?xml version="1.0"?>
+<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld>
+    <p:bg>
+      <p:bgPr>
+        <a:blipFill>
+          <a:blip r:embed="rIdBg"/>
+          <a:stretch><a:fillRect/></a:stretch>
+        </a:blipFill>
+      </p:bgPr>
+    </p:bg>
+    <p:spTree/>
+  </p:cSld>
+</p:sldMaster>`;
+    const ctx: ImageParseContext = {
+      archive: {
+        readText: async () => undefined,
+        readBytes: async (path) =>
+          path === 'ppt/media/image1.png' ? new Uint8Array([0x89]) : undefined,
+        list: () => [],
+      },
+      slidePartPath: 'ppt/slideMasters/slideMaster1.xml',
+      rels: new Map([
+        [
+          'rIdBg',
+          { type: 'image', target: '../media/image1.png', external: false },
+        ],
+      ]),
+      uploadImage: async () => 'cdn://master-bg.png',
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+    };
+
+    const { master } = await parseMaster(xml, 'm', 't', ctx);
+    expect(master.background.image).toEqual({ src: 'cdn://master-bg.png' });
+    // Fill stays as the theme role so transparent regions still get a color.
+    expect(master.background.fill).toEqual({ kind: 'role', role: 'background' });
+    expect(ctx.report.skippedImages).toBe(0);
+  });
+
+  it('falls back to color-only when the master blipFill upload is missing', async () => {
+    const xml = `<?xml version="1.0"?>
+<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld>
+    <p:bg>
+      <p:bgPr>
+        <a:blipFill><a:blip r:embed="rIdBg"/></a:blipFill>
+      </p:bgPr>
+    </p:bg>
+    <p:spTree/>
+  </p:cSld>
+</p:sldMaster>`;
+    const { master } = await parseMaster(xml, 'm', 't', stubImageCtx());
+    expect(master.background.image).toBeUndefined();
+    // No solid sibling either, so we land on the default role-bound fill.
+    expect(master.background.fill).toEqual({ kind: 'role', role: 'background' });
+  });
+
+  it('parses non-identity <p:clrMap> mappings (benchmark deck swaps bg2/tx2)', async () => {
     const xml = `<?xml version="1.0"?>
 <p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
@@ -50,7 +133,7 @@ describe('parseMaster', () => {
             accent4="accent4" accent5="accent5" accent6="accent6"
             hlink="hlink" folHlink="folHlink"/>
 </p:sldMaster>`;
-    const { clrMap } = parseMaster(xml, 'm', 't');
+    const { clrMap } = await parseMaster(xml, 'm', 't', stubImageCtx());
     // Identity entries skipped; only the swaps land in the map.
     expect(clrMap.get('bg2')).toBe('dk2');
     expect(clrMap.get('tx2')).toBe('lt2');

--- a/packages/slides/test/import/pptx/slide.test.ts
+++ b/packages/slides/test/import/pptx/slide.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseSlide } from '../../../src/import/pptx/slide';
+import { ImportReport } from '../../../src/import/pptx/report';
+import type { PptxArchive } from '../../../src/import/pptx/unzip';
+
+/**
+ * Build a `PptxArchive` mock backed by an in-memory file map. Only the
+ * methods the importer actually calls are populated — `list()` is a
+ * no-op because slide parsing doesn't walk the archive.
+ */
+function makeArchive(files: Record<string, string | Uint8Array>): PptxArchive {
+  return {
+    readText: async (path) => {
+      const v = files[path];
+      return typeof v === 'string' ? v : undefined;
+    },
+    readBytes: async (path) => {
+      const v = files[path];
+      if (v instanceof Uint8Array) return v;
+      if (typeof v === 'string') return new TextEncoder().encode(v);
+      return undefined;
+    },
+    list: () => [],
+  };
+}
+
+const SLIDE_WITH_BLIPFILL = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld>
+    <p:bg>
+      <p:bgPr>
+        <a:blipFill>
+          <a:blip r:embed="rIdImg"><a:alphaModFix amt="80000"/></a:blip>
+          <a:stretch><a:fillRect/></a:stretch>
+        </a:blipFill>
+      </p:bgPr>
+    </p:bg>
+    <p:spTree/>
+  </p:cSld>
+</p:sld>`;
+
+const SLIDE_RELS = `<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdImg" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>
+</Relationships>`;
+
+const SLIDE_BLIPFILL_NO_REL = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld>
+    <p:bg>
+      <p:bgPr>
+        <a:blipFill>
+          <a:blip r:embed="rIdMissing"/>
+          <a:stretch><a:fillRect/></a:stretch>
+        </a:blipFill>
+      </p:bgPr>
+    </p:bg>
+    <p:spTree/>
+  </p:cSld>
+</p:sld>`;
+
+describe('parseSlide — blipFill background', () => {
+  it('populates background.image when blipFill resolves and uploadImage is provided', async () => {
+    const archive = makeArchive({
+      'ppt/slides/slide1.xml': SLIDE_WITH_BLIPFILL,
+      'ppt/slides/_rels/slide1.xml.rels': SLIDE_RELS,
+      'ppt/media/image1.png': new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+    });
+    const uploads: Array<{ mime: string; size: number }> = [];
+    const report = new ImportReport();
+
+    const slide = await parseSlide({
+      archive,
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      uploadImage: async (bytes, mime) => {
+        uploads.push({ mime, size: bytes.byteLength });
+        return `cdn://uploaded/${uploads.length}.png`;
+      },
+      scale: { sx: 1, sy: 1 },
+      report,
+      clrMap: new Map(),
+    });
+
+    expect(slide).toBeDefined();
+    expect(slide!.background.image).toEqual({
+      src: 'cdn://uploaded/1.png',
+      opacity: 0.8,
+    });
+    // Theme-role fill stays on so transparent regions still get a color.
+    expect(slide!.background.fill).toEqual({ kind: 'role', role: 'background' });
+    expect(uploads).toEqual([{ mime: 'image/png', size: 4 }]);
+    expect(report.skippedImages).toBe(0);
+  });
+
+  it('falls back to a color background when uploadImage is not configured', async () => {
+    const archive = makeArchive({
+      'ppt/slides/slide1.xml': SLIDE_WITH_BLIPFILL,
+      'ppt/slides/_rels/slide1.xml.rels': SLIDE_RELS,
+      'ppt/media/image1.png': new Uint8Array([0x89]),
+    });
+    const report = new ImportReport();
+
+    const slide = await parseSlide({
+      archive,
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      // no uploadImage — dry-run / CLI fixture style
+      scale: { sx: 1, sy: 1 },
+      report,
+      clrMap: new Map(),
+    });
+
+    expect(slide).toBeDefined();
+    expect(slide!.background.image).toBeUndefined();
+    expect(report.skippedImages).toBeGreaterThan(0);
+  });
+
+  it('counts a skip and falls through when the blip rel does not resolve', async () => {
+    const archive = makeArchive({
+      'ppt/slides/slide1.xml': SLIDE_BLIPFILL_NO_REL,
+      'ppt/slides/_rels/slide1.xml.rels': SLIDE_RELS,
+    });
+    const report = new ImportReport();
+
+    const slide = await parseSlide({
+      archive,
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      uploadImage: async () => 'cdn://unused.png',
+      scale: { sx: 1, sy: 1 },
+      report,
+      clrMap: new Map(),
+    });
+
+    expect(slide).toBeDefined();
+    expect(slide!.background.image).toBeUndefined();
+    expect(report.skippedImages).toBe(1);
+  });
+});

--- a/packages/slides/test/view/canvas/slide-renderer.test.ts
+++ b/packages/slides/test/view/canvas/slide-renderer.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import type { Slide, SlidesDocument } from '../../../src/model/presentation';
-import { DEFAULT_BACKGROUND } from '../../../src/model/presentation';
+import { DEFAULT_BACKGROUND, SLIDE_HEIGHT, SLIDE_WIDTH } from '../../../src/model/presentation';
 import type { Theme } from '../../../src/model/theme';
 import { DEFAULT_MASTER } from '../../../src/model/master';
 import { BUILT_IN_LAYOUTS } from '../../../src/model/layout';
@@ -8,6 +9,7 @@ import { asCtx, createCtxSpy } from '../../../src/view/canvas/ctx-spy';
 // Install Path2D global before the slide renderer pulls in shape builders.
 import '../../../src/view/canvas/test-canvas-env';
 import { SlideRenderer } from '../../../src/view/canvas/slide-renderer';
+import { clearImageCacheForTests } from '../../../src/view/canvas/image-cache';
 
 const THEME: Theme = {
   id: 't', name: 't',
@@ -102,17 +104,92 @@ describe('SlideRenderer.render', () => {
     expect(ctx.scale).toHaveBeenCalledWith(1.0, 1.0); // 0.5 * 2
   });
 
-  it('background image is not drawn yet (image-fill backgrounds are v2)', () => {
-    const { renderer, ctx } = makeRenderer();
-    const slide: Slide = {
-      ...blankSlide(),
-      background: {
-        fill: { kind: 'srgb', value: '#fff' },
-        image: { src: 'x.png', w: 1, h: 1 },
-      },
-    };
-    renderer.render(slide, DOC);
-    expect(ctx.drawImage).not.toHaveBeenCalled();
+  describe('image-fill backgrounds', () => {
+    // jsdom's `<img>` never auto-completes; replace `Image` with a fake
+    // that flips to `complete` on the next microtask so the cache hits
+    // on the second render. Mirrors the pattern in image-renderer.test.
+    class FakeImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      complete = false;
+      naturalWidth = 100;
+      naturalHeight = 80;
+      private _src = '';
+      get src(): string { return this._src; }
+      set src(value: string) {
+        this._src = value;
+        queueMicrotask(() => {
+          this.complete = true;
+          this.onload?.();
+        });
+      }
+    }
+
+    const flushMicrotasks = (): Promise<void> =>
+      new Promise((resolve) => queueMicrotask(() => resolve()));
+
+    beforeEach(() => {
+      vi.stubGlobal('Image', FakeImage);
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      clearImageCacheForTests();
+    });
+
+    it('paints the slide background image stretched to 1920x1080', async () => {
+      const { renderer, ctx } = makeRenderer();
+      const slide: Slide = {
+        ...blankSlide(),
+        background: {
+          fill: { kind: 'srgb', value: '#fff' },
+          image: { src: 'bg.png' },
+        },
+      };
+      // First render kicks off the load; image not yet complete.
+      renderer.render(slide, DOC);
+      expect(ctx.drawImage).not.toHaveBeenCalled();
+
+      await flushMicrotasks();
+
+      // markDirty was scheduled via the onAssetLoad callback; second
+      // render hits the loaded cache entry and paints.
+      renderer.render(slide, DOC);
+      expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+      const [, dx, dy, dw, dh] =
+        (ctx.drawImage as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(dx).toBe(0);
+      expect(dy).toBe(0);
+      expect(dw).toBe(SLIDE_WIDTH);
+      expect(dh).toBe(SLIDE_HEIGHT);
+    });
+
+    it('inherits a master-level background image when the slide has none', async () => {
+      const { renderer, ctx } = makeRenderer();
+      const docWithMasterImage: SlidesDocument = {
+        ...DOC,
+        meta: { ...DOC.meta, masterId: 'm-with-image' },
+        masters: [
+          {
+            ...DEFAULT_MASTER,
+            id: 'm-with-image',
+            background: {
+              fill: { kind: 'role', role: 'background' },
+              image: { src: 'master-bg.png' },
+            },
+          },
+        ],
+      };
+      renderer.render(blankSlide(), docWithMasterImage);
+      await flushMicrotasks();
+      renderer.render(blankSlide(), docWithMasterImage);
+      expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call ctx.drawImage when neither slide nor master has an image', () => {
+      const { renderer, ctx } = makeRenderer();
+      renderer.render(blankSlide(), DOC);
+      expect(ctx.drawImage).not.toHaveBeenCalled();
+    });
   });
 
   it('forceRender paints even when not dirty', () => {


### PR DESCRIPTION
## Summary

- The PPTX importer only recognised `<a:solidFill>` inside `<p:bg><p:bgPr>`, so decks whose slides use image backgrounds (very common in Google Slides exports, including the reporting OSSCA Yorkie deck) imported as flat white slides.
- Add a `parseBlipFill` helper extracted from `parsePic` so both foreground `<p:pic>` and background `<p:bgPr>` share the same blip resolve + upload + alphaModFix/srcRect pipeline. Slide and master `parseBackground` populate the new `Background.image` / `MasterBackground.image` field; renderer paints it stretched across the logical 1920×1080 region after the existing full-canvas color fill so transparent regions still show a color underneath.
- `ImageRef` (declared but never populated) is replaced with `BackgroundImage = { src; opacity?; crop? }` to match what the renderer actually consumes. `parseMaster` is now async because its background path may await an upload.
- bgRef (theme background-style references), gradFill, pattFill, and `<a:tile>` mode remain out of scope — image backgrounds were the dominant gap and account for every slide in the reporting deck.

## Test plan

- [x] `pnpm verify:fast` (lint + unit, 792 frontend/backend + 1004 slides tests)
- [x] `parseSlide` blipFill — success, no `uploadImage` fallback, unresolved rel skip
- [x] `parseMaster` blipFill — success, fallback when upload missing
- [x] `slide-renderer` — slide image painted at (0, 0, SLIDE_WIDTH, SLIDE_HEIGHT); master inheritance when slide has no image; no `drawImage` when neither has one
- [x] Manual smoke: import `11. 2026 OSSCA_참여형_Project Guide_Yorkie.pptx` against `pnpm dev`, confirm each slide shows its image background
- [x] Spot-check `Yorkie, 캐즘 뛰어넘기.pptx` (existing benchmark deck) — confirm solid-color backgrounds did not regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)