### PR TITLE
Slides: bake group resize into children (no more text distortion)

### DIFF
--- a/docs/tasks/active/20260612-slides-group-resize-bake-todo.md
+++ b/docs/tasks/active/20260612-slides-group-resize-bake-todo.md
@@ -1,0 +1,78 @@
+# Slides: Bake Group Resize Into Children
+
+**Goal:** Stop distorting glyphs (and other rendered content) when a
+group is resized non-uniformly. Bake the resize delta into each
+child's frame at commit time, so the canvas render-scale stays 1.
+
+**Why:** Today the renderer multiplies child draws by
+`(frame.w / refSize.w, frame.h / refSize.h)`. For a non-uniform group
+resize this distorts text glyphs and any other content drawn at a
+fixed font / line size. Google Slides and PowerPoint do not distort
+in this case — they bake the resize into children. `ungroup` already
+has the bake math (`applyGroupTransform`); this task wires the same
+bake into the group resize commit.
+
+## Approach
+
+1. Pure helper `bakeGroupScale(group: GroupElement)` in
+   `packages/slides/src/model/group.ts`. Returns the next
+   `{ children, refSize }` such that:
+   - `sx = frame.w / oldRefSize.w`, `sy = frame.h / oldRefSize.h`.
+   - For each child: `frame.x *= sx`, `frame.y *= sy`,
+     `frame.w *= sx`, `frame.h *= sy`. Rotation preserved.
+   - For connector children: free endpoints `x *= sx, y *= sy`;
+     attached endpoints unchanged.
+   - New `refSize = { w: group.frame.w, h: group.frame.h }`.
+   - No-op (return identity) when both scale factors are 1.
+
+2. Store method `bakeGroupResize(slideId, groupId)` on the `Store`
+   interface, implemented in `MemSlidesStore` and
+   `YorkieSlidesStore`. Reads the group, calls the pure helper,
+   writes the new children array + refSize back atomically.
+
+3. Editor wiring: in `SlidesEditorImpl.startResize`'s `onUp`, when
+   the resized element is a group, call
+   `this.options.store.bakeGroupResize(slide.id, elementId)` AFTER
+   `updateElementFrame`, inside the same `store.batch`. So the
+   gesture is still one undo unit and the resize + bake commit
+   together.
+
+## Steps
+
+- [ ] **Step 1:** Add pure helper `bakeGroupScale` to
+  `packages/slides/src/model/group.ts` with co-located unit tests in
+  `packages/slides/test/model/group.test.ts` (or create the file
+  if missing). Cases:
+  - Identity (sx = sy = 1) returns input.
+  - Uniform 2x: child frames double in all dims.
+  - Non-uniform (sx=2, sy=1): widths double, heights unchanged.
+  - Rotated child: rotation preserved, dims still scale.
+  - Connector with free + attached endpoints: free scales, attached unchanged.
+
+- [ ] **Step 2:** Add `bakeGroupResize(slideId, groupId)` to the
+  `Store` interface in `packages/slides/src/store/store.ts`.
+
+- [ ] **Step 3:** Implement `bakeGroupResize` in
+  `packages/slides/src/store/memory.ts` using the pure helper. No-op
+  when group has no children or scale factors are 1.
+
+- [ ] **Step 4:** Implement `bakeGroupResize` in
+  `packages/frontend/src/app/slides/yorkie-slides-store.ts` (the
+  collaborative impl) using the same pure helper.
+
+- [ ] **Step 5:** Wire into `SlidesEditorImpl.startResize`'s `onUp`
+  in `packages/slides/src/view/editor/editor.ts`. Single-element
+  group branch only (multi-resize Task 5 already bakes multi-select
+  via per-child frame updates and so does not need this hook).
+
+- [ ] **Step 6:** Integration test in `packages/slides/test/view/editor/editor.test.ts`:
+  - Seed a group with one text child + one rect child.
+  - Resize the group non-uniformly.
+  - After commit: `group.data.refSize` matches `group.frame.{w,h}`;
+    children's frames are scaled accordingly; child element's
+    rotation preserved.
+
+- [ ] **Step 7:** Run `pnpm verify:fast`. Confirm green.
+
+- [ ] **Step 8:** Commit with subject under 70 chars; body explains
+  the bake rationale + the GS/PPT parity reference. Open PR.

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -37,6 +37,7 @@ import {
   defaultLight,
   generateId,
   getLayout,
+  bakeGroupScale,
   isBlocksEmpty,
   groupToTransform,
   migrateDocument,
@@ -1595,6 +1596,55 @@ export class YorkieSlidesStore implements SlidesStore {
           }
         }
       });
