### PR TITLE
Slides: deselect shapes on body-area click

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,6 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
-| slides body click deselect (2026-05-31) | [20260531-slides-body-click-deselect-todo.md](./active/20260531-slides-body-click-deselect-todo.md) | - |
 | cursor follows text color (2026-05-30) | [20260530-cursor-follows-text-color-todo.md](./active/20260530-cursor-follows-text-color-todo.md) | [20260530-cursor-follows-text-color-lessons.md](./active/20260530-cursor-follows-text-color-lessons.md) |
 | docs pending inline style (2026-05-30) | [20260530-docs-pending-inline-style-todo.md](./active/20260530-docs-pending-inline-style-todo.md) | [20260530-docs-pending-inline-style-lessons.md](./active/20260530-docs-pending-inline-style-lessons.md) |
 | pptx paragraph bullet style (2026-05-30) | [20260530-pptx-paragraph-bullet-style-todo.md](./active/20260530-pptx-paragraph-bullet-style-todo.md) | - |
@@ -37,7 +36,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 228
+- Archived task count: 229
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides body click deselect (2026-05-31)
+Latest active task: cursor follows text color (2026-05-30)

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,11 +18,16 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides body click deselect (2026-05-31) | [20260531-slides-body-click-deselect-todo.md](./active/20260531-slides-body-click-deselect-todo.md) | - |
+| cursor follows text color (2026-05-30) | [20260530-cursor-follows-text-color-todo.md](./active/20260530-cursor-follows-text-color-todo.md) | [20260530-cursor-follows-text-color-lessons.md](./active/20260530-cursor-follows-text-color-lessons.md) |
+| docs pending inline style (2026-05-30) | [20260530-docs-pending-inline-style-todo.md](./active/20260530-docs-pending-inline-style-todo.md) | [20260530-docs-pending-inline-style-lessons.md](./active/20260530-docs-pending-inline-style-lessons.md) |
+| pptx paragraph bullet style (2026-05-30) | [20260530-pptx-paragraph-bullet-style-todo.md](./active/20260530-pptx-paragraph-bullet-style-todo.md) | - |
 | slides shift modifiers (2026-05-28) | [20260528-slides-shift-modifiers-todo.md](./active/20260528-slides-shift-modifiers-todo.md) | [20260528-slides-shift-modifiers-lessons.md](./active/20260528-slides-shift-modifiers-lessons.md) |
 | docs unlink href (2026-05-26) | [20260526-docs-unlink-href-todo.md](./active/20260526-docs-unlink-href-todo.md) | [20260526-docs-unlink-href-lessons.md](./active/20260526-docs-unlink-href-lessons.md) |
 | slides group selection ui (2026-05-26) | [20260526-slides-group-selection-ui-todo.md](./active/20260526-slides-group-selection-ui-todo.md) | [20260526-slides-group-selection-ui-lessons.md](./active/20260526-slides-group-selection-ui-lessons.md) |
 | slides text autofit (2026-05-25) | [20260525-slides-text-autofit-todo.md](./active/20260525-slides-text-autofit-todo.md) | [20260525-slides-text-autofit-lessons.md](./active/20260525-slides-text-autofit-lessons.md) |
 | slides textbox toolbar focus (2026-05-25) | [20260525-slides-textbox-toolbar-focus-todo.md](./active/20260525-slides-textbox-toolbar-focus-todo.md) | [20260525-slides-textbox-toolbar-focus-lessons.md](./active/20260525-slides-textbox-toolbar-focus-lessons.md) |
+| docs local caret anchoring (2026-05-19) | [20260519-docs-local-caret-anchoring-todo.md](./active/20260519-docs-local-caret-anchoring-todo.md) | [20260519-docs-local-caret-anchoring-lessons.md](./active/20260519-docs-local-caret-anchoring-lessons.md) |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
 | slides package mvp (2026-05-05) | [20260505-slides-package-mvp-todo.md](./active/20260505-slides-package-mvp-todo.md) | [20260505-slides-package-mvp-lessons.md](./active/20260505-slides-package-mvp-lessons.md) |
@@ -35,4 +40,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 228
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides shift modifiers (2026-05-28)
+Latest active task: slides body click deselect (2026-05-31)

