### PR TITLE
Slides: paint cell/shape text overflow while editing

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides cell edit overflow (2026-06-16) | [20260616-slides-cell-edit-overflow-todo.md](./active/20260616-slides-cell-edit-overflow-todo.md) | [20260616-slides-cell-edit-overflow-lessons.md](./active/20260616-slides-cell-edit-overflow-lessons.md) |
 | slides cell edit shrink (2026-06-16) | [20260616-slides-cell-edit-shrink-todo.md](./active/20260616-slides-cell-edit-shrink-todo.md) | [20260616-slides-cell-edit-shrink-lessons.md](./active/20260616-slides-cell-edit-shrink-lessons.md) |
 | slides textbox border (2026-06-15) | [20260615-slides-textbox-border-todo.md](./active/20260615-slides-textbox-border-todo.md) | - |
 | slides tables (2026-06-08) | [20260608-slides-tables-todo.md](./active/20260608-slides-tables-todo.md) | - |
@@ -34,4 +35,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 273
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides cell edit shrink (2026-06-16)
+Latest active task: slides cell edit overflow (2026-06-16)

--- a/docs/tasks/active/20260616-slides-cell-edit-overflow-lessons.md
+++ b/docs/tasks/active/20260616-slides-cell-edit-overflow-lessons.md
@@ -24,10 +24,39 @@ cross-package change into a contained one.
 ## Match the real clip boundary, not an arbitrary margin
 
 First instinct was a fixed overflow margin, which would just relocate the
-same clip. The committed render is bounded by the slide canvas, so
-extending the editing surface to `SLIDE_WIDTH/HEIGHT - frame.origin`
-makes the two pipelines clip at the same place — no discontinuity at
-commit. Tie the fix to the system's actual boundary.
+same clip. The committed render is bounded by the slide canvas, so the
+editing surface should be the slide canvas: a full-slide canvas
+positioned over the slide, with the box content shifted to its slide
+coordinates (a new default-0 `paintOriginX/Y` on the docs editor). The
+two pipelines then clip at the exact same place, so overflow matches in
+every direction with no discontinuity at commit. Tie the fix to the
+system's actual boundary instead of a guessed margin.
+
+## Don't ship the half-fix you already see the limitation of
+
+The first cut extended the canvas only right/bottom and documented "left/
+top overflow stays clipped" as a known limitation. The user hit exactly
+that on the next test (middle-anchored cell → top text clipped). A
+documented limitation in the same area you're touching is a near-term bug
+report waiting to happen — when the complete fix is only marginally more
+code (here: one default-0 paint offset), do the complete fix.
+
+## A paint offset beats per-anchor canvas juggling
+
+The tempting slides-only hack was to inflate `contentHeight` and reposition
+the canvas per vertical anchor to fake top overflow. That re-derives the
+anchor math in a second place and is fragile. Adding one honest
+`paintOriginX/Y` to the docs paint — which `paintLayout` already supported
+via its `originX/originY` args — kept the anchor math in exactly one place
+and made the slides side a pure geometry pass-through.
+
+## Cross-package type dep needs a rebuild
+
+`@wafflebase/slides` typechecks against `@wafflebase/docs`'s built `dist`,
+not its source. Editing a docs type and running slides `verify:fast`
+fails with a stale-type error until `pnpm --filter @wafflebase/docs build`
+runs. `dist` is gitignored (CI rebuilds in dependency order), so nothing
+to commit — but locally, rebuild docs before trusting a slides typecheck.
 
 ## Same gate, two symptoms
 

--- a/docs/tasks/active/20260616-slides-cell-edit-overflow-lessons.md
+++ b/docs/tasks/active/20260616-slides-cell-edit-overflow-lessons.md
@@ -1,0 +1,38 @@
+# Lessons — slides cell/shape text-edit overflow clipping
+
+## Root cause was an asymmetry, not a single broken value
+
+The bug only made sense by comparing two render paths side by side:
+the in-place editor (canvas bitmap = box → hard clip) vs the committed
+renderer (`paintTextBody` with no `ctx.clip()` → spills to slide edge).
+Neither path was "wrong" in isolation; the defect was that they
+disagreed. Lesson: for "looks different while editing vs after commit"
+bugs, line up the two paint pipelines and diff their clipping/anchoring,
+rather than hunting for one bad number.
+
+## Read the layering before resizing a canvas
+
+The fix hinged on a non-obvious fact: the docs `TextEditor` binds its
+mouse listeners and all `getBoundingClientRect` math to the **container**,
+and uses the **canvas** only for the cosmetic I-beam (`setCanvasCursor`).
+That meant the canvas could be enlarged and set `pointer-events: none`
+without touching cursor-placement or click-outside-to-commit — the whole
+change stayed in the slides wrapper, zero docs edits. Verifying which
+element owns which responsibility *before* coding turned a scary
+cross-package change into a contained one.
+
+## Match the real clip boundary, not an arbitrary margin
+
+First instinct was a fixed overflow margin, which would just relocate the
+same clip. The committed render is bounded by the slide canvas, so
+extending the editing surface to `SLIDE_WIDTH/HEIGHT - frame.origin`
+makes the two pipelines clip at the same place — no discontinuity at
+commit. Tie the fix to the system's actual boundary.
+
+## Same gate, two symptoms
+
+`growMode === 'never'` already meant "fixed box" (shape + cell). Both
+share the identical commit-vs-edit clip mismatch, so the principled fix
+covered shapes for free — the reported cell bug was one instance of a
+class. Relates to [[the shrink fix]] which set cells to `'never'` in the
+first place, making this gate include them.

--- a/docs/tasks/active/20260616-slides-cell-edit-overflow-todo.md
+++ b/docs/tasks/active/20260616-slides-cell-edit-overflow-todo.md
@@ -21,58 +21,71 @@ renderer:
 
 So the same overflow exists in both, but only the editor clips it.
 
