### PR TITLE
Improve a11y coverage and tidy Radix wrapper usage in frontend

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| a11y + Radix cleanup (2026-06-20) | [20260620-a11y-radix-cleanup-todo.md](./active/20260620-a11y-radix-cleanup-todo.md) | [20260620-a11y-radix-cleanup-lessons.md](./active/20260620-a11y-radix-cleanup-lessons.md) |
 | design docs archive cleanup (2026-06-20) | [20260620-design-docs-archive-cleanup-todo.md](./active/20260620-design-docs-archive-cleanup-todo.md) | [20260620-design-docs-archive-cleanup-lessons.md](./active/20260620-design-docs-archive-cleanup-lessons.md) |
 | docs comments polish (2026-06-20) | [20260620-docs-comments-polish-todo.md](./active/20260620-docs-comments-polish-todo.md) | [20260620-docs-comments-polish-lessons.md](./active/20260620-docs-comments-polish-lessons.md) |
 | release v0.4.6 (2026-06-20) | [20260620-release-v0.4.6-todo.md](./active/20260620-release-v0.4.6-todo.md) | - |

--- a/docs/tasks/active/20260620-a11y-radix-cleanup-lessons.md
+++ b/docs/tasks/active/20260620-a11y-radix-cleanup-lessons.md
@@ -40,6 +40,28 @@ state semantics and adds consistent styling. Override sizing via `className`
 The `components/ui/*` wrappers are function components (ref-as-prop). Missing
 `forwardRef`/`displayName` is correct for React 19, not a defect.
 
+## Stage 4 (Popover migration) deferred — audit overstated the value
+A static audit flagged three hand-rolled popovers (sheets `CommentPopover`,
+`DocsCommentPopover`, `docs-link-popover`) for migration to a new Radix
+`Popover`. Deeper reading reversed the recommendation:
+
+- **sheets CommentPopover**: bespoke right→left→stacked positioning that keeps
+  the active cell uncovered (`sheet-view.tsx`). Radix's flip model can't
+  replicate it — Radix would be a *downgrade*. Its only wart (a portal-exclusion
+  click-outside hack) works fine.
+- **docs-link-popover**: the audit called "no click-outside dismiss" a bug, but
+  cursor tracking (`onCursorLinkChange`) already dismisses when the caret leaves
+  the link. Every editor click is "outside" the Radix content, so naively
+  enabling Radix outside-dismiss would close the popover *the instant it opens*.
+- **DocsCommentPopover**: dismiss is owned by a parent collaboration hook and
+  reply-input autofocus would fight Radix `FocusScope`.
+
+All three are entangled with canvas hit-testing / editor focus / collab state
+and can only be verified with a live app (DB + Yorkie + canvas). **Lesson:** a
+static "should use Radix X" finding is a hypothesis, not a verdict — read the
+runtime wiring (who owns open/close, what drives positioning) before adding a
+dependency. Don't blindly refactor collaboration UI you can't manually verify.
+
 ## Verification gotcha
 `tsc --noEmit -p tsconfig.app.json` reports many PRE-EXISTING errors in
 untouched files — it is NOT the project gate. The real gate is `pnpm verify:fast`

--- a/docs/tasks/active/20260620-a11y-radix-cleanup-lessons.md
+++ b/docs/tasks/active/20260620-a11y-radix-cleanup-lessons.md
@@ -1,0 +1,47 @@
+# a11y + Radix cleanup — lessons
+
+## Radix Themes ≠ Radix Primitives
+The request linked the **Radix Themes** docs, but the project uses **Radix
+Primitives** wrapped by **shadcn/ui** (`components/ui/`, new-york, Tailwind v4).
+Different products — clarify which before "reviewing Radix usage". No migration
+to Themes; the Primitives + shadcn stack fits the Canvas-heavy app.
+
+## Keyboard handlers inside a Radix menu are dead code unless you steal focus
+Both table-size grid pickers live inside `DropdownMenuContent`. Radix's
+`FocusScope.onMountAutoFocus` focuses the **content container** (not a tabbable
+child) and the content's keydown handler **prevents `Tab`** into descendants.
+So a `tabIndex={0}` grid with `onKeyDown` never receives keys — the handler is
+unreachable.
+
+**Fix pattern:** on the menu content, `onOpenAutoFocus={(e) => { e.preventDefault();
+gridRef.current?.focus(); }}`. When the grid lives in a child component, query it
+from a content ref: `contentRef.current?.querySelector('[role="grid"]')?.focus()`.
+Then `stopPropagation()` on the handled arrow/Enter keys so the menu's own
+roving-focus handler doesn't fire and steal focus back.
+
+**Lesson:** when adding keyboard nav to a custom widget rendered inside a Radix
+overlay (Menu/Popover/Dialog), verify the element actually receives focus —
+don't assume `tabIndex` is enough. Test reachability, not just handler logic.
+
+## `aria-label` vs `title` for icon buttons
+`title=` is a tooltip, NOT a reliable accessible name (screen readers may ignore
+it, no keyboard/touch surface). For icon-only buttons add `aria-label` for the
+name AND a Radix `Tooltip` for the visible hint — they serve different users.
+
+## Toggle conversion preserves a11y for free
+Radix `Toggle` sets both `data-state=on` and `aria-pressed`, and the project's
+`toggle.tsx` keys its pressed visual off `aria-pressed` too (survives the
+`data-state` clobber when wrapped in `TooltipTrigger asChild`). Converting a
+hand-rolled `<button aria-pressed>` to `<Toggle pressed onPressedChange>` keeps
+state semantics and adds consistent styling. Override sizing via `className`
+(tailwind-merge lets later `h-/w-/min-w-/p-` utilities win) to fit compact bars.
+
+## React 19 shadcn wrappers: no forwardRef by design
+The `components/ui/*` wrappers are function components (ref-as-prop). Missing
+`forwardRef`/`displayName` is correct for React 19, not a defect.
+
+## Verification gotcha
+`tsc --noEmit -p tsconfig.app.json` reports many PRE-EXISTING errors in
+untouched files — it is NOT the project gate. The real gate is `pnpm verify:fast`
+(tokens build + lint + per-package typecheck + tests). Check that your edited
+files don't appear in tsc output rather than expecting a clean run.

