### PR TITLE
Docs PDF: stop export throwing on C1 controls and U+201B

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -22,7 +22,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | docx table deferred (2026-06-26) | [20260626-docx-table-deferred-todo.md](./active/20260626-docx-table-deferred-todo.md) | - |
 | docs collaboration convergence (2026-06-25) | [20260625-docs-collaboration-convergence-todo.md](./active/20260625-docs-collaboration-convergence-todo.md) | [20260625-docs-collaboration-convergence-lessons.md](./active/20260625-docs-collaboration-convergence-lessons.md) |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
-| pdf export followup (2026-05-01) | [20260501-pdf-export-followup-todo.md](./active/20260501-pdf-export-followup-todo.md) | - |
+| pdf export followup (2026-05-01) | [20260501-pdf-export-followup-todo.md](./active/20260501-pdf-export-followup-todo.md) | [20260501-pdf-export-followup-lessons.md](./active/20260501-pdf-export-followup-lessons.md) |
 | docs wordprocessor (2026-03-25) | [20260325-docs-wordprocessor-todo.md](./active/20260325-docs-wordprocessor-todo.md) | [20260325-docs-wordprocessor-lessons.md](./active/20260325-docs-wordprocessor-lessons.md) |
 
 ## Archive

--- a/docs/tasks/active/20260501-pdf-export-followup-lessons.md
+++ b/docs/tasks/active/20260501-pdf-export-followup-lessons.md
@@ -1,0 +1,43 @@
+# PDF export follow-up — Lessons
+
+## WinAnsi "Latin-safe" classification must be exact
+
+- The painter routes characters to pdf-lib StandardFonts (WinAnsi) vs the
+  embedded Korean font by a `LATIN_SAFE_CHARS` character class. WinAnsi
+  *throws* on any code point it can't encode, and that throw is not local
+  — it aborts the whole `PdfExporter.export`. So a too-permissive safe
+  class is a latent "one bad character kills the export" bug, not a
+  cosmetic glyph issue.
+- Two specific traps in a `U+0000–U+00FF`-style range:
+  - **C1 controls (U+0080–U+009F)** look like Latin-1 but are unencodable
+    controls. Strip them alongside C0/DEL; they're invisible paste
+    artifacts with no layout meaning.
+  - **U+201B** sits inside the obvious `U+2018–U+201E` quote range but is
+    absent from CP1252. Enumerate quote ranges around it, not through it.
+- Verify exhaustively, not by sampling: probing *every* code point the
+  classifier called "safe" against `font.widthOfTextAtSize` /
+  `encodeText` surfaced the complete 33-char set in one shot and proved
+  0 throwers after the fix. Cheaper and more convincing than hand-picking
+  examples.
+
+## The scan/paint sync contract
+
+- `scanFontsUsed` (pdf-fonts.ts) decides *which* fonts get embedded;
+  `splitMixedScript`/`resolveFontKey` (pdf-style-map.ts) decide *which*
+  font each run uses. If a character routes to `kr-*` at paint time but
+  `scanFontsUsed` didn't flag `needsKR`, `embedAllFonts` aliases `kr-*`
+  back to Helvetica and the draw throws. Any change to one file's
+  character class must be mirrored in the other.
+
+## Tooling note: invisible bytes in source
+
+- Writing literal C1/control bytes into a file is fragile — they're
+  invisible in Read output, the Edit tool can't reliably match them (it
+  normalizes `\uXXXX` escapes), and they make git treat the file as
+  binary. In tests, build control characters with
+  `String.fromCharCode(0x90)` constants; in prose, write them in escape
+  notation (`U+0080`). A quick node scan for code points in `0x00-0x1F` /
+  `0x7F-0x9F` confirms no stray bytes slipped in.
+- Editing a regex that already contains literal `\u` escapes: the Edit
+  tool kept failing to match. A tiny `node -e` string replace on the raw
+  file bytes is the reliable fallback.