-## Approach (option A — make editing match the committed render)
+## Approach (option A — make editing mirror the committed slide canvas)
 
-The committed render effectively clips at the slide canvas. Enlarge the
-editing canvas to the slide's right/bottom edge so overflow paints
-identically, while keeping the interactive box at the cell size.
+The committed render clips only at the slide canvas. So mount the editing
+canvas as a **full-slide surface positioned over the slide** — the box
+sits at its slide coordinates inside it — and shift the docs paint so the
+box content still lands at the box position. Overflow then paints in
+EVERY direction exactly where the committed renderer puts it.
 
 - `container` stays editFrame-sized: outline, mouse listeners, and all
   `getBoundingClientRect` math live on the container, so click→cursor
   mapping is unchanged. Set `container.style.cursor = 'text'` (the
   `pointer-events: none` canvas no longer carries the I-beam).
-- `canvas` grows to `max(frame, slideEdge - frame.origin)` and gets
-  `pointer-events: none` so overflow-region clicks fall through to
-  "click-outside-to-commit".
+- `canvas` becomes `SLIDE_WIDTH × SLIDE_HEIGHT`, absolutely positioned at
+  `(-editFrame.x, -editFrame.y) * scale`, `pointer-events: none` so
+  overflow-region clicks fall through to "click-outside-to-commit".
+- New docs option `paintOriginX/Y` (default 0) shifts all painting (runs,
+  selection, cursor) by `(editFrame.x, editFrame.y)`. Cancelled by the
+  canvas's negative CSS offset, so box content lands at the container
+  origin and pointer math (container-relative) is untouched.
 - `contentWidth/contentHeight` stay `frame.w/h` → wrapping + vertical
-  anchor unchanged; only the paint surface grows.
+  anchor unchanged.
 - Gate: `growMode === 'never'` (shapes + cells). Auto-grow text
   elements never overflow, so they keep the frame-sized canvas.
 
-Known limitation: only right/bottom overflow is covered. Left/top
-overflow (center/right-aligned long tokens, middle/bottom-anchored
-vertical overflow) stays clipped while editing; the common
-top-left-anchored cell case is fully fixed.
+`initializeTextBox` is called only from the slides wrapper, so the new
+docs option is safe (defaults preserve every other path).
 
 ## Plan
 
 - [x] Root-cause investigation (systematic-debugging)
-- [x] `MountSlidesTextBoxOptions.overflowBounds?: { width; height }`
-- [x] Wrapper: enlarge canvas + pointer-events none + container cursor
-- [x] editor.ts: pass overflowBounds for shape/cell (not text)
-- [x] Wrapper unit test: canvas size / pointer-events / container size
-- [x] Editor test: cell dblclick passes overflowBounds to slide bounds
-- [x] `pnpm test` (slides, 258 files) + `pnpm verify:fast` — both green
+- [x] docs `TextBoxEditorOptions.paintOriginX/Y` (default 0) → `paintLayout`
+- [x] `MountSlidesTextBoxOptions.overflowBounds?: { left; top; width; height }`
+- [x] Wrapper: full-slide canvas, absolute offset, pointer-events none,
+      container cursor, `paintOriginX/Y` pass-through
+- [x] editor.ts: pass overflowBounds = full slide rect for shape/cell
+- [x] Wrapper unit test: canvas size / offset / pointer-events / container
+- [x] Editor test: cell dblclick passes full-slide overflowBounds
+- [x] docs + slides suites + `pnpm verify:fast` — all green (docs rebuilt)
 
 ## Review
 
-- `text-box-editor.ts` — added `overflowBounds`. When set and larger than
-  `frame`, the canvas grows to that logical size and gets
-  `pointer-events: none`; the container stays frame-sized and gains
-  `cursor: text` (the docs editor's I-beam rides on the canvas, which no
-  longer receives pointer events). All mouse handling / rect math in the
-  docs `TextEditor` is bound to the **container**, so cursor placement is
-  unchanged; only the paint surface grows.
-- `editor.ts` — passes `overflowBounds` for every non-text target
-  (`growMode === 'never'`: shapes + cells), extending to the slide
-  right/bottom edge. Shapes share the identical commit-vs-edit clip
-  mismatch, so they are fixed by the same gate.
+- `docs/.../text-box-editor.ts` — added `paintOriginX/Y` (default 0),
+  applied to the single `paintLayout` call (which already offsets runs,
+  selection, and cursor by its `originX/originY` args). Only the slides
+  wrapper calls `initializeTextBox`, so no other path is affected.
+- `slides/.../text-box-editor.ts` — `overflowBounds` now describes the
+  full paint rect (`left/top/width/height`). When set, the canvas is
+  mounted at that size, absolutely positioned at `(-left, -top) * scale`,
+  and `pointer-events: none`; the container stays frame-sized and gains
+  `cursor: text`. `paintOriginX/Y = left/top` is forwarded so the box
+  content lands at the container origin while overflow spills into the
+  surrounding canvas in every direction. All mouse / rect math in the
+  docs `TextEditor` is container-relative, so cursor placement, IME, and
+  click-outside-to-commit are unchanged.
+- `slides/.../editor.ts` — passes the whole slide rect (`left = editFrame.x,
+  top = editFrame.y, width/height = SLIDE_WIDTH/HEIGHT`) for every non-text
+  target (`growMode === 'never'`: shapes + cells), so the editing canvas
+  mirrors the committed slide canvas one-to-one. Shapes share the identical
+  commit-vs-edit clip mismatch and are fixed by the same gate.
 
-Verification: `text-box-overflow.test.ts` (3 cases — grow + pointer-events,
-no-bounds no-op, bounds==frame no-op) and a new `cell-text-edit-entry`
-case asserting the editor extends to `SLIDE_WIDTH/HEIGHT - frame.origin`.
-Full slides suite (258 files, 1793 passed) + `verify:fast` green.
+Verification: `text-box-overflow.test.ts` (full-slide canvas + offset +
+pointer-events; no-op when bounds absent or zero-margin) and a
+`cell-text-edit-entry` case asserting the full-slide overflowBounds. Docs
+(59 files) + slides (258 files, 1793 passed) + `verify:fast` green.
 
