### PR TITLE
Slides: edit text inside shapes (PowerPoint / Google Slides parity)

### DIFF
--- a/docs/design/slides/slides-shapes.md
+++ b/docs/design/slides/slides-shapes.md
@@ -48,8 +48,6 @@ task docs under `docs/tasks/`.
 - **Connector behaviour.** `line` and `arrow` are free-floating;
   elbow / curved connectors that snap between two source elements
   are a separate workstream.
-- **Shape-internal text.** Text inside a shape continues to be a
-  separate `TextElement` overlapping the shape, as today.
 - **Path-precise hit-testing.** Selection still uses the rotated
   frame AABB. Click-through-the-hole-of-donut behaviour using
   `ctx.isPointInPath(path, x, y)` is a follow-up.
@@ -95,6 +93,11 @@ export type ShapeElement = ElementBase & {
     adjustments?: number[];
     fill?: ThemeColor;
     stroke?: ShapeStroke;
+    /**
+     * Optional inline text body painted on top of the fill/stroke.
+     * Absent on freshly-inserted shapes. See `Shape text body` below.
+     */
+    text?: TextBody;
   };
 };
 ```
@@ -120,6 +123,83 @@ The full OOXML catalog has ~187 `prstGeom` presets. The remaining
 it lands, `ShapeKind` will gain a `'preset'` variant with
 `data.presetName: string`. We don't reserve the slot up front
 because an unused field would expose noise in the live schema.
+
+### Shape text body
+
+Shapes can carry inline text directly via `data.text`, painted on
+top of the fill/stroke. Matches PowerPoint and Google Slides where
+every autoshape is a text container (double-click / Enter / type-
+to-edit all enter text editing inside the shape).
+
+```ts
+// packages/slides/src/model/element.ts
+export type TextBody = {
+  blocks: Block[];
+  autofit?: AutofitMode;
+  verticalAnchor?: VerticalAnchorMode;
+};
+```
+
+The same `TextBody` shape backs `TextElement.data` (via intersection
+with `{ fill?, stroke? }`) so the docs text-box editor, the canvas
+text renderer, and the autofit / vertical-anchor wiring all reuse
+one structural type across both element kinds.
+
+**Render order.** `shape-renderer.ts:drawShape` paints fill → stroke
+→ `paintTextBody(ctx, size, data.text, theme, {padding, defaultVerticalAnchor})`
+in that order, where `paintTextBody` is exported from
+`text-renderer.ts` and shared with `drawText`. Shape callers pass
+`SHAPE_TEXT_PADDING = { x: 14.4, y: 7.2 }` (PowerPoint's default
+`<a:bodyPr lIns="91440" tIns="45720">` converted at the deck scale)
+and `defaultVerticalAnchor: 'middle'`.
+
+**Editor entry.** Double-click and the type-to-edit / F2 / Enter
+keyboard rules accept `el.type === 'shape'` in addition to
+`'text'`. `enterEditMode` builds an `EditTarget` descriptor that
+papers over the per-kind differences:
+
+| | TextElement | ShapeElement |
+| --- | --- | --- |
+| blocks | `data.blocks` | `data.text?.blocks ?? [seed]` |
+| edit frame | `element.frame` | element frame inset by `SHAPE_TEXT_PADDING` |
+| autofit default | `'grow'` (frame tracks content) | `'none'` (frame is user-sized) |
+| verticalAnchor default | `'top'` | `'middle'` |
+| commit bridge | `store.withTextElement` | `store.withShapeText` |
+| post-commit frame fit | yes (auto-grow) | no |
+
+**Store API.** `SlidesStore.withShapeText(slideId, elementId, cb)`
+mirrors `withTextElement` but reads/writes `data.text.blocks`. It
+seeds an empty body on first entry and drops `data.text` again on
+commit when the body ends up empty so freshly-inserted shapes never
+accumulate empty `<p:txBody>` cruft on round-trips.
+
+**PPTX mapping.** OOXML `<p:sp>` always pairs `<p:spPr>` (shape
+props) with `<p:txBody>`; the importer folds `<p:txBody>` directly
+into `ShapeElement.data.text`. Stand-alone text boxes (`txBox`
+preset, no `prstGeom`) keep producing a `TextElement` — `txBox` is
+OOXML's text-box-only preset and has no shape geometry. Pre-feature
+imports of labelled shapes layered (`ShapeElement` + paired
+`TextElement`); the new form is one element.
+
+**v1 limitations.**
+- *Type-to-edit first character.* The keystroke is consumed
+  (`preventDefault`) and enters edit mode, but the first character is
+  not yet inserted into the freshly-mounted text-box — the user has
+  to type it again. Forwarding the initial character requires threading
+  an `initialText` through `mountSlidesTextBox` into the docs editor;
+  deferred as a follow-up.
+- *Two import formats coexist in Yorkie storage.* Pre-feature decks
+  imported a labelled shape as two layered elements (`ShapeElement`
+  with no text + paired `TextElement` overlay); those documents keep
+  rendering in the layered form indefinitely (no migration). Decks
+  imported after this feature use the folded form (one `ShapeElement`
+  with `data.text`). Visually the two differ only in the default
+  inset and anchor — the folded form picks up the PowerPoint default
+  inset (`SHAPE_TEXT_PADDING`) and `'middle'` anchor; the layered form
+  uses whatever the paired TextElement was positioned at. Both render
+  fine; future contributors editing this branch should be aware that
+  the `parseSp` prstGeom branch and the legacy reader paths can both
+  appear in a single workspace.
 
 ### Renderer architecture
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides shape inline text (2026-05-31) | [20260531-slides-shape-inline-text-todo.md](./active/20260531-slides-shape-inline-text-todo.md) | [20260531-slides-shape-inline-text-lessons.md](./active/20260531-slides-shape-inline-text-lessons.md) |
 | cursor follows text color (2026-05-30) | [20260530-cursor-follows-text-color-todo.md](./active/20260530-cursor-follows-text-color-todo.md) | [20260530-cursor-follows-text-color-lessons.md](./active/20260530-cursor-follows-text-color-lessons.md) |
 | docs pending inline style (2026-05-30) | [20260530-docs-pending-inline-style-todo.md](./active/20260530-docs-pending-inline-style-todo.md) | [20260530-docs-pending-inline-style-lessons.md](./active/20260530-docs-pending-inline-style-lessons.md) |
 | pptx paragraph bullet style (2026-05-30) | [20260530-pptx-paragraph-bullet-style-todo.md](./active/20260530-pptx-paragraph-bullet-style-todo.md) | - |
@@ -39,4 +40,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 230
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: cursor follows text color (2026-05-30)
+Latest active task: slides shape inline text (2026-05-31)

--- a/docs/tasks/active/20260531-slides-shape-inline-text-lessons.md
+++ b/docs/tasks/active/20260531-slides-shape-inline-text-lessons.md
@@ -1,0 +1,96 @@
+# Slides shape inline text — lessons
+
+## Yorkie proxy semantics — `in` operator is unreliable across batches
+
+`'foo' in eAny.data` returned `false` even after a prior `doc.update`
+batch wrote `eAny.data.foo`. The proxy's `has` trap apparently doesn't
+honor fields added by prior batches. Effect: a presence check at the
+top of `YorkieSlidesStore.withShapeText` false-negatived, the
+"no-op-on-no-change" early return fired, and the second `withShapeText`
+call silently skipped the write. The diagnostic was opaque — tests just
+saw stale read values, never an exception.
+
+**Rule for this codebase.** Detect prior-batch field presence via
+`yorkieToPlain(eAny.data.foo) !== undefined`, not the `in` operator.
+For shape text specifically, see
+`packages/frontend/src/app/slides/yorkie-slides-store.ts`
+`withShapeText` — the comment block above `priorTextPlain` documents
+why.
+
+## Yorkie nested-field replacement leaks prior state
+
+After the first `eAny.data.text = { ... }` write created the field,
+overwriting it again via `eAny.data.text = { ...different }` in a
+later batch left readers (`store.read()` + `yorkieToPlain`) seeing the
+ORIGINAL value. Splitting into:
+
+```
+const existing = eAny.data.text as { blocks?, ... } | undefined;
+if (existing) existing.blocks = clone(next);    // mutate sub-field
+else eAny.data.text = clone({ ..., blocks: next });  // create
+```
+
+made the second write visible. Per-key mutation on an existing CRDT-
+backed object propagates as expected; wholesale object replacement on
+top of an existing subtree is opaque. Same rule as `updateElementData`
+(`yorkie-slides-store.ts:1010-1020`), but extended to nested-object
+fields too.
+
+## "Drop on empty" is a destructive op under LWW
+
+The first draft of `withShapeText` called `delete eAny.data.text` when
+the body ended up empty. Code review caught this: under concurrent
+edits, a peer typing into the same shape can have its content wiped
+because `delete` is a wholesale-field LWW op (worse than the per-field
+LWW the sibling `withTextElement.blocks` does). Rule going forward:
+**don't delete CRDT fields you can write into emptily.** Persist an
+empty body instead — the renderer's `isBlocksEmpty` short-circuit
+makes it visually invisible, and `<p:txBody>` cruft is only a
+PPTX-export concern (which doesn't exist yet).
+
+## Filtering "the editing element" needs to be element-kind aware
+
+`editor.ts:render()` removed the editing element from the slide
+canvas to avoid double-painting text. For text elements that's
+correct — the element IS just text. For shapes, the fill/stroke is
+the bulk of the visual; filtering the whole shape made it disappear
+during edit, which the user immediately noticed. The fix:
+element-kind-aware filtering — drop text elements entirely, but for
+shapes clone with `data.text` removed so fill/stroke keep painting
+underneath the editor canvas.
+
+## In-place text-box editor canvas vs. renderer canvas alignment
+
+`mountSlidesTextBox` defaults to `allowEditorGrow = autofit !== 'shrink'`,
+so 'none' autofit still grows the editor canvas to fit text. On mount
+the docs editor measures the initial text and fires
+`onContentHeightChange(textH)`, which **shrinks** the editor canvas to
+text height and re-anchors text at `originY = 0`. The renderer keeps
+the full inner frame and middle-anchors text → visible "jump" on
+commit. Fix: added an explicit `growMode?: 'auto' | 'never'` opt;
+shape edit passes `'never'` so the editor canvas stays at the
+mount-time `frame.h` and the middle anchor agrees with the renderer.
+
+**Rule.** When a docs text-box is in a slot whose **slide frame** does
+NOT track content, the editor canvas mustn't track content either —
+otherwise the live anchor calc diverges from the post-commit anchor
+calc. `autofit === 'none'` alone isn't enough because the docs editor
+treats 'none' as "grow live, don't commit growth"; a separate signal
+is needed.
+
+## Test the visual contract, not just the wiring
+
+The first-pass `shape-renderer-text.test.ts` y-inset test asserted
+only a lower bound (`y >= 7`). A renderer regression that painted
+text 30 px below the inset would pass. Code review caught it. Rule:
+when asserting paint positions, bound from above and below so a
+regression that drifts in either direction fails.
+
+## Don't over-rely on Cmd/text element seeding patterns
+
+`buildInsertElement` seeds text-element inlines with
+`style: { color: DEFAULT_TEXT_COLOR }` (an explicit role binding).
+My shape seed used `style: {}` (implicit, relying on the
+`makeColorResolver` `#000000` → role remap). Both render the same,
+but the asymmetry is confusing; code review flagged it. Picked the
+explicit-role form for consistency.

