### PR TITLE
Remove inline style attributes from Yorkie Tree on clear

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| docs unlink href (2026-05-26) | [20260526-docs-unlink-href-todo.md](./active/20260526-docs-unlink-href-todo.md) | [20260526-docs-unlink-href-lessons.md](./active/20260526-docs-unlink-href-lessons.md) |
 | slides group selection ui (2026-05-26) | [20260526-slides-group-selection-ui-todo.md](./active/20260526-slides-group-selection-ui-todo.md) | [20260526-slides-group-selection-ui-lessons.md](./active/20260526-slides-group-selection-ui-lessons.md) |
 | slides toolbar add slide focus (2026-05-26) | [20260526-slides-toolbar-add-slide-focus-todo.md](./active/20260526-slides-toolbar-add-slide-focus-todo.md) | [20260526-slides-toolbar-add-slide-focus-lessons.md](./active/20260526-slides-toolbar-add-slide-focus-lessons.md) |
 | slides textbox toolbar focus (2026-05-25) | [20260525-slides-textbox-toolbar-focus-todo.md](./active/20260525-slides-textbox-toolbar-focus-todo.md) | [20260525-slides-textbox-toolbar-focus-lessons.md](./active/20260525-slides-textbox-toolbar-focus-lessons.md) |
@@ -33,4 +34,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 219
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides group selection ui (2026-05-26)
+Latest active task: docs unlink href (2026-05-26)

--- a/docs/tasks/active/20260526-docs-unlink-href-lessons.md
+++ b/docs/tasks/active/20260526-docs-unlink-href-lessons.md
@@ -1,0 +1,35 @@
+# Lessons: Docs unlink doesn't remove hyperlink
+
+## Yorkie Tree `styleByPath` only merges — it never deletes
+
+`tree.styleByPath(path, attrs)` merges `attrs` into the node's existing
+attributes. There is no way to delete an attribute by passing it as
+`undefined` (Yorkie attribute payloads are flat string maps, and the
+serializer drops undefined values anyway). To remove an attribute you
+**must** call `tree.removeStyleByPath(fromPath, toPath, keys[])`.
+
+This is documented inline in two existing call sites
+(`setBlockType`, `updateTableCellSpan`) but the inline `applyStyle`
+path missed it — so "clear a style" (e.g. unlink → `{ href: undefined }`)
+silently no-op'd in the CRDT.
+
+## The optimistic cache masked the bug locally
+
+`applyStyle` updates an in-memory cache via `applyInlineStyleHelper`
+(a plain object spread that *does* keep `href: undefined`), then writes
+the CRDT. So the link looked removed locally until the next tree
+re-read (remote change → `dirty = true`, or reload), and never changed
+for other collaborators. When debugging CRDT writes, **assert against a
+fresh re-read from the tree, not the optimistic cache** — in the test,
+construct a second `YorkieDocStore` over the same `yorkie.Document`
+(fresh stores start `dirty = true`, forcing a tree parse).
+
+## Fix shape
+
+`removedInlineStyleAttrs(style)` returns the Yorkie attribute name(s)
+for any `InlineStyle` key explicitly set to `undefined`, mapped through
+the same serialization scheme as `serializeInlineStyle` (e.g.
+`image` → `image.src/width/height/alt`). `applyStyle` calls
+`removeStyleByPath` per styled inline alongside the existing
+`styleByPath` merge. General fix — covers any future cleared key, not
+just `href`.