-Known limitation (documented in todo): only right/bottom overflow is
-covered; left/top overflow (center/right-aligned long tokens,
-middle/bottom-anchored vertical overflow) stays clipped while editing.
+Note: `initializeTextBox`'s cosmetic link-hover cursor (set on the now
+`pointer-events: none` canvas) no longer shows during shape/cell edit; the
+container carries the `text` I-beam. Functionally inert.

--- a/docs/tasks/active/20260616-slides-cell-edit-overflow-todo.md
+++ b/docs/tasks/active/20260616-slides-cell-edit-overflow-todo.md
@@ -1,0 +1,78 @@
+# Slides — text overflowing a cell/shape box is clipped while editing
+
+## Problem
+
+When text overflows the cell width during text-edit mode, the overflow
+is not shown. After committing, the overflowing text renders normally.
+
+## Root cause
+
+Asymmetric clipping between the in-place editor and the committed
+renderer:
+
+- **Editing**: `mountSlidesTextBox` creates a single `<canvas>` sized
+  exactly to the editFrame (cell inner rect). The canvas bitmap is the
+  only clip — `paintLayout` draws every run with no `contentWidth`
+  clip — so glyphs past `frame.w` / `frame.h` are cut at the bitmap
+  edge.
+- **Committed**: `paintCellContents` / `paintShapeText` translate to the
+  box origin and call `paintTextBody` with **no `ctx.clip()`**. Overflow
+  spills onto the full slide canvas, clipped only at the slide bounds.
+
+So the same overflow exists in both, but only the editor clips it.
+
+## Approach (option A — make editing match the committed render)
+
+The committed render effectively clips at the slide canvas. Enlarge the
+editing canvas to the slide's right/bottom edge so overflow paints
+identically, while keeping the interactive box at the cell size.
+
+- `container` stays editFrame-sized: outline, mouse listeners, and all
+  `getBoundingClientRect` math live on the container, so click→cursor
+  mapping is unchanged. Set `container.style.cursor = 'text'` (the
+  `pointer-events: none` canvas no longer carries the I-beam).
+- `canvas` grows to `max(frame, slideEdge - frame.origin)` and gets
+  `pointer-events: none` so overflow-region clicks fall through to
+  "click-outside-to-commit".
+- `contentWidth/contentHeight` stay `frame.w/h` → wrapping + vertical
+  anchor unchanged; only the paint surface grows.
+- Gate: `growMode === 'never'` (shapes + cells). Auto-grow text
+  elements never overflow, so they keep the frame-sized canvas.
+
+Known limitation: only right/bottom overflow is covered. Left/top
+overflow (center/right-aligned long tokens, middle/bottom-anchored
+vertical overflow) stays clipped while editing; the common
+top-left-anchored cell case is fully fixed.
+
+## Plan
+
+- [x] Root-cause investigation (systematic-debugging)
+- [x] `MountSlidesTextBoxOptions.overflowBounds?: { width; height }`
+- [x] Wrapper: enlarge canvas + pointer-events none + container cursor
+- [x] editor.ts: pass overflowBounds for shape/cell (not text)
+- [x] Wrapper unit test: canvas size / pointer-events / container size
+- [x] Editor test: cell dblclick passes overflowBounds to slide bounds
+- [x] `pnpm test` (slides, 258 files) + `pnpm verify:fast` — both green
+
+## Review
+
+- `text-box-editor.ts` — added `overflowBounds`. When set and larger than
+  `frame`, the canvas grows to that logical size and gets
+  `pointer-events: none`; the container stays frame-sized and gains
+  `cursor: text` (the docs editor's I-beam rides on the canvas, which no
+  longer receives pointer events). All mouse handling / rect math in the
+  docs `TextEditor` is bound to the **container**, so cursor placement is
+  unchanged; only the paint surface grows.
+- `editor.ts` — passes `overflowBounds` for every non-text target
+  (`growMode === 'never'`: shapes + cells), extending to the slide
+  right/bottom edge. Shapes share the identical commit-vs-edit clip
+  mismatch, so they are fixed by the same gate.
+
+Verification: `text-box-overflow.test.ts` (3 cases — grow + pointer-events,
+no-bounds no-op, bounds==frame no-op) and a new `cell-text-edit-entry`
+case asserting the editor extends to `SLIDE_WIDTH/HEIGHT - frame.origin`.
+Full slides suite (258 files, 1793 passed) + `verify:fast` green.
+
+Known limitation (documented in todo): only right/bottom overflow is
+covered; left/top overflow (center/right-aligned long tokens,
+middle/bottom-anchored vertical overflow) stays clipped while editing.

