### PR TITLE
Build Docker images on native arm64 runners to fix release hang

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,12 +14,22 @@ env:
   IMAGE_NAME: yorkieteam/wafflebase
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     permissions:
       contents: read
-      packages: write
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,22 +43,73 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Determine Docker tags
-        id: tags
-        run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            VERSION="${{ github.event.release.tag_name }}"
-            echo "tags=${{ env.IMAGE_NAME }}:${VERSION},${{ env.IMAGE_NAME }}:latest" >> "$GITHUB_OUTPUT"
-          else
-            echo "tags=${{ env.IMAGE_NAME }}:latest" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+      # Build natively on the matching runner architecture (no QEMU emulation)
+      # and push by digest only; the merge job assembles the tagged manifest.
+      - name: Build and push image by digest
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: ${{ steps.tags.outputs.tags }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:latest
-          cache-to: type=inline
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge & push manifest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # push to main -> :latest ; release -> :<tag_name> + :latest
+      - name: Determine tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:latest

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| docker publish arm64 native (2026-05-25) | [20260525-docker-publish-arm64-native-todo.md](./active/20260525-docker-publish-arm64-native-todo.md) | - |
+| release v0.4.2 (2026-05-25) | [20260525-release-v0.4.2-todo.md](./active/20260525-release-v0.4.2-todo.md) | - |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
 | slides package mvp (2026-05-05) | [20260505-slides-package-mvp-todo.md](./active/20260505-slides-package-mvp-todo.md) | [20260505-slides-package-mvp-lessons.md](./active/20260505-slides-package-mvp-lessons.md) |
@@ -30,4 +32,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 213
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: docs comments followup (2026-05-17)
+Latest active task: docker publish arm64 native (2026-05-25)

--- a/docs/tasks/active/20260525-docker-publish-arm64-native-todo.md
+++ b/docs/tasks/active/20260525-docker-publish-arm64-native-todo.md
@@ -1,0 +1,54 @@
+# Docker Publish — native arm64 runners (no QEMU)
+
+## Problem
+
+The v0.4.2 release Docker build hangs and fails. `Docker Publish` runs:
+
+- Previous releases (v0.4.1 / v0.4.0 / v0.3.x): ~2–3 min, success.
+- v0.4.2 (run 26367212237): attempt 1 ran exactly 6h (16:54:50 → 22:55:08)
+  and was cancelled by GitHub's hard 6-hour job limit; attempt 2 grinding again.
+
+### Root cause
+
+The workflow builds `linux/amd64,linux/arm64` in a single job on an amd64
+runner. arm64 is produced via **QEMU emulation**. The `Dockerfile` pins the
+**builder** stage to `--platform=$BUILDPLATFORM` (native, fast) but the
+**runtime** stage is NOT pinned, so for the arm64 target these run emulated:
+
+- `pnpm install --frozen-lockfile --prod`
+- `npx prisma@6.6.0 generate`  ← notoriously slow/hangs under QEMU arm64
+
+Normally these layers are **cache hits** from `cache-from: type=registry,ref=:latest`
+(`type=inline`), so the emulated RUNs never execute → ~3 min. The release was
+preceded by #294 ("Bump deps", rewrote `pnpm-lock.yaml` 687 lines + 6
+package.json) and #295 (version bump, touched lockfile + all package.json),
+which **invalidated those cached layers**. The release then executed the arm64
+runtime stage emulated for the first time → exceeded the 6h limit. `type=inline`
+cache also can't recover (no multi-arch / intermediate-stage caching).
+
+## Fix
+
+Build each platform on a **native runner** (no QEMU), push by digest, merge a
+multi-arch manifest. Repo is public → `ubuntu-24.04-arm` is free.
+
+## Tasks
+
+- [ ] Rewrite `.github/workflows/docker-publish.yml`:
+  - [ ] `build` matrix: `linux/amd64`→`ubuntu-24.04`, `linux/arm64`→`ubuntu-24.04-arm`
+  - [ ] `push-by-digest=true`, export + upload digest artifact per arch
+  - [ ] `cache-from/to: type=gha,mode=max,scope=<arch>` (replaces broken inline cache)
+  - [ ] `timeout-minutes` safety net on build + merge jobs
+  - [ ] `merge` job: download digests, `docker/metadata-action` tags
+        (`latest` always; `<release tag>` on release), `buildx imagetools create`
+  - [ ] preserve trigger semantics: push→`:latest`, release→`:<tag>` + `:latest`
+- [ ] Validate workflow YAML (actionlint if available)
+- [ ] `pnpm verify:fast`
+- [ ] Self code review over branch diff
+- [ ] Open PR; cancel the stuck run 26367212237
+
+## Notes / tradeoffs
+
+- `type=gha` keeps Docker Hub clean (vs `type=registry` cache tags). GHA cache is
+  ref-scoped, so release (tag ref) builds get a cold cache and rebuild natively
+  (~minutes, acceptable); main pushes reuse their scope and stay fast.
+- No `setup-qemu-action` needed — every stage now builds natively.