--- a/docs/tasks/active/20260531-slides-body-click-deselect-todo.md
+++ b/docs/tasks/active/20260531-slides-body-click-deselect-todo.md
@@ -1,0 +1,42 @@
+# Slides — Body-area click deselects shapes
+
+## Context
+
+Currently in the slides editor a shape stays selected when the user
+clicks the gray area surrounding the slide canvas. Only clicks landing
+on the slide canvas itself trigger deselection (via the empty-canvas
+branch of `onPointerDown`). Google Slides deselects on clicks anywhere
+in the editor body (the area bracketed by the rulers).
+
+Scope: limit the new listener to the ruler-bracketed editor body
+(the `scrollHost` element). Avoid a global `document`-level listener
+so toolbar / side panel / format panel clicks remain inert with
+respect to selection.
+
+## Plan
+
+- [ ] Extend `SlidesEditorOptions` with optional `bodyHost?: HTMLElement`.
+- [ ] In `attachInteractions`, bind `pointerdown` on `bodyHost` and
+      fire `onBodyPointerDown` only when `e.target === bodyHost`
+      (i.e., the click landed on the empty area, not on a child like
+      the canvas wrap or the rulers).
+- [ ] `onBodyPointerDown` behavior:
+  - During paint/insert mode → no-op (user is in a different gesture
+    domain; missing the canvas shouldn't clear or insert).
+  - While text editing → commit + exit (mirrors clicking outside the
+    text-box container while still inside the slide canvas).
+  - Otherwise → `selection.click(null, {})` with `refitPoppedScope` so
+    drilled-in groups pop on body click, matching the empty-canvas
+    branch of `onPointerDown`.
+- [ ] Pass `scrollHost` as `bodyHost` in `slides-view.tsx`.
+- [ ] Unit test: dispatch `pointerdown` with `target === bodyHost`
+      clears selection; dispatch with a child target does not.
+- [ ] `pnpm verify:fast` green.
+
+## Notes
+
+- `attachInteractions` already short-circuits in read-only mode, so the
+  new binding inherits that gate without extra plumbing.
+- The mobile shell (`mobile-slides-view.tsx`) does not own a comparable
+  ruler-bracketed body region today; leaving it unwired keeps the
+  mobile gesture surface unchanged.

--- a/docs/tasks/archive/2026/05/20260531-slides-body-click-deselect-lessons.md
+++ b/docs/tasks/archive/2026/05/20260531-slides-body-click-deselect-lessons.md
@@ -1,0 +1,84 @@
+# Slides Body-Click Deselect — Lessons
+
+Companion to `20260531-slides-body-click-deselect-todo.md`. PR
+[#319](https://github.com/wafflebase/wafflebase/pull/319), commit
+`3b009e84`.
+
+## What landed
+
+- `SlidesEditorOptions.bodyHost?: HTMLElement` opt-in option, registered
+  inside `attachInteractions` with a strict `e.target === bodyHost`
+  filter so the canvas wrap, rulers, and corner keep their own handlers.
+- `onBodyPointerDown` mirrors the empty-canvas branch's deselect path
+  (`selection.click(null, {})` + `refitPoppedScope`), but skips the
+  `startLasso` fall-through (no lasso on the gray gutter).
+- Frontend passes `scrollHost` as `bodyHost` — the scroll container that
+  already covers "canvas-area minus the ruler gutter", which is exactly
+  the click-to-deselect region the user expects.
+- 3 unit tests: direct body click clears, child click does NOT clear
+  (proves the strict target filter), insert-mode body click is inert.
+
+## Strict `target === bodyHost` is what makes this safe
+
+The body handler sits on `scrollHost`, which contains `canvasWrap`
+(canvas + overlay) as a child. Every pointerdown on the slide bubbles
+through `scrollHost`, so the listener fires on those events too. The
+single-line `if (e.target !== this.options.bodyHost) return;` is the
+only thing keeping the body path from stealing canvas-level intents
+(lasso start, hit-test, drag). Worth keeping that comment in place if
+the handler grows.
+
+This generalises: any time you bind a listener on a container that
+already owns interactive children, decide up-front whether you want
+*bubbled* events or only *direct* events. `===` on `target` is the
+direct-only filter; `currentTarget` reads the listener's host. The two
+diverge specifically when there's nested DOM with its own handlers.
+
+## `attachInteractions` is the single binding seam
+
+PR #282's lessons file already documented this: every pointer +
+document-keydown listener lives in `attachInteractions`, gated by
+`!options.readOnly`. The new body binding inherits both properties for
+free — no separate read-only check, no separate cleanup wiring (because
+`this.on()` registers in `this.listeners` for `detach()` to drain).
+
+The temptation to add this binding "near where `scrollHost` lives" in
+the frontend would have broken the gate: shared-link viewers mount the
+editor with `readOnly: true` and expect no mutation. Routing through
+the editor's binding seam is the institutional answer.
+
+## Stale dist tripped pre-commit verify:fast
+
+First `pnpm verify:fast` run failed with TypeScript errors in
+`packages/slides/src/import/pptx/*` about `BlockMarker` and `marker` on
+`Block`. Nothing the body-click change touched. The user's memory note
+"Packages consume built dist, not src — rebuild a producer package
+after cross-package API changes" predicted this exactly: `@wafflebase/docs`
+had pending API changes in src that hadn't been rebuilt to dist, so
+slides' typecheck (consuming `@wafflebase/docs` from dist) saw a stale
+type surface.
+
+Fix: `pnpm --filter @wafflebase/docs build` then re-run verify:fast.
+Generalisable: a verify failure in a package you didn't touch, with
+errors about another package's exports, is almost always a stale-dist
+problem. Rebuild the named producer first before assuming a real
+regression.
+
+## Mobile shell deliberately unwired
+
+`mobile-slides-view.tsx` doesn't expose a ruler-bracketed body region,
+so it gets no `bodyHost`. This matches the existing pattern for ruler
+options: opt-in shells that don't have the surface simply omit the
+option. Documenting the omission in the JSDoc (`"Omit on shells that
+don't expose a comparable body region (e.g., the mobile mount)"`)
+prevents the next contributor from "fixing" the missing wiring.
+
+## Verification evidence
+
+- `pnpm verify:fast` exit 0 (after rebuilding `@wafflebase/docs`).
+- 3 new tests in `packages/slides/test/view/editor/editor.test.ts`
+  green via `pnpm exec vitest run test/view/editor/editor.test.ts -t
+  "bodyHost click deselect"` — 3 passed, 91 skipped (the `-t` filter).
+- Pre-push hook ran `verify:self`, exit 0.
+- Manual smoke in `pnpm dev` confirmed: select a shape, click the gray
+  area → deselects; ruler drag-out and canvas lasso unaffected.

--- a/docs/tasks/archive/2026/05/20260531-slides-body-click-deselect-todo.md
+++ b/docs/tasks/archive/2026/05/20260531-slides-body-click-deselect-todo.md
@@ -15,12 +15,12 @@ respect to selection.
 
 ## Plan
 
-- [ ] Extend `SlidesEditorOptions` with optional `bodyHost?: HTMLElement`.
-- [ ] In `attachInteractions`, bind `pointerdown` on `bodyHost` and
+- [x] Extend `SlidesEditorOptions` with optional `bodyHost?: HTMLElement`.
+- [x] In `attachInteractions`, bind `pointerdown` on `bodyHost` and
       fire `onBodyPointerDown` only when `e.target === bodyHost`
       (i.e., the click landed on the empty area, not on a child like
       the canvas wrap or the rulers).
-- [ ] `onBodyPointerDown` behavior:
+- [x] `onBodyPointerDown` behavior:
   - During paint/insert mode → no-op (user is in a different gesture
     domain; missing the canvas shouldn't clear or insert).
   - While text editing → commit + exit (mirrors clicking outside the
@@ -28,10 +28,18 @@ respect to selection.
   - Otherwise → `selection.click(null, {})` with `refitPoppedScope` so
     drilled-in groups pop on body click, matching the empty-canvas
     branch of `onPointerDown`.
-- [ ] Pass `scrollHost` as `bodyHost` in `slides-view.tsx`.
-- [ ] Unit test: dispatch `pointerdown` with `target === bodyHost`
+- [x] Pass `scrollHost` as `bodyHost` in `slides-view.tsx`.
+- [x] Unit test: dispatch `pointerdown` with `target === bodyHost`
       clears selection; dispatch with a child target does not.
-- [ ] `pnpm verify:fast` green.
+- [x] `pnpm verify:fast` green.
+
+## Review
+
+Landed in commit `3b009e84`, PR
+[#319](https://github.com/wafflebase/wafflebase/pull/319). All plan items
+ticked; 3 new unit tests pass; pre-push `verify:self` green; manual
+smoke in `pnpm dev` confirmed (shape deselects on gray-area click; ruler
+drag-out and canvas lasso/hit-test unaffected).
 
 ## Notes
 

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,13 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 228
+Total archived tasks: 229
 
-## 2026/05 (83 tasks)
+## 2026/05 (84 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides body click deselect (2026-05-31) | [20260531-slides-body-click-deselect-todo.md](./2026/05/20260531-slides-body-click-deselect-todo.md) | [20260531-slides-body-click-deselect-lessons.md](./2026/05/20260531-slides-body-click-deselect-lessons.md) |
 | design docs cleanup (2026-05-30) | [20260530-design-docs-cleanup-todo.md](./2026/05/20260530-design-docs-cleanup-todo.md) | [20260530-design-docs-cleanup-lessons.md](./2026/05/20260530-design-docs-cleanup-lessons.md) |
 | docs tab multi bullet (2026-05-30) | [20260530-docs-tab-multi-bullet-todo.md](./2026/05/20260530-docs-tab-multi-bullet-todo.md) | [20260530-docs-tab-multi-bullet-lessons.md](./2026/05/20260530-docs-tab-multi-bullet-lessons.md) |
 | docs toolbar groups (2026-05-30) | [20260530-docs-toolbar-groups-todo.md](./2026/05/20260530-docs-toolbar-groups-todo.md) | [20260530-docs-toolbar-groups-lessons.md](./2026/05/20260530-docs-toolbar-groups-lessons.md) |

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -519,6 +519,7 @@ export function SlidesView({
       hRulerCanvas,
       vRulerCanvas,
       rulerCorner,
+      bodyHost: scrollHost,
       onShowShortcutsHelp: () => setHelpOpen(true),
       onStartPresentation: (from) => onStartPresentationRef.current?.(from),
       onToast: (msg) => onToastRef.current(msg),

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -193,6 +193,17 @@ export interface SlidesEditorOptions extends SlideRendererOptions {
   hRulerCanvas?: HTMLCanvasElement;
   vRulerCanvas?: HTMLCanvasElement;
   rulerCorner?: HTMLElement;
+  /**
+   * Optional ruler-bracketed editor body (the gray area surrounding
+   * the slide canvas). When supplied, a `pointerdown` whose target is
+   * the host itself — i.e., the click landed on the empty area, not on
+   * a child like the canvas wrap or the rulers — clears the selection
+   * and pops any drilled-in group scope, matching Google Slides'
+   * "click outside the slide to deselect" behavior. Omit on shells
+   * that don't expose a comparable body region (e.g., the mobile
+   * mount).
+   */
+  bodyHost?: HTMLElement;
 }
 
 export interface SlidesEditor {
@@ -1493,6 +1504,17 @@ class SlidesEditorImpl implements SlidesEditor {
         startRulerDragOut(this.guideDragHost(), 'y', e as PointerEvent);
       });
     }
+
+    // Body-area click: pointerdowns on the gray space surrounding the
+    // slide canvas (between the rulers and the slide) deselect any
+    // selected elements. Strict `target === bodyHost` check so children
+    // — the canvas wrap, the rulers, the corner — keep their own
+    // handlers (canvas owns lasso / drag, rulers own guide drag-out).
+    if (this.options.bodyHost !== undefined) {
+      this.on(this.options.bodyHost, 'pointerdown', (e) =>
+        this.onBodyPointerDown(e as PointerEvent),
+      );
+    }
   }
 
   /**
@@ -1864,6 +1886,35 @@ class SlidesEditorImpl implements SlidesEditor {
       return;
     }
     this.startLasso(e.clientX, e.clientY);
+  }
+
+  private onBodyPointerDown(e: PointerEvent): void {
+    // Only the empty body itself — clicks that bubble up from a child
+    // (canvas wrap, rulers, corner) are owned by those elements'
+    // dedicated handlers.
+    if (e.target !== this.options.bodyHost) return;
+
+    // Inert during paint / insert modes: missing the slide canvas
+    // shouldn't apply a paint or place a shape, and silently
+    // deselecting under the user's gesture would feel surprising.
+    if (this.paintSnapshot !== null) return;
+    if (this.insertKind !== null) return;
+
+    // Mirror the canvas branch: clicking outside an open text-box
+    // commits and exits edit mode. No deselect — the user's intent is
+    // just to leave the textbox.
+    if (this.editingElementId !== null) {
+      this.exitEditMode('commit');
+      return;
+    }
+
+    const slide = this.currentSlide();
+    if (!slide) return;
+    const beforeScope = this.selection.getScope();
+    // `selection.click(null, {})` clears ids + pops scope in one notify,
+    // matching the empty-canvas branch above.
+    this.selection.click(null, {});
+    this.refitPoppedScope(beforeScope, this.selection.getScope(), slide.id);
   }
 
   private onDoubleClick(e: MouseEvent): void {

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -2625,3 +2625,80 @@ describe('elementContextItems — text vertical align', () => {
     expect(store.canRedo()).toBe(redoBefore);
   });
 });
+
+describe('Editor — bodyHost click deselect', () => {
+  let editor: SlidesEditor | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    if (editor) {
+      editor.detach();
+      editor = null;
+    }
+  });
+
+  function makeBodyFixture() {
+    const { canvas, overlay, store } = makeFixture();
+    const bodyHost = document.createElement('div');
+    document.body.appendChild(bodyHost);
+    let elementId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      elementId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    return { canvas, overlay, store, bodyHost, elementId };
+  }
+
+  it('pointerdown directly on bodyHost clears the selection', () => {
+    const { canvas, overlay, store, bodyHost, elementId } = makeBodyFixture();
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1, bodyHost,
+    });
+    editor.setSelection([elementId]);
+    expect(editor.getSelection()).toEqual([elementId]);
+
+    bodyHost.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 5, clientY: 5, pointerType: 'mouse', bubbles: true,
+    }));
+
+    expect(editor.getSelection()).toEqual([]);
+  });
+
+  it('pointerdown on a bodyHost child does NOT clear the selection', () => {
+    const { canvas, overlay, store, bodyHost, elementId } = makeBodyFixture();
+    // Simulate a child element inside bodyHost (e.g., the canvas wrap).
+    // Children own their own pointer handlers — the body handler must
+    // strictly check `e.target === bodyHost` to avoid stealing those.
+    const child = document.createElement('div');
+    bodyHost.appendChild(child);
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1, bodyHost,
+    });
+    editor.setSelection([elementId]);
+
+    child.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 5, clientY: 5, pointerType: 'mouse', bubbles: true,
+    }));
+
+    expect(editor.getSelection()).toEqual([elementId]);
+  });
+
+  it('bodyHost pointerdown is inert during insert mode', () => {
+    const { canvas, overlay, store, bodyHost, elementId } = makeBodyFixture();
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1, bodyHost,
+    });
+    editor.setSelection([elementId]);
+    editor.setInsertMode('rect');
+
+    bodyHost.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 5, clientY: 5, pointerType: 'mouse', bubbles: true,
+    }));
+
+    expect(editor.getSelection()).toEqual([elementId]);
+  });
+});


### PR DESCRIPTION
## Summary

- Clicking the gray area surrounding the slide canvas now deselects shapes, matching Google Slides. Previously only clicks landing on the slide canvas itself deselected, so users had to either hit the slide or press Esc.
- Adds an optional `bodyHost` to `SlidesEditorOptions`; when supplied, the editor binds `pointerdown` that fires only when `e.target === bodyHost` so the canvas wrap, rulers, and corner keep their own handlers.
- Frontend wires `scrollHost` (the gray scroll container between the rulers and the slide) as `bodyHost`.

Behavior matches the empty-canvas branch of `onPointerDown`: inert during paint/insert modes, commits any open text-box edit if active, otherwise clears selection + pops drilled-in group scope via `selection.click(null, {})`. Read-only mounts already skip `attachInteractions`, so the new binding inherits that gate without extra plumbing. Mobile shell does not own a comparable body region today and is intentionally left unwired.

## Test plan

- [x] `pnpm verify:fast` green
- [x] New unit tests in `packages/slides/test/view/editor/editor.test.ts`:
  - direct pointerdown on `bodyHost` clears selection
  - pointerdown on a `bodyHost` child does NOT clear selection (strict target check)
  - body pointerdown is inert during insert mode
- [x] Manual smoke in `pnpm dev`: select a shape, click the gray area around the slide → shape deselects; click on a ruler → guide drag-out still works; click on the slide canvas → existing canvas behavior (lasso / hit-test) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added click-to-deselect behavior: clicking the slide editor body area now deselects shapes, while clicks on toolbars and panels remain inactive.

* **Documentation**
  * Updated task documentation with interaction specifications and implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->