### PR TITLE
Expose docs shortcuts missing from the help-modal catalog

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,8 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| docs shortcuts catalog (2026-06-28) | [20260628-docs-shortcuts-catalog-todo.md](./active/20260628-docs-shortcuts-catalog-todo.md) | [20260628-docs-shortcuts-catalog-lessons.md](./active/20260628-docs-shortcuts-catalog-lessons.md) |
+| release v0.4.8 (2026-06-28) | [20260628-release-v0.4.8-todo.md](./active/20260628-release-v0.4.8-todo.md) | - |
 | docs collaboration convergence (2026-06-25) | [20260625-docs-collaboration-convergence-todo.md](./active/20260625-docs-collaboration-convergence-todo.md) | [20260625-docs-collaboration-convergence-lessons.md](./active/20260625-docs-collaboration-convergence-lessons.md) |
 | docs wordprocessor (2026-03-25) | [20260325-docs-wordprocessor-todo.md](./active/20260325-docs-wordprocessor-todo.md) | [20260325-docs-wordprocessor-lessons.md](./active/20260325-docs-wordprocessor-lessons.md) |
 
@@ -26,4 +28,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 322
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: docs collaboration convergence (2026-06-25)
+Latest active task: docs shortcuts catalog (2026-06-28)

--- a/docs/tasks/active/20260325-docs-wordprocessor-todo.md
+++ b/docs/tasks/active/20260325-docs-wordprocessor-todo.md
@@ -49,4 +49,4 @@ Design doc: [docs-wordprocessor-roadmap.md](../../design/docs/docs-wordprocessor
 - [ ] 6.3 Spell Check
 - [x] 6.4 Print / PDF Export
 - [ ] 6.5 Named Styles
-- [ ] 6.6 Full Keyboard Shortcuts mapping
+- [x] 6.6 Full Keyboard Shortcuts mapping — single catalog (`shortcuts-catalog.ts`) + shared help modal (⌘/Ctrl+/); catalog drift fixed (heading 1–6, paste-formatting, word nav/delete now exposed). See [20260628-docs-shortcuts-catalog-todo.md](20260628-docs-shortcuts-catalog-todo.md)

--- a/docs/tasks/active/20260628-docs-shortcuts-catalog-lessons.md
+++ b/docs/tasks/active/20260628-docs-shortcuts-catalog-lessons.md
@@ -1,0 +1,31 @@
+# Docs Keyboard Shortcuts Catalog Drift — Lessons
+
+## What happened
+
+The roadmap item "6.6 Full Keyboard Shortcuts mapping" looked far from done on
+paper, but the infrastructure (single catalog, shared help modal, ⌘/Ctrl+/) was
+already shipped. The real gap was **catalog drift**: runtime bindings live in a
+plain `switch` in `text-editor.ts`, which is invisible to any static check, so
+five implemented shortcuts never appeared in the help modal.
+
+## Lessons
+
+- **A checkbox in a roadmap is not ground truth.** Audit the actual code before
+  estimating remaining work — here "0% / not started" was really "80% done, plus
+  a drift bug." Reading `handleKeyDown` end-to-end found gaps the first survey
+  missed (the initial pass only caught headings; word-nav, word-delete, and
+  paste-formatting were also undocumented).
+
+- **Non-symbolic dispatch invites drift.** A `switch`-based key handler has no
+  introspectable table, so the catalog and the bindings can diverge silently.
+  Mitigation used: a test that pins the known binding set + a header-comment
+  dual-edit convention (same approach Slides already adopted).
+
+- **Cross-platform honesty in a shortcuts reference.** `Cmd+Backspace` line-delete
+  is Mac-only in the handler; documenting it cross-platform would mislead
+  Windows/Linux users. Added a `WordMod` token (⌥ Mac / Ctrl elsewhere) so the
+  word-level combos render correctly per platform instead of faking `Alt`.
+
+- **TDD caught the WordMod formatting** before it shipped — the failing
+  `formatCombo('WordMod+…')` test forced the token into `formatCombo`, which is
+  easy to forget when only adding catalog rows.

--- a/docs/tasks/active/20260628-docs-shortcuts-catalog-todo.md
+++ b/docs/tasks/active/20260628-docs-shortcuts-catalog-todo.md
@@ -1,0 +1,57 @@
+# Docs Keyboard Shortcuts Catalog Drift Fix — Task Tracking
+
+Parent roadmap item: [6.6 Full Keyboard Shortcuts mapping](20260325-docs-wordprocessor-todo.md)
+Design doc: [docs-font-controls.md] / [docs-wordprocessor-roadmap.md](../../design/docs/docs-wordprocessor-roadmap.md)
+
+## Problem
+
+The docs editor already has the full keyboard-shortcuts infrastructure:
+single source-of-truth catalog (`packages/docs/src/view/shortcuts-catalog.ts`),
+a shared help modal (`ShortcutsHelpDialog`, opened by ⌘/Ctrl+/), and runtime
+bindings in `text-editor.ts`. But several **implemented** shortcuts are missing
+from the catalog, so the help modal silently omits them (catalog drift).
+
+### Missing from catalog (but implemented in `text-editor.ts`)
+
+- [x] Heading 1–6 — `Mod+Alt+1` … `Mod+Alt+6` (text-editor.ts ~L956)
+- [x] Paste formatting / apply format painter — `Mod+Alt+V` (text-editor.ts ~L934)
+- [x] Move caret by word — `WordMod+Arrow ←/→` (Alt on Mac, Ctrl elsewhere) (L743/751)
+- [x] Delete previous / next word — `WordMod+Backspace` / `WordMod+Delete` (L711/719)
+
+Intentionally NOT added (Mac-only / would mislead Windows users):
+- `Cmd+Backspace` line-delete (Mac only, `isMac && metaKey`)
+
+## Plan
+
+- [x] Add a `WordMod` token to `formatCombo` (⌥ on Mac, Ctrl elsewhere) — word nav/delete
+- [x] Add the missing entries to `SHORTCUTS` in the right categories
+- [x] Add a sync-convention note to the catalog header comment (mirror Slides)
+- [x] Add `packages/docs/test/view/shortcuts-catalog.test.ts` (TDD: write failing first)
+- [x] `pnpm verify:fast` green
+- [x] Tick 6.6 in the parent roadmap todo
+
+## Review
+
+**Outcome:** 6.6 was ~80% done — infra (single catalog, shared `ShortcutsHelpDialog`,
+⌘/Ctrl+/ entry) already shipped. The gap was catalog drift: bindings live in a
+non-symbolic `switch` in `text-editor.ts`, so five real shortcuts never reached
+the help modal. Audited the whole `handleKeyDown` and added the missing entries.
+
+**Changed files**
+- `packages/docs/src/view/shortcuts-catalog.ts` — `WordMod` token in `formatCombo`;
+  6 new entries (heading 1–6 collapsed into one multi-chip row, paste-formatting,
+  move-by-word, delete prev/next word); header comment now documents the dual-edit
+  convention.
+- `packages/docs/test/view/shortcuts-catalog.test.ts` — new; structure checks,
+  `formatCombo` (incl. `WordMod`), and an anti-drift assertion that every binding
+  shown above has a catalog combo.
+
+**Verification:** `pnpm --filter @wafflebase/docs test` → 995 passed / 1 skipped;
+`pnpm verify:fast` → EXIT 0.
+
+**Deliberately excluded:** `Cmd+Backspace` line-delete is Mac-only in the handler
+(`isMac && metaKey`); listing it cross-platform would mislead Windows/Linux users.
+
+**Known limitation:** no automated assertion binds the `switch` to the catalog
+(same as Slides). The new anti-drift test pins the *known* set but a brand-new
+binding still needs a manual catalog entry — the header comment flags this.

--- a/packages/docs/src/view/shortcuts-catalog.ts
+++ b/packages/docs/src/view/shortcuts-catalog.ts
@@ -4,8 +4,14 @@
  * few in the frontend, e.g. comments toggle); this catalog drives the
  * help modal opened by Cmd/Ctrl+/.
  *
