### PR TITLE
Reconcile slides undo/redo by id to stop document churn

### DIFF
--- a/docs/tasks/active/20260621-slides-native-undo-migration-lessons.md
+++ b/docs/tasks/active/20260621-slides-native-undo-migration-lessons.md
@@ -1,0 +1,16 @@
+# Slides native undo migration — lessons
+
+**Created**: 2026-06-21
+
+## Lessons
+
+(filled in when the migration work starts)
+
+- Starting point from the #388 churn fix: Slides was the only store on
+  snapshot-based undo; Sheets and Docs already use `doc.history`. The
+  snapshot rebuild is what made undo/redo O(document) and caused the
+  node-OOM incident — native undo is O(change) by construction.
+
+- Known central challenge before any code: slides `batch()` runs N
+  independent `doc.update()` calls, so a multi-edit batch is N native undo
+  units. Grouping a batch into one undo unit is the prerequisite refactor.

--- a/docs/tasks/active/20260621-slides-native-undo-migration-todo.md
+++ b/docs/tasks/active/20260621-slides-native-undo-migration-todo.md
@@ -1,0 +1,95 @@
+# Slides undo/redo — migrate to Yorkie-native `doc.history`
+
+**Created**: 2026-06-21
+
+Follow-up to PR #388 (Reconcile slides undo/redo by id to stop document
+churn). Design doc to be written first:
+`docs/design/slides/slides-native-undo.md`.
+
+## Problem
+
+`YorkieSlidesStore` is the only document store that rolls its own
+snapshot-based undo/redo: `batch()` pushes a full `SlidesDocument`
+snapshot onto `undoStack`, and `undo()` restores it via `replaceRoot`.
+Sheets (`yorkie-store.ts`) and Docs (`yorkie-doc-store.ts`) both use
+Yorkie-native `doc.history.undo()/redo()`.
+
+The snapshot approach caused the 2026-06-20 node-OOM incident: restoring
+a snapshot rewrote the whole Yorkie root, tombstoning the entire document
+on every undo/redo. PR #388 fixed that by reconciling the live root
+against the snapshot by id — a targeted fix that keeps the snapshot
+architecture.
+
+Yorkie-native undo would remove the whole problem class by construction:
+`doc.history.undo()` applies the *reverse operations* of the last change,
+touching only what changed. It also:
+
+- needs no snapshot stacks (drops the per-batch full-document `read()`);
+- has better collaborative semantics — it reverts only the local client's
+  operations, instead of overwriting a peer's change that landed between
+  `batch()` and `undo()` (a gap the store's own comments flag as
+  "deliberately ignored in Phase 4a").
+
+## Goal / Non-Goals
+
+- Goal: replace the snapshot undo/redo in `YorkieSlidesStore` with
+  `doc.history`, matching Docs/Sheets. Remove `undoStack` / `redoStack` /
+  `replaceRoot` and the snapshot machinery once parity is proven.
+- Non-Goal: changing `MemSlidesStore` (the non-Yorkie fallback) unless
+  required for shared behavior — decide during design.
+- Non-Goal: redesigning the editor's batch/selection model beyond what the
+  undo-unit grouping requires.
+
+## Key challenges (verification points)
+
+1. **One batch = one undo unit.** This is the central refactor. Slides
+   `batch()` does NOT wrap its work in a single `doc.update`; each of the
+   ~46 mutators calls `this.doc.update()` independently, so a batch of N
+   edits (e.g. dragging 3 selected elements) becomes N native undo units.
+   Sheets/Docs avoid this by doing one `doc.update` per public action.
+   Options: (a) make `batch()` open a single `doc.update` and have
+   mutators operate on an ambient root passed down, or (b) Yorkie undo-unit
+   grouping if available. Validate undo grouping with a multi-element drag.
+
+2. **Op reversibility.** Confirm every slides mutation produces a
+   Yorkie-reversible change: set/add/remove/move/style/tree, the array
+   move primitives (`moveFront`/`moveAfter`), group/ungroup, table ops,
+   connector endpoint edits, guides. Anything Yorkie can't reverse breaks
+   native undo.
+
+3. **Collaborative semantics change.** Native undo reverts only local
+   ops, not absolute state. Re-validate any test/UX that assumed snapshot
+   absolute-restore. (Net improvement, but a behavior change.)
+
+4. **Undo floor.** Mirror Docs' `undoFloor`
+   (`getUndoStackForTest().length > undoFloor`) so a user can't undo past
+   the initially seeded deck (the "new deck opens with one slide" seed).
+
+5. **Presence / selection.** Ensure undo/redo plays correctly with the
+   selection overlay and presence after reverse ops (selection may point
+   at re-created/removed element ids).
+
+6. **MemSlidesStore parity.** The fallback store uses snapshot undo.
+   Decide whether to keep its snapshot path or unify the interface.
+
+## Plan
+
+- [ ] Write `docs/design/slides/slides-native-undo.md` (this plan + the
+      batch→undo-unit design, op-reversibility audit, semantics)
+- [ ] Refactor `batch()` so one batch maps to one Yorkie undo unit
+      (single `doc.update` / ambient root)
+- [ ] Swap `undo()` / `redo()` / `canUndo()` / `canRedo()` to
+      `doc.history`, add an undo floor
+- [ ] Port undo/redo tests; keep the `getGarbageLen` churn test as a
+      regression guard (native undo should also be ~zero churn)
+- [ ] Remove `undoStack` / `redoStack` / `replaceRoot` and the reconcile
+      helpers once native parity is green
+- [ ] `pnpm verify:fast`; manual smoke (multi-element drag undo, undo
+      across a concurrent peer edit)
+
+## References
+
+- PR #388 — interim reconcile fix (keeps snapshot architecture)
+- Incident: `second-brain`
+  `00_log/incidents/2026/2026-06-20-yorkie-document-oom-node-cascade.md`
+- Reference impls: `yorkie-doc-store.ts` (Docs), `yorkie-store.ts` (Sheets)

