### PR TITLE
Add external data sources design docs and task plans

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -20,6 +20,10 @@ Spreadsheet engine — data model, formulas, rendering, collaboration.
 | [batch-transactions.md](sheets/batch-transactions.md)                | Store-level batch transactions for atomic undo/redo grouping                                       |
 | [collaboration.md](sheets/collaboration.md)                          | Yorkie collaboration — worksheet storage, structural concurrency, and test strategy              |
 | [datasource.md](sheets/datasource.md)                                | External PostgreSQL datasources, multi-tab documents, SQL editor, ReadOnlyStore                    |
+| [lakehouse-connected-sheet.md](sheets/lakehouse-connected-sheet.md)  | Lakehouse connected sheet — read Iceberg/Delta open table formats from object storage via embedded DuckDB, time-travel slider over commit history, reuses datasource ReadOnlyStore spine |
+| [file-import.md](sheets/file-import.md)                              | File import — Excel `.xlsx` already ships (client-side, multi-sheet); adds CSV (papaparse) + Parquet/JSON via DuckDB; two-engine split (client-side parsers vs backend DuckDB), Import vs Connect |
+| [bigquery-connector.md](sheets/bigquery-connector.md)                | BigQuery connector — read-only BigQuery via native `@google-cloud/bigquery`; extends the datasource spine (not DuckDB); cost guardrails (dry-run + maximumBytesBilled) |
+| [mysql-connector.md](sheets/mysql-connector.md)                      | MySQL connector — read-only MySQL/MariaDB via native `mysql2`; extends the PostgreSQL datasource with an `engine` discriminator; smallest connector, reuses the datasource spine |
 | [axis-id-selection.md](sheets/axis-id-selection.md)                  | Axis ID based selection & presence — stable selection across remote structural edits              |
 | [comments.md](sheets/comments.md)                                    | Sheet cell comments — threaded comments, resolve flow, anchor stability, side panel UI            |
 