--- a/docs/tasks/active/20260501-pdf-export-followup-todo.md
+++ b/docs/tasks/active/20260501-pdf-export-followup-todo.md
@@ -1,7 +1,7 @@
 ---
 title: PDF export — font fallback and regression coverage follow-up
 date: 2026-05-01
-status: not-started
+status: complete
 parent: 20260501-pdf-export-parity (archived)
 ---
 
@@ -12,10 +12,61 @@ fixes shipped in #168 / #170 / #171.
 
 ## Remaining work
 
-- [ ] Investigate remaining font fallback / glyph issues observed after
+- [x] Investigate remaining font fallback / glyph issues observed after
       table content parity landed (Korean / mixed-script runs).
-- [ ] Add focused regression tests once the broken font/glyph cases are
+- [x] Add focused regression tests once the broken font/glyph cases are
       reduced to minimal repro fixtures.
+
+## Investigation findings
+
+The PDF painter classifies each character of a run as "Latin-safe" (drawn
+with pdf-lib's WinAnsi-encoded StandardFonts) or "needs the embedded
+Korean font". An exhaustive probe of every code point the painter treated
+as Latin-safe found **33 characters that WinAnsi cannot actually encode** —
+for those, `widthOfTextAtSize` / `drawText` *throws* (`WinAnsi cannot
+encode "…"`), which aborts the **entire** export, not just one run:
+
+1. **U+0080–U+009F (C1 controls, 32 chars).** These sit inside the
+   `U+0000–U+00FF` "safe" range, but `splitMixedScript` only stripped C0
+   controls + DEL (`U+0000–U+001F`, `U+007F`). A pasted/imported stray C1
+   byte reached Helvetica/Times and threw.
+2. **U+201B (reversed-9 quote).** The `U+2018–U+201E` "specials" range
+   wrongly included it; CP1252 has no slot for U+201B, so the StandardFonts
+   threw.
+
+### Fix
+
+- `pdf-style-map.ts`
+  - Strip regex extended to C1: `[U+0000–U+001F, U+007F]` →
+    `[U+0000–U+001F, U+007F–U+009F]` (C1 controls are invisible paste
+    artifacts, dropped like C0).
+  - `LATIN_SAFE_CHARS` quote block split around U+201B:
+    `U+2018–U+201E` → `U+2018–U+201A` + `U+201C–U+201E`, so U+201B routes
+    to the embedded font instead of throwing.
+- `pdf-fonts.ts`
+  - `LATIN_SPECIAL_CHARS` given the same U+201B carve-out so
+    `scanFontsUsed` flags `needsKR` when U+201B is present — otherwise
+    `resolveFontKey` would alias `kr-*` back to Helvetica and throw again.
+    The two files' character classes are a documented contract.
+
+### Verification
+
+- New `test/export/pdf-font-fallback.test.ts`: unit coverage for C1
+  stripping + U+201B routing, `scanFontsUsed` KR-embed trigger, and
+  end-to-end `PdfExporter.export` no-throw for C1 / U+201B / mixed
+  Korean-Latin-special runs. Tests fail on `main`, pass after the fix.
+- Exhaustive re-probe after the fix: **0 throwers** across the whole
+  Latin-safe range for both Helvetica and Times (was 33).
+- Full `test/export/` suite green (105 tests); `pnpm verify:fast` green.
+
+### Known limitation (accepted)
+
+Routing U+201B to the embedded font means a doc that is otherwise pure
+Latin but contains a stray U+201B now triggers the Noto KR fetch. This is
+consistent with the existing design — any non-WinAnsi character (a `•`
+bullet, `※`, `●`, etc.) already forces the KR embed — and is strictly
+better than the pre-fix hard throw. No separate lightweight fallback font
+is introduced (out of scope).
 
 ## References
 

--- a/packages/docs/src/export/pdf-fonts.ts
+++ b/packages/docs/src/export/pdf-fonts.ts
@@ -7,7 +7,10 @@ import type { Document, Block, Inline } from '../model/types.js';
 // The WinAnsi "specials" beyond Latin-1 (U+0000–U+00FF) that pdf-lib's
 // StandardFonts can still encode: typographic quotes, dashes, the Euro
 // sign, etc. Factored out so both regexes below derive from one source.
-const LATIN_SPECIAL_CHARS = '\\u0152\\u0153\\u0160\\u0161\\u017D\\u017E\\u0192\\u02C6\\u02DC\\u2013\\u2014\\u2018-\\u201E\\u2020-\\u2022\\u2026\\u2030\\u2039\\u203A\\u20AC\\u2122';
+// The quote block is split around U+201B (reversed-9 quote), which CP1252
+// can't encode — it must route to the Korean font. Keep in sync with the
+// `LATIN_SAFE_CHARS` definition in `pdf-style-map.ts`.
+const LATIN_SPECIAL_CHARS = '\\u0152\\u0153\\u0160\\u0161\\u017D\\u017E\\u0192\\u02C6\\u02DC\\u2013\\u2014\\u2018-\\u201A\\u201C-\\u201E\\u2020-\\u2022\\u2026\\u2030\\u2039\\u203A\\u20AC\\u2122';
 // Match `splitMixedScript`'s definition in pdf-style-map.ts: any character
 // pdf-lib's WinAnsi-encoded StandardFonts cannot encode. Detecting these
 // here triggers Korean font embed so the painter has glyphs for CJK

--- a/packages/docs/src/export/pdf-style-map.ts
+++ b/packages/docs/src/export/pdf-style-map.ts
@@ -12,7 +12,12 @@ import { customFontKey, type PdfFontKey } from './pdf-fonts.js';
 // Coverage: Basic Latin + Latin-1 Supplement (U+0000–U+00FF) plus the
 // individual code points WinAnsi additionally encodes via the standard
 // PDF text-state encoding table.
-const LATIN_SAFE_CHARS = '\\u0000-\\u00FF\\u0152\\u0153\\u0160\\u0161\\u017D\\u017E\\u0192\\u02C6\\u02DC\\u2013\\u2014\\u2018-\\u201E\\u2020-\\u2022\\u2026\\u2030\\u2039\\u203A\\u20AC\\u2122';
+//
+// The U+2018–U+201E quote block is enumerated as U+2018–U+201A and
+// U+201C–U+201E so U+201B (reversed-9 quote) is *excluded*: CP1252 has no
+// slot for it, so the StandardFonts throw on it — it must route to the
+// embedded Korean font instead. Keep this in sync with `pdf-fonts.ts`.
+const LATIN_SAFE_CHARS = '\\u0000-\\u00FF\\u0152\\u0153\\u0160\\u0161\\u017D\\u017E\\u0192\\u02C6\\u02DC\\u2013\\u2014\\u2018-\\u201A\\u201C-\\u201E\\u2020-\\u2022\\u2026\\u2030\\u2039\\u203A\\u20AC\\u2122';
 const NEEDS_CJK_FONT = new RegExp(`[^${LATIN_SAFE_CHARS}]`);
 const SCRIPT_SPLIT = new RegExp(
   `[^${LATIN_SAFE_CHARS}]+|[${LATIN_SAFE_CHARS}]+`,
@@ -44,11 +49,14 @@ export interface ScriptSegment {
  * a strict "is this Hangul" check — so CJK punctuation (※, 「」) and
  * geometric shapes (●○■) route correctly.
  *
- * C0 control characters (\n, \r, \t, etc.) are stripped: WinAnsi has no
- * encoding for them and they have no visual representation at draw time.
- * Layout/pagination already breaks lines at logical boundaries, so any
- * control char surviving into a `LayoutRun.text` is a paste-time artifact
- * we can drop without losing meaning.
+ * C0 control characters (\n, \r, \t, etc.), DEL, and the C1 controls
+ * (U+0080–U+009F) are stripped: WinAnsi has no encoding for them and they
+ * have no visual representation at draw time. The C1 block sits inside the
+ * "Latin-safe" U+0000–U+00FF range, so without this strip a pasted C1 byte
+ * would route to a StandardFont and throw "WinAnsi cannot encode" — taking
+ * the whole export down. Layout/pagination already breaks lines at logical
+ * boundaries, so any control char surviving into a `LayoutRun.text` is a
+ * paste-time artifact we can drop without losing meaning.
  *
  * IMPORTANT: U+FFFC (Object Replacement Character) is the placeholder
  * text for image inlines and MUST NOT be added to the strip range here.
@@ -60,7 +68,7 @@ export interface ScriptSegment {
 export function splitMixedScript(text: string): ScriptSegment[] {
   if (!text) return [];
   // eslint-disable-next-line no-control-regex
-  const cleaned = text.replace(/[\u0000-\u001F\u007F]/g, '');
+  const cleaned = text.replace(/[\u0000-\u001F\u007F-\u009F]/g, '');
   if (!cleaned) return [];
   const segments: ScriptSegment[] = [];
   for (const match of cleaned.matchAll(SCRIPT_SPLIT)) {

--- a/packages/docs/test/export/pdf-font-fallback.test.ts
+++ b/packages/docs/test/export/pdf-font-fallback.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+//
+// Regression coverage for the WinAnsi font-fallback throw bug: a handful
+// of characters were classified "Latin-safe" (routed to pdf-lib's
+// StandardFonts) that WinAnsi cannot actually encode, so `drawText` /
+// `widthOfTextAtSize` threw and aborted the entire export.
+//
+//   - U+0080-U+009F (C1 controls): inside the U+0000-U+00FF "safe" range
+//     but only C0 controls were stripped, so a pasted C1 byte reached
+//     Helvetica and threw.
+//   - U+201B (reversed-9 quote): the U+2018-U+201E "specials" range
+//     wrongly included it; CP1252 has no U+201B, so Helvetica/Times threw.
+//
+// C1 controls are built with String.fromCharCode so no invisible bytes
+// live in the source; U+201B is referenced as ‛ for the same reason.
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PDFDocument } from 'pdf-lib';
+import { splitMixedScript } from '../../src/export/pdf-style-map.js';
+import { scanFontsUsed } from '../../src/export/pdf-fonts.js';
+import { PdfExporter } from '../../src/export/pdf-exporter.js';
+import { PdfFonts, type PdfFontKey } from '../../src/export/pdf-fonts.js';
+import {
+  DEFAULT_BLOCK_STYLE,
+  DEFAULT_PAGE_SETUP,
+  generateBlockId,
+} from '../../src/model/types.js';
+import type { Document } from '../../src/model/types.js';
+import { stubMeasurer } from '../view/_stub-measurer.js';
+
+if (typeof Blob.prototype.arrayBuffer !== 'function') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (Blob.prototype as any).arrayBuffer = function (this: Blob): Promise<ArrayBuffer> {
+    return new Promise((resolve, reject) => {
+      const r = new FileReader();
+      r.onload = () => resolve(r.result as ArrayBuffer);
+      r.onerror = () => reject(r.error);
+      r.readAsArrayBuffer(this);
+    });
+  };
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_FONT = fs.readFileSync(
+  path.resolve(__dirname, 'fixtures/fonts/test-cjk.ttf'),
+).buffer as ArrayBuffer;
+
+const ALL_KEYS: PdfFontKey[] = [
+  'sans-regular', 'sans-bold', 'sans-italic', 'sans-boldItalic',
+  'serif-regular', 'serif-bold', 'serif-italic', 'serif-boldItalic',
+  'kr-sans-regular', 'kr-sans-bold',
+  'kr-serif-regular', 'kr-serif-bold',
+];
+
+function fontsForTest(): PdfFonts {
+  const sources: Partial<Record<PdfFontKey, () => Promise<ArrayBuffer>>> = {};
+  for (const k of ALL_KEYS) sources[k] = () => Promise.resolve(TEST_FONT);
+  return new PdfFonts({ sources });
+}
+
+// Representative C1 controls: U+0090 (DCS) and U+0085 (NEL).
+const C1_A = String.fromCharCode(0x90);
+const C1_B = String.fromCharCode(0x85);
+// U+201B — reversed-9 quote, not encodable by CP1252/WinAnsi.
+const REV_QUOTE = '‛';
+
+const para = (text: string): Document => ({
+  blocks: [{
+    id: generateBlockId(),
+    type: 'paragraph',
+    inlines: [{ text, style: {} }],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  }],
+  pageSetup: { ...DEFAULT_PAGE_SETUP },
+});
+
+describe('splitMixedScript — control & misclassified specials', () => {
+  it('strips C1 control characters (U+0080-U+009F)', () => {
+    // C1 controls are invisible paste artifacts WinAnsi cannot encode.
+    // Stripping mirrors the existing C0 handling.
+    expect(splitMixedScript(`a${C1_A}b`)).toEqual([
+      { text: 'ab', needsCustomFont: false },
+    ]);
+    expect(splitMixedScript(`${C1_A}${C1_B}`)).toEqual([]);
+  });
+
+  it('routes U+201B to the embedded (non-WinAnsi) font', () => {
+    // U+201B is not in CP1252; it must not be drawn with a StandardFont.
+    expect(splitMixedScript(REV_QUOTE)).toEqual([
+      { text: REV_QUOTE, needsCustomFont: true },
+    ]);
+  });
+
+  it('still treats genuine CP1252 specials as Latin-safe', () => {
+    // The neighbours of U+201B in the specials range stay WinAnsi-safe:
+    // U+2018, U+2019, U+201A, U+201C, U+201D, U+201E.
+    const specials = '‘’‚“”„';
+    expect(splitMixedScript(specials)).toEqual([
+      { text: specials, needsCustomFont: false },
+    ]);
+  });
+});
+
+describe('scanFontsUsed — misclassified specials trigger KR embed', () => {
+  it('requires the Korean font when only non-WinAnsi specials are present', () => {
+    // U+201B must route to an embedded font, which means scanFontsUsed has
+    // to embed one — otherwise resolveFontKey aliases kr-* back to
+    // Helvetica and the draw throws.
+    expect(scanFontsUsed(para(REV_QUOTE)).needsKR).toBe(true);
+  });
+
+  it('does not require the Korean font for C1 controls (stripped at paint)', () => {
+    expect(scanFontsUsed(para(`a${C1_A}b`)).needsKR).toBe(false);
+  });
+});
+
+describe('PdfExporter — never throws on misclassified characters', () => {
+  const exportText = (text: string) =>
+    PdfExporter.export(para(text), {
+      fonts: fontsForTest(),
+      measurer: stubMeasurer(),
+    });
+
+  it('exports a C1 control character without throwing', async () => {
+    const blob = await exportText(`Hello${C1_A}World`);
+    const reloaded = await PDFDocument.load(new Uint8Array(await blob.arrayBuffer()));
+    expect(reloaded.getPageCount()).toBe(1);
+  });
+
+  it('exports U+201B without throwing', async () => {
+    const blob = await exportText(`quote${REV_QUOTE}here`);
+    const reloaded = await PDFDocument.load(new Uint8Array(await blob.arrayBuffer()));
+    expect(reloaded.getPageCount()).toBe(1);
+  });
+
+  it('exports a mixed Korean/Latin run with a stray special without throwing', async () => {
+    const blob = await exportText(`Hello 안녕${REV_QUOTE} World`);
+    const reloaded = await PDFDocument.load(new Uint8Array(await blob.arrayBuffer()));
+    expect(reloaded.getPageCount()).toBe(1);
+  });
+});

--- a/packages/docs/test/export/pdf-font-fallback.test.ts
+++ b/packages/docs/test/export/pdf-font-fallback.test.ts
@@ -13,19 +13,24 @@
 //
 // C1 controls are built with String.fromCharCode so no invisible bytes
 // live in the source; U+201B is referenced as ‛ for the same reason.
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { PDFDocument } from 'pdf-lib';
+import { PDFDocument, type PDFFont } from 'pdf-lib';
+import fontkit from '@pdf-lib/fontkit';
 import { splitMixedScript } from '../../src/export/pdf-style-map.js';
 import { scanFontsUsed } from '../../src/export/pdf-fonts.js';
 import { PdfExporter } from '../../src/export/pdf-exporter.js';
 import { PdfFonts, type PdfFontKey } from '../../src/export/pdf-fonts.js';
+import { PdfPainter, type EmbeddedFonts } from '../../src/export/pdf-painter.js';
+import { computeLayout } from '../../src/view/layout.js';
+import { paginateLayout } from '../../src/view/pagination.js';
 import {
   DEFAULT_BLOCK_STYLE,
   DEFAULT_PAGE_SETUP,
   generateBlockId,
+  getEffectiveDimensions,
 } from '../../src/model/types.js';
 import type { Document } from '../../src/model/types.js';
 import { stubMeasurer } from '../view/_stub-measurer.js';
@@ -111,7 +116,10 @@ describe('scanFontsUsed — misclassified specials trigger KR embed', () => {
     expect(scanFontsUsed(para(REV_QUOTE)).needsKR).toBe(true);
   });
 
-  it('does not require the Korean font for C1 controls (stripped at paint)', () => {
+  it('does not pull in the Korean font for C1 controls', () => {
+    // scanFontsUsed classifies C1 as Latin-safe (it sits inside the
+    // U+0000–U+00FF range), so a stray C1 byte never triggers the heavy
+    // KR embed. The actual removal happens later, at paint time.
     expect(scanFontsUsed(para(`a${C1_A}b`)).needsKR).toBe(false);
   });
 });
@@ -139,5 +147,73 @@ describe('PdfExporter — never throws on misclassified characters', () => {
     const blob = await exportText(`Hello 안녕${REV_QUOTE} World`);
     const reloaded = await PDFDocument.load(new Uint8Array(await blob.arrayBuffer()));
     expect(reloaded.getPageCount()).toBe(1);
+  });
+});
+
+interface DrawCall {
+  text: string;
+  font: PDFFont;
+}
+
+// Paint a single-paragraph doc and capture every `drawText(text, opts)`
+// call with its resolved font. Lets the routing tests assert *which* font
+// each segment uses and that no character was silently dropped — the
+// no-throw `getPageCount` checks above can't distinguish "rendered" from
+// "dropped". Mirrors `collectPaintedText` in pdf-painter.test.ts, but also
+// records the font so we can verify the WinAnsi-vs-embedded split.
+async function collectDraws(
+  text: string,
+): Promise<{ draws: DrawCall[]; fonts: EmbeddedFonts }> {
+  const pdfDoc = await PDFDocument.create();
+  pdfDoc.registerFontkit(fontkit);
+  const fonts = await PdfPainter.embedAllFonts(pdfDoc, fontsForTest(), {
+    needsKR: true, needsKRSerif: true, needsLatinSerif: true,
+    needsBold: true, needsItalic: true, customFamilies: new Map(),
+  });
+
+  const doc = para(text);
+  const pageSetup = doc.pageSetup!;
+  const { width } = getEffectiveDimensions(pageSetup);
+  const contentWidth = width - pageSetup.margins.left - pageSetup.margins.right;
+  const { layout } = computeLayout(doc.blocks, stubMeasurer(), contentWidth);
+  const pagination = paginateLayout(layout, pageSetup);
+  const lp = pagination.pages[0];
+  const page = pdfDoc.addPage([(lp.width / 96) * 72, (lp.height / 96) * 72]);
+
+  const draws: DrawCall[] = [];
+  vi.spyOn(page, 'drawText').mockImplementation((t, opts) => {
+    // The painter always passes a font; `options` is optional only in
+    // pdf-lib's signature.
+    draws.push({ text: t, font: opts?.font as PDFFont });
+  });
+
+  PdfPainter.paintPage(page, lp, pagination.pageSetup, fonts, {
+    doc, imageMap: new Map(), layoutBlocks: layout.blocks,
+  });
+  return { draws, fonts };
+}
+
+describe('PdfPainter — routing of the fixed characters', () => {
+  it('routes U+201B + Korean to the embedded font and keeps Latin on the StandardFont', async () => {
+    const { draws, fonts } = await collectDraws(`Hello 안녕${REV_QUOTE} World`);
+
+    // Korean and U+201B are both non-WinAnsi, so they form one contiguous
+    // segment drawn with the embedded Korean font — and neither is dropped.
+    const krSegment = draws.find((d) => d.text.includes(REV_QUOTE));
+    expect(krSegment).toBeDefined();
+    expect(krSegment!.text).toContain('안녕');
+    expect(krSegment!.font).toBe(fonts['kr-sans-regular']);
+
+    // The Latin segments stay on the WinAnsi StandardFont.
+    const latinSegment = draws.find((d) => d.text.includes('Hello'));
+    expect(latinSegment?.font).toBe(fonts['sans-regular']);
+  });
+
+  it('drops C1 controls entirely — never handed to a font', async () => {
+    const { draws } = await collectDraws(`Hello${C1_A}World`);
+    const painted = draws.map((d) => d.text).join('');
+    expect(painted).not.toContain(C1_A);
+    // The surrounding Latin is preserved and re-joined after the strip.
+    expect(painted).toContain('HelloWorld');
   });
 });


### PR DESCRIPTION
## Summary

Continues the archived `20260501-pdf-export-followup` task — the remaining
font-fallback investigation + regression coverage.

The PDF painter classifies each run character as **Latin-safe** (drawn with
pdf-lib's WinAnsi-encoded StandardFonts) or **needs the embedded Korean
font**. WinAnsi *throws* on any code point it can't encode, and that throw
aborts the **entire** export — not just one run. An exhaustive probe of every
character the painter treated as Latin-safe found **33 it can't actually
encode**:

1. **U+0080–U+009F (C1 controls, 32 chars)** — inside the `U+0000–U+00FF`
   "safe" range, but `splitMixedScript` only stripped C0 + DEL, so a pasted /
   imported stray C1 byte reached Helvetica/Times and threw.
2. **U+201B (reversed-9 quote)** — the `U+2018–U+201E` specials range wrongly
   included it; CP1252 has no slot for U+201B.

### Fix

- `pdf-style-map.ts`: strip C1 controls alongside C0/DEL; split the quote
  range around U+201B so it routes to the embedded Korean font instead of
  throwing.
- `pdf-fonts.ts`: mirror the U+201B carve-out so `scanFontsUsed` flags
  `needsKR` (otherwise the `kr-*` keys alias back to Helvetica and throw
  again). The two files' character classes are a documented contract.

### Known limitation (accepted)

Routing U+201B to the embedded font means a stray U+201B in an otherwise pure-
Latin doc now triggers the Noto KR fetch — consistent with how any non-WinAnsi
character (`•`, `※`, `●`) already forces the KR embed, and strictly better
than the pre-fix hard throw.

## Test plan

- New `packages/docs/test/export/pdf-font-fallback.test.ts`: C1 stripping +
  U+201B routing, `scanFontsUsed` KR-embed trigger, and end-to-end
  `PdfExporter.export` no-throw for C1 / U+201B / mixed Korean-Latin-special
  runs. **Fails on `main`, passes after the fix.**
- Exhaustive re-probe after the fix: **0 throwers** across the whole
  Latin-safe range for both Helvetica and Times (was 33).
- `pnpm verify:fast` green (965 tests); full `test/export/` suite green
  (105 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PDF export crashes caused by stray control characters.
  * Improved handling of a specific reversed quote character so it follows the correct embedded-font path instead of failing.
  * Enhanced reliability for mixed Latin/Korean content, preventing export errors and aborts.
* **Documentation**
  * Updated task notes with the latest investigation details and guidance on the affected PDF export font-routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->