--- a/packages/docs/src/view/text-box-editor.ts
+++ b/packages/docs/src/view/text-box-editor.ts
@@ -76,6 +76,21 @@ export interface TextBoxEditorOptions {
   contentHeight: number;
 
   /**
+   * Logical-pixel offset applied to ALL painting (runs, selection,
+   * cursor) so the content's top-left lands at `(paintOriginX,
+   * paintOriginY)` within the canvas instead of `(0, 0)`. Lets the
+   * caller mount a canvas that is LARGER than the content box and place
+   * the box anywhere inside it — used by slides to paint text that
+   * overflows a fixed box (shape / table cell) into the surrounding
+   * canvas area in every direction. Layout, wrapping (`contentWidth`),
+   * the vertical anchor (`contentHeight`), and all pointer math (which
+   * is driven off `container`, not the canvas) are unaffected. Both
+   * default to 0 — the standard "canvas == content box" path.
+   */
+  paintOriginX?: number;
+  paintOriginY?: number;
+
+  /**
    * Called on blur / Escape with the final `Block[]` snapshot. Slides
    * applies the snapshot through `store.withTextElement` to commit it
    * into the Yorkie root.
@@ -390,6 +405,8 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
   let contentHeight = opts.contentHeight;
   const dpr = opts.dpr ?? 1;
   const scale = opts.scale ?? 1;
+  const paintOriginX = opts.paintOriginX ?? 0;
+  const paintOriginY = opts.paintOriginY ?? 0;
   const colorResolver = opts.colorResolver;
 
   // Seed an in-memory store with the supplied blocks. Empty input gets
@@ -556,7 +573,7 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
     // (text, cursor, selection rects) by the vertical anchor offset. The
     // cursor and selectionRects coords above are already in layout-local
     // space; paintLayout adds originY to them internally.
-    paintLayout(ctx, layout, 0, currentOriginY, {
+    paintLayout(ctx, layout, paintOriginX, paintOriginY + currentOriginY, {
       cursor: cursorOpt,
       selectionRects,
       requestRender,

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -3186,6 +3186,20 @@ class SlidesEditorImpl implements SlidesEditor {
       // so the wrapper can inject it on first focus(). Absent for every
       // other entry path (dblclick, F2/Enter, click on empty placeholder).
       initialText: options?.initialText,
+      // Fixed boxes (shape / cell) don't auto-grow, so text can overflow
+      // the box. The committed slide renderer paints that overflow with no
+      // per-box clip (bounded only by the slide edge), but the editing
+      // canvas would otherwise clip it at the box. Enlarge the editing
+      // paint surface to the slide's right/bottom edge so live editing
+      // matches the committed render. Text elements auto-grow instead, so
+      // they never overflow and keep the frame-sized canvas.
+      overflowBounds:
+        target.kind === 'text'
+          ? undefined
+          : {
+              width: Math.max(target.editFrame.w, SLIDE_WIDTH - target.editFrame.x),
+              height: Math.max(target.editFrame.h, SLIDE_HEIGHT - target.editFrame.y),
+            },
       onContentHeightChange: (h: number): void => {
         const changed = this.lastEditingContentHeight !== h;
         this.lastEditingContentHeight = h;

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -3188,17 +3188,20 @@ class SlidesEditorImpl implements SlidesEditor {
       initialText: options?.initialText,
       // Fixed boxes (shape / cell) don't auto-grow, so text can overflow
       // the box. The committed slide renderer paints that overflow with no
-      // per-box clip (bounded only by the slide edge), but the editing
-      // canvas would otherwise clip it at the box. Enlarge the editing
-      // paint surface to the slide's right/bottom edge so live editing
-      // matches the committed render. Text elements auto-grow instead, so
-      // they never overflow and keep the frame-sized canvas.
+      // per-box clip — bounded only by the slide edge. Mount the editing
+      // canvas as a full-slide surface positioned over the slide (the box
+      // sits `editFrame.x/y` px inside it) so live overflow paints in every
+      // direction exactly where the committed render puts it. Text elements
+      // auto-grow instead, so they never overflow and keep the frame-sized
+      // canvas.
       overflowBounds:
         target.kind === 'text'
           ? undefined
           : {
-              width: Math.max(target.editFrame.w, SLIDE_WIDTH - target.editFrame.x),
-              height: Math.max(target.editFrame.h, SLIDE_HEIGHT - target.editFrame.y),
+              left: target.editFrame.x,
+              top: target.editFrame.y,
+              width: SLIDE_WIDTH,
+              height: SLIDE_HEIGHT,
             },
       onContentHeightChange: (h: number): void => {
         const changed = this.lastEditingContentHeight !== h;

--- a/packages/slides/src/view/editor/text-box-editor.ts
+++ b/packages/slides/src/view/editor/text-box-editor.ts
@@ -175,6 +175,21 @@ export interface MountSlidesTextBoxOptions {
    * See docs/design/slides/slides-hover-and-text-edit-entry.md § P2.6.
    */
   initialText?: string;
+  /**
+   * Paint surface size (logical px) for fixed boxes whose text can
+   * overflow — shapes and table cells (`growMode: 'never'`). When set
+   * and larger than `frame`, the editing canvas is enlarged to this
+   * size so overflowing text is painted live exactly as the committed
+   * slide renderer paints it (neither clips the overflow; the committed
+   * canvas is bounded only by the slide edge). The interactive box stays
+   * `frame`-sized: the container keeps the outline + mouse listeners, and
+   * the enlarged canvas is `pointer-events: none` so clicks past the box
+   * still fall through to "click-outside-to-commit". `contentWidth/Height`
+   * stay `frame.w/h`, so wrapping and vertical anchor are unaffected —
+   * only the surface grows (to the right / bottom). Omitted for
+   * auto-growing text elements, which never overflow.
+   */
+  overflowBounds?: { width: number; height: number };
 }
 
 export interface SlidesTextBoxEditor {
@@ -256,7 +271,7 @@ export interface SlidesTextBoxEditor {
 }
 
 export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextBoxEditor {
-  const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest, onContentHeightChange, colorResolver, autofit, verticalAnchor, growMode, initialText } = opts;
+  const { overlay, frame, scale, blocks, onCommit, onCancel, onLinkRequest, onContentHeightChange, colorResolver, autofit, verticalAnchor, growMode, initialText, overflowBounds } = opts;
   // Deck-level font pre-scale (from `deckFontScale(meta)`). Composed
   // ahead of shrink-autofit so the editor reads the same effective
   // font size the committed canvas paints. Defaults to `1` so existing
@@ -305,21 +320,47 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
   }
   overlay.appendChild(container);
 
