### PR TITLE
Mount toolbar on slides share + enforce viewer read-only

### DIFF
--- a/docs/design/slides/slides.md
+++ b/docs/design/slides/slides.md
@@ -537,6 +537,34 @@ when fewer than 3 elements are selected.
   integer-typed in the toolbar; revisit with an epsilon if undo-stack
   bloat is reported.
 
+### Read-only mounts
+
+Viewer-role share links mount the same editor scaffolding as the owner
+route but with every mutating interaction suppressed. Each public
+entry point opts in via an option flag:
+
+- `initializeEditor({ ..., readOnly: true })` — the constructor skips
+  `attachInteractions()`, so the canvas + overlay + document-level
+  pointer and keyboard listeners are never bound. The programmatic
+  surface (`setCurrentSlide`, `markDirty`, `render`, …) stays live so
+  the host shell can still drive navigation; remote peer edits flow
+  through `markDirty()` + `render()` exactly as in the editable case.
+- `mountThumbnailPanel(panel, store, editor, { readOnly: true })` —
+  click-to-navigate stays wired, but each item's `draggable` flag is
+  cleared and the `dragstart` / `dragover` / `drop` / `contextmenu`
+  bindings are skipped, so drag-reorder and the bulk-delete context
+  menu are inert.
+- `mountNotesPanel(notes, store, editor, { readOnly: true })` — the
+  textarea is rendered with the native `readOnly` attribute set and
+  the `input` listener (which calls `store.withNotes`) is skipped, so
+  visitors can read speaker notes but never overwrite them.
+
+`SlidesView` (frontend) passes its `readOnly` prop through to all
+three. `SharedSlidesLayout` wires the share-link viewer role to it
+(`shared-document.tsx`) and additionally suppresses the empty-deck
+seed so a viewer arriving before the owner has saved the first slide
+never mutates the doc on their behalf.
+
 ### Presentation mode
 
 See [slides-presentation-mode.md](./slides-presentation-mode.md) for

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,6 +19,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | slides homepage docs (2026-05-21) | [20260521-slides-homepage-docs-todo.md](./active/20260521-slides-homepage-docs-todo.md) | - |
+| slides thumbnail async bg (2026-05-21) | [20260521-slides-thumbnail-async-bg-todo.md](./active/20260521-slides-thumbnail-async-bg-todo.md) | - |
 | slides shape move ghost (2026-05-19) | [20260519-slides-shape-move-ghost-todo.md](./active/20260519-slides-shape-move-ghost-todo.md) | - |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | - |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
@@ -29,7 +30,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 201
+- Archived task count: 202
 - Archive index: [archive/README.md](./archive/README.md)
 
 Latest active task: slides homepage docs (2026-05-21)

