### PR TITLE
Coalesce an IME-composed character into one undo unit

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -47,6 +47,7 @@ Word processor engine — rich text, tables, pagination, collaboration.
 | [docs-font-controls.md](docs/docs-font-controls.md)                              | Docs font controls — curated family picker (14 fonts), Google-Docs-style size input, line spacing, clear formatting, shared text-formatting components |
 | [docs-pending-inline-style.md](docs/docs-pending-inline-style.md)                | Pending inline style at a collapsed caret — stored marks for toolbar toggles, IME-aware, view-local            |
 | [docs-local-caret-anchoring.md](docs/docs-local-caret-anchoring.md)              | Local caret anchoring — Yorkie Tree-anchored caret/selection, resolves to DocPosition at render time (issue #237) |
+| [docs-ime-undo-history.md](docs/docs-ime-undo-history.md)                        | IME undo history — coalesce one composed character into a single Yorkie undo unit, fix Hangul undo toggle (issue #318) |
 
 ## Slides
 

--- a/docs/design/docs/docs-ime-undo-history.md
+++ b/docs/design/docs/docs-ime-undo-history.md
@@ -46,7 +46,7 @@ From the SDK source, after each `doc.update()` the change is executed, its
 `reverseOps` are collected, and **iff there is at least one reverse op, exactly
 one entry is pushed onto the undo stack**:
 
-```
+```ts
 // @yorkie-js/sdk 0.7.8, Document.update internals
 if (reverseOps.length) {
   this.internalHistory.pushUndo(reverseOps);   // one undo unit per doc.update()
@@ -158,14 +158,33 @@ Normative rules:
   one `doc.update()` → one undo unit. No interim delete needed (nothing was
   written to the model).
 
-Rendering the transient composing text:
+Rendering the transient composing text — **view-local layout injection**:
 
 - Today the composing glyph is visible only because interim text is written to
   the model and painted from it; there is **no existing transient text overlay**
-  for composition (image overlays exist in `doc-canvas.ts`, but not text). So this
-  change adds a small transient-render path: paint the composing string as a
-  view-local run at the caret position (reusing existing measure/paint), drawn
-  after the document content and cleared on `compositionend`.
+  for composition (image overlays exist in `doc-canvas.ts`, but not text).
+- Two techniques were considered: (A) paint the composing string as a run at the
+  caret position on the canvas, and (B) inject the composing text into the
+  layout as a view-local synthetic run. (A) is simpler but does **not reflow** —
+  mid-paragraph composition would overlap the following text. **(B) is chosen**
+  so wrapping and following-text-shift stay correct, matching the "no regression
+  to live composition rendering" goal.
+- Concretely: thread a `composingContext = { blockId, offset, text }`
+  through `computeLayout()` (`layout.ts:215`) into `layoutBlock()`
+  (`layout.ts:328`). The composing run inherits the inline style at the
+  insertion point in the layout (left-biased at a boundary, same as newly typed
+  text), so no `style` field is needed.
+  Right after `measureSegments()` and before the wrapping
+  loop, splice a **synthetic `MeasuredSegment`** at the composing offset. The
+  wrapping loop, alignment, line-height, and caret pixel resolution
+  (`resolvePositionPixel`, `peer-cursor.ts:97`) all treat it as an ordinary run,
+  so reflow and caret placement come for free. The synthetic run lives only
+  inside `layoutBlock()` scope — it is never written to `doc.document.blocks`.
+- The caret's block must be marked dirty on every composing keystroke (the
+  incremental layout cache keys off `blockId` only), and the injection is cleared
+  when composition ends or aborts (focus loss / Escape) so no ghost text remains.
+- Body, header, footer, and table-cell blocks all funnel through the same
+  `layoutBlock()`, so a single seam covers every region.
 
 `packages/docs/src/view/hangul.ts` (software Hangul assembly, used when the
 browser does not fire composition events): it already separates `commit` vs
@@ -224,9 +243,11 @@ drift-corrected position, not a stale absolute offset.
    Proposed: accept this (matches Google Docs / Notion). Confirm it is acceptable;
    if live composing visibility is required, the interim would have to be shared
    by some non-undo channel (e.g. presence), not the document model.
-3. **Transient render technique.** Paint the composing run on the canvas
-   (proposed, keeps a single rendering pipeline) vs. a positioned visible
-   `textarea` overlay. Confirm preference.
+3. **Transient render technique.** *Resolved: view-local layout injection.* The
+   composing text is spliced into `layoutBlock()` as a synthetic run rather than
+   painted at the caret or overlaid via a `textarea`, so it reflows correctly
+   (following text shifts, lines wrap) while never touching the document model.
+   See *Implementation shape → Rendering the transient composing text*.
 
 ## References
 

--- a/docs/design/docs/docs-ime-undo-history.md
+++ b/docs/design/docs/docs-ime-undo-history.md
@@ -1,0 +1,237 @@
+---
+title: docs-ime-undo-history
+target-version: 0.4.4
+---
+
+<!-- Proposed — ready for maintainer review before implementation (issue #318). -->
+
+# Docs IME Undo History
+
+## Summary
+
+Make a single IME-composed character (e.g. one Hangul syllable) a single undo
+entry in the docs editor, so one Undo removes it cleanly — matching how a typed
+English character already behaves, and how Google Docs / Notion handle IME.
+
+Today, typing one Hangul syllable via the browser IME lands as **multiple
+overlapping undo units** at the same position. Stepping through them with Undo
+makes the character appear to "toggle" between visible and hidden instead of
+being removed once (issue #318):
+
+- 1st Undo → character disappears
+- 2nd Undo → same character reappears
+- 3rd Undo → disappears again …
+
+The character is only truly gone after an even number of undos. English input is
+unaffected.
+
+## Background
+
+### How undo/redo works in the docs editor
+
+Undo/redo in the docs editor is implemented by **Yorkie's document history**. The
+editor keeps no undo stack of its own — `YorkieDocStore.snapshot()` is a no-op
+(`packages/frontend/src/app/docs/yorkie-doc-store.ts:2469`), and `undo()` /
+`redo()` delegate straight to `doc.history.undo()` / `doc.history.redo()`
+(`yorkie-doc-store.ts:2473`–`2485`). The document text lives in the
+`root.content` Tree, and every edit is a `doc.update()` that mutates it; the undo
+stack is whatever Yorkie records for those updates.
+
+So "an undo entry" in this editor means **one entry on Yorkie's undo stack**, and
+the bug's "multiple undo history entries" are exactly that.
+
+### How Yorkie forms undo units (confirmed against @yorkie-js/sdk 0.7.8)
+
+From the SDK source, after each `doc.update()` the change is executed, its
+`reverseOps` are collected, and **iff there is at least one reverse op, exactly
+one entry is pushed onto the undo stack**:
+
+```
+// @yorkie-js/sdk 0.7.8, Document.update internals
+if (reverseOps.length) {
+  this.internalHistory.pushUndo(reverseOps);   // one undo unit per doc.update()
+}
+```
+
+The undo stack is therefore `Array<Array<HistoryOperation>>` — one array per
+`doc.update()`, holding all reverse ops of that single transaction
+(`getUndoStackForTest(): Array<Array<HistoryOperation<P>>>`). Two consequences,
+both load-bearing for this design:
+
+1. **One `doc.update()` = one undo unit.** Multiple Tree edits inside the *same*
+   `doc.update()` collapse into one unit.
+2. **There is no way to exclude a Tree edit from history, and no cross-update
+   grouping.** `update(updater, message?)` exposes no "skip history" option, and
+   Tree edits always produce reverse ops. (The SDK's `addToHistory` flag applies
+   only to *presence* `set`, not to Tree edits.)
+
+**This bug is not a Yorkie defect.** Yorkie records exactly one undo unit per
+`doc.update()`, as designed. The defect is that IME composition issues many
+`doc.update()`s for one character.
+
+### Why one Hangul syllable becomes many undo units
+
+The IME pipeline in `packages/docs/src/view/text-editor.ts` writes **interim
+composition state into the Tree** and rewrites it repeatedly:
+
+- `handleInput()` during an active composition (`text-editor.ts:455`–`476`): for
+  each `compositionupdate` it does `docDeleteText(previous interim)` then
+  `docInsertText(current interim)`.
+- `handleCompositionEnd()` (`text-editor.ts:401`–`416`): it again does
+  `docDeleteText(interim)` then `docInsertText(finalText)`, using `e.data` as the
+  source of truth (to correct iOS textarea drift).
+
+`docInsertText` / `docDeleteText` (`text-editor.ts:264`–`289`) each call
+`doc.insertText` / `doc.deleteText`, and each of those is its own `doc.update()`
+in `YorkieDocStore` (`yorkie-doc-store.ts:1502`+). So a single jamo `"ㅏ"`
+produces, at minimum:
+
+| Step | Mutation | `doc.update()` | undo unit |
+| --- | --- | --- | --- |
+| compositionupdate | insert `"ㅏ"` | #1 | insert ㅏ |
+| compositionend | delete 1 | #2 | delete ㅏ |
+| compositionend | insert `"ㅏ"` | #3 | insert ㅏ |
+
+A composed syllable like `"가"` (ㄱ → 가) adds another delete+insert pair during
+composition, reaching ~5 units. Every unit is a delete or insert at the **same
+start position**, so undoing them one at a time alternates the character on and
+off — exactly the reported toggle.
+
+> Aside: the issue's own guess (compositionstart vs compositionend as two
+> entries) is directionally right but not exact — the entries come from the
+> per-`compositionupdate` interim delete/insert plus the compositionend
+> delete/insert, each a separate `doc.update()`.
+
+## Goals
+
+- One IME composition that yields one composed character = **one undo unit**. One
+  Undo removes it; one Redo restores it.
+- Behavior parity with English input and with Google Docs / Notion.
+- Correct across regions that share `root.content`: body paragraphs, headers,
+  footers, and table cells.
+- No regression to live composition rendering (the composing glyph still shows
+  while typing) or to the pending inline-style anchor.
+
+## Non-Goals
+
+- Changing undo granularity for non-IME edits (English typing, paste, structural
+  edits) — those already behave correctly.
+- Coalescing a whole multi-syllable *word* into one undo unit. Scope is one
+  composed character = one unit (each Korean syllable ends its own composition).
+  Word-level grouping is a possible follow-up.
+- Replacing or re-architecting Yorkie history.
+
+## Proposal Details
+
+### Decision: interim composition must not produce a `doc.update()`
+
+Per the SDK analysis above, the undo stack gets one unit per `doc.update()`, with
+no way to exclude or group Tree edits. So **the only way to stop generating extra
+undo units is to stop issuing `doc.update()`s for interim composing text.**
+Grouping multiple updates into one unit (an earlier "Approach B") is not
+expressible in @yorkie-js/sdk 0.7.8 and is rejected.
+
+Normative rules:
+
+1. While a composition is active, **no `doc.update()` / Tree edit is performed**
+   for interim composing text.
+2. The committed text is written to the Tree **exactly once**, in a single
+   `doc.update()`, when the composed character is final → one undo unit.
+3. In-progress composing text is **view-local**: rendered transiently at the
+   caret, never written to the document model. A direct consequence: because the
+   interim is no longer in the shared model, collaborators see the character only
+   once it is committed, not the half-composed jamo (see Risks / Open Questions #2).
+
+### Implementation shape
+
+`packages/docs/src/view/text-editor.ts`:
+
+- **`handleCompositionStart`** (`:386`) — keep capturing `startPosition` and the
+  anchored composition position (the `updateCompositionStartPosition` bridge from
+  `docs-local-caret-anchoring.md` / PR #257 stays). A selection present at start
+  (`deleteSelection()`, `:391`) is its own concern — see Open Questions #1.
+- **`handleInput` while composing** (`:455`–`476`) — replace the
+  `docDeleteText`/`docInsertText` pair with updating a **transient composing
+  string** (view-local) and a render request. No model mutation.
+- **`handleCompositionEnd`** (`:401`–`416`) — clear the transient string and
+  perform **one** `docInsertText(anchoredStartPosition, e.data)` →
+  one `doc.update()` → one undo unit. No interim delete needed (nothing was
+  written to the model).
+
+Rendering the transient composing text:
+
+- Today the composing glyph is visible only because interim text is written to
+  the model and painted from it; there is **no existing transient text overlay**
+  for composition (image overlays exist in `doc-canvas.ts`, but not text). So this
+  change adds a small transient-render path: paint the composing string as a
+  view-local run at the caret position (reusing existing measure/paint), drawn
+  after the document content and cleared on `compositionend`.
+
+`packages/docs/src/view/hangul.ts` (software Hangul assembly, used when the
+browser does not fire composition events): it already separates `commit` vs
+`composing` (`hangul.ts:86`–`89`). Route `composing` through the same transient
+render and `commit` through the single `docInsertText`, so both the browser-IME
+path and the software path yield one undo unit per syllable.
+
+`packages/frontend/src/app/docs/yorkie-doc-store.ts`: no API change required;
+`insertText()` already wraps a single `doc.update()`. The anchored start position
+(`updateCompositionStartPosition`) must be used so the single commit lands at the
+drift-corrected position, not a stale absolute offset.
+
+### Risks and Mitigation
+
+- **New transient render path is the main cost.** Composing text must now be
+  painted view-locally. Mitigation: reuse existing run measurement/painting;
+  scope it to a single run at the caret; cover with the IME browser script.
+- **Pending inline-style anchor.** The `pending` style logic currently rides on
+  the interim delete/insert (`keepPending` / `rewindAnchor`, `text-editor.ts:268`,
+  `:284`). With no interim edits, rebind the anchor off the single final insert.
+  Add a "set style → IME-type → style applied to composed char" unit test.
+- **Syllable boundaries.** Korean fires `compositionend` → `compositionstart`
+  back-to-back between syllables; each syllable is its own composition and its own
+  single undo unit. Confirm no stranded transient string and no cross-syllable
+  merge.
+- **Tables / headers / footers.** All share `root.content`; cover composition
+  inside a table cell.
+- **iOS textarea drift.** The `e.data` source-of-truth at compositionend is
+  preserved — we still commit `e.data`, just once and without the interim churn.
+- **Peer visibility of composing text.** Because interim text is no longer
+  written to the shared model, collaborators no longer see in-progress jamo and
+  see the character only on commit. Mitigation: this matches Google Docs / Notion
+  and is treated as the intended behavior; confirm in Open Questions #2.
+
+## Test Plan
+
+- Unit (`packages/frontend/tests/app/docs/yorkie-doc-store.test.ts`, which has
+  undo/redo coverage but no IME case): typing one jamo and one composed syllable
+  each grows `getUndoStackForTest().length` by exactly 1; one undo empties, one
+  redo restores.
+- Unit: pending inline-style survives IME composition.
+- Browser (`packages/docs/scripts/verify-ime-browser.mjs`): assert one Undo
+  removes a composed syllable in a single step — single + multi-syllable, batchim,
+  mixed EN/KR, compose-after-delete.
+- Table-cell composition undo.
+
+## Open Questions (decisions requested)
+
+1. **Selection-replace grouping.** When composition starts over a selection, the
+   `deleteSelection()` is a real edit. Should it be the **same** undo unit as the
+   composed insert (one Undo restores the original selection *and* removes the
+   character) or **two**? Proposed: one unit — fold the delete and the final
+   insert into a single `doc.update()`.
+2. **Peer visibility of composing text.** Approach A makes the in-progress
+   composition view-local, so collaborators see the character only on commit.
+   Proposed: accept this (matches Google Docs / Notion). Confirm it is acceptable;
+   if live composing visibility is required, the interim would have to be shared
+   by some non-undo channel (e.g. presence), not the document model.
+3. **Transient render technique.** Paint the composing run on the canvas
+   (proposed, keeps a single rendering pipeline) vs. a positioned visible
+   `textarea` overlay. Confirm preference.
+
+## References
+
+- Issue: https://github.com/wafflebase/wafflebase/issues/318
+- Yorkie history: `@yorkie-js/sdk` 0.7.8 — `Document.update` `pushUndo(reverseOps)`,
+  `getUndoStackForTest(): Array<Array<HistoryOperation>>`.
+- Related: `docs/design/docs/docs-local-caret-anchoring.md` (issue #237 / PR #257)
+- Related: `docs/design/docs/docs-pending-inline-style.md` (pending style anchor)

--- a/docs/tasks/active/20260604-ime-undo-history-todo.md
+++ b/docs/tasks/active/20260604-ime-undo-history-todo.md
@@ -1,0 +1,125 @@
+# IME Undo History — one composed character = one undo unit (issue #318)
+
+Branch: `docs/ime-undo-history` · Design: `docs/design/docs/docs-ime-undo-history.md`
+
+## Status
+
+Implementation done (approach B) and `pnpm verify:fast` green. Self-review
+round 1 findings addressed (see "Review round 1" below). New tests: 11 layout
+injection + 7 editor-level IME + 5 frontend store (undo units + presence clamp).
+Remaining before merge: manual smoke in `pnpm dev`, lessons file, archive, push.
+
+Untracked files that must NOT be staged into this PR: `.claude/issues.md`,
+`docs/design/docs/docs-ime-undo-history.ko.md`,
+`docs/design/docs/docs-local-caret-anchoring-ko.md` (KO translations, unrelated).
+
+### Review round 1 (addressed)
+- [x] **Blocker — presence leak:** caret offset past model length (view-local
+      composing) was published raw to peer presence. Fixed: `clampPosToModel`
+      in `yorkie-doc-store.ts` clamps `activeCursorPos` + selection endpoints
+      before `p.set`. Tested.
+- [x] **Stale preview after remote anchor correction:** `setCompositionStartPosition`
+      now re-`emitComposingContext()` + marks old/new block dirty + requests
+      render. Path-covered by test.
+- [x] **Ghost text on blur/abort:** added `TextEditor.cancelComposition()`
+      (commits visible preview, clears injection); called from `handleBlur`.
+      Tested (browser + software-Hangul paths).
+- [x] **Software-Hangul undo:** confirmed snapshot timing unchanged from
+      original; under Yorkie each commit is one undo unit (fix now applies to
+      this path too). Added software-Hangul view-local + flush test.
+- [x] CodeRabbit ts code-fence nit.
+
+## Problem
+
+Typing one Hangul syllable via the browser IME lands as multiple overlapping
+Yorkie undo units (interim `compositionupdate` delete/insert pairs + the
+`compositionend` delete/insert), so Undo "toggles" the character on/off instead
+of removing it once. Yorkie records exactly one undo unit per `doc.update()` and
+offers no cross-update grouping (confirmed @yorkie-js/sdk 0.7.8) — so the fix is
+to stop issuing `doc.update()`s for interim composing text and commit the final
+text exactly once.
+
+## Chosen render approach: B — layout injection (NOT the note's original A)
+
+The design note proposed painting the composing run at the caret on the canvas
+(approach A). That overlaps following text on mid-paragraph composition (no
+reflow). We instead inject the composing text as a **view-local synthetic run
+into `layoutBlock()`**, so wrapping / following-text-shift is correct while the
+document model stays untouched. The design note is updated to record this.
+
+Injection seam (from layout-engine exploration):
+- `layoutBlock()` (`layout.ts:328`), right after `measureSegments()` and before
+  the wrapping loop — splice a synthetic `MeasuredSegment` at the composing
+  offset.
+- Thread a `composingContext?: { blockId, offset, text, style }` param through
+  `computeLayout()` (`layout.ts:215`) → `layoutBlock()`.
+- All regions (body / header / footer / table cell) funnel through the same
+  `layoutBlock()`, so one seam covers them all.
+- Caret pixel resolution (`resolvePositionPixel`, `peer-cursor.ts:97`) walks the
+  synthetic run like any normal run — no change needed.
+
+## Tasks
+
+### 1. Design note + plan
+- [ ] Update `docs-ime-undo-history.md`: record approach B (layout injection) as
+      the chosen transient-render technique; note reflow correctness; adjust
+      Open Question #3 to "resolved: layout injection".
+- [ ] Fix CodeRabbit nit: add `ts` language tag to the fenced SDK snippet (`:49`).
+
+### 2. Layout: view-local composing run injection
+- [ ] Add `ComposingContext` type and optional param to `computeLayout` +
+      `layoutBlock`; splice synthetic segment after `measureSegments()`.
+- [ ] Ensure the synthetic run carries correct `charOffsets`/width and is marked
+      so it's never persisted (scope-local to layout only).
+- [ ] Thread `composingContext` from `editor.ts recomputeLayout()` (read from
+      TextEditor composition state); mark caret block dirty each keystroke.
+
+### 3. text-editor.ts: stop interim model writes
+- [ ] `CompositionState`: replace `currentLength` (model-written length) with
+      `composingText: string` (view-local).
+- [ ] `handleInput` while composing (`:455–476`): no `docDeleteText`/
+      `docInsertText`; just set `composingText`, move caret to start+len, request
+      render.
+- [ ] `handleCompositionEnd` (`:401–416`): no interim delete; single
+      `docInsertText(anchoredStart, e.data)` → one `doc.update()` → one undo unit.
+      Keep `e.data` as source of truth (iOS drift).
+- [ ] `handleCompositionStart` (`:386`): keep `startPosition` capture + anchor
+      bridge (PR #257). Selection-present → fold `deleteSelection()` + final
+      insert into one undo unit (Open Question #1 proposed: one unit).
+- [ ] Software Hangul path `applyHangulResult` (`:4505`): route `composing` via
+      the view-local render, `commit` via single `docInsertText`.
+- [ ] Expose composing state to editor's layout (getter or callback) so
+      `recomputeLayout` can build `composingContext`.
+
+### 4. Pending inline-style anchor
+- [ ] Rebind pending-style anchor off the single final insert (interim
+      delete/insert `keepPending`/`rewindAnchor` no longer fire). Verify
+      `pending.consumeForInsert` still applies style to the committed char.
+
+### 5. Tests
+- [ ] Unit (`yorkie-doc-store.test.ts`): one jamo and one composed syllable each
+      grow `getUndoStackForTest().length` by exactly 1; one undo empties, one
+      redo restores.
+- [ ] Unit: pending inline-style survives IME composition.
+- [ ] Unit/layout: composing-run injection reflows following text (width grows,
+      wrap happens) and caret sits at start+len.
+- [ ] Browser (`packages/docs/scripts/verify-ime-browser.mjs`): one Undo removes
+      a composed syllable in one step — single/multi-syllable, batchim, mixed
+      EN/KR, compose-after-delete.
+- [ ] Table-cell composition undo.
+
+### 6. Verify + ship
+- [ ] `pnpm verify:fast` green.
+- [ ] Self code-review over branch diff; manual smoke in `pnpm dev` (compose
+      mid-paragraph, header, table cell; Undo once).
+- [ ] Capture lessons; archive; PR body Summary + Test plan; address review.
+
+## Risks / watch-outs
+- Syllable boundary: Korean fires `compositionend`→`compositionstart` back to
+  back; confirm no stranded `composingText` and no cross-syllable merge.
+- Composing run must clear on `compositionend` AND on composition abort (focus
+  loss, Escape) — leftover injection would show ghost text.
+- Peer visibility: collaborators now see the char only on commit (accepted,
+  matches Google Docs / Notion — Open Question #2).
+- Incremental layout cache keys off blockId only; marking the caret block dirty
+  each keystroke is required or the composing run won't update.

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -7,7 +7,7 @@ import { DocCanvas } from './doc-canvas.js';
 import { Cursor } from './cursor.js';
 import { Selection, computeSelectionRects } from './selection.js';
 import { TextEditor } from './text-editor.js';
-import { computeLayout, resolveInlineFont, type DocumentLayout, type LayoutCache, type LayoutRun } from './layout.js';
+import { computeLayout, resolveInlineFont, type ComposingContext, type DocumentLayout, type LayoutCache, type LayoutRun } from './layout.js';
 import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getPageYOffset, getHeaderYStart, getFooterYStart, paginatedPixelToPosition, type PaginatedLayout } from './pagination.js';
 import { CanvasTextMeasurer } from './canvas-measurer.js';
 import type { TextMeasurer } from './measurer.js';
@@ -522,6 +522,11 @@ export function initialize(
   let footerLayout: DocumentLayout | null = null;
   let layoutCache: LayoutCache | undefined;
   let dirtyBlockIds: Set<string> | undefined;
+  // View-local IME composing text injected into the layout of the caret's
+  // block during composition (never written to the model). Pushed here by
+  // the TextEditor; consumed by recomputeLayout. See
+  // docs/design/docs/docs-ime-undo-history.md.
+  let composingContext: ComposingContext | null = null;
   let needsScrollIntoView = false;
   let focused = !readOnly;
 
@@ -738,6 +743,7 @@ export function initialize(
       contentWidth,
       dirtyBlockIds,
       layoutCache,
+      composingContext ?? undefined,
     );
     layout = result.layout;
     layoutCache = result.cache;
@@ -751,6 +757,9 @@ export function initialize(
         doc.document.header.blocks,
         measurer,
         contentWidth,
+        undefined,
+        undefined,
+        composingContext ?? undefined,
       ).layout;
     } else {
       headerLayout = null;
@@ -760,6 +769,9 @@ export function initialize(
         doc.document.footer.blocks,
         measurer,
         contentWidth,
+        undefined,
+        undefined,
+        composingContext ?? undefined,
       ).layout;
     } else {
       footerLayout = null;
@@ -1469,6 +1481,13 @@ export function initialize(
     textEditor.setCursorTarget(canvas);
     textEditor.setPendingStyle(pending);
 
+    // Receive view-local IME composing text so recomputeLayout injects it
+    // into the caret block's layout (never written to the model). The
+    // TextEditor marks the block dirty and requests a render on each change.
+    textEditor.onComposingContextChange = (ctx) => {
+      composingContext = ctx;
+    };
+
     textEditor.onDragGuideline = (pos) => {
       dragGuideline = pos;
       renderPaintOnly();
@@ -1855,6 +1874,10 @@ export function initialize(
   };
   const handleBlur = () => {
     focused = false;
+    // Finalize any in-progress IME composition so no view-local composing
+    // text is left injected in the layout (ghost text) when focus leaves
+    // mid-composition without a compositionend.
+    textEditor?.cancelComposition();
     pending.clear();
     cursor.stopBlink();
     render();

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -217,7 +217,7 @@ export function injectComposingInline(
       const before = inline.text.slice(0, localOffset);
       const after = inline.text.slice(localOffset);
       if (before.length > 0) result.push({ ...inline, text: before });
-      result.push({ text, style: { ...inline.style } });
+      result.push({ text, style: composingStyleFrom(inline.style) });
       if (after.length > 0) result.push({ ...inline, text: after });
       inserted = true;
     } else {
@@ -230,10 +230,22 @@ export function injectComposingInline(
     // Offset at/after the end, or an empty block: append, inheriting the
     // trailing inline's style when there is one.
     const style = inlines.length > 0 ? inlines[inlines.length - 1].style : {};
-    result.push({ text, style: { ...style } });
+    result.push({ text, style: composingStyleFrom(style) });
   }
 
   return result;
+}
+
+/**
+ * Inherit only the *visual* (text) style for a composing run. Structural
+ * metadata — `image` (Object Replacement placeholder) and `pageNumber` —
+ * must be dropped: otherwise composing right after an image inline would
+ * make `measureSegments` treat the typed preview as an image rather than
+ * text, breaking IME layout at image / page-number boundaries.
+ */
+function composingStyleFrom(style: InlineStyle): InlineStyle {
+  const { image: _image, pageNumber: _pageNumber, ...textStyle } = style;
+  return textStyle;
 }
 
 /**

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -176,6 +176,67 @@ export interface LayoutCache {
 }
 
 /**
+ * View-local IME composing text to splice into one block's layout.
+ *
+ * During IME composition the interim text is *not* written to the
+ * document model (so it produces no Yorkie undo unit — see
+ * `docs/design/docs/docs-ime-undo-history.md`). Instead it is injected
+ * here as a synthetic inline at `offset`, so wrapping / following-text
+ * reflow and caret placement stay correct while the model is untouched.
+ * It lives only inside the layout pass and is never persisted.
+ */
+export interface ComposingContext {
+  blockId: string;
+  /** Character offset within the block where composing text sits. */
+  offset: number;
+  /** The view-local composing string (empty string = nothing to inject). */
+  text: string;
+}
+
+/**
+ * Splice `text` into `inlines` at character `offset`, inheriting the
+ * style at the insertion point (left-biased at an inline boundary, the
+ * same rule newly typed text follows). Returns a new array; the inputs
+ * are not mutated. Used to render IME composing text view-locally.
+ */
+export function injectComposingInline(
+  inlines: Inline[],
+  offset: number,
+  text: string,
+): Inline[] {
+  if (text.length === 0) return inlines;
+
+  const result: Inline[] = [];
+  let pos = 0;
+  let inserted = false;
+
+  for (const inline of inlines) {
+    const len = inline.text.length;
+    if (!inserted && offset <= pos + len) {
+      const localOffset = offset - pos;
+      const before = inline.text.slice(0, localOffset);
+      const after = inline.text.slice(localOffset);
+      if (before.length > 0) result.push({ ...inline, text: before });
+      result.push({ text, style: { ...inline.style } });
+      if (after.length > 0) result.push({ ...inline, text: after });
+      inserted = true;
+    } else {
+      result.push(inline);
+    }
+    pos += len;
+  }
+
+  if (!inserted) {
+    // Offset at/after the end, or an empty block: append, inheriting the
+    // trailing inline's style when there is one.
+    const style = inlines.length > 0 ? inlines[inlines.length - 1].style : {};
+    result.push({ text, style: { ...style } });
+  }
+
+  return result;
+}
+
+/**
  * A segment of text with uniform style, ready for measurement.
  * Tracks which inline it came from and character offsets.
  */
@@ -218,6 +279,7 @@ export function computeLayout(
   contentWidth: number,
   dirtyBlockIds?: Set<string>,
   cache?: LayoutCache,
+  composingContext?: ComposingContext,
 ): { layout: DocumentLayout; cache: LayoutCache } {
   const availableWidth = contentWidth;
   const canUseCache = cache != null
@@ -248,7 +310,9 @@ export function computeLayout(
     let lines: LayoutLine[];
 
     if (block.type === 'table' && block.tableData) {
-      const tableLayout = computeTableLayout(block.tableData, block.id, measurer, availableWidth);
+      const tableLayout = computeTableLayout(
+        block.tableData, block.id, measurer, availableWidth, composingContext,
+      );
       // Merge per-table blockParentMap into document-level map
       for (const [k, v] of tableLayout.blockParentMap) {
         blockParentMap.set(k, v);
@@ -275,7 +339,7 @@ export function computeLayout(
     } else if (canUseCache && !dirtyBlockIds!.has(block.id) && cache!.blocks.has(block.id)) {
       lines = cache!.blocks.get(block.id)!.lines;
     } else {
-      lines = layoutBlock(effectiveBlock, measurer, availableWidth);
+      lines = layoutBlock(effectiveBlock, measurer, availableWidth, composingContext);
       assignLineHeights(lines, effectiveBlock);
 
       const alignWidth = availableWidth - effectiveBlock.style.marginLeft;
@@ -329,9 +393,15 @@ export function layoutBlock(
   block: Block,
   measurer: TextMeasurer,
   maxWidth: number,
+  composingContext?: ComposingContext,
 ): LayoutLine[] {
   // Resolve heading defaults into inlines before measurement
-  const inlines = resolveBlockInlines(block);
+  const resolved = resolveBlockInlines(block);
+  // Splice in view-local IME composing text for this block, if any, so it
+  // reflows like real text without being written to the document model.
+  const inlines = composingContext?.blockId === block.id
+    ? injectComposingInline(resolved, composingContext.offset, composingContext.text)
+    : resolved;
   // Measure all segments (word-level)
   const segments = measureSegments(inlines, measurer);
 

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -1,6 +1,6 @@
 import type { TableData, Block, BlockCellInfo } from '../model/types.js';
 import { LIST_INDENT_PX } from '../model/types.js';
-import type { LayoutLine } from './layout.js';
+import type { ComposingContext, LayoutLine } from './layout.js';
 import { applyAlignment, assignLineHeights, layoutBlock } from './layout.js';
 import { ptToPx, Theme } from './theme.js';
 import type { TextMeasurer } from './measurer.js';
@@ -39,6 +39,7 @@ function layoutCellBlocks(
   measurer: TextMeasurer,
   maxWidth: number,
   blockParentMap?: Map<string, BlockCellInfo>,
+  composingContext?: ComposingContext,
 ): { lines: LayoutLine[]; blockBoundaries: number[] } {
   if (blocks.length === 0) {
     const defaultHeight = ptToPx(Theme.defaultFontSize) * 1.5;
@@ -60,6 +61,7 @@ function layoutCellBlocks(
         block.id,
         measurer,
         maxWidth,
+        composingContext,
       );
       if (blockParentMap) {
         for (const [k, v] of nestedLayout.blockParentMap) {
@@ -90,7 +92,7 @@ function layoutCellBlocks(
           },
         };
 
-    const blockLines = layoutBlock(effectiveBlock, measurer, maxWidth);
+    const blockLines = layoutBlock(effectiveBlock, measurer, maxWidth, composingContext);
     assignLineHeights(blockLines, effectiveBlock);
 
     const alignWidth = maxWidth - (effectiveBlock.style.marginLeft ?? 0);
@@ -124,6 +126,7 @@ export function computeTableLayout(
   tableBlockId: string,
   measurer: TextMeasurer,
   contentWidth: number,
+  composingContext?: ComposingContext,
 ): LayoutTable {
   const { rows, columnWidths } = tableData;
   const numCols = columnWidths.length;
@@ -165,7 +168,9 @@ export function computeTableLayout(
       const padding = cell?.style?.padding ?? DEFAULT_CELL_PADDING;
       const innerWidth = Math.max(cellWidth - padding * 2, 0);
 
-      const { lines, blockBoundaries } = layoutCellBlocks(cell?.blocks ?? [], measurer, innerWidth, blockParentMap);
+      const { lines, blockBoundaries } = layoutCellBlocks(
+        cell?.blocks ?? [], measurer, innerWidth, blockParentMap, composingContext,
+      );
       const cellHeight = lines.reduce((sum, l) => sum + l.height, 0) + padding * 2;
 
       cellRow.push({ lines, blockBoundaries, width: cellWidth, height: cellHeight, merged: false });

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -29,8 +29,13 @@ interface CompositionState {
   active: boolean;
   /** Cursor position where composition started */
   startPosition: DocPosition;
-  /** Length of currently composed text inserted into the model */
-  currentLength: number;
+  /**
+   * The current view-local composing text. NOT written to the document
+   * model — it is injected into the layout for rendering only, so one
+   * composed character commits as a single undo unit. See
+   * docs/design/docs/docs-ime-undo-history.md.
+   */
+  composingText: string;
 }
 
 /**
@@ -58,8 +63,16 @@ export class TextEditor {
   private composition: CompositionState = {
     active: false,
     startPosition: { blockId: '', offset: 0 },
-    currentLength: 0,
+    composingText: '',
   };
+  /**
+   * Set by the editor to receive the view-local IME composing text so it
+   * can be injected into the layout of the caret's block (never written
+   * to the model). Called with `null` when composition ends or aborts.
+   */
+  onComposingContextChange:
+    | ((ctx: { blockId: string; offset: number; text: string } | null) => void)
+    | null = null;
   /**
    * When true, all input events are ignored until the next microtask.
    * Set after compositionend to prevent post-composition duplicate insertion.
@@ -74,7 +87,8 @@ export class TextEditor {
   // (e.g., Mobile Safari with hidden textarea sends raw jamo as insertText).
   private hangulAssembler = new HangulAssembler();
   private hangulStartPos: DocPosition = { blockId: '', offset: 0 };
-  private hangulComposingLength = 0;
+  /** View-local software-Hangul composing preview (not written to model). */
+  private hangulComposingText = '';
   private handleFocus: (() => void) | null = null;
   private handleBlur: (() => void) | null = null;
   /** Track shift key state for paste handler (ClipboardEvent lacks shiftKey). */
@@ -227,7 +241,26 @@ export class TextEditor {
    */
   setCompositionStartPosition(pos: DocPosition): void {
     if (!this.composition.active) return;
+    const prevBlockId = this.composition.startPosition.blockId;
     this.composition.startPosition = { ...pos };
+    // Move the caret back to the end of the composing text (start + length).
+    // A remote change first restores the local cursor to the *clamped* model
+    // position (the composing text isn't in the model, so the clamp lands it
+    // before the preview); without this the caret would sit in front of the
+    // injected composing run while the preview renders after it.
+    const caretPos: DocPosition = {
+      blockId: pos.blockId,
+      offset: pos.offset + this.composition.composingText.length,
+    };
+    this.cursor.moveTo(caretPos, this.getWrapAffinity(caretPos));
+    // Re-publish the view-local composing injection at the corrected
+    // position so the preview does not render at the stale offset until the
+    // next input event. Mark both the old and new block dirty so the old
+    // block sheds its injection and the new one picks it up.
+    this.markDirty(prevBlockId);
+    this.markDirty(pos.blockId);
+    this.emitComposingContext();
+    this.requestRender();
   }
 
   isComposing(): boolean {
@@ -383,17 +416,81 @@ export class TextEditor {
 
   // --- IME Composition handlers ---
 
+  /**
+   * Push the current view-local composing text (browser IME or software
+   * Hangul) to the editor so it can be injected into the layout. Emits
+   * `null` when there is nothing composing, clearing any injection.
+   */
+  private emitComposingContext(): void {
+    if (!this.onComposingContextChange) return;
+    if (this.composition.active && this.composition.composingText.length > 0) {
+      this.onComposingContextChange({
+        blockId: this.composition.startPosition.blockId,
+        offset: this.composition.startPosition.offset,
+        text: this.composition.composingText,
+      });
+    } else if (this.hangulComposingText.length > 0) {
+      this.onComposingContextChange({
+        blockId: this.hangulStartPos.blockId,
+        offset: this.hangulStartPos.offset,
+        text: this.hangulComposingText,
+      });
+    } else {
+      this.onComposingContextChange(null);
+    }
+  }
+
+  /**
+   * Abort any in-progress IME composition — used on blur, where a
+   * `compositionend` is not guaranteed to fire. Commits the currently
+   * visible composing text (so an in-progress character is not lost) and
+   * clears the view-local layout injection so no ghost text is left
+   * rendered. A no-op when nothing is composing; normally `compositionend`
+   * fires before blur and this finds nothing to do.
+   */
+  cancelComposition(): void {
+    // Software Hangul: flush commits the in-progress syllable and clears
+    // its view-local preview (and already emits + re-renders).
+    if (this.hangulAssembler.isComposing) {
+      this.flushHangul();
+    }
+    if (!this.composition.active) return;
+    const { startPosition, composingText } = this.composition;
+    this.composition.active = false;
+    this.composition.composingText = '';
+    if (composingText.length > 0) {
+      // Commit the visible preview (no compositionend e.data is available
+      // here) as a single insert → one undo unit.
+      this.docInsertText(startPosition, composingText);
+      const endPos: DocPosition = {
+        blockId: startPosition.blockId,
+        offset: startPosition.offset + composingText.length,
+      };
+      this.markDirty(startPosition.blockId);
+      this.cursor.moveTo(endPos, this.getWrapAffinity(endPos));
+    }
+    this.emitComposingContext();
+    // Notify listeners that composition ended so the collaboration layer
+    // clears its cached composition-start anchor (otherwise a blur-aborted
+    // composition leaves a stale anchor behind).
+    for (const cb of this.compositionEndListeners) cb();
+    this.requestRender();
+  }
+
   private handleCompositionStart = (): void => {
     // Cancel any pending post-compositionend ignore — a new composition is
     // starting (e.g. syllable boundary in Korean: compositionend → compositionstart).
     this.ignoreInputUntilNextTick = false;
     this.saveSnapshot();
+    // A selection present at composition start is deleted here as its own
+    // edit (its own undo unit); the composed character commits as a second
+    // unit on compositionend. See docs-ime-undo-history.md Open Question #1.
     this.deleteSelection();
     const startPosition: DocPosition = { ...this.cursor.position };
     this.composition = {
       active: true,
       startPosition,
-      currentLength: 0,
+      composingText: '',
     };
     for (const cb of this.compositionStartListeners) cb({ ...startPosition });
   };
@@ -406,11 +503,12 @@ export class TextEditor {
     // the model during composition. This corrects any drift caused by
     // browser-specific textarea.value quirks (e.g. accumulation on iOS).
     const finalText = e.data || '';
-    const { startPosition, currentLength } = this.composition;
+    const { startPosition } = this.composition;
 
-    if (currentLength > 0) {
-      this.docDeleteText(startPosition, currentLength, { keepPending: true });
-    }
+    // Interim composing text was never written to the model (it was only
+    // injected into the layout for rendering), so there is nothing to
+    // delete first. Commit the final text in a single insert → exactly one
+    // doc.update() → one Yorkie undo unit. This is the issue #318 fix.
     if (finalText.length > 0) {
       this.docInsertText(startPosition, finalText);
     }
@@ -418,11 +516,16 @@ export class TextEditor {
       blockId: startPosition.blockId,
       offset: startPosition.offset + finalText.length,
     };
+
+    // Clear the view-local composing state and its layout injection before
+    // re-render so the block lays out from the now-committed model text.
+    this.composition.active = false;
+    this.composition.composingText = '';
+    this.emitComposingContext();
+
     this.markDirty(startPosition.blockId);
     this.cursor.moveTo(endPos, this.getWrapAffinity(endPos));
 
-    this.composition.active = false;
-    this.composition.currentLength = 0;
     for (const cb of this.compositionEndListeners) cb();
     this.requestRender();
 
@@ -455,22 +558,19 @@ export class TextEditor {
     if (this.composition.active) {
       // Browser IME path: read textarea.value which contains the current
       // composing text as managed by the browser's native IME system.
+      // The interim text is kept view-local (injected into the layout for
+      // rendering) and is NOT written to the model, so it produces no undo
+      // units; only the final compositionend commit does. (issue #318)
       const newText = this.textarea.value;
-      const { startPosition, currentLength } = this.composition;
+      const { startPosition } = this.composition;
 
-      if (currentLength > 0) {
-        this.docDeleteText(startPosition, currentLength, { keepPending: true });
-      }
-      if (newText.length > 0) {
-        this.docInsertText(startPosition, newText);
-      }
-
-      this.composition.currentLength = newText.length;
+      this.composition.composingText = newText;
       const compPos: DocPosition = {
         blockId: startPosition.blockId,
         offset: startPosition.offset + newText.length,
       };
       this.markDirty(startPosition.blockId);
+      this.emitComposingContext();
       this.cursor.moveTo(compPos, this.getWrapAffinity(compPos));
       this.requestRender();
       return;
@@ -4504,8 +4604,10 @@ export class TextEditor {
 
   private applyHangulResult(result: HangulResult): void {
     if (result.commit) {
-      if (this.hangulComposingLength > 0) {
-        this.docDeleteText(this.hangulStartPos, this.hangulComposingLength, { keepPending: true });
+      // Commit the finished syllable to the model in a single insert → one
+      // undo unit. The interim `composing` preview was view-local (only
+      // injected into the layout), so there is nothing to delete first.
+      if (this.hangulComposingText !== '') {
         this.docInsertText(this.hangulStartPos, result.commit);
         this.hangulStartPos = {
           blockId: this.hangulStartPos.blockId,
@@ -4519,29 +4621,28 @@ export class TextEditor {
           offset: this.cursor.position.offset + result.commit.length,
         };
       }
-      this.hangulComposingLength = 0;
+      this.hangulComposingText = '';
     }
 
     if (result.composing) {
-      if (this.hangulComposingLength === 0 && !result.commit) {
+      if (this.hangulComposingText === '' && !result.commit) {
         this.saveSnapshot();
         this.deleteSelection();
         this.hangulStartPos = { ...this.cursor.position };
       }
-      if (this.hangulComposingLength > 0) {
-        this.docDeleteText(this.hangulStartPos, this.hangulComposingLength, { keepPending: true });
-      }
-      this.docInsertText(this.hangulStartPos, result.composing);
-      this.hangulComposingLength = result.composing.length;
+      // View-local preview: rendered via layout injection, never written
+      // to the model (so it produces no undo unit until commit).
+      this.hangulComposingText = result.composing;
     } else {
-      this.hangulComposingLength = 0;
+      this.hangulComposingText = '';
     }
 
     const hangulPos: DocPosition = {
       blockId: this.hangulStartPos.blockId,
-      offset: this.hangulStartPos.offset + this.hangulComposingLength,
+      offset: this.hangulStartPos.offset + this.hangulComposingText.length,
     };
     this.markDirty(this.hangulStartPos.blockId);
+    this.emitComposingContext();
     this.cursor.moveTo(hangulPos, this.getWrapAffinity(hangulPos));
     this.requestRender();
   }

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -473,6 +473,9 @@ export class TextEditor {
       this.markDirty(startPosition.blockId);
       this.cursor.moveTo(endPos, this.getWrapAffinity(endPos));
     }
+    // Drop the now-committed preedit from the hidden textarea so a later
+    // non-IME `input` (after refocus) doesn't re-read and reinsert it.
+    this.textarea.value = '';
     this.emitComposingContext();
     // Notify listeners that composition ended so the collaboration layer
     // clears its cached composition-start anchor (otherwise a blur-aborted

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -4,7 +4,7 @@ import { Doc, type EditContext } from '../model/document.js';
 import { serializeClipboard, deserializeClipboard, cloneTableCells, parseHtmlToBlocks, parseHtmlTableToTableCells, parseMarkdownTableToTableCells, parseMarkdownWithTables, WAFFLEDOCS_MIME } from './clipboard.js';
 import { Cursor } from './cursor.js';
 import { Selection, expandCellRangeForMerges, findMergeTopLeft } from './selection.js';
-import type { DocumentLayout } from './layout.js';
+import type { ComposingContext, DocumentLayout } from './layout.js';
 import type { PaginatedLayout } from './pagination.js';
 import { paginatedPixelToPosition, findPageForPosition, getPageYOffset, getPageXOffset, getHeaderYStart, getFooterYStart, getTableOriginYForPageLine, resolveClickTarget } from './pagination.js';
 import { resolveInlineFont } from './layout.js';
@@ -71,7 +71,7 @@ export class TextEditor {
    * to the model). Called with `null` when composition ends or aborts.
    */
   onComposingContextChange:
-    | ((ctx: { blockId: string; offset: number; text: string } | null) => void)
+    | ((ctx: ComposingContext | null) => void)
     | null = null;
   /**
    * When true, all input events are ignored until the next microtask.
@@ -248,10 +248,7 @@ export class TextEditor {
     // position (the composing text isn't in the model, so the clamp lands it
     // before the preview); without this the caret would sit in front of the
     // injected composing run while the preview renders after it.
-    const caretPos: DocPosition = {
-      blockId: pos.blockId,
-      offset: pos.offset + this.composition.composingText.length,
-    };
+    const caretPos = this.composingEndPos(pos, this.composition.composingText);
     this.cursor.moveTo(caretPos, this.getWrapAffinity(caretPos));
     // Re-publish the view-local composing injection at the corrected
     // position so the preview does not render at the stale offset until the
@@ -265,6 +262,16 @@ export class TextEditor {
 
   isComposing(): boolean {
     return this.composition.active;
+  }
+
+  /**
+   * Position at the end of composing text that starts at `start` — i.e.
+   * where the caret sits while a composition of `text` is in progress (or
+   * just after it commits). Centralises the `start + length` offset math
+   * shared by the browser-IME and software-Hangul paths.
+   */
+  private composingEndPos(start: DocPosition, text: string): DocPosition {
+    return { blockId: start.blockId, offset: start.offset + text.length };
   }
 
   /**
@@ -462,10 +469,7 @@ export class TextEditor {
       // Commit the visible preview (no compositionend e.data is available
       // here) as a single insert → one undo unit.
       this.docInsertText(startPosition, composingText);
-      const endPos: DocPosition = {
-        blockId: startPosition.blockId,
-        offset: startPosition.offset + composingText.length,
-      };
+      const endPos = this.composingEndPos(startPosition, composingText);
       this.markDirty(startPosition.blockId);
       this.cursor.moveTo(endPos, this.getWrapAffinity(endPos));
     }
@@ -512,10 +516,7 @@ export class TextEditor {
     if (finalText.length > 0) {
       this.docInsertText(startPosition, finalText);
     }
-    const endPos: DocPosition = {
-      blockId: startPosition.blockId,
-      offset: startPosition.offset + finalText.length,
-    };
+    const endPos = this.composingEndPos(startPosition, finalText);
 
     // Clear the view-local composing state and its layout injection before
     // re-render so the block lays out from the now-committed model text.
@@ -565,10 +566,7 @@ export class TextEditor {
       const { startPosition } = this.composition;
 
       this.composition.composingText = newText;
-      const compPos: DocPosition = {
-        blockId: startPosition.blockId,
-        offset: startPosition.offset + newText.length,
-      };
+      const compPos = this.composingEndPos(startPosition, newText);
       this.markDirty(startPosition.blockId);
       this.emitComposingContext();
       this.cursor.moveTo(compPos, this.getWrapAffinity(compPos));
@@ -4637,10 +4635,7 @@ export class TextEditor {
       this.hangulComposingText = '';
     }
 
-    const hangulPos: DocPosition = {
-      blockId: this.hangulStartPos.blockId,
-      offset: this.hangulStartPos.offset + this.hangulComposingText.length,
-    };
+    const hangulPos = this.composingEndPos(this.hangulStartPos, this.hangulComposingText);
     this.markDirty(this.hangulStartPos.blockId);
     this.emitComposingContext();
     this.cursor.moveTo(hangulPos, this.getWrapAffinity(hangulPos));

--- a/packages/docs/test/view/composing-injection.test.ts
+++ b/packages/docs/test/view/composing-injection.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeLayout,
+  injectComposingInline,
+  type ComposingContext,
+} from '../../src/view/layout.js';
+import { createBlock } from '../../src/model/types.js';
+import type { LayoutBlock } from '../../src/view/layout.js';
+import type { Inline } from '../../src/model/types.js';
+import { stubMeasurer } from './_stub-measurer.js';
+
+/** Concatenate the visible text of every run across a laid-out block. */
+function blockText(lb: LayoutBlock): string {
+  return lb.lines.flatMap((l) => l.runs.map((r) => r.text)).join('');
+}
+
+describe('injectComposingInline', () => {
+  it('splices composing text mid-inline, splitting the inline', () => {
+    const inlines: Inline[] = [{ text: 'ABCD', style: {} }];
+    const result = injectComposingInline(inlines, 2, 'X');
+    expect(result.map((i) => i.text)).toEqual(['AB', 'X', 'CD']);
+  });
+
+  it('inherits the style at the insertion point (left-biased at a boundary)', () => {
+    const inlines: Inline[] = [
+      { text: 'AB', style: { bold: true } },
+      { text: 'CD', style: { italic: true } },
+    ];
+    // Offset 2 is the boundary; left bias means the composing text inherits
+    // the preceding bold inline's style.
+    const result = injectComposingInline(inlines, 2, 'X');
+    const composing = result.find((i) => i.text === 'X');
+    expect(composing?.style).toEqual({ bold: true });
+  });
+
+  it('appends at end-of-block, inheriting the trailing style', () => {
+    const inlines: Inline[] = [{ text: 'AB', style: { bold: true } }];
+    const result = injectComposingInline(inlines, 2, 'Z');
+    expect(result.map((i) => i.text)).toEqual(['AB', 'Z']);
+    expect(result[1].style).toEqual({ bold: true });
+  });
+
+  it('injects into an empty block', () => {
+    const result = injectComposingInline([], 0, 'Q');
+    expect(result.map((i) => i.text)).toEqual(['Q']);
+  });
+
+  it('returns the input unchanged for empty composing text', () => {
+    const inlines: Inline[] = [{ text: 'AB', style: {} }];
+    expect(injectComposingInline(inlines, 1, '')).toBe(inlines);
+  });
+
+  it('does not mutate the input inlines', () => {
+    const inlines: Inline[] = [{ text: 'ABCD', style: {} }];
+    injectComposingInline(inlines, 2, 'X');
+    expect(inlines).toEqual([{ text: 'ABCD', style: {} }]);
+  });
+});
+
+describe('computeLayout with composingContext', () => {
+  const measurer = stubMeasurer(8); // 8px per char
+
+  function paragraph(id: string, text: string) {
+    const block = createBlock('paragraph');
+    block.id = id;
+    block.inlines = [{ text, style: {} }];
+    return block;
+  }
+
+  it('injects composing text into the matching block only', () => {
+    const a = paragraph('a', 'ABCD');
+    const b = paragraph('b', 'WXYZ');
+    const composing: ComposingContext = { blockId: 'a', offset: 2, text: 'oo' };
+    const { layout } = computeLayout([a, b], measurer, 600, undefined, undefined, composing);
+    expect(blockText(layout.blocks[0])).toBe('ABooCD');
+    expect(blockText(layout.blocks[1])).toBe('WXYZ'); // untouched
+  });
+
+  it('reflows following text — composing text widens the line', () => {
+    const a = paragraph('a', 'ABCD');
+    const noComposing = computeLayout([a], measurer, 600).layout.blocks[0];
+    const composing: ComposingContext = { blockId: 'a', offset: 2, text: 'oo' };
+    const withComposing = computeLayout(
+      [paragraph('a', 'ABCD')], measurer, 600, undefined, undefined, composing,
+    ).layout.blocks[0];
+    // "ABCD" (4) -> "ABooCD" (6): the single line is 2 chars * 8px wider.
+    expect(withComposing.lines[0].width).toBe(noComposing.lines[0].width + 16);
+  });
+
+  it('reflows by wrapping when composing text overflows the line', () => {
+    // Width fits 5 chars (40px). "ABCD" is one line; injecting "XX" makes
+    // "ABXXCD" (6 chars / 48px), which must wrap to a second line.
+    const a = paragraph('a', 'ABCD');
+    const composing: ComposingContext = { blockId: 'a', offset: 2, text: 'XX' };
+    const { layout } = computeLayout([a], measurer, 40, undefined, undefined, composing);
+    expect(layout.blocks[0].lines.length).toBe(2);
+    expect(blockText(layout.blocks[0])).toBe('ABXXCD');
+  });
+
+  it('injects into an empty block', () => {
+    const empty = createBlock('paragraph');
+    empty.id = 'e';
+    empty.inlines = [{ text: '', style: {} }];
+    const composing: ComposingContext = { blockId: 'e', offset: 0, text: '가' };
+    const { layout } = computeLayout([empty], measurer, 600, undefined, undefined, composing);
+    expect(blockText(layout.blocks[0])).toBe('가');
+  });
+
+  it('leaves layout unchanged when composingContext targets no present block', () => {
+    const a = paragraph('a', 'ABCD');
+    const composing: ComposingContext = { blockId: 'ghost', offset: 0, text: 'oo' };
+    const { layout } = computeLayout([a], measurer, 600, undefined, undefined, composing);
+    expect(blockText(layout.blocks[0])).toBe('ABCD');
+  });
+});

--- a/packages/docs/test/view/composing-injection.test.ts
+++ b/packages/docs/test/view/composing-injection.test.ts
@@ -55,6 +55,27 @@ describe('injectComposingInline', () => {
     injectComposingInline(inlines, 2, 'X');
     expect(inlines).toEqual([{ text: 'ABCD', style: {} }]);
   });
+
+  it('drops structural metadata (image/pageNumber) so the composing run stays text', () => {
+    // Composing right after an inline image must not inherit `image`, or
+    // measureSegments would treat the preview as an image instead of text.
+    const inlines: Inline[] = [
+      { text: '￼', style: { image: { src: 'x', width: 10, height: 10 } } as Inline['style'] },
+    ];
+    const result = injectComposingInline(inlines, 1, '가');
+    const composing = result.find((i) => i.text === '가');
+    expect(composing?.style.image).toBeUndefined();
+    expect(composing?.style.pageNumber).toBeUndefined();
+  });
+
+  it('keeps visual style (bold) while dropping structural metadata', () => {
+    const inlines: Inline[] = [
+      { text: 'A', style: { bold: true, pageNumber: true } as Inline['style'] },
+    ];
+    const composing = injectComposingInline(inlines, 1, 'X').find((i) => i.text === 'X');
+    expect(composing?.style.bold).toBe(true);
+    expect(composing?.style.pageNumber).toBeUndefined();
+  });
 });
 
 describe('computeLayout with composingContext', () => {

--- a/packages/docs/test/view/ime-composition-editor.test.ts
+++ b/packages/docs/test/view/ime-composition-editor.test.ts
@@ -62,10 +62,14 @@ describe('docs editor — IME composition keeps interim text out of the model', 
   let editor: EditorAPI;
   let origGetContext: HTMLCanvasElement['getContext'];
   let origRAF: typeof window.requestAnimationFrame;
+  let origResizeObserver: unknown;
+  let origOffscreenCanvas: unknown;
 
   beforeEach(() => {
     origGetContext = HTMLCanvasElement.prototype.getContext;
     origRAF = window.requestAnimationFrame;
+    origResizeObserver = (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+    origOffscreenCanvas = (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas;
     installCanvasShim();
     window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
       queueMicrotask(() => cb(performance.now()));
@@ -83,6 +87,8 @@ describe('docs editor — IME composition keeps interim text out of the model', 
     document.body.removeChild(container);
     HTMLCanvasElement.prototype.getContext = origGetContext;
     window.requestAnimationFrame = origRAF;
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = origResizeObserver;
+    (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas = origOffscreenCanvas;
   });
 
   function textarea(): HTMLTextAreaElement {

--- a/packages/docs/test/view/ime-composition-editor.test.ts
+++ b/packages/docs/test/view/ime-composition-editor.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initialize, type EditorAPI } from '../../src/view/editor.js';
+import { MemDocStore } from '../../src/store/memory.js';
+import { createEmptyBlock } from '../../src/model/types.js';
+
+/**
+ * Editor-level guard for the IME undo-history fix (issue #318).
+ *
+ * The root cause was that interim IME composition text was written to the
+ * document model on every `compositionupdate`, producing many model
+ * mutations (and, under Yorkie, many undo units) for one character. The
+ * fix keeps interim composing text view-local (injected into the layout
+ * only) and commits the final text exactly once on `compositionend`.
+ *
+ * These tests assert the load-bearing behavior at the docs layer: the
+ * model is untouched during composition and receives the composed text
+ * exactly once at the end. (The "exactly one Yorkie undo unit" assertion
+ * lives in the frontend's yorkie-doc-store tests, since MemDocStore uses
+ * snapshot-based undo and cannot reproduce the operation-level toggle.)
+ */
+
+function installCanvasShim(): void {
+  const ctxHandler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'measureText') {
+        return (text: string) => ({
+          width: typeof text === 'string' ? text.length * 8 : 0,
+          actualBoundingBoxAscent: 8,
+          actualBoundingBoxDescent: 2,
+        });
+      }
+      if (prop === 'canvas') return null;
+      if (prop === 'font') return '12px sans-serif';
+      return () => {};
+    },
+    set() {
+      return true;
+    },
+  };
+  const fakeCtx = new Proxy({}, ctxHandler) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as {
+    getContext: (kind: string) => unknown;
+  }).getContext = (kind: string) => (kind === '2d' ? fakeCtx : null);
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+  if (!(globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas) {
+    (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+      constructor(public width: number, public height: number) {}
+      getContext(): unknown {
+        return { font: '12px sans-serif', measureText: (t: string) => ({ width: t.length * 8 }) };
+      }
+    };
+  }
+}
+
+describe('docs editor — IME composition keeps interim text out of the model', () => {
+  let container: HTMLElement;
+  let editor: EditorAPI;
+  let origGetContext: HTMLCanvasElement['getContext'];
+  let origRAF: typeof window.requestAnimationFrame;
+
+  beforeEach(() => {
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    origRAF = window.requestAnimationFrame;
+    installCanvasShim();
+    window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      queueMicrotask(() => cb(performance.now()));
+      return 0;
+    };
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    const store = new MemDocStore();
+    store.setDocument({ blocks: [createEmptyBlock()] });
+    editor = initialize(container, store);
+  });
+
+  afterEach(() => {
+    editor.dispose();
+    document.body.removeChild(container);
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+    window.requestAnimationFrame = origRAF;
+  });
+
+  function textarea(): HTMLTextAreaElement {
+    const el = container.querySelector('textarea');
+    if (!el) throw new Error('textarea not mounted');
+    return el;
+  }
+
+  function blockText(): string {
+    return editor.getDoc().document.blocks[0].inlines.map((i) => i.text).join('');
+  }
+
+  function compositionStart(): void {
+    textarea().dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+  }
+  function composingInput(value: string): void {
+    const ta = textarea();
+    ta.value = value;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+  function compositionEnd(data: string): void {
+    const ta = textarea();
+    ta.dispatchEvent(new CompositionEvent('compositionend', { data, bubbles: true }));
+  }
+
+  it('does not write interim composing text to the model, commits once at end', () => {
+    compositionStart();
+
+    // Interim jamo / syllable steps — model must stay empty (view-local only).
+    composingInput('ㄱ');
+    expect(blockText()).toBe('');
+    composingInput('가');
+    expect(blockText()).toBe('');
+
+    // Commit: the composed syllable lands in the model exactly once.
+    compositionEnd('가');
+    expect(blockText()).toBe('가');
+  });
+
+  it('commits consecutive syllables, each via a single end-of-composition write', () => {
+    // First syllable.
+    compositionStart();
+    composingInput('ㄱ');
+    composingInput('가');
+    compositionEnd('가');
+    expect(blockText()).toBe('가');
+
+    // Second syllable (Korean fires end -> start between syllables).
+    compositionStart();
+    composingInput('ㄴ');
+    composingInput('나');
+    compositionEnd('나');
+    expect(blockText()).toBe('가나');
+  });
+
+  it('uses e.data as the source of truth at commit (iOS drift correction)', () => {
+    compositionStart();
+    composingInput('ㅎ');
+    // Even if textarea.value drifted, the committed text follows e.data.
+    compositionEnd('한');
+    expect(blockText()).toBe('한');
+  });
+
+  it('blur mid-composition commits the visible preview and ends composition', () => {
+    compositionStart();
+    composingInput('ㄱ');
+    composingInput('가');
+    expect(blockText()).toBe(''); // still view-local
+    // Focus leaves before any compositionend fires.
+    textarea().dispatchEvent(new FocusEvent('blur', { bubbles: true }));
+    expect(blockText()).toBe('가'); // preview committed, no ghost text left
+    expect(editor.isComposing()).toBe(false);
+  });
+
+  it('software Hangul (no composition events) stays view-local, commits on flush', () => {
+    // Mobile-Safari path: raw jamo arrive as plain input, assembled in-app.
+    composingInput('ㄱ');
+    expect(blockText()).toBe('');
+    composingInput('ㅏ'); // assembles to "가" as a view-local preview
+    expect(blockText()).toBe('');
+    // Blur flushes the software-Hangul assembler, committing the syllable.
+    textarea().dispatchEvent(new FocusEvent('blur', { bubbles: true }));
+    expect(blockText()).toBe('가');
+  });
+
+  it('updateCompositionStartPosition mid-composition still commits correctly', () => {
+    compositionStart();
+    composingInput('ㄱ');
+    expect(blockText()).toBe('');
+    // Simulate the collaboration layer correcting the anchor after a remote
+    // change. This must re-publish the composing preview without throwing
+    // and keep composition active so the final commit lands.
+    const blockId = editor.getDoc().document.blocks[0].id;
+    editor.updateCompositionStartPosition({ blockId, offset: 0 });
+    expect(editor.isComposing()).toBe(true);
+    compositionEnd('가');
+    expect(blockText()).toBe('가');
+  });
+
+  it('updateCompositionStartPosition moves the caret to the end of the composing text', () => {
+    let lastCursor: { blockId: string; offset: number } | null = null;
+    editor.onCursorMove((pos) => {
+      lastCursor = pos;
+    });
+    compositionStart();
+    composingInput('ㅎ');
+    composingInput('한'); // composing text length 1
+    const blockId = editor.getDoc().document.blocks[0].id;
+    // A remote change resolves the composition start to offset 0; the caret
+    // must follow to 0 + length("한") = 1, not stay before the preview.
+    editor.updateCompositionStartPosition({ blockId, offset: 0 });
+    expect(lastCursor).toEqual({ blockId, offset: 1 });
+  });
+
+  it('blur aborting composition fires onCompositionEnd (clears collab anchor)', () => {
+    let ended = 0;
+    editor.onCompositionEnd(() => {
+      ended++;
+    });
+    compositionStart();
+    composingInput('ㄱ');
+    textarea().dispatchEvent(new FocusEvent('blur', { bubbles: true }));
+    expect(ended).toBe(1);
+    expect(editor.isComposing()).toBe(false);
+  });
+
+  it('applies a pending inline style to the committed composed character', () => {
+    // Toggle bold at the collapsed caret, then compose a syllable.
+    editor.applyStyle({ bold: true });
+    compositionStart();
+    composingInput('ㅂ');
+    composingInput('바');
+    compositionEnd('바');
+
+    const inlines = editor.getDoc().document.blocks[0].inlines;
+    const composed = inlines.find((i) => i.text.includes('바'));
+    expect(composed?.style.bold).toBe(true);
+  });
+});

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -863,6 +863,33 @@ export class YorkieDocStore implements DocStore {
     };
   }
 
+  /**
+   * Clamp a document position's offset to its block's model text length.
+   *
+   * The local caret can legitimately sit past the model length during IME
+   * composition, because the in-progress composing text is rendered
+   * view-locally (injected into the layout) but never written to the
+   * shared model. Peers do not have that text, so publishing the raw,
+   * out-of-model offset into presence would point their cursor overlay at
+   * a position that does not exist in the shared document. Clamp before
+   * publishing so presence always references a valid model position. The
+   * anchors already clamp via `anchorDocPosition`; this keeps the raw
+   * presence offset consistent with them. Best-effort: an unresolvable
+   * block id falls through unchanged.
+   */
+  private clampPosToModel(pos: DocPosition): DocPosition {
+    try {
+      const currentDoc = this.getDocument();
+      const { path, region } = this.resolveBlockTreePath(pos.blockId, currentDoc);
+      const block = this.getBlockByRegion(currentDoc, path, region);
+      if (!block) return pos;
+      const len = this.blockTextLength(block);
+      return { blockId: pos.blockId, offset: Math.max(0, Math.min(pos.offset, len)) };
+    } catch {
+      return pos;
+    }
+  }
+
   private topLevelRegionIndex(
     currentDoc: Document,
     region: DocRegion,
@@ -2629,12 +2656,23 @@ export class YorkieDocStore implements DocStore {
       };
     } | null,
   ): void {
-    this.localCursorAnchor = pos ? this.anchorDocPosition(pos, 'backward') : null;
-    this.localSelectionAnchor = this.anchorDocRange(selection ?? null);
+    // Clamp to the model before publishing so an out-of-model offset (e.g.
+    // the caret sitting after view-local IME composing text) never leaks
+    // into peer presence. See clampPosToModel.
+    const clampedPos = pos ? this.clampPosToModel(pos) : null;
+    const clampedSelection = selection
+      ? {
+          ...selection,
+          anchor: this.clampPosToModel(selection.anchor),
+          focus: this.clampPosToModel(selection.focus),
+        }
+      : selection;
+    this.localCursorAnchor = clampedPos ? this.anchorDocPosition(clampedPos, 'backward') : null;
+    this.localSelectionAnchor = this.anchorDocRange(clampedSelection ?? null);
     this.doc.update((_, p) => {
       p.set({
-        activeCursorPos: pos ?? undefined,
-        activeSelection: selection ?? undefined,
+        activeCursorPos: clampedPos ?? undefined,
+        activeSelection: clampedSelection ?? undefined,
       });
     });
   }

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -365,6 +365,69 @@ describe('YorkieDocStore', () => {
       expect(restored).toEqual({ blockId: block.id, offset: 5 });
     });
 
+    // --- IME composition undo (issue #318) ---
+    //
+    // The fixed IME path keeps interim composing text out of the model and
+    // commits a composed syllable in a single `insertText` (one
+    // `doc.update()`), so one composed character is exactly one Yorkie undo
+    // unit. These guard that contract at the store level; the docs package
+    // covers the "interim text never reaches the model" half.
+    function blockText(id: string): string {
+      return store.getBlock(id)?.inlines.map((i) => i.text).join('') ?? '';
+    }
+
+    it('a single committed syllable adds exactly one undo unit', () => {
+      const block = makeBlock('');
+      store.setDocument({ blocks: [block] });
+      const before = doc.getUndoStackForTest().length;
+      // What compositionend now does: commit the whole syllable at once.
+      store.insertText(block.id, 0, '가');
+      expect(doc.getUndoStackForTest().length).toBe(before + 1);
+      expect(blockText(block.id)).toBe('가');
+    });
+
+    it('one undo removes a composed syllable cleanly (no toggle)', () => {
+      const block = makeBlock('가');
+      store.setDocument({ blocks: [block] });
+      store.insertText(block.id, 1, '나'); // commit a second syllable
+      expect(blockText(block.id)).toBe('가나');
+      store.undo();
+      // Gone in ONE undo — not toggled back on by a second undo unit.
+      expect(blockText(block.id)).toBe('가');
+    });
+
+    it('clamps an out-of-model cursor offset before publishing to presence', () => {
+      // During IME composition the caret can sit past the model length
+      // because the composing text is view-local. Presence must not publish
+      // that out-of-model offset to peers.
+      const block = makeBlock('가'); // model length 1
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 3 }, null);
+      expect(store.getPresenceCursorPos()).toEqual({ blockId: block.id, offset: 1 });
+    });
+
+    it('leaves an in-range cursor offset untouched in presence', () => {
+      const block = makeBlock('Hello');
+      store.setDocument({ blocks: [block] });
+      store.updateCursorPos({ blockId: block.id, offset: 3 }, null);
+      expect(store.getPresenceCursorPos()).toEqual({ blockId: block.id, offset: 3 });
+    });
+
+    it('contrast: the legacy interim-write churn produced many undo units', () => {
+      const block = makeBlock('');
+      store.setDocument({ blocks: [block] });
+      const before = doc.getUndoStackForTest().length;
+      // The pre-fix per-compositionupdate pattern: each insert/delete was its
+      // own doc.update(), so one syllable stacked several reversible units at
+      // the same position — the reported on/off toggle.
+      store.insertText(block.id, 0, 'ㄱ');
+      store.deleteText(block.id, 0, 1);
+      store.insertText(block.id, 0, '가');
+      store.deleteText(block.id, 0, 1);
+      store.insertText(block.id, 0, '가');
+      expect(doc.getUndoStackForTest().length).toBeGreaterThan(before + 1);
+    });
+
     // Regression: ensureTree() in docs-view.tsx populates the Tree with an
     // initial block via doc.update() *before* YorkieDocStore is constructed.
     // When the doc already has blocks, editor.ts skips its setDocument


### PR DESCRIPTION
## Summary

Fixes the Hangul IME undo "toggle" (issue #318): typing one Korean syllable used
to land as **multiple overlapping Yorkie undo units**, so Undo flipped the
character on/off instead of removing it once. Now **one IME-composed character =
one undo unit**, matching English input and Google Docs / Notion.

Opened design-note-first; now contains the full implementation on the same
branch.

## Why

Undo/redo is Yorkie's document history: each `doc.update()` is exactly one undo
unit, and (confirmed against `@yorkie-js/sdk` 0.7.8) there is no way to exclude a
Tree edit from history or group across updates. The IME pipeline wrote interim
composition into the Tree on every `compositionupdate` (delete + insert) and
again at `compositionend`, so one syllable produced 3–5 reversible edits at the
same position — the toggle.

**Approach B (view-local layout injection):** interim composing text is never
written to the model; it is injected into the *layout* as a synthetic inline at
the caret, so it wraps/reflows like real text while the model stays untouched.
The character is committed exactly once on `compositionend` → one `doc.update()`
→ one undo unit. (Approach A — painting at the caret — was rejected: it doesn't
reflow, so mid-paragraph composition would overlap following text.)

Body / header / footer / table-cell all funnel through the same `layoutBlock`,
so one seam covers every region.

## Linked Issues

Fixes #318

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — green locally (pre-push lanes: lint, unit, builds, chunk budgets, entropy); CI to re-confirm.
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): the only Yorkie-path change is a **frontend
presence-offset clamp** (`clampPosToModel` in `yorkie-doc-store.ts`); no
backend/Yorkie-server logic changed. Covered by unit tests against a real
`yorkie.Document`. CI `verify:integration` runs automatically regardless.

## Risk Assessment

- User-facing risk: touches the Docs text-input/composition path. Mitigated by
  23 new unit tests (layout injection + reflow, editor IME behavior, undo units,
  presence clamp) and manual smoke (one-step undo, mid-paragraph reflow, blur,
  software-Hangul) in the standalone playground and the full Yorkie app.
- Data/security risk: none. No schema/auth/persistence change; interim composing
  text is never written to the shared model.
- Rollback plan: revert this PR's commits — isolated to docs layout/text-editor
  + one frontend presence clamp; no migrations or API changes.

## Notes for Reviewers

- UI changes: no new chrome; behavior change is IME composition rendering + undo
  granularity. (Composing text rendering is unchanged visually; it just no longer
  hits the model.)
- Incorporates two rounds of self-review: presence-leak clamp, stale-preview
  re-emit on remote anchor correction, blur ghost-text cleanup + `compositionEnd`
  lifecycle, and caret-follows-composing-text on remote correction.
- AI tools assisted (codebase/SDK investigation, design note, implementation)
  using Claude Code (Claude Opus 4.8); the author reviewed the root-cause
  analysis and every change.
- Follow-up: the docs playground IME smoke script (`test:ime`) pre-dates this
  work and is broken against the Alice-seeded demo (expects an empty doc) —
  tracked separately, not addressed here.