+  // Paint surface size (logical px). For auto-growing text elements this
+  // is exactly the frame. For fixed boxes (shape / cell) the caller may
+  // pass `overflowBounds` to enlarge the canvas past the frame so text
+  // that overflows the box is painted live — matching the committed slide
+  // renderer, which paints cell/shape overflow with no per-box clip. We
+  // only grow to the right / bottom (origin stays at the frame top-left);
+  // `contentWidth/Height` below stay `frame.w/h` so wrapping and the
+  // vertical anchor are unchanged.
+  const canvasLogicalW = overflowBounds
+    ? Math.max(frame.w, overflowBounds.width)
+    : frame.w;
+  const canvasLogicalH = overflowBounds
+    ? Math.max(frame.h, overflowBounds.height)
+    : frame.h;
+  const overflowing = canvasLogicalW > frame.w || canvasLogicalH > frame.h;
+
   const canvas = document.createElement('canvas');
-  // CSS size (host pixels) = frame * scale; bitmap pixel size also
+  // CSS size (host pixels) = surface * scale; bitmap pixel size also
   // accounts for devicePixelRatio so high-DPI displays paint at native
   // resolution instead of being upscaled by the browser (which would
   // produce blurry text). The text-box editor's paint path then scales
   // its draws by `dpr` so logical text-box coords still map 1:1 to host
   // CSS pixels.
   const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1;
-  const cssW = Math.max(1, Math.round(frame.w * scale));
-  const cssH = Math.max(1, Math.round(frame.h * scale));
+  const cssW = Math.max(1, Math.round(canvasLogicalW * scale));
+  const cssH = Math.max(1, Math.round(canvasLogicalH * scale));
   canvas.width = Math.max(1, Math.round(cssW * dpr));
   canvas.height = Math.max(1, Math.round(cssH * dpr));
   canvas.style.width = `${cssW}px`;
   canvas.style.height = `${cssH}px`;
   canvas.style.display = 'block';
+  if (overflowing) {
+    // The canvas now extends past the cell/shape box (the container). Let
+    // clicks in that overflow region fall through to the slide canvas so
+    // "click outside the box to commit" still fires; the container (still
+    // frame-sized) keeps the mouse listeners for in-box cursor placement.
+    // The container also carries the I-beam now — the docs editor sets the
+    // text cursor on the canvas, which no longer receives pointer events.
+    canvas.style.pointerEvents = 'none';
+    container.style.cursor = 'text';
+  }
   container.appendChild(canvas);
 
   let mounted = true;

--- a/packages/slides/src/view/editor/text-box-editor.ts
+++ b/packages/slides/src/view/editor/text-box-editor.ts
@@ -176,20 +176,25 @@ export interface MountSlidesTextBoxOptions {
    */
   initialText?: string;
   /**
-   * Paint surface size (logical px) for fixed boxes whose text can
-   * overflow — shapes and table cells (`growMode: 'never'`). When set
-   * and larger than `frame`, the editing canvas is enlarged to this
-   * size so overflowing text is painted live exactly as the committed
-   * slide renderer paints it (neither clips the overflow; the committed
-   * canvas is bounded only by the slide edge). The interactive box stays
-   * `frame`-sized: the container keeps the outline + mouse listeners, and
-   * the enlarged canvas is `pointer-events: none` so clicks past the box
-   * still fall through to "click-outside-to-commit". `contentWidth/Height`
-   * stay `frame.w/h`, so wrapping and vertical anchor are unaffected —
-   * only the surface grows (to the right / bottom). Omitted for
-   * auto-growing text elements, which never overflow.
+   * Paint surface for fixed boxes whose text can overflow — shapes and
+   * table cells (`growMode: 'never'`). When set, the editing canvas is
+   * enlarged to `width × height` (logical px) and positioned so the box
+   * sits `left` px from its left edge and `top` px from its top, letting
+   * overflowing text paint in EVERY direction exactly as the committed
+   * slide renderer does (which clips only at the slide edge). Slides
+   * passes the whole slide rect, so the editing canvas mirrors the
+   * committed slide canvas one-to-one.
+   *
+   * The interactive box stays `frame`-sized: the container keeps the
+   * outline + mouse listeners (all pointer math is container-relative),
+   * and the enlarged canvas is `pointer-events: none` so clicks past the
+   * box still fall through to "click-outside-to-commit". `contentWidth/
+   * Height` stay `frame.w/h`, so wrapping and the vertical anchor are
+   * unaffected; `left`/`top` flow through to the docs editor's
+   * `paintOriginX/Y` so the box content still lands at the box position.
+   * Omitted for auto-growing text elements, which never overflow.
    */
-  overflowBounds?: { width: number; height: number };
+  overflowBounds?: { left: number; top: number; width: number; height: number };
 }
 
 export interface SlidesTextBoxEditor {
@@ -320,21 +325,20 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
   }
   overlay.appendChild(container);
 
-  // Paint surface size (logical px). For auto-growing text elements this
-  // is exactly the frame. For fixed boxes (shape / cell) the caller may
-  // pass `overflowBounds` to enlarge the canvas past the frame so text
-  // that overflows the box is painted live — matching the committed slide
-  // renderer, which paints cell/shape overflow with no per-box clip. We
-  // only grow to the right / bottom (origin stays at the frame top-left);
-  // `contentWidth/Height` below stay `frame.w/h` so wrapping and the
-  // vertical anchor are unchanged.
-  const canvasLogicalW = overflowBounds
-    ? Math.max(frame.w, overflowBounds.width)
-    : frame.w;
-  const canvasLogicalH = overflowBounds
-    ? Math.max(frame.h, overflowBounds.height)
-    : frame.h;
-  const overflowing = canvasLogicalW > frame.w || canvasLogicalH > frame.h;
+  // Paint surface (logical px). For auto-growing text elements this is
+  // exactly the frame. For fixed boxes (shape / cell) the caller may pass
+  // `overflowBounds` to mount a LARGER canvas with the box positioned
+  // `left`/`top` px inside it, so text that overflows the box is painted
+  // live in every direction — matching the committed slide renderer,
+  // which paints cell/shape overflow with no per-box clip. `contentWidth/
+  // Height` below stay `frame.w/h` so wrapping and the vertical anchor are
+  // unchanged; `left`/`top` become the docs editor's `paintOriginX/Y`.
+  const canvasLogicalW = overflowBounds ? overflowBounds.width : frame.w;
+  const canvasLogicalH = overflowBounds ? overflowBounds.height : frame.h;
+  const padLeft = overflowBounds ? overflowBounds.left : 0;
+  const padTop = overflowBounds ? overflowBounds.top : 0;
+  const overflowing =
+    canvasLogicalW > frame.w || canvasLogicalH > frame.h || padLeft > 0 || padTop > 0;
 
   const canvas = document.createElement('canvas');
   // CSS size (host pixels) = surface * scale; bitmap pixel size also