+    });
+  }
+
+  bakeGroupResize(slideId: string, groupId: string): void {
+    this.requireBatch();
+    this.doc.update((r) => {
+      const s = r.slides.find((s) => s.id === slideId);
+      if (!s) return;
+
+      const proxyElements = s.elements as unknown as ProxyArray;
+      const path = yorkieFindElementPath(proxyElements, groupId);
+      if (!path) return;
+
+      const group = path[path.length - 1];
+      if (group.type !== 'group') return;
+
+      const plainGroup = unwrapElement(group) as unknown as GroupElement;
+      const gAny = group as unknown as {
+        frame: Frame;
+        data: { refSize: { w: number; h: number }; children: ProxyArray };
+      };
+
+      if (plainGroup.data.children.length === 0) {
+        gAny.data.refSize = { w: plainGroup.frame.w, h: plainGroup.frame.h };
+        return;
+      }
+
+      const { children: bakedChildren, refSize } = bakeGroupScale(plainGroup);
+      if (bakedChildren === plainGroup.data.children) {
+        // bakeGroupScale returned identity — sync refSize defensively.
+        gAny.data.refSize = refSize;
+        return;
+      }
+
+      gAny.data.children.forEach((ch, i) => {
+        const next = bakedChildren[i];
+        const chAny = ch as unknown as {
+          type: string;
+          frame: Frame;
+          start?: Endpoint;
+          end?: Endpoint;
+        };
+        chAny.frame = { ...next.frame };
+        if (next.type === 'connector') {
+          (chAny as unknown as Record<'start' | 'end', Endpoint>).start = next.start;
+          (chAny as unknown as Record<'start' | 'end', Endpoint>).end = next.end;
+        }
+      });
+      gAny.data.refSize = refSize;
     });
   }
 

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -81,6 +81,7 @@ export {
   applyGroupTransform,
   applyInverseMatrix,
   applyInversePoint,
+  bakeGroupScale,
   buildElementWorldLookup,
   composeAncestorTransform,
   composeGroupMatrix,

--- a/packages/slides/src/model/group.ts
+++ b/packages/slides/src/model/group.ts
@@ -463,3 +463,65 @@ function walkWorld(
     out.set(el.id, { ...el, frame: applyMatrix(el.frame, accum) });
   }
 }
+
+/**
+ * Bake a group's render-scale into its children, so the renderer no
+ * longer applies `scale(scaleX, scaleY)` to draw children. Used at the
+ * commit point of a group resize so non-uniform scale stops distorting
+ * text glyphs and any other content drawn at fixed sizes. Matches
+ * Google Slides / PowerPoint behavior, where resizing a group never
+ * leaves text squished.
+ *
+ * Math: with `sx = group.frame.w / refSize.w` and
+ * `sy = group.frame.h / refSize.h`, each child's local frame scales by
+ * `(sx, sy)` (position and dimensions both). Rotation is preserved.
+ * Connector children's free endpoints scale the same way; attached
+ * endpoints are unchanged (the target shape is the source of truth).
+ *
+ * Returns the next `children` array and the new `refSize`. If both
+ * scale factors are already 1 (or `refSize` is unset and equals
+ * `frame.w/h` by default), returns the inputs untouched.
+ *
+ * The transform is NOT recursive: a child group keeps its own
+ * `refSize`. Its descendants are scaled later when that inner group is
+ * itself resized (or its resize is baked). This matches OOXML grouped
+ * geometry, where each level owns its scale.
+ */
+export function bakeGroupScale(group: GroupElement): {
+  children: Element[];
+  refSize: { w: number; h: number };
+} {
+  const { w, h } = group.frame;
+  const refW = group.data.refSize?.w ?? w;
+  const refH = group.data.refSize?.h ?? h;
+  const sx = refW > 0 ? w / refW : 1;
+  const sy = refH > 0 ? h / refH : 1;
+  if (sx === 1 && sy === 1) {
+    return { children: group.data.children, refSize: { w: refW, h: refH } };
+  }
+
+  const scaleFrame = (f: Frame): Frame => ({
+    x: f.x * sx,
+    y: f.y * sy,
+    w: f.w * sx,
+    h: f.h * sy,
+    rotation: f.rotation,
+  });
+
+  const children: Element[] = group.data.children.map((child) => {
+    if (child.type === 'connector') {
+      const start =
+        child.start.kind === 'free'
+          ? { kind: 'free' as const, x: child.start.x * sx, y: child.start.y * sy }
+          : child.start;
+      const end =
+        child.end.kind === 'free'
+          ? { kind: 'free' as const, x: child.end.x * sx, y: child.end.y * sy }
+          : child.end;
+      return { ...child, frame: scaleFrame(child.frame), start, end };
+    }
+    return { ...child, frame: scaleFrame(child.frame) } as Element;
+  });
+
+  return { children, refSize: { w, h } };
+}

