### PR TITLE
Docs: finish DOCX/table deferred follow-ups (widths, HF tables)

### DIFF
--- a/docs/design/docs/docs-docx-import-export.md
+++ b/docs/design/docs/docs-docx-import-export.md
@@ -26,7 +26,6 @@ typefaces.
 
 - Round-trip fidelity (preserving every Word-specific attribute is not a goal).
 - Floating / anchored images — only inline images are in scope.
-- Nested tables — content is flattened to text on import.
 - Form controls, SmartArt, WordArt, embedded OLE objects.
 - Comments, track changes, footnotes/endnotes.
 - Real-time collaborative import (single-user import, then collaborate).
@@ -336,11 +335,17 @@ half-points → points: value / 2
 
 ### 2.5 Nested Table Handling
 
-When a `<w:tbl>` is encountered inside a `<w:tc>` (table cell):
+When a `<w:tbl>` is encountered inside a `<w:tc>` (table cell), it is
+imported as a native nested `table` block:
 
-1. Recursively extract all text content from the nested table.
-2. Join cell texts with ` | ` separators, rows with newlines.
-3. Insert the result as paragraph blocks in the parent cell.
+1. `convertTable` recurses on the inner `<w:tbl>` (see `convertTable` in
+   `docx-importer.ts`, which calls itself for `<w:tbl>` cell children).
+2. The resulting `table` block is appended to the parent cell's `blocks`,
+   so structure, widths, merges, and styling are preserved rather than
+   flattened to text.
+
+The grid walk is direct-child only (`findDirectChild`) so a nested grid
+never inflates the outer table's column count.
 
 ### 2.6 Frontend Integration
 
@@ -471,6 +476,5 @@ docker-compose.yml              # + MinIO service
 | Complex OOXML edge cases (theme colors, inherited styles) | Start with direct property values; add theme resolution later if needed |
 | Large image files slowing import | Validate file size (10 MB limit per image); show progress indicator |
 | Korean fonts not available on user's system | Fallback to Noto Sans/Serif KR from Google Fonts |
-| Nested table content loss | Show a warning toast when nested tables are flattened to text |
 | Export fidelity — Word may render differently | Test with Word, Google Docs, LibreOffice; focus on structural correctness over pixel-perfect |
 | S3 credentials in dev environment | MinIO with default creds for local dev; real S3 for production |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,7 +19,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | slides shared editor toolbar parity (2026-06-27) | [20260627-slides-shared-editor-toolbar-parity-todo.md](./active/20260627-slides-shared-editor-toolbar-parity-todo.md) | [20260627-slides-shared-editor-toolbar-parity-lessons.md](./active/20260627-slides-shared-editor-toolbar-parity-lessons.md) |
-| docx table deferred (2026-06-26) | [20260626-docx-table-deferred-todo.md](./active/20260626-docx-table-deferred-todo.md) | - |
+| docx table deferred (2026-06-26) | [20260626-docx-table-deferred-todo.md](./active/20260626-docx-table-deferred-todo.md) | [20260626-docx-table-deferred-lessons.md](./active/20260626-docx-table-deferred-lessons.md) |
 | docs collaboration convergence (2026-06-25) | [20260625-docs-collaboration-convergence-todo.md](./active/20260625-docs-collaboration-convergence-todo.md) | [20260625-docs-collaboration-convergence-lessons.md](./active/20260625-docs-collaboration-convergence-lessons.md) |
 | slides themes layouts import (2026-05-07) | [20260507-slides-themes-layouts-import-todo.md](./active/20260507-slides-themes-layouts-import-todo.md) | [20260507-slides-themes-layouts-import-lessons.md](./active/20260507-slides-themes-layouts-import-lessons.md) |
 | pdf export followup (2026-05-01) | [20260501-pdf-export-followup-todo.md](./active/20260501-pdf-export-followup-todo.md) | [20260501-pdf-export-followup-lessons.md](./active/20260501-pdf-export-followup-lessons.md) |

--- a/docs/tasks/active/20260626-docx-table-deferred-lessons.md
+++ b/docs/tasks/active/20260626-docx-table-deferred-lessons.md
@@ -1,0 +1,57 @@
+# DOCX table deferred follow-ups — lessons
+
+## Verify the stated root cause before implementing it
+
+The todo claimed structural HF edits were no-ops because "the table store
+ops (`resolveTableBlock` / `findTableIndex` / `resolveTableTreePath`) assume
+the body path." Those functions don't exist, and the store table ops
+(`insertTableRow`, etc.) were *already* region-aware (keyed by block id via
+`findBlock` → `findBlockInAnyArray`). The real blockers were elsewhere:
+
+1. Body-only block-array reads (`this.doc.document.blocks`) in
+   `ensureBlockAfter`, `getPositionBeforeTable`, `getPositionAfterTable` —
+   these already used the context-aware `getBlockIndex()` for the index but
+   then indexed into the body array. Switch to `getContextBlocks()`.
+2. The `editContext === 'body'` guards in `text-editor.ts`.
+3. The editor API table commands resolving the cursor cell via the
+   **body-only** `layout.blockParentMap`. The merged body+header+footer map
+   lives on `doc.blockParentMap` (built in the render loop, line ~1140).
+
+Lesson: when a todo names a mechanism, grep for it first. Map the real data
+flow rather than trusting the description.
+
+## Two parallel block-parent maps exist — pick the right one
+
+`editor.ts` keeps a body-only `layout.blockParentMap` and a merged
+`doc.blockParentMap` (= body ∪ header ∪ footer, set via
+`doc.setBlockParentMap`). Anything that must work across regions (table
+structural commands, `isInTable`, merge context) must use `doc.blockParentMap`.
+`doc.editContext` is kept in sync by `setEditContext` (line 222), so
+`doc.getContextBlocks()` / `getBlockIndex()` resolve correctly from the API.
+
+## Don't let a width fallback re-enable structural hardening
+
+First cut derived `columnWidths` from `tcW` *before* computing the structural
+`numCols`, which re-enabled the grid shape-hardening (clamp, gridBefore
+padding) that the gridless tests intentionally disable — silently dropping
+cell content. Fix: keep the structural `numCols` gated on the real
+`<w:tblGrid>` (0 when absent) and derive render-time `columnWidths`
+*after* the row loop. Structural behavior and rendering width are separate
+concerns; don't couple them through one array length.
+
+## Mirror existing behavior exactly for affinity math
+
+The HF caret resolvers had the same wrap-boundary bug the body resolver
+(`resolvePositionPixel`) already solved. Copy the exact condition
+(`affinity === 'forward' && remaining === lineChars && li < end - 1` →
+jump to next line) rather than reinventing it, so all caret paths agree.
+
+## Scope notes that became "known limitations"
+
+- Absolute `<w:tblW>` import needs a model field (`TableData` only has
+  fractional `columnWidths`). Calling that out kept the item honest rather
+  than faking support.
+- PDF export doesn't paint HF tables at all (`paintHFRegion` walks only
+  `lb.lines`), so the page-number-in-HF-table fix is canvas-only. Checking
+  the sibling renderer surfaced that the todo's "shared with PDF painter"
+  note was inaccurate.

--- a/docs/tasks/active/20260626-docx-table-deferred-lessons.md
+++ b/docs/tasks/active/20260626-docx-table-deferred-lessons.md
@@ -1,12 +1,40 @@
 # DOCX table deferred follow-ups — lessons
 
+## Check EVERY DocStore implementation, not just the in-memory one (cost me a blocking bug)
+
+My first pass concluded the table store ops were already region-aware after
+grepping only `packages/docs/src/` — where `MemDocStore.findBlockInAnyArray`
+*is* region-aware. I even rewrote the todo Scope line to drop
+`packages/frontend/src/app/docs/yorkie-doc-store.ts`. But the production
+editor uses `YorkieDocStore`, whose `resolveTableTreePath` searched only
+`currentDoc.blocks` (body) and threw `Table block not found` for header/footer
+tables. Dropping the `editContext === 'body'` guards therefore turned a safe
+no-op into an uncaught crash in the real app — the exact thing #417's guards
+prevented. The functions the todo named (`resolveTableTreePath`,
+`findTableIndex`, `resolveTableBlock`) **did** exist — in the file I had
+removed from scope.
+
+A self code-review (multi-agent) caught it; the MemDocStore-only unit tests
+all passed and masked it. Fix: make `resolveTableTreePath` delegate to the
+already-region-aware `resolveBlockTreePath`, and make `resolveTableBlock`
+pick the region root (body/header/footer) from the tree path. Added
+header/footer structural-op tests in `yorkie-doc-store.test.ts`.
+
+Lessons:
+1. The `Store` abstraction has ≥2 impls (`MemDocStore`, `YorkieDocStore`).
+   A behavior is only region-aware if **every** impl is — grep both
+   `packages/docs/src/store/` AND `packages/frontend/src/app/docs/`.
+2. Don't narrow a todo's Scope list without proving the dropped file is
+   irrelevant. The original scope named yorkie-doc-store.ts for a reason.
+3. Unit tests against the in-memory store can't prove the collaborative
+   path. Add a matching test in `yorkie-doc-store.test.ts` for anything that
+   touches store ops.
+
 ## Verify the stated root cause before implementing it
 
-The todo claimed structural HF edits were no-ops because "the table store
-ops (`resolveTableBlock` / `findTableIndex` / `resolveTableTreePath`) assume
-the body path." Those functions don't exist, and the store table ops
-(`insertTableRow`, etc.) were *already* region-aware (keyed by block id via
-`findBlock` → `findBlockInAnyArray`). The real blockers were elsewhere:
+The todo also described the mechanism imprecisely for the *in-memory* store:
+there, the table store ops (`insertTableRow`, etc.) were already region-aware
+(keyed by block id via `findBlock` → `findBlockInAnyArray`). The real blockers were elsewhere:
 
 1. Body-only block-array reads (`this.doc.document.blocks`) in
    `ensureBlockAfter`, `getPositionBeforeTable`, `getPositionAfterTable` —

--- a/docs/tasks/active/20260626-docx-table-deferred-todo.md
+++ b/docs/tasks/active/20260626-docx-table-deferred-todo.md
@@ -75,6 +75,14 @@ common-path bugs.
 
 All six deferred items shipped in one PR. Implementation summary above.
 
+A self code-review of the branch diff found no blocking bugs. One adjacent,
+pre-existing correctness bug it surfaced was also fixed: the Delete /
+Ctrl-Delete "merge with next block" paths resolved the sibling from the
+body block array while `getBlockIndex` is context-aware, so deleting at the
+end of a header/footer paragraph could no-op or throw "Cannot merge blocks
+from different regions". Both sites now use `getContextBlocks()`
+(`handleDelete`, `handleWordDelete`), with a regression test.
+
 ### Tests
 
 - `pnpm --filter @wafflebase/docs typecheck` — clean.

--- a/docs/tasks/active/20260626-docx-table-deferred-todo.md
+++ b/docs/tasks/active/20260626-docx-table-deferred-todo.md
@@ -1,10 +1,12 @@
 # DOCX table deferred follow-ups
 
-**Status:** not-started
+**Status:** complete
 **Parent:** `20260412-docx-table-style-followup` (archived)
 **Scope:** `packages/docs/src/import/docx-importer.ts`,
+`packages/docs/src/import/docx-style-map.ts`,
 `packages/docs/src/export/docx-exporter.ts`,
-`packages/frontend/src/app/docs/yorkie-doc-store.ts`
+`packages/docs/src/view/{table-renderer,doc-canvas,editor,text-editor}.ts`,
+`packages/docs/src/model/document.ts`
 
 ## Background
 
@@ -15,42 +17,86 @@ blockers.
 
 ## Items
 
