### PR TITLE
Honor blipFill <a:stretch><a:fillRect> cover crop on PPTX import

### DIFF
--- a/docs/design/slides/slides-themes-layouts-import.md
+++ b/docs/design/slides/slides-themes-layouts-import.md
@@ -362,6 +362,9 @@ choice is **reuse existing**.
 | `<p:cxnSp>` | ShapeElement (line/arrow) | ✅ |
 | `<p:grpSp>` | Flatten: child frames composed with group transform | ⚠️ (group lost) |
 | `<p:graphicFrame><a:tbl>` | Matrix of TextElements + border ShapeElements per cell | ⚠️ (until docs-tables integration in v1.5) |
+| `<p:sp>` with `<a:blipFill>` | ImageElement (shape `xfrm` → frame); full-bleed template visuals built as `custGeom`/`prstGeom` + blip | ✅ (non-rect freeform clip path lost) |
+| `<a:blipFill>` `<a:srcRect>` | source crop → `ImageElement.data.crop` | ✅ |
+| `<a:blipFill>` `<a:stretch><a:fillRect>` (negative insets) | "Fill" / cover crop → equivalent `data.crop`. Cover case only; positive-inset letterbox falls back to full stretch; not composed with `srcRect` | ✅ |
 | `<a:blip>` `alphaModFix` | `amt / 100_000` → `ImageElement.data.opacity` (clamped to `[0, 1]`; dropped at 1) | ✅ |
 | `<a:blip>` recolor / duotone | dropped | ❌ |
 | `frame.rotation` (`rot`) | EMU degrees → radians | ✅ |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,6 +19,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | docker publish arm64 native (2026-05-25) | [20260525-docker-publish-arm64-native-todo.md](./active/20260525-docker-publish-arm64-native-todo.md) | - |
+| pptx blipfill fillrect crop (2026-05-25) | [20260525-pptx-blipfill-fillrect-crop-todo.md](./active/20260525-pptx-blipfill-fillrect-crop-todo.md) | - |
 | release v0.4.2 (2026-05-25) | [20260525-release-v0.4.2-todo.md](./active/20260525-release-v0.4.2-todo.md) | - |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |

