### PR TITLE
Preserve fill/border on txBox=1 text boxes in PPTX import

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| pptx textbox fill import (2026-06-23) | [20260623-pptx-textbox-fill-import-todo.md](./active/20260623-pptx-textbox-fill-import-todo.md) | [20260623-pptx-textbox-fill-import-lessons.md](./active/20260623-pptx-textbox-fill-import-lessons.md) |
 | docs comments followup (2026-05-17) | [20260517-docs-comments-followup-todo.md](./active/20260517-docs-comments-followup-todo.md) | [20260517-docs-comments-followup-lessons.md](./active/20260517-docs-comments-followup-lessons.md) |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
 | pdf export followup (2026-05-01) | [20260501-pdf-export-followup-todo.md](./active/20260501-pdf-export-followup-todo.md) | - |
@@ -29,4 +30,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 309
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: docs comments followup (2026-05-17)
+Latest active task: pptx textbox fill import (2026-06-23)

--- a/docs/tasks/active/20260623-pptx-textbox-fill-import-lessons.md
+++ b/docs/tasks/active/20260623-pptx-textbox-fill-import-lessons.md
@@ -1,0 +1,29 @@
+# Lessons — PPTX text-box fill/border import
+
+## Don't trust simplifying comments as invariants
+
+The dropped-fill bug was guarded by a confident comment: "`txBox=1`
+shapes have no fill/stroke and exist only as a host for `<p:txBody>`."
+That is false for real exports — Google Slides emits labelled callout
+boxes as `txBox="1"` with explicit `solidFill` + `ln`. When a branch
+discards data based on an assumption, check the assumption against a real
+file before trusting it.
+
+## Verify on the real artifact, not just a synthetic test
+
+The synthetic test used `srgbClr` for the fill and passed immediately
+after the fix. The real `slide7.xml` uses `schemeClr val="lt1"`, which
+takes a different code path (`clrMap` → `SCHEME_TO_ROLE`). Running the
+fix against the actual file caught that my test's `clrMap` was malformed
+(I mapped the scheme token to a hex string instead of a scheme slot
+name). `clrMap` maps an OOXML scheme token → scheme slot name; an empty
+map is the identity mapping. Always re-run the fix on the source file
+that reproduced the bug.
+
+## Check the whole round-trip before adding fields
+
+Before threading fill/stroke through the importer I confirmed the model
+already had `TextElement.data.fill`/`stroke`, the renderer painted them
+(`text-renderer.ts:144-152`), and the exporter wrote them
+(`textElementToXml`). The gap was import-only, so the fix stayed small
+and the round-trip stayed symmetric — no new model fields, no migration.

--- a/docs/tasks/active/20260623-pptx-textbox-fill-import-todo.md
+++ b/docs/tasks/active/20260623-pptx-textbox-fill-import-todo.md
@@ -1,0 +1,46 @@
+# PPTX import: preserve fill/border on `txBox="1"` text boxes
+
+## Problem
+
+On an imported deck (slide 7 of "Yorkie 실시간 동시 편집 적용하기.pptx"), the
+"Network Interruption" box renders behind a connector line — its white
+background is gone, so the dark line shows through the box. In the
+original PPTX the box sits above the line in z-order and covers it.
+
+## Root cause
+
+The box is a Google-Slides-exported text box: a `<p:sp>` with
+`<p:cNvSpPr txBox="1"/>` that carries an explicit `<a:solidFill>`
+(white, `schemeClr lt1`) background **and** an `<a:ln>` black border.
+
+`parseSp` (`packages/slides/src/import/pptx/shape.ts`) routed every
+`txBox="1"` shape through `buildTextElement`, which only parsed the text
+body and **dropped** the fill/stroke — on the assumption "text boxes have
+no fill/stroke". So the box imported as a transparent `TextElement`, and
+the connector line (drawn just before it in z-order) showed through.
+
+The model (`TextElement.data.fill`/`stroke`), the renderer
+(`text-renderer.ts` paints both), and the PPTX exporter
+(`textElementToXml` writes both) all already supported a filled/bordered
+text box — only the importer was dropping the data.
+
+## Plan
+
+- [x] Reproduce: confirm slide-7 box is `txBox="1"` + `solidFill` + `ln`
+- [x] Confirm model/renderer/exporter already support text-box fill+stroke
+- [x] Failing test: filled+bordered `txBox="1"` keeps `data.fill`/`stroke`
+- [x] Fix: parse fill/stroke in the `isTextBox` branch, thread into
+      `buildTextElement`
+- [x] Verify on the real `slide7.xml` (schemeClr fill resolves to a role)
+- [x] Full slides test suite + sheets gate green
+
+## Review
+
+- Fix is 2 spots in `shape.ts`: the `isTextBox` branch now calls the
+  existing `parseShapeFill`/`parseShapeStroke` and passes the results to
+  `buildTextElement`, which gained two optional params.
+- No model/renderer/exporter change needed — round-trip stays symmetric.
+- Tests: `test/import/pptx/shape.test.ts` gains a regression case; full
+  slides suite 2274 pass / 2 skip; sheets 1279 pass.
+- Known unrelated failure: `test/anim/player.test.ts` `.at()` typecheck
+  error (pre-existing, CI never runs that gate).

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -449,10 +449,19 @@ async function parseSp(sp: Element, ctx: SlideParseContext): Promise<SlideElemen
   // element this `<p:sp>` emits by `parseChild`, which has the source
   // `<p:sp>` node and the slide clrMap in scope.
 
