### PR TITLE
Add Slides to homepage and documentation site

### DIFF
--- a/docs/design/docs-site.md
+++ b/docs/design/docs-site.md
@@ -7,9 +7,10 @@ target-version: 0.1.0
 
 ## Summary
 
-Add a VitePress-based documentation site as `packages/documentation` to provide user guides
-(spreadsheet editing, formulas, collaboration) and developer references (REST API, CLI).
-Served at `wafflebase.io/docs` as a subpath of the existing GitHub Pages deployment.
+A VitePress-based documentation site at `packages/documentation` provides
+user guides for each shipped module (Sheets, Docs, Slides) and developer
+references (self-hosting, REST API, CLI). Served at `wafflebase.io/docs`
+as a subpath of the existing GitHub Pages deployment.
 
 ## Goals
 
@@ -38,19 +39,32 @@ packages/documentation/
 ├── index.md                  # Docs home (VitePress home layout)
 ├── guide/
 │   ├── getting-started.md    # Getting started
-│   ├── editing-cells.md      # Cell editing
-│   ├── formulas.md           # Formula usage
-│   └── collaboration.md      # Real-time collaboration
-└── api/
-    ├── rest-api.md           # REST API reference
-    └── cli.md                # CLI reference
+│   └── collaboration.md      # Real-time collaboration & sharing
+├── sheets/
+│   ├── build-a-budget.md     # Sheets tutorial
+│   ├── formulas.md           # Formulas reference
+│   ├── charts.md             # Charts & pivot tables
+│   └── keyboard-shortcuts.md
+├── docs-editor/
+│   ├── writing-a-document.md
+│   └── keyboard-shortcuts.md
+├── slides/
+│   ├── build-a-deck.md       # Slides tutorial
+│   ├── themes-and-layouts.md
+│   └── keyboard-shortcuts.md
+└── developers/
+    ├── self-hosting.md
+    ├── rest-api.md
+    └── cli.md
 ```
 
 ### VitePress Configuration
 
 - `base: '/docs/'` so all asset/link paths are prefixed correctly
-- Sidebar with two sections: Guide and API Reference
-- Top nav linking back to main site (`wafflebase.io`)
+- Top nav order: **Guide / Sheets / Docs / Slides / Developers** — mirrors
+  the homepage's product progression
+- Sidebar groups one per nav entry; Slides group sits between Docs and
+  Developers
 - Brand colors via CSS variable overrides to match homepage amber/gold theme
 - Built-in local search enabled
 
@@ -87,14 +101,31 @@ packages/documentation/
 ### Content Outline
 
 **Guide section:**
-- Getting Started: what Wafflebase is, how to create a document, basic navigation
-- Editing Cells: selecting, typing, copy/paste, undo/redo, cell types
-- Formulas: supported functions, formula syntax, cell references, examples
-- Collaboration: sharing documents, real-time co-editing, presence indicators
+- Getting Started: what Wafflebase is, how to create a document, basic
+  navigation
+- Collaboration & Sharing: sharing documents, real-time co-editing,
+  presence indicators
 
-**API section:**
-- REST API: authentication (API keys), endpoints for documents/tabs/cells, examples
-- CLI: installation, configuration, available commands, usage examples
+**Sheets section:**
+- Build a Budget: hands-on tutorial
+- Formulas: supported functions, syntax, cell references, examples
+- Charts & Pivot Tables: data visualization and aggregation
+- Keyboard Shortcuts: full reference
+
+**Docs section:**
+- Writing a Document: editor tour, formatting, pagination
+- Keyboard Shortcuts: full reference
+
+**Slides section:**
+- Build a Deck: hands-on tutorial (counterpart to Build a Budget)
+- Themes & Layouts: 4-tier theme model, 11 Google-Slides-parity layouts,
+  placeholders
+- Keyboard Shortcuts: full reference
+
+**Developers section:**
+- Self-Hosting: deploying Wafflebase on your own infrastructure
+- REST API: API key authentication, endpoints for documents/tabs/cells
+- CLI: installation, configuration, command reference
 
 ## Risks and Mitigation
 

--- a/docs/design/homepage.md
+++ b/docs/design/homepage.md
@@ -19,8 +19,9 @@ custom waffle-themed illustrations.
 
 - Present Wafflebase's value proposition with the locked Butter & Maple
   design language.
-- Showcase Sheets and Docs as a single cohesive workspace via two live
-  iframes (Spreadsheet / Word processor) inside a tabbed demo card.
+- Showcase Sheets, Docs, and Slides as a single cohesive office suite
+  via three live iframes (Spreadsheet / Word processor / Presentation)
+  inside a tabbed demo card.
 - Provide developers with REST API and CLI code examples in a tabbed dark
   card.
 - Preserve the existing auth flow ("Get Started Free" → `/login`, or
@@ -85,8 +86,8 @@ Theme system uses the existing class-based Tailwind mechanism (`light` /
 |---|---|---|
 | 1 | NavBar | Sticky header, waffle logo, nav links, theme toggle, primary CTA |
 | 2 | Hero | Single-column centered layout: eyebrow + Fraunces H1 + sub + CTA pair + 4 product stats |
-| 3 | DemoSection | Sheet/Doc tab card — both tabs embed live `/shared/{token}` iframes (Doc tab is lazy-mounted) with theme sync via `postMessage` |
-| 4 | FeaturesSection | 3 hero cards with waffle-pocket glyphs + 4 compact secondary cards |
+| 3 | DemoSection | Sheets / Docs / Slides tab card — three tabs embed live `/shared/{token}` iframes (Docs + Slides tabs lazy-mount on first activation) with theme sync via `postMessage` |
+| 4 | FeaturesSection | 3 hero cards with waffle-pocket glyphs + 6 compact secondary cards (3×2, product-balanced: 2 Sheets / 2 Docs / 2 Slides) |
 | 5 | UseCasesSection | 3 scenarios (Internal tools / Customer dashboards / Specs & launch plans) |
 | 6 | WhySection | Comparison table vs Google Workspace inside a paper card |
 | 7 | DeveloperSection | Single dark code card with REST API / CLI tabs |
@@ -106,9 +107,12 @@ Right: `<ThemeToggle>` (sun/moon icon) + primary `<WbButton>` ("Get Started" or
 Single column, centered, max-width 920px, padded `pt-20 md:pt-28 pb-14 md:pb-20`.
 
 - Butter pill eyebrow `v0.3 · Apache-2.0 · Self-hosted` (leaf glow dot).
-- Fraunces `clamp(40, 6vw, 68)px` H1: "Word Processor & Spreadsheet *You Can
-  Own*" (italic + syrup-deep emphasis on the trailing phrase).
-- Sub copy 17–19px, max-width 560px.
+- Fraunces `clamp(40, 6vw, 68)px` H1: "The Office Suite *You Can Own*"
+  (italic + syrup-deep emphasis on the trailing phrase). `max-w-[20ch]`
+  accommodates the shorter title without orphan wraps.
+- Sub copy 17–19px, max-width 560px:
+  "Sheets, Docs, and Slides. Real-time collaboration, REST API, fully
+  self-hosted."
 - CTA pair: primary "Get Started Free →" (or "Go to Workspace →" if signed in)
   + ghost "View on GitHub →".
 - 4 stats: Apache-2.0 / Self-hosted / REST + CLI / Real-time, centered.
@@ -121,20 +125,25 @@ focused on messaging instead of duplicating the demo.
 
 Section frame: `--wb-paper` rounded card (18px), syrup-deep drop shadow.
 
-- **Tab bar** — `Spreadsheet` ↔ `Word processor` icon + label tabs. Active tab
-  gets butter-tinted `--wb-paper` bg + `--wb-syrup` 2px bottom border;
-  inactive uses `--wb-sub` text.
+- **Tab bar** — `Spreadsheet` / `Word processor` / `Presentation` icon + label
+  tabs. Active tab gets butter-tinted `--wb-paper` bg + `--wb-syrup` 2px
+  bottom border; inactive uses `--wb-sub` text. Default active tab is
+  `sheet`.
 - **Sheet tab** — live iframe `/shared/{VITE_DEMO_SHARED_TOKEN}` (default
   `bed3dbe8-…`). Loaded eagerly on mount.
 - **Doc tab** — live iframe `/shared/{VITE_DEMO_DOC_SHARED_TOKEN}` (default
-  `08fe575d-…`). Mounted lazily on first activation so the initial pageload
-  only fetches the sheet demo. Once mounted, both iframes stay alive across
-  tab switches via `display` toggling — no reloads.
-- **Theme sync** — both iframes receive `{ type: 'theme-change', theme }` via
-  `postMessage` whenever the homepage theme changes; the shared
+  `08fe575d-…`). Mounted lazily on first activation.
+- **Slides tab** — live iframe `/shared/{VITE_DEMO_SLIDES_SHARED_TOKEN}`
+  (default `bf4e92f1-…`). Mounted lazily on first activation so the
+  initial pageload only fetches the sheet demo. Once mounted, all
+  iframes stay alive across tab switches via `display` toggling — no
+  reloads.
+- **Theme sync** — all three iframes receive `{ type: 'theme-change', theme }`
+  via `postMessage` whenever the homepage theme changes; the shared
   `ThemeProvider` inside the iframe applies the change without reload.
 - **Footer** — tab-aware mono hint text on the left, `wafflebase@0.3.7` on
-  the right.
+  the right (Slides hint: "Tip: arrow keys navigate slides — press F to
+  present.").
 
 #### FeaturesSection
 
@@ -144,21 +153,30 @@ Two-tier layout. 3 large cards (waffle-pocket glyphs):
 2. REST API & CLI — `embed` glyph
 3. Self-Hosted & Open Source — `reactive` glyph
 
-Plus 4 compact cards for Formulas / Charts & Pivot / Document Editor /
-Sharing & Permissions, each with a butter-tinted lucide icon chip. All cards
-use the handoff card shadow (`0 1px 0 rgba(42,30,18,0.04), 0 12px 28px -16px
+Plus 6 compact cards in a 3×2 grid (`md:grid-cols-2`), product-balanced at
+2 per module so the 3-product suite reads visually:
+
+- **Sheets** — Formulas (FunctionSquare), Charts & Pivot Tables (BarChart3)
+- **Docs** — Page-Based Document Editor (FileText), Tables & Pagination (Rows3)
+- **Slides** — Themes & Layouts (Palette), Presentation Mode (Presentation)
+
+Each card uses a butter-tinted lucide icon chip. All cards use the handoff
+card shadow (`0 1px 0 rgba(42,30,18,0.04), 0 12px 28px -16px
 rgba(42,30,18,0.18)`) and hover scale 1.005.
 
 #### UseCasesSection
 
 3-card grid. Each card: `0n` mono number + butter "tag" pill + 21px Fraunces
 title + sub copy + "Read the docs →" syrup link. Hover translates -2px.
