### PR TITLE
Slides: keep table cell text-edit box at full cell size

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides cell edit shrink (2026-06-16) | [20260616-slides-cell-edit-shrink-todo.md](./active/20260616-slides-cell-edit-shrink-todo.md) | [20260616-slides-cell-edit-shrink-lessons.md](./active/20260616-slides-cell-edit-shrink-lessons.md) |
+| slides textbox border (2026-06-15) | [20260615-slides-textbox-border-todo.md](./active/20260615-slides-textbox-border-todo.md) | - |
 | slides tables (2026-06-08) | [20260608-slides-tables-todo.md](./active/20260608-slides-tables-todo.md) | - |
 | slides hover text edit browser smoke (2026-06-07) | [20260607-slides-hover-text-edit-browser-smoke-todo.md](./active/20260607-slides-hover-text-edit-browser-smoke-todo.md) | - |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
@@ -32,4 +34,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 273
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides tables (2026-06-08)
+Latest active task: slides cell edit shrink (2026-06-16)

--- a/docs/tasks/active/20260616-slides-cell-edit-shrink-lessons.md
+++ b/docs/tasks/active/20260616-slides-cell-edit-shrink-lessons.md
@@ -1,0 +1,28 @@
+# Lessons — slides cell text-edit box shrink
+
+## What the bug taught
+
+- When one element kind is added to a code path that branches on
+  `kind`, audit **every** kind-keyed branch, not just the obvious one.
+  Cell editing reused the shape/text mount path but the `growMode`
+  ternary (`kind === 'shape' ? 'never' : 'auto'`) silently put cells in
+  the text bucket. The matching gates (`editingGrowApplicable`, the
+  commit frame-fit) had already been written as `kind === 'text'`, so
+  the ternary was the lone outlier — a clear "default branch swallowed a
+  new case" smell. Prefer `kind === 'text' ? … : …` (allow-list the
+  auto-grow case) over `kind === 'shape' ? … : …` (deny-list one fixed
+  case) so future kinds default to the safe/fixed behaviour.
+
+## Test-env gotcha
+
+- The slides `test-canvas-env` fake 2D context is intentionally narrow
+  (methods added on demand). Rendering a `table` element through the
+  editor in jsdom was new, so `setLineDash`/`getLineDash` were missing.
+  When a jsdom editor test newly renders an element kind, expect to
+  extend the fake ctx.
+
+## Process
+
+- TDD reproduced the bug precisely: the red assertion was literally
+  `expected 'auto' to be 'never'`, which both proves the diagnosis and
+  documents the fix in one line.

