### PR TITLE
Slides: fix font-size +/- stuck on shape after first click

### DIFF
--- a/packages/docs/src/view/text-box-editor.ts
+++ b/packages/docs/src/view/text-box-editor.ts
@@ -590,6 +590,24 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
     }
   };
 
+  // Fire the cursor-move callback after a style mutation. The caret and
+  // selection didn't move, but the styles under them did — toolbar pickers
+  // (font size, bold, list state, …) drive off `onCursorMove` to refresh
+  // from `getRangeStyleSummary` / `getBlockStyle`. Without this, the next
+  // `renderNow` dedupes against `lastCursorMoveKey` (which only encodes
+  // cursor + selection) and skips the dispatch — leaving the picker stuck
+  // on the pre-mutation value. Mirrors `notifyStyleApplied` in the full
+  // docs editor (`view/editor.ts`).
+  const notifyStyleApplied = (): void => {
+    if (!cursorMoveCallback) return;
+    const selRange = selection.hasSelection() && selection.range
+      ? { anchor: selection.range.anchor, focus: selection.range.focus }
+      : null;
+    // Sync the dedupe key so the imminent renderNow doesn't double-fire.
+    lastCursorMoveKey = JSON.stringify({ cur: cursor.position, sel: selRange });
+    cursorMoveCallback(cursor.position, selRange);
+  };
+
   // TextEditor wiring. The editor is positionally identical to the one
   // `initialize` constructs, except every page-aware getter is replaced
   // with a shim:
@@ -767,6 +785,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
       layoutCache = undefined;
     }
     requestRender();
+    notifyStyleApplied();
   };
 
   const api: TextBoxEditorAPI = {
@@ -971,6 +990,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
       });
       layoutCache = undefined;
       requestRender();
+      notifyStyleApplied();
     },
 
     getBlockType(): { type: BlockType; headingLevel?: HeadingLevel; listKind?: 'ordered' | 'unordered'; listLevel?: number } {
@@ -998,6 +1018,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
       doc.setBlockType(cursor.position.blockId, type, opts);
       layoutCache = undefined;
       requestRender();
+      notifyStyleApplied();
     },
 
     toggleList(kind: 'ordered' | 'unordered'): void {
@@ -1014,6 +1035,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
       });
       layoutCache = undefined;
       requestRender();
+      notifyStyleApplied();
     },
 
     indent(): void {
@@ -1036,6 +1058,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
       });
       layoutCache = undefined;
       requestRender();
+      notifyStyleApplied();
     },
 
     outdent(): void {
@@ -1059,6 +1082,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
       });
       layoutCache = undefined;
       requestRender();
+      notifyStyleApplied();
     },
 
     insertLink(url: string): void {
@@ -1068,6 +1092,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
         doc.applyInlineStyle(range, { href: url });
         layoutCache = undefined;
         requestRender();
+        notifyStyleApplied();
       } else {
         docStore.snapshot();
         const pos = cursor.position;
@@ -1080,6 +1105,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
         cursor.moveTo({ blockId: pos.blockId, offset: pos.offset + url.length });
         layoutCache = undefined;
         requestRender();
+        notifyStyleApplied();
       }
     },
 
@@ -1110,6 +1136,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
       doc.applyInlineStyle(range, { href: undefined });
       layoutCache = undefined;
       requestRender();
+      notifyStyleApplied();
     },
 
     getLinkAtCursor(): string | undefined {

--- a/packages/docs/test/view/text-box-editor.test.ts
+++ b/packages/docs/test/view/text-box-editor.test.ts
@@ -392,6 +392,7 @@ describe('TextBoxEditorAPI — formatting surface', () => {
     api.detach();
   });
 
+
   it('onLinkRequest fires when requestLink is called', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -721,5 +722,56 @@ describe('initializeTextBox — verticalAnchor', () => {
       });
       api.detach();
     }).not.toThrow();
+  });
+
+  /**
+   * Regression test for the slides FontSizePicker bug.
+   *
+   * Toolbar pickers (FontSizePicker, format toggles) refresh their
+   * value off `onCursorMove`. A style apply doesn't move the caret or
+   * selection, so `renderNow`'s dedupe key stayed the same and the
+   * callback never fired. The picker's `value` then stayed pinned to
+   * the pre-mutation size; the second + click re-issued the same size
+   * and the user saw no further growth.
+   *
+   * After the fix, every style-mutating path also calls
+   * `notifyStyleApplied()` so subscribers see each apply. Reuses this
+   * describe's canvas shim (real-ish ctx + measureText stub) because
+   * the regression requires non-empty content to acquire a real
+   * selection range.
+   */
+  it('fires onCursorMove after applyStyle so toolbar pickers refresh (regression: slides font-size +)', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const canvas = document.createElement('canvas');
+    canvas.width = 400;
+    canvas.height = 200;
+    container.appendChild(canvas);
+    const api = initializeTextBox({
+      container,
+      canvas,
+      blocks: [makeBlock('hello')],
+      contentWidth: 400,
+      contentHeight: 200,
+    });
+    const cb = vi.fn();
+    api.onCursorMove(cb);
+    // Cmd/Ctrl+A on the textarea selects all so applyStyle has a real range.
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    api.focus();
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'a',
+        metaKey: true,
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await new Promise<void>((r) => queueMicrotask(r));
+    const before = cb.mock.calls.length;
+    api.applyStyle({ fontSize: 12 });
+    expect(cb.mock.calls.length).toBeGreaterThan(before);
+    api.detach();
   });
 });


### PR DESCRIPTION
## Summary

- The slides FontSizePicker's `value` comes from `useResolvedFontSize`, which subscribes to the editor via `onCursorMove`. In the shared docs text-box editor, `renderNow` only fires the cursor-move callback when the caret or selection actually moves — `applyStyle({ fontSize: ... })` (caret unchanged) was silently swallowed.
- Net effect: first + click bumped 11→12; the picker's `value` stayed at 11 → next click recomputed `base = 11, next = 12` and reapplied the same size. The user sees the first step then nothing.
- Fix mirrors the existing `notifyStyleApplied` pattern in the full docs editor: add a small helper in `text-box-editor.ts` and call it after every style mutation (`applyStyleImpl`, `applyBlockStyle`, `setBlockType`, `toggleList`, `indent`, `outdent`, both `insertLink` branches, `removeLink`). The file backs both slides shape/text-element inline editing and docs table-cell editing, so the latent stale-toolbar issue is plugged in both surfaces.

## Test plan

- [x] `pnpm verify:fast` — green (lint + 926 docs / 1279 frontend / 1774 slides / 191 sheets / 175 backend tests).
- [x] New regression test `packages/docs/test/view/text-box-editor.test.ts` — drives Cmd+A → `applyStyle({fontSize: 12})` and asserts the `onCursorMove` subscriber fires.
- [x] Manual smoke (reporter): open a slide, enter a shape's text-edit, click Font Size + repeatedly. Now grows on every click. Same path verified for `applyBlockStyle` (align) and list/indent toggles through the text-edit toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* **Fixed formatting toolbar state synchronization** - The formatting toolbar now correctly reflects newly applied text formatting (such as font size, color, bold, italic, etc.) immediately, even when your cursor position doesn't change. This ensures toolbar indicators stay synchronized with your actual document formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->