--- a/docs/tasks/active/20260620-a11y-radix-cleanup-todo.md
+++ b/docs/tasks/active/20260620-a11y-radix-cleanup-todo.md
@@ -1,0 +1,56 @@
+# a11y + Radix cleanup (Stage 1+2)
+
+Scope: no new dependencies. Frontend chrome only (not canvas internals).
+Result of a Radix-usage / a11y review. High-severity issues: none. This is
+accessibility-label coverage + a few hand-rolled widgets → existing Radix
+wrappers.
+
+## Stage 2 — Radix wrapper cleanups (`components/ui/`)
+
+- [x] `separator.tsx:14` — `data-slot="separator-root"` → `"separator"`
+- [x] `context-menu.tsx:1` — drop no-op `"use client"`
+- [x] `context-menu.tsx:45` — align `data-[inset=true]` → `data-[inset]` with dropdown-menu
+
+## Stage 2 — Find bars → Tooltip / Toggle
+
+- [x] `app/docs/docs-find-bar.tsx` — icon buttons `title=` → Tooltip; match-case/regex → Toggle; inputs aria-label; counter aria-live
+- [x] `components/find-bar.tsx` — prev/next/close icon buttons → Tooltip; find input aria-label; counter aria-live
+- [x] `app/docs/docs-detail.tsx:177` — comments toggle `<button aria-pressed>` → Toggle (+ Tooltip)
+
+## Stage 1 — a11y label coverage (no Radix change)
+
+Workspaces / docs / share:
+- [x] `app/workspaces/workspace-settings.tsx` — icon buttons aria-label (remove-member, copy-invite, revoke-invite, revoke-key, copy-key); confirm input htmlFor/id; name/slug/key-name input aria-labels
+- [x] `app/datasources/datasource-list.tsx` — filter input aria-label
+- [x] `app/documents/document-list.tsx` — filter input aria-label; row keyboard nav (role=button/tabIndex/onKeyDown)
+- [x] `components/share-dialog.tsx` — copy/revoke link aria-label
+- [x] `components/tab-bar.tsx` — add-tab aria-label; rename input aria-label
+- [x] `components/datasource-selector.tsx` — aria-pressed on selection
+- [x] `app/spreadsheet/datasource-view.tsx` — SQL textarea aria-label; query error role=alert
+- [x] `app/docs/docs-link-popover.tsx` — URL input aria-label (icon buttons already labeled)
+- [x] `components/text-formatting/line-spacing-picker.tsx` — aria-label
+- [x] `components/mobile-edit-panel.tsx`; `app/slides/toolbar/table-controls.tsx` — aria-labels
+- [x] Grid pickers keyboard nav: `app/docs/table-grid-picker.tsx`, `app/slides/table-picker.tsx` (role=grid + arrow/Enter, focus stolen on menu open)
+- [ ] Low (deferred): invite-accept / shared-document role=status/alert; why-section icon alt
+
+## Verify
+- [x] `pnpm verify:fast` green (frontend 574 tests pass, lint clean)
+- [ ] manual smoke for find bars + comments toggle + grid-picker keyboard nav
+
+## Review
+
+Scope delivered: 18 frontend files. Two Radix-correctness wrapper fixes, find
+bar Tooltip/Toggle conversions, comments-panel Toggle, ~30 aria-label/aria-live
+additions, two table-size grid pickers made keyboard-operable.
+
+Self-review (code-review skill, medium) surfaced one real bug: the new
+grid-picker keyboard handlers were **unreachable** because the grids render
+inside a Radix `DropdownMenuContent` (focus goes to the content container, Tab
+into descendants is blocked). Fixed by `onOpenAutoFocus` → focus the grid, plus
+`stopPropagation()` on handled keys. All other changes verified correct.
+
+Deferred (low severity, can be a follow-up): role=status/alert on async
+status text in invite-accept/shared-document; text alt on why-section
+comparison icons. Not migrated (deliberate): canvas context menus (Radix blocks
+canvas pointer events), comment/link popovers (need a `Popover` primitive — that
+was Stage 4, out of scope here).