--- a/docs/tasks/archive/2026/05/20260523-slides-share-toolbar-lessons.md
+++ b/docs/tasks/archive/2026/05/20260523-slides-share-toolbar-lessons.md
@@ -1,0 +1,59 @@
+# Lessons — Slides share toolbar + read-only canvas
+
+Captured during implementation. Worth carrying into the next share-link
+or read-only-mount task.
+
+## Findings
+
+- **`attachInteractions()` is the single binding seam in `SlidesEditorImpl`.**
+  Every pointer + document keydown listener is attached inside this one
+  method (`editor.ts:1036`). Constructor work outside it is pure state
+  setup (`selection.subscribe(...)`, `buildKeyRules(...)`). When you
+  need an "interaction-free editor" mode, gating that call alone is
+  sufficient — no need to thread a flag through every interaction
+  module. Verified by grepping `editor.ts` for `this.on(...)` /
+  `addEventListener` outside `attachInteractions` (only the in-flight
+  pointermove/up handlers inside drag callbacks, which are themselves
+  gated on a handler that won't fire without `attachInteractions`).
+- **Drag-handler tests in jsdom can't use `DataTransfer`.** The
+  constructor isn't implemented. Either stub via
+  `Object.defineProperty(DragEvent.prototype, 'dataTransfer', …)` or
+  test indirectly (`item.draggable === false`, or "menu DOM not
+  mounted"). The thumbnail-panel suite already documents this limit;
+  the existing pattern is observational, not synthetic-event.
+- **`ensureSlidesRoot` writes even on viewer mounts of unmigrated decks.**
+  `yorkie-slides-store.ts` has an unconditional `doc.update()` migration
+  block that backfills `themes`/`masters`/`notes` for pre-v0.5 docs. The
+  empty-deck seed-skip in `slides-view.tsx` doesn't cover this. A
+  future "no viewer writes" guarantee needs to either gate the migration
+  on role, or run server-side at upgrade time. Left as a known limit
+  (see comment at `slides-view.tsx` `ensureSlidesRoot` call).
+- **Lazy-imported sibling components share a Suspense boundary cleanly.**
+  Adding a second `lazy()` import (`SlidesToolbar`) alongside
+  `SlidesView` in `shared-document.tsx` did not need a second
+  `<Suspense>` — the existing fallback covers both, and both chunks
+  share the `@wafflebase/slides` dependency chunk so the extra lazy
+  surface is a small JS-only chunk (chunk gate went 87 → 88 / 90).
+- **`import type` from `@wafflebase/slides` is safe in non-slides routes.**
+  Type-only imports are erased by tsc + esbuild, so referencing
+  `SlidesEditor` / `Theme` / `YorkieSlidesStore` types in
+  `shared-document.tsx` does not pull the slides runtime into the
+  shared-document chunk. The lazy split for `SlidesView` /
+  `SlidesToolbar` is what gates the runtime; types are free.
+
+## Process
+
+- **Verify comment veracity before shipping.** The `SharedSlidesLayout`
+  block had a 6-line "Phase 4a no-op" comment that became false the
+  moment readOnly was wired. The reviewer caught it; I had read past
+  it twice. Add "comment veracity" to the self-review checklist.
+- **`pnpm verify:fast` from a sub-directory fails with `command not
+  found`.** It's a root-level script. Always run from
+  `/Users/hackerwins/Development/wafflebase/wafflebase`, not a package
+  subdir. (Cost me one cycle of "EXIT=254" confusion.)
+- **Adding optional flags to multiple public APIs in one PR is fine when
+  they share a single conceptual gate.** Three signatures changed
+  (`SlidesEditorOptions`, `MountThumbnailPanelOptions`,
+  `MountNotesPanelOptions`), each backwards-compatible (optional
+  bag, opt-in). The reviewer didn't flag fan-out because the gate is
+  one-line in each consumer.

--- a/docs/tasks/archive/2026/05/20260523-slides-share-toolbar-lessons.md
+++ b/docs/tasks/archive/2026/05/20260523-slides-share-toolbar-lessons.md
@@ -33,7 +33,9 @@ or read-only-mount task.
   `SlidesView` in `shared-document.tsx` did not need a second
   `<Suspense>` — the existing fallback covers both, and both chunks
   share the `@wafflebase/slides` dependency chunk so the extra lazy
-  surface is a small JS-only chunk (chunk gate went 87 → 88 / 90).
+  surface emits the toolbar's contextual subsections (idle / object /
+  text-edit / mobile) as their own chunks, so the final count rose to
+  91 against the budget that this PR bumps from 90 to 93.
 - **`import type` from `@wafflebase/slides` is safe in non-slides routes.**
   Type-only imports are erased by tsc + esbuild, so referencing
   `SlidesEditor` / `Theme` / `YorkieSlidesStore` types in

--- a/docs/tasks/archive/2026/05/20260523-slides-share-toolbar-todo.md
+++ b/docs/tasks/archive/2026/05/20260523-slides-share-toolbar-todo.md
@@ -1,0 +1,57 @@
+# Slides share — toolbar for editors + read-only canvas for viewers
+
+Two related gaps in `SharedSlidesLayout`:
+
+1. `SlidesToolbar` was never mounted, so editor-role share links had a
+   canvas with no editing controls.
+2. `SlidesView` accepts `readOnly` only for API parity — the underlying
+   editor still binds all pointer/keyboard handlers, so viewer-role
+   shares can still mutate the deck (drag elements, type into text
+   boxes, reorder thumbnails, edit notes).
+
+## Background
+
+- `slides-detail.tsx` (owner route `/p/:id`) mounts `<SlidesToolbar>`
+  immediately above `<SlidesView>`.
+- `shared-document.tsx`'s `SharedSlidesLayout` mounted only
+  `<SlidesView readOnly={readOnly} />` — the toolbar was missing
+  entirely, and the layout didn't capture the editor/store instances
+  the toolbar would need.
+- `SharedDocsLayout` already shows the pattern
+  (`{!readOnly && <DocsFormattingToolbar editor={editor} />}`); the
+  slides side mirrors it.
+- For the read-only canvas, the cleanest surgery is at the editor
+  options: skipping `attachInteractions()` strips every pointer +
+  keyboard listener at once. The thumbnail and notes panels need the
+  same flag so drag-reorder, right-click bulk delete, and notes typing
+  are gated too.
+
+## Tasks
+
+- [x] Editor-role toolbar: state + `SlidesView` wiring + lazy
+  `SlidesToolbar` mount in `SharedSlidesLayout`.
+- [x] `onImagePick`: toast info — workspace-scoped image upload isn't
+  available to share-link viewers.
+- [x] Slides package: add `readOnly?: boolean` to
+  `SlidesEditorOptions`; skip `attachInteractions()` when true so the
+  canvas + overlay + document keydown listeners never bind.
+- [x] Slides package: add `readOnly?: boolean` to
+  `mountThumbnailPanel`; skip drag-reorder + right-click context and
+  clear `item.draggable` (keep click + ArrowUp/Down navigation).
+- [x] Slides package: add `readOnly?: boolean` to `mountNotesPanel`;
+  set `textarea.readOnly = true` and skip the `input` listener.
+- [x] `slides-view.tsx`: thread `readOnly` through `initializeEditor`,
+  `mountThumbnailPanel`, `mountNotesPanel`; skip the empty-deck seed
+  (`store.batch(() => store.addSlide(...))`) when read-only.
+- [x] Cover read-only behavior with vitest in `editor.test.ts`,
+  `thumbnail-panel.test.ts`, `notes-panel.test.ts`.
+- [x] Update `docs/design/slides/slides.md` with a "Read-only mounts"
+  section.
+- [x] Run `pnpm verify:fast` and confirm green.
+
+## Non-goals
+
+- Image upload from the shared editor (requires workspace auth).
+- The theme side panel — defer to a follow-up.
+- Yorkie write enforcement on the server side (a viewer that bypasses
+  the UI today would still hit Yorkie ACLs — out of scope for this PR).

--- a/docs/tasks/archive/2026/05/20260523-slides-share-toolbar-todo.md
+++ b/docs/tasks/archive/2026/05/20260523-slides-share-toolbar-todo.md
@@ -53,5 +53,7 @@ Two related gaps in `SharedSlidesLayout`:
 
 - Image upload from the shared editor (requires workspace auth).
 - The theme side panel — defer to a follow-up.
-- Yorkie write enforcement on the server side (a viewer that bypasses
-  the UI today would still hit Yorkie ACLs — out of scope for this PR).
+- Server-side write enforcement. This PR only adds UI-level gating; a
+  viewer who bypasses the UI and writes directly to Yorkie is not
+  blocked by anything we ship here. Whatever (or no) protection exists
+  server-side is out of scope.

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,13 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 201
+Total archived tasks: 202
 
-## 2026/05 (56 tasks)
+## 2026/05 (57 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides share toolbar (2026-05-23) | [20260523-slides-share-toolbar-todo.md](./2026/05/20260523-slides-share-toolbar-todo.md) | [20260523-slides-share-toolbar-lessons.md](./2026/05/20260523-slides-share-toolbar-lessons.md) |
 | slides arrow key text edit (2026-05-21) | [20260521-slides-arrow-key-text-edit-todo.md](./2026/05/20260521-slides-arrow-key-text-edit-todo.md) | [20260521-slides-arrow-key-text-edit-lessons.md](./2026/05/20260521-slides-arrow-key-text-edit-lessons.md) |
 | slides group handle bbox (2026-05-20) | [20260520-slides-group-handle-bbox-todo.md](./2026/05/20260520-slides-group-handle-bbox-todo.md) | [20260520-slides-group-handle-bbox-lessons.md](./2026/05/20260520-slides-group-handle-bbox-lessons.md) |
 | slides drag connector crash (2026-05-19) | [20260519-slides-drag-connector-crash-todo.md](./2026/05/20260519-slides-drag-connector-crash-todo.md) | [20260519-slides-drag-connector-crash-lessons.md](./2026/05/20260519-slides-drag-connector-crash-lessons.md) |

--- a/harness.config.json
+++ b/harness.config.json
@@ -2,8 +2,8 @@
   "frontend": {
     "chunkBudgets": {
       "maxChunkKb": 710,
-      "maxChunkCount": 90,
-      "maxChunkCountReason": "Bumped from 85 → 90 in the Slides toolbar redesign — extracting the docs text-formatting controls into shared components/text-formatting/{style,format,paragraph}-group plus the new slides toolbar split (insert / arrange / object / image / text-element / text-edit sections) added measured chunks (87). +3 headroom absorbs the next incremental primitive. Prior bump: 80 → 85 when shared-document.tsx lazy-loaded SlidesView for slides share links.",
+      "maxChunkCount": 93,
+      "maxChunkCountReason": "Bumped from 90 → 93 when shared-document.tsx lazy-loaded SlidesToolbar alongside SlidesView for editor-role slides shares — Vite splits the toolbar's contextual subsections (idle / object / text-edit / mobile) into their own dynamic-import chunks, so the share-link route gained ~3 chunks. Only slides share-link visitors download them; sheets/docs share routes are unaffected. Prior bump: 85 → 90 in the Slides toolbar redesign — extracting the docs text-formatting controls into shared components/text-formatting/{style,format,paragraph}-group plus the new slides toolbar split (insert / arrange / object / image / text-element / text-edit sections) added measured chunks (87). +3 headroom absorbs the next incremental primitive. Prior bump: 80 → 85 when shared-document.tsx lazy-loaded SlidesView for slides share links.",
       "overrides": [
         {
           "pattern": "^pending-imports-",

--- a/packages/frontend/src/app/shared/shared-document.tsx
+++ b/packages/frontend/src/app/shared/shared-document.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { YorkieProvider, DocumentProvider, useDocument } from "@yorkie-js/react";
+import { toast } from "sonner";
 import { resolveShareLink, ResolvedShareLink } from "@/api/share-links";
 import { fetchMeOptional } from "@/api/auth";
 import { Loader } from "@/components/loader";
@@ -17,6 +18,8 @@ import type { UserPresence as UserPresenceType } from "@/types/users";
 import { UserPresence } from "@/components/user-presence";
 import { DocsView, type EditorAPI } from "@/app/docs/docs-view";
 import { DocsFormattingToolbar } from "@/app/docs/docs-formatting-toolbar";
+import type { SlidesEditor, Theme } from "@wafflebase/slides";
+import type { YorkieSlidesStore } from "@/app/slides/yorkie-slides-store";
 import { IconDatabase, IconMessage, IconTable } from "@tabler/icons-react";
 
 type PeerJumpTarget = {
@@ -37,6 +40,12 @@ const DataSourceView = lazy(() =>
 const SlidesView = lazy(() =>
   import("@/app/slides/slides-view").then((module) => ({
     default: module.SlidesView,
+  })),
+);
+
+const SlidesToolbar = lazy(() =>
+  import("@/app/slides/toolbar").then((module) => ({
+    default: module.SlidesToolbar,
   })),
 );
 
@@ -214,12 +223,36 @@ function SharedDocsLayout({ resolved }: { resolved: ResolvedShareLink }) {
 }
 
 function SharedSlidesLayout({ resolved }: { resolved: ResolvedShareLink }) {
-  // `SlidesView` accepts `readOnly` for API parity with `DocsView` but
-  // currently treats it as a no-op (see slides-view.tsx — Phase 4a).
-  // The share-link role is forwarded so it lights up automatically when
-  // Phase 4b wires the read-only path. Until then, viewer-role shares
-  // see the "View only" badge but the editor is still interactive.
+  // The share-link role decides whether the visitor gets the editing
+  // toolbar + an interactive canvas, or a viewer-only mount with every
+  // pointer/keyboard handler suppressed. Interaction gating lives in
+  // `SlidesView` (which forwards `readOnly` to `initializeEditor`,
+  // `mountThumbnailPanel`, and `mountNotesPanel`).
   const readOnly = resolved.role === "viewer";
+  const [editor, setEditor] = useState<SlidesEditor | null>(null);
+  const [store, setStore] = useState<YorkieSlidesStore | null>(null);
+  const [currentThemeId, setCurrentThemeId] = useState("default-light");
+
+  useEffect(() => {
+    if (!store) return;
+    setCurrentThemeId(store.read().meta.themeId);
+    return store.onChange(() => {
+      setCurrentThemeId(store.read().meta.themeId);
+    });
+  }, [store]);
+
+  const activeTheme = useMemo<Theme | null>(() => {
+    if (!store) return null;
+    const doc = store.read();
+    return doc.themes.find((t) => t.id === currentThemeId) ?? null;
+  }, [store, currentThemeId]);
+
+  // Image insert is gated on workspace-scoped auth (see image-upload.ts),
+  // which share-link viewers don't have. Surface a toast instead of
+  // silently dropping the click.
+  const handleImagePick = useCallback(() => {
+    toast.info("Image upload isn't available in shared editing.");
+  }, []);
 
   return (
     <div className="flex h-screen w-full flex-col">
@@ -236,7 +269,19 @@ function SharedSlidesLayout({ resolved }: { resolved: ResolvedShareLink }) {
       </header>
       <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
         <Suspense fallback={<Loader />}>
-          <SlidesView readOnly={readOnly} />
+          {!readOnly && (
+            <SlidesToolbar
+              editor={editor}
+              store={store}
+              theme={activeTheme}
+              onImagePick={handleImagePick}
+            />
+          )}
+          <SlidesView
+            readOnly={readOnly}
+            onEditorReady={setEditor}
+            onStoreReady={setStore}
+          />
         </Suspense>
       </div>
     </div>

--- a/packages/frontend/src/app/slides/mobile-slides-view.tsx
+++ b/packages/frontend/src/app/slides/mobile-slides-view.tsx
@@ -317,6 +317,12 @@ export function MobileSlidesView({
       hostH = 1;
     }
 
+    // TODO: when `SharedSlidesLayout` grows a phone-width branch and
+    // mounts `MobileSlidesView` for share links, accept and forward a
+    // `readOnly` prop here (the slides editor already supports it via
+    // `SlidesEditorOptions.readOnly`). Today the share-link route
+    // always uses desktop `SlidesView`, so this mount is owner-only
+    // and never read-only.
     const editor = initializeEditor({
       canvas,
       overlay,

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -100,6 +100,7 @@ function computeFitSize(availWidth: number, availHeight: number): {
  */
 export function SlidesView({
   documentId,
+  readOnly,
   onEditorReady,
   onStoreReady,
   onStartPresentation,
@@ -109,6 +110,7 @@ export function SlidesView({
   const [didMount, setDidMount] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const { doc, loading, error } = useDocument<YorkieSlidesRoot, SlidesPresence>();
+  const readOnlyMount = readOnly === true;
 
   // Capture the latest onStartPresentation in a ref so the editor's
   // Cmd/Ctrl+Enter handler always calls the freshest callback, without
@@ -165,6 +167,12 @@ export function SlidesView({
       }
     }
 
+    // Known gap (intentional in this PR): `ensureSlidesRoot` may run a
+    // `doc.update()` migration block when a viewer mounts an
+    // unmigrated pre-v0.5 deck, contradicting the empty-deck-seed
+    // policy below. Fixing it properly (gating the migration on a
+    // role, or migrating server-side) is owned by the doc-migration
+    // workstream — not the share-link toolbar work.
     ensureSlidesRoot(doc);
 
     // Build the canvas + overlay DOM into the container. The slides
@@ -313,7 +321,12 @@ export function SlidesView({
     // seed the canvas would stay blank until the user clicked the
     // "+ Slide" toolbar button. Seeding once on first mount matches
     // Google Slides' "new deck always opens with one slide" UX.
-    if (store.read().slides.length === 0) {
+    //
+    // Skipped when this mount is read-only — share-link viewers must
+    // never write to the deck, and a viewer arriving before the owner
+    // has saved the first slide should see an empty canvas rather
+    // than mutating the doc on their behalf.
+    if (!readOnlyMount && store.read().slides.length === 0) {
       store.batch(() => store.addSlide("blank"));
     }
     const editor = initializeEditor({
@@ -323,6 +336,7 @@ export function SlidesView({
       hostWidth: hostW,
       hostHeight: hostH,
       dpr,
+      readOnly: readOnlyMount,
       onShowShortcutsHelp: () => setHelpOpen(true),
       onStartPresentation: (from) => onStartPresentationRef.current?.(from),
       onToast: (msg) => onToastRef.current(msg),
@@ -412,8 +426,9 @@ export function SlidesView({
       thumbsHost,
       store,
       editor,
+      { readOnly: readOnlyMount },
     );
-    mountNotesPanel(notesHost, store, editor);
+    mountNotesPanel(notesHost, store, editor, { readOnly: readOnlyMount });
 
     // Re-render on ANY store change — local batch commits OR remote
     // changes pushed in by another peer.
@@ -495,7 +510,9 @@ export function SlidesView({
     };
     // onEditorReady / onStoreReady are intentionally excluded — re-mounting
     // on every identity change of the parent's setter would tear down the
-    // editor.
+    // editor. `readOnlyMount` is also excluded: it is derived from a share-
+    // link role that is fixed for the lifetime of the route, so toggling
+    // it at runtime is not a supported scenario.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [didMount, doc]);
 

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -139,8 +139,8 @@ export type { SlidesTextBoxEditor } from './view/editor/text-box-editor';
 export type { AlignDirection, DistributeAxis, AlignReference } from './view/editor/align';
 
 // View — Editor (Phase 3b additions)
-export { mountThumbnailPanel, type ThumbnailPanelHandle } from './view/editor/thumbnail-panel';
-export { mountNotesPanel } from './view/editor/notes-panel';
+export { mountThumbnailPanel, type ThumbnailPanelHandle, type MountThumbnailPanelOptions } from './view/editor/thumbnail-panel';
+export { mountNotesPanel, type MountNotesPanelOptions, type NotesPanelHandle } from './view/editor/notes-panel';
 export { showLayoutPicker, type LayoutPickerOptions } from './view/editor/layout-picker';
 export { showContextMenu, dismiss as dismissContextMenu, type ContextMenuItem } from './view/editor/context-menu';
 export { MIME_TYPE as SLIDES_CLIPBOARD_MIME, serializeElements, deserializeElements } from './view/editor/interactions/clipboard';

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -128,6 +128,15 @@ export interface SlidesEditorOptions extends SlideRendererOptions {
    * `toast.info`). No-op when omitted.
    */
   onToast?: (message: string) => void;
+  /**
+   * When true, the editor renders the deck but skips every pointer
+   * and keyboard binding. The canvas still paints from the store
+   * (so remote peer edits flow through `markDirty()` + `render()`),
+   * but clicks, drags, double-click text entry, the context menu,
+   * and every document-level keymap action become inert. Used by
+   * share-link viewers — see `shared-document.tsx`.
+   */
+  readOnly?: boolean;
 }
 
 export interface SlidesEditor {
@@ -428,7 +437,14 @@ class SlidesEditorImpl implements SlidesEditor {
       group: () => this.group(),
       ungroup: () => this.ungroup(),
     });
-    this.attachInteractions();
+    // Read-only mounts (viewer-role share links) skip every pointer +
+    // keyboard binding. The renderer still paints, including remote
+    // peer edits, but the user cannot mutate. The editor's
+    // programmatic surface (`setCurrentSlide`, `markDirty`, etc.) keeps
+    // working so the host shell can drive navigation.
+    if (!options.readOnly) {
+      this.attachInteractions();
+    }
   }
 
   private requestRender(): void {

--- a/packages/slides/src/view/editor/notes-panel.ts
+++ b/packages/slides/src/view/editor/notes-panel.ts
@@ -7,6 +7,16 @@ export interface NotesPanelHandle {
   dispose(): void;
 }
 
+export interface MountNotesPanelOptions {
+  /**
+   * Render the textarea as `readOnly` and skip the `input` listener
+   * that writes back into the store. Used by viewer-role share links
+   * so anonymous visitors can still read speaker notes without
+   * mutating them.
+   */
+  readOnly?: boolean;
+}
+
 /**
  * Mount a speaker-notes panel into `container`. v1 is a plain
  * `<textarea>` bound to the current slide's `notes` Block[] via
@@ -21,10 +31,13 @@ export function mountNotesPanel(
   container: HTMLElement,
   store: SlidesStore,
   editor: SlidesEditor,
+  options: MountNotesPanelOptions = {},
 ): NotesPanelHandle {
+  const readOnly = options.readOnly === true;
   container.innerHTML = '';
   const ta = document.createElement('textarea');
   ta.placeholder = 'Speaker notes…';
+  ta.readOnly = readOnly;
   ta.style.width = '100%';
   ta.style.minHeight = '80px';
   // Theme tokens from shadcn (frontend's index.css) so the textarea
@@ -48,13 +61,15 @@ export function mountNotesPanel(
     ta.value = blocksToText(slide.notes);
   };
 
-  ta.addEventListener('input', () => {
-    const id = editor.getCurrentSlideId();
-    if (!id) return;
-    store.batch(() => {
-      store.withNotes(id, () => textToBlocks(ta.value));
+  if (!readOnly) {
+    ta.addEventListener('input', () => {
+      const id = editor.getCurrentSlideId();
+      if (!id) return;
+      store.batch(() => {
+        store.withNotes(id, () => textToBlocks(ta.value));
+      });
     });
-  });
+  }
 
   // Re-bind when the current slide changes. We subscribe to BOTH
   // selection changes (covers in-place edits like select/deselect on

--- a/packages/slides/src/view/editor/thumbnail-panel.ts
+++ b/packages/slides/src/view/editor/thumbnail-panel.ts
@@ -112,6 +112,17 @@ export interface ThumbnailPanelHandle {
   getSelectedSlideIds(): readonly string[];
 }
 
+export interface MountThumbnailPanelOptions {
+  /**
+   * Disable every mutating thumbnail interaction. The panel still
+   * renders thumbs and routes click + ArrowUp/Down to
+   * `editor.setCurrentSlide`, but drag-reorder, the right-click bulk
+   * context menu, and the draggable cursor are all suppressed. Used
+   * by viewer-role share links.
+   */
+  readOnly?: boolean;
+}
+
 /**
  * Mount a slide thumbnail panel into `container`. Each slide gets a
  * mini-canvas rendered via `renderThumbnail`; clicking a thumbnail
@@ -125,7 +136,9 @@ export function mountThumbnailPanel(
   container: HTMLElement,
   store: SlidesStore,
   editor: SlidesEditor,
+  options: MountThumbnailPanelOptions = {},
 ): ThumbnailPanelHandle {
+  const readOnly = options.readOnly === true;
   let selectedSlideIds: string[] = [];
   let disposed = false;
 
@@ -442,7 +455,10 @@ export function mountThumbnailPanel(
         : 'var(--border, #444)';
       item.style.border = `${BORDER_PX}px solid ${borderColor}`;
       item.style.marginBottom = '8px';
-      item.draggable = true;
+      // Read-only viewers keep the click-to-navigate affordance but
+      // never see a drag cursor — drag-reorder handlers are skipped
+      // below too.
+      item.draggable = !readOnly;
 
       const canvas = document.createElement('canvas');
       // Backing store at device pixels; CSS box at logical pixels.
@@ -489,46 +505,49 @@ export function mountThumbnailPanel(
 
       // HTML5 drag-and-drop reorder. jsdom only partially implements
       // dataTransfer, so unit-level coverage is skipped; T6 visual
-      // verifies the path.
-      item.addEventListener('dragstart', (e) => {
-        if (e.dataTransfer) {
-          e.dataTransfer.setData('text/plain', slide.id);
-          e.dataTransfer.effectAllowed = 'move';
-        }
-      });
-      item.addEventListener('dragover', (e) => {
-        e.preventDefault();
-        if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
-      });
-      item.addEventListener('drop', (e) => {
-        e.preventDefault();
-        const sourceId = e.dataTransfer?.getData('text/plain');
-        if (!sourceId || sourceId === slide.id) return;
-        const targetIndex = doc.slides.findIndex((s) => s.id === slide.id);
-        store.batch(() => store.moveSlide(sourceId, targetIndex));
-        render();
-      });
+      // verifies the path. Skipped entirely for read-only viewers —
+      // every handler below mutates the store.
+      if (!readOnly) {
+        item.addEventListener('dragstart', (e) => {
+          if (e.dataTransfer) {
+            e.dataTransfer.setData('text/plain', slide.id);
+            e.dataTransfer.effectAllowed = 'move';
+          }
+        });
+        item.addEventListener('dragover', (e) => {
+          e.preventDefault();
+          if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+        });
+        item.addEventListener('drop', (e) => {
+          e.preventDefault();
+          const sourceId = e.dataTransfer?.getData('text/plain');
+          if (!sourceId || sourceId === slide.id) return;
+          const targetIndex = doc.slides.findIndex((s) => s.id === slide.id);
+          store.batch(() => store.moveSlide(sourceId, targetIndex));
+          render();
+        });
 
-      item.addEventListener('contextmenu', (e) => {
-        e.preventDefault();
-        // If the right-clicked slide isn't already in the shift-selected
-        // set, replace selection with just that slide. Matches the
-        // canvas right-click semantics in editor.ts (right-click selects
-        // what was clicked before opening the menu) — without this, a
-        // user could right-click a slide they hadn't selected and end
-        // up with a Delete that nukes a different slide.
-        const targetIds = selectedSlideIds.includes(slide.id)
-          ? [...selectedSlideIds]
-          : [slide.id];
-        if (!selectedSlideIds.includes(slide.id)) {
-          // Visual treatment for selectedSlideIds is not implemented
-          // (only `isCurrent` styles the border), so no DOM update is
-          // needed here either — the state mutation is purely logical.
-          selectedSlideIds = [slide.id];
-        }
-        const items = buildContextMenuItems(targetIds, slide.id, e);
-        showContextMenu(document.body, items, e.clientX, e.clientY);
-      });
+        item.addEventListener('contextmenu', (e) => {
+          e.preventDefault();
+          // If the right-clicked slide isn't already in the shift-selected
+          // set, replace selection with just that slide. Matches the
+          // canvas right-click semantics in editor.ts (right-click selects
+          // what was clicked before opening the menu) — without this, a
+          // user could right-click a slide they hadn't selected and end
+          // up with a Delete that nukes a different slide.
+          const targetIds = selectedSlideIds.includes(slide.id)
+            ? [...selectedSlideIds]
+            : [slide.id];
+          if (!selectedSlideIds.includes(slide.id)) {
+            // Visual treatment for selectedSlideIds is not implemented
+            // (only `isCurrent` styles the border), so no DOM update is
+            // needed here either — the state mutation is purely logical.
+            selectedSlideIds = [slide.id];
+          }
+          const items = buildContextMenuItems(targetIds, slide.id, e);
+          showContextMenu(document.body, items, e.clientX, e.clientY);
+        });
+      }
 
       container.appendChild(item);
       if (intersectionObserver) intersectionObserver.observe(item);

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -678,6 +678,88 @@ describe('initialize', () => {
   });
 });
 
+describe('initialize with readOnly: true', () => {
+  let editor: SlidesEditor | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    if (editor) {
+      editor.detach();
+      editor = null;
+    }
+  });
+
+  it('does not bind pointerdown — clicking an element leaves selection empty', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      readOnly: true,
+    });
+    // Click within the rect's logical bounds (100,100)-(300,200). With
+    // host scale 1920→1920, world coords match client coords.
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 150, clientY: 150, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(editor.getSelection()).toEqual([]);
+    // Sanity: the element does exist; a non-readOnly editor would have
+    // selected it. (Mirrors the parallel test under 'initialize'.)
+    expect(store.read().slides[0].elements.find((el) => el.id === elementId)).toBeDefined();
+  });
+
+  it('does not bind document keydown — Delete leaves the element in place', () => {
+    const { canvas, overlay, store } = makeFixture();
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      readOnly: true,
+    });
+    // Programmatic selection still works (the surface for navigation),
+    // but the Delete keymap action must not fire because the document
+    // keydown listener was never bound.
+    editor.setSelection([elementId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Delete', bubbles: true,
+    }));
+    expect(
+      store.read().slides[0].elements.find((el) => el.id === elementId),
+    ).toBeDefined();
+  });
+
+  it('detach is safe and rendering after detach is a no-op', () => {
+    const { canvas, overlay, store } = makeFixture();
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 960, hostHeight: 540, dpr: 1,
+      readOnly: true,
+    });
+    editor.detach();
+    // Mirrors the editable-path detach test: post-detach the editor's
+    // programmatic surface must stay safe to call without throwing.
+    expect(() => editor!.render()).not.toThrow();
+    expect(() => editor!.markDirty()).not.toThrow();
+    editor = null;
+  });
+});
+
 describe('align/distribute', () => {
   let editor: SlidesEditor | null = null;
 

--- a/packages/slides/test/view/editor/notes-panel.test.ts
+++ b/packages/slides/test/view/editor/notes-panel.test.ts
@@ -55,4 +55,15 @@ describe('mountNotesPanel', () => {
     expect((store.read().slides[1].notes[0]?.inlines?.[0] as { text: string }).text).toBe('second slide notes');
     expect((store.read().slides[0].notes[0]?.inlines?.[0] as { text: string }).text).toBe('first slide notes');
   });
+
+  it('readOnly: true marks textarea read-only and ignores input', () => {
+    const { notes, store, editor } = makeFixture();
+    mountNotesPanel(notes, store, editor, { readOnly: true });
+    const ta = notes.querySelector<HTMLTextAreaElement>('textarea')!;
+    expect(ta.readOnly).toBe(true);
+    ta.value = 'attempted edit';
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+    // Store remains untouched — the input listener was never attached.
+    expect(store.read().slides[0].notes).toEqual([]);
+  });
 });

--- a/packages/slides/test/view/editor/thumbnail-panel.test.ts
+++ b/packages/slides/test/view/editor/thumbnail-panel.test.ts
@@ -77,6 +77,45 @@ describe('mountThumbnailPanel', () => {
   });
 });
 
+describe('mountThumbnailPanel — readOnly', () => {
+  it('marks every thumbnail non-draggable', () => {
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor, { readOnly: true });
+    const items = panel.querySelectorAll<HTMLDivElement>('[data-slide-id]');
+    expect(items.length).toBeGreaterThan(0);
+    for (const el of items) expect(el.draggable).toBe(false);
+  });
+
+  it('right-click does not mount the bulk-action context menu', () => {
+    const { panel, store, editor } = makeFixture();
+    const slideIds = store.read().slides.map((s) => s.id);
+    mountThumbnailPanel(panel, store, editor, { readOnly: true });
+    const second = panel.querySelector<HTMLDivElement>(
+      `[data-slide-id="${slideIds[1]}"]`,
+    )!;
+    second.dispatchEvent(new MouseEvent('contextmenu', {
+      bubbles: true, cancelable: true, clientX: 10, clientY: 10,
+    }));
+    // Direct evidence the contextmenu listener was skipped: no menu
+    // DOM was appended to document.body. The non-readOnly path would
+    // have mounted `.wfb-slides-context-menu` here.
+    expect(
+      document.body.querySelector('.wfb-slides-context-menu'),
+    ).toBeNull();
+  });
+
+  it('click still navigates between slides (read-only keeps navigation interactive)', () => {
+    const { panel, store, editor } = makeFixture();
+    mountThumbnailPanel(panel, store, editor, { readOnly: true });
+    const slideIds = store.read().slides.map((s) => s.id);
+    const second = panel.querySelector<HTMLDivElement>(
+      `[data-slide-id="${slideIds[1]}"]`,
+    )!;
+    second.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    expect(editor.getCurrentSlideId()).toBe(slideIds[1]);
+  });
+});
+
 describe('mountThumbnailPanel — scroll preservation across re-render', () => {
   it('restores parent scrollTop after innerHTML wipe (simulated browser clamp)', () => {
     const { panel, store, editor } = makeFixture();


### PR DESCRIPTION
## Summary

- `SharedSlidesLayout` never mounted `SlidesToolbar`, so editor-role share-link visitors saw a canvas with no editing controls. The layout now lazy-mounts `SlidesToolbar` alongside `SlidesView` (gated on `!readOnly`), mirroring `SharedDocsLayout`. Image upload from the shared toolbar surfaces an info toast — the workspace-scoped upload API needs JWT that share-link visitors don't carry.
- `SlidesView` accepted `readOnly` only for API parity; the underlying editor still bound every pointer + keyboard handler, so viewer-role shares could mutate the deck. Adds an opt-in `readOnly` flag on `initializeEditor`, `mountThumbnailPanel`, and `mountNotesPanel`, and threads it through `SlidesView` — `attachInteractions()` short-circuits, thumbnail drag/contextmenu handlers are skipped, the notes textarea is `readOnly`. The empty-deck seed is also suppressed in read-only mounts.
- Chunk budget bumped 90 → 93 to absorb the lazy `SlidesToolbar` subsections (idle / object / text-edit / mobile); only slides share-link visitors download these chunks.

## Test plan

- [x] `pnpm verify:fast` green.
- [x] `pnpm verify:frontend:chunks` green (91 / 93).
- [x] New vitest cases in `editor.test.ts`, `thumbnail-panel.test.ts`, `notes-panel.test.ts` exercise the `readOnly` gate against the parallel writeable assertions.
- [x] Manual smoke (editor-role share link): toolbar appears, all controls work, image-pick shows the info toast.
- [x] Manual smoke (viewer-role share link): canvas paints, slide switching via click/arrow works, but element clicks / Delete / drag-reorder / notes typing all no-op.
- [x] CI green.

## Known limitations (out of scope)

- `ensureSlidesRoot` may still run a `doc.update()` migration on viewer mounts of unmigrated pre-v0.5 decks — covered by an in-source comment and owned by the doc-migration workstream.
- `MobileSlidesView` does not forward `readOnly` yet (only mounted from the owner route today); a TODO marks the spot for when `SharedSlidesLayout` grows a phone-width branch.
- Server-side Yorkie ACLs that would block a viewer who bypasses the UI and writes directly are not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented read-only mode for shared slide links to prevent viewer edits while preserving navigation and viewing.
  * Thumbnail panel in read-only mode disables drag-reordering and context menus; click navigation remains functional.
  * Speaker notes rendered as non-editable for shared read-only viewers.

* **Documentation**
  * Added design and implementation documentation for read-only slides and toolbar support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->