-- [ ] **5. `w:tblW` / `w:tcW`** — honor table/cell width overrides on
-      import (and likely export).
-- [ ] **7. Replace nested-table flattening with native rendering** — the
-      importer already imports nested tables as native `table` blocks (see
-      the `should import nested tables` test); audit the remaining
-      flattening claims in `docs-docx-import-export.md` and remove the stale
-      "flattened to text" path / warning.
-- [ ] **Structural row/column edits inside header/footer tables** — Tab at
-      the last header/footer cell, and insert/delete row/column, currently
-      no-op in header/footer because the table store ops
-      (`resolveTableBlock` / `findTableIndex` / `resolveTableTreePath`)
-      assume the body path. Make them region-aware, then drop the
-      `editContext === 'body'` guards in `text-editor.ts`
-      (`moveToNextCell` / `moveToPrevCell` and the arrow table-exit branches).
+- [x] **5. `w:tblW` / `w:tcW`** — honor cell width overrides on import and
+      export. **Import:** `<w:tcW>` (dxa) is now read in
+      `mapTableCellProperties`; when a table has no `<w:tblGrid>`,
+      `deriveColWidthsFromCells` derives column proportions from per-cell
+      `tcW` (even-share fallback) — set as render-time `columnWidths` only,
+      so the structural shape-hardening stays gated on the grid (gridless
+      tests unchanged). **Export:** each `<w:tc>` now emits `<w:tcW>` (dxa,
+      summed over spanned columns) before `<w:gridSpan>`. *Note:* absolute
+      `<w:tblW>` is intentionally not honored — the docs `TableData` model has
+      no absolute table width (fractional `columnWidths` fill the content
+      area); adding one would be a model change beyond this follow-up.
+- [x] **7. Replace nested-table flattening with native rendering** — the
+      importer already imports nested tables as native `table` blocks
+      (`convertTable` recurses on `<w:tbl>` cell children). Removed the stale
+      "flattened to text" non-goal, the §2.5 flatten algorithm, and the
+      warning-toast risk row in `docs-docx-import-export.md`; replaced §2.5
+      with the native-recursion description.
+- [x] **Structural row/column edits inside header/footer tables** — the table
+      store ops were already region-aware (keyed by block id via `findBlock`).
+      The real blockers were: body-only block-array access in
+      `ensureBlockAfter` / `getPositionBeforeTable` / `getPositionAfterTable`
+      (now `getContextBlocks()`); the `editContext === 'body'` guards in
+      `moveToNextCell` / `moveToPrevCell` and the four arrow table-exit
+      branches (dropped); and the editor API table commands resolving the
+      cursor cell via the body-only `layout.blockParentMap` (switched to the
+      merged `doc.blockParentMap`, plus region-aware `deleteTable` re-home).
 
 ## Header/footer table refinements (from PR #417 review)
 
 Edge cases in the shipped header/footer cell editing; none are crashes or
 common-path bugs.
 
-- [ ] **Page-number tokens inside header/footer table cells** — a
-      `pageNumber: true` inline in a cell renders its `#` placeholder, not
-      the page number. `renderTableContent` (`table-renderer.ts`, shared
-      with the body + PDF painter) draws `run.text` directly; thread an
-      optional `pageNumber` through and substitute like
-      `renderRunWithPageNumber`, then pass it from
-      `renderHeaderFooterBlocks`.
-- [ ] **`lineAffinity` in the HF cell caret/selection resolvers** —
-      `computeHFTableCellCaretPixel` resolves `remaining === lineChars` to
-      the previous visual line, so the caret at a wrap boundary can render
-      on the prior line for forward affinity (wrapped multi-line cells). The
-      existing header *paragraph* caret (`computeHFCursorPixel`) has the same
-      limitation — fix both by threading `cursor.lineAffinity` through.
-- [ ] **Mixed table / non-table HF selections** — when a selection spans a
-      cell and an outside header/footer paragraph,
-      `computeHFTableCellSelectionRects` collapses both endpoints to the one
-      in-table cell and drops the paragraph portion. Split rendering between
-      the flat HF path and the table path (or clamp the outside endpoint to
-      the table edge by document order).
+- [x] **Page-number tokens inside header/footer table cells** —
+      `renderTableContent` now takes an optional `pageNumber` and substitutes
+      it for a `style.pageNumber` run's `#` placeholder (mirrors
+      `renderRunWithPageNumber`); threaded from `renderHeaderFooterBlocks` and
+      into nested-table recursion. *Note:* the canvas path is fixed; PDF
+      export does not paint header/footer **tables** at all yet
+      (`paintHFRegion` only walks `lb.lines`), so page-number-in-HF-table in
+      PDF is moot until HF tables render in PDF — a separate, larger gap.
+- [x] **`lineAffinity` in the HF cell caret/selection resolvers** — threaded
+      `cursor.lineAffinity` into `computeHFTableCellCaretPixel` and
+      `computeHFCursorPixel`; both now apply the forward-affinity
+      wrap-boundary jump (start of next visual line) mirroring the body
+      resolver `resolvePositionPixel`. All four call sites pass
+      `cursor.lineAffinity`.
+- [x] **Mixed table / non-table HF selections** — `computeHFSelectionRects`
+      now has three branches: both-in-table (table path), neither (flat
+      scan), and mixed (render the table cells clamped to the edge nearest the
+      outside endpoint *plus* the flat paragraph run between that endpoint and
+      the table boundary). Extracted `hfFlatLayoutRects` / `mapHFLayoutRects`
+      helpers; `computeHFTableCellSelectionRects` clamps the whole-cell box to
+      the table edge by document order when one endpoint is outside.
+
+## Review
+
+All six deferred items shipped in one PR. Implementation summary above.
+
+### Tests
+
+- `pnpm --filter @wafflebase/docs typecheck` — clean.
+- `pnpm --filter @wafflebase/docs test` — 62 files, 973 passing, 1 skipped.
+- New/extended tests:
+  - `test/import/docx-importer.test.ts` — tcW-derived columns without a
+    tblGrid; even-share fallback; gridless gridBefore/gridAfter unchanged.
+  - `test/export/docx-exporter.test.ts` — per-cell `<w:tcW>` dxa output.
+  - `test/view/table-renderer.test.ts` — page-number substitution in cells.
+  - `test/view/hf-caret-selection.test.ts` (new) — forward/backward affinity
+    at a wrap boundary; mixed table/paragraph HF selection; pure-paragraph
+    selection regression.
+  - `test/view/header-table-nav.test.ts` — header-table insert/delete
+    row/column, isInTable/getCellAddress, Tab-appends-row, ArrowRight exit.
+
+### Known limitations / deferred
+
+- Absolute `<w:tblW>` (dxa) is not honored on import — needs a `TableData`
+  absolute-width model field; out of scope for this follow-up.
+- PDF export still does not paint header/footer **tables** (`paintHFRegion`
+  walks only `lb.lines`); page-number-in-HF-table in PDF depends on that
+  larger feature.
+- Mixed HF selection uses a bounding-box approximation for the table portion
+  (matches the existing both-endpoints-in-table behavior), not a precise
+  reading-order highlight.

--- a/docs/tasks/active/20260626-docx-table-deferred-todo.md
+++ b/docs/tasks/active/20260626-docx-table-deferred-todo.md
@@ -75,13 +75,27 @@ common-path bugs.
 
 All six deferred items shipped in one PR. Implementation summary above.
 
-A self code-review of the branch diff found no blocking bugs. One adjacent,
-pre-existing correctness bug it surfaced was also fixed: the Delete /
-Ctrl-Delete "merge with next block" paths resolved the sibling from the
-body block array while `getBlockIndex` is context-aware, so deleting at the
-end of a header/footer paragraph could no-op or throw "Cannot merge blocks
-from different regions". Both sites now use `getContextBlocks()`
-(`handleDelete`, `handleWordDelete`), with a regression test.
+A self code-review of the branch diff surfaced and fixed two correctness bugs:
+
+1. **Blocking (introduced):** dropping the `editContext === 'body'` guards
+   crashed header/footer table structural ops in the **Yorkie** editor.
+   `YorkieDocStore.resolveTableTreePath` was body-only (searched only
+   `doc.blocks`, threw `Table block not found` for HF tables); the
+   MemDocStore unit tests masked it. Fixed by making `resolveTableTreePath`
+   delegate to the region-aware `resolveBlockTreePath` and `resolveTableBlock`
+   pick the region root from the tree path. Added header/footer structural-op
+   tests in `packages/frontend/tests/app/docs/yorkie-doc-store.test.ts`.
+2. **Adjacent (pre-existing):** the Delete / Ctrl-Delete "merge with next
+   block" paths resolved the sibling from the body block array while
+   `getBlockIndex` is context-aware, so deleting at the end of a header/footer
+   paragraph could no-op or throw "Cannot merge blocks from different
+   regions". Both sites now use `getContextBlocks()`, with a regression test.
+
+Two pre-existing, out-of-scope items the review noted (unmodified lines, not
+fixed here): `editor.ts` `insertTable` (line ~2801) and the ruler cursor-cell
+lookup (line ~1662) still use the body-only `layout.blockParentMap`; making
+table *insertion* region-aware needs region-aware `doc.insertTable` /
+`insertTableInCell` and is a separate follow-up.
 
 ### Tests
 

--- a/packages/docs/src/export/docx-exporter.ts
+++ b/packages/docs/src/export/docx-exporter.ts
@@ -269,6 +269,15 @@ ${bodyXml}
         }
 
         const tcPrParts: string[] = [];
+        // <w:tcW> preferred cell width (dxa), summed over spanned columns so a
+        // consumer that honors tcW over the grid still gets the right widths.
+        // Per CT_TcPr ordering, tcW precedes gridSpan.
+        const span = cell.colSpan && cell.colSpan > 1 ? cell.colSpan : 1;
+        let cellTwips = 0;
+        for (let s = 0; s < span && c + s < nCols; s++) {
+          cellTwips += Math.round((tableData.columnWidths[c + s] ?? 0) * totalTwips);
+        }
+        if (cellTwips > 0) tcPrParts.push(`<w:tcW w:w="${cellTwips}" w:type="dxa"/>`);
         if (cell.colSpan && cell.colSpan > 1) tcPrParts.push(`<w:gridSpan w:val="${cell.colSpan}"/>`);
         if (cell.rowSpan && cell.rowSpan > 1) tcPrParts.push(`<w:vMerge w:val="restart"/>`);
         if (cell.style.backgroundColor) {

--- a/packages/docs/src/import/docx-importer.ts
+++ b/packages/docs/src/import/docx-importer.ts
@@ -277,7 +277,7 @@ export class DocxImporter {
       }
     }
     const totalWidth = colWidthsRaw.reduce((a, b) => a + b, 0) || 1;
-    const columnWidths = colWidthsRaw.map((w) => w / totalWidth);
+    let columnWidths = colWidthsRaw.map((w) => w / totalWidth);
     // Row-cell clamp target. When tblGrid is missing we cannot clamp
     // (we do not yet know how many columns exist), so numCols stays 0
     // and the clamp is effectively disabled.
@@ -480,6 +480,18 @@ export class DocxImporter {
       DocxImporter.applyTblBordersInheritance(rows, tblBorders);
     }
 
+    // No <w:tblGrid> (malformed or hand-authored docx): derive column widths
+    // for rendering from per-cell <w:tcW> dxa values, falling back to an even
+    // share. This only sets the render-time `columnWidths`; the structural
+    // shape-hardening above stays gated on `numCols` (0 here), so gridless
+    // rows keep their original cell shape.
+    if (columnWidths.length === 0) {
+      const derived: number[] = [];
+      DocxImporter.deriveColWidthsFromCells(tblEl, derived);
+      const dTotal = derived.reduce((a, b) => a + b, 0) || 1;
+      columnWidths = derived.map((w) => w / dTotal);
+    }
+
     const tableData: TableData = { rows, columnWidths };
     if (hasRowHeight) tableData.rowHeights = rowHeights;
 
@@ -537,6 +549,38 @@ export class DocxImporter {
         }
       }
     }
