### PR TITLE
Surface omitted Slides toolbar items on mobile

### DIFF
--- a/docs/tasks/active/20260621-slides-mobile-toolbar-parity-todo.md
+++ b/docs/tasks/active/20260621-slides-mobile-toolbar-parity-todo.md
@@ -1,0 +1,86 @@
+# Slides mobile toolbar parity — surface omitted menu items
+
+## Problem
+
+On the Slides mobile view several toolbar menu items present on desktop
+are missing. Investigation traced the root cause: `MobileSlidesLayout`
+(`slides-detail.tsx`) never ported the desktop panel system, and the
+mobile toolbar branch (`mobile-toolbar.tsx`) only receives
+`onToggleThemePanel` — and even that arrives `undefined` because the
+mobile layout does not pass it.
+
+### Confirmed gaps (desktop → mobile)
+
+| Item | Desktop location | Mobile status | Action |
+| --- | --- | --- | --- |
+| Theme panel | `RightGlobals` toggle + `ThemePanel` drawer | overflow item disabled (prop not wired) | wire |
+| Format options panel | `RightGlobals` toggle + `FormatPanel` drawer | absent | wire |
+| Motion panel | `RightGlobals` toggle + `MotionPanel` drawer | absent | wire |
+| Slide background color | `RightGlobals` ThemedColorPicker dropdown | overflow item "coming soon" (disabled) | implement |
+| Table insert | `InsertGroup` `TablePicker` | absent from Insert sheet | add |
+| Format Painter | left zone | absent | leave out (not meaningful on touch) |
+| Zoom control | left zone | absent | leave out (mobile fits to viewport) |
+
+## Approach
+
+Panels render as **bottom sheets** (`Sheet side="bottom"`), matching the
+existing mobile Insert/Format sheets. Each panel gains a
+`variant?: 'drawer' | 'sheet'` prop: `drawer` keeps the current docked
+`<aside>`; `sheet` drops the fixed width / left border / own header and
+returns scrollable content so the bottom `Sheet` owns the chrome (title +
+built-in close). Slide background stays toolbar-local (it only needs
+store + current slide + theme, all already passed to the mobile toolbar).
+
+## Tasks
+
+- [ ] `ThemePanel`: add `variant` prop; `sheet` mode returns content-only.
+- [ ] `FormatPanel`: add `variant` prop; `sheet` mode returns content-only.
+- [ ] `MotionPanel`: add `variant` prop; `sheet` mode returns content-only.
+- [ ] `TablePicker`: add optional `trigger` prop (mirror `ShapePicker`).
+- [ ] `mobile-toolbar.tsx`:
+  - [ ] Extend `MobileSlidesToolbarProps` with `onToggleFormatPanel`,
+        `onToggleMotionPanel` (Theme already present).
+  - [ ] `OverflowMenu`: enable Theme; add Format options + Motion; wire
+        Slide background via a toolbar-local `SlideBackgroundSheet`.
+  - [ ] Add `TablePicker` (custom trigger) to the Insert sheet grid.
+  - [ ] Thread new props through Idle/Object bars.
+- [ ] `toolbar/index.tsx`: forward `onToggleFormatPanel` /
+      `onToggleMotionPanel` to `MobileSlidesToolbar`.
+- [ ] `slides-detail.tsx` `MobileSlidesLayout`:
+  - [ ] Add `rightPanel` state ("theme" | "format" | "motion" | null).
+  - [ ] Pass the three toggle callbacks + open flags to `SlidesToolbar`.
+  - [ ] Render the three panels inside a bottom `Sheet`.
+- [x] `pnpm verify:fast` green.
+- [x] Self code-review over branch diff.
+
+## Review outcome (high-effort code-review)
+
+Applied:
+- **Correctness**: Format/Motion overflow items were gated only on
+  `!onToggle*` (always-defined closures) so they never disabled — tapping
+  before editor/store mounted opened an empty header-only sheet. Now gated
+  on `canPanels = store && editor` (and Theme on `store`).
+- **Reuse**: extracted `useSlideBackground(store, slideId, theme, onCommit)`
+  shared by desktop `RightGlobals` and the mobile `SlideBackgroundSheet` —
+  kills verbatim duplication of the store-write rules + the double
+  `store.read()`.
+- **Simplification**: mobile panel-sheet title/description now from a
+  `MOBILE_PANEL_META` table instead of stacked ternaries; corrected the
+  misleading "controlled DropdownMenu" comment.
+
+Deferred (known limitations):
+- `useSlidesShellState` extraction — Desktop/MobileSlidesLayout already
+  duplicate store/theme/present state pre-PR; the in-code TODO tracks it.
+  Out of scope here to avoid desktop regression risk.
+- Text-edit mobile bar has no overflow (Theme/Format/Motion/background
+  unreachable while editing text). Intentional: text editing is a focused
+  mode on the compact bar; exit to access design panels (matches the
+  existing mobile bar design).
+
+## Verification
+
+- `pnpm verify:fast` green (lint + unit, desktop global-controls included).
+- Manual smoke in `pnpm dev` at <768px: Theme/Format/Motion bottom sheets
+  open from overflow, Slide background applies, Table inserts. (pending)
+- Desktop toolbar unchanged — panels still dock as drawers, background
+  dropdown still works via the shared hook.

