### PR TITLE
Slides tables: peer presence for table cell-range selection

### DIFF
--- a/docs/tasks/active/20260608-slides-tables-lessons.md
+++ b/docs/tasks/active/20260608-slides-tables-lessons.md
@@ -99,6 +99,47 @@ portalled into `document.body`, so query `[role="menuitem"]` off
 surface the component actually touches (`read`, `batch`,
 `updateTableCellStyle`, `getCurrentSlideId`) and cast through `unknown`.
 
+## Scope a "presence" field to its substrate, not the design doc
+
+The design doc listed three table presence fields (`selectedTableCells`,
+`textCursorCell`, `resizingTableEdge`). Only one was actually buildable
+now: `selectedTableCells`, the static analogue of the already-wired
+`selectedElementIds`. The other two have no substrate to extend:
+- `resizingTableEdge` is a *live drag preview*; the element-level
+  `activeFrames` live-frame broadcast it pairs with is itself deferred
+  (live-presence task P2 — blocked on "no single gesture-end chokepoint
+  to clear" the live frames). Build table edge-resize presence with that.
+- `textCursorCell` is framed as an extension of `textCursor`, but slides
+  renders zero peer text carets today (only docs does). Needs that layer
+  first (a separate PR per the live-presence todo).
+
+Before estimating a presence field, check (a) does local state for it
+exist, and (b) is there a *broadcast precedent* (a sibling field already
+wired through `updatePresence`)? `selectedTableCells` had both
+(`editor.cellSelection` + `selectedElementIds`); the other two had
+neither. Same recurring theme as the earlier "verify the substrate
+exists" lesson.
+
+## Clearing an optional presence field: set it to `undefined`, guard on read
+
+Yorkie `Presence.set` MERGES, so a field is "cleared" by broadcasting it
+as `undefined` and having every consumer guard with `if (presence.field)`
+(docs does exactly this for `activeCursorPos` / `activeSelection`). The
+`broadcast()` in `slides-view.tsx` therefore always includes
+`selectedTableCells` (value or `undefined`) — never omits the key — so a
+peer's cell highlight disappears the instant they click away.
+
+## Keep peer presence visible when a projection can be empty
+
+First cut suppressed the cell-selected table's plain ring *unconditionally*
+whenever `selectedTableCells` was set, then drew highlights. But the
+cell→rect projection can legitimately return zero rects — a drag range
+that lands entirely on merge-*covered* cells whose anchor sits outside the
+range, or a table that was just deleted. Result: ring gone, no highlights,
+peer presence invisible. Fix: project first, and suppress the ring only
+when rects actually rendered. General rule — when a "replace A with B"
+overlay can produce an empty B, gate the removal of A on B being non-empty.
+
 ## Test conventions
 
 - Integration tests are auto-discovered by `tests/**/*.integration.ts`

--- a/docs/tasks/active/20260608-slides-tables-todo.md
+++ b/docs/tasks/active/20260608-slides-tables-todo.md
@@ -141,7 +141,7 @@ What landed (in commit order):
       deleteTableColumn, mergeTableCells, unmergeTableCells,
       updateTableColumnWidths, updateTableRowHeights,
       updateTableCellStyle, withTableCellBody)
