### PR TITLE
Slides: import & render custom-geometry (freeform) shapes

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides freeform custgeom (2026-06-18) | [20260618-slides-freeform-custgeom-todo.md](./active/20260618-slides-freeform-custgeom-todo.md) | [20260618-slides-freeform-custgeom-lessons.md](./active/20260618-slides-freeform-custgeom-lessons.md) |
 | slides color picker recent (2026-06-17) | [20260617-slides-color-picker-recent-todo.md](./active/20260617-slides-color-picker-recent-todo.md) | [20260617-slides-color-picker-recent-lessons.md](./active/20260617-slides-color-picker-recent-lessons.md) |
 | slides cell edit overflow (2026-06-16) | [20260616-slides-cell-edit-overflow-todo.md](./active/20260616-slides-cell-edit-overflow-todo.md) | [20260616-slides-cell-edit-overflow-lessons.md](./active/20260616-slides-cell-edit-overflow-lessons.md) |
 | slides cell edit shrink (2026-06-16) | [20260616-slides-cell-edit-shrink-todo.md](./active/20260616-slides-cell-edit-shrink-todo.md) | [20260616-slides-cell-edit-shrink-lessons.md](./active/20260616-slides-cell-edit-shrink-lessons.md) |
@@ -38,4 +39,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 273
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides color picker recent (2026-06-17)
+Latest active task: slides freeform custgeom (2026-06-18)

--- a/docs/tasks/active/20260618-slides-freeform-custgeom-lessons.md
+++ b/docs/tasks/active/20260618-slides-freeform-custgeom-lessons.md
@@ -1,0 +1,62 @@
+# Lessons — Slides freeform (custGeom) import & render
+
+## What was wrong
+
+`parseSp` (`import/pptx/shape.ts`) dispatched on `txBox → blipFill →
+prstGeom → txBody`, else `return []`. OOXML `<a:custGeom>` freeforms with a
+solid fill and no image/text matched no branch and were **silently
+dropped**. The user's deck slide 1 lost 15 such shapes (decorative blobs,
+e.g. the bottom-right `#4B6BF5` background). The renderer/model also had no
+freeform path type, so even a branch would have had nowhere to draw.
+
+## Fix shape
+
+1. Model: new `'freeform'` ShapeKind + `FreeformPath`/`FreeformCommand`
+   (commands normalized to `[0,1]` of the source path viewBox) + optional
+   `ShapeElement.data.path`.
+2. Parser: `parseCustGeomPath` normalizes `<a:path w h>/<a:pt>` per its own
+   viewBox; reduces `<a:arcTo>` to a centre-parametrised arc.
+3. Renderer: special-case `freeform` in `drawShape` (before
+   `PATH_BUILDERS`, like action buttons) — data-driven geometry can't be a
+   parametric `PathBuilder`.
+4. Dispatch: custGeom branch after prstGeom, mirroring its text/placeholder
+   folding.
+
+## Lessons / gotchas
+
+- **Anisotropic normalize/rescale is self-consistent.** Storing a point as
+  `(x/pathW, y/pathH)` and painting it as `(nx*frameW, ny*frameH)` applies
+  the same per-axis scale to every coordinate — including arc radii
+  (`rx=wR/pathW`, painted `rx*frameW`), so `Path2D.ellipse` arcs join the
+  pen without a spurious connecting line.
+- **OOXML angles are 60000ths of a degree**; positive sweep is clockwise in
+  screen space (y-down), which maps to canvas `ellipse(..., counterclockwise
+  = sweep < 0)`.
+- **Adding a `ShapeKind` member is safe** because every `Record<ShapeKind>`
+  in the repo is `Partial<...>` (`shape-icon`, `connection-sites/overrides`)
+  and the picker iterates an explicit list, not the union. Freeform stays
+  import-only with no picker/handle UX.
+- **Persistence round-trips for free**: the import path assigns
+  `r.slides = pending.slides` wholesale, `readElement`'s generic shape
+  branch unwraps `data` via `yorkieToPlain`, and `migrate` spreads
+  `...el.data` — none of them whitelist data keys, so `path` survives
+  collaboration + reload without extra wiring.
+- **Existing decks are not retroactively fixed.** A document imported before
+  this change already has the freeforms dropped in its Yorkie state; the
+  source deck must be re-imported to recover them.
+
+## Verification
+
+- Unit: `freeform.test.ts` (parser normalize / quad / arc / no-viewBox +
+  dispatch-keeps-solid-freeform) and `shape-renderer.test.ts` freeform
+  fill/stroke/placeholder. `pnpm verify:fast` green.
+- End-to-end: a throwaway test ran `importPptx` on the real deck →
+  slide 1 imported **15 freeform shapes** (recursive), vs **0** on `main`.
+  (Deleted after confirming.)
+
+## Out of scope (v1)
+
+Freeform drawing UI / picker / drag-handle editing; `<p:style>` fillRef
+(style-ref) fills (affects the no-explicit-fill freeforms — pre-existing
+limitation, also true for prstGeom shapes); gradient/pattern fills; PDF
+export (not yet in source).

