### PR TITLE
Display ghost-preview drag-move + move cursor on hover

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -72,6 +72,7 @@ Presentation engine — slides, free-position elements, presentation mode, colla
 | [slides-mobile-view.md](slides/slides-mobile-view.md)                                 | Mobile view (read-only) — viewport-768 branch in SlidesView, dedicated MobileSlidesView reusing SlideRenderer, swipe nav, Present entry, no editor mount                                                    |
 | [slides-mobile-edit.md](slides/slides-mobile-edit.md)                                 | Mobile light edit (Phase B) — mount full SlidesEditor on touch, hit-test tolerance, bottom-sheet text formatting, slide-ops FAB, undo/redo header, perm-gated read-only fallback                            |
 | [slides-group.md](slides/slides-group.md)                                             | Group / ungroup — nested element tree with group-local child coords, Google Slides drill-in selection, PPTX `<p:grpSp>` preservation, recursive renderer / hit-test / PDF export                              |
+| [slides-shape-move.md](slides/slides-shape-move.md)                                   | Shape drag-move — `move` hover cursor on selected shapes, ghost preview at `GHOST_ALPHA` follows pointer, commit only on release                                                                            |
 
 ## Common
 

--- a/docs/design/slides/slides-shape-move.md
+++ b/docs/design/slides/slides-shape-move.md
@@ -1,0 +1,156 @@
+---
+title: slides-shape-move
+target-version: 0.4.2
+---
+
+# Slides Shape Move — Ghost Drag & Move Cursor
+
+## Summary
+
+Refine shape drag-move in the slides editor so the gesture matches the
+visual language already used for shape-insert hover preview:
+
+- A `move` cursor appears when the pointer is over a **selected** shape,
+  signaling that a drag will move it.
+- During drag, the original shape and its selection handles stay in
+  place. A semi-transparent **ghost** copy of the shape follows the
+  cursor at `GHOST_ALPHA` (same constant the insert hover preview uses).
+- On pointer release, the shape commits to the new position in a single
+  `store.batch()` — same commit pathway as today.
+
+This makes the drag intent explicit ("you are previewing where it will
+land"), removes the visual jump that comes from synthesizing a slide
+with live frames, and reuses existing ghost-rendering infrastructure in
+`slide-renderer.ts`.
+
+### Goals
+
+- Drag-move shapes via ghost preview that follows the cursor.
+- Show a `move` cursor on hover over a selected shape's bounding box.
+- Keep original shape + selection handles + snap guidelines visible
+  during drag (handles anchor to the original frame).
+- Commit only on `pointerup`; ESC cancels with no store mutation.
+- Reuse the existing `drawSlide(..., ghost?)` path; do **not** add a new
+  canvas layer.
+
+### Non-Goals
+
+- Connector drag (current endpoint-based routing is kept — connectors
+  are excluded from the ghost path in v1).
+- Alt-drag duplicate / clone-while-drag.
+- Keyboard arrow-key nudges (single discrete move, no ghost needed).
+- Touch-input cursor changes (touch has no cursor concept; ghost
+  rendering still applies).
+- Group/grouped-shape semantics (current code uses multi-select only).
+
+## Proposal Details
+
+### Affected files
+
+| File | Change |
+| ---- | ------ |
+| `packages/slides/src/view/canvas/slide-renderer.ts` | `drawSlide(...)` and `forceRender(...)` accept `ghosts?: ReadonlyArray<Element>` instead of `ghost?: Element`. |
+| `packages/slides/src/view/editor/editor.ts` | `startDrag()` paints ghosts via `forceRender(originalSlide, doc, ghosts)`; overlay (handles + snap guides) anchored to original frame. New hover-cursor logic on `pointermove` over the canvas. |
+| `packages/slides/src/view/editor/overlay.ts` | Accept snap guides as an explicit parameter; do not depend on synthesized live frames. |
+| `docs/design/README.md` | Add row linking to this design doc under "Slides". |
+
+### Cursor rules
+
+Applied in the editor's `pointermove` handler (mouse pointers only —
+`PointerEvent.pointerType === 'mouse'`):
+
+| Condition | Cursor |
+| --------- | ------ |
+| Insert mode active (`insertKind !== null`) | `crosshair` (existing) |
+| Pointer over a resize/rotate handle | resize/rotate (existing) |
+| Pointer inside a **selected** element's bbox (any of the multi-selection) | `move` |
+| Pointer inside text-editing element (`editingElementId === el.id`) | `text` / default (no override) |
+| Otherwise | `''` (default) |
+
+The check runs against `selection.get()` and the element hit-test
+helper already used by `onPointerDown`. Cursor writes go through a
+single setter to avoid layout-thrash from repeated assignments to the
+same value.
+
+### Ghost rendering pipeline
+
+Today: `drawSlide(ctx, slide, doc, theme, onAssetLoad, ghost?: Element)`
+paints all `slide.elements` then, if `ghost` is defined, paints it once
+on top at `GHOST_ALPHA`.
+
+Change: accept `ghosts?: ReadonlyArray<Element>`. Iterate the array
+after the regular `slide.elements` loop. Each ghost is drawn through
+the normal `drawElement` path under a `ctx.save() / ctx.globalAlpha =
+GHOST_ALPHA / ctx.restore()` band. Order inside the array preserves
+relative z-order of the originals.
+
+`forceRender(slide, doc, ghosts?)` mirrors the same signature.
+
+Call sites:
+
+- `paintWithHoverGhost()` (insert hover preview) wraps its single
+  element into `[ghost]`.
+- `paintLive()` (drag) builds `ghosts` from the current `selection`:
+  ```ts
+  const ghosts = selectedElements
+    .filter((el) => !isConnector(el))
+    .map((el) => ({ ...el, x: el.x + dx, y: el.y + dy }));
+  ```
+  then calls `this.renderer.forceRender(originalSlide, doc, ghosts)`.
+  No synthesized slide is created.
+
+**Connectors during drag (v1 behavior):** Connectors are excluded from
+the `ghosts` array. While a drag is in flight they render against their
+**original** endpoint geometry — no live re-routing in the preview.
+On `pointerup`, the shape commit triggers the normal repaint and any
+attached connector picks up the new endpoint via its existing lookup
+path. Tracked as a follow-up: live connector re-routing during drag
+preview.
+
+### Overlay rules during drag
+
+- Selection handles (corner / edge / rotate) anchor to the **original**
+  bbox — they do not move with the ghost.
+- Snap guides anchor to the **ghost** bbox — `snapDelta(...)` is still
+  called per `mousemove` with the same `bbox`, `otherFrames`, threshold
+  inputs as today. Result `{ dx, dy, guides }` feeds: (a) ghost frame
+  offset, (b) `renderOverlay(..., guides)`.
+- `renderOverlay` gains an explicit `snapGuides` parameter rather than
+  inferring guides from the live-frame map (which goes away).
+
+### Commit and cancel
+
+- `pointerup`: `store.batch(() => store.updateElement(id, { x, y }))`
+  for each moved element. Identical to current logic. Then clear
+  ghost state, `markDirty()`, `render()`, `repaintOverlay()`.
+- Pointer leaves canvas mid-drag: current capture pattern via
+  `document.addEventListener('pointermove'/'pointerup', ...)` keeps the
+  drag alive — no change.
+- ESC during drag: drop ghosts, do not call `store.updateElement`,
+  `markDirty()` + `render()` + `repaintOverlay()`.
+
+### Tests
+
+Unit tests in `packages/slides/src/view/editor/*.test.ts`:
+
+- `startDrag` → simulated `mousemove` calls `forceRender(slide, doc,
+  ghosts)` with `ghosts.length === selection.length` and the synthetic
+  offset; the slide argument is unchanged (referential equality with
+  original).
+- Cursor: `pointermove` over a selected element's bbox sets
+  `canvas.style.cursor === 'move'`; over empty space leaves it default.
+- Multi-select drag (2 elements) → ghosts array length 2; both offset
+  by the same `(dx, dy)`.
+- `mouseup` → `store.updateElement` invoked inside one `store.batch`
+  with new `(x, y)` per element.
+- ESC mid-drag → no `store.updateElement` call; ghost state cleared.
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| `forceRender` signature change cascades through callers | Only one caller today (`paintWithHoverGhost`); update inline. Type-checker will catch any miss. |
+| Per-`mousemove` `forceRender` cost with many shapes | Same cost profile as today's live-frame redraw. raf-throttle is already the pattern in `onInsertHoverMove`; apply the same in `startDrag` if profiling shows jank. |
+| Connector visual regression during drag | v1 keeps connectors out of the ghost path; tracked as follow-up. |
+| Cursor flicker from `style.cursor` writes per `pointermove` | Cache last cursor value; only write when it differs. |
+| Touch-input regressions | Cursor logic gated on `pointerType === 'mouse'`; ghost rendering applies to touch too and is the desired behavior on mobile-edit. |

--- a/docs/design/slides/slides-shape-move.md
+++ b/docs/design/slides/slides-shape-move.md
@@ -30,8 +30,9 @@ with live frames, and reuses existing ghost-rendering infrastructure in
 - Keep original shape + selection handles + snap guidelines visible
   during drag (handles anchor to the original frame).
 - Commit only on `pointerup` (single `store.batch`).
-- Reuse the existing `drawSlide(..., ghost?)` path; do **not** add a new
-  canvas layer.
+- Reuse the existing ghost-rendering path in `drawSlide` /
+  `forceRender` (generalized in this PR from `ghost?: Element` to
+  `ghosts?: readonly Element[]`); do **not** add a new canvas layer.
 
 ### Non-Goals
 
@@ -121,9 +122,19 @@ preview.
 
 ### Commit and cancel
 
-- `pointerup`: `store.batch(() => store.updateElement(id, { x, y }))`
-  for each moved element. Identical to current logic. Then clear
-  ghost state, `markDirty()`, `render()`, `repaintOverlay()`.
+- `pointerup`: open a single `store.batch(...)` and commit each
+  moved element via the path that matches its type:
+  - **Non-connectors:** `store.updateElementFrame(slideId, id,
+    fromWorldFrame(newWorld, scope, slide))` — the dragged world frame
+    is lifted back to the element's scope-local frame.
+  - **Connectors:** `commitTranslate(store, slideId, el, dx, dy)` —
+    `updateElementFrame` throws on connectors because their `frame` is
+    derived from endpoints; `commitTranslate` instead translates each
+    free endpoint by `(dx, dy)` (attached endpoints stay anchored).
+  - **Zero-delta skip:** if `dx === 0 && dy === 0` (pure
+    click-without-drag), open NO batch — `store.batch` unconditionally
+    pushes an undo snapshot and clears the redo stack.
+  After the batch, `markDirty()`, `render()`, `repaintOverlay()`.
 - Pointer leaves canvas mid-drag: current capture pattern via
   `document.addEventListener('pointermove'/'pointerup', ...)` keeps the
   drag alive — no change.

--- a/docs/design/slides/slides-shape-move.md
+++ b/docs/design/slides/slides-shape-move.md
@@ -29,7 +29,7 @@ with live frames, and reuses existing ghost-rendering infrastructure in
 - Show a `move` cursor on hover over a selected shape's bounding box.
 - Keep original shape + selection handles + snap guidelines visible
   during drag (handles anchor to the original frame).
-- Commit only on `pointerup`; ESC cancels with no store mutation.
+- Commit only on `pointerup` (single `store.batch`).
 - Reuse the existing `drawSlide(..., ghost?)` path; do **not** add a new
   canvas layer.
 
@@ -37,6 +37,7 @@ with live frames, and reuses existing ghost-rendering infrastructure in
 
 - Connector drag (current endpoint-based routing is kept — connectors
   are excluded from the ghost path in v1).
