### PR TITLE
Add slides image drag-drop and clipboard paste input

### DIFF
--- a/docs/tasks/active/20260505-slides-package-mvp-todo.md
+++ b/docs/tasks/active/20260505-slides-package-mvp-todo.md
@@ -60,7 +60,7 @@ Brainstorming summary: see commit message for `docs/design/slides/slides.md`.
 
 - [x] 5.1 `view/editor/text-box-editor.ts` — docs `initializeTextBox` bridge, double-click → mount → blur commit
 - [x] 5.2 ~~Yorkie Tree wiring for `TextElement.data.blocks` and `Slide.notes`~~ — reverted: nested `Tree` inside an array element gets JSON-serialised by Yorkie, no CRDT semantics. Bodies/notes stay as plain `Block[]` JSON; commits resolve LWW on blur. Per-keystroke convergence deferred to Phase 5a-2 (root-level `textTrees: { [elementId]: Tree }` map keyed by id).
-- [ ] 5.3 Image input paths — upload, drag-drop, clipboard paste (workspace image API reuse)
+- [x] 5.3 Image input paths — upload (toolbar file picker), drag-drop, clipboard paste (workspace image API reuse). Insert frame aspect-preserved + capped at 80% of the slide. See [`20260507-slides-phase5b-1-image-plan.md`](./20260507-slides-phase5b-1-image-plan.md) (Continuation 2026-06-21).
 - [x] 5.4 Slide-canvas text painting via docs `paintLayout` — same baseline math + font path as the in-place editor. Slide-side CJK font registry shim was dropped because the editor itself relied on docs' `buildFont` and Korean rendered fine; if a missing-glyph case surfaces later, route through `resolveFontFamily` at the docs level so both surfaces benefit.
 - [x] 5.5 `view/present/presenter.ts` + `presentation-mode.tsx` — fullscreen, fit-to-screen, key nav
 - [x] 5.6 `export/pdf.ts` — 13.333"×7.5" page mapping. **Shipped as P0

