### PR TITLE
Fix to catch referenced errors in IFERROR/IFNA

### DIFF
--- a/packages/sheets/src/formula/functions-helpers.ts
+++ b/packages/sheets/src/formula/functions-helpers.ts
@@ -1,5 +1,5 @@
 import { ParseTree } from 'antlr4ts/tree/ParseTree';
-import { EvalNode, ErrNode } from './formula';
+import { ErrValue, ErrValues, EvalNode, ErrNode } from './formula';
 import { ref2str } from './arguments';
 import { Grid } from '../model/core/types';
 import {
@@ -60,6 +60,22 @@ export function isFormulaError(value: unknown): value is FormulaError {
     value !== null &&
     (value as FormulaError).t === 'err'
   );
+}
+
+export function errorValueFromNode(
+  node: EvalNode,
+  grid?: Grid,
+): ErrValue | undefined {
+  if (node.t === 'err') {
+    return ErrValues.includes(node.v) ? node.v : undefined;
+  }
+  if (node.t === 'ref' && grid && !isSrng(node.v)) {
+    const stored = grid.get(node.v)?.v;
+    if (stored && (ErrValues as readonly string[]).includes(stored)) {
+      return stored as ErrValue;
+    }
+  }
+  return undefined;
 }
 
 export function getRefsFromExpression(

--- a/packages/sheets/src/formula/functions-info.ts
+++ b/packages/sheets/src/formula/functions-info.ts
@@ -1,6 +1,6 @@
 import { ParseTree } from 'antlr4ts/tree/ParseTree';
 import { FunctionContext } from '../../antlr/FormulaParser';
-import { ErrValue, ErrValues, EvalNode, ErrNode, errValueCode } from './formula';
+import { ErrValue, EvalNode, ErrNode, errValueCode } from './formula';
 import { NumberArgs } from './arguments';
 import { Grid } from '../model/core/types';
 import {
@@ -10,6 +10,7 @@ import {
   toSref,
 } from '../model/core/coordinates';
 import {
+  errorValueFromNode,
   toStr,
 } from './functions-helpers';
 
@@ -417,25 +418,12 @@ export function errortypeFunc(
   const exprs = ctx.args()?.expr() ?? [];
 
   const node = visit(exprs[0]);
-  const errValue = resolveErrValue(node, grid);
+  const errValue = errorValueFromNode(node, grid);
   if (errValue !== undefined) {
     return { t: 'num', v: errValueCode(errValue) };
   }
 
   return ErrNode.NA;
-}
-
-function resolveErrValue(node: EvalNode, grid?: Grid): ErrValue | undefined {
-  if (node.t === 'err') {
-    return errValueCode(node.v) > 0 ? node.v : undefined;
-  }
-  if (node.t === 'ref' && grid && !isSrng(node.v)) {
-    const stored = grid.get(node.v)?.v;
-    if (stored && (ErrValues as readonly string[]).includes(stored)) {
-      return stored as ErrValue;
-    }
-  }
-  return undefined;
 }
 
 /**

--- a/packages/sheets/src/formula/functions-logical.ts
+++ b/packages/sheets/src/formula/functions-logical.ts
@@ -4,6 +4,7 @@ import { ErrValue, EvalNode, ErrNode } from './formula';
 import { NumberArgs, BoolArgs } from './arguments';
 import { Grid } from '../model/core/types';
 import {
+  errorValueFromNode,
   toStr,
 } from './functions-helpers';
 
@@ -212,12 +213,12 @@ export function chooseFunc(
 export function iferrorFunc(
   ctx: FunctionContext,
   visit: (tree: ParseTree) => EvalNode,
-  _grid?: Grid,
+  grid?: Grid,
 ): EvalNode {
   const exprs = ctx.args()?.expr() ?? [];
 
   const value = visit(exprs[0]);
-  if (value.t === 'err') {
+  if (errorValueFromNode(value, grid) !== undefined) {
     return visit(exprs[1]);
   }
 
@@ -231,12 +232,12 @@ export function iferrorFunc(
 export function ifnaFunc(
   ctx: FunctionContext,
   visit: (tree: ParseTree) => EvalNode,
-  _grid?: Grid,
+  grid?: Grid,
 ): EvalNode {
   const exprs = ctx.args()?.expr() ?? [];
 
   const value = visit(exprs[0]);
-  if (value.t === 'err' && value.v === ErrValue.NA) {
+  if (errorValueFromNode(value, grid) === ErrValue.NA) {
     return visit(exprs[1]);
   }
 

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -825,12 +825,28 @@ describe('Formula', () => {
     expect(evaluate('=IFERROR("hello","error")')).toBe('hello');
     expect(evaluate('=IFERROR(1+2,"error")')).toBe('3');
     expect(evaluate('=IFERROR(SUM(),"fallback")')).toBe('fallback');
+
+    const grid: Grid = new Map<string, Cell>();
+    grid.set('A1', { v: '#DIV/0!' });
+    grid.set('A2', { v: '#N/A' });
+    grid.set('A3', { v: 'plain' });
+
+    expect(evaluate('=IFERROR(A1,"fallback")', grid)).toBe('fallback');
+    expect(evaluate('=IFERROR(A2,"fallback")', grid)).toBe('fallback');
+    expect(evaluate('=IFERROR(A3,"fallback")', grid)).toBe('plain');
   });
 
   it('should correctly evaluate IFNA function', () => {
     expect(evaluate('=IFNA(SUM(),"fallback")')).toBe('fallback');
     expect(evaluate('=IFNA(MOD(1,0),"fallback")')).toBe('#DIV/0!');
     expect(evaluate('=IFNA(10,"fallback")')).toBe('10');
+
+    const grid: Grid = new Map<string, Cell>();
+    grid.set('A1', { v: '#DIV/0!' });
+    grid.set('A2', { v: '#N/A' });
+
+    expect(evaluate('=IFNA(A1,"fallback")', grid)).toBe('#DIV/0!');
+    expect(evaluate('=IFNA(A2,"fallback")', grid)).toBe('fallback');
   });
 
   it('should correctly evaluate PI function', () => {


### PR DESCRIPTION
## Summary

- Reuse the referenced-cell error detection already used by `ERROR.TYPE`.
- Make `IFERROR(A1, fallback)` catch stored error sentinels from referenced cells.
- Make `IFNA(A1, fallback)` catch referenced `#N/A` while preserving other errors.

## Why

`IFERROR` and `IFNA` evaluate a cell reference to a ref node before the final result is rendered. That meant direct errors were caught, but a referenced cell whose stored value was an error sentinel leaked through. This keeps the behavior consistent with `ERROR.TYPE`, which already treats stored formula error values as errors.

## Linked Issues

Fixes #273

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅

Skip reason (if applicable):

Local verification:

- `pnpm --filter @wafflebase/sheets exec vitest run test/formula/formula.test.ts -t "IFERROR|IFNA|ERROR.TYPE"`
- `pnpm --filter @wafflebase/sheets typecheck`
- `TZ=UTC pnpm --filter @wafflebase/sheets test`
- `npm audit signatures`
- `git diff --check`

## Risk Assessment

- User-facing risk: Low; scoped to formula error handling for referenced cells.
- Data/security risk: Low; no persistence, network, or schema changes.
- Rollback plan: Revert this commit to restore previous formula behavior.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): None.
- Follow-up work (if any): None known.
- AI assistance: Codex assisted with implementation; I reviewed the diff and verification results before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * IFERROR function now properly detects errors from cell references and returns the fallback value when errors are found.
  * IFNA function improved to distinguish between `#N/A` errors (replaced with fallback) and other errors (passed through) when using cell references.

* **Tests**
  * Enhanced test coverage for IFERROR and IFNA with referenced error cells.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
