### PR TITLE
Stick site header by scoping scroll to content area

### DIFF
--- a/packages/frontend/src/app/Layout.tsx
+++ b/packages/frontend/src/app/Layout.tsx
@@ -104,12 +104,8 @@ export default function Layout() {
       />
       <SidebarInset>
         <SiteHeader title={title} />
-        <div className="flex flex-1 flex-col">
-          <div className="@container/main flex flex-1 flex-col gap-2">
-            <div className="flex flex-col h-full">
-              <Outlet />
-            </div>
-          </div>
+        <div className="flex flex-1 flex-col min-h-0 overflow-y-auto">
+          <Outlet />
         </div>
       </SidebarInset>
     </SidebarProvider>


### PR DESCRIPTION
## Summary

- `Layout.tsx`'s `<Outlet/>` wrapper chained three flex containers without `min-h-0` or `overflow-y-auto`, so the `<body>` became the scroll container and the `SiteHeader` scrolled off the top on `/w/:id`, `/w/:id/settings`, `/documents`, `/settings`, etc.
- Collapsed the three wrappers into one `flex flex-1 flex-col min-h-0 overflow-y-auto` div so `SiteHeader` (already `shrink-0`) stays pinned and only the content area scrolls.
- Dropped the unused `@container/main` context — no `@*:` consumers exist in the codebase (the only other instance in `document-detail.tsx` is similarly unused and out of scope here).

Detail pages (`docs-detail`, `sheet-view`, `slides-detail`) render their own `<SidebarProvider>`/`<SidebarInset>` and don't go through this Layout, so they're unaffected.

## Test plan

- [x] `pnpm verify:fast` green (done locally)
- [x] `pnpm dev`, visit `/w/<slug>` — long document list scrolls inside the page; SiteHeader stays pinned
- [x] Same on `/w/<slug>/settings` — workspace settings (workspace name → danger zone) scrolls inside; SiteHeader pinned
- [x] Same on `/w/<slug>/datasources`, `/documents`, `/settings`
- [x] Detail pages unchanged: `/d/<id>`, `/s/<id>`, `/p/<id>` still render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved main content scrolling behavior and overflow handling in the application layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->