### PR TITLE
Slides: text-edit + adjust drag entry on grouped elements

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides grouped text edit entry (2026-06-03) | [20260603-slides-grouped-text-edit-entry-todo.md](./active/20260603-slides-grouped-text-edit-entry-todo.md) | [20260603-slides-grouped-text-edit-entry-lessons.md](./active/20260603-slides-grouped-text-edit-entry-lessons.md) |
 | slides font load repaint (2026-06-03) | [20260603-slides-font-load-repaint-todo.md](./active/20260603-slides-font-load-repaint-todo.md) | [20260603-slides-font-load-repaint-lessons.md](./active/20260603-slides-font-load-repaint-lessons.md) |
 | no smoking union outline (2026-06-01) | [20260601-no-smoking-union-outline-todo.md](./active/20260601-no-smoking-union-outline-todo.md) | [20260601-no-smoking-union-outline-lessons.md](./active/20260601-no-smoking-union-outline-lessons.md) |
 | slides connector elbow curved routing (2026-06-01) | [20260601-slides-connector-elbow-curved-routing-todo.md](./active/20260601-slides-connector-elbow-curved-routing-todo.md) | [20260601-slides-connector-elbow-curved-routing-lessons.md](./active/20260601-slides-connector-elbow-curved-routing-lessons.md) |

--- a/docs/tasks/active/20260603-slides-grouped-text-edit-entry-lessons.md
+++ b/docs/tasks/active/20260603-slides-grouped-text-edit-entry-lessons.md
@@ -1,0 +1,66 @@
+# Lessons — grouped element edit entry
+
+**Date:** 2026-06-03
+
+## Pattern to watch for
+
+Whenever editor code looks up an element by id, ask: "is this
+likely to be called for an element nested inside a group?" If yes,
+**never use `Array.prototype.find` on `slide.elements`** — it's
+non-recursive and will silently return `undefined` for grouped
+elements, which the surrounding code then treats as "no such
+element" and bails. The store side uses `findElementPath`
+recursively; the view side should match.
+
+Bugs found together in this PR:
+
+| Symptom | File | Line |
+|---|---|---|
+| Grouped text-box won't enter edit on double-click | `editor.ts` | 2172 (was) |
+| Grouped shape's adjustment diamond drag does nothing | `editor.ts` | 3288 (was) |
+| Editing element keeps painting under the in-place editor | `editor.ts` | 893–907 (was) |
+| Adjustment live preview misses grouped shape | `editor.ts` | 3360 (was) |
+
+All four were one pattern: `slide.elements.find/map` assuming top-
+level. Use the recursive helpers (`findElement`, `findElementPath`,
+`buildElementWorldLookup`) or write a small recursive walker.
+
+## World vs local frame
+
+For overlay DOM mounts (text-box editor, adjustment handles) and
+for math that compares against pointer coords, the frame must be in
+world coords. The stored frame is **group-local**. Compose the
+ancestor transforms with `buildElementWorldLookup` (canonical) or
+`scopeAncestorTransform` + `applyGroupTransform`.
+
+Store-side writes go through `updateElementFrame` /
+`updateElementData` which still take element-local frames — so on
+write-back, don't blindly hand world coords to the store.
+`enterEditMode` keeps `enterFrameH = localElement.frame.h` for the
+post-commit autofit comparison even though the mount path uses the
+world-frame element.
+
+## jsdom can't drive overlay handle hit-test
+
+`Editor.handleAtClient` reads `overlay.getBoundingClientRect()` and
+the overlay's child handle positions. jsdom returns zero for both,
+so a unit test that "drags the adjustment diamond" doesn't reach
+`startAdjustmentDrag`. Two viable strategies:
+
+1. Test the helper (`replaceShapeAdjustments`, world-frame
+   resolution) in isolation rather than the full pointer path.
+2. Manual smoke against `pnpm dev` for the actual drag.
+
+Don't waste cycles trying to fake layout in jsdom — `puppeteer`
+against the dev server confirms the drag end-to-end (and lets you
+read the store state to verify the write).
+
+## "Same root cause" really means the same diff
+
+When the user reported the slide 31 Dogfooding case mid-PR, the
+temptation was to file a follow-up. But the root cause was
+literally the same pattern on adjacent functions in the same file.
+Folding both into one PR kept the recursive-walk + world-frame
+discipline consistent across all four call sites — splitting
+would have meant two reviews of the same idea against the same
+file and a higher chance of one side drifting.