--- a/packages/slides/src/node.ts
+++ b/packages/slides/src/node.ts
@@ -74,6 +74,7 @@ export {
   applyGroupTransform,
   applyInverseMatrix,
   applyInversePoint,
+  bakeGroupScale,
   buildElementWorldLookup,
   composeAncestorTransform,
   composeGroupMatrix,

--- a/packages/slides/src/store/memory.ts
+++ b/packages/slides/src/store/memory.ts
@@ -39,6 +39,7 @@ import {
   applyGroupTransform,
   applyInverseMatrix,
   applyInversePoint,
+  bakeGroupScale,
   buildElementWorldLookup,
   composeAncestorTransform,
   findElementPath,
@@ -999,6 +1000,42 @@ export class MemSlidesStore implements SlidesStore {
         }
       }
     }
+  }
+
+  bakeGroupResize(slideId: string, groupId: string): void {
+    this.requireBatch();
+    const slide = this.requireSlide(slideId);
+    const path = findElementPath(slide.elements, groupId);
+    if (!path) return; // Stale group id — tolerate.
+    const group = path[path.length - 1];
+    if (group.type !== 'group') return;
+    if (group.data.children.length === 0) {
+      // No children to bake; just sync refSize to the current frame so
+      // subsequent renders read scale=1.
+      group.data.refSize = { w: group.frame.w, h: group.frame.h };
+      return;
+    }
+
+    const { children, refSize } = bakeGroupScale(group);
+    if (children === group.data.children) {
+      // bakeGroupScale returned identity (scale was already 1) — sync
+      // refSize defensively in case it was undefined.
+      group.data.refSize = refSize;
+      return;
+    }
+    // Mutate children in place (preserve object identity per ungroup /
+    // refitGroup convention so Yorkie path stability holds inside a
+    // batch).
+    for (let i = 0; i < group.data.children.length; i++) {
+      const next = children[i];
+      const cur = group.data.children[i];
+      cur.frame = { ...next.frame };
+      if (cur.type === 'connector' && next.type === 'connector') {
+        cur.start = next.start;
+        cur.end = next.end;
+      }
+    }
+    group.data.refSize = refSize;
   }
 
   // --- text bridges ---

