### PR TITLE
Slides: fix grouped connector render + rotate-tooltip drift/flicker

### DIFF
--- a/docs/tasks/active/20260612-slides-grouped-connector-render-todo.md
+++ b/docs/tasks/active/20260612-slides-grouped-connector-render-todo.md
@@ -1,0 +1,205 @@
+# Slides: render attached connectors correctly inside a group
+
+**Owner:** @hackerwins
+**Date:** 2026-06-12
+
+## Why
+
+When the user selects two shapes plus the `Line` connector that joins
+them and runs `Group` (`Cmd/Ctrl + Alt + G`), the line jumps to a
+visibly wrong position on the slide. Both shapes still render at the
+same on-screen location; only the line is offset by roughly the
+group's `(x, y)` (plus the group's rotation/scale if any).
+
+Reproduced from a shared deck at
+`http://localhost:5173/shared/6f9bc4c8-3dbd-48a8-bb88-b6044ad1529b`.
+
+Root cause is a contract collision between the store and the
+renderer:
+
+1. `MemSlidesStore.group()` keeps a connector as a child of the new
+   `GroupElement` when both endpoints reference elements that are
+   themselves joining the group
+   (`packages/slides/src/store/memory.ts:684-708`, partition added by
+   PR #263). Children's frames are stored in **group-local**
+   coordinates.
+
+2. `slide-renderer.ts` builds an element lookup with
+   `buildElementWorldLookup(slide.elements)`
+   (`packages/slides/src/view/canvas/slide-renderer.ts:201`). For
+   elements inside a group, that helper lifts each child's frame into
+   **world** space via `applyMatrix(child.frame, accum)`
+   (`packages/slides/src/model/group.ts:411-465`). PR #320 introduced
+   this so connectors from outside a group could correctly target
+   grouped shapes.
+
+3. `drawElement` for a `GroupElement` applies the group's transform to
+   `ctx` (`packages/slides/src/view/canvas/element-renderer.ts:118-136`)
+   and then recurses into children
+   (`element-renderer.ts:150-152`). Shape / text / image children
+   apply their **local** frame on top of that ctx transform, so they
+   end up in the correct world position.
+
+4. **Connector children take an early return** at
+   `element-renderer.ts:80-85`: they skip the per-element frame
+   transform and call `drawConnector` directly. `drawConnector` reads
+   its endpoint positions from the world-lookup (so they arrive in
+   slide-world coordinates) and calls `ctx.moveTo/lineTo` with those
+   coordinates (`connector-renderer.ts:15-17`, `36-43`). But the ctx
+   is **still in the group's transformed space** from step 3.
+
+   Net effect: the group transform is applied a second time on top of
+   already-world endpoints. The line moves by the group's translation
+   (plus any rotation / scale).
+
+Free endpoints inside grouped connectors don't trigger the user-visible
+bug because they are normalised to group-local in `group()`
+(`memory.ts:787-799`) and `drawConnector` then draws them under the
+group's ctx transform, which moves them back to world. They render
+correctly **only by accident** — undoing the parent transform (the
+attached-endpoint fix) would break them unless the renderer also picks
+up the world-coord version of the connector that
+`buildElementWorldLookup` already exposes (it lifts `free` endpoints
+to world inside its `walkWorld` connector branch, group.ts:441-460).
+So the fix is unified: undo the parent transform, hand `drawConnector`
+the lookup's view of the connector, and both endpoint kinds agree on
+slide-world coords.
+
+The stale "NOTE" at `element-renderer.ts:146-149` ("In v1, group()
+never includes connectors as children") still encodes the original
+invariant from before PR #263 wired connector partitioning in. The
+store and the renderer disagree.
+
+Test gap: `packages/slides/test/store/group-mutations.test.ts:336-377`
+only checks that the connector becomes a child; nothing asserts the
+rendered geometry. `slide-renderer.test.ts` has no group + connector
+case.
+
+## Scope
+
+- `drawElement` learns the cumulative parent-group transform (chain of
+  `groupToTransform`s from slide root down to the current parent).
+- When the child is a connector and the parent transform is not
+  identity, swap the connector for the lookup's view (free endpoints
+  lifted to world), save the ctx, multiply by the inverse of the
+  parent transform so the ctx returns to slide-world, draw, then
+  restore.
+- `drawSlide` (slide-renderer.ts) does not need to change — the
+  default arg on `drawElement` already feeds `IDENTITY_GROUP_TRANSFORM`
+  to top-level calls.
+- Replace the stale "group() never includes connectors" NOTE with a
+  short note describing the new transform-reset path.
+- Add unit tests in `slide-renderer.test.ts`:
+  - Attached: assert `ctx.transform` runs before `moveTo` with the
+    expected inverse coefficients.
+  - Free: assert the `moveTo` / `lineTo` arguments match the pre-group
+    world coords (the swap to the lookup version is what makes this
+    hold).
+
+Out of scope:
+
+- The connector's cached `frame` (`connector-frame.ts:103`) is still
+  a world-bbox after grouping. It is only used as a hit-test /
+  selection bbox; fixing that is a separate cleanup.
+- Connectors with `free` endpoints inside groups already render
+  correctly; no behavioral change for them.
+
+## Bundled fix: rotation tooltip offset
+
+While testing the grouped-connector fix, a separate pre-existing bug
+surfaced: the `'45°'` tooltip that floats next to the cursor during a
+rotate drag is drawn `(slideOffsetCssX, slideOffsetCssY)` to the top-
+left of where the cursor actually is.
+
+Root cause:
+
+- `acquireRotateTooltip` in `editor.ts:5145-5149` appends the tooltip
+  to `overlay.parentElement` (= `canvasWrap` in the slides-view) so
+  `renderOverlay`'s `innerHTML` reset can't wipe it mid-drag.
+- `showTooltip` in `editor.ts:5049-5063` then computes the tooltip
+  position against `overlay.getBoundingClientRect()` — the WRONG
+  reference frame for an element parented to `canvasWrap`.
+- This was harmless until PR #353 (variable pasteboard) gave the
+  overlay a non-zero `left/top` relative to its parent so off-slide
+  shapes could stay paint-/selectable. After #353 the two
+  containers' origins differ by exactly the pasteboard offset, which
+  is the visible miss distance.
+
+Not a regression of this PR — `element-renderer.ts` doesn't touch any
+overlay/tooltip code. But the user requested it be bundled here.
+
+Fix (`editor.ts:5049-5054`): cache the tooltip's actual parent once,
+and compute `localX/Y` against the parent rect. One-line containment
+change; no other call sites of the tooltip are affected.
+
+Regression test (`editor.test.ts`, new `describe('rotate — angle
+tooltip positioning')`): stand up `wrap > canvas + overlay` with the
+overlay's `getBoundingClientRect` stubbed to a non-zero origin,
+dispatch a real `pointerdown` on the rotate handle + `pointermove`
+on the document, and assert the tooltip's `style.transform` encodes
+client-coord-relative offsets (parent-frame), not overlay-relative
+ones.
+
+## Bundled fix: rotate tooltip flicker on re-acquire
+
+After the first rotate completed, the next pointerdown on the rotate
+handle visibly flickered the tooltip at the previous drag's last
+position before snapping to the new click.
+
+Root cause:
+
+- `acquireRotateTooltip` (`editor.ts:5135-5139`) re-used the existing
+  element and flipped `display: block` immediately.
+- `transform` was last written by `showTooltip` at the previous
+  drag's terminal pointermove and was never reset.
+- `startRotate` only set `transform` in the FIRST pointermove of the
+  new drag — one paint frame later. The intermediate frame painted
+  the stale position.
+
+Fix:
+
+- `acquireRotateTooltip` (`editor.ts:5135-5147`) returns the cached
+  element AS-IS, leaving `display: none`.
+- `startRotate` (`editor.ts:5083`) calls
+  `showTooltip(clientX, clientY, 0)` immediately after defining it,
+  so `transform` and `display: block` are written together on the
+  pointerdown frame.
+
+Regression test: complete one rotate cycle (pointerdown → pointermove
+at (400, 200) → pointerup) so the tooltip carries
+`translate(414px, 214px)`; dispatch a second pointerdown on the
+rotate handle WITHOUT any pointermove; assert the tooltip's
+`transform` now matches the new pointerdown coords + 14, not the
+stale (414, 214) value, and `display === 'block'`. Pre-fix this
+fails on the transform check; post-fix it passes.
+
+## Plan
+
+- [ ] `packages/slides/src/view/canvas/element-renderer.ts` — extend
+      `drawElement` signature with `parentTransform: GroupTransform`
+      (defaulting to `IDENTITY_GROUP_TRANSFORM`). In the group branch,
+      compose with `groupToTransform(group)` and pass to the recursive
+      calls. In the connector branch, if `parentTransform` is not
+      identity, save / invert via the existing `applyInverseMatrix`
+      math (point form already lives in `applyInversePoint`; we need
+      the 6-number matrix form for `ctx.transform`) and apply.
+- [ ] `packages/slides/src/view/canvas/slide-renderer.ts` — pass
+      `IDENTITY_GROUP_TRANSFORM` at the top-level loop call.
+- [ ] `packages/slides/test/view/canvas/slide-renderer.test.ts` — new
+      test "draws a connector inside a group at the same world
+      coords as it did before grouping". Uses two rects and an
+      attached connector. Records `moveTo` / `lineTo` calls into the
+      existing 2D-context stub before and after `store.group()`.
+- [ ] `packages/slides/src/view/canvas/element-renderer.ts` — replace
+      the stale `// NOTE: Connectors inside groups are painted in
+      raw ctx space …` comment.
+- [ ] `pnpm verify:fast` green.
+
+## Verification
+
+- `pnpm --filter @wafflebase/slides test` — new regression test +
+  existing suite passes.
+- `pnpm verify:fast` — lint + unit tests across the monorepo.
+- Manual smoke (deferred to the next session): open the shared deck,
+  group the two shapes + line, confirm the line stays anchored to the
+  shapes.

--- a/docs/tasks/active/20260612-slides-grouped-connector-render-todo.md
+++ b/docs/tasks/active/20260612-slides-grouped-connector-render-todo.md
@@ -203,3 +203,64 @@ fails on the transform check; post-fix it passes.
 - Manual smoke (deferred to the next session): open the shared deck,
   group the two shapes + line, confirm the line stays anchored to the
   shapes.
+
+## Code review follow-ups
+
+Pre-push review surfaced one blocking concern (fixed) and several
+latent/style items (recorded, deferred).
+
+**Fixed before push.**
+
+- `invertGroupTransform` no longer throws on singular matrices
+  (`element-renderer.ts:268-290`). Pre-fix, a degenerate group
+  (frame.w or h = 0, or PPTX-imported `refSize` orders of magnitude
+  larger than `frame`) yielded `det ≈ 0` and the
+  `throw new Error(...)` escaped through `drawElement`'s
+  `try/finally` into `drawSlide`'s top-level element loop, blanking
+  every subsequent element on the slide. Now it returns `null` and
+  the connector branch skips that connector's paint. The user still
+  sees the broken group's shape children, which is where their
+  attention belongs.
+
+**Deferred (non-blocking).**
+
+- **Flip blindness in `groupToTransform`** — already named above. A
+  flipped group ancestor leaves residual mirror in the inverse;
+  `walkWorld` has the same blind spot. The right depth is a shared
+  `elementCtxTransform(frame, refSize)` helper that both
+  `groupToTransform` and the renderer consume.
+- **Reference-equality identity check** (`element-renderer.ts:99`).
+  `composeGroupMatrix` always allocates fresh, so any group
+  recursion enters the inverse branch even when the composed matrix
+  is numerically identity. Functionally a no-op. Future cleanup:
+  structural check `isIdentityGroupTransform(t)`, or drop the gate
+  and always run inverse.
+- **Ghost connector inside group ghost** (`element-renderer.ts:100`).
+  `elementsLookup` is built from the committed slide tree; current
+  ghost paths produce top-level connector ghosts only (safe `else`
+  branch). A future grouped ghost tree with a connector child
+  would hit the inverse path with a lookup miss and fall back to
+  group-local endpoints. Future fix: transient lookup over the
+  ghost tree.
+- **`tooltipContainer` cached once at startRotate**
+  (`editor.ts:5063`). If the parent re-mounts mid-drag (mobile
+  branch swap, devtools open), the cached reference goes stale.
+  Future fix: re-resolve inside `showTooltip` each call, or assert
+  `isConnected`.
+- **`overlay.parentElement` null fallback in acquireRotateTooltip**
+  (`editor.ts:5155`). Appends the tooltip inside overlay when the
+  parent is missing, which then gets wiped by
+  `renderOverlay`'s `innerHTML = ''`. Not exercised by current
+  hosts. Future fix: fall back to `document.body` or assert on
+  initialize.
+- **`as typeof element` cast on lookup result**. Today's invariant
+  holds; tomorrow's `walkWorld` change could break it without a TS
+  error. Future cleanup: narrow with `worldEl.type === 'connector'
+  ? worldEl : element`.
+- **Three copies of the affine inverse math** (`element-renderer.ts`
+  `invertGroupTransform`, `model/group.ts` `applyInverseMatrix` /
+  `applyInversePoint`). Future cleanup: export a 6-coef inverse
+  from `model/group.ts` and consume from all three sites.
+- **Acquire-then-show invariant unannotated** (`editor.ts:5135`).
+  Future cleanup: rename to `acquireHiddenRotateTooltip` or warn
+  when `releaseRotateTooltip` runs on a still-hidden element.

--- a/packages/slides/src/view/canvas/ctx-spy.ts
+++ b/packages/slides/src/view/canvas/ctx-spy.ts
@@ -34,6 +34,7 @@ export interface CtxSpy {
   rotate: SpyFn;
   scale: SpyFn;
   setTransform: SpyFn;
+  transform: SpyFn;
 
   // paths
   beginPath: SpyFn;
@@ -81,6 +82,7 @@ export function createCtxSpy(): CtxSpy {
     rotate: vi.fn(),
     scale: vi.fn(),
     setTransform: vi.fn(),
+    transform: vi.fn(),
 
     beginPath: vi.fn(),
     closePath: vi.fn(),

--- a/packages/slides/src/view/canvas/element-renderer.ts
+++ b/packages/slides/src/view/canvas/element-renderer.ts
@@ -4,6 +4,12 @@ import { placeholderHintFor } from '../../model/placeholder-hints';
 import type { SlidesDocument } from '../../model/presentation';
 import { deckFontScale } from '../../model/presentation';
 import type { Theme } from '../../model/theme';
+import {
+  IDENTITY_GROUP_TRANSFORM,
+  composeGroupMatrix,
+  groupToTransform,
+  type GroupTransform,
+} from '../../model/group';
 import { drawConnector } from './connector-renderer';
 import { drawShape, paintShapeText } from './shape-renderer';
 import { drawTable } from './table-renderer';
@@ -76,11 +82,34 @@ export function drawElement(
   onAssetLoad: () => void,
   elementsLookup: ReadonlyMap<string, Element> = EMPTY_LOOKUP,
   parentFlip: FlipState = NO_FLIP,
+  parentTransform: GroupTransform = IDENTITY_GROUP_TRANSFORM,
 ): void {
   // Connectors paint directly in world coordinates and need a lookup map
   // to resolve attached endpoints — skip the per-element frame transform.
   if (element.type === 'connector') {
-    drawConnector(ctx, element, elementsLookup, theme);
+    // Inside a group the ctx already has the group's transform applied
+    // and the connector's own `start.x/y` / `end.x/y` for free endpoints
+    // are stored in group-local space (store.group() normalises them).
+    // `buildElementWorldLookup` re-lifts those free endpoints into world
+    // space, and attached endpoints always resolve through the lookup
+    // against world frames — so the lookup's connector is the single
+    // source of truth for "world-coordinate endpoints".
+    //
+    // We undo the parent-group transform so the ctx is back at
+    // slide-world, then hand drawConnector the lookup's view of the
+    // connector. Both endpoint kinds now agree on world coords; the
+    // bug where attached endpoints drifted by the group's translation
+    // (and free endpoints stayed correct only by coincidence) is gone.
+    if (parentTransform !== IDENTITY_GROUP_TRANSFORM) {
+      const worldEl = (elementsLookup.get(element.id) ?? element) as typeof element;
+      ctx.save();
+      const inv = invertGroupTransform(parentTransform);
+      ctx.transform(inv.a, inv.b, inv.c, inv.d, inv.tx, inv.ty);
+      drawConnector(ctx, worldEl, elementsLookup, theme);
+      ctx.restore();
+    } else {
+      drawConnector(ctx, element, elementsLookup, theme);
+    }
     return;
   }
 
@@ -143,12 +172,18 @@ export function drawElement(
       // the group's own frame transform places them correctly in world
       // space. Arbitrary nesting depth is handled by recursion.
       //
-      // NOTE: Connectors inside groups are painted in raw ctx space
-      // (drawConnector returns before the frame transform is applied).
-      // In v1, group() never includes connectors as children (Task 11
-      // invariant), so this is safe. A TODO remains for v2+ support.
+      // Connector children take the early return at the top of
+      // drawElement and use `childTransform` to undo this ctx layer
+      // before painting in world coords — see the connector branch above.
+      const childTransform = composeGroupMatrix(
+        parentTransform,
+        groupToTransform(element),
+      );
       for (const child of element.data.children) {
-        drawElement(ctx, child, doc, theme, onAssetLoad, elementsLookup, totalFlip);
+        drawElement(
+          ctx, child, doc, theme, onAssetLoad,
+          elementsLookup, totalFlip, childTransform,
+        );
       }
     } else {
       // Resolved per-deck so PPTX decks authored at a non-default
@@ -228,4 +263,29 @@ export function drawElement(
   // text renderer to a colorResolver that closes over the deck's
   // resolved palette.
   void doc;
+}
+
+/**
+ * Affine inverse of a GroupTransform in the 6-coefficient form
+ * `ctx.transform` consumes. Used to undo the cumulative parent-group
+ * transform before drawing a grouped connector in world coords.
+ *
+ * The math matches `applyInverseMatrix` in model/group.ts but returns
+ * the raw a/b/c/d/tx/ty fields needed by the canvas API.
+ */
+function invertGroupTransform(t: GroupTransform): {
+  a: number; b: number; c: number; d: number; tx: number; ty: number;
+} {
+  const det = t.a * t.d - t.b * t.c;
+  if (Math.abs(det) < 1e-9) {
+    throw new Error('[slides] cannot invert singular group transform (group frame must have non-zero w and h)');
+  }
+  return {
+    a:  t.d / det,
+    b: -t.b / det,
+    c: -t.c / det,
+    d:  t.a / det,
+    tx: -(t.d * t.tx - t.c * t.ty) / det,
+    ty:  (t.b * t.tx - t.a * t.ty) / det,
+  };
 }

--- a/packages/slides/src/view/canvas/element-renderer.ts
+++ b/packages/slides/src/view/canvas/element-renderer.ts
@@ -101,9 +101,13 @@ export function drawElement(
     // bug where attached endpoints drifted by the group's translation
     // (and free endpoints stayed correct only by coincidence) is gone.
     if (parentTransform !== IDENTITY_GROUP_TRANSFORM) {
+      const inv = invertGroupTransform(parentTransform);
+      // Singular parent transform — group has zero width or height. Skip
+      // the connector rather than crashing the slide; the broken group
+      // is visible on its own.
+      if (inv === null) return;
       const worldEl = (elementsLookup.get(element.id) ?? element) as typeof element;
       ctx.save();
-      const inv = invertGroupTransform(parentTransform);
       ctx.transform(inv.a, inv.b, inv.c, inv.d, inv.tx, inv.ty);
       drawConnector(ctx, worldEl, elementsLookup, theme);
       ctx.restore();
@@ -272,14 +276,20 @@ export function drawElement(
  *
  * The math matches `applyInverseMatrix` in model/group.ts but returns
  * the raw a/b/c/d/tx/ty fields needed by the canvas API.
+ *
+ * Returns `null` instead of throwing when the matrix is singular
+ * (det ≈ 0) — this lives in the render hot path and a throw inside
+ * `drawConnector` would escape `drawElement`'s try/finally and abort
+ * the rest of `drawSlide`'s element loop, blanking the slide. A
+ * degenerate group should drop the connector silently and let the
+ * rest of the slide paint; the offending group has bigger problems
+ * the user can see and fix separately.
  */
 function invertGroupTransform(t: GroupTransform): {
   a: number; b: number; c: number; d: number; tx: number; ty: number;
-} {
+} | null {
   const det = t.a * t.d - t.b * t.c;
-  if (Math.abs(det) < 1e-9) {
-    throw new Error('[slides] cannot invert singular group transform (group frame must have non-zero w and h)');
-  }
+  if (Math.abs(det) < 1e-9) return null;
   return {
     a:  t.d / det,
     b: -t.b / det,

--- a/packages/slides/src/view/canvas/test-canvas-env.ts
+++ b/packages/slides/src/view/canvas/test-canvas-env.ts
@@ -66,6 +66,7 @@ function makeFakeCanvasCtx(): unknown {
     rotate: noop,
     scale: noop,
     setTransform: noop,
+    transform: noop,
 
     beginPath: noop,
     closePath: noop,

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -5047,10 +5047,23 @@ class SlidesEditorImpl implements SlidesEditor {
     };
 
     const tooltip = this.acquireRotateTooltip();
+    // The tooltip is appended to overlay.parentElement (see
+    // `acquireRotateTooltip`) so `renderOverlay`'s innerHTML reset
+    // doesn't wipe it mid-drag. That means `tooltip.style.transform`
+    // is interpreted in the PARENT's containing block — not the
+    // overlay's. When the slides-view installs a pasteboard, the
+    // overlay lives inside `canvasWrap` at `(slideOffsetCssX,
+    // slideOffsetCssY)`, so basing the coords on the overlay's rect
+    // would translate the tooltip by that offset relative to where
+    // the mouse actually is. Measure against the parent rect instead.
+    const tooltipContainer = tooltip.parentElement ?? this.options.overlay;
     const showTooltip = (clientPx: number, clientPy: number, delta: number) => {
-      const rect = this.options.overlay.getBoundingClientRect();
+      const rect = tooltipContainer.getBoundingClientRect();
       const localX = clientPx - rect.left;
       const localY = clientPy - rect.top;
+      // `transform` first, then `display: block` — same paint frame
+      // so the tooltip never lands at a stale position; see
+      // `acquireRotateTooltip` for context.
       // Show absolute rotation for single-element (matches Google Slides),
       // delta for multi (since the selection had no group rotation).
       const display = isMulti
@@ -5062,6 +5075,12 @@ class SlidesEditorImpl implements SlidesEditor {
       tooltip.style.transform = `translate(${localX + 14}px, ${localY + 14}px)`;
       tooltip.style.display = 'block';
     };
+    // Paint the tooltip at the click position immediately so the user
+    // gets a 0° reading next to the cursor without waiting for the
+    // first pointermove. acquireRotateTooltip keeps the element hidden
+    // until this call, so this is also the only place `display: block`
+    // gets set on a re-acquired element — no stale-transform flicker.
+    showTooltip(clientX, clientY, 0);
 
     const onMove = (ev: MouseEvent) => {
       const cur = this.clientToLogical(ev.clientX, ev.clientY);
@@ -5123,10 +5142,13 @@ class SlidesEditorImpl implements SlidesEditor {
    */
   private rotateTooltipEl: HTMLDivElement | null = null;
   private acquireRotateTooltip(): HTMLDivElement {
-    if (this.rotateTooltipEl) {
-      this.rotateTooltipEl.style.display = 'block';
-      return this.rotateTooltipEl;
-    }
+    // Hand back the existing element as-is (still `display: none`) so
+    // the caller can set the live `transform` and the visible `display`
+    // together in one paint frame. Flipping `display: block` here would
+    // paint the previous drag's last `transform` for one frame, which
+    // shows up as a flicker at the old position before the first
+    // `pointermove` reaches `showTooltip`.
+    if (this.rotateTooltipEl) return this.rotateTooltipEl;
     const el = document.createElement('div');
     el.className = 'wfb-slides-rotate-tooltip';
     el.style.position = 'absolute';

--- a/packages/slides/test/view/canvas/slide-renderer.test.ts
+++ b/packages/slides/test/view/canvas/slide-renderer.test.ts
@@ -454,4 +454,72 @@ describe('drawSlide — grouped connector', () => {
     expect(postEnd[0]).toBeCloseTo(preEnd[0], 6);
     expect(postEnd[1]).toBeCloseTo(preEnd[1], 6);
   });
+
+  it('skips a grouped connector when its parent transform is singular and keeps painting the rest of the slide', () => {
+    // Hand-roll a slide with a zero-width group so the connector
+    // branch hits a singular parentTransform — store.group() clamps
+    // groups to MIN_GROUP_DIM = 1, but a degenerate PPTX import or
+    // external mutation can still leak w=0 or h=0 with refSize > 0.
+    // Pre-fix this threw out of invertGroupTransform; the throw
+    // escaped drawElement's try/finally and aborted drawSlide's
+    // element loop, blanking every subsequent element. Now the
+    // connector is silently skipped and the rest of the slide
+    // continues to paint.
+    const a: Element = {
+      id: 'sing-a', type: 'shape',
+      frame: { x: 0, y: 0, w: 50, h: 50, rotation: 0 },
+      data: { kind: 'rect', fill: { kind: 'srgb', value: '#a00' } },
+    };
+    const b: Element = {
+      id: 'sing-b', type: 'shape',
+      frame: { x: 100, y: 0, w: 50, h: 50, rotation: 0 },
+      data: { kind: 'rect', fill: { kind: 'srgb', value: '#0a0' } },
+    };
+    const c: Element = {
+      id: 'sing-c', type: 'connector',
+      routing: 'straight',
+      start: { kind: 'attached', elementId: 'sing-a', siteIndex: 0 },
+      end:   { kind: 'attached', elementId: 'sing-b', siteIndex: 0 },
+      arrowheads: {},
+      frame: { x: 0, y: 0, w: 0, h: 0, rotation: 0 },
+    };
+    const group: Element = {
+      id: 'sing-g', type: 'group',
+      // w = 0 with refSize.w > 0 forces scaleX = 0 → det = 0 in the
+      // composed parent transform inside the connector child branch.
+      frame: { x: 50, y: 50, w: 0, h: 50, rotation: 0 },
+      data: { children: [a, b, c], refSize: { w: 200, h: 100 } },
+    };
+    const trailing: Element = {
+      id: 'sing-trailing', type: 'shape',
+      frame: { x: 500, y: 500, w: 50, h: 50, rotation: 0 },
+      data: { kind: 'rect', fill: { kind: 'srgb', value: '#0aa' } },
+    };
+
+    const slide: Slide = {
+      id: 'sing-slide', layoutId: 'blank',
+      background: { ...DEFAULT_BACKGROUND, fill: { kind: 'srgb', value: '#fff' } },
+      elements: [group, trailing], notes: [],
+    };
+
+    const ctx = createCtxSpy();
+    const opts = { hostWidth: SLIDE_WIDTH, hostHeight: SLIDE_HEIGHT, dpr: 1 };
+
+    expect(() => drawSlide(asCtx(ctx), slide, DOC, opts)).not.toThrow();
+
+    // Trailing shape sits after the broken group in slide.elements.
+    // Pre-fix, the connector's throw would short-circuit drawSlide's
+    // for-loop before the trailing rect's `ctx.fill` ever fired. The
+    // group's child rects (a, b) also call `ctx.fill` even under a
+    // zero-scale ctx transform, so the easiest tell is the call count:
+    // a + b + trailing = 3 fills with the fix, 2 without.
+    expect(ctx.fill.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+    // The connector itself must NOT have emitted any path commands —
+    // drawConnector is the only caller of `ctx.moveTo`/`ctx.lineTo`
+    // in this fixture, so zero calls confirms the singular branch
+    // dropped the paint.
+    expect(ctx.moveTo).not.toHaveBeenCalled();
+    expect(ctx.lineTo).not.toHaveBeenCalled();
+  });
 });

--- a/packages/slides/test/view/canvas/slide-renderer.test.ts
+++ b/packages/slides/test/view/canvas/slide-renderer.test.ts
@@ -325,3 +325,133 @@ describe('drawSlide ghosts', () => {
     expect(omitted.restore.mock.calls.length).toBe(empty.restore.mock.calls.length);
   });
 });
+
+describe('drawSlide — grouped connector', () => {
+  it('undoes the group transform before painting an attached connector child so the world-coord contract holds', () => {
+    // Two rects + an attached connector between them on the slide root.
+    // After grouping all three, the connector becomes a group child but
+    // still resolves its endpoints via the slide-world lookup
+    // (`buildElementWorldLookup` lifts grouped frames to world). The
+    // ctx is in the group's transformed space at the moment we recurse
+    // into the connector child, so the renderer must apply the inverse
+    // before calling drawConnector — otherwise the line drifts by the
+    // group's translation.
+    const store = new MemSlidesStore();
+    let sid = '';
+    let a = '', b = '', c = '';
+    store.batch(() => { sid = store.addSlide('blank', 0); });
+    store.batch(() => {
+      a = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 200, w: 80, h: 60, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#a00' } },
+      });
+      b = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 600, y: 500, w: 80, h: 60, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#0a0' } },
+      });
+      c = store.addElement(sid, {
+        type: 'connector',
+        routing: 'straight',
+        start: { kind: 'attached', elementId: a, siteIndex: 0 },
+        end:   { kind: 'attached', elementId: b, siteIndex: 0 },
+        arrowheads: {},
+        frame: { x: 0, y: 0, w: 0, h: 0, rotation: 0 },
+      });
+    });
+
+    const opts = { hostWidth: SLIDE_WIDTH, hostHeight: SLIDE_HEIGHT, dpr: 1 };
+
+    // Pre-group baseline: connector is at slide root, no group ancestor.
+    // drawElement's connector early-return takes the identity-parent
+    // branch and never calls ctx.transform.
+    const pre = createCtxSpy();
+    drawSlide(asCtx(pre), store.read().slides[0], store.read(), opts);
+    expect(pre.transform).not.toHaveBeenCalled();
+
+    // Group all three. The connector joins the group's children (both
+    // endpoints internal → see store/memory.ts partition).
+    store.batch(() => { store.group(sid, [a, b, c]); });
+    const grouped = store.read().slides[0].elements[0];
+    expect(grouped.type).toBe('group');
+    const groupFrame = grouped.frame;
+
+    // Post-group: rendering the grouped connector applies the inverse
+    // of the group's transform via `ctx.transform`. With no rotation
+    // and `refSize == frame.w/h`, the group's matrix is just
+    // translate(x, y); the inverse is translate(-x, -y).
+    // `expect.closeTo(0)` absorbs the `-0` that `-t.b / det` produces
+    // for the b/c slots when t.b / t.c are zero.
+    const post = createCtxSpy();
+    drawSlide(asCtx(post), store.read().slides[0], store.read(), opts);
+    expect(post.transform).toHaveBeenCalledWith(
+      1,
+      expect.closeTo(0),
+      expect.closeTo(0),
+      1,
+      -groupFrame.x,
+      -groupFrame.y,
+    );
+
+    // The save/transform/restore bracket sits around drawConnector, so
+    // a save lands before moveTo and a restore lands after stroke.
+    const transformOrder = post.transform.mock.invocationCallOrder[0];
+    const moveToOrder = post.moveTo.mock.invocationCallOrder[0];
+    expect(transformOrder).toBeLessThan(moveToOrder);
+  });
+
+  it('draws a grouped free-endpoint connector at the same world coords as before grouping', () => {
+    // Two shapes + a connector with both endpoints `free` (not attached
+    // to either shape). store.group() normalises the free endpoint
+    // coords to group-local, and `buildElementWorldLookup` re-lifts
+    // them. The renderer must consult the lookup version so free
+    // endpoints — like attached ones — paint at slide-world coords.
+    const store = new MemSlidesStore();
+    let sid = '';
+    let a = '', b = '', c = '';
+    store.batch(() => { sid = store.addSlide('blank', 0); });
+    store.batch(() => {
+      a = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 200, w: 80, h: 60, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#a00' } },
+      });
+      b = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 600, y: 500, w: 80, h: 60, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#0a0' } },
+      });
+      c = store.addElement(sid, {
+        type: 'connector',
+        routing: 'straight',
+        start: { kind: 'free', x: 200, y: 250 },
+        end:   { kind: 'free', x: 600, y: 550 },
+        arrowheads: {},
+        frame: { x: 0, y: 0, w: 0, h: 0, rotation: 0 },
+      });
+    });
+
+    const opts = { hostWidth: SLIDE_WIDTH, hostHeight: SLIDE_HEIGHT, dpr: 1 };
+
+    const pre = createCtxSpy();
+    drawSlide(asCtx(pre), store.read().slides[0], store.read(), opts);
+    const preStart = pre.moveTo.mock.calls[0] as [number, number];
+    const preEnd = pre.lineTo.mock.calls[pre.lineTo.mock.calls.length - 1] as [number, number];
+
+    store.batch(() => { store.group(sid, [a, b, c]); });
+
+    const post = createCtxSpy();
+    drawSlide(asCtx(post), store.read().slides[0], store.read(), opts);
+    const postStart = post.moveTo.mock.calls[0] as [number, number];
+    const postEnd = post.lineTo.mock.calls[post.lineTo.mock.calls.length - 1] as [number, number];
+
+    // The raw arguments to moveTo / lineTo should be the same world
+    // coords; the ctx transform stack inside drawElement absorbs the
+    // group transform via the inverse save/restore band.
+    expect(postStart[0]).toBeCloseTo(preStart[0], 6);
+    expect(postStart[1]).toBeCloseTo(preStart[1], 6);
+    expect(postEnd[0]).toBeCloseTo(preEnd[0], 6);
+    expect(postEnd[1]).toBeCloseTo(preEnd[1], 6);
+  });
+});

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -2762,3 +2762,241 @@ describe('Editor — bodyHost click deselect', () => {
     expect(editor.getSelection()).toEqual([elementId]);
   });
 });
+
+describe('rotate — angle tooltip positioning', () => {
+  let editor: SlidesEditor | null = null;
+  afterEach(() => {
+    if (editor) { editor.detach(); editor = null; }
+    document.body.innerHTML = '';
+  });
+
+  // jsdom returns zeros for `getBoundingClientRect`. The tooltip lives
+  // in `overlay.parentElement`, so its `style.transform` translate is
+  // interpreted relative to the parent. When the slides-view installs
+  // a pasteboard, overlay sits offset inside canvasWrap; computing the
+  // tooltip position against the overlay's rect would drift the
+  // tooltip by that offset. This test exposes the mismatch by giving
+  // the overlay a non-zero `getBoundingClientRect` while leaving the
+  // parent at the origin, then asserting the tooltip's translate equals
+  // the raw client-coord position (the parent-frame coords), not the
+  // overlay-relative coords.
+  it('positions the angle tooltip in the parent (canvasWrap) frame, not the offset overlay frame', () => {
+    const wrap = document.createElement('div');
+    wrap.style.position = 'relative';
+    document.body.appendChild(wrap);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 960;
+    canvas.height = 540;
+    wrap.appendChild(canvas);
+
+    const overlay = document.createElement('div');
+    overlay.style.position = 'absolute';
+    // Mimic the slides-view: overlay sits at (slideOffsetCssX, Y) inside wrap.
+    const OVERLAY_OFFSET_X = 50;
+    const OVERLAY_OFFSET_Y = 30;
+    overlay.style.left = `${OVERLAY_OFFSET_X}px`;
+    overlay.style.top  = `${OVERLAY_OFFSET_Y}px`;
+    wrap.appendChild(overlay);
+
+    // jsdom doesn't reflect the inline left/top into getBoundingClientRect.
+    // Stub it so the editor's overlay-rect math sees the offset.
+    overlay.getBoundingClientRect = (): DOMRect => ({
+      x: OVERLAY_OFFSET_X, y: OVERLAY_OFFSET_Y,
+      left: OVERLAY_OFFSET_X, top: OVERLAY_OFFSET_Y,
+      right: OVERLAY_OFFSET_X + 960, bottom: OVERLAY_OFFSET_Y + 540,
+      width: 960, height: 540,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const store = new MemSlidesStore();
+    store.batch(() => store.addSlide('blank'));
+    let shapeId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      shapeId = store.addElement(sid, {
+        type: 'shape',
+        // Sized so the rotate handle ends up at a known overlay-local
+        // position. Frame at (100, 50, 200, 100) → axis-aligned rotate
+        // handle at (left + width/2, top - 24) = (200, 26) in overlay
+        // CSS px (host scale = 1: hostWidth=960, dpr=1, SLIDE_WIDTH=1920
+        // → scale = 0.5, so this rotate handle lands at (100, 1) in
+        // overlay px — but with hostWidth=1920 it's (200, 26)).
+        frame: { x: 100, y: 50, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+    });
+    editor.setSelection([shapeId]);
+
+    // Find the rotate handle the editor just painted. Its CSS left/top
+    // (minus HANDLE_SIZE/2 = 4) gives the handle's centre in overlay
+    // CSS px. Convert to client coords by adding the overlay offset.
+    const rotateHandle = overlay.querySelector<HTMLDivElement>(
+      '[data-handle="rotate"]',
+    );
+    expect(rotateHandle).not.toBeNull();
+    const handleLeft = parseFloat(rotateHandle!.style.left);
+    const handleTop  = parseFloat(rotateHandle!.style.top);
+    const handleCxOverlay = handleLeft + 4;
+    const handleCyOverlay = handleTop + 4;
+    const rotateClientX = handleCxOverlay + OVERLAY_OFFSET_X;
+    const rotateClientY = handleCyOverlay + OVERLAY_OFFSET_Y;
+
+    // pointerdown on the overlay at the rotate handle's client coords —
+    // routes through onPointerDown → handleAtClient → startRotate.
+    overlay.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: rotateClientX, clientY: rotateClientY, bubbles: true,
+    }));
+
+    // pointermove on document drives `showTooltip`. Pick a target
+    // somewhere clearly off the handle so the tooltip transform is
+    // a non-trivial number we can inspect.
+    const MOVE_CLIENT_X = 400;
+    const MOVE_CLIENT_Y = 200;
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: MOVE_CLIENT_X, clientY: MOVE_CLIENT_Y, bubbles: true,
+    }));
+
+    // The tooltip lives outside the overlay, in `overlay.parentElement`
+    // (= wrap), so renderOverlay's innerHTML reset doesn't wipe it.
+    // Its `style.transform` is interpreted in wrap's frame; we want it
+    // to encode (clientX + 14, clientY + 14) since wrap sits at
+    // (0, 0) in jsdom's default rect. Pre-fix this would be
+    // (clientX - OVERLAY_OFFSET_X + 14, clientY - OVERLAY_OFFSET_Y + 14).
+    const tooltip = document.querySelector<HTMLDivElement>(
+      '.wfb-slides-rotate-tooltip',
+    );
+    expect(tooltip).not.toBeNull();
+    const transform = tooltip!.style.transform;
+    // Match `translate(<x>px, <y>px)` and parse out the two numbers.
+    const m = /^translate\((-?\d+(?:\.\d+)?)px,\s*(-?\d+(?:\.\d+)?)px\)$/.exec(
+      transform,
+    );
+    expect(m, `unexpected transform format: ${transform}`).not.toBeNull();
+    const tx = parseFloat(m![1]);
+    const ty = parseFloat(m![2]);
+    expect(tx).toBeCloseTo(MOVE_CLIENT_X + 14, 4);
+    expect(ty).toBeCloseTo(MOVE_CLIENT_Y + 14, 4);
+
+    // Release the drag so the document-level handlers come off.
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: MOVE_CLIENT_X, clientY: MOVE_CLIENT_Y, bubbles: true,
+    }));
+  });
+
+  // After one rotate completes, `acquireRotateTooltip` used to flip
+  // `display: block` while the previous drag's `transform` was still on
+  // the element, painting a stale position for one frame before the
+  // first `pointermove` corrected it. The fix: acquire keeps it
+  // hidden, and `startRotate` calls `showTooltip(clientX, clientY, 0)`
+  // immediately so `transform` and `display: block` land in the same
+  // paint frame. Regression: at the moment of the second pointerdown
+  // (before any pointermove), the tooltip's transform must reflect the
+  // NEW click position — not the previous drag's last move.
+  it('paints the angle tooltip at the new pointerdown on re-acquire, not the previous drag\'s last position', () => {
+    const wrap = document.createElement('div');
+    wrap.style.position = 'relative';
+    document.body.appendChild(wrap);
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 960; canvas.height = 540;
+    wrap.appendChild(canvas);
+
+    const overlay = document.createElement('div');
+    overlay.style.position = 'absolute';
+    const OVERLAY_OFFSET_X = 50;
+    const OVERLAY_OFFSET_Y = 30;
+    overlay.style.left = `${OVERLAY_OFFSET_X}px`;
+    overlay.style.top  = `${OVERLAY_OFFSET_Y}px`;
+    wrap.appendChild(overlay);
+    overlay.getBoundingClientRect = (): DOMRect => ({
+      x: OVERLAY_OFFSET_X, y: OVERLAY_OFFSET_Y,
+      left: OVERLAY_OFFSET_X, top: OVERLAY_OFFSET_Y,
+      right: OVERLAY_OFFSET_X + 960, bottom: OVERLAY_OFFSET_Y + 540,
+      width: 960, height: 540,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const store = new MemSlidesStore();
+    store.batch(() => store.addSlide('blank'));
+    let shapeId = '';
+    store.batch(() => {
+      const sid = store.read().slides[0].id;
+      shapeId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 100, y: 50, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+    });
+    editor.setSelection([shapeId]);
+
+    const grabHandleClient = (): { x: number; y: number } => {
+      const h = overlay.querySelector<HTMLDivElement>(
+        '[data-handle="rotate"]',
+      );
+      if (!h) throw new Error('rotate handle missing');
+      return {
+        x: parseFloat(h.style.left) + 4 + OVERLAY_OFFSET_X,
+        y: parseFloat(h.style.top)  + 4 + OVERLAY_OFFSET_Y,
+      };
+    };
+
+    // ── First rotation cycle: drive transform to (414, 214). ──
+    const r1 = grabHandleClient();
+    overlay.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: r1.x, clientY: r1.y, bubbles: true,
+    }));
+    const MOVE_X = 400;
+    const MOVE_Y = 200;
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: MOVE_X, clientY: MOVE_Y, bubbles: true,
+    }));
+    // pointerup releases the tooltip (display: none) but keeps the
+    // element + its stale transform around for re-use next drag.
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: MOVE_X, clientY: MOVE_Y, bubbles: true,
+    }));
+
+    const tooltip = document.querySelector<HTMLDivElement>(
+      '.wfb-slides-rotate-tooltip',
+    );
+    expect(tooltip).not.toBeNull();
+    const staleTransform = tooltip!.style.transform;
+    expect(staleTransform).toMatch(/translate\(414px,\s*214px\)/);
+    expect(tooltip!.style.display).toBe('none');
+
+    // ── Second rotation cycle: pointerdown only, NO pointermove. ──
+    const r2 = grabHandleClient();
+    overlay.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: r2.x, clientY: r2.y, bubbles: true,
+    }));
+
+    // Pre-fix behaviour: display flips to 'block' but transform still
+    // reads `translate(414px, 214px)`. Post-fix: showTooltip is called
+    // immediately with the new pointerdown coords, and `transform`
+    // moves with `display` in the same paint frame.
+    const newTransform = tooltip!.style.transform;
+    const m = /^translate\((-?\d+(?:\.\d+)?)px,\s*(-?\d+(?:\.\d+)?)px\)$/.exec(
+      newTransform,
+    );
+    expect(m, `unexpected transform format: ${newTransform}`).not.toBeNull();
+    const tx = parseFloat(m![1]);
+    const ty = parseFloat(m![2]);
+    expect(tx).toBeCloseTo(r2.x + 14, 4);
+    expect(ty).toBeCloseTo(r2.y + 14, 4);
+    expect(tooltip!.style.display).toBe('block');
+
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: r2.x, clientY: r2.y, bubbles: true,
+    }));
+  });
+});