--- a/docs/tasks/active/20260526-docs-unlink-href-todo.md
+++ b/docs/tasks/active/20260526-docs-unlink-href-todo.md
@@ -1,0 +1,68 @@
+# Docs unlink doesn't remove hyperlink (Yorkie store)
+
+## Problem
+
+Clicking the unlink button in the docs editor does not remove the
+hyperlink. The link reappears after re-reading from the Yorkie tree
+(remote change / reload) and never disappears for other collaborators.
+
+## Root cause
+
+`editor.removeLink()` clears the link via
+`doc.applyInlineStyle(range, { href: undefined })`. In the Yorkie store
+(`packages/frontend/src/app/docs/yorkie-doc-store.ts`) this intent is
+dropped at two layers:
+
+1. `serializeInlineStyle` only emits defined keys
+   (`if (style.href !== undefined) attrs.href = style.href`), so
+   `{ href: undefined }` serializes to `{}`.
+2. `applyStyle` writes styles with `tree.styleByPath(path, { ...existing, ...styleAttrs })`.
+   `styleByPath` only *merges* attributes — it never removes one. So the
+   old `href` attribute survives on the Tree node (the CRDT source of
+   truth). The optimistic in-memory cache removes it, which is why the
+   link looks gone until the next tree re-read.
+
+Other code paths already handle attribute removal with
+`tree.removeStyleByPath(...)` (see lines ~1026-1047, ~2086-2091), but
+`applyStyle` never did.
+
+## Fix
+
+In `applyStyle`, detect inline-style keys explicitly set to `undefined`,
+map them to their Yorkie attribute name(s), and call
+`tree.removeStyleByPath(...)` for the styled inline range — in addition
+to the existing `styleByPath` merge. General enough to cover any
+undefined-clearing key, not just `href`.
+
+## Checklist
+
+- [x] Add `removedInlineStyleAttrs(style)` helper mapping undefined keys → attr names
+- [x] Call `removeStyleByPath` per styled inline in `applyStyle`
+- [x] Regression test: apply href then clear it, verify removed from the Tree (fresh store re-read)
+- [x] `pnpm verify:fast` green
+- [x] Self code review over branch diff
+- [ ] Open PR
+
+## Review
+
+Root cause confirmed and fixed in
+`packages/frontend/src/app/docs/yorkie-doc-store.ts`:
+
+- `applyStyle` now computes `removedInlineStyleAttrs(style)` and calls
+  `tree.removeStyleByPath([...blockPath, i], [...blockPath, i + 1], removeAttrs)`
+  per styled inline, alongside the existing `styleByPath` merge. The
+  inline path range matches the established single-node removal pattern
+  used by `setBlockType` / `updateTableCellSpan`.
+- The fix is general: any `InlineStyle` key explicitly set to `undefined`
+  is removed, not just `href`.
+
+Verification:
+- New tests in `tests/app/docs/yorkie-doc-store.test.ts`
+  ("applyStyle attribute removal") assert href is gone after a fresh
+  re-read from the CRDT tree, and that unrelated styles (bold) survive.
+- Confirmed the tests FAIL on the unfixed source (git stash) and PASS
+  with the fix.
+- `pnpm verify:fast` green (lint + all unit tests, exit 0).
+
+No design-doc change: this is a bug fix, not an architecture change; the
+gotcha is documented inline and in the lessons file.

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -100,6 +100,35 @@ function serializeInlineStyle(style: InlineStyle): Record<string, string> {
   return attrs;
 }
 
+/**
+ * Yorkie's `styleByPath` only merges attributes — it can never delete one.
+ * When a caller clears a style by passing the key explicitly set to
+ * `undefined` (e.g. `removeLink` → `{ href: undefined }`), the key is dropped
+ * by `serializeInlineStyle`, so the merge silently keeps the old value on the
+ * Tree node. This returns the Yorkie attribute names to pass to
+ * `removeStyleByPath` so the clear actually lands in the CRDT.
+ */
+function removedInlineStyleAttrs(style: Partial<InlineStyle>): string[] {
+  const toRemove: string[] = [];
+  const clear = (key: keyof InlineStyle, ...attrNames: string[]): void => {
+    if (key in style && style[key] === undefined) toRemove.push(...attrNames);
+  };
+  clear('bold', 'bold');
+  clear('italic', 'italic');
+  clear('underline', 'underline');
+  clear('strikethrough', 'strikethrough');
+  clear('superscript', 'superscript');
+  clear('subscript', 'subscript');
+  clear('fontSize', 'fontSize');
+  clear('fontFamily', 'fontFamily');
+  clear('color', 'color');
+  clear('backgroundColor', 'backgroundColor');
+  clear('href', 'href');
+  clear('pageNumber', 'pageNumber');
+  clear('image', 'image.src', 'image.width', 'image.height', 'image.alt');
+  return toRemove;
+}
+
 function parseInlineStyle(attrs: Record<string, string> | undefined): InlineStyle {
   if (!attrs) return {};
   const style: InlineStyle = {};
@@ -1424,11 +1453,18 @@ export class YorkieDocStore implements DocStore {
 
       if (startIdx === -1 || endIdx === -1) return;
 
-      // Step 5: Apply style via styleByPath to each inline in the range
+      // Step 5: Apply style via styleByPath to each inline in the range.
+      // styleByPath only merges, so keys explicitly cleared to `undefined`
+      // (e.g. removeLink → { href: undefined }) must also be removed via
+      // removeStyleByPath; otherwise the old attribute survives on the node.
       const styleAttrs = serializeInlineStyle(style as InlineStyle);
+      const removeAttrs = removedInlineStyleAttrs(style);
       for (let i = startIdx; i < endIdx; i++) {
         const existingAttrs = inlines[i].attributes ?? {};
         tree.styleByPath([...blockPath, i], { ...existingAttrs, ...styleAttrs });
+        if (removeAttrs.length > 0) {
+          tree.removeStyleByPath([...blockPath, i], [...blockPath, i + 1], removeAttrs);
+        }
       }
 
       // Step 6: Clean up empty inlines produced by boundary splits

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -429,6 +429,33 @@ describe('YorkieDocStore', () => {
     });
   });
 