-- [ ] Presence: `selectedTableCells` (IN PROGRESS, branch
+- [x] Presence: `selectedTableCells` (branch
       `slides-table-cell-presence`) — static cell-range presence, the
       table analogue of the already-wired `selectedElementIds`. Pipeline:
       `SlidesPresence.selectedTableCells` → broadcast on
@@ -149,7 +149,10 @@ What landed (in commit order):
       `computePeerOverlays` (new `cellRangeRectsOf` projector + `cellRects`
       output) → `renderPeerOverlays` peer-tinted cell fills. Geometry
       shared with the local path via a new `projectCellRangeRects` helper
-      in `table-renderer.ts`.
+      in `table-renderer.ts`. Ring suppressed only when rects actually
+      render (merge-hole / deleted-table ranges keep the ring so presence
+      never vanishes). Pure-fn + DOM-builder unit tests; live two-user
+      smoke still recommended before merge.
   - [ ] `resizingTableEdge` — DEFERRED with the live-frame broadcast.
         It is a *live drag preview*; the element-level `activeFrames`
         live broadcast it pairs with is itself deferred (P2 of

--- a/docs/tasks/active/20260608-slides-tables-todo.md
+++ b/docs/tasks/active/20260608-slides-tables-todo.md
@@ -141,10 +141,25 @@ What landed (in commit order):
       deleteTableColumn, mergeTableCells, unmergeTableCells,
       updateTableColumnWidths, updateTableRowHeights,
       updateTableCellStyle, withTableCellBody)
-- [ ] Presence: `selectedTableCells`, `textCursorCell`,
-      `resizingTableEdge` (still open — the peer-presence rendering layer
-      now exists as of PR #390, so this extends it rather than waiting on
-      it; see Status note)
+- [ ] Presence: `selectedTableCells` (IN PROGRESS, branch
+      `slides-table-cell-presence`) — static cell-range presence, the
+      table analogue of the already-wired `selectedElementIds`. Pipeline:
+      `SlidesPresence.selectedTableCells` → broadcast on
+      `editor.onCellSelectionChange` → `mapPresenceToPeerView` →
+      `computePeerOverlays` (new `cellRangeRectsOf` projector + `cellRects`
+      output) → `renderPeerOverlays` peer-tinted cell fills. Geometry
+      shared with the local path via a new `projectCellRangeRects` helper
+      in `table-renderer.ts`.
+  - [ ] `resizingTableEdge` — DEFERRED with the live-frame broadcast.
+        It is a *live drag preview*; the element-level `activeFrames`
+        live broadcast it pairs with is itself deferred (P2 of
+        `archive/2026/06/20260621-slides-live-presence-todo.md`, blocked
+        on the "no single gesture-end chokepoint to clear" problem). Build
+        table edge-resize presence together with that, not standalone.
+  - [ ] `textCursorCell` — DEFERRED. The design doc frames it as an
+        extension of `textCursor`, but slides renders NO peer text carets
+        today (only docs does); the live-presence todo lists peer text
+        carets as an explicit separate PR. Needs that substrate first.
 - [x] Two-user integration test — landed as
       `frontend/tests/app/slides/yorkie-slides-table-concurrent.integration.ts`
       (concurrent disjoint-cell edits, concurrent row insert,

--- a/packages/frontend/src/app/slides/peer-view.ts
+++ b/packages/frontend/src/app/slides/peer-view.ts
@@ -35,6 +35,7 @@ export function mapPresenceToPeerView(
             position: presence.draggingGuide.position,
           }
         : undefined,
+      selectedTableCells: presence.selectedTableCells,
     });
   }
   return views;

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -973,13 +973,28 @@ export function SlidesView({
     // SlidesDetail via `initialPresence` and stay intact across these
     // partial updates.
     const broadcast = () => {
+      // Table cell-range presence: map the editor's local cell selection
+      // to the wire shape, or `undefined` to clear it (Presence.set
+      // merges, and peers guard on the field — so undefined reads the
+      // same as a deleted key). The table id rides as `elementId`.
+      const cell = editor.getCellSelection();
       store.updatePresence({
         activeSlideId: editor.getCurrentSlideId(),
         selectedElementIds: editor.getSelection().slice(),
+        selectedTableCells: cell
+          ? {
+              elementId: cell.tableId,
+              r0: cell.r0,
+              c0: cell.c0,
+              r1: cell.r1,
+              c1: cell.c1,
+            }
+          : undefined,
       });
     };
     const offSelection = editor.onSelectionChange(broadcast);
     const offSlide = editor.onCurrentSlideChange(broadcast);
+    const offCellSelection = editor.onCellSelectionChange(broadcast);
 
     // RAF loop so async asset loads (image cache) repaint, and
     // thumbnail count stays in sync with store mutations the panel
@@ -1024,6 +1039,7 @@ export function SlidesView({
       cleanupImagePaths();
       offSelection();
       offSlide();
+      offCellSelection();
       offChange();
       offPeers();
       thumbHandle?.dispose();

--- a/packages/frontend/src/types/users.ts
+++ b/packages/frontend/src/types/users.ts
@@ -62,4 +62,20 @@ export type SlidesPresence = {
     axis: 'x' | 'y';
     position: number;
   };
+  /**
+   * Cell range the user has selected inside a table (the table analogue
+   * of `selectedElementIds`). `elementId` is the table; `r0/c0`–`r1/c1`
+   * are the inclusive anchor/focus cell coords. Cleared by broadcasting
+   * `undefined` when the cell selection ends — consumers guard on
+   * presence, so a deleted-or-undefined key reads the same. Peer text
+   * carets inside a cell (`textCursorCell`) and live edge-resize preview
+   * (`resizingTableEdge`) are deferred with the live-presence work.
+   */
+  selectedTableCells?: {
+    elementId: string;
+    r0: number;
+    c0: number;
+    r1: number;
+    c1: number;
+  };
 };

--- a/packages/frontend/tests/app/slides/peer-view.test.ts
+++ b/packages/frontend/tests/app/slides/peer-view.test.ts
@@ -87,4 +87,35 @@ describe("mapPresenceToPeerView", () => {
     ]);
     expect(out[0].draggingGuide).toEqual({ axis: "x", position: 120 });
   });
+
+  it("forwards a table cell-range selection", () => {
+    const out = mapPresenceToPeerView(
+      [
+        {
+          clientID: "c1",
+          presence: presence({
+            activeSlideId: "s1",
+            selectedElementIds: ["t1"],
+            selectedTableCells: { elementId: "t1", r0: 0, c0: 0, r1: 1, c1: 2 },
+          }),
+        },
+      ],
+      "light",
+    );
+    expect(out[0].selectedTableCells).toEqual({
+      elementId: "t1",
+      r0: 0,
+      c0: 0,
+      r1: 1,
+      c1: 2,
+    });
+  });
+
+  it("leaves selectedTableCells undefined when the peer has no cell range", () => {
+    const out = mapPresenceToPeerView(
+      [{ clientID: "c1", presence: presence({ activeSlideId: "s1" }) }],
+      "light",
+    );
+    expect(out[0].selectedTableCells).toBeUndefined();
+  });
 });

--- a/packages/slides/src/view/canvas/table-renderer.ts
+++ b/packages/slides/src/view/canvas/table-renderer.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_CELL_PADDING,
   isBlocksEmpty,
   type CellBorder,
+  type Frame,
   type TableCell,
   type TableElement,
 } from '../../model/element';
