### PR TITLE
Bump version to v0.4.2

### DIFF
--- a/docs/tasks/active/20260525-release-v0.4.2-todo.md
+++ b/docs/tasks/active/20260525-release-v0.4.2-todo.md
@@ -1,0 +1,106 @@
+---
+title: Release v0.4.2
+date: 2026-05-25
+status: in-progress
+---
+
+# Release v0.4.2
+
+## Scope
+
+Cut a **patch** release covering the 25 commits between `v0.4.1` and
+`HEAD`. The dominant theme this cycle is **infrastructure & quality**:
+backend security hardening (CSRF, rate limiting, request validation,
+structured logging), a new shared `@wafflebase/tokens` design-tokens
+package, a frontend test migration from `node:test` to Vitest, a
+repaired and CI-wired frontend Yorkie integration lane, dependency
+bumps clearing 22 Dependabot alerts, and dependency-ordered package
+builds.
+
+On the product side: **Slides** gained rulers + presentation-wide
+guides, group/ungroup with a nested element tree, connector hit-test
+and drag-UX fixes, ghost-preview drag-move, a mobile editor shell with
+a morphing toolbar, share-link toolbar with viewer read-only
+enforcement, lazy-painted thumbnails, and PPTX shape-level blipFill
+image import. **Sheets / Formulas** added a power (`^`) operator, a
+unary postfix percentage operator, and an IFERROR/IFNA referenced-error
+fix. The homepage and docs site now feature Slides.
+
+### Devops impact
+
+No Prisma schema migration. #289 introduced three **optional** backend
+env vars, all with safe defaults:
+
+- `BACKEND_TRUST_PROXY` (default `0`)
+- `BACKEND_JSON_BODY_LIMIT` (default `25mb`)
+- `LOG_LEVEL` (default `info`)
+
+The image bump is therefore routine, **but** production deployments
+behind a reverse proxy should set `BACKEND_TRUST_PROXY=1` so the new
+rate limiter reads the real client IP from `X-Forwarded-For` instead of
+the proxy hop.
+
+## Highlights since v0.4.1
+
+### Infrastructure / Quality
+
+- Harden backend: CSRF, rate limit, validation, observability — #289
+- Introduce `@wafflebase/tokens` shared design tokens package — #292
+- Repair and CI-wire the frontend Yorkie integration lane — #290
+- Migrate frontend tests from `node:test` to Vitest — #291
+- Bump deps and pnpm overrides to clear 22 Dependabot alerts — #294
+- Build packages in dependency order in pnpm build — #287
+
+### Slides
+
+- Add slides ruler + presentation-wide draggable guides — #285
+- Provide group / ungroup with nested element tree — #263
+- Refit group on drill-out + rotation-preserving handles + multi-rotate — #269
+- Select precise shape and add connector hit-test — #266
+- Fix connector endpoint drag UX (no-crash translate + ghost line preview) — #265
+- Display ghost-preview drag-move + move cursor on hover — #267
+- Add mobile shell and morphing toolbar for slides editor — #268
+- Mount toolbar on slides share + enforce viewer read-only — #282
+- Lazy-paint slides thumbnails + show async image backgrounds — #271
+- Skip slides arrow-key shape nudge while editing text-box — #272
+- Import PPTX shape-level blipFill as ImageElement — #284
+
+### Sheets / Formulas
+
+- Support power (`^`) operator in sheets — #276
+- Support unary postfix percentage operator in sheet — #286
+- Fix to catch referenced errors in IFERROR/IFNA — #275
+
+### Homepage / Site
+
+- Add Slides to homepage and documentation site — #277
+- Stick site header by scoping scroll to content area — #283
+
+## Tasks
+
+- [x] Bump version `0.4.1` → `0.4.2` across the 9 `package.json` files
+      (root + 8 packages: backend, cli, docs, documentation, frontend,
+      sheets, slides, tokens)
+- [x] Run `pnpm verify:fast` and confirm pass (389 files / 3993 tests)
+- [x] Run `pnpm verify:self` (full builds) and confirm pass (10 lanes)
+- [x] Commit `Bump version to v0.4.2` on `release/v0.4.2` branch
+- [ ] Open PR against `main`
+- [ ] After merge, tag `v0.4.2` and create GitHub release with
+      hand-categorised highlights (Infra/Quality, Slides, Sheets/Formulas,
+      Site)
+- [ ] Verify `npm-publish.yml` and `docker-publish.yml` workflows succeed
+- [ ] Confirm `@wafflebase/cli@0.4.2` and `@wafflebase/docs@0.4.2` on npm,
+      and `yorkieteam/wafflebase:v0.4.2` on Docker Hub (multi-arch)
+- [ ] Bump server image in `yorkie-team/devops` (note
+      `BACKEND_TRUST_PROXY=1` for prod proxy) and open devops PR
+
+## Contributors
+
+- @hackerwins (maintainer)
+- @mahavirkunwar — #286 🎉 first contribution
+- @MaksZhukov — #276 🎉 first contribution
+- @resolvicomai — #275 🎉 first contribution
+
+## Review
+
+_To be completed after release._

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wafflebase",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "description": "Super Simple Spreadsheet",
   "scripts": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wafflebase/backend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "private": true,
   "license": "Apache-2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wafflebase/cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "CLI for Wafflebase spreadsheet API",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wafflebase/docs",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "Apache-2.0",
   "description": "Canvas-based document editor for Wafflebase",
   "type": "module",

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wafflebase/documentation",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vitepress dev --port 5174 --no-open",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wafflebase/frontend",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/sheets/package.json
+++ b/packages/sheets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wafflebase/sheets",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "Apache-2.0",
   "description": "Frontend for Wafflebase",
   "type": "module",

