### PR TITLE
feat: introduce @playwright/test for behavioral e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,13 @@ jobs:
       WAFFLEBASE_E2E_AUTH: "1"
       JWT_SECRET: ci-e2e-jwt-secret
       FRONTEND_URL: http://localhost:5173
+      # GitHub OAuth strategy is instantiated at boot and demands
+      # clientID/clientSecret even when /auth/github is never hit
+      # during e2e. Stub values keep AppModule wiring happy; the
+      # test-auth bypass (WAFFLEBASE_E2E_AUTH=1) is what specs use.
+      GITHUB_CLIENT_ID: ci-e2e-stub
+      GITHUB_CLIENT_SECRET: ci-e2e-stub
+      GITHUB_CALLBACK_URL: http://localhost:3000/auth/github/callback
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,3 +292,101 @@ jobs:
               comment_id: existing.id,
               body: updated,
             });
+
+  verify-e2e:
+    runs-on: ubuntu-latest
+    needs: verify-self
+    env:
+      DATABASE_URL: postgresql://wafflebase:wafflebase@localhost:5432/wafflebase
+      DATASOURCE_ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      RUN_DB_INTEGRATION_TESTS: "true"
+      RUN_YORKIE_INTEGRATION_TESTS: "true"
+      YORKIE_RPC_ADDR: http://localhost:8080
+      WAFFLEBASE_E2E_AUTH: "1"
+      JWT_SECRET: ci-e2e-jwt-secret
+      FRONTEND_URL: http://localhost:5173
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: wafflebase
+          POSTGRES_PASSWORD: wafflebase
+          POSTGRES_DB: wafflebase
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U wafflebase -d wafflebase"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      matrix:
+        node-version: [22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace packages
+        # Same rebuild step as verify-integration: tokens/docs/slides/sheets
+        # are imported by backend + frontend at runtime via their dist/.
+        run: |
+          pnpm tokens build
+          pnpm --filter @wafflebase/docs build
+          pnpm slides build
+          pnpm sheets build
+
+      - name: Install Playwright chromium
+        run: pnpm --filter @wafflebase/frontend exec playwright install chromium --with-deps
+
+      - name: Start Yorkie server
+        run: |
+          docker run -d --name yorkie \
+            -p 8080:8080 -p 8081:8081 \
+            yorkieteam/yorkie:latest server --pprof-enabled
+
+      - name: Wait for Yorkie to accept connections on :8080
+        run: |
+          for i in $(seq 1 30); do
+            if nc -z localhost 8080; then
+              echo "Yorkie is up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Yorkie did not become reachable on :8080" >&2
+          docker logs yorkie || true
+          exit 1
+
+      - name: Apply database migrations
+        run: pnpm --filter @wafflebase/backend exec prisma migrate deploy
+
+      - name: Verify E2E Lane
+        id: e2e
+        run: pnpm verify:e2e:standalone
+
+      - name: Upload Playwright report
+        if: failure() && steps.e2e.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: packages/frontend/playwright-report
+          retention-days: 14
+
+      - name: Upload Playwright traces
+        if: failure() && steps.e2e.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: packages/frontend/test-results
+          retention-days: 14
+
+      - name: Yorkie logs on failure
+        if: failure()
+        run: docker logs yorkie

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ pnpm verify:fast                    # Lint + unit tests (pre-commit gate)
 pnpm verify:self                    # verify:fast + all builds
 pnpm verify:full                    # verify:self + integration (DB required)
 pnpm verify:browser:docker          # Visual + interaction tests in Docker
+pnpm verify:e2e                     # Playwright behavioral e2e (needs backend with WAFFLEBASE_E2E_AUTH=1)
+pnpm verify:e2e:standalone          # One-shot: boots backend + frontend + runs e2e
 pnpm test                           # Sheets package tests only (Vitest)
 pnpm sheets build:formula           # IMPORTANT: regenerate ANTLR formula parser
 pnpm backend migrate                # Run Prisma database migrations

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -83,6 +83,7 @@ Infrastructure, frontend/backend, and cross-cutting concerns.
 | [context-menu.md](context-menu.md)                     | Unified context menu — Radix ContextMenu, desktop/mobile parity, menu items                       |
 | [rest-api.md](rest-api.md)                             | REST API v1 — workspace-scoped API keys, `/api/v1/` documents/tabs/cells/content endpoints, Yorkie service, CLI auth endpoints |
 | [cli.md](cli.md)                                       | `wafflebase` CLI — OAuth login + API keys, ctx switching, docs/sheets/api-keys namespaces, content/export/import, agent integration |
+| [e2e-testing.md](e2e-testing.md)                       | E2E behavioral testing — @playwright/test, test-auth bypass, fixtures, POC, lane + CI integration  |
 | [harness-engineering.md](harness-engineering.md)       | Verification lane strategy, phase roadmap, rollout status, and harness v1 completion criteria      |
 | [homepage.md](homepage.md)                             | Homepage landing page — sections, live demo, theme support, developer examples                     |
 | [docs-site.md](docs-site.md)                           | Documentation site — VitePress setup, package structure, deployment under /docs subpath            |

--- a/docs/design/e2e-testing.md
+++ b/docs/design/e2e-testing.md
@@ -1,0 +1,315 @@
+---
+title: e2e-testing
+target-version: 0.5.0
+---
+
+<!-- Make sure to append document link in design README.md after creating the document. -->
+
+# E2E Testing with @playwright/test
+
+## Summary
+
+Introduce `@playwright/test` as a first-class end-to-end testing system that
+targets real application routes (login → dashboard → editor) and runs against
+a full local stack (Postgres + Yorkie + backend + frontend). The new system
+coexists with the existing visual-regression baselines
+(`scripts/verify-visual-browser.mjs`) and interaction-regression scripts
+(`scripts/verify-interaction-browser.mjs`), and is intended to be the default
+home for **new** behavioral e2e tests — particularly those that an AI agent
+exercises via the Puppeteer MCP during a smoke step and then wants to codify
+as a permanent regression.
+
+The current browser-test infrastructure uses Playwright's API directly from
+custom Node scripts. It works for the 43 visual baselines but creates
+friction for adding behavioral tests: scenarios are hardcoded, lockstep
+edits across two files are required to add one, and there are no fixtures,
+traces, or standard reporters. Behavioral coverage is limited to three
+hardcoded scenarios (cell input, formula, scroll), which means agent-driven
+smoke checks rarely become permanent tests.
+
+### Goals
+
+- A single, well-known place (`packages/frontend/tests/e2e/`) where any new
+  behavioral e2e test lives.
+- A copy-paste template (`__template__.spec.ts`) that an agent can fill in
+  during a "promote my smoke check" step.
+- Test-only auth bypass that lets specs reach authenticated routes in under
+  one second per worker, without touching GitHub OAuth.
+- Standard Playwright fixtures (`auth`, `freshDoc`) discoverable through a
+  single `fixtures/index.ts` re-export.
+- A `verify:e2e` lane wired into `harness.config.json` and CI, with
+  failure-only HTML report + trace artifacts retained for 14 days.
+- A first proof-of-concept scenario shipped together with the infrastructure
+  so the pattern is demonstrable, not aspirational.
+
+### Non-Goals
+
+- **Migrating existing visual baselines** (43 PNGs under
+  `tests/visual/baselines/`) to `toHaveScreenshot()`. The
+  bit-perfect-vs-threshold semantics differ, font-rendering Docker
+  consistency must be re-validated, and the migration is large enough to
+  warrant its own design pass. **This decision is explicitly deferred and
+  revisited only after the new system has been stable for at least one
+  release cycle.** Visual regressions continue to use
+  `verify:browser:docker` indefinitely until that decision is made.
+- **Migrating existing interaction scripts** (cell input / formula / scroll)
+  in the first PR. These are moved opportunistically in later PRs and the
+  old verifier is removed only once its scenario count reaches zero.
+- **Replacing vitest unit/component tests.** Anything that runs in jsdom
+  stays in jsdom.
+- **Expanding e2e to other packages** (`sheets`, `docs`, `slides`,
+  `backend`, `cli`). First cycle is `frontend` only.
+- **Real GitHub OAuth in CI.** External-service dependencies stay out of
+  the e2e lane.
+
+## Proposal Details
+
+### Architecture overview
+
+```
+packages/frontend/
+├── playwright.config.ts                # config: projects, reporter, trace, baseURL
+├── tests/
+│   ├── e2e/                            # new @playwright/test home
+│   │   ├── fixtures/
+│   │   │   ├── auth.ts                 # storageState + test-user fixture
+│   │   │   ├── doc.ts                  # freshDoc seed + teardown (PR2+)
+│   │   │   └── index.ts                # re-export of `test`, `expect`
+│   │   ├── support/
+│   │   │   └── pages/                  # optional page-object helpers
+│   │   ├── specs/
+│   │   │   └── dashboard/
+│   │   │       └── create-slides-doc.spec.ts  # POC
+│   │   ├── __template__.spec.ts        # copy-this-file template
+│   │   └── README.md                   # quick-start for humans + agents
+│   ├── visual/                         # existing baselines (untouched)
+│   └── …                               # existing vitest files (untouched)
+└── scripts/
+    ├── verify-visual-browser.mjs       # legacy, unchanged
+    └── verify-interaction-browser.mjs  # legacy, unchanged
+```
+
+Rationale:
+
+- One canonical home (`tests/e2e/`) so the answer to "where does a new e2e
+  test go?" is fixed.
+- `fixtures/index.ts` exposes an extended `test` plus `expect`. Every spec
+  imports from the same path, which makes the pattern easy for an agent to
+  reproduce.
+- Legacy scripts continue to power `verify:browser:docker` so visual
+  coverage does not regress.
+
+### Test-only auth bypass
+
+A new `TestAuthController` is added under `packages/backend/src/auth/`,
+gated on `WAFFLEBASE_E2E_AUTH === '1'`. The controller exposes a single
+endpoint:
+
+```
+POST /test/auth/login
+body: { username: string, email: string }
+→ idempotent findOrCreateUser({ authProvider: 'test', ... })
+→ sets wafflebase_session + wafflebase_refresh cookies (same shape as
+   production)
+→ returns { ok: true, userId }
+```
+
+Guard rails:
+
+- The controller is registered inside `AuthModule` only when the env var is
+  set at module-construction time. In production deploys (where the env
+  is never set) the route is not registered, so requests to
+  `/test/auth/login` return 404.
+- Backend logs `[test-auth] DEV-ONLY ROUTES ENABLED` on startup when the
+  flag is on. Reviewers grepping for the controller name find a clear
+  marker.
+- Token signing reuses `AuthService.signTokens()` — the JWT shape and
+  cookie attributes match real OAuth login.
+- Deployment hardening: the `WAFFLEBASE_E2E_AUTH` env var is never set in
+  any production Dockerfile or deploy manifest. README + design doc both
+  state this explicitly.
+
+The Playwright auth fixture (`tests/e2e/fixtures/auth.ts`) uses a
+per-worker `storageState` cache. On first use per worker it POSTs to
+`/test/auth/login` with `username = "e2e-${workerIndex}"`, persists the
+resulting cookies to `playwright/.auth/worker-${workerIndex}.json`, and
+re-uses that file for the rest of the worker's lifetime. Specs simply
+import `test` and `expect` from `../fixtures` — no per-test login cost
+visible to the test author.
+
+### Lane / CI integration
+
+Lane definitions:
+
+| Command | Purpose | Browser | Requires |
+|---|---|---|---|
+| `pnpm verify:e2e` | Run e2e against an already-running stack | Yes (host Chromium) | `docker compose up -d` + `pnpm dev` with `WAFFLEBASE_E2E_AUTH=1` |
+| `pnpm verify:e2e:standalone` | One-shot wrapper (`scripts/run-e2e-standalone.mjs`) that builds, starts backend + frontend preview in the background, waits on `:3000` and `:5173`, runs the e2e lane, then tears down | Yes | `docker compose up -d` |
+| `pnpm verify:ci` (extended) | Adds `verify:e2e:standalone` after existing lanes | Yes | CI services for Postgres + Yorkie |
+| `pnpm verify:browser:docker` (unchanged) | Visual + interaction regression in Dockerfile.playwright | Yes (Docker) | — |
+
+Actionable preflight messages (e.g. "start backend with
+`WAFFLEBASE_E2E_AUTH=1`" or "docker compose up -d for Postgres + Yorkie")
+are emitted from `scripts/run-e2e-standalone.mjs` itself when expected
+ports/services are not reachable. `harness.config.json` does not yet
+carry a `lanes:` schema; introducing one is left as a follow-up after
+the new lane has settled.
+
+CI layout (`.github/workflows/ci.yml`): a new `verify-e2e` job parallel to
+`verify-integration`. It declares Postgres and Yorkie as services
+(reusing the existing pattern), then builds + starts backend
+(`WAFFLEBASE_E2E_AUTH=1`) and frontend in background steps, waits on the
+listening ports, runs `pnpm verify:e2e`, and uploads `playwright-report/`
+and `test-results/` on failure (14-day retention).
+
+The job is kept separate from `verify-browser` so that:
+
+- Visual regression failures (fast image diffs) surface independently of
+  e2e behavioural failures (slower).
+- Dockerfile.playwright stays a thin chromium image; it does not gain
+  responsibility for booting Postgres/Yorkie/backend.
+
+### Playwright config
+
+`packages/frontend/playwright.config.ts` (sketch):
+
+```ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/e2e/specs',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['html'], ['github']] : 'list',
+  use: {
+    baseURL: process.env.WAFFLEBASE_E2E_BASE_URL ?? 'http://localhost:5173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium-desktop', use: { ...devices['Desktop Chrome'] } },
+  ],
+});
+```
+
+Mobile project is added when the first mobile-specific spec lands, not
+preemptively.
+
+### Proof-of-concept spec
+
+`packages/frontend/tests/e2e/specs/dashboard/create-slides-doc.spec.ts`:
+
+```ts
+import { test, expect } from '../../fixtures';
+
+test.describe('Dashboard: create slides document', () => {
+  test('creates a new slides document and lists it', async ({ page }) => {
+    await page.goto('/');
+    await expect(
+      page.getByRole('heading', { name: /my documents/i }),
+    ).toBeVisible();
+
+    const docsBefore = await page.getByTestId('document-row').count();
+    await page.getByRole('button', { name: /new slides/i }).click();
+
+    await expect(page).toHaveURL(/\/document\/[a-z0-9-]+/);
+    await expect(page.getByTestId('slides-editor')).toBeVisible();
+
+    await page.goto('/');
+    const docsAfter = await page.getByTestId('document-row').count();
+    expect(docsAfter).toBe(docsBefore + 1);
+  });
+});
+```
+
+Selector policy:
+
+- Prefer `getByRole`, `getByText`, `getByLabel` — accessible by
+  construction.
+- Fall back to `data-testid` only when role/text selectors are ambiguous or
+  missing.
+- Avoid CSS class or structural selectors; they break on refactor.
+- If a needed selector is missing, add `data-testid` in the same PR.
+
+Cleanup is deferred: PR 1 leaves created docs in the database. A
+`freshDoc` fixture with `afterEach` teardown is introduced in PR 2 when
+multi-spec leakage starts to matter.
+
+### Agent-facing surface
+
+- `packages/frontend/tests/e2e/README.md` (≤50 lines): how to run, how to
+  add, how to debug. Linked from `CLAUDE.md` Commands section.
+- `__template__.spec.ts`: a minimal Arrange/Act/Assert spec stub with TODO
+  markers. Copy-paste is the intended workflow.
+- `docs/design/e2e-testing.md` (this document): why the system exists, the
+  conventions, the boundaries.
+- Future: a user-side skill (under `~/.claude/`, not committed to this
+  repo) that detects "just smoke-tested via Puppeteer MCP, want to codify?"
+  and walks the agent through generating a spec. Out of scope for the
+  first PR.
+
+Updates to existing docs in the first PR:
+
+- `CLAUDE.md` Commands table: add `pnpm verify:e2e`.
+- `docs/design/README.md` Common table: link this document.
+- `docs/design/harness-engineering.md` lane list: add `verify:e2e`.
+
+### Coexistence rules
+
+| New test kind | Lives in |
+|---|---|
+| User-visible behavior / interaction | `tests/e2e/` (new) |
+| Pixel-diff visual regression | `tests/visual/baselines/` + harness page (existing) |
+| jsdom-compatible unit / component | `tests/*.test.ts(x)` (vitest, existing) |
+
+Rule of thumb: if the test is not a pixel comparison, it belongs in the
+new system. Adding new scenarios to `verify-interaction-browser.mjs` is
+disallowed after PR 1; the old verifier is read-only until it is removed.
+
+### Migration roadmap
+
+| PR | Scope |
+|---|---|
+| **PR 1** (this spec) | Infra + auth fixture + Docker/CI + POC + template + docs |
+| PR 2…N | New behavioral specs, 1–3 per PR |
+| PR M | Port the three existing interaction scenarios (cell / formula / scroll) |
+| PR M+1 | Delete `scripts/verify-interaction-browser.mjs`; remove the interaction step from `verify:browser:docker` |
+| (Deferred) | Visual regression migration to `toHaveScreenshot()` — see Non-Goals |
+
+### Risks and Mitigation
+
+**Test-auth route leaks to production.** Mitigated by env-var gating at
+module construction time (route literally not registered without
+`WAFFLEBASE_E2E_AUTH=1`), startup log marker, explicit README note. Code
+review checklist item for any auth-module change. A post-merge smoke
+check on the production backend image confirms `/test/auth/login` returns
+404 with the env unset; this becomes part of the PR's verification list.
+
+**Flaky first PR.** Real-route tests against a live stack are more
+brittle than harness-page tests. Mitigated by `retries: 2` in CI, trace
+artifacts on every failure, and a single high-signal POC scenario (not
+ten). If the POC proves flaky within one week post-merge, the lane is
+demoted to `continue-on-error: true` while we stabilize; infra stays.
+
+**Workflow drift — new tests still land in legacy verifier.** Mitigated by
+explicit "do not add new scenarios" comment at the top of both legacy
+scripts and a CLAUDE.md note pointing new tests at `tests/e2e/`. Long-term
+mitigation is finishing the migration (PR M+1) so the legacy path
+disappears.
+
+**Two systems coexisting indefinitely.** A real risk because we explicitly
+defer visual migration. Mitigated by making the coexistence boundary
+sharp (pixel-diff = old, everything else = new) and reviewing the deferral
+at each release cycle. The visual system is small (≈85 PNGs, one
+verifier) and is acceptable to keep if the cost of migration outweighs
+the benefit; the decision is revisited, not forgotten.
+
+**Auth fixture stuck on first failure.** A bad cookie cached in
+`playwright/.auth/worker-N.json` would poison every subsequent run.
+Mitigated by deleting the auth cache on Playwright `globalSetup` (fresh
+storage state each run, then reused within the run).
+
+**Docker font-consistency regressions.** Not relevant for PR 1 (no
+screenshot assertions). Becomes relevant only when the visual migration is
+revisited, at which point this design is re-opened.

--- a/docs/design/e2e-testing.md
+++ b/docs/design/e2e-testing.md
@@ -13,8 +13,8 @@ Introduce `@playwright/test` as a first-class end-to-end testing system that
 targets real application routes (login → dashboard → editor) and runs against
 a full local stack (Postgres + Yorkie + backend + frontend). The new system
 coexists with the existing visual-regression baselines
-(`scripts/verify-visual-browser.mjs`) and interaction-regression scripts
-(`scripts/verify-interaction-browser.mjs`), and is intended to be the default
+(`packages/frontend/scripts/verify-visual-browser.mjs`) and interaction-regression scripts
+(`packages/frontend/scripts/verify-interaction-browser.mjs`), and is intended to be the default
 home for **new** behavioral e2e tests — particularly those that an AI agent
 exercises via the Puppeteer MCP during a smoke step and then wants to codify
 as a permanent regression.
@@ -31,12 +31,12 @@ smoke checks rarely become permanent tests.
 
 - A single, well-known place (`packages/frontend/tests/e2e/`) where any new
   behavioral e2e test lives.
-- A copy-paste template (`__template__.spec.ts`) that an agent can fill in
+- A copy-paste template (`packages/frontend/tests/e2e/__template__.spec.ts`) that an agent can fill in
   during a "promote my smoke check" step.
 - Test-only auth bypass that lets specs reach authenticated routes in under
   one second per worker, without touching GitHub OAuth.
 - Standard Playwright fixtures (`auth`, `freshDoc`) discoverable through a
-  single `fixtures/index.ts` re-export.
+  single `packages/frontend/tests/e2e/fixtures/index.ts` re-export.
 - A `verify:e2e` lane wired into `harness.config.json` and CI, with
   failure-only HTML report + trace artifacts retained for 14 days.
 - A first proof-of-concept scenario shipped together with the infrastructure
@@ -93,7 +93,7 @@ Rationale:
 
 - One canonical home (`tests/e2e/`) so the answer to "where does a new e2e
   test go?" is fixed.
-- `fixtures/index.ts` exposes an extended `test` plus `expect`. Every spec
+- `packages/frontend/tests/e2e/fixtures/index.ts` exposes an extended `test` plus `expect`. Every spec
   imports from the same path, which makes the pattern easy for an agent to
   reproduce.
 - Legacy scripts continue to power `verify:browser:docker` so visual
@@ -129,7 +129,7 @@ Guard rails:
   any production Dockerfile or deploy manifest. README + design doc both
   state this explicitly.
 
-The Playwright auth fixture (`tests/e2e/fixtures/auth.ts`) uses a
+The Playwright auth fixture (`packages/frontend/tests/e2e/fixtures/auth.ts`) uses a
 per-worker `storageState` cache. On first use per worker it POSTs to
 `/test/auth/login` with `username = "e2e-${workerIndex}"`, persists the
 resulting cookies to `playwright/.auth/worker-${workerIndex}.json`, and
@@ -240,7 +240,7 @@ multi-spec leakage starts to matter.
 
 - `packages/frontend/tests/e2e/README.md` (≤50 lines): how to run, how to
   add, how to debug. Linked from `CLAUDE.md` Commands section.
-- `__template__.spec.ts`: a minimal Arrange/Act/Assert spec stub with TODO
+- `packages/frontend/tests/e2e/__template__.spec.ts`: a minimal Arrange/Act/Assert spec stub with TODO
   markers. Copy-paste is the intended workflow.
 - `docs/design/e2e-testing.md` (this document): why the system exists, the
   conventions, the boundaries.
@@ -264,7 +264,7 @@ Updates to existing docs in the first PR:
 | jsdom-compatible unit / component | `tests/*.test.ts(x)` (vitest, existing) |
 
 Rule of thumb: if the test is not a pixel comparison, it belongs in the
-new system. Adding new scenarios to `verify-interaction-browser.mjs` is
+new system. Adding new scenarios to `packages/frontend/scripts/verify-interaction-browser.mjs` is
 disallowed after PR 1; the old verifier is read-only until it is removed.
 
 ### Migration roadmap
@@ -274,7 +274,7 @@ disallowed after PR 1; the old verifier is read-only until it is removed.
 | **PR 1** (this spec) | Infra + auth fixture + Docker/CI + POC + template + docs |
 | PR 2…N | New behavioral specs, 1–3 per PR |
 | PR M | Port the three existing interaction scenarios (cell / formula / scroll) |
-| PR M+1 | Delete `scripts/verify-interaction-browser.mjs`; remove the interaction step from `verify:browser:docker` |
+| PR M+1 | Delete `packages/frontend/scripts/verify-interaction-browser.mjs`; remove the interaction step from `verify:browser:docker` |
 | (Deferred) | Visual regression migration to `toHaveScreenshot()` — see Non-Goals |
 
 ### Risks and Mitigation
@@ -306,7 +306,7 @@ verifier) and is acceptable to keep if the cost of migration outweighs
 the benefit; the decision is revisited, not forgotten.
 
 **Auth fixture stuck on first failure.** A bad cookie cached in
-`playwright/.auth/worker-N.json` would poison every subsequent run.
+`playwright/.auth/worker-<N>.json` would poison every subsequent run.
 Mitigated by deleting the auth cache on Playwright `globalSetup` (fresh
 storage state each run, then reused within the run).
 

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -181,6 +181,7 @@ Hook scripts live in `scripts/hooks/`.
 | `pnpm verify:frontend:visual` | Playwright screenshot baseline (desktop+mobile) |
 | `pnpm verify:frontend:interaction` | Browser interaction regression (cell input, formula, scroll) |
 | `pnpm verify:browser:docker` | Browser visual+interaction via Docker (CI-consistent) |
+| `pnpm verify:e2e`            | Behavioral end-to-end (real backend + frontend, Playwright Test) |
 | `pnpm verify:entropy` | Dead-code (knip) + doc-staleness entropy gate |
 | `pnpm verify:self` | Runner: `verify:fast` + builds + chunk budgets + entropy; generates `.harness-reports/` JSON |
 

--- a/docs/tasks/active/20260601-e2e-playwright-test-lessons.md
+++ b/docs/tasks/active/20260601-e2e-playwright-test-lessons.md
@@ -1,0 +1,117 @@
+# Lessons — E2E Testing with @playwright/test
+
+Paired with [20260601-e2e-playwright-test-todo.md](20260601-e2e-playwright-test-todo.md)
+and design [docs/design/e2e-testing.md](../../design/e2e-testing.md).
+
+## What surprised us
+
+### 1. The plan's POC selectors were guesses; reality diverged on three axes
+
+The plan referenced "New Slides", `/document/:id`, and a "My Documents"
+heading. The actual dashboard:
+
+- Uses `<DropdownMenu>` (Radix) with a "New" trigger button — items
+  `New Sheet` / `New Document` / `New Presentation`. No "New Slides".
+- Routes presentations to `/p/:id`, not `/document/:id`.
+- Has no `<h1>` heading; the visible-marker for "documents page ready"
+  is the `Filter by title…` input.
+
+The POC spec, the `data-testid` placements, and the URL regex all had
+to be adjusted in Task 4. **Takeaway:** before writing an e2e spec,
+spend five minutes confirming the actual route + selector shape rather
+than trusting plan text. The plan author worked from memory of "how a
+dashboard probably works" and was wrong on every detail.
+
+### 2. NestJS module-gating defeats `jest.isolateModulesAsync`
+
+Task 2's plan called for two e2e cases in one file — one with the env
+unset (404), one with the env set (200 + cookies) — using
+`jest.isolateModulesAsync` to re-import `AppModule` with a fresh
+module cache between them.
+
+In practice, `@nestjs/core` re-loaded inside `isolateModulesAsync`
+becomes a separate module instance. The `ThrottlerGuard` injects
+`Reflector`, but Nest's `TestingInjector` does class-identity checks
+against the original `Reflector` import — they no longer match, and
+DI fails.
+
+The first attempt worked around this by patching the cached
+`AuthModule`'s `controllers` metadata via `Reflect.defineMetadata`.
+This was worse than no test: it mutated module metadata for the
+remainder of the Jest process AND it stopped exercising the actual
+env-driven path (it tested the patch instead).
+
+**Final shape:** keep only the 404 case in
+`test-auth.e2e-spec.ts` (which IS the security-critical direction —
+"production deploys cannot serve this route"). The 200-direction is
+covered naturally by the Playwright auth fixture: every e2e spec
+POSTs `/test/auth/login` on first use, so a regression breaks the
+whole Playwright lane. Documented in the file's header comment so
+future readers don't add it back.
+
+### 3. Code review caught two production-relevant nits
+
+The original `TestAuthController`:
+
+- `throw new Error(...)` → became 500 + raw stack instead of clean JSON.
+  Fixed to `InternalServerErrorException`.
+- `secure: false` hardcoded on the cookie. Production `AuthController`
+  derives it from `NODE_ENV`. Closing the gap defends-in-depth against
+  the route ever mounting in a production-like env (which would still
+  require the gate failing first).
+
+Both were one-line fixes that mattered in principle even though the
+env gate makes them unreachable in practice. **Takeaway:** even on
+test-only code, mirror production patterns so the codebase stays
+self-consistent and so a future env-gate slip doesn't expose a worse
+shape than the rest of the code.
+
+### 4. `harness.config.json` doesn't carry a lane schema
+
+The first draft of the design doc said the new lane would add a
+`lanes:` entry with `requires:` hints to `harness.config.json`. Reading
+the actual file showed it only contains `frontend.chunkBudgets` and
+`entropy` settings — there's no `lanes:` schema yet. Rather than
+invent one for a single use case, the design doc was amended to defer
+that schema and the standalone orchestrator
+(`scripts/run-e2e-standalone.mjs`) emits actionable preflight hints
+itself ("DATABASE_URL is unset", "docker compose up -d", etc.).
+
+### 5. POC chose chromium-desktop only; mobile branch deliberately untagged
+
+`slides-detail.tsx` has separate `DesktopSlidesLayout` and
+`MobileSlidesLayout` branches. The `data-testid="slides-editor"` went
+only on the desktop branch because the Playwright config has only the
+`chromium-desktop` project. Adding a `chromium-mobile` project (and
+its testid) is straightforward when a mobile-specific spec lands —
+not before.
+
+## What worked well
+
+- **Tight subagent dispatches with full task text + scene-setting
+  context** kept implementers focused. Each one read at most 2–3
+  source files of its own; the controller didn't bleed the whole
+  conversation into them.
+- **Two-stage review (spec → code quality)** caught both
+  spec-divergences (the `Reflect.defineMetadata` workaround) and
+  code-quality nits (exception type, cookie secure flag) in
+  separate, easy-to-action passes.
+- **Plan↔reality divergences were documented in commit messages**
+  (Task 4's commit explicitly names "the plan referenced 'New Slides'
+  and '/document/:id'; actual labels are 'New Presentation' and
+  '/p/:id'"). Future archaeologists won't have to git-blame to
+  understand why the file diverges from the plan.
+
+## What to remember next time
+
+- **First five minutes of any e2e task: open the actual route in a
+  browser and inspect the DOM**, before writing or even refining the
+  spec. Save five iterations downstream.
+- **NestJS module re-import isolation in Jest is unsolved in the
+  general case.** If a test needs to re-construct a module under
+  different env, the answer is usually a separate child process, not
+  `jest.isolateModulesAsync`.
+- **For tests of security gates, prefer the negative direction.** The
+  "absence" assertion (404 when env unset) is what locks production
+  safety; the positive direction is often naturally covered by
+  downstream tests that depend on it.

--- a/docs/tasks/active/20260601-e2e-playwright-test-plan.md
+++ b/docs/tasks/active/20260601-e2e-playwright-test-plan.md
@@ -1,0 +1,1164 @@
+# E2E Testing with @playwright/test — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up `@playwright/test` as the home for new behavioral e2e tests, with a test-only auth bypass on the backend, fixtures + template + docs on the frontend, lane + CI integration, and one proof-of-concept spec.
+
+**Architecture:** A new env-gated `TestAuthController` issues real JWT cookies via the existing `AuthService.createTokens()` path. Playwright specs live under `packages/frontend/tests/e2e/`, import a shared `test`/`expect` from `tests/e2e/fixtures/index.ts`, and authenticate per-worker by hitting `/test/auth/login` once and caching `storageState`. Lane orchestrator `scripts/run-e2e-standalone.mjs` boots backend + frontend preview, waits on ports, runs the lane, and tears down. CI runs the lane in a `verify-e2e` job with Postgres + Yorkie services.
+
+**Tech Stack:** `@playwright/test` 1.58.2 (pin to existing Playwright version), NestJS 11 (backend), Vite 5 (frontend dev/preview), GitHub Actions.
+
+**Design doc:** [docs/design/e2e-testing.md](../../design/e2e-testing.md)
+
+---
+
+## File Structure
+
+**Create:**
+- `packages/backend/src/auth/test-auth.controller.ts` — env-gated controller
+- `packages/backend/src/auth/test-auth.controller.spec.ts` — unit test (env gating, payload shape)
+- `packages/backend/test/test-auth.e2e-spec.ts` — http-level e2e test (404 when unset, 200 + cookies when set)
+- `packages/frontend/playwright.config.ts`
+- `packages/frontend/tests/e2e/fixtures/auth.ts`
+- `packages/frontend/tests/e2e/fixtures/index.ts`
+- `packages/frontend/tests/e2e/specs/dashboard/create-slides-doc.spec.ts`
+- `packages/frontend/tests/e2e/__template__.spec.ts`
+- `packages/frontend/tests/e2e/README.md`
+- `scripts/run-e2e-standalone.mjs`
+
+**Modify:**
+- `packages/backend/src/auth/auth.module.ts` — conditionally register `TestAuthController`
+- `packages/backend/.eslintrc` / project test config — include the new `*.spec.ts`/`*.e2e-spec.ts`
+- `packages/frontend/package.json` — add `@playwright/test` devDep + scripts
+- `package.json` (root) — add `verify:e2e`, `verify:e2e:standalone`
+- `.github/workflows/ci.yml` — add `verify-e2e` job
+- `CLAUDE.md` — add `pnpm verify:e2e` to Commands
+- `docs/design/README.md` — link `e2e-testing.md` in Common table
+- `docs/design/harness-engineering.md` — list `verify:e2e` in lane table
+- `packages/frontend/scripts/verify-interaction-browser.mjs` — add "do not add new scenarios" header
+- `packages/frontend/scripts/verify-visual-browser.mjs` — add "do not add new scenarios" header
+- `packages/frontend/.gitignore` — ignore `playwright/.auth/`, `playwright-report/`, `test-results/`
+
+---
+
+## Task 1: Backend — `TestAuthController` (env-gated)
+
+**Files:**
+- Create: `packages/backend/src/auth/test-auth.controller.ts`
+- Create: `packages/backend/src/auth/test-auth.controller.spec.ts`
+- Modify: `packages/backend/src/auth/auth.module.ts`
+
+- [ ] **Step 1.1: Write the failing unit test**
+
+Create `packages/backend/src/auth/test-auth.controller.spec.ts`:
+
+```ts
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Response } from 'express';
+import { AuthService } from './auth.service';
+import { UserService } from '../user/user.service';
+import { TestAuthController } from './test-auth.controller';
+
+describe('TestAuthController', () => {
+  let controller: TestAuthController;
+  let userService: { findOrCreateUser: jest.Mock };
+  let authService: AuthService;
+  let res: Pick<Response, 'cookie' | 'json' | 'status'> & { cookie: jest.Mock; json: jest.Mock };
+
+  beforeEach(async () => {
+    userService = { findOrCreateUser: jest.fn() };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [TestAuthController],
+      providers: [
+        AuthService,
+        JwtService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) =>
+              ({
+                JWT_SECRET: 'test-secret',
+                JWT_ACCESS_EXPIRES_IN: '1h',
+                JWT_REFRESH_EXPIRES_IN: '7d',
+                NODE_ENV: 'test',
+              })[key],
+          },
+        },
+        { provide: UserService, useValue: userService },
+      ],
+    }).compile();
+
+    controller = moduleRef.get(TestAuthController);
+    authService = moduleRef.get(AuthService);
+    res = {
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis() as never,
+    };
+  });
+
+  it('creates or fetches the test user and sets both auth cookies', async () => {
+    userService.findOrCreateUser.mockResolvedValue({
+      id: 42,
+      username: 'e2e-0',
+      email: 'e2e-0@test.local',
+      photo: null,
+      authProvider: 'test',
+    });
+
+    await controller.login(
+      { username: 'e2e-0', email: 'e2e-0@test.local' },
+      res as unknown as Response,
+    );
+
+    expect(userService.findOrCreateUser).toHaveBeenCalledWith({
+      authProvider: 'test',
+      username: 'e2e-0',
+      email: 'e2e-0@test.local',
+      photo: null,
+    });
+    expect(res.cookie).toHaveBeenCalledWith(
+      'wafflebase_session',
+      expect.any(String),
+      expect.objectContaining({ httpOnly: true, sameSite: 'lax' }),
+    );
+    expect(res.cookie).toHaveBeenCalledWith(
+      'wafflebase_refresh',
+      expect.any(String),
+      expect.objectContaining({ httpOnly: true, sameSite: 'lax' }),
+    );
+    expect(res.json).toHaveBeenCalledWith({ ok: true, userId: 42 });
+  });
+});
+```
+
+- [ ] **Step 1.2: Run the test and confirm it fails (controller missing)**
+
+Run: `pnpm --filter @wafflebase/backend test test-auth.controller`
+Expected: FAIL — `Cannot find module './test-auth.controller'`.
+
+- [ ] **Step 1.3: Implement `TestAuthController`**
+
+Create `packages/backend/src/auth/test-auth.controller.ts`:
+
+```ts
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Post,
+  Res,
+} from '@nestjs/common';
+import { Response, CookieOptions } from 'express';
+import { AuthService } from './auth.service';
+import { UserService } from '../user/user.service';
+
+const ACCESS_COOKIE_NAME = 'wafflebase_session';
+const REFRESH_COOKIE_NAME = 'wafflebase_refresh';
+
+type LoginBody = { username: string; email: string };
+
+@Controller('test/auth')
+export class TestAuthController {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly userService: UserService,
+  ) {}
+
+  @Post('login')
+  @HttpCode(200)
+  async login(@Body() body: LoginBody, @Res() res: Response) {
+    const user = await this.userService.findOrCreateUser({
+      authProvider: 'test',
+      username: body.username,
+      email: body.email,
+      photo: null,
+    });
+
+    if (!user) {
+      throw new Error('Failed to create test user');
+    }
+
+    const tokens = this.authService.createTokens(user);
+    const baseCookieOptions: CookieOptions = {
+      httpOnly: true,
+      secure: false,
+      sameSite: 'lax',
+    };
+
+    res.cookie(ACCESS_COOKIE_NAME, tokens.accessToken, baseCookieOptions);
+    res.cookie(REFRESH_COOKIE_NAME, tokens.refreshToken, baseCookieOptions);
+    res.json({ ok: true, userId: user.id });
+  }
+}
+```
+
+- [ ] **Step 1.4: Run the test and confirm it passes**
+
+Run: `pnpm --filter @wafflebase/backend test test-auth.controller`
+Expected: PASS (1 spec).
+
+- [ ] **Step 1.5: Gate registration in `AuthModule`**
+
+Modify `packages/backend/src/auth/auth.module.ts` — replace the `controllers:` and `providers:` lines:
+
+```ts
+import { TestAuthController } from './test-auth.controller';
+
+const TEST_AUTH_ENABLED = process.env.WAFFLEBASE_E2E_AUTH === '1';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot(),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn:
+            (configService.get<string>('JWT_ACCESS_EXPIRES_IN') ?? '1h') as ms.StringValue,
+        },
+      }),
+      inject: [ConfigService],
+    }),
+    UserModule,
+  ],
+  controllers: [
+    AuthController,
+    ...(TEST_AUTH_ENABLED ? [TestAuthController] : []),
+  ],
+  providers: [AuthService, CliAuthStore, GitHubAuthGuard, JwtStrategy, GitHubStrategy],
+})
+export class AuthModule {
+  constructor() {
+    if (TEST_AUTH_ENABLED) {
+      console.warn('[test-auth] DEV-ONLY ROUTES ENABLED (WAFFLEBASE_E2E_AUTH=1)');
+    }
+  }
+}
+```
+
+- [ ] **Step 1.6: Run backend test suite to confirm nothing else broke**
+
+Run: `pnpm --filter @wafflebase/backend test`
+Expected: All existing specs PASS plus the new one.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add packages/backend/src/auth/test-auth.controller.ts \
+        packages/backend/src/auth/test-auth.controller.spec.ts \
+        packages/backend/src/auth/auth.module.ts
+git commit -m "feat(backend): env-gated POST /test/auth/login for e2e
+
+Adds TestAuthController, registered only when WAFFLEBASE_E2E_AUTH=1.
+Issues real JWT cookies via the existing AuthService.createTokens()
+path so the test session is indistinguishable from a GitHub OAuth one.
+Production deploys never set the env, so the route is not mounted."
+```
+
+---
+
+## Task 2: Backend — HTTP-level e2e for the env gate
+
+**Files:**
+- Create: `packages/backend/test/test-auth.e2e-spec.ts`
+
+- [ ] **Step 2.1: Write the failing http e2e test**
+
+Create `packages/backend/test/test-auth.e2e-spec.ts`:
+
+```ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from 'src/app.module';
+
+describe('Test auth route (e2e)', () => {
+  let app: INestApplication;
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('returns 404 when WAFFLEBASE_E2E_AUTH is unset', async () => {
+    delete process.env.WAFFLEBASE_E2E_AUTH;
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    await request(app.getHttpServer())
+      .post('/test/auth/login')
+      .send({ username: 'e2e-0', email: 'e2e-0@test.local' })
+      .expect(404);
+  });
+
+  it('returns 200 + auth cookies when WAFFLEBASE_E2E_AUTH=1', async () => {
+    process.env.WAFFLEBASE_E2E_AUTH = '1';
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    const res = await request(app.getHttpServer())
+      .post('/test/auth/login')
+      .send({ username: 'e2e-0', email: 'e2e-0@test.local' })
+      .expect(200);
+
+    expect(res.body).toEqual({ ok: true, userId: expect.any(Number) });
+    const cookies = (res.headers['set-cookie'] as unknown as string[]).join(';');
+    expect(cookies).toContain('wafflebase_session=');
+    expect(cookies).toContain('wafflebase_refresh=');
+
+    delete process.env.WAFFLEBASE_E2E_AUTH;
+  });
+});
+```
+
+- [ ] **Step 2.2: Run the test and confirm it currently fails because module gating happens at construction, but the test reuses the same Node process**
+
+Run: `pnpm --filter @wafflebase/backend test:e2e test-auth.e2e-spec`
+Expected behavior: the first case must run BEFORE the second (Jest preserves declaration order within a file). If both fail with module-cache issues, switch to `jest.isolateModulesAsync` around the import of `AppModule` inside each `it()`. Adjust the test to:
+
+```ts
+it('returns 404 when WAFFLEBASE_E2E_AUTH is unset', async () => {
+  delete process.env.WAFFLEBASE_E2E_AUTH;
+  await jest.isolateModulesAsync(async () => {
+    const { AppModule } = await import('src/app.module');
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+    await request(app.getHttpServer())
+      .post('/test/auth/login')
+      .send({ username: 'e2e-0', email: 'e2e-0@test.local' })
+      .expect(404);
+  });
+});
+```
+
+Apply the same `isolateModulesAsync` wrapper to the second case. Re-run.
+
+- [ ] **Step 2.3: Confirm both cases pass**
+
+Run: `pnpm --filter @wafflebase/backend test:e2e test-auth.e2e-spec`
+Expected: PASS (2 specs).
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add packages/backend/test/test-auth.e2e-spec.ts
+git commit -m "test(backend): http-level gate test for /test/auth/login
+
+Confirms the route is 404 without WAFFLEBASE_E2E_AUTH=1 and 200 with
+real session/refresh cookies when the env is set. Locks the security
+contract in CI."
+```
+
+---
+
+## Task 3: Frontend — Playwright deps, config, fixtures, template, README
+
+**Files:**
+- Modify: `packages/frontend/package.json`
+- Create: `packages/frontend/playwright.config.ts`
+- Create: `packages/frontend/tests/e2e/fixtures/auth.ts`
+- Create: `packages/frontend/tests/e2e/fixtures/index.ts`
+- Create: `packages/frontend/tests/e2e/__template__.spec.ts`
+- Create: `packages/frontend/tests/e2e/README.md`
+- Modify: `packages/frontend/.gitignore`
+
+- [ ] **Step 3.1: Add `@playwright/test` devDep**
+
+```bash
+pnpm --filter @wafflebase/frontend add -D @playwright/test@1.58.2
+```
+
+Confirm `packages/frontend/package.json` `devDependencies` now lists `"@playwright/test": "1.58.2"`. The existing `playwright` entry at the same version stays — both packages share the same chromium download.
+
+- [ ] **Step 3.2: Add frontend scripts**
+
+Append to `packages/frontend/package.json` `"scripts"`:
+
+```json
+"e2e": "playwright test",
+"e2e:ui": "playwright test --ui",
+"e2e:debug": "playwright test --debug"
+```
+
+- [ ] **Step 3.3: Write `playwright.config.ts`**
+
+Create `packages/frontend/playwright.config.ts`:
+
+```ts
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.WAFFLEBASE_E2E_BASE_URL ?? 'http://localhost:5173';
+
+export default defineConfig({
+  testDir: 'tests/e2e/specs',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['html'], ['github']] : 'list',
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium-desktop', use: { ...devices['Desktop Chrome'] } },
+  ],
+  outputDir: 'test-results',
+});
+```
+
+- [ ] **Step 3.4: Write `fixtures/auth.ts`**
+
+Create `packages/frontend/tests/e2e/fixtures/auth.ts`:
+
+```ts
+import { test as base, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const AUTH_DIR = path.join(process.cwd(), 'playwright', '.auth');
+const BACKEND_URL = process.env.WAFFLEBASE_E2E_BACKEND_URL ?? 'http://localhost:3000';
+
+type Fixtures = Record<string, never>;
+type WorkerFixtures = { workerStorageState: string };
+
+export const test = base.extend<Fixtures, WorkerFixtures>({
+  workerStorageState: [
+    async ({ browser }, use, workerInfo) => {
+      fs.mkdirSync(AUTH_DIR, { recursive: true });
+      const file = path.join(AUTH_DIR, `worker-${workerInfo.workerIndex}.json`);
+
+      if (!fs.existsSync(file)) {
+        const ctx = await browser.newContext();
+        const res = await ctx.request.post(`${BACKEND_URL}/test/auth/login`, {
+          data: {
+            username: `e2e-${workerInfo.workerIndex}`,
+            email: `e2e-${workerInfo.workerIndex}@test.local`,
+          },
+        });
+        if (!res.ok()) {
+          throw new Error(
+            `Test auth login failed (${res.status()}). ` +
+              `Is the backend running with WAFFLEBASE_E2E_AUTH=1?`,
+          );
+        }
+        await ctx.storageState({ path: file });
+        await ctx.close();
+      }
+
+      await use(file);
+    },
+    { scope: 'worker' },
+  ],
+
+  storageState: ({ workerStorageState }, use) => use(workerStorageState),
+});
+
+export { expect };
+```
+
+- [ ] **Step 3.5: Write `fixtures/index.ts`**
+
+Create `packages/frontend/tests/e2e/fixtures/index.ts`:
+
+```ts
+export { test, expect } from './auth';
+```
+
+- [ ] **Step 3.6: Write `__template__.spec.ts`**
+
+Create `packages/frontend/tests/e2e/__template__.spec.ts`:
+
+```ts
+// COPY THIS FILE. Replace the TODOs. Delete this header comment.
+// Quick guide: ./README.md
+//
+// Pattern: Arrange / Act / Assert
+//   Arrange — navigate and assert preconditions
+//   Act     — perform the user-visible actions (click / fill / keyboard)
+//   Assert  — check user-observable outcomes (URL, role, text, count)
+//
+// Selector priority:
+//   1. getByRole(name)
+//   2. getByText / getByLabel
+//   3. data-testid (add to the component in the same PR if missing)
+//   Avoid CSS class or structural selectors; they break on refactor.
+
+import { test, expect } from '../fixtures';
+
+test.describe('TODO: feature name', () => {
+  test('TODO: behavior described in one sentence', async ({ page }) => {
+    // Arrange
+    await page.goto('/');
+
+    // Act
+    // TODO: user actions
+
+    // Assert
+    // TODO: user-observable outcomes
+  });
+});
+```
+
+- [ ] **Step 3.7: Write `tests/e2e/README.md`**
+
+Create `packages/frontend/tests/e2e/README.md`:
+
+````markdown
+# E2E Tests (Playwright Test)
+
+Behavioral end-to-end tests that drive the real app. For visual /
+pixel-diff regression see `packages/frontend/scripts/verify-visual-browser.mjs`;
+for jsdom unit tests see `packages/frontend/tests/`.
+
+## Run
+
+```bash
+# One-shot (recommended): builds + boots backend + frontend, runs e2e, tears down.
+docker compose up -d                    # postgres + yorkie (once per machine)
+pnpm verify:e2e:standalone
+
+# Or, against a running dev stack:
+docker compose up -d
+WAFFLEBASE_E2E_AUTH=1 pnpm dev          # in one terminal
+pnpm verify:e2e                         # in another
+```
+
+## Debug
+
+```bash
+pnpm frontend e2e:ui                    # Playwright UI mode
+pnpm frontend e2e:debug                 # Inspector
+npx playwright show-trace test-results/<test>/trace.zip
+```
+
+## Add a test
+
+```bash
+cp packages/frontend/tests/e2e/__template__.spec.ts \
+   packages/frontend/tests/e2e/specs/<area>/<name>.spec.ts
+```
+
+Then fill in the TODOs. Imports: `import { test, expect } from '../fixtures'`.
+
+## Add a fixture
+
+Drop a new file in `fixtures/`, then re-export `test` from
+`fixtures/index.ts` extending the existing chain. Every spec imports from
+`../fixtures` only — never from `@playwright/test` directly.
+
+## Selectors
+
+Prefer `getByRole` / `getByText` / `getByLabel`. Fall back to
+`data-testid` only if no semantic selector works; add the `data-testid`
+to the component in the same PR.
+````
+
+- [ ] **Step 3.8: Update frontend `.gitignore`**
+
+Append to `packages/frontend/.gitignore`:
+
+```
+playwright/.auth/
+playwright-report/
+test-results/
+```
+
+- [ ] **Step 3.9: Verify Playwright config loads**
+
+Run: `pnpm --filter @wafflebase/frontend exec playwright test --list`
+Expected: lists 0 tests (no specs yet), no config errors.
+
+- [ ] **Step 3.10: Commit**
+
+```bash
+git add packages/frontend/package.json packages/frontend/playwright.config.ts \
+        packages/frontend/tests/e2e/ packages/frontend/.gitignore \
+        pnpm-lock.yaml
+git commit -m "chore(frontend): @playwright/test config, fixtures, template
+
+Auth fixture POSTs /test/auth/login once per worker and caches
+storageState. Template + README give a copy-paste path for new specs.
+No spec files yet — the POC lands in the next commit."
+```
+
+---
+
+## Task 4: Frontend — POC spec + missing `data-testid`s
+
+**Files:**
+- Create: `packages/frontend/tests/e2e/specs/dashboard/create-slides-doc.spec.ts`
+- Modify: dashboard list component (add `data-testid="document-row"` to each row)
+- Modify: slides editor root component (add `data-testid="slides-editor"`)
+
+- [ ] **Step 4.1: Locate the dashboard list and slides editor root**
+
+Run: `grep -rn "My Documents\|document-list\|DocumentList" packages/frontend/src/ | head`
+Run: `grep -rn "SlidesEditor\|slides-editor\|presentation-route" packages/frontend/src/ | head`
+
+Identify the React file rendering each document row in the dashboard and the file rendering the slides editor when navigating to `/document/:id` (or whichever route serves a slides doc — check `App.tsx` / router).
+
+- [ ] **Step 4.2: Write the failing spec**
+
+Create `packages/frontend/tests/e2e/specs/dashboard/create-slides-doc.spec.ts`:
+
+```ts
+import { test, expect } from '../../fixtures';
+
+test.describe('Dashboard: create slides document', () => {
+  test('creates a new slides document and lists it', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(
+      page.getByRole('heading', { name: /my documents/i }),
+    ).toBeVisible();
+
+    const docsBefore = await page.getByTestId('document-row').count();
+
+    await page.getByRole('button', { name: /new slides/i }).click();
+
+    await expect(page).toHaveURL(/\/document\/[a-z0-9-]+/);
+    await expect(page.getByTestId('slides-editor')).toBeVisible();
+
+    await page.goto('/');
+    const docsAfter = await page.getByTestId('document-row').count();
+    expect(docsAfter).toBe(docsBefore + 1);
+  });
+});
+```
+
+- [ ] **Step 4.3: Run the spec — it will fail until selectors exist**
+
+```bash
+docker compose up -d
+WAFFLEBASE_E2E_AUTH=1 pnpm dev            # in one terminal
+pnpm --filter @wafflebase/frontend e2e specs/dashboard/create-slides-doc.spec.ts
+```
+
+Expected: FAIL, almost certainly on `getByTestId('document-row')` or `getByRole('button', { name: /new slides/i })`. Inspect the trace (`test-results/.../trace.zip`) to see where.
+
+- [ ] **Step 4.4: Add `data-testid="document-row"` to the dashboard row component**
+
+In the dashboard file located in Step 4.1, find the JSX element representing one document row (the `<li>` / `<Link>` / `<tr>` wrapper) and add `data-testid="document-row"` to it.
+
+- [ ] **Step 4.5: Add `data-testid="slides-editor"` to the slides editor root**
+
+Find the top-level element of the slides editor component (the wrapper around the canvas + toolbar) and add `data-testid="slides-editor"`.
+
+- [ ] **Step 4.6: Confirm the "New Slides" button has an accessible name**
+
+Find the New Slides creation button on the dashboard. If it uses an icon only, add `aria-label="New slides"`. If it already has visible text "New slides" or "New Presentation", update the spec's name regex (`/new slides/i`) to match. Prefer the accessible-name path.
+
+- [ ] **Step 4.7: Re-run the spec**
+
+```bash
+pnpm --filter @wafflebase/frontend e2e specs/dashboard/create-slides-doc.spec.ts
+```
+
+Expected: PASS (1 spec).
+
+- [ ] **Step 4.8: Force a failure to validate trace output**
+
+Temporarily change the assertion to `expect(docsAfter).toBe(docsBefore + 99)`. Re-run. Confirm `test-results/<test>/trace.zip` is produced and `npx playwright show-trace test-results/<test>/trace.zip` opens. Revert the assertion.
+
+- [ ] **Step 4.9: Commit**
+
+```bash
+git add packages/frontend/tests/e2e/specs packages/frontend/src
+git commit -m "feat(frontend): e2e POC — create slides document from dashboard
+
+First Playwright Test spec exercises the real /dashboard → click 'New
+Slides' → /document/:id flow against a live backend. Adds the minimum
+data-testid hooks needed for stable selection."
+```
+
+---
+
+## Task 5: Lane scripts — `verify:e2e` + `verify:e2e:standalone`
+
+**Files:**
+- Modify: `package.json` (root)
+- Create: `scripts/run-e2e-standalone.mjs`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 5.1: Add the root scripts**
+
+Edit root `package.json` `"scripts"`:
+
+```json
+"verify:e2e": "pnpm --filter @wafflebase/frontend e2e",
+"verify:e2e:standalone": "node ./scripts/run-e2e-standalone.mjs"
+```
+
+Place them adjacent to `verify:integration` and `verify:browser:docker`.
+
+- [ ] **Step 5.2: Write the standalone orchestrator**
+
+Create `scripts/run-e2e-standalone.mjs`:
+
+```js
+#!/usr/bin/env node
+// One-shot e2e runner: boots backend + frontend preview, waits on ports,
+// runs `pnpm verify:e2e`, tears down. Designed for CI and clean local runs.
+
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import process from 'node:process';
+
+const BACKEND_PORT = Number(process.env.PORT ?? 3000);
+const FRONTEND_PORT = 5173;
+const WAIT_TIMEOUT_MS = 60_000;
+const WAIT_INTERVAL_MS = 500;
+
+const children = [];
+
+function startChild(cmd, args, env = {}) {
+  const child = spawn(cmd, args, {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    env: { ...process.env, ...env },
+    shell: false,
+  });
+  children.push(child);
+  return child;
+}
+
+function waitForPort(port) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + WAIT_TIMEOUT_MS;
+    const tick = () => {
+      const socket = net.connect(port, '127.0.0.1');
+      socket.once('connect', () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.once('error', () => {
+        socket.destroy();
+        if (Date.now() > deadline) {
+          reject(new Error(`Timed out waiting for :${port}`));
+        } else {
+          setTimeout(tick, WAIT_INTERVAL_MS);
+        }
+      });
+    };
+    tick();
+  });
+}
+
+function preflightHints() {
+  const hints = [];
+  if (!process.env.DATABASE_URL && !process.env.SKIP_E2E_PREFLIGHT) {
+    hints.push(
+      "  • DATABASE_URL is unset — did you run `docker compose up -d` and source the backend .env?",
+    );
+  }
+  if (hints.length > 0) {
+    console.warn('[verify:e2e:standalone] preflight hints:');
+    for (const h of hints) console.warn(h);
+  }
+}
+
+function cleanup() {
+  for (const c of children) {
+    if (!c.killed) c.kill('SIGTERM');
+  }
+}
+
+process.on('exit', cleanup);
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(130);
+});
+process.on('SIGTERM', () => {
+  cleanup();
+  process.exit(143);
+});
+
+(async () => {
+  preflightHints();
+
+  console.log('[verify:e2e:standalone] starting backend (WAFFLEBASE_E2E_AUTH=1)');
+  startChild('pnpm', ['--filter', '@wafflebase/backend', 'start:dev'], {
+    WAFFLEBASE_E2E_AUTH: '1',
+  });
+
+  console.log('[verify:e2e:standalone] starting frontend dev server');
+  startChild('pnpm', ['--filter', '@wafflebase/frontend', 'dev']);
+
+  try {
+    await Promise.all([waitForPort(BACKEND_PORT), waitForPort(FRONTEND_PORT)]);
+  } catch (err) {
+    console.error(`[verify:e2e:standalone] ${err.message}`);
+    console.error(
+      'Hints: `docker compose up -d` for Postgres + Yorkie; check backend logs for missing env.',
+    );
+    cleanup();
+    process.exit(1);
+  }
+
+  console.log('[verify:e2e:standalone] running playwright');
+  const playwright = startChild('pnpm', ['verify:e2e']);
+  playwright.on('exit', (code) => {
+    cleanup();
+    process.exit(code ?? 1);
+  });
+})();
+```
+
+Make it executable:
+
+```bash
+chmod +x scripts/run-e2e-standalone.mjs
+```
+
+- [ ] **Step 5.3: Add `pnpm verify:e2e` to `CLAUDE.md` Commands table**
+
+In `CLAUDE.md`, under the `## Commands` block, add a row after `pnpm verify:integration`:
+
+```text
+pnpm verify:e2e                     # Playwright behavioral e2e (needs backend with WAFFLEBASE_E2E_AUTH=1)
+pnpm verify:e2e:standalone          # One-shot: boots backend + frontend + runs e2e
+```
+
+- [ ] **Step 5.4: Smoke-test the lane locally**
+
+```bash
+docker compose up -d
+WAFFLEBASE_E2E_AUTH=1 pnpm dev      # in one terminal
+pnpm verify:e2e                     # in another
+```
+
+Expected: POC spec passes.
+
+Then test the standalone variant from a clean state (kill `pnpm dev` first):
+
+```bash
+pnpm verify:e2e:standalone
+```
+
+Expected: backend + frontend boot, spec passes, processes terminate cleanly.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add package.json scripts/run-e2e-standalone.mjs CLAUDE.md
+git commit -m "feat(harness): verify:e2e + verify:e2e:standalone lanes
+
+verify:e2e runs Playwright against an already-running stack.
+verify:e2e:standalone boots backend (WAFFLEBASE_E2E_AUTH=1) and
+frontend, waits on ports, runs the lane, tears down."
+```
+
+---
+
+## Task 6: CI — `verify-e2e` job
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 6.1: Add the `verify-e2e` job alongside `verify-integration`**
+
+Append a new job after `verify-integration` in `.github/workflows/ci.yml`. Mirror its Postgres + Yorkie setup; add a Playwright browser install and run the lane via the standalone script.
+
+```yaml
+  verify-e2e:
+    runs-on: ubuntu-latest
+    needs: verify-self
+    env:
+      DATABASE_URL: postgresql://wafflebase:wafflebase@localhost:5432/wafflebase
+      DATASOURCE_ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      RUN_DB_INTEGRATION_TESTS: "true"
+      RUN_YORKIE_INTEGRATION_TESTS: "true"
+      YORKIE_RPC_ADDR: http://localhost:8080
+      WAFFLEBASE_E2E_AUTH: "1"
+      JWT_SECRET: ci-e2e-jwt-secret
+      FRONTEND_URL: http://localhost:5173
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: wafflebase
+          POSTGRES_PASSWORD: wafflebase
+          POSTGRES_DB: wafflebase
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U wafflebase -d wafflebase"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      matrix:
+        node-version: [22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace packages
+        run: |
+          pnpm tokens build
+          pnpm --filter @wafflebase/docs build
+          pnpm slides build
+          pnpm sheets build
+
+      - name: Install Playwright browser (chromium only)
+        run: pnpm --filter @wafflebase/frontend exec playwright install chromium --with-deps
+
+      - name: Start Yorkie server
+        run: |
+          docker run -d --name yorkie \
+            -p 8080:8080 -p 8081:8081 \
+            yorkieteam/yorkie:latest server --pprof-enabled
+
+      - name: Wait for Yorkie
+        run: |
+          for i in $(seq 1 30); do
+            if nc -z localhost 8080; then exit 0; fi
+            sleep 1
+          done
+          docker logs yorkie || true
+          exit 1
+
+      - name: Apply database migrations
+        run: pnpm --filter @wafflebase/backend exec prisma migrate deploy
+
+      - name: Run e2e lane (standalone)
+        id: e2e
+        run: pnpm verify:e2e:standalone
+
+      - name: Upload Playwright report
+        if: failure() && steps.e2e.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: packages/frontend/playwright-report
+          retention-days: 14
+
+      - name: Upload Playwright traces
+        if: failure() && steps.e2e.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: packages/frontend/test-results
+          retention-days: 14
+
+      - name: Yorkie logs on failure
+        if: failure()
+        run: docker logs yorkie
+```
+
+- [ ] **Step 6.2: Validate workflow syntax locally**
+
+Run: `act -W .github/workflows/ci.yml --list 2>/dev/null || yamllint .github/workflows/ci.yml`
+(If neither tool is installed, skip — the next push will surface any YAML error.)
+
+- [ ] **Step 6.3: Commit and push to a feature branch**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: verify-e2e job with Postgres + Yorkie + Playwright
+
+Mirrors verify-integration's service setup, installs chromium with
+deps, runs verify:e2e:standalone, and uploads playwright-report and
+test-results on failure (14-day retention)."
+git push -u origin <feature-branch>
+```
+
+- [ ] **Step 6.4: Observe the run on GitHub**
+
+Expected: `verify-e2e` job goes green. If red, download the artifacts and run `npx playwright show-trace <trace.zip>` locally to diagnose. Iterate until green.
+
+---
+
+## Task 7: Docs — design cross-links + legacy headers
+
+**Files:**
+- Modify: `docs/design/README.md`
+- Modify: `docs/design/harness-engineering.md`
+- Modify: `packages/frontend/scripts/verify-visual-browser.mjs`
+- Modify: `packages/frontend/scripts/verify-interaction-browser.mjs`
+
+- [ ] **Step 7.1: Link the new design doc from `docs/design/README.md`**
+
+In the "Common" table, insert a row between `harness-engineering.md` and `homepage.md`:
+
+```markdown
+| [e2e-testing.md](e2e-testing.md)                       | E2E behavioral testing — @playwright/test, test-auth bypass, fixtures, POC, lane + CI integration |
+```
+
+- [ ] **Step 7.2: Mention `verify:e2e` in `harness-engineering.md` lane list**
+
+Add a row under the existing lane table (search for `verify:browser:docker`):
+
+```markdown
+| `pnpm verify:e2e`            | **browser**       | Behavioral end-to-end (real backend + frontend, Playwright Test)         |
+```
+
+(Match the column count of the existing table — adjust if needed.)
+
+- [ ] **Step 7.3: Add "do not add new scenarios" headers to legacy verifiers**
+
+Prepend to `packages/frontend/scripts/verify-visual-browser.mjs`:
+
+```js
+// LEGACY VERIFIER — visual baseline only.
+// Do not add new scenarios here. New e2e tests go in
+// `packages/frontend/tests/e2e/` (Playwright Test).
+// See docs/design/e2e-testing.md.
+```
+
+Prepend the equivalent header to `verify-interaction-browser.mjs`:
+
+```js
+// LEGACY VERIFIER — interaction regression only (cell input / formula /
+// scroll). Do not add new scenarios here. New e2e tests go in
+// `packages/frontend/tests/e2e/` (Playwright Test).
+// See docs/design/e2e-testing.md.
+```
+
+(Place them after any existing shebang/use-strict lines.)
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add docs/design/README.md docs/design/harness-engineering.md \
+        packages/frontend/scripts/verify-visual-browser.mjs \
+        packages/frontend/scripts/verify-interaction-browser.mjs
+git commit -m "docs: link e2e-testing design + mark legacy verifiers
+
+Adds the new design doc to the design index, lists verify:e2e in the
+harness-engineering lane table, and marks the legacy .mjs verifiers as
+closed to new scenarios. Migration plan is in the design doc."
+```
+
+---
+
+## Task 8: Final verification + self-review + PR
+
+- [ ] **Step 8.1: Full local verification**
+
+```bash
+pnpm verify:fast                        # arch + unit tests
+pnpm verify:e2e:standalone              # new lane end-to-end
+```
+
+Both green.
+
+- [ ] **Step 8.2: Production-safety check**
+
+```bash
+WAFFLEBASE_E2E_AUTH= NODE_ENV=production pnpm --filter @wafflebase/backend build
+NODE_ENV=production pnpm --filter @wafflebase/backend start &
+BACKEND_PID=$!
+sleep 3
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://localhost:3000/test/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"username":"x","email":"x@x"}'
+kill $BACKEND_PID
+```
+
+Expected: `404`.
+
+- [ ] **Step 8.3: Rebase on `origin/main`**
+
+```bash
+git fetch && git rebase origin/main
+```
+
+Resolve any conflicts. Re-run `pnpm verify:fast`.
+
+- [ ] **Step 8.4: Self code-review**
+
+Run the `/code-review` skill (or `superpowers:requesting-code-review`) over the full branch diff. Address blocking findings, note non-blocking as known limitations on the PR body.
+
+- [ ] **Step 8.5: Capture lessons**
+
+Create `docs/tasks/active/20260601-e2e-playwright-test-lessons.md` summarizing any surprises (CI timing, fixture quirks, selector additions, env-gating gotchas) — at least one entry; if there were no surprises, write "No surprises" and one sentence on why.
+
+- [ ] **Step 8.6: Archive task pair after merge**
+
+Once the PR is merged:
+
+```bash
+pnpm tasks:archive && pnpm tasks:index
+git add docs/tasks tasks
+git commit -m "chore(tasks): archive e2e-playwright-test"
+git push
+```
+
+- [ ] **Step 8.7: Open PR**
+
+Title (≤70 chars): `feat: introduce @playwright/test for behavioral e2e`
+
+Body:
+
+```markdown
+## Summary
+- Test-only `/test/auth/login` route, env-gated on `WAFFLEBASE_E2E_AUTH=1`
+- `@playwright/test` scaffold under `packages/frontend/tests/e2e/` with
+  fixtures, template, README
+- POC spec: create a slides document from the dashboard, against a live
+  backend
+- `verify:e2e` + `verify:e2e:standalone` lanes; CI `verify-e2e` job
+- Design doc and cross-links; legacy `.mjs` verifiers marked closed
+
+## Test plan
+- [ ] `pnpm verify:fast` green
+- [ ] `pnpm verify:e2e:standalone` green from clean state
+- [ ] Backend prod build returns 404 for `/test/auth/login` with the env unset
+- [ ] CI `verify-e2e` job green
+- [ ] Induced failure produces `trace.zip` artifact
+
+Design: docs/design/e2e-testing.md
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check** — every section of the design doc maps to a task:
+
+| Spec section | Task |
+|---|---|
+| Test-only auth bypass | Task 1, 2 |
+| Architecture overview / directory layout | Task 3 (config + fixtures + template + README) |
+| Lane / CI integration | Task 5, 6 |
+| Playwright config | Task 3.3 |
+| Proof-of-concept spec | Task 4 |
+| Selector policy | Task 4.4–4.6 + README (Task 3.7) |
+| Agent-facing surface | Task 3.7 (README), Task 5.3 (CLAUDE.md), Task 7 (design index + harness doc) |
+| Coexistence rules | Task 7.3 (legacy verifier headers) |
+| Risks — production leak | Task 1.5 (gating), Task 2 (e2e gate test), Task 8.2 (prod-safety check) |
+| Risks — flaky tests | Task 3.3 (retries: 2 in CI) |
+| Risks — workflow drift | Task 7.3 (legacy headers) |
+| Non-goals (visual migration) | Documented in design doc; nothing in plan |
+
+No gaps.
+
+**Placeholder scan** — no `TBD`, `TODO`, or "handle edge cases" steps. Every code-changing step shows the code or the exact lines to add.
+
+**Type consistency check** — `AuthService.createTokens(user) => { accessToken, refreshToken }` is the API used in both Task 1.3 and the existing controller; `UserService.findOrCreateUser({ authProvider, username, email, photo })` matches the existing call site in `auth.controller.ts`. Cookie names (`wafflebase_session`, `wafflebase_refresh`) match production. Fixture's `workerStorageState` worker fixture wires into Playwright's `storageState` via `({ workerStorageState }, use) => use(workerStorageState)`, consistent end-to-end.

--- a/docs/tasks/active/20260601-e2e-playwright-test-todo.md
+++ b/docs/tasks/active/20260601-e2e-playwright-test-todo.md
@@ -1,0 +1,70 @@
+# TODO — E2E Testing with @playwright/test
+
+Design doc: [docs/design/e2e-testing.md](../../design/e2e-testing.md)
+
+One PR introducing infrastructure, auth fixture, Docker/CI integration,
+one POC scenario, and agent-facing docs/template. Visual baseline
+migration is explicitly deferred — see design doc Non-Goals.
+
+## PR 1 — Infra + POC
+
+User value: behavioral e2e tests live in a single, agent-friendly home,
+with one demonstrable scenario proving the loop end-to-end.
+
+- [ ] commit 1 — `feat(backend): test-only POST /test/auth/login route`
+  - Gated on `WAFFLEBASE_E2E_AUTH=1`; module-construction guard
+  - Reuses `AuthService.signTokens()` and `findOrCreateUser`
+  - Startup log marker when enabled
+  - Unit test: route exists when env set, 404 when unset
+- [ ] commit 2 — `chore(frontend): add @playwright/test, playwright.config, fixtures scaffold`
+  - Add devDependency, pin to existing Playwright version (1.58.2)
+  - `playwright.config.ts` with `baseURL`, trace/screenshot/video on failure
+  - `tests/e2e/fixtures/{auth.ts,index.ts}` with worker-scoped storageState
+  - `tests/e2e/__template__.spec.ts` Arrange/Act/Assert stub
+  - `tests/e2e/README.md` (≤50 lines)
+- [ ] commit 3 — `feat(frontend): POC e2e — create slides document from dashboard`
+  - `specs/dashboard/create-slides-doc.spec.ts`
+  - Add any missing `data-testid` to dashboard / slides editor
+  - Selector policy: getByRole first, testid only when necessary
+- [ ] commit 4 — `feat(harness): verify:e2e + verify:e2e:standalone lanes`
+  - Root `package.json` scripts
+  - `scripts/run-e2e-standalone.mjs` orchestrator (boot backend +
+    frontend preview, wait-on, run, teardown, actionable preflight
+    errors for missing Postgres/Yorkie/env)
+  - Append `pnpm verify:e2e` to `CLAUDE.md` Commands table
+- [ ] commit 5 — `ci: verify-e2e GitHub Actions job`
+  - Postgres + Yorkie services
+  - Backend started with `WAFFLEBASE_E2E_AUTH=1`
+  - Upload `playwright-report/` + `test-results/` on failure
+- [ ] commit 6 — `docs: e2e-testing design doc + cross-links`
+  - `docs/design/e2e-testing.md` (this spec)
+  - `docs/design/README.md` Common table row
+  - `docs/design/harness-engineering.md` lane list update
+  - "Do not add new scenarios" header on legacy `verify-*-browser.mjs`
+- [ ] verify: `pnpm verify:fast` per commit
+- [ ] verify: full local run — `pnpm verify:e2e` against running stack
+- [ ] verify: standalone — `pnpm verify:e2e:standalone` succeeds from
+  clean state with only `docker compose up -d`
+- [ ] verify: CI green on a feature branch (Postgres + Yorkie services
+  reachable, trace artifact uploads on a forced failure)
+- [ ] verify: induced failure produces usable trace.zip (`npx playwright
+  show-trace`)
+- [ ] verify: production build of backend confirms `/test/auth/login`
+  returns 404 when env unset
+- [ ] self-review via `/code-review` or `superpowers:requesting-code-review`
+- [ ] PR opened, reviewed, merged
+
+## Out of scope for PR 1 (tracked here for future picks)
+
+- Port `cell-input` / `formula` / `scroll` from
+  `verify-interaction-browser.mjs` to Playwright Test
+- `freshDoc` fixture with `afterEach` document deletion
+- Mobile project in `playwright.config.ts` (added when first mobile spec
+  lands)
+- User-side skill that detects "smoke-tested via MCP, codify?" flow
+- Visual baseline migration — explicitly deferred, decision revisited at
+  each release cycle
+
+## Lessons
+
+See [20260601-e2e-playwright-test-lessons.md](20260601-e2e-playwright-test-lessons.md).

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "verify:frontend:interaction": "pnpm frontend test:interaction",
     "verify:browser:docker": "pnpm frontend test:browser:docker",
     "verify:browser:docker:update": "pnpm frontend test:visual:browser:docker:update",
+    "verify:e2e": "pnpm --filter @wafflebase/frontend e2e",
+    "verify:e2e:standalone": "node ./scripts/run-e2e-standalone.mjs",
     "verify:entropy": "node ./scripts/verify-entropy.mjs",
     "verify:self": "node ./scripts/verify-self.mjs",
     "verify:ci": "node ./scripts/verify-ci.mjs",

--- a/packages/backend/src/auth/auth.module.ts
+++ b/packages/backend/src/auth/auth.module.ts
@@ -9,6 +9,9 @@ import { CliAuthStore } from './cli-auth.store';
 import { GitHubAuthGuard } from './github-auth.guard';
 import { GitHubStrategy } from './github.strategy';
 import { JwtStrategy } from './jwt.strategy';
+import { TestAuthController } from './test-auth.controller';
+
+const TEST_AUTH_ENABLED = process.env.WAFFLEBASE_E2E_AUTH === '1';
 
 @Module({
   imports: [
@@ -26,7 +29,16 @@ import { JwtStrategy } from './jwt.strategy';
     }),
     UserModule,
   ],
-  controllers: [AuthController],
+  controllers: [
+    AuthController,
+    ...(TEST_AUTH_ENABLED ? [TestAuthController] : []),
+  ],
   providers: [AuthService, CliAuthStore, GitHubAuthGuard, JwtStrategy, GitHubStrategy],
 })
-export class AuthModule {}
+export class AuthModule {
+  constructor() {
+    if (TEST_AUTH_ENABLED) {
+      console.warn('[test-auth] DEV-ONLY ROUTES ENABLED (WAFFLEBASE_E2E_AUTH=1)');
+    }
+  }
+}

--- a/packages/backend/src/auth/test-auth.controller.spec.ts
+++ b/packages/backend/src/auth/test-auth.controller.spec.ts
@@ -66,12 +66,12 @@ describe('TestAuthController', () => {
     expect(res.cookie).toHaveBeenCalledWith(
       'wafflebase_session',
       expect.any(String),
-      expect.objectContaining({ httpOnly: true, sameSite: 'lax' }),
+      expect.objectContaining({ httpOnly: true, sameSite: 'lax', secure: false }),
     );
     expect(res.cookie).toHaveBeenCalledWith(
       'wafflebase_refresh',
       expect.any(String),
-      expect.objectContaining({ httpOnly: true, sameSite: 'lax' }),
+      expect.objectContaining({ httpOnly: true, sameSite: 'lax', secure: false }),
     );
     expect(res.json).toHaveBeenCalledWith({ ok: true, userId: 42 });
   });

--- a/packages/backend/src/auth/test-auth.controller.spec.ts
+++ b/packages/backend/src/auth/test-auth.controller.spec.ts
@@ -63,15 +63,18 @@ describe('TestAuthController', () => {
       email: 'e2e-0@test.local',
       photo: null,
     });
+    // Exact match (not objectContaining) so a future regression that adds
+    // an unintended attribute — e.g. `domain: 'evil.com'`, `secure: true`
+    // out of band, `sameSite: 'none'` — fails the test loudly.
     expect(res.cookie).toHaveBeenCalledWith(
       'wafflebase_session',
       expect.any(String),
-      expect.objectContaining({ httpOnly: true, sameSite: 'lax', secure: false }),
+      { httpOnly: true, sameSite: 'lax', secure: false },
     );
     expect(res.cookie).toHaveBeenCalledWith(
       'wafflebase_refresh',
       expect.any(String),
-      expect.objectContaining({ httpOnly: true, sameSite: 'lax', secure: false }),
+      { httpOnly: true, sameSite: 'lax', secure: false },
     );
     expect(res.json).toHaveBeenCalledWith({ ok: true, userId: 42 });
   });

