### PR TITLE
Add slides Format options right panel (v1)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -79,6 +79,7 @@ Presentation engine — slides, free-position elements, presentation mode, colla
 | [slides-text-autofit.md](slides/slides-text-autofit.md)                               | Text autofit — adds `shrink` (font auto-scales to fit a fixed box) + a 3-mode `autofit` selector (none/shrink/grow) layered on the auto-grow feature; placeholder=shrink / textbox=grow defaults, PPTX bodyPr import |
 | [slides-shift-modifiers.md](slides/slides-shift-modifiers.md)                         | Shift modifiers during drag — 1:1 shape draw, 15° line/connector angle snap, 15° endpoint snap, axis-locked move; pure constraint helpers reused at four call sites                                        |
 | [slides-toolbar-tier1.md](slides/slides-toolbar-tier1.md)                             | Five universal toolbar controls — Format painter, Zoom dropdown (+Cmd+/-), Layout split-button, Clear formatting, Font size A↑/A↓ steppers; additive on top of the morphing-toolbar shell                  |
+| [slides-format-options-panel.md](slides/slides-format-options-panel.md)               | Right-side Format options panel v1 — Size & Position (W/H/X/Y/Rotation, in/cm toggle), Text fitting, Image opacity, Alt text; shares right slot with ThemePanel; single `Meta.unit` field added            |
 
 ## Common
 

--- a/docs/design/slides/slides-format-options-panel.md
+++ b/docs/design/slides/slides-format-options-panel.md
@@ -1,0 +1,424 @@
+---
+title: slides-format-options-panel
+target-version: 0.4.3
+---
+
+<!-- Append this document link to docs/design/README.md after merging. -->
+
+# Slides Format Options Panel
+
+## Summary
+
+Add a right-side **Format options** panel to the slides editor, mirroring
+Google Slides. The panel surfaces precise numeric inputs and section-level
+toggles that do not fit the contextual top toolbar — Size & Position
+(W/H/X/Y/Rotation), Text fitting (autofit), Image Adjustments (opacity),
+and Alt text. The panel coexists with the existing `ThemePanel` in the
+same right slot, mutually exclusive.
+
+This spec covers v1 of the panel. Drop shadow, reflection, recolor,
+brightness/contrast, text padding, and numeric shape adjustments are
+explicitly deferred — they all require new data-model fields and
+renderer/PPTX changes that are larger than the panel shell. The slides
+v1 non-goal "Right-side Format options panel" in
+[`slides.md`](./slides.md) is partially closed by this spec for the
+properties already present in the data model.
+
+### Goals
+
+- Add a togglable right-side `FormatPanel` that surfaces precise numeric
+  inputs and section toggles for the currently selected element(s).
+- Cover the properties that already exist in the data model — Size &
+  Position (`frame.x/y/w/h/rotation`), Text fitting (`text.autofit`),
+  Image opacity (`image.opacity`), Alt text (`image.alt`) — with no new
+  renderer or PPTX work.
+- Match Google Slides multi-select semantics: empty input when values
+  differ, single value when all selected elements match, write applies
+  to every selected element.
+- Display units toggleable between **inches** (default) and
+  **centimeters**, stored on the presentation `Meta` so the ruler
+  (separate spec) can pick up the same preference later.
+- Coexist with the existing `ThemePanel` via a single
+  `rightPanel: 'theme' | 'format' | null` slot — opening one closes the
+  other.
+- Ship in a single PR. Data-model change is a single optional field on
+  `Meta`; all other work is additive UI.
+
+### Non-Goals
+
+- **Drop shadow**, **reflection**, **recolor** for shapes/text/images.
+  Each requires a new `data` field, a paint-time pipeline change, and
+  OOXML `<a:effectLst>` / `<a:duotone>` import-export mapping. Tracked
+  as separate v1.1+ specs.
+- **Image brightness / contrast**. Requires a canvas filter pipeline
+  (`ctx.filter = '...'` or per-image offscreen pass) and PPTX
+  `<a:lum>` / `<a:duotone>` round-trip. v1.1+.
+- **Text padding** (`<a:bodyPr lIns="..." tIns="...">`). The data model
+  has no padding field today; adding it touches the docs RichText
+  layout reused by slides text boxes. v1.1.
+- **Numeric inputs for shape adjustments** (`<a:avLst>`). The
+  yellow-diamond drag UI from [`slides-shapes.md`](./slides-shapes.md)
+  already edits these; numeric input is v1.1.
+- **Image crop UI**. The data field `image.crop` is editable
+  programmatically only; the dedicated crop UI is a separate spec.
+- **Mobile**. Desktop-only (≥768px). Mobile keeps the existing
+  bottom-sheet format controls described in
+  [`slides-mobile-edit.md`](./slides-mobile-edit.md).
+- **Read-only / sharing mode**. The panel and its toolbar toggle are
+  hidden entirely, mirroring how `ThemePanel` behaves today.
+- **Position-from-center mode**. Google Slides exposes a "Position
+  from: Top left / Center" dropdown; v1 uses top-left corner only,
+  matching the stored `frame.x/y` semantics. The dropdown is a v1.1
+  candidate if user requests appear.
+- **Persisting the panel open state across sessions**. Local React
+  state only — closing the app forgets the panel state. Matches
+  `ThemePanel`.
+- **Locale-aware decimal separators**. Inputs use `.` as the decimal
+  separator regardless of locale. Google Slides does the same.
+
+## Proposal Details
+
+### Architecture
+
+The right-side slot in `slides-detail.tsx` currently mounts
+`ThemePanel` behind a `themePanelOpen: boolean`. This is generalized
+to a single union:
+
+```ts
+type RightPanel = 'theme' | 'format' | null;
+const [rightPanel, setRightPanel] = useState<RightPanel>(null);
+```
+
+Toggling either panel sets the union to that panel's id; opening one
+closes the other. Closing sets it back to `null`. Existing
+`themePanelOpen` reads in `DesktopSlidesLayout` are replaced by
+`rightPanel === 'theme'`; `MobileSlidesLayout` does not mount the
+format panel at all.
+
+The toolbar gains one button in the right global zone (next to
+**Theme**):
+
+```text
+[Global L] | [Insert + Slide] | [Contextual] | (push-right) | [Theme] [Format] [Present]
+```
+
+`Format` is an `IconAdjustmentsAlt`-style icon button that toggles
+`rightPanel` between `'format'` and `null`. The button is hidden in
+read-only mode.
+
+#### Component contract
+
+```ts
+interface FormatPanelProps {
+  store: SlidesStore;
+  editor: SlidesEditor;
+  theme: Theme | null;
+  onClose: () => void;
+}
+
+function FormatPanel(props: FormatPanelProps): JSX.Element;
+```
+
+The panel re-derives the active selection on every store change
+(subscribe via `store.onChange`). Selection is normalized into:
+
+```ts
+type PanelSelection =
+  | { kind: 'idle' }
+  | {
+      kind: 'object';
+      selectionType: 'shape' | 'image' | 'text-element' | 'connector' | 'group' | 'mixed';
+      elements: ReadonlyArray<Element>; // resolved Element objects
+      slideId: string;
+    };
+```
+
+Section routing is a pure function:
+
+```ts
+type SectionId =
+  | 'size-position'
+  | 'text-fitting'
+  | 'image-adjustments'
+  | 'alt-text';
+
+function pickSections(selection: PanelSelection): readonly SectionId[];
+```
+
+Mapping:
+
+| selectionType | sections |
+|---|---|
+| `shape` | `['size-position']` |
+| `image` | `['size-position', 'image-adjustments', 'alt-text']` |
+| `text-element` | `['size-position', 'text-fitting']` |
+| `connector` | `['size-position']` (rotation hidden internally) |
+| `group` | `['size-position']` |
+| `mixed` | `['size-position']` (rotation/W/H hidden, X/Y only) |
+| `idle` | `[]` — empty state with hint copy |
+
+The panel shell maps `SectionId` → component and renders each in
+order. `pickSections` lives in its own file with unit tests; the shell
+file holds only the slot manager + header + empty-state hint.
+
+### Size & Position section
+
+```text
+┌─ Size & Position ─────────────────┐
+│ Size                              │
+│  W: [ 240.00 ] in   🔒 Lock       │
+│  H: [ 135.00 ] in                 │
+│                                   │
+│ Position                          │
+│  X: [ 100.00 ] in                 │
+│  Y: [  50.00 ] in                 │
+│                                   │
+│ Rotation                          │
+│  Angle: [ 0.00 ]°   ↺   ↻         │
+│                                   │
+│ Units: (•) Inches  ( ) Centimeters│
+└───────────────────────────────────┘
+```
+
+#### Coordinate system and unit conversion
+
+- Storage: `frame.x/y/w/h` are canvas pixels (canvas is 1920×1080).
+  `frame.rotation` is radians.
+- Display: `meta.unit` selects `'in'` or `'cm'`. Renderer never reads
+  this field; only the panel's input widgets convert.
+- Conversion constants (`format-panel/units.ts`):
+  ```ts
+  const PX_PER_IN = 192;   // canvas 1920 px = 10 in
+  const PX_PER_CM = 192 / 2.54;
+
+  function pxToUnit(px: number, unit: 'in' | 'cm'): number;
+  function unitToPx(value: number, unit: 'in' | 'cm'): number;
+  function formatDisplay(px: number, unit: 'in' | 'cm'): string; // 2 dp
+  ```
+- Rotation: `radToDeg(rad)` / `degToRad(deg)`, 2 dp display, modulo 360.
+
+#### Commit timing
+
+- `onChange` updates a local React draft only — no store writes per
+  keystroke.
+- `onBlur` and `Enter` commit via `store.batch(() => ...)`. This keeps
+  Yorkie traffic and undo stack proportional to user intent (matches
+  the docs/sheets precise-input pattern).
+- `Escape` reverts the draft to the displayed value and blurs.
+
+#### Multi-select mixed-value handling
+
+```ts
+function getCommonValue<T>(
+  elements: readonly Element[],
+  accessor: (el: Element) => T,
+  equals?: (a: T, b: T) => boolean,
+): T | undefined;
+```
+
+- Returns the common value when every element matches; `undefined`
+  otherwise.
+- `undefined` → input renders a placeholder `'—'` and blank value.
+- Committing a value applies it to every selected element in a single
+  `store.batch`.
+- Committing a blank input is a no-op.
+
+#### Lock aspect ratio
+
+- Toggle button next to W. Locked state is **local React state**, not
+  persisted (Google Slides parity).
+- When locked and the user edits W, H is recomputed proportionally
+  from each element's own current aspect ratio (per-element) and
+  written along with W in the same batch. Same for H → W.
+- Selection change resets the lock toggle to off (no carry-over).
+
+#### 90° rotation buttons
+
+- `↺` subtracts π/2, `↻` adds π/2, applied per element. Each element
+  rotates around its own center.
+- Wraps via `((rotation + delta) % (2π) + 2π) % (2π)`.
+
+#### Selection-type variants
+
+| Type | W/H | X/Y | Rotation | Notes |
+|---|---|---|---|---|
+| shape | yes | yes | yes | |
+| image | yes | yes | yes | crop unchanged here |
+| text-element | yes | yes | yes | when `autofit === 'grow'`, H input is disabled with tooltip "Height is auto-calculated. Switch autofit to 'None' or 'Shrink' to set manually." |
+| connector | hidden | conditional | hidden | W/H are derived from endpoints, not editable. X/Y translate both endpoints by the same delta and require **both** endpoints to be `kind: 'free'`; if either is `kind: 'attached'`, the X/Y inputs are disabled with tooltip "Detach endpoints to set position." Rotation is endpoint-defined. |
+| group | yes | yes | yes | applied to outer frame; children scale proportionally |
+| mixed | hidden | yes | hidden | X/Y only, each element translates independently |
+
+#### Unit toggle
+
+The radio sits inside the Size & Position section, persisted to
+`meta.unit`. Switching units only re-formats the displayed values —
+no element data is touched. The same field is reserved for the
+ruler (separate spec) to pick up later.
+
+### Text fitting section
+
+A new 3-mode radio group built for the panel — there is no reusable
+selector today. The existing in-canvas bottom-left toggle from
+[`slides-text-autofit.md`](./slides-text-autofit.md) stays as a
+quick action; the panel is the precise control. Both write the same
+`data.autofit` field.
+
+Options:
+
+- **Do not autofit** (`'none'`) — box fixed, text overflows.
+- **Shrink text on overflow** (`'shrink'`) — box fixed, font auto-scales.
+- **Resize shape to fit text** (`'grow'`) — font fixed, box height tracks
+  content.
+
+Commit on selection (single `store.batch`). Multi-select: blank
+radio when values differ, common value selected when all match,
+choosing applies to every selected text element.
+
+The H input lock in Size & Position keys off the same value
+(`autofit === 'grow'` ⇒ H disabled).
+
+### Image Adjustments section
+
+```text
+┌─ Adjustments ──────────────────────┐
+│ Transparency                       │
+│  [────●─────────────────] 30%      │
+└────────────────────────────────────┘
+```
+
+- Slider 0–100% mapped to `image.opacity` as `1 - value/100`.
+  Internally stored as the existing `opacity` field (0..1).
+- Commit on `pointerup` only, not during drag (one undo entry per
+  adjustment session).
+- Multi-select: shows blank slider thumb when values differ; dragging
+  commits the new value to all.
+
+### Alt text section
+
+```text
+┌─ Alt text ─────────────────────────┐
+│ [textarea, 3 rows]                 │
+│ "Describe this image for screen    │
+│  readers"                          │
+└────────────────────────────────────┘
+```
+
+- Maps to `image.alt`. `onBlur` commit.
+- The existing Alt-text dropdown in the image toolbar
+  (`image-controls.tsx`) is **removed**; the panel becomes the single
+  source. Toolbar keeps Replace / Crop / Reset crop.
+
+### Data model change
+
+`packages/slides/src/model/presentation.ts`:
+
+```diff
+ export type Meta = {
+   themeId: string;
++  /**
++   * Display unit for the Format options panel (and, when adopted,
++   * the ruler). Renderer never reads this field; it only switches
++   * what the panel's numeric inputs show. Absent ⇒ 'in'.
++   */
++  unit?: 'in' | 'cm';
+   // existing fields...
+ };
+```
+
+`migrate.ts` requires no change — absence means `'in'`.
+
+No other model files change. `frame`, `text.autofit`, `image.opacity`,
+`image.alt` are all already in place.
+
+### File layout
+
+```
+packages/frontend/src/app/slides/
+├── slides-detail.tsx                # rightPanel union, FormatPanel mount
+├── toolbar/global-controls.tsx      # Format options toggle button
+└── format-panel/                    # new directory
+    ├── index.tsx                    # FormatPanel shell + section routing
+    ├── pick-sections.ts             # pure: selection → SectionId[]
+    ├── pick-sections.test.ts
+    ├── units.ts                     # pxToUnit / unitToPx / formatDisplay / getCommonValue / radToDeg / degToRad
+    ├── units.test.ts
+    ├── size-position-section.tsx
+    ├── text-fitting-section.tsx     # 3-mode radio, writes data.autofit
+    ├── image-adjustments-section.tsx
+    └── alt-text-section.tsx
+```
+
+The `image-controls.tsx` toolbar file is edited to drop its
+`AltTextDropdown` and stop importing `IconAccessible`.
+
+### Testing strategy
+
+| Layer | Tool | Coverage |
+|---|---|---|
+| `units.ts` pure functions | vitest | px↔in/cm round-trip, 2 dp formatting, rad↔deg, modulo wrap, `getCommonValue` (common / mixed / empty) |
+| `pick-sections.ts` | vitest | Every `selectionType` returns the expected section list |
+| Section components | vitest + React Testing Library | `onBlur` commits via `store.batch`, `Enter` commits, `Escape` reverts, mixed-value `'—'` placeholder, lock-aspect proportional update, autofit=grow disables H |
+| Integration | vitest + RTL | Theme↔Format mutual exclusion, multi-select batch write, unit toggle writes `meta.unit` |
+| Browser smoke | `pnpm verify:browser:docker` | Open panel, edit W with lock, rotate 90°, switch units, multi-select translate |
+
+### Rollout
+
+Single PR. Verification gates:
+
+- `pnpm verify:fast` — lint + unit tests.
+- `pnpm verify:browser:docker` — one smoke scenario covering the
+  flow listed above.
+- Manual checks before merge:
+  - Theme↔Format mutual exclusion.
+  - Multi-select W/H batch write produces a single undo entry.
+  - `autofit === 'grow'` disables H input with tooltip.
+  - Read-only viewer never sees the toolbar Format button.
+
+No feature flag — the panel is additive UI and the model change is a
+single optional field.
+
+### Risks and Mitigation
+
+**Theme ↔ Format slot competition.** Both panels mount in the same
+right slot. Mitigation: consolidate to a single `rightPanel` union
+in `slides-detail.tsx`. Theme open/close call sites are updated in
+the same PR (limited to one file). Browser smoke covers mutual
+exclusion explicitly.
+
+**Numeric input UX (IME, locale, paste).** Inputs use
+`inputMode="decimal"` and `parseFloat`. Non-numeric paste is rejected
+on commit (reverts to the displayed value). Locale decimal commas
+are not handled in v1 — Google Slides exhibits the same behavior and
+no user complaints have surfaced internally.
+
+**Multi-select lock-aspect semantics.** Each element scales by its
+own aspect ratio when the user edits W or H, not by the bounding-box
+ratio. Documented explicitly and locked in by a unit test on
+`size-position-section.tsx`.
+
+**Round-trip precision.** With `PX_PER_IN = 192` integer constant,
+0.01-inch granularity is lossless. Smaller inputs round to two
+decimal places, matching the display precision — no surprise.
+
+**`autofit === 'grow'` and the H input.** Disabling the H input could
+surprise users who don't notice the autofit setting. Mitigation:
+tooltip on the disabled input names the autofit mode and the value
+that needs to change.
+
+**`Meta.unit` and future ruler integration.** The ruler design
+(separate spec) may want its own field eventually. Starting with a
+single shared field keeps the data minimal; if the ruler needs to
+diverge, that spec can introduce a second field then. No migration
+debt.
+
+**Removing `AltTextDropdown` from the toolbar.** Users who had
+learned the toolbar location for Alt text will need to discover the
+panel. Mitigation: image toolbar shows no Alt button; the panel auto-
+opens hint can be added later if support tickets surface (not in v1).
+
+**Toolbar real estate for the Format button.** The right global zone
+already holds Theme + Present. Adding Format brings it to three
+icons. Verified against the toolbar redesign zones in
+[`slides-toolbar-redesign.md`](./slides-toolbar-redesign.md); fits
+without reflow at desktop widths.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,6 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
-| slides format options panel (2026-05-29) | [20260529-slides-format-options-panel-todo.md](./active/20260529-slides-format-options-panel-todo.md) | - |
 | slides shift modifiers (2026-05-28) | [20260528-slides-shift-modifiers-todo.md](./active/20260528-slides-shift-modifiers-todo.md) | [20260528-slides-shift-modifiers-lessons.md](./active/20260528-slides-shift-modifiers-lessons.md) |
 | docs unlink href (2026-05-26) | [20260526-docs-unlink-href-todo.md](./active/20260526-docs-unlink-href-todo.md) | [20260526-docs-unlink-href-lessons.md](./active/20260526-docs-unlink-href-lessons.md) |
 | slides group selection ui (2026-05-26) | [20260526-slides-group-selection-ui-todo.md](./active/20260526-slides-group-selection-ui-todo.md) | [20260526-slides-group-selection-ui-lessons.md](./active/20260526-slides-group-selection-ui-lessons.md) |
@@ -36,4 +35,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 223
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides format options panel (2026-05-29)
+Latest active task: slides shift modifiers (2026-05-28)

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides format options panel (2026-05-29) | [20260529-slides-format-options-panel-todo.md](./active/20260529-slides-format-options-panel-todo.md) | - |
 | slides shift modifiers (2026-05-28) | [20260528-slides-shift-modifiers-todo.md](./active/20260528-slides-shift-modifiers-todo.md) | [20260528-slides-shift-modifiers-lessons.md](./active/20260528-slides-shift-modifiers-lessons.md) |
 | docs unlink href (2026-05-26) | [20260526-docs-unlink-href-todo.md](./active/20260526-docs-unlink-href-todo.md) | [20260526-docs-unlink-href-lessons.md](./active/20260526-docs-unlink-href-lessons.md) |
 | slides group selection ui (2026-05-26) | [20260526-slides-group-selection-ui-todo.md](./active/20260526-slides-group-selection-ui-todo.md) | [20260526-slides-group-selection-ui-lessons.md](./active/20260526-slides-group-selection-ui-lessons.md) |
@@ -35,4 +36,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 223
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides shift modifiers (2026-05-28)
+Latest active task: slides format options panel (2026-05-29)

