### PR TITLE
Add @user mentions to comments (mention-only)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -89,6 +89,7 @@ Infrastructure, frontend/backend, and cross-cutting concerns.
 | [backend.md](backend.md)                               | Backend package — NestJS modules, API reference, auth system, database schema, security            |
 | [sharing.md](sharing.md)                               | URL-based token sharing with anonymous access and role-based permissions                           |
 | [context-menu.md](context-menu.md)                     | Unified context menu — Radix ContextMenu, desktop/mobile parity, menu items                       |
+| [comments-mentions.md](comments-mentions.md)           | Comment `@user` mentions — inline `@[username](userId)` tokens in plain `body`, member autocomplete, blue chips; mention-only (notifications deferred), shared frontend module |
 | [rest-api.md](rest-api.md)                             | REST API v1 — workspace-scoped API keys, `/api/v1/` documents/tabs/cells/content endpoints, Yorkie service, CLI auth endpoints |
 | [cli.md](cli.md)                                       | `wafflebase` CLI — OAuth login + API keys, ctx switching, docs/sheets/api-keys namespaces, content/export/import, agent integration |
 | [harness-engineering.md](harness-engineering.md)       | Verification lane strategy, phase roadmap, rollout status, and harness v1 completion criteria      |

--- a/docs/design/comments-mentions.md
+++ b/docs/design/comments-mentions.md
@@ -84,7 +84,7 @@ Token grammar (kept deliberately small):
   username/userId containing `]`/`)` because those are stripped/escaped at
   serialize time — see `serializeMention`.)
 
-### New shared helper — `components/comments/mentions.ts`
+### New shared helper — `packages/frontend/src/components/comments/mentions.ts`
 
 Pure, DOM-free functions (unit-testable, node-safe):
 
@@ -189,13 +189,15 @@ CommentThreadCard ── CommentBody ── parseMentionBody ── blue chips
 
 ### Testing
 
-- `mentions.test.ts` — parse/serialize round-trip; escape edge cases
-  (`@[` in prose, `]`/`)` inside names, adjacent mentions, mention at
-  string start/end, empty body); `extractMentionedUserIds`.
+- `packages/frontend/tests/components/comments/mentions.test.ts` —
+  parse/serialize round-trip; escape edge cases (`@[` in prose, `]`/`)`
+  inside names, adjacent mentions, mention at string start/end, empty body);
+  `extractMentionedUserIds`.
 - Composer interaction test — `@` opens dropdown, filter, keyboard select,
-  submit produces a tokenized body, manual edit drops to plain text. Use
-  `.test.ts` + `IS_REACT_ACT_ENVIRONMENT` (jsdom react-dom is available;
-  `.tsx` render tests are flaky per project memory).
+  submit produces a tokenized body, manual edit drops to plain text. Use a
+  plain test (not JSX) under the `tests/` runner with
+  `IS_REACT_ACT_ENVIRONMENT` (jsdom react-dom is available; JSX render tests
+  are flaky per project memory).
 - `CommentBody` render test — chips rendered, plain text preserved.
 - `pnpm verify:fast` green.
 

--- a/docs/design/comments-mentions.md
+++ b/docs/design/comments-mentions.md
@@ -1,0 +1,215 @@
+---
+title: comments-mentions
+target-version: 0.5.0
+---
+
+<!-- Append document link in design README.md (Common section) after creating. -->
+
+# Comment Mentions
+
+## Summary
+
+Add Google-Docs-style `@user` mentions to comments. While typing a comment
+or reply, a user types `@`, picks a workspace member from an autocomplete
+dropdown, and the mention renders as a blue chip in the posted comment.
+
+This is a **mention-only** scope: input, storage, and rendering. It does
+**not** add a notification system (in-app or email). Notifications remain a
+separate follow-up (`docs-comments-followup` roadmap, Step 4) and are listed
+under Non-Goals.
+
+The work lands entirely in the **shared frontend comments module**
+(`packages/frontend/src/components/comments/`), so both live consumers
+(sheets cells, docs ranges) get mentions in the same change; slides inherits
+them for free when slides comments land. No CRDT schema change and no
+domain-package (`@wafflebase/sheets`/`docs`) type change: a mention is
+encoded inline in the existing plain-string `Comment.body`.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Typing `@` in the comment composer (new thread or reply) opens a member
+  autocomplete; selecting a member inserts a mention.
+- A posted comment renders mentions as blue, non-editable chips with a hover
+  tooltip (username + photo). Click is a no-op for now.
+- Mentions are stored stably (embedded `userId`) so a later username change
+  or duplicate username never breaks rendering.
+- Zero change to `Comment`/`Thread` types, CRDT schema, or any store; the
+  feature is additive in the shared frontend module only.
+- Mentionable set = current workspace members, sourced from the existing
+  `GET /workspaces/:id` response (no new backend).
+
+### Non-Goals
+
+- **Notifications** (in-app feed, unread badge, email) — separate follow-up.
+- Mentioning users who are not workspace members (e.g. by email).
+- Rich `contentEditable` input with in-textarea chips — we keep the plain
+  `<textarea>` and tokenize on submit (see Risks).
+- Mention-driven access grants ("mention to share").
+- Slides comments themselves (mention support is inherited once they exist).
+
+## Proposal Details
+
+### Data model — unchanged
+
+`Comment.body` stays a plain `string` (owned by `@wafflebase/sheets`). A
+mention is encoded inline as a token:
+
+```
+@[username](userId)
+```
+
+Example stored body:
+
+```
+Hi @[김철수](u_42), can you review this?
+```
+
+Because the `userId` is embedded, rendering never has to guess which member
+a display name refers to. `Thread`/`Comment` types, the Yorkie schema, and
+every `CommentStore` implementation are untouched — the token is opaque
+text to them. This keeps the change from rippling into the `@wafflebase/*`
+packages.
+
+Token grammar (kept deliberately small):
+
+- `username` segment: any run of characters except `]`.
+- `userId` segment: any run of characters except `)`.
+- A literal `@[` in normal prose is preserved verbatim: the parser only
+  treats `@[...](...)` as a mention when **both** brackets close in order;
+  otherwise the text is emitted as-is. (Serialization never produces a
+  username/userId containing `]`/`)` because those are stripped/escaped at
+  serialize time — see `serializeMention`.)
+
+### New shared helper — `components/comments/mentions.ts`
+
+Pure, DOM-free functions (unit-testable, node-safe):
+
+```ts
+type MentionRef = { userId: string; username: string };
+type BodySegment =
+  | { type: 'text'; value: string }
+  | { type: 'mention'; userId: string; username: string };
+
+// "Hi @[김철수](u_42)!" -> [text "Hi ", mention, text "!"]
+function parseMentionBody(body: string): BodySegment[];
+
+// { userId:'u_42', username:'김철수' } -> "@[김철수](u_42)"
+// strips ']' from username and ')' from userId to keep the grammar safe.
+function serializeMention(ref: MentionRef): string;
+
+// extract userIds referenced in a body (for future notification work)
+function extractMentionedUserIds(body: string): string[];
+```
+
+`extractMentionedUserIds` is included now because it is trivial and is the
+single integration point a future notification feature needs — but nothing
+in this PR consumes it beyond a unit test, so it carries no runtime weight.
+
+### Member source — `useWorkspaceMembers(workspaceId)`
+
+A small frontend hook that reads the existing `GET /workspaces/:id`
+response (`workspace.members[].user`) and returns
+`{ userId, username, photo }[]`. `findOne` already includes
+`members: { include: { user: true } }`, so **no new backend endpoint**.
+
+Each consumer's comment controller already knows its `workspaceId`
+(documents are workspace-scoped); it passes the member list (or the hook
+result) down to `CommentComposer` as a prop. The shared module never
+fetches on its own — it stays presentation-only and testable.
+
+### Input — `MentionTextarea` inside `CommentComposer`
+
+`CommentComposer` keeps its `<textarea>`. Mention behavior is layered via a
+small `MentionTextarea` wrapper / hook:
+
+- **Trigger**: detect an `@` immediately preceded by start-of-text or
+  whitespace, followed by the in-progress query (`@ki`). Show a dropdown
+  anchored under the caret listing members whose username matches the query
+  (case-insensitive prefix/substring).
+- **Dropdown**: reuses `AuthorAvatar` for each row. Keyboard: ↑/↓ move,
+  Enter/Tab select, Esc closes. These keys are intercepted **only while the
+  dropdown is open**, so the composer's existing Cmd/Ctrl+Enter submit and
+  Escape-cancel are unaffected when it's closed.
+- **Selection (approach B — tokenize on submit)**: selecting a member
+  replaces the in-progress `@ki` with a clean `@username ` in the textarea
+  and records the chosen mention in a view-local **mention map**
+  (`{ matchedText, userId, username }`). On submit, the composer walks the
+  mention map and rewrites each still-present `@username` occurrence into a
+  `@[username](userId)` token before calling `onSubmit(body)`. If the user
+  manually edited a mention's text so it no longer matches, that mention is
+  silently dropped to plain text (graceful — never emits a broken token).
+- **IME safety**: while an IME composition is active
+  (`compositionstart`/`compositionend`), the `@`-trigger and key handling
+  are suppressed so Korean/CJK composition isn't hijacked. (Reflects the
+  docs IME known-issue lessons.)
+
+`CommentComposer`'s `onSubmit(body: string)` signature is unchanged — the
+body it passes up already contains tokens, so every store and consumer works
+without modification.
+
+### Render — `CommentBody` inside `CommentThreadCard`
+
+The thread card currently prints `comment.body` as plain text. Replace that
+with a shared `CommentBody` component:
+
+- Runs `parseMentionBody(body)`.
+- Renders `text` segments verbatim (preserving whitespace/newlines as today).
+- Renders `mention` segments as a styled chip: blue text, subtle background,
+  `@username`, `title`/tooltip showing username (+ photo via a lightweight
+  popover/tooltip). Click is a no-op (cursor default), leaving room for a
+  profile/jump action when notifications land.
+- Used by both sheets and docs thread cards (single component).
+
+### Wiring summary
+
+```
+GET /workspaces/:id ──┐
+                      ├─ useWorkspaceMembers(workspaceId) ─┐
+consumer controller ──┘                                    │ members[]
+                                                           ▼
+CommentComposer ── MentionTextarea(@ dropdown) ── onSubmit("…@[u](id)…")
+                                                           │
+                                                           ▼
+                                              CommentStore (unchanged)
+                                                           │
+                                                           ▼
+CommentThreadCard ── CommentBody ── parseMentionBody ── blue chips
+```
+
+### Testing
+
+- `mentions.test.ts` — parse/serialize round-trip; escape edge cases
+  (`@[` in prose, `]`/`)` inside names, adjacent mentions, mention at
+  string start/end, empty body); `extractMentionedUserIds`.
+- Composer interaction test — `@` opens dropdown, filter, keyboard select,
+  submit produces a tokenized body, manual edit drops to plain text. Use
+  `.test.ts` + `IS_REACT_ACT_ENVIRONMENT` (jsdom react-dom is available;
+  `.tsx` render tests are flaky per project memory).
+- `CommentBody` render test — chips rendered, plain text preserved.
+- `pnpm verify:fast` green.
+
+## Risks and Mitigation
+
+- **Approach B mapping drift.** Tokenizing on submit (clean textarea, no
+  in-line chip) means a user can edit a mention's text after selecting it.
+  *Mitigation:* mentions whose text no longer matches the recorded map entry
+  are dropped to plain text rather than emitting a malformed token — a
+  graceful, well-defined fallback. The alternative (approach A, insert the
+  raw token immediately) was rejected for showing `@[name](id)` noise in the
+  input.
+- **Token collision with user prose.** Someone could literally type
+  `@[x](y)`. *Mitigation:* this renders as a chip only if `y` parses as a
+  segment; worst case it renders as a chip with an arbitrary id and no
+  tooltip match — cosmetically odd, never a crash or data corruption. Real
+  mentions always carry a valid workspace `userId`.
+- **IME hijack.** Composition events gate the trigger (see Input). Covered
+  by the lessons from prior docs IME work; manual smoke in `pnpm dev` with
+  Korean input before merge.
+- **Stale member list.** The dropdown shows members as of the last
+  `GET /workspaces/:id`. A just-added member may be briefly unmentionable;
+  acceptable for v1 and self-heals on refetch.
+- **Anonymous/share-link viewers.** Such sessions may lack a workspace
+  member list; the dropdown is simply empty (no mentions offered). Rendering
+  of existing mention chips still works (parse-only, no member fetch needed).