--- a/packages/frontend/src/app/datasources/datasource-list.tsx
+++ b/packages/frontend/src/app/datasources/datasource-list.tsx
@@ -243,6 +243,7 @@ export function DataSourceList({ data, workspaceId }: { data: DataSource[]; work
       <div className="flex items-center justify-between py-4">
         <Input
           placeholder="Filter by name..."
+          aria-label="Filter data sources by name"
           value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
           onChange={(e) =>
             table.getColumn("name")?.setFilterValue(e.target.value)

--- a/packages/frontend/src/app/docs/docs-detail.tsx
+++ b/packages/frontend/src/app/docs/docs-detail.tsx
@@ -11,6 +11,12 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { SiteHeader } from "@/components/site-header";
 import { ShareDialog } from "@/components/share-dialog";
 import { UserPresence } from "@/components/user-presence";
+import { Toggle } from "@/components/ui/toggle";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { usePresenceUpdater } from "@/hooks/use-presence-updater";
 import { IconFolder, IconSettings, IconDatabase, IconMessage } from "@tabler/icons-react";
 import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
@@ -174,17 +180,24 @@ function DocsLayout({ documentId }: { documentId: string }) {
           onRename={handleRenameDocument}
         >
           <div className="flex items-center gap-2">
-            <button
-              type="button"
-              className={`inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-sm hover:bg-muted ${
-                commentsPanelOpen ? "bg-muted" : ""
-              }`}
-              aria-label={commentsPanelOpen ? "Hide comments" : "Show comments"}
-              aria-pressed={commentsPanelOpen}
-              onClick={() => setCommentsPanelOpen((v) => !v)}
-            >
-              <IconMessage size={16} />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Toggle
+                  size="sm"
+                  className="h-7 w-7 min-w-7 p-0"
+                  aria-label={
+                    commentsPanelOpen ? "Hide comments" : "Show comments"
+                  }
+                  pressed={commentsPanelOpen}
+                  onPressedChange={setCommentsPanelOpen}
+                >
+                  <IconMessage size={16} />
+                </Toggle>
+              </TooltipTrigger>
+              <TooltipContent>
+                {commentsPanelOpen ? "Hide comments" : "Show comments"}
+              </TooltipContent>
+            </Tooltip>
             <ShareDialog documentId={documentId} />
             <UserPresence
               onSelectPeer={handleSelectPeer}

--- a/packages/frontend/src/app/docs/docs-find-bar.tsx
+++ b/packages/frontend/src/app/docs/docs-find-bar.tsx
@@ -9,6 +9,12 @@ import {
   IconLetterCase,
   IconRegex,
 } from "@tabler/icons-react";
+import { Toggle } from "@/components/ui/toggle";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface DocsFindBarProps {
   editor: EditorAPI | null;
@@ -159,12 +165,8 @@ export function DocsFindBar({
 
   const iconBtnClass =
     "flex items-center justify-center w-6 h-6 rounded hover:bg-muted text-muted-foreground disabled:opacity-40";
-  const toggleBtnClass = (active: boolean) =>
-    `flex items-center justify-center w-6 h-6 rounded ${
-      active
-        ? "bg-primary/10 text-primary"
-        : "hover:bg-muted text-muted-foreground"
-    }`;
+  const toggleClass =
+    "w-6 h-6 min-w-6 p-0 rounded text-muted-foreground [&_svg:not([class*='size-'])]:size-3.5";
 
   const containerRect = containerRef.current?.getBoundingClientRect();
   const fixedTop = containerRect?.top ?? 0;
@@ -184,46 +186,83 @@ export function DocsFindBar({
           type="text"
           className="flex-1 rounded border bg-background px-2 py-1 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
           placeholder="Find"
+          aria-label="Find"
           value={query}
           onChange={(e) => handleQueryChange(e.target.value)}
           onKeyDown={handleSearchKeyDown}
         />
-        <span className="min-w-[60px] text-center text-xs text-muted-foreground">
+        <span
+          className="min-w-[60px] text-center text-xs text-muted-foreground"
+          aria-live="polite"
+        >
           {query ? counterText : ""}
         </span>
-        <button
-          className={toggleBtnClass(caseSensitive)}
-          title="Match case"
-          onClick={() => setCaseSensitive(!caseSensitive)}
-        >
-          <IconLetterCase size={14} />
-        </button>
-        <button
-          className={toggleBtnClass(useRegex)}
-          title="Use regex"
-          onClick={() => setUseRegex(!useRegex)}
-        >
-          <IconRegex size={14} />
-        </button>
-        <button
-          className={iconBtnClass}
-          title="Previous (Shift+Enter)"
-          disabled={matchCount === 0}
-          onClick={handlePrevious}
-        >
-          <IconChevronUp size={14} />
-        </button>
-        <button
-          className={iconBtnClass}
-          title="Next (Enter)"
-          disabled={matchCount === 0}
-          onClick={handleNext}
-        >
-          <IconChevronDown size={14} />
-        </button>
-        <button className={iconBtnClass} title="Close (Esc)" onClick={handleClose}>
-          <IconX size={14} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Toggle
+              size="sm"
+              className={toggleClass}
+              aria-label="Match case"
+              pressed={caseSensitive}
+              onPressedChange={setCaseSensitive}
+            >
+              <IconLetterCase size={14} />
+            </Toggle>
+          </TooltipTrigger>
+          <TooltipContent>Match case</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Toggle
+              size="sm"
+              className={toggleClass}
+              aria-label="Use regex"
+              pressed={useRegex}
+              onPressedChange={setUseRegex}
+            >
+              <IconRegex size={14} />
+            </Toggle>
+          </TooltipTrigger>
+          <TooltipContent>Use regex</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className={iconBtnClass}
+              aria-label="Previous match"
+              disabled={matchCount === 0}
+              onClick={handlePrevious}
+            >
+              <IconChevronUp size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Previous (Shift+Enter)</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className={iconBtnClass}
+              aria-label="Next match"
+              disabled={matchCount === 0}
+              onClick={handleNext}
+            >
+              <IconChevronDown size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Next (Enter)</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className={iconBtnClass}
+              aria-label="Close find bar"
+              onClick={handleClose}
+            >
+              <IconX size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Close (Esc)</TooltipContent>
+        </Tooltip>
       </div>
 
       {/* Replace row */}
@@ -233,6 +272,7 @@ export function DocsFindBar({
             type="text"
             className="flex-1 rounded border bg-background px-2 py-1 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
             placeholder="Replace"
+            aria-label="Replace with"
             value={replacement}
             onChange={(e) => setReplacement(e.target.value)}
             onKeyDown={handleReplaceKeyDown}

--- a/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
+++ b/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
@@ -68,6 +68,7 @@ import { isMac, modKey } from "@/components/text-formatting/platform";
 
 function TableDropdown({ editor }: { editor: EditorAPI | null }) {
   const [open, setOpen] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <Tooltip>
@@ -83,7 +84,19 @@ function TableDropdown({ editor }: { editor: EditorAPI | null }) {
         </TooltipTrigger>
         <TooltipContent>Insert table</TooltipContent>
       </Tooltip>
-      <DropdownMenuContent align="start" sideOffset={4}>
+      <DropdownMenuContent
+        ref={contentRef}
+        align="start"
+        sideOffset={4}
+        // Radix focuses the menu content container on open; redirect
+        // focus to the grid so its arrow-key handler is reachable.
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          contentRef.current
+            ?.querySelector<HTMLElement>('[role="grid"]')
+            ?.focus();
+        }}
+      >
         <TableGridPicker
           onSelect={(rows, cols) => {
             editor?.insertTable(rows, cols);

--- a/packages/frontend/src/app/docs/docs-link-popover.tsx
+++ b/packages/frontend/src/app/docs/docs-link-popover.tsx
@@ -209,6 +209,7 @@ export function DocsLinkPopover({
           <input
             ref={inputRef}
             type="url"
+            aria-label="Link URL"
             className="h-7 flex-1 rounded border bg-background px-2 text-xs text-foreground outline-none focus:ring-1 focus:ring-ring"
             placeholder="Enter URL"
             value={editUrl}

--- a/packages/frontend/src/app/docs/table-grid-picker.tsx
+++ b/packages/frontend/src/app/docs/table-grid-picker.tsx
@@ -58,6 +58,47 @@ export function TableGridPicker({ onSelect }: TableGridPickerProps) {
     [resolveCell, onSelect],
   );
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const clamp = (n: number) => Math.max(0, Math.min(n, MAX_SIZE - 1));
+      // stopPropagation on handled keys so the enclosing Radix menu's
+      // arrow-key navigation doesn't also fire and steal focus.
+      switch (e.key) {
+        case "ArrowRight":
+          e.preventDefault();
+          e.stopPropagation();
+          setHoverCol((c) => clamp((c < 0 ? -1 : c) + 1));
+          if (hoverRow < 0) setHoverRow(0);
+          break;
+        case "ArrowLeft":
+          e.preventDefault();
+          e.stopPropagation();
+          setHoverCol((c) => clamp(c - 1));
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          e.stopPropagation();
+          setHoverRow((r) => clamp((r < 0 ? -1 : r) + 1));
+          if (hoverCol < 0) setHoverCol(0);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          e.stopPropagation();
+          setHoverRow((r) => clamp(r - 1));
+          break;
+        case "Enter":
+        case " ":
+          e.preventDefault();
+          e.stopPropagation();
+          if (hoverRow >= 0 && hoverCol >= 0) {
+            onSelect(hoverRow + 1, hoverCol + 1);
+          }
+          break;
+      }
+    },
+    [hoverRow, hoverCol, onSelect],
+  );
+
   const handleMouseLeave = useCallback((e: React.MouseEvent) => {
     const grid = gridRef.current;
     if (grid) {
@@ -101,10 +142,19 @@ export function TableGridPicker({ onSelect }: TableGridPickerProps) {
     <div className="p-2">
       <div
         ref={gridRef}
+        role="grid"
+        tabIndex={0}
+        aria-label={
+          hoverRow >= 0 && hoverCol >= 0
+            ? `Insert ${hoverRow + 1} by ${hoverCol + 1} table`
+            : "Insert table, use arrow keys to size"
+        }
+        className="outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
         style={{ width: gridW, height: gridH, position: "relative" }}
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
         onClick={handleClick}
+        onKeyDown={handleKeyDown}
       >
         {cells}
       </div>

--- a/packages/frontend/src/app/docs/table-grid-picker.tsx
+++ b/packages/frontend/src/app/docs/table-grid-picker.tsx
@@ -122,6 +122,8 @@ export function TableGridPicker({ onSelect }: TableGridPickerProps) {
       cells.push(
         <div
           key={`${r}-${c}`}
+          role="gridcell"
+          aria-selected={isHighlighted}
           className={`absolute rounded-sm border transition-colors ${
             isHighlighted
               ? "bg-primary/20 border-primary"

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -456,6 +456,7 @@ export function DocumentList({
       <div className="flex items-center justify-between py-4">
         <Input
           placeholder="Filter by title..."
+          aria-label="Filter documents by title"
           value={(table.getColumn("title")?.getFilterValue() as string) ?? ""}
           onChange={(e) =>
             table.getColumn("title")?.setFilterValue(e.target.value)
@@ -550,11 +551,22 @@ export function DocumentList({
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
-                  className="cursor-pointer hover:bg-muted"
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Open ${String(row.getValue("title") ?? "document")}`}
+                  className="cursor-pointer hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
                   onClick={(e: MouseEvent<HTMLElement>) => {
                     if ((e.target as HTMLElement).closest("input, button")) {
                       return;
                     }
+                    navigate(getDocumentPath(row.original));
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key !== "Enter" && e.key !== " ") return;
+                    if ((e.target as HTMLElement).closest("input, button")) {
+                      return;
+                    }
+                    e.preventDefault();
                     navigate(getDocumentPath(row.original));
                   }}
                 >

--- a/packages/frontend/src/app/slides/table-picker.tsx
+++ b/packages/frontend/src/app/slides/table-picker.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { IconTable } from '@tabler/icons-react';
 import type { SlidesEditor } from '@wafflebase/slides';
 import {
@@ -40,6 +40,7 @@ export function TablePicker({ editor, disabled }: TablePickerProps) {
   // selection yet" so the legend reads `0 × 0`.
   const [hoverRow, setHoverRow] = useState(-1);
   const [hoverCol, setHoverCol] = useState(-1);
+  const gridRef = useRef<HTMLDivElement>(null);
 
   const commit = (rows: number, cols: number): void => {
     if (!editor || rows < 1 || cols < 1) return;
@@ -51,6 +52,43 @@ export function TablePicker({ editor, disabled }: TablePickerProps) {
 
   const rowsLabel = hoverRow + 1;
   const colsLabel = hoverCol + 1;
+
+  const handleGridKeyDown = (e: React.KeyboardEvent): void => {
+    const clampRow = (n: number) =>
+      Math.max(0, Math.min(n, PICKER_MAX_ROWS - 1));
+    const clampCol = (n: number) =>
+      Math.max(0, Math.min(n, PICKER_MAX_COLS - 1));
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        e.stopPropagation();
+        setHoverCol((c) => clampCol((c < 0 ? -1 : c) + 1));
+        if (hoverRow < 0) setHoverRow(0);
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        e.stopPropagation();
+        setHoverCol((c) => clampCol(c - 1));
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        e.stopPropagation();
+        setHoverRow((r) => clampRow((r < 0 ? -1 : r) + 1));
+        if (hoverCol < 0) setHoverCol(0);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        e.stopPropagation();
+        setHoverRow((r) => clampRow(r - 1));
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        e.stopPropagation();
+        if (hoverRow >= 0 && hoverCol >= 0) commit(hoverRow + 1, hoverCol + 1);
+        break;
+    }
+  };
 
   return (
     <DropdownMenu
@@ -81,14 +119,24 @@ export function TablePicker({ editor, disabled }: TablePickerProps) {
       <DropdownMenuContent
         align="start"
         className="flex flex-col gap-1 p-2"
+        // Radix focuses the menu content container on open; redirect
+        // focus to the grid so its arrow-key handler is reachable.
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          gridRef.current?.focus();
+        }}
         onMouseLeave={() => {
           setHoverRow(-1);
           setHoverCol(-1);
         }}
       >
         <div
+          ref={gridRef}
           role="grid"
-          aria-label={`Insert ${rowsLabel} by ${colsLabel} table`}
+          tabIndex={0}
+          aria-label={`Insert ${rowsLabel} by ${colsLabel} table, use arrow keys to size`}
+          onKeyDown={handleGridKeyDown}
+          className="outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
           style={{
             display: 'grid',
             gridTemplateColumns: `repeat(${PICKER_MAX_COLS}, ${CELL_PX}px)`,

--- a/packages/frontend/src/app/slides/table-picker.tsx
+++ b/packages/frontend/src/app/slides/table-picker.tsx
@@ -134,7 +134,11 @@ export function TablePicker({ editor, disabled }: TablePickerProps) {
           ref={gridRef}
           role="grid"
           tabIndex={0}
-          aria-label={`Insert ${rowsLabel} by ${colsLabel} table, use arrow keys to size`}
+          aria-label={
+            hoverRow >= 0 && hoverCol >= 0
+              ? `Insert ${rowsLabel} by ${colsLabel} table`
+              : 'Insert table, use arrow keys to size'
+          }
           onKeyDown={handleGridKeyDown}
           className="outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
           style={{

--- a/packages/frontend/src/app/slides/toolbar/table-controls.tsx
+++ b/packages/frontend/src/app/slides/toolbar/table-controls.tsx
@@ -430,6 +430,7 @@ export function TableControls({
               <input
                 autoFocus
                 type="number"
+                aria-label="Cell padding (px)"
                 step={1}
                 min={PADDING_MIN}
                 max={PADDING_MAX}

--- a/packages/frontend/src/app/spreadsheet/datasource-view.tsx
+++ b/packages/frontend/src/app/spreadsheet/datasource-view.tsx
@@ -147,6 +147,7 @@ export function DataSourceView({
       {/* SQL Editor */}
       <div className="border-b p-2 shrink-0">
         <textarea
+          aria-label="SQL query"
           className="w-full h-24 p-2 font-mono text-sm border rounded resize-y bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
           placeholder="SELECT * FROM users LIMIT 100"
           value={query}
@@ -177,7 +178,9 @@ export function DataSourceView({
           </span>
         )}
         {queryError && (
-          <span className="text-xs text-destructive truncate">{queryError}</span>
+          <span role="alert" className="text-xs text-destructive truncate">
+            {queryError}
+          </span>
         )}
       </div>
 

--- a/packages/frontend/src/app/workspaces/workspace-settings.tsx
+++ b/packages/frontend/src/app/workspaces/workspace-settings.tsx
@@ -249,6 +249,7 @@ export default function WorkspaceSettings() {
             value={name}
             onChange={(e) => setName(e.target.value)}
             className="max-w-sm"
+            aria-label="Workspace name"
           />
           {name.trim() !== workspace.name && name.trim() !== "" && (
             <Button type="submit" disabled={updateMutation.isPending}>
@@ -282,6 +283,7 @@ export default function WorkspaceSettings() {
             value={slug}
             onChange={(e) => setSlug(e.target.value)}
             className="max-w-sm"
+            aria-label="Workspace URL slug"
           />
           {slug.trim() !== workspace.slug && slug.trim() !== "" && (
             <Button type="submit" disabled={updateMutation.isPending}>
@@ -325,6 +327,7 @@ export default function WorkspaceSettings() {
                         variant="ghost"
                         size="sm"
                         className="text-destructive hover:text-destructive"
+                        aria-label="Remove member"
                         onClick={() =>
                           removeMemberMutation.mutate(member.user.id)
                         }
@@ -386,6 +389,7 @@ export default function WorkspaceSettings() {
                       <Button
                         variant="ghost"
                         size="sm"
+                        aria-label="Copy invite link"
                         onClick={() => copyInviteLink(invite.token)}
                       >
                         <Copy className="h-4 w-4" />
@@ -394,6 +398,7 @@ export default function WorkspaceSettings() {
                         variant="ghost"
                         size="sm"
                         className="text-destructive hover:text-destructive"
+                        aria-label="Revoke invite"
                         onClick={() =>
                           revokeInviteMutation.mutate(invite.id)
                         }
@@ -465,6 +470,7 @@ export default function WorkspaceSettings() {
                             variant="ghost"
                             size="sm"
                             className="text-destructive hover:text-destructive"
+                            aria-label="Revoke API key"
                             onClick={() =>
                               revokeApiKeyMutation.mutate(apiKey.id)
                             }
@@ -532,10 +538,14 @@ export default function WorkspaceSettings() {
               deleteMutation.mutate();
             }}
           >
-            <label className="text-sm text-muted-foreground">
+            <label
+              htmlFor="delete-confirm"
+              className="text-sm text-muted-foreground"
+            >
               Type <strong>{workspace.name}</strong> to confirm:
             </label>
             <Input
+              id="delete-confirm"
               value={deleteConfirmName}
               onChange={(e) => setDeleteConfirmName(e.target.value)}
               className="mt-2"
@@ -595,6 +605,7 @@ export default function WorkspaceSettings() {
               value={keyName}
               onChange={(e) => setKeyName(e.target.value)}
               placeholder="e.g. CI pipeline"
+              aria-label="API key name"
               autoFocus
             />
             <DialogFooter className="mt-4">
@@ -643,6 +654,7 @@ export default function WorkspaceSettings() {
             <Button
               variant="ghost"
               size="sm"
+              aria-label="Copy API key"
               onClick={() => {
                 if (revealedKey) {
                   navigator.clipboard.writeText(revealedKey.key);

--- a/packages/frontend/src/components/datasource-selector.tsx
+++ b/packages/frontend/src/components/datasource-selector.tsx
@@ -78,6 +78,7 @@ export function DataSourceSelector({
                   {datasources.map((ds) => (
                     <button
                       key={ds.id}
+                      aria-pressed={selectedId === ds.id}
                       className={cn(
                         "flex items-center gap-2 px-3 py-2 rounded-md border text-sm text-left cursor-pointer",
                         "hover:bg-muted/50 transition-colors",

--- a/packages/frontend/src/components/find-bar.tsx
+++ b/packages/frontend/src/components/find-bar.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { IconChevronUp, IconChevronDown, IconX } from "@tabler/icons-react";
 import type { Spreadsheet } from "@wafflebase/sheets";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface FindBarProps {
   spreadsheet: Spreadsheet | undefined;
@@ -106,38 +111,57 @@ export function FindBar({ spreadsheet, onClose }: FindBarProps) {
         type="text"
         className="h-7 w-48 rounded border-none bg-transparent px-1 text-sm outline-none focus:ring-0"
         placeholder="Find..."
+        aria-label="Find in sheet"
         value={query}
         onChange={(e) => handleSearch(e.target.value)}
       />
-      <span className="min-w-[3.5rem] text-center text-xs text-muted-foreground">
+      <span
+        className="min-w-[3.5rem] text-center text-xs text-muted-foreground"
+        aria-live="polite"
+      >
         {query ? `${displayIndex}/${total}` : ""}
       </span>
-      <button
-        type="button"
-        className="rounded p-0.5 hover:bg-muted disabled:opacity-30"
-        onClick={handlePrevious}
-        disabled={total === 0}
-        title="Previous (Shift+Enter)"
-      >
-        <IconChevronUp size={16} />
-      </button>
-      <button
-        type="button"
-        className="rounded p-0.5 hover:bg-muted disabled:opacity-30"
-        onClick={handleNext}
-        disabled={total === 0}
-        title="Next (Enter)"
-      >
-        <IconChevronDown size={16} />
-      </button>
-      <button
-        type="button"
-        className="rounded p-0.5 hover:bg-muted"
-        onClick={handleClose}
-        title="Close (Esc)"
-      >
-        <IconX size={16} />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="rounded p-0.5 hover:bg-muted disabled:opacity-30"
+            onClick={handlePrevious}
+            disabled={total === 0}
+            aria-label="Previous match"
+          >
+            <IconChevronUp size={16} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Previous (Shift+Enter)</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="rounded p-0.5 hover:bg-muted disabled:opacity-30"
+            onClick={handleNext}
+            disabled={total === 0}
+            aria-label="Next match"
+          >
+            <IconChevronDown size={16} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Next (Enter)</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="rounded p-0.5 hover:bg-muted"
+            onClick={handleClose}
+            aria-label="Close find bar"
+          >
+            <IconX size={16} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Close (Esc)</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/packages/frontend/src/components/mobile-edit-panel.tsx
+++ b/packages/frontend/src/components/mobile-edit-panel.tsx
@@ -72,6 +72,7 @@ export function MobileEditPanel({
         </span>
         <textarea
           ref={textareaRef}
+          aria-label={`Edit cell ${cellRef}`}
           className="min-w-0 flex-1 resize-none rounded border bg-background px-2 py-1 text-sm leading-5 outline-none focus:ring-1 focus:ring-ring"
           rows={1}
           value={value}

--- a/packages/frontend/src/components/share-dialog.tsx
+++ b/packages/frontend/src/components/share-dialog.tsx
@@ -173,6 +173,7 @@ export function ShareDialog({ documentId }: { documentId: string }) {
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7"
+                          aria-label="Copy link"
                           onClick={() => handleCopy(link.token)}
                         >
                           <IconCopy className="h-3.5 w-3.5" />
@@ -181,6 +182,7 @@ export function ShareDialog({ documentId }: { documentId: string }) {
                           variant="ghost"
                           size="icon"
                           className="h-7 w-7 text-destructive"
+                          aria-label="Revoke link"
                           onClick={() => handleDelete(link.id)}
                         >
                           <IconTrash className="h-3.5 w-3.5" />

--- a/packages/frontend/src/components/tab-bar.tsx
+++ b/packages/frontend/src/components/tab-bar.tsx
@@ -104,6 +104,7 @@ function SortableTab({
       {isEditing ? (
         <input
           ref={inputRef}
+          aria-label="Rename tab"
           className="w-20 bg-transparent border-b border-primary text-sm outline-none"
           value={editValue}
           onChange={(e) => onEditValueChange(e.target.value)}
@@ -268,7 +269,10 @@ export function TabBar({
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <button className="shrink-0 flex items-center justify-center size-7 ml-1 rounded hover:bg-muted/50 text-muted-foreground cursor-pointer">
+            <button
+              aria-label="Add tab"
+              className="shrink-0 flex items-center justify-center size-7 ml-1 rounded hover:bg-muted/50 text-muted-foreground cursor-pointer"
+            >
               <IconPlus className="size-4" />
             </button>
           </DropdownMenuTrigger>

--- a/packages/frontend/src/components/text-formatting/line-spacing-picker.tsx
+++ b/packages/frontend/src/components/text-formatting/line-spacing-picker.tsx
@@ -95,6 +95,7 @@ export function LineSpacingPicker({
             <input
               autoFocus
               type="number"
+              aria-label="Custom line spacing"
               step={0.05}
               min={LINE_SPACING_MIN}
               max={LINE_SPACING_MAX}

--- a/packages/frontend/src/components/ui/context-menu.tsx
+++ b/packages/frontend/src/components/ui/context-menu.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
 
@@ -42,7 +40,7 @@ function ContextMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset=true]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/packages/frontend/src/components/ui/separator.tsx
+++ b/packages/frontend/src/components/ui/separator.tsx
@@ -11,7 +11,7 @@ function Separator({
 }: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
   return (
     <SeparatorPrimitive.Root
-      data-slot="separator-root"
+      data-slot="separator"
       decorative={decorative}
       orientation={orientation}
       className={cn(


### PR DESCRIPTION
## Summary

Review of how the frontend uses Radix found the **Radix Primitives** wrappers
(shadcn/ui in `components/ui/`) well-wired — no high-severity defects — but
icon-only buttons, filter inputs, and status text lacked accessible names, and
two table-size grid pickers were mouse-only. This PR closes those gaps and does
a few small Radix wrapper tidy-ups.

> Note: the original ask linked the **Radix Themes** docs; this project uses
> **Radix Primitives + shadcn/ui**, a different product. No migration to Themes.

### a11y coverage (~30 additions, no behavior change)
- `aria-label` on icon-only buttons (workspace settings copy/revoke/remove, share dialog, tab bar, find bars, link/cell editors)
- `aria-label`/label-id on unlabeled inputs (filters, SQL textarea, URL, line spacing, delete-confirm)
- `aria-live` on find-bar match counters; `role="alert"` on query-error text; `aria-pressed` on datasource selection
- `document-list` rows made keyboard-activatable (`role="button"` + Enter/Space)
- docs & slides table-size grid pickers made keyboard-operable (arrow keys + Enter/Space)

### Radix usage
- find-bar icon buttons → `Tooltip`; match-case/regex and the docs comments-panel button → `Toggle` (keeps `aria-pressed` semantics)
- wrapper tidy-ups: `separator` `data-slot`, drop no-op `"use client"`, align `data-inset` selector with `dropdown-menu`

### Notable fix from self-review
The new grid-picker keyboard handlers were initially **unreachable**: the grids
render inside a Radix menu, which focuses the content container and blocks Tab
into descendants. Fixed by focusing the grid on menu open (`onOpenAutoFocus`)
and `stopPropagation()` on handled keys.

### Deferred (out of scope)
Migrating the three hand-rolled popovers to a new `Popover` primitive was
investigated and **deferred**: all three are entangled with canvas hit-testing /
editor focus / collaboration state, the sheets one has bespoke positioning Radix
can't replicate, and they need live smoke testing. Rationale captured in the
task lessons file.

## Test plan
- [x] `pnpm verify:fast` green (frontend lint clean, 574 frontend tests pass; all packages pass)
- [ ] Manual smoke (UI changed): find bars (sheets + docs), docs comments toggle, and **keyboard** sizing of the docs/slides insert-table grid pickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation (arrow keys, Enter/Space) to grid and table pickers for improved control.
  * Enhanced UI controls with tooltip help text showing keyboard shortcuts.

* **Bug Fixes**
  * Improved accessibility across multiple components with proper labels and semantic roles.
  * Enhanced focus management in dropdown menus for better keyboard navigation.

* **Documentation**
  * Added task planning documentation for accessibility and UI library improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->