-Cards are: Internal tools, Customer dashboards, Specs & launch plans.
+Cards are: Internal tools (Sheets embed), Pitch decks & all-hands (Slides
+theming + self-host), Specs & launch plans (Docs + Sheets references).
 
 #### WhySection
 
 Wafflebase vs Google Workspace comparison. Inside a `--wb-paper` card with rule
-borders. Leaf check / berry cross / butter "Limited" pill markers.
+borders. Leaf check / berry cross / butter "Limited" pill markers. The
+"single app" row reads "Slides, Docs & Sheets in one app" to match the
+3-product suite framing.
 
 #### DeveloperSection
 
@@ -189,8 +207,10 @@ landings.
 #### Footer
 
 `--wb-bg` background with rule top border. Two-column layout: brand block
-(WaffleLogo + Fraunces wordmark + tagline) + 3-column sitemap (Product /
-Community / Project). Bottom bar: copyright + repo URL.
+(WaffleLogo + Fraunces wordmark + tagline: "Self-hosted collaborative
+presentations, word processor, and spreadsheet, with real-time editing
+and a REST API for automation.") + 3-column sitemap (Product / Community
+/ Project). Bottom bar: copyright + repo URL.
 
 ### Theme System
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides homepage docs (2026-05-21) | [20260521-slides-homepage-docs-todo.md](./active/20260521-slides-homepage-docs-todo.md) | - |
 | slides shape move ghost (2026-05-19) | [20260519-slides-shape-move-ghost-todo.md](./active/20260519-slides-shape-move-ghost-todo.md) | - |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | - |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
@@ -31,4 +32,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 201
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides shape move ghost (2026-05-19)
+Latest active task: slides homepage docs (2026-05-21)