--- a/docs/tasks/active/20260507-slides-phase5b-1-image-lessons.md
+++ b/docs/tasks/active/20260507-slides-phase5b-1-image-lessons.md
@@ -1,0 +1,112 @@
+# Slides Phase 5b-1 (Image Input) — Lessons
+
+## Always re-check the plan against the live code before resuming
+
+The original plan proposed `SlidesEditor.insertImage` + a slides-package
+`image-frame.ts`. Neither existed; image insertion had landed via a
+frontend `insert-image.ts` + `store.addElement` instead. Resuming straight
+from the plan would have built a parallel, conflicting path. Gap-analysis
+first (which of the three input paths actually exist, with file:line) was
+the load-bearing step. Result: toolbar picker existed; drag-drop, paste,
+and the 80 % insert cap were missing.
+
+## Drag-drop and paste want different hosts
+
+- `drop` / `dragover` → the **canvas wrapper**. Drop events dispatch to the
+  element under the cursor, so canvas-scoping is correct and avoids
+  hijacking drops elsewhere on the page.
+- `paste` → the **document**. When no text box is focused the paste target
+  is `document.body`; a canvas-scoped paste listener never fires for the
+  common "copy elsewhere, click slide, Cmd+V" case. This also matches the
+  slides editor's existing document-level keydown model (`editor.ts:2113`),
+  so element-paste (Cmd+V → `readClipboard` JSON) and image-paste cohabit:
+  whichever the clipboard actually holds wins; the other no-ops.
+
+Guard the document paste with an extra check so it doesn't steal a paste
+meant for an unrelated `<input>` / textarea / contenteditable (the
+document-title field), on top of the `getEditingElementId()` text-box gate.
+
+## Late-loading deps → capture the callback in a ref
+
+The parent's `uploadFn` is `useCallback([workspaceId])`; its identity flips
+once the workspace id loads. The slides-view mount effect runs once
+(`[didMount, doc]`), so a listener closing over `uploadFn` directly would
+freeze the pre-load version that throws "not loaded yet". Mirror the
+existing `onStartPresentationRef` pattern: store `uploadImage` in a ref
+updated every render and have the listener read `ref.current`.
+
+## jsdom event constructors are unreliable — synthesise events instead
+
+`new DragEvent(...)` / `new ClipboardEvent(...)` aren't dependable under
+jsdom. Tests dispatch a plain `Event('drop'|'paste')` with a
+`dataTransfer` / `clipboardData` property defined via `Object.defineProperty`,
+and assert through a real `MemSlidesStore`. Keeps the drop/paste/gate/cleanup
+logic covered without depending on jsdom DnD internals (and dodges the
+flaky-test trap noted in prior memories).
+
+## The dragover gate must not call getAsFile() (drop silently no-op'd)
+
+First cut shared one helper between the `dragover` gate and the `drop`
+extractor: `hasImageFile = pickImageFile(dt) !== null`, and `pickImageFile`
+reads `item.getAsFile()`. But during `dragover` the browser withholds file
+contents — `getAsFile()` returns `null` and `dataTransfer.files` is empty
+(only `item.kind` / `item.type` are exposed). So the gate was always false
+mid-drag, `onDragOver` never called `preventDefault()`, the browser kept the
+default "navigate to file" behaviour, and `drop` never fired. Clipboard
+paste was unaffected (it only reads at `paste` time, where contents are
+available), which is exactly the symptom the user reported: paste worked,
+drag-drop didn't.
+
+Fix: split the two. `hasImageFile` (dragover gate) checks only
+`item.kind === 'file' && item.type.startsWith('image/')`; `pickImageFile`
+(drop/paste extractor) keeps `getAsFile()` / `files`. Also `preventDefault`
+on both `dragenter` and `dragover`. Regression test locks it: a transfer
+whose `getAsFile()` returns `null` (mid-drag) must still report
+`hasImageFile === true`.
+
+Lesson: the unit test that "passed" used a drop-shaped transfer (`files`
+populated), so it never exercised the dragover phase. When testing DnD,
+simulate the dragover transfer shape (items with `type` set, `getAsFile`
+→ null) separately from the drop shape.
+
+## Code-review fixes (don't gate drop on edit mode; guard paste behind modals)
+
+A high-effort review surfaced four real issues, all fixed before PR:
+
+1. **Drop while editing navigated the tab (data loss).** The first cut
+   gated `dragover`/`drop` on `getEditingElementId() === null` and bailed
+   *before* `preventDefault`. But the slides text box installs no drop
+   handler, so a drop on bare canvas while editing fell through to the
+   browser default → navigate to the `file://` URL → editor unmounts.
+   Fix: drop is NOT gated on edit mode; it always `preventDefault`s and
+   inserts (matches Google Slides). Only **paste** keeps the edit gate
+   (the text box's textarea genuinely owns paste).
+2. **Paste behind a modal inserted a stray image.** The document-level
+   paste listener didn't know about open Radix dialogs (shortcuts/share/
+   comments); a paste meant for the dialog dropped an image onto the
+   hidden slide. Fix: the paste guard also bails when
+   `activeElement.closest('[role="dialog"],[role="alertdialog"],[aria-modal]')`.
+3. **Silent swallow when no current slide.** `preventDefault` ran before
+   the `slideId` check, consuming the drop/paste with no feedback. Fix:
+   for paste, resolve `slideId` before `preventDefault`; for drop, still
+   consume (so the browser can't navigate) but bail cleanly if no slide.
+4. **`computeImageFrame` NaN on a non-finite dimension.** `Infinity > 0`
+   is true, so the `> 0` guard passed and `Infinity * scale` produced
+   NaN — an unrenderable frame persisted to the CRDT. Fix: require
+   `Number.isFinite` on both dims and never multiply on the bad path
+   (collapse to a finite centred 0×0).
+
+Non-blocking (logged as follow-up, not done here): `hasImageFile` /
+`pickImageFile` + the drag/paste plumbing are a third copy of the same
+logic in docs (`packages/docs/src/view/editor.ts` `hasImageItem` /
+`getImageFile`) and sheets (`sheet-view.tsx`); `computeImageFrame`'s
+fit-center math duplicates `presenter.ts` / `thumbnail-panel.ts`. A
+shared `installImageInput({ host, isEditingGuard, onFile })` +
+`fitInside` util across docs/sheets/slides would collapse all three.
+
+## Keep insert-frame policy where the upload is
+
+Cap-at-80 % + centre lives in the frontend `insert-image.ts`
+(`computeImageFrame`) next to the uploader, not in the slides package. The
+slides model stays free of insert-frame policy; all three input paths funnel
+through the one helper, so there's a single place to change the cap.

--- a/docs/tasks/active/20260507-slides-phase5b-1-image-plan.md
+++ b/docs/tasks/active/20260507-slides-phase5b-1-image-plan.md
@@ -650,3 +650,63 @@ git push
   paths.
 - Sub-image-of-image embed (e.g. SVG processing). The frontend
   hands raw bytes to `/images`; the server stores the file as-is.
+
+---
+
+## Continuation (2026-06-21): gap analysis + what shipped
+
+The original plan above proposed an architecture (a `SlidesEditor.insertImage`
+API + a slides-package `image-frame.ts` helper) that was **not** the path
+taken. By the time this was revisited, image insertion had already landed
+differently:
+
+- **Already done (toolbar file picker):** `slides-detail.tsx` →
+  `handleImagePick` opens a hidden `<input type="file" accept="image/*">`
+  and calls `insertImageOnSlide({ store, slideId, file, upload })`
+  (`packages/frontend/src/app/slides/insert-image.ts`). Upload reuses the
+  workspace `/api/v1/.../images` API via `uploadImageFile`
+  (`spreadsheet/image-upload.ts`) — same endpoint as docs/sheets.
+- **Was missing (this continuation closes it):**
+  1. **Drag-and-drop** a local image file onto the canvas.
+  2. **Clipboard paste** of an image.
+  3. **80 % insert cap** — `insert-image.ts` inserted at natural size 1:1
+     and centred only, so an oversized source (e.g. 3840×2160) spilled off
+     every slide edge. The plan called for an aspect-preserved 80 % cap; it
+     had been dropped.
+
+### What shipped
+
+- `insert-image.ts` — extracted a pure `computeImageFrame(naturalW,
+  naturalH)` that aspect-preserves + caps at 80 % of 1920×1080 + centres,
+  with a 0-dimension guard. `insertImageOnSlide` now routes through it.
+- `slides-image-input.ts` (new) — `pickImageFile` / `hasImageFile` plus
+  `setupSlidesImagePaths({ canvasWrap, editor, store, upload })`. **Two
+  hosts, deliberately:** `drop`/`dragover` on `canvasWrap` (drop dispatches
+  to the cursor's element), `paste` on `document` (matches the editor's
+  document-level keyboard model — when no text box is focused the paste
+  target is `document.body`, which a canvas-scoped listener never sees).
+  **Paste** gates on `editor.getEditingElementId() === null` and bails
+  when an unrelated input/textarea/contenteditable is focused or a modal
+  dialog is open. **Drop is intentionally NOT gated on edit mode** — the
+  slides text box installs no drop handler, so bailing while editing
+  would hand a bare-canvas drop to the browser default (navigate to the
+  file → unmount the editor); drop always `preventDefault`s and inserts.
+- `slides-view.tsx` — new optional `uploadImage` prop, captured in a ref
+  (the parent's `uploadFn` identity changes once the workspace id loads),
+  wired via `setupSlidesImagePaths` at mount + cleaned up on unmount.
+  Read-only share-link mounts pass no uploader, so the paths stay off.
+- `slides-detail.tsx` (desktop) passes `uploadImage={uploadFn}`. Mobile
+  (`MobileSlidesView`) keeps its own touch-oriented insert; desktop file
+  drag-drop is not a mobile affordance.
+
+### Deviations from the original plan (intentional)
+
+- No `SlidesEditor.insertImage` API and no slides-package `image-frame.ts`.
+  The insert policy (cap, centre) lives in the frontend `insert-image.ts`
+  next to the upload, keeping the slides package free of insert-frame
+  policy. Both approaches work; this matched the already-landed code.
+- Tests cover the pure frame math and the `pickImageFile` / drop / paste /
+  editing-gate / cleanup logic through a real `MemSlidesStore`, rather than
+  dispatching jsdom `DragEvent` / `ClipboardEvent` (whose constructors are
+  unreliable in jsdom) — events are synthesised as `Event` with a
+  defined `dataTransfer` / `clipboardData`.

--- a/packages/frontend/src/app/slides/insert-image.ts
+++ b/packages/frontend/src/app/slides/insert-image.ts
@@ -1,10 +1,51 @@
-import type { SlidesStore } from '@wafflebase/slides';
+import { SLIDE_HEIGHT, SLIDE_WIDTH, type SlidesStore } from '@wafflebase/slides';
 
 export interface InsertImageArgs {
   store: SlidesStore;
   slideId: string;
   file: File;
   upload: (file: File) => Promise<{ url: string; w: number; h: number }>;
+}
+
+/** Inserted images are capped at this fraction of the slide in each axis. */
+const MAX_INSERT_RATIO = 0.8;
+
+/**
+ * Default frame for a freshly-inserted image. Aspect-preserved, capped
+ * at 80 % of the slide (1920×1080 logical) in each dimension, and
+ * centred. Images smaller than the cap keep their natural size 1:1 (no
+ * upscaling), so what the user dropped in is what they see.
+ *
+ * Without the cap, a large source (e.g. a 3840×2160 screenshot) would
+ * insert at natural size and spill off every edge of the slide.
+ */
+export function computeImageFrame(
+  naturalWidth: number,
+  naturalHeight: number,
+): { x: number; y: number; w: number; h: number; rotation: number } {
+  const maxW = SLIDE_WIDTH * MAX_INSERT_RATIO;
+  const maxH = SLIDE_HEIGHT * MAX_INSERT_RATIO;
+  // Guard against a non-finite or 0 natural dimension (a failed
+  // preflight): collapse to a finite, centred 0×0 frame rather than
+  // letting Infinity/NaN reach the CRDT. `Infinity > 0` is true but
+  // `Infinity * scale` is Infinity/NaN, so a `> 0` check alone is not
+  // enough — require finiteness too, and never multiply on the bad path.
+  const valid =
+    Number.isFinite(naturalWidth) &&
+    Number.isFinite(naturalHeight) &&
+    naturalWidth > 0 &&
+    naturalHeight > 0;
+  // Fit-inside scale (≤ 1); 1:1 when the image already fits the cap.
+  const scale = valid ? Math.min(1, maxW / naturalWidth, maxH / naturalHeight) : 0;
+  const w = valid ? naturalWidth * scale : 0;
+  const h = valid ? naturalHeight * scale : 0;
+  return {
+    x: (SLIDE_WIDTH - w) / 2,
+    y: (SLIDE_HEIGHT - h) / 2,
+    w,
+    h,
+    rotation: 0,
+  };
 }
 
 /**
@@ -21,13 +62,7 @@ export async function insertImageOnSlide(args: InsertImageArgs): Promise<string>
   args.store.batch(() => {
     elementId = args.store.addElement(args.slideId, {
       type: 'image',
-      frame: {
-        x: (1920 - w) / 2,
-        y: (1080 - h) / 2,
-        w,
-        h,
-        rotation: 0,
-      },
+      frame: computeImageFrame(w, h),
       data: { src: url },
     });
   });

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -372,6 +372,7 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
               onStartPresentation={handleStartPresentation}
               documentId={documentId}
               zoomController={zoomControllerRef.current}
+              uploadImage={uploadFn}
             />
             {rightPanel === "theme" && store && (
               <ThemePanel

--- a/packages/frontend/src/app/slides/slides-image-input.ts
+++ b/packages/frontend/src/app/slides/slides-image-input.ts
@@ -1,0 +1,163 @@
+import type { SlidesEditor, SlidesStore } from '@wafflebase/slides';
+import { toast } from 'sonner';
+import { insertImageOnSlide } from './insert-image';
+
+/** Subset of `DataTransfer` we read — lets tests pass plain objects. */
+interface TransferLike {
+  items?: ArrayLike<{ kind: string; type: string; getAsFile(): File | null }>;
+  files?: ArrayLike<File>;
+}
+
+/**
+ * True when the transfer looks like it carries an image file. Checks
+ * only `item.kind` / `item.type` (and `files` types) — deliberately NOT
+ * `getAsFile()`, which returns null during `dragover` (the browser
+ * withholds file contents until `drop`). This is the `dragover` gate;
+ * if it called `getAsFile()` it would always be false mid-drag, the
+ * handler would never `preventDefault()`, and `drop` would never fire.
+ */
+export function hasImageFile(dt: TransferLike | null): boolean {
+  if (!dt) return false;
+  if (dt.items) {
+    for (const item of Array.from(dt.items)) {
+      if (item.kind === 'file' && item.type.startsWith('image/')) return true;
+    }
+  }
+  if (dt.files) {
+    for (const file of Array.from(dt.files)) {
+      if (file.type.startsWith('image/')) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * First image file in a drag or clipboard transfer, or null. Reads
+ * `item.getAsFile()` / `files`, which are only populated at `drop` /
+ * `paste` time — call this from the drop / paste handler, not from
+ * `dragover` (use `hasImageFile` there).
+ */
+export function pickImageFile(dt: TransferLike | null): File | null {
+  if (!dt) return null;
+  if (dt.items) {
+    for (const item of Array.from(dt.items)) {
+      if (item.kind === 'file' && item.type.startsWith('image/')) {
+        const file = item.getAsFile();
+        if (file) return file;
+      }
+    }
+  }
+  if (dt.files) {
+    for (const file of Array.from(dt.files)) {
+      if (file.type.startsWith('image/')) return file;
+    }
+  }
+  return null;
+}
+
+export interface SlidesImagePathDeps {
+  /** Canvas wrapper — host for drag-and-drop (drop fires on the element under the cursor). */
+  canvasWrap: HTMLElement;
+  editor: Pick<SlidesEditor, 'getEditingElementId' | 'getCurrentSlideId'>;
+  store: SlidesStore;
+  upload: (file: File) => Promise<{ url: string; w: number; h: number }>;
+}
+
+/**
+ * Install drag-and-drop + clipboard-paste image input on the slides
+ * canvas. Returns a cleanup function that removes every listener.
+ *
+ * Two hosts, deliberately:
+ *   - `drop` / `dragover` on `canvasWrap` — drop events dispatch to the
+ *     element under the cursor, so scoping them to the canvas is both
+ *     correct and avoids hijacking drops elsewhere on the page.
+ *   - `paste` on `document` — mirrors the editor's keyboard model
+ *     (`document`-level keydown). When no text box is focused the paste
+ *     target is `document.body`, which a canvas-scoped listener would
+ *     never see, so the listener must live on the document.
+ *
+ * Both paths are gated on the editor NOT being in text-edit mode — when
+ * the user is typing inside a text box the docs editor's own listeners
+ * own paste / drop. The paste path additionally bails when focus sits in
+ * an unrelated editable (e.g. the document-title field) so it never
+ * steals a paste meant for that input.
+ */
+export function setupSlidesImagePaths(deps: SlidesImagePathDeps): () => void {
+  const { canvasWrap, editor, store, upload } = deps;
+
+  const insert = (slideId: string, file: File) => {
+    void insertImageOnSlide({ store, slideId, file, upload }).catch((err) => {
+      console.error('Failed to insert image', err);
+      toast.error('Failed to insert image');
+    });
+  };
+
+  // NOTE: drag-drop is deliberately NOT gated on text-edit mode. The
+  // slides text box installs no drop handler, so bailing while editing
+  // would leave a bare-canvas drop to the browser default — which
+  // navigates the tab to the file:// URL and unmounts the editor (data
+  // loss). Dropping an image always inserts a new element on the slide,
+  // matching Google Slides. We still `preventDefault` for any image drag
+  // so the browser never takes over.
+  const onDragOver = (e: DragEvent) => {
+    if (!hasImageFile(e.dataTransfer)) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+  };
+
+  const onDrop = (e: DragEvent) => {
+    const file = pickImageFile(e.dataTransfer);
+    if (!file) return;
+    // Consume the drop regardless so the browser never navigates to the
+    // file, even if there's transiently no slide to insert into.
+    e.preventDefault();
+    const slideId = editor.getCurrentSlideId();
+    if (!slideId) return;
+    insert(slideId, file);
+  };
+
+  const onPaste = (e: ClipboardEvent) => {
+    // A focused text box / dialog / unrelated input owns the paste.
+    if (editor.getEditingElementId() !== null) return;
+    if (isPasteOwnedElsewhere()) return;
+    const file = pickImageFile(e.clipboardData);
+    if (!file) return;
+    const slideId = editor.getCurrentSlideId();
+    if (!slideId) return;
+    e.preventDefault();
+    insert(slideId, file);
+  };
+
+  const docHost = canvasWrap.ownerDocument ?? document;
+  // dragenter + dragover both preventDefault so the browser accepts the
+  // drop (without it the drop never fires and the file opens in the tab).
+  canvasWrap.addEventListener('dragenter', onDragOver);
+  canvasWrap.addEventListener('dragover', onDragOver);
+  canvasWrap.addEventListener('drop', onDrop);
+  docHost.addEventListener('paste', onPaste);
+
+  return () => {
+    canvasWrap.removeEventListener('dragenter', onDragOver);
+    canvasWrap.removeEventListener('dragover', onDragOver);
+    canvasWrap.removeEventListener('drop', onDrop);
+    docHost.removeEventListener('paste', onPaste);
+  };
+}
+
+/**
+ * True when something other than the bare slides canvas owns the paste:
+ * a focused editable (input / textarea / contenteditable — e.g. the
+ * document-title field or speaker-notes), OR an open modal dialog
+ * (shortcuts help, share, comments). In those cases the document-level
+ * listener must not steal the paste and drop a stray image onto the
+ * slide hidden behind the dialog. The slides text box itself runs
+ * through the editor's `getEditingElementId` gate, not this check.
+ */
+function isPasteOwnedElsewhere(): boolean {
+  const el = document.activeElement as HTMLElement | null;
+  if (!el) return false;
+  const tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable) return true;
+  return el.closest('[role="dialog"], [role="alertdialog"], [aria-modal="true"]')
+    !== null;
+}

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -19,6 +19,7 @@ import type { SlidesPresence } from "@/types/users";
 import { SlidesShortcutsHelp } from "./slides-shortcuts-help";
 import { clearPendingImport, peekPendingImport } from "./pending-imports";
 import { YorkieSlidesStore, ensureSlidesRoot } from "./yorkie-slides-store";
+import { setupSlidesImagePaths } from "./slides-image-input";
 import { mapPresenceToPeerView } from "./peer-view";
 import { FIT_ZOOM, type ZoomController } from "./zoom-controller";
 import { useGoogleFontsLink } from "@/components/text-formatting/font-catalog";
@@ -65,6 +66,14 @@ interface SlidesViewProps {
    * dropdown and view share state without each rebuilding the other.
    */
   zoomController?: ZoomController | null;
+  /**
+   * Uploads a local image file through the workspace image API and
+   * returns its URL + intrinsic size. Supplied by the parent shell
+   * (which owns the workspace id + auth). When provided, the canvas
+   * gains drag-and-drop and clipboard-paste image input; when omitted
+   * (e.g. a read-only share-link mount) those paths stay off.
+   */
+  uploadImage?: (file: File) => Promise<{ url: string; w: number; h: number }>;
 }
 
 // Logical slide aspect (1920×1080 = 16:9). The canvas is sized to fit
@@ -133,6 +142,7 @@ export function SlidesView({
   onStoreReady,
   onStartPresentation,
   zoomController,
+  uploadImage,
 }: SlidesViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<SlidesEditor | null>(null);
@@ -156,6 +166,14 @@ export function SlidesView({
   // callback identity).
   const onStartPresentationRef = useRef(onStartPresentation);
   onStartPresentationRef.current = onStartPresentation;
+
+  // Capture the latest uploadImage in a ref so the mount-time drag /
+  // paste listeners always call the freshest uploader. The parent's
+  // `uploadFn` identity changes once the workspace id finishes loading
+  // (it is `useCallback([workspaceId])`); without the ref the listeners
+  // would close over the pre-load version that throws "not loaded yet".
+  const uploadImageRef = useRef(uploadImage);
+  uploadImageRef.current = uploadImage;
 
   // Stable ref for the toast callback — wired into the editor at mount time.
   // Using sonner's toast.info directly; the ref prevents stale closure issues.
@@ -620,6 +638,25 @@ export function SlidesView({
     onEditorReady?.(editor);
     onStoreReady?.(store);
 
+    // Drag-and-drop + clipboard-paste image input. Drop fires on the
+    // canvas wrapper (cursor target); paste rides the document (matches
+    // the editor's document-level keyboard model — see slides-image-
+    // input.ts). Both no-op while a text box is being edited. Read-only
+    // mounts get no uploader, so the paths stay off. The upload wrapper
+    // reads `uploadImageRef` so a late-loading workspace id is picked up.
+    const cleanupImagePaths = readOnlyMount
+      ? () => {}
+      : setupSlidesImagePaths({
+          canvasWrap,
+          editor,
+          store,
+          upload: (file) => {
+            const fn = uploadImageRef.current;
+            if (!fn) return Promise.reject(new Error("Image upload unavailable"));
+            return fn(file);
+          },
+        });
+
     // Refit canvas to the right column, taking the current notes height
     // into account. Extracted into a function because two paths call
     // it: the ResizeObserver below, and the notes-drag handler (where
@@ -984,6 +1021,7 @@ export function SlidesView({
         document.body.style.userSelect = "";
       }
       cancelAnimationFrame(raf);
+      cleanupImagePaths();
       offSelection();
       offSlide();
       offChange();

--- a/packages/frontend/tests/app/slides/insert-image.test.ts
+++ b/packages/frontend/tests/app/slides/insert-image.test.ts
@@ -1,6 +1,56 @@
 import { describe, it, expect, vi } from 'vitest';
-import { MemSlidesStore } from '@wafflebase/slides';
-import { insertImageOnSlide } from '@/app/slides/insert-image.ts';
+import { MemSlidesStore, SLIDE_HEIGHT, SLIDE_WIDTH } from '@wafflebase/slides';
+import {
+  computeImageFrame,
+  insertImageOnSlide,
+} from '@/app/slides/insert-image.ts';
+
+describe('computeImageFrame', () => {
+  it('uses natural size 1:1 for images within the 80% cap', () => {
+    const frame = computeImageFrame(200, 100);
+    expect(frame.w).toBe(200);
+    expect(frame.h).toBe(100);
+    expect(frame.x).toBe((SLIDE_WIDTH - 200) / 2);
+    expect(frame.y).toBe((SLIDE_HEIGHT - 100) / 2);
+    expect(frame.rotation).toBe(0);
+  });
+
+  it('caps oversized landscape images at 80% of the slide width', () => {
+    const frame = computeImageFrame(3840, 1080);
+    expect(frame.w).toBe(SLIDE_WIDTH * 0.8);
+    expect(frame.h).toBeCloseTo(SLIDE_WIDTH * 0.8 * (1080 / 3840));
+    expect(frame.x).toBeCloseTo((SLIDE_WIDTH - frame.w) / 2);
+    expect(frame.y).toBeCloseTo((SLIDE_HEIGHT - frame.h) / 2);
+  });
+
+  it('caps tall portrait images at 80% of the slide height', () => {
+    const frame = computeImageFrame(800, 4000);
+    expect(frame.h).toBe(SLIDE_HEIGHT * 0.8);
+    expect(frame.w).toBeCloseTo(SLIDE_HEIGHT * 0.8 * (800 / 4000));
+  });
+
+  it('falls back to a centred 0×0 frame when a dimension is missing', () => {
+    const frame = computeImageFrame(0, 0);
+    expect(frame.w).toBe(0);
+    expect(frame.h).toBe(0);
+    expect(frame.x).toBe(SLIDE_WIDTH / 2);
+    expect(frame.y).toBe(SLIDE_HEIGHT / 2);
+  });
+
+  it('never produces a NaN / non-finite frame for bad dimensions', () => {
+    for (const [w, h] of [
+      [Infinity, 1080],
+      [800, Infinity],
+      [NaN, 600],
+      [-100, 200],
+    ] as const) {
+      const frame = computeImageFrame(w, h);
+      for (const v of [frame.x, frame.y, frame.w, frame.h]) {
+        expect(Number.isFinite(v)).toBe(true);
+      }
+    }
+  });
+});
 
 describe('insertImageOnSlide', () => {
   it('uploads then adds an image element centered on the slide', async () => {

--- a/packages/frontend/tests/app/slides/slides-image-input.test.ts
+++ b/packages/frontend/tests/app/slides/slides-image-input.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MemSlidesStore } from '@wafflebase/slides';
+import {
+  hasImageFile,
+  pickImageFile,
+  setupSlidesImagePaths,
+} from '@/app/slides/slides-image-input.ts';
+
+const pngFile = () => new File(['bytes'], 'a.png', { type: 'image/png' });
+
+/** Minimal DataTransfer-like stub. */
+function transfer(opts: {
+  items?: Array<{ kind: string; type: string; file: File | null }>;
+  files?: File[];
+}) {
+  return {
+    items: opts.items?.map((i) => ({
+      kind: i.kind,
+      type: i.type,
+      getAsFile: () => i.file,
+    })),
+    files: opts.files,
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('pickImageFile / hasImageFile', () => {
+  it('finds an image via items (dragover phase)', () => {
+    const file = pngFile();
+    const dt = transfer({ items: [{ kind: 'file', type: 'image/png', file }] });
+    expect(pickImageFile(dt)).toBe(file);
+    expect(hasImageFile(dt)).toBe(true);
+  });
+
+  it('finds an image via files (drop / paste phase)', () => {
+    const file = pngFile();
+    expect(pickImageFile(transfer({ files: [file] }))).toBe(file);
+  });
+
+  it('hasImageFile is true mid-drag when getAsFile() returns null', () => {
+    // During `dragover` the browser withholds file contents, so
+    // getAsFile() is null but item.type is known. The dragover gate must
+    // still report true — otherwise preventDefault never runs and drop
+    // never fires. (Regression: drag-and-drop silently no-op'd.)
+    const dt = transfer({ items: [{ kind: 'file', type: 'image/png', file: null }] });
+    expect(hasImageFile(dt)).toBe(true);
+    expect(pickImageFile(dt)).toBeNull();
+  });
+
+  it('ignores non-image items and a null transfer', () => {
+    const text = new File(['x'], 'a.txt', { type: 'text/plain' });
+    expect(pickImageFile(transfer({ files: [text] }))).toBeNull();
+    expect(pickImageFile(null)).toBeNull();
+    expect(hasImageFile(null)).toBe(false);
+  });
+});
+
+describe('setupSlidesImagePaths', () => {
+  function fixture(editingId: string | null = null) {
+    const store = new MemSlidesStore();
+    let slideId = '';
+    store.batch(() => {
+      slideId = store.addSlide('blank');
+    });
+    const editor = {
+      getEditingElementId: () => editingId,
+      getCurrentSlideId: () => slideId,
+    };
+    const canvasWrap = document.createElement('div');
+    document.body.appendChild(canvasWrap);
+    const upload = vi.fn(async () => ({ url: 'https://cdn/a.png', w: 200, h: 100 }));
+    const cleanup = setupSlidesImagePaths({ canvasWrap, editor, store, upload });
+    return { store, slideId, canvasWrap, upload, cleanup };
+  }
+
+  function dropEvent(dt: unknown) {
+    const ev = new Event('drop', { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, 'dataTransfer', { value: dt });
+    return ev;
+  }
+  function pasteEvent(dt: unknown) {
+    const ev = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, 'clipboardData', { value: dt });
+    return ev;
+  }
+
+  const countElements = (store: MemSlidesStore, slideId: string) =>
+    store.read().slides.find((s) => s.id === slideId)!.elements.length;
+
+  it('inserts a dropped image onto the current slide', async () => {
+    const { store, slideId, canvasWrap, upload, cleanup } = fixture();
+    canvasWrap.dispatchEvent(dropEvent(transfer({ files: [pngFile()] })));
+    await flush();
+    expect(upload).toHaveBeenCalledOnce();
+    expect(countElements(store, slideId)).toBe(1);
+    cleanup();
+  });
+
+  it('inserts a pasted image (document-level listener)', async () => {
+    const { store, slideId, upload, cleanup } = fixture();
+    document.dispatchEvent(pasteEvent(transfer({ files: [pngFile()] })));
+    await flush();
+    expect(upload).toHaveBeenCalledOnce();
+    expect(countElements(store, slideId)).toBe(1);
+    cleanup();
+  });
+
+  it('still inserts on drop while a text box is being edited', async () => {
+    // Drop is NOT gated on edit mode: the slides text box has no drop
+    // handler, so bailing would hand a bare-canvas drop to the browser
+    // (which navigates the tab). The drop must be consumed + inserted.
+    const { store, slideId, canvasWrap, upload, cleanup } = fixture('el-editing');
+    canvasWrap.dispatchEvent(dropEvent(transfer({ files: [pngFile()] })));
+    await flush();
+    expect(upload).toHaveBeenCalledOnce();
+    expect(countElements(store, slideId)).toBe(1);
+    cleanup();
+  });
+
+  it('does NOT insert on paste while a text box is being edited', async () => {
+    const { store, slideId, upload, cleanup } = fixture('el-editing');
+    document.dispatchEvent(pasteEvent(transfer({ files: [pngFile()] })));
+    await flush();
+    expect(upload).not.toHaveBeenCalled();
+    expect(countElements(store, slideId)).toBe(0);
+    cleanup();
+  });
+
+  it('does NOT insert on paste while a modal dialog is open', async () => {
+    const { store, slideId, upload, cleanup } = fixture();
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    const btn = document.createElement('button');
+    dialog.appendChild(btn);
+    document.body.appendChild(dialog);
+    btn.focus();
+    document.dispatchEvent(pasteEvent(transfer({ files: [pngFile()] })));
+    await flush();
+    expect(upload).not.toHaveBeenCalled();
+    expect(countElements(store, slideId)).toBe(0);
+    cleanup();
+    dialog.remove();
+  });
+
+  it('removes its listeners on cleanup', async () => {
+    const { store, slideId, canvasWrap, upload, cleanup } = fixture();
+    cleanup();
+    canvasWrap.dispatchEvent(dropEvent(transfer({ files: [pngFile()] })));
+    document.dispatchEvent(pasteEvent(transfer({ files: [pngFile()] })));
+    await flush();
+    expect(upload).not.toHaveBeenCalled();
+    expect(countElements(store, slideId)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the Phase 5b-1 image input paths for Slides. The toolbar "+ Image" file picker already existed; this wires the two missing paths and fixes the insert frame:

- **Drag-and-drop** a local image file onto the canvas
- **Clipboard paste** of an image (Cmd+V)
- **80% insert cap** — inserts were natural-size 1:1, so an oversized source (e.g. a 3840×2160 screenshot) spilled off every slide edge. Inserts are now aspect-preserved, capped at 80% of the slide, and centred. All three paths (picker, drop, paste) funnel through one `computeImageFrame`.

### How it's wired

`setupSlidesImagePaths` installs listeners on two deliberate hosts:
- `drop`/`dragover` on the **canvas wrapper** — drop dispatches to the element under the cursor.
- `paste` on the **document** — matches the editor's document-level keyboard model; with no text box focused the paste target is `document.body`, which a canvas-scoped listener never sees.

**Drop is intentionally not gated on text-edit mode**: the slides text box installs no drop handler, so bailing while editing would hand a bare-canvas drop to the browser default (navigate the tab to the `file://` URL → unmount the editor). Drop always `preventDefault`s + inserts. **Paste** keeps the edit-mode gate and also defers when an unrelated input/textarea/contenteditable is focused or a modal dialog is open. Image-paste and the editor's Cmd+V element-paste read disjoint clipboard slots, so they don't collide.

Read-only share-link mounts get no uploader, so the paths stay off. Upload reuses the workspace `/api/v1/.../images` API (same as docs/sheets) via the existing `uploadFn`, captured in a ref so a late-loading workspace id is picked up.

Closes item 5.3 of the Slides MVP todo.

## Test plan

- `pnpm verify:fast` green.
- New unit tests (17): `computeImageFrame` cap/aspect/centre + non-finite-dimension guard; `pickImageFile`/`hasImageFile` including the dragover-phase `getAsFile()===null` case; drop inserts (incl. while editing), paste inserts, paste deferred while editing / behind a modal, listener cleanup.
- Manual smoke (`pnpm dev`): toolbar picker, desktop file drag-drop onto canvas, and clipboard paste all insert a centred image; pasting while editing a text box types into the box instead.

## Review

Self-reviewed at high effort before opening. Fixed four findings (drop-while-editing tab navigation, paste-behind-modal stray insert, silent swallow when no current slide, `computeImageFrame` NaN on a non-finite dimension). Non-blocking follow-up logged in the lessons doc: `hasImageFile`/`pickImageFile` + the drag/paste plumbing are a third copy of logic in docs/sheets — a shared `installImageInput` util would collapse all three. Mobile keeps its own touch insert (file drag-drop is not a touch affordance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image input via drag-and-drop and clipboard paste for slides.
  * Improved image sizing: automatically capped at 80% of slide dimensions with aspect ratio preservation and centered placement.

* **Tests**
  * Added test coverage for image input utilities and insertion behavior.

* **Documentation**
  * Updated implementation documentation and gap analysis for image input features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->