--- a/docs/tasks/active/20260621-slides-undo-redo-churn-lessons.md
+++ b/docs/tasks/active/20260621-slides-undo-redo-churn-lessons.md
@@ -37,3 +37,14 @@
   compiles against `@wafflebase/docs/dist`, not its source. After pulling
   `main` (new docs exports), run `pnpm --filter @wafflebase/docs build`
   before `verify:fast`, or typecheck fails on unrelated missing exports.
+
+- Reusing a narrow rebuild mapping is a trap for an id-based reconcile.
+  The snapshot rebuild reconstructed text `data` as `{ blocks, autofit }`,
+  dropping `fill` / `stroke` / `effects` / `alt` (set via
+  `updateElementData`). With the old whole-array splice this was a hidden
+  data-loss-on-undo; with the reconcile it ALSO churned every styled text
+  element (rebuilt shape never deep-equals the stored one). A reconcile is
+  only as lossless as the desired tree it diffs against — the rebuild must
+  reproduce the stored shape field-for-field, or unchanged elements look
+  changed. Caught by CodeRabbit; reproduced with a styled-text test
+  (data → `{ blocks: [] }`) before fixing the mapping to clone whole `data`.

--- a/docs/tasks/active/20260621-slides-undo-redo-churn-lessons.md
+++ b/docs/tasks/active/20260621-slides-undo-redo-churn-lessons.md
@@ -1,0 +1,39 @@
+# Slides undo/redo churn — lessons
+
+**Created**: 2026-06-21
+
+## Lessons
+
+(filled in as work progresses)
+
+- Reproduce first: `doc.getGarbageLen()` is a clean black-box proxy for
+  CRDT op churn — splice-replace of an array turns every removed node
+  into garbage, so the garbage delta after an undo measures exactly how
+  much the restore path churned. No server attach needed.
+
+- A local (unattached) Yorkie document never GCs, so `getGarbageLen()`
+  grows monotonically. Measure the delta around a single `undo()` to
+  isolate that one restore's churn from prior operations.
+
+- `read()` runs `migrateDocument`, which wraps legacy color strings into
+  `ThemeColor` objects. A snapshot is therefore in migrated shape; if the
+  live root stored the legacy shape, the first reconcile rewrites every
+  migrated field — a one-time migration cost that looks like churn. It
+  fooled the first churn run (1336 → 186) until the test seeded canonical
+  `ThemeColor` fills. Lesson: when diffing a snapshot against live CRDT
+  state, make sure both sides are in the same (post-migration) shape, or
+  you measure migration, not the thing you changed.
+
+- Reconcile, don't rebuild: keep CRDT node identity by reordering with
+  the array move primitives (`moveFront` / `moveAfter`) instead of splice
+  remove + re-insert. Moves relink nodes and emit no garbage; splice
+  tombstones the moved subtree.
+
+- The Yorkie JS object proxy supports the `delete` operator (verified
+  with a scratch test) — needed to drop optional fields (e.g.
+  `placeholderRef`) during in-place reconcile.
+
+- Stale workspace dist after a `main` pull: `pnpm slides typecheck`
+  compiles against `@wafflebase/docs/dist`, not its source. After pulling
+  `main` (new docs exports), run `pnpm --filter @wafflebase/docs build`
+  before `verify:fast`, or typecheck fails on unrelated missing exports.

