### PR TITLE
Slides: keep text-edit on Cmd+Arrow / clipboard shortcuts

### DIFF
--- a/packages/slides/src/view/editor/interactions/keyboard.ts
+++ b/packages/slides/src/view/editor/interactions/keyboard.ts
@@ -342,9 +342,16 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
 
     // z-order: Cmd+↑ bring forward, Cmd+↓ send backward,
     //          Cmd+Shift+↑ bring to front, Cmd+Shift+↓ send to back.
+    // Skipped while typing in a text-box: reordering repaints the
+    // overlay (clearing its children), which blurs the focused textarea
+    // and commits/exits text-edit. Without the guard, Cmd+Arrow inside
+    // a text-box kicks the user out of edit mode instead of moving the
+    // caret to the document start/end (the macOS default).
     {
       match: (e) =>
-        (e.key === 'ArrowUp' || e.key === 'ArrowDown') && isModPressed(e),
+        (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
+        isModPressed(e) &&
+        !isEditableTarget(e.target),
       run: (e) => {
         const ids = ctx.selection.get();
         if (ids.length === 0) return;

--- a/packages/slides/src/view/editor/interactions/keyboard.ts
+++ b/packages/slides/src/view/editor/interactions/keyboard.ts
@@ -251,10 +251,24 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
     ),
 
     // --- T2: clipboard / duplicate / z-order ---
+    //
+    // The clipboard / duplicate rules below operate on the SELECTED
+    // element(s). While the user is typing in a text-box, the editing
+    // element is in `selection`, so an unguarded rule would copy / cut /
+    // duplicate the whole element instead of the selected text — and the
+    // `e.preventDefault()` would also swallow the textarea's own native
+    // cut/copy/paste. Cmd+X in particular would delete the text-box the
+    // user is editing. Every rule therefore gates on
+    // `!isEditableTarget(e.target)` so the shortcut falls through to the
+    // textarea default while editing, matching the nudge / delete rules.
 
     // Cmd+C — copy selected elements via custom MIME.
     {
-      match: (e) => keyEquals(e.key, 'c') && isModPressed(e) && !e.shiftKey,
+      match: (e) =>
+        keyEquals(e.key, 'c') &&
+        isModPressed(e) &&
+        !e.shiftKey &&
+        !isEditableTarget(e.target),
       run: async (e) => {
         const ids = ctx.selection.get();
         if (ids.length === 0) return;
@@ -269,7 +283,11 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
 
     // Cmd+X — cut: copy then remove.
     {
-      match: (e) => keyEquals(e.key, 'x') && isModPressed(e) && !e.shiftKey,
+      match: (e) =>
+        keyEquals(e.key, 'x') &&
+        isModPressed(e) &&
+        !e.shiftKey &&
+        !isEditableTarget(e.target),
       run: async (e) => {
         const ids = ctx.selection.get();
         if (ids.length === 0) return;
@@ -288,7 +306,10 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
     // Cmd+V — paste from clipboard. Offsets each pasted element by
     // (10, 10) so the copy doesn't overlap the source exactly.
     {
-      match: (e) => keyEquals(e.key, 'v') && isModPressed(e),
+      match: (e) =>
+        keyEquals(e.key, 'v') &&
+        isModPressed(e) &&
+        !isEditableTarget(e.target),
       run: async (e) => {
         const slide = currentSlide(ctx);
         if (!slide) return;
@@ -313,7 +334,11 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
     // Cmd+D — duplicate selected elements (or the current slide if no
     // element is selected).
     {
-      match: (e) => keyEquals(e.key, 'd') && isModPressed(e) && !e.shiftKey,
+      match: (e) =>
+        keyEquals(e.key, 'd') &&
+        isModPressed(e) &&
+        !e.shiftKey &&
+        !isEditableTarget(e.target),
       run: (e) => {
         e.preventDefault();
         const slide = currentSlide(ctx);


### PR DESCRIPTION
## Summary

In slides text-edit mode, several Cmd-modified shortcuts leaked into the slide-canvas keyboard rules instead of the focused textarea, because those rules were missing the `!isEditableTarget(e.target)` guard that the nudge / delete rules already carry. While editing, the editing element is in `selection`, so the rules acted on the whole element.

Two symptoms fixed:

1. **Cmd+Arrow Up/Down exited text-edit** — the z-order rule (bring forward / send backward) matched while typing. It reordered the element and repainted the overlay (`overlay.innerHTML = ''`), removing the focused textarea → `blur` → commit → `finishEditMode`.

2. **Cmd+X deleted the whole text-box** — the cut rule copied the selected *element* then `removeElements(...)`, so cutting selected text removed the text-box being edited. Cmd+C / Cmd+V / Cmd+D shared the same missing guard (copy element instead of text; all four `preventDefault()` also swallowed the textarea's native cut/copy/paste).

Fix: add `!isEditableTarget(e.target)` to the z-order and clipboard/duplicate rules (Cmd+C / X / V / D), so each falls through to the textarea default while editing and only acts on slide elements when the canvas (not an editable target) has focus.

## Test plan

- [x] `pnpm verify:fast` green (lint + unit tests)
- [x] Manual smoke in `pnpm dev`, in a slide text-box edit:
  - Cmd+↓ / Cmd+↑ → caret moves, edit mode stays
  - select text → Cmd+X / Cmd+C → cuts/copies the **text**, text-box stays
  - Cmd+V → pastes text
- [x] On canvas (no text-edit), element selected: Cmd+↓/↑ reorders, Cmd+C/X/V/D still copy / cut / paste / duplicate the element

🤖 Generated with [Claude Code](https://claude.com/claude-code)