### PR TITLE
Slides: canvas layout-editing mode (theme builder PR3 commit 5)

### DIFF
--- a/docs/design/slides/slides-themes-layouts-import.md
+++ b/docs/design/slides/slides-themes-layouts-import.md
@@ -545,6 +545,70 @@ Per-layout placeholder geometry editing (canvas drag) remains a
 follow-up; its store methods (`updateLayout` /
 `updateLayoutPlaceholderFrame`) already ship.
 
+#### Commit 5 — canvas layout-editing mode (designed 2026-06-27)
+
+The remaining builder surface: drag a layout's placeholders on the canvas
+to edit their geometry, committing through the already-shipped
+`updateLayoutPlaceholderFrame` (+ its `cascadeLayoutFrame` re-flow). Decided
+2026-06-27: **layouts only** on canvas (master background/colors/fonts stay
+in the Customize panel — a master has no positioned placeholders to drag),
+entered via a **Customize-tab button**.
+
+**Approach — synthetic-slide reuse.** Rather than build a second canvas
+editor, feed the existing `SlidesEditor` a transient `Slide` built from a
+layout and route its geometry commits to the layout. The editor already
+funnels every slide read through one method (`currentSlide()` →
+`store.read().slides`) and reads `this.options.store` *dynamically* at
+commit time, so a store-level proxy is a clean "virtual-slide gate":
+
+1. **`buildLayoutSlide(layout, master, theme): Slide`** (pure, slides
+   package) — materializes a transient slide (synthetic id
+   `__layout__<layoutId>`) from the layout's `placeholders`, each element
+   carrying its `placeholderRef`. Reuses `applyLayoutToSlide` on an empty
+   slide so geometry/typography match real slides. Never persisted.
+
+2. **`LayoutEditStore`** (a `SlidesStore` proxy) — wraps the real store +
+   the current `layoutId`.
+   - `read()` → `{ ...realDoc, slides: [buildLayoutSlide(...)] }`, keeping
+     the real `themes`/`masters`/`layouts` so the renderer resolves
+     correctly.
+   - `updateElementFrame(_, elementId, frame)` → map element →
+     `placeholderRef` → `real.updateLayoutPlaceholderFrame(layoutId, ref,
+     frame)`. The shipped cascade re-flows live slides.
+   - `batch` / `onChange` delegate to the real store → one undo unit, and
+     edits repaint live slides immediately.
+   - Structural mutations (`addElement`, `removeElement*`,
+     `withTextElement`, table/connector/guide ops) → guarded no-ops, so no
+     layout edit can leak into slide content.
+
+3. **Editor `layoutEditMode` flag** — the UX gate the proxy can't cover.
+   When set: allow select / move / resize / rotate of placeholders;
+   suppress text-edit entry (double-click), delete, insert, duplicate, and
+   structural context-menu items. `enterLayoutEditMode(store, layoutId)` /
+   `exitLayoutEditMode()` swap `options.store` (new `setStore`) and toggle
+   the flag, reusing `setCurrentSlide`'s reset (exits crop, clears
+   selection, repaints).
+
+4. **`mountLayoutListPanel`** (vanilla, slides package) — in layout-edit
+   mode the left rail renders the layouts as a selectable list instead of
+   slide thumbnails (the existing `mountThumbnailPanel` is slide-specific —
+   reorder / new / duplicate / delete — so a separate small panel is
+   cleaner than overloading it). Click a layout → re-point the proxy's
+   `layoutId` + `editor.setCurrentSlide('__layout__…')`.
+
+5. **Frontend wiring** (`DesktopSlidesLayout` + `slides-view.tsx` +
+   `theme-panel.tsx`) — a `layoutEditTarget: layoutId | null` state
+   (parallel to `presentingFrom`); an **"Edit layout positions"** button in
+   the Customize tab enters the mode; `slides-view` swaps the left rail to
+   `mountLayoutListPanel` and calls `editor.enterLayoutEditMode` while
+   active; an exit affordance restores normal editing + the previous slide.
+
+Component boundaries are independently testable: `buildLayoutSlide` and
+`LayoutEditStore` get vitest coverage (layout → slide elements with refs;
+drag → `updateLayoutPlaceholderFrame`; structural ops no-op; single batch);
+the editor flag, layout list panel, and frontend wiring are covered by the
+browser lane (enter mode, drag a placeholder).
+
 #### Customization + theme-switching UX (model A — in-place edit, re-pick resets)
 
 Decided 2026-06-26. The theme builder edits the deck's active theme **in

--- a/docs/tasks/active/20260507-slides-themes-layouts-import-lessons.md
+++ b/docs/tasks/active/20260507-slides-themes-layouts-import-lessons.md
@@ -175,4 +175,14 @@ canvas. Lessons from reusing the slide editor for a non-slide target:
   behavior only had browser-lane coverage. Use this harness for editor
   changes (gate + store-swap got 4 real gesture tests).
 
+- **Smoke test caught an id-keyed cache going stale under in-place edits.**
+  `renderLayoutPreview` cached by `theme.id:master.id:layout.id` — fine when
+  those were immutable, but the theme builder edits them in place, so the
+  rail preview served the pre-edit bitmap (data saved, preview stale). The
+  canvas updated because the editor has its own rAF render loop; the rail
+  has none and relied on the cache. Fix: key the cache on rendered *content*
+  (colors/fonts/background/geometry) + cap it. Lesson: when a feature makes
+  a previously-immutable object editable, audit every id-keyed cache /
+  memo of that object — they silently go stale.
+
 ## Brainstorming

--- a/docs/tasks/active/20260507-slides-themes-layouts-import-lessons.md
+++ b/docs/tasks/active/20260507-slides-themes-layouts-import-lessons.md
@@ -128,4 +128,51 @@ shipped code:
   recovered it. Commit (or at least don't stash) before reaching for
   comparison tricks on a dirty tree.
 
+## PR3 commit 5 (canvas layout-editing mode) — 2026-06-27
+
+Shipped the remaining builder piece: drag a layout's placeholders on the
+canvas. Lessons from reusing the slide editor for a non-slide target:
+
+- **A store proxy is the cleanest "virtual-slide gate."** The editor
+  funnels every slide read through one method (`currentSlide()` →
+  `store.read().slides`) and reads `this.options.store` *dynamically* at
+  every commit site. So a `SlidesStore` proxy that serves one synthetic
+  slide from `read()` and reroutes `updateElementFrame` →
+  `updateLayoutPlaceholderFrame` reuses the entire drag/resize/snap/overlay
+  stack with zero edits to the 5000-line editor. Structural mutations
+  become guarded no-ops on the proxy, so layout edits can't leak into
+  slide content — data safety lives in the proxy, not in UI gating.
+- **But `buildKeyRules` captures the store ref.** It's the one place the
+  editor doesn't read `this.options.store` lazily — keyboard nudge/delete
+  close over the store passed at construction. A store swap MUST rebuild
+  the key rules (extracted `installKeyRules`), or arrow-nudge keeps writing
+  to the pre-swap store. `handleKeyDown` reads `this.keyRules` dynamically,
+  so reassigning the field is enough.
+- **Synthetic element ids must be deterministic.** `applyLayoutToSlide`
+  stamps `generateId()` ids; the editor holds an element id between reading
+  the slide and committing a drag, so a fresh id per `read()` breaks the
+  ref mapping. `buildLayoutSlide` overwrites ids with
+  `placeholderElementId(ref)` so the synthetic slide is reproducible.
+- **One UX gate covers all text-edit paths.** Every entry route (1-click,
+  dblclick, P1.5 slow-double-click, Enter, type-to-edit) funnels through
+  `private enterEditMode` — a single early-return on the mode flag gates
+  them all.
+- **Toolbar was already safe by construction.** In layout-edit mode the
+  current slide id is synthetic and absent from the *real* store the
+  toolbar reads; `getToolbarState` returns `idle` when the slide isn't
+  found, and each control guards on `!slide`. No extra gating needed — the
+  toolbar is inert without a single change. Worth checking shared surfaces
+  for this kind of free safety before adding new gates.
+- **Toggle host visibility, don't dispose the live panel.** The mount
+  effect's `store.onChange` / rAF handlers call `thumbHandle.refreshContent`
+  directly. Hiding the thumbnail host and mounting the layout list into a
+  sibling host (instead of disposing the thumbnail panel) kept those
+  handlers correct and untouched — disposing would have forced
+  null-guards through the whole effect.
+- **Editor IS unit-testable in jsdom.** `test/view/editor/*.test.ts` use
+  `src/view/canvas/test-canvas-env` + `initialize(...)` and simulate
+  pointer gestures — contrary to the earlier assumption that editor
+  behavior only had browser-lane coverage. Use this harness for editor
+  changes (gate + store-swap got 4 real gesture tests).
+
 ## Brainstorming

--- a/docs/tasks/active/20260507-slides-themes-layouts-import-todo.md
+++ b/docs/tasks/active/20260507-slides-themes-layouts-import-todo.md
@@ -74,25 +74,29 @@ Decisions: synthetic-slide reuse (store proxy + editor flag), layouts only on
 canvas, entered via Customize-tab button. Design: see the design doc
 "Commit 5 — canvas layout-editing mode" subsection.
 
-- [ ] commit 5a — `feat(slides): buildLayoutSlide + LayoutEditStore proxy`
-      — pure synthetic slide from a layout; `SlidesStore` proxy routing
-      `updateElementFrame` → `updateLayoutPlaceholderFrame`, structural ops
-      guarded no-ops, `batch`/`onChange` delegate. Vitest.
-- [ ] commit 5b — `feat(slides): editor layoutEditMode + setStore + enter/exit`
-      — mode flag suppresses text-edit/delete/insert/structural ops; allows
-      move/resize/rotate; store swap reusing setCurrentSlide reset.
-- [ ] commit 5c — `feat(slides): mountLayoutListPanel`
-      — left-rail layouts list variant; click selects layout to edit.
-- [ ] commit 5d — `feat(frontend): layout-edit mode wiring + Customize entry`
-      — `layoutEditTarget` state, slides-view rail swap + enter/exit, Customize
-      tab "Edit layout positions" button.
-- [ ] verify: layout placeholder position edit re-flows only slides on that layout; user-moved/added elements untouched (covered by `mem-theme-builder.test.ts` cascade block; re-confirm via `buildLayoutSlide` round-trip)
-- [ ] verify: each edit + cascade is a single undo unit (LayoutEditStore `batch` delegation test)
-- [ ] verify: structural ops (delete/insert/text-edit) are inert in layout-edit mode
-- [ ] verify: `pnpm verify:fast` per commit
-- [ ] verify: `pnpm verify:browser:docker` covers layout-edit entry + a placeholder drag
-- [ ] verify (optional/stretch): two-user Yorkie concurrent master/layout + slide edit convergence — no dedicated test today; add if cheap, else note as known gap
-- [ ] docs: fold as-built notes into design doc; capture lessons
+- [x] commit 5a — `feat(slides): buildLayoutSlide + LayoutEditStore proxy`
+      — pure synthetic slide from a layout (deterministic ref-derived ids);
+      `SlidesStore` proxy routing `updateElementFrame` →
+      `updateLayoutPlaceholderFrame`, structural ops guarded no-ops,
+      `batch`/`onChange` delegate. 15 vitest cases; all 2440 slides tests green.
+- [x] commit 5b — `feat(slides): editor layoutEditMode + setStore + enter/exit`
+      — store swap rebuilds key rules; `layoutEditMode` flag gates text-edit
+      entry at the single `enterEditMode` chokepoint; drag/nudge route to the
+      layout via the proxy. 4 vitest cases (jsdom editor harness); 2444 green.
+- [x] commit 5c — `feat(slides): mountLayoutListPanel`
+      — vanilla layouts-list rail (preview + name), onSelect + setSelectedLayoutId
+      / refresh / dispose; store-subscribed previews. 4 vitest cases.
+- [x] commit 5d — `feat(frontend): layout-edit mode wiring + Customize entry`
+      — `layoutEditTarget` state, SlidesView rail swap (sibling host, thumbnails
+      hidden not disposed) + enter/exit via editor, Customize "Edit layout
+      positions" button + "Done" banner. Build + lint + 722 frontend tests green.
+- [x] verify: layout placeholder position edit re-flows only slides on that layout; user-moved/added elements untouched (`mem-theme-builder.test.ts` cascade block; `buildLayoutSlide` ref round-trip)
+- [x] verify: each edit + cascade is a single undo unit (LayoutEditStore `batch` delegation test + 5b drag-undo test)
+- [x] verify: structural ops (delete/insert/text-edit) are inert in layout-edit mode (proxy no-op tests + editor text-edit gate test; toolbar idle via `getToolbarState`)
+- [x] verify: `pnpm verify:fast` per commit
+- [ ] verify: manual smoke — enter layout-edit, drag a placeholder, confirm cascade + Done exit (UI changed; do before merge per CLAUDE.md). `verify:browser:docker` visual harness covers static comps, not interactive drag.
+- [ ] verify (optional/stretch): two-user Yorkie concurrent master/layout + slide edit convergence — no dedicated test today; known gap (theme-builder mutations are plain-JSON LWW, accepted in design Risks).
+- [x] docs: fold as-built notes into design doc; capture lessons
 - [ ] PR opened, reviewed, merged
 
 #### Already verified in commits 1–4 (PR3)

--- a/docs/tasks/active/20260507-slides-themes-layouts-import-todo.md
+++ b/docs/tasks/active/20260507-slides-themes-layouts-import-todo.md
@@ -68,18 +68,39 @@ Plan re-split into 5 commits for reviewability.
 - [x] commit 4 — `feat(frontend): theme builder panel (colors / fonts / background)`
       — entered via the Theme panel's "Customize" tab (no separate toolbar
       button); edits apply live to all slides
