### PR TITLE
Repair table merge invariant on cell paste

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| table paste merge (2026-06-19) | [20260619-table-paste-merge-todo.md](./active/20260619-table-paste-merge-todo.md) | [20260619-table-paste-merge-lessons.md](./active/20260619-table-paste-merge-lessons.md) |
 | slides freeform custgeom (2026-06-18) | [20260618-slides-freeform-custgeom-todo.md](./active/20260618-slides-freeform-custgeom-todo.md) | [20260618-slides-freeform-custgeom-lessons.md](./active/20260618-slides-freeform-custgeom-lessons.md) |
 | slides color picker recent (2026-06-17) | [20260617-slides-color-picker-recent-todo.md](./active/20260617-slides-color-picker-recent-todo.md) | [20260617-slides-color-picker-recent-lessons.md](./active/20260617-slides-color-picker-recent-lessons.md) |
 | slides cell edit overflow (2026-06-16) | [20260616-slides-cell-edit-overflow-todo.md](./active/20260616-slides-cell-edit-overflow-todo.md) | [20260616-slides-cell-edit-overflow-lessons.md](./active/20260616-slides-cell-edit-overflow-lessons.md) |
@@ -39,4 +40,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 273
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides freeform custgeom (2026-06-18)
+Latest active task: table paste merge (2026-06-19)

--- a/docs/tasks/active/20260619-table-paste-merge-lessons.md
+++ b/docs/tasks/active/20260619-table-paste-merge-lessons.md
@@ -1,0 +1,29 @@
+# Lessons: table cell paste across a merged region
+
+## What broke
+
+Table cell copy/paste preserved merge span metadata (`colSpan`/`rowSpan`,
+including `colSpan: 0` covered markers) verbatim. The layout trusts a grid
+invariant — anchor spans match in-bounds `colSpan: 0` covered cells — and
+paste silently violated it (orphaned covered cells, anchors overrunning the
+grid). Only edge clamping existed; no structural repair.
+
+## Lessons
+
+- **When data carries a structural invariant, every mutation path that copies
+  it must re-establish that invariant, not just clamp indices.** `pasteTableCells`
+  clamped loop bounds but trusted the copied spans. The merged-cell grid is an
+  invariant (anchor ⇔ covered cells, in bounds); copy/paste is a mutation path
+  that broke it.
+- **Repair at the destination, in one helper, beats sanitizing N sources.**
+  There are several paste sources (internal payload, HTML, markdown) and two
+  consumers (Docs, Slides). A single `normalizeTableMerges(td)` after the write
+  covers all of them and also handles destination merges that straddle the
+  paste boundary.
+- **Reproduce the data flow before asserting a cause.** The private
+  `getSelectedTableCells` / `pasteTableCells` weren't unit-reachable, so I
+  mirrored their exact logic on a real merged table to produce the broken grids
+  and confirmed the invariant violation empirically before writing any fix.
+- **Slides reuses the Docs engine for table cell text** — a fix in the Docs
+  `TextEditor` paste path automatically covers Slides table cells. Worth
+  checking the shared engine before assuming a bug is package-local.

