### PR TITLE
Build packages in dependency order in pnpm build

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| pptx shape blipfill (2026-05-23) | [20260523-pptx-shape-blipfill-todo.md](./active/20260523-pptx-shape-blipfill-todo.md) | - |
 | slides ruler (2026-05-23) | [20260523-slides-ruler-todo.md](./active/20260523-slides-ruler-todo.md) | - |
 | slides homepage docs (2026-05-21) | [20260521-slides-homepage-docs-todo.md](./active/20260521-slides-homepage-docs-todo.md) | - |
 | slides thumbnail async bg (2026-05-21) | [20260521-slides-thumbnail-async-bg-todo.md](./active/20260521-slides-thumbnail-async-bg-todo.md) | - |
@@ -31,7 +32,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 202
+- Archived task count: 203
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides ruler (2026-05-23)
+Latest active task: pptx shape blipfill (2026-05-23)

--- a/docs/tasks/archive/2026/05/20260524-build-dependency-order-todo.md
+++ b/docs/tasks/archive/2026/05/20260524-build-dependency-order-todo.md
@@ -1,0 +1,59 @@
+# Fix `pnpm build` dependency ordering
+
+## Problem
+
+`pnpm build` fails with exit code 1. `slides` and `backend` builds fail with
+TS2305 / TS2353 / TS2339 errors about missing exports from `@wafflebase/docs`
+(`detectUnit`, `getGridConfig`, `drawTicks`, `RulerUnit`, `GridConfig`,
+`TickDensity`) and `@wafflebase/slides` (`Guide`, `guides`).
+
+## Root cause
+
+Cross-package type resolution uses each package's built `dist/*.d.ts`, not its
+source. The `dist/` folders are gitignored and were stale (predating commit
+#285 which added the ruler + guides symbols). The `build` script:
+
+1. **Never builds `@wafflebase/docs`** — it is absent from the concurrent list,
+   yet slides/frontend/backend/cli all depend on it.
+2. Builds packages **concurrently with no dependency ordering**, so consumers
+   read stale/half-written dist of their dependencies.
+
+Dependency graph:
+
+```
+docs    (leaf)
+sheets  (leaf)
+slides   -> docs
+frontend -> docs, sheets, slides
+backend  -> docs, sheets, slides
+cli      -> docs, slides
+```
+
+Correct topological order: `(docs, sheets) -> slides -> (frontend, backend, cli)`.
+
+## Plan
+
+- [x] Rewrite root `build` script to build in topological order
+- [x] Verify from clean dist: `rm -rf packages/*/dist && pnpm build` passes
+- [x] Run `pnpm verify:fast`
+- [x] Commit on `fix/build-dependency-order`
+
+## Review
+
+New `build` script:
+
+```
+concurrently "pnpm --filter @wafflebase/docs build" "pnpm sheets build" \
+  && pnpm slides build \
+  && concurrently "pnpm frontend build" "pnpm backend build" "pnpm cli build"
+```
+
+- Tier 0 (leaves, parallel): docs, sheets
+- Tier 1: slides (needs docs dist)
+- Tier 2 (parallel): frontend, backend, cli (need docs/sheets/slides dist)
+
+Verification:
+
+- `rm -rf packages/*/dist && pnpm build` -> exit 0 (clean state, was exit 1 before)
+- `pnpm verify:fast` -> exit 0 (792 tests pass)
+

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,13 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 202
+Total archived tasks: 203
 
-## 2026/05 (57 tasks)
+## 2026/05 (58 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| build dependency order (2026-05-24) | [20260524-build-dependency-order-todo.md](./2026/05/20260524-build-dependency-order-todo.md) | - |
 | slides share toolbar (2026-05-23) | [20260523-slides-share-toolbar-todo.md](./2026/05/20260523-slides-share-toolbar-todo.md) | [20260523-slides-share-toolbar-lessons.md](./2026/05/20260523-slides-share-toolbar-lessons.md) |
 | slides arrow key text edit (2026-05-21) | [20260521-slides-arrow-key-text-edit-todo.md](./2026/05/20260521-slides-arrow-key-text-edit-todo.md) | [20260521-slides-arrow-key-text-edit-lessons.md](./2026/05/20260521-slides-arrow-key-text-edit-lessons.md) |
 | slides group handle bbox (2026-05-20) | [20260520-slides-group-handle-bbox-todo.md](./2026/05/20260520-slides-group-handle-bbox-todo.md) | [20260520-slides-group-handle-bbox-lessons.md](./2026/05/20260520-slides-group-handle-bbox-lessons.md) |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Super Simple Spreadsheet",
   "scripts": {
     "dev": "concurrently \"pnpm frontend dev\" \"pnpm backend start:dev\" \"pnpm documentation dev\"",
-    "build": "concurrently \"pnpm sheets build\" \"pnpm slides build\" \"pnpm frontend build\" \"pnpm backend build\" \"pnpm cli build\"",
+    "build": "concurrently \"pnpm --filter @wafflebase/docs build\" \"pnpm sheets build\" && pnpm slides build && concurrently \"pnpm frontend build\" \"pnpm backend build\" \"pnpm cli build\"",
     "test": "concurrently \"pnpm sheets test\" \"pnpm slides test\" \"pnpm frontend test\" \"pnpm backend test\" \"pnpm cli test\" \"pnpm --filter @wafflebase/docs test\"",
     "verify:architecture": "pnpm frontend lint:arch && pnpm backend lint:arch",
     "verify:fast": "pnpm verify:architecture && pnpm frontend lint && pnpm frontend test && pnpm backend test && pnpm sheets typecheck && pnpm sheets test && pnpm slides typecheck && pnpm slides test && pnpm cli typecheck && pnpm cli test && pnpm --filter @wafflebase/docs typecheck && pnpm --filter @wafflebase/docs test",


### PR DESCRIPTION
## Summary

`pnpm build` failed with exit code 1: the `slides` and `backend` package
builds errored on missing exports.

```
slides:  @wafflebase/docs has no exported member 'detectUnit' / 'getGridConfig'
         / 'drawTicks' / 'RulerUnit' / 'GridConfig' / 'TickDensity'
backend: @wafflebase/slides has no exported member 'Guide';
         'guides' does not exist on type 'SlidesDocument'
```

**Root cause** — these symbols were added in #285 (slides ruler + guides) and
are correctly exported from source, but cross-package type resolution reads each
dependency's built `dist/*.d.ts` (gitignored, often stale), not its source. The
root `build` script (a) never built `@wafflebase/docs` at all, and (b) ran every
package build **concurrently with no dependency ordering**, so `slides` compiled
against `docs`' stale dist and `backend` against `slides`' stale dist.

Dependency graph:

```
docs    (leaf)
sheets  (leaf)
slides   -> docs
frontend -> docs, sheets, slides
backend  -> docs, sheets, slides
cli      -> docs, slides
```

**Fix** — build in topological order: `(docs, sheets) -> slides ->
(frontend, backend, cli)`, so every package compiles against freshly built
dependency declarations.

## Test plan

- [x] `rm -rf packages/*/dist && pnpm build` → exit 0 (was exit 1 before, from a clean dist state)
- [x] `pnpm verify:fast` → exit 0 (792 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated root build script execution sequence to optimize the build process

* **Documentation**
  * Added new task documentation for build improvement
  * Updated task tracking and archive records

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->