-  // Pure text box — `txBox=1` shapes have no fill/stroke and exist only
-  // as a host for `<p:txBody>`.
+  // Text box (`txBox=1`) — a `<p:txBody>` host that usually has no
+  // fill/stroke. But Google Slides exports labelled callout boxes as
+  // `txBox=1` shapes carrying an explicit `<a:solidFill>` background and
+  // `<a:ln>` border (e.g. the "Network Interruption" label); preserve
+  // those so the box stays opaque instead of letting underlying shapes
+  // (a connector line, here) show through it. The renderer paints a text
+  // element's `data.fill`/`data.stroke` just like a shape's.
   if (isTextBox && txBody) {
-    return [buildTextElement(elementId, frame, txBody, ctx, placeholderRef, layoutSizeKey)];
+    const fill = parseShapeFill(spPr, ctx);
+    const stroke = parseShapeStroke(spPr, ctx);
+    return [
+      buildTextElement(elementId, frame, txBody, ctx, placeholderRef, layoutSizeKey, fill, stroke),
+    ];
   }
 
   // Shape with `<a:blipFill>` — treat as picture, regardless of geometry.
@@ -633,13 +642,19 @@ function buildTextElement(
   ctx: SlideParseContext,
   placeholderRef: PlaceholderRef | undefined,
   layoutSizeKey: string | undefined,
+  fill?: TextElement['data']['fill'],
+  stroke?: TextElement['data']['stroke'],
 ): TextElement {
   return {
     id,
     type: 'text',
     frame,
     ...(placeholderRef ? { placeholderRef } : {}),
-    data: buildTextBody(txBody, ctx, placeholderRef, layoutSizeKey),
+    data: {
+      ...buildTextBody(txBody, ctx, placeholderRef, layoutSizeKey),
+      ...(fill ? { fill } : {}),
+      ...(stroke ? { stroke } : {}),
+    },
   };
 }
 

--- a/packages/slides/test/import/pptx/shape.test.ts
+++ b/packages/slides/test/import/pptx/shape.test.ts
@@ -77,6 +77,41 @@ const SLIDE_WITH_SHAPE_AND_EMPTY_TEXT = `<?xml version="1.0"?>
   </p:cSld>
 </p:sld>`;
 
+/**
+ * A `txBox="1"` `<p:sp>` that carries an explicit `<a:solidFill>` background
+ * and `<a:ln>` border. Google Slides exports labelled callout boxes this way
+ * (e.g. the "Network Interruption" box). The importer must preserve the fill
+ * and stroke; dropping them leaves the box transparent so underlying shapes
+ * (a connector line, here) show through it.
+ */
+const SLIDE_WITH_FILLED_TEXTBOX = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Label"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="0" y="0"/>
+            <a:ext cx="2000000" cy="500000"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+          <a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill>
+          <a:ln w="38100"><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:ln>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:rPr lang="en-US"/><a:t>Network Interruption</a:t></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
 describe('parseSlide — shape inline text', () => {
   it('folds <p:txBody> inside a prstGeom <p:sp> into ShapeElement.data.text', async () => {
     const slide = await parseSlide({
@@ -117,5 +152,31 @@ describe('parseSlide — shape inline text', () => {
     expect(el.type).toBe('shape');
     if (el.type !== 'shape') return;
     expect(el.data.text).toBeUndefined();
+  });
+
+  it('preserves the fill and border of a txBox="1" shape that carries them', async () => {
+    const slide = await parseSlide({
+      archive: makeArchive({
+        'ppt/slides/slide1.xml': SLIDE_WITH_FILLED_TEXTBOX,
+      }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    expect(slide).toBeDefined();
+    expect(slide!.elements).toHaveLength(1);
+    const el = slide!.elements[0];
+    expect(el.type).toBe('text');
+    if (el.type !== 'text') return;
+    // The white background must survive so the box stays opaque.
+    expect(el.data.fill).toBeDefined();
+    // The black border must survive too.
+    expect(el.data.stroke).toBeDefined();
+    expect(el.data.stroke!.width).toBeGreaterThan(0);
+    expect(el.data.blocks[0].inlines.map((i) => i.text).join('')).toBe(
+      'Network Interruption',
+    );
   });
 });


### PR DESCRIPTION
## Summary

On an imported deck, slide 7's "Network Interruption" box rendered
*behind* a connector line — its white background was gone, so the dark
line showed through. In the original PPTX the box sits above the line in
z-order and covers it.

Root cause is import-only: the box is a Google-Slides-exported text box
(`<p:sp>` with `<p:cNvSpPr txBox="1"/>`) that carries an explicit
`<a:solidFill>` background **and** `<a:ln>` border. `parseSp` routed
every `txBox="1"` shape through `buildTextElement`, which parsed only the
text body and **dropped** the fill/stroke (on the assumption that text
boxes have none). So the box imported transparent and the connector line
behind it showed through.

The `TextElement` model (`data.fill`/`stroke`), the canvas text renderer
(`text-renderer.ts` paints both), and the PPTX exporter
(`textElementToXml` writes both) all already support a filled/bordered
text box — only the importer was discarding the data. The fix parses
fill/stroke in the `isTextBox` branch via the existing
`parseShapeFill`/`parseShapeStroke` and threads them into
`buildTextElement`. No model/renderer/exporter change; round-trip stays
symmetric.

## Test plan

- New regression test in `test/import/pptx/shape.test.ts`: a
  filled+bordered `txBox="1"` shape keeps `data.fill` and `data.stroke`.
- Verified against the actual `slide7.xml` (its fill is `schemeClr lt1`,
  which resolves through `clrMap` → a `background` role).
- Full slides suite: 2274 pass / 2 skip. Sheets gate: 1279 pass.
- Pre-existing unrelated failure: `test/anim/player.test.ts` `.at()`
  typecheck error (CI never runs that gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)