--- a/docs/tasks/active/20260525-pptx-blipfill-fillrect-crop-todo.md
+++ b/docs/tasks/active/20260525-pptx-blipfill-fillrect-crop-todo.md
@@ -1,0 +1,85 @@
+# PPTX blipFill `<a:stretch><a:fillRect>` cover-crop support
+
+## Problem
+
+Importing a PPTX where a photo is placed as a `<p:sp>` freeform shape with
+`<a:blipFill>` (not a `<p:pic>`) distorts the image when the shape's frame
+aspect ratio differs from the photo's. PowerPoint reconciles the mismatch with
+a **negative `<a:stretch><a:fillRect>`** (Fill/cover crop): it scales the image
+larger than the shape and clips it. Our importer (`parseBlipFill`) only reads
+`<a:srcRect>` and ignores `<a:stretch><a:fillRect>`, so with no crop the
+renderer stretches the whole image into the frame → squish.
+
+Repro deck: "Blue Green Colorful Daycare Center Presentation.pptx"
+- Slide 3, Freeform 15: `image50.jpeg` 1200×1800 (2:3) into a square frame
+  (`ext 6350000×6349974`, AR 1.0) with `fillRect l="-31963" t="-36905"
+  r="-9496" b="-75284"`. Fill-region AR = 0.667 = native AR (so PowerPoint
+  shows it undistorted).
+- Slide 8: 3 more negative `fillRect`s.
+
+## Root cause
+
+`packages/slides/src/import/pptx/image.ts` `parseBlipFill()` derives `Crop`
+only from `<a:srcRect>`. `<a:stretch><a:fillRect>` (destination cover-crop) is
+never read. Renderer `image-renderer.ts` then hits the no-crop `drawImage(img,
+0, 0, w, h)` full-stretch branch.
+
+## Fix
+
+The crop infrastructure already exists end-to-end (`Crop` type, optional
+`ImageElement.data.crop`, renderer source-rect path, `srcRect` import). A
+negative/zero `fillRect` is mathematically equivalent to a source crop:
+
+```text
+l,t,r,b = insets / 100000
+fw = 1 - l - r ; fh = 1 - t - b
+crop = { x: -l/fw, y: -t/fh, w: 1/fw, h: 1/fh }
+```
+
+In `parseBlipFill`, when `srcRect` yields no crop, fall back to deriving a crop
+from `<a:stretch><a:fillRect>`. Only apply when the result is a valid
+sub-rectangle within `[0,1]` (the cover case). Default (all-zero) → no-op;
+positive insets (letterbox) → skip (keep current behavior). No model/renderer
+changes.
+
+Limitation (documented): `srcRect` takes precedence; we do not compose
+`srcRect` + `fillRect` (rare). Non-rect freeform clip paths still not honored
+(pre-existing v1 limitation).
+
+## Steps
+
+- [x] Write failing unit test in `packages/slides/test/import/pptx/image.test.ts`
+      for negative `fillRect` → expected cover crop (use slide-3 Freeform 15 values).
+- [x] Add no-op (all-zero fillRect), positive-inset (skip), and srcRect-
+      precedence assertions.
+- [x] Implement `parseStretchFillRect` fallback in `image.ts`.
+- [x] `pnpm --filter @wafflebase/slides test` green (1300 tests).
+- [x] `pnpm verify:fast` green.
+- [x] Self code-review over branch diff (subagent: Ready to merge=Yes; applied 2
+      minor nits, declined 1 with reasoning).
+- [x] Open PR — #297.
+
+## Review
+
+Root cause exactly as predicted: `parseBlipFill` read only `<a:srcRect>` and
+dropped `<a:stretch><a:fillRect>`. Fix derives the equivalent source `Crop`
+from the negative fillRect (cover case only), reusing the existing crop
+pipeline — no model or renderer change (`image.ts` +48/-1).
+
+**End-to-end verification** against the real deck (temporary jsdom test, since
+removed): slide 3 (display order = `slide3.xml`) yields 29 images, exactly 1
+cropped — the portrait photo nested inside a `<p:grpSp>` — with
+`crop = {x:0.22595, y:0.17393, w:0.70692, h:0.47128}`. Cropped-source pixel AR
+= (0.70692·1200)/(0.47128·1800) ≈ 1.0 = the square frame AR ⇒ no distortion,
+matching PowerPoint. (Caught a debug-only mistake: the first pass filtered only
+top-level elements and missed the grouped photo; recursion confirmed the fix.)
+
+Also fixes the 3 negative-fillRect shapes on slide 8.
+
+**Limitations (accepted for v1):** `srcRect` takes precedence — `srcRect` +
+`fillRect` are not composed; positive-inset (letterbox) fillRects fall back to
+full stretch; `<a:tile>` fills unchanged; non-rect freeform clip paths still
+not honored (pre-existing).
+
+**Note:** Only affects *new* imports. The already-shared document was imported
+before the fix and must be re-imported to pick up the corrected crop.

--- a/packages/slides/src/import/pptx/image.ts
+++ b/packages/slides/src/import/pptx/image.ts
@@ -85,7 +85,11 @@ export async function parseBlipFill(
     return undefined;
   }
 