--- a/docs/tasks/active/20260603-slides-grouped-text-edit-entry-todo.md
+++ b/docs/tasks/active/20260603-slides-grouped-text-edit-entry-todo.md
@@ -1,0 +1,152 @@
+# Slides: text-edit + adjustment-drag entry on grouped elements
+
+**Owner:** @hackerwins
+**Date:** 2026-06-03
+
+## Why
+
+On slide 22 of
+`http://localhost:5173/shared/a9ccf804-5ed0-4661-baeb-ca4361acc8dc`
+("타겟 사용자 찾기"), double-clicking the right-column text
+"웹/모바일에서 도구 형 서비스를 개발하는 개발자" never enters text-edit mode.
+The same gesture works on the title at the top of the same slide.
+
+The textbox (`id 63bb8301`) is nested inside a group (`id 86919428`)
+that also contains the dark background rect and the "설명" label.
+`Selection.doubleClick` correctly drills into the group and selects
+the leaf textbox, but the subsequent `Editor.enterEditMode` bails out
+silently:
+
+```ts
+// editor.ts:2172
+const element = slide.elements.find((e) => e.id === elementId);
+if (!element || (element.type !== 'text' && element.type !== 'shape')) {
+  return;
+}
+```
+
+`Array.prototype.find` doesn't descend into `group.data.children`, so
+any text/shape nested in a group is invisible to this path. Runtime
+verification on the live page:
+
+| Call | Result |
+|---|---|
+| `editor.enterTextEditing('7cb15d29')` (slide-root title) | `isTextEditing: true` ✓ |
+| `editor.enterTextEditing('63bb8301')` (grouped textbox) | `isTextEditing: false` ✗ |
+
+Same class of bug exists at the render-skip path (`editor.ts:893–907`):
+it uses a flat `.map().filter()` to hide the editing element from the
+slide canvas, so even if `enterEditMode` were patched in isolation
+the editing element would keep painting underneath the overlay
+(visible ghost copy).
+
+## Scope
+
+- `enterEditMode` must locate elements anywhere in the slide's element
+  tree, not just at the top level.
+- The text-box editor mounts to the overlay DOM in **world** coords
+  (`frame.x * scale`, `frame.y * scale`, CSS rotate around centre).
+  For grouped elements the stored `frame` is **group-local**, so the
+  mount path must compose the ancestor group transforms before
+  passing the frame to `mountTextBox`. There is already a canonical
+  helper for this: `buildElementWorldLookup` in `model/group.ts`.
+- The render-skip path must walk the element tree recursively so the
+  editing element is masked regardless of how deeply it is nested.
+- Store mutations (`withTextElement`, `withShapeText`,
+  `updateElementFrame`) already use `findElementPath` and handle
+  grouped elements; no store-side changes needed.
+
+During implementation a second instance of the same anti-pattern
+turned up on slide 31: the shape "Dogfooding" (a `pentagonArrow`
+nested in a group) has an adjustment diamond, but dragging it did
+nothing. `Editor.startAdjustmentDrag` opened with the same flat
+`Array.prototype.find` and the same group-local-frame math. Folded
+into this PR rather than chased into a follow-up — the fix is the
+exact same shape and the diff sits in the same handful of lines.
+
+## Plan
+
+- [x] Branch off `main`, write this todo.
+- [x] `enterEditMode`: replace the flat `find` with a path-based
+      lookup (`findElement` recursive helper already lives at
+      `editor.ts:3795`). Build the world frame via
+      `buildElementWorldLookup` and pass that world-frame element to
+      `buildEditTarget`. Keep `enterFrameH` reading the **local**
+      element height since `store.updateElementFrame` writes back in
+      local space.
+- [x] Render-skip path (`editor.ts:893–907`): replace the flat map
+      with a recursive walker (`maskEditingElement`) that rebuilds
+      the element tree, preserving group nesting. Shape-text strip
+      behaviour and text-element omission stay identical.
+- [x] `startAdjustmentDrag` (`editor.ts:3278`): swap the flat
+      `find` for `buildElementWorldLookup` so the start element
+      resolves anywhere in the slide tree AND its frame is already
+      composed through the ancestor group transforms — exactly what
+      `adjustmentWorldToLocal` needs since the pointer it converts
+      is in world coords.
+- [x] `paintLiveAdjustments` (`editor.ts:3358`): replace the flat
+      map with `replaceShapeAdjustments` (recursive) and resolve
+      the live overlay element via `buildElementWorldLookup` so the
+      yellow diamond and outline track grouped shapes during drag.
+- [x] Vitest: `test/view/editor/grouped-text-edit-entry.test.ts` —
+      asserts that `enterTextEditing(id)` on a grouped text element
+      enters edit mode AND that the frame the mount path passes
+      equals `buildElementWorldLookup(...).get(id).frame`.
+      (Adjustment-drag end-to-end isn't testable in jsdom because
+      handle hit-testing reads `overlay.getBoundingClientRect` which
+      jsdom reports as zero; manual smoke covers it.)
+- [x] Manual smoke: slide 22 of the shared deck, double-click
+      "웹/모바일..." → text-edit enters and the in-place editor lines
+      up with the dark rect. Then Escape to exit. Title editing on
+      the same slide still works.
+- [x] Manual smoke: slide 31 of the same deck, drill into the
+      Dogfooding group, drag the yellow diamond on the pentagon
+      arrow → store's `data.adjustments` reflects the new value
+      (verified live; undid the test mutation via `store.undo()`).
+- [x] `pnpm verify:fast` green.
+
+## Out of scope (deliberate)
+
+- Groups with `rotation !== 0` or non-uniform scale. The world-frame
+  path supports them mathematically (composeAncestorTransform tracks
+  rotation; applyGroupTransform scales w/h), but autofit-grow at
+  commit writes the editor's reported content height directly into
+  `frame.h` via `store.updateElementFrame`. That value is in the
+  editor's logical coords (= world h for scale-1 groups). For scaled
+  groups the height would need to be divided by the cumulative
+  scaleY before being stored. The slide-22 deck (and every group on
+  it) has rotation 0 and refSize === frame, so the scope-1 case
+  covers the reported bug. Scaled-group autofit becomes a follow-up
+  if a real deck triggers it.
+- Docs/sheets: this is a slides-only path; no other package surfaces
+  the same `slide.elements.find` pattern.
+
+## Review
+
+Two view-layer code paths assumed `slide.elements` is flat:
+
+- `enterEditMode` and the editing-element render mask (text-edit
+  entry on grouped text/shape).
+- `startAdjustmentDrag` and `paintLiveAdjustments` (adjustment
+  diamond drag on grouped shapes).
+
+Both got the same shape of fix: resolve the element via the
+recursive helper, and use `buildElementWorldLookup` whenever the
+downstream code expects world coords (overlay mount, world↔local
+adjustment conversion). The store-side mutation APIs
+(`requireElement`, `updateElementData`, `updateElementFrame`,
+`withTextElement`, `withShapeText`) already walk the tree via
+`findElementPath`, so the writes work transparently.
+
+Live verification on the shared deck:
+
+- Slide 22 "웹/모바일…" double-click → edit mode entered, in-place
+  editor's dashed outline aligns with the dark rect; canvas no
+  longer double-paints the underlying text.
+- Slide 31 Dogfooding pentagon arrow adjustment drag → adjustments
+  went 50000 → 19376 in the store after a 100-px horizontal drag
+  through the in-flight live preview.
+
+## Lessons
+
+See [20260603-slides-grouped-text-edit-entry-lessons.md](./20260603-slides-grouped-text-edit-entry-lessons.md).