### PR DESCRIPTION
## Summary

Three slides-editor bugs surfaced while testing groups; they travel together because the same `/shared/<id>` deck exercises them in sequence.

1. **Lines drift after grouping their endpoints** (the reported bug). The store keeps a connector as a group child when both endpoints reference candidates, but `drawElement`'s connector branch skipped the per-element frame transform — `drawConnector` expects world-coord endpoints and `buildElementWorldLookup` lifts grouped targets to world, so the group transform was being applied a second time on top of already-world endpoints. `drawElement` now threads a cumulative `parentTransform`; on a connector child it inverts that transform onto the ctx and hands `drawConnector` the lookup's view of the connector so `free` endpoints (which are lifted to world by `walkWorld`) agree with `attached` endpoints. The "v1 group() never includes connectors" NOTE in `element-renderer.ts` was stale since #263.

2. **Rotate angle tooltip drifts by the pasteboard offset.** `acquireRotateTooltip` appends to `overlay.parentElement` so `renderOverlay`'s `innerHTML` reset can't wipe it mid-drag, but `showTooltip` was computing coords against `overlay`'s rect. These origins agreed until #353 gave the overlay a non-zero `slideOffsetCssX/Y` inside `canvasWrap`. Measure against the actual tooltip parent rect instead.

3. **Rotate tooltip flickers at the previous drag's last position** on re-acquire. `acquireRotateTooltip` flipped `display: block` immediately while `transform` still held the previous drag's terminal value; only the first `pointermove` corrected it. Acquire now leaves the element hidden; `startRotate` calls `showTooltip(clientX, clientY, 0)` once immediately after defining it, so `transform` and `display: block` land in the same paint frame. Bonus: a 0° readout pops at the click position with zero input latency.