@@ -352,12 +356,20 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
   canvas.style.height = `${cssH}px`;
   canvas.style.display = 'block';
   if (overflowing) {
-    // The canvas now extends past the cell/shape box (the container). Let
-    // clicks in that overflow region fall through to the slide canvas so
-    // "click outside the box to commit" still fires; the container (still
-    // frame-sized) keeps the mouse listeners for in-box cursor placement.
-    // The container also carries the I-beam now — the docs editor sets the
-    // text cursor on the canvas, which no longer receives pointer events.
+    // Position the enlarged canvas so the box (the container's content
+    // box at 0,0) sits `left`/`top` px inside it — the canvas extends up
+    // and to the left as well as down/right. `paintOriginX/Y` below shift
+    // the docs paint by the same amount, so the box content lands exactly
+    // at the container origin while overflow spills into the surrounding
+    // canvas area.
+    canvas.style.position = 'absolute';
+    canvas.style.left = `${-padLeft * scale}px`;
+    canvas.style.top = `${-padTop * scale}px`;
+    // Let clicks in the overflow region fall through to the slide canvas
+    // so "click outside the box to commit" still fires; the container
+    // (still frame-sized) keeps the mouse listeners for in-box cursor
+    // placement. The container carries the I-beam now — the docs editor
+    // sets the text cursor on the canvas, which no longer takes events.
     canvas.style.pointerEvents = 'none';
     container.style.cursor = 'text';
   }
@@ -424,6 +436,12 @@ export function mountSlidesTextBox(opts: MountSlidesTextBoxOptions): SlidesTextB
     // (`cssW * browser dpr` = `frame.w * scale * browser dpr`).
     contentWidth: frame.w,
     contentHeight: frame.h,
+    // Shift the docs paint so the box content lands at the container
+    // origin even though the canvas extends `padLeft`/`padTop` px above
+    // and to the left (overflow paint room). Both 0 for the frame-sized
+    // canvas (no overflowBounds).
+    paintOriginX: padLeft,
+    paintOriginY: padTop,
     dpr: dpr * scale,
     // The container CSS size is `frame * scale` host pixels but
     // `contentWidth/Height` are in logical pixels — pass `scale` so the

--- a/packages/slides/test/view/editor/cell-text-edit-entry.test.ts
+++ b/packages/slides/test/view/editor/cell-text-edit-entry.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, afterEach } from 'vitest';
 import '../../../src/view/canvas/test-canvas-env';
 import type { TableElement } from '../../../src/model/element';
+import { SLIDE_WIDTH, SLIDE_HEIGHT } from '../../../src/model/presentation';
 import { MemSlidesStore } from '../../../src/store/memory';
 import { initialize, type SlidesEditor } from '../../../src/view/editor/editor';
 import type {
@@ -114,5 +115,38 @@ describe('table cell text-edit entry — box sizing', () => {
     // editFrame height ≈ cell height (100) minus top/bottom padding;
     // a shrunk box would be far smaller than this.
     expect(captured.opts!.frame.h).toBeGreaterThan(50);
+  });
+
+  it('extends the paint surface to the slide bounds so overflow shows', () => {
+    const { canvas, overlay, store } = setup();
+    let sid = '';
+    store.batch(() => {
+      sid = store.addSlide('blank');
+      store.addElement(sid, {
+        type: 'table',
+        frame: { x: 200, y: 200, w: 200, h: 200, rotation: 0 },
+        data: tableData(),
+      });
+    });
+
+    const captured: { opts?: MountSlidesTextBoxOptions } = {};
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: makeCapturingMount(captured),
+    });
+
+    canvas.dispatchEvent(
+      new MouseEvent('dblclick', { clientX: 250, clientY: 250, bubbles: true }),
+    );
+
+    const opts = captured.opts!;
+    expect(opts.overflowBounds).toBeDefined();
+    // Editing text that overflows the cell must paint up to the slide
+    // edge — exactly where the committed renderer clips it.
+    expect(opts.overflowBounds!.width).toBe(SLIDE_WIDTH - opts.frame.x);
+    expect(opts.overflowBounds!.height).toBe(SLIDE_HEIGHT - opts.frame.y);
+    // And the surface is strictly larger than the cell box.
+    expect(opts.overflowBounds!.width).toBeGreaterThan(opts.frame.w);
   });
 });

--- a/packages/slides/test/view/editor/cell-text-edit-entry.test.ts
+++ b/packages/slides/test/view/editor/cell-text-edit-entry.test.ts
@@ -142,11 +142,13 @@ describe('table cell text-edit entry — box sizing', () => {
 
     const opts = captured.opts!;
     expect(opts.overflowBounds).toBeDefined();
-    // Editing text that overflows the cell must paint up to the slide
-    // edge — exactly where the committed renderer clips it.
-    expect(opts.overflowBounds!.width).toBe(SLIDE_WIDTH - opts.frame.x);
-    expect(opts.overflowBounds!.height).toBe(SLIDE_HEIGHT - opts.frame.y);
-    // And the surface is strictly larger than the cell box.
-    expect(opts.overflowBounds!.width).toBeGreaterThan(opts.frame.w);
+    // The editing canvas mirrors the committed slide canvas: a full-slide
+    // surface with the cell positioned at its slide coordinates, so
+    // overflow paints in every direction exactly where the committed
+    // renderer puts it.
+    expect(opts.overflowBounds!.width).toBe(SLIDE_WIDTH);
+    expect(opts.overflowBounds!.height).toBe(SLIDE_HEIGHT);
+    expect(opts.overflowBounds!.left).toBe(opts.frame.x);
+    expect(opts.overflowBounds!.top).toBe(opts.frame.y);
   });
 });