--- a/docs/tasks/active/20260618-slides-freeform-custgeom-todo.md
+++ b/docs/tasks/active/20260618-slides-freeform-custgeom-todo.md
@@ -1,0 +1,77 @@
+# Slides: import & render custom-geometry (freeform) shapes
+
+> **Status (2026-06-18): DONE.** All plan items implemented + tested.
+> `pnpm verify:fast` green. End-to-end re-import of the user's deck now
+> yields 15 freeform shapes on slide 1 (0 on `main`). See the matching
+> `*-lessons.md`.
+
+## Problem
+
+PPTX `<a:custGeom>` freeform shapes are silently dropped on import.
+`parseSp` (`packages/slides/src/import/pptx/shape.ts`) dispatches only on
+`txBox` → `blipFill` → `prstGeom` → `txBody`, else `return []`. A custom
+freeform with a solid/scheme fill and no image and no text matches no branch
+and vanishes.
+
+Repro: the user's deck
+(`베이지 화이트 알록달록 … 프레젠테이션.pptx`) slide 1, bottom-right
+Group 5 → Freeform 7 (`custGeom` + `solidFill #4B6BF5`, no text) is dropped,
+so its background does not render. Slide 1 alone drops 15 custGeom freeforms;
+only the 2 with a `blipFill` (treated as images) survive.
+
+Root cause is twofold:
+1. The model/renderer has **no** freeform (path) shape type.
+2. The importer has **no** `custGeom` branch.
+
+## Goal
+
+Import custGeom freeforms as a new `freeform` ShapeKind that stores a
+normalized vector path, and render it (fill + stroke) in the canvas
+renderer. Import-only for v1 (no picker / drag-handle editing UX, matching
+how blip-clip-path loss is already accepted for v1).
+
+## Plan
+
+### Model — `packages/slides/src/model/element.ts`
+- [ ] Add `'freeform'` to the `ShapeKind` union.
+- [ ] Add `FreeformPath` / `FreeformCommand` types (commands normalized to
+      `[0,1]` of the path viewBox: `M`/`L`/`Q`/`C`/`A`/`Z`).
+- [ ] Add optional `path?: FreeformPath` to `ShapeElement['data']`.
+
+### Path builder — `packages/slides/src/view/canvas/shapes/freeform.ts` (new)
+- [ ] `buildFreeformPath(size, path): Path2D` — scale normalized commands to
+      frame px. Exported for tests + future PDF reuse.
+
+### Renderer — `packages/slides/src/view/canvas/shape-renderer.ts`
+- [ ] Special-case `data.kind === 'freeform'` in `drawShape` (before the
+      `PATH_BUILDERS` lookup, like action buttons): build path from
+      `data.path`, fill (nonzero) + stroke with the shared logic. Missing
+      `data.path` → placeholder rect fallback.
+
+### Parser — `packages/slides/src/import/pptx/freeform.ts` (new)
+- [ ] `parseCustGeomPath(custGeom): FreeformPath | undefined` — read
+      `<a:pathLst>/<a:path w h>`, normalize each `<a:pt>` by that path's
+      `w`/`h`, map `moveTo`/`lnTo`/`quadBezTo`/`cubicBezTo`/`arcTo`/`close`.
+      Concatenate multiple `<a:path>` elements.
+
+### Dispatch — `packages/slides/src/import/pptx/shape.ts`
+- [ ] Add a `custGeom` branch after `prstGeom`: build a `freeform`
+      ShapeElement (reuse `parseShapeFill` / `parseShapeStroke`), fold in
+      `txBody` text + `placeholderRef` exactly like the prstGeom branch.
+
+### Tests (TDD — write failing first)
+- [ ] `test/import/pptx/freeform.test.ts` — parse a custGeom path → normalized
+      commands; dispatch keeps a solid-fill freeform (no longer dropped).
+- [ ] renderer test — `drawShape` on a freeform issues fill/stroke (extend
+      existing shape-renderer test harness).
+
+### Verify
+- [ ] `pnpm verify:fast`
+- [ ] Re-run the dispatch simulation against the user's slide 1: 0 dropped.
+- [ ] Manual smoke in `pnpm dev` if practical.
+
+## Non-Goals (v1)
+- Freeform drawing UI / shape picker entry / drag-handle editing.
+- arcTo exactness beyond elliptical-arc approximation.
+- PDF export (slides PDF export is not yet in source).
+- Path fill-rule attrs (`<a:path fill="...">`), gradient/pattern fills.

