### PR TITLE
Make caret track resolved text color at cursor position

### DIFF
--- a/docs/tasks/active/20260530-cursor-follows-text-color-lessons.md
+++ b/docs/tasks/active/20260530-cursor-follows-text-color-lessons.md
@@ -1,0 +1,3 @@
+# Cursor follows text color — lessons
+
+(Populated post-implementation.)

--- a/docs/tasks/active/20260530-cursor-follows-text-color-todo.md
+++ b/docs/tasks/active/20260530-cursor-follows-text-color-todo.md
@@ -1,0 +1,70 @@
+# Cursor color follows text color
+
+## Problem
+
+In Slides with the **Simple Dark** theme (and any future deck theme whose
+text is light on a dark background), the text-edit caret renders with
+`Theme.cursorColor` from the docs `Theme` (light/dark mode of the docs
+package itself, *not* the deck theme). When the docs theme is in light
+mode but the slide background is dark, the caret paints in dark ink and
+is effectively invisible against the slide background.
+
+Google Slides / Docs solve this by making the caret track the **resolved
+text color at the cursor position**, so a red run shows a red caret, a
+white run on a dark slide shows a white caret. That is the fix we want.
+
+## Scope
+
+Three caret paint sites use `Theme.cursorColor` today:
+
+1. `paint-layout.ts` — caret drawn for any caller that hands a `cursor`
+   option to `paintLayout` (slides text-box editor goes through this).
+2. `doc-canvas.ts` — body caret in the paginated docs editor.
+3. `doc-canvas.ts` — header / footer carets in the paginated docs editor.
+
+All three should resolve the caret color from the inline at the cursor
+position, with the existing `theme.cursorColor` as fallback.
+
+## Plan
+
+1. **Helper** — add `resolveColorAtPosition(block, offset, colorResolver, fallback)`
+   to `packages/docs/src/model/color.ts`. Walks the inline list the same
+   way `getStyleAtCursor` / `getSelectionStyle` do, reads
+   `inline.style.color`, runs it through `colorResolver`, returns the hex
+   string or the supplied fallback.
+2. **paint-layout** — extend `PaintLayoutOpts.cursor` with an optional
+   `color?: string`. In the cursor paint block, use
+   `cursor.color ?? theme.cursorColor`.
+3. **doc-canvas** — widen the `cursor` / `headerCursor` / `footerCursor`
+   render params with the same optional `color`, fall back to
+   `Theme.cursorColor`.
+4. **Callers compute the color**:
+   - Slides text-box (`packages/docs/src/view/text-box-editor.ts`) —
+     resolve from `doc.getBlock(cursor.position.blockId)` + the
+     theme-aware `colorResolver` already passed in; fall back to
+     `Theme.cursorColor`.
+   - Docs body / header / footer (`packages/docs/src/view/editor.ts`) —
+     resolve from the relevant doc; no colorResolver in docs today, so
+     pass `defaultColorResolver`.
+5. **Tests** — extend the existing `text-box-editor` / `paint-layout`
+   unit tests to assert the caret fill matches the resolved text color.
+
+## Verification
+
+- `pnpm verify:fast` before commit.
+- Manual smoke in `pnpm dev`: open a Simple Dark deck, enter a text
+  placeholder, confirm the caret is visible (light on dark background).
+- Manual smoke: in light-theme docs, change run color to red and confirm
+  the caret turns red as the cursor crosses into the red run.
+
+## Out of scope
+
+- Honouring `styleBuffer` (toolbar-picked color before the next keystroke)
+  in the caret. The buffer is a TextEditor-internal concept; today it
+  flips back to the stored style on the next selection. Keeping caret
+  color tied to the stored style matches Google Slides v1 and avoids a
+  cross-class refactor.
+- Selection-spanning caret. The caret only paints at the focus end of
+  the selection; same behaviour as today.
+- Cursor visibility for peer carets (those already carry a per-peer
+  color from presence).