--- a/packages/slides/package.json
+++ b/packages/slides/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wafflebase/slides",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "Apache-2.0",
   "description": "Presentation engine for Wafflebase",
   "type": "module",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wafflebase/tokens",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "Apache-2.0",
   "description": "Shared design tokens for Wafflebase (palette, semantic colors, radius, typography)",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release bumping `0.4.1 → 0.4.2` across the root and all 8
packages (backend, cli, docs, documentation, frontend, sheets, slides,
tokens). Covers the 25 commits merged since `v0.4.1`.

The dominant theme this cycle is **infrastructure & quality**:

- Harden backend: CSRF, rate limit, validation, observability (#289)
- Introduce `@wafflebase/tokens` shared design tokens package (#292)
- Repair and CI-wire the frontend Yorkie integration lane (#290)
- Migrate frontend tests from `node:test` to Vitest (#291)
- Bump deps and pnpm overrides to clear 22 Dependabot alerts (#294)
- Build packages in dependency order in pnpm build (#287)

Product work: Slides rulers + presentation-wide guides (#285),
group/ungroup with a nested element tree (#263), connector hit-test
(#266) and drag-UX fixes (#265), ghost-preview drag-move (#267), a
mobile editor shell + morphing toolbar (#268), share-link toolbar with
viewer read-only (#282), lazy-painted thumbnails (#271), and PPTX
shape-level blipFill import (#284). Sheets / Formulas gained a power
(`^`) operator (#276), a unary postfix percentage operator (#286), and
an IFERROR/IFNA referenced-error fix (#275).

### Devops impact

No Prisma migration. #289 adds three **optional** backend env vars with
safe defaults — `BACKEND_TRUST_PROXY` (`0`), `BACKEND_JSON_BODY_LIMIT`
(`25mb`), `LOG_LEVEL` (`info`). The image bump stays routine, but
production behind a reverse proxy should set `BACKEND_TRUST_PROXY=1` so
the new rate limiter reads the real client IP.

## Test plan

- [x] `pnpm verify:fast` — lint + unit tests green
- [x] `pnpm verify:self` — all 10 build/test lanes green (90.7s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