-- [ ] commit 5 — canvas layout-editing mode: thumbnail panel → layouts/master
-      list + drag placeholders, on top of the shipped updateLayout /
-      updateLayoutPlaceholderFrame store methods (separate follow-up; the
-      panel covers the colors/fonts/background v1 surface today)
-- [ ] verify: theme/master color edit repaints all slides <100 ms (role-resolved)
-- [ ] verify: master/layout background edit cascades to inheriting slides on repaint
-- [ ] verify: layout placeholder position edit re-flows only slides on that layout; user-moved/added elements untouched
-- [ ] verify: master placeholder font-size edit picks up on unmodified placeholders only
-- [ ] verify: each edit + cascade is a single undo unit
-- [ ] verify: two-user Yorkie concurrent master + slide edit convergence
-- [ ] verify: `pnpm verify:browser:docker` covers theme builder entry
+### Commit 5 — canvas layout-editing mode (planned 2026-06-27)
+
+Decisions: synthetic-slide reuse (store proxy + editor flag), layouts only on
+canvas, entered via Customize-tab button. Design: see the design doc
+"Commit 5 — canvas layout-editing mode" subsection.
+
+- [ ] commit 5a — `feat(slides): buildLayoutSlide + LayoutEditStore proxy`
+      — pure synthetic slide from a layout; `SlidesStore` proxy routing
+      `updateElementFrame` → `updateLayoutPlaceholderFrame`, structural ops
+      guarded no-ops, `batch`/`onChange` delegate. Vitest.
+- [ ] commit 5b — `feat(slides): editor layoutEditMode + setStore + enter/exit`
+      — mode flag suppresses text-edit/delete/insert/structural ops; allows
+      move/resize/rotate; store swap reusing setCurrentSlide reset.
+- [ ] commit 5c — `feat(slides): mountLayoutListPanel`
+      — left-rail layouts list variant; click selects layout to edit.
+- [ ] commit 5d — `feat(frontend): layout-edit mode wiring + Customize entry`
+      — `layoutEditTarget` state, slides-view rail swap + enter/exit, Customize
+      tab "Edit layout positions" button.
+- [ ] verify: layout placeholder position edit re-flows only slides on that layout; user-moved/added elements untouched (covered by `mem-theme-builder.test.ts` cascade block; re-confirm via `buildLayoutSlide` round-trip)
+- [ ] verify: each edit + cascade is a single undo unit (LayoutEditStore `batch` delegation test)
+- [ ] verify: structural ops (delete/insert/text-edit) are inert in layout-edit mode
+- [ ] verify: `pnpm verify:fast` per commit
+- [ ] verify: `pnpm verify:browser:docker` covers layout-edit entry + a placeholder drag
+- [ ] verify (optional/stretch): two-user Yorkie concurrent master/layout + slide edit convergence — no dedicated test today; add if cheap, else note as known gap
+- [ ] docs: fold as-built notes into design doc; capture lessons
 - [ ] PR opened, reviewed, merged
+
+#### Already verified in commits 1–4 (PR3)
+
+- [x] theme/master color edit repaints all slides <100 ms (role-resolved at render)
+- [x] master/layout background edit cascades to inheriting slides on repaint (`mem-theme-builder.test.ts` updateMaster + resolveBackgroundFill)
+- [x] master placeholder font-size edit picks up on unmodified placeholders only (`mem-theme-builder.test.ts` master-style cascade block)
+- [x] layout geometry cascade — re-flow matching / user-moved untouched / only edited layout (`mem-theme-builder.test.ts` cascade block)
 
 ## Cross-cutting
 

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -211,13 +211,17 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
   // layout they were just looking at.
   const handleEditLayouts = useCallback(() => {
     if (!store) return;
+    // Already editing a layout — don't recompute the target from the
+    // synthetic current slide (which would jump to the first slide's
+    // layout). The rail drives switching while a session is live.
+    if (layoutEditTarget) return;
     const doc = store.read();
     const currentId = editor?.getCurrentSlideId();
     const current = doc.slides.find((s) => s.id === currentId);
     setLayoutEditTarget(
       current?.layoutId ?? doc.slides[0]?.layoutId ?? "title-body",
     );
-  }, [store, editor]);
+  }, [store, editor, layoutEditTarget]);
 
   // Resolve the active Theme object — fed to the contextual color and
   // font pickers in the toolbar so their "Theme" rows match the deck.
@@ -406,6 +410,7 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
               zoomController={zoomControllerRef.current}
               uploadImage={uploadFn}
               layoutEditTarget={layoutEditTarget}
+              onLayoutEditTargetChange={setLayoutEditTarget}
             />
             {rightPanel === "theme" && store && (
               <ThemePanel

--- a/packages/frontend/src/app/slides/slides-detail.tsx
+++ b/packages/frontend/src/app/slides/slides-detail.tsx
@@ -169,6 +169,10 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
   const [presentingFrom, setPresentingFrom] = useState<
     "current" | "first" | null
   >(null);
+  // Canvas layout-editing mode (PR3 theme builder): the layout id being
+  // edited, or null while editing slides normally. Entered from the Theme
+  // panel's Customize tab; SlidesView swaps the rail + canvas accordingly.
+  const [layoutEditTarget, setLayoutEditTarget] = useState<string | null>(null);
   // Mirror the deck size so the Present button can disable itself when
   // the deck momentarily holds zero slides (before the editor seeds its
   // initial slide). Re-evaluated on every store change.
@@ -201,6 +205,19 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
     },
     [store],
   );
+
+  // Enter layout-edit mode on the current slide's layout (falling back to
+  // the first slide's, then 'title-body'), so the user starts editing the
+  // layout they were just looking at.
+  const handleEditLayouts = useCallback(() => {
+    if (!store) return;
+    const doc = store.read();
+    const currentId = editor?.getCurrentSlideId();
+    const current = doc.slides.find((s) => s.id === currentId);
+    setLayoutEditTarget(
+      current?.layoutId ?? doc.slides[0]?.layoutId ?? "title-body",
+    );
+  }, [store, editor]);
 
   // Resolve the active Theme object — fed to the contextual color and
   // font pickers in the toolbar so their "Theme" rows match the deck.
@@ -365,6 +382,21 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
             motionPanelOpen={rightPanel === "motion"}
             zoomController={zoomControllerRef.current}
           />
+          {layoutEditTarget && (
+            <div className="flex items-center justify-between gap-2 border-b bg-muted/50 px-4 py-1.5 text-xs">
+              <span className="text-muted-foreground">
+                Editing layout placeholders — drag to reposition. Changes
+                apply to slides using that layout.
+              </span>
+              <button
+                type="button"
+                onClick={() => setLayoutEditTarget(null)}
+                className="shrink-0 rounded border bg-background px-2 py-1 font-medium hover:bg-muted"
+              >
+                Done
+              </button>
+            </div>
+          )}
           <div className="flex flex-1 min-h-0 overflow-hidden">
             <SlidesView
               onEditorReady={setEditor}