--- a/packages/docs/src/model/color.ts
+++ b/packages/docs/src/model/color.ts
@@ -45,3 +45,36 @@ export function storedColorsEqual(
 export function wrapLegacyColor(c: string | StoredColor): StoredColor {
   return c;
 }
+
+/**
+ * Resolve the visible text color at a character offset inside a single
+ * block. Finds the inline whose span covers `offset` (with the standard
+ * "cursor at the seam between two inlines belongs to the leading
+ * inline" rule used by `getStyleAtCursor` / `getSelectionStyle`), runs
+ * its `style.color` through `colorResolver`, and falls back when the
+ * inline has no color or the resolver returns `undefined`.
+ *
+ * The caret painter consumes this so the cursor tracks the text color
+ * it would assume on the next keystroke — important in slides on dark
+ * themes, where the docs `Theme.cursorColor` (light/dark mode of the
+ * docs package) does not know about deck-theme backgrounds and would
+ * otherwise paint a dark caret on a dark slide.
+ */
+export function resolveColorAtPosition(
+  block: { inlines: ReadonlyArray<{ text: string; style: { color?: StoredColor } }> } | undefined,
+  offset: number,
+  colorResolver: ColorResolver,
+  fallback: string,
+): string {
+  if (!block || block.inlines.length === 0) return fallback;
+  let pos = 0;
+  for (const inline of block.inlines) {
+    const inlineEnd = pos + inline.text.length;
+    if (offset <= inlineEnd) {
+      return colorResolver(inline.style.color) ?? fallback;
+    }
+    pos = inlineEnd;
+  }
+  const last = block.inlines[block.inlines.length - 1];
+  return colorResolver(last.style.color) ?? fallback;
+}

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -141,7 +141,7 @@ export class DocCanvas {
     scrollY: number,
     canvasWidth: number,
     viewportHeight: number,
-    cursor?: { x: number; y: number; height: number; visible: boolean },
+    cursor?: { x: number; y: number; height: number; visible: boolean; color?: string },
     selectionRects?: Array<{ x: number; y: number; width: number; height: number }>,
     focused: boolean = true,
     peerCursors?: Array<{
@@ -163,8 +163,8 @@ export class DocCanvas {
     footerLayout?: DocumentLayout | null,
     headerFooter?: { header?: { marginFromEdge: number }; footer?: { marginFromEdge: number } },
     editContext?: EditContext,
-    headerCursor?: { x: number; y: number; height: number; visible: boolean },
-    footerCursor?: { x: number; y: number; height: number; visible: boolean },
+    headerCursor?: { x: number; y: number; height: number; visible: boolean; color?: string },
+    footerCursor?: { x: number; y: number; height: number; visible: boolean; color?: string },
     hfSelectionRects?: Array<{ x: number; y: number; width: number; height: number }>,
     imageSelectionRect?: ImageRect,
     imageResizeHudText?: string,
@@ -270,7 +270,7 @@ export class DocCanvas {
         }
 
         if (editContext === 'header' && headerCursor?.visible) {
-          this.ctx.fillStyle = Theme.cursorColor;
+          this.ctx.fillStyle = headerCursor.color ?? Theme.cursorColor;
           this.ctx.fillRect(headerCursor.x, headerCursor.y, Theme.cursorWidth, headerCursor.height);
         }
 
@@ -325,7 +325,7 @@ export class DocCanvas {
         }
 
         if (editContext === 'footer' && footerCursor?.visible) {
-          this.ctx.fillStyle = Theme.cursorColor;
+          this.ctx.fillStyle = footerCursor.color ?? Theme.cursorColor;
           this.ctx.fillRect(footerCursor.x, footerCursor.y, Theme.cursorWidth, footerCursor.height);
         }
 
@@ -563,7 +563,7 @@ export class DocCanvas {
       if (focused && cursor?.visible && !imageSelectionRect) {
         if (cursor.y >= pageY + margins.top &&
             cursor.y < pageY + margins.top + contentHeight) {
-          this.ctx.fillStyle = Theme.cursorColor;
+          this.ctx.fillStyle = cursor.color ?? Theme.cursorColor;
           this.ctx.fillRect(cursor.x, cursor.y, Theme.cursorWidth, cursor.height);
         }
       }

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -15,7 +15,8 @@ import type { DocPosition, HeaderFooter } from '../model/types.js';
 import { findMarkerAt, type CommentMarker, type HighlightRect } from './comment-markers.js';
 import { Ruler, RULER_SIZE } from './ruler/index.js';
 import { computeScaleFactor } from './scale.js';
-import { setThemeMode, type ThemeMode } from './theme.js';
+import { Theme, setThemeMode, type ThemeMode } from './theme.js';
+import { defaultColorResolver, resolveColorAtPosition } from '../model/color.js';
 import { type PeerCursor, resolvePositionPixel } from './peer-cursor.js';
 import { computeTableMergeContext, type TableMergeContext } from './table-merge-context.js';
 import { resolveNestedTableLayout } from './table-layout.js';
@@ -857,9 +858,24 @@ export function initialize(
     lastLogicalCanvasWidth = logicalCanvasWidth;
 
     // Hide cursor when in cell-range selection mode
-    const cursorPixel = selection.range?.tableCellRange
+    const cursorPixelRaw = selection.range?.tableCellRange
       ? undefined
       : cursor.getPixelPosition(paginatedLayout, layout, measurer, logicalCanvasWidth);
+    // Caret color tracks the resolved text color at the cursor position
+    // so it stays readable when the user picks a non-default color.
+    // findBlock walks body / header / footer / cell blocks so this works
+    // regardless of editCtx.
+    const cursorPixel = cursorPixelRaw
+      ? {
+          ...cursorPixelRaw,
+          color: resolveColorAtPosition(
+            doc.findBlock(cursor.position.blockId),
+            cursor.position.offset,
+            defaultColorResolver,
+            Theme.cursorColor,
+          ),
+        }
+      : undefined;
 
     // Auto-scroll to keep cursor visible (only on keyboard/input-driven renders)
     if (needsScrollIntoView && cursorPixel) {
@@ -1010,17 +1026,28 @@ export function initialize(
     const editCtx = textEditor?.getEditContext() ?? 'body';
 
     // Compute header/footer cursor and selection
-    let hfCursorHeader: { x: number; y: number; height: number; visible: boolean } | undefined;
-    let hfCursorFooter: { x: number; y: number; height: number; visible: boolean } | undefined;
+    let hfCursorHeader: { x: number; y: number; height: number; visible: boolean; color?: string } | undefined;
+    let hfCursorFooter: { x: number; y: number; height: number; visible: boolean; color?: string } | undefined;
     let hfSelectionRects: Array<{ x: number; y: number; width: number; height: number }> | undefined;
 
     if (editCtx === 'header' && headerLayout && doc.document.header) {
       const hfPage = textEditor?.getHFActivePageIndex() ?? 0;
-      hfCursorHeader = computeHFCursorPixel(
+      const hfPixel = computeHFCursorPixel(
         cursor.position, headerLayout, doc.document.header, 'header',
         paginatedLayout, measurer, logicalCanvasWidth,
         hfPage, cursor.isVisible(),
       );
+      if (hfPixel) {
+        hfCursorHeader = {
+          ...hfPixel,
+          color: resolveColorAtPosition(
+            doc.findBlock(cursor.position.blockId),
+            cursor.position.offset,
+            defaultColorResolver,
+            Theme.cursorColor,
+          ),
+        };
+      }
       if (selection.hasSelection() && selection.range) {
         hfSelectionRects = computeHFSelectionRects(
           selection.range, headerLayout, doc.document.header, 'header',
@@ -1030,11 +1057,22 @@ export function initialize(
     }
     if (editCtx === 'footer' && footerLayout && doc.document.footer) {
       const hfPageF = textEditor?.getHFActivePageIndex() ?? 0;
-      hfCursorFooter = computeHFCursorPixel(
+      const hfPixel = computeHFCursorPixel(
         cursor.position, footerLayout, doc.document.footer, 'footer',
         paginatedLayout, measurer, logicalCanvasWidth,
         hfPageF, cursor.isVisible(),
       );
+      if (hfPixel) {
+        hfCursorFooter = {
+          ...hfPixel,
+          color: resolveColorAtPosition(
+            doc.findBlock(cursor.position.blockId),
+            cursor.position.offset,
+            defaultColorResolver,
+            Theme.cursorColor,
+          ),
+        };
+      }
       if (selection.hasSelection() && selection.range) {
         hfSelectionRects = computeHFSelectionRects(
           selection.range, footerLayout, doc.document.footer, 'footer',

--- a/packages/docs/src/view/paint-layout.ts
+++ b/packages/docs/src/view/paint-layout.ts
@@ -29,9 +29,12 @@ export interface PaintLayoutOpts {
    * Optional text caret in layout-local coordinates (i.e. relative to
    * the layout origin passed via `originX/originY`). When provided and
    * `visible` the caret is drawn after the run-content pass so it sits
-   * on top of the painted text.
+   * on top of the painted text. `color` overrides
+   * `theme.cursorColor` for this caret only — callers use it to track
+   * the resolved text color at the cursor position (so a red run shows
+   * a red caret, a light run on a dark slide stays visible).
    */
-  cursor?: { x: number; y: number; height: number; visible: boolean };
+  cursor?: { x: number; y: number; height: number; visible: boolean; color?: string };
 
   /**
    * Optional selection rectangles in layout-local coordinates. Painted
@@ -133,7 +136,7 @@ export function paintLayout(
 
   // 4. Cursor caret — drawn last so it sits on top of every run.
   if (opts.cursor?.visible) {
-    ctx.fillStyle = theme.cursorColor;
+    ctx.fillStyle = opts.cursor.color ?? theme.cursorColor;
     ctx.fillRect(
       originX + opts.cursor.x,
       originY + opts.cursor.y,

--- a/packages/docs/src/view/text-box-editor.ts
+++ b/packages/docs/src/view/text-box-editor.ts
@@ -27,6 +27,7 @@
  */
 import type { Block, PageSetup, InlineStyle, BlockStyle, BlockType, HeadingLevel } from '../model/types.js';
 import type { ColorResolver } from '../model/color.js';
+import { defaultColorResolver, resolveColorAtPosition } from '../model/color.js';
 import { createEmptyBlock, CLEAR_INLINE_STYLE } from '../model/types.js';
 import { Doc } from '../model/document.js';
 import { MemDocStore } from '../store/memory.js';
@@ -502,14 +503,25 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
     // Cursor caret. Same page-space → layout-local translation (subtract
     // Theme.pageGap). paintLayout adds originY to cursor.y internally,
     // so we do NOT pre-add currentOriginY here either.
-    let cursorOpt: { x: number; y: number; height: number; visible: boolean } | undefined;
+    // Caret color follows the resolved text color at the cursor position
+    // so the caret stays readable on deck themes where `Theme.cursorColor`
+    // (docs light/dark mode) does not match the slide background.
+    let cursorOpt: { x: number; y: number; height: number; visible: boolean; color?: string } | undefined;
     const cursorPixel = cursor.getPixelPosition(paginatedLayout, layout, measurer, contentWidth);
     if (cursorPixel) {
+      const cursorBlock = doc.findBlock(cursor.position.blockId);
+      const cursorColor = resolveColorAtPosition(
+        cursorBlock,
+        cursor.position.offset,
+        colorResolver ?? defaultColorResolver,
+        Theme.cursorColor,
+      );
       cursorOpt = {
         x: cursorPixel.x,
         y: cursorPixel.y - Theme.pageGap,
         height: cursorPixel.height,
         visible: cursorPixel.visible && focused,
+        color: cursorColor,
       };
     }
 

--- a/packages/docs/test/model/color.test.ts
+++ b/packages/docs/test/model/color.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   defaultColorResolver,
+  resolveColorAtPosition,
   storedColorsEqual,
   wrapLegacyColor,
 } from '../../src/model/color.js';
@@ -97,5 +98,59 @@ describe('storedColorsEqual', () => {
         { kind: 'srgb', value: '#abc' },
       ),
     ).toBe(false);
+  });
+});
+
+describe('resolveColorAtPosition', () => {
+  const fallback = '#000000';
+  it('returns the fallback when the block is missing or empty', () => {
+    expect(resolveColorAtPosition(undefined, 0, defaultColorResolver, fallback)).toBe(fallback);
+    expect(
+      resolveColorAtPosition({ inlines: [] }, 0, defaultColorResolver, fallback),
+    ).toBe(fallback);
+  });
+
+  it('returns the color of the inline whose span covers offset', () => {
+    const block = {
+      inlines: [
+        { text: 'red', style: { color: '#ff0000' } },
+        { text: 'blue', style: { color: '#0000ff' } },
+      ],
+    };
+    // offset 0..3 → inside "red"
+    expect(resolveColorAtPosition(block, 0, defaultColorResolver, fallback)).toBe('#ff0000');
+    expect(resolveColorAtPosition(block, 2, defaultColorResolver, fallback)).toBe('#ff0000');
+    // offset 3 sits at the seam — the cursor belongs to the first inline
+    // (matches getStyleAtCursor / getSelectionStyle behaviour).
+    expect(resolveColorAtPosition(block, 3, defaultColorResolver, fallback)).toBe('#ff0000');
+    // offset 4 lands inside "blue"
+    expect(resolveColorAtPosition(block, 4, defaultColorResolver, fallback)).toBe('#0000ff');
+  });
+
+  it('falls back when the resolved color is undefined (e.g. role with no resolver)', () => {
+    const block = {
+      inlines: [{ text: 'hi', style: { color: { kind: 'role' as const, role: 'accent1' } } }],
+    };
+    // defaultColorResolver returns undefined for role colors → fallback.
+    expect(resolveColorAtPosition(block, 0, defaultColorResolver, fallback)).toBe(fallback);
+  });
+
+  it('honours a theme-aware resolver for role colors', () => {
+    const block = {
+      inlines: [{ text: 'hi', style: { color: { kind: 'role' as const, role: 'accent1' } } }],
+    };
+    expect(
+      resolveColorAtPosition(
+        block,
+        0,
+        (c) => (c && typeof c === 'object' && c.kind === 'role' ? '#abcdef' : undefined),
+        fallback,
+      ),
+    ).toBe('#abcdef');
+  });
+
+  it('returns the fallback when the inline has no color set', () => {
+    const block = { inlines: [{ text: 'hi', style: {} }] };
+    expect(resolveColorAtPosition(block, 0, defaultColorResolver, fallback)).toBe(fallback);
   });
 });

--- a/packages/docs/test/view/themed-color.test.ts
+++ b/packages/docs/test/view/themed-color.test.ts
@@ -69,6 +69,45 @@ describe('paintLayout colorResolver', () => {
     expect(fillStyles).toContain('#ff9900');
   });
 
+  it('paints the cursor caret in the supplied cursor.color (overrides theme cursor)', () => {
+    const blocks: Block[] = [
+      {
+        id: 'b1',
+        type: 'paragraph',
+        inlines: [{ text: 'Hi', style: { color: '#ffffff' } }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      },
+    ];
+    const { ctx, fillStyles } = makeFakeCtx();
+    const measurer = new StubMeasurer();
+    const { layout } = computeLayout(blocks, measurer, 200);
+    paintLayout(ctx, layout, 0, 0, {
+      cursor: { x: 10, y: 0, height: 16, visible: true, color: '#ffffff' },
+    });
+    // The white caret color must reach fillStyle — without the override
+    // the dark `Theme.cursorColor` would paint instead.
+    expect(fillStyles).toContain('#ffffff');
+  });
+
+  it('falls back to theme cursorColor when cursor.color is omitted', () => {
+    const blocks: Block[] = [
+      {
+        id: 'b1',
+        type: 'paragraph',
+        inlines: [{ text: 'Hi', style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      },
+    ];
+    const { ctx, fillStyles } = makeFakeCtx();
+    const measurer = new StubMeasurer();
+    const { layout } = computeLayout(blocks, measurer, 200);
+    paintLayout(ctx, layout, 0, 0, {
+      cursor: { x: 10, y: 0, height: 16, visible: true },
+    });
+    // No explicit color → theme.cursorColor (a hex value) used.
+    expect(fillStyles.some((s) => /^#[0-9a-fA-F]{6}$/.test(s))).toBe(true);
+  });
+
   it('falls back to theme defaultColor when the resolver returns undefined', () => {
     const blocks: Block[] = [
       {

--- a/packages/docs/test/view/themed-color.test.ts
+++ b/packages/docs/test/view/themed-color.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { computeLayout } from '../../src/view/layout.js';
 import { paintLayout } from '../../src/view/paint-layout.js';
+import { Theme } from '../../src/view/theme.js';
 import { DEFAULT_BLOCK_STYLE, type Block } from '../../src/model/types.js';
 import type { ColorResolver } from '../../src/model/color.js';
 import { StubMeasurer } from './_stub-measurer.js';
@@ -70,11 +71,13 @@ describe('paintLayout colorResolver', () => {
   });
 
   it('paints the cursor caret in the supplied cursor.color (overrides theme cursor)', () => {
+    // Distinct text and caret colors so the caret assertion cannot
+    // accidentally pass on the text-paint fillStyle.
     const blocks: Block[] = [
       {
         id: 'b1',
         type: 'paragraph',
-        inlines: [{ text: 'Hi', style: { color: '#ffffff' } }],
+        inlines: [{ text: 'Hi', style: { color: '#ff0000' } }],
         style: { ...DEFAULT_BLOCK_STYLE },
       },
     ];
@@ -82,19 +85,23 @@ describe('paintLayout colorResolver', () => {
     const measurer = new StubMeasurer();
     const { layout } = computeLayout(blocks, measurer, 200);
     paintLayout(ctx, layout, 0, 0, {
-      cursor: { x: 10, y: 0, height: 16, visible: true, color: '#ffffff' },
+      cursor: { x: 10, y: 0, height: 16, visible: true, color: '#00ff00' },
     });
-    // The white caret color must reach fillStyle — without the override
-    // the dark `Theme.cursorColor` would paint instead.
-    expect(fillStyles).toContain('#ffffff');
+    // Cursor is the LAST paint pass in paintLayout (see paint-layout.ts
+    // step 4), so the caret fillStyle is the final entry.
+    expect(fillStyles[fillStyles.length - 1]).toBe('#00ff00');
+    // Sanity: the distinct text color reached fillStyle too.
+    expect(fillStyles).toContain('#ff0000');
   });
 
   it('falls back to theme cursorColor when cursor.color is omitted', () => {
+    // Text color picked to differ from Theme.cursorColor so the caret
+    // assertion cannot match a stray text-paint fillStyle.
     const blocks: Block[] = [
       {
         id: 'b1',
         type: 'paragraph',
-        inlines: [{ text: 'Hi', style: {} }],
+        inlines: [{ text: 'Hi', style: { color: '#ff00ff' } }],
         style: { ...DEFAULT_BLOCK_STYLE },
       },
     ];
@@ -104,8 +111,10 @@ describe('paintLayout colorResolver', () => {
     paintLayout(ctx, layout, 0, 0, {
       cursor: { x: 10, y: 0, height: 16, visible: true },
     });
-    // No explicit color → theme.cursorColor (a hex value) used.
-    expect(fillStyles.some((s) => /^#[0-9a-fA-F]{6}$/.test(s))).toBe(true);
+    // Cursor is the last paint pass → the final fillStyle entry must be
+    // the theme fallback exactly.
+    expect(fillStyles[fillStyles.length - 1]).toBe(Theme.cursorColor);
+    expect(Theme.cursorColor).not.toBe('#ff00ff');
   });
 
   it('falls back to theme defaultColor when the resolver returns undefined', () => {


### PR DESCRIPTION
## Summary

- Slides text-edit caret on dark deck themes (e.g. Simple Dark) was invisible — the docs `Theme.cursorColor` knows about light/dark mode of the docs package but not about per-deck slide backgrounds, so a dark caret painted on top of a dark slide.
- Match Google Docs/Slides behaviour: caret picks up the resolved text color at the cursor position (light text → light caret, red text → red caret).
- Adds `resolveColorAtPosition` helper next to `defaultColorResolver`, widens the three caret paint sites (`paintLayout`, `DocCanvas` body/header/footer) with an optional `cursor.color`, and threads the resolved color from the slides text-box editor and the docs full editor. Falls back to `Theme.cursorColor` when no color is supplied so existing callers are unaffected.

## Test plan

- [x] `pnpm verify:fast`
- [x] Unit: 5 new cases in `packages/docs/test/model/color.test.ts` cover the seam rule, role-color fallback, missing color, theme-aware resolver
- [x] Unit: 2 new cases in `packages/docs/test/view/themed-color.test.ts` assert the `cursor.color` override + `Theme.cursorColor` fallback paths
- [x] Manual smoke: open a Simple Dark deck in `pnpm dev`, enter a text placeholder, confirm the caret is visible against the dark slide background
- [x] Manual smoke: in light-theme docs, set a run to red, place the caret inside it, confirm the caret renders red

Design notes in `docs/tasks/active/20260530-cursor-follows-text-color-todo.md`.

Out of scope: honouring `styleBuffer` (toolbar-picked color before next keystroke); selection-spanning caret; peer carets already carry their own per-peer color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added documentation about cursor color rendering improvements.

* **Bug Fixes**
  * Text cursor now automatically matches the surrounding text color instead of using a fixed theme color, improving visibility with dark themes where contrast could make the cursor invisible.

* **Tests**
  * Added test coverage for cursor color resolution and rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->