### PR TITLE
Fix to match non-english titles in document-list filter

### DIFF
--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -112,6 +112,15 @@ export function DocumentList({
     {
       accessorKey: "title",
       header: "Title",
+      filterFn: (row, columnId, filterValue) => {
+        const cellValue = String(row.getValue(columnId) ?? "")
+          .normalize("NFC")
+          .toLowerCase();
+        const search = String(filterValue ?? "")
+          .normalize("NFC")
+          .toLowerCase();
+        return cellValue.includes(search);
+      },
       cell: ({ row }) => {
         const docType = row.original.type;
         return (


### PR DESCRIPTION
## Summary
TanStack Table's default includesString filter compares Unicode code points as-is. Korean text from sources that emit decomposed jamo (macOS file system, some pasted content) does not match a query typed through an IME that emits NFC-precomposed syllables (the common case) — so a query of "이" missed titles like "이력서" when the stored title was NFD. Apply NFC normalization on both sides of the includes check in a custom filterFn on the title column.

## Why

## Linked Issues

Fixes #

## Author checklist

- [X] I searched existing issues and PRs and confirmed this is not a duplicate.
- [X] I read every line of this diff and can explain why each change is necessary.
- [X] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [X] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the document title filter to provide more reliable matching, now supporting case-insensitive searches and better handling of special characters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->