--- a/docs/tasks/active/20260621-slides-undo-redo-churn-todo.md
+++ b/docs/tasks/active/20260621-slides-undo-redo-churn-todo.md
@@ -1,0 +1,93 @@
+# Slides undo/redo document churn — diff-based replaceRoot
+
+**Created**: 2026-06-21
+
+Design: `docs/design/slides/slides-collaboration.md` (reconcile note added)
+
+## Problem
+
+`YorkieSlidesStore.replaceRoot()` (the undo/redo restore path) rewrites
+the Yorkie root by splicing the *entire* `r.slides` and `r.layouts`
+arrays:
+
+```ts
+r.slides.splice(0, r.slides.length, ...(nextSlides as never[]));
+r.layouts.splice(0, r.layouts.length, ...(nextLayouts as never[]));
+```
+
+Each rebuilt slide is a fresh object holding freshly `clone()`d
+elements, so every undo/redo — even one reverting a single-element move
+— removes every slide (with all nested elements) and re-adds clones.
+The op churn is proportional to the whole document, not to what changed.
+
+Repeated undo/redo accumulated CRDT tombstones until one slides
+document reached 118MB. Server housekeeping (snapshot/compaction) loads
+the whole document into memory; with no pod memory limit it exhausted
+the 8GB EKS node and cascaded node OOMs.
+
+See incident: second-brain
+`00_log/incidents/2026/2026-06-20-yorkie-document-oom-node-cascade.md`.
+
+## Decisions (confirmed)
+
+- Fix at the source: make `replaceRoot()` reconcile by `id` so it only
+  touches elements/slides/layouts that actually changed.
+- Reproduce first: a black-box churn test using `doc.getGarbageLen()`
+  must go Red on current `main` before the fix, Green after.
+- Preserve CRDT identity for matched nodes (field-level in-place update,
+  Yorkie move primitives for reorder) instead of remove + re-add.
+- `meta` / `themes` / `masters` / `guides`: keep whole-value assignment
+  (no deep id-reconcile) but **only write when changed** (JSON compare
+  against the current root). A theme/master is a deep nested object;
+  reassigning it unconditionally would tombstone tens of nodes on every
+  undo, even an undo that never touched the theme. Guarding the write
+  makes a single-element-move undo near-zero churn.
+
+## Plan
+
+- [x] Red: add `yorkie-slides-undo-churn.test.ts`
+  - [x] Seed a doc (3 slides × 20 elements) via `ensureSlidesRoot` + update
+  - [x] Change one element frame in a batch, `undo()`, assert
+        `getGarbageLen()` delta is small (< 30) — failed on current code
+        (undo churned 1336 nodes, redo 1456)
+  - [x] Correctness: undo/redo restores `read()` exactly for
+        single-field change, reorder, add cases
+  - [x] Correctness: nested group child change recurses correctly
+  - [x] Mixed-content churn (text + group present) stays < 30
+- [x] Implement diff-based `replaceRoot()`
+  - [x] `reconcileArrayById(arr, desired, updateItem)` helper:
+        remove by id, append by id, reorder via move primitives, recurse
+  - [x] Slide reconcile: elements (recursive), background, notes, layoutId
+  - [x] Element reconcile: skip if deep-equal; else update changed
+        fields in place; remove stale fields (e.g. `placeholderRef`);
+        recurse group `data.children`
+  - [x] Layout reconcile by id
+  - [x] meta/themes/masters/guides: whole-value assignment guarded by a
+        structural compare (no write when unchanged)
+- [x] Green: churn test passes; all correctness assertions pass
+- [x] `pnpm verify:fast` green
+- [x] Self-review the branch diff
+- [ ] Open PR (English); capture lessons; archive task docs
+
+## Verification
+
+- Churn test Red on current code (undo 1336 / redo 1456 garbage nodes),
+  Green after fix (< 30 for undo / redo / mixed-content)
+- Correctness tests pass (move / reorder / add / group recursion)
+- `pnpm verify:fast` green (after `@wafflebase/docs build` to refresh the
+  stale dist from the `main` pull — unrelated to this change)
+
+## Results
+
+- Root cause: `replaceRoot` spliced the whole `slides` / `layouts`
+  arrays, so every undo/redo tombstoned the entire document. One element
+  moved + undone churned 1336 CRDT nodes on a 3×20 deck.
+- Fix: `replaceRoot` now builds the desired tree from the snapshot (same
+  mapping) and reconciles the live root by id — remove/append/reorder
+  (move primitives) + recurse, skipping deep-equal subtrees. The same
+  single-element undo now churns a handful of nodes.
+- Discovery: a bare `'#abc'` string fill is wrapped to a `ThemeColor` by
+  `migrateDocument` on read, so the first undo migrates every element — a
+  one-time cost, not steady-state churn. The editor stores canonical
+  `ThemeColor` fills, so real decks don't hit it; the test seeds the
+  canonical shape to measure steady state.

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -771,19 +771,22 @@ export class YorkieSlidesStore implements SlidesStore {
         background: clone(s.background),
         elements: s.elements.map((e) => {
           if (e.type === 'text') {
-            const td = e.data as { blocks?: Block[]; autofit?: AutofitMode };
+            const td = e.data as { blocks?: Block[] };
             return {
               id: e.id,
               type: 'text',
               frame: { ...e.frame },
-              // Carry placeholderRef and autofit through snapshot restore
-              // (undo/redo); the prior bare `{ id, type, frame, blocks }`
-              // rebuild dropped both — stripping placeholder identity and
-              // the autofit mode deck-wide on every undo/redo.
+              // Carry placeholderRef through snapshot restore (undo/redo);
+              // the prior bare `{ id, type, frame, blocks }` rebuild dropped
+              // it, stripping placeholder identity on every undo/redo.
               ...(e.placeholderRef ? { placeholderRef: clone(e.placeholderRef) } : {}),
+              // Carry the WHOLE text `data` — blocks plus the Format-Options
+              // fields (fill / stroke / effects / alt / autofit). A narrow
+              // `{ blocks, autofit }` rebuild silently dropped fill/stroke/
+              // effects/alt on every undo/redo (and churned the element).
               data: {
+                ...clone(e.data),
                 blocks: clone(td.blocks ?? []),
-                ...(td.autofit ? { autofit: td.autofit } : {}),
               },
             } as YorkieElement;
           }

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -175,6 +175,214 @@ function unwrapElement(e: unknown): YorkieElement {
 }
 
 // ---------------------------------------------------------------------------
+// undo/redo reconcile — apply a snapshot to the live Yorkie root by diffing,
+// touching only what actually changed.
+//
+// The old `replaceRoot` rewrote the root with `slides.splice(0, len, ...)` /
+// `layouts.splice(0, len, ...)`, so every undo/redo removed and re-added the
+// entire document. Each cycle tombstoned thousands of CRDT nodes; repeated
+// undo/redo bloated one deck to 118MB and OOM-cascaded the EKS nodes during
+// server housekeeping (2026-06-20 incident). Reconciling by id keeps unchanged
+// nodes — and their CRDT identity — in place, so a single-element undo touches
+// a single element.
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural deep-equality, independent of object key order. Used to decide
+ * whether a field actually changed before writing it — writing an equal value
+ * would tombstone the old CRDT subtree for nothing.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (
+    typeof a !== 'object' ||
+    typeof b !== 'object' ||
+    a === null ||
+    b === null
+  ) {
+    return false;
+  }
+  const aArr = Array.isArray(a);
+  if (aArr !== Array.isArray(b)) return false;
+  if (aArr) {
+    const aa = a as unknown[];
+    const bb = b as unknown[];
+    if (aa.length !== bb.length) return false;
+    for (let i = 0; i < aa.length; i++) {
+      if (!deepEqual(aa[i], bb[i])) return false;
+    }
+    return true;
+  }
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const ak = Object.keys(ao);
+  if (ak.length !== Object.keys(bo).length) return false;
+  for (const k of ak) {
+    if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
+    if (!deepEqual(ao[k], bo[k])) return false;
+  }
+  return true;
+}
+
+/** A Yorkie id-keyed array proxy: indexable, spliceable, and movable. */
+type ReconcileArray = MovableArray & {
+  [index: number]: { id: string };
+  splice(start: number, deleteCount: number, ...items: unknown[]): unknown;
+};
+
+/**
+ * Reconcile a Yorkie id-keyed array proxy against a desired plain array,
+ * touching only what changed: remove ids absent from `desired`, insert new
+ * ids, reorder survivors with Yorkie move primitives (no remove/re-add, so no
+ * tombstones), then recurse into each survivor via `updateItem`.
+ */
+function reconcileArrayById<T extends { id: string }>(
+  arr: unknown,
+  desired: T[],
+  updateItem: (target: ProxyArray[number], desired: T) => void,
+): void {
+  const a = arr as ReconcileArray;
+  const list = arr as unknown as ProxyArray;
+  // 1. Remove items absent from `desired`.
+  const desiredIds = new Set(desired.map((d) => d.id));
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (!desiredIds.has(list[i].id)) a.splice(i, 1);
+  }
+  // 2. Append items new to the target (final position fixed in step 3).
+  const present = new Set<string>();
+  for (let i = 0; i < list.length; i++) present.add(list[i].id);
+  for (const d of desired) {
+    if (!present.has(d.id)) a.splice(list.length, 0, d);
+  }
+  // 3. Reorder to `desired` order, only when it differs. Moves relink nodes
+  //    in place and emit no garbage, unlike splice remove + re-insert.
+  let sameOrder = list.length === desired.length;
+  if (sameOrder) {
+    for (let i = 0; i < desired.length; i++) {
+      if (list[i].id !== desired[i].id) {
+        sameOrder = false;
+        break;
+      }
+    }
+  }
+  if (!sameOrder) {
+    const ticketById = new Map<string, TimeTicket>();
+    for (let i = 0; i < list.length; i++) {
+      ticketById.set(list[i].id, a.getElementByIndex(i).getID());
+    }
+    let prev: TimeTicket | null = null;
+    for (const d of desired) {
+      const t = ticketById.get(d.id)!;
+      if (prev === null) a.moveFront(t);
+      else a.moveAfter(prev, t);
+      prev = t;
+    }
+  }
+  // 4. Update survivors, now index-aligned with `desired`.
+  for (let i = 0; i < desired.length; i++) {
+    updateItem(list[i], desired[i]);
+  }
+}
+
+/**
+ * Reconcile the plain fields of a Yorkie object proxy: delete keys absent from
+ * `desired`, assign keys whose value differs. `skip` names keys the caller
+ * handles separately (e.g. a nested array reconciled by id).
+ */
+function reconcileObjectFields(
+  target: Record<string, unknown>,
+  desired: Record<string, unknown>,
+  skip?: Set<string>,
+): void {
+  const plain = yorkieToPlain<Record<string, unknown>>(target);
+  for (const k of Object.keys(plain)) {
+    if (skip?.has(k)) continue;
+    if (!(k in desired)) delete target[k];
+  }
+  for (const k of Object.keys(desired)) {
+    if (skip?.has(k)) continue;
+    if (!deepEqual(plain[k], desired[k])) target[k] = clone(desired[k]);
+  }
+}
+
+/** Reconcile a group element's `data` — recurse children by id, then the
+ *  remaining plain fields (`refSize`). */
+function updateGroupData(
+  target: { children: unknown; [k: string]: unknown },
+  desired: YorkieGroupElement['data'],
+): void {
+  reconcileArrayById(
+    target.children,
+    desired.children as unknown as { id: string }[],
+    updateElement as (target: ProxyArray[number], d: { id: string }) => void,
+  );
+  reconcileObjectFields(
+    target as Record<string, unknown>,
+    desired as unknown as Record<string, unknown>,
+    new Set(['children']),
+  );
+}
+
+/**
+ * Reconcile one element. Unchanged elements return immediately (the common
+ * case — this is what keeps undo/redo cheap). Groups recurse so editing one
+ * child never churns its siblings; leaf elements swap only their changed
+ * top-level fields.
+ */
+function updateElement(target: ProxyArray[number], desired: YorkieElement): void {
+  const plain = unwrapElement(target);
+  if (deepEqual(plain, desired)) return;
+  if (desired.type === 'group' && plain.type === 'group') {
+    if (!deepEqual((plain as YorkieGroupElement).frame, desired.frame)) {
+      (target as Record<string, unknown>).frame = clone(desired.frame);
+    }
+    updateGroupData(
+      (target as { data: { children: unknown; [k: string]: unknown } }).data,
+      desired.data,
+    );
+    return;
+  }
+  reconcileObjectFields(
+    target as Record<string, unknown>,
+    desired as unknown as Record<string, unknown>,
+    new Set(['id']),
+  );
+}
+
+/** Reconcile one slide — scalar/background/notes fields, then elements by id. */
+function updateSlide(target: ProxyArray[number], desired: YorkieSlide): void {
+  const t = target as unknown as {
+    layoutId: string;
+    background: unknown;
+    notes: unknown;
+    elements: unknown;
+  };
+  if (t.layoutId !== desired.layoutId) t.layoutId = desired.layoutId;
+  if (!deepEqual(yorkieToPlain(t.background), desired.background)) {
+    t.background = clone(desired.background);
+  }
+  if (!deepEqual(yorkieToPlain(t.notes), desired.notes)) {
+    t.notes = clone(desired.notes);
+  }
+  reconcileArrayById(
+    t.elements,
+    desired.elements as unknown as { id: string }[],
+    updateElement as (target: ProxyArray[number], d: { id: string }) => void,
+  );
+}
+
+/** Reconcile one layout. Layouts rarely change on undo/redo, and their
+ *  placeholders have no ids, so changed layouts swap fields wholesale. */
+function updateLayout(target: ProxyArray[number], desired: YorkieLayout): void {
+  if (deepEqual(yorkieToPlain(target), desired)) return;
+  reconcileObjectFields(
+    target as Record<string, unknown>,
+    desired as unknown as Record<string, unknown>,
+    new Set(['id']),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // ensureSlidesRoot — initialise the Yorkie root with the slides shape. Safe
 // to call on every mount.
 //
@@ -552,23 +760,11 @@ export class YorkieSlidesStore implements SlidesStore {
 
   private replaceRoot(snapshot: SlidesDocument): void {
     this.doc.update((r) => {
-      r.meta = clone(snapshot.meta);
-      // Themes/masters are part of the snapshot too — undo of an op that
-      // touches them needs them mirrored here. Until Task 5 ships the
-      // theme-edit ops these arrays don't change, but writing them keeps
-      // the Yorkie root consistent with the cloned snapshot.
-      //
-      // Guides also live on the snapshot — without rewriting them here,
-      // undo / redo of addGuide / moveGuide / removeGuide silently
-      // diverges from the editor's pre-batch state.
-      const rootAny = r as {
-        themes?: Theme[];
-        masters?: Master[];
-        guides?: Array<{ id: string; axis: 'x' | 'y'; position: number }>;
-      };
-      rootAny.themes = clone(snapshot.themes);
-      rootAny.masters = clone(snapshot.masters);
-      rootAny.guides = clone(snapshot.guides ?? []);
+      // Build the desired Yorkie-shaped tree from the snapshot (same mapping
+      // as before), then reconcile the live root against it by id so only
+      // changed nodes are written. The old code spliced the whole slides /
+      // layouts arrays, tombstoning every node on every undo/redo. See the
+      // reconcile helpers above and the 2026-06-20 node-OOM incident.
       const nextSlides: YorkieSlide[] = snapshot.slides.map((s) => ({
         id: s.id,
         layoutId: s.layoutId,
@@ -595,9 +791,42 @@ export class YorkieSlidesStore implements SlidesStore {
         }),
         notes: clone(s.notes ?? []),
       }));
-      r.slides.splice(0, r.slides.length, ...(nextSlides as never[]));
       const nextLayouts = clone(snapshot.layouts) as YorkieLayout[];
-      r.layouts.splice(0, r.layouts.length, ...(nextLayouts as never[]));
+
+      // meta / themes / masters / guides: small, bounded, and reconciling
+      // them deeply isn't worth it — but each is a nested object, so writing
+      // unconditionally would tombstone tens of nodes on every undo even when
+      // they never changed. Guard each write on a structural compare.
+      const rootAny = r as {
+        themes?: Theme[];
+        masters?: Master[];
+        guides?: Array<{ id: string; axis: 'x' | 'y'; position: number }>;
+      };
+      const nextMeta = clone(snapshot.meta);
+      const nextThemes = clone(snapshot.themes);
+      const nextMasters = clone(snapshot.masters);
+      const nextGuides = clone(snapshot.guides ?? []);
+      if (!deepEqual(yorkieToPlain(r.meta), nextMeta)) r.meta = nextMeta;
+      if (!deepEqual(yorkieToPlain(rootAny.themes), nextThemes)) {
+        rootAny.themes = nextThemes;
+      }
+      if (!deepEqual(yorkieToPlain(rootAny.masters), nextMasters)) {
+        rootAny.masters = nextMasters;
+      }
+      if (!deepEqual(yorkieToPlain(rootAny.guides), nextGuides)) {
+        rootAny.guides = nextGuides;
+      }
+
+      reconcileArrayById(
+        r.slides,
+        nextSlides as unknown as { id: string }[],
+        updateSlide as (target: ProxyArray[number], d: { id: string }) => void,
+      );
+      reconcileArrayById(
+        r.layouts,
+        nextLayouts as unknown as { id: string }[],
+        updateLayout as (target: ProxyArray[number], d: { id: string }) => void,
+      );
     });
   }
 

--- a/packages/frontend/tests/app/slides/yorkie-slides-undo-churn.test.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-undo-churn.test.ts
@@ -142,6 +142,53 @@ describe('YorkieSlidesStore — undo/redo churn', () => {
 
     expect(churn).toBeLessThan(30);
   });
+
+  // A styled text box carries fill / stroke / effects / alt in `data`
+  // (set via the Format Options panel → updateElementData). The snapshot
+  // rebuild must carry those through, or an undo of an UNRELATED edit both
+  // loses the styling and churns the text element.
+  it('preserves styled text data and does not churn it on undo', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    let sid = '';
+    let shapeId = '';
+    let textId = '';
+    store.batch(() => {
+      sid = store.addSlide('blank');
+      textId = store.addElement(sid, {
+        type: 'text',
+        frame: { x: 0, y: 0, w: 100, h: 40, rotation: 0 },
+        data: { blocks: [] },
+      });
+      shapeId = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 5, y: 5, w: 10, h: 10, rotation: 0 },
+        data: { kind: 'rect', fill: { kind: 'srgb', value: '#abc' } },
+      });
+    });
+    store.batch(() =>
+      store.updateElementData(sid, textId, {
+        fill: { kind: 'srgb', value: '#f00' },
+        alt: 'hello',
+      }),
+    );
+
+    // Move the shape (not the text), then undo. The untouched text must
+    // keep its fill / alt and must not churn.
+    store.batch(() => store.updateElementFrame(sid, shapeId, { x: 99 }));
+    const before = doc.getGarbageLen();
+    store.undo();
+    const churn = doc.getGarbageLen() - before;
+
+    const text = store
+      .read()
+      .slides[0].elements.find((e) => e.id === textId);
+    expect(text?.data).toMatchObject({
+      fill: { kind: 'srgb', value: '#f00' },
+      alt: 'hello',
+    });
+    expect(churn).toBeLessThan(30);
+  });
 });
 
 describe('YorkieSlidesStore — undo/redo correctness (reconcile)', () => {
@@ -190,7 +237,7 @@ describe('YorkieSlidesStore — undo/redo correctness (reconcile)', () => {
       added = store.addElement(slideIds[0], {
         type: 'shape',
         frame: { x: 1, y: 1, w: 10, h: 10, rotation: 0 },
-        data: { kind: 'rect', fill: '#def' },
+        data: { kind: 'rect', fill: { kind: 'srgb', value: '#def' } },
       });
     });
     expect(store.read().slides[0].elements.map((e) => e.id)).toContain(added);
@@ -215,12 +262,12 @@ describe('YorkieSlidesStore — undo/redo correctness (reconcile)', () => {
       a = store.addElement(sid, {
         type: 'shape',
         frame: { x: 0, y: 0, w: 10, h: 10, rotation: 0 },
-        data: { kind: 'rect', fill: '#abc' },
+        data: { kind: 'rect', fill: { kind: 'srgb', value: '#abc' } },
       });
       b = store.addElement(sid, {
         type: 'shape',
         frame: { x: 20, y: 20, w: 10, h: 10, rotation: 0 },
-        data: { kind: 'rect', fill: '#abc' },
+        data: { kind: 'rect', fill: { kind: 'srgb', value: '#abc' } },
       });
     });
     store.batch(() => {

--- a/packages/frontend/tests/app/slides/yorkie-slides-undo-churn.test.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-undo-churn.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import yorkie from '@yorkie-js/sdk';
+import type { Document } from '@yorkie-js/sdk';
+import type { YorkieSlidesRoot } from '../../../src/types/slides-document.ts';
+import {
+  YorkieSlidesStore,
+  ensureSlidesRoot,
+} from '../../../src/app/slides/yorkie-slides-store.ts';
+
+function makeDoc(): Document<YorkieSlidesRoot> {
+  const doc = new yorkie.Document<YorkieSlidesRoot>(
+    `test-${Date.now()}-${Math.random()}`,
+  );
+  ensureSlidesRoot(doc);
+  return doc;
+}
+
+/**
+ * Seed `slides` slides, each with `perSlide` shape elements, in a single
+ * batch. Returns the created slide ids and a parallel array of element
+ * ids per slide.
+ */
+function seedDeck(
+  store: YorkieSlidesStore,
+  slides: number,
+  perSlide: number,
+): { slideIds: string[]; elementIds: string[][] } {
+  const slideIds: string[] = [];
+  const elementIds: string[][] = [];
+  store.batch(() => {
+    for (let s = 0; s < slides; s++) {
+      const sid = store.addSlide('blank');
+      slideIds.push(sid);
+      const els: string[] = [];
+      for (let e = 0; e < perSlide; e++) {
+        els.push(
+          store.addElement(sid, {
+            type: 'shape',
+            frame: { x: e, y: e, w: 100, h: 50, rotation: 0 },
+            // Canonical ThemeColor fill (what the editor stores). A bare
+            // '#abc' string would be wrapped by `migrateDocument` on read,
+            // so the first undo would migrate every element — a one-time
+            // cost that masks the steady-state reconcile churn we measure.
+            data: { kind: 'rect', fill: { kind: 'srgb', value: '#abc' } },
+          }),
+        );
+      }
+      elementIds.push(els);
+    }
+  });
+  return { slideIds, elementIds };
+}
+
+describe('YorkieSlidesStore — undo/redo churn', () => {
+  // Regression guard for the 2026-06-20 node-OOM incident: `replaceRoot`
+  // used to splice the whole `slides` / `layouts` arrays, so every undo
+  // / redo tombstoned the entire document. Repeated undo/redo bloated one
+  // deck to 118MB and OOM-cascaded the EKS nodes during housekeeping.
+  //
+  // `getGarbageLen()` counts CRDT nodes pending GC. A local (unattached)
+  // document never GCs, so the delta across a single `undo()` measures
+  // exactly how much that restore churned. Reverting one element's frame
+  // must touch ~that one element — not all 60 elements + 3 slides + the
+  // layout/theme/master trees.
+  it('undo of a single-element move does not churn the whole document', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    const { slideIds, elementIds } = seedDeck(store, 3, 20);
+
+    store.batch(() =>
+      store.updateElementFrame(slideIds[1], elementIds[1][10], { x: 999 }),
+    );
+
+    const before = doc.getGarbageLen();
+    store.undo();
+    const churn = doc.getGarbageLen() - before;
+
+    expect(churn).toBeLessThan(30);
+  });
+
+  it('redo of a single-element move does not churn the whole document', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    const { slideIds, elementIds } = seedDeck(store, 3, 20);
+
+    store.batch(() =>
+      store.updateElementFrame(slideIds[1], elementIds[1][10], { x: 999 }),
+    );
+    store.undo();
+
+    const before = doc.getGarbageLen();
+    store.redo();
+    const churn = doc.getGarbageLen() - before;
+
+    expect(churn).toBeLessThan(30);
+  });
+
+  // The incident deck was a real presentation — text boxes and groups, not
+  // just shapes. Prove unchanged text / group elements round-trip through
+  // the snapshot rebuild without churning: only the one moved shape should
+  // tombstone anything.
+  it('does not churn unchanged text / group elements on undo', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    let sid = '';
+    const shapeIds: string[] = [];
+    let ga = '';
+    let gb = '';
+    store.batch(() => {
+      sid = store.addSlide('blank');
+      for (let i = 0; i < 10; i++) {
+        shapeIds.push(
+          store.addElement(sid, {
+            type: 'shape',
+            frame: { x: i, y: i, w: 10, h: 10, rotation: 0 },
+            data: { kind: 'rect', fill: { kind: 'srgb', value: '#abc' } },
+          }),
+        );
+      }
+      store.addElement(sid, {
+        type: 'text',
+        frame: { x: 0, y: 0, w: 100, h: 40, rotation: 0 },
+        data: { blocks: [] },
+      });
+      ga = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 1, y: 1, w: 5, h: 5, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+      gb = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 8, y: 8, w: 5, h: 5, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+    });
+    store.batch(() => store.group(sid, [ga, gb]));
+
+    store.batch(() => store.updateElementFrame(sid, shapeIds[0], { x: 500 }));
+    const before = doc.getGarbageLen();
+    store.undo();
+    const churn = doc.getGarbageLen() - before;
+
+    expect(churn).toBeLessThan(30);
+  });
+});
+
+describe('YorkieSlidesStore — undo/redo correctness (reconcile)', () => {
+  it('restores exact content for a single-element move', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    const { slideIds, elementIds } = seedDeck(store, 2, 5);
+    const original = store.read();
+
+    store.batch(() =>
+      store.updateElementFrame(slideIds[0], elementIds[0][2], { x: 777 }),
+    );
+    expect(store.read().slides[0].elements[2].frame.x).toBe(777);
+
+    store.undo();
+    expect(store.read()).toEqual(original);
+
+    store.redo();
+    expect(store.read().slides[0].elements[2].frame.x).toBe(777);
+  });
+
+  it('restores element order after a reorder', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    const { slideIds } = seedDeck(store, 1, 4);
+    const before = store.read().slides[0].elements.map((e) => e.id);
+
+    store.batch(() => store.reorderElement(slideIds[0], before[0], 3));
+    const reordered = store.read().slides[0].elements.map((e) => e.id);
+    expect(reordered).not.toEqual(before);
+
+    store.undo();
+    expect(store.read().slides[0].elements.map((e) => e.id)).toEqual(before);
+
+    store.redo();
+    expect(store.read().slides[0].elements.map((e) => e.id)).toEqual(reordered);
+  });
+
+  it('restores an added element (undo removes, redo re-adds)', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    const { slideIds } = seedDeck(store, 1, 2);
+
+    let added = '';
+    store.batch(() => {
+      added = store.addElement(slideIds[0], {
+        type: 'shape',
+        frame: { x: 1, y: 1, w: 10, h: 10, rotation: 0 },
+        data: { kind: 'rect', fill: '#def' },
+      });
+    });
+    expect(store.read().slides[0].elements.map((e) => e.id)).toContain(added);
+
+    store.undo();
+    expect(store.read().slides[0].elements.map((e) => e.id)).not.toContain(
+      added,
+    );
+
+    store.redo();
+    expect(store.read().slides[0].elements.map((e) => e.id)).toContain(added);
+  });
+
+  it('restores a nested group child frame change', () => {
+    const doc = makeDoc();
+    const store = new YorkieSlidesStore(doc);
+    let sid = '';
+    let a = '';
+    let b = '';
+    store.batch(() => {
+      sid = store.addSlide('blank');
+      a = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 0, y: 0, w: 10, h: 10, rotation: 0 },
+        data: { kind: 'rect', fill: '#abc' },
+      });
+      b = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 20, y: 20, w: 10, h: 10, rotation: 0 },
+        data: { kind: 'rect', fill: '#abc' },
+      });
+    });
+    store.batch(() => {
+      store.group(sid, [a, b]);
+    });
+    const original = store.read();
+
+    store.batch(() => store.updateElementFrame(sid, a, { x: 5 }));
+    expect(store.read()).not.toEqual(original);
+
+    store.undo();
+    expect(store.read()).toEqual(original);
+  });
+});