--- a/packages/backend/src/auth/test-auth.controller.spec.ts
+++ b/packages/backend/src/auth/test-auth.controller.spec.ts
@@ -1,0 +1,78 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Response } from 'express';
+import { AuthService } from './auth.service';
+import { UserService } from '../user/user.service';
+import { TestAuthController } from './test-auth.controller';
+
+describe('TestAuthController', () => {
+  let controller: TestAuthController;
+  let userService: { findOrCreateUser: jest.Mock };
+  let res: Pick<Response, 'cookie' | 'json' | 'status'> & { cookie: jest.Mock; json: jest.Mock };
+
+  beforeEach(async () => {
+    userService = { findOrCreateUser: jest.fn() };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [TestAuthController],
+      providers: [
+        AuthService,
+        JwtService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) =>
+              ({
+                JWT_SECRET: 'test-secret',
+                JWT_ACCESS_EXPIRES_IN: '1h',
+                JWT_REFRESH_EXPIRES_IN: '7d',
+                NODE_ENV: 'test',
+              })[key],
+          },
+        },
+        { provide: UserService, useValue: userService },
+      ],
+    }).compile();
+
+    controller = moduleRef.get(TestAuthController);
+    res = {
+      cookie: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      status: jest.fn().mockReturnThis() as never,
+    };
+  });
+
+  it('creates or fetches the test user and sets both auth cookies', async () => {
+    userService.findOrCreateUser.mockResolvedValue({
+      id: 42,
+      username: 'e2e-0',
+      email: 'e2e-0@test.local',
+      photo: null,
+      authProvider: 'test',
+    });
+
+    await controller.login(
+      { username: 'e2e-0', email: 'e2e-0@test.local' },
+      res as unknown as Response,
+    );
+
+    expect(userService.findOrCreateUser).toHaveBeenCalledWith({
+      authProvider: 'test',
+      username: 'e2e-0',
+      email: 'e2e-0@test.local',
+      photo: null,
+    });
+    expect(res.cookie).toHaveBeenCalledWith(
+      'wafflebase_session',
+      expect.any(String),
+      expect.objectContaining({ httpOnly: true, sameSite: 'lax' }),
+    );
+    expect(res.cookie).toHaveBeenCalledWith(
+      'wafflebase_refresh',
+      expect.any(String),
+      expect.objectContaining({ httpOnly: true, sameSite: 'lax' }),
+    );
+    expect(res.json).toHaveBeenCalledWith({ ok: true, userId: 42 });
+  });
+});

