### PR TITLE
Add slides text autofit: shrink mode + GS-style toggle UI

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -76,6 +76,7 @@ Presentation engine — slides, free-position elements, presentation mode, colla
 | [slides-shape-move.md](slides/slides-shape-move.md)                                   | Shape drag-move — `move` hover cursor on selected shapes, ghost preview at `GHOST_ALPHA` follows pointer, commit only on release                                                                            |
 | [slides-ruler.md](slides/slides-ruler.md)                                             | Slides ruler — H/V rulers (corner origin, inch/cm), presentation-wide draggable guides, snap integration, read-only mount handling                                                                          |
 | [slides-textbox-autogrow.md](slides/slides-textbox-autogrow.md)                       | Text box authoring — insert-to-edit focus, drag sizing (width+position), content-fit auto-grow height via a docs `onContentHeightChange` callback                                                            |
+| [slides-text-autofit.md](slides/slides-text-autofit.md)                               | Text autofit — adds `shrink` (font auto-scales to fit a fixed box) + a 3-mode `autofit` selector (none/shrink/grow) layered on the auto-grow feature; placeholder=shrink / textbox=grow defaults, PPTX bodyPr import |
 
 ## Common
 

--- a/docs/design/slides/slides-text-autofit.md
+++ b/docs/design/slides/slides-text-autofit.md
@@ -55,9 +55,11 @@ persist `frame.h` on commit (unchanged from the auto-grow feature).
 
 ### Non-Goals
 
-- A user-facing control to switch modes (toolbar / format panel) — a
-  follow-up PR. v1 ships the engine, the selector field, and parity
-  defaults.
+- A toolbar / Format-panel mode picker. v1 ships an **in-context
+  bottom-left toggle button** on a selected text element (Google-Slides
+  parity; see "Mode toggle UI" below) that flips between `grow` and
+  `shrink`. `'none'` is reachable via the API / PPTX import only, not
+  this button.
 - Re-implementing auto-grow — it already exists; this only gates and
   reuses it.
 - Vertical text anchoring; `lnSpcReduction`; PPTX export (import only);
@@ -145,6 +147,26 @@ mode:
 persist is **automatically gated**: the wrapper only fires
 `onContentHeightChange` for grow, so `lastEditingContentHeight` stays
 `null` for shrink/none and no `frame.h` write happens.
