### PR TITLE
Add slides ruler + presentation-wide draggable guides

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -73,6 +73,7 @@ Presentation engine — slides, free-position elements, presentation mode, colla
 | [slides-mobile-edit.md](slides/slides-mobile-edit.md)                                 | Mobile light edit (Phase B) — mount full SlidesEditor on touch, hit-test tolerance, bottom-sheet text formatting, slide-ops FAB, undo/redo header, perm-gated read-only fallback                            |
 | [slides-group.md](slides/slides-group.md)                                             | Group / ungroup — nested element tree with group-local child coords, Google Slides drill-in selection, PPTX `<p:grpSp>` preservation, recursive renderer / hit-test / PDF export                              |
 | [slides-shape-move.md](slides/slides-shape-move.md)                                   | Shape drag-move — `move` hover cursor on selected shapes, ghost preview at `GHOST_ALPHA` follows pointer, commit only on release                                                                            |
+| [slides-ruler.md](slides/slides-ruler.md)                                             | Slides ruler — H/V rulers (corner origin, inch/cm), presentation-wide draggable guides, snap integration, read-only mount handling                                                                          |
 
 ## Common
 

--- a/docs/design/slides/slides-ruler.md
+++ b/docs/design/slides/slides-ruler.md
@@ -1,0 +1,383 @@
+---
+title: slides-ruler
+target-version: 0.4.2
+---
+
+# Slides Ruler
+
+## Summary
+
+Add horizontal and vertical rulers to the slides editor, plus
+presentation-wide alignment guides that users can drag out of the
+rulers. The ruler is primarily a placement aid: it shows slide
+coordinates (corner origin, inch / cm based on locale) and exposes
+draggable guides that participate in the existing snap engine. Text
+indent / tab handles inside text boxes are explicitly deferred to a
+later release.
+
+The design reuses the tick rendering and unit helpers from the docs
+ruler (`packages/docs/src/view/ruler.ts`) by extracting them into a
+shared low-level module so both packages stay visually consistent.
+
+### Goals
+
+- Horizontal ruler above the slide canvas and vertical ruler to the
+  left, always visible in the editor.
+- Corner origin (top-left = 0,0), inch / cm display driven by
+  `navigator.language`. Same convention as the docs ruler.
+- Tick density automatically adjusts to the editor zoom factor so the
+  ruler stays legible across zoom 0.25× – 3×.
+- Drag from a ruler onto the canvas to create a persistent alignment
+  guide; drag an existing guide to reposition; drag a guide back onto
+  a ruler to delete.
+- Guides live at the presentation level (one shared set across all
+  slides), synchronized through Yorkie so collaborators see the same
+  alignment scaffolding.
+- Guides participate in the existing element drag / resize snap
+  engine with a higher priority than other-element edges but lower
+  than slide-center.
+- Read-only share-link mounts display rulers and guides but suppress
+  every mutating interaction.
+
+### Non-Goals
+
+- Text-box-local ruler mode with first-line indent (▽) and left indent
+  (△) handles or tab stops. Google Slides / PowerPoint switch the
+  horizontal ruler into text-box coordinates while editing text; this
+  is deferred. The current scope is slide-coordinate placement only.
+- `View > Show ruler` toggle. The ruler is always on in v1, matching
+  the docs convention. A toggle can land later once Slides gains a
+  full View menu and persisted user preferences.
+- `View > Show guides` toggle. Guides are always visible in v1.
+- Per-slide guides. Guides are presentation-wide; if a user wants a
+  guide on only one slide they can place an unmoving line shape, but
+  the ruler-drag affordance produces presentation-level guides.
+- Center-origin coordinates (PowerPoint's `-6.67 … 0 … +6.67`). Corner
+  origin keeps a single coordinate convention across docs and slides.
+- Numeric position input (e.g. "place a guide at exactly 4.0\""). v1
+  is drag-only; numeric input can land alongside the broader Format
+  options panel in v2.
+- Guides rendered into PDF export or shown in presentation mode.
+  Guides are editor scaffolding, not slide content.
+
+## Proposal Details
+
+### Architecture
+
+The docs and slides rulers share a low-level rendering core; each
+package owns its own controller and interactions.
+
+```
+packages/docs/src/view/ruler/
+├── index.ts            # MOVED — existing docs Ruler class (was view/ruler.ts)
+├── tick-renderer.ts    # NEW (extracted) — tick + label drawing
+└── unit.ts             # NEW (extracted) — RulerUnit, locale detect
+
+packages/slides/src/view/editor/ruler/
+├── ruler.ts            # SlidesRuler controller (H/V canvases + corner)
+├── guides-layer.ts     # paints permanent guides on the overlay layer
+└── interactions.ts     # ruler drag-out, guide drag, hit-test
+```
+
+The docs file move is import-path-preserving: existing `from
+'../view/ruler'` resolves to the new `ruler/index.ts`. No call sites
+need to change.
+
+The shared modules take `pxPerUnit` as an argument so docs (96 dpi)
+and slides (144 dpi — see "Coordinate system") can both use them
+without coupling to either coordinate space.
+
+slides already depends on `@wafflebase/docs`, so the imports flow
+cleanly from slides → docs without a new package boundary.
+
+### DOM and render structure
+
+The ruler attaches to the slide stage as absolutely positioned
+canvases. Permanent guides paint into the existing overlay layer
+rather than into the ruler, because they belong to the slide
+coordinate system (they zoom and pan with the slide content).
+
+```
+editor-shell.tsx
+└── <slide-stage> (position: relative)
+    ├── <ruler-corner>    absolute; top:0; left:0; 20×20
+    ├── <h-ruler-canvas>  absolute; top:0; left:20px; right:0; height:20px
+    ├── <v-ruler-canvas>  absolute; top:20px; left:0; bottom:0; width:20px
+    └── <canvas-pane>     absolute; top:20px; left:20px; right:0; bottom:0
+        ├── <slide-canvas>      # existing
+        └── <overlay>           # existing
+            └── <guides-layer>  # NEW — permanent magenta solid lines
+```
+
+The slide canvas area is offset by 20 px on top and left to make room
+for the rulers. Ruler canvases use DPR-aware backing stores
+(`devicePixelRatio` ×) and `ctx.scale(dpr, dpr)`.
+
+`SlidesRuler` is the controller:
+
+```ts
+class SlidesRuler {
+  constructor(opts: {
+    container: HTMLElement;
+    hCanvas: HTMLCanvasElement;
+    vCanvas: HTMLCanvasElement;
+    corner: HTMLElement;
+  });
+
+  render(viewport: {
+    scrollX: number; scrollY: number;
+    zoom: number;
+    slideW: number; slideH: number;
+  }): void;
+
+  setUnit(unit: 'inch' | 'cm'): void;
+
+  onGuideDragStart(cb: (axis: 'x' | 'y') => void): void;
+
+  dispose(): void;
+}
+```
+
+### Coordinate system
+
+Slides logical canvas is 1920 × 1080 px and maps to a 13.333" × 7.5"
+PDF page (slides.md). The implied physical scale is therefore:
+
+| Constant | Slides | Docs (for comparison) |
+| --- | --- | --- |
+| `PX_PER_INCH` | 144 | 96 |
+| `PX_PER_CM` | ≈ 56.7 | ≈ 37.8 |
+
+Slides logical px are *not* CSS px; they sit one zoom step above. The
+ruler renders one inch / cm of slide content as `PX_PER_UNIT × zoom`
+screen pixels. The shared tick renderer takes `pxPerUnit` as a
+parameter to stay neutral.
+
+The corner origin (0, 0) is the top-left of the slide. Both rulers
+count outward in positive values only. Coordinates outside `[0,
+slideW]` / `[0, slideH]` are clipped (no negative ticks).
+
+### Tick density by zoom
+
+`one unit on screen = pxPerUnit × zoom`. Tick density adapts so the
+ruler does not become unreadable when the user zooms out:
+
+| One unit on screen | Display |
+| --- | --- |
+| ≥ 60 px | major + half + minor |
+| 30 – 60 px | major + half |
+| 15 – 30 px | major only, labels every 1 unit |
+| < 15 px | major only, labels thinned to every 2nd or 4th unit |
+
+The transition points are wired to `view.zoom`; the renderer recomputes
+its display level on every `render()` call.
+
+### Unit selection
+
+Locale-driven defaults, same as docs: if `navigator.language` matches
+a metric locale (everything except `en-US`, `en-GB`, `my`), use `cm`,
+else `inch`. A user-facing unit toggle is not surfaced in v1 — when a
+Slides settings surface lands, both docs and slides will share it.
+
+### Guides — data model and Yorkie schema
+
+Guides live on the presentation root, not per-slide. A guide is an
+infinite line at a fixed slide-x (vertical guide) or slide-y
+(horizontal guide) value.
+
+```ts
+type Guide = {
+  id: string;          // stable
+  axis: 'x' | 'y';
+  position: number;    // slide logical px, clamped to [0, slideW] or [0, slideH]
+};
+
+type SlidesDocument = {
+  meta: { title: string };
+  slides: Slide[];
+  layouts: Layout[];
+  guides: Guide[];     // NEW
+};
+```
+
+Yorkie root gains `guides: Yorkie.Array<Guide>`. `Yorkie.Array` (rather
+than a plain object) gives deterministic convergence under concurrent
+add/remove without per-guide id collisions.
+
+Store API additions:
+
+```ts
+interface SlidesStore {
+  // ...existing
+  addGuide(axis: 'x' | 'y', position: number): string;
+  moveGuide(id: string, position: number): void;
+  removeGuide(id: string): void;
+}
+```
+
+All three are wrapped in `store.batch()` to produce one undo step per
+user action.
+
+#### Migration
+
+Existing Yorkie documents do not have `root.guides`. `YorkieSlidesStore`
+initializes it lazily on attach:
+
+```ts
+if (!root.guides) {
+  root.guides = [];
+}
+```
+
+No schema migration script is required; the first attach by any
+client writes the empty array.
+
+### Presence
+
+```ts
+type SlidesPresence = {
+  // ...existing
+  draggingGuide?: {
+    id?: string;            // undefined while creating from ruler
+    axis: 'x' | 'y';
+    position: number;
+  };
+};
+```
+
+Drag previews flow through presence at ~60 fps; `addGuide` /
+`moveGuide` commit once on `mouseup`. This mirrors the
+drag/resize/rotate pattern in slides.md.
+
+### Interactions
+
+| Action | Input | Behavior |
+| --- | --- | --- |
+| Create guide | mousedown on a ruler, drag onto canvas | shows magenta solid preview via presence; on mouseup inside slide → `addGuide`; on mouseup outside → cancel |
+| Move guide | mousedown within 4 px of an existing guide, drag | presence preview; commit `moveGuide` on mouseup |
+| Delete by drag | drag guide back onto a ruler | cursor switches to a delete affordance; mouseup over ruler → `removeGuide` |
+| Delete by menu | right-click guide | context menu: Delete guide / Delete all on this axis / Delete all guides |
+| Hover cursor | hover within 4 px of guide | `col-resize` (vertical guide) / `row-resize` (horizontal guide) |
+| Ruler ticks | hover ruler | tick + label only; no interaction beyond drag-out |
+
+There is no explicit "guide selected" state in v1 — hover is the only
+trigger. Keeping a separate selection model out keeps the interaction
+surface small.
+
+#### Visual treatment
+
+- Permanent guides: 1 px magenta **solid** line, full slide extent.
+- Existing snap guides (slide-center, element edges) stay 1 px magenta
+  **dashed** lines.
+- The ruler shows a small magenta marker (▼ for vertical guides, ▶ for
+  horizontal guides) at the guide's position, so guide positions are
+  scannable along the ruler edge.
+- Drag preview shows a position label near the cursor ("4.25\"" or
+  "10.7 cm") in the current unit.
+- Dragging outside the slide bounds turns the label red and a
+  mouseup at that position cancels the operation.
+
+#### Snap integration
+
+`packages/slides/src/view/editor/snap.ts` gains a new candidate kind:
+
+```ts
+type SnapGuide = {
+  kind: 'slide-center' | 'edge' | 'guide';  // NEW: 'guide'
+  axis: 'x' | 'y';
+  position: number;
+  guideId?: string;
+};
+```
+
+When multiple candidates fall within the existing 4-slide-px snap
+threshold, ties resolve in this priority:
+
+1. `slide-center`
+2. `guide`
+3. `edge`
+
+User-placed guides outrank other-element edges because they encode
+explicit intent. When an element drag snaps to a guide, the
+implementation thickens that guide to 1.5 px and deepens its color
+rather than overlaying a dashed snap indicator on top — keeps the
+visual uncluttered.
+
+Resize and guide-drag participate in the same snap logic. Keyboard
+nudge (Arrow / Shift+Arrow) does not trigger snap; nudge stays a
+precision tool.
+
+`align()` and `distribute()` do not reference guides. Guides are a
+drag-time aid, not an alignment command target.
+
+### Read-only mounts
+
+Viewer-role share links mount the same editor scaffolding (see
+slides.md → "Read-only mounts"). The ruler and guides follow the same
+opt-in pattern:
+
+- Rulers and guides are **rendered** so viewers can see slide
+  measurements and the deck's alignment scaffolding.
+- `initializeEditor({ readOnly: true })` skips:
+  - the ruler `mousedown` listener (no drag-out → no guide creation),
+  - the guide hover hit-test (no move / no delete),
+  - the guide right-click context menu,
+  - the cursor change on hover (so read-only is visually consistent).
+- Peer presence stays receive-only: viewers see other collaborators'
+  drag previews but do not broadcast their own.
+
+### Presentation mode and PDF export
+
+`view/present/presenter.ts` does not mount the ruler or guides layer.
+`export/pdf.ts` ignores `guides` entirely. Both are editor-only
+affordances.
+
+### Phasing
+
+Six PRs, each independently demoable.
+
+| Phase | Scope | Verification |
+| --- | --- | --- |
+| P1. Extract shared core | Move tick / unit code from `packages/docs/src/view/ruler.ts` into `view/ruler/tick-renderer.ts` and `view/ruler/unit.ts`. `pxPerUnit` becomes a parameter. Docs behavior unchanged. | `pnpm verify:fast`, docs ruler visual smoke |
+| P2. Slides ruler display | `SlidesRuler` controller, H/V canvases, corner DOM, zoom + scroll + unit rendering. No guide code yet. | `pnpm verify:fast`, browser smoke at zoom 0.5 / 1 / 2 |
+| P3. Guides data + render | `Guide` type, store API, `MemSlidesStore` + Yorkie schema + lazy init. Guides paint into the overlay layer. No interactions. | Unit tests for store CRUD, integration test for Mem vs Yorkie equivalence and concurrent add/remove convergence |
+| P4. Guide interactions | Ruler drag-out, guide drag/move/delete, presence preview, ruler markers, context menu. | Interaction tests (drag sequences), two-user presence test |
+| P5. Snap integration | Add `'guide'` kind, priority resolution, hit-snap visual emphasis. | Snap-priority unit tests, nudge-no-snap test |
+| P6. Read-only mounts + polish | `readOnly` branch suppresses listeners, presentation-mode and PDF skip guides. Design doc finalized. | Read-only mount tests, `pnpm verify:browser:docker` |
+
+Verification gates:
+
+- Every PR: `pnpm verify:fast`.
+- P3 / P4: `pnpm verify:integration` (Yorkie + Postgres).
+- P6: `pnpm verify:browser:docker`.
+
+### Testing strategy
+
+- **Unit (`packages/slides/src/**/*.test.ts`)**
+  - `view/editor/ruler/ruler.test.ts` — tick density transitions
+    across zoom thresholds, label values at sample positions for
+    inch and cm.
+  - `store/memory.test.ts` — `addGuide` / `moveGuide` / `removeGuide`
+    including batch behavior.
+  - `view/editor/snap.test.ts` — priority resolution between
+    slide-center / guide / edge candidates.
+- **Integration (`packages/frontend/tests/app/slides/`)**
+  - `yorkie-slides-store.test.ts` — guide CRUD equivalence between
+    `MemSlidesStore` and `YorkieSlidesStore`.
+  - `two-user-slides-yorkie.ts` extension — concurrent add / move /
+    remove of guides converge.
+- **Visual / browser** — extend `verify:browser:docker` with a
+  scenario that creates a guide, drags an element onto it, and
+  reloads to verify persistence.
+
+## Risks and Mitigation
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Extracting the shared core breaks docs rendering. | Docs ruler regression. | P1 lands as a no-op refactor with the existing docs ruler tests gating. Visual smoke before merging. |
+| Slides 144-dpi vs docs 96-dpi confuses readers and reviewers. | Subtle tick / label bugs. | The shared tick renderer accepts `pxPerUnit` as input — there is no implicit dpi constant. Tests assert tick positions at known zoom × pxPerUnit values. |
+| Guides on the Yorkie root migrate poorly for old documents. | Existing decks fail to load. | `if (!root.guides) root.guides = []` on attach. The lazy init is idempotent, runs on the first session, and adds no schema migration step. |
+| Snap priority among slide-center, guide, and edge feels surprising. | Users fight the tool. | Document the rule in user-facing help. Priority is overridable in code; tune based on early feedback before broad rollout. |
+| Always-on rulers eat 20 px on the top and left, hurting smaller laptop screens. | Cramped canvas. | The 20 px footprint matches docs. A `View > Show ruler` toggle is the planned escape hatch in a later release once a Slides View menu lands. |
+| Permanent guides accidentally end up in PDFs. | Wrong export output. | `export/pdf.ts` explicitly ignores `guides`; covered by a unit test that renders a deck with one guide and asserts the PDF page contains no extra paint operations. |
+| Concurrent ruler drag-out conflicts with concurrent element drag. | Confusing presence. | The two paths use distinct presence fields (`draggingFrame` vs `draggingGuide`) and distinct interaction states in the editor, so they never collide. |

--- a/docs/design/slides/slides-ruler.md
+++ b/docs/design/slides/slides-ruler.md
@@ -100,18 +100,20 @@ coordinate system (they zoom and pan with the slide content).
 ```text
 editor-shell.tsx
 └── <slide-stage> (position: relative)
-    ├── <ruler-corner>    absolute; top:0; left:0; 20×20
-    ├── <h-ruler-canvas>  absolute; top:0; left:20px; right:0; height:20px
-    ├── <v-ruler-canvas>  absolute; top:20px; left:0; bottom:0; width:20px
-    └── <canvas-pane>     absolute; top:20px; left:20px; right:0; bottom:0
+    ├── <ruler-corner>    absolute; top:0; left:0; 14×14
+    ├── <h-ruler-canvas>  absolute; top:0; left:14px; right:0; height:14px
+    ├── <v-ruler-canvas>  absolute; top:14px; left:0; bottom:0; width:14px
+    └── <canvas-pane>     absolute; top:14px; left:14px; right:0; bottom:0
         ├── <slide-canvas>      # existing
         └── <overlay>           # existing
             └── <guides-layer>  # NEW — permanent magenta solid lines
 ```
 
-The slide canvas area is offset by 20 px on top and left to make room
-for the rulers. Ruler canvases use DPR-aware backing stores
-(`devicePixelRatio` ×) and `ctx.scale(dpr, dpr)`.
+The slide canvas area is offset by 14 px on top and left to make room
+for the rulers. The slim 14-px footprint (vs. the docs ruler's 20 px)
+keeps the chrome quiet — a slide is more of a stage than a measured
+page. Ruler canvases use DPR-aware backing stores (`devicePixelRatio`
+×) and `ctx.scale(dpr, dpr)`.
 
 `SlidesRuler` is the controller:
 
@@ -392,6 +394,6 @@ Verification gates:
 | Slides 144-dpi vs docs 96-dpi confuses readers and reviewers. | Subtle tick / label bugs. | The shared tick renderer accepts `pxPerUnit` as input — there is no implicit dpi constant. Tests assert tick positions at known zoom × pxPerUnit values. |
 | Guides on the Yorkie root migrate poorly for old documents. | Existing decks fail to load. | `if (!root.guides) root.guides = []` on attach. The lazy init is idempotent, runs on the first session, and adds no schema migration step. |
 | Snap priority among slide-center, guide, and edge feels surprising. | Users fight the tool. | Document the rule in user-facing help. Priority is overridable in code; tune based on early feedback before broad rollout. |
-| Always-on rulers eat 20 px on the top and left, hurting smaller laptop screens. | Cramped canvas. | The 20 px footprint matches docs. A `View > Show ruler` toggle is the planned escape hatch in a later release once a Slides View menu lands. |
+| Always-on rulers eat 14 px on the top and left, hurting smaller laptop screens. | Cramped canvas. | The slides ruler is intentionally slimmer than the docs ruler (14 vs 20 px) and uses a transparent background so the chrome stays light. A `View > Show ruler` toggle is the planned escape hatch in a later release once a Slides View menu lands. |
 | Permanent guides accidentally end up in PDFs. | Wrong export output. | `export/pdf.ts` explicitly ignores `guides`; covered by a unit test that renders a deck with one guide and asserts the PDF page contains no extra paint operations. |
 | Concurrent ruler drag-out conflicts with concurrent element drag. | Confusing presence. | The two paths use distinct presence fields (`draggingFrame` vs `draggingGuide`) and distinct interaction states in the editor, so they never collide. |

--- a/docs/design/slides/slides-ruler.md
+++ b/docs/design/slides/slides-ruler.md
@@ -67,7 +67,7 @@ shared low-level module so both packages stay visually consistent.
 The docs and slides rulers share a low-level rendering core; each
 package owns its own controller and interactions.
 
-```
+```text
 packages/docs/src/view/ruler/
 ├── index.ts            # MOVED — existing docs Ruler class (was view/ruler.ts)
 ├── tick-renderer.ts    # NEW (extracted) — tick + label drawing
@@ -97,7 +97,7 @@ canvases. Permanent guides paint into the existing overlay layer
 rather than into the ruler, because they belong to the slide
 coordinate system (they zoom and pan with the slide content).
 
-```
+```text
 editor-shell.tsx
 └── <slide-stage> (position: relative)
     ├── <ruler-corner>    absolute; top:0; left:0; 20×20

--- a/docs/design/slides/slides-ruler.md
+++ b/docs/design/slides/slides-ruler.md
@@ -245,9 +245,13 @@ type SlidesPresence = {
 };
 ```
 
-Drag previews flow through presence at ~60 fps; `addGuide` /
-`moveGuide` commit once on `mouseup`. This mirrors the
-drag/resize/rotate pattern in slides.md.
+In v1 the `draggingGuide` field is reserved on `SlidesPresence` but
+the editor does not broadcast it: the live preview is local-only.
+`addGuide` / `moveGuide` commit once on `mouseup`, and the resulting
+store change propagates through the standard CRDT path so peers see
+the committed guide on their next render. Broadcasting the in-flight
+preview to peers is a tracked v1.1 follow-up — the schema is already
+in place to keep it a non-breaking change.
 
 ### Interactions
 
@@ -266,16 +270,25 @@ surface small.
 
 #### Visual treatment
 
-- Permanent guides: 1 px magenta **solid** line, full slide extent.
-- Existing snap guides (slide-center, element edges) stay 1 px magenta
-  **dashed** lines.
-- The ruler shows a small magenta marker (▼ for vertical guides, ▶ for
-  horizontal guides) at the guide's position, so guide positions are
-  scannable along the ruler edge.
-- Drag preview shows a position label near the cursor ("4.25\"" or
-  "10.7 cm") in the current unit.
-- Dragging outside the slide bounds turns the label red and a
-  mouseup at that position cancels the operation.
+- Permanent guides: 1 px magenta solid line spanning the slide.
+- Snap guides (slide-center, element edges) inherit the existing
+  1-px solid magenta style — kept consistent with the pre-ruler snap
+  rendering so the differentiation lives in how the snap target is
+  marked rather than in line style.
+- When an element drag snaps to a permanent guide, the matching guide
+  is thickened to 2 px and shifted to a deeper magenta (`#be123c`)
+  instead of overlaying a separate snap indicator on top.
+- In-flight drag preview (creating or moving a guide) paints at
+  ~55 % opacity so the user can distinguish the drag from a committed
+  guide; the committed copy is suppressed while its preview is in
+  flight to avoid a double line.
+- Drag interactions clamp into the slide extent
+  (`[0, SLIDE_WIDTH]` for vertical, `[0, SLIDE_HEIGHT]` for
+  horizontal); a mouseup outside the slide cancels guide creation.
+- Ruler markers (small triangles on the ruler at each guide's
+  position) and per-drag position labels (`4.25"` / `10.7 cm`) are
+  tracked as v1.1 polish; the line + cursor swap are already
+  sufficient to position guides confidently.
 
 #### Snap integration
 
@@ -290,18 +303,19 @@ type SnapGuide = {
 };
 ```
 
-When multiple candidates fall within the existing 4-slide-px snap
-threshold, ties resolve in this priority:
+When multiple candidates fall within the 8-slide-px snap threshold
+(the engine's existing constant), ties resolve in this priority:
 
 1. `slide-center`
 2. `guide`
 3. `edge`
 
 User-placed guides outrank other-element edges because they encode
-explicit intent. When an element drag snaps to a guide, the
-implementation thickens that guide to 1.5 px and deepens its color
-rather than overlaying a dashed snap indicator on top — keeps the
-visual uncluttered.
+explicit intent — a higher-priority candidate wins even when an
+edge happens to be closer numerically. When an element drag snaps
+to a guide, the implementation thickens that guide to 2 px and
+deepens its color rather than overlaying a separate indicator on
+top — keeps the visual uncluttered.
 
 Resize and guide-drag participate in the same snap logic. Keyboard
 nudge (Arrow / Shift+Arrow) does not trigger snap; nudge stays a

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides ruler (2026-05-23) | [20260523-slides-ruler-todo.md](./active/20260523-slides-ruler-todo.md) | - |
 | slides homepage docs (2026-05-21) | [20260521-slides-homepage-docs-todo.md](./active/20260521-slides-homepage-docs-todo.md) | - |
 | slides thumbnail async bg (2026-05-21) | [20260521-slides-thumbnail-async-bg-todo.md](./active/20260521-slides-thumbnail-async-bg-todo.md) | - |
 | slides shape move ghost (2026-05-19) | [20260519-slides-shape-move-ghost-todo.md](./active/20260519-slides-shape-move-ghost-todo.md) | - |
@@ -33,4 +34,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 202
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides homepage docs (2026-05-21)
+Latest active task: slides ruler (2026-05-23)

--- a/docs/tasks/active/20260523-slides-ruler-todo.md
+++ b/docs/tasks/active/20260523-slides-ruler-todo.md
@@ -1,0 +1,1288 @@
+# Slides Ruler — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Design doc:** [`docs/design/slides/slides-ruler.md`](../../design/slides/slides-ruler.md)
+
+**Goal:** Bring horizontal and vertical rulers to the slides editor
+with corner origin + inch/cm display, and add presentation-wide
+draggable guides that participate in the existing snap engine.
+
+**Architecture:** Extract a low-level `tick-renderer` + `unit` module
+from `packages/docs/src/view/ruler.ts` so docs and slides share the
+same tick/label math. Add a new `SlidesRuler` controller in
+`packages/slides/src/view/editor/ruler/` that draws H/V canvases on
+top of the slide stage and emits drag-out events for guides. Store
+guides on `SlidesDocument.guides` (presentation-wide); the Yorkie
+adapter lazy-initializes the new field. Guides become a third snap
+candidate kind (`'guide'`) ranking between `slide-center` and `edge`.
+
+**Tech Stack:** TypeScript, Vitest + jsdom, Canvas 2D, Yorkie 0.6,
+existing `MemSlidesStore` / `YorkieSlidesStore`.
+
+**Phasing:** Six commits / PRs, each independently demoable. Earlier
+phases land mechanical refactors and structural scaffolding; later
+phases add interactions and polish.
+
+| Phase | Scope | PR |
+| --- | --- | --- |
+| P1 | Extract shared tick/unit core (docs only; no behavior change) | 1 |
+| P2 | Slides ruler display (no guide code) | 2 |
+| P3 | Guide data model + Yorkie schema + passive render | 3 |
+| P4 | Guide interactions (drag-out, move, delete) | 4 |
+| P5 | Snap integration | 5 |
+| P6 | Read-only mounts + presentation/PDF exclusion | 6 |
+
+---
+
+## Chunk 1: Phase 1 — extract shared tick / unit core
+
+Move the tick rendering and locale-aware unit helpers into a
+sub-directory so they can be imported from `@wafflebase/slides`
+without leaking docs-specific concepts (pages, margins, indent).
+**No docs behavior change.** Existing imports `from '../view/ruler'`
+keep working because the new `ruler/index.ts` re-exports the public
+surface.
+
+### Task 1.1: Restructure docs ruler files
+
+**Files:**
+- Create: `packages/docs/src/view/ruler/index.ts` (formerly `ruler.ts`)
+- Create: `packages/docs/src/view/ruler/unit.ts`
+- Create: `packages/docs/src/view/ruler/tick-renderer.ts`
+- Delete: `packages/docs/src/view/ruler.ts` (after Git history-preserving move)
+
+- [ ] **Step 1: Move `ruler.ts` to `ruler/index.ts`**
+
+```bash
+git mv packages/docs/src/view/ruler.ts packages/docs/src/view/ruler/index.ts
+```
+
+Run `pnpm verify:fast` to confirm imports still resolve.
+
+- [ ] **Step 2: Extract `unit.ts`**
+
+Cut the unit type, locale detection, and grid config from `index.ts`
+into a sibling module. Keep `getGridConfig` exporting the same shape
+but accept an optional `pxPerInch` override (default 96) so slides
+can pass 144:
+
+```ts
+// packages/docs/src/view/ruler/unit.ts
+export type RulerUnit = 'inch' | 'cm';
+
+export interface GridConfig {
+  majorStepPx: number;
+  subdivisions: number;
+  minorStepPx: number;
+}
+
+const INCH_LOCALES = ['en-US', 'en-GB', 'my'];
+
+export function detectUnit(locale: string | undefined): RulerUnit {
+  if (!locale) return 'inch';
+  if (INCH_LOCALES.includes(locale)) return 'inch';
+  if (locale.startsWith('en')) return 'inch';
+  return 'cm';
+}
+
+export function getGridConfig(unit: RulerUnit, pxPerInch = 96): GridConfig {
+  if (unit === 'inch') {
+    return { majorStepPx: pxPerInch, subdivisions: 8, minorStepPx: pxPerInch / 8 };
+  }
+  const cmPx = pxPerInch / 2.54;
+  return { majorStepPx: cmPx, subdivisions: 10, minorStepPx: cmPx / 10 };
+}
+
+export function snapToGrid(px: number, step: number): number {
+  return Math.round(px / step) * step;
+}
+```
+
+In `index.ts`, replace inline definitions with:
+
+```ts
+import { detectUnit, getGridConfig, snapToGrid, type RulerUnit, type GridConfig } from './unit';
+export { detectUnit, getGridConfig, snapToGrid };
+export type { RulerUnit, GridConfig };
+```
+
+- [ ] **Step 3: Extract `tick-renderer.ts`**
+
+Move the tick-drawing helper(s) used by `renderHorizontal` /
+`renderVertical` in the Ruler class into a standalone function that
+takes the canvas context, current viewport, and `GridConfig`. The
+function should not reference pages or margins — those stay in
+`index.ts`. Public API:
+
+```ts
+// packages/docs/src/view/ruler/tick-renderer.ts
+import type { GridConfig, RulerUnit } from './unit';
+
+export interface TickRenderOpts {
+  ctx: CanvasRenderingContext2D;
+  axis: 'h' | 'v';
+  /** Visible length in CSS pixels (canvas client size on the active axis). */
+  length: number;
+  /** Pixel offset of slide/page origin within the canvas. */
+  origin: number;
+  /** Multiplier from "one unit" to CSS pixels (= pxPerUnit × zoom). */
+  scale: number;
+  grid: GridConfig;
+  unit: RulerUnit;
+  /** Optional density override; defaults to full density. */
+  density?: 'full' | 'half-only' | 'major' | 'major-thinned';
+  /** Optional color overrides; default to theme. */
+  marginBg?: string;
+  contentBg?: string;
+  tickColor?: string;
+  labelFont?: string;
+}
+
+export function drawTicks(opts: TickRenderOpts): void { /* ... */ }
+```
+
+The `density` parameter is set by slides (Phase 2) based on zoom; docs
+calls without it (defaults to `'full'`).
+
+- [ ] **Step 4: Update docs `Ruler` class to use `drawTicks`**
+
+In `packages/docs/src/view/ruler/index.ts`, replace the inline tick
+drawing in `renderHorizontal` / `renderVertical` with a `drawTicks`
+call. Pass the existing 96-dpi grid (no behavior change for docs).
+
+- [ ] **Step 5: Run docs ruler unit tests**
+
+```bash
+pnpm --filter @wafflebase/docs test ruler
+```
+
+Expected: all existing tests pass. If any fail, the extraction broke
+something — fix before continuing.
+
+- [ ] **Step 6: Visual smoke (manual)**
+
+```bash
+pnpm dev
+```
+
+Open any docs document, confirm the ruler looks identical to `main`
+(tick positions, labels, indent handles, margin drag).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/docs/src/view/ruler/
+git commit -m "$(cat <<'EOF'
+Extract docs ruler tick + unit helpers into a shared module
+
+Move tick rendering and locale-aware unit math out of the monolithic
+Ruler class so the slides package can reuse them. Public docs API
+(imports from `../view/ruler`) is unchanged — the directory now
+exports the same surface via `index.ts`.
+
+Preparation for the slides ruler (see
+docs/design/slides/slides-ruler.md). No behavior change for docs.
+EOF
+)"
+```
+
+---
+
+## Chunk 2: Phase 2 — Slides ruler display
+
+Add the H/V ruler canvases and the corner element to the slides
+editor. Wire them to the editor's viewport (scroll + zoom). No
+interactions yet — pure display.
+
+### Task 2.1: SlidesRuler controller
+
+**Files:**
+- Create: `packages/slides/src/view/editor/ruler/ruler.ts`
+- Create: `packages/slides/src/view/editor/ruler/index.ts` (barrel)
+- Create: `packages/slides/test/view/editor/ruler/ruler.test.ts`
+- Modify: `packages/slides/src/index.ts` (export `SlidesRuler`)
+
+**Constants and imports:**
+
+Before writing the controller, expose the ruler primitives from the
+docs package barrel:
+
+```ts
+// packages/docs/src/index.ts (append)
+export {
+  detectUnit,
+  getGridConfig,
+  drawTicks,
+  snapToGrid,
+  type RulerUnit,
+  type GridConfig,
+} from './view/ruler';
+```
+
+Then import from the package root in the slides controller:
+
+```ts
+// packages/slides/src/view/editor/ruler/ruler.ts
+import {
+  detectUnit,
+  getGridConfig,
+  drawTicks,
+  type RulerUnit,
+  type GridConfig,
+} from '@wafflebase/docs';
+
+export const RULER_SIZE = 20;          // px
+export const SLIDES_PX_PER_INCH = 144; // 1920 / 13.333
+```
+
+Verify the new exports resolve with `pnpm verify:fast` before
+proceeding.
+
+- [ ] **Step 1: Write failing unit test**
+
+```ts
+// packages/slides/test/view/editor/ruler/ruler.test.ts
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SlidesRuler, RULER_SIZE } from '../../../../src/view/editor/ruler/ruler';
+
+describe('SlidesRuler', () => {
+  let container: HTMLElement;
+  let hCanvas: HTMLCanvasElement;
+  let vCanvas: HTMLCanvasElement;
+  let corner: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    hCanvas = document.createElement('canvas');
+    vCanvas = document.createElement('canvas');
+    corner = document.createElement('div');
+    container.append(corner, hCanvas, vCanvas);
+    document.body.appendChild(container);
+  });
+
+  it('renders without throwing at zoom 1', () => {
+    const ruler = new SlidesRuler({ container, hCanvas, vCanvas, corner });
+    expect(() =>
+      ruler.render({ scrollX: 0, scrollY: 0, zoom: 1, slideW: 1920, slideH: 1080 }),
+    ).not.toThrow();
+  });
+
+  it('exposes RULER_SIZE = 20', () => {
+    expect(RULER_SIZE).toBe(20);
+  });
+});
+```
+
+Run: `pnpm --filter @wafflebase/slides test ruler`
+Expected: FAIL ("Cannot find module './ruler'").
+
+- [ ] **Step 2: Implement `SlidesRuler` skeleton**
+
+```ts
+// packages/slides/src/view/editor/ruler/ruler.ts
+import {
+  detectUnit,
+  getGridConfig,
+  drawTicks,
+  type RulerUnit,
+  type GridConfig,
+} from '@wafflebase/docs';
+
+export const RULER_SIZE = 20;
+export const SLIDES_PX_PER_INCH = 144;
+
+export interface SlidesRulerViewport {
+  scrollX: number;
+  scrollY: number;
+  zoom: number;
+  slideW: number;
+  slideH: number;
+}
+
+type Density = 'full' | 'half-only' | 'major' | 'major-thinned';
+
+export class SlidesRuler {
+  private hCtx: CanvasRenderingContext2D | null;
+  private vCtx: CanvasRenderingContext2D | null;
+  private unit: RulerUnit;
+  private grid: GridConfig;
+  private guideDragCb: ((axis: 'x' | 'y') => void) | null = null;
+
+  constructor(private opts: {
+    container: HTMLElement;
+    hCanvas: HTMLCanvasElement;
+    vCanvas: HTMLCanvasElement;
+    corner: HTMLElement;
+  }) {
+    this.hCtx = opts.hCanvas.getContext('2d');
+    this.vCtx = opts.vCanvas.getContext('2d');
+    this.unit = detectUnit(navigator?.language);
+    this.grid = getGridConfig(this.unit, SLIDES_PX_PER_INCH);
+  }
+
+  setUnit(unit: RulerUnit) {
+    this.unit = unit;
+    this.grid = getGridConfig(unit, SLIDES_PX_PER_INCH);
+  }
+
+  onGuideDragStart(cb: (axis: 'x' | 'y') => void) {
+    this.guideDragCb = cb;
+  }
+
+  render(viewport: SlidesRulerViewport) {
+    this.resizeCanvases();
+    const density = this.densityFor(viewport.zoom);
+    this.paintAxis('h', viewport, density);
+    this.paintAxis('v', viewport, density);
+  }
+
+  private densityFor(zoom: number): Density {
+    const pxPerUnit = this.grid.majorStepPx * zoom;
+    if (pxPerUnit >= 60) return 'full';
+    if (pxPerUnit >= 30) return 'half-only';
+    if (pxPerUnit >= 15) return 'major';
+    return 'major-thinned';
+  }
+
+  private resizeCanvases() {
+    // Sync backing stores to container size × devicePixelRatio.
+    // For h: width = container.clientWidth - RULER_SIZE, height = RULER_SIZE.
+    // For v: width = RULER_SIZE, height = container.clientHeight - RULER_SIZE.
+    // Apply ctx.scale(dpr, dpr) after resize.
+  }
+
+  private paintAxis(axis: 'h' | 'v', v: SlidesRulerViewport, density: Density) {
+    const ctx = axis === 'h' ? this.hCtx : this.vCtx;
+    if (!ctx) return;
+    const length = axis === 'h'
+      ? this.opts.hCanvas.clientWidth
+      : this.opts.vCanvas.clientHeight;
+    const origin = axis === 'h' ? -v.scrollX * v.zoom : -v.scrollY * v.zoom;
+    drawTicks({
+      ctx, axis, length, origin,
+      scale: v.zoom,
+      grid: this.grid,
+      unit: this.unit,
+      density,
+    });
+  }
+
+  dispose() {
+    // No listeners attached in Phase 2; Phase 4 adds mousedown handlers
+    // and a matching teardown.
+  }
+}
+```
+
+The paint methods compute density from `v.zoom`:
+
+```ts
+const pxPerUnitOnScreen =
+  (this.unit === 'inch' ? SLIDES_PX_PER_INCH : SLIDES_PX_PER_INCH / 2.54) * v.zoom;
+
+const density: 'full' | 'half-only' | 'major' | 'major-thinned' =
+  pxPerUnitOnScreen >= 60 ? 'full'
+  : pxPerUnitOnScreen >= 30 ? 'half-only'
+  : pxPerUnitOnScreen >= 15 ? 'major'
+  : 'major-thinned';
+```
+
+- [ ] **Step 3: Run test, verify it passes**
+
+```bash
+pnpm --filter @wafflebase/slides test ruler
+```
+
+- [ ] **Step 4: Add density coverage tests**
+
+For each of the four density bands, render at the corresponding zoom
+and assert against a spied canvas context (use the existing
+`createCtxSpy` harness in `packages/slides/src/view/canvas/ctx-spy.ts`)
+that the right number of `fillText` calls fire.
+
+```ts
+import { asCtx, createCtxSpy } from '../../../../src/view/canvas/ctx-spy';
+
+it('uses major-only labels at zoom 0.1', () => {
+  const spy = createCtxSpy();
+  hCanvas.getContext = () => asCtx(spy);
+  vCanvas.getContext = () => asCtx(spy);
+  const ruler = new SlidesRuler({ container, hCanvas, vCanvas, corner });
+  ruler.render({ scrollX: 0, scrollY: 0, zoom: 0.1, slideW: 1920, slideH: 1080 });
+  expect(spy.fillTextCalls.length).toBeGreaterThan(0);
+  expect(spy.fillTextCalls.length).toBeLessThan(5); // major-thinned
+});
+```
+
+### Task 2.2: Mount the ruler in the editor shell
+
+**Files:**
+- Modify: `packages/frontend/src/app/slides/slides-view.tsx` (or wherever the slide stage is composed)
+- Modify: `packages/slides/src/view/editor/editor.ts` (expose `setRulerViewport()` / call ruler from paint)
+
+- [ ] **Step 1: Find the slide stage DOM**
+
+Search for the element that hosts `<canvas>` and the selection overlay:
+
+```bash
+grep -rn "slide-canvas\|slide-stage\|overlay" packages/frontend/src/app/slides/ | head
+```
+
+This is where the ruler canvases must be inserted as siblings of the
+existing canvas/overlay, positioned absolutely.
+
+- [ ] **Step 2: Adjust DOM structure**
+
+In the React shell, render three new sibling elements ahead of the
+canvas pane:
+
+```tsx
+<div className="slide-stage" style={{ position: 'relative' }}>
+  <div ref={cornerRef}    className="ruler-corner" />
+  <canvas ref={hRulerRef} className="ruler-h"      />
+  <canvas ref={vRulerRef} className="ruler-v"      />
+  <div    ref={paneRef}   className="canvas-pane">
+    <canvas ref={slideRef} />
+    <div ref={overlayRef} className="overlay" />
+  </div>
+</div>
+```
+
+CSS (Tailwind or matching the existing styling layer):
+
+```css
+.ruler-corner { position: absolute; top: 0; left: 0; width: 20px; height: 20px; z-index: 3; }
+.ruler-h      { position: absolute; top: 0; left: 20px; right: 0; height: 20px; z-index: 2; }
+.ruler-v      { position: absolute; top: 20px; left: 0; bottom: 0; width: 20px; z-index: 1; }
+.canvas-pane  { position: absolute; top: 20px; left: 20px; right: 0; bottom: 0; }
+```
+
+- [ ] **Step 3: Wire ruler to editor paint cycle**
+
+In `editor.ts`, instantiate a `SlidesRuler` after the canvas is
+mounted, and call `ruler.render({ ... })` at the end of each paint:
+
+```ts
+this.ruler = new SlidesRuler({
+  container: stageEl,
+  hCanvas: hRulerCanvas,
+  vCanvas: vRulerCanvas,
+  corner: cornerEl,
+});
+
+// inside render():
+this.ruler.render({
+  scrollX: this.viewport.scrollX,
+  scrollY: this.viewport.scrollY,
+  zoom: this.viewport.zoom,
+  slideW: 1920,
+  slideH: 1080,
+});
+```
+
+`editor.dispose()` must call `ruler.dispose()`.
+
+- [ ] **Step 4: Manual smoke**
+
+```bash
+pnpm dev
+```
+
+Open a slides document. Confirm:
+- H/V rulers appear at top and left, 20 px each
+- Slide canvas is offset 20 px down and 20 px right
+- Labels at zoom 1: 0", 1", 2", … (or 0 cm, 1 cm, … on metric locales)
+- Labels thin out as you zoom out; full minor ticks appear when zoomed in past 60 px per unit
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/slides packages/frontend/src/app/slides packages/docs/src
+git commit -m "$(cat <<'EOF'
+Add horizontal and vertical rulers to the slides editor
+
+H/V rulers attach to the slide stage as absolutely positioned canvases
+(20 px each), drawn through the shared docs tick renderer with a
+slides-specific 144 dpi constant (1920 px / 13.333"). Tick density
+adapts to editor zoom so the ruler stays legible from 0.25× to 3×.
+
+Display-only in this PR — guide drag-out, snap, and interactions land
+in follow-ups.
+
+See docs/design/slides/slides-ruler.md.
+EOF
+)"
+```
+
+---
+
+## Chunk 3: Phase 3 — Guide data model + Yorkie schema + passive render
+
+Add the `Guide` type, store API, in-memory implementation, Yorkie
+adapter, and a passive render pass. Users still cannot create guides
+through the UI; this PR makes them creatable via the store and
+visible if they exist.
+
+### Task 3.1: Model + store API
+
+**Files:**
+- Modify: `packages/slides/src/model/presentation.ts` (add `Guide`, extend `SlidesDocument`)
+- Modify: `packages/slides/src/store/store.ts` (interface additions)
+- Modify: `packages/slides/src/store/memory.ts` (implementation)
+- Test: `packages/slides/test/store/memory.test.ts`
+
+- [ ] **Step 1: Add type to model**
+
+```ts
+// packages/slides/src/model/presentation.ts
+export type GuideAxis = 'x' | 'y';
+
+export interface Guide {
+  id: string;
+  axis: GuideAxis;
+  position: number;
+}
+
+export interface SlidesDocument {
+  meta: { title: string };
+  slides: Slide[];
+  layouts: Layout[];
+  guides: Guide[];                  // NEW
+  // ...other existing fields (themes, etc.)
+}
+```
+
+Add `guides: []` to all factory functions / fixtures that construct a
+`SlidesDocument` (search `meta:.*title` in the codebase to find them).
+
+- [ ] **Step 2: Add interface methods**
+
+```ts
+// in SlidesStore
+addGuide(axis: GuideAxis, position: number): string;
+moveGuide(id: string, position: number): void;
+removeGuide(id: string): void;
+```
+
+Document in JSDoc that position is clamped by callers; the store does
+not enforce bounds (it is geometry-agnostic).
+
+- [ ] **Step 3: Write failing tests**
+
+```ts
+// packages/slides/test/store/memory.test.ts (append)
+describe('guides', () => {
+  it('adds a guide and returns a stable id', () => {
+    const store = new MemSlidesStore(fixture());
+    const id = store.addGuide('x', 200);
+    expect(store.read().guides).toEqual([{ id, axis: 'x', position: 200 }]);
+  });
+
+  it('moves a guide', () => {
+    const store = new MemSlidesStore(fixture());
+    const id = store.addGuide('y', 100);
+    store.moveGuide(id, 250);
+    expect(store.read().guides[0].position).toBe(250);
+  });
+
+  it('removes a guide', () => {
+    const store = new MemSlidesStore(fixture());
+    const id = store.addGuide('x', 200);
+    store.removeGuide(id);
+    expect(store.read().guides).toEqual([]);
+  });
+
+  it('groups add+move+remove into one undo step when wrapped in batch', () => {
+    const store = new MemSlidesStore(fixture());
+    store.batch(() => {
+      const id = store.addGuide('x', 100);
+      store.moveGuide(id, 200);
+    });
+    store.undo();
+    expect(store.read().guides).toEqual([]);
+  });
+});
+```
+
+Run: `pnpm --filter @wafflebase/slides test memory`
+Expected: FAIL ("addGuide is not a function").
+
+- [ ] **Step 4: Implement in `MemSlidesStore`**
+
+```ts
+addGuide(axis: GuideAxis, position: number): string {
+  const id = nanoid();
+  this.commit('addGuide', (doc) => {
+    doc.guides.push({ id, axis, position });
+  });
+  return id;
+}
+
+moveGuide(id: string, position: number): void {
+  this.commit('moveGuide', (doc) => {
+    const g = doc.guides.find((g) => g.id === id);
+    if (g) g.position = position;
+  });
+}
+
+removeGuide(id: string): void {
+  this.commit('removeGuide', (doc) => {
+    doc.guides = doc.guides.filter((g) => g.id !== id);
+  });
+}
+```
+
+`commit` (or whatever the existing pattern is — match the surrounding
+code) handles batching and undo entry creation. Verify by reading a
+neighbouring mutator like `addElement` and copying its shape.
+
+- [ ] **Step 5: Run tests, verify they pass**
+
+```bash
+pnpm --filter @wafflebase/slides test memory
+```
+
+### Task 3.2: Yorkie adapter
+
+**Files:**
+- Modify: `packages/frontend/src/app/slides/yorkie-slides-store.ts`
+- Modify: `packages/backend/src/yorkie/yorkie.types.ts` (add `guides` to the slides root shape)
+- Test: `packages/frontend/tests/app/slides/yorkie-slides-store.test.ts`
+
+- [ ] **Step 1: Extend backend Yorkie type**
+
+```ts
+// packages/backend/src/yorkie/yorkie.types.ts
+export interface SlidesDocumentYorkie {
+  // existing
+  guides?: Array<{ id: string; axis: 'x' | 'y'; position: number }>;
+}
+```
+
+`guides` is optional in the type so old documents (without it) still
+parse.
+
+- [ ] **Step 2: Lazy init on attach**
+
+In `yorkie-slides-store.ts`, find the `update(root => …)` block that
+runs after attach. Add:
+
+```ts
+doc.update((root) => {
+  if (!root.guides) {
+    root.guides = [];
+  }
+});
+```
+
+This is idempotent — once the first session writes the empty array,
+subsequent attaches no-op.
+
+- [ ] **Step 3: Implement the three guide methods**
+
+Mirror the pattern of `addElement` / `removeElement` (use
+`Yorkie.Array.push` / `splice` / index-based update inside a
+`doc.update` callback):
+
+```ts
+addGuide(axis: GuideAxis, position: number): string {
+  const id = nanoid();
+  this.doc.update((root) => {
+    root.guides.push({ id, axis, position });
+  });
+  return id;
+}
+
+moveGuide(id: string, position: number): void {
+  this.doc.update((root) => {
+    const idx = root.guides.findIndex((g: Guide) => g.id === id);
+    if (idx >= 0) root.guides[idx].position = position;
+  });
+}
+
+removeGuide(id: string): void {
+  this.doc.update((root) => {
+    const idx = root.guides.findIndex((g: Guide) => g.id === id);
+    if (idx >= 0) root.guides.deleteByIndex(idx);
+  });
+}
+```
+
+(Adjust API calls to match the actual Yorkie.Array surface used elsewhere in the file.)
+
+- [ ] **Step 4: Equivalence test (Mem vs Yorkie)**
+
+In `yorkie-slides-store.test.ts`, add a section that runs the same
+operation sequence against both `MemSlidesStore` and a Yorkie-attached
+`YorkieSlidesStore` and asserts `read()` returns the same `guides`
+array.
+
+- [ ] **Step 5: Concurrent convergence test**
+
+Extend `packages/frontend/tests/app/slides/two-user-slides-yorkie.ts`
+(or the equivalent two-user helper) with a scenario where user A and
+user B concurrently `addGuide` and `removeGuide`, then sync. Assert
+both clients converge to the same `guides` array. Gate with
+`RUN_YORKIE_INTEGRATION_TESTS`.
+
+### Task 3.3: Passive render
+
+**Files:**
+- Create: `packages/slides/src/view/editor/ruler/guides-layer.ts`
+- Modify: `packages/slides/src/view/editor/overlay.ts` (mount the guides layer)
+
+- [ ] **Step 1: Implement `paintGuides`**
+
+```ts
+// packages/slides/src/view/editor/ruler/guides-layer.ts
+import type { Guide } from '../../../model/presentation';
+
+export function paintGuides(
+  ctx: CanvasRenderingContext2D,
+  guides: ReadonlyArray<Guide>,
+  view: { zoom: number; scrollX: number; scrollY: number; slideW: number; slideH: number },
+): void {
+  ctx.save();
+  ctx.strokeStyle = '#ff2d92';  // magenta
+  ctx.lineWidth = 1;
+  for (const g of guides) {
+    ctx.beginPath();
+    if (g.axis === 'x') {
+      const x = (g.position - view.scrollX) * view.zoom + 0.5;
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, view.slideH * view.zoom);
+    } else {
+      const y = (g.position - view.scrollY) * view.zoom + 0.5;
+      ctx.moveTo(0, y);
+      ctx.lineTo(view.slideW * view.zoom, y);
+    }
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+```
+
+- [ ] **Step 2: Mount in overlay paint**
+
+In `overlay.ts`, find the existing overlay paint sequence (selection
+handles, snap guides). Append a `paintGuides(ctx, doc.guides, view)`
+call after element overlays but before selection handles.
+
+- [ ] **Step 3: Manual smoke**
+
+Open browser devtools, attach the editor, run:
+
+```js
+editor.store.addGuide('x', 400);
+editor.store.addGuide('y', 300);
+editor.render();
+```
+
+Confirm two magenta lines appear on the slide canvas (crossing).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/slides packages/frontend packages/backend
+git commit -m "$(cat <<'EOF'
+Add presentation-wide guides to the slides data model
+
+Introduce a Guide type stored on SlidesDocument.guides, with addGuide
+/ moveGuide / removeGuide on the SlidesStore interface. Implement on
+MemSlidesStore and YorkieSlidesStore; the Yorkie adapter lazy-inits
+the new array on attach so existing decks load without migration.
+
+Guides render passively as magenta solid lines through the overlay
+layer. User interactions land in the next PR.
+
+See docs/design/slides/slides-ruler.md.
+EOF
+)"
+```
+
+---
+
+## Chunk 4: Phase 4 — Guide interactions
+
+User-facing creation, repositioning, and deletion of guides via
+ruler drag-out, guide drag, and context menu. Presence-driven
+previews keep CRDT operations bounded to one per gesture.
+
+### Task 4.1: Drag-out from the rulers
+
+**Files:**
+- Create: `packages/slides/src/view/editor/ruler/interactions.ts`
+- Modify: `packages/slides/src/view/editor/ruler/ruler.ts` (wire `mousedown`)
+- Modify: `packages/slides/src/view/editor/editor.ts` (own the interaction state)
+- Modify: `packages/slides/src/view/editor/selection.ts` (presence field — `draggingGuide`)
+
+- [ ] **Step 1: Add presence field**
+
+Find the existing `SlidesPresence` type (search `selectedElementIds`).
+Add:
+
+```ts
+draggingGuide?: {
+  id?: string;
+  axis: 'x' | 'y';
+  position: number;
+};
+```
+
+- [ ] **Step 2: Hook ruler mousedown**
+
+In `ruler.ts` constructor, attach listeners (when not read-only):
+
+```ts
+opts.hCanvas.addEventListener('mousedown', (e) => this.onRulerMousedown(e, 'x'));
+opts.vCanvas.addEventListener('mousedown', (e) => this.onRulerMousedown(e, 'y'));
+```
+
+`onRulerMousedown` fires the `guideDragCb` (set via `onGuideDragStart`),
+which the editor uses to start a guide-drag interaction:
+
+```ts
+private onRulerMousedown(e: MouseEvent, axis: 'x' | 'y') {
+  if (!this.guideDragCb) return;
+  e.preventDefault();
+  this.guideDragCb(axis);  // hand off to editor
+}
+```
+
+Track listener references in a private array for `dispose()`.
+
+- [ ] **Step 3: Implement guide drag in editor**
+
+```ts
+// packages/slides/src/view/editor/ruler/interactions.ts
+export function startGuideDrag(
+  editor: SlidesEditor,
+  axis: 'x' | 'y',
+  initialEvent: MouseEvent,
+): void {
+  const slideToScreen = editor.viewport.zoom;
+  const startScreen = axis === 'x' ? initialEvent.clientX : initialEvent.clientY;
+  // ... attach window mousemove/mouseup
+}
+```
+
+On `mousemove`:
+- Convert screen Y/X back to slide-logical coords.
+- Update presence: `draggingGuide: { axis, position }`.
+- Paint preview through the overlay path on the next animation frame.
+
+On `mouseup`:
+- If pointer inside slide bounds: `store.batch(() => store.addGuide(axis, position))`.
+- Otherwise: discard (no store call).
+- Clear presence.
+
+- [ ] **Step 4: Tests**
+
+Use the existing editor test harness (`packages/slides/test/view/editor/editor.test.ts`).
+Simulate a mousedown on the ruler canvas + mousemove + mouseup, assert:
+
+```ts
+it('creates a guide via ruler drag-out', () => {
+  // arrange editor + dispatch mousedown on hCanvas, mousemove, mouseup over slide
+  expect(store.read().guides).toEqual([
+    expect.objectContaining({ axis: 'x', position: 400 }),
+  ]);
+});
+```
+
+### Task 4.2: Drag existing guide
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/hit-test.ts` (add guide hit-test within 4 px)
+- Modify: `packages/slides/src/view/editor/ruler/interactions.ts`
+
+- [ ] **Step 1: Guide hit-test**
+
+Add a helper:
+
+```ts
+export function hitTestGuide(
+  guides: ReadonlyArray<Guide>,
+  point: { x: number; y: number },
+  thresholdPx: number,
+  zoom: number,
+): Guide | null {
+  const t = thresholdPx / zoom;
+  return guides.find((g) =>
+    g.axis === 'x' ? Math.abs(point.x - g.position) <= t
+                   : Math.abs(point.y - g.position) <= t,
+  ) ?? null;
+}
+```
+
+- [ ] **Step 2: Cursor + start-drag on slide canvas**
+
+In the slide canvas `mousemove` handler (which already runs for
+element hit-testing), if no element is under the pointer but a guide
+is within 4 px, set the cursor to `col-resize` (vertical guide) or
+`row-resize` (horizontal guide).
+
+On `mousedown` with a guide hit, start a `moveGuide` drag: presence
+preview, `moveGuide(id, position)` on mouseup.
+
+- [ ] **Step 3: Tests**
+
+```ts
+it('moves a guide on drag', () => {
+  store.addGuide('x', 200);
+  // dispatch mousedown at slide-x=200, mousemove to slide-x=350, mouseup
+  expect(store.read().guides[0].position).toBe(350);
+});
+```
+
+### Task 4.3: Delete by dragging guide onto a ruler
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/ruler/interactions.ts`
+
+- [ ] **Step 1: Detect ruler-region mouseup**
+
+While dragging an existing guide, on every `mousemove` check whether
+the cursor is over a ruler canvas (use `elementFromPoint` or compare
+against ruler bounds). If over the matching ruler, set the cursor to
+a delete affordance (use `not-allowed` for v1; an icon overlay can
+come later).
+
+On `mouseup` over the ruler: `store.removeGuide(id)`.
+
+- [ ] **Step 2: Test**
+
+```ts
+it('deletes a guide when dragged onto the ruler', () => {
+  const id = store.addGuide('x', 200);
+  // dispatch mousedown at guide, mousemove into ruler region, mouseup
+  expect(store.read().guides).toEqual([]);
+});
+```
+
+### Task 4.4: Right-click menu + ruler markers
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/context-menu.ts`
+- Modify: `packages/slides/src/view/editor/ruler/ruler.ts` (paint magenta markers)
+
+- [ ] **Step 1: Context menu entries**
+
+Extend the existing slides context menu (used elsewhere in the editor)
+with three new actions, gated on a guide being under the pointer:
+
+- "Delete guide" → `store.removeGuide(id)`
+- "Delete all on this axis" → `store.batch(() => guides.filter(...).forEach(removeGuide))`
+- "Delete all guides" → batch + removeAll
+
+- [ ] **Step 2: Ruler markers**
+
+In `SlidesRuler.paintHorizontal` / `paintVertical`, after `drawTicks`,
+paint a small magenta triangle for each guide whose axis matches the
+ruler:
+
+```ts
+ctx.fillStyle = '#ff2d92';
+ctx.beginPath();
+ctx.moveTo(screenX - 4, 0);
+ctx.lineTo(screenX + 4, 0);
+ctx.lineTo(screenX,    RULER_SIZE - 2);
+ctx.closePath();
+ctx.fill();
+```
+
+Wire this by extending `render()` to accept the current guide list:
+
+```ts
+render(viewport: SlidesRulerViewport, guides: ReadonlyArray<Guide>): void
+```
+
+Update the editor's paint call accordingly.
+
+- [ ] **Step 3: Two-user presence test**
+
+In `two-user-slides-yorkie.ts`, simulate user A dragging a guide
+and assert user B receives `draggingGuide` presence updates without
+any CRDT operation firing during the drag.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/slides packages/frontend
+git commit -m "$(cat <<'EOF'
+Make slides guides draggable from the rulers
+
+Mousedown on a ruler starts a drag-out gesture; mouseup inside the
+slide commits via store.addGuide. Existing guides drag to reposition
+and can be deleted by dragging back onto a ruler or via the right-
+click menu. Intermediate frames travel through presence so the CRDT
+sees one operation per gesture.
+
+Each ruler paints small magenta markers showing the positions of
+guides on its axis.
+
+See docs/design/slides/slides-ruler.md.
+EOF
+)"
+```
+
+---
+
+## Chunk 5: Phase 5 — Snap integration
+
+Guides become a snap-candidate kind alongside slide-center and
+element edges, with explicit priority resolution.
+
+### Task 5.1: Extend SnapGuide and snap engine
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/snap.ts`
+- Modify: `packages/slides/src/view/editor/snap-candidates.ts`
+- Test: `packages/slides/test/view/editor/snap.test.ts`
+
+- [ ] **Step 1: Extend type**
+
+```ts
+// snap.ts
+export type SnapGuide = {
+  kind: 'slide-center' | 'edge' | 'guide';
+  axis: 'x' | 'y';
+  position: number;
+  guideId?: string;
+};
+```
+
+- [ ] **Step 2: Add guides to candidate list**
+
+In `snap-candidates.ts` (the function that builds the candidate set
+before each `snapDelta` call), append a candidate for each guide:
+
+```ts
+for (const g of doc.guides) {
+  candidates.push({ kind: 'guide', axis: g.axis, position: g.position, guideId: g.id });
+}
+```
+
+- [ ] **Step 3: Priority resolution in snapDelta**
+
+When multiple candidates fall within the threshold:
+
+```ts
+const order = { 'slide-center': 0, 'guide': 1, 'edge': 2 };
+hits.sort((a, b) => order[a.kind] - order[b.kind] || Math.abs(a.delta) - Math.abs(b.delta));
+return hits[0];
+```
+
+- [ ] **Step 4: Tests**
+
+```ts
+it('prefers slide-center over a guide within the same threshold', () => {
+  const doc = makeDoc({ guides: [{ id: 'g1', axis: 'x', position: 962 }] });
+  // slide-center at 960; both within 4 px of dragged frame at 961
+  const snap = snapDelta(doc, dragged, threshold);
+  expect(snap?.kind).toBe('slide-center');
+});
+
+it('prefers a guide over an element edge', () => {
+  const doc = makeDoc({
+    guides: [{ id: 'g1', axis: 'x', position: 100 }],
+    slides: [{ elements: [{ frame: { x: 102, ...} }] }],
+  });
+  const snap = snapDelta(doc, draggedNear(100), threshold);
+  expect(snap?.kind).toBe('guide');
+});
+
+it('does not trigger snap during arrow-key nudge', () => {
+  // verify nudge path bypasses snap entirely
+});
+```
+
+### Task 5.2: Visual emphasis on snapped guide
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/ruler/guides-layer.ts`
+
+- [ ] **Step 1: Receive snap target**
+
+Extend `paintGuides` to take an optional `snappedGuideId: string | null`
+and thicken / deepen color when it matches:
+
+```ts
+const isSnapped = g.id === snappedGuideId;
+ctx.lineWidth = isSnapped ? 1.5 : 1;
+ctx.strokeStyle = isSnapped ? '#ff007a' : '#ff2d92';
+```
+
+- [ ] **Step 2: Wire from overlay paint**
+
+```ts
+paintGuides(ctx, doc.guides, view, editor.currentSnap?.guideId ?? null);
+```
+
+- [ ] **Step 3: Manual smoke**
+
+`pnpm dev`, drag an element near a guide, confirm the guide turns
+thicker / darker the moment the element snaps.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/slides
+git commit -m "$(cat <<'EOF'
+Make slides guides participate in the snap engine
+
+Add 'guide' as a third SnapGuide kind, ranked between slide-center
+and element edges. When an element drag snaps to a guide, the guide
+itself thickens and deepens color so the snap target is unambiguous.
+
+Keyboard nudge intentionally bypasses snap; tests pin the behavior.
+
+See docs/design/slides/slides-ruler.md.
+EOF
+)"
+```
+
+---
+
+## Chunk 6: Phase 6 — Read-only mounts + presentation/PDF exclusion + browser smoke
+
+Polish: read-only viewers see rulers/guides but cannot edit; the
+presenter and PDF exporter ignore them; a browser-driven scenario
+verifies persistence end-to-end.
+
+### Task 6.1: Read-only branch
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/editor.ts` (`initializeEditor` options)
+- Modify: `packages/slides/src/view/editor/ruler/ruler.ts` (accept `readOnly` flag)
+- Modify: `packages/slides/src/view/editor/ruler/interactions.ts` (no-op when read-only)
+
+- [ ] **Step 1: Plumb `readOnly` to the ruler**
+
+Update the `SlidesRuler` constructor to accept `readOnly?: boolean`.
+When true, skip the `mousedown` listener binding in Task 4.1 Step 2.
+
+- [ ] **Step 2: Skip interactions in read-only mode**
+
+In `editor.ts`, where `attachInteractions()` is gated by `readOnly`,
+also skip:
+- guide hover hit-test (cursor change on `mousemove`)
+- right-click context menu entries for guides
+
+- [ ] **Step 3: Tests**
+
+```ts
+it('does not allow guide creation in read-only mode', () => {
+  const editor = initializeEditor({ ..., readOnly: true });
+  // dispatch mousedown on ruler + mouseup
+  expect(store.read().guides).toEqual([]);
+});
+```
+
+### Task 6.2: Presentation and PDF exclusion
+
+**Files:**
+- Verify: `packages/slides/src/view/present/presenter.ts` does not import the ruler / guides layer
+- Modify: `packages/slides/src/export/pdf.ts` (assert guides are ignored)
+- Test: `packages/slides/test/export/pdf.test.ts`
+
+- [ ] **Step 1: PDF test**
+
+```ts
+it('does not render guides into PDF output', async () => {
+  const doc = makeDoc({ guides: [{ id: 'g1', axis: 'x', position: 400 }] });
+  const a = await exportPdf(doc);
+  const b = await exportPdf({ ...doc, guides: [] });
+  expect(a.length).toBe(b.length); // bytes identical
+});
+```
+
+Adjust assertion to whatever signal matches the existing PDF test
+infrastructure (e.g. paint-call counts).
+
+- [ ] **Step 2: Presenter check**
+
+Grep the presenter module:
+
+```bash
+grep -n "guide\|ruler" packages/slides/src/view/present/
+```
+
+Confirm no references. If any slipped in, remove them.
+
+### Task 6.3: Browser smoke (verify:browser:docker)
+
+**Files:**
+- Modify or add: `packages/frontend/tests/browser/slides-ruler.spec.ts`
+
+- [ ] **Step 1: Scenario**
+
+```ts
+test('guide created in one session persists after reload', async ({ page }) => {
+  await page.goto('/slides/<fixture-id>');
+  await dragFrom(page, '.ruler-h', { x: 400, y: 10 }, { x: 400, y: 200 });
+  await expect(page.locator('.guides-layer-canvas-marker')).toBeVisible();
+  await page.reload();
+  await expect(page.locator('.guides-layer-canvas-marker')).toBeVisible();
+});
+```
+
+Use the existing browser-test harness conventions; the locator names
+above are placeholders to be replaced with the actual selectors used
+by the project's browser tests.
+
+- [ ] **Step 2: Run**
+
+```bash
+pnpm verify:browser:docker
+```
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add packages/slides packages/frontend
+git commit -m "$(cat <<'EOF'
+Finish slides ruler — read-only handling and browser smoke
+
+Read-only mounts render the ruler and existing guides but suppress
+every mutating interaction (drag-out, guide drag, context menu).
+Presentation mode and PDF export ignore guides — covered by a PDF
+byte-equality test.
+
+Browser smoke verifies a ruler drag-out persists across reload via
+Yorkie sync.
+
+Closes the implementation tracked in
+docs/tasks/active/20260523-slides-ruler-todo.md.
+EOF
+)"
+```
+
+---
+
+## Verification gates
+
+| Phase | Gate | Command |
+| --- | --- | --- |
+| P1, P2, P5 | unit + lint | `pnpm verify:fast` |
+| P3 | unit + integration (Yorkie convergence) | `pnpm verify:integration` |
+| P4 | unit + integration (presence) | `pnpm verify:integration` |
+| P6 | full + browser | `pnpm verify:browser:docker` |
+
+Each commit must pass `pnpm verify:fast`. The integration / browser
+gates only block the PRs that touch their respective subsystems.
+
+---
+
+## Out of scope (tracked for follow-ups)
+
+- `View > Show ruler` and `View > Show guides` toggles (await a
+  Slides View menu and a persisted-preferences surface).
+- Text-box-local ruler mode with indent / tab handles. Plan picks
+  this up after the docs RichText extraction lands (see
+  `docs/design/slides/slides-text-engine-audit.md`).
+- Numeric guide position input (e.g. "place at exactly 4.0\"").
+- Per-slide guides; for v1 they are strictly presentation-wide.
+- Center-origin coordinates (PowerPoint convention).

--- a/packages/backend/src/yorkie/slides-tree.spec.ts
+++ b/packages/backend/src/yorkie/slides-tree.spec.ts
@@ -73,6 +73,7 @@ function makeDeck(): SlidesDocument {
         notes: [],
       },
     ],
+    guides: [],
   } as unknown as SlidesDocument;
 }
 

--- a/packages/backend/src/yorkie/slides-tree.ts
+++ b/packages/backend/src/yorkie/slides-tree.ts
@@ -18,7 +18,7 @@
  * fields overwrite whatever is on the root, and `meta` is rewritten as a
  * fresh object so stale theme/master ids cannot leak from a prior write.
  */
-import type { Master, Theme } from '@wafflebase/slides';
+import type { Guide, Master, Theme } from '@wafflebase/slides';
 import type {
   SlidesDocument,
   SlidesLayout,
@@ -37,6 +37,8 @@ export interface SlidesYorkieRoot extends Record<string, unknown> {
   masters?: Master[];
   layouts?: SlidesLayout[];
   slides?: SlidesSlide[];
+  /** Presentation-wide alignment guides. Optional for pre-ruler decks. */
+  guides?: Guide[];
 }
 
 /**
@@ -62,6 +64,7 @@ export function readSlidesRoot(root: SlidesYorkieRoot): SlidesDocument {
   const masters = unwrapJson<Master[]>(root.masters) ?? [];
   const layouts = unwrapJson<SlidesLayout[]>(root.layouts) ?? [];
   const slides = unwrapJson<SlidesSlide[]>(root.slides) ?? [];
+  const guides = unwrapJson<Guide[]>(root.guides) ?? [];
   return {
     meta: {
       title: metaSrc?.title ?? 'Untitled presentation',
@@ -72,6 +75,7 @@ export function readSlidesRoot(root: SlidesYorkieRoot): SlidesDocument {
     masters,
     layouts,
     slides,
+    guides,
   };
 }
 
@@ -98,6 +102,10 @@ export function writeSlidesRoot(
   root.masters = document.masters;
   root.layouts = document.layouts;
   root.slides = document.slides;
+  // Older callers (and well-typed-but-incomplete test fixtures) may
+  // pass a document without a `guides` field. Normalize to an empty
+  // array on write so `readSlidesRoot` always returns the same shape.
+  root.guides = document.guides ?? [];
 }
 
 /**

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -123,7 +123,20 @@ export {
   drawPeerLabel,
 } from './view/peer-cursor.js';
 export { Selection } from './view/selection.js';
-export { Ruler, RULER_SIZE } from './view/ruler.js';
+export {
+  Ruler,
+  RULER_SIZE,
+  detectUnit,
+  getGridConfig,
+  snapToGrid,
+  drawTicks,
+} from './view/ruler/index.js';
+export type {
+  RulerUnit,
+  GridConfig,
+  TickDensity,
+  DrawTicksOpts,
+} from './view/ruler/index.js';
 export { FindReplaceState } from './view/find-replace.js';
 export type { SearchMatch, SearchOptions } from './model/types.js';
 export type { CommentMarker, HighlightRect } from './view/comment-markers.js';

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -13,7 +13,7 @@ import { CanvasTextMeasurer } from './canvas-measurer.js';
 import type { TextMeasurer } from './measurer.js';
 import type { DocPosition, HeaderFooter } from '../model/types.js';
 import { findMarkerAt, type CommentMarker, type HighlightRect } from './comment-markers.js';
-import { Ruler, RULER_SIZE } from './ruler.js';
+import { Ruler, RULER_SIZE } from './ruler/index.js';
 import { computeScaleFactor } from './scale.js';
 import { setThemeMode, type ThemeMode } from './theme.js';
 import { type PeerCursor, resolvePositionPixel } from './peer-cursor.js';

--- a/packages/docs/src/view/ruler/index.ts
+++ b/packages/docs/src/view/ruler/index.ts
@@ -1,46 +1,25 @@
-import type { PaginatedLayout } from './pagination.js';
-import { getPageXOffset, getPageYOffset, getTotalHeight } from './pagination.js';
-import type { BlockStyle, PageMargins } from '../model/types.js';
-import { Theme } from './theme.js';
+import type { PaginatedLayout } from '../pagination.js';
+import { getPageXOffset, getPageYOffset, getTotalHeight } from '../pagination.js';
+import type { BlockStyle, PageMargins } from '../../model/types.js';
+import { Theme } from '../theme.js';
+import {
+  detectUnit,
+  getGridConfig,
+  snapToGrid,
+  type RulerUnit,
+  type GridConfig,
+} from './unit.js';
+import { drawTicks } from './tick-renderer.js';
 
-export type RulerUnit = 'inch' | 'cm';
-
-export interface GridConfig {
-  majorStepPx: number;
-  subdivisions: number;
-  minorStepPx: number;
-}
-
-const INCH_LOCALES = ['en-US', 'en-GB', 'my'];
-
-export function detectUnit(locale: string | undefined): RulerUnit {
-  if (!locale) return 'inch';
-  if (INCH_LOCALES.includes(locale)) return 'inch';
-  if (locale.startsWith('en')) return 'inch';
-  return 'cm';
-}
-
-export function getGridConfig(unit: RulerUnit): GridConfig {
-  if (unit === 'inch') {
-    return { majorStepPx: 96, subdivisions: 8, minorStepPx: 12 };
-  }
-  const cmPx = 96 / 2.54;
-  return { majorStepPx: cmPx, subdivisions: 10, minorStepPx: cmPx / 10 };
-}
-
-export function snapToGrid(px: number, step: number): number {
-  return Math.round(px / step) * step;
-}
+export { detectUnit, getGridConfig, snapToGrid, drawTicks };
+export type { RulerUnit, GridConfig };
+export type { TickDensity, DrawTicksOpts } from './tick-renderer.js';
 
 export const RULER_SIZE = 20;
-const TICK_MAJOR = 10;
-const TICK_HALF = 7;
-const TICK_MINOR = 4;
 // Colors are read from the active theme at render time.
 const marginBg = () => Theme.rulerMarginBackground;
 const contentBg = () => Theme.rulerContentBackground;
 const tickColor = () => Theme.rulerTickColor;
-const LABEL_FONT = '9px Arial';
 const HIT_ZONE = 4;
 
 export class Ruler {
@@ -180,47 +159,15 @@ export class Ruler {
     ctx.fillRect(contentLeft, 0, contentRight - contentLeft, RULER_SIZE);
 
     // 3. Draw tick marks from page left to page right
-    ctx.strokeStyle = tickColor();
-    ctx.lineWidth = 1;
-    ctx.fillStyle = tickColor();
-    ctx.font = LABEL_FONT;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'top';
-
-    const { subdivisions, minorStepPx } = this.grid;
-
-    // Calculate the first tick index from page start
-    const pageLeft = pageX;
-    const pageRight = pageX + pageWidth;
-
-    // Draw ticks from page left to page right
-    const startTick = 0;
-    const endTick = Math.ceil(pageWidth / minorStepPx);
-
-    ctx.beginPath();
-    for (let i = startTick; i <= endTick; i++) {
-      const xRaw = pageLeft + i * minorStepPx;
-      if (xRaw < pageLeft || xRaw > pageRight) continue;
-      const x = Math.round(xRaw) + 0.5;
-
-      let tickHeight: number;
-      if (i % subdivisions === 0) {
-        tickHeight = TICK_MAJOR;
-      } else if (i % (subdivisions / 2) === 0) {
-        tickHeight = TICK_HALF;
-      } else {
-        tickHeight = TICK_MINOR;
-      }
-
-      ctx.moveTo(x, RULER_SIZE);
-      ctx.lineTo(x, RULER_SIZE - tickHeight);
-
-      // Draw label at major ticks
-      if (i % subdivisions === 0 && i > 0) {
-        ctx.fillText(String(i / subdivisions), x, 1);
-      }
-    }
-    ctx.stroke();
+    drawTicks({
+      ctx,
+      axis: 'h',
+      start: pageX,
+      length: pageWidth,
+      grid: this.grid,
+      color: tickColor(),
+      rulerSize: RULER_SIZE,
+    });
 
     // 4. Draw indent handles if blockStyle is available
     if (blockStyle !== null) {
@@ -299,38 +246,15 @@ export class Ruler {
     this.vCtx.fillRect(0, contentTop, RULER_SIZE, contentBottom - contentTop);
 
     // Tick marks
-    const { subdivisions, minorStepPx } = this.grid;
-    const startPx = pageTopInViewport;
-    const endPx = pageTopInViewport + focusedPage.height;
-
-    this.vCtx.strokeStyle = tickColor();
-    this.vCtx.fillStyle = tickColor();
-    this.vCtx.font = LABEL_FONT;
-    this.vCtx.textAlign = 'center';
-    this.vCtx.textBaseline = 'middle';
-    this.vCtx.lineWidth = 1;
-
-    for (let px = startPx; px <= endPx; px += minorStepPx) {
-      const relPx = px - startPx;
-      const tickIndex = Math.round(relPx / minorStepPx);
-      const isMajor = tickIndex % subdivisions === 0;
-      const isHalf = tickIndex % (subdivisions / 2) === 0;
-      const tickW = isMajor ? TICK_MAJOR : isHalf ? TICK_HALF : TICK_MINOR;
-      const y = Math.round(px) + 0.5;
-
-      this.vCtx.beginPath();
-      this.vCtx.moveTo(RULER_SIZE, y);
-      this.vCtx.lineTo(RULER_SIZE - tickW, y);
-      this.vCtx.stroke();
-
-      if (isMajor && tickIndex > 0) {
-        this.vCtx.save();
-        this.vCtx.translate(6, y);
-        this.vCtx.rotate(-Math.PI / 2);
-        this.vCtx.fillText(String(tickIndex / subdivisions), 0, 0);
-        this.vCtx.restore();
-      }
-    }
+    drawTicks({
+      ctx: this.vCtx,
+      axis: 'v',
+      start: pageTopInViewport,
+      length: focusedPage.height,
+      grid: this.grid,
+      color: tickColor(),
+      rulerSize: RULER_SIZE,
+    });
 
     this.vCtx.restore();
   }

--- a/packages/docs/src/view/ruler/tick-renderer.ts
+++ b/packages/docs/src/view/ruler/tick-renderer.ts
@@ -13,6 +13,12 @@ import type { GridConfig } from './unit.js';
 
 export type TickDensity = 'full' | 'half-only' | 'major' | 'major-thinned';
 
+export interface TickHeights {
+  major: number;
+  half: number;
+  minor: number;
+}
+
 export interface DrawTicksOpts {
   ctx: CanvasRenderingContext2D;
   axis: 'h' | 'v';
@@ -30,13 +36,32 @@ export interface DrawTicksOpts {
   density?: TickDensity;
   /** Ruler thickness in px; defaults to 20. */
   rulerSize?: number;
+  /**
+   * Per-kind tick lengths in px. Defaults to docs proportions (10 / 7
+   * / 4 for a 20-px ruler). Slim rulers (e.g. slides at 14 px) pass
+   * smaller values so ticks + labels coexist without overlap.
+   */
+  tickHeights?: TickHeights;
+  /**
+   * Inset (in px) for the horizontal ruler's label baseline, measured
+   * from the top edge of the ruler canvas. Defaults to 1 — the docs
+   * ruler reserves an extra pixel of breathing room. Slim rulers may
+   * pass 0 to keep labels from colliding with the major tick.
+   */
+  labelInset?: number;
+  /**
+   * Inset (in px) for the rotated label of the vertical ruler,
+   * measured from the inner edge of the ruler canvas. Defaults to 6
+   * to match the docs ruler. Slim rulers pass a smaller value.
+   */
+  verticalLabelInset?: number;
 }
 
-const TICK_MAJOR = 10;
-const TICK_HALF = 7;
-const TICK_MINOR = 4;
+const DEFAULT_TICK_HEIGHTS: TickHeights = { major: 10, half: 7, minor: 4 };
 const DEFAULT_LABEL_FONT = '9px Arial';
 const DEFAULT_RULER_SIZE = 20;
+const DEFAULT_LABEL_INSET = 1;
+const DEFAULT_VERTICAL_LABEL_INSET = 6;
 
 type TickKind = 'major' | 'half' | 'minor';
 
@@ -56,10 +81,6 @@ function labelIntervalForDensity(density: TickDensity): number {
   return density === 'major-thinned' ? 2 : 1;
 }
 
-function tickLength(kind: TickKind): number {
-  return kind === 'major' ? TICK_MAJOR : kind === 'half' ? TICK_HALF : TICK_MINOR;
-}
-
 export function drawTicks(opts: DrawTicksOpts): void {
   const {
     ctx, axis, start, length, grid,
@@ -67,6 +88,9 @@ export function drawTicks(opts: DrawTicksOpts): void {
     labelFont = DEFAULT_LABEL_FONT,
     density = 'full',
     rulerSize = DEFAULT_RULER_SIZE,
+    tickHeights = DEFAULT_TICK_HEIGHTS,
+    labelInset = DEFAULT_LABEL_INSET,
+    verticalLabelInset = DEFAULT_VERTICAL_LABEL_INSET,
   } = opts;
   const { subdivisions, minorStepPx } = grid;
 
@@ -79,6 +103,11 @@ export function drawTicks(opts: DrawTicksOpts): void {
 
   const endTick = Math.ceil(length / minorStepPx);
   const labelEvery = labelIntervalForDensity(density);
+
+  const tickLength = (kind: TickKind): number =>
+    kind === 'major' ? tickHeights.major
+    : kind === 'half' ? tickHeights.half
+    : tickHeights.minor;
 
   if (axis === 'h') {
     ctx.textAlign = 'center';
@@ -104,7 +133,7 @@ export function drawTicks(opts: DrawTicksOpts): void {
       const unitIndex = i / subdivisions;
       if (unitIndex % labelEvery !== 0) continue;
       const x = Math.round(raw) + 0.5;
-      ctx.fillText(String(unitIndex), x, 1);
+      ctx.fillText(String(unitIndex), x, labelInset);
     }
     return;
   }
@@ -134,7 +163,11 @@ export function drawTicks(opts: DrawTicksOpts): void {
     if (unitIndex % labelEvery !== 0) continue;
     const y = Math.round(raw) + 0.5;
     ctx.save();
-    ctx.translate(6, y);
+    // Rotated labels for the vertical ruler. `verticalLabelInset`
+    // controls how far inward the label center sits from the ruler's
+    // inner edge — docs uses 6 (default), slim rulers use a smaller
+    // value so labels stay clear of the ticks.
+    ctx.translate(verticalLabelInset, y);
     ctx.rotate(-Math.PI / 2);
     ctx.fillText(String(unitIndex), 0, 0);
     ctx.restore();

--- a/packages/docs/src/view/ruler/tick-renderer.ts
+++ b/packages/docs/src/view/ruler/tick-renderer.ts
@@ -1,0 +1,142 @@
+/**
+ * Tick + label drawing for ruler canvases. Pure renderer — no DOM,
+ * no layout knowledge (pages, slides). The caller fills backgrounds
+ * and decorations (indent handles, guide markers); `drawTicks` adds
+ * tick marks and integer-unit labels within the measured region.
+ *
+ * Coordinates are canvas pixels. The caller pre-scales `grid` for
+ * the active zoom factor (slides) or passes the unscaled grid
+ * (docs at implicit zoom 1).
+ */
+
+import type { GridConfig } from './unit.js';
+
+export type TickDensity = 'full' | 'half-only' | 'major' | 'major-thinned';
+
+export interface DrawTicksOpts {
+  ctx: CanvasRenderingContext2D;
+  axis: 'h' | 'v';
+  /** Canvas-px coord where the measured region begins on this axis. */
+  start: number;
+  /** Canvas-px length of the measured region on this axis. */
+  length: number;
+  /** Grid steps in canvas-px space (pre-scaled by the caller). */
+  grid: GridConfig;
+  /** Stroke + fill color. Caller may also set context state ahead of the call. */
+  color?: string;
+  /** Label font; defaults to '9px Arial'. */
+  labelFont?: string;
+  /** Density override; defaults to 'full'. */
+  density?: TickDensity;
+  /** Ruler thickness in px; defaults to 20. */
+  rulerSize?: number;
+}
+
+const TICK_MAJOR = 10;
+const TICK_HALF = 7;
+const TICK_MINOR = 4;
+const DEFAULT_LABEL_FONT = '9px Arial';
+const DEFAULT_RULER_SIZE = 20;
+
+type TickKind = 'major' | 'half' | 'minor';
+
+function classify(i: number, subdivisions: number): TickKind {
+  if (i % subdivisions === 0) return 'major';
+  if (subdivisions % 2 === 0 && i % (subdivisions / 2) === 0) return 'half';
+  return 'minor';
+}
+
+function shouldDraw(kind: TickKind, density: TickDensity): boolean {
+  if (density === 'full') return true;
+  if (density === 'half-only') return kind !== 'minor';
+  return kind === 'major';
+}
+
+function labelIntervalForDensity(density: TickDensity): number {
+  return density === 'major-thinned' ? 2 : 1;
+}
+
+function tickLength(kind: TickKind): number {
+  return kind === 'major' ? TICK_MAJOR : kind === 'half' ? TICK_HALF : TICK_MINOR;
+}
+
+export function drawTicks(opts: DrawTicksOpts): void {
+  const {
+    ctx, axis, start, length, grid,
+    color,
+    labelFont = DEFAULT_LABEL_FONT,
+    density = 'full',
+    rulerSize = DEFAULT_RULER_SIZE,
+  } = opts;
+  const { subdivisions, minorStepPx } = grid;
+
+  if (color) {
+    ctx.strokeStyle = color;
+    ctx.fillStyle = color;
+  }
+  ctx.font = labelFont;
+  ctx.lineWidth = 1;
+
+  const endTick = Math.ceil(length / minorStepPx);
+  const labelEvery = labelIntervalForDensity(density);
+
+  if (axis === 'h') {
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+    ctx.beginPath();
+    for (let i = 0; i <= endTick; i++) {
+      const raw = start + i * minorStepPx;
+      if (raw < start || raw > start + length) continue;
+
+      const kind = classify(i, subdivisions);
+      if (!shouldDraw(kind, density)) continue;
+
+      const x = Math.round(raw) + 0.5;
+      const h = tickLength(kind);
+      ctx.moveTo(x, rulerSize);
+      ctx.lineTo(x, rulerSize - h);
+    }
+    ctx.stroke();
+
+    for (let i = subdivisions; i <= endTick; i += subdivisions) {
+      const raw = start + i * minorStepPx;
+      if (raw < start || raw > start + length) continue;
+      const unitIndex = i / subdivisions;
+      if (unitIndex % labelEvery !== 0) continue;
+      const x = Math.round(raw) + 0.5;
+      ctx.fillText(String(unitIndex), x, 1);
+    }
+    return;
+  }
+
+  // Vertical
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  for (let i = 0; i <= endTick; i++) {
+    const raw = start + i * minorStepPx;
+    if (raw < start || raw > start + length) continue;
+
+    const kind = classify(i, subdivisions);
+    if (!shouldDraw(kind, density)) continue;
+
+    const y = Math.round(raw) + 0.5;
+    const w = tickLength(kind);
+    ctx.beginPath();
+    ctx.moveTo(rulerSize, y);
+    ctx.lineTo(rulerSize - w, y);
+    ctx.stroke();
+  }
+
+  for (let i = subdivisions; i <= endTick; i += subdivisions) {
+    const raw = start + i * minorStepPx;
+    if (raw < start || raw > start + length) continue;
+    const unitIndex = i / subdivisions;
+    if (unitIndex % labelEvery !== 0) continue;
+    const y = Math.round(raw) + 0.5;
+    ctx.save();
+    ctx.translate(6, y);
+    ctx.rotate(-Math.PI / 2);
+    ctx.fillText(String(unitIndex), 0, 0);
+    ctx.restore();
+  }
+}

--- a/packages/docs/src/view/ruler/unit.ts
+++ b/packages/docs/src/view/ruler/unit.ts
@@ -1,0 +1,46 @@
+/**
+ * Locale-aware unit detection and grid configuration for the
+ * docs/slides rulers. Pure helpers — no DOM, no canvas.
+ *
+ * `getGridConfig` takes `pxPerInch` so callers can specify their own
+ * physical scale: docs uses 96 (1 CSS px = 1/96 inch), slides uses
+ * 144 (1920 px logical canvas / 13.333"). Defaults to 96 for
+ * backwards compatibility with the existing docs caller.
+ */
+
+export type RulerUnit = 'inch' | 'cm';
+
+export interface GridConfig {
+  majorStepPx: number;
+  subdivisions: number;
+  minorStepPx: number;
+}
+
+const INCH_LOCALES = ['en-US', 'en-GB', 'my'];
+
+export function detectUnit(locale: string | undefined): RulerUnit {
+  if (!locale) return 'inch';
+  if (INCH_LOCALES.includes(locale)) return 'inch';
+  if (locale.startsWith('en')) return 'inch';
+  return 'cm';
+}
+
+export function getGridConfig(unit: RulerUnit, pxPerInch = 96): GridConfig {
+  if (unit === 'inch') {
+    return {
+      majorStepPx: pxPerInch,
+      subdivisions: 8,
+      minorStepPx: pxPerInch / 8,
+    };
+  }
+  const cmPx = pxPerInch / 2.54;
+  return {
+    majorStepPx: cmPx,
+    subdivisions: 10,
+    minorStepPx: cmPx / 10,
+  };
+}
+
+export function snapToGrid(px: number, step: number): number {
+  return Math.round(px / step) * step;
+}

--- a/packages/docs/test/view/ruler.test.ts
+++ b/packages/docs/test/view/ruler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectUnit, getGridConfig, snapToGrid, Ruler } from '../../src/view/ruler.js';
+import { detectUnit, getGridConfig, snapToGrid, Ruler } from '../../src/view/ruler/index.js';
 
 describe('ruler units', () => {
   it('detectUnit returns inch for en-US', () => {

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -281,6 +281,13 @@ export function SlidesView({
     canvasArea.style.paddingTop = `${SLIDES_RULER_SIZE}px`;
     canvasArea.style.paddingLeft = `${SLIDES_RULER_SIZE}px`;
 
+    // Seed the host dimensions before mounting any DOM that references
+    // them. `refitCanvas` will replace these on the first
+    // ResizeObserver tick; the seed only avoids a 0×0 flash.
+    const initial = computeFitSize(MIN_HOST_W, MIN_HOST_W / SLIDE_ASPECT);
+    let hostW = initial.width;
+    let hostH = initial.height;
+
     // Ruler DOM: corner square (top-left), horizontal canvas across
     // the top gutter, vertical canvas down the left gutter. All three
     // are absolute to canvasArea so they hug the frame's edges
@@ -300,13 +307,11 @@ export function SlidesView({
     // bitmap intrinsic size (300×150 default). Set explicit
     // width/height in `refitCanvas` below, and seed an initial value
     // here so the first paint isn't a 0×0 sliver in the corner.
-    const initialFrameW = hostW;
-    const initialFrameH = hostH;
     const hRulerCanvas = document.createElement("canvas");
     hRulerCanvas.style.position = "absolute";
     hRulerCanvas.style.left = `${SLIDES_RULER_SIZE}px`;
     hRulerCanvas.style.top = "0";
-    hRulerCanvas.style.width = `${initialFrameW}px`;
+    hRulerCanvas.style.width = `${hostW}px`;
     hRulerCanvas.style.height = `${SLIDES_RULER_SIZE}px`;
     hRulerCanvas.style.zIndex = "2";
     canvasArea.appendChild(hRulerCanvas);
@@ -316,7 +321,7 @@ export function SlidesView({
     vRulerCanvas.style.left = "0";
     vRulerCanvas.style.top = `${SLIDES_RULER_SIZE}px`;
     vRulerCanvas.style.width = `${SLIDES_RULER_SIZE}px`;
-    vRulerCanvas.style.height = `${initialFrameH}px`;
+    vRulerCanvas.style.height = `${hostH}px`;
     vRulerCanvas.style.zIndex = "1";
     canvasArea.appendChild(vRulerCanvas);
 
@@ -325,10 +330,6 @@ export function SlidesView({
     // outside, on the canvas-area frame).
     const canvasWrap = document.createElement("div");
     canvasWrap.style.position = "relative";
-
-    const initial = computeFitSize(MIN_HOST_W, MIN_HOST_W / SLIDE_ASPECT);
-    let hostW = initial.width;
-    let hostH = initial.height;
     canvasWrap.style.width = `${hostW}px`;
     canvasWrap.style.height = `${hostH}px`;
 

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -2,6 +2,7 @@ import {
   initializeEditor,
   mountThumbnailPanel,
   mountNotesPanel,
+  SLIDES_RULER_SIZE,
   type SlidesEditor,
   type ThumbnailPanelHandle,
 } from "@wafflebase/slides";
@@ -261,7 +262,8 @@ export function SlidesView({
     right.style.minWidth = "0";  // allow the column to shrink + width-fit
     right.style.minHeight = "0";
 
-    // Canvas + overlay live inside this wrapper. Sized later by the
+    // Canvas + overlay live inside this wrapper, with the H/V rulers
+    // pinned to the wrapper's top + left edges. Sized later by the
     // ResizeObserver below — mounting at MIN_HOST_W avoids a flash of
     // an unsized canvas during the first layout pass.
     const canvasWrap = document.createElement("div");
@@ -271,8 +273,44 @@ export function SlidesView({
     const initial = computeFitSize(MIN_HOST_W, MIN_HOST_W / SLIDE_ASPECT);
     let hostW = initial.width;
     let hostH = initial.height;
+    // The slide canvas is offset by the ruler gutter so canvasWrap's
+    // outer dimensions = host + ruler.
+    canvasWrap.style.width = `${hostW + SLIDES_RULER_SIZE}px`;
+    canvasWrap.style.height = `${hostH + SLIDES_RULER_SIZE}px`;
+
+    // Ruler DOM: corner square (top-left), horizontal canvas across
+    // the top gutter, vertical canvas down the left gutter. All three
+    // are absolute relative to canvasWrap so they stay glued to the
+    // canvas as it resizes.
+    const rulerCorner = document.createElement("div");
+    rulerCorner.style.position = "absolute";
+    rulerCorner.style.left = "0";
+    rulerCorner.style.top = "0";
+    rulerCorner.style.width = `${SLIDES_RULER_SIZE}px`;
+    rulerCorner.style.height = `${SLIDES_RULER_SIZE}px`;
+    rulerCorner.style.zIndex = "3";
+    canvasWrap.appendChild(rulerCorner);
+
+    const hRulerCanvas = document.createElement("canvas");
+    hRulerCanvas.style.position = "absolute";
+    hRulerCanvas.style.left = `${SLIDES_RULER_SIZE}px`;
+    hRulerCanvas.style.top = "0";
+    hRulerCanvas.style.height = `${SLIDES_RULER_SIZE}px`;
+    hRulerCanvas.style.zIndex = "2";
+    canvasWrap.appendChild(hRulerCanvas);
+
+    const vRulerCanvas = document.createElement("canvas");
+    vRulerCanvas.style.position = "absolute";
+    vRulerCanvas.style.left = "0";
+    vRulerCanvas.style.top = `${SLIDES_RULER_SIZE}px`;
+    vRulerCanvas.style.width = `${SLIDES_RULER_SIZE}px`;
+    vRulerCanvas.style.zIndex = "1";
+    canvasWrap.appendChild(vRulerCanvas);
 
     const canvas = document.createElement("canvas");
+    canvas.style.position = "absolute";
+    canvas.style.left = `${SLIDES_RULER_SIZE}px`;
+    canvas.style.top = `${SLIDES_RULER_SIZE}px`;
     canvas.width = hostW * dpr;
     canvas.height = hostH * dpr;
     canvas.style.width = `${hostW}px`;
@@ -293,8 +331,8 @@ export function SlidesView({
 
     const overlay = document.createElement("div");
     overlay.style.position = "absolute";
-    overlay.style.left = "0";
-    overlay.style.top = "0";
+    overlay.style.left = `${SLIDES_RULER_SIZE}px`;
+    overlay.style.top = `${SLIDES_RULER_SIZE}px`;
     overlay.style.width = `${hostW}px`;
     overlay.style.height = `${hostH}px`;
     overlay.style.pointerEvents = "none";
@@ -337,6 +375,9 @@ export function SlidesView({
       hostHeight: hostH,
       dpr,
       readOnly: readOnlyMount,
+      hRulerCanvas,
+      vRulerCanvas,
+      rulerCorner,
       onShowShortcutsHelp: () => setHelpOpen(true),
       onStartPresentation: (from) => onStartPresentationRef.current?.(from),
       onToast: (msg) => onToastRef.current(msg),
@@ -364,7 +405,11 @@ export function SlidesView({
       const reservedForNotes = notesHost.getBoundingClientRect().height + 12;
       const availW = Math.max(MIN_HOST_W, Math.min(MAX_HOST_W, rightRect.width));
       const availH = Math.max(MIN_HOST_W / SLIDE_ASPECT, rightRect.height - reservedForNotes);
-      const fit = computeFitSize(availW, availH);
+      // Reserve the ruler gutter so the slide canvas itself never
+      // overflows the right column: canvasWrap outer = host + gutter.
+      const slideAvailW = Math.max(MIN_HOST_W, availW - SLIDES_RULER_SIZE);
+      const slideAvailH = Math.max(MIN_HOST_W / SLIDE_ASPECT, availH - SLIDES_RULER_SIZE);
+      const fit = computeFitSize(slideAvailW, slideAvailH);
       const nextW = Math.round(fit.width);
       const nextH = Math.round(fit.height);
       if (nextW === hostW && nextH === hostH) return;
@@ -376,6 +421,8 @@ export function SlidesView({
       canvas.style.height = `${hostH}px`;
       overlay.style.width = `${hostW}px`;
       overlay.style.height = `${hostH}px`;
+      canvasWrap.style.width = `${hostW + SLIDES_RULER_SIZE}px`;
+      canvasWrap.style.height = `${hostH + SLIDES_RULER_SIZE}px`;
       editor.setHostSize(hostW, hostH);
     });
     resizeObserver.observe(right);

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -292,6 +292,11 @@ export function SlidesView({
     canvasArea.style.alignItems = "center";
     canvasArea.style.paddingTop = `${SLIDES_RULER_SIZE}px`;
     canvasArea.style.paddingLeft = `${SLIDES_RULER_SIZE}px`;
+    // Clip the over-sized permanent guide lines (they extend past the
+    // slide bounds so they visually reach the rulers). Also trims any
+    // shadow that might bleed past the SLIDE_FRAME_GAP — acceptable
+    // since the shadow's outer fade is already near-zero opacity.
+    canvasArea.style.overflow = "hidden";
 
     // Seed the host dimensions before mounting any DOM that references
     // them. `refitCanvas` will replace these on the first
@@ -319,13 +324,20 @@ export function SlidesView({
     // bitmap intrinsic size (300×150 default). Set explicit
     // width/height in `refitCanvas` below, and seed an initial value
     // here so the first paint isn't a 0×0 sliver in the corner.
+    // Rulers sit at z-index 1 (below canvasWrap's z-index 2) so the
+    // permanent guide lines — which extend past the slide bounds into
+    // the ruler area — paint on top of the ruler ticks instead of
+    // disappearing under them. The corner stays at z-index 3 above
+    // both; no guide can cross the corner because guides always sit
+    // at slide-x ≥ 0, which after centring + padding maps to a frame
+    // x well to the right of the corner's 14×14 footprint.
     const hRulerCanvas = document.createElement("canvas");
     hRulerCanvas.style.position = "absolute";
     hRulerCanvas.style.left = `${SLIDES_RULER_SIZE}px`;
     hRulerCanvas.style.top = "0";
     hRulerCanvas.style.width = `${hostW}px`;
     hRulerCanvas.style.height = `${SLIDES_RULER_SIZE}px`;
-    hRulerCanvas.style.zIndex = "2";
+    hRulerCanvas.style.zIndex = "1";
     canvasArea.appendChild(hRulerCanvas);
 
     const vRulerCanvas = document.createElement("canvas");
@@ -339,9 +351,13 @@ export function SlidesView({
 
     // Canvas + overlay live inside this wrapper at the slide's
     // intrinsic host dimensions (no ruler offset — the ruler lives
-    // outside, on the canvas-area frame).
+    // outside, on the canvas-area frame). `z-index: 2` pushes its
+    // overlay (and the over-sized permanent guide lines inside it)
+    // above the ruler canvases at z-index 1 so guides visually
+    // connect through the ruler ticks.
     const canvasWrap = document.createElement("div");
     canvasWrap.style.position = "relative";
+    canvasWrap.style.zIndex = "2";
     canvasWrap.style.width = `${hostW}px`;
     canvasWrap.style.height = `${hostH}px`;
 
@@ -490,6 +506,19 @@ export function SlidesView({
     // `notesHeight` changes without `right`'s own size changing).
     const refitCanvas = () => {
       const rightRect = right.getBoundingClientRect();
+      // Re-clamp notesHeight against the live column cap. The drag
+      // handler enforces MAX_NOTES_H_RATIO while the divider is being
+      // dragged, but a height restored from localStorage or a window
+      // resize would otherwise let the notes panel exceed the cap
+      // until the next user drag.
+      const maxNotesH = Math.max(
+        MIN_NOTES_H,
+        Math.floor(rightRect.height * MAX_NOTES_H_RATIO),
+      );
+      if (notesHeight > maxNotesH) {
+        notesHeight = maxNotesH;
+        notesHost.style.height = `${notesHeight}px`;
+      }
       // Notes section reserves its own height + the 6 px resizer.
       const reservedBelow = notesHeight + 6;
       const availW = Math.max(MIN_HOST_W, Math.min(MAX_HOST_W, rightRect.width));

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -57,6 +57,18 @@ interface SlidesViewProps {
 const SLIDE_ASPECT = 16 / 9;
 const MIN_HOST_W = 320;  // floor so very narrow viewports still paint something usable
 const MAX_HOST_W = 1600; // ceiling so on ultra-wide displays we don't paint a 4K bitmap
+/**
+ * Breathing room (px) between the slide edge and the ruler / canvas-
+ * area edge. Without this the slide touches the ruler at zoom-to-fit,
+ * which:
+ *   - lets the slide's 12-px drop-shadow blur into the ruler ticks
+ *   - leaves the slide's 1-px hairline outline overlapping the ruler edge
+ * Subtracting this from the available width / height shrinks the slide
+ * just enough that the flex centering produces equal padding on every
+ * side. `SlidesRuler` keeps its `(frame - host) / 2` offset math —
+ * tick "0" still lands on the slide's actual left / top edge.
+ */
+const SLIDE_FRAME_GAP = 12;
 
 function computeFitSize(availWidth: number, availHeight: number): {
   width: number;
@@ -486,9 +498,16 @@ export function SlidesView({
         rightRect.height - reservedBelow,
       );
       // Reserve the ruler gutter so the slide canvas itself never
-      // overflows the right column: canvasWrap outer = host + gutter.
-      const slideAvailW = Math.max(MIN_HOST_W, availW - SLIDES_RULER_SIZE);
-      const slideAvailH = Math.max(MIN_HOST_W / SLIDE_ASPECT, availH - SLIDES_RULER_SIZE);
+      // overflows the right column, plus a SLIDE_FRAME_GAP on both
+      // sides so the slide elevation doesn't bleed into the rulers.
+      const slideAvailW = Math.max(
+        MIN_HOST_W,
+        availW - SLIDES_RULER_SIZE - SLIDE_FRAME_GAP * 2,
+      );
+      const slideAvailH = Math.max(
+        MIN_HOST_W / SLIDE_ASPECT,
+        availH - SLIDES_RULER_SIZE - SLIDE_FRAME_GAP * 2,
+      );
       const fit = computeFitSize(slideAvailW, slideAvailH);
       const nextW = Math.round(fit.width);
       const nextH = Math.round(fit.height);

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -295,11 +295,18 @@ export function SlidesView({
     rulerCorner.style.zIndex = "3";
     canvasArea.appendChild(rulerCorner);
 
+    // Canvas elements don't expand to fill their containing block from
+    // absolute-position `left/right` alone — they fall back to the
+    // bitmap intrinsic size (300×150 default). Set explicit
+    // width/height in `refitCanvas` below, and seed an initial value
+    // here so the first paint isn't a 0×0 sliver in the corner.
+    const initialFrameW = hostW;
+    const initialFrameH = hostH;
     const hRulerCanvas = document.createElement("canvas");
     hRulerCanvas.style.position = "absolute";
     hRulerCanvas.style.left = `${SLIDES_RULER_SIZE}px`;
-    hRulerCanvas.style.right = "0";
     hRulerCanvas.style.top = "0";
+    hRulerCanvas.style.width = `${initialFrameW}px`;
     hRulerCanvas.style.height = `${SLIDES_RULER_SIZE}px`;
     hRulerCanvas.style.zIndex = "2";
     canvasArea.appendChild(hRulerCanvas);
@@ -308,8 +315,8 @@ export function SlidesView({
     vRulerCanvas.style.position = "absolute";
     vRulerCanvas.style.left = "0";
     vRulerCanvas.style.top = `${SLIDES_RULER_SIZE}px`;
-    vRulerCanvas.style.bottom = "0";
     vRulerCanvas.style.width = `${SLIDES_RULER_SIZE}px`;
+    vRulerCanvas.style.height = `${initialFrameH}px`;
     vRulerCanvas.style.zIndex = "1";
     canvasArea.appendChild(vRulerCanvas);
 
@@ -484,6 +491,18 @@ export function SlidesView({
       const fit = computeFitSize(slideAvailW, slideAvailH);
       const nextW = Math.round(fit.width);
       const nextH = Math.round(fit.height);
+
+      // Pin each ruler canvas to the full frame extent — canvas
+      // elements don't pick up a width from `left + right` alone, so
+      // they need explicit CSS dimensions. Updated unconditionally so
+      // that a notes-drag (canvasArea height changes, host doesn't)
+      // still refreshes the vertical ruler.
+      const areaRect = canvasArea.getBoundingClientRect();
+      const rulerHCss = Math.max(0, Math.round(areaRect.width - SLIDES_RULER_SIZE));
+      const rulerVCss = Math.max(0, Math.round(areaRect.height - SLIDES_RULER_SIZE));
+      hRulerCanvas.style.width = `${rulerHCss}px`;
+      vRulerCanvas.style.height = `${rulerVCss}px`;
+
       if (nextW === hostW && nextH === hostH) return;
       hostW = nextW;
       hostH = nextH;

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -258,9 +258,23 @@ export function SlidesView({
     right.style.paddingLeft = "12px";
     right.style.display = "flex";
     right.style.flexDirection = "column";
-    right.style.gap = "12px";
+    // Gap is 0 so the notes resizer sits flush against the notes panel
+    // (mirrors Google Slides' divider treatment). Canvas-area to
+    // resizer breathing is provided by the canvas drop shadow itself.
+    right.style.gap = "0";
     right.style.minWidth = "0";  // allow the column to shrink + width-fit
     right.style.minHeight = "0";
+
+    // Canvas area: flex-1 column that vertically + horizontally
+    // centers the slide canvas inside the remaining space. Without
+    // this the slide hugs the top edge and leaves an awkward gap
+    // below — especially on tall viewports.
+    const canvasArea = document.createElement("div");
+    canvasArea.style.flex = "1 1 auto";
+    canvasArea.style.minHeight = "0";
+    canvasArea.style.display = "flex";
+    canvasArea.style.justifyContent = "center";
+    canvasArea.style.alignItems = "center";
 
     // Canvas + overlay live inside this wrapper, with the H/V rulers
     // pinned to the wrapper's top + left edges. Sized later by the
@@ -268,7 +282,6 @@ export function SlidesView({
     // an unsized canvas during the first layout pass.
     const canvasWrap = document.createElement("div");
     canvasWrap.style.position = "relative";
-    canvasWrap.style.alignSelf = "flex-start";
 
     const initial = computeFitSize(MIN_HOST_W, MIN_HOST_W / SLIDE_ASPECT);
     let hostW = initial.width;
@@ -338,9 +351,67 @@ export function SlidesView({
     overlay.style.pointerEvents = "none";
     canvasWrap.appendChild(overlay);
 
-    right.appendChild(canvasWrap);
+    canvasArea.appendChild(canvasWrap);
+    right.appendChild(canvasArea);
+
+    // Notes resizer — horizontal counterpart of the thumbnail-panel
+    // divider. Drag up to expand the speaker-notes panel; drag down
+    // to shrink it. Visually a hairline at the column edge that
+    // thickens on hover, matching the left handle's behavior so the
+    // two affordances feel like a set.
+    const notesResizer = document.createElement("div");
+    notesResizer.style.cursor = "row-resize";
+    notesResizer.style.position = "relative";
+    notesResizer.style.height = "6px";
+    notesResizer.style.flexShrink = "0";
+    notesResizer.setAttribute("aria-label", "Resize speaker notes");
+    notesResizer.setAttribute("role", "separator");
+    notesResizer.setAttribute("aria-orientation", "horizontal");
+    const notesResizerLine = document.createElement("div");
+    notesResizerLine.style.position = "absolute";
+    notesResizerLine.style.left = "0";
+    notesResizerLine.style.right = "0";
+    notesResizerLine.style.top = "50%";
+    notesResizerLine.style.height = "1px";
+    notesResizerLine.style.background = "var(--border, #4444)";
+    notesResizerLine.style.transform = "translateY(-50%)";
+    notesResizerLine.style.transition = "background 120ms";
+    notesResizer.appendChild(notesResizerLine);
+    notesResizer.addEventListener("mouseenter", () => {
+      notesResizerLine.style.background = "var(--primary, #3a7)";
+      notesResizerLine.style.height = "2px";
+    });
+    notesResizer.addEventListener("mouseleave", () => {
+      notesResizerLine.style.background = "var(--border, #4444)";
+      notesResizerLine.style.height = "1px";
+    });
+    right.appendChild(notesResizer);
+
+    // Notes height is user-controlled and persisted across reloads.
+    // Mirrors the thumbnail-panel width persistence so both
+    // dimensions of the editor chrome remember the user's choice.
+    const NOTES_STORAGE_KEY = "wfb-slides-notes-height";
+    const MIN_NOTES_H = 60;
+    const DEFAULT_NOTES_H = 120;
+    /** Cap so the canvas always gets ≥ 40 % of the column even with
+     * notes maxed out. Re-evaluated against the current column height
+     * during each drag tick (not just the initial value). */
+    const MAX_NOTES_H_RATIO = 0.6;
+    let notesHeight = (() => {
+      try {
+        const raw = window.localStorage.getItem(NOTES_STORAGE_KEY);
+        const n = raw ? Number.parseInt(raw, 10) : NaN;
+        if (!Number.isFinite(n)) return DEFAULT_NOTES_H;
+        return Math.max(MIN_NOTES_H, n);
+      } catch {
+        return DEFAULT_NOTES_H;
+      }
+    })();
 
     const notesHost = document.createElement("div");
+    notesHost.style.height = `${notesHeight}px`;
+    notesHost.style.flexShrink = "0";
+    notesHost.style.overflow = "auto";
     right.appendChild(notesHost);
 
     layout.appendChild(right);
@@ -390,21 +461,19 @@ export function SlidesView({
     onEditorReady?.(editor);
     onStoreReady?.(store);
 
-    // Auto-fit the canvas to the right column. Re-fits on ResizeObserver
-    // ticks (window resize, sidebar collapse, devtools open). Caps at
-    // MAX_HOST_W so we don't paint a 4K bitmap on ultra-wide displays
-    // — the slide is logically 1920×1080 anyway.
-    const resizeObserver = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-      const rightRect = entry.contentRect;
-      // Reserve room for the notes panel below the canvas + the column
-      // gap (12px). The notes panel is content-sized so we can't query
-      // a fixed value; subtract a generous reservation that errs on the
-      // side of leaving the canvas a bit small rather than overflowing.
-      const reservedForNotes = notesHost.getBoundingClientRect().height + 12;
+    // Refit canvas to the right column, taking the current notes height
+    // into account. Extracted into a function because two paths call
+    // it: the ResizeObserver below, and the notes-drag handler (where
+    // `notesHeight` changes without `right`'s own size changing).
+    const refitCanvas = () => {
+      const rightRect = right.getBoundingClientRect();
+      // Notes section reserves its own height + the 6 px resizer.
+      const reservedBelow = notesHeight + 6;
       const availW = Math.max(MIN_HOST_W, Math.min(MAX_HOST_W, rightRect.width));
-      const availH = Math.max(MIN_HOST_W / SLIDE_ASPECT, rightRect.height - reservedForNotes);
+      const availH = Math.max(
+        MIN_HOST_W / SLIDE_ASPECT,
+        rightRect.height - reservedBelow,
+      );
       // Reserve the ruler gutter so the slide canvas itself never
       // overflows the right column: canvasWrap outer = host + gutter.
       const slideAvailW = Math.max(MIN_HOST_W, availW - SLIDES_RULER_SIZE);
@@ -424,7 +493,13 @@ export function SlidesView({
       canvasWrap.style.width = `${hostW + SLIDES_RULER_SIZE}px`;
       canvasWrap.style.height = `${hostH + SLIDES_RULER_SIZE}px`;
       editor.setHostSize(hostW, hostH);
-    });
+    };
+
+    // Auto-fit the canvas to the right column. Re-fits on ResizeObserver
+    // ticks (window resize, sidebar collapse, devtools open). Caps at
+    // MAX_HOST_W so we don't paint a 4K bitmap on ultra-wide displays
+    // — the slide is logically 1920×1080 anyway.
+    const resizeObserver = new ResizeObserver(() => refitCanvas());
     resizeObserver.observe(right);
 
     // Drag-to-resize the left column. Mousedown latches; mousemove
@@ -434,6 +509,11 @@ export function SlidesView({
     let dragging = false;
     let dragStartX = 0;
     let dragStartLeft = 0;
+    // Notes drag is a sibling state machine — single document
+    // mousemove / mouseup pair routes both gestures.
+    let draggingNotes = false;
+    let dragStartY = 0;
+    let dragStartNotesH = 0;
     const onResizerDown = (e: MouseEvent) => {
       e.preventDefault();
       dragging = true;
@@ -444,28 +524,73 @@ export function SlidesView({
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
     };
+    const onNotesResizerDown = (e: MouseEvent) => {
+      e.preventDefault();
+      draggingNotes = true;
+      dragStartY = e.clientY;
+      dragStartNotesH = notesHeight;
+      document.body.style.cursor = "row-resize";
+      document.body.style.userSelect = "none";
+    };
     const onDocMouseMove = (e: MouseEvent) => {
-      if (!dragging) return;
-      const next = Math.min(
-        MAX_LEFT_W,
-        Math.max(MIN_LEFT_W, dragStartLeft + (e.clientX - dragStartX)),
-      );
-      if (next === leftWidth) return;
-      leftWidth = next;
-      layout.style.gridTemplateColumns = `${leftWidth}px 6px 1fr`;
+      if (dragging) {
+        const next = Math.min(
+          MAX_LEFT_W,
+          Math.max(MIN_LEFT_W, dragStartLeft + (e.clientX - dragStartX)),
+        );
+        if (next === leftWidth) return;
+        leftWidth = next;
+        layout.style.gridTemplateColumns = `${leftWidth}px 6px 1fr`;
+        return;
+      }
+      if (draggingNotes) {
+        const rightRect = right.getBoundingClientRect();
+        // Cap notes at MAX_NOTES_H_RATIO of the column so the canvas
+        // always gets the remaining 40 %+. Re-evaluated each tick so
+        // dragging works even after a window resize.
+        const maxH = Math.max(
+          MIN_NOTES_H,
+          Math.floor(rightRect.height * MAX_NOTES_H_RATIO),
+        );
+        // Drag UP (cursor moves up the screen) ⇒ notes grow taller.
+        const next = Math.min(
+          maxH,
+          Math.max(MIN_NOTES_H, dragStartNotesH - (e.clientY - dragStartY)),
+        );
+        if (next === notesHeight) return;
+        notesHeight = next;
+        notesHost.style.height = `${notesHeight}px`;
+        // The right column's outer height didn't change, so the
+        // ResizeObserver won't fire. Re-fit manually so the canvas
+        // shrinks / grows in step with the notes panel.
+        refitCanvas();
+      }
     };
     const onDocMouseUp = () => {
-      if (!dragging) return;
-      dragging = false;
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-      try {
-        window.localStorage.setItem(STORAGE_KEY, String(leftWidth));
-      } catch {
-        /* ignore quota / privacy-mode failures */
+      if (dragging) {
+        dragging = false;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        try {
+          window.localStorage.setItem(STORAGE_KEY, String(leftWidth));
+        } catch {
+          /* ignore quota / privacy-mode failures */
+        }
+        return;
+      }
+      if (draggingNotes) {
+        draggingNotes = false;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        try {
+          window.localStorage.setItem(NOTES_STORAGE_KEY, String(notesHeight));
+        } catch {
+          /* ignore quota / privacy-mode failures */
+        }
       }
     };
     resizer.addEventListener("mousedown", onResizerDown);
+    notesResizer.addEventListener("mousedown", onNotesResizerDown);
     document.addEventListener("mousemove", onDocMouseMove);
     document.addEventListener("mouseup", onDocMouseUp);
 
@@ -539,7 +664,7 @@ export function SlidesView({
       document.removeEventListener("mousemove", onDocMouseMove);
       document.removeEventListener("mouseup", onDocMouseUp);
       // If the user navigated mid-drag, restore body cursor / select.
-      if (dragging) {
+      if (dragging || draggingNotes) {
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
       }

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -266,35 +266,26 @@ export function SlidesView({
     right.style.minHeight = "0";
 
     // Canvas area: flex-1 column that vertically + horizontally
-    // centers the slide canvas inside the remaining space. Without
-    // this the slide hugs the top edge and leaves an awkward gap
-    // below — especially on tall viewports.
+    // centers the slide canvas inside the remaining space. The rulers
+    // sit on the area's top + left edges (NOT around the slide
+    // itself), so the slide can drift inside the frame while the
+    // ruler stays pinned. Padding-top / padding-left reserve the
+    // gutter the ruler occupies before the flex centering kicks in.
     const canvasArea = document.createElement("div");
+    canvasArea.style.position = "relative";
     canvasArea.style.flex = "1 1 auto";
     canvasArea.style.minHeight = "0";
     canvasArea.style.display = "flex";
     canvasArea.style.justifyContent = "center";
     canvasArea.style.alignItems = "center";
-
-    // Canvas + overlay live inside this wrapper, with the H/V rulers
-    // pinned to the wrapper's top + left edges. Sized later by the
-    // ResizeObserver below — mounting at MIN_HOST_W avoids a flash of
-    // an unsized canvas during the first layout pass.
-    const canvasWrap = document.createElement("div");
-    canvasWrap.style.position = "relative";
-
-    const initial = computeFitSize(MIN_HOST_W, MIN_HOST_W / SLIDE_ASPECT);
-    let hostW = initial.width;
-    let hostH = initial.height;
-    // The slide canvas is offset by the ruler gutter so canvasWrap's
-    // outer dimensions = host + ruler.
-    canvasWrap.style.width = `${hostW + SLIDES_RULER_SIZE}px`;
-    canvasWrap.style.height = `${hostH + SLIDES_RULER_SIZE}px`;
+    canvasArea.style.paddingTop = `${SLIDES_RULER_SIZE}px`;
+    canvasArea.style.paddingLeft = `${SLIDES_RULER_SIZE}px`;
 
     // Ruler DOM: corner square (top-left), horizontal canvas across
     // the top gutter, vertical canvas down the left gutter. All three
-    // are absolute relative to canvasWrap so they stay glued to the
-    // canvas as it resizes.
+    // are absolute to canvasArea so they hug the frame's edges
+    // regardless of where the slide ends up inside the centred
+    // content box.
     const rulerCorner = document.createElement("div");
     rulerCorner.style.position = "absolute";
     rulerCorner.style.left = "0";
@@ -302,30 +293,42 @@ export function SlidesView({
     rulerCorner.style.width = `${SLIDES_RULER_SIZE}px`;
     rulerCorner.style.height = `${SLIDES_RULER_SIZE}px`;
     rulerCorner.style.zIndex = "3";
-    canvasWrap.appendChild(rulerCorner);
+    canvasArea.appendChild(rulerCorner);
 
     const hRulerCanvas = document.createElement("canvas");
     hRulerCanvas.style.position = "absolute";
     hRulerCanvas.style.left = `${SLIDES_RULER_SIZE}px`;
+    hRulerCanvas.style.right = "0";
     hRulerCanvas.style.top = "0";
     hRulerCanvas.style.height = `${SLIDES_RULER_SIZE}px`;
     hRulerCanvas.style.zIndex = "2";
-    canvasWrap.appendChild(hRulerCanvas);
+    canvasArea.appendChild(hRulerCanvas);
 
     const vRulerCanvas = document.createElement("canvas");
     vRulerCanvas.style.position = "absolute";
     vRulerCanvas.style.left = "0";
     vRulerCanvas.style.top = `${SLIDES_RULER_SIZE}px`;
+    vRulerCanvas.style.bottom = "0";
     vRulerCanvas.style.width = `${SLIDES_RULER_SIZE}px`;
     vRulerCanvas.style.zIndex = "1";
-    canvasWrap.appendChild(vRulerCanvas);
+    canvasArea.appendChild(vRulerCanvas);
+
+    // Canvas + overlay live inside this wrapper at the slide's
+    // intrinsic host dimensions (no ruler offset — the ruler lives
+    // outside, on the canvas-area frame).
+    const canvasWrap = document.createElement("div");
+    canvasWrap.style.position = "relative";
+
+    const initial = computeFitSize(MIN_HOST_W, MIN_HOST_W / SLIDE_ASPECT);
+    let hostW = initial.width;
+    let hostH = initial.height;
+    canvasWrap.style.width = `${hostW}px`;
+    canvasWrap.style.height = `${hostH}px`;
 
     const canvas = document.createElement("canvas");
-    canvas.style.position = "absolute";
-    canvas.style.left = `${SLIDES_RULER_SIZE}px`;
-    canvas.style.top = `${SLIDES_RULER_SIZE}px`;
     canvas.width = hostW * dpr;
     canvas.height = hostH * dpr;
+    canvas.style.display = "block";
     canvas.style.width = `${hostW}px`;
     canvas.style.height = `${hostH}px`;
     canvas.style.background = "#fff";
@@ -344,8 +347,8 @@ export function SlidesView({
 
     const overlay = document.createElement("div");
     overlay.style.position = "absolute";
-    overlay.style.left = `${SLIDES_RULER_SIZE}px`;
-    overlay.style.top = `${SLIDES_RULER_SIZE}px`;
+    overlay.style.left = "0";
+    overlay.style.top = "0";
     overlay.style.width = `${hostW}px`;
     overlay.style.height = `${hostH}px`;
     overlay.style.pointerEvents = "none";
@@ -490,8 +493,8 @@ export function SlidesView({
       canvas.style.height = `${hostH}px`;
       overlay.style.width = `${hostW}px`;
       overlay.style.height = `${hostH}px`;
-      canvasWrap.style.width = `${hostW + SLIDES_RULER_SIZE}px`;
-      canvasWrap.style.height = `${hostH + SLIDES_RULER_SIZE}px`;
+      canvasWrap.style.width = `${hostW}px`;
+      canvasWrap.style.height = `${hostH}px`;
       editor.setHostSize(hostW, hostH);
     };
 

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -73,6 +73,19 @@ function clone<T>(value: T): T {
 }
 
 /**
+ * Reject `NaN` / `Infinity` before they reach the Yorkie root. The
+ * snap engine's `Math.abs(diff)` and the overlay's
+ * `position * scale` math both propagate `NaN` silently, so a bad
+ * value committed here would surface as a hard-to-diagnose
+ * downstream artifact rather than a clear error.
+ */
+function assertFiniteGuidePosition(op: string, position: number): void {
+  if (!Number.isFinite(position)) {
+    throw new Error(`${op}: position must be a finite number, got ${position}`);
+  }
+}
+
+/**
  * Convert a Yorkie object/array proxy to a plain JS value. Yorkie proxies
  * implement `toJSON()` that returns a JSON string (not a plain object), so
  * we parse it back. Returns the input unchanged when it doesn't have the
@@ -476,9 +489,18 @@ export class YorkieSlidesStore implements SlidesStore {
       // touches them needs them mirrored here. Until Task 5 ships the
       // theme-edit ops these arrays don't change, but writing them keeps
       // the Yorkie root consistent with the cloned snapshot.
-      const rootAny = r as { themes?: Theme[]; masters?: Master[] };
+      //
+      // Guides also live on the snapshot — without rewriting them here,
+      // undo / redo of addGuide / moveGuide / removeGuide silently
+      // diverges from the editor's pre-batch state.
+      const rootAny = r as {
+        themes?: Theme[];
+        masters?: Master[];
+        guides?: Array<{ id: string; axis: 'x' | 'y'; position: number }>;
+      };
       rootAny.themes = clone(snapshot.themes);
       rootAny.masters = clone(snapshot.masters);
+      rootAny.guides = clone(snapshot.guides ?? []);
       const nextSlides: YorkieSlide[] = snapshot.slides.map((s) => ({
         id: s.id,
         layoutId: s.layoutId,
@@ -1475,6 +1497,7 @@ export class YorkieSlidesStore implements SlidesStore {
 
   addGuide(axis: 'x' | 'y', position: number): string {
     this.requireBatch();
+    assertFiniteGuidePosition('addGuide', position);
     const id = generateId();
     this.doc.update((r) => {
       const rootAny = r as { guides?: Array<{ id: string; axis: 'x' | 'y'; position: number }> };
@@ -1486,6 +1509,7 @@ export class YorkieSlidesStore implements SlidesStore {
 
   moveGuide(id: string, position: number): void {
     this.requireBatch();
+    assertFiniteGuidePosition('moveGuide', position);
     this.doc.update((r) => {
       const rootAny = r as { guides?: Array<{ id: string; position: number }> };
       const guide = rootAny.guides?.find((g) => g.id === id);

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -151,12 +151,23 @@ export function ensureSlidesRoot(
   // ships the proper migration; this is the minimum to keep the
   // SlidesDocument well-formed.
   doc.update((r) => {
-    const rootAny = r as { themes?: Theme[]; masters?: Master[] };
+    const rootAny = r as {
+      themes?: Theme[];
+      masters?: Master[];
+      guides?: unknown[];
+    };
     if (rootAny.themes == null || rootAny.themes.length === 0) {
       rootAny.themes = [clone(defaultLight)];
     }
     if (rootAny.masters == null || rootAny.masters.length === 0) {
       rootAny.masters = [clone(DEFAULT_MASTER)];
+    }
+    // Pre-v0.4.2 (pre-ruler) docs predate the guides array. Lazy-init
+    // an empty list so the slides store and renderer can read it
+    // unconditionally. The first session writes the empty array; later
+    // attaches no-op.
+    if (rootAny.guides == null) {
+      rootAny.guides = [];
     }
     // Backfill `meta.themeId` / `meta.masterId` against the document's
     // own `themes` / `masters` arrays, not against hard-coded ids. A
@@ -297,15 +308,21 @@ export class YorkieSlidesStore implements SlidesStore {
       return { id, layoutId, background, elements, notes };
     });
     const layouts = (root.layouts ?? []).map((l) => yorkieToPlain<Layout>(l));
-    const rootAny = root as { themes?: unknown; masters?: unknown };
+    const rootAny = root as {
+      themes?: unknown;
+      masters?: unknown;
+      guides?: unknown;
+    };
     const themes = yorkieToPlain<Theme[]>(rootAny.themes);
     const masters = yorkieToPlain<Master[]>(rootAny.masters);
+    const guides = yorkieToPlain<unknown[]>(rootAny.guides);
     return migrateDocument({
       meta,
       themes,
       masters,
       slides,
       layouts,
+      guides,
     });
   }
 
@@ -1451,6 +1468,39 @@ export class YorkieSlidesStore implements SlidesStore {
       // Same rationale as withTextElement above — write back regardless
       // of whether `fn` returned a value or mutated in place.
       s.notes = clone(next ?? blocks) as unknown as YorkieSlide['notes'];
+    });
+  }
+
+  // --- guides (presentation-wide) ---
+
+  addGuide(axis: 'x' | 'y', position: number): string {
+    this.requireBatch();
+    const id = generateId();
+    this.doc.update((r) => {
+      const rootAny = r as { guides?: Array<{ id: string; axis: 'x' | 'y'; position: number }> };
+      if (rootAny.guides == null) rootAny.guides = [];
+      rootAny.guides.push({ id, axis, position });
+    });
+    return id;
+  }
+
+  moveGuide(id: string, position: number): void {
+    this.requireBatch();
+    this.doc.update((r) => {
+      const rootAny = r as { guides?: Array<{ id: string; position: number }> };
+      const guide = rootAny.guides?.find((g) => g.id === id);
+      if (!guide) throw new Error(`Guide not found: ${id}`);
+      guide.position = position;
+    });
+  }
+
+  removeGuide(id: string): void {
+    this.requireBatch();
+    this.doc.update((r) => {
+      const rootAny = r as { guides?: Array<{ id: string }> };
+      const idx = rootAny.guides?.findIndex((g) => g.id === id) ?? -1;
+      if (idx === -1) throw new Error(`Guide not found: ${id}`);
+      rootAny.guides!.splice(idx, 1);
     });
   }
 

--- a/packages/frontend/src/types/slides-document.ts
+++ b/packages/frontend/src/types/slides-document.ts
@@ -37,6 +37,19 @@ export interface YorkieSlidesRoot {
   layouts: YorkieLayout[];
   themes?: Theme[];
   masters?: Master[];
+  /**
+   * Presentation-wide alignment guides. Optional in the Yorkie root
+   * because pre-v0.4.2 documents predate the ruler; `ensureSlidesRoot`
+   * lazy-inits an empty array on attach so consumers never see
+   * `undefined`. See docs/design/slides/slides-ruler.md.
+   */
+  guides?: YorkieGuide[];
+}
+
+export interface YorkieGuide {
+  id: string;
+  axis: 'x' | 'y';
+  position: number;
 }
 
 export interface YorkieSlide {

--- a/packages/frontend/src/types/users.ts
+++ b/packages/frontend/src/types/users.ts
@@ -51,4 +51,15 @@ export type SlidesPresence = {
     h: number;
     rotation: number;
   }>;
+  /**
+   * Live preview of a guide being created from the ruler or an
+   * existing guide being dragged. `id` is absent when the user is
+   * creating a new guide; present when an existing guide is moving.
+   * Cleared on mouseup. See docs/design/slides/slides-ruler.md.
+   */
+  draggingGuide?: {
+    id?: string;
+    axis: 'x' | 'y';
+    position: number;
+  };
 };

--- a/packages/slides/src/import/pptx/index.ts
+++ b/packages/slides/src/import/pptx/index.ts
@@ -133,6 +133,7 @@ export async function importPptx(
     masters,
     layouts,
     slides,
+    guides: [],
   };
 
   return { document, report };

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -13,6 +13,8 @@ export { ImportReport } from './import/pptx/report';
 export type {
   Background,
   BackgroundImage,
+  Guide,
+  GuideAxis,
   Layout,
   Meta,
   PlaceholderSpec,

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -135,6 +135,15 @@ export { collectSnapCandidates } from './view/editor/snap-candidates';
 
 // View — Editor (Phase 3a)
 export { initialize as initializeEditor, type SlidesEditor, type SlidesEditorOptions, type InsertKind, type ConnectorInsertKind } from './view/editor/editor';
+
+// View — Ruler (H/V rulers + future guides)
+export {
+  SlidesRuler,
+  RULER_SIZE as SLIDES_RULER_SIZE,
+  SLIDES_PX_PER_INCH,
+  type SlidesRulerOptions,
+  type SlidesRulerViewport,
+} from './view/editor/ruler';
 export type { SlidesTextBoxEditor } from './view/editor/text-box-editor';
 export type { AlignDirection, DistributeAxis, AlignReference } from './view/editor/align';
 

--- a/packages/slides/src/model/migrate.ts
+++ b/packages/slides/src/model/migrate.ts
@@ -1,6 +1,7 @@
-import type { SlidesDocument } from './presentation';
+import type { Guide, GuideAxis, SlidesDocument } from './presentation';
 import type { ThemeColor } from './theme';
 import { DEFAULT_MASTER } from './master';
+import { generateId } from './element';
 import { defaultLight } from '../themes/default-light';
 
 const LAYOUT_ID_MIGRATIONS: Record<string, string> = {
@@ -29,12 +30,27 @@ export function migrateDocument(input: unknown): SlidesDocument {
   return { meta, themes, masters, layouts, slides, guides };
 }
 
-function migrateGuide(g: any): any {
-  return {
-    id: g?.id,
-    axis: g?.axis === 'y' ? 'y' : 'x',
-    position: typeof g?.position === 'number' ? g.position : 0,
-  };
+/**
+ * Normalise an arbitrary guide-shaped value into a well-typed
+ * `Guide`. Two hardenings vs. raw shape pass-through:
+ *
+ * - **id**: synthesised when missing or non-string. Without this the
+ *   editor's hit-test treats a guide-shaped object as targetable
+ *   (axis + position are enough) but moveGuide / removeGuide call
+ *   into the store with `undefined`, which then throws
+ *   `Guide not found: undefined`.
+ * - **position**: only accepted if finite. `NaN` / `Infinity` would
+ *   otherwise propagate into the snap engine's `Math.abs(diff)` math
+ *   and corrupt drag dx/dy, and into the overlay's
+ *   `position * scale` arithmetic.
+ */
+function migrateGuide(g: any): Guide {
+  const id = typeof g?.id === 'string' && g.id.length > 0 ? g.id : generateId();
+  const axis: GuideAxis = g?.axis === 'y' ? 'y' : 'x';
+  const rawPos = g?.position;
+  const position =
+    typeof rawPos === 'number' && Number.isFinite(rawPos) ? rawPos : 0;
+  return { id, axis, position };
 }
 
 function migrateLayout(layout: any): any {

--- a/packages/slides/src/model/migrate.ts
+++ b/packages/slides/src/model/migrate.ts
@@ -22,7 +22,19 @@ export function migrateDocument(input: unknown): SlidesDocument {
     : [DEFAULT_MASTER];
   const layouts = Array.isArray(raw?.layouts) ? raw.layouts.map(migrateLayout) : [];
   const slides = Array.isArray(raw?.slides) ? raw.slides.map(migrateSlide) : [];
-  return { meta, themes, masters, layouts, slides };
+  // Pre-ruler decks did not carry `guides`. Default to an empty array
+  // so consumers downstream never see undefined and the read-path stays
+  // shape-stable across pre- / post-v0.4.2 documents.
+  const guides = Array.isArray(raw?.guides) ? raw.guides.map(migrateGuide) : [];
+  return { meta, themes, masters, layouts, slides, guides };
+}
+
+function migrateGuide(g: any): any {
+  return {
+    id: g?.id,
+    axis: g?.axis === 'y' ? 'y' : 'x',
+    position: typeof g?.position === 'number' ? g.position : 0,
+  };
 }
 
 function migrateLayout(layout: any): any {

--- a/packages/slides/src/model/presentation.ts
+++ b/packages/slides/src/model/presentation.ts
@@ -49,12 +49,32 @@ export type Meta = {
   masterId: string;
 };
 
+export type GuideAxis = 'x' | 'y';
+
+/**
+ * Presentation-wide alignment guide. A guide is an infinite line at a
+ * fixed slide-x (axis: 'x' → vertical guide) or slide-y (axis: 'y' →
+ * horizontal guide) value, shared across every slide in the deck.
+ * Phase 3 adds the data model + passive render; user-driven create /
+ * move / delete arrives in Phase 4.
+ *
+ * See docs/design/slides/slides-ruler.md.
+ */
+export type Guide = {
+  id: string;
+  axis: GuideAxis;
+  /** Slide logical px, clamped by callers into the slide's extent. */
+  position: number;
+};
+
 export type SlidesDocument = {
   meta: Meta;
   themes: Theme[];
   masters: Master[];
   layouts: Layout[];
   slides: Slide[];
+  /** Presentation-wide alignment guides. See {@link Guide}. */
+  guides: Guide[];
 };
 
 export const DEFAULT_BACKGROUND: Background = {

--- a/packages/slides/src/node.ts
+++ b/packages/slides/src/node.ts
@@ -26,6 +26,8 @@
 export type {
   Background,
   BackgroundImage,
+  Guide,
+  GuideAxis,
   Layout,
   Meta,
   PlaceholderSpec,

--- a/packages/slides/src/store/memory.ts
+++ b/packages/slides/src/store/memory.ts
@@ -1,6 +1,8 @@
 import type { SlidesStore } from './store';
 import type {
   Background,
+  Guide,
+  GuideAxis,
   Slide,
   SlidesDocument,
 } from '../model/presentation';
@@ -50,6 +52,7 @@ function emptyDocument(): SlidesDocument {
     masters: [clone(DEFAULT_MASTER)],
     layouts: clone(BUILT_IN_LAYOUTS),
     slides: [],
+    guides: [],
   };
 }
 
@@ -868,6 +871,30 @@ export class MemSlidesStore implements SlidesStore {
     if (next !== undefined) {
       slide.notes = clone(next);
     }
+  }
+
+  // --- guides ---
+
+  addGuide(axis: GuideAxis, position: number): string {
+    this.requireBatch();
+    const id = generateId();
+    const guide: Guide = { id, axis, position };
+    this.doc.guides.push(guide);
+    return id;
+  }
+
+  moveGuide(id: string, position: number): void {
+    this.requireBatch();
+    const guide = this.doc.guides.find((g) => g.id === id);
+    if (!guide) throw new Error(`Guide not found: ${id}`);
+    guide.position = position;
+  }
+
+  removeGuide(id: string): void {
+    this.requireBatch();
+    const idx = this.doc.guides.findIndex((g) => g.id === id);
+    if (idx === -1) throw new Error(`Guide not found: ${id}`);
+    this.doc.guides.splice(idx, 1);
   }
 
   // --- transactions ---

--- a/packages/slides/src/store/memory.ts
+++ b/packages/slides/src/store/memory.ts
@@ -41,6 +41,19 @@ import {
   applyGroupTransformToPoint,
 } from '../import/pptx/group';
 
+/**
+ * Throw early when a caller passes `NaN` / `Infinity` into a guide
+ * mutator. The renderer's `position * scale` math and the snap
+ * engine's `Math.abs(diff)` both propagate `NaN` silently, so
+ * letting a bad value reach the store would surface as a hard-to-
+ * diagnose downstream artifact.
+ */
+function assertFinitePosition(op: string, position: number): void {
+  if (!Number.isFinite(position)) {
+    throw new Error(`${op}: position must be a finite number, got ${position}`);
+  }
+}
+
 function emptyDocument(): SlidesDocument {
   return {
     meta: {
@@ -877,6 +890,7 @@ export class MemSlidesStore implements SlidesStore {
 
   addGuide(axis: GuideAxis, position: number): string {
     this.requireBatch();
+    assertFinitePosition('addGuide', position);
     const id = generateId();
     const guide: Guide = { id, axis, position };
     this.doc.guides.push(guide);
@@ -885,6 +899,7 @@ export class MemSlidesStore implements SlidesStore {
 
   moveGuide(id: string, position: number): void {
     this.requireBatch();
+    assertFinitePosition('moveGuide', position);
     const guide = this.doc.guides.find((g) => g.id === id);
     if (!guide) throw new Error(`Guide not found: ${id}`);
     guide.position = position;

--- a/packages/slides/src/store/store.ts
+++ b/packages/slides/src/store/store.ts
@@ -1,5 +1,9 @@
 import type { Block } from '@wafflebase/docs';
-import type { Background, SlidesDocument } from '../model/presentation';
+import type {
+  Background,
+  GuideAxis,
+  SlidesDocument,
+} from '../model/presentation';
 import type { ArrowheadStyle, Endpoint } from '../model/connector';
 import type { ElementInit, Frame } from '../model/element';
 import type { Theme } from '../model/theme';
@@ -140,6 +144,18 @@ export interface SlidesStore {
     elementId: string,
     stroke: import('../model/element').Stroke | undefined,
   ): void;
+
+  // --- guides (presentation-wide) ---
+
+  /**
+   * Insert a presentation-wide alignment guide. Returns the new guide id.
+   * Callers should clamp `position` into the slide's extent
+   * (`[0, SLIDE_WIDTH]` for axis `'x'`, `[0, SLIDE_HEIGHT]` for `'y'`)
+   * before calling; the store is geometry-agnostic.
+   */
+  addGuide(axis: GuideAxis, position: number): string;
+  moveGuide(id: string, position: number): void;
+  removeGuide(id: string): void;
 
   // --- text bridges (Phase 5 wires these to docs Tree) ---
 

--- a/packages/slides/src/view/canvas/layout-preview.ts
+++ b/packages/slides/src/view/canvas/layout-preview.ts
@@ -77,6 +77,7 @@ export function renderLayoutPreview(
     masters: [master],
     layouts: [layout],
     slides: [slide],
+    guides: [],
   };
   renderThumbnail(ctx, slide, doc, {
     hostWidth: size.w,

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -47,6 +47,7 @@ import {
 import { runKeyRules, type KeyRule } from './keymap';
 import { showLayoutPicker } from './layout-picker';
 import { renderOverlay } from './overlay';
+import { SlidesRuler } from './ruler/ruler';
 import { Selection } from './selection';
 import { hitTestSlide } from './hit-test-elements';
 import { snapDelta, type SnapGuide } from './snap';
@@ -137,6 +138,17 @@ export interface SlidesEditorOptions extends SlideRendererOptions {
    * share-link viewers — see `shared-document.tsx`.
    */
   readOnly?: boolean;
+  /**
+   * Optional H/V ruler DOM hosts. When all three are supplied the
+   * editor instantiates a `SlidesRuler` and paints it on every
+   * `render()` / `setHostSize()` call. Omitting them keeps the
+   * editor ruler-free (mobile mount, headless tests). Drag-out and
+   * guide interactions land in a later phase; this PR is display
+   * only — see docs/design/slides/slides-ruler.md.
+   */
+  hRulerCanvas?: HTMLCanvasElement;
+  vRulerCanvas?: HTMLCanvasElement;
+  rulerCorner?: HTMLElement;
 }
 
 export interface SlidesEditor {
@@ -409,6 +421,13 @@ class SlidesEditorImpl implements SlidesEditor {
   private hitCtx: HitTestCtx;
   /** Per-shell click tolerance (slide-logical pixels). */
   private hitTolerance = DEFAULT_HIT_TOLERANCE;
+  /**
+   * Optional H/V ruler. Instantiated only when the host passes all
+   * three ruler DOM refs (`hRulerCanvas`, `vRulerCanvas`,
+   * `rulerCorner`). Painted at the end of every `render()` so it
+   * stays in lock-step with the slide canvas size/zoom.
+   */
+  private ruler: SlidesRuler | null = null;
 
   constructor(options: SlidesEditorOptions) {
     this.options = options;
@@ -416,6 +435,17 @@ class SlidesEditorImpl implements SlidesEditor {
     if (!ctx) throw new Error('SlidesEditor: canvas has no 2D context');
     this.hitCtx = ctx;
     this.renderer = new SlideRenderer(ctx, options);
+    if (
+      options.hRulerCanvas !== undefined &&
+      options.vRulerCanvas !== undefined &&
+      options.rulerCorner !== undefined
+    ) {
+      this.ruler = new SlidesRuler({
+        hCanvas: options.hRulerCanvas,
+        vCanvas: options.vRulerCanvas,
+        corner: options.rulerCorner,
+      });
+    }
     this.currentId = options.store.read().slides[0]?.id;
     this.mountTextBox = options.mountTextBox ?? mountSlidesTextBox;
     this.selection.subscribe(() => {
@@ -580,7 +610,10 @@ class SlidesEditorImpl implements SlidesEditor {
     const doc = this.options.store.read();
     const id = this.currentId;
     const slide = id ? doc.slides.find((s) => s.id === id) : undefined;
-    if (!slide) return;
+    if (!slide) {
+      this.paintRuler();
+      return;
+    }
     // Hide the element currently in edit mode from the slide canvas —
     // the text-box editor's own canvas is layered on top of the same
     // frame, so leaving the element in the slide pass would double-paint
@@ -593,9 +626,19 @@ class SlidesEditorImpl implements SlidesEditor {
         elements: slide.elements.filter((e) => e.id !== editingId),
       };
       this.renderer.forceRender(visible, doc);
+      this.paintRuler();
       return;
     }
     this.renderer.render(slide, doc);
+    this.paintRuler();
+  }
+
+  private paintRuler(): void {
+    if (this.ruler === null) return;
+    this.ruler.render({
+      hostWidth: this.options.hostWidth,
+      hostHeight: this.options.hostHeight,
+    });
   }
 
   getSelection(): readonly string[] {
@@ -1041,6 +1084,8 @@ class SlidesEditorImpl implements SlidesEditor {
       target.removeEventListener(type, handler as EventListener);
     }
     this.listeners.length = 0;
+    this.ruler?.dispose();
+    this.ruler = null;
   }
 
   /** Internal helper used by interaction modules in T3-T7. */

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -2055,6 +2055,7 @@ class SlidesEditorImpl implements SlidesEditor {
         rawDy,
         otherFrames,
         { w: SLIDE_WIDTH, h: SLIDE_HEIGHT },
+        this.options.store.read().guides,
       );
       liveDx = dx;
       liveDy = dy;

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -48,6 +48,12 @@ import { runKeyRules, type KeyRule } from './keymap';
 import { showLayoutPicker } from './layout-picker';
 import { renderOverlay } from './overlay';
 import { SlidesRuler } from './ruler/ruler';
+import {
+  hitTestGuide,
+  startGuideMove,
+  startRulerDragOut,
+  type GuideDragHost,
+} from './ruler/interactions';
 import { Selection } from './selection';
 import { hitTestSlide } from './hit-test-elements';
 import { snapDelta, type SnapGuide } from './snap';
@@ -428,6 +434,15 @@ class SlidesEditorImpl implements SlidesEditor {
    * stays in lock-step with the slide canvas size/zoom.
    */
   private ruler: SlidesRuler | null = null;
+  /**
+   * Live preview of a guide being created from the ruler or an
+   * existing guide being repositioned. Non-null only while a drag is
+   * in flight; cleared on commit / cancel. Repaints flow through
+   * `repaintOverlay` which forwards this to the overlay renderer.
+   */
+  private pendingGuide:
+    | { id?: string; axis: 'x' | 'y'; position: number }
+    | null = null;
 
   constructor(options: SlidesEditorOptions) {
     this.options = options;
@@ -494,6 +509,7 @@ class SlidesEditorImpl implements SlidesEditor {
         slideWidth: SLIDE_WIDTH,
         slideHeight: SLIDE_HEIGHT,
         permanentGuides: doc.guides,
+      pendingGuide: this.pendingGuide,
       });
       this.reattachEditingTextBox();
       return;
@@ -538,6 +554,7 @@ class SlidesEditorImpl implements SlidesEditor {
       allElements: slide.elements,
       connectorAffordance: this.connectorAffordance(),
       permanentGuides: doc.guides,
+      pendingGuide: this.pendingGuide,
     });
     // renderOverlay clears `overlay.innerHTML` on every call, which
     // would also unmount the text-box container. Re-append it after
@@ -1156,6 +1173,88 @@ class SlidesEditorImpl implements SlidesEditor {
     const onContext = (e: Event) => this.onContextMenu(e as MouseEvent);
     this.on(this.options.canvas, 'contextmenu', onContext);
     this.on(this.options.overlay, 'contextmenu', onContext);
+
+    // Ruler drag-out: pressing on either ruler canvas seeds a pending
+    // guide that follows the cursor. The drag is owned by
+    // `startRulerDragOut` (it attaches its own document-level
+    // pointermove / pointerup) so the gesture continues even if the
+    // cursor wanders off the ruler. Only bound when the host actually
+    // mounted the ruler (read-only viewers skip the ruler-canvas
+    // listener entirely so even pointermove on the ruler is inert).
+    if (this.options.hRulerCanvas !== undefined) {
+      this.on(this.options.hRulerCanvas, 'pointerdown', (e) => {
+        startRulerDragOut(this.guideDragHost(), 'x', e as PointerEvent);
+      });
+    }
+    if (this.options.vRulerCanvas !== undefined) {
+      this.on(this.options.vRulerCanvas, 'pointerdown', (e) => {
+        startRulerDragOut(this.guideDragHost(), 'y', e as PointerEvent);
+      });
+    }
+  }
+
+  /**
+   * Set the in-flight guide preview state and trigger an overlay
+   * repaint. Passing `null` clears the preview. The interaction module
+   * uses this through the `GuideDragHost` interface; the editor's
+   * `repaintOverlay` reads `this.pendingGuide` to render the preview.
+   */
+  private setPendingGuide(
+    guide: { id?: string; axis: 'x' | 'y'; position: number } | null,
+  ): void {
+    this.pendingGuide = guide;
+    this.repaintOverlay();
+  }
+
+  /**
+   * Compose the GuideDragHost backed by editor state. Captures
+   * coordinate-conversion + region tests so the ruler interaction
+   * module stays unaware of zoom / DPR / DOM layout.
+   */
+  private guideDragHost(): GuideDragHost {
+    return {
+      setPendingGuide: (guide) => this.setPendingGuide(guide),
+      commitAddGuide: (axis, position) => {
+        this.options.store.batch(() => {
+          this.options.store.addGuide(axis, position);
+        });
+      },
+      commitMoveGuide: (id, position) => {
+        this.options.store.batch(() => {
+          this.options.store.moveGuide(id, position);
+        });
+      },
+      commitRemoveGuide: (id) => {
+        this.options.store.batch(() => {
+          this.options.store.removeGuide(id);
+        });
+      },
+      readGuides: () => this.options.store.read().guides,
+      clientToLogical: (cx, cy) => this.clientToLogical(cx, cy),
+      isOverRuler: (cx, cy) => {
+        const h = this.options.hRulerCanvas;
+        const v = this.options.vRulerCanvas;
+        if (h !== undefined) {
+          const r = h.getBoundingClientRect();
+          if (cx >= r.left && cx <= r.right && cy >= r.top && cy <= r.bottom) {
+            return 'h';
+          }
+        }
+        if (v !== undefined) {
+          const r = v.getBoundingClientRect();
+          if (cx >= r.left && cx <= r.right && cy >= r.top && cy <= r.bottom) {
+            return 'v';
+          }
+        }
+        return null;
+      },
+      isInsideSlide: (x, y) =>
+        x >= 0 && x <= SLIDE_WIDTH && y >= 0 && y <= SLIDE_HEIGHT,
+      setBodyCursor: (cursor) => {
+        if (typeof document === 'undefined') return;
+        document.body.style.cursor = cursor ?? '';
+      },
+    };
   }
 
   private onContextMenu(e: MouseEvent): void {
@@ -1167,6 +1266,19 @@ class SlidesEditorImpl implements SlidesEditor {
     const { x, y } = this.clientToLogical(e.clientX, e.clientY);
     const hitResult = hitTestSlide(slide, x, y, this.hitOptions());
     if (hitResult === null) {
+      // Guide hit takes precedence over the empty-canvas menu when the
+      // user right-clicks directly on / near an alignment guide. Same
+      // 4-px hit zone as pointerdown.
+      const guide = hitTestGuide(this.options.store.read().guides, { x, y });
+      if (guide !== null) {
+        showContextMenu(
+          document.body,
+          this.guideContextItems(guide.id, guide.axis),
+          e.clientX,
+          e.clientY,
+        );
+        return;
+      }
       showContextMenu(document.body, this.canvasContextItems(x, y), e.clientX, e.clientY);
       return;
     }
@@ -1217,6 +1329,46 @@ class SlidesEditorImpl implements SlidesEditor {
       { label: 'Send backward',  run: () => this.dispatchKey('ArrowDown', { meta: true }) },
       { label: 'Bring to front', run: () => this.dispatchKey('ArrowUp',   { meta: true, shift: true }) },
       { label: 'Send to back',   run: () => this.dispatchKey('ArrowDown', { meta: true, shift: true }) },
+    ];
+  }
+
+  private guideContextItems(
+    guideId: string,
+    axis: 'x' | 'y',
+  ): ContextMenuItem[] {
+    const store = this.options.store;
+    return [
+      {
+        label: 'Delete guide',
+        run: () => {
+          store.batch(() => store.removeGuide(guideId));
+        },
+      },
+      {
+        label: axis === 'x'
+          ? 'Delete all vertical guides'
+          : 'Delete all horizontal guides',
+        run: () => {
+          const ids = store
+            .read()
+            .guides.filter((g) => g.axis === axis)
+            .map((g) => g.id);
+          if (ids.length === 0) return;
+          store.batch(() => {
+            for (const id of ids) store.removeGuide(id);
+          });
+        },
+      },
+      {
+        label: 'Delete all guides',
+        run: () => {
+          const ids = store.read().guides.map((g) => g.id);
+          if (ids.length === 0) return;
+          store.batch(() => {
+            for (const id of ids) store.removeGuide(id);
+          });
+        },
+      },
     ];
   }
 
@@ -1326,6 +1478,17 @@ class SlidesEditorImpl implements SlidesEditor {
     // (which descends into groups) and route through Selection.click so the
     // drill-in state machine picks the right element at the current scope.
     const hitResult = hitTestSlide(slide, x, y, this.hitOptions());
+    if (hitResult === null) {
+      // No element under the pointer — check for an alignment guide
+      // within the 4-px hit zone. Elements take precedence (guides are
+      // editor scaffolding that lives "underneath" content); guides
+      // pre-empt the empty-canvas fallbacks below (lasso, drill-out).
+      const guide = hitTestGuide(this.options.store.read().guides, { x, y });
+      if (guide !== null) {
+        startGuideMove(this.guideDragHost(), guide, e as PointerEvent);
+        return;
+      }
+    }
     if (hitResult !== null) {
       const mods = { shift: e.shiftKey };
       // If the scope-level element under the pointer is already in the
@@ -1557,7 +1720,16 @@ class SlidesEditorImpl implements SlidesEditor {
     if (this.editingElementId !== null) return;
     if (this.handleAtClient(e.clientX, e.clientY) !== null) return;
 
-    const desired = this.isPointerOverSelected(e.clientX, e.clientY) ? 'move' : '';
+    let desired = '';
+    if (this.isPointerOverSelected(e.clientX, e.clientY)) {
+      desired = 'move';
+    } else {
+      const { x, y } = this.clientToLogical(e.clientX, e.clientY);
+      const guide = hitTestGuide(this.options.store.read().guides, { x, y });
+      if (guide !== null) {
+        desired = guide.axis === 'x' ? 'col-resize' : 'row-resize';
+      }
+    }
     if (this.lastHoverCursor === desired) return;
     this.lastHoverCursor = desired;
     this.options.canvas.style.cursor = desired;
@@ -2041,6 +2213,7 @@ class SlidesEditorImpl implements SlidesEditor {
       allElements: synthetic.elements,
       connectorAffordance: this.connectorAffordance(),
       permanentGuides: this.options.store.read().guides,
+      pendingGuide: this.pendingGuide,
     });
   }
 
@@ -2071,6 +2244,7 @@ class SlidesEditorImpl implements SlidesEditor {
       allElements: slide.elements,
       connectorAffordance: this.connectorAffordance(),
       permanentGuides: this.options.store.read().guides,
+      pendingGuide: this.pendingGuide,
     });
   }
 

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -484,12 +484,16 @@ class SlidesEditorImpl implements SlidesEditor {
   }
 
   private repaintOverlay(): void {
-    const slide = this.currentSlide();
+    const doc = this.options.store.read();
+    const slide = this.currentId
+      ? doc.slides.find((s) => s.id === this.currentId)
+      : undefined;
     if (!slide) {
       renderOverlay(this.options.overlay, [], {
         scale: this.scale(),
         slideWidth: SLIDE_WIDTH,
         slideHeight: SLIDE_HEIGHT,
+        permanentGuides: doc.guides,
       });
       this.reattachEditingTextBox();
       return;
@@ -533,6 +537,7 @@ class SlidesEditorImpl implements SlidesEditor {
       // pass always.
       allElements: slide.elements,
       connectorAffordance: this.connectorAffordance(),
+      permanentGuides: doc.guides,
     });
     // renderOverlay clears `overlay.innerHTML` on every call, which
     // would also unmount the text-box container. Re-append it after
@@ -1053,6 +1058,15 @@ class SlidesEditorImpl implements SlidesEditor {
 
   markDirty(): void {
     this.renderer.markDirty();
+    // External markDirty signals "the store changed in a way the editor
+    // didn't initiate" (remote Yorkie edit, host shell mutation outside
+    // an interaction handler). Both the canvas AND the overlay need to
+    // refresh — the overlay carries permanent guides and selection
+    // chrome that may now reference different ids / positions. Internal
+    // mutators call `renderer.markDirty()` directly + their own
+    // `repaintOverlay()`, so this branch only fires for external
+    // signals and doesn't double-paint.
+    this.repaintOverlay();
   }
 
   detach(): void {
@@ -2026,6 +2040,7 @@ class SlidesEditorImpl implements SlidesEditor {
       guides,
       allElements: synthetic.elements,
       connectorAffordance: this.connectorAffordance(),
+      permanentGuides: this.options.store.read().guides,
     });
   }
 
@@ -2055,6 +2070,7 @@ class SlidesEditorImpl implements SlidesEditor {
       guides,
       allElements: slide.elements,
       connectorAffordance: this.connectorAffordance(),
+      permanentGuides: this.options.store.read().guides,
     });
   }
 
@@ -2686,6 +2702,10 @@ class SlidesEditorImpl implements SlidesEditor {
 export function initialize(options: SlidesEditorOptions): SlidesEditor {
   const editor = new SlidesEditorImpl(options);
   editor.render();
+  // Paint the overlay once on mount so deck-wide chrome (permanent
+  // guides) is visible before any user interaction. Selection is empty
+  // at this point so the only overlay output is the guides themselves.
+  editor.markDirty();
   return editor;
 }
 

--- a/packages/slides/src/view/editor/notes-panel.ts
+++ b/packages/slides/src/view/editor/notes-panel.ts
@@ -38,19 +38,25 @@ export function mountNotesPanel(
   const ta = document.createElement('textarea');
   ta.placeholder = 'Speaker notes…';
   ta.readOnly = readOnly;
+  // Fill the host's drag-resized height instead of carrying its own
+  // intrinsic size. The slides editor shell owns the notes resizer
+  // affordance, so the textarea here is a content slot — no border,
+  // no rounded box, no user-resize handle.
   ta.style.width = '100%';
-  ta.style.minHeight = '80px';
+  ta.style.height = '100%';
+  ta.style.boxSizing = 'border-box';
+  ta.style.resize = 'none';
   // Theme tokens from shadcn (frontend's index.css) so the textarea
-  // follows the surrounding light/dark mode. Fallbacks keep jsdom and
-  // theme-less hosts on a sensible dark surface.
-  ta.style.background = 'var(--background, #2a2a2a)';
+  // follows the surrounding light/dark mode. Background stays
+  // transparent so the panel blends with the editor column instead of
+  // floating as its own boxy surface.
+  ta.style.background = 'transparent';
   ta.style.color = 'var(--foreground, #ddd)';
-  ta.style.border = '1px solid var(--border, #444)';
-  ta.style.borderRadius = '4px';
+  ta.style.border = 'none';
+  ta.style.outline = 'none';
   ta.style.padding = '8px';
   ta.style.fontFamily = 'system-ui, sans-serif';
   ta.style.fontSize = '14px';
-  ta.style.resize = 'vertical';
   container.appendChild(ta);
 
   const sync = (): void => {

--- a/packages/slides/src/view/editor/notes-panel.ts
+++ b/packages/slides/src/view/editor/notes-panel.ts
@@ -35,7 +35,9 @@ export function mountNotesPanel(
 ): NotesPanelHandle {
   const readOnly = options.readOnly === true;
   container.innerHTML = '';
+  ensureNotesPanelStyles();
   const ta = document.createElement('textarea');
+  ta.className = 'wfb-slides-notes-ta';
   ta.placeholder = 'Speaker notes…';
   ta.readOnly = readOnly;
   // Fill the host's drag-resized height instead of carrying its own
@@ -49,7 +51,10 @@ export function mountNotesPanel(
   // Theme tokens from shadcn (frontend's index.css) so the textarea
   // follows the surrounding light/dark mode. Background stays
   // transparent so the panel blends with the editor column instead of
-  // floating as its own boxy surface.
+  // floating as its own boxy surface. The `outline: none` here drops
+  // the boxy default focus ring; keyboard users get a subtler 2-px
+  // inset ring via the `:focus-visible` rule installed by
+  // `ensureNotesPanelStyles` so a11y stays intact (WCAG 2.4.7).
   ta.style.background = 'transparent';
   ta.style.color = 'var(--foreground, #ddd)';
   ta.style.border = 'none';
@@ -92,6 +97,28 @@ export function mountNotesPanel(
       offSlide();
     },
   };
+}
+
+/**
+ * Inject a `:focus-visible` outline rule for the notes textarea once
+ * per document. The inline `outline: none` strips the default focus
+ * ring (which would render as a boxy rectangle around the borderless
+ * panel); this rule re-adds a subtle 2-px inset ring that only shows
+ * for keyboard focus — WCAG 2.4.7 compliant without re-introducing
+ * the chrome we deliberately removed for mouse users.
+ */
+function ensureNotesPanelStyles(): void {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById('wfb-slides-notes-panel-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'wfb-slides-notes-panel-styles';
+  style.textContent =
+    '.wfb-slides-notes-ta:focus-visible {' +
+    '  outline: 2px solid var(--ring, #3a7);' +
+    '  outline-offset: -2px;' +
+    '  border-radius: 2px;' +
+    '}';
+  document.head.appendChild(style);
 }
 
 function blocksToText(blocks: readonly Block[]): string {

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -119,9 +119,21 @@ export function renderOverlay(
         // Thicken + deepen the line so the snap target is obvious.
         // Keeps the visual uncluttered — no extra dashed indicator on
         // top of the existing solid line.
+        //
+        // Widening from 1 px to 2 px shifts the line's right (or
+        // bottom) edge outward by 1 px — visually offsetting the
+        // emphasis by 0.5 px from the snapped coord. Counter-shift
+        // `left` / `top` by -0.5 so the centre of the 2-px line stays
+        // anchored on the snap coordinate.
         el.style.background = '#be123c';
-        if (g.axis === 'x') el.style.width = '2px';
-        else el.style.height = '2px';
+        const pos = g.position * options.scale;
+        if (g.axis === 'x') {
+          el.style.width = '2px';
+          el.style.left = `${pos - 0.5}px`;
+        } else {
+          el.style.height = '2px';
+          el.style.top = `${pos - 0.5}px`;
+        }
       }
       overlay.appendChild(el);
     }
@@ -397,12 +409,14 @@ function makeGuide(guide: SnapGuide, options: OverlayOptions): HTMLDivElement {
 }
 
 /**
- * Render a presentation-wide alignment guide as a 1-px magenta line
- * spanning the full slide on its axis. Phase 5 will differentiate
- * permanent vs snap guide styling; for now we match snap-guide colors
- * so Phase 3 (display-only) lands without churning the visual
- * baseline. `data-guide` carries the guide id so future interaction
- * passes (hover / hit-test) can find it.
+ * Render a presentation-wide alignment guide as a 1-px magenta line.
+ * The line is extended past the slide bounds by `GUIDE_EXTEND_PX` on
+ * each end so it visually connects into the H / V rulers — the
+ * canvas-area's `overflow: hidden` clips the excess at its outer
+ * frame edge so the line doesn't leak into the notes panel below.
+ *
+ * `data-guide` carries the guide id so future interaction passes
+ * (hover / hit-test) can find it.
  */
 function makePermanentGuide(
   guide: Guide,
@@ -417,17 +431,25 @@ function makePermanentGuide(
   el.style.pointerEvents = 'none';
   if (guide.axis === 'x') {
     el.style.left = `${guide.position * scale}px`;
-    el.style.top = '0px';
+    el.style.top = `-${GUIDE_EXTEND_PX}px`;
     el.style.width = '1px';
-    el.style.height = `${slideHeight * scale}px`;
+    el.style.height = `${GUIDE_EXTEND_PX * 2 + slideHeight * scale}px`;
   } else {
-    el.style.left = '0px';
+    el.style.left = `-${GUIDE_EXTEND_PX}px`;
     el.style.top = `${guide.position * scale}px`;
-    el.style.width = `${slideWidth * scale}px`;
+    el.style.width = `${GUIDE_EXTEND_PX * 2 + slideWidth * scale}px`;
     el.style.height = '1px';
   }
   return el;
 }
+
+/**
+ * Distance (in CSS pixels) the permanent guide line extends past
+ * the slide on every side. Large enough to always reach the
+ * canvas-area frame on any reasonable viewport; the `overflow:
+ * hidden` clip on canvasArea trims the excess.
+ */
+const GUIDE_EXTEND_PX = 10_000;
 
 function handleCursor(kind: string): string {
   switch (kind) {

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -92,6 +92,18 @@ export function renderOverlay(
 ): void {
   overlay.innerHTML = '';
 
+  // Build a set of permanent-guide ids that are currently the active
+  // snap target. The snap engine reports `guideId` on its winning
+  // SnapGuide entries; we use that to thicken / deepen the matching
+  // permanent guide rather than overlay a separate dashed indicator
+  // on top.
+  const snappedGuideIds = new Set<string>();
+  if (options.guides) {
+    for (const g of options.guides) {
+      if (g.kind === 'guide' && g.guideId) snappedGuideIds.add(g.guideId);
+    }
+  }
+
   // Permanent guides paint first so selection handles, snap guides, and
   // connector affordances all overlay on top of them. They render
   // regardless of selection state — the ruler's guides are deck-wide
@@ -102,7 +114,16 @@ export function renderOverlay(
       // in its place — suppress the committed copy so the user does
       // not see a double line at the original position.
       if (options.pendingGuide?.id === g.id) continue;
-      overlay.appendChild(makePermanentGuide(g, options));
+      const el = makePermanentGuide(g, options);
+      if (snappedGuideIds.has(g.id)) {
+        // Thicken + deepen the line so the snap target is obvious.
+        // Keeps the visual uncluttered — no extra dashed indicator on
+        // top of the existing solid line.
+        el.style.background = '#be123c';
+        if (g.axis === 'x') el.style.width = '2px';
+        else el.style.height = '2px';
+      }
+      overlay.appendChild(el);
     }
   }
 
@@ -163,6 +184,10 @@ export function renderOverlay(
   // single rotated element being dragged also gets visible guides.
   if (options.guides && options.guides.length > 0) {
     for (const g of options.guides) {
+      // Snaps to a presentation guide are visualised by emphasising
+      // the permanent guide above (thicker + darker), so don't lay an
+      // additional snap-guide line on top.
+      if (g.kind === 'guide') continue;
       overlay.appendChild(makeGuide(g, options));
     }
   }

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -41,6 +41,13 @@ export interface OverlayOptions {
    */
   permanentGuides?: readonly Guide[];
   /**
+   * Live preview of a guide currently being created or repositioned.
+   * Painted with reduced opacity so the user can distinguish the
+   * in-flight drag from the committed guides underneath. Cleared by
+   * the editor on commit / cancel.
+   */
+  pendingGuide?: { id?: string; axis: 'x' | 'y'; position: number } | null;
+  /**
    * All elements on the active slide. Optional and only consulted when a
    * selected connector has an `attached` endpoint — `resolveEndpoint`
    * needs the host element's frame to compute the endpoint's world
@@ -91,8 +98,25 @@ export function renderOverlay(
   // scaffolding, not selection feedback.
   if (options.permanentGuides && options.permanentGuides.length > 0) {
     for (const g of options.permanentGuides) {
+      // While dragging an existing guide we paint the pending preview
+      // in its place — suppress the committed copy so the user does
+      // not see a double line at the original position.
+      if (options.pendingGuide?.id === g.id) continue;
       overlay.appendChild(makePermanentGuide(g, options));
     }
+  }
+
+  // In-flight drag preview: same line treatment, half-opacity so the
+  // user can tell the drag has not committed yet.
+  if (options.pendingGuide) {
+    const previewGuide: Guide = {
+      id: options.pendingGuide.id ?? '__pending__',
+      axis: options.pendingGuide.axis,
+      position: options.pendingGuide.position,
+    };
+    const preview = makePermanentGuide(previewGuide, options);
+    preview.style.opacity = '0.55';
+    overlay.appendChild(preview);
   }
 
   // Connector affordance (Task 13): blue dots over the nearest shape's

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -1,6 +1,7 @@
 import type { ConnectorElement, Endpoint } from '../../model/connector';
 import type { Element, Frame } from '../../model/element';
 import { combinedBoundingBox } from '../../model/frame';
+import type { Guide } from '../../model/presentation';
 import {
   getConnectionSites,
   siteWorldPos,
@@ -31,6 +32,14 @@ export interface OverlayOptions {
   slideHeight: number;
   /** Snap guides to render under the selection handles. Empty/omitted = none. */
   guides?: readonly SnapGuide[];
+  /**
+   * Presentation-wide alignment guides (the ruler's persistent guides).
+   * Rendered as 1-px magenta lines spanning the slide canvas, beneath
+   * selection handles but above element paints. Phase 3 keeps them
+   * visually identical to snap guides; Phase 5 will differentiate
+   * (snap = dashed, permanent = solid) once both can coexist on screen.
+   */
+  permanentGuides?: readonly Guide[];
   /**
    * All elements on the active slide. Optional and only consulted when a
    * selected connector has an `attached` endpoint — `resolveEndpoint`
@@ -75,6 +84,16 @@ export function renderOverlay(
   options: OverlayOptions,
 ): void {
   overlay.innerHTML = '';
+
+  // Permanent guides paint first so selection handles, snap guides, and
+  // connector affordances all overlay on top of them. They render
+  // regardless of selection state — the ruler's guides are deck-wide
+  // scaffolding, not selection feedback.
+  if (options.permanentGuides && options.permanentGuides.length > 0) {
+    for (const g of options.permanentGuides) {
+      overlay.appendChild(makePermanentGuide(g, options));
+    }
+  }
 
   // Connector affordance (Task 13): blue dots over the nearest shape's
   // connection sites. Rendered first so the selection handles paint on
@@ -311,6 +330,39 @@ function makeGuide(guide: SnapGuide, options: OverlayOptions): HTMLDivElement {
   const { scale, slideWidth, slideHeight } = options;
   const el = document.createElement('div');
   el.className = 'wfb-slides-snap-guide';
+  el.style.position = 'absolute';
+  el.style.background = '#e11d48';
+  el.style.pointerEvents = 'none';
+  if (guide.axis === 'x') {
+    el.style.left = `${guide.position * scale}px`;
+    el.style.top = '0px';
+    el.style.width = '1px';
+    el.style.height = `${slideHeight * scale}px`;
+  } else {
+    el.style.left = '0px';
+    el.style.top = `${guide.position * scale}px`;
+    el.style.width = `${slideWidth * scale}px`;
+    el.style.height = '1px';
+  }
+  return el;
+}
+
+/**
+ * Render a presentation-wide alignment guide as a 1-px magenta line
+ * spanning the full slide on its axis. Phase 5 will differentiate
+ * permanent vs snap guide styling; for now we match snap-guide colors
+ * so Phase 3 (display-only) lands without churning the visual
+ * baseline. `data-guide` carries the guide id so future interaction
+ * passes (hover / hit-test) can find it.
+ */
+function makePermanentGuide(
+  guide: Guide,
+  options: OverlayOptions,
+): HTMLDivElement {
+  const { scale, slideWidth, slideHeight } = options;
+  const el = document.createElement('div');
+  el.className = 'wfb-slides-guide';
+  el.dataset.guide = guide.id;
   el.style.position = 'absolute';
   el.style.background = '#e11d48';
   el.style.pointerEvents = 'none';

--- a/packages/slides/src/view/editor/ruler/index.ts
+++ b/packages/slides/src/view/editor/ruler/index.ts
@@ -1,0 +1,7 @@
+export {
+  SlidesRuler,
+  RULER_SIZE,
+  SLIDES_PX_PER_INCH,
+  type SlidesRulerOptions,
+  type SlidesRulerViewport,
+} from './ruler';

--- a/packages/slides/src/view/editor/ruler/interactions.ts
+++ b/packages/slides/src/view/editor/ruler/interactions.ts
@@ -62,22 +62,28 @@ export interface GuideDragHost {
 /**
  * Hit-test a slide-logical pointer against the live guide list.
  * Returns the closest guide within `GUIDE_HIT_PX` of the pointer, or
- * null if none qualify. Caller is responsible for picking among
- * overlapping guides — `find` returns the first match in `guides[]`
- * order, which is the deck's authored z-order.
+ * `null` if none qualify. Scans the full list (instead of returning
+ * the first match) so two stacked guides near the pointer resolve to
+ * the one the user actually clicked on, not whichever sits earlier
+ * in `guides[]` order.
  */
 export function hitTestGuide(
   guides: readonly Guide[],
   point: { x: number; y: number },
 ): Guide | null {
+  let best: Guide | null = null;
+  let bestDist = GUIDE_HIT_PX + 1;
   for (const g of guides) {
     const d =
       g.axis === 'x'
         ? Math.abs(point.x - g.position)
         : Math.abs(point.y - g.position);
-    if (d <= GUIDE_HIT_PX) return g;
+    if (d <= GUIDE_HIT_PX && d < bestDist) {
+      best = g;
+      bestDist = d;
+    }
   }
-  return null;
+  return best;
 }
 
 /**

--- a/packages/slides/src/view/editor/ruler/interactions.ts
+++ b/packages/slides/src/view/editor/ruler/interactions.ts
@@ -1,0 +1,185 @@
+/**
+ * Ruler / guide drag interactions for the slides editor.
+ *
+ * Three gestures share the same drag-state machine, all driven through
+ * pointer events on the editor surface:
+ *
+ * 1. **Create**: mousedown on the H or V ruler canvas seeds a pending
+ *    guide. mousemove updates its position. mouseup inside the slide
+ *    commits via `store.addGuide`; mouseup outside cancels.
+ *
+ * 2. **Move**: mousedown within `GUIDE_HIT_PX` of an existing guide
+ *    seeds a pending guide carrying the guide's id. mousemove updates
+ *    position. mouseup over the slide commits via `store.moveGuide`;
+ *    mouseup over a ruler deletes via `store.removeGuide`.
+ *
+ * 3. **Delete-by-drag**: a sub-case of (2) — mouseup over a ruler
+ *    triggers `removeGuide` instead of `moveGuide`.
+ *
+ * The editor owns the pending state (`pendingGuide` on `SlidesEditorImpl`)
+ * and the overlay repaint pipeline; this module is a stateless helper
+ * that wires document-level pointer listeners and calls back into the
+ * editor through a narrow API.
+ *
+ * Hit-test distance is in slide-logical pixels (4 px on the slide
+ * canvas, scaled by the editor zoom to get the screen tolerance).
+ */
+
+import { SLIDE_HEIGHT, SLIDE_WIDTH, type Guide } from '../../../model/presentation';
+
+/** Hit-test tolerance for grabbing an existing guide, in slide-logical px. */
+export const GUIDE_HIT_PX = 4;
+
+export interface GuideDragHost {
+  /** Update the pending preview + repaint overlay; also broadcast presence. */
+  setPendingGuide(
+    guide: { id?: string; axis: 'x' | 'y'; position: number } | null,
+  ): void;
+  /** Commit add / move / remove inside a batch. */
+  commitAddGuide(axis: 'x' | 'y', position: number): void;
+  commitMoveGuide(id: string, position: number): void;
+  commitRemoveGuide(id: string): void;
+  /** Read the live guide list for hit-testing. */
+  readGuides(): readonly Guide[];
+  /**
+   * Convert a client (screen-space) coordinate into slide-logical
+   * coordinates. Caller does the actual scale and origin math; this
+   * keeps the interactions module unaware of zoom + DPR specifics.
+   */
+  clientToLogical(clientX: number, clientY: number): { x: number; y: number };
+  /** True if a client point falls over the H or V ruler region. */
+  isOverRuler(clientX: number, clientY: number): 'h' | 'v' | null;
+  /**
+   * True if a logical point falls inside the slide bounds
+   * `[0, SLIDE_WIDTH] × [0, SLIDE_HEIGHT]`. Used to gate
+   * commit-vs-cancel on mouseup.
+   */
+  isInsideSlide(x: number, y: number): boolean;
+  /** Pointer position relative to the slide canvas (slide-logical px). */
+  setBodyCursor(cursor: string | null): void;
+}
+
+/**
+ * Hit-test a slide-logical pointer against the live guide list.
+ * Returns the closest guide within `GUIDE_HIT_PX` of the pointer, or
+ * null if none qualify. Caller is responsible for picking among
+ * overlapping guides — `find` returns the first match in `guides[]`
+ * order, which is the deck's authored z-order.
+ */
+export function hitTestGuide(
+  guides: readonly Guide[],
+  point: { x: number; y: number },
+): Guide | null {
+  for (const g of guides) {
+    const d =
+      g.axis === 'x'
+        ? Math.abs(point.x - g.position)
+        : Math.abs(point.y - g.position);
+    if (d <= GUIDE_HIT_PX) return g;
+  }
+  return null;
+}
+
+/**
+ * Start a drag-out from the ruler: the user pressed down on the
+ * horizontal or vertical ruler. We seed a pending guide at the
+ * cursor's projection onto the slide, then attach document-level
+ * pointermove + pointerup so the gesture continues even if the
+ * cursor wanders off the ruler.
+ *
+ * Returns a disposer that detaches the listeners (mostly for tests;
+ * production callers can rely on mouseup teardown).
+ */
+export function startRulerDragOut(
+  host: GuideDragHost,
+  axis: 'x' | 'y',
+  initialEvent: PointerEvent,
+): () => void {
+  initialEvent.preventDefault();
+  host.setBodyCursor(axis === 'x' ? 'col-resize' : 'row-resize');
+
+  const onMove = (e: PointerEvent) => {
+    const { x, y } = host.clientToLogical(e.clientX, e.clientY);
+    const position = axis === 'x' ? x : y;
+    host.setPendingGuide({ axis, position });
+  };
+  const onUp = (e: PointerEvent) => {
+    document.removeEventListener('pointermove', onMove);
+    document.removeEventListener('pointerup', onUp);
+    host.setBodyCursor(null);
+    const { x, y } = host.clientToLogical(e.clientX, e.clientY);
+    if (host.isInsideSlide(x, y)) {
+      const position = clamp(axis === 'x' ? x : y, axis);
+      host.commitAddGuide(axis, position);
+    }
+    host.setPendingGuide(null);
+  };
+  document.addEventListener('pointermove', onMove);
+  document.addEventListener('pointerup', onUp);
+
+  // Prime the preview at the current cursor so the user sees the line
+  // immediately, before any pointer movement.
+  const start = host.clientToLogical(initialEvent.clientX, initialEvent.clientY);
+  host.setPendingGuide({ axis, position: axis === 'x' ? start.x : start.y });
+
+  return () => {
+    document.removeEventListener('pointermove', onMove);
+    document.removeEventListener('pointerup', onUp);
+  };
+}
+
+/**
+ * Start dragging an existing guide. mouseup over the slide commits a
+ * `moveGuide`; mouseup over either ruler triggers `removeGuide` —
+ * this is the "drag back to delete" affordance.
+ */
+export function startGuideMove(
+  host: GuideDragHost,
+  guide: Guide,
+  initialEvent: PointerEvent,
+): () => void {
+  initialEvent.preventDefault();
+  host.setBodyCursor(guide.axis === 'x' ? 'col-resize' : 'row-resize');
+
+  const onMove = (e: PointerEvent) => {
+    const { x, y } = host.clientToLogical(e.clientX, e.clientY);
+    const position = clamp(guide.axis === 'x' ? x : y, guide.axis);
+    host.setPendingGuide({ id: guide.id, axis: guide.axis, position });
+  };
+  const onUp = (e: PointerEvent) => {
+    document.removeEventListener('pointermove', onMove);
+    document.removeEventListener('pointerup', onUp);
+    host.setBodyCursor(null);
+    const overRuler = host.isOverRuler(e.clientX, e.clientY);
+    if (overRuler) {
+      host.commitRemoveGuide(guide.id);
+    } else {
+      const { x, y } = host.clientToLogical(e.clientX, e.clientY);
+      const position = clamp(guide.axis === 'x' ? x : y, guide.axis);
+      if (position !== guide.position) {
+        host.commitMoveGuide(guide.id, position);
+      }
+    }
+    host.setPendingGuide(null);
+  };
+  document.addEventListener('pointermove', onMove);
+  document.addEventListener('pointerup', onUp);
+
+  // Seed the preview at the guide's current position so the line
+  // visibly "lifts off" without needing the first mousemove.
+  host.setPendingGuide({
+    id: guide.id,
+    axis: guide.axis,
+    position: guide.position,
+  });
+
+  return () => {
+    document.removeEventListener('pointermove', onMove);
+    document.removeEventListener('pointerup', onUp);
+  };
+}
+
+function clamp(value: number, axis: 'x' | 'y'): number {
+  const max = axis === 'x' ? SLIDE_WIDTH : SLIDE_HEIGHT;
+  return Math.max(0, Math.min(max, value));
+}

--- a/packages/slides/src/view/editor/ruler/ruler.ts
+++ b/packages/slides/src/view/editor/ruler/ruler.ts
@@ -8,12 +8,16 @@
  * the slide canvas extent. Guides and drag-out gestures land in a
  * later phase.
  *
- * The slides canvas has no scroll in v1 (the deck zoom-to-fits the
- * available column width via `editor.setHostSize`), so the ruler
- * derives its scale entirely from the host dimensions: one slide
- * logical pixel maps to `hostWidth / SLIDE_WIDTH` host pixels, which
- * the renderer pre-multiplies into the grid step sizes before
- * handing them to `drawTicks`.
+ * Layout contract: the host positions both ruler canvases as
+ * absolutely-placed frames around the canvas area (top edge / left
+ * edge), NOT around the slide itself. The slide can drift inside the
+ * frame as the column resizes or the speaker-notes panel is dragged;
+ * the ruler stays pinned to the frame and projects its tick "zero"
+ * onto wherever the slide's left / top edge currently lives. The
+ * renderer reads each ruler canvas's own `clientWidth` /
+ * `clientHeight` to know its painted extent and derives the slide
+ * offset from `(frame - host) / 2` (the canvas-area's flex centering
+ * is the source of truth for that).
  */
 
 import {
@@ -72,7 +76,7 @@ export interface SlidesRulerOptions {
 }
 
 export interface SlidesRulerViewport {
-  /** Slide-canvas width in CSS pixels (excluding the 20 px ruler gutter). */
+  /** Slide-canvas width in CSS pixels (excluding the 14-px ruler gutter). */
   hostWidth: number;
   /** Slide-canvas height in CSS pixels. */
   hostHeight: number;
@@ -162,16 +166,22 @@ export class SlidesRuler {
   ): void {
     const ctx = this.hCtx;
     if (!ctx) return;
-    this.resizeCanvas(this.hCanvas, hostWidth, RULER_SIZE);
-    // Transparent ruler: clear instead of painting a background fill
-    // so the canvas wrapper's color shows through. Keeps the slide
-    // edge + drop shadow as the strongest visual anchor in the
-    // canvas area.
-    ctx.clearRect(0, 0, hostWidth, RULER_SIZE);
+    // The host pins the H ruler with `left: RULER_SIZE; right: 0`, so
+    // its painted width is whatever the column gives it. Match the
+    // backing store to that laid-out CSS width (fall back to host width
+    // in environments where layout hasn't run, e.g. jsdom).
+    const frameWidth = this.hCanvas.clientWidth || hostWidth;
+    this.resizeCanvas(this.hCanvas, frameWidth, RULER_SIZE);
+    ctx.clearRect(0, 0, frameWidth, RULER_SIZE);
+    // The slide is centred horizontally inside the canvas area's
+    // content box (canvasArea has padding-left: RULER_SIZE), so within
+    // the H ruler's own coordinate system the slide left edge sits at
+    // half the leftover space.
+    const slideOffset = Math.max(0, (frameWidth - hostWidth) / 2);
     drawTicks({
       ctx,
       axis: 'h',
-      start: 0,
+      start: slideOffset,
       length: hostWidth,
       grid,
       color: TICK_COLOR,
@@ -191,12 +201,14 @@ export class SlidesRuler {
   ): void {
     const ctx = this.vCtx;
     if (!ctx) return;
-    this.resizeCanvas(this.vCanvas, RULER_SIZE, hostHeight);
-    ctx.clearRect(0, 0, RULER_SIZE, hostHeight);
+    const frameHeight = this.vCanvas.clientHeight || hostHeight;
+    this.resizeCanvas(this.vCanvas, RULER_SIZE, frameHeight);
+    ctx.clearRect(0, 0, RULER_SIZE, frameHeight);
+    const slideOffset = Math.max(0, (frameHeight - hostHeight) / 2);
     drawTicks({
       ctx,
       axis: 'v',
-      start: 0,
+      start: slideOffset,
       length: hostHeight,
       grid,
       color: TICK_COLOR,
@@ -229,8 +241,10 @@ export class SlidesRuler {
       ctx?.setTransform(1, 0, 0, 1, 0, 0);
       ctx?.scale(this.dpr, this.dpr);
     }
-    canvas.style.width = `${width}px`;
-    canvas.style.height = `${height}px`;
+    // CSS dimensions intentionally NOT set here — the host owns the
+    // absolute positioning (top / left / right / bottom on the ruler
+    // canvases). Setting them would override the host's "right: 0"
+    // pin and shrink the ruler back to host width.
   }
 }
 

--- a/packages/slides/src/view/editor/ruler/ruler.ts
+++ b/packages/slides/src/view/editor/ruler/ruler.ts
@@ -27,8 +27,16 @@ import {
 
 import { SLIDE_WIDTH } from '../../../model/presentation';
 
-/** Ruler thickness in CSS pixels (matches the docs ruler). */
-export const RULER_SIZE = 20;
+/**
+ * Ruler thickness in CSS pixels.
+ *
+ * Intentionally slimmer than the docs ruler (20 px). The slide is a
+ * "stage" rather than a "page" — a heavy ruler bar clutters the
+ * canvas chrome and competes with the slide elevation. 14 px keeps
+ * the tick + integer-unit label readable while reclaiming ~30 % of
+ * the gutter the docs ruler reserves.
+ */
+export const RULER_SIZE = 14;
 
 /**
  * Pixel-per-inch in the slides logical coordinate system.
@@ -40,8 +48,18 @@ export const RULER_SIZE = 20;
  */
 export const SLIDES_PX_PER_INCH = 144;
 
-const TICK_COLOR = '#999999';
-const RULER_BG = '#f5f5f5';
+// Tick + label proportions tuned to the slim 14-px ruler. Major ticks
+// occupy ~40 % of the ruler height so an 8-px label can sit at the
+// top edge (y = 0) without colliding with the tick stem at the
+// bottom.
+const TICK_HEIGHTS = { major: 6, half: 4, minor: 2 };
+const LABEL_FONT = '8px Arial';
+const LABEL_INSET = 0;
+const VERTICAL_LABEL_INSET = 4;
+// Soft neutral so the ruler reads as chrome, not a measurement bar.
+// Inherits from the surrounding column instead of painting its own
+// background — keeps the visual weight on the slide itself.
+const TICK_COLOR = '#b0b0b0';
 
 export interface SlidesRulerOptions {
   hCanvas: HTMLCanvasElement;
@@ -91,7 +109,9 @@ export class SlidesRuler {
       detectUnit(typeof navigator !== 'undefined' ? navigator.language : undefined);
     this.unit = detected;
     this.grid = getGridConfig(detected, SLIDES_PX_PER_INCH);
-    this.corner.style.background = RULER_BG;
+    // Transparent corner — inherits the surrounding column color so
+    // the slim ruler reads as soft chrome, not a framed bar.
+    this.corner.style.background = 'transparent';
   }
 
   setUnit(unit: RulerUnit): void {
@@ -143,8 +163,11 @@ export class SlidesRuler {
     const ctx = this.hCtx;
     if (!ctx) return;
     this.resizeCanvas(this.hCanvas, hostWidth, RULER_SIZE);
-    ctx.fillStyle = RULER_BG;
-    ctx.fillRect(0, 0, hostWidth, RULER_SIZE);
+    // Transparent ruler: clear instead of painting a background fill
+    // so the canvas wrapper's color shows through. Keeps the slide
+    // edge + drop shadow as the strongest visual anchor in the
+    // canvas area.
+    ctx.clearRect(0, 0, hostWidth, RULER_SIZE);
     drawTicks({
       ctx,
       axis: 'h',
@@ -154,6 +177,10 @@ export class SlidesRuler {
       color: TICK_COLOR,
       density,
       rulerSize: RULER_SIZE,
+      tickHeights: TICK_HEIGHTS,
+      labelFont: LABEL_FONT,
+      labelInset: LABEL_INSET,
+      verticalLabelInset: VERTICAL_LABEL_INSET,
     });
   }
 
@@ -165,8 +192,7 @@ export class SlidesRuler {
     const ctx = this.vCtx;
     if (!ctx) return;
     this.resizeCanvas(this.vCanvas, RULER_SIZE, hostHeight);
-    ctx.fillStyle = RULER_BG;
-    ctx.fillRect(0, 0, RULER_SIZE, hostHeight);
+    ctx.clearRect(0, 0, RULER_SIZE, hostHeight);
     drawTicks({
       ctx,
       axis: 'v',
@@ -176,6 +202,10 @@ export class SlidesRuler {
       color: TICK_COLOR,
       density,
       rulerSize: RULER_SIZE,
+      tickHeights: TICK_HEIGHTS,
+      labelFont: LABEL_FONT,
+      labelInset: LABEL_INSET,
+      verticalLabelInset: VERTICAL_LABEL_INSET,
     });
   }
 

--- a/packages/slides/src/view/editor/ruler/ruler.ts
+++ b/packages/slides/src/view/editor/ruler/ruler.ts
@@ -1,0 +1,212 @@
+/**
+ * SlidesRuler — horizontal + vertical rulers for the slides editor.
+ *
+ * Reuses the docs ruler's tick / unit primitives via the shared
+ * exports on `@wafflebase/docs`, with a slides-specific 144 dpi
+ * physical scale (1920 logical px / 13.333"). Display-only in v1:
+ * paint ticks + integer-unit labels (inch / cm, locale-driven) along
+ * the slide canvas extent. Guides and drag-out gestures land in a
+ * later phase.
+ *
+ * The slides canvas has no scroll in v1 (the deck zoom-to-fits the
+ * available column width via `editor.setHostSize`), so the ruler
+ * derives its scale entirely from the host dimensions: one slide
+ * logical pixel maps to `hostWidth / SLIDE_WIDTH` host pixels, which
+ * the renderer pre-multiplies into the grid step sizes before
+ * handing them to `drawTicks`.
+ */
+
+import {
+  detectUnit,
+  getGridConfig,
+  drawTicks,
+  type RulerUnit,
+  type GridConfig,
+  type TickDensity,
+} from '@wafflebase/docs';
+
+import { SLIDE_WIDTH } from '../../../model/presentation';
+
+/** Ruler thickness in CSS pixels (matches the docs ruler). */
+export const RULER_SIZE = 20;
+
+/**
+ * Pixel-per-inch in the slides logical coordinate system.
+ *
+ * Slides ship a 1920 × 1080 logical canvas that maps to a 13.333" ×
+ * 7.5" PDF page (matches PowerPoint's 16:9 default). 1920 / 13.333 ≈
+ * 144, so one slide logical pixel ≈ 1/144 inch. Compare with the docs
+ * ruler, where logical px are 1/96 inch (CSS pixels).
+ */
+export const SLIDES_PX_PER_INCH = 144;
+
+const TICK_COLOR = '#999999';
+const RULER_BG = '#f5f5f5';
+
+export interface SlidesRulerOptions {
+  hCanvas: HTMLCanvasElement;
+  vCanvas: HTMLCanvasElement;
+  corner: HTMLElement;
+  /** Override the device-pixel-ratio (mainly for tests). */
+  dpr?: number;
+  /** Override locale-driven unit detection. */
+  unit?: RulerUnit;
+}
+
+export interface SlidesRulerViewport {
+  /** Slide-canvas width in CSS pixels (excluding the 20 px ruler gutter). */
+  hostWidth: number;
+  /** Slide-canvas height in CSS pixels. */
+  hostHeight: number;
+  /**
+   * Slide-logical pixels currently visible in the host. Reserved for a
+   * future pannable / scrolled mode; pass 0 in v1.
+   */
+  scrollX?: number;
+  scrollY?: number;
+}
+
+export class SlidesRuler {
+  private readonly hCanvas: HTMLCanvasElement;
+  private readonly vCanvas: HTMLCanvasElement;
+  private readonly corner: HTMLElement;
+  private readonly hCtx: CanvasRenderingContext2D | null;
+  private readonly vCtx: CanvasRenderingContext2D | null;
+  private readonly dpr: number;
+  private unit: RulerUnit;
+  private grid: GridConfig;
+  private disposed = false;
+
+  constructor(opts: SlidesRulerOptions) {
+    this.hCanvas = opts.hCanvas;
+    this.vCanvas = opts.vCanvas;
+    this.corner = opts.corner;
+    this.hCtx = opts.hCanvas.getContext('2d');
+    this.vCtx = opts.vCanvas.getContext('2d');
+    this.dpr =
+      opts.dpr ??
+      (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
+    const detected =
+      opts.unit ??
+      detectUnit(typeof navigator !== 'undefined' ? navigator.language : undefined);
+    this.unit = detected;
+    this.grid = getGridConfig(detected, SLIDES_PX_PER_INCH);
+    this.corner.style.background = RULER_BG;
+  }
+
+  setUnit(unit: RulerUnit): void {
+    if (this.unit === unit) return;
+    this.unit = unit;
+    this.grid = getGridConfig(unit, SLIDES_PX_PER_INCH);
+  }
+
+  getUnit(): RulerUnit {
+    return this.unit;
+  }
+
+  render(viewport: SlidesRulerViewport): void {
+    if (this.disposed) return;
+    const { hostWidth, hostHeight } = viewport;
+    if (hostWidth <= 0 || hostHeight <= 0) return;
+
+    const zoom = hostWidth / SLIDE_WIDTH;
+    const scaledGrid: GridConfig = {
+      subdivisions: this.grid.subdivisions,
+      majorStepPx: this.grid.majorStepPx * zoom,
+      minorStepPx: this.grid.minorStepPx * zoom,
+    };
+    const density = pickDensity(scaledGrid.majorStepPx);
+
+    this.paintHorizontal(hostWidth, scaledGrid, density);
+    this.paintVertical(hostHeight, scaledGrid, density);
+  }
+
+  /**
+   * Test seam: returns the density band that would be used for the
+   * given zoom factor (host width / SLIDE_WIDTH). The renderer derives
+   * its band from the same calculation, so tests can pin transitions
+   * without spying on the canvas context.
+   */
+  densityFor(zoom: number): TickDensity {
+    return pickDensity(this.grid.majorStepPx * zoom);
+  }
+
+  dispose(): void {
+    this.disposed = true;
+  }
+
+  private paintHorizontal(
+    hostWidth: number,
+    grid: GridConfig,
+    density: TickDensity,
+  ): void {
+    const ctx = this.hCtx;
+    if (!ctx) return;
+    this.resizeCanvas(this.hCanvas, hostWidth, RULER_SIZE);
+    ctx.fillStyle = RULER_BG;
+    ctx.fillRect(0, 0, hostWidth, RULER_SIZE);
+    drawTicks({
+      ctx,
+      axis: 'h',
+      start: 0,
+      length: hostWidth,
+      grid,
+      color: TICK_COLOR,
+      density,
+      rulerSize: RULER_SIZE,
+    });
+  }
+
+  private paintVertical(
+    hostHeight: number,
+    grid: GridConfig,
+    density: TickDensity,
+  ): void {
+    const ctx = this.vCtx;
+    if (!ctx) return;
+    this.resizeCanvas(this.vCanvas, RULER_SIZE, hostHeight);
+    ctx.fillStyle = RULER_BG;
+    ctx.fillRect(0, 0, RULER_SIZE, hostHeight);
+    drawTicks({
+      ctx,
+      axis: 'v',
+      start: 0,
+      length: hostHeight,
+      grid,
+      color: TICK_COLOR,
+      density,
+      rulerSize: RULER_SIZE,
+    });
+  }
+
+  private resizeCanvas(
+    canvas: HTMLCanvasElement,
+    width: number,
+    height: number,
+  ): void {
+    const backingW = Math.max(1, Math.round(width * this.dpr));
+    const backingH = Math.max(1, Math.round(height * this.dpr));
+    if (canvas.width !== backingW || canvas.height !== backingH) {
+      canvas.width = backingW;
+      canvas.height = backingH;
+      const ctx = canvas.getContext('2d');
+      // Reset transform first — Canvas spec preserves the active
+      // transform across width/height assignments only in some
+      // browsers, and ctx.scale composes on top of the existing
+      // matrix. setTransform(1,0,0,1,0,0) zeroes the matrix; the
+      // subsequent scale(dpr,dpr) then produces 1 CSS px = 1 logical
+      // unit regardless of prior frames.
+      ctx?.setTransform(1, 0, 0, 1, 0, 0);
+      ctx?.scale(this.dpr, this.dpr);
+    }
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+  }
+}
+
+function pickDensity(majorStepOnScreen: number): TickDensity {
+  if (majorStepOnScreen >= 60) return 'full';
+  if (majorStepOnScreen >= 30) return 'half-only';
+  if (majorStepOnScreen >= 15) return 'major';
+  return 'major-thinned';
+}

--- a/packages/slides/src/view/editor/snap.ts
+++ b/packages/slides/src/view/editor/snap.ts
@@ -1,31 +1,51 @@
 import type { Frame } from '../../model/element';
+import type { Guide } from '../../model/presentation';
 
 const SNAP_THRESHOLD = 8;
 
 export interface SlideDimensions { w: number; h: number; }
 
+export type SnapGuideKind = 'slide-center' | 'guide' | 'edge';
+
 export type SnapGuide =
-  | { axis: 'x'; position: number; kind: 'slide-center' | 'edge' }
-  | { axis: 'y'; position: number; kind: 'slide-center' | 'edge' };
+  | { axis: 'x'; position: number; kind: SnapGuideKind; guideId?: string }
+  | { axis: 'y'; position: number; kind: SnapGuideKind; guideId?: string };
 
 type Candidate = {
   from: number;
   to: number;
-  kind: 'slide-center' | 'edge';
+  kind: SnapGuideKind;
+  /** Set when `kind === 'guide'`; matches the source `Guide.id`. */
+  guideId?: string;
+};
+
+/**
+ * Priority among snap candidates within the same threshold band. Lower
+ * number wins. Slide-center > user-placed guide > other-element edge.
+ *
+ * Rationale: slide-center is the strongest visual anchor and most
+ * commonly intended; explicit guides reflect direct user intent and
+ * should win over implicit element-edge alignment.
+ */
+const PRIORITY: Record<SnapGuideKind, number> = {
+  'slide-center': 0,
+  'guide': 1,
+  'edge': 2,
 };
 
 /**
  * Adjust a (dx, dy) drag delta so the dragged group's bounding-box
- * edges or centre snap to the slide centre or to a non-selected
- * element's edge, whichever is closest within an 8 px threshold.
+ * edges or centre snap to the slide centre, a presentation-wide
+ * alignment guide, or a non-selected element's edge — whichever wins
+ * inside the 8 px threshold.
  *
- * Both axes are computed independently. If no candidate is within
- * threshold on an axis, the original delta is returned unchanged on
- * that axis. The smallest correction wins per axis.
+ * Both axes are computed independently. Among candidates that fall
+ * inside the threshold, `PRIORITY` resolves ties; within the same
+ * kind, the smallest correction wins.
  *
  * Also returns a `guides` array describing which alignment line(s)
- * won the snap, so an overlay layer can render visible guide lines
- * during drag. Empty when no axis snapped.
+ * won the snap so an overlay layer can render visible feedback during
+ * the drag. Empty when no axis snapped.
  */
 export function snapDelta(
   bbox: { x: number; y: number; w: number; h: number },
@@ -33,6 +53,7 @@ export function snapDelta(
   dy: number,
   others: readonly Frame[],
   slide: SlideDimensions,
+  guides: readonly Guide[] = [],
 ): { dx: number; dy: number; guides: SnapGuide[] } {
   const dragged = {
     leftPx: bbox.x + dx,
@@ -69,19 +90,37 @@ export function snapDelta(
     );
   }
 
+  // Presentation-wide guides. Three candidate offsets per guide so the
+  // dragged frame can snap by either edge or by its centre.
+  for (const g of guides) {
+    if (g.axis === 'x') {
+      xCandidates.push(
+        { from: dragged.leftPx,    to: g.position, kind: 'guide', guideId: g.id },
+        { from: dragged.rightPx,   to: g.position, kind: 'guide', guideId: g.id },
+        { from: dragged.centerXPx, to: g.position, kind: 'guide', guideId: g.id },
+      );
+    } else {
+      yCandidates.push(
+        { from: dragged.topPx,     to: g.position, kind: 'guide', guideId: g.id },
+        { from: dragged.bottomPx,  to: g.position, kind: 'guide', guideId: g.id },
+        { from: dragged.centerYPx, to: g.position, kind: 'guide', guideId: g.id },
+      );
+    }
+  }
+
   const xResult = bestSnapAdjust(xCandidates);
   const yResult = bestSnapAdjust(yCandidates);
 
-  const guides: SnapGuide[] = [];
+  const snapGuides: SnapGuide[] = [];
   const xGuide = toGuide('x', xResult.winner);
-  if (xGuide) guides.push(xGuide);
+  if (xGuide) snapGuides.push(xGuide);
   const yGuide = toGuide('y', yResult.winner);
-  if (yGuide) guides.push(yGuide);
+  if (yGuide) snapGuides.push(yGuide);
 
   return {
     dx: dx + xResult.adjust,
     dy: dy + yResult.adjust,
-    guides,
+    guides: snapGuides,
   };
 }
 
@@ -90,23 +129,40 @@ function toGuide(
   winner: Candidate | null,
 ): SnapGuide | null {
   if (!winner) return null;
-  return { axis, position: winner.to, kind: winner.kind };
+  return {
+    axis,
+    position: winner.to,
+    kind: winner.kind,
+    guideId: winner.guideId,
+  };
 }
 
 function bestSnapAdjust(
   cands: Candidate[],
 ): { adjust: number; winner: Candidate | null } {
-  let best = 0;
-  let bestAbs = SNAP_THRESHOLD + 1;
   let winner: Candidate | null = null;
+  let bestAbs = SNAP_THRESHOLD + 1;
   for (const c of cands) {
     const diff = c.to - c.from;
     const abs = Math.abs(diff);
-    if (abs <= SNAP_THRESHOLD && abs < bestAbs) {
-      best = diff;
-      bestAbs = abs;
+    if (abs > SNAP_THRESHOLD) continue;
+    if (winner === null) {
       winner = c;
+      bestAbs = abs;
+      continue;
+    }
+    const pNew = PRIORITY[c.kind];
+    const pCur = PRIORITY[winner.kind];
+    if (pNew < pCur) {
+      // Higher priority kind wins regardless of distance — guides
+      // outrank element edges even when an edge happens to be closer.
+      winner = c;
+      bestAbs = abs;
+    } else if (pNew === pCur && abs < bestAbs) {
+      winner = c;
+      bestAbs = abs;
     }
   }
-  return { adjust: best, winner };
+  if (!winner) return { adjust: 0, winner: null };
+  return { adjust: winner.to - winner.from, winner };
 }

--- a/packages/slides/test/store/memory.test.ts
+++ b/packages/slides/test/store/memory.test.ts
@@ -709,3 +709,90 @@ describe('MemSlidesStore — batch / undo / redo', () => {
     expect(() => store.addSlide('blank')).toThrow(/must be wrapped in batch/);
   });
 });
+
+describe('MemSlidesStore — guides', () => {
+  it('starts with no guides', () => {
+    const store = new MemSlidesStore();
+    expect(store.read().guides).toEqual([]);
+  });
+
+  it('addGuide appends and returns a stable id', () => {
+    const store = new MemSlidesStore();
+    let id!: string;
+    store.batch(() => {
+      id = store.addGuide('x', 400);
+    });
+    expect(store.read().guides).toEqual([
+      { id, axis: 'x', position: 400 },
+    ]);
+  });
+
+  it('moveGuide updates only the targeted guide position', () => {
+    const store = new MemSlidesStore();
+    let a!: string;
+    let b!: string;
+    store.batch(() => {
+      a = store.addGuide('x', 100);
+      b = store.addGuide('y', 250);
+    });
+    store.batch(() => store.moveGuide(a, 175));
+    const guides = store.read().guides;
+    expect(guides.find((g) => g.id === a)?.position).toBe(175);
+    expect(guides.find((g) => g.id === b)?.position).toBe(250);
+  });
+
+  it('removeGuide drops the guide from the list', () => {
+    const store = new MemSlidesStore();
+    let id!: string;
+    store.batch(() => {
+      id = store.addGuide('x', 100);
+      store.addGuide('y', 200);
+    });
+    store.batch(() => store.removeGuide(id));
+    const guides = store.read().guides;
+    expect(guides).toHaveLength(1);
+    expect(guides[0].axis).toBe('y');
+  });
+
+  it('moveGuide throws on missing id', () => {
+    const store = new MemSlidesStore();
+    expect(() =>
+      store.batch(() => store.moveGuide('does-not-exist', 0)),
+    ).toThrow(/Guide not found/);
+  });
+
+  it('removeGuide throws on missing id', () => {
+    const store = new MemSlidesStore();
+    expect(() =>
+      store.batch(() => store.removeGuide('does-not-exist')),
+    ).toThrow(/Guide not found/);
+  });
+
+  it('mutations require a batch', () => {
+    const store = new MemSlidesStore();
+    expect(() => store.addGuide('x', 100)).toThrow(/must be wrapped in batch/);
+    expect(() => store.moveGuide('id', 100)).toThrow(/must be wrapped in batch/);
+    expect(() => store.removeGuide('id')).toThrow(/must be wrapped in batch/);
+  });
+
+  it('groups add + move + remove into one undo step when wrapped in batch', () => {
+    const store = new MemSlidesStore();
+    store.batch(() => {
+      const id = store.addGuide('x', 100);
+      store.moveGuide(id, 200);
+      store.removeGuide(id);
+    });
+    expect(store.read().guides).toEqual([]);
+    store.undo();
+    // Single undo restores the pre-batch state (no guide).
+    expect(store.read().guides).toEqual([]);
+  });
+
+  it('undoing addGuide drops the guide', () => {
+    const store = new MemSlidesStore();
+    store.batch(() => store.addGuide('x', 100));
+    expect(store.read().guides).toHaveLength(1);
+    store.undo();
+    expect(store.read().guides).toEqual([]);
+  });
+});

--- a/packages/slides/test/view/canvas/element-renderer.test.ts
+++ b/packages/slides/test/view/canvas/element-renderer.test.ts
@@ -31,6 +31,7 @@ const DOC: SlidesDocument = {
   masters: [DEFAULT_MASTER],
   layouts: BUILT_IN_LAYOUTS,
   slides: [],
+  guides: [],
 };
 
 const shapeAt = (

--- a/packages/slides/test/view/canvas/group-render.test.ts
+++ b/packages/slides/test/view/canvas/group-render.test.ts
@@ -64,6 +64,7 @@ function emptyDoc(): SlidesDocument {
     masters: [DEFAULT_MASTER],
     layouts: BUILT_IN_LAYOUTS,
     slides: [],
+    guides: [],
   };
 }
 

--- a/packages/slides/test/view/canvas/slide-renderer.test.ts
+++ b/packages/slides/test/view/canvas/slide-renderer.test.ts
@@ -30,6 +30,7 @@ const DOC: SlidesDocument = {
   masters: [DEFAULT_MASTER],
   layouts: BUILT_IN_LAYOUTS,
   slides: [],
+  guides: [],
 };
 
 function blankSlide(): Slide {

--- a/packages/slides/test/view/canvas/thumbnail.test.ts
+++ b/packages/slides/test/view/canvas/thumbnail.test.ts
@@ -25,6 +25,7 @@ const DOC: SlidesDocument = {
   masters: [DEFAULT_MASTER],
   layouts: BUILT_IN_LAYOUTS,
   slides: [],
+  guides: [],
 };
 
 const blankSlide = (id: string): Slide => ({

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -744,6 +744,48 @@ describe('initialize with readOnly: true', () => {
     ).toBeDefined();
   });
 
+  it('does not bind ruler pointerdown — drag-out cannot create a guide', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const hRulerCanvas = document.createElement('canvas');
+    const vRulerCanvas = document.createElement('canvas');
+    const rulerCorner = document.createElement('div');
+    document.body.append(hRulerCanvas, vRulerCanvas, rulerCorner);
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      readOnly: true,
+      hRulerCanvas, vRulerCanvas, rulerCorner,
+    });
+    expect(store.read().guides).toEqual([]);
+    hRulerCanvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 500, clientY: 5, pointerType: 'mouse', bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 500, clientY: 200, pointerType: 'mouse', bubbles: true,
+    }));
+    expect(store.read().guides).toEqual([]);
+  });
+
+  it('does not start guide drag on slide canvas pointerdown', () => {
+    const { canvas, overlay, store } = makeFixture();
+    // Seed a guide so the hit-test would otherwise succeed.
+    store.batch(() => store.addGuide('x', 400));
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      readOnly: true,
+    });
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 400, clientY: 100, pointerType: 'mouse', bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: 500, clientY: 100, pointerType: 'mouse', bubbles: true,
+    }));
+    // Guide must stay at 400 — the readOnly editor never bound the
+    // pointerdown listener that routes to startGuideMove.
+    expect(store.read().guides[0].position).toBe(400);
+  });
+
   it('detach is safe and rendering after detach is a no-op', () => {
     const { canvas, overlay, store } = makeFixture();
     editor = initialize({

--- a/packages/slides/test/view/editor/ruler/interactions.test.ts
+++ b/packages/slides/test/view/editor/ruler/interactions.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  GUIDE_HIT_PX,
+  hitTestGuide,
+  startGuideMove,
+  startRulerDragOut,
+  type GuideDragHost,
+} from '../../../../src/view/editor/ruler/interactions';
+import type { Guide } from '../../../../src/model/presentation';
+
+function makeHost(initialGuides: Guide[] = []): {
+  host: GuideDragHost;
+  state: {
+    pendingGuide: { id?: string; axis: 'x' | 'y'; position: number } | null;
+    guides: Guide[];
+    cursor: string | null;
+    isInside: boolean;
+    overRuler: 'h' | 'v' | null;
+    /** Last (x, y) returned by clientToLogical; tests override via the
+     * `cursor*` helpers below by mutating this directly. */
+    logical: { x: number; y: number };
+  };
+  addGuide: ReturnType<typeof vi.fn>;
+  moveGuide: ReturnType<typeof vi.fn>;
+  removeGuide: ReturnType<typeof vi.fn>;
+} {
+  const state = {
+    pendingGuide: null as
+      | { id?: string; axis: 'x' | 'y'; position: number }
+      | null,
+    // Deep-clone each guide so per-test mutations (moveGuide writes
+    // `g.position`) cannot leak into the shared `seed` fixtures across
+    // tests in this file.
+    guides: initialGuides.map((g) => ({ ...g })),
+    cursor: null as string | null,
+    isInside: true,
+    overRuler: null as 'h' | 'v' | null,
+    logical: { x: 0, y: 0 },
+  };
+  const addGuide = vi.fn((axis: 'x' | 'y', position: number) => {
+    state.guides.push({ id: `g${state.guides.length + 1}`, axis, position });
+  });
+  const moveGuide = vi.fn((id: string, position: number) => {
+    const g = state.guides.find((g) => g.id === id);
+    if (g) g.position = position;
+  });
+  const removeGuide = vi.fn((id: string) => {
+    state.guides = state.guides.filter((g) => g.id !== id);
+  });
+  const host: GuideDragHost = {
+    setPendingGuide: (g) => {
+      state.pendingGuide = g;
+    },
+    commitAddGuide: (axis, position) => addGuide(axis, position),
+    commitMoveGuide: (id, position) => moveGuide(id, position),
+    commitRemoveGuide: (id) => removeGuide(id),
+    readGuides: () => state.guides,
+    clientToLogical: () => ({ ...state.logical }),
+    isOverRuler: () => state.overRuler,
+    isInsideSlide: () => state.isInside,
+    setBodyCursor: (c) => {
+      state.cursor = c;
+    },
+  };
+  return { host, state, addGuide, moveGuide, removeGuide };
+}
+
+function pointerEvent(
+  type: string,
+  client: { x: number; y: number },
+): PointerEvent {
+  // jsdom does not implement the PointerEvent constructor in some
+  // versions; fall back to MouseEvent and cast — startRulerDragOut /
+  // startGuideMove only read `clientX` / `clientY` / `preventDefault`.
+  const ctor = (globalThis as { PointerEvent?: typeof PointerEvent })
+    .PointerEvent;
+  if (ctor) {
+    return new ctor(type, { clientX: client.x, clientY: client.y, bubbles: true });
+  }
+  return new MouseEvent(type, {
+    clientX: client.x,
+    clientY: client.y,
+    bubbles: true,
+  }) as unknown as PointerEvent;
+}
+
+describe('hitTestGuide', () => {
+  const guides: Guide[] = [
+    { id: 'a', axis: 'x', position: 400 },
+    { id: 'b', axis: 'y', position: 300 },
+  ];
+
+  it('returns the vertical guide when the pointer is within 4 px on x', () => {
+    expect(hitTestGuide(guides, { x: 402, y: 0 })).toMatchObject({ id: 'a' });
+    expect(hitTestGuide(guides, { x: 396, y: 0 })).toMatchObject({ id: 'a' });
+  });
+
+  it('returns the horizontal guide when the pointer is within 4 px on y', () => {
+    expect(hitTestGuide(guides, { x: 0, y: 302 })).toMatchObject({ id: 'b' });
+  });
+
+  it('returns null when the pointer is past the 4-px zone', () => {
+    expect(hitTestGuide(guides, { x: 405, y: 305 })).toBeNull();
+  });
+
+  it('honors the exact GUIDE_HIT_PX boundary', () => {
+    expect(hitTestGuide(guides, { x: 400 + GUIDE_HIT_PX, y: 0 })).not.toBeNull();
+    expect(
+      hitTestGuide(guides, { x: 400 + GUIDE_HIT_PX + 1, y: 0 }),
+    ).toBeNull();
+  });
+});
+
+describe('startRulerDragOut', () => {
+  let env: ReturnType<typeof makeHost>;
+  beforeEach(() => {
+    env = makeHost();
+    env.state.logical = { x: 500, y: 0 };
+  });
+
+  it('seeds the pending guide on mousedown', () => {
+    startRulerDragOut(env.host, 'x', pointerEvent('pointerdown', { x: 500, y: 0 }));
+    expect(env.state.pendingGuide).toEqual({ axis: 'x', position: 500 });
+  });
+
+  it('commits addGuide on mouseup inside the slide', () => {
+    startRulerDragOut(env.host, 'x', pointerEvent('pointerdown', { x: 500, y: 0 }));
+    env.state.logical = { x: 600, y: 0 };
+    document.dispatchEvent(pointerEvent('pointermove', { x: 600, y: 0 }));
+    expect(env.state.pendingGuide).toEqual({ axis: 'x', position: 600 });
+    env.state.isInside = true;
+    env.state.logical = { x: 600, y: 0 };
+    document.dispatchEvent(pointerEvent('pointerup', { x: 600, y: 0 }));
+    expect(env.addGuide).toHaveBeenCalledWith('x', 600);
+    expect(env.state.pendingGuide).toBeNull();
+  });
+
+  it('cancels on mouseup outside the slide', () => {
+    startRulerDragOut(env.host, 'y', pointerEvent('pointerdown', { x: 0, y: 50 }));
+    env.state.isInside = false;
+    document.dispatchEvent(pointerEvent('pointerup', { x: 9999, y: 9999 }));
+    expect(env.addGuide).not.toHaveBeenCalled();
+    expect(env.state.pendingGuide).toBeNull();
+  });
+
+  it('clears the body cursor on mouseup', () => {
+    startRulerDragOut(env.host, 'x', pointerEvent('pointerdown', { x: 50, y: 0 }));
+    expect(env.state.cursor).toBe('col-resize');
+    env.state.logical = { x: 50, y: 0 };
+    document.dispatchEvent(pointerEvent('pointerup', { x: 50, y: 0 }));
+    expect(env.state.cursor).toBeNull();
+  });
+});
+
+describe('startGuideMove', () => {
+  const seed: Guide = { id: 'a', axis: 'x', position: 400 };
+
+  it('moves the guide on mouseup over the slide', () => {
+    const env = makeHost([seed]);
+    env.state.logical = { x: 400, y: 0 };
+    startGuideMove(env.host, seed, pointerEvent('pointerdown', { x: 400, y: 0 }));
+    env.state.logical = { x: 550, y: 0 };
+    document.dispatchEvent(pointerEvent('pointermove', { x: 550, y: 0 }));
+    expect(env.state.pendingGuide).toMatchObject({ id: 'a', position: 550 });
+    env.state.overRuler = null;
+    document.dispatchEvent(pointerEvent('pointerup', { x: 550, y: 0 }));
+    expect(env.moveGuide).toHaveBeenCalledWith('a', 550);
+    expect(env.removeGuide).not.toHaveBeenCalled();
+    expect(env.state.pendingGuide).toBeNull();
+  });
+
+  it('deletes the guide on mouseup over a ruler', () => {
+    const env = makeHost([seed]);
+    env.state.logical = { x: 400, y: 0 };
+    startGuideMove(env.host, seed, pointerEvent('pointerdown', { x: 400, y: 0 }));
+    env.state.overRuler = 'h';
+    document.dispatchEvent(pointerEvent('pointerup', { x: 200, y: 5 }));
+    expect(env.removeGuide).toHaveBeenCalledWith('a');
+    expect(env.moveGuide).not.toHaveBeenCalled();
+  });
+
+  it('skips moveGuide when the position is unchanged', () => {
+    const env = makeHost([seed]);
+    env.state.logical = { x: 400, y: 0 };
+    startGuideMove(env.host, seed, pointerEvent('pointerdown', { x: 400, y: 0 }));
+    document.dispatchEvent(pointerEvent('pointerup', { x: 400, y: 0 }));
+    expect(env.moveGuide).not.toHaveBeenCalled();
+  });
+
+  it('clamps the new position into the slide extent', () => {
+    const env = makeHost([seed]);
+    env.state.logical = { x: 400, y: 0 };
+    startGuideMove(env.host, seed, pointerEvent('pointerdown', { x: 400, y: 0 }));
+    env.state.logical = { x: 9999, y: 0 };
+    document.dispatchEvent(pointerEvent('pointermove', { x: 9999, y: 0 }));
+    expect(env.state.pendingGuide?.position).toBe(1920);
+    document.dispatchEvent(pointerEvent('pointerup', { x: 9999, y: 0 }));
+    expect(env.moveGuide).toHaveBeenCalledWith('a', 1920);
+  });
+});

--- a/packages/slides/test/view/editor/ruler/ruler.test.ts
+++ b/packages/slides/test/view/editor/ruler/ruler.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import '../../../../src/view/canvas/test-canvas-env';
+import {
+  SlidesRuler,
+  RULER_SIZE,
+  SLIDES_PX_PER_INCH,
+} from '../../../../src/view/editor/ruler/ruler';
+
+function mount(): {
+  container: HTMLElement;
+  hCanvas: HTMLCanvasElement;
+  vCanvas: HTMLCanvasElement;
+  corner: HTMLElement;
+} {
+  const container = document.createElement('div');
+  const corner = document.createElement('div');
+  const hCanvas = document.createElement('canvas');
+  const vCanvas = document.createElement('canvas');
+  container.append(corner, hCanvas, vCanvas);
+  document.body.appendChild(container);
+  return { container, hCanvas, vCanvas, corner };
+}
+
+describe('SlidesRuler', () => {
+  let dom: ReturnType<typeof mount>;
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    dom = mount();
+  });
+
+  it('exposes RULER_SIZE = 20 and SLIDES_PX_PER_INCH = 144', () => {
+    expect(RULER_SIZE).toBe(20);
+    expect(SLIDES_PX_PER_INCH).toBe(144);
+  });
+
+  it('renders without throwing at zoom 1', () => {
+    const ruler = new SlidesRuler({
+      hCanvas: dom.hCanvas,
+      vCanvas: dom.vCanvas,
+      corner: dom.corner,
+      dpr: 1,
+      unit: 'inch',
+    });
+    expect(() =>
+      ruler.render({ hostWidth: 1920, hostHeight: 1080 }),
+    ).not.toThrow();
+  });
+
+  it('no-ops on zero-sized viewport', () => {
+    const ruler = new SlidesRuler({
+      hCanvas: dom.hCanvas,
+      vCanvas: dom.vCanvas,
+      corner: dom.corner,
+      dpr: 1,
+      unit: 'inch',
+    });
+    expect(() =>
+      ruler.render({ hostWidth: 0, hostHeight: 0 }),
+    ).not.toThrow();
+  });
+
+  it('paints the corner background on construction', () => {
+    new SlidesRuler({
+      hCanvas: dom.hCanvas,
+      vCanvas: dom.vCanvas,
+      corner: dom.corner,
+      dpr: 1,
+      unit: 'inch',
+    });
+    expect(dom.corner.style.background).not.toBe('');
+  });
+
+  describe('density transitions', () => {
+    // Slides ship a 144 dpi physical scale. The density bands divide
+    // on `majorStepOnScreen = 144 * zoom`:
+    //   ≥ 60 → 'full'         (zoom ≥ 0.4167)
+    //   ≥ 30 → 'half-only'    (zoom ≥ 0.2083)
+    //   ≥ 15 → 'major'        (zoom ≥ 0.1042)
+    //   else → 'major-thinned'
+    //
+    // The metric grid uses a different majorStepPx (~56.7 px = 1 cm),
+    // so the same zoom yields different bands — pin transitions for
+    // both unit choices.
+
+    it('inch bands transition at zoom 0.4167 / 0.2083 / 0.1042', () => {
+      const ruler = new SlidesRuler({
+        hCanvas: dom.hCanvas,
+        vCanvas: dom.vCanvas,
+        corner: dom.corner,
+        dpr: 1,
+        unit: 'inch',
+      });
+      expect(ruler.densityFor(1)).toBe('full');
+      expect(ruler.densityFor(0.5)).toBe('full');
+      expect(ruler.densityFor(0.42)).toBe('full');
+      expect(ruler.densityFor(0.41)).toBe('half-only');
+      expect(ruler.densityFor(0.25)).toBe('half-only');
+      expect(ruler.densityFor(0.2)).toBe('major');
+      expect(ruler.densityFor(0.11)).toBe('major');
+      expect(ruler.densityFor(0.1)).toBe('major-thinned');
+      expect(ruler.densityFor(0.05)).toBe('major-thinned');
+    });
+
+    it('cm bands shift because the metric major step is smaller', () => {
+      const ruler = new SlidesRuler({
+        hCanvas: dom.hCanvas,
+        vCanvas: dom.vCanvas,
+        corner: dom.corner,
+        dpr: 1,
+        unit: 'cm',
+      });
+      // majorStepPx ≈ 56.7 px (1 cm at 144 dpi). At zoom 1 that
+      // already lands below the 60-px 'full' threshold — the cm ruler
+      // shows 'half-only' at its baseline, which matches Google Slides
+      // (which also shows fewer minor ticks under metric).
+      expect(ruler.densityFor(1.2)).toBe('full');     // 68 ≥ 60
+      expect(ruler.densityFor(1)).toBe('half-only');  // 56.7
+      expect(ruler.densityFor(0.6)).toBe('half-only');// 34
+      expect(ruler.densityFor(0.3)).toBe('major');    // 17
+      expect(ruler.densityFor(0.2)).toBe('major-thinned'); // 11.3
+    });
+  });
+
+  it('setUnit recomputes the grid', () => {
+    const ruler = new SlidesRuler({
+      hCanvas: dom.hCanvas,
+      vCanvas: dom.vCanvas,
+      corner: dom.corner,
+      dpr: 1,
+      unit: 'inch',
+    });
+    expect(ruler.getUnit()).toBe('inch');
+    // At zoom 1 with inch (144 dpi major), density is 'full'.
+    expect(ruler.densityFor(1)).toBe('full');
+    ruler.setUnit('cm');
+    expect(ruler.getUnit()).toBe('cm');
+    // cm major step (~56.7 px @ 144 dpi) sits between 30 and 60 at
+    // zoom 1, so the band drops to 'half-only' after the switch.
+    expect(ruler.densityFor(1)).toBe('half-only');
+    // At zoom 0.2 the cm major step is ~11 px → 'major-thinned'.
+    expect(ruler.densityFor(0.2)).toBe('major-thinned');
+  });
+
+  it('dispose blocks further rendering', () => {
+    const ruler = new SlidesRuler({
+      hCanvas: dom.hCanvas,
+      vCanvas: dom.vCanvas,
+      corner: dom.corner,
+      dpr: 1,
+      unit: 'inch',
+    });
+    ruler.dispose();
+    // After dispose, render is a no-op; canvas dimensions stay at the
+    // default 300×150 (no resize was triggered).
+    ruler.render({ hostWidth: 1920, hostHeight: 1080 });
+    expect(dom.hCanvas.width).toBe(300);
+    expect(dom.vCanvas.width).toBe(300);
+  });
+
+  it('resizes backing canvases according to dpr', () => {
+    const ruler = new SlidesRuler({
+      hCanvas: dom.hCanvas,
+      vCanvas: dom.vCanvas,
+      corner: dom.corner,
+      dpr: 2,
+      unit: 'inch',
+    });
+    ruler.render({ hostWidth: 800, hostHeight: 450 });
+    // h-ruler: 800 × 20 CSS, doubled by dpr
+    expect(dom.hCanvas.width).toBe(1600);
+    expect(dom.hCanvas.height).toBe(40);
+    expect(dom.hCanvas.style.width).toBe('800px');
+    expect(dom.hCanvas.style.height).toBe('20px');
+    // v-ruler: 20 × 450 CSS, doubled by dpr
+    expect(dom.vCanvas.width).toBe(40);
+    expect(dom.vCanvas.height).toBe(900);
+    expect(dom.vCanvas.style.width).toBe('20px');
+    expect(dom.vCanvas.style.height).toBe('450px');
+  });
+});

--- a/packages/slides/test/view/editor/ruler/ruler.test.ts
+++ b/packages/slides/test/view/editor/ruler/ruler.test.ts
@@ -29,8 +29,11 @@ describe('SlidesRuler', () => {
     dom = mount();
   });
 
-  it('exposes RULER_SIZE = 20 and SLIDES_PX_PER_INCH = 144', () => {
-    expect(RULER_SIZE).toBe(20);
+  it('exposes a slim RULER_SIZE (14) and SLIDES_PX_PER_INCH = 144', () => {
+    // 14 px keeps an 8-px label visible above the 6-px major tick
+    // while reclaiming ~30 % of the gutter the docs ruler reserves
+    // — see ruler.ts for the rationale.
+    expect(RULER_SIZE).toBe(14);
     expect(SLIDES_PX_PER_INCH).toBe(144);
   });
 
@@ -167,15 +170,15 @@ describe('SlidesRuler', () => {
       unit: 'inch',
     });
     ruler.render({ hostWidth: 800, hostHeight: 450 });
-    // h-ruler: 800 × 20 CSS, doubled by dpr
-    expect(dom.hCanvas.width).toBe(1600);
-    expect(dom.hCanvas.height).toBe(40);
+    // h-ruler: 800 × RULER_SIZE CSS, doubled by dpr
+    expect(dom.hCanvas.width).toBe(800 * 2);
+    expect(dom.hCanvas.height).toBe(RULER_SIZE * 2);
     expect(dom.hCanvas.style.width).toBe('800px');
-    expect(dom.hCanvas.style.height).toBe('20px');
-    // v-ruler: 20 × 450 CSS, doubled by dpr
-    expect(dom.vCanvas.width).toBe(40);
+    expect(dom.hCanvas.style.height).toBe(`${RULER_SIZE}px`);
+    // v-ruler: RULER_SIZE × 450 CSS, doubled by dpr
+    expect(dom.vCanvas.width).toBe(RULER_SIZE * 2);
     expect(dom.vCanvas.height).toBe(900);
-    expect(dom.vCanvas.style.width).toBe('20px');
+    expect(dom.vCanvas.style.width).toBe(`${RULER_SIZE}px`);
     expect(dom.vCanvas.style.height).toBe('450px');
   });
 });

--- a/packages/slides/test/view/editor/ruler/ruler.test.ts
+++ b/packages/slides/test/view/editor/ruler/ruler.test.ts
@@ -170,15 +170,15 @@ describe('SlidesRuler', () => {
       unit: 'inch',
     });
     ruler.render({ hostWidth: 800, hostHeight: 450 });
-    // h-ruler: 800 × RULER_SIZE CSS, doubled by dpr
+    // CSS width / height are owned by the host (slides-view's absolute
+    // positioning on the ruler canvases via top / left / right /
+    // bottom), so the ruler only updates the backing-store dimensions.
+    // In jsdom there is no layout pass, so `clientWidth` is 0 and the
+    // ruler falls back to the host extent — yielding the same backing
+    // size a browser would compute under default centring.
     expect(dom.hCanvas.width).toBe(800 * 2);
     expect(dom.hCanvas.height).toBe(RULER_SIZE * 2);
-    expect(dom.hCanvas.style.width).toBe('800px');
-    expect(dom.hCanvas.style.height).toBe(`${RULER_SIZE}px`);
-    // v-ruler: RULER_SIZE × 450 CSS, doubled by dpr
     expect(dom.vCanvas.width).toBe(RULER_SIZE * 2);
     expect(dom.vCanvas.height).toBe(900);
-    expect(dom.vCanvas.style.width).toBe(`${RULER_SIZE}px`);
-    expect(dom.vCanvas.style.height).toBe('450px');
   });
 });

--- a/packages/slides/test/view/editor/snap.test.ts
+++ b/packages/slides/test/view/editor/snap.test.ts
@@ -111,16 +111,19 @@ describe('snapDelta', () => {
 
   it('prefers a user guide over a closer element edge', () => {
     // Edge at x=500 right edge — dragged left edge at 503 → 3 px gap.
-    // Guide at x=505 → dragged left edge at 503 → 2 px gap.
-    // Both inside threshold (8). Closer = edge, but guide outranks it.
+    // Guide at x=507 → dragged left edge at 503 → 4 px gap.
+    // Both inside threshold (8). Edge is the *closer* candidate
+    // numerically, but guide still wins via priority — which is what
+    // the priority rule actually claims. Earlier fixture had the
+    // guide at 505 (only 2 px away) so the test would have passed
+    // even without the priority rule kicking in.
     const others: Frame[] = [f(400, 400, 100, 100)];
-    const guides = [{ id: 'g1', axis: 'x' as const, position: 505 }];
+    const guides = [{ id: 'g1', axis: 'x' as const, position: 507 }];
     const result = snapDelta(
       { x: 0, y: 0, w: 100, h: 100 }, 503, 0, others, SLIDE, guides,
     );
-    // dragged left edge (originally 0) + dx → 505 (= guide.position).
-    // So dx should be 505 (snap by left edge to the guide).
-    expect(result.dx).toBe(505);
+    // dragged left edge (originally 0) + dx → 507 (= guide.position).
+    expect(result.dx).toBe(507);
     expect(result.guides[0]).toMatchObject({
       kind: 'guide',
       guideId: 'g1',

--- a/packages/slides/test/view/editor/snap.test.ts
+++ b/packages/slides/test/view/editor/snap.test.ts
@@ -75,4 +75,78 @@ describe('snapDelta', () => {
     );
     expect(result.guides).toEqual([]);
   });
+
+  // --- Phase 5: presentation-wide guides as snap targets ---
+
+  it('snaps the dragged left edge to a vertical guide', () => {
+    // bbox at x=860 + dx=37 puts left edge at 897. Guide at 900 is
+    // 3 px away — inside threshold. Snap: dx = 40 (left edge → 900).
+    const guides = [{ id: 'g1', axis: 'x' as const, position: 900 }];
+    const result = snapDelta(
+      { x: 860, y: 0, w: 100, h: 100 }, 37, 0, [], SLIDE, guides,
+    );
+    expect(result.dx).toBe(40);
+    expect(result.guides[0]).toMatchObject({
+      axis: 'x',
+      position: 900,
+      kind: 'guide',
+      guideId: 'g1',
+    });
+  });
+
+  it('prefers slide-center over a user guide within the same threshold', () => {
+    // Both candidates within threshold; slide-center wins.
+    // dragged bbox (x=860, w=100) at dx=53 → centre at 1013, snap to 960 (Δ=−3).
+    // Guide at 1014 → dragged left edge (860+53+? — use centre snap instead).
+    // Construct so slide-centre and guide both qualify; slide-centre
+    // demands centre→960 (dx=50). Guide at 960 also matches by centre
+    // (Δ=0). With ties on position they both target 960; the priority
+    // rule keeps `kind: 'slide-center'`.
+    const guides = [{ id: 'g1', axis: 'x' as const, position: 960 }];
+    const result = snapDelta(
+      { x: 860, y: 0, w: 100, h: 100 }, 53, 0, [], SLIDE, guides,
+    );
+    expect(result.guides[0].kind).toBe('slide-center');
+  });
+
+  it('prefers a user guide over a closer element edge', () => {
+    // Edge at x=500 right edge — dragged left edge at 503 → 3 px gap.
+    // Guide at x=505 → dragged left edge at 503 → 2 px gap.
+    // Both inside threshold (8). Closer = edge, but guide outranks it.
+    const others: Frame[] = [f(400, 400, 100, 100)];
+    const guides = [{ id: 'g1', axis: 'x' as const, position: 505 }];
+    const result = snapDelta(
+      { x: 0, y: 0, w: 100, h: 100 }, 503, 0, others, SLIDE, guides,
+    );
+    // dragged left edge (originally 0) + dx → 505 (= guide.position).
+    // So dx should be 505 (snap by left edge to the guide).
+    expect(result.dx).toBe(505);
+    expect(result.guides[0]).toMatchObject({
+      kind: 'guide',
+      guideId: 'g1',
+    });
+  });
+
+  it('snaps the dragged top edge to a horizontal guide', () => {
+    const guides = [{ id: 'gh', axis: 'y' as const, position: 300 }];
+    const result = snapDelta(
+      { x: 0, y: 0, w: 100, h: 100 }, 0, 297, [], SLIDE, guides,
+    );
+    expect(result.dy).toBe(300);
+    expect(result.guides[0]).toMatchObject({
+      axis: 'y',
+      position: 300,
+      kind: 'guide',
+      guideId: 'gh',
+    });
+  });
+
+  it('does not snap when a guide is outside the 8-px threshold', () => {
+    const guides = [{ id: 'g1', axis: 'x' as const, position: 500 }];
+    const result = snapDelta(
+      { x: 0, y: 0, w: 100, h: 100 }, 10, 0, [], SLIDE, guides,
+    );
+    expect(result.dx).toBe(10);
+    expect(result.guides).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

- Add horizontal + vertical rulers to the slides editor, plus presentation-wide alignment guides that can be drag-created from the rulers and snapped to during element drags.
- Tone-down the chrome: slim **14-px transparent ruler** pinned to the **canvas-area frame** (not the slide), slide vertically + horizontally **centered**, speaker-notes panel **borderless** with a Google-Slides-style **top-drag resizer**.
- Reuse the docs ruler's tick + unit primitives via shared exports on `@wafflebase/docs` (slides extracts `tickHeights` / `labelFontSize` / `labelInset` params; docs behaviour preserved bit-for-bit).

Design: [`docs/design/slides/slides-ruler.md`](../blob/slides-ruler-extract-core/docs/design/slides/slides-ruler.md) · Plan: [`docs/tasks/active/20260523-slides-ruler-todo.md`](../blob/slides-ruler-extract-core/docs/tasks/active/20260523-slides-ruler-todo.md)

### What landed (13 commits across 6 phases + UX polish)

- **P1** — Extract docs ruler tick + unit helpers into a shared module (no docs behaviour change).
- **P2** — `SlidesRuler` controller, H/V canvases, 144 dpi, zoom-aware density.
- **P3** — `Guide` type + Yorkie schema + Mem/Yorkie store APIs + passive overlay paint.
- **P4** — Ruler drag-out → addGuide; existing guide drag → moveGuide / drag-onto-ruler → removeGuide; hover cursor; right-click menu.
- **P5** — Guides participate in the snap engine with priority `slide-center > guide > edge`; snapped guide is thickened + deepened.
- **P6** — Read-only mount tests; design doc reconciled with shipped behavior.
- **Polish** — Slim transparent ruler; ruler pinned to frame; slide vertically centered; notes borderless + draggable top divider with localStorage persistence.

## Test plan

- [x] Open a slides document — ruler appears at the top + left edges of the **canvas area** (stays put as the slide drifts inside the frame).
- [x] Slide is **vertically AND horizontally centered** in the canvas area on tall viewports.
- [x] Drag from either ruler onto the canvas → magenta preview line follows cursor → mouseup commits a new guide.
- [x] Drag an existing guide (hover within 4 px → cursor swaps to `col-resize` / `row-resize`) → repositions on mouseup.
- [x] Drag a guide back onto a ruler → guide is deleted.
- [x] Right-click on a guide → context menu shows *Delete guide* / *Delete all on this axis* / *Delete all guides*.
- [x] Drag an element near a guide → element snaps; the guide thickens to 2 px in deeper magenta.
- [x] `slide-center` snap still wins over a guide within the same threshold; guide still wins over a closer element edge.
- [x] Drag the divider above the speaker notes upward → notes panel grows, canvas shrinks (clamped to ≥ 40 % of column height).
- [x] Reload — speaker notes height persists (`wfb-slides-notes-height`); left thumbnail width persists (`wfb-slides-left-width`).
- [x] Open with a viewer-role share link → ruler + guides **visible**, but drag-out / guide-drag / right-click menu **inert**.
- [x] Concurrent users see committed guides appear (in-flight preview is local-only in v1; presence field reserved).
- [x] Presentation mode + per-slide thumbnails do **not** paint guides.
- [x] `pnpm verify:fast` passes (1273 slides tests + 792 docs tests + backend / frontend gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Horizontal and vertical rulers in the slides editor with locale-aware units.
  * Draggable presentation-wide alignment guides: create from rulers, move, delete; persist with the presentation.
  * Guides integrated into snapping with clarified priority so center snaps and guides behave predictably.
  * Speaker notes panel now resizable with persistent height.

* **Documentation**
  * Added design spec and phased implementation plan for ruler/guide features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->