--- a/packages/backend/src/auth/test-auth.controller.ts
+++ b/packages/backend/src/auth/test-auth.controller.ts
@@ -1,0 +1,49 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Post,
+  Res,
+} from '@nestjs/common';
+import { Response, CookieOptions } from 'express';
+import { AuthService } from './auth.service';
+import { UserService } from '../user/user.service';
+
+const ACCESS_COOKIE_NAME = 'wafflebase_session';
+const REFRESH_COOKIE_NAME = 'wafflebase_refresh';
+
+type LoginBody = { username: string; email: string };
+
+@Controller('test/auth')
+export class TestAuthController {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly userService: UserService,
+  ) {}
+
+  @Post('login')
+  @HttpCode(200)
+  async login(@Body() body: LoginBody, @Res() res: Response) {
+    const user = await this.userService.findOrCreateUser({
+      authProvider: 'test',
+      username: body.username,
+      email: body.email,
+      photo: null,
+    });
+
+    if (!user) {
+      throw new Error('Failed to create test user');
+    }
+
+    const tokens = this.authService.createTokens(user);
+    const baseCookieOptions: CookieOptions = {
+      httpOnly: true,
+      secure: false,
+      sameSite: 'lax',
+    };
+
+    res.cookie(ACCESS_COOKIE_NAME, tokens.accessToken, baseCookieOptions);
+    res.cookie(REFRESH_COOKIE_NAME, tokens.refreshToken, baseCookieOptions);
+    res.json({ ok: true, userId: user.id });
+  }
+}

