### PR TITLE
Seed dark slides theme when creating a deck in dark mode

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,6 +19,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | release v0.4.4 (2026-06-08) | [20260608-release-v0.4.4-todo.md](./active/20260608-release-v0.4.4-todo.md) | - |
+| slides dark theme on create (2026-06-08) | [20260608-slides-dark-theme-on-create-todo.md](./active/20260608-slides-dark-theme-on-create-todo.md) | [20260608-slides-dark-theme-on-create-lessons.md](./active/20260608-slides-dark-theme-on-create-lessons.md) |
 | slides hover text edit browser smoke (2026-06-07) | [20260607-slides-hover-text-edit-browser-smoke-todo.md](./active/20260607-slides-hover-text-edit-browser-smoke-todo.md) | - |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |

--- a/docs/tasks/active/20260608-slides-dark-theme-on-create-lessons.md
+++ b/docs/tasks/active/20260608-slides-dark-theme-on-create-lessons.md
@@ -1,0 +1,40 @@
+# Lessons — slides dark theme on create
+
+## Effect ordering between a context provider and its consumers
+
+`ThemeProvider`'s `useState` initializer for `resolvedTheme` reads
+`window.matchMedia(...)` only — it does not consult the `theme` value
+loaded from `localStorage` on the same line above. When a user has
+explicitly chosen `theme = 'dark'` but their OS is `light` (or vice
+versa), the first render exposes a stale `resolvedTheme`. The provider's
+own `useEffect` fixes it on the next tick.
+
+React passive effects run bottom-up — a child's effect fires BEFORE its
+parent's. So a child that reads `resolvedTheme` inside a mount effect
+on the same commit gets the stale value, not the corrected one.
+
+The fix used in `SlidesView` is to gate the mount effect on a
+`didMount` state set by a separate `useEffect(() => setDidMount(true), [])`.
+That state flip + the provider's `setResolvedTheme` are both batched into
+the next render, so by the time the gated effect runs, the context has
+caught up.
+
+The first cut of `MobileSlidesView` mirrored the ref pattern but skipped
+the gate, which the code review caught: a one-shot seed driven by context
+state is only safe if the effect waits for context to settle. Whenever
+you're reading provider state to make an irreversible decision at mount
+time, copy the gating pattern, not just the ref pattern.
+
+## "needsRoot" as the right boundary for new-vs-migration
+
+`ensureSlidesRoot` runs for both brand-new decks and pre-v0.5 migrations.
+Tying the dark-theme seed to the `needsRoot` branch — rather than to the
+themes-backfill branch a few lines down — keeps the seed from repainting
+someone else's existing deck just because the current viewer happens to
+be in dark mode. The themes backfill still uses `defaultLight` for
+migrations.
+
+The corresponding unit test asserts that a doc with `meta` already set
+(but no `themes`) is NOT repainted, even when `initialThemePreference: 'dark'`
+is passed. Locking that behavior down in a test means the next person to
+touch the function can't accidentally widen the seed scope.

--- a/docs/tasks/active/20260608-slides-dark-theme-on-create-todo.md
+++ b/docs/tasks/active/20260608-slides-dark-theme-on-create-todo.md
@@ -1,0 +1,31 @@
+# Slides — seed dark theme for new decks in dark mode
+
+When a user creates a new Presentation while the app is in dark mode,
+seed the document with `defaultDark` instead of `defaultLight` so the
+editor and slide canvas don't clash on first open. The theme switcher
+in the right pane remains the escape hatch.
+
+## Scope
+
+- New decks only. A migrated pre-v0.5 deck (one that already has `meta`
+  but no `themes` array) keeps its existing look — we don't repaint
+  someone else's deck just because the current viewer is in dark mode.
+- Both desktop (`slides-view.tsx`) and mobile (`mobile-slides-view.tsx`)
+  call sites.
+
+## Plan
+
+- [x] `ensureSlidesRoot(doc, { initialThemePreference?: 'light' | 'dark' })`
+      — gate dark seeding on `needsRoot` so migrations stay on light.
+- [x] Pass `useTheme().resolvedTheme` from both call sites.
+- [x] Unit tests: dark seeds `defaultDark`; light seeds `defaultLight`;
+      dark preference does NOT replace themes when `meta` already exists.
+- [x] `pnpm verify:fast`.
+
+## Notes
+
+- `defaultDark` already exists at `packages/slides/src/themes/default-dark.ts`
+  with id `'default-dark'`. No new theme work needed.
+- The theme-provider already exposes a `resolvedTheme: 'light' | 'dark'`
+  that respects both explicit user choice and the OS `prefers-color-scheme`
+  media query — exactly what we want for seeding decisions.

--- a/packages/frontend/src/app/slides/mobile-slides-view.tsx
+++ b/packages/frontend/src/app/slides/mobile-slides-view.tsx
@@ -17,6 +17,7 @@ import {
   type SlidesEditor,
 } from "@wafflebase/slides";
 import { Loader } from "@/components/loader";
