### PR TITLE
Archive v0.4.7 release task after publish

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,6 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
-| release v0.4.7 (2026-06-23) | [20260623-release-v0.4.7-todo.md](./active/20260623-release-v0.4.7-todo.md) | - |
 | slides fonts (2026-06-16) | [20260616-slides-fonts-todo.md](./active/20260616-slides-fonts-todo.md) | [20260616-slides-fonts-lessons.md](./active/20260616-slides-fonts-lessons.md) |
 | slides tables (2026-06-08) | [20260608-slides-tables-todo.md](./active/20260608-slides-tables-todo.md) | [20260608-slides-tables-lessons.md](./active/20260608-slides-tables-lessons.md) |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
@@ -30,7 +29,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 ## Archive
 
-- Archived task count: 302
+- Archived task count: 303
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: release v0.4.7 (2026-06-23)
+Latest active task: slides fonts (2026-06-16)

--- a/docs/tasks/archive/2026/06/20260623-release-v0.4.7-todo.md
+++ b/docs/tasks/archive/2026/06/20260623-release-v0.4.7-todo.md
@@ -35,7 +35,24 @@ frontend a11y/Radix tidy.
       pre-existing slides `test/anim/player.test.ts` `.at()` typecheck
       error fails (known gate gap CI never runs; unrelated to this diff).
 - [x] Commit on `release/v0.4.7` (`--no-verify`, known gap only).
-- [ ] Push + open PR (Summary + Test plan); merge after CI green.
+- [x] `/code-review --effort medium` over the branch diff — 0 blocking
+      findings (docs + version-bump only).
+- [x] Push + open PR (Summary + Test plan); merged — PR #402.
+
+## Post-merge release
+
+- [x] Sync `main` (PR #402 squash-merged as `9f11c2dd`); `main` at `0.4.7`.
+- [x] Annotated tag `v0.4.7` on the merge commit, pushed.
+- [x] GitHub Release `v0.4.7` published with hand-categorised highlights
+      + Contributors (both maintainers per convention; all window PRs by
+      @hackerwins).
+- [x] `npm-publish.yml` (run 27964432583) + `docker-publish.yml`
+      (run 27964434204) workflows succeeded.
+- [x] Confirmed `@wafflebase/cli@0.4.7` + `@wafflebase/docs@0.4.7` on npm,
+      and `yorkieteam/wafflebase:v0.4.7` in the registry (manifest HTTP
+      200; Docker Hub web index lags but the image is present).
+- [x] Bump server image in `yorkie-team/devops` — external repo, out of
+      this repo's scope (image-tag-only; tracked in `yorkie-team/devops`).
 
 ## Tasks staying active (genuine remaining work)
 
@@ -91,3 +108,11 @@ Genuine open-phase tasks remain active.
 `verify:fast` green except the documented pre-existing slides typecheck
 gap, so the commit used `--no-verify`. The slides `.at()`/lib-target
 typecheck error remains tracked separately as a known gate gap.
+
+The release shipped via PR #402 (squash `9f11c2dd`). Tag `v0.4.7` +
+GitHub Release published, which drove `npm-publish.yml` and
+`docker-publish.yml` to success; `@wafflebase/cli@0.4.7`,
+`@wafflebase/docs@0.4.7` (npm) and `yorkieteam/wafflebase:v0.4.7`
+(registry manifest 200) confirmed live. The only remaining step is the
+external `yorkie-team/devops` server-image bump, out of this repo's
+scope. Release complete.

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -6,12 +6,13 @@ Completed task records, grouped by year/month.
 - Move completed tasks from root/active into archive: `pnpm tasks:archive`
 - Back to tasks index: [../README.md](../README.md)
 
-Total archived tasks: 302
+Total archived tasks: 303
 
-## 2026/06 (56 tasks)
+## 2026/06 (57 tasks)
 
 | Task | Todo | Lessons |
 |---|---|---|
+| release v0.4.7 (2026-06-23) | [20260623-release-v0.4.7-todo.md](./2026/06/20260623-release-v0.4.7-todo.md) | - |
 | comments mentions (2026-06-21) | [20260621-comments-mentions-todo.md](./2026/06/20260621-comments-mentions-todo.md) | [20260621-comments-mentions-lessons.md](./2026/06/20260621-comments-mentions-lessons.md) |
 | dependabot alerts (2026-06-21) | [20260621-dependabot-alerts-todo.md](./2026/06/20260621-dependabot-alerts-todo.md) | - |
 | slides live presence (2026-06-21) | [20260621-slides-live-presence-todo.md](./2026/06/20260621-slides-live-presence-todo.md) | - |


### PR DESCRIPTION
## Summary

Post-merge cleanup for the v0.4.7 release (shipped via #402). Records the
post-merge steps in the release task doc and archives it.

- v0.4.7 tag + GitHub Release published.
- `npm-publish.yml` + `docker-publish.yml` workflows succeeded.
- Confirmed `@wafflebase/cli@0.4.7`, `@wafflebase/docs@0.4.7` on npm and
  `yorkieteam/wafflebase:v0.4.7` in the registry (manifest HTTP 200).
- Ticked the release task's post-merge boxes (the `yorkie-team/devops`
  server-image bump is external, out of this repo's scope) and ran
  `pnpm tasks:archive` → moved into `archive/2026/06/`. 8 active tasks remain.

## Test plan

- [x] `pnpm tasks:archive && pnpm tasks:index` regenerated indexes.
- Docs-only change (task doc move + post-merge notes); no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)