### PR TITLE
Slides tables: concurrent test, cell padding, 18pt text default

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -22,7 +22,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | docs comments polish (2026-06-20) | [20260620-docs-comments-polish-todo.md](./active/20260620-docs-comments-polish-todo.md) | [20260620-docs-comments-polish-lessons.md](./active/20260620-docs-comments-polish-lessons.md) |
 | release v0.4.6 (2026-06-20) | [20260620-release-v0.4.6-todo.md](./active/20260620-release-v0.4.6-todo.md) | - |
 | slides fonts (2026-06-16) | [20260616-slides-fonts-todo.md](./active/20260616-slides-fonts-todo.md) | [20260616-slides-fonts-lessons.md](./active/20260616-slides-fonts-lessons.md) |
-| slides tables (2026-06-08) | [20260608-slides-tables-todo.md](./active/20260608-slides-tables-todo.md) | - |
+| slides tables (2026-06-08) | [20260608-slides-tables-todo.md](./active/20260608-slides-tables-todo.md) | [20260608-slides-tables-lessons.md](./active/20260608-slides-tables-lessons.md) |
 | slides hover text edit browser smoke (2026-06-07) | [20260607-slides-hover-text-edit-browser-smoke-todo.md](./active/20260607-slides-hover-text-edit-browser-smoke-todo.md) | - |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |

--- a/docs/tasks/active/20260608-slides-tables-lessons.md
+++ b/docs/tasks/active/20260608-slides-tables-lessons.md
@@ -53,6 +53,42 @@ Format options panel (`slides-format-options-panel.md`); building a
 standalone toolbar version now would be thrown away. Respect the
 stated home for a deferred item.
 
+## Slide typed text inherited the docs 11pt default (not slide-appropriate)
+
+Surfaced while reviewing table cell text: any slide text typed into an
+*empty* body (table cell, shape) — plus freshly inserted text boxes —
+fell through to the docs engine's `DEFAULT_INLINE_STYLE.fontSize = 11`
+(the Google *Docs* default), while body placeholders are 18pt
+(`DEFAULT_MASTER`). PowerPoint uses 18pt for table/text, Google Slides
+14pt — both far above 11. Fix: a single `SLIDES_DEFAULT_TEXT_SIZE = 18`
++ `makeDefaultSlidesTextBlock()` in `view/editor/default-text.ts`,
+applied at the THREE seams that mint a new/empty slide text body:
+`insert.ts` (text-box model seed) and the two edit-target builders in
+`editor.ts` — shape (`body?.blocks ?? [seed]`) and cell
+(`cell.body.blocks.length > 0 ? … : [seed]`). The cell stores no font
+size itself; the seed lives in the typed run, so the renderer's
+`deckFontScale` applies uniformly and table text now matches body text.
+
+**Altitude trap (cost a smoke-test cycle):** the first attempt seeded the
+default only in `mountSlidesTextBox` when `blocks` was empty (`[]`). But
+the cell/shape target builders never pass `[]` — they pass
+`[emptyShapeTextBlock()]`, a pre-seeded empty paragraph that itself
+omitted `fontSize`. So the mount seed was dead code for the real paths and
+smoke still showed 11 pt. The fix belongs at the seed source
+(`emptyShapeTextBlock`, now folded into the shared helper), not at a
+downstream chokepoint the real path skips. **Find the function that
+actually mints the empty body.**
+
+Dev note: the frontend aliases `@wafflebase/slides` → `slides/src` (Vite),
+so `pnpm dev` runs source — no rebuild to smoke a slides change. The
+frontend *test* lane resolves the built `dist`, so rebuild for tests.
+
+Test note: the text-box wiring tests use a capturing/mock mount that
+records `opts.blocks` — assert the seam there
+(`cell-text-edit-entry.test.ts`, `text-box-editor.test.ts`), which
+exercises the real target builder, not the real `mountSlidesTextBox` with
+`[]` (a path the app never takes).
+
 ## Radix dropdowns in jsdom need a pointer sequence, not `.click()`
 
 Component tests that open a Radix `DropdownMenu` must dispatch