--- a/packages/backend/src/auth/test-auth.controller.ts
+++ b/packages/backend/src/auth/test-auth.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   HttpCode,
+  InternalServerErrorException,
   Post,
   Res,
 } from '@nestjs/common';
@@ -32,13 +33,13 @@ export class TestAuthController {
     });
 
     if (!user) {
-      throw new Error('Failed to create test user');
+      throw new InternalServerErrorException('Failed to create test user');
     }
 
     const tokens = this.authService.createTokens(user);
     const baseCookieOptions: CookieOptions = {
       httpOnly: true,
-      secure: false,
+      secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
     };
 

--- a/packages/backend/test/test-auth.e2e-spec.ts
+++ b/packages/backend/test/test-auth.e2e-spec.ts
@@ -1,0 +1,139 @@
+/**
+ * HTTP-level gate tests for /test/auth/login.
+ *
+ * The env check (WAFFLEBASE_E2E_AUTH=1) is evaluated at NestJS module
+ * construction time, so each describe block compiles AppModule with the env
+ * in the required state. Jest runs describe blocks sequentially and honours
+ * the order of beforeAll calls, so the 404 block (env unset) runs before the
+ * 200 block (env set).
+ *
+ * The 200 case calls UserService.findOrCreateUser + Prisma; it is therefore
+ * gated behind RUN_DB_INTEGRATION_TESTS via describeDb (same as other DB
+ * e2e suites in this package).  The 404 case does not hit the DB and always
+ * runs.
+ */
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import * as cookieParser from 'cookie-parser';
+import { AppModule } from 'src/app.module';
+import { YorkieService } from 'src/yorkie/yorkie.service';
+import {
+  setIntegrationEnvDefaults,
+  setAuthEnvDefaults,
+  applyGlobalBootstrap,
+  describeDb,
+} from './helpers/integration-helpers';
+
+// Stub shared by both describe blocks so the Yorkie gRPC client never dials.
+const yorkieStub = {
+  onModuleInit: () => Promise.resolve(),
+  onModuleDestroy: () => Promise.resolve(),
+  withDocument: () => Promise.resolve(null),
+};
+
+// ── 404 case ─────────────────────────────────────────────────────────────────
+// Module must be compiled while WAFFLEBASE_E2E_AUTH is absent.  Jest loads
+// this file fresh (no prior import of AppModule), so as long as we compile
+// before setting the env we get the unguarded module.
+describe('Test auth route (e2e) — env gate OFF', () => {
+  let app: INestApplication;
+  let moduleRef: TestingModule;
+
+  beforeAll(async () => {
+    // Ensure the flag is absent before AppModule is compiled.
+    delete process.env.WAFFLEBASE_E2E_AUTH;
+    setIntegrationEnvDefaults();
+    setAuthEnvDefaults();
+
+    moduleRef = await Test.createTestingModule({ imports: [AppModule] })
+      .overrideProvider(YorkieService)
+      .useValue(yorkieStub)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    applyGlobalBootstrap(app);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await moduleRef.close();
+  });
+
+  it('returns 404 when WAFFLEBASE_E2E_AUTH is unset', async () => {
+    await request(app.getHttpServer())
+      .post('/test/auth/login')
+      .send({ username: 'e2e-0', email: 'e2e-0@test.local' })
+      .expect(404);
+  });
+});
+
+// ── 200 case ─────────────────────────────────────────────────────────────────
+// We need a *second* NestJS app compiled after WAFFLEBASE_E2E_AUTH=1 is set.
+// AppModule is already loaded in the Jest module cache from the block above,
+// but ts-jest caches at the JS level per require() call — re-importing the
+// same path returns the cached module.  That means the TOP-LEVEL const
+// TEST_AUTH_ENABLED in auth.module.ts was already evaluated with env unset.
+//
+// Using jest.isolateModulesAsync to force a fresh require() is the correct
+// tool, but NestJS's TestingInjector breaks when @nestjs/core is loaded twice
+// (Reflector class identity mismatch with ThrottlerGuard's APP_GUARD).
+//
+// Workaround: patch the cached AuthModule's controllers array directly before
+// compiling the second app.  This is intentionally narrow — only the
+// controllers list changes, nothing else in the DI graph.
+describeDb('Test auth route (e2e) — env gate ON', () => {
+  let app: INestApplication;
+  let moduleRef: TestingModule;
+
+  beforeAll(async () => {
+    process.env.WAFFLEBASE_E2E_AUTH = '1';
+    setIntegrationEnvDefaults();
+    setAuthEnvDefaults();
+
+    // Force the cached AuthModule to include TestAuthController.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { TestAuthController } = require('src/auth/test-auth.controller') as {
+      TestAuthController: new (...args: unknown[]) => unknown;
+    };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { AuthModule } = require('src/auth/auth.module') as {
+      AuthModule: { prototype: unknown };
+    };
+    const meta: unknown[] = Reflect.getMetadata('controllers', AuthModule) ?? [];
+    if (!meta.includes(TestAuthController)) {
+      meta.push(TestAuthController);
+      Reflect.defineMetadata('controllers', meta, AuthModule);
+    }
+
+    moduleRef = await Test.createTestingModule({ imports: [AppModule] })
+      .overrideProvider(YorkieService)
+      .useValue(yorkieStub)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    applyGlobalBootstrap(app);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    delete process.env.WAFFLEBASE_E2E_AUTH;
+    await app.close();
+    await moduleRef.close();
+  });
+
+  it('returns 200 + auth cookies when WAFFLEBASE_E2E_AUTH=1', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/test/auth/login')
+      .send({ username: 'e2e-0', email: 'e2e-0@test.local' })
+      .expect(200);
+
+    expect(res.body).toEqual({ ok: true, userId: expect.any(Number) });
+    const cookies = (res.headers['set-cookie'] as unknown as string[]).join(';');
+    expect(cookies).toContain('wafflebase_session=');
+    expect(cookies).toContain('wafflebase_refresh=');
+  });
+});

