### PR TITLE
Sheets: scope entry loader to content area like docs/slides

### DIFF
--- a/packages/frontend/src/app/documents/document-detail.tsx
+++ b/packages/frontend/src/app/documents/document-detail.tsx
@@ -674,15 +674,15 @@ function DocumentLayout({ documentId }: { documentId: string }) {
     [doc],
   );
 
-  if (!doc || !activeTabId) {
-    return <Loader />;
-  }
-
-  const root = doc.getRoot();
-  const tabs: TabMeta[] = root.tabOrder
-    .map((id: string) => root.tabs[id])
-    .filter(Boolean);
-  const activeTab = root.tabs[activeTabId];
+  // Render the chrome (sidebar + header) immediately and show the loader
+  // inside the content area only — matching the docs/slides layouts, where
+  // the spinner is scoped to the content slot rather than the whole route.
+  const ready = Boolean(doc && activeTabId);
+  const root = doc && activeTabId ? doc.getRoot() : null;
+  const tabs: TabMeta[] = root
+    ? root.tabOrder.map((id: string) => root.tabs[id]).filter(Boolean)
+    : [];
+  const activeTab = root && activeTabId ? root.tabs[activeTabId] : undefined;
 
   return (
     <SidebarProvider>
@@ -742,7 +742,9 @@ function DocumentLayout({ documentId }: { documentId: string }) {
             <div className="@container/main flex flex-1 flex-col gap-2">
               <div className="flex flex-col h-full">
                 <Suspense fallback={<Loader />}>
-                  {activeTab?.type === "datasource" ? (
+                  {!ready || !activeTabId ? (
+                    <Loader />
+                  ) : activeTab?.type === "datasource" ? (
                     <DataSourceView tabId={activeTabId} />
                   ) : (
                     <SheetView
@@ -757,15 +759,17 @@ function DocumentLayout({ documentId }: { documentId: string }) {
                 </Suspense>
               </div>
             </div>
-            <TabBar
-              tabs={tabs}
-              activeTabId={activeTabId}
-              onSelectTab={setActiveTabId}
-              onAddTab={handleAddTab}
-              onRenameTab={handleRenameTab}
-              onDeleteTab={handleDeleteTab}
-              onMoveTab={handleMoveTab}
-            />
+            {ready && activeTabId && (
+              <TabBar
+                tabs={tabs}
+                activeTabId={activeTabId}
+                onSelectTab={setActiveTabId}
+                onAddTab={handleAddTab}
+                onRenameTab={handleRenameTab}
+                onDeleteTab={handleDeleteTab}
+                onMoveTab={handleMoveTab}
+              />
+            )}
           </div>
           {commentsPanelOpen && (
             <CommentSidePanel<SheetCellAnchor>


### PR DESCRIPTION
## Summary

On the Documents page, entering a **sheet** flashed a full-screen loading
spinner, while **docs** and **slides** showed the spinner only inside the
content area (sidebar + header chrome stayed visible).

Root cause: `DocumentLayout` (`document-detail.tsx`) had an early
`if (!doc || !activeTabId) return <Loader />;` *above* the chrome, so the
whole route was replaced by the loader while the Yorkie doc attached. Docs
(`DocsLayout`) and slides (`DesktopSlidesLayout`) instead render the chrome
unconditionally and let the inner view (`DocsView`/`SlidesView`) show the
loader inside the content slot.

This change brings sheets in line:
- Drops the full-route early return.
- Computes `root`/`tabs`/`activeTab` defensively (`root` is `null` until ready).
- Moves `<Loader />` into the existing `<Suspense>` content slot via a
  `!ready || !activeTabId` branch.
- Gates the `TabBar` on `ready` so no empty tab bar renders during load.

No behavior change once loaded; only the loading-window visuals change.

## Test plan

- `pnpm verify:fast` — lint + unit tests green (926 passed).
- `tsc --noEmit` and `eslint` on the changed file — clean.
- Manual: open a sheet, a doc, and a slide from the Documents page; all three
  now show the spinner scoped to the content area with sidebar/header present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)