--- a/docs/tasks/active/20260521-slides-homepage-docs-todo.md
+++ b/docs/tasks/active/20260521-slides-homepage-docs-todo.md
@@ -1,0 +1,647 @@
+# Slides on homepage + documentation site
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Design docs to update (same PR):**
+- [`docs/design/homepage.md`](../../design/homepage.md)
+- [`docs/design/docs-site.md`](../../design/docs-site.md)
+
+**Goal:** Reframe the homepage and documentation site from a 2-product
+("Word Processor & Spreadsheet") narrative to a 3-product office-suite
+narrative that includes Slides. Add a live Slides demo tab, refresh the
+hero, add Slides-focused feature/use-case cards, and ship 3 new
+Slides documentation pages.
+
+**Out of scope (intentional deferrals):**
+
+- Slides REST API / CLI surfaces (does not exist yet — DeveloperSection
+  stays Sheets-only).
+- Additional Slides docs pages beyond the v1 three (`shapes-and-connectors`,
+  `presentation-mode`, etc. are follow-ups in their own PRs).
+- Live Sheets-cell embedding inside slides (feature not implemented —
+  UseCase card copy must not promise it).
+- NavBar / OpenSourceSection / DeveloperSection / index.html / routing /
+  ThemeProvider — unchanged.
+
+**Visual decisions locked during brainstorming:**
+
+| Decision | Value |
+|---|---|
+| Hero H1 | "The Office Suite You Can Own" |
+| Hero sub | "Sheets, Docs, and Slides. Real-time collaboration, REST API, fully self-hosted." |
+| Demo tab order | Sheets → Docs → Slides |
+| Demo default active | Sheets |
+| Slides demo token (env default) | `bf4e92f1-f289-43dd-be1b-8a47c14f0e7a` |
+| Slides demo env var | `VITE_DEMO_SLIDES_SHARED_TOKEN` |
+| Features grid | 6 secondary cards, product-balanced 2/2/2 |
+| Removed card | "Sharing & Permissions" (overlaps Real-Time Collab hero card) |
+| Added Docs card | "Tables & Pagination" |
+| Added Slides cards | "Themes & Layouts" + "Presentation Mode" |
+| UseCase swap | Card 2 ("Customer dashboards") → Slides pitch-deck case |
+| WhySection row | "Sheets & Docs in one app" → "Slides, Docs & Sheets in one app" |
+| Footer brand copy | "presentations, word processor, and spreadsheet" |
+| Stats | unchanged (Apache-2.0 / Self-hosted / REST + CLI / Real-time) |
+| Docs pages added | `slides/build-a-deck.md`, `slides/themes-and-layouts.md`, `slides/keyboard-shortcuts.md` |
+| Docs nav/sidebar position | After "Docs", before "Developers" |
+
+---
+
+## Chunk 1: Slides demo iframe
+
+### Task 1: Add Slides tab to DemoSection
+
+**Files:**
+- Modify: `packages/frontend/src/app/home/demo-section.tsx`
+- Modify (env types): `packages/frontend/src/vite-env.d.ts` (if it declares the existing demo tokens; otherwise skip)
+- Modify (env example): `packages/frontend/.env.example` (if it documents `VITE_DEMO_SHARED_TOKEN`; otherwise skip)
+
+Extend the existing 2-tab pattern to 3 tabs. Reuse the lazy-mount +
+`display`-toggle pattern from the Docs tab so Slides mounts only on
+first activation. Default active tab stays `sheet`.
+
+- [ ] **Step 1: Read demo-section.tsx and confirm current structure**
+
+  Confirm `TAB_ORDER: Tab[] = ["sheet", "doc"]` and that the Doc tab uses
+  lazy mounting via `docMounted`.
+
+- [ ] **Step 2: Extend the Tab type and TAB_ORDER**
+
+  ```typescript
+  type Tab = "sheet" | "doc" | "slides";
+  const TAB_ORDER: Tab[] = ["sheet", "doc", "slides"];
+  ```
+
+- [ ] **Step 3: Add the Slides token constant**
+
+  ```typescript
+  const DEMO_SLIDES_TOKEN =
+    import.meta.env.VITE_DEMO_SLIDES_SHARED_TOKEN ??
+    "bf4e92f1-f289-43dd-be1b-8a47c14f0e7a";
+  ```
+
+- [ ] **Step 4: Mirror the Doc lazy-mount and state pattern for Slides**
+
+  - Add `slidesIframeRef`, `slidesMounted` (lazy), `slidesState` ("loading" | "loaded" | "error").
+  - Add `slidesUrl` locked at first render (mirroring `docUrl`).
+  - Extend `useEffect(... tab === "doc" → setDocMounted(true))` to also handle `"slides" → setSlidesMounted(true)`.
+  - Extend the theme-sync `useEffect` to call `postTheme(slidesIframeRef, slidesState === "loaded", resolvedTheme)`.
+
+- [ ] **Step 5: Add a third `<DemoTab>` to the tablist**
+
+  Order: `Spreadsheet` → `Word processor` → `Presentation` (label).
+  Use a new `<SlidesIcon>` helper (small SVG, 14×14) matching the
+  Sheet/Doc icon style — a rounded rectangle with a triangular play
+  glyph or a single horizontal text line.
+
+- [ ] **Step 6: Add a third `<DemoFrame>` inside the tab body**
+
+  Gated behind `{slidesMounted && (...)}`. Wire `visible={tab === "slides"}`,
+  `iframeRef={slidesIframeRef}`, `src={slidesUrl}`, `title="Wafflebase
+  live demo presentation"`, `panelId="demo-panel-slides"`,
+  `tabId="demo-tab-slides"`.
+
+- [ ] **Step 7: Update the footer tip copy**
+
+  Extend the ternary so each tab has its own tip. Suggested:
+  - sheet: existing copy
+  - doc: existing copy
+  - slides: "Tip: arrow keys navigate slides — press F to present."
+
+- [ ] **Step 8: Verify keyboard tab navigation still works**
+
+  `handleTabKey` already uses `TAB_ORDER` length, so adding a third entry
+  is automatic. Manually verify ←/→ wraps through all three tabs.
+
+- [ ] **Step 9: Add the env var to the .env.example (if one exists for frontend)**
+
+  Document `VITE_DEMO_SLIDES_SHARED_TOKEN` next to the existing two
+  tokens. Default in code is the brainstorming-confirmed token, so the
+  env var is optional.
+
+- [ ] **Step 10: Manual smoke**
+
+  `pnpm dev` → unauthenticated `/` → DemoSection shows three tabs.
+  Click Slides → loads `/shared/bf4e92f1-…`, shows slide content. Switch
+  back to Sheets, Docs, Slides — no reloads. Toggle theme — all three
+  iframes pick up the change without reloading.
+
+- [ ] **Step 11: Commit**
+
+  ```bash
+  git add packages/frontend/src/app/home/demo-section.tsx
+  git commit -m "Add Slides tab to homepage DemoSection"
+  ```
+
+---
+
+## Chunk 2: Hero + Footer copy refresh
+
+### Task 2: Update Hero H1, sub, and Footer brand copy
+
+**Files:**
+- Modify: `packages/frontend/src/app/home/hero-section.tsx`
+- Modify: `packages/frontend/src/app/home/footer.tsx`
+
+- [ ] **Step 1: Rewrite Hero H1**
+
+  Replace the existing two-line H1 with:
+
+  ```tsx
+  <h1
+    className="font-display font-semibold text-[color:var(--wb-ink)] leading-[1.04] tracking-[-0.025em] text-[clamp(40px,6vw,68px)] m-0 mb-6 max-w-[20ch]"
+    style={{ fontFeatureSettings: "'ss01' on, 'ss02' on" }}
+  >
+    The Office Suite{" "}
+    <em className="font-medium italic text-[color:var(--wb-syrup-deep)]">
+      You Can Own
+    </em>
+  </h1>
+  ```
+
+  Note the `max-w-[20ch]` (was `16ch`) — "The Office Suite You Can Own"
+  is 27 characters vs 36 for the previous title, so the constraint
+  relaxes. Verify wrapping in dev at 320px / 768px / 1280px viewports.
+
+- [ ] **Step 2: Rewrite Hero sub**
+
+  ```tsx
+  <p className="text-[color:var(--wb-sub)] leading-[1.55] text-[clamp(17px,1.4vw,19px)] max-w-[560px] m-0 mb-10">
+    Sheets, Docs, and Slides. Real-time collaboration, REST API,
+    fully self-hosted.
+  </p>
+  ```
+
+- [ ] **Step 3: Update Footer brand copy**
+
+  In `footer.tsx`, replace the brand paragraph:
+
+  ```tsx
+  <p className="text-[14px] leading-[1.55] text-[color:var(--wb-sub)] max-w-[280px] m-0">
+    Self-hosted collaborative presentations, word processor, and
+    spreadsheet, with real-time editing and a REST API for automation.
+  </p>
+  ```
+
+- [ ] **Step 4: Manual smoke**
+
+  `pnpm dev` → check Hero copy at multiple viewport widths. Confirm
+  no awkward orphan wrap on the H1 italic emphasis. Check Footer too.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add packages/frontend/src/app/home/hero-section.tsx \
+          packages/frontend/src/app/home/footer.tsx
+  git commit -m "Reframe homepage hero + footer as 3-product suite"
+  ```
+
+---
+
+## Chunk 3: FeaturesSection — 6 product-balanced cards
+
+### Task 3: Rebuild the secondary feature grid
+
+**Files:**
+- Modify: `packages/frontend/src/app/home/features-section.tsx`
+
+Drop "Sharing & Permissions", add "Tables & Pagination" (Docs),
+"Themes & Layouts" (Slides), "Presentation Mode" (Slides). Reorder
+to group by product.
+
+- [ ] **Step 1: Update lucide imports**
+
+  Replace the `Shield` import with the new icons. Final import:
+
+  ```typescript
+  import {
+    BarChart3,
+    FileText,
+    FunctionSquare,
+    Palette,
+    Presentation,
+    Rows3,
+  } from "lucide-react";
+  ```
+
+  (`Shield` was used by "Sharing & Permissions" — removed.)
+
+- [ ] **Step 2: Replace SECONDARY_FEATURES**
+
+  ```typescript
+  const SECONDARY_FEATURES: SecondaryFeature[] = [
+    {
+      Icon: FunctionSquare,
+      title: "Google Sheets-Compatible Formulas",
+      description: "SUM, VLOOKUP, IF, and cross-sheet references",
+      href: "/docs/sheets/formulas",
+    },
+    {
+      Icon: BarChart3,
+      title: "Charts & Pivot Tables",
+      description: "Built-in data visualization and aggregation",
+      href: "/docs/sheets/charts",
+    },
+    {
+      Icon: FileText,
+      title: "Page-Based Document Editor",
+      description: "Write and format documents with a clean, paginated editor",
+      href: "/docs/docs-editor/writing-a-document",
+    },
+    {
+      Icon: Rows3,
+      title: "Tables & Pagination",
+      description:
+        "Rich tables, page breaks, and pagination for long-form documents",
+      href: "/docs/docs-editor/writing-a-document",
+    },
+    {
+      Icon: Palette,
+      title: "Themes & Layouts",
+      description:
+        "Four-tier theme system and Google-Slides-parity layouts for decks",
+      href: "/docs/slides/themes-and-layouts",
+    },
+    {
+      Icon: Presentation,
+      title: "Presentation Mode",
+      description:
+        "Full-screen player with keyboard navigation and click-to-advance",
+      href: "/docs/slides/build-a-deck",
+    },
+  ];
+  ```
+
+- [ ] **Step 3: Verify the grid still renders cleanly**
+
+  The existing JSX uses `md:grid-cols-2 gap-3 md:gap-4`. Six cards in a
+  two-column grid renders as 3 rows of 2 — no markup change needed.
+  Spot-check at 768px / 1280px breakpoints.
+
+- [ ] **Step 4: Manual smoke**
+
+  Hover each card → shadow + scale animation works. Click each card →
+  navigates to the correct `/docs/...` path (some pages don't exist
+  yet — that's expected; Chunk 5 ships them).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add packages/frontend/src/app/home/features-section.tsx
+  git commit -m "Rebalance feature cards across Sheets, Docs, Slides"
+  ```
+
+---
+
+## Chunk 4: UseCasesSection + WhySection copy
+
+### Task 4: Swap card 2 to a Slides pitch-deck case and update WhySection row
+
+**Files:**
+- Modify: `packages/frontend/src/app/home/use-cases-section.tsx`
+- Modify: `packages/frontend/src/app/home/why-section.tsx`
+
+UseCase card 2 ("Customer dashboards") is a near-duplicate Sheets case.
+Replace it with a Slides case. Copy must NOT promise live Sheets-cell
+embedding inside slides (feature not implemented).
+
+- [ ] **Step 1: Replace USE_CASES[1] in use-cases-section.tsx**
+
+  ```typescript
+  {
+    tag: "Pitch decks & all-hands",
+    title: "Ship the deck on your brand, not Google's",
+    body: "Four-tier theme system, Google-Slides-parity layouts, and a self-hosted store — your team's decks live where your data lives.",
+    href: "/docs/slides/build-a-deck",
+  },
+  ```
+
+  Leave cards 0 and 2 unchanged.
+
+- [ ] **Step 2: Update the WhySection comparison row**
+
+  In `why-section.tsx`, find the row labeled `"Sheets & Docs in one
+  app"` and rewrite the label to `"Slides, Docs & Sheets in one app"`.
+  Wafflebase column stays `<CheckMark />`. Google Workspace column
+  stays `<CheckMark />` (they do offer all three).
+
+- [ ] **Step 3: Manual smoke**
+
+  `pnpm dev` → scroll through UseCasesSection. Card 2 reads as a Slides
+  case, links to `/docs/slides/build-a-deck`. WhySection row reads
+  correctly.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add packages/frontend/src/app/home/use-cases-section.tsx \
+          packages/frontend/src/app/home/why-section.tsx
+  git commit -m "Add Slides use-case and update suite comparison row"
+  ```
+
+---
+
+## Chunk 5: Documentation site — Slides section
+
+### Task 5: Add Slides nav/sidebar entries to VitePress config
+
+**Files:**
+- Modify: `packages/documentation/.vitepress/config.ts`
+
+- [ ] **Step 1: Add Slides to the top `nav`**
+
+  Insert after the "Docs" entry, before "Developers":
+
+  ```typescript
+  { text: "Slides", link: "/slides/build-a-deck" },
+  ```
+
+- [ ] **Step 2: Add Slides group to the `sidebar`**
+
+  Insert a new group object after the existing "Docs" group:
+
+  ```typescript
+  {
+    text: "Slides",
+    items: [
+      { text: "Build a Deck", link: "/slides/build-a-deck" },
+      {
+        text: "Themes & Layouts",
+        link: "/slides/themes-and-layouts",
+      },
+      {
+        text: "Keyboard Shortcuts",
+        link: "/slides/keyboard-shortcuts",
+      },
+    ],
+  },
+  ```
+
+- [ ] **Step 3: Commit (config-only, before content lands)**
+
+  ```bash
+  git add packages/documentation/.vitepress/config.ts
+  git commit -m "Docs: add Slides nav and sidebar entries"
+  ```
+
+### Task 6: Write `slides/build-a-deck.md`
+
+**Files:**
+- Create: `packages/documentation/slides/build-a-deck.md`
+
+Counterpart to `sheets/build-a-budget.md`. End-to-end tutorial:
+create a slides document → apply a theme → add a layout-based slide
+→ insert and edit a text placeholder → add a shape → use Present mode.
+
+- [ ] **Step 1: Read `packages/documentation/sheets/build-a-budget.md` to mirror its tone, length, and section structure.**
+
+- [ ] **Step 2: Draft the page with these sections**
+  - One-paragraph intro: what you'll build (a 3-slide intro deck)
+  - "Create a new presentation" — Workspace → New → Presentation
+  - "Pick a theme" — apply one of the built-in themes; reference the 4-tier theme model briefly
+  - "Add a title slide" — pick a layout (Title slide); fill placeholders
+  - "Add a content slide" — Title + Body layout; bullet text
+  - "Add a shape" — toolbar Shape menu, drag to size, apply theme color
+  - "Present" — F key to enter, ← / → to navigate, Esc to exit
+  - "Next steps" — link to Themes & Layouts page and Keyboard Shortcuts page
+
+- [ ] **Step 3: Sanity-check screenshots / asset references**
+
+  This first pass can ship without screenshots if needed — a follow-up
+  PR adds them. If screenshots ARE added, drop them in
+  `packages/documentation/public/slides/` and reference with
+  `![](/slides/build-a-deck-step3.png)`.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add packages/documentation/slides/build-a-deck.md \
+          packages/documentation/public/slides/   # only if screenshots added
+  git commit -m "Docs: add Slides 'Build a Deck' tutorial"
+  ```
+
+### Task 7: Write `slides/themes-and-layouts.md`
+
+**Files:**
+- Create: `packages/documentation/slides/themes-and-layouts.md`
+
+Reference doc covering the theme model (without exposing internal
+architecture detail) and the available layouts.
+
+- [ ] **Step 1: Read `docs/design/slides/slides-themes-layouts-import.md`** as the authoritative source.
+
+- [ ] **Step 2: Draft user-facing sections**
+  - "What is a theme?" — colors, fonts, background; one-paragraph intro
+  - "Built-in themes" — short visual catalog (table or grid of theme names + screenshot thumbnails if available)
+  - "Switching themes" — toolbar / sidebar action
+  - "Layouts" — table of the 11 Google-Slides-parity layouts with name + a one-line "use this for…" description
+  - "Changing a slide's layout" — context menu / split-button on the toolbar
+  - "Placeholders" — what they are, how they retain their type on layout change
+
+  Keep architecture and CRDT detail in the design doc — this page is
+  for end users.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add packages/documentation/slides/themes-and-layouts.md
+  git commit -m "Docs: add Slides 'Themes & Layouts' reference"
+  ```
+
+### Task 8: Write `slides/keyboard-shortcuts.md`
+
+**Files:**
+- Create: `packages/documentation/slides/keyboard-shortcuts.md`
+
+Tabular catalog. Pattern matches `sheets/keyboard-shortcuts.md` and
+`docs-editor/keyboard-shortcuts.md`.
+
+- [ ] **Step 1: Read `docs/design/slides/slides-keyboard-shortcuts.md`** to ensure the catalog matches the shipped shortcuts (it explicitly mentions a single catalog source — use it as the source of truth).
+
+- [ ] **Step 2: Draft a table grouped by category**
+  - Selection & navigation
+  - Editing (text, shapes)
+  - Insert (shapes, text box, image)
+  - Slide ops (new slide, duplicate, delete, reorder)
+  - View (zoom, fit, present)
+  - History (undo, redo)
+
+  Cross-platform: list both Cmd and Ctrl where they differ. Mirror the
+  format of the existing Sheets/Docs shortcut pages so cross-product
+  parity is visible.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add packages/documentation/slides/keyboard-shortcuts.md
+  git commit -m "Docs: add Slides keyboard shortcuts reference"
+  ```
+
+---
+
+## Chunk 6: Design doc updates
+
+### Task 9: Update `docs/design/homepage.md`
+
+**Files:**
+- Modify: `docs/design/homepage.md`
+
+Bring the design doc in sync with the shipped changes so the doc is
+authoritative again.
+
+- [ ] **Step 1: Update Summary + Goals to mention three products**
+
+- [ ] **Step 2: Update the Page Sections table description for DemoSection** — "Sheet/Doc tab card" → "Sheets / Docs / Slides tab card (3 live iframes)"
+
+- [ ] **Step 3: Rewrite the Hero subsection's title/sub quotation**
+
+- [ ] **Step 4: Rewrite the DemoSection subsection**
+  - Mention the third tab and the `VITE_DEMO_SLIDES_SHARED_TOKEN` env var
+  - Document that Slides mounts lazily, mirroring Docs
+
+- [ ] **Step 5: Rewrite FeaturesSection's "4 compact cards" → "6 compact cards (3×2, product-balanced)"** and list the new card titles
+
+- [ ] **Step 6: Rewrite UseCasesSection's card list**
+
+- [ ] **Step 7: Update WhySection's comparison-row example**
+
+- [ ] **Step 8: Update Footer brand copy excerpt**
+
+### Task 10: Update `docs/design/docs-site.md`
+
+**Files:**
+- Modify: `docs/design/docs-site.md`
+
+- [ ] **Step 1: Update the package structure tree** to include `slides/`
+
+- [ ] **Step 2: Update the VitePress Configuration section** to mention the new nav/sidebar group (order: Guide / Sheets / Docs / Slides / Developers)
+
+- [ ] **Step 3: Update Content Outline** with a new "Slides section" subsection listing the three pages
+
+- [ ] **Step 4: Commit design docs in one go**
+
+  ```bash
+  git add docs/design/homepage.md docs/design/docs-site.md
+  git commit -m "Update homepage + docs-site design docs for Slides"
+  ```
+
+---
+
+## Chunk 7: Verify, smoke, PR
+
+### Task 11: Pre-commit verify
+
+- [ ] **Step 1: Run the fast verify gate**
+
+  ```bash
+  pnpm verify:fast
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 2: Build the documentation site**
+
+  ```bash
+  pnpm --filter @wafflebase/documentation build
+  ```
+
+  Expected: PASS — no broken links from sidebar/nav to the new pages.
+  Confirm `.vitepress/dist/slides/build-a-deck.html` (and the other two)
+  exist.
+
+- [ ] **Step 3: Build the frontend**
+
+  ```bash
+  pnpm --filter @wafflebase/frontend build
+  ```
+
+  Expected: PASS — no missing icon imports, no TS errors.
+
+### Task 12: Manual smoke
+
+- [ ] **Step 1: Homepage in `pnpm dev`**
+  - Unauthenticated `/` renders the new Hero copy.
+  - DemoSection: three tabs, default Sheets, Slides lazy-mounts, theme sync works on all three.
+  - FeaturesSection: 6 cards, 3×2 grid, all six link to `/docs/...`.
+  - UseCasesSection: card 2 reads as the Slides pitch-deck case.
+  - WhySection comparison row reads "Slides, Docs & Sheets in one app".
+  - Footer brand copy includes "presentations, word processor, and spreadsheet".
+
+- [ ] **Step 2: Documentation site in `pnpm --filter @wafflebase/documentation dev`**
+  - Top nav has "Slides" between "Docs" and "Developers".
+  - Sidebar shows the Slides group with three items.
+  - Each new page renders, links to each other work, code samples (if any) format correctly.
+
+- [ ] **Step 3: Click-through from homepage to docs**
+  - Homepage feature cards → docs pages
+  - UseCase 2 → `/docs/slides/build-a-deck`
+  - Verify these resolve (frontend serves `/docs/*` from copied VitePress build per `docs/design/docs-site.md`).
+
+### Task 13: Self code review
+
+- [ ] **Step 1: Dispatch `/code-review` over the branch diff**
+
+  Apply blocking findings; note non-blocking as known limitations.
+
+### Task 14: Open PR
+
+- [ ] **Step 1: Rebase on `origin/main`**
+
+  ```bash
+  git fetch origin
+  git rebase origin/main
+  ```
+
+- [ ] **Step 2: Push and open PR**
+
+  Title (≤70 chars): `Add Slides to homepage and documentation site`
+
+  Body:
+  ```markdown
+  ## Summary
+
+  - Reframe homepage as a 3-product office suite: new Hero copy
+    ("The Office Suite You Can Own"), live Slides tab in DemoSection
+    (Sheets → Docs → Slides, default Sheets), and a 6-card
+    product-balanced FeaturesSection.
+  - Swap UseCase card 2 to a Slides pitch-deck case; update WhySection
+    comparison row and Footer brand copy.
+  - Add 3 new documentation pages — Build a Deck, Themes & Layouts,
+    Keyboard Shortcuts — under a new `slides/` group in the VitePress
+    site.
+  - Refresh `docs/design/homepage.md` and `docs/design/docs-site.md` to
+    match.
+
+  ## Test plan
+
+  - [x] `pnpm verify:fast`
+  - [x] `pnpm --filter @wafflebase/documentation build` (no broken links)
+  - [x] `pnpm --filter @wafflebase/frontend build`
+  - [x] Manual: homepage at 320 / 768 / 1280 px viewports
+  - [x] Manual: theme toggle propagates to all three demo iframes
+  - [x] Manual: Slides tab lazy-mounts on first activation; no reload on tab switch
+  - [x] Manual: docs site nav/sidebar shows Slides group; all three pages render
+  ```
+
+### Task 15: Post-merge cleanup
+
+- [ ] **Step 1: Write the lessons file**
+
+  Create `docs/tasks/active/20260521-slides-homepage-docs-lessons.md`
+  with any surprises encountered (e.g., copy wrapping at a tricky
+  breakpoint, an unexpected iframe reload, a VitePress sidebar quirk).
+  One short note per lesson; skip if nothing notable.
+
+- [ ] **Step 2: Archive + reindex**
+
+  ```bash
+  pnpm tasks:archive
+  pnpm tasks:index
+  ```
+
+- [ ] **Step 3: Commit + push the archive move**
+
+  ```bash
+  git add docs/tasks/
+  git commit -m "Archive 20260521-slides-homepage-docs task"
+  git push
+  ```

--- a/packages/documentation/.vitepress/config.ts
+++ b/packages/documentation/.vitepress/config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
       { text: "Guide", link: "/guide/getting-started" },
       { text: "Sheets", link: "/sheets/build-a-budget" },
       { text: "Docs", link: "/docs-editor/writing-a-document" },
+      { text: "Slides", link: "/slides/build-a-deck" },
       { text: "Developers", link: "/developers/self-hosting" },
     ],
 
@@ -104,6 +105,20 @@ export default defineConfig({
           {
             text: "Keyboard Shortcuts",
             link: "/docs-editor/keyboard-shortcuts",
+          },
+        ],
+      },
+      {
+        text: "Slides",
+        items: [
+          { text: "Build a Deck", link: "/slides/build-a-deck" },
+          {
+            text: "Themes & Layouts",
+            link: "/slides/themes-and-layouts",
+          },
+          {
+            text: "Keyboard Shortcuts",
+            link: "/slides/keyboard-shortcuts",
           },
         ],
       },

--- a/packages/documentation/docs-editor/writing-a-document.md
+++ b/packages/documentation/docs-editor/writing-a-document.md
@@ -58,9 +58,24 @@ Use the alignment dropdown in the toolbar to align paragraphs:
 - **Center** — Centered text
 - **Right** — Right-aligned text
 
-## Page Layout
+## Tables
 
-Documents are displayed with a page-based layout, similar to a printed document. Pages use A4 size by default with standard margins. As you type, text flows naturally across pages.
+Insert a table from the toolbar to lay out structured content. Click the **Table** button, drag to pick the grid size, and the table appears at the cursor.
+
+- **Tab** moves between cells (Shift+Tab moves backward).
+- Right-click a cell for row and column operations — insert above/below, insert left/right, delete row/column, merge or split cells.
+- Drag a column or row border to resize.
+- Tables can be nested — insert a table inside a cell to build sub-grids.
+
+When a table is taller than the remaining space on a page, its rows split across the page boundary automatically.
+
+## Pagination
+
+Documents use a page-based layout similar to a printed document. Pages default to A4 with standard margins, and text flows across pages as you type.
+
+- Long paragraphs and tables break naturally at the page boundary — line splitting keeps headings, table headers, and partial rows in sync with the layout.
+- The editor renders one page per "sheet" so you can scroll through the deck of pages exactly as they will print or export.
+- Export to PDF preserves the same pagination — what you see on screen matches the exported document.
 
 ## Undo and Redo
 

--- a/packages/documentation/slides/build-a-deck.md
+++ b/packages/documentation/slides/build-a-deck.md
@@ -1,0 +1,61 @@
+# Build a Deck
+
+In this guide, you'll build a short three-slide deck from scratch. Along the way, you'll pick a theme, use a layout, add text and a shape, and present the deck full-screen.
+
+## 1. Create a New Presentation
+
+From your workspace, click **New** → **Presentation**. You'll see a blank deck with a single title slide and a thumbnail strip on the left.
+
+## 2. Pick a Theme
+
+A **theme** controls the colors, fonts, and background used across every slide. Wafflebase ships with several built-in themes.
+
+Open the **Theme** panel from the right sidebar and click any theme to apply it to the whole deck. You can switch themes any time — your content stays put.
+
+See [Themes & Layouts](./themes-and-layouts) for the full set of built-in themes and how the four-tier theme model works.
+
+## 3. Add a Title
+
+The blank deck opens with a **Title slide** layout. Double-click the title placeholder and type a deck title — for example, `Q2 Roadmap`. Double-click the subtitle placeholder and add a short tagline.
+
+The placeholders inherit the heading and body fonts from the active theme, so you don't need to format text manually.
+
+## 4. Add a Content Slide
+
+Insert a new slide:
+
+- Press `⌘+M` (Mac) or `Ctrl+M` (Windows/Linux), **or**
+- Click the **+** button at the top of the slide thumbnail strip.
+
+The new slide reuses the current slide's layout. To pick a different layout, click the **Layout** split-button in the toolbar and choose **Title and body**.
+
+Type a title — `Themes` — and add a few bullet points in the body placeholder:
+
+- Theme picker in the right sidebar
+- One-click reskin of the whole deck
+- Built-in light and dark themes
+
+## 5. Add a Shape
+
+Slides ship with an OOXML-aligned shape library. From the toolbar, click **Shape** and pick a rectangle. Drag on the canvas to draw it.
+
+With the shape selected, the **Fill** color in the toolbar shows the active theme palette at the top — so you can apply the theme's accent color without picking a hex value.
+
+## 6. Present
+
+When you're ready to present:
+
+- Press `⌘+Enter` / `Ctrl+Enter` to start from the current slide, **or**
+- Press `⌘+Shift+Enter` / `Ctrl+Shift+Enter` to start from the first slide.
+
+In presentation mode:
+
+- `→` / `Page Down` / click — advance to the next slide
+- `←` / `Page Up` — go back
+- `Esc` — exit
+
+## What's Next
+
+- [Themes & Layouts](./themes-and-layouts) — Catalog of themes, layouts, and placeholders
+- [Keyboard Shortcuts](./keyboard-shortcuts) — Full shortcut reference
+- [Collaboration & Sharing](/guide/collaboration) — Invite others to co-edit the deck

--- a/packages/documentation/slides/keyboard-shortcuts.md
+++ b/packages/documentation/slides/keyboard-shortcuts.md
@@ -1,0 +1,78 @@
+# Keyboard Shortcuts
+
+Keyboard shortcuts for the slides editor. Mac shortcuts are shown with `⌘`, Windows/Linux with `Ctrl`. Press `⌘+/` (or `Ctrl+/`) in the editor to open the in-app shortcuts help.
+
+## Selection
+
+| Action | Shortcut |
+|---|---|
+| Select all elements on the slide | `⌘+A` / `Ctrl+A` |
+| Cycle to next element | `Tab` |
+| Cycle to previous element | `Shift+Tab` |
+| Clear selection / exit text edit | `Esc` |
+| Enter text edit on selected text element | `F2` or `Enter` |
+
+## Slides
+
+| Action | Shortcut |
+|---|---|
+| New slide (after current) | `⌘+M` / `Ctrl+M` |
+| Duplicate current slide | `⌘+Shift+D` / `Ctrl+Shift+D` |
+| Next slide | `Page Down` |
+| Previous slide | `Page Up` |
+
+## Editing
+
+| Action | Shortcut |
+|---|---|
+| Undo | `⌘+Z` / `Ctrl+Z` |
+| Redo | `⌘+Shift+Z` / `Ctrl+Shift+Z` |
+| Delete selected | `Delete` / `Backspace` |
+| Duplicate selected | `⌘+D` / `Ctrl+D` |
+| Nudge selection | Arrow keys |
+| Nudge selection (larger step) | `Shift+Arrow` |
+
+## Clipboard
+
+| Action | Shortcut |
+|---|---|
+| Copy | `⌘+C` / `Ctrl+C` |
+| Cut | `⌘+X` / `Ctrl+X` |
+| Paste | `⌘+V` / `Ctrl+V` |
+| Paste without formatting | `⌘+Shift+V` / `Ctrl+Shift+V` |
+
+## Z-order
+
+| Action | Shortcut |
+|---|---|
+| Bring to front | `⌘+Shift+]` / `Ctrl+Shift+]` |
+| Send to back | `⌘+Shift+[` / `Ctrl+Shift+[` |
+| Bring forward | `⌘+]` / `Ctrl+]` |
+| Send backward | `⌘+[` / `Ctrl+[` |
+
+## Text Editing
+
+These apply while editing inside a text box.
+
+| Action | Shortcut |
+|---|---|
+| Bold | `⌘+B` / `Ctrl+B` |
+| Italic | `⌘+I` / `Ctrl+I` |
+| Underline | `⌘+U` / `Ctrl+U` |
+| Insert / edit link | `⌘+K` / `Ctrl+K` |
+
+## Present
+
+| Action | Shortcut |
+|---|---|
+| Start from current slide | `⌘+Enter` / `Ctrl+Enter` |
+| Start from first slide | `⌘+Shift+Enter` / `Ctrl+Shift+Enter` |
+| Next slide (in present mode) | `→` / `Page Down` / Click |
+| Previous slide (in present mode) | `←` / `Page Up` |
+| Exit | `Esc` |
+
+## Help
+
+| Action | Shortcut |
+|---|---|
+| Open shortcuts help | `⌘+/` / `Ctrl+/` |

--- a/packages/documentation/slides/themes-and-layouts.md
+++ b/packages/documentation/slides/themes-and-layouts.md
@@ -1,0 +1,54 @@
+# Themes & Layouts
+
+Themes and layouts let you set the visual style of a deck once and reuse it across every slide.
+
+## What is a Theme?
+
+A **theme** bundles the colors, fonts, and background used across a deck. Switching themes reskins the whole deck in one click — your content (text, images, shapes) stays put, only the visual treatment changes.
+
+Each theme defines:
+
+- A **color scheme** with theme roles (background, text, accent, etc.). Shapes and text bound to a theme role automatically update when you switch themes.
+- A **font scheme** for headings and body text. Text inside placeholders picks up the theme's heading or body font automatically.
+- A **background** style applied to every slide.
+
+## Built-in Themes
+
+Wafflebase ships with several Google-Slides-parity themes covering light, dark, and accent variations. Open the **Theme** panel from the right sidebar to see thumbnails and apply one with a click.
+
+You can switch themes at any time. The theme picker shows a live preview of the active deck under each theme.
+
+## Layouts
+
+A **layout** is a pre-arranged template for a slide — for example, "Title slide" or "Title and body". Each layout defines a set of **placeholders** that you fill in with your content.
+
+The built-in layouts match Google Slides:
+
+| Layout | Use it for |
+|---|---|
+| Title slide | The opening slide of a deck — large title + subtitle |
+| Section header | Section dividers between groups of slides |
+| Title and body | A title with a single body region (text, bullets, or content) |
+| Title and two columns | A title above two side-by-side content regions |
+| Title only | A title with the rest of the slide left blank |
+| One column text | A full-width body region for prose-heavy slides |
+| Main point | A single large takeaway, centered |
+| Section title and description | A section title plus a paragraph of description |
+| Caption | A large image area with a caption below |
+| Big number | A single large numeric stat as the focal point |
+| Blank | Empty canvas, no placeholders |
+
+## Changing a Slide's Layout
+
+Open the **Layout** split-button on the toolbar (or right-click a slide in the thumbnail strip → **Apply layout**) and pick a new layout. The slide's existing placeholders are matched to the new layout's slots when their types align, so the title stays a title and the body stays a body.
+
+## Placeholders
+
+A **placeholder** is a typed content slot in a layout — a title, a body, an image area, a footer. Placeholders carry the layout's default formatting (font, size, alignment) so text added through them automatically matches the theme.
+
+When you switch layouts, Wafflebase preserves placeholder identity where possible: a title placeholder remains a title even if the new layout positions it differently, so its content survives the change.
+
+## What's Next
+
+- [Build a Deck](./build-a-deck) — End-to-end tutorial
+- [Keyboard Shortcuts](./keyboard-shortcuts) — Layout switching, slide ops, and more

--- a/packages/frontend/src/app/home/demo-section.tsx
+++ b/packages/frontend/src/app/home/demo-section.tsx
@@ -194,7 +194,7 @@ export function DemoSection() {
                 ? "Tip: double-click a cell to edit. Totals recompute on the same engine."
                 : tab === "doc"
                   ? "Tip: edit any paragraph or heading — changes sync in real time."
-                  : "Tip: arrow keys navigate slides — press F to present."}
+                  : "Tip: arrow keys navigate — ⌘/Ctrl+Enter to present."}
             </span>
             <span className="shrink-0">{`wafflebase@${__APP_VERSION__}`}</span>
           </div>

--- a/packages/frontend/src/app/home/demo-section.tsx
+++ b/packages/frontend/src/app/home/demo-section.tsx
@@ -11,22 +11,31 @@ const DEMO_DOC_TOKEN =
   import.meta.env.VITE_DEMO_DOC_SHARED_TOKEN ??
   "08fe575d-c5c0-451f-9b00-37d1833f68cc";
 
-type Tab = "sheet" | "doc";
+const DEMO_SLIDES_TOKEN =
+  import.meta.env.VITE_DEMO_SLIDES_SHARED_TOKEN ??
+  "bf4e92f1-f289-43dd-be1b-8a47c14f0e7a";
 
-const TAB_ORDER: Tab[] = ["sheet", "doc"];
+type Tab = "sheet" | "doc" | "slides";
+
+const TAB_ORDER: Tab[] = ["sheet", "doc", "slides"];
 
 export function DemoSection() {
   const { resolvedTheme } = useTheme();
   const sheetIframeRef = useRef<HTMLIFrameElement>(null);
   const docIframeRef = useRef<HTMLIFrameElement>(null);
+  const slidesIframeRef = useRef<HTMLIFrameElement>(null);
   const [tab, setTab] = useState<Tab>("sheet");
   const [docMounted, setDocMounted] = useState(false);
+  const [slidesMounted, setSlidesMounted] = useState(false);
   const [sheetState, setSheetState] = useState<"loading" | "loaded" | "error">(
     "loading",
   );
   const [docState, setDocState] = useState<"loading" | "loaded" | "error">(
     "loading",
   );
+  const [slidesState, setSlidesState] = useState<
+    "loading" | "loaded" | "error"
+  >("loading");
 
   // Lock the iframe URLs to the initial theme so subsequent theme changes
   // don't mutate the `src` prop and trigger a full reload — theme updates
@@ -39,11 +48,16 @@ export function DemoSection() {
     () =>
       `${window.location.origin}/shared/${DEMO_DOC_TOKEN}?theme=${resolvedTheme}`,
   );
+  const [slidesUrl] = useState(
+    () =>
+      `${window.location.origin}/shared/${DEMO_SLIDES_TOKEN}?theme=${resolvedTheme}`,
+  );
 
-  // Mount the doc iframe lazily, on first activation of the doc tab,
-  // so the initial pageload only fetches the sheet iframe.
+  // Mount the doc / slides iframes lazily, on first activation of their
+  // tab, so the initial pageload only fetches the sheet iframe.
   useEffect(() => {
     if (tab === "doc") setDocMounted(true);
+    if (tab === "slides") setSlidesMounted(true);
   }, [tab]);
 
   // Forward theme changes to live iframes via postMessage so they update
@@ -51,7 +65,8 @@ export function DemoSection() {
   useEffect(() => {
     postTheme(sheetIframeRef, sheetState === "loaded", resolvedTheme);
     postTheme(docIframeRef, docState === "loaded", resolvedTheme);
-  }, [resolvedTheme, sheetState, docState]);
+    postTheme(slidesIframeRef, slidesState === "loaded", resolvedTheme);
+  }, [resolvedTheme, sheetState, docState, slidesState]);
 
   const handleTabKey = (e: React.KeyboardEvent, key: Tab) => {
     if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
@@ -112,6 +127,15 @@ export function DemoSection() {
               tabId="demo-tab-doc"
               panelId="demo-panel-doc"
             />
+            <DemoTab
+              active={tab === "slides"}
+              onClick={() => setTab("slides")}
+              onKeyDown={(e) => handleTabKey(e, "slides")}
+              icon={<SlidesIcon />}
+              label="Presentation"
+              tabId="demo-tab-slides"
+              panelId="demo-panel-slides"
+            />
             <span className="flex-1" />
           </div>
 
@@ -142,6 +166,19 @@ export function DemoSection() {
                 onError={() => setDocState("error")}
               />
             )}
+            {slidesMounted && (
+              <DemoFrame
+                visible={tab === "slides"}
+                iframeRef={slidesIframeRef}
+                src={slidesUrl}
+                title="Wafflebase live demo presentation"
+                state={slidesState}
+                panelId="demo-panel-slides"
+                tabId="demo-tab-slides"
+                onLoad={() => setSlidesState("loaded")}
+                onError={() => setSlidesState("error")}
+              />
+            )}
           </div>
 
           {/* Footer */}