-  const crop = blipFill ? parseSrcRect(child(blipFill, 'srcRect')) : undefined;
+  // Prefer `<a:srcRect>` (source crop); fall back to `<a:stretch><a:fillRect>`
+  // (destination cover crop). PowerPoint expresses "Fill" cropping either way.
+  const crop = blipFill
+    ? parseSrcRect(child(blipFill, 'srcRect')) ?? parseStretchFillRect(blipFill)
+    : undefined;
   const opacity = blip ? parseAlphaModFix(child(blip, 'alphaModFix')) : undefined;
   return {
     src,
@@ -151,5 +155,48 @@ function parseSrcRect(srcRect: Element | undefined): Crop | undefined {
     w: Math.max(0, 1 - l - r),
     h: Math.max(0, 1 - t - b),
   };
+}
+
+/**
+ * `<a:stretch><a:fillRect l t r b/></a:stretch>` — insets (thousandths of a
+ * percent) of the destination rectangle the image is stretched into, relative
+ * to the shape bounds. NEGATIVE insets scale the image *past* the shape
+ * (PowerPoint "Fill" / cover crop) and the shape clips it; this is the
+ * destination-side dual of `<a:srcRect>`. We convert it to the equivalent
+ * source `Crop` so the renderer's source-rect path reproduces the cover
+ * region instead of stretching the whole image into a mismatched frame.
+ *
+ * The fill region maps image fraction `u` to shape fraction `x` via
+ * `x = l + u·(1-l-r)`, so the shape window `x∈[0,1]` corresponds to source
+ * `u∈[-l/fw, (1-l)/fw]` (with `fw = 1-l-r`). Only the cover case (resulting
+ * crop within `[0,1]`) is representable: the default all-zero fillRect is a
+ * no-op, and positive insets (image inset / letterbox) would sample outside
+ * the image, so we skip them and fall back to a full stretch.
+ */
+function parseStretchFillRect(blipFill: Element): Crop | undefined {
+  const stretch = child(blipFill, 'stretch');
+  const fillRect = stretch ? child(stretch, 'fillRect') : undefined;
+  if (!fillRect) return undefined;
+  const l = (attrInt(fillRect, 'l') ?? 0) / 100_000;
+  const t = (attrInt(fillRect, 't') ?? 0) / 100_000;
+  const r = (attrInt(fillRect, 'r') ?? 0) / 100_000;
+  const b = (attrInt(fillRect, 'b') ?? 0) / 100_000;
+  // Default fillRect (no-op): image fills the shape exactly, no crop needed.
+  if (l === 0 && t === 0 && r === 0 && b === 0) return undefined;
+  const fw = 1 - l - r;
+  const fh = 1 - t - b;
+  if (fw <= 0 || fh <= 0) return undefined;
+  const crop: Crop = { x: -l / fw, y: -t / fh, w: 1 / fw, h: 1 / fh };
+  // Only the cover case maps cleanly to a source sub-rectangle.
+  const EPS = 1e-9;
+  if (
+    crop.x < -EPS ||
+    crop.y < -EPS ||
+    crop.x + crop.w > 1 + EPS ||
+    crop.y + crop.h > 1 + EPS
+  ) {
+    return undefined;
+  }
+  return crop;
 }
 

--- a/packages/slides/test/import/pptx/image.test.ts
+++ b/packages/slides/test/import/pptx/image.test.ts
@@ -91,6 +91,122 @@ describe('parsePic', () => {
     expect(result?.data.crop).toEqual({ x: 0.1, y: 0.2, w: 0.9, h: 0.8 });
   });
 
