### PR TITLE
Slides: invalidate measure cache when web fonts finish loading

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides font load repaint (2026-06-03) | [20260603-slides-font-load-repaint-todo.md](./active/20260603-slides-font-load-repaint-todo.md) | [20260603-slides-font-load-repaint-lessons.md](./active/20260603-slides-font-load-repaint-lessons.md) |
+| no smoking union outline (2026-06-01) | [20260601-no-smoking-union-outline-todo.md](./active/20260601-no-smoking-union-outline-todo.md) | [20260601-no-smoking-union-outline-lessons.md](./active/20260601-no-smoking-union-outline-lessons.md) |
 | slides connector elbow curved routing (2026-06-01) | [20260601-slides-connector-elbow-curved-routing-todo.md](./active/20260601-slides-connector-elbow-curved-routing-todo.md) | [20260601-slides-connector-elbow-curved-routing-lessons.md](./active/20260601-slides-connector-elbow-curved-routing-lessons.md) |
 | slides hover text edit entry (2026-06-01) | [20260601-slides-hover-text-edit-entry-todo.md](./active/20260601-slides-hover-text-edit-entry-todo.md) | [20260601-slides-hover-text-edit-entry-lessons.md](./active/20260601-slides-hover-text-edit-entry-lessons.md) |
 | slides shape text hit test (2026-06-01) | [20260601-slides-shape-text-hit-test-todo.md](./active/20260601-slides-shape-text-hit-test-todo.md) | [20260601-slides-shape-text-hit-test-lessons.md](./active/20260601-slides-shape-text-hit-test-lessons.md) |
@@ -35,4 +37,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 247
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides connector elbow curved routing (2026-06-01)
+Latest active task: slides font load repaint (2026-06-03)

--- a/docs/tasks/active/20260603-slides-font-load-repaint-lessons.md
+++ b/docs/tasks/active/20260603-slides-font-load-repaint-lessons.md
@@ -1,0 +1,74 @@
+# Slides: font-load repaint — lessons
+
+**Owner:** @hackerwins
+**Date:** 2026-06-03
+
+## What surprised me
+
+- Two-layer cache. Knowing that `Noto Sans KR` is loaded via
+  unicode-range subsets is half the story; the load timing itself
+  wouldn't be sticky if `cachedMeasureText` re-ran on every
+  `computeLayout`. The real reason "navigate away and back doesn't
+  fix it" is the **module-scoped `WeakMap<TextMeasurer, …>`** holding
+  the fallback widths against the slides text-renderer's singleton
+  measurer. The first hypothesis ("font loads late, paint is stale")
+  was directionally right but stopped short — and would have been
+  defeated by the user's counter-test (re-render with fonts already
+  loaded). Always pressure-test a hypothesis against the obvious
+  retry path before claiming root cause.
+- The in-place text-box editor doesn't share this measurer.
+  `initializeTextBox` allocates a fresh `CanvasTextMeasurer()` per
+  mount (`packages/docs/src/view/text-box-editor.ts:390`), so its
+  cache starts empty. That's why the bug felt "view-mode only" —
+  the editor accidentally side-stepped it.
+
+## Evidence I should have collected earlier
+
+- Captured `fillText` calls + a side-by-side `measureText` probe
+  against (a) a loaded font and (b) an intentionally-bogus font name
+  pegged the layout-time width to the fallback metric within ~1 px.
+  That single comparison is more convincing than any amount of
+  source-tracing.
+- `grep -rn clearMeasureCache packages` returning only the
+  definition was the moment the second-half hypothesis became
+  obvious. Worth checking "is the safety valve actually wired up?"
+  whenever a stale-state bug is in play.
+
+## Choices made
+
+- **Listener over preload.** Lazy unicode-range subsets keep loading
+  throughout the session; a single `loadingdone` listener catches
+  every subset load, while a one-shot preload at mount would need to
+  walk every block's text and force-load each matching subset.
+- **Slides only.** `DocCanvas` has the same class of bug (its
+  measurer is also module-scoped, and `clearMeasureCache` has no
+  callers from docs either). Bundling the fix would have expanded
+  the diff and the regression sweep; the user reported slides, ship
+  slides, follow up on docs separately.
+- **Editor-owned, host-notified.** The editor self-invalidates +
+  re-paints the main canvas (so headless or mobile mounts already
+  benefit) and exposes a single `onFontsLoaded` hook for hosts that
+  own sibling renderers (the desktop `SlidesView` uses it to refresh
+  the thumbnail panel). Avoids duplicating the listener / cache-drain
+  logic in two places.
+- **No `?` chaining inside `attachInteractions`.** The font-load
+  listener registers OUTSIDE the `if (!options.readOnly)` block so
+  share-link viewers — which see the exact same gap — also get the
+  invalidation. The existing `this.on(...)` infrastructure handles
+  cleanup uniformly via `detach()`.
+- **`thumbHandle` became `let … | null`.** The editor's
+  `onFontsLoaded` closure runs at some later tick, but
+  `mountThumbnailPanel` mounts after the editor. Capturing a `let`
+  binding the assignment can later fill in is cleaner than a ref or a
+  pre-construction promise dance.
+
+## What to watch in PR review
+
+- A reviewer might ask "why not call `clearMeasureCache` inside
+  `paintTextBody` if `document.fonts.status === 'loaded'`?" — that
+  bumps the check into the hot paint loop and doesn't help when the
+  status was `loaded` at paint time but a *new* subset finished
+  loading two frames later. Reactive listener stays clean.
+- Vitest mock of `@wafflebase/docs` spreads `...actual` so every
+  other export keeps real behavior. Keep an eye on partial-mock drift
+  if future docs exports gain test-relevant side effects.

