### PR TITLE
Resolve grouped connector endpoints to world coords

### DIFF
--- a/docs/design/slides/slides-connectors.md
+++ b/docs/design/slides/slides-connectors.md
@@ -173,6 +173,36 @@ This is called every render frame for any attached endpoint. No cache,
 no stale coordinates, no CRDT divergence risk. The cost is negligible
 (few attached endpoints per slide).
 
+`siteWorldPos` reads `el.frame.x/y/w/h/rotation` as **world** (slide-
+logical) coordinates. Group children, however, store their frames in
+group-local space (see `slides-group.md`) — so the lookup map handed
+to `resolveEndpoint` must lift those local frames into world coords or
+endpoints attached to grouped elements snap to the local offset
+interpreted as world (typically near the slide origin).
+
+For this, `buildElementWorldLookup(slide.elements)` in
+`packages/slides/src/model/group.ts` walks the element tree DFS,
+composes the chain of ancestor `groupToTransform`s via
+`composeGroupMatrix`, and emits each leaf with its frame rewritten
+through `applyGroupTransform`. Top-level elements pass through
+unchanged. Free connector-endpoint coords on nested connectors are
+lifted via `applyGroupTransformToPoint`. All callsites that build an
+`id → Element` map for `resolveEndpoint` / `computeConnectorFrame`
+use this helper:
+
+| Callsite | Purpose |
+| --- | --- |
+| `slide-renderer.ts` (paint pass) | resolve attached endpoints while rendering |
+| `editor.ts` (drag-move ghost) | snap ghost lines onto the dragging shape's site |
+| `editor.ts` (endpoint-drag Shift constraint) | resolve the fixed-other-end pin |
+| `overlay.ts` (selection handles) | place endpoint handles over the connector |
+| `MemSlidesStore.elementsLookup` | shared between batched connector reflows and detach-on-delete |
+
+`flattenElements` is kept for callers that only need tree iteration
+(e.g. iterating connectors to find ones that depend on a moved
+element); resolver paths must always go through
+`buildElementWorldLookup`.
+
 ### 3. Routing
 
 Three pure functions, no side effects, fully unit-testable:

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -36,7 +36,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 229
+- Archived task count: 230
 - Archive index: [archive/README.md](./archive/README.md)
 
 Latest active task: cursor follows text color (2026-05-30)