--- a/packages/slides/test/view/editor/text-box-overflow.test.ts
+++ b/packages/slides/test/view/editor/text-box-overflow.test.ts
@@ -5,12 +5,13 @@ import type { Block } from '@wafflebase/docs';
 import { mountSlidesTextBox } from '../../../src/view/editor/text-box-editor';
 
 /**
- * `overflowBounds` enlarges the editing paint surface past the box so
- * text that overflows a fixed box (shape / table cell) is painted live,
- * matching the committed slide renderer (which clips only at the slide
- * edge). The interactive box stays frame-sized: the container keeps its
- * size + mouse listeners, and the enlarged canvas is `pointer-events:
- * none` so clicks past the box still fall through to commit-outside.
+ * `overflowBounds` mounts a LARGER editing canvas with the box positioned
+ * `left`/`top` px inside it, so text that overflows a fixed box (shape /
+ * table cell) is painted live in every direction — matching the committed
+ * slide renderer (which clips only at the slide edge). The interactive box
+ * stays frame-sized: the container keeps its size + mouse listeners, and
+ * the enlarged canvas is `pointer-events: none` so clicks past the box
+ * still fall through to commit-outside.
  */
 function block(text: string): Block {
   return {
@@ -31,7 +32,7 @@ describe('mountSlidesTextBox overflow paint surface', () => {
 
   const FRAME = { x: 200, y: 150, w: 100, h: 80, rotation: 0 };
 
-  it('enlarges the canvas and disables its pointer events when overflowBounds is set', () => {
+  it('mounts a full-slide canvas offset so the box content lands at the origin', () => {
     const tb = mountSlidesTextBox({
       overlay,
       frame: FRAME,
@@ -39,14 +40,19 @@ describe('mountSlidesTextBox overflow paint surface', () => {
       blocks: [block('Long overflowing text')],
       onCommit: (): void => {},
       onCancel: (): void => {},
-      // Slide-bounds extent the editor would compute for a cell at (200,150).
-      overflowBounds: { width: 1720, height: 930 },
+      // Full slide rect the editor passes for a box at (200,150).
+      overflowBounds: { left: 200, top: 150, width: 1920, height: 1080 },
     });
 
     const canvas = tb.container.querySelector('canvas')!;
-    // Canvas grows to the overflow extent (logical * scale).
-    expect(canvas.style.width).toBe('1720px');
-    expect(canvas.style.height).toBe('930px');
+    // Canvas spans the whole slide (logical * scale).
+    expect(canvas.style.width).toBe('1920px');
+    expect(canvas.style.height).toBe('1080px');
+    // Positioned so the box sits left/top px inside it — extends up/left
+    // (and down/right) of the box for overflow in every direction.
+    expect(canvas.style.position).toBe('absolute');
+    expect(canvas.style.left).toBe('-200px');
+    expect(canvas.style.top).toBe('-150px');
     // Clicks over the overflow region must fall through to the slide.
     expect(canvas.style.pointerEvents).toBe('none');
     // The interactive box (container) stays frame-sized and keeps the I-beam.
@@ -70,13 +76,14 @@ describe('mountSlidesTextBox overflow paint surface', () => {
     const canvas = tb.container.querySelector('canvas')!;
     expect(canvas.style.width).toBe('100px');
     expect(canvas.style.height).toBe('80px');
-    // No overflow → canvas keeps default pointer events (captured by container).
+    // No overflow → canvas keeps default flow + pointer events.
+    expect(canvas.style.position).toBe('');
     expect(canvas.style.pointerEvents).toBe('');
 
     tb.detach();
   });
 
-  it('does not shrink the canvas below the frame for small overflowBounds', () => {
+  it('does not offset the canvas when the box already fills the bounds', () => {
     const tb = mountSlidesTextBox({
       overlay,
       frame: FRAME,
@@ -84,14 +91,15 @@ describe('mountSlidesTextBox overflow paint surface', () => {
       blocks: [block('hi')],
       onCommit: (): void => {},
       onCancel: (): void => {},
-      // A box flush against the slide edge: bounds == frame, no growth.
-      overflowBounds: { width: 100, height: 80 },
+      // A box whose bounds equal its own size with no margin: no growth.
+      overflowBounds: { left: 0, top: 0, width: 100, height: 80 },
     });
 
     const canvas = tb.container.querySelector('canvas')!;
     expect(canvas.style.width).toBe('100px');
     expect(canvas.style.height).toBe('80px');
-    // Not overflowing → pointer events stay on the canvas.
+    // Not overflowing → canvas stays in flow with pointer events.
+    expect(canvas.style.position).toBe('');
     expect(canvas.style.pointerEvents).toBe('');
 
     tb.detach();

--- a/packages/slides/test/view/editor/text-box-overflow.test.ts
+++ b/packages/slides/test/view/editor/text-box-overflow.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import type { Block } from '@wafflebase/docs';
+import { mountSlidesTextBox } from '../../../src/view/editor/text-box-editor';
+
+/**
+ * `overflowBounds` enlarges the editing paint surface past the box so
+ * text that overflows a fixed box (shape / table cell) is painted live,
+ * matching the committed slide renderer (which clips only at the slide
+ * edge). The interactive box stays frame-sized: the container keeps its
+ * size + mouse listeners, and the enlarged canvas is `pointer-events:
+ * none` so clicks past the box still fall through to commit-outside.
+ */
+function block(text: string): Block {
+  return {
+    id: 'b1', type: 'paragraph',
+    inlines: [{ text, style: {} }],
+    style: {},
+  } as Block;
+}
+
+describe('mountSlidesTextBox overflow paint surface', () => {
+  let overlay: HTMLDivElement;
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    overlay = document.createElement('div');
+    overlay.style.position = 'absolute';
+    document.body.appendChild(overlay);
+  });
+
+  const FRAME = { x: 200, y: 150, w: 100, h: 80, rotation: 0 };
+
+  it('enlarges the canvas and disables its pointer events when overflowBounds is set', () => {
+    const tb = mountSlidesTextBox({
+      overlay,
+      frame: FRAME,
+      scale: 1,
+      blocks: [block('Long overflowing text')],
+      onCommit: (): void => {},
+      onCancel: (): void => {},
+      // Slide-bounds extent the editor would compute for a cell at (200,150).
+      overflowBounds: { width: 1720, height: 930 },
+    });
+
+    const canvas = tb.container.querySelector('canvas')!;
+    // Canvas grows to the overflow extent (logical * scale).
+    expect(canvas.style.width).toBe('1720px');
+    expect(canvas.style.height).toBe('930px');
+    // Clicks over the overflow region must fall through to the slide.
+    expect(canvas.style.pointerEvents).toBe('none');
+    // The interactive box (container) stays frame-sized and keeps the I-beam.
+    expect(tb.container.style.width).toBe('100px');
+    expect(tb.container.style.height).toBe('80px');
+    expect(tb.container.style.cursor).toBe('text');
+
+    tb.detach();
+  });
+
+  it('keeps the canvas at frame size when overflowBounds is absent', () => {
+    const tb = mountSlidesTextBox({
+      overlay,
+      frame: FRAME,
+      scale: 1,
+      blocks: [block('hi')],
+      onCommit: (): void => {},
+      onCancel: (): void => {},
+    });
+
+    const canvas = tb.container.querySelector('canvas')!;
+    expect(canvas.style.width).toBe('100px');
+    expect(canvas.style.height).toBe('80px');
+    // No overflow → canvas keeps default pointer events (captured by container).
+    expect(canvas.style.pointerEvents).toBe('');
+
+    tb.detach();
+  });
+
+  it('does not shrink the canvas below the frame for small overflowBounds', () => {
+    const tb = mountSlidesTextBox({
+      overlay,
+      frame: FRAME,
+      scale: 1,
+      blocks: [block('hi')],
+      onCommit: (): void => {},
+      onCancel: (): void => {},
+      // A box flush against the slide edge: bounds == frame, no growth.
+      overflowBounds: { width: 100, height: 80 },
+    });
+
+    const canvas = tb.container.querySelector('canvas')!;
+    expect(canvas.style.width).toBe('100px');
+    expect(canvas.style.height).toBe('80px');
+    // Not overflowing → pointer events stay on the canvas.
+    expect(canvas.style.pointerEvents).toBe('');
+
+    tb.detach();
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #367.

Text that overflows a table cell (or shape) box was clipped during
text-edit mode but rendered normally after commit. Root cause is an
asymmetry between two paint paths:

- **Editing** — the in-place editor paints into a `<canvas>` sized
  exactly to the box, so the canvas bitmap clips any overflow.
- **Committed** — `paintCellContents` / `paintShapeText` paint via
  `paintTextBody` with **no `ctx.clip()`**, so overflow spills onto the
  full slide canvas, clipped only at the slide edge.

### Fix — make the editing surface mirror the committed slide canvas

Mount the editing canvas as a **full-slide surface positioned over the
slide** (the box sits at its slide coordinates inside it) and shift the
docs paint so the box content still lands at the box position. Overflow
then paints in **every** direction exactly where the committed renderer
puts it.

- New docs option `paintOriginX/Y` (default 0) offsets all painting
  (runs, selection, cursor) via `paintLayout`'s existing `originX/originY`
  args. `initializeTextBox` is called only from the slides wrapper, so
  every other path is unaffected.
- Slides wrapper: when `overflowBounds` is set, the canvas becomes
  `SLIDE_WIDTH × SLIDE_HEIGHT`, absolutely positioned at
  `(-left, -top) * scale`, `pointer-events: none` (so clicks past the box
  fall through to click-outside-to-commit); `paintOriginX/Y = left/top`.
  The negative CSS offset cancels the paint offset, so the box content
  lands at the container origin and **all container-relative pointer math
  (cursor placement, IME, click-outside) is unchanged**. The container
  stays box-sized and carries the I-beam (`cursor: text`).
- `contentWidth/contentHeight` stay at the box size → wrapping and the
  vertical anchor are untouched; only the paint surface grows.
- Gate: `growMode === 'never'` (shapes + cells). Shapes share the
  identical clip mismatch and are fixed by the same gate. Auto-grow text
  elements never overflow and keep the frame-sized canvas.

The whole change stays in the slides layer plus one default-0 docs option.

## Test plan

- `text-box-overflow.test.ts` — real `mountSlidesTextBox`: full-slide
  canvas, `(-left,-top)` offset, `pointer-events: none`, container stays
  frame-sized with `cursor: text`; no-op when `overflowBounds` absent or
  zero-margin.
- `cell-text-edit-entry.test.ts` — dblclick a cell asserts the editor
  passes the full-slide rect (`left/top = frame.x/y`, `width/height =
  SLIDE_WIDTH/HEIGHT`).
- docs (59 files) + full slides suite (258 files, 1793 passed); `pnpm
  verify:fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text overflow clipping behavior to match the final rendered result during editing.

* **New Features**
  * Added support for controlling text overflow rendering in editors (shapes and cells).
  * Introduced paint origin offset controls for editor positioning.

* **Tests**
  * Added test coverage for text editor overflow handling.

* **Documentation**
  * Added documentation for the text overflow clipping fix and implementation strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->