--- a/packages/backend/test/test-auth.e2e-spec.ts
+++ b/packages/backend/test/test-auth.e2e-spec.ts
@@ -1,16 +1,22 @@
 /**
- * HTTP-level gate tests for /test/auth/login.
+ * HTTP-level gate test for /test/auth/login.
  *
- * The env check (WAFFLEBASE_E2E_AUTH=1) is evaluated at NestJS module
- * construction time, so each describe block compiles AppModule with the env
- * in the required state. Jest runs describe blocks sequentially and honours
- * the order of beforeAll calls, so the 404 block (env unset) runs before the
- * 200 block (env set).
+ * Verifies the security-critical direction of the env gate: when
+ * WAFFLEBASE_E2E_AUTH is unset, the route is not registered and POST
+ * /test/auth/login returns 404. This locks the contract that a
+ * production deploy (which never sets the env) cannot serve the
+ * test-auth route.
  *
- * The 200 case calls UserService.findOrCreateUser + Prisma; it is therefore
- * gated behind RUN_DB_INTEGRATION_TESTS via describeDb (same as other DB
- * e2e suites in this package).  The 404 case does not hit the DB and always
- * runs.
+ * The complementary direction — "with the env set, the route returns
+ * 200 and issues cookies" — is not tested here. NestJS's testing module
+ * captures AuthModule's controllers metadata at first compile, and
+ * `jest.isolateModulesAsync` doesn't work cleanly with @nestjs/core +
+ * ThrottlerGuard's Reflector identity check. Rather than patch module
+ * metadata in-process (which would mutate AuthModule for the rest of
+ * the Jest run and only test the patch, not the env), we cover the
+ * 200-path through the Playwright auth fixture: every e2e spec POSTs
+ * /test/auth/login on first use, so a regression there fails the whole
+ * Playwright lane.
  */
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -22,10 +28,9 @@ import {
   setIntegrationEnvDefaults,
   setAuthEnvDefaults,
   applyGlobalBootstrap,
-  describeDb,
 } from './helpers/integration-helpers';
 