@@ -373,12 +405,14 @@ function DesktopSlidesLayout({ documentId }: { documentId: string }) {
               documentId={documentId}
               zoomController={zoomControllerRef.current}
               uploadImage={uploadFn}
+              layoutEditTarget={layoutEditTarget}
             />
             {rightPanel === "theme" && store && (
               <ThemePanel
                 store={store}
                 currentThemeId={currentThemeId}
                 onClose={() => setRightPanel(null)}
+                onEditLayouts={handleEditLayouts}
               />
             )}
             {rightPanel === "format" && store && editor && (

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -1,12 +1,16 @@
 import {
   initializeEditor,
   mountThumbnailPanel,
+  mountLayoutListPanel,
   mountNotesPanel,
+  LayoutEditStore,
+  layoutEditSlideId,
   SLIDES_RULER_SIZE,
   SLIDE_WIDTH,
   SLIDE_HEIGHT,
   type SlidesEditor,
   type ThumbnailPanelHandle,
+  type LayoutListPanelHandle,
   type NotesPanelHandle,
 } from "@wafflebase/slides";
 import { useEffect, useRef, useState } from "react";
@@ -74,6 +78,13 @@ interface SlidesViewProps {
    * (e.g. a read-only share-link mount) those paths stay off.
    */
   uploadImage?: (file: File) => Promise<{ url: string; w: number; h: number }>;
+  /**
+   * Canvas layout-editing mode (PR3 theme builder). When set to a layout
+   * id, the left rail switches from slide thumbnails to a layouts list and
+   * the canvas edits that layout's placeholders via a `LayoutEditStore`.
+   * `null` (the default) is normal slide editing.
+   */
+  layoutEditTarget?: string | null;
 }
 
 // Logical slide aspect (1920×1080 = 16:9). The canvas is sized to fit
@@ -143,9 +154,19 @@ export function SlidesView({
   onStartPresentation,
   zoomController,
   uploadImage,
+  layoutEditTarget = null,
 }: SlidesViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<SlidesEditor | null>(null);
+  // Refs shared with the layout-edit effect below (populated by the mount
+  // effect). The real store, the two left-rail hosts, and the live
+  // layout-edit session (proxy store + list panel + restore slide id).
+  const storeRef = useRef<YorkieSlidesStore | null>(null);
+  const thumbsHostRef = useRef<HTMLDivElement | null>(null);
+  const layoutListHostRef = useRef<HTMLDivElement | null>(null);
+  const layoutEditStoreRef = useRef<LayoutEditStore | null>(null);
+  const layoutListHandleRef = useRef<LayoutListPanelHandle | null>(null);
+  const prevSlideIdRef = useRef<string | null>(null);
   const [didMount, setDidMount] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const { doc, loading, error } = useDocument<YorkieSlidesRoot, SlidesPresence>();
@@ -284,6 +305,15 @@ export function SlidesView({
     left.style.paddingRight = "12px";
     const thumbsHost = document.createElement("div");
     left.appendChild(thumbsHost);
+    // Sibling host for the layout-edit rail. Hidden until layout-edit
+    // mode mounts the layouts list into it; toggling visibility (rather
+    // than disposing the thumbnail panel) keeps the store.onChange / rAF
+    // handlers below untouched.
+    const layoutListHost = document.createElement("div");
+    layoutListHost.style.display = "none";
+    left.appendChild(layoutListHost);
+    thumbsHostRef.current = thumbsHost;
+    layoutListHostRef.current = layoutListHost;
     layout.appendChild(left);
 
     // Drag handle between thumbnail panel and canvas. Visually a thin
@@ -581,6 +611,7 @@ export function SlidesView({
     document.head.appendChild(style);
 
     const store = new YorkieSlidesStore(doc);
+    storeRef.current = store;
     // Brand-new presentations land here with `slides: []`. The editor's
     // `render()` bails out when no current slide exists, so without this
     // seed the canvas would stay blank until the user clicked the
@@ -1044,6 +1075,14 @@ export function SlidesView({
       offPeers();
       thumbHandle?.dispose();
       notesHandle?.dispose();
+      // Tear down any active layout-edit session so its store.onChange
+      // subscription doesn't outlive the store.
+      layoutListHandleRef.current?.dispose();
+      layoutListHandleRef.current = null;
+      layoutEditStoreRef.current = null;
+      thumbsHostRef.current = null;
+      layoutListHostRef.current = null;
+      storeRef.current = null;
       editor.detach();
       store.dispose();
       editorRef.current = null;
@@ -1058,6 +1097,54 @@ export function SlidesView({
     // it at runtime is not a supported scenario.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [didMount, doc]);
+
+  // Drive canvas layout-editing mode off the `layoutEditTarget` prop. The
+  // mount effect above owns the editor / store / rail hosts; this effect
+  // reacts to enter / switch / exit transitions using the shared refs.
+  useEffect(() => {
+    const editor = editorRef.current;
+    const store = storeRef.current;
+    const thumbsHost = thumbsHostRef.current;
+    const listHost = layoutListHostRef.current;
+    if (!editor || !store || !thumbsHost || !listHost) return;
+
+    if (layoutEditTarget) {
+      if (!layoutEditStoreRef.current) {
+        // ENTER: swap the editor onto a LayoutEditStore, hide the slide
+        // thumbnails, and mount the layouts list.
+        prevSlideIdRef.current = editor.getCurrentSlideId() ?? null;
+        const les = new LayoutEditStore(store, layoutEditTarget);
+        layoutEditStoreRef.current = les;
+        editor.enterLayoutEditMode(les);
+        thumbsHost.style.display = "none";
+        listHost.style.display = "";
+        layoutListHandleRef.current = mountLayoutListPanel(listHost, store, {
+          selectedLayoutId: layoutEditTarget,
+          onSelect: (id) => {
+            les.setLayoutId(id);
+            editor.setCurrentSlide(layoutEditSlideId(id));
+            layoutListHandleRef.current?.setSelectedLayoutId(id);
+          },
+        });
+      } else if (layoutEditStoreRef.current.getLayoutId() !== layoutEditTarget) {
+        // SWITCH: parent re-pointed the target while the session is live.
+        layoutEditStoreRef.current.setLayoutId(layoutEditTarget);
+        editor.setCurrentSlide(layoutEditSlideId(layoutEditTarget));
+        layoutListHandleRef.current?.setSelectedLayoutId(layoutEditTarget);
+      }
+    } else if (layoutEditStoreRef.current) {
+      // EXIT: dispose the list, restore the thumbnails, and put the
+      // editor back on the real store + the slide the user was on.
+      layoutListHandleRef.current?.dispose();
+      layoutListHandleRef.current = null;
+      listHost.style.display = "none";
+      thumbsHost.style.display = "";
+      const restoreId =
+        prevSlideIdRef.current ?? store.read().slides[0]?.id ?? "";
+      editor.exitLayoutEditMode(store, restoreId);
+      layoutEditStoreRef.current = null;
+    }
+  }, [layoutEditTarget, didMount]);
 
   if (loading) {
     return (

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -85,6 +85,13 @@ interface SlidesViewProps {
    * `null` (the default) is normal slide editing.
    */
   layoutEditTarget?: string | null;
+  /**
+   * Report the layout the view wants edited: a layout id when the user
+   * picks a different row in the layouts rail, or `null` when the editor
+   * is torn down (doc reload / unmount) while a session is active, so the
+   * parent's `layoutEditTarget` stays the single source of truth.
+   */
+  onLayoutEditTargetChange?: (layoutId: string | null) => void;
 }
 
 // Logical slide aspect (1920×1080 = 16:9). The canvas is sized to fit
@@ -155,6 +162,7 @@ export function SlidesView({
   zoomController,
   uploadImage,
   layoutEditTarget = null,
+  onLayoutEditTargetChange,
 }: SlidesViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<SlidesEditor | null>(null);
@@ -167,6 +175,10 @@ export function SlidesView({
   const layoutEditStoreRef = useRef<LayoutEditStore | null>(null);
   const layoutListHandleRef = useRef<LayoutListPanelHandle | null>(null);
   const prevSlideIdRef = useRef<string | null>(null);
+  // Freshest callback for the mount-effect cleanup (which is keyed on
+  // [didMount, doc], so it can't list this prop as a dep).
+  const onLayoutEditTargetChangeRef = useRef(onLayoutEditTargetChange);
+  onLayoutEditTargetChangeRef.current = onLayoutEditTargetChange;
   const [didMount, setDidMount] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const { doc, loading, error } = useDocument<YorkieSlidesRoot, SlidesPresence>();
@@ -1076,10 +1088,15 @@ export function SlidesView({
       thumbHandle?.dispose();
       notesHandle?.dispose();
       // Tear down any active layout-edit session so its store.onChange
-      // subscription doesn't outlive the store.
+      // subscription doesn't outlive the store. If a session was live (the
+      // editor is being rebuilt under us, e.g. doc reload), tell the parent
+      // to leave layout-edit mode — otherwise the new editor comes up on
+      // the real store while the banner/rail still claim layout editing.
+      const hadLayoutSession = layoutEditStoreRef.current !== null;
       layoutListHandleRef.current?.dispose();
       layoutListHandleRef.current = null;
       layoutEditStoreRef.current = null;
+      if (hadLayoutSession) onLayoutEditTargetChangeRef.current?.(null);
       thumbsHostRef.current = null;
       layoutListHostRef.current = null;
       storeRef.current = null;
@@ -1120,11 +1137,10 @@ export function SlidesView({
         listHost.style.display = "";
         layoutListHandleRef.current = mountLayoutListPanel(listHost, store, {
           selectedLayoutId: layoutEditTarget,
-          onSelect: (id) => {
-            les.setLayoutId(id);
-            editor.setCurrentSlide(layoutEditSlideId(id));
-            layoutListHandleRef.current?.setSelectedLayoutId(id);
-          },
+          // Route the pick through the parent so `layoutEditTarget` stays
+          // the single source of truth; this effect's SWITCH branch below
+          // then re-points the proxy + editor + marker.
+          onSelect: (id) => onLayoutEditTargetChange?.(id),
         });
       } else if (layoutEditStoreRef.current.getLayoutId() !== layoutEditTarget) {
         // SWITCH: parent re-pointed the target while the session is live.
@@ -1144,7 +1160,7 @@ export function SlidesView({
       editor.exitLayoutEditMode(store, restoreId);
       layoutEditStoreRef.current = null;
     }
-  }, [layoutEditTarget, didMount]);
+  }, [layoutEditTarget, didMount, onLayoutEditTargetChange]);
 
   if (loading) {
     return (

--- a/packages/frontend/src/app/slides/theme-builder-panel.tsx
+++ b/packages/frontend/src/app/slides/theme-builder-panel.tsx
@@ -10,9 +10,8 @@
  * undo step (wrapped in store.batch).
  *
  * v1 surface: theme color roles, theme heading/body fonts, master
- * background fill. Per-layout placeholder geometry editing (canvas drag)
- * is the remaining builder piece; the store methods for it already exist
- * (updateLayout / updateLayoutPlaceholderFrame).
+ * background fill, and an entry point into canvas layout-editing mode
+ * (drag a layout's placeholders), driven by `onEditLayouts`.
  */
 
 import { useEffect, useState } from "react";
@@ -32,6 +31,12 @@ interface ThemeBuilderPanelProps {
   store: SlidesStore;
   /** Active theme id, kept in sync by the parent via store.onChange. */
   currentThemeId: string;
+  /**
+   * Enter canvas layout-editing mode (drag layout placeholders). When
+   * omitted the Layouts section is hidden — e.g. the mobile sheet, which
+   * has no canvas drag surface.
+   */
+  onEditLayouts?: () => void;
 }
 
 /** The 12 theme color roles, in editing order, with human labels. */
@@ -69,6 +74,7 @@ function toColorInputValue(hex: string): string {
 export function ThemeBuilderPanel({
   store,
   currentThemeId,
+  onEditLayouts,
 }: ThemeBuilderPanelProps) {
   // Re-render on any store change (local commit or remote peer edit) so
   // the controls reflect the current theme/master. The store reads below
@@ -206,6 +212,25 @@ export function ThemeBuilderPanel({
           Applies to slides that haven&apos;t set their own background.
         </p>
       </section>
+
+      {onEditLayouts && (
+        <section className="flex flex-col gap-2">
+          <h3 className="text-xs font-semibold text-muted-foreground">
+            Layouts
+          </h3>
+          <button
+            type="button"
+            onClick={onEditLayouts}
+            className="rounded border px-2 py-1.5 text-xs font-medium hover:bg-muted"
+          >
+            Edit layout positions
+          </button>
+          <p className="text-[11px] text-muted-foreground">
+            Drag a layout&apos;s placeholders on the canvas. Changes flow to
+            slides using that layout.
+          </p>
+        </section>
+      )}
     </div>
   );
 }

--- a/packages/frontend/src/app/slides/theme-panel.tsx
+++ b/packages/frontend/src/app/slides/theme-panel.tsx
@@ -14,6 +14,11 @@ interface ThemePanelProps {
    * own header — so a mobile bottom `Sheet` owns the chrome.
    */
   variant?: "drawer" | "sheet";
+  /**
+   * Enter canvas layout-editing mode from the Customize tab. Omitted on
+   * surfaces without a canvas drag target (mobile sheet).
+   */
+  onEditLayouts?: () => void;
 }
 
 type View = "themes" | "customize";
@@ -34,6 +39,7 @@ export function ThemePanel({
   currentThemeId,
   onClose,
   variant = "drawer",
+  onEditLayouts,
 }: ThemePanelProps) {
   const [view, setView] = useState<View>("themes");
 
@@ -117,7 +123,11 @@ export function ThemePanel({
         </section>
       </div>
     ) : (
-      <ThemeBuilderPanel store={store} currentThemeId={currentThemeId} />
+      <ThemeBuilderPanel
+        store={store}
+        currentThemeId={currentThemeId}
+        onEditLayouts={onEditLayouts}
+      />
     );
 
   if (variant === "sheet") {

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -138,7 +138,15 @@ export {
 export type { Point } from './model/frame';
 export { boundingBox, combinedBoundingBox, containsPoint, framesApproxEqual, toLocal } from './model/frame';
 
-export { BUILT_IN_LAYOUTS, applyLayoutToSlide, getLayout, slotRefsForLayout } from './model/layout';
+export {
+  BUILT_IN_LAYOUTS,
+  applyLayoutToSlide,
+  buildLayoutSlide,
+  getLayout,
+  layoutEditSlideId,
+  placeholderElementId,
+  slotRefsForLayout,
+} from './model/layout';
 
 export { migrateDocument } from './model/migrate';
 
@@ -161,6 +169,7 @@ export type {
   LayoutPatch,
 } from './store/store';
 export { MemSlidesStore } from './store/memory';
+export { LayoutEditStore } from './store/layout-edit-store';
 
 // View — Canvas renderers (Phase 2)
 export { GHOST_ALPHA, SlideRenderer, type SlideRendererOptions } from './view/canvas/slide-renderer';

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -211,6 +211,7 @@ export type { AlignDirection, DistributeAxis, AlignReference } from './view/edit
 
 // View — Editor (Phase 3b additions)
 export { mountThumbnailPanel, type ThumbnailPanelHandle, type MountThumbnailPanelOptions } from './view/editor/thumbnail-panel';
+export { mountLayoutListPanel, type LayoutListPanelHandle, type MountLayoutListPanelOptions } from './view/editor/layout-list-panel';
 export { mountNotesPanel, type MountNotesPanelOptions, type NotesPanelHandle } from './view/editor/notes-panel';
 export { showLayoutPicker, type LayoutPickerOptions } from './view/editor/layout-picker';
 export { showContextMenu, dismiss as dismissContextMenu, type ContextMenuItem } from './view/editor/context-menu';

--- a/packages/slides/src/index.ts
+++ b/packages/slides/src/index.ts
@@ -144,6 +144,7 @@ export {
   buildLayoutSlide,
   getLayout,
   layoutEditSlideId,
+  parsePlaceholderElementId,
   placeholderElementId,
   slotRefsForLayout,
 } from './model/layout';

--- a/packages/slides/src/model/layout.ts
+++ b/packages/slides/src/model/layout.ts
@@ -198,6 +198,60 @@ export function getLayout(layoutId: string): Layout {
 }
 
 /**
+ * Stable synthetic slide id for layout-edit mode (PR3 commit 5). Derived
+ * from the layout id so the same layout always maps to the same id —
+ * `setCurrentSlide` short-circuits on an unchanged id, so a fixed id lets
+ * the editor track which layout is being edited.
+ */
+export function layoutEditSlideId(layoutId: string): string {
+  return `__layout__${layoutId}`;
+}
+
+/**
+ * Deterministic element id for a layout placeholder, derived from its
+ * `(type, index)` slot (PR3 commit 5). `buildLayoutSlide` stamps these so
+ * the synthetic slide's element ids are stable across rebuilds — the
+ * editor holds an element id between reading the slide and committing a
+ * drag, so a fresh `generateId()` per build would break the ref mapping.
+ */
+export function placeholderElementId(ref: PlaceholderRef): string {
+  return `__ph__${ref.type}_${ref.index}`;
+}
+
+/**
+ * Materialize a transient Slide from a layout so the existing canvas
+ * editor can render and drag its placeholders (PR3 commit 5). Each
+ * placeholder becomes an element carrying its `(type, index)`
+ * `placeholderRef`; the LayoutEditStore proxy maps a dragged element's ref
+ * back to `updateLayoutPlaceholderFrame`. The slide is never persisted.
+ *
+ * Reuses `applyLayoutToSlide` so geometry and master/theme-seeded
+ * typography match exactly what a real slide created from this layout
+ * gets. Background is left empty (inherit) so the renderer resolves
+ * layout→master→theme just as it does for live slides.
+ */
+export function buildLayoutSlide(
+  layout: Layout,
+  master: Master,
+  theme: Theme,
+): Slide {
+  const slide: Slide = {
+    id: layoutEditSlideId(layout.id),
+    layoutId: layout.id,
+    background: {},
+    elements: [],
+    notes: [],
+  };
+  applyLayoutToSlide(slide, layout, { master, theme });
+  // Stamp deterministic ids so the synthetic slide is reproducible across
+  // reads (applyLayoutToSlide assigns fresh generateId() ids).
+  for (const el of slide.elements) {
+    if (el.placeholderRef) el.id = placeholderElementId(el.placeholderRef);
+  }
+  return slide;
+}
+
+/**
  * Re-slot a slide for a new layout (mutates `slide`).
  *
  * 1. Partition existing elements by `placeholderRef`: ref-bearing

--- a/packages/slides/src/model/layout.ts
+++ b/packages/slides/src/model/layout.ts
@@ -218,6 +218,34 @@ export function placeholderElementId(ref: PlaceholderRef): string {
   return `__ph__${ref.type}_${ref.index}`;
 }
 
+const PLACEHOLDER_TYPES: ReadonlySet<string> = new Set<PlaceholderType>([
+  'title',
+  'subtitle',
+  'body',
+  'caption',
+  'big-number',
+]);
+
+/**
+ * Inverse of `placeholderElementId` — recover the `(type, index)` slot from
+ * a synthetic element id, or `undefined` when the id is not a placeholder
+ * element id (a real element / malformed input). Splits on the LAST `_` so
+ * hyphenated types like `big-number` round-trip.
+ */
+export function parsePlaceholderElementId(
+  id: string,
+): PlaceholderRef | undefined {
+  if (!id.startsWith('__ph__')) return undefined;
+  const rest = id.slice('__ph__'.length);
+  const sep = rest.lastIndexOf('_');
+  if (sep <= 0) return undefined;
+  const type = rest.slice(0, sep);
+  const indexStr = rest.slice(sep + 1);
+  if (!PLACEHOLDER_TYPES.has(type)) return undefined;
+  if (!/^\d+$/.test(indexStr)) return undefined;
+  return { type: type as PlaceholderType, index: Number(indexStr) };
+}
+
 /**
  * Materialize a transient Slide from a layout so the existing canvas
  * editor can render and drag its placeholders (PR3 commit 5). Each

--- a/packages/slides/src/store/layout-edit-store.ts
+++ b/packages/slides/src/store/layout-edit-store.ts
@@ -21,7 +21,11 @@ import type {
 } from '../model/element';
 import type { Master } from '../model/master';
 import type { Theme } from '../model/theme';
-import { buildLayoutSlide, getLayout } from '../model/layout';
+import {
+  buildLayoutSlide,
+  getLayout,
+  parsePlaceholderElementId,
+} from '../model/layout';
 import type {
   LayoutPatch,
   MasterPatch,
@@ -89,15 +93,12 @@ export class LayoutEditStore implements SlidesStore {
     elementId: string,
     frame: Partial<Frame>,
   ): void {
-    const ref = this.refForElement(elementId);
+    // The synthetic element id deterministically encodes its slot, so we
+    // recover the ref by parsing rather than rebuilding the synthetic slide
+    // on every drag/resize/nudge commit.
+    const ref = parsePlaceholderElementId(elementId);
     if (!ref) return; // unknown / non-placeholder element → inert
     this.real.updateLayoutPlaceholderFrame(this.layoutId, ref, frame);
-  }
-
-  /** Map a synthetic element id back to its layout placeholder slot. */
-  private refForElement(elementId: string): PlaceholderRef | undefined {
-    const slide = this.read().slides[0];
-    return slide.elements.find((e) => e.id === elementId)?.placeholderRef;
   }
 
   // --- theme-builder mutations: delegate (panel edit surface) ---

--- a/packages/slides/src/store/layout-edit-store.ts
+++ b/packages/slides/src/store/layout-edit-store.ts
@@ -1,0 +1,308 @@
+import type { Block } from '@wafflebase/docs';
+import type {
+  Background,
+  GuideAxis,
+  SlideAnimation,
+  SlideTransition,
+  SlidesDocument,
+} from '../model/presentation';
+import type {
+  ArrowheadStyle,
+  ConnectorRouting,
+  Endpoint,
+} from '../model/connector';
+import type {
+  CellStyle,
+  ElementInit,
+  Frame,
+  ObjectAnimation,
+  PlaceholderRef,
+  Stroke,
+} from '../model/element';
+import type { Master } from '../model/master';
+import type { Theme } from '../model/theme';
+import { buildLayoutSlide, getLayout } from '../model/layout';
+import type {
+  LayoutPatch,
+  MasterPatch,
+  SlidesStore,
+  ThemePatch,
+} from './store';
+
+/**
+ * LayoutEditStore — the "virtual-slide gate" for canvas layout-editing
+ * mode (PR3 commit 5).
+ *
+ * Wraps the real `SlidesStore` plus a current layout id. It presents the
+ * editor with a single synthetic slide (`buildLayoutSlide`) so the
+ * existing drag / resize / snap / overlay machinery edits a layout's
+ * placeholders, and routes the only geometry commit the editor makes
+ * (`updateElementFrame`) to `updateLayoutPlaceholderFrame` on the real
+ * store. Everything that would mutate slide content is a guarded no-op,
+ * so a layout edit can never leak into a real slide. `batch`, undo/redo,
+ * and `onChange` delegate to the real store, so one drag is one undo unit
+ * and layout edits repaint live slides through the real store's cascade.
+ *
+ * Theme-builder mutations (`updateTheme` / `updateMaster` / `updateLayout`
+ * / `updateLayoutPlaceholderFrame`) delegate straight through — they are
+ * the panel's edit surface and are safe in this mode.
+ */
+export class LayoutEditStore implements SlidesStore {
+  constructor(
+    private readonly real: SlidesStore,
+    private layoutId: string,
+  ) {}
+
+  setLayoutId(layoutId: string): void {
+    this.layoutId = layoutId;
+  }
+
+  getLayoutId(): string {
+    return this.layoutId;
+  }
+
+  // --- read: serve the synthetic layout slide ---
+
+  read(): SlidesDocument {
+    const doc = this.real.read();
+    const layout =
+      doc.layouts.find((l) => l.id === this.layoutId) ?? getLayout(this.layoutId);
+    const master = this.resolveMaster(doc);
+    const theme = this.resolveTheme(doc);
+    return { ...doc, slides: [buildLayoutSlide(layout, master, theme)] };
+  }
+
+  private resolveMaster(doc: SlidesDocument): Master {
+    return (
+      doc.masters.find((m) => m.id === doc.meta.masterId) ?? doc.masters[0]
+    );
+  }
+
+  private resolveTheme(doc: SlidesDocument): Theme {
+    return doc.themes.find((t) => t.id === doc.meta.themeId) ?? doc.themes[0];
+  }
+
+  // --- geometry commit: route to the layout placeholder ---
+
+  updateElementFrame(
+    _slideId: string,
+    elementId: string,
+    frame: Partial<Frame>,
+  ): void {
+    const ref = this.refForElement(elementId);
+    if (!ref) return; // unknown / non-placeholder element → inert
+    this.real.updateLayoutPlaceholderFrame(this.layoutId, ref, frame);
+  }
+
+  /** Map a synthetic element id back to its layout placeholder slot. */
+  private refForElement(elementId: string): PlaceholderRef | undefined {
+    const slide = this.read().slides[0];
+    return slide.elements.find((e) => e.id === elementId)?.placeholderRef;
+  }
+
+  // --- theme-builder mutations: delegate (panel edit surface) ---
+
+  addTheme(theme: Theme): void {
+    this.real.addTheme(theme);
+  }
+  applyTheme(themeId: string): void {
+    this.real.applyTheme(themeId);
+  }
+  updateTheme(themeId: string, patch: ThemePatch): void {
+    this.real.updateTheme(themeId, patch);
+  }
+  updateMaster(masterId: string, patch: MasterPatch): void {
+    this.real.updateMaster(masterId, patch);
+  }
+  updateLayout(layoutId: string, patch: LayoutPatch): void {
+    this.real.updateLayout(layoutId, patch);
+  }
+  updateLayoutPlaceholderFrame(
+    layoutId: string,
+    ref: PlaceholderRef,
+    frame: Partial<Frame>,
+  ): void {
+    this.real.updateLayoutPlaceholderFrame(layoutId, ref, frame);
+  }
+  setUnit(unit: 'in' | 'cm'): void {
+    this.real.setUnit(unit);
+  }
+  pushRecentColor(hex: string): void {
+    this.real.pushRecentColor(hex);
+  }
+
+  // --- transactions / notifications / history: delegate ---
+
+  batch(fn: () => void): void {
+    this.real.batch(fn);
+  }
+  onChange(cb: () => void): () => void {
+    return this.real.onChange?.(cb) ?? (() => undefined);
+  }
+  undo(): void {
+    this.real.undo();
+  }
+  redo(): void {
+    this.real.redo();
+  }
+  canUndo(): boolean {
+    return this.real.canUndo();
+  }
+  canRedo(): boolean {
+    return this.real.canRedo();
+  }
+
+  // --- structural mutations: guarded no-ops ---
+  // Layout-edit mode only repositions placeholders. Everything below is
+  // inert so a layout edit can never create or mutate a persisted slide.
+
+  addSlide(_layoutId: string, _atIndex?: number): string {
+    return '';
+  }
+  duplicateSlide(_slideId: string): string {
+    return '';
+  }
+  removeSlide(_slideId: string): void {}
+  removeSlides(_slideIds: string[]): void {}
+  moveSlide(_slideId: string, _toIndex: number): void {}
+  moveSlides(_slideIds: string[], _toIndex: number): void {}
+  updateSlideBackground(_slideId: string, _bg: Background): void {}
+  applyLayout(_slideId: string, _layoutId: string): void {}
+  setSlideTransition(
+    _slideId: string,
+    _transition: SlideTransition | undefined,
+  ): void {}
+  addAnimation(_slideId: string, _anim: SlideAnimation): string {
+    return '';
+  }
+  updateAnimation(
+    _slideId: string,
+    _animId: string,
+    _patch: Partial<ObjectAnimation>,
+  ): void {}
+  removeAnimation(_slideId: string, _animId: string): void {}
+  reorderAnimation(_slideId: string, _animId: string, _toIndex: number): void {}
+
+  addElement(
+    _slideId: string,
+    _init: ElementInit,
+    _parentGroupId?: string,
+  ): string {
+    return '';
+  }
+  removeElement(_slideId: string, _elementId: string): void {}
+  removeElements(_slideId: string, _elementIds: string[]): void {}
+  updateElementData(_slideId: string, _elementId: string, _patch: object): void {}
+  reorderElement(_slideId: string, _elementId: string, _toIndex: number): void {}
+
+  group(
+    _slideId: string,
+    _elementIds: string[],
+  ): { groupId: string; excludedConnectorIds: string[] } {
+    return { groupId: '', excludedConnectorIds: [] };
+  }
+  ungroup(_slideId: string, _groupId: string): string[] {
+    return [];
+  }
+  refitGroup(_slideId: string, _groupId: string): void {}
+  bakeGroupResize(_slideId: string, _groupId: string): void {}
+
+  updateConnectorEndpoint(
+    _slideId: string,
+    _elementId: string,
+    _side: 'start' | 'end',
+    _endpoint: Endpoint,
+  ): void {}
+  updateConnectorArrowheads(
+    _slideId: string,
+    _elementId: string,
+    _heads: { start?: ArrowheadStyle | null; end?: ArrowheadStyle | null },
+  ): void {}
+  updateConnectorStroke(
+    _slideId: string,
+    _elementId: string,
+    _stroke: Stroke | undefined,
+  ): void {}
+  updateConnectorRouting(
+    _slideId: string,
+    _elementId: string,
+    _routing: ConnectorRouting,
+  ): void {}
+  updateConnectorElbowBend(
+    _slideId: string,
+    _elementId: string,
+    _bend: number | undefined,
+  ): void {}
+  updateConnectorCurveBend(
+    _slideId: string,
+    _elementId: string,
+    _bend: number | undefined,
+  ): void {}
+
+  addGuide(_axis: GuideAxis, _position: number): string {
+    return '';
+  }
+  moveGuide(_id: string, _position: number): void {}
+  removeGuide(_id: string): void {}
+
+  withTextElement(
+    _slideId: string,
+    _elementId: string,
+    _fn: (blocks: Block[]) => Block[] | void,
+  ): void {}
+  withShapeText(
+    _slideId: string,
+    _elementId: string,
+    _fn: (blocks: Block[]) => Block[] | void,
+  ): void {}
+  withTableCellBody(
+    _slideId: string,
+    _elementId: string,
+    _row: number,
+    _col: number,
+    _fn: (blocks: Block[]) => Block[] | void,
+  ): void {}
+  insertTableRow(_slideId: string, _elementId: string, _atIndex: number): void {}
+  insertTableColumn(
+    _slideId: string,
+    _elementId: string,
+    _atIndex: number,
+  ): void {}
+  deleteTableRow(_slideId: string, _elementId: string, _atIndex: number): void {}
+  deleteTableColumn(
+    _slideId: string,
+    _elementId: string,
+    _atIndex: number,
+  ): void {}
+  mergeTableCells(
+    _slideId: string,
+    _elementId: string,
+    _range: { r0: number; c0: number; r1: number; c1: number },
+  ): void {}
+  unmergeTableCells(
+    _slideId: string,
+    _elementId: string,
+    _anchor: { row: number; col: number },
+  ): void {}
+  updateTableCellStyle(
+    _slideId: string,
+    _elementId: string,
+    _row: number,
+    _col: number,
+    _patch: Partial<CellStyle>,
+  ): void {}
+  updateTableColumnWidths(
+    _slideId: string,
+    _elementId: string,
+    _widths: readonly number[],
+  ): void {}
+  updateTableRowHeights(
+    _slideId: string,
+    _elementId: string,
+    _heights: readonly number[],
+  ): void {}
+  withNotes(
+    _slideId: string,
+    _fn: (blocks: Block[]) => Block[] | void,
+  ): void {}
+}

--- a/packages/slides/src/view/canvas/layout-preview.ts
+++ b/packages/slides/src/view/canvas/layout-preview.ts
@@ -7,9 +7,41 @@ import { renderThumbnail } from './thumbnail';
 import { slotRefsForLayout } from '../../model/layout';
 
 const cache = new Map<string, HTMLCanvasElement>();
+/**
+ * Cap so live theme-builder editing (each edit mints a new content key)
+ * can't grow the cache without bound. Insertion-ordered Map → deleting the
+ * first key evicts the oldest entry.
+ */
+const CACHE_CAP = 128;
 
 /** Test-only handle to clear the module cache between cases. */
 export const _previewCacheForTest = cache;
+
+/**
+ * Cache key that reflects the rendered CONTENT, not just ids. The theme
+ * builder edits themes / masters / layouts in place (ids unchanged), so an
+ * id-only key would serve a stale bitmap after a color, font, background,
+ * or placeholder-geometry edit. Immutable built-ins still hash to a stable
+ * key, so the layout picker keeps its cache hits.
+ */
+function previewKey(
+  layout: Layout,
+  theme: Theme,
+  master: Master,
+  size: { w: number; h: number },
+  dpr: number,
+): string {
+  const sig = JSON.stringify([
+    theme.colors,
+    theme.fonts,
+    master.background,
+    master.placeholderStyles,
+    layout.placeholders,
+    layout.background ?? null,
+    layout.staticElements,
+  ]);
+  return `${theme.id}:${master.id}:${layout.id}:${size.w}x${size.h}@${dpr}:${sig}`;
+}
 
 function syntheticSlide(layout: Layout): Slide {
   const refs = slotRefsForLayout(layout);
@@ -51,7 +83,7 @@ export function renderLayoutPreview(
     typeof window !== 'undefined' && window.devicePixelRatio
       ? window.devicePixelRatio
       : 1;
-  const key = `${theme.id}:${master.id}:${layout.id}:${size.w}x${size.h}@${dpr}`;
+  const key = previewKey(layout, theme, master, size, dpr);
   const hit = cache.get(key);
   if (hit) return hit;
 
@@ -85,5 +117,12 @@ export function renderLayoutPreview(
     dpr,
   });
   cache.set(key, canvas);
+  // Evict the oldest entry once past the cap (Map preserves insertion
+  // order). Built-in previews stay hot; stale edited-layout bitmaps fall
+  // out over a long editing session.
+  if (cache.size > CACHE_CAP) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
   return canvas;
 }

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -1356,7 +1356,15 @@ class SlidesEditorImpl implements SlidesEditor {
     this.setCellSelection(null);
     this.options.store = store;
     this.installKeyRules();
-    this.currentId = currentId ?? store.read().slides[0]?.id;
+    // Resolve to a slide that actually exists in the new store. A caller-
+    // supplied id can be stale (e.g. a peer deleted the slide while the
+    // user was in layout-edit mode); fall back to the first slide rather
+    // than leaving a dangling current id and a blank canvas.
+    const slides = store.read().slides;
+    this.currentId =
+      currentId && slides.some((s) => s.id === currentId)
+        ? currentId
+        : slides[0]?.id;
     this.renderer.markDirty();
     this.render();
     this.repaintOverlay();

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -358,6 +358,19 @@ export interface SlidesEditor {
   getCurrentSlideId(): string | undefined;
   setCurrentSlide(id: string): void;
   /**
+   * Enter canvas layout-editing mode (PR3 theme builder). The editor
+   * swaps to the given `LayoutEditStore` so it renders + edits a synthetic
+   * layout slide; placeholder drag / resize / nudge route through that
+   * store to `updateLayoutPlaceholderFrame`, and text editing is
+   * suppressed. The current slide becomes the store's synthetic slide.
+   */
+  enterLayoutEditMode(store: SlidesStore): void;
+  /**
+   * Leave layout-editing mode, restoring the real store and making
+   * `slideId` current again. Inverse of `enterLayoutEditMode`.
+   */
+  exitLayoutEditMode(store: SlidesStore, slideId: string): void;
+  /**
    * The id of the text element currently in edit mode, or null if no
    * text-box editor is active. Exposed primarily for tests + future
    * UI affordances (e.g. disabling toolbar actions while editing).
@@ -639,6 +652,12 @@ class SlidesEditorImpl implements SlidesEditor {
   private disposed = false;
   private keyRules!: KeyRule[];
   private currentId: string | undefined;
+  /**
+   * True while canvas layout-editing mode is active (PR3 theme builder).
+   * Gates text-edit entry; the swapped `LayoutEditStore` already no-ops
+   * structural mutations, so this only covers the UX the proxy can't.
+   */
+  private layoutEditMode = false;
   private currentSlideListeners = new Set<() => void>();
   private insertModeListeners = new Set<() => void>();
   /**
@@ -922,32 +941,7 @@ class SlidesEditorImpl implements SlidesEditor {
       this.renderer.markDirty();
       this.repaintOverlay();
     });
-    this.keyRules = buildKeyRules({
-      store: this.options.store,
-      selection: this.selection,
-      currentSlideId: () => this.getCurrentSlideId(),
-      setCurrentSlide: (id: string) => this.setCurrentSlide(id),
-      enterEditMode: (
-        slideId: string,
-        elementId: string,
-        options?: { initialText?: string },
-      ) => this.enterEditMode(slideId, elementId, options),
-      requestRender: () => this.requestRender(),
-      onStartPresentation: this.options.onStartPresentation,
-      onShowShortcutsHelp: this.options.onShowShortcutsHelp,
-      getInsertMode: () => this.getInsertMode(),
-      setInsertMode: (kind) => this.setInsertMode(kind),
-      group: () => this.group(),
-      ungroup: () => this.ungroup(),
-      isPaintingFormat: () => this.isPaintingFormat(),
-      cancelFormatPaint: () => this.cancelFormatPaint(),
-      getCellSelection: () => this.cellSelection,
-      clearCellSelection: () => {
-        if (this.cellSelection === null) return;
-        this.setCellSelection(null);
-        this.repaintOverlay();
-      },
-    });
+    this.installKeyRules();
     // Read-only mounts (viewer-role share links) skip every pointer +
     // keyboard binding. The renderer still paints, including remote
     // peer edits, but the user cannot mutate. The editor's
@@ -1311,6 +1305,72 @@ class SlidesEditorImpl implements SlidesEditor {
     this.render();
     this.repaintOverlay();
     for (const cb of this.currentSlideListeners) cb();
+  }
+
+  /**
+   * Build (or rebuild) the keyboard rules against the current
+   * `this.options.store`. Rebuilt by `setStore` because `buildKeyRules`
+   * captures the store reference — arrow-nudge / delete would otherwise
+   * keep writing to the pre-swap store.
+   */
+  private installKeyRules(): void {
+    this.keyRules = buildKeyRules({
+      store: this.options.store,
+      selection: this.selection,
+      currentSlideId: () => this.getCurrentSlideId(),
+      setCurrentSlide: (id: string) => this.setCurrentSlide(id),
+      enterEditMode: (
+        slideId: string,
+        elementId: string,
+        options?: { initialText?: string },
+      ) => this.enterEditMode(slideId, elementId, options),
+      requestRender: () => this.requestRender(),
+      onStartPresentation: this.options.onStartPresentation,
+      onShowShortcutsHelp: this.options.onShowShortcutsHelp,
+      getInsertMode: () => this.getInsertMode(),
+      setInsertMode: (kind) => this.setInsertMode(kind),
+      group: () => this.group(),
+      ungroup: () => this.ungroup(),
+      isPaintingFormat: () => this.isPaintingFormat(),
+      cancelFormatPaint: () => this.cancelFormatPaint(),
+      getCellSelection: () => this.cellSelection,
+      clearCellSelection: () => {
+        if (this.cellSelection === null) return;
+        this.setCellSelection(null);
+        this.repaintOverlay();
+      },
+    });
+  }
+
+  /**
+   * Swap the editor's backing store and reset transient interaction
+   * state. Exits crop / text editing, clears selection, rebuilds the
+   * key rules against the new store, then makes `currentId` current
+   * (defaulting to the new store's first slide). Used by layout-edit
+   * mode to route the editor at a `LayoutEditStore` and back.
+   */
+  private setStore(store: SlidesStore, currentId?: string): void {
+    if (this.editingElementId !== null) this.exitEditMode('commit');
+    if (this.cropSession !== null) this.exitImageCrop(true);
+    this.selection.clear();
+    this.setCellSelection(null);
+    this.options.store = store;
+    this.installKeyRules();
+    this.currentId = currentId ?? store.read().slides[0]?.id;
+    this.renderer.markDirty();
+    this.render();
+    this.repaintOverlay();
+    for (const cb of this.currentSlideListeners) cb();
+  }
+
+  enterLayoutEditMode(store: SlidesStore): void {
+    this.layoutEditMode = true;
+    this.setStore(store);
+  }
+
+  exitLayoutEditMode(store: SlidesStore, slideId: string): void {
+    this.layoutEditMode = false;
+    this.setStore(store, slideId);
   }
 
   onSelectionChange(cb: () => void): () => void {
@@ -3533,6 +3593,10 @@ class SlidesEditorImpl implements SlidesEditor {
     elementId: string,
     options?: { initialText?: string; cell?: { row: number; col: number } },
   ): void {
+    // Layout-edit mode repositions placeholders only — no text editing.
+    // This is the single chokepoint for every entry path (1-click,
+    // dblclick, P1.5 slow double-click, Enter, type-to-edit).
+    if (this.layoutEditMode) return;
     // If we're already editing some other text-box, commit it first so
     // the text in flight is not lost when focus moves.
     if (this.editingElementId !== null) {

--- a/packages/slides/src/view/editor/layout-list-panel.ts
+++ b/packages/slides/src/view/editor/layout-list-panel.ts
@@ -1,0 +1,129 @@
+import { BUILT_IN_LAYOUTS } from '../../model/layout';
+import { renderLayoutPreview } from '../canvas/layout-preview';
+import type { SlidesStore } from '../../store/store';
+
+const PREVIEW_W = 160;
+const PREVIEW_H = 90;
+
+export interface MountLayoutListPanelOptions {
+  /** The layout currently being edited; its row carries the marker. */
+  selectedLayoutId?: string;
+  /** Called when the user picks a layout row to edit. */
+  onSelect: (layoutId: string) => void;
+}
+
+export interface LayoutListPanelHandle {
+  /** Move the selection marker to a different layout row. */
+  setSelectedLayoutId(layoutId: string): void;
+  /**
+   * Rebuild the preview canvases from the current store — call after a
+   * theme / master / layout-geometry edit so the rail reflects it.
+   */
+  refresh(): void;
+  /** Remove the panel DOM and detach store subscriptions. */
+  dispose(): void;
+}
+
+/**
+ * Mount the layout-edit rail (PR3 commit 5c). While layout-edit mode is
+ * active this replaces the slide thumbnail panel with a vertical list of
+ * the deck's layouts; clicking a row drives the editor to edit that
+ * layout. Pure vanilla DOM, mirroring `mountThumbnailPanel` /
+ * `showLayoutPicker` so the frontend mounts it the same way.
+ */
+export function mountLayoutListPanel(
+  container: HTMLElement,
+  store: SlidesStore,
+  options: MountLayoutListPanelOptions,
+): LayoutListPanelHandle {
+  let selectedLayoutId = options.selectedLayoutId;
+
+  const root = document.createElement('div');
+  root.className = 'wfb-slides-layout-list';
+  root.setAttribute('role', 'listbox');
+  root.setAttribute('aria-label', 'Layouts');
+  root.style.display = 'flex';
+  root.style.flexDirection = 'column';
+  root.style.gap = '8px';
+  root.style.padding = '8px';
+  container.appendChild(root);
+
+  function applySelection(): void {
+    for (const row of root.querySelectorAll<HTMLElement>('[data-layout-id]')) {
+      const on = row.dataset.layoutId === selectedLayoutId;
+      row.dataset.selected = String(on);
+      row.setAttribute('aria-selected', String(on));
+      row.style.outline = on
+        ? '2px solid var(--primary, #3a7)'
+        : '1px solid var(--border, #444)';
+    }
+  }
+
+  function build(): void {
+    root.replaceChildren();
+    const doc = store.read();
+    const theme =
+      doc.themes.find((t) => t.id === doc.meta.themeId) ?? doc.themes[0];
+    const master =
+      doc.masters.find((m) => m.id === doc.meta.masterId) ?? doc.masters[0];
+    // Edit the document-local layouts when present so previews show
+    // builder edits; fall back to the shared built-ins for pre-PR1 docs.
+    const layouts = doc.layouts.length > 0 ? doc.layouts : BUILT_IN_LAYOUTS;
+
+    for (const layout of layouts) {
+      const row = document.createElement('div');
+      row.dataset.layoutId = layout.id;
+      row.tabIndex = 0;
+      row.setAttribute('role', 'option');
+      row.setAttribute('aria-label', layout.name);
+      row.style.cursor = 'pointer';
+      row.style.boxSizing = 'border-box';
+      row.style.padding = '4px';
+      row.style.borderRadius = '4px';
+
+      const canvas = renderLayoutPreview(layout, theme, master, {
+        w: PREVIEW_W,
+        h: PREVIEW_H,
+      });
+      canvas.style.width = '100%';
+      canvas.style.height = 'auto';
+      canvas.style.display = 'block';
+      row.appendChild(canvas);
+
+      const label = document.createElement('div');
+      label.textContent = layout.name;
+      label.style.fontSize = '12px';
+      label.style.marginTop = '4px';
+      label.style.textAlign = 'center';
+      row.appendChild(label);
+
+      const pick = (): void => options.onSelect(layout.id);
+      row.addEventListener('click', pick);
+      row.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          pick();
+        }
+      });
+      root.appendChild(row);
+    }
+    applySelection();
+  }
+
+  build();
+  const unsubscribe = store.onChange?.(() => build());
+
+  return {
+    setSelectedLayoutId(layoutId: string): void {
+      selectedLayoutId = layoutId;
+      applySelection();
+    },
+    refresh(): void {
+      build();
+    },
+    dispose(): void {
+      unsubscribe?.();
+      root.remove();
+    },
+  };
+}

--- a/packages/slides/test/model/build-layout-slide.test.ts
+++ b/packages/slides/test/model/build-layout-slide.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildLayoutSlide,
+  getLayout,
+  layoutEditSlideId,
+  placeholderElementId,
+} from '../../src/model/layout';
+import { DEFAULT_MASTER } from '../../src/model/master';
+import { defaultLight } from '../../src/themes/default-light';
+
+/**
+ * PR3 commit 5a — `buildLayoutSlide` materializes a transient Slide from
+ * a layout so the existing canvas editor can render and edit the layout's
+ * placeholders. Never persisted; the LayoutEditStore proxy serves it from
+ * `read()` and routes geometry commits back to the layout.
+ */
+describe('buildLayoutSlide', () => {
+  it('materializes one element per placeholder, each carrying its (type,index) ref', () => {
+    const layout = getLayout('title-body');
+    const slide = buildLayoutSlide(layout, DEFAULT_MASTER, defaultLight);
+
+    expect(slide.elements).toHaveLength(2);
+    expect(slide.elements.map((e) => e.placeholderRef)).toEqual([
+      { type: 'title', index: 0 },
+      { type: 'body', index: 0 },
+    ]);
+  });
+
+  it('indexes same-type slots so a second body placeholder is index 1', () => {
+    const layout = getLayout('title-two-columns');
+    const slide = buildLayoutSlide(layout, DEFAULT_MASTER, defaultLight);
+
+    expect(slide.elements.map((e) => e.placeholderRef)).toEqual([
+      { type: 'title', index: 0 },
+      { type: 'body', index: 0 },
+      { type: 'body', index: 1 },
+    ]);
+  });
+
+  it('copies each placeholder frame from the layout spec', () => {
+    const layout = getLayout('title-body');
+    const slide = buildLayoutSlide(layout, DEFAULT_MASTER, defaultLight);
+
+    expect(slide.elements[0].frame).toEqual(layout.placeholders[0].frame);
+    expect(slide.elements[1].frame).toEqual(layout.placeholders[1].frame);
+  });
+
+  it('uses a stable synthetic id derived from the layout id', () => {
+    const layout = getLayout('title-body');
+    const slide = buildLayoutSlide(layout, DEFAULT_MASTER, defaultLight);
+
+    expect(slide.id).toBe(layoutEditSlideId('title-body'));
+    expect(slide.layoutId).toBe('title-body');
+  });
+
+  it('inherits background (empty) so the renderer resolves layout→master→theme', () => {
+    const layout = getLayout('title-body');
+    const slide = buildLayoutSlide(layout, DEFAULT_MASTER, defaultLight);
+
+    expect(slide.background).toEqual({});
+  });
+
+  it('assigns deterministic, ref-derived element ids that are stable across builds', () => {
+    const layout = getLayout('title-two-columns');
+    const a = buildLayoutSlide(layout, DEFAULT_MASTER, defaultLight);
+    const b = buildLayoutSlide(layout, DEFAULT_MASTER, defaultLight);
+
+    // Same ids across two independent builds — the editor holds an id
+    // between reading the slide and committing a drag, so a fresh
+    // generateId() per build would break the ref mapping.
+    expect(a.elements.map((e) => e.id)).toEqual(b.elements.map((e) => e.id));
+    expect(a.elements.map((e) => e.id)).toEqual([
+      placeholderElementId({ type: 'title', index: 0 }),
+      placeholderElementId({ type: 'body', index: 0 }),
+      placeholderElementId({ type: 'body', index: 1 }),
+    ]);
+  });
+
+  it('produces an empty-placeholder slide for the blank layout', () => {
+    const layout = getLayout('blank');
+    const slide = buildLayoutSlide(layout, DEFAULT_MASTER, defaultLight);
+
+    expect(slide.elements).toEqual([]);
+    expect(slide.notes).toEqual([]);
+  });
+});

--- a/packages/slides/test/model/build-layout-slide.test.ts
+++ b/packages/slides/test/model/build-layout-slide.test.ts
@@ -3,6 +3,7 @@ import {
   buildLayoutSlide,
   getLayout,
   layoutEditSlideId,
+  parsePlaceholderElementId,
   placeholderElementId,
 } from '../../src/model/layout';
 import { DEFAULT_MASTER } from '../../src/model/master';
@@ -74,6 +75,23 @@ describe('buildLayoutSlide', () => {
       placeholderElementId({ type: 'body', index: 0 }),
       placeholderElementId({ type: 'body', index: 1 }),
     ]);
+  });
+
+  it('round-trips placeholderElementId ↔ parsePlaceholderElementId, including hyphenated types', () => {
+    for (const ref of [
+      { type: 'title' as const, index: 0 },
+      { type: 'body' as const, index: 1 },
+      { type: 'big-number' as const, index: 0 },
+      { type: 'subtitle' as const, index: 2 },
+    ]) {
+      expect(parsePlaceholderElementId(placeholderElementId(ref))).toEqual(ref);
+    }
+  });
+
+  it('parsePlaceholderElementId returns undefined for non-placeholder ids', () => {
+    expect(parsePlaceholderElementId('some-uuid-1234')).toBeUndefined();
+    expect(parsePlaceholderElementId('__ph__bogustype_0')).toBeUndefined();
+    expect(parsePlaceholderElementId('__ph__title_x')).toBeUndefined();
   });
 
   it('produces an empty-placeholder slide for the blank layout', () => {

--- a/packages/slides/test/store/layout-edit-store.test.ts
+++ b/packages/slides/test/store/layout-edit-store.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { MemSlidesStore } from '../../src/store/memory';
+import { LayoutEditStore } from '../../src/store/layout-edit-store';
+import {
+  layoutEditSlideId,
+  placeholderElementId,
+} from '../../src/model/layout';
+
+/**
+ * PR3 commit 5a — `LayoutEditStore` is the "virtual-slide gate" for
+ * canvas layout-editing mode. It wraps the real store and a current
+ * layout id, serving a single synthetic slide from `read()` and routing
+ * `updateElementFrame` to `updateLayoutPlaceholderFrame`. Structural
+ * mutations are guarded no-ops so a layout edit can never leak into slide
+ * content. `batch` / undo / `onChange` delegate to the real store.
+ */
+describe('LayoutEditStore', () => {
+  const TITLE_REF = { type: 'title' as const, index: 0 };
+
+  it('read() serves a single synthetic slide for the current layout', () => {
+    const real = new MemSlidesStore();
+    const proxy = new LayoutEditStore(real, 'title-body');
+
+    const doc = proxy.read();
+    expect(doc.slides).toHaveLength(1);
+    expect(doc.slides[0].id).toBe(layoutEditSlideId('title-body'));
+    expect(doc.slides[0].elements.map((e) => e.placeholderRef)).toEqual([
+      { type: 'title', index: 0 },
+      { type: 'body', index: 0 },
+    ]);
+  });
+
+  it('read() carries through the real document meta/themes/masters/layouts', () => {
+    const real = new MemSlidesStore();
+    const proxy = new LayoutEditStore(real, 'title-body');
+
+    const realDoc = real.read();
+    const doc = proxy.read();
+    expect(doc.meta).toEqual(realDoc.meta);
+    expect(doc.themes).toEqual(realDoc.themes);
+    expect(doc.masters).toEqual(realDoc.masters);
+    expect(doc.layouts).toEqual(realDoc.layouts);
+  });
+
+  it('updateElementFrame routes to updateLayoutPlaceholderFrame on the layout', () => {
+    const real = new MemSlidesStore();
+    const proxy = new LayoutEditStore(real, 'title-body');
+    const titleId = placeholderElementId(TITLE_REF);
+
+    proxy.batch(() => {
+      proxy.updateElementFrame(layoutEditSlideId('title-body'), titleId, {
+        x: 111,
+        y: 222,
+      });
+    });
+
+    // The real layout's title placeholder moved.
+    const layout = real.read().layouts.find((l) => l.id === 'title-body')!;
+    const titleSpec = layout.placeholders.find(
+      (p) => p.placeholder.type === 'title',
+    )!;
+    expect(titleSpec.frame.x).toBe(111);
+    expect(titleSpec.frame.y).toBe(222);
+
+    // And the synthetic slide reflects it on the next read.
+    const synthTitle = proxy
+      .read()
+      .slides[0].elements.find((e) => e.id === titleId)!;
+    expect(synthTitle.frame.x).toBe(111);
+    expect(synthTitle.frame.y).toBe(222);
+  });
+
+  it('updateElementFrame for an unknown element id is a no-op', () => {
+    const real = new MemSlidesStore();
+    const proxy = new LayoutEditStore(real, 'title-body');
+    const before = real.read().layouts;
+
+    expect(() =>
+      proxy.batch(() =>
+        proxy.updateElementFrame('x', 'no-such-element', { x: 5 }),
+      ),
+    ).not.toThrow();
+    expect(real.read().layouts).toEqual(before);
+  });
+
+  it('a frame edit is a single undo unit on the real store', () => {
+    const real = new MemSlidesStore();
+    const proxy = new LayoutEditStore(real, 'title-body');
+    const titleId = placeholderElementId(TITLE_REF);
+    const originalX = real
+      .read()
+      .layouts.find((l) => l.id === 'title-body')!
+      .placeholders.find((p) => p.placeholder.type === 'title')!.frame.x;
+
+    proxy.batch(() => {
+      proxy.updateElementFrame(layoutEditSlideId('title-body'), titleId, {
+        x: 999,
+      });
+    });
+    expect(proxy.canUndo()).toBe(true);
+
+    proxy.undo();
+    const restored = real
+      .read()
+      .layouts.find((l) => l.id === 'title-body')!
+      .placeholders.find((p) => p.placeholder.type === 'title')!.frame.x;
+    expect(restored).toBe(originalX);
+  });
+
+  it('structural mutations are guarded no-ops (no slide ever created)', () => {
+    const real = new MemSlidesStore();
+    const proxy = new LayoutEditStore(real, 'title-body');
+
+    proxy.batch(() => {
+      const id = proxy.addElement(layoutEditSlideId('title-body'), {
+        type: 'shape',
+        frame: { x: 0, y: 0, w: 10, h: 10, rotation: 0 },
+        data: { kind: 'rect' },
+      } as never);
+      expect(id).toBe('');
+      proxy.removeElement('x', 'y');
+      proxy.removeElements('x', ['y']);
+      proxy.addSlide('blank');
+      proxy.applyLayout('x', 'blank');
+    });
+
+    // The real document still has zero persisted slides.
+    expect(real.read().slides).toEqual([]);
+  });
+
+  it('setLayoutId switches which layout read() serves', () => {
+    const real = new MemSlidesStore();
+    const proxy = new LayoutEditStore(real, 'title-body');
+    expect(proxy.read().slides[0].id).toBe(layoutEditSlideId('title-body'));
+
+    proxy.setLayoutId('big-number');
+    expect(proxy.getLayoutId()).toBe('big-number');
+    expect(proxy.read().slides[0].id).toBe(layoutEditSlideId('big-number'));
+    expect(
+      proxy.read().slides[0].elements.map((e) => e.placeholderRef?.type),
+    ).toEqual(['big-number', 'body']);
+  });
+
+  it('delegates theme-builder mutations to the real store', () => {
+    const real = new MemSlidesStore();
+    const proxy = new LayoutEditStore(real, 'title-body');
+
+    proxy.batch(() => {
+      proxy.updateTheme('default-light', { colors: { accent1: '#ABCDEF' } });
+    });
+    expect(
+      real.read().themes.find((t) => t.id === 'default-light')!.colors.accent1,
+    ).toBe('#ABCDEF');
+  });
+});

--- a/packages/slides/test/view/canvas/layout-preview.test.ts
+++ b/packages/slides/test/view/canvas/layout-preview.test.ts
@@ -41,6 +41,47 @@ describe('renderLayoutPreview', () => {
     expect(b.width).toBe(80);
   });
 
+  it('busts the cache when a layout placeholder frame changes (same layout id)', () => {
+    _previewCacheForTest.clear();
+    const base = BUILT_IN_LAYOUTS[3]; // title-body
+    const size = { w: 160, h: 90 } as const;
+    const a = renderLayoutPreview(base, defaultLight, DEFAULT_MASTER, size);
+    // Theme-builder geometry edit: same layout id, moved placeholder.
+    const edited = {
+      ...base,
+      placeholders: base.placeholders.map((p, i) =>
+        i === 0 ? { ...p, frame: { ...p.frame, x: p.frame.x + 100 } } : p,
+      ),
+    };
+    const b = renderLayoutPreview(edited, defaultLight, DEFAULT_MASTER, size);
+    expect(b).not.toBe(a);
+  });
+
+  it('busts the cache when theme colors change (same theme id)', () => {
+    _previewCacheForTest.clear();
+    const layout = BUILT_IN_LAYOUTS[1];
+    const size = { w: 160, h: 90 } as const;
+    const a = renderLayoutPreview(layout, defaultLight, DEFAULT_MASTER, size);
+    const editedTheme = {
+      ...defaultLight,
+      colors: { ...defaultLight.colors, accent1: '#FF0000' },
+    };
+    const b = renderLayoutPreview(layout, editedTheme, DEFAULT_MASTER, size);
+    expect(b).not.toBe(a);
+  });
+
+  it('bounds the cache so live editing does not leak canvases', () => {
+    _previewCacheForTest.clear();
+    // Each distinct size is a distinct key; render well past the cap.
+    for (let i = 0; i < 200; i++) {
+      renderLayoutPreview(BUILT_IN_LAYOUTS[1], defaultLight, DEFAULT_MASTER, {
+        w: 100 + i,
+        h: 90,
+      });
+    }
+    expect(_previewCacheForTest.size).toBeLessThanOrEqual(128);
+  });
+
   it('renders all 11 layouts without throwing', () => {
     _previewCacheForTest.clear();
     for (const layout of BUILT_IN_LAYOUTS) {

--- a/packages/slides/test/view/editor/layout-edit-mode.test.ts
+++ b/packages/slides/test/view/editor/layout-edit-mode.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+import { describe, expect, it, afterEach } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import { MemSlidesStore } from '../../../src/store/memory';
+import { LayoutEditStore } from '../../../src/store/layout-edit-store';
+import {
+  layoutEditSlideId,
+  placeholderElementId,
+} from '../../../src/model/layout';
+import { initialize, type SlidesEditor } from '../../../src/view/editor/editor';
+import type {
+  MountSlidesTextBoxOptions,
+  SlidesTextBoxEditor,
+} from '../../../src/view/editor/text-box-editor';
+
+/**
+ * PR3 commit 5b — the editor's layout-edit mode. `enterLayoutEditMode`
+ * swaps the editor's store to a LayoutEditStore (so it renders/edits a
+ * synthetic layout slide) and gates text editing; `exitLayoutEditMode`
+ * restores the real store and slide. Geometry commits (drag / nudge)
+ * route through the swapped store to `updateLayoutPlaceholderFrame`.
+ */
+function makeMockMount() {
+  return function mount(opts: MountSlidesTextBoxOptions): SlidesTextBoxEditor {
+    const container = document.createElement('div');
+    container.className = 'wfb-slides-text-box-editor';
+    container.style.position = 'absolute';
+    opts.overlay.appendChild(container);
+    let mounted = true;
+    return {
+      isEditing: () => mounted,
+      focus: () => undefined,
+      commit: () => opts.onCommit(opts.blocks),
+      detach: () => { mounted = false; container.remove(); },
+      container,
+      getSelectionStyle: () => ({}),
+      getRangeStyleSummary: () => ({}),
+      applyStyle: () => {},
+      clearInlineFormatting: () => {},
+      applyBlockStyle: () => {},
+      getBlockType: () => ({ type: 'paragraph' as const }),
+      getBlockStyle: () => ({}),
+      setBlockType: () => {},
+      toggleList: () => {},
+      indent: () => {},
+      outdent: () => {},
+      insertLink: () => {},
+      removeLink: () => {},
+      getLinkAtCursor: () => undefined,
+      requestLink: () => {},
+      undo: () => {},
+      redo: () => {},
+      onCursorMove: () => () => {},
+    };
+  };
+}
+
+function setup() {
+  document.body.innerHTML = '';
+  const canvas = document.createElement('canvas');
+  canvas.width = 1920;
+  canvas.height = 1080;
+  const overlay = document.createElement('div');
+  overlay.style.position = 'absolute';
+  document.body.appendChild(canvas);
+  document.body.appendChild(overlay);
+  const store = new MemSlidesStore();
+  return { canvas, overlay, store };
+}
+
+function click(canvas: HTMLCanvasElement, x: number, y: number) {
+  canvas.dispatchEvent(new PointerEvent('pointerdown', {
+    clientX: x, clientY: y, pointerType: 'mouse', button: 0, bubbles: true,
+  }));
+  canvas.dispatchEvent(new PointerEvent('pointerup', {
+    clientX: x, clientY: y, pointerType: 'mouse', button: 0, bubbles: true,
+  }));
+}
+
+describe('editor layout-edit mode', () => {
+  let editor: SlidesEditor | null = null;
+  afterEach(() => {
+    if (editor) { editor.detach(); editor = null; }
+  });
+
+  it('enterLayoutEditMode makes the synthetic layout slide current', () => {
+    const { canvas, overlay, store } = setup();
+    store.batch(() => store.addSlide('title-body'));
+    const layoutStore = new LayoutEditStore(store, 'title-body');
+
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: makeMockMount(),
+    });
+    editor.enterLayoutEditMode(layoutStore);
+
+    expect(editor.getCurrentSlideId()).toBe(layoutEditSlideId('title-body'));
+  });
+
+  it('suppresses text-edit entry while in layout-edit mode (still selects)', () => {
+    const { canvas, overlay, store } = setup();
+    store.batch(() => store.addSlide('title-body'));
+    const layoutStore = new LayoutEditStore(store, 'title-body');
+
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: makeMockMount(),
+    });
+    editor.enterLayoutEditMode(layoutStore);
+
+    const titleId = placeholderElementId({ type: 'title', index: 0 });
+    const title = layoutStore
+      .read()
+      .slides[0].elements.find((e) => e.id === titleId)!;
+
+    click(canvas, title.frame.x + title.frame.w / 2, title.frame.y + title.frame.h / 2);
+
+    // Empty placeholder: in normal mode this 1-click-enters edit. In
+    // layout-edit mode it must only select.
+    expect(editor.getEditingElementId()).toBeNull();
+    expect(editor.getSelection()).toEqual([titleId]);
+  });
+
+  it('dragging a placeholder commits to the layout (updateLayoutPlaceholderFrame)', () => {
+    const { canvas, overlay, store } = setup();
+    store.batch(() => store.addSlide('title-body'));
+    const layoutStore = new LayoutEditStore(store, 'title-two-columns');
+
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: makeMockMount(),
+    });
+    editor.enterLayoutEditMode(layoutStore);
+
+    // First body column of title-two-columns (HALF-width, so snapping to
+    // slide edges/centre doesn't dominate the delta).
+    const bodyId = placeholderElementId({ type: 'body', index: 0 });
+    const before = store
+      .read()
+      .layouts.find((l) => l.id === 'title-two-columns')!
+      .placeholders.filter((p) => p.placeholder.type === 'body')[0].frame;
+    editor.setSelection([bodyId]);
+
+    const cx = before.x + before.w / 2;
+    const cy = before.y + before.h / 2;
+    canvas.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: cx, clientY: cy, pointerType: 'mouse', button: 0, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointermove', {
+      clientX: cx + 120, clientY: cy + 80, bubbles: true,
+    }));
+    document.dispatchEvent(new PointerEvent('pointerup', {
+      clientX: cx + 120, clientY: cy + 80, bubbles: true,
+    }));
+
+    const after = store
+      .read()
+      .layouts.find((l) => l.id === 'title-two-columns')!
+      .placeholders.filter((p) => p.placeholder.type === 'body')[0].frame;
+
+    // The layout placeholder moved (~+120,+80 modulo ≤10px snap), and the
+    // edit is undoable as one unit.
+    expect(Math.abs(after.x - (before.x + 120))).toBeLessThanOrEqual(10);
+    expect(Math.abs(after.y - (before.y + 80))).toBeLessThanOrEqual(10);
+    expect(store.canUndo()).toBe(true);
+    store.undo();
+    expect(
+      store
+        .read()
+        .layouts.find((l) => l.id === 'title-two-columns')!
+        .placeholders.filter((p) => p.placeholder.type === 'body')[0].frame.x,
+    ).toBe(before.x);
+  });
+
+  it('exitLayoutEditMode restores the real store and the given slide', () => {
+    const { canvas, overlay, store } = setup();
+    let sid = '';
+    store.batch(() => { sid = store.addSlide('title-body'); });
+    const layoutStore = new LayoutEditStore(store, 'title-body');
+
+    editor = initialize({
+      canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1,
+      mountTextBox: makeMockMount(),
+    });
+    editor.enterLayoutEditMode(layoutStore);
+    expect(editor.getCurrentSlideId()).toBe(layoutEditSlideId('title-body'));
+
+    editor.exitLayoutEditMode(store, sid);
+    expect(editor.getCurrentSlideId()).toBe(sid);
+
+    // Back in normal mode: clicking an empty placeholder enters text edit.
+    const titleId = store
+      .read()
+      .slides.find((s) => s.id === sid)!
+      .elements.find((e) => e.placeholderRef?.type === 'title')!.id;
+    const title = store
+      .read()
+      .slides.find((s) => s.id === sid)!
+      .elements.find((e) => e.id === titleId)!;
+    click(canvas, title.frame.x + title.frame.w / 2, title.frame.y + title.frame.h / 2);
+    expect(editor.getEditingElementId()).toBe(titleId);
+  });
+});

--- a/packages/slides/test/view/editor/layout-edit-mode.test.ts
+++ b/packages/slides/test/view/editor/layout-edit-mode.test.ts
@@ -188,6 +188,13 @@ describe('editor layout-edit mode', () => {
     editor.exitLayoutEditMode(store, sid);
     expect(editor.getCurrentSlideId()).toBe(sid);
 
+    // Re-enter then exit restoring a slide id that no longer exists (e.g.
+    // a peer deleted it during layout editing): fall back to a real slide
+    // rather than leaving a dangling current id / blank canvas.
+    editor.enterLayoutEditMode(layoutStore);
+    editor.exitLayoutEditMode(store, "deleted-slide-id");
+    expect(editor.getCurrentSlideId()).toBe(sid);
+
     // Back in normal mode: clicking an empty placeholder enters text edit.
     const titleId = store
       .read()

--- a/packages/slides/test/view/editor/layout-list-panel.test.ts
+++ b/packages/slides/test/view/editor/layout-list-panel.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import '../../../src/view/canvas/test-canvas-env';
+import { MemSlidesStore } from '../../../src/store/memory';
+import { BUILT_IN_LAYOUTS } from '../../../src/model/layout';
+import { mountLayoutListPanel } from '../../../src/view/editor/layout-list-panel';
+
+/**
+ * PR3 commit 5c — `mountLayoutListPanel` replaces the slide thumbnail
+ * rail while in layout-edit mode: a selectable list of the deck's
+ * layouts. Clicking one drives the editor to edit that layout.
+ */
+function setup() {
+  document.body.innerHTML = '';
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const store = new MemSlidesStore();
+  return { container, store };
+}
+
+describe('mountLayoutListPanel', () => {
+  let handle: ReturnType<typeof mountLayoutListPanel> | null = null;
+  afterEach(() => {
+    if (handle) { handle.dispose(); handle = null; }
+  });
+
+  it('renders one selectable row per built-in layout, labelled by name', () => {
+    const { container, store } = setup();
+    handle = mountLayoutListPanel(container, store, { onSelect: () => {} });
+
+    const rows = container.querySelectorAll('[data-layout-id]');
+    expect(rows).toHaveLength(BUILT_IN_LAYOUTS.length);
+    const names = Array.from(rows).map((r) => r.textContent);
+    for (const layout of BUILT_IN_LAYOUTS) {
+      expect(names.some((n) => n?.includes(layout.name))).toBe(true);
+    }
+  });
+
+  it('calls onSelect with the layout id when a row is clicked', () => {
+    const { container, store } = setup();
+    const onSelect = vi.fn();
+    handle = mountLayoutListPanel(container, store, { onSelect });
+
+    container
+      .querySelector<HTMLElement>('[data-layout-id="title-body"]')!
+      .click();
+
+    expect(onSelect).toHaveBeenCalledWith('title-body');
+  });
+
+  it('marks the selected layout row and moves the marker on update', () => {
+    const { container, store } = setup();
+    handle = mountLayoutListPanel(container, store, {
+      selectedLayoutId: 'title-body',
+      onSelect: () => {},
+    });
+
+    const selected = () =>
+      container.querySelector<HTMLElement>('[data-selected="true"]')?.dataset
+        .layoutId;
+    expect(selected()).toBe('title-body');
+
+    handle.setSelectedLayoutId('big-number');
+    expect(selected()).toBe('big-number');
+  });
+
+  it('dispose removes the panel DOM and unsubscribes', () => {
+    const { container, store } = setup();
+    handle = mountLayoutListPanel(container, store, { onSelect: () => {} });
+    expect(container.querySelectorAll('[data-layout-id]').length).toBeGreaterThan(0);
+
+    handle.dispose();
+    handle = null;
+    expect(container.querySelectorAll('[data-layout-id]')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Completes PR3 of the slides theme builder (`20260507-slides-themes-layouts-import`) — the last open piece, **canvas layout-editing mode**: enter from the Theme panel's Customize tab → **Edit layout positions**, the left rail switches from slide thumbnails to a layouts list, and you drag a layout's placeholders on the canvas. Edits cascade to slides using that layout (re-flowing only placeholders the user hasn't moved).

### Approach — synthetic-slide reuse
Rather than build a second canvas editor, the existing `SlidesEditor` is fed a **transient slide built from a layout** and its geometry commits are rerouted:

- **`buildLayoutSlide` + `LayoutEditStore`** (`packages/slides`) — a `SlidesStore` proxy serving one synthetic slide from `read()`, routing `updateElementFrame` → `updateLayoutPlaceholderFrame`, with structural mutations as guarded no-ops (data can't leak into slides). `batch`/`onChange`/undo delegate, so one drag = one undo unit and edits repaint live slides.
- **Editor `layoutEditMode`** — `enterLayoutEditMode`/`exitLayoutEditMode` swap the editor's store (rebuilding key rules, which capture the store ref) and gate text-edit entry at the single `enterEditMode` chokepoint. The toolbar is naturally inert (the synthetic slide id isn't in the real store → `getToolbarState` returns idle).
- **`mountLayoutListPanel`** — a vanilla layouts rail (preview + name), shown by hiding the thumbnail host (not disposing it) so the existing `onChange`/rAF handlers stay intact.
- **Frontend wiring** — `layoutEditTarget` state is the single source of truth; the rail routes picks through it, and editor teardown (doc reload) exits cleanly.

### Self-review fixes folded in
Doc-reload safety, deleted-restore-slide fallback, re-entry guard, parse-the-id instead of rebuilding the synthetic slide per commit, and a **layout-preview cache** that keyed on ids while the theme builder mutates those objects in place (surfaced by the smoke test — the rail preview showed a stale bitmap; now keyed on rendered content + capped).

Design + plan: `docs/design/slides/slides-themes-layouts-import.md` (Commit 5 subsection) and the task todo/lessons.

## Test plan

- [x] `pnpm verify:fast` green (lint + ~5,800 unit tests across all packages), post-rebase on `main`.
- [x] **27 new unit tests** (TDD): `buildLayoutSlide` + deterministic ids, `LayoutEditStore` routing/undo/no-ops, editor enter/exit + drag→layout + text-edit gate, layout list panel, content-keyed preview cache + eviction.
- [x] Slides typecheck + build, frontend lint + build clean.
- [x] Self code-review (high effort, 7 angles) over the full diff; findings fixed.
- [ ] **Manual smoke** (UI): enter layout-edit → drag a placeholder (rail preview updates live) → confirm cascade to slides on that layout → Done restores prior slide; text-edit suppressed; single-undo. _In progress with the author._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