--- a/docs/design/comments-mentions.md
+++ b/docs/design/comments-mentions.md
@@ -32,7 +32,9 @@ encoded inline in the existing plain-string `Comment.body`.
 - Typing `@` in the comment composer (new thread or reply) opens a member
   autocomplete; selecting a member inserts a mention.
 - A posted comment renders mentions as blue, non-editable chips with a hover
-  tooltip (username + photo). Click is a no-op for now.
+  tooltip (username). Click is a no-op for now. (Photo-in-tooltip is
+  deferred: the token carries only username + userId, and chips must render
+  parse-only for anonymous viewers without a member fetch.)
 - Mentions are stored stably (embedded `userId`) so a later username change
   or duplicate username never breaks rendering.
 - Zero change to `Comment`/`Thread` types, CRDT schema, or any store; the
@@ -99,6 +101,9 @@ function parseMentionBody(body: string): BodySegment[];
 // strips ']' from username and ')' from userId to keep the grammar safe.
 function serializeMention(ref: MentionRef): string;
 
+// "Hi @[김철수](u_42)" -> "Hi @김철수" (for truncated previews)
+function mentionBodyToPlainText(body: string): string;
+
 // extract userIds referenced in a body (for future notification work)
 function extractMentionedUserIds(body: string): string[];
 ```
@@ -157,9 +162,13 @@ with a shared `CommentBody` component:
 - Runs `parseMentionBody(body)`.
 - Renders `text` segments verbatim (preserving whitespace/newlines as today).
 - Renders `mention` segments as a styled chip: blue text, subtle background,
-  `@username`, `title`/tooltip showing username (+ photo via a lightweight
-  popover/tooltip). Click is a no-op (cursor default), leaving room for a
-  profile/jump action when notifications land.
+  `@username`, native `title` tooltip showing the username. Click is a no-op
+  (cursor default), leaving room for a profile/jump action when
+  notifications land. Photo-in-tooltip is deferred (parse-only render needs
+  no member list, so chips show for anonymous viewers too).
+- Truncated previews that cannot host chips (side-panel snippet,
+  `OrphanedCard`) use `mentionBodyToPlainText(body)` (mentions → `@username`)
+  so the raw `@[…](…)` token never leaks.
 - Used by both sheets and docs thread cards (single component).
 
 ### Wiring summary

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,10 +18,11 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| comments mentions (2026-06-21) | [20260621-comments-mentions-todo.md](./active/20260621-comments-mentions-todo.md) | - |
 | slides live presence (2026-06-21) | [20260621-slides-live-presence-todo.md](./active/20260621-slides-live-presence-todo.md) | - |
 | slides native undo migration (2026-06-21) | [20260621-slides-native-undo-migration-todo.md](./active/20260621-slides-native-undo-migration-todo.md) | [20260621-slides-native-undo-migration-lessons.md](./active/20260621-slides-native-undo-migration-lessons.md) |
 | slides pdf export (2026-06-21) | [20260621-slides-pdf-export-todo.md](./active/20260621-slides-pdf-export-todo.md) | - |
-| slides format effects (2026-06-20) | [20260620-slides-format-effects-todo.md](./active/20260620-slides-format-effects-todo.md) | - |
+| slides format effects (2026-06-20) | [20260620-slides-format-effects-todo.md](./active/20260620-slides-format-effects-todo.md) | [20260620-slides-format-effects-lessons.md](./active/20260620-slides-format-effects-lessons.md) |
 | slides fonts (2026-06-16) | [20260616-slides-fonts-todo.md](./active/20260616-slides-fonts-todo.md) | [20260616-slides-fonts-lessons.md](./active/20260616-slides-fonts-lessons.md) |
 | slides tables (2026-06-08) | [20260608-slides-tables-todo.md](./active/20260608-slides-tables-todo.md) | [20260608-slides-tables-lessons.md](./active/20260608-slides-tables-lessons.md) |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
@@ -36,4 +37,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 295
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides live presence (2026-06-21)
+Latest active task: comments mentions (2026-06-21)

--- a/docs/tasks/active/20260621-comments-mentions-lessons.md
+++ b/docs/tasks/active/20260621-comments-mentions-lessons.md
@@ -1,0 +1,75 @@
+# Comment Mentions — Lessons
+
+## Inline token in the existing string body avoids a CRDT/type ripple
+
+Storing each mention as `@[username](userId)` inside the existing plain
+`Comment.body` string meant **zero** change to `Comment`/`Thread` (owned by
+`@wafflebase/sheets`), the Yorkie schema, and every `CommentStore`. The token
+is opaque text to all of them. Embedding `userId` (not just `@username`) keeps
+rendering stable across username changes/duplicates without a lookup.
+
+**Apply:** When adding rich content to a CRDT-backed plain-text field, prefer
+an inline, self-describing token over a parallel structured field or a body
+type change — it keeps the change in the presentation layer.
+
+## Frontend tests live in `tests/`, not next to source
+
+The frontend vitest `include` is `["tests/**/*.test.ts", "tests/**/*.test.tsx"]`
+(`vite.config.ts`). A `*.test.ts` placed next to source under `src/` is
+silently **not run**. Mirror the source path under `tests/` and import via
+`../../../src/...` with explicit `.ts` extensions (matching the package's
+import style). A stray `src/.../theme-fonts.test.ts` exists but is dead.
+
+## React onChange in jsdom needs the prototype value setter
+
+Simulating typing with `textarea.value = "x"; dispatch('input')` does **not**
+fire React's synthetic `onChange`: React patches the element's own `value`
+setter to track changes, so the assignment updates the tracker and the event
+is deduped away. Use the prototype setter to bypass the instance patch:
+
+```ts
+const set = Object.getOwnPropertyDescriptor(
+  HTMLTextAreaElement.prototype, "value",
+)!.set!;
+set.call(ta, value); ta.dispatchEvent(new Event("input", { bubbles: true }));
+```
+
+(The repo's `font-size-picker.test.ts` happened to pass with plain assignment
+for an `<input>`, but it's unreliable — the prototype-setter form is correct.)
+
+## Tokenize-on-submit needs the inverse path for edit entry (review catch)
+
+The blocking bug the self-review found: tokenize-on-submit (approach B) only
+handled *new* text. Editing an existing comment fed the stored tokenized body
+straight into the textarea, so the user saw raw `@[kim](u1)` and — because the
+edit composer's mention map started empty — `applySelectedMentions` dropped
+every mention on save. Fix: de-tokenize `initialBody` for display
+(`mentionBodyToPlainText`) **and** seed the mention map from its tokens
+(`parseMentionBody`), then always replay the map on submit (lossless even when
+the member list never loaded).
+
+**Apply:** Any "serialize on submit" input has a symmetric "deserialize +
+seed on entry" obligation. Build and test the round-trip (entry → unchanged
+save) as one unit, not just the forward direction.
+
+## Match boundary regex to the actual identifier charset
+
+Usernames are GitHub logins (`profile.username`), i.e. ASCII `[A-Za-z0-9-]`.
+That makes `@kim(?![A-Za-z0-9-])` exactly right: a following space, comma, or
+CJK particle ends the mention; only another login char (`@kimchi`) blocks it.
+The review's "CJK username eats the next word" concern doesn't apply because
+display names aren't the username. The leading trigger boundary was widened to
+`[^A-Za-z0-9-]` so `안녕@kim` (no space, common in CJK input) opens the
+dropdown while `email@host` stays excluded.
+
+**Apply:** Before picking `\w`/`\s`/custom classes for an identifier boundary,
+pin down the identifier's real charset at its source. Don't infer it from
+illustrative test fixtures (ours used `김철수` as a *display* example).
+
+## Share the query cache key, don't invent a parallel one
+
+`useWorkspaceMembers` first used `["workspace", id, "members"]` — a second
+cache entry for the same `fetchWorkspace(id)` the app already caches under
+`["workspaces", id]`. Reusing the canonical key shares the fetch and
+invalidations. Grep existing `queryKey`s before adding a query for an endpoint
+that's already fetched elsewhere.

--- a/docs/tasks/active/20260621-comments-mentions-todo.md
+++ b/docs/tasks/active/20260621-comments-mentions-todo.md
@@ -27,25 +27,31 @@ Scope decisions (locked in brainstorming):
 - [x] `mentions.test.ts` — round-trip, `@[` in prose, names with `]`/`)`,
   adjacent mentions, start/end, empty body. 14 tests pass.
 
-### 2. Member source — `useWorkspaceMembers(workspaceId)`
-- [ ] Hook reading `GET /workspaces/:id` → `{userId, username, photo}[]`.
-  Confirm where the existing workspace fetch lives; reuse it (don't add a
-  duplicate request) if one already caches the workspace.
-- [ ] Thread the member list from each consumer controller (docs + sheets)
-  into `CommentComposer` as a prop. Anonymous/share-link → empty list.
+### 2. Member source — `useWorkspaceMembers(workspaceId)` ✅
+- [x] Hook reading `GET /workspaces/:id` (existing `fetchWorkspace`) →
+  `{userId, username, photo}[]` via tanstack `useQuery` (5-min staleTime,
+  shared cache key). No new request type / endpoint.
+- [x] Threaded members from the views (docs: `docs-detail` → `DocsView` new
+  `workspaceId` prop → popover + new-thread composer; sheets: `sheet-view`
+  already had `workspaceId` → `CommentPopover`) into `CommentComposer`.
+  Anonymous/share-link (`shared-document`, read-only) → empty list, dropdown
+  disabled, existing chips still render.
 
-### 3. Input — `MentionTextarea` in `CommentComposer`
-- [ ] `@`-trigger detection (start-of-text or whitespace before `@`).
-- [ ] Member dropdown anchored at caret; reuse `AuthorAvatar`; username
-  case-insensitive match.
-- [ ] Keyboard ↑/↓/Enter/Tab/Esc intercepted **only when open**; existing
-  Cmd/Ctrl+Enter submit + Esc-cancel preserved when closed.
-- [ ] Mention map records `{matchedText, userId, username}` on select;
-  textarea shows clean `@username `.
-- [ ] On submit, rewrite still-matching `@username` → token; drop edited
-  ones to plain text.
-- [ ] IME: suppress trigger/keys during composition
-  (`compositionstart`/`compositionend`).
+### 3. Input — mention autocomplete in `CommentComposer` ✅
+- [x] `@`-trigger detection via `detectMentionQuery` (start-of-text or
+  whitespace before `@`; stops at whitespace; ignores `email@host`).
+- [x] Member dropdown (`role=listbox`/`option`) reusing `AuthorAvatar`;
+  username case-insensitive substring match, capped at 8.
+- [x] Keyboard ↑/↓/Enter/Tab/Esc intercepted **only when open**;
+  Cmd/Ctrl+Enter submit + Esc-cancel preserved (Cmd+Enter falls through
+  even with dropdown open).
+- [x] Mention map (`selectedRef`) records `{userId, username}` on select;
+  textarea shows clean `@username `; `onMouseDown` keeps focus.
+- [x] On submit, `applySelectedMentions` rewrites still-matching
+  `@username` → token (longest-first, boundary lookahead); edited mentions
+  drop to plain text.
+- [x] IME: `compositionstart`/`compositionend` suppress trigger/keys.
+- [x] 27 helper unit tests + 5 composer interaction tests pass.
 
 ### 4. Render — `CommentBody` in `CommentThreadCard` ✅
 - [x] Replace plain-text body output with `CommentBody`.

--- a/docs/tasks/active/20260621-comments-mentions-todo.md
+++ b/docs/tasks/active/20260621-comments-mentions-todo.md
@@ -1,0 +1,73 @@
+# Comment Mentions — Todo
+
+Implements `@user` mentions in comments (mention-only; notifications
+deferred). Design: `docs/design/comments-mentions.md`. Continuation of the
+`docs-comments-followup` roadmap Step 4 (the `+ notifications` half stays
+deferred).
+
+Scope decisions (locked in brainstorming):
+
+- Mention-only: input + storage + render. No notification infra.
+- Storage: inline `@[username](userId)` token in the existing plain-string
+  `Comment.body`. No CRDT/type change.
+- Tokenize on submit (approach B) + view-local mention map; manual edit of a
+  mention drops it to plain text gracefully.
+- Mentionable set = workspace members via existing `GET /workspaces/:id`
+  (no new backend).
+- Chip click = no-op for now; hover tooltip shows username + photo.
+- Lands in the shared module → sheets + docs both get it; slides inherits.
+
+## Tasks
+
+### 1. Pure helpers — `components/comments/mentions.ts`
+- [ ] `parseMentionBody(body): BodySegment[]` (text / mention segments).
+- [ ] `serializeMention({userId, username})` → `@[username](userId)`;
+  strip `]` from username and `)` from userId.
+- [ ] `extractMentionedUserIds(body): string[]` (future notification hook).
+- [ ] `mentions.test.ts` — round-trip, `@[` in prose, names with `]`/`)`,
+  adjacent mentions, start/end, empty body.
+
+### 2. Member source — `useWorkspaceMembers(workspaceId)`
+- [ ] Hook reading `GET /workspaces/:id` → `{userId, username, photo}[]`.
+  Confirm where the existing workspace fetch lives; reuse it (don't add a
+  duplicate request) if one already caches the workspace.
+- [ ] Thread the member list from each consumer controller (docs + sheets)
+  into `CommentComposer` as a prop. Anonymous/share-link → empty list.
+
+### 3. Input — `MentionTextarea` in `CommentComposer`
+- [ ] `@`-trigger detection (start-of-text or whitespace before `@`).
+- [ ] Member dropdown anchored at caret; reuse `AuthorAvatar`; username
+  case-insensitive match.
+- [ ] Keyboard ↑/↓/Enter/Tab/Esc intercepted **only when open**; existing
+  Cmd/Ctrl+Enter submit + Esc-cancel preserved when closed.
+- [ ] Mention map records `{matchedText, userId, username}` on select;
+  textarea shows clean `@username `.
+- [ ] On submit, rewrite still-matching `@username` → token; drop edited
+  ones to plain text.
+- [ ] IME: suppress trigger/keys during composition
+  (`compositionstart`/`compositionend`).
+
+### 4. Render — `CommentBody` in `CommentThreadCard`
+- [ ] Replace plain-text body output with `CommentBody`.
+- [ ] Text segments verbatim (whitespace/newlines preserved).
+- [ ] Mention chip: blue, hover tooltip (username + photo), click no-op.
+- [ ] Used by both sheets + docs thread cards.
+
+### 5. Tests + verification
+- [ ] Composer interaction test (`.test.ts` + `IS_REACT_ACT_ENVIRONMENT`):
+  `@` opens dropdown, filter, keyboard select, tokenized submit, edit→drop.
+- [ ] `CommentBody` render test (chips + plain text).
+- [ ] `pnpm verify:fast` green.
+- [ ] Manual smoke in `pnpm dev`: mention in docs + sheets comment, Korean
+  IME path, chip render + tooltip.
+
+### 6. Wrap-up
+- [ ] Self code-review over full branch diff (`/code-review`); apply
+  blocking findings.
+- [ ] Capture lessons in `20260621-comments-mentions-lessons.md`.
+- [ ] `pnpm tasks:archive && pnpm tasks:index`; PR (Summary + Test plan).
+
+## Out of scope (tracked elsewhere)
+- Notifications (in-app + email) — `docs-comments-followup` Step 4 remainder.
+- Slides comments (mentions inherited once they exist).
+- Mentioning non-members / mention-to-share.

--- a/docs/tasks/active/20260621-comments-mentions-todo.md
+++ b/docs/tasks/active/20260621-comments-mentions-todo.md
@@ -19,13 +19,13 @@ Scope decisions (locked in brainstorming):
 
 ## Tasks
 
-### 1. Pure helpers — `components/comments/mentions.ts`
-- [ ] `parseMentionBody(body): BodySegment[]` (text / mention segments).
-- [ ] `serializeMention({userId, username})` → `@[username](userId)`;
+### 1. Pure helpers — `components/comments/mentions.ts` ✅
+- [x] `parseMentionBody(body): BodySegment[]` (text / mention segments).
+- [x] `serializeMention({userId, username})` → `@[username](userId)`;
   strip `]` from username and `)` from userId.
-- [ ] `extractMentionedUserIds(body): string[]` (future notification hook).
-- [ ] `mentions.test.ts` — round-trip, `@[` in prose, names with `]`/`)`,
-  adjacent mentions, start/end, empty body.
+- [x] `extractMentionedUserIds(body): string[]` (future notification hook).
+- [x] `mentions.test.ts` — round-trip, `@[` in prose, names with `]`/`)`,
+  adjacent mentions, start/end, empty body. 14 tests pass.
 
 ### 2. Member source — `useWorkspaceMembers(workspaceId)`
 - [ ] Hook reading `GET /workspaces/:id` → `{userId, username, photo}[]`.
@@ -47,11 +47,15 @@ Scope decisions (locked in brainstorming):
 - [ ] IME: suppress trigger/keys during composition
   (`compositionstart`/`compositionend`).
 
-### 4. Render — `CommentBody` in `CommentThreadCard`
-- [ ] Replace plain-text body output with `CommentBody`.
-- [ ] Text segments verbatim (whitespace/newlines preserved).
-- [ ] Mention chip: blue, hover tooltip (username + photo), click no-op.
-- [ ] Used by both sheets + docs thread cards.
+### 4. Render — `CommentBody` in `CommentThreadCard` ✅
+- [x] Replace plain-text body output with `CommentBody`.
+- [x] Text segments verbatim (whitespace/newlines preserved).
+- [x] Mention chip: blue, `title` tooltip (username), click no-op. Photo
+  enrichment deferred (token carries username+userId only; parse-only
+  render works for anonymous viewers).
+- [x] Used by both sheets + docs thread cards (shared component).
+- [x] Side-panel snippet + OrphanedCard preview use `mentionBodyToPlainText`
+  so the raw token never leaks into truncated previews.
 
 ### 5. Tests + verification
 - [ ] Composer interaction test (`.test.ts` + `IS_REACT_ACT_ENVIRONMENT`):

--- a/docs/tasks/active/20260621-comments-mentions-todo.md
+++ b/docs/tasks/active/20260621-comments-mentions-todo.md
@@ -64,18 +64,37 @@ Scope decisions (locked in brainstorming):
   so the raw token never leaks into truncated previews.
 
 ### 5. Tests + verification
-- [ ] Composer interaction test (`.test.ts` + `IS_REACT_ACT_ENVIRONMENT`):
-  `@` opens dropdown, filter, keyboard select, tokenized submit, edit→drop.
-- [ ] `CommentBody` render test (chips + plain text).
-- [ ] `pnpm verify:fast` green.
+- [x] Composer interaction test (`.test.ts` + `IS_REACT_ACT_ENVIRONMENT`):
+  `@` opens dropdown, filter, keyboard select, tokenized submit, edit→drop,
+  edit-entry round-trip.
+- [x] `CommentBody` render test (chips + plain text).
+- [x] `pnpm verify:fast` green (EXIT=0 across all lanes).
 - [ ] Manual smoke in `pnpm dev`: mention in docs + sheets comment, Korean
-  IME path, chip render + tooltip.
+  IME path, chip render + tooltip. **(pending — needs running app)**
 
 ### 6. Wrap-up
-- [ ] Self code-review over full branch diff (`/code-review`); apply
-  blocking findings.
-- [ ] Capture lessons in `20260621-comments-mentions-lessons.md`.
+- [x] Self code-review over full branch diff (subagent). Findings applied:
+  edit round-trip (blocking), CJK trigger boundary, shared query cache.
+  Reviewer #2 (CJK-username boundary) confirmed non-issue — usernames are
+  ASCII GitHub logins.
+- [x] Capture lessons in `20260621-comments-mentions-lessons.md`.
 - [ ] `pnpm tasks:archive && pnpm tasks:index`; PR (Summary + Test plan).
+  **(pending — after manual smoke + user go-ahead)**
+
+## Review
+
+Shipped mention-only (input + storage + render) across the shared comments
+module, live for sheets + docs (slides inherits when its comments land).
+Commits on `feat/comments-mentions`:
+
+1. `mentions.ts` token helpers + design/task docs.
+2. `CommentBody` chip render + `mentionBodyToPlainText` previews.
+3. `@` autocomplete composer + `useWorkspaceMembers` + view wiring.
+4. Self-review fixes (edit round-trip, CJK trigger, shared cache).
+
+No CRDT/`@wafflebase/*` type change. 59 comments tests; `verify:fast` green.
+Deferred: notifications (Step 4 remainder), photo-in-chip tooltip, the
+docs-comments visual harness scenarios (separate todo).
 
 ## Out of scope (tracked elsewhere)
 - Notifications (in-app + email) — `docs-comments-followup` Step 4 remainder.

--- a/packages/frontend/src/app/docs/comments/DocsCommentPopover.tsx
+++ b/packages/frontend/src/app/docs/comments/DocsCommentPopover.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { CommentThreadCard } from "@/components/comments/components/CommentThreadCard";
+import type { MentionMember } from "@/components/comments/components/CommentComposer";
 import type {
   CommentAuthor,
   DocsRangeAnchor,
@@ -12,6 +13,7 @@ type Props = {
   anchorRect: { x: number; y: number };
   currentUser?: CommentAuthor;
   readOnly?: boolean;
+  members?: MentionMember[];
   onReply: (body: string) => Promise<void> | void;
   onResolveToggle: () => Promise<void> | void;
   onEdit: (commentId: string, body: string) => Promise<void> | void;
@@ -33,6 +35,7 @@ export function DocsCommentPopover({
   anchorRect,
   currentUser,
   readOnly,
+  members,
   onReply,
   onResolveToggle,
   onEdit,
@@ -100,6 +103,7 @@ export function DocsCommentPopover({
           currentUserId={currentUser?.userId}
           readOnly={readOnly}
           autoFocusReply
+          members={members}
           onReply={onReply}
           onResolveToggle={onResolveToggle}
           onEdit={onEdit}

--- a/packages/frontend/src/app/docs/docs-detail.tsx
+++ b/packages/frontend/src/app/docs/docs-detail.tsx
@@ -216,6 +216,7 @@ function DocsLayout({ documentId }: { documentId: string }) {
             onEditorReady={setEditor}
             onJumpHandleReady={setJumpHandle}
             documentId={documentId}
+            workspaceId={documentData?.workspaceId}
             commentsPanelOpen={commentsPanelOpen}
             onCommentsPanelOpenChange={setCommentsPanelOpen}
           />

--- a/packages/frontend/src/app/docs/docs-view.tsx
+++ b/packages/frontend/src/app/docs/docs-view.tsx
@@ -16,6 +16,7 @@ import { fetchMeOptional } from "@/api/auth";
 import { Button } from "@/components/ui/button";
 import { CommentComposer } from "@/components/comments/components/CommentComposer";
 import { CommentSidePanel } from "@/components/comments/components/CommentSidePanel";
+import { useWorkspaceMembers } from "@/components/comments/use-workspace-members";
 import { OrphanedCard } from "@/components/comments/components/OrphanedCard";
 import { YorkieDocStore } from "./yorkie-doc-store";
 import { useGoogleFontsLink } from "@/components/text-formatting/font-catalog";
@@ -115,6 +116,12 @@ interface DocsViewProps {
    * the editor finishes mounting.
    */
   documentId?: string;