@@ -155,7 +192,9 @@ export function DemoSection() {
             <span className="truncate pr-3">
               {tab === "sheet"
                 ? "Tip: double-click a cell to edit. Totals recompute on the same engine."
-                : "Tip: edit any paragraph or heading — changes sync in real time."}
+                : tab === "doc"
+                  ? "Tip: edit any paragraph or heading — changes sync in real time."
+                  : "Tip: arrow keys navigate slides — press F to present."}
             </span>
             <span className="shrink-0">wafflebase@0.3.7</span>
           </div>
@@ -316,6 +355,27 @@ function DocIcon() {
         stroke="currentColor"
         strokeWidth="1.2"
         strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function SlidesIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <rect
+        x="1"
+        y="2"
+        width="12"
+        height="9"
+        rx="1.5"
+        stroke="currentColor"
+        strokeWidth="1.2"
+      />
+      <path
+        d="M5.5 5.5l3 1.5-3 1.5z"
+        fill="currentColor"
+        opacity="0.7"
       />
     </svg>
   );

--- a/packages/frontend/src/app/home/demo-section.tsx
+++ b/packages/frontend/src/app/home/demo-section.tsx
@@ -196,7 +196,7 @@ export function DemoSection() {
                   ? "Tip: edit any paragraph or heading — changes sync in real time."
                   : "Tip: arrow keys navigate slides — press F to present."}
             </span>
