### PR TITLE
Import PPTX shape-level blipFill as ImageElement

### DIFF
--- a/docs/tasks/active/20260523-pptx-shape-blipfill-todo.md
+++ b/docs/tasks/active/20260523-pptx-shape-blipfill-todo.md
@@ -1,0 +1,77 @@
+# PPTX Shape `<a:blipFill>` Import
+
+## Problem
+
+Modern PPTX templates (e.g., the user-supplied "Multicolor Pastel Doodle
+Creative Project Proposal Presentation.pptx") build their visual background
+from full-bleed `<p:sp>` elements whose `<p:spPr>` carries `<a:custGeom>` +
+`<a:blipFill>` — i.e. an image-filled rectangle that *is* the slide
+background, not a `<p:bg>` element.
+
+The current importer parses shape fill via `parseShapeFill`
+(`packages/slides/src/import/pptx/shape.ts:564-573`):
+
+```ts
+function parseShapeFill(spPr, ctx) {
+  const solid = child(spPr, 'solidFill');
+  if (solid) return parseColorFromContainer(solid, ctx.clrMap);
+  // gradient, pattern, blip-fill on shape — out of v1 scope.
+  return undefined;
+}
+```
+
+Every `<a:blipFill>` on a shape is silently dropped, so the imported deck
+shows a blank white slide with floating text — none of the doodle artwork or
+background panels survive.
+
+This PR closes that gap by emitting an `ImageElement` whenever a `<p:sp>`
+carries `<a:blipFill>`, regardless of geometry. The existing `parsePic` flow
+already handles `<p:pic>` the same way; we extend it to `<p:sp>` so the
+two semantically-equivalent PPTX export patterns both round-trip.
+
+## Goal
+
+- A `<p:sp>` with `<a:blipFill>` in `<p:spPr>` becomes an `ImageElement`
+  whose `frame` comes from `<a:xfrm>` and whose `data` comes from
+  `parseBlipFill` (same uploader, crop, opacity handling as `<p:pic>`).
+- If the same shape also carries visible text (rare but legal), a coincident
+  `TextElement` is layered on top — the same dual-emission pattern already
+  used for `prstGeom + txBody`.
+- Existing `<p:pic>` behavior is unchanged.
+
+## Non-goals (tracked separately as PPTX import gaps)
+
+- `<a:gradFill>` / `<a:pattFill>` on shapes
+- Master / layout `<p:bgRef>` resolution against `<a:bgFillStyleLst>`
+- Master / layout decorative shape rendering (shapes-as-theme)
+- Full `<a:custGeom>` path → arbitrary shape conversion. With this PR a
+  custGeom shape *with* a blipFill renders as a rect-cropped image, which
+  is exact for the rectangle-shaped freeforms PPT exports use 99% of the
+  time but loses the clip path for legitimately non-rect freeforms. We
+  accept that v1 tradeoff.
+
+## Steps
+
+- [ ] Add a `parseBlipSp` helper in `shape.ts` that returns an
+      `ImageElement` for any `<p:sp>` whose `<p:spPr>` contains
+      `<a:blipFill>`. Reuse the existing `parseBlipFill` helper from
+      `image.ts`.
+- [ ] In `parseSp`, branch on blipFill *before* the `prstGeom` check.
+      Emit `[image]` or `[image, text]` and short-circuit.
+- [ ] Build the `ImageParseContext` lazily to avoid allocation on the
+      common no-blip path.
+- [ ] Add a focused unit test in
+      `packages/slides/test/import/pptx/shape-blipfill.test.ts`:
+  - `<p:sp>` + `prstGeom rect` + `blipFill` → `ImageElement`
+  - `<p:sp>` + `custGeom` + `blipFill` → `ImageElement`
+  - `<p:sp>` + `blipFill` + `txBox` text → `[Image, Text]`
+  - `<p:sp>` without `blipFill` → unchanged
+- [ ] `pnpm verify:fast` green.
+- [ ] Manual smoke: import the user's PPTX through `/slides/import` and
+      confirm slide 1 shows the cream background + doodles.
+- [ ] Capture lessons in `20260523-pptx-shape-blipfill-lessons.md`,
+      archive task files, open PR.
+
+## Review
+
+(filled after completion)

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -1,6 +1,7 @@
 import type {
   Element as SlideElement,
   GroupElement,
+  ImageElement,
   PlaceholderRef,
   PlaceholderType,
   ShapeElement,
@@ -26,7 +27,7 @@ import {
   IDENTITY_TRANSFORM,
   type GroupTransform,
 } from './group';
-import { parsePic, type ImageParseContext } from './image';
+import { parseBlipFill, parsePic, type ImageParseContext } from './image';
 import { ImportReport } from './report';
 import { parseTable } from './table';
 import { parseTextBody } from './text';
@@ -305,7 +306,7 @@ async function parseChild(
 ): Promise<SlideElement[] | undefined> {
   switch (el.localName) {
     case 'sp': {
-      const sps = parseSp(el, ctx);
+      const sps = await parseSp(el, ctx);
       return sps.length > 0 ? sps : undefined;
     }
     case 'pic': {
@@ -357,7 +358,7 @@ function withId(elem: SlideElement, ctx: SlideParseContext, sourceEl: Element): 
   return elem;
 }
 
-function parseSp(sp: Element, ctx: SlideParseContext): SlideElement[] {
+async function parseSp(sp: Element, ctx: SlideParseContext): Promise<SlideElement[]> {
   const nvSpPr = child(sp, 'nvSpPr');
   const cNvSpPr = nvSpPr ? child(nvSpPr, 'cNvSpPr') : undefined;
   const isTextBox = cNvSpPr ? attr(cNvSpPr, 'txBox') === '1' : false;
@@ -385,6 +386,32 @@ function parseSp(sp: Element, ctx: SlideParseContext): SlideElement[] {
     return [buildTextElement(elementId, frame, txBody, ctx, placeholderRef, layoutSizeKey)];
   }
 
+  // Shape with `<a:blipFill>` — treat as picture, regardless of geometry.
+  // PowerPoint exports routinely build full-bleed visuals (e.g. doodle
+  // template backgrounds) as `<p:sp>` wrapping `<a:custGeom>` (or
+  // `<a:prstGeom prst="rect">`) + `<a:blipFill>`, which is semantically
+  // equivalent to a `<p:pic>`. Treating it as an `ImageElement` preserves
+  // the visible result; the clip path of a genuinely non-rect freeform
+  // is lost, which we accept for v1 (covers >99% of real-world decks).
+  const blipFill = spPr ? child(spPr, 'blipFill') : undefined;
+  if (blipFill) {
+    const image = await buildImageFromBlip(elementId, frame, blipFill, ctx);
+    if (image) {
+      if (!hasText) return [image];
+      const text = buildTextElement(
+        generateId(),
+        frame,
+        txBody!,
+        ctx,
+        placeholderRef,
+        layoutSizeKey,
+      );
+      return [image, text];
+    }
+    // Blip upload failed / unresolved — fall through so the shape still
+    // contributes whatever geometry / text it has rather than vanishing.
+  }
+
   // Shape with `prstGeom` — emit the shape, then layer a coincident
   // TextElement on top when the shape also carries visible text (the
   // "labelled rect / callout" pattern, ubiquitous in PowerPoint).
@@ -409,6 +436,25 @@ function parseSp(sp: Element, ctx: SlideParseContext): SlideElement[] {
   }
 
   return [];
+}
+
+async function buildImageFromBlip(
+  id: string,
+  frame: SlideElement['frame'],
+  blipFill: Element,
+  ctx: SlideParseContext,
+): Promise<ImageElement | undefined> {
+  const imageCtx: ImageParseContext = {
+    archive: ctx.archive,
+    slidePartPath: ctx.slidePartPath,
+    rels: ctx.rels,
+    uploadImage: ctx.uploadImage,
+    scale: ctx.scale,
+    report: ctx.report,
+  };
+  const blip = await parseBlipFill(blipFill, imageCtx);
+  if (!blip) return undefined;
+  return { id, type: 'image', frame, data: blip };
 }
 
 /**

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -614,7 +614,9 @@ function parseShapeFill(
   if (!spPr) return undefined;
   const solid = child(spPr, 'solidFill');
   if (solid) return parseColorFromContainer(solid, ctx.clrMap);
-  // gradient, pattern, blip-fill on shape — out of v1 scope.
+  // gradient and pattern fills on shapes are out of v1 scope. Blip
+  // fills *are* handled — see the `<a:blipFill>` branch in `parseSp`,
+  // which short-circuits to an `ImageElement` before we get here.
   return undefined;
 }
 

--- a/packages/slides/test/import/pptx/shape-blipfill.test.ts
+++ b/packages/slides/test/import/pptx/shape-blipfill.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+  parseSpTree,
+  type SlideParseContext,
+} from '../../../src/import/pptx/shape';
+import { ImportReport } from '../../../src/import/pptx/report';
+import {
+  DEFAULT_WIDESCREEN_EMU,
+  emuScale,
+} from '../../../src/import/pptx/geometry';
+import { parseXml } from '../../../src/import/pptx/xml';
+import type { PptxRel } from '../../../src/import/pptx/rels';
+import type { PptxArchive } from '../../../src/import/pptx/unzip';
+import type {
+  ImageElement,
+  TextElement,
+} from '../../../src/model/element';
+
+const SCALE = emuScale(DEFAULT_WIDESCREEN_EMU);
+
+function archive(media: Record<string, Uint8Array> = {}): PptxArchive {
+  return {
+    readText: async () => undefined,
+    readBytes: async (path) => media[path],
+    list: () => [],
+  };
+}
+
+function rels(target: string): Map<string, PptxRel> {
+  const m = new Map<string, PptxRel>();
+  m.set('rId1', { type: 'image', target, external: false });
+  return m;
+}
+
+function ctx(opts: {
+  archive?: PptxArchive;
+  rels?: Map<string, PptxRel>;
+  uploadImage?: (b: Uint8Array, m: string) => Promise<string>;
+} = {}): SlideParseContext {
+  return {
+    archive: opts.archive ?? archive(),
+    slidePartPath: 'ppt/slides/slide1.xml',
+    rels: opts.rels ?? new Map(),
+    uploadImage: opts.uploadImage,
+    scale: SCALE,
+    report: new ImportReport(),
+    idMap: new Map(),
+    placeholderSizes: new Map(),
+    clrMap: new Map(),
+  };
+}
+
+function spTreeFrom(spXml: string): Element {
+  return parseXml(
+    `<root xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:spTree>${spXml}</p:spTree></root>`,
+  ).documentElement.firstElementChild!;
+}
+
+/**
+ * Mimics the user-supplied "doodle" template: a `<p:sp>` whose `<p:spPr>`
+ * carries `<a:custGeom>` and a `<a:blipFill>` covering the entire slide.
+ * Before the fix this was silently dropped (no fill, invisible rect);
+ * after the fix it becomes a coincident `ImageElement`.
+ */
+const SP_CUSTGEOM_BLIPFILL = `<p:sp>
+  <p:nvSpPr><p:cNvPr id="2" name="Freeform 2"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+  <p:spPr>
+    <a:xfrm><a:off x="0" y="0"/><a:ext cx="18288000" cy="10287000"/></a:xfrm>
+    <a:custGeom><a:avLst/><a:gdLst/><a:ahLst/><a:cxnLst/><a:rect r="r" b="b" t="t" l="l"/><a:pathLst/></a:custGeom>
+    <a:blipFill>
+      <a:blip r:embed="rId1"/>
+      <a:stretch><a:fillRect/></a:stretch>
+    </a:blipFill>
+  </p:spPr>
+</p:sp>`;
+
+const SP_RECT_BLIPFILL = `<p:sp>
+  <p:nvSpPr><p:cNvPr id="3" name="Pic-shaped Rect"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+  <p:spPr>
+    <a:xfrm><a:off x="100000" y="100000"/><a:ext cx="900000" cy="600000"/></a:xfrm>
+    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+    <a:blipFill>
+      <a:blip r:embed="rId1"/>
+      <a:stretch><a:fillRect/></a:stretch>
+    </a:blipFill>
+  </p:spPr>
+</p:sp>`;
+
+const SP_BLIPFILL_WITH_TEXT = `<p:sp>
+  <p:nvSpPr><p:cNvPr id="4" name="Image with caption"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+  <p:spPr>
+    <a:xfrm><a:off x="0" y="0"/><a:ext cx="9144000" cy="5143500"/></a:xfrm>
+    <a:custGeom><a:avLst/><a:gdLst/><a:ahLst/><a:cxnLst/><a:rect r="r" b="b" t="t" l="l"/><a:pathLst/></a:custGeom>
+    <a:blipFill>
+      <a:blip r:embed="rId1"/>
+      <a:stretch><a:fillRect/></a:stretch>
+    </a:blipFill>
+  </p:spPr>
+  <p:txBody>
+    <a:bodyPr/>
+    <a:lstStyle/>
+    <a:p><a:r><a:rPr lang="en-US" sz="2400"/><a:t>Caption</a:t></a:r></a:p>
+  </p:txBody>
+</p:sp>`;
+
+/**
+ * Solid-fill rect — control case proving the new branch is targeted at
+ * `<a:blipFill>` only and doesn't disturb the existing prstGeom + fill
+ * path.
+ */
+const SP_RECT_SOLID = `<p:sp>
+  <p:nvSpPr><p:cNvPr id="5" name="Solid rect"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+  <p:spPr>
+    <a:xfrm><a:off x="0" y="0"/><a:ext cx="500000" cy="500000"/></a:xfrm>
+    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+    <a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>
+  </p:spPr>
+</p:sp>`;
+
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+describe('parseSp — <p:sp> with <a:blipFill>', () => {
+  it('emits an ImageElement for custGeom + blipFill (the "doodle template" pattern)', async () => {
+    const uploads: Array<{ bytes: Uint8Array; mime: string }> = [];
+    const tree = spTreeFrom(SP_CUSTGEOM_BLIPFILL);
+    const c = ctx({
+      archive: archive({ 'ppt/media/image1.jpeg': PNG_BYTES }),
+      rels: rels('../media/image1.jpeg'),
+      uploadImage: async (bytes, mime) => {
+        uploads.push({ bytes, mime });
+        return 'cdn://uploaded.jpg';
+      },
+    });
+
+    const out = await parseSpTree(tree, c);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe('image');
+    const img = out[0] as ImageElement;
+    expect(img.data.src).toBe('cdn://uploaded.jpg');
+    expect(img.frame.w).toBeGreaterThan(0);
+    expect(img.frame.h).toBeGreaterThan(0);
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].mime).toBe('image/jpeg');
+  });
+
+  it('emits an ImageElement for prstGeom rect + blipFill', async () => {
+    const tree = spTreeFrom(SP_RECT_BLIPFILL);
+    const c = ctx({
+      archive: archive({ 'ppt/media/image1.png': PNG_BYTES }),
+      rels: rels('../media/image1.png'),
+      uploadImage: async () => 'cdn://rect.png',
+    });
+
+    const out = await parseSpTree(tree, c);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe('image');
+    expect((out[0] as ImageElement).data.src).toBe('cdn://rect.png');
+  });
+
+  it('layers a TextElement on top when the shape also carries visible text', async () => {
+    const tree = spTreeFrom(SP_BLIPFILL_WITH_TEXT);
+    const c = ctx({
+      archive: archive({ 'ppt/media/image1.png': PNG_BYTES }),
+      rels: rels('../media/image1.png'),
+      uploadImage: async () => 'cdn://captioned.png',
+    });
+
+    const out = await parseSpTree(tree, c);
+
+    expect(out).toHaveLength(2);
+    expect(out[0].type).toBe('image');
+    expect(out[1].type).toBe('text');
+    const text = out[1] as TextElement;
+    expect(text.data.blocks.length).toBeGreaterThan(0);
+    // Image and text share the same frame (coincident overlay).
+    expect(out[1].frame).toEqual(out[0].frame);
+  });
+
+  it('falls through to existing path when blip upload fails', async () => {
+    const tree = spTreeFrom(SP_CUSTGEOM_BLIPFILL);
+    // No uploadImage → parseBlipFill returns undefined.
+    const c = ctx({ rels: rels('../media/image1.jpeg') });
+
+    const out = await parseSpTree(tree, c);
+
+    // custGeom-only shape with no prstGeom and no text produces nothing,
+    // so the shape gracefully drops rather than emitting a phantom image.
+    expect(out).toHaveLength(0);
+    expect(c.report.skippedImages).toBe(1);
+  });
+
+  it('leaves solid-filled shapes unchanged (control)', async () => {
+    const tree = spTreeFrom(SP_RECT_SOLID);
+    const c = ctx();
+
+    const out = await parseSpTree(tree, c);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe('shape');
+  });
+});

--- a/packages/slides/test/import/pptx/shape-blipfill.test.ts
+++ b/packages/slides/test/import/pptx/shape-blipfill.test.ts
@@ -192,6 +192,23 @@ describe('parseSp — <p:sp> with <a:blipFill>', () => {
     expect(c.report.skippedImages).toBe(1);
   });
 
+  it('falls through to the underlying shape for prstGeom + blipFill when upload fails', async () => {
+    // Same prstGeom rect + blipFill XML as the success-path test, but with
+    // no `uploadImage` callback: `parseBlipFill` returns undefined, the new
+    // blip branch yields no image, and we fall through to the existing
+    // prstGeom branch which emits the rectangle. Locks in the graceful
+    // degradation contract so an image upload outage can't make rect
+    // shapes vanish from the slide.
+    const tree = spTreeFrom(SP_RECT_BLIPFILL);
+    const c = ctx({ rels: rels('../media/image1.png') });
+
+    const out = await parseSpTree(tree, c);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe('shape');
+    expect(c.report.skippedImages).toBe(1);
+  });
+
   it('leaves solid-filled shapes unchanged (control)', async () => {
     const tree = spTreeFrom(SP_RECT_SOLID);
     const c = ctx();


### PR DESCRIPTION
## Summary

- Modern PPTX templates (e.g. the Multicolor Pastel Doodle deck) build full-bleed slide backgrounds as `<p:sp>` wrapping `<a:custGeom>` (or `<a:prstGeom rect>`) + `<a:blipFill>`, which is semantically equivalent to `<p:pic>`. The shape parser previously dropped every shape-level blip fill (`parseShapeFill` only handled `<a:solidFill>`), so imported decks landed as blank rectangles wherever the artwork should have been.
- `parseSp` now detects `<a:blipFill>` in `<p:spPr>` before the `prstGeom` branch and emits an `ImageElement` via the existing `parseBlipFill` helper (same uploader / crop / opacity path as `<p:pic>`). If the same shape also carries visible text, a coincident `TextElement` is layered on top, matching the existing `prstGeom + txBody` dual-emission pattern.
- Genuinely non-rect freeforms lose their clip path under this approach — accepted as a v1 tradeoff because rectangular freeforms dominate real-world exports and the alternative is the prior empty-rectangle behavior. Gradient / pattern fills and master / layout `<p:bgRef>` resolution remain unhandled and are tracked separately.

## Test plan

- [x] `pnpm verify:fast` — all 349 test files pass (sheets + docs + slides + frontend + backend)
- [x] New unit tests cover: `custGeom` + blipFill, `prstGeom rect` + blipFill, blipFill + text overlay, upload-failure fallback, solid-fill control
- [x] Manual smoke: import the Multicolor Pastel Doodle PPTX through `/slides/import`, confirm slide-1 cream background + doodles render
- [ ] CI green

## Task doc

`docs/tasks/active/20260523-pptx-shape-blipfill-todo.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image-filled backgrounds on PPTX shapes are now properly imported instead of being dropped during the import process.
  * Shapes that contain both image fills and text content now correctly preserve both elements with proper layering.

* **Tests**
  * Added comprehensive test coverage for various image-filled shape import scenarios to ensure reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->