### PR TITLE
Fix SUMPRODUCT boolean coercion

### DIFF
--- a/packages/sheets/src/formula/formula.ts
+++ b/packages/sheets/src/formula/formula.ts
@@ -32,6 +32,8 @@ import {
   parseRef,
   parseRange,
   isCrossSheetRef,
+  parseCrossSheetRef,
+  toSref,
 } from '../model/core/coordinates';
 
 /**
@@ -651,6 +653,16 @@ export type EvalNode =
   | ArrNode
   | LambdaNode;
 
+function cellValueToEvalNode(value: string | undefined): EvalNode {
+  const val = value || '';
+  if (val === '') return { t: 'num', v: 0 };
+  if (val === 'TRUE' || val === 'true') return { t: 'bool', v: true };
+  if (val === 'FALSE' || val === 'false') return { t: 'bool', v: false };
+  const num = Number(val);
+  if (!isNaN(num)) return { t: 'num', v: num };
+  return { t: 'str', v: val };
+}
+
 /**
  * `Evaluator` class evaluates the formula. The grammar of the formula is defined in
  * `antlr/Formula.g4` file.
@@ -739,12 +751,21 @@ class Evaluator implements FormulaVisitor<EvalNode> {
   }
 
   visitAddSub(ctx: AddSubContext): EvalNode {
-    const left = NumberArgs.map(this.visit(ctx.expr(0)), this.grid);
+    const rawLeft = this.visit(ctx.expr(0));
+    const rawRight = this.visit(ctx.expr(1));
+    const arrayResult = this.evalArrayArithmetic(
+      rawLeft,
+      rawRight,
+      ctx._op.type,
+    );
+    if (arrayResult) return arrayResult;
+
+    const left = NumberArgs.map(rawLeft, this.grid);
     if (left.t === 'err') {
       return left;
     }
 
-    const right = NumberArgs.map(this.visit(ctx.expr(1)), this.grid);
+    const right = NumberArgs.map(rawRight, this.grid);
     if (right.t === 'err') {
       return right;
     }
@@ -757,12 +778,21 @@ class Evaluator implements FormulaVisitor<EvalNode> {
   }
 
   visitMulDiv(ctx: MulDivContext): EvalNode {
-    const left = NumberArgs.map(this.visit(ctx.expr(0)), this.grid);
+    const rawLeft = this.visit(ctx.expr(0));
+    const rawRight = this.visit(ctx.expr(1));
+    const arrayResult = this.evalArrayArithmetic(
+      rawLeft,
+      rawRight,
+      ctx._op.type,
+    );
+    if (arrayResult) return arrayResult;
+
+    const left = NumberArgs.map(rawLeft, this.grid);
     if (left.t === 'err') {
       return left;
     }
 
-    const right = NumberArgs.map(this.visit(ctx.expr(1)), this.grid);
+    const right = NumberArgs.map(rawRight, this.grid);
     if (right.t === 'err') {
       return right;
     }
@@ -811,17 +841,43 @@ class Evaluator implements FormulaVisitor<EvalNode> {
   }
 
   visitComparison(ctx: ComparisonContext): EvalNode {
-    const left = this.resolveValue(this.visit(ctx.expr(0)));
+    const rawLeft = this.visit(ctx.expr(0));
+    const rawRight = this.visit(ctx.expr(1));
+    const arrayResult = this.evalArrayComparison(
+      rawLeft,
+      rawRight,
+      ctx._op.type,
+    );
+    if (arrayResult) return arrayResult;
+
+    const left = this.resolveValue(rawLeft);
     if (left.t === 'err') {
       return left;
     }
 
-    const right = this.resolveValue(this.visit(ctx.expr(1)));
+    const right = this.resolveValue(rawRight);
     if (right.t === 'err') {
       return right;
     }
 
-    const op = ctx._op.type;
+    return this.compareValues(left, right, ctx._op.type);
+  }
+
+  private compareValues(left: EvalNode, right: EvalNode, op: number): EvalNode {
+    if (left.t === 'empty') left = { t: 'num', v: 0 };
+    if (right.t === 'empty') right = { t: 'num', v: 0 };
+    if (left.t === 'err') return left;
+    if (right.t === 'err') return right;
+    if (left.t === 'ref') left = this.resolveValue(left);
+    if (right.t === 'ref') right = this.resolveValue(right);
+    if (
+      left.t === 'arr' ||
+      left.t === 'lambda' ||
+      right.t === 'arr' ||
+      right.t === 'lambda'
+    ) {
+      return ErrNode.VALUE;
+    }
 
     // Different types: EQ→false, NEQ→true, order: num < str < bool
     if (left.t !== right.t) {
@@ -853,6 +909,130 @@ class Evaluator implements FormulaVisitor<EvalNode> {
     const lv = (left as NumNode).v;
     const rv = (right as NumNode).v;
     return this.compareBool(op, lv < rv ? -1 : lv > rv ? 1 : 0);
+  }
+
+  private evalArrayComparison(
+    left: EvalNode,
+    right: EvalNode,
+    op: number,
+  ): EvalNode | undefined {
+    const leftArray = this.toArrayNode(left);
+    if (leftArray?.t === 'err') return leftArray;
+    const rightArray = this.toArrayNode(right);
+    if (rightArray?.t === 'err') return rightArray;
+    if (!leftArray && !rightArray) return undefined;
+
+    return this.mapArrayPair(leftArray, rightArray, left, right, (a, b) =>
+      this.compareValues(a, b, op),
+    );
+  }
+
+  private evalArrayArithmetic(
+    left: EvalNode,
+    right: EvalNode,
+    op: number,
+  ): EvalNode | undefined {
+    if (left.t !== 'arr' && right.t !== 'arr') return undefined;
+
+    const leftArray = this.toArrayNode(left);
+    if (leftArray?.t === 'err') return leftArray;
+    const rightArray = this.toArrayNode(right);
+    if (rightArray?.t === 'err') return rightArray;
+    if (!leftArray && !rightArray) return undefined;
+
+    return this.mapArrayPair(leftArray, rightArray, left, right, (a, b) => {
+      const leftNum = NumberArgs.map(a, this.grid);
+      if (leftNum.t === 'err') return leftNum;
+      const rightNum = NumberArgs.map(b, this.grid);
+      if (rightNum.t === 'err') return rightNum;
+
+      switch (op) {
+        case FormulaParser.ADD:
+          return { t: 'num', v: leftNum.v + rightNum.v };
+        case FormulaParser.SUB:
+          return { t: 'num', v: leftNum.v - rightNum.v };
+        case FormulaParser.MUL:
+          return { t: 'num', v: leftNum.v * rightNum.v };
+        case FormulaParser.DIV:
+          if (rightNum.v === 0) return ErrNode.DIV0;
+          return { t: 'num', v: leftNum.v / rightNum.v };
+        default:
+          return ErrNode.ERROR;
+      }
+    });
+  }
+
+  private mapArrayPair(
+    leftArray: ArrNode | undefined,
+    rightArray: ArrNode | undefined,
+    leftScalar: EvalNode,
+    rightScalar: EvalNode,
+    mapper: (left: EvalNode, right: EvalNode) => EvalNode,
+  ): EvalNode {
+    const rows = leftArray?.rows ?? rightArray?.rows ?? 1;
+    const cols = leftArray?.cols ?? rightArray?.cols ?? 1;
+    if (
+      (leftArray && (leftArray.rows !== rows || leftArray.cols !== cols)) ||
+      (rightArray && (rightArray.rows !== rows || rightArray.cols !== cols))
+    ) {
+      return ErrNode.VALUE;
+    }
+
+    const values: EvalNode[][] = [];
+    for (let r = 0; r < rows; r++) {
+      const row: EvalNode[] = [];
+      for (let c = 0; c < cols; c++) {
+        row.push(
+          mapper(
+            leftArray ? leftArray.v[r][c] : leftScalar,
+            rightArray ? rightArray.v[r][c] : rightScalar,
+          ),
+        );
+      }
+      values.push(row);
+    }
+
+    return { t: 'arr', v: values, rows, cols };
+  }
+
+  private toArrayNode(node: EvalNode): ArrNode | ErrNode | undefined {
+    if (node.t === 'arr') return node;
+    if (node.t !== 'ref' || !this.grid || !isSrng(node.v)) return undefined;
+
+    try {
+      let localRange = node.v;
+      let prefix = '';
+      if (isCrossSheetRef(node.v)) {
+        const { sheetName, localRef } = parseCrossSheetRef(node.v);
+        localRange = localRef;
+        prefix = `${sheetName}!`;
+      }
+
+      const [a, b] = parseRange(localRange);
+      const minR = Math.min(a.r, b.r);
+      const maxR = Math.max(a.r, b.r);
+      const minC = Math.min(a.c, b.c);
+      const maxC = Math.max(a.c, b.c);
+      const values: EvalNode[][] = [];
+
+      for (let row = minR; row <= maxR; row++) {
+        const cells: EvalNode[] = [];
+        for (let col = minC; col <= maxC; col++) {
+          const ref = `${prefix}${toSref({ r: row, c: col })}`;
+          cells.push(cellValueToEvalNode(this.grid.get(ref)?.v));
+        }
+        values.push(cells);
+      }
+
+      return {
+        t: 'arr',
+        v: values,
+        rows: maxR - minR + 1,
+        cols: maxC - minC + 1,
+      };
+    } catch {
+      return ErrNode.REF;
+    }
   }
 
   private resolveValue(node: EvalNode): EvalNode {

--- a/packages/sheets/src/formula/functions-math.ts
+++ b/packages/sheets/src/formula/functions-math.ts
@@ -1414,16 +1414,11 @@ export function sumproductFunc(
 
   const arrays: number[][] = [];
   for (const expr of exprs) {
-    const refs = getRefsFromExpression(expr, visit, grid);
-    if (refs.t === 'err') {
-      return refs;
-    }
+    const matrix = getReferenceMatrixFromExpression(expr, visit, grid);
+    if (matrix.t === 'err') return matrix;
 
-    const values: number[] = [];
-    for (const ref of refs.v) {
-      const cellVal = grid?.get(ref)?.v || '';
-      values.push(cellVal !== '' && !isNaN(Number(cellVal)) ? Number(cellVal) : 0);
-    }
+    const values = flattenSumproductValues(matrix, grid);
+    if (!Array.isArray(values)) return values;
     arrays.push(values);
   }
 
@@ -1442,6 +1437,52 @@ export function sumproductFunc(
   }
 
   return { t: 'num', v: total };
+}
+
+function flattenSumproductValues(
+  matrix: MatrixResult,
+  grid?: Grid,
+): number[] | ErrNode {
+  const values: number[] = [];
+
+  if (matrix.t === 'matrix') {
+    for (const ref of matrix.v.refs) {
+      const value = coerceSumproductCell(grid?.get(ref)?.v);
+      if (value.t === 'err') return value;
+      values.push(value.v);
+    }
+    return values;
+  }
+
+  for (const row of matrix.values) {
+    for (const node of row) {
+      const value = coerceSumproductNode(node, grid);
+      if (value.t === 'err') return value;
+      values.push(value.v);
+    }
+  }
+
+  return values;
+}
+
+function coerceSumproductCell(
+  value: string | undefined,
+): { t: 'num'; v: number } | ErrNode {
+  const raw = value || '';
+  if (raw === '') return { t: 'num', v: 0 };
+  if (raw === 'TRUE' || raw === 'true') return { t: 'num', v: 1 };
+  if (raw === 'FALSE' || raw === 'false') return { t: 'num', v: 0 };
+
+  const num = Number(raw);
+  return { t: 'num', v: isNaN(num) ? 0 : num };
+}
+
+function coerceSumproductNode(
+  node: EvalNode,
+  grid?: Grid,
+): { t: 'num'; v: number } | ErrNode {
+  if (node.t === 'err') return node;
+  return NumberArgs.map(node, grid);
 }
 
 /**

--- a/packages/sheets/test/formula/formula.test.ts
+++ b/packages/sheets/test/formula/formula.test.ts
@@ -1157,6 +1157,18 @@ describe('Formula', () => {
     expect(evaluate('=SUMPRODUCT(A1:A3)', grid)).toBe('6');
   });
 
+  it('should coerce booleans in SUMPRODUCT array expressions', () => {
+    const grid: Grid = new Map<string, Cell>();
+    grid.set('A1', { v: 'North' });
+    grid.set('A2', { v: 'South' });
+    grid.set('A3', { v: 'North' });
+    grid.set('B1', { v: '10' });
+    grid.set('B2', { v: '20' });
+    grid.set('B3', { v: '30' });
+
+    expect(evaluate('=SUMPRODUCT((A1:A3="North")*B1:B3)', grid)).toBe('40');
+  });
+
   it('should correctly evaluate GCD function', () => {
     expect(evaluate('=GCD(12,8)')).toBe('4');
     expect(evaluate('=GCD(24,36,48)')).toBe('12');


### PR DESCRIPTION
Closes #196.

## Summary
- evaluate range comparisons as arrays so expressions like `(A1:A3="North")` can be used inside `SUMPRODUCT`
- support array arithmetic for the comparison result multiplied by a range
- flatten array results in `SUMPRODUCT` while coercing booleans to `1`/`0`
- add regression coverage for `SUMPRODUCT((A1:A3="North")*B1:B3)`

## Tests
- `pnpm --filter @wafflebase/sheets exec vitest --run test/formula/formula.test.ts -t "SUMPRODUCT"`
- `pnpm --filter @wafflebase/sheets test`
- `pnpm --filter @wafflebase/sheets typecheck`
- `git diff --check`

Note: the repo pre-push `verify:self` hook was also attempted. `sheets:build`, `docs:build`, and `slides:build` passed, but `verify:fast` failed in unrelated frontend docs tests with `localStorage.getItem is not a function` in this local Node environment.