--- a/docs/tasks/active/20260616-slides-cell-edit-shrink-todo.md
+++ b/docs/tasks/active/20260616-slides-cell-edit-shrink-todo.md
@@ -1,0 +1,54 @@
+# Slides — table cell text-edit box shrinks on entry
+
+## Problem
+
+Double-clicking a table cell to enter text-edit mode collapses the
+editing box to the text height instead of keeping the full cell size.
+
+## Root cause
+
+`enterEditMode` passes `growMode` to the text-box mount as:
+
+```ts
+growMode: target.kind === 'shape' ? 'never' : 'auto',
+```
+
+Only shapes get `'never'`; cells fall through to `'auto'`. Combined
+with the cell's `autofit: 'none'`, `text-box-editor.ts` computes
+`allowEditorGrow = true`, so the editing canvas resizes to the content
+height — shrinking a tall cell down to a single text line.
+
+Cells are structurally identical to shapes here: fixed box, vertical
+anchor, and row auto-grow happens only on commit via the renderer
+(`computeTableLayout`'s `max(declared, contentHeight)` rule). So the
+editing box must stay at the cell's inner-frame height → `growMode:
+'never'`, exactly like shapes.
+
+## Plan
+
+- [x] Investigate root cause (systematic-debugging)
+- [x] Failing test: dblclick a cell asserts mount `growMode === 'never'`
+      and the editFrame keeps the cell's inner height
+- [x] Fix: `editor.ts` growMode → `target.kind === 'text' ? 'auto' : 'never'`
+- [x] `pnpm test` (slides) green — 257 files, 1789 passed
+- [x] `pnpm verify:fast` — EXIT 0
+- [x] Self code-review over the branch diff
+- [ ] PR
+
+## Review
+
+Three-line behavioural change plus a test-env stub gap:
+
+- `editor.ts` — cell text-edit now passes `growMode: 'never'` (was
+  `'auto'`). Shapes already did this; cells are structurally identical
+  (fixed box, vertical anchor, row auto-grow deferred to commit-time
+  renderer). The other two grow-related gates (`editingGrowApplicable`
+  and the commit-time frame fit) were already `kind === 'text'`-only, so
+  the mount `growMode` was the lone inconsistency.
+- `test-canvas-env.ts` — added `setLineDash`/`getLineDash` noop stubs.
+  Rendering a `table` element through the editor in jsdom was previously
+  untested; the table border renderer calls `setLineDash`, which the
+  fake 2D context lacked.
+
+Verification: new `cell-text-edit-entry.test.ts` goes red (`'auto'`)
+before the fix, green after. Full slides suite + `verify:fast` green.

--- a/packages/slides/src/view/canvas/test-canvas-env.ts
+++ b/packages/slides/src/view/canvas/test-canvas-env.ts
@@ -76,6 +76,11 @@ function makeFakeCanvasCtx(): unknown {
     ellipse: noop,
     rect: noop,
 
+    // Table borders draw dashed segments; the renderer toggles the dash
+    // pattern around each stroke. jsdom has neither method.
+    setLineDash: noop,
+    getLineDash: (): number[] => [],
+
     fillRect: noop,
     strokeRect: noop,
     clearRect: noop,

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -3162,13 +3162,16 @@ class SlidesEditorImpl implements SlidesEditor {
       // 'grow' (and absent) tracks content height, 'none' is fixed. The
       // wrapper gates onContentHeightChange so shrink/none never auto-grow.
       autofit: target.autofit,
-      // Shapes keep the editor canvas at the inner-frame height so the
-      // middle vertical anchor in the editor agrees with the renderer's
-      // middle anchor inside the original frame. Without this the docs
+      // Shapes and table cells keep the editor canvas at the inner-frame
+      // height so the vertical anchor in the editor agrees with the
+      // renderer's anchor inside the original frame. Without this the docs
       // editor would shrink the canvas to text height and anchor at
       // originY=0, producing a visible jump between edit and committed
-      // positions. Text elements keep the default auto-grow behavior.
-      growMode: target.kind === 'shape' ? 'never' : 'auto',
+      // positions — for cells this reads as the box collapsing to the text
+      // height on entry. Cell rows auto-grow only on commit via the
+      // renderer, so the box must stay fixed while editing, just like a
+      // shape. Only text elements keep the default auto-grow behavior.
+      growMode: target.kind === 'text' ? 'auto' : 'never',
       // Mirror the slide canvas offset so in-place editing keeps the
       // caret and text glyphs aligned with the committed render.
       verticalAnchor: target.verticalAnchor,

--- a/packages/slides/test/view/editor/cell-text-edit-entry.test.ts
+++ b/packages/slides/test/view/editor/cell-text-edit-entry.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, expect, it, afterEach } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import type { TableElement } from '../../../src/model/element';
+import { MemSlidesStore } from '../../../src/store/memory';
+import { initialize, type SlidesEditor } from '../../../src/view/editor/editor';
+import type {
+  MountSlidesTextBoxOptions,
+  SlidesTextBoxEditor,
+} from '../../../src/view/editor/text-box-editor';
+
+/**
+ * Capturing mock mount: records the options the editor passes to
+ * `mountTextBox` so the test can assert how the cell editor is sized.
+ */
+function makeCapturingMount(captured: {
+  opts?: MountSlidesTextBoxOptions;
+}) {
+  return function mount(opts: MountSlidesTextBoxOptions): SlidesTextBoxEditor {
+    captured.opts = opts;
+    const container = document.createElement('div');
+    container.className = 'wfb-slides-text-box-editor';
+    container.style.position = 'absolute';
+    opts.overlay.appendChild(container);
+    let mounted = true;
+    return {
+      isEditing: () => mounted,
+      focus: () => undefined,
+      commit: () => opts.onCommit(opts.blocks),
+      detach: () => { mounted = false; container.remove(); },
+      container,
+      getSelectionStyle: () => ({}),
+      getRangeStyleSummary: () => ({}),
+      applyStyle: () => {},
+      clearInlineFormatting: () => {},
+      applyBlockStyle: () => {},
+      getBlockType: () => ({ type: 'paragraph' as const }),
+      getBlockStyle: () => ({}),
+      setBlockType: () => {},
+      toggleList: () => {},
+      indent: () => {},
+      outdent: () => {},
+      insertLink: () => {},
+      removeLink: () => {},
+      getLinkAtCursor: () => undefined,
+      requestLink: () => {},
+      undo: () => {},
+      redo: () => {},
+      onCursorMove: () => () => {},
+    };
+  };
+}
+
+function setup() {
+  document.body.innerHTML = '';
+  const canvas = document.createElement('canvas');
+  canvas.width = 1920;
+  canvas.height = 1080;
+  const overlay = document.createElement('div');
+  overlay.style.position = 'absolute';
+  document.body.appendChild(canvas);
+  document.body.appendChild(overlay);
+  const store = new MemSlidesStore();
+  return { canvas, overlay, store };
+}
+
+/** 2×2 table, 100×100 cells, all empty bodies. */
+function tableData(): TableElement['data'] {
+  const emptyCell = () => ({ body: { blocks: [] }, style: {} });
+  return {
+    columnWidths: [100, 100],
+    rows: [
+      { height: 100, cells: [emptyCell(), emptyCell()] },
+      { height: 100, cells: [emptyCell(), emptyCell()] },
+    ],
+  };
+}
+
+describe('table cell text-edit entry — box sizing', () => {
+  let editor: SlidesEditor | null = null;
+  afterEach(() => {
+    if (editor) { editor.detach(); editor = null; }
+  });
+
+  it('keeps the editing box at the cell height (growMode never)', () => {
+    const { canvas, overlay, store } = setup();
+    let sid = '';
+    store.batch(() => {
+      sid = store.addSlide('blank');
+      store.addElement(sid, {
+        type: 'table',
+        frame: { x: 200, y: 200, w: 200, h: 200, rotation: 0 },
+        data: tableData(),
+      });
+    });
+
+    const captured: { opts?: MountSlidesTextBoxOptions } = {};
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: makeCapturingMount(captured),
+    });
+
+    // Double-click inside cell (0,0): table at (200,200), cell spans
+    // local x[0,100] y[0,100] → world (250,250).
+    canvas.dispatchEvent(
+      new MouseEvent('dblclick', { clientX: 250, clientY: 250, bubbles: true }),
+    );
+
+    expect(captured.opts).toBeDefined();
+    // The editor canvas must stay at the cell's inner-frame height — the
+    // cell text-edit box must not shrink to the (empty) content height.
+    expect(captured.opts!.growMode).toBe('never');
+    // editFrame height ≈ cell height (100) minus top/bottom padding;
+    // a shrunk box would be far smaller than this.
+    expect(captured.opts!.frame.h).toBeGreaterThan(50);
+  });
+});


### PR DESCRIPTION
## Summary

Double-clicking a table cell to enter text-edit mode collapsed the
editing box down to the text height instead of keeping the cell's full
size. The cell text-box mount passed `growMode: 'auto'`, which (combined
with the cell's `autofit: 'none'`) lets the docs editor shrink its
canvas to the content height.

Cells are structurally identical to shapes here — fixed box, vertical
anchor, and row auto-grow happens only on commit via the renderer. So
pass `growMode: 'never'` for both shapes and cells; only text elements
keep the auto-grow behavior. The two other grow-related gates
(`editingGrowApplicable`, the commit-time frame fit) were already
`kind === 'text'`-only, so the mount `growMode` was the lone outlier.

Also adds `setLineDash`/`getLineDash` noop stubs to the slides test
canvas env so a `table` element can render through the editor in jsdom
(the table border renderer calls `setLineDash`).

## Test plan

- New `cell-text-edit-entry.test.ts` — dblclick a cell asserts the mount
  receives `growMode: 'never'` and the editFrame keeps the cell's inner
  height. Red (`expected 'auto' to be 'never'`) before the fix, green
  after.
- Full slides suite green (257 files, 1789 passed).
- `pnpm verify:fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the text-edit box would incorrectly shrink when double-clicking to edit table-cell text.

* **Tests**
  * Added test coverage for table-cell text-edit entry and box sizing behavior.

* **Documentation**
  * Updated task documentation with details about the cell text-editing fix and lessons learned from the implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->