+  /**
+   * Workspace owning this document. Sources the `@` mention member list for
+   * the comment composers. Omitted on anonymous share-link mounts, which
+   * disables the mention dropdown (existing chips still render).
+   */
+  workspaceId?: string;
 }
 
 /**
@@ -131,6 +138,7 @@ export function DocsView({
   commentsPanelOpen,
   onCommentsPanelOpenChange,
   documentId,
+  workspaceId,
 }: DocsViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   // State-mirrored handle on the same DOM node, so effects that depend
@@ -169,6 +177,7 @@ export function DocsView({
       photo: me.photo || undefined,
     };
   }, [me]);
+  const mentionMembers = useWorkspaceMembers(workspaceId);
 
   const comments = useDocsComments({
     doc: doc ?? null,
@@ -590,6 +599,7 @@ export function DocsView({
           anchorRect={comments.active.anchorRect}
           currentUser={currentUser ?? undefined}
           readOnly={readOnly}
+          members={mentionMembers}
           onReply={(body) => comments.reply(comments.active!.thread.id, body)}
           onResolveToggle={() => comments.toggleResolved(comments.active!.thread)}
           onEdit={(commentId, body) =>
@@ -611,6 +621,7 @@ export function DocsView({
           <CommentComposer
             submitLabel="Comment"
             autoFocus
+            members={mentionMembers}
             onSubmit={comments.submitNewComment}
             onCancel={comments.closeCompose}
             disabled={!currentUser}

--- a/packages/frontend/src/app/spreadsheet/components/comments/CommentPopover.tsx
+++ b/packages/frontend/src/app/spreadsheet/components/comments/CommentPopover.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef } from "react";
 
-import { CommentComposer } from "@/components/comments/components/CommentComposer";
+import {
+  CommentComposer,
+  type MentionMember,
+} from "@/components/comments/components/CommentComposer";
 import { CommentThreadCard } from "@/components/comments/components/CommentThreadCard";
 import type { CommentAuthor } from "@/types/comments";
 import type { Thread } from "@wafflebase/sheets";
@@ -8,6 +11,7 @@ import type { Thread } from "@wafflebase/sheets";
 type Props = {
   threads: Thread[];
   currentUser: CommentAuthor | null;
+  members?: MentionMember[];
   onAddThread: (body: string) => Promise<void>;
   onReply: (threadId: string, body: string) => Promise<void>;
   onResolve: (threadId: string) => Promise<void>;
@@ -32,6 +36,7 @@ type Props = {
 export function CommentPopover({
   threads,
   currentUser,
+  members,
   onAddThread,
   onReply,
   onResolve,
@@ -88,6 +93,7 @@ export function CommentPopover({
             currentUserId={currentUser?.userId}
             readOnly={isReadOnly}
             autoFocusReply={threadIdx === 0}
+            members={members}
             onReply={(body) => onReply(thread.id, body)}
             onResolveToggle={() => onResolve(thread.id)}
             onEdit={(commentId, body) => onEditComment(thread.id, commentId, body)}
@@ -101,6 +107,7 @@ export function CommentPopover({
           submitLabel="Comment"
           onSubmit={(body) => onAddThread(body)}
           autoFocus
+          members={members}
         />
       )}
 

--- a/packages/frontend/src/app/spreadsheet/sheet-view.tsx
+++ b/packages/frontend/src/app/spreadsheet/sheet-view.tsx
@@ -45,6 +45,7 @@ import { FindBar } from "@/components/find-bar";
 import { toast } from "sonner";
 import { getDefaultChartColumns } from "./chart-utils";
 import { CommentPopover } from "./components/comments/CommentPopover";
+import { useWorkspaceMembers } from "@/components/comments/use-workspace-members";
 import { copyThread } from "./yorkie-worksheet-comments";
 import { SheetsShortcutsHelp } from "./sheets-shortcuts-help";
 
@@ -168,6 +169,7 @@ export function SheetView({
         : null,
     [currentUserData],
   );
+  const mentionMembers = useWorkspaceMembers(workspaceId);
   const [paintFormatActive, setPaintFormatActive] = useState(false);
   const [paintFormatSourceRef, setPaintFormatSourceRef] = useState<Ref | null>(
     null,
@@ -1581,6 +1583,7 @@ export function SheetView({
             <CommentPopover
               threads={activeCellThreads}
               currentUser={commentAuthor}
+              members={mentionMembers}
               onAddThread={handleCommentAddThread}
               onReply={handleCommentReply}
               onResolve={handleCommentResolve}

--- a/packages/frontend/src/components/comments/components/CommentBody.tsx
+++ b/packages/frontend/src/components/comments/components/CommentBody.tsx
@@ -1,0 +1,38 @@
+import { Fragment } from "react";
+
+import { parseMentionBody } from "../mentions.ts";
+
+type Props = {
+  body: string;
+};
+
+/**
+ * Render a comment body, turning inline `@[username](userId)` tokens into
+ * mention chips while leaving the surrounding text intact (whitespace and
+ * newlines preserved via `whitespace-pre-wrap`). Parse-only: it needs no
+ * member list, so existing mentions render even for anonymous viewers.
+ *
+ * The chip's `title` shows the username; click is a no-op for now, leaving
+ * room for a profile/jump action when mention notifications land.
+ */
+export function CommentBody({ body }: Props) {
+  const segments = parseMentionBody(body);
+  return (
+    <p className="whitespace-pre-wrap text-xs text-foreground">
+      {segments.map((segment, i) =>
+        segment.type === "text" ? (
+          <Fragment key={i}>{segment.value}</Fragment>
+        ) : (
+          <span
+            key={i}
+            data-mention-user-id={segment.userId}
+            title={segment.username}
+            className="rounded-sm bg-primary/10 px-0.5 font-medium text-primary"
+          >
+            @{segment.username}
+          </span>
+        ),
+      )}
+    </p>
+  );
+}