--- a/packages/slides/src/import/pptx/freeform.ts
+++ b/packages/slides/src/import/pptx/freeform.ts
@@ -1,0 +1,141 @@
+import type { FreeformCommand, FreeformPath } from '../../model/element';
+import { attrInt, child, children } from './xml';
+
+/** OOXML angles are in 60000ths of a degree. */
+function angToRad(v: number): number {
+  return (v / 60_000) * (Math.PI / 180);
+}
+
+function pt(el: Element | undefined): { x: number; y: number } | undefined {
+  if (!el) return undefined;
+  const x = attrInt(el, 'x');
+  const y = attrInt(el, 'y');
+  if (x == null || y == null) return undefined;
+  return { x, y };
+}
+
+/**
+ * Parse an OOXML `<a:custGeom>` into a normalized {@link FreeformPath}.
+ *
+ * Each `<a:path w h>` declares its own coordinate space; we normalize
+ * every point to `[0, 1]` of that path's `w`/`h` so the renderer can scale
+ * the stored geometry to any frame. Multiple `<a:path>` elements are
+ * concatenated into one command list (each begins with its own `moveTo`)
+ * and painted with the default nonzero winding rule, matching PowerPoint;
+ * oppositely-wound sub-paths therefore read as holes, same-wound ones as a
+ * union. (A leading `moveTo` per `<a:path>` is assumed, as PowerPoint
+ * always emits one.)
+ *
+ * Supports the segment kinds real-world decks use: `moveTo`, `lnTo`,
+ * `quadBezTo`, `cubicBezTo`, `arcTo`, `close`. `arcTo` is reduced to a
+ * centre-parametrised elliptical arc by deriving the centre from the
+ * current point. Returns `undefined` when there is no usable geometry.
+ */
+export function parseCustGeomPath(custGeom: Element): FreeformPath | undefined {
+  const pathLst = child(custGeom, 'pathLst');
+  if (!pathLst) return undefined;
+
+  const commands: FreeformCommand[] = [];
+
+  for (const path of children(pathLst, 'path')) {
+    const w = attrInt(path, 'w');
+    const h = attrInt(path, 'h');
+    // Without a positive viewBox we cannot normalize; skip this sub-path
+    // rather than divide by zero and emit NaN coordinates.
+    if (!w || !h || w <= 0 || h <= 0) continue;
+
+    const nx = (x: number) => x / w;
+    const ny = (y: number) => y / h;
+    // Current point in path-space px, needed to centre-parametrise arcs.
+    let cur = { x: 0, y: 0 };
+
+    for (let i = 0; i < path.childNodes.length; i++) {
+      const node = path.childNodes[i];
+      if (node.nodeType !== 1) continue;
+      const seg = node as Element;
+      switch (seg.localName) {
+        case 'moveTo': {
+          const p = pt(child(seg, 'pt'));
+          if (!p) break;
+          cur = p;
+          commands.push({ c: 'M', x: nx(p.x), y: ny(p.y) });
+          break;
+        }
+        case 'lnTo': {
+          const p = pt(child(seg, 'pt'));
+          if (!p) break;
+          cur = p;
+          commands.push({ c: 'L', x: nx(p.x), y: ny(p.y) });
+          break;
+        }
+        case 'quadBezTo': {
+          const pts = children(seg, 'pt');
+          const c = pt(pts[0]);
+          const end = pt(pts[1]);
+          if (!c || !end) break;
+          cur = end;
+          commands.push({
+            c: 'Q',
+            x1: nx(c.x),
+            y1: ny(c.y),
+            x: nx(end.x),
+            y: ny(end.y),
+          });
+          break;
+        }
+        case 'cubicBezTo': {
+          const pts = children(seg, 'pt');
+          const c1 = pt(pts[0]);
+          const c2 = pt(pts[1]);
+          const end = pt(pts[2]);
+          if (!c1 || !c2 || !end) break;
+          cur = end;
+          commands.push({
+            c: 'C',
+            x1: nx(c1.x),
+            y1: ny(c1.y),
+            x2: nx(c2.x),
+            y2: ny(c2.y),
+            x: nx(end.x),
+            y: ny(end.y),
+          });
+          break;
+        }
+        case 'arcTo': {
+          const wR = attrInt(seg, 'wR');
+          const hR = attrInt(seg, 'hR');
+          const stAngRaw = attrInt(seg, 'stAng');
+          const swAngRaw = attrInt(seg, 'swAng');
+          if (wR == null || hR == null || stAngRaw == null || swAngRaw == null) {
+            break;
+          }
+          const start = angToRad(stAngRaw);
+          const sweep = angToRad(swAngRaw);
+          // Derive the ellipse centre so it passes through the current
+          // point at angle `start` (OOXML's arcTo is relative to the pen).
+          const cx = cur.x - wR * Math.cos(start);
+          const cy = cur.y - hR * Math.sin(start);
+          cur = {
+            x: cx + wR * Math.cos(start + sweep),
+            y: cy + hR * Math.sin(start + sweep),
+          };
+          commands.push({
+            c: 'A',
+            cx: nx(cx),
+            cy: ny(cy),
+            rx: wR / w,
+            ry: hR / h,
+            start,
+            sweep,
+          });
+          break;
+        }
+        case 'close':
+          commands.push({ c: 'Z' });
+          break;
+      }
+    }
+  }
+
+  return commands.length ? { commands } : undefined;
+}

