### PR TITLE
Slides text box: insert-to-edit, drag sizing, content-fit auto-grow

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -74,6 +74,7 @@ Presentation engine — slides, free-position elements, presentation mode, colla
 | [slides-group.md](slides/slides-group.md)                                             | Group / ungroup — nested element tree with group-local child coords, Google Slides drill-in selection, PPTX `<p:grpSp>` preservation, recursive renderer / hit-test / PDF export                              |
 | [slides-shape-move.md](slides/slides-shape-move.md)                                   | Shape drag-move — `move` hover cursor on selected shapes, ghost preview at `GHOST_ALPHA` follows pointer, commit only on release                                                                            |
 | [slides-ruler.md](slides/slides-ruler.md)                                             | Slides ruler — H/V rulers (corner origin, inch/cm), presentation-wide draggable guides, snap integration, read-only mount handling                                                                          |
+| [slides-textbox-autogrow.md](slides/slides-textbox-autogrow.md)                       | Text box authoring — insert-to-edit focus, drag sizing (width+position), content-fit auto-grow height via a docs `onContentHeightChange` callback                                                            |
 
 ## Common
 

--- a/docs/design/slides/slides-textbox-autogrow.md
+++ b/docs/design/slides/slides-textbox-autogrow.md
@@ -1,0 +1,174 @@
+---
+title: slides-textbox-autogrow
+target-version: 0.5.0
+---
+
+<!-- Make sure to append document link in design README.md after creating the document. -->
+
+# Slides Text Box — Insert-to-Edit, Drag Sizing, Auto-Grow
+
+## Summary
+
+Three coordinated improvements to the Slides text-box authoring flow,
+bringing it in line with Google Slides:
+
+1. **Insert-to-edit** — inserting a text box drops the caret straight
+   inside it (text-editing focus), instead of leaving an empty selected
+   box that needs a double-click to type into.
+2. **Drag sizing** — a text box can be drawn by dragging a rectangle
+   (width + position), like shapes already can, instead of always being a
+   single-click fixed-size box.
+3. **Auto-grow** — the box height tracks its content (grow *and* shrink,
+   minimum one line), updated live while typing.
+
+Today (`editor.ts:startInsert`) the `text` branch single-click inserts a
+fixed `TEXT_DEFAULT_W × TEXT_DEFAULT_H` box, selects it, and stops. Edit
+mode is only reachable via `onDoubleClick`. Height is fixed: the docs
+text engine lays text out by width only and never reports content height
+back to the host, so a box never resizes to its content.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Inserting a text box immediately enters edit mode with a blinking
+  caret (`enterEditMode` + `focus()`), matching Google Slides / PowerPoint.
+- Text supports drag-to-size (width + position from the drag rect; a
+  sub-threshold drag falls back to the default width), reusing the
+  existing shape drag-preview flow.
+- Text-box height fits its content (grow + shrink, min one line),
+  reflected live during editing and persisted to the element frame.
+- Shapes are unaffected — they still insert selected (no auto edit-mode).
+
+### Non-Goals
+
+- Width auto-fit (Google Slides "shrink text on overflow" / "resize
+  shape to fit text" width modes). Width stays user-controlled.
+- A per-element "do not autofit / shrink text to fit" autofit mode
+  selector. Auto-grow is the single behavior for text boxes here.
+- Shape text auto-grow (text inside non-text shapes).
+- Mobile-specific tuning beyond what the shared editor already provides.
+
+## Proposal Details
+
+### Behavior
+
+| Action | Result |
+| --- | --- |
+| Toolbar text → click (no drag) | Default-width box at the click point, height = one line, **edit mode + focus**. |
+| Toolbar text → drag | Box at the drawn width + position, height = content (one line when empty), **edit mode + focus**. |
+| Typing wraps past current height | Box grows downward live. |
+| Deleting content | Box shrinks back to content height (min one line). |
+
+Reconciliation note: because height always follows content (Google
+Slides behavior), the drawn rectangle's **height is not retained** — the
+drag contributes width and top-left position only, and the box snaps to
+content height on creation. Shapes keep honoring the full drawn rect.
+
+### Auto-grow: live height via a docs callback
+
+The docs text engine already computes `layout.totalHeight` in
+`computeLayout` on every `recomputeLayout()`; it is currently consumed
+only internally in `packages/docs/src/view/text-box-editor.ts`. Text
+layout is width-driven and
+never clips by height, so height is purely the canvas/container size.
+Live growth therefore needs two new seams in the docs text-box editor:
+
+```ts
+// packages/docs/src/view/text-box-editor.ts — TextBoxEditorOptions
+/** Fired when the laid-out content height changes (logical px). */
+onContentHeightChange?: (contentHeight: number) => void;
+
+// TextBoxEditorAPI
+/** Resize the editing surface's logical content height + repaint. */
+setContentHeight(contentHeight: number): void;
+```
+
+- `contentHeight` becomes a mutable `let` in `initializeTextBox`.
+  `setContentHeight` updates it, rebuilds the shim paginated layout
+  (`buildShimPaginatedLayout`), and `requestRender()`s.
+- `renderNow` compares `layout.totalHeight` against the last reported
+  value and calls `onContentHeightChange(totalHeight)` only on change
+  (same de-dupe pattern as `onCursorMove`).
+- No loop: `onContentHeightChange` → host resizes canvas + calls
+  `setContentHeight` → which re-renders but does not change
+  `totalHeight` (height is not a layout input), so it does not re-fire.
+
+### Slides wrapper (`packages/slides/src/view/editor/text-box-editor.ts`)
+
+`mountSlidesTextBox` gains an `onContentHeightChange` option that it
+forwards to `initializeTextBox`. When the docs editor reports a new
+content height, the wrapper:
+
+1. Resizes its `container` and `canvas` (CSS + bitmap, honoring `dpr`)
+   to the new `height * scale`.
+2. Calls `api.setContentHeight(newLogicalHeight)` so the docs editor's
+   pointer math and shim page height stay consistent.
+3. Surfaces the new logical height to the slides editor via the
+   `onContentHeightChange` callback so the editor can persist it.
+
+The wrapper exposes the host-facing callback through
+`SlidesTextBoxEditor`.
+
+### Slides editor (`packages/slides/src/view/editor/editor.ts`)
+
+- `startInsert` `text` branch: replace the single-click insert with a
+  drag-to-size flow mirroring the shape branch (live ghost preview via
+  `forceRender(slide, doc, [ghost])`, `buildInsertElement('text', …)`
+  for click-vs-drag). On `pointerup`, add the element, select it, disarm
+  insert mode, then call `enterEditMode(slide.id, id)`.
+- `enterEditMode`: pass an `onContentHeightChange` into `mountTextBox`.
+  Height fit is `frame.h = max(MIN_TEXT_H, contentHeight)`
+  (`MIN_TEXT_H` = one line). On change, persist via
+  `store.updateElementFrame(slideId, elementId, { h })`. Frame writes go
+  through a `batch` consistent with the rest of the editor.
+- The committed slide canvas already renders text by width via
+  `packages/slides/src/view/canvas/text-renderer.ts`; with the frame
+height now matching content, no
+  extra clipping work is needed.
+
+### `buildInsertElement` (`packages/slides/src/view/editor/interactions/insert.ts`)
+
+The `text` kind currently early-returns a fixed-size frame. Change it to
+participate in the same click-vs-drag rect logic as shapes: drag rect
+when the pointer moved past `CLICK_THRESHOLD_PX_SQ`, else
+`TEXT_DEFAULT_W` width at `start`. Height at insert time can stay
+`TEXT_DEFAULT_H`; `enterEditMode`'s first `onContentHeightChange` snaps
+it to content (one line) immediately.
+
+### Files
+
+- `packages/docs/src/view/text-box-editor.ts` — `onContentHeightChange`
+  option, `setContentHeight()` API, fire-on-change in `renderNow`.
+- `packages/docs/src/index.ts` — confirm `TextBoxEditorAPI` re-export
+  covers the new method (interface change only, no new export needed).
+- `packages/slides/src/view/editor/text-box-editor.ts` — forward
+  callback, resize container/canvas, delegate `setContentHeight`.
+- `packages/slides/src/view/editor/interactions/insert.ts` — text
+  click-vs-drag sizing.
+- `packages/slides/src/view/editor/editor.ts` — text drag insert +
+  `enterEditMode` on insert; persist height on grow.
+
+### Testing
+
+- `buildInsertElement` unit: text drag → drawn-width rect; sub-threshold
+  → default width.
+- docs `text-box-editor` unit: `onContentHeightChange` fires when a line
+  is added/removed; `setContentHeight` rebuilds the shim layout.
+- slides editor: inserting a text box sets `editingElementId` and calls
+  `focus()`; an auto-grow height change calls `updateElementFrame`.
+
+## Risks and Mitigation
+
+- **Resize/recompute feedback loop.** Mitigated by firing
+  `onContentHeightChange` only on `totalHeight` change and by
+  `setContentHeight` not feeding back into `totalHeight`.
+- **Collaboration churn.** Live `updateElementFrame` on every keystroke
+  could spam CRDT ops. Mitigated by only persisting when the rounded
+  height actually changes; intermediate visual growth is local
+  container/canvas resizing, not a store write.
+- **Editing overlay vs committed canvas mismatch.** The editing canvas
+  and the committed `text-renderer` both lay out by width via the same
+  `computeLayout`, so a fitted height stays pixel-consistent on commit.
+- **Scope creep into width autofit / autofit modes.** Explicitly a
+  non-goal; height-only fit keeps the change bounded.

--- a/docs/design/slides/slides-textbox-autogrow.md
+++ b/docs/design/slides/slides-textbox-autogrow.md
@@ -113,19 +113,21 @@ The wrapper exposes the host-facing callback through
 ### Slides editor (`packages/slides/src/view/editor/editor.ts`)
 
 - `startInsert` `text` branch: replace the single-click insert with a
-  drag-to-size flow mirroring the shape branch (live ghost preview via
-  `forceRender(slide, doc, [ghost])`, `buildInsertElement('text', …)`
-  for click-vs-drag). On `pointerup`, add the element, select it, disarm
-  insert mode, then call `enterEditMode(slide.id, id)`.
-- `enterEditMode`: pass an `onContentHeightChange` into `mountTextBox`.
-  Height fit is `frame.h = max(MIN_TEXT_H, contentHeight)`
-  (`MIN_TEXT_H` = one line). On change, persist via
-  `store.updateElementFrame(slideId, elementId, { h })`. Frame writes go
-  through a `batch` consistent with the rest of the editor.
+  drag-to-size flow mirroring the shape branch (`buildInsertElement('text',
+  …)` for click-vs-drag). No ghost preview — an empty text box paints
+  nothing, so the box appears on release. On `pointerup`, add the element,
+  select it, disarm insert mode, then call `enterEditMode(slide.id, id)`.
+- `enterEditMode`: pass an `onContentHeightChange` into `mountTextBox` that
+  records the latest reported content height. The height is persisted **at
+  commit**, not per-keystroke: `onCommit` writes `frame.h = max(MIN_TEXT_BOX_H,
+  contentHeight)` via `store.updateElementFrame(slideId, elementId, { h })`
+  in the **same `batch`** as the `withTextElement` text write — one undo
+  entry, no per-keystroke CRDT churn. Live visual growth is the wrapper
+  resizing its editing canvas; the store frame only changes on commit
+  (consistent with text, which is also local until commit).
 - The committed slide canvas already renders text by width via
-  `packages/slides/src/view/canvas/text-renderer.ts`; with the frame
-height now matching content, no
-  extra clipping work is needed.
+  `packages/slides/src/view/canvas/text-renderer.ts`; with the frame height
+  now matching content, no extra clipping work is needed.
 
 ### `buildInsertElement` (`packages/slides/src/view/editor/interactions/insert.ts`)
 
@@ -152,21 +154,26 @@ it to content (one line) immediately.
 ### Testing
 
 - `buildInsertElement` unit: text drag → drawn-width rect; sub-threshold
-  → default width.
-- docs `text-box-editor` unit: `onContentHeightChange` fires when a line
-  is added/removed; `setContentHeight` rebuilds the shim layout.
-- slides editor: inserting a text box sets `editingElementId` and calls
-  `focus()`; an auto-grow height change calls `updateElementFrame`.
+  → default width; height stays `TEXT_DEFAULT_H`.
+- docs `text-box-editor` unit (jsdom, no canvas ctx → `renderNow`
+  early-returns): API-surface only — `onContentHeightChange` option is
+  accepted and `setContentHeight` exists / does not throw.
+- slides `mountSlidesTextBox` (under `test-canvas-env`, where `renderNow`
+  runs): `onContentHeightChange` fires with a positive height; more
+  paragraphs report a larger height; the container resizes to fit.
+- slides editor: inserting a text box enters edit mode
+  (`getEditingElementId` set); a reported height is persisted into
+  `frame.h` at commit, in one undo batch with the text write.
 
 ## Risks and Mitigation
 
 - **Resize/recompute feedback loop.** Mitigated by firing
   `onContentHeightChange` only on `totalHeight` change and by
   `setContentHeight` not feeding back into `totalHeight`.
-- **Collaboration churn.** Live `updateElementFrame` on every keystroke
-  could spam CRDT ops. Mitigated by only persisting when the rounded
-  height actually changes; intermediate visual growth is local
-  container/canvas resizing, not a store write.
+- **Collaboration churn.** Persisting `updateElementFrame` per keystroke
+  would spam CRDT ops and fragment undo. Mitigated by committing the
+  height **once**, in the same `batch` as the text write; intermediate
+  visual growth is local container/canvas resizing, never a store write.
 - **Editing overlay vs committed canvas mismatch.** The editing canvas
   and the committed `text-renderer` both lay out by width via the same
   `computeLayout`, so a fitted height stays pixel-consistent on commit.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -21,6 +21,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | docker publish arm64 native (2026-05-25) | [20260525-docker-publish-arm64-native-todo.md](./active/20260525-docker-publish-arm64-native-todo.md) | - |
 | pptx blipfill fillrect crop (2026-05-25) | [20260525-pptx-blipfill-fillrect-crop-todo.md](./active/20260525-pptx-blipfill-fillrect-crop-todo.md) | - |
 | release v0.4.2 (2026-05-25) | [20260525-release-v0.4.2-todo.md](./active/20260525-release-v0.4.2-todo.md) | - |
+| slides textbox autogrow (2026-05-25) | [20260525-slides-textbox-autogrow-todo.md](./active/20260525-slides-textbox-autogrow-todo.md) | [20260525-slides-textbox-autogrow-lessons.md](./active/20260525-slides-textbox-autogrow-lessons.md) |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
 | slides package mvp (2026-05-05) | [20260505-slides-package-mvp-todo.md](./active/20260505-slides-package-mvp-todo.md) | [20260505-slides-package-mvp-lessons.md](./active/20260505-slides-package-mvp-lessons.md) |

--- a/docs/tasks/active/20260525-slides-textbox-autogrow-lessons.md
+++ b/docs/tasks/active/20260525-slides-textbox-autogrow-lessons.md
@@ -1,0 +1,20 @@
+# Lessons — Slides Text Box Insert-to-Edit + Auto-Grow
+
+Captured during implementation of
+`20260525-slides-textbox-autogrow-todo.md`.
+
+## Context / key facts
+
+- The slides package consumes the **built** `@wafflebase/docs` (`dist/`),
+  not its source. Docs API changes must be rebuilt
+  (`pnpm --filter @wafflebase/docs build`) before slides typecheck/tests
+  see them.
+- jsdom has no canvas 2D context, so the docs `renderNow` early-returns;
+  the docs unit env cannot exercise live render paths. The slides package
+  shim `test-canvas-env` patches `getContext('2d')` (and `OffscreenCanvas`)
+  so `renderNow` runs there — that is the right home for end-to-end
+  text-box render/height tests.
+
+## Lessons
+
+(filled in as they come up)

--- a/docs/tasks/active/20260525-slides-textbox-autogrow-lessons.md
+++ b/docs/tasks/active/20260525-slides-textbox-autogrow-lessons.md
@@ -17,4 +17,31 @@ Captured during implementation of
 
 ## Lessons
 
-(filled in as they come up)
+- **Reconciling conflicting user preferences early.** The user picked
+  "keep the drawn rectangle" for drag sizing *and* "Google-Slides-style
+  auto-grow" for height. Those collide on the height axis. Surfacing the
+  reconciliation explicitly (drag sets width + position only; height
+  always fits content) in the design doc before coding avoided building
+  the wrong thing. When two answers conflict, name the conflict and pick
+  a rule rather than silently honoring one.
+
+- **Persist derived geometry at commit, not per keystroke.** The first
+  instinct (spec draft) was a live `updateElementFrame` on every height
+  change. That fragments undo and spams CRDT ops, and is inconsistent
+  with text itself (which is local until commit). Writing `frame.h` once,
+  in the same `batch` as `withTextElement`, gives one undo entry and a
+  single CRDT op. Live visual growth is just the editing canvas resizing
+  — no store writes.
+
+- **Pick a callback seam that the test env can reach.** Tying the height
+  signal to `renderNow` (which early-returns without a 2D ctx) means the
+  docs jsdom unit env can't exercise it. The slides `test-canvas-env`
+  shim *does* supply a working `getContext('2d')`, so the end-to-end
+  firing/resize test lives in the slides package; the docs package only
+  asserts the API surface. Match the test to where the code path runs.
+
+- **Mirror existing interaction patterns.** The text drag-insert flow
+  reuses the shape branch's `pointermove`/`pointerup`/`keydown(Escape,
+  capture)` structure verbatim (including the `cleanup` closure that
+  references `onUp`/`onKey` declared after it). Following the established
+  shape pattern kept lint happy and behavior consistent for free.

--- a/docs/tasks/active/20260525-slides-textbox-autogrow-todo.md
+++ b/docs/tasks/active/20260525-slides-textbox-autogrow-todo.md
@@ -1,0 +1,728 @@
+# Slides Text Box — Insert-to-Edit + Drag Sizing + Auto-Grow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make slides text boxes behave like Google Slides — inserting one
+drops the caret straight into edit mode, the box can be drawn by dragging,
+and its height fits the content (grow + shrink) live while typing.
+
+**Architecture:** The docs text engine gains a height-change callback
+(`onContentHeightChange`) plus a `setContentHeight()` setter. The slides
+text-box wrapper resizes its editing container/canvas live on each height
+change and reports the logical height back to the slides editor, which
+persists the final height into the element frame **at commit time** (in the
+same `batch` as the text write — one undo entry, no per-keystroke CRDT
+churn). The slides editor enters edit mode immediately after a text insert,
+and text insert uses the same click-vs-drag rect logic as shapes.
+
+**Tech Stack:** TypeScript, Vitest (jsdom), `@wafflebase/docs` canvas text
+engine, slides Canvas editor. The slides package consumes the **built**
+docs `dist/`, so docs changes must be rebuilt before the slides tasks.
+
+**Design doc:** `docs/design/slides/slides-textbox-autogrow.md`
+
+---
+
+### Task 1: docs text engine — `onContentHeightChange` + `setContentHeight`
+
+**Files:**
+- Modify: `packages/docs/src/view/text-box-editor.ts`
+- Test: `packages/docs/test/view/text-box-editor.test.ts`
+
+Context: `computeLayout` already returns `layout.totalHeight`; today it is
+used only internally. `renderNow` early-returns when there is no canvas 2D
+context (the docs jsdom test env), so the live firing is verified in the
+slides package (Task 2, which runs under `test-canvas-env`). Here we only
+add the API surface and verify it constructs/sets without throwing.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `describe('initializeTextBox', ...)` block in
+`packages/docs/test/view/text-box-editor.test.ts`:
+
+```ts
+  it('accepts an onContentHeightChange option without throwing', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const canvas = document.createElement('canvas');
+    canvas.width = 400;
+    canvas.height = 200;
+    container.appendChild(canvas);
+    const onContentHeightChange = vi.fn();
+    const api = initializeTextBox({
+      container,
+      canvas,
+      blocks: [],
+      contentWidth: 400,
+      contentHeight: 200,
+      onContentHeightChange,
+    });
+    // jsdom has no 2D context, so renderNow early-returns and the
+    // callback never fires here — firing is covered in the slides
+    // package under test-canvas-env. We only assert construction.
+    expect(typeof api.setContentHeight).toBe('function');
+    api.detach();
+  });
+
+  it('setContentHeight exists and does not throw', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const canvas = document.createElement('canvas');
+    canvas.width = 400;
+    canvas.height = 200;
+    container.appendChild(canvas);
+    const api = initializeTextBox({
+      container,
+      canvas,
+      blocks: [],
+      contentWidth: 400,
+      contentHeight: 200,
+    });
+    expect(() => api.setContentHeight(120)).not.toThrow();
+    api.detach();
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @wafflebase/docs test -- text-box-editor`
+Expected: FAIL — `api.setContentHeight is not a function` /
+`onContentHeightChange` not a known option (TS).
+
+- [ ] **Step 3: Add the option to `TextBoxEditorOptions`**
+
+In `packages/docs/src/view/text-box-editor.ts`, inside the
+`TextBoxEditorOptions` interface (after the `onLinkRequest?` field, ~line
+115):
+
+```ts
+  /**
+   * Fired after layout when the laid-out content height changes (logical
+   * px). The host uses this to grow/shrink the editing surface and to
+   * persist the fitted height. De-duped: only fires when the height
+   * actually changes. Never fires while there is no canvas 2D context
+   * (renderNow early-returns).
+   */
+  onContentHeightChange?: (contentHeight: number) => void;
+```
+
+- [ ] **Step 4: Add `setContentHeight` to `TextBoxEditorAPI`**
+
+In the `TextBoxEditorAPI` interface (after `detach(): void;`, ~line 129):
+
+```ts
+  /**
+   * Resize the editing surface's logical content height and repaint.
+   * Layout is width-driven, so this does not re-wrap text — it only
+   * changes the shim page height + canvas the editor paints into.
+   */
+  setContentHeight(contentHeight: number): void;
+```
+
+- [ ] **Step 5: Make `contentHeight` mutable + add the de-dupe field**
+
+Change the destructure at the top of `initializeTextBox` (~line 253):
+
+```ts
+  const { container, canvas, contentWidth } = opts;
+  let contentHeight = opts.contentHeight;
+  const dpr = opts.dpr ?? 1;
+  const scale = opts.scale ?? 1;
+```
+
+Add near `let renderRAF: number | null = null;` (~line 305):
+
+```ts
+  // Last content height reported via onContentHeightChange. Starts at -1
+  // so the first real layout always fires once.
+  let lastReportedHeight = -1;
+```
+
+- [ ] **Step 6: Fire the callback from `renderNow` after recompute**
+
+In `renderNow`, immediately after the `recomputeLayout();` call (~line
+316), insert:
+
+```ts
+    // Report height changes so the host can grow/shrink the box. Fires
+    // only when the laid-out height actually changed. Lives here (post
+    // recompute) so `layout.totalHeight` is fresh; renderNow already
+    // early-returned above when there is no ctx, so this never fires in
+    // a context-less env.
+    if (layout.totalHeight !== lastReportedHeight) {
+      lastReportedHeight = layout.totalHeight;
+      opts.onContentHeightChange?.(layout.totalHeight);
+    }
+```
+
+- [ ] **Step 7: Implement `setContentHeight` in the returned api**
+
+In the `const api: TextBoxEditorAPI = { ... }` object, after `detach()`
+(~line 552), add:
+
+```ts
+    setContentHeight(next: number): void {
+      contentHeight = next;
+      paginatedLayout = buildShimPaginatedLayout(layout, contentWidth, contentHeight);
+      requestRender();
+    },
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `pnpm --filter @wafflebase/docs test -- text-box-editor`
+Expected: PASS (all existing + 2 new).
+
+- [ ] **Step 9: Typecheck + rebuild docs dist (slides consumes dist)**
+
+Run: `pnpm --filter @wafflebase/docs typecheck && pnpm --filter @wafflebase/docs build`
+Expected: no type errors; `dist/` rebuilt so the slides package sees the
+new `setContentHeight` / `onContentHeightChange`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/docs/src/view/text-box-editor.ts packages/docs/test/view/text-box-editor.test.ts
+git commit -m "Add content-height callback + setter to docs text-box editor"
+```
+
+---
+
+### Task 2: slides wrapper — live resize + forward height
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/text-box-editor.ts`
+- Test: `packages/slides/test/view/editor/text-box-autogrow.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/slides/test/view/editor/text-box-autogrow.test.ts`:
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import type { Block } from '@wafflebase/docs';
+import { mountSlidesTextBox } from '../../../src/view/editor/text-box-editor';
+
+// Drain the docs editor's rAF-scheduled renderNow (jsdom polyfills rAF
+// via setTimeout; 16ms is enough to flush a frame + cursor-blink restart).
+function flushRaf(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 16));
+}
+
+function para(id: string, text: string): Block {
+  return { id, type: 'paragraph', inlines: [{ text, style: {} }], style: {} } as Block;
+}
+
+describe('mountSlidesTextBox auto-grow', () => {
+  let overlay: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    overlay = document.createElement('div');
+    overlay.style.position = 'absolute';
+    document.body.appendChild(overlay);
+  });
+
+  it('reports content height and resizes the container on mount', async () => {
+    const heights: number[] = [];
+    const tb = mountSlidesTextBox({
+      overlay,
+      frame: { x: 0, y: 0, w: 400, h: 300, rotation: 0 },
+      scale: 1,
+      blocks: [para('p1', 'one line')],
+      onCommit: () => {},
+      onCancel: () => {},
+      onContentHeightChange: (h) => heights.push(h),
+    });
+    await flushRaf();
+    await flushRaf();
+    expect(heights.length).toBeGreaterThan(0);
+    const reported = heights[heights.length - 1];
+    expect(reported).toBeGreaterThan(0);
+    // Container is resized to the reported height (scale = 1).
+    expect(tb.container.style.height).toBe(`${Math.max(1, Math.round(reported))}px`);
+    tb.detach();
+  });
+
+  it('reports a larger height for more paragraphs', async () => {
+    const oneH: number[] = [];
+    const tb1 = mountSlidesTextBox({
+      overlay,
+      frame: { x: 0, y: 0, w: 400, h: 300, rotation: 0 },
+      scale: 1,
+      blocks: [para('p1', 'a')],
+      onCommit: () => {},
+      onCancel: () => {},
+      onContentHeightChange: (h) => oneH.push(h),
+    });
+    await flushRaf();
+    await flushRaf();
+    tb1.detach();
+
+    const fourH: number[] = [];
+    const tb4 = mountSlidesTextBox({
+      overlay,
+      frame: { x: 0, y: 0, w: 400, h: 300, rotation: 0 },
+      scale: 1,
+      blocks: [para('p1', 'a'), para('p2', 'b'), para('p3', 'c'), para('p4', 'd')],
+      onCommit: () => {},
+      onCancel: () => {},
+      onContentHeightChange: (h) => fourH.push(h),
+    });
+    await flushRaf();
+    await flushRaf();
+    expect(fourH[fourH.length - 1]).toBeGreaterThan(oneH[oneH.length - 1]);
+    tb4.detach();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @wafflebase/slides test -- text-box-autogrow`
+Expected: FAIL — `onContentHeightChange` not wired (heights empty) / TS
+error on the option.
+
+- [ ] **Step 3: Add the option to `MountSlidesTextBoxOptions`**
+
+In `packages/slides/src/view/editor/text-box-editor.ts`, inside
+`MountSlidesTextBoxOptions` (after `onLinkRequest?`, ~line 53):
+
+```ts
+  /**
+   * Fired (logical px) when the docs editor's content height changes.
+   * The wrapper has already resized its container/canvas and called
+   * `setContentHeight` by the time this fires; the slides editor uses it
+   * to persist the fitted frame height at commit time.
+   */
+  onContentHeightChange?: (contentHeight: number) => void;
+```
+
+- [ ] **Step 4: Wire the live-resize handler into `initializeTextBox`**
+
+In `mountSlidesTextBox`, add `onContentHeightChange` to the destructure
+(~line 102):
+
+```ts
+  const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest, onContentHeightChange } = opts;
+```
+
+Then, in the `initializeTextBox({ ... })` options object (after
+`onLinkRequest,` ~line 183), add:
+
+```ts
+    onContentHeightChange: (h: number): void => {
+      // Grow/shrink the editing surface to fit content. Width is fixed;
+      // only height tracks. cssH is host pixels (logical * slide scale);
+      // the canvas bitmap also multiplies by the browser dpr captured at
+      // mount. Setting canvas.height resets the bitmap — setContentHeight
+      // then schedules a repaint at the new size.
+      const targetH = Math.max(1, h);
+      const cssH = Math.max(1, Math.round(targetH * scale));
+      container.style.height = `${cssH}px`;
+      canvas.style.height = `${cssH}px`;
+      canvas.height = Math.max(1, Math.round(cssH * dpr));
+      api.setContentHeight(targetH);
+      onContentHeightChange?.(targetH);
+    },
+```
+
+(`api` is referenced lazily — this callback only fires from the docs
+editor's rAF render, after `const api = initializeTextBox(...)` has been
+assigned, so there is no temporal-dead-zone hazard.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm --filter @wafflebase/slides test -- text-box-autogrow`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm --filter @wafflebase/slides typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/slides/src/view/editor/text-box-editor.ts packages/slides/test/view/editor/text-box-autogrow.test.ts
+git commit -m "Resize slides text-box editing surface to fit content live"
+```
+
+---
+
+### Task 3: insert.ts — text drag sizing
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/interactions/insert.ts:297-321`
+- Test: `packages/slides/test/view/editor/interactions/insert.test.ts`
+
+Behavior: text insert participates in click-vs-drag like shapes — drag
+sets width + top-left, a sub-threshold drag uses `TEXT_DEFAULT_W`. Height
+stays `TEXT_DEFAULT_H` at insert time (the editor's first
+`onContentHeightChange` snaps it to content on commit), so the drawn
+height is intentionally not retained.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the `describe('buildInsertElement — text', ...)` block in
+`packages/slides/test/view/editor/interactions/insert.test.ts` with:
+
+```ts
+describe('buildInsertElement — text', () => {
+  it('click (no drag) → default width, height TEXT_DEFAULT_H, anchored at start', () => {
+    const text = buildInsertElement('text', { x: 50, y: 50 }, { x: 50, y: 50 });
+    expect(text.type).toBe('text');
+    expect(text.frame).toEqual({ x: 50, y: 50, w: 400, h: 80, rotation: 0 });
+  });
+
+  it('drag → width from the drag rect, height stays TEXT_DEFAULT_H', () => {
+    const text = buildInsertElement('text', { x: 10, y: 20 }, { x: 210, y: 220 });
+    // Width follows the drag (200); height is NOT retained (stays 80).
+    expect(text.frame).toEqual({ x: 10, y: 20, w: 200, h: 80, rotation: 0 });
+  });
+
+  it('backwards drag → top-left normalised', () => {
+    const text = buildInsertElement('text', { x: 300, y: 300 }, { x: 100, y: 50 });
+    expect(text.frame).toEqual({ x: 100, y: 50, w: 200, h: 80, rotation: 0 });
+  });
+
+  it('sub-threshold drag (< 4px) → treated as click → default width', () => {
+    const text = buildInsertElement('text', { x: 10, y: 10 }, { x: 12, y: 12 });
+    expect(text.frame).toEqual({ x: 10, y: 10, w: 400, h: 80, rotation: 0 });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @wafflebase/slides test -- interactions/insert`
+Expected: FAIL — drag case returns `w: 400` (current code ignores the
+drag for text).
+
+- [ ] **Step 3: Rewrite the text branch of `buildInsertElement`**
+
+In `packages/slides/src/view/editor/interactions/insert.ts`, replace the
+`if (kind === 'text') { ... }` block (lines 297-321) with:
+
+```ts
+  if (kind === 'text') {
+    // Text participates in the same click-vs-drag rect logic as shapes:
+    // a real drag sets the width + top-left; a sub-threshold drag uses
+    // the default width. Height is NOT taken from the drag — the editor
+    // fits it to content (one line) on the first layout / commit — so we
+    // always seed TEXT_DEFAULT_H here.
+    const dx = end.x - start.x;
+    const dy = end.y - start.y;
+    const isClick = dx * dx + dy * dy < CLICK_THRESHOLD_PX_SQ;
+    const w = isClick ? TEXT_DEFAULT_W : Math.abs(dx);
+    const x = isClick ? start.x : Math.min(start.x, end.x);
+    const y = isClick ? start.y : Math.min(start.y, end.y);
+    return {
+      type: 'text',
+      frame: { x, y, w, h: TEXT_DEFAULT_H, rotation: 0 },
+      data: {
+        blocks: [{
+          id: 'placeholder',
+          type: 'paragraph',
+          inlines: [{ text: '', style: { color: DEFAULT_TEXT_COLOR } }],
+          style: { ...DEFAULT_BLOCK_STYLE },
+        } as Block],
+      },
+    };
+  }
+```
+
+(`CLICK_THRESHOLD_PX_SQ`, `TEXT_DEFAULT_W`, `TEXT_DEFAULT_H`,
+`DEFAULT_TEXT_COLOR`, `DEFAULT_BLOCK_STYLE`, and `Block` are all already
+imported/declared in this file.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @wafflebase/slides test -- interactions/insert`
+Expected: PASS (new text cases + all existing shape cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/slides/src/view/editor/interactions/insert.ts packages/slides/test/view/editor/interactions/insert.test.ts
+git commit -m "Support drag-to-size for slides text-box insertion"
+```
+
+---
+
+### Task 4: editor.ts — insert-to-edit + commit-time height persist
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/editor.ts`
+  (text branch of `startInsert` ~1805; `enterEditMode` ~1569;
+  `finishEditMode` ~1661; add a `MIN_TEXT_BOX_H` const + a
+  `lastEditingContentHeight` field)
+- Test: `packages/slides/test/view/editor/text-box-editor.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+First extend the mock in
+`packages/slides/test/view/editor/text-box-editor.test.ts`. Add a
+`fireContentHeight` method to the `MockTextBox` interface (after
+`fireCancel(): void;`):
+
+```ts
+  /** Fire onContentHeightChange with a logical height. */
+  fireContentHeight(h: number): void;
+```
+
+And in `makeMockMount`'s `tb` object (after `fireCancel`):
+
+```ts
+      fireContentHeight(h: number): void {
+        opts.onContentHeightChange?.(h);
+      },
+```
+
+Then add a new `describe` block at the end of the file:
+
+```ts
+describe('slides text-box insert-to-edit + auto-grow', () => {
+  let editor: SlidesEditor | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    if (editor) { editor.detach(); editor = null; }
+  });
+
+  it('inserting a text box enters edit mode and adds the element', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const { mount } = makeMockMount();
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: mount,
+    });
+    editor.setInsertMode('text');
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 300, clientY: 200, bubbles: true }));
+    document.dispatchEvent(new PointerEvent('pointerup', { clientX: 300, clientY: 200, bubbles: true }));
+
+    const els = store.read().slides[0].elements;
+    expect(els.length).toBe(1);
+    expect(els[0].type).toBe('text');
+    expect(editor.getEditingElementId()).toBe(els[0].id);
+    // Insert mode disarms after placing.
+    expect(editor.getInsertMode()).toBeNull();
+  });
+
+  it('commits the fitted content height into the element frame (one undo entry)', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const slideId = store.read().slides[0].id;
+    let elementId = '';
+    store.batch(() => {
+      elementId = store.addElement(slideId, {
+        type: 'text',
+        frame: { x: 100, y: 100, w: 400, h: 80, rotation: 0 },
+        data: { blocks: [{ id: 'b1', type: 'paragraph', inlines: [{ text: 'hi', style: {} }], style: {} } as Block] },
+      });
+    });
+    const { mount, current } = makeMockMount();
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: mount,
+    });
+    editor.enterTextEditing(elementId);
+    // Simulate the docs editor reporting a grown content height.
+    current()!.fireContentHeight(150);
+    current()!.fireCommit([{ id: 'b1', type: 'paragraph', inlines: [{ text: 'hi there', style: {} }], style: {} } as Block]);
+
+    const el = store.read().slides[0].elements.find((e) => e.id === elementId)!;
+    expect(el.frame.h).toBe(150);
+    // Text + height landed in one batch → one undo restores both.
+    store.undo();
+    const reverted = store.read().slides[0].elements.find((e) => e.id === elementId)!;
+    expect(reverted.frame.h).toBe(80);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @wafflebase/slides test -- view/editor/text-box-editor`
+Expected: FAIL — insert does not enter edit mode (current text branch
+single-click inserts without `enterEditMode`); height is not persisted.
+
+- [ ] **Step 3: Add the module constant + instance field**
+
+In `packages/slides/src/view/editor/editor.ts`, add near the top-level
+constants (after the `import` block, before the class):
+
+```ts
+/**
+ * Floor for an auto-grown text box's frame height (logical px). Content
+ * height normally exceeds this; the floor only guards against a
+ * degenerate near-zero height.
+ */
+const MIN_TEXT_BOX_H = 24;
+```
+
+In the class field declarations (near `private editingElementId`):
+
+```ts
+  /**
+   * Latest content height (logical px) reported by the active text-box
+   * editor via onContentHeightChange. Null when not editing or when the
+   * editor has not reported yet. Read at commit to fit the frame height.
+   */
+  private lastEditingContentHeight: number | null = null;
+```
+
+- [ ] **Step 4: Rewrite the text branch of `startInsert`**
+
+Replace the `if (kind === 'text') { ... return; }` block in `startInsert`
+(lines 1805-1816) with a drag flow that mirrors the shape branch but with
+no ghost (an empty text box renders nothing) and enters edit mode on
+release:
+
+```ts
+    if (kind === 'text') {
+      // Drag-to-size like shapes, but without a ghost preview (an empty
+      // text box paints nothing). On release, place the box and drop the
+      // caret straight inside it — matching Google Slides.
+      this.insertDragging = true;
+      this.hoverPreview = null;
+      let endPoint = start;
+      let cancelled = false;
+      const onMove = (ev: MouseEvent): void => {
+        endPoint = this.clientToLogical(ev.clientX, ev.clientY);
+      };
+      const cleanup = (): void => {
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+        document.removeEventListener('keydown', onKey, true);
+        this.insertDragging = false;
+      };
+      const onUp = (): void => {
+        cleanup();
+        if (cancelled) return;
+        const init = buildInsertElement('text', start, endPoint);
+        let id = '';
+        this.options.store.batch(() => {
+          id = this.options.store.addElement(slide.id, init);
+          this.selection.set([id]);
+        });
+        this.setInsertMode(null);
+        // enterEditMode mounts the docs text-box, repaints, and focuses.
+        this.enterEditMode(slide.id, id);
+      };
+      const onKey = (ev: KeyboardEvent): void => {
+        if (ev.key !== 'Escape') return;
+        ev.preventDefault();
+        ev.stopImmediatePropagation();
+        cancelled = true;
+        cleanup();
+        this.setInsertMode(null);
+        this.renderer.markDirty();
+        this.render();
+      };
+      document.addEventListener('pointermove', onMove);
+      document.addEventListener('pointerup', onUp);
+      document.addEventListener('keydown', onKey, true);
+      return;
+    }
+```
+
+- [ ] **Step 5: Track + persist content height in `enterEditMode`**
+
+In `enterEditMode`, capture the entry height and reset the tracker right
+after the `element` null-check (~line 1578):
+
+```ts
+    const enterFrameH = element.frame.h;
+    this.lastEditingContentHeight = null;
+```
+
+Add `onContentHeightChange` to the `this.mountTextBox({ ... })` options
+(after `onLinkRequest: this.options.onLinkRequest,` ~line 1604):
+
+```ts
+      onContentHeightChange: (h: number): void => {
+        this.lastEditingContentHeight = h;
+      },
+```
+
+Extend the `onCommit` body so the fitted height lands in the same batch as
+the text write. Replace the existing `store.batch(...)` call inside
+`onCommit` (~line 1612-1614) with:
+
+```ts
+            this.options.store.batch(() => {
+              this.options.store.withTextElement(slideId, elementId, () => next);
+              const h = this.lastEditingContentHeight;
+              if (h !== null) {
+                const targetH = Math.max(MIN_TEXT_BOX_H, h);
+                if (targetH !== enterFrameH) {
+                  this.options.store.updateElementFrame(slideId, elementId, { h: targetH });
+                }
+              }
+            });
+```
+
+- [ ] **Step 6: Reset the tracker in `finishEditMode`**
+
+In `finishEditMode` (~line 1661), after `this.editingElementId = null;`:
+
+```ts
+    this.lastEditingContentHeight = null;
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `pnpm --filter @wafflebase/slides test -- view/editor/text-box-editor`
+Expected: PASS (new insert-to-edit + auto-grow tests + all existing
+wiring tests).
+
+- [ ] **Step 8: Typecheck**
+
+Run: `pnpm --filter @wafflebase/slides typecheck`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/slides/src/view/editor/editor.ts packages/slides/test/view/editor/text-box-editor.test.ts
+git commit -m "Enter edit mode on text insert; fit frame height at commit"
+```
+
+---
+
+### Task 5: Verification + smoke
+
+- [ ] **Step 1: Full fast gate**
+
+Run: `pnpm verify:fast`
+Expected: lint + unit tests pass across packages.
+
+- [ ] **Step 2: Self gate (includes builds + entropy)**
+
+Run: `pnpm verify:self`
+Expected: builds pass; entropy (knip/doc-staleness) clean.
+
+- [ ] **Step 3: Manual smoke (UI changed) in `pnpm dev`**
+
+- Insert a text box via the toolbar, click once → caret appears inside,
+  box is one line tall, typing flows immediately.
+- Insert via drag → box width follows the drag, height fits content.
+- Type multiple lines → box grows; delete lines → box shrinks.
+- Click away → committed; reopen → height preserved.
+- Insert a shape → still selected only (no auto edit-mode); double-click
+  still edits text boxes.
+
+- [ ] **Step 4: Capture lessons + archive**
+
+Update `docs/tasks/active/20260525-slides-textbox-autogrow-lessons.md`,
+then `pnpm tasks:archive && pnpm tasks:index`, commit task docs.
+
+---
+
+## Review
+
+(filled in after implementation)

--- a/docs/tasks/active/20260525-slides-textbox-autogrow-todo.md
+++ b/docs/tasks/active/20260525-slides-textbox-autogrow-todo.md
@@ -725,4 +725,48 @@ then `pnpm tasks:archive && pnpm tasks:index`, commit task docs.
 
 ## Review
 
-(filled in after implementation)
+All five tasks implemented via TDD; each step's test failed first, then
+passed after the minimal change.
+
+- **Task 1 (docs engine):** added `onContentHeightChange` option +
+  `setContentHeight()`; fired (de-duped) from `renderNow` post-recompute.
+  Docs unit tests assert the API surface (no canvas ctx in jsdom).
+  794 docs tests green; typecheck clean; `dist/` rebuilt for slides.
+- **Task 2 (slides wrapper):** forwards the callback, resizes
+  container/canvas to the fitted height, delegates `setContentHeight`.
+  End-to-end test under `test-canvas-env` confirms a positive reported
+  height that grows with paragraph count and resizes the container.
+- **Task 3 (insert.ts):** text now uses the shape click-vs-drag rect
+  logic for width + top-left; height stays `TEXT_DEFAULT_H` at insert.
+- **Task 4 (editor.ts):** text insert drag-sizes then enters edit mode
+  (caret inside immediately); the reported content height is fitted into
+  `frame.h` at commit, in one batch with the text write (verified by the
+  single-undo test).
+- **Task 5 (verification):** `pnpm verify:fast` and `pnpm verify:self`
+  both exit 0 (lint, all unit tests, every build, entropy/knip/
+  doc-staleness clean).
+
+### Outcome vs goals
+
+- Insert-to-edit: ✅ — `enterEditMode` on insert (`getEditingElementId`
+  set in test).
+- Drag sizing: ✅ — width + position from the drag; sub-threshold →
+  default width.
+- Auto-grow (content fit, grow + shrink, min one line): ✅ — live canvas
+  resize while editing, `frame.h` fitted at commit.
+- Shapes unaffected: ✅ — only the `text` insert branch changed.
+
+### Known limitations / follow-ups
+
+- No live ghost preview while dragging a text box (an empty text box
+  paints nothing). The box appears on release. Acceptable for v1.
+- `enterEditMode` resolves the element via `slide.elements.find` (top
+  level), so auto-grow applies to top-level text boxes; text inside
+  groups is out of scope here.
+- Width autofit and a per-element autofit-mode selector remain non-goals.
+
+### Pending before merge
+
+- Manual UI smoke in `pnpm dev` (insert click/drag, type to grow, delete
+  to shrink, reopen to confirm persisted height, shapes still
+  select-only) — requires an interactive browser session.

--- a/packages/docs/src/view/text-box-editor.ts
+++ b/packages/docs/src/view/text-box-editor.ts
@@ -113,6 +113,15 @@ export interface TextBoxEditorOptions {
    * `onLinkRequest(cb)` API.
    */
   onLinkRequest?: () => void;
+
+  /**
+   * Fired after layout when the laid-out content height changes (logical
+   * px). The host uses this to grow/shrink the editing surface and to
+   * persist the fitted height. De-duped: only fires when the height
+   * actually changes. Never fires while there is no canvas 2D context
+   * (renderNow early-returns).
+   */
+  onContentHeightChange?: (contentHeight: number) => void;
 }
 
 export interface TextBoxEditorAPI {
@@ -127,6 +136,13 @@ export interface TextBoxEditorAPI {
    * cursor blink, and flush a final `onCommit`. Idempotent.
    */
   detach(): void;
+
+  /**
+   * Resize the editing surface's logical content height and repaint.
+   * Layout is width-driven, so this does not re-wrap text — it only
+   * changes the shim page height + canvas the editor paints into.
+   */
+  setContentHeight(contentHeight: number): void;
 
   // ─── Text-formatting surface (mirrors EditorAPI) ───────────────────────────
   // These are needed so shared text-formatting toolbar components can drive
@@ -250,7 +266,8 @@ function buildShimPaginatedLayout(
  * mounting on a `dblclick`).
  */
 export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI {
-  const { container, canvas, contentWidth, contentHeight } = opts;
+  const { container, canvas, contentWidth } = opts;
+  let contentHeight = opts.contentHeight;
   const dpr = opts.dpr ?? 1;
   const scale = opts.scale ?? 1;
 
@@ -303,6 +320,9 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
   // since the shim's only page is at pageIndex 0 → pageY = pageGap).
   const ctx = canvas.getContext('2d') ?? null;
   let renderRAF: number | null = null;
+  // Last content height reported via onContentHeightChange. Starts at -1
+  // so the first real layout always fires once.
+  let lastReportedHeight = -1;
 
   const renderNow = (): void => {
     renderRAF = null;
@@ -314,6 +334,15 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
     // makes this cheap: only blocks whose content / width changed
     // re-measure; the rest reuse the previous frame's lines.
     recomputeLayout();
+    // Report height changes so the host can grow/shrink the box. Fires
+    // only when the laid-out height actually changed. Lives here (post
+    // recompute) so `layout.totalHeight` is fresh; renderNow already
+    // early-returned above when there is no ctx, so this never fires in
+    // a context-less env.
+    if (layout.totalHeight !== lastReportedHeight) {
+      lastReportedHeight = layout.totalHeight;
+      opts.onContentHeightChange?.(layout.totalHeight);
+    }
     ctx.save();
     // Reset any previous transform, clear in DEVICE-pixel space, then
     // scale to CSS pixels for the rest of the paint. Caller-supplied
@@ -549,6 +578,12 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
         textarea.removeEventListener('keydown', handleEscape, true);
         textarea.remove();
       }
+    },
+
+    setContentHeight(next: number): void {
+      contentHeight = next;
+      paginatedLayout = buildShimPaginatedLayout(layout, contentWidth, contentHeight);
+      requestRender();
     },
 
     // ── Formatting surface ────────────────────────────────────────────────────

--- a/packages/docs/test/view/text-box-editor.test.ts
+++ b/packages/docs/test/view/text-box-editor.test.ts
@@ -38,6 +38,47 @@ describe('initializeTextBox', () => {
     api.detach();
   });
 
+  it('accepts an onContentHeightChange option without throwing', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const canvas = document.createElement('canvas');
+    canvas.width = 400;
+    canvas.height = 200;
+    container.appendChild(canvas);
+    const onContentHeightChange = vi.fn();
+    const api = initializeTextBox({
+      container,
+      canvas,
+      blocks: [],
+      contentWidth: 400,
+      contentHeight: 200,
+      onContentHeightChange,
+    });
+    // jsdom has no 2D context, so renderNow early-returns and the
+    // callback never fires here — firing is covered in the slides
+    // package under test-canvas-env. We only assert construction.
+    expect(typeof api.setContentHeight).toBe('function');
+    api.detach();
+  });
+
+  it('setContentHeight exists and does not throw', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const canvas = document.createElement('canvas');
+    canvas.width = 400;
+    canvas.height = 200;
+    container.appendChild(canvas);
+    const api = initializeTextBox({
+      container,
+      canvas,
+      blocks: [],
+      contentWidth: 400,
+      contentHeight: 200,
+    });
+    expect(() => api.setContentHeight(120)).not.toThrow();
+    api.detach();
+  });
+
   it('seeds an empty paragraph when blocks is empty', () => {
     const { container, api } = mount([]);
     // The hidden textarea TextEditor mounts is a child of `container`.

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -78,6 +78,13 @@ export type ConnectorInsertKind = 'connector:line' | 'connector:arrow';
 
 export type InsertKind = ShapeKind | 'text' | ConnectorInsertKind;
 
+/**
+ * Floor for an auto-grown text box's frame height (logical px). Content
+ * height normally exceeds this; the floor only guards against a
+ * degenerate near-zero height.
+ */
+const MIN_TEXT_BOX_H = 24;
+
 /** Internal helper — recognise connector insert-mode keys. */
 function isConnectorInsertKind(
   kind: InsertKind | null,
@@ -397,6 +404,12 @@ class SlidesEditorImpl implements SlidesEditor {
    */
   private editingElementId: string | null = null;
   private editingTextBox: SlidesTextBoxEditor | null = null;
+  /**
+   * Latest content height (logical px) reported by the active text-box
+   * editor via onContentHeightChange. Null when not editing or when the
+   * editor has not reported yet. Read at commit to fit the frame height.
+   */
+  private lastEditingContentHeight: number | null = null;
   /** Listeners for text-editing state changes (enter + exit). */
   private textEditingListeners = new Set<() => void>();
   /** The currently active text-box editor, or null when not editing. */
@@ -1577,6 +1590,12 @@ class SlidesEditorImpl implements SlidesEditor {
     const element = slide.elements.find((e) => e.id === elementId);
     if (!element || element.type !== 'text') return;
 
+    // Frame height at entry; the committed fit only writes when the
+    // content height differs from this. Reset the per-edit tracker so a
+    // stale height from a previous edit can't leak into this commit.
+    const enterFrameH = element.frame.h;
+    this.lastEditingContentHeight = null;
+
     // Make sure the selection is on the editing element so the rest of
     // the editor (toolbar etc.) reflects the active target.
     this.selection.set([elementId]);
@@ -1602,6 +1621,9 @@ class SlidesEditorImpl implements SlidesEditor {
       scale: this.scale(),
       blocks,
       onLinkRequest: this.options.onLinkRequest,
+      onContentHeightChange: (h: number): void => {
+        this.lastEditingContentHeight = h;
+      },
       onCommit: (next) => {
         // Persist via withTextElement and exit edit mode. We snapshot
         // the slide id at enter-time because the user could have
@@ -1611,6 +1633,15 @@ class SlidesEditorImpl implements SlidesEditor {
           try {
             this.options.store.batch(() => {
               this.options.store.withTextElement(slideId, elementId, () => next);
+              // Fit the frame height to the content in the SAME batch as
+              // the text write — one undo entry, no per-keystroke churn.
+              const h = this.lastEditingContentHeight;
+              if (h !== null) {
+                const targetH = Math.max(MIN_TEXT_BOX_H, h);
+                if (targetH !== enterFrameH) {
+                  this.options.store.updateElementFrame(slideId, elementId, { h: targetH });
+                }
+              }
             });
           } catch {
             // The element may have been removed during editing; swallow
@@ -1662,6 +1693,7 @@ class SlidesEditorImpl implements SlidesEditor {
     const tb = this.editingTextBox;
     this.editingTextBox = null;
     this.editingElementId = null;
+    this.lastEditingContentHeight = null;
     this.activeTextEditor = null;
     for (const cb of this.textEditingListeners) cb();
     if (tb !== null) {
@@ -1803,15 +1835,48 @@ class SlidesEditorImpl implements SlidesEditor {
     const start = this.clientToLogical(clientX, clientY);
 
     if (kind === 'text') {
-      // Single-click insert.
-      const init = buildInsertElement('text', start, start);
-      this.options.store.batch(() => {
-        const id = this.options.store.addElement(slide.id, init);
-        this.selection.set([id]);
-      });
-      this.setInsertMode(null);
-      this.renderer.markDirty();
-      this.render();
+      // Drag-to-size like shapes, but without a ghost preview (an empty
+      // text box paints nothing). On release, place the box and drop the
+      // caret straight inside it — matching Google Slides.
+      this.insertDragging = true;
+      this.hoverPreview = null;
+      let endPoint = start;
+      let cancelled = false;
+      const onMove = (ev: MouseEvent): void => {
+        endPoint = this.clientToLogical(ev.clientX, ev.clientY);
+      };
+      const cleanup = (): void => {
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+        document.removeEventListener('keydown', onKey, true);
+        this.insertDragging = false;
+      };
+      const onUp = (): void => {
+        cleanup();
+        if (cancelled) return;
+        const init = buildInsertElement('text', start, endPoint);
+        let id = '';
+        this.options.store.batch(() => {
+          id = this.options.store.addElement(slide.id, init);
+          this.selection.set([id]);
+        });
+        this.setInsertMode(null);
+        // enterEditMode mounts the docs text-box, repaints, and focuses.
+        this.enterEditMode(slide.id, id);
+      };
+      const onKey = (ev: KeyboardEvent): void => {
+        if (ev.key !== 'Escape') return;
+        ev.preventDefault();
+        ev.stopImmediatePropagation();
+        cancelled = true;
+        cleanup();
+        this.setInsertMode(null);
+        this.renderer.markDirty();
+        this.render();
+      };
+      document.addEventListener('pointermove', onMove);
+      document.addEventListener('pointerup', onUp);
+      document.addEventListener('keydown', onKey, true);
       return;
     }
 

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -365,7 +365,8 @@ class SlidesEditorImpl implements SlidesEditor {
    * insert is armed and the cursor is over the slide. `null` whenever
    * the ghost should not paint (no insert mode, text mode, cursor
    * outside the canvas, mid-drag). Only shape kinds get a ghost —
-   * text uses a single-click insert at fixed size, no preview needed.
+   * text drag-inserts but an empty text box paints nothing, so no
+   * preview is shown.
    */
   private hoverPreview: { kind: ShapeKind; x: number; y: number } | null = null;
   /** rAF handle so rapid mousemoves coalesce into one paint per frame. */
@@ -1707,7 +1708,7 @@ class SlidesEditorImpl implements SlidesEditor {
   /**
    * Update the hover-ghost position as the cursor moves over the slide
    * canvas. No-op when not in shape-insert mode, when text-insert is
-   * armed (text uses a single-click insert and has no useful ghost),
+   * armed (text drag-inserts but an empty box paints no useful ghost),
    * or while a drag-to-size insert is already in flight (the live
    * drag preview from `startInsert` takes over rendering).
    */

--- a/packages/slides/src/view/editor/interactions/insert.ts
+++ b/packages/slides/src/view/editor/interactions/insert.ts
@@ -287,7 +287,10 @@ function defaultsForShape(
  * Build the ElementInit for a freshly-inserted element given the
  * pointer's drag start and end. Behaviour:
  *
- *   - `text` — single-click, default-sized box anchored at `start`.
+ *   - `text` — drag rect sets width + top-left (clamped to
+ *     `MIN_TEXT_BOX_W`); a sub-threshold drag uses `TEXT_DEFAULT_W` at
+ *     `start`. Height is always `TEXT_DEFAULT_H` (the editor fits it to
+ *     content on commit).
  *   - shape, pointer moved ≥ √CLICK_THRESHOLD_PX_SQ — drag rect.
  *   - shape, pointer ~stationary — per-kind default size from
  *     `DEFAULT_INSERT_SIZE`, top-left anchored at `start`.

--- a/packages/slides/src/view/editor/interactions/insert.ts
+++ b/packages/slides/src/view/editor/interactions/insert.ts
@@ -21,6 +21,14 @@ const DEFAULT_BACKGROUND: ThemeColor = { kind: 'role', role: 'background' };
 const DEFAULT_STROKE_WIDTH = 2;
 const TEXT_DEFAULT_W = 400;
 const TEXT_DEFAULT_H = 80;
+/**
+ * Minimum width (slide-logical px) for a drag-drawn text box. A
+ * near-vertical drag (large dy, tiny dx) clears the click threshold but
+ * would otherwise yield a sliver-width box; combined with width-driven
+ * wrapping + auto-grow that produces a pathological tall, 1-char-wide
+ * column. Clamp so an off-axis gesture still gives a usable box.
+ */
+const MIN_TEXT_BOX_W = 40;
 
 export interface Point { x: number; y: number; }
 
@@ -303,7 +311,7 @@ export function buildInsertElement(
     const dx = end.x - start.x;
     const dy = end.y - start.y;
     const isClick = dx * dx + dy * dy < CLICK_THRESHOLD_PX_SQ;
-    const w = isClick ? TEXT_DEFAULT_W : Math.abs(dx);
+    const w = isClick ? TEXT_DEFAULT_W : Math.max(MIN_TEXT_BOX_W, Math.abs(dx));
     const x = isClick ? start.x : Math.min(start.x, end.x);
     const y = isClick ? start.y : Math.min(start.y, end.y);
     return {

--- a/packages/slides/src/view/editor/interactions/insert.ts
+++ b/packages/slides/src/view/editor/interactions/insert.ts
@@ -295,9 +295,20 @@ export function buildInsertElement(
   end: Point,
 ): ElementInit {
   if (kind === 'text') {
+    // Text participates in the same click-vs-drag rect logic as shapes:
+    // a real drag sets the width + top-left; a sub-threshold drag uses
+    // the default width. Height is NOT taken from the drag — the editor
+    // fits it to content (one line) on the first layout / commit — so we
+    // always seed TEXT_DEFAULT_H here.
+    const dx = end.x - start.x;
+    const dy = end.y - start.y;
+    const isClick = dx * dx + dy * dy < CLICK_THRESHOLD_PX_SQ;
+    const w = isClick ? TEXT_DEFAULT_W : Math.abs(dx);
+    const x = isClick ? start.x : Math.min(start.x, end.x);
+    const y = isClick ? start.y : Math.min(start.y, end.y);
     return {
       type: 'text',
-      frame: { x: start.x, y: start.y, w: TEXT_DEFAULT_W, h: TEXT_DEFAULT_H, rotation: 0 },
+      frame: { x, y, w, h: TEXT_DEFAULT_H, rotation: 0 },
       data: {
         blocks: [{
           id: 'placeholder',

--- a/packages/slides/src/view/editor/text-box-editor.ts
+++ b/packages/slides/src/view/editor/text-box-editor.ts
@@ -161,6 +161,11 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
     onCancel();
   };
 
+  // NOTE: the `onContentHeightChange` callback below references `api`. That
+  // is safe only because `initializeTextBox` never fires it synchronously
+  // during construction — its first paint goes through `requestRender()`
+  // (rAF/microtask), so the callback always runs after this `const` binds.
+  // If the docs editor ever fires it synchronously, forward-declare `api`.
   const api: TextBoxEditorAPI = initializeTextBox({
     container,
     canvas,

--- a/packages/slides/src/view/editor/text-box-editor.ts
+++ b/packages/slides/src/view/editor/text-box-editor.ts
@@ -51,6 +51,13 @@ export interface MountSlidesTextBoxOptions {
    * to the docs text-box, which wires it to the inner `TextEditor`.
    */
   onLinkRequest?: () => void;
+  /**
+   * Fired (logical px) when the docs editor's content height changes.
+   * The wrapper has already resized its container/canvas and called
+   * `setContentHeight` by the time this fires; the slides editor uses it
+   * to persist the fitted frame height at commit time.
+   */
+  onContentHeightChange?: (contentHeight: number) => void;
 }
 
 export interface SlidesTextBoxEditor {
@@ -99,7 +106,7 @@ export interface SlidesTextBoxEditor {
 }
 
 export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextBoxEditor {
-  const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest } = opts;
+  const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest, onContentHeightChange } = opts;
 
   // Container positioned over the element frame in host-pixel space.
   const container = document.createElement('div');
@@ -181,6 +188,20 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
     onCommit: handleCommit,
     onCancel: handleCancel,
     onLinkRequest,
+    onContentHeightChange: (h: number): void => {
+      // Grow/shrink the editing surface to fit content. Width is fixed;
+      // only height tracks. cssH is host pixels (logical * slide scale);
+      // the canvas bitmap also multiplies by the browser dpr captured at
+      // mount. Setting canvas.height resets the bitmap — setContentHeight
+      // then schedules a repaint at the new size.
+      const targetH = Math.max(1, h);
+      const cssH = Math.max(1, Math.round(targetH * scale));
+      container.style.height = `${cssH}px`;
+      canvas.style.height = `${cssH}px`;
+      canvas.height = Math.max(1, Math.round(cssH * dpr));
+      api.setContentHeight(targetH);
+      onContentHeightChange?.(targetH);
+    },
   });
 
   return {

--- a/packages/slides/test/view/editor/interactions/insert.test.ts
+++ b/packages/slides/test/view/editor/interactions/insert.test.ts
@@ -33,13 +33,26 @@ describe('buildInsertElement — drag-shaped shapes', () => {
 });
 
 describe('buildInsertElement — text', () => {
-  it('returns a default-sized text box anchored at the start point', () => {
+  it('click (no drag) → default width, height TEXT_DEFAULT_H, anchored at start', () => {
     const text = buildInsertElement('text', { x: 50, y: 50 }, { x: 50, y: 50 });
     expect(text.type).toBe('text');
-    expect(text.frame.w).toBe(400);
-    expect(text.frame.h).toBe(80);
-    expect(text.frame.x).toBe(50);
-    expect(text.frame.y).toBe(50);
+    expect(text.frame).toEqual({ x: 50, y: 50, w: 400, h: 80, rotation: 0 });
+  });
+
+  it('drag → width from the drag rect, height stays TEXT_DEFAULT_H', () => {
+    const text = buildInsertElement('text', { x: 10, y: 20 }, { x: 210, y: 220 });
+    // Width follows the drag (200); height is NOT retained (stays 80).
+    expect(text.frame).toEqual({ x: 10, y: 20, w: 200, h: 80, rotation: 0 });
+  });
+
+  it('backwards drag → top-left normalised', () => {
+    const text = buildInsertElement('text', { x: 300, y: 300 }, { x: 100, y: 50 });
+    expect(text.frame).toEqual({ x: 100, y: 50, w: 200, h: 80, rotation: 0 });
+  });
+
+  it('sub-threshold drag (< 4px) → treated as click → default width', () => {
+    const text = buildInsertElement('text', { x: 10, y: 10 }, { x: 12, y: 12 });
+    expect(text.frame).toEqual({ x: 10, y: 10, w: 400, h: 80, rotation: 0 });
   });
 });
 

--- a/packages/slides/test/view/editor/interactions/insert.test.ts
+++ b/packages/slides/test/view/editor/interactions/insert.test.ts
@@ -54,6 +54,13 @@ describe('buildInsertElement — text', () => {
     const text = buildInsertElement('text', { x: 10, y: 10 }, { x: 12, y: 12 });
     expect(text.frame).toEqual({ x: 10, y: 10, w: 400, h: 80, rotation: 0 });
   });
+
+  it('near-vertical drag → width clamped to MIN_TEXT_BOX_W (no sliver box)', () => {
+    // dx=2, dy=60 clears the click threshold (sub-pixel width would
+    // otherwise auto-grow into a 1-char-wide column).
+    const text = buildInsertElement('text', { x: 10, y: 20 }, { x: 12, y: 80 });
+    expect(text.frame).toEqual({ x: 10, y: 20, w: 40, h: 80, rotation: 0 });
+  });
 });
 
 describe('buildInsertElement — category defaults', () => {

--- a/packages/slides/test/view/editor/text-box-autogrow.test.ts
+++ b/packages/slides/test/view/editor/text-box-autogrow.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import type { Block } from '@wafflebase/docs';
+import { mountSlidesTextBox } from '../../../src/view/editor/text-box-editor';
+
+// Drain the docs editor's rAF-scheduled renderNow (jsdom polyfills rAF
+// via setTimeout; 16ms is enough to flush a frame + cursor-blink restart).
+function flushRaf(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 16));
+}
+
+function para(id: string, text: string): Block {
+  return { id, type: 'paragraph', inlines: [{ text, style: {} }], style: {} } as Block;
+}
+
+describe('mountSlidesTextBox auto-grow', () => {
+  let overlay: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    overlay = document.createElement('div');
+    overlay.style.position = 'absolute';
+    document.body.appendChild(overlay);
+  });
+
+  it('reports content height and resizes the container on mount', async () => {
+    const heights: number[] = [];
+    const tb = mountSlidesTextBox({
+      overlay,
+      frame: { x: 0, y: 0, w: 400, h: 300, rotation: 0 },
+      scale: 1,
+      blocks: [para('p1', 'one line')],
+      onCommit: () => {},
+      onCancel: () => {},
+      onContentHeightChange: (h) => heights.push(h),
+    });
+    await flushRaf();
+    await flushRaf();
+    expect(heights.length).toBeGreaterThan(0);
+    const reported = heights[heights.length - 1];
+    expect(reported).toBeGreaterThan(0);
+    // Container is resized to the reported height (scale = 1).
+    expect(tb.container.style.height).toBe(`${Math.max(1, Math.round(reported))}px`);
+    tb.detach();
+  });
+
+  it('reports a larger height for more paragraphs', async () => {
+    const oneH: number[] = [];
+    const tb1 = mountSlidesTextBox({
+      overlay,
+      frame: { x: 0, y: 0, w: 400, h: 300, rotation: 0 },
+      scale: 1,
+      blocks: [para('p1', 'a')],
+      onCommit: () => {},
+      onCancel: () => {},
+      onContentHeightChange: (h) => oneH.push(h),
+    });
+    await flushRaf();
+    await flushRaf();
+    tb1.detach();
+
+    const fourH: number[] = [];
+    const tb4 = mountSlidesTextBox({
+      overlay,
+      frame: { x: 0, y: 0, w: 400, h: 300, rotation: 0 },
+      scale: 1,
+      blocks: [para('p1', 'a'), para('p2', 'b'), para('p3', 'c'), para('p4', 'd')],
+      onCommit: () => {},
+      onCancel: () => {},
+      onContentHeightChange: (h) => fourH.push(h),
+    });
+    await flushRaf();
+    await flushRaf();
+    expect(fourH[fourH.length - 1]).toBeGreaterThan(oneH[oneH.length - 1]);
+    tb4.detach();
+  });
+});

--- a/packages/slides/test/view/editor/text-box-editor.test.ts
+++ b/packages/slides/test/view/editor/text-box-editor.test.ts
@@ -24,6 +24,8 @@ interface MockTextBox extends SlidesTextBoxEditor {
   fireCommit(blocks: Block[]): void;
   /** Fire onCancel, simulating an Escape press. */
   fireCancel(): void;
+  /** Fire onContentHeightChange with a logical height. */
+  fireContentHeight(h: number): void;
   /** Snapshot of the original mount opts for inspection. */
   opts: MountSlidesTextBoxOptions;
 }
@@ -66,6 +68,9 @@ function makeMockMount(): {
       },
       fireCancel(): void {
         opts.onCancel();
+      },
+      fireContentHeight(h: number): void {
+        opts.onContentHeightChange?.(h);
       },
       opts,
       // Formatting surface — no-op stubs for the mock (real delegation is
@@ -536,5 +541,64 @@ describe('SlidesEditor text-editing API', () => {
     expect(typeof textEditor!.undo).toBe('function');
     expect(typeof textEditor!.redo).toBe('function');
     expect(typeof textEditor!.onCursorMove).toBe('function');
+  });
+});
+
+describe('slides text-box insert-to-edit + auto-grow', () => {
+  let editor: SlidesEditor | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    if (editor) { editor.detach(); editor = null; }
+  });
+
+  it('inserting a text box enters edit mode and adds the element', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const { mount } = makeMockMount();
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: mount,
+    });
+    editor.setInsertMode('text');
+    canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 300, clientY: 200, bubbles: true }));
+    document.dispatchEvent(new PointerEvent('pointerup', { clientX: 300, clientY: 200, bubbles: true }));
+
+    const els = store.read().slides[0].elements;
+    expect(els.length).toBe(1);
+    expect(els[0].type).toBe('text');
+    expect(editor.getEditingElementId()).toBe(els[0].id);
+    // Insert mode disarms after placing.
+    expect(editor.getInsertMode()).toBeNull();
+  });
+
+  it('commits the fitted content height into the element frame (one undo entry)', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const slideId = store.read().slides[0].id;
+    let elementId = '';
+    store.batch(() => {
+      elementId = store.addElement(slideId, {
+        type: 'text',
+        frame: { x: 100, y: 100, w: 400, h: 80, rotation: 0 },
+        data: { blocks: [{ id: 'b1', type: 'paragraph', inlines: [{ text: 'hi', style: {} }], style: {} } as Block] },
+      });
+    });
+    const { mount, current } = makeMockMount();
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: mount,
+    });
+    editor.enterTextEditing(elementId);
+    // Simulate the docs editor reporting a grown content height.
+    current()!.fireContentHeight(150);
+    current()!.fireCommit([{ id: 'b1', type: 'paragraph', inlines: [{ text: 'hi there', style: {} }], style: {} } as Block]);
+
+    const el = store.read().slides[0].elements.find((e) => e.id === elementId)!;
+    expect(el.frame.h).toBe(150);
+    // Text + height landed in one batch → one undo restores both.
+    store.undo();
+    const reverted = store.read().slides[0].elements.find((e) => e.id === elementId)!;
+    expect(reverted.frame.h).toBe(80);
   });
 });


### PR DESCRIPTION
## Summary

Brings the Slides text-box authoring flow in line with Google Slides:

- **Insert-to-edit** — inserting a text box drops the caret straight inside it (edit mode + focus), instead of leaving an empty selected box that needed a double-click. Shapes are unchanged (still select-only).
- **Drag sizing** — a text box can be drawn by dragging (width + position from the drag rect); a sub-threshold drag uses the default width. A near-vertical drag is clamped to a usable minimum width.
- **Auto-grow** — the box height fits its content (grow + shrink, min one line), live while typing. The drawn height is intentionally not retained (height tracks content). The fitted height is persisted into the element frame **at commit**, in the same batch as the text write — one undo entry, no per-keystroke CRDT churn.

### Mechanism

- `@wafflebase/docs` text engine: new `onContentHeightChange` option (fired from `renderNow` after layout, de-duped) + `setContentHeight()` setter. `computeLayout` already produced `layout.totalHeight`; it was only used internally.
- Slides text-box wrapper resizes its editing container/canvas to the fitted height, delegates `setContentHeight`, and reports the logical height to the editor.
- Slides editor enters edit mode on text insert and writes `frame.h` at commit.

Design: `docs/design/slides/slides-textbox-autogrow.md` · Plan: `docs/tasks/active/20260525-slides-textbox-autogrow-todo.md`

### Non-goals

Width autofit, a per-element autofit-mode selector, and auto-grow for text inside non-text shapes.

## Test Plan

- [x] `pnpm verify:fast` (lint + unit) — green
- [x] `pnpm verify:self` (+ all builds + entropy/knip/doc-staleness) — green
- [x] docs unit (API surface) + slides end-to-end auto-grow tests under `test-canvas-env`; insert-to-edit + one-undo height-fit tests
- [x] Self code review (reviewer subagent); Important finding (sliver-width drag) fixed
- [x] Manual smoke in `pnpm dev`: insert via click and via drag → caret inside, one-line tall; type to grow, delete to shrink; reopen → height preserved; shapes still select-only; double-click still edits

## Known limitations

- No live ghost preview while dragging a text box (an empty box paints nothing); the box appears on release.
- `enterEditMode` resolves the element top-level, so auto-grow applies to top-level text boxes; text inside groups is out of scope (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Text boxes now auto-grow height as you type, expanding and shrinking dynamically with your content
  * Insert text boxes using drag-to-size; releases to immediately enter edit mode

* **Documentation**
  * Added comprehensive design and implementation documentation for text box auto-grow feature

* **Tests**
  * Added test coverage for auto-grow behavior and insert-to-edit workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->