--- a/docs/tasks/active/20260603-slides-font-load-repaint-todo.md
+++ b/docs/tasks/active/20260603-slides-font-load-repaint-todo.md
@@ -1,0 +1,101 @@
+# Slides: invalidate measure cache on font load + repaint
+
+**Owner:** @hackerwins
+**Date:** 2026-06-03
+
+## Why
+
+CJK runs in slide text (e.g. a title `"Yorkie, 캐즘 뛰어넘기"`) render with
+a visibly wider inter-run gap in view mode than in the in-place
+text-box editor — even after the user navigates between slides and
+comes back. Reproduces at slide 1 of
+`http://localhost:5173/shared/a9ccf804-5ed0-4661-baeb-ca4361acc8dc`.
+
+Root cause is two compounded facts:
+
+1. The Latin-Korean subsets of `Noto Sans KR` are loaded lazily by the
+   browser via `unicode-range`. On first paint of the slide canvas,
+   the relevant subsets are not yet loaded, so `ctx.measureText("캐즘")`
+   returns **fallback** advance widths (≈ 311 px for `"캐즘 "` at 138.67 px
+   in this deck) rather than the real Noto Sans KR widths (≈ 286 px).
+2. `cachedMeasureText` (`packages/docs/src/view/layout.ts:48`) memoises
+   results in a `WeakMap<TextMeasurer, Map<key, width>>` whose key
+   doesn't include font-load state and is **never invalidated**.
+   `clearMeasureCache` is defined but has no callers
+   (`grep -rn clearMeasureCache packages` → only the definition).
+
+The slides text renderer uses a **module-scoped singleton**
+`CanvasTextMeasurer` (`packages/slides/src/view/canvas/text-renderer.ts:28`);
+its cache persists for the page's lifetime. Even after fonts finish
+loading and the user navigates between slides (`renderer.markDirty()`
+is hit), `computeLayout` reads the stale fallback widths from the
+cache, leaving the next run's `run.x` anchored ~25 px past the actual
+glyph end. The gap appears as visibly wide character spacing.
+
+The in-place text-box editor doesn't show the bug because
+`initializeTextBox` constructs a **fresh** `CanvasTextMeasurer` per
+mount (`packages/docs/src/view/text-box-editor.ts:390`); its cache
+starts empty and the first measurement uses the now-loaded font.
+
+Measured evidence (captured `fillText` + `measureText` in a fresh page):
+
+| Source | `measureText("캐즘 ")` |
+|---|---|
+| Fallback (font not in `document.fonts`) | **311.71 px** ← layout used this |
+| Loaded `Noto Sans KR` | 286.13 px ← editor uses this |
+| Captured slide-canvas gap (`run("뛰어넘기").x - run("캐즘").x`) | **312 px** |
+
+## Scope
+
+- Subscribe to `document.fonts` load events from the slides editor.
+- When fonts finish loading, call `clearMeasureCache()` from
+  `@wafflebase/docs` and request a repaint of the main canvas + the
+  thumbnail panel so both pick up fresh widths.
+- Clean up the listener on `SlidesEditor.detach()`.
+- Out of scope: docs editor (same class of bug — `DocCanvas`'s
+  measurer is also module-scoped — but the user-reported case is
+  slides, and docs has its own follow-up surface). PDF / PPTX export
+  paths already preload fonts via `document.fonts.load`.
+
+## Plan
+
+- [ ] Export `clearMeasureCache` through the `@wafflebase/docs` index
+      (already exported from `view/layout.ts`; verify the re-export).
+- [ ] Add a `SlidesEditorOptions.onFontsLoaded?` hook so the React
+      `SlidesView` (which owns both the editor and the thumbnail panel)
+      can refresh thumbnails too.
+- [ ] In `SlidesEditorImpl` constructor, register a
+      `document.fonts.addEventListener('loadingdone', handler)` via the
+      existing `this.on(...)` infrastructure so it gets torn down in
+      `detach()`. Handler calls `clearMeasureCache()`,
+      `this.renderer.markDirty()`, and `options.onFontsLoaded?.()`.
+- [ ] In `SlidesView`, wire `onFontsLoaded` to call
+      `panel.refreshContent()` so painted thumbnails repaint at the
+      new widths.
+- [ ] Guard for SSR / Node test envs where `document` /
+      `document.fonts` are absent — no-op the registration.
+- [ ] Vitest: in `packages/slides/test/view/editor/` (or a new file),
+      mount a `SlidesEditorImpl` against a stubbed `document.fonts`
+      that exposes `addEventListener`/`removeEventListener`. Dispatch
+      `loadingdone`; assert (a) `clearMeasureCache` was invoked
+      (spyable via a re-export wrap), (b) `renderer.markDirty()` was
+      invoked, (c) `detach()` removes the listener.
+- [ ] `pnpm verify:fast` green.
+
+## Out of scope (deliberate)
+
+- Pre-loading deck fonts at mount time. Lazy unicode-range subsets
+  make a full preload non-trivial (would need to walk every block's
+  text + force load each subset). The reactive `loadingdone` path
+  catches every subset load with one listener.
+- Mirroring the fix in `DocCanvas`. Same class of bug exists for docs
+  but is a separate ticket; bundling would blur the diff and require
+  a docs-side regression sweep.
+- A `clearMeasureCache` call in the slide renderer's own `dispose` —
+  the cache is module-scoped and shared by every other consumer
+  (thumbnails, text-box-editor mounts past detach). Premature drain
+  would punish unrelated paths.
+
+## Review
+
+(filled in after implementation)

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -91,7 +91,7 @@ export {
 export { paintLayout, type PaintLayoutOpts } from './view/paint-layout.js';
 export { findPositionAtPixel, type PixelPosition } from './view/find-position-at-pixel.js';
 export type { TableMergeContext } from './view/table-merge-context.js';
-export { computeLayout, computeListCounters } from './view/layout.js';
+export { computeLayout, computeListCounters, clearMeasureCache } from './view/layout.js';
 export type {
   DocumentLayout,
   LayoutBlock,

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -509,6 +509,13 @@ export function SlidesView({
     if (!readOnlyMount && store.read().slides.length === 0) {
       store.batch(() => store.addSlide("blank"));
     }
+    // Late-bound thumbnail handle. `mountThumbnailPanel` runs further
+    // down (after the editor and the resize/notes wiring), but the
+    // editor's `onFontsLoaded` callback fires from a document.fonts
+    // event that can land at any later tick. Capturing a `let` lets
+    // that closure read whichever value the assignment below has
+    // installed by the time the event arrives.
+    let thumbHandle: ThumbnailPanelHandle | null = null;
     const editor = initializeEditor({
       canvas,
       overlay,
@@ -524,6 +531,10 @@ export function SlidesView({
       onShowShortcutsHelp: () => setHelpOpen(true),
       onStartPresentation: (from) => onStartPresentationRef.current?.(from),
       onToast: (msg) => onToastRef.current(msg),
+      // The editor clears the shared cachedMeasureText and repaints the
+      // main canvas; we also repaint already-painted thumbnails so
+      // their pre-font-load fallback widths stop showing through.
+      onFontsLoaded: () => thumbHandle?.refreshContent(),
       // onLinkRequest is still intentionally unwired — the link popover
       // needs a richer TextBoxEditorAPI (insertLink / getLinkAtCursor)
       // before it can drive the docs text-box. Cmd+K no-ops at the
@@ -745,7 +756,7 @@ export function SlidesView({
     document.addEventListener("mousemove", onDocMouseMove);
     document.addEventListener("mouseup", onDocMouseUp);
 
-    const thumbHandle: ThumbnailPanelHandle = mountThumbnailPanel(
+    thumbHandle = mountThumbnailPanel(
       thumbsHost,
       store,
       editor,
@@ -774,7 +785,7 @@ export function SlidesView({
     const offChange = store.onChange(() => {
       editor.markDirty();
       editor.render();
-      thumbHandle.refreshContent();
+      thumbHandle?.refreshContent();
     });
 
     // Local presence: broadcast active slide + selection. Yorkie's
@@ -804,7 +815,7 @@ export function SlidesView({
       const n = store.getSlideCount();
       if (n !== lastSlideCount) {
         lastSlideCount = n;
-        thumbHandle.refresh();
+        thumbHandle?.refresh();
       }
       raf = requestAnimationFrame(tick);
     };
@@ -825,7 +836,7 @@ export function SlidesView({
       offSelection();
       offSlide();
       offChange();
-      thumbHandle.dispose();
+      thumbHandle?.dispose();
       editor.detach();
       store.dispose();
       editorRef.current = null;

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -9,7 +9,7 @@ import type {
   VerticalAnchorMode,
 } from '../../model/element';
 import type { Block } from '@wafflebase/docs';
-import { DEFAULT_BLOCK_STYLE } from '@wafflebase/docs';
+import { DEFAULT_BLOCK_STYLE, clearMeasureCache } from '@wafflebase/docs';
 import { SHAPE_TEXT_PADDING } from '../canvas/shape-renderer';
 import type { ThemeColor } from '../../model/theme';
 import type { ConnectorElement } from '../../model/connector';
@@ -235,6 +235,16 @@ export interface SlidesEditorOptions extends SlideRendererOptions {
    * mount).
    */
   bodyHost?: HTMLElement;
+  /**
+   * Fired after the editor has invalidated the shared `cachedMeasureText`
+   * cache in response to a `document.fonts` `loadingdone` event and
+   * marked the main canvas dirty. The host wires this to any
+   * sibling renderers it owns — most importantly the thumbnail panel,
+   * whose own `SlideRenderer` instances drew with the pre-load
+   * fallback widths and would otherwise stay stale. No-op when omitted
+   * (headless tests, mounts without a thumbnail strip).
+   */
+  onFontsLoaded?: () => void;
 }
 
 export interface SlidesEditor {
@@ -665,6 +675,28 @@ class SlidesEditorImpl implements SlidesEditor {
     // working so the host shell can drive navigation.
     if (!options.readOnly) {
       this.attachInteractions();
+    }
+    // Repaint with fresh width metrics when web fonts (Noto Sans KR
+    // unicode-range subsets etc.) finish loading. The slides text
+    // renderer's `CanvasTextMeasurer` is module-scoped, and
+    // `cachedMeasureText` memoises `(font, text) → width` without a
+    // load-state key. Without this listener, the layout computed during
+    // the initial paint — when CJK subsets are still unloaded — pins
+    // each run's `x` against the fallback font's wider advance widths;
+    // `fillText` later draws with the loaded Noto Sans KR glyphs (≈ 25 px
+    // narrower at 138.67 px for "캐즘 "), leaving a visible gap before
+    // the next run. Re-entering edit mode masks the bug because
+    // `initializeTextBox` allocates a fresh measurer per mount.
+    //
+    // We attach to read-only mounts too — share-link viewers see the
+    // same gap. SSR / Node test envs lack `document.fonts`; bail.
+    if (typeof document !== 'undefined' && document.fonts) {
+      this.on(document.fonts, 'loadingdone', () => {
+        clearMeasureCache();
+        this.renderer.markDirty();
+        this.render();
+        options.onFontsLoaded?.();
+      });
     }
   }
 

--- a/packages/slides/test/view/editor/editor-font-invalidation.test.ts
+++ b/packages/slides/test/view/editor/editor-font-invalidation.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import { MemSlidesStore } from '../../../src/store/memory';
+import { initialize, type SlidesEditor } from '../../../src/view/editor/editor';
+import { SlideRenderer } from '../../../src/view/canvas/slide-renderer';
+
+// Mock clearMeasureCache so the spy survives jsdom's lack of a real
+// Canvas 2D measureText pipeline (which would otherwise short-circuit
+// the cache without our import path executing). Spreading `...actual`
+// keeps every other docs export pointing at the real module so the
+// editor's other imports — `DEFAULT_BLOCK_STYLE`, `Block`, etc. —
+// behave exactly as in production.
+vi.mock('@wafflebase/docs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@wafflebase/docs')>();
+  return {
+    ...actual,
+    clearMeasureCache: vi.fn(actual.clearMeasureCache),
+  };
+});
+
+import { clearMeasureCache } from '@wafflebase/docs';
+
+function makeFixture() {
+  const canvas = document.createElement('canvas');
+  canvas.width = 960;
+  canvas.height = 540;
+  const overlay = document.createElement('div');
+  overlay.style.position = 'absolute';
+  document.body.appendChild(canvas);
+  document.body.appendChild(overlay);
+  const store = new MemSlidesStore();
+  store.batch(() => store.addSlide('blank'));
+  return { canvas, overlay, store };
+}
+
+describe('SlidesEditor font-load cache invalidation', () => {
+  let editor: SlidesEditor | null = null;
+  let originalFonts: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+    // jsdom omits `document.fonts`. Install a stub `EventTarget` so
+    // the editor's listener wiring exercises the same `addEventListener`
+    // path it uses in the browser.
+    originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts');
+    Object.defineProperty(document, 'fonts', {
+      value: new EventTarget(),
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (editor) {
+      editor.detach();
+      editor = null;
+    }
+    if (originalFonts) {
+      Object.defineProperty(document, 'fonts', originalFonts);
+    } else {
+      // We installed a stub where none existed; drop it.
+      // @ts-expect-error — removing a configurable property we installed.
+      delete document.fonts;
+    }
+  });
+
+  it('clears the measure cache, marks the renderer dirty, and fires onFontsLoaded when fonts finish', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const markDirtySpy = vi.spyOn(SlideRenderer.prototype, 'markDirty');
+    const onFontsLoaded = vi.fn();
+    editor = initialize({
+      canvas,
+      overlay,
+      store,
+      hostWidth: 960,
+      hostHeight: 540,
+      dpr: 1,
+      onFontsLoaded,
+    });
+    // The mount + initial render path may call markDirty incidentally
+    // (selection seeding, overlay paint); reset so the assertion below
+    // measures the font-load handler alone.
+    markDirtySpy.mockClear();
+    (clearMeasureCache as ReturnType<typeof vi.fn>).mockClear();
+
+    document.fonts.dispatchEvent(new Event('loadingdone'));
+
+    expect(clearMeasureCache).toHaveBeenCalledTimes(1);
+    expect(markDirtySpy).toHaveBeenCalledTimes(1);
+    expect(onFontsLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the font-load listener on detach', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const onFontsLoaded = vi.fn();
+    editor = initialize({
+      canvas,
+      overlay,
+      store,
+      hostWidth: 960,
+      hostHeight: 540,
+      dpr: 1,
+      onFontsLoaded,
+    });
+    editor.detach();
+    editor = null;
+    (clearMeasureCache as ReturnType<typeof vi.fn>).mockClear();
+
+    document.fonts.dispatchEvent(new Event('loadingdone'));
+
+    expect(clearMeasureCache).not.toHaveBeenCalled();
+    expect(onFontsLoaded).not.toHaveBeenCalled();
+  });
+
+  it('registers the listener on read-only mounts as well', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const onFontsLoaded = vi.fn();
+    editor = initialize({
+      canvas,
+      overlay,
+      store,
+      hostWidth: 960,
+      hostHeight: 540,
+      dpr: 1,
+      readOnly: true,
+      onFontsLoaded,
+    });
+
+    document.fonts.dispatchEvent(new Event('loadingdone'));
+
+    // Share-link viewers see the same stale-cache gap; the listener
+    // must fire even though attachInteractions is skipped.
+    expect(onFontsLoaded).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Korean (and any other lazy-loaded unicode-range) runs in slide text rendered with a visibly wider inter-run gap in view mode than inside the in-place text-box editor, and the gap **persisted across slide navigation, peer edits, and re-mounts**. The reported reproduction: title `"Yorkie, 캐즘 뛰어넘기"` at slide 1 of a shared deck.
- Root cause is two compounded facts:
  - The slides text renderer's `CanvasTextMeasurer` is a **module-scoped singleton** (`packages/slides/src/view/canvas/text-renderer.ts:28`).
  - `cachedMeasureText` (`packages/docs/src/view/layout.ts:48`) memoises `(font, text) → width` in a `WeakMap<TextMeasurer, …>` whose key omits font-load state and is never invalidated. `clearMeasureCache` was defined but had **no callers** in production (`grep -rn clearMeasureCache packages` returned only the definition).
  - First paint runs before lazy `Noto Sans KR` subsets are loaded → `ctx.measureText("캐즘")` returns ~25 px wider fallback widths → those widths get pinned into the cache → every subsequent layout reads the stale entry, leaving each run's `x` ~25 px past the actual glyph end at 138.67 px.
- The in-place text-box editor side-stepped the bug by accident: `initializeTextBox` allocates a fresh `CanvasTextMeasurer` per mount, so its cache starts empty and the first measurement uses the loaded font.
- Fix: `SlidesEditor` subscribes to `document.fonts` `loadingdone`, drains the shared cache via the previously-unused `clearMeasureCache` export, marks the main renderer dirty, and notifies the host through a new `onFontsLoaded` hook so the desktop `SlidesView` can also re-paint already-painted thumbnails. The listener registers on read-only mounts too — share-link viewers see the same gap.

Measured evidence (captured `fillText` + `measureText` in a fresh page before the fix):

| Source | `measureText("캐즘 ")` |
|---|---|
| Fallback (font not in `document.fonts`) | **311.71 px** ← layout used this |
| Loaded `Noto Sans KR` | 286.13 px ← in-place editor uses this |
| Captured slide-canvas gap (`run("뛰어넘기").x - run("캐즘").x`) | **312 px** |

## Test plan

- [x] `pnpm verify:fast` (exit 0).
- [x] New unit suite `packages/slides/test/view/editor/editor-font-invalidation.test.ts` (3 cases) stubs `document.fonts` as an `EventTarget`, dispatches `loadingdone`, asserts `clearMeasureCache` + `SlideRenderer.markDirty` + `onFontsLoaded` fire, asserts `detach()` removes the listener, and asserts the listener attaches even on `readOnly: true` mounts.
- [x] Existing `editor.test.ts` (94 cases) still green.
- [x] Manual smoke in the original repro deck — first load of slide 1 now renders the title with the same tight inter-run gap as the in-place editor; navigating between slides keeps it correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed slide text rendering to accurately refresh when web fonts finish loading. Previously, slides displayed with fallback font metrics until cache was cleared.
  * Thumbnail panel now synchronizes with font changes for consistent visual updates.

* **Documentation**
  * Added task documentation detailing font-load repaint investigation, root-cause analysis, implementation decisions, and review considerations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafflebase/wafflebase/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->