### PR DESCRIPTION
## Summary

The **v0.4.2 release Docker build hangs and fails** ([run 26367212237](https://github.com/wafflebase/wafflebase/actions/runs/26367212237)). Attempt 1 ran for **exactly 6h** (16:54:50 → 22:55:08) and was cancelled by GitHub's hard 6-hour job limit; attempt 2 was grinding toward the same fate. Previous releases (v0.4.1 / v0.4.0 / v0.3.x) all finished in ~2–3 min.

### Root cause

`docker-publish.yml` built `linux/amd64,linux/arm64` in a **single job on an amd64 runner**, so arm64 was produced under **QEMU emulation**. The `Dockerfile` pins the *builder* stage to `--platform=$BUILDPLATFORM` (native, fast), but the *runtime* stage is not pinned, so for the arm64 target these ran emulated:

- `pnpm install --frozen-lockfile --prod`
- `npx prisma@6.6.0 generate` ← notoriously slow / hangs under QEMU arm64

These were normally **inline-cache hits** (`cache-from: type=registry,ref=:latest`), so the emulated `RUN`s never executed → ~3 min. The release was immediately preceded by #294 ("Bump deps", rewrote `pnpm-lock.yaml` 687 lines + 6 `package.json`) and #295 (version bump, touched lockfile + all `package.json`), which **invalidated those cached layers**. The release then executed the arm64 runtime stage emulated for the first time → past the 6h limit. `type=inline` cache also can't recover (no multi-arch / intermediate-stage caching).

### Fix

Build each platform on its **own native runner** — no QEMU anywhere:

- `build` matrix: `linux/amd64` → `ubuntu-24.04`, `linux/arm64` → `ubuntu-24.04-arm` (free on this public repo), each pushed **by digest**.
- `merge` job downloads the digests and assembles the multi-arch manifest via `docker buildx imagetools create`, applying tags from `docker/metadata-action`.
- Replace the broken `type=inline` cache with `type=gha,mode=max` scoped per arch.
- Add `timeout-minutes` (30 build / 15 merge) so a hang fails fast instead of burning 6h.

Tag semantics are unchanged: push to `main` → `:latest`; release → `:<tag_name>` + `:latest`. Pattern follows the official Docker "distribute build across multiple runners" reference.

**Tradeoff:** `type=gha` keeps Docker Hub clean (vs `type=registry` cache tags). GHA cache is ref-scoped, so release (tag-ref) builds get a cold cache and rebuild natively (~minutes, acceptable); `main` pushes reuse their scope and stay fast.

## Test plan

- [x] `pnpm verify:fast` green (lint + 792 unit tests).
- [x] Workflow YAML parses; jobs `build` + `merge`.
- [ ] CI on this PR runs `Docker Publish` (push to `main` path) — confirm both arch builds finish in minutes and the manifest merges.
- [ ] After merge, re-cut/re-run the v0.4.2 release publish and confirm a multi-arch image (`docker buildx imagetools inspect yorkieteam/wafflebase:v0.4.2` shows amd64 + arm64).

> Note: the stuck run 26367212237 should be cancelled (`gh run cancel 26367212237`) so it stops burning CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker image publishing for ARM64 architecture builds that previously hung during execution.

* **Chores**
  * Optimized Docker publish workflow with per-architecture build jobs and manifest assembly.
  * Added task documentation tracking Docker publish improvements and release v0.4.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->