+import { useTheme } from "@/components/theme-provider";
 import { usePointerSwipe } from "@/hooks/use-pointer-swipe";
 import type { YorkieSlidesRoot } from "@/types/slides-document";
 import type { SlidesPresence } from "@/types/users";
@@ -99,6 +100,23 @@ export function MobileSlidesView({
     SlidesPresence
   >();
 
+  // Read the resolved (light|dark) theme through a ref so the store-mount
+  // effect can seed a brand-new deck with the matching theme without
+  // re-running when the user later toggles dark mode. The `didMount`
+  // gate below pushes the seed read out by one render — without it,
+  // child-before-parent effect ordering would let this effect fire
+  // before `ThemeProvider`'s effect flips `resolvedTheme` from the
+  // matchMedia-only initial value to the localStorage-corrected one,
+  // which would silently seed a light deck for a user whose explicit
+  // dark preference disagrees with their OS setting.
+  const { resolvedTheme } = useTheme();
+  const resolvedThemeRef = useRef(resolvedTheme);
+  resolvedThemeRef.current = resolvedTheme;
+  const [didMount, setDidMount] = useState(false);
+  useEffect(() => {
+    setDidMount(true);
+  }, []);
+
   // Stash the lifted-state callbacks behind refs so the effects below
   // don't re-run whenever the parent renders with a fresh closure for
   // either callback. The parent today passes `setStore`/`setEditor`
@@ -120,8 +138,10 @@ export function MobileSlidesView({
   // cleanup. Disposed in cleanup either way.
   const [store, setStore] = useState<YorkieSlidesStore | null>(null);
   useEffect(() => {
-    if (!doc) return;
-    ensureSlidesRoot(doc);
+    if (!didMount || !doc) return;
+    ensureSlidesRoot(doc, {
+      initialThemePreference: resolvedThemeRef.current,
+    });
     const s = new YorkieSlidesStore(doc);
     setStore(s);
     onStoreReadyRef.current?.(s);
@@ -130,7 +150,7 @@ export function MobileSlidesView({
       setStore(null);
       onStoreReadyRef.current?.(null);
     };
-  }, [doc]);
+  }, [didMount, doc]);
 
   // Snapshot of the slide list the mobile shell renders. Refreshed
   // whenever the store fires `onChange` so the footer indicator and

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -12,6 +12,7 @@ import { useEffect, useRef, useState } from "react";
 import { useDocument } from "@yorkie-js/react";
 import { toast } from "sonner";
 import { Loader } from "@/components/loader";
+import { useTheme } from "@/components/theme-provider";
 import type { YorkieSlidesRoot } from "@/types/slides-document";
 import type { SlidesPresence } from "@/types/users";
 import { SlidesShortcutsHelp } from "./slides-shortcuts-help";
@@ -137,6 +138,14 @@ export function SlidesView({
   const { doc, loading, error } = useDocument<YorkieSlidesRoot, SlidesPresence>();
   const readOnlyMount = readOnly === true;
 
+  // Capture the resolved (light|dark) theme into a ref so the mount
+  // effect — which doesn't track theme as a dependency — can read the
+  // current value when seeding a brand-new deck. Only the value at
+  // first-creation time matters; later toggles don't change the deck.
+  const { resolvedTheme } = useTheme();
+  const resolvedThemeRef = useRef(resolvedTheme);
+  resolvedThemeRef.current = resolvedTheme;
+
   // Capture the latest onStartPresentation in a ref so the editor's
   // Cmd/Ctrl+Enter handler always calls the freshest callback, without
   // adding the prop to the mount effect's deps (which would tear down
@@ -199,7 +208,9 @@ export function SlidesView({
     // policy below. Fixing it properly (gating the migration on a
     // role, or migrating server-side) is owned by the doc-migration
     // workstream — not the share-link toolbar work.
-    ensureSlidesRoot(doc);
+    ensureSlidesRoot(doc, {
+      initialThemePreference: resolvedThemeRef.current,
+    });
 
     // Build the canvas + overlay DOM into the container. The slides
     // editor is vanilla DOM, so we hand-build the scaffolding here

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -31,6 +31,7 @@ import {
   applyLayoutToSlide,
   composeAncestorTransform,
   computeConnectorFrame,
+  defaultDark,
   defaultLight,
   generateId,
   getLayout,
@@ -159,18 +160,28 @@ function unwrapElement(e: unknown): YorkieElement {
  * array (defaulting to `[]` if missing) and each text element's
  * `data.blocks` is an array (defaulting to `[]` if missing). No Tree
  * creation here.
+ *
+ * `initialThemePreference` only applies to brand-new decks (the
+ * `needsRoot` branch). A pre-v0.5 doc being migrated keeps `defaultLight`
+ * so we don't repaint an existing deck just because the current viewer
+ * happens to be in dark mode.
  */
 export function ensureSlidesRoot(
   doc: YorkieDocument<YorkieSlidesRoot>,
+  options?: { initialThemePreference?: 'light' | 'dark' },
 ): void {
   const root = doc.getRoot();
   const needsRoot = root.meta == null || root.slides == null || root.layouts == null;
+  const seedTheme =
+    needsRoot && options?.initialThemePreference === 'dark'
+      ? defaultDark
+      : defaultLight;
   if (needsRoot) {
     doc.update((r) => {
       if (r.meta == null) {
         r.meta = {
           title: 'Untitled presentation',
-          themeId: 'default-light',
+          themeId: seedTheme.id,
           masterId: 'default',
         };
       }
@@ -190,7 +201,7 @@ export function ensureSlidesRoot(
       guides?: unknown[];
     };
     if (rootAny.themes == null || rootAny.themes.length === 0) {
-      rootAny.themes = [clone(defaultLight)];
+      rootAny.themes = [clone(seedTheme)];
     }
     if (rootAny.masters == null || rootAny.masters.length === 0) {
       rootAny.masters = [clone(DEFAULT_MASTER)];

--- a/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-store.test.ts
@@ -26,6 +26,56 @@ describe('YorkieSlidesStore — read', () => {
   });
 });
 
+describe('ensureSlidesRoot — initial theme preference', () => {
+  it('seeds default-light when no preference is provided', () => {
+    const doc = new yorkie.Document<YorkieSlidesRoot>(
+      `test-${Date.now()}-${Math.random()}`,
+    );
+    ensureSlidesRoot(doc);
+    const root = doc.getRoot();
+    expect(root.meta.themeId).toBe('default-light');
+    expect(root.themes.map((t) => t.id)).toEqual(['default-light']);
+  });
+
+  it('seeds default-dark when initialThemePreference is "dark"', () => {
+    const doc = new yorkie.Document<YorkieSlidesRoot>(
+      `test-${Date.now()}-${Math.random()}`,
+    );
+    ensureSlidesRoot(doc, { initialThemePreference: 'dark' });
+    const root = doc.getRoot();
+    expect(root.meta.themeId).toBe('default-dark');
+    expect(root.themes.map((t) => t.id)).toEqual(['default-dark']);
+  });
+
+  it('does NOT change theme on a doc whose meta already exists', () => {
+    // Migration safety: an existing deck that lacks a `themes` array
+    // (pre-v0.5 shape) but already has `meta` must keep its existing
+    // look. A current dark-mode viewer mounting that deck should NOT
+    // repaint it to default-dark.
+    const doc = new yorkie.Document<YorkieSlidesRoot>(
+      `test-${Date.now()}-${Math.random()}`,
+    );
+    doc.update((r) => {
+      const rootAny = r as unknown as {
+        meta: { title: string; themeId: string; masterId: string };
+        slides: unknown[];
+        layouts: unknown[];
+      };
+      rootAny.meta = {
+        title: 'Pre-existing deck',
+        themeId: 'default-light',
+        masterId: 'default',
+      };
+      rootAny.slides = [];
+      rootAny.layouts = [];
+    });
+    ensureSlidesRoot(doc, { initialThemePreference: 'dark' });
+    const root = doc.getRoot();
+    expect(root.meta.themeId).toBe('default-light');
+    expect(root.themes.map((t) => t.id)).toEqual(['default-light']);
+  });
+});
+
 describe('YorkieSlidesStore — slide ops', () => {
   it('addSlide pushes onto the array and returns the new id', () => {
     const doc = makeDoc();

--- a/packages/slides/src/node.ts
+++ b/packages/slides/src/node.ts
@@ -100,6 +100,7 @@ export {
 
 export { migrateDocument } from './model/migrate';
 export { defaultLight } from './themes/default-light';
+export { defaultDark } from './themes/default-dark';
 
 export {
   BUILT_IN_LAYOUTS,


### PR DESCRIPTION
## Summary

- New presentations now seed `defaultDark` when the user is in dark mode, instead of always seeding `defaultLight`. The eye-strain mismatch of a bright white slide canvas inside a dark editor chrome is gone, and the theme switcher in the right pane still lets users override.
- The dark seed only applies to brand-new decks (`needsRoot` is true). A pre-v0.5 deck being migrated still gets `defaultLight` backfilled — we don't repaint someone else's existing deck just because the current viewer happens to be in dark mode.
- `MobileSlidesView` picks up the same `didMount` gate `SlidesView` already has, so the mount effect waits one tick for `ThemeProvider`'s `resolvedTheme` to settle. Without the gate, a user whose explicit `theme=dark` disagrees with their OS would see the seed fire before the provider corrects `resolvedTheme`, silently producing a light deck.

## Test plan

- [x] `pnpm verify:fast` (lint + 902 unit tests including 3 new ones in `tests/app/slides/yorkie-slides-store.test.ts` covering light seed / dark seed / migration safety)
- [x] Manual smoke (light mode): create a new Presentation → verify it opens with `defaultLight` (white canvas)
- [x] Manual smoke (dark mode): toggle dark mode → create a new Presentation → verify it opens with `defaultDark`
- [x] Manual smoke (existing deck): open an existing Presentation in dark mode → verify its theme is unchanged
- [x] Manual smoke (mobile): create a new Presentation on mobile in dark mode → verify dark seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)