--- a/packages/frontend/src/app/slides/format-panel/index.tsx
+++ b/packages/frontend/src/app/slides/format-panel/index.tsx
@@ -24,6 +24,12 @@ export interface FormatPanelProps {
   store: SlidesStore;
   editor: SlidesEditor;
   onClose: () => void;
+  /**
+   * `drawer` (default) docks as a fixed-width column on desktop;
+   * `sheet` returns content-only for a mobile bottom `Sheet` that owns
+   * the chrome (title + built-in close).
+   */
+  variant?: 'drawer' | 'sheet';
 }
 
 function derivePanelSelection(
@@ -61,7 +67,12 @@ function derivePanelSelection(
   return { kind: 'object', selectionType, elements, slideId };
 }
 
-export function FormatPanel({ store, editor, onClose }: FormatPanelProps) {
+export function FormatPanel({
+  store,
+  editor,
+  onClose,
+  variant = 'drawer',
+}: FormatPanelProps) {
   const [tick, setTick] = useState(0);
   useEffect(() => {
     const u1 = store.onChange?.(() => setTick((t) => t + 1));
@@ -194,24 +205,9 @@ export function FormatPanel({ store, editor, onClose }: FormatPanelProps) {
     [store, selection],
   );
 
-  return (
-    <aside
-      aria-label="Format options"
-      className="flex w-72 shrink-0 flex-col border-l bg-background"
-    >
-      <header className="flex items-center justify-between border-b p-2">
-        <h2 className="text-sm font-semibold">Format options</h2>
-        <button
-          type="button"
-          aria-label="Close format options"
-          onClick={onClose}
-          className="rounded p-1 hover:bg-muted"
-        >
-          ×
-        </button>
-      </header>
-      <div className="flex-1 overflow-y-auto">
-        {selection.kind === 'idle' && (
+  const content = (
+    <>
+      {selection.kind === 'idle' && (
           <p className="p-4 text-xs text-muted-foreground">
             Select an object to edit its format.
           </p>
@@ -296,7 +292,30 @@ export function FormatPanel({ store, editor, onClose }: FormatPanelProps) {
                 );
             }
           })}
-      </div>
+    </>
+  );
+
+  if (variant === 'sheet') {
+    return <div className="min-h-0 flex-1 overflow-y-auto">{content}</div>;
+  }
+
+  return (
+    <aside
+      aria-label="Format options"
+      className="flex w-72 shrink-0 flex-col border-l bg-background"
+    >
+      <header className="flex items-center justify-between border-b p-2">
+        <h2 className="text-sm font-semibold">Format options</h2>
+        <button
+          type="button"
+          aria-label="Close format options"
+          onClick={onClose}
+          className="rounded p-1 hover:bg-muted"
+        >
+          ×
+        </button>
+      </header>
+      <div className="flex-1 overflow-y-auto">{content}</div>
     </aside>
   );
 }

--- a/packages/frontend/src/app/slides/motion-panel/index.tsx
+++ b/packages/frontend/src/app/slides/motion-panel/index.tsx
@@ -7,9 +7,20 @@ export interface MotionPanelProps {
   store: SlidesStore;
   editor: SlidesEditor;
   onClose: () => void;
+  /**
+   * `drawer` (default) docks as a fixed-width column on desktop;
+   * `sheet` returns content-only for a mobile bottom `Sheet` that owns
+   * the chrome (title + built-in close).
+   */
+  variant?: 'drawer' | 'sheet';
 }
 
-export function MotionPanel({ store, editor, onClose }: MotionPanelProps) {
+export function MotionPanel({
+  store,
+  editor,
+  onClose,
+  variant = 'drawer',
+}: MotionPanelProps) {
   const [tick, setTick] = useState(0);
   useEffect(() => {
     const u1 = store.onChange?.(() => setTick((t) => t + 1));
@@ -28,6 +39,30 @@ export function MotionPanel({ store, editor, onClose }: MotionPanelProps) {
   const slideId = editor.getCurrentSlideId();
   const selectedElementIds = editor.getSelection();
 
+  const content = (
+    <>
+      <section data-testid="motion-transition-section">
+        {slideId !== undefined && (
+          <TransitionSection store={store} slideId={slideId} />
+        )}
+      </section>
+      <section data-testid="motion-animation-section">
+        {slideId !== undefined && (
+          <AnimationSection
+            store={store}
+            slideId={slideId}
+            selectedElementIds={selectedElementIds}
+            editor={editor}
+          />
+        )}
+      </section>
+    </>
+  );
+
+  if (variant === 'sheet') {
+    return <div className="min-h-0 flex-1 overflow-y-auto">{content}</div>;
+  }
+
   return (
     <aside
       aria-label="Motion"
@@ -44,23 +79,7 @@ export function MotionPanel({ store, editor, onClose }: MotionPanelProps) {
           ×
         </button>
       </header>
-      <div className="flex-1 overflow-y-auto">
-        <section data-testid="motion-transition-section">
-          {slideId !== undefined && (
-            <TransitionSection store={store} slideId={slideId} />
-          )}
-        </section>
-        <section data-testid="motion-animation-section">
-          {slideId !== undefined && (
-            <AnimationSection
-              store={store}
-              slideId={slideId}
-              selectedElementIds={selectedElementIds}
-              editor={editor}
-            />
-          )}
-        </section>
-      </div>
+      <div className="flex-1 overflow-y-auto">{content}</div>
     </aside>
   );
 }

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -27,6 +27,13 @@ import { insertImageOnSlide } from "./insert-image";
 import { ThemePanel } from "./theme-panel";
 import { FormatPanel } from "./format-panel";
 import { MotionPanel } from "./motion-panel";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import type { YorkieSlidesStore } from "./yorkie-slides-store";
 import {
   createZoomController,
@@ -421,6 +428,22 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
   );
 }
 
+/** Titles + sr-only descriptions for the mobile design/format bottom sheets. */
+const MOBILE_PANEL_META = {
+  theme: {
+    title: "Theme",
+    description: "Pick a built-in theme for the deck.",
+  },
+  format: {
+    title: "Format options",
+    description: "Edit size, position, and effects for the selected object.",
+  },
+  motion: {
+    title: "Motion",
+    description: "Configure slide transitions and object animations.",
+  },
+} as const;
+
 /**
  * MobileSlidesLayout — same chrome as `DesktopSlidesLayout` (sidebar
  * drawer + SiteHeader + SlidesToolbar) but mounts `MobileSlidesView`
@@ -442,6 +465,12 @@ function MobileSlidesLayout({ documentId }: { documentId: string }) {
     "current" | "first" | null
   >(null);
   const [slideCount, setSlideCount] = useState(0);
+  // Which design/format panel is open as a bottom sheet. Mirrors the
+  // desktop `rightPanel` side-drawer state machine, but the panels render
+  // inside a `Sheet` instead of docking next to the canvas.
+  type RightPanel = "theme" | "format" | "motion" | null;
+  const [rightPanel, setRightPanel] = useState<RightPanel>(null);
+  const panelMeta = rightPanel ? MOBILE_PANEL_META[rightPanel] : null;
   // Mirror the active theme so the Format sheet's theme-bound pickers
   // (shape fill, text color, font family) get a non-null Theme to
   // resolve against. Without this they are gated behind a `!theme`
@@ -620,6 +649,18 @@ function MobileSlidesLayout({ documentId }: { documentId: string }) {
             theme={activeTheme}
             onImagePick={handleImagePick}
             upload={uploadFn}
+            onToggleThemePanel={() =>
+              setRightPanel((p) => (p === "theme" ? null : "theme"))
+            }
+            themePanelOpen={rightPanel === "theme"}
+            onToggleFormatPanel={() =>
+              setRightPanel((p) => (p === "format" ? null : "format"))
+            }
+            formatPanelOpen={rightPanel === "format"}
+            onToggleMotionPanel={() =>
+              setRightPanel((p) => (p === "motion" ? null : "motion"))
+            }
+            motionPanelOpen={rightPanel === "motion"}
           />
           <MobileSlidesView
             mode="edit"
@@ -627,6 +668,48 @@ function MobileSlidesLayout({ documentId }: { documentId: string }) {
             onEditorReady={setEditor}
           />
         </div>
+        <Sheet
+          open={rightPanel !== null}
+          onOpenChange={(o) => {
+            if (!o) setRightPanel(null);
+          }}
+        >
+          <SheetContent
+            side="bottom"
+            className="max-h-[80vh] gap-0 p-0 pb-[env(safe-area-inset-bottom,8px)]"
+          >
+            <SheetHeader className="border-b">
+              <SheetTitle>{panelMeta?.title}</SheetTitle>
+              <SheetDescription className="sr-only">
+                {panelMeta?.description}
+              </SheetDescription>
+            </SheetHeader>
+            {rightPanel === "theme" && store && (
+              <ThemePanel
+                variant="sheet"
+                store={store}
+                currentThemeId={currentThemeId}
+                onClose={() => setRightPanel(null)}
+              />
+            )}
+            {rightPanel === "format" && store && editor && (
+              <FormatPanel
+                variant="sheet"
+                store={store}
+                editor={editor}
+                onClose={() => setRightPanel(null)}
+              />
+            )}
+            {rightPanel === "motion" && store && editor && (
+              <MotionPanel
+                variant="sheet"
+                store={store}
+                editor={editor}
+                onClose={() => setRightPanel(null)}
+              />
+            )}
+          </SheetContent>
+        </Sheet>
       </SidebarInset>
       {presentingFrom &&
         store &&

--- a/packages/frontend/src/app/slides/table-picker.tsx
+++ b/packages/frontend/src/app/slides/table-picker.tsx
@@ -20,6 +20,16 @@ const CELL_GAP_PX = 2;
 interface TablePickerProps {
   editor: SlidesEditor | null;
   disabled?: boolean;
+  /**
+   * Optional custom trigger (mirrors `ShapePicker`/`LinePicker`). When
+   * provided it replaces the default 28px icon button — used by the
+   * mobile Insert sheet to render a full-width sheet-action button.
+   * Rendered `asChild`, so it must forward props/ref to a single DOM
+   * element.
+   */
+  trigger?: React.ReactNode;
+  /** Fired after a table is committed — lets a host sheet close. */
+  onInsert?: () => void;
 }
 
 /**
@@ -33,7 +43,12 @@ interface TablePickerProps {
  * tables can be built incrementally via the right-click "Insert
  * row / column" context menu after the initial insert.
  */
-export function TablePicker({ editor, disabled }: TablePickerProps) {
+export function TablePicker({
+  editor,
+  disabled,
+  trigger,
+  onInsert,
+}: TablePickerProps) {
   const [open, setOpen] = useState(false);
   // Hover position drives the highlight extent: cell (r, c) is
   // highlighted when r <= hoverRow && c <= hoverCol. -1 means "no
@@ -48,6 +63,7 @@ export function TablePicker({ editor, disabled }: TablePickerProps) {
     setOpen(false);
     setHoverRow(-1);
     setHoverCol(-1);
+    onInsert?.();
   };
 
   const rowsLabel = hoverRow + 1;
@@ -101,21 +117,25 @@ export function TablePicker({ editor, disabled }: TablePickerProps) {
         }
       }}
     >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              disabled={disabled || !editor}
-              aria-label="Insert table"
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
-            >
-              <IconTable size={16} />
-            </button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent>Insert table</TooltipContent>
-      </Tooltip>
+      {trigger ? (
+        <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                disabled={disabled || !editor}
+                aria-label="Insert table"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
+              >
+                <IconTable size={16} />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Insert table</TooltipContent>
+        </Tooltip>
+      )}
       <DropdownMenuContent
         align="start"
         className="flex flex-col gap-1 p-2"

--- a/packages/frontend/src/app/slides/theme-panel.tsx
+++ b/packages/frontend/src/app/slides/theme-panel.tsx
@@ -7,15 +7,46 @@ interface ThemePanelProps {
   store: SlidesStore;
   currentThemeId: string;
   onClose: () => void;
+  /**
+   * `drawer` (default) docks as a fixed-width `<aside>` column on the
+   * right of the desktop editor. `sheet` returns content-only — no
+   * width / border / own header — so a mobile bottom `Sheet` owns the
+   * chrome (title + built-in close).
+   */
+  variant?: "drawer" | "sheet";
 }
 
 /**
- * Right-docked side panel listing the five built-in themes. Clicking
- * a thumbnail batches `addTheme` + `applyTheme` so the change is one
- * undo step. Sized as a fixed-width column; the parent layout puts it
- * to the right of the slides editor.
+ * Side panel listing the built-in themes. Clicking a thumbnail batches
+ * `addTheme` + `applyTheme` so the change is one undo step. On desktop
+ * it docks as a fixed-width column (`variant="drawer"`); on mobile it
+ * renders inside a bottom sheet (`variant="sheet"`).
  */
-export function ThemePanel({ store, currentThemeId, onClose }: ThemePanelProps) {
+export function ThemePanel({
+  store,
+  currentThemeId,
+  onClose,
+  variant = "drawer",
+}: ThemePanelProps) {
+  const list = (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {BUILT_IN_THEMES.map((t) => (
+        <ThemeThumbnail
+          key={t.id}
+          theme={t}
+          selected={t.id === currentThemeId}
+          onClick={() => applyBuiltInTheme(store, t.id)}
+        />
+      ))}
+    </div>
+  );
+
+  if (variant === "sheet") {
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">{list}</div>
+    );
+  }
+
   return (
     <aside
       aria-label="Theme picker"
@@ -55,16 +86,7 @@ export function ThemePanel({ store, currentThemeId, onClose }: ThemePanelProps) 
           <IconX size={16} />
         </button>
       </header>
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {BUILT_IN_THEMES.map((t) => (
-          <ThemeThumbnail
-            key={t.id}
-            theme={t}
-            selected={t.id === currentThemeId}
-            onClick={() => applyBuiltInTheme(store, t.id)}
-          />
-        ))}
-      </div>
+      {list}
     </aside>
   );
 }

--- a/packages/frontend/src/app/slides/toolbar/global-controls.tsx
+++ b/packages/frontend/src/app/slides/toolbar/global-controls.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   IconAdjustmentsAlt,
   IconArrowBackUp,
@@ -7,13 +7,9 @@ import {
   IconPalette,
   IconSparkles,
 } from "@tabler/icons-react";
-import type {
-  SlidesEditor,
-  SlidesStore,
-  Theme,
-  ThemeColor,
-} from "@wafflebase/slides";
+import type { SlidesEditor, SlidesStore, Theme } from "@wafflebase/slides";
 import { resolveColor } from "@wafflebase/slides";
+import { useSlideBackground } from "../use-slide-background";
 import { Toggle } from "@/components/ui/toggle";
 import {
   DropdownMenu,
@@ -141,36 +137,23 @@ export function RightGlobals({
   // color swatches are plain <button>s, not DropdownMenuItem.
   const [backgroundOpen, setBackgroundOpen] = useState(false);
   const backgroundMenu = useMenuCloseHandlers(releaseFocusToBody);
-  const onBackgroundChange = useCallback(
-    (color: ThemeColor, opts?: { commit?: boolean; record?: boolean }) => {
-      if (!store || !slideId) return;
-      store.batch(() => {
-        store.updateSlideBackground(slideId, { fill: color });
-        if (opts?.record && color.kind === 'srgb') {
-          store.pushRecentColor(color.value);
-        }
-      });
-      // Only a discrete swatch pick closes the palette; live custom-input
-      // changes (and the custom blur, which records only) keep it open.
-      if (opts?.commit) {
-        backgroundMenu.markSwatchClicked();
-        setBackgroundOpen(false);
-      }
+  // Only a discrete swatch pick closes the palette; live custom-input
+  // changes (and the custom blur, which records only) keep it open.
+  const { backgroundFill, onChange: onBackgroundChange } = useSlideBackground(
+    store,
+    slideId,
+    theme ?? null,
+    () => {
+      backgroundMenu.markSwatchClicked();
+      setBackgroundOpen(false);
     },
-    [store, slideId, backgroundMenu],
   );
 
   const hasSlideStyleGroup = !!store;
 
-  // Read the current slide's background fill once: the raw ThemeColor drives
-  // the picker's "active" swatch marker, and its resolved CSS string drives
-  // the swatch button's stripe. Both fall back to undefined (empty outlined
-  // slot / no marker) when nothing is known yet.
-  const backgroundFill = useMemo(() => {
-    if (!store || !slideId || !theme) return undefined;
-    const slide = store.read().slides.find((s) => s.id === slideId);
-    return slide?.background?.fill;
-  }, [store, slideId, theme]);
+  // The raw ThemeColor drives the picker's "active" swatch marker, and its
+  // resolved CSS string drives the swatch button's stripe. Both fall back to
+  // undefined (empty outlined slot / no marker) when nothing is known yet.
   const currentBackground = backgroundFill
     ? resolveColor(backgroundFill, theme!)
     : undefined;

--- a/packages/frontend/src/app/slides/toolbar/index.tsx
+++ b/packages/frontend/src/app/slides/toolbar/index.tsx
@@ -89,6 +89,8 @@ export function SlidesToolbar({
         onImagePick={onImagePick}
         upload={upload}
         onToggleThemePanel={onToggleThemePanel}
+        onToggleFormatPanel={onToggleFormatPanel}
+        onToggleMotionPanel={onToggleMotionPanel}
       />
     );
   }

--- a/packages/frontend/src/app/slides/toolbar/mobile-toolbar.tsx
+++ b/packages/frontend/src/app/slides/toolbar/mobile-toolbar.tsx
@@ -17,7 +17,12 @@
  */
 
 import { useCallback, useState } from "react";
-import type { InsertKind, SlidesEditor, SlidesStore, Theme } from "@wafflebase/slides";
+import type {
+  InsertKind,
+  SlidesEditor,
+  SlidesStore,
+  Theme,
+} from "@wafflebase/slides";
 import { findElementPath } from "@wafflebase/slides";
 import {
   IconBold,
@@ -29,6 +34,7 @@ import {
   IconPhoto,
   IconPlus,
   IconShape,
+  IconTable,
   IconTrash,
   IconTypography,
   IconUnderline,
@@ -68,6 +74,9 @@ import { TextElementControls } from "./text-element-controls";
 import { ArrangeMenu } from "./arrange-menu";
 import { ShapePicker } from "../shape-picker";
 import { LinePicker } from "../line-picker";
+import { TablePicker } from "../table-picker";
+import { ThemedColorPicker } from "../themed-color-picker";
+import { useSlideBackground } from "../use-slide-background";
 
 export interface MobileSlidesToolbarProps {
   editor: SlidesEditor | null;
@@ -77,6 +86,8 @@ export interface MobileSlidesToolbarProps {
   onImagePick: () => void;
   upload?: (file: File) => Promise<{ url: string; w: number; h: number }>;
   onToggleThemePanel?: () => void;
+  onToggleFormatPanel?: () => void;
+  onToggleMotionPanel?: () => void;
 }
 
 export function MobileSlidesToolbar(props: MobileSlidesToolbarProps) {
@@ -92,8 +103,11 @@ export function MobileSlidesToolbar(props: MobileSlidesToolbarProps) {
 function IdleMobileBar({
   editor,
   store,
+  theme,
   onImagePick,
   onToggleThemePanel,
+  onToggleFormatPanel,
+  onToggleMotionPanel,
 }: MobileSlidesToolbarProps) {
   return (
     <Toolbar className="flex h-10 items-center gap-1 border-b px-2">
@@ -101,7 +115,14 @@ function IdleMobileBar({
       <ToolbarSeparator className="mx-1" />
       <InsertSheet editor={editor} onImagePick={onImagePick} />
       <div className="flex-1" />
-      <OverflowMenu onToggleThemePanel={onToggleThemePanel} />
+      <OverflowMenu
+        editor={editor}
+        store={store}
+        theme={theme}
+        onToggleThemePanel={onToggleThemePanel}
+        onToggleFormatPanel={onToggleFormatPanel}
+        onToggleMotionPanel={onToggleMotionPanel}
+      />
     </Toolbar>
   );
 }
@@ -118,6 +139,8 @@ function ObjectMobileBar({
   onImagePick,
   upload,
   onToggleThemePanel,
+  onToggleFormatPanel,
+  onToggleMotionPanel,
 }: MobileSlidesToolbarProps & {
   state: Extract<ToolbarState, { kind: "object" }>;
 }) {
@@ -166,7 +189,14 @@ function ObjectMobileBar({
       >
         <IconTrash size={16} />
       </button>
-      <OverflowMenu onToggleThemePanel={onToggleThemePanel} />
+      <OverflowMenu
+        editor={editor}
+        store={store}
+        theme={theme}
+        onToggleThemePanel={onToggleThemePanel}
+        onToggleFormatPanel={onToggleFormatPanel}
+        onToggleMotionPanel={onToggleMotionPanel}
+      />
     </Toolbar>
   );
 }
@@ -330,6 +360,22 @@ function InsertSheet({
               >
                 <IconLine size={20} />
                 Line
+              </button>
+            }
+          />
+          <TablePicker
+            editor={editor}
+            disabled={!editor}
+            onInsert={() => setOpen(false)}
+            trigger={
+              <button
+                type="button"
+                aria-label="Table"
+                disabled={!editor}
+                className={SHEET_ACTION_BUTTON_CLASS}
+              >
+                <IconTable size={20} />
+                Table
               </button>
             }
           />
@@ -515,34 +561,135 @@ function TextFormatSheet({
 // ---------------------------------------------------------------------------
 
 function OverflowMenu({
+  editor,
+  store,
+  theme,
   onToggleThemePanel,
+  onToggleFormatPanel,
+  onToggleMotionPanel,
 }: {
+  editor: SlidesEditor | null;
+  store: SlidesStore | null;
+  theme?: Theme | null;
   onToggleThemePanel?: () => void;
+  onToggleFormatPanel?: () => void;
+  onToggleMotionPanel?: () => void;
 }) {
+  // Only `backgroundOpen` is controlled — the DropdownMenu itself is
+  // uncontrolled and auto-closes on select. The background sheet lives
+  // outside the menu so it survives the dropdown unmount.
+  const [backgroundOpen, setBackgroundOpen] = useState(false);
+  const slideId = editor?.getCurrentSlideId();
+  const canBackground = !!store && !!slideId && !!theme;
+  // Theme reads the deck (store); Format/Motion panels need a live editor
+  // selection context. Gate the items on real readiness so a tap before
+  // the editor/store mounts can't open an empty header-only sheet — the
+  // `onToggle*` props are always-defined closures and never gate alone.
+  const canTheme = !!onToggleThemePanel && !!store;
+  const canPanels = !!store && !!editor;
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          aria-label="More slide options"
-          className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-sm hover:bg-muted"
-        >
-          <IconDotsVertical size={16} />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuLabel>Design</DropdownMenuLabel>
-        <DropdownMenuItem
-          onClick={() => onToggleThemePanel?.()}
-          disabled={!onToggleThemePanel}
-        >
-          Theme…
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled>
-          Slide background… (coming soon)
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="More slide options"
+            className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-sm hover:bg-muted"
+          >
+            <IconDotsVertical size={16} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel>Design</DropdownMenuLabel>
+          <DropdownMenuItem
+            onClick={() => onToggleThemePanel?.()}
+            disabled={!canTheme}
+          >
+            Theme…
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => setBackgroundOpen(true)}
+            disabled={!canBackground}
+          >
+            Slide background…
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => onToggleFormatPanel?.()}
+            disabled={!onToggleFormatPanel || !canPanels}
+          >
+            Format options…
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => onToggleMotionPanel?.()}
+            disabled={!onToggleMotionPanel || !canPanels}
+          >
+            Motion…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {canBackground && (
+        <SlideBackgroundSheet
+          open={backgroundOpen}
+          onOpenChange={setBackgroundOpen}
+          store={store!}
+          theme={theme!}
+          slideId={slideId!}
+        />
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Slide background sheet (toolbar-local)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mobile bottom-sheet wrapper around `ThemedColorPicker`, mirroring the
+ * desktop `RightGlobals` slide-background dropdown. Writes through
+ * `store.updateSlideBackground` for the current slide; a discrete
+ * swatch pick closes the sheet, live custom-input changes keep it open.
+ */
+function SlideBackgroundSheet({
+  open,
+  onOpenChange,
+  store,
+  theme,
+  slideId,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  store: SlidesStore;
+  theme: Theme;
+  slideId: string;
+}) {
+  const { backgroundFill, onChange } = useSlideBackground(
+    store,
+    slideId,
+    theme,
+    () => onOpenChange(false),
+  );
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="bottom" className="pb-[env(safe-area-inset-bottom,8px)]">
+        <SheetHeader>
+          <SheetTitle>Slide background</SheetTitle>
+          <SheetDescription className="sr-only">
+            Pick a fill color for the current slide background.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="px-4 pb-4">
+          <ThemedColorPicker
+            value={backgroundFill}
+            theme={theme}
+            onChange={onChange}
+            recentColors={store.read().meta.recentColors}
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 }
 

--- a/packages/frontend/src/app/slides/use-slide-background.ts
+++ b/packages/frontend/src/app/slides/use-slide-background.ts
@@ -1,0 +1,46 @@
+import { useCallback, useMemo } from "react";
+import type { SlidesStore, Theme, ThemeColor } from "@wafflebase/slides";
+
+/**
+ * Shared slide-background read + write semantics for the current slide.
+ *
+ * Both the desktop `RightGlobals` dropdown and the mobile
+ * `SlideBackgroundSheet` consume this so the store-write rules
+ * (batched `updateSlideBackground` + `pushRecentColor` on a recorded
+ * sRGB pick) live in exactly one place. `onCommit` fires only for a
+ * discrete swatch pick (`opts.commit`) so the caller can close its
+ * popover/sheet; live custom-input changes keep it open.
+ */
+export function useSlideBackground(
+  store: SlidesStore | null,
+  slideId: string | undefined,
+  theme: Theme | null,
+  onCommit?: () => void,
+): {
+  backgroundFill: ThemeColor | undefined;
+  onChange: (
+    color: ThemeColor,
+    opts?: { commit?: boolean; record?: boolean },
+  ) => void;
+} {
+  const backgroundFill = useMemo(() => {
+    if (!store || !slideId || !theme) return undefined;
+    return store.read().slides.find((s) => s.id === slideId)?.background?.fill;
+  }, [store, slideId, theme]);
+
+  const onChange = useCallback(
+    (color: ThemeColor, opts?: { commit?: boolean; record?: boolean }) => {
+      if (!store || !slideId) return;
+      store.batch(() => {
+        store.updateSlideBackground(slideId, { fill: color });
+        if (opts?.record && color.kind === "srgb") {
+          store.pushRecentColor(color.value);
+        }
+      });
+      if (opts?.commit) onCommit?.();
+    },
+    [store, slideId, onCommit],
+  );
+
+  return { backgroundFill, onChange };
+}


### PR DESCRIPTION
## Summary

On the Slides mobile view several desktop toolbar items were missing.
Root cause: `MobileSlidesLayout` never ported the desktop panel system,
so **Theme / Format options / Motion** were unreachable on phones (the
Theme overflow item was even disabled because its toggle was never
threaded through), **Slide background** was a "coming soon" stub, and
**Table insert** was absent from the Insert sheet.

This PR brings the mobile toolbar to parity with the desktop design
surface:

- **Theme / Format / Motion panels** now open as **bottom sheets** on
  mobile. Each panel gains a `variant: 'drawer' | 'sheet'` prop — `sheet`
  returns content-only so the `Sheet` owns the chrome (title + built-in
  close); desktop keeps docking as fixed-width drawers (`drawer`,
  default).
- **Slide background** is a working toolbar-local bottom sheet wrapping
  `ThemedColorPicker`.
- **Table insert** is surfaced in the mobile Insert sheet via a new
  optional custom `trigger` on `TablePicker` (mirrors
  `ShapePicker`/`LinePicker`).
- Format/Motion overflow items are gated on a live `editor + store` so a
  tap before mount can't open an empty header-only sheet.
- Slide-background read/write semantics are shared between the desktop
  `RightGlobals` control and the new mobile sheet via a `useSlideBackground`
  hook (removes verbatim duplication).

Format Painter and Zoom are intentionally left out (not meaningful on
touch / mobile fits to viewport).

### Known limitations
- Desktop/`Mobile`SlidesLayout still duplicate shell state (store/theme/
  present); the in-code `useSlidesShellState` TODO tracks that larger
  extraction — out of scope here.
- The text-edit mobile bar has no overflow menu (focused editing mode);
  exit text editing to reach the design panels.

## Test plan

- [x] `pnpm verify:fast` (lint + unit; desktop `global-controls` covered)
- [ ] Manual smoke in `pnpm dev` at <768px: Theme/Format/Motion bottom
      sheets open from the overflow menu, Slide background applies, Table
      inserts; desktop toolbar unchanged (panels still dock, background
      dropdown still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)