--- a/packages/slides/src/import/pptx/freeform.ts
+++ b/packages/slides/src/import/pptx/freeform.ts
@@ -109,6 +109,10 @@ export function parseCustGeomPath(custGeom: Element): FreeformPath | undefined {
           if (wR == null || hR == null || stAngRaw == null || swAngRaw == null) {
             break;
           }
+          // A non-positive radius is malformed and would make
+          // `Path2D.ellipse` throw at render time (negative radius), so
+          // skip the segment rather than poison the whole shape's paint.
+          if (wR <= 0 || hR <= 0) break;
           const start = angToRad(stAngRaw);
           const sweep = angToRad(swAngRaw);
           // Derive the ellipse centre so it passes through the current

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -479,6 +479,11 @@ async function parseSp(sp: Element, ctx: SlideParseContext): Promise<SlideElemen
   // `<a:blipFill>` is handled by the image branch above.)
   const custGeom = spPr ? child(spPr, 'custGeom') : undefined;
   if (custGeom) {
+    // Only emit when there's actual geometry. A custGeom with an empty /
+    // unparseable `<a:pathLst>` has nothing to render; emitting a path-less
+    // freeform would resurrect the "phantom shape" the blipFill-fallback
+    // path deliberately drops (see shape-blipfill.test.ts). Shapes with a
+    // real path are kept — that is the silent-loss bug this branch fixes.
     const path = parseCustGeomPath(custGeom);
     if (path) {
       const shape = buildFreeformElement(elementId, frame, sp, path, ctx);

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -1,5 +1,6 @@
 import type {
   Element as SlideElement,
+  FreeformPath,
   GroupElement,
   ImageElement,
   PlaceholderRef,
@@ -30,6 +31,7 @@ import {
   IDENTITY_TRANSFORM,
   type GroupTransform,
 } from './group';
+import { parseCustGeomPath } from './freeform';
 import { parseBlipFill, parsePic, type ImageParseContext } from './image';
 import { ImportReport } from './report';
 import { parseTable } from './table';
@@ -469,6 +471,25 @@ async function parseSp(sp: Element, ctx: SlideParseContext): Promise<SlideElemen
     return [shape];
   }
 
+  // Shape with `<a:custGeom>` — a freeform/path shape. PowerPoint exports
+  // decorative blobs, doodles, and silhouettes as custom geometry; without
+  // a branch here they match nothing below and are silently dropped. Emit
+  // a `freeform` ShapeElement carrying the normalized vector path so the
+  // fill/stroke (and any inline text) render. (custGeom that also has a
+  // `<a:blipFill>` is handled by the image branch above.)
+  const custGeom = spPr ? child(spPr, 'custGeom') : undefined;
+  if (custGeom) {
+    const path = parseCustGeomPath(custGeom);
+    if (path) {
+      const shape = buildFreeformElement(elementId, frame, sp, path, ctx);
+      if (hasText) {
+        shape.data.text = buildTextBody(txBody!, ctx, placeholderRef, layoutSizeKey);
+      }
+      if (placeholderRef) shape.placeholderRef = placeholderRef;
+      return [shape];
+    }
+  }
+
   // No prstGeom but has text — treat as plain text box.
   if (txBody) {
     return [buildTextElement(elementId, frame, txBody, ctx, placeholderRef, layoutSizeKey)];
@@ -669,6 +690,30 @@ function buildShapeElement(
     data: {
       kind,
       ...(adjustments ? { adjustments } : {}),
+      ...(fill ? { fill } : {}),
+      ...(stroke ? { stroke } : {}),
+    },
+  };
+}
+
+function buildFreeformElement(
+  id: string,
+  frame: SlideElement['frame'],
+  sp: Element,
+  path: FreeformPath,
+  ctx: SlideParseContext,
+): ShapeElement {
+  const spPr = child(sp, 'spPr');
+  const fill = parseShapeFill(spPr, ctx);
+  const stroke = parseShapeStroke(spPr, ctx);
+
+  return {
+    id,
+    type: 'shape',
+    frame,
+    data: {
+      kind: 'freeform',
+      path,
       ...(fill ? { fill } : {}),
       ...(stroke ? { stroke } : {}),
     },

--- a/packages/slides/src/model/element.ts
+++ b/packages/slides/src/model/element.ts
@@ -81,7 +81,36 @@ export type ShapeKind =
   | 'actionButtonEnd' | 'actionButtonHome'
   | 'actionButtonInformation' | 'actionButtonReturn'
   | 'actionButtonMovie' | 'actionButtonSound'
-  | 'actionButtonDocument' | 'actionButtonHelp';
+  | 'actionButtonDocument' | 'actionButtonHelp'
+  // Freeform — arbitrary vector path imported from OOXML `<a:custGeom>`.
+  // Unlike every other kind it has no parametric `PathBuilder`; its
+  // geometry lives in `ShapeElement.data.path` (see {@link FreeformPath}).
+  | 'freeform';
+
+/**
+ * One command of a {@link FreeformPath}, mirroring an OOXML
+ * `<a:custGeom>/<a:path>` segment. All coordinates are **normalized to
+ * `[0, 1]`** of the path's own viewBox (the `<a:path w h>` extents) so the
+ * renderer can scale a single stored path to any frame size, exactly the
+ * way parametric builders scale to `FrameSize`.
+ *
+ * - `M` moveTo · `L` lineTo · `Q` quadratic Bézier · `C` cubic Bézier
+ * - `A` elliptical arc (`<a:arcTo>` reduced to a centre-parametrised arc:
+ *   centre `cx,cy`, radii `rx,ry`, `start`/`sweep` in radians)
+ * - `Z` closePath
+ */
+export type FreeformCommand =
+  | { c: 'M'; x: number; y: number }
+  | { c: 'L'; x: number; y: number }
+  | { c: 'Q'; x1: number; y1: number; x: number; y: number }
+  | { c: 'C'; x1: number; y1: number; x2: number; y2: number; x: number; y: number }
+  | { c: 'A'; cx: number; cy: number; rx: number; ry: number; start: number; sweep: number }
+  | { c: 'Z' };
+
+/** Normalized vector geometry backing a `'freeform'` ShapeElement. */
+export type FreeformPath = {
+  commands: FreeformCommand[];
+};
 
 /**
  * Stroke descriptor shared by ShapeElement, TextElement, and ConnectorElement.
@@ -203,6 +232,14 @@ export type ShapeElement = ElementBase & {
      * thousandths of the relevant dimension).
      */
     adjustments?: number[];
+    /**
+     * Vector geometry for `kind === 'freeform'` shapes (OOXML
+     * `<a:custGeom>`). Absent for every parametric kind, which derives
+     * its path from `kind` + `adjustments` via a `PathBuilder`. Stored
+     * normalized to `[0, 1]` so it scales with the frame. See
+     * {@link FreeformPath}.
+     */
+    path?: FreeformPath;
     fill?: ThemeColor;
     stroke?: Stroke;
     /**

--- a/packages/slides/src/view/canvas/shape-renderer.ts
+++ b/packages/slides/src/view/canvas/shape-renderer.ts
@@ -5,6 +5,7 @@ import { resolveStrokeColor } from './render-context';
 import { PATH_BUILDERS } from './shapes';
 import { isActionButton } from './shapes/action-buttons';
 import type { FrameSize } from './shapes/builder';
+import { buildFreeformPath } from './shapes/freeform';
 import { paintTextBody } from './text-renderer';
 
 export type { FrameSize } from './shapes/builder';
@@ -86,6 +87,19 @@ export function drawShape(
     return;
   }
 
+  // Freeform (`<a:custGeom>`) — geometry is data-driven, not parametric.
+  // Fall back to a placeholder rect if the path is somehow missing so the
+  // slide still renders something at the frame. Filled with the default
+  // nonzero winding rule, matching PowerPoint's custGeom rendering.
+  if (data.kind === 'freeform') {
+    if (!data.path) {
+      drawPlaceholderRect(ctx, size, data, theme);
+      return;
+    }
+    paintFillStroke(ctx, buildFreeformPath(size, data.path), data, theme);
+    return;
+  }
+
   const builder = PATH_BUILDERS.get(data.kind);
   if (!builder) {
     if (!placeholderWarned.has(data.kind)) {
@@ -98,17 +112,35 @@ export function drawShape(
     drawPlaceholderRect(ctx, size, data, theme);
     return;
   }
-  const path = builder(size, data.adjustments);
-  if (data.fill && !OPEN_PATH_KINDS.has(data.kind)) {
+  paintFillStroke(ctx, builder(size, data.adjustments), data, theme, {
+    skipFill: OPEN_PATH_KINDS.has(data.kind),
+    fillRule: EVENODD_KINDS.has(data.kind) ? 'evenodd' : 'nonzero',
+  });
+}
+
+/**
+ * Paint a path's fill + stroke from a shape's `data`, the one place that
+ * maps `data.fill`/`data.stroke` onto the canvas for every Path2D-based
+ * kind (parametric and freeform). `skipFill` suppresses the auto-closing
+ * fill for open-path kinds (brackets/braces); `fillRule` selects even-odd
+ * winding for kinds with real holes (donut/noSmoking). Round joins keep
+ * concave corners (e.g. plus / mathPlus inner notches) from sprouting
+ * miter spikes.
+ */
+function paintFillStroke(
+  ctx: CanvasRenderingContext2D,
+  path: Path2D,
+  data: ShapeElement['data'],
+  theme: Theme,
+  opts?: { skipFill?: boolean; fillRule?: CanvasFillRule },
+): void {
+  if (data.fill && !opts?.skipFill) {
     ctx.fillStyle = resolveColor(data.fill, theme);
-    ctx.fill(path, EVENODD_KINDS.has(data.kind) ? 'evenodd' : 'nonzero');
+    ctx.fill(path, opts?.fillRule ?? 'nonzero');
   }
   if (data.stroke) {
     ctx.strokeStyle = resolveStrokeColor(data.stroke.color, theme);
     ctx.lineWidth = data.stroke.width;
-    // Round joins so concave corners (e.g. plus / mathPlus inner
-    // notches) don't sprout miter spikes that look like a small
-    // square at the cross's centre.
     ctx.lineJoin = 'round';
     ctx.stroke(path);
   }

--- a/packages/slides/src/view/canvas/shapes/freeform.ts
+++ b/packages/slides/src/view/canvas/shapes/freeform.ts
@@ -1,0 +1,63 @@
+// packages/slides/src/view/canvas/shapes/freeform.ts
+import type { FreeformPath } from '../../../model/element';
+import type { FrameSize } from './builder';
+
+/**
+ * Build a `Path2D` for a freeform (OOXML `<a:custGeom>`) shape.
+ *
+ * Unlike the parametric `PathBuilder`s, freeform geometry is data-driven:
+ * the commands are stored normalized to `[0, 1]` of the source path's
+ * viewBox, so we simply scale each coordinate by the frame size. The
+ * result is in element-local coordinates (top-left at 0,0), matching every
+ * other shape path — the caller owns fill/stroke/theme just like
+ * `drawShape` does for parametric kinds.
+ *
+ * Arc commands are emitted with anisotropic radii (`rx*w`, `ry*h`); since
+ * the centre is derived from the segment's start point at parse time, the
+ * arc joins the current point without a spurious connecting line.
+ */
+export function buildFreeformPath(
+  { w, h }: FrameSize,
+  path: FreeformPath,
+): Path2D {
+  const p = new Path2D();
+  for (const cmd of path.commands) {
+    switch (cmd.c) {
+      case 'M':
+        p.moveTo(cmd.x * w, cmd.y * h);
+        break;
+      case 'L':
+        p.lineTo(cmd.x * w, cmd.y * h);
+        break;
+      case 'Q':
+        p.quadraticCurveTo(cmd.x1 * w, cmd.y1 * h, cmd.x * w, cmd.y * h);
+        break;
+      case 'C':
+        p.bezierCurveTo(
+          cmd.x1 * w,
+          cmd.y1 * h,
+          cmd.x2 * w,
+          cmd.y2 * h,
+          cmd.x * w,
+          cmd.y * h,
+        );
+        break;
+      case 'A':
+        p.ellipse(
+          cmd.cx * w,
+          cmd.cy * h,
+          cmd.rx * w,
+          cmd.ry * h,
+          0,
+          cmd.start,
+          cmd.start + cmd.sweep,
+          cmd.sweep < 0,
+        );
+        break;
+      case 'Z':
+        p.closePath();
+        break;
+    }
+  }
+  return p;
+}

--- a/packages/slides/test/import/pptx/freeform.test.ts
+++ b/packages/slides/test/import/pptx/freeform.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { parseCustGeomPath } from '../../../src/import/pptx/freeform';
+import { parseSlide } from '../../../src/import/pptx/slide';
+import { ImportReport } from '../../../src/import/pptx/report';
+import { parseXml } from '../../../src/import/pptx/xml';
+import type { PptxArchive } from '../../../src/import/pptx/unzip';
+
+function makeArchive(files: Record<string, string>): PptxArchive {
+  return {
+    readText: async (path) => files[path],
+    readBytes: async () => undefined,
+    list: () => [],
+  };
+}
+
+function custGeomEl(inner: string): Element {
+  const doc = parseXml(
+    `<a:custGeom xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">${inner}</a:custGeom>`,
+  );
+  return doc.documentElement;
+}
+
+describe('parseCustGeomPath', () => {
+  it('normalizes points to [0,1] of the path viewBox', () => {
+    const el = custGeomEl(`
+      <a:pathLst>
+        <a:path w="100" h="200">
+          <a:moveTo><a:pt x="50" y="100"/></a:moveTo>
+          <a:lnTo><a:pt x="100" y="200"/></a:lnTo>
+          <a:cubicBezTo>
+            <a:pt x="0" y="0"/><a:pt x="50" y="0"/><a:pt x="100" y="100"/>
+          </a:cubicBezTo>
+          <a:close/>
+        </a:path>
+      </a:pathLst>`);
+    const path = parseCustGeomPath(el);
+    expect(path).toBeDefined();
+    expect(path!.commands).toEqual([
+      { c: 'M', x: 0.5, y: 0.5 },
+      { c: 'L', x: 1, y: 1 },
+      { c: 'C', x1: 0, y1: 0, x2: 0.5, y2: 0, x: 1, y: 0.5 },
+      { c: 'Z' },
+    ]);
+  });
+
+  it('parses quadBezTo with one control point', () => {
+    const el = custGeomEl(`
+      <a:pathLst>
+        <a:path w="10" h="10">
+          <a:moveTo><a:pt x="0" y="0"/></a:moveTo>
+          <a:quadBezTo><a:pt x="5" y="10"/><a:pt x="10" y="0"/></a:quadBezTo>
+        </a:path>
+      </a:pathLst>`);
+    const path = parseCustGeomPath(el);
+    expect(path!.commands).toEqual([
+      { c: 'M', x: 0, y: 0 },
+      { c: 'Q', x1: 0.5, y1: 1, x: 1, y: 0 },
+    ]);
+  });
+
+  it('reduces arcTo to a centre-parametrised arc joined to the current point', () => {
+    const el = custGeomEl(`
+      <a:pathLst>
+        <a:path w="100" h="100">
+          <a:moveTo><a:pt x="100" y="50"/></a:moveTo>
+          <a:arcTo wR="50" hR="50" stAng="0" swAng="5400000"/>
+        </a:path>
+      </a:pathLst>`);
+    const path = parseCustGeomPath(el);
+    const arc = path!.commands[1];
+    expect(arc.c).toBe('A');
+    if (arc.c !== 'A') return;
+    // start at (100,50), wR=hR=50, stAng=0 → centre (50,50) → normalized (0.5,0.5)
+    expect(arc.cx).toBeCloseTo(0.5);
+    expect(arc.cy).toBeCloseTo(0.5);
+    expect(arc.rx).toBeCloseTo(0.5);
+    expect(arc.ry).toBeCloseTo(0.5);
+    expect(arc.start).toBeCloseTo(0);
+    expect(arc.sweep).toBeCloseTo(Math.PI / 2); // 90°
+  });
+
+  it('returns undefined for a path with no usable viewBox', () => {
+    const el = custGeomEl(
+      `<a:pathLst><a:path w="0" h="0"><a:moveTo><a:pt x="1" y="1"/></a:moveTo></a:path></a:pathLst>`,
+    );
+    expect(parseCustGeomPath(el)).toBeUndefined();
+  });
+});
+
+const SLIDE_WITH_SOLID_FREEFORM = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Freeform 7"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="1000000"/></a:xfrm>
+          <a:custGeom>
+            <a:pathLst>
+              <a:path w="200" h="100">
+                <a:moveTo><a:pt x="0" y="0"/></a:moveTo>
+                <a:lnTo><a:pt x="200" y="0"/></a:lnTo>
+                <a:lnTo><a:pt x="200" y="100"/></a:lnTo>
+                <a:lnTo><a:pt x="0" y="100"/></a:lnTo>
+                <a:close/>
+              </a:path>
+            </a:pathLst>
+          </a:custGeom>
+          <a:solidFill><a:srgbClr val="4B6BF5"/></a:solidFill>
+        </p:spPr>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
+describe('parseSlide — custGeom freeform dispatch', () => {
+  it('keeps a solid-fill custGeom shape (regression: it was silently dropped)', async () => {
+    const slide = await parseSlide({
+      archive: makeArchive({ 'ppt/slides/slide1.xml': SLIDE_WITH_SOLID_FREEFORM }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    expect(slide).toBeDefined();
+    expect(slide!.elements).toHaveLength(1);
+    const el = slide!.elements[0];
+    expect(el.type).toBe('shape');
+    if (el.type !== 'shape') return;
+    expect(el.data.kind).toBe('freeform');
+    expect(el.data.fill).toBeDefined();
+    expect(el.data.path?.commands.length).toBe(5);
+    expect(el.data.path?.commands[0]).toEqual({ c: 'M', x: 0, y: 0 });
+  });
+});

--- a/packages/slides/test/import/pptx/freeform.test.ts
+++ b/packages/slides/test/import/pptx/freeform.test.ts
@@ -53,6 +53,7 @@ describe('parseCustGeomPath', () => {
         </a:path>
       </a:pathLst>`);
     const path = parseCustGeomPath(el);
+    expect(path).toBeDefined();
     expect(path!.commands).toEqual([
       { c: 'M', x: 0, y: 0 },
       { c: 'Q', x1: 0.5, y1: 1, x: 1, y: 0 },

--- a/packages/slides/test/view/canvas/shape-renderer.test.ts
+++ b/packages/slides/test/view/canvas/shape-renderer.test.ts
@@ -101,6 +101,40 @@ describe('drawShape — unknown kind fallback', () => {
   });
 });
 
+describe('drawShape — freeform', () => {
+  const triangle = {
+    commands: [
+      { c: 'M' as const, x: 0, y: 0 },
+      { c: 'L' as const, x: 1, y: 1 },
+      { c: 'L' as const, x: 0, y: 1 },
+      { c: 'Z' as const },
+    ],
+  };
+
+  it('fills the freeform path with the given fill', () => {
+    const ctx = createCtxSpy();
+    drawShape(asCtx(ctx), size, shape({ kind: 'freeform', path: triangle, fill: srgb('#4b6bf5') }), THEME);
+    expect(ctx.fillStyle).toBe('#4b6bf5');
+    expect(ctx.fill).toHaveBeenCalledTimes(1);
+    expect(ctx.fill.mock.calls[0][0]).toBeInstanceOf(Path2D);
+  });
+
+  it('strokes the freeform path when stroke is set', () => {
+    const ctx = createCtxSpy();
+    drawShape(asCtx(ctx), size, shape({
+      kind: 'freeform', path: triangle, stroke: { color: srgb('#000'), width: 2 },
+    }), THEME);
+    expect(ctx.stroke).toHaveBeenCalledTimes(1);
+    expect(ctx.stroke.mock.calls[0][0]).toBeInstanceOf(Path2D);
+  });
+
+  it('falls back to a placeholder rect when path is missing', () => {
+    const ctx = createCtxSpy();
+    drawShape(asCtx(ctx), size, shape({ kind: 'freeform', fill: srgb('#abc') }), THEME);
+    expect(ctx.fillRect).toHaveBeenCalledWith(0, 0, 100, 60);
+  });
+});
+
 describe('drawShape — donut (evenodd fill rule)', () => {
   it('passes the evenodd fill rule to ctx.fill so the hole shows', () => {
     const ctx = createCtxSpy();


### PR DESCRIPTION
## Summary

PPTX `<a:custGeom>` freeform shapes were **silently dropped** on import. `parseSp` dispatched on `txBox → blipFill → prstGeom → txBody` and `return []`'d everything else, so a custom-geometry shape with a solid fill and no image/text matched no branch and vanished. The user's deck lost **15** decorative freeforms on slide 1 alone (e.g. the bottom-right `#4B6BF5` background blob). The model/renderer also had no freeform path type for the importer to target.

This adds end-to-end freeform support:

- **Model** (`model/element.ts`) — new `'freeform'` `ShapeKind` + `FreeformPath`/`FreeformCommand` types (commands normalized to `[0,1]` of the source path viewBox) + optional `ShapeElement.data.path`.
- **Parser** (`import/pptx/freeform.ts`) — `parseCustGeomPath` normalizes each `<a:path w h>/<a:pt>` by its own viewBox and reduces `<a:arcTo>` to a centre-parametrised elliptical arc.
- **Renderer** (`view/canvas/shapes/freeform.ts`, `shape-renderer.ts`) — `buildFreeformPath` builds the `Path2D`; `drawShape` special-cases `freeform` before the `PATH_BUILDERS` lookup (like action buttons), since data-driven geometry can't be a parametric builder. Fill/stroke painting is unified into a shared `paintFillStroke` helper used by both the parametric and freeform branches.
- **Dispatch** (`import/pptx/shape.ts`) — new `custGeom` branch after `prstGeom`, mirroring its inline-text and placeholder folding.

Import-only for v1 (no picker / drag-handle editing UX), matching the existing acceptance that blip clip paths are lost.

Persistence needs no extra wiring: import assigns `r.slides` wholesale, `readElement` unwraps shape `data` via `yorkieToPlain`, and `migrate` spreads `...el.data` — none whitelist data keys, so `path` round-trips through collaboration + reload.

> Note: documents imported **before** this change already have the freeforms dropped in their Yorkie state; the source deck must be **re-imported** to recover them.

## Test plan

- **Unit** — `test/import/pptx/freeform.test.ts` (parser normalize / quad / arc / no-viewBox + dispatch keeps a solid-fill freeform that was previously dropped) and `test/view/canvas/shape-renderer.test.ts` freeform fill / stroke / placeholder cases.
- **`pnpm verify:fast`** green (all packages).
- **End-to-end** — a throwaway test ran `importPptx` on the real user deck → slide 1 imported **15** freeform shapes (recursive), vs **0** on `main`. Removed after confirming.

## Known limitations (v1)

- Freeform drawing UI / picker / drag-handle editing.
- `<p:style>` `fillRef` (style-ref) fills — affects freeforms with no explicit `solidFill`; pre-existing limitation that also applies to `prstGeom` shapes.
- Gradient/pattern fills; PDF export (not yet in source).
- A `<a:path>` is assumed to begin with `moveTo` (PowerPoint always emits one); a leading non-`moveTo` arc would anchor at the path origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where custom geometry freeform shapes from PowerPoint files were being silently dropped during import. These shapes are now properly imported and rendered on slides with fills and strokes.

* **Tests**
  * Added test coverage for freeform shape parsing and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->