+ * Keep this list in sync with `text-editor.ts handleKeyDown` whenever a
+ * binding is added or removed. The runtime handler is a `switch`, not a
+ * symbolic table, so there is no automated assertion that every binding
+ * has a catalog entry — dual-edit is the convention.
+ *
  * Keys use platform-neutral tokens:
- *   - `Mod`  — Cmd on macOS, Ctrl elsewhere
+ *   - `Mod`      — Cmd on macOS, Ctrl elsewhere
+ *   - `WordMod`  — Option (⌥) on macOS, Ctrl elsewhere (word-level nav/delete)
  *   - `Shift`, `Alt`
  *   - Named keys (`Enter`, `Tab`, `Esc`, `Arrow ↑`, …)
  *   - Printable letters in upper case (`A`, `B`, …)
@@ -37,9 +43,13 @@ export const SHORTCUTS: ReadonlyArray<ShortcutEntry> = [
   { category: 'Editing', keys: ['Mod+V'],               description: 'Paste' },
   { category: 'Editing', keys: ['Mod+Shift+V'],         description: 'Paste without formatting' },
   { category: 'Editing', keys: ['Mod+Shift+C'],         description: 'Copy formatting (format painter)' },
+  { category: 'Editing', keys: ['Mod+Alt+V'],           description: 'Paste formatting (apply format painter)' },
+  { category: 'Editing', keys: ['WordMod+Backspace'],   description: 'Delete previous word' },
+  { category: 'Editing', keys: ['WordMod+Delete'],      description: 'Delete next word' },
 
   // Navigation ----------------------------------------------------------
   { category: 'Navigation', keys: ['Arrow ←/→'],         description: 'Move caret by character' },
+  { category: 'Navigation', keys: ['WordMod+Arrow ←/→'], description: 'Move caret by word' },
   { category: 'Navigation', keys: ['Arrow ↑/↓'],         description: 'Move caret by line' },
   { category: 'Navigation', keys: ['Home', 'End'],       description: 'Go to start / end of line' },
   { category: 'Navigation', keys: ['Mod+Home', 'Mod+End'], description: 'Go to start / end of document' },
@@ -64,6 +74,7 @@ export const SHORTCUTS: ReadonlyArray<ShortcutEntry> = [
   { category: 'Paragraph', keys: ['Mod+Shift+8'],       description: 'Unordered (bulleted) list' },
   { category: 'Paragraph', keys: ['Mod+]', 'Mod+['],    description: 'Increase / decrease indent' },
   { category: 'Paragraph', keys: ['Mod+Alt+0'],         description: 'Reset block to paragraph' },
+  { category: 'Paragraph', keys: ['Mod+Alt+1', 'Mod+Alt+2', 'Mod+Alt+3', 'Mod+Alt+4', 'Mod+Alt+5', 'Mod+Alt+6'], description: 'Apply heading 1 – 6' },
   { category: 'Paragraph', keys: ['Mod+Enter'],         description: 'Insert page break' },
 
   // Find ---------------------------------------------------------------
@@ -93,6 +104,7 @@ export function formatCombo(combo: string, isMac: boolean): string {
     .map((part) => part.trim())
     .map((part) => {
       if (part === 'Mod') return mod;
+      if (part === 'WordMod') return isMac ? '⌥' : 'Ctrl';
       if (part === 'Shift') return isMac ? '⇧' : 'Shift';
       if (part === 'Alt') return isMac ? '⌥' : 'Alt';
       return part;

--- a/packages/docs/test/view/shortcuts-catalog.test.ts
+++ b/packages/docs/test/view/shortcuts-catalog.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { SHORTCUTS, formatCombo } from '../../src/view/shortcuts-catalog';
+
+describe('shortcuts catalog', () => {
+  it('every entry has at least one non-empty key combo', () => {
+    for (const entry of SHORTCUTS) {
+      expect(entry.keys.length).toBeGreaterThan(0);
+      for (const combo of entry.keys) {
+        expect(combo).not.toBe('');
+      }
+    }
+  });
+
+  it('every entry has a non-empty description', () => {
+    for (const entry of SHORTCUTS) {
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every entry uses a known category', () => {
+    const allowed = new Set([
+      'Editing', 'Navigation', 'Format', 'Paragraph',
+      'Find', 'Comments', 'History', 'Help',
+    ]);
+    for (const entry of SHORTCUTS) {
+      expect(allowed.has(entry.category)).toBe(true);
+    }
+  });
+
+  it('exposes every shortcut implemented in text-editor.ts (no catalog drift)', () => {
+    const combos = new Set(SHORTCUTS.flatMap((s) => s.keys));
+    // Heading 1–6
+    for (const level of [1, 2, 3, 4, 5, 6]) {
+      expect(combos.has(`Mod+Alt+${level}`)).toBe(true);
+    }
+    // Apply format painter (paste formatting)
+    expect(combos.has('Mod+Alt+V')).toBe(true);
+    // Word-level caret movement + deletion
+    expect(combos.has('WordMod+Arrow ←/→')).toBe(true);
+    expect(combos.has('WordMod+Backspace')).toBe(true);
+    expect(combos.has('WordMod+Delete')).toBe(true);
+  });
+
+  it('covers the high-visibility shortcuts', () => {
+    const descriptions = SHORTCUTS.map((s) => s.description.toLowerCase());
+    expect(descriptions.some((d) => d.includes('select all'))).toBe(true);
+    expect(descriptions.some((d) => d.includes('bold'))).toBe(true);
+    expect(descriptions.some((d) => d.includes('heading'))).toBe(true);
+    expect(descriptions.some((d) => d.includes('page break'))).toBe(true);
+    expect(descriptions.some((d) => d.includes('keyboard shortcuts'))).toBe(true);
+  });
+});
+
+describe('formatCombo', () => {
+  it('rewrites Mod to ⌘ on mac and Ctrl elsewhere', () => {
+    expect(formatCombo('Mod+A', true)).toBe('⌘A');
+    expect(formatCombo('Mod+A', false)).toBe('Ctrl+A');
+  });
+
+  it('combines modifiers correctly', () => {
+    expect(formatCombo('Mod+Shift+X', true)).toBe('⌘⇧X');
+    expect(formatCombo('Mod+Shift+X', false)).toBe('Ctrl+Shift+X');
+    expect(formatCombo('Mod+Alt+1', true)).toBe('⌘⌥1');
+    expect(formatCombo('Mod+Alt+1', false)).toBe('Ctrl+Alt+1');
+  });
+
+  it('rewrites WordMod to ⌥ on mac and Ctrl elsewhere', () => {
+    expect(formatCombo('WordMod+Backspace', true)).toBe('⌥Backspace');
+    expect(formatCombo('WordMod+Backspace', false)).toBe('Ctrl+Backspace');
+  });
+
+  it('preserves named keys', () => {
+    expect(formatCombo('Arrow ←/→', true)).toBe('Arrow ←/→');
+    expect(formatCombo('Enter', false)).toBe('Enter');
+  });
+});


### PR DESCRIPTION
## Summary

Completes roadmap item **6.6 Full Keyboard Shortcuts mapping** for Docs.

The docs keyboard-shortcuts infrastructure was already shipped — a single
source-of-truth catalog (`shortcuts-catalog.ts`), the shared `ShortcutsHelpDialog`,
and a `Cmd/Ctrl+/` entry point. The gap was **catalog drift**: runtime bindings
live in a non-symbolic `switch` in `text-editor.ts`, so several *implemented*
shortcuts never reached the catalog and were silently hidden from the help modal:

| Shortcut | Action | Handler |
|---|---|---|
| `Mod+Alt+1`…`6` | Apply heading 1–6 | text-editor.ts L956 |
| `Mod+Alt+V` | Paste formatting (apply format painter) | L934 |
| `WordMod+Arrow ←/→` | Move caret by word | L743/751 |
| `WordMod+Backspace` / `Delete` | Delete previous / next word | L711/719 |

### Changes
- Add the missing entries to `SHORTCUTS`.
- Add a `WordMod` token to `formatCombo` (Option `⌥` on macOS, `Ctrl` elsewhere)
  so word-level combos render correctly per platform instead of faking `Alt`.
- Document the dual-edit sync convention in the catalog header comment (mirrors
  the Slides catalog).
- New `shortcuts-catalog.test.ts`: structure checks, `formatCombo` (incl. `WordMod`),
  and an anti-drift assertion pinning the known binding set.

**Deliberately excluded:** `Cmd+Backspace` line-delete is Mac-only in the handler
(`isMac && metaKey`); listing it cross-platform would mislead Windows/Linux users.

## Test plan
- `pnpm --filter @wafflebase/docs test` → 995 passed / 1 skipped
- `pnpm verify:fast` → green
- Each catalogued combo cross-checked against `text-editor.ts handleKeyDown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer keyboard shortcuts catalog with more editing, navigation, and heading shortcuts.
  * Improved shortcut display so platform-specific modifier keys render correctly.

* **Bug Fixes**
  * Fixed missing shortcuts in the help view so it now matches available editor actions.
  * Resolved shortcut label drift between different screens.

* **Documentation**
  * Added task tracking and lessons learned notes for the shortcuts catalog update.
  * Updated the active tasks list and roadmap progress for keyboard shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->