-// Stub shared by both describe blocks so the Yorkie gRPC client never dials.
+// Stub so the Yorkie gRPC client never dials.
 const yorkieStub = {
   onModuleInit: () => Promise.resolve(),
   onModuleDestroy: () => Promise.resolve(),
@@ -67,73 +72,5 @@ describe('Test auth route (e2e) — env gate OFF', () => {
       .post('/test/auth/login')
       .send({ username: 'e2e-0', email: 'e2e-0@test.local' })
       .expect(404);
-  });
-});
-
-// ── 200 case ─────────────────────────────────────────────────────────────────
-// We need a *second* NestJS app compiled after WAFFLEBASE_E2E_AUTH=1 is set.
-// AppModule is already loaded in the Jest module cache from the block above,
-// but ts-jest caches at the JS level per require() call — re-importing the
-// same path returns the cached module.  That means the TOP-LEVEL const
-// TEST_AUTH_ENABLED in auth.module.ts was already evaluated with env unset.
-//
-// Using jest.isolateModulesAsync to force a fresh require() is the correct
-// tool, but NestJS's TestingInjector breaks when @nestjs/core is loaded twice
-// (Reflector class identity mismatch with ThrottlerGuard's APP_GUARD).
-//
-// Workaround: patch the cached AuthModule's controllers array directly before
-// compiling the second app.  This is intentionally narrow — only the
-// controllers list changes, nothing else in the DI graph.
-describeDb('Test auth route (e2e) — env gate ON', () => {
-  let app: INestApplication;
-  let moduleRef: TestingModule;
-
-  beforeAll(async () => {
-    process.env.WAFFLEBASE_E2E_AUTH = '1';
-    setIntegrationEnvDefaults();
-    setAuthEnvDefaults();
-
-    // Force the cached AuthModule to include TestAuthController.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { TestAuthController } = require('src/auth/test-auth.controller') as {
-      TestAuthController: new (...args: unknown[]) => unknown;
-    };
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { AuthModule } = require('src/auth/auth.module') as {
-      AuthModule: { prototype: unknown };
-    };
-    const meta: unknown[] = Reflect.getMetadata('controllers', AuthModule) ?? [];
-    if (!meta.includes(TestAuthController)) {
-      meta.push(TestAuthController);
-      Reflect.defineMetadata('controllers', meta, AuthModule);
-    }
-
-    moduleRef = await Test.createTestingModule({ imports: [AppModule] })
-      .overrideProvider(YorkieService)
-      .useValue(yorkieStub)
-      .compile();
-
-    app = moduleRef.createNestApplication();
-    app.use(cookieParser());
-    applyGlobalBootstrap(app);
-    await app.init();
-  });
-
-  afterAll(async () => {
-    delete process.env.WAFFLEBASE_E2E_AUTH;
-    await app.close();
-    await moduleRef.close();
-  });
-
-  it('returns 200 + auth cookies when WAFFLEBASE_E2E_AUTH=1', async () => {
-    const res = await request(app.getHttpServer())
-      .post('/test/auth/login')
-      .send({ username: 'e2e-0', email: 'e2e-0@test.local' })
-      .expect(200);
-
-    expect(res.body).toEqual({ ok: true, userId: expect.any(Number) });
-    const cookies = (res.headers['set-cookie'] as unknown as string[]).join(';');
-    expect(cookies).toContain('wafflebase_session=');
-    expect(cookies).toContain('wafflebase_refresh=');
   });
 });