+  }
+
+  /**
+   * Derive relative column weights from per-cell <w:tcW> values when a table
+   * has no <w:tblGrid>. Walks direct-child rows and keeps the row that yields
+   * the most grid columns (gridSpan-aware): a cell with gridSpan N spreads its
+   * width across N columns, and cells without a usable dxa <w:tcW> contribute a
+   * unit weight so the column still renders at an even share. Results are
+   * pushed onto `out`; if every row is empty `out` is left untouched.
+   */
+  private static deriveColWidthsFromCells(tblEl: Element, out: number[]): void {
+    let best: number[] = [];
+    for (let i = 0; i < tblEl.childNodes.length; i++) {
+      const node = tblEl.childNodes[i];
+      if (node.nodeType !== 1 || (node as Element).localName !== 'tr') continue;
+      const trEl = node as Element;
+      const weights: number[] = [];
+      for (let j = 0; j < trEl.childNodes.length; j++) {
+        const tcNode = trEl.childNodes[j];
+        if (tcNode.nodeType !== 1 || (tcNode as Element).localName !== 'tc') continue;
+        const tcEl = tcNode as Element;
+        const tcPr = tcEl.getElementsByTagNameNS(W, 'tcPr')[0];
+        const props = tcPr ? mapTableCellProperties(tcPr) : {};
+        const span = props.colSpan && props.colSpan > 1 ? props.colSpan : 1;
+        const total = props.widthTwips && props.widthTwips > 0 ? props.widthTwips : 0;
+        for (let s = 0; s < span; s++) {
+          weights.push(total > 0 ? total / span : 1);
+        }
+      }
+      if (weights.length > best.length) best = weights;
+    }
+    for (const w of best) out.push(w);
   }
 
   /**

--- a/packages/docs/src/import/docx-importer.ts
+++ b/packages/docs/src/import/docx-importer.ts
@@ -350,8 +350,10 @@ export class DocxImporter {
         if (tcNode.nodeType !== 1 || (tcNode as Element).localName !== 'tc') continue;
         const tcEl = tcNode as Element;
 
-        // Parse cell properties
-        const tcPr = tcEl.getElementsByTagNameNS(W, 'tcPr')[0];
+        // Parse cell properties. Direct-child only: getElementsByTagNameNS
+        // recurses, so an outer cell with no own <w:tcPr> would otherwise
+        // inherit a nested table cell's tcPr (gridSpan/vMerge/shd/borders).
+        const tcPr = DocxImporter.findDirectChild(tcEl, 'tcPr');
         let colSpan = 1;
         let vMerge: 'restart' | 'continue' | undefined;
         let cellProps: ReturnType<typeof mapTableCellProperties> = {};
@@ -570,7 +572,9 @@ export class DocxImporter {
         const tcNode = trEl.childNodes[j];
         if (tcNode.nodeType !== 1 || (tcNode as Element).localName !== 'tc') continue;
         const tcEl = tcNode as Element;
-        const tcPr = tcEl.getElementsByTagNameNS(W, 'tcPr')[0];
+        // Direct-child only so a nested table's tcW/gridSpan never leaks into
+        // the outer table's derived column widths.
+        const tcPr = DocxImporter.findDirectChild(tcEl, 'tcPr');
         const props = tcPr ? mapTableCellProperties(tcPr) : {};
         const span = props.colSpan && props.colSpan > 1 ? props.colSpan : 1;
         const total = props.widthTwips && props.widthTwips > 0 ? props.widthTwips : 0;

--- a/packages/docs/src/import/docx-style-map.ts
+++ b/packages/docs/src/import/docx-style-map.ts
@@ -163,6 +163,8 @@ export function mapTableCellProperties(tcPr: Element): {
   padding?: number;
   colSpan?: number;
   vMerge?: 'restart' | 'continue';
+  /** Preferred cell width in twips, when <w:tcW> declares a dxa value. */
+  widthTwips?: number;
 } {
   const result: ReturnType<typeof mapTableCellProperties> = {};
 
@@ -213,6 +215,19 @@ export function mapTableCellProperties(tcPr: Element): {
       if (Number.isFinite(parsed) && parsed > maxTwips) maxTwips = parsed;
     }
     if (maxTwips >= 0) result.padding = twipsToPx(maxTwips);
+  }
+
+  // <w:tcW> preferred cell width. Only dxa (twips) is convertible without a
+  // table total; pct/auto are left for the grid/even-share fallback. Used to
+  // derive column widths when <w:tblGrid> is absent (see docx-importer).
+  const tcW = getW(tcPr, 'tcW');
+  if (tcW) {
+    const type = getWAttr(tcW, 'type');
+    const w = getWAttr(tcW, 'w');
+    if ((!type || type === 'dxa') && w) {
+      const parsed = parseInt(w, 10);
+      if (Number.isFinite(parsed) && parsed > 0) result.widthTwips = parsed;
+    }
   }
 
   const tcBorders = getW(tcPr, 'tcBorders');