--- a/packages/slides/src/store/store.ts
+++ b/packages/slides/src/store/store.ts
@@ -126,6 +126,18 @@ export interface SlidesStore {
    */
   refitGroup(slideId: string, groupId: string): void;
 
+  /**
+   * Bake a group's render-scale into its children, then reset `refSize`
+   * to the group's current `frame.{w,h}`. Called at the commit point of
+   * a group resize so the renderer no longer scales children at paint
+   * time — text glyphs and any fixed-size content stop being distorted
+   * under non-uniform group resizes. Matches Google Slides / PowerPoint
+   * behaviour. No-op when the group has no children or when the scale
+   * factors are already 1 (the gesture did not actually change size,
+   * or `refSize` was unset).
+   */
+  bakeGroupResize(slideId: string, groupId: string): void;
+
   // --- connector-level ---
 
   /** Update an endpoint of an existing connector. */

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -5362,6 +5362,15 @@ class SlidesEditorImpl implements SlidesEditor {
       const localFrame = fromWorldFrame(live.worldFrame, scope, startSlide);
       this.options.store.batch(() => {
         this.options.store.updateElementFrame(startSlide.id, elementId, localFrame);
+        // For groups, bake the resize delta into the children so the
+        // renderer no longer applies scale(sx, sy) when drawing them.
+        // Without this, non-uniform group resize distorts text glyphs
+        // and any fixed-size content. Google Slides / PowerPoint
+        // resize behaviour matches: text never squishes inside a
+        // resized group.
+        if (startEl.type === 'group') {
+          this.options.store.bakeGroupResize(startSlide.id, elementId);
+        }
       });
       this.renderer.markDirty();
       this.render();

--- a/packages/slides/test/model/group.test.ts
+++ b/packages/slides/test/model/group.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import * as fc from 'fast-check';
 import type { GroupElement, ShapeElement } from '../../src/model/element';
+import type { ConnectorElement } from '../../src/model/connector';
 import {
   applyGroupTransform,
   applyInverseMatrix,
   applyInversePoint,
+  bakeGroupScale,
   findElementPath,
   groupToTransform,
   isGroupDescendantOf,
@@ -505,5 +507,95 @@ describe('worldTightFrame', () => {
     expect(aWorldAfter.h).toBeCloseTo(aWorldBefore.h, 3);
     expect(bWorldAfter.x).toBeCloseTo(bWorldBefore.x, 3);
     expect(bWorldAfter.y).toBeCloseTo(bWorldBefore.y, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bakeGroupScale — bake the group's render-scale into children at commit time
+// ---------------------------------------------------------------------------
+
+describe('bakeGroupScale', () => {
+  it('returns the input untouched when scale factors are already 1', () => {
+    const g: GroupElement = {
+      ...group('g', { x: 0, y: 0, w: 200, h: 100 }, [
+        shape('a', { x: 10, y: 10, w: 50, h: 30 }),
+      ]),
+      data: {
+        children: [shape('a', { x: 10, y: 10, w: 50, h: 30 })],
+        refSize: { w: 200, h: 100 },
+      },
+    };
+    const { children, refSize } = bakeGroupScale(g);
+    expect(refSize).toEqual({ w: 200, h: 100 });
+    expect(children).toBe(g.data.children);
+  });
+
+  it('scales each child frame uniformly when group doubled both axes', () => {
+    const g: GroupElement = {
+      ...group('g', { x: 0, y: 0, w: 400, h: 200 }, []),
+      data: {
+        children: [
+          shape('a', { x: 10, y: 10, w: 50, h: 30 }),
+          shape('b', { x: 100, y: 50, w: 60, h: 20, rotation: Math.PI / 6 }),
+        ],
+        refSize: { w: 200, h: 100 },
+      },
+    };
+    const { children, refSize } = bakeGroupScale(g);
+    expect(refSize).toEqual({ w: 400, h: 200 });
+    expect(children[0].frame).toMatchObject({ x: 20, y: 20, w: 100, h: 60 });
+    expect(children[1].frame).toMatchObject({
+      x: 200, y: 100, w: 120, h: 40,
+    });
+    expect(children[1].frame.rotation).toBeCloseTo(Math.PI / 6);
+  });
+
+  it('non-uniform scale (sx=2, sy=1): widths double, heights stay', () => {
+    const g: GroupElement = {
+      ...group('g', { x: 0, y: 0, w: 400, h: 100 }, []),
+      data: {
+        children: [shape('a', { x: 10, y: 20, w: 50, h: 30 })],
+        refSize: { w: 200, h: 100 },
+      },
+    };
+    const { children, refSize } = bakeGroupScale(g);
+    expect(refSize).toEqual({ w: 400, h: 100 });
+    expect(children[0].frame).toMatchObject({ x: 20, y: 20, w: 100, h: 30 });
+  });
+
+  it('connector children: free endpoints scale; attached endpoints unchanged', () => {
+    const connector: ConnectorElement = {
+      id: 'c',
+      type: 'connector',
+      frame: { x: 0, y: 0, w: 100, h: 50, rotation: 0 },
+      routing: 'straight',
+      start: { kind: 'free', x: 10, y: 20 },
+      end:   { kind: 'attached', elementId: 'target', siteIndex: 0 },
+      arrowheads: {},
+    };
+    const g: GroupElement = {
+      ...group('g', { x: 0, y: 0, w: 400, h: 100 }, []),
+      data: {
+        children: [connector],
+        refSize: { w: 200, h: 50 },
+      },
+    };
+    const { children } = bakeGroupScale(g);
+    const baked = children[0] as ConnectorElement;
+    expect(baked.start).toEqual({ kind: 'free', x: 20, y: 40 });
+    expect(baked.end).toEqual({ kind: 'attached', elementId: 'target', siteIndex: 0 });
+    expect(baked.frame).toMatchObject({ x: 0, y: 0, w: 200, h: 100 });
+  });
+
+  it('treats missing refSize as identity (frame.w/h), giving a no-op', () => {
+    const g: GroupElement = {
+      ...group('g', { x: 0, y: 0, w: 200, h: 100 }, [
+        shape('a', { x: 10, y: 10, w: 50, h: 30 }),
+      ]),
+    };
+    // No refSize on data — defaults to frame.{w,h}.
+    const { children, refSize } = bakeGroupScale(g);
+    expect(refSize).toEqual({ w: 200, h: 100 });
+    expect(children).toBe(g.data.children);
   });
 });

--- a/packages/slides/test/view/editor/editor.test.ts
+++ b/packages/slides/test/view/editor/editor.test.ts
@@ -3000,3 +3000,55 @@ describe('rotate — angle tooltip positioning', () => {
     }));
   });
 });
+
+describe('group resize commit — bake into children', () => {
+  let editor: SlidesEditor | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    if (editor) { editor.detach(); editor = null; }
+  });
+
+  it('bakes the resize into child frames and resets refSize on group SE-handle drag', () => {
+    const { canvas, overlay, store } = makeGroupedFixture();
+    editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
+
+    // Select the group and inspect its starting geometry.
+    const slide0 = store.read().slides[0];
+    const group0 = slide0.elements[0] as Extract<typeof slide0.elements[0], { type: 'group' }>;
+    expect(group0.type).toBe('group');
+    const refBefore = { w: group0.frame.w, h: group0.frame.h };
+    const childAFrameBefore = { ...group0.data.children[0].frame };
+    editor.setSelection([group0.id]);
+
+    // Drag the SE handle by (+100, +50) logical px.
+    const seHandle = overlay.querySelector<HTMLDivElement>('[data-handle="se"]')!;
+    expect(seHandle).not.toBeNull();
+    const left = parseFloat(seHandle.style.left);
+    const top = parseFloat(seHandle.style.top);
+    const startX = left + 4;
+    const startY = top + 4;
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: startX, clientY: startY, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: startX + 100, clientY: startY + 50, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: startX + 100, clientY: startY + 50, bubbles: true,
+    }));
+
+    // After commit: group's frame.w/h grew; refSize matches new frame
+    // (so renderer scale is 1); child frames scaled proportionally.
+    const slide1 = store.read().slides[0];
+    const group1 = slide1.elements[0] as typeof group0;
+    const sx = group1.frame.w / refBefore.w;
+    const sy = group1.frame.h / refBefore.h;
+    expect(sx).toBeGreaterThan(1);
+    expect(sy).toBeGreaterThan(1);
+    expect(group1.data.refSize?.w).toBeCloseTo(group1.frame.w, 3);
+    expect(group1.data.refSize?.h).toBeCloseTo(group1.frame.h, 3);
+    expect(group1.data.children[0].frame.w).toBeCloseTo(childAFrameBefore.w * sx, 3);
+    expect(group1.data.children[0].frame.h).toBeCloseTo(childAFrameBefore.h * sy, 3);
+  });
+});


