### PR TITLE
Archive v0.4.5 release todo

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,6 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
-| release v0.4.5 (2026-06-12) | [20260612-release-v0.4.5-todo.md](./active/20260612-release-v0.4.5-todo.md) | - |
 | slides tables (2026-06-08) | [20260608-slides-tables-todo.md](./active/20260608-slides-tables-todo.md) | - |
 | slides hover text edit browser smoke (2026-06-07) | [20260607-slides-hover-text-edit-browser-smoke-todo.md](./active/20260607-slides-hover-text-edit-browser-smoke-todo.md) | - |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
@@ -30,7 +29,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 272
+- Archived task count: 273
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: release v0.4.5 (2026-06-12)
+Latest active task: slides tables (2026-06-08)

--- a/docs/tasks/archive/2026/06/20260612-release-v0.4.5-todo.md
+++ b/docs/tasks/archive/2026/06/20260612-release-v0.4.5-todo.md
@@ -1,7 +1,7 @@
 ---
 title: Release v0.4.5
 date: 2026-06-12
-status: in-progress
+status: done
 ---
 
 # Release v0.4.5
@@ -72,17 +72,19 @@ this is the routine **image-tag-only** kind of bump per
       (root + 8 packages: backend, cli, docs, documentation, frontend,
       sheets, slides, tokens)
 - [x] Run `pnpm verify:fast` and confirm pass
-- [ ] Commit `Bump version to v0.4.5` on `release/v0.4.5` branch
-- [ ] Self-review the branch diff with `/code-review` before push
-- [ ] Open PR against `main`
-- [ ] After merge, tag `v0.4.5` and create GitHub release with
+- [x] Commit `Bump version to v0.4.5` on `release/v0.4.5` branch
+- [x] Self-review the branch diff with `/code-review` before push
+- [x] Open PR against `main` (#363, squash-merged as `4259b34b`)
+- [x] After merge, tag `v0.4.5` and create GitHub release with
       hand-categorised highlights (Slides Editing/UX, Connectors,
       Tables, Themes & PPTX import, Docs/Slides, Docs, Sheets+Docs)
-- [ ] Verify `npm-publish.yml` and `docker-publish.yml` workflows succeed
-- [ ] Confirm `@wafflebase/cli@0.4.5` and `@wafflebase/docs@0.4.5` on npm,
-      and `yorkieteam/wafflebase:v0.4.5` on Docker Hub (multi-arch)
-- [ ] Bump server image in `yorkie-team/devops` and open devops PR
-      (image-tag-only — no env changes this cycle)
+- [x] Verify `npm-publish.yml` and `docker-publish.yml` workflows succeed
+      (runs 27423302282 + 27423302340, both green)
+- [x] Confirm `@wafflebase/cli@0.4.5` and `@wafflebase/docs@0.4.5` on npm,
+      and `yorkieteam/wafflebase:v0.4.5` on Docker Hub (multi-arch
+      amd64 + arm64)
+- [x] Bump server image in `yorkie-team/devops` and open devops PR
+      (image-tag-only — no env changes this cycle): yorkie-team/devops#320
 
 ## Contributors
 
@@ -91,4 +93,12 @@ this is the routine **image-tag-only** kind of bump per
 
 ## Review
 
-_To be completed after release._
+Tag `v0.4.5` cut and published. NPM (`@wafflebase/cli@0.4.5`,
+`@wafflebase/docs@0.4.5`) and Docker Hub
+(`yorkieteam/wafflebase:v0.4.5`, multi-arch amd64 + arm64) artefacts
+confirmed live. Devops bump opened as `yorkie-team/devops#320`
+(image-tag-only, no env changes — routine bump per the release
+policy). Two PRs shipped: `wafflebase/wafflebase#363` (Bump version
+to v0.4.5) preceded by `bf9f3c47` (audit active tasks + scope v0.4.5
+release) on `release/v0.4.5`. Slides tables (P5 presence + P6 PDF
+export tail) remains active for the next cycle.

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,13 +6,14 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 272
+Total archived tasks: 273
 
-## 2026/06 (27 tasks)
+## 2026/06 (28 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
 | multi select resize (2026-06-12) | [20260612-multi-select-resize-todo.md](./2026/06/20260612-multi-select-resize-todo.md) | [20260612-multi-select-resize-lessons.md](./2026/06/20260612-multi-select-resize-lessons.md) |
+| release v0.4.5 (2026-06-12) | [20260612-release-v0.4.5-todo.md](./2026/06/20260612-release-v0.4.5-todo.md) | - |
 | slides connector bend handles (2026-06-12) | [20260612-slides-connector-bend-handles-todo.md](./2026/06/20260612-slides-connector-bend-handles-todo.md) | - |
 | slides group resize bake (2026-06-12) | [20260612-slides-group-resize-bake-todo.md](./2026/06/20260612-slides-group-resize-bake-todo.md) | - |
 | slides grouped connector render (2026-06-12) | [20260612-slides-grouped-connector-render-todo.md](./2026/06/20260612-slides-grouped-connector-render-todo.md) | - |


### PR DESCRIPTION
## Summary

Post-release housekeeping: close out and archive the v0.4.5 release
todo now that all artefacts are live.

- Release tag + GitHub notes: https://github.com/wafflebase/wafflebase/releases/tag/v0.4.5
- npm: `@wafflebase/cli@0.4.5`, `@wafflebase/docs@0.4.5`
- Docker Hub: `yorkieteam/wafflebase:v0.4.5` (amd64 + arm64)
- Devops PR: yorkie-team/devops#320 (image-tag-only, no env changes)

## Test plan

- [x] `pnpm tasks:archive && pnpm tasks:index` regenerates both indexes cleanly
- [x] Pre-push verify lanes green (all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated task tracking and archive documentation to reflect completion of release work and current project priorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->