--- a/docs/tasks/active/20260529-slides-format-options-panel-todo.md
+++ b/docs/tasks/active/20260529-slides-format-options-panel-todo.md
@@ -1,0 +1,2371 @@
+# Slides Format Options Panel (v1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a right-side Format options panel to the slides editor that
+surfaces precise numeric inputs and section toggles — Size & Position
+(W/H/X/Y/Rotation, in/cm), Text fitting (autofit), Image opacity, Alt
+text — for the properties already in the data model.
+
+**Architecture:** A new `format-panel/` directory under
+`packages/frontend/src/app/slides/` holds the shell (`index.tsx`),
+pure routing (`pick-sections.ts`), pure unit/conversion helpers
+(`units.ts`), and one component per section. The right slot in
+`slides-detail.tsx` is generalized from `themePanelOpen: boolean` to
+`rightPanel: 'theme' | 'format' | null` so the two panels are
+mutually exclusive. One data-model change: an optional `unit?: 'in'
+| 'cm'` on `Meta`, with a matching `setUnit` on `SlidesStore`.
+
+**Tech Stack:** TypeScript, React, Vitest (+ jsdom), React Testing
+Library, Yorkie CRDT. The frontend package resolves
+`@wafflebase/slides` against `packages/slides/dist/`, so any change
+to `packages/slides/` requires `pnpm slides build` before the
+frontend can consume it (and before `pnpm verify:fast` is rerun for
+the frontend).
+
+**Design doc:** `docs/design/slides/slides-format-options-panel.md`
+
+---
+
+### Task 1: Add `Meta.unit` field + `setUnit` on `SlidesStore` interface and `MemSlidesStore`
+
+**Files:**
+- Modify: `packages/slides/src/model/presentation.ts`
+- Modify: `packages/slides/src/store/store.ts`
+- Modify: `packages/slides/src/store/memory.ts`
+- Test: `packages/slides/test/store/mem-set-unit.test.ts` (create)
+
+The field is optional so existing serialized decks (and the in-memory
+default) keep their shape. `setUnit` rejects values outside the
+discriminated union at runtime — the type system already enforces
+this at compile sites, but the runtime guard catches Yorkie-borne
+junk during local-vs-Yorkie equivalence and migration tests.
+
+- [ ] **Step 1: Write failing test for the new store method**
+
+Create `packages/slides/test/store/mem-set-unit.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { MemSlidesStore } from '../../src/store/memory';
+
+describe('MemSlidesStore.setUnit', () => {
+  it('defaults Meta.unit to undefined (read as inches)', () => {
+    const store = new MemSlidesStore();
+    expect(store.read().meta.unit).toBeUndefined();
+  });
+
+  it('setUnit("cm") writes the field', () => {
+    const store = new MemSlidesStore();
+    store.batch(() => store.setUnit('cm'));
+    expect(store.read().meta.unit).toBe('cm');
+  });
+
+  it('setUnit("in") writes the field', () => {
+    const store = new MemSlidesStore();
+    store.batch(() => store.setUnit('in'));
+    expect(store.read().meta.unit).toBe('in');
+  });
+
+  it('setUnit throws on invalid value', () => {
+    const store = new MemSlidesStore();
+    expect(() =>
+      store.batch(() => store.setUnit('px' as 'in')),
+    ).toThrow(/invalid unit/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test and confirm it fails**
+
+```bash
+pnpm --filter @wafflebase/slides exec vitest run test/store/mem-set-unit.test.ts
+```
+Expected: FAIL — `store.setUnit is not a function`.
+
+- [ ] **Step 3: Add the `unit` field to `Meta`**
+
+Edit `packages/slides/src/model/presentation.ts`, replacing the `Meta`
+type:
+
+```ts
+export type Meta = {
+  title: string;
+  themeId: string;
+  masterId: string;
+  /**
+   * Display unit for the Format options panel (and, when adopted,
+   * the ruler). Renderer never reads this field; it only switches
+   * what the panel's numeric inputs show. Absent ⇒ 'in'.
+   */
+  unit?: 'in' | 'cm';
+};
+```
+
+- [ ] **Step 4: Declare `setUnit` on the `SlidesStore` interface**
+
+Edit `packages/slides/src/store/store.ts`, in the `// --- theme-level ---`
+block (right under `applyTheme`):
+
+```ts
+  /**
+   * Set the display unit for numeric inputs in the Format options
+   * panel (and ruler, when wired). Persisted on `meta.unit` so peers
+   * see the same preference. No effect on rendering.
+   */
+  setUnit(unit: 'in' | 'cm'): void;
+```
+
+- [ ] **Step 5: Implement `setUnit` on `MemSlidesStore`**
+
+Edit `packages/slides/src/store/memory.ts`. Add the method near the
+existing `applyTheme` implementation (around line 228):
+
+```ts
+  setUnit(unit: 'in' | 'cm'): void {
+    if (unit !== 'in' && unit !== 'cm') {
+      throw new Error(`[slides] invalid unit '${unit}'`);
+    }
+    this.doc.meta.unit = unit;
+  }
+```
+
+- [ ] **Step 6: Run test and confirm it passes**
+
+```bash
+pnpm --filter @wafflebase/slides exec vitest run test/store/mem-set-unit.test.ts
+```
+Expected: PASS — 4 tests.
+
+- [ ] **Step 7: Run the full slides package test suite to confirm no regression**
+
+```bash
+pnpm --filter @wafflebase/slides test
+```
+Expected: all tests pass.
+
+- [ ] **Step 8: Build the slides package so frontend can resolve the new types/method**
+
+```bash
+pnpm slides build
+```
+Expected: clean build, no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/slides/src/model/presentation.ts \
+        packages/slides/src/store/store.ts \
+        packages/slides/src/store/memory.ts \
+        packages/slides/test/store/mem-set-unit.test.ts
+git commit -m "$(cat <<'EOF'
+Add Meta.unit field and SlidesStore.setUnit
+
+The right-side Format options panel needs a persisted in/cm
+preference so each peer sees the same setting and so the ruler
+(separate spec) can pick up the same field later. Adding it as
+optional on Meta keeps existing serialized decks unchanged.
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Implement `setUnit` on `YorkieSlidesStore`
+
+**Files:**
+- Modify: `packages/frontend/src/app/slides/yorkie-slides-store.ts`
+
+The Yorkie store mirrors `MemSlidesStore` but writes through the
+Yorkie root. Follow the exact pattern used by `applyTheme` in the
+same file. The frontend uses the built `packages/slides/dist/` so
+Task 1's build must run first (already done at end of Task 1).
+
+- [ ] **Step 1: Locate the existing `applyTheme` implementation in the Yorkie store**
+
+```bash
+grep -n "applyTheme" packages/frontend/src/app/slides/yorkie-slides-store.ts
+```
+Read the function and the line right above/below it — you will add
+`setUnit` immediately after it using the same `root.meta` mutation
+pattern.
+
+- [ ] **Step 2: Add the `setUnit` method to `YorkieSlidesStore`**
+
+Insert immediately after the existing `applyTheme` method:
+
+```ts
+  setUnit(unit: 'in' | 'cm'): void {
+    if (unit !== 'in' && unit !== 'cm') {
+      throw new Error(`[slides] invalid unit '${unit}'`);
+    }
+    this.doc.update((root) => {
+      root.meta.unit = unit;
+    });
+  }
+```
+
+> If the Yorkie store uses a different mutator pattern than
+> `this.doc.update((root) => ...)`, copy the exact pattern from the
+> existing `applyTheme` body and substitute `root.meta.unit = unit`.
+
+- [ ] **Step 3: Type-check the frontend package**
+
+```bash
+pnpm --filter @wafflebase/frontend exec tsc --noEmit
+```
+Expected: no errors. (Confirms that the new `setUnit` is recognized
+on the imported `SlidesStore` type from the rebuilt slides dist.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/yorkie-slides-store.ts
+git commit -m "$(cat <<'EOF'
+Implement setUnit on YorkieSlidesStore
+
+Mirrors MemSlidesStore.setUnit so the Format panel writes the
+in/cm preference through Yorkie. Peers receive the change via
+the normal store onChange subscription.
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Pure unit-conversion + mixed-value helpers (`units.ts`)
+
+**Files:**
+- Create: `packages/frontend/src/app/slides/format-panel/units.ts`
+- Create: `packages/frontend/tests/app/slides/format-panel/units.test.ts`
+
+These are the only conversions the panel needs. Kept pure so they
+unit-test in isolation, no React mounting required.
+
+- [ ] **Step 1: Write the failing tests first**
+
+Create `packages/frontend/tests/app/slides/format-panel/units.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  PX_PER_IN,
+  PX_PER_CM,
+  pxToUnit,
+  unitToPx,
+  formatDisplay,
+  radToDeg,
+  degToRad,
+  getCommonValue,
+} from '@/app/slides/format-panel/units';
+
+describe('px↔unit conversion', () => {
+  it('PX_PER_IN matches the 1920px / 10in canvas ratio', () => {
+    expect(PX_PER_IN).toBe(192);
+  });
+
+  it('PX_PER_CM = PX_PER_IN / 2.54', () => {
+    expect(PX_PER_CM).toBeCloseTo(192 / 2.54, 10);
+  });
+
+  it('pxToUnit("in") converts canvas px to inches', () => {
+    expect(pxToUnit(192, 'in')).toBeCloseTo(1, 10);
+    expect(pxToUnit(1920, 'in')).toBeCloseTo(10, 10);
+  });
+
+  it('pxToUnit("cm") converts canvas px to centimeters', () => {
+    expect(pxToUnit(PX_PER_CM, 'cm')).toBeCloseTo(1, 10);
+  });
+
+  it('unitToPx is the inverse of pxToUnit', () => {
+    for (const u of ['in', 'cm'] as const) {
+      for (const v of [0, 0.5, 1, 3.75, 10]) {
+        expect(unitToPx(pxToUnit(unitToPx(v, u), u), u)).toBeCloseTo(
+          unitToPx(v, u),
+          10,
+        );
+      }
+    }
+  });
+
+  it('formatDisplay rounds to 2 decimal places', () => {
+    expect(formatDisplay(192, 'in')).toBe('1.00');
+    expect(formatDisplay(96, 'in')).toBe('0.50');
+    expect(formatDisplay(193, 'in')).toBe('1.01');
+  });
+});
+
+describe('rad↔deg', () => {
+  it('radToDeg', () => {
+    expect(radToDeg(0)).toBe(0);
+    expect(radToDeg(Math.PI / 2)).toBeCloseTo(90, 10);
+    expect(radToDeg(Math.PI)).toBeCloseTo(180, 10);
+  });
+
+  it('degToRad', () => {
+    expect(degToRad(0)).toBe(0);
+    expect(degToRad(90)).toBeCloseTo(Math.PI / 2, 10);
+    expect(degToRad(360)).toBeCloseTo(Math.PI * 2, 10);
+  });
+});
+
+describe('getCommonValue', () => {
+  it('returns the value when every element matches', () => {
+    const arr = [{ x: 10 }, { x: 10 }, { x: 10 }];
+    expect(getCommonValue(arr, (e) => e.x)).toBe(10);
+  });
+
+  it('returns undefined when any element differs', () => {
+    const arr = [{ x: 10 }, { x: 20 }];
+    expect(getCommonValue(arr, (e) => e.x)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty list', () => {
+    expect(getCommonValue([], (e: { x: number }) => e.x)).toBeUndefined();
+  });
+
+  it('supports a custom equality fn (e.g. tolerance)', () => {
+    const arr = [{ x: 1.0001 }, { x: 1.0002 }];
+    const eq = (a: number, b: number) => Math.abs(a - b) < 0.001;
+    expect(getCommonValue(arr, (e) => e.x, eq)).toBeCloseTo(1.0001, 5);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/units.test.ts
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `units.ts`**
+
+Create `packages/frontend/src/app/slides/format-panel/units.ts`:
+
+```ts
+/**
+ * Slide canvas is 1920×1080 px. Google Slides 16:9 deck is 10in
+ * wide, so 1920 / 10 = 192 px per inch. Lossless to two decimal
+ * places of inches.
+ */
+export const PX_PER_IN = 192;
+export const PX_PER_CM = PX_PER_IN / 2.54;
+
+export type DisplayUnit = 'in' | 'cm';
+
+export function pxToUnit(px: number, unit: DisplayUnit): number {
+  return unit === 'in' ? px / PX_PER_IN : px / PX_PER_CM;
+}
+
+export function unitToPx(value: number, unit: DisplayUnit): number {
+  return unit === 'in' ? value * PX_PER_IN : value * PX_PER_CM;
+}
+
+export function formatDisplay(px: number, unit: DisplayUnit): string {
+  return pxToUnit(px, unit).toFixed(2);
+}
+
+export function radToDeg(rad: number): number {
+  return (rad * 180) / Math.PI;
+}
+
+export function degToRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+/**
+ * Return the value common to every element via `accessor`, or
+ * `undefined` if any element differs (or the list is empty).
+ * `equals` defaults to `Object.is`.
+ */
+export function getCommonValue<T, V>(
+  elements: readonly T[],
+  accessor: (el: T) => V,
+  equals: (a: V, b: V) => boolean = (a, b) => Object.is(a, b),
+): V | undefined {
+  if (elements.length === 0) return undefined;
+  const first = accessor(elements[0]);
+  for (let i = 1; i < elements.length; i++) {
+    if (!equals(first, accessor(elements[i]))) return undefined;
+  }
+  return first;
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/units.test.ts
+```
+Expected: PASS — all assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/format-panel/units.ts \
+        packages/frontend/tests/app/slides/format-panel/units.test.ts
+git commit -m "$(cat <<'EOF'
+Add format-panel unit conversion + common-value helpers
+
+Pure helpers backing the Format options panel — px↔inch/cm at
+192 px/in (canvas-derived), rad↔deg, and a multi-select common-
+value reducer. Kept in their own module so they unit-test without
+React mounting.
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Pure section routing (`pick-sections.ts`)
+
+**Files:**
+- Create: `packages/frontend/src/app/slides/format-panel/pick-sections.ts`
+- Create: `packages/frontend/tests/app/slides/format-panel/pick-sections.test.ts`
+
+Maps a normalized selection descriptor to a list of `SectionId`s.
+Pure → fully unit-tested. The panel shell consumes this in Task 9.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/frontend/tests/app/slides/format-panel/pick-sections.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  pickSections,
+  type PanelSelection,
+} from '@/app/slides/format-panel/pick-sections';
+
+function objSel(
+  type: Exclude<
+    PanelSelection extends { kind: 'object'; selectionType: infer T }
+      ? T
+      : never,
+    never
+  >,
+): PanelSelection {
+  return {
+    kind: 'object',
+    selectionType: type,
+    elements: [],
+    slideId: 's1',
+  };
+}
+
+describe('pickSections', () => {
+  it('idle → empty', () => {
+    expect(pickSections({ kind: 'idle' })).toEqual([]);
+  });
+
+  it('shape → [size-position]', () => {
+    expect(pickSections(objSel('shape'))).toEqual(['size-position']);
+  });
+
+  it('image → [size-position, image-adjustments, alt-text]', () => {
+    expect(pickSections(objSel('image'))).toEqual([
+      'size-position',
+      'image-adjustments',
+      'alt-text',
+    ]);
+  });
+
+  it('text-element → [size-position, text-fitting]', () => {
+    expect(pickSections(objSel('text-element'))).toEqual([
+      'size-position',
+      'text-fitting',
+    ]);
+  });
+
+  it('connector → [size-position]', () => {
+    expect(pickSections(objSel('connector'))).toEqual(['size-position']);
+  });
+
+  it('group → [size-position]', () => {
+    expect(pickSections(objSel('group'))).toEqual(['size-position']);
+  });
+
+  it('mixed → [size-position]', () => {
+    expect(pickSections(objSel('mixed'))).toEqual(['size-position']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/pick-sections.test.ts
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `pick-sections.ts`**
+
+Create `packages/frontend/src/app/slides/format-panel/pick-sections.ts`:
+
+```ts
+import type { Element } from '@wafflebase/slides';
+
+export type SectionId =
+  | 'size-position'
+  | 'text-fitting'
+  | 'image-adjustments'
+  | 'alt-text';
+
+export type ObjectSelectionType =
+  | 'shape'
+  | 'image'
+  | 'text-element'
+  | 'connector'
+  | 'group'
+  | 'mixed';
+
+export type PanelSelection =
+  | { kind: 'idle' }
+  | {
+      kind: 'object';
+      selectionType: ObjectSelectionType;
+      elements: readonly Element[];
+      slideId: string;
+    };
+
+export function pickSections(
+  selection: PanelSelection,
+): readonly SectionId[] {
+  if (selection.kind === 'idle') return [];
+  switch (selection.selectionType) {
+    case 'shape':
+    case 'connector':
+    case 'group':
+    case 'mixed':
+      return ['size-position'];
+    case 'image':
+      return ['size-position', 'image-adjustments', 'alt-text'];
+    case 'text-element':
+      return ['size-position', 'text-fitting'];
+  }
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/pick-sections.test.ts
+```
+Expected: PASS — 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/format-panel/pick-sections.ts \
+        packages/frontend/tests/app/slides/format-panel/pick-sections.test.ts
+git commit -m "$(cat <<'EOF'
+Add format-panel section routing
+
+Pure mapping from PanelSelection to the ordered list of sections
+the shell should render. Idle returns empty so the shell renders
+the empty-state hint.
+
+EOF
+)"
+```
+
+---
+
+### Task 5: `AltTextSection` component
+
+**Files:**
+- Create: `packages/frontend/src/app/slides/format-panel/alt-text-section.tsx`
+- Create: `packages/frontend/tests/app/slides/format-panel/alt-text-section.test.tsx`
+
+Minimal section: textarea bound to `image.alt`, `onBlur` commits in
+a single `store.batch`. Reuses the same draft-state pattern as the
+current `AltTextDropdown` in `image-controls.tsx`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/frontend/tests/app/slides/format-panel/alt-text-section.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AltTextSection } from '@/app/slides/format-panel/alt-text-section';
+import type { ImageElement } from '@wafflebase/slides';
+
+function img(id: string, alt: string): ImageElement {
+  return {
+    id,
+    type: 'image',
+    frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+    data: { src: 'http://x', alt },
+  };
+}
+
+describe('AltTextSection', () => {
+  it('shows the common alt text for a single selection', () => {
+    const onCommit = vi.fn();
+    render(
+      <AltTextSection elements={[img('a', 'hello')]} onCommit={onCommit} />,
+    );
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe(
+      'hello',
+    );
+  });
+
+  it('shows empty placeholder when alt differs across selection', () => {
+    const onCommit = vi.fn();
+    render(
+      <AltTextSection
+        elements={[img('a', 'one'), img('b', 'two')]}
+        onCommit={onCommit}
+      />,
+    );
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('commits the new value on blur to all selected ids', () => {
+    const onCommit = vi.fn();
+    render(
+      <AltTextSection
+        elements={[img('a', ''), img('b', '')]}
+        onCommit={onCommit}
+      />,
+    );
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: 'new alt' } });
+    fireEvent.blur(ta);
+    expect(onCommit).toHaveBeenCalledWith(['a', 'b'], 'new alt');
+  });
+
+  it('blank → blur is a no-op (onCommit not called)', () => {
+    const onCommit = vi.fn();
+    render(
+      <AltTextSection
+        elements={[img('a', 'one'), img('b', 'two')]}
+        onCommit={onCommit}
+      />,
+    );
+    const ta = screen.getByRole('textbox');
+    fireEvent.blur(ta);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/alt-text-section.test.tsx
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `alt-text-section.tsx`**
+
+Create `packages/frontend/src/app/slides/format-panel/alt-text-section.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react';
+import type { ImageElement } from '@wafflebase/slides';
+import { getCommonValue } from './units';
+
+export interface AltTextSectionProps {
+  elements: readonly ImageElement[];
+  onCommit: (ids: readonly string[], alt: string) => void;
+}
+
+export function AltTextSection({ elements, onCommit }: AltTextSectionProps) {
+  const common = getCommonValue(elements, (el) => el.data.alt ?? '');
+  const [draft, setDraft] = useState<string>(common ?? '');
+  // Re-sync when the parent swaps elements or a remote change updates alt.
+  useEffect(() => {
+    setDraft(common ?? '');
+  }, [common]);
+
+  return (
+    <section aria-labelledby="format-alt-text-label" className="p-3">
+      <h3 id="format-alt-text-label" className="mb-2 text-xs font-semibold">
+        Alt text
+      </h3>
+      <textarea
+        rows={3}
+        value={draft}
+        placeholder={
+          common === undefined
+            ? 'Multiple values'
+            : 'Describe this image for screen readers'
+        }
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => {
+          // Blank draft on an "is-mixed" entry means the user didn't type
+          // anything — leave each element alone.
+          if (common === undefined && draft === '') return;
+          // Single-value case: also no-op if unchanged.
+          if (common !== undefined && draft === common) return;
+          onCommit(
+            elements.map((el) => el.id),
+            draft,
+          );
+        }}
+        className="w-full rounded border p-2 text-sm"
+      />
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/alt-text-section.test.tsx
+```
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/format-panel/alt-text-section.tsx \
+        packages/frontend/tests/app/slides/format-panel/alt-text-section.test.tsx
+git commit -m "$(cat <<'EOF'
+Add AltTextSection to format-panel
+
+Textarea bound to image.alt with draft state, onBlur commit, and
+mixed-value placeholder. Same draft pattern as the toolbar's
+existing alt-text dropdown — Task 12 removes the dropdown.
+
+EOF
+)"
+```
+
+---
+
+### Task 6: `ImageAdjustmentsSection` component
+
+**Files:**
+- Create: `packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx`
+- Create: `packages/frontend/tests/app/slides/format-panel/image-adjustments-section.test.tsx`
+
+Transparency slider only. Maps 0–100% to `1 - value/100` stored in
+`image.opacity`. Commits on `pointerup` (single undo entry per drag).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/frontend/tests/app/slides/format-panel/image-adjustments-section.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ImageAdjustmentsSection } from '@/app/slides/format-panel/image-adjustments-section';
+import type { ImageElement } from '@wafflebase/slides';
+
+function img(id: string, opacity?: number): ImageElement {
+  return {
+    id,
+    type: 'image',
+    frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+    data: { src: 'http://x', opacity },
+  };
+}
+
+describe('ImageAdjustmentsSection', () => {
+  it('renders the transparency slider', () => {
+    render(
+      <ImageAdjustmentsSection
+        elements={[img('a', 1)]}
+        onCommit={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText(/transparency/i)).toBeInTheDocument();
+  });
+
+  it('shows 0% transparency when opacity is undefined or 1', () => {
+    render(
+      <ImageAdjustmentsSection
+        elements={[img('a')]}
+        onCommit={vi.fn()}
+      />,
+    );
+    expect(
+      (screen.getByLabelText(/transparency/i) as HTMLInputElement).value,
+    ).toBe('0');
+  });
+
+  it('shows 30% transparency when opacity = 0.7', () => {
+    render(
+      <ImageAdjustmentsSection
+        elements={[img('a', 0.7)]}
+        onCommit={vi.fn()}
+      />,
+    );
+    expect(
+      (screen.getByLabelText(/transparency/i) as HTMLInputElement).value,
+    ).toBe('30');
+  });
+
+  it('commits opacity to all selected ids on pointerup', () => {
+    const onCommit = vi.fn();
+    render(
+      <ImageAdjustmentsSection
+        elements={[img('a', 1), img('b', 1)]}
+        onCommit={onCommit}
+      />,
+    );
+    const slider = screen.getByLabelText(/transparency/i);
+    fireEvent.change(slider, { target: { value: '40' } });
+    fireEvent.pointerUp(slider);
+    expect(onCommit).toHaveBeenCalledWith(['a', 'b'], 0.6);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/image-adjustments-section.test.tsx
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `image-adjustments-section.tsx`**
+
+Create `packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx`:
+
+```tsx
+import { useState } from 'react';
+import type { ImageElement } from '@wafflebase/slides';
+import { getCommonValue } from './units';
+
+export interface ImageAdjustmentsSectionProps {
+  elements: readonly ImageElement[];
+  onCommit: (ids: readonly string[], opacity: number) => void;
+}
+
+/** Convert opacity (0..1, undefined → 1) to transparency percent (0..100). */
+function opacityToTransparency(opacity: number | undefined): number {
+  return Math.round((1 - (opacity ?? 1)) * 100);
+}
+
+export function ImageAdjustmentsSection({
+  elements,
+  onCommit,
+}: ImageAdjustmentsSectionProps) {
+  const common = getCommonValue(elements, (el) =>
+    opacityToTransparency(el.data.opacity),
+  );
+  const [draft, setDraft] = useState<number>(common ?? 0);
+
+  return (
+    <section aria-labelledby="format-adjustments-label" className="p-3">
+      <h3
+        id="format-adjustments-label"
+        className="mb-2 text-xs font-semibold"
+      >
+        Adjustments
+      </h3>
+      <label className="block text-xs">
+        <span className="mb-1 block">Transparency</span>
+        <input
+          aria-label="Transparency"
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={draft}
+          onChange={(e) => setDraft(Number(e.target.value))}
+          onPointerUp={() => {
+            const opacity = 1 - draft / 100;
+            onCommit(
+              elements.map((el) => el.id),
+              opacity,
+            );
+          }}
+          className="w-full"
+        />
+        <span className="text-xs text-muted-foreground">{draft}%</span>
+      </label>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/image-adjustments-section.test.tsx
+```
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx \
+        packages/frontend/tests/app/slides/format-panel/image-adjustments-section.test.tsx
+git commit -m "$(cat <<'EOF'
+Add ImageAdjustmentsSection (transparency)
+
+Maps the existing image.opacity field to a 0..100% transparency
+slider. pointerUp commit so a drag produces one undo entry per
+adjustment session.
+
+EOF
+)"
+```
+
+---
+
+### Task 7: `TextFittingSection` component
+
+**Files:**
+- Create: `packages/frontend/src/app/slides/format-panel/text-fitting-section.tsx`
+- Create: `packages/frontend/tests/app/slides/format-panel/text-fitting-section.test.tsx`
+
+3-mode radio group writing `data.autofit` directly. No reusable
+selector exists today, so the radio is built locally.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/frontend/tests/app/slides/format-panel/text-fitting-section.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TextFittingSection } from '@/app/slides/format-panel/text-fitting-section';
+import type { TextElement, AutofitMode } from '@wafflebase/slides';
+
+function text(id: string, autofit?: AutofitMode): TextElement {
+  return {
+    id,
+    type: 'text',
+    frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+    data: { blocks: [], autofit },
+  };
+}
+
+describe('TextFittingSection', () => {
+  it('selects the common autofit value (defaulting absent → "grow")', () => {
+    render(
+      <TextFittingSection
+        elements={[text('a', undefined), text('b', 'grow')]}
+        onCommit={vi.fn()}
+      />,
+    );
+    expect((screen.getByLabelText(/resize shape to fit/i) as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('no radio is checked when autofit differs across the selection', () => {
+    render(
+      <TextFittingSection
+        elements={[text('a', 'grow'), text('b', 'shrink')]}
+        onCommit={vi.fn()}
+      />,
+    );
+    expect((screen.getByLabelText(/do not autofit/i) as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByLabelText(/shrink text/i) as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByLabelText(/resize shape to fit/i) as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('selecting a mode commits to every element id', () => {
+    const onCommit = vi.fn();
+    render(
+      <TextFittingSection
+        elements={[text('a', 'grow'), text('b', 'grow')]}
+        onCommit={onCommit}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/shrink text/i));
+    expect(onCommit).toHaveBeenCalledWith(['a', 'b'], 'shrink');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/text-fitting-section.test.tsx
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `text-fitting-section.tsx`**
+
+Create `packages/frontend/src/app/slides/format-panel/text-fitting-section.tsx`:
+
+```tsx
+import type { AutofitMode, TextElement } from '@wafflebase/slides';
+import { getCommonValue } from './units';
+
+export interface TextFittingSectionProps {
+  elements: readonly TextElement[];
+  onCommit: (ids: readonly string[], mode: AutofitMode) => void;
+}
+
+const MODES: { mode: AutofitMode; label: string }[] = [
+  { mode: 'none', label: 'Do not autofit' },
+  { mode: 'shrink', label: 'Shrink text on overflow' },
+  { mode: 'grow', label: 'Resize shape to fit text' },
+];
+
+export function TextFittingSection({
+  elements,
+  onCommit,
+}: TextFittingSectionProps) {
+  // Absent autofit defaults to 'grow' per slides-text-autofit.md.
+  const common = getCommonValue(
+    elements,
+    (el): AutofitMode => el.data.autofit ?? 'grow',
+  );
+  return (
+    <section aria-labelledby="format-text-fitting-label" className="p-3">
+      <h3
+        id="format-text-fitting-label"
+        className="mb-2 text-xs font-semibold"
+      >
+        Text fitting
+      </h3>
+      <div role="radiogroup" className="space-y-1">
+        {MODES.map(({ mode, label }) => (
+          <label key={mode} className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="format-text-fitting"
+              aria-label={label}
+              checked={common === mode}
+              onChange={() =>
+                onCommit(
+                  elements.map((el) => el.id),
+                  mode,
+                )
+              }
+            />
+            {label}
+          </label>
+        ))}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/text-fitting-section.test.tsx
+```
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/format-panel/text-fitting-section.tsx \
+        packages/frontend/tests/app/slides/format-panel/text-fitting-section.test.tsx
+git commit -m "$(cat <<'EOF'
+Add TextFittingSection (autofit 3-mode radio)
+
+Direct 3-radio control for none/shrink/grow. Same autofit field
+the existing in-canvas toggle writes — both UI surfaces stay in
+sync via the store onChange path.
+
+EOF
+)"
+```
+
+---
+
+### Task 8: `SizePositionSection` component
+
+**Files:**
+- Create: `packages/frontend/src/app/slides/format-panel/size-position-section.tsx`
+- Create: `packages/frontend/tests/app/slides/format-panel/size-position-section.test.tsx`
+
+The largest section. Handles W/H/X/Y inputs, lock aspect, rotation
+input + 90° buttons, and the in/cm radio. Multi-select uses
+`getCommonValue` and writes to every element in a single
+`store.batch` via the parent's commit callbacks. Connector-specific
+hides W/H/rotation; the `mixed` case hides W/H/rotation too (X/Y
+only).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/frontend/tests/app/slides/format-panel/size-position-section.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SizePositionSection } from '@/app/slides/format-panel/size-position-section';
+import type { ShapeElement, ConnectorElement, Element } from '@wafflebase/slides';
+
+function shape(
+  id: string,
+  frame: { x: number; y: number; w: number; h: number; rotation: number },
+): ShapeElement {
+  return { id, type: 'shape', frame, data: { kind: 'rect' } };
+}
+
+function connector(id: string): ConnectorElement {
+  return {
+    id,
+    type: 'connector',
+    frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+    routing: 'straight',
+    start: { kind: 'free', x: 0, y: 0 },
+    end: { kind: 'free', x: 100, y: 0 },
+    arrowheads: {},
+  };
+}
+
+const defaultCommit = {
+  onCommitFrame: vi.fn(),
+  onTranslate: vi.fn(),
+  onSetUnit: vi.fn(),
+  onRotate90: vi.fn(),
+};
+
+describe('SizePositionSection (shape)', () => {
+  it('shows W/H/X/Y/Rotation inputs and the in/cm radio', () => {
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[shape('a', { x: 192, y: 96, w: 384, h: 192, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect(screen.getByLabelText(/^width$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^height$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^x position$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^y position$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/rotation/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/inches/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/centimeters/i)).toBeInTheDocument();
+  });
+
+  it('shows the value formatted in the active unit', () => {
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[shape('a', { x: 192, y: 96, w: 384, h: 192, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect((screen.getByLabelText(/^width$/i) as HTMLInputElement).value).toBe(
+      '2.00',
+    );
+    expect((screen.getByLabelText(/^x position$/i) as HTMLInputElement).value).toBe(
+      '1.00',
+    );
+  });
+
+  it('commits w-change in canvas px on blur', () => {
+    const onCommitFrame = vi.fn();
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[shape('a', { x: 0, y: 0, w: 192, h: 192, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+        onCommitFrame={onCommitFrame}
+      />,
+    );
+    const w = screen.getByLabelText(/^width$/i);
+    fireEvent.change(w, { target: { value: '3.00' } });
+    fireEvent.blur(w);
+    expect(onCommitFrame).toHaveBeenCalledWith(['a'], { w: 576 });
+  });
+
+  it('mixed values render an empty input', () => {
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[
+          shape('a', { x: 0, y: 0, w: 100, h: 100, rotation: 0 }),
+          shape('b', { x: 0, y: 0, w: 200, h: 100, rotation: 0 }),
+        ]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect((screen.getByLabelText(/^width$/i) as HTMLInputElement).value).toBe('');
+  });
+
+  it('rotate90 button calls onRotate90 with all ids and direction', () => {
+    const onRotate90 = vi.fn();
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[shape('a', { x: 0, y: 0, w: 100, h: 100, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+        onRotate90={onRotate90}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/rotate 90 clockwise/i));
+    expect(onRotate90).toHaveBeenCalledWith(['a'], 1);
+  });
+
+  it('unit radio change calls onSetUnit', () => {
+    const onSetUnit = vi.fn();
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[shape('a', { x: 0, y: 0, w: 100, h: 100, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+        onSetUnit={onSetUnit}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/centimeters/i));
+    expect(onSetUnit).toHaveBeenCalledWith('cm');
+  });
+});
+
+describe('SizePositionSection (connector)', () => {
+  it('hides W/H and rotation; X/Y disabled if any endpoint is attached', () => {
+    const conn = connector('c1');
+    render(
+      <SizePositionSection
+        kind="connector"
+        elements={[conn]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect(screen.queryByLabelText(/^width$/i)).toBeNull();
+    expect(screen.queryByLabelText(/^height$/i)).toBeNull();
+    expect(screen.queryByLabelText(/rotation/i)).toBeNull();
+    expect(screen.getByLabelText(/^x position$/i)).toBeEnabled();
+  });
+
+  it('disables X/Y when a connector has an attached endpoint', () => {
+    const attached: ConnectorElement = {
+      ...connector('c1'),
+      start: { kind: 'attached', elementId: 'e1', siteIndex: 0 },
+    };
+    render(
+      <SizePositionSection
+        kind="connector"
+        elements={[attached]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect(screen.getByLabelText(/^x position$/i)).toBeDisabled();
+  });
+});
+
+describe('SizePositionSection (mixed)', () => {
+  it('only X and Y inputs are visible', () => {
+    const mixedSel: Element[] = [
+      shape('a', { x: 0, y: 0, w: 100, h: 100, rotation: 0 }),
+      connector('c1'),
+    ];
+    render(
+      <SizePositionSection
+        kind="mixed"
+        elements={mixedSel}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect(screen.queryByLabelText(/^width$/i)).toBeNull();
+    expect(screen.queryByLabelText(/^height$/i)).toBeNull();
+    expect(screen.queryByLabelText(/rotation/i)).toBeNull();
+    expect(screen.getByLabelText(/^x position$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^y position$/i)).toBeInTheDocument();
+  });
+});
+
+describe('SizePositionSection (text-element with autofit=grow)', () => {
+  it('disables H input', () => {
+    render(
+      <SizePositionSection
+        kind="text-element"
+        textAutofitMode="grow"
+        elements={[shape('t', { x: 0, y: 0, w: 100, h: 100, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect(screen.getByLabelText(/^height$/i)).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/size-position-section.test.tsx
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `size-position-section.tsx`**
+
+Create `packages/frontend/src/app/slides/format-panel/size-position-section.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react';
+import type {
+  ConnectorElement,
+  Element,
+  Frame,
+} from '@wafflebase/slides';
+import {
+  DisplayUnit,
+  degToRad,
+  formatDisplay,
+  getCommonValue,
+  pxToUnit,
+  radToDeg,
+  unitToPx,
+} from './units';
+
+export type SectionKind =
+  | 'shape'
+  | 'image'
+  | 'text-element'
+  | 'connector'
+  | 'group'
+  | 'mixed';
+
+export interface SizePositionSectionProps {
+  kind: SectionKind;
+  elements: readonly Element[];
+  unit: DisplayUnit;
+  /** Set when kind === 'text-element' to gate the H input. */
+  textAutofitMode?: 'none' | 'shrink' | 'grow';
+  onCommitFrame: (ids: readonly string[], patch: Partial<Frame>) => void;
+  onTranslate: (ids: readonly string[], dx: number, dy: number) => void;
+  onSetUnit: (unit: DisplayUnit) => void;
+  /** direction: +1 = clockwise, -1 = counter-clockwise. */
+  onRotate90: (ids: readonly string[], direction: 1 | -1) => void;
+}
+
+function anyEndpointAttached(els: readonly Element[]): boolean {
+  return els.some(
+    (el) =>
+      el.type === 'connector' &&
+      ((el as ConnectorElement).start.kind === 'attached' ||
+        (el as ConnectorElement).end.kind === 'attached'),
+  );
+}
+
+export function SizePositionSection(props: SizePositionSectionProps) {
+  const { kind, elements, unit, textAutofitMode } = props;
+  const ids = elements.map((el) => el.id);
+
+  const showWH = kind !== 'connector' && kind !== 'mixed';
+  const showRotation =
+    kind !== 'connector' && kind !== 'mixed';
+  const xyDisabled = kind === 'connector' && anyEndpointAttached(elements);
+  const hDisabled = kind === 'text-element' && textAutofitMode === 'grow';
+
+  const w = getCommonValue(elements, (el) => el.frame.w);
+  const h = getCommonValue(elements, (el) => el.frame.h);
+  const x = getCommonValue(elements, (el) => el.frame.x);
+  const y = getCommonValue(elements, (el) => el.frame.y);
+  const rotation = getCommonValue(elements, (el) => el.frame.rotation);
+
+  return (
+    <section aria-labelledby="format-size-position-label" className="p-3">
+      <h3
+        id="format-size-position-label"
+        className="mb-2 text-xs font-semibold"
+      >
+        Size &amp; Position
+      </h3>
+
+      {showWH && (
+        <div className="mb-3 space-y-2">
+          <UnitInput
+            label="Width"
+            valuePx={w}
+            unit={unit}
+            onCommit={(px) => props.onCommitFrame(ids, { w: px })}
+          />
+          <UnitInput
+            label="Height"
+            valuePx={h}
+            unit={unit}
+            disabled={hDisabled}
+            disabledTooltip={
+              hDisabled
+                ? "Height is auto-calculated. Switch autofit to 'None' or 'Shrink' to set manually."
+                : undefined
+            }
+            onCommit={(px) => props.onCommitFrame(ids, { h: px })}
+          />
+        </div>
+      )}
+
+      <div className="mb-3 space-y-2">
+        <UnitInput
+          label="X position"
+          valuePx={x}
+          unit={unit}
+          disabled={xyDisabled}
+          disabledTooltip={
+            xyDisabled ? 'Detach endpoints to set position.' : undefined
+          }
+          onCommit={(px) => {
+            if (x === undefined) return;
+            props.onTranslate(ids, px - x, 0);
+          }}
+        />
+        <UnitInput
+          label="Y position"
+          valuePx={y}
+          unit={unit}
+          disabled={xyDisabled}
+          disabledTooltip={
+            xyDisabled ? 'Detach endpoints to set position.' : undefined
+          }
+          onCommit={(px) => {
+            if (y === undefined) return;
+            props.onTranslate(ids, 0, px - y);
+          }}
+        />
+      </div>
+
+      {showRotation && (
+        <div className="mb-3 flex items-center gap-2">
+          <RotationInput
+            valueRad={rotation}
+            onCommit={(rad) => props.onCommitFrame(ids, { rotation: rad })}
+          />
+          <button
+            type="button"
+            aria-label="Rotate 90 counter-clockwise"
+            onClick={() => props.onRotate90(ids, -1)}
+            className="rounded border px-2 py-1 text-xs hover:bg-muted"
+          >
+            ↺
+          </button>
+          <button
+            type="button"
+            aria-label="Rotate 90 clockwise"
+            onClick={() => props.onRotate90(ids, 1)}
+            className="rounded border px-2 py-1 text-xs hover:bg-muted"
+          >
+            ↻
+          </button>
+        </div>
+      )}
+
+      <fieldset className="mt-2 text-xs">
+        <legend className="mb-1">Units</legend>
+        <label className="mr-3 inline-flex items-center gap-1">
+          <input
+            type="radio"
+            name="format-unit"
+            aria-label="Inches"
+            checked={unit === 'in'}
+            onChange={() => props.onSetUnit('in')}
+          />
+          Inches
+        </label>
+        <label className="inline-flex items-center gap-1">
+          <input
+            type="radio"
+            name="format-unit"
+            aria-label="Centimeters"
+            checked={unit === 'cm'}
+            onChange={() => props.onSetUnit('cm')}
+          />
+          Centimeters
+        </label>
+      </fieldset>
+    </section>
+  );
+}
+
+interface UnitInputProps {
+  label: string;
+  valuePx: number | undefined;
+  unit: DisplayUnit;
+  disabled?: boolean;
+  disabledTooltip?: string;
+  onCommit: (px: number) => void;
+}
+
+function UnitInput({
+  label,
+  valuePx,
+  unit,
+  disabled,
+  disabledTooltip,
+  onCommit,
+}: UnitInputProps) {
+  const display = valuePx === undefined ? '' : formatDisplay(valuePx, unit);
+  const [draft, setDraft] = useState<string>(display);
+  useEffect(() => setDraft(display), [display]);
+
+  return (
+    <label className="flex items-center gap-2 text-xs">
+      <span className="w-20 shrink-0">{label}</span>
+      <input
+        aria-label={label}
+        type="text"
+        inputMode="decimal"
+        disabled={disabled}
+        title={disabled ? disabledTooltip : undefined}
+        value={draft}
+        placeholder={valuePx === undefined ? '—' : undefined}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+          if (e.key === 'Escape') {
+            setDraft(display);
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        onBlur={() => {
+          if (draft === '') return; // blank → no-op
+          const n = parseFloat(draft);
+          if (!Number.isFinite(n)) {
+            setDraft(display);
+            return;
+          }
+          onCommit(unitToPx(n, unit));
+        }}
+        className="w-24 rounded border px-2 py-1 text-right"
+      />
+      <span className="w-6 text-muted-foreground">{unit}</span>
+    </label>
+  );
+}
+
+interface RotationInputProps {
+  valueRad: number | undefined;
+  onCommit: (rad: number) => void;
+}
+
+function RotationInput({ valueRad, onCommit }: RotationInputProps) {
+  const display =
+    valueRad === undefined ? '' : radToDeg(valueRad).toFixed(2);
+  const [draft, setDraft] = useState<string>(display);
+  useEffect(() => setDraft(display), [display]);
+
+  return (
+    <label className="flex items-center gap-2 text-xs">
+      <span className="w-20 shrink-0">Rotation</span>
+      <input
+        aria-label="Rotation"
+        type="text"
+        inputMode="decimal"
+        value={draft}
+        placeholder={valueRad === undefined ? '—' : undefined}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+          if (e.key === 'Escape') {
+            setDraft(display);
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        onBlur={() => {
+          if (draft === '') return;
+          const n = parseFloat(draft);
+          if (!Number.isFinite(n)) {
+            setDraft(display);
+            return;
+          }
+          onCommit(degToRad(n));
+        }}
+        className="w-24 rounded border px-2 py-1 text-right"
+      />
+      <span className="w-6 text-muted-foreground">°</span>
+    </label>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/size-position-section.test.tsx
+```
+Expected: PASS — all tests.
+
+- [ ] **Step 5: Add lock-aspect-ratio toggle**
+
+The v1 spec includes a per-element aspect-ratio lock that re-computes
+H from a W change (and vice versa) using each element's own
+current aspect ratio. The lock is **local React state** — it does
+not persist across selection changes or sessions.
+
+Add to `size-position-section.test.tsx`:
+
+```tsx
+describe('SizePositionSection lock aspect', () => {
+  it('locked W edit also commits proportional H (per element)', () => {
+    const onCommitFrame = vi.fn();
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[
+          shape('a', { x: 0, y: 0, w: 100, h: 50, rotation: 0 }),
+          shape('b', { x: 0, y: 0, w: 200, h: 200, rotation: 0 }),
+        ]}
+        unit="in"
+        {...defaultCommit}
+        onCommitFrame={onCommitFrame}
+      />,
+    );
+    // Toggle the lock on.
+    fireEvent.click(screen.getByLabelText(/lock aspect ratio/i));
+    const w = screen.getByLabelText(/^width$/i);
+    // Mixed values → input is blank, so we type a value that becomes both.
+    fireEvent.change(w, { target: { value: '2.00' } });  // 2in = 384 px
+    fireEvent.blur(w);
+    // The commit callback is invoked per element with its own H
+    // computed from the new W: a's ratio = 50/100 = 0.5 → h=192;
+    // b's ratio = 200/200 = 1   → h=384. Implementation must walk
+    // each element rather than using a single shared ratio.
+    expect(onCommitFrame).toHaveBeenCalled();
+  });
+});
+```
+
+Then modify the `SizePositionSection` implementation:
+
+1. Add `const [locked, setLocked] = useState(false);` and reset it
+   with `useEffect(() => setLocked(false), [elements])`.
+2. Replace the simple `onCommit={(px) => props.onCommitFrame(ids, { w: px })}`
+   on the Width input with a callback that, when `locked`, computes
+   per-element H and calls a new `onLockedResize` prop instead:
+   ```ts
+   onCommit={(px) =>
+     locked
+       ? props.onLockedResize(elements, 'w', px)
+       : props.onCommitFrame(ids, { w: px })
+   }
+   ```
+3. Add the corresponding lock-aware branch on the Height input.
+4. Add a lock button between W and H:
+   ```tsx
+   <button
+     type="button"
+     aria-label="Lock aspect ratio"
+     aria-pressed={locked}
+     onClick={() => setLocked((v) => !v)}
+     className={'rounded p-1 text-xs ' + (locked ? 'bg-muted' : '')}
+   >
+     🔒
+   </button>
+   ```
+5. Add the prop to `SizePositionSectionProps`:
+   ```ts
+   onLockedResize: (
+     elements: readonly Element[],
+     axis: 'w' | 'h',
+     newPx: number,
+   ) => void;
+   ```
+
+Update `defaultCommit` in the test file to include
+`onLockedResize: vi.fn()`.
+
+In `FormatPanel` (Task 9), add the `onLockedResize` implementation:
+
+```ts
+const lockedResize = useCallback(
+  (elems: readonly Element[], axis: 'w' | 'h', newPx: number) => {
+    if (selection.kind !== 'object') return;
+    store.batch(() => {
+      for (const el of elems) {
+        const ratio = el.frame.h / el.frame.w;
+        const patch =
+          axis === 'w'
+            ? { w: newPx, h: newPx * ratio }
+            : { h: newPx, w: ratio === 0 ? el.frame.w : newPx / ratio };
+        store.updateElementFrame(selection.slideId, el.id, patch);
+      }
+    });
+  },
+  [store, selection],
+);
+```
+
+And pass `onLockedResize={lockedResize}` to `<SizePositionSection>`.
+
+- [ ] **Step 6: Re-run the section tests and confirm they pass**
+
+```bash
+pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/size-position-section.test.tsx
+```
+Expected: PASS — including the new lock-aspect test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/format-panel/size-position-section.tsx \
+        packages/frontend/tests/app/slides/format-panel/size-position-section.test.tsx
+git commit -m "$(cat <<'EOF'
+Add SizePositionSection (W/H/X/Y/Rotation + unit toggle)
+
+Numeric inputs with onBlur/Enter commit, Escape revert, mixed-
+value blank placeholder, in/cm radio, ↺/↻ 90° rotation. Connector
+W/H/rotation hidden, X/Y disabled when an endpoint is attached.
+text-element + autofit=grow disables H with tooltip.
+
+EOF
+)"
+```
+
+---
+
+### Task 9: `FormatPanel` shell (`index.tsx`)
+
+**Files:**
+- Create: `packages/frontend/src/app/slides/format-panel/index.tsx`
+
+The shell subscribes to `store.onChange` and `editor.onSelectionChange`,
+derives the `PanelSelection`, resolves the unit from `meta.unit`
+(default `'in'`), and routes to sections via `pickSections`. The
+shell also owns the commit callbacks that wrap `store.batch`.
+
+- [ ] **Step 1: Implement the shell**
+
+Create `packages/frontend/src/app/slides/format-panel/index.tsx`:
+
+```tsx
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type {
+  Element,
+  Frame,
+  ImageElement,
+  SlidesEditor,
+  SlidesStore,
+  TextElement,
+  AutofitMode,
+} from '@wafflebase/slides';
+import { findElementPath } from '@wafflebase/slides';
+import { pickSections, type PanelSelection } from './pick-sections';
+import { AltTextSection } from './alt-text-section';
+import { ImageAdjustmentsSection } from './image-adjustments-section';
+import { TextFittingSection } from './text-fitting-section';
+import { SizePositionSection } from './size-position-section';
+import type { DisplayUnit } from './units';
+
+export interface FormatPanelProps {
+  store: SlidesStore;
+  editor: SlidesEditor;
+  onClose: () => void;
+}
+
+function derivePanelSelection(
+  store: SlidesStore,
+  editor: SlidesEditor,
+): PanelSelection {
+  const slideId = editor.getCurrentSlideId();
+  const ids = editor.getSelection();
+  if (!slideId || ids.length === 0) return { kind: 'idle' };
+  const slide = store.read().slides.find((s) => s.id === slideId);
+  if (!slide) return { kind: 'idle' };
+  const elements: Element[] = [];
+  for (const id of ids) {
+    const path = findElementPath(slide.elements, id);
+    if (path) elements.push(path[path.length - 1]);
+  }
+  if (elements.length === 0) return { kind: 'idle' };
+  const types = new Set(elements.map((el) => el.type));
+  let selectionType:
+    | 'shape'
+    | 'image'
+    | 'text-element'
+    | 'connector'
+    | 'group'
+    | 'mixed';
+  if (types.size > 1) selectionType = 'mixed';
+  else if (types.has('shape')) selectionType = 'shape';
+  else if (types.has('image')) selectionType = 'image';
+  else if (types.has('text')) selectionType = 'text-element';
+  else if (types.has('connector')) selectionType = 'connector';
+  else if (types.has('group')) selectionType = 'group';
+  else selectionType = 'mixed';
+  return { kind: 'object', selectionType, elements, slideId };
+}
+
+export function FormatPanel({ store, editor, onClose }: FormatPanelProps) {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const u1 = store.onChange?.(() => setTick((t) => t + 1));
+    const u2 = editor.onSelectionChange(() => setTick((t) => t + 1));
+    return () => {
+      u1?.();
+      u2();
+    };
+  }, [store, editor]);
+
+  // tick gates re-derivation; the store/editor reads are the source of truth.
+  void tick;
+
+  const selection = useMemo(
+    () => derivePanelSelection(store, editor),
+    [store, editor, tick],
+  );
+  const unit: DisplayUnit = store.read().meta.unit ?? 'in';
+  const sections = pickSections(selection);
+
+  const commitFrame = useCallback(
+    (ids: readonly string[], patch: Partial<Frame>) => {
+      const slideId =
+        selection.kind === 'object' ? selection.slideId : undefined;
+      if (!slideId) return;
+      store.batch(() => {
+        for (const id of ids) store.updateElementFrame(slideId, id, patch);
+      });
+    },
+    [store, selection],
+  );
+
+  const translate = useCallback(
+    (ids: readonly string[], dx: number, dy: number) => {
+      if (selection.kind !== 'object') return;
+      store.batch(() => {
+        for (const id of ids) {
+          const el = selection.elements.find((e) => e.id === id);
+          if (!el) continue;
+          store.updateElementFrame(selection.slideId, id, {
+            x: el.frame.x + dx,
+            y: el.frame.y + dy,
+          });
+        }
+      });
+    },
+    [store, selection],
+  );
+
+  const rotate90 = useCallback(
+    (ids: readonly string[], direction: 1 | -1) => {
+      if (selection.kind !== 'object') return;
+      const delta = (direction * Math.PI) / 2;
+      store.batch(() => {
+        for (const id of ids) {
+          const el = selection.elements.find((e) => e.id === id);
+          if (!el) continue;
+          const next = ((el.frame.rotation + delta) % (Math.PI * 2)
+            + Math.PI * 2) % (Math.PI * 2);
+          store.updateElementFrame(selection.slideId, id, { rotation: next });
+        }
+      });
+    },
+    [store, selection],
+  );
+
+  const setUnit = useCallback(
+    (next: DisplayUnit) => {
+      store.batch(() => store.setUnit(next));
+    },
+    [store],
+  );
+
+  const commitElementData = useCallback(
+    (ids: readonly string[], patch: object) => {
+      if (selection.kind !== 'object') return;
+      store.batch(() => {
+        for (const id of ids) store.updateElementData(selection.slideId, id, patch);
+      });
+    },
+    [store, selection],
+  );
+
+  const lockedResize = useCallback(
+    (elems: readonly Element[], axis: 'w' | 'h', newPx: number) => {
+      if (selection.kind !== 'object') return;
+      store.batch(() => {
+        for (const el of elems) {
+          const ratio = el.frame.w === 0 ? 1 : el.frame.h / el.frame.w;
+          const patch =
+            axis === 'w'
+              ? { w: newPx, h: newPx * ratio }
+              : { h: newPx, w: ratio === 0 ? el.frame.w : newPx / ratio };
+          store.updateElementFrame(selection.slideId, el.id, patch);
+        }
+      });
+    },
+    [store, selection],
+  );
+
+  return (
+    <aside
+      aria-label="Format options"
+      className="flex w-72 shrink-0 flex-col border-l bg-background"
+    >
+      <header className="flex items-center justify-between border-b p-2">
+        <h2 className="text-sm font-semibold">Format options</h2>
+        <button
+          type="button"
+          aria-label="Close format options"
+          onClick={onClose}
+          className="rounded p-1 hover:bg-muted"
+        >
+          ×
+        </button>
+      </header>
+      <div className="flex-1 overflow-y-auto">
+        {selection.kind === 'idle' && (
+          <p className="p-4 text-xs text-muted-foreground">
+            Select an object to edit its format.
+          </p>
+        )}
+        {selection.kind === 'object' &&
+          sections.map((id) => {
+            switch (id) {
+              case 'size-position': {
+                const textAutofitMode =
+                  selection.selectionType === 'text-element'
+                    ? ((selection.elements[0] as TextElement).data.autofit ??
+                        'grow')
+                    : undefined;
+                return (
+                  <SizePositionSection
+                    key={id}
+                    kind={selection.selectionType}
+                    elements={selection.elements}
+                    unit={unit}
+                    textAutofitMode={textAutofitMode}
+                    onCommitFrame={commitFrame}
+                    onTranslate={translate}
+                    onSetUnit={setUnit}
+                    onRotate90={rotate90}
+                    onLockedResize={lockedResize}
+                  />
+                );
+              }
+              case 'text-fitting':
+                return (
+                  <TextFittingSection
+                    key={id}
+                    elements={selection.elements as readonly TextElement[]}
+                    onCommit={(ids, mode: AutofitMode) =>
+                      commitElementData(ids, { autofit: mode })
+                    }
+                  />
+                );
+              case 'image-adjustments':
+                return (
+                  <ImageAdjustmentsSection
+                    key={id}
+                    elements={selection.elements as readonly ImageElement[]}
+                    onCommit={(ids, opacity) =>
+                      commitElementData(ids, { opacity })
+                    }
+                  />
+                );
+              case 'alt-text':
+                return (
+                  <AltTextSection
+                    key={id}
+                    elements={selection.elements as readonly ImageElement[]}
+                    onCommit={(ids, alt) => commitElementData(ids, { alt })}
+                  />
+                );
+            }
+          })}
+      </div>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm --filter @wafflebase/frontend exec tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/format-panel/index.tsx
+git commit -m "$(cat <<'EOF'
+Add FormatPanel shell
+
+Derives PanelSelection from editor + store, routes to sections
+via pickSections, owns the commit callbacks that wrap store.batch.
+Subscribes to both selection and store changes so the panel
+follows remote edits and selection swaps.
+
+EOF
+)"
+```
+
+---
+
+### Task 10: Remove the Alt-text dropdown from `image-controls.tsx`
+
+**Files:**
+- Modify: `packages/frontend/src/app/slides/toolbar/image-controls.tsx`
+
+The Format panel is now the single home for image alt text. The
+toolbar dropdown becomes redundant — remove it and the unused icon
+import.
+
+- [ ] **Step 1: Remove the AltTextDropdown render and its helper**
+
+Edit `packages/frontend/src/app/slides/toolbar/image-controls.tsx`:
+
+1. Delete the entire `AltTextDropdown` component definition at the
+   bottom of the file (lines starting from `interface
+   AltTextDropdownProps` through the closing `}`).
+2. Remove the `<ToolbarSeparator className="mx-1" />` and
+   `<AltTextDropdown ... />` block from the return of
+   `ImageControls`.
+3. Remove the unused imports: `useEffect`, `useState`, `IconAccessible`,
+   `DropdownMenu`, `DropdownMenuContent`, `DropdownMenuTrigger`. Keep
+   what the Replace / Crop / Reset crop buttons still need.
+4. Remove the `onSaveAlt` callback (no longer referenced).
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm --filter @wafflebase/frontend exec tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/toolbar/image-controls.tsx
+git commit -m "$(cat <<'EOF'
+Drop toolbar alt-text dropdown — moved to Format panel
+
+The Format panel's Alt text section is the single source. Removing
+the toolbar dropdown avoids two-surface drift.
+
+EOF
+)"
+```
+
+---
+
+### Task 11: Add "Format options" toggle button to global toolbar
+
+**Files:**
+- Modify: `packages/frontend/src/app/slides/toolbar/global-controls.tsx`
+- Modify: `packages/frontend/src/app/slides/toolbar/index.tsx`
+
+The Format button sits in the right global zone next to Theme. It
+flips `rightPanel` between `'format'` and `null` via a callback
+provided by `slides-detail.tsx` (added in Task 12).
+
+- [ ] **Step 1: Inspect the existing Theme toggle for the same pattern**
+
+```bash
+grep -n "Theme\|onToggleThemePanel\|themePanelOpen" packages/frontend/src/app/slides/toolbar/global-controls.tsx packages/frontend/src/app/slides/toolbar/index.tsx
+```
+
+Note the prop name shape (`onToggleThemePanel`, `themePanelOpen`)
+and how it threads from `SlidesToolbar` to `global-controls.tsx`.
+
+- [ ] **Step 2: Add `onToggleFormatPanel` and `formatPanelOpen` props alongside the existing theme props**
+
+Edit `packages/frontend/src/app/slides/toolbar/global-controls.tsx`:
+
+- Add to the props interface:
+  ```ts
+  onToggleFormatPanel?: () => void;
+  formatPanelOpen?: boolean;
+  ```
+- Add a button next to the Theme toggle:
+  ```tsx
+  {props.onToggleFormatPanel && (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label="Format options"
+          aria-pressed={!!props.formatPanelOpen}
+          onClick={props.onToggleFormatPanel}
+          className={
+            'inline-flex h-7 w-7 items-center justify-center rounded-md text-sm hover:bg-muted ' +
+            (props.formatPanelOpen ? 'bg-muted' : '')
+          }
+        >
+          <IconAdjustmentsAlt size={16} />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>Format options</TooltipContent>
+    </Tooltip>
+  )}
+  ```
+- Add `IconAdjustmentsAlt` to the `@tabler/icons-react` import.
+
+Edit `packages/frontend/src/app/slides/toolbar/index.tsx` to forward
+the two new props (`onToggleFormatPanel`, `formatPanelOpen`) from
+`SlidesToolbarProps` down to `<GlobalControls />`.
+
+- [ ] **Step 3: Type-check**
+
+```bash
+pnpm --filter @wafflebase/frontend exec tsc --noEmit
+```
+Expected: no errors (the new props are optional, so call sites that
+don't pass them still type-check).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/toolbar/global-controls.tsx \
+        packages/frontend/src/app/slides/toolbar/index.tsx
+git commit -m "$(cat <<'EOF'
+Add Format options toolbar toggle
+
+Right global zone gains a Format button next to Theme. Wired via
+two optional props that slides-detail will set in the next task —
+mobile and read-only call sites can keep ignoring them.
+
+EOF
+)"
+```
+
+---
+
+### Task 12: Wire `rightPanel` union and mount `FormatPanel` in `slides-detail.tsx`
+
+**Files:**
+- Modify: `packages/frontend/src/app/slides/slides-detail.tsx`
+
+Replace `themePanelOpen: boolean` with `rightPanel: 'theme' |
+'format' | null`. Both panels read from this single source; opening
+one closes the other. Mount `FormatPanel` next to `ThemePanel`,
+mutually exclusive. Mobile branch is untouched (no FormatPanel).
+Read-only viewers don't pass the toggle props, so the toolbar
+button is hidden.
+
+- [ ] **Step 1: Add the import and replace the `themePanelOpen` state**
+
+Edit `packages/frontend/src/app/slides/slides-detail.tsx`:
+
+- Add import: `import { FormatPanel } from './format-panel';`
+- In `DesktopSlidesLayout`, replace:
+  ```ts
+  const [themePanelOpen, setThemePanelOpen] = useState(false);
+  ```
+  with:
+  ```ts
+  type RightPanel = 'theme' | 'format' | null;
+  const [rightPanel, setRightPanel] = useState<RightPanel>(null);
+  ```
+
+- [ ] **Step 2: Update the Theme toggle, the Format toggle, and the mounts**
+
+In the same `DesktopSlidesLayout`'s `<SlidesToolbar ... />` props:
+
+```tsx
+<SlidesToolbar
+  editor={editor}
+  store={store}
+  theme={activeTheme}
+  onImagePick={handleImagePick}
+  upload={uploadFn}
+  onToggleThemePanel={() =>
+    setRightPanel((p) => (p === 'theme' ? null : 'theme'))
+  }
+  themePanelOpen={rightPanel === 'theme'}
+  onToggleFormatPanel={() =>
+    setRightPanel((p) => (p === 'format' ? null : 'format'))
+  }
+  formatPanelOpen={rightPanel === 'format'}
+/>
+```
+
+And replace the existing right-slot mount:
+
+```tsx
+{rightPanel === 'theme' && store && (
+  <ThemePanel
+    store={store}
+    currentThemeId={currentThemeId}
+    onClose={() => setRightPanel(null)}
+  />
+)}
+{rightPanel === 'format' && store && editor && (
+  <FormatPanel
+    store={store}
+    editor={editor}
+    onClose={() => setRightPanel(null)}
+  />
+)}
+```
+
+- [ ] **Step 3: Type-check + run all unit tests**
+
+```bash
+pnpm --filter @wafflebase/frontend exec tsc --noEmit
+pnpm verify:fast
+```
+Expected: no errors, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/frontend/src/app/slides/slides-detail.tsx
+git commit -m "$(cat <<'EOF'
+Wire FormatPanel and unify right-slot panel state
+
+themePanelOpen boolean is generalized to a single rightPanel union
+so Theme and Format are mutually exclusive in the slot. Opening
+one closes the other. Mobile and the read-only viewer are
+untouched — they never pass the format toggle props, so the
+toolbar button stays hidden there.
+
+EOF
+)"
+```
+
+---
+
+### Task 13: Browser smoke test
+
+**Files:**
+- Create or extend: a slides browser smoke spec under
+  `packages/frontend/tests/browser/slides/` (or the project-standard
+  location — `pnpm verify:browser:docker --help` and the existing
+  smoke specs are the source of truth)
+
+Exercise the panel in a real browser so we catch the integrations
+that jsdom does not (canvas, real DOM layout, mouse + keyboard
+events end-to-end).
+
+- [ ] **Step 1: Locate the existing slides browser smoke file**
+
+```bash
+find packages/frontend/tests/browser -path '*slides*' -name '*.ts*' 2>/dev/null
+find packages -path '*tests/browser*' -name '*.ts*' 2>/dev/null | head -10
+```
+
+Identify the spec that mounts the slides editor (e.g. covers the
+toolbar or themes). Add a new test there or create a sibling spec.
+
+- [ ] **Step 2: Add a smoke test covering the core flows**
+
+The test should:
+
+1. Mount the slides editor with a single slide.
+2. Insert a rectangle, select it.
+3. Click the toolbar "Format options" button. Assert panel visible.
+4. Change Width from `2.00` (or whatever the rendered default is) to
+   `4.00` — assert the rectangle's rendered width doubles.
+5. Click `↻` 90° — assert rotation visible on the canvas / DOM
+   overlay.
+6. Switch units to Centimeters — assert the input re-formats to
+   `~10.16` cm for 4 in.
+7. Click "Theme" — assert ThemePanel opens AND Format panel closes
+   (mutual exclusion).
+8. Close the Theme panel and reopen Format — assert previously
+   typed Width is preserved (it was committed at blur).
+
+Each step should produce visible state change; assertions should be
+on canvas + DOM, not on internal React state.
+
+- [ ] **Step 3: Run the smoke**
+
+```bash
+pnpm verify:browser:docker
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/frontend/tests/browser/...   # actual path from step 1
+git commit -m "$(cat <<'EOF'
+Add browser smoke for FormatPanel core flows
+
+Covers the integration points jsdom cannot: width commit moves the
+rendered rect, 90° rotation paints, in↔cm re-formats, Theme/Format
+panels are mutually exclusive in the right slot.
+
+EOF
+)"
+```
+
+---
+
+### Task 14: Self-review and final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Re-run the full verification gate**
+
+```bash
+pnpm verify:fast
+```
+Expected: lint clean, all unit tests pass.
+
+- [ ] **Step 2: Manual smoke in `pnpm dev`**
+
+Start the dev server:
+
+```bash
+docker compose up -d
+pnpm dev
+```
+
+Manually verify:
+
+1. Open a slides document. Toolbar shows Format button next to
+   Theme.
+2. Idle: opening the panel shows "Select an object to edit its
+   format."
+3. Select a shape. Size & Position section is populated with W/H/X/Y
+   formatted in inches, Rotation in degrees, in/cm radio matches
+   `meta.unit`.
+4. Edit W from 2.00 to 4.00, blur. Rectangle widens; undo reverts
+   in one step.
+5. Select two shapes with different W. W input is blank with `—`
+   placeholder. Type `3.00`, blur. Both rectangles widen.
+6. Select an image. Size & Position + Adjustments + Alt text show.
+   Drag the transparency slider; image fades on pointerup; undo is
+   one step.
+7. Select a text element. Size & Position + Text fitting show.
+   Switch autofit to 'grow' — H input becomes disabled with a
+   tooltip.
+8. Select a connector (line). W/H and Rotation are hidden. X/Y is
+   enabled when both endpoints are free; disabled with tooltip
+   when an endpoint is attached.
+9. Click Theme. Format panel closes, Theme opens.
+10. Close Theme. Open Format. Confirm the panel still shows the
+    correct selection.
+11. Switch unit to Centimeters — values re-format; another peer (or
+    a refresh) shows the same unit.
+
+Any failure → file a fix as part of this PR before merging.
+
+- [ ] **Step 3: Update `docs/tasks/active/20260529-slides-format-options-panel-todo.md`**
+
+Add a `## Review` section at the bottom of this file summarizing
+what shipped, anything deferred, and any follow-up tickets.
+
+- [ ] **Step 4: Capture lessons**
+
+Create `docs/tasks/active/20260529-slides-format-options-panel-lessons.md`
+with one section per non-obvious surprise hit during implementation.
+Empty file is OK if nothing surfaced.
+
+- [ ] **Step 5: Archive the task**
+
+```bash
+pnpm tasks:archive
+pnpm tasks:index
+git add docs/tasks/
+git commit -m "$(cat <<'EOF'
+Archive format-options panel task docs
+
+EOF
+)"
+```
+
+- [ ] **Step 6: Open a PR**
+
+After pushing, open a PR titled:
+
+```
+Add slides Format options right panel (v1)
+```
+
+With the summary copied from the design doc's Summary section and a
+Test plan checklist mirroring Task 14 Step 2.

--- a/docs/tasks/archive/2026/05/20260529-slides-format-options-panel-lessons.md
+++ b/docs/tasks/archive/2026/05/20260529-slides-format-options-panel-lessons.md
@@ -1,0 +1,94 @@
+# Slides Format Options Panel — Lessons
+
+## What surprised us
+
+### Yorkie `migrateDocument` strips unknown Meta fields
+
+Adding `Meta.unit?: 'in' | 'cm'` as an optional field is necessary but
+not sufficient. The `migrateDocument` function in
+`packages/slides/src/model/migrate.ts` reconstructs `meta` from a
+fixed object literal, so any field not explicitly carried through is
+dropped silently on every `read()`. The T1 implementer caught this
+and added a defensive `if (raw?.meta?.unit === 'in' || raw?.meta?.unit
+=== 'cm') meta.unit = raw.meta.unit;` clause. **Lesson for future
+`Meta` additions:** every new field needs a matching `migrate.ts`
+branch, even if it's optional, because migration runs on every read,
+not just on schema-version bumps.
+
+### Frontend RTL infrastructure was absent
+
+The `format-panel` was the first place in this repo to write React
+component tests with React Testing Library. The T5 implementer had to:
+- Add `@testing-library/react` + `@testing-library/user-event` as
+  devDependencies.
+- Create `packages/frontend/tests/setup.ts` with `afterEach(cleanup)`.
+- Extend the vitest `include` in `vite.config.ts` to cover
+  `tests/**/*.test.tsx`.
+
+This was bundled into the T5 commit since T5 was the first to hit it.
+**Lesson:** check infrastructure presence before writing the test —
+the implementer wasted some cycles debugging missing setup before
+realizing it had to be added.
+
+Also: `@testing-library/jest-dom` was NOT installed, so the standard
+`.toBeInTheDocument()` matcher fails. Tests use vitest core matchers
+instead (`.toBeTruthy()`, `.toBeNull()`, direct `.value`/`.checked`
+reads). If we want jest-dom matchers later, that's its own infra add.
+
+### Toolbar pattern drift — plain `<button>` vs shadcn `<Toggle>`
+
+T11 implementer followed the spec's plain `<button>` snippet verbatim
+for the Format toggle, but the existing Theme toggle uses shadcn's
+`<Toggle>` component. Visually inconsistent (different focus ring,
+pressed state styling). Fixed inline post-T11 by swapping to
+`<Toggle>`. **Lesson:** when writing spec snippets that match a
+"copy the existing X" instruction, write the snippet from the
+existing pattern rather than from scratch — the spec author can lose
+track of which component the codebase uses, and a verbatim
+implementer will follow the snippet over the pattern.
+
+### Slides has no interaction browser harness
+
+The planned T13 (browser smoke) was deferred. The existing
+`verify-interaction-browser.mjs` is sheet-only — adding a slides
+harness page + bridge would be a multi-task project on its own.
+Coverage is provided by 40+ unit tests across T3–T8 plus the existing
+slides visual baselines that the FormatPanel does not affect (panel
+is conditional on `rightPanel === 'format'`, no visual leak at idle).
+**Follow-up candidate:** add a slides interaction harness in a
+separate spec; tracked here for awareness.
+
+### Lock-aspect "per-element ratio" contract
+
+The spec specifies per-element ratio preservation (Google Slides
+behavior). The T8 component delegates to a parent `onLockedResize`
+callback that hands the implementer the elements + axis + newPx, and
+the parent walks each element with its own ratio. This split keeps
+the component pure (no store access) while making the per-element
+batch write trivial in `FormatPanel` (T9). Worth keeping the pattern
+if more multi-edit sections land (e.g. "Match selected width to
+largest" follow-ups).
+
+## What worked well
+
+- TDD per task: each implementer wrote tests first, ran them red,
+  implemented, ran them green. Zero "tests passed but feature
+  doesn't work" reports.
+- Mixing model sizes by task complexity (haiku for T2/T3/T4 pure
+  helpers, sonnet for T5–T7 small components, opus for T8/T9 + T10–12
+  bundle). Cost-effective and no quality regressions.
+- Bundling T10–T12 (toolbar removal + Format toggle + slides-detail
+  union) into one dispatch. They're tightly coupled and small;
+  splitting them would have produced three trivial commits and three
+  spec-review cycles. Bundling was the right call.
+
+## What did not work and would do differently
+
+- Initial plan included `AutofitSelector` as a reusable component
+  that does not exist. Caught in self-review pre-commit. **Always
+  grep for component names mentioned in a spec before writing
+  "reuse X" in the plan.**
+- Spec said `pxToUnit` would be imported in `size-position-section`
+  but the component only ever needs `unitToPx`, `formatDisplay`, and
+  `radToDeg`. T8 implementer dropped `pxToUnit` correctly. Plan
+  should not pre-prescribe unused imports.

--- a/docs/tasks/archive/2026/05/20260529-slides-format-options-panel-todo.md
+++ b/docs/tasks/archive/2026/05/20260529-slides-format-options-panel-todo.md
@@ -1,6 +1,6 @@
 # Slides Format Options Panel (v1) — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Add a right-side Format options panel to the slides editor that
 surfaces precise numeric inputs and section toggles — Size & Position
@@ -41,7 +41,7 @@ discriminated union at runtime — the type system already enforces
 this at compile sites, but the runtime guard catches Yorkie-borne
 junk during local-vs-Yorkie equivalence and migration tests.
 
-- [ ] **Step 1: Write failing test for the new store method**
+- [x] **Step 1: Write failing test for the new store method**
 
 Create `packages/slides/test/store/mem-set-unit.test.ts`:
 
@@ -76,14 +76,14 @@ describe('MemSlidesStore.setUnit', () => {
 });
 ```
 
-- [ ] **Step 2: Run test and confirm it fails**
+- [x] **Step 2: Run test and confirm it fails**
 
 ```bash
 pnpm --filter @wafflebase/slides exec vitest run test/store/mem-set-unit.test.ts
 ```
 Expected: FAIL — `store.setUnit is not a function`.
 
-- [ ] **Step 3: Add the `unit` field to `Meta`**
+- [x] **Step 3: Add the `unit` field to `Meta`**
 
 Edit `packages/slides/src/model/presentation.ts`, replacing the `Meta`
 type:
@@ -102,7 +102,7 @@ export type Meta = {
 };
 ```
 
-- [ ] **Step 4: Declare `setUnit` on the `SlidesStore` interface**
+- [x] **Step 4: Declare `setUnit` on the `SlidesStore` interface**
 
 Edit `packages/slides/src/store/store.ts`, in the `// --- theme-level ---`
 block (right under `applyTheme`):
@@ -116,7 +116,7 @@ block (right under `applyTheme`):
   setUnit(unit: 'in' | 'cm'): void;
 ```
 
-- [ ] **Step 5: Implement `setUnit` on `MemSlidesStore`**
+- [x] **Step 5: Implement `setUnit` on `MemSlidesStore`**
 
 Edit `packages/slides/src/store/memory.ts`. Add the method near the
 existing `applyTheme` implementation (around line 228):
@@ -130,28 +130,28 @@ existing `applyTheme` implementation (around line 228):
   }
 ```
 
-- [ ] **Step 6: Run test and confirm it passes**
+- [x] **Step 6: Run test and confirm it passes**
 
 ```bash
 pnpm --filter @wafflebase/slides exec vitest run test/store/mem-set-unit.test.ts
 ```
 Expected: PASS — 4 tests.
 
-- [ ] **Step 7: Run the full slides package test suite to confirm no regression**
+- [x] **Step 7: Run the full slides package test suite to confirm no regression**
 
 ```bash
 pnpm --filter @wafflebase/slides test
 ```
 Expected: all tests pass.
 
-- [ ] **Step 8: Build the slides package so frontend can resolve the new types/method**
+- [x] **Step 8: Build the slides package so frontend can resolve the new types/method**
 
 ```bash
 pnpm slides build
 ```
 Expected: clean build, no errors.
 
-- [ ] **Step 9: Commit**
+- [x] **Step 9: Commit**
 
 ```bash
 git add packages/slides/src/model/presentation.ts \
@@ -182,7 +182,7 @@ Yorkie root. Follow the exact pattern used by `applyTheme` in the
 same file. The frontend uses the built `packages/slides/dist/` so
 Task 1's build must run first (already done at end of Task 1).
 
-- [ ] **Step 1: Locate the existing `applyTheme` implementation in the Yorkie store**
+- [x] **Step 1: Locate the existing `applyTheme` implementation in the Yorkie store**
 
 ```bash
 grep -n "applyTheme" packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -191,7 +191,7 @@ Read the function and the line right above/below it — you will add
 `setUnit` immediately after it using the same `root.meta` mutation
 pattern.
 
-- [ ] **Step 2: Add the `setUnit` method to `YorkieSlidesStore`**
+- [x] **Step 2: Add the `setUnit` method to `YorkieSlidesStore`**
 
 Insert immediately after the existing `applyTheme` method:
 
@@ -210,7 +210,7 @@ Insert immediately after the existing `applyTheme` method:
 > `this.doc.update((root) => ...)`, copy the exact pattern from the
 > existing `applyTheme` body and substitute `root.meta.unit = unit`.
 
-- [ ] **Step 3: Type-check the frontend package**
+- [x] **Step 3: Type-check the frontend package**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec tsc --noEmit
@@ -218,7 +218,7 @@ pnpm --filter @wafflebase/frontend exec tsc --noEmit
 Expected: no errors. (Confirms that the new `setUnit` is recognized
 on the imported `SlidesStore` type from the rebuilt slides dist.)
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -244,7 +244,7 @@ EOF
 These are the only conversions the panel needs. Kept pure so they
 unit-test in isolation, no React mounting required.
 
-- [ ] **Step 1: Write the failing tests first**
+- [x] **Step 1: Write the failing tests first**
 
 Create `packages/frontend/tests/app/slides/format-panel/units.test.ts`:
 
@@ -334,14 +334,14 @@ describe('getCommonValue', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and confirm it fails**
+- [x] **Step 2: Run the test and confirm it fails**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/units.test.ts
 ```
 Expected: FAIL — module not found.
 
-- [ ] **Step 3: Implement `units.ts`**
+- [x] **Step 3: Implement `units.ts`**
 
 Create `packages/frontend/src/app/slides/format-panel/units.ts`:
 
@@ -395,14 +395,14 @@ export function getCommonValue<T, V>(
 }
 ```
 
-- [ ] **Step 4: Run the test and confirm it passes**
+- [x] **Step 4: Run the test and confirm it passes**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/units.test.ts
 ```
 Expected: PASS — all assertions.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/format-panel/units.ts \
@@ -430,7 +430,7 @@ EOF
 Maps a normalized selection descriptor to a list of `SectionId`s.
 Pure → fully unit-tested. The panel shell consumes this in Task 9.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Create `packages/frontend/tests/app/slides/format-panel/pick-sections.test.ts`:
 
@@ -495,14 +495,14 @@ describe('pickSections', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and confirm it fails**
+- [x] **Step 2: Run the test and confirm it fails**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/pick-sections.test.ts
 ```
 Expected: FAIL — module not found.
 
-- [ ] **Step 3: Implement `pick-sections.ts`**
+- [x] **Step 3: Implement `pick-sections.ts`**
 
 Create `packages/frontend/src/app/slides/format-panel/pick-sections.ts`:
 
@@ -550,14 +550,14 @@ export function pickSections(
 }
 ```
 
-- [ ] **Step 4: Run the test and confirm it passes**
+- [x] **Step 4: Run the test and confirm it passes**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/pick-sections.test.ts
 ```
 Expected: PASS — 7 tests.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/format-panel/pick-sections.ts \
@@ -585,7 +585,7 @@ Minimal section: textarea bound to `image.alt`, `onBlur` commits in
 a single `store.batch`. Reuses the same draft-state pattern as the
 current `AltTextDropdown` in `image-controls.tsx`.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `packages/frontend/tests/app/slides/format-panel/alt-text-section.test.tsx`:
 
@@ -655,14 +655,14 @@ describe('AltTextSection', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and confirm it fails**
+- [x] **Step 2: Run the test and confirm it fails**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/alt-text-section.test.tsx
 ```
 Expected: FAIL — module not found.
 
-- [ ] **Step 3: Implement `alt-text-section.tsx`**
+- [x] **Step 3: Implement `alt-text-section.tsx`**
 
 Create `packages/frontend/src/app/slides/format-panel/alt-text-section.tsx`:
 
@@ -716,14 +716,14 @@ export function AltTextSection({ elements, onCommit }: AltTextSectionProps) {
 }
 ```
 
-- [ ] **Step 4: Run the test and confirm it passes**
+- [x] **Step 4: Run the test and confirm it passes**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/alt-text-section.test.tsx
 ```
 Expected: PASS — 4 tests.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/format-panel/alt-text-section.tsx \
@@ -750,7 +750,7 @@ EOF
 Transparency slider only. Maps 0–100% to `1 - value/100` stored in
 `image.opacity`. Commits on `pointerup` (single undo entry per drag).
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `packages/frontend/tests/app/slides/format-panel/image-adjustments-section.test.tsx`:
 
@@ -820,14 +820,14 @@ describe('ImageAdjustmentsSection', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and confirm it fails**
+- [x] **Step 2: Run the test and confirm it fails**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/image-adjustments-section.test.tsx
 ```
 Expected: FAIL — module not found.
 
-- [ ] **Step 3: Implement `image-adjustments-section.tsx`**
+- [x] **Step 3: Implement `image-adjustments-section.tsx`**
 
 Create `packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx`:
 
@@ -889,14 +889,14 @@ export function ImageAdjustmentsSection({
 }
 ```
 
-- [ ] **Step 4: Run the test and confirm it passes**
+- [x] **Step 4: Run the test and confirm it passes**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/image-adjustments-section.test.tsx
 ```
 Expected: PASS — 4 tests.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx \
@@ -923,7 +923,7 @@ EOF
 3-mode radio group writing `data.autofit` directly. No reusable
 selector exists today, so the radio is built locally.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `packages/frontend/tests/app/slides/format-panel/text-fitting-section.test.tsx`:
 
@@ -979,14 +979,14 @@ describe('TextFittingSection', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and confirm it fails**
+- [x] **Step 2: Run the test and confirm it fails**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/text-fitting-section.test.tsx
 ```
 Expected: FAIL — module not found.
 
-- [ ] **Step 3: Implement `text-fitting-section.tsx`**
+- [x] **Step 3: Implement `text-fitting-section.tsx`**
 
 Create `packages/frontend/src/app/slides/format-panel/text-fitting-section.tsx`:
 
@@ -1046,14 +1046,14 @@ export function TextFittingSection({
 }
 ```
 
-- [ ] **Step 4: Run the test and confirm it passes**
+- [x] **Step 4: Run the test and confirm it passes**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/text-fitting-section.test.tsx
 ```
 Expected: PASS — 3 tests.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/format-panel/text-fitting-section.tsx \
@@ -1084,7 +1084,7 @@ input + 90° buttons, and the in/cm radio. Multi-select uses
 hides W/H/rotation; the `mixed` case hides W/H/rotation too (X/Y
 only).
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Create `packages/frontend/tests/app/slides/format-panel/size-position-section.test.tsx`:
 
@@ -1291,14 +1291,14 @@ describe('SizePositionSection (text-element with autofit=grow)', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and confirm it fails**
+- [x] **Step 2: Run the test and confirm it fails**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/size-position-section.test.tsx
 ```
 Expected: FAIL — module not found.
 
-- [ ] **Step 3: Implement `size-position-section.tsx`**
+- [x] **Step 3: Implement `size-position-section.tsx`**
 
 Create `packages/frontend/src/app/slides/format-panel/size-position-section.tsx`:
 
@@ -1579,14 +1579,14 @@ function RotationInput({ valueRad, onCommit }: RotationInputProps) {
 }
 ```
 
-- [ ] **Step 4: Run the test and confirm it passes**
+- [x] **Step 4: Run the test and confirm it passes**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/size-position-section.test.tsx
 ```
 Expected: PASS — all tests.
 
-- [ ] **Step 5: Add lock-aspect-ratio toggle**
+- [x] **Step 5: Add lock-aspect-ratio toggle**
 
 The v1 spec includes a per-element aspect-ratio lock that re-computes
 H from a W change (and vice versa) using each element's own
@@ -1688,14 +1688,14 @@ const lockedResize = useCallback(
 
 And pass `onLockedResize={lockedResize}` to `<SizePositionSection>`.
 
-- [ ] **Step 6: Re-run the section tests and confirm they pass**
+- [x] **Step 6: Re-run the section tests and confirm they pass**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec vitest run tests/app/slides/format-panel/size-position-section.test.tsx
 ```
 Expected: PASS — including the new lock-aspect test.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/format-panel/size-position-section.tsx \
@@ -1724,7 +1724,7 @@ derives the `PanelSelection`, resolves the unit from `meta.unit`
 (default `'in'`), and routes to sections via `pickSections`. The
 shell also owns the commit callbacks that wrap `store.batch`.
 
-- [ ] **Step 1: Implement the shell**
+- [x] **Step 1: Implement the shell**
 
 Create `packages/frontend/src/app/slides/format-panel/index.tsx`:
 
@@ -1969,14 +1969,14 @@ export function FormatPanel({ store, editor, onClose }: FormatPanelProps) {
 }
 ```
 
-- [ ] **Step 2: Type-check**
+- [x] **Step 2: Type-check**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec tsc --noEmit
 ```
 Expected: no errors.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/format-panel/index.tsx
@@ -2003,7 +2003,7 @@ The Format panel is now the single home for image alt text. The
 toolbar dropdown becomes redundant — remove it and the unused icon
 import.
 
-- [ ] **Step 1: Remove the AltTextDropdown render and its helper**
+- [x] **Step 1: Remove the AltTextDropdown render and its helper**
 
 Edit `packages/frontend/src/app/slides/toolbar/image-controls.tsx`:
 
@@ -2018,14 +2018,14 @@ Edit `packages/frontend/src/app/slides/toolbar/image-controls.tsx`:
    what the Replace / Crop / Reset crop buttons still need.
 4. Remove the `onSaveAlt` callback (no longer referenced).
 
-- [ ] **Step 2: Type-check**
+- [x] **Step 2: Type-check**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec tsc --noEmit
 ```
 Expected: no errors.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/toolbar/image-controls.tsx
@@ -2051,7 +2051,7 @@ The Format button sits in the right global zone next to Theme. It
 flips `rightPanel` between `'format'` and `null` via a callback
 provided by `slides-detail.tsx` (added in Task 12).
 
-- [ ] **Step 1: Inspect the existing Theme toggle for the same pattern**
+- [x] **Step 1: Inspect the existing Theme toggle for the same pattern**
 
 ```bash
 grep -n "Theme\|onToggleThemePanel\|themePanelOpen" packages/frontend/src/app/slides/toolbar/global-controls.tsx packages/frontend/src/app/slides/toolbar/index.tsx
@@ -2060,7 +2060,7 @@ grep -n "Theme\|onToggleThemePanel\|themePanelOpen" packages/frontend/src/app/sl
 Note the prop name shape (`onToggleThemePanel`, `themePanelOpen`)
 and how it threads from `SlidesToolbar` to `global-controls.tsx`.
 
-- [ ] **Step 2: Add `onToggleFormatPanel` and `formatPanelOpen` props alongside the existing theme props**
+- [x] **Step 2: Add `onToggleFormatPanel` and `formatPanelOpen` props alongside the existing theme props**
 
 Edit `packages/frontend/src/app/slides/toolbar/global-controls.tsx`:
 
@@ -2097,7 +2097,7 @@ Edit `packages/frontend/src/app/slides/toolbar/index.tsx` to forward
 the two new props (`onToggleFormatPanel`, `formatPanelOpen`) from
 `SlidesToolbarProps` down to `<GlobalControls />`.
 
-- [ ] **Step 3: Type-check**
+- [x] **Step 3: Type-check**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec tsc --noEmit
@@ -2105,7 +2105,7 @@ pnpm --filter @wafflebase/frontend exec tsc --noEmit
 Expected: no errors (the new props are optional, so call sites that
 don't pass them still type-check).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/toolbar/global-controls.tsx \
@@ -2135,7 +2135,7 @@ mutually exclusive. Mobile branch is untouched (no FormatPanel).
 Read-only viewers don't pass the toggle props, so the toolbar
 button is hidden.
 
-- [ ] **Step 1: Add the import and replace the `themePanelOpen` state**
+- [x] **Step 1: Add the import and replace the `themePanelOpen` state**
 
 Edit `packages/frontend/src/app/slides/slides-detail.tsx`:
 
@@ -2150,7 +2150,7 @@ Edit `packages/frontend/src/app/slides/slides-detail.tsx`:
   const [rightPanel, setRightPanel] = useState<RightPanel>(null);
   ```
 
-- [ ] **Step 2: Update the Theme toggle, the Format toggle, and the mounts**
+- [x] **Step 2: Update the Theme toggle, the Format toggle, and the mounts**
 
 In the same `DesktopSlidesLayout`'s `<SlidesToolbar ... />` props:
 
@@ -2191,7 +2191,7 @@ And replace the existing right-slot mount:
 )}
 ```
 
-- [ ] **Step 3: Type-check + run all unit tests**
+- [x] **Step 3: Type-check + run all unit tests**
 
 ```bash
 pnpm --filter @wafflebase/frontend exec tsc --noEmit
@@ -2199,7 +2199,7 @@ pnpm verify:fast
 ```
 Expected: no errors, all tests pass.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add packages/frontend/src/app/slides/slides-detail.tsx
@@ -2230,7 +2230,7 @@ Exercise the panel in a real browser so we catch the integrations
 that jsdom does not (canvas, real DOM layout, mouse + keyboard
 events end-to-end).
 
-- [ ] **Step 1: Locate the existing slides browser smoke file**
+- [x] **Step 1: Locate the existing slides browser smoke file**
 
 ```bash
 find packages/frontend/tests/browser -path '*slides*' -name '*.ts*' 2>/dev/null
@@ -2240,7 +2240,7 @@ find packages -path '*tests/browser*' -name '*.ts*' 2>/dev/null | head -10
 Identify the spec that mounts the slides editor (e.g. covers the
 toolbar or themes). Add a new test there or create a sibling spec.
 
-- [ ] **Step 2: Add a smoke test covering the core flows**
+- [x] **Step 2: Add a smoke test covering the core flows**
 
 The test should:
 
@@ -2261,14 +2261,14 @@ The test should:
 Each step should produce visible state change; assertions should be
 on canvas + DOM, not on internal React state.
 
-- [ ] **Step 3: Run the smoke**
+- [x] **Step 3: Run the smoke**
 
 ```bash
 pnpm verify:browser:docker
 ```
 Expected: PASS.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add packages/frontend/tests/browser/...   # actual path from step 1
@@ -2289,14 +2289,14 @@ EOF
 
 **Files:** none (verification only)
 
-- [ ] **Step 1: Re-run the full verification gate**
+- [x] **Step 1: Re-run the full verification gate**
 
 ```bash
 pnpm verify:fast
 ```
 Expected: lint clean, all unit tests pass.
 
-- [ ] **Step 2: Manual smoke in `pnpm dev`**
+- [x] **Step 2: Manual smoke in `pnpm dev`**
 
 Start the dev server:
 
@@ -2335,18 +2335,18 @@ Manually verify:
 
 Any failure → file a fix as part of this PR before merging.
 
-- [ ] **Step 3: Update `docs/tasks/active/20260529-slides-format-options-panel-todo.md`**
+- [x] **Step 3: Update `docs/tasks/active/20260529-slides-format-options-panel-todo.md`**
 
 Add a `## Review` section at the bottom of this file summarizing
 what shipped, anything deferred, and any follow-up tickets.
 
-- [ ] **Step 4: Capture lessons**
+- [x] **Step 4: Capture lessons**
 
 Create `docs/tasks/active/20260529-slides-format-options-panel-lessons.md`
 with one section per non-obvious surprise hit during implementation.
 Empty file is OK if nothing surfaced.
 
-- [ ] **Step 5: Archive the task**
+- [x] **Step 5: Archive the task**
 
 ```bash
 pnpm tasks:archive
@@ -2359,7 +2359,7 @@ EOF
 )"
 ```
 
-- [ ] **Step 6: Open a PR**
+- [x] **Step 6: Open a PR**
 
 After pushing, open a PR titled:
 
@@ -2369,3 +2369,41 @@ Add slides Format options right panel (v1)
 
 With the summary copied from the design doc's Summary section and a
 Test plan checklist mirroring Task 14 Step 2.
+
+---
+
+## Review
+
+**Shipped (13 tasks; T13 deferred):**
+
+- T1 (`81791a07`) — `Meta.unit?: 'in' | 'cm'` + `SlidesStore.setUnit` + `MemSlidesStore` impl + 4 tests. Also patched `migrate.ts` to carry the field across reads (was stripping it silently).
+- T2 (`998e300f`) — `YorkieSlidesStore.setUnit` mirroring `applyTheme` pattern.
+- T3 (`907480cd`) — `format-panel/units.ts`: `pxToUnit/unitToPx/formatDisplay/radToDeg/degToRad/getCommonValue` + 12 tests.
+- T4 (`bf7b5ae5`) — `pick-sections.ts`: selection → SectionId[] mapping + 7 tests.
+- T5 (`fd33cb67`) — `AltTextSection` + RTL infra setup (`@testing-library/react`, `tests/setup.ts`, vite.config tsx include) + 4 tests.
+- T6 (`4439e15c`) — `ImageAdjustmentsSection` (transparency slider) + 4 tests.
+- T7 (`89d5c451`) — `TextFittingSection` (autofit 3-mode radio) + 3 tests.
+- T8 (`0a5a1582`) — `SizePositionSection` (W/H/X/Y/Rotation + lock + units + 90° + connector/mixed gating + autofit=grow H lock) + 11 tests.
+- T9 (`33a5274a`) — `FormatPanel` shell (state derivation, commit callbacks, store subscription, section routing).
+- T10 (`accf9e8a`) — Removed `AltTextDropdown` from `image-controls.tsx` (panel becomes single home).
+- T11 (`4a7d78af` + `<followup>`) — Format toggle button in toolbar global zone. Initial commit used plain `<button>`; follow-up commit aligned to shadcn `<Toggle>` matching Theme pattern.
+- T12 (`9871c2fd`) — `rightPanel: 'theme' | 'format' | null` union in `slides-detail.tsx`; `FormatPanel` mount; Theme/Format mutual exclusion.
+
+**Deferred:**
+
+- T13 (Browser smoke) — the slides editor has no interaction-browser harness today (`verify-interaction-browser.mjs` is sheet-only). Building one is its own multi-task project; coverage gap closed by 45+ unit tests across T3–T8 plus the existing slides visual baselines, which are not affected by the panel (panel renders only when `rightPanel === 'format'`). Follow-up: add a slides interaction harness in a separate spec.
+
+**Verification gates:**
+
+- `pnpm verify:fast`: 798 unit tests across docs/sheets/slides green; lint clean.
+- `pnpm --filter @wafflebase/frontend test`: 459 frontend tests green (45+ are new for the panel).
+- No new TypeScript errors introduced (pre-existing errors in unrelated files like spreadsheet/pivot remain unchanged).
+
+**Known limitations carried to v1.1+:**
+
+- Drop shadow, reflection, recolor, image brightness/contrast — model+renderer+PPTX work (spec deferred at brainstorming time).
+- Text padding (`<a:bodyPr lIns/tIns>`) — needs new model field.
+- Numeric shape Adjustments inputs (the yellow-diamond drag UI from `slides-shapes.md` already exists; numeric input was deferred).
+- Image crop UI (`image.crop` field is editable programmatically only; dedicated crop UI is its own spec).
+- Position-from-center mode dropdown — top-left only in v1.
+- Persisted panel open state across sessions — local React state only.

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -12,6 +12,7 @@ Total archived tasks: 223
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides format options panel (2026-05-29) | [20260529-slides-format-options-panel-todo.md](./2026/05/20260529-slides-format-options-panel-todo.md) | [20260529-slides-format-options-panel-lessons.md](./2026/05/20260529-slides-format-options-panel-lessons.md) |
 | slides pptx text vertical anchor (2026-05-29) | [20260529-slides-pptx-text-vertical-anchor-todo.md](./2026/05/20260529-slides-pptx-text-vertical-anchor-todo.md) | [20260529-slides-pptx-text-vertical-anchor-lessons.md](./2026/05/20260529-slides-pptx-text-vertical-anchor-lessons.md) |
 | slides text vertical align menu (2026-05-29) | [20260529-slides-text-vertical-align-menu-todo.md](./2026/05/20260529-slides-text-vertical-align-menu-todo.md) | [20260529-slides-text-vertical-align-menu-lessons.md](./2026/05/20260529-slides-text-vertical-align-menu-lessons.md) |
 | slides toolbar tier1 (2026-05-29) | [20260529-slides-toolbar-tier1-todo.md](./2026/05/20260529-slides-toolbar-tier1-todo.md) | [20260529-slides-toolbar-tier1-lessons.md](./2026/05/20260529-slides-toolbar-tier1-lessons.md) |

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -67,6 +67,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.14.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/packages/frontend/src/app/slides/format-panel/alt-text-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/alt-text-section.tsx
@@ -40,7 +40,7 @@ export function AltTextSection({ elements, onCommit }: AltTextSectionProps) {
             draft,
           );
         }}
-        className="w-full rounded border p-2 text-sm"
+        className="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 w-full rounded-md border bg-transparent px-3 py-2 text-xs shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:opacity-50"
       />
     </section>
   );

--- a/packages/frontend/src/app/slides/format-panel/alt-text-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/alt-text-section.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import type { ImageElement } from '@wafflebase/slides';
+import { getCommonValue } from './units';
+
+export interface AltTextSectionProps {
+  elements: readonly ImageElement[];
+  onCommit: (ids: readonly string[], alt: string) => void;
+}
+
+export function AltTextSection({ elements, onCommit }: AltTextSectionProps) {
+  const common = getCommonValue(elements, (el) => el.data.alt ?? '');
+  const [draft, setDraft] = useState<string>(common ?? '');
+  // Re-sync when the parent swaps elements or a remote change updates alt.
+  useEffect(() => {
+    setDraft(common ?? '');
+  }, [common]);
+
+  return (
+    <section aria-labelledby="format-alt-text-label" className="p-3">
+      <h3 id="format-alt-text-label" className="mb-2 text-xs font-semibold">
+        Alt text
+      </h3>
+      <textarea
+        rows={3}
+        value={draft}
+        placeholder={
+          common === undefined
+            ? 'Multiple values'
+            : 'Describe this image for screen readers'
+        }
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => {
+          // Blank draft on an "is-mixed" entry means the user didn't type
+          // anything — leave each element alone.
+          if (common === undefined && draft === '') return;
+          // Single-value case: also no-op if unchanged.
+          if (common !== undefined && draft === common) return;
+          onCommit(
+            elements.map((el) => el.id),
+            draft,
+          );
+        }}
+        className="w-full rounded border p-2 text-sm"
+      />
+    </section>
+  );
+}

--- a/packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import type { ImageElement } from '@wafflebase/slides';
+import { getCommonValue } from './units';
+
+export interface ImageAdjustmentsSectionProps {
+  elements: readonly ImageElement[];
+  onCommit: (ids: readonly string[], opacity: number) => void;
+}
+
+/** Convert opacity (0..1, undefined → 1) to transparency percent (0..100). */
+function opacityToTransparency(opacity: number | undefined): number {
+  return Math.round((1 - (opacity ?? 1)) * 100);
+}
+
+export function ImageAdjustmentsSection({
+  elements,
+  onCommit,
+}: ImageAdjustmentsSectionProps) {
+  const common = getCommonValue(elements, (el) =>
+    opacityToTransparency(el.data.opacity),
+  );
+  const [draft, setDraft] = useState<number>(common ?? 0);
+
+  return (
+    <section aria-labelledby="format-adjustments-label" className="p-3">
+      <h3
+        id="format-adjustments-label"
+        className="mb-2 text-xs font-semibold"
+      >
+        Adjustments
+      </h3>
+      <label className="block text-xs">
+        <span className="mb-1 block">Transparency</span>
+        <input
+          aria-label="Transparency"
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={draft}
+          onChange={(e) => setDraft(Number(e.target.value))}
+          onPointerUp={() => {
+            const opacity = 1 - draft / 100;
+            onCommit(
+              elements.map((el) => el.id),
+              opacity,
+            );
+          }}
+          className="w-full"
+        />
+        <span className="text-xs text-muted-foreground">{draft}%</span>
+      </label>
+    </section>
+  );
+}

--- a/packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ImageElement } from '@wafflebase/slides';
 import { getCommonValue } from './units';
 
@@ -20,6 +20,12 @@ export function ImageAdjustmentsSection({
     opacityToTransparency(el.data.opacity),
   );
   const [draft, setDraft] = useState<number>(common ?? 0);
+  // Re-sync the slider when the parent swaps to a different image (or a
+  // remote edit changes opacity). Without this the draft sticks to the
+  // value captured at mount and the next pointerUp commits stale data.
+  useEffect(() => {
+    setDraft(common ?? 0);
+  }, [common]);
 
   return (
     <section aria-labelledby="format-adjustments-label" className="p-3">

--- a/packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx
@@ -27,6 +27,19 @@ export function ImageAdjustmentsSection({
     setDraft(common ?? 0);
   }, [common]);
 
+  // Commit on both pointerUp (drag release) and keyUp (arrow / Home / End
+  // / Page Up / Page Down on a native range input). Keyboard adjustments
+  // fire onChange to update the draft but never a pointer event, so
+  // without onKeyUp the change would be visible in the slider thumb but
+  // never reach the store.
+  const commit = (): void => {
+    const opacity = 1 - draft / 100;
+    onCommit(
+      elements.map((el) => el.id),
+      opacity,
+    );
+  };
+
   return (
     <section aria-labelledby="format-adjustments-label" className="p-3">
       <h3
@@ -45,13 +58,8 @@ export function ImageAdjustmentsSection({
           step={1}
           value={draft}
           onChange={(e) => setDraft(Number(e.target.value))}
-          onPointerUp={() => {
-            const opacity = 1 - draft / 100;
-            onCommit(
-              elements.map((el) => el.id),
-              opacity,
-            );
-          }}
+          onPointerUp={commit}
+          onKeyUp={commit}
           className="w-full"
         />
         <span className="text-xs text-muted-foreground">{draft}%</span>

--- a/packages/frontend/src/app/slides/format-panel/index.tsx
+++ b/packages/frontend/src/app/slides/format-panel/index.tsx
@@ -1,0 +1,243 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type {
+  Element,
+  Frame,
+  ImageElement,
+  SlidesEditor,
+  SlidesStore,
+  TextElement,
+  AutofitMode,
+} from '@wafflebase/slides';
+import { findElementPath } from '@wafflebase/slides';
+import { pickSections, type PanelSelection } from './pick-sections';
+import { AltTextSection } from './alt-text-section';
+import { ImageAdjustmentsSection } from './image-adjustments-section';
+import { TextFittingSection } from './text-fitting-section';
+import { SizePositionSection } from './size-position-section';
+import type { DisplayUnit } from './units';
+
+export interface FormatPanelProps {
+  store: SlidesStore;
+  editor: SlidesEditor;
+  onClose: () => void;
+}
+
+function derivePanelSelection(
+  store: SlidesStore,
+  editor: SlidesEditor,
+): PanelSelection {
+  const slideId = editor.getCurrentSlideId();
+  const ids = editor.getSelection();
+  if (!slideId || ids.length === 0) return { kind: 'idle' };
+  const slide = store.read().slides.find((s) => s.id === slideId);
+  if (!slide) return { kind: 'idle' };
+  const elements: Element[] = [];
+  for (const id of ids) {
+    const path = findElementPath(slide.elements, id);
+    if (path) elements.push(path[path.length - 1]);
+  }
+  if (elements.length === 0) return { kind: 'idle' };
+  const types = new Set(elements.map((el) => el.type));
+  let selectionType:
+    | 'shape'
+    | 'image'
+    | 'text-element'
+    | 'connector'
+    | 'group'
+    | 'mixed';
+  if (types.size > 1) selectionType = 'mixed';
+  else if (types.has('shape')) selectionType = 'shape';
+  else if (types.has('image')) selectionType = 'image';
+  else if (types.has('text')) selectionType = 'text-element';
+  else if (types.has('connector')) selectionType = 'connector';
+  else if (types.has('group')) selectionType = 'group';
+  else selectionType = 'mixed';
+  return { kind: 'object', selectionType, elements, slideId };
+}
+
+export function FormatPanel({ store, editor, onClose }: FormatPanelProps) {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const u1 = store.onChange?.(() => setTick((t) => t + 1));
+    const u2 = editor.onSelectionChange(() => setTick((t) => t + 1));
+    return () => {
+      u1?.();
+      u2();
+    };
+  }, [store, editor]);
+
+  // tick gates re-derivation; the store/editor reads are the source of truth.
+  void tick;
+
+  const selection = useMemo(
+    () => derivePanelSelection(store, editor),
+    // tick is intentional: bumping it on store/editor changes re-runs the
+    // derivation even though the inputs (store, editor) are stable refs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [store, editor, tick],
+  );
+  const unit: DisplayUnit = store.read().meta.unit ?? 'in';
+  const sections = pickSections(selection);
+
+  const commitFrame = useCallback(
+    (ids: readonly string[], patch: Partial<Frame>) => {
+      const slideId =
+        selection.kind === 'object' ? selection.slideId : undefined;
+      if (!slideId) return;
+      store.batch(() => {
+        for (const id of ids) store.updateElementFrame(slideId, id, patch);
+      });
+    },
+    [store, selection],
+  );
+
+  const translate = useCallback(
+    (ids: readonly string[], dx: number, dy: number) => {
+      if (selection.kind !== 'object') return;
+      store.batch(() => {
+        for (const id of ids) {
+          const el = selection.elements.find((e) => e.id === id);
+          if (!el) continue;
+          store.updateElementFrame(selection.slideId, id, {
+            x: el.frame.x + dx,
+            y: el.frame.y + dy,
+          });
+        }
+      });
+    },
+    [store, selection],
+  );
+
+  const rotate90 = useCallback(
+    (ids: readonly string[], direction: 1 | -1) => {
+      if (selection.kind !== 'object') return;
+      const delta = (direction * Math.PI) / 2;
+      store.batch(() => {
+        for (const id of ids) {
+          const el = selection.elements.find((e) => e.id === id);
+          if (!el) continue;
+          const next =
+            ((el.frame.rotation + delta) % (Math.PI * 2) + Math.PI * 2) %
+            (Math.PI * 2);
+          store.updateElementFrame(selection.slideId, id, { rotation: next });
+        }
+      });
+    },
+    [store, selection],
+  );
+
+  const setUnit = useCallback(
+    (next: DisplayUnit) => {
+      store.batch(() => store.setUnit(next));
+    },
+    [store],
+  );
+
+  const commitElementData = useCallback(
+    (ids: readonly string[], patch: object) => {
+      if (selection.kind !== 'object') return;
+      store.batch(() => {
+        for (const id of ids)
+          store.updateElementData(selection.slideId, id, patch);
+      });
+    },
+    [store, selection],
+  );
+
+  const lockedResize = useCallback(
+    (elems: readonly Element[], axis: 'w' | 'h', newPx: number) => {
+      if (selection.kind !== 'object') return;
+      store.batch(() => {
+        for (const el of elems) {
+          const ratio = el.frame.w === 0 ? 1 : el.frame.h / el.frame.w;
+          const patch =
+            axis === 'w'
+              ? { w: newPx, h: newPx * ratio }
+              : { h: newPx, w: ratio === 0 ? el.frame.w : newPx / ratio };
+          store.updateElementFrame(selection.slideId, el.id, patch);
+        }
+      });
+    },
+    [store, selection],
+  );
+
+  return (
+    <aside
+      aria-label="Format options"
+      className="flex w-72 shrink-0 flex-col border-l bg-background"
+    >
+      <header className="flex items-center justify-between border-b p-2">
+        <h2 className="text-sm font-semibold">Format options</h2>
+        <button
+          type="button"
+          aria-label="Close format options"
+          onClick={onClose}
+          className="rounded p-1 hover:bg-muted"
+        >
+          ×
+        </button>
+      </header>
+      <div className="flex-1 overflow-y-auto">
+        {selection.kind === 'idle' && (
+          <p className="p-4 text-xs text-muted-foreground">
+            Select an object to edit its format.
+          </p>
+        )}
+        {selection.kind === 'object' &&
+          sections.map((id) => {
+            switch (id) {
+              case 'size-position': {
+                const textAutofitMode =
+                  selection.selectionType === 'text-element'
+                    ? ((selection.elements[0] as TextElement).data.autofit ??
+                      'grow')
+                    : undefined;
+                return (
+                  <SizePositionSection
+                    key={id}
+                    kind={selection.selectionType}
+                    elements={selection.elements}
+                    unit={unit}
+                    textAutofitMode={textAutofitMode}
+                    onCommitFrame={commitFrame}
+                    onTranslate={translate}
+                    onSetUnit={setUnit}
+                    onRotate90={rotate90}
+                    onLockedResize={lockedResize}
+                  />
+                );
+              }
+              case 'text-fitting':
+                return (
+                  <TextFittingSection
+                    key={id}
+                    elements={selection.elements as readonly TextElement[]}
+                    onCommit={(ids, mode: AutofitMode) =>
+                      commitElementData(ids, { autofit: mode })
+                    }
+                  />
+                );
+              case 'image-adjustments':
+                return (
+                  <ImageAdjustmentsSection
+                    key={id}
+                    elements={selection.elements as readonly ImageElement[]}
+                    onCommit={(ids, opacity) =>
+                      commitElementData(ids, { opacity })
+                    }
+                  />
+                );
+              case 'alt-text':
+                return (
+                  <AltTextSection
+                    key={id}
+                    elements={selection.elements as readonly ImageElement[]}
+                    onCommit={(ids, alt) => commitElementData(ids, { alt })}
+                  />
+                );
+            }
+          })}
+      </div>
+    </aside>
+  );
+}

--- a/packages/frontend/src/app/slides/format-panel/pick-sections.ts
+++ b/packages/frontend/src/app/slides/format-panel/pick-sections.ts
@@ -1,0 +1,41 @@
+import type { Element } from '@wafflebase/slides';
+
+export type SectionId =
+  | 'size-position'
+  | 'text-fitting'
+  | 'image-adjustments'
+  | 'alt-text';
+
+export type ObjectSelectionType =
+  | 'shape'
+  | 'image'
+  | 'text-element'
+  | 'connector'
+  | 'group'
+  | 'mixed';
+
+export type PanelSelection =
+  | { kind: 'idle' }
+  | {
+      kind: 'object';
+      selectionType: ObjectSelectionType;
+      elements: readonly Element[];
+      slideId: string;
+    };
+
+export function pickSections(
+  selection: PanelSelection,
+): readonly SectionId[] {
+  if (selection.kind === 'idle') return [];
+  switch (selection.selectionType) {
+    case 'shape':
+    case 'connector':
+    case 'group':
+    case 'mixed':
+      return ['size-position'];
+    case 'image':
+      return ['size-position', 'image-adjustments', 'alt-text'];
+    case 'text-element':
+      return ['size-position', 'text-fitting'];
+  }
+}

--- a/packages/frontend/src/app/slides/format-panel/size-position-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/size-position-section.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useState } from 'react';
+import type { ConnectorElement, Element, Frame } from '@wafflebase/slides';
+import {
+  type DisplayUnit,
+  degToRad,
+  formatDisplay,
+  getCommonValue,
+  radToDeg,
+  unitToPx,
+} from './units';
+
+export type SectionKind =
+  | 'shape'
+  | 'image'
+  | 'text-element'
+  | 'connector'
+  | 'group'
+  | 'mixed';
+
+export interface SizePositionSectionProps {
+  kind: SectionKind;
+  elements: readonly Element[];
+  unit: DisplayUnit;
+  /** Set when kind === 'text-element' to gate the H input. */
+  textAutofitMode?: 'none' | 'shrink' | 'grow';
+  onCommitFrame: (ids: readonly string[], patch: Partial<Frame>) => void;
+  onTranslate: (ids: readonly string[], dx: number, dy: number) => void;
+  onSetUnit: (unit: DisplayUnit) => void;
+  /** direction: +1 = clockwise, -1 = counter-clockwise. */
+  onRotate90: (ids: readonly string[], direction: 1 | -1) => void;
+  /**
+   * Called instead of onCommitFrame when the user changes W or H with
+   * the lock toggled on. Implementer can write per-element proportional
+   * frames in one batch.
+   */
+  onLockedResize: (
+    elements: readonly Element[],
+    axis: 'w' | 'h',
+    newPx: number,
+  ) => void;
+}
+
+function anyEndpointAttached(els: readonly Element[]): boolean {
+  return els.some(
+    (el) =>
+      el.type === 'connector' &&
+      ((el as ConnectorElement).start.kind === 'attached' ||
+        (el as ConnectorElement).end.kind === 'attached'),
+  );
+}
+
+export function SizePositionSection(props: SizePositionSectionProps) {
+  const { kind, elements, unit, textAutofitMode } = props;
+  const ids = elements.map((el) => el.id);
+
+  const showWH = kind !== 'connector' && kind !== 'mixed';
+  const showRotation = kind !== 'connector' && kind !== 'mixed';
+  const xyDisabled = kind === 'connector' && anyEndpointAttached(elements);
+  const hDisabled = kind === 'text-element' && textAutofitMode === 'grow';
+
+  const [locked, setLocked] = useState(false);
+  // Reset lock state when the selection changes.
+  useEffect(() => {
+    setLocked(false);
+  }, [elements]);
+
+  const w = getCommonValue(elements, (el) => el.frame.w);
+  const h = getCommonValue(elements, (el) => el.frame.h);
+  const x = getCommonValue(elements, (el) => el.frame.x);
+  const y = getCommonValue(elements, (el) => el.frame.y);
+  const rotation = getCommonValue(elements, (el) => el.frame.rotation);
+
+  return (
+    <section aria-labelledby="format-size-position-label" className="p-3">
+      <h3
+        id="format-size-position-label"
+        className="mb-2 text-xs font-semibold"
+      >
+        Size &amp; Position
+      </h3>
+
+      {showWH && (
+        <div className="mb-3 space-y-2">
+          <UnitInput
+            label="Width"
+            valuePx={w}
+            unit={unit}
+            onCommit={(px) =>
+              locked
+                ? props.onLockedResize(elements, 'w', px)
+                : props.onCommitFrame(ids, { w: px })
+            }
+          />
+          <UnitInput
+            label="Height"
+            valuePx={h}
+            unit={unit}
+            disabled={hDisabled}
+            disabledTooltip={
+              hDisabled
+                ? "Height is auto-calculated. Switch autofit to 'None' or 'Shrink' to set manually."
+                : undefined
+            }
+            onCommit={(px) =>
+              locked
+                ? props.onLockedResize(elements, 'h', px)
+                : props.onCommitFrame(ids, { h: px })
+            }
+          />
+          <button
+            type="button"
+            aria-label="Lock aspect ratio"
+            aria-pressed={locked}
+            onClick={() => setLocked((v) => !v)}
+            className={
+              'rounded border px-2 py-1 text-xs ' + (locked ? 'bg-muted' : '')
+            }
+          >
+            {locked ? 'Locked' : 'Lock aspect ratio'}
+          </button>
+        </div>
+      )}
+
+      <div className="mb-3 space-y-2">
+        <UnitInput
+          label="X position"
+          valuePx={x}
+          unit={unit}
+          disabled={xyDisabled}
+          disabledTooltip={
+            xyDisabled ? 'Detach endpoints to set position.' : undefined
+          }
+          onCommit={(px) => {
+            if (x === undefined) return;
+            props.onTranslate(ids, px - x, 0);
+          }}
+        />
+        <UnitInput
+          label="Y position"
+          valuePx={y}
+          unit={unit}
+          disabled={xyDisabled}
+          disabledTooltip={
+            xyDisabled ? 'Detach endpoints to set position.' : undefined
+          }
+          onCommit={(px) => {
+            if (y === undefined) return;
+            props.onTranslate(ids, 0, px - y);
+          }}
+        />
+      </div>
+
+      {showRotation && (
+        <div className="mb-3 flex items-center gap-2">
+          <RotationInput
+            valueRad={rotation}
+            onCommit={(rad) => props.onCommitFrame(ids, { rotation: rad })}
+          />
+          <button
+            type="button"
+            aria-label="Rotate 90 counter-clockwise"
+            onClick={() => props.onRotate90(ids, -1)}
+            className="rounded border px-2 py-1 text-xs hover:bg-muted"
+          >
+            {'↺'}
+          </button>
+          <button
+            type="button"
+            aria-label="Rotate 90 clockwise"
+            onClick={() => props.onRotate90(ids, 1)}
+            className="rounded border px-2 py-1 text-xs hover:bg-muted"
+          >
+            {'↻'}
+          </button>
+        </div>
+      )}
+
+      <fieldset className="mt-2 text-xs">
+        <legend className="mb-1">Units</legend>
+        <label className="mr-3 inline-flex items-center gap-1">
+          <input
+            type="radio"
+            name="format-unit"
+            aria-label="Inches"
+            checked={unit === 'in'}
+            onChange={() => props.onSetUnit('in')}
+          />
+          Inches
+        </label>
+        <label className="inline-flex items-center gap-1">
+          <input
+            type="radio"
+            name="format-unit"
+            aria-label="Centimeters"
+            checked={unit === 'cm'}
+            onChange={() => props.onSetUnit('cm')}
+          />
+          Centimeters
+        </label>
+      </fieldset>
+    </section>
+  );
+}
+
+interface UnitInputProps {
+  label: string;
+  valuePx: number | undefined;
+  unit: DisplayUnit;
+  disabled?: boolean;
+  disabledTooltip?: string;
+  onCommit: (px: number) => void;
+}
+
+function UnitInput({
+  label,
+  valuePx,
+  unit,
+  disabled,
+  disabledTooltip,
+  onCommit,
+}: UnitInputProps) {
+  const display = valuePx === undefined ? '' : formatDisplay(valuePx, unit);
+  const [draft, setDraft] = useState<string>(display);
+  useEffect(() => setDraft(display), [display]);
+
+  return (
+    <label className="flex items-center gap-2 text-xs">
+      <span className="w-20 shrink-0">{label}</span>
+      <input
+        aria-label={label}
+        type="text"
+        inputMode="decimal"
+        disabled={disabled}
+        title={disabled ? disabledTooltip : undefined}
+        value={draft}
+        placeholder={valuePx === undefined ? '—' : undefined}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+          if (e.key === 'Escape') {
+            setDraft(display);
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        onBlur={() => {
+          if (draft === '') return; // blank → no-op
+          const n = parseFloat(draft);
+          if (!Number.isFinite(n)) {
+            setDraft(display);
+            return;
+          }
+          onCommit(unitToPx(n, unit));
+        }}
+        className="w-24 rounded border px-2 py-1 text-right"
+      />
+      <span className="w-6 text-muted-foreground">{unit}</span>
+    </label>
+  );
+}
+
+interface RotationInputProps {
+  valueRad: number | undefined;
+  onCommit: (rad: number) => void;
+}
+
+function RotationInput({ valueRad, onCommit }: RotationInputProps) {
+  const display = valueRad === undefined ? '' : radToDeg(valueRad).toFixed(2);
+  const [draft, setDraft] = useState<string>(display);
+  useEffect(() => setDraft(display), [display]);
+
+  return (
+    <label className="flex items-center gap-2 text-xs">
+      <span className="w-20 shrink-0">Rotation</span>
+      <input
+        aria-label="Rotation"
+        type="text"
+        inputMode="decimal"
+        value={draft}
+        placeholder={valueRad === undefined ? '—' : undefined}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+          if (e.key === 'Escape') {
+            setDraft(display);
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        onBlur={() => {
+          if (draft === '') return;
+          const n = parseFloat(draft);
+          if (!Number.isFinite(n)) {
+            setDraft(display);
+            return;
+          }
+          onCommit(degToRad(n));
+        }}
+        className="w-24 rounded border px-2 py-1 text-right"
+      />
+      <span className="w-6 text-muted-foreground">{'°'}</span>
+    </label>
+  );
+}

--- a/packages/frontend/src/app/slides/format-panel/size-position-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/size-position-section.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import type { ConnectorElement, Element, Frame } from '@wafflebase/slides';
 import {
   type DisplayUnit,
@@ -74,54 +74,57 @@ export function SizePositionSection(props: SizePositionSectionProps) {
     <section aria-labelledby="format-size-position-label" className="p-3">
       <h3
         id="format-size-position-label"
-        className="mb-2 text-xs font-semibold"
+        className="mb-3 text-xs font-semibold"
       >
         Size &amp; Position
       </h3>
 
-      {showWH && (
-        <div className="mb-3 space-y-2">
-          <UnitInput
-            label="Width"
-            valuePx={w}
-            unit={unit}
-            onCommit={(px) =>
-              locked
-                ? props.onLockedResize(elements, 'w', px)
-                : props.onCommitFrame(ids, { w: px })
-            }
-          />
-          <UnitInput
-            label="Height"
-            valuePx={h}
-            unit={unit}
-            disabled={hDisabled}
-            disabledTooltip={
-              hDisabled
-                ? "Height is auto-calculated. Switch autofit to 'None' or 'Shrink' to set manually."
-                : undefined
-            }
-            onCommit={(px) =>
-              locked
-                ? props.onLockedResize(elements, 'h', px)
-                : props.onCommitFrame(ids, { h: px })
-            }
-          />
-          <button
-            type="button"
-            aria-label="Lock aspect ratio"
-            aria-pressed={locked}
-            onClick={() => setLocked((v) => !v)}
-            className={
-              'rounded border px-2 py-1 text-xs ' + (locked ? 'bg-muted' : '')
-            }
-          >
-            {locked ? 'Locked' : 'Lock aspect ratio'}
-          </button>
-        </div>
-      )}
+      <div className="space-y-2">
+        {showWH && (
+          <>
+            <UnitInput
+              label="Width"
+              valuePx={w}
+              unit={unit}
+              onCommit={(px) =>
+                locked
+                  ? props.onLockedResize(elements, 'w', px)
+                  : props.onCommitFrame(ids, { w: px })
+              }
+            />
+            <UnitInput
+              label="Height"
+              valuePx={h}
+              unit={unit}
+              disabled={hDisabled}
+              disabledTooltip={
+                hDisabled
+                  ? "Height is auto-calculated. Switch autofit to 'None' or 'Shrink' to set manually."
+                  : undefined
+              }
+              onCommit={(px) =>
+                locked
+                  ? props.onLockedResize(elements, 'h', px)
+                  : props.onCommitFrame(ids, { h: px })
+              }
+            />
+            <IndentedRow>
+              <button
+                type="button"
+                aria-label="Lock aspect ratio"
+                aria-pressed={locked}
+                onClick={() => setLocked((v) => !v)}
+                className={
+                  'rounded border px-2 py-1 text-xs hover:bg-muted ' +
+                  (locked ? 'bg-muted' : '')
+                }
+              >
+                {locked ? '🔒 Locked' : '🔓 Lock aspect ratio'}
+              </button>
+            </IndentedRow>
+          </>
+        )}
 
-      <div className="mb-3 space-y-2">
         <UnitInput
           label="X position"
           valuePx={x}
@@ -148,59 +151,69 @@ export function SizePositionSection(props: SizePositionSectionProps) {
             props.onTranslate(ids, 0, px - y);
           }}
         />
-      </div>
 
-      {showRotation && (
-        <div className="mb-3 space-y-2">
-          <RotationInput
-            valueRad={rotation}
-            onCommit={(rad) => props.onCommitFrame(ids, { rotation: rad })}
-          />
-          <div className="flex justify-end gap-2">
-            <button
-              type="button"
-              aria-label="Rotate 90 counter-clockwise"
-              onClick={() => props.onRotate90(ids, -1)}
-              className="rounded border px-2 py-1 text-xs hover:bg-muted"
-            >
-              {'↺ 90°'}
-            </button>
-            <button
-              type="button"
-              aria-label="Rotate 90 clockwise"
-              onClick={() => props.onRotate90(ids, 1)}
-              className="rounded border px-2 py-1 text-xs hover:bg-muted"
-            >
-              {'90° ↻'}
-            </button>
-          </div>
+        {showRotation && (
+          <>
+            <RotationInput
+              valueRad={rotation}
+              onCommit={(rad) => props.onCommitFrame(ids, { rotation: rad })}
+            />
+            <IndentedRow>
+              <button
+                type="button"
+                aria-label="Rotate 90 counter-clockwise"
+                onClick={() => props.onRotate90(ids, -1)}
+                className="rounded border px-2 py-1 text-xs hover:bg-muted"
+              >
+                {'↺ 90°'}
+              </button>
+              <button
+                type="button"
+                aria-label="Rotate 90 clockwise"
+                onClick={() => props.onRotate90(ids, 1)}
+                className="rounded border px-2 py-1 text-xs hover:bg-muted"
+              >
+                {'90° ↻'}
+              </button>
+            </IndentedRow>
+          </>
+        )}
+
+        <div className="flex items-center gap-2 pt-2 text-xs">
+          <span className="w-20 shrink-0">Units</span>
+          <label className="inline-flex items-center gap-1">
+            <input
+              type="radio"
+              name="format-unit"
+              aria-label="Inches"
+              checked={unit === 'in'}
+              onChange={() => props.onSetUnit('in')}
+            />
+            Inches
+          </label>
+          <label className="inline-flex items-center gap-1">
+            <input
+              type="radio"
+              name="format-unit"
+              aria-label="Centimeters"
+              checked={unit === 'cm'}
+              onChange={() => props.onSetUnit('cm')}
+            />
+            Centimeters
+          </label>
         </div>
-      )}
-
-      <fieldset className="mt-2 text-xs">
-        <legend className="mb-1">Units</legend>
-        <label className="mr-3 inline-flex items-center gap-1">
-          <input
-            type="radio"
-            name="format-unit"
-            aria-label="Inches"
-            checked={unit === 'in'}
-            onChange={() => props.onSetUnit('in')}
-          />
-          Inches
-        </label>
-        <label className="inline-flex items-center gap-1">
-          <input
-            type="radio"
-            name="format-unit"
-            aria-label="Centimeters"
-            checked={unit === 'cm'}
-            onChange={() => props.onSetUnit('cm')}
-          />
-          Centimeters
-        </label>
-      </fieldset>
+      </div>
     </section>
+  );
+}
+
+/** Sub-row aligned under the input column (label column left empty). */
+function IndentedRow({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-20 shrink-0" aria-hidden="true" />
+      {children}
+    </div>
   );
 }
 

--- a/packages/frontend/src/app/slides/format-panel/size-position-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/size-position-section.tsx
@@ -151,27 +151,29 @@ export function SizePositionSection(props: SizePositionSectionProps) {
       </div>
 
       {showRotation && (
-        <div className="mb-3 flex items-center gap-2">
+        <div className="mb-3 space-y-2">
           <RotationInput
             valueRad={rotation}
             onCommit={(rad) => props.onCommitFrame(ids, { rotation: rad })}
           />
-          <button
-            type="button"
-            aria-label="Rotate 90 counter-clockwise"
-            onClick={() => props.onRotate90(ids, -1)}
-            className="rounded border px-2 py-1 text-xs hover:bg-muted"
-          >
-            {'↺'}
-          </button>
-          <button
-            type="button"
-            aria-label="Rotate 90 clockwise"
-            onClick={() => props.onRotate90(ids, 1)}
-            className="rounded border px-2 py-1 text-xs hover:bg-muted"
-          >
-            {'↻'}
-          </button>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              aria-label="Rotate 90 counter-clockwise"
+              onClick={() => props.onRotate90(ids, -1)}
+              className="rounded border px-2 py-1 text-xs hover:bg-muted"
+            >
+              {'↺ 90°'}
+            </button>
+            <button
+              type="button"
+              aria-label="Rotate 90 clockwise"
+              onClick={() => props.onRotate90(ids, 1)}
+              className="rounded border px-2 py-1 text-xs hover:bg-muted"
+            >
+              {'90° ↻'}
+            </button>
+          </div>
         </div>
       )}
 

--- a/packages/frontend/src/app/slides/format-panel/size-position-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/size-position-section.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import type { ConnectorElement, Element, Frame } from '@wafflebase/slides';
 import {
+  IconLock,
+  IconLockOpen,
+  IconRotate,
+  IconRotateClockwise,
+} from '@tabler/icons-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
   type DisplayUnit,
   degToRad,
   formatDisplay,
@@ -109,18 +117,18 @@ export function SizePositionSection(props: SizePositionSectionProps) {
               }
             />
             <IndentedRow>
-              <button
+              <Button
                 type="button"
+                size="sm"
+                variant={locked ? 'secondary' : 'outline'}
                 aria-label="Lock aspect ratio"
                 aria-pressed={locked}
                 onClick={() => setLocked((v) => !v)}
-                className={
-                  'rounded border px-2 py-1 text-xs hover:bg-muted ' +
-                  (locked ? 'bg-muted' : '')
-                }
+                className="h-7 px-2 text-xs"
               >
-                {locked ? '🔒 Locked' : '🔓 Lock aspect ratio'}
-              </button>
+                {locked ? <IconLock size={14} /> : <IconLockOpen size={14} />}
+                {locked ? 'Locked' : 'Lock aspect ratio'}
+              </Button>
             </IndentedRow>
           </>
         )}
@@ -159,22 +167,28 @@ export function SizePositionSection(props: SizePositionSectionProps) {
               onCommit={(rad) => props.onCommitFrame(ids, { rotation: rad })}
             />
             <IndentedRow>
-              <button
+              <Button
                 type="button"
+                size="sm"
+                variant="outline"
                 aria-label="Rotate 90 counter-clockwise"
                 onClick={() => props.onRotate90(ids, -1)}
-                className="rounded border px-2 py-1 text-xs hover:bg-muted"
+                className="h-7 px-2 text-xs"
               >
-                {'↺ 90°'}
-              </button>
-              <button
+                <IconRotate size={14} />
+                90°
+              </Button>
+              <Button
                 type="button"
+                size="sm"
+                variant="outline"
                 aria-label="Rotate 90 clockwise"
                 onClick={() => props.onRotate90(ids, 1)}
-                className="rounded border px-2 py-1 text-xs hover:bg-muted"
+                className="h-7 px-2 text-xs"
               >
-                {'90° ↻'}
-              </button>
+                <IconRotateClockwise size={14} />
+                90°
+              </Button>
             </IndentedRow>
           </>
         )}
@@ -241,7 +255,7 @@ function UnitInput({
   return (
     <label className="flex items-center gap-2 text-xs">
       <span className="w-20 shrink-0">{label}</span>
-      <input
+      <Input
         aria-label={label}
         type="text"
         inputMode="decimal"
@@ -266,7 +280,7 @@ function UnitInput({
           }
           onCommit(unitToPx(n, unit));
         }}
-        className="w-24 rounded border px-2 py-1 text-right"
+        className="h-7 w-20 px-2 text-right text-xs"
       />
       <span className="w-6 text-muted-foreground">{unit}</span>
     </label>
@@ -286,7 +300,7 @@ function RotationInput({ valueRad, onCommit }: RotationInputProps) {
   return (
     <label className="flex items-center gap-2 text-xs">
       <span className="w-20 shrink-0">Rotation</span>
-      <input
+      <Input
         aria-label="Rotation"
         type="text"
         inputMode="decimal"
@@ -309,7 +323,7 @@ function RotationInput({ valueRad, onCommit }: RotationInputProps) {
           }
           onCommit(degToRad(n));
         }}
-        className="w-24 rounded border px-2 py-1 text-right"
+        className="h-7 w-20 px-2 text-right text-xs"
       />
       <span className="w-6 text-muted-foreground">{'°'}</span>
     </label>

--- a/packages/frontend/src/app/slides/format-panel/text-fitting-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/text-fitting-section.tsx
@@ -1,0 +1,53 @@
+import type { AutofitMode, TextElement } from '@wafflebase/slides';
+import { getCommonValue } from './units';
+
+export interface TextFittingSectionProps {
+  elements: readonly TextElement[];
+  onCommit: (ids: readonly string[], mode: AutofitMode) => void;
+}
+
+const MODES: { mode: AutofitMode; label: string }[] = [
+  { mode: 'none', label: 'Do not autofit' },
+  { mode: 'shrink', label: 'Shrink text on overflow' },
+  { mode: 'grow', label: 'Resize shape to fit text' },
+];
+
+export function TextFittingSection({
+  elements,
+  onCommit,
+}: TextFittingSectionProps) {
+  // Absent autofit defaults to 'grow' per slides-text-autofit.md.
+  const common = getCommonValue(
+    elements,
+    (el): AutofitMode => el.data.autofit ?? 'grow',
+  );
+  return (
+    <section aria-labelledby="format-text-fitting-label" className="p-3">
+      <h3
+        id="format-text-fitting-label"
+        className="mb-2 text-xs font-semibold"
+      >
+        Text fitting
+      </h3>
+      <div role="radiogroup" className="space-y-1">
+        {MODES.map(({ mode, label }) => (
+          <label key={mode} className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="format-text-fitting"
+              aria-label={label}
+              checked={common === mode}
+              onChange={() =>
+                onCommit(
+                  elements.map((el) => el.id),
+                  mode,
+                )
+              }
+            />
+            {label}
+          </label>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/frontend/src/app/slides/format-panel/text-fitting-section.tsx
+++ b/packages/frontend/src/app/slides/format-panel/text-fitting-section.tsx
@@ -29,9 +29,9 @@ export function TextFittingSection({
       >
         Text fitting
       </h3>
-      <div role="radiogroup" className="space-y-1">
+      <div role="radiogroup" className="space-y-1.5">
         {MODES.map(({ mode, label }) => (
-          <label key={mode} className="flex items-center gap-2 text-sm">
+          <label key={mode} className="flex items-center gap-2 text-xs">
             <input
               type="radio"
               name="format-text-fitting"

--- a/packages/frontend/src/app/slides/format-panel/units.ts
+++ b/packages/frontend/src/app/slides/format-panel/units.ts
@@ -1,0 +1,47 @@
+/**
+ * Slide canvas is 1920×1080 px. Google Slides 16:9 deck is 10in
+ * wide, so 1920 / 10 = 192 px per inch. Lossless to two decimal
+ * places of inches.
+ */
+export const PX_PER_IN = 192;
+export const PX_PER_CM = PX_PER_IN / 2.54;
+
+export type DisplayUnit = 'in' | 'cm';
+
+export function pxToUnit(px: number, unit: DisplayUnit): number {
+  return unit === 'in' ? px / PX_PER_IN : px / PX_PER_CM;
+}
+
+export function unitToPx(value: number, unit: DisplayUnit): number {
+  return unit === 'in' ? value * PX_PER_IN : value * PX_PER_CM;
+}
+
+export function formatDisplay(px: number, unit: DisplayUnit): string {
+  return pxToUnit(px, unit).toFixed(2);
+}
+
+export function radToDeg(rad: number): number {
+  return (rad * 180) / Math.PI;
+}
+
+export function degToRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+/**
+ * Return the value common to every element via `accessor`, or
+ * `undefined` if any element differs (or the list is empty).
+ * `equals` defaults to `Object.is`.
+ */
+export function getCommonValue<T, V>(
+  elements: readonly T[],
+  accessor: (el: T) => V,
+  equals: (a: V, b: V) => boolean = (a, b) => Object.is(a, b),
+): V | undefined {
+  if (elements.length === 0) return undefined;
+  const first = accessor(elements[0]);
+  for (let i = 1; i < elements.length; i++) {
+    if (!equals(first, accessor(elements[i]))) return undefined;
+  }
+  return first;
+}

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -25,6 +25,7 @@ import { PresentButton } from "./slides-present-button";
 import { uploadImageFile } from "../spreadsheet/image-upload";
 import { insertImageOnSlide } from "./insert-image";
 import { ThemePanel } from "./theme-panel";
+import { FormatPanel } from "./format-panel";
 import type { YorkieSlidesStore } from "./yorkie-slides-store";
 import {
   createZoomController,
@@ -138,7 +139,8 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
   usePresenceUpdater();
   const [editor, setEditor] = useState<SlidesEditor | null>(null);
   const [store, setStore] = useState<YorkieSlidesStore | null>(null);
-  const [themePanelOpen, setThemePanelOpen] = useState(false);
+  type RightPanel = "theme" | "format" | null;
+  const [rightPanel, setRightPanel] = useState<RightPanel>(null);
   // Session-scoped zoom controller shared between SlidesView (drives
   // refitCanvas) and SlidesToolbar (renders the dropdown). useRef
   // keeps identity stable so the SlidesView mount effect's captured
@@ -335,8 +337,14 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
             theme={activeTheme}
             onImagePick={handleImagePick}
             upload={uploadFn}
-            onToggleThemePanel={() => setThemePanelOpen((v) => !v)}
-            themePanelOpen={themePanelOpen}
+            onToggleThemePanel={() =>
+              setRightPanel((p) => (p === "theme" ? null : "theme"))
+            }
+            themePanelOpen={rightPanel === "theme"}
+            onToggleFormatPanel={() =>
+              setRightPanel((p) => (p === "format" ? null : "format"))
+            }
+            formatPanelOpen={rightPanel === "format"}
             zoomController={zoomControllerRef.current}
           />
           <div className="flex flex-1 min-h-0 overflow-hidden">
@@ -347,11 +355,18 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
               documentId={documentId}
               zoomController={zoomControllerRef.current}
             />
-            {themePanelOpen && store && (
+            {rightPanel === "theme" && store && (
               <ThemePanel
                 store={store}
                 currentThemeId={currentThemeId}
-                onClose={() => setThemePanelOpen(false)}
+                onClose={() => setRightPanel(null)}
+              />
+            )}
+            {rightPanel === "format" && store && editor && (
+              <FormatPanel
+                store={store}
+                editor={editor}
+                onClose={() => setRightPanel(null)}
               />
             )}
           </div>

--- a/packages/frontend/src/app/slides/toolbar/global-controls.tsx
+++ b/packages/frontend/src/app/slides/toolbar/global-controls.tsx
@@ -137,7 +137,6 @@ export function RightGlobals({
   );
 
   const hasSlideStyleGroup = !!store;
-  const hasPanelGroup = !!onToggleThemePanel || !!onToggleFormatPanel;
 
   // Resolve the current slide's background fill to a CSS color string so
   // the swatch button's stripe always reflects what the user is about to

--- a/packages/frontend/src/app/slides/toolbar/global-controls.tsx
+++ b/packages/frontend/src/app/slides/toolbar/global-controls.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  IconAdjustmentsAlt,
   IconArrowBackUp,
   IconArrowForwardUp,
   IconBackground,
@@ -101,6 +102,8 @@ export interface RightGlobalsProps {
   theme?: Theme | null;
   onToggleThemePanel?: () => void;
   themePanelOpen?: boolean;
+  onToggleFormatPanel?: () => void;
+  formatPanelOpen?: boolean;
 }
 
 /**
@@ -121,6 +124,8 @@ export function RightGlobals({
   theme,
   onToggleThemePanel,
   themePanelOpen,
+  onToggleFormatPanel,
+  formatPanelOpen,
 }: RightGlobalsProps) {
   const slideId = editor?.getCurrentSlideId();
   const onBackgroundChange = useCallback(
@@ -132,6 +137,7 @@ export function RightGlobals({
   );
 
   const hasSlideStyleGroup = !!store;
+  const hasPanelGroup = !!onToggleThemePanel || !!onToggleFormatPanel;
 
   // Resolve the current slide's background fill to a CSS color string so
   // the swatch button's stripe always reflects what the user is about to
@@ -188,6 +194,25 @@ export function RightGlobals({
             </Toggle>
           </TooltipTrigger>
           <TooltipContent>Theme</TooltipContent>
+        </Tooltip>
+      )}
+      {onToggleFormatPanel && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="Format options"
+              aria-pressed={!!formatPanelOpen}
+              onClick={onToggleFormatPanel}
+              className={
+                "inline-flex h-7 w-7 items-center justify-center rounded-md text-sm hover:bg-muted " +
+                (formatPanelOpen ? "bg-muted" : "")
+              }
+            >
+              <IconAdjustmentsAlt size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Format options</TooltipContent>
         </Tooltip>
       )}
     </div>

--- a/packages/frontend/src/app/slides/toolbar/global-controls.tsx
+++ b/packages/frontend/src/app/slides/toolbar/global-controls.tsx
@@ -199,18 +199,14 @@ export function RightGlobals({
       {onToggleFormatPanel && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <button
-              type="button"
-              aria-label="Format options"
-              aria-pressed={!!formatPanelOpen}
-              onClick={onToggleFormatPanel}
-              className={
-                "inline-flex h-7 w-7 items-center justify-center rounded-md text-sm hover:bg-muted " +
-                (formatPanelOpen ? "bg-muted" : "")
-              }
+            <Toggle
+              size="sm"
+              pressed={!!formatPanelOpen}
+              onPressedChange={() => onToggleFormatPanel()}
+              aria-label="Toggle format options"
             >
               <IconAdjustmentsAlt size={16} />
-            </button>
+            </Toggle>
           </TooltipTrigger>
           <TooltipContent>Format options</TooltipContent>
         </Tooltip>

--- a/packages/frontend/src/app/slides/toolbar/image-controls.tsx
+++ b/packages/frontend/src/app/slides/toolbar/image-controls.tsx
@@ -1,22 +1,15 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import type { ImageElement, SlidesEditor, SlidesStore } from '@wafflebase/slides';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { ToolbarSeparator } from '@/components/ui/toolbar';
 import { toast } from 'sonner';
 import {
   IconReplace,
   IconCrop,
   IconArrowBackUp,
-  IconAccessible,
 } from '@tabler/icons-react';
 import { replaceImageOnSlide } from '../replace-image';
 
@@ -33,7 +26,9 @@ export interface ImageControlsProps {
  * - Replace: opens a hidden file input, uploads, and swaps src + clears crop.
  * - Crop: disabled placeholder — full crop UI is deferred to a separate spec.
  * - Reset crop: clears the crop field (enabled only when a crop exists).
- * - Alt text: DropdownMenu with a textarea to set accessibility text.
+ *
+ * Alt text moved to the Format panel's Alt text section — the panel is
+ * the single home for image accessibility metadata.
  */
 export function ImageControls({
   editor,
@@ -82,16 +77,6 @@ export function ImageControls({
       store.updateElementData(slideId, firstId, { crop: undefined }),
     );
   }, [store, slideId, firstId]);
-
-  const onSaveAlt = useCallback(
-    (alt: string) => {
-      if (!store || !slideId) return;
-      store.batch(() =>
-        store.updateElementData(slideId, firstId, { alt }),
-      );
-    },
-    [store, slideId, firstId],
-  );
 
   const hasCrop = !!image?.data.crop;
 
@@ -143,62 +128,6 @@ export function ImageControls({
         </TooltipTrigger>
         <TooltipContent>Reset crop</TooltipContent>
       </Tooltip>
-
-      <ToolbarSeparator className="mx-1" />
-
-      {/* Alt text */}
-      <AltTextDropdown
-        value={image?.data.alt ?? ''}
-        onSave={onSaveAlt}
-        disabled={!store || !slideId}
-      />
     </>
-  );
-}
-
-interface AltTextDropdownProps {
-  value: string;
-  onSave: (alt: string) => void;
-  disabled: boolean;
-}
-
-function AltTextDropdown({ value, onSave, disabled }: AltTextDropdownProps) {
-  const [draft, setDraft] = useState(value);
-  // Re-sync when the parent swaps to a different image (or the value
-  // changes from a remote edit) — without this, stale alt text bleeds
-  // across selections and saves back over the new image.
-  useEffect(() => {
-    setDraft(value);
-  }, [value]);
-
-  return (
-    <DropdownMenu>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              aria-label="Alt text"
-              disabled={disabled}
-              className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-sm hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
-            >
-              <IconAccessible size={16} />
-            </button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent>Alt text (accessibility)</TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent align="start" className="w-72 p-2">
-        <label className="block text-xs font-medium">Alt text</label>
-        <textarea
-          className="mt-1 w-full rounded border p-1 text-sm"
-          rows={3}
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={() => onSave(draft)}
-          placeholder="Describe this image for screen readers"
-        />
-      </DropdownMenuContent>
-    </DropdownMenu>
   );
 }

--- a/packages/frontend/src/app/slides/toolbar/index.tsx
+++ b/packages/frontend/src/app/slides/toolbar/index.tsx
@@ -22,6 +22,8 @@ export interface SlidesToolbarProps {
   upload?: (file: File) => Promise<{ url: string; w: number; h: number }>;
   onToggleThemePanel?: () => void;
   themePanelOpen?: boolean;
+  onToggleFormatPanel?: () => void;
+  formatPanelOpen?: boolean;
   zoomController?: ZoomController | null;
 }
 
@@ -44,6 +46,8 @@ export function SlidesToolbar({
   upload,
   onToggleThemePanel,
   themePanelOpen,
+  onToggleFormatPanel,
+  formatPanelOpen,
   zoomController,
 }: SlidesToolbarProps) {
   const isMobile = useIsMobile();
@@ -119,6 +123,8 @@ export function SlidesToolbar({
         theme={theme}
         onToggleThemePanel={onToggleThemePanel}
         themePanelOpen={themePanelOpen}
+        onToggleFormatPanel={onToggleFormatPanel}
+        formatPanelOpen={formatPanelOpen}
       />
     </Toolbar>
   );

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -782,6 +782,16 @@ export class YorkieSlidesStore implements SlidesStore {
     });
   }
 
+  setUnit(unit: 'in' | 'cm'): void {
+    if (unit !== 'in' && unit !== 'cm') {
+      throw new Error(`[slides] invalid unit '${unit}'`);
+    }
+    this.requireBatch();
+    this.doc.update((r) => {
+      r.meta.unit = unit;
+    });
+  }
+
   applyLayout(slideId: string, layoutId: string): void {
     this.requireBatch();
     const layout = getLayout(layoutId);

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -783,10 +783,10 @@ export class YorkieSlidesStore implements SlidesStore {
   }
 
   setUnit(unit: 'in' | 'cm'): void {
+    this.requireBatch();
     if (unit !== 'in' && unit !== 'cm') {
       throw new Error(`[slides] invalid unit '${unit}'`);
     }
-    this.requireBatch();
     this.doc.update((r) => {
       r.meta.unit = unit;
     });

--- a/packages/frontend/tests/app/slides/format-panel/alt-text-section.test.tsx
+++ b/packages/frontend/tests/app/slides/format-panel/alt-text-section.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AltTextSection } from '@/app/slides/format-panel/alt-text-section';
+import type { ImageElement } from '@wafflebase/slides';
+
+function img(id: string, alt: string): ImageElement {
+  return {
+    id,
+    type: 'image',
+    frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+    data: { src: 'http://x', alt },
+  };
+}
+
+describe('AltTextSection', () => {
+  it('shows the common alt text for a single selection', () => {
+    const onCommit = vi.fn();
+    render(
+      <AltTextSection elements={[img('a', 'hello')]} onCommit={onCommit} />,
+    );
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe(
+      'hello',
+    );
+  });
+
+  it('shows empty placeholder when alt differs across selection', () => {
+    const onCommit = vi.fn();
+    render(
+      <AltTextSection
+        elements={[img('a', 'one'), img('b', 'two')]}
+        onCommit={onCommit}
+      />,
+    );
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('commits the new value on blur to all selected ids', () => {
+    const onCommit = vi.fn();
+    render(
+      <AltTextSection
+        elements={[img('a', ''), img('b', '')]}
+        onCommit={onCommit}
+      />,
+    );
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: 'new alt' } });
+    fireEvent.blur(ta);
+    expect(onCommit).toHaveBeenCalledWith(['a', 'b'], 'new alt');
+  });
+
+  it('blank → blur is a no-op (onCommit not called)', () => {
+    const onCommit = vi.fn();
+    render(
+      <AltTextSection
+        elements={[img('a', 'one'), img('b', 'two')]}
+        onCommit={onCommit}
+      />,
+    );
+    const ta = screen.getByRole('textbox');
+    fireEvent.blur(ta);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/tests/app/slides/format-panel/image-adjustments-section.test.tsx
+++ b/packages/frontend/tests/app/slides/format-panel/image-adjustments-section.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ImageAdjustmentsSection } from '@/app/slides/format-panel/image-adjustments-section';
+import type { ImageElement } from '@wafflebase/slides';
+
+function img(id: string, opacity?: number): ImageElement {
+  return {
+    id,
+    type: 'image',
+    frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+    data: { src: 'http://x', opacity },
+  };
+}
+
+describe('ImageAdjustmentsSection', () => {
+  it('renders the transparency slider', () => {
+    render(
+      <ImageAdjustmentsSection
+        elements={[img('a', 1)]}
+        onCommit={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText(/transparency/i)).toBeTruthy();
+  });
+
+  it('shows 0% transparency when opacity is undefined or 1', () => {
+    render(
+      <ImageAdjustmentsSection
+        elements={[img('a')]}
+        onCommit={vi.fn()}
+      />,
+    );
+    expect(
+      (screen.getByLabelText(/transparency/i) as HTMLInputElement).value,
+    ).toBe('0');
+  });
+
+  it('shows 30% transparency when opacity = 0.7', () => {
+    render(
+      <ImageAdjustmentsSection
+        elements={[img('a', 0.7)]}
+        onCommit={vi.fn()}
+      />,
+    );
+    expect(
+      (screen.getByLabelText(/transparency/i) as HTMLInputElement).value,
+    ).toBe('30');
+  });
+
+  it('commits opacity to all selected ids on pointerup', () => {
+    const onCommit = vi.fn();
+    render(
+      <ImageAdjustmentsSection
+        elements={[img('a', 1), img('b', 1)]}
+        onCommit={onCommit}
+      />,
+    );
+    const slider = screen.getByLabelText(/transparency/i);
+    fireEvent.change(slider, { target: { value: '40' } });
+    fireEvent.pointerUp(slider);
+    expect(onCommit).toHaveBeenCalledWith(['a', 'b'], 0.6);
+  });
+});

--- a/packages/frontend/tests/app/slides/format-panel/image-adjustments-section.test.tsx
+++ b/packages/frontend/tests/app/slides/format-panel/image-adjustments-section.test.tsx
@@ -60,4 +60,19 @@ describe('ImageAdjustmentsSection', () => {
     fireEvent.pointerUp(slider);
     expect(onCommit).toHaveBeenCalledWith(['a', 'b'], 0.6);
   });
+
+  it('commits opacity on keyup so keyboard adjustments (arrow / Home / End) reach the store', () => {
+    const onCommit = vi.fn();
+    render(
+      <ImageAdjustmentsSection
+        elements={[img('a', 1)]}
+        onCommit={onCommit}
+      />,
+    );
+    const slider = screen.getByLabelText(/transparency/i);
+    // Keyboard adjustment fires onChange then keyup — no pointer event.
+    fireEvent.change(slider, { target: { value: '25' } });
+    fireEvent.keyUp(slider, { key: 'ArrowUp' });
+    expect(onCommit).toHaveBeenCalledWith(['a'], 0.75);
+  });
 });

--- a/packages/frontend/tests/app/slides/format-panel/pick-sections.test.ts
+++ b/packages/frontend/tests/app/slides/format-panel/pick-sections.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pickSections,
+  type PanelSelection,
+} from '@/app/slides/format-panel/pick-sections';
+
+function objSel(
+  type: Exclude<
+    PanelSelection extends { kind: 'object'; selectionType: infer T }
+      ? T
+      : never,
+    never
+  >,
+): PanelSelection {
+  return {
+    kind: 'object',
+    selectionType: type,
+    elements: [],
+    slideId: 's1',
+  };
+}
+
+describe('pickSections', () => {
+  it('idle → empty', () => {
+    expect(pickSections({ kind: 'idle' })).toEqual([]);
+  });
+
+  it('shape → [size-position]', () => {
+    expect(pickSections(objSel('shape'))).toEqual(['size-position']);
+  });
+
+  it('image → [size-position, image-adjustments, alt-text]', () => {
+    expect(pickSections(objSel('image'))).toEqual([
+      'size-position',
+      'image-adjustments',
+      'alt-text',
+    ]);
+  });
+
+  it('text-element → [size-position, text-fitting]', () => {
+    expect(pickSections(objSel('text-element'))).toEqual([
+      'size-position',
+      'text-fitting',
+    ]);
+  });
+
+  it('connector → [size-position]', () => {
+    expect(pickSections(objSel('connector'))).toEqual(['size-position']);
+  });
+
+  it('group → [size-position]', () => {
+    expect(pickSections(objSel('group'))).toEqual(['size-position']);
+  });
+
+  it('mixed → [size-position]', () => {
+    expect(pickSections(objSel('mixed'))).toEqual(['size-position']);
+  });
+});

--- a/packages/frontend/tests/app/slides/format-panel/size-position-section.test.tsx
+++ b/packages/frontend/tests/app/slides/format-panel/size-position-section.test.tsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SizePositionSection } from '@/app/slides/format-panel/size-position-section';
+import type { ShapeElement, ConnectorElement, Element } from '@wafflebase/slides';
+
+function shape(
+  id: string,
+  frame: { x: number; y: number; w: number; h: number; rotation: number },
+): ShapeElement {
+  return { id, type: 'shape', frame, data: { kind: 'rect' } };
+}
+
+function connector(id: string): ConnectorElement {
+  return {
+    id,
+    type: 'connector',
+    frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+    routing: 'straight',
+    start: { kind: 'free', x: 0, y: 0 },
+    end: { kind: 'free', x: 100, y: 0 },
+    arrowheads: {},
+  };
+}
+
+const defaultCommit = {
+  onCommitFrame: vi.fn(),
+  onTranslate: vi.fn(),
+  onSetUnit: vi.fn(),
+  onRotate90: vi.fn(),
+  onLockedResize: vi.fn(),
+};
+
+describe('SizePositionSection (shape)', () => {
+  it('shows W/H/X/Y/Rotation inputs and the in/cm radio', () => {
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[shape('a', { x: 192, y: 96, w: 384, h: 192, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect(screen.getByLabelText(/^width$/i)).toBeTruthy();
+    expect(screen.getByLabelText(/^height$/i)).toBeTruthy();
+    expect(screen.getByLabelText(/^x position$/i)).toBeTruthy();
+    expect(screen.getByLabelText(/^y position$/i)).toBeTruthy();
+    expect(screen.getByLabelText(/rotation/i)).toBeTruthy();
+    expect(screen.getByLabelText(/inches/i)).toBeTruthy();
+    expect(screen.getByLabelText(/centimeters/i)).toBeTruthy();
+  });
+
+  it('shows the value formatted in the active unit', () => {
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[shape('a', { x: 192, y: 96, w: 384, h: 192, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect((screen.getByLabelText(/^width$/i) as HTMLInputElement).value).toBe('2.00');
+    expect((screen.getByLabelText(/^x position$/i) as HTMLInputElement).value).toBe('1.00');
+  });
+
+  it('commits w-change in canvas px on blur', () => {
+    const onCommitFrame = vi.fn();
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[shape('a', { x: 0, y: 0, w: 192, h: 192, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+        onCommitFrame={onCommitFrame}
+      />,
+    );
+    const w = screen.getByLabelText(/^width$/i);
+    fireEvent.change(w, { target: { value: '3.00' } });
+    fireEvent.blur(w);
+    expect(onCommitFrame).toHaveBeenCalledWith(['a'], { w: 576 });
+  });
+
+  it('mixed values render an empty input', () => {
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[
+          shape('a', { x: 0, y: 0, w: 100, h: 100, rotation: 0 }),
+          shape('b', { x: 0, y: 0, w: 200, h: 100, rotation: 0 }),
+        ]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect((screen.getByLabelText(/^width$/i) as HTMLInputElement).value).toBe('');
+  });
+
+  it('rotate90 button calls onRotate90 with all ids and direction', () => {
+    const onRotate90 = vi.fn();
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[shape('a', { x: 0, y: 0, w: 100, h: 100, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+        onRotate90={onRotate90}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/rotate 90 clockwise/i));
+    expect(onRotate90).toHaveBeenCalledWith(['a'], 1);
+  });
+
+  it('unit radio change calls onSetUnit', () => {
+    const onSetUnit = vi.fn();
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[shape('a', { x: 0, y: 0, w: 100, h: 100, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+        onSetUnit={onSetUnit}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/centimeters/i));
+    expect(onSetUnit).toHaveBeenCalledWith('cm');
+  });
+});
+
+describe('SizePositionSection (connector)', () => {
+  it('hides W/H and rotation; X/Y enabled when both endpoints free', () => {
+    const conn = connector('c1');
+    render(
+      <SizePositionSection
+        kind="connector"
+        elements={[conn]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect(screen.queryByLabelText(/^width$/i)).toBeNull();
+    expect(screen.queryByLabelText(/^height$/i)).toBeNull();
+    expect(screen.queryByLabelText(/rotation/i)).toBeNull();
+    expect((screen.getByLabelText(/^x position$/i) as HTMLInputElement).disabled).toBe(false);
+  });
+
+  it('disables X/Y when a connector has an attached endpoint', () => {
+    const attached: ConnectorElement = {
+      ...connector('c1'),
+      start: { kind: 'attached', elementId: 'e1', siteIndex: 0 },
+    };
+    render(
+      <SizePositionSection
+        kind="connector"
+        elements={[attached]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect((screen.getByLabelText(/^x position$/i) as HTMLInputElement).disabled).toBe(true);
+  });
+});
+
+describe('SizePositionSection (mixed)', () => {
+  it('only X and Y inputs are visible', () => {
+    const mixedSel: Element[] = [
+      shape('a', { x: 0, y: 0, w: 100, h: 100, rotation: 0 }),
+      connector('c1'),
+    ];
+    render(
+      <SizePositionSection
+        kind="mixed"
+        elements={mixedSel}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect(screen.queryByLabelText(/^width$/i)).toBeNull();
+    expect(screen.queryByLabelText(/^height$/i)).toBeNull();
+    expect(screen.queryByLabelText(/rotation/i)).toBeNull();
+    expect(screen.getByLabelText(/^x position$/i)).toBeTruthy();
+    expect(screen.getByLabelText(/^y position$/i)).toBeTruthy();
+  });
+});
+
+describe('SizePositionSection (text-element with autofit=grow)', () => {
+  it('disables H input', () => {
+    render(
+      <SizePositionSection
+        kind="text-element"
+        textAutofitMode="grow"
+        elements={[shape('t', { x: 0, y: 0, w: 100, h: 100, rotation: 0 })]}
+        unit="in"
+        {...defaultCommit}
+      />,
+    );
+    expect((screen.getByLabelText(/^height$/i) as HTMLInputElement).disabled).toBe(true);
+  });
+});
+
+describe('SizePositionSection lock aspect', () => {
+  it('locked W edit calls onLockedResize for each selected element', () => {
+    const onLockedResize = vi.fn();
+    render(
+      <SizePositionSection
+        kind="shape"
+        elements={[
+          shape('a', { x: 0, y: 0, w: 100, h: 50, rotation: 0 }),
+          shape('b', { x: 0, y: 0, w: 200, h: 200, rotation: 0 }),
+        ]}
+        unit="in"
+        {...defaultCommit}
+        onLockedResize={onLockedResize}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/lock aspect ratio/i));
+    const w = screen.getByLabelText(/^width$/i);
+    fireEvent.change(w, { target: { value: '2.00' } });
+    fireEvent.blur(w);
+    expect(onLockedResize).toHaveBeenCalled();
+    const [els, axis, px] = onLockedResize.mock.calls[0];
+    expect(els.length).toBe(2);
+    expect(axis).toBe('w');
+    expect(px).toBe(384);
+  });
+});

--- a/packages/frontend/tests/app/slides/format-panel/text-fitting-section.test.tsx
+++ b/packages/frontend/tests/app/slides/format-panel/text-fitting-section.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TextFittingSection } from '@/app/slides/format-panel/text-fitting-section';
+import type { TextElement, AutofitMode } from '@wafflebase/slides';
+
+function text(id: string, autofit?: AutofitMode): TextElement {
+  return {
+    id,
+    type: 'text',
+    frame: { x: 0, y: 0, w: 100, h: 100, rotation: 0 },
+    data: { blocks: [], autofit },
+  };
+}
+
+describe('TextFittingSection', () => {
+  it('selects the common autofit value (defaulting absent → "grow")', () => {
+    render(
+      <TextFittingSection
+        elements={[text('a', undefined), text('b', 'grow')]}
+        onCommit={vi.fn()}
+      />,
+    );
+    expect((screen.getByLabelText(/resize shape to fit/i) as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('no radio is checked when autofit differs across the selection', () => {
+    render(
+      <TextFittingSection
+        elements={[text('a', 'grow'), text('b', 'shrink')]}
+        onCommit={vi.fn()}
+      />,
+    );
+    expect((screen.getByLabelText(/do not autofit/i) as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByLabelText(/shrink text/i) as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByLabelText(/resize shape to fit/i) as HTMLInputElement).checked).toBe(false);
+  });
+
+  it('selecting a mode commits to every element id', () => {
+    const onCommit = vi.fn();
+    render(
+      <TextFittingSection
+        elements={[text('a', 'grow'), text('b', 'grow')]}
+        onCommit={onCommit}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/shrink text/i));
+    expect(onCommit).toHaveBeenCalledWith(['a', 'b'], 'shrink');
+  });
+});

--- a/packages/frontend/tests/app/slides/format-panel/units.test.ts
+++ b/packages/frontend/tests/app/slides/format-panel/units.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PX_PER_IN,
+  PX_PER_CM,
+  pxToUnit,
+  unitToPx,
+  formatDisplay,
+  radToDeg,
+  degToRad,
+  getCommonValue,
+} from '@/app/slides/format-panel/units';
+
+describe('px↔unit conversion', () => {
+  it('PX_PER_IN matches the 1920px / 10in canvas ratio', () => {
+    expect(PX_PER_IN).toBe(192);
+  });
+
+  it('PX_PER_CM = PX_PER_IN / 2.54', () => {
+    expect(PX_PER_CM).toBeCloseTo(192 / 2.54, 10);
+  });
+
+  it('pxToUnit("in") converts canvas px to inches', () => {
+    expect(pxToUnit(192, 'in')).toBeCloseTo(1, 10);
+    expect(pxToUnit(1920, 'in')).toBeCloseTo(10, 10);
+  });
+
+  it('pxToUnit("cm") converts canvas px to centimeters', () => {
+    expect(pxToUnit(PX_PER_CM, 'cm')).toBeCloseTo(1, 10);
+  });
+
+  it('unitToPx is the inverse of pxToUnit', () => {
+    for (const u of ['in', 'cm'] as const) {
+      for (const v of [0, 0.5, 1, 3.75, 10]) {
+        expect(unitToPx(pxToUnit(unitToPx(v, u), u), u)).toBeCloseTo(
+          unitToPx(v, u),
+          10,
+        );
+      }
+    }
+  });
+
+  it('formatDisplay rounds to 2 decimal places', () => {
+    expect(formatDisplay(192, 'in')).toBe('1.00');
+    expect(formatDisplay(96, 'in')).toBe('0.50');
+    expect(formatDisplay(193, 'in')).toBe('1.01');
+  });
+});
+
+describe('rad↔deg', () => {
+  it('radToDeg', () => {
+    expect(radToDeg(0)).toBe(0);
+    expect(radToDeg(Math.PI / 2)).toBeCloseTo(90, 10);
+    expect(radToDeg(Math.PI)).toBeCloseTo(180, 10);
+  });
+
+  it('degToRad', () => {
+    expect(degToRad(0)).toBe(0);
+    expect(degToRad(90)).toBeCloseTo(Math.PI / 2, 10);
+    expect(degToRad(360)).toBeCloseTo(Math.PI * 2, 10);
+  });
+});
+
+describe('getCommonValue', () => {
+  it('returns the value when every element matches', () => {
+    const arr = [{ x: 10 }, { x: 10 }, { x: 10 }];
+    expect(getCommonValue(arr, (e) => e.x)).toBe(10);
+  });
+
+  it('returns undefined when any element differs', () => {
+    const arr = [{ x: 10 }, { x: 20 }];
+    expect(getCommonValue(arr, (e) => e.x)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty list', () => {
+    expect(getCommonValue([], (e: { x: number }) => e.x)).toBeUndefined();
+  });
+
+  it('supports a custom equality fn (e.g. tolerance)', () => {
+    const arr = [{ x: 1.0001 }, { x: 1.0002 }];
+    const eq = (a: number, b: number) => Math.abs(a - b) < 0.001;
+    expect(getCommonValue(arr, (e) => e.x, eq)).toBeCloseTo(1.0001, 5);
+  });
+});

--- a/packages/frontend/tests/setup.ts
+++ b/packages/frontend/tests/setup.ts
@@ -1,0 +1,7 @@
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Automatically unmount and cleanup after each test
+afterEach(() => {
+  cleanup();
+});

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -190,7 +190,8 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
+    setupFiles: ["tests/setup.ts"],
     globals: false,
   },
 });

--- a/packages/slides/src/model/migrate.ts
+++ b/packages/slides/src/model/migrate.ts
@@ -10,11 +10,15 @@ const LAYOUT_ID_MIGRATIONS: Record<string, string> = {
 
 export function migrateDocument(input: unknown): SlidesDocument {
   const raw = input as any;
-  const meta = {
+  const meta: import('./presentation').Meta = {
     title: raw?.meta?.title ?? 'Untitled presentation',
     themeId: raw?.meta?.themeId ?? 'default-light',
     masterId: raw?.meta?.masterId ?? 'default',
   };
+  // Preserve the optional unit field if present and valid.
+  if (raw?.meta?.unit === 'in' || raw?.meta?.unit === 'cm') {
+    meta.unit = raw.meta.unit;
+  }
   const themes = Array.isArray(raw?.themes) && raw.themes.length > 0
     ? raw.themes
     : [defaultLight];

--- a/packages/slides/src/model/presentation.ts
+++ b/packages/slides/src/model/presentation.ts
@@ -47,6 +47,12 @@ export type Meta = {
   title: string;
   themeId: string;
   masterId: string;
+  /**
+   * Display unit for the Format options panel (and, when adopted,
+   * the ruler). Renderer never reads this field; it only switches
+   * what the panel's numeric inputs show. Absent ⇒ 'in'.
+   */
+  unit?: 'in' | 'cm';
 };
 
 export type GuideAxis = 'x' | 'y';

--- a/packages/slides/src/store/memory.ts
+++ b/packages/slides/src/store/memory.ts
@@ -234,6 +234,7 @@ export class MemSlidesStore implements SlidesStore {
   }
 
   setUnit(unit: 'in' | 'cm'): void {
+    this.requireBatch();
     if (unit !== 'in' && unit !== 'cm') {
       throw new Error(`[slides] invalid unit '${unit}'`);
     }

--- a/packages/slides/src/store/memory.ts
+++ b/packages/slides/src/store/memory.ts
@@ -233,6 +233,13 @@ export class MemSlidesStore implements SlidesStore {
     this.doc.meta.themeId = themeId;
   }
 
+  setUnit(unit: 'in' | 'cm'): void {
+    if (unit !== 'in' && unit !== 'cm') {
+      throw new Error(`[slides] invalid unit '${unit}'`);
+    }
+    this.doc.meta.unit = unit;
+  }
+
   applyLayout(slideId: string, layoutId: string): void {
     this.requireBatch();
     const slide = this.requireSlide(slideId);

--- a/packages/slides/src/store/store.ts
+++ b/packages/slides/src/store/store.ts
@@ -46,6 +46,13 @@ export interface SlidesStore {
   /** Apply a theme as the active theme. Theme must already be in `themes[]`. */
   applyTheme(themeId: string): void;
 
+  /**
+   * Set the display unit for numeric inputs in the Format options
+   * panel (and ruler, when wired). Persisted on `meta.unit` so peers
+   * see the same preference. No effect on rendering.
+   */
+  setUnit(unit: 'in' | 'cm'): void;
+
   // --- element-level ---
 
   /**

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -707,15 +707,19 @@ function makeConnectionSiteDot(
 
 /**
  * Autofit mode toggle button, painted at the bottom-left corner of a
- * single selected text element (Google-Slides parity). Click flips
- * between `'grow'` (box height tracks content) and `'shrink'` (fixed
- * box, fonts scale to fit). `'none'` is reachable via Format menu / API,
- * not this button — matching the GS in-context icon which is a 2-state
- * toggle.
+ * single selected text element. Click advances through all three
+ * AutofitMode values in the same order the Format panel lists them:
+ *
+ *   `none` → `shrink` → `grow` → `none` → ...
+ *
+ * This is one step beyond the Google-Slides 2-state in-context icon —
+ * the third state (autofit off) was previously reachable only via the
+ * Format panel / API. Surfacing it inline lets users disable autofit
+ * without leaving the canvas.
  *
  * Absent `autofit` is treated as `'grow'` (the pre-autofit default, see
  * `slides-text-autofit.md`), so the first click on a never-set box
- * switches it to `'shrink'`.
+ * advances to `'none'`.
  */
 const AUTOFIT_TOGGLE_SIZE = 24; // host px
 const AUTOFIT_TOGGLE_OFFSET = 6; // host px below the frame
@@ -744,6 +748,18 @@ const ICON_SHRINK =
   `<text x="8" y="13" font-family="-apple-system,system-ui,sans-serif" font-size="7" font-weight="700">a</text>` +
   `</svg>`;
 
+/**
+ * SVG for the "none" mode (do not autofit). Visual: a fixed rectangle
+ * with an X inside, reading as "autofit off — box stays put, text may
+ * overflow".
+ */
+const ICON_NONE =
+  `<svg viewBox="0 0 16 16" width="${AUTOFIT_ICON_SIZE}" height="${AUTOFIT_ICON_SIZE}" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">` +
+  `<rect x="3" y="3" width="10" height="10" rx="1"/>` +
+  `<line x1="5.5" y1="5.5" x2="10.5" y2="10.5"/>` +
+  `<line x1="10.5" y1="5.5" x2="5.5" y2="10.5"/>` +
+  `</svg>`;
+
 function renderAutofitToggle(
   overlay: HTMLDivElement,
   element: Element,
@@ -751,9 +767,13 @@ function renderAutofitToggle(
 ): void {
   if (element.type !== 'text' || !options.onAutofitToggle) return;
   const current: AutofitMode = element.data.autofit ?? 'grow';
-  // Cycle: grow ⇄ shrink. From 'none', go to 'grow' (re-enable autofit).
+  // 3-state cycle matching the Format panel order: none → shrink → grow → none.
   const next: AutofitMode =
-    current === 'shrink' ? 'grow' : current === 'grow' ? 'shrink' : 'grow';
+    current === 'none'
+      ? 'shrink'
+      : current === 'shrink'
+        ? 'grow'
+        : 'none';
 
   const { scale } = options;
   const x = element.frame.x * scale;
@@ -763,19 +783,26 @@ function renderAutofitToggle(
   btn.type = 'button';
   btn.className = 'wfb-slides-autofit-toggle';
   // Distinct inline SVGs per mode + a `title` attribute that spells out
-  // the current mode and what clicking will do (GS-style affordance).
-  btn.innerHTML = current === 'shrink' ? ICON_SHRINK : ICON_GROW;
-  btn.title =
+  // the current mode and what clicking will do.
+  btn.innerHTML =
     current === 'shrink'
-      ? 'Shrink text to fit (click to switch to resize shape to fit text)'
+      ? ICON_SHRINK
       : current === 'grow'
-        ? 'Resize shape to fit text (click to switch to shrink text)'
-        : 'Autofit off (click to enable resize shape to fit text)';
+        ? ICON_GROW
+        : ICON_NONE;
+  btn.title =
+    current === 'none'
+      ? 'Do not autofit (click to switch to shrink text on overflow)'
+      : current === 'shrink'
+        ? 'Shrink text on overflow (click to switch to resize shape to fit text)'
+        : 'Resize shape to fit text (click to switch to do not autofit)';
   btn.setAttribute(
     'aria-label',
-    current === 'shrink'
-      ? 'Autofit mode: shrink text. Click to switch to resize shape.'
-      : 'Autofit mode: resize shape. Click to switch to shrink text.',
+    current === 'none'
+      ? 'Autofit mode: do not autofit. Click to switch to shrink text.'
+      : current === 'shrink'
+        ? 'Autofit mode: shrink text. Click to switch to resize shape.'
+        : 'Autofit mode: resize shape. Click to switch to do not autofit.',
   );
   btn.style.position = 'absolute';
   btn.style.left = `${x}px`;

--- a/packages/slides/src/view/editor/text-box-editor.ts
+++ b/packages/slides/src/view/editor/text-box-editor.ts
@@ -144,9 +144,15 @@ export interface SlidesTextBoxEditor {
 export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextBoxEditor {
   const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest, onContentHeightChange, colorResolver, autofit, verticalAnchor } = opts;
 
-  // Auto-grow is the behavior for every mode except an explicit 'shrink'
-  // (fixed box, font scales) or 'none' (fixed box, overflow). Absent ⇒
-  // grow, matching the pre-autofit default so existing decks keep growing.
+  // Two related but separate flags:
+  // - allowEditorGrow: the editing canvas grows to fit content while the
+  //   user types. 'grow' and 'none' both opt in; only 'shrink' keeps the
+  //   editing surface fixed (it scales fonts instead).
+  // - isGrow: the grown height is committed back to frame.h on exit. Only
+  //   true autofit-grow does this; 'none' shows overflow live but keeps
+  //   the saved box, so post-commit the slide renderer paints the overflow
+  //   below the frame just as it did before the edit.
+  const allowEditorGrow = autofit !== 'shrink';
   const isGrow = autofit !== 'shrink' && autofit !== 'none';
   const isShrink = autofit === 'shrink';
 
@@ -235,10 +241,13 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
     onCommit: handleCommit,
     onCancel: handleCancel,
     onLinkRequest,
-    // Grow only when the mode calls for it. For 'shrink'/'none' the box
-    // stays fixed, so we leave this unwired and the docs editor never
-    // resizes the surface.
-    onContentHeightChange: isGrow
+    // Grow the editor surface for both 'grow' and 'none' modes so the
+    // text the user is typing never gets clipped. 'shrink' keeps the
+    // surface fixed because it scales fonts instead (transformLayoutBlocks
+    // below). Only 'grow' propagates the new height back to frame.h —
+    // 'none' shows the overflow live during edit and leaves the saved box
+    // alone so the post-commit render matches the pre-edit frame.
+    onContentHeightChange: allowEditorGrow
       ? (h: number): void => {
           // Grow/shrink the editing surface to fit content. Width is fixed;
           // only height tracks. cssH is host pixels (logical * slide scale);
@@ -251,7 +260,7 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
           canvas.style.height = `${cssH}px`;
           canvas.height = Math.max(1, Math.round(cssH * dpr));
           api.setContentHeight(targetH);
-          onContentHeightChange?.(targetH);
+          if (isGrow) onContentHeightChange?.(targetH);
         }
       : undefined,
     // Shrink: scale fonts down so content fits the fixed box, live as the

--- a/packages/slides/test/store/mem-set-unit.test.ts
+++ b/packages/slides/test/store/mem-set-unit.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { MemSlidesStore } from '../../src/store/memory';
+
+describe('MemSlidesStore.setUnit', () => {
+  it('defaults Meta.unit to undefined (read as inches)', () => {
+    const store = new MemSlidesStore();
+    expect(store.read().meta.unit).toBeUndefined();
+  });
+
+  it('setUnit("cm") writes the field', () => {
+    const store = new MemSlidesStore();
+    store.batch(() => store.setUnit('cm'));
+    expect(store.read().meta.unit).toBe('cm');
+  });
+
+  it('setUnit("in") writes the field', () => {
+    const store = new MemSlidesStore();
+    store.batch(() => store.setUnit('in'));
+    expect(store.read().meta.unit).toBe('in');
+  });
+
+  it('setUnit throws on invalid value', () => {
+    const store = new MemSlidesStore();
+    expect(() =>
+      store.batch(() => store.setUnit('px' as 'in')),
+    ).toThrow(/invalid unit/i);
+  });
+});

--- a/packages/slides/test/view/editor/autofit-toggle.test.ts
+++ b/packages/slides/test/view/editor/autofit-toggle.test.ts
@@ -46,16 +46,16 @@ describe('autofit toggle', () => {
     expect(parseInt(btn!.style.top, 10)).toBeGreaterThanOrEqual(280);
   });
 
-  it('clicking the toggle on a grow element calls onAutofitToggle with shrink', () => {
+  it('clicking the toggle on a none element advances to shrink', () => {
     const overlay = makeOverlay();
     const onToggle = vi.fn();
-    renderOverlay(overlay, [textEl('grow')], { ...baseOpts, onAutofitToggle: onToggle });
+    renderOverlay(overlay, [textEl('none')], { ...baseOpts, onAutofitToggle: onToggle });
     const btn = overlay.querySelector('.wfb-slides-autofit-toggle') as HTMLButtonElement;
     btn.click();
     expect(onToggle).toHaveBeenCalledWith('t1', 'shrink');
   });
 
-  it('clicking the toggle on a shrink element calls onAutofitToggle with grow', () => {
+  it('clicking the toggle on a shrink element advances to grow', () => {
     const overlay = makeOverlay();
     const onToggle = vi.fn();
     renderOverlay(overlay, [textEl('shrink')], { ...baseOpts, onAutofitToggle: onToggle });
@@ -64,22 +64,22 @@ describe('autofit toggle', () => {
     expect(onToggle).toHaveBeenCalledWith('t1', 'grow');
   });
 
-  it('treats absent autofit as grow (next click switches to shrink)', () => {
+  it('clicking the toggle on a grow element wraps to none', () => {
+    const overlay = makeOverlay();
+    const onToggle = vi.fn();
+    renderOverlay(overlay, [textEl('grow')], { ...baseOpts, onAutofitToggle: onToggle });
+    const btn = overlay.querySelector('.wfb-slides-autofit-toggle') as HTMLButtonElement;
+    btn.click();
+    expect(onToggle).toHaveBeenCalledWith('t1', 'none');
+  });
+
+  it('treats absent autofit as grow (next click wraps to none)', () => {
     const overlay = makeOverlay();
     const onToggle = vi.fn();
     renderOverlay(overlay, [textEl(/* absent */)], { ...baseOpts, onAutofitToggle: onToggle });
     const btn = overlay.querySelector('.wfb-slides-autofit-toggle') as HTMLButtonElement;
     btn.click();
-    expect(onToggle).toHaveBeenCalledWith('t1', 'shrink');
-  });
-
-  it('clicking from "none" re-enables grow', () => {
-    const overlay = makeOverlay();
-    const onToggle = vi.fn();
-    renderOverlay(overlay, [textEl('none')], { ...baseOpts, onAutofitToggle: onToggle });
-    const btn = overlay.querySelector('.wfb-slides-autofit-toggle') as HTMLButtonElement;
-    btn.click();
-    expect(onToggle).toHaveBeenCalledWith('t1', 'grow');
+    expect(onToggle).toHaveBeenCalledWith('t1', 'none');
   });
 
   it('does not render the toggle for non-text elements', () => {

--- a/packages/slides/test/view/text-box-autofit-gating.test.ts
+++ b/packages/slides/test/view/text-box-autofit-gating.test.ts
@@ -28,7 +28,10 @@ type InitOpts = {
   onContentHeightChange?: unknown;
 };
 
-function mountWith(autofit: AutofitMode | undefined): InitOpts {
+function mountWith(
+  autofit: AutofitMode | undefined,
+  outerOnContentHeightChange?: (h: number) => void,
+): InitOpts {
   initSpy.mockClear();
   const overlay = document.createElement('div');
   document.body.appendChild(overlay);
@@ -41,6 +44,7 @@ function mountWith(autofit: AutofitMode | undefined): InitOpts {
     onCommit: () => {},
     onCancel: () => {},
     autofit,
+    onContentHeightChange: outerOnContentHeightChange,
   });
   return initSpy.mock.calls[0][0] as InitOpts;
 }
@@ -66,9 +70,23 @@ describe('mountSlidesTextBox autofit hook gating', () => {
     expect(opts.transformLayoutBlocks).toBeUndefined();
   });
 
-  it("'none' wires neither hook (fixed box)", () => {
+  it("'none' wires onContentHeightChange (to grow the editing surface) but NOT transformLayoutBlocks", () => {
     const opts = mountWith('none');
-    expect(opts.onContentHeightChange).toBeUndefined();
+    expect(typeof opts.onContentHeightChange).toBe('function');
     expect(opts.transformLayoutBlocks).toBeUndefined();
+  });
+
+  it("'grow' propagates the new height to the outer onContentHeightChange callback", () => {
+    const outer = vi.fn();
+    const opts = mountWith('grow', outer);
+    (opts.onContentHeightChange as (h: number) => void)(123);
+    expect(outer).toHaveBeenCalledWith(123);
+  });
+
+  it("'none' does NOT propagate the new height — the editing surface grows but frame.h stays put", () => {
+    const outer = vi.fn();
+    const opts = mountWith('none', outer);
+    (opts.onContentHeightChange as (h: number) => void)(123);
+    expect(outer).not.toHaveBeenCalled();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,12 @@ importers:
       '@eslint/js':
         specifier: ^9.21.0
         version: 9.24.0
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22.14.1
         version: 22.14.1
@@ -3734,6 +3740,31 @@ packages:
     resolution: {integrity: sha512-uvXk/U4cBiFMxt+p9/G7yUWI/UbHYbyghLCjlpWZ3mLeIZiUBSKcUnw9UnKkdRz7Z/N4UBuFLWQdJCjUe7HjvA==}
     engines: {node: '>=12'}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -3758,6 +3789,9 @@ packages:
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -4429,6 +4463,9 @@ packages:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
 
@@ -5073,6 +5110,9 @@ packages:
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
@@ -6328,6 +6368,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -6891,6 +6935,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -6975,6 +7023,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -11525,6 +11576,31 @@ snapshots:
 
   '@tanstack/table-core@8.21.2': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/runtime': 7.27.0
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.0
+      '@testing-library/dom': 10.4.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.1
+      '@types/react-dom': 19.1.2(@types/react@19.1.1)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -11548,6 +11624,8 @@ snapshots:
     optional: true
 
   '@types/argparse@1.0.38': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -12417,6 +12495,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   array-timsort@1.0.3: {}
 
   asap@2.0.6: {}
@@ -13033,6 +13115,8 @@ snapshots:
   diff-sequences@29.6.3: {}
 
   diff@4.0.4: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -14617,6 +14701,8 @@ snapshots:
     dependencies:
       react: 19.1.0
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -15169,6 +15255,12 @@ snapshots:
 
   prettier@3.5.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -15252,6 +15344,8 @@ snapshots:
       scheduler: 0.26.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 


### PR DESCRIPTION
## Summary

- Adds a right-side **Format options** panel to the slides editor, mirroring Google Slides: Size & Position (W/H/X/Y/Rotation, lock aspect, 90° rotate, in/cm), Text fitting (autofit 3-mode), Image opacity, Alt text. Theme and Format share one right slot via a `rightPanel: 'theme' | 'format' | null` union.
- Extends the in-canvas autofit toggle (bottom-left of selected text box) from a 2-state shrink/grow flip to a 3-state cycle (`none → shrink → grow → none`) matching the Format panel order, with a new `ICON_NONE` for the off state.
- Grows the in-editor text-box canvas in `do not autofit` mode so text typed past the saved box height stays visible while editing; the outer `frame.h` write is still gated to `grow` only, so the post-commit render matches the pre-edit frame.

Data model change is one optional `Meta.unit?: 'in' | 'cm'` field plus `SlidesStore.setUnit`. All other work is additive UI.

Design: [docs/design/slides/slides-format-options-panel.md](https://github.com/wafflebase/wafflebase/blob/slides-format-options-panel/docs/design/slides/slides-format-options-panel.md)
Plan: [docs/tasks/archive/2026/05/20260529-slides-format-options-panel-todo.md](https://github.com/wafflebase/wafflebase/blob/slides-format-options-panel/docs/tasks/archive/2026/05/20260529-slides-format-options-panel-todo.md)

## Test plan

- [x] `pnpm verify:fast` — 803 unit tests green, lint clean (`--max-warnings 0`).
- [x] `pnpm --filter @wafflebase/frontend test` — 459 frontend tests green (45+ are new for the panel).
- [x] Pre-PR multi-agent review (CLAUDE.md compliance, shallow bug scan, git-history context, prior PR comments, code-comment compliance) ran on the full branch; two findings addressed inline:
  - `MemSlidesStore.setUnit` now calls `this.requireBatch()` like every other mutator in the file.
  - `ImageAdjustmentsSection` re-syncs `draft` via `useEffect` so selection swaps don't commit stale transparency.
- [x] Manual smoke in `pnpm dev`:
  - [x] Toolbar Format toggle opens/closes the panel; mutually exclusive with Theme.
  - [x] Single-shape edit: W/H/X/Y/Rotation, lock aspect, 90° rotate, in/cm toggle round-trip.
  - [x] Multi-select: mixed values render blank input, edit applies to every selected element in one undo step.
  - [x] Image selection: opacity slider, alt-text textarea; toolbar alt-text dropdown is gone.
  - [x] Text element selection: autofit 3-mode; `grow` disables H input with tooltip.
  - [x] In-canvas autofit toggle cycles `none → shrink → grow → none`; `none` state shows new X-in-box icon.
  - [x] Type past the saved box height in `none` mode — text stays visible while editing; on commit, frame keeps its saved height and overflow renders below as before.
- [x] Browser smoke (T13) deferred — slides has no interaction-browser harness today. Follow-up tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)