Code-review follow-up (in the second commit): the connector inverse path used to throw on a singular parent transform — that throw escaped `drawElement`'s `try/finally` and blanked the whole slide. `invertGroupTransform` now returns `null` and the connector branch skips the paint, so a degenerate group only takes itself down, not the rest of the slide.

## Regression coverage

- `slide-renderer.test.ts` — attached connector: `ctx.transform` runs before `moveTo` with the expected inverse coefficients; free connector: pre/post-group `moveTo`/`lineTo` args match (the lookup swap).
- `editor.test.ts` — pasteboard layout: tooltip transform encodes parent-frame coords, not overlay-relative; two-cycle drag: second pointerdown's transform reflects the new click position, not the previous drag's last move.

## Known limitations / follow-ups

Recorded in `docs/tasks/active/20260612-slides-grouped-connector-render-todo.md`:

- `groupToTransform` doesn't model `flipH`/`flipV` — a flipped group ancestor leaves residual mirror.
- Reference-equality identity gate on `parentTransform` (functionally fine; structural check is the right contract).
- Ghost connector inside a group ghost would lookup-miss; not currently exercised.
- `tooltipContainer` is captured once at `startRotate` — re-mount mid-drag goes stale.
- `overlay.parentElement` null fallback inside `acquireRotateTooltip` puts the tooltip back into `renderOverlay`'s wipe radius (not exercised by current hosts).
- Three copies of the 6-coef affine inverse math (`element-renderer.ts` + `model/group.ts`).
- `as typeof element` cast on the lookup result — TS can't prove the per-id type invariant.
- `acquireRotateTooltip` now expects an immediate `showTooltip` in the same tick (silent contract).

## Test plan

- [x] `pnpm verify:fast` green
- [x] `pnpm --filter @wafflebase/slides test` — 1732 / 1734 (2 pre-existing skips)
- [ ] Manual smoke at `localhost:5173/shared/6f9bc4c8-3dbd-48a8-bb88-b6044ad1529b`: group two shapes + line, confirm the line stays anchored after grouping
- [ ] Manual smoke: rotate a shape with a non-zero pasteboard, confirm the `°` tooltip tracks the cursor (no offset)
- [ ] Manual smoke: rotate twice in a row, confirm no flicker on the second pointerdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed grouped connectors rendering at incorrect positions.
  * Corrected rotation tooltip positioning to display at the correct location.
  * Eliminated rotation tooltip flickering when re-initiating rotation interactions.

* **Tests**
  * Added tests for grouped connector rendering behavior.
  * Added tests for rotation tooltip positioning and interaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->