-            <span className="shrink-0">wafflebase@0.3.7</span>
+            <span className="shrink-0">{`wafflebase@${__APP_VERSION__}`}</span>
           </div>
         </div>
       </div>

--- a/packages/frontend/src/app/home/features-section.tsx
+++ b/packages/frontend/src/app/home/features-section.tsx
@@ -73,7 +73,7 @@ const SECONDARY_FEATURES: SecondaryFeature[] = [
     title: "Tables & Pagination",
     description:
       "Rich tables, page breaks, and pagination for long-form documents",
-    href: "/docs/docs-editor/writing-a-document",
+    href: "/docs/docs-editor/writing-a-document#tables",
   },
   {
     Icon: Palette,

--- a/packages/frontend/src/app/home/features-section.tsx
+++ b/packages/frontend/src/app/home/features-section.tsx
@@ -1,4 +1,11 @@
-import { BarChart3, FileText, FunctionSquare, Shield } from "lucide-react";
+import {
+  BarChart3,
+  FileText,
+  FunctionSquare,
+  Palette,
+  Presentation,
+  Rows3,
+} from "lucide-react";
 import type { ComponentType, ReactNode } from "react";
 import { FeatureGlyph, type GlyphKind } from "./primitives/feature-glyph";
 import { SectionHead } from "./primitives/section-head";
@@ -56,15 +63,31 @@ const SECONDARY_FEATURES: SecondaryFeature[] = [
   },
   {
     Icon: FileText,
-    title: "Document Editor",
-    description: "Write and format documents with a clean, page-based editor",
+    title: "Page-Based Document Editor",
+    description:
+      "Write and format documents with a clean, paginated editor",
     href: "/docs/docs-editor/writing-a-document",
   },
   {
-    Icon: Shield,
-    title: "Sharing & Permissions",
-    description: "URL sharing with role-based access control",
-    href: "/docs/guide/collaboration",
+    Icon: Rows3,
+    title: "Tables & Pagination",
+    description:
+      "Rich tables, page breaks, and pagination for long-form documents",
+    href: "/docs/docs-editor/writing-a-document",
+  },
+  {
+    Icon: Palette,
+    title: "Themes & Layouts",
+    description:
+      "Four-tier theme system and Google-Slides-parity layouts for decks",
+    href: "/docs/slides/themes-and-layouts",
+  },
+  {
+    Icon: Presentation,
+    title: "Presentation Mode",
+    description:
+      "Full-screen player with keyboard navigation and click-to-advance",
+    href: "/docs/slides/build-a-deck",
   },
 ];
 

