### PR TITLE
Keep rotated PPTX shapes inside their group's bbox

### DIFF
--- a/docs/tasks/active/20260517-pptx-rotated-child-group-scale-lessons.md
+++ b/docs/tasks/active/20260517-pptx-rotated-child-group-scale-lessons.md
@@ -1,0 +1,72 @@
+# Lessons — PPTX rotated child + non-uniform group scale
+
+## What I almost got wrong
+
+Initial instinct on seeing "scale child by per-axis matrix scale" was
+that the math was already correct — every prior test passed, including
+one explicitly named "rescales when chExt differs from ext". Easy to
+walk away thinking the import is fine.
+
+The trap is that the existing "non-uniform scale" coverage used a
+**uniform** 0.5× scale (2000000 / 1000000 in both axes), and the
+"rotated group" coverage used uniform 200×200 groups (`localSx ==
+localSy`). The dangerous combination — rotated child + non-uniform
+local scale — had no test, so the bug shipped.
+
+## Generalisable lesson
+
+When auditing a coverage matrix, count *combinations*, not features:
+"we have a rotation test" + "we have a non-uniform scale test" does
+NOT imply "we have a rotation × non-uniform scale test". For transform
+code where features compose, the bug always lives in the off-diagonal
+cells.
+
+## OOXML emission detail worth remembering
+
+PowerPoint / Google Slides set `<a:chOff>` / `<a:chExt>` to the
+**visual rotated** bbox of children, not the unrotated bbox. So if a
+single child has `rot="5400000"` (90°) with `<a:ext cx="A" cy="B"/>`,
+the enclosing group will emit `<a:chExt cx="B" cy="A"/>` — swapped.
+Any importer that "scales the unrotated dims" will end up off-axis.
+
+## Solver shape
+
+For per-axis scale (sx, sy) applied to a rectangle of size (w, h)
+rotated by θ, the rotated rectangle whose visual bbox matches the
+scaled visual bbox is the solution of:
+
+    [|cos θ| |sin θ|] [w']   [(w|cos θ| + h|sin θ|) · sx]
+    [|sin θ| |cos θ|] [h'] = [(w|sin θ| + h|cos θ|) · sy]
+
+Determinant = cos(2θ). Singular at 45° + k·90°, where no axis-aligned
+rectangle satisfies both scaled visual extents — fall back to
+unrotated scaling for those.
+
+For θ = 0: identity → matches existing behaviour.
+For θ = 90°: swaps sx ↔ sy on h and w — the most common real case.
+
+## Verification gap I should be honest about
+
+End-to-end "re-import the PPTX and verify slide 7 visually" was not
+performed locally — the unit test asserts the post-transform visual
+bbox matches the group `ext` using the exact EMU values from slide 7,
+which is strong evidence but not a pixel-perfect screenshot diff. The
+manual smoke is deferred to PR review.
+
+## Lesson from the code review pass
+
+First pass shipped a 270° "symmetry" test that ran the same code path
+as the 90° test (because `|cos|`/`|sin|` make rotation
+quadrant-invariant) — looked like additional coverage, was actually
+redundant. Reviewer caught it. **Whenever a fix uses absolute values
+to collapse symmetries, every "symmetry" test added afterward is
+suspect: it might be exercising the same branch.** The genuine
+coverage dimension here is *off-axis* rotation, where cos·sin ≠ 0.
+
+Reviewer also caught a latent corruption mode: for sufficiently
+non-uniform scale at off-axis angles, the algebraic solver returns
+negative w'/h'. Two-line guard fixes it (fall back to per-axis
+scaling). I'd derived the math for the dominant case (axis-aligned)
+and not stress-tested the solver outside it. **Whenever you ship a
+closed-form solver, pick a torture-test input in a different regime
+and trace by hand before claiming the math covers the general case.**

--- a/docs/tasks/active/20260517-pptx-rotated-child-group-scale-todo.md
+++ b/docs/tasks/active/20260517-pptx-rotated-child-group-scale-todo.md
@@ -1,0 +1,89 @@
+# PPTX import: rotated child + non-uniform group scale overflows group
+
+## Problem
+
+When importing a `.pptx`, shapes with their own rotation that live inside
+a `<p:grpSp>` whose `chExt` is sized for the **rotated visual extent**
+(the common emission from PowerPoint / Google Slides) overflow the
+group's `ext` after import.
+
+Concretely on slide 7 of `Yorkie, 캐즘 뛰어넘기.pptx`, the centre
+`rightArrowCallout` (sp id=135) has `rot="5400000"` (90°) and lives
+inside a `<p:grpSp>` whose `ext = 1827900 × 1404064` but
+`chExt = 1827900 × 2399700` — `chExt.cy` matches the post-rotation
+visual height. After import the arrow renders ~503 px tall in a
+~295 px slot, breaching the orange "Library" rect that sits above it.
+
+## Root Cause
+
+`applyGroupTransform` in `packages/slides/src/import/pptx/group.ts`
+extracts per-axis scales from the cumulative matrix and applies them
+to the **unrotated** `frame.w` / `frame.h`:
+
+```ts
+const scaleX = Math.sqrt(t.a*t.a + t.b*t.b);  // 1.0
+const scaleY = Math.sqrt(t.c*t.c + t.d*t.d);  // 0.585
+const w = frame.w * scaleX;                   // unrotated dim, wrong axis
+const h = frame.h * scaleY;
+```
+
+`frame.rotation` is left out of the sizing math entirely. For a 90°
+rotated child, the visually-vertical extent is `frame.w` and the
+visually-horizontal extent is `frame.h` — so the X/Y scales have to be
+swapped, otherwise the visual bbox after rotation no longer matches the
+group's `ext`. For 0° / 180° (current happy path) no swap is needed,
+which is why every existing test passed.
+
+For arbitrary rotations the visual bbox after non-uniform scale is a
+parallelogram; the closest representable rotated rectangle is found by
+solving:
+
+```
+w' · |cos θ| + h' · |sin θ| = (w · |cos θ| + h · |sin θ|) · scaleX
+w' · |sin θ| + h' · |cos θ| = (w · |sin θ| + h · |cos θ|) · scaleY
+```
+
+The system is singular at 45° + k·90° (cos² = sin²); for those we fall
+back to the current behaviour since no rotated rectangle can satisfy
+both visual extents under non-uniform scale. The same fallback fires
+when the closed-form solution turns negative (the regime where no
+*positive-sided* rectangle satisfies both extents) — see review note
+from `requesting-code-review` pass.
+
+## Plan
+
+- [x] Add a failing unit test in `test/import/pptx/group.test.ts`
+      covering a 90°-rotated child inside a group with non-uniform
+      `chExt`, asserting the post-transform visual bbox matches the
+      group `ext`.
+- [x] Implement the visual-bbox-aware scaling in `applyGroupTransform`
+      (general 2×2 solve, falling back to the current `w*scaleX` /
+      `h*scaleY` when the determinant is degenerate).
+- [x] Add a 270° regression test to confirm symmetry. *(Replaced
+      after review with a non-axis-aligned 30° solver test and a
+      negative-fallback test; pure 270° is degenerate under `|cos|·
+      |sin|` and didn't exercise the general solver.)*
+- [x] Existing tests cover the rotation=0 / uniform-scale fast paths;
+      no extra test needed there.
+- [x] Apply review feedback: negative-w/h fallback, off-axis solver
+      test, looser singular threshold (1e-6), naming polish, abs-cos
+      doc-comment clarification.
+- [x] `pnpm verify:fast` green (48 files, 792 tests passing).
+- [ ] Manual smoke: re-import `Yorkie, 캐즘 뛰어넘기.pptx`, verify
+      slide 7 arrow now fits inside its group. *(Deferred to PR
+      review — covered analytically by the new unit test that asserts
+      the visual bbox matches the group ext using the exact EMU values
+      from slide 7.)*
+- [x] Capture lessons.
+- [ ] Open PR.
+
+## Notes
+
+- The deck size for this repro is 9144000 × 5143500 EMU (standard
+  widescreen 16:9), so `scale.sx ≈ scale.sy` — the non-uniformity comes
+  purely from the inner group's `chExt`/`ext` ratio, not the deck-level
+  scale. The fix has to live in `applyGroupTransform`, not `parseXfrm`.
+- Only the inner-most group is affected here; the bug surfaces whenever
+  `(localSx, localSy)` are non-uniform AND the child carries its own
+  rotation that is not a multiple of 180°.
+- Connectors don't carry their own `rotation`, so they are unaffected.

--- a/packages/slides/src/import/pptx/group.ts
+++ b/packages/slides/src/import/pptx/group.ts
@@ -102,6 +102,22 @@ export function composeGroupTransform(
  * world frame. The element's own rotation is preserved; the group's
  * accumulated rotation is added on top so the renderer's "rotate
  * around own center" maps to the correct visual orientation.
+ *
+ * When the child carries its own rotation θ and the group applies a
+ * non-uniform per-axis scale, the child's `w` / `h` are *not* the
+ * dimensions that get directly scaled — the visible (post-rotation)
+ * extents are. PowerPoint / Google Slides emit `<a:chExt>` to match
+ * the rotated visual bbox of their children, so we have to find new
+ * `w'` / `h'` such that the rotated rectangle's visual bbox after
+ * import equals the visual bbox before import multiplied per-axis:
+ *
+ *   w' · |cos θ| + h' · |sin θ| = (w · |cos θ| + h · |sin θ|) · scaleX
+ *   w' · |sin θ| + h' · |cos θ| = (w · |sin θ| + h · |cos θ|) · scaleY
+ *
+ * Determinant = cos² - sin² = cos(2θ). The system degenerates at
+ * θ ≡ 45° (mod 90°); for those rare cases a rotated rectangle cannot
+ * satisfy both visual extents under non-uniform scale, so we fall
+ * back to the unrotated scaling (`w*scaleX`, `h*scaleY`).
  */
 export function applyGroupTransform(frame: Frame, t: GroupTransform): Frame {
   // Apply matrix to the child's center.
@@ -115,8 +131,8 @@ export function applyGroupTransform(frame: Frame, t: GroupTransform): Frame {
   // still produce a reasonable approximation.
   const scaleX = Math.sqrt(t.a * t.a + t.b * t.b);
   const scaleY = Math.sqrt(t.c * t.c + t.d * t.d);
-  const w = frame.w * scaleX;
-  const h = frame.h * scaleY;
+
+  const { w, h } = scaleRotatedFrame(frame.w, frame.h, frame.rotation, scaleX, scaleY);
 
   return {
     x: cxWorld - w / 2,
@@ -125,6 +141,46 @@ export function applyGroupTransform(frame: Frame, t: GroupTransform): Frame {
     h,
     rotation: frame.rotation + t.rotation,
   };
+}
+
+function scaleRotatedFrame(
+  w: number,
+  h: number,
+  rotation: number,
+  scaleX: number,
+  scaleY: number,
+): { w: number; h: number } {
+  // Fast path: uniform scale, or no rotation (θ ≡ 0 mod 180°). In both
+  // cases the visual bbox aligns with (w, h), so per-axis scaling is
+  // exact and matches the prior behaviour.
+  if (scaleX === scaleY || rotation === 0) {
+    return { w: w * scaleX, h: h * scaleY };
+  }
+  // |cos θ| / |sin θ| — the visual bbox is rotation-quadrant-invariant
+  // (θ and θ + π/2 swap the axes rather than negate them), so the
+  // solver only cares about absolute values.
+  const cosA = Math.abs(Math.cos(rotation));
+  const sinA = Math.abs(Math.sin(rotation));
+  // det = cos² - sin² = cos(2θ). Near zero at 45° / 135° / ...; no
+  // axis-aligned rectangle can hit both target extents in that case.
+  const det = cosA * cosA - sinA * sinA;
+  if (Math.abs(det) < 1e-6) {
+    return { w: w * scaleX, h: h * scaleY };
+  }
+  const A = (w * cosA + h * sinA) * scaleX;
+  const B = (w * sinA + h * cosA) * scaleY;
+  const wNew = (cosA * A - sinA * B) / det;
+  const hNew = (cosA * B - sinA * A) / det;
+  // A negative wNew / hNew means the visual-bbox invariant can't be
+  // satisfied by an axis-aligned rectangle with positive sides under
+  // this scale + rotation combo (same failure mode as the singular
+  // det; the algebraic solver flips signs at the boundary). Fall back
+  // to per-axis scaling so downstream renderers / hit-test math never
+  // see a negative frame extent.
+  if (wNew <= 0 || hNew <= 0) {
+    return { w: w * scaleX, h: h * scaleY };
+  }
+  return { w: wNew, h: hNew };
 }
 
 /**

--- a/packages/slides/test/import/pptx/group.test.ts
+++ b/packages/slides/test/import/pptx/group.test.ts
@@ -103,6 +103,126 @@ describe('composeGroupTransform + applyGroupTransform', () => {
     expect(world.rotation).toBeCloseTo(Math.PI / 2, 9);
   });
 
+  it('keeps a 90°-rotated child inside the group when chExt sizes the rotated bbox', () => {
+    // Pattern emitted by PowerPoint / Google Slides when you rotate a
+    // shape inside a group: the child's <a:ext> is the *unrotated* box
+    // (wide), but the group's <a:chExt> matches the *rotated visual*
+    // bbox (tall). The visible width/height of the child must equal
+    // the group's `ext` after import — otherwise the rotated shape
+    // overflows its enclosing group.
+    const grp = grpSp(`<p:grpSp>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="4084750" y="2000661"/>
+          <a:ext cx="1827900" cy="1404064"/>
+          <a:chOff x="4572084" y="1597469"/>
+          <a:chExt cx="1827900" cy="2399700"/>
+        </a:xfrm>
+      </p:grpSpPr>
+    </p:grpSp>`);
+    const t = composeGroupTransform(IDENTITY_TRANSFORM, grp, SCALE);
+
+    // Child shape: <a:xfrm rot="5400000">, off (4286184, 1883369),
+    // ext (2399700, 1827900) — i.e. wide-then-rotated-tall.
+    const child = {
+      x: 4286184 * SCALE.sx,
+      y: 1883369 * SCALE.sy,
+      w: 2399700 * SCALE.sx,
+      h: 1827900 * SCALE.sy,
+      rotation: Math.PI / 2,
+    };
+    const world = applyGroupTransform(child, t);
+
+    // The visual bbox (post-rotation) for a rect (w, h) rotated by θ is
+    // (|w·cosθ| + |h·sinθ|) × (|w·sinθ| + |h·cosθ|). For θ = 90° that
+    // simplifies to (h × w). The group's `ext` is (1827900, 1404064)
+    // EMU — the post-import visual width and height must match.
+    const visualW = Math.abs(world.h);
+    const visualH = Math.abs(world.w);
+    expect(visualW).toBeCloseTo(1827900 * SCALE.sx, 6);
+    expect(visualH).toBeCloseTo(1404064 * SCALE.sy, 6);
+
+    // Centre still lands at the group centre.
+    expect(world.x + world.w / 2).toBeCloseTo(
+      (4084750 + 1827900 / 2) * SCALE.sx,
+      6,
+    );
+    expect(world.y + world.h / 2).toBeCloseTo(
+      (2000661 + 1404064 / 2) * SCALE.sy,
+      6,
+    );
+    expect(world.rotation).toBeCloseTo(Math.PI / 2, 9);
+  });
+
+  it('preserves the visual bbox for an off-axis rotation under non-uniform scale', () => {
+    // Non-axis-aligned rotation actually exercises the general 2×2
+    // solver (the 90° case is degenerate — cos·sin = 0 — and matches
+    // the prior swap-scales behaviour).
+    const grp = grpSp(`<p:grpSp>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="1200000" cy="900000"/>
+          <a:chOff x="0" y="0"/>
+          <a:chExt cx="1000000" cy="1000000"/>
+        </a:xfrm>
+      </p:grpSpPr>
+    </p:grpSp>`);
+    const t = composeGroupTransform(IDENTITY_TRANSFORM, grp, SCALE);
+
+    const theta = Math.PI / 6; // 30°
+    const w = 10 * SCALE.sx;
+    const h = 10 * SCALE.sy;
+    const child = { x: 0, y: 0, w, h, rotation: theta };
+    const world = applyGroupTransform(child, t);
+
+    // Group's per-axis scale is (1.2, 0.9). The visual bbox of the
+    // rotated rectangle pre-transform is (w·cos + h·sin, w·sin + h·cos);
+    // post-transform it should be that scaled per-axis.
+    const cosA = Math.cos(theta);
+    const sinA = Math.sin(theta);
+    const expectedVisualW = (w * cosA + h * sinA) * 1.2;
+    const expectedVisualH = (w * sinA + h * cosA) * 0.9;
+    const actualVisualW = world.w * cosA + world.h * sinA;
+    const actualVisualH = world.w * sinA + world.h * cosA;
+    expect(actualVisualW).toBeCloseTo(expectedVisualW, 6);
+    expect(actualVisualH).toBeCloseTo(expectedVisualH, 6);
+    expect(world.w).toBeGreaterThan(0);
+    expect(world.h).toBeGreaterThan(0);
+  });
+
+  it('falls back to per-axis scaling when the solver would produce a negative side', () => {
+    // For sufficiently aspect-mismatched scale at off-axis rotations,
+    // the closed-form solution turns negative — no axis-aligned
+    // rectangle satisfies both visual extents under that scale + θ
+    // combo. Fallback: scale unrotated dims, which is no-worse-than
+    // the pre-fix behaviour for this degenerate case.
+    const grp = grpSp(`<p:grpSp>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="1000000" cy="2000000"/>
+          <a:chOff x="0" y="0"/>
+          <a:chExt cx="1000000" cy="1000000"/>
+        </a:xfrm>
+      </p:grpSpPr>
+    </p:grpSp>`);
+    const t = composeGroupTransform(IDENTITY_TRANSFORM, grp, SCALE);
+
+    const child = {
+      x: 0,
+      y: 0,
+      w: 10 * SCALE.sx,
+      h: 20 * SCALE.sy,
+      rotation: Math.PI / 6,
+    };
+    const world = applyGroupTransform(child, t);
+
+    // scaleX = 1, scaleY = 2 → fallback path: w' = w·scaleX, h' = h·scaleY.
+    expect(world.w).toBeCloseTo(10 * SCALE.sx * 1, 6);
+    expect(world.h).toBeCloseTo(20 * SCALE.sy * 2, 6);
+  });
+
   it('composes nested rotated groups via full matrix multiplication', () => {
     // Outer group rotated 90° around (1000, 1000):
     //   any local point (lx, ly) → (1000 + (1000 - ly), 1000 + (lx - 1000))


### PR DESCRIPTION
## Summary

- `applyGroupTransform` previously scaled a child's unrotated `w`/`h` by the group's per-axis scales and ignored `frame.rotation`. For shapes with their own rotation living inside a `<p:grpSp>` whose `chExt` is sized for the **rotated visual** bbox (the standard PowerPoint / Google Slides emission), this produced shapes that overflowed their group. On slide 7 of a real customer deck, a 90°-rotated `rightArrowCallout` rendered ~503 px tall in a ~295 px slot and breached the rectangle above it.
- Fix: solve a 2×2 linear system for new `(w', h')` such that the rotated rectangle's visual bbox matches the pre-import visual bbox scaled per-axis. Uniform-scale and zero-rotation cases short-circuit to the prior `w*scaleX`, `h*scaleY` (preserves all prior numerical behaviour). Singular determinants (45° + k·90°) and the negative-w'/h' regime (off-axis with sufficiently mismatched scale) fall back to per-axis scaling.
- Three new unit tests: the slide-7 90° case using the exact EMU values, an off-axis (30°) solver test that exercises the general path with positive solutions, and a negative-fallback test that locks in the bail-out behaviour.

See `docs/tasks/active/20260517-pptx-rotated-child-group-scale-todo.md` and `…-lessons.md` for the full root-cause derivation and review-pass takeaways.

## Test plan

- [x] `pnpm verify:fast` green (frontend 1268, slides 1006, backend 191, docs 792 tests).
- [x] All 8 group-transform unit tests pass, including the three new ones.
- [ ] Manual smoke: re-import `Yorkie, 캐즘 뛰어넘기.pptx`, verify slide 7 arrow now fits inside its enclosing group. (Strong analytical evidence already in the 90° unit test, which uses the exact EMU values from slide 7.)
- [ ] Regression watch: check that other rotated shapes inside groups across the rest of the deck still look correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)