--- a/docs/tasks/active/20260603-slides-grouped-text-edit-entry-todo.md
+++ b/docs/tasks/active/20260603-slides-grouped-text-edit-entry-todo.md
@@ -116,8 +116,17 @@ exact same shape and the diff sits in the same handful of lines.
   groups the height would need to be divided by the cumulative
   scaleY before being stored. The slide-22 deck (and every group on
   it) has rotation 0 and refSize === frame, so the scope-1 case
-  covers the reported bug. Scaled-group autofit becomes a follow-up
-  if a real deck triggers it.
+  covers the reported bug. To keep the silent-miswrite hole closed
+  in the meantime, `enterEditMode` detects ancestor transform
+  (world frame w/h/rotation diverging from local) and skips the
+  post-commit autofit-grow write in that case. Scaled-group autofit
+  becomes a follow-up if a real deck triggers it.
+- Connector-endpoint drag on connectors nested inside groups.
+  `startConnectorEndpointDrag` (editor.ts:3135) has the same
+  flat-find pattern. PPTX import can produce connectors inside
+  groups (`<p:cxnSp>` inside `<p:grpSp>`); the editor-side
+  `group()` op currently forbids them, so the user-reachable
+  failure mode is import-only. Deferred to keep this PR scoped.
 - Docs/sheets: this is a slides-only path; no other package surfaces
   the same `slide.elements.find` pattern.
 

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -888,22 +888,14 @@ class SlidesEditorImpl implements SlidesEditor {
     // For TextElement the whole element is text, so we filter it out.
     // For ShapeElement the fill/stroke are still part of the slide and
     // must keep painting underneath the editor — only the `data.text`
-    // body gets stripped. Cloning is structural-only (no deep block
-    // copy) so this stays cheap on every frame.
+    // body gets stripped. The walker is recursive so the mask hits
+    // elements nested inside groups too; cloning is structural-only
+    // (no deep block copy) so this stays cheap on every frame.
     if (this.editingElementId !== null) {
       const editingId = this.editingElementId;
       const visible = {
         ...slide,
-        elements: slide.elements
-          .map((e) => {
-            if (e.id !== editingId) return e;
-            if (e.type === 'shape') {
-              const { text: _omit, ...rest } = e.data;
-              return { ...e, data: rest } as typeof e;
-            }
-            return null;
-          })
-          .filter((e): e is Element => e !== null),
+        elements: maskEditingElement(slide.elements, editingId),
       };
       this.renderer.forceRender(visible, doc);
       this.paintRuler();
@@ -2169,23 +2161,44 @@ class SlidesEditorImpl implements SlidesEditor {
     const doc = this.options.store.read();
     const slide = doc.slides.find((s) => s.id === slideId);
     if (!slide) return;
-    const element = slide.elements.find((e) => e.id === elementId);
-    if (!element || (element.type !== 'text' && element.type !== 'shape')) {
+    // Resolve the element anywhere in the slide tree (including inside
+    // groups) — `Array.prototype.find` would only see top-level
+    // elements, so grouped text/shape would silently fail to enter
+    // edit mode.
+    const localElement = findElement(slide.elements, elementId);
+    if (
+      !localElement ||
+      (localElement.type !== 'text' && localElement.type !== 'shape')
+    ) {
       return;
     }
+
+    // The overlay text-box mounts in WORLD coords (`frame.x * scale`,
+    // CSS rotate around centre). For grouped elements the stored
+    // `frame` is group-local; compose the ancestor transforms via
+    // `buildElementWorldLookup` so the editor lines up with where the
+    // slide canvas paints the element. For top-level elements the
+    // world lookup returns the live element by reference, so this is
+    // a no-op.
+    const worldLookup = buildElementWorldLookup(slide.elements);
+    const worldElement = worldLookup.get(elementId) as
+      | TextElement
+      | ShapeElement;
 
     // Build a small descriptor that papers over the difference between
     // editing a TextElement (text in `data.blocks`, frame auto-grows to
     // fit content) and a ShapeElement (text in `data.text.blocks`,
     // frame is user-sized and does NOT auto-grow into the text). All
     // the wiring below works off `target` so the two kinds stay aligned.
-    const target = buildEditTarget(element);
+    const target = buildEditTarget(worldElement);
 
     // Frame height at entry; the committed fit only writes when the
     // content height differs from this (text-element only; shapes skip
-    // the post-commit frame fit). Reset the per-edit tracker so a stale
-    // height from a previous edit can't leak into this commit.
-    const enterFrameH = element.frame.h;
+    // the post-commit frame fit). Read from the LOCAL element because
+    // `store.updateElementFrame` writes the height back in local space.
+    // Reset the per-edit tracker so a stale height from a previous
+    // edit can't leak into this commit.
+    const enterFrameH = localElement.frame.h;
     this.lastEditingContentHeight = null;
 
     // Make sure the selection is on the editing element so the rest of
@@ -3272,7 +3285,13 @@ class SlidesEditorImpl implements SlidesEditor {
     const selectedIds = this.selection.get();
     if (selectedIds.length !== 1) return;
     const elementId = selectedIds[0];
-    const startEl = startSlide.elements.find((e) => e.id === elementId);
+    // World lookup so grouped shapes resolve and the world↔local
+    // conversion below operates on the world frame the canvas paints
+    // (pointer logical coords are world coords). The render-side
+    // `paintLiveAdjustments` recurses into groups to write the live
+    // preview, and the store commit goes through `updateElementData`
+    // which is already group-aware.
+    const startEl = buildElementWorldLookup(startSlide.elements).get(elementId);
     if (!startEl || startEl.type !== 'shape') return;
 
     const handles = ADJUSTMENT_HANDLES.get(startEl.data.kind);
@@ -3339,20 +3358,28 @@ class SlidesEditorImpl implements SlidesEditor {
   private paintLiveAdjustments(elementId: string, adjustments: number[]): void {
     // Render a synthetic slide where the target shape's data has the live
     // adjustments applied. Mirrors paintLive but overrides element data
-    // instead of frame, using the same forceRender pattern.
+    // instead of frame, using the same forceRender pattern. The walker
+    // recurses into groups so adjustments on grouped shapes preview
+    // correctly.
     const slide = this.currentSlide();
     if (!slide) return;
     const synthetic = {
       ...slide,
-      elements: slide.elements.map((el) => {
-        if (el.id !== elementId || el.type !== 'shape') return el;
-        return { ...el, data: { ...el.data, adjustments } };
-      }),
+      elements: replaceShapeAdjustments(
+        slide.elements,
+        elementId,
+        adjustments,
+      ),
     };
     this.renderer.forceRender(synthetic, this.options.store.read());
     // Repaint overlay so adjustment handles follow the live shape.
-    const selected = synthetic.elements.filter((e) => this.selection.has(e.id));
-    renderOverlay(this.options.overlay, selected, {
+    // `buildElementWorldLookup` resolves the live element (with the new
+    // adjustments) AND composes ancestor group transforms into its
+    // frame — both required so the yellow diamond tracks the shape
+    // inside a group.
+    const liveEl = buildElementWorldLookup(synthetic.elements).get(elementId);
+    if (!liveEl) return;
+    renderOverlay(this.options.overlay, [liveEl], {
       scale: this.scale(),
       slideWidth: SLIDE_WIDTH,
       slideHeight: SLIDE_HEIGHT,
@@ -3801,6 +3828,79 @@ function findElement(elements: readonly Element[], id: string): Element | undefi
     }
   }
   return undefined;
+}
+
+/**
+ * Rebuild a slide's element tree with the target shape's
+ * `data.adjustments` overridden. Used by the adjustment-drag live
+ * preview so a grouped shape's renderer sees the in-flight values
+ * without mutating the store. Non-matching elements are aliased.
+ */
+function replaceShapeAdjustments(
+  elements: readonly Element[],
+  targetId: string,
+  adjustments: number[],
+): Element[] {
+  const out: Element[] = [];
+  for (const el of elements) {
+    if (el.id === targetId && el.type === 'shape') {
+      out.push({ ...el, data: { ...el.data, adjustments } });
+      continue;
+    }
+    if (el.type === 'group') {
+      out.push({
+        ...el,
+        data: {
+          ...el.data,
+          children: replaceShapeAdjustments(
+            el.data.children,
+            targetId,
+            adjustments,
+          ),
+        },
+      });
+      continue;
+    }
+    out.push(el);
+  }
+  return out;
+}
+
+/**
+ * Rebuild a slide's element tree with the in-edit element masked: a
+ * text element is dropped entirely, a shape element keeps its
+ * fill/stroke but has `data.text` stripped so the renderer doesn't
+ * paint the body that the in-place text-box editor now owns. Groups
+ * are walked recursively so the mask applies regardless of nesting
+ * depth. Shallow clones only; block arrays are aliased.
+ */
+function maskEditingElement(
+  elements: readonly Element[],
+  editingId: string,
+): Element[] {
+  const out: Element[] = [];
+  for (const el of elements) {
+    if (el.id === editingId) {
+      if (el.type === 'shape') {
+        const { text: _omit, ...rest } = el.data;
+        out.push({ ...el, data: rest } as typeof el);
+      }
+      // TextElement → drop entirely; the overlay editor owns it now.
+      continue;
+    }
+    if (el.type === 'group') {
+      out.push({
+        ...el,
+        data: {
+          ...el.data,
+          children: maskEditingElement(el.data.children, editingId),
+        },
+      });
+      continue;
+    }
+    out.push(el);
+  }
+  return out;
 }
 
 /**

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -2199,6 +2199,23 @@ class SlidesEditorImpl implements SlidesEditor {
     // Reset the per-edit tracker so a stale height from a previous
     // edit can't leak into this commit.
     const enterFrameH = localElement.frame.h;
+    // The autofit-grow commit path reads the editor's reported content
+    // height (in world / canvas-logical coords) and writes it straight
+    // into `frame.h` (LOCAL). For top-level elements local === world;
+    // for groups with rotation 0 + unit scale, w/h/rotation still
+    // match between local and world. When they DIVERGE (rotated or
+    // scaled ancestor group), the world-h cannot be stored as local-h
+    // without dividing by the cumulative scaleY — out of scope here.
+    // Skip the fit in those cases so we never corrupt the stored
+    // height; rotated/scaled groups simply don't autofit-grow on
+    // commit. Falls through cleanly for normal (top-level / scale-1)
+    // elements.
+    const localFrame = localElement.frame;
+    const worldFrame = worldElement.frame;
+    const ancestorHasTransform =
+      worldFrame.w !== localFrame.w ||
+      worldFrame.h !== localFrame.h ||
+      worldFrame.rotation !== localFrame.rotation;
     this.lastEditingContentHeight = null;
 
     // Make sure the selection is on the editing element so the rest of
@@ -2266,8 +2283,13 @@ class SlidesEditorImpl implements SlidesEditor {
                 // Fit the frame height to the content in the SAME batch
                 // as the text write — one undo entry, no per-keystroke
                 // churn. Shapes keep their authored frame; skip the fit.
+                // Also skip when the element sits inside a rotated /
+                // non-unit-scale group: the reported height is in world
+                // coords, and writing it into the local `frame.h`
+                // without composing the inverse ancestor transform
+                // would silently corrupt the stored height.
                 const h = this.lastEditingContentHeight;
-                if (h !== null) {
+                if (h !== null && !ancestorHasTransform) {
                   const targetH = Math.max(MIN_TEXT_BOX_H, h);
                   if (targetH !== enterFrameH) {
                     this.options.store.updateElementFrame(slideId, elementId, { h: targetH });

--- a/packages/slides/test/view/editor/grouped-text-edit-entry.test.ts
+++ b/packages/slides/test/view/editor/grouped-text-edit-entry.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { describe, expect, it, afterEach } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import type { Block } from '@wafflebase/docs';
+import type { Frame } from '../../../src/model/element';
+import { MemSlidesStore } from '../../../src/store/memory';
+import { buildElementWorldLookup } from '../../../src/model/group';
+import { initialize, type SlidesEditor } from '../../../src/view/editor/editor';
+import type {
+  MountSlidesTextBoxOptions,
+  SlidesTextBoxEditor,
+} from '../../../src/view/editor/text-box-editor';
+
+/**
+ * Capturing mock mount: records the frame the editor passed in so the
+ * test can assert it's in world coords (group transform composed),
+ * not the raw group-local frame.
+ */
+function makeCapturingMount(captured: { frame?: Frame }) {
+  return function mount(opts: MountSlidesTextBoxOptions): SlidesTextBoxEditor {
+    captured.frame = opts.frame;
+    const container = document.createElement('div');
+    container.className = 'wfb-slides-text-box-editor';
+    container.style.position = 'absolute';
+    opts.overlay.appendChild(container);
+    let mounted = true;
+    return {
+      isEditing: () => mounted,
+      focus: () => undefined,
+      commit: () => opts.onCommit(opts.blocks),
+      detach: () => { mounted = false; container.remove(); },
+      container,
+      getSelectionStyle: () => ({}),
+      getRangeStyleSummary: () => ({}),
+      applyStyle: () => {},
+      clearInlineFormatting: () => {},
+      applyBlockStyle: () => {},
+      getBlockType: () => ({ type: 'paragraph' as const }),
+      getBlockStyle: () => ({}),
+      setBlockType: () => {},
+      toggleList: () => {},
+      indent: () => {},
+      outdent: () => {},
+      insertLink: () => {},
+      removeLink: () => {},
+      getLinkAtCursor: () => undefined,
+      requestLink: () => {},
+      undo: () => {},
+      redo: () => {},
+      onCursorMove: () => {},
+    };
+  };
+}
+
+function block(text: string): Block {
+  return {
+    id: 'b1', type: 'paragraph',
+    inlines: [{ text, style: {} }],
+    style: {},
+  } as Block;
+}
+
+function setup() {
+  document.body.innerHTML = '';
+  const canvas = document.createElement('canvas');
+  canvas.width = 1920;
+  canvas.height = 1080;
+  const overlay = document.createElement('div');
+  overlay.style.position = 'absolute';
+  document.body.appendChild(canvas);
+  document.body.appendChild(overlay);
+  const store = new MemSlidesStore();
+  return { canvas, overlay, store };
+}
+
+describe('enterTextEditing for grouped elements', () => {
+  let editor: SlidesEditor | null = null;
+  afterEach(() => {
+    if (editor) { editor.detach(); editor = null; }
+  });
+
+  it('enters edit mode on a text element nested inside a group', () => {
+    // Slide-22 regression: `Array.prototype.find` only walked the
+    // top-level `slide.elements`, so any text/shape inside a group
+    // silently failed to enter text-edit mode.
+    const { canvas, overlay, store } = setup();
+    let sid = '';
+    let textId = '';
+    store.batch(() => {
+      sid = store.addSlide('blank');
+      textId = store.addElement(sid, {
+        type: 'text',
+        frame: { x: 100, y: 200, w: 300, h: 80, rotation: 0 },
+        data: { blocks: [block('Inside a group')] },
+      });
+      const labelId = store.addElement(sid, {
+        type: 'text',
+        frame: { x: 0, y: 200, w: 80, h: 80, rotation: 0 },
+        data: { blocks: [block('label')] },
+      });
+      // group() requires at least 2 elements at the same level.
+      store.group(sid, [labelId, textId]);
+    });
+
+    const captured: { frame?: Frame } = {};
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: makeCapturingMount(captured),
+    });
+
+    editor.enterTextEditing(textId);
+
+    expect(editor.getEditingElementId()).toBe(textId);
+    expect(captured.frame).toBeDefined();
+  });
+
+  it('passes world (not group-local) frame to the text-box mount', () => {
+    // The overlay text-box mounts in world coords (`frame.x * scale`);
+    // for a grouped element the stored `frame` is group-local. The
+    // mount path must compose the ancestor group transforms before
+    // handing the frame to `mountTextBox`, or the editor lines up
+    // outside the visible element on the slide canvas.
+    //
+    // Place the elements far enough apart that `store.group()`'s AABB
+    // wrap produces a group origin that is clearly NOT (0, 0), so the
+    // world frame is meaningfully different from any nested local
+    // coords.
+    const { canvas, overlay, store } = setup();
+    let sid = '';
+    let textId = '';
+    store.batch(() => {
+      sid = store.addSlide('blank');
+      textId = store.addElement(sid, {
+        type: 'text',
+        frame: { x: 600, y: 400, w: 200, h: 60, rotation: 0 },
+        data: { blocks: [block('Body')] },
+      });
+      const otherId = store.addElement(sid, {
+        type: 'text',
+        frame: { x: 500, y: 300, w: 40, h: 40, rotation: 0 },
+        data: { blocks: [block('x')] },
+      });
+      store.group(sid, [otherId, textId]);
+    });
+
+    const slide = store.read().slides.find((s) => s.id === sid)!;
+    // Canonical world frame for the grouped element. Whatever the
+    // editor passes to mount must equal this — the mount path uses
+    // this same helper internally.
+    const expected = buildElementWorldLookup(slide.elements).get(textId)!.frame;
+
+    const captured: { frame?: Frame } = {};
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: makeCapturingMount(captured),
+    });
+
+    editor.enterTextEditing(textId);
+
+    expect(captured.frame?.x).toBeCloseTo(expected.x, 5);
+    expect(captured.frame?.y).toBeCloseTo(expected.y, 5);
+    expect(captured.frame?.w).toBeCloseTo(expected.w, 5);
+    expect(captured.frame?.h).toBeCloseTo(expected.h, 5);
+    // The original world coords we wrote — sanity check that the
+    // expected frame matches the visible position on the slide
+    // (group AABB wrap doesn't change the child's world position).
+    expect(expected.x).toBeCloseTo(600, 5);
+    expect(expected.y).toBeCloseTo(400, 5);
+  });
+});


### PR DESCRIPTION
## Summary

Two view-layer paths in the slides editor assumed `slide.elements` is flat, so any text/shape nested inside a group silently failed to enter the relevant interaction:

- **Text-edit entry (slide 22 of the Yorkie deck, "웹/모바일…" textbox).** Double-click drilled in via `Selection.doubleClick`, but `Editor.enterEditMode` resolved the click target via `Array.prototype.find` and bailed — and the canvas mask for the in-edit element used the same flat pattern, so even an isolated entry fix would have ghost-painted the original underneath.
- **Adjustment-handle drag (slide 31 "Dogfooding" pentagonArrow).** The yellow diamond armed but never wrote because `startAdjustmentDrag` had the same flat `find` AND used the group-local frame for the world↔local conversion. `paintLiveAdjustments` had the matching flat-map bug.

Both paths now resolve elements via the existing recursive helpers (`findElement`, `buildElementWorldLookup`) and pass world-frame elements where downstream code expects world coords. Store-side mutation APIs already walk the tree, so writes are transparent.

Code-review follow-up commit guards the post-commit autofit-grow write against silent miswrite under rotated / non-unit-scale ancestor groups (height would be stored as local even though it's measured in world). The guard skips the fit when local and world `frame.{w,h,rotation}` diverge — for slide 22's groups they don't, so behavior there is unchanged.

## Test plan

- [x] `pnpm verify:fast` (lint + unit) green.
- [x] Vitest `grouped-text-edit-entry.test.ts` covers the world-frame mount contract.
- [x] Manual smoke: slide 22 of the reporter's deck — double-click "웹/모바일…" → text-edit enters and the in-place editor's dashed outline lines up with the dark rect.
- [x] Manual smoke: slide 31 — drill into the Dogfooding group, drag the yellow adjustment diamond → `data.adjustments` reflects the new value (verified live; the test mutation was undone via `store.undo()`).

## Out of scope (deliberate)

- Rotated / non-unit-scale groups still get the autofit-grow skip (guarded against corruption, not fully supported). Real-deck need would unlock the proper inverse-transform write-back as a follow-up.
- `startConnectorEndpointDrag` has the same flat-find pattern. PPTX import can produce nested connectors but the editor-side group op forbids them; user-reachable failure mode is import-only and tracked in the todo's out-of-scope section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text editing for elements nested inside groups. Double-click now correctly enters text-edit mode for grouped elements.
  * Resolved duplicate text rendering when editing text within grouped shapes.
  * Improved coordinate handling for overlay positioning when editing grouped elements.

* **Tests**
  * Added test coverage for text editing in grouped elements.

* **Documentation**
  * Added implementation notes and lessons for grouped element editing patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->