--- a/packages/frontend/src/app/home/footer.tsx
+++ b/packages/frontend/src/app/home/footer.tsx
@@ -59,8 +59,9 @@ export function Footer() {
               Wafflebase
             </a>
             <p className="text-[14px] leading-[1.55] text-[color:var(--wb-sub)] max-w-[280px] m-0">
-              Self-hosted collaborative word processor and spreadsheet, with
-              real-time editing and a REST API for automation.
+              Self-hosted collaborative presentations, word processor, and
+              spreadsheet, with real-time editing and a REST API for
+              automation.
             </p>
           </div>
 

--- a/packages/frontend/src/app/home/hero-section.tsx
+++ b/packages/frontend/src/app/home/hero-section.tsx
@@ -43,10 +43,10 @@ export function HeroSection({
 
           {/* Title */}
           <h1
-            className="font-display font-semibold text-[color:var(--wb-ink)] leading-[1.04] tracking-[-0.025em] text-[clamp(40px,6vw,68px)] m-0 mb-6 max-w-[16ch]"
+            className="font-display font-semibold text-[color:var(--wb-ink)] leading-[1.04] tracking-[-0.025em] text-[clamp(40px,6vw,68px)] m-0 mb-6 max-w-[20ch]"
             style={{ fontFeatureSettings: "'ss01' on, 'ss02' on" }}
           >
-            Word Processor & Spreadsheet{" "}
+            The Office Suite{" "}
             <em className="font-medium italic text-[color:var(--wb-syrup-deep)]">
               You Can Own
             </em>
@@ -54,8 +54,8 @@ export function HeroSection({
 
           {/* Sub */}
           <p className="text-[color:var(--wb-sub)] leading-[1.55] text-[clamp(17px,1.4vw,19px)] max-w-[560px] m-0 mb-10">
-            Self-host a collaborative word processor and spreadsheet with
-            real-time editing and a REST API for automation.
+            Sheets, Docs, and Slides. Real-time collaboration, REST API,
+            fully self-hosted.
           </p>
 
           {/* CTAs */}

--- a/packages/frontend/src/app/home/hero-section.tsx
+++ b/packages/frontend/src/app/home/hero-section.tsx
@@ -4,6 +4,9 @@ import { WbButton } from "./primitives/wb-button";
 
 const GITHUB_URL = "https://github.com/wafflebase/wafflebase";
 
+// `v0.4` from `0.4.1` — minor-version label for the marketing eyebrow.
+const VERSION_LABEL = `v${__APP_VERSION__.split(".").slice(0, 2).join(".")}`;
+
 const STATS = [
   { value: "Apache-2.0", label: "License" },
   { value: "Self-hosted", label: "Deployment" },
@@ -38,7 +41,7 @@ export function HeroSection({
                   "0 0 0 3px color-mix(in srgb, var(--wb-leaf) 25%, transparent)",
               }}
             />
-            v0.3 · Apache-2.0 · Self-hosted
+            {VERSION_LABEL} · Apache-2.0 · Self-hosted
           </div>
 
           {/* Title */}

--- a/packages/frontend/src/app/home/hero-section.tsx
+++ b/packages/frontend/src/app/home/hero-section.tsx
@@ -46,11 +46,11 @@ export function HeroSection({
 
           {/* Title */}
           <h1
-            className="font-display font-semibold text-[color:var(--wb-ink)] leading-[1.04] tracking-[-0.025em] text-[clamp(40px,6vw,68px)] m-0 mb-6 max-w-[20ch]"
+            className="font-display font-semibold text-[color:var(--wb-ink)] leading-[1.04] tracking-[-0.025em] text-[clamp(40px,6vw,68px)] m-0 mb-6"
             style={{ fontFeatureSettings: "'ss01' on, 'ss02' on" }}
           >
-            The Office Suite{" "}
-            <em className="font-medium italic text-[color:var(--wb-syrup-deep)]">
+            <span className="block">The Office Suite</span>
+            <em className="block font-medium italic text-[color:var(--wb-syrup-deep)]">
               You Can Own
             </em>
           </h1>

--- a/packages/frontend/src/app/home/use-cases-section.tsx
+++ b/packages/frontend/src/app/home/use-cases-section.tsx
@@ -15,10 +15,10 @@ const USE_CASES: UseCase[] = [
     href: "/docs/sheets/sheet",
   },
   {
-    tag: "Customer dashboards",
-    title: "Let customers slice their own numbers",
-    body: "Ship a sheet view of their data with formulas they can modify. Great for billing breakdowns, forecasts, what-ifs.",
-    href: "/docs/sheets/formulas",
+    tag: "Pitch decks & all-hands",
+    title: "Ship the deck on your brand, not Google's",
+    body: "Four-tier theme system, Google-Slides-parity layouts, and a self-hosted store — your team's decks live where your data lives.",
+    href: "/docs/slides/build-a-deck",
   },
   {
     tag: "Specs & launch plans",

--- a/packages/frontend/src/app/home/why-section.tsx
+++ b/packages/frontend/src/app/home/why-section.tsx
@@ -43,7 +43,7 @@ const rows: { label: string; wafflebase: ReactNode; others: ReactNode }[] = [
     others: <CheckMark />,
   },
   {
-    label: "Sheets & Docs in one app",
+    label: "Slides, Docs & Sheets in one app",
     wafflebase: <CheckMark />,
     others: <CheckMark />,
   },

--- a/packages/frontend/src/app/home/why-section.tsx
+++ b/packages/frontend/src/app/home/why-section.tsx
@@ -43,7 +43,7 @@ const rows: { label: string; wafflebase: ReactNode; others: ReactNode }[] = [
     others: <CheckMark />,
   },
   {
-    label: "Slides, Docs & Sheets in one app",
+    label: "Sheets, Docs & Slides in one app",
     wafflebase: <CheckMark />,
     others: <CheckMark />,
   },

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/** Root package.json version, injected via vite.config.ts `define`. */
+declare const __APP_VERSION__: string;

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import path from "path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -5,6 +6,14 @@ import { defineConfig, loadEnv, type Plugin, type Connect } from "vite";
 
 const utilShimPath = path.resolve(__dirname, "./src/lib/util-shim.js");
 const assertShimPath = path.resolve(__dirname, "./src/lib/assert-shim.cjs");
+
+// Root package.json is the single source of truth for the version
+// surfaced on the homepage. Read at config-eval time and inject as a
+// build-time constant so the hero eyebrow and demo footer always
+// match the shipped package.
+const rootPkg = JSON.parse(
+  readFileSync(path.resolve(__dirname, "../../package.json"), "utf-8"),
+) as { version: string };
 
 /**
  * Replaces the `<!--GA_SNIPPET-->` marker in index.html with the GA4
@@ -150,6 +159,7 @@ export default defineConfig({
   },
   define: {
     "process.env": {},
+    __APP_VERSION__: JSON.stringify(rootPkg.version),
   },
   optimizeDeps: {
     esbuildOptions: {


### PR DESCRIPTION
## Summary

Reframe the public surface from a 2-product narrative ("Word Processor & Spreadsheet") to a 3-product office-suite narrative now that Slides is
shipped alongside Sheets and Docs.

**Homepage** (`packages/frontend/src/app/home/`):
- Hero: `The Office Suite` / `You Can Own` (forced two-line H1) + sub
  copy "Sheets, Docs, and Slides. Real-time collaboration, REST API,
  fully self-hosted."
- DemoSection: third live Slides tab (Sheets → Docs → Slides, default
  Sheets), lazy-mounted, theme-synced via existing `postMessage`
  pattern. Token defaults to a public demo deck; override via
  `VITE_DEMO_SLIDES_SHARED_TOKEN`.
- FeaturesSection: 6 secondary cards in a product-balanced 3×2 grid
  (Sheets 2, Docs 2, Slides 2). "Sharing & Permissions" dropped to
  remove overlap with the Real-Time Collaboration hero card.
- UseCasesSection: card 2 replaced with a Slides pitch-deck case.
- WhySection: comparison row updated to "Sheets, Docs & Slides in one
  app".
- Footer: brand copy now reads "presentations, word processor, and
  spreadsheet".
- Version label: hero eyebrow and demo footer now read from
  `__APP_VERSION__`, injected at vite build time from the root
  `package.json` so the strings can't drift from the shipped version
  again.

**Documentation site** (`packages/documentation/`):
- New `slides/` group with three pages: `build-a-deck`,
  `themes-and-layouts`, `keyboard-shortcuts`.
- Nav + sidebar position Slides between Docs and Developers.
- `docs-editor/writing-a-document.md` gains Tables and Pagination
  sections so the new "Tables & Pagination" feature card lands on
  real content.

**Design docs**: `docs/design/homepage.md` and `docs/design/docs-site.md`
brought back in sync with the shipped state.

**Plan**: `docs/tasks/active/20260521-slides-homepage-docs-todo.md`
documents the brainstormed decisions chunk-by-chunk.

Slides REST API/CLI, additional Slides docs pages (shapes / connectors
/ presentation-mode deep dives), and live Sheets-cell embedding inside
slides are intentionally out of scope.

## Test plan

- [x] `pnpm verify:fast` (frontend + backend + sheets + docs + slides + documentation)
- [x] `pnpm --filter @wafflebase/documentation build` — no broken links to new pages
- [x] `pnpm --filter @wafflebase/frontend build` — no missing imports
- [x] Manual smoke (`pnpm dev` at localhost:5173):
  - Hero copy and version label correct
  - All three demo tabs render; Slides lazy-mounts on first activation; no reloads on switch
  - Theme toggle propagates to all three iframes via `postMessage`
  - 6 feature cards render in 3×2 grid; all hrefs resolve
  - UseCase 2 reads as Slides pitch-deck case
  - WhySection row reads "Sheets, Docs & Slides in one app"
  - Footer brand copy includes "presentations, word processor, and spreadsheet"
- [x] Manual smoke (docs site at localhost:5174):
  - Top nav order: Guide / Sheets / Docs / Slides / Developers
  - Slides sidebar group shows three pages, all render
  - `writing-a-document#tables` resolves and ToC lists Tables + Pagination
- [x] Self code review (5-agent parallel pass); blocking findings applied in `433c9e92`

Demo iframe shows "Link unavailable" in local dev for all three tabs
since the demo tokens are production-bound — production at
wafflebase.io serves the real shared decks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slides module demo to the homepage with live presentation tab alongside Sheets and Docs
  * Introduced Slides documentation with guides on building decks, themes, layouts, and keyboard shortcuts

* **Documentation**
  * Expanded documentation site structure to include Slides tutorials and developer references
  * Reorganized content around module-specific user guides (Sheets, Docs, Slides)

* **UI/UX Updates**
  * Redesigned homepage messaging to position Wafflebase as a complete office suite
  * Updated feature cards and comparison table to highlight all three product modules
  * Enhanced demo with theme synchronization across all live iframes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->