+
+### Mode toggle UI
+
+A small button is painted at the bottom-left of a selected text
+element's frame (Google-Slides parity affordance). Clicking flips the
+mode between `'grow'` and `'shrink'`. The host opts in by passing
+`OverlayOptions.onAutofitToggle(elementId, nextMode)`; the slides editor
+wires that to a `store.batch(() => store.updateElementData(...))` that
+patches only `data.autofit`. Renderer / editor wiring already react to
+the new mode on the next repaint — no separate re-mount.
+
+- **Visibility:** single text element selected; suppressed automatically
+  during in-place editing (the editor filters the editing element out of
+  the overlay's `selected` list).
+- **From `'none'`:** clicking the button re-enables autofit by switching
+  to `'grow'`. `'none'` itself stays API-only (no UI to enter it).
+- **Mode-switch geometry:** flipping `grow` → `shrink` keeps the current
+  `frame.h` (the box becomes fixed at its current size). `shrink` → `grow`
+  re-fits height on the next edit; the renderer paints at `frame.h`
+  meanwhile.
 
 ### Default seeding & persistence
 

--- a/docs/design/slides/slides-text-autofit.md
+++ b/docs/design/slides/slides-text-autofit.md
@@ -1,0 +1,184 @@
+---
+title: slides-text-autofit
+target-version: 0.5.0
+---
+
+<!-- Make sure to append document link in design README.md after creating the document. -->
+
+# Slides Text Autofit
+
+## Summary
+
+Google Slides and PowerPoint expose **three text-box autofit modes**, and
+each box (or the layout slot that owns it) picks one:
+
+| Mode             | Behavior                                              | OOXML           |
+| ---------------- | ---------------------------------------------------- | --------------- |
+| Do not autofit   | Box fixed; text overflows                            | `<a:noAutofit/>` |
+| Shrink on overflow | Box fixed; **font size auto-shrinks** to fit       | `<a:normAutofit fontScale=…/>` |
+| Resize to fit text | Font fixed; **box height grows/shrinks** to content | `<a:spAutoFit/>` |
+
+The **grow** behavior ("resize to fit text") already shipped — see
+[slides-textbox-autogrow.md](slides-textbox-autogrow.md), which made text
+boxes auto-grow their height to content via a docs `onContentHeightChange`
+hook, persisted to the frame on commit. That was the single, unconditional
+text-box behavior.
+
+This document **layers the remaining two modes on top of auto-grow**:
+
+- A persisted `AutofitMode` field (`'none' | 'shrink' | 'grow'`) that
+  selects the behavior per text element.
+- **`shrink`** — fonts auto-scale down to fit a fixed box (the user's
+  original request: "text size changes with the amount of content"). New.
+- The existing auto-grow becomes the **`grow`** mode (and the default for
+  absent fields, so existing decks are unchanged).
+- Parity defaults: layout **placeholders default to `shrink`** (protect
+  the template), free-drawn **text boxes default to `grow`**.
+- PPTX `<a:bodyPr>` autofit child mapped on import.
+
+The shrink scale is a **derived value, computed live and never stored**;
+each client computes it deterministically from `(blocks, frame, font
+metrics)`, so collaborators agree without syncing. Grow continues to
+persist `frame.h` on commit (unchanged from the auto-grow feature).
+
+### Goals
+
+- Add `AutofitMode` to `TextElement.data.autofit`; **absent ⇒ `grow`**
+  (the pre-autofit default) so existing decks keep auto-growing.
+- Implement a shared, deterministic shrink engine reused by the committed
+  canvas renderer and the in-place editor (pixel-identical).
+- Reuse the existing auto-grow mechanism for `grow`; gate it off for
+  `shrink`/`none`.
+- Seed parity defaults (placeholder → shrink, text box → grow); map the
+  PPTX `<a:bodyPr>` autofit child on import; persist the mode through the
+  Yorkie store.
+
+### Non-Goals
+
+- A user-facing control to switch modes (toolbar / format panel) — a
+  follow-up PR. v1 ships the engine, the selector field, and parity
+  defaults.
+- Re-implementing auto-grow — it already exists; this only gates and
+  reuses it.
+- Vertical text anchoring; `lnSpcReduction`; PPTX export (import only);
+  bidirectional "grow text to fill empty space" (shrink scale capped at
+  `1.0`).
+- Scaling horizontal indents during shrink (see Risks).
+
+## Proposal Details
+
+### Data model
+
+`packages/slides/src/model/element.ts`:
+
+```ts
+export type AutofitMode = 'none' | 'shrink' | 'grow';
+
+export type TextElement = ElementBase & {
+  type: 'text';
+  data: {
+    blocks: Block[];
+    stroke?: Stroke;
+    fill?: ThemeColor;
+    /**
+     * Autofit behavior. Absent ⇒ 'grow' (the pre-autofit auto-grow
+     * default) so existing decks keep growing. Set 'none' explicitly to
+     * disable; 'shrink' to scale fonts to a fixed box.
+     */
+    autofit?: AutofitMode;
+  };
+};
+```
+
+`AutofitMode` is exported from the `@wafflebase/slides` barrel so the
+frontend Yorkie schema can reference it.
+
+### Shrink engine
+
+New pure module `packages/slides/src/model/autofit.ts`, built on docs
+`computeLayout` (which returns `layout.totalHeight`):
+
+```ts
+/** Largest font scale in [FLOOR, 1] whose laid-out height fits the box. */
+export function computeAutofitScale(blocks, measurer, frameW, frameH, padding): number;
+/** Multiply every inline fontSize + block vertical margin by `scale`. */
+export function scaleBlocks(blocks, scale): Block[];
+/** Content height for grow callers: totalHeight + 2·padding. */
+export function computeAutofitHeight(blocks, measurer, frameW, padding): number;
+```
+
+`computeAutofitScale` cannot solve scale analytically (smaller fonts wrap
+differently, so height is non-linear in scale): it **binary-searches**
+(~8 iterations, floor `0.1`, cap `1.0`), re-laying-out per probe.
+`scaleBlocks` preserves block/inline identity (ids, text, counts) so the
+editor cursor/selection stay valid against the scaled layout;
+`lineHeight` (a ratio) is left unscaled. Renderer text inset is currently
+`0`, so callers pass `padding = 0`.
+
+### Committed canvas renderer
+
+`view/canvas/text-renderer.ts` `drawText`: when `data.autofit ===
+'shrink'`, compute the scale and lay out `scaleBlocks(...)`. `grow`/`none`/
+absent fall through to the existing paint (grow relies on `frame.h`
+already equaling content height, written on commit by the auto-grow
+feature).
+
+### In-place editor
+
+The editor mounts docs `initializeTextBox`, which already fires
+`onContentHeightChange` (grow) and exposes `setContentHeight`. This adds
+**one optional docs hook**, `transformLayoutBlocks?: (blocks) => Block[]`,
+applied in `recomputeLayout` before `computeLayout` (layout-only, never
+written back to the document). Absent ⇒ identity, so the docs
+word-processor is unaffected.
+
+The slides wrapper (`view/editor/text-box-editor.ts`) selects behavior by
+mode:
+
+| Mode | `onContentHeightChange` (grow) | `transformLayoutBlocks` (shrink) |
+| --- | --- | --- |
+| `grow` / absent | wired (auto-grow) | — |
+| `shrink` | unwired (fixed box) | wired (scale fonts) |
+| `none` | unwired (fixed box) | — |
+
+`editor.ts` passes `element.data.autofit` through. Its commit-time height
+persist is **automatically gated**: the wrapper only fires
+`onContentHeightChange` for grow, so `lastEditingContentHeight` stays
+`null` for shrink/none and no `frame.h` write happens.
+
+### Default seeding & persistence
+
+Creation sites: `model/layout.ts` placeholder → `shrink`;
+`view/editor/interactions/insert.ts` inserted box → `grow`;
+`import/pptx/shape.ts` → from bodyPr; table cells → omitted (⇒ grow via
+absent, matching prior behavior).
+
+Seeding the model init is not enough — the production **Yorkie store**
+(`packages/frontend/src/app/slides/yorkie-slides-store.ts`) rebuilds text
+`data` in three places that must each carry `autofit` (a bare `{ blocks }`
+rebuild drops it): `addElement`, `addSlide` placeholder seeding, and the
+undo/redo snapshot restore (which also now carries the previously-dropped
+`placeholderRef`). The Yorkie text schema gains `autofit?`. A Mem-vs-
+Yorkie equivalence test asserts the field survives all three paths.
+
+### PPTX import
+
+`import/pptx/text.ts` `detectAutofitMode(txBody)` maps the `<a:bodyPr>`
+child: `normAutofit`→`shrink`, `spAutoFit`→`grow`, `noAutofit`/absent→
+`none`. The existing `normAutofit` fontScale baking is kept (imported
+decks render visually identical); the live engine re-engages on edit.
+
+### Risks and Mitigation
+
+- **Shrink algorithm drift vs PowerPoint.** Our binary search won't
+  reproduce PowerPoint's exact `fontScale`. *Mitigation:* import keeps the
+  baked sizes; the engine only recomputes after a user edit.
+- **Determinism.** Shrink scale is a pure function of `(blocks, frame,
+  font metrics)`, so all clients agree with nothing persisted.
+- **Indents not scaled.** `scaleBlocks` scales font size + vertical
+  margins only; `marginLeft` / `textIndent` / list indent stay full-size.
+  Applied identically in renderer and editor (no commit jump) — an
+  aesthetic v1 limitation, not a correctness bug.
+- **Absent ⇒ grow.** Existing decks created under the auto-grow feature
+  (no `autofit` field) keep growing; `none` must be set explicitly. This
+  preserves the just-shipped behavior rather than silently freezing boxes.

--- a/docs/tasks/active/20260525-slides-text-autofit-lessons.md
+++ b/docs/tasks/active/20260525-slides-text-autofit-lessons.md
@@ -1,0 +1,105 @@
+# Slides Text Autofit — Lessons
+
+## What shipped
+
+3-mode autofit (`none`/`shrink`/`grow`) for slides text boxes, GS/PPT
+parity. Hybrid persistence: shrink scale derived live (never stored),
+grow `frame.h` written on commit. Engine `model/autofit.ts` on top of
+docs `computeLayout`; committed renderer + in-place editor share the
+scale; placeholders default shrink, free text boxes default grow; PPTX
+`<a:bodyPr>` mapped on import.
+
+## Lessons (things that bit, or nearly did)
+
+1. **Adding a field to placeholder specs is not enough — the stamping
+   sites drop it.** `MemSlidesStore.addSlide` and `applyLayoutToSlide`
+   both re-seed text placeholders with master typography via
+   `cloned.data = { blocks: seedPlaceholderBlocks(...) }` — a full
+   reassignment that discards every other `data` field (`autofit`,
+   `stroke`, `fill`). The unit test that asserted `BUILT_IN_LAYOUTS`
+   specs carry `autofit: 'shrink'` PASSED while real slides got nothing.
+   Fix: `data = { ...cloned.data, blocks }`, and test END-TO-END through
+   `addSlide`/`applyLayoutToSlide`, not the spec constant. **Rule:** when
+   you add a field to an element/placeholder, grep every site that
+   rebuilds that element's `data`/object and test the real construction
+   path.
+
+2. **No node-canvas in the slides/docs test env.** `CanvasTextMeasurer`
+   throws when asked to measure non-empty text under Vitest/jsdom. All
+   docs text-box tests mount with EMPTY blocks for exactly this reason
+   (empty paragraph → `computeLayout` never calls `measureWidth`). Engine
+   tests inject a fake `TextMeasurer` (`measureWidth = len*size*k`) so
+   wrapping is deterministic and non-linear. **Rule:** anything touching
+   text measurement must either use empty blocks or a fake measurer.
+
+3. **A throw in derived-value computation must not roll back the real
+   write.** The grow-commit path computes `computeAutofitHeight` with a
+   `CanvasTextMeasurer` (throws headless). Computing it INSIDE the
+   `store.batch()` alongside `withTextElement` would let a measurement
+   failure roll back / lose the user's text. Fix: compute the height
+   BEFORE the batch, guarded by try/catch, then write text + height
+   together in one batch (height only when defined). **Rule:** keep
+   best-effort derived computation out of the transaction that carries
+   the must-persist data.
+
+4. **The docs text-box editor never reuses its LayoutCache.**
+   `recomputeLayout` passes `dirtyBlockIds = undefined`, and
+   `computeLayout`'s `canUseCache` requires `dirtyBlockIds != null`. So
+   every render is a full fresh layout — which is why a shrink scale that
+   changes per keystroke (live autofit) is safe: there is no stale cached
+   line data. A code reviewer flagged a "stale cache" risk; it does not
+   apply for this caller.
+
+5. **Shrink scale is non-linear in font size.** Smaller fonts wrap
+   differently, so content height is not proportional to scale.
+   `computeAutofitScale` binary-searches (re-laying-out per probe,
+   floor 0.1, ~8 steps), capped at 1.0 (never enlarges past authored
+   size — matches GS/PPT).
+
+6. **grow = bidirectional (spAutoFit).** Both GS and PowerPoint shrink
+   the box back when text is deleted, not just grow. No `max(originalH)`
+   floor — the box tracks content both ways (natural min is one line).
+
+7. **The Mem store is not the only store — the Yorkie (production) store
+   has its OWN element-construction code.** This was the biggest miss.
+   `MemSlidesStore` (tested) preserves `data` via spreads, but
+   `YorkieSlidesStore` (production, `packages/frontend/...`) rebuilds text
+   `data` from scratch in THREE places — `addElement`, `addSlide`
+   placeholder seeding, and the undo/redo snapshot restore — each as a
+   bare `{ blocks }`, dropping `autofit`. Every branch test passed because
+   they all run against `MemSlidesStore`; the feature was inert by default
+   in production until the final whole-branch review caught it. The
+   undo/redo restore path ALSO dropped `placeholderRef` (a pre-existing
+   bug, untested because the undo/redo test only used `blank` slides).
+   **Rule:** when adding a persisted field, the inventory of "creation
+   sites" MUST include the Yorkie store's addElement / addSlide / snapshot
+   restore, the Yorkie schema type (`types/slides-document.ts`), AND a
+   Mem-vs-Yorkie equivalence assertion for the new field — `stripIds()`
+   only compares type/frame, so structural equivalence tests won't catch
+   a dropped `data` field.
+
+8. **A parallel feature landed on `main` mid-flight and owned half of
+   mine.** While this branch was in review, `slides-textbox-autogrow`
+   merged — it implemented the `grow` half (live content-fit height via a
+   docs `onContentHeightChange` + `setContentHeight`) in the same five
+   files. `git rebase origin/main` surfaced it (a `README.md` conflict was
+   the first hint). The fix was a reframe, not a merge: rebuild the branch
+   on `main`, cherry-pick the still-clean net-new commits (engine,
+   renderer shrink, type, defaults, PPTX import, Yorkie persistence), and
+   hand-write the editor/docs wiring to **reuse** main's grow mechanism —
+   `grow` now delegates to `onContentHeightChange`, `shrink` adds a new
+   `transformLayoutBlocks` hook, and the wrapper gates which fires by mode.
+   **Rule:** before a long-lived feature branch, check whether an
+   overlapping design doc / PR is already in flight; rebase early and
+   often so a parallel merge surfaces while the diff is small.
+   **Consequence:** `absent ⇒ grow` (not `none`) so decks created under
+   the auto-grow feature keep growing — the default had to follow what
+   already shipped.
+
+## Process note
+
+Subagent-driven execution worked well; the two-stage review caught the
+Task 4 stamping gap (implementer flagged it; investigation found a
+SECOND identical site). Trivial review nits (doc wording, extra test
+assertions) were applied inline by the controller rather than spending a
+subagent round-trip — faster for one-liners on already-approved code.

--- a/docs/tasks/active/20260525-slides-text-autofit-todo.md
+++ b/docs/tasks/active/20260525-slides-text-autofit-todo.md
@@ -1,0 +1,808 @@
+# Slides Text Autofit Implementation Plan
+
+> **Reconciliation note (post-implementation):** The `grow` mode in this
+> plan was independently shipped on `main` as `slides-textbox-autogrow`
+> (docs `onContentHeightChange` + `setContentHeight`) while this branch
+> was in review. The branch was rebased onto that work: the engine,
+> renderer shrink, type, defaults, PPTX import, and Yorkie persistence
+> below are unchanged, but the editor/docs wiring (Tasks 5–6) was
+> reworked to **reuse** main's auto-grow for `grow` and add only a
+> `transformLayoutBlocks` hook for `shrink`. Absent `autofit` ⇒ `grow`
+> (not `none`) to preserve the shipped auto-grow default. See the design
+> doc and `*-lessons.md` (lesson 8).
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give slides text boxes Google-Slides/PowerPoint-parity autofit — `none` / `shrink` (font auto-scales to fit a fixed box) / `grow` (box height tracks content) — with shrink computed live (no persistence) and grow height written on commit.
+
+**Architecture:** A pure engine module (`model/autofit.ts`) sits on top of the docs `computeLayout` primitive that the slides renderer already uses. The committed canvas renderer and the in-place editor both feed blocks through the same shrink scale, keeping them pixel-identical. The editor's live behavior needs two small, backward-compatible optional hooks on docs `initializeTextBox`. Defaults: placeholders → `shrink`, free text boxes → `grow`; PPTX `<a:bodyPr>` autofit child maps on import.
+
+**Tech Stack:** TypeScript, Vitest, `@wafflebase/docs` (`computeLayout`, `TextMeasurer`, `Block`), `@wafflebase/slides`.
+
+Design doc: `docs/design/slides/slides-text-autofit.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `packages/slides/src/model/element.ts` | `AutofitMode` type + `TextElement.data.autofit` field | Modify |
+| `packages/slides/src/model/autofit.ts` | Pure engine: `scaleBlocks`, `computeAutofitScale`, `computeAutofitHeight` | Create |
+| `packages/slides/test/model/autofit.test.ts` | Engine tests with a fake `TextMeasurer` | Create |
+| `packages/slides/src/view/canvas/text-renderer.ts` | Apply shrink scale in `drawText` | Modify |
+| `packages/slides/src/view/editor/interactions/insert.ts` | Seed inserted text box `autofit: 'grow'` | Modify |
+| `packages/slides/src/model/layout.ts` | Seed placeholder `autofit: 'shrink'` | Modify |
+| `packages/docs/src/view/text-box-editor.ts` | Optional `transformLayoutBlocks` + `onContentHeight` hooks; shim page height = `max(contentHeight, totalHeight)` | Modify |
+| `packages/docs/test/view/text-box-editor.test.ts` | Hook tests | Create/extend |
+| `packages/slides/src/view/editor/text-box-editor.ts` | Wire shrink transform + grow live-resize | Modify |
+| `packages/slides/src/view/editor/editor.ts` | On commit, write grow `frame.h` | Modify |
+| `packages/slides/src/import/pptx/text.ts` | `detectAutofitMode(txBody)` helper | Modify |
+| `packages/slides/src/import/pptx/shape.ts` | Set `data.autofit` from bodyPr in `buildTextElement` | Modify |
+| `packages/slides/test/import/*.test.ts` | Import mode-mapping test | Create/extend |
+
+**Conventions discovered:**
+- `computeLayout(blocks, measurer, contentWidth)` returns `{ layout, cache }`; `layout.totalHeight` is content height. `measurer` is typed `TextMeasurer` (interface with one method `measureWidth(text, font: ResolvedFont): number`) — inject a fake in tests; jsdom has no real Canvas 2D context.
+- `Block.style.{marginTop,marginBottom}` are px; `lineHeight` is a ratio (do NOT scale). `Inline.style.fontSize?` defaults to `DEFAULT_INLINE_STYLE.fontSize` (11).
+- Slides resolves `@wafflebase/docs` against its built `dist/`, so **rebuild docs** (`pnpm docs build`) after editing the docs package before slides typechecks against it.
+- The committed renderer currently paints real text at `(0,0)` with no inset → pass `padding = 0` for v1.
+
+---
+
+### Task 1: Add `AutofitMode` type and `TextElement.data.autofit` field
+
+**Files:**
+- Modify: `packages/slides/src/model/element.ts:103` (near `PlaceholderType`) and `:122-130` (`TextElement`)
+
+- [ ] **Step 1: Add the type and field**
+
+In `packages/slides/src/model/element.ts`, add after the `PlaceholderRef` type (around line 114):
+
+```ts
+/**
+ * Text-box autofit behavior, mirroring OOXML `<a:bodyPr>` children:
+ * - 'none'   ↔ <a:noAutofit/>   — box fixed, text overflows
+ * - 'shrink' ↔ <a:normAutofit/> — box fixed, font auto-scales down to fit
+ * - 'grow'   ↔ <a:spAutoFit/>   — font fixed, box height tracks content
+ *
+ * The shrink scale is derived live at render/edit time and never stored.
+ * The grow height is written to `frame.h` on edit commit.
+ */
+export type AutofitMode = 'none' | 'shrink' | 'grow';
+```
+
+Then extend `TextElement.data` (around line 124-129):
+
+```ts
+export type TextElement = ElementBase & {
+  type: 'text';
+  data: {
+    /** Domain-level read view; the Yorkie store backs this with a Tree. */
+    blocks: Block[];
+    stroke?: Stroke;
+    fill?: ThemeColor;
+    /**
+     * Autofit behavior. Absent ⇒ 'none' so documents created before this
+     * field keep their current fixed-size rendering (no migration).
+     */
+    autofit?: AutofitMode;
+  };
+};
+```
+
+- [ ] **Step 2: Verify the package typechecks**
+
+Run: `pnpm --filter @wafflebase/slides exec tsc --noEmit`
+Expected: PASS (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/slides/src/model/element.ts
+git commit -m "Add AutofitMode type and TextElement.data.autofit field"
+```
+
+---
+
+### Task 2: Autofit engine (`model/autofit.ts`)
+
+**Files:**
+- Create: `packages/slides/src/model/autofit.ts`
+- Test: `packages/slides/test/model/autofit.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/slides/test/model/autofit.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_BLOCK_STYLE,
+  type Block,
+  type ResolvedFont,
+  type TextMeasurer,
+} from '@wafflebase/docs';
+import {
+  scaleBlocks,
+  computeAutofitScale,
+  computeAutofitHeight,
+} from '../../src/model/autofit';
+
+// Width proportional to font size so wrapping (and therefore totalHeight)
+// changes with scale — exercises the non-linear binary search.
+const fakeMeasurer: TextMeasurer = {
+  measureWidth: (text: string, font: ResolvedFont) => text.length * font.size * 0.6,
+};
+
+function para(text: string, fontSize = 20): Block {
+  return {
+    id: `b-${text}`,
+    type: 'paragraph',
+    inlines: [{ text, style: { fontSize } }],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  };
+}
+
+describe('scaleBlocks', () => {
+  it('returns the same reference when scale is 1', () => {
+    const blocks = [para('hello')];
+    expect(scaleBlocks(blocks, 1)).toBe(blocks);
+  });
+
+  it('multiplies inline fontSize and block margins, preserving identity', () => {
+    const [b] = scaleBlocks([para('hello', 20)], 0.5);
+    expect(b.inlines[0].style.fontSize).toBe(10);
+    expect(b.id).toBe('b-hello');
+    expect(b.inlines[0].text).toBe('hello');
+    expect(b.style.marginBottom).toBe(DEFAULT_BLOCK_STYLE.marginBottom * 0.5);
+  });
+
+  it('falls back to the default font size (11) when inline has none', () => {
+    const blocks: Block[] = [{
+      id: 'x', type: 'paragraph',
+      inlines: [{ text: 'a', style: {} }],
+      style: { ...DEFAULT_BLOCK_STYLE },
+    }];
+    expect(scaleBlocks(blocks, 0.5)[0].inlines[0].style.fontSize).toBe(5.5);
+  });
+});
+
+describe('computeAutofitScale', () => {
+  it('returns 1 when content already fits the box', () => {
+    const scale = computeAutofitScale([para('hi', 20)], fakeMeasurer, 1000, 1000, 0);
+    expect(scale).toBe(1);
+  });
+
+  it('returns a scale < 1 when content overflows', () => {
+    // Many lines into a short box → must shrink.
+    const blocks = Array.from({ length: 20 }, (_, i) => para(`line ${i}`, 40));
+    const scale = computeAutofitScale(blocks, fakeMeasurer, 200, 60, 0);
+    expect(scale).toBeGreaterThan(0.1);
+    expect(scale).toBeLessThan(1);
+  });
+
+  it('never returns below the floor', () => {
+    const blocks = Array.from({ length: 500 }, (_, i) => para(`line ${i}`, 80));
+    const scale = computeAutofitScale(blocks, fakeMeasurer, 50, 20, 0);
+    expect(scale).toBeGreaterThanOrEqual(0.1);
+  });
+});
+
+describe('computeAutofitHeight', () => {
+  it('returns content height plus twice the padding', () => {
+    const single = computeAutofitHeight([para('hi', 20)], fakeMeasurer, 1000, 0);
+    const padded = computeAutofitHeight([para('hi', 20)], fakeMeasurer, 1000, 8);
+    expect(padded).toBe(single + 16);
+    expect(single).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @wafflebase/slides exec vitest run test/model/autofit.test.ts`
+Expected: FAIL — `Cannot find module '../../src/model/autofit'`.
+
+- [ ] **Step 3: Implement the engine**
+
+Create `packages/slides/src/model/autofit.ts`:
+
+```ts
+import {
+  computeLayout,
+  DEFAULT_INLINE_STYLE,
+  type Block,
+  type TextMeasurer,
+} from '@wafflebase/docs';
+
+/** Lowest font scale shrink will ever apply (matches the box-protect intent). */
+const SHRINK_FLOOR = 0.1;
+/** Binary-search iterations; ~8 lands within ~0.4% of the true fit. */
+const SEARCH_STEPS = 8;
+
+/**
+ * Multiply every inline font size and block vertical margin by `scale`.
+ * Pure: returns new objects but preserves block/inline identity (id,
+ * type, text, ordering, counts) so a `Cursor`/`Selection` keyed by
+ * (blockId, offset) stays valid against the scaled layout. `lineHeight`
+ * is a ratio and is intentionally left unscaled.
+ */
+export function scaleBlocks(blocks: Block[], scale: number): Block[] {
+  if (scale === 1) return blocks;
+  return blocks.map((b) => ({
+    ...b,
+    style: {
+      ...b.style,
+      marginTop: b.style.marginTop * scale,
+      marginBottom: b.style.marginBottom * scale,
+    },
+    inlines: b.inlines.map((inl) => ({
+      ...inl,
+      style: {
+        ...inl.style,
+        fontSize: (inl.style.fontSize ?? DEFAULT_INLINE_STYLE.fontSize ?? 11) * scale,
+      },
+    })),
+  }));
+}
+
+/** Content height for grow mode: laid-out height + symmetric padding. */
+export function computeAutofitHeight(
+  blocks: Block[],
+  measurer: TextMeasurer,
+  frameW: number,
+  padding: number,
+): number {
+  return computeLayout(blocks, measurer, frameW).layout.totalHeight + 2 * padding;
+}
+
+/**
+ * Largest font scale in (FLOOR, 1] whose laid-out height fits the box.
+ * Height is non-linear in scale (smaller fonts wrap differently), so this
+ * binary-searches, re-laying-out per probe. Returns 1 when the content
+ * already fits — shrink never enlarges past authored size.
+ */
+export function computeAutofitScale(
+  blocks: Block[],
+  measurer: TextMeasurer,
+  frameW: number,
+  frameH: number,
+  padding: number,
+): number {
+  const avail = frameH - 2 * padding;
+  if (avail <= 0) return SHRINK_FLOOR;
+  if (computeLayout(blocks, measurer, frameW).layout.totalHeight <= avail) return 1;
+
+  let lo = SHRINK_FLOOR;
+  let hi = 1;
+  for (let i = 0; i < SEARCH_STEPS; i++) {
+    const mid = (lo + hi) / 2;
+    const h = computeLayout(scaleBlocks(blocks, mid), measurer, frameW).layout.totalHeight;
+    if (h <= avail) lo = mid;
+    else hi = mid;
+  }
+  return lo;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @wafflebase/slides exec vitest run test/model/autofit.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/slides/src/model/autofit.ts packages/slides/test/model/autofit.test.ts
+git commit -m "Add slides text autofit engine (scale/height helpers)"
+```
+
+---
+
+### Task 3: Apply shrink in the committed renderer (`drawText`)
+
+**Files:**
+- Modify: `packages/slides/src/view/canvas/text-renderer.ts:80-116`
+- Test: covered by Task 2 (the engine) + the full suite; `drawText` is canvas-bound so wiring is verified by typecheck + suite + manual smoke.
+
+- [ ] **Step 1: Wire the shrink path into `drawText`**
+
+In `text-renderer.ts`, add the import:
+
+```ts
+import { computeAutofitScale, scaleBlocks } from '../../model/autofit';
+```
+
+Replace the layout block at the end of `drawText` (currently lines 109-115):
+
+```ts
+  const normalized: Block[] = data.blocks.map((b) => ({
+    ...b,
+    style: normalizeBlockStyle(b.style),
+  }));
+  const colorResolver = makeColorResolver(theme);
+
+  // Shrink autofit: scale fonts down so content fits the fixed box. The
+  // same scale is applied in the in-place editor (text-box-editor.ts) so
+  // the committed canvas and editing surface stay pixel-identical.
+  let toLayout = normalized;
+  if (data.autofit === 'shrink') {
+    const scale = computeAutofitScale(normalized, measurer, size.w, size.h, 0);
+    if (scale !== 1) toLayout = scaleBlocks(normalized, scale);
+  }
+
+  const { layout } = computeLayout(toLayout, measurer, size.w);
+  paintLayout(ctx, layout, 0, 0, { colorResolver });
+```
+
+(`grow` and `none` fall through unchanged: `grow` relies on `frame.h` already equaling content height, written on commit in Task 6.)
+
+- [ ] **Step 2: Verify typecheck and full slides suite**
+
+Run: `pnpm --filter @wafflebase/slides exec tsc --noEmit && pnpm test`
+Expected: PASS. (`pnpm test` runs the slides/sheets vitest suites.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/slides/src/view/canvas/text-renderer.ts
+git commit -m "Apply shrink autofit scale in slides text renderer"
+```
+
+---
+
+### Task 4: Seed parity defaults (placeholder = shrink, text box = grow)
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/interactions/insert.ts:298-320`
+- Modify: `packages/slides/src/model/layout.ts:32-37`
+- Test: `packages/slides/test/model/layout.test.ts` (extend) and an `insert` default test
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `packages/slides/test/model/layout.test.ts` (inside an existing or new `describe`):
+
+```ts
+import { buildBuiltinLayouts } from '../../src/model/layout';
+
+it('seeds text placeholders with shrink autofit', () => {
+  const layouts = buildBuiltinLayouts();
+  const textPlaceholders = layouts
+    .flatMap((l) => l.placeholders)
+    .filter((p) => p.type === 'text');
+  expect(textPlaceholders.length).toBeGreaterThan(0);
+  for (const p of textPlaceholders) {
+    expect(p.data.autofit).toBe('shrink');
+  }
+});
+```
+
+> Adjust `buildBuiltinLayouts` to the actual exported builder name in `layout.ts` if it differs; the assertion is what matters — every text placeholder's `data.autofit === 'shrink'`.
+
+Create `packages/slides/test/view/insert-defaults.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildInsertElement } from '../../src/view/editor/interactions/insert';
+
+describe('buildInsertElement text default', () => {
+  it('seeds a user-inserted text box with grow autofit', () => {
+    const el = buildInsertElement('text', { x: 0, y: 0 }, { x: 100, y: 40 });
+    expect(el.type).toBe('text');
+    if (el.type === 'text') expect(el.data.autofit).toBe('grow');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @wafflebase/slides exec vitest run test/model/layout.test.ts test/view/insert-defaults.test.ts`
+Expected: FAIL — `autofit` is `undefined`.
+
+- [ ] **Step 3: Add the defaults**
+
+In `insert.ts`, inside the `kind === 'text'` branch (line 301), add `autofit: 'grow'` to `data`:
+
+```ts
+      data: {
+        autofit: 'grow',
+        blocks: [{
+          id: 'placeholder',
+          type: 'paragraph',
+          inlines: [{ text: '', style: { color: DEFAULT_TEXT_COLOR } }],
+          style: { ...DEFAULT_BLOCK_STYLE },
+        } as Block],
+      },
+```
+
+In `layout.ts`, in `textPlaceholder` (line 35), add `autofit: 'shrink'`:
+
+```ts
+    data: { autofit: 'shrink', blocks: emptyBlocks() },
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @wafflebase/slides exec vitest run test/model/layout.test.ts test/view/insert-defaults.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/slides/src/view/editor/interactions/insert.ts packages/slides/src/model/layout.ts packages/slides/test/model/layout.test.ts packages/slides/test/view/insert-defaults.test.ts
+git commit -m "Seed slides autofit defaults: placeholder shrink, text box grow"
+```
+
+---
+
+### Task 5: docs `initializeTextBox` autofit hooks
+
+**Files:**
+- Modify: `packages/docs/src/view/text-box-editor.ts:41-115` (options), `:272-284` (recomputeLayout)
+- Test: `packages/docs/test/view/text-box-editor.test.ts` (create or extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend `packages/docs/test/view/text-box-editor.test.ts`. (jsdom has no Canvas 2D context, so `recomputeLayout` runs via `computeLayout` which only needs the measurer; the render path early-returns on a null ctx. We assert the hooks fire.)
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { initializeTextBox, DEFAULT_BLOCK_STYLE, type Block } from '../../src/index';
+
+function block(text: string): Block {
+  return { id: 'b1', type: 'paragraph', inlines: [{ text, style: {} }], style: { ...DEFAULT_BLOCK_STYLE } };
+}
+
+describe('initializeTextBox autofit hooks', () => {
+  it('calls transformLayoutBlocks before layout and onContentHeight after', () => {
+    const container = document.createElement('div');
+    const canvas = document.createElement('canvas');
+    const transform = vi.fn((blocks: Block[]) => blocks);
+    const onContentHeight = vi.fn();
+
+    const api = initializeTextBox({
+      container,
+      canvas,
+      blocks: [block('hello')],
+      contentWidth: 200,
+      contentHeight: 100,
+      transformLayoutBlocks: transform,
+      onContentHeight,
+    });
+
+    expect(transform).toHaveBeenCalled();
+    expect(onContentHeight).toHaveBeenCalledWith(expect.any(Number));
+    api.detach();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @wafflebase/docs exec vitest run test/view/text-box-editor.test.ts`
+Expected: FAIL — options not accepted / hooks never invoked.
+
+- [ ] **Step 3: Add the options and wire them**
+
+In `text-box-editor.ts`, extend `TextBoxEditorOptions` (after `onLinkRequest?`, around line 115):
+
+```ts
+  /**
+   * Optional transform applied to the document blocks immediately before
+   * each layout (NOT to the committed document). Slides autofit "shrink"
+   * uses this to scale font sizes so the editor renders at the same scale
+   * as the committed slide canvas. MUST preserve block/inline identity
+   * (ids, text, counts) so cursor/selection offsets stay valid. Absent ⇒
+   * identity.
+   */
+  transformLayoutBlocks?: (blocks: Block[]) => Block[];
+  /**
+   * Optional callback fired after each layout with the laid-out content
+   * height in logical pixels. Slides autofit "grow" uses this to resize
+   * the overlay live. Absent ⇒ no-op.
+   */
+  onContentHeight?: (height: number) => void;
+```
+
+Replace `recomputeLayout` (lines 272-284):
+
+```ts
+  const recomputeLayout = (): void => {
+    const sourceBlocks = doc.document.blocks;
+    const blocksForLayout = opts.transformLayoutBlocks
+      ? opts.transformLayoutBlocks(sourceBlocks)
+      : sourceBlocks;
+    const result = computeLayout(
+      blocksForLayout,
+      measurer,
+      contentWidth,
+      undefined,
+      layoutCache,
+    );
+    layout = result.layout;
+    layoutCache = result.cache;
+    doc.setBlockParentMap(layout.blockParentMap);
+    // Size the shim page to at least the content height so the caret /
+    // selection page-space math stays correct when content overflows the
+    // authored box (grow mode, or any overflow). Harmless for fixed boxes.
+    const pageHeight = Math.max(contentHeight, layout.totalHeight);
+    paginatedLayout = buildShimPaginatedLayout(layout, contentWidth, pageHeight);
+    opts.onContentHeight?.(layout.totalHeight);
+  };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @wafflebase/docs exec vitest run test/view/text-box-editor.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Rebuild docs (slides consumes dist) and commit**
+
+```bash
+pnpm --filter @wafflebase/docs build
+git add packages/docs/src/view/text-box-editor.ts packages/docs/test/view/text-box-editor.test.ts
+git commit -m "Add autofit hooks to docs initializeTextBox"
+```
+
+---
+
+### Task 6: Wire the editor (live shrink + live grow + grow commit)
+
+**Files:**
+- Modify: `packages/slides/src/view/editor/text-box-editor.ts:35-184`
+- Modify: `packages/slides/src/view/editor/editor.ts:1599-1625`
+- Test: typecheck + full suite + manual smoke (canvas-bound live behavior is not unit-testable in jsdom).
+
+- [ ] **Step 1: Pass the autofit mode into the wrapper and wire both hooks**
+
+In `text-box-editor.ts`, add `autofit` to `MountSlidesTextBoxOptions`:
+
+```ts
+  /** Autofit mode of the text element (drives shrink scale / grow resize). */
+  autofit?: AutofitMode;
+```
+
+Add imports:
+
+```ts
+import type { AutofitMode } from '../../model/element';
+import { computeAutofitScale, scaleBlocks } from '../../model/autofit';
+import { CanvasTextMeasurer } from '@wafflebase/docs';
+```
+
+Add a module-scope measurer near the top of the file:
+
+```ts
+const autofitMeasurer = new CanvasTextMeasurer();
+```
+
+In `mountSlidesTextBox`, destructure `autofit` from opts and pass the hooks into `initializeTextBox` (extend the existing call at line 157):
+
+```ts
+  const api: TextBoxEditorAPI = initializeTextBox({
+    container,
+    canvas,
+    blocks,
+    contentWidth: frame.w,
+    contentHeight: frame.h,
+    dpr: dpr * scale,
+    scale,
+    onCommit: handleCommit,
+    onCancel: handleCancel,
+    onLinkRequest,
+    transformLayoutBlocks:
+      autofit === 'shrink'
+        ? (bs) => {
+            const s = computeAutofitScale(bs, autofitMeasurer, frame.w, frame.h, 0);
+            return s === 1 ? bs : scaleBlocks(bs, s);
+          }
+        : undefined,
+    onContentHeight:
+      autofit === 'grow'
+        ? (logicalHeight) => {
+            // Live-resize the overlay container + canvas as content grows.
+            // The persisted frame.h is written separately on commit
+            // (editor.ts), per the hybrid persistence model.
+            const newCssH = Math.max(1, Math.round(logicalHeight * scale));
+            container.style.height = `${newCssH}px`;
+            canvas.style.height = `${newCssH}px`;
+            canvas.height = Math.max(1, Math.round(newCssH * dpr));
+          }
+        : undefined,
+  });
+```
+
+> Ordering note: docs fires `onContentHeight` inside `recomputeLayout`, which runs at the start of `renderNow` *before* `clearRect`/paint, so the canvas is resized before docs paints into it — no extra render nudge needed.
+
+- [ ] **Step 2: Pass `autofit` through from the editor and write grow height on commit**
+
+In `editor.ts` `enterEditMode` (line 1599), pass `autofit: element.data.autofit` into `mountTextBox`. Then in the `onCommit` handler (lines 1605-1621), after the blocks write, set the grow height:
+
+```ts
+      onCommit: (next) => {
+        if (!cancelled) {
+          try {
+            this.options.store.batch(() => {
+              this.options.store.withTextElement(slideId, elementId, () => next);
+              if (element.data.autofit === 'grow') {
+                const h = computeAutofitHeight(next, autofitMeasurer, element.frame.w, 0);
+                this.options.store.updateElementFrame(slideId, elementId, { h });
+              }
+            });
+          } catch {
+            // Element may have been removed during editing; swallow.
+          }
+        }
+        this.finishEditMode();
+      },
+```
+
+Add to `editor.ts` imports:
+
+```ts
+import { computeAutofitHeight } from '../../model/autofit';
+import { CanvasTextMeasurer } from '@wafflebase/docs';
+```
+
+Add a private field or module-scope measurer for `autofitMeasurer` in `editor.ts` (mirror the wrapper):
+
+```ts
+  private readonly autofitMeasurer = new CanvasTextMeasurer();
+```
+
+…and reference it as `this.autofitMeasurer` in the `onCommit` call above. Verify `mountTextBox` (the editor's wrapper-invoking method) forwards the new `autofit` option through to `mountSlidesTextBox`; extend its option object if it whitelists fields.
+
+- [ ] **Step 3: Verify typecheck + full suite**
+
+Run: `pnpm --filter @wafflebase/slides exec tsc --noEmit && pnpm test`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/slides/src/view/editor/text-box-editor.ts packages/slides/src/view/editor/editor.ts
+git commit -m "Wire slides text editor autofit: live shrink, live grow, grow commit"
+```
+
+---
+
+### Task 7: PPTX import — map `<a:bodyPr>` autofit child
+
+**Files:**
+- Modify: `packages/slides/src/import/pptx/text.ts:38-56` (add `detectAutofitMode`)
+- Modify: `packages/slides/src/import/pptx/shape.ts:548-561` (set `data.autofit`)
+- Test: `packages/slides/test/import/autofit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/slides/test/import/autofit.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { DOMParser } from '@xmldom/xmldom';
+import { detectAutofitMode } from '../../src/import/pptx/text';
+
+function txBody(autofitXml: string): Element {
+  const xml = `<p:txBody xmlns:p="p" xmlns:a="a"><a:bodyPr>${autofitXml}</a:bodyPr><a:p/></p:txBody>`;
+  return new DOMParser().parseFromString(xml, 'text/xml').documentElement as unknown as Element;
+}
+
+describe('detectAutofitMode', () => {
+  it('maps <a:normAutofit/> to shrink', () => {
+    expect(detectAutofitMode(txBody('<a:normAutofit/>'))).toBe('shrink');
+  });
+  it('maps <a:spAutoFit/> to grow', () => {
+    expect(detectAutofitMode(txBody('<a:spAutoFit/>'))).toBe('grow');
+  });
+  it('maps <a:noAutofit/> to none', () => {
+    expect(detectAutofitMode(txBody('<a:noAutofit/>'))).toBe('none');
+  });
+  it('defaults to none when bodyPr has no autofit child', () => {
+    expect(detectAutofitMode(txBody(''))).toBe('none');
+  });
+});
+```
+
+> Use whatever XML parser the existing import tests use; check a sibling test in `packages/slides/test/import/` and match its `txBody`/`child` construction helpers if they differ from `@xmldom/xmldom`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @wafflebase/slides exec vitest run test/import/autofit.test.ts`
+Expected: FAIL — `detectAutofitMode` not exported.
+
+- [ ] **Step 3: Implement `detectAutofitMode` and wire it**
+
+In `text.ts`, add the helper (it reuses the existing `child` import) and export it:
+
+```ts
+import type { AutofitMode } from '../../model/element';
+
+/**
+ * Map the `<a:bodyPr>` autofit child to an AutofitMode. normAutofit's
+ * fontScale is still baked into run sizes by `parseTextBody` (keeping
+ * imported decks visually identical); this only tags the mode so the
+ * live engine re-engages once the user edits the box.
+ */
+export function detectAutofitMode(txBody: Element): AutofitMode {
+  const bodyPr = child(txBody, 'bodyPr');
+  if (!bodyPr) return 'none';
+  if (child(bodyPr, 'normAutofit')) return 'shrink';
+  if (child(bodyPr, 'spAutoFit')) return 'grow';
+  return 'none';
+}
+```
+
+In `shape.ts` `buildTextElement` (line 553), set `autofit`:
+
+```ts
+    data: {
+      autofit: detectAutofitMode(txBody),
+      blocks: parseTextBody(txBody, {
+        rels: ctx.rels,
+        report: ctx.report,
+        defaultFontSize,
+        clrMap: ctx.clrMap,
+      }),
+    },
+```
+
+Add the import to `shape.ts`: `import { parseTextBody, detectAutofitMode } from './text';` (extend the existing `parseTextBody` import).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @wafflebase/slides exec vitest run test/import/autofit.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/slides/src/import/pptx/text.ts packages/slides/src/import/pptx/shape.ts packages/slides/test/import/autofit.test.ts
+git commit -m "Map PPTX bodyPr autofit child to TextElement.autofit on import"
+```
+
+---
+
+### Task 8: Full verification + manual smoke
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the fast gate**
+
+Run: `pnpm verify:fast`
+Expected: PASS (lint + unit).
+
+- [ ] **Step 2: Run builds**
+
+Run: `pnpm verify:self`
+Expected: PASS (verify:fast + all package builds).
+
+- [ ] **Step 3: Manual smoke in dev**
+
+Run: `pnpm dev`, then in the slides editor:
+- Insert a text box, type past the bottom edge → box height grows live; click out → box stays grown (grow).
+- Add a layout with a body placeholder, type a long paragraph → font shrinks to fit; the editing surface matches the committed canvas with no jump on commit (shrink).
+- Import a PPTX with an autofit body placeholder → renders unchanged; editing it re-engages shrink.
+
+- [ ] **Step 4: Capture lessons + finalize**
+
+Record anything non-obvious in `docs/tasks/active/20260525-slides-text-autofit-lessons.md`, then proceed to the project PR workflow (self-review via code-review skill, rebase on `origin/main`, open PR).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 3-mode `AutofitMode` field → Task 1. ✓
+- Shared engine on `computeLayout` → Task 2. ✓
+- Committed renderer shrink → Task 3. ✓
+- grow = `frame.h` on commit → Task 6 Step 2. ✓
+- Parity defaults (placeholder shrink / text box grow) → Task 4. ✓
+- Editor WYSIWYG via docs hooks → Tasks 5 + 6. ✓
+- PPTX bodyPr import mapping (keep baking) → Task 7. ✓
+- Hybrid persistence (shrink never stored; grow on commit) → Tasks 3/6. ✓
+- Back-compat absent ⇒ none (no migration) → Task 1 field is optional; renderer only branches on `=== 'shrink'`/`=== 'grow'`. ✓
+- Non-goals (mode UI, vertical anchor, lnSpcReduction, export, bidirectional grow) → not in any task. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. Two "adjust to actual name" notes (Task 4 `buildBuiltinLayouts`, Task 7 XML helper) are explicit verification asks, not deferred work.
+
+**Type consistency:** `AutofitMode` ('none'|'shrink'|'grow') used identically in element.ts, autofit.ts callers, text-box-editor.ts, and import. `computeAutofitScale(blocks, measurer, frameW, frameH, padding)` and `computeAutofitHeight(blocks, measurer, frameW, padding)` signatures match between definition (Task 2), renderer (Task 3), editor (Task 6), and tests. `transformLayoutBlocks`/`onContentHeight` names match between docs definition (Task 5) and slides usage (Task 6).

--- a/packages/docs/src/view/text-box-editor.ts
+++ b/packages/docs/src/view/text-box-editor.ts
@@ -125,6 +125,16 @@ export interface TextBoxEditorOptions {
   onContentHeightChange?: (contentHeight: number) => void;
 
   /**
+   * Optional transform applied to the document blocks immediately before
+   * each layout (NOT to the committed document). Slides autofit "shrink"
+   * uses this to scale font sizes down so the editor renders at the same
+   * scale as the committed slide canvas. MUST preserve block/inline
+   * identity (ids, text, counts) so cursor/selection offsets stay valid.
+   * Absent ⇒ identity (docs/sheets callers unaffected).
+   */
+  transformLayoutBlocks?: (blocks: Block[]) => Block[];
+
+  /**
    * Resolves a stored `Inline.style.color` / `backgroundColor` to a hex
    * string at paint time. Slides supplies a theme-aware resolver so the
    * in-place editor paints text in the deck's theme color — matching the
@@ -302,8 +312,12 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
   let paginatedLayout: PaginatedLayout = buildShimPaginatedLayout(layout, contentWidth, contentHeight);
 
   const recomputeLayout = (): void => {
+    const sourceBlocks = doc.document.blocks;
+    const blocksForLayout = opts.transformLayoutBlocks
+      ? opts.transformLayoutBlocks(sourceBlocks)
+      : sourceBlocks;
     const result = computeLayout(
-      doc.document.blocks,
+      blocksForLayout,
       measurer,
       contentWidth,
       undefined,

--- a/packages/docs/test/view/text-box-editor.test.ts
+++ b/packages/docs/test/view/text-box-editor.test.ts
@@ -61,6 +61,32 @@ describe('initializeTextBox', () => {
     api.detach();
   });
 
+  it('applies transformLayoutBlocks to the layout blocks (not the document)', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const canvas = document.createElement('canvas');
+    canvas.width = 400;
+    canvas.height = 200;
+    container.appendChild(canvas);
+    // transformLayoutBlocks runs inside recomputeLayout (called at
+    // construction, before the ctx check), so unlike onContentHeightChange
+    // it fires even in jsdom. Empty blocks avoid text measurement.
+    const transform = vi.fn((blocks: Block[]) => blocks);
+    const api = initializeTextBox({
+      container,
+      canvas,
+      blocks: [],
+      contentWidth: 400,
+      contentHeight: 200,
+      transformLayoutBlocks: transform,
+    });
+    expect(transform).toHaveBeenCalled();
+    const passed = transform.mock.calls[0][0];
+    expect(Array.isArray(passed)).toBe(true);
+    expect(passed[0]).toHaveProperty('id'); // received live document blocks
+    api.detach();
+  });
+
   it('setContentHeight exists and does not throw', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -42,6 +42,7 @@ import {
   worldTightFrame,
 } from '@wafflebase/slides';
 import type { Block } from '@wafflebase/docs';
+import type { AutofitMode } from '@wafflebase/slides';
 import type { SlidesPresence } from '@/types/users';
 import type {
   YorkieElement,
@@ -524,11 +525,20 @@ export class YorkieSlidesStore implements SlidesStore {
         background: clone(s.background),
         elements: s.elements.map((e) => {
           if (e.type === 'text') {
+            const td = e.data as { blocks?: Block[]; autofit?: AutofitMode };
             return {
               id: e.id,
               type: 'text',
               frame: { ...e.frame },
-              data: { blocks: clone(e.data.blocks ?? []) },
+              // Carry placeholderRef and autofit through snapshot restore
+              // (undo/redo); the prior bare `{ id, type, frame, blocks }`
+              // rebuild dropped both — stripping placeholder identity and
+              // the autofit mode deck-wide on every undo/redo.
+              ...(e.placeholderRef ? { placeholderRef: clone(e.placeholderRef) } : {}),
+              data: {
+                blocks: clone(td.blocks ?? []),
+                ...(td.autofit ? { autofit: td.autofit } : {}),
+              },
             } as YorkieElement;
           }
           return clone(e) as YorkieElement;
@@ -561,15 +571,24 @@ export class YorkieSlidesStore implements SlidesStore {
           const placeholderStyle =
             master.placeholderStyles[placeholderRef.type]
             ?? master.placeholderStyles.body;
+          const placeholderData = placeholder.data as {
+            blocks?: Block[];
+            autofit?: AutofitMode;
+          };
           const blocks = placeholderStyle
             ? seedPlaceholderBlocks(placeholderStyle, theme)
-            : (placeholder.data as { blocks?: Block[] }).blocks ?? [];
+            : placeholderData.blocks ?? [];
           return {
             id: elementId,
             type: 'text',
             frame: placeholder.frame,
             placeholderRef,
-            data: { blocks: clone(blocks) },
+            // Preserve the placeholder's seeded autofit mode (e.g. 'shrink')
+            // through the master-typography re-seed of `blocks`.
+            data: {
+              blocks: clone(blocks),
+              ...(placeholderData.autofit ? { autofit: placeholderData.autofit } : {}),
+            },
           } as YorkieElement;
         }
         return {
@@ -833,12 +852,17 @@ export class YorkieSlidesStore implements SlidesStore {
       }
 
       if (init.type === 'text') {
-        const blocks = (init.data as { blocks?: Block[] }).blocks ?? [];
+        const textData = init.data as { blocks?: Block[]; autofit?: AutofitMode };
         (targetArray as unknown as YorkieElement[]).push({
           id,
           type: 'text',
           frame: { ...init.frame },
-          data: { blocks: clone(blocks) },
+          // Preserve the seeded autofit mode (e.g. inserted text boxes
+          // default to 'grow'); a bare `{ blocks }` would drop it.
+          data: {
+            blocks: clone(textData.blocks ?? []),
+            ...(textData.autofit ? { autofit: textData.autofit } : {}),
+          },
         } as YorkieElement);
         return;
       }

--- a/packages/frontend/src/types/slides-document.ts
+++ b/packages/frontend/src/types/slides-document.ts
@@ -1,6 +1,7 @@
 import type { Block } from '@wafflebase/docs';
 import type {
   ArrowheadStyle,
+  AutofitMode,
   ConnectorRouting,
   Endpoint,
   Master,
@@ -94,7 +95,7 @@ export interface YorkieTextElement {
   type: 'text';
   frame: YorkieFrame;
   placeholderRef?: PlaceholderRef;
-  data: { blocks: Block[] };
+  data: { blocks: Block[]; autofit?: AutofitMode };
 }
 
 export interface YorkieImageElement {

--- a/packages/frontend/tests/app/slides/yorkie-slides-equivalence.test.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-equivalence.test.ts
@@ -63,6 +63,49 @@ describe('YorkieSlidesStore ≡ MemSlidesStore (single client, local doc)', () =
     expect(yo.slides.length).toBe(2);
   });
 
+  it('seeds + persists autofit defaults equivalently, surviving undo/redo', () => {
+    // Guards the production Yorkie store's text-element construction paths
+    // (addSlide placeholder seed, addElement insert, undo/redo snapshot
+    // restore), each of which rebuilds `data` and previously dropped
+    // `autofit`. stripIds() compares only type/frame, so this is separate.
+    const check = (doc: SlidesDocument, label: string): void => {
+      const slide = doc.slides[0];
+      const placeholders = slide.elements.filter(
+        (e) => e.type === 'text' && e.placeholderRef,
+      );
+      const inserted = slide.elements.filter(
+        (e) => e.type === 'text' && !e.placeholderRef,
+      );
+      expect(placeholders.length, `${label}: has placeholders`).toBeGreaterThan(0);
+      for (const p of placeholders) {
+        if (p.type === 'text') {
+          expect(p.data.autofit, `${label}: placeholder autofit`).toBe('shrink');
+        }
+      }
+      expect(inserted.length, `${label}: has inserted box`).toBe(1);
+      if (inserted[0]?.type === 'text') {
+        expect(inserted[0].data.autofit, `${label}: inserted autofit`).toBe('grow');
+      }
+    };
+
+    const { mem, yo } = runBoth((store) => {
+      let sid!: string;
+      store.batch(() => { sid = store.addSlide('title-body', 0); });
+      store.batch(() => {
+        store.addElement(sid, {
+          type: 'text',
+          frame: { x: 10, y: 10, w: 100, h: 40, rotation: 0 },
+          data: { autofit: 'grow', blocks: [] },
+        });
+      });
+      // Exercise the snapshot-restore path.
+      store.undo();
+      store.redo();
+    });
+    check(mem, 'mem');
+    check(yo, 'yorkie');
+  });
+
   it('add element, updateElementFrame, reorderElement, remove', () => {
     const { mem, yo } = runBoth((store) => {
       let slideId = '';

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -30,7 +30,7 @@ import {
 import { parseBlipFill, parsePic, type ImageParseContext } from './image';
 import { ImportReport } from './report';
 import { parseTable } from './table';
-import { parseTextBody } from './text';
+import { parseTextBody, detectAutofitMode } from './text';
 import type { PptxArchive } from './unzip';
 import type { PptxRel } from './rels';
 import type { UploadImage } from './index';
@@ -551,6 +551,7 @@ function buildTextElement(
     frame,
     ...(placeholderRef ? { placeholderRef } : {}),
     data: {
+      autofit: detectAutofitMode(txBody),
       blocks: parseTextBody(txBody, {
         rels: ctx.rels,
         report: ctx.report,

--- a/packages/slides/src/import/pptx/text.ts
+++ b/packages/slides/src/import/pptx/text.ts
@@ -5,6 +5,7 @@ import { containsHangul, parsePrimaryTypeface } from './font';
 import { ImportReport } from './report';
 import type { PptxRel } from './rels';
 import { attr, attrInt, child, children, NS, textOf } from './xml';
+import type { AutofitMode } from '../../model/element';
 
 /**
  * Per-slide context the text parser needs to resolve hyperlink relationships
@@ -24,6 +25,20 @@ export interface TextParseContext {
   defaultFontSize?: number;
   /** Master-level `<p:clrMap>` translation table for `<a:schemeClr>` lookups. */
   clrMap?: ClrMap;
+}
+
+/**
+ * Map the `<a:bodyPr>` autofit child to an AutofitMode. normAutofit's
+ * fontScale is still baked into run sizes by `parseTextBody` (keeping
+ * imported decks visually identical); this only tags the mode so the
+ * live engine re-engages once the user edits the box.
+ */
+export function detectAutofitMode(txBody: Element): AutofitMode {
+  const bodyPr = child(txBody, 'bodyPr');
+  if (!bodyPr) return 'none';
+  if (child(bodyPr, 'normAutofit')) return 'shrink';
+  if (child(bodyPr, 'spAutoFit')) return 'grow';
+  return 'none';
 }
 
 /**

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -43,6 +43,7 @@ export { DEFAULT_MASTER } from './model/master';
 export { seedPlaceholderBlocks } from './model/placeholder-blocks';
 
 export type {
+  AutofitMode,
   Crop,
   Element,
   ElementBase,

--- a/packages/slides/src/model/autofit.ts
+++ b/packages/slides/src/model/autofit.ts
@@ -1,0 +1,75 @@
+import {
+  computeLayout,
+  DEFAULT_INLINE_STYLE,
+  type Block,
+  type TextMeasurer,
+} from '@wafflebase/docs';
+
+/** Lowest font scale shrink will ever apply (matches the box-protect intent). */
+const SHRINK_FLOOR = 0.1;
+/** Binary-search iterations; ~8 lands within ~0.4% of the true fit. */
+const SEARCH_STEPS = 8;
+
+/**
+ * Multiply every inline font size and block vertical margin by `scale`.
+ * Pure: returns new objects but preserves block/inline identity (id,
+ * type, text, ordering, counts) so a `Cursor`/`Selection` keyed by
+ * (blockId, offset) stays valid against the scaled layout. `lineHeight`
+ * is a ratio and is intentionally left unscaled.
+ */
+export function scaleBlocks(blocks: Block[], scale: number): Block[] {
+  if (scale === 1) return blocks;
+  return blocks.map((b) => ({
+    ...b,
+    style: {
+      ...b.style,
+      marginTop: b.style.marginTop * scale,
+      marginBottom: b.style.marginBottom * scale,
+    },
+    inlines: b.inlines.map((inl) => ({
+      ...inl,
+      style: {
+        ...inl.style,
+        fontSize: (inl.style.fontSize ?? DEFAULT_INLINE_STYLE.fontSize ?? 11) * scale,
+      },
+    })),
+  }));
+}
+
+/** Content height for grow mode: laid-out height + symmetric padding. */
+export function computeAutofitHeight(
+  blocks: Block[],
+  measurer: TextMeasurer,
+  frameW: number,
+  padding: number,
+): number {
+  return computeLayout(blocks, measurer, frameW).layout.totalHeight + 2 * padding;
+}
+
+/**
+ * Largest font scale in (FLOOR, 1] whose laid-out height fits the box.
+ * Height is non-linear in scale (smaller fonts wrap differently), so this
+ * binary-searches, re-laying-out per probe. Returns 1 when the content
+ * already fits — shrink never enlarges past authored size.
+ */
+export function computeAutofitScale(
+  blocks: Block[],
+  measurer: TextMeasurer,
+  frameW: number,
+  frameH: number,
+  padding: number,
+): number {
+  const avail = frameH - 2 * padding;
+  if (avail <= 0) return SHRINK_FLOOR;
+  if (computeLayout(blocks, measurer, frameW).layout.totalHeight <= avail) return 1;
+
+  let lo = SHRINK_FLOOR;
+  let hi = 1;
+  for (let i = 0; i < SEARCH_STEPS; i++) {
+    const mid = (lo + hi) / 2;
+    const h = computeLayout(scaleBlocks(blocks, mid), measurer, frameW).layout.totalHeight;
+    if (h <= avail) lo = mid;
+    else hi = mid;
+  }
+  return lo;
+}

--- a/packages/slides/src/model/autofit.ts
+++ b/packages/slides/src/model/autofit.ts
@@ -36,16 +36,6 @@ export function scaleBlocks(blocks: Block[], scale: number): Block[] {
   }));
 }
 
-/** Content height for grow mode: laid-out height + symmetric padding. */
-export function computeAutofitHeight(
-  blocks: Block[],
-  measurer: TextMeasurer,
-  frameW: number,
-  padding: number,
-): number {
-  return computeLayout(blocks, measurer, frameW).layout.totalHeight + 2 * padding;
-}
-
 /**
  * Largest font scale in [FLOOR, 1] whose laid-out height fits the box.
  * (FLOOR is inclusive: it is returned when even the smallest probe

--- a/packages/slides/src/model/autofit.ts
+++ b/packages/slides/src/model/autofit.ts
@@ -47,7 +47,9 @@ export function computeAutofitHeight(
 }
 
 /**
- * Largest font scale in (FLOOR, 1] whose laid-out height fits the box.
+ * Largest font scale in [FLOOR, 1] whose laid-out height fits the box.
+ * (FLOOR is inclusive: it is returned when even the smallest probe
+ * overflows, or when the box has no usable height.)
  * Height is non-linear in scale (smaller fonts wrap differently), so this
  * binary-searches, re-laying-out per probe. Returns 1 when the content
  * already fits — shrink never enlarges past authored size.

--- a/packages/slides/src/model/element.ts
+++ b/packages/slides/src/model/element.ts
@@ -113,6 +113,17 @@ export type PlaceholderRef = {
   index: number;
 };
 
+/**
+ * Text-box autofit behavior, mirroring OOXML `<a:bodyPr>` children:
+ * - 'none'   ↔ <a:noAutofit/>   — box fixed, text overflows
+ * - 'shrink' ↔ <a:normAutofit/> — box fixed, font auto-scales down to fit
+ * - 'grow'   ↔ <a:spAutoFit/>   — font fixed, box height tracks content
+ *
+ * The shrink scale is derived live at render/edit time and never stored.
+ * The grow height is written to `frame.h` on edit commit.
+ */
+export type AutofitMode = 'none' | 'shrink' | 'grow';
+
 export type ElementBase = {
   id: string;
   frame: Frame;
@@ -126,6 +137,11 @@ export type TextElement = ElementBase & {
     blocks: Block[];
     stroke?: Stroke;
     fill?: ThemeColor;
+    /**
+     * Autofit behavior. Absent ⇒ 'none' so documents created before this
+     * field keep their current fixed-size rendering (no migration).
+     */
+    autofit?: AutofitMode;
   };
 };
 

--- a/packages/slides/src/model/element.ts
+++ b/packages/slides/src/model/element.ts
@@ -138,8 +138,11 @@ export type TextElement = ElementBase & {
     stroke?: Stroke;
     fill?: ThemeColor;
     /**
-     * Autofit behavior. Absent ⇒ 'none' so documents created before this
-     * field keep their current fixed-size rendering (no migration).
+     * Autofit behavior. **Absent ⇒ `'grow'`** (the pre-autofit auto-grow
+     * default established by the `slides-textbox-autogrow` feature) so
+     * existing decks keep growing. Set `'none'` explicitly to disable
+     * auto-grow; `'shrink'` to scale fonts to a fixed box. See
+     * `docs/design/slides/slides-text-autofit.md`.
      */
     autofit?: AutofitMode;
   };

--- a/packages/slides/src/model/layout.ts
+++ b/packages/slides/src/model/layout.ts
@@ -32,7 +32,7 @@ function textPlaceholder(
   return {
     type: 'text',
     frame: { x, y, w, h, rotation: 0 },
-    data: { blocks: emptyBlocks() },
+    data: { autofit: 'shrink', blocks: emptyBlocks() },
     placeholder: { type },
   };
 }

--- a/packages/slides/src/model/layout.ts
+++ b/packages/slides/src/model/layout.ts
@@ -323,7 +323,13 @@ export function applyLayoutToSlide(
         context.master.placeholderStyles[slot.ref.type]
         ?? context.master.placeholderStyles.body;
       if (placeholderStyle) {
-        cloned.data = { blocks: seedPlaceholderBlocks(placeholderStyle, context.theme) };
+        // Preserve the cloned spec's `data` fields (notably `autofit`)
+        // while replacing only `blocks` — a bare `data = { blocks }`
+        // would drop the placeholder's seeded autofit mode.
+        cloned.data = {
+          ...cloned.data,
+          blocks: seedPlaceholderBlocks(placeholderStyle, context.theme),
+        };
       }
     }
     const fresh = {

--- a/packages/slides/src/store/memory.ts
+++ b/packages/slides/src/store/memory.ts
@@ -122,7 +122,14 @@ export class MemSlidesStore implements SlidesStore {
             master.placeholderStyles[ref.type]
             ?? master.placeholderStyles.body;
           if (placeholderStyle) {
-            cloned.data = { blocks: seedPlaceholderBlocks(placeholderStyle, theme) };
+            // Preserve spread of the cloned spec's `data` (notably
+            // `autofit`) while replacing only `blocks` with master-styled
+            // seeds — a bare `data = { blocks }` would drop the
+            // placeholder's seeded autofit mode.
+            cloned.data = {
+              ...cloned.data,
+              blocks: seedPlaceholderBlocks(placeholderStyle, theme),
+            };
           }
         }
         return {

--- a/packages/slides/src/view/canvas/text-renderer.ts
+++ b/packages/slides/src/view/canvas/text-renderer.ts
@@ -7,6 +7,7 @@ import {
   type ColorResolver,
   type StoredColor,
 } from '@wafflebase/docs';
+import { computeAutofitScale, scaleBlocks } from '../../model/autofit';
 import type { TextElement } from '../../model/element';
 import type { PlaceholderStyle } from '../../model/master';
 import type { Theme, ThemeColor } from '../../model/theme';
@@ -111,7 +112,17 @@ export function drawText(
     style: normalizeBlockStyle(b.style),
   }));
   const colorResolver = makeColorResolver(theme);
-  const { layout } = computeLayout(normalized, measurer, size.w);
+
+  // Shrink autofit: scale fonts down so content fits the fixed box. The
+  // same scale is applied in the in-place editor (text-box-editor.ts) so
+  // the committed canvas and editing surface stay pixel-identical.
+  let toLayout = normalized;
+  if (data.autofit === 'shrink') {
+    const scale = computeAutofitScale(normalized, measurer, size.w, size.h, 0);
+    if (scale !== 1) toLayout = scaleBlocks(normalized, scale);
+  }
+
+  const { layout } = computeLayout(toLayout, measurer, size.w);
   paintLayout(ctx, layout, 0, 0, { colorResolver });
 }
 

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1638,6 +1638,10 @@ class SlidesEditorImpl implements SlidesEditor {
       frame: element.frame,
       scale: this.scale(),
       blocks,
+      // Drives editor autofit: 'shrink' scales fonts to fit the fixed box,
+      // 'grow' (and absent) tracks content height, 'none' is fixed. The
+      // wrapper gates onContentHeightChange so shrink/none never auto-grow.
+      autofit: element.data.autofit,
       colorResolver: makeColorResolver(getActiveTheme(doc)),
       onLinkRequest: this.options.onLinkRequest,
       onContentHeightChange: (h: number): void => {

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -581,6 +581,18 @@ class SlidesEditorImpl implements SlidesEditor {
       pendingGuide: this.pendingGuide,
       memberOutlines,
       contextBox,
+      // Autofit mode toggle (GS-style bottom-left affordance on a single
+      // selected text element). Patch only `data.autofit`, then request a
+      // render so the canvas + overlay reflect the new mode immediately
+      // (the store batch by itself does not force a repaint on this path).
+      onAutofitToggle: (elementId, nextMode) => {
+        this.options.store.batch(() => {
+          this.options.store.updateElementData(slide.id, elementId, {
+            autofit: nextMode,
+          });
+        });
+        this.requestRender();
+      },
     });
     // renderOverlay clears `overlay.innerHTML` on every call, which
     // would also unmount the text-box container. Re-append it after

--- a/packages/slides/src/view/editor/interactions/insert.ts
+++ b/packages/slides/src/view/editor/interactions/insert.ts
@@ -321,6 +321,7 @@ export function buildInsertElement(
       type: 'text',
       frame: { x, y, w, h: TEXT_DEFAULT_H, rotation: 0 },
       data: {
+        autofit: 'grow',
         blocks: [{
           id: 'placeholder',
           type: 'paragraph',

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -1,5 +1,5 @@
 import type { ConnectorElement, Endpoint } from '../../model/connector';
-import type { Element, Frame } from '../../model/element';
+import type { AutofitMode, Element, Frame } from '../../model/element';
 import { combinedBoundingBox } from '../../model/frame';
 import type { Guide } from '../../model/presentation';
 import {
@@ -83,6 +83,14 @@ export interface OverlayOptions {
     cursor: { x: number; y: number };
     zoom: number;
   };
+  /**
+   * Click handler for the autofit mode toggle. When provided AND a
+   * single text element is selected, the overlay paints a small toggle
+   * button at the element's bottom-left corner (Google-Slides parity).
+   * Clicking flips between `'grow'` (auto-grow box) and `'shrink'` (fixed
+   * box, fonts scale). Omit to suppress the toggle entirely.
+   */
+  onAutofitToggle?: (elementId: string, nextMode: AutofitMode) => void;
 }
 
 /**
@@ -219,6 +227,17 @@ export function renderOverlay(
     renderAdjustmentHandles(overlay, selectedElements[0], options);
   } else {
     renderAxisAlignedHandles(overlay, selectedElements, options);
+  }
+
+  // Autofit toggle (Google-Slides bottom-left affordance). Single text
+  // element, not currently editing (the editing element is filtered out
+  // of `selectedElements` upstream), host opted in via `onAutofitToggle`.
+  if (
+    selectedElements.length === 1 &&
+    selectedElements[0].type === 'text' &&
+    options.onAutofitToggle
+  ) {
+    renderAutofitToggle(overlay, selectedElements[0], options);
   }
 
   // Snap guide lines (drag-time visual feedback). Rendered last so they
@@ -684,4 +703,75 @@ function makeConnectionSiteDot(
   // Affordance only — must not intercept the live connector drag.
   el.style.pointerEvents = 'none';
   return el;
+}
+
+/**
+ * Autofit mode toggle button, painted at the bottom-left corner of a
+ * single selected text element (Google-Slides parity). Click flips
+ * between `'grow'` (box height tracks content) and `'shrink'` (fixed
+ * box, fonts scale to fit). `'none'` is reachable via Format menu / API,
+ * not this button — matching the GS in-context icon which is a 2-state
+ * toggle.
+ *
+ * Absent `autofit` is treated as `'grow'` (the pre-autofit default, see
+ * `slides-text-autofit.md`), so the first click on a never-set box
+ * switches it to `'shrink'`.
+ */
+const AUTOFIT_TOGGLE_SIZE = 22; // host px
+const AUTOFIT_TOGGLE_OFFSET = 4; // host px below the frame
+
+function renderAutofitToggle(
+  overlay: HTMLDivElement,
+  element: Element,
+  options: OverlayOptions,
+): void {
+  if (element.type !== 'text' || !options.onAutofitToggle) return;
+  const current: AutofitMode = element.data.autofit ?? 'grow';
+  // Cycle: grow ⇄ shrink. From 'none', go to 'grow' (re-enable autofit).
+  const next: AutofitMode =
+    current === 'shrink' ? 'grow' : current === 'grow' ? 'shrink' : 'grow';
+
+  const { scale } = options;
+  const x = element.frame.x * scale;
+  const y = (element.frame.y + element.frame.h) * scale + AUTOFIT_TOGGLE_OFFSET;
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'wfb-slides-autofit-toggle';
+  // GS uses an icon-only button with a hover tooltip; we match that with
+  // a single-character glyph that visually distinguishes the two modes
+  // and a `title` attribute spelling out the current mode + click action.
+  btn.textContent = current === 'shrink' ? 'A↕' : '↕';
+  btn.title =
+    current === 'shrink'
+      ? 'Shrink text to fit (click to switch to resize shape to fit text)'
+      : current === 'grow'
+        ? 'Resize shape to fit text (click to switch to shrink text)'
+        : 'Autofit off (click to enable resize shape to fit text)';
+  btn.style.position = 'absolute';
+  btn.style.left = `${x}px`;
+  btn.style.top = `${y}px`;
+  btn.style.width = `${AUTOFIT_TOGGLE_SIZE}px`;
+  btn.style.height = `${AUTOFIT_TOGGLE_SIZE}px`;
+  btn.style.padding = '0';
+  btn.style.margin = '0';
+  btn.style.border = '1px solid #888';
+  btn.style.borderRadius = '4px';
+  btn.style.background = '#fff';
+  btn.style.color = '#333';
+  btn.style.fontSize = '11px';
+  btn.style.lineHeight = `${AUTOFIT_TOGGLE_SIZE - 2}px`;
+  btn.style.textAlign = 'center';
+  btn.style.cursor = 'pointer';
+  btn.style.boxSizing = 'border-box';
+  btn.style.pointerEvents = 'auto';
+  btn.style.userSelect = 'none';
+  // Disable browser default focus ring on mousedown so the button
+  // doesn't steal focus from the slide canvas after a click.
+  btn.addEventListener('mousedown', (e) => e.preventDefault());
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    options.onAutofitToggle?.(element.id, next);
+  });
+  overlay.appendChild(btn);
 }

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -717,8 +717,32 @@ function makeConnectionSiteDot(
  * `slides-text-autofit.md`), so the first click on a never-set box
  * switches it to `'shrink'`.
  */
-const AUTOFIT_TOGGLE_SIZE = 22; // host px
-const AUTOFIT_TOGGLE_OFFSET = 4; // host px below the frame
+const AUTOFIT_TOGGLE_SIZE = 24; // host px
+const AUTOFIT_TOGGLE_OFFSET = 6; // host px below the frame
+const AUTOFIT_ICON_SIZE = 16; // svg viewport drawn inside the button
+
+/**
+ * SVG for the "grow" mode (resize shape to fit text). Visual: a thin
+ * rectangle with a vertical two-headed arrow inside, suggesting the box
+ * height can change.
+ */
+const ICON_GROW =
+  `<svg viewBox="0 0 16 16" width="${AUTOFIT_ICON_SIZE}" height="${AUTOFIT_ICON_SIZE}" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">` +
+  `<rect x="3" y="3" width="10" height="10" rx="1"/>` +
+  `<line x1="8" y1="5.5" x2="8" y2="10.5"/>` +
+  `<polyline points="6.5,7 8,5.5 9.5,7"/>` +
+  `<polyline points="6.5,9 8,10.5 9.5,9"/>` +
+  `</svg>`;
+
+/**
+ * SVG for the "shrink" mode (shrink text to fit shape). Visual: a big
+ * "A" and a smaller "a", reading as "letters scale down".
+ */
+const ICON_SHRINK =
+  `<svg viewBox="0 0 16 16" width="${AUTOFIT_ICON_SIZE}" height="${AUTOFIT_ICON_SIZE}" fill="currentColor" aria-hidden="true">` +
+  `<text x="0" y="13" font-family="-apple-system,system-ui,sans-serif" font-size="11" font-weight="700">A</text>` +
+  `<text x="8" y="13" font-family="-apple-system,system-ui,sans-serif" font-size="7" font-weight="700">a</text>` +
+  `</svg>`;
 
 function renderAutofitToggle(
   overlay: HTMLDivElement,
@@ -738,37 +762,62 @@ function renderAutofitToggle(
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'wfb-slides-autofit-toggle';
-  // GS uses an icon-only button with a hover tooltip; we match that with
-  // a single-character glyph that visually distinguishes the two modes
-  // and a `title` attribute spelling out the current mode + click action.
-  btn.textContent = current === 'shrink' ? 'A↕' : '↕';
+  // Distinct inline SVGs per mode + a `title` attribute that spells out
+  // the current mode and what clicking will do (GS-style affordance).
+  btn.innerHTML = current === 'shrink' ? ICON_SHRINK : ICON_GROW;
   btn.title =
     current === 'shrink'
       ? 'Shrink text to fit (click to switch to resize shape to fit text)'
       : current === 'grow'
         ? 'Resize shape to fit text (click to switch to shrink text)'
         : 'Autofit off (click to enable resize shape to fit text)';
+  btn.setAttribute(
+    'aria-label',
+    current === 'shrink'
+      ? 'Autofit mode: shrink text. Click to switch to resize shape.'
+      : 'Autofit mode: resize shape. Click to switch to shrink text.',
+  );
   btn.style.position = 'absolute';
   btn.style.left = `${x}px`;
   btn.style.top = `${y}px`;
   btn.style.width = `${AUTOFIT_TOGGLE_SIZE}px`;
   btn.style.height = `${AUTOFIT_TOGGLE_SIZE}px`;
+  btn.style.display = 'inline-flex';
+  btn.style.alignItems = 'center';
+  btn.style.justifyContent = 'center';
   btn.style.padding = '0';
   btn.style.margin = '0';
-  btn.style.border = '1px solid #888';
+  btn.style.border = '1px solid rgba(60, 64, 67, 0.2)';
   btn.style.borderRadius = '4px';
   btn.style.background = '#fff';
-  btn.style.color = '#333';
-  btn.style.fontSize = '11px';
-  btn.style.lineHeight = `${AUTOFIT_TOGGLE_SIZE - 2}px`;
-  btn.style.textAlign = 'center';
+  btn.style.color = 'rgb(60, 64, 67)'; // Google-grey-700-ish
+  btn.style.boxShadow = '0 1px 2px rgba(0, 0, 0, 0.15)';
   btn.style.cursor = 'pointer';
   btn.style.boxSizing = 'border-box';
   btn.style.pointerEvents = 'auto';
   btn.style.userSelect = 'none';
-  // Disable browser default focus ring on mousedown so the button
-  // doesn't steal focus from the slide canvas after a click.
-  btn.addEventListener('mousedown', (e) => e.preventDefault());
+  btn.style.transition = 'background 80ms ease, border-color 80ms ease';
+  btn.addEventListener('mouseenter', () => {
+    btn.style.background = '#f1f3f4';
+    btn.style.borderColor = 'rgba(60, 64, 67, 0.35)';
+  });
+  btn.addEventListener('mouseleave', () => {
+    btn.style.background = '#fff';
+    btn.style.borderColor = 'rgba(60, 64, 67, 0.2)';
+  });
+  // The editor attaches a `pointerdown` listener on the overlay itself
+  // (editor.ts) that runs hit-test → select-or-clear. Without stopping
+  // propagation HERE the button click would be treated as a click on
+  // empty space (the button sits below the frame), deselecting the very
+  // element we're trying to toggle. We stop at `pointerdown` because
+  // that fires before `mousedown`/`click` and is what the editor listens
+  // for. `mousedown.preventDefault()` is kept to also block the focus
+  // steal that would otherwise pull focus off the canvas.
+  btn.addEventListener('pointerdown', (e) => e.stopPropagation());
+  btn.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  });
   btn.addEventListener('click', (e) => {
     e.stopPropagation();
     options.onAutofitToggle?.(element.id, next);

--- a/packages/slides/src/view/editor/text-box-editor.ts
+++ b/packages/slides/src/view/editor/text-box-editor.ts
@@ -23,6 +23,7 @@
  */
 import {
   initializeTextBox,
+  CanvasTextMeasurer,
   type Block,
   type TextBoxEditorAPI,
   type InlineStyle,
@@ -31,7 +32,15 @@ import {
   type HeadingLevel,
   type ColorResolver,
 } from '@wafflebase/docs';
-import type { Frame } from '../../model/element';
+import type { AutofitMode, Frame } from '../../model/element';
+import { computeAutofitScale, scaleBlocks } from '../../model/autofit';
+
+/**
+ * Measurer for the live "shrink" scale computation. Module-scope so its
+ * font-metrics cache is shared across edit sessions; one mount lives only
+ * as long as one edit session, so there's no per-instance state to leak.
+ */
+const autofitMeasurer = new CanvasTextMeasurer();
 
 export interface MountSlidesTextBoxOptions {
   /** The slides editor's selection overlay. The wrapper appends a child container. */
@@ -59,6 +68,16 @@ export interface MountSlidesTextBoxOptions {
    * to persist the fitted frame height at commit time.
    */
   onContentHeightChange?: (contentHeight: number) => void;
+  /**
+   * Autofit mode of the text element. Drives which behavior the editor
+   * wires:
+   * - 'shrink' → fonts auto-scale down to fit the fixed box
+   *   (`transformLayoutBlocks`); the box does NOT auto-grow.
+   * - 'grow' (and absent, the pre-autofit default) → box height tracks
+   *   content via `onContentHeightChange`.
+   * - 'none' → fixed box, no scaling, text overflows.
+   */
+  autofit?: AutofitMode;
   /**
    * Theme-aware color resolver built from the deck's active theme (see
    * `makeColorResolver` in the canvas text-renderer). Forwarded to the
@@ -115,7 +134,13 @@ export interface SlidesTextBoxEditor {
 }
 
 export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextBoxEditor {
-  const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest, onContentHeightChange, colorResolver } = opts;
+  const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest, onContentHeightChange, colorResolver, autofit } = opts;
+
+  // Auto-grow is the behavior for every mode except an explicit 'shrink'
+  // (fixed box, font scales) or 'none' (fixed box, overflow). Absent ⇒
+  // grow, matching the pre-autofit default so existing decks keep growing.
+  const isGrow = autofit !== 'shrink' && autofit !== 'none';
+  const isShrink = autofit === 'shrink';
 
   // Container positioned over the element frame in host-pixel space.
   const container = document.createElement('div');
@@ -202,20 +227,34 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
     onCommit: handleCommit,
     onCancel: handleCancel,
     onLinkRequest,
-    onContentHeightChange: (h: number): void => {
-      // Grow/shrink the editing surface to fit content. Width is fixed;
-      // only height tracks. cssH is host pixels (logical * slide scale);
-      // the canvas bitmap also multiplies by the browser dpr captured at
-      // mount. Setting canvas.height resets the bitmap — setContentHeight
-      // then schedules a repaint at the new size.
-      const targetH = Math.max(1, h);
-      const cssH = Math.max(1, Math.round(targetH * scale));
-      container.style.height = `${cssH}px`;
-      canvas.style.height = `${cssH}px`;
-      canvas.height = Math.max(1, Math.round(cssH * dpr));
-      api.setContentHeight(targetH);
-      onContentHeightChange?.(targetH);
-    },
+    // Grow only when the mode calls for it. For 'shrink'/'none' the box
+    // stays fixed, so we leave this unwired and the docs editor never
+    // resizes the surface.
+    onContentHeightChange: isGrow
+      ? (h: number): void => {
+          // Grow/shrink the editing surface to fit content. Width is fixed;
+          // only height tracks. cssH is host pixels (logical * slide scale);
+          // the canvas bitmap also multiplies by the browser dpr captured at
+          // mount. Setting canvas.height resets the bitmap — setContentHeight
+          // then schedules a repaint at the new size.
+          const targetH = Math.max(1, h);
+          const cssH = Math.max(1, Math.round(targetH * scale));
+          container.style.height = `${cssH}px`;
+          canvas.style.height = `${cssH}px`;
+          canvas.height = Math.max(1, Math.round(cssH * dpr));
+          api.setContentHeight(targetH);
+          onContentHeightChange?.(targetH);
+        }
+      : undefined,
+    // Shrink: scale fonts down so content fits the fixed box, live as the
+    // user types. The same scale is applied in the committed renderer
+    // (text-renderer.ts) so the editing surface stays pixel-identical.
+    transformLayoutBlocks: isShrink
+      ? (bs): Block[] => {
+          const s = computeAutofitScale(bs, autofitMeasurer, frame.w, frame.h, 0);
+          return s === 1 ? bs : scaleBlocks(bs, s);
+        }
+      : undefined,
     colorResolver,
   });
 

--- a/packages/slides/src/view/editor/text-box-editor.ts
+++ b/packages/slides/src/view/editor/text-box-editor.ts
@@ -251,8 +251,14 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
     // (text-renderer.ts) so the editing surface stays pixel-identical.
     transformLayoutBlocks: isShrink
       ? (bs): Block[] => {
-          const s = computeAutofitScale(bs, autofitMeasurer, frame.w, frame.h, 0);
-          return s === 1 ? bs : scaleBlocks(bs, s);
+          try {
+            const s = computeAutofitScale(bs, autofitMeasurer, frame.w, frame.h, 0);
+            return s === 1 ? bs : scaleBlocks(bs, s);
+          } catch {
+            // Measurement unavailable (e.g. a canvas-less headless env);
+            // fall back to unscaled blocks rather than failing the mount.
+            return bs;
+          }
         }
       : undefined,
     colorResolver,

--- a/packages/slides/test/import/pptx/text.test.ts
+++ b/packages/slides/test/import/pptx/text.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
-import { parseTextBody } from '../../../src/import/pptx/text';
+import { parseTextBody, detectAutofitMode } from '../../../src/import/pptx/text';
 import { ImportReport } from '../../../src/import/pptx/report';
 import { parseXml } from '../../../src/import/pptx/xml';
 import type { PptxRel } from '../../../src/import/pptx/rels';
@@ -143,6 +143,24 @@ describe('parseTextBody — paragraphs', () => {
     const blocks = parseTextBody(t, { report: new ImportReport() });
     expect(blocks).toHaveLength(1);
     expect(blocks[0].inlines.map((i) => i.text)).toEqual(['line1', '\n', 'line2']);
+  });
+});
+
+describe('detectAutofitMode', () => {
+  it('maps <a:normAutofit/> to shrink', () => {
+    expect(detectAutofitMode(txBody('<a:txBody><a:bodyPr><a:normAutofit/></a:bodyPr><a:p/></a:txBody>'))).toBe('shrink');
+  });
+  it('maps <a:spAutoFit/> to grow', () => {
+    expect(detectAutofitMode(txBody('<a:txBody><a:bodyPr><a:spAutoFit/></a:bodyPr><a:p/></a:txBody>'))).toBe('grow');
+  });
+  it('maps <a:noAutofit/> to none', () => {
+    expect(detectAutofitMode(txBody('<a:txBody><a:bodyPr><a:noAutofit/></a:bodyPr><a:p/></a:txBody>'))).toBe('none');
+  });
+  it('defaults to none when bodyPr has no autofit child', () => {
+    expect(detectAutofitMode(txBody('<a:txBody><a:bodyPr/><a:p/></a:txBody>'))).toBe('none');
+  });
+  it('defaults to none when there is no bodyPr', () => {
+    expect(detectAutofitMode(txBody('<a:txBody><a:p/></a:txBody>'))).toBe('none');
   });
 });
 

--- a/packages/slides/test/model/autofit.test.ts
+++ b/packages/slides/test/model/autofit.test.ts
@@ -8,7 +8,6 @@ import {
 import {
   scaleBlocks,
   computeAutofitScale,
-  computeAutofitHeight,
 } from '../../src/model/autofit';
 
 // Width proportional to font size so wrapping (and therefore totalHeight)
@@ -73,21 +72,8 @@ describe('computeAutofitScale', () => {
   });
 });
 
-describe('computeAutofitHeight', () => {
-  it('returns content height plus twice the padding', () => {
-    const single = computeAutofitHeight([para('hi', 20)], fakeMeasurer, 1000, 0);
-    const padded = computeAutofitHeight([para('hi', 20)], fakeMeasurer, 1000, 8);
-    expect(padded).toBe(single + 16);
-    expect(single).toBeGreaterThan(0);
-  });
-});
-
 describe('empty content (e.g. a freshly inserted text box)', () => {
   it('computeAutofitScale returns 1 for no blocks', () => {
     expect(computeAutofitScale([], fakeMeasurer, 200, 200, 0)).toBe(1);
-  });
-
-  it('computeAutofitHeight returns just the padding for no blocks', () => {
-    expect(computeAutofitHeight([], fakeMeasurer, 200, 8)).toBe(16);
   });
 });

--- a/packages/slides/test/model/autofit.test.ts
+++ b/packages/slides/test/model/autofit.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_BLOCK_STYLE,
+  type Block,
+  type ResolvedFont,
+  type TextMeasurer,
+} from '@wafflebase/docs';
+import {
+  scaleBlocks,
+  computeAutofitScale,
+  computeAutofitHeight,
+} from '../../src/model/autofit';
+
+// Width proportional to font size so wrapping (and therefore totalHeight)
+// changes with scale — exercises the non-linear binary search.
+const fakeMeasurer: TextMeasurer = {
+  measureWidth: (text: string, font: ResolvedFont) => text.length * font.size * 0.6,
+};
+
+function para(text: string, fontSize = 20): Block {
+  return {
+    id: `b-${text}`,
+    type: 'paragraph',
+    inlines: [{ text, style: { fontSize } }],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  };
+}
+
+describe('scaleBlocks', () => {
+  it('returns the same reference when scale is 1', () => {
+    const blocks = [para('hello')];
+    expect(scaleBlocks(blocks, 1)).toBe(blocks);
+  });
+
+  it('multiplies inline fontSize and block margins, preserving identity', () => {
+    const [b] = scaleBlocks([para('hello', 20)], 0.5);
+    expect(b.inlines[0].style.fontSize).toBe(10);
+    expect(b.id).toBe('b-hello');
+    expect(b.inlines[0].text).toBe('hello');
+    expect(b.style.marginBottom).toBe(DEFAULT_BLOCK_STYLE.marginBottom * 0.5);
+  });
+
+  it('falls back to the default font size (11) when inline has none', () => {
+    const blocks: Block[] = [{
+      id: 'x', type: 'paragraph',
+      inlines: [{ text: 'a', style: {} }],
+      style: { ...DEFAULT_BLOCK_STYLE },
+    }];
+    expect(scaleBlocks(blocks, 0.5)[0].inlines[0].style.fontSize).toBe(5.5);
+  });
+});
+
+describe('computeAutofitScale', () => {
+  it('returns 1 when content already fits the box', () => {
+    const scale = computeAutofitScale([para('hi', 20)], fakeMeasurer, 1000, 1000, 0);
+    expect(scale).toBe(1);
+  });
+
+  it('returns a scale < 1 when content overflows', () => {
+    const blocks = Array.from({ length: 20 }, (_, i) => para(`line ${i}`, 40));
+    const scale = computeAutofitScale(blocks, fakeMeasurer, 200, 200, 0);
+    expect(scale).toBeGreaterThan(0.1);
+    expect(scale).toBeLessThan(1);
+  });
+
+  it('never returns below the floor', () => {
+    const blocks = Array.from({ length: 500 }, (_, i) => para(`line ${i}`, 80));
+    const scale = computeAutofitScale(blocks, fakeMeasurer, 50, 20, 0);
+    expect(scale).toBeGreaterThanOrEqual(0.1);
+  });
+});
+
+describe('computeAutofitHeight', () => {
+  it('returns content height plus twice the padding', () => {
+    const single = computeAutofitHeight([para('hi', 20)], fakeMeasurer, 1000, 0);
+    const padded = computeAutofitHeight([para('hi', 20)], fakeMeasurer, 1000, 8);
+    expect(padded).toBe(single + 16);
+    expect(single).toBeGreaterThan(0);
+  });
+});

--- a/packages/slides/test/model/autofit.test.ts
+++ b/packages/slides/test/model/autofit.test.ts
@@ -33,11 +33,14 @@ describe('scaleBlocks', () => {
   });
 
   it('multiplies inline fontSize and block margins, preserving identity', () => {
-    const [b] = scaleBlocks([para('hello', 20)], 0.5);
+    const source = [para('hello', 20)];
+    const [b] = scaleBlocks(source, 0.5);
     expect(b.inlines[0].style.fontSize).toBe(10);
     expect(b.id).toBe('b-hello');
     expect(b.inlines[0].text).toBe('hello');
     expect(b.style.marginBottom).toBe(DEFAULT_BLOCK_STYLE.marginBottom * 0.5);
+    // Source blocks must not be mutated (binary search re-scales them repeatedly).
+    expect(source[0].inlines[0].style.fontSize).toBe(20);
   });
 
   it('falls back to the default font size (11) when inline has none', () => {
@@ -76,5 +79,15 @@ describe('computeAutofitHeight', () => {
     const padded = computeAutofitHeight([para('hi', 20)], fakeMeasurer, 1000, 8);
     expect(padded).toBe(single + 16);
     expect(single).toBeGreaterThan(0);
+  });
+});
+
+describe('empty content (e.g. a freshly inserted text box)', () => {
+  it('computeAutofitScale returns 1 for no blocks', () => {
+    expect(computeAutofitScale([], fakeMeasurer, 200, 200, 0)).toBe(1);
+  });
+
+  it('computeAutofitHeight returns just the padding for no blocks', () => {
+    expect(computeAutofitHeight([], fakeMeasurer, 200, 8)).toBe(16);
   });
 });

--- a/packages/slides/test/model/layout-apply.test.ts
+++ b/packages/slides/test/model/layout-apply.test.ts
@@ -124,6 +124,22 @@ describe('applyLayoutToSlide', () => {
     }
   });
 
+  it('fresh placeholder via context preserves the seeded autofit mode', () => {
+    // The master-typography re-seed replaces data.blocks; it must keep
+    // the placeholder's autofit 'shrink' (a bare `data = { blocks }`
+    // reassignment would drop it).
+    const slide = makeSlide('blank', []);
+    applyLayoutToSlide(slide, getLayout('title-body'), {
+      master: DEFAULT_MASTER,
+      theme: defaultLight,
+    });
+    const textEls = slide.elements.filter((e) => e.type === 'text');
+    expect(textEls.length).toBeGreaterThan(0);
+    for (const el of textEls) {
+      if (el.type === 'text') expect(el.data.autofit).toBe('shrink');
+    }
+  });
+
   it('6. user-added elements are untouched', () => {
     const fromLayout = getLayout('title-body');
     const userText = textEl('user', 'mine', { x: 50, y: 50, w: 100, h: 30 }); // no ref

--- a/packages/slides/test/model/layout.test.ts
+++ b/packages/slides/test/model/layout.test.ts
@@ -64,6 +64,16 @@ describe('BUILT_IN_LAYOUTS', () => {
       'big-number': ['big-number', 'body'],
     });
   });
+
+  it('seeds text placeholders with shrink autofit', () => {
+    const textPlaceholders = BUILT_IN_LAYOUTS
+      .flatMap((l) => l.placeholders)
+      .filter((p) => p.type === 'text');
+    expect(textPlaceholders.length).toBeGreaterThan(0);
+    for (const p of textPlaceholders) {
+      expect(p.data.autofit).toBe('shrink');
+    }
+  });
 });
 
 describe('getLayout', () => {

--- a/packages/slides/test/store/memory.test.ts
+++ b/packages/slides/test/store/memory.test.ts
@@ -38,6 +38,21 @@ describe('MemSlidesStore — slides', () => {
     expect(store.read().slides.map((s) => s.id)).toEqual([id]);
   });
 
+  it('addSlide stamps text placeholders with shrink autofit', () => {
+    // End-to-end guard: the layout spec seeds autofit 'shrink', and the
+    // master-typography re-seed during stamping must preserve it (a bare
+    // `data = { blocks }` reassignment would drop it).
+    const store = new MemSlidesStore();
+    let sid!: string;
+    store.batch(() => { sid = store.addSlide('title-body', 0); });
+    const slide = store.read().slides.find((s) => s.id === sid)!;
+    const textEls = slide.elements.filter((e) => e.type === 'text');
+    expect(textEls.length).toBeGreaterThan(0);
+    for (const el of textEls) {
+      if (el.type === 'text') expect(el.data.autofit).toBe('shrink');
+    }
+  });
+
   it('addSlide with atIndex inserts at that position', () => {
     const store = new MemSlidesStore();
     let a!: string;

--- a/packages/slides/test/view/editor/autofit-toggle.test.ts
+++ b/packages/slides/test/view/editor/autofit-toggle.test.ts
@@ -94,6 +94,27 @@ describe('autofit toggle', () => {
     expect(overlay.querySelector('.wfb-slides-autofit-toggle')).toBeNull();
   });
 
+  it('stops pointerdown / mousedown / click propagation so the editor does not clear selection', () => {
+    // Regression: the editor attaches a pointerdown listener on the overlay
+    // itself that runs hit-test → select-or-clear. The toggle sits BELOW the
+    // frame, so without propagation guards the click is treated as a click on
+    // empty space and clears the selection of the very element we're toggling.
+    const overlay = makeOverlay();
+    renderOverlay(overlay, [textEl('grow')], { ...baseOpts, onAutofitToggle: vi.fn() });
+    const btn = overlay.querySelector('.wfb-slides-autofit-toggle') as HTMLButtonElement;
+
+    const overlaySpy = vi.fn();
+    overlay.addEventListener('pointerdown', overlaySpy);
+    overlay.addEventListener('mousedown', overlaySpy);
+    overlay.addEventListener('click', overlaySpy);
+
+    btn.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+    btn.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    btn.click();
+
+    expect(overlaySpy).not.toHaveBeenCalled();
+  });
+
   it('does not render the toggle when multiple elements are selected', () => {
     const overlay = makeOverlay();
     const t2: TextElement = { ...textEl('shrink'), id: 't2' };

--- a/packages/slides/test/view/editor/autofit-toggle.test.ts
+++ b/packages/slides/test/view/editor/autofit-toggle.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { renderOverlay } from '../../../src/view/editor/overlay';
+import type { ShapeElement, TextElement } from '../../../src/model/element';
+
+function textEl(autofit?: 'none' | 'shrink' | 'grow'): TextElement {
+  return {
+    id: 't1',
+    type: 'text',
+    frame: { x: 100, y: 200, w: 300, h: 80, rotation: 0 },
+    data: {
+      blocks: [],
+      ...(autofit ? { autofit } : {}),
+    },
+  };
+}
+
+function shapeEl(): ShapeElement {
+  return {
+    id: 's1',
+    type: 'shape',
+    frame: { x: 0, y: 0, w: 50, h: 50, rotation: 0 },
+    data: { kind: 'rect' },
+  };
+}
+
+function makeOverlay(): HTMLDivElement {
+  const overlay = document.createElement('div');
+  document.body.appendChild(overlay);
+  return overlay;
+}
+
+const baseOpts = { scale: 1, slideWidth: 1920, slideHeight: 1080 };
+
+describe('autofit toggle', () => {
+  it('renders a toggle button at the frame bottom-left for a single text element', () => {
+    const overlay = makeOverlay();
+    renderOverlay(overlay, [textEl('grow')], {
+      ...baseOpts,
+      onAutofitToggle: vi.fn(),
+    });
+    const btn = overlay.querySelector('.wfb-slides-autofit-toggle') as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+    // Bottom-left of frame (100, 200+80=280) + a small offset below.
+    expect(btn!.style.left).toBe('100px');
+    expect(parseInt(btn!.style.top, 10)).toBeGreaterThanOrEqual(280);
+  });
+
+  it('clicking the toggle on a grow element calls onAutofitToggle with shrink', () => {
+    const overlay = makeOverlay();
+    const onToggle = vi.fn();
+    renderOverlay(overlay, [textEl('grow')], { ...baseOpts, onAutofitToggle: onToggle });
+    const btn = overlay.querySelector('.wfb-slides-autofit-toggle') as HTMLButtonElement;
+    btn.click();
+    expect(onToggle).toHaveBeenCalledWith('t1', 'shrink');
+  });
+
+  it('clicking the toggle on a shrink element calls onAutofitToggle with grow', () => {
+    const overlay = makeOverlay();
+    const onToggle = vi.fn();
+    renderOverlay(overlay, [textEl('shrink')], { ...baseOpts, onAutofitToggle: onToggle });
+    const btn = overlay.querySelector('.wfb-slides-autofit-toggle') as HTMLButtonElement;
+    btn.click();
+    expect(onToggle).toHaveBeenCalledWith('t1', 'grow');
+  });
+
+  it('treats absent autofit as grow (next click switches to shrink)', () => {
+    const overlay = makeOverlay();
+    const onToggle = vi.fn();
+    renderOverlay(overlay, [textEl(/* absent */)], { ...baseOpts, onAutofitToggle: onToggle });
+    const btn = overlay.querySelector('.wfb-slides-autofit-toggle') as HTMLButtonElement;
+    btn.click();
+    expect(onToggle).toHaveBeenCalledWith('t1', 'shrink');
+  });
+
+  it('clicking from "none" re-enables grow', () => {
+    const overlay = makeOverlay();
+    const onToggle = vi.fn();
+    renderOverlay(overlay, [textEl('none')], { ...baseOpts, onAutofitToggle: onToggle });
+    const btn = overlay.querySelector('.wfb-slides-autofit-toggle') as HTMLButtonElement;
+    btn.click();
+    expect(onToggle).toHaveBeenCalledWith('t1', 'grow');
+  });
+
+  it('does not render the toggle for non-text elements', () => {
+    const overlay = makeOverlay();
+    renderOverlay(overlay, [shapeEl()], { ...baseOpts, onAutofitToggle: vi.fn() });
+    expect(overlay.querySelector('.wfb-slides-autofit-toggle')).toBeNull();
+  });
+
+  it('does not render the toggle when no onAutofitToggle callback is provided', () => {
+    const overlay = makeOverlay();
+    renderOverlay(overlay, [textEl('grow')], baseOpts);
+    expect(overlay.querySelector('.wfb-slides-autofit-toggle')).toBeNull();
+  });
+
+  it('does not render the toggle when multiple elements are selected', () => {
+    const overlay = makeOverlay();
+    const t2: TextElement = { ...textEl('shrink'), id: 't2' };
+    renderOverlay(overlay, [textEl('grow'), t2], {
+      ...baseOpts,
+      onAutofitToggle: vi.fn(),
+    });
+    expect(overlay.querySelector('.wfb-slides-autofit-toggle')).toBeNull();
+  });
+});

--- a/packages/slides/test/view/editor/interactions/insert-defaults.test.ts
+++ b/packages/slides/test/view/editor/interactions/insert-defaults.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { buildInsertElement } from '../../../../src/view/editor/interactions/insert';
+
+describe('buildInsertElement text default', () => {
+  it('seeds a user-inserted text box with grow autofit', () => {
+    const el = buildInsertElement('text', { x: 0, y: 0 }, { x: 100, y: 40 });
+    expect(el.type).toBe('text');
+    if (el.type === 'text') expect(el.data.autofit).toBe('grow');
+  });
+});

--- a/packages/slides/test/view/text-box-autofit-gating.test.ts
+++ b/packages/slides/test/view/text-box-autofit-gating.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AutofitMode, Frame } from '../../src/model/element';
+
+// Capture the options the wrapper passes to docs `initializeTextBox` so we
+// can assert which autofit hooks get wired per mode. `vi.hoisted` makes the
+// spy available to the hoisted `vi.mock` factory below.
+const { initSpy } = vi.hoisted(() => ({ initSpy: vi.fn() }));
+
+vi.mock('@wafflebase/docs', async (importActual) => {
+  const actual = await importActual<typeof import('@wafflebase/docs')>();
+  return {
+    ...actual,
+    // Record opts, return a no-op API (the wrapper only stores it and
+    // delegates lazily; nothing is invoked during mount).
+    initializeTextBox: (opts: unknown) => {
+      initSpy(opts);
+      return new Proxy({}, { get: () => () => undefined });
+    },
+  };
+});
+
+// Import AFTER the mock so the wrapper binds the mocked initializeTextBox.
+import { mountSlidesTextBox } from '../../src/view/editor/text-box-editor';
+
+type InitOpts = {
+  transformLayoutBlocks?: unknown;
+  onContentHeightChange?: unknown;
+};
+
+function mountWith(autofit: AutofitMode | undefined): InitOpts {
+  initSpy.mockClear();
+  const overlay = document.createElement('div');
+  document.body.appendChild(overlay);
+  const frame: Frame = { x: 0, y: 0, w: 200, h: 100, rotation: 0 };
+  mountSlidesTextBox({
+    overlay,
+    frame,
+    scale: 1,
+    blocks: [],
+    onCommit: () => {},
+    onCancel: () => {},
+    autofit,
+  });
+  return initSpy.mock.calls[0][0] as InitOpts;
+}
+
+describe('mountSlidesTextBox autofit hook gating', () => {
+  beforeEach(() => initSpy.mockClear());
+
+  it("'shrink' wires transformLayoutBlocks and NOT onContentHeightChange", () => {
+    const opts = mountWith('shrink');
+    expect(typeof opts.transformLayoutBlocks).toBe('function');
+    expect(opts.onContentHeightChange).toBeUndefined();
+  });
+
+  it("'grow' wires onContentHeightChange and NOT transformLayoutBlocks", () => {
+    const opts = mountWith('grow');
+    expect(typeof opts.onContentHeightChange).toBe('function');
+    expect(opts.transformLayoutBlocks).toBeUndefined();
+  });
+
+  it("absent autofit behaves like grow (auto-grow, no font scale)", () => {
+    const opts = mountWith(undefined);
+    expect(typeof opts.onContentHeightChange).toBe('function');
+    expect(opts.transformLayoutBlocks).toBeUndefined();
+  });
+
+  it("'none' wires neither hook (fixed box)", () => {
+    const opts = mountWith('none');
+    expect(opts.onContentHeightChange).toBeUndefined();
+    expect(opts.transformLayoutBlocks).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Layers the remaining two text-box autofit modes on top of the auto-grow
feature that recently shipped (`slides-textbox-autogrow`), giving slides
Google-Slides/PowerPoint parity, **including the in-context bottom-left
mode toggle** users have on selected text elements in GS.

- Adds a persisted `AutofitMode` field (`'none' | 'shrink' | 'grow'`) on
  `TextElement.data.autofit`. **Absent ⇒ `grow`** so existing decks keep
  the shipped auto-grow behavior; `none` must be set explicitly (API /
  PPTX import only).
- **New `shrink` mode** — fonts auto-scale down to fit a fixed box (the
  original request: "text size changes with the amount of content"), via
  a deterministic binary-search engine (`model/autofit.ts`) shared by the
  committed canvas renderer and the in-place editor (pixel-identical).
- **Reuses** the existing auto-grow for `grow` — the wrapper gates main's
  `onContentHeightChange` to grow/absent and wires a new docs
  `transformLayoutBlocks` hook only for shrink; `none` is fixed.
- **Mode toggle UI** — a small button at the bottom-left of a selected
  text element flips between `grow` and `shrink` on click (GS-parity
  affordance). Wired through `OverlayOptions.onAutofitToggle` → a single
  `store.updateElementData` patch; renderer + editor react on the next
  repaint. Hidden during in-place editing.
- Parity defaults: layout placeholders → `shrink`, inserted text boxes →
  `grow`. Preserved through Mem-store stamping **and** the production
  Yorkie store (addElement / addSlide / undo-redo restore; the restore
  path also regains the previously-dropped `placeholderRef`).
- PPTX `<a:bodyPr>` autofit child mapped on import (keeps the existing
  `normAutofit` fontScale baking).

Shrink scale is derived live and never stored — a pure function of
`(blocks, frame, font metrics)`, so collaborators agree without syncing.

Design: `docs/design/slides/slides-text-autofit.md`.

## Test plan

Automated (all green via `pnpm verify:self` — lint, all package tests,
all builds, knip dead-code=0, doc-staleness=0):

- [x] Engine unit tests (fake `TextMeasurer`): scale binary search, identity preservation, floor, empty content.
- [x] Mode-gating test: `shrink` wires only `transformLayoutBlocks`; `grow`/absent only `onContentHeightChange`; `none` neither.
- [x] Defaults end-to-end: placeholders `shrink` via `addSlide` + `applyLayoutToSlide`; inserted box `grow`.
- [x] Mem-vs-Yorkie equivalence: `autofit` survives insert + add-slide + undo/redo in the production store.
- [x] PPTX `detectAutofitMode` mapping (all five cases).
- [x] docs `transformLayoutBlocks` hook fires layout-only; docs editor unaffected when absent.
- [x] Autofit-toggle button: renders only for single text element + callback, click cycles grow ⇄ shrink, absent ⇒ grow, none → grow, hidden on shapes / multi-select.

Manual (pending before merge):

- [x] \`pnpm dev\` smoke: insert box → auto-grows while typing; click bottom-left toggle → switches to shrink, fonts scale; click again → back to grow; imported PPTX re-engages on edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text autofit modes added: shrink, grow, none — placeholders default to shrink; new inserts default to grow; grow writes final height, shrink scales text to fit.
  * In-editor autofit toggle to switch modes while editing; PPTX import now maps PowerPoint autofit to these modes.

* **Documentation**
  * New design, plan, and lessons docs describing autofit behavior, defaults, and verification.

* **Tests**
  * Expanded tests covering autofit model, editor UX, import mapping, store persistence, and equivalence across stores.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->