### PR TITLE
Slides: clearer border toolbar icons (pencil color, style dash)

### DIFF
--- a/packages/frontend/src/app/slides/toolbar/border-picker.tsx
+++ b/packages/frontend/src/app/slides/toolbar/border-picker.tsx
@@ -14,7 +14,7 @@ import {
   useMenuCloseHandlers,
 } from '@/components/menu-focus';
 import { ColorSwatchButton } from '@/components/color-swatch-button';
-import { IconBorderStyle2, IconChevronDown, IconLineDashed, IconLineHeight } from '@tabler/icons-react';
+import { IconBorderStyle2, IconChevronDown, IconLineHeight, IconPencil } from '@tabler/icons-react';
 
 export interface BorderPickerProps {
   value?: Stroke;
@@ -109,7 +109,7 @@ export function BorderPicker({
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
               <ColorSwatchButton
-                icon={<IconBorderStyle2 size={14} />}
+                icon={<IconPencil size={14} />}
                 color={currentBorderColor}
                 label="Border color"
                 disabled={disabled}
@@ -162,7 +162,7 @@ export function BorderPicker({
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
               <button type="button" aria-label="Border dash" disabled={disabled} className={btnClass}>
-                <IconLineDashed size={16} />
+                <IconBorderStyle2 size={16} />
                 <IconChevronDown size={12} className="ml-0.5 opacity-50" />
               </button>
             </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary

When a shape is selected in Slides, the contextual toolbar shows three
adjacent border controls — **Border color / Border weight / Border dash** —
that all used generic line/border glyphs. They were hard to tell apart at a
glance and relied entirely on hover tooltips.

This swaps two icons so the triggers read distinctly:

| Control | Before | After |
|---|---|---|
| Border color | `IconBorderStyle2` | `IconPencil` ✏️ (Google Slides parity; the color stripe already signals it's a color control) |
| Border dash | `IconLineDashed` | `IconBorderStyle2` |
| Border weight | `IconLineHeight` | _(unchanged)_ |

Icon-only change in `border-picker.tsx`; no behavior change.

## Test plan

- [x] `pnpm verify:fast` green (lint + unit, slides typecheck after rebuilding `@wafflebase/docs` dist)
- [ ] Manual smoke: select a shape, confirm the Border color trigger shows a pencil and Border dash shows the bordered-square glyph, both pickers still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)