--- a/docs/tasks/active/20260531-slides-shape-inline-text-todo.md
+++ b/docs/tasks/active/20260531-slides-shape-inline-text-todo.md
@@ -1,0 +1,163 @@
+# Slides — inline text inside shapes
+
+## Problem
+
+In Slides today, shapes (`ShapeElement`) cannot hold text. Double-clicking
+a shape only drills selection — `editor.ts:1869-1903` ignores the hit
+unless `el.type === 'text'`. The workaround is to overlay a separate
+`TextElement` on top of the shape, which:
+
+- Diverges from the user mental model carried over from PowerPoint and
+  Google Slides, where every autoshape is a text container (double-click
+  / Enter / typing all enter text-edit inside the shape).
+- Breaks PPTX round-trip fidelity. OOXML `<p:sp>` always pairs a shape
+  with `<p:txBody>`; on import we currently drop or split the pair, and
+  on export we cannot reconstruct it from an unrelated overlapping
+  `TextElement`.
+- Forces the user to manually align, group, move, and delete two
+  elements that they think of as one.
+
+`docs/design/slides/slides-shapes.md:51-52` explicitly lists
+"Shape-internal text" as a non-goal. That decision is what we are
+revisiting here.
+
+## Goal
+
+A shape can carry inline text in its `data.text` body, edited via the
+same docs text-box editor used for `TextElement`, painted on top of the
+shape's fill/stroke. Behavior matches Google Slides / PowerPoint:
+
+- Double-click a selected shape → enter text edit inside the shape.
+- Typing a printable character while a shape is selected → enter text
+  edit and consume the character (same as Slides/PPT).
+- Text body is optional and absent on freshly inserted shapes; the
+  first edit lazily initializes an empty block.
+- OOXML mapping: `ShapeElement.data.text ↔ <p:sp>/<p:txBody>`.
+
+## Non-goals (for this task)
+
+- Removing `TextElement`. OOXML keeps the "text box" preset distinct
+  from a shape with no fill/stroke; we will too. `TextElement` remains
+  the canonical text-only primitive.
+- Path-clipped text reflow (text wrapping inside arbitrary path
+  geometries — chevrons, callouts). v1 lays text inside the shape's
+  rotated AABB frame, same way `TextElement` lays inside its frame.
+  Logged as a follow-up.
+- Per-shape default text styles (e.g. bold body text inside a
+  `roundRect`). The first keystroke uses the deck theme's default body
+  style, same as `TextElement`.
+
+## Plan
+
+Single PR. Ordering inside the PR keeps each commit `pnpm verify:fast`
+green so the branch is bisectable.
+
+### Step 1 — data model + renderer + edit-mode entry
+
+1. **Extract shared `TextBody` type** in
+   `packages/slides/src/model/element.ts`:
+   ```ts
+   type TextBody = {
+     blocks: Block[];
+     autofit?: AutofitMode;
+     verticalAnchor?: VerticalAnchorMode;
+   };
+   ```
+   `TextElement.data` keeps `blocks/autofit/verticalAnchor/stroke/fill`
+   structure; we just hoist the three shared fields into the alias for
+   reuse in `ShapeElement.data.text?: TextBody`.
+2. **`ShapeElement.data.text?: TextBody`** — optional; absent on
+   freshly inserted shapes. No migration: existing decks read undefined
+   and render as today.
+3. **Renderer** — in the slide element painter, after the shape's
+   fill/stroke pass, if `data.text?.blocks.length`, run the existing
+   `paintLayout` pipeline with the shape's frame as the layout frame.
+   Reuse the same `colorResolver` wiring `TextElement` uses (deck
+   theme aware).
+4. **Edit-mode entry** — in `editor.ts`:
+   - `onDoubleClick` (line 1899): allow `el.type === 'shape'` in
+     addition to `'text'`.
+   - `enterEditMode` (line 1905): when the target is a shape, read
+     `el.data.text?.blocks ?? [emptyBlock()]` and the shape's
+     `autofit` / `verticalAnchor` analogues. The commit path
+     currently calls `store.withTextElement(slideId, elementId, cb)`
+     (`packages/slides/src/store/memory.ts:876-890`), which is
+     text-element-specific. Add a sibling `store.withShapeText` (or
+     widen the existing method) so the Yorkie Tree edits land at
+     `element.data.text.blocks` for shapes instead of
+     `element.data.blocks`. Same atomicity semantics.
+   - If blocks end up empty (no inlines, no text), drop `data.text`
+     on commit so empty shapes don't accumulate empty bodies.
+5. **Hit / selection** — no change. Hit-test still uses the rotated
+   frame AABB; double-click drill-in already drives the right path
+   for grouped shapes.
+6. **Tests**
+   - Model: `addShape` then set `data.text`, render snapshot includes
+     the painted text.
+   - Editor: double-click on a shape → `editingElementId` becomes the
+     shape id; ESC commits and the shape now carries `data.text`.
+   - Renderer: shape with text paints fill/stroke under the text.
+
+### Step 2 — type-to-edit (PPT/Slides parity)
+
+7. **Keystroke router** — when a shape (or text element) is selected
+   and the keystroke is a printable character (not a shortcut), enter
+   edit mode and forward the character to the docs editor as the
+   first insertion. Mirrors PPT/GS. Add a unit test for both shape and
+   text element.
+
+### Step 3 — PPTX import
+
+The slides package currently has **no PPTX exporter** (only
+`importPptx` in `packages/slides/src/index.ts`). Export is a separate
+workstream — out of scope here. Step 3 is import-only.
+
+8. **Importer** — in `packages/slides/src/import/pptx/shape.ts:430-441`,
+   when a `<p:sp>` has both `prstGeom` and `<p:txBody>`, today it
+   emits two layered elements (`ShapeElement` + `TextElement`). Change
+   to emit a single `ShapeElement` with `data.text` populated from
+   the same `parseTextBody` / `detectAutofitMode` / `detectVerticalAnchor`
+   helpers in `packages/slides/src/import/pptx/text.ts`. Keep the
+   `txBox` preset path producing a standalone `TextElement` (per
+   non-goal — `txBox` is OOXML's text-box-only preset).
+9. **Tests** — import a fixture `<p:sp>` with `<p:txBody>` and assert
+   the resulting element is one `ShapeElement` with `data.text.blocks`
+   populated (not the two-element layered form).
+
+### Step 4 — docs + cleanup
+
+11. **Update `docs/design/slides/slides-shapes.md`**:
+    - Remove "Shape-internal text" from the non-goals list.
+    - Add a "Shape text body" section describing the `data.text`
+      contract, render order, and PPTX mapping.
+12. **Cross-link** from `docs/design/slides/slides.md` element table.
+13. Optional helper migration note: if any of the seeded layouts ship
+    a TextElement-over-Shape pair where the shape is purely
+    decorative, consider collapsing into a single shape + text. Not
+    blocking; logged as follow-up if any are found.
+
+## Verification
+
+- `pnpm verify:fast` green before each commit.
+- `pnpm verify:self` before opening the PR (touches model + renderer
+  + PPTX).
+- Manual smoke in `pnpm dev`:
+  - Insert a `roundRect`, double-click, type "Hello", ESC; reload,
+    text persists, paints over the fill.
+  - Insert a shape, type "x" while it's selected (no double-click) —
+    enters edit and inserts "x".
+  - Round-trip via PPTX export → import.
+- Two-client smoke: both clients edit the same shape's text via
+  Yorkie; no divergence.
+
+## Open questions
+
+- **Default vertical anchor for shape text** — Google Slides uses
+  middle for most shapes (rounded rect, ellipse) and top for
+  callouts. PPTX preset defaults are per-shape in OOXML. Simplest v1:
+  `'middle'` for all closed shapes; revisit if it looks wrong on
+  callouts.
+- **Default padding** — PPTX `<a:bodyPr lIns/tIns/rIns/bIns>` defaults
+  are 91440/45720/91440/45720 EMU (≈0.1"/0.05"). For v1 we can either
+  hard-code these or hoist into `TextBody.padding`. Lean toward the
+  hard-coded constants until a PPTX file forces non-default values.

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -33,6 +33,7 @@ import {
   defaultLight,
   generateId,
   getLayout,
+  isBlocksEmpty,
   groupToTransform,
   migrateDocument,
   normalizeToGroupLocal,
@@ -1527,6 +1528,69 @@ export class YorkieSlidesStore implements SlidesStore {
         ...eAny.data,
         blocks: clone(next ?? blocks),
       };
+    });
+  }
+
+  withShapeText(
+    slideId: string,
+    elementId: string,
+    fn: (blocks: Block[]) => Block[] | void,
+  ): void {
+    this.requireBatch();
+    this.doc.update((r) => {
+      const s = r.slides.find((s) => s.id === slideId);
+      if (!s) throw new Error(`Slide not found: ${slideId}`);
+      const path = yorkieFindElementPath(s.elements as unknown as ProxyArray, elementId);
+      if (!path) throw new Error(`Element not found: ${elementId}`);
+      const e = path[path.length - 1];
+      if (e.type !== 'shape') {
+        throw new Error(`Element ${elementId} is not a shape element`);
+      }
+      const eAny = e as { data: Record<string, unknown> };
+      // Detect prior `text` presence via `yorkieToPlain` rather than the
+      // `'text' in eAny.data` operator — the Yorkie proxy doesn't honor
+      // `in` for fields added by prior batches, so the `in` check
+      // false-negatives across batch boundaries and skips writes.
+      const priorTextPlain = yorkieToPlain<{
+        blocks?: Block[];
+        autofit?: unknown;
+        verticalAnchor?: unknown;
+      }>(eAny.data.text);
+      const hadTextField = priorTextPlain !== undefined;
+      const priorText = priorTextPlain ?? {};
+      const priorBlocks = priorText.blocks ?? [];
+      const returned = fn(priorBlocks);
+      const nextBlocks = returned !== undefined ? clone(returned) : priorBlocks;
+      // Concurrency-safety: we only ever WRITE the `data.text` field
+      // — we never DELETE it. Deleting a whole field is a
+      // wholesale-LWW op that can race against a concurrent peer's
+      // typing in a way that wipes their content; writing
+      // `{ ...text, blocks: [] }` is a per-field LWW op symmetric
+      // with what `withTextElement.blocks` already does.
+      //
+      // The one shortcut: if the shape entered the edit with no body
+      // (`data.text` absent) and exits with no body, skip the write
+      // so we don't materialise an empty body on shapes the user
+      // never typed into. Existing bodies the user cleared retain an
+      // empty body (visually invisible — the renderer short-circuits
+      // via `isBlocksEmpty`).
+      if (isBlocksEmpty(nextBlocks) && !hadTextField) return;
+      // Write strategy: for the FIRST write (no prior `text` field),
+      // create the whole `text` object via assignment to `eAny.data.text`.
+      // For SUBSEQUENT writes, mutate only the `blocks` sub-field of the
+      // existing Yorkie subtree — re-assigning the whole `text` object on
+      // top of an existing Yorkie subtree leaves the prior subtree's
+      // state visible to readers (Yorkie's wholesale-replace semantic
+      // for nested objects is opaque); but per-key assignment on a
+      // CRDT-backed object propagates as expected.
+      const existingText = eAny.data.text as
+        | { blocks?: unknown; autofit?: unknown; verticalAnchor?: unknown }
+        | undefined;
+      if (existingText !== undefined) {
+        existingText.blocks = clone(nextBlocks);
+      } else {
+        eAny.data.text = clone({ ...priorText, blocks: nextBlocks });
+      }
     });
   }
 