--- a/packages/frontend/src/components/comments/components/CommentComposer.tsx
+++ b/packages/frontend/src/components/comments/components/CommentComposer.tsx
@@ -1,8 +1,30 @@
-import { useEffect, useLayoutEffect, useRef, useState, KeyboardEvent } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from "react";
 
 import { Button } from "@/components/ui/button";
 
+import {
+  applySelectedMentions,
+  detectMentionQuery,
+  type MentionRef,
+} from "../mentions.ts";
+import { AuthorAvatar } from "./AuthorAvatar";
+
 const MAX_TEXTAREA_HEIGHT_PX = 200;
+const MAX_MENTION_RESULTS = 8;
+
+/** A workspace member offered in the `@` mention autocomplete. */
+export type MentionMember = {
+  userId: string;
+  username: string;
+  photo?: string;
+};
 
 type CommentComposerProps = {
   initialBody?: string;
@@ -17,15 +39,28 @@ type CommentComposerProps = {
    * matches the comment body font size for visual continuity.
    */
   compact?: boolean;
+  /**
+   * Workspace members offered in the `@` mention autocomplete. When omitted
+   * (or empty), mentions are disabled and the composer behaves as a plain
+   * textarea — existing mention tokens still render fine elsewhere.
+   */
+  members?: MentionMember[];
 };
 
 /**
- * Plain-text comment input form with submit/cancel actions. Used for
- * new threads and replies, by any consumer (docs, sheets, slides).
+ * Plain-text comment input form with submit/cancel actions and optional
+ * `@user` mention autocomplete. Used for new threads and replies, by any
+ * consumer (docs, sheets, slides).
  *
  * Keyboard:
  * - Cmd/Ctrl+Enter: submit
  * - Escape: cancel (only when onCancel is provided)
+ * - When the mention dropdown is open: ↑/↓ move, Enter/Tab select, Esc closes
+ *
+ * Mentions are tokenized on submit (approach B): the textarea shows clean
+ * `@username` text; `serializeMention` runs over the selected mentions just
+ * before `onSubmit`, so the body handed up already contains
+ * `@[username](userId)` tokens and every store works unchanged.
  */
 export function CommentComposer({
   initialBody = "",
@@ -35,10 +70,34 @@ export function CommentComposer({
   disabled = false,
   autoFocus = false,
   compact = false,
+  members,
 }: CommentComposerProps) {
   const [body, setBody] = useState(initialBody);
   const trimmed = body.trim();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Mention autocomplete state. `selectedRef` is the mention map (approach B):
+  // username -> chosen ref, accumulated as the user picks members and replayed
+  // at submit. It is view-local and never needs to trigger a render.
+  const mentionsEnabled = !!members && members.length > 0;
+  const [mentionQuery, setMentionQuery] = useState<{
+    query: string;
+    start: number;
+  } | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const selectedRef = useRef<MentionRef[]>([]);
+  const composingRef = useRef(false);
+
+  const filteredMembers =
+    mentionsEnabled && mentionQuery
+      ? members!
+          .filter((m) =>
+            m.username.toLowerCase().includes(mentionQuery.query.toLowerCase()),
+          )
+          .slice(0, MAX_MENTION_RESULTS)
+      : [];
+  const dropdownOpen = mentionQuery !== null && filteredMembers.length > 0;
+  const safeIndex = Math.min(activeIndex, filteredMembers.length - 1);
 
   // Auto-grow the textarea. Reset to "auto" first so scrollHeight reflects
   // current content (otherwise the height never shrinks when lines are
@@ -80,12 +139,56 @@ export function CommentComposer({
 
   const [submitting, setSubmitting] = useState(false);
 
+  const refreshMentionQuery = (value: string, caret: number) => {
+    if (!mentionsEnabled || composingRef.current) {
+      setMentionQuery(null);
+      return;
+    }
+    setMentionQuery(detectMentionQuery(value, caret));
+    setActiveIndex(0);
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    setBody(value);
+    refreshMentionQuery(value, e.target.selectionStart ?? value.length);
+  };
+
+  const selectMember = (member: MentionMember) => {
+    const ta = textareaRef.current;
+    if (!ta || !mentionQuery) return;
+    const value = ta.value;
+    const queryEnd = mentionQuery.start + 1 + mentionQuery.query.length;
+    const before = value.slice(0, mentionQuery.start);
+    const after = value.slice(queryEnd);
+    const insertion = `@${member.username} `;
+    const newValue = before + insertion + after;
+    setBody(newValue);
+    if (!selectedRef.current.some((m) => m.username === member.username)) {
+      selectedRef.current.push({
+        userId: member.userId,
+        username: member.username,
+      });
+    }
+    setMentionQuery(null);
+    const caret = before.length + insertion.length;
+    requestAnimationFrame(() => {
+      ta.focus();
+      ta.setSelectionRange(caret, caret);
+    });
+  };
+
   const submit = async () => {
     if (!trimmed || submitting) return;
     setSubmitting(true);
     try {
-      await onSubmit(trimmed);
+      const finalBody = mentionsEnabled
+        ? applySelectedMentions(body, selectedRef.current).trim()
+        : trimmed;
+      await onSubmit(finalBody);
       setBody("");
+      selectedRef.current = [];
+      setMentionQuery(null);
     } catch (err) {
       console.error("Failed to submit comment:", err);
     } finally {
@@ -94,6 +197,31 @@ export function CommentComposer({
   };
 
   const handleKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (dropdownOpen && !composingRef.current) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % filteredMembers.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex(
+          (i) => (i - 1 + filteredMembers.length) % filteredMembers.length,
+        );
+        return;
+      }
+      if (e.key === "Tab" || (e.key === "Enter" && !(e.metaKey || e.ctrlKey))) {
+        e.preventDefault();
+        selectMember(filteredMembers[safeIndex]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setMentionQuery(null);
+        return;
+      }
+    }
+
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       void submit();
@@ -109,19 +237,61 @@ export function CommentComposer({
 
   return (
     <div className={compact ? "flex flex-col gap-1.5" : "flex flex-col gap-3"}>
-      <textarea
-        ref={textareaRef}
-        value={body}
-        onChange={(e) => setBody(e.target.value)}
-        onKeyDown={handleKey}
-        disabled={disabled}
-        rows={compact ? 1 : 3}
-        placeholder={
-          disabled ? "Sign in to leave a comment." : "Add a comment..."
-        }
-        aria-label="Comment body"
-        className={textareaClass}
-      />
+      <div className="relative">
+        <textarea
+          ref={textareaRef}
+          value={body}
+          onChange={handleChange}
+          onKeyDown={handleKey}
+          onCompositionStart={() => {
+            composingRef.current = true;
+            setMentionQuery(null);
+          }}
+          onCompositionEnd={(e) => {
+            composingRef.current = false;
+            refreshMentionQuery(
+              e.currentTarget.value,
+              e.currentTarget.selectionStart ?? e.currentTarget.value.length,
+            );
+          }}
+          disabled={disabled}
+          rows={compact ? 1 : 3}
+          placeholder={
+            disabled ? "Sign in to leave a comment." : "Add a comment..."
+          }
+          aria-label="Comment body"
+          className={textareaClass}
+        />
+        {dropdownOpen && (
+          <ul
+            role="listbox"
+            aria-label="Mention suggestions"
+            className="absolute left-0 top-full z-50 mt-1 max-h-48 w-56 overflow-auto rounded-md border bg-popover p-1 shadow-md"
+          >
+            {filteredMembers.map((m, i) => (
+              <li key={m.userId}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={i === safeIndex}
+                  // onMouseDown (not onClick) so the textarea keeps focus and
+                  // the selection range stays valid through the insertion.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    selectMember(m);
+                  }}
+                  className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs ${
+                    i === safeIndex ? "bg-accent" : "hover:bg-accent"
+                  }`}
+                >
+                  <AuthorAvatar author={m} size="md" />
+                  <span className="truncate">{m.username}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
       {(!compact || trimmed.length > 0) && (
         <div className="flex justify-end gap-2">
           {onCancel && (

--- a/packages/frontend/src/components/comments/components/CommentComposer.tsx
+++ b/packages/frontend/src/components/comments/components/CommentComposer.tsx
@@ -12,9 +12,18 @@ import { Button } from "@/components/ui/button";
 import {
   applySelectedMentions,
   detectMentionQuery,
+  mentionBodyToPlainText,
+  parseMentionBody,
   type MentionRef,
 } from "../mentions.ts";
 import { AuthorAvatar } from "./AuthorAvatar";
+
+/** Seed the mention map from an existing tokenized body (edit entry). */
+function seedMentions(body: string): MentionRef[] {
+  return parseMentionBody(body).flatMap((s) =>
+    s.type === "mention" ? [{ userId: s.userId, username: s.username }] : [],
+  );
+}
 
 const MAX_TEXTAREA_HEIGHT_PX = 200;
 const MAX_MENTION_RESULTS = 8;
@@ -72,7 +81,11 @@ export function CommentComposer({
   compact = false,
   members,
 }: CommentComposerProps) {
-  const [body, setBody] = useState(initialBody);
+  // The textarea shows de-tokenized text (`@username`); the stored body's
+  // `@[username](userId)` tokens are re-applied on submit. On edit entry we
+  // also seed the mention map from the existing tokens so an untouched save
+  // round-trips them losslessly (and a touched one drops only what changed).
+  const [body, setBody] = useState(() => mentionBodyToPlainText(initialBody));
   const trimmed = body.trim();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -85,7 +98,7 @@ export function CommentComposer({
     start: number;
   } | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
-  const selectedRef = useRef<MentionRef[]>([]);
+  const selectedRef = useRef<MentionRef[]>(seedMentions(initialBody));
   const composingRef = useRef(false);
 
   const filteredMembers =
@@ -182,9 +195,10 @@ export function CommentComposer({
     if (!trimmed || submitting) return;
     setSubmitting(true);
     try {
-      const finalBody = mentionsEnabled
-        ? applySelectedMentions(body, selectedRef.current).trim()
-        : trimmed;
+      // Always replay the mention map (empty for plain new comments), so an
+      // edited comment keeps its tokens even when the member list never
+      // loaded (e.g. mentions disabled for this session).
+      const finalBody = applySelectedMentions(body, selectedRef.current).trim();
       await onSubmit(finalBody);
       setBody("");
       selectedRef.current = [];

--- a/packages/frontend/src/components/comments/components/CommentSidePanel.tsx
+++ b/packages/frontend/src/components/comments/components/CommentSidePanel.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { formatRelativeTime } from "@/lib/utils";
 import type { CommentAnchor, Thread } from "@/types/comments";
 
+import { mentionBodyToPlainText } from "../mentions.ts";
 import { AuthorAvatar } from "./AuthorAvatar";
 
 type Props<A extends CommentAnchor> = {
@@ -107,7 +108,7 @@ export function CommentSidePanel<A extends CommentAnchor>({
                     </time>
                   </div>
                   <p className="line-clamp-2 text-xs text-muted-foreground">
-                    {root.body.split("\n")[0].slice(0, 80)}
+                    {mentionBodyToPlainText(root.body).split("\n")[0].slice(0, 80)}
                   </p>
                   {renderAnchorLabel && (
                     <div className="text-[10px] text-muted-foreground">

--- a/packages/frontend/src/components/comments/components/CommentThreadCard.tsx
+++ b/packages/frontend/src/components/comments/components/CommentThreadCard.tsx
@@ -18,6 +18,7 @@ import type {
 } from "@/types/comments";
 
 import { AuthorAvatar } from "./AuthorAvatar";
+import { CommentBody } from "./CommentBody";
 import { CommentComposer } from "./CommentComposer";
 
 type Props<A extends CommentAnchor> = {
@@ -164,7 +165,7 @@ export function CommentThreadCard<A extends CommentAnchor>({
             onCancel={() => setEditingCommentId(null)}
           />
         ) : (
-          <p className="whitespace-pre-wrap text-xs text-foreground">{c.body}</p>
+          <CommentBody body={c.body} />
         )}
       </div>
     );

--- a/packages/frontend/src/components/comments/components/CommentThreadCard.tsx
+++ b/packages/frontend/src/components/comments/components/CommentThreadCard.tsx
@@ -19,7 +19,7 @@ import type {
 
 import { AuthorAvatar } from "./AuthorAvatar";
 import { CommentBody } from "./CommentBody";
-import { CommentComposer } from "./CommentComposer";
+import { CommentComposer, type MentionMember } from "./CommentComposer";
 
 type Props<A extends CommentAnchor> = {
   thread: Thread<A>;
@@ -28,6 +28,8 @@ type Props<A extends CommentAnchor> = {
   readOnly?: boolean;
   /** Autofocus the inline reply composer on mount. */
   autoFocusReply?: boolean;
+  /** Workspace members for the reply/edit composers' @ mention dropdown. */
+  members?: MentionMember[];
   onReply: (body: string) => Promise<void> | void;
   onResolveToggle: () => Promise<void> | void;
   onEdit: (commentId: string, body: string) => Promise<void> | void;
@@ -49,6 +51,7 @@ export function CommentThreadCard<A extends CommentAnchor>({
   currentUserId,
   readOnly = false,
   autoFocusReply = false,
+  members,
   onReply,
   onResolveToggle,
   onEdit,
@@ -158,6 +161,7 @@ export function CommentThreadCard<A extends CommentAnchor>({
             submitLabel="Save"
             autoFocus
             compact
+            members={members}
             onSubmit={async (body) => {
               await onEdit(c.id, body);
               setEditingCommentId(null);
@@ -188,6 +192,7 @@ export function CommentThreadCard<A extends CommentAnchor>({
             onSubmit={onReply}
             compact
             autoFocus={autoFocusReply}
+            members={members}
           />
         </div>
       )}

--- a/packages/frontend/src/components/comments/components/OrphanedCard.tsx
+++ b/packages/frontend/src/components/comments/components/OrphanedCard.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { formatRelativeTime } from "@/lib/utils";
 import type { Comment } from "@/types/comments";
 
+import { mentionBodyToPlainText } from "../mentions.ts";
 import { AuthorAvatar } from "./AuthorAvatar";
 
 type Props = {
@@ -49,7 +50,9 @@ export function OrphanedCard({ quotedText, root, commentCount, trailing }: Props
           {quotedText}
         </blockquote>
       )}
-      <p className="line-clamp-2 text-xs text-foreground">{root.body}</p>
+      <p className="line-clamp-2 text-xs text-foreground">
+        {mentionBodyToPlainText(root.body)}
+      </p>
       {commentCount > 1 && (
         <span className="text-xs text-muted-foreground">
           {commentCount} comments

--- a/packages/frontend/src/components/comments/mentions.ts
+++ b/packages/frontend/src/components/comments/mentions.ts
@@ -57,9 +57,12 @@ export function parseMentionBody(body: string): BodySegment[] {
   return segments;
 }
 
-// A mention query continues until whitespace; the char before `@` must be
-// start-of-text or whitespace so `email@host` never triggers the dropdown.
-const MENTION_QUERY_RE = /(?:^|\s)@(\S*)$/;
+// A mention query runs after an `@` whose preceding char is start-of-text or
+// anything that is not a username character (`[A-Za-z0-9-]`). That excludes
+// `email@host` (preceded by a letter) while still triggering after CJK text
+// typed with no space (`안녕@kim`). The query itself excludes whitespace and
+// `@`, so the `$`-anchored match always picks the last in-progress mention.
+const MENTION_QUERY_RE = /(?:^|[^A-Za-z0-9-])@([^\s@]*)$/;
 
 /**
  * Inspect the text up to `caret` and return the in-progress mention query
@@ -88,7 +91,10 @@ function escapeRegExp(value: string): string {
  * usernames are processed first so a shorter one can't match inside a longer
  * one, and a trailing-boundary lookahead means an edited mention
  * (`@kim` → `@kimX`) is left as plain text rather than emitting a broken
- * token. GitHub usernames are unique, so keying by username is unambiguous.
+ * token. Usernames are GitHub logins (`[A-Za-z0-9-]`, unique), so keying by
+ * username is unambiguous and the boundary class matches the login charset —
+ * a following non-login char (space, punctuation, CJK particle) ends the
+ * mention cleanly.
  */
 export function applySelectedMentions(
   body: string,

--- a/packages/frontend/src/components/comments/mentions.ts
+++ b/packages/frontend/src/components/comments/mentions.ts
@@ -57,6 +57,59 @@ export function parseMentionBody(body: string): BodySegment[] {
   return segments;
 }
 
+// A mention query continues until whitespace; the char before `@` must be
+// start-of-text or whitespace so `email@host` never triggers the dropdown.
+const MENTION_QUERY_RE = /(?:^|\s)@(\S*)$/;
+
+/**
+ * Inspect the text up to `caret` and return the in-progress mention query
+ * (the run after an `@` at a word boundary), or `null` when the caret is not
+ * inside one. `start` is the index of the `@`.
+ */
+export function detectMentionQuery(
+  text: string,
+  caret: number,
+): { query: string; start: number } | null {
+  const before = text.slice(0, caret);
+  const match = MENTION_QUERY_RE.exec(before);
+  if (!match) return null;
+  const query = match[1];
+  return { query, start: caret - query.length - 1 };
+}
+
+const REGEX_SPECIALS = /[.*+?^${}()|[\]\\]/g;
+function escapeRegExp(value: string): string {
+  return value.replace(REGEX_SPECIALS, '\\$&');
+}
+
+/**
+ * Convert the plain `@username` text of *selected* mentions into
+ * `@[username](userId)` tokens (approach B — tokenize on submit). Longer
+ * usernames are processed first so a shorter one can't match inside a longer
+ * one, and a trailing-boundary lookahead means an edited mention
+ * (`@kim` → `@kimX`) is left as plain text rather than emitting a broken
+ * token. GitHub usernames are unique, so keying by username is unambiguous.
+ */
+export function applySelectedMentions(
+  body: string,
+  mentions: ReadonlyArray<MentionRef>,
+): string {
+  const byUsername = new Map<string, MentionRef>();
+  for (const m of mentions) byUsername.set(m.username, m);
+  const ordered = [...byUsername.values()].sort(
+    (a, b) => b.username.length - a.username.length,
+  );
+  let result = body;
+  for (const ref of ordered) {
+    const re = new RegExp(
+      `@${escapeRegExp(ref.username)}(?![A-Za-z0-9-])`,
+      'g',
+    );
+    result = result.replace(re, serializeMention(ref));
+  }
+  return result;
+}
+
 /**
  * Flatten a body to readable plain text, rendering each mention as
  * `@username`. For truncated previews (side-panel snippet) where chips

--- a/packages/frontend/src/components/comments/mentions.ts
+++ b/packages/frontend/src/components/comments/mentions.ts
@@ -58,6 +58,19 @@ export function parseMentionBody(body: string): BodySegment[] {
 }
 
 /**
+ * Flatten a body to readable plain text, rendering each mention as
+ * `@username`. For truncated previews (side-panel snippet) where chips
+ * cannot be shown but the raw token must not leak.
+ */
+export function mentionBodyToPlainText(body: string): string {
+  return parseMentionBody(body)
+    .map((segment) =>
+      segment.type === 'text' ? segment.value : `@${segment.username}`,
+    )
+    .join('');
+}
+
+/**
  * The userIds mentioned in a body, in first-seen order and de-duplicated.
  * Single integration point a future notification feature consumes.
  */

--- a/packages/frontend/src/components/comments/mentions.ts
+++ b/packages/frontend/src/components/comments/mentions.ts
@@ -1,0 +1,72 @@
+/**
+ * Mention encoding for comment bodies.
+ *
+ * A mention is stored inline in the plain-string `Comment.body` as a token:
+ *
+ *     @[username](userId)
+ *
+ * Embedding the `userId` keeps rendering stable across username changes and
+ * duplicates. The token is opaque text to every `CommentStore` and to the
+ * `@wafflebase/*` packages, so this feature needs no data-model change.
+ *
+ * Design: docs/design/comments-mentions.md
+ */
+
+export type MentionRef = { userId: string; username: string };
+
+export type BodySegment =
+  | { type: 'text'; value: string }
+  | { type: 'mention'; userId: string; username: string };
+
+// `username` is any run of characters except `]`; `userId` any run except `)`.
+// A literal `@[…](…)` only matches when both brackets close in order, so
+// stray `@[` or `@[name]` text is preserved verbatim by `parseMentionBody`.
+const MENTION_RE = /@\[([^\]]*)\]\(([^)]*)\)/g;
+
+/**
+ * Encode a mention as `@[username](userId)`. The username's `]` and the
+ * userId's `)` are stripped so the produced token can never be ambiguous to
+ * the parser.
+ */
+export function serializeMention({ userId, username }: MentionRef): string {
+  const safeUsername = username.replace(/\]/g, '');
+  const safeUserId = userId.replace(/\)/g, '');
+  return `@[${safeUsername}](${safeUserId})`;
+}
+
+/**
+ * Split a body into ordered text and mention segments. Adjacent mentions
+ * produce no empty text segment between them, and an empty body yields `[]`.
+ */
+export function parseMentionBody(body: string): BodySegment[] {
+  const segments: BodySegment[] = [];
+  let lastIndex = 0;
+  // Fresh lastIndex per call: MENTION_RE is a shared global-flagged regex.
+  MENTION_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = MENTION_RE.exec(body)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', value: body.slice(lastIndex, match.index) });
+    }
+    segments.push({ type: 'mention', username: match[1], userId: match[2] });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < body.length) {
+    segments.push({ type: 'text', value: body.slice(lastIndex) });
+  }
+  return segments;
+}
+
+/**
+ * The userIds mentioned in a body, in first-seen order and de-duplicated.
+ * Single integration point a future notification feature consumes.
+ */
+export function extractMentionedUserIds(body: string): string[] {
+  const ids: string[] = [];
+  for (const segment of parseMentionBody(body)) {
+    if (segment.type === 'mention' && !ids.includes(segment.userId)) {
+      ids.push(segment.userId);
+    }
+  }
+  return ids;
+}

--- a/packages/frontend/src/components/comments/use-workspace-members.ts
+++ b/packages/frontend/src/components/comments/use-workspace-members.ts
@@ -17,8 +17,10 @@ import type { MentionMember } from "./components/CommentComposer";
 export function useWorkspaceMembers(
   workspaceId: string | undefined,
 ): MentionMember[] {
+  // Same key/fetcher as the rest of the app's workspace-detail query, so the
+  // member list shares one cache entry instead of issuing a duplicate fetch.
   const { data } = useQuery({
-    queryKey: ["workspace", workspaceId, "members"],
+    queryKey: ["workspaces", workspaceId],
     queryFn: () => fetchWorkspace(workspaceId!),
     enabled: !!workspaceId,
     staleTime: 5 * 60 * 1000,

--- a/packages/frontend/src/components/comments/use-workspace-members.ts
+++ b/packages/frontend/src/components/comments/use-workspace-members.ts
@@ -1,0 +1,36 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchWorkspace } from "@/api/workspaces";
+
+import type { MentionMember } from "./components/CommentComposer";
+
+/**
+ * Workspace members for the comment `@` mention autocomplete, sourced from
+ * the existing `GET /workspaces/:id` response (no dedicated endpoint). The
+ * userId is stringified to match `CommentAuthor.userId`.
+ *
+ * Returns an empty list when no workspace is in scope (e.g. anonymous
+ * share-link viewers), which disables the mention dropdown while existing
+ * mention chips still render fine.
+ */
+export function useWorkspaceMembers(
+  workspaceId: string | undefined,
+): MentionMember[] {
+  const { data } = useQuery({
+    queryKey: ["workspace", workspaceId, "members"],
+    queryFn: () => fetchWorkspace(workspaceId!),
+    enabled: !!workspaceId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return useMemo(
+    () =>
+      (data?.members ?? []).map((m) => ({
+        userId: String(m.user.id),
+        username: m.user.username,
+        photo: m.user.photo || undefined,
+      })),
+    [data],
+  );
+}

--- a/packages/frontend/tests/components/comments/comment-body.test.ts
+++ b/packages/frontend/tests/components/comments/comment-body.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+/**
+ * Tests for CommentBody — renders a plain-string comment body, turning
+ * inline @[username](userId) tokens into mention chips while leaving the
+ * surrounding text intact.
+ *
+ * JSX is avoided (matching the package's tests/**\/*.test.ts runner) by
+ * building elements with React.createElement.
+ */
+import { describe, test, expect, afterEach } from 'vitest';
+import { createElement as h, act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { CommentBody } from '../../../src/components/comments/components/CommentBody.tsx';
+
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+function render(ui: ReactElement): HTMLElement {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => {
+    root!.render(ui);
+  });
+  return host;
+}
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+});
+
+describe('CommentBody', () => {
+  test('renders plain text verbatim with no mention chips', () => {
+    const el = render(h(CommentBody, { body: 'just plain text' }));
+    expect(el.textContent).toBe('just plain text');
+    expect(el.querySelector('[data-mention-user-id]')).toBeNull();
+  });
+
+  test('renders a mention as a chip carrying the userId and username', () => {
+    const el = render(
+      h(CommentBody, { body: 'Hi @[김철수](u_42), review?' }),
+    );
+    const chip = el.querySelector(
+      '[data-mention-user-id="u_42"]',
+    ) as HTMLElement | null;
+    expect(chip).not.toBeNull();
+    expect(chip!.textContent).toBe('@김철수');
+    expect(chip!.getAttribute('title')).toBe('김철수');
+  });
+
+  test('keeps the text surrounding a mention', () => {
+    const el = render(
+      h(CommentBody, { body: 'Hi @[김철수](u_42), review?' }),
+    );
+    expect(el.textContent).toBe('Hi @김철수, review?');
+  });
+
+  test('renders multiple mentions', () => {
+    const el = render(h(CommentBody, { body: '@[a](1) and @[b](2)' }));
+    expect(el.querySelectorAll('[data-mention-user-id]').length).toBe(2);
+  });
+});

--- a/packages/frontend/tests/components/comments/comment-composer-mentions.test.ts
+++ b/packages/frontend/tests/components/comments/comment-composer-mentions.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+/**
+ * Tests for CommentComposer's `@` mention autocomplete.
+ *
+ * Asserts:
+ *   - typing "@" + query opens a member dropdown filtered by username,
+ *   - keyboard select (Enter) inserts clean `@username` text,
+ *   - submit tokenizes selected mentions into `@[username](userId)`,
+ *   - a mention whose text was edited after selection drops to plain text,
+ *   - with no `members` prop the composer stays a plain textarea.
+ *
+ * JSX is avoided (matching the package's tests/**\/*.test.ts runner) by
+ * building elements with React.createElement.
+ */
+import { describe, test, expect, afterEach, vi } from "vitest";
+import { createElement as h, act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import {
+  CommentComposer,
+  type MentionMember,
+} from "../../../src/components/comments/components/CommentComposer.tsx";
+
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const MEMBERS: MentionMember[] = [
+  { userId: "u1", username: "kim" },
+  { userId: "u2", username: "kimchi" },
+  { userId: "u3", username: "bob" },
+];
+
+let root: Root | null = null;
+let host: HTMLDivElement | null = null;
+
+function render(ui: ReactElement): HTMLElement {
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  act(() => {
+    root!.render(ui);
+  });
+  return host;
+}
+
+// React patches the element's own `value` setter to track changes, so a
+// plain `ta.value = …` assignment updates React's tracker and the synthetic
+// onChange is then deduped away. Calling the prototype setter bypasses the
+// instance patch: the DOM value changes without touching React's tracker, so
+// the dispatched input event is seen as a real change.
+const nativeValueSetter = Object.getOwnPropertyDescriptor(
+  HTMLTextAreaElement.prototype,
+  "value",
+)!.set!;
+
+function type(ta: HTMLTextAreaElement, value: string) {
+  act(() => {
+    nativeValueSetter.call(ta, value);
+    ta.selectionStart = value.length;
+    ta.selectionEnd = value.length;
+    ta.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function key(ta: HTMLTextAreaElement, init: KeyboardEventInit) {
+  act(() => {
+    ta.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, ...init }));
+  });
+}
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = null;
+  host?.remove();
+  host = null;
+});
+
+describe("CommentComposer mentions", () => {
+  test("typing @ + query opens a dropdown filtered by username", () => {
+    const el = render(
+      h(CommentComposer, {
+        submitLabel: "Comment",
+        onSubmit: () => {},
+        members: MEMBERS,
+      }),
+    );
+    const ta = el.querySelector("textarea") as HTMLTextAreaElement;
+    type(ta, "@k");
+    const options = el.querySelectorAll('[role="option"]');
+    expect(options.length).toBe(2); // kim, kimchi (not bob)
+  });
+
+  test("Enter selects the active member and inserts clean @username text", () => {
+    const el = render(
+      h(CommentComposer, {
+        submitLabel: "Comment",
+        onSubmit: () => {},
+        members: MEMBERS,
+      }),
+    );
+    const ta = el.querySelector("textarea") as HTMLTextAreaElement;
+    type(ta, "@k");
+    key(ta, { key: "Enter" });
+    expect(ta.value).toBe("@kim ");
+    expect(el.querySelector('[role="listbox"]')).toBeNull();
+  });
+
+  test("submit tokenizes the selected mention", async () => {
+    const onSubmit = vi.fn();
+    const el = render(
+      h(CommentComposer, { submitLabel: "Comment", onSubmit, members: MEMBERS }),
+    );
+    const ta = el.querySelector("textarea") as HTMLTextAreaElement;
+    type(ta, "@k");
+    key(ta, { key: "Enter" });
+    await act(async () => {
+      (
+        el.querySelector("button:last-of-type") as HTMLButtonElement
+      ).click();
+    });
+    expect(onSubmit).toHaveBeenCalledWith("@[kim](u1)");
+  });
+
+  test("a mention edited after selection drops to plain text on submit", async () => {
+    const onSubmit = vi.fn();
+    const el = render(
+      h(CommentComposer, { submitLabel: "Comment", onSubmit, members: MEMBERS }),
+    );
+    const ta = el.querySelector("textarea") as HTMLTextAreaElement;
+    type(ta, "@k");
+    key(ta, { key: "Enter" });
+    type(ta, "@kimX");
+    await act(async () => {
+      (
+        el.querySelector("button:last-of-type") as HTMLButtonElement
+      ).click();
+    });
+    expect(onSubmit).toHaveBeenCalledWith("@kimX");
+  });
+
+  test("no dropdown when the members prop is absent", () => {
+    const el = render(
+      h(CommentComposer, { submitLabel: "Comment", onSubmit: () => {} }),
+    );
+    const ta = el.querySelector("textarea") as HTMLTextAreaElement;
+    type(ta, "@k");
+    expect(el.querySelector('[role="listbox"]')).toBeNull();
+  });
+});

--- a/packages/frontend/tests/components/comments/comment-composer-mentions.test.ts
+++ b/packages/frontend/tests/components/comments/comment-composer-mentions.test.ts
@@ -139,6 +139,26 @@ describe("CommentComposer mentions", () => {
     expect(onSubmit).toHaveBeenCalledWith("@kimX");
   });
 
+  test("edit entry shows de-tokenized text and round-trips on save", async () => {
+    const onSubmit = vi.fn();
+    const el = render(
+      h(CommentComposer, {
+        submitLabel: "Save",
+        onSubmit,
+        members: MEMBERS,
+        initialBody: "hey @[kim](u1) look",
+      }),
+    );
+    const ta = el.querySelector("textarea") as HTMLTextAreaElement;
+    // The raw token is never shown to the user.
+    expect(ta.value).toBe("hey @kim look");
+    // An untouched save re-emits the original token losslessly.
+    await act(async () => {
+      (el.querySelector("button:last-of-type") as HTMLButtonElement).click();
+    });
+    expect(onSubmit).toHaveBeenCalledWith("hey @[kim](u1) look");
+  });
+
   test("no dropdown when the members prop is absent", () => {
     const el = render(
       h(CommentComposer, { submitLabel: "Comment", onSubmit: () => {} }),

--- a/packages/frontend/tests/components/comments/mentions.test.ts
+++ b/packages/frontend/tests/components/comments/mentions.test.ts
@@ -4,6 +4,7 @@ import {
   parseMentionBody,
   serializeMention,
   extractMentionedUserIds,
+  mentionBodyToPlainText,
 } from '../../../src/components/comments/mentions.ts';
 
 describe('serializeMention', () => {
@@ -97,5 +98,17 @@ describe('extractMentionedUserIds', () => {
 
   it('returns an empty array when there are no mentions', () => {
     expect(extractMentionedUserIds('plain text')).toEqual([]);
+  });
+});
+
+describe('mentionBodyToPlainText', () => {
+  it('renders each mention as @username for previews', () => {
+    expect(mentionBodyToPlainText('Hi @[김철수](u_42), review?')).toBe(
+      'Hi @김철수, review?',
+    );
+  });
+
+  it('leaves bodies without mentions unchanged', () => {
+    expect(mentionBodyToPlainText('plain text')).toBe('plain text');
   });
 });

--- a/packages/frontend/tests/components/comments/mentions.test.ts
+++ b/packages/frontend/tests/components/comments/mentions.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  parseMentionBody,
+  serializeMention,
+  extractMentionedUserIds,
+} from '../../../src/components/comments/mentions.ts';
+
+describe('serializeMention', () => {
+  it('encodes a mention as @[username](userId)', () => {
+    expect(serializeMention({ userId: 'u_42', username: '김철수' })).toBe(
+      '@[김철수](u_42)',
+    );
+  });
+
+  it('strips "]" from username so the grammar stays unambiguous', () => {
+    expect(serializeMention({ userId: 'u1', username: 'a]b' })).toBe(
+      '@[ab](u1)',
+    );
+  });
+
+  it('strips ")" from userId so the grammar stays unambiguous', () => {
+    expect(serializeMention({ userId: 'u)1', username: 'a' })).toBe(
+      '@[a](u1)',
+    );
+  });
+});
+
+describe('parseMentionBody', () => {
+  it('returns an empty array for an empty body', () => {
+    expect(parseMentionBody('')).toEqual([]);
+  });
+
+  it('returns a single text segment when there are no mentions', () => {
+    expect(parseMentionBody('just plain text')).toEqual([
+      { type: 'text', value: 'just plain text' },
+    ]);
+  });
+
+  it('splits text around a single mention', () => {
+    expect(parseMentionBody('Hi @[김철수](u_42), review?')).toEqual([
+      { type: 'text', value: 'Hi ' },
+      { type: 'mention', userId: 'u_42', username: '김철수' },
+      { type: 'text', value: ', review?' },
+    ]);
+  });
+
+  it('handles a mention at the start and end with no surrounding text', () => {
+    expect(parseMentionBody('@[a](1)')).toEqual([
+      { type: 'mention', userId: '1', username: 'a' },
+    ]);
+  });
+
+  it('keeps adjacent mentions without empty text segments between them', () => {
+    expect(parseMentionBody('@[a](1)@[b](2)')).toEqual([
+      { type: 'mention', userId: '1', username: 'a' },
+      { type: 'mention', userId: '2', username: 'b' },
+    ]);
+  });
+
+  it('leaves an unclosed "@[" sequence as plain text', () => {
+    expect(parseMentionBody('email me @[foo bar')).toEqual([
+      { type: 'text', value: 'email me @[foo bar' },
+    ]);
+  });
+
+  it('leaves "@[name]" without a "(id)" group as plain text', () => {
+    expect(parseMentionBody('a list item @[todo] here')).toEqual([
+      { type: 'text', value: 'a list item @[todo] here' },
+    ]);
+  });
+});
+
+describe('round-trip', () => {
+  it('parse(serialize(ref)) yields the original mention', () => {
+    const ref = { userId: 'u_99', username: '김영희' };
+    expect(parseMentionBody(serializeMention(ref))).toEqual([
+      { type: 'mention', userId: 'u_99', username: '김영희' },
+    ]);
+  });
+});
+
+describe('extractMentionedUserIds', () => {
+  it('returns the ids of all mentions in document order', () => {
+    expect(extractMentionedUserIds('hi @[a](1) and @[b](2)')).toEqual([
+      '1',
+      '2',
+    ]);
+  });
+
+  it('de-duplicates repeated mentions of the same user', () => {
+    expect(extractMentionedUserIds('@[a](1) @[a](1) @[b](2)')).toEqual([
+      '1',
+      '2',
+    ]);
+  });
+
+  it('returns an empty array when there are no mentions', () => {
+    expect(extractMentionedUserIds('plain text')).toEqual([]);
+  });
+});

--- a/packages/frontend/tests/components/comments/mentions.test.ts
+++ b/packages/frontend/tests/components/comments/mentions.test.ts
@@ -5,6 +5,8 @@ import {
   serializeMention,
   extractMentionedUserIds,
   mentionBodyToPlainText,
+  detectMentionQuery,
+  applySelectedMentions,
 } from '../../../src/components/comments/mentions.ts';
 
 describe('serializeMention', () => {
@@ -110,5 +112,64 @@ describe('mentionBodyToPlainText', () => {
 
   it('leaves bodies without mentions unchanged', () => {
     expect(mentionBodyToPlainText('plain text')).toBe('plain text');
+  });
+});
+
+describe('detectMentionQuery', () => {
+  it('detects an in-progress query before the caret', () => {
+    expect(detectMentionQuery('hi @ki', 6)).toEqual({ query: 'ki', start: 3 });
+  });
+
+  it('detects a bare "@" as an empty query', () => {
+    expect(detectMentionQuery('@', 1)).toEqual({ query: '', start: 0 });
+  });
+
+  it('uses the caret position, not the end of the string', () => {
+    expect(detectMentionQuery('hi @kim', 5)).toEqual({ query: 'k', start: 3 });
+  });
+
+  it('returns null when "@" is not at a word boundary (email)', () => {
+    expect(detectMentionQuery('mail a@b', 8)).toBeNull();
+  });
+
+  it('returns null once the query contains whitespace', () => {
+    expect(detectMentionQuery('hi @kim now', 11)).toBeNull();
+  });
+
+  it('returns null when there is no "@" before the caret', () => {
+    expect(detectMentionQuery('hello ', 6)).toBeNull();
+  });
+});
+
+describe('applySelectedMentions', () => {
+  it('tokenizes a selected mention', () => {
+    expect(
+      applySelectedMentions('hi @kim', [{ username: 'kim', userId: 'u1' }]),
+    ).toBe('hi @[kim](u1)');
+  });
+
+  it('does not let a shorter username match inside a longer one', () => {
+    expect(
+      applySelectedMentions('@kim and @kimchi', [
+        { username: 'kim', userId: 'u1' },
+        { username: 'kimchi', userId: 'u2' },
+      ]),
+    ).toBe('@[kim](u1) and @[kimchi](u2)');
+  });
+
+  it('drops a mention whose text was edited after selection', () => {
+    expect(
+      applySelectedMentions('@kimX', [{ username: 'kim', userId: 'u1' }]),
+    ).toBe('@kimX');
+  });
+
+  it('tokenizes every occurrence of a selected user', () => {
+    expect(
+      applySelectedMentions('@kim @kim', [{ username: 'kim', userId: 'u1' }]),
+    ).toBe('@[kim](u1) @[kim](u1)');
+  });
+
+  it('leaves unselected "@words" as plain text', () => {
+    expect(applySelectedMentions('hi @bob', [])).toBe('hi @bob');
   });
 });

--- a/packages/frontend/tests/components/comments/mentions.test.ts
+++ b/packages/frontend/tests/components/comments/mentions.test.ts
@@ -139,6 +139,10 @@ describe('detectMentionQuery', () => {
   it('returns null when there is no "@" before the caret', () => {
     expect(detectMentionQuery('hello ', 6)).toBeNull();
   });
+
+  it('triggers after non-login text typed with no space (CJK)', () => {
+    expect(detectMentionQuery('안녕@kim', 6)).toEqual({ query: 'kim', start: 2 });
+  });
 });
 
 describe('applySelectedMentions', () => {


### PR DESCRIPTION
## Summary

Adds Google-Docs-style `@user` mentions to comments — **mention-only** scope
(input, storage, render). Notifications remain a separate follow-up
(`docs-comments-followup` Step 4). Lands in the shared comments module, so
sheets + docs get it together; slides inherits when its comments land.

A mention is stored inline in the existing plain-string `Comment.body` as a
`@[username](userId)` token, so there is **no CRDT schema change and no
`@wafflebase/*` type change** — the token is opaque text to every store.

- **Helpers** (`mentions.ts`, pure/TDD'd): `parseMentionBody`,
  `serializeMention`, `mentionBodyToPlainText`, `extractMentionedUserIds`,
  `detectMentionQuery` (`@` trigger), `applySelectedMentions` (tokenize on
  submit).
- **Input**: `CommentComposer` gains an `@` autocomplete — member dropdown,
  keyboard nav (↑/↓/Enter/Tab/Esc, intercepted only when open),
  Korean-IME-guarded, tokenized on submit (approach B). Edit entry
  de-tokenizes for display and round-trips losslessly.
- **Render**: shared `CommentBody` turns tokens into blue chips (username
  tooltip, no-op click); truncated previews use `mentionBodyToPlainText` so
  the raw token never leaks.
- **Members**: `useWorkspaceMembers` sources the list from the existing
  `GET /workspaces/:id` (no new backend), threaded via `DocsView`
  (new `workspaceId` prop) and `sheet-view` into the popovers. Anonymous
  share-link mounts pass no members → dropdown disabled, chips still render.

Design: `docs/design/comments-mentions.md`.

## Test plan

- `pnpm verify:fast` green; pre-push harness (builds + chunks + entropy) green.
- 34 mention unit/interaction tests: token round-trip + escape edges, `@`
  trigger (incl. `email@host` exclusion and CJK `안녕@kim`),
  tokenize-on-submit + edited-mention drop, edit-entry round-trip, chip
  render + plain-text preview.
- Two adversarial self-reviews (subagents); blocking edit-flow bug fixed.
- Manual smoke: mentions in docs + sheets comments, Korean IME, chip + tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)