+- ESC mid-drag cancel (undo is the v1 fallback; tracked as follow-up).
 - Alt-drag duplicate / clone-while-drag.
 - Keyboard arrow-key nudges (single discrete move, no ghost needed).
 - Touch-input cursor changes (touch has no cursor concept; ghost
@@ -50,8 +51,7 @@ with live frames, and reuses existing ghost-rendering infrastructure in
 | File | Change |
 | ---- | ------ |
 | `packages/slides/src/view/canvas/slide-renderer.ts` | `drawSlide(...)` and `forceRender(...)` accept `ghosts?: ReadonlyArray<Element>` instead of `ghost?: Element`. |
-| `packages/slides/src/view/editor/editor.ts` | `startDrag()` paints ghosts via `forceRender(originalSlide, doc, ghosts)`; overlay (handles + snap guides) anchored to original frame. New hover-cursor logic on `pointermove` over the canvas. |
-| `packages/slides/src/view/editor/overlay.ts` | Accept snap guides as an explicit parameter; do not depend on synthesized live frames. |
+| `packages/slides/src/view/editor/editor.ts` | New `paintMoveGhost()` helper; `startDrag()` paints ghosts via `forceRender(originalSlide, doc, ghosts)` and routes handles + snap guides explicitly. New hover-cursor logic on `pointermove` over the canvas (`onSelectionHoverMove` + `isPointerOverSelected`). |
 | `docs/design/README.md` | Add row linking to this design doc under "Slides". |
 
 ### Cursor rules
@@ -115,8 +115,9 @@ preview.
   called per `mousemove` with the same `bbox`, `otherFrames`, threshold
   inputs as today. Result `{ dx, dy, guides }` feeds: (a) ghost frame
   offset, (b) `renderOverlay(..., guides)`.
-- `renderOverlay` gains an explicit `snapGuides` parameter rather than
-  inferring guides from the live-frame map (which goes away).
+- `renderOverlay` already exposes `guides`; the drag path now passes
+  them explicitly from `snapDelta`'s output rather than inferring them
+  from a synthesized-frame map (which goes away).
 
 ### Commit and cancel
 
@@ -126,8 +127,8 @@ preview.
 - Pointer leaves canvas mid-drag: current capture pattern via
   `document.addEventListener('pointermove'/'pointerup', ...)` keeps the
   drag alive — no change.
-- ESC during drag: drop ghosts, do not call `store.updateElement`,
-  `markDirty()` + `render()` + `repaintOverlay()`.
+- ESC mid-drag cancel is **out of scope for v1** — undo is the
+  fallback. Tracked as a follow-up.
 
 ### Tests
 
@@ -143,7 +144,10 @@ Unit tests in `packages/slides/src/view/editor/*.test.ts`:
   by the same `(dx, dy)`.
 - `mouseup` → `store.updateElement` invoked inside one `store.batch`
   with new `(x, y)` per element.
-- ESC mid-drag → no `store.updateElement` call; ghost state cleared.
+- Connector in multi-selection drag → `pointerup` does **not** throw;
+  the connector's frame is unchanged.
+- Rotated element hover hit-test uses rotation-aware `containsPoint`,
+  not axis-aligned bbox.
 
 ### Risks and Mitigation
 

--- a/docs/tasks/active/20260519-slides-shape-move-ghost-todo.md
+++ b/docs/tasks/active/20260519-slides-shape-move-ghost-todo.md
@@ -25,6 +25,23 @@ gated on `pointerType === 'mouse'` and cached to avoid layout thrash.
 **Tech Stack:** TypeScript, Vitest + jsdom, Canvas 2D, existing
 `createCtxSpy` test harness.
 
+> **Note (post-rebase):** This plan was authored against an earlier
+> `origin/main` than what shipped. Origin/main's group-aware drag landed
+> in between and the final implementation differs in two ways from the
+> code snippets below:
+>
+> - `startDrag` works in **world-frame** coordinates (`toWorldFrame` /
+>   `fromWorldFrame` / `scope`) so drilled-in group selections move
+>   correctly.
+> - On commit, **connectors go through `commitTranslate`** (endpoint
+>   translation), not `updateElementFrame` — the latter throws for
+>   connectors. The snippet at Step 3 commits everything through
+>   `updateElementFrame` for clarity but the shipped code routes by
+>   element type.
+>
+> The design doc (`docs/design/slides/slides-shape-move.md`) is the
+> authoritative reference for the final behavior.
+
 **Out of scope for this PR (tracked as follow-ups):**
 
 - Connector live re-routing during ghost drag (connectors stay attached

--- a/docs/tasks/active/20260519-slides-shape-move-ghost-todo.md
+++ b/docs/tasks/active/20260519-slides-shape-move-ghost-todo.md
@@ -1,0 +1,906 @@
+# Slides shape move — ghost preview + move cursor
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Design doc:** [`docs/design/slides/slides-shape-move.md`](../../design/slides/slides-shape-move.md)
+
+**Goal:** When a shape is selected, hover shows a `move` cursor. Drag
+moves a translucent ghost of the shape (at `GHOST_ALPHA`) while the
+original shape and selection handles stay anchored to their starting
+frame. On `pointerup`, the shape commits to the ghost's position.
+
+**Architecture:** Extend the existing ghost-rendering path in
+`slide-renderer.ts` (already used by the shape-insert hover preview)
+from a single `ghost?: Element` to a `ghosts?: ReadonlyArray<Element>`.
+In the editor, add a `paintMoveGhost()` method that calls
+`forceRender(originalSlide, doc, ghosts)` and routes `snapGuides`
+through `renderOverlay` against the **original** frames (so handles
+don't move with the ghost). `startDrag()` switches from the current
+synthesized-slide `paintLive` path to `paintMoveGhost`. `paintLive` is
+left untouched because it is still used by resize/rotate/adjustment
+flows where seeing the live frame is the correct affordance. Hover
+cursor is set inside the existing `pointermove` listener on the canvas,
+gated on `pointerType === 'mouse'` and cached to avoid layout thrash.
+
+**Tech Stack:** TypeScript, Vitest + jsdom, Canvas 2D, existing
+`createCtxSpy` test harness.
+
+**Out of scope for this PR (tracked as follow-ups):**
+
+- Connector live re-routing during ghost drag (connectors stay attached
+  to their original endpoints during the preview)
+- ESC mid-drag cancel
+- Alt-drag clone
+- Keyboard-nudge ghosting
+
+---
+
+## Chunk 1: Renderer accepts a ghost array
+
+### Task 1: Extend `drawSlide` / `forceRender` to take `ghosts?: ReadonlyArray<Element>`
+
+**Files:**
+- Modify: `packages/slides/src/view/canvas/slide-renderer.ts:79-83` (`forceRender` signature)
+- Modify: `packages/slides/src/view/canvas/slide-renderer.ts:92-162` (`drawSlide` signature + ghost loop)
+- Test: `packages/slides/test/view/canvas/slide-renderer.test.ts` (new file)
+
+The existing API takes a single optional `ghost?: Element`. Generalize
+to `ghosts?: ReadonlyArray<Element>` so the drag-move path can hand
+multiple ghosts in one pass while the existing hover-preview path passes
+a single-element array.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/slides/test/view/canvas/slide-renderer.test.ts`. We
+use `MemSlidesStore` to build a real `SlidesDocument` (mirroring
+`editor.test.ts`) so the test won't break if `drawSlide`'s internal
+theme / background lookup gains new doc requirements.
+
+```typescript
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import { asCtx, createCtxSpy } from '../../../src/view/canvas/ctx-spy';
+import { drawSlide } from '../../../src/view/canvas/slide-renderer';
+import { MemSlidesStore } from '../../../src/store/memory';
+import { SLIDE_HEIGHT, SLIDE_WIDTH } from '../../../src/model/presentation';
+import type { Element } from '../../../src/model/element';
+
+function buildDoc() {
+  const store = new MemSlidesStore();
+  let elementId = '';
+  store.batch(() => {
+    const sid = store.addSlide('blank');
+    elementId = store.addElement(sid, {
+      type: 'shape',
+      frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+      data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+    });
+  });
+  const doc = store.read();
+  const slide = doc.slides[0];
+  return { doc, slide, elementId };
+}
+
+function makeGhost(id: string, x: number): Element {
+  return {
+    id,
+    type: 'shape',
+    frame: { x, y: 100, w: 100, h: 100, rotation: 0 },
+    data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+  } as Element;
+}
+
+describe('drawSlide ghosts', () => {
+  it('each ghost adds one matched save/restore pair on top of the baseline', () => {
+    const { doc, slide } = buildDoc();
+    const opts = { hostWidth: SLIDE_WIDTH, hostHeight: SLIDE_HEIGHT, dpr: 1 };
+
+    const baseline = createCtxSpy();
+    drawSlide(asCtx(baseline), slide, doc, opts);
+
+    const twoGhosts = createCtxSpy();
+    drawSlide(
+      asCtx(twoGhosts),
+      slide,
+      doc,
+      opts,
+      () => undefined,
+      [makeGhost('g1', 300), makeGhost('g2', 600)],
+    );
+
+    expect(twoGhosts.save.mock.calls.length).toBe(
+      baseline.save.mock.calls.length + 2,
+    );
+    expect(twoGhosts.restore.mock.calls.length).toBe(
+      baseline.restore.mock.calls.length + 2,
+    );
+  });
+
+  it('omitting ghosts equals an empty array', () => {
+    const { doc, slide } = buildDoc();
+    const opts = { hostWidth: SLIDE_WIDTH, hostHeight: SLIDE_HEIGHT, dpr: 1 };
+
+    const omitted = createCtxSpy();
+    const empty = createCtxSpy();
+    drawSlide(asCtx(omitted), slide, doc, opts);
+    drawSlide(asCtx(empty), slide, doc, opts, () => undefined, []);
+
+    expect(omitted.save.mock.calls.length).toBe(empty.save.mock.calls.length);
+    expect(omitted.restore.mock.calls.length).toBe(empty.restore.mock.calls.length);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `pnpm --filter @wafflebase/slides test slide-renderer`
+Expected: TypeScript error or runtime failure because `drawSlide` still
+takes `ghost?: Element` (single), not an array.
+
+- [ ] **Step 3: Update `slide-renderer.ts` to accept an array**
+
+In `packages/slides/src/view/canvas/slide-renderer.ts`, change the
+`forceRender` signature and the `drawSlide` signature + ghost loop.
+
+Replace lines 69–84 (`forceRender` doc block + method):
+
+```typescript
+  /**
+   * Paint unconditionally (bypass the dirty check). Used by interaction
+   * live-paint paths in the editor that need to draw an in-memory
+   * frame override on every mousemove without committing to the store.
+   *
+   * `ghosts` — optional elements drawn on top of the committed slide at
+   * `GHOST_ALPHA`. Used by the shape-insert hover preview (single
+   * element) and the shape-move drag preview (one per selected element).
+   * Kept out of `slide` so the ghost never participates in selection,
+   * hit-test, or z-order.
+   */
+  forceRender(
+    slide: Slide,
+    doc: SlidesDocument,
+    ghosts?: ReadonlyArray<Element>,
+  ): void {
+    this.dirty = true;
+    drawSlide(this.ctx, slide, doc, this.options, () => this.markDirty(), ghosts);
+    this.dirty = false;
+  }
+```
+
+Replace lines 92–99 (`drawSlide` signature):
+
+```typescript
+export function drawSlide(
+  ctx: CanvasRenderingContext2D,
+  slide: Slide,
+  doc: SlidesDocument,
+  options: SlideRendererOptions,
+  onAssetLoad: () => void = () => undefined,
+  ghosts?: ReadonlyArray<Element>,
+): void {
+```
+
+Replace lines 151–161 (single-ghost block):
+
+```typescript
+  if (ghosts !== undefined && ghosts.length > 0) {
+    // Paint hover/drag-preview ghosts on top of the committed slide so
+    // their semi-transparency reveals the underlying content. One
+    // save/restore band per ghost keeps `globalAlpha` writes scoped
+    // and isolates any future per-ghost style overrides.
+    for (const ghost of ghosts) {
+      ctx.save();
+      ctx.globalAlpha = GHOST_ALPHA;
+      drawElement(ctx, ghost, doc, theme, onAssetLoad, elementsLookup);
+      ctx.restore();
+    }
+  }
+```
+
+- [ ] **Step 4: Update the existing `paintWithHoverGhost` caller**
+
+In `packages/slides/src/view/editor/editor.ts:1219`, change the
+single-element call to pass an array:
+
+```typescript
+    this.renderer.forceRender(slide, this.options.store.read(), [ghost]);
+```
+
+- [ ] **Step 5: Run the test — confirm it passes**
+
+Run: `pnpm --filter @wafflebase/slides test slide-renderer`
+Expected: PASS (both new tests).
+
+- [ ] **Step 6: Run the full slides suite for regressions**
+
+Run: `pnpm --filter @wafflebase/slides test`
+Expected: PASS (existing `editor.test.ts` hover-preview tests should
+still pass — the array-of-one path renders identically).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/slides/src/view/canvas/slide-renderer.ts \
+        packages/slides/src/view/editor/editor.ts \
+        packages/slides/test/view/canvas/slide-renderer.test.ts
+git commit -m "Slides: accept ghost array in drawSlide/forceRender"
+```
+
+---
+
+## Chunk 2: Editor uses ghost rendering for drag-move
+
+### Task 2: Add `paintMoveGhost` helper alongside `paintLive`
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/editor.ts` (insert new method after `paintLive`, around line 1510)
+
+`paintLive` synthesizes a slide with overridden frames — that's correct
+for resize/rotate/adjustment where the live frame is what the user
+needs to see. For drag-move we want the original slide unchanged plus
+ghost overlays. Adding a sibling method keeps each call site
+single-purpose.
+
+- [ ] **Step 1: Add `paintMoveGhost` method to `SlidesEditor`**
+
+In `packages/slides/src/view/editor/editor.ts`, insert this method
+right after the existing `paintLive` (after line 1510, before
+`currentSlide`):
+
+```typescript
+  /**
+   * Drag-move preview: paint the slide unchanged + a translucent ghost
+   * of each selected element at its dragged position. Overlay handles
+   * render against the **original** frames so they stay anchored to the
+   * starting position (the user reads the ghost as "where it will land"
+   * and the handles as "where it started").
+   *
+   * Connectors are excluded from `ghosts` for v1; they keep rendering
+   * at their original endpoints during the drag preview. On commit, the
+   * connector's normal endpoint-lookup path re-routes them.
+   */
+  private paintMoveGhost(
+    ghosts: ReadonlyArray<Element>,
+    selectedOriginals: ReadonlyArray<Element>,
+    guides: readonly SnapGuide[] = [],
+  ): void {
+    const slide = this.currentSlide();
+    if (!slide) return;
+    this.renderer.forceRender(slide, this.options.store.read(), ghosts);
+    renderOverlay(this.options.overlay, selectedOriginals, {
+      scale: this.scale(),
+      slideWidth: SLIDE_WIDTH,
+      slideHeight: SLIDE_HEIGHT,
+      guides,
+      allElements: slide.elements,
+      connectorAffordance: this.connectorAffordance(),
+    });
+  }
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm --filter @wafflebase/slides exec tsc --noEmit`
+Expected: PASS — `paintMoveGhost` is private and unused; TS allows
+unused privates.
+
+- [ ] **Step 3: Commit (small, reviewable)**
+
+```bash
+git add packages/slides/src/view/editor/editor.ts
+git commit -m "Slides: add paintMoveGhost helper for drag-move preview"
+```
+
+---
+
+### Task 3: Switch `startDrag` to use `paintMoveGhost`
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/editor.ts:1432-1485` (`startDrag` body)
+- Test: `packages/slides/test/view/editor/editor.test.ts` (add ghost-during-drag assertion)
+
+Replace the synthesized-slide `paintLive` call with `paintMoveGhost`.
+Build `ghosts` by cloning each selected element with offset frame.
+Exclude connectors. Keep snap calculation untouched.
+
+- [ ] **Step 1: Add a failing test for ghost-during-drag**
+
+Insert this test in `packages/slides/test/view/editor/editor.test.ts`
+after the existing "drag moves the selected element..." test (after
+line 143). It verifies the store is **not** mutated mid-drag — only on
+`pointerup` — which is the user-visible contract that ghost rendering
+must preserve.
+
+```typescript
+  it('drag does not mutate the store until pointerup (ghost-only preview)', () => {
+    const { canvas, overlay, store } = makeFixture();
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    dispatchMouseDown(canvas, 200, 150);
+    // Mid-drag mousemove — frame in the store must still be the original.
+    document.dispatchEvent(new PointerEvent('pointermove', { clientX: 300, clientY: 220, bubbles: true }));
+    const midFrame = store.read().slides[0].elements[0].frame;
+    expect(midFrame.x).toBe(100);
+    expect(midFrame.y).toBe(100);
+    // Release commits.
+    document.dispatchEvent(new PointerEvent('pointerup', { clientX: 300, clientY: 220, bubbles: true }));
+    const finalFrame = store.read().slides[0].elements[0].frame;
+    expect(finalFrame.x).not.toBe(100);
+  });
+```
+
+- [ ] **Step 2: Run the test — confirm it passes against current code**
+
+Run: `pnpm --filter @wafflebase/slides test editor`
+Expected: PASS. (Current code already commits only at `pointerup` via
+`store.batch` — the test pins the contract so the rewrite cannot
+regress it.)
+
+- [ ] **Step 3: Replace `startDrag`'s `paintLive` call with `paintMoveGhost`**
+
+In `packages/slides/src/view/editor/editor.ts`, replace lines 1432–1485
+(the entire `startDrag` body) with:
+
+```typescript
+  private startDrag(clientX: number, clientY: number): void {
+    const startSlide = this.currentSlide();
+    if (!startSlide) return;
+    const selectedIds = new Set(this.selection.get());
+    const originals = startSlide.elements.filter((el) => selectedIds.has(el.id));
+    if (originals.length === 0) return;
+
+    // Connectors are excluded from the ghost preview in v1. They keep
+    // rendering at their original endpoints during the drag and re-route
+    // on commit via the normal endpoint-lookup path.
+    const ghostSources = originals.filter((el) => el.type !== 'connector');
+
+    const start = this.clientToLogical(clientX, clientY);
+    const otherFrames = startSlide.elements
+      .filter((e) => !selectedIds.has(e.id))
+      .map((e) => e.frame);
+    const originalFrames = originals.map((el) => el.frame);
+
+    // Final commit values; updated each mousemove so onUp can apply
+    // them in a single batch without re-running the snap math.
+    const committed = new Map<string, Frame>(
+      originals.map((el) => [el.id, { ...el.frame }]),
+    );
+
+    const onMove = (ev: MouseEvent) => {
+      const cur = this.clientToLogical(ev.clientX, ev.clientY);
+      const rawDx = cur.x - start.x;
+      const rawDy = cur.y - start.y;
+      const bbox = combinedBoundingBox(originalFrames)!;
+      const { dx, dy, guides } = snapDelta(
+        bbox,
+        rawDx,
+        rawDy,
+        otherFrames,
+        { w: SLIDE_WIDTH, h: SLIDE_HEIGHT },
+      );
+
+      const ghosts: Element[] = ghostSources.map((el) => ({
+        ...el,
+        frame: { ...el.frame, x: el.frame.x + dx, y: el.frame.y + dy },
+      } as Element));
+
+      for (const el of originals) {
+        committed.set(el.id, { ...el.frame, x: el.frame.x + dx, y: el.frame.y + dy });
+      }
+
+      // Original slide untouched; ghosts drawn on top at GHOST_ALPHA;
+      // handles anchor to the originals.
+      this.paintMoveGhost(ghosts, originals, guides);
+    };
+    const onUp = (_ev: MouseEvent) => {
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+      const slideId = startSlide.id;
+      this.options.store.batch(() => {
+        for (const [id, frame] of committed) {
+          this.options.store.updateElementFrame(slideId, id, frame);
+        }
+      });
+      this.renderer.markDirty();
+      this.render();
+      // Clear lingering snap-guide nodes from the last `paintMoveGhost`.
+      this.repaintOverlay();
+    };
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp);
+  }
+```
+
+- [ ] **Step 4: Run the slides test suite**
+
+Run: `pnpm --filter @wafflebase/slides test`
+Expected: PASS — both existing drag tests (single + multi-select drag,
+editor.test.ts lines 117 and 145) plus the new "no mid-drag mutation"
+test.
+
+- [ ] **Step 5: Add a ghost-array assertion test**
+
+This test spies on the renderer to confirm `forceRender` receives a
+ghost array of the right length during the drag. Add after the test
+inserted in Step 1:
+
+```typescript
+  it('drag paints one ghost per selected non-connector element', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let aId = '';
+    let bId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      aId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 100, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+      bId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 400, y: 400, w: 100, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#0a0' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([aId, bId]);
+
+    // Spy on canvas 2D fillRect to count paints per mousemove. Element
+    // fills each call beginPath/fill — but a much cleaner signal is the
+    // overlay's selected-handles count, which equals selection size for
+    // multi-select (axis-aligned bbox handles).
+    dispatchMouseDown(canvas, 150, 150);
+    document.dispatchEvent(new PointerEvent('pointermove', { clientX: 200, clientY: 180, bubbles: true }));
+    // Selection handles still anchor to original frames — they should
+    // NOT have moved with the ghost.
+    const handles = overlay.querySelectorAll('[data-handle]');
+    expect(handles.length).toBeGreaterThan(0);
+    // Bounding-bbox top-left handle ('nw') in axis-aligned multi-select
+    // sits at min(x) of selected originals: x=100, y=100.
+    const nw = overlay.querySelector<HTMLDivElement>('[data-handle="nw"]')!;
+    expect(parseFloat(nw.style.left)).toBeCloseTo(100 - 4, 0); // handle is centred on the corner; size 8 → offset -4
+    expect(parseFloat(nw.style.top)).toBeCloseTo(100 - 4, 0);
+
+    document.dispatchEvent(new PointerEvent('pointerup', { clientX: 200, clientY: 180, bubbles: true }));
+  });
+```
+
+- [ ] **Step 6: Run the new test**
+
+Run: `pnpm --filter @wafflebase/slides test editor`
+Expected: PASS.
+
+If the handle-offset assertion fails because of an unrelated centring
+convention, inspect the actual `style.left` value in the failure
+output and adjust the `-4` offset to match — the meaningful assertion
+is that the handle's left/top is anchored near `(100, 100)` (the
+original position) rather than near `(150, 130)` (the dragged
+position).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/slides/src/view/editor/editor.ts \
+        packages/slides/test/view/editor/editor.test.ts
+git commit -m "Slides: ghost preview for shape drag-move"
+```
+
+---
+
+## Chunk 3: Move cursor on selected-shape hover
+
+### Task 4: Show `move` cursor when hovering a selected element's bbox
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/editor.ts` (extend the existing canvas `pointermove` handler at line 845)
+- Test: `packages/slides/test/view/editor/editor.test.ts`
+
+Today the `pointermove` handler only drives the insert hover preview.
+Extend it: when not in insert mode and the pointer is inside a selected
+element's bounding box, set `canvas.style.cursor = 'move'`. Cache the
+last value so we don't write to the DOM every `mousemove`.
+
+- [ ] **Step 1: Write a failing test**
+
+Add to `packages/slides/test/view/editor/editor.test.ts` (near the
+other cursor tests, after the `setInsertMode toggles a crosshair cursor`
+test around line 91):
+
+```typescript
+  it('hover over a selected shape sets cursor to move', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([elementId]);
+    // Hover inside the selected shape's bbox.
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 150, clientY: 150, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('move');
+    // Hover empty space — cursor returns to default.
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 800, clientY: 500, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('');
+  });
+
+  it('hover over a non-selected shape does not set move cursor', () => {
+    const { canvas, overlay, store } = makeFixture();
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    // No selection.
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 150, clientY: 150, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('');
+  });
+
+  it('move cursor logic is skipped for non-mouse pointers (touch)', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([elementId]);
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 150, clientY: 150, pointerType: 'touch', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('');
+  });
+
+  it('hover does not override the crosshair cursor in insert mode', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([elementId]);
+    editor.setInsertMode('rect');
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 150, clientY: 150, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('crosshair');
+  });
+```
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `pnpm --filter @wafflebase/slides test editor`
+Expected: FAIL — the four new tests expect `'move'` / `''` / unchanged
+`'crosshair'`, but the current handler never writes the cursor outside
+insert mode.
+
+- [ ] **Step 3: Implement hover-cursor logic**
+
+In `packages/slides/src/view/editor/editor.ts`, find the
+`onInsertHoverMove` method (starts around line 1160). Add a new
+method right after it:
+
+```typescript
+  /**
+   * Drag-affordance cursor. On `pointermove` over the canvas, if the
+   * pointer is a mouse and we're idle (no insert mode, no text edit, no
+   * handle hit), set `cursor: move` whenever the pointer is inside the
+   * bbox of any selected element. Otherwise restore the default.
+   *
+   * Cached against `lastHoverCursor` so we only touch the DOM when the
+   * value actually changes — `pointermove` fires at frame rate and
+   * writing identical strings to `style.cursor` is wasted work.
+   */
+  private onSelectionHoverMove(e: MouseEvent): void {
+    if (e.pointerType !== undefined && e.pointerType !== 'mouse') return;
+    if (this.insertKind !== null) return;
+    if (this.editingElementId !== null) return;
+    if (this.handleAtClient(e.clientX, e.clientY) !== null) return;
+
+    const desired = this.isPointerOverSelected(e.clientX, e.clientY) ? 'move' : '';
+    if (this.lastHoverCursor === desired) return;
+    this.lastHoverCursor = desired;
+    this.options.canvas.style.cursor = desired;
+  }
+
+  private isPointerOverSelected(clientX: number, clientY: number): boolean {
+    const slide = this.currentSlide();
+    if (!slide) return false;
+    const selectedIds = new Set(this.selection.get());
+    if (selectedIds.size === 0) return false;
+    const { x, y } = this.clientToLogical(clientX, clientY);
+    for (const el of slide.elements) {
+      if (!selectedIds.has(el.id)) continue;
+      const f = el.frame;
+      if (x >= f.x && x <= f.x + f.w && y >= f.y && y <= f.y + f.h) return true;
+    }
+    return false;
+  }
+```
+
+Then add the `lastHoverCursor` field near the other private cursor
+state (look for `private insertKind` around line 281; insert the new
+field nearby):
+
+```typescript
+  private lastHoverCursor: string = '';
+```
+
+Now wire the new handler into the existing `pointermove` listener.
+Find `attachInteractions` (line 822). Replace the line:
+
+```typescript
+    const onMove = (e: Event) => this.onInsertHoverMove(e as MouseEvent);
+```
+
+with:
+
+```typescript
+    const onMove = (e: Event) => {
+      this.onInsertHoverMove(e as MouseEvent);
+      this.onSelectionHoverMove(e as MouseEvent);
+    };
+```
+
+Reset the cached cursor on `pointerleave` so a leave→re-enter cycle
+always writes the new value. In the same method, find `onLeave`:
+
+```typescript
+    const onLeave = () => this.onInsertHoverLeave();
+```
+
+Replace with:
+
+```typescript
+    const onLeave = () => {
+      this.onInsertHoverLeave();
+      if (this.lastHoverCursor !== '' && this.insertKind === null) {
+        this.options.canvas.style.cursor = '';
+        this.lastHoverCursor = '';
+      }
+    };
+```
+
+Insert mode also needs to reset the cache. Find `setInsertMode` (line
+696) and update it so that when leaving insert mode the cache is
+cleared too — the existing code at line 707 already writes
+`canvas.style.cursor = ''` when `kind === null`. Add one line right
+after the existing `this.options.overlay.style.cursor = cursor;`:
+
+```typescript
+    if (kind === null) this.lastHoverCursor = '';
+```
+
+- [ ] **Step 4: Run the cursor tests — confirm they pass**
+
+Run: `pnpm --filter @wafflebase/slides test editor`
+Expected: PASS for the four new cursor tests AND all existing tests.
+
+- [ ] **Step 5: Verify no flicker via assertion**
+
+Add one more test that calls `pointermove` twice in the selected bbox
+and asserts the cursor was only written once (i.e., the cache works):
+
+```typescript
+  it('repeated pointermove inside a selected shape does not re-write cursor', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([elementId]);
+
+    let writes = 0;
+    const desc = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'style')!;
+    // jsdom uses CSSStyleDeclaration; intercept the cursor setter on
+    // this instance only.
+    const original = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(canvas.style),
+      'cursor',
+    );
+    Object.defineProperty(canvas.style, 'cursor', {
+      configurable: true,
+      get() {
+        return (this as unknown as { _cursor?: string })._cursor ?? '';
+      },
+      set(v: string) {
+        (this as unknown as { _cursor?: string })._cursor = v;
+        writes++;
+      },
+    });
+
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 150, clientY: 150, pointerType: 'mouse', bubbles: true,
+    }));
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 160, clientY: 160, pointerType: 'mouse', bubbles: true,
+    }));
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 170, clientY: 160, pointerType: 'mouse', bubbles: true,
+    }));
+
+    expect(writes).toBe(1);
+
+    // Restore (avoid bleed into other tests).
+    if (original) Object.defineProperty(canvas.style, 'cursor', original);
+    void desc;
+  });
+```
+
+- [ ] **Step 6: Run the flicker test**
+
+Run: `pnpm --filter @wafflebase/slides test editor`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/slides/src/view/editor/editor.ts \
+        packages/slides/test/view/editor/editor.test.ts
+git commit -m "Slides: move cursor on hover over selected shape"
+```
+
+---
+
+## Chunk 4: Verification + smoke + PR
+
+### Task 5: Pre-commit verify and manual smoke
+
+- [ ] **Step 1: Lint + unit-test gate**
+
+Run: `pnpm verify:fast`
+Expected: PASS.
+
+- [ ] **Step 2: Slides-specific test pass**
+
+Run: `pnpm --filter @wafflebase/slides test`
+Expected: PASS.
+
+- [ ] **Step 3: Manual smoke in dev server**
+
+Run: `pnpm dev` (frontend at :5173, backend at :3000).
+
+Open a Slides document and verify:
+
+- Single shape: select it, hover inside → cursor is `move`. Click-drag
+  → original shape stays put; a translucent ghost follows the cursor;
+  selection handles stay on the original. Release → shape jumps to the
+  ghost's position.
+- Hover outside the selected shape (empty area or unselected shape) →
+  cursor returns to default.
+- Multi-select (Shift-click 2 shapes): drag from inside one → both show
+  ghosts at the same offset; union handles stay anchored to originals.
+- Snap: drag a shape near another's edge → magenta snap guides appear
+  at the ghost's snapped position.
+- Text box: select, drag → ghost shows the text-box outline + text at
+  reduced opacity.
+- Image: select, drag → ghost shows the image at reduced opacity.
+- Connector + shape: select both, drag → ghost shows for shape only;
+  connector stays at original endpoints during the drag; on release,
+  the connector re-routes to the shape's new position.
+- Insert mode: arm `rect` → cursor `crosshair` regardless of hover over
+  selected shapes (insert preview still works).
+
+- [ ] **Step 4: If anything looks off, fix and re-test before commit**
+
+Common gotchas:
+- Selection handles drift with the ghost → `paintMoveGhost` is passing
+  the wrong frames to `renderOverlay`. It must pass `originals` (the
+  pre-drag elements), not ghosts or live frames.
+- Ghost flicker on every frame → `forceRender` may not be receiving the
+  array; double-check `ghosts` is an array, not a single element.
+- Cursor flickers from `move` to default and back → cache isn't being
+  consulted; check `lastHoverCursor` is on the instance not module
+  scope.
+
+---
+
+### Task 6: Open PR
+
+- [ ] **Step 1: Rebase on `origin/main`**
+
+Run:
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+- [ ] **Step 2: Self code review**
+
+Dispatch `/code-review` over the branch diff. Address blocking findings.
+
+- [ ] **Step 3: Push branch and open PR**
+
+Title (≤70 chars): `Slides: ghost preview + move cursor for shape drag`
+
+Body:
+```markdown
+## Summary
+
+- Drag-move on slides shapes now paints a translucent ghost (at
+  `GHOST_ALPHA`) following the cursor while the original shape and
+  selection handles stay anchored. Commit happens on release.
+- Hover over a selected shape sets `cursor: move`.
+- Extends the existing ghost path in `slide-renderer.ts` from a single
+  optional element to an array; same path that already drives the
+  shape-insert hover preview.
+
+Design doc: `docs/design/slides/slides-shape-move.md`.
+
+Connector live re-routing during the preview, ESC mid-drag cancel,
+alt-drag clone, and keyboard-nudge ghosting are intentionally deferred.
+
+## Test plan
+
+- [x] `pnpm verify:fast`
+- [x] `pnpm --filter @wafflebase/slides test`
+- [x] Manual: single-shape drag → ghost shows, handles stay anchored,
+      release commits.
+- [x] Manual: multi-select drag → both ghosts at same offset.
+- [x] Manual: snap guides appear against ghost position.
+- [x] Manual: connector attached to a moved shape re-routes on commit.
+- [x] Manual: insert mode's crosshair cursor is not overridden by hover.
+```
+
+---
+
+### Task 7: Post-merge cleanup
+
+- [ ] **Step 1: Write lessons file**
+
+Create `docs/tasks/active/20260519-slides-shape-move-ghost-lessons.md`
+with anything surprising learned during implementation (e.g., a snap
+edge case, a jsdom quirk in the cursor test). One short note per
+lesson; skip if nothing notable.
+
+- [ ] **Step 2: Archive**
+
+```bash
+pnpm tasks:archive
+pnpm tasks:index
+```
+
+- [ ] **Step 3: Commit + push the archive move**
+
+```bash
+git add docs/tasks/
+git commit -m "Archive 20260519-slides-shape-move-ghost task"
+git push
+```