--- a/packages/docs/src/model/document.ts
+++ b/packages/docs/src/model/document.ts
@@ -601,12 +601,21 @@ export class Doc {
    * Returns the ID of the block immediately after `blockIndex`.
    */
   ensureBlockAfter(blockIndex: number): string {
-    const blocks = this.document.blocks;
+    // Resolve against the active editing context (body / header / footer) so
+    // exiting a header/footer table appends the new paragraph to that region.
+    const blocks = this.getContextBlocks();
     if (blockIndex < blocks.length - 1) {
       return blocks[blockIndex + 1].id;
     }
     const newBlock = createEmptyBlock();
-    this.store.insertBlock(blockIndex + 1, newBlock);
+    const sibling = blocks[blockIndex];
+    if (sibling) {
+      // insertBlockAfter is region-aware (keyed by sibling id) in both the
+      // in-memory and Yorkie stores; insertBlock(index) is body-only.
+      this.store.insertBlockAfter(sibling.id, newBlock);
+    } else {
+      this.store.insertBlock(blockIndex + 1, newBlock);
+    }
     this.refresh();
     return newBlock.id;
   }

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -683,6 +683,7 @@ export class DocCanvas {
         renderTableContent(
           this.ctx, lb.block.tableData, lb.layoutTable, originX, tableY,
           0, undefined, undefined, this.requestRender ?? undefined,
+          undefined, undefined, undefined, undefined, undefined, pageNumber,
         );
         continue;
       }

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -296,6 +296,7 @@ export interface EditorAPI {
  */
 function computeHFTableCellCaretPixel(
   position: DocPosition,
+  lineAffinity: 'forward' | 'backward',
   hfLayout: DocumentLayout,
   hf: HeaderFooter,
   region: 'header' | 'footer',
@@ -332,6 +333,17 @@ function computeHFTableCellCaretPixel(
     const line = cell.lines[li];
     let lineChars = 0;
     for (const run of line.runs) lineChars += run.text.length;
+    // At a wrap boundary, forward affinity belongs to the start of the
+    // next visual line rather than the end of this one. Mirrors the body
+    // caret resolver (`resolvePositionPixel`).
+    if (
+      lineAffinity === 'forward' &&
+      remaining === lineChars &&
+      li < blockEndLine - 1
+    ) {
+      remaining = 0;
+      continue;
+    }
     if (remaining <= lineChars || li === blockEndLine - 1) {
       lineIdx = li;
       lineHeight = line.height;
@@ -377,8 +389,11 @@ function computeHFTableCellCaretPixel(
   };
 }
 
-function computeHFCursorPixel(
+// Exported for unit tests only — not re-exported from the package index, so
+// this does not widen the published API surface.
+export function computeHFCursorPixel(
   position: DocPosition,
+  lineAffinity: 'forward' | 'backward',
   hfLayout: DocumentLayout,
   hf: HeaderFooter,
   region: 'header' | 'footer',
@@ -393,7 +408,7 @@ function computeHFCursorPixel(
     // The caret may be inside a header/footer table cell, whose inner block
     // is not a top-level hfLayout block. Resolve it via the cell map.
     return computeHFTableCellCaretPixel(
-      position, hfLayout, hf, region, paginatedLayout, measurer,
+      position, lineAffinity, hfLayout, hf, region, paginatedLayout, measurer,
       canvasWidth, activePageIndex, cursorVisible,
     );
   }
@@ -407,9 +422,20 @@ function computeHFCursorPixel(
   let lineHeight = lb.lines[0]?.height ?? 14;
   let offsetRemaining = position.offset;
 
-  for (const line of lb.lines) {
+  for (let li = 0; li < lb.lines.length; li++) {
+    const line = lb.lines[li];
     let lineChars = 0;
     for (const run of line.runs) lineChars += run.text.length;
+    // At a wrap boundary, forward affinity belongs to the start of the
+    // next visual line. Mirrors the body caret resolver.
+    if (
+      lineAffinity === 'forward' &&
+      offsetRemaining === lineChars &&
+      li < lb.lines.length - 1
+    ) {
+      offsetRemaining = 0;
+      continue;
+    }
     if (offsetRemaining <= lineChars) {
       lineHeight = line.height;
       cursorLineY = line.y;
@@ -553,14 +579,40 @@ function computeHFTableCellSelectionRects(
     return rects;
   }
 
-  // Otherwise: whole-cell highlight over the bounding row/col box. When one
-  // endpoint is outside the table, clamp that side to the table edge.
-  const a = anchorCell ?? focusCell!;
-  const b = focusCell ?? anchorCell!;
-  const r0 = Math.min(a.rowIndex, b.rowIndex);
-  const r1 = Math.max(a.rowIndex, b.rowIndex);
-  const c0 = Math.min(a.colIndex, b.colIndex);
-  const c1 = Math.max(a.colIndex, b.colIndex);
+  // Otherwise: whole-cell highlight over the bounding row/col box.
+  let r0: number, r1: number, c0: number, c1: number;
+  if (anchorCell && focusCell) {
+    r0 = Math.min(anchorCell.rowIndex, focusCell.rowIndex);
+    r1 = Math.max(anchorCell.rowIndex, focusCell.rowIndex);
+    c0 = Math.min(anchorCell.colIndex, focusCell.colIndex);
+    c1 = Math.max(anchorCell.colIndex, focusCell.colIndex);
+  } else {
+    // Mixed selection: one endpoint is an outside header/footer paragraph.
+    // Clamp the table coverage to the edge nearest that endpoint by document
+    // order so the whole run of cells between the edge and the in-table cell
+    // highlights. The outside paragraph portion itself is rendered separately
+    // by computeHFSelectionRects. (The bounding-box approximation matches the
+    // both-endpoints case above.)
+    const inCell = (anchorCell ?? focusCell)!;
+    const outsideBlockId = anchorCell
+      ? selectionRange.focus.blockId
+      : selectionRange.anchor.blockId;
+    const tableIdx = hfLayout.blocks.findIndex(
+      (bl) => bl.block.id === cellInfo.tableBlockId,
+    );
+    const outsideIdx = hfLayout.blocks.findIndex(
+      (bl) => bl.block.id === outsideBlockId,
+    );
+    const lastRow = tl.cells.length - 1;
+    const lastCol = tl.columnPixelWidths.length - 1;
+    if (outsideIdx !== -1 && outsideIdx < tableIdx) {
+      // Outside endpoint precedes the table: cover from the first cell.
+      r0 = 0; c0 = 0; r1 = inCell.rowIndex; c1 = inCell.colIndex;
+    } else {
+      // Outside endpoint follows the table (or unknown): cover to the last cell.
+      r0 = inCell.rowIndex; c0 = inCell.colIndex; r1 = lastRow; c1 = lastCol;
+    }
+  }
   for (let r = r0; r <= r1; r++) {
     for (let c = c0; c <= c1; c++) {
       if (tl.cells[r]?.[c]?.merged) continue;
@@ -577,59 +629,23 @@ function computeHFTableCellSelectionRects(
 }
 
 /**
- * Compute selection rects within a header/footer layout for all visible pages.
+ * Build layout-relative selection rects across a contiguous run of flat
+ * (non-table) header/footer blocks. `startBlockIdx`/`endBlockIdx` index into
+ * `hfLayout.blocks` and must already be ordered (`start <= end`). Returns
+ * rects in header/footer layout coordinates (caller maps them to the page).
  */
-function computeHFSelectionRects(
-  selectionRange: { anchor: DocPosition; focus: DocPosition },
+function hfFlatLayoutRects(
   hfLayout: DocumentLayout,
-  hf: HeaderFooter,
-  region: 'header' | 'footer',
-  paginatedLayout: PaginatedLayout,
+  startBlockIdx: number,
+  startOffset: number,
+  endBlockIdx: number,
+  endOffset: number,
   measurer: TextMeasurer,
-  canvasWidth: number,
-  activePageIndex: number,
 ): Array<{ x: number; y: number; width: number; height: number }> {
-  // If either endpoint is inside a header/footer table cell, route to the
-  // table-aware path (the cell's inner block is not a top-level hfLayout
-  // block, so the flat scan below would find nothing).
-  const anchorCell = hfLayout.blockParentMap.get(selectionRange.anchor.blockId);
-  const focusCell = hfLayout.blockParentMap.get(selectionRange.focus.blockId);
-  if (anchorCell || focusCell) {
-    return computeHFTableCellSelectionRects(
-      selectionRange, anchorCell, focusCell, hfLayout, hf, region,
-      paginatedLayout, measurer, canvasWidth, activePageIndex,
-    );
-  }
-
-  const rects: Array<{ x: number; y: number; width: number; height: number }> = [];
-  const pageX = getPageXOffset(paginatedLayout, canvasWidth);
-  const { margins } = paginatedLayout.pageSetup;
-
-  // Find start/end offsets across header/footer blocks
-  let startBlockIdx = -1, endBlockIdx = -1;
-  let startOffset = 0, endOffset = 0;
-  for (let i = 0; i < hfLayout.blocks.length; i++) {
-    if (hfLayout.blocks[i].block.id === selectionRange.anchor.blockId) {
-      startBlockIdx = i;
-      startOffset = selectionRange.anchor.offset;
-    }
-    if (hfLayout.blocks[i].block.id === selectionRange.focus.blockId) {
-      endBlockIdx = i;
-      endOffset = selectionRange.focus.offset;
-    }
-  }
-  if (startBlockIdx === -1 || endBlockIdx === -1) return rects;
-
-  // Normalize direction
-  if (startBlockIdx > endBlockIdx || (startBlockIdx === endBlockIdx && startOffset > endOffset)) {
-    [startBlockIdx, endBlockIdx] = [endBlockIdx, startBlockIdx];
-    [startOffset, endOffset] = [endOffset, startOffset];
-  }
-
-  // Build rects for each line in the selection range (layout-relative)
   const layoutRects: Array<{ x: number; y: number; width: number; height: number }> = [];
   for (let bi = startBlockIdx; bi <= endBlockIdx; bi++) {
     const lb = hfLayout.blocks[bi];
+    if (!lb) continue;
     let blockCharsSoFar = 0;
     for (const line of lb.lines) {
       let lineChars = 0;
@@ -679,26 +695,130 @@ function computeHFSelectionRects(
       blockCharsSoFar += lineChars;
     }
   }
+  return layoutRects;
+}
 
-  // Map layout rects to the active page only
-  {
-    let baseY: number;
-    if (region === 'header') {
-      baseY = getHeaderYStart(paginatedLayout, activePageIndex, hf.marginFromEdge);
-    } else {
-      baseY = getFooterYStart(paginatedLayout, activePageIndex, hfLayout.totalHeight, hf.marginFromEdge);
-    }
-    for (const r of layoutRects) {
-      rects.push({
-        x: pageX + margins.left + r.x,
-        y: baseY + r.y,
-        width: r.width,
-        height: r.height,
-      });
-    }
+/**
+ * Map header/footer layout-relative rects to absolute page coordinates on the
+ * active page.
+ */
+function mapHFLayoutRects(
+  layoutRects: Array<{ x: number; y: number; width: number; height: number }>,
+  hfLayout: DocumentLayout,
+  hf: HeaderFooter,
+  region: 'header' | 'footer',
+  paginatedLayout: PaginatedLayout,
+  canvasWidth: number,
+  activePageIndex: number,
+): Array<{ x: number; y: number; width: number; height: number }> {
+  const pageX = getPageXOffset(paginatedLayout, canvasWidth);
+  const { margins } = paginatedLayout.pageSetup;
+  const baseY = region === 'header'
+    ? getHeaderYStart(paginatedLayout, activePageIndex, hf.marginFromEdge)
+    : getFooterYStart(paginatedLayout, activePageIndex, hfLayout.totalHeight, hf.marginFromEdge);
+  return layoutRects.map((r) => ({
+    x: pageX + margins.left + r.x,
+    y: baseY + r.y,
+    width: r.width,
+    height: r.height,
+  }));
+}
+
+/**
+ * Compute selection rects within a header/footer layout for all visible pages.
+ *
+ * Exported for unit tests only — not re-exported from the package index.
+ */
+export function computeHFSelectionRects(
+  selectionRange: { anchor: DocPosition; focus: DocPosition },
+  hfLayout: DocumentLayout,
+  hf: HeaderFooter,
+  region: 'header' | 'footer',
+  paginatedLayout: PaginatedLayout,
+  measurer: TextMeasurer,
+  canvasWidth: number,
+  activePageIndex: number,
+): Array<{ x: number; y: number; width: number; height: number }> {
+  const anchorCell = hfLayout.blockParentMap.get(selectionRange.anchor.blockId);
+  const focusCell = hfLayout.blockParentMap.get(selectionRange.focus.blockId);
+
+  // Both endpoints inside table cells: pure table-aware path.
+  if (anchorCell && focusCell) {
+    return computeHFTableCellSelectionRects(
+      selectionRange, anchorCell, focusCell, hfLayout, hf, region,
+      paginatedLayout, measurer, canvasWidth, activePageIndex,
+    );
   }
 
-  return rects;
+  // Mixed selection: one endpoint is a table cell and the other is an outside
+  // header/footer paragraph. Render both portions — the table cells clamped to
+  // the edge nearest the outside endpoint, plus the flat paragraph run between
+  // that endpoint and the table boundary.
+  if (anchorCell || focusCell) {
+    const tableRects = computeHFTableCellSelectionRects(
+      selectionRange, anchorCell, focusCell, hfLayout, hf, region,
+      paginatedLayout, measurer, canvasWidth, activePageIndex,
+    );
+    const cellInfo = (anchorCell ?? focusCell)!;
+    const outside = anchorCell ? selectionRange.focus : selectionRange.anchor;
+    const tableIdx = hfLayout.blocks.findIndex(
+      (bl) => bl.block.id === cellInfo.tableBlockId,
+    );
+    const outsideIdx = hfLayout.blocks.findIndex(
+      (bl) => bl.block.id === outside.blockId,
+    );
+    if (tableIdx === -1 || outsideIdx === -1) return tableRects;
+
+    let flatLayoutRects: Array<{ x: number; y: number; width: number; height: number }>;
+    if (outsideIdx < tableIdx) {
+      // Outside endpoint precedes the table: from it through the block just
+      // before the table.
+      const prev = hfLayout.blocks[tableIdx - 1];
+      flatLayoutRects = hfFlatLayoutRects(
+        hfLayout, outsideIdx, outside.offset,
+        tableIdx - 1, prev ? getBlockTextLength(prev.block) : 0, measurer,
+      );
+    } else {
+      // Outside endpoint follows the table: from the block just after the
+      // table through it.
+      flatLayoutRects = hfFlatLayoutRects(
+        hfLayout, tableIdx + 1, 0, outsideIdx, outside.offset, measurer,
+      );
+    }
+    const flatRects = mapHFLayoutRects(
+      flatLayoutRects, hfLayout, hf, region, paginatedLayout,
+      canvasWidth, activePageIndex,
+    );
+    return [...tableRects, ...flatRects];
+  }
+
+  // Neither endpoint in a table: flat scan across non-table blocks.
+  let startBlockIdx = -1, endBlockIdx = -1;
+  let startOffset = 0, endOffset = 0;
+  for (let i = 0; i < hfLayout.blocks.length; i++) {
+    if (hfLayout.blocks[i].block.id === selectionRange.anchor.blockId) {
+      startBlockIdx = i;
+      startOffset = selectionRange.anchor.offset;
+    }
+    if (hfLayout.blocks[i].block.id === selectionRange.focus.blockId) {
+      endBlockIdx = i;
+      endOffset = selectionRange.focus.offset;
+    }
+  }
+  if (startBlockIdx === -1 || endBlockIdx === -1) return [];
+
+  // Normalize direction
+  if (startBlockIdx > endBlockIdx || (startBlockIdx === endBlockIdx && startOffset > endOffset)) {
+    [startBlockIdx, endBlockIdx] = [endBlockIdx, startBlockIdx];
+    [startOffset, endOffset] = [endOffset, startOffset];
+  }
+
+  const layoutRects = hfFlatLayoutRects(
+    hfLayout, startBlockIdx, startOffset, endBlockIdx, endOffset, measurer,
+  );
+  return mapHFLayoutRects(
+    layoutRects, hfLayout, hf, region, paginatedLayout, canvasWidth, activePageIndex,
+  );
 }
 
 /**
@@ -1176,13 +1296,13 @@ export function initialize(
       ? undefined
       : editCtx === 'header' && headerLayout && doc.document.header
         ? computeHFCursorPixel(
-            cursor.position, headerLayout, doc.document.header, 'header',
+            cursor.position, cursor.lineAffinity, headerLayout, doc.document.header, 'header',
             paginatedLayout, measurer, logicalCanvasWidth, hfActivePageIndex,
             cursor.isVisible(),
           )
         : editCtx === 'footer' && footerLayout && doc.document.footer
           ? computeHFCursorPixel(
-              cursor.position, footerLayout, doc.document.footer, 'footer',
+              cursor.position, cursor.lineAffinity, footerLayout, doc.document.footer, 'footer',
               paginatedLayout, measurer, logicalCanvasWidth, hfActivePageIndex,
               cursor.isVisible(),
             )
@@ -1358,7 +1478,7 @@ export function initialize(
     if (editCtx === 'header' && headerLayout && doc.document.header) {
       const hfPage = textEditor?.getHFActivePageIndex() ?? 0;
       const hfPixel = computeHFCursorPixel(
-        cursor.position, headerLayout, doc.document.header, 'header',
+        cursor.position, cursor.lineAffinity, headerLayout, doc.document.header, 'header',
         paginatedLayout, measurer, logicalCanvasWidth,
         hfPage, cursor.isVisible(),
       );
@@ -1383,7 +1503,7 @@ export function initialize(
     if (editCtx === 'footer' && footerLayout && doc.document.footer) {
       const hfPageF = textEditor?.getHFActivePageIndex() ?? 0;
       const hfPixel = computeHFCursorPixel(
-        cursor.position, footerLayout, doc.document.footer, 'footer',
+        cursor.position, cursor.lineAffinity, footerLayout, doc.document.footer, 'footer',
         paginatedLayout, measurer, logicalCanvasWidth,
         hfPageF, cursor.isVisible(),
       );
@@ -2722,23 +2842,25 @@ export function initialize(
       render();
     },
     deleteTable: () => {
-      const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
+      const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
       const tableBlockId = cellInfo.tableBlockId;
       docStore.snapshot();
 
       // Check if this table is itself nested inside a cell
-      const parentCellInfo = layout.blockParentMap.get(tableBlockId);
+      const parentCellInfo = doc.blockParentMap.get(tableBlockId);
       if (parentCellInfo) {
         // Nested table — remove from parent cell's blocks
         const cursorBlockId = doc.deleteTableInCell(tableBlockId);
         cursor.moveTo({ blockId: cursorBlockId, offset: 0 });
       } else {
-        // Top-level table (existing logic)
+        // Top-level table (existing logic). Re-home within the active context
+        // (body / header / footer) so deleting a header/footer table keeps the
+        // caret in that region.
         const blockIndex = doc.getBlockIndex(tableBlockId);
         doc.deleteBlock(tableBlockId);
         // Move cursor to nearest block
-        const blocks = doc.document.blocks;
+        const blocks = doc.getContextBlocks();
         if (blocks.length > 0) {
           const newIndex = Math.min(blockIndex, blocks.length - 1);
           cursor.moveTo({ blockId: blocks[newIndex].id, offset: 0 });
@@ -2747,14 +2869,14 @@ export function initialize(
       invalidateLayout();
       render();
     },
-    isInTable: () => layout.blockParentMap.has(cursor.position.blockId),
+    isInTable: () => doc.blockParentMap.has(cursor.position.blockId),
     getCellAddress: (): CellAddress | undefined => {
-      const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
+      const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return undefined;
       return { rowIndex: cellInfo.rowIndex, colIndex: cellInfo.colIndex };
     },
     insertTableRow: (above: boolean) => {
-      const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
+      const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
       docStore.snapshot();
       const idx = above ? cellInfo.rowIndex : cellInfo.rowIndex + 1;
@@ -2763,7 +2885,7 @@ export function initialize(
       render();
     },
     deleteTableRow: () => {
-      const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
+      const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
       docStore.snapshot();
       const tableBlockId = cellInfo.tableBlockId;
@@ -2779,7 +2901,7 @@ export function initialize(
       render();
     },
     insertTableColumn: (left: boolean) => {
-      const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
+      const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
       docStore.snapshot();
       const idx = left ? cellInfo.colIndex : cellInfo.colIndex + 1;
@@ -2788,7 +2910,7 @@ export function initialize(
       render();
     },
     deleteTableColumn: () => {
-      const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
+      const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
       docStore.snapshot();
       const tableBlockId = cellInfo.tableBlockId;
@@ -2804,7 +2926,7 @@ export function initialize(
       render();
     },
     mergeTableCells: (range: CellRange) => {
-      const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
+      const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
       docStore.snapshot();
       const tableBlockId = cellInfo.tableBlockId;
@@ -2817,7 +2939,7 @@ export function initialize(
       render();
     },
     splitTableCell: () => {
-      const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
+      const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
       docStore.snapshot();
       doc.splitCell(cellInfo.tableBlockId, { rowIndex: cellInfo.rowIndex, colIndex: cellInfo.colIndex });
@@ -2825,7 +2947,7 @@ export function initialize(
       render();
     },
     getTableMergeContext: () =>
-      computeTableMergeContext(doc, layout.blockParentMap, cursor.position, selection.range),
+      computeTableMergeContext(doc, doc.blockParentMap, cursor.position, selection.range),
     applyTableCellStyle: (style: Partial<CellStyle>) => {
       docStore.snapshot();
       // Cell-range selection: apply to all cells in range
@@ -2845,7 +2967,7 @@ export function initialize(
         return;
       }
       // Single cell
-      const cellInfo = layout.blockParentMap.get(cursor.position.blockId);
+      const cellInfo = doc.blockParentMap.get(cursor.position.blockId);
       if (!cellInfo) return;
       doc.applyCellStyle(cellInfo.tableBlockId, { rowIndex: cellInfo.rowIndex, colIndex: cellInfo.colIndex }, style);
       markDirty(cellInfo.tableBlockId);

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -277,6 +277,14 @@ export function renderTableContent(
   focused?: boolean,
   rowSplitOffset?: number,
   rowSplitHeight?: number,
+  /**
+   * Current 1-based page number. When supplied, a run whose inline carries
+   * `style.pageNumber` paints this value instead of its `#` placeholder
+   * glyph — header/footer table cells can host page-number fields just like
+   * flat header/footer paragraphs. Undefined in the body, where page-number
+   * fields are not supported.
+   */
+  pageNumber?: number,
 ): void {
   const { rows } = tableData;
   const { cells, columnXOffsets, columnPixelWidths, rowYOffsets, rowHeights } = tableLayout;
@@ -386,6 +394,7 @@ export function renderTableContent(
               nestedX, nestedY,
               0, undefined, undefined,
               requestRender, dragImageRun, selectionRects, focused,
+              undefined, undefined, pageNumber,
             );
           }
           continue;
@@ -462,7 +471,14 @@ export function renderTableContent(
           // the translucent selection highlight stays visible inside a
           // colored span. Don't redraw them here.
 
-          ctx.fillText(run.text, runX, baselineY);
+          // Page-number field: substitute the resolved page number for the
+          // `#` placeholder. Mirrors `renderRunWithPageNumber` on the flat
+          // header/footer paragraph path.
+          const drawText =
+            pageNumber !== undefined && style.pageNumber
+              ? String(pageNumber)
+              : run.text;
+          ctx.fillText(drawText, runX, baselineY);
 
           // Underline
           if (style.underline) {

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -1826,10 +1826,13 @@ export class TextEditor {
       this.docDeleteText(this.cursor.position, 1);
       this.markDirty(this.cursor.position.blockId);
     } else {
-      // At end of block — merge with next (structural change)
+      // At end of block — merge with next (structural change). Resolve the
+      // sibling within the active context so this works in header/footer too
+      // (getBlockIndex is already context-aware).
+      const ctxBlocks = this.doc.getContextBlocks();
       const idx = this.doc.getBlockIndex(this.cursor.position.blockId);
-      if (idx < this.doc.document.blocks.length - 1) {
-        const nextBlock = this.doc.document.blocks[idx + 1];
+      if (idx < ctxBlocks.length - 1) {
+        const nextBlock = ctxBlocks[idx + 1];
         this.invalidateLayout();
         this.doc.mergeBlocks(this.cursor.position.blockId, nextBlock.id);
       }
@@ -1871,11 +1874,13 @@ export class TextEditor {
       this.docDeleteText(pos, count);
       this.markDirty(pos.blockId);
     } else {
-      // At end of block — merge with next (same as normal delete)
+      // At end of block — merge with next (same as normal delete),
+      // context-aware so header/footer paragraphs merge correctly.
+      const ctxBlocks = this.doc.getContextBlocks();
       const idx = this.doc.getBlockIndex(pos.blockId);
-      if (idx < this.doc.document.blocks.length - 1) {
+      if (idx < ctxBlocks.length - 1) {
         this.invalidateLayout();
-        this.doc.mergeBlocks(pos.blockId, this.doc.document.blocks[idx + 1].id);
+        this.doc.mergeBlocks(pos.blockId, ctxBlocks[idx + 1].id);
       }
     }
     this.requestRender();

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -3871,8 +3871,10 @@ export class TextEditor {
   }
 
   private getPositionBeforeTable(tableBlockId: string): DocPosition | undefined {
-    // For nested tables, find the previous block in the parent cell
-    const parentCellInfo = this.getLayout().blockParentMap.get(tableBlockId);
+    // For nested tables, find the previous block in the parent cell. Use the
+    // active layout so a nested table inside a header/footer cell resolves its
+    // parent (the body layout map omits header/footer cells).
+    const parentCellInfo = this.getActiveLayout().blockParentMap.get(tableBlockId);
     if (parentCellInfo) {
       const parentTable = this.doc.getBlock(parentCellInfo.tableBlockId);
       const parentCell = parentTable.tableData!.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];
@@ -3893,8 +3895,9 @@ export class TextEditor {
   }
 
   private getPositionAfterTable(tableBlockId: string): DocPosition | undefined {
-    // For nested tables, find the next block in the parent cell
-    const parentCellInfo = this.getLayout().blockParentMap.get(tableBlockId);
+    // For nested tables, find the next block in the parent cell. Active layout
+    // so header/footer nested tables resolve their parent cell.
+    const parentCellInfo = this.getActiveLayout().blockParentMap.get(tableBlockId);
     if (parentCellInfo) {
       const parentTable = this.doc.getBlock(parentCellInfo.tableBlockId);
       const parentCell = parentTable.tableData!.rows[parentCellInfo.rowIndex].cells[parentCellInfo.colIndex];

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -2234,8 +2234,8 @@ export class TextEditor {
               const prevCellPos = this.getPrevCellLastPosition(arrowCellInfo);
               if (prevCellPos) {
                 newPos = prevCellPos;
-              } else if (this.editContext === 'body') {
-                // At first cell: exit table upward (body only).
+              } else {
+                // At first cell: exit table upward (region-aware).
                 newPos = this.getPositionBeforeTable(tableBlockId);
               }
             } else if (this.moveToPrevCell()) {
@@ -2259,8 +2259,8 @@ export class TextEditor {
               const nextCellPos = this.getNextCellFirstPosition(arrowCellInfo);
               if (nextCellPos) {
                 newPos = nextCellPos;
-              } else if (this.editContext === 'body') {
-                // At last cell: exit table downward (body only).
+              } else {
+                // At last cell: exit table downward (region-aware).
                 newPos = this.getPositionAfterTable(tableBlockId);
               }
             } else if (this.moveToNextCell()) {
@@ -2337,9 +2337,8 @@ export class TextEditor {
                 offset: Math.min(pos.offset, getBlockTextLength(lastBlock)),
               };
             }
-          } else if (this.editContext === 'body') {
-            // Exit table upward (body only — header/footer arrows stay in
-            // the table; exiting into header sibling blocks is not wired).
+          } else {
+            // Exit table upward (region-aware: body, header, or footer).
             const parentCellInfo = this.getActiveLayout().blockParentMap.get(tableBlockId);
             if (parentCellInfo) {
               // Nested table — move to the block before this table in parent cell
@@ -2363,14 +2362,14 @@ export class TextEditor {
                 // Exit outer table
                 const outerIdx = this.doc.getBlockIndex(parentCellInfo.tableBlockId);
                 if (outerIdx > 0) {
-                  const prevBlock = this.doc.document.blocks[outerIdx - 1];
+                  const prevBlock = this.doc.getContextBlocks()[outerIdx - 1];
                   newPos = { blockId: prevBlock.id, offset: getBlockTextLength(prevBlock) };
                 }
               }
             } else {
               const blockIndex = this.doc.getBlockIndex(tableBlockId);
               if (blockIndex > 0) {
-                const prevBlock = this.doc.document.blocks[blockIndex - 1];
+                const prevBlock = this.doc.getContextBlocks()[blockIndex - 1];
                 newPos = { blockId: prevBlock.id, offset: getBlockTextLength(prevBlock) };
               }
             }
@@ -2438,8 +2437,8 @@ export class TextEditor {
                 offset: Math.min(pos.offset, getBlockTextLength(firstBlock)),
               };
             }
-          } else if (this.editContext === 'body') {
-            // Exit table downward (body only — see the upward case).
+          } else {
+            // Exit table downward (region-aware: body, header, or footer).
             const parentCellInfo = this.getActiveLayout().blockParentMap.get(tableBlockId);
             if (parentCellInfo) {
               // Nested table — move to the block after this table in parent cell
@@ -3882,7 +3881,7 @@ export class TextEditor {
     }
     const idx = this.doc.getBlockIndex(tableBlockId);
     if (idx > 0) {
-      const prev = this.doc.document.blocks[idx - 1];
+      const prev = this.doc.getContextBlocks()[idx - 1];
       return { blockId: prev.id, offset: getBlockTextLength(prev) };
     }
     return undefined;
@@ -3902,7 +3901,7 @@ export class TextEditor {
       return this.getNextCellFirstPosition(parentCellInfo);
     }
     const idx = this.doc.getBlockIndex(tableBlockId);
-    const blocks = this.doc.document.blocks;
+    const blocks = this.doc.getContextBlocks();
     if (idx < blocks.length - 1) {
       return { blockId: blocks[idx + 1].id, offset: 0 };
     }
@@ -4611,11 +4610,9 @@ export class TextEditor {
     }
     // At last cell
     if (addRowAtEnd) {
-      // Structural row insertion targets the body table store path; header/
-      // footer table row/column ops are not wired (resolveTableBlock assumes
-      // the body). Tab at the last header/footer cell is a no-op rather than
-      // a crash.
-      if (this.editContext !== 'body') return false;
+      // Tab at the last cell inserts a new row. The table store ops are keyed
+      // by block id (region-aware via findBlock), so this works in the body,
+      // header, and footer alike.
       // Tab: insert a new row and move to it
       this.saveSnapshot();
       const newRowIndex = td.rows.length;
@@ -4647,10 +4644,8 @@ export class TextEditor {
       this.cursor.moveTo({ blockId: parentCell.blocks[0].id, offset: 0 });
       return this.moveToNextCell(addRowAtEnd);
     }
-    // Header/footer: exiting the table into sibling blocks is not wired;
-    // keep the caret in the last cell rather than jumping into the body.
-    if (this.editContext !== 'body') return false;
-    // Top-level table — move to the block after the table
+    // Top-level table — move to the block after the table (region-aware:
+    // ensureBlockAfter / getBlockIndex resolve against the active context).
     const blockIndex = this.doc.getBlockIndex(tableBlockId);
     const nextId = this.doc.ensureBlockAfter(blockIndex);
     this.cursor.moveTo({ blockId: nextId, offset: 0 });
@@ -4707,12 +4702,10 @@ export class TextEditor {
       this.cursor.moveTo({ blockId: parentCell.blocks[0].id, offset: 0 });
       return this.moveToPrevCell();
     }
-    // Header/footer: don't exit the table into sibling blocks (not wired).
-    if (this.editContext !== 'body') return false;
-    // Top-level table — move to the block before the table
+    // Top-level table — move to the block before the table (region-aware).
     const blockIndex = this.doc.getBlockIndex(tableBlockId);
     if (blockIndex > 0) {
-      const prevBlock = this.doc.document.blocks[blockIndex - 1];
+      const prevBlock = this.doc.getContextBlocks()[blockIndex - 1];
       this.cursor.moveTo({ blockId: prevBlock.id, offset: getBlockTextLength(prevBlock) });
       return true;
     }

--- a/packages/docs/test/export/docx-exporter.test.ts
+++ b/packages/docs/test/export/docx-exporter.test.ts
@@ -85,6 +85,34 @@ describe('DocxExporter', () => {
     expect(reimported.blocks[0].tableData!.rows[0].cells[0].blocks[0].inlines[0].text).toBe('A1');
   });
 
+  it('should emit per-cell <w:tcW> widths matching the column ratios', async () => {
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'table',
+        inlines: [],
+        style: { ...DEFAULT_BLOCK_STYLE },
+        tableData: {
+          rows: [{
+            cells: [
+              { blocks: [{ id: generateBlockId(), type: 'paragraph', inlines: [{ text: 'A', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }], style: {} },
+              { blocks: [{ id: generateBlockId(), type: 'paragraph', inlines: [{ text: 'B', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } }], style: {} },
+            ],
+          }],
+          columnWidths: [0.25, 0.75],
+        },
+      }],
+    };
+
+    const blob = await DocxExporter.export(doc);
+    const JSZip = (await import('jszip')).default;
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    const docXml = await zip.file('word/document.xml')!.async('string');
+    // totalTwips = 9000 → 0.25×9000 = 2250, 0.75×9000 = 6750.
+    expect(docXml).toContain('<w:tcW w:w="2250" w:type="dxa"/>');
+    expect(docXml).toContain('<w:tcW w:w="6750" w:type="dxa"/>');
+  });
+
   it('should skip horizontal merge placeholder cells (no extra w:tc with w:vMerge)', async () => {
     // Owner with colSpan=2 covers the next grid column; the placeholder
     // at cell index 1 must NOT round-trip as a stray vMerge continuation,

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -347,6 +347,39 @@ describe('DocxImporter', () => {
     expect(td.columnWidths[1]).toBeCloseTo(0.5, 5);
   });
 
+  it('does not let a nested table tcW leak into the gridless outer column widths', async () => {
+    // Outer table has no <w:tblGrid>. Its first cell has NO direct <w:tcPr>
+    // but contains a nested table whose cells declare a huge tcW; the second
+    // cell declares tcW=1000. A recursive tcPr lookup would pull the nested
+    // 9999 into the outer column-width derivation. Direct-child lookup must
+    // treat the first outer cell as a unit weight, so the second cell (1000)
+    // dominates the outer ratios.
+    const buffer = await createMinimalDocx(`
+      <w:tbl>
+        <w:tr>
+          <w:tc>
+            <w:tbl>
+              <w:tblGrid><w:gridCol w:w="9999"/></w:tblGrid>
+              <w:tr>
+                <w:tc><w:tcPr><w:tcW w:w="9999" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>inner</w:t></w:r></w:p></w:tc>
+              </w:tr>
+            </w:tbl>
+          </w:tc>
+          <w:tc><w:tcPr><w:tcW w:w="1000" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    const outer = doc.blocks[0].tableData!;
+    expect(outer.columnWidths).toHaveLength(2);
+    // Outer col 0 = unit weight (1), col 1 = 1000 → col 1 dominates. With the
+    // recursive-lookup bug it would be [9999, 1000] → col 1 ≈ 0.09.
+    expect(outer.columnWidths[1]).toBeGreaterThan(0.9);
+    // The nested table is still imported as a native block in the first cell.
+    const nested = outer.rows[0].cells[0].blocks.find((b) => b.type === 'table');
+    expect(nested).toBeDefined();
+  });
+
   it('should pad horizontal merge placeholders so cells.length matches numCols', async () => {
     // 5-column row with [A, B(gridSpan=4)]. Downstream layout, rendering,
     // and click handling all index `rows[r].cells[c]` by grid column and

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -310,6 +310,43 @@ describe('DocxImporter', () => {
     expect(td.columnWidths[2]).toBeCloseTo(3 / 6, 5);
   });
 
+  it('should derive column widths from <w:tcW> when <w:tblGrid> is absent', async () => {
+    // No <w:tblGrid> (hand-authored / malformed docx). Column proportions must
+    // come from per-cell <w:tcW> dxa widths so the table still renders with the
+    // right column ratios (1000/3000 → 1/4, 3/4).
+    const buffer = await createMinimalDocx(`
+      <w:tbl>
+        <w:tr>
+          <w:tc><w:tcPr><w:tcW w:w="1000" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc>
+          <w:tc><w:tcPr><w:tcW w:w="3000" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    const td = doc.blocks[0].tableData!;
+    expect(td.columnWidths).toHaveLength(2);
+    expect(td.columnWidths[0]).toBeCloseTo(1 / 4, 5);
+    expect(td.columnWidths[1]).toBeCloseTo(3 / 4, 5);
+    // Both cells preserved and aligned to the derived 2-column grid.
+    expect(td.rows[0].cells).toHaveLength(2);
+  });
+
+  it('falls back to even-share columns when tblGrid and tcW are both absent', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:tbl>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    const td = doc.blocks[0].tableData!;
+    expect(td.columnWidths).toHaveLength(2);
+    expect(td.columnWidths[0]).toBeCloseTo(0.5, 5);
+    expect(td.columnWidths[1]).toBeCloseTo(0.5, 5);
+  });
+
   it('should pad horizontal merge placeholders so cells.length matches numCols', async () => {
     // 5-column row with [A, B(gridSpan=4)]. Downstream layout, rendering,
     // and click handling all index `rows[r].cells[c]` by grid column and

--- a/packages/docs/test/view/header-table-nav.test.ts
+++ b/packages/docs/test/view/header-table-nav.test.ts
@@ -205,6 +205,36 @@ describe('header table structural edits (region-aware)', () => {
     expect(editor._getCursorForTest().blockId).toBe(rows[2].cells[0].blocks[0].id);
   });
 
+  test('Delete at the end of a header paragraph merges with the next header paragraph', () => {
+    // Regression: the merge-next path resolved the sibling from the body
+    // block array, so deleting at the end of a header paragraph either no-op'd
+    // or threw "Cannot merge blocks from different regions".
+    const store = new MemDocStore();
+    store.setDocument({
+      blocks: [para('body')],
+      header: { blocks: [para('AAA'), para('BBB')], marginFromEdge: 48 },
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const editor = initialize(container, store);
+    editors.push(editor);
+
+    const first = store.getDocument().header!.blocks[0].id;
+    editor._setEditContextForTest('header');
+    editor._setSelectionForTest({
+      anchor: { blockId: first, offset: 3 },
+      focus: { blockId: first, offset: 3 },
+    });
+    const ta = container.querySelector('textarea')!;
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete', bubbles: true, cancelable: true }));
+
+    const headerBlocks = store.getDocument().header!.blocks;
+    expect(headerBlocks).toHaveLength(1);
+    expect(headerBlocks[0].inlines.map((i) => i.text).join('')).toBe('AAABBB');
+    // Body untouched.
+    expect(store.getDocument().blocks).toHaveLength(1);
+  });
+
   test('ArrowRight at the last header cell exits into the trailing header paragraph', () => {
     const { editor, table, container, store } = setup();
     // c11 'No42' length 4 — caret at end.

--- a/packages/docs/test/view/header-table-nav.test.ts
+++ b/packages/docs/test/view/header-table-nav.test.ts
@@ -116,3 +116,108 @@ describe('header table arrow navigation', () => {
     expect(pos.blockId).toBe(c11);
   });
 });
+
+describe('header table structural edits (region-aware)', () => {
+  const editors: EditorAPI[] = [];
+  beforeEach(() => { installCanvasShim(); document.body.innerHTML = ''; });
+  afterEach(() => {
+    for (const editor of editors.splice(0)) editor.dispose();
+    document.body.innerHTML = '';
+  });
+
+  function setup(): {
+    editor: EditorAPI;
+    table: Block;
+    container: HTMLElement;
+    store: MemDocStore;
+  } {
+    const store = new MemDocStore();
+    const table = headerTableBlock();
+    store.setDocument({
+      blocks: [para('body')],
+      header: { blocks: [table, para('')], marginFromEdge: 48 },
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const editor = initialize(container, store);
+    editors.push(editor);
+    return { editor, table, container, store };
+  }
+
+  function placeInCell(editor: EditorAPI, blockId: string): void {
+    editor._setEditContextForTest('header');
+    editor._setSelectionForTest({
+      anchor: { blockId, offset: 0 },
+      focus: { blockId, offset: 0 },
+    });
+  }
+
+  test('isInTable / getCellAddress resolve a header cell cursor', () => {
+    const { editor, table } = setup();
+    placeInCell(editor, table.tableData!.rows[0].cells[0].blocks[0].id);
+    expect(editor.isInTable()).toBe(true);
+    expect(editor.getCellAddress()).toEqual({ rowIndex: 0, colIndex: 0 });
+  });
+
+  test('insertTableRow adds a row to the header table', () => {
+    const { editor, table, store } = setup();
+    placeInCell(editor, table.tableData!.rows[0].cells[0].blocks[0].id);
+    editor.insertTableRow(false);
+    const rows = store.getDocument().header!.blocks[0].tableData!.rows;
+    expect(rows).toHaveLength(3);
+  });
+
+  test('deleteTableRow removes a row from the header table', () => {
+    const { editor, table, store } = setup();
+    placeInCell(editor, table.tableData!.rows[1].cells[0].blocks[0].id);
+    editor.deleteTableRow();
+    const rows = store.getDocument().header!.blocks[0].tableData!.rows;
+    expect(rows).toHaveLength(1);
+  });
+
+  test('insertTableColumn adds a column to the header table', () => {
+    const { editor, table, store } = setup();
+    placeInCell(editor, table.tableData!.rows[0].cells[0].blocks[0].id);
+    editor.insertTableColumn(false);
+    const td = store.getDocument().header!.blocks[0].tableData!;
+    expect(td.columnWidths).toHaveLength(3);
+    expect(td.rows[0].cells).toHaveLength(3);
+  });
+
+  test('deleteTableColumn removes a column from the header table', () => {
+    const { editor, table, store } = setup();
+    placeInCell(editor, table.tableData!.rows[0].cells[0].blocks[0].id);
+    editor.deleteTableColumn();
+    const td = store.getDocument().header!.blocks[0].tableData!;
+    expect(td.columnWidths).toHaveLength(1);
+    expect(td.rows[0].cells).toHaveLength(1);
+  });
+
+  test('Tab at the last header cell appends a row and moves into it', () => {
+    const { editor, table, container, store } = setup();
+    const last = table.tableData!.rows[1].cells[1].blocks[0].id;
+    placeInCell(editor, last);
+    const ta = container.querySelector('textarea')!;
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }));
+    const rows = store.getDocument().header!.blocks[0].tableData!.rows;
+    expect(rows).toHaveLength(3);
+    // Caret moved into the freshly inserted row's first cell.
+    expect(editor._getCursorForTest().blockId).toBe(rows[2].cells[0].blocks[0].id);
+  });
+
+  test('ArrowRight at the last header cell exits into the trailing header paragraph', () => {
+    const { editor, table, container, store } = setup();
+    // c11 'No42' length 4 — caret at end.
+    const c11 = table.tableData!.rows[1].cells[1].blocks[0].id;
+    editor._setEditContextForTest('header');
+    editor._setSelectionForTest({
+      anchor: { blockId: c11, offset: 4 },
+      focus: { blockId: c11, offset: 4 },
+    });
+    const ta = container.querySelector('textarea')!;
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true }));
+    const trailingParaId = store.getDocument().header!.blocks[1].id;
+    expect(editor._getCursorForTest().blockId).toBe(trailingParaId);
+    expect(editor.isInTable()).toBe(false);
+  });
+});

--- a/packages/docs/test/view/hf-caret-selection.test.ts
+++ b/packages/docs/test/view/hf-caret-selection.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeHFCursorPixel,
+  computeHFSelectionRects,
+} from '../../src/view/editor.js';
+import type { DocumentLayout, LayoutBlock, LayoutRun } from '../../src/view/layout.js';
+import type { LayoutTable } from '../../src/view/table-layout.js';
+import type { PaginatedLayout } from '../../src/view/pagination.js';
+import type { TextMeasurer } from '../../src/view/measurer.js';
+import {
+  DEFAULT_BLOCK_STYLE,
+  DEFAULT_CELL_STYLE,
+  DEFAULT_PAGE_SETUP,
+  type Block,
+  type HeaderFooter,
+  type TableData,
+} from '../../src/model/types.js';
+
+// Each glyph is 6px wide in the stub measurer.
+const measurer: TextMeasurer = {
+  measureWidth: (text: string) => text.length * 6,
+};
+
+function run(text: string, charStart: number, x: number): LayoutRun {
+  const charOffsets = Array.from({ length: text.length }, (_, i) => (i + 1) * 6);
+  return {
+    inline: { text, style: {} },
+    text,
+    x,
+    width: text.length * 6,
+    inlineIndex: 0,
+    charStart,
+    charEnd: charStart + text.length,
+    charOffsets,
+  };
+}
+
+function para(id: string, text: string): Block {
+  return {
+    id,
+    type: 'paragraph',
+    inlines: [{ text, style: {} }],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  };
+}
+
+const paginatedLayout: PaginatedLayout = {
+  pages: [{ pageIndex: 0, lines: [], width: 816, height: 1056 }],
+  pageSetup: DEFAULT_PAGE_SETUP,
+};
+
+describe('computeHFCursorPixel — lineAffinity at wrap boundary', () => {
+  // A single paragraph wrapped into two visual lines of 5 chars each. The
+  // caret at offset 5 sits exactly on the wrap boundary: backward affinity
+  // belongs to the end of line 0, forward affinity to the start of line 1.
+  function makeWrappedHeader(): { hfLayout: DocumentLayout; hf: HeaderFooter } {
+    const block = para('p1', 'AAAAABBBBB');
+    const lb: LayoutBlock = {
+      block,
+      x: 0,
+      y: 0,
+      width: 60,
+      height: 32,
+      lines: [
+        { y: 0, height: 16, width: 30, runs: [run('AAAAA', 0, 0)] },
+        { y: 16, height: 16, width: 30, runs: [run('BBBBB', 5, 0)] },
+      ],
+    };
+    const hfLayout: DocumentLayout = {
+      blocks: [lb],
+      totalHeight: 32,
+      blockParentMap: new Map(),
+    };
+    return { hfLayout, hf: { blocks: [block], marginFromEdge: 48 } };
+  }
+
+  it('places a backward-affinity caret on the first visual line', () => {
+    const { hfLayout, hf } = makeWrappedHeader();
+    const pixel = computeHFCursorPixel(
+      { blockId: 'p1', offset: 5 }, 'backward', hfLayout, hf, 'header',
+      paginatedLayout, measurer, 816, 0, true,
+    );
+    expect(pixel).toBeDefined();
+    // pageX = 0 (page fills canvas), margins.left = 96, x within line = 5×6px.
+    expect(pixel!.x).toBe(96 + 30);
+    // baseY = pageY(pageGap 40) + marginFromEdge(48) = 88; line 0 y offset 0.
+    expect(pixel!.y).toBe(88);
+  });
+
+  it('places a forward-affinity caret on the next visual line', () => {
+    const { hfLayout, hf } = makeWrappedHeader();
+    const back = computeHFCursorPixel(
+      { blockId: 'p1', offset: 5 }, 'backward', hfLayout, hf, 'header',
+      paginatedLayout, measurer, 816, 0, true,
+    );
+    const fwd = computeHFCursorPixel(
+      { blockId: 'p1', offset: 5 }, 'forward', hfLayout, hf, 'header',
+      paginatedLayout, measurer, 816, 0, true,
+    );
+    expect(back).toBeDefined();
+    expect(fwd).toBeDefined();
+    // Forward affinity drops the caret to the start (x at line origin) of the
+    // next visual line, one line height (16px) lower than backward affinity.
+    expect(fwd!.y - back!.y).toBe(16);
+    expect(fwd!.x).toBeLessThan(back!.x);
+  });
+});
+
+describe('computeHFSelectionRects — mixed table / paragraph selection', () => {
+  // Header layout: a paragraph block followed by a 1×1 table block. A
+  // selection spanning the paragraph into the table cell must render BOTH the
+  // paragraph portion and the table cell, not collapse to the cell alone.
+  function makeMixedHeader(): { hfLayout: DocumentLayout; hf: HeaderFooter } {
+    const pBlock = para('p1', 'HELLO');
+    const cellBlock = para('c0', 'X');
+    const tableData: TableData = {
+      rows: [{ cells: [{ blocks: [cellBlock], style: { ...DEFAULT_CELL_STYLE } }] }],
+      columnWidths: [1],
+    };
+    const tableBlock: Block = {
+      id: 't1',
+      type: 'table',
+      inlines: [],
+      style: { ...DEFAULT_BLOCK_STYLE },
+      tableData,
+    };
+    const tl: LayoutTable = {
+      cells: [[{ lines: [], blockBoundaries: [0], width: 100, height: 20, merged: false }]],
+      columnXOffsets: [0],
+      columnPixelWidths: [100],
+      rowYOffsets: [0],
+      rowHeights: [20],
+      totalWidth: 100,
+      totalHeight: 20,
+      blockParentMap: new Map(),
+    };
+    const pLb: LayoutBlock = {
+      block: pBlock,
+      x: 0,
+      y: 0,
+      width: 30,
+      height: 16,
+      lines: [{ y: 0, height: 16, width: 30, runs: [run('HELLO', 0, 0)] }],
+    };
+    const tLb: LayoutBlock = {
+      block: tableBlock,
+      x: 0,
+      y: 16,
+      width: 100,
+      height: 20,
+      lines: [],
+      layoutTable: tl,
+    };
+    const blockParentMap = new Map([
+      ['c0', { tableBlockId: 't1', rowIndex: 0, colIndex: 0 }],
+    ]);
+    const hfLayout: DocumentLayout = {
+      blocks: [pLb, tLb],
+      totalHeight: 36,
+      blockParentMap,
+    };
+    return {
+      hfLayout,
+      hf: { blocks: [pBlock, tableBlock], marginFromEdge: 48 },
+    };
+  }
+
+  it('renders both the table cell and the outside paragraph portion', () => {
+    const { hfLayout, hf } = makeMixedHeader();
+    const rects = computeHFSelectionRects(
+      { anchor: { blockId: 'p1', offset: 2 }, focus: { blockId: 'c0', offset: 1 } },
+      hfLayout, hf, 'header', paginatedLayout, measurer, 816, 0,
+    );
+    // At least one rect for the table cell + at least one for the paragraph.
+    expect(rects.length).toBeGreaterThanOrEqual(2);
+    // A 100px-wide table cell rect must be present.
+    expect(rects.some((r) => r.width === 100)).toBe(true);
+    // The paragraph portion (from offset 2 to end of "HELLO" = 3 chars × 6px)
+    // produces a narrow rect that is not the full cell width.
+    expect(rects.some((r) => r.width > 0 && r.width < 100)).toBe(true);
+  });
+
+  it('still works for a pure paragraph selection (no table endpoints)', () => {
+    const { hfLayout, hf } = makeMixedHeader();
+    const rects = computeHFSelectionRects(
+      { anchor: { blockId: 'p1', offset: 0 }, focus: { blockId: 'p1', offset: 5 } },
+      hfLayout, hf, 'header', paginatedLayout, measurer, 816, 0,
+    );
+    expect(rects.length).toBe(1);
+    expect(rects[0].width).toBe(30); // 5 glyphs × 6px
+  });
+});

--- a/packages/docs/test/view/table-renderer.test.ts
+++ b/packages/docs/test/view/table-renderer.test.ts
@@ -465,6 +465,55 @@ describe('renderTableContent page-number fields', () => {
     const drawn = fillText.mock.calls.map((c) => c[0]);
     expect(drawn).toContain('#');
   });
+
+  it('propagates the page number into a nested table cell', () => {
+    // The page-number run lives in a nested table inside an outer cell. The
+    // recursive renderTableContent call must thread pageNumber down so the
+    // nested cell substitutes the number, not its '#' placeholder.
+    const { ctx, fillText } = makeRecordingCtx();
+    const inner = makePageNumberCellTable();
+    const nestedBlock = {
+      id: 'nested',
+      type: 'table' as const,
+      inlines: [],
+      style: { ...DEFAULT_BLOCK_STYLE },
+      tableData: inner.tableData,
+    };
+    const outerTableData: TableData = {
+      rows: [{ cells: [{ blocks: [nestedBlock], style: { ...DEFAULT_CELL_STYLE } }] }],
+      columnWidths: [1],
+    };
+    const outerLayout: LayoutTable = {
+      cells: [
+        [
+          {
+            lines: [
+              { y: 0, height: 16, width: 40, runs: [], nestedTable: inner.layout },
+            ],
+            blockBoundaries: [0],
+            width: 40,
+            height: 16,
+            merged: false,
+          },
+        ],
+      ],
+      columnXOffsets: [0],
+      columnPixelWidths: [40],
+      rowYOffsets: [0],
+      rowHeights: [16],
+      totalWidth: 40,
+      totalHeight: 16,
+      blockParentMap: new Map(),
+    };
+    renderTableContent(
+      ctx, outerTableData, outerLayout, 0, 0,
+      undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, 9,
+    );
+    const drawn = fillText.mock.calls.map((c) => c[0]);
+    expect(drawn).toContain('9');
+    expect(drawn).not.toContain('#');
+  });
 });
 
 describe('DocCanvas ↔ table-renderer wiring', () => {

--- a/packages/docs/test/view/table-renderer.test.ts
+++ b/packages/docs/test/view/table-renderer.test.ts
@@ -374,6 +374,99 @@ describe('renderTableContent image inlines', () => {
   });
 });
 
+describe('renderTableContent page-number fields', () => {
+  // A header/footer table cell can host a page-number field
+  // (`inline.style.pageNumber`). Its layout run carries a `#` placeholder;
+  // renderTableContent must substitute the resolved page number when one is
+  // threaded through, mirroring the flat header/footer paragraph path.
+  function makePageNumberCellTable(): {
+    tableData: TableData;
+    layout: LayoutTable;
+  } {
+    const pnStyle = { pageNumber: true };
+    const tableData: TableData = {
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [
+                {
+                  id: 'b1',
+                  type: 'paragraph',
+                  inlines: [{ text: '#', style: pnStyle }],
+                  style: { ...DEFAULT_BLOCK_STYLE },
+                },
+              ],
+              style: { ...DEFAULT_CELL_STYLE },
+            },
+          ],
+        },
+      ],
+      columnWidths: [1],
+    };
+    const layout: LayoutTable = {
+      cells: [
+        [
+          {
+            lines: [
+              {
+                y: 0,
+                height: 16,
+                width: 40,
+                runs: [
+                  {
+                    inline: { text: '#', style: pnStyle },
+                    text: '#',
+                    x: 0,
+                    width: 10,
+                    inlineIndex: 0,
+                    charStart: 0,
+                    charEnd: 1,
+                    charOffsets: [10],
+                  },
+                ],
+              },
+            ],
+            blockBoundaries: [0],
+            width: 40,
+            height: 16,
+            merged: false,
+          },
+        ],
+      ],
+      columnXOffsets: [0],
+      columnPixelWidths: [40],
+      rowYOffsets: [0],
+      rowHeights: [16],
+      totalWidth: 40,
+      totalHeight: 16,
+      blockParentMap: new Map(),
+    };
+    return { tableData, layout };
+  }
+
+  it('substitutes the page number for the placeholder when pageNumber is supplied', () => {
+    const { ctx, fillText } = makeRecordingCtx();
+    const { tableData, layout } = makePageNumberCellTable();
+    renderTableContent(
+      ctx, tableData, layout, 0, 0,
+      undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, 7,
+    );
+    const drawn = fillText.mock.calls.map((c) => c[0]);
+    expect(drawn).toContain('7');
+    expect(drawn).not.toContain('#');
+  });
+
+  it('draws the literal placeholder when no page number is threaded (body path)', () => {
+    const { ctx, fillText } = makeRecordingCtx();
+    const { tableData, layout } = makePageNumberCellTable();
+    renderTableContent(ctx, tableData, layout, 0, 0);
+    const drawn = fillText.mock.calls.map((c) => c[0]);
+    expect(drawn).toContain('#');
+  });
+});
+
 describe('DocCanvas ↔ table-renderer wiring', () => {
   // A full DocCanvas.render() test would need an HTMLCanvasElement, a
   // paginated layout, a selection object, and a request-render callback —

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -2162,50 +2162,16 @@ export class YorkieDocStore implements DocStore {
   // -----------------------------------------------------------------------
 
   /**
-   * Resolve a table block's tree path. For top-level tables, returns a
-   * single-element array with the tree-adjusted index. For nested tables
-   * (inside a cell), returns the full path segments through the tree
-   * hierarchy: [parentTableIdx, rowIdx, cellIdx, blockIdx, ...].
+   * Resolve a table block's tree path. A table is just a block, so this
+   * delegates to the region-aware `resolveBlockTreePath`, which covers body,
+   * header, and footer (and nested tables). Returns:
+   * - Body top-level table:    `[treeIdx]`
+   * - Header top-level table:  `[0, blockIdx]`
+   * - Footer top-level table:  `[footerTreeIdx, blockIdx]`
+   * - Nested table:            `[...regionPrefix, rowIdx, cellIdx, blockIdx, ...]`
    */
   private resolveTableTreePath(tableBlockId: string): number[] {
-    const currentDoc = this.getDocument();
-
-    // Check if it's a top-level block
-    const bodyIdx = currentDoc.blocks.findIndex((b) => b.id === tableBlockId);
-    if (bodyIdx !== -1) {
-      return [bodyIdx + this.bodyTreeOffset(currentDoc)];
-    }
-
-    // Nested table — recursively search through the document structure
-    function findInBlocks(blocks: Block[], targetId: string, basePath: number[]): number[] | null {
-      for (let i = 0; i < blocks.length; i++) {
-        const block = blocks[i];
-        if (block.id === targetId) {
-          return [...basePath, i];
-        }
-        if (block.type === 'table' && block.tableData) {
-          for (let r = 0; r < block.tableData.rows.length; r++) {
-            for (let c = 0; c < block.tableData.rows[r].cells.length; c++) {
-              const cell = block.tableData.rows[r].cells[c];
-              const result = findInBlocks(cell.blocks, targetId, [...basePath, i, r, c]);
-              if (result) return result;
-            }
-          }
-        }
-      }
-      return null;
-    }
-
-    const offset = this.bodyTreeOffset(currentDoc);
-    const path = findInBlocks(currentDoc.blocks, tableBlockId, []);
-
-    if (!path) {
-      throw new Error(`Table block not found: ${tableBlockId}`);
-    }
-
-    // Add the body tree offset to the first segment
-    path[0] += offset;
-    return path;
+    return this.resolveBlockTreePath(tableBlockId, this.getDocument()).path;
   }
 
   /** Returns body array index and tree-adjusted index for a table block. */
@@ -2222,17 +2188,31 @@ export class YorkieDocStore implements DocStore {
 
   /**
    * Resolve the table Block from the cached document using the tree path
-   * returned by resolveTableTreePath(). For top-level tables, this indexes
-   * into `doc.blocks`. For nested tables, it walks through the table
-   * hierarchy (row → cell → blocks).
+   * returned by resolveTableTreePath(). Region-aware: a header table path
+   * starts `[0, blockIdx]`, a footer table path starts `[footerTreeIdx,
+   * blockIdx]`, and a body table path starts `[treeIdx]` (= bodyArrayIdx +
+   * bodyTreeOffset). Nested tables append [rowIdx, colIdx, blockIdx] triplets.
    */
   private resolveTableBlock(treePath: number[], doc: Document): Block {
     const offset = this.bodyTreeOffset(doc);
-    const bodyIdx = treePath[0] - offset;
-    let block = doc.blocks[bodyIdx];
-    // Walk deeper for nested tables: path segments after the first are
-    // [rowIdx, colIdx, blockIdx] triplets leading to the target block.
-    for (let i = 1; i < treePath.length; i += 3) {
+    const footerTreeIdx = offset + doc.blocks.length;
+    let block: Block;
+    let nestedStart: number;
+    if (doc.header && treePath[0] === 0) {
+      // Header region: [0, blockIdx, ...nested]
+      block = doc.header.blocks[treePath[1]];
+      nestedStart = 2;
+    } else if (doc.footer && treePath[0] === footerTreeIdx) {
+      // Footer region: [footerTreeIdx, blockIdx, ...nested]
+      block = doc.footer.blocks[treePath[1]];
+      nestedStart = 2;
+    } else {
+      // Body region: [treeIdx, ...nested]
+      block = doc.blocks[treePath[0] - offset];
+      nestedStart = 1;
+    }
+    // Walk deeper for nested tables: [rowIdx, colIdx, blockIdx] triplets.
+    for (let i = nestedStart; i < treePath.length; i += 3) {
       const r = treePath[i];
       const c = treePath[i + 1];
       const b = treePath[i + 2];

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -688,6 +688,12 @@ describe('YorkieDocStore', () => {
     // Regression: resolveTableTreePath was body-only, so structural ops on a
     // header/footer table threw "Table block not found" in the real editor
     // (the MemDocStore path is region-aware, which masked it in unit tests).
+    //
+    // Assertions read through a FRESH YorkieDocStore so they parse the actual
+    // Yorkie tree rather than the mutating store's patched cache — otherwise a
+    // wrong-but-non-throwing tree path would still pass via the cache splice.
+    const fromTree = () => new YorkieDocStore(doc).getDocument();
+
     it('insertTableRow into a header table does not throw and grows the table', () => {
       const tableBlock = createTableBlock(2, 2);
       store.setDocument({
@@ -697,7 +703,7 @@ describe('YorkieDocStore', () => {
       expect(() =>
         store.insertTableRow(tableBlock.id, 2, { cells: [createTableCell(), createTableCell()] }),
       ).not.toThrow();
-      const headerTable = store.getDocument().header!.blocks.find((b) => b.type === 'table')!;
+      const headerTable = fromTree().header!.blocks.find((b) => b.type === 'table')!;
       expect(headerTable.tableData!.rows.length).toBe(3);
     });
 
@@ -708,12 +714,13 @@ describe('YorkieDocStore', () => {
         header: { blocks: [tableBlock], marginFromEdge: 48 },
       });
       const id = tableBlock.id;
+      const headerTd = () => fromTree().header!.blocks[0].tableData!;
       expect(() => store.insertTableColumn(id, 1, [createTableCell(), createTableCell()])).not.toThrow();
-      expect(store.getDocument().header!.blocks[0].tableData!.rows[0].cells.length).toBe(3);
+      expect(headerTd().rows[0].cells.length).toBe(3);
       expect(() => store.deleteTableColumn(id, 0)).not.toThrow();
-      expect(store.getDocument().header!.blocks[0].tableData!.rows[0].cells.length).toBe(2);
+      expect(headerTd().rows[0].cells.length).toBe(2);
       expect(() => store.deleteTableRow(id, 0)).not.toThrow();
-      expect(store.getDocument().header!.blocks[0].tableData!.rows.length).toBe(1);
+      expect(headerTd().rows.length).toBe(1);
     });
 
     it('insertTableRow into a footer table targets the footer region', () => {
@@ -725,10 +732,11 @@ describe('YorkieDocStore', () => {
       expect(() =>
         store.insertTableRow(tableBlock.id, 2, { cells: [createTableCell(), createTableCell()] }),
       ).not.toThrow();
-      const footerTable = store.getDocument().footer!.blocks.find((b) => b.type === 'table')!;
+      const tree = fromTree();
+      const footerTable = tree.footer!.blocks.find((b) => b.type === 'table')!;
       expect(footerTable.tableData!.rows.length).toBe(3);
       // Body untouched.
-      expect(store.getDocument().blocks.length).toBe(1);
+      expect(tree.blocks.length).toBe(1);
     });
   });
 

--- a/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
+++ b/packages/frontend/tests/app/docs/yorkie-doc-store.test.ts
@@ -684,6 +684,54 @@ describe('YorkieDocStore', () => {
     });
   });
 
+  describe('region-aware table structural ops (header / footer)', () => {
+    // Regression: resolveTableTreePath was body-only, so structural ops on a
+    // header/footer table threw "Table block not found" in the real editor
+    // (the MemDocStore path is region-aware, which masked it in unit tests).
+    it('insertTableRow into a header table does not throw and grows the table', () => {
+      const tableBlock = createTableBlock(2, 2);
+      store.setDocument({
+        blocks: [makeBlock('body')],
+        header: { blocks: [tableBlock, makeBlock('after')], marginFromEdge: 48 },
+      });
+      expect(() =>
+        store.insertTableRow(tableBlock.id, 2, { cells: [createTableCell(), createTableCell()] }),
+      ).not.toThrow();
+      const headerTable = store.getDocument().header!.blocks.find((b) => b.type === 'table')!;
+      expect(headerTable.tableData!.rows.length).toBe(3);
+    });
+
+    it('deleteTableRow / insertTableColumn / deleteTableColumn work on a header table', () => {
+      const tableBlock = createTableBlock(2, 2);
+      store.setDocument({
+        blocks: [makeBlock('body')],
+        header: { blocks: [tableBlock], marginFromEdge: 48 },
+      });
+      const id = tableBlock.id;
+      expect(() => store.insertTableColumn(id, 1, [createTableCell(), createTableCell()])).not.toThrow();
+      expect(store.getDocument().header!.blocks[0].tableData!.rows[0].cells.length).toBe(3);
+      expect(() => store.deleteTableColumn(id, 0)).not.toThrow();
+      expect(store.getDocument().header!.blocks[0].tableData!.rows[0].cells.length).toBe(2);
+      expect(() => store.deleteTableRow(id, 0)).not.toThrow();
+      expect(store.getDocument().header!.blocks[0].tableData!.rows.length).toBe(1);
+    });
+
+    it('insertTableRow into a footer table targets the footer region', () => {
+      const tableBlock = createTableBlock(2, 2);
+      store.setDocument({
+        blocks: [makeBlock('body')],
+        footer: { blocks: [makeBlock('foot'), tableBlock], marginFromEdge: 48 },
+      });
+      expect(() =>
+        store.insertTableRow(tableBlock.id, 2, { cells: [createTableCell(), createTableCell()] }),
+      ).not.toThrow();
+      const footerTable = store.getDocument().footer!.blocks.find((b) => b.type === 'table')!;
+      expect(footerTable.tableData!.rows.length).toBe(3);
+      // Body untouched.
+      expect(store.getDocument().blocks.length).toBe(1);
+    });
+  });
+
   describe('updateTableCell', () => {
     it('should update one cell without affecting others', () => {
       const { tableBlock, doc } = makeTableDoc();


### PR DESCRIPTION
## Summary

Closes all six deferred items in `docs/tasks/active/20260626-docx-table-deferred-todo.md` (split from the shipped #417 header/footer-tables work).

1. **`w:tcW` cell widths (import + export).** `mapTableCellProperties` reads `<w:tcW>` (dxa); when a table has no `<w:tblGrid>`, `deriveColWidthsFromCells` derives column proportions from per-cell `tcW` (even-share fallback) as render-time `columnWidths` only — structural shape-hardening stays gated on the real grid, so gridless behavior is unchanged. Export emits per-cell `<w:tcW>` (dxa, summed over spanned columns) before `<w:gridSpan>`. *Absolute `<w:tblW>` is intentionally not honored — `TableData` has no absolute-width field.*
2. **Native nested-table docs.** Nested tables already import as native `table` blocks (`convertTable` recurses); removed the stale "flattened to text" non-goal, the §2.5 flatten algorithm, and the warning-toast risk row from `docs-docx-import-export.md`.
3. **Page-number fields in HF table cells.** `renderTableContent` takes an optional `pageNumber` and substitutes it for a `style.pageNumber` run's `#` placeholder (mirrors `renderRunWithPageNumber`), threaded from `renderHeaderFooterBlocks` and into nested-table recursion. *(Canvas only; PDF export does not yet paint HF tables.)*
4. **`lineAffinity` in HF caret resolvers.** Threaded `cursor.lineAffinity` into `computeHFCursorPixel` / `computeHFTableCellCaretPixel`; a caret at a wrap boundary now lands on the next visual line for forward affinity, matching the body resolver.
5. **Mixed table/paragraph HF selections.** `computeHFSelectionRects` now renders both the table cells (clamped to the edge nearest the outside endpoint) and the flat paragraph run, instead of collapsing to the single in-table cell.
6. **Region-aware structural row/column edits in HF tables.** Tab and insert/delete row/column now work in header/footer. `ensureBlockAfter` / `getPositionBefore|AfterTable` use `getContextBlocks()`; the `editContext === 'body'` guards are dropped; the editor API table commands resolve the cursor cell via the merged `doc.blockParentMap`; `deleteTable` re-homes within the active region.

Self code-review also surfaced and fixed an adjacent pre-existing bug: the Delete / Ctrl-Delete merge-next paths resolved the sibling from the body block array while `getBlockIndex` is context-aware, so deleting at the end of a header/footer paragraph could no-op or throw "Cannot merge blocks from different regions". Both now use `getContextBlocks()`.

## Test plan

- `pnpm --filter @wafflebase/docs typecheck` — clean.
- `pnpm --filter @wafflebase/docs test` — 62 files, 974 tests passing (1 skipped).
- `pnpm verify:self` — green (ran via pre-push, incl. all builds).
- New / extended tests:
  - `test/import/docx-importer.test.ts` — tcW-derived columns without a `tblGrid`; even-share fallback; gridless gridBefore/gridAfter behavior unchanged.
  - `test/export/docx-exporter.test.ts` — per-cell `<w:tcW>` dxa output.
  - `test/view/table-renderer.test.ts` — page-number substitution in cells.
  - `test/view/hf-caret-selection.test.ts` (new) — forward/backward affinity at a wrap boundary; mixed table/paragraph selection; pure-paragraph regression.
  - `test/view/header-table-nav.test.ts` — header-table insert/delete row/column, `isInTable`/`getCellAddress`, Tab-appends-row, ArrowRight exit, HF paragraph merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved DOCX table handling, including better support for tables in headers, footers, and nested structures.
  * Page numbers now render correctly inside table content in header/footer areas.
  * DOCX export now preserves table cell widths more accurately.

* **Bug Fixes**
  * Fixed table editing and navigation issues when working outside the main document body.
  * Improved selection and caret behavior around wrapped lines and table cells.
  * DOCX import now handles tables without grid metadata more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->