### PR TITLE
Select precise shape and add connector hit-test

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides precise shape hit test (2026-05-19) | [20260519-slides-precise-shape-hit-test-todo.md](./active/20260519-slides-precise-shape-hit-test-todo.md) | - |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | - |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
 | slides package mvp (2026-05-05) | [20260505-slides-package-mvp-todo.md](./active/20260505-slides-package-mvp-todo.md) | [20260505-slides-package-mvp-lessons.md](./active/20260505-slides-package-mvp-lessons.md) |
@@ -30,4 +31,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 195
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: docs comments followup (2026-05-17)
+Latest active task: slides precise shape hit test (2026-05-19)

--- a/docs/tasks/active/20260519-slides-precise-shape-hit-test-todo.md
+++ b/docs/tasks/active/20260519-slides-precise-shape-hit-test-todo.md
@@ -163,3 +163,67 @@ a new design doc — TBD after implementation. Decide based on size:
   - Insert line connector → click off the line by 20px → no select.
     Click within 4px → selects.
   - Rotated rect → corner of bbox is dead, body selects.
+
+## Phase 2 — precision pass (heart, smileyFace, brackets)
+
+### Why a second pass
+
+The v1 commit (`3657c92e`) routed filled shapes through
+`isPointInPath`, but curved shapes still felt imprecise. Two reasons:
+
+1. **AA fringe + round-join extension.** The renderer fills the
+   polyline interior and then strokes with `lineJoin: 'round'`. The
+   visible boundary is ~1-2 px outside the fill polygon. Clicks on
+   that visible band fell outside `isPointInPath` and missed.
+2. **Stroke-only shapes fell back to bbox.** Brackets / braces (in
+   `OPEN_PATH_KINDS`) and unfilled outlines had huge empty bbox
+   regions that selected the shape.
+
+### Approach
+
+Add an `isPointInStroke` fallback after `isPointInPath`:
+- `lineWidth = stroke.width + 2 * tolerance` (defaults to a 12 px
+  band around the polyline outline; matches a ~6 viewport-px halo at
+  default zoom).
+- For unfilled / `OPEN_PATH_KINDS` shapes, this becomes the primary
+  test, replacing the v1 bbox fallback.
+- An entirely empty shape (no `fill`, no `stroke`) is invisible and
+  no longer selectable — `hitShape` returns `false` instead of
+  bbox-true.
+
+### Test environment
+
+`view/canvas/test-canvas-env.ts` got an `isPointInStroke` shim:
+- `distanceToSegment` for subpath polylines.
+- 32-sample polyline distance for `ellipse` ops.
+- 4-edge distance for `rect` ops.
+
+`makeFakeCanvasCtx` (jsdom prototype patch) and `createTestCanvas`
+(explicit factory) both expose the new method so editor.test.ts and
+new precision tests work.
+
+### New tests
+
+In `select.test.ts > selectAt — precise shape geometry`:
+- stroke-only ellipse — outline click hits, bbox corner misses.
+- smileyFace — interior hit, 3-px-outside-fill hit (AA band).
+- heart — lobe centre + just-above-lobe-top hit; dip empty area
+  misses.
+- leftBracket — bbox middle (far from the C-shape) misses.
+
+V1's "falls back to bbox for stroke-only" assertion was removed —
+v2 tightens that path.
+
+### Trade-offs
+
+- The tolerance band trades exact-edge precision for "Google
+  Slides-feels-natural" click forgiveness. Defaults to 6 logical
+  pixels, scaled by the editor's zoom so the viewport-px feel is
+  ~constant.
+- Anti-aliased rounded joins on heart's V tip still extend a tiny
+  bit beyond `isPointInStroke`'s rectangular cap result. Sub-pixel
+  at slide-scale, ignored.
+- Ellipse outline distance in the test shim is a 32-segment
+  polyline; chord error is sub-pixel for typical shape sizes but
+  large for extreme aspect ratios. Tests pick points well clear of
+  the boundary to stay deterministic.

--- a/docs/tasks/active/20260519-slides-precise-shape-hit-test-todo.md
+++ b/docs/tasks/active/20260519-slides-precise-shape-hit-test-todo.md
@@ -1,0 +1,165 @@
+# Slides — precise shape & connector hit-test
+
+## Problem
+
+Today every slides element is selected by its axis-aligned bounding
+rect (`containsPoint` in `packages/slides/src/model/frame.ts:9`,
+called from `interactions/select.ts:40` and
+`view/editor/editor.ts:1854`).
+
+That feels wrong in two ways:
+
+1. **Filled shapes** — clicking the empty corners of an ellipse,
+   diamond, star, etc. still selects them, even though the user
+   visually clicked off the shape.
+2. **Connectors (lines/arrows)** — far worse, because a long diagonal
+   line has a huge bbox; large empty regions select the line.
+
+## Goal
+
+Selection should be based on the **drawn area**, with a small touch
+tolerance for thin geometry.
+
+- `ShapeElement` (filled / closed) — hit iff the point is inside the
+  Path2D produced by the registered `PATH_BUILDERS` builder, in
+  element-local coordinates (after un-rotation / un-flip).
+- `ShapeElement` (stroke-only or `OPEN_PATH_KINDS` — brackets / braces
+  / unfilled outlines) — hit iff the point is within
+  `stroke.width / 2 + tolerance` of the path's polyline approximation.
+- `ConnectorElement` — hit iff the point is within
+  `stroke.width / 2 + tolerance` of the routed segments. Endpoints +
+  arrowhead area count as hits.
+- `TextElement` / `ImageElement` / action buttons — keep bbox hit
+  (`containsPoint`). These are rectangular by intent.
+
+Tolerance baseline: **6 px** at logical-slide coordinates (i.e. the
+same coord space `selectAt` already takes). Mobile already passes a
+larger handle tolerance separately — we will reuse the same per-shell
+constant for the line tolerance.
+
+## Plan
+
+### 1. New module: `view/editor/hit-test/element-hit.ts`
+
+Single entry point used by both `selectAt` and `editor.ts`:
+
+```ts
+hitTestElement(
+  el: Element,
+  px: number, py: number,           // world / slide-logical
+  ctx: { isPointInPath: ... },      // 2d ctx, real or test shim
+  opts?: { tolerance?: number; elements?: ReadonlyMap<string, Element> },
+): boolean
+```
+
+- `text` / `image` → `containsPoint(el.frame, px, py)`.
+- `shape` (action buttons) → `containsPoint` (special-cased renderer,
+  always rectangular).
+- `shape` (filled, registered in `PATH_BUILDERS`):
+  - `local = toLocal(frame, {px, py})`.
+  - Apply flip inverse: `lx = flipH ? w - local.x : local.x`,
+    `ly = flipV ? h - local.y : local.y`.
+  - Run `ctx.isPointInPath(path, lx, ly, fillRule)` where `fillRule`
+    is `'evenodd'` for `EVENODD_KINDS` (currently `donut`) else
+    `'nonzero'`.
+- `shape` (no `data.fill` OR `OPEN_PATH_KINDS`):
+  - Approximate the Path2D's outline as polyline segments and run
+    `distanceToPolyline(local, segments)`; hit iff
+    `<= stroke.width / 2 + tolerance`.
+  - The path builders use a closed subset of Path2D ops (rect,
+    ellipse, moveTo/lineTo, quadraticCurveTo, bezierCurveTo, arc) —
+    same subset that `test-canvas-env.ts` already approximates. We
+    will introduce a small `Path2D → polyline` extractor in the same
+    module (NOT installed globally) by intercepting these ops through
+    a recording Path2D wrapper. Builders take a `Path2D` constructor
+    via the global, so we cannot intercept without re-running the
+    builder against a recording shim.
+  - Pragmatic v1: only run the stroke-distance branch for unfilled
+    shapes (rare in real decks) and brackets/braces (handful of
+    kinds). For brackets/braces we hard-code the polyline matching
+    each builder's geometry — they are simple. For "stroke-only on a
+    normally-filled shape" we fall back to the path's bbox (existing
+    behaviour) and revisit if it becomes a complaint.
+- `connector`:
+  - Resolve endpoints via `resolveEndpoint`, route via `routeStraight`
+    (today the only routing).
+  - Returns `points: Point[]`. `hit = distanceToPolyline({px,py}, points)`
+    `<= stroke.width / 2 + tolerance`.
+  - Future routings (`elbow`, `curved` — currently unused) follow the
+    same pattern once `routeElbow` / `routeCurved` land.
+
+### 2. Wire it into the two `topmostUnderPoint` sites
+
+- `packages/slides/src/view/editor/interactions/select.ts:38` —
+  replace `containsPoint(...)` call with `hitTestElement(...)`.
+  Take a 2d context + tolerance from the caller; `selectAt` grows a
+  new options arg.
+- `packages/slides/src/view/editor/editor.ts:854` — same. Both
+  callsites in `editor.ts` (`onContextMenu`, `onPointerDown`,
+  `onDoubleClick`) already have access to `this.renderer` / a canvas
+  context. We will pass `this.options.canvas.getContext('2d')` (cached
+  reference) and the editor's per-shell tolerance.
+
+### 3. Tests
+
+- `packages/slides/test/view/editor/interactions/select.test.ts` —
+  extend with:
+  - Click inside ellipse bbox but outside the ellipse → no hit.
+  - Click on diamond's empty corner → no hit; click on its centre → hit.
+  - Click on a rotated rect's bbox corner that lies outside the
+    rotated rect → no hit.
+  - Click on flipped shape (asymmetric, e.g. rightArrow) — hit/miss
+    follow visual geometry after flip.
+- New `packages/slides/test/view/editor/connector-hit.test.ts`:
+  - Straight connector from (10,10) to (200,10), stroke width 2:
+    point (100, 12) is a hit (within tolerance); (100, 30) is a miss.
+  - Endpoint area is a hit.
+  - Diagonal connector: a point far inside its bbox but far from the
+    line is a miss.
+- Existing `select.test.ts` rect-based tests stay green (rect uses
+  `buildRect` — `isPointInPath` should agree with bbox for axis-
+  aligned rects).
+- Use `createTestCanvas` from `view/canvas/test-canvas-env.ts` —
+  already has Path2D shim + `isPointInPath`.
+
+### 4. Design note
+
+Add a short section to `docs/design/slides/slides.md` (Hit testing) or
+a new design doc — TBD after implementation. Decide based on size:
+- < 1 page → fold into `slides.md`.
+- otherwise → `docs/design/slides/slides-hit-test.md`.
+
+## Out of scope
+
+- New `EVENODD_KINDS` entries beyond `donut`. We will trust the
+  renderer's existing list.
+- Tolerance UI / configurability — single constant in editor for now.
+- Elbow / curved connector routing (not implemented yet — see
+  `routing.ts`).
+- Reusing the precise hit-test for marquee / lasso selection. Lasso
+  already uses bbox intersection; bbox is acceptable for marquee.
+
+## Risks
+
+- **Builder side-effects at hit-test time** — path builders are pure
+  and cheap (no allocations beyond Path2D). Hit-test recomputes the
+  Path2D per click; that is fine.
+- **`isPointInPath` rounding on path boundaries** — tolerance of a
+  pixel either side is acceptable for click; we will not pad the
+  filled path. Tests pick interior / exterior points well clear of
+  the boundary.
+- **Open-path shapes other than brackets/braces** — if a normally
+  filled shape has `fill: undefined` (stroke-only outline), the v1
+  falls back to bbox. Document this in the design note. Real decks
+  rarely render stroke-only ovals.
+
+## Verification
+
+- `pnpm test --filter @wafflebase/slides` green.
+- `pnpm verify:fast` green.
+- Manual smoke in `pnpm dev`:
+  - Insert ellipse → click corners → no select. Click centre →
+    selects.
+  - Insert line connector → click off the line by 20px → no select.
+    Click within 4px → selects.
+  - Rotated rect → corner of bbox is dead, body selects.