### PR DESCRIPTION
## Summary

- The renderer applies `ctx.scale(frame.w / refSize.w, frame.h / refSize.h)` to a group's children. For a non-uniform group resize this distorts text glyphs and any fixed-size content. Google Slides and PowerPoint do not distort either — they bake the resize into children so the renderer's scale stays 1.
- This PR adds a pure helper `bakeGroupScale(group)` in `model/group.ts` that scales each child's frame and free connector endpoints by the same factors. A new store method `bakeGroupResize(slideId, groupId)` wraps it for `MemSlidesStore` and `YorkieSlidesStore`. `SlidesEditorImpl.startResize`'s `onUp` calls it inside the same `store.batch` as `updateElementFrame`, so the gesture is still one undo unit.
- Coverage: 5 unit tests in `model/group.test.ts` (identity, uniform 2x, non-uniform, rotated child preserved, mixed-endpoint connector, missing-refSize default) plus a single-group SE-handle drag integration test in `editor.test.ts` that asserts post-commit `refSize == frame.{w,h}` and child frames scale proportionally.

Multi-select resize (already shipped under #359) baked dimensions into children via per-child `updateElementFrame`, so this hook is the single-group case only — multi paths already produce the parity behaviour.

## Test plan

- [x] `pnpm verify:fast` — 1753 slides + 1279 sheets + 925 docs + 531 frontend + 191 cli, all green.
- [x] `pnpm verify:self` — all 10 lanes green in ~102s.
- [x] Manual smoke (`pnpm dev`):
  - [x] Group two text boxes. Drag the group's SE handle non-uniformly. Confirm text inside both boxes stays readable (no horizontal squish).
  - [x] Group a rect + a text box. Resize. Re-open the group's text and confirm the font size is unchanged (only the frame grew).
  - [x] Resize → undo. Confirm one undo step reverts both the group's frame and the children's frames.
  - [x] Group with a connector child whose endpoint is attached to a shape inside the group. Resize. Confirm the attached endpoint still points at the same shape; the free endpoint scales with the bbox.