--- a/docs/tasks/active/20260608-slides-tables-lessons.md
+++ b/docs/tasks/active/20260608-slides-tables-lessons.md
@@ -38,6 +38,31 @@ Trees (the design doc's "per-cell body Tree" is aspirational). The
 integration test therefore asserts disjoint-cell convergence and
 structural-op convergence, NOT same-cell character merge.
 
+## Some "deferred" items are UI-only gaps over finished infra
+
+The P3 "cell padding control" looked like a feature but the model
+(`CellStyle.padding`), renderer (`paddingOf` with `DEFAULT_CELL_PADDING`
+fallback in `table-renderer.ts`), and store (`updateTableCellStyle`
+takes an arbitrary `Partial<CellStyle>` patch) already supported it
+end-to-end. Only the toolbar control was missing. Before estimating a
+deferred item, grep the model/renderer/store for the field — the
+"feature" may be a 30-line dropdown over a fully-built pipeline.
+
+Conversely, the per-side border picker is genuinely deferred to the
+Format options panel (`slides-format-options-panel.md`); building a
+standalone toolbar version now would be thrown away. Respect the
+stated home for a deferred item.
+
+## Radix dropdowns in jsdom need a pointer sequence, not `.click()`
+
+Component tests that open a Radix `DropdownMenu` must dispatch
+`pointerdown` -> `pointerup` -> `click` (a synthetic `.click()` no-ops).
+Pattern lifted from `line-spacing-picker.test.ts`. The menu content is
+portalled into `document.body`, so query `[role="menuitem"]` off
+`document.body`, not the render host. Mock only the store/editor read
+surface the component actually touches (`read`, `batch`,
+`updateTableCellStyle`, `getCurrentSlideId`) and cast through `unknown`.
+
 ## Test conventions
 
 - Integration tests are auto-discovered by `tests/**/*.integration.ts`

--- a/docs/tasks/active/20260608-slides-tables-lessons.md
+++ b/docs/tasks/active/20260608-slides-tables-lessons.md
@@ -1,0 +1,52 @@
+# Slides Tables — lessons
+
+## Workspace dist resolution bites twice
+
+Frontend integration tests (`tsx --test`) resolve `@wafflebase/slides`
+and `@wafflebase/docs` to their built `dist/*.es.js` / `*.d.ts`, NOT to
+source. Two stale-dist failures hit while adding the P5 test:
+
+1. `SyntaxError: ... does not provide an export named 'pushRecent'` —
+   the slides `dist` was behind source. Fix: `pnpm --filter
+   @wafflebase/slides build`.
+2. `pnpm verify:fast` slides typecheck: `'paintOriginX' does not exist
+   in type 'TextBoxEditorOptions'` — this was a **stale `@wafflebase/docs`
+   `.d.ts`**, not a real type error. Source had `paintOriginX`; the dist
+   `.d.ts` predated it. Fix: `pnpm --filter @wafflebase/docs build`.
+
+**Rule:** on any "missing export" / "property does not exist on an
+imported workspace type" failure, rebuild the *upstream* workspace
+package (the one that owns the symbol) before suspecting a regression.
+A pre-existing `verify:fast` failure on `main` that touches only an
+imported workspace type is almost always this.
+
+## "Presence" in a design doc can mean an unbuilt rendering layer
+
+The slides-tables design doc listed P5 presence as a few new
+`SlidesPresence` fields extending an "existing `textCursor`". Reality:
+the slides editor renders zero peer presence today — `getPeers()` is
+unconsumed and there is no `textCursor` field. Adding table presence
+means building peer-overlay rendering for slides from scratch. Verify
+the substrate exists before estimating a "just add fields" task.
+
+## Per-cell table body is LWW JSON, not a CRDT Tree
+
+`YorkieSlidesStore.withTableCellBody` snapshots `cell.body.blocks` via
+`yorkieToPlain`, runs the callback, and writes the whole array back —
+so cell bodies are last-writer-wins per cell, not character-mergeable
+Trees (the design doc's "per-cell body Tree" is aspirational). The
+integration test therefore asserts disjoint-cell convergence and
+structural-op convergence, NOT same-cell character merge.
+
+## Test conventions
+
+- Integration tests are auto-discovered by `tests/**/*.integration.ts`
+  and run with `tsx --test` (type-stripping, no full typecheck — the
+  frontend `tsconfig` `include` is `src` only, so test files are not
+  project-typechecked; rely on eslint + a green run).
+- Reuse `createTwoUserSlides` from `tests/helpers/two-user-slides-yorkie.ts`;
+  it seeds the root and gives a 4-round `sync()` that guarantees
+  convergence.
+- Tables read back through the generic `data` branch of
+  `readElement`, so `read().slides[i].elements[j].data.rows[r].cells[c]`
+  is fully populated (body.blocks, gridSpan, rowSpan).

--- a/docs/tasks/active/20260608-slides-tables-todo.md
+++ b/docs/tasks/active/20260608-slides-tables-todo.md
@@ -99,10 +99,15 @@ What landed (in commit order):
 - [x] Contextual toolbar: Table mode (TableControls component)
 - [x] Cell-style toolbar: fill, vertical-align, border preset
       dropdown (All / Outer / Clear)
-- [ ] Cell padding control (deferred — not needed for benchmark deck;
-      add when a user asks)
+- [x] Cell padding control — uniform-padding dropdown in
+      `TableControls` (presets 0/2/5/10 px + Custom), patches every
+      target cell's `style.padding` via the existing
+      `updateTableCellStyle` path. Model/renderer/store already
+      supported `padding`; this was a UI-only gap. Behavioral test:
+      `tests/app/slides/toolbar/table-controls.test.ts`.
 - [ ] Per-side border picker (current is preset-only; per-side comes
-      with the Format options panel work)
+      with the Format options panel work — deferred there, not built
+      standalone)
 
 ## P4 — Structural edits
 

--- a/docs/tasks/active/20260608-slides-tables-todo.md
+++ b/docs/tasks/active/20260608-slides-tables-todo.md
@@ -8,11 +8,31 @@ import path (`packages/slides/src/import/pptx/table.ts`) which loses
 merges, per-side borders, and structural fidelity. Benchmark deck:
 the Yorkie 캐즘 deck (tables on slides 24–27, 33–35).
 
-## Status (2026-06-09)
+## Status (2026-06-20)
 
-P1–P4 are done; P5's granular Yorkie ops are done but presence and
-the two-user integration test are deferred; P6 (PDF export) is not
-started.
+P1–P4 are done. P5's granular Yorkie ops AND the two-user integration
+test are done; presence is deferred (see note below). P6 (PDF export)
+is blocked — slides has no PDF export module yet at all.
+
+Discovered while picking up P5/P6 (2026-06-20):
+
+- **Presence is a bigger feature than it looks.** The slides editor
+  renders NO peer-presence overlays today — `YorkieSlidesStore.getPeers()`
+  exists but nothing in `view/` consumes it, and there is no existing
+  `textCursor` presence field (the design doc's "extend existing
+  textCursor" premise does not hold). Adding `selectedTableCells` /
+  `textCursorCell` / `resizingTableEdge` is net-new peer-overlay
+  rendering for slides, not a field add. Deferred until slides grows a
+  peer-presence rendering layer (tracked in slides-collaboration.md).
+- **P6 PDF export is blocked.** `packages/slides/src/export/pdf.ts`
+  does not exist — slides PDF export is itself an unstarted "Phase 5b"
+  item (see the comment in `frontend/src/app/slides/slides-view.tsx`).
+  The table PDF case can only land once that module exists.
+- **Cell body is LWW JSON, not a Tree.** Despite the design doc saying
+  "per-cell `body` Tree", `withTableCellBody` stores `cell.body.blocks`
+  as a plain JSON value (last-writer-wins per cell). Same-cell
+  concurrent edits resolve LWW; different-cell edits both survive. The
+  integration test covers the different-cell / structural cases.
 
 What landed (in commit order):
 
@@ -108,10 +128,13 @@ What landed (in commit order):
       updateTableColumnWidths, updateTableRowHeights,
       updateTableCellStyle, withTableCellBody)
 - [ ] Presence: `selectedTableCells`, `textCursorCell`,
-      `resizingTableEdge`
-- [ ] `two-user-slides-table-yorkie.ts` integration test (concurrent
-      cell edits, concurrent row insert, concurrent col insert,
-      concurrent merge + cell edit)
+      `resizingTableEdge` (deferred — needs a slides peer-presence
+      rendering layer that does not exist yet; see Status note)
+- [x] Two-user integration test — landed as
+      `frontend/tests/app/slides/yorkie-slides-table-concurrent.integration.ts`
+      (concurrent disjoint-cell edits, concurrent row insert,
+      concurrent col insert, concurrent merge + disjoint-cell edit).
+      4/4 green against a live Yorkie server.
 
 ## P6 — PDF export
 

--- a/packages/frontend/src/app/slides/toolbar/table-controls.tsx
+++ b/packages/frontend/src/app/slides/toolbar/table-controls.tsx
@@ -9,10 +9,12 @@ import type {
   ThemeColor,
   VerticalAnchorMode,
 } from '@wafflebase/slides';
+import { DEFAULT_CELL_PADDING } from '@wafflebase/slides';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -23,7 +25,9 @@ import {
   IconAlignBoxLeftMiddle,
   IconAlignBoxLeftBottom,
   IconBorderAll,
+  IconBoxPadding,
   IconBucketDroplet,
+  IconCheck,
 } from '@tabler/icons-react';
 import { ThemedColorPicker } from '../themed-color-picker';
 import { ColorSwatchButton } from '@/components/color-swatch-button';
@@ -33,6 +37,15 @@ import {
 } from '@/components/menu-focus';
 
 const BORDER_PRESET_DEFAULT: CellBorder = { color: '#000000', width: 1 };
+
+/**
+ * Uniform cell-padding presets (px), applied to all four sides. Mirrors
+ * Google Slides' single "Cell padding" control rather than per-side
+ * margins — per-side editing belongs in the Format options panel.
+ */
+const PADDING_PRESETS = [0, 2, 5, 10] as const;
+const PADDING_MIN = 0;
+const PADDING_MAX = 100;
 
 export interface TableControlsProps {
   editor: SlidesEditor | null;
@@ -83,6 +96,10 @@ export function TableControls({
 
   const [fillOpen, setFillOpen] = useState(false);
   const fillMenu = useMenuCloseHandlers(releaseFocusToBody);
+
+  const [paddingOpen, setPaddingOpen] = useState(false);
+  const [paddingCustom, setPaddingCustom] = useState(false);
+  const [paddingDraft, setPaddingDraft] = useState('');
 
   /**
    * Resolve the target cell coordinates: explicit range when set,
@@ -209,6 +226,23 @@ export function TableControls({
     [store, slideId, tableId, table, targetCells],
   );
 
+  /** Set uniform padding on all four sides of every target cell. */
+  const applyPadding = useCallback(
+    (px: number) => {
+      applyStyle({ padding: { top: px, right: px, bottom: px, left: px } });
+    },
+    [applyStyle],
+  );
+
+  const commitPaddingCustom = useCallback(() => {
+    const n = Number(paddingDraft);
+    if (Number.isFinite(n)) {
+      applyPadding(Math.max(PADDING_MIN, Math.min(PADDING_MAX, Math.round(n))));
+    }
+    setPaddingOpen(false);
+    setPaddingCustom(false);
+  }, [paddingDraft, applyPadding]);
+
   // The vAlign group reflects the FIRST cell in the target set —
   // mixed ranges show no toggle pressed (sampleVAlign === undefined).
   const sampleCell = (() => {
@@ -222,6 +256,22 @@ export function TableControls({
   const setVAlign = (anchor: VerticalAnchorMode): void => {
     applyStyle({ verticalAlign: anchor });
   };
+
+  // Current padding, sampled from the first target cell with the
+  // renderer's DEFAULT_CELL_PADDING fallback. A check mark / custom
+  // default only shows when all four sides match (the uniform control
+  // can't represent an asymmetric value — e.g. the 4/8/4/8 default).
+  const sampleUniformPadding: number | undefined = (() => {
+    if (!sampleCell) return undefined;
+    const p = sampleCell.style.padding;
+    const sides = [
+      p?.top ?? DEFAULT_CELL_PADDING.top,
+      p?.right ?? DEFAULT_CELL_PADDING.right,
+      p?.bottom ?? DEFAULT_CELL_PADDING.bottom,
+      p?.left ?? DEFAULT_CELL_PADDING.left,
+    ];
+    return sides.every((s) => s === sides[0]) ? sides[0] : undefined;
+  })();
 
   return (
     <>
@@ -341,6 +391,80 @@ export function TableControls({
           <DropdownMenuItem onSelect={() => applyBorderPreset('clear')}>
             Clear borders
           </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Cell padding — uniform on all four sides */}
+      <DropdownMenu
+        open={paddingOpen}
+        onOpenChange={(o) => {
+          setPaddingOpen(o);
+          if (!o) setPaddingCustom(false);
+        }}
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Cell padding"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md hover:bg-muted"
+              >
+                <IconBoxPadding size={16} />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Cell padding</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent className="w-[140px]">
+          {paddingCustom ? (
+            <form
+              className="flex items-center gap-1 p-1"
+              onSubmit={(e) => {
+                e.preventDefault();
+                commitPaddingCustom();
+              }}
+            >
+              <input
+                autoFocus
+                type="number"
+                step={1}
+                min={PADDING_MIN}
+                max={PADDING_MAX}
+                value={paddingDraft}
+                onChange={(e) => setPaddingDraft(e.target.value)}
+                onBlur={commitPaddingCustom}
+                className="h-7 w-full rounded border border-border bg-background px-2 text-sm outline-none"
+              />
+              <span className="pr-1 text-xs text-muted-foreground">px</span>
+            </form>
+          ) : (
+            <>
+              {PADDING_PRESETS.map((p) => (
+                <DropdownMenuItem
+                  key={p}
+                  onSelect={() => {
+                    applyPadding(p);
+                    setPaddingOpen(false);
+                  }}
+                  className="flex items-center justify-between"
+                >
+                  <span>{p} px</span>
+                  {sampleUniformPadding === p && <IconCheck size={14} />}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={(e) => {
+                  e.preventDefault();
+                  setPaddingCustom(true);
+                  setPaddingDraft(String(sampleUniformPadding ?? ''));
+                }}
+              >
+                Custom…
+              </DropdownMenuItem>
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </>

--- a/packages/frontend/src/app/slides/toolbar/table-controls.tsx
+++ b/packages/frontend/src/app/slides/toolbar/table-controls.tsx
@@ -236,7 +236,9 @@ export function TableControls({
 
   const commitPaddingCustom = useCallback(() => {
     const n = Number(paddingDraft);
-    if (Number.isFinite(n)) {
+    // Guard the blank input: `Number('')` is 0 (finite), so without this
+    // a blur of an untouched Custom field would silently zero the padding.
+    if (paddingDraft.trim() !== '' && Number.isFinite(n)) {
       applyPadding(Math.max(PADDING_MIN, Math.min(PADDING_MAX, Math.round(n))));
     }
     setPaddingOpen(false);

--- a/packages/frontend/tests/app/slides/toolbar/table-controls.test.ts
+++ b/packages/frontend/tests/app/slides/toolbar/table-controls.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+/**
+ * Behavioral tests for the TableControls cell-padding dropdown.
+ *
+ * Asserts that picking a uniform padding preset patches every targeted
+ * cell's style through `store.updateTableCellStyle`, inside a single
+ * `store.batch`. Radix DropdownMenu opens on a full pointerdown ->
+ * pointerup -> click sequence in jsdom (see line-spacing-picker.test.ts),
+ * not a synthetic `.click()`.
+ */
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { createElement as h, act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { TooltipProvider } from '../../../../src/components/ui/tooltip.tsx';
+import { TableControls } from '../../../../src/app/slides/toolbar/table-controls.tsx';
+
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+function render(ui: ReactElement): HTMLElement {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => {
+    root!.render(h(TooltipProvider, null, ui));
+  });
+  return host;
+}
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+});
+
+function pointerClick(el: HTMLElement): void {
+  act(() => {
+    el.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 0 }),
+    );
+    el.dispatchEvent(
+      new PointerEvent('pointerup', { bubbles: true, cancelable: true, button: 0 }),
+    );
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+  });
+}
+
+// A 2x2 table with empty cells. `cell()` carries the minimal shape the
+// component reads (style + span markers).
+function makeTable(id: string) {
+  const cell = () => ({ body: { blocks: [] }, style: {} });
+  return {
+    id,
+    type: 'table' as const,
+    frame: { x: 0, y: 0, w: 200, h: 80, rotation: 0 },
+    data: {
+      columnWidths: [100, 100],
+      rows: [
+        { height: 40, cells: [cell(), cell()] },
+        { height: 40, cells: [cell(), cell()] },
+      ],
+    },
+  };
+}
+
+/** Minimal store/editor doubles covering only what TableControls reads. */
+function makeFixture(table: ReturnType<typeof makeTable>) {
+  const updateTableCellStyle = vi.fn();
+  const batch = vi.fn((fn: () => void) => fn());
+  const store = {
+    read: () => ({
+      slides: [{ id: 's1', elements: [table] }],
+      meta: { recentColors: [] },
+    }),
+    batch,
+    updateTableCellStyle,
+    pushRecentColor: vi.fn(),
+  };
+  const editor = { getCurrentSlideId: () => 's1' };
+  // The component's prop types are the real slides types; the doubles
+  // satisfy the read surface, so cast through unknown at the call site.
+  return { store, editor, updateTableCellStyle, batch };
+}
+
+function openPaddingMenu(elHost: HTMLElement): HTMLElement[] {
+  const trigger = elHost.querySelector(
+    '[aria-label="Cell padding"]',
+  ) as HTMLElement;
+  pointerClick(trigger);
+  return [...document.body.querySelectorAll('[role="menuitem"]')] as HTMLElement[];
+}
+
+describe('TableControls — cell padding', () => {
+  test('picking a preset patches every cell with uniform padding in one batch', () => {
+    const table = makeTable('t1');
+    const { store, editor, updateTableCellStyle, batch } = makeFixture(table);
+
+    const el = render(
+      h(TableControls, {
+        editor: editor as never,
+        store: store as never,
+        theme: null,
+        ids: ['t1'],
+        cellRange: null,
+      }),
+    );
+
+    const items = openPaddingMenu(el);
+    const five = items.find((n) => n.textContent === '5 px');
+    expect(five).toBeTruthy();
+    pointerClick(five!);
+
+    // One batch, four cells, each with the uniform padding patch.
+    expect(batch).toHaveBeenCalledTimes(1);
+    expect(updateTableCellStyle).toHaveBeenCalledTimes(4);
+    const pad = { top: 5, right: 5, bottom: 5, left: 5 };
+    for (const [, , , , patch] of updateTableCellStyle.mock.calls) {
+      expect(patch).toEqual({ padding: pad });
+    }
+    // Covers each of the 2x2 coordinates exactly once.
+    const coords = updateTableCellStyle.mock.calls
+      .map(([, , row, col]) => `${row},${col}`)
+      .sort();
+    expect(coords).toEqual(['0,0', '0,1', '1,0', '1,1']);
+  });
+
+  test('a cell range scopes the padding to the selected cells only', () => {
+    const table = makeTable('t1');
+    const { store, editor, updateTableCellStyle } = makeFixture(table);
+
+    const el = render(
+      h(TableControls, {
+        editor: editor as never,
+        store: store as never,
+        theme: null,
+        ids: ['t1'],
+        // Just the top row (0,0)-(0,1).
+        cellRange: { tableId: 't1', r0: 0, c0: 0, r1: 0, c1: 1 },
+      }),
+    );
+
+    const items = openPaddingMenu(el);
+    const zero = items.find((n) => n.textContent === '0 px');
+    pointerClick(zero!);
+
+    expect(updateTableCellStyle).toHaveBeenCalledTimes(2);
+    const coords = updateTableCellStyle.mock.calls
+      .map(([, , row, col]) => `${row},${col}`)
+      .sort();
+    expect(coords).toEqual(['0,0', '0,1']);
+  });
+});

--- a/packages/frontend/tests/app/slides/yorkie-slides-table-concurrent.integration.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-table-concurrent.integration.ts
@@ -1,0 +1,198 @@
+/**
+ * Concurrent multi-user integration tests for YorkieSlidesStore table
+ * ops. Validates that the granular table mutations landed in P5
+ * (insertTableRow / insertTableColumn / mergeTableCells /
+ * withTableCellBody) converge across two real Yorkie clients.
+ *
+ * Requires a running Yorkie server:
+ *   docker compose up -d
+ *   YORKIE_RPC_ADDR=http://localhost:8080 pnpm frontend test:integration
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createTwoUserSlides } from '../../helpers/two-user-slides-yorkie.ts';
+import type { YorkieSlidesStore } from '@/app/slides/yorkie-slides-store.ts';
+
+const shouldRun = Boolean(process.env.YORKIE_RPC_ADDR);
+
+// Minimal docs paragraph block — the cell body reuses the docs Block
+// schema, and a one-line literal is cheaper than importing a fixture.
+const paragraph = (text: string) => ({
+  id: 'p1',
+  type: 'paragraph' as const,
+  inlines: [{ text, style: {} }],
+  style: {},
+});
+
+/**
+ * Seed a fresh `rows × cols` table on a fresh slide via store A and
+ * sync it to B. Returns the slide id and table element id, both stores
+ * already converged on the empty grid.
+ */
+async function seedTable(
+  ctx: { storeA: YorkieSlidesStore; sync(): Promise<void> },
+  rows: number,
+  cols: number,
+): Promise<{ slideId: string; tableId: string }> {
+  let slideId = '';
+  let tableId = '';
+  ctx.storeA.batch(() => {
+    slideId = ctx.storeA.addSlide('blank');
+    const colWidth = 100;
+    const rowHeight = 40;
+    tableId = ctx.storeA.addElement(slideId, {
+      type: 'table',
+      frame: { x: 0, y: 0, w: colWidth * cols, h: rowHeight * rows, rotation: 0 },
+      data: {
+        columnWidths: Array(cols).fill(colWidth),
+        rows: Array(rows)
+          .fill(0)
+          .map(() => ({
+            height: rowHeight,
+            cells: Array(cols)
+              .fill(0)
+              .map(() => ({ body: { blocks: [] }, style: {} })),
+          })),
+      },
+    });
+  });
+  await ctx.sync();
+  return { slideId, tableId };
+}
+
+// Read the inline text of a table cell from a store snapshot.
+function cellText(
+  store: YorkieSlidesStore,
+  slideId: string,
+  tableId: string,
+  row: number,
+  col: number,
+): string {
+  const slide = store.read().slides.find((s) => s.id === slideId)!;
+  const table = slide.elements.find((e) => e.id === tableId)!;
+  // Tables read back through the generic `data` branch.
+  const data = (table as { data: { rows: Array<{ cells: Array<{ body: { blocks: Array<{ inlines: Array<{ text: string }> }> } }> }> } }).data;
+  const blocks = data.rows[row].cells[col].body.blocks;
+  return blocks[0]?.inlines[0]?.text ?? '';
+}
+
+function tableData(
+  store: YorkieSlidesStore,
+  slideId: string,
+  tableId: string,
+): {
+  columnWidths: number[];
+  rows: Array<{ cells: Array<{ gridSpan?: number; rowSpan?: number }> }>;
+} {
+  const slide = store.read().slides.find((s) => s.id === slideId)!;
+  const table = slide.elements.find((e) => e.id === tableId)!;
+  return (table as { data: never }).data;
+}
+
+describe('YorkieSlidesStore concurrent table edits', { skip: !shouldRun }, () => {
+  it('two clients edit different cells → both edits survive', async () => {
+    const ctx = await createTwoUserSlides('table-cell-edit-disjoint');
+    try {
+      const { slideId, tableId } = await seedTable(ctx, 2, 2);
+
+      ctx.storeA.batch(() =>
+        ctx.storeA.withTableCellBody(slideId, tableId, 0, 0, () => [
+          paragraph('A00'),
+        ]),
+      );
+      ctx.storeB.batch(() =>
+        ctx.storeB.withTableCellBody(slideId, tableId, 1, 1, () => [
+          paragraph('B11'),
+        ]),
+      );
+      await ctx.sync();
+
+      for (const store of [ctx.storeA, ctx.storeB]) {
+        assert.equal(cellText(store, slideId, tableId, 0, 0), 'A00');
+        assert.equal(cellText(store, slideId, tableId, 1, 1), 'B11');
+      }
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('two clients append a row each → both rows survive (2 → 4)', async () => {
+    const ctx = await createTwoUserSlides('table-row-insert');
+    try {
+      const { slideId, tableId } = await seedTable(ctx, 2, 2);
+
+      ctx.storeA.batch(() => ctx.storeA.insertTableRow(slideId, tableId, 2));
+      ctx.storeB.batch(() => ctx.storeB.insertTableRow(slideId, tableId, 2));
+      await ctx.sync();
+
+      const a = tableData(ctx.storeA, slideId, tableId);
+      const b = tableData(ctx.storeB, slideId, tableId);
+      assert.equal(a.rows.length, 4);
+      assert.equal(b.rows.length, 4);
+      // Every row keeps the 2-column width.
+      for (const row of a.rows) assert.equal(row.cells.length, 2);
+      // Same ordering / shape on both peers.
+      assert.deepEqual(
+        a.rows.map((r) => r.cells.length),
+        b.rows.map((r) => r.cells.length),
+      );
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('two clients append a column each → both columns survive (2 → 4)', async () => {
+    const ctx = await createTwoUserSlides('table-col-insert');
+    try {
+      const { slideId, tableId } = await seedTable(ctx, 2, 2);
+
+      ctx.storeA.batch(() => ctx.storeA.insertTableColumn(slideId, tableId, 2));
+      ctx.storeB.batch(() => ctx.storeB.insertTableColumn(slideId, tableId, 2));
+      await ctx.sync();
+
+      const a = tableData(ctx.storeA, slideId, tableId);
+      const b = tableData(ctx.storeB, slideId, tableId);
+      assert.equal(a.columnWidths.length, 4);
+      assert.equal(b.columnWidths.length, 4);
+      // Each row's cell count tracks the widened grid on both peers.
+      for (const row of a.rows) assert.equal(row.cells.length, 4);
+      for (const row of b.rows) assert.equal(row.cells.length, 4);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+
+  it('A merges a cell range while B edits a disjoint cell → both apply', async () => {
+    const ctx = await createTwoUserSlides('table-merge-vs-edit');
+    try {
+      const { slideId, tableId } = await seedTable(ctx, 2, 2);
+
+      // A merges the top row (0,0)-(0,1); B types into a bottom cell.
+      ctx.storeA.batch(() =>
+        ctx.storeA.mergeTableCells(slideId, tableId, {
+          r0: 0,
+          c0: 0,
+          r1: 0,
+          c1: 1,
+        }),
+      );
+      ctx.storeB.batch(() =>
+        ctx.storeB.withTableCellBody(slideId, tableId, 1, 0, () => [
+          paragraph('B10'),
+        ]),
+      );
+      await ctx.sync();
+
+      for (const store of [ctx.storeA, ctx.storeB]) {
+        const data = tableData(store, slideId, tableId);
+        // Merge anchor spans two columns; the covered cell is marked 0.
+        assert.equal(data.rows[0].cells[0].gridSpan, 2);
+        assert.equal(data.rows[0].cells[1].gridSpan, 0);
+        // The concurrent edit on the disjoint bottom cell survives.
+        assert.equal(cellText(store, slideId, tableId, 1, 0), 'B10');
+      }
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+});

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -174,6 +174,10 @@ export {
   type SlidesRulerViewport,
 } from './view/editor/ruler';
 export type { SlidesTextBoxEditor } from './view/editor/text-box-editor';
+export {
+  SLIDES_DEFAULT_TEXT_SIZE,
+  makeDefaultSlidesTextBlock,
+} from './view/editor/default-text';
 export type { AlignDirection, DistributeAxis, AlignReference } from './view/editor/align';
 
 // View — Editor (Phase 3b additions)

--- a/packages/slides/src/view/editor/default-text.ts
+++ b/packages/slides/src/view/editor/default-text.ts
@@ -21,9 +21,9 @@ const DEFAULT_TEXT_COLOR: ThemeColor = { kind: 'role', role: 'text' };
 /**
  * A single empty paragraph carrying the slides default inline style
  * (theme `text` color + {@link SLIDES_DEFAULT_TEXT_SIZE}). Seeds new
- * text boxes (`insert.ts`) and the in-place editor for empty cell /
- * shape bodies (`mountSlidesTextBox`) so the first keystroke renders at
- * the slide default instead of the docs 11 pt fallback.
+ * text boxes (`insert.ts`) and the edit-target builders for empty cell /
+ * shape bodies (`editor.ts`) so the first keystroke renders at the slide
+ * default instead of the docs 11 pt fallback.
  *
  * Cast through `Block`: `style.color` carries a `ThemeColor` that the
  * text-renderer's color resolver maps to a concrete color at paint time

--- a/packages/slides/src/view/editor/default-text.ts
+++ b/packages/slides/src/view/editor/default-text.ts
@@ -1,0 +1,47 @@
+import { DEFAULT_BLOCK_STYLE, type Block } from '@wafflebase/docs';
+import type { ThemeColor } from '../../model/theme';
+
+/**
+ * Default font size (pt) for freshly typed slide text — plain text
+ * boxes, table cells, and shape inline text.
+ *
+ * Slides text that the user types into an empty body would otherwise
+ * fall through to the docs engine's `DEFAULT_INLINE_STYLE.fontSize`
+ * (11 pt — the Google *Docs* default), which renders noticeably smaller
+ * than the body placeholder (18 pt) and than the table/text defaults in
+ * PowerPoint (18 pt) and Google Slides (14 pt). We standardize on
+ * PowerPoint's 18 pt, which also matches the `body` placeholder in
+ * `DEFAULT_MASTER`, so typed text reads at a consistent slide size.
+ */
+export const SLIDES_DEFAULT_TEXT_SIZE = 18;
+
+/** Bind new runs to the deck's `text` role so they follow the theme. */
+const DEFAULT_TEXT_COLOR: ThemeColor = { kind: 'role', role: 'text' };
+
+/**
+ * A single empty paragraph carrying the slides default inline style
+ * (theme `text` color + {@link SLIDES_DEFAULT_TEXT_SIZE}). Seeds new
+ * text boxes (`insert.ts`) and the in-place editor for empty cell /
+ * shape bodies (`mountSlidesTextBox`) so the first keystroke renders at
+ * the slide default instead of the docs 11 pt fallback.
+ *
+ * Cast through `Block`: `style.color` carries a `ThemeColor` that the
+ * text-renderer's color resolver maps to a concrete color at paint time
+ * (same convention as every other slides text run).
+ */
+export function makeDefaultSlidesTextBlock(id = 'placeholder'): Block {
+  return {
+    id,
+    type: 'paragraph',
+    inlines: [
+      {
+        text: '',
+        style: { color: DEFAULT_TEXT_COLOR, fontSize: SLIDES_DEFAULT_TEXT_SIZE },
+      },
+    ],
+    // Fully-defaulted block style — `computeLayout` reads `marginTop` /
+    // `marginBottom` without a fallback, so a sparse style would NaN the
+    // cumulative y and shift the paint. Matches the prior insert seed.
+    style: { ...DEFAULT_BLOCK_STYLE },
+  } as Block;
+}

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -12,7 +12,7 @@ import type {
 } from '../../model/element';
 import { DEFAULT_CELL_BORDER, DEFAULT_CELL_PADDING } from '../../model/element';
 import type { Block } from '@wafflebase/docs';
-import { DEFAULT_BLOCK_STYLE, clearMeasureCache } from '@wafflebase/docs';
+import { clearMeasureCache } from '@wafflebase/docs';
 import { SHAPE_TEXT_PADDING } from '../canvas/shape-renderer';
 import {
   computeTableLayout,
@@ -54,6 +54,7 @@ import {
   buildInsertElement,
   type ShapeOrTextInsertKind,
 } from './interactions/insert';
+import { makeDefaultSlidesTextBlock } from './default-text';
 import { bendFromCursor } from '../canvas/connector-bend';
 import { commitBend } from './interactions/bend-drag';
 import { dragEndpoint } from './interactions/connector-endpoint-drag';
@@ -5866,7 +5867,7 @@ function buildEditTarget(element: TextElement | ShapeElement): EditTarget {
   };
   return {
     kind: 'shape',
-    blocks: body?.blocks ?? [emptyShapeTextBlock()],
+    blocks: body?.blocks ?? [makeDefaultSlidesTextBlock()],
     autofit: body?.autofit ?? 'none',
     verticalAnchor: body?.verticalAnchor ?? 'middle',
     editFrame: innerFrame,
@@ -5930,7 +5931,7 @@ function buildCellEditTarget(
 
   return {
     kind: 'cell',
-    blocks: cell.body.blocks.length > 0 ? cell.body.blocks : [emptyShapeTextBlock()],
+    blocks: cell.body.blocks.length > 0 ? cell.body.blocks : [makeDefaultSlidesTextBlock()],
     // Cell content never shrinks (the row auto-grows instead — see
     // CR#5 / slides-tables.md). 'none' mirrors what paintCellContents
     // forwards to paintTextBody at render time.
@@ -5956,25 +5957,6 @@ function cellPadding(cell: TableCell): {
     left: p?.left ?? DEFAULT_CELL_PADDING.left,
   };
 }
-
-/**
- * Seed block for a shape whose `data.text` is absent at edit-entry.
- * Mirrors the seed `buildInsertElement` writes for a fresh text element
- * — fully-populated `style` so `computeLayout` reads non-undefined
- * `marginTop` / `marginBottom`, and an inline bound to the deck's
- * `text` color role so newly-typed runs inherit the theme (matches
- * `interactions/insert.ts`'s text-element seed exactly).
- */
-function emptyShapeTextBlock(): Block {
-  return {
-    id: 'placeholder',
-    type: 'paragraph',
-    inlines: [{ text: '', style: { color: SHAPE_TEXT_SEED_COLOR } }],
-    style: { ...DEFAULT_BLOCK_STYLE },
-  } as Block;
-}
-
-const SHAPE_TEXT_SEED_COLOR = { kind: 'role' as const, role: 'text' as const };
 
 /**
  * Given a hit result and the current selection scope, return the element id

--- a/packages/slides/src/view/editor/interactions/insert.ts
+++ b/packages/slides/src/view/editor/interactions/insert.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_BLOCK_STYLE, type Block } from '@wafflebase/docs';
 import type { ElementInit, ShapeKind } from '../../../model/element';
 import type { ThemeColor } from '../../../model/theme';
+import { makeDefaultSlidesTextBlock } from '../default-text';
 
 /**
  * Subset of editor `InsertKind` that `buildInsertElement` handles —
@@ -322,23 +322,11 @@ export function buildInsertElement(
       frame: { x, y, w, h: TEXT_DEFAULT_H, rotation: 0 },
       data: {
         autofit: 'grow',
-        blocks: [{
-          id: 'placeholder',
-          type: 'paragraph',
-          // Bind the inline color to the deck's `text` role so the box
-          // renders in the active theme. The text-renderer's color
-          // resolver also remaps the docs default `'#000000'` to the
-          // `text` role (covers freshly typed runs that inherit
-          // `DEFAULT_INLINE_STYLE` instead of this explicit role).
-          inlines: [{ text: '', style: { color: DEFAULT_TEXT_COLOR } }],
-          // Fully-defaulted style — `computeLayout` reads `marginTop`
-          // and `marginBottom` without a fallback, so a sparse style
-          // would NaN the cumulative y and the slide canvas would
-          // paint at a different offset than the text-box editor
-          // (which seeds through `MemDocStore.setDocument`, which
-          // normalises). See `text-renderer.ts:drawText`.
-          style: { ...DEFAULT_BLOCK_STYLE },
-        } as Block],
+        // Seed the slides default inline style (theme `text` color +
+        // SLIDES_DEFAULT_TEXT_SIZE) so a new text box reads at the slide
+        // default rather than the docs 11 pt fallback. Shared with the
+        // empty-body cell / shape editor seed in `mountSlidesTextBox`.
+        blocks: [makeDefaultSlidesTextBlock()],
       },
     };
   }

--- a/packages/slides/test/view/editor/cell-text-edit-entry.test.ts
+++ b/packages/slides/test/view/editor/cell-text-edit-entry.test.ts
@@ -5,6 +5,7 @@ import type { TableElement } from '../../../src/model/element';
 import { SLIDE_WIDTH, SLIDE_HEIGHT } from '../../../src/model/presentation';
 import { MemSlidesStore } from '../../../src/store/memory';
 import { initialize, type SlidesEditor } from '../../../src/view/editor/editor';
+import { SLIDES_DEFAULT_TEXT_SIZE } from '../../../src/view/editor/default-text';
 import type {
   MountSlidesTextBoxOptions,
   SlidesTextBoxEditor,
@@ -115,6 +116,36 @@ describe('table cell text-edit entry — box sizing', () => {
     // editFrame height ≈ cell height (100) minus top/bottom padding;
     // a shrunk box would be far smaller than this.
     expect(captured.opts!.frame.h).toBeGreaterThan(50);
+  });
+
+  it('seeds an empty cell at the slides default font size (18pt), not docs 11pt', () => {
+    const { canvas, overlay, store } = setup();
+    let sid = '';
+    store.batch(() => {
+      sid = store.addSlide('blank');
+      store.addElement(sid, {
+        type: 'table',
+        frame: { x: 200, y: 200, w: 200, h: 200, rotation: 0 },
+        data: tableData(),
+      });
+    });
+
+    const captured: { opts?: MountSlidesTextBoxOptions } = {};
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: makeCapturingMount(captured),
+    });
+
+    canvas.dispatchEvent(
+      new MouseEvent('dblclick', { clientX: 250, clientY: 250, bubbles: true }),
+    );
+
+    // The empty cell's edit body is seeded with the slides default run so
+    // the first keystroke renders at SLIDES_DEFAULT_TEXT_SIZE rather than
+    // falling through to the docs 11pt DEFAULT_INLINE_STYLE.
+    const seed = captured.opts!.blocks[0]?.inlines[0];
+    expect(seed?.style.fontSize).toBe(SLIDES_DEFAULT_TEXT_SIZE);
   });
 
   it('extends the paint surface to the slide bounds so overflow shows', () => {

--- a/packages/slides/test/view/editor/interactions/insert-defaults.test.ts
+++ b/packages/slides/test/view/editor/interactions/insert-defaults.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, expect } from 'vitest';
 import { buildInsertElement } from '../../../../src/view/editor/interactions/insert';
+import { SLIDES_DEFAULT_TEXT_SIZE } from '../../../../src/view/editor/default-text';
 
 describe('buildInsertElement text default', () => {
   it('seeds a user-inserted text box with grow autofit', () => {
     const el = buildInsertElement('text', { x: 0, y: 0 }, { x: 100, y: 40 });
     expect(el.type).toBe('text');
     if (el.type === 'text') expect(el.data.autofit).toBe('grow');
+  });
+
+  it('seeds the text box at the slides default font size (18pt), not docs 11pt', () => {
+    const el = buildInsertElement('text', { x: 0, y: 0 }, { x: 100, y: 40 });
+    if (el.type !== 'text') throw new Error('expected a text element');
+    const inline = el.data.blocks[0]?.inlines[0];
+    expect(inline?.style.fontSize).toBe(SLIDES_DEFAULT_TEXT_SIZE);
+    expect(SLIDES_DEFAULT_TEXT_SIZE).toBe(18);
   });
 });

--- a/packages/slides/test/view/editor/text-box-editor.test.ts
+++ b/packages/slides/test/view/editor/text-box-editor.test.ts
@@ -7,6 +7,7 @@ import type { TextElement } from '../../../src/model/element';
 import { defaultDark } from '../../../src/themes';
 import { resolveColor } from '../../../src/model/theme';
 import { initialize, type SlidesEditor } from '../../../src/view/editor/editor';
+import { SLIDES_DEFAULT_TEXT_SIZE } from '../../../src/view/editor/default-text';
 import type {
   MountSlidesTextBoxOptions,
   SlidesTextBoxEditor,
@@ -231,6 +232,29 @@ describe('slides text-box editor wiring', () => {
     dispatchDblClick(canvas, 150, 150);
     expect(editor.getEditingElementId()).toBe(shapeId);
     expect(current()).not.toBeNull();
+  });
+
+  it('fresh shape edit seeds the slides default font size (18pt), not docs 11pt', () => {
+    const { canvas, overlay, store } = makeFixture();
+    const slideId = store.read().slides[0].id;
+    store.batch(() => {
+      store.addElement(slideId, {
+        type: 'shape',
+        frame: { x: 100, y: 100, w: 200, h: 100, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#abc' } },
+      });
+    });
+    const { mount, current } = makeMockMount();
+    editor = initialize({
+      canvas, overlay, store,
+      hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: mount,
+    });
+    dispatchDblClick(canvas, 150, 150);
+    // A shape with no prior text body seeds its edit blocks with the
+    // slides default run so the first keystroke is 18pt.
+    const seed = current()!.opts.blocks[0]?.inlines[0];
+    expect(seed?.style.fontSize).toBe(SLIDES_DEFAULT_TEXT_SIZE);
   });
 
   it('shape edit-mode commits typed text into ShapeElement.data.text via withShapeText', () => {


### PR DESCRIPTION
## Summary

Three follow-ups on the slides-tables work (all on one branch):

1. **Two-user Yorkie concurrent integration test** — validates the granular table CRDT ops that already shipped: concurrent disjoint-cell edits both survive, concurrent row/column appends both land (2→4), and a merge concurrent with a disjoint-cell edit applies both. Auto-discovered by the `*.integration.ts` lane; skips without `YORKIE_RPC_ADDR`.

2. **Cell padding control** — a uniform "Cell padding" dropdown in `TableControls` (presets 0/2/5/10 px + Custom input), patching every target cell's `style.padding` via the existing `updateTableCellStyle` path (scoped to the active cell range or the whole table). Model/renderer/store already supported `padding`; this was a UI-only gap. Per-side padding stays out of scope — it belongs in the Format options panel with the deferred per-side border picker.

3. **Default typed text → 18pt (PowerPoint parity)** — text typed into an empty slide body (table cell, shape) and freshly inserted text boxes fell through to the docs engine's `DEFAULT_INLINE_STYLE.fontSize = 11` (the Google *Docs* default), rendering visibly smaller than the 18pt body placeholder and than PowerPoint (18pt) / Google Slides (14pt). A single `SLIDES_DEFAULT_TEXT_SIZE = 18` + `makeDefaultSlidesTextBlock()` is applied at the three seams that mint a new/empty body: `insert.ts` (text box) and the shape/cell edit-target builders in `editor.ts` (folding away the duplicate `emptyShapeTextBlock`). The size lives in the typed run, so `deckFontScale` applies uniformly.

The remaining slides-tables todo items (presence, PDF export) are blocked on separate infrastructure (slides peer-presence rendering, slides PDF export module) and are out of scope here.

## Test plan

- `pnpm verify:fast` — green (sheets/slides/frontend/backend/docs unit + lint + typecheck).
- New/updated tests:
  - `yorkie-slides-table-concurrent.integration.ts` — 4/4 green against a live Yorkie (`YORKIE_RPC_ADDR=http://localhost:8080 pnpm frontend test:integration`).
  - `table-controls.test.ts` — preset click patches the right cells (whole-table 4, range 2) with the uniform `{padding}` in one batch.
  - `insert-defaults` / `cell-text-edit-entry` / `text-box-editor` — text-box, cell, and shape edit-entry seeds are 18pt.
- Manual smoke (`pnpm dev`): insert a table, type in a cell → text now reads at body size (18pt); Cell padding dropdown changes the text inset; per-range scoping works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)