+  describe('applyStyle attribute removal', () => {
+    // Re-read via a fresh store over the same doc to bypass the optimistic
+    // cache and assert the CRDT Tree (source of truth) actually changed.
+    const reread = (b: Block) =>
+      new YorkieDocStore(doc).getBlock(b.id)!;
+
+    it('clears href from the Tree when applyStyle gets { href: undefined }', () => {
+      const block = makeBlock('Hello');
+      store.setDocument({ blocks: [block] });
+      store.applyStyle(block.id, 0, 5, { href: 'https://example.com' });
+      expect(reread(block).inlines[0].style.href).toBe('https://example.com');
+
+      store.applyStyle(block.id, 0, 5, { href: undefined });
+      expect(reread(block).inlines[0].style.href).toBeUndefined();
+    });
+
+    it('keeps other styles when only href is cleared', () => {
+      const block = makeBlock('Hello');
+      store.setDocument({ blocks: [block] });
+      store.applyStyle(block.id, 0, 5, { bold: true, href: 'https://example.com' });
+      store.applyStyle(block.id, 0, 5, { href: undefined });
+      const inline = reread(block).inlines[0];
+      expect(inline.style.href).toBeUndefined();
+      expect(inline.style.bold).toBe(true);
+    });
+  });
+
   describe('caching', () => {
     it('getDocument returns a deep clone (mutations do not affect store)', () => {
       const block = makeBlock('Hello');


### PR DESCRIPTION
## Summary

Clicking **unlink** in the docs editor did nothing — the hyperlink stayed.

`removeLink` clears the link via `applyInlineStyle(range, { href: undefined })`, but the Yorkie store (`yorkie-doc-store.ts`) only wrote styles with `tree.styleByPath`, which **merges** attributes and can never delete one. `serializeInlineStyle` also drops `undefined` keys, so the clear was silently lost and the `href` survived on the Tree node (the CRDT source of truth). The optimistic in-memory cache removed it, so the link *looked* gone locally until the next tree re-read (remote change / reload) — and never disappeared for other collaborators.

This is exactly the gotcha already handled in `setBlockType` and `updateTableCellSpan` ("styleByPath merges, not replaces" → use `removeStyleByPath`), but the inline `applyStyle` path missed it.

### Fix

`applyStyle` now computes the Yorkie attribute names of any `InlineStyle` key explicitly set to `undefined` (`removedInlineStyleAttrs`) and calls `tree.removeStyleByPath` per styled inline, alongside the existing `styleByPath` merge. The inline path range matches the established single-node removal pattern. General fix: covers any cleared key, not just `href`.

## Test plan

- New tests in `tests/app/docs/yorkie-doc-store.test.ts` ("applyStyle attribute removal"):
  - clears `href` from the Tree when `applyStyle` gets `{ href: undefined }`
  - keeps other styles (bold) when only `href` is cleared
  - both assert against a **fresh re-read from the CRDT tree** (new `YorkieDocStore` over the same doc), not the optimistic cache
- Confirmed the tests **fail on the unfixed source** and **pass with the fix**.
- `pnpm verify:fast` green (lint + all unit tests); pre-push `verify:self` (all build lanes + entropy) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)