### PR DESCRIPTION
## Summary

`YorkieSlidesStore.replaceRoot()` (the undo/redo restore path) rewrote the
Yorkie root by splicing the **whole** `slides` and `layouts` arrays:

```ts
r.slides.splice(0, r.slides.length, ...rebuilt);
r.layouts.splice(0, r.layouts.length, ...rebuilt);
```

Every rebuilt slide held freshly `clone()`d elements, so every undo/redo —
even one reverting a single-element move — removed and re-added the entire
document. The churn was proportional to the whole deck, not to what changed.

Repeated undo/redo accumulated CRDT tombstones until one deck reached 118MB.
Server housekeeping loads the whole document into memory; with no pod memory
limit it exhausted the 8GB EKS node and cascaded node OOMs (2026-06-20).

This change keeps the existing snapshot→Yorkie-shape mapping, then reconciles
the live root against it **by id** so only changed nodes are written:

- remove ids absent from the snapshot, append new ids;
- reorder survivors with the Yorkie array **move primitives** (relink, no
  tombstones) instead of splice remove + re-insert;
- recurse into matched slides/elements/group children, skipping deep-equal
  subtrees; leaf elements swap only their changed fields;
- `meta` / `themes` / `masters` / `guides` keep whole-value assignment but
  guarded by a structural compare, so an unchanged theme isn't re-tombstoned.