--- a/docs/tasks/active/20260619-table-paste-merge-todo.md
+++ b/docs/tasks/active/20260619-table-paste-merge-todo.md
@@ -1,0 +1,66 @@
+# Fix: table cell paste across a merged region breaks the table
+
+## Problem
+
+In a Docs table (also reachable from Slides table cells, which reuse the
+Docs engine), copying a cell range that touches a merged region and pasting
+it breaks the table structure.
+
+Reported repro: 3x3 table, select a 2x2 region overlapping a merge, copy,
+paste into a single cell → table renders broken.
+
+## Root cause
+
+Table cell copy/paste preserves merge span metadata verbatim:
+
+- `getSelectedTableCells` (`text-editor.ts`) slices the selected cells
+  including `colSpan` / `rowSpan` and `colSpan: 0` covered markers.
+- `cloneTableCells` (`clipboard.ts`) keeps those spans.
+- `pasteTableCells` (`text-editor.ts`) writes them into the destination
+  with only edge clamping — it never re-establishes a consistent merge
+  structure.
+
+The layout (`table-layout.ts`) trusts the grid invariant (an anchor's span
+matches `colSpan: 0` covered cells, all in bounds). Paste violates it two ways:
+
+1. **Orphaned covered cell** — copy a range whose top-left is a covered cell
+   (anchor outside the copy) → pasted `colSpan: 0` with no anchor.
+2. **Span overrun** — paste a merged anchor near the edge → covered cells fall
+   out of bounds, anchor claims a span with no matching covered cells.
+
+Both empirically confirmed by replicating the copy/paste data flow.
+
+## Plan
+
+- [x] Add `normalizeTableMerges(td: TableData)` pure helper in `model/types.ts`
+      that repairs the invariant in place (clamp anchors to bounds, mark
+      covered cells, restore orphaned covered cells, first-anchor-wins on
+      overlap).
+- [x] Call it in `pasteTableCells` for both branches (in-table paste and
+      new-table-from-cells) before persisting.
+- [x] Regression test reproducing the broken grids the copy/paste flow
+      produces and asserting the helper repairs them.
+- [x] `pnpm verify:fast` green.
+
+## Review
+
+Fix is contained: one pure helper (`normalizeTableMerges`, 62 lines) plus two
+call sites in `pasteTableCells`. The helper repairs the merge invariant the
+layout trusts, so it covers every paste source (internal WAFFLEDOCS payload,
+HTML table, markdown table) and both Docs and Slides (Slides table cells reuse
+the Docs `TextEditor`).
+
+Decisions:
+- Repair the **destination** grid after paste rather than sanitizing the copied
+  source — one place catches orphaned covered cells, overrunning anchors, and
+  even destination merges straddling the paste boundary.
+- Edge-overrun anchors clamp to the grid; if that leaves a 1x1 they become
+  normal cells (drop the unfulfillable span) but keep their content.
+- Overlap resolved row-major, first-anchor-wins (deterministic).
+- Healthy merges are untouched (verified), so running over the whole table is
+  safe.
+
+Regression test: `test/model/table-merge-normalize.test.ts` (4 cases). Each
+broken case asserts `gridViolations(...) > 0` before normalize and `=== []`
+after, proving both the bug and the fix. Full docs suite (60 files) and
+`pnpm verify:fast` green.

--- a/packages/docs/src/model/types.ts
+++ b/packages/docs/src/model/types.ts
@@ -515,6 +515,68 @@ export function createTableBlock(rows: number, cols: number): Block {
   };
 }
 