+  it('derives a cover Crop from a negative <a:stretch><a:fillRect>', async () => {
+    // Slide-3 "Freeform 15" values: a 2:3 portrait photo fill-cropped into a
+    // square shape. Negative insets scale the image past the shape bounds; the
+    // equivalent source crop must restore the un-distorted cover region.
+    const pic = picEl(`<p:pic>
+      <p:blipFill>
+        <a:blip r:embed="rId3"/>
+        <a:stretch><a:fillRect l="-31963" t="-36905" r="-9496" b="-75284"/></a:stretch>
+      </p:blipFill>
+      <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm></p:spPr>
+    </p:pic>`);
+    const result = await parsePic(pic, {
+      archive: fakeArchive({ 'ppt/media/image1.png': new Uint8Array([1]) }),
+      slidePartPath: 'ppt/slides/slide1.xml',
+      rels: new Map([
+        ['rId3', { type: 'image', target: '../media/image1.png', external: false }],
+      ]),
+      uploadImage: async () => 'u',
+      scale: emuScale(DEFAULT_WIDESCREEN_EMU),
+      report: new ImportReport(),
+    });
+    expect(result?.data.crop?.x).toBeCloseTo(0.22595, 4);
+    expect(result?.data.crop?.y).toBeCloseTo(0.17393, 4);
+    expect(result?.data.crop?.w).toBeCloseTo(0.70692, 4);
+    expect(result?.data.crop?.h).toBeCloseTo(0.47128, 4);
+  });
+
+  it('ignores a default (all-zero) <a:fillRect> — no crop', async () => {
+    const pic = picEl(`<p:pic>
+      <p:blipFill>
+        <a:blip r:embed="rId3"/>
+        <a:stretch><a:fillRect l="0" t="0" r="0" b="0"/></a:stretch>
+      </p:blipFill>
+      <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm></p:spPr>
+    </p:pic>`);
+    const result = await parsePic(pic, {
+      archive: fakeArchive({ 'ppt/media/image1.png': new Uint8Array([1]) }),
+      slidePartPath: 'ppt/slides/slide1.xml',
+      rels: new Map([
+        ['rId3', { type: 'image', target: '../media/image1.png', external: false }],
+      ]),
+      uploadImage: async () => 'u',
+      scale: emuScale(DEFAULT_WIDESCREEN_EMU),
+      report: new ImportReport(),
+    });
+    expect(result?.data.crop).toBeUndefined();
+  });
+
+  it('skips a positive-inset (letterbox) <a:fillRect> — no crop', async () => {
+    // Positive insets draw the image *inside* the shape (margins). Our Crop
+    // model is source-only, so we leave it as a full stretch rather than
+    // sampling outside the image bounds.
+    const pic = picEl(`<p:pic>
+      <p:blipFill>
+        <a:blip r:embed="rId3"/>
+        <a:stretch><a:fillRect l="10000" t="10000" r="10000" b="10000"/></a:stretch>
+      </p:blipFill>
+      <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm></p:spPr>
+    </p:pic>`);
+    const result = await parsePic(pic, {
+      archive: fakeArchive({ 'ppt/media/image1.png': new Uint8Array([1]) }),
+      slidePartPath: 'ppt/slides/slide1.xml',
+      rels: new Map([
+        ['rId3', { type: 'image', target: '../media/image1.png', external: false }],
+      ]),
+      uploadImage: async () => 'u',
+      scale: emuScale(DEFAULT_WIDESCREEN_EMU),
+      report: new ImportReport(),
+    });
+    expect(result?.data.crop).toBeUndefined();
+  });
+
+  it('skips a degenerate <a:fillRect> whose insets collapse the fill region', async () => {
+    // l+r >= 1 (or t+b >= 1) makes the fill width/height non-positive; bail.
+    const pic = picEl(`<p:pic>
+      <p:blipFill>
+        <a:blip r:embed="rId3"/>
+        <a:stretch><a:fillRect l="60000" t="0" r="60000" b="0"/></a:stretch>
+      </p:blipFill>
+      <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm></p:spPr>
+    </p:pic>`);
+    const result = await parsePic(pic, {
+      archive: fakeArchive({ 'ppt/media/image1.png': new Uint8Array([1]) }),
+      slidePartPath: 'ppt/slides/slide1.xml',
+      rels: new Map([
+        ['rId3', { type: 'image', target: '../media/image1.png', external: false }],
+      ]),
+      uploadImage: async () => 'u',
+      scale: emuScale(DEFAULT_WIDESCREEN_EMU),
+      report: new ImportReport(),
+    });
+    expect(result?.data.crop).toBeUndefined();
+  });
+
+  it('prefers <a:srcRect> over <a:fillRect> when both are present', async () => {
+    const pic = picEl(`<p:pic>
+      <p:blipFill>
+        <a:blip r:embed="rId3"/>
+        <a:srcRect l="10000" t="20000" r="0" b="0"/>
+        <a:stretch><a:fillRect l="-50000" t="-50000" r="0" b="0"/></a:stretch>
+      </p:blipFill>
+      <p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm></p:spPr>
+    </p:pic>`);
+    const result = await parsePic(pic, {
+      archive: fakeArchive({ 'ppt/media/image1.png': new Uint8Array([1]) }),
+      slidePartPath: 'ppt/slides/slide1.xml',
+      rels: new Map([
+        ['rId3', { type: 'image', target: '../media/image1.png', external: false }],
+      ]),
+      uploadImage: async () => 'u',
+      scale: emuScale(DEFAULT_WIDESCREEN_EMU),
+      report: new ImportReport(),
+    });
+    expect(result?.data.crop).toEqual({ x: 0.1, y: 0.2, w: 0.9, h: 0.8 });
+  });
+
   it('skips and bumps the report when uploadImage throws', async () => {
     const report = new ImportReport();
     const result = await parsePic(picEl(PIC), {


### PR DESCRIPTION
## Summary

Importing a `.pptx` where a photo is placed as a `<p:sp>` freeform shape with `<a:blipFill>` distorted the image when the shape's frame aspect ratio differed from the photo's. PowerPoint reconciles the mismatch with a **negative `<a:stretch><a:fillRect>`** (its "Fill" / cover crop): it scales the image past the shape bounds and the shape clips it. Our importer read only `<a:srcRect>` (source crop) and **ignored `<a:stretch><a:fillRect>`**, so with no crop the renderer stretched the whole image into the frame — squishing it.

**Repro:** "Blue Green Colorful Daycare Center Presentation.pptx", slide 3 — a 1200×1800 (2:3 portrait) photo placed in a square frame via `fillRect l="-31963" t="-36905" r="-9496" b="-75284"`. The fill-region AR works out to exactly the photo's native 2:3, so PowerPoint shows it undistorted; we squished it. Slide 8 has 3 more.

## Fix

A negative/zero `fillRect` (cover case) is mathematically the dual of a source crop, which the model and renderer already support. `parseStretchFillRect()` in `image.ts` derives the equivalent source `Crop` when `<a:srcRect>` yields none:

```
l,t,r,b = insets / 100_000
fw = 1 - l - r ; fh = 1 - t - b
crop = { x: -l/fw, y: -t/fh, w: 1/fw, h: 1/fh }
```

Applied only when the result stays within `[0,1]` (cover). Default all-zero `fillRect` → no-op; positive-inset/letterbox `fillRect` → falls back to full stretch. **No model or renderer change** — reuses the existing `Crop` pipeline (so backgrounds via `<p:bgPr>` benefit too).

### Limitations (accepted for v1)
- `srcRect` takes precedence; `srcRect` + `fillRect` are not composed.
- Positive-inset (letterbox) fillRects fall back to full stretch.
- `<a:tile>` fills unchanged; non-rect freeform clip paths still not honored (pre-existing).

### Note
Only affects **new** imports — an already-imported document must be re-imported to pick up the corrected crop.

## Test plan

- `pnpm --filter @wafflebase/slides test` — 1301 pass, incl. 5 new `image.test.ts` cases (cover crop with real slide-3 values, all-zero no-op, positive-inset skip, degenerate `fw<=0` skip, srcRect precedence).
- `pnpm verify:fast` — green.
- End-to-end verified against the real deck (temporary jsdom test, since removed): slide 3 yields exactly 1 cropped image (the photo, nested in a `<p:grpSp>`) with `crop = {x:0.226, y:0.174, w:0.707, h:0.471}`; cropped-source pixel AR ≈ 1.0 = the square frame ⇒ no distortion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image distortion in PPTX imports by properly handling image fill cropping configurations.

* **Documentation**
  * Enhanced PPTX import documentation with additional image fill mapping guidelines.

* **Tests**
  * Expanded test coverage for image cropping behavior in PPTX file imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->