### PR TITLE
Remap connector endpoints on paste and duplicate

### DIFF
--- a/docs/tasks/active/20260620-connector-paste-remap-todo.md
+++ b/docs/tasks/active/20260620-connector-paste-remap-todo.md
@@ -1,0 +1,69 @@
+# Connector paste/duplicate — remap attached endpoints
+
+## Problem
+
+In Slides, connecting two shapes with an arrow (connector), selecting all,
+then pasting (Cmd+V) or duplicating (Cmd+D) produces a pasted arrow that
+still points at the **original** shapes instead of the pasted copies.
+
+## Root cause
+
+- A connector endpoint references its shape by id: `Endpoint = { kind:
+  'attached'; elementId; siteIndex }` (`model/connector.ts`).
+- Paste (`keyboard.ts` Cmd+V) and duplicate (Cmd+D) call `store.addElement`
+  per element. `addElement` assigns a fresh id to the element itself but
+  copies the connector's `start.elementId` / `end.elementId` verbatim —
+  there is no old→new id remap.
+- The clipboard serializer (`clipboard.ts`) additionally stripped each
+  element's own `id`, so the paste path had no key to correlate copies.
+
+Result: pasted/duplicated connectors keep pointing at the source shapes.
+
+## Plan
+
+- [x] Preserve element `id` through clipboard serialize/deserialize so the
+      paste path can build a source→new id map. (`addElement` overrides the
+      incoming id anyway, so keeping it is harmless.)
+- [x] Add a pure, testable helper `pasteElements(store, slideId, sources,
+      dx, dy)` that: (1) inserts each source offset by (dx,dy), recording
+      `sourceId → newId`; (2) for every pasted connector, remaps each
+      `attached` endpoint whose `elementId` is in the map to the new id via
+      `updateConnectorEndpoint` (which recomputes the frame). Endpoints
+      pointing outside the pasted set are left untouched.
+- [x] Wire Cmd+V and Cmd+D in `keyboard.ts` through the helper.
+- [x] Tests: serializer preserves id; helper remaps endpoints to the new
+      shapes; endpoints outside the set are preserved.
+
+## Known limitations / non-goals
+
+- Pasting a **group** still duplicates nested child ids verbatim
+  (pre-existing `addElement` behavior); connectors attached to a
+  group-nested child are not remapped. Out of scope here.
+
+## Review
+
+- Implemented `pasteElements` helper; wired Cmd+V and Cmd+D in `keyboard.ts`
+  through it; clipboard serializer now preserves `id`.
+- Verification (isolated worktree, fresh from `origin/main`):
+  - `pnpm slides typecheck` — clean.
+  - `pnpm slides test` — 261 files, 1816 passed / 2 skipped.
+  - New `paste.test.ts` covers: endpoints remap to pasted shapes; endpoints
+    outside the paste set are preserved; non-connector frames offset.
+- Note: a concurrent session was sharing the primary checkout and reverting
+  tracked-file edits; work was moved into `.claude/worktrees/` to isolate it,
+  then redone in the `wafflesheets` clean clone (rebased onto `main` #374).
+
+### Code review (high effort, self) — findings + resolution
+
+1. **Free-endpoint connectors weren't offset on paste/duplicate.** A
+   connector's frame is recomputed from its endpoints on insert, so the
+   `frame` offset was discarded for connectors — a standalone line/arrow's
+   copy landed exactly on the original (pre-existing behavior). **Fixed** in
+   `pasteElements` by shifting `free` endpoints by `(dx, dy)`; covered by a
+   test asserting `start`/`end` move.
+2. **Remap pattern mirrors `MemSlidesStore.duplicateSlide`** (which already
+   does element-id regeneration + connector-endpoint remap + frame recompute).
+   Kept separate: the two operate via different mechanisms (store ops on a
+   live slide vs. mutating a detached `clone()` before splice), so the only
+   shareable part is the trivial endpoint rewrite. Not worth a shared helper.
+3. Group-nested child remap remains a documented non-goal (see above).

--- a/packages/slides/src/view/editor/interactions/clipboard.ts
+++ b/packages/slides/src/view/editor/interactions/clipboard.ts
@@ -1,4 +1,4 @@
-import type { Element, ElementInit } from '../../../model/element';
+import type { Element } from '../../../model/element';
 
 /**
  * Custom MIME type used for slides element clipboard payloads. Phase 4's
@@ -15,19 +15,19 @@ const MAGIC = 'wafflebase/slides@v1';
 
 interface Payload {
   magic: string;
-  elements: ElementInit[];
+  elements: Element[];
 }
 
 /**
- * JSON-encode the given elements for the custom MIME type. The `id`
- * field is stripped from each element — paste assigns fresh ids.
+ * JSON-encode the given elements for the custom MIME type.
+ *
+ * Each element's `id` is preserved so the paste path can build a source→new
+ * id map and remap attached connector endpoints onto the pasted copies (see
+ * {@link pasteElements}). The id is otherwise harmless on paste: `addElement`
+ * always overwrites the incoming id with a freshly generated one.
  */
 export function serializeElements(elements: readonly Element[]): string {
-  const stripped: ElementInit[] = elements.map((e) => {
-    const { id: _drop, ...rest } = e;
-    return rest as ElementInit;
-  });
-  const payload: Payload = { magic: MAGIC, elements: stripped };
+  const payload: Payload = { magic: MAGIC, elements: [...elements] };
   return JSON.stringify(payload);
 }
 
@@ -35,7 +35,7 @@ export function serializeElements(elements: readonly Element[]): string {
  * Parse a JSON payload produced by {@link serializeElements}. Throws if
  * the payload is not JSON or is missing the slides magic.
  */
-export function deserializeElements(json: string): ElementInit[] {
+export function deserializeElements(json: string): Element[] {
   let parsed: unknown;
   try {
     parsed = JSON.parse(json);

--- a/packages/slides/src/view/editor/interactions/keyboard.ts
+++ b/packages/slides/src/view/editor/interactions/keyboard.ts
@@ -1,4 +1,4 @@
-import type { Element, ElementInit } from '../../../model/element';
+import type { Element } from '../../../model/element';
 import type { SlidesStore } from '../../../store/store';
 import type { InsertKind } from '../editor';
 import type { Selection } from '../selection';
@@ -25,6 +25,7 @@ import {
   deserializeElements,
 } from './clipboard';
 import { commitTranslate } from './drag';
+import { pasteElements } from './paste';
 
 export interface KeyboardContext {
   store: SlidesStore;
@@ -313,18 +314,12 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
       run: async (e) => {
         const slide = currentSlide(ctx);
         if (!slide) return;
-        const inits = await readClipboard();
-        if (inits === null) return;
+        const sources = await readClipboard();
+        if (sources === null) return;
         e.preventDefault();
-        const newIds: string[] = [];
+        let newIds: string[] = [];
         ctx.store.batch(() => {
-          for (const init of inits) {
-            const offsetInit = {
-              ...init,
-              frame: { ...init.frame, x: init.frame.x + 10, y: init.frame.y + 10 },
-            } as ElementInit;
-            newIds.push(ctx.store.addElement(slide.id, offsetInit));
-          }
+          newIds = pasteElements(ctx.store, slide.id, sources, 10, 10);
         });
         ctx.selection.set(newIds);
         ctx.requestRender();
@@ -348,16 +343,9 @@ export function buildKeyRules(ctx: KeyboardContext): KeyRule[] {
           ctx.store.batch(() => ctx.store.duplicateSlide(slide.id));
         } else {
           const selected = slide.elements.filter((el) => ids.includes(el.id));
-          const newIds: string[] = [];
+          let newIds: string[] = [];
           ctx.store.batch(() => {
-            for (const el of selected) {
-              const { id: _drop, ...rest } = el;
-              const offsetInit = {
-                ...rest,
-                frame: { ...rest.frame, x: rest.frame.x + 10, y: rest.frame.y + 10 },
-              } as ElementInit;
-              newIds.push(ctx.store.addElement(slide.id, offsetInit));
-            }
+            newIds = pasteElements(ctx.store, slide.id, selected, 10, 10);
           });
           ctx.selection.set(newIds);
         }
@@ -767,7 +755,7 @@ async function writeClipboard(elements: readonly Element[]): Promise<void> {
  * which a sibling slides instance using writeText would also produce).
  * Returns `null` when the clipboard is empty or holds non-slides text.
  */
-async function readClipboard(): Promise<ElementInit[] | null> {
+async function readClipboard(): Promise<Element[] | null> {
   // Path 1: rich clipboard read (custom MIME).
   try {
     const items = await navigator.clipboard.read();
@@ -801,7 +789,7 @@ async function readClipboard(): Promise<ElementInit[] | null> {
   }
 }
 
-function tryDeserialize(json: string): ElementInit[] | null {
+function tryDeserialize(json: string): Element[] | null {
   try {
     return deserializeElements(json);
   } catch {

--- a/packages/slides/src/view/editor/interactions/paste.ts
+++ b/packages/slides/src/view/editor/interactions/paste.ts
@@ -1,0 +1,92 @@
+import type { Element, ElementInit } from '../../../model/element';
+import type { Endpoint } from '../../../model/connector';
+import type { SlidesStore } from '../../../store/store';
+
+/**
+ * Shift a connector endpoint by `(dx, dy)`. A `free` endpoint carries its
+ * own coordinates (the connector frame is derived from them, so offsetting
+ * `frame` alone is discarded by `computeConnectorFrame`) and must be moved
+ * explicitly. An `attached` endpoint follows its shape, which is offset on
+ * its own, so it is left untouched.
+ */
+function shiftEndpoint(ep: Endpoint, dx: number, dy: number): Endpoint {
+  return ep.kind === 'free' ? { ...ep, x: ep.x + dx, y: ep.y + dy } : ep;
+}
+
+/**
+ * Source element for a paste. Cmd+D passes live {@link Element}s straight
+ * from the selection; Cmd+V passes clipboard payloads. Both carry an `id`
+ * (the clipboard serializer preserves it precisely so connector endpoints
+ * can be remapped here) which keys the old→new id map below.
+ */
+export type PasteSource = Element;
+
+/**
+ * Insert copies of `sources` onto `slideId`, offset by `(dx, dy)`, and
+ * remap attached connector endpoints so a connector pasted together with
+ * its endpoint shapes follows the new copies instead of the originals.
+ *
+ * Without this remap, `store.addElement` assigns each copy a fresh id but
+ * leaves a connector's `start.elementId` / `end.elementId` pointing at the
+ * source shapes — so a pasted arrow visually snaps back onto the originals.
+ *
+ * An attached endpoint whose target is **not** part of `sources` is left
+ * untouched (it keeps referencing the existing element).
+ * `updateConnectorEndpoint` recomputes the connector frame from the new
+ * endpoints.
+ *
+ * Must be called inside `store.batch()`. Returns the new ids in source order.
+ */
+export function pasteElements(
+  store: SlidesStore,
+  slideId: string,
+  sources: readonly PasteSource[],
+  dx: number,
+  dy: number,
+): string[] {
+  const idMap = new Map<string, string>();
+  const newIds: string[] = [];
+
+  // Pass 1 — insert every element, recording source id → new id.
+  for (const src of sources) {
+    let init = {
+      ...src,
+      frame: { ...src.frame, x: src.frame.x + dx, y: src.frame.y + dy },
+    } as ElementInit;
+    // A connector's frame is recomputed from its endpoints on insert, so the
+    // frame offset above is discarded for connectors — shift the free
+    // endpoints directly so a standalone line/arrow lands offset like every
+    // other pasted element.
+    if (src.type === 'connector') {
+      init = {
+        ...init,
+        start: shiftEndpoint(src.start, dx, dy),
+        end: shiftEndpoint(src.end, dx, dy),
+      } as ElementInit;
+    }
+    const newId = store.addElement(slideId, init);
+    newIds.push(newId);
+    idMap.set(src.id, newId);
+  }
+
+  // Pass 2 — rewrite attached connector endpoints to the pasted copies.
+  // Done after pass 1 so the map covers every pasted element regardless of
+  // order, and so the remapped target shapes already exist for the frame
+  // recompute inside updateConnectorEndpoint.
+  sources.forEach((src, i) => {
+    if (src.type !== 'connector') return;
+    const newId = newIds[i];
+    for (const side of ['start', 'end'] as const) {
+      const ep = src[side];
+      if (ep.kind !== 'attached') continue;
+      const mapped = idMap.get(ep.elementId);
+      if (mapped === undefined) continue; // target outside the paste set
+      store.updateConnectorEndpoint(slideId, newId, side, {
+        ...ep,
+        elementId: mapped,
+      });
+    }
+  });
+
+  return newIds;
+}

--- a/packages/slides/test/view/editor/interactions/clipboard.test.ts
+++ b/packages/slides/test/view/editor/interactions/clipboard.test.ts
@@ -16,8 +16,10 @@ describe('clipboard serialization', () => {
     expect(parsed).toHaveLength(2);
     expect(parsed[0].frame.x).toBe(10);
     expect(parsed[1].frame.x).toBe(20);
-    // Ids are stripped — paste assigns fresh ones.
-    expect((parsed[0] as { id?: string }).id).toBeUndefined();
+    // Ids are preserved so paste can remap connector endpoints onto the
+    // pasted copies; addElement still assigns fresh ids on insert.
+    expect(parsed[0].id).toBe('a');
+    expect(parsed[1].id).toBe('b');
   });
 
   it('rejects non-slides JSON', () => {

--- a/packages/slides/test/view/editor/interactions/paste.test.ts
+++ b/packages/slides/test/view/editor/interactions/paste.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import type { Element } from '../../../../src/model/element';
+import type { ConnectorElement } from '../../../../src/model/connector';
+import { MemSlidesStore } from '../../../../src/store/memory';
+import { pasteElements } from '../../../../src/view/editor/interactions/paste';
+
+const rect = (id: string, x: number, y: number): Element => ({
+  id,
+  type: 'shape',
+  frame: { x, y, w: 100, h: 100, rotation: 0 },
+  data: { kind: 'rect' },
+});
+
+const connector = (
+  id: string,
+  startId: string,
+  endId: string,
+): ConnectorElement => ({
+  id,
+  type: 'connector',
+  frame: { x: 0, y: 0, w: 0, h: 0, rotation: 0 },
+  routing: 'straight',
+  start: { kind: 'attached', elementId: startId, siteIndex: 1 },
+  end: { kind: 'attached', elementId: endId, siteIndex: 3 },
+  arrowheads: { end: { kind: 'triangle', size: 'md' } },
+});
+
+function setup() {
+  const store = new MemSlidesStore();
+  let slideId = '';
+  store.batch(() => {
+    slideId = store.addSlide('blank');
+  });
+  return { store, slideId };
+}
+
+describe('pasteElements — connector endpoint remap', () => {
+  it('remaps attached endpoints to the pasted shapes, not the originals', () => {
+    const { store, slideId } = setup();
+    const sources: Element[] = [
+      rect('a', 0, 0),
+      rect('b', 300, 0),
+      connector('c', 'a', 'b'),
+    ];
+
+    let newIds: string[] = [];
+    store.batch(() => {
+      newIds = pasteElements(store, slideId, sources, 10, 10);
+    });
+
+    const elements = store.read().slides[0].elements;
+    // The originals were never added here, so the slide holds only the 3 pastes.
+    expect(elements).toHaveLength(3);
+
+    const [newA, newB, newC] = newIds;
+    const pasted = elements.find((e) => e.id === newC) as ConnectorElement;
+    expect(pasted.start).toMatchObject({ kind: 'attached', elementId: newA, siteIndex: 1 });
+    expect(pasted.end).toMatchObject({ kind: 'attached', elementId: newB, siteIndex: 3 });
+    // Crucially, the pasted connector does NOT point at the source ids.
+    expect((pasted.start as { elementId: string }).elementId).not.toBe('a');
+    expect((pasted.end as { elementId: string }).elementId).not.toBe('b');
+  });
+
+  it('leaves endpoints pointing outside the pasted set untouched', () => {
+    const { store, slideId } = setup();
+    // Only the connector + its start shape are pasted; the end shape 'b'
+    // is not in the source set.
+    const sources: Element[] = [rect('a', 0, 0), connector('c', 'a', 'b')];
+
+    let newIds: string[] = [];
+    store.batch(() => {
+      newIds = pasteElements(store, slideId, sources, 10, 10);
+    });
+
+    const [newA, newC] = newIds;
+    const pasted = store
+      .read()
+      .slides[0].elements.find((e) => e.id === newC) as ConnectorElement;
+    expect(pasted.start).toMatchObject({ kind: 'attached', elementId: newA });
+    // 'b' was not pasted → endpoint preserved as-is.
+    expect(pasted.end).toMatchObject({ kind: 'attached', elementId: 'b' });
+  });
+
+  it('offsets non-connector frames and free connector endpoints by (dx, dy)', () => {
+    const { store, slideId } = setup();
+    const freeConnector: ConnectorElement = {
+      id: 'c',
+      type: 'connector',
+      frame: { x: 0, y: 0, w: 0, h: 0, rotation: 0 },
+      routing: 'straight',
+      start: { kind: 'free', x: 10, y: 10 },
+      end: { kind: 'free', x: 50, y: 50 },
+      arrowheads: {},
+    };
+    const sources: Element[] = [rect('a', 0, 0), freeConnector];
+
+    let newIds: string[] = [];
+    store.batch(() => {
+      newIds = pasteElements(store, slideId, sources, 10, 10);
+    });
+
+    const elements = store.read().slides[0].elements;
+    const pastedRect = elements.find((e) => e.id === newIds[0])!;
+    expect(pastedRect.frame.x).toBe(10);
+    expect(pastedRect.frame.y).toBe(10);
+
+    // Free connector endpoints carry their own coords; they must be offset
+    // too (the connector frame is derived from them on insert).
+    const pastedConnector = elements.find((e) => e.id === newIds[1]) as ConnectorElement;
+    expect(pastedConnector.start).toMatchObject({ kind: 'free', x: 20, y: 20 });
+    expect(pastedConnector.end).toMatchObject({ kind: 'free', x: 60, y: 60 });
+  });
+});


### PR DESCRIPTION
## Summary

In Slides, connecting two shapes with an arrow, selecting all, then pasting (Cmd+V) or duplicating (Cmd+D) produced a pasted arrow that still pointed at the **original** shapes instead of the pasted copies.

**Root cause:** A connector endpoint references its target shape by id (`Endpoint = { kind: 'attached', elementId, siteIndex }`). Paste and duplicate inserted each element via `store.addElement`, which assigns a fresh id to the element itself but copied the connector's `start.elementId`/`end.elementId` verbatim — there was no old→new id remap. The clipboard serializer additionally stripped each element's own `id`, so the paste path had no key to correlate copies.

**Fix:**
- `clipboard.ts` — preserve element `id` through serialize/deserialize (`addElement` overwrites the incoming id on insert, so this is harmless).
- New `pasteElements` helper — inserts each source offset by `(dx, dy)` recording `sourceId → newId`, then rewrites each `attached` connector endpoint whose target was pasted via `updateConnectorEndpoint` (which recomputes the frame). Endpoints whose target is outside the paste set stay attached to the original. This mirrors the existing connector-remap already done by `MemSlidesStore.duplicateSlide`.
- `keyboard.ts` — Cmd+V and Cmd+D route through `pasteElements`.
- Free-endpoint connectors (standalone lines/arrows): their frame is recomputed from endpoints on insert, so the paste offset is shifted onto the `free` endpoints directly — the copy now lands offset like every other pasted element (previously it landed exactly on top of the original).

**Known limitation:** Pasting a *group* still duplicates nested child ids verbatim (pre-existing `addElement` behavior); a connector attached to a group-nested child is not remapped. Out of scope here.

## Test plan
- `pnpm slides typecheck` — clean.
- `pnpm slides test` — 261 files, 1816 passed / 2 skipped.
- New `paste.test.ts`: endpoints remap to pasted shapes; endpoints outside the paste set are preserved; non-connector frames **and** free connector endpoints are offset.
- `clipboard.test.ts` updated to assert ids are preserved through round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)