--- a/packages/slides/src/view/canvas/slide-renderer.ts
+++ b/packages/slides/src/view/canvas/slide-renderer.ts
@@ -72,21 +72,27 @@ export class SlideRenderer {
    * live-paint paths in the editor that need to draw an in-memory
    * frame override on every mousemove without committing to the store.
    *
-   * `ghost` — optional element drawn on top of the committed slide at
-   * `GHOST_ALPHA`. Used by two live-paint paths:
-   *   - shape-insert hover preview (the to-be-inserted shape under the
-   *     cursor before mousedown).
-   *   - connector endpoint drag preview (a ghost copy of the connector
-   *     with the dragged endpoint moved to the cursor target, while
-   *     the real connector stays anchored on `slide`).
+   * `ghosts` — optional elements drawn on top of the committed slide at
+   * `GHOST_ALPHA`. Used by three live-paint paths:
+   *   - shape-insert hover preview (single ghost of the to-be-inserted
+   *     shape under the cursor before mousedown).
+   *   - connector endpoint drag preview (single ghost copy of the
+   *     connector with the dragged endpoint moved to the cursor target,
+   *     while the real connector stays anchored on `slide`).
+   *   - shape-move drag preview (one ghost per selected element at the
+   *     dragged offset).
    * Kept out of `slide` so the ghost never participates in selection,
    * hit-test, or z-order. For a connector ghost, attached endpoints
    * still resolve through `slide`'s element lookup, so a half-attached
    * ghost line stays visually anchored to its host shape.
    */
-  forceRender(slide: Slide, doc: SlidesDocument, ghost?: Element): void {
+  forceRender(
+    slide: Slide,
+    doc: SlidesDocument,
+    ghosts?: ReadonlyArray<Element>,
+  ): void {
     this.dirty = true;
-    drawSlide(this.ctx, slide, doc, this.options, () => this.markDirty(), ghost);
+    drawSlide(this.ctx, slide, doc, this.options, () => this.markDirty(), ghosts);
     this.dirty = false;
   }
 }
@@ -103,7 +109,7 @@ export function drawSlide(
   doc: SlidesDocument,
   options: SlideRendererOptions,
   onAssetLoad: () => void = () => undefined,
-  ghost?: Element,
+  ghosts?: ReadonlyArray<Element>,
 ): void {
   const theme = getActiveTheme(doc);
   const { hostWidth, hostHeight, dpr } = options;
@@ -159,16 +165,17 @@ export function drawSlide(
     drawElement(ctx, element, doc, theme, onAssetLoad, elementsLookup);
   }
 
-  if (ghost !== undefined) {
-    // Paint the hover-preview ghost on top of the committed slide so
-    // its semi-transparency reveals the underlying content. Using
-    // `globalAlpha` rather than per-shape opacity means every kind
-    // (filled basic, outlined callout, two-tone action button) ends
-    // up at the same readable opacity without per-renderer tweaks.
-    ctx.save();
-    ctx.globalAlpha = GHOST_ALPHA;
-    drawElement(ctx, ghost, doc, theme, onAssetLoad, elementsLookup);
-    ctx.restore();
+  if (ghosts !== undefined && ghosts.length > 0) {
+    // Paint hover/drag-preview ghosts on top of the committed slide so
+    // their semi-transparency reveals the underlying content. One
+    // save/restore band per ghost keeps `globalAlpha` writes scoped
+    // and isolates any future per-ghost style overrides.
+    for (const ghost of ghosts) {
+      ctx.save();
+      ctx.globalAlpha = GHOST_ALPHA;
+      drawElement(ctx, ghost, doc, theme, onAssetLoad, elementsLookup);
+      ctx.restore();
+    }
   }
 }
 

--- a/packages/slides/src/view/canvas/slide-renderer.ts
+++ b/packages/slides/src/view/canvas/slide-renderer.ts
@@ -89,7 +89,7 @@ export class SlideRenderer {
   forceRender(
     slide: Slide,
     doc: SlidesDocument,
-    ghosts?: ReadonlyArray<Element>,
+    ghosts?: readonly Element[],
   ): void {
     this.dirty = true;
     drawSlide(this.ctx, slide, doc, this.options, () => this.markDirty(), ghosts);
@@ -109,7 +109,7 @@ export function drawSlide(
   doc: SlidesDocument,
   options: SlideRendererOptions,
   onAssetLoad: () => void = () => undefined,
-  ghosts?: ReadonlyArray<Element>,
+  ghosts?: readonly Element[],
 ): void {
   const theme = getActiveTheme(doc);
   const { hostWidth, hostHeight, dpr } = options;

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1399,7 +1399,7 @@ class SlidesEditorImpl implements SlidesEditor {
       { x: this.hoverPreview.x, y: this.hoverPreview.y },
     );
     const ghost = { ...init, id: '__hover_preview__' } as Element;
-    this.renderer.forceRender(slide, this.options.store.read(), ghost);
+    this.renderer.forceRender(slide, this.options.store.read(), [ghost]);
   }
 
   private startInsert(clientX: number, clientY: number): void {
@@ -1442,7 +1442,7 @@ class SlidesEditorImpl implements SlidesEditor {
       endPoint = this.clientToLogical(ev.clientX, ev.clientY);
       const init = buildInsertElement(kind, start, endPoint);
       const ghost = { ...init, id: '__preview__' } as Element;
-      this.renderer.forceRender(slide, this.options.store.read(), ghost);
+      this.renderer.forceRender(slide, this.options.store.read(), [ghost]);
     };
     const cleanup = () => {
       document.removeEventListener('pointermove', onMove);
@@ -1518,7 +1518,7 @@ class SlidesEditorImpl implements SlidesEditor {
       this.connectorCursor = endPoint;
       const init = buildConnectorInit(variant, start, endPoint, slide.elements, this.scale());
       const ghost = { ...init, id: '__preview__' } as Element;
-      this.renderer.forceRender(slide, this.options.store.read(), ghost);
+      this.renderer.forceRender(slide, this.options.store.read(), [ghost]);
       // Repaint the overlay so the connection-points dots track the
       // cursor. The forceRender above paints the canvas; the overlay
       // is a separate DOM layer and needs its own update.

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1403,12 +1403,18 @@ class SlidesEditorImpl implements SlidesEditor {
   private isPointerOverSelected(clientX: number, clientY: number): boolean {
     const slide = this.currentSlide();
     if (!slide) return false;
-    const selectedIds = new Set(this.selection.get());
-    if (selectedIds.size === 0) return false;
+    const selectedIds = this.selection.get();
+    if (selectedIds.length === 0) return false;
+    const scope = this.selection.getScope();
     const { x, y } = this.clientToLogical(clientX, clientY);
-    for (const el of slide.elements) {
-      if (!selectedIds.has(el.id)) continue;
-      if (containsPoint(el.frame, x, y)) return true;
+    // Hit-test against world frames so drilled-in selections (elements
+    // inside a group) also flip the cursor — `slide.elements` is the
+    // top-level tree, so a raw walk would miss grouped descendants.
+    for (const id of selectedIds) {
+      const el = findElement(slide.elements, id);
+      if (!el) continue;
+      const worldFrame = toWorldFrame(el.frame, scope, slide);
+      if (containsPoint(worldFrame, x, y)) return true;
     }
     return false;
   }
@@ -1686,16 +1692,6 @@ class SlidesEditorImpl implements SlidesEditor {
     }
     if (originalWorldFrames.size === 0) return;
 
-    // Connectors render via endpoint lookup; their `frame` is derived,
-    // not stored, so a frame-only ghost would paint at the wrong place.
-    // Excluding them from `ghostSources` makes the connector render at
-    // its original endpoint geometry during the drag preview; on
-    // commit, `commitTranslate` moves the endpoints by (liveDx, liveDy).
-    const ghostSources: Element[] = [];
-    for (const el of originals.values()) {
-      if (el.type !== 'connector') ghostSources.push(el);
-    }
-
     const start = this.clientToLogical(clientX, clientY);
     // Collect snap candidates within the active scope, excluding the
     // dragged elements. Each candidate is an axis-aligned AABB so
@@ -1720,17 +1716,35 @@ class SlidesEditorImpl implements SlidesEditor {
       liveDx = dx;
       liveDy = dy;
 
-      // Ghosts paint at WORLD coords — they bypass the scope coordinate
-      // system because they're drawn on top of the unmodified slide
+      // Ghosts paint at WORLD coords on top of the unmodified slide
       // (which itself paints group-local frames through their group's
-      // transform). The original slide is untouched.
-      const ghosts: Element[] = ghostSources.map((el) => {
-        const baseWorld = originalWorldFrames.get(el.id)!;
-        return {
-          ...el,
-          frame: { ...baseWorld, x: baseWorld.x + dx, y: baseWorld.y + dy },
-        } as Element;
-      });
+      // transform). Non-connectors translate their world frame;
+      // connectors render via endpoint lookup, so their ghost must
+      // translate the endpoints — free endpoints by (dx, dy), attached
+      // endpoints stay anchored to their host shape. This mirrors what
+      // `translateElement` and `commitTranslate` do on commit, so the
+      // ghost preview matches the post-commit visual.
+      const ghosts: Element[] = [];
+      for (const el of originals.values()) {
+        if (el.type === 'connector') {
+          ghosts.push({
+            ...el,
+            start: el.start.kind === 'free'
+              ? { kind: 'free', x: el.start.x + dx, y: el.start.y + dy }
+              : el.start,
+            end: el.end.kind === 'free'
+              ? { kind: 'free', x: el.end.x + dx, y: el.end.y + dy }
+              : el.end,
+            frame: { ...el.frame, x: el.frame.x + dx, y: el.frame.y + dy },
+          } as Element);
+        } else {
+          const baseWorld = originalWorldFrames.get(el.id)!;
+          ghosts.push({
+            ...el,
+            frame: { ...baseWorld, x: baseWorld.x + dx, y: baseWorld.y + dy },
+          } as Element);
+        }
+      }
 
       // Handles anchor to the ORIGINAL world frames so the user reads
       // them as "where it started"; the ghost reads as "where it will

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1,5 +1,5 @@
 import type { Element, Frame, ShapeKind } from '../../model/element';
-import { combinedBoundingBox } from '../../model/frame';
+import { combinedBoundingBox, containsPoint } from '../../model/frame';
 import { DEFAULT_HIT_TOLERANCE, type HitTestCtx } from './element-hit';
 import { SLIDE_HEIGHT, SLIDE_WIDTH, type Slide } from '../../model/presentation';
 import type { SlidesStore } from '../../store/store';
@@ -1992,7 +1992,7 @@ class SlidesEditorImpl implements SlidesEditor {
       this.renderer.forceRender(
         startSlide,
         this.options.store.read(),
-        ghostConnector,
+        [ghostConnector],
       );
       // Overlay: original connector → handles stay at the pre-drag
       // positions. On mouseup, `dragEndpoint` commits and the next

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1402,8 +1402,7 @@ class SlidesEditorImpl implements SlidesEditor {
     const { x, y } = this.clientToLogical(clientX, clientY);
     for (const el of slide.elements) {
       if (!selectedIds.has(el.id)) continue;
-      const f = el.frame;
-      if (x >= f.x && x <= f.x + f.w && y >= f.y && y <= f.y + f.h) return true;
+      if (containsPoint(el.frame, x, y)) return true;
     }
     return false;
   }

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1255,6 +1255,12 @@ class SlidesEditorImpl implements SlidesEditor {
     // the editor (toolbar etc.) reflects the active target.
     this.selection.set([elementId]);
     this.editingElementId = elementId;
+    // Drop any stale hover-move cursor; once text-edit owns the box,
+    // the next pointermove path early-returns without touching cursor.
+    if (this.lastHoverCursor !== '') {
+      this.options.canvas.style.cursor = '';
+      this.lastHoverCursor = '';
+    }
 
     const blocks = element.data.blocks;
     // Escape sets `cancelled` first, THEN the docs editor routes the

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1619,8 +1619,8 @@ class SlidesEditorImpl implements SlidesEditor {
     const selectedIds = new Set(this.selection.get());
 
     // Capture each selected element's frame in WORLD coordinates and
-    // the element snapshot itself. The frame map drives snap math /
-    // overlay placement; the element map is needed at commit time
+    // the element snapshot itself. The world-frame map drives snap math
+    // and ghost placement; the element map is needed at commit time
     // because connectors translate through their endpoints, not their
     // frame — `commitTranslate` reads `el.start`/`el.end` from the
     // pre-drag snapshot.
@@ -1634,14 +1634,22 @@ class SlidesEditorImpl implements SlidesEditor {
     }
     if (originalWorldFrames.size === 0) return;
 
+    // Connectors render via endpoint lookup; their `frame` is derived,
+    // not stored, so a frame-only ghost would paint at the wrong place.
+    // Excluding them from `ghostSources` makes the connector render at
+    // its original endpoint geometry during the drag preview; on
+    // commit, `commitTranslate` moves the endpoints by (liveDx, liveDy).
+    const ghostSources: Element[] = [];
+    for (const el of originals.values()) {
+      if (el.type !== 'connector') ghostSources.push(el);
+    }
+
     const start = this.clientToLogical(clientX, clientY);
     // Collect snap candidates within the active scope, excluding the
     // dragged elements. Each candidate is an axis-aligned AABB so
     // rotated shapes/groups snap against their visible bbox.
     const otherFrames = collectSnapCandidates(startSlide, [...scope], selectedIds);
 
-    // Track live world frames in memory; commit once at mouseup.
-    const live = new Map(originalWorldFrames);
     let liveDx = 0;
     let liveDy = 0;
 
@@ -1650,46 +1658,74 @@ class SlidesEditorImpl implements SlidesEditor {
       const rawDx = cur.x - start.x;
       const rawDy = cur.y - start.y;
       const bbox = combinedBoundingBox(Array.from(originalWorldFrames.values()))!;
-      const { dx, dy, guides } = snapDelta(bbox, rawDx, rawDy, otherFrames, { w: SLIDE_WIDTH, h: SLIDE_HEIGHT });
+      const { dx, dy, guides } = snapDelta(
+        bbox,
+        rawDx,
+        rawDy,
+        otherFrames,
+        { w: SLIDE_WIDTH, h: SLIDE_HEIGHT },
+      );
       liveDx = dx;
       liveDy = dy;
 
-      for (const [id, base] of originalWorldFrames) {
-        live.set(id, { ...base, x: base.x + dx, y: base.y + dy });
-      }
-      // Repaint canvas + overlay with the live frames; we DO NOT touch
-      // the store yet. `guides` flow through to the overlay so magenta
-      // alignment lines render alongside the selection handles.
-      this.paintLiveScoped(live, scope, guides);
+      // Ghosts paint at WORLD coords — they bypass the scope coordinate
+      // system because they're drawn on top of the unmodified slide
+      // (which itself paints group-local frames through their group's
+      // transform). The original slide is untouched.
+      const ghosts: Element[] = ghostSources.map((el) => {
+        const baseWorld = originalWorldFrames.get(el.id)!;
+        return {
+          ...el,
+          frame: { ...baseWorld, x: baseWorld.x + dx, y: baseWorld.y + dy },
+        } as Element;
+      });
+
+      // Handles anchor to the ORIGINAL world frames so the user reads
+      // them as "where it started"; the ghost reads as "where it will
+      // land". Build pseudo-elements with the world frame patched in.
+      const handleElements: Element[] = Array.from(originals.values()).map((el) => ({
+        ...el,
+        frame: originalWorldFrames.get(el.id)!,
+      } as Element));
+
+      this.paintMoveGhost(ghosts, handleElements, guides);
     };
     const onUp = (_ev: MouseEvent) => {
       document.removeEventListener('pointermove', onMove);
       document.removeEventListener('pointerup', onUp);
-      // Commit one batch. Non-connectors get their live world frame
-      // converted back to scope-local before writing. Connectors take
-      // a different path: their world-coord endpoints translate by
-      // (liveDx, liveDy) through `commitTranslate`. `updateElementFrame`
-      // rejects connectors because their frame is derived from
-      // endpoints.
+      // Skip the batch when the pointer never moved past snap noise:
+      // an empty `store.batch` still pushes an undo snapshot and clears
+      // the redo stack. A pure click-without-drag must be a no-op
+      // against history.
+      if (liveDx === 0 && liveDy === 0) {
+        this.renderer.markDirty();
+        this.render();
+        this.repaintOverlay();
+        return;
+      }
       const slideId = startSlide.id;
       this.options.store.batch(() => {
-        for (const [id, worldFrame] of live) {
+        for (const [id, baseWorld] of originalWorldFrames) {
           const el = originals.get(id);
           if (!el) continue;
           if (el.type === 'connector') {
+            // Connectors translate via endpoints; `updateElementFrame`
+            // rejects them because their frame is derived.
             commitTranslate(this.options.store, slideId, el, liveDx, liveDy);
             continue;
           }
-          const localFrame = fromWorldFrame(worldFrame, scope, startSlide);
+          const newWorld = {
+            ...baseWorld,
+            x: baseWorld.x + liveDx,
+            y: baseWorld.y + liveDy,
+          };
+          const localFrame = fromWorldFrame(newWorld, scope, startSlide);
           this.options.store.updateElementFrame(slideId, id, localFrame);
         }
       });
       this.renderer.markDirty();
       this.render();
-      // `render()` repaints only the canvas — without an explicit overlay
-      // refresh, the magenta guide nodes from the last `paintLiveScoped`
-      // would persist after mouseup. `repaintOverlay()` rebuilds the
-      // overlay with `selected` and no `guides`, clearing them.
+      // Clear lingering snap-guide nodes from the last `paintMoveGhost`.
       this.repaintOverlay();
     };
     document.addEventListener('pointermove', onMove);
@@ -1764,8 +1800,6 @@ class SlidesEditorImpl implements SlidesEditor {
    * at their original endpoints during the drag preview. On commit, the
    * connector's normal endpoint-lookup path re-routes them.
    */
-  // @ts-expect-error TS6133 — wired up by `startDrag` in the next task
-  // of the shape-move-ghost plan; remove this directive then.
   private paintMoveGhost(
     ghosts: readonly Element[],
     selectedOriginals: readonly Element[],

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -304,6 +304,7 @@ interface ListenerEntry<E extends Event = Event> {
 class SlidesEditorImpl implements SlidesEditor {
   readonly selection = new Selection();
   insertKind: InsertKind | null = null;
+  private lastHoverCursor: string = '';
   private renderer: SlideRenderer;
   private listeners: ListenerEntry[] = [];
   private disposed = false;
@@ -841,6 +842,7 @@ class SlidesEditorImpl implements SlidesEditor {
     const cursor = kind === null ? '' : 'crosshair';
     this.options.canvas.style.cursor = cursor;
     this.options.overlay.style.cursor = cursor;
+    if (kind === null) this.lastHoverCursor = '';
     // Any insert-mode change clears the stale ghost: when the user
     // disarms (null), switches to text mode (no preview), or swaps
     // shape kind A → B, we drop the cached preview so the next
@@ -977,8 +979,17 @@ class SlidesEditorImpl implements SlidesEditor {
     // empty-area moves. mouseleave clears the ghost (otherwise it
     // would stick at the last in-canvas pointer position while the
     // user is in the toolbar).
-    const onMove = (e: Event) => this.onInsertHoverMove(e as MouseEvent);
-    const onLeave = () => this.onInsertHoverLeave();
+    const onMove = (e: Event) => {
+      this.onInsertHoverMove(e as MouseEvent);
+      this.onSelectionHoverMove(e as PointerEvent);
+    };
+    const onLeave = () => {
+      this.onInsertHoverLeave();
+      if (this.lastHoverCursor !== '' && this.insertKind === null) {
+        this.options.canvas.style.cursor = '';
+        this.lastHoverCursor = '';
+      }
+    };
     this.on(this.options.canvas, 'pointermove', onMove);
     this.on(this.options.canvas, 'pointerleave', onLeave);
     // Double-click on the slide canvas (or overlay, when the click
@@ -1359,6 +1370,42 @@ class SlidesEditorImpl implements SlidesEditor {
       this.hoverRenderRaf = null;
       this.paintWithHoverGhost();
     });
+  }
+
+  /**
+   * Drag-affordance cursor. On `pointermove` over the canvas, if the
+   * pointer is a mouse and we're idle (no insert mode, no text edit, no
+   * handle hit), set `cursor: move` whenever the pointer is inside the
+   * bbox of any selected element. Otherwise restore the default.
+   *
+   * Cached against `lastHoverCursor` so we only touch the DOM when the
+   * value actually changes — `pointermove` fires at frame rate and
+   * writing identical strings to `style.cursor` is wasted work.
+   */
+  private onSelectionHoverMove(e: PointerEvent): void {
+    if (e.pointerType !== undefined && e.pointerType !== 'mouse') return;
+    if (this.insertKind !== null) return;
+    if (this.editingElementId !== null) return;
+    if (this.handleAtClient(e.clientX, e.clientY) !== null) return;
+
+    const desired = this.isPointerOverSelected(e.clientX, e.clientY) ? 'move' : '';
+    if (this.lastHoverCursor === desired) return;
+    this.lastHoverCursor = desired;
+    this.options.canvas.style.cursor = desired;
+  }
+
+  private isPointerOverSelected(clientX: number, clientY: number): boolean {
+    const slide = this.currentSlide();
+    if (!slide) return false;
+    const selectedIds = new Set(this.selection.get());
+    if (selectedIds.size === 0) return false;
+    const { x, y } = this.clientToLogical(clientX, clientY);
+    for (const el of slide.elements) {
+      if (!selectedIds.has(el.id)) continue;
+      const f = el.frame;
+      if (x >= f.x && x <= f.x + f.w && y >= f.y && y <= f.y + f.h) return true;
+    }
+    return false;
   }
 
   /** Cursor left the canvas — drop the ghost and repaint cleanly. */

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1430,7 +1430,7 @@ class SlidesEditorImpl implements SlidesEditor {
     // Drag-to-size for shapes. Mark insertDragging so the hover-ghost
     // listener stops repainting; the drag preview below owns the
     // canvas until mouseup. The preview is rendered through the same
-    // `forceRender(slide, doc, ghost)` channel as the hover ghost so
+    // `forceRender(slide, doc, [ghost])` channel as the hover ghost so
     // the in-progress shape stays semi-transparent — the user can see
     // any underlying content while sizing, and the commit on mouseup
     // is the moment the shape goes opaque.
@@ -1490,7 +1490,7 @@ class SlidesEditorImpl implements SlidesEditor {
   /**
    * Drag-to-place flow for connectors. Mirrors `startInsert`'s shape
    * branch: live ghost preview during the drag (rendered via the same
-   * `forceRender(slide, doc, ghost)` channel), commit on mouseup,
+   * `forceRender(slide, doc, [ghost])` channel), commit on mouseup,
    * ESC cancels with capture-phase pre-emption so the keyboard rule's
    * own `setInsertMode(null)` Esc handler doesn't double-fire.
    *

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -3,6 +3,8 @@ import { combinedBoundingBox, containsPoint } from '../../model/frame';
 import { DEFAULT_HIT_TOLERANCE, type HitTestCtx } from './element-hit';
 import { SLIDE_HEIGHT, SLIDE_WIDTH, type Slide } from '../../model/presentation';
 import type { SlidesStore } from '../../store/store';
+import type { Endpoint } from '../../model/connector';
+import { resolveEndpoint } from '../canvas/connector-frame';
 import { SlideRenderer, type SlideRendererOptions } from '../canvas/slide-renderer';
 import {
   alignFrames,
@@ -51,7 +53,7 @@ import { snapDelta, type SnapGuide } from './snap';
 import { collectSnapCandidates } from './snap-candidates';
 import { toWorldFrame, fromWorldFrame } from './frame-space';
 import { mountSlidesTextBox, type SlidesTextBoxEditor } from './text-box-editor';
-import { findElementPath } from '../../model/group';
+import { findElementPath, flattenElements } from '../../model/group';
 
 /**
  * Connector insert-mode keys exposed by `setInsertMode`. Distinct from
@@ -1698,6 +1700,14 @@ class SlidesEditorImpl implements SlidesEditor {
     // rotated shapes/groups snap against their visible bbox.
     const otherFrames = collectSnapCandidates(startSlide, [...scope], selectedIds);
 
+    // Lookup map for resolving connector endpoints to world coords —
+    // needed when a ghost connector's attached endpoint targets a
+    // dragged shape (the ghost line must follow the ghost shape's
+    // connection site, not snap back to the original).
+    const slideLookup = new Map<string, Element>(
+      flattenElements(startSlide.elements).map((e) => [e.id, e] as const),
+    );
+
     let liveDx = 0;
     let liveDy = 0;
 
@@ -1718,23 +1728,40 @@ class SlidesEditorImpl implements SlidesEditor {
 
       // Ghosts paint at WORLD coords on top of the unmodified slide
       // (which itself paints group-local frames through their group's
-      // transform). Non-connectors translate their world frame;
-      // connectors render via endpoint lookup, so their ghost must
-      // translate the endpoints — free endpoints by (dx, dy), attached
-      // endpoints stay anchored to their host shape. This mirrors what
-      // `translateElement` and `commitTranslate` do on commit, so the
-      // ghost preview matches the post-commit visual.
+      // transform). Non-connectors translate their world frame.
+      //
+      // Connectors render via endpoint lookup against the underlying
+      // slide elements, so we must materialize each endpoint into the
+      // ghost itself rather than relying on the lookup:
+      //  - `free` endpoint            → translate by (dx, dy).
+      //  - `attached` to a dragged    → resolve to world coords and
+      //    element                      translate by (dx, dy) so the
+      //                                 ghost line meets the ghost
+      //                                 shape's connection site.
+      //  - `attached` to a non-dragged → keep as-is; the renderer
+      //    element                      resolves it against the
+      //                                 untouched slide, matching the
+      //                                 commit-time behavior of
+      //                                 `commitTranslate` (which only
+      //                                 moves free endpoints).
+      const ghostEndpoint = (ep: Endpoint): Endpoint => {
+        if (ep.kind === 'free') {
+          return { kind: 'free', x: ep.x + dx, y: ep.y + dy };
+        }
+        if (selectedIds.has(ep.elementId)) {
+          const world = resolveEndpoint(ep, slideLookup);
+          return { kind: 'free', x: world.x + dx, y: world.y + dy };
+        }
+        return ep;
+      };
+
       const ghosts: Element[] = [];
       for (const el of originals.values()) {
         if (el.type === 'connector') {
           ghosts.push({
             ...el,
-            start: el.start.kind === 'free'
-              ? { kind: 'free', x: el.start.x + dx, y: el.start.y + dy }
-              : el.start,
-            end: el.end.kind === 'free'
-              ? { kind: 'free', x: el.end.x + dx, y: el.end.y + dy }
-              : el.end,
+            start: ghostEndpoint(el.start),
+            end: ghostEndpoint(el.end),
             frame: { ...el.frame, x: el.frame.x + dx, y: el.frame.y + dy },
           } as Element);
         } else {

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1753,6 +1753,37 @@ class SlidesEditorImpl implements SlidesEditor {
     });
   }
 
+  /**
+   * Drag-move preview: paint the slide unchanged + a translucent ghost
+   * of each selected element at its dragged position. Overlay handles
+   * render against the **original** frames so they stay anchored to the
+   * starting position (the user reads the ghost as "where it will land"
+   * and the handles as "where it started").
+   *
+   * Connectors are excluded from `ghosts` for v1; they keep rendering
+   * at their original endpoints during the drag preview. On commit, the
+   * connector's normal endpoint-lookup path re-routes them.
+   */
+  // @ts-expect-error TS6133 — wired up by `startDrag` in the next task
+  // of the shape-move-ghost plan; remove this directive then.
+  private paintMoveGhost(
+    ghosts: readonly Element[],
+    selectedOriginals: readonly Element[],
+    guides: readonly SnapGuide[] = [],
+  ): void {
+    const slide = this.currentSlide();
+    if (!slide) return;
+    this.renderer.forceRender(slide, this.options.store.read(), ghosts);
+    renderOverlay(this.options.overlay, selectedOriginals, {
+      scale: this.scale(),
+      slideWidth: SLIDE_WIDTH,
+      slideHeight: SLIDE_HEIGHT,
+      guides,
+      allElements: slide.elements,
+      connectorAffordance: this.connectorAffordance(),
+    });
+  }
+
   private currentSlide() {
     const id = this.currentId;
     if (!id) return undefined;

--- a/packages/slides/test/view/canvas/slide-renderer.test.ts
+++ b/packages/slides/test/view/canvas/slide-renderer.test.ts
@@ -8,8 +8,10 @@ import { BUILT_IN_LAYOUTS } from '../../../src/model/layout';
 import { asCtx, createCtxSpy } from '../../../src/view/canvas/ctx-spy';
 // Install Path2D global before the slide renderer pulls in shape builders.
 import '../../../src/view/canvas/test-canvas-env';
-import { SlideRenderer } from '../../../src/view/canvas/slide-renderer';
+import { SlideRenderer, drawSlide } from '../../../src/view/canvas/slide-renderer';
 import { clearImageCacheForTests } from '../../../src/view/canvas/image-cache';
+import { MemSlidesStore } from '../../../src/store/memory';
+import type { Element } from '../../../src/model/element';
 
 const THEME: Theme = {
   id: 't', name: 't',
@@ -250,5 +252,75 @@ describe('SlideRenderer.render', () => {
     // fillStyle assignment should land that hex even though the
     // model-level color was a role binding.
     expect(ctx.fillStyle).toBe('#fff');
+  });
+});
+
+function buildDoc() {
+  const store = new MemSlidesStore();
+  let elementId = '';
+  store.batch(() => {
+    const sid = store.addSlide('blank');
+    elementId = store.addElement(sid, {
+      type: 'shape',
+      frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+      data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+    });
+  });
+  const doc = store.read();
+  const slide = doc.slides[0];
+  return { doc, slide, elementId };
+}
+
+function makeGhost(id: string, x: number): Element {
+  return {
+    id,
+    type: 'shape',
+    frame: { x, y: 100, w: 100, h: 100, rotation: 0 },
+    data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+  } as Element;
+}
+
+describe('drawSlide ghosts', () => {
+  it('each ghost adds one wrapper save/restore plus the drawElement save/restore on top of the baseline', () => {
+    const { doc, slide } = buildDoc();
+    const opts = { hostWidth: SLIDE_WIDTH, hostHeight: SLIDE_HEIGHT, dpr: 1 };
+
+    const baseline = createCtxSpy();
+    drawSlide(asCtx(baseline), slide, doc, opts);
+
+    const twoGhosts = createCtxSpy();
+    drawSlide(
+      asCtx(twoGhosts),
+      slide,
+      doc,
+      opts,
+      () => undefined,
+      [makeGhost('g1', 300), makeGhost('g2', 600)],
+    );
+
+    // Each ghost contributes the new wrapper save/restore (for the
+    // `globalAlpha` scope) AND the per-element save/restore that
+    // `drawElement` always emits for the frame transform. With two
+    // ghosts that is 2 * 2 = 4 additional save/restore pairs on top
+    // of the baseline.
+    expect(twoGhosts.save.mock.calls.length).toBe(
+      baseline.save.mock.calls.length + 4,
+    );
+    expect(twoGhosts.restore.mock.calls.length).toBe(
+      baseline.restore.mock.calls.length + 4,
+    );
+  });
+
+  it('omitting ghosts equals an empty array', () => {
+    const { doc, slide } = buildDoc();
+    const opts = { hostWidth: SLIDE_WIDTH, hostHeight: SLIDE_HEIGHT, dpr: 1 };
+
+    const omitted = createCtxSpy();
+    const empty = createCtxSpy();
+    drawSlide(asCtx(omitted), slide, doc, opts);
+    drawSlide(asCtx(empty), slide, doc, opts, () => undefined, []);
+
+    expect(omitted.save.mock.calls.length).toBe(empty.save.mock.calls.length);
+    expect(omitted.restore.mock.calls.length).toBe(empty.restore.mock.calls.length);
   });
 });

--- a/packages/slides/test/view/canvas/slide-renderer.test.ts
+++ b/packages/slides/test/view/canvas/slide-renderer.test.ts
@@ -232,7 +232,7 @@ describe('SlideRenderer.render', () => {
     ctx.stroke.mockImplementation(() => {
       alphaAtStroke.push(ctx.globalAlpha);
     });
-    renderer.forceRender(slide, DOC, ghostConnector);
+    renderer.forceRender(slide, DOC, [ghostConnector]);
     // The ghost connector's line strokes once.
     expect(alphaAtStroke).toContain(GHOST_ALPHA);
     // And `save`/`restore` bracket the ghost paint so the alpha

--- a/packages/slides/test/view/canvas/slide-renderer.test.ts
+++ b/packages/slides/test/view/canvas/slide-renderer.test.ts
@@ -8,7 +8,7 @@ import { BUILT_IN_LAYOUTS } from '../../../src/model/layout';
 import { asCtx, createCtxSpy } from '../../../src/view/canvas/ctx-spy';
 // Install Path2D global before the slide renderer pulls in shape builders.
 import '../../../src/view/canvas/test-canvas-env';
-import { SlideRenderer, drawSlide } from '../../../src/view/canvas/slide-renderer';
+import { SlideRenderer, drawSlide, GHOST_ALPHA } from '../../../src/view/canvas/slide-renderer';
 import { clearImageCacheForTests } from '../../../src/view/canvas/image-cache';
 import { MemSlidesStore } from '../../../src/store/memory';
 import type { Element } from '../../../src/model/element';
@@ -281,16 +281,24 @@ function makeGhost(id: string, x: number): Element {
 }
 
 describe('drawSlide ghosts', () => {
-  it('each ghost adds one wrapper save/restore plus the drawElement save/restore on top of the baseline', () => {
+  it('paints each ghost with globalAlpha set to GHOST_ALPHA', () => {
     const { doc, slide } = buildDoc();
     const opts = { hostWidth: SLIDE_WIDTH, hostHeight: SLIDE_HEIGHT, dpr: 1 };
 
-    const baseline = createCtxSpy();
-    drawSlide(asCtx(baseline), slide, doc, opts);
+    const spy = createCtxSpy();
+    // Observe every write to globalAlpha. The ghost band sets it to
+    // GHOST_ALPHA between save() and restore(); the rest of the render
+    // either never writes it or writes 1.
+    const alphaWrites: number[] = [];
+    let alpha = spy.globalAlpha;
+    Object.defineProperty(spy, 'globalAlpha', {
+      configurable: true,
+      get() { return alpha; },
+      set(v: number) { alpha = v; alphaWrites.push(v); },
+    });
 
-    const twoGhosts = createCtxSpy();
     drawSlide(
-      asCtx(twoGhosts),
+      asCtx(spy),
       slide,
       doc,
       opts,
@@ -298,17 +306,9 @@ describe('drawSlide ghosts', () => {
       [makeGhost('g1', 300), makeGhost('g2', 600)],
     );
 
-    // Each ghost contributes the new wrapper save/restore (for the
-    // `globalAlpha` scope) AND the per-element save/restore that
-    // `drawElement` always emits for the frame transform. With two
-    // ghosts that is 2 * 2 = 4 additional save/restore pairs on top
-    // of the baseline.
-    expect(twoGhosts.save.mock.calls.length).toBe(
-      baseline.save.mock.calls.length + 4,
-    );
-    expect(twoGhosts.restore.mock.calls.length).toBe(
-      baseline.restore.mock.calls.length + 4,
-    );
+    // Both ghosts must have been painted at GHOST_ALPHA.
+    const ghostAlphaWrites = alphaWrites.filter((a) => a === GHOST_ALPHA);
+    expect(ghostAlphaWrites.length).toBe(2);
   });
 
   it('omitting ghosts equals an empty array', () => {

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -90,6 +90,121 @@ describe('initialize', () => {
     expect(overlay.style.cursor).toBe('');
   });
 
+  it('hover over a selected shape sets cursor to move', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([elementId]);
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 150, clientY: 150, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('move');
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 800, clientY: 500, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('');
+  });
+
+  it('hover over a non-selected shape does not set move cursor', () => {
+    const { canvas, overlay, store } = makeFixture();
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    // No selection.
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 150, clientY: 150, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('');
+  });
+
+  it('move cursor logic is skipped for non-mouse pointers (touch)', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([elementId]);
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 150, clientY: 150, pointerType: 'touch', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('');
+  });
+
+  it('hover does not override the crosshair cursor in insert mode', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([elementId]);
+    editor.setInsertMode('rect');
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 150, clientY: 150, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('crosshair');
+  });
+
+  it('repeated pointermove inside a selected shape does not re-write cursor', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([elementId]);
+
+    let writes = 0;
+    const cursorStore: { v: string } = { v: '' };
+    Object.defineProperty(canvas.style, 'cursor', {
+      configurable: true,
+      get() { return cursorStore.v; },
+      set(v: string) { cursorStore.v = v; writes++; },
+    });
+
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 150, clientY: 150, pointerType: 'mouse', bubbles: true,
+    }));
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 160, clientY: 160, pointerType: 'mouse', bubbles: true,
+    }));
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 170, clientY: 160, pointerType: 'mouse', bubbles: true,
+    }));
+
+    expect(writes).toBe(1);
+  });
+
   function dispatchMouseDown(target: globalThis.Element | Document, x: number, y: number, shift = false): void {
     target.dispatchEvent(new PointerEvent('pointerdown', {
       clientX: x, clientY: y, shiftKey: shift, bubbles: true,

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -205,6 +205,38 @@ describe('initialize', () => {
     expect(writes).toBe(1);
   });
 
+  it('hover hit-test respects element rotation', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        // Rotated 45deg around centre (200, 150). The bbox corners
+        // (100,100)/(300,200) are now empty space; the rotated extent
+        // pushes out beyond the axis-aligned bbox.
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: Math.PI / 4 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([elementId]);
+
+    // (100, 100) is INSIDE the axis-aligned bbox but OUTSIDE the rotated
+    // shape — the rotated rect's top-left corner is at the centre's
+    // y-axis-up direction, well above this point. Should be no 'move'.
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 100, clientY: 100, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('');
+
+    // Centre (200, 150) is inside the rotated rect — should be 'move'.
+    canvas.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: 200, clientY: 150, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(canvas.style.cursor).toBe('move');
+  });
+
   function dispatchMouseDown(target: globalThis.Element | Document, x: number, y: number, shift = false): void {
     target.dispatchEvent(new PointerEvent('pointerdown', {
       clientX: x, clientY: y, shiftKey: shift, bubbles: true,

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -394,6 +394,47 @@ describe('initialize', () => {
     expect(connectorAfter.frame.y - connectorBefore.frame.y).toBe(shapeDy);
   });
 
+  it('click-without-drag does not push a no-op undo snapshot or wipe redo', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let shapeId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      shapeId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+
+    // Establish a non-empty redo stack so we can verify the click does
+    // not silently wipe it.
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 10, y: 10, w: 20, h: 20, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#fff' } },
+      });
+    });
+    store.undo();
+    expect(store.canRedo()).toBe(true);
+    const undoBefore = store.canUndo();
+
+    editor.setSelection([shapeId]);
+    // Mousedown on the selected shape then immediate mouseup with no
+    // pointermove — the drag delta is 0. `onUp` must skip the batch
+    // entirely (an empty `store.batch` would push an undo snapshot and
+    // clear the redo stack).
+    dispatchMouseDown(canvas, 200, 150);
+    document.dispatchEvent(new PointerEvent('pointerup', { clientX: 200, clientY: 150, bubbles: true }));
+
+    // Undo state must be exactly what it was before the click.
+    expect(store.canUndo()).toBe(undoBefore);
+    // Redo stack must be intact.
+    expect(store.canRedo()).toBe(true);
+  });
+
   it('clicking on an already-selected element preserves the multi-selection and drags all of them', () => {
     const { canvas, overlay, store } = makeFixture();
     let aId = '';

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -142,6 +142,70 @@ describe('initialize', () => {
     void elementId;
   });
 
+  it('drag does not mutate the store until pointerup (ghost-only preview)', () => {
+    const { canvas, overlay, store } = makeFixture();
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    dispatchMouseDown(canvas, 200, 150);
+    // Mid-drag mousemove — frame in the store must still be the original.
+    document.dispatchEvent(new PointerEvent('pointermove', { clientX: 300, clientY: 220, bubbles: true }));
+    const midFrame = store.read().slides[0].elements[0].frame;
+    expect(midFrame.x).toBe(100);
+    expect(midFrame.y).toBe(100);
+    // Release commits.
+    document.dispatchEvent(new PointerEvent('pointerup', { clientX: 300, clientY: 220, bubbles: true }));
+    const finalFrame = store.read().slides[0].elements[0].frame;
+    expect(finalFrame.x).not.toBe(100);
+  });
+
+  it('multi-select drag keeps selection handles anchored to the original bbox', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let aId = '';
+    let bId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      aId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 100, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+      bId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 400, y: 400, w: 100, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#0a0' } },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([aId, bId]);
+
+    dispatchMouseDown(canvas, 150, 150);
+    document.dispatchEvent(new PointerEvent('pointermove', { clientX: 200, clientY: 180, bubbles: true }));
+
+    // Multi-select renders axis-aligned bbox handles. The 'nw' handle
+    // should anchor at the combined bbox top-left (min x = 100, min y = 100)
+    // even mid-drag, NOT at the dragged position.
+    const nw = overlay.querySelector<HTMLDivElement>('[data-handle="nw"]');
+    expect(nw).not.toBeNull();
+    const nwLeft = parseFloat(nw!.style.left);
+    const nwTop = parseFloat(nw!.style.top);
+    // Handles are centred on the corner with a small offset (HANDLE_SIZE/2 = 4).
+    // The meaningful assertion: handles are near (100, 100), NOT near (150, 130).
+    expect(nwLeft).toBeLessThan(120);
+    expect(nwTop).toBeLessThan(120);
+    expect(nwLeft).toBeGreaterThan(80);
+    expect(nwTop).toBeGreaterThan(80);
+
+    document.dispatchEvent(new PointerEvent('pointerup', { clientX: 200, clientY: 180, bubbles: true }));
+    void aId; void bId;
+  });
+
   it('clicking on an already-selected element preserves the multi-selection and drags all of them', () => {
     const { canvas, overlay, store } = makeFixture();
     let aId = '';

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -203,7 +203,48 @@ describe('initialize', () => {
     expect(nwTop).toBeGreaterThan(80);
 
     document.dispatchEvent(new PointerEvent('pointerup', { clientX: 200, clientY: 180, bubbles: true }));
-    void aId; void bId;
+  });
+
+  it('drag with a connector in the selection does not throw and translates both together', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let shapeId = '';
+    let connectorId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      shapeId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 100, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+      connectorId = store.addElement(sid, {
+        type: 'connector',
+        routing: 'straight',
+        start: { kind: 'free', x: 300, y: 300 },
+        end: { kind: 'free', x: 400, y: 400 },
+        arrowheads: {},
+        frame: { x: 300, y: 300, w: 100, h: 100, rotation: 0 },
+      });
+    });
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+    editor.setSelection([shapeId, connectorId]);
+
+    const shapeBefore = store.read().slides[0].elements.find((e) => e.id === shapeId)!;
+    const connectorBefore = store.read().slides[0].elements.find((e) => e.id === connectorId)!;
+    dispatchMouseDown(canvas, 150, 150);
+    document.dispatchEvent(new PointerEvent('pointermove', { clientX: 250, clientY: 200, bubbles: true }));
+    expect(() =>
+      document.dispatchEvent(new PointerEvent('pointerup', { clientX: 250, clientY: 200, bubbles: true })),
+    ).not.toThrow();
+
+    const shapeAfter = store.read().slides[0].elements.find((e) => e.id === shapeId)!;
+    const connectorAfter = store.read().slides[0].elements.find((e) => e.id === connectorId)!;
+    // Both elements translate by the same (dx, dy) — connector via
+    // commitTranslate (endpoints), shape via updateElementFrame.
+    const shapeDx = shapeAfter.frame.x - shapeBefore.frame.x;
+    const shapeDy = shapeAfter.frame.y - shapeBefore.frame.y;
+    expect(shapeDx).not.toBe(0);
+    expect(connectorAfter.frame.x - connectorBefore.frame.x).toBe(shapeDx);
+    expect(connectorAfter.frame.y - connectorBefore.frame.y).toBe(shapeDy);
   });
 
   it('clicking on an already-selected element preserves the multi-selection and drags all of them', () => {


### PR DESCRIPTION
## Summary

- Drag-move on a selected slide shape now paints a translucent ghost
  (at `GHOST_ALPHA`) following the cursor while the original shape +
  selection handles stay anchored. Store commits in a single
  `store.batch()` on `pointerup`.
- Hover over a selected shape sets `cursor: 'move'` (mouse pointers
  only; cached to avoid layout-thrash; rotation-aware via
  `containsPoint`).
- The renderer's existing single `ghost?: Element` slot is generalized
  to `readonly Element[]` so the same `GHOST_ALPHA` pipeline drives
  shape-insert hover preview (1 ghost), connector endpoint drag
  preview (1 ghost), and shape-move drag preview (N ghosts).
- Group-aware: world-space frames feed ghost positioning + snap math;
  commits go through `fromWorldFrame` → `updateElementFrame` for
  non-connectors and `commitTranslate` (endpoints) for connectors.

**Design:** [`docs/design/slides/slides-shape-move.md`](docs/design/slides/slides-shape-move.md)

**Deferred follow-ups:** live connector re-routing during ghost preview,
ESC mid-drag cancel, alt-drag clone, keyboard-nudge ghosting.

## Test plan

- [x] `pnpm verify:fast` (lint + unit; 792 docs, 1271 sheets, 1051+ slides, 143 backend)
- [x] Unit: ghost-array renderer + GHOST_ALPHA invariant
- [x] Unit: store untouched mid-drag; commit batches on `pointerup`
- [x] Unit: multi-select handles anchored to original bbox during drag
- [x] Unit: connector in multi-selection translates via endpoints, no throw
- [x] Unit: click-without-drag (zero delta) does not push undo or wipe redo
- [x] Unit: `move` cursor toggles on selected/unselected/touch/insert-mode/no-flicker
- [x] Unit: rotation-aware hit-test (point inside AABB but outside rotated rect)
- [x] Manual: single-shape drag — ghost follows cursor, handles anchored, release commits
- [x] Manual: multi-select drag — both ghosts at same offset, snap guides against ghost bbox
- [x] Manual: connector + shape multi-selection — connector translates with shape on commit
- [x] Manual: insert-mode crosshair is not overridden by hover-move
- [x] Manual: rotated shape — `move` cursor only inside the rotated body, not the AABB corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shape drag-move with semi-transparent preview that follows the cursor
  * Move cursor affordance when hovering over selected shapes

* **Documentation**
  * Added design documentation for shape drag-move behavior, including cursor interactions and rendering pipeline specifications

* **Tests**
  * Added test coverage for ghost rendering and hover cursor behavior in the editor

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->