--- a/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
@@ -344,3 +344,107 @@ describe('YorkieSlidesStore — group / ungroup', () => {
     expect(updated.frame.x).toBe(99);
   });
 });
+
+describe('YorkieSlidesStore — withShapeText', () => {
+  // Inline test helpers — the docs Block schema is straightforward and
+  // a one-line constructor is cheaper than importing a fixture util.
+  type TestBlock = {
+    id: string;
+    type: 'paragraph';
+    inlines: Array<{ text: string; style: Record<string, never> }>;
+    style: Record<string, never>;
+  };
+  const paragraph = (text: string, id = 'p1'): TestBlock => ({
+    id,
+    type: 'paragraph',
+    inlines: [{ text, style: {} }],
+    style: {},
+  });
+
+  function addShape(
+    store: YorkieSlidesStore,
+  ): { slideId: string; shapeId: string } {
+    let slideId = '';
+    let shapeId = '';
+    store.batch(() => {
+      slideId = store.addSlide('blank');
+      shapeId = store.addElement(slideId, {
+        type: 'shape',
+        frame: { x: 0, y: 0, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb', value: '#abc' } },
+      });
+    });
+    return { slideId, shapeId };
+  }
+
+  it('writes data.text on a shape that had none and round-trips through read()', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    const { slideId, shapeId } = addShape(store);
+    store.batch(() => {
+      store.withShapeText(slideId, shapeId, (blocks) => {
+        // First entry: shape has no prior body, so the callback receives [].
+        expect(blocks).toEqual([]);
+        return [paragraph('Hello') as never];
+      });
+    });
+    const el = store.read().slides[0].elements[0] as {
+      data: { text?: { blocks: Array<{ inlines: Array<{ text: string }> }> } };
+    };
+    expect(el.data.text?.blocks[0].inlines[0].text).toBe('Hello');
+  });
+
+  it('preserves an empty body after the user clears prior text (no destructive delete)', () => {
+    // Concurrency contract: once data.text exists, withShapeText only
+    // writes the `blocks` field — it never deletes data.text. A peer
+    // typing into the same shape during a blur must not have its
+    // content wiped by a wholesale-field delete.
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    const { slideId, shapeId } = addShape(store);
+    store.batch(() => {
+      store.withShapeText(slideId, shapeId, () => [paragraph('typed') as never]);
+    });
+    store.batch(() => {
+      store.withShapeText(slideId, shapeId, () => [paragraph('') as never]);
+    });
+    const el = store.read().slides[0].elements[0] as {
+      data: { text?: { blocks: Array<{ inlines: Array<{ text: string }> }> } };
+    };
+    expect(el.data.text).toBeDefined();
+    expect(el.data.text!.blocks[0].inlines[0].text).toBe('');
+  });
+
+  it('is a no-op when entered without and exited without data.text (click-in-then-blur)', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    const { slideId, shapeId } = addShape(store);
+    store.batch(() => {
+      store.withShapeText(slideId, shapeId, () => [paragraph('') as never]);
+    });
+    const el = store.read().slides[0].elements[0] as {
+      data: { text?: unknown };
+    };
+    expect(el.data.text).toBeUndefined();
+  });
+
+  it('throws on a non-shape element', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    let slideId = '';
+    let textId = '';
+    store.batch(() => {
+      slideId = store.addSlide('blank');
+      textId = store.addElement(slideId, {
+        type: 'text',
+        frame: { x: 0, y: 0, w: 100, h: 40, rotation: 0 },
+        data: { blocks: [] },
+      });
+    });
+    expect(() =>
+      store.batch(() =>
+        store.withShapeText(slideId, textId, () => undefined),
+      ),
+    ).toThrow(/not a shape element/);
+  });
+});

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -6,6 +6,7 @@ import type {
   PlaceholderType,
   ShapeElement,
   ShapeStroke,
+  TextBody,
   TextElement,
 } from '../../model/element';
 import { generateId } from '../../model/element';
@@ -423,22 +424,25 @@ async function parseSp(sp: Element, ctx: SlideParseContext): Promise<SlideElemen
     // contributes whatever geometry / text it has rather than vanishing.
   }
 
-  // Shape with `prstGeom` — emit the shape, then layer a coincident
-  // TextElement on top when the shape also carries visible text (the
-  // "labelled rect / callout" pattern, ubiquitous in PowerPoint).
+  // Shape with `prstGeom` — emit a single ShapeElement. If the OOXML
+  // `<p:sp>` carries a non-empty `<p:txBody>`, fold it into
+  // `data.text` so the shape owns its inline text directly (matches
+  // PowerPoint / Google Slides where every autoshape is a text
+  // container). The renderer paints `data.text` on top of the shape's
+  // fill/stroke; the editor's double-click / type-to-edit paths route
+  // through `withShapeText`. Pre-shape-text-body imports used a paired
+  // (`ShapeElement`, `TextElement`) layered form; the new form is one
+  // element. Placeholder-bound shapes still propagate `placeholderRef`
+  // — it lives on the element itself, not on the text body, so the
+  // layout-slot identity transfers naturally to the shape.
   const prstGeom = spPr ? child(spPr, 'prstGeom') : undefined;
   if (prstGeom) {
     const shape = buildShapeElement(elementId, frame, sp, prstGeom, ctx);
-    if (!hasText) return [shape];
-    const text = buildTextElement(
-      generateId(),
-      frame,
-      txBody!,
-      ctx,
-      placeholderRef,
-      layoutSizeKey,
-    );
-    return [shape, text];
+    if (hasText) {
+      shape.data.text = buildTextBody(txBody!, ctx, placeholderRef, layoutSizeKey);
+    }
+    if (placeholderRef) shape.placeholderRef = placeholderRef;
+    return [shape];
   }
 
   // No prstGeom but has text — treat as plain text box.
@@ -548,6 +552,28 @@ function buildTextElement(
   placeholderRef: PlaceholderRef | undefined,
   layoutSizeKey: string | undefined,
 ): TextElement {
+  return {
+    id,
+    type: 'text',
+    frame,
+    ...(placeholderRef ? { placeholderRef } : {}),
+    data: buildTextBody(txBody, ctx, placeholderRef, layoutSizeKey),
+  };
+}
+
+/**
+ * Parse a `<p:txBody>` (the OOXML element that PPTX uses for both
+ * stand-alone text boxes and the text inside shapes) into a `TextBody`.
+ * Shared between `buildTextElement` (text-only `<p:sp>`) and the
+ * prstGeom branch of `parseSp` (shape `<p:sp>` whose `<p:txBody>` now
+ * folds into `ShapeElement.data.text`).
+ */
+function buildTextBody(
+  txBody: Element,
+  ctx: SlideParseContext,
+  placeholderRef: PlaceholderRef | undefined,
+  layoutSizeKey: string | undefined,
+): TextBody {
   // Inheritance order: layout placeholder default (parsed from the
   // imported deck) → hardcoded per-type fallback for placeholders we
   // recognise → leave undefined (docs renderer default).
@@ -561,21 +587,15 @@ function buildTextElement(
   );
   const verticalAnchor = detectVerticalAnchor(txBody);
   return {
-    id,
-    type: 'text',
-    frame,
-    ...(placeholderRef ? { placeholderRef } : {}),
-    data: {
-      autofit: detectAutofitMode(txBody),
-      ...(verticalAnchor !== undefined ? { verticalAnchor } : {}),
-      blocks: parseTextBody(txBody, {
-        rels: ctx.rels,
-        report: ctx.report,
-        defaultFontSize,
-        clrMap: ctx.clrMap,
-        markerDefaults,
-      }),
-    },
+    autofit: detectAutofitMode(txBody),
+    ...(verticalAnchor !== undefined ? { verticalAnchor } : {}),
+    blocks: parseTextBody(txBody, {
+      rels: ctx.rels,
+      report: ctx.report,
+      defaultFontSize,
+      clrMap: ctx.clrMap,
+      markerDefaults,
+    }),
   };
 }
 

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -58,10 +58,11 @@ export type {
   ShapeKind,
   ShapeStroke,
   Stroke,
+  TextBody,
   TextElement,
   VerticalAnchorMode,
 } from './model/element';