@@ -135,6 +136,55 @@ export function computeTableLayout(
   for (let r = 0; r < nRows; r++) rowY[r + 1] = rowY[r] + rowH[r];
 
   return { colX, rowY, rowH };
+}
+
+/**
+ * Project an inclusive cell range to world-space rects — one per
+ * non-covered cell, expanded to the cell's merged span. Covered cells
+ * (`gridSpan === 0 || rowSpan === 0`) contribute nothing: the anchor's
+ * rect already spans them. `layout` must come from
+ * `computeTableLayout(table.data, …)` with the same `fontScale` the
+ * renderer used, so the rects land exactly on the painted grid.
+ *
+ * Pure geometry: shared by the editor's local cell-range overlay and the
+ * peer-presence overlay so both draw identical rectangles.
+ */
+export function projectCellRangeRects(
+  table: Pick<TableElement, 'frame' | 'data'>,
+  range: { r0: number; c0: number; r1: number; c1: number },
+  layout: TableLayout,
+): Frame[] {
+  const { columnWidths, rows } = table.data;
+  const nCols = columnWidths.length;
+  const nRows = rows.length;
+  const rmin = Math.min(range.r0, range.r1);
+  const rmax = Math.max(range.r0, range.r1);
+  const cmin = Math.min(range.c0, range.c1);
+  const cmax = Math.max(range.c0, range.c1);
+
+  const rects: Frame[] = [];
+  for (let r = rmin; r <= rmax; r++) {
+    for (let c = cmin; c <= cmax; c++) {
+      const cell = rows[r]?.cells[c];
+      if (!cell) continue;
+      // Covered cells own no rect; the merge anchor paints the full span.
+      if (cell.gridSpan === 0 || cell.rowSpan === 0) continue;
+      const gs = Math.min(Math.max(cell.gridSpan ?? 1, 1), nCols - c);
+      const rs = Math.min(Math.max(cell.rowSpan ?? 1, 1), nRows - r);
+      const x0 = layout.colX[c];
+      const x1 = layout.colX[c + gs];
+      const y0 = layout.rowY[r];
+      const y1 = layout.rowY[r + rs];
+      rects.push({
+        x: table.frame.x + x0,
+        y: table.frame.y + y0,
+        w: x1 - x0,
+        h: y1 - y0,
+        rotation: table.frame.rotation,
+      });
+    }
+  }
+  return rects;
 }
 
 function paintCellFills(

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -30,6 +30,7 @@ import { SHAPE_TEXT_PADDING } from '../canvas/shape-renderer';
 import {
   computeTableLayout,
   nextCellInDirection,
+  projectCellRangeRects,
   tableCellAtPoint,
   tableEdgeAt,
   type TableLayout,
@@ -1072,7 +1073,7 @@ class SlidesEditorImpl implements SlidesEditor {
     // table cell after the table is already element-selected). Skipped
     // while text-edit is active so the in-place editor's outline owns
     // the visual focus.
-    const cellRangeRects: Frame[] = [];
+    let cellRangeRects: Frame[] = [];
     if (this.cellSelection !== null && this.editingElementId === null) {
       const sel = this.cellSelection;
       const tableEl = findElement(slide.elements, sel.tableId);
@@ -1080,41 +1081,11 @@ class SlidesEditorImpl implements SlidesEditor {
         const layout = computeTableLayout(tableEl.data, {
           fontScale: deckFontScale(doc.meta),
         });
-        const nCols = tableEl.data.columnWidths.length;
-        const nRows = tableEl.data.rows.length;
-        const rmin = Math.min(sel.r0, sel.r1);
-        const rmax = Math.max(sel.r0, sel.r1);
-        const cmin = Math.min(sel.c0, sel.c1);
-        const cmax = Math.max(sel.c0, sel.c1);
-        for (let r = rmin; r <= rmax; r++) {
-          for (let c = cmin; c <= cmax; c++) {
-            const cell = tableEl.data.rows[r]?.cells[c];
-            if (!cell) continue;
-            // Skip covered cells — they have no rect of their own; the
-            // anchor's rect (with its full merged span) is painted from
-            // its own (r, c).
-            if (cell.gridSpan === 0 || cell.rowSpan === 0) continue;
-            const gs = Math.min(
-              Math.max(cell.gridSpan ?? 1, 1),
-              nCols - c,
-            );
-            const rs = Math.min(
-              Math.max(cell.rowSpan ?? 1, 1),
-              nRows - r,
-            );
-            const x0 = layout.colX[c];
-            const x1 = layout.colX[c + gs];
-            const y0 = layout.rowY[r];
-            const y1 = layout.rowY[r + rs];
-            cellRangeRects.push({
-              x: tableEl.frame.x + x0,
-              y: tableEl.frame.y + y0,
-              w: x1 - x0,
-              h: y1 - y0,
-              rotation: tableEl.frame.rotation,
-            });
-          }
-        }
+        cellRangeRects = projectCellRangeRects(
+          tableEl,
+          { r0: sel.r0, c0: sel.c0, r1: sel.r1, c1: sel.c1 },
+          layout,
+        );
       } else {
         // The table was removed (or replaced); drop the stale selection.
         this.setCellSelection(null);
@@ -1156,7 +1127,7 @@ class SlidesEditorImpl implements SlidesEditor {
       scale: this.scale(),
       slideWidth: SLIDE_WIDTH,
       slideHeight: SLIDE_HEIGHT,
-      peerOverlays: this.currentPeerOverlays(slide),
+      peerOverlays: this.currentPeerOverlays(slide, deckFontScale(doc.meta)),
       // Pass the full slide so connector endpoint handles can resolve
       // `attached` endpoints to world positions via the host element's
       // frame. Free endpoints don't need this map but it's cheap to
@@ -5134,7 +5105,9 @@ class SlidesEditorImpl implements SlidesEditor {
   ): void {
     const slide = this.currentSlide();
     if (!slide) return;
-    this.renderer.forceRender(slide, this.options.store.read(), ghosts);
+    // One read clone serves the ghost render, peer font scale, and guides.
+    const doc = this.options.store.read();
+    this.renderer.forceRender(slide, doc, ghosts);
     renderOverlay(this.options.overlay, handleElements, {
       scale: this.scale(),
       slideWidth: SLIDE_WIDTH,
@@ -5142,11 +5115,11 @@ class SlidesEditorImpl implements SlidesEditor {
       // Keep peer rings / name tags visible through the gesture preview —
       // this path rebuilds the overlay DOM, so omitting peers would drop
       // them on the first drag/resize/rotate repaint until the gesture ends.
-      peerOverlays: this.currentPeerOverlays(slide),
+      peerOverlays: this.currentPeerOverlays(slide, deckFontScale(doc.meta)),
       guides,
       allElements: slide.elements,
       connectorAffordance: this.connectorAffordance(),
-      permanentGuides: this.options.store.read().guides,
+      permanentGuides: doc.guides,
       pendingGuide: this.pendingGuide,
     });
   }
@@ -5162,14 +5135,30 @@ class SlidesEditorImpl implements SlidesEditor {
    * filters to peers on `slide` and prefers their live `activeFrames`
    * over the static selection ring. Shared by `repaintOverlay` and
    * `paintGhostPreview` so peers render in every overlay path.
+   *
+   * `fontScale` (deck pt→px) is threaded in so the cell-range projector
+   * lays out a peer's selected table on the same grid the renderer used;
+   * callers pass `deckFontScale(doc.meta)` from the doc they already hold.
    */
-  private currentPeerOverlays(slide: Slide): PeerOverlays | undefined {
+  private currentPeerOverlays(
+    slide: Slide,
+    fontScale: number,
+  ): PeerOverlays | undefined {
     if (this.peers.length === 0) return undefined;
     const peerLookup = buildElementWorldLookup(slide.elements);
     return computePeerOverlays(
       this.peers,
       slide.id,
       (id) => peerLookup.get(id)?.frame,
+      // Project a peer's table cell-range onto the painted grid. Only
+      // invoked when a peer actually has `selectedTableCells`, so the
+      // layout cost stays off the common no-cell-presence path.
+      (elementId, range) => {
+        const el = findElement(slide.elements, elementId);
+        if (el?.type !== 'table') return undefined;
+        const layout = computeTableLayout(el.data, { fontScale });
+        return projectCellRangeRects(el, range, layout);
+      },
     );
   }
 

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -715,6 +715,28 @@ function makeTableResizePreview(
 }
 
 /**
+ * Position a non-interactive overlay div at a world `frame` scaled to the
+ * viewport: left/top/size, `border-box`, `pointer-events:none`, and the
+ * shared `!== 0` rotation guard (CSS-rotate about the box centre). The
+ * caller owns only the paint (fill / border). Shared by the cell-range
+ * highlight, the peer cell highlights, and the dashed outline so the
+ * frame→CSS math lives in one place.
+ */
+function positionRect(el: HTMLDivElement, frame: Frame, scale: number): void {
+  el.style.position = 'absolute';
+  el.style.left = `${frame.x * scale}px`;
+  el.style.top = `${frame.y * scale}px`;
+  el.style.width = `${frame.w * scale}px`;
+  el.style.height = `${frame.h * scale}px`;
+  el.style.boxSizing = 'border-box';
+  el.style.pointerEvents = 'none';
+  if (frame.rotation !== 0) {
+    el.style.transform = `rotate(${frame.rotation}rad)`;
+    el.style.transformOrigin = 'center';
+  }
+}
+
+/**
  * Cell-range selection highlight: a semi-transparent blue fill over the
  * cell's world rect. Lives below the selection handles so the table's
  * outer handles still receive pointer events for resize. Stacks
@@ -724,18 +746,8 @@ function makeTableResizePreview(
  */
 function makeCellRangeRect(frame: Frame, scale: number): HTMLDivElement {
   const div = document.createElement('div');
-  div.style.position = 'absolute';
-  div.style.left = `${frame.x * scale}px`;
-  div.style.top = `${frame.y * scale}px`;
-  div.style.width = `${frame.w * scale}px`;
-  div.style.height = `${frame.h * scale}px`;
+  positionRect(div, frame, scale);
   div.style.background = 'rgba(26, 115, 232, 0.18)';
-  div.style.boxSizing = 'border-box';
-  div.style.pointerEvents = 'none';
-  if (frame.rotation !== 0) {
-    div.style.transformOrigin = 'center';
-    div.style.transform = `rotate(${frame.rotation}rad)`;
-  }
   div.dataset.slidesCellRange = 'true';
   return div;
 }
@@ -758,20 +770,8 @@ function appendOutline(
 ): void {
   const el = document.createElement('div');
   el.className = className;
-  el.style.position = 'absolute';
-  el.style.left = `${frame.x * scale}px`;
-  el.style.top = `${frame.y * scale}px`;
-  el.style.width = `${frame.w * scale}px`;
-  el.style.height = `${frame.h * scale}px`;
-  // Match renderRotatedHandles' `!== 0` guard (Frame.rotation is always
-  // a number); a non-zero rotation CSS-rotates the box about its centre.
-  if (frame.rotation !== 0) {
-    el.style.transform = `rotate(${frame.rotation}rad)`;
-    el.style.transformOrigin = 'center';
-  }
-  el.style.boxSizing = 'border-box';
+  positionRect(el, frame, scale);
   el.style.border = border;
-  el.style.pointerEvents = 'none';
   overlay.appendChild(el);
 }
 
@@ -819,19 +819,9 @@ function renderPeerOverlays(
   for (const cell of peers.cellRects) {
     const el = document.createElement('div');
     el.className = 'wfb-slides-peer-cell';
-    el.style.position = 'absolute';
-    el.style.left = `${cell.frame.x * scale}px`;
-    el.style.top = `${cell.frame.y * scale}px`;
-    el.style.width = `${cell.frame.w * scale}px`;
-    el.style.height = `${cell.frame.h * scale}px`;
+    positionRect(el, cell.frame, scale);
     el.style.background = cell.color;
     el.style.opacity = '0.22';
-    el.style.boxSizing = 'border-box';
-    el.style.pointerEvents = 'none';
-    if (cell.frame.rotation !== 0) {
-      el.style.transform = `rotate(${cell.frame.rotation}rad)`;
-      el.style.transformOrigin = 'center';
-    }
     overlay.appendChild(el);
   }
 

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -810,6 +810,31 @@ function renderPeerOverlays(
     overlay.appendChild(el);
   }
 
+  // Peer table cell-range highlights: a translucent peer-tinted fill per
+  // cell, painted before rings/labels so a peer ring (e.g. of another
+  // selected element) and the name tag stay legible on top. Opacity on
+  // the element (not an rgba colour) keeps this independent of the peer
+  // colour's format. Overlapping cells deepen slightly, same as the local
+  // cell-range overlay.
+  for (const cell of peers.cellRects) {
+    const el = document.createElement('div');
+    el.className = 'wfb-slides-peer-cell';
+    el.style.position = 'absolute';
+    el.style.left = `${cell.frame.x * scale}px`;
+    el.style.top = `${cell.frame.y * scale}px`;
+    el.style.width = `${cell.frame.w * scale}px`;
+    el.style.height = `${cell.frame.h * scale}px`;
+    el.style.background = cell.color;
+    el.style.opacity = '0.22';
+    el.style.boxSizing = 'border-box';
+    el.style.pointerEvents = 'none';
+    if (cell.frame.rotation !== 0) {
+      el.style.transform = `rotate(${cell.frame.rotation}rad)`;
+      el.style.transformOrigin = 'center';
+    }
+    overlay.appendChild(el);
+  }
+
   for (const ring of peers.rings) {
     // Reuse the shared outline builder (same rotated-frame math as the
     // member / context outlines) with a solid peer-coloured border.

--- a/packages/slides/src/view/editor/peers.ts
+++ b/packages/slides/src/view/editor/peers.ts
@@ -131,8 +131,21 @@ export function computePeerOverlays(
     if (peer.activeSlideId !== currentSlideId) continue;
 
     let anchor: { x: number; y: number } | undefined;
-    // The table whose ring is replaced by cell highlights below.
-    const cellTableId = peer.selectedTableCells?.elementId;
+
+    // Project a cell-range selection first so the ring loop can drop the
+    // table's plain outline ONLY when highlights actually replace it. A
+    // merge-hole drag range (or a deleted table) yields no rects — keep
+    // the ring then so the peer's presence never goes invisible.
+    const peerCellRects: Frame[] = [];
+    let cellTableId: string | undefined;
+    if (peer.selectedTableCells && cellRangeRectsOf) {
+      const sel = peer.selectedTableCells;
+      const rects = cellRangeRectsOf(sel.elementId, sel);
+      if (rects && rects.length > 0) {
+        for (const frame of rects) peerCellRects.push(frame);
+        cellTableId = sel.elementId;
+      }
+    }
 
     if (peer.activeFrames && peer.activeFrames.length > 0) {
       for (const f of peer.activeFrames) {
@@ -151,15 +164,9 @@ export function computePeerOverlays(
       }
     }
 
-    if (peer.selectedTableCells && cellRangeRectsOf) {
-      const { elementId, r0, c0, r1, c1 } = peer.selectedTableCells;
-      const rects = cellRangeRectsOf(elementId, { r0, c0, r1, c1 });
-      if (rects) {
-        for (const frame of rects) cellRects.push({ frame, color: peer.color });
-        if (!anchor && rects.length > 0) {
-          anchor = { x: rects[0].x, y: rects[0].y };
-        }
-      }
+    for (const frame of peerCellRects) cellRects.push({ frame, color: peer.color });
+    if (!anchor && peerCellRects.length > 0) {
+      anchor = { x: peerCellRects[0].x, y: peerCellRects[0].y };
     }
 
     if (peer.draggingGuide) {

--- a/packages/slides/src/view/editor/peers.ts
+++ b/packages/slides/src/view/editor/peers.ts
@@ -34,6 +34,19 @@ export interface PeerView {
   }>;
   /** Live preview of a guide the peer is creating or dragging. */
   draggingGuide?: { axis: 'x' | 'y'; position: number };
+  /**
+   * Cell range the peer has selected inside a table. The static analogue
+   * of `selectedElementIds` for tables — when present, the table's plain
+   * selection ring is suppressed and the cells are highlighted instead
+   * (matching the local cell-range overlay). `elementId` is the table.
+   */
+  selectedTableCells?: {
+    elementId: string;
+    r0: number;
+    c0: number;
+    r1: number;
+    c1: number;
+  };
 }
 
 /** A peer selection / live-frame outline, in world coords. */
@@ -57,11 +70,29 @@ export interface PeerGuideLine {
   color: string;
 }
 
+/** A single highlighted table cell in a peer's cell-range selection. */
+export interface PeerCellRect {
+  frame: Frame;
+  color: string;
+}
+
 export interface PeerOverlays {
   rings: PeerRing[];
   labels: PeerLabel[];
   guides: PeerGuideLine[];
+  cellRects: PeerCellRect[];
 }
+
+/**
+ * Resolve a peer's table cell-range to world-space rects. Injected by the
+ * editor (which owns `computeTableLayout` + `projectCellRangeRects`) so
+ * `computePeerOverlays` stays geometry-free and unit-testable. Returns
+ * `undefined` when the table id no longer resolves on the current slide.
+ */
+export type CellRangeRectsOf = (
+  elementId: string,
+  range: { r0: number; c0: number; r1: number; c1: number },
+) => Frame[] | undefined;
 
 /**
  * Project the peers active on the current slide into overlay draw specs.
@@ -74,25 +105,34 @@ export interface PeerOverlays {
  * For each peer on `currentSlideId`:
  *  - if it has live `activeFrames`, every frame becomes a ring (the
  *    static selection ring is suppressed to avoid a doubled outline);
- *  - otherwise each resolvable `selectedElementIds` frame becomes a ring;
- *  - a single name-tag label anchors to the first ring's top-left;
+ *  - otherwise each resolvable `selectedElementIds` frame becomes a ring,
+ *    EXCEPT the table a peer is cell-selecting (its cells are highlighted
+ *    instead, so the ring would double the outline);
+ *  - `selectedTableCells` becomes per-cell highlight rects (via the
+ *    injected `cellRangeRectsOf`);
+ *  - a single name-tag label anchors to the first ring's top-left, or the
+ *    first cell rect when only a cell range is selected;
  *  - a `draggingGuide` becomes a guide line.
  */
 export function computePeerOverlays(
   peers: readonly PeerView[],
   currentSlideId: string | undefined,
   worldFrameOf: (elementId: string) => Frame | undefined,
+  cellRangeRectsOf?: CellRangeRectsOf,
 ): PeerOverlays {
   const rings: PeerRing[] = [];
   const labels: PeerLabel[] = [];
   const guides: PeerGuideLine[] = [];
+  const cellRects: PeerCellRect[] = [];
 
-  if (!currentSlideId) return { rings, labels, guides };
+  if (!currentSlideId) return { rings, labels, guides, cellRects };
 
   for (const peer of peers) {
     if (peer.activeSlideId !== currentSlideId) continue;
 
     let anchor: { x: number; y: number } | undefined;
+    // The table whose ring is replaced by cell highlights below.
+    const cellTableId = peer.selectedTableCells?.elementId;
 
     if (peer.activeFrames && peer.activeFrames.length > 0) {
       for (const f of peer.activeFrames) {
@@ -102,10 +142,23 @@ export function computePeerOverlays(
       }
     } else if (peer.selectedElementIds && peer.selectedElementIds.length > 0) {
       for (const id of peer.selectedElementIds) {
+        // The cell-selected table shows highlights, not a ring.
+        if (id === cellTableId) continue;
         const frame = worldFrameOf(id);
         if (!frame) continue;
         rings.push({ frame, color: peer.color });
         if (!anchor) anchor = { x: frame.x, y: frame.y };
+      }
+    }
+
+    if (peer.selectedTableCells && cellRangeRectsOf) {
+      const { elementId, r0, c0, r1, c1 } = peer.selectedTableCells;
+      const rects = cellRangeRectsOf(elementId, { r0, c0, r1, c1 });
+      if (rects) {
+        for (const frame of rects) cellRects.push({ frame, color: peer.color });
+        if (!anchor && rects.length > 0) {
+          anchor = { x: rects[0].x, y: rects[0].y };
+        }
       }
     }
 
@@ -122,5 +175,5 @@ export function computePeerOverlays(
     }
   }
 
-  return { rings, labels, guides };
+  return { rings, labels, guides, cellRects };
 }

--- a/packages/slides/test/view/canvas/table-cell-range-rects.test.ts
+++ b/packages/slides/test/view/canvas/table-cell-range-rects.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import type { Frame, TableElement } from '../../../src/model/element';
+import {
+  computeTableLayout,
+  projectCellRangeRects,
+} from '../../../src/view/canvas/table-renderer';
+
+/** Build a uniform-grid table at `frame` with the given column widths /
+ *  row heights, all cells empty + unmerged unless overridden. */
+function table(
+  frame: Frame,
+  columnWidths: number[],
+  rowHeights: number[],
+  override: (r: number, c: number) => Partial<TableElement['data']['rows'][number]['cells'][number]> = () => ({}),
+): TableElement {
+  return {
+    id: 't1',
+    type: 'table',
+    frame,
+    data: {
+      columnWidths,
+      rows: rowHeights.map((height, r) => ({
+        height,
+        cells: columnWidths.map((_, c) => ({
+          body: { blocks: [] },
+          style: {},
+          ...override(r, c),
+        })),
+      })),
+    },
+  };
+}
+
+const f = (x: number, y: number, w: number, h: number, rotation = 0): Frame => ({
+  x,
+  y,
+  w,
+  h,
+  rotation,
+});
+
+describe('projectCellRangeRects', () => {
+  it('projects a single cell to a frame offset by the table origin', () => {
+    const t = table(f(100, 200, 100, 40), [40, 60], [20, 20]);
+    const layout = computeTableLayout(t.data);
+    const rects = projectCellRangeRects(t, { r0: 1, c0: 1, r1: 1, c1: 1 }, layout);
+    // Cell (1,1): x = 100 + 40, y = 200 + 20, w = 60, h = 20.
+    expect(rects).toEqual([f(140, 220, 60, 20)]);
+  });
+
+  it('emits one rect per non-covered cell across a range', () => {
+    const t = table(f(0, 0, 100, 40), [50, 50], [20, 20]);
+    const layout = computeTableLayout(t.data);
+    const rects = projectCellRangeRects(t, { r0: 0, c0: 0, r1: 1, c1: 1 }, layout);
+    expect(rects).toEqual([
+      f(0, 0, 50, 20),
+      f(50, 0, 50, 20),
+      f(0, 20, 50, 20),
+      f(50, 20, 50, 20),
+    ]);
+  });
+
+  it('normalizes a reversed (focus-before-anchor) range', () => {
+    const t = table(f(0, 0, 100, 40), [50, 50], [20, 20]);
+    const layout = computeTableLayout(t.data);
+    const forward = projectCellRangeRects(t, { r0: 0, c0: 0, r1: 1, c1: 1 }, layout);
+    const reversed = projectCellRangeRects(t, { r0: 1, c0: 1, r1: 0, c1: 0 }, layout);
+    expect(reversed).toEqual(forward);
+  });
+
+  it('expands a merge anchor to its full span and skips covered cells', () => {
+    // Top row is one 2-wide merged cell: anchor (0,0) gridSpan 2,
+    // covered cell (0,1) gridSpan 0.
+    const t = table(f(0, 0, 100, 40), [50, 50], [20, 20], (r, c) => {
+      if (r === 0 && c === 0) return { gridSpan: 2 };
+      if (r === 0 && c === 1) return { gridSpan: 0 };
+      return {};
+    });
+    const layout = computeTableLayout(t.data);
+    const rects = projectCellRangeRects(t, { r0: 0, c0: 0, r1: 0, c1: 1 }, layout);
+    // Only the anchor contributes a rect, spanning both columns.
+    expect(rects).toEqual([f(0, 0, 100, 20)]);
+  });
+
+  it('carries the table rotation onto every rect', () => {
+    const t = table(f(0, 0, 100, 20), [50, 50], [20], () => ({}));
+    t.frame.rotation = 0.5;
+    const layout = computeTableLayout(t.data);
+    const rects = projectCellRangeRects(t, { r0: 0, c0: 0, r1: 0, c1: 1 }, layout);
+    expect(rects.every((r) => r.rotation === 0.5)).toBe(true);
+  });
+});

--- a/packages/slides/test/view/editor/peers.test.ts
+++ b/packages/slides/test/view/editor/peers.test.ts
@@ -121,4 +121,65 @@ describe('computePeerOverlays', () => {
     expect(out.rings).toEqual([]);
     expect(out.labels).toEqual([]);
   });
+
+  it('highlights a peer table cell-range and suppresses that table ring', () => {
+    const rects = [frame(0, 0, 60, 20), frame(0, 20, 60, 20)];
+    const out = computePeerOverlays(
+      [
+        peer({
+          clientID: 'c1',
+          // The table is element-selected AND cell-selected — the ring
+          // is replaced by the cell highlights to avoid a doubled outline.
+          selectedElementIds: ['t1'],
+          selectedTableCells: { elementId: 't1', r0: 0, c0: 0, r1: 1, c1: 0 },
+        }),
+      ],
+      's1',
+      lookup({ t1: frame(100, 100, 60, 40) }),
+      (elementId) => (elementId === 't1' ? rects : undefined),
+    );
+    expect(out.rings).toEqual([]);
+    expect(out.cellRects).toEqual([
+      { frame: rects[0], color: '#ff0000' },
+      { frame: rects[1], color: '#ff0000' },
+    ]);
+    // Label falls back to the first cell rect when no ring anchors it.
+    expect(out.labels).toEqual([{ x: 0, y: 0, text: 'Ada', color: '#ff0000' }]);
+  });
+
+  it('keeps rings for other selected elements while highlighting the cell table', () => {
+    const rects = [frame(0, 0, 60, 20)];
+    const out = computePeerOverlays(
+      [
+        peer({
+          clientID: 'c1',
+          selectedElementIds: ['t1', 'e2'],
+          selectedTableCells: { elementId: 't1', r0: 0, c0: 0, r1: 0, c1: 0 },
+        }),
+      ],
+      's1',
+      lookup({ t1: frame(100, 100, 60, 40), e2: frame(5, 5, 10, 10) }),
+      () => rects,
+    );
+    // t1's ring is suppressed; e2 still rings. Cell highlights come from t1.
+    expect(out.rings).toEqual([{ frame: frame(5, 5, 10, 10), color: '#ff0000' }]);
+    expect(out.cellRects).toEqual([{ frame: rects[0], color: '#ff0000' }]);
+    // Anchor prefers the first resolved ring (e2) over the cell rect.
+    expect(out.labels).toEqual([{ x: 5, y: 5, text: 'Ada', color: '#ff0000' }]);
+  });
+
+  it('omits cell highlights when no projector is supplied', () => {
+    const out = computePeerOverlays(
+      [
+        peer({
+          clientID: 'c1',
+          selectedElementIds: ['t1'],
+          selectedTableCells: { elementId: 't1', r0: 0, c0: 0, r1: 0, c1: 0 },
+        }),
+      ],
+      's1',
+      lookup({ t1: frame(0, 0, 10, 10) }),
+    );
+    expect(out.cellRects).toEqual([]);
+  });
 });

--- a/packages/slides/test/view/editor/peers.test.ts
+++ b/packages/slides/test/view/editor/peers.test.ts
@@ -168,7 +168,7 @@ describe('computePeerOverlays', () => {
     expect(out.labels).toEqual([{ x: 5, y: 5, text: 'Ada', color: '#ff0000' }]);
   });
 
-  it('omits cell highlights when no projector is supplied', () => {
+  it('omits cell highlights but keeps the table ring when no projector is supplied', () => {
     const out = computePeerOverlays(
       [
         peer({
@@ -181,5 +181,26 @@ describe('computePeerOverlays', () => {
       lookup({ t1: frame(0, 0, 10, 10) }),
     );
     expect(out.cellRects).toEqual([]);
+    // No rects → presence must not vanish: the table ring is kept.
+    expect(out.rings).toEqual([{ frame: frame(0, 0, 10, 10), color: '#ff0000' }]);
+  });
+
+  it('keeps the table ring when the cell projector yields no rects (merge hole)', () => {
+    const out = computePeerOverlays(
+      [
+        peer({
+          clientID: 'c1',
+          selectedElementIds: ['t1'],
+          selectedTableCells: { elementId: 't1', r0: 0, c0: 1, r1: 0, c1: 2 },
+        }),
+      ],
+      's1',
+      lookup({ t1: frame(0, 0, 80, 40) }),
+      // Range falls entirely on merge-covered cells → empty projection.
+      () => [],
+    );
+    expect(out.cellRects).toEqual([]);
+    expect(out.rings).toEqual([{ frame: frame(0, 0, 80, 40), color: '#ff0000' }]);
+    expect(out.labels).toEqual([{ x: 0, y: 0, text: 'Ada', color: '#ff0000' }]);
   });
 });


### PR DESCRIPTION
## Summary

Adds **table cell-range peer presence** to the slides editor — the
`selectedTableCells` field from the slides-tables P5 plan
(`docs/tasks/active/20260608-slides-tables-todo.md`).

When a collaborator selects a cell range inside a table, peers now see
their selection as translucent peer-tinted cell highlights, mirroring
how `selectedElementIds` already renders peer selection rings. This is
the static analogue of element selection presence.

Pipeline:
`SlidesPresence.selectedTableCells` → broadcast on
`editor.onCellSelectionChange` (alongside the existing selection/slide
broadcast) → `mapPresenceToPeerView` → `computePeerOverlays` (new
`cellRangeRectsOf` projector + `cellRects` output) → `renderPeerOverlays`
cell fills.

The cell-range→world-rect geometry the local overlay already computed
inline is extracted into a shared `projectCellRangeRects` helper in
`table-renderer.ts`, reused by both the local path and the peer
projector — keeping `computePeerOverlays` geometry-free and
unit-testable. `overlay.ts` gains a shared `positionRect` helper so the
frame→CSS math lives in one place across the three rect builders.

The cell-selected table's plain selection ring is suppressed to avoid a
doubled outline — but only when highlights actually render, so a
merge-hole drag range or a deleted table keeps the ring and presence
never goes invisible.

### Deferred (with rationale, see todo)
- **`resizingTableEdge`** — a live drag preview; pairs with the
  still-deferred `activeFrames` live-frame broadcast (same
  gesture-end-clearing problem).
- **`textCursorCell`** — needs a slides peer text-caret layer that does
  not exist yet (only docs renders peer carets).

## Test plan
- `pnpm verify:fast` — green.
- New unit tests:
  - `projectCellRangeRects` geometry (single/range/reversed/merged-span/
    rotation) — `slides/test/view/canvas/table-cell-range-rects.test.ts`.
  - `computePeerOverlays` cell-range cases incl. ring suppression and the
    keep-ring-on-empty-projection edge — `slides/test/view/editor/peers.test.ts`.
  - `mapPresenceToPeerView` forwards `selectedTableCells` —
    `frontend/tests/app/slides/peer-view.test.ts`.
- **Remaining**: live two-user smoke (one peer cell-selects, the other
  sees the highlights track + clear) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)