A single-element-move undo now churns a handful of CRDT nodes instead of 1336.

## Test plan

New `tests/app/slides/yorkie-slides-undo-churn.test.ts` uses
`doc.getGarbageLen()` as a black-box churn probe (a local doc never GCs, so
the delta around one `undo()` is exactly that restore's churn):

- **Churn (was Red, now Green):** single-element move + undo/redo on a 3×20
  deck — `1336`/`1456` garbage nodes before, `< 30` after.
- **Mixed content:** text + group present, churn still `< 30`.
- **Correctness:** undo/redo restores `read()` exactly for a move, a reorder,
  an add, and a nested group-child change.

`pnpm verify:fast` green (frontend lint + all package typecheck/test). Note:
`pnpm --filter @wafflebase/docs build` was needed first to refresh a stale
`dist` from a `main` pull — unrelated to this change.

Incident: `second-brain` `00_log/incidents/2026/2026-06-20-yorkie-document-oom-node-cascade.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Yorkie-backed slides undo/redo by reconciling the root by element id (instead of wholesale replacement), preserving CRDT identity during reorders and updating only changed nodes.
  * Reduced CRDT churn and memory growth during undo/redo, including correct restoration of text element data and stable handling of optional fields.

* **Tests**
  * Added regression and correctness tests verifying low churn and accurate undo/redo behavior, including nested groups and reorder/add/remove cases.

* **Documentation**
  * Added a new guide describing how to diagnose undo/redo churn and reconcile CRDT state safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up

This PR fixes the churn at the snapshot layer. The more fundamental fix is
to move slides undo/redo to Yorkie-native `doc.history` — as Docs and
Sheets already do — which is churn-free by construction (it applies only
the reverse ops of the last change). Slides is the only store still on
snapshot-based undo.

Tracked in `docs/tasks/active/20260621-slides-native-undo-migration-todo.md`
(added in this PR). The central prerequisite is grouping a `batch()` into a
single Yorkie undo unit: today each mutator opens its own `doc.update`, so a
multi-edit batch is N undo units.