-export { generateId } from './model/element';
+export { generateId, isBlocksEmpty, isElementEmpty } from './model/element';
 
 export type { GroupTransform } from './model/group';
 export {

--- a/packages/slides/src/model/element.ts
+++ b/packages/slides/src/model/element.ts
@@ -136,33 +136,42 @@ export type ElementBase = {
   placeholderRef?: PlaceholderRef;
 };
 
+/**
+ * Shared shape of a text body — the inline content plus the OOXML
+ * `<a:bodyPr>`-equivalent props that govern its layout. Used as
+ * `TextElement.data` (via intersection) and as `ShapeElement.data.text`
+ * for shapes that carry inline text. Mirrors OOXML `<a:txBody>`.
+ */
+export type TextBody = {
+  /** Domain-level read view; the Yorkie store backs this with a Tree. */
+  blocks: Block[];
+  /**
+   * Autofit behavior. **Absent ⇒ `'grow'`** (the pre-autofit auto-grow
+   * default established by the `slides-textbox-autogrow` feature) so
+   * existing decks keep growing. Set `'none'` explicitly to disable
+   * auto-grow; `'shrink'` to scale fonts to a fixed box. See
+   * `docs/design/slides/slides-text-autofit.md`.
+   */
+  autofit?: AutofitMode;
+  /**
+   * Vertical position of the laid-out content inside the text frame.
+   * Mirrors OOXML `<a:bodyPr anchor>`:
+   * - `'top'` ↔ `anchor="t"` (and absent — preserves pre-feature behavior)
+   * - `'middle'` ↔ `anchor="ctr"`
+   * - `'bottom'` ↔ `anchor="b"`
+   *
+   * Imported from PPTX; the renderer translates the paint origin by
+   * `(frame.h − layout.totalHeight) * factor` so content sits at the
+   * top / middle / bottom of the frame.
+   */
+  verticalAnchor?: VerticalAnchorMode;
+};
+
 export type TextElement = ElementBase & {
   type: 'text';
-  data: {
-    /** Domain-level read view; the Yorkie store backs this with a Tree. */
-    blocks: Block[];
+  data: TextBody & {
     stroke?: Stroke;
     fill?: ThemeColor;
-    /**
-     * Autofit behavior. **Absent ⇒ `'grow'`** (the pre-autofit auto-grow
-     * default established by the `slides-textbox-autogrow` feature) so
-     * existing decks keep growing. Set `'none'` explicitly to disable
-     * auto-grow; `'shrink'` to scale fonts to a fixed box. See
-     * `docs/design/slides/slides-text-autofit.md`.
-     */
-    autofit?: AutofitMode;
-    /**
-     * Vertical position of the laid-out content inside the text frame.
-     * Mirrors OOXML `<a:bodyPr anchor>`:
-     * - `'top'` ↔ `anchor="t"` (and absent — preserves pre-feature behavior)
-     * - `'middle'` ↔ `anchor="ctr"`
-     * - `'bottom'` ↔ `anchor="b"`
-     *
-     * Imported from PPTX; the renderer translates the paint origin by
-     * `(frame.h − layout.totalHeight) * factor` so content sits at the
-     * top / middle / bottom of the frame.
-     */
-    verticalAnchor?: VerticalAnchorMode;
   };
 };
 
@@ -196,6 +205,14 @@ export type ShapeElement = ElementBase & {
     adjustments?: number[];
     fill?: ThemeColor;
     stroke?: Stroke;
+    /**
+     * Inline text body painted on top of the shape's fill/stroke.
+     * Absent on freshly-inserted shapes; lazily initialised when the
+     * user enters text-edit (double-click, Enter, or type-to-edit) and
+     * dropped again on commit when the body ends up empty. Mirrors
+     * OOXML `<p:sp>/<p:txBody>` for PPTX round-trip.
+     */
+    text?: TextBody;
   };
 };
 
@@ -245,7 +262,20 @@ export function generateId(): string {
 
 export function isElementEmpty(el: Element): boolean {
   if (el.type !== 'text') return false;
-  return el.data.blocks.every((b) =>
-    b.inlines.every((inline) => inline.text === ''),
+  return isBlocksEmpty(el.data.blocks);
+}
+
+/**
+ * True iff a `Block[]` carries no visible characters — either zero
+ * blocks or every inline is the empty string. Shared between the
+ * text renderer (placeholder ghost-text branch), the shape renderer
+ * (skip text paint when shape's body is empty), and the store
+ * (`withShapeText` drops `data.text` again when an edit leaves the
+ * body empty so OOXML round-trips don't carry empty `<p:txBody>`).
+ */
+export function isBlocksEmpty(blocks: Block[]): boolean {
+  return (
+    blocks.length === 0 ||
+    blocks.every((b) => b.inlines.every((inline) => inline.text === ''))
   );
 }

--- a/packages/slides/src/node.ts
+++ b/packages/slides/src/node.ts
@@ -58,9 +58,10 @@ export type {
   ShapeKind,
   ShapeStroke,
   Stroke,
+  TextBody,
   TextElement,
 } from './model/element';
-export { generateId } from './model/element';
+export { generateId, isBlocksEmpty, isElementEmpty } from './model/element';
 
 export type { Point } from './model/frame';
 export { boundingBox, combinedBoundingBox, containsPoint, toLocal } from './model/frame';

--- a/packages/slides/src/store/memory.ts
+++ b/packages/slides/src/store/memory.ts
@@ -10,7 +10,7 @@ import type { Block } from '@wafflebase/docs';
 import type { ArrowheadStyle, Endpoint } from '../model/connector';
 import type { Stroke } from '../model/element';
 import type { Element, ElementInit, Frame, GroupElement } from '../model/element';
-import { generateId } from '../model/element';
+import { generateId, isBlocksEmpty } from '../model/element';
 import { BUILT_IN_LAYOUTS, applyLayoutToSlide, getLayout, slotRefsForLayout } from '../model/layout';
 import { DEFAULT_BACKGROUND } from '../model/presentation';
 import { DEFAULT_MASTER } from '../model/master';
@@ -888,6 +888,41 @@ export class MemSlidesStore implements SlidesStore {
     if (next !== undefined) {
       e.data.blocks = clone(next);
     }
+  }
+
+  withShapeText(
+    slideId: string, elementId: string,
+    fn: (blocks: Block[]) => Block[] | void,
+  ): void {
+    this.requireBatch();
+    const slide = this.requireSlide(slideId);
+    const e = this.requireElement(slide, elementId);
+    if (e.type !== 'shape') {
+      throw new Error(`Element ${elementId} is not a shape element`);
+    }
+    // Seed an empty body on first entry so `fn` always receives the
+    // canonical mutable handle.
+    const prior = e.data.text?.blocks ?? [];
+    const returned = fn(prior);
+    const next = returned !== undefined ? clone(returned) : prior;
+    // Concurrency-safety contract (mirrors `withTextElement.blocks`):
+    // we only ever write the `data.text.blocks` field — we do NOT
+    // delete the whole `data.text` field on empty commits. A blur on
+    // an empty body must not race against a peer's typing in a way
+    // that wipes their text wholesale (deleting `data.text` is a
+    // wholesale-field LWW op; writing `{ ...text, blocks: [] }` is a
+    // per-field LWW op symmetric with what `withTextElement` does).
+    //
+    // The one shortcut: if the shape entered the edit with no body and
+    // exits with no body (click-in-and-out without typing), we skip
+    // the write entirely so we don't materialise an empty body on
+    // shapes the user never typed into. Existing bodies that the user
+    // cleared retain an empty body (visually invisible — the renderer
+    // short-circuits via `isBlocksEmpty`).
+    if (isBlocksEmpty(next) && isBlocksEmpty(prior) && e.data.text === undefined) {
+      return;
+    }
+    e.data.text = { ...e.data.text, blocks: next };
   }
 
   withNotes(

--- a/packages/slides/src/store/store.ts
+++ b/packages/slides/src/store/store.ts
@@ -172,6 +172,18 @@ export interface SlidesStore {
     elementId: string,
     fn: (blocks: Block[]) => Block[] | void,
   ): void;
+  /**
+   * Mutate the optional inline text body of a shape element
+   * (`data.text.blocks`). Implementations seed an empty body when
+   * `data.text` is absent and drop the field again on commit if the
+   * resulting blocks carry no visible characters, so freshly-inserted
+   * shapes never accumulate empty `<p:txBody>` cruft.
+   */
+  withShapeText(
+    slideId: string,
+    elementId: string,
+    fn: (blocks: Block[]) => Block[] | void,
+  ): void;
   /** Mutate a slide's speaker notes via the docs Tree. */
   withNotes(
     slideId: string,

--- a/packages/slides/src/view/canvas/shape-renderer.ts
+++ b/packages/slides/src/view/canvas/shape-renderer.ts
@@ -5,8 +5,25 @@ import { resolveStrokeColor } from './render-context';
 import { PATH_BUILDERS } from './shapes';
 import { isActionButton } from './shapes/action-buttons';
 import type { FrameSize } from './shapes/builder';
+import { paintTextBody } from './text-renderer';
 
 export type { FrameSize } from './shapes/builder';
+
+/**
+ * Insets (in deck-canvas px at the default 1920×1080 size) applied when
+ * painting a shape's `data.text`. Mirrors PowerPoint's default
+ * `<a:bodyPr lIns="91440" tIns="45720">` — 0.1" / 0.05" — converted at
+ * the deck scale (91440 EMU × 1920 / 12192000 EMU = 14.4 px;
+ * 45720 EMU × 1920 / 12192000 EMU = 7.2 px). These match what an
+ * unmodified shape in PowerPoint / Google Slides shows so inserted
+ * shapes look right out of the box.
+ *
+ * Exported so the editor's `enterEditMode` can inset the in-place
+ * text-box editing frame by the same amount — the user's caret and
+ * glyphs while editing land where the committed paint will, without
+ * a visible "shift" on commit.
+ */
+export const SHAPE_TEXT_PADDING = { x: 14.4, y: 7.2 } as const;
 
 const placeholderWarned = new Set<string>();
 
@@ -54,7 +71,9 @@ export function drawShape(
   theme: Theme,
 ): void {
   if (isActionButton(data.kind)) {
-    return drawActionButton(ctx, size, data, theme);
+    drawActionButton(ctx, size, data, theme);
+    paintShapeText(ctx, size, data, theme);
+    return;
   }
 
   const builder = PATH_BUILDERS.get(data.kind);
@@ -83,6 +102,7 @@ export function drawShape(
     ctx.lineJoin = 'round';
     ctx.stroke(path);
   }
+  paintShapeText(ctx, size, data, theme);
 }
 
 function drawPlaceholderRect(
@@ -100,4 +120,24 @@ function drawPlaceholderRect(
     ctx.lineWidth = data.stroke.width;
     ctx.strokeRect(0, 0, w, h);
   }
+  paintShapeText(ctx, { w, h }, data, theme);
+}
+
+/**
+ * Paint a shape's optional inline text body on top of its fill/stroke,
+ * using PowerPoint-default insets and a `'middle'` vertical anchor
+ * default (matches what PowerPoint / Google Slides do when a shape is
+ * created and the user types into it without changing alignment).
+ */
+function paintShapeText(
+  ctx: CanvasRenderingContext2D,
+  size: FrameSize,
+  data: ShapeElement['data'],
+  theme: Theme,
+): void {
+  if (!data.text) return;
+  paintTextBody(ctx, size, data.text, theme, {
+    padding: SHAPE_TEXT_PADDING,
+    defaultVerticalAnchor: 'middle',
+  });
 }

--- a/packages/slides/src/view/canvas/text-renderer.ts
+++ b/packages/slides/src/view/canvas/text-renderer.ts
@@ -8,11 +8,16 @@ import {
   type StoredColor,
 } from '@wafflebase/docs';
 import { computeAutofitScale, scaleBlocks } from '../../model/autofit';
-import type { TextElement, VerticalAnchorMode } from '../../model/element';
+import {
+  isBlocksEmpty,
+  type TextBody,
+  type TextElement,
+  type VerticalAnchorMode,
+} from '../../model/element';
 import type { PlaceholderStyle } from '../../model/master';
 import type { Theme, ThemeColor } from '../../model/theme';
 import { resolveColor, resolveFont } from '../../model/theme';
-import type { FrameSize } from './shape-renderer';
+import type { FrameSize } from './shapes/builder';
 
 /**
  * Module-scope measurer reused across every text-element render. Owning
@@ -91,11 +96,7 @@ export function drawText(
   // a placeholder seeded by `buildInsertElement` typically has one
   // block with one inline whose `text === ''`, so the cheaper-to-detect
   // `data.blocks.length === 0` case alone is not sufficient.
-  const allEmpty =
-    data.blocks.length === 0 ||
-    data.blocks.every((b) => b.inlines.every((inl) => inl.text === ''));
-
-  if (allEmpty) {
+  if (isTextBodyEmpty(data)) {
     if (options?.placeholderHint) {
       // Hint always paints at the top of the frame regardless of
       // data.verticalAnchor — placeholder ghost text is not anchor-aware
@@ -110,28 +111,70 @@ export function drawText(
     }
     return;
   }
-  const normalized: Block[] = data.blocks.map((b) => ({
+  paintTextBody(ctx, size, data, theme);
+}
+
+/**
+ * True iff a `TextBody` carries no visible characters. Thin wrapper
+ * over the model-level `isBlocksEmpty`; kept as a named view-layer
+ * symbol because the placeholder-hint branch reads more naturally as
+ * "the text body is empty" than "its blocks are empty".
+ */
+export function isTextBodyEmpty(body: TextBody): boolean {
+  return isBlocksEmpty(body.blocks);
+}
+
+/**
+ * Paint a non-empty `TextBody` into the given frame. Shared between
+ * `drawText` (text elements) and `drawShape` (shapes that carry inline
+ * text via `data.text`). Layout + paint go through
+ * `@wafflebase/docs.paintLayout` so all surfaces produce pixel-identical
+ * output.
+ *
+ * Callers can supply optional `padding` (insets the layout width and
+ * paint origin) and a `defaultVerticalAnchor` (used when the body
+ * doesn't set its own anchor). Shape callers typically pass
+ * `defaultVerticalAnchor: 'middle'` and a small padding to mirror
+ * PowerPoint / Google Slides defaults; text-element callers pass
+ * neither (anchor defaults to `'top'`, padding `0`).
+ *
+ * Skips painting when the body is empty.
+ */
+export function paintTextBody(
+  ctx: CanvasRenderingContext2D,
+  size: FrameSize,
+  body: TextBody,
+  theme: Theme,
+  opts: {
+    padding?: { x: number; y: number };
+    defaultVerticalAnchor?: VerticalAnchorMode;
+  } = {},
+): void {
+  if (isTextBodyEmpty(body)) return;
+  const padX = opts.padding?.x ?? 0;
+  const padY = opts.padding?.y ?? 0;
+  const innerW = Math.max(0, size.w - 2 * padX);
+  const innerH = Math.max(0, size.h - 2 * padY);
+  const normalized: Block[] = body.blocks.map((b) => ({
     ...b,
     style: normalizeBlockStyle(b.style),
   }));
   const colorResolver = makeColorResolver(theme);
 
-  // Shrink autofit: scale fonts down so content fits the fixed box. The
+  // Shrink autofit: scale fonts down so content fits the inner box. The
   // same scale is applied in the in-place editor (text-box-editor.ts) so
   // the committed canvas and editing surface stay pixel-identical.
   let toLayout = normalized;
-  if (data.autofit === 'shrink') {
-    // padding=0 here so the shrink scale targets the full frame height.
-    // computeVerticalOriginY below also compares against size.h, so the
-    // scaled totalHeight will fit and originY stays non-negative. If a
-    // future caller changes the padding arg, mirror it in originY.
-    const scale = computeAutofitScale(normalized, measurer, size.w, size.h, 0);
+  if (body.autofit === 'shrink') {
+    const scale = computeAutofitScale(normalized, measurer, innerW, innerH, 0);
     if (scale !== 1) toLayout = scaleBlocks(normalized, scale);
   }
 
-  const { layout } = computeLayout(toLayout, measurer, size.w);
-  const originY = computeVerticalOriginY(data.verticalAnchor, size.h, layout.totalHeight);
-  paintLayout(ctx, layout, 0, originY, { colorResolver });
+  const { layout } = computeLayout(toLayout, measurer, innerW);
+  const anchor = body.verticalAnchor ?? opts.defaultVerticalAnchor ?? 'top';
+  const originY =
+    padY + computeVerticalOriginY(anchor, innerH, layout.totalHeight);
+  paintLayout(ctx, layout, padX, originY, { colorResolver });
 }
 
 /**

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1,11 +1,16 @@
 import type {
+  AutofitMode,
   Element,
   Frame,
   ShapeKind,
   Stroke,
   ShapeElement,
   TextElement,
+  VerticalAnchorMode,
 } from '../../model/element';
+import type { Block } from '@wafflebase/docs';
+import { DEFAULT_BLOCK_STYLE } from '@wafflebase/docs';
+import { SHAPE_TEXT_PADDING } from '../canvas/shape-renderer';
 import type { ThemeColor } from '../../model/theme';
 import type { ConnectorElement } from '../../model/connector';
 import { combinedBoundingBox, containsPoint } from '../../model/frame';
@@ -774,16 +779,29 @@ class SlidesEditorImpl implements SlidesEditor {
       this.paintRuler();
       return;
     }
-    // Hide the element currently in edit mode from the slide canvas —
-    // the text-box editor's own canvas is layered on top of the same
-    // frame, so leaving the element in the slide pass would double-paint
-    // the text (one copy from `drawText`, one from the editor's
-    // `paintLayout`).
+    // Hide the element-currently-in-edit's text from the slide canvas
+    // so the text-box editor's own canvas doesn't double-paint it (one
+    // copy from `drawText`, one from the editor's `paintLayout`).
+    //
+    // For TextElement the whole element is text, so we filter it out.
+    // For ShapeElement the fill/stroke are still part of the slide and
+    // must keep painting underneath the editor — only the `data.text`
+    // body gets stripped. Cloning is structural-only (no deep block
+    // copy) so this stays cheap on every frame.
     if (this.editingElementId !== null) {
       const editingId = this.editingElementId;
       const visible = {
         ...slide,
-        elements: slide.elements.filter((e) => e.id !== editingId),
+        elements: slide.elements
+          .map((e) => {
+            if (e.id !== editingId) return e;
+            if (e.type === 'shape') {
+              const { text: _omit, ...rest } = e.data;
+              return { ...e, data: rest } as typeof e;
+            }
+            return null;
+          })
+          .filter((e): e is Element => e !== null),
       };
       this.renderer.forceRender(visible, doc);
       this.paintRuler();
@@ -1918,10 +1936,11 @@ class SlidesEditorImpl implements SlidesEditor {
   }
 
   private onDoubleClick(e: MouseEvent): void {
-    // Double-click on a text element enters edit mode. For grouped
-    // elements, drill in one level first so the user can descend into
-    // groups the same way Google Slides does. Clicks on non-text
-    // non-group elements at the leaf level are ignored.
+    // Double-click enters text-edit on text elements and on shapes
+    // (matches PowerPoint / Google Slides where every autoshape is a
+    // text container). For grouped elements, drill in one level first
+    // so the user descends into groups the same way Google Slides does.
+    // Clicks on other element kinds at the leaf level are ignored.
     const slide = this.currentSlide();
     if (!slide) return;
     const { x, y } = this.clientToLogical(e.clientX, e.clientY);
@@ -1940,14 +1959,14 @@ class SlidesEditorImpl implements SlidesEditor {
     this.selection.doubleClick(hitResult);
     this.refitPoppedScope(beforeScope, this.selection.getScope(), slide.id);
 
-    // After drill-in, check if the newly-selected element is a text box.
+    // After drill-in, check if the newly-selected element accepts text.
     // Use the leaf-most element id from the hit (which is what
     // Selection.doubleClick ultimately lands on at the deepest available
     // scope level).
     const selectedIds = this.selection.get();
     if (selectedIds.length !== 1) return;
     const el = findElement(slide.elements, selectedIds[0]);
-    if (!el || el.type !== 'text') return;
+    if (!el || (el.type !== 'text' && el.type !== 'shape')) return;
     e.preventDefault();
     e.stopPropagation();
     this.enterEditMode(slide.id, el.id);
@@ -1967,11 +1986,21 @@ class SlidesEditorImpl implements SlidesEditor {
     const slide = doc.slides.find((s) => s.id === slideId);
     if (!slide) return;
     const element = slide.elements.find((e) => e.id === elementId);
-    if (!element || element.type !== 'text') return;
+    if (!element || (element.type !== 'text' && element.type !== 'shape')) {
+      return;
+    }
+
+    // Build a small descriptor that papers over the difference between
+    // editing a TextElement (text in `data.blocks`, frame auto-grows to
+    // fit content) and a ShapeElement (text in `data.text.blocks`,
+    // frame is user-sized and does NOT auto-grow into the text). All
+    // the wiring below works off `target` so the two kinds stay aligned.
+    const target = buildEditTarget(element);
 
     // Frame height at entry; the committed fit only writes when the
-    // content height differs from this. Reset the per-edit tracker so a
-    // stale height from a previous edit can't leak into this commit.
+    // content height differs from this (text-element only; shapes skip
+    // the post-commit frame fit). Reset the per-edit tracker so a stale
+    // height from a previous edit can't leak into this commit.
     const enterFrameH = element.frame.h;
     this.lastEditingContentHeight = null;
 
@@ -1986,7 +2015,6 @@ class SlidesEditorImpl implements SlidesEditor {
       this.lastHoverCursor = '';
     }
 
-    const blocks = element.data.blocks;
     // Escape sets `cancelled` first, THEN the docs editor routes the
     // blur cascade through the onCommit branch below. The flag tells
     // onCommit to skip the store write so the user's in-flight edits
@@ -1996,38 +2024,53 @@ class SlidesEditorImpl implements SlidesEditor {
     let cancelled = false;
     const tb = this.mountTextBox({
       overlay: this.options.overlay,
-      frame: element.frame,
+      // Shapes inset the editing frame by the same padding the renderer
+      // applies (`SHAPE_TEXT_PADDING`) so the caret + glyphs in the
+      // editor sit where the committed paint will land. Text elements
+      // pass the full element frame as today.
+      frame: target.editFrame,
       scale: this.scale(),
-      blocks,
+      blocks: target.blocks,
       // Drives editor autofit: 'shrink' scales fonts to fit the fixed box,
       // 'grow' (and absent) tracks content height, 'none' is fixed. The
       // wrapper gates onContentHeightChange so shrink/none never auto-grow.
-      autofit: element.data.autofit,
+      autofit: target.autofit,
+      // Shapes keep the editor canvas at the inner-frame height so the
+      // middle vertical anchor in the editor agrees with the renderer's
+      // middle anchor inside the original frame. Without this the docs
+      // editor would shrink the canvas to text height and anchor at
+      // originY=0, producing a visible jump between edit and committed
+      // positions. Text elements keep the default auto-grow behavior.
+      growMode: target.kind === 'shape' ? 'never' : 'auto',
       // Mirror the slide canvas offset so in-place editing keeps the
       // caret and text glyphs aligned with the committed render.
-      verticalAnchor: element.data.verticalAnchor,
+      verticalAnchor: target.verticalAnchor,
       colorResolver: makeColorResolver(getActiveTheme(doc)),
       onLinkRequest: this.options.onLinkRequest,
       onContentHeightChange: (h: number): void => {
         this.lastEditingContentHeight = h;
       },
       onCommit: (next) => {
-        // Persist via withTextElement and exit edit mode. We snapshot
-        // the slide id at enter-time because the user could have
-        // switched slides during editing — withTextElement only
-        // resolves on the slide we actually edited.
+        // Persist via the kind-appropriate bridge and exit edit mode.
+        // We snapshot the slide id at enter-time because the user could
+        // have switched slides during editing.
         if (!cancelled) {
           try {
             this.options.store.batch(() => {
-              this.options.store.withTextElement(slideId, elementId, () => next);
-              // Fit the frame height to the content in the SAME batch as
-              // the text write — one undo entry, no per-keystroke churn.
-              const h = this.lastEditingContentHeight;
-              if (h !== null) {
-                const targetH = Math.max(MIN_TEXT_BOX_H, h);
-                if (targetH !== enterFrameH) {
-                  this.options.store.updateElementFrame(slideId, elementId, { h: targetH });
+              if (target.kind === 'text') {
+                this.options.store.withTextElement(slideId, elementId, () => next);
+                // Fit the frame height to the content in the SAME batch
+                // as the text write — one undo entry, no per-keystroke
+                // churn. Shapes keep their authored frame; skip the fit.
+                const h = this.lastEditingContentHeight;
+                if (h !== null) {
+                  const targetH = Math.max(MIN_TEXT_BOX_H, h);
+                  if (targetH !== enterFrameH) {
+                    this.options.store.updateElementFrame(slideId, elementId, { h: targetH });
+                  }
                 }
+              } else {
+                this.options.store.withShapeText(slideId, elementId, () => next);
               }
             });
           } catch {
@@ -3452,6 +3495,76 @@ function findElement(elements: readonly Element[], id: string): Element | undefi
   }
   return undefined;
 }
+
+/**
+ * Resolved inputs for a single text-edit session. Both TextElement and
+ * ShapeElement-with-text take the same docs text-box mount path; this
+ * descriptor papers over their per-kind differences:
+ *
+ * - **TextElement** — blocks live at `data.blocks`; the editor frame
+ *   is the element frame; `autofit`/`verticalAnchor` come straight off
+ *   `data`; on commit the frame may auto-grow to fit content.
+ * - **ShapeElement** — blocks live at `data.text?.blocks` (seeded to
+ *   one empty paragraph on first entry); the editor frame is the
+ *   element frame inset by `SHAPE_TEXT_PADDING` so editing aligns
+ *   pixel-for-pixel with the committed paint; `autofit` defaults to
+ *   `'none'` (the shape frame is user-sized and does NOT auto-grow);
+ *   `verticalAnchor` defaults to `'middle'` to match PowerPoint /
+ *   Google Slides behavior.
+ */
+type EditTarget = {
+  kind: 'text' | 'shape';
+  blocks: Block[];
+  autofit?: AutofitMode;
+  verticalAnchor?: VerticalAnchorMode;
+  editFrame: Frame;
+};
+
+function buildEditTarget(element: TextElement | ShapeElement): EditTarget {
+  if (element.type === 'text') {
+    return {
+      kind: 'text',
+      blocks: element.data.blocks,
+      autofit: element.data.autofit,
+      verticalAnchor: element.data.verticalAnchor,
+      editFrame: element.frame,
+    };
+  }
+  const body = element.data.text;
+  const innerFrame: Frame = {
+    x: element.frame.x + SHAPE_TEXT_PADDING.x,
+    y: element.frame.y + SHAPE_TEXT_PADDING.y,
+    w: Math.max(0, element.frame.w - 2 * SHAPE_TEXT_PADDING.x),
+    h: Math.max(0, element.frame.h - 2 * SHAPE_TEXT_PADDING.y),
+    rotation: element.frame.rotation,
+  };
+  return {
+    kind: 'shape',
+    blocks: body?.blocks ?? [emptyShapeTextBlock()],
+    autofit: body?.autofit ?? 'none',
+    verticalAnchor: body?.verticalAnchor ?? 'middle',
+    editFrame: innerFrame,
+  };
+}
+
+/**
+ * Seed block for a shape whose `data.text` is absent at edit-entry.
+ * Mirrors the seed `buildInsertElement` writes for a fresh text element
+ * — fully-populated `style` so `computeLayout` reads non-undefined
+ * `marginTop` / `marginBottom`, and an inline bound to the deck's
+ * `text` color role so newly-typed runs inherit the theme (matches
+ * `interactions/insert.ts`'s text-element seed exactly).
+ */
+function emptyShapeTextBlock(): Block {
+  return {
+    id: 'placeholder',
+    type: 'paragraph',
+    inlines: [{ text: '', style: { color: SHAPE_TEXT_SEED_COLOR } }],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  } as Block;
+}
+
+const SHAPE_TEXT_SEED_COLOR = { kind: 'role' as const, role: 'text' as const };
 
 /**
  * Given a hit result and the current selection scope, return the element id

--- a/packages/slides/src/view/editor/interactions/keyboard.ts
+++ b/packages/slides/src/view/editor/interactions/keyboard.ts
@@ -471,10 +471,10 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
       },
     },
 
-    // F2 / Enter — enter text-edit mode on the selected text element.
-    // Only fires when:
+    // F2 / Enter — enter text-edit mode on the selected text element
+    // or shape. Only fires when:
     //   - exactly one element is selected,
-    //   - that element is type 'text',
+    //   - that element accepts text (type 'text' or 'shape'),
     //   - the focused target isn't an editable input (so Enter still
     //     submits dialogs and the text-box editor's own Enter keeps
     //     inserting newlines).
@@ -491,7 +491,41 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
         const selected = ctx.selection.get();
         if (selected.length !== 1) return;
         const element = slide.elements.find((el) => el.id === selected[0]);
-        if (!element || element.type !== 'text') return;
+        if (!element || (element.type !== 'text' && element.type !== 'shape')) {
+          return;
+        }
+        e.preventDefault();
+        ctx.enterEditMode(slide.id, element.id);
+      },
+    },
+
+    // Type-to-edit — printable keystroke on a single selected text or
+    // shape element enters text-edit mode. Mirrors PowerPoint / Google
+    // Slides where typing a character starts editing inside the shape.
+    //
+    // v1 caveat: the keystroke itself is consumed (preventDefault) so
+    // it doesn't navigate or activate a shortcut, but it is NOT yet
+    // inserted into the freshly-mounted text-box — the user has to type
+    // the first character again. Forwarding the initial character into
+    // the docs editor requires plumbing an `initialText` through
+    // `mountSlidesTextBox` and is logged as a follow-up. Without this
+    // rule the keystroke would fall through to the host (and on most
+    // surfaces do nothing useful) which is the bigger UX bug.
+    {
+      match: (e) =>
+        isPrintableKey(e) &&
+        !isModPressed(e) &&
+        !e.altKey &&
+        !isEditableTarget(e.target),
+      run: (e) => {
+        const slide = currentSlide(ctx);
+        if (!slide) return;
+        const selected = ctx.selection.get();
+        if (selected.length !== 1) return;
+        const element = slide.elements.find((el) => el.id === selected[0]);
+        if (!element || (element.type !== 'text' && element.type !== 'shape')) {
+          return;
+        }
         e.preventDefault();
         ctx.enterEditMode(slide.id, element.id);
       },
@@ -653,6 +687,20 @@ function tryDeserialize(json: string): ElementInit[] | null {
 
 function keyEquals(eventKey: string, target: string): boolean {
   return eventKey.toLowerCase() === target.toLowerCase();
+}
+
+/**
+ * True when the keyboard event represents a single printable character
+ * — what the user thinks of as "typing". Used by the type-to-edit rule
+ * to distinguish a real keystroke ("h") from a navigation/function key
+ * ("ArrowLeft", "F1", "Tab", "Escape"). Modifier-only events
+ * (`'Shift'`) have `key.length > 1` so they fall through.
+ *
+ * The caller must additionally gate on `!isModPressed(e) && !e.altKey`
+ * so Cmd/Ctrl/Alt shortcuts aren't routed into edit mode.
+ */
+function isPrintableKey(e: KeyboardEvent): boolean {
+  return e.key.length === 1;
 }
 
 function isEditableTarget(target: EventTarget | null): boolean {

--- a/packages/slides/src/view/editor/text-box-editor.ts
+++ b/packages/slides/src/view/editor/text-box-editor.ts
@@ -79,6 +79,23 @@ export interface MountSlidesTextBoxOptions {
    */
   autofit?: AutofitMode;
   /**
+   * Override `autofit`'s default canvas-grow behavior. The docs
+   * text-box normally grows its canvas to fit content for both `'grow'`
+   * and `'none'` autofit so live typing isn't clipped (`'shrink'`
+   * scales fonts instead). For shape inline text that growth breaks
+   * vertical-anchor alignment: the editor canvas shrinks to text height
+   * and anchors at originY=0, while the renderer keeps the original
+   * inner-frame height and anchors text in the middle — producing a
+   * visible "jump" between editing and committed positions.
+   *
+   * Set `'never'` to force the editor canvas to stay at the mount-time
+   * `frame.h`. Text overflows during typing identically to how it
+   * overflows after commit, and the middle/bottom anchors keep their
+   * intended position. Use for shape text editing; leave undefined for
+   * text elements (preserves the prior auto-grow behavior).
+   */
+  growMode?: 'auto' | 'never';
+  /**
    * Vertical anchor of the text element. Forwarded to the docs text-box
    * editor so the in-place editor positions text at the same y as the
    * committed slide canvas. Mirrors OOXML `<a:bodyPr anchor>`. Absent ⇒
@@ -155,18 +172,24 @@ export interface SlidesTextBoxEditor {
 }
 
 export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextBoxEditor {
-  const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest, onContentHeightChange, colorResolver, autofit, verticalAnchor } = opts;
+  const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest, onContentHeightChange, colorResolver, autofit, verticalAnchor, growMode } = opts;
 
   // Two related but separate flags:
   // - allowEditorGrow: the editing canvas grows to fit content while the
   //   user types. 'grow' and 'none' both opt in; only 'shrink' keeps the
-  //   editing surface fixed (it scales fonts instead).
+  //   editing surface fixed (it scales fonts instead). A `growMode:
+  //   'never'` opt-in forces this off — used for shape inline text where
+  //   the canvas must stay at the mount-time height so vertical-anchor
+  //   math agrees with the post-commit renderer (otherwise the editor
+  //   shrinks the canvas to text height + originY=0 and the renderer
+  //   anchors text in the middle of the unchanged inner frame, producing
+  //   a visible "jump" between edit and committed positions).
   // - isGrow: the grown height is committed back to frame.h on exit. Only
   //   true autofit-grow does this; 'none' shows overflow live but keeps
   //   the saved box, so post-commit the slide renderer paints the overflow
   //   below the frame just as it did before the edit.
-  const allowEditorGrow = autofit !== 'shrink';
-  const isGrow = autofit !== 'shrink' && autofit !== 'none';
+  const allowEditorGrow = growMode === 'never' ? false : autofit !== 'shrink';
+  const isGrow = autofit !== 'shrink' && autofit !== 'none' && growMode !== 'never';
   const isShrink = autofit === 'shrink';
 
   // Container positioned over the element frame in host-pixel space.

--- a/packages/slides/test/import/pptx/shape.test.ts
+++ b/packages/slides/test/import/pptx/shape.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseSlide } from '../../../src/import/pptx/slide';
+import { ImportReport } from '../../../src/import/pptx/report';
+import type { PptxArchive } from '../../../src/import/pptx/unzip';
+
+function makeArchive(files: Record<string, string>): PptxArchive {
+  return {
+    readText: async (path) => files[path],
+    readBytes: async () => undefined,
+    list: () => [],
+  };
+}
+
+/**
+ * A `<p:sp>` that carries both `prstGeom` (a roundRect) and a non-empty
+ * `<p:txBody>` ("Hi"). Pre-shape-text-body imports emitted this as two
+ * layered elements (ShapeElement + paired TextElement); the new
+ * importer folds the text into the shape's `data.text`.
+ */
+const SLIDE_WITH_SHAPE_AND_TEXT = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Rounded"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="0" y="0"/>
+            <a:ext cx="2000000" cy="1000000"/>
+          </a:xfrm>
+          <a:prstGeom prst="roundRect"><a:avLst/></a:prstGeom>
+          <a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:rPr lang="en-US"/><a:t>Hi</a:t></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
+/**
+ * A `<p:sp>` with `prstGeom` but only an empty paragraph in `<p:txBody>`
+ * — the shape was created but the user never typed in it. PowerPoint
+ * emits an empty `<a:p>` on every shape; the importer must NOT seed an
+ * empty `data.text` for this case (round-trip noise).
+ */
+const SLIDE_WITH_SHAPE_AND_EMPTY_TEXT = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Plain"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="0" y="0"/>
+            <a:ext cx="2000000" cy="1000000"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:endParaRPr/></a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
+describe('parseSlide — shape inline text', () => {
+  it('folds <p:txBody> inside a prstGeom <p:sp> into ShapeElement.data.text', async () => {
+    const slide = await parseSlide({
+      archive: makeArchive({
+        'ppt/slides/slide1.xml': SLIDE_WITH_SHAPE_AND_TEXT,
+      }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    expect(slide).toBeDefined();
+    // Single element, not the legacy two-layered (shape + text) form.
+    expect(slide!.elements).toHaveLength(1);
+    const el = slide!.elements[0];
+    expect(el.type).toBe('shape');
+    if (el.type !== 'shape') return;
+    expect(el.data.kind).toBe('roundRect');
+    expect(el.data.text?.blocks).toBeDefined();
+    expect(el.data.text!.blocks[0].inlines.map((i) => i.text).join('')).toBe('Hi');
+  });
+
+  it('does not seed data.text when the shape\'s txBody carries no visible characters', async () => {
+    const slide = await parseSlide({
+      archive: makeArchive({
+        'ppt/slides/slide1.xml': SLIDE_WITH_SHAPE_AND_EMPTY_TEXT,
+      }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    expect(slide).toBeDefined();
+    expect(slide!.elements).toHaveLength(1);
+    const el = slide!.elements[0];
+    expect(el.type).toBe('shape');
+    if (el.type !== 'shape') return;
+    expect(el.data.text).toBeUndefined();
+  });
+});

--- a/packages/slides/test/store/memory.test.ts
+++ b/packages/slides/test/store/memory.test.ts
@@ -306,6 +306,100 @@ describe('MemSlidesStore — text bridges', () => {
     });
   });
 
+  it('withShapeText seeds an empty body on first call and persists the return value', () => {
+    const store = new MemSlidesStore();
+    let id = '';
+    let slideId = '';
+    store.batch(() => {
+      slideId = store.addSlide('blank');
+      id = store.addElement(slideId, shapeInit());
+      store.withShapeText(slideId, id, (blocks) => {
+        // First entry: no prior text, so seeded with [].
+        expect(blocks).toEqual([]);
+        return [paragraph('Hello')];
+      });
+    });
+    const e = store.read().slides[0].elements[0] as {
+      data: { text?: { blocks: Block[] } };
+    };
+    expect(e.data.text?.blocks[0].inlines[0].text).toBe('Hello');
+  });
+
+  it('withShapeText preserves prior blocks on subsequent calls', () => {
+    const store = new MemSlidesStore();
+    let id = '';
+    let slideId = '';
+    store.batch(() => {
+      slideId = store.addSlide('blank');
+      id = store.addElement(slideId, shapeInit());
+      store.withShapeText(slideId, id, () => [paragraph('first')]);
+    });
+    store.batch(() => {
+      store.withShapeText(slideId, id, (blocks) => {
+        expect(blocks[0].inlines[0].text).toBe('first');
+        return [paragraph('second')];
+      });
+    });
+    const e = store.read().slides[0].elements[0] as {
+      data: { text?: { blocks: Block[] } };
+    };
+    expect(e.data.text?.blocks[0].inlines[0].text).toBe('second');
+  });
+
+  it('withShapeText preserves an empty body after the user clears typed text', () => {
+    // Concurrency contract: once `data.text` exists, withShapeText only
+    // writes the `blocks` field — it never deletes `data.text`. A peer
+    // typing into the same shape during a blur must not have its content
+    // wiped by the wholesale-field delete that an earlier draft did.
+    // The renderer's `isBlocksEmpty` short-circuit means an empty body
+    // is visually invisible, so persisting it is harmless.
+    const store = new MemSlidesStore();
+    let id = '';
+    let slideId = '';
+    store.batch(() => {
+      slideId = store.addSlide('blank');
+      id = store.addElement(slideId, shapeInit());
+      store.withShapeText(slideId, id, () => [paragraph('typed')]);
+    });
+    store.batch(() => {
+      store.withShapeText(slideId, id, () => [paragraph('')]);
+    });
+    const e = store.read().slides[0].elements[0] as {
+      data: { text?: { blocks: Block[] } };
+    };
+    expect(e.data.text).toBeDefined();
+    expect(e.data.text!.blocks[0].inlines[0].text).toBe('');
+  });
+
+  it('withShapeText is a no-op when entered with no body and exited with no body', () => {
+    // Click-into-shape-then-blur (no typing) must not materialise an
+    // empty `data.text` on a shape that previously had none — keeps
+    // freshly-inserted shapes clean.
+    const store = new MemSlidesStore();
+    let id = '';
+    let slideId = '';
+    store.batch(() => {
+      slideId = store.addSlide('blank');
+      id = store.addElement(slideId, shapeInit());
+      store.withShapeText(slideId, id, () => [paragraph('')]);
+    });
+    const e = store.read().slides[0].elements[0] as {
+      data: { text?: { blocks: Block[] } };
+    };
+    expect(e.data.text).toBeUndefined();
+  });
+
+  it('withShapeText throws on a non-shape element', () => {
+    const store = new MemSlidesStore();
+    store.batch(() => {
+      const slide = store.addSlide('blank');
+      const id = store.addElement(slide, textInit(0));
+      expect(() => store.withShapeText(slide, id, () => undefined)).toThrow(
+        /not a shape element/,
+      );
+    });
+  });
+
   it('withNotes round-trips the speaker notes', () => {
     const store = new MemSlidesStore();
     store.batch(() => {

--- a/packages/slides/test/view/canvas/shape-renderer-text.test.ts
+++ b/packages/slides/test/view/canvas/shape-renderer-text.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { Block } from '@wafflebase/docs';
+import type { ShapeElement } from '../../../src/model/element';
+import type { Theme } from '../../../src/model/theme';
+import { asCtx, createCtxSpy } from '../../../src/view/canvas/ctx-spy';
+import '../../../src/view/canvas/test-canvas-env';
+
+// Import the renderer *after* the canvas shim is installed so the docs
+// measurer can lazily acquire its fake ctx on first text layout.
+const { drawShape } = await import('../../../src/view/canvas/shape-renderer');
+
+const THEME: Theme = {
+  id: 't',
+  name: 't',
+  colors: {
+    text: '#000',
+    background: '#fff',
+    textSecondary: '#444',
+    backgroundAlt: '#f3f3f3',
+    accent1: '#abc',
+    accent2: '#bcd',
+    accent3: '#cde',
+    accent4: '#def',
+    accent5: '#e0e1e2',
+    accent6: '#f0f1f2',
+    hyperlink: '#11c',
+    visitedHyperlink: '#71a',
+  },
+  fonts: { heading: 'Inter', body: 'Inter' },
+};
+
+const size = { w: 400, h: 200 };
+const srgb = (value: string) => ({ kind: 'srgb' as const, value });
+
+function paragraph(text: string): Block {
+  return {
+    id: `b${Math.random().toString(36).slice(2, 8)}`,
+    type: 'paragraph',
+    inlines: [{ text, style: {} }],
+    style: {},
+  } as Block;
+}
+
+const shape = (data: ShapeElement['data']): ShapeElement['data'] => data;
+
+describe('drawShape — inline text', () => {
+  beforeAll(() => {
+    expect(
+      typeof (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas,
+    ).toBe('function');
+  });
+
+  it('skips text paint when data.text is absent', () => {
+    const ctx = createCtxSpy();
+    drawShape(asCtx(ctx), size, shape({ kind: 'rect', fill: srgb('#abc') }), THEME);
+    expect(ctx.fillText).not.toHaveBeenCalled();
+  });
+
+  it('skips text paint when data.text has no visible characters', () => {
+    const ctx = createCtxSpy();
+    drawShape(
+      asCtx(ctx),
+      size,
+      shape({
+        kind: 'rect',
+        fill: srgb('#abc'),
+        text: { blocks: [paragraph('')] },
+      }),
+      THEME,
+    );
+    expect(ctx.fillText).not.toHaveBeenCalled();
+  });
+
+  it('paints the inline text on top of the shape fill', () => {
+    const ctx = createCtxSpy();
+    drawShape(
+      asCtx(ctx),
+      size,
+      shape({
+        kind: 'rect',
+        fill: srgb('#abc'),
+        text: { blocks: [paragraph('Hello')] },
+      }),
+      THEME,
+    );
+    // Fill happens first; the text runs follow.
+    expect(ctx.fill).toHaveBeenCalledTimes(1);
+    expect(ctx.fillText).toHaveBeenCalled();
+    const joined = ctx.fillText.mock.calls.map((c) => c[0]).join('');
+    expect(joined).toBe('Hello');
+  });
+
+  it('paints text on top of the placeholder-rect fallback for unknown shape kinds', () => {
+    const ctx = createCtxSpy();
+    drawShape(
+      asCtx(ctx),
+      size,
+      shape({
+        kind: '__test_unknown__' as never,
+        fill: srgb('#abc'),
+        text: { blocks: [paragraph('X')] },
+      }),
+      THEME,
+    );
+    expect(ctx.fillRect).toHaveBeenCalledTimes(1); // placeholder fill
+    expect(ctx.fillText).toHaveBeenCalled();
+  });
+
+  it('applies the PowerPoint-default 14.4 / 7.2 px insets to the text origin', () => {
+    const ctx = createCtxSpy();
+    drawShape(
+      asCtx(ctx),
+      size,
+      shape({
+        kind: 'rect',
+        text: {
+          blocks: [paragraph('a')],
+          // Anchor 'top' so we can read the inset y directly from the
+          // first fillText call without subtracting the middle-anchor
+          // offset.
+          verticalAnchor: 'top',
+        },
+      }),
+      THEME,
+    );
+    expect(ctx.fillText).toHaveBeenCalled();
+    const [, x, y] = ctx.fillText.mock.calls[0];
+    // `paintLayout` snaps x/y to integer pixels, so 14.4 lands at 14
+    // and 7.2 floors into the baseline. Bound y from above too — the
+    // first-line baseline can't be more than ~25 px below the inset
+    // for the docs default 11 pt font; if it ends up far below
+    // (e.g., y = 50) something is centering or anchoring wrong.
+    expect(x).toBeGreaterThanOrEqual(14);
+    expect(x).toBeLessThan(15);
+    expect(y).toBeGreaterThanOrEqual(7);
+    expect(y).toBeLessThan(25);
+  });
+});

--- a/packages/slides/test/view/editor/interactions/keyboard.test.ts
+++ b/packages/slides/test/view/editor/interactions/keyboard.test.ts
@@ -398,10 +398,9 @@ describe('keyboard — F2 / Enter enters text edit', () => {
     expect(editor.getEditingElementId()).toBe(textId);
   });
 
-  it('does not enter edit mode for non-text elements', () => {
+  it('Enter on a selected shape enters edit mode (PowerPoint / Google Slides parity)', () => {
     const { editor: e, store, mountedSpy } = fixtureWithTextElement();
     editor = e;
-    // The non-text element from makeFixture style — add a shape and select it instead.
     let shapeId = '';
     store.batch(() => {
       shapeId = store.addElement(store.read().slides[0].id, {
@@ -412,6 +411,86 @@ describe('keyboard — F2 / Enter enters text edit', () => {
     });
     editor.setSelection([shapeId]);
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(mountedSpy).toHaveBeenCalledTimes(1);
+    expect(editor.getEditingElementId()).toBe(shapeId);
+  });
+
+  it('does not enter edit mode for non-text, non-shape elements (image)', () => {
+    const { editor: e, store, mountedSpy } = fixtureWithTextElement();
+    editor = e;
+    let imageId = '';
+    store.batch(() => {
+      imageId = store.addElement(store.read().slides[0].id, {
+        type: 'image',
+        frame: { x: 300, y: 100, w: 100, h: 60, rotation: 0 },
+        data: { src: 'about:blank' },
+      });
+    });
+    editor.setSelection([imageId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(mountedSpy).not.toHaveBeenCalled();
+    expect(editor.getEditingElementId()).toBe(null);
+  });
+
+  it('type-to-edit: printable key on a selected text element enters edit mode', () => {
+    const { editor: e, textId, mountedSpy } = fixtureWithTextElement();
+    editor = e;
+    editor.setSelection([textId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'h', bubbles: true }));
+    expect(mountedSpy).toHaveBeenCalledTimes(1);
+    expect(editor.getEditingElementId()).toBe(textId);
+  });
+
+  it('type-to-edit: printable key on a selected shape enters edit mode', () => {
+    const { editor: e, store, mountedSpy } = fixtureWithTextElement();
+    editor = e;
+    let shapeId = '';
+    store.batch(() => {
+      shapeId = store.addElement(store.read().slides[0].id, {
+        type: 'shape',
+        frame: { x: 300, y: 100, w: 100, h: 60, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor.setSelection([shapeId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'x', bubbles: true }));
+    expect(mountedSpy).toHaveBeenCalledTimes(1);
+    expect(editor.getEditingElementId()).toBe(shapeId);
+  });
+
+  it('type-to-edit: arrow keys do NOT enter edit mode (printable gate)', () => {
+    const { editor: e, textId, mountedSpy } = fixtureWithTextElement();
+    editor = e;
+    editor.setSelection([textId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect(mountedSpy).not.toHaveBeenCalled();
+    expect(editor.getEditingElementId()).toBe(null);
+  });
+
+  it('type-to-edit: Cmd+S does NOT enter edit mode (modifier gate)', () => {
+    const { editor: e, textId, mountedSpy } = fixtureWithTextElement();
+    editor = e;
+    editor.setSelection([textId]);
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 's', metaKey: true, bubbles: true }),
+    );
+    expect(mountedSpy).not.toHaveBeenCalled();
+    expect(editor.getEditingElementId()).toBe(null);
+  });
+
+  it('type-to-edit: does not fire on non-text, non-shape selection', () => {
+    const { editor: e, store, mountedSpy } = fixtureWithTextElement();
+    editor = e;
+    let imageId = '';
+    store.batch(() => {
+      imageId = store.addElement(store.read().slides[0].id, {
+        type: 'image',
+        frame: { x: 300, y: 100, w: 100, h: 60, rotation: 0 },
+        data: { src: 'about:blank' },
+      });
+    });
+    editor.setSelection([imageId]);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'h', bubbles: true }));
     expect(mountedSpy).not.toHaveBeenCalled();
     expect(editor.getEditingElementId()).toBe(null);
   });

--- a/packages/slides/test/view/editor/text-box-editor.test.ts
+++ b/packages/slides/test/view/editor/text-box-editor.test.ts
@@ -211,7 +211,55 @@ describe('slides text-box editor wiring', () => {
     expect(mountCount).toBe(1);
   });
 
-  it('double-click on a non-text element does not enter edit mode', () => {
+  it('double-click on a shape enters text-edit mode (PowerPoint / Google Slides parity)', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const slideId = store.read().slides[0].id;
+    let shapeId = '';
+    store.batch(() => {
+      shapeId = store.addElement(slideId, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    const { mount, current } = makeMockMount();
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: mount,
+    });
+    dispatchDblClick(canvas, 150, 150);
+    expect(editor.getEditingElementId()).toBe(shapeId);
+    expect(current()).not.toBeNull();
+  });
+
+  it('shape edit-mode commits typed text into ShapeElement.data.text via withShapeText', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const slideId = store.read().slides[0].id;
+    let shapeId = '';
+    store.batch(() => {
+      shapeId = store.addElement(slideId, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    const { mount, current } = makeMockMount();
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: mount,
+    });
+    dispatchDblClick(canvas, 150, 150);
+    expect(editor.getEditingElementId()).toBe(shapeId);
+    current()!.fireCommit([paragraph('typed in shape')]);
+    const el = store.read().slides[0].elements[0] as {
+      data: { text?: { blocks: Block[] } };
+    };
+    expect(el.data.text?.blocks[0].inlines[0].text).toBe('typed in shape');
+  });
+
+  it('shape edit mounts the text-box on the inner (padded) frame', () => {
     const { canvas, overlay, store } = makeFixture();
     const slideId = store.read().slides[0].id;
     store.batch(() => {
@@ -219,6 +267,64 @@ describe('slides text-box editor wiring', () => {
         type: 'shape',
         frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
         data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    const { mount, current } = makeMockMount();
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: mount,
+    });
+    dispatchDblClick(canvas, 150, 150);
+    const opts = current()!.opts;
+    // SHAPE_TEXT_PADDING = { x: 14.4, y: 7.2 } — inner frame = element
+    // frame inset by that on each side.
+    expect(opts.frame.x).toBeCloseTo(100 + 14.4, 5);
+    expect(opts.frame.y).toBeCloseTo(100 + 7.2, 5);
+    expect(opts.frame.w).toBeCloseTo(200 - 2 * 14.4, 5);
+    expect(opts.frame.h).toBeCloseTo(100 - 2 * 7.2, 5);
+    // Shapes default to middle anchor + 'none' autofit (PowerPoint /
+    // Google Slides parity).
+    expect(opts.verticalAnchor).toBe('middle');
+    expect(opts.autofit).toBe('none');
+  });
+
+  it('shape edit on a fresh shape that commits empty does not materialise data.text', () => {
+    // Click-in-then-blur path: shape has no prior text body, user
+    // doesn't type, editor exits. Store's withShapeText short-circuits
+    // so the shape stays clean (no empty `<p:txBody>` cruft).
+    const { canvas, overlay, store } = makeFixture();
+    const slideId = store.read().slides[0].id;
+    let shapeId = '';
+    store.batch(() => {
+      shapeId = store.addElement(slideId, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    const { mount, current } = makeMockMount();
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: mount,
+    });
+    dispatchDblClick(canvas, 150, 150);
+    current()!.fireCommit([paragraph('')]);
+    const el = store.read().slides[0].elements.find((e) => e.id === shapeId) as {
+      data: { text?: unknown };
+    };
+    expect(el.data.text).toBeUndefined();
+  });
+
+  it('double-click on a non-text non-shape element does not enter edit mode', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const slideId = store.read().slides[0].id;
+    store.batch(() => {
+      store.addElement(slideId, {
+        type: 'image',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { src: 'about:blank' },
       });
     });
     const { mount, current } = makeMockMount();


### PR DESCRIPTION
## Summary

- Shapes now carry an optional inline text body painted on top of fill/stroke and editable via the existing docs text-box editor — double-click, F2/Enter, or typing a printable character on a selected shape all enter text edit. Matches PowerPoint / Google Slides behavior where every autoshape is a text container.
- Hoists a shared `TextBody` type from `TextElement.data`, adds `ShapeElement.data.text?: TextBody`. Backward-compatible (optional field, no migration).
- New `SlidesStore.withShapeText(slideId, elementId, cb)` mirrors `withTextElement`. Concurrency-safe: only ever writes `data.text.blocks`, never deletes `data.text` (a `delete` would race-wipe peer typing).
- Renderer paints `data.text` on top of shape fill/stroke via a shared `paintTextBody` helper (in `text-renderer.ts`) with PowerPoint default insets (`SHAPE_TEXT_PADDING = { x: 14.4, y: 7.2 }`) and `'middle'` vertical anchor.
- Editor mounts the in-place text-box on the inner padded frame so the caret aligns with the committed paint. New `growMode: 'never'` opt keeps the editor canvas at the inner-frame height so the middle anchor matches the renderer (without it the canvas shrinks to text height + anchors at `originY=0`, producing a visible jump on commit). The shape stays visible during edit — only the text body is hidden from the slide-canvas pass, not the whole element.
- PPTX import: `<p:sp>` with both `prstGeom` and `<p:txBody>` now folds into one `ShapeElement.data.text` instead of the prior two-element layered form. Stand-alone `txBox`-preset text boxes keep producing `TextElement`.
- Design doc `slides-shapes.md` updated — removes "Shape-internal text" from non-goals; adds a "Shape text body" section covering the data-model contract, render order, editor entry table, store API, PPTX mapping, and v1 limitations.

### v1 limitations (called out in design doc)
- Type-to-edit consumes the first keystroke (`preventDefault`) but doesn't yet insert it into the freshly-mounted text-box; the user has to type it again. Forwarding the initial character requires threading an `initialText` through `mountSlidesTextBox` into the docs editor — deferred follow-up.
- Two import formats coexist in Yorkie storage: pre-feature decks keep their layered (ShapeElement + paired TextElement) form indefinitely (no migration); post-feature imports use the folded form (one ShapeElement with `data.text`).

## Test plan
- [x] `pnpm verify:fast` green (frontend + backend + slides + sheets + docs lint/typecheck/tests).
- [x] `pnpm verify:self` green (adds the package builds).
- [x] New unit tests:
  - `packages/slides/test/store/memory.test.ts` — `withShapeText` round-trip, seed-on-entry, no-delete-on-empty (preserves empty body if user typed and cleared), no-op when entered with no text and committed empty.
  - `packages/slides/test/view/canvas/shape-renderer-text.test.ts` — text paints on top of fill, skips when absent/empty, paints on placeholder-rect fallback, applies the PowerPoint-default 14.4 / 7.2 px insets.
  - `packages/slides/test/view/editor/text-box-editor.test.ts` — double-click on shape enters edit; commit lands in `data.text`; mount frame inset by `SHAPE_TEXT_PADDING`; image (non-text/non-shape) doesn't enter edit; clean shape committed empty doesn't materialize `data.text`.
  - `packages/slides/test/view/editor/interactions/keyboard.test.ts` — Enter on selected shape enters edit; type-to-edit on text + shape; arrow keys / Cmd+S don't fire (printable + modifier gates); image doesn't fire.
  - `packages/slides/test/import/pptx/shape.test.ts` — `<p:sp>` with prstGeom + txBody folds into one ShapeElement with `data.text`; empty `<p:txBody>` does NOT seed `data.text`.
  - `packages/frontend/tests/app/slides/yorkie-slides-store.test.ts` — `withShapeText` round-trip through a real Yorkie doc; no-destructive-delete confirmed; no-op short-circuit; non-shape throws.
- [x] Manual smoke in `pnpm dev`:
  - Insert a roundRect, double-click, type "Hello", ESC — shape stays visible during edit; text persists at the same vertical position before/after commit.
  - Insert a shape, type 'x' while it's selected (no double-click) — enters edit mode (note v1 caveat: 'x' itself not yet inserted).
  - Two-client Yorkie smoke: both clients edit the same shape's text; no divergence; B's blur on an empty body does not wipe A's typed content.
  - Import a PPTX deck with labelled shapes; verify single ShapeElement with `data.text` per shape (not the layered form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)