### PR TITLE
Harden docs/sheets comment flows from PR #248 review

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,6 +19,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | design docs archive cleanup (2026-06-20) | [20260620-design-docs-archive-cleanup-todo.md](./active/20260620-design-docs-archive-cleanup-todo.md) | [20260620-design-docs-archive-cleanup-lessons.md](./active/20260620-design-docs-archive-cleanup-lessons.md) |
+| docs comments polish (2026-06-20) | [20260620-docs-comments-polish-todo.md](./active/20260620-docs-comments-polish-todo.md) | [20260620-docs-comments-polish-lessons.md](./active/20260620-docs-comments-polish-lessons.md) |
 | release v0.4.6 (2026-06-20) | [20260620-release-v0.4.6-todo.md](./active/20260620-release-v0.4.6-todo.md) | - |
 | slides fonts (2026-06-16) | [20260616-slides-fonts-todo.md](./active/20260616-slides-fonts-todo.md) | [20260616-slides-fonts-lessons.md](./active/20260616-slides-fonts-lessons.md) |
 | slides tables (2026-06-08) | [20260608-slides-tables-todo.md](./active/20260608-slides-tables-todo.md) | - |

--- a/docs/tasks/active/20260517-docs-comments-followup-todo.md
+++ b/docs/tasks/active/20260517-docs-comments-followup-todo.md
@@ -149,20 +149,21 @@ PR #248.
 ## Smaller polish from PR #248 review
 
 These items were noted in code review but deferred to keep the
-landing PR scoped.
+landing PR scoped. **All four done** in
+`20260620-docs-comments-polish-todo.md`.
 
-- [ ] Right-click "Insert comment" menu inside table cells
+- [x] Right-click "Insert comment" menu inside table cells
   (currently suppressed because the table context menu has priority;
   table menu has no comment item).
-- [ ] Replace `as unknown as SharedThread<SheetCellAnchor>` casts in
+- [x] Replace `as unknown as SharedThread<SheetCellAnchor>` casts in
   `app/spreadsheet/components/comments/CommentPopover.tsx` and
   `app/documents/document-detail.tsx` by re-exporting `Thread<A>`
   from `@wafflebase/sheets` (or migrating sheets fully to the shared
   type).
-- [ ] Re-resolve `pendingRangeRef` paths just before `addThread`
+- [x] Re-resolve `pendingRangeRef` paths just before `addThread`
   fires, so a stale-after-remote-delete compose surfaces a graceful
   toast instead of a Yorkie SDK error.
-- [ ] Promise rejection handling on the Resolve / Reply icon buttons
+- [x] Promise rejection handling on the Resolve / Reply icon buttons
   (currently `void onResolveToggle()` — fire-and-forget). Add a
   pending state + error toast once the failure paths are exercised
   end-to-end.