+/**
+ * Repair a table's merge invariant in place. The layout
+ * (`view/table-layout.ts`) trusts that:
+ *  - an anchor (`colSpan`/`rowSpan` > 1) stays within the grid and has every
+ *    cell it covers marked `colSpan: 0`;
+ *  - a covered cell (`colSpan: 0`) is reachable from such an anchor.
+ *
+ * Table cell paste copies merge metadata verbatim, so a pasted block can
+ * carry an anchor whose span overruns the grid, or a covered marker whose
+ * anchor was left behind. This walks the grid in row-major order and repairs
+ * both: anchors are clamped to the bounds and re-mark their covered cells;
+ * orphaned covered markers are restored to normal cells; on overlap the first
+ * anchor in row-major order wins.
+ */
+export function normalizeTableMerges(td: TableData): void {
+  const numRows = td.rows.length;
+  if (numRows === 0) return;
+  const numCols = td.rows[0].cells.length;
+
+  // coverage[r][c] — true once an accepted anchor claims this cell.
+  const coverage: boolean[][] = Array.from({ length: numRows }, () =>
+    new Array<boolean>(numCols).fill(false),
+  );
+
+  for (let r = 0; r < numRows; r++) {
+    for (let c = 0; c < numCols; c++) {
+      const cell = td.rows[r].cells[c];
+      if (!cell) continue;
+
+      if (coverage[r][c]) {
+        // Claimed by an earlier anchor — force it covered and drop any span
+        // it carried (this is how overlapping anchors are resolved).
+        cell.colSpan = 0;
+        cell.rowSpan = undefined;
+        continue;
+      }
+
+      const cs = cell.colSpan ?? 1;
+      const rs = cell.rowSpan ?? 1;
+      if (cs <= 1 && rs <= 1) {
+        // Normal cell, or an orphaned `colSpan: 0` marker with no anchor —
+        // either way it owns its single cell, so clear any span markers.
+        cell.colSpan = undefined;
+        cell.rowSpan = undefined;
+        continue;
+      }
+
+      // Anchor: clamp the span to the grid, then claim its covered cells.
+      const clampedCols = Math.min(cs, numCols - c);
+      const clampedRows = Math.min(rs, numRows - r);
+      cell.colSpan = clampedCols > 1 ? clampedCols : undefined;
+      cell.rowSpan = clampedRows > 1 ? clampedRows : undefined;
+      for (let dr = 0; dr < clampedRows; dr++) {
+        for (let dc = 0; dc < clampedCols; dc++) {
+          if (dr === 0 && dc === 0) continue;
+          coverage[r + dr][c + dc] = true;
+        }
+      }
+    }
+  }
+}
+
 // --- Search ---
 
 export interface SearchOptions {

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1,5 +1,5 @@
 import type { Block, BlockCellInfo, CellAddress, DocPosition, DocRange, Inline, InlineStyle, HeadingLevel, TableCell } from '../model/types.js';
-import { generateBlockId, getBlockText, getBlockTextLength, DEFAULT_BLOCK_STYLE, createBlock, createTableBlock } from '../model/types.js';
+import { generateBlockId, getBlockText, getBlockTextLength, DEFAULT_BLOCK_STYLE, createBlock, createTableBlock, normalizeTableMerges } from '../model/types.js';
 import { Doc, type EditContext } from '../model/document.js';
 import { serializeClipboard, deserializeClipboard, cloneTableCells, parseHtmlToBlocks, parseHtmlTableToTableCells, parseMarkdownTableToTableCells, parseMarkdownWithTables, WAFFLEDOCS_MIME } from './clipboard.js';
 import { Cursor } from './cursor.js';
@@ -3435,6 +3435,9 @@ export class TextEditor {
           td.rows[r].cells[c] = cloned;
         }
       }
+      // Copied cells carry merge spans verbatim; repair the grid invariant
+      // before the table is inserted (see normalizeTableMerges).
+      normalizeTableMerges(td);
       const blockIdx = this.doc.getBlockIndex(pos.blockId);
       this.doc.insertBlockAt(blockIdx + 1, tableBlock);
       this.invalidateLayout();
@@ -3464,6 +3467,9 @@ export class TextEditor {
         td.rows[targetRow].cells[targetCol] = cloned;
       }
     }
+    // Pasting a range that touches a merge can overrun the grid or leave an
+    // orphaned covered cell; repair the merge invariant before persisting.
+    normalizeTableMerges(td);
     this.doc.updateBlockDirect(tableBlockId, tableBlock);
 
     this.invalidateLayout();