--- a/packages/slides/src/view/canvas/shape-renderer.ts
+++ b/packages/slides/src/view/canvas/shape-renderer.ts
@@ -16,7 +16,7 @@ const placeholderWarned = new Set<string>();
  * kinds so concentric counter-clockwise sub-paths punch holes (donut)
  * rather than filling the whole interior.
  */
-const EVENODD_KINDS: ReadonlySet<ShapeKind> = new Set(['donut']);
+export const EVENODD_KINDS: ReadonlySet<ShapeKind> = new Set(['donut']);
 
 /**
  * Shape kinds whose `PathBuilder` returns an open (un-`closePath`'d)
@@ -32,7 +32,7 @@ const EVENODD_KINDS: ReadonlySet<ShapeKind> = new Set(['donut']);
  * stroke-only brackets), but a future deck with a filled bracket
  * would silently render incorrectly without this guard.
  */
-const OPEN_PATH_KINDS: ReadonlySet<ShapeKind> = new Set([
+export const OPEN_PATH_KINDS: ReadonlySet<ShapeKind> = new Set([
   'leftBracket',
   'rightBracket',
   'leftBrace',

--- a/packages/slides/src/view/canvas/test-canvas-env.ts
+++ b/packages/slides/src/view/canvas/test-canvas-env.ts
@@ -99,6 +99,23 @@ function makeFakeCanvasCtx(): unknown {
     ): boolean {
       return isPointInPathImpl(path as unknown as TestPath2D, x, y, fillRule);
     },
+    // The hit-test also falls back to `isPointInStroke` for clicks
+    // near a stroked outline (heart, smileyFace, brackets, …). Reads
+    // the proxy's own `lineWidth` so callers can set it before the
+    // call as they would on a real ctx.
+    isPointInStroke(
+      this: { lineWidth: number },
+      path: Path2D,
+      x: number,
+      y: number,
+    ): boolean {
+      return isPointInStrokeImpl(
+        path as unknown as TestPath2D,
+        x,
+        y,
+        this.lineWidth,
+      );
+    },
   };
 }
 
@@ -398,6 +415,100 @@ function isPointInPathImpl(
   return false;
 }
 
+function distanceToSegment(
+  px: number, py: number,
+  ax: number, ay: number,
+  bx: number, by: number,
+): number {
+  const dx = bx - ax;
+  const dy = by - ay;
+  const lenSq = dx * dx + dy * dy;
+  let t = lenSq === 0 ? 0 : ((px - ax) * dx + (py - ay) * dy) / lenSq;
+  if (t < 0) t = 0;
+  else if (t > 1) t = 1;
+  const cx = ax + t * dx;
+  const cy = ay + t * dy;
+  return Math.hypot(px - cx, py - cy);
+}
+
+/**
+ * Sub-pixel-accurate distance from a point to the outline of one path
+ * op. Used by `isPointInStrokeImpl`. Ellipses are sampled with 32
+ * polyline segments — same density the curved-shape builders already
+ * use for visible rendering, so the test answer matches the browser's
+ * to within a chord error.
+ */
+function opOutlineDistance(op: Op, x: number, y: number): number {
+  if (op.kind === 'rect') {
+    const segs: Array<[number, number, number, number]> = [
+      [op.x, op.y, op.x + op.w, op.y],
+      [op.x + op.w, op.y, op.x + op.w, op.y + op.h],
+      [op.x + op.w, op.y + op.h, op.x, op.y + op.h],
+      [op.x, op.y + op.h, op.x, op.y],
+    ];
+    let min = Infinity;
+    for (const [ax, ay, bx, by] of segs) {
+      const d = distanceToSegment(x, y, ax, ay, bx, by);
+      if (d < min) min = d;
+    }
+    return min;
+  }
+  if (op.kind === 'ellipse') {
+    const N = 32;
+    let min = Infinity;
+    let prev = { x: op.cx + op.rx, y: op.cy };
+    for (let i = 1; i <= N; i++) {
+      const t = (i / N) * Math.PI * 2;
+      const next = {
+        x: op.cx + op.rx * Math.cos(t),
+        y: op.cy + op.ry * Math.sin(t),
+      };
+      const d = distanceToSegment(x, y, prev.x, prev.y, next.x, next.y);
+      if (d < min) min = d;
+      prev = next;
+    }
+    return min;
+  }
+  // subpath
+  if (op.points.length === 0) return Infinity;
+  let min = Infinity;
+  for (let i = 1; i < op.points.length; i++) {
+    const a = op.points[i - 1];
+    const b = op.points[i];
+    const d = distanceToSegment(x, y, a.x, a.y, b.x, b.y);
+    if (d < min) min = d;
+  }
+  if (op.closed && op.points.length >= 2) {
+    const a = op.points[op.points.length - 1];
+    const b = op.points[0];
+    const d = distanceToSegment(x, y, a.x, a.y, b.x, b.y);
+    if (d < min) min = d;
+  }
+  return min;
+}
+
+/**
+ * Point-in-stroke test approximating browser `isPointInStroke`. A
+ * point hits the stroked outline iff its distance to ANY op's outline
+ * is `≤ lineWidth / 2`. We ignore `lineJoin` / `lineCap` because the
+ * extra coverage from rounded joins / caps is sub-pixel at typical
+ * stroke widths — and our hit-test callers add a tolerance pad on top
+ * of `lineWidth` anyway.
+ */
+function isPointInStrokeImpl(
+  path: TestPath2D,
+  x: number,
+  y: number,
+  lineWidth: number,
+): boolean {
+  path.finalize();
+  const half = lineWidth / 2;
+  for (const op of path.ops) {
+    if (opOutlineDistance(op, x, y) <= half) return true;
+  }
+  return false;
+}
+
 // Install the global Path2D shim (idempotent). Builders call
 // `new Path2D()` at module load time, so the global must be in place
 // before any builder module is imported.
@@ -419,6 +530,11 @@ if (typeof (globalThis as { Path2D?: unknown }).Path2D === 'undefined') {
  */
 export interface TestCanvas2DContext {
   isPointInPath(path: Path2D, x: number, y: number, fillRule?: FillRule): boolean;
+  /**
+   * Distance-based stroke hit-test against the polyline-approximated
+   * outline. Honours the current `lineWidth`, like a real ctx.
+   */
+  isPointInStroke(path: Path2D, x: number, y: number): boolean;
   // Mutable state — assignable so renderers that record line styles
   // can be inspected by tests after the call.
   lineWidth: number;
@@ -458,6 +574,14 @@ export function createTestCanvas(
           fillRule: FillRule = 'nonzero',
         ): boolean {
           return isPointInPathImpl(path as unknown as TestPath2D, x, y, fillRule);
+        },
+        isPointInStroke(path: Path2D, x: number, y: number): boolean {
+          return isPointInStrokeImpl(
+            path as unknown as TestPath2D,
+            x,
+            y,
+            ctx.lineWidth,
+          );
         },
         save(): void {},
         restore(): void {},

--- a/packages/slides/src/view/canvas/test-canvas-env.ts
+++ b/packages/slides/src/view/canvas/test-canvas-env.ts
@@ -85,6 +85,20 @@ function makeFakeCanvasCtx(): unknown {
     measureText: (text: string): { width: number } => ({ width: text.length * 8 }),
 
     drawImage: noop,
+
+    // The slides editor calls `isPointInPath` from its click hit-test
+    // (`view/editor/element-hit.ts`). Real browser canvases provide it;
+    // jsdom does not, so route through the same Path2D shim used by
+    // `createTestCanvas` so editor.test.ts can dispatch pointerdown
+    // events without crashing.
+    isPointInPath(
+      path: Path2D,
+      x: number,
+      y: number,
+      fillRule: FillRule = 'nonzero',
+    ): boolean {
+      return isPointInPathImpl(path as unknown as TestPath2D, x, y, fillRule);
+    },
   };
 }
 

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1,5 +1,6 @@
 import type { Element, Frame, ShapeKind } from '../../model/element';
 import { combinedBoundingBox } from '../../model/frame';
+import { DEFAULT_HIT_TOLERANCE, type HitTestCtx } from './element-hit';
 import { SLIDE_HEIGHT, SLIDE_WIDTH, type Slide } from '../../model/presentation';
 import type { SlidesStore } from '../../store/store';
 import { SlideRenderer, type SlideRendererOptions } from '../canvas/slide-renderer';
@@ -377,11 +378,19 @@ class SlidesEditorImpl implements SlidesEditor {
   // by Node's `--experimental-strip-types` (used by the frontend test
   // runner via `frontend/tests/resolve-hooks.mjs`).
   private options: SlidesEditorOptions;
+  /**
+   * 2D context kept for click-time `isPointInPath` lookups. Reuses the
+   * renderer's canvas context so we don't allocate a second one.
+   */
+  private hitCtx: HitTestCtx;
+  /** Per-shell click tolerance (slide-logical pixels). */
+  private hitTolerance = DEFAULT_HIT_TOLERANCE;
 
   constructor(options: SlidesEditorOptions) {
     this.options = options;
     const ctx = options.canvas.getContext('2d');
     if (!ctx) throw new Error('SlidesEditor: canvas has no 2D context');
+    this.hitCtx = ctx;
     this.renderer = new SlideRenderer(ctx, options);
     this.currentId = options.store.read().slides[0]?.id;
     this.mountTextBox = options.mountTextBox ?? mountSlidesTextBox;
@@ -993,7 +1002,7 @@ class SlidesEditorImpl implements SlidesEditor {
     const slide = this.currentSlide();
     if (!slide) return;
     const { x, y } = this.clientToLogical(e.clientX, e.clientY);
-    const hitResult = hitTestSlide(slide, x, y);
+    const hitResult = hitTestSlide(slide, x, y, this.hitOptions());
     if (hitResult === null) {
       showContextMenu(document.body, this.canvasContextItems(x, y), e.clientX, e.clientY);
       return;
@@ -1157,7 +1166,7 @@ class SlidesEditorImpl implements SlidesEditor {
     // Hit-test against an element first. Use the depth-aware hitTestSlide
     // (which descends into groups) and route through Selection.click so the
     // drill-in state machine picks the right element at the current scope.
-    const hitResult = hitTestSlide(slide, x, y);
+    const hitResult = hitTestSlide(slide, x, y, this.hitOptions());
     if (hitResult !== null) {
       const mods = { shift: e.shiftKey };
       // If the scope-level element under the pointer is already in the
@@ -1194,7 +1203,7 @@ class SlidesEditorImpl implements SlidesEditor {
     const slide = this.currentSlide();
     if (!slide) return;
     const { x, y } = this.clientToLogical(e.clientX, e.clientY);
-    const hitResult = hitTestSlide(slide, x, y);
+    const hitResult = hitTestSlide(slide, x, y, this.hitOptions());
     if (hitResult === null) return;
     // The text-box editor's container lives inside the overlay, so a
     // dblclick *inside* the active editor bubbles up here. Re-entering
@@ -1756,6 +1765,18 @@ class SlidesEditorImpl implements SlidesEditor {
     return {
       x: (clientX - rect.left) / scale,
       y: (clientY - rect.top) / scale,
+    };
+  }
+
+  /**
+   * Common arguments for `selectAt` / `topmostUnderPoint`. Connector
+   * tolerance scales with the editor's zoom so a 6-logical-pixel
+   * threshold stays at a roughly-constant 6 viewport pixels.
+   */
+  private hitOptions(): { ctx: HitTestCtx; tolerance: number } {
+    return {
+      ctx: this.hitCtx,
+      tolerance: this.hitTolerance / this.scale(),
     };
   }
 

--- a/packages/slides/src/view/editor/element-hit.ts
+++ b/packages/slides/src/view/editor/element-hit.ts
@@ -84,16 +84,18 @@ function hitShape(
   opts: HitTestOptions,
 ): boolean {
   const frame = el.frame;
+  // Action buttons paint via a dedicated renderer (`drawActionButton`)
+  // that is NOT in PATH_BUILDERS — they have a body + glyph and no
+  // path-based outline to widen. Selection stays strict bbox so the
+  // click region doesn't pick up the tolerance halo other shapes use
+  // for AA-fringe forgiveness.
+  if (isActionButton(el.data.kind)) return containsPoint(frame, px, py);
+
   const tol = opts.tolerance ?? DEFAULT_HIT_TOLERANCE;
   // Fast bbox reject with a tolerance pad so clicks just outside the
   // bbox — but still within the stroke band — can reach the precise
   // tests below.
   if (!containsPointPadded(frame, px, py, tol)) return false;
-
-  // Action buttons paint via a dedicated renderer (`drawActionButton`)
-  // that is NOT in PATH_BUILDERS — they have a body + glyph. Selection
-  // stays bbox-based.
-  if (isActionButton(el.data.kind)) return true;
 
   const builder = PATH_BUILDERS.get(el.data.kind);
   if (!builder) return true; // unknown kind → placeholder rect; bbox is what we have.

--- a/packages/slides/src/view/editor/element-hit.ts
+++ b/packages/slides/src/view/editor/element-hit.ts
@@ -1,0 +1,142 @@
+import type { Element, ShapeElement } from '../../model/element';
+import type { ConnectorElement } from '../../model/connector';
+import { containsPoint, toLocal } from '../../model/frame';
+import { PATH_BUILDERS } from '../canvas/shapes';
+import { isActionButton } from '../canvas/shapes/action-buttons';
+import { EVENODD_KINDS, OPEN_PATH_KINDS } from '../canvas/shape-renderer';
+import { resolveEndpoint } from '../canvas/connector-frame';
+
+/** Default click tolerance, in slide-logical pixels. */
+export const DEFAULT_HIT_TOLERANCE = 6;
+
+/**
+ * Minimal 2D context surface that `hitTestElement` needs. Production
+ * passes the real canvas 2D context; tests pass the `createTestCanvas`
+ * shim from `view/canvas/test-canvas-env.ts`.
+ */
+export interface HitTestCtx {
+  isPointInPath(
+    path: Path2D,
+    x: number,
+    y: number,
+    fillRule?: CanvasFillRule,
+  ): boolean;
+}
+
+export interface HitTestOptions {
+  /**
+   * Click tolerance in slide-logical pixels. Applied to connectors so
+   * thin lines stay clickable. Defaults to {@link DEFAULT_HIT_TOLERANCE}.
+   */
+  tolerance?: number;
+  /**
+   * Element lookup needed by connectors with attached endpoints.
+   * Defaults to an empty map; attached endpoints then fall back to
+   * the origin per `resolveEndpoint`.
+   */
+  elements?: ReadonlyMap<string, Element>;
+}
+
+const EMPTY_LOOKUP: ReadonlyMap<string, Element> = new Map();
+
+/**
+ * True iff the slide-logical point `(px, py)` lies on the visible
+ * drawn area of `el`. Used by selection and right-click hit-test.
+ *
+ * - text / image / action-button shapes → bbox (`containsPoint`).
+ * - filled shape with a registered path builder → `isPointInPath`
+ *   against the local `Path2D`, with rotation + `flipH/flipV` inverted.
+ * - stroke-only shape (no `data.fill`) and `OPEN_PATH_KINDS`
+ *   (brackets/braces) → bbox. Their outline is a thin polyline; an
+ *   `isPointInPath` against the auto-closed shape would include large
+ *   visually-empty regions. Stroke-distance hit-test for these is
+ *   tracked separately (see task doc).
+ * - connector → distance from `(px, py)` to the routed polyline must
+ *   be `≤ stroke.width / 2 + tolerance`.
+ */
+export function hitTestElement(
+  el: Element,
+  px: number,
+  py: number,
+  ctx: HitTestCtx,
+  opts: HitTestOptions = {},
+): boolean {
+  if (el.type === 'connector') return hitConnector(el, px, py, opts);
+  if (el.type !== 'shape') return containsPoint(el.frame, px, py);
+  return hitShape(el, px, py, ctx);
+}
+
+function hitShape(
+  el: ShapeElement,
+  px: number,
+  py: number,
+  ctx: HitTestCtx,
+): boolean {
+  const frame = el.frame;
+  // Fast bbox reject: anything outside the rotated bbox is also outside
+  // the path. Saves a Path2D rebuild for off-shape clicks.
+  if (!containsPoint(frame, px, py)) return false;
+
+  // Action buttons paint via a dedicated renderer (`drawActionButton`)
+  // that is NOT in PATH_BUILDERS — they have a body + glyph. Selection
+  // stays bbox-based.
+  if (isActionButton(el.data.kind)) return true;
+
+  // Stroke-only kinds (no fill, or open-path brackets/braces) fall back
+  // to bbox. See module doc for the trade-off.
+  if (!el.data.fill || OPEN_PATH_KINDS.has(el.data.kind)) return true;
+
+  const builder = PATH_BUILDERS.get(el.data.kind);
+  if (!builder) return true; // unknown kind → placeholder rect; bbox is what we have.
+
+  const local = toLocal(frame, { x: px, y: py });
+  // Invert flipH/flipV in centered local coords. The renderer flips
+  // after rotating around the centre, so the path itself stays
+  // un-flipped; we map the world hit point into the path's frame
+  // instead. Mirrors `connection-sites/index.ts` resolveSite().
+  const lx = frame.flipH ? frame.w - local.x : local.x;
+  const ly = frame.flipV ? frame.h - local.y : local.y;
+  const path = builder({ w: frame.w, h: frame.h }, el.data.adjustments);
+  const fillRule: CanvasFillRule = EVENODD_KINDS.has(el.data.kind)
+    ? 'evenodd'
+    : 'nonzero';
+  return ctx.isPointInPath(path, lx, ly, fillRule);
+}
+
+function hitConnector(
+  el: ConnectorElement,
+  px: number,
+  py: number,
+  opts: HitTestOptions,
+): boolean {
+  const elements = opts.elements ?? EMPTY_LOOKUP;
+  const tol = opts.tolerance ?? DEFAULT_HIT_TOLERANCE;
+  const half = (el.stroke?.width ?? 1) / 2;
+  const limit = half + tol;
+  const a = resolveEndpoint(el.start, elements);
+  const b = resolveEndpoint(el.end, elements);
+  // PR1 supports straight routing only — single segment. Elbow/curved
+  // routings extend this to a polyline / sampled bezier (see task doc).
+  return distanceToSegment(px, py, a.x, a.y, b.x, b.y) <= limit;
+}
+
+function distanceToSegment(
+  px: number,
+  py: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+): number {
+  const dx = bx - ax;
+  const dy = by - ay;
+  const lenSq = dx * dx + dy * dy;
+  let t = lenSq === 0 ? 0 : ((px - ax) * dx + (py - ay) * dy) / lenSq;
+  if (t < 0) t = 0;
+  else if (t > 1) t = 1;
+  const cx = ax + t * dx;
+  const cy = ay + t * dy;
+  const ex = px - cx;
+  const ey = py - cy;
+  return Math.sqrt(ex * ex + ey * ey);
+}

--- a/packages/slides/src/view/editor/element-hit.ts
+++ b/packages/slides/src/view/editor/element-hit.ts
@@ -13,6 +13,10 @@ export const DEFAULT_HIT_TOLERANCE = 6;
  * Minimal 2D context surface that `hitTestElement` needs. Production
  * passes the real canvas 2D context; tests pass the `createTestCanvas`
  * shim from `view/canvas/test-canvas-env.ts`.
+ *
+ * `isPointInStroke` is optional only because some hand-rolled stubs
+ * (rare; not the shipped shim) might omit it. When absent the
+ * stroke-band fallback degrades to bbox for unfilled shapes.
  */
 export interface HitTestCtx {
   isPointInPath(
@@ -21,6 +25,9 @@ export interface HitTestCtx {
     y: number,
     fillRule?: CanvasFillRule,
   ): boolean;
+  isPointInStroke?(path: Path2D, x: number, y: number): boolean;
+  /** Honoured by `isPointInStroke` to set the band thickness. */
+  lineWidth?: number;
 }
 
 export interface HitTestOptions {
@@ -44,13 +51,16 @@ const EMPTY_LOOKUP: ReadonlyMap<string, Element> = new Map();
  * drawn area of `el`. Used by selection and right-click hit-test.
  *
  * - text / image / action-button shapes → bbox (`containsPoint`).
- * - filled shape with a registered path builder → `isPointInPath`
- *   against the local `Path2D`, with rotation + `flipH/flipV` inverted.
- * - stroke-only shape (no `data.fill`) and `OPEN_PATH_KINDS`
- *   (brackets/braces) → bbox. Their outline is a thin polyline; an
- *   `isPointInPath` against the auto-closed shape would include large
- *   visually-empty regions. Stroke-distance hit-test for these is
- *   tracked separately (see task doc).
+ * - shape with a registered path builder:
+ *   - filled (and not `OPEN_PATH_KINDS`) → `isPointInPath` against the
+ *     local `Path2D`, with rotation + `flipH/flipV` inverted.
+ *   - then a stroke band fallback (`isPointInStroke` with
+ *     `lineWidth = stroke.width + 2*tolerance`) so clicks on or near
+ *     the visible outline still hit. Catches the AA fringe + round-
+ *     join extension on filled shapes (heart, smileyFace, …) and is
+ *     the primary test for stroke-only shapes (brackets/braces,
+ *     unfilled outlines).
+ *   - no fill and no stroke → invisible, no hit.
  * - connector → distance from `(px, py)` to the routed polyline must
  *   be `≤ stroke.width / 2 + tolerance`.
  */
@@ -63,7 +73,7 @@ export function hitTestElement(
 ): boolean {
   if (el.type === 'connector') return hitConnector(el, px, py, opts);
   if (el.type !== 'shape') return containsPoint(el.frame, px, py);
-  return hitShape(el, px, py, ctx);
+  return hitShape(el, px, py, ctx, opts);
 }
 
 function hitShape(
@@ -71,20 +81,19 @@ function hitShape(
   px: number,
   py: number,
   ctx: HitTestCtx,
+  opts: HitTestOptions,
 ): boolean {
   const frame = el.frame;
-  // Fast bbox reject: anything outside the rotated bbox is also outside
-  // the path. Saves a Path2D rebuild for off-shape clicks.
-  if (!containsPoint(frame, px, py)) return false;
+  const tol = opts.tolerance ?? DEFAULT_HIT_TOLERANCE;
+  // Fast bbox reject with a tolerance pad so clicks just outside the
+  // bbox — but still within the stroke band — can reach the precise
+  // tests below.
+  if (!containsPointPadded(frame, px, py, tol)) return false;
 
   // Action buttons paint via a dedicated renderer (`drawActionButton`)
   // that is NOT in PATH_BUILDERS — they have a body + glyph. Selection
   // stays bbox-based.
   if (isActionButton(el.data.kind)) return true;
-
-  // Stroke-only kinds (no fill, or open-path brackets/braces) fall back
-  // to bbox. See module doc for the trade-off.
-  if (!el.data.fill || OPEN_PATH_KINDS.has(el.data.kind)) return true;
 
   const builder = PATH_BUILDERS.get(el.data.kind);
   if (!builder) return true; // unknown kind → placeholder rect; bbox is what we have.
@@ -97,10 +106,64 @@ function hitShape(
   const lx = frame.flipH ? frame.w - local.x : local.x;
   const ly = frame.flipV ? frame.h - local.y : local.y;
   const path = builder({ w: frame.w, h: frame.h }, el.data.adjustments);
-  const fillRule: CanvasFillRule = EVENODD_KINDS.has(el.data.kind)
-    ? 'evenodd'
-    : 'nonzero';
-  return ctx.isPointInPath(path, lx, ly, fillRule);
+
+  // Visibility gate: the renderer paints `fill` (unless OPEN_PATH) and
+  // `stroke` independently. A shape with neither is invisible and
+  // therefore not clickable, even though its bbox/frame exists.
+  const hasFill =
+    el.data.fill !== undefined && !OPEN_PATH_KINDS.has(el.data.kind);
+  const hasStroke = el.data.stroke !== undefined;
+  if (!hasFill && !hasStroke) return false;
+
+  // 1) Filled body → `isPointInPath` against the path's interior.
+  if (hasFill) {
+    const fillRule: CanvasFillRule = EVENODD_KINDS.has(el.data.kind)
+      ? 'evenodd'
+      : 'nonzero';
+    if (ctx.isPointInPath(path, lx, ly, fillRule)) return true;
+  }
+
+  // 2) Stroke band — clicks on or near the visible outline. Catches
+  //    the AA fringe / round-join extension on filled shapes (heart's
+  //    lobes, smileyFace's face circle, …) AND is the primary test
+  //    for stroke-only shapes (brackets/braces, unfilled outlines).
+  if (typeof ctx.isPointInStroke === 'function') {
+    const strokeWidth = el.data.stroke?.width ?? 0;
+    const lineWidth = strokeWidth + 2 * tol;
+    const prev = ctx.lineWidth;
+    ctx.lineWidth = lineWidth;
+    try {
+      if (ctx.isPointInStroke(path, lx, ly)) return true;
+    } finally {
+      ctx.lineWidth = prev;
+    }
+  } else if (!hasFill) {
+    // No `isPointInStroke` available (custom stub) and no filled body
+    // — fall back to bbox so the shape stays selectable.
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Like `containsPoint`, but inflates the local rect by `pad` on every
+ * side. Used as the fast reject for shapes whose visible stroke can
+ * extend slightly outside the frame.
+ */
+function containsPointPadded(
+  frame: ShapeElement['frame'],
+  px: number,
+  py: number,
+  pad: number,
+): boolean {
+  const local = toLocal(frame, { x: px, y: py });
+  return (
+    local.x >= -pad &&
+    local.x <= frame.w + pad &&
+    local.y >= -pad &&
+    local.y <= frame.h + pad
+  );
 }
 
 function hitConnector(

--- a/packages/slides/src/view/editor/hit-test-elements.ts
+++ b/packages/slides/src/view/editor/hit-test-elements.ts
@@ -1,7 +1,11 @@
 import type { Element } from '../../model/element';
 import type { Slide } from '../../model/presentation';
-import { containsPoint } from '../../model/frame';
 import { applyInversePoint, groupToTransform } from '../../model/group';
+import {
+  DEFAULT_HIT_TOLERANCE,
+  hitTestElement,
+  type HitTestCtx,
+} from './element-hit';
 
 export interface HitResult {
   /** The leaf-most element under the point. */
@@ -11,20 +15,54 @@ export interface HitResult {
 }
 
 /**
+ * Caller-supplied context for the per-element precise hit-test
+ * (`isPointInPath` + `isPointInStroke`). The 2D context is reused
+ * from the slide renderer; tolerance defaults to
+ * {@link DEFAULT_HIT_TOLERANCE} in slide-logical pixels.
+ */
+export interface HitTestSlideOptions {
+  ctx: HitTestCtx;
+  tolerance?: number;
+}
+
+/**
  * Hit-test in world (slide-root) coordinates. Returns the leaf-most
  * element under (x, y), plus the chain of ancestor groups containing it,
  * or null if no element is hit.
  *
- * The full `ancestorPath` is exposed so that Task 8's drill-in selection
- * state machine can determine which group layer to enter without requiring
- * a second traversal.
+ * The full `ancestorPath` is exposed so that the drill-in selection
+ * state machine can determine which group layer to enter without
+ * requiring a second traversal.
+ *
+ * Leaf elements are tested against their drawn geometry — filled shapes
+ * via `ctx.isPointInPath` against the Path2D from `PATH_BUILDERS`, with
+ * an `isPointInStroke` fallback for the visible-outline band, and
+ * connectors via point-to-segment distance. See `element-hit.ts`.
  */
 export function hitTestSlide(
   slide: Slide,
   x: number,
   y: number,
+  options: HitTestSlideOptions,
 ): HitResult | null {
-  return hitTestRecursive(slide.elements, x, y, []);
+  // Connectors with attached endpoints look elements up by id. Build the
+  // flat lookup once at the root so each connector hit-test doesn't
+  // rebuild it. We index across the whole element tree (groups included)
+  // because attached endpoints can target any element by id, regardless
+  // of group depth.
+  const lookup = buildElementLookup(slide.elements);
+  const tolerance = options.tolerance ?? DEFAULT_HIT_TOLERANCE;
+  return hitTestRecursive(slide.elements, x, y, [], {
+    ctx: options.ctx,
+    tolerance,
+    lookup,
+  });
+}
+
+interface InternalOptions {
+  ctx: HitTestCtx;
+  tolerance: number;
+  lookup: ReadonlyMap<string, Element>;
 }
 
 function hitTestRecursive(
@@ -32,6 +70,7 @@ function hitTestRecursive(
   x: number,
   y: number,
   ancestors: string[],
+  options: InternalOptions,
 ): HitResult | null {
   // Iterate front-to-back (last in array is topmost z-order).
   for (let i = elements.length - 1; i >= 0; i--) {
@@ -48,12 +87,18 @@ function hitTestRecursive(
         local.x,
         local.y,
         [...ancestors, el.id],
+        options,
       );
       if (hit) return hit;
       continue;
     }
 
-    if (containsPoint(el.frame, x, y)) {
+    if (
+      hitTestElement(el, x, y, options.ctx, {
+        tolerance: options.tolerance,
+        elements: options.lookup,
+      })
+    ) {
       return { elementId: el.id, ancestorPath: [...ancestors, el.id] };
     }
   }
@@ -61,3 +106,20 @@ function hitTestRecursive(
   return null;
 }
 
+function buildElementLookup(
+  elements: readonly Element[],
+): ReadonlyMap<string, Element> {
+  const map = new Map<string, Element>();
+  collect(elements, map);
+  return map;
+}
+
+function collect(
+  elements: readonly Element[],
+  out: Map<string, Element>,
+): void {
+  for (const el of elements) {
+    out.set(el.id, el);
+    if (el.type === 'group') collect(el.data.children, out);
+  }
+}

--- a/packages/slides/src/view/editor/interactions/select.ts
+++ b/packages/slides/src/view/editor/interactions/select.ts
@@ -1,9 +1,14 @@
 import type { Slide } from '../../../model/presentation';
-import { hitTestSlide } from '../hit-test-elements';
+import {
+  hitTestSlide,
+  type HitTestSlideOptions,
+} from '../hit-test-elements';
 
 export interface SelectModifiers {
   shift?: boolean;
 }
+
+export type SelectAtOptions = HitTestSlideOptions;
 
 /**
  * Compute the new selection when the user clicks at logical-slide
@@ -11,15 +16,19 @@ export interface SelectModifiers {
  *
  * Hit-testing iterates from last to first so the topmost (front) element
  * wins for overlapping shapes — matches the array-order = z-order
- * convention.
+ * convention. Each element is tested against its drawn geometry (not its
+ * bbox) via `hitTestSlide` → `hitTestElement`, so clicking the empty
+ * corner of an ellipse or off a connector line does NOT select it.
  */
 export function selectAt(
   slide: Slide,
-  x: number, y: number,
+  x: number,
+  y: number,
   mods: SelectModifiers,
   current: readonly string[],
+  options: SelectAtOptions,
 ): string[] {
-  const hit = topmostUnderPoint(slide, x, y);
+  const hit = topmostUnderPoint(slide, x, y, options);
 
   if (mods.shift) {
     if (hit === null) return [...current]; // shift on empty: no-op
@@ -35,8 +44,13 @@ export function selectAt(
   return [hit];
 }
 
-function topmostUnderPoint(slide: Slide, x: number, y: number): string | null {
-  return hitTestSlide(slide, x, y)?.elementId ?? null;
+function topmostUnderPoint(
+  slide: Slide,
+  x: number,
+  y: number,
+  options: SelectAtOptions,
+): string | null {
+  return hitTestSlide(slide, x, y, options)?.elementId ?? null;
 }
 
 function toggleId(ids: readonly string[], id: string): string[] {

--- a/packages/slides/test/view/editor/connector-hit.test.ts
+++ b/packages/slides/test/view/editor/connector-hit.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import { createTestCanvas } from '../../../src/view/canvas/test-canvas-env';
+import type { ConnectorElement } from '../../../src/model/connector';
+import {
+  hitTestElement,
+  DEFAULT_HIT_TOLERANCE,
+} from '../../../src/view/editor/element-hit';
+
+const baseConnector = (
+  start: ConnectorElement['start'],
+  end: ConnectorElement['end'],
+  strokeWidth = 2,
+): ConnectorElement => ({
+  id: 'c1',
+  type: 'connector',
+  routing: 'straight',
+  start,
+  end,
+  arrowheads: {},
+  frame: { x: 0, y: 0, w: 0, h: 0, rotation: 0 },
+  stroke: { color: { kind: 'role', role: 'text' }, width: strokeWidth },
+});
+
+const ctx = createTestCanvas(1, 1).getContext('2d');
+
+describe('hitTestElement — connector', () => {
+  const horizontal = baseConnector(
+    { kind: 'free', x: 10, y: 10 },
+    { kind: 'free', x: 200, y: 10 },
+  );
+
+  it('hits a point on the line', () => {
+    expect(hitTestElement(horizontal, 100, 10, ctx)).toBe(true);
+  });
+
+  it('hits a point just off the line within tolerance', () => {
+    // stroke half-width = 1; default tolerance = 6 → limit = 7.
+    expect(hitTestElement(horizontal, 100, 16, ctx)).toBe(true);
+  });
+
+  it('misses a point well off the line', () => {
+    expect(hitTestElement(horizontal, 100, 30, ctx)).toBe(false);
+  });
+
+  it('hits at the endpoints', () => {
+    expect(hitTestElement(horizontal, 10, 10, ctx)).toBe(true);
+    expect(hitTestElement(horizontal, 200, 10, ctx)).toBe(true);
+  });
+
+  it('misses past the endpoints (beyond stroke + tolerance)', () => {
+    expect(hitTestElement(horizontal, -10, 10, ctx)).toBe(false);
+    expect(hitTestElement(horizontal, 250, 10, ctx)).toBe(false);
+  });
+
+  it('misses a point inside its bbox but far from the diagonal line', () => {
+    // A diagonal connector from (10, 10) to (200, 200) — bbox spans
+    // 190x190 but the line itself only occupies the y=x diagonal.
+    // (10, 190) is inside the bbox, ~127 px from the diagonal.
+    const diagonal = baseConnector(
+      { kind: 'free', x: 10, y: 10 },
+      { kind: 'free', x: 200, y: 200 },
+    );
+    expect(hitTestElement(diagonal, 10, 190, ctx)).toBe(false);
+    // (50, 50) is on the diagonal.
+    expect(hitTestElement(diagonal, 50, 50, ctx)).toBe(true);
+  });
+
+  it('respects a caller-supplied tolerance override', () => {
+    // tolerance = 1 → limit = 1 + half-width 1 = 2.
+    expect(hitTestElement(horizontal, 100, 5, ctx, { tolerance: 1 })).toBe(false);
+    expect(hitTestElement(horizontal, 100, 11, ctx, { tolerance: 1 })).toBe(true);
+  });
+
+  it('uses default tolerance when none is provided', () => {
+    expect(DEFAULT_HIT_TOLERANCE).toBeGreaterThan(0);
+  });
+
+  it('scales the hit threshold with stroke width', () => {
+    const thick = baseConnector(
+      { kind: 'free', x: 10, y: 10 },
+      { kind: 'free', x: 200, y: 10 },
+      20,
+    );
+    // half-width = 10 + tolerance 6 → 16 px tolerated.
+    expect(hitTestElement(thick, 100, 25, ctx)).toBe(true);
+    expect(hitTestElement(thick, 100, 40, ctx)).toBe(false);
+  });
+});

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -1160,10 +1160,11 @@ describe('Editor — dragging connectors translates endpoints', () => {
     store.batch(() => {
       slideId = store.addSlide('blank');
       // Tiny host tucked in the corner — its connection site is near
-      // (25, 10), so the connector's bbox spans from there to its free
-      // end at (300, 200). The click target lands well inside that
-      // bbox, and the host is far enough from the dragged bbox edges
-      // that snap (8px threshold) can't engage.
+      // (25, 10), so the connector's straight line spans from there to
+      // its free end at (300, 200). The click target lands directly on
+      // the line (precise hit-test requires this — bbox-only clicks no
+      // longer select connectors), and the host is far enough from the
+      // dragged path edges that snap (8px threshold) can't engage.
       hostId = store.addElement(slideId, {
         type: 'shape',
         frame: { x: 10, y: 10, w: 30, h: 30, rotation: 0 },
@@ -1181,10 +1182,12 @@ describe('Editor — dragging connectors translates endpoints', () => {
     editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
     editor.setSelection([connectorId]);
 
-    // Drag the connector body by (+30, +15).
-    canvas.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 200, clientY: 150 }));
-    document.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientX: 230, clientY: 165 }));
-    document.dispatchEvent(new PointerEvent('pointerup',   { bubbles: true, clientX: 230, clientY: 165 }));
+    // Drag the connector body by (+30, +15). The pointerdown lands on
+    // the midpoint of the line from (25, 10) to (300, 200) so the
+    // precise hit-test selects the connector.
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 162, clientY: 105 }));
+    document.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientX: 192, clientY: 120 }));
+    document.dispatchEvent(new PointerEvent('pointerup',   { bubbles: true, clientX: 192, clientY: 120 }));
 
     const slide = store.read().slides[0];
     const connector = slide.elements.find((e) => e.id === connectorId)!;

--- a/packages/slides/test/view/editor/hit-test-elements.test.ts
+++ b/packages/slides/test/view/editor/hit-test-elements.test.ts
@@ -1,15 +1,27 @@
 import { describe, expect, it } from 'vitest';
 import * as fc from 'fast-check';
+import '../../../src/view/canvas/test-canvas-env';
+import { createTestCanvas } from '../../../src/view/canvas/test-canvas-env';
 import { hitTestSlide } from '../../../src/view/editor/hit-test-elements';
 import { applyGroupTransform } from '../../../src/model/group';
 import type { Slide } from '../../../src/model/presentation';
 import type { GroupElement, ShapeElement } from '../../../src/model/element';
 
+const ctx = createTestCanvas(1, 1).getContext('2d');
+const hitOpts = { ctx };
+
 function shape(
   id: string,
   frame: { x: number; y: number; w: number; h: number; rotation?: number },
 ): ShapeElement {
-  return { id, type: 'shape', frame: { rotation: 0, ...frame }, data: { kind: 'rect' } };
+  // Precise hit-test requires the shape to actually render — give it a
+  // fill so `isPointInPath` has a body to land on.
+  return {
+    id,
+    type: 'shape',
+    frame: { rotation: 0, ...frame },
+    data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+  };
 }
 
 function group(
@@ -32,19 +44,19 @@ function slide(elements: Slide['elements']): Slide {
 
 describe('hitTestSlide', () => {
   it('returns null when the point misses everything', () => {
-    expect(hitTestSlide(slide([]), 0, 0)).toBeNull();
+    expect(hitTestSlide(slide([]), 0, 0, hitOpts)).toBeNull();
   });
 
   it('hits a slide-root shape', () => {
     const a = shape('a', { x: 10, y: 10, w: 20, h: 20 });
-    const r = hitTestSlide(slide([a]), 15, 15);
+    const r = hitTestSlide(slide([a]), 15, 15, hitOpts);
     expect(r?.elementId).toBe('a');
     expect(r?.ancestorPath).toEqual(['a']);
   });
 
   it('misses a slide-root shape when point is outside', () => {
     const a = shape('a', { x: 10, y: 10, w: 20, h: 20 });
-    expect(hitTestSlide(slide([a]), 5, 5)).toBeNull();
+    expect(hitTestSlide(slide([a]), 5, 5, hitOpts)).toBeNull();
   });
 
   it('returns null when the point is inside a group bbox but misses every child', () => {
@@ -52,7 +64,7 @@ describe('hitTestSlide', () => {
     // world (75, 75) maps to group-local (25, 25) which is past inner.
     const inner = shape('inner', { x: 0, y: 0, w: 20, h: 20 });
     const g = group('g', { x: 50, y: 50, w: 100, h: 100 }, [inner]);
-    const r = hitTestSlide(slide([g]), 75, 75);
+    const r = hitTestSlide(slide([g]), 75, 75, hitOpts);
     expect(r).toBeNull();
   });
 
@@ -61,7 +73,7 @@ describe('hitTestSlide', () => {
     // world (55, 55) → group-local (5, 5) → inside inner
     const inner = shape('inner', { x: 0, y: 0, w: 20, h: 20 });
     const g = group('g', { x: 50, y: 50, w: 100, h: 100 }, [inner]);
-    const r = hitTestSlide(slide([g]), 55, 55);
+    const r = hitTestSlide(slide([g]), 55, 55, hitOpts);
     expect(r?.elementId).toBe('inner');
     expect(r?.ancestorPath).toEqual(['g', 'inner']);
   });
@@ -75,7 +87,7 @@ describe('hitTestSlide', () => {
     const leafWorld = applyGroupTransform(leafInInner, outer);
     const cx = leafWorld.x + leafWorld.w / 2;
     const cy = leafWorld.y + leafWorld.h / 2;
-    const r = hitTestSlide(slide([outer]), cx, cy);
+    const r = hitTestSlide(slide([outer]), cx, cy, hitOpts);
     expect(r?.elementId).toBe('leaf');
     expect(r?.ancestorPath).toEqual(['outer', 'inner', 'leaf']);
   });
@@ -83,7 +95,7 @@ describe('hitTestSlide', () => {
   it('returns the topmost (front) element when shapes overlap', () => {
     const a = shape('a', { x: 0, y: 0, w: 50, h: 50 });
     const b = shape('b', { x: 0, y: 0, w: 50, h: 50 });
-    const r = hitTestSlide(slide([a, b]), 25, 25);
+    const r = hitTestSlide(slide([a, b]), 25, 25, hitOpts);
     expect(r?.elementId).toBe('b');
   });
 
@@ -93,7 +105,7 @@ describe('hitTestSlide', () => {
     const child = shape('child', { x: 0, y: 0, w: 100, h: 100 });
     const g = group('g', { x: 50, y: 50, w: 100, h: 100 }, [child]);
     // world (60, 60) is inside both bg and the group; group is on top.
-    const r = hitTestSlide(slide([bg, g]), 60, 60);
+    const r = hitTestSlide(slide([bg, g]), 60, 60, hitOpts);
     expect(r?.elementId).toBe('child');
     expect(r?.ancestorPath).toEqual(['g', 'child']);
   });
@@ -122,7 +134,7 @@ describe('hitTestSlide property', () => {
           const leafWorld = applyGroupTransform(leaf.frame, g);
           const wx = leafWorld.x + leafWorld.w / 2;
           const wy = leafWorld.y + leafWorld.h / 2;
-          const r = hitTestSlide(slide([g]), wx, wy);
+          const r = hitTestSlide(slide([g]), wx, wy, hitOpts);
           expect(r?.elementId).toBe('leaf');
           expect(r?.ancestorPath).toEqual(['g', 'leaf']);
         },

--- a/packages/slides/test/view/editor/interactions/select.test.ts
+++ b/packages/slides/test/view/editor/interactions/select.test.ts
@@ -100,15 +100,116 @@ describe('selectAt — precise shape geometry', () => {
     expect(selectAt(slide, 50, 50, {}, [], hitOpts)).toEqual(['d']);
   });
 
-  it('falls back to bbox for stroke-only shapes (no fill)', () => {
-    // Empty corners of an unfilled ellipse stay clickable in v1 — see
-    // task doc for why path-distance hit-test is deferred.
+  it('selects a stroke-only ellipse when clicking on the outline', () => {
     const outlined: Element = {
       id: 'o', type: 'shape',
       frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
       data: { kind: 'ellipse', stroke: { color: '#000', width: 1 } },
     };
     const slide = blankSlide([outlined]);
-    expect(selectAt(slide, 4, 4, {}, [], hitOpts)).toEqual(['o']);
+    // Outline at angle 0 is (100, 50). Click 2 px inside still hits the
+    // stroke band (stroke 1 + 2*6 tolerance → 13 px wide).
+    expect(selectAt(slide, 98, 50, {}, [], hitOpts)).toEqual(['o']);
+  });
+
+  it('ignores empty bbox corners of a stroke-only ellipse', () => {
+    // The (4, 4) bbox corner is ~15 px from the outline — well outside
+    // the 6.5 px-half stroke band. Pre-v2 this returned ['o']; v2's
+    // precision pass tightens it.
+    const outlined: Element = {
+      id: 'o', type: 'shape',
+      frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+      data: { kind: 'ellipse', stroke: { color: '#000', width: 1 } },
+    };
+    const slide = blankSlide([outlined]);
+    expect(selectAt(slide, 4, 4, {}, [], hitOpts)).toEqual([]);
+  });
+
+  it('selects a filled smileyFace via its interior', () => {
+    const smiley: Element = {
+      id: 'sm', type: 'shape',
+      frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+      data: {
+        kind: 'smileyFace',
+        fill: { kind: 'srgb' as const, value: '#ff0' },
+      },
+    };
+    const slide = blankSlide([smiley]);
+    // Slightly off-centre so we avoid the mouth band CCW subpath. The
+    // face's interior at (60, 60) is well inside the body and outside
+    // any cut-out.
+    expect(selectAt(slide, 60, 60, {}, [], hitOpts)).toEqual(['sm']);
+  });
+
+  it('selects a filled smileyFace when clicking just outside the face circle (AA band)', () => {
+    // Real users routinely click 1-3 px outside a curved boundary;
+    // with v1 those clicks missed. The stroke-band fallback covers
+    // them now.
+    const smiley: Element = {
+      id: 'sm', type: 'shape',
+      frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+      data: {
+        kind: 'smileyFace',
+        fill: { kind: 'srgb' as const, value: '#ff0' },
+      },
+    };
+    const slide = blankSlide([smiley]);
+    // Outline at angle 0 is (100, 50). (103, 50) is 3 px outside the
+    // fill polygon — inside the 6 px tolerance band.
+    expect(selectAt(slide, 103, 50, {}, [], hitOpts)).toEqual(['sm']);
+  });
+
+  it('selects a filled heart at its centre and tolerates near-edge clicks', () => {
+    // 200x200 frame so the lobe geometry has clear interior + edge
+    // sample points without sub-pixel ambiguity.
+    const heart: Element = {
+      id: 'h', type: 'shape',
+      frame: { x: 0, y: 0, w: 200, h: 200, rotation: 0 },
+      data: { kind: 'heart', fill: { kind: 'srgb' as const, value: '#f00' } },
+    };
+    const slide = blankSlide([heart]);
+    // Lobe centre on the right side: lobeR=50, lobeY=50; right lobe
+    // centre is (cx+lobeR, lobeY) = (150, 50). Well inside the right
+    // lobe.
+    expect(selectAt(slide, 150, 50, {}, [], hitOpts)).toEqual(['h']);
+    // 3 px above the top of the right lobe (lobe top ≈ y=0) — inside
+    // tolerance.
+    expect(selectAt(slide, 150, -3, {}, [], hitOpts)).toEqual(['h']);
+  });
+
+  it('ignores clicks in the empty space above the heart dip', () => {
+    // The dip between the two lobes (around (100, 0)) is outside the
+    // heart even though it's inside the bbox. v2 still rejects when
+    // the click is more than `tolerance` from any drawn edge.
+    const heart: Element = {
+      id: 'h', type: 'shape',
+      frame: { x: 0, y: 0, w: 200, h: 200, rotation: 0 },
+      data: { kind: 'heart', fill: { kind: 'srgb' as const, value: '#f00' } },
+    };
+    const slide = blankSlide([heart]);
+    // (100, 10) is ~15 px from the nearest lobe arc — well outside the
+    // 6 px tolerance band. (200x200 frame so the lobes meet sharply at
+    // x=100 only at the y=lobeY=50 dip.)
+    expect(selectAt(slide, 100, 10, {}, [], hitOpts)).toEqual([]);
+  });
+
+  it('selects a filled leftBracket along the visible stroke even though OPEN_PATH skips fill', () => {
+    // Brackets/braces are OPEN_PATH_KINDS: the renderer ignores `fill`
+    // and only strokes the path. v1 fell back to bbox here; v2 uses
+    // the stroke band so empty regions inside the bracket bbox stop
+    // selecting.
+    const bracket: Element = {
+      id: 'br', type: 'shape',
+      frame: { x: 0, y: 0, w: 100, h: 200, rotation: 0 },
+      data: {
+        kind: 'leftBracket',
+        fill: { kind: 'srgb' as const, value: '#000' },
+        stroke: { color: '#000', width: 2 },
+      },
+    };
+    const slide = blankSlide([bracket]);
+    // The middle of the bbox at (50, 100) is far from the visible
+    // C-shape outline → no hit.
+    expect(selectAt(slide, 50, 100, {}, [], hitOpts)).toEqual([]);
   });
 });

--- a/packages/slides/test/view/editor/interactions/select.test.ts
+++ b/packages/slides/test/view/editor/interactions/select.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
+import '../../../../src/view/canvas/test-canvas-env';
+import { createTestCanvas } from '../../../../src/view/canvas/test-canvas-env';
 import type { Slide } from '../../../../src/model/presentation';
 import type { Element } from '../../../../src/model/element';
-import { selectAt } from '../../../../src/view/editor/interactions/select';
+import {
+  selectAt,
+  type SelectAtOptions,
+} from '../../../../src/view/editor/interactions/select';
 
 const blankSlide = (elements: Element[]): Slide => ({
   id: 's1', layoutId: 'blank',
@@ -14,6 +19,19 @@ const rect = (id: string, x: number, y: number, w = 100, h = 100): Element => ({
   frame: { x, y, w, h, rotation: 0 },
   data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
 });
+const ellipse = (id: string, x: number, y: number, w = 100, h = 100): Element => ({
+  id, type: 'shape',
+  frame: { x, y, w, h, rotation: 0 },
+  data: { kind: 'ellipse', fill: { kind: 'srgb' as const, value: '#abc' } },
+});
+const diamond = (id: string, x: number, y: number, w = 100, h = 100): Element => ({
+  id, type: 'shape',
+  frame: { x, y, w, h, rotation: 0 },
+  data: { kind: 'diamond', fill: { kind: 'srgb' as const, value: '#abc' } },
+});
+
+const testCtx = createTestCanvas(1, 1).getContext('2d');
+const hitOpts: SelectAtOptions = { ctx: testCtx };
 
 describe('selectAt', () => {
   const a = rect('a', 0, 0);
@@ -22,37 +40,75 @@ describe('selectAt', () => {
   const slide = blankSlide([a, b, overlapping]);
 
   it('selects the topmost element under the point (last in array)', () => {
-    expect(selectAt(slide, 60, 60, {}, [])).toEqual(['c']);
+    expect(selectAt(slide, 60, 60, {}, [], hitOpts)).toEqual(['c']);
   });
 
   it('selects a non-overlapping element', () => {
-    expect(selectAt(slide, 250, 250, {}, [])).toEqual(['b']);
+    expect(selectAt(slide, 250, 250, {}, [], hitOpts)).toEqual(['b']);
   });
 
   it('clears selection when clicking on empty canvas', () => {
-    expect(selectAt(slide, 500, 500, {}, ['a'])).toEqual([]);
+    expect(selectAt(slide, 500, 500, {}, ['a'], hitOpts)).toEqual([]);
   });
 
   it('shift-click toggles addition to multi-select', () => {
-    expect(selectAt(slide, 250, 250, { shift: true }, ['c'])).toEqual(['c', 'b']);
+    expect(selectAt(slide, 250, 250, { shift: true }, ['c'], hitOpts)).toEqual(['c', 'b']);
   });
 
   it('shift-click toggles removal of an already-selected element', () => {
-    expect(selectAt(slide, 250, 250, { shift: true }, ['c', 'b'])).toEqual(['c']);
+    expect(selectAt(slide, 250, 250, { shift: true }, ['c', 'b'], hitOpts)).toEqual(['c']);
   });
 
   it('shift-click on empty canvas leaves selection unchanged', () => {
-    expect(selectAt(slide, 500, 500, { shift: true }, ['a'])).toEqual(['a']);
+    expect(selectAt(slide, 500, 500, { shift: true }, ['a'], hitOpts)).toEqual(['a']);
   });
 
   it('clicking an already-selected element preserves the multi-selection', () => {
     // Without this, a no-shift click on one of several selected
     // elements would collapse the selection to just the hit and the
     // follow-up drag would only move that one element.
-    expect(selectAt(slide, 250, 250, {}, ['a', 'b'])).toEqual(['a', 'b']);
+    expect(selectAt(slide, 250, 250, {}, ['a', 'b'], hitOpts)).toEqual(['a', 'b']);
   });
 
   it('clicking a non-selected element while others are selected replaces selection', () => {
-    expect(selectAt(slide, 60, 60, {}, ['b'])).toEqual(['c']);
+    expect(selectAt(slide, 60, 60, {}, ['b'], hitOpts)).toEqual(['c']);
+  });
+});
+
+describe('selectAt — precise shape geometry', () => {
+  it('ignores clicks in an ellipse bbox corner outside the ellipse', () => {
+    // 100x100 ellipse at origin — the (4, 4) bbox corner is well
+    // outside the ellipse (1 = (50-4)²/50² + (50-4)²/50² > 1).
+    const slide = blankSlide([ellipse('e', 0, 0)]);
+    expect(selectAt(slide, 4, 4, {}, [], hitOpts)).toEqual([]);
+  });
+
+  it('selects an ellipse when clicking near its centre', () => {
+    const slide = blankSlide([ellipse('e', 0, 0)]);
+    expect(selectAt(slide, 50, 50, {}, [], hitOpts)).toEqual(['e']);
+  });
+
+  it('ignores clicks in a diamond bbox corner outside the diamond', () => {
+    // 100x100 diamond at origin — the (5, 5) bbox corner is well
+    // outside the diamond's |x-50|/50 + |y-50|/50 ≤ 1 region.
+    const slide = blankSlide([diamond('d', 0, 0)]);
+    expect(selectAt(slide, 5, 5, {}, [], hitOpts)).toEqual([]);
+  });
+
+  it('selects a diamond when clicking its centre', () => {
+    const slide = blankSlide([diamond('d', 0, 0)]);
+    expect(selectAt(slide, 50, 50, {}, [], hitOpts)).toEqual(['d']);
+  });
+
+  it('falls back to bbox for stroke-only shapes (no fill)', () => {
+    // Empty corners of an unfilled ellipse stay clickable in v1 — see
+    // task doc for why path-distance hit-test is deferred.
+    const outlined: Element = {
+      id: 'o', type: 'shape',
+      frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+      data: { kind: 'ellipse', stroke: { color: '#000', width: 1 } },
+    };
+    const slide = blankSlide([outlined]);
+    expect(selectAt(slide, 4, 4, {}, [], hitOpts)).toEqual(['o']);
   });
 });


### PR DESCRIPTION
## Summary

- Replace axis-aligned bbox hit-test for slides elements with a path-based precise hit-test.
- Filled shapes route through `ctx.isPointInPath` against the Path2D from `PATH_BUILDERS`, with rotation + `flipH/flipV` inverted into element-local coords; then an `isPointInStroke` fallback (`lineWidth = stroke.width + 2 * tolerance`) catches AA-fringe + round-join clicks and is the primary test for stroke-only / `OPEN_PATH_KINDS` shapes.
- Connectors use point-to-segment distance with `stroke.width / 2 + tolerance`.
- Tolerance defaults to 6 logical pixels and the editor divides by zoom so the click feel stays at ~6 viewport pixels.
- `test-canvas-env.ts` got an `isPointInStroke` shim (distance-to-segment / 32-sample ellipse / 4-edge rect) on both the jsdom prototype patch and `createTestCanvas`.

## Why

Clicking the empty corners of an ellipse, diamond, star, etc. used to select them, and a long diagonal connector claimed a huge bbox area behind the line. After v1 (Path2D-only), heart and smileyFace still felt imprecise because the renderer's AA fringe + `lineJoin: round` extends 1–2 px outside the fill polygon — the v2 stroke band closes that gap.

## Test plan

- [x] `pnpm --filter @wafflebase/slides test --run` (1044/1044)
- [x] `pnpm verify:fast`
- [ ] Manual smoke in `pnpm dev`:
  - [ ] Ellipse / diamond / star — bbox corners no longer select; interior + edge clicks do.
  - [ ] Line / arrow connector — only clicks within ~6 viewport px of the line select.
  - [ ] Heart, smileyFace — clicks on the visible outline select; clicks well inside the bbox dip (above the heart's lobes) do not.
  - [ ] Brackets / braces — bbox interior no longer selects; clicks on the visible C-shape do.

## Known limitations (non-blocking)

- The bbox fast-reject in `hitShape` is padded by `tolerance`, so at very low zoom (e.g. 10%) the reject window grows to ~60 logical px. Precise tests still narrow it down; in practice this matches the "feels-natural 6 viewport-px halo" the design targets.
- `docs/design/slides/slides-shapes.md` mentioned `ctx.isPointInPath`-based hit-test as a follow-up — that note is now stale. A design doc refresh (and a short hit-test section in `slides.md`) is deferred to a follow-up so this PR stays focused on the behavioral change. The new module is well-commented and the task doc (`docs/tasks/active/20260519-slides-precise-shape-hit-test-todo.md`) captures the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Precise geometric hit-testing for element selection: shape- and connector-aware detection with zoom-aware tolerance, improving accuracy for ellipses, diamonds, rotated/flipped shapes, stroke-only outlines, and connector endpoints (applies to click, right-click, and double-click flows).

* **Tests**
  * Expanded test coverage for connector hits and precise shape geometry (ellipse, diamond, stroked shapes, brackets, and selection interactions).

* **Documentation**
  * Added a new active task/design entry describing the precise hit-testing plan and verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->