--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+playwright/.auth/
+playwright-report/
+test-results/

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "vite",
+    "dev:e2e": "vite --host 127.0.0.1",
     "build": "vite build",
     "lint": "eslint . --max-warnings 0",
     "lint:arch": "eslint -c eslint.arch.config.js \"src/**/*.{ts,tsx}\"",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -21,7 +21,10 @@
     "test:interaction:docker": "bash ../../scripts/run-browser-tests-docker.sh interaction",
     "test:browser:docker": "bash ../../scripts/run-browser-tests-docker.sh all",
     "preview": "vite preview",
-    "docs:screenshots": "node ./scripts/capture-docs-screenshots.mjs"
+    "docs:screenshots": "node ./scripts/capture-docs-screenshots.mjs",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:debug": "playwright test --debug"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -67,6 +70,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@playwright/test": "1.58.2",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.14.1",

--- a/packages/frontend/playwright.config.ts
+++ b/packages/frontend/playwright.config.ts
@@ -4,6 +4,7 @@ const baseURL = process.env.WAFFLEBASE_E2E_BASE_URL ?? 'http://localhost:5173';
 
 export default defineConfig({
   testDir: 'tests/e2e/specs',
+  globalSetup: './tests/e2e/global-setup.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/packages/frontend/playwright.config.ts
+++ b/packages/frontend/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.WAFFLEBASE_E2E_BASE_URL ?? 'http://localhost:5173';
+
+export default defineConfig({
+  testDir: 'tests/e2e/specs',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['html'], ['github']] : 'list',
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium-desktop', use: { ...devices['Desktop Chrome'] } },
+  ],
+  outputDir: 'test-results',
+});

--- a/packages/frontend/scripts/verify-interaction-browser.mjs
+++ b/packages/frontend/scripts/verify-interaction-browser.mjs
@@ -1,3 +1,7 @@
+// LEGACY VERIFIER — interaction regression only (cell input / formula /
+// scroll). Do NOT add new scenarios here. New e2e tests go in
+// `packages/frontend/tests/e2e/` (Playwright Test).
+// See docs/design/e2e-testing.md.
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createServer } from "vite";