--- a/packages/docs/test/model/table-merge-normalize.test.ts
+++ b/packages/docs/test/model/table-merge-normalize.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { Doc } from '../../src/model/document.js';
+import { normalizeTableMerges, DEFAULT_BLOCK_STYLE, generateBlockId } from '../../src/model/types.js';
+import { cloneTableCells } from '../../src/view/clipboard.js';
+import type { TableCell, TableData } from '../../src/model/types.js';
+
+/**
+ * Regression coverage for "pasting a copied cell range that touches a merged
+ * region breaks the table".
+ *
+ * Table cell paste copies merge metadata (`colSpan` / `rowSpan`, including the
+ * `colSpan: 0` covered markers) verbatim, so the pasted block can violate the
+ * grid invariant the layout trusts. `normalizeTableMerges` repairs that
+ * invariant; `pasteTableCells` runs it after writing the pasted cells.
+ *
+ * These tests reproduce the exact cell shapes the copy/paste data flow
+ * produces, then assert the helper restores a consistent grid.
+ */
+
+// Mirror of TextEditor.getSelectedTableCells: slice the selected rectangle
+// verbatim (spans included), then clone like the clipboard does.
+function copyRange(
+  td: TableData,
+  r0: number,
+  c0: number,
+  r1: number,
+  c1: number,
+): TableCell[][] {
+  const rows: TableCell[][] = [];
+  for (let r = r0; r <= r1; r++) {
+    const row: TableCell[] = [];
+    for (let c = c0; c <= c1; c++) {
+      const cell = td.rows[r]?.cells[c];
+      if (cell) row.push(cell);
+    }
+    rows.push(row);
+  }
+  return cloneTableCells(rows);
+}
+
+// Mirror of TextEditor.pasteTableCells (in-table branch) write loop.
+function pasteRange(
+  td: TableData,
+  cells: TableCell[][],
+  startRow: number,
+  startCol: number,
+): void {
+  for (let r = 0; r < cells.length; r++) {
+    const targetRow = startRow + r;
+    if (targetRow >= td.rows.length) break;
+    for (let c = 0; c < cells[r].length; c++) {
+      const targetCol = startCol + c;
+      if (targetCol >= td.rows[targetRow].cells.length) continue;
+      td.rows[targetRow].cells[targetCol] = cloneTableCells([[cells[r][c]]])[0][0];
+    }
+  }
+}
+
+/**
+ * The grid invariant the layout (table-layout.ts) relies on. Returns a list
+ * of violations; an empty list means the grid is consistent.
+ */
+function gridViolations(td: TableData): string[] {
+  const numRows = td.rows.length;
+  const numCols = td.rows[0]?.cells.length ?? 0;
+  const coveredBy: (string | null)[][] = Array.from({ length: numRows }, () =>
+    new Array<string | null>(numCols).fill(null),
+  );
+  const violations: string[] = [];
+
+  for (let r = 0; r < numRows; r++) {
+    for (let c = 0; c < numCols; c++) {
+      const cell = td.rows[r].cells[c];
+      const cs = cell.colSpan ?? 1;
+      const rs = cell.rowSpan ?? 1;
+      if (cs > 1 || rs > 1) {
+        for (let dr = 0; dr < rs; dr++) {
+          for (let dc = 0; dc < cs; dc++) {
+            if (dr === 0 && dc === 0) continue;
+            const rr = r + dr;
+            const cc = c + dc;
+            if (rr >= numRows || cc >= numCols) {
+              violations.push(`anchor (${r},${c}) span ${cs}x${rs} overruns grid`);
+              continue;
+            }
+            if (coveredBy[rr][cc] !== null) {
+              violations.push(`cell (${rr},${cc}) covered by both ${coveredBy[rr][cc]} and ${r},${c}`);
+            }
+            coveredBy[rr][cc] = `${r},${c}`;
+          }
+        }
+      }
+    }
+  }
+
+  for (let r = 0; r < numRows; r++) {
+    for (let c = 0; c < numCols; c++) {
+      if (td.rows[r].cells[c].colSpan === 0 && coveredBy[r][c] === null) {
+        violations.push(`orphaned covered cell (${r},${c}) with no anchor`);
+      }
+    }
+  }
+  return violations;
+}
+
+function mergedTable(): TableData {
+  const doc = Doc.create();
+  const id = doc.insertTable(1, 3, 3);
+  // Top-left 2x2 merge: anchor (0,0) colSpan2/rowSpan2; covered (0,1),(1,0),(1,1).
+  doc.mergeCells(id, {
+    start: { rowIndex: 0, colIndex: 0 },
+    end: { rowIndex: 1, colIndex: 1 },
+  });
+  return doc.getBlock(id).tableData!;
+}
+
+describe('normalizeTableMerges', () => {
+  it('leaves a healthy merged grid untouched', () => {
+    const td = mergedTable();
+    expect(gridViolations(td)).toEqual([]);
+    normalizeTableMerges(td);
+    expect(gridViolations(td)).toEqual([]);
+    expect(td.rows[0].cells[0].colSpan).toBe(2);
+    expect(td.rows[0].cells[0].rowSpan).toBe(2);
+    expect(td.rows[0].cells[1].colSpan).toBe(0);
+  });
+
+  it('restores an orphaned covered cell (copy starts inside a merge)', () => {
+    const src = mergedTable();
+    // Select bottom-right 2x2 (1,1)-(2,2): top-left (1,1) is a covered cell
+    // whose anchor (0,0) is NOT in the selection.
+    const copied = copyRange(src, 1, 1, 2, 2);
+    expect(copied[0][0].colSpan).toBe(0);
+
+    const dst = mergedTable();
+    // Split dst's merge first so we paste into a plain region.
+    pasteRange(dst, copied, 0, 0);
+    expect(gridViolations(dst).length).toBeGreaterThan(0); // broken pre-normalize
+
+    normalizeTableMerges(dst);
+    expect(gridViolations(dst)).toEqual([]);
+    // The pasted covered marker at (0,0) is restored to a normal cell.
+    expect(dst.rows[0].cells[0].colSpan ?? 1).not.toBe(0);
+  });
+
+  it('clamps a merged anchor pasted near the grid edge', () => {
+    const src = mergedTable();
+    const copied = copyRange(src, 0, 0, 1, 1); // the merged 2x2
+
+    const dst = mergedTable();
+    pasteRange(dst, copied, 2, 2); // anchor lands in the last cell
+    expect(gridViolations(dst).length).toBeGreaterThan(0); // overrun pre-normalize
+
+    normalizeTableMerges(dst);
+    expect(gridViolations(dst)).toEqual([]);
+  });
+
+  it('resolves overlapping anchors with first-anchor-wins', () => {
+    const td: TableData = {
+      columnWidths: [1 / 3, 1 / 3, 1 / 3],
+      rows: [
+        { cells: [cell({ colSpan: 2, rowSpan: 2 }), cell({ colSpan: 2 }), cell()] },
+        { cells: [cell(), cell(), cell()] },
+        { cells: [cell(), cell(), cell()] },
+      ],
+    };
+    normalizeTableMerges(td);
+    expect(gridViolations(td)).toEqual([]);
+  });
+});
+
+function cell(spans?: { colSpan?: number; rowSpan?: number }): TableCell {
+  return {
+    blocks: [{ id: generateBlockId(), type: 'paragraph', inlines: [{ text: '', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }],
+    style: {},
+    ...(spans?.colSpan != null ? { colSpan: spans.colSpan } : {}),
+    ...(spans?.rowSpan != null ? { rowSpan: spans.rowSpan } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

In a Docs table (also reachable from Slides table cells, which reuse the Docs engine), copying a cell range that touches a merged region and pasting it broke the table structure.

**Root cause:** table cell copy/paste preserved merge span metadata (`colSpan`/`rowSpan`, including the `colSpan: 0` covered markers) verbatim. The layout (`view/table-layout.ts`) trusts a grid invariant — an anchor's span matches its in-bounds `colSpan: 0` covered cells — and `pasteTableCells` only clamped loop bounds, never re-establishing that invariant. Two breakages resulted:

1. **Orphaned covered cell** — copy a range whose top-left is a covered cell (its anchor left outside the copy) → pasted `colSpan: 0` with no anchor → layout skips it, the column collapses.
2. **Span overrun** — paste a merged anchor near the edge → its covered cells fall out of bounds, the anchor claims a span with no matching covered cells → overlap.

## Changes

- `packages/docs/src/model/types.ts` — new pure helper `normalizeTableMerges(td)` that repairs the invariant in place (clamp anchors to grid bounds, re-mark covered cells, restore orphaned covered markers to normal cells, first-anchor-wins on overlap).
- `packages/docs/src/view/text-editor.ts` — call it in both `pasteTableCells` branches (in-table paste and new-table-from-cells) before persisting.

Repairing the **destination** grid in one helper covers every paste source (internal payload, HTML table, markdown table) and both Docs and Slides.

## Test plan

- New regression test `packages/docs/test/model/table-merge-normalize.test.ts` (4 cases) reproduces the exact broken grids the copy/paste data flow produces. Each broken case asserts the grid invariant is violated **before** normalize and consistent **after** — proving both the bug and the fix. Healthy merges are left untouched.
- `pnpm verify:fast` green (all packages). Full docs suite (60 files) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table corruption that occurred when pasting cell ranges across merged regions in Docs and Slides.

* **Documentation**
  * Updated task tracking documentation to reflect current active work and added lessons learned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->