--- a/docs/tasks/archive/2026/05/20260531-slides-group-nested-connector-lessons.md
+++ b/docs/tasks/archive/2026/05/20260531-slides-group-nested-connector-lessons.md
@@ -1,0 +1,44 @@
+# Lessons — group-nested connector endpoints
+
+## What went well
+
+- **Read the data first.** Unzipping the offending PPTX and walking
+  `slide24.xml` showed exactly which `<a:stCxn id="…" idx="…">` pairs
+  attached to which shape. That alone pinned the bug to "the target
+  shape lives inside `<p:grpSp>`" before reading a line of import or
+  render code.
+- The pre-existing comment at `element-renderer.ts` ("Connectors
+  inside groups are painted in raw ctx space") explicitly flagged a
+  related coordinate-space asymmetry — a useful breadcrumb that
+  hinted the issue was on the lookup side.
+- Following TDD: writing a failing test in `connector-frame.test.ts`
+  for the group-nested case took ~5 minutes and immediately validated
+  the fix.
+
+## What to watch for next time
+
+- **Coordinate-space audit when bridging tree-structured data and a
+  flat lookup.** `flattenElements` was advertised as "DFS so things
+  inside groups still resolve" — but flattening alone doesn't lift the
+  frames out of group-local space. Any flat map used by a *renderer*
+  that consumes `el.frame.x/y` as world coords needs world frames at
+  build time, not deferred per-call ancestor walks.
+- **PPTX `<p:grpSp>` is more permissive than our editor's `group()`
+  invariant.** Imported decks can break "v1 invariant: connectors are
+  never inside groups" and "groups never nest arbitrarily" assumptions.
+  Anywhere those invariants are quoted, leave a note that the *editor*
+  enforces them but the *importer* doesn't.
+- **Pre-existing typecheck failures on main can mask regressions.**
+  `pnpm slides typecheck` was red on `BlockMarker` before I touched
+  anything; fixed by `pnpm --filter @wafflebase/docs build` to refresh
+  the docs `dist/` consumed by slides. Worth adding a sanity rebuild
+  step to verify lanes when a fresh repo greets you with red.
+
+## Process notes
+
+- The bug was diagnosed by reading the actual XML, not by guessing
+  from screenshots. When a visual bug has a clear data-source artifact
+  (here: `<a:stCxn id>`), prefer parsing it over inferring.
+- Replaced six `new Map(flattenElements(...).map(...))` sites in one
+  pass; introducing the helper made the diff smaller than fixing each
+  callsite locally and kept all renderers in agreement.

--- a/docs/tasks/archive/2026/05/20260531-slides-group-nested-connector-todo.md
+++ b/docs/tasks/archive/2026/05/20260531-slides-group-nested-connector-todo.md
@@ -1,0 +1,64 @@
+# Slides: connector endpoints attached to grouped elements
+
+Status: done
+
+## Problem
+
+In imported PPTX decks where a `<p:cxnSp>` connector targets a shape
+nested inside a `<p:grpSp>` (e.g. a user-avatar pic inside a group),
+the rendered arrow points to the **wrong** world position. Reproducer:
+slide 24 of `Yorkie, 캐즘 뛰어넘기.pptx` — connectors 362/366 attach
+to pic id=363 which lives inside group 371; both arrows land near the
+slide's top-left corner instead of at the avatar.
+
+## Root cause
+
+1. PPTX importer correctly registers nested ids in `idMap` and emits
+   `attached` endpoints pointing at the in-group element.
+2. Group children are stored with **group-local** `frame` (via
+   `worldToGroupLocal` in `import/pptx/shape.ts`). Renderer composes
+   the parent group transform when *drawing* them, so visual position
+   is correct.
+3. The connector lookup map built by `slide-renderer.ts` (and
+   `editor.ts`, `overlay.ts`, `store/memory.ts`) uses
+   `flattenElements(slide.elements)` which preserves those local
+   frames. `siteWorldPos()` then treats `el.frame.x/y` as world
+   coordinates → endpoint snaps to the local offset interpreted as
+   world, missing the group's translation/scale/rotation entirely.
+
+## Fix
+
+Option A (chosen): introduce `buildElementWorldLookup(elements)` in
+`model/group.ts` that does a DFS while composing ancestor group
+transforms via `groupToTransform` + `composeGroupMatrix`, and returns
+each leaf with its frame transformed into world space via
+`applyMatrix`. Replace the `new Map(flattenElements(...).map(...))`
+construction at every connector-resolver callsite. For connector
+elements inside groups we lift their `free` endpoints + `frame` to
+world coords too (for parity, although our current group invariant
+forbids connectors inside groups).
+
+## Todo
+
+- [x] Investigate root cause (slide 24 XML, importer, renderer paths)
+- [x] Failing test in `test/view/canvas/connector-frame.test.ts`
+- [x] Add `buildElementWorldLookup` in `model/group.ts`
+- [x] Replace lookup construction at:
+  - `view/canvas/slide-renderer.ts`
+  - `view/editor/editor.ts` (two sites)
+  - `view/editor/overlay.ts`
+  - `store/memory.ts` (`elementsLookup`, `detachConnectorsTargeting`)
+- [x] Update `docs/design/slides/slides-connectors.md`
+- [x] `pnpm verify:fast`
+- [x] Browser smoke on the affected deck (user confirmed)
+- [x] Write lessons file, archive
+
+## Files touched (planned)
+
+- `packages/slides/src/model/group.ts`
+- `packages/slides/src/view/canvas/slide-renderer.ts`
+- `packages/slides/src/view/editor/editor.ts`
+- `packages/slides/src/view/editor/overlay.ts`
+- `packages/slides/src/store/memory.ts`
+- `packages/slides/test/view/canvas/connector-frame.test.ts`
+- `docs/design/slides/slides-connectors.md`

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,13 +6,14 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 229
+Total archived tasks: 230
 
-## 2026/05 (84 tasks)
+## 2026/05 (85 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
 | slides body click deselect (2026-05-31) | [20260531-slides-body-click-deselect-todo.md](./2026/05/20260531-slides-body-click-deselect-todo.md) | [20260531-slides-body-click-deselect-lessons.md](./2026/05/20260531-slides-body-click-deselect-lessons.md) |
+| slides group nested connector (2026-05-31) | [20260531-slides-group-nested-connector-todo.md](./2026/05/20260531-slides-group-nested-connector-todo.md) | [20260531-slides-group-nested-connector-lessons.md](./2026/05/20260531-slides-group-nested-connector-lessons.md) |
 | design docs cleanup (2026-05-30) | [20260530-design-docs-cleanup-todo.md](./2026/05/20260530-design-docs-cleanup-todo.md) | [20260530-design-docs-cleanup-lessons.md](./2026/05/20260530-design-docs-cleanup-lessons.md) |
 | docs tab multi bullet (2026-05-30) | [20260530-docs-tab-multi-bullet-todo.md](./2026/05/20260530-docs-tab-multi-bullet-todo.md) | [20260530-docs-tab-multi-bullet-lessons.md](./2026/05/20260530-docs-tab-multi-bullet-lessons.md) |
 | docs toolbar groups (2026-05-30) | [20260530-docs-toolbar-groups-todo.md](./2026/05/20260530-docs-toolbar-groups-todo.md) | [20260530-docs-toolbar-groups-lessons.md](./2026/05/20260530-docs-toolbar-groups-lessons.md) |

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -69,6 +69,7 @@ export {
   applyGroupTransform,
   applyInverseMatrix,
   applyInversePoint,
+  buildElementWorldLookup,
   composeAncestorTransform,
   composeGroupMatrix,
   findElementPath,

--- a/packages/slides/src/model/group.ts
+++ b/packages/slides/src/model/group.ts
@@ -1,5 +1,8 @@
 import type { Element, Frame, GroupElement } from './element';
-import { applyGroupTransform as applyMatrix } from '../import/pptx/group';
+import {
+  applyGroupTransform as applyMatrix,
+  applyGroupTransformToPoint,
+} from '../import/pptx/group';
 import type { GroupTransform } from '../import/pptx/group';
 import { boundingBox } from './frame';
 
@@ -365,10 +368,11 @@ export function worldTightFrame(group: GroupElement): {
 
 /**
  * DFS walk of an element tree that returns a flat list containing every
- * element at every depth. Used by `slide-renderer.ts` to build an
- * `elementsLookup` that includes elements nested inside groups, so that
- * connector endpoints referencing elements inside groups can resolve
- * correctly.
+ * element at every depth. Used internally by `buildElementWorldLookup`
+ * and by store-level connector bookkeeping that only needs the tree
+ * topology — callers that resolve connector endpoints (via
+ * `resolveEndpoint` / `siteWorldPos`) must use `buildElementWorldLookup`
+ * instead, since this helper preserves group-local frames as-is.
  */
 export function flattenElements(elements: Element[]): Element[] {
   const result: Element[] = [];
@@ -379,4 +383,83 @@ export function flattenElements(elements: Element[]): Element[] {
     }
   }
   return result;
+}
+
+/**
+ * Build an `id → Element` lookup where every element is returned with
+ * its **world** frame — group transforms composed up the ancestor
+ * chain. `siteWorldPos` reads `frame.x/y/w/h/rotation` as world
+ * coords, so handing it a group-local frame makes connectors that
+ * attach to elements inside a group land at the wrong position (see
+ * the slide-24 PPTX bug where a connector targeting a `<p:pic>`
+ * nested in a `<p:grpSp>` rendered near the slide origin).
+ *
+ * Top-level elements pass through by reference. Anything below a
+ * group is shallow-cloned with `applyMatrix` (free connector endpoints
+ * via `applyGroupTransformToPoint`). The return type is `ReadonlyMap`
+ * — treat the values as read-only since some entries alias the live
+ * document.
+ */
+export function buildElementWorldLookup(
+  elements: readonly Element[],
+): ReadonlyMap<string, Element> {
+  const out = new Map<string, Element>();
+  walkWorld(elements, 0, IDENTITY_GROUP_TRANSFORM, out);
+  return out;
+}
+
+function walkWorld(
+  elements: readonly Element[],
+  depth: number,
+  accum: GroupTransform,
+  out: Map<string, Element>,
+): void {
+  for (const el of elements) {
+    if (el.type === 'group') {
+      // Recurse first so children pick up the composed transform.
+      // `groupToTransform` reads `el.frame` as a transform local to its
+      // parent space; composing with `accum` (which maps that parent
+      // space to world) yields the correct world transform for
+      // children, regardless of how deeply nested.
+      const next = composeGroupMatrix(accum, groupToTransform(el));
+      walkWorld(el.data.children, depth + 1, next, out);
+      // Then lift the group's own frame into world. At depth 0 the
+      // frame is already in world space.
+      out.set(el.id, depth === 0 ? el : { ...el, frame: applyMatrix(el.frame, accum) });
+      continue;
+    }
+    if (depth === 0) {
+      out.set(el.id, el);
+      continue;
+    }
+    if (el.type === 'connector') {
+      // Connector children can be produced by PPTX import (`<p:cxnSp>`
+      // inside `<p:grpSp>`); the editor-side `group()` op forbids
+      // them. Lift `free` endpoints so cross-group resolution sees a
+      // consistent space; the renderer's separate v2 TODO around
+      // painting nested connectors is tracked in `element-renderer.ts`.
+      const start =
+        el.start.kind === 'free'
+          ? {
+              kind: 'free' as const,
+              ...applyGroupTransformToPoint(el.start.x, el.start.y, accum),
+            }
+          : el.start;
+      const end =
+        el.end.kind === 'free'
+          ? {
+              kind: 'free' as const,
+              ...applyGroupTransformToPoint(el.end.x, el.end.y, accum),
+            }
+          : el.end;
+      out.set(el.id, {
+        ...el,
+        frame: applyMatrix(el.frame, accum),
+        start,
+        end,
+      });
+      continue;
+    }
+    out.set(el.id, { ...el, frame: applyMatrix(el.frame, accum) });
+  }
 }

--- a/packages/slides/src/node.ts
+++ b/packages/slides/src/node.ts
@@ -73,6 +73,7 @@ export {
   applyGroupTransform,
   applyInverseMatrix,
   applyInversePoint,
+  buildElementWorldLookup,
   composeAncestorTransform,
   composeGroupMatrix,
   findElementPath,

--- a/packages/slides/src/store/memory.ts
+++ b/packages/slides/src/store/memory.ts
@@ -28,6 +28,7 @@ import {
   applyGroupTransform,
   applyInverseMatrix,
   applyInversePoint,
+  buildElementWorldLookup,
   composeAncestorTransform,
   findElementPath,
   flattenElements,
@@ -1026,17 +1027,11 @@ export class MemSlidesStore implements SlidesStore {
     }
   }
 
-  /**
-   * Read-only id → Element map for the given slide. Walks the full
-   * element tree (including elements nested inside groups) so that
-   * connector frame helpers can resolve attached endpoints regardless
-   * of group depth.
-   */
+  /** Read-only id → Element map (with world frames) for the given slide. */
   private elementsLookup(slideId: string): ReadonlyMap<string, Element> {
     const i = this.doc.slides.findIndex((s) => s.id === slideId);
     if (i === -1) return new Map();
-    const slide = this.doc.slides[i];
-    return new Map(flattenElements(slide.elements).map((e) => [e.id, e] as const));
+    return buildElementWorldLookup(this.doc.slides[i].elements);
   }
 
   /**
@@ -1048,7 +1043,7 @@ export class MemSlidesStore implements SlidesStore {
    */
   private detachConnectorsTargeting(slide: Slide, targetId: string): void {
     const allElements = flattenElements(slide.elements);
-    const lookup = new Map(allElements.map((e) => [e.id, e] as const));
+    const lookup = buildElementWorldLookup(slide.elements);
     for (const el of allElements) {
       if (el.type !== 'connector') continue;
       let mutated = false;

--- a/packages/slides/src/view/canvas/slide-renderer.ts
+++ b/packages/slides/src/view/canvas/slide-renderer.ts
@@ -1,7 +1,7 @@
 import type { Element } from '../../model/element';
 import type { BackgroundImage, Slide, SlidesDocument } from '../../model/presentation';
 import { SLIDE_HEIGHT, SLIDE_WIDTH } from '../../model/presentation';
-import { flattenElements } from '../../model/group';
+import { buildElementWorldLookup } from '../../model/group';
 import { resolveColor } from '../../model/theme';
 import { drawElement } from './element-renderer';
 import { drawImage } from './image-renderer';
@@ -151,16 +151,9 @@ export function drawSlide(
     drawImage(ctx, { w: SLIDE_WIDTH, h: SLIDE_HEIGHT }, bgImage, onAssetLoad);
   }
 
-  // Iterate elements in array order = z-order, last is front.
-  // Element lookup is consumed by the connector renderer to resolve
-  // attached endpoints. Built once per slide-render so each connector
-  // doesn't rebuild it.
-  // flattenElements walks the tree DFS so elements nested inside groups
-  // are included — a connector whose endpoint targets a shape inside a
-  // group can still resolve the attachment point correctly.
-  const elementsLookup = new Map<string, Element>(
-    flattenElements(slide.elements).map((e) => [e.id, e] as const),
-  );
+  // Iterate elements in array order = z-order, last is front. Built
+  // once per slide-render so each connector doesn't rebuild it.
+  const elementsLookup = buildElementWorldLookup(slide.elements);
   for (const element of slide.elements) {
     drawElement(ctx, element, doc, theme, onAssetLoad, elementsLookup);
   }

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -77,8 +77,8 @@ import { mountSlidesTextBox, type SlidesTextBoxEditor } from './text-box-editor'
 import { getActiveTheme } from '../canvas/render-context';
 import { makeColorResolver } from '../canvas/text-renderer';
 import {
+  buildElementWorldLookup,
   findElementPath,
-  flattenElements,
   worldTightFrame,
 } from '../../model/group';
 
@@ -2487,13 +2487,10 @@ class SlidesEditorImpl implements SlidesEditor {
     // rotated shapes/groups snap against their visible bbox.
     const otherFrames = collectSnapCandidates(startSlide, [...scope], selectedIds);
 
-    // Lookup map for resolving connector endpoints to world coords —
-    // needed when a ghost connector's attached endpoint targets a
-    // dragged shape (the ghost line must follow the ghost shape's
-    // connection site, not snap back to the original).
-    const slideLookup = new Map<string, Element>(
-      flattenElements(startSlide.elements).map((e) => [e.id, e] as const),
-    );
+    // Needed when a ghost connector's attached endpoint targets a
+    // dragged shape: the ghost line must follow the ghost shape's
+    // connection site, not snap back to the original.
+    const slideLookup = buildElementWorldLookup(startSlide.elements);
 
     let liveDx = 0;
     let liveDy = 0;
@@ -2812,14 +2809,9 @@ class SlidesEditorImpl implements SlidesEditor {
     // once at mousedown — the opposite endpoint stays fixed for the
     // duration of this drag, so we don't need to re-resolve per move.
     const otherEndpoint = side === 'start' ? startConnector.end : startConnector.start;
-    // Use flattenElements so endpoints attached to shapes nested inside
-    // groups resolve correctly — a flat root scan would miss them and
-    // resolveEndpoint would return its {0,0} sentinel, snapping the
-    // Shift constraint to the slide origin instead of the real anchor.
-    // Mirrors the move-drag lookup above.
     const otherWorld = resolveEndpoint(
       otherEndpoint,
-      new Map(flattenElements(startSlide.elements).map((e) => [e.id, e] as const)),
+      buildElementWorldLookup(startSlide.elements),
     );
 
     const recompute = (cur: { x: number; y: number }) => {

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -7,6 +7,7 @@ import {
   siteWorldPos,
 } from '../canvas/connection-sites';
 import { resolveEndpoint } from '../canvas/connector-frame';
+import { buildElementWorldLookup } from '../../model/group';
 import type { SnapGuide } from './snap';
 import { ADJUSTMENT_HANDLES } from '../canvas/shapes/index';
 import {
@@ -272,9 +273,7 @@ function renderConnectorEndpointHandles(
   options: OverlayOptions,
 ): void {
   const { scale, allElements } = options;
-  const map = new Map<string, Element>(
-    (allElements ?? []).map((e) => [e.id, e]),
-  );
+  const map = buildElementWorldLookup(allElements ?? []);
   const a = resolveEndpoint(connector.start, map);
   const b = resolveEndpoint(connector.end, map);
   overlay.appendChild(

--- a/packages/slides/test/view/canvas/connector-frame.test.ts
+++ b/packages/slides/test/view/canvas/connector-frame.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ConnectorElement } from '../../../src/model/connector';
-import type { Element } from '../../../src/model/element';
+import type { Element, GroupElement, ShapeElement } from '../../../src/model/element';
+import { buildElementWorldLookup } from '../../../src/model/group';
 import { computeConnectorFrame } from '../../../src/view/canvas/connector-frame';
 
 const baseConnector = (
@@ -62,5 +63,147 @@ describe('computeConnectorFrame', () => {
     expect(f.y).toBeCloseTo(-1);
     expect(f.w).toBeCloseTo(52);
     expect(f.h).toBeCloseTo(52);
+  });
+
+  it('attached to shape nested in a group: resolves through group transform', () => {
+    // Reproduces the slide-24 PPTX bug: a top-level connector targets a
+    // shape inside a <p:grpSp>. Group children store their frames in
+    // group-local coords, so the lookup MUST hand the connector a
+    // world-frame view of the nested target — otherwise siteWorldPos
+    // would treat the local (10, 5) offset as world coordinates.
+    const child: ShapeElement = {
+      id: 'child',
+      type: 'shape',
+      // group-local frame inside the group's (0..refSize.w × 0..refSize.h) space
+      frame: { x: 10, y: 5, w: 100, h: 100, rotation: 0 },
+      data: { kind: 'rect' },
+    };
+    const group: GroupElement = {
+      id: 'g',
+      type: 'group',
+      frame: { x: 500, y: 300, w: 200, h: 200, rotation: 0 },
+      data: { children: [child], refSize: { w: 200, h: 200 } },
+    };
+    const c = baseConnector(
+      { kind: 'free', x: 0, y: 0 },
+      { kind: 'attached', elementId: 'child', siteIndex: 1 }, // E of child
+    );
+    const lookup = buildElementWorldLookup([group]);
+    const f = computeConnectorFrame(c, lookup);
+    // child's world frame: (500+10, 300+5, 100, 100) → east site (610, 355).
+    // bbox of (0,0)-(610,355) ± stroke half-width (= 1).
+    expect(f.x).toBeCloseTo(-1);
+    expect(f.y).toBeCloseTo(-1);
+    expect(f.w).toBeCloseTo(612);
+    expect(f.h).toBeCloseTo(357);
+  });
+});
+
+describe('buildElementWorldLookup', () => {
+  it('top-level elements pass through with their own frames', () => {
+    const a: Element = {
+      id: 'a',
+      type: 'shape',
+      frame: { x: 10, y: 20, w: 30, h: 40, rotation: 0 },
+      data: { kind: 'rect' },
+    };
+    const lookup = buildElementWorldLookup([a]);
+    expect(lookup.get('a')?.frame).toEqual(a.frame);
+  });
+
+  it('group children come back with composed world frames', () => {
+    const child: ShapeElement = {
+      id: 'child',
+      type: 'shape',
+      frame: { x: 10, y: 5, w: 100, h: 100, rotation: 0 },
+      data: { kind: 'rect' },
+    };
+    const group: GroupElement = {
+      id: 'g',
+      type: 'group',
+      frame: { x: 500, y: 300, w: 200, h: 200, rotation: 0 },
+      data: { children: [child], refSize: { w: 200, h: 200 } },
+    };
+    const lookup = buildElementWorldLookup([group]);
+    const w = lookup.get('child')?.frame;
+    expect(w?.x).toBeCloseTo(510);
+    expect(w?.y).toBeCloseTo(305);
+    expect(w?.w).toBeCloseTo(100);
+    expect(w?.h).toBeCloseTo(100);
+  });
+
+  it('nested groups compose transforms', () => {
+    const leaf: ShapeElement = {
+      id: 'leaf',
+      type: 'shape',
+      frame: { x: 1, y: 2, w: 10, h: 10, rotation: 0 },
+      data: { kind: 'rect' },
+    };
+    const inner: GroupElement = {
+      id: 'inner',
+      type: 'group',
+      frame: { x: 100, y: 200, w: 50, h: 50, rotation: 0 },
+      data: { children: [leaf], refSize: { w: 50, h: 50 } },
+    };
+    const outer: GroupElement = {
+      id: 'outer',
+      type: 'group',
+      frame: { x: 1000, y: 2000, w: 300, h: 300, rotation: 0 },
+      data: { children: [inner], refSize: { w: 300, h: 300 } },
+    };
+    const lookup = buildElementWorldLookup([outer]);
+    const w = lookup.get('leaf')?.frame;
+    // outer translates (100,200)→(1100,2200); leaf adds (1,2) → (1101, 2202).
+    expect(w?.x).toBeCloseTo(1101);
+    expect(w?.y).toBeCloseTo(2202);
+  });
+
+  it('nested groups themselves are lifted to world frames', () => {
+    // Guards against the case where a connector attaches to a nested
+    // GROUP element (rare but possible — `siteIndex` works on any
+    // element). The inner group's stored frame is in the OUTER group's
+    // local space; the lookup must lift it through the outer transform
+    // or `siteWorldPos` reads the local offset as world.
+    const inner: GroupElement = {
+      id: 'inner',
+      type: 'group',
+      frame: { x: 100, y: 200, w: 50, h: 50, rotation: 0 },
+      data: { children: [], refSize: { w: 50, h: 50 } },
+    };
+    const outer: GroupElement = {
+      id: 'outer',
+      type: 'group',
+      frame: { x: 1000, y: 2000, w: 300, h: 300, rotation: 0 },
+      data: { children: [inner], refSize: { w: 300, h: 300 } },
+    };
+    const lookup = buildElementWorldLookup([outer]);
+    expect(lookup.get('inner')?.frame.x).toBeCloseTo(1100);
+    expect(lookup.get('inner')?.frame.y).toBeCloseTo(2200);
+    // Outer (top-level) keeps its already-world frame untouched.
+    expect(lookup.get('outer')?.frame).toEqual(outer.frame);
+  });
+
+  it('group scaling propagates to children', () => {
+    const child: ShapeElement = {
+      id: 'child',
+      type: 'shape',
+      frame: { x: 10, y: 10, w: 50, h: 50, rotation: 0 },
+      data: { kind: 'rect' },
+    };
+    // frame.w / refSize.w = 200/100 = 2× horizontal scale.
+    const group: GroupElement = {
+      id: 'g',
+      type: 'group',
+      frame: { x: 0, y: 0, w: 200, h: 100, rotation: 0 },
+      data: { children: [child], refSize: { w: 100, h: 100 } },
+    };
+    const lookup = buildElementWorldLookup([group]);
+    const w = lookup.get('child')?.frame;
+    // Centre scales 2× horizontally: child local centre (35, 35) →
+    // world centre (70, 35); width 50 → 100, height 50 → 50.
+    expect(w?.x).toBeCloseTo(20);
+    expect(w?.y).toBeCloseTo(10);
+    expect(w?.w).toBeCloseTo(100);
+    expect(w?.h).toBeCloseTo(50);
   });
 });


### PR DESCRIPTION
## Summary

- Imported PPTX decks where a `<p:cxnSp>` connector targeted an element inside a `<p:grpSp>` (e.g. slide 24 of `Yorkie, 캐즘 뛰어넘기.pptx` — arrows pointing at a user avatar nested in a group with its background ellipse) rendered arrows near the slide origin instead of at the target. Cause: `siteWorldPos` reads `el.frame.x/y` as slide-world coords, but group children are stored with frames in their parent group's local space, and `flattenElements` flattened the tree without lifting those frames.
- New `buildElementWorldLookup(elements)` in `packages/slides/src/model/group.ts` walks the tree DFS while composing ancestor `groupToTransform`s and emits each non-top-level entry with its frame rewritten through `applyMatrix`. Replaces the `flattenElements`-based lookup at every connector-resolver callsite (slide-renderer, two editor sites, overlay, store).
- `flattenElements` is kept for callers that only need tree topology (iterating connectors by id/type). The design-doc section in `docs/design/slides/slides-connectors.md` documents which lookup belongs where.

## Test plan

- [x] `pnpm verify:fast` green
- [x] New unit tests in `connector-frame.test.ts` cover: shape nested in a group, group children with world frames, nested groups composing transforms, group scaling propagating to children, nested group elements themselves lifted to world frames
- [x] Manual smoke on the affected deck (user-verified) — slide 24 arrows now land on the avatar