--- a/packages/frontend/scripts/verify-visual-browser.mjs
+++ b/packages/frontend/scripts/verify-visual-browser.mjs
@@ -1,3 +1,7 @@
+// LEGACY VERIFIER — visual baseline only.
+// Do NOT add new scenarios here. New e2e tests go in
+// `packages/frontend/tests/e2e/` (Playwright Test).
+// See docs/design/e2e-testing.md.
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -534,6 +534,7 @@ export function DocumentList({
               table.getRowModel().rows.map((row) => (
                 <TableRow
                   key={row.id}
+                  data-testid="document-row"
                   data-state={row.getIsSelected() && "selected"}
                   className="cursor-pointer hover:bg-muted"
                   onClick={(e: MouseEvent<HTMLElement>) => {

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -330,7 +330,10 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
             <UserPresence />
           </div>
         </SiteHeader>
-        <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
+        <div
+          className="flex flex-1 flex-col min-h-0 overflow-hidden"
+          data-testid="slides-editor"
+        >
           <SlidesToolbar
             editor={editor}
             store={store}

--- a/packages/frontend/tests/e2e/README.md
+++ b/packages/frontend/tests/e2e/README.md
@@ -1,0 +1,47 @@
+# E2E Tests (Playwright Test)
+
+Behavioral end-to-end tests that drive the real app. For visual /
+pixel-diff regression see `packages/frontend/scripts/verify-visual-browser.mjs`;
+for jsdom unit tests see `packages/frontend/tests/`.
+
+## Run
+
+```bash
+# One-shot (recommended): builds + boots backend + frontend, runs e2e, tears down.
+docker compose up -d                    # postgres + yorkie (once per machine)
+pnpm verify:e2e:standalone
+
+# Or, against a running dev stack:
+docker compose up -d
+WAFFLEBASE_E2E_AUTH=1 pnpm dev          # in one terminal
+pnpm verify:e2e                         # in another
+```
+
+## Debug
+
+```bash
+pnpm frontend e2e:ui                    # Playwright UI mode
+pnpm frontend e2e:debug                 # Inspector
+npx playwright show-trace test-results/<test>/trace.zip
+```
+
+## Add a test
+
+```bash
+cp packages/frontend/tests/e2e/__template__.spec.ts \
+   packages/frontend/tests/e2e/specs/<area>/<name>.spec.ts
+```
+
+Then fill in the TODOs. Imports: `import { test, expect } from '../fixtures'`.
+
+## Add a fixture
+
+Drop a new file in `fixtures/`, then re-export `test` from
+`fixtures/index.ts` extending the existing chain. Every spec imports from
+`../fixtures` only — never from `@playwright/test` directly.
+
+## Selectors
+
+Prefer `getByRole` / `getByText` / `getByLabel`. Fall back to
+`data-testid` only if no semantic selector works; add the `data-testid`
+to the component in the same PR.

--- a/packages/frontend/tests/e2e/__template__.spec.ts
+++ b/packages/frontend/tests/e2e/__template__.spec.ts
@@ -1,0 +1,28 @@
+// COPY THIS FILE. Replace the TODOs. Delete this header comment.
+// Quick guide: ./README.md
+//
+// Pattern: Arrange / Act / Assert
+//   Arrange — navigate and assert preconditions
+//   Act     — perform the user-visible actions (click / fill / keyboard)
+//   Assert  — check user-observable outcomes (URL, role, text, count)
+//
+// Selector priority:
+//   1. getByRole(name)
+//   2. getByText / getByLabel
+//   3. data-testid (add to the component in the same PR if missing)
+//   Avoid CSS class or structural selectors; they break on refactor.
+
+import { test, expect } from '../fixtures'; // eslint-disable-line @typescript-eslint/no-unused-vars
+
+test.describe('TODO: feature name', () => {
+  test('TODO: behavior described in one sentence', async ({ page }) => {
+    // Arrange
+    await page.goto('/');
+
+    // Act
+    // TODO: user actions
+
+    // Assert
+    // TODO: user-observable outcomes
+  });
+});

--- a/packages/frontend/tests/e2e/fixtures/auth.ts
+++ b/packages/frontend/tests/e2e/fixtures/auth.ts
@@ -6,7 +6,17 @@ const AUTH_DIR = path.join(process.cwd(), 'playwright', '.auth');
 const BACKEND_URL = process.env.WAFFLEBASE_E2E_BACKEND_URL ?? 'http://localhost:3000';
 
 type Fixtures = Record<string, never>;
-type WorkerFixtures = { workerStorageState: string };
+type WorkerFixtures = {
+  workerStorageState: string;
+  /**
+   * Slug of the default workspace auto-created for the worker's test user.
+   * Mirrors UserService.findOrCreateUser's slug rule:
+   *   `${username}-s-workspace` (lowercased, non-alnum collapsed to dashes).
+   * Specs should navigate directly to `/w/${workspaceSlug}` to skip
+   * HomeOrRedirect's chain of fetches.
+   */
+  workspaceSlug: string;
+};
 
 export const test = base.extend<Fixtures, WorkerFixtures>({
   workerStorageState: [
@@ -39,6 +49,15 @@ export const test = base.extend<Fixtures, WorkerFixtures>({
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   storageState: ({ workerStorageState }, use) => use(workerStorageState),
+
+  workspaceSlug: [
+    // No fixture deps; the destructure is required by Playwright's signature.
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use, workerInfo) => {
+      await use(`e2e-${workerInfo.workerIndex}-s-workspace`);
+    },
+    { scope: 'worker' },
+  ],
 });
 
 export { expect };

--- a/packages/frontend/tests/e2e/fixtures/auth.ts
+++ b/packages/frontend/tests/e2e/fixtures/auth.ts
@@ -1,0 +1,44 @@
+import { test as base, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const AUTH_DIR = path.join(process.cwd(), 'playwright', '.auth');
+const BACKEND_URL = process.env.WAFFLEBASE_E2E_BACKEND_URL ?? 'http://localhost:3000';
+
+type Fixtures = Record<string, never>;
+type WorkerFixtures = { workerStorageState: string };
+
+export const test = base.extend<Fixtures, WorkerFixtures>({
+  workerStorageState: [
+    async ({ browser }, use, workerInfo) => {
+      fs.mkdirSync(AUTH_DIR, { recursive: true });
+      const file = path.join(AUTH_DIR, `worker-${workerInfo.workerIndex}.json`);
+
+      if (!fs.existsSync(file)) {
+        const ctx = await browser.newContext();
+        const res = await ctx.request.post(`${BACKEND_URL}/test/auth/login`, {
+          data: {
+            username: `e2e-${workerInfo.workerIndex}`,
+            email: `e2e-${workerInfo.workerIndex}@test.local`,
+          },
+        });
+        if (!res.ok()) {
+          throw new Error(
+            `Test auth login failed (${res.status()}). ` +
+              `Is the backend running with WAFFLEBASE_E2E_AUTH=1?`,
+          );
+        }
+        await ctx.storageState({ path: file });
+        await ctx.close();
+      }
+
+      await use(file);
+    },
+    { scope: 'worker' },
+  ],
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  storageState: ({ workerStorageState }, use) => use(workerStorageState),
+});
+
+export { expect };

--- a/packages/frontend/tests/e2e/fixtures/index.ts
+++ b/packages/frontend/tests/e2e/fixtures/index.ts
@@ -1,0 +1,1 @@
+export { test, expect } from './auth';

--- a/packages/frontend/tests/e2e/global-setup.ts
+++ b/packages/frontend/tests/e2e/global-setup.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Wipe the per-worker auth cache at the start of every run.
+ *
+ * The auth fixture (fixtures/auth.ts) caches storageState to
+ * playwright/.auth/worker-<N>.json per worker. Without this wipe a
+ * stale cookie (post-expiry, after a JWT_SECRET rotation, after a
+ * DB wipe between local runs) would silently poison every subsequent
+ * spec until the operator remembered to delete the cache by hand.
+ *
+ * Running this once per Playwright invocation costs ~1ms and removes
+ * a class of opaque failures.
+ */
+export default async function globalSetup(): Promise<void> {
+  const authDir = path.join(process.cwd(), 'playwright', '.auth');
+  if (fs.existsSync(authDir)) {
+    fs.rmSync(authDir, { recursive: true, force: true });
+  }
+}

--- a/packages/frontend/tests/e2e/specs/dashboard/create-slides-doc.spec.ts
+++ b/packages/frontend/tests/e2e/specs/dashboard/create-slides-doc.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '../../fixtures';
+
+test.describe('Dashboard: create presentation', () => {
+  test('creates a new presentation and lists it on the dashboard', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for the documents page filter to be ready as a precondition
+    // (the page has no h1; the filter input is the most reliable visible marker).
+    await expect(page.getByPlaceholder(/filter by title/i)).toBeVisible();
+
+    const docsBefore = await page.getByTestId('document-row').count();
+
+    await page.getByRole('button', { name: /^new$/i }).click();
+    await page.getByRole('menuitem', { name: /new presentation/i }).click();
+
+    // Creation navigates to /p/<id> and mounts the slides editor.
+    await expect(page).toHaveURL(/\/p\/[a-z0-9-]+/i);
+    await expect(page.getByTestId('slides-editor')).toBeVisible();
+
+    // Back on the dashboard, the row count went up by exactly one.
+    await page.goto('/');
+    await expect(page.getByPlaceholder(/filter by title/i)).toBeVisible();
+    const docsAfter = await page.getByTestId('document-row').count();
+    expect(docsAfter).toBe(docsBefore + 1);
+  });
+});

--- a/packages/frontend/tests/e2e/specs/dashboard/create-slides-doc.spec.ts
+++ b/packages/frontend/tests/e2e/specs/dashboard/create-slides-doc.spec.ts
@@ -1,11 +1,20 @@
 import { test, expect } from '../../fixtures';
 
 test.describe('Dashboard: create presentation', () => {
-  test('creates a new presentation and lists it on the dashboard', async ({ page }) => {
-    await page.goto('/');
+  test('creates a new presentation and lists it on the dashboard', async ({
+    page,
+    workspaceSlug,
+  }) => {
+    // Skip HomeOrRedirect → Navigate → PrivateRoute → Layout chain by
+    // navigating directly to the workspace dashboard. The slug is
+    // deterministic per worker (UserService.findOrCreateUser auto-creates
+    // a `${username}-s-workspace` workspace on first login).
+    const dashboardPath = `/w/${workspaceSlug}`;
 
-    // Wait for the documents page filter to be ready as a precondition
-    // (the page has no h1; the filter input is the most reliable visible marker).
+    await page.goto(dashboardPath);
+
+    // The filter input is the dashboard's most reliable visible marker:
+    // it has no h1 heading, and document rows are absent for fresh users.
     await expect(page.getByPlaceholder(/filter by title/i)).toBeVisible();
 
     const docsBefore = await page.getByTestId('document-row').count();
@@ -18,7 +27,7 @@ test.describe('Dashboard: create presentation', () => {
     await expect(page.getByTestId('slides-editor')).toBeVisible();
 
     // Back on the dashboard, the row count went up by exactly one.
-    await page.goto('/');
+    await page.goto(dashboardPath);
     await expect(page.getByPlaceholder(/filter by title/i)).toBeVisible();
     const docsAfter = await page.getByTestId('document-row').count();
     expect(docsAfter).toBe(docsBefore + 1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,9 @@ importers:
       '@eslint/js':
         specifier: ^9.21.0
         version: 9.24.0
+      '@playwright/test':
+        specifier: 1.58.2
+        version: 1.58.2
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2500,6 +2503,11 @@ packages:
   '@pkgr/core@0.2.2':
     resolution: {integrity: sha512-25L86MyPvnlQoX2MTIV2OiUcb6vJ6aRbFa9pbwByn95INKD5mFH2smgjDhq+fwJoqAgvgbdJLj6Tz7V9X5CFAQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/client@6.6.0':
     resolution: {integrity: sha512-vfp73YT/BHsWWOAuthKQ/1lBgESSqYqAWZEYyTdGXyFAHpmewwWL2Iz6ErIzkj4aHbuc6/cGSsE6ZY+pBO04Cg==}
@@ -10251,6 +10259,10 @@ snapshots:
   '@pinojs/redact@0.4.0': {}
 
   '@pkgr/core@0.2.2': {}
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@prisma/client@6.6.0(prisma@6.6.0(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:

--- a/scripts/run-e2e-standalone.mjs
+++ b/scripts/run-e2e-standalone.mjs
@@ -83,20 +83,14 @@ process.on('SIGTERM', () => {
     WAFFLEBASE_E2E_AUTH: '1',
   });
 
-  // Force vite to bind to 127.0.0.1 explicitly. Vite v6 defaults to
-  // `localhost`, which on Ubuntu CI can resolve to ::1 only — orchestrator
-  // probes IPv4 (`net.connect(5173, '127.0.0.1')`), so the port never opens
-  // from its point of view and waitForPort times out at 60s. `--host
-  // 127.0.0.1` makes the bind explicit and matches the probe.
-  console.log('[verify:e2e:standalone] starting frontend dev server on 127.0.0.1');
-  startChild('pnpm', [
-    '--filter',
-    '@wafflebase/frontend',
-    'dev',
-    '--',
-    '--host',
-    '127.0.0.1',
-  ]);
+  // dev:e2e runs `vite --host 127.0.0.1`. Vite v6 defaults to binding
+  // `localhost`, which on Ubuntu CI can resolve to ::1 only —
+  // orchestrator probes IPv4 (`net.connect(5173, '127.0.0.1')`), so
+  // the port never opens from its point of view and waitForPort times
+  // out at 60s. Using a dedicated script avoids pnpm `--`-arg passing
+  // ambiguity.
+  console.log('[verify:e2e:standalone] starting frontend dev server (dev:e2e, 127.0.0.1)');
+  startChild('pnpm', ['--filter', '@wafflebase/frontend', 'dev:e2e']);
 
   try {
     await Promise.all([waitForPort(BACKEND_PORT), waitForPort(FRONTEND_PORT)]);

--- a/scripts/run-e2e-standalone.mjs
+++ b/scripts/run-e2e-standalone.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// One-shot e2e runner: boots backend + frontend dev server, waits on
+// ports, runs `pnpm verify:e2e`, tears down. Designed for CI and clean
+// local runs. Postgres + Yorkie must already be up (docker compose up -d).
+
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import process from 'node:process';
+
+const BACKEND_PORT = Number(process.env.PORT ?? 3000);
+const FRONTEND_PORT = 5173;
+const WAIT_TIMEOUT_MS = 60_000;
+const WAIT_INTERVAL_MS = 500;
+
+const children = [];
+
+function startChild(cmd, args, env = {}) {
+  const child = spawn(cmd, args, {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    env: { ...process.env, ...env },
+    shell: false,
+  });
+  children.push(child);
+  return child;
+}
+
+function waitForPort(port) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + WAIT_TIMEOUT_MS;
+    const tick = () => {
+      const socket = net.connect(port, '127.0.0.1');
+      socket.once('connect', () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.once('error', () => {
+        socket.destroy();
+        if (Date.now() > deadline) {
+          reject(new Error(`Timed out waiting for :${port}`));
+        } else {
+          setTimeout(tick, WAIT_INTERVAL_MS);
+        }
+      });
+    };
+    tick();
+  });
+}
+
+function preflightHints() {
+  const hints = [];
+  if (!process.env.DATABASE_URL && !process.env.SKIP_E2E_PREFLIGHT) {
+    hints.push(
+      "  • DATABASE_URL is unset — run `docker compose up -d` and source the backend .env first.",
+    );
+  }
+  if (hints.length > 0) {
+    console.warn('[verify:e2e:standalone] preflight hints:');
+    for (const h of hints) console.warn(h);
+  }
+}
+
+function cleanup() {
+  for (const c of children) {
+    if (!c.killed) c.kill('SIGTERM');
+  }
+}
+
+process.on('exit', cleanup);
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(130);
+});
+process.on('SIGTERM', () => {
+  cleanup();
+  process.exit(143);
+});
+
+(async () => {
+  preflightHints();
+
+  console.log('[verify:e2e:standalone] starting backend (WAFFLEBASE_E2E_AUTH=1)');
+  startChild('pnpm', ['--filter', '@wafflebase/backend', 'start:dev'], {
+    WAFFLEBASE_E2E_AUTH: '1',
+  });
+
+  console.log('[verify:e2e:standalone] starting frontend dev server');
+  startChild('pnpm', ['--filter', '@wafflebase/frontend', 'dev']);
+
+  try {
+    await Promise.all([waitForPort(BACKEND_PORT), waitForPort(FRONTEND_PORT)]);
+  } catch (err) {
+    console.error(`[verify:e2e:standalone] ${err.message}`);
+    console.error(
+      'Hints: `docker compose up -d` for Postgres + Yorkie; check backend logs for missing env.',
+    );
+    cleanup();
+    process.exit(1);
+  }
+
+  console.log('[verify:e2e:standalone] running playwright');
+  const playwright = startChild('pnpm', ['verify:e2e']);
+  playwright.on('exit', (code) => {
+    cleanup();
+    process.exit(code ?? 1);
+  });
+})();

--- a/scripts/run-e2e-standalone.mjs
+++ b/scripts/run-e2e-standalone.mjs
@@ -83,8 +83,20 @@ process.on('SIGTERM', () => {
     WAFFLEBASE_E2E_AUTH: '1',
   });
 
-  console.log('[verify:e2e:standalone] starting frontend dev server');
-  startChild('pnpm', ['--filter', '@wafflebase/frontend', 'dev']);
+  // Force vite to bind to 127.0.0.1 explicitly. Vite v6 defaults to
+  // `localhost`, which on Ubuntu CI can resolve to ::1 only — orchestrator
+  // probes IPv4 (`net.connect(5173, '127.0.0.1')`), so the port never opens
+  // from its point of view and waitForPort times out at 60s. `--host
+  // 127.0.0.1` makes the bind explicit and matches the probe.
+  console.log('[verify:e2e:standalone] starting frontend dev server on 127.0.0.1');
+  startChild('pnpm', [
+    '--filter',
+    '@wafflebase/frontend',
+    'dev',
+    '--',
+    '--host',
+    '127.0.0.1',
+  ]);
 
   try {
     await Promise.all([waitForPort(BACKEND_PORT), waitForPort(FRONTEND_PORT)]);


### PR DESCRIPTION
## Summary

- Adds env-gated `POST /test/auth/login` on the backend so Playwright tests can authenticate without GitHub OAuth. The route only registers when `WAFFLEBASE_E2E_AUTH=1` is set at module-construction time; production deploys (which never set the env) return 404, locked in by a dedicated e2e gate test.
- Stands up `@playwright/test` under `packages/frontend/tests/e2e/` with a worker-scoped `auth` fixture (one `storageState` cache per worker), a copy-paste `__template__.spec.ts`, a quick-start `README.md`, and one POC spec that creates a presentation from the dashboard. New tests target real app routes (`/` → `/p/:id`), not harness pages.
- Wires `pnpm verify:e2e` and `pnpm verify:e2e:standalone` lanes, ships `scripts/run-e2e-standalone.mjs` for one-shot CI runs, adds a `verify-e2e` GitHub Actions job parallel to `verify-integration`, and marks the existing `.mjs` verifiers as closed to new scenarios.

Design: [docs/design/e2e-testing.md](https://github.com/wafflebase/wafflebase/blob/feat/e2e-playwright-test/docs/design/e2e-testing.md). Visual-baseline migration is explicitly deferred — see Non-Goals.

## Test plan

- [x] `pnpm verify:fast` green (post-rebase, 877 tests)
- [x] Backend unit test: `TestAuthController` issues cookies via `AuthService.createTokens` (`pnpm --filter @wafflebase/backend test test-auth.controller`)
- [x] Backend e2e gate: `/test/auth/login` returns 404 without `WAFFLEBASE_E2E_AUTH=1` (`pnpm --filter @wafflebase/backend test:e2e test-auth.e2e-spec`)
- [x] `pnpm verify:entropy` clean (design-doc refs resolve, no dead code)
- [x] `playwright test --list` discovers the POC spec
- [ ] Local smoke: `pnpm verify:e2e:standalone` from a clean state (POC spec green)
- [ ] CI `verify-e2e` job green on this PR
- [ ] Production-safety check: built backend returns 404 for `/test/auth/login` with the env unset
- [ ] Trace artifact generation verified (force a failure, confirm `trace.zip` produced and `npx playwright show-trace` opens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)