--- a/docs/tasks/active/20260620-docs-comments-polish-lessons.md
+++ b/docs/tasks/active/20260620-docs-comments-polish-lessons.md
@@ -1,0 +1,54 @@
+# Docs/Sheets Comments Polish — Lessons
+
+## Type duplication across packages is structural, not nominal
+
+The `as unknown as SharedThread<SheetCellAnchor>` casts existed only
+because sheets and the frontend each declared their own structurally
+identical `Thread`. TypeScript is structural, so the casts were never
+needed for safety — dropping them entirely already compiled (only
+unused-import errors). The real fix is single-source-of-truth: the
+lowest package (`@wafflebase/sheets`) owns the base shape, higher
+packages alias it (`Thread<A> = BaseThread<A>`). To let the frontend
+instantiate the generic with a docs-only anchor, the sheets constraint
+has to be loosened to `A extends { kind: string }`, not `A extends
+CommentAnchor` (sheets' own union) — otherwise `DocsRangeAnchor`
+violates the bound.
+
+## Frontend `tsc -b` is NOT a gate here
+
+`verify:fast` runs `frontend lint` + `frontend test`, but only
+`typecheck` for sheets/slides/cli/docs — not the frontend. `npx tsc -b`
+on the frontend reports ~110 pre-existing baseline errors (yorkie SDK
+`ProxyArray` typing, etc.). Don't treat that count as a regression
+signal; instead diff the *specific files* you touched and confirm they
+gain no new errors. Build the workspace dists first
+(`pnpm --filter @wafflebase/{sheets,docs,slides} build`) or the count
+balloons from stale dist types.
+
+## Throwing inside Yorkie `doc.update` propagates and rolls back
+
+`addThread` throws `StaleCommentAnchorError` inside the `doc.update`
+callback (before any mutation). The added unit test confirms the error
+rejects the `addThread` promise *and* leaves `root.comments` empty —
+so the `instanceof` check in the controller is reachable and no partial
+thread is persisted. Worth a test because "does update rethrow?" is not
+obvious from the SDK types.
+
+## Two context menus, one menu item
+
+The docs text context menu and table context menu are mutually
+exclusive (`isInTable()` gate), but both need the same "Insert comment"
+row. Code review correctly flagged the hand-copied button as drift risk
+(shortcut hint, label, icon in two places). Extracted
+`InsertCommentMenuItem` as a thin presentational component — the two
+menus pass their own (identical) class string and an `onSelect` that
+wraps `beginCompose()` + `close()`.
+
+## Declined cleanup: don't merge differently-shaped error handlers
+
+The reviewer suggested one `runWithToast` helper for the three
+`try/catch + toast.error` sites. Declined: the controller distinguishes
+error types and drives compose state; the card's resolve handler has a
+busy flag, delete does not. Forcing a shared helper adds parameters for
+no real gain. Recorded the reasoning in the todo rather than complying
+reflexively.

--- a/docs/tasks/active/20260620-docs-comments-polish-todo.md
+++ b/docs/tasks/active/20260620-docs-comments-polish-todo.md
@@ -1,0 +1,93 @@
+# Docs/Sheets Comments — PR #248 Review Polish
+
+Spun off from `20260517-docs-comments-followup-todo.md`. Implements the
+four "Smaller polish from PR #248 review" items that were deferred to
+keep the landing PR scoped. Each is self-contained; no new product
+surface, just hardening the existing comment flows.
+
+Branch: `docs-comments-review-polish`.
+
+## Item 1 — "Insert comment" in the table context menu
+
+Right-clicking inside a docs table cell shows `DocsTableContextMenu`,
+which has priority and returns early in `DocsCommentContextMenu`
+(`if (editor.isInTable()) return;`). The table menu had no comment item,
+so there was no way to comment on text inside a table cell via the menu
+(`Cmd+Alt+M` still worked).
+
+The anchor path already supports table cells — `docPositionToTreePath`
+"handles … (recursively) blocks inside table cells" (docs-anchor.ts) — so
+this is purely a menu-wiring gap, not new anchor work.
+
+- [x] Add `onInsertComment?` + `readOnly?` props to `DocsTableContextMenu`.
+- [x] Capture whether a non-empty selection exists when the menu opens
+  (`editor.getActiveSelection()` is null for a collapsed caret) and only
+  render the "Insert comment" item when there is a range to anchor to.
+- [x] Wire `docs-view.tsx` to pass `readOnly` + `onInsertComment={() =>
+  comments.beginCompose()}`.
+- [x] Extract `InsertCommentMenuItem` (shared by the text + table menus)
+  so the label / icon / ⌘⌥M hint live in one place (code-review finding).
+
+## Item 2 — Remove `as unknown as SharedThread<SheetCellAnchor>` casts
+
+Two casts (`CommentPopover.tsx`, `document-detail.tsx`) bridge the sheets
+`Thread` type to the shared frontend `Thread<A>`. They are two distinct
+but structurally identical declarations. Root cause: duplicated thread
+shape. Fix per the follow-up todo: make `@wafflebase/sheets` own the base
+shape and have the frontend shared type alias it, so the two are literally
+one type (drift-proof) and no cast is needed.
+
+- [x] sheets `comment/types.ts`: make `Thread` generic —
+  `Thread<A extends { kind: string } = CommentAnchor>` (anchor: A).
+  Default keeps every existing non-generic usage working.
+- [x] frontend `types/comments.ts`: re-export `Comment`/`CommentAuthor`
+  from sheets, alias `SheetCellAnchor` to sheets `CommentAnchor`, and
+  define `Thread<A> = BaseThread<A>`. Keep the JSDoc invariants.
+- [x] Drop both casts; remove now-unused imports.
+- [x] `pnpm sheets typecheck` (clean) + `pnpm sheets test` (1279) green.
+
+## Item 3 — Graceful toast when the pending range goes stale
+
+`YorkieCommentStore.addThread` calls `tree.pathRangeToPosRange(...)` on the
+paths captured at compose time. If a collaborator deletes that text
+between compose and submit, the SDK throws a raw error.
+
+- [x] `addThread`: wrap `pathRangeToPosRange` and throw a typed
+  `StaleCommentAnchorError` when the stored paths no longer resolve.
+- [x] Controller `submitNewComment`: catch `StaleCommentAnchorError`,
+  show a `toast.error(...)`, and close the composer. Other errors keep
+  the existing retry-keeps-composer-open behavior.
+- [x] Added a unit test asserting the typed error propagates out of
+  `doc.update` and nothing is persisted (also proves Yorkie rethrows).
+
+## Item 4 — Pending state + error toast on Resolve (and Delete)
+
+`CommentThreadCard` fires `void onResolveToggle()` / `void onDelete()` —
+fire-and-forget, so a rejected promise is swallowed.
+
+- [x] Resolve button: in-flight `disabled` state + `toast.error` on reject.
+- [x] Delete menu item: `toast.error` on reject (menu closes on click, so
+  no visible pending state needed).
+- [x] Reply is already handled by `CommentComposer` (keeps body on error) —
+  no change.
+
+## Verification
+
+- [x] `pnpm verify:fast` green (EXIT=0).
+- [ ] Manual smoke in `pnpm dev`: table-cell comment, stale-range toast,
+  resolve error toast (where reproducible). _(pending — do before merge.)_
+- [x] Self code-review over the branch diff (2 parallel review agents):
+  no correctness bugs; acted on the shared-menu-item cleanup finding.
+
+## Review notes
+
+- **Considered and declined** the reviewer's suggestion to merge the three
+  `try/catch + toast.error` sites into one helper. The controller handler
+  distinguishes `StaleCommentAnchorError` from other errors and drives
+  compose state; the card's resolve handler carries a busy flag while
+  delete does not. The control flow genuinely differs, so a shared helper
+  would add parameters for little gain.
+- **Non-blocking, left as-is:** `onInsertComment` ignores `beginCompose()`'s
+  `false` return (silent no-op if the selection was lost between menu-open
+  and click) — but this matches the pre-existing text-menu behavior, so it
+  is consistent, not a regression.

--- a/packages/frontend/src/app/docs/comments/DocsCommentContextMenu.tsx
+++ b/packages/frontend/src/app/docs/comments/DocsCommentContextMenu.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { IconMessage2Plus } from "@tabler/icons-react";
 import type { EditorAPI } from "@wafflebase/docs";
+
+import { InsertCommentMenuItem } from "./InsertCommentMenuItem";
 
 interface Props {
   editor: EditorAPI | null;
@@ -96,17 +97,13 @@ export function DocsCommentContextMenu({
       className="fixed z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95"
       style={{ left: position.x, top: position.y }}
     >
-      <button
+      <InsertCommentMenuItem
         className="flex w-full cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground"
-        onClick={() => {
+        onSelect={() => {
           onInsertComment();
           close();
         }}
-      >
-        <IconMessage2Plus size={16} className="text-muted-foreground" />
-        Insert comment
-        <span className="ml-auto text-xs text-muted-foreground">⌘⌥M</span>
-      </button>
+      />
     </div>
   );
 }

--- a/packages/frontend/src/app/docs/comments/InsertCommentMenuItem.tsx
+++ b/packages/frontend/src/app/docs/comments/InsertCommentMenuItem.tsx
@@ -1,0 +1,24 @@
+import { IconMessage2Plus } from "@tabler/icons-react";
+
+interface Props {
+  /** Runs `beginCompose` and closes the host menu. */
+  onSelect: () => void;
+  /** Host menu's button class — the two menus share identical styling. */
+  className: string;
+}
+
+/**
+ * Shared "Insert comment" row. Both the text context menu
+ * (`DocsCommentContextMenu`) and the table context menu
+ * (`DocsTableContextMenu`) render it, so the label, icon, and ⌘⌥M
+ * shortcut hint live in one place and can't drift apart.
+ */
+export function InsertCommentMenuItem({ onSelect, className }: Props) {
+  return (
+    <button className={className} onClick={onSelect}>
+      <IconMessage2Plus size={16} className="text-muted-foreground" />
+      Insert comment
+      <span className="ml-auto text-xs text-muted-foreground">⌘⌥M</span>
+    </button>
+  );
+}

--- a/packages/frontend/src/app/docs/comments/docs-comments-controller.ts
+++ b/packages/frontend/src/app/docs/comments/docs-comments-controller.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import type { Document } from "@yorkie-js/react";
 import type { EditorAPI } from "@wafflebase/docs";
 
@@ -16,6 +17,7 @@ import {
 } from "./docs-anchor";
 import { computeCommentMarkers } from "./decorations";
 import {
+  StaleCommentAnchorError,
   YorkieCommentStore,
   copyDocsThread,
 } from "./yorkie-comment-store";
@@ -249,7 +251,20 @@ export function useDocsComments(opts: UseDocsCommentsOpts): UseDocsCommentsHandl
       // Close the composer only on success. If addThread throws, leave
       // it open so the user can retry; CommentComposer already logs the
       // error and keeps the body intact (it clears only on resolve).
-      await store.addThread(pending, body, currentUser);
+      try {
+        await store.addThread(pending, body, currentUser);
+      } catch (err) {
+        // A collaborator deleted the anchored text between compose and
+        // submit. The range can't be re-anchored, so retrying is futile —
+        // dismiss the composer with a toast instead of leaving it stuck.
+        if (err instanceof StaleCommentAnchorError) {
+          toast.error("That text was changed by a collaborator. Try selecting the text again.");
+          pendingRangeRef.current = null;
+          setComposeOpen(false);
+          return;
+        }
+        throw err;
+      }
       pendingRangeRef.current = null;
       setComposeOpen(false);
     },

--- a/packages/frontend/src/app/docs/comments/yorkie-comment-store.ts
+++ b/packages/frontend/src/app/docs/comments/yorkie-comment-store.ts
@@ -27,6 +27,19 @@ export interface YorkieCommentStoreOptions {
   now?: () => number;
 }
 
+/**
+ * Thrown by `addThread` when the paths captured at compose time no longer
+ * resolve to a position in the tree — a collaborator deleted the anchored
+ * text between opening the composer and submitting. Lets the caller show a
+ * graceful toast instead of leaking a raw Yorkie SDK error.
+ */
+export class StaleCommentAnchorError extends Error {
+  constructor() {
+    super('Comment anchor range no longer resolves');
+    this.name = 'StaleCommentAnchorError';
+  }
+}
+
 function defaultId(): string {
   return Math.random().toString(36).slice(2);
 }
@@ -144,7 +157,16 @@ export class YorkieCommentStore
 
     this.doc.update((root) => {
       const tree = root.content;
-      const posRange = tree.pathRangeToPosRange([input.startPath, input.endPath]);
+      // Re-resolve the compose-time paths against the current tree. A
+      // concurrent delete can shrink the tree so the stored paths point
+      // out of bounds; `pathRangeToPosRange` then throws. Translate that
+      // into a typed error the controller can turn into a toast.
+      let posRange: ReturnType<typeof tree.pathRangeToPosRange>;
+      try {
+        posRange = tree.pathRangeToPosRange([input.startPath, input.endPath]);
+      } catch {
+        throw new StaleCommentAnchorError();
+      }
       // New docs seed `comments` at bootstrap (see `initialDocsRoot`), so the
       // container is shared across replicas and concurrent inserts merge. This
       // guard only fires for legacy docs created before that seeding; on those,

--- a/packages/frontend/src/app/docs/docs-table-context-menu.tsx
+++ b/packages/frontend/src/app/docs/docs-table-context-menu.tsx
@@ -20,10 +20,17 @@ import {
   IconPalette,
   IconTableOff,
 } from "@tabler/icons-react";
+import { InsertCommentMenuItem } from "./comments/InsertCommentMenuItem";
 
 interface DocsTableContextMenuProps {
   editor: EditorAPI | null;
   containerRef: React.RefObject<HTMLDivElement | null>;
+  readOnly?: boolean;
+  /**
+   * Called when the user picks "Insert comment" on a selection inside a
+   * table cell. Runs `beginCompose`. Omitted / read-only hides the item.
+   */
+  onInsertComment?: () => void;
 }
 
 interface MenuPosition {
@@ -40,10 +47,16 @@ interface MenuPosition {
 export function DocsTableContextMenu({
   editor,
   containerRef,
+  readOnly = false,
+  onInsertComment,
 }: DocsTableContextMenuProps) {
   const [position, setPosition] = useState<MenuPosition | null>(null);
   const [showColors, setShowColors] = useState(false);
   const [mergeCtx, setMergeCtx] = useState<TableMergeContext>({ state: 'none' });
+  // Whether a non-empty selection existed when the menu opened — comments
+  // need a text range to anchor to (`getActiveSelection` is null for a
+  // collapsed caret), so the item only appears when there's text selected.
+  const [hasSelection, setHasSelection] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const handleContextMenu = useCallback(
@@ -52,6 +65,7 @@ export function DocsTableContextMenu({
       e.preventDefault();
       setPosition({ x: e.clientX, y: e.clientY });
       setMergeCtx(editor.getTableMergeContext());
+      setHasSelection(!!editor.getActiveSelection());
       setShowColors(false);
     },
     [editor],
@@ -226,6 +240,19 @@ export function DocsTableContextMenu({
             ))}
           </div>
         </div>
+      )}
+
+      {onInsertComment && !readOnly && hasSelection && (
+        <>
+          <div className={sep} />
+          <InsertCommentMenuItem
+            className={item}
+            onSelect={() => {
+              onInsertComment();
+              close();
+            }}
+          />
+        </>
       )}
 
       <div className={sep} />

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -571,6 +571,10 @@ export function DocsView({
       <DocsTableContextMenu
         editor={mountedEditor}
         containerRef={containerRef}
+        readOnly={readOnly}
+        onInsertComment={() => {
+          comments.beginCompose();
+        }}
       />
       <DocsCommentContextMenu
         editor={mountedEditor}

--- a/packages/frontend/src/app/documents/document-detail.tsx
+++ b/packages/frontend/src/app/documents/document-detail.tsx
@@ -67,7 +67,7 @@ import {
 import type { Thread, CommentAnchor } from "@wafflebase/sheets";
 import { cellAnchorToSref } from "@wafflebase/sheets";
 import { CommentSidePanel } from "@/components/comments/components/CommentSidePanel";
-import type { SheetCellAnchor, Thread as SharedThread } from "@/types/comments";
+import type { SheetCellAnchor } from "@/types/comments";
 import { copyThread } from "@/app/spreadsheet/yorkie-worksheet-comments";
 
 const SheetView = lazy(() => import("@/app/spreadsheet/sheet-view"));
@@ -773,7 +773,7 @@ function DocumentLayout({ documentId }: { documentId: string }) {
           </div>
           {commentsPanelOpen && (
             <CommentSidePanel<SheetCellAnchor>
-              threads={allThreads as unknown as SharedThread<SheetCellAnchor>[]}
+              threads={allThreads}
               onJumpTo={(t) => handleJumpToCell(t.anchor)}
               onClose={() => setCommentsPanelOpen(false)}
               renderAnchorLabel={(t) => {

--- a/packages/frontend/src/app/spreadsheet/components/comments/CommentPopover.tsx
+++ b/packages/frontend/src/app/spreadsheet/components/comments/CommentPopover.tsx
@@ -2,11 +2,7 @@ import { useEffect, useRef } from "react";
 
 import { CommentComposer } from "@/components/comments/components/CommentComposer";
 import { CommentThreadCard } from "@/components/comments/components/CommentThreadCard";
-import type {
-  CommentAuthor,
-  SheetCellAnchor,
-  Thread as SharedThread,
-} from "@/types/comments";
+import type { CommentAuthor } from "@/types/comments";
 import type { Thread } from "@wafflebase/sheets";
 
 type Props = {
@@ -88,7 +84,7 @@ export function CommentPopover({
           className="first:pt-0 [&:not(:first-child)]:border-t [&:not(:first-child)]:pt-3"
         >
           <CommentThreadCard
-            thread={thread as unknown as SharedThread<SheetCellAnchor>}
+            thread={thread}
             currentUserId={currentUser?.userId}
             readOnly={isReadOnly}
             autoFocusReply={threadIdx === 0}

--- a/packages/frontend/src/components/comments/components/CommentThreadCard.tsx
+++ b/packages/frontend/src/components/comments/components/CommentThreadCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Check, MoreHorizontal } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -53,7 +54,32 @@ export function CommentThreadCard<A extends CommentAnchor>({
   onDelete,
 }: Props<A>) {
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(false);
   const [rootComment, ...replyComments] = thread.comments;
+
+  const handleResolveToggle = async () => {
+    if (resolving) return;
+    setResolving(true);
+    try {
+      await onResolveToggle();
+    } catch {
+      toast.error(
+        thread.resolved
+          ? "Couldn't reopen this thread. Please try again."
+          : "Couldn't resolve this thread. Please try again.",
+      );
+    } finally {
+      setResolving(false);
+    }
+  };
+
+  const handleDelete = async (commentId: string) => {
+    try {
+      await onDelete(commentId);
+    } catch {
+      toast.error("Couldn't delete this comment. Please try again.");
+    }
+  };
 
   const renderComment = (c: Comment, isRoot: boolean) => {
     const canEditOrDelete =
@@ -80,8 +106,9 @@ export function CommentThreadCard<A extends CommentAnchor>({
                 variant="ghost"
                 size="sm"
                 className="h-6 w-6 p-0"
+                disabled={resolving}
                 onClick={() => {
-                  void onResolveToggle();
+                  void handleResolveToggle();
                 }}
                 aria-label={thread.resolved ? "Reopen thread" : "Resolve thread"}
                 title={thread.resolved ? "Reopen" : "Resolve"}
@@ -112,7 +139,7 @@ export function CommentThreadCard<A extends CommentAnchor>({
                     <DropdownMenuItem
                       className="text-destructive focus:text-destructive"
                       onClick={() => {
-                        void onDelete(c.id);
+                        void handleDelete(c.id);
                       }}
                     >
                       Delete

--- a/packages/frontend/src/types/comments.ts
+++ b/packages/frontend/src/types/comments.ts
@@ -1,47 +1,48 @@
 import type { TreePosStructRange } from '@yorkie-js/sdk';
+import type {
+  CommentAnchor as SheetCellAnchorBase,
+  Thread as BaseThread,
+} from '@wafflebase/sheets';
 
-export type CommentAuthor = {
-  userId: string;
-  username: string;
-  photo?: string;
+// `Comment`/`CommentAuthor` and the base `Thread` shape are owned by
+// `@wafflebase/sheets` (the lowest package in the dependency graph). The
+// frontend re-exports them and only adds the anchor variants its richer
+// consumers (docs ranges) need, so there is a single thread declaration
+// rather than two coincidentally-identical ones.
+export type { Comment, CommentAuthor } from '@wafflebase/sheets';
+
+/**
+ * Sheet-cell anchor — owned by `@wafflebase/sheets`; positions survive
+ * row/column shifts because `rowId` / `colId` are stable axis ids, not
+ * numeric indices.
+ */
+export type SheetCellAnchor = SheetCellAnchorBase;
+
+/**
+ * Docs text-range anchor. `posRange` is the authoritative CRDT-stable
+ * position from Yorkie Tree; `blockId` is a hint captured at creation
+ * (may go stale after structural edits); `quotedText` is an immutable
+ * snapshot of the anchored text, used by the side-panel orphan card when
+ * the range no longer resolves.
+ */
+export type DocsRangeAnchor = {
+  kind: 'docs-range';
+  blockId: string;
+  posRange: TreePosStructRange;
+  quotedText: string;
 };
 
 /**
  * Discriminated union of all supported comment anchor types. New
- * consumers add their variant alongside the existing ones — the
- * shared comment helpers stay anchor-generic.
- *
- * - `sheet-cell` — anchored to a cell in a specific tab; positions
- *   survive row/column shifts because `rowId` / `colId` are stable
- *   axis ids, not numeric indices.
- * - `docs-range` — anchored to a text range. `posRange` is the
- *   authoritative CRDT-stable position from Yorkie Tree; `blockId` is
- *   a hint captured at creation (may go stale after structural edits);
- *   `quotedText` is an immutable snapshot of the anchored text, used by
- *   the side-panel orphan card when the range no longer resolves.
+ * consumers add their variant alongside the existing ones — the shared
+ * comment helpers stay anchor-generic.
  */
-export type CommentAnchor =
-  | { kind: 'sheet-cell'; tabId: string; rowId: string; colId: string }
-  | {
-      kind: 'docs-range';
-      blockId: string;
-      posRange: TreePosStructRange;
-      quotedText: string;
-    };
-
-export type DocsRangeAnchor = Extract<CommentAnchor, { kind: 'docs-range' }>;
-export type SheetCellAnchor = Extract<CommentAnchor, { kind: 'sheet-cell' }>;
-
-export type Comment = {
-  id: string;
-  author: CommentAuthor;
-  body: string;
-  createdAt: number;
-  editedAt?: number;
-};
+export type CommentAnchor = SheetCellAnchor | DocsRangeAnchor;
 
 /**
- * Comment thread.
+ * Comment thread — aliases the base shape owned by `@wafflebase/sheets`
+ * so the sheets store's `Thread` and this shared type are literally the
+ * same type (no bridging casts needed).
  *
  * Invariants enforced by every store implementation:
  * - `comments.length >= 1` — deleting `comments[0]` deletes the whole
@@ -53,12 +54,4 @@ export type Comment = {
  *   reopening clears both.
  * - `editedAt > createdAt` when present.
  */
-export type Thread<A extends CommentAnchor = CommentAnchor> = {
-  id: string;
-  anchor: A;
-  comments: Comment[];
-  resolved: boolean;
-  resolvedAt?: number;
-  resolvedBy?: CommentAuthor;
-  createdAt: number;
-};
+export type Thread<A extends CommentAnchor = CommentAnchor> = BaseThread<A>;

--- a/packages/frontend/tests/app/docs/comments/yorkie-comment-store.test.ts
+++ b/packages/frontend/tests/app/docs/comments/yorkie-comment-store.test.ts
@@ -3,7 +3,10 @@ import yorkie from '@yorkie-js/sdk';
 import { DEFAULT_BLOCK_STYLE, generateBlockId } from '@wafflebase/docs';
 import type { Block } from '@wafflebase/docs';
 
-import { YorkieCommentStore } from '../../../../src/app/docs/comments/yorkie-comment-store.ts';
+import {
+  StaleCommentAnchorError,
+  YorkieCommentStore,
+} from '../../../../src/app/docs/comments/yorkie-comment-store.ts';
 import { resolveDocsAnchor } from '../../../../src/app/docs/comments/docs-anchor.ts';
 import type { YorkieDocsRoot } from '../../../../src/types/docs-document.ts';
 import type { CommentAuthor } from '../../../../src/types/comments.ts';
@@ -100,6 +103,25 @@ describe('YorkieCommentStore — addThread', () => {
     const stored = doc.getRoot().comments?.[t.id];
     expect(stored, 'thread must be persisted under root.comments').toBeTruthy();
     expect(stored?.comments[0].body).toBe('is this right?');
+  });
+
+  it('throws StaleCommentAnchorError when the paths no longer resolve', async () => {
+    // Block index 5 is out of bounds (only one block exists) — mimics a
+    // collaborator deleting the anchored text between compose and submit.
+    await expect(
+      store.addThread(
+        {
+          startPath: [5, 0, 0],
+          endPath: [5, 0, 1],
+          blockId: block.id,
+          quotedText: 'gone',
+        },
+        'orphaned compose',
+        alice,
+      ),
+    ).rejects.toBeInstanceOf(StaleCommentAnchorError);
+    // Nothing was persisted — the failed update did not leak a partial thread.
+    expect(doc.getRoot().comments ?? {}).toEqual({});
   });
 
   it('round-trips: anchor resolves back to the original path range', async () => {

--- a/packages/sheets/src/comment/types.ts
+++ b/packages/sheets/src/comment/types.ts
@@ -19,9 +19,16 @@ export type Comment = {
   editedAt?: number;
 };
 
-export type Thread = {
+/**
+ * Comment thread. Generic over the anchor so this same shape is the
+ * canonical base for every consumer (sheets cells, docs ranges, …): the
+ * frontend's shared `Thread<A>` aliases this type, keeping the two in
+ * lockstep instead of relying on coincidentally-identical declarations.
+ * Sheets itself only ever uses the default `sheet-cell` anchor.
+ */
+export type Thread<A extends { kind: string } = CommentAnchor> = {
   id: string;
-  anchor: CommentAnchor;
+  anchor: A;
   comments: Comment[];
   resolved: boolean;
   resolvedAt?: number;


### PR DESCRIPTION
## Summary

Implements the four deferred "Smaller polish from PR #248 review" items
(tracked in `docs/tasks/active/20260620-docs-comments-polish-todo.md`),
hardening the existing docs/sheets comment flows — no new product surface.

- **Table-cell comments.** `DocsTableContextMenu` now shows an "Insert
  comment" row when there's a text selection inside a table cell
  (previously suppressed because the table menu had priority and no
  comment item). Extracted a shared `InsertCommentMenuItem` so the text
  and table menus share one label / icon / `⌘⌥M` hint and can't drift.
- **Thread type unification.** `@wafflebase/sheets` now owns a generic
  base `Thread<A>`; the frontend shared type aliases it
  (`Thread<A> = BaseThread<A>`), removing the two
  `as unknown as SharedThread<SheetCellAnchor>` casts. Drift-proof single
  source of truth rather than two coincidentally-identical declarations.
- **Stale-anchor toast.** `YorkieCommentStore.addThread` throws a typed
  `StaleCommentAnchorError` when the compose-time paths no longer resolve
  (a collaborator deleted the anchored text); the controller catches it
  and shows a toast instead of leaking a raw Yorkie SDK error.
- **Resolve/Delete hardening.** `CommentThreadCard` gets a pending
  `disabled` state on Resolve and error toasts on Resolve + Delete,
  replacing the fire-and-forget `void onResolveToggle()` calls.

## Test plan

- `pnpm verify:fast` — green (lint + 560 frontend tests + 1279 sheets
  tests + sheets/slides/cli/docs typechecks).
- New unit test in `yorkie-comment-store.test.ts` asserts
  `StaleCommentAnchorError` rejects `addThread`, propagates out of
  `doc.update`, and persists no partial thread.
- Self code-review over the branch diff (parallel agents): no correctness
  bugs.
- **Manual smoke (pending before merge):** table-cell comment insert,
  two-user stale-range toast, resolve error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Insert comment" action to the docs table context menu with selection-based visibility.
  * Comment operations now display error toasts on resolve/delete failures.
  * Resolve button disables during in-flight operations.

* **Bug Fixes**
  * Improved error handling for stale comment anchors when content is deleted during composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->