### PR TITLE
Show progress toast during docs/slides export

### DIFF
--- a/docs/design/export-progress.md
+++ b/docs/design/export-progress.md
@@ -37,7 +37,8 @@ flow ("Exporting … 12 / 50 slides").
 ### A. Progress callback in exporters
 
 Each exporter gains an optional callback, mirroring the import
-wrapped-callback pattern (`docx-importer.ts`, `pptx/index.ts`):
+wrapped-callback pattern (`packages/docs/src/import/docx-importer.ts`,
+`packages/slides/src/import/pptx/index.ts`):
 
 ```ts
 onProgress?: (done: number, total: number, phase: string) => void;
@@ -50,12 +51,12 @@ toast never sticks.
 
 Per-export progress unit:
 
-| Export        | Unit        | Phase label | Loop location                              |
-| ------------- | ----------- | ----------- | ------------------------------------------ |
-| Slides PDF    | slide       | `slides`    | `slides/src/export/pdf.ts` per-slide loop  |
-| Slides PPTX   | slide       | `slides`    | `slides/src/export/pptx/index.ts` per-slide |
-| Docs PDF      | page        | `pages`     | `docs/src/export/pdf-exporter.ts` per-page |
-| Docs DOCX     | image fetch | `images`    | `docs/src/export/docx-exporter.ts` images  |
+| Export        | Unit        | Phase label | Loop location                                          |
+| ------------- | ----------- | ----------- | ------------------------------------------------------ |
+| Slides PDF    | slide       | `slides`    | `packages/slides/src/export/pdf.ts` per-slide loop     |
+| Slides PPTX   | slide       | `slides`    | `packages/slides/src/export/pptx/index.ts` per-slide   |
+| Docs PDF      | page        | `pages`     | `packages/docs/src/export/pdf-exporter.ts` per-page    |
+| Docs DOCX     | image fetch | `images`    | `packages/docs/src/export/docx-exporter.ts` per-image  |
 
 DOCX reports on image fetches (the actual bottleneck for large files,
 identical to import's "Embedding images X / Y"); when a document has no
@@ -94,7 +95,7 @@ units" — but start with per-unit for the smoothest progress.
 
 A shared `updateExportToast` helper (added to
 `packages/frontend/src/app/docs/export-utils.ts`) mirrors `updateImportToast`
-in `document-list.tsx`:
+in `packages/frontend/src/app/documents/document-list.tsx`:
 
 ```ts
 function updateExportToast(id, title, done, total, unit): string | number {
@@ -105,7 +106,8 @@ function updateExportToast(id, title, done, total, unit): string | number {
 }
 ```
 
-Each export button (`docs-export-button.tsx`, `slides-export-button.tsx`)
+Each export button (`packages/frontend/src/app/docs/docs-export-button.tsx`,
+`packages/frontend/src/app/slides/slides-export-button.tsx`)
 threads an `onProgress` into its export action, which calls
 `updateExportToast`. On success the toast becomes `toast.success`; on failure
 the existing `toast.error` path is preserved. The current spinner icon and

--- a/docs/design/export-progress.md
+++ b/docs/design/export-progress.md
@@ -117,7 +117,7 @@ exports only flash briefly.
 
 ### Data flow (slides PDF example)
 
-```
+```text
 slides-export-button → exportSlidesPdf(doc, { onProgress })
   loop slides: drawSlide → emit(done, total, 'slides') → await yieldToPaint()
 onProgress(done, total, 'slides') → updateExportToast(id, title, done, total, 'slides')

--- a/docs/design/export-progress.md
+++ b/docs/design/export-progress.md
@@ -1,0 +1,145 @@
+---
+title: export-progress
+target-version: 0.4.9
+---
+
+# Export Progress Reporting
+
+## Summary
+
+Large exports (slides PDF/PPTX, docs PDF/DOCX) freeze the UI for several
+seconds with only a spinner. The root cause is two-fold: the heavy export
+loops run **synchronously on the main thread**, blocking the event loop, and
+there is **no progress reporting**. This design adds an `onProgress` callback
+to each exporter and inserts cooperative event-loop yields between work units,
+then surfaces progress through a Sonner toast that mirrors the existing import
+flow ("Exporting … 12 / 50 slides").
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Show incremental progress for slides PDF, slides PPTX, docs PDF, docs DOCX.
+- Keep the UI responsive during export (toast actually repaints).
+- Reuse the import toast UX for consistency.
+- Keep the export libraries (`@wafflebase/docs`, `@wafflebase/slides`) pure —
+  no DOM/toast coupling; they only expose callbacks.
+
+**Non-Goals**
+
+- Cancellation (the chosen toast UX has no cancel button, matching import).
+- Web workers / off-main-thread export (much larger change; deferred).
+- A determinate progress-bar modal (rejected for import/export UX parity).
+- Sheets export (out of scope for this task).
+
+## Proposal Details
+
+### A. Progress callback in exporters
+
+Each exporter gains an optional callback, mirroring the import
+wrapped-callback pattern (`docx-importer.ts`, `pptx/index.ts`):
+
+```ts
+onProgress?: (done: number, total: number, phase: string) => void;
+```
+
+Contract: emit `(0, total, phase)` once before work starts, then `(done,
+total, phase)` after each unit completes, ending at `(total, total, phase)`.
+Wrap emit in `try/finally` so a failing unit still advances `done` and the
+toast never sticks.
+
+Per-export progress unit:
+
+| Export        | Unit        | Phase label | Loop location                              |
+| ------------- | ----------- | ----------- | ------------------------------------------ |
+| Slides PDF    | slide       | `slides`    | `slides/src/export/pdf.ts` per-slide loop  |
+| Slides PPTX   | slide       | `slides`    | `slides/src/export/pptx/index.ts` per-slide |
+| Docs PDF      | page        | `pages`     | `docs/src/export/pdf-exporter.ts` per-page |
+| Docs DOCX     | image fetch | `images`    | `docs/src/export/docx-exporter.ts` images  |
+
+DOCX reports on image fetches (the actual bottleneck for large files,
+identical to import's "Embedding images X / Y"); when a document has no
+images, `total` is 0 and the toast shows the indeterminate
+`Exporting "…"` form.
+
+### B. Cooperative yield (the real un-freeze)
+
+Reporting alone is insufficient: a blocked event loop never repaints the
+toast. Between each unit the loop awaits a macrotask yield:
+
+```ts
+// small per-package util, e.g. slides/src/export/yield.ts
+export function yieldToPaint(): Promise<void> {
+  // MessageChannel macrotask avoids setTimeout's ~4ms clamp
+  if (typeof MessageChannel === 'undefined') {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return new Promise((resolve) => {
+    const ch = new MessageChannel();
+    ch.port1.onmessage = () => resolve();
+    ch.port2.postMessage(0);
+  });
+}
+```
+
+`docs` and `slides` each get a tiny local copy (no shared package needed).
+In non-DOM contexts (Node CLI export, tests) `MessageChannel` is available in
+modern Node; a `setTimeout(0)` fallback guards if it is undefined.
+
+Overhead is negligible: 50 slides → 50 yields; a 500-page doc → a few hundred
+zero-delay macrotasks. If profiling shows cost, throttle to "yield every N
+units" — but start with per-unit for the smoothest progress.
+
+### C. Frontend toast wiring
+
+A shared `updateExportToast` helper (added to
+`packages/frontend/src/app/docs/export-utils.ts`) mirrors `updateImportToast`
+in `document-list.tsx`:
+
+```ts
+function updateExportToast(id, title, done, total, unit): string | number {
+  const description = total > 0 ? `${Math.min(done, total)} / ${total} ${unit}` : undefined;
+  if (id === undefined) return toast.loading(`Exporting "${title}"…`, { description });
+  toast.loading(`Exporting "${title}"…`, { id, description });
+  return id;
+}
+```
+
+Each export button (`docs-export-button.tsx`, `slides-export-button.tsx`)
+threads an `onProgress` into its export action, which calls
+`updateExportToast`. On success the toast becomes `toast.success`; on failure
+the existing `toast.error` path is preserved. The current spinner icon and
+`disabled` state stay as complementary feedback. The toast is shown always
+(matching import) and is immediately replaced by the success toast, so small
+exports only flash briefly.
+
+### Data flow (slides PDF example)
+
+```
+slides-export-button → exportSlidesPdf(doc, { onProgress })
+  loop slides: drawSlide → emit(done, total, 'slides') → await yieldToPaint()
+onProgress(done, total, 'slides') → updateExportToast(id, title, done, total, 'slides')
+done → toast.success("Exported \"Deck\"")
+```
+
+## Risks and Mitigation
+
+- **Yield overhead on huge docs** — per-unit macrotask yields add up on
+  500+ page PDFs. Mitigation: MessageChannel (no 4ms clamp); fall back to
+  throttled "every N units" if profiling warrants.
+- **Node/CLI export path** — exporters run headless in the CLI. Mitigation:
+  `MessageChannel` exists in modern Node; guard with `setTimeout` fallback and
+  treat `onProgress` as optional (CLI passes none).
+- **Toast flash on tiny exports** — accepted; matches import, success toast
+  replaces it instantly.
+- **Partial-failure stuck toast** — emit in `try/finally`; final throw routes
+  to the existing error toast which dismisses the loading toast.
+
+## Testing
+
+- Unit test per exporter: inject an `onProgress` mock, assert it starts at
+  `(0, total)`, is monotonically non-decreasing, and ends at `(total, total)`.
+- `yieldToPaint` is a pure function with no build impact; smoke-test it
+  resolves.
+- Manual smoke in `pnpm dev`: export a large deck/doc, confirm the toast
+  counts up and the UI stays responsive.

--- a/docs/tasks/active/20260628-export-progress-lessons.md
+++ b/docs/tasks/active/20260628-export-progress-lessons.md
@@ -1,0 +1,47 @@
+# Export Progress Reporting — Lessons
+
+## What worked
+
+- **The freeze fix is yielding, not progress.** Reporting `onProgress` alone
+  would never repaint a Sonner toast — the heavy export loops hold the main
+  thread synchronously. The load-bearing change is `await yieldToPaint()`
+  (a `MessageChannel` macrotask, no `setTimeout` 4ms clamp) *between* units.
+  Progress reporting is the visible half; the yield is what unblocks paint.
+- **Phase string as the unit label.** Emitting `'slides'`/`'pages'`/`'images'`
+  and forwarding it straight into `updateExportToast(..., unit)` removed any
+  per-export mapping table in the frontend — one less thing to keep in sync.
+- **Per-task reviewers instructed to verify guessed identifiers against source.**
+  The plan's test fixtures guessed import paths; the dispatch prompts told each
+  implementer to confirm against the real model files. This caught
+  `BUILT_IN_THEMES` living in `src/themes/index.ts`, not `src/model/theme`
+  (Task 2), and the inline image style shape (Task 4) — before a red build.
+
+## Gotchas worth remembering
+
+- **PPTX export has no browser trigger.** `exportPptx` is unreferenced in
+  `packages/frontend` (CLI/Node only). We still added the library-level
+  `onProgress` for parity/future, but there is no toast wiring — there was no
+  UI freeze to fix. Surface "is this even reachable from the UI?" during
+  planning, not after.
+- **Frontend consumes built dist, not src.** New exporter options
+  (`onProgress`) were invisible to the frontend typecheck until
+  `pnpm --filter @wafflebase/docs build && pnpm --filter @wafflebase/slides build`
+  ran. The frontend task's first step had to be the rebuild.
+  (See memory: packages-consume-built-dist.)
+- **DOCX needs no yield.** Its bottleneck is per-image `await imageFetcher()`,
+  genuine async I/O that already cedes the loop — so DOCX is progress-only,
+  mirroring the import "Embedding images X/Y" UX. Don't add a yield where the
+  await already exists.
+- **Count must equal fetch calls.** DOCX `total` = unique srcs *per part*
+  (body/header/footer have separate dedupe arrays), matching `collectImages`'s
+  per-part `entries.some(...)`. A global dedupe would have under-counted and
+  left `done > total`.
+
+## Known minor limitations (non-blocking, from final review)
+
+- `exportPdfAndDownload`'s `metadata` param is now unreachable via the UI
+  (onProgress inserted before it); harmless, candidate for a tidy-up.
+- `yieldToPaint()` allocates a fresh `MessageChannel` per call (GC-eligible;
+  React's scheduler reuses one — optional micro-opt).
+- PPTX/Docs-PDF progress tests assert the contract loosely (no exact call
+  count / `>0` not `>1`); fixtures make them pass reliably.

--- a/docs/tasks/active/20260628-export-progress-lessons.md
+++ b/docs/tasks/active/20260628-export-progress-lessons.md
@@ -37,11 +37,37 @@
   per-part `entries.some(...)`. A global dedupe would have under-counted and
   left `done > total`.
 
-## Known minor limitations (non-blocking, from final review)
+## Code-review pass (high-effort, 7 finder angles)
 
-- `exportPdfAndDownload`'s `metadata` param is now unreachable via the UI
-  (onProgress inserted before it); harmless, candidate for a tidy-up.
-- `yieldToPaint()` allocates a fresh `MessageChannel` per call (GC-eligible;
-  React's scheduler reuses one — optional micro-opt).
-- PPTX/Docs-PDF progress tests assert the contract loosely (no exact call
-  count / `>0` not `>1`); fixtures make them pass reliably.
+After the branch was green, a `/code-review` pass surfaced findings. Fixed the
+high-value, low-risk ones in commit "Address export-progress code-review
+findings":
+
+- **DOCX stuck at `0/N`**: the initial `(0, N)` emit was gated on `onProgress`
+  alone, but fetching is gated on `imageFetcher && onProgress`. A caller with
+  `onProgress` but no fetcher emitted `(0, N)` then never advanced. Now both
+  the total and the emit are gated on `reportProgress = imageFetcher &&
+  onProgress`.
+- **Zero-image DOCX toast flash**: `updateExportToast` now returns `undefined`
+  (creates no toast) when `total === 0`, so an image-less DOCX no longer
+  flashes a descriptionless loading spinner before success.
+- **Slides button re-entrancy**: added the `if (exporting) return` guard the
+  docs button already had.
+- **PPTX loop**: loops on the captured `slideTotal` rather than re-reading
+  `deck.slides.length`.
+
+## Known minor limitations (deliberately not fixed)
+
+- **100%-then-save gap**: PDF exporters emit `(total, total)` after the last
+  page/slide, but `pdf.save()` still runs for a moment after — the toast reads
+  100% during final serialization. Still strictly better than a frozen
+  spinner; a true "finalizing" state is out of scope.
+- **`exportPdfAndDownload`'s `metadata` param** is unreachable via the UI
+  (onProgress inserted before it). No caller passes it; harmless.
+- **`yieldToPaint()` allocates a `MessageChannel` per call.** A module-level
+  reused channel (React-scheduler style) would save allocations, but the
+  queue/state it needs adds more risk than the cheap allocation costs — left
+  simple per the design's accepted per-call shape.
+- **Cross-part duplicate image** (same src in body + header) counts as 2 and is
+  fetched twice — pre-existing per-part dedupe behavior; count still matches
+  fetches so the bar is correct.

--- a/docs/tasks/active/20260628-export-progress-plan.md
+++ b/docs/tasks/active/20260628-export-progress-plan.md
@@ -1,0 +1,797 @@
+# Export Progress Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show incremental, import-style toast progress for large docs/slides exports and keep the UI responsive by yielding the event loop between heavy work units.
+
+**Architecture:** Each exporter gains an optional `onProgress(done, total, phase)` callback emitted per work unit (slide / page / image). Synchronous render loops (`drawSlide`, `paintPage`, `slideToXml`) `await yieldToPaint()` between units so the browser can repaint the toast. The frontend forwards the library `phase` string straight into a shared `updateExportToast` helper (the phase string — `slides`/`pages`/`images` — doubles as the toast unit label).
+
+**Tech Stack:** TypeScript, Vitest (jsdom), Sonner toasts, React.
+
+## Global Constraints
+
+- Design doc: `docs/design/export-progress.md`.
+- `onProgress` is always **optional**; CLI/Node/test callers omit it and behavior is unchanged.
+- Emit contract per exporter: `(0, total, phase)` once before work, then monotonically increasing `done` after each unit, ending at `(total, total, phase)`.
+- Phase strings are exactly `'slides'` (slides PDF + PPTX), `'pages'` (docs PDF), `'images'` (docs DOCX).
+- Producer packages (`@wafflebase/docs`, `@wafflebase/slides`) are consumed as **built dist** by the frontend — rebuild them before the frontend typechecks (memory: packages-consume-built-dist).
+- Docs imports use explicit `.js` extensions (NodeNext); slides imports use no extension. Match each package.
+- `pnpm verify:fast` green before every commit.
+
+---
+
+### Task 1: Slides yield util + Slides PDF progress
+
+**Files:**
+- Create: `packages/slides/src/export/yield.ts`
+- Modify: `packages/slides/src/export/pdf.ts` (`ExportSlidesPdfOptions` ~line 54-72; export loop ~line 129-163)
+- Test: `packages/slides/test/export/pdf.test.ts` (append one `it`)
+
+**Interfaces:**
+- Produces: `yieldToPaint(): Promise<void>` from `./yield`.
+- Produces: `ExportSlidesPdfOptions.onProgress?: (done: number, total: number, phase: string) => void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the top-level `describe` block (after the existing `collectFontFamilies` describe) in `packages/slides/test/export/pdf.test.ts`. It reuses the file's existing `baseDoc` / `blankSlide` helpers and global stubs (`OffscreenCanvas`, `Image`, object-URL) set up in `beforeEach`.
+
+```ts
+describe('exportSlidesPdf progress', () => {
+  it('reports monotonic per-slide progress ending at total', async () => {
+    const { exportSlidesPdf } = await import('../../src/export/pdf');
+    const doc = baseDoc([blankSlide('s1'), blankSlide('s2'), blankSlide('s3')]);
+    const calls: Array<[number, number, string]> = [];
+    await exportSlidesPdf(doc, {
+      onProgress: (done, total, phase) => calls.push([done, total, phase]),
+    });
+    expect(calls[0]).toEqual([0, 3, 'slides']);
+    expect(calls[calls.length - 1]).toEqual([3, 3, 'slides']);
+    const dones = calls.map((c) => c[0]);
+    expect(dones).toEqual([...dones].sort((a, b) => a - b)); // non-decreasing
+    expect(calls.every((c) => c[1] === 3 && c[2] === 'slides')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @wafflebase/slides test -- pdf.test.ts`
+Expected: FAIL — `onProgress` is not a known option / callback never invoked (`calls[0]` is `undefined`).
+
+- [ ] **Step 3: Create the yield util**
+
+Create `packages/slides/src/export/yield.ts`:
+
+```ts
+/**
+ * Resolve on the next macrotask so the browser can paint between heavy
+ * synchronous export units (per-slide canvas raster, per-slide XML). A
+ * `MessageChannel` macrotask avoids `setTimeout`'s ~4 ms clamp; falls back
+ * to `setTimeout(0)` where `MessageChannel` is unavailable (older Node).
+ */
+export function yieldToPaint(): Promise<void> {
+  if (typeof MessageChannel === 'undefined') {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return new Promise((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => resolve();
+    channel.port2.postMessage(0);
+  });
+}
+```
+
+- [ ] **Step 4: Add the option and emit + yield in the loop**
+
+In `packages/slides/src/export/pdf.ts`:
+
+Add the import near the other view imports (top of file):
+
+```ts
+import { yieldToPaint } from './yield';
+```
+
+Add the field to `ExportSlidesPdfOptions` (after `title?: string;`):
+
+```ts
+  /** Progress callback: `(done, total, 'slides')` once before work, then after each rendered slide. */
+  onProgress?: (done: number, total: number, phase: string) => void;
+```
+
+Replace the export loop (the `try { for (const slide of doc.slides) { … } } finally { … }` block) so it emits and yields. The body of the loop is unchanged — only the `onProgress` / `done` / `yieldToPaint` lines are added:
+
+```ts
+  const onProgress = opts.onProgress;
+  const total = doc.slides.length;
+  onProgress?.(0, total, 'slides');
+
+  try {
+    let done = 0;
+    for (const slide of doc.slides) {
+      const cloned = prepareExportSlide(slide, doc, map);
+
+      const srcs = imageSrcsToPreload(cloned);
+      await Promise.all(srcs.map((s) => awaitImageLoaded(s, assetTimeoutMs)));
+
+      const canvas = createExportCanvas(
+        Math.round(SLIDE_WIDTH * scale),
+        Math.round(SLIDE_HEIGHT * scale),
+      );
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        throw new Error('Failed to acquire a 2D context for PDF export.');
+      }
+      drawSlide(ctx as unknown as CanvasRenderingContext2D, cloned, doc, {
+        hostWidth: SLIDE_WIDTH,
+        hostHeight: SLIDE_HEIGHT,
+        dpr: scale,
+      });
+
+      const bytes = await canvasToBytes(canvas, format, quality);
+      const image =
+        format === 'jpeg' ? await pdf.embedJpg(bytes) : await pdf.embedPng(bytes);
+      const page = pdf.addPage([pageWidth, pageHeight]);
+      page.drawImage(image, { x: 0, y: 0, width: pageWidth, height: pageHeight });
+
+      done += 1;
+      onProgress?.(done, total, 'slides');
+      if (done < total) await yieldToPaint();
+    }
+  } finally {
+    if (temp.length > 0) {
+      evictImageSrcs(temp);
+      for (const url of temp) URL.revokeObjectURL(url);
+    }
+  }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @wafflebase/slides test -- pdf.test.ts`
+Expected: PASS (both the new progress test and the existing PDF tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/slides/src/export/yield.ts packages/slides/src/export/pdf.ts packages/slides/test/export/pdf.test.ts
+git commit -m "Slides PDF export: report per-slide progress and yield to paint"
+```
+
+---
+
+### Task 2: Slides PPTX progress (library only)
+
+PPTX export has **no frontend trigger** today (`exportPptx` is unreferenced in `packages/frontend`; only CLI/Node use it). This task adds the library-level callback for parity and future UI wiring — there is no toast wiring step.
+
+**Files:**
+- Modify: `packages/slides/src/export/pptx/index.ts` (`ExportPptxOptions` ~line 61-72; slide loop ~line 267-341)
+- Test: Create `packages/slides/test/export/pptx/progress.test.ts`
+
+**Interfaces:**
+- Consumes: `yieldToPaint` from `../yield` (created in Task 1).
+- Produces: `ExportPptxOptions.onProgress?: (done: number, total: number, phase: string) => void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/slides/test/export/pptx/progress.test.ts`. Mirror the deck-building style used by the sibling pptx tests (e.g. `slide.test.ts`) — a minimal image-free deck so `fetchImage` is unnecessary.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { exportPptx } from '../../../src/export/pptx/index';
+import type { Slide, SlidesDocument } from '../../../src/model/presentation';
+import { DEFAULT_BACKGROUND } from '../../../src/model/presentation';
+import { DEFAULT_MASTER } from '../../../src/model/master';
+import { BUILT_IN_LAYOUTS } from '../../../src/model/layout';
+import { BUILT_IN_THEMES } from '../../../src/model/theme';
+
+const blankSlide = (id: string): Slide => ({
+  id,
+  layoutId: 'blank',
+  background: { ...DEFAULT_BACKGROUND },
+  elements: [],
+  notes: [],
+});
+
+const deck = (slides: Slide[]): SlidesDocument => ({
+  meta: { title: 'Deck', themeId: BUILT_IN_THEMES[0].id, masterId: 'default' },
+  themes: [BUILT_IN_THEMES[0]],
+  masters: [DEFAULT_MASTER],
+  layouts: BUILT_IN_LAYOUTS,
+  slides,
+  guides: [],
+});
+
+describe('exportPptx progress', () => {
+  it('reports monotonic per-slide progress ending at total', async () => {
+    const calls: Array<[number, number, string]> = [];
+    await exportPptx(deck([blankSlide('s1'), blankSlide('s2')]), {
+      onProgress: (done, total, phase) => calls.push([done, total, phase]),
+    });
+    expect(calls[0]).toEqual([0, 2, 'slides']);
+    expect(calls[calls.length - 1]).toEqual([2, 2, 'slides']);
+    expect(calls.every((c) => c[1] === 2 && c[2] === 'slides')).toBe(true);
+  });
+});
+```
+
+> If `BUILT_IN_THEMES` / `DEFAULT_MASTER` / `BUILT_IN_LAYOUTS` import paths differ, copy the exact imports from an existing passing test in `packages/slides/test/export/pptx/` rather than guessing.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @wafflebase/slides test -- progress.test.ts`
+Expected: FAIL — `calls` is empty (`calls[0]` is `undefined`).
+
+- [ ] **Step 3: Add the option and emit + yield in the slide loop**
+
+In `packages/slides/src/export/pptx/index.ts`:
+
+Add the import next to the other local imports (with the `.js` extension this package's index uses elsewhere — note: confirm; this file uses `.js` extensions):
+
+```ts
+import { yieldToPaint } from '../yield.js';
+```
+
+Add the field to `ExportPptxOptions` (after the `fetchImage?` field):
+
+```ts
+  /** Progress callback: `(done, total, 'slides')` once before work, then after each serialized slide. */
+  onProgress?: (done: number, total: number, phase: string) => void;
+```
+
+Just before the slide loop (`for (let i = 0; i < deck.slides.length; i++) {`), emit the initial tick:
+
+```ts
+  const onProgress = opts.onProgress;
+  const slideTotal = deck.slides.length;
+  onProgress?.(0, slideTotal, 'slides');
+```
+
+At the **end** of the loop body, immediately after `slideRIds.push(slideRId);`, add:
+
+```ts
+    onProgress?.(i + 1, slideTotal, 'slides');
+    if (i + 1 < slideTotal) await yieldToPaint();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @wafflebase/slides test -- progress.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/slides/src/export/pptx/index.ts packages/slides/test/export/pptx/progress.test.ts
+git commit -m "Slides PPTX export: report per-slide progress and yield to paint"
+```
+
+---
+
+### Task 3: Docs yield util + Docs PDF progress
+
+**Files:**
+- Create: `packages/docs/src/export/yield.ts`
+- Modify: `packages/docs/src/export/pdf-exporter.ts` (`PdfExportOptions` ~line 30-50; per-page loop ~line 137-159)
+- Test: `packages/docs/test/export/pdf-exporter.test.ts` (append one `it`)
+
+**Interfaces:**
+- Produces: `yieldToPaint(): Promise<void>` from `./yield.js`.
+- Produces: `PdfExportOptions.onProgress?: (done: number, total: number, phase: string) => void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Open `packages/docs/test/export/pdf-exporter.test.ts`, read the top to find how it builds a `Document` and which `measurer` stub it passes to `PdfExporter.export`. Append a test that reuses that exact pattern. Template (adapt the doc/measurer construction to match the file's existing helpers):
+
+```ts
+it('reports per-page progress ending at total', async () => {
+  const doc = makeDoc(); // reuse the file's existing doc-builder/fixture
+  const calls: Array<[number, number, string]> = [];
+  await PdfExporter.export(doc, {
+    measurer: makeMeasurer(), // reuse the file's existing measurer stub
+    onProgress: (done, total, phase) => calls.push([done, total, phase]),
+  });
+  expect(calls[0][0]).toBe(0);
+  expect(calls[0][2]).toBe('pages');
+  const last = calls[calls.length - 1];
+  expect(last[0]).toBe(last[1]); // done === total at the end
+  expect(last[1]).toBeGreaterThan(0);
+  const dones = calls.map((c) => c[0]);
+  expect(dones).toEqual([...dones].sort((a, b) => a - b));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @wafflebase/docs test -- pdf-exporter.test.ts`
+Expected: FAIL — `calls` empty (`calls[0]` undefined).
+
+- [ ] **Step 3: Create the yield util**
+
+Create `packages/docs/src/export/yield.ts` (identical body to the slides copy):
+
+```ts
+/**
+ * Resolve on the next macrotask so the browser can paint between heavy
+ * synchronous export units (per-page PDF paint). A `MessageChannel`
+ * macrotask avoids `setTimeout`'s ~4 ms clamp; falls back to `setTimeout(0)`
+ * where `MessageChannel` is unavailable (older Node).
+ */
+export function yieldToPaint(): Promise<void> {
+  if (typeof MessageChannel === 'undefined') {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return new Promise((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => resolve();
+    channel.port2.postMessage(0);
+  });
+}
+```
+
+- [ ] **Step 4: Add the option and emit + yield in the per-page loop**
+
+In `packages/docs/src/export/pdf-exporter.ts`:
+
+Add the import beside the other `./` imports (with `.js`):
+
+```ts
+import { yieldToPaint } from './yield.js';
+```
+
+Add the field to `PdfExportOptions` (after `fontResolver?`):
+
+```ts
+  /** Progress callback: `(done, total, 'pages')` once before paint, then after each painted page. */
+  onProgress?: (done: number, total: number, phase: string) => void;
+```
+
+The per-page loop must become awaitable. Change the loop at lines ~137-159 to emit and yield. Note `export()` is already `async`, so adding `await` inside is safe:
+
+```ts
+    const blockIdToPage = new Map<string, number>();
+    const onProgress = opts.onProgress;
+    const pageTotal = pagination.pages.length;
+    onProgress?.(0, pageTotal, 'pages');
+    for (let i = 0; i < pageTotal; i++) {
+      const lp = pagination.pages[i];
+      const pageWidthPt = lp.width / PX_PER_PT;
+      const pageHeightPt = lp.height / PX_PER_PT;
+      const page = pdfDoc.addPage([pageWidthPt, pageHeightPt]);
+      PdfPainter.paintPage(page, lp, pagination.pageSetup, embeddedFonts, {
+        doc,
+        imageMap,
+        pageNumber: i + 1,
+        headerLayout,
+        footerLayout,
+        listCounters,
+        layoutBlocks: layout.blocks,
+        embeddableFamilies,
+      });
+
+      for (const pl of lp.lines) {
+        const block = layout.blocks[pl.blockIndex]?.block;
+        if (block && !blockIdToPage.has(block.id)) {
+          blockIdToPage.set(block.id, i);
+        }
+      }
+
+      onProgress?.(i + 1, pageTotal, 'pages');
+      if (i + 1 < pageTotal) await yieldToPaint();
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @wafflebase/docs test -- pdf-exporter.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/docs/src/export/yield.ts packages/docs/src/export/pdf-exporter.ts packages/docs/test/export/pdf-exporter.test.ts
+git commit -m "Docs PDF export: report per-page progress and yield to paint"
+```
+
+---
+
+### Task 4: Docs DOCX progress (image fetches)
+
+DOCX's freeze is dominated by image fetches, which already `await` (so they yield naturally) — this task adds **progress reporting only**, mirroring the import "Embedding images X / Y" UX. No `yieldToPaint`.
+
+**Files:**
+- Modify: `packages/docs/src/export/docx-exporter.ts` (`export()` signature ~line 34-63; add a `countImageSrcs` helper)
+- Test: `packages/docs/test/export/docx-exporter.test.ts` (append one `it`)
+
+**Interfaces:**
+- Produces: `DocxExporter.export(doc, imageFetcher?, onProgress?)` where `onProgress?: (done: number, total: number, phase: string) => void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/docs/test/export/docx-exporter.test.ts` (the file already polyfills `Blob.arrayBuffer`). Build a doc with two image inlines and a stub fetcher:
+
+```ts
+it('reports per-image progress ending at total', async () => {
+  const PNG = new Blob(
+    [Uint8Array.from(atob(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAen63NgAAAAASUVORK5CYII='
+    ), (c) => c.charCodeAt(0))],
+    { type: 'image/png' },
+  );
+  const doc: Document = {
+    blocks: [{
+      id: generateBlockId(),
+      type: 'paragraph',
+      inlines: [
+        { text: '', style: { image: { src: 'a.png', width: 10, height: 10 } } },
+        { text: '', style: { image: { src: 'b.png', width: 10, height: 10 } } },
+      ],
+      style: { ...DEFAULT_BLOCK_STYLE },
+    }],
+  };
+  const calls: Array<[number, number, string]> = [];
+  await DocxExporter.export(doc, async () => PNG, (d, t, p) => calls.push([d, t, p]));
+  expect(calls[0]).toEqual([0, 2, 'images']);
+  expect(calls[calls.length - 1]).toEqual([2, 2, 'images']);
+  expect(calls.every((c) => c[2] === 'images')).toBe(true);
+});
+```
+
+> Confirm the inline `image` style shape (`src`/`width`/`height`) against `packages/docs/src/model/types.ts`; copy the exact field names if they differ.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @wafflebase/docs test -- docx-exporter.test.ts`
+Expected: FAIL — `onProgress` is not accepted / `calls` empty.
+
+- [ ] **Step 3: Add the parameter, total count, and wrapped fetcher**
+
+In `packages/docs/src/export/docx-exporter.ts`, change the `export` signature and wrap the fetcher. Replace lines 34-63 (signature through the first `collectImages` body-loop) with:
+
+```ts
+  static async export(
+    doc: Document,
+    imageFetcher?: ImageFetcher,
+    onProgress?: (done: number, total: number, phase: string) => void,
+  ): Promise<Blob> {
+    const zip = new JSZip();
+    const docImageEntries: ImageEntry[] = [];
+    const headerImageEntries: ImageEntry[] = [];
+    const footerImageEntries: ImageEntry[] = [];
+    const makeCounter = () => {
+      let n = 10; // Start after reserved IDs
+      return () => `rId${n++}`;
+    };
+    const nextDocRId = makeCounter();
+    const nextHeaderRId = makeCounter();
+    const nextFooterRId = makeCounter();
+    let mediaSeq = 0;
+    const nextMediaName = (ext: string) => `media/image_${++mediaSeq}.${ext}`;
+
+    // Progress: total = unique image srcs per part (matches the per-part
+    // dedupe in collectImages). Wrap the fetcher to emit after each fetch,
+    // in a `finally` so a failed fetch still advances the bar.
+    let imagesDone = 0;
+    const imagesTotal = onProgress
+      ? DocxExporter.countImageSrcs(doc.blocks) +
+        DocxExporter.countImageSrcs(doc.header?.blocks) +
+        DocxExporter.countImageSrcs(doc.footer?.blocks)
+      : 0;
+    onProgress?.(0, imagesTotal, 'images');
+    const fetcher: ImageFetcher | undefined =
+      imageFetcher && onProgress
+        ? async (url: string) => {
+            try {
+              return await imageFetcher(url);
+            } finally {
+              imagesDone += 1;
+              onProgress(imagesDone, imagesTotal, 'images');
+            }
+          }
+        : imageFetcher;
+
+    // Collect and fetch images referenced from the main document body.
+    if (fetcher) {
+      for (const block of doc.blocks) {
+        await DocxExporter.collectImages(block, fetcher, zip, docImageEntries, nextDocRId, nextMediaName);
+      }
+    }
+```
+
+Then update the **header** and **footer** image-collection calls (lines ~74-78 and ~86-90) to use `fetcher` instead of `imageFetcher` in both the `if (...)` guard and the `collectImages(...)` argument:
+
+```ts
+      if (fetcher) {
+        for (const block of doc.header.blocks) {
+          await DocxExporter.collectImages(block, fetcher, zip, headerImageEntries, nextHeaderRId, nextMediaName);
+        }
+      }
+```
+
+```ts
+      if (fetcher) {
+        for (const block of doc.footer.blocks) {
+          await DocxExporter.collectImages(block, fetcher, zip, footerImageEntries, nextFooterRId, nextMediaName);
+        }
+      }
+```
+
+- [ ] **Step 4: Add the `countImageSrcs` helper**
+
+Add this private static method to the `DocxExporter` class (e.g. just above `collectImages`):
+
+```ts
+  /** Unique image srcs in a block list (incl. table cells), matching the
+   *  per-part dedupe in `collectImages` so the count equals fetch calls. */
+  private static countImageSrcs(blocks: Block[] | undefined): number {
+    if (!blocks) return 0;
+    const srcs = new Set<string>();
+    const walk = (block: Block): void => {
+      for (const inline of block.inlines) {
+        if (inline.style.image) srcs.add(inline.style.image.src);
+      }
+      if (block.tableData) {
+        for (const row of block.tableData.rows) {
+          for (const cell of row.cells) {
+            for (const cellBlock of cell.blocks) walk(cellBlock);
+          }
+        }
+      }
+    };
+    for (const block of blocks) walk(block);
+    return srcs.size;
+  }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @wafflebase/docs test -- docx-exporter.test.ts`
+Expected: PASS (new test + existing round-trip tests unaffected — they call `export(doc)` / `export(doc, fetcher)` with no `onProgress`, so the wrapper stays inactive).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/docs/src/export/docx-exporter.ts packages/docs/test/export/docx-exporter.test.ts
+git commit -m "Docs DOCX export: report per-image embedding progress"
+```
+
+---
+
+### Task 5: Frontend toast wiring (docs PDF, docs DOCX, slides PDF)
+
+Wires the new callbacks into an import-style Sonner toast. PPTX has no UI trigger, so it is intentionally not wired here.
+
+**Files:**
+- Modify: `packages/frontend/src/app/docs/export-utils.ts` (add `updateExportToast`)
+- Modify: `packages/frontend/src/app/docs/pdf-actions.ts` (`exportPdfAndDownload`)
+- Modify: `packages/frontend/src/app/docs/docx-actions.ts` (`exportDocxAndDownload`)
+- Modify: `packages/frontend/src/app/slides/pdf-actions.ts` (`exportSlidesPdfAndDownload`)
+- Modify: `packages/frontend/src/app/docs/docs-export-button.tsx` (`runExport`)
+- Modify: `packages/frontend/src/app/slides/slides-export-button.tsx` (`handleExportPdf`)
+
+**Interfaces:**
+- Consumes: `PdfExportOptions.onProgress`, `ExportSlidesPdfOptions.onProgress`, `DocxExporter.export(…, onProgress)` from Tasks 1/3/4.
+- Produces: `updateExportToast(toastId, title, done, total, unit): string | number`.
+- Produces (action signatures): all three take `onProgress?: (done: number, total: number, phase: string) => void` and forward the library `phase` straight through; the button uses `phase` as the toast `unit`.
+
+- [ ] **Step 1: Rebuild producer packages so the frontend sees the new options**
+
+Run: `pnpm --filter @wafflebase/docs build && pnpm --filter @wafflebase/slides build`
+Expected: both builds succeed (the new `onProgress` fields are now in dist `.d.ts`).
+
+- [ ] **Step 2: Add the `updateExportToast` helper**
+
+In `packages/frontend/src/app/docs/export-utils.ts`, add a `sonner` import at the top:
+
+```ts
+import { toast } from "sonner";
+```
+
+Append the helper (mirrors `updateImportToast` in `document-list.tsx`):
+
+```ts
+/**
+ * Lazily create (first tick) or update the export progress toast, mirroring
+ * the import toast. `unit` is the exporter's phase string ("slides" | "pages"
+ * | "images"). Returns the toast id so the caller can thread it to
+ * success/error.
+ */
+export function updateExportToast(
+  toastId: string | number | undefined,
+  title: string,
+  done: number,
+  total: number,
+  unit: string,
+): string | number {
+  const description =
+    total > 0 ? `${Math.min(done, total)} / ${total} ${unit}` : undefined;
+  if (toastId === undefined) {
+    return toast.loading(`Exporting "${title}"…`, { description });
+  }
+  toast.loading(`Exporting "${title}"…`, { id: toastId, description });
+  return toastId;
+}
+```
+
+- [ ] **Step 3: Thread `onProgress` through the three actions**
+
+`packages/frontend/src/app/docs/pdf-actions.ts` — add `onProgress` (before the optional `metadata`, so the button can pass it positionally) and forward it:
+
+```ts
+export async function exportPdfAndDownload(
+  doc: DocsDocument,
+  title: string,
+  onProgress?: (done: number, total: number, phase: string) => void,
+  metadata?: { title?: string; author?: string },
+): Promise<void> {
+  const { PdfExporter, CanvasTextMeasurer } = await import("@wafflebase/docs");
+  const { FONT_FILES } = await import(
+    "../../components/text-formatting/font-files.data"
+  );
+  const blob = await PdfExporter.export(doc, {
+    imageFetcher: docsImageFetcher,
+    metadata: { title: metadata?.title ?? title, author: metadata?.author },
+    measurer: new CanvasTextMeasurer(),
+    fontResolver: (family) => FONT_FILES[family],
+    onProgress,
+  });
+  downloadBlob(blob, safeFilename(title, "pdf"));
+}
+```
+
+`packages/frontend/src/app/docs/docx-actions.ts` — `exportDocxAndDownload`:
+
+```ts
+export async function exportDocxAndDownload(
+  doc: DocsDocument,
+  title: string,
+  onProgress?: (done: number, total: number, phase: string) => void,
+): Promise<void> {
+  const blob = await DocxExporter.export(doc, docsImageFetcher, onProgress);
+  downloadBlob(blob, safeFilename(title, "docx"));
+}
+```
+
+`packages/frontend/src/app/slides/pdf-actions.ts` — `exportSlidesPdfAndDownload`:
+
+```ts
+export async function exportSlidesPdfAndDownload(
+  doc: SlidesDocument,
+  title: string,
+  onProgress?: (done: number, total: number, phase: string) => void,
+): Promise<void> {
+  const families = collectFontFamilies(doc);
+  for (const family of families) ensureFontLink(family);
+  if (typeof document !== "undefined" && document.fonts) {
+    await Promise.all(
+      families.map((family) =>
+        document.fonts.load(`16px "${family}"`).catch(() => {
+          /* a single font failing to load must not abort the export */
+        }),
+      ),
+    );
+  }
+
+  const bytes = await exportSlidesPdf(doc, {
+    imageFetcher: docsImageFetcher,
+    title,
+    onProgress,
+  });
+  const blob = new Blob([bytes], { type: "application/pdf" });
+  downloadBlob(blob, safeFilename(title, "pdf"));
+}
+```
+
+- [ ] **Step 4: Wire the docs export button toast**
+
+In `packages/frontend/src/app/docs/docs-export-button.tsx`, import the helper and rewrite `runExport` to manage the toast lifecycle:
+
+```ts
+import { updateExportToast } from "./export-utils";
+```
+
+```ts
+  const runExport = async (
+    kind: "docx" | "pdf",
+    fn: (
+      doc: ReturnType<ReturnType<EditorAPI["getStore"]>["getDocument"]>,
+      title: string,
+      onProgress?: (done: number, total: number, phase: string) => void,
+    ) => Promise<void>,
+  ) => {
+    if (!editor || exporting) return;
+    setExporting(true);
+    const t = title || "document";
+    let toastId: string | number | undefined;
+    try {
+      await fn(editor.getStore().getDocument(), t, (done, total, phase) => {
+        toastId = updateExportToast(toastId, t, done, total, phase);
+      });
+      const message = `Exported "${t}"`;
+      if (toastId !== undefined) toast.success(message, { id: toastId });
+      else toast.success(message);
+    } catch (err) {
+      console.error(`${kind.toUpperCase()} export failed`, err);
+      const message =
+        err instanceof Error ? `Export failed: ${err.message}` : "Export failed";
+      if (toastId !== undefined) toast.error(message, { id: toastId });
+      else toast.error(message);
+    } finally {
+      setExporting(false);
+    }
+  };
+```
+
+> If the inline `fn` type is awkward against the imported function types, define a local
+> `type ExportAction = (doc: DocsDocument, title: string, onProgress?: (d: number, t: number, p: string) => void) => Promise<void>;`
+> (importing `Document as DocsDocument` from `@wafflebase/docs`) and type `fn: ExportAction`. The `onSelect` call sites (`runExport("docx", exportDocxAndDownload)` / `runExport("pdf", exportPdfAndDownload)`) stay unchanged.
+
+- [ ] **Step 5: Wire the slides export button toast**
+
+In `packages/frontend/src/app/slides/slides-export-button.tsx`:
+
+```ts
+import { updateExportToast } from "../docs/export-utils";
+```
+
+```ts
+  const handleExportPdf = async () => {
+    if (!store) return;
+    setExporting(true);
+    const t = title || "presentation";
+    let toastId: string | number | undefined;
+    try {
+      await exportSlidesPdfAndDownload(store.read(), t, (done, total, phase) => {
+        toastId = updateExportToast(toastId, t, done, total, phase);
+      });
+      const message = `Exported "${t}"`;
+      if (toastId !== undefined) toast.success(message, { id: toastId });
+      else toast.success(message);
+    } catch (err) {
+      console.error("Slides PDF export failed", err);
+      const message =
+        err instanceof Error ? `Export failed: ${err.message}` : "Export failed";
+      if (toastId !== undefined) toast.error(message, { id: toastId });
+      else toast.error(message);
+    } finally {
+      setExporting(false);
+    }
+  };
+```
+
+- [ ] **Step 6: Verify the frontend typechecks and the lane is green**
+
+Run: `pnpm verify:fast`
+Expected: PASS (lint + unit tests across packages, including the new exporter tests).
+
+- [ ] **Step 7: Manual smoke (UI changed)**
+
+Run `pnpm dev`, open a large deck and a large doc, and export PDF/DOCX. Confirm: the toast appears and counts up (`12 / 50 slides`, `8 / 120 pages`, `3 / 5 images`), the UI stays responsive during export, and a success toast replaces the loading toast when the download fires.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/frontend/src/app/docs/export-utils.ts \
+        packages/frontend/src/app/docs/pdf-actions.ts \
+        packages/frontend/src/app/docs/docx-actions.ts \
+        packages/frontend/src/app/slides/pdf-actions.ts \
+        packages/frontend/src/app/docs/docs-export-button.tsx \
+        packages/frontend/src/app/slides/slides-export-button.tsx
+git commit -m "Frontend: show import-style toast progress during docs/slides export"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Slides PDF progress + responsiveness → Task 1 ✅
+- Slides PPTX progress (library) → Task 2 ✅ (no UI trigger exists; documented)
+- Docs PDF progress + responsiveness → Task 3 ✅
+- Docs DOCX progress (image fetches) → Task 4 ✅
+- Import-style toast UX, shared helper → Task 5 ✅
+- `yieldToPaint` (MessageChannel + setTimeout fallback) → Tasks 1 & 3 ✅
+- Optional callback / unchanged CLI+test behavior → enforced by optional params; existing tests call exporters without `onProgress` ✅
+
+**Placeholder scan:** No TBD/TODO. Two "confirm the exact shape against the source" notes (DOCX inline image fields; PPTX fixture imports) are deliberate guards against guessed field names, each with the file to check — not deferred work.
+
+**Type consistency:** `onProgress?: (done: number, total: number, phase: string) => void` is identical across `ExportSlidesPdfOptions`, `ExportPptxOptions`, `PdfExportOptions`, `DocxExporter.export`, and all three frontend actions. `yieldToPaint(): Promise<void>` identical in both packages. `updateExportToast(toastId, title, done, total, unit)` consumes `phase` as `unit`. Phase strings `'slides'`/`'pages'`/`'images'` are consistent between emit sites and tests.

--- a/docs/tasks/active/20260628-export-progress-todo.md
+++ b/docs/tasks/active/20260628-export-progress-todo.md
@@ -8,27 +8,47 @@ keep the UI responsive by yielding the event loop between work units.
 ## Plan
 
 ### Packages: yield util + onProgress callbacks
-- [ ] `slides/src/export/yield.ts` — `yieldToPaint()` (MessageChannel + setTimeout fallback)
-- [ ] `docs/src/export/yield.ts` — same helper (local copy)
-- [ ] Slides PDF (`slides/src/export/pdf.ts`) — add `onProgress`, emit per slide, `await yieldToPaint()`
-- [ ] Slides PPTX (`slides/src/export/pptx/index.ts`) — add `onProgress`, emit per slide, yield
-- [ ] Docs PDF (`docs/src/export/pdf-exporter.ts`) — add `onProgress`, emit per page, yield
-- [ ] Docs DOCX (`docs/src/export/docx-exporter.ts`) — add `onProgress`, emit per image fetch (mirror import)
+- [x] `slides/src/export/yield.ts` — `yieldToPaint()` (MessageChannel + setTimeout fallback)
+- [x] `docs/src/export/yield.ts` — same helper (local copy)
+- [x] Slides PDF (`slides/src/export/pdf.ts`) — add `onProgress`, emit per slide, `await yieldToPaint()`
+- [x] Slides PPTX (`slides/src/export/pptx/index.ts`) — add `onProgress`, emit per slide, yield
+- [x] Docs PDF (`docs/src/export/pdf-exporter.ts`) — add `onProgress`, emit per page, yield
+- [x] Docs DOCX (`docs/src/export/docx-exporter.ts`) — add `onProgress`, emit per image fetch (mirror import)
 
 ### Frontend: toast wiring
-- [ ] `export-utils.ts` — `updateExportToast(id, title, done, total, unit)` helper
-- [ ] `docs-export-button.tsx` — thread `onProgress` into DOCX + PDF actions
-- [ ] `slides-export-button.tsx` — thread `onProgress` into PDF action
-- [ ] `docx-actions.ts` / `pdf-actions.ts` (docs) — accept + forward `onProgress`
-- [ ] `pdf-actions.ts` (slides) — accept + forward `onProgress`
-- [ ] success → `toast.success`, failure → existing `toast.error`
+- [x] `export-utils.ts` — `updateExportToast(id, title, done, total, unit)` helper
+- [x] `docs-export-button.tsx` — thread `onProgress` into DOCX + PDF actions
+- [x] `slides-export-button.tsx` — thread `onProgress` into PDF action
+- [x] `docx-actions.ts` / `pdf-actions.ts` (docs) — accept + forward `onProgress`
+- [x] `pdf-actions.ts` (slides) — accept + forward `onProgress`
+- [x] success → `toast.success`, failure → existing `toast.error`
 
 ### Tests + verify
-- [ ] Unit test each exporter: `onProgress` starts (0,total), monotonic, ends (total,total)
-- [ ] Rebuild producer packages (docs/slides) before frontend typecheck
-- [ ] `pnpm verify:fast`
-- [ ] Manual smoke in `pnpm dev`: large deck/doc, toast counts up, UI responsive
+- [x] Unit test each exporter: `onProgress` starts (0,total), monotonic, ends (total,total)
+- [x] Rebuild producer packages (docs/slides) before frontend typecheck
+- [x] `pnpm verify:fast` — green
+- [ ] Manual smoke in `pnpm dev`: large deck/doc, toast counts up, UI responsive (human to verify)
 
 ## Review
 
-(to fill in after implementation)
+Executed via subagent-driven development across 5 tasks (one commit each), TDD
+throughout. Per-task spec+quality reviews all came back ✅/Approved; final
+whole-branch review (Opus) returned **READY TO MERGE** with no Critical or
+Important findings.
+
+**Shipped:**
+- `yieldToPaint()` (MessageChannel macrotask) in both docs + slides packages.
+- `onProgress(done, total, phase)` on slides PDF/PPTX, docs PDF/DOCX exporters
+  — optional, behavior unchanged when omitted (CLI/tests).
+- Import-style Sonner toast via shared `updateExportToast`, wired to the docs
+  (PDF/DOCX) and slides (PDF) export buttons. Phase string doubles as the unit
+  label ("12 / 50 slides").
+
+**Scope note:** PPTX got library-level `onProgress` but no toast — `exportPptx`
+has no frontend trigger today.
+
+**Known minor follow-ups (non-blocking):** dead `metadata` param on
+`exportPdfAndDownload`; per-call `MessageChannel` allocation; loose test
+assertions. See lessons file.
+
+**Pending:** manual `pnpm dev` smoke (UI changed) before merge.

--- a/docs/tasks/active/20260628-export-progress-todo.md
+++ b/docs/tasks/active/20260628-export-progress-todo.md
@@ -1,0 +1,34 @@
+# Export Progress Reporting — TODO
+
+Design: `docs/design/export-progress.md`
+
+Show incremental progress (Sonner toast, import-style) for large exports and
+keep the UI responsive by yielding the event loop between work units.
+
+## Plan
+
+### Packages: yield util + onProgress callbacks
+- [ ] `slides/src/export/yield.ts` — `yieldToPaint()` (MessageChannel + setTimeout fallback)
+- [ ] `docs/src/export/yield.ts` — same helper (local copy)
+- [ ] Slides PDF (`slides/src/export/pdf.ts`) — add `onProgress`, emit per slide, `await yieldToPaint()`
+- [ ] Slides PPTX (`slides/src/export/pptx/index.ts`) — add `onProgress`, emit per slide, yield
+- [ ] Docs PDF (`docs/src/export/pdf-exporter.ts`) — add `onProgress`, emit per page, yield
+- [ ] Docs DOCX (`docs/src/export/docx-exporter.ts`) — add `onProgress`, emit per image fetch (mirror import)
+
+### Frontend: toast wiring
+- [ ] `export-utils.ts` — `updateExportToast(id, title, done, total, unit)` helper
+- [ ] `docs-export-button.tsx` — thread `onProgress` into DOCX + PDF actions
+- [ ] `slides-export-button.tsx` — thread `onProgress` into PDF action
+- [ ] `docx-actions.ts` / `pdf-actions.ts` (docs) — accept + forward `onProgress`
+- [ ] `pdf-actions.ts` (slides) — accept + forward `onProgress`
+- [ ] success → `toast.success`, failure → existing `toast.error`
+
+### Tests + verify
+- [ ] Unit test each exporter: `onProgress` starts (0,total), monotonic, ends (total,total)
+- [ ] Rebuild producer packages (docs/slides) before frontend typecheck
+- [ ] `pnpm verify:fast`
+- [ ] Manual smoke in `pnpm dev`: large deck/doc, toast counts up, UI responsive
+
+## Review
+
+(to fill in after implementation)

--- a/packages/docs/src/export/docx-exporter.ts
+++ b/packages/docs/src/export/docx-exporter.ts
@@ -34,6 +34,7 @@ export class DocxExporter {
   static async export(
     doc: Document,
     imageFetcher?: ImageFetcher,
+    onProgress?: (done: number, total: number, phase: string) => void,
   ): Promise<Blob> {
     const zip = new JSZip();
     // rIds are scoped per .rels file in OOXML, so give each part its own
@@ -55,10 +56,32 @@ export class DocxExporter {
     let mediaSeq = 0;
     const nextMediaName = (ext: string) => `media/image_${++mediaSeq}.${ext}`;
 
+    // Progress: total = unique image srcs per part (matches the per-part
+    // dedupe in collectImages). Wrap the fetcher to emit after each fetch,
+    // in a `finally` so a failed fetch still advances the bar.
+    let imagesDone = 0;
+    const imagesTotal = onProgress
+      ? DocxExporter.countImageSrcs(doc.blocks) +
+        DocxExporter.countImageSrcs(doc.header?.blocks) +
+        DocxExporter.countImageSrcs(doc.footer?.blocks)
+      : 0;
+    onProgress?.(0, imagesTotal, 'images');
+    const fetcher: ImageFetcher | undefined =
+      imageFetcher && onProgress
+        ? async (url: string) => {
+            try {
+              return await imageFetcher(url);
+            } finally {
+              imagesDone += 1;
+              onProgress(imagesDone, imagesTotal, 'images');
+            }
+          }
+        : imageFetcher;
+
     // Collect and fetch images referenced from the main document body.
-    if (imageFetcher) {
+    if (fetcher) {
       for (const block of doc.blocks) {
-        await DocxExporter.collectImages(block, imageFetcher, zip, docImageEntries, nextDocRId, nextMediaName);
+        await DocxExporter.collectImages(block, fetcher, zip, docImageEntries, nextDocRId, nextMediaName);
       }
     }
 
@@ -71,9 +94,9 @@ export class DocxExporter {
 
     if (doc.header && doc.header.blocks.length > 0) {
       headerRId = nextDocRId();
-      if (imageFetcher) {
+      if (fetcher) {
         for (const block of doc.header.blocks) {
-          await DocxExporter.collectImages(block, imageFetcher, zip, headerImageEntries, nextHeaderRId, nextMediaName);
+          await DocxExporter.collectImages(block, fetcher, zip, headerImageEntries, nextHeaderRId, nextMediaName);
         }
       }
       const headerXml = DocxExporter.buildHeaderFooterXml(doc.header, 'header', headerImageEntries);
@@ -83,9 +106,9 @@ export class DocxExporter {
     }
     if (doc.footer && doc.footer.blocks.length > 0) {
       footerRId = nextDocRId();
-      if (imageFetcher) {
+      if (fetcher) {
         for (const block of doc.footer.blocks) {
-          await DocxExporter.collectImages(block, imageFetcher, zip, footerImageEntries, nextFooterRId, nextMediaName);
+          await DocxExporter.collectImages(block, fetcher, zip, footerImageEntries, nextFooterRId, nextMediaName);
         }
       }
       const footerXml = DocxExporter.buildHeaderFooterXml(doc.footer, 'footer', footerImageEntries);
@@ -363,6 +386,27 @@ ${blocks}
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
 ${rels}
 </Relationships>`;
+  }
+
+  /** Unique image srcs in a block list (incl. table cells), matching the
+   *  per-part dedupe in `collectImages` so the count equals fetch calls. */
+  private static countImageSrcs(blocks: Block[] | undefined): number {
+    if (!blocks) return 0;
+    const srcs = new Set<string>();
+    const walk = (block: Block): void => {
+      for (const inline of block.inlines) {
+        if (inline.style.image) srcs.add(inline.style.image.src);
+      }
+      if (block.tableData) {
+        for (const row of block.tableData.rows) {
+          for (const cell of row.cells) {
+            for (const cellBlock of cell.blocks) walk(cellBlock);
+          }
+        }
+      }
+    };
+    for (const block of blocks) walk(block);
+    return srcs.size;
   }
 
   private static async collectImages(

--- a/packages/docs/src/export/docx-exporter.ts
+++ b/packages/docs/src/export/docx-exporter.ts
@@ -56,27 +56,30 @@ export class DocxExporter {
     let mediaSeq = 0;
     const nextMediaName = (ext: string) => `media/image_${++mediaSeq}.${ext}`;
 
-    // Progress: total = unique image srcs per part (matches the per-part
-    // dedupe in collectImages). Wrap the fetcher to emit after each fetch,
-    // in a `finally` so a failed fetch still advances the bar.
+    // Progress: only report when we will actually fetch images — i.e. both a
+    // fetcher and a callback are present. Reporting on `onProgress` alone
+    // would emit `(0, N)` and then never advance (no fetches happen), leaving
+    // the bar stuck. total = unique image srcs per part (matches the per-part
+    // dedupe in collectImages). Wrap the fetcher to emit after each fetch, in
+    // a `finally` so a failed fetch still advances the bar.
+    const reportProgress = Boolean(imageFetcher && onProgress);
     let imagesDone = 0;
-    const imagesTotal = onProgress
+    const imagesTotal = reportProgress
       ? DocxExporter.countImageSrcs(doc.blocks) +
         DocxExporter.countImageSrcs(doc.header?.blocks) +
         DocxExporter.countImageSrcs(doc.footer?.blocks)
       : 0;
-    onProgress?.(0, imagesTotal, 'images');
-    const fetcher: ImageFetcher | undefined =
-      imageFetcher && onProgress
-        ? async (url: string) => {
-            try {
-              return await imageFetcher(url);
-            } finally {
-              imagesDone += 1;
-              onProgress(imagesDone, imagesTotal, 'images');
-            }
+    if (reportProgress) onProgress!(0, imagesTotal, 'images');
+    const fetcher: ImageFetcher | undefined = reportProgress
+      ? async (url: string) => {
+          try {
+            return await imageFetcher!(url);
+          } finally {
+            imagesDone += 1;
+            onProgress!(imagesDone, imagesTotal, 'images');
           }
-        : imageFetcher;
+        }
+      : imageFetcher;
 
     // Collect and fetch images referenced from the main document body.
     if (fetcher) {

--- a/packages/docs/src/export/pdf-exporter.ts
+++ b/packages/docs/src/export/pdf-exporter.ts
@@ -24,6 +24,7 @@ import {
   collectAndEmbedImages,
   type ImageFetcher,
 } from './pdf-image-painter.js';
+import { yieldToPaint } from './yield.js';
 
 const PX_PER_PT = 96 / 72;
 
@@ -47,6 +48,8 @@ export interface PdfExportOptions {
    * can't import the frontend catalog). Omit and export behaves as before.
    */
   fontResolver?: PdfFontResolver;
+  /** Progress callback: `(done, total, 'pages')` once before paint, then after each painted page. */
+  onProgress?: (done: number, total: number, phase: string) => void;
 }
 
 export class PdfExporter {
@@ -134,7 +137,10 @@ export class PdfExporter {
     // body block id → page index (the first page on which the block
     // appears) so the outline tree can later resolve heading targets.
     const blockIdToPage = new Map<string, number>();
-    for (let i = 0; i < pagination.pages.length; i++) {
+    const onProgress = opts.onProgress;
+    const pageTotal = pagination.pages.length;
+    onProgress?.(0, pageTotal, 'pages');
+    for (let i = 0; i < pageTotal; i++) {
       const lp = pagination.pages[i];
       const pageWidthPt = lp.width / PX_PER_PT;
       const pageHeightPt = lp.height / PX_PER_PT;
@@ -156,6 +162,9 @@ export class PdfExporter {
           blockIdToPage.set(block.id, i);
         }
       }
+
+      onProgress?.(i + 1, pageTotal, 'pages');
+      if (i + 1 < pageTotal) await yieldToPaint();
     }
 
     // 7. Outline tree. Built after all pages exist so getPage(i) works.

--- a/packages/docs/src/export/pdf-exporter.ts
+++ b/packages/docs/src/export/pdf-exporter.ts
@@ -164,7 +164,9 @@ export class PdfExporter {
       }
 
       onProgress?.(i + 1, pageTotal, 'pages');
-      if (i + 1 < pageTotal) await yieldToPaint();
+      // Only yield on the interactive (progress-reporting) path; headless/CLI
+      // exports gain nothing from the extra event-loop turn per page.
+      if (onProgress && i + 1 < pageTotal) await yieldToPaint();
     }
 
     // 7. Outline tree. Built after all pages exist so getPage(i) works.

--- a/packages/docs/src/export/yield.ts
+++ b/packages/docs/src/export/yield.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolve on the next macrotask so the browser can paint between heavy
+ * synchronous export units (per-page PDF paint). A `MessageChannel`
+ * macrotask avoids `setTimeout`'s ~4 ms clamp; falls back to `setTimeout(0)`
+ * where `MessageChannel` is unavailable (older Node).
+ */
+export function yieldToPaint(): Promise<void> {
+  if (typeof MessageChannel === 'undefined') {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return new Promise((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => resolve();
+    channel.port2.postMessage(0);
+  });
+}

--- a/packages/docs/test/export/docx-exporter.test.ts
+++ b/packages/docs/test/export/docx-exporter.test.ts
@@ -403,6 +403,31 @@ describe('DocxExporter', () => {
     expect(new Set(mediaFiles).size).toBe(2);
   });
 
+  it('reports per-image progress ending at total', async () => {
+    const PNG = new Blob(
+      [Uint8Array.from(atob(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAen63NgAAAAASUVORK5CYII='
+      ), (c) => c.charCodeAt(0))],
+      { type: 'image/png' },
+    );
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [
+          { text: '', style: { image: { src: 'a.png', width: 10, height: 10 } } },
+          { text: '', style: { image: { src: 'b.png', width: 10, height: 10 } } },
+        ],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+    const calls: Array<[number, number, string]> = [];
+    await DocxExporter.export(doc, async () => PNG, (d, t, p) => calls.push([d, t, p]));
+    expect(calls[0]).toEqual([0, 2, 'images']);
+    expect(calls[calls.length - 1]).toEqual([2, 2, 'images']);
+    expect(calls.every((c) => c[2] === 'images')).toBe(true);
+  });
+
   it('should export and re-import a table inside a header', async () => {
     const doc: Document = {
       blocks: [{

--- a/packages/docs/test/export/docx-exporter.test.ts
+++ b/packages/docs/test/export/docx-exporter.test.ts
@@ -428,6 +428,45 @@ describe('DocxExporter', () => {
     expect(calls.every((c) => c[2] === 'images')).toBe(true);
   });
 
+  it('emits no progress when onProgress is given without an imageFetcher', async () => {
+    // A doc with images but no fetcher still throws the existing guard. The
+    // point of this test: we must NOT emit a misleading (0, N) beforehand —
+    // that would briefly show a progress bar stuck at 0 before the error.
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [
+          { text: '', style: { image: { src: 'a.png', width: 10, height: 10 } } },
+        ],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+    const calls: Array<[number, number, string]> = [];
+    await expect(
+      DocxExporter.export(doc, undefined, (d, t, p) => calls.push([d, t, p])),
+    ).rejects.toThrow(/imageFetcher/);
+    expect(calls).toEqual([]);
+  });
+
+  it('emits no progress for an image-free document', async () => {
+    // total would be 0; reporting (0, 0) then nothing is pointless noise, and
+    // the toast layer would flash a descriptionless spinner. Emit nothing.
+    const doc: Document = {
+      blocks: [{
+        id: generateBlockId(),
+        type: 'paragraph',
+        inlines: [{ text: 'No images here', style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      }],
+    };
+    const calls: Array<[number, number, string]> = [];
+    await DocxExporter.export(doc, async () => new Blob(), (d, t, p) =>
+      calls.push([d, t, p]),
+    );
+    expect(calls).toEqual([[0, 0, 'images']]);
+  });
+
   it('should export and re-import a table inside a header', async () => {
     const doc: Document = {
       blocks: [{

--- a/packages/docs/test/export/docx-exporter.test.ts
+++ b/packages/docs/test/export/docx-exporter.test.ts
@@ -425,7 +425,9 @@ describe('DocxExporter', () => {
     await DocxExporter.export(doc, async () => PNG, (d, t, p) => calls.push([d, t, p]));
     expect(calls[0]).toEqual([0, 2, 'images']);
     expect(calls[calls.length - 1]).toEqual([2, 2, 'images']);
-    expect(calls.every((c) => c[2] === 'images')).toBe(true);
+    const dones = calls.map((c) => c[0]);
+    expect(dones).toEqual([...dones].sort((a, b) => a - b));
+    expect(calls.every((c) => c[1] === 2 && c[2] === 'images')).toBe(true);
   });
 
   it('emits no progress when onProgress is given without an imageFetcher', async () => {

--- a/packages/docs/test/export/pdf-exporter.test.ts
+++ b/packages/docs/test/export/pdf-exporter.test.ts
@@ -328,6 +328,30 @@ describe('PdfExporter (metadata)', () => {
   });
 });
 
+describe('PdfExporter (progress)', () => {
+  it('reports per-page progress ending at total', async () => {
+    const longDoc: Document = {
+      blocks: Array.from({ length: 200 }, (_, i) => ({
+        id: `p${i}`,
+        type: 'paragraph' as const,
+        inlines: [{ text: `Paragraph ${i}: lorem ipsum dolor sit amet consectetur adipiscing elit.`, style: {} }],
+        style: { ...DEFAULT_BLOCK_STYLE },
+      })),
+    };
+    const calls: Array<[number, number, string]> = [];
+    await PdfExporter.export(longDoc, exportOpts({
+      onProgress: (done, total, phase) => calls.push([done, total, phase]),
+    }));
+    expect(calls[0][0]).toBe(0);
+    expect(calls[0][2]).toBe('pages');
+    const last = calls[calls.length - 1];
+    expect(last[0]).toBe(last[1]); // done === total at the end
+    expect(last[1]).toBeGreaterThan(0);
+    const dones = calls.map((c) => c[0]);
+    expect(dones).toEqual([...dones].sort((a, b) => a - b));
+  });
+});
+
 describe('PdfExporter (outline)', () => {
   it('emits a heading outline tree', async () => {
     const blob = await PdfExporter.export(headingFixture, exportOpts());

--- a/packages/docs/test/export/pdf-exporter.test.ts
+++ b/packages/docs/test/export/pdf-exporter.test.ts
@@ -349,6 +349,8 @@ describe('PdfExporter (progress)', () => {
     expect(last[1]).toBeGreaterThan(0);
     const dones = calls.map((c) => c[0]);
     expect(dones).toEqual([...dones].sort((a, b) => a - b));
+    // Lock the contract for every callback: constant total, constant phase.
+    expect(calls.every((c) => c[1] === last[1] && c[2] === 'pages')).toBe(true);
   });
 });
 

--- a/packages/frontend/src/app/docs/docs-export-button.tsx
+++ b/packages/frontend/src/app/docs/docs-export-button.tsx
@@ -12,9 +12,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import type { Document as DocsDocument } from "@wafflebase/docs";
 import type { EditorAPI } from "./docs-view";
 import { exportDocxAndDownload } from "./docx-actions";
 import { exportPdfAndDownload } from "./pdf-actions";
+import { updateExportToast } from "./export-utils";
 
 interface DocsExportButtonProps {
   editor: EditorAPI | null;
@@ -30,19 +32,30 @@ interface DocsExportButtonProps {
 export function DocsExportButton({ editor, title }: DocsExportButtonProps) {
   const [exporting, setExporting] = useState(false);
 
-  const runExport = async (
-    kind: "docx" | "pdf",
-    fn: typeof exportDocxAndDownload | typeof exportPdfAndDownload,
-  ) => {
+  type ExportAction = (
+    doc: DocsDocument,
+    title: string,
+    onProgress?: (d: number, t: number, p: string) => void,
+  ) => Promise<void>;
+
+  const runExport = async (kind: "docx" | "pdf", fn: ExportAction) => {
     if (!editor || exporting) return;
     setExporting(true);
+    const t = title || "document";
+    let toastId: string | number | undefined;
     try {
-      await fn(editor.getStore().getDocument(), title || "document");
+      await fn(editor.getStore().getDocument(), t, (done, total, phase) => {
+        toastId = updateExportToast(toastId, t, done, total, phase);
+      });
+      const message = `Exported "${t}"`;
+      if (toastId !== undefined) toast.success(message, { id: toastId });
+      else toast.success(message);
     } catch (err) {
       console.error(`${kind.toUpperCase()} export failed`, err);
-      toast.error(
-        err instanceof Error ? `Export failed: ${err.message}` : "Export failed",
-      );
+      const message =
+        err instanceof Error ? `Export failed: ${err.message}` : "Export failed";
+      if (toastId !== undefined) toast.error(message, { id: toastId });
+      else toast.error(message);
     } finally {
       setExporting(false);
     }

--- a/packages/frontend/src/app/docs/docx-actions.ts
+++ b/packages/frontend/src/app/docs/docx-actions.ts
@@ -50,7 +50,8 @@ export async function pickAndImportDocx(
 export async function exportDocxAndDownload(
   doc: DocsDocument,
   title: string,
+  onProgress?: (done: number, total: number, phase: string) => void,
 ): Promise<void> {
-  const blob = await DocxExporter.export(doc, docsImageFetcher);
+  const blob = await DocxExporter.export(doc, docsImageFetcher, onProgress);
   downloadBlob(blob, safeFilename(title, "docx"));
 }

--- a/packages/frontend/src/app/docs/export-utils.ts
+++ b/packages/frontend/src/app/docs/export-utils.ts
@@ -1,5 +1,6 @@
 import type { ImageFetcher, ImageUploader } from "@wafflebase/docs";
 import { fetchWithAuth } from "@/api/auth";
+import { toast } from "sonner";
 
 const BACKEND_BASE = import.meta.env.VITE_BACKEND_API_URL ?? "";
 
@@ -108,6 +109,28 @@ export function pickFile(accept: string): Promise<File | null> {
     document.body.appendChild(input);
     input.click();
   });
+}
+
+/**
+ * Lazily create (first tick) or update the export progress toast, mirroring
+ * the import toast. `unit` is the exporter's phase string ("slides" | "pages"
+ * | "images"). Returns the toast id so the caller can thread it to
+ * success/error.
+ */
+export function updateExportToast(
+  toastId: string | number | undefined,
+  title: string,
+  done: number,
+  total: number,
+  unit: string,
+): string | number {
+  const description =
+    total > 0 ? `${Math.min(done, total)} / ${total} ${unit}` : undefined;
+  if (toastId === undefined) {
+    return toast.loading(`Exporting "${title}"…`, { description });
+  }
+  toast.loading(`Exporting "${title}"…`, { id: toastId, description });
+  return toastId;
 }
 
 /**

--- a/packages/frontend/src/app/docs/export-utils.ts
+++ b/packages/frontend/src/app/docs/export-utils.ts
@@ -115,7 +115,9 @@ export function pickFile(accept: string): Promise<File | null> {
  * Lazily create (first tick) or update the export progress toast, mirroring
  * the import toast. `unit` is the exporter's phase string ("slides" | "pages"
  * | "images"). Returns the toast id so the caller can thread it to
- * success/error.
+ * success/error. Returns `undefined` when there is nothing to show yet (a
+ * zero-unit export, e.g. an image-less DOCX) so the caller falls back to a
+ * fresh success/error toast instead of flashing a descriptionless spinner.
  */
 export function updateExportToast(
   toastId: string | number | undefined,
@@ -123,10 +125,13 @@ export function updateExportToast(
   done: number,
   total: number,
   unit: string,
-): string | number {
+): string | number | undefined {
   const description =
     total > 0 ? `${Math.min(done, total)} / ${total} ${unit}` : undefined;
   if (toastId === undefined) {
+    // Nothing to report yet (total 0) — don't create a loading toast that
+    // would immediately be replaced by success, producing a visible flash.
+    if (total === 0) return undefined;
     return toast.loading(`Exporting "${title}"…`, { description });
   }
   toast.loading(`Exporting "${title}"…`, { id: toastId, description });

--- a/packages/frontend/src/app/docs/pdf-actions.ts
+++ b/packages/frontend/src/app/docs/pdf-actions.ts
@@ -13,6 +13,7 @@ import { docsImageFetcher, downloadBlob, safeFilename } from "./export-utils";
 export async function exportPdfAndDownload(
   doc: DocsDocument,
   title: string,
+  onProgress?: (done: number, total: number, phase: string) => void,
   metadata?: { title?: string; author?: string },
 ): Promise<void> {
   // Dynamic import keeps pdf-lib + fontkit out of the initial bundle.
@@ -31,6 +32,7 @@ export async function exportPdfAndDownload(
     metadata: { title: metadata?.title ?? title, author: metadata?.author },
     measurer: new CanvasTextMeasurer(),
     fontResolver: (family) => FONT_FILES[family],
+    onProgress,
   });
   downloadBlob(blob, safeFilename(title, "pdf"));
 }

--- a/packages/frontend/src/app/slides/pdf-actions.ts
+++ b/packages/frontend/src/app/slides/pdf-actions.ts
@@ -25,6 +25,7 @@ import { docsImageFetcher, downloadBlob, safeFilename } from "../docs/export-uti
 export async function exportSlidesPdfAndDownload(
   doc: SlidesDocument,
   title: string,
+  onProgress?: (done: number, total: number, phase: string) => void,
 ): Promise<void> {
   const families = collectFontFamilies(doc);
   for (const family of families) ensureFontLink(family);
@@ -41,6 +42,7 @@ export async function exportSlidesPdfAndDownload(
   const bytes = await exportSlidesPdf(doc, {
     imageFetcher: docsImageFetcher,
     title,
+    onProgress,
   });
   const blob = new Blob([bytes], { type: "application/pdf" });
   downloadBlob(blob, safeFilename(title, "pdf"));

--- a/packages/frontend/src/app/slides/slides-export-button.tsx
+++ b/packages/frontend/src/app/slides/slides-export-button.tsx
@@ -14,6 +14,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { exportSlidesPdfAndDownload } from "./pdf-actions";
+import { updateExportToast } from "../docs/export-utils";
 
 interface SlidesExportButtonProps {
   store: SlidesStore | null;
@@ -37,13 +38,21 @@ export function SlidesExportButton({
   const handleExportPdf = async () => {
     if (!store) return;
     setExporting(true);
+    const t = title || "presentation";
+    let toastId: string | number | undefined;
     try {
-      await exportSlidesPdfAndDownload(store.read(), title || "presentation");
+      await exportSlidesPdfAndDownload(store.read(), t, (done, total, phase) => {
+        toastId = updateExportToast(toastId, t, done, total, phase);
+      });
+      const message = `Exported "${t}"`;
+      if (toastId !== undefined) toast.success(message, { id: toastId });
+      else toast.success(message);
     } catch (err) {
       console.error("Slides PDF export failed", err);
-      toast.error(
-        err instanceof Error ? `Export failed: ${err.message}` : "Export failed",
-      );
+      const message =
+        err instanceof Error ? `Export failed: ${err.message}` : "Export failed";
+      if (toastId !== undefined) toast.error(message, { id: toastId });
+      else toast.error(message);
     } finally {
       setExporting(false);
     }

--- a/packages/frontend/src/app/slides/slides-export-button.tsx
+++ b/packages/frontend/src/app/slides/slides-export-button.tsx
@@ -36,7 +36,7 @@ export function SlidesExportButton({
   const [exporting, setExporting] = useState(false);
 
   const handleExportPdf = async () => {
-    if (!store) return;
+    if (!store || exporting) return;
     setExporting(true);
     const t = title || "presentation";
     let toastId: string | number | undefined;

--- a/packages/slides/src/export/pdf.ts
+++ b/packages/slides/src/export/pdf.ts
@@ -42,6 +42,7 @@ import {
   getOrLoadImage,
   isImageFailed,
 } from '../view/canvas/image-cache';
+import { yieldToPaint } from './yield';
 
 /**
  * Fetches the raw bytes of an image `src`. Supplied by the frontend so
@@ -69,6 +70,8 @@ export interface ExportSlidesPdfOptions {
   assetTimeoutMs?: number;
   /** Title written into the PDF metadata. */
   title?: string;
+  /** Progress callback: `(done, total, 'slides')` once before work, then after each rendered slide. */
+  onProgress?: (done: number, total: number, phase: string) => void;
 }
 
 // 1×1 transparent PNG. Used as a taint-free stand-in for images whose
@@ -126,7 +129,12 @@ export async function exportSlidesPdf(
   const pageWidth = PAGE_WIDTH_PT;
   const pageHeight = (SLIDE_HEIGHT / SLIDE_WIDTH) * PAGE_WIDTH_PT;
 
+  const onProgress = opts.onProgress;
+  const total = doc.slides.length;
+  onProgress?.(0, total, 'slides');
+
   try {
+    let done = 0;
     for (const slide of doc.slides) {
       const cloned = prepareExportSlide(slide, doc, map);
 
@@ -154,6 +162,10 @@ export async function exportSlidesPdf(
         format === 'jpeg' ? await pdf.embedJpg(bytes) : await pdf.embedPng(bytes);
       const page = pdf.addPage([pageWidth, pageHeight]);
       page.drawImage(image, { x: 0, y: 0, width: pageWidth, height: pageHeight });
+
+      done += 1;
+      onProgress?.(done, total, 'slides');
+      if (done < total) await yieldToPaint();
     }
   } finally {
     if (temp.length > 0) {

--- a/packages/slides/src/export/pdf.ts
+++ b/packages/slides/src/export/pdf.ts
@@ -131,10 +131,12 @@ export async function exportSlidesPdf(
 
   const onProgress = opts.onProgress;
   const total = doc.slides.length;
-  onProgress?.(0, total, 'slides');
 
   try {
+    // Emit inside the try so a throwing callback can't skip the finally that
+    // revokes the temp object URLs allocated by resolveDeckImages() above.
     let done = 0;
+    onProgress?.(0, total, 'slides');
     for (const slide of doc.slides) {
       const cloned = prepareExportSlide(slide, doc, map);
 
@@ -165,7 +167,10 @@ export async function exportSlidesPdf(
 
       done += 1;
       onProgress?.(done, total, 'slides');
-      if (done < total) await yieldToPaint();
+      // Only yield when progress is being reported — i.e. the interactive
+      // (browser) path. Headless/CLI exports gain nothing from the extra
+      // event-loop turn.
+      if (onProgress && done < total) await yieldToPaint();
     }
   } finally {
     if (temp.length > 0) {

--- a/packages/slides/src/export/pptx/index.ts
+++ b/packages/slides/src/export/pptx/index.ts
@@ -42,6 +42,7 @@
 
 import type { SlidesDocument } from '../../model/presentation.js';
 import { resolveBackgroundFill } from '../../model/presentation.js';
+import { yieldToPaint } from '../yield.js';
 import type { ImageElement } from '../../model/element.js';
 import { flattenElements, buildElementWorldLookup } from '../../model/group.js';
 import { computeConnectorFrame } from '../../view/canvas/connector-frame.js';
@@ -69,6 +70,8 @@ export interface ExportPptxOptions {
    * this option throws a clear error rather than writing broken XML.
    */
   fetchImage?: (src: string) => Promise<{ bytes: Uint8Array; mime: string }>;
+  /** Progress callback: `(done, total, 'slides')` once before work, then after each serialized slide. */
+  onProgress?: (done: number, total: number, phase: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -264,6 +267,10 @@ export async function exportPptx(
   // -------------------------------------------------------------------------
   const slideRIds: string[] = [];
 
+  const onProgress = opts.onProgress;
+  const slideTotal = deck.slides.length;
+  onProgress?.(0, slideTotal, 'slides');
+
   for (let i = 0; i < deck.slides.length; i++) {
     const slide = deck.slides[i];
     const slidePath = `ppt/slides/slide${i + 1}.xml`;
@@ -338,6 +345,8 @@ export async function exportPptx(
       `slides/slide${i + 1}.xml`,
     );
     slideRIds.push(slideRId);
+    onProgress?.(i + 1, slideTotal, 'slides');
+    if (i + 1 < slideTotal) await yieldToPaint();
   }
 
   // -------------------------------------------------------------------------

--- a/packages/slides/src/export/pptx/index.ts
+++ b/packages/slides/src/export/pptx/index.ts
@@ -346,7 +346,9 @@ export async function exportPptx(
     );
     slideRIds.push(slideRId);
     onProgress?.(i + 1, slideTotal, 'slides');
-    if (i + 1 < slideTotal) await yieldToPaint();
+    // Only yield on the interactive (progress-reporting) path; headless/CLI
+    // exports gain nothing from the extra event-loop turn per slide.
+    if (onProgress && i + 1 < slideTotal) await yieldToPaint();
   }
 
   // -------------------------------------------------------------------------

--- a/packages/slides/src/export/pptx/index.ts
+++ b/packages/slides/src/export/pptx/index.ts
@@ -271,7 +271,7 @@ export async function exportPptx(
   const slideTotal = deck.slides.length;
   onProgress?.(0, slideTotal, 'slides');
 
-  for (let i = 0; i < deck.slides.length; i++) {
+  for (let i = 0; i < slideTotal; i++) {
     const slide = deck.slides[i];
     const slidePath = `ppt/slides/slide${i + 1}.xml`;
 

--- a/packages/slides/src/export/yield.ts
+++ b/packages/slides/src/export/yield.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolve on the next macrotask so the browser can paint between heavy
+ * synchronous export units (per-slide canvas raster, per-slide XML). A
+ * `MessageChannel` macrotask avoids `setTimeout`'s ~4 ms clamp; falls back
+ * to `setTimeout(0)` where `MessageChannel` is unavailable (older Node).
+ */
+export function yieldToPaint(): Promise<void> {
+  if (typeof MessageChannel === 'undefined') {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return new Promise((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = () => resolve();
+    channel.port2.postMessage(0);
+  });
+}

--- a/packages/slides/test/export/pdf.test.ts
+++ b/packages/slides/test/export/pdf.test.ts
@@ -245,3 +245,19 @@ describe('exportSlidesPdf', () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 });
+
+describe('exportSlidesPdf progress', () => {
+  it('reports monotonic per-slide progress ending at total', async () => {
+    const { exportSlidesPdf } = await import('../../src/export/pdf');
+    const doc = baseDoc([blankSlide('s1'), blankSlide('s2'), blankSlide('s3')]);
+    const calls: Array<[number, number, string]> = [];
+    await exportSlidesPdf(doc, {
+      onProgress: (done, total, phase) => calls.push([done, total, phase]),
+    });
+    expect(calls[0]).toEqual([0, 3, 'slides']);
+    expect(calls[calls.length - 1]).toEqual([3, 3, 'slides']);
+    const dones = calls.map((c) => c[0]);
+    expect(dones).toEqual([...dones].sort((a, b) => a - b)); // non-decreasing
+    expect(calls.every((c) => c[1] === 3 && c[2] === 'slides')).toBe(true);
+  });
+});

--- a/packages/slides/test/export/pptx/progress.test.ts
+++ b/packages/slides/test/export/pptx/progress.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { exportPptx } from '../../../src/export/pptx/index.js';
+import type { Slide, SlidesDocument } from '../../../src/model/presentation.js';
+import { DEFAULT_BACKGROUND } from '../../../src/model/presentation.js';
+import { DEFAULT_MASTER } from '../../../src/model/master.js';
+import { BUILT_IN_LAYOUTS } from '../../../src/model/layout.js';
+import { BUILT_IN_THEMES } from '../../../src/themes/index.js';
+
+const blankSlide = (id: string): Slide => ({
+  id,
+  layoutId: 'blank',
+  background: { ...DEFAULT_BACKGROUND },
+  elements: [],
+  notes: [],
+});
+
+const deck = (slides: Slide[]): SlidesDocument => ({
+  meta: { title: 'Deck', themeId: BUILT_IN_THEMES[0].id, masterId: 'default' },
+  themes: [BUILT_IN_THEMES[0]],
+  masters: [DEFAULT_MASTER],
+  layouts: BUILT_IN_LAYOUTS,
+  slides,
+  guides: [],
+});
+
+describe('exportPptx progress', () => {
+  it('reports monotonic per-slide progress ending at total', async () => {
+    const calls: Array<[number, number, string]> = [];
+    await exportPptx(deck([blankSlide('s1'), blankSlide('s2')]), {
+      onProgress: (done, total, phase) => calls.push([done, total, phase]),
+    });
+    expect(calls[0]).toEqual([0, 2, 'slides']);
+    expect(calls[calls.length - 1]).toEqual([2, 2, 'slides']);
+    expect(calls.every((c) => c[1] === 2 && c[2] === 'slides')).toBe(true);
+  });
+});

--- a/packages/slides/test/export/pptx/progress.test.ts
+++ b/packages/slides/test/export/pptx/progress.test.ts
@@ -32,5 +32,7 @@ describe('exportPptx progress', () => {
     expect(calls[0]).toEqual([0, 2, 'slides']);
     expect(calls[calls.length - 1]).toEqual([2, 2, 'slides']);
     expect(calls.every((c) => c[1] === 2 && c[2] === 'slides')).toBe(true);
+    const dones = calls.map((c) => c[0]);
+    expect(dones).toEqual([...dones].sort((a, b) => a - b));
   });
 });


### PR DESCRIPTION
## Summary

Large exports (slides PDF/PPTX, docs PDF/DOCX) froze the UI with only a spinner. This adds an import-style **progress toast** and — the real fix — keeps the UI responsive during export.

Two parts, per `docs/design/export-progress.md`:

- **`onProgress(done, total, phase)`** — an optional callback on each exporter (slides PDF/PPTX, docs PDF/DOCX), mirroring the existing import wrapped-callback pattern. Optional everywhere, so CLI/Node/tests are unchanged.
- **`yieldToPaint()`** — a `MessageChannel` macrotask awaited *between* heavy synchronous units (per-slide `drawSlide`, per-page `paintPage`, per-slide `slideToXml`). Reporting alone can't repaint a blocked event loop; this is what unfreezes the UI. (DOCX needs no yield — its per-image `await fetch` already cedes the loop.)

The frontend wires the callback into a Sonner toast via a shared `updateExportToast`; the exporter `phase` string (`slides`/`pages`/`images`) doubles as the toast unit label → "12 / 50 slides".

**Scope note:** PPTX gets the library-level callback for parity, but is not wired to a toast — `exportPptx` has no frontend trigger today.

## Test plan

- [x] Unit tests per exporter assert the emit contract: starts `(0, total, phase)`, monotonic, ends `(total, total, phase)`.
- [x] `pnpm verify:fast` green; full `verify:self` (builds + entropy) green on push.
- [x] Manual smoke in `pnpm dev`: export a large deck/doc, confirm the toast counts up and the UI stays responsive.

## Review notes

Built via spec → plan → per-task TDD with per-task and whole-branch reviews; a final `/code-review` pass fixed: DOCX `0/N`-stuck when `onProgress` given without a fetcher, a zero-image DOCX toast flash, the slides button's missing re-entrancy guard, and a PPTX loop bound. Known minor non-blocking items (100%-during-`save()` gap, per-call `MessageChannel`) are documented in the task lessons file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export actions now show live progress while files are being generated.
  * Progress updates appear for slides and document exports, with clearer “done / total” status during longer exports.
  * Export toasts now update in place and switch to success or error messages when finished.

* **Bug Fixes**
  * Improved export responsiveness so the interface stays usable during heavy exports.
  * Progress now continues correctly even if an individual export step fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->