--- a/docs/design/sheets/bigquery-connector.md
+++ b/docs/design/sheets/bigquery-connector.md
@@ -71,7 +71,7 @@ model BigQuerySource {
   location    String?  // e.g. "US", "asia-northeast3"
   // service-account JSON key, AES-256-GCM encrypted (reuse crypto.util.ts)
   credentials String
-  maxBytesBilled BigInt? // per-connection ceiling (optional)
+  maximumBytesBilled BigInt? // per-connection ceiling (matches the BigQuery API name; optional)
   authorID    Int
   author      User      @relation(fields: [authorID], references: [id])
   workspaceId String

--- a/docs/design/sheets/bigquery-connector.md
+++ b/docs/design/sheets/bigquery-connector.md
@@ -1,0 +1,142 @@
+---
+title: bigquery-connector
+target-version: 0.5.0
+---
+
+# BigQuery Connector
+
+> Part of the External Data Sources initiative — see the [epic index](../../tasks/active/20260625-sheets-external-data-sources-todo.md).
+> Extends the existing [PostgreSQL datasource](datasource.md) pattern.
+
+## Summary
+
+Connect a Wafflebase document to **Google BigQuery** as a read-only datasource:
+write GoogleSQL `SELECT` queries and render results in a read-only tab. It
+reuses the existing datasource read-only spine — encrypted credentials, the
+SELECT-only validator, the `{ columns, rows, … }` response shape, and the
+`ReadOnlyStore` — and swaps the `pg` client for the **native
+`@google-cloud/bigquery`** client. The one BigQuery-specific addition is **cost
+guardrails**, because BigQuery bills by bytes scanned.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Read-only BigQuery query results in a sheet tab, reusing the datasource spine.
+- Service-account authentication with the key **encrypted at rest** (reuse
+  `crypto.util.ts`).
+- **Cost guardrails**: dry-run byte/cost estimate, a `maximumBytesBilled`
+  ceiling, and a pre-run warning.
+- Dataset / table / column schema browser.
+
+### Non-Goals
+
+- Writing back to BigQuery.
+- Other warehouses (Snowflake, Redshift) — separate connectors later.
+- BI Engine / streaming / continuous queries.
+
+## Architecture Overview
+
+This extends the existing datasource family:
+
+```
+  Frontend (reuses datasource view shell)
+   BigQueryDialog · SQL editor · cost-estimate banner · results grid
+        │ REST API
+   Backend BigQueryModule
+   ┌──────────────┬────────────────┬─────────────────────┐
+   │ Controller   │ Service        │ Crypto (AES-256)    │
+   │ (REST)       │ (@google-cloud │ (reuse crypto.util) │
+   │              │  /bigquery)    │                     │
+   └──────────────┴───────┬────────┴─────────────────────┘
+        Prisma            │ service-account key (decrypted per request)
+   BigQuerySource row     ▼
+                     Google BigQuery  ── dry-run estimate + maximumBytesBilled
+```
+
+Compared to the existing PostgreSQL datasource, only the **driver** (pg →
+`@google-cloud/bigquery`), the **auth** (password → service-account JSON), and
+the **cost guardrails** differ; everything else is shared.
+
+## Proposal Details
+
+### 1. Connection model (Prisma)
+
+```prisma
+model BigQuerySource {
+  id          String   @id @default(uuid())
+  name        String
+  projectId   String
+  dataset     String?  // default dataset (optional)
+  location    String?  // e.g. "US", "asia-northeast3"
+  // service-account JSON key, AES-256-GCM encrypted (reuse crypto.util.ts)
+  credentials String
+  maxBytesBilled BigInt? // per-connection ceiling (optional)
+  authorID    Int
+  author      User      @relation(fields: [authorID], references: [id])
+  workspaceId String
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+}
+```
+
+### 2. Query execution (native client)
+
+- `@google-cloud/bigquery` client, authenticated from the decrypted
+  service-account key.
+- Reuse the SELECT/WITH-only validator (GoogleSQL dialect) and the 10,000-row
+  cap; map result schema + rows to the shared
+  `{ columns: [{name, dataTypeID}], rows, rowCount, truncated, executionTime }`
+  shape → `ReadOnlyStore` + `toCell` render unchanged (BigQuery STRUCT/ARRAY →
+  JSON-string cells, like nested JSON).
+
+### 3. Cost guardrails (the BigQuery-specific part)
+
+BigQuery charges by **bytes scanned**, and a `LIMIT` does **not** reduce the
+scan (full scan unless the table is partitioned/clustered). So:
+
+- **Dry run** (`dryRun: true`) before execution → returns
+  `totalBytesProcessed`; surface an estimated bytes/cost banner.
+- **`maximumBytesBilled`** ceiling (per-connection + per-query) → BigQuery hard-
+  fails a query that would exceed it, so a runaway scan cannot bill.
+- **Warning UI** when the estimate exceeds a threshold; require confirmation.
+
+### 4. Schema browser
+
+List datasets → tables → columns (BigQuery metadata API) in a sidebar, so users
+don't have to memorize names; click to insert into the editor.
+
+### 5. Frontend
+
+Reuse the datasource view shell: a `BigQueryDialog` (project/dataset + key
+upload + test), a SQL editor view, and a **cost-estimate banner** above the
+Run button.
+
+## Test Strategy
+
+- **Unit** (no network): validator, response-shape mapping, credential masking,
+  cost-threshold logic — with the BigQuery client mocked.
+- **Integration** (gated, e.g. `RUN_BIGQUERY_INTEGRATION_TESTS`): against a real
+  BigQuery project using the **free tier** (1 TB/month query, 10 GB storage),
+  scoped to a tiny fixture dataset; service-account key via repo secrets, never
+  on fork PRs. Dry-run/`maximumBytesBilled` assertions covered here.
+- There is no first-party local BigQuery emulator; integration tests therefore
+  use the free tier rather than an emulator.
+
+## Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| **Runaway query cost** (bytes scanned) | Dry-run estimate + `maximumBytesBilled` ceiling + warning UI; default a conservative per-connection cap. |
+| Service-account key exposure | AES-256-GCM at rest (`crypto.util.ts`); masked in API responses; decrypt only per request. |
+| Over-broad key permissions | Document least-privilege (BigQuery Data Viewer + Job User); never request write scopes. |
+| No local emulator for CI | Gate integration tests; use the free tier with a tiny fixture; unit tests mock the client. |
+| Result size / cost on large tables | 10k-row cap + dry-run; encourage partition/cluster-aware queries in docs. |
+
+## References
+
+- [External Data Sources epic index](../../tasks/active/20260625-sheets-external-data-sources-todo.md) — umbrella + future roadmap
+- [datasource.md](datasource.md) — read-only spine this extends
+- `@google-cloud/bigquery` Node client: <https://cloud.google.com/nodejs/docs/reference/bigquery/latest>
+- BigQuery dry-run / `maximumBytesBilled`: <https://cloud.google.com/bigquery/docs/best-practices-costs>

--- a/docs/design/sheets/file-import.md
+++ b/docs/design/sheets/file-import.md
@@ -1,0 +1,170 @@
+---
+title: file-import
+target-version: 0.5.0
+---
+
+# File Import — CSV / Parquet / JSON / Excel
+
+> Part of the External Data Sources initiative — see the [epic index](../../tasks/active/20260625-sheets-external-data-sources-todo.md). The new
+> formats here build on the embedded DuckDB engine from
+> [lakehouse-connected-sheet.md](lakehouse-connected-sheet.md); the existing
+> client-side path does **not** need DuckDB.
+
+## Summary
+
+Let users bring a **data file** — CSV, Parquet, newline-JSON, or Excel
+(`.xlsx`) — into a Wafflebase document, either as an editable sheet (**Import**)
+or a read-only tab (**Connect**).
+
+Crucially, **Excel import already exists** and the design must not reinvent it.
+This doc's job is to (1) record what already ships, (2) add the missing formats
+(Parquet, JSON, and remote/large CSV), and (3) define the **two-engine split**
+between the existing client-side parser path and the new backend DuckDB path.
+
+## Current state (what already ships)
+
+| Capability | Status | Where |
+|------------|--------|-------|
+| **`.xlsx` import** | ✅ **Shipped** (PR #270) — **multi-sheet**, client-side, materializes to editable `sheet` tabs | `packages/sheets/src/import/xlsx-importer.ts` (`importXlsxWorkbook` / `importXlsxFile`), `packages/frontend/src/app/spreadsheet/xlsx-actions.ts` (`pickAndImportXlsx`) |
+| CSV import | ⚠️ **Not wired** — `papaparse` is already a dependency of `@wafflebase/sheets` but unused | `packages/sheets/package.json` |
+| Parquet / JSON import | ❌ none | — |
+| Remote / object-storage file Connect | ❌ none | — |
+
+The shipped XLSX path is fully **client-side**: it unzips the workbook in the
+browser, parses `xl/workbook.xml` + `sharedStrings.xml` + each worksheet, and
+builds a `SpreadsheetDocument` of editable sheets — no server round-trip, no
+native engine. This is the right model for "open this spreadsheet file", and it
+should stay as-is.
+
+## Goals / Non-Goals
+
+### Goals
+
+- **CSV import (quick win)** — wire up the already-present `papaparse` for
+  small local CSV → editable sheet, mirroring the XLSX path. No DuckDB.
+- **Parquet & JSON import** — formats with no practical client-side reader;
+  parse via the **backend embedded DuckDB** engine and materialize.
+- **Remote / object-storage Connect** — point at `https://…` or `s3://…`
+  (CSV/Parquet/JSON, glob/partitioned) and render a read-only tab via DuckDB +
+  `ReadOnlyStore`.
+- **Large-file path** — when a file exceeds the client materialize cap, route
+  it through the backend (DuckDB) and offer Connect instead of choking the
+  browser/Yorkie doc.
+- Reuse the existing S3 upload infra for backend-parsed uploads.
+
+### Non-Goals
+
+- **Re-implementing XLSX import** — it already exists and is multi-sheet; only
+  incremental polish (e.g., styles/formulas fidelity) is in scope, tracked
+  separately.
+- Writing edited cells back to the source file (export is a separate roadmap
+  item).
+- Schema mapping UI / transforms beyond header + type inference (later).
+
+## Proposal Details
+
+### 1. Two engines, by purpose
+
+The key design decision: **don't force everything through one path.**
+
+| Engine | Best for | Mode | Round-trip |
+|--------|----------|------|-----------|
+| **Client-side parsers** (existing XLSX; CSV via `papaparse`) | small local uploads of "spreadsheet-shaped" files | Import (materialize, editable) | none — runs in browser |
+| **Backend DuckDB** (new) | Parquet, JSON, large CSV, remote/object files | Import (large) **and** Connect (read-only) | upload or read-in-place |
+
+XLSX stays client-side (it works and avoids a server hop). CSV gets the same
+client-side treatment for small files. DuckDB is added only where the browser
+can't reasonably go: Parquet, JSON, big files, and remote/object sources.
+
+### 2. CSV import (client-side, quick win)
+
+- Add a CSV branch beside `pickAndImportXlsx` in
+  `packages/frontend/src/app/spreadsheet/xlsx-actions.ts` (or a sibling
+  `csv-actions.ts`) using the already-installed `papaparse`.
+- Parse → build a one-sheet `SpreadsheetDocument` via the same
+  `createSpreadsheetDocumentFromImportedXlsxSheets` shape → editable sheet.
+- Header detection + basic type coercion (numbers/dates) on import.
+
+### 3. Parquet / JSON / large-file import (backend DuckDB)
+
+- **Upload endpoint** stores the file via the existing S3 bucket infra
+  (`packages/backend/src/image/image.service.ts` pattern: `S3Client`, MinIO
+  `forcePathStyle`, bucket auto-create) under a short-lived `imports/` key.
+- **Parse via DuckDB**: `read_parquet(...)`, `read_json_auto(...)`,
+  `read_csv_auto(...)` for large CSV.
+- **Preview** returns first N rows + inferred columns (the datasource
+  `{ columns, rows, truncated, … }` shape) so the user confirms before
+  materializing.
+- **Materialize** through the standard `Store` write path (the same one used
+  for paste/fill) into an editable `sheet` tab, capped by a materialize limit;
+  above the cap, suggest Connect.
+
+### 4. Connect mode (remote / object-storage files)
+
+Identical to a lakehouse tab but pointed at a raw file (or glob) rather than an
+OTF table:
+
+- Tab metadata stores the file URI + format.
+- Read into `ReadOnlyStore`; **no** time-travel slider (raw files have no commit
+  history — that is the OTF differentiator).
+
+### 5. Frontend
+
+- Extend the existing import entry point: file picker / drag-and-drop / URL
+  field → detect format from extension/content → route:
+  - `.xlsx` → existing client-side importer (unchanged).
+  - `.csv` (small) → client-side `papaparse`.
+  - `.parquet` / `.json` / large / remote → backend DuckDB (preview →
+    Import or Connect).
+- Reuse `tab-bar.tsx` for the resulting tab and the datasource/lakehouse view
+  shell for the Connect preview.
+
+### 6. Format support matrix (target)
+
+| Format | Import | Connect | Engine |
+|--------|--------|---------|--------|
+| Excel `.xlsx` (multi-sheet) | ✅ **already shipped** | — | client-side (sheets pkg) |
+| CSV / TSV (small) | ➕ quick win | — | client-side `papaparse` |
+| CSV / TSV (large / remote / object) | ➕ new | ➕ new | backend DuckDB |
+| Parquet (single / partitioned glob) | ➕ new | ➕ new | backend DuckDB |
+| JSON (ndjson / array) | ➕ new | ➕ new | backend DuckDB |
+
+(✅ shipped · ➕ proposed)
+
+## Current Limitations
+
+1. XLSX importer fidelity (styles/formulas) is out of scope here — tracked
+   separately.
+2. Import is capped by the Yorkie materialize limit; large files must use
+   Connect.
+3. DuckDB type inference may need manual reformat for ambiguous columns.
+4. No transform/cleaning step (split, trim, pivot) at import time — edit after.
+
+## Rollout
+
+- **Phase 1** — CSV import (client-side `papaparse`) — smallest change, mirrors
+  the shipped XLSX path.
+- **Phase 2** — Parquet/JSON import via backend DuckDB (upload → preview →
+  materialize), reusing S3 upload infra.
+- **Phase 3** — Remote/object-storage **Connect** for raw files
+  (glob/Hive partitioning) + large-file routing (Connect suggestion at the cap).
+
+## Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Duplicating the existing XLSX importer | Explicitly out of scope; new work targets only CSV + DuckDB-backed formats. |
+| Untrusted uploaded files | Size limits; DuckDB read-only scan; isolate the `imports/` S3 prefix; TTL cleanup. |
+| Huge files bloating the Yorkie document | Materialize cap; suggest Connect mode above the cap. |
+| Two engines diverging in behavior | Both produce the same `SpreadsheetDocument` / `{ columns, rows, … }` shape; share header/type-coercion helpers where possible. |
+| S3 temp storage growth | Short-lived `imports/` keys, deleted post-import or by lifecycle/TTL. |
+
+## References
+
+- Existing XLSX importer: `packages/sheets/src/import/xlsx-importer.ts` (PR #270)
+- [External Data Sources epic index](../../tasks/active/20260625-sheets-external-data-sources-todo.md) — umbrella + future roadmap
+- [lakehouse-connected-sheet.md](lakehouse-connected-sheet.md) — DuckDB engine
+- [datasource.md](datasource.md) — read-only spine + response shape
+- DuckDB CSV import: <https://duckdb.org/docs/data/csv/overview>
+- DuckDB Parquet: <https://duckdb.org/docs/data/parquet/overview>
+- DuckDB JSON: <https://duckdb.org/docs/data/json/overview>

--- a/docs/design/sheets/file-import.md
+++ b/docs/design/sheets/file-import.md
@@ -42,8 +42,10 @@ should stay as-is.
 
 - **CSV import (quick win)** — wire up the already-present `papaparse` for
   small local CSV → editable sheet, mirroring the XLSX path. No DuckDB.
-- **Parquet & JSON import** — formats with no practical client-side reader;
-  parse via the **backend embedded DuckDB** engine and materialize.
+- **Parquet & JSON import** — small local files parse client-side (`hyparquet`
+  for Parquet, `JSON.parse` for JSON); large/remote files parse via the
+  **backend embedded DuckDB** engine and materialize. The split is by
+  size/location, not format (see §1).
 - **Remote / object-storage Connect** — point at `https://…` or `s3://…`
   (CSV/Parquet/JSON, glob/partitioned) and render a read-only tab via DuckDB +
   `ReadOnlyStore`.
@@ -69,27 +71,33 @@ The key design decision: **don't force everything through one path.**
 
 | Engine | Best for | Mode | Round-trip |
 |--------|----------|------|-----------|
-| **Client-side parsers** (existing XLSX; CSV via `papaparse`) | small local uploads of "spreadsheet-shaped" files | Import (materialize, editable) | none — runs in browser |
-| **Backend DuckDB** (new) | Parquet, JSON, large CSV, remote/object files | Import (large) **and** Connect (read-only) | upload or read-in-place |
+| **Client-side parsers** (existing XLSX; CSV via `papaparse`; small Parquet via `hyparquet`; small JSON via `JSON.parse`) | small local uploads | Import (materialize, editable) | none — runs in browser |
+| **Backend DuckDB** (new) | large CSV/Parquet/JSON, remote/object files | Import (large) **and** Connect (read-only) | upload or read-in-place |
 
-XLSX stays client-side (it works and avoids a server hop). CSV gets the same
-client-side treatment for small files. DuckDB is added only where the browser
-can't reasonably go: Parquet, JSON, big files, and remote/object sources.
+XLSX stays client-side (it works and avoids a server hop). CSV, and small
+Parquet/JSON, get the same client-side treatment. DuckDB is added only where the
+browser can't reasonably go: large files and remote/object sources.
 
 ### 2. CSV import (client-side, quick win)
 
 - Add a CSV branch beside `pickAndImportXlsx` in
   `packages/frontend/src/app/spreadsheet/xlsx-actions.ts` (or a sibling
   `csv-actions.ts`) using the already-installed `papaparse`.
-- Parse → build a one-sheet `SpreadsheetDocument` via the same
-  `createSpreadsheetDocumentFromImportedXlsxSheets` shape → editable sheet.
+- Parse → build a one-sheet `SpreadsheetDocument` → editable sheet. The existing
+  `createSpreadsheetDocumentFromImportedXlsxSheets` is typed for
+  `ImportedXlsxSheet[]` (multi-sheet, XLSX-specific metadata like `cellCount`),
+  so CSV either gets a small generic helper extracted from it
+  (`createSpreadsheetDocumentFromImportedSheets`, taking a flat sheet shape) or a
+  CSV-specific builder — don't force CSV through the XLSX-shaped abstraction.
 - Header detection + basic type coercion (numbers/dates) on import.
 
-### 3. Parquet / JSON / large-file import (backend DuckDB)
+### 3. Large / remote Parquet / JSON / CSV import (backend DuckDB)
 
-- **Upload endpoint** stores the file via the existing S3 bucket infra
-  (`packages/backend/src/image/image.service.ts` pattern: `S3Client`, MinIO
-  `forcePathStyle`, bucket auto-create) under a short-lived `imports/` key.
+- **Upload endpoint** stores the file in S3. Reuse only the underlying
+  `S3Client` configuration from `image.service.ts` (endpoint, credentials,
+  bucket, MinIO `forcePathStyle`, bucket auto-create) — not its image-specific
+  processing. Extract a generic `StorageService` / `S3Service` rather than
+  depending on the image domain. Store under a short-lived `imports/` key.
 - **Parse via DuckDB**: `read_parquet(...)`, `read_json_auto(...)`,
   `read_csv_auto(...)` for large CSV.
 - **Preview** returns first N rows + inferred columns (the datasource
@@ -114,8 +122,8 @@ OTF table:
   field → detect format from extension/content → route:
   - `.xlsx` → existing client-side importer (unchanged).
   - `.csv` (small) → client-side `papaparse`.
-  - `.parquet` / `.json` / large / remote → backend DuckDB (preview →
-    Import or Connect).
+  - `.parquet` (small) → client-side `hyparquet`; `.json` (small) → `JSON.parse`.
+  - large / remote / object → backend DuckDB (preview → Import or Connect).
 - Reuse `tab-bar.tsx` for the resulting tab and the datasource/lakehouse view
   shell for the Connect preview.
 
@@ -126,8 +134,10 @@ OTF table:
 | Excel `.xlsx` (multi-sheet) | ✅ **already shipped** | — | client-side (sheets pkg) |
 | CSV / TSV (small) | ➕ quick win | — | client-side `papaparse` |
 | CSV / TSV (large / remote / object) | ➕ new | ➕ new | backend DuckDB |
-| Parquet (single / partitioned glob) | ➕ new | ➕ new | backend DuckDB |
-| JSON (ndjson / array) | ➕ new | ➕ new | backend DuckDB |
+| Parquet (small local) | ➕ new | — | client-side `hyparquet` |
+| Parquet (large / partitioned glob / remote) | ➕ new | ➕ new | backend DuckDB |
+| JSON (small local, ndjson / array) | ➕ new | — | client-side `JSON.parse` |
+| JSON (large / remote) | ➕ new | ➕ new | backend DuckDB |
 
 (✅ shipped · ➕ proposed)
 
@@ -154,7 +164,7 @@ OTF table:
 | Risk | Mitigation |
 |------|------------|
 | Duplicating the existing XLSX importer | Explicitly out of scope; new work targets only CSV + DuckDB-backed formats. |
-| Untrusted uploaded files | Size limits; DuckDB read-only scan; isolate the `imports/` S3 prefix; TTL cleanup. |
+| Untrusted uploaded files | A restricted DuckDB connection: disable extensions that can fetch/exfiltrate (`httpfs`, `sqlite_scanner`, `fts`), cap `memory_limit` + `threads=1`, and expose only an allowlist of import functions (`read_parquet`/`read_csv_auto`/`read_json_auto`) — **no raw SQL passthrough** on the import path. Magic-number check before ingestion (e.g. Parquet `PAR1`). Isolate the `imports/` S3 prefix with TTL cleanup; run DuckDB in a sandboxed process/container where feasible. |
 | Huge files bloating the Yorkie document | Materialize cap; suggest Connect mode above the cap. |
 | Two engines diverging in behavior | Both produce the same `SpreadsheetDocument` / `{ columns, rows, … }` shape; share header/type-coercion helpers where possible. |
 | S3 temp storage growth | Short-lived `imports/` keys, deleted post-import or by lifecycle/TTL. |

--- a/docs/design/sheets/lakehouse-connected-sheet.md
+++ b/docs/design/sheets/lakehouse-connected-sheet.md
@@ -135,15 +135,22 @@ type LakehouseTableRef = {
 };
 
 type TimeTravelPoint =
-  | { kind: "version"; version: number }      // Delta version / Iceberg sequence
+  | { kind: "version"; version: number }      // integer; interpreted per the source format (Delta version / Iceberg sequence)
   | { kind: "snapshot"; snapshotId: string }  // Iceberg snapshot id
   | { kind: "timestamp"; iso: string };       // point-in-time
 ```
 
+A bare integer is ambiguous on its own, but `asOf` is always resolved in the
+context of the connection's `format` (Delta vs Iceberg), so `kind: "version"`
+needs no further split; Iceberg's stable snapshot id is the `"snapshot"` variant.
+
 Lakehouse tabs store **only metadata** in `tabs[tabId]`; the rows are ephemeral
 and loaded into a `ReadOnlyStore` on read, exactly like datasource tabs.
 Persisting `lakehouseRef` + `asOf` to Yorkie means collaborators open the same
-table at the same point in time.
+table at the same point in time. Because these are new Yorkie-persisted
+`TabMeta` fields, `worksheet-shape-migration.ts` must tolerate old documents
+that lack them (treat missing `lakehouseSourceId`/`lakehouseRef`/`asOf` as
+`undefined` — no backfill needed); cover this in the migration's tests.
 
 ### 2. Connection Model (Prisma)
 
@@ -162,9 +169,12 @@ model LakehouseSource {
   region        String?
   bucket        String?
   basePath      String?  // table root or metadata path
-  catalogMode   String   @default("direct-metadata") // | "rest-catalog" | "s3-tables" | "unity"
+  catalogMode   CatalogMode @default(direct_metadata)
   catalogUri    String?
-  // credentials, AES-256-GCM encrypted (one packed JSON blob: accessKey/secretKey/sasToken/oauth)
+  // credentials, AES-256-GCM encrypted (one packed JSON blob: accessKey/secretKey/sasToken/oauth).
+  // Optional only because the credential blob is written in a second step after
+  // the row is created (matching the datasource create→test→save flow); a saved,
+  // usable connection always has credentials.
   credentials   String?
   authorID      Int
   author        User      @relation(fields: [authorID], references: [id])
@@ -172,6 +182,15 @@ model LakehouseSource {
   workspace     Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
+
+  @@unique([workspaceId, name]) // no duplicate connection names within a workspace
+}
+
+enum CatalogMode {
+  direct_metadata
+  rest_catalog
+  s3_tables
+  unity
 }
 ```
 

--- a/docs/design/sheets/lakehouse-connected-sheet.md
+++ b/docs/design/sheets/lakehouse-connected-sheet.md
@@ -1,0 +1,451 @@
+---
+title: lakehouse-connected-sheet
+target-version: 0.5.0
+---
+
+# Lakehouse Connected Sheet
+
+## Summary
+
+A **Lakehouse Connected Sheet** lets users point a Wafflebase document at an
+**open table format** (OTF) — **Apache Iceberg** or **Delta Lake** — sitting in
+object storage (S3, GCS, Azure Blob, MinIO), and browse it inside a read-only
+spreadsheet tab. Because these formats keep a metadata layer of immutable
+**snapshots / versions**, the tab adds a **time-travel slider**: dragging the
+slider re-reads the table *as of* a past commit and repaints the grid, turning
+"observe how this table changed over time" from a manual SQL chore (re-running
+queries with different snapshot predicates) into a single draggable timeline.
+
+This builds directly on the existing
+[Data Sources](datasource.md) feature. It reuses the same read-only
+spreadsheet spine — encrypted-credential storage, a SELECT-only validator, the
+`{ columns, rows, … }` query response shape, and the `ReadOnlyStore` in the
+sheet engine — and swaps the PostgreSQL `pg` client for an **embedded DuckDB**
+engine (`@duckdb/node-api`) that reads OTFs natively.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Connect a Wafflebase document to an Iceberg or Delta Lake table in object
+  storage and render it in a read-only tab.
+- Support the common object-storage backends: Amazon S3, S3-compatible
+  (MinIO, Cloudflare R2, …), Google Cloud Storage, and Azure Blob / ADLS.
+- Provide a **time-travel slider** over the table's commit history (snapshot
+  id for Iceberg, version number for Delta) that re-queries the table *as of*
+  the selected commit.
+- Keep object-storage credentials encrypted at rest, reusing the datasource
+  AES-256-GCM scheme.
+- Reuse the existing read-only rendering path (`ReadOnlyStore`, `toCell`) and
+  multi-tab document structure unchanged.
+- Persist the chosen table reference and time-travel point to the Yorkie
+  document so collaborators see the same view.
+
+### Non-Goals
+
+- **Apache Hudi** support (deferred — see [Technical Verification](#5-technical-verification)).
+- Writing back to lakehouse tables (read-only, like datasource tabs).
+- A general SQL-over-lakehouse editor in v1 (queries are table scans with an
+  optional `asOf`; ad-hoc SQL is a later phase).
+- Sub-commit time travel (granularity is per-commit, not arbitrary instants).
+- Running DuckDB in the browser (DuckDB-Wasm) — the engine runs in the backend
+  (see the pure-JS note in Technical Verification for the future browser path).
+- A hosted query API (MotherDuck) — the engine is embedded in our backend.
+
+## Architecture Overview
+
+The design intentionally mirrors [`datasource.md`](datasource.md); only the
+shaded boxes are new.
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Frontend                                                  │
+│  ┌──────────┐  ┌──────────────┐  ┌─────────────────────┐   │
+│  │  TabBar  │  │ Lakehouse    │  │ LakehouseView       │   │
+│  │ Sheet│DS │  │ Selector     │  │  - table picker     │   │
+│  │   │LH    │  │              │  │  - TimeTravelSlider │   │ ← new
+│  └──────────┘  └──────────────┘  │  - results grid     │   │
+│                                  └─────────┬───────────┘   │
+│  ┌──────────────────┐  ┌──────────────────┐│               │
+│  │ LakehouseDialog  │  │ ReadOnlyStore    ││ (reused)      │
+│  │ (create/edit)    │  │ (sheet engine)   ││               │
+│  └──────────────────┘  └──────────────────┘│               │
+└─────────────────────────────────────┬──────┴───────────────┘
+                                      │ REST API
+┌─────────────────────────────────────┴──────────────────────┐
+│  Backend (NestJS)                                          │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │ LakehouseModule                                     │   │
+│  │  ┌────────────┐ ┌────────────────┐ ┌─────────────┐  │   │
+│  │  │ Controller │ │ Service        │ │ SQL/scan    │  │   │
+│  │  │ (REST API) │ │ (DuckDB Neo)   │ │ validator   │  │   │
+│  │  └────────────┘ └───────┬────────┘ └─────────────┘  │   │
+│  │  ┌────────────┐         │ INSTALL/LOAD iceberg,     │   │
+│  │  │ Crypto     │         │ delta, httpfs, azure      │   │
+│  │  │ (AES-256)  │         │ CREATE SECRET (creds)     │   │
+│  │  └────────────┘         ▼                           │   │
+│  └─────────────────┬───────────────────────────────────┘   │
+│        Prisma      │                  embedded DuckDB      │
+│  ┌─────────────────┴────────┐   (in-process, native dep)   │
+│  │ PostgreSQL               │              │               │
+│  │ (LakehouseSource rows)   │              ▼               │
+│  └──────────────────────────┘   Object storage (S3/GCS/    │
+│                                  Azure/MinIO) — Iceberg /  │
+│                                  Delta metadata + parquet  │
+└────────────────────────────────────────────────────────────┘
+```
+
+**Key point on deployment:** DuckDB is **embedded** in the NestJS process via
+`@duckdb/node-api` — a native npm dependency that ships prebuilt binaries, just
+like the `pg` client is a dependency today. There is **no separate DuckDB
+service and no external API to call.** The backend reads object storage
+directly using the stored, decrypted credentials, keeping the trust boundary
+identical to the current PostgreSQL datasource path.
+
+## Proposal Details
+
+### 1. Multi-Tab Document Structure
+
+Reuse the existing `SpreadsheetDocument` / `TabMeta` structure (canonical in
+[`collaboration.md`](collaboration.md)). Add a third tab type and two
+lakehouse-specific fields:
+
+```typescript
+type TabType = "sheet" | "datasource" | "lakehouse";
+
+type TabMeta = {
+  id: string;
+  name: string;
+  type: TabType;
+  // datasource tabs
+  datasourceId?: string;
+  query?: string;
+  // lakehouse tabs (new)
+  lakehouseSourceId?: string;       // FK to the connection
+  lakehouseRef?: LakehouseTableRef; // which table (catalog/namespace/table or metadata URI)
+  asOf?: TimeTravelPoint;           // selected commit; undefined = latest
+};
+
+type LakehouseTableRef = {
+  // direct-metadata mode (no catalog):
+  metadataUri?: string;             // e.g. s3://bucket/db/table  (Delta) or .../metadata.json (Iceberg)
+  // catalog mode:
+  namespace?: string[];
+  table?: string;
+};
+
+type TimeTravelPoint =
+  | { kind: "version"; version: number }      // Delta version / Iceberg sequence
+  | { kind: "snapshot"; snapshotId: string }  // Iceberg snapshot id
+  | { kind: "timestamp"; iso: string };       // point-in-time
+```
+
+Lakehouse tabs store **only metadata** in `tabs[tabId]`; the rows are ephemeral
+and loaded into a `ReadOnlyStore` on read, exactly like datasource tabs.
+Persisting `lakehouseRef` + `asOf` to Yorkie means collaborators open the same
+table at the same point in time.
+
+### 2. Connection Model (Prisma)
+
+Add a `LakehouseSource` model alongside `DataSource`
+(`packages/backend/prisma/schema.prisma`). It keeps the same workspace-scoped
+ownership (`workspaceId`, `authorID`) and reuses the AES-256-GCM credential
+encryption.
+
+```prisma
+model LakehouseSource {
+  id            String   @id @default(uuid())
+  name          String
+  format        String   // "iceberg" | "delta"
+  storage       String   // "s3" | "s3-compatible" | "gcs" | "azure" | "local"
+  endpoint      String?  // custom endpoint (MinIO/R2/GCS-interop)
+  region        String?
+  bucket        String?
+  basePath      String?  // table root or metadata path
+  catalogMode   String   @default("direct-metadata") // | "rest-catalog" | "s3-tables" | "unity"
+  catalogUri    String?
+  // credentials, AES-256-GCM encrypted (one packed JSON blob: accessKey/secretKey/sasToken/oauth)
+  credentials   String?
+  authorID      Int
+  author        User      @relation(fields: [authorID], references: [id])
+  workspaceId   String
+  workspace     Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+}
+```
+
+Credentials are encrypted with the existing
+`packages/backend/src/datasource/crypto.util.ts` (`DATASOURCE_ENCRYPTION_KEY`),
+masked in all API responses, and decrypted only to mint a DuckDB secret.
+
+### 3. Backend Lakehouse Module
+
+Located at `packages/backend/src/lakehouse/`, mirroring the datasource module
+layout (service / controller / DTO / validator + reused crypto).
+
+#### DuckDB query service (embedded)
+
+- `LakehouseService` owns a **long-lived** DuckDB instance and a small
+  connection pool. **Do not** create a fresh instance per request — DuckDB is
+  in-process, so a singleton instance with per-query connections amortizes the
+  extension-load cost.
+- On first use, `INSTALL` / `LOAD` the `iceberg`, `delta`, and `httpfs` /
+  `azure` extensions (auto-downloaded from DuckDB's extension repo, or
+  pre-bundled into the backend image for locked-down networks).
+- Per query: `CREATE SECRET` from the decrypted credentials (scoped to the
+  request), then run a wrapped read:
+  - **Iceberg, direct metadata:** `iceberg_scan('s3://…/metadata/….metadata.json')`.
+  - **Iceberg, catalog:** `ATTACH` an Iceberg REST catalog / S3 Tables, then
+    `SELECT … FROM <ns>.<table>`.
+  - **Delta:** `delta_scan('s3://…/table')`.
+- Reuse the datasource guardrails: a SELECT/scan-only validator (adapted from
+  `sql-validator.ts`), a `LIMIT 10001` wrap with a 10,000-row truncation flag,
+  and statement / connection timeouts.
+
+#### Query response shape (identical to datasource)
+
+```typescript
+{
+  columns: Array<{ name: string; dataTypeID: number }>;
+  rows: Record<string, unknown>[];
+  rowCount: number;
+  truncated: boolean;
+  executionTime: number;
+}
+```
+
+Returning the same shape means the frontend API client, `ReadOnlyStore`, and
+`toCell` (`packages/sheets/src/store/readonly.ts`) are reused **unchanged**.
+DuckDB struct/list/JSON values arrive as objects and are rendered via `toCell`
+as JSON strings; timestamps as ISO strings — the same handling shipped in the
+`feat/support-json-postgresql` work (commit 51c01826).
+
+#### API Endpoints
+
+All require JWT auth and workspace membership (mirrors datasource access
+control).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/workspaces/:wid/lakehouse-sources` | Create a lakehouse connection |
+| GET | `/workspaces/:wid/lakehouse-sources` | List (credentials masked) |
+| GET | `/lakehouse-sources/:id` | Get one |
+| PATCH | `/lakehouse-sources/:id` | Update |
+| DELETE | `/lakehouse-sources/:id` | Delete |
+| POST | `/lakehouse-sources/:id/test` | Test storage + table reachability |
+| GET | `/lakehouse-sources/:id/tables` | List tables (catalog mode) |
+| GET | `/lakehouse-sources/:id/history` | Commit timeline for a table (drives the slider) |
+| POST | `/lakehouse-sources/:id/read` | Read rows, optional `asOf` |
+
+### 4. Time-Travel Slider (headline feature)
+
+This is the differentiator over a plain datasource tab.
+
+**History endpoint** returns the table's commit timeline:
+
+```typescript
+type LakehouseHistory = Array<{
+  ref: TimeTravelPoint;     // version or snapshot id
+  timestamp: string;        // ISO commit time
+  operation?: string;       // e.g. "append", "overwrite", "delete"
+  summary?: Record<string, string>; // record/file counts when available
+}>;
+```
+
+Sourced from:
+- **Iceberg** — the `iceberg_snapshots(...)` metadata function.
+- **Delta** — the Delta history (`… ('HISTORY')` / version log).
+
+**Read-at-version:** the `/read` endpoint accepts an optional `asOf`
+(`TimeTravelPoint`) and emits DuckDB time-travel syntax:
+- **Delta:** `delta_scan('…', version => N)` or `TIMESTAMP AS OF`.
+- **Iceberg:** snapshot selection on `iceberg_scan` / `… AT (VERSION => …)`.
+
+> The exact per-extension argument names are version-sensitive and confirmed in
+> the **Phase 0 spike** (see [Rollout](#7-rollout)) before wiring the slider.
+
+**Frontend `TimeTravelSlider`** sits above the results grid inside a
+`LakehouseView` (cloned from `datasource-view.tsx`):
+- Discrete stops = commits, labeled with timestamp + operation; the right end
+  is "latest".
+- Dragging selects a commit, calls `/read` with the new `asOf`, and reloads the
+  `ReadOnlyStore` + repaints — the same reload path datasource queries use.
+- The selected `asOf` is written to the Yorkie `TabMeta`, so collaborators see
+  the same point in time. A "Latest" affordance clears `asOf`.
+
+A `TabBar` "New Lakehouse" entry and a `LakehouseSelector` (cloned from
+`datasource-selector.tsx`) create the tab and pick the table.
+
+### 5. Technical Verification
+
+All claims below were verified against current DuckDB / ecosystem docs (June
+2026); citations are in [References](#references).
+
+#### Object-storage backends (DuckDB `httpfs` / `azure`)
+
+| Backend | Supported | Mechanism |
+|---------|-----------|-----------|
+| Amazon S3 | ✅ | `httpfs` + `CREATE SECRET (TYPE s3)` (or `credential_chain`) |
+| S3-compatible (MinIO, R2, …) | ✅ | `httpfs` + custom `ENDPOINT` / path-style addressing |
+| Google Cloud Storage | ✅ | `httpfs` via GCS S3-interoperability (HMAC keys) |
+| Azure Blob / ADLS Gen2 | ✅ | `azure` extension + Azure secret |
+| Local filesystem | ✅ | native (dev / on-box tables) |
+
+#### Open table formats
+
+| Format | Read | Time travel | Status |
+|--------|------|-------------|--------|
+| **Apache Iceberg** | ✅ | ✅ snapshot id / timestamp | **Supported.** DuckDB `iceberg` extension; direct-metadata reads, Iceberg REST Catalogs, and Amazon S3 Tables. Upstream labels parts experimental but core read + snapshot time-travel are functional. |
+| **Delta Lake** | ✅ | ✅ `VERSION AS OF` / `TIMESTAMP AS OF` | **Supported.** DuckDB `delta` extension (built on Delta Kernel). Read + time travel graduated from experimental to GA in DuckDB v1.5.2; broad object-store coverage via the DuckDB FileSystem API. |
+| **Apache Hudi** | ❌ | — | **Unsupported / deferred.** No native DuckDB reader and no JS/Node reader exist; Hudi reads (incl. time travel) go through JVM query engines (Spark / Flink / Trino). Future path: **Apache XTable** metadata translation (Hudi → Iceberg/Delta) so the existing Iceberg/Delta path picks it up, or a Trino gateway. Tracked as a known gap. |
+
+#### Engine choice & deployment
+
+- **Embedded DuckDB** via `@duckdb/node-api` (the "Neo" client). The older
+  `duckdb-node` package is being deprecated (last release on the 1.4.x line; no
+  1.5.x), so the Neo client is the correct, Promise-native choice.
+- It runs **in-process** in the NestJS backend (native dependency, prebuilt
+  binaries) — **not** a separate service and **not** an external API. This
+  directly answers the deployment question: DuckDB is *added to the backend*
+  and executed there, the same way `pg` is today.
+- **MotherDuck** (hosted DuckDB-as-a-service) is a possible "just call an API"
+  alternative but is intentionally **not** chosen: embedded keeps object-store
+  credentials inside our own backend and avoids a SaaS dependency.
+
+#### Pure-JS alternative (future, not chosen)
+
+`icebird` (built on `hyparquet`) reads Iceberg parquet directly in JS/browser
+with no native binary, but supports only a subset of Iceberg features and has
+**no** Delta or Hudi reader. `delta-rs` has no first-party Node binding. These
+are recorded as a potential **no-native-deps / browser (DuckDB-Wasm or icebird)**
+path for a later phase, not the v1 engine.
+
+### 6. Current Limitations
+
+1. **Read-only** — no write-back to lakehouse tables.
+2. **Iceberg + Delta only** — Hudi is unsupported (see above).
+3. **Per-commit time-travel granularity** — the slider stops at commits, not
+   arbitrary instants (timestamp queries resolve to the commit at-or-before).
+4. **GCS via interop** — GCS uses S3-interoperability (HMAC keys); native GCS
+   auth is not first-class in `httpfs`.
+5. **Native binary in the backend image** — `@duckdb/node-api` ships platform
+   binaries; the deploy image must match the runtime platform.
+6. **Extension auto-download** — `iceberg`/`delta` auto-load from DuckDB's repo
+   on first use; locked-down networks must pre-bundle the extensions.
+7. **Single-table scans in v1** — no joins / ad-hoc SQL across lakehouse tables
+   yet.
+8. **No schema browser** for catalog mode beyond a flat table list initially.
+
+### 7. Rollout
+
+Phased, each phase a separate PR with `pnpm verify:fast` green:
+
+- **Phase 0 — Verification spike.** A standalone script proves the DuckDB path
+  end-to-end against sample Iceberg and Delta tables in MinIO (read + history +
+  `asOf`), and pins exact extension argument names. No product code.
+- **Phase 1 — Connection + Iceberg read.** `LakehouseSource` model, module,
+  encrypted creds, `test`, and direct-metadata Iceberg read rendered via
+  `ReadOnlyStore`.
+- **Phase 2 — Delta read** + catalog mode (Iceberg REST / S3 Tables).
+- **Phase 3 — Time-travel slider.** History endpoint, `asOf` reads,
+  `TimeTravelSlider`, Yorkie persistence.
+- **Phase 4 — Catalog/table browser** and polish.
+- **Later — Hudi via XTable**, ad-hoc SQL, pure-JS/browser path.
+
+### 8. Test Strategy
+
+The hard part is verifying **many storage connectors** (S3 / Azure / GCS /
+MinIO) without paying for cloud or leaking credentials. The plan: local
+emulators for CI ($0, deterministic), a free cloud tier for occasional real
+fidelity, committed OTF fixtures, and one parameterized connector-parity suite.
+
+#### Free / local object storage (CI default, $0)
+
+| Emulator | Emulates | Notes |
+|----------|----------|-------|
+| **MinIO** | S3 + any S3-compatible (R2, B2, …) | Already used for image storage in dev (`forcePathStyle`, `localhost:9000`, `minioadmin`); add a docker-compose service. Primary S3 target. |
+| **Azurite** | Azure Blob / ADLS | Microsoft's official emulator; docker-compose service for the `azure` connector. |
+| **fake-gcs-server** | Google Cloud Storage | For the GCS connector; alternatively exercise GCS's S3-interop (HMAC) path through MinIO. |
+| **Local filesystem** | n/a | Cheapest — DuckDB reads files directly; used for unit tests with no network. |
+
+#### Optional real-cloud smoke (free tiers)
+
+For periodic real-fidelity checks (not per-PR): **Cloudflare R2** (10 GB free,
+no egress, S3-compatible) is the best fit; **Backblaze B2** (10 GB free,
+S3-compatible), **AWS S3** (5 GB/12 mo), and **Azure / GCS** free credit are
+alternatives. Opt-in, scheduled or manual, credentials via repo secrets, and
+**never run on fork PRs**.
+
+#### Fixtures (sample OTF tables with history)
+
+- Commit **tiny pre-built Iceberg + Delta tables** (metadata + a few small
+  parquet files) with **≥3 snapshots/versions** as test fixtures —
+  deterministic, no generation step in the hot CI path.
+- A documented regeneration script (PyIceberg / Python `deltalake` / DuckDB's
+  Delta-write) recreates them when the schema changes.
+- Test setup seeds the fixtures into MinIO / Azurite (and local FS).
+
+#### Connector-parity suite (the multi-connector matrix)
+
+One **storage-connector contract** suite, parameterized over a list of backend
+configs, runs the *same* assertions against each backend so parity is
+guaranteed without duplicated tests:
+
+```
+for backend in [ minio-s3, azurite-azure, gcs-interop, local-fs ]:
+  - secret minting from encrypted creds succeeds
+  - list/reach the fixture table
+  - read N rows (matches expected)
+  - history length == fixture commit count
+  - asOf(version K) returns the historical row set
+```
+
+Matrix dimensions: **storage backend × format (Iceberg / Delta) × auth mode**
+(S3 key/secret · Azure connection-string/SAS · GCS HMAC).
+
+#### Test layers (mirror existing repo gates)
+
+| Layer | Scope | Gate |
+|-------|-------|------|
+| **Unit** (no network) | `asOf` syntax builder, scan-only validator, credential masking, `{ columns, rows, … }` mapping; DuckDB over local-FS fixtures | always on (`pnpm verify:fast`) |
+| **Integration** | real DuckDB vs MinIO/Azurite containers — read + history + `asOf` | `RUN_LAKEHOUSE_INTEGRATION_TESTS=true` (mirrors `RUN_DB_INTEGRATION_TESTS` / `RUN_YORKIE_INTEGRATION_TESTS`) |
+| **CI** | docker-compose adds MinIO + Azurite services (like the Postgres + Yorkie services in `.github/workflows/ci.yml`), seeds fixtures, runs the gated suites per PR | per-PR |
+| **Cloud smoke** | R2 free tier, real S3-compatible fidelity | scheduled / manual only |
+
+#### Time-travel assertions
+
+Against a fixture with ≥3 commits: latest read; `asOf` version N returns the
+historical row set; timestamp `asOf` resolves to the commit at-or-before; the
+history endpoint returns an ordered timeline with operations.
+
+## Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Credential exposure (object-storage keys/SAS) | Reuse AES-256-GCM at rest (`crypto.util.ts`); mask in all API responses; decrypt only to mint a request-scoped DuckDB secret. |
+| Resource exhaustion (huge tables/scans) | Reuse 10,000-row limit + statement/connection timeouts; set DuckDB `memory_limit` / `threads`; push down `asOf`, projection, and `LIMIT`. |
+| Untrusted SQL / side-effecting functions | v1 exposes table scans, not free SQL; reuse the SELECT/scan-only validator; run DuckDB without filesystem/credentials beyond the request secret. |
+| In-process DuckDB starves the Node event loop | Singleton instance + bounded connection pool; consider a worker thread for heavy scans; cap concurrency per workspace. |
+| Extension download blocked in prod networks | Pre-bundle `iceberg`/`delta`/`httpfs`/`azure` into the backend image; pin extension versions. |
+| Native binary / platform mismatch in deploy image | Build the image on the target platform; document the `@duckdb/node-api` platform matrix. |
+| Iceberg extension marked experimental upstream | Pin DuckDB + extension versions; gate on the Phase 0 spike; keep the feature behind a flag until validated. |
+| Time-travel semantics differ per format | Normalize to a single `TimeTravelPoint`; resolve timestamps to commit-at-or-before; surface the resolved commit in the UI. |
+
+## References
+
+- DuckDB Delta extension (read/write, time travel, Unity Catalog):
+  <https://duckdb.org/docs/current/core_extensions/delta> ·
+  <https://duckdb.org/2026/05/07/delta-uc-updates>
+- DuckDB Iceberg extension (overview, REST catalogs, S3 Tables, S3 import):
+  <https://duckdb.org/docs/current/core_extensions/iceberg/overview> ·
+  <https://duckdb.org/docs/stable/guides/network_cloud_storage/s3_iceberg_import>
+- DuckDB Node "Neo" client; old `duckdb-node` deprecation:
+  <https://duckdb.org/docs/lts/clients/node_neo/overview> ·
+  <https://github.com/duckdb/duckdb-node-neo>
+- Iceberg in the browser (DuckDB-Wasm — future JS path):
+  <https://duckdb.org/2025/12/16/iceberg-in-the-browser>
+- Icebird — pure-JS Iceberg reader: <https://github.com/hyparam/icebird>
+- delta-rs (no first-party Node binding): <https://delta-io.github.io/delta-rs/>
+- Apache Hudi reads are engine-centric:
+  <https://hudi.apache.org/docs/reading_tables_streaming_reads/>

--- a/docs/design/sheets/mysql-connector.md
+++ b/docs/design/sheets/mysql-connector.md
@@ -1,0 +1,130 @@
+---
+title: mysql-connector
+target-version: 0.5.0
+---
+
+# MySQL Connector
+
+> Part of the External Data Sources initiative — see the [epic index](../../tasks/active/20260625-sheets-external-data-sources-todo.md).
+> Extends the existing [PostgreSQL datasource](datasource.md) to MySQL.
+
+## Summary
+
+Connect a Wafflebase document to **MySQL / MariaDB** as a read-only datasource —
+the same experience as the existing PostgreSQL datasource, with a different
+driver. The top-level `README.md` already promises this: *"Data Source
+integration (coming soon) — Connect directly to PostgreSQL/MySQL to query live
+data."*
+
+It reuses the entire datasource read-only spine — encrypted credentials, the
+SELECT-only validator, the `{ columns, rows, … }` response shape, and the
+`ReadOnlyStore` — and adds an `engine` discriminator on the connection plus the
+native `mysql2` client. This is the **smallest** of the external-data
+connectors: no new engine, no cost guardrails, no time travel.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Read-only MySQL / MariaDB query results in a datasource tab, reusing the
+  datasource spine end-to-end.
+- An `engine` field on the connection (`postgres` | `mysql`) with the right
+  default port (5432 vs 3306) and driver dispatch.
+- Reuse the SELECT/WITH-only validator, 10,000-row cap, timeouts, and
+  AES-256-GCM credential encryption.
+- Schema browser parity (`information_schema` tables/columns).
+
+### Non-Goals
+
+- Write-back to MySQL.
+- Databases beyond MySQL / MariaDB (SQLite and warehouses are separate tracks).
+- Any change to the lakehouse / file-import DuckDB engine — unrelated.
+
+## Architecture Overview
+
+Same datasource family as PostgreSQL; the only differences are the **driver**
+(`pg` → `mysql2`) and the **default port** behind an `engine` discriminator.
+
+```
+  Frontend (existing datasource view + dialog)
+   DataSourceDialog (engine: postgres | mysql) · SQL editor · results grid
+        │ REST API (existing datasource endpoints)
+   Backend DataSourceModule
+   ┌──────────────┬──────────────────────────────┬─────────────────────┐
+   │ Controller   │ Service (driver dispatch)    │ Crypto (AES-256)    │
+   │ (REST)       │  ├─ pg     (postgres)        │ (reuse crypto.util) │
+   │              │  └─ mysql2 (mysql)           │                     │
+   └──────────────┴───────────────┬──────────────┴─────────────────────┘
+        Prisma                    │ decrypted creds
+   DataSource row (engine)        ▼
+                              PostgreSQL  /  MySQL · MariaDB
+```
+
+## Proposal Details
+
+### 1. Connection model (Prisma)
+
+Extend the existing `DataSource` model with an `engine` discriminator rather than
+a new table:
+
+```prisma
+model DataSource {
+  // ... existing fields (host, port, database, username, password, sslEnabled) ...
+  engine String @default("postgres") // "postgres" | "mysql"
+}
+```
+
+- Default port resolves by engine when unset (5432 / 3306).
+- Existing rows default to `postgres` (backward compatible; no data migration of
+  values needed beyond adding the column).
+
+### 2. Query execution (native `mysql2`)
+
+- The service dispatches on `engine`: `pg.Client` for postgres, `mysql2` for
+  mysql. Add `mysql2` to `packages/backend` dependencies.
+- Reuse the SELECT/WITH-only validator and the `LIMIT 10001` wrap + 10,000-row
+  truncation flag. (MySQL dialect uses backtick identifiers, but SELECT/WITH
+  detection and the forbidden-keyword list are unaffected.)
+- Map `mysql2` field metadata + rows to the shared
+  `{ columns: [{name, dataTypeID}], rows, rowCount, truncated, executionTime }`
+  shape → `ReadOnlyStore` + `toCell` render unchanged.
+- Date/time handling: return DATE / DATETIME / TIMESTAMP as raw strings (set
+  `dateStrings: true` on the mysql2 connection) to avoid the timezone shift the
+  Postgres path also guards against (commit 51c01826).
+
+### 3. Frontend
+
+The existing `DataSourceDialog` / datasource view gain an **engine selector**
+(PostgreSQL / MySQL); the port field defaults by engine. Everything else (SQL
+editor, results grid, tab) is reused unchanged.
+
+### 4. Schema browser
+
+`information_schema.tables` / `information_schema.columns` exist in MySQL too, so
+the schema browser (a datasource next-step) works for both engines with the same
+queries.
+
+## Test Strategy
+
+- **Unit** (no network): engine dispatch, validator, response-shape mapping,
+  type/date coercion — with the client mocked.
+- **Integration** (gated): a **MySQL service in docker-compose** alongside the
+  existing Postgres service; run the datasource integration suite against both
+  engines behind `RUN_DB_INTEGRATION_TESTS`. MySQL is free and runs fully local
+  (no cloud, no cost) — the simplest connector to CI.
+
+## Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Dialect differences (identifiers, functions) | Validator only gates statement type + forbidden keywords; the `LIMIT` wrap is valid MySQL. Document dialect notes. |
+| Auth plugin (`caching_sha2_password` on MySQL 8) | `mysql2` supports it natively; document required server config / TLS. |
+| Timezone shift on DATE/DATETIME | `dateStrings: true` returns raw strings (mirrors the Postgres raw-text approach). |
+| Charset / encoding (utf8mb4) | Default connection charset utf8mb4; document. |
+| Credential exposure | Reuse AES-256-GCM (`crypto.util.ts`); masked in API responses. |
+
+## References
+
+- [datasource.md](datasource.md) — the PostgreSQL datasource this extends
+- [External Data Sources epic index](../../tasks/active/20260625-sheets-external-data-sources-todo.md)
+- `mysql2` Node client: <https://github.com/sidorares/node-mysql2>

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -21,6 +21,11 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | docs shortcuts catalog (2026-06-28) | [20260628-docs-shortcuts-catalog-todo.md](./active/20260628-docs-shortcuts-catalog-todo.md) | [20260628-docs-shortcuts-catalog-lessons.md](./active/20260628-docs-shortcuts-catalog-lessons.md) |
 | release v0.4.8 (2026-06-28) | [20260628-release-v0.4.8-todo.md](./active/20260628-release-v0.4.8-todo.md) | - |
 | docs collaboration convergence (2026-06-25) | [20260625-docs-collaboration-convergence-todo.md](./active/20260625-docs-collaboration-convergence-todo.md) | [20260625-docs-collaboration-convergence-lessons.md](./active/20260625-docs-collaboration-convergence-lessons.md) |
+| sheets bigquery connector (2026-06-25) | [20260625-sheets-bigquery-connector-todo.md](./active/20260625-sheets-bigquery-connector-todo.md) | - |
+| sheets external data sources (2026-06-25) | [20260625-sheets-external-data-sources-todo.md](./active/20260625-sheets-external-data-sources-todo.md) | - |
+| sheets file import (2026-06-25) | [20260625-sheets-file-import-todo.md](./active/20260625-sheets-file-import-todo.md) | - |
+| sheets lakehouse connector (2026-06-25) | [20260625-sheets-lakehouse-connector-todo.md](./active/20260625-sheets-lakehouse-connector-todo.md) | - |
+| sheets mysql connector (2026-06-25) | [20260625-sheets-mysql-connector-todo.md](./active/20260625-sheets-mysql-connector-todo.md) | - |
 | docs wordprocessor (2026-03-25) | [20260325-docs-wordprocessor-todo.md](./active/20260325-docs-wordprocessor-todo.md) | [20260325-docs-wordprocessor-lessons.md](./active/20260325-docs-wordprocessor-lessons.md) |
 
 ## Archive

--- a/docs/tasks/active/20260625-sheets-bigquery-connector-todo.md
+++ b/docs/tasks/active/20260625-sheets-bigquery-connector-todo.md
@@ -25,7 +25,7 @@ Each task lists **what / files / reuse / done**. Mirror
 `packages/backend/src/bigquery/` (new module), reuse `datasource/crypto.util.ts`.
 
 - [ ] **`BigQuerySource` model + migration** — project, dataset, location,
-  `credentials` (service-account JSON, AES-256-GCM), optional `maxBytesBilled`,
+  `credentials` (service-account JSON, AES-256-GCM), optional `maximumBytesBilled`,
   workspaceId, authorID. Done: CRUD; key encrypted + masked.
 - [ ] **Module scaffold (controller/dto/service)** — workspace-scoped CRUD +
   `POST /:id/test`. Done: controller-contract e2e green.

--- a/docs/tasks/active/20260625-sheets-bigquery-connector-todo.md
+++ b/docs/tasks/active/20260625-sheets-bigquery-connector-todo.md
@@ -1,0 +1,96 @@
+# TODO — BigQuery connector in sheets (③, single feature issue)
+
+Design doc: [bigquery-connector.md](../../design/sheets/bigquery-connector.md) ·
+Issue bodies: [20260625-sheets-external-data-sources-issues.md](20260625-sheets-external-data-sources-issues.md) ·
+Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
+
+Single feature issue (no subissues). The milestones below are internal, not
+separate issues; may ship in 1–2 PRs, each `pnpm verify:fast` green. Extends the
+existing PostgreSQL datasource pattern via the native `@google-cloud/bigquery`
+client. Independent of Roadmaps ①②④. ~600–1000 LOC.
+
+Each task lists **what / files / reuse / done**. Mirror
+`packages/backend/src/datasource/` and `datasource-view.tsx`.
+
+## Task breakdown (internal milestones, not subissues)
+
+```
+  M1 connection ─► M2 query ─► { M3 cost guardrails ★, M4 schema browser, M5 frontend, M6 refresh(later) }
+```
+
+### M1 — Connection model
+
+**Goal:** store an encrypted BigQuery connection.
+**Files:** `packages/backend/prisma/schema.prisma`,
+`packages/backend/src/bigquery/` (new module), reuse `datasource/crypto.util.ts`.
+
+- [ ] **`BigQuerySource` model + migration** — project, dataset, location,
+  `credentials` (service-account JSON, AES-256-GCM), optional `maxBytesBilled`,
+  workspaceId, authorID. Done: CRUD; key encrypted + masked.
+- [ ] **Module scaffold (controller/dto/service)** — workspace-scoped CRUD +
+  `POST /:id/test`. Done: controller-contract e2e green.
+
+### M2 — Query execution
+
+**Goal:** run GoogleSQL and render read-only.
+**Files:** `packages/backend/src/bigquery/bigquery.service.ts`, reuse
+`datasource/sql-validator.ts`, `packages/sheets/src/store/readonly.ts`.
+
+- [ ] **`@google-cloud/bigquery` client + auth** — add dep; authenticate from the
+  decrypted service-account key. Done: a query runs against a test dataset.
+- [ ] **Validate + map to response shape** — reuse SELECT/WITH validator
+  (GoogleSQL) + 10k cap; map schema/rows → `{ columns:[{name,dataTypeID}], rows,
+  rowCount, truncated, executionTime }`; STRUCT/ARRAY → JSON-string via `toCell`.
+  Done: a SELECT renders read-only in a tab.
+
+### M3 — Cost guardrails ★ (the defining BigQuery concern)
+
+**Goal:** never let a runaway scan bill.
+**Files:** `bigquery.service.ts`, frontend BigQuery view.
+
+- [ ] **Dry-run estimate** — run `dryRun: true` first → `totalBytesProcessed`;
+  return an estimate before execution. Done: estimate surfaced pre-run.
+- [ ] **`maximumBytesBilled` ceiling** — per-connection + per-query cap passed to
+  the job. Done: an over-ceiling query hard-fails with a clear message.
+- [ ] **Warning UI** — banner + confirm when estimate exceeds a threshold. Done:
+  user confirms before an expensive run.
+
+### M4 — Schema browser
+
+**Goal:** browse datasets/tables/columns.
+**Files:** `bigquery.service.ts` (+ endpoint), frontend sidebar.
+
+- [ ] **List datasets → tables → columns** — via the BigQuery metadata API. Done:
+  sidebar lists; click inserts into the editor.
+
+### M5 — Frontend
+
+**Goal:** end-to-end UX.
+**Files:** `packages/frontend/src/components/bigquery-dialog.tsx`,
+`packages/frontend/src/app/spreadsheet/bigquery-view.tsx`, reuse datasource view.
+
+- [ ] **`BigQueryDialog`** — project/dataset + service-account key upload + Test.
+  Done: connection created from the UI.
+- [ ] **SQL editor view + cost banner** — reuse the datasource view shell; show
+  the dry-run estimate above Run. Done: create → query → results + estimate.
+
+### M6 — Scheduled refresh / result cache (later)
+
+- [ ] **Cache last result per tab; manual + optional interval refresh** — re-run
+  shows a fresh estimate. Done: cached results reused; refresh re-runs.
+
+## Acceptance (issue-level)
+
+- Create connection → run a SELECT → read-only results with a pre-run cost estimate.
+- Over-ceiling queries blocked; key encrypted at rest + masked.
+- `pnpm verify:fast`; integration behind `RUN_BIGQUERY_INTEGRATION_TESTS` (free tier, repo secrets, never fork PRs).
+
+## Cross-cutting
+
+- [ ] `docs/design/README.md` updated (done on ideation branch)
+- [ ] Lessons in `20260625-sheets-bigquery-connector-lessons.md`
+- [ ] After merge: `pnpm tasks:archive && pnpm tasks:index`
+
+## Review
+
+(filled in at completion)

--- a/docs/tasks/active/20260625-sheets-bigquery-connector-todo.md
+++ b/docs/tasks/active/20260625-sheets-bigquery-connector-todo.md
@@ -1,8 +1,6 @@
 # TODO — BigQuery connector in sheets (③, single feature issue)
 
-Design doc: [bigquery-connector.md](../../design/sheets/bigquery-connector.md) ·
-Issue bodies: [20260625-sheets-external-data-sources-issues.md](20260625-sheets-external-data-sources-issues.md) ·
-Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
+Design doc: [bigquery-connector.md](../../design/sheets/bigquery-connector.md) · Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
 
 Single feature issue (no subissues). The milestones below are internal, not
 separate issues; may ship in 1–2 PRs, each `pnpm verify:fast` green. Extends the
@@ -15,10 +13,10 @@ Each task lists **what / files / reuse / done**. Mirror
 ## Task breakdown (internal milestones, not subissues)
 
 ```
-  M1 connection ─► M2 query ─► { M3 cost guardrails ★, M4 schema browser, M5 frontend, M6 refresh(later) }
+  BQ-1 connection ─► BQ-2 query ─► { BQ-3 cost guardrails ★, BQ-4 schema browser, BQ-5 frontend, BQ-6 refresh(later) }
 ```
 
-### M1 — Connection model
+### BQ-1 — Connection model
 
 **Goal:** store an encrypted BigQuery connection.
 **Files:** `packages/backend/prisma/schema.prisma`,
@@ -30,7 +28,7 @@ Each task lists **what / files / reuse / done**. Mirror
 - [ ] **Module scaffold (controller/dto/service)** — workspace-scoped CRUD +
   `POST /:id/test`. Done: controller-contract e2e green.
 
-### M2 — Query execution
+### BQ-2 — Query execution
 
 **Goal:** run GoogleSQL and render read-only.
 **Files:** `packages/backend/src/bigquery/bigquery.service.ts`, reuse
@@ -43,7 +41,7 @@ Each task lists **what / files / reuse / done**. Mirror
   rowCount, truncated, executionTime }`; STRUCT/ARRAY → JSON-string via `toCell`.
   Done: a SELECT renders read-only in a tab.
 
-### M3 — Cost guardrails ★ (the defining BigQuery concern)
+### BQ-3 — Cost guardrails ★ (the defining BigQuery concern)
 
 **Goal:** never let a runaway scan bill.
 **Files:** `bigquery.service.ts`, frontend BigQuery view.
@@ -55,7 +53,7 @@ Each task lists **what / files / reuse / done**. Mirror
 - [ ] **Warning UI** — banner + confirm when estimate exceeds a threshold. Done:
   user confirms before an expensive run.
 
-### M4 — Schema browser
+### BQ-4 — Schema browser
 
 **Goal:** browse datasets/tables/columns.
 **Files:** `bigquery.service.ts` (+ endpoint), frontend sidebar.
@@ -63,7 +61,7 @@ Each task lists **what / files / reuse / done**. Mirror
 - [ ] **List datasets → tables → columns** — via the BigQuery metadata API. Done:
   sidebar lists; click inserts into the editor.
 
-### M5 — Frontend
+### BQ-5 — Frontend
 
 **Goal:** end-to-end UX.
 **Files:** `packages/frontend/src/components/bigquery-dialog.tsx`,
@@ -74,7 +72,7 @@ Each task lists **what / files / reuse / done**. Mirror
 - [ ] **SQL editor view + cost banner** — reuse the datasource view shell; show
   the dry-run estimate above Run. Done: create → query → results + estimate.
 
-### M6 — Scheduled refresh / result cache (later)
+### BQ-6 — Scheduled refresh / result cache (later)
 
 - [ ] **Cache last result per tab; manual + optional interval refresh** — re-run
   shows a fresh estimate. Done: cached results reused; refresh re-runs.

--- a/docs/tasks/active/20260625-sheets-external-data-sources-todo.md
+++ b/docs/tasks/active/20260625-sheets-external-data-sources-todo.md
@@ -4,8 +4,6 @@ Umbrella for the three "Connected Sheets over the open stack" roadmaps. This
 file is the **map**: strategy, master dependency graph, and links to each
 roadmap's design doc (architecture) and task doc (execution).
 
-Issue bodies (paste-ready): [20260625-sheets-external-data-sources-issues.md](20260625-sheets-external-data-sources-issues.md)
-
 **Strategy:** one embedded **DuckDB** engine (in the NestJS backend) + the
 existing datasource read-only spine unlock a family of sources — the open-stack
 equivalent of Connected Sheets. Two ingestion modes apply across all:
@@ -71,7 +69,7 @@ vision; not yet scoped into roadmaps):
 ## Cross-cutting
 
 - [ ] Design docs landed on `docs/ideation` branch.
-- [ ] Maintainer files 3 roadmap issues + subissues from the issue-bodies doc.
+- [ ] Maintainer files 3 roadmap issues + subissues.
 - [ ] Per roadmap completion: lessons in the paired `*-lessons.md`, then
       `pnpm tasks:archive && pnpm tasks:index`.
 

--- a/docs/tasks/active/20260625-sheets-external-data-sources-todo.md
+++ b/docs/tasks/active/20260625-sheets-external-data-sources-todo.md
@@ -1,0 +1,80 @@
+# TODO — External Data Sources (Epic index)
+
+Umbrella for the three "Connected Sheets over the open stack" roadmaps. This
+file is the **map**: strategy, master dependency graph, and links to each
+roadmap's design doc (architecture) and task doc (execution).
+
+Issue bodies (paste-ready): [20260625-sheets-external-data-sources-issues.md](20260625-sheets-external-data-sources-issues.md)
+
+**Strategy:** one embedded **DuckDB** engine (in the NestJS backend) + the
+existing datasource read-only spine unlock a family of sources — the open-stack
+equivalent of Connected Sheets. Two ingestion modes apply across all:
+**Connect** (live read-only via `ReadOnlyStore`) vs **Import** (materialize to
+editable cells).
+
+## Roadmaps → docs
+
+| # | Roadmap | Design doc (roadmap issue links) | Task doc (subissues link) |
+|---|---------|----------------------------------|----------------------------|
+| ① | File Import | [file-import.md](../../design/sheets/file-import.md) | [20260625-sheets-file-import-todo.md](20260625-sheets-file-import-todo.md) |
+| ② | Lakehouse connector | [lakehouse-connected-sheet.md](../../design/sheets/lakehouse-connected-sheet.md) | [20260625-sheets-lakehouse-connector-todo.md](20260625-sheets-lakehouse-connector-todo.md) |
+| ③ | BigQuery connector | [bigquery-connector.md](../../design/sheets/bigquery-connector.md) | [20260625-sheets-bigquery-connector-todo.md](20260625-sheets-bigquery-connector-todo.md) |
+| ④ | MySQL connector | [mysql-connector.md](../../design/sheets/mysql-connector.md) | [20260625-sheets-mysql-connector-todo.md](20260625-sheets-mysql-connector-todo.md) |
+
+## Master dependency graph (across roadmaps)
+
+```
+  ① File Import
+     FI-1 · CSV (client-side) ── independent, ship first ───────────────►
+     FI-2 · Parquet ┐
+     FI-3 · JSON    ┘┄(large path)┄┐
+     FI-4 · Connect ──────────────┐│
+     FI-5 · large-file routing ◄─FI-4
+                                  ││
+  ② Lakehouse                     ││
+     LH-0 · DuckDB engine ◄───────┴┴── (FI large/remote depend on LH-0)
+      ├─► LH-1 ─► {LH-2, LH-3, LH-4 ─► LH-7, LH-5 ─► LH-9, LH-8}
+      └─► LH-6 · storage backends ──► shared with FI-4
+
+  ③ BigQuery  (independent — single issue, datasource family)
+  ④ MySQL     (independent — single issue, datasource family)
+
+  Legend: ─► hard dep   ┄► soft dep (only the large/remote file path)
+```
+
+Key facts:
+- **LH-0 (DuckDB engine) is the one cross-roadmap unblocker** — File Import's
+  large/remote paths (FI-2/3/4) depend on it; CSV (FI-1) does not.
+- **LH-6 (storage backends)** is shared by Lakehouse and File Import FI-4.
+- **BigQuery (③) is fully independent** and can run in parallel from day one.
+
+## Suggested start order
+
+1. Parallel: `FI-1` (no deps) ‖ `LH-0` (engine) ‖ `BQ-1→BQ-2` (independent).
+2. `LH-1 → LH-3 → LH-5` (lakehouse + time travel headline).
+3. `FI-2/FI-3` then `FI-4/FI-5`; `LH-2/4/6/7/8`.
+4. `BQ-3` (cost guardrails) early once BQ-2 lands.
+5. Later: `LH-9` (Hudi), `BQ-6` (refresh/cache).
+
+## Future / beyond these roadmaps
+
+The same engine + datasource spine unlock more sources (from the original
+vision; not yet scoped into roadmaps):
+
+- **SQLite** — native driver, extends the datasource pattern (like the MySQL roadmap ④).
+- **More warehouses — Snowflake / Redshift / ClickHouse** — datasource family like BigQuery; per-warehouse auth/driver.
+- **Catalog integrations — Unity Catalog / Glue / Polaris / Nessie** — extends Lakehouse LH-4 into a governed table browser.
+- **SaaS imports — Google Sheets / Airtable / Notion** — API integrations.
+- **DuckLake** — DuckDB's SQL-based lakehouse catalog format (forward-looking).
+- **Export / write-back / scheduled refresh** — reverse direction: sheet → Parquet/CSV/Iceberg; periodic re-materialization.
+
+## Cross-cutting
+
+- [ ] Design docs landed on `docs/ideation` branch.
+- [ ] Maintainer files 3 roadmap issues + subissues from the issue-bodies doc.
+- [ ] Per roadmap completion: lessons in the paired `*-lessons.md`, then
+      `pnpm tasks:archive && pnpm tasks:index`.
+
+## Review
+
+(filled in at completion)

--- a/docs/tasks/active/20260625-sheets-file-import-todo.md
+++ b/docs/tasks/active/20260625-sheets-file-import-todo.md
@@ -1,0 +1,147 @@
+# TODO — File Import in sheets (Roadmap ①)
+
+Design doc: [file-import.md](../../design/sheets/file-import.md) ·
+Issue bodies: [20260625-sheets-external-data-sources-issues.md](20260625-sheets-external-data-sources-issues.md) ·
+Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
+
+Engine split by **size/location, not format**: small local files parse
+client-side; large/remote/object-storage files use the backend DuckDB engine
+(LH-0). XLSX import already ships (`packages/sheets/src/import/xlsx-importer.ts`,
+PR #270) — not a subtask.
+
+Each subissue is one PR. Every task lists **what / files / reuse / done**.
+
+## Subissue dependency graph
+
+```
+  FI-1 · CSV (client-side)      ── independent, ship first
+  FI-2 · Parquet ┐
+  FI-3 · JSON    ┘── (large path) ┄► depends on Lakehouse LH-0 (DuckDB engine)
+  FI-4 · Remote/object Connect ──► depends on LH-0 + LH-6 (storage backends)
+  FI-5 · Large-file routing ──► depends on FI-4
+```
+
+---
+
+## FI-1 — CSV import (client-side)  ·  depends on: —
+
+**Goal:** import a local CSV into an editable sheet, fully client-side. No backend.
+**Primary files:** `packages/frontend/src/app/spreadsheet/csv-actions.ts` (new),
+the import entry point that calls `pickAndImportXlsx`, `packages/sheets` for the
+header/coercion helper.
+
+- [ ] **`csv-actions.ts` (parse + map).**
+  Scope: pick a `.csv`, parse with `papaparse` (already a `@wafflebase/sheets`
+  dep), build a one-sheet `SpreadsheetDocument`.
+  Reuse: `createSpreadsheetDocumentFromImportedXlsxSheets` shape in
+  `xlsx-actions.ts`.
+  Done: a CSV file produces an editable sheet document.
+- [ ] **Header detect + basic type coercion.**
+  Scope: first row → bold header; coerce obvious number/date columns.
+  Done: numbers/dates land as typed cells, not strings.
+- [ ] **Wire into the import entry point.**
+  Scope: add "Import CSV" beside the existing XLSX import action.
+  Done: end-to-end picker → editable sheet.
+
+**Acceptance:** CSV picker → editable single sheet (bold header); `pnpm verify:fast`.
+
+---
+
+## FI-2 — Parquet import  ·  depends on: Lakehouse LH-0 (large path)
+
+**Goal:** import Parquet — small files client-side, large/remote via backend DuckDB.
+**Primary files:** `packages/sheets` (hyparquet integration),
+`packages/backend/src/file-import/` (new) reusing `lakehouse/duckdb.service.ts`,
+`packages/backend/src/image/image.service.ts` (S3 upload), frontend import dialog.
+
+- [ ] **Small local: client-side `hyparquet`.**
+  Scope: add `hyparquet` dep; read a local `.parquet` in the browser → materialize
+  via the standard `Store` write path.
+  Done: a small Parquet imports with no server round-trip.
+- [ ] **Large/remote: backend DuckDB `read_parquet` + preview.**
+  Scope: upload to S3 (`imports/` prefix) via the image S3 infra; read with
+  `DuckDbService.read_parquet`; return first-N preview in the shared
+  `{ columns, rows, truncated }` shape; materialize on confirm.
+  Reuse: `image.service.ts`, `DuckDbService` (LH-0).
+  Done: a large Parquet previews then materializes.
+- [ ] **Glob for partitioned sets (large path).**
+  Scope: accept `.../*.parquet` + Hive partitioning.
+  Done: a partitioned dataset reads as one table.
+
+**Acceptance:** small Parquet client-side, large via backend; `pnpm verify:fast`
++ MinIO integration.
+
+---
+
+## FI-3 — JSON import  ·  depends on: Lakehouse LH-0 (large path)
+
+**Goal:** import JSON — array-of-records → grid; nested → JSON-string cell.
+**Primary files:** `packages/sheets` (mapping + `toCell` reuse),
+`packages/backend/src/file-import/` (DuckDB large path).
+
+- [ ] **Array-of-records → grid (client `JSON.parse`).**
+  Scope: keys → columns, objects → rows for small files.
+  Done: flat JSON imports as a clean table.
+- [ ] **Nested values → JSON-string cells.**
+  Scope: objects/arrays in a cell rendered via `toCell` (`JSON.stringify`).
+  Reuse: `packages/sheets/src/store/readonly.ts` `toCell`.
+  Done: nested fields show as JSON strings (matches the design's worked example).
+- [ ] **Large/remote: backend DuckDB `read_json_auto`.**
+  Scope: same upload→preview→materialize path as FI-2.
+  Done: a large JSON file imports via backend.
+- [ ] **Document tabular-vs-nested scope.**
+  Scope: note that Power-Query-style nested **expand** is deferred.
+  Done: scope captured in the design doc.
+
+**Acceptance:** flat JSON tabular; nested → JSON-string cell; scope documented;
+`pnpm verify:fast`.
+
+---
+
+## FI-4 — Remote/object-storage file Connect  ·  depends on: LH-0, LH-6
+
+**Goal:** point at a remote/object raw file → read-only tab (no time-travel slider).
+**Primary files:** `packages/backend/src/file-import/` (read via DuckDbService),
+`packages/sheets/.../worksheet-document.ts` (file-connect `TabMeta`),
+`packages/frontend/src/app/spreadsheet/` (URL field + view).
+
+- [ ] **Backend read remote/object file → response shape.**
+  Scope: read `https://…` / `s3://…` (glob/Hive) through `DuckDbService`;
+  `LIMIT` + truncation; return `{ columns, rows, … }`.
+  Reuse: LH-6 storage secrets, `DuckDbService`.
+  Done: a remote Parquet glob returns rows.
+- [ ] **File-connect tab.**
+  Scope: a read-only tab storing `{ uri, format }` in `TabMeta`; render via
+  `ReadOnlyStore`; no slider (raw files have no commit history).
+  Done: tab persists + renders.
+- [ ] **Frontend URL field.**
+  Scope: add a URL input to the import entry → Connect.
+  Done: paste a URL → read-only tab.
+
+**Acceptance:** remote Parquet glob renders read-only; `pnpm verify:fast`.
+
+---
+
+## FI-5 — Large-file routing  ·  depends on: FI-4
+
+**Goal:** protect the browser/Yorkie doc from oversized materialization.
+**Primary files:** `packages/frontend/src/app/spreadsheet/` (import flow).
+
+- [ ] **Materialize cap + Connect suggestion.**
+  Scope: when an upload exceeds a configurable rows×cols cap, stop materializing
+  and offer Connect mode instead.
+  Done: a large file routes to Connect with a clear prompt; cap documented.
+
+**Acceptance:** large CSV/Parquet routes to Connect; `pnpm verify:fast`.
+
+---
+
+## Cross-cutting
+
+- [ ] `docs/design/README.md` Sheets section updated (done on ideation branch)
+- [ ] Lessons in paired `20260625-sheets-file-import-lessons.md`
+- [ ] After all merged: `pnpm tasks:archive && pnpm tasks:index`
+
+## Review
+
+(filled in at completion)

--- a/docs/tasks/active/20260625-sheets-file-import-todo.md
+++ b/docs/tasks/active/20260625-sheets-file-import-todo.md
@@ -1,8 +1,6 @@
 # TODO — File Import in sheets (Roadmap ①)
 
-Design doc: [file-import.md](../../design/sheets/file-import.md) ·
-Issue bodies: [20260625-sheets-external-data-sources-issues.md](20260625-sheets-external-data-sources-issues.md) ·
-Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
+Design doc: [file-import.md](../../design/sheets/file-import.md) · Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
 
 Engine split by **size/location, not format**: small local files parse
 client-side; large/remote/object-storage files use the backend DuckDB engine

--- a/docs/tasks/active/20260625-sheets-file-import-todo.md
+++ b/docs/tasks/active/20260625-sheets-file-import-todo.md
@@ -30,11 +30,16 @@ Each subissue is one PR. Every task lists **what / files / reuse / done**.
 the import entry point that calls `pickAndImportXlsx`, `packages/sheets` for the
 header/coercion helper.
 
+- [ ] **Generalize the document builder (prerequisite refactor).**
+  Scope: `createSpreadsheetDocumentFromImportedXlsxSheets` in `xlsx-actions.ts`
+  is typed for `ImportedXlsxSheet[]` (XLSX-specific, e.g. `cellCount`). Extract a
+  generic `createSpreadsheetDocumentFromImportedSheets` taking a flat sheet shape
+  (or add a CSV-specific builder) so CSV isn't forced through the XLSX-shaped
+  helper. Done: XLSX path still works; a generic builder exists for CSV.
 - [ ] **`csv-actions.ts` (parse + map).**
   Scope: pick a `.csv`, parse with `papaparse` (already a `@wafflebase/sheets`
   dep), build a one-sheet `SpreadsheetDocument`.
-  Reuse: `createSpreadsheetDocumentFromImportedXlsxSheets` shape in
-  `xlsx-actions.ts`.
+  Reuse: the generic builder above.
   Done: a CSV file produces an editable sheet document.
 - [ ] **Header detect + basic type coercion.**
   Scope: first row → bold header; coerce obvious number/date columns.

--- a/docs/tasks/active/20260625-sheets-lakehouse-connector-todo.md
+++ b/docs/tasks/active/20260625-sheets-lakehouse-connector-todo.md
@@ -1,8 +1,6 @@
 # TODO — Lakehouse connector in sheets (Roadmap ②)
 
-Design doc: [lakehouse-connected-sheet.md](../../design/sheets/lakehouse-connected-sheet.md) ·
-Issue bodies: [20260625-sheets-external-data-sources-issues.md](20260625-sheets-external-data-sources-issues.md) ·
-Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
+Design doc: [lakehouse-connected-sheet.md](../../design/sheets/lakehouse-connected-sheet.md) · Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
 
 Reads open table formats (Iceberg/Delta) from object storage via embedded
 DuckDB, with a time-travel slider. Reuses the datasource read-only spine.

--- a/docs/tasks/active/20260625-sheets-lakehouse-connector-todo.md
+++ b/docs/tasks/active/20260625-sheets-lakehouse-connector-todo.md
@@ -17,7 +17,7 @@ and `packages/frontend/src/app/spreadsheet/datasource-view.tsx`.
 ```
   LH-0 · DuckDB engine  ── foundational; also unblocks File Import FI-2/3/4
    ├─► LH-1 · Iceberg read + connection model
-   │     ├─► LH-2 · format auto-detect (needs LH-3 too)
+   │     ├─► LH-2 · format auto-detect (needs LH-1; Delta cases mockable until LH-3)
    │     ├─► LH-3 · Delta read
    │     ├─► LH-4 · catalog mode ──► LH-7 · catalog/table browser + polish
    │     ├─► LH-5 · time-travel slider ──► LH-9 · Hudi via XTable (later)
@@ -91,11 +91,15 @@ read-only in a new tab.
   Reuse: `src/datasource/sql-validator.ts`. Output the shared
   `{ columns:[{name,dataTypeID}], rows, rowCount, truncated, executionTime }`.
   Done: returns correct rows for the Iceberg fixture.
-- [ ] **Sheets: lakehouse tab type + `TabMeta` fields.**
+- [ ] **Sheets: lakehouse tab type + `TabMeta` fields + Yorkie migration.**
   Scope: add `"lakehouse"` to `TabType`; add `lakehouseSourceId`,
-  `lakehouseRef`, `asOf` to `TabMeta` (design §1).
-  Files: `packages/sheets/src/model/workbook/worksheet-document.ts`.
-  Done: types compile; a lakehouse tab round-trips through Yorkie.
+  `lakehouseRef`, `asOf` to `TabMeta` (design §1). Make
+  `worksheet-shape-migration.ts` tolerate old documents missing these fields
+  (leave them `undefined`; no backfill) and add a migration test case.
+  Files: `packages/sheets/src/model/workbook/worksheet-document.ts`,
+  `packages/backend/src/yorkie/worksheet-shape-migration.ts` (+ its `.spec.ts`).
+  Done: types compile; old docs migrate cleanly; a lakehouse tab round-trips
+  through Yorkie.
 - [ ] **Frontend: dialog + selector + view + tab entry.**
   Scope: `LakehouseDialog` (create/edit connection + Test), `LakehouseSelector`
   (pick when adding a tab), `LakehouseView` (loads `/read` results into a

--- a/docs/tasks/active/20260625-sheets-lakehouse-connector-todo.md
+++ b/docs/tasks/active/20260625-sheets-lakehouse-connector-todo.md
@@ -1,0 +1,264 @@
+# TODO — Lakehouse connector in sheets (Roadmap ②)
+
+Design doc: [lakehouse-connected-sheet.md](../../design/sheets/lakehouse-connected-sheet.md) ·
+Issue bodies: [20260625-sheets-external-data-sources-issues.md](20260625-sheets-external-data-sources-issues.md) ·
+Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
+
+Reads open table formats (Iceberg/Delta) from object storage via embedded
+DuckDB, with a time-travel slider. Reuses the datasource read-only spine.
+
+Each subissue is one PR. Every task lists **what / files / reuse / done** so a
+contributor can pick it up without reading the whole design doc. Paths are the
+intended targets; mirror the existing `packages/backend/src/datasource/` module
+and `packages/frontend/src/app/spreadsheet/datasource-view.tsx`.
+
+## Subissue dependency graph
+
+```
+  LH-0 · DuckDB engine  ── foundational; also unblocks File Import FI-2/3/4
+   ├─► LH-1 · Iceberg read + connection model
+   │     ├─► LH-2 · format auto-detect (needs LH-3 too)
+   │     ├─► LH-3 · Delta read
+   │     ├─► LH-4 · catalog mode ──► LH-7 · catalog/table browser + polish
+   │     ├─► LH-5 · time-travel slider ──► LH-9 · Hudi via XTable (later)
+   │     └─► LH-8 · test strategy (emulators + parity)
+   └─► LH-6 · object-storage backends (S3/GCS/Azure/MinIO)  [shared with FI-4]
+```
+
+---
+
+## LH-0 — Embedded DuckDB engine in backend  ·  depends on: —
+
+**Goal:** an in-process DuckDB usable by the backend, proven against Iceberg &
+Delta on MinIO, with time-travel syntax pinned.
+**Primary files:** `packages/backend/src/lakehouse/duckdb.service.ts` (new),
+`packages/backend/package.json`, root `docker-compose.yml`, backend image build.
+
+- [ ] **Verification spike (throwaway script).**
+  Scope: read latest rows + history + a past version for one Iceberg and one
+  Delta table on a local MinIO; confirm exact syntax (`iceberg_scan(...)`,
+  `delta_scan(..., version => N)`, `TIMESTAMP AS OF`, `iceberg_snapshots(...)`).
+  Files: scratch script + a temporary MinIO `docker-compose` service.
+  Done: findings (syntax + version pins) written back into the design doc; no
+  product code committed.
+- [ ] **DuckDB singleton + connection pool.**
+  Scope: a `DuckDbService` owning one DuckDB instance and lending pooled
+  connections; `INSTALL`/`LOAD iceberg, delta, httpfs, azure` once on module
+  init (never per request). Add `@duckdb/node-api` dependency.
+  Files: `packages/backend/src/lakehouse/duckdb.service.ts`, `package.json`.
+  Done: service injectable; a unit test runs `SELECT 42` through a pooled conn.
+- [ ] **Extension loading for CI/locked networks.**
+  Scope: ensure extensions auto-load offline (pre-bundle or vendored path);
+  document the env for air-gapped deploys.
+  Done: integration runs with no network extension fetch.
+- [ ] **DuckDB binary in the backend image.**
+  Scope: add the native binary to the backend Docker build; match runtime platform.
+  Files: backend `Dockerfile` / CI image step.
+  Done: container boots and loads extensions.
+
+**Acceptance:** an integration test reads a committed Iceberg + Delta fixture
+from MinIO through `DuckDbService`; engine reusable by LH-1; `pnpm verify:fast`.
+
+---
+
+## LH-1 — Connection model + Iceberg read  ·  depends on: LH-0
+
+**Goal:** create an encrypted lakehouse connection and render an Iceberg table
+read-only in a new tab.
+**Primary files:** `packages/backend/prisma/schema.prisma`,
+`packages/backend/src/lakehouse/` (module/service/controller/dto),
+`packages/sheets/src/model/workbook/worksheet-document.ts`,
+`packages/frontend/src/app/spreadsheet/lakehouse-view.tsx`,
+`packages/frontend/src/components/{lakehouse-dialog,lakehouse-selector,tab-bar}.tsx`,
+`packages/frontend/src/api/lakehouse.ts`.
+
+- [ ] **`LakehouseSource` Prisma model + migration.**
+  Scope: model per design §2 (name, format, storage, endpoint, region, bucket,
+  basePath, catalogMode, catalogUri, credentials, workspaceId, authorID).
+  Reuse: `src/datasource/crypto.util.ts` to encrypt `credentials`. Run
+  `pnpm backend migrate`.
+  Done: CRUD persists; `credentials` stored encrypted, masked in API responses.
+- [ ] **Lakehouse backend module (service/controller/dto).**
+  Scope: mirror `src/datasource/`; endpoints `POST|GET|PATCH|DELETE
+  /workspaces/:wid/lakehouse-sources`, `POST /:id/test`, `POST /:id/read`;
+  workspace-membership guard.
+  Reuse: datasource controller/dto patterns, `combined-auth` guard.
+  Done: controller-contract e2e green; non-members get 403.
+- [ ] **Iceberg read via `iceberg_scan`.**
+  Scope: `read` executes direct-metadata Iceberg through `DuckDbService`; wrap
+  `SELECT * FROM (...) LIMIT 10001`, set 10k truncation flag + statement/connection
+  timeouts; scan-only validation.
+  Reuse: `src/datasource/sql-validator.ts`. Output the shared
+  `{ columns:[{name,dataTypeID}], rows, rowCount, truncated, executionTime }`.
+  Done: returns correct rows for the Iceberg fixture.
+- [ ] **Sheets: lakehouse tab type + `TabMeta` fields.**
+  Scope: add `"lakehouse"` to `TabType`; add `lakehouseSourceId`,
+  `lakehouseRef`, `asOf` to `TabMeta` (design §1).
+  Files: `packages/sheets/src/model/workbook/worksheet-document.ts`.
+  Done: types compile; a lakehouse tab round-trips through Yorkie.
+- [ ] **Frontend: dialog + selector + view + tab entry.**
+  Scope: `LakehouseDialog` (create/edit connection + Test), `LakehouseSelector`
+  (pick when adding a tab), `LakehouseView` (loads `/read` results into a
+  `ReadOnlyStore` and renders), "New Lakehouse" item in `tab-bar.tsx`, and an
+  `api/lakehouse.ts` client.
+  Reuse: `datasource-view.tsx`, `datasource-dialog.tsx`, `datasource-selector.tsx`,
+  `ReadOnlyStore` + `toCell`.
+  Done: user creates a connection → adds a lakehouse tab → sees rows.
+
+**Acceptance:** Iceberg connection on MinIO → tab → rows render; creds encrypted
++ masked; workspace-scoped; `pnpm verify:fast`; integration behind
+`RUN_LAKEHOUSE_INTEGRATION_TESTS`.
+
+---
+
+## LH-2 — Format auto-detect + manual override  ·  depends on: LH-1, LH-3
+
+**Goal:** the user doesn't have to declare Iceberg vs Delta for a direct path.
+**Primary files:** `packages/backend/src/lakehouse/lakehouse.service.ts`,
+`packages/frontend/src/components/lakehouse-dialog.tsx`.
+
+- [ ] **Path-marker detection.**
+  Scope: on `test`/`read`, list the table root and detect `_delta_log/` → Delta,
+  `metadata/` + `*.metadata.json` → Iceberg, `.hoodie/` → Hudi (unsupported).
+  Done: returns a `detectedFormat` for fixtures of each type.
+- [ ] **`format` becomes `auto | iceberg | delta` (default `auto`) + override.**
+  Scope: model/UI field; catalog mode skips detection (catalog implies format).
+  Done: override respected; `.hoodie/` yields a clear "Hudi unsupported" error.
+
+**Acceptance:** Delta & Iceberg auto-detected; override works; Hudi rejected
+clearly; `pnpm verify:fast`.
+
+---
+
+## LH-3 — Delta read  ·  depends on: LH-1
+
+**Goal:** read Delta tables, reusing all LH-1 infrastructure.
+**Primary files:** `packages/backend/src/lakehouse/lakehouse.service.ts`, test fixtures.
+
+- [ ] **`delta_scan` read path.**
+  Scope: `format=delta` branch calling `delta_scan(...)` through `DuckDbService`;
+  same wrap/limit/timeout/response as Iceberg.
+  Done: a Delta fixture renders read-only.
+- [ ] **Delta test fixtures.**
+  Scope: commit a tiny Delta table (≥3 versions) under test fixtures + a regen note.
+  Done: used by LH-8 parity/time-travel tests.
+
+**Acceptance:** Delta table renders read-only; `pnpm verify:fast`.
+
+---
+
+## LH-4 — Catalog mode (Iceberg REST / S3 Tables)  ·  depends on: LH-1
+
+**Goal:** connect to a managed catalog and list its tables.
+**Primary files:** `packages/backend/src/lakehouse/lakehouse.service.ts` + controller.
+
+- [ ] **Attach Iceberg REST catalog / S3 Tables.**
+  Scope: when `catalogMode != direct-metadata`, `ATTACH` the catalog (OAuth2/ARN
+  via stored creds) and read `<ns>.<table>`.
+  Done: a REST-catalog table renders.
+- [ ] **`GET /:id/tables` (catalog listing).**
+  Scope: list namespaces/tables from the catalog for the picker.
+  Done: endpoint returns the table list for a test catalog.
+
+**Acceptance:** REST-catalog Iceberg renders; tables list returns; `pnpm verify:fast`.
+
+---
+
+## LH-5 — Time-travel slider  ·  depends on: LH-1 (ideally LH-3)
+
+**Goal:** drag a slider over commit history to view the table *as of* a commit.
+**Primary files:** `packages/backend/src/lakehouse/lakehouse.{service,controller}.ts`,
+`packages/frontend/src/app/spreadsheet/lakehouse-view.tsx` + a new
+`TimeTravelSlider` component, `packages/sheets/.../worksheet-document.ts` (asOf persist).
+
+- [ ] **History endpoint `GET /:id/history`.**
+  Scope: return `[{ ref, timestamp, operation, summary? }]` from
+  `iceberg_snapshots(...)` (Iceberg) / Delta history.
+  Done: ordered timeline for a ≥3-commit fixture.
+- [ ] **`/read` accepts `asOf` → time-travel SQL.**
+  Scope: emit `delta_scan(version=>N)` / `TIMESTAMP AS OF` / Iceberg snapshot
+  selection per `TimeTravelPoint`.
+  Done: `asOf` version N returns the historical row set; timestamp resolves to
+  commit-at-or-before.
+- [ ] **`TimeTravelSlider` UI + Yorkie persistence.**
+  Scope: discrete stops = commits (label = timestamp + operation), "Latest" at
+  the right; on change call `/read` with the new `asOf`, reload the
+  `ReadOnlyStore`, and write `asOf` to `TabMeta`.
+  Done: dragging repaints; collaborators see the same `asOf`; "Latest" clears it.
+
+**Acceptance:** drag re-queries + repaints at the selected commit; `asOf` shared
+via Yorkie; `pnpm verify:fast`.
+
+---
+
+## LH-6 — Object-storage backends (S3 / GCS / Azure / MinIO)  ·  depends on: LH-0
+
+**Goal:** mint DuckDB secrets for each storage backend. Shared with File Import FI-4.
+**Primary files:** `packages/backend/src/lakehouse/duckdb.service.ts` (secret minting).
+
+- [ ] **S3 + S3-compatible (MinIO/R2).** Scope: `CREATE SECRET (TYPE s3)` from
+  decrypted creds; custom endpoint + path-style for compatibles. Done: reads from MinIO.
+- [ ] **Azure Blob / ADLS.** Scope: `azure` extension + Azure secret. Done: reads from Azurite.
+- [ ] **GCS (S3-interop / HMAC).** Scope: HMAC-key secret via httpfs. Done: reads a GCS-interop fixture.
+
+**Acceptance:** the same fixture reads from each backend (verified by LH-8 parity
+suite); `pnpm verify:fast`.
+
+---
+
+## LH-7 — Catalog/table browser + polish  ·  depends on: LH-4
+
+**Goal:** pick a table from a list instead of typing a metadata URI.
+**Primary files:** `packages/frontend/src/components/lakehouse-selector.tsx`,
+`lakehouse-view.tsx`.
+
+- [ ] **Table browser.** Scope: flat list + namespace navigation from
+  `GET /:id/tables`; select to set `lakehouseRef`. Done: pick a table, tab loads it.
+- [ ] **Connection-test UX + states.** Scope: surface test result, loading,
+  unreachable/credential errors. Done: clear messages for bad creds / unreachable storage.
+
+**Acceptance:** select a catalog table end-to-end; clear errors; `pnpm verify:fast`;
+smoke in `pnpm dev`.
+
+---
+
+## LH-8 — Test strategy (emulators + connector-parity)  ·  depends on: LH-1
+
+**Goal:** verify many connectors with $0 local CI.
+Detail: design [§8](../../design/sheets/lakehouse-connected-sheet.md#8-test-strategy).
+**Primary files:** root `docker-compose.yml`, `.github/workflows/ci.yml`,
+`packages/backend/test/lakehouse-*.e2e-spec.ts`, committed fixtures.
+
+- [ ] **Emulator services + fixture seeding.** Scope: MinIO + Azurite in
+  docker-compose; seed committed Iceberg/Delta fixtures at test setup. Done: emulators reachable in CI.
+- [ ] **Parameterized connector-parity suite.** Scope: one suite over
+  `[minio-s3, azurite-azure, gcs-interop, local-fs]` asserting secret mint →
+  list → read N rows → history length → `asOf(version K)`. Done: green for all backends.
+- [ ] **CI gate + wiring.** Scope: `RUN_LAKEHOUSE_INTEGRATION_TESTS` gate; run
+  per PR like the existing Postgres/Yorkie services. Done: CI runs the suite on PRs.
+- [ ] **(optional) R2 free-tier smoke.** Scope: scheduled/manual job, repo
+  secrets, never fork PRs. Done: real S3-compatible read passes off the hot path.
+
+**Acceptance:** parity green across all local backends; CI runs gated suites per PR.
+
+---
+
+## LH-9 — Hudi via Apache XTable (later)  ·  depends on: LH-5
+
+**Goal:** decide a best-effort Hudi path.
+- [ ] **Evaluate Apache XTable** (Hudi → Iceberg/Delta metadata translation) and
+  a Trino-gateway alternative; record the decision (+ demo if pursued) in the design doc.
+
+**Acceptance:** decision documented with rationale.
+
+---
+
+## Cross-cutting
+
+- [ ] `docs/design/README.md` Sheets section updated (done on ideation branch)
+- [ ] Lessons in paired `20260625-sheets-lakehouse-connector-lessons.md`
+- [ ] After all merged: `pnpm tasks:archive && pnpm tasks:index`
+
+## Review
+
+(filled in at completion)

--- a/docs/tasks/active/20260625-sheets-mysql-connector-todo.md
+++ b/docs/tasks/active/20260625-sheets-mysql-connector-todo.md
@@ -55,9 +55,12 @@ one extra driver.
 **Goal:** browse MySQL tables/columns.
 **Files:** `datasource.service.ts` (+ existing schema endpoint if present), frontend sidebar.
 
-- [ ] **`information_schema` listing (engine-agnostic)** — the same
-  `information_schema.tables/columns` queries work for MySQL. Done: browse + click
-  to insert.
+- [ ] **`information_schema` listing (per-engine template)** — reuse the Postgres
+  `information_schema.tables/columns` query patterns, adjusting for MySQL dialect
+  (backtick quoting, identifier case sensitivity, `table_type`/`table_schema`
+  value differences). Keep an engine-keyed query template rather than assuming
+  one query string works unchanged. Done: browse + click to insert on both
+  engines.
 
 ### M4 — Test
 

--- a/docs/tasks/active/20260625-sheets-mysql-connector-todo.md
+++ b/docs/tasks/active/20260625-sheets-mysql-connector-todo.md
@@ -1,0 +1,87 @@
+# TODO — MySQL connector in sheets (④, single feature issue)
+
+Design doc: [mysql-connector.md](../../design/sheets/mysql-connector.md) ·
+Issue bodies: [20260625-sheets-external-data-sources-issues.md](20260625-sheets-external-data-sources-issues.md) ·
+Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
+
+Single feature issue (no subissues). Milestones below are internal; ~1 PR,
+`pnpm verify:fast` green. Extends the existing PostgreSQL datasource to
+MySQL/MariaDB via the native `mysql2` client behind an `engine` discriminator.
+Independent of Roadmaps ①②③. ~250–450 LOC.
+
+Each task lists **what / files / reuse / done**. This is the smallest connector:
+almost everything is the existing `packages/backend/src/datasource/` module plus
+one extra driver.
+
+## Task breakdown (internal milestones, not subissues)
+
+```
+  M1 connection + query (foundation) ─► { M2 frontend, M3 schema browser, M4 test }
+```
+
+### M1 — Connection (engine discriminator) + query execution
+
+**Goal:** run a MySQL SELECT read-only without breaking the Postgres path.
+**Files:** `packages/backend/prisma/schema.prisma`,
+`packages/backend/src/datasource/datasource.service.ts`,
+`packages/backend/package.json`, reuse `datasource/sql-validator.ts` +
+`crypto.util.ts`.
+
+- [ ] **`engine` field + migration** — add `engine String @default("postgres")`
+  to `DataSource`; existing rows default to postgres (backward compatible). Done:
+  migration applies; Postgres connections unaffected.
+- [ ] **`mysql2` dependency + driver dispatch** — add `mysql2`; the service picks
+  `pg` vs `mysql2` by `engine`; default port by engine (5432/3306). Done: a MySQL
+  connection connects.
+- [ ] **Execute + map to response shape** — reuse the SELECT/WITH validator and
+  `LIMIT 10001` + 10k cap; map `mysql2` fields/rows → `{ columns:[{name,dataTypeID}],
+  rows, rowCount, truncated, executionTime }`; set `dateStrings: true` to avoid
+  timezone shift (mirrors the Postgres raw-text approach). Done: a MySQL SELECT
+  renders read-only; Postgres path unchanged.
+
+### M2 — Frontend: engine selector
+
+**Goal:** create a MySQL connection from the UI.
+**Files:** `packages/frontend/src/components/datasource-dialog.tsx`,
+`packages/frontend/src/app/spreadsheet/datasource-view.tsx`.
+
+- [ ] **Engine selector + port default** — add a PostgreSQL/MySQL choice; the
+  port field defaults by engine. Done: dialog creates a MySQL connection.
+- [ ] **Reuse the datasource view** — MySQL tabs use the existing SQL editor /
+  results grid unchanged. Done: create → tab → query → results end-to-end.
+
+### M3 — Schema browser
+
+**Goal:** browse MySQL tables/columns.
+**Files:** `datasource.service.ts` (+ existing schema endpoint if present), frontend sidebar.
+
+- [ ] **`information_schema` listing (engine-agnostic)** — the same
+  `information_schema.tables/columns` queries work for MySQL. Done: browse + click
+  to insert.
+
+### M4 — Test
+
+**Goal:** CI covers both engines locally, no cost.
+**Files:** root `docker-compose.yml`, `packages/backend/test/datasource-*.e2e-spec.ts`.
+
+- [ ] **MySQL docker-compose service** — alongside the existing Postgres service.
+  Done: MySQL reachable in CI.
+- [ ] **Run datasource integration against MySQL** — parameterize the suite over
+  both engines behind `RUN_DB_INTEGRATION_TESTS`. Done: integration green for
+  Postgres and MySQL.
+
+## Acceptance (issue-level)
+
+- Create a MySQL connection → tab → query → results end-to-end; Postgres path unaffected.
+- Creds encrypted + masked; integration green for both engines; `pnpm verify:fast`.
+
+## Cross-cutting
+
+- [ ] `docs/design/README.md` updated (done on ideation branch)
+- [ ] Consider updating root `README.md` "coming soon" copy when shipped
+- [ ] Lessons in `20260625-sheets-mysql-connector-lessons.md`
+- [ ] After merge: `pnpm tasks:archive && pnpm tasks:index`
+
+## Review
+
+(filled in at completion)

--- a/docs/tasks/active/20260625-sheets-mysql-connector-todo.md
+++ b/docs/tasks/active/20260625-sheets-mysql-connector-todo.md
@@ -1,8 +1,6 @@
 # TODO — MySQL connector in sheets (④, single feature issue)
 
-Design doc: [mysql-connector.md](../../design/sheets/mysql-connector.md) ·
-Issue bodies: [20260625-sheets-external-data-sources-issues.md](20260625-sheets-external-data-sources-issues.md) ·
-Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
+Design doc: [mysql-connector.md](../../design/sheets/mysql-connector.md) · Epic index: [20260625-sheets-external-data-sources-todo.md](20260625-sheets-external-data-sources-todo.md)
 
 Single feature issue (no subissues). Milestones below are internal; ~1 PR,
 `pnpm verify:fast` green. Extends the existing PostgreSQL datasource to


### PR DESCRIPTION
## Summary
Design docs for four sheet data connectors built on the existing datasource read-only spine: a lakehouse connector (Iceberg/Delta over object storage via embedded DuckDB with a time-travel slider), file import (CSV/Parquet/JSON), and BigQuery and MySQL connectors.

Lakehouse and file import are roadmaps split into scoped subissue task docs; BigQuery and MySQL are single cohesive connectors. Each task lists what/files/reuse/done so contributors can pick it up directly.

## Why

## Linked Issues

Fixes #

## Author checklist

- [X] I searched existing issues and PRs and confirmed this is not a duplicate.
- [X] I read every line of this diff and can explain why each change is necessary.
- [X] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [X] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
- Follow-up work (if any):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new Sheets design documents for external data sources, including file import, Lakehouse connected sheets (time-travel + read-only), BigQuery, and MySQL/MariaDB.
  * Added supporting Sheets task/roadmap documents to outline implementation steps, UX expectations, and rollout sequencing for each initiative.
  * Expanded the Sheets design document index to include the new connectors and import/connect specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->