### PR TITLE
Refresh homepage + docs for current product; add PPTX export to slides UI

### DIFF
--- a/docs/design/homepage.md
+++ b/docs/design/homepage.md
@@ -89,10 +89,11 @@ Theme system uses the existing class-based Tailwind mechanism (`light` /
 | 3 | DemoSection | Sheets / Docs / Slides tab card — three tabs embed live `/shared/{token}` iframes (Docs + Slides tabs lazy-mount on first activation) with theme sync via `postMessage` |
 | 4 | FeaturesSection | 3 hero cards with waffle-pocket glyphs + 6 compact secondary cards (3×2, product-balanced: 2 Sheets / 2 Docs / 2 Slides) |
 | 5 | UseCasesSection | 3 scenarios (Internal tools / Customer dashboards / Specs & launch plans) |
-| 6 | WhySection | Comparison table vs Google Workspace inside a paper card |
-| 7 | DeveloperSection | Single dark code card with REST API / CLI tabs |
-| 8 | OpenSourceSection | Apache-2.0 callout with `<BigWaffle>` illustration + Star/Contribute CTAs |
-| 9 | Footer | Brand block + 3 link columns + bottom copyright row |
+| 6 | InteropSection | Import/Export format matrix — "no lock-in" paper cards |
+| 7 | WhySection | Comparison table vs Google Workspace inside a paper card |
+| 8 | DeveloperSection | Single dark code card with REST API / CLI tabs |
+| 9 | OpenSourceSection | Apache-2.0 callout with `<BigWaffle>` illustration + Star/Contribute CTAs |
+| 10 | Footer | Brand block + 3 link columns + bottom copyright row |
 
 #### NavBar
 
@@ -156,9 +157,9 @@ Two-tier layout. 3 large cards (waffle-pocket glyphs):
 Plus 6 compact cards in a 3×2 grid (`md:grid-cols-2`), product-balanced at
 2 per module so the 3-product suite reads visually:
 
-- **Sheets** — Formulas (FunctionSquare), Charts & Pivot Tables (BarChart3)
-- **Docs** — Page-Based Document Editor (FileText), Tables & Pagination (Rows3)
-- **Slides** — Themes & Layouts (Palette), Presentation Mode (Presentation)
+- **Sheets** — Formulas (FunctionSquare), Charts/Pivots/SQL Datasources (BarChart3)
+- **Docs** — Page-Based Document Editor (FileText), Comments/Mentions/Spell Check (MessageSquare)
+- **Slides** — Themes/Layouts/Shapes (Palette), Animations & Presentation Mode (Presentation)
 
 Each card uses a butter-tinted lucide icon chip. All cards use the handoff
 card shadow (`0 1px 0 rgba(42,30,18,0.04), 0 12px 28px -16px
@@ -171,12 +172,22 @@ title + sub copy + "Read the docs →" syrup link. Hover translates -2px.
 Cards are: Internal tools (Sheets embed), Pitch decks & all-hands (Slides
 theming + self-host), Specs & launch plans (Docs + Sheets references).
 
+#### InteropSection
+
+"No lock-in" format matrix. Two `--wb-paper` cards (handoff card shadow)
+inside a `max-w-[760px]` 2-column grid: **Import** (XLSX → Sheets, DOCX →
+Docs, PPTX → Slides) and **Export** (DOCX, PPTX, PDF). Each format is a
+rule-bordered chip with a lucide file icon. Reflects the shipped
+import/export code only — Sheets is import-only (no XLSX export yet), so
+it is listed under Import but not Export.
+
 #### WhySection
 
 Wafflebase vs Google Workspace comparison. Inside a `--wb-paper` card with rule
 borders. Leaf check / berry cross / butter "Limited" pill markers. The
 "single app" row reads "Slides, Docs & Sheets in one app" to match the
-3-product suite framing.
+3-product suite framing. Import/export differentiation lives in the
+dedicated InteropSection above, not in this table.
 
 #### DeveloperSection
 
@@ -250,6 +261,7 @@ packages/frontend/src/app/home/
 ├── demo-section.tsx
 ├── features-section.tsx
 ├── use-cases-section.tsx
+├── interop-section.tsx
 ├── why-section.tsx
 ├── developer-section.tsx
 ├── opensource-section.tsx

--- a/docs/tasks/active/20260628-homepage-refresh-todo.md
+++ b/docs/tasks/active/20260628-homepage-refresh-todo.md
@@ -145,7 +145,39 @@ comments side panel, @mention notifications, connector arrowhead picker.
 
 ## Review
 
-Status: **Phase 1 (homepage) implemented + verified; Phase 2 (docs) in progress**
+Status: **Shipped as PR #429** (homepage-refresh → main). CI `verify-self`
+running; MERGEABLE.
+
+### Commits (3, rebased onto origin/main)
+1. Refresh homepage for the three-product suite
+2. Add PPTX export to the slides editor toolbar
+3. Refresh documentation for Slides and import/export
+
+### Rebase conflict with #428 (resolved by integration, not just merge)
+While the branch was in review, `origin/main` gained **#428 "Show progress
+toast during docs/slides export"**, which touched the same export files
+(`slides-export-button.tsx`, `export-utils.ts`, and added an `onProgress`
+option to `exportPptx`). Rather than pick a side:
+- Merged `runExport(label, fn)` with #428's progress-toast pattern so **both**
+  PDF and PPTX exports now drive `updateExportToast` + success/error toast id.
+- Added an `onProgress?` param to `exportSlidesPptxAndDownload`, forwarded to
+  `exportPptx`'s new per-slide progress callback.
+- `export-utils.ts` auto-merged cleanly (#428's `updateExportToast` + this
+  branch's `safeFilename` `"pptx"` union).
+Re-verified post-rebase: `verify:fast` green, frontend build green, docs build
+green.
+
+### Lesson
+Long-lived branches touching a hot area (exports) should `git fetch` + check
+`origin/main` before the final commit — #428 landed mid-task and would have
+been a silent semantic conflict (PPTX export with no progress toast) if merged
+naively instead of integrated.
+
+### Non-blocking review notes (from /code-review, accepted)
+- PPTX image-fetch failure aborts the export — same behavior as the PDF path,
+  not a regression.
+- Home card-shadow / card-shell duplication mirrors the existing home/ pattern;
+  promoting a shared primitive is a separate cleanup.
 
 ### What changed
 - `use-cases-section.tsx` — broken `/docs/sheets/sheet` → `/docs/sheets/build-a-budget`.

--- a/docs/tasks/active/20260628-homepage-refresh-todo.md
+++ b/docs/tasks/active/20260628-homepage-refresh-todo.md
@@ -1,6 +1,6 @@
 # Homepage Refresh — content + interop section
 
-Status: **planning**
+Status: **shipped — PR #429** (see Review section for the authoritative final state)
 Branch: `homepage-refresh`
 
 ## Context
@@ -22,10 +22,10 @@ Import/export matrix actually shipped in code:
 | Capability | Import | Export |
 |---|---|---|
 | Sheets (XLSX) | ✅ `packages/sheets/src/import/xlsx-importer.ts` | ❌ (none yet) |
-| Docs (DOCX)   | ✅ `packages/docs/src/import/docx-importer.ts` | ✅ `export/docx-exporter.ts` |
-| Docs (PDF)    | — | ✅ `export/pdf-exporter.ts` |
-| Slides (PPTX) | ✅ `packages/slides/src/import/pptx/` | ✅ `export/pptx/` |
-| Slides (PDF)  | — | ✅ `export/pdf.ts` |
+| Docs (DOCX)   | ✅ `packages/docs/src/import/docx-importer.ts` | ✅ `packages/docs/src/export/docx-exporter.ts` |
+| Docs (PDF)    | — | ✅ `packages/docs/src/export/pdf-exporter.ts` |
+| Slides (PPTX) | ✅ `packages/slides/src/import/pptx/` | ✅ `packages/slides/src/export/pptx/` |
+| Slides (PDF)  | — | ✅ `packages/slides/src/export/pdf.ts` |
 
 → Honest framing: **Import** XLSX, DOCX, PPTX · **Export** DOCX, PPTX, PDF.
 Do NOT claim XLSX export (not implemented).
@@ -39,7 +39,7 @@ writing-a-document}`, `guide/{collaboration,getting-started}`,
 ## Work items
 
 ### 1. Fix broken link 🔴
-- [ ] `use-cases-section.tsx:15` — `/docs/sheets/sheet` does not exist.
+- [x] `use-cases-section.tsx:15` — `/docs/sheets/sheet` does not exist.
       Replace with `/docs/sheets/build-a-budget` (closest matching the
       "embed an editable grid" internal-tools use case).
 
@@ -47,42 +47,43 @@ writing-a-document}`, `guide/{collaboration,getting-started}`,
 Keep the 3 hero pillars (Collaboration / REST API & CLI / Self-hosted).
 Update the 6 secondary cards (2 per product) to current breadth:
 
-- [ ] Sheets · Formulas & Cross-Sheet References — keep (`/docs/sheets/formulas`)
-- [ ] Sheets · Charts, Pivots & SQL Datasources (BarChart3) —
+- [x] Sheets · Formulas & Cross-Sheet References — keep (`/docs/sheets/formulas`)
+- [x] Sheets · Charts, Pivots & SQL Datasources (BarChart3) —
       "Visualize, aggregate, and pull live data from PostgreSQL" → `/docs/sheets/charts`
-- [ ] Docs · Page-Based Document Editor — keep (`/docs/docs-editor/writing-a-document`)
-- [ ] Docs · Comments, Mentions & Spell Check (MessageSquare) —
+- [x] Docs · Page-Based Document Editor — keep (`/docs/docs-editor/writing-a-document`)
+- [x] Docs · Comments, Mentions & Spell Check (MessageSquare) —
       "Inline threads, @mentions, and live spell checking" → `/docs/docs-editor/writing-a-document`
       (no dedicated comments page yet; anchor TBD)
-- [ ] Slides · Themes, Layouts & Shapes (Palette) —
+- [x] Slides · Themes, Layouts & Shapes (Palette) —
       "23 built-in themes, Google-Slides-parity layouts, 55+ shapes & connectors" → `/docs/slides/themes-and-layouts`
-- [ ] Slides · Animations & Presentation Mode (Presentation) —
+- [x] Slides · Animations & Presentation Mode (Presentation) —
       "Object/slide animations plus a full-screen keyboard-driven player" → `/docs/slides/build-a-deck`
 
 ### 3. New Interop section 🟡
-- [ ] New component `interop-section.tsx`, mounted in `page.tsx` between
+- [x] New component `interop-section.tsx`, mounted in `page.tsx` between
       `UseCasesSection` and `WhySection` (pairs with the no-lock-in message).
-- [ ] Reuse `<SectionHead>` + the existing paper-card style (no new tokens).
-- [ ] Content: kicker "No lock-in", title "Bring your files — and take
+- [x] Reuse `<SectionHead>` + the existing paper-card style (no new tokens).
+- [x] Content: kicker "No lock-in", title "Bring your files — and take
       them with you.", two columns: **Import** (XLSX → Sheets, DOCX → Docs,
       PPTX → Slides) and **Export** (DOCX, PPTX, PDF). lucide file icons.
-- [ ] Add one row to the WhySection table: "Import & export PPTX, DOCX, PDF"
-      → Wafflebase ✅ / Google Workspace = Limited.
+- [~] Add one row to the WhySection table: "Import & export PPTX, DOCX, PDF"
+      → added, then **reverted at user request** (interop story lives only in
+      the dedicated InteropSection, not duplicated in the comparison table).
 
 ### 4. Design doc + verify
-- [ ] Update `docs/design/homepage.md`: add InteropSection to the section
+- [x] Update `docs/design/homepage.md`: add InteropSection to the section
       table + file structure; refresh FeaturesSection card list.
-- [ ] `pnpm verify:fast` green.
-- [ ] Self-review via `/code-review` over the branch diff.
-- [ ] Manual smoke in `pnpm dev` (homepage renders, new section + links).
+- [x] `pnpm verify:fast` green.
+- [x] Self-review via `/code-review` over the branch diff.
+- [x] Manual smoke in `pnpm dev` (homepage renders, new section + links).
 
-## Open decisions (confirm before coding)
+## Decisions (resolved with user before coding)
 
-1. Interop section placement: UseCases → **Interop** → Why (proposed) — OK?
-2. Secondary-card swaps: drop "Tables & Pagination" for "Comments/Mentions/
-   Spell Check"? (Tables still mentioned via Docs editor card description.)
-3. Docs link for the comments card — no dedicated page exists; point at
-   `writing-a-document` for now, or omit the link?
+1. Interop section placement → UseCases → **Interop** → Why. ✅
+2. Secondary-card swaps → dropped "Tables & Pagination" for "Comments/Mentions/
+   Spell Check" (tables still noted in the Docs editor card). ✅
+3. Docs link for the comments card → points at `/docs/guide/collaboration`
+   (where comments/mentions are documented; updated per PR #429 review). ✅
 
 ## Phase 2 — Documentation parity (`packages/documentation`)
 

--- a/docs/tasks/active/20260628-homepage-refresh-todo.md
+++ b/docs/tasks/active/20260628-homepage-refresh-todo.md
@@ -1,0 +1,183 @@
+# Homepage Refresh — content + interop section
+
+Status: **planning**
+Branch: `homepage-refresh`
+
+## Context
+
+The homepage (`packages/frontend/src/app/home/`) was last given a content
+pass in #277 (initial Slides addition). Since then the product gained
+large capabilities that the page never advertises: DOCX/PDF export, PPTX
+import/export, XLSX import, comments/mentions, spell check, charts/pivots,
+SQL datasources, slide shapes/connectors/animations, ~23 themes. Version
+strings are already dynamic (`__APP_VERSION__`), so nothing there is stale.
+
+This task does **content + one new section only** — no design-system or
+layout-engine changes. Demo-iframe verification was explicitly deferred.
+
+## Verified facts (read from source, not design docs)
+
+Import/export matrix actually shipped in code:
+
+| Capability | Import | Export |
+|---|---|---|
+| Sheets (XLSX) | ✅ `packages/sheets/src/import/xlsx-importer.ts` | ❌ (none yet) |
+| Docs (DOCX)   | ✅ `packages/docs/src/import/docx-importer.ts` | ✅ `export/docx-exporter.ts` |
+| Docs (PDF)    | — | ✅ `export/pdf-exporter.ts` |
+| Slides (PPTX) | ✅ `packages/slides/src/import/pptx/` | ✅ `export/pptx/` |
+| Slides (PDF)  | — | ✅ `export/pdf.ts` |
+
+→ Honest framing: **Import** XLSX, DOCX, PPTX · **Export** DOCX, PPTX, PDF.
+Do NOT claim XLSX export (not implemented).
+
+Docs-site pages that exist (link targets must resolve to these):
+`developers/{cli,rest-api,self-hosting}`, `docs-editor/{keyboard-shortcuts,
+writing-a-document}`, `guide/{collaboration,getting-started}`,
+`sheets/{build-a-budget,charts,formulas,keyboard-shortcuts}`,
+`slides/{build-a-deck,keyboard-shortcuts,themes-and-layouts}`.
+
+## Work items
+
+### 1. Fix broken link 🔴
+- [ ] `use-cases-section.tsx:15` — `/docs/sheets/sheet` does not exist.
+      Replace with `/docs/sheets/build-a-budget` (closest matching the
+      "embed an editable grid" internal-tools use case).
+
+### 2. Refresh Features secondary cards 🟠
+Keep the 3 hero pillars (Collaboration / REST API & CLI / Self-hosted).
+Update the 6 secondary cards (2 per product) to current breadth:
+
+- [ ] Sheets · Formulas & Cross-Sheet References — keep (`/docs/sheets/formulas`)
+- [ ] Sheets · Charts, Pivots & SQL Datasources (BarChart3) —
+      "Visualize, aggregate, and pull live data from PostgreSQL" → `/docs/sheets/charts`
+- [ ] Docs · Page-Based Document Editor — keep (`/docs/docs-editor/writing-a-document`)
+- [ ] Docs · Comments, Mentions & Spell Check (MessageSquare) —
+      "Inline threads, @mentions, and live spell checking" → `/docs/docs-editor/writing-a-document`
+      (no dedicated comments page yet; anchor TBD)
+- [ ] Slides · Themes, Layouts & Shapes (Palette) —
+      "23 built-in themes, Google-Slides-parity layouts, 55+ shapes & connectors" → `/docs/slides/themes-and-layouts`
+- [ ] Slides · Animations & Presentation Mode (Presentation) —
+      "Object/slide animations plus a full-screen keyboard-driven player" → `/docs/slides/build-a-deck`
+
+### 3. New Interop section 🟡
+- [ ] New component `interop-section.tsx`, mounted in `page.tsx` between
+      `UseCasesSection` and `WhySection` (pairs with the no-lock-in message).
+- [ ] Reuse `<SectionHead>` + the existing paper-card style (no new tokens).
+- [ ] Content: kicker "No lock-in", title "Bring your files — and take
+      them with you.", two columns: **Import** (XLSX → Sheets, DOCX → Docs,
+      PPTX → Slides) and **Export** (DOCX, PPTX, PDF). lucide file icons.
+- [ ] Add one row to the WhySection table: "Import & export PPTX, DOCX, PDF"
+      → Wafflebase ✅ / Google Workspace = Limited.
+
+### 4. Design doc + verify
+- [ ] Update `docs/design/homepage.md`: add InteropSection to the section
+      table + file structure; refresh FeaturesSection card list.
+- [ ] `pnpm verify:fast` green.
+- [ ] Self-review via `/code-review` over the branch diff.
+- [ ] Manual smoke in `pnpm dev` (homepage renders, new section + links).
+
+## Open decisions (confirm before coding)
+
+1. Interop section placement: UseCases → **Interop** → Why (proposed) — OK?
+2. Secondary-card swaps: drop "Tables & Pagination" for "Comments/Mentions/
+   Spell Check"? (Tables still mentioned via Docs editor card description.)
+3. Docs link for the comments card — no dedicated page exists; point at
+   `writing-a-document` for now, or omit the link?
+
+## Phase 2 — Documentation parity (`packages/documentation`)
+
+Docs site was content-frozen since #277 (only version bumps). No broken
+links. Two problem classes; user approved Tier 1 + Import/Export page +
+other gaps. Kept on the same branch → one combined PR.
+
+### Tier 1 — stale "Slides-omitted" framing (verified against code) ✅
+- [x] `.vitepress/config.ts:52` — site description add presentations.
+- [x] `developers/rest-api.md:3` — intro: add presentation data.
+- [x] `developers/rest-api.md:35` — "two kinds" → three; added Slides column
+      to API Surface table; loosened TYPE_MISMATCH wording.
+- [x] `developers/rest-api.md` Create — `type` add `"slides"` + slides example;
+      Images note includes slides.
+- [x] `developers/rest-api.md` Document Content — "(docs only)" → "(docs and
+      slides)"; noted SlidesDocument body shape.
+- [x] `README.md` — added Slides section + Import & Export row; Getting Started
+      desc includes slides; "Four sidebar sections" → Five.
+
+### PPTX export → wire into slides editor UI (new user request)
+- [x] `slides/pptx-actions.ts` — add `exportSlidesPptxAndDownload` (reuses
+      `exportPptx` from browser entry + credentialed `docsImageFetcher`
+      adapter → `{bytes,mime}`).
+- [x] `docs/export-utils.ts` — `safeFilename` ext union add `"pptx"`.
+- [x] `slides/slides-export-button.tsx` — add "PowerPoint (.pptx)" menu item,
+      refactor to a generic `runExport(label, fn)` helper; update header doc.
+- [x] Verified: tsc clean, frontend build green (jszip bundles for browser),
+      verify:fast green. Manual smoke (open deck → Export → PowerPoint)
+      deferred to pre-merge.
+
+### Import/Export — new cross-product page
+- [x] New `guide/import-export.md`; added to Guide sidebar (config.ts) +
+      README content table. Matrix reflects UI reality: Import XLSX→Sheets,
+      DOCX→Docs, PPTX→Slides; Export DOCX+PDF (Docs), **PPTX+PDF (Slides,
+      now both)**, Sheets export CLI-only. Fidelity + CLI sections included.
+- [x] `pnpm --filter @wafflebase/documentation build` green (dead-link gate).
+
+### Other coverage gaps (facts gathered via 4 parallel Explore agents)
+- [x] `guide/collaboration.md` — Comments & Mentions section (Sheets cell +
+      Docs text-range comments, resolve, docs comments panel, @mention
+      autocomplete). Intro now says sheet/document/**presentation**.
+- [x] `docs-editor/writing-a-document.md` — Images, Headers & Footers, Spell
+      Check sections.
+- [x] `slides/build-a-deck.md` — Add a Table, Connect Shapes, Animations &
+      Transitions sections.
+- [x] `slides/themes-and-layouts.md` — enumerated all 23 built-in themes
+      (Simple Light default … Wafflebase brand), from code registry.
+- [x] New `sheets/datasources.md` — added to Sheets sidebar (config.ts) +
+      README content table.
+
+**Vaporware deliberately NOT documented** (flagged deferred by agents):
+docs Image Options panel / rotation / crop, spell-check toggle UI, Sheets
+comments side panel, @mention notifications, connector arrowhead picker.
+
+### Verify
+- [x] `pnpm --filter @wafflebase/documentation build` green (dead-link gate
+      passes; all new pages + sidebar links resolve).
+- [x] Each new section sourced from verified code/design facts with exact UI
+      labels (button/menu text, shortcuts).
+
+## Review
+
+Status: **Phase 1 (homepage) implemented + verified; Phase 2 (docs) in progress**
+
+### What changed
+- `use-cases-section.tsx` — broken `/docs/sheets/sheet` → `/docs/sheets/build-a-budget`.
+- `features-section.tsx` — 4 of 6 secondary cards refreshed to current breadth
+  (Charts/Pivots/SQL Datasources, Comments/Mentions/Spell Check, Themes/Layouts/
+  Shapes, Animations & Presentation Mode); swapped `Rows3` icon for `MessageSquare`.
+- `interop-section.tsx` — new "No lock-in" section, Import/Export format cards.
+- `page.tsx` — mounted `<InteropSection>` between UseCases and Why.
+- `why-section.tsx` — no change to rows; the proposed "Import & export PPTX,
+  DOCX, PDF" row was added then **removed at user request** (interop story now
+  lives solely in the dedicated InteropSection, not duplicated in the table).
+- `docs/design/homepage.md` — section table, file structure, Features + Interop +
+  Why subsections updated.
+
+### Decisions confirmed with user
+- Docs card 2 → Comments/Mentions/Spell Check (drop Tables & Pagination card;
+  tables now noted in the Docs editor card description).
+- Interop placement → UseCases → **Interop** → Why.
+
+### Verification
+- `pnpm verify:fast` — green (lint + unit).
+- `pnpm --filter @wafflebase/frontend build` — green.
+- Frontend typecheck (`tsc --noEmit`) — clean.
+- Visual smoke (puppeteer, dark theme): Interop section renders with Import
+  (XLSX→Sheets, DOCX→Docs, PPTX→Slides) / Export (DOCX, PPTX, PDF) cards;
+  Why table shows the new interop row; all section headings present in order.
+
+### Honesty guardrails applied
+- No XLSX export claim (Sheets is import-only in code).
+- Theme card says "Built-in themes" (no hard count) to avoid over-claiming.
+
+### Follow-ups (not in scope)
+- Demo iframe liveness check (3 hardcoded shared tokens) — deferred by user.
+- No dedicated `/docs/.../comments` page exists; comments card points at
+  `writing-a-document`. Consider a comments doc page later.

--- a/packages/documentation/.vitepress/config.ts
+++ b/packages/documentation/.vitepress/config.ts
@@ -49,7 +49,7 @@ if (gaId) {
 export default defineConfig({
   title: "Wafflebase Docs",
   description:
-    "Documentation for Wafflebase — collaborative spreadsheet and document editor",
+    "Documentation for Wafflebase — collaborative spreadsheets, documents, and presentations",
   base: "/docs/",
 
   head,
@@ -81,6 +81,7 @@ export default defineConfig({
             text: "Collaboration & Sharing",
             link: "/guide/collaboration",
           },
+          { text: "Import & Export", link: "/guide/import-export" },
         ],
       },
       {
@@ -89,6 +90,7 @@ export default defineConfig({
           { text: "Build a Budget", link: "/sheets/build-a-budget" },
           { text: "Formulas", link: "/sheets/formulas" },
           { text: "Charts & Pivot Tables", link: "/sheets/charts" },
+          { text: "External Datasources", link: "/sheets/datasources" },
           {
             text: "Keyboard Shortcuts",
             link: "/sheets/keyboard-shortcuts",

--- a/packages/documentation/README.md
+++ b/packages/documentation/README.md
@@ -8,8 +8,9 @@ VitePress-based documentation site for Wafflebase. Serves user guides and develo
 
 | Page | Description |
 |------|-------------|
-| [Getting Started](guide/getting-started.md) | Sign in, create sheets or documents, first steps |
+| [Getting Started](guide/getting-started.md) | Sign in, create sheets, docs, or slides, first steps |
 | [Collaboration](guide/collaboration.md) | Share documents, real-time editing, permissions |
+| [Import & Export](guide/import-export.md) | XLSX/DOCX/PPTX import, DOCX/PPTX/PDF export, CLI automation |
 
 ### Sheets
 
@@ -18,6 +19,7 @@ VitePress-based documentation site for Wafflebase. Serves user guides and develo
 | [Build a Budget](sheets/build-a-budget.md) | Learn formulas, formatting, and layout |
 | [Formulas](sheets/formulas.md) | Formula syntax, function reference, examples |
 | [Charts](sheets/charts.md) | Chart types, creation, editing, pivot tables |
+| [External Datasources](sheets/datasources.md) | Connect PostgreSQL, run SQL, read-only result tabs |
 | [Keyboard Shortcuts](sheets/keyboard-shortcuts.md) | Spreadsheet shortcut reference |
 
 ### Docs
@@ -26,6 +28,14 @@ VitePress-based documentation site for Wafflebase. Serves user guides and develo
 |------|-------------|
 | [Writing a Document](docs-editor/writing-a-document.md) | Text editing, formatting, page layout |
 | [Keyboard Shortcuts](docs-editor/keyboard-shortcuts.md) | Document editor shortcut reference |
+
+### Slides
+
+| Page | Description |
+|------|-------------|
+| [Build a Deck](slides/build-a-deck.md) | Slides, elements, themes, presenting |
+| [Themes & Layouts](slides/themes-and-layouts.md) | Theme system and slide layouts |
+| [Keyboard Shortcuts](slides/keyboard-shortcuts.md) | Presentation editor shortcut reference |
 
 ### Developers
 
@@ -50,7 +60,7 @@ Site configuration is in `.vitepress/config.ts`:
 
 - **Base path**: `/docs/` (deployed as subpath of the main site)
 - **Search**: Local search provider (no external service)
-- **Navigation**: Four sidebar sections — Guide, Sheets, Docs, and Developers
+- **Navigation**: Five sidebar sections — Guide, Sheets, Docs, Slides, and Developers
 - **Theme**: Default VitePress theme with custom CSS overrides
 
 ## Tech Stack

--- a/packages/documentation/developers/rest-api.md
+++ b/packages/documentation/developers/rest-api.md
@@ -1,6 +1,6 @@
 # REST API
 
-The Wafflebase REST API lets you read and write spreadsheet and document data programmatically. All endpoints are under `/api/v1/`.
+The Wafflebase REST API lets you read and write spreadsheet, document, and presentation data programmatically. All endpoints are under `/api/v1/`.
 
 ## Authentication
 
@@ -32,17 +32,17 @@ Replace `:workspaceId` with your workspace ID.
 
 ## API Surface by Document Type
 
-A workspace holds two kinds of documents — **sheets** (spreadsheets) and **docs** (word-processor documents). The endpoints below are grouped accordingly:
+A workspace holds three kinds of documents — **sheets** (spreadsheets), **docs** (word-processor documents), and **slides** (presentations). The endpoints below are grouped accordingly:
 
-| Section | Sheet | Doc |
-|---------|:-----:|:---:|
-| [Documents](#documents) | ✅ | ✅ |
-| [Images](#images) | ✅ | ✅ |
-| [Tabs](#tabs-sheets-only) | ✅ | — |
-| [Cells](#cells-sheets-only) | ✅ | — |
-| [Document Content](#document-content-docs-only) | — | ✅ |
+| Section | Sheet | Doc | Slides |
+|---------|:-----:|:---:|:------:|
+| [Documents](#documents) | ✅ | ✅ | ✅ |
+| [Images](#images) | ✅ | ✅ | ✅ |
+| [Tabs](#tabs-sheets-only) | ✅ | — | — |
+| [Cells](#cells-sheets-only) | ✅ | — | — |
+| [Document Content](#document-content-docs-and-slides) | — | ✅ | ✅ |
 
-Calling a sheet-only endpoint on a doc — or a doc-only endpoint on a sheet — returns `HTTP 409` with code `TYPE_MISMATCH`.
+Calling an endpoint against the wrong document type — e.g. a tabs/cells call on a doc, or a content call on a sheet — returns `HTTP 409` with code `TYPE_MISMATCH`.
 
 ## Documents
 
@@ -79,12 +79,19 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"title": "Meeting Notes", "type": "doc"}' \
   https://api.wafflebase.io/api/v1/workspaces/:wid/documents
+
+# Create a slides deck
+curl -X POST \
+  -H "Authorization: Bearer wfb_..." \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Launch Deck", "type": "slides"}' \
+  https://api.wafflebase.io/api/v1/workspaces/:wid/documents
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `title` | string | Yes | Document title |
-| `type` | string | No | `"sheet"` (default) or `"doc"` |
+| `type` | string | No | `"sheet"` (default), `"doc"`, or `"slides"` |
 
 ### Get Document
 
@@ -114,7 +121,7 @@ DELETE /api/v1/workspaces/:wid/documents/:did
 
 ## Images
 
-Workspace-scoped image storage. Images are stored under the workspace and may be referenced by both sheets and docs.
+Workspace-scoped image storage. Images are stored under the workspace and may be referenced by sheets, docs, and slides.
 
 ### Upload Image
 
@@ -279,11 +286,11 @@ curl -X PATCH \
   .../tabs/:tid/cells
 ```
 
-## Document Content (docs only)
+## Document Content (docs and slides)
 
-Read or replace the full content tree of a **doc** (word-processor) document. The content is the live Yorkie CRDT document — collaborators in the editor see updates from `PUT` immediately.
+Read or replace the full content tree of a **doc** (word-processor) or **slides** (presentation) document. The content is the live Yorkie CRDT document — collaborators in the editor see updates from `PUT` immediately.
 
-Calling these endpoints against a sheet returns `HTTP 409` with code `TYPE_MISMATCH`.
+Calling these endpoints against a sheet returns `HTTP 409` with code `TYPE_MISMATCH`. The body shape depends on the document type: docs use the block-tree `Document` JSON described below, while slides use the deck's `SlidesDocument` JSON (slides, elements, theme). Read the content first to see the exact shape before writing it back.
 
 ### Get Document Content
 

--- a/packages/documentation/developers/rest-api.md
+++ b/packages/documentation/developers/rest-api.md
@@ -46,7 +46,7 @@ Calling an endpoint against the wrong document type — e.g. a tabs/cells call o
 
 ## Documents
 
-Document CRUD works for both sheets and docs. Each document carries a `type` field (`"sheet"` or `"doc"`).
+Document CRUD works for sheets, docs, and slides. Each document carries a `type` field (`"sheet"`, `"doc"`, or `"slides"`).
 
 ### List Documents
 

--- a/packages/documentation/docs-editor/writing-a-document.md
+++ b/packages/documentation/docs-editor/writing-a-document.md
@@ -69,6 +69,25 @@ Insert a table from the toolbar to lay out structured content. Click the **Table
 
 When a table is taller than the remaining space on a page, its rows split across the page boundary automatically.
 
+## Images
+
+Click the **Insert image** button in the toolbar and choose:
+
+- **Upload from computer** — pick an image file from your device.
+- **By URL…** — paste the address of an image on the web.
+
+You can also drag an image file straight onto the page, or paste one copied
+from another app.
+
+Once an image is placed, click it to select it. Eight square handles appear
+around the edges:
+
+- Drag a **corner** handle to resize while keeping the aspect ratio (hold
+  **Shift** to resize freely).
+- Drag a **side** handle to stretch one dimension.
+- **Arrow keys** nudge the image a pixel at a time (**Shift** for larger steps).
+- **Delete** / **Backspace** removes it; **Esc** deselects.
+
 ## Pagination
 
 Documents use a page-based layout similar to a printed document. Pages default to A4 with standard margins, and text flows across pages as you type.
@@ -76,6 +95,26 @@ Documents use a page-based layout similar to a printed document. Pages default t
 - Long paragraphs and tables break naturally at the page boundary — line splitting keeps headings, table headers, and partial rows in sync with the layout.
 - The editor renders one page per "sheet" so you can scroll through the deck of pages exactly as they will print or export.
 - Export to PDF preserves the same pagination — what you see on screen matches the exported document.
+
+## Headers & Footers
+
+Add content that repeats on every page — a title, a date, or a page number.
+
+- **Double-click** the margin area above the body (header) or below it (footer)
+  to start editing it. Click back into the body, or press **Esc**, to leave.
+- While editing a header or footer, click **Insert page number** in the toolbar
+  to drop in a number that updates automatically on each page.
+
+A header or footer applies to the whole document. Tables, page breaks, and
+horizontal rules can't be placed inside them.
+
+## Spell Check
+
+Misspelled words are underlined with a red squiggle as you type — spell check
+is on by default. Right-click an underlined word to see suggestions and click
+one to replace it.
+
+Spell check currently covers English (Latin-script) words in the body text.
 
 ## Undo and Redo
 

--- a/packages/documentation/guide/collaboration.md
+++ b/packages/documentation/guide/collaboration.md
@@ -1,6 +1,6 @@
 # Collaboration & Sharing
 
-Wafflebase lets multiple people edit the same sheet or document at the same time. Share via link — no account required for recipients.
+Wafflebase lets multiple people edit the same sheet, document, or presentation at the same time. Share via link — no account required for recipients.
 
 ## Share a Document
 
@@ -37,6 +37,57 @@ When a collaborator opens your shared link, you'll see:
 
 ::: tip
 Each collaborator gets a unique color. If your collaborators sign in with GitHub, their name will appear next to their cursor.
+:::
+
+## Comments & Mentions
+
+Leave feedback without changing the content. Comments work on cells in sheets
+and on selected text in documents.
+
+### Add a comment
+
+**In a sheet:**
+
+1. Select the cell you want to comment on
+2. Right-click and choose **Insert comment**, or press **⌘+Option+M** /
+   **Ctrl+Alt+M**
+3. Type your comment and click **Comment**
+
+**In a document:**
+
+1. Select the text you want to comment on
+2. Right-click and choose **Insert comment**, press **⌘+Option+M** /
+   **Ctrl+Alt+M**, or click the comment icon in the toolbar
+3. Type your comment and click **Comment**
+
+The commented text is highlighted so everyone can see where the discussion is.
+
+### Reply, resolve, edit
+
+- **Reply** — Open a comment and click **Reply** to continue the thread.
+- **Resolve** — Hover the thread and click the check (✓) to resolve it.
+  Resolved threads are tucked away but never lost.
+- **Edit / Delete** — Hover your own comment and use the **⋯** menu. Deleting
+  the first comment removes the whole thread.
+
+### The comments panel (documents)
+
+In a document, click the comment icon in the toolbar — or press
+**⌘+Option+Shift+M** / **Ctrl+Alt+Shift+M** — to open the comments panel. It
+lists every thread under **Open** and **Resolved** tabs; click a thread to jump
+to its text. If the text a comment was attached to is later deleted, the thread
+moves to an orphaned list so the conversation is preserved.
+
+### Mention a teammate
+
+Type **@** inside a comment to mention a workspace member. An autocomplete list
+appears — keep typing to filter, then use **↑ / ↓** and **Enter** (or **Tab**)
+to pick someone. The mention is inserted as a blue chip so it stands out in the
+thread.
+
+::: tip
+Mentions highlight who a comment is for. Only people who are members of the
+workspace can be mentioned.
 :::
 
 ## How Conflicts Work

--- a/packages/documentation/guide/import-export.md
+++ b/packages/documentation/guide/import-export.md
@@ -1,0 +1,78 @@
+# Import & Export
+
+Wafflebase reads and writes the file formats your team already uses, so you
+can bring existing work in and take finished work out. Nothing is locked to
+the platform.
+
+## At a glance
+
+| Product | Import | Export |
+|---------|--------|--------|
+| **Sheets** | Excel (`.xlsx`) | — *(CSV/JSON via [CLI](../developers/cli))* |
+| **Docs** | Word (`.docx`) | Word (`.docx`), PDF (`.pdf`) |
+| **Slides** | PowerPoint (`.pptx`) | PowerPoint (`.pptx`), PDF (`.pdf`) |
+
+Import always creates a **new** document; it never overwrites an open one.
+Export downloads a file from the document you are editing.
+
+## Importing files
+
+From your workspace, open the **New** menu and choose an import option:
+
+- **Import XLSX** — creates a new spreadsheet from an Excel workbook. Each
+  sheet in the workbook becomes a tab. Values, formulas, and basic cell
+  formatting are brought across.
+- **Import DOCX** — creates a new document from a Word file, mapping
+  paragraphs, headings, lists, tables, and inline formatting into the editor.
+- **Import PPTX** — creates a new deck from a PowerPoint file: slides,
+  text boxes, shapes, images, tables, and theme colors are converted to
+  native Wafflebase elements.
+
+Large files show a progress indicator while they are parsed and any embedded
+images are uploaded into your workspace.
+
+## Exporting files
+
+### Docs
+
+In the document editor, open the **Export** menu (the download icon in the
+header) and choose:
+
+- **Word (`.docx`)** — the full document, including tables and headers/footers.
+- **PDF (`.pdf`)** — a paginated, print-ready PDF that mirrors the on-screen
+  page layout.
+
+### Slides
+
+In the presentation editor, open the **Export** menu and choose:
+
+- **PowerPoint (`.pptx`)** — an editable deck with slides, shapes, text,
+  images, tables, and the theme preserved as DrawingML.
+- **PDF (`.pdf`)** — one slide per page, ready to share or print.
+
+### Sheets
+
+Spreadsheets export to CSV or JSON through the
+[command-line tool](../developers/cli) (`wafflebase sheets …`). A built-in
+download menu in the grid editor is on the roadmap.
+
+## Fidelity notes
+
+Wafflebase aims for a faithful round-trip, but the source formats are large
+and some constructs have no exact equivalent:
+
+- **PPTX/DOCX import is best-effort.** Common content — text, lists, tables,
+  shapes, images, and theme colors — converts cleanly. Rare or
+  application-specific features (embedded objects, macros, exotic effects) may
+  be simplified or dropped.
+- **Fonts** referenced by an imported file must be available in Wafflebase to
+  render identically; otherwise a close fallback is substituted.
+- **Re-exporting** a file you imported will not be byte-identical to the
+  original, but preserves the structure and content faithfully.
+
+## Automating with the CLI
+
+Every import/export path above is also scriptable. See the
+[CLI reference](../developers/cli) for `docs export`, `docs import`,
+`slides export`, `slides import`, and the `sheets` cell import/export
+commands — useful for batch conversions and pipelines.

--- a/packages/documentation/sheets/datasources.md
+++ b/packages/documentation/sheets/datasources.md
@@ -1,0 +1,47 @@
+# External Datasources
+
+A **datasource** connects a spreadsheet to an external PostgreSQL database. You
+write a SQL query and its results appear in a read-only tab, right next to your
+regular editable sheets.
+
+## Connect a database
+
+1. Click the **+** at the end of the tab bar and choose **New DataSource**.
+2. In the **Select DataSource** dialog, fill in the connection details:
+   - **Name** — a label for the connection
+   - **Host** and **Port** (defaults to `5432`)
+   - **Database**, **Username**, and **Password**
+   - **SSL** — toggle on if your database requires it
+3. Click **Test Connection** to confirm the credentials work, then save.
+
+A new tab is added with a database icon to distinguish it from sheet tabs.
+
+## Run a query
+
+The datasource tab has a SQL editor at the top and a results grid below it.
+
+1. Type a `SELECT` query — for example, `SELECT * FROM users LIMIT 100`.
+2. Click **Execute**, or press **⌘+Enter** / **Ctrl+Enter**.
+
+The results load into the grid below: the first row holds the column names and
+each following row is a record. Re-run the query with **Execute** whenever you
+want fresh data — results don't refresh automatically.
+
+::: tip
+Queries are capped at 10,000 rows and a 30-second runtime, so add a `LIMIT`
+clause when exploring large tables.
+:::
+
+## Working with results
+
+- The results grid is **read-only** — it reflects the database, so you can't
+  edit, sort, or filter the cells in place. Shape the data with SQL instead.
+- Reference query results from other tabs with formulas, just like any sheet,
+  to build summaries and dashboards on top of live data.
+
+## Good to know
+
+- Datasources connect to **PostgreSQL** databases.
+- The connection belongs to the person who created it. Collaborators can see the
+  query and its last results, but run their own connection to execute it.
+- Only the latest query for a tab is saved.

--- a/packages/documentation/slides/build-a-deck.md
+++ b/packages/documentation/slides/build-a-deck.md
@@ -54,6 +54,56 @@ In presentation mode:
 - `←` / `Page Up` — go back
 - `Esc` — exit
 
+## Add a Table
+
+Click the **Insert table** button in the toolbar and drag across the grid
+picker to choose the number of rows and columns, then click to drop the table
+on the slide.
+
+- **Double-click** a cell to edit its text; the text-formatting toolbar appears
+  while you type.
+- **Tab** / **Shift+Tab** move between cells — pressing Tab in the last cell
+  adds a new row.
+- **Right-click** a cell for structure changes: **Insert row above/below**,
+  **Insert column left/right**, **Delete row/column**, and **Merge cells** /
+  **Unmerge cells**.
+
+## Connect Shapes
+
+Use connectors to link shapes — handy for flowcharts and diagrams. Click the
+**Line** dropdown in the toolbar and pick a tool:
+
+- **Line** and **Arrow** — straight connectors.
+- **Elbow connector** — right-angled routing.
+- **Curved connector** — a smooth curve.
+
+Drag from the start point to the end point. As you approach a shape, connection
+points appear and the endpoint snaps to it, so the connector stays attached when
+you later move the shape. To change the routing of a selected connector,
+right-click it and choose **Straight**, **Elbow**, or **Curved**.
+
+## Animations & Transitions
+
+Open the **Motion** panel from the right sidebar to add motion to a deck.
+
+**Slide transitions** (how one slide gives way to the next):
+
+1. In the **Transition** section, pick a type — Fade, Dissolve, Slide, Flip,
+   Cube, Wipe, or Push.
+2. Choose a speed (Slow / Medium / Fast).
+3. Click **Apply to all slides** to use the same transition everywhere.
+
+**Object animations** (how an element enters, exits, or is emphasized):
+
+1. Select an element on the slide.
+2. In the **Animation** section, click **+ Add animation**.
+3. Pick a **Category** (Entrance, Exit, or Emphasis) and an **Effect**, then set
+   when it runs with **Start** — **On Click**, **With Previous**, or **After
+   Previous**. Fine-tune **Duration**, **Delay**, and **Easing** as needed.
+
+Click the **▶ Play** button to preview the animations right in the editor.
+They also run when you present the deck.
+
 ## What's Next
 
 - [Themes & Layouts](./themes-and-layouts) — Catalog of themes, layouts, and placeholders

--- a/packages/documentation/slides/themes-and-layouts.md
+++ b/packages/documentation/slides/themes-and-layouts.md
@@ -14,9 +14,18 @@ Each theme defines:
 
 ## Built-in Themes
 
-Wafflebase ships with several Google-Slides-parity themes covering light, dark, and accent variations. Open the **Theme** panel from the right sidebar to see thumbnails and apply one with a click.
+Wafflebase ships with **23 built-in themes** covering neutral, light,
+editorial, vibrant, and dark looks. Open the **Theme** panel from the right
+sidebar to see thumbnails and apply one with a click.
 
-You can switch themes at any time. The theme picker shows a live preview of the active deck under each theme.
+- **Simple Light** *(default)* and **Simple Dark** — neutral baselines
+- Streamline, Swiss, Paradigm, Material, Shift, Momentum, Focus, Luxe, Modern
+  Writer, Coral, Spearmint, Pop, Tropic, Marina, Geometric, Plum, Slate,
+  Forest, Spotlight, Beach Day
+- **Wafflebase** — the Wafflebase brand palette
+
+New decks start on **Simple Light**. You can switch themes at any time — the
+theme picker shows a live preview of the active deck under each one.
 
 ## Layouts
 

--- a/packages/documentation/slides/themes-and-layouts.md
+++ b/packages/documentation/slides/themes-and-layouts.md
@@ -19,9 +19,9 @@ editorial, vibrant, and dark looks. Open the **Theme** panel from the right
 sidebar to see thumbnails and apply one with a click.
 
 - **Simple Light** *(default)* and **Simple Dark** — neutral baselines
-- Streamline, Swiss, Paradigm, Material, Shift, Momentum, Focus, Luxe, Modern
-  Writer, Coral, Spearmint, Pop, Tropic, Marina, Geometric, Plum, Slate,
-  Forest, Spotlight, Beach Day
+- Streamline, Swiss, Paradigm, Material, Shift, Momentum, Focus, Luxe,
+  Modern Writer, Coral, Spearmint, Pop, Tropic, Marina, Geometric, Plum,
+  Slate, Forest, Spotlight, Beach Day
 - **Wafflebase** — the Wafflebase brand palette
 
 New decks start on **Simple Light**. You can switch themes at any time — the

--- a/packages/frontend/src/app/docs/export-utils.ts
+++ b/packages/frontend/src/app/docs/export-utils.ts
@@ -142,7 +142,10 @@ export function updateExportToast(
  * Build a filesystem-safe filename for export downloads.
  * Adds the extension if not already present.
  */
-export function safeFilename(title: string, ext: "docx" | "pdf"): string {
+export function safeFilename(
+  title: string,
+  ext: "docx" | "pdf" | "pptx",
+): string {
   // Strip filesystem-unsafe characters; if nothing usable is left,
   // fall back to "document" so we don't return a hidden file like ".pdf".
   const sanitized = (title || "").replace(/[\\/:*?"<>|]+/g, "_").trim();

--- a/packages/frontend/src/app/home/features-section.tsx
+++ b/packages/frontend/src/app/home/features-section.tsx
@@ -72,7 +72,7 @@ const SECONDARY_FEATURES: SecondaryFeature[] = [
     Icon: MessageSquare,
     title: "Comments, Mentions & Spell Check",
     description: "Inline threads, @mentions, and live spell checking",
-    href: "/docs/docs-editor/writing-a-document",
+    href: "/docs/guide/collaboration",
   },
   {
     Icon: Palette,

--- a/packages/frontend/src/app/home/features-section.tsx
+++ b/packages/frontend/src/app/home/features-section.tsx
@@ -2,9 +2,9 @@ import {
   BarChart3,
   FileText,
   FunctionSquare,
+  MessageSquare,
   Palette,
   Presentation,
-  Rows3,
 } from "lucide-react";
 import type { ComponentType, ReactNode } from "react";
 import { FeatureGlyph, type GlyphKind } from "./primitives/feature-glyph";
@@ -57,36 +57,35 @@ const SECONDARY_FEATURES: SecondaryFeature[] = [
   },
   {
     Icon: BarChart3,
-    title: "Charts & Pivot Tables",
-    description: "Built-in data visualization and aggregation",
+    title: "Charts, Pivots & SQL Datasources",
+    description: "Visualize, aggregate, and pull live data from PostgreSQL",
     href: "/docs/sheets/charts",
   },
   {
     Icon: FileText,
     title: "Page-Based Document Editor",
     description:
-      "Write and format documents with a clean, paginated editor",
+      "Paginated editor with rich tables, page breaks, and headers/footers",
     href: "/docs/docs-editor/writing-a-document",
   },
   {
-    Icon: Rows3,
-    title: "Tables & Pagination",
-    description:
-      "Rich tables, page breaks, and pagination for long-form documents",
-    href: "/docs/docs-editor/writing-a-document#tables",
+    Icon: MessageSquare,
+    title: "Comments, Mentions & Spell Check",
+    description: "Inline threads, @mentions, and live spell checking",
+    href: "/docs/docs-editor/writing-a-document",
   },
   {
     Icon: Palette,
-    title: "Themes & Layouts",
+    title: "Themes, Layouts & Shapes",
     description:
-      "Four-tier theme system and Google-Slides-parity layouts for decks",
+      "Built-in themes, Google-Slides-parity layouts, 55+ shapes & connectors",
     href: "/docs/slides/themes-and-layouts",
   },
   {
     Icon: Presentation,
-    title: "Presentation Mode",
+    title: "Animations & Presentation Mode",
     description:
-      "Full-screen player with keyboard navigation and click-to-advance",
+      "Object and slide animations plus a full-screen keyboard-driven player",
     href: "/docs/slides/build-a-deck",
   },
 ];

--- a/packages/frontend/src/app/home/interop-section.tsx
+++ b/packages/frontend/src/app/home/interop-section.tsx
@@ -1,0 +1,123 @@
+import {
+  FileInput,
+  FileOutput,
+  FileSpreadsheet,
+  FileText,
+  FileType,
+  Presentation,
+} from "lucide-react";
+import type { ComponentType } from "react";
+import { SectionHead } from "./primitives/section-head";
+
+type Format = {
+  Icon: ComponentType<{ className?: string }>;
+  format: string;
+  target?: string;
+};
+
+const IMPORTS: Format[] = [
+  { Icon: FileSpreadsheet, format: "XLSX", target: "Sheets" },
+  { Icon: FileText, format: "DOCX", target: "Docs" },
+  { Icon: Presentation, format: "PPTX", target: "Slides" },
+];
+
+const EXPORTS: Format[] = [
+  { Icon: FileText, format: "DOCX" },
+  { Icon: Presentation, format: "PPTX" },
+  { Icon: FileType, format: "PDF" },
+];
+
+const CARD_SHADOW =
+  "0 1px 0 rgba(42,30,18,0.04), 0 12px 28px -16px rgba(42,30,18,0.18)";
+
+export function InteropSection() {
+  return (
+    <section className="bg-[color:var(--wb-bg)] py-16 md:py-20 px-6 md:px-8">
+      <div className="max-w-[1200px] mx-auto">
+        <SectionHead
+          kicker="No lock-in"
+          title="Bring your files — and take them with you."
+          sub="Import what you already have and export what you make. Wafflebase speaks the formats your team already uses, so your data is never trapped."
+        />
+
+        <div className="max-w-[760px] mx-auto grid grid-cols-1 md:grid-cols-2 gap-5 md:gap-6">
+          <InteropCard
+            Glyph={FileInput}
+            title="Import"
+            caption="Open existing files directly"
+            formats={IMPORTS}
+          />
+          <InteropCard
+            Glyph={FileOutput}
+            title="Export"
+            caption="Download in standard formats"
+            formats={EXPORTS}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type InteropCardProps = {
+  Glyph: ComponentType<{ className?: string }>;
+  title: string;
+  caption: string;
+  formats: Format[];
+};
+
+function InteropCard({ Glyph, title, caption, formats }: InteropCardProps) {
+  return (
+    <div
+      className="flex flex-col gap-4 rounded-2xl border border-[color:var(--wb-rule)] bg-[color:var(--wb-paper)] p-6 md:p-7"
+      style={{ boxShadow: CARD_SHADOW }}
+    >
+      <div className="flex items-center gap-3">
+        <div
+          className="inline-flex items-center justify-center size-9 rounded-lg"
+          style={{
+            background: "color-mix(in srgb, var(--wb-butter) 35%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--wb-syrup) 25%, transparent)",
+          }}
+        >
+          <Glyph className="size-[18px] text-[color:var(--wb-syrup-deep)]" />
+        </div>
+        <div>
+          <h3 className="font-body font-semibold text-[16px] text-[color:var(--wb-ink)] m-0">
+            {title}
+          </h3>
+          <p className="font-body text-[12.5px] text-[color:var(--wb-sub)] m-0">
+            {caption}
+          </p>
+        </div>
+      </div>
+
+      <ul className="flex flex-col gap-2 list-none p-0 m-0">
+        {formats.map(({ Icon, format, target }) => (
+          <li
+            key={format}
+            className="flex items-center gap-2.5 rounded-lg border border-[color:var(--wb-rule)] px-3 py-2"
+            style={{
+              background: "color-mix(in srgb, var(--wb-rule) 14%, var(--wb-paper))",
+            }}
+          >
+            <Icon className="size-4 shrink-0 text-[color:var(--wb-syrup-deep)]" />
+            <span className="font-code text-[13px] font-medium text-[color:var(--wb-ink)]">
+              {format}
+            </span>
+            {target ? (
+              <>
+                <span className="font-code text-[12px] text-[color:var(--wb-sub)]">
+                  →
+                </span>
+                <span className="font-body text-[13px] text-[color:var(--wb-sub)]">
+                  {target}
+                </span>
+              </>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/home/page.tsx
+++ b/packages/frontend/src/app/home/page.tsx
@@ -4,6 +4,7 @@ import { HeroSection } from "./hero-section";
 import { DemoSection } from "./demo-section";
 import { FeaturesSection } from "./features-section";
 import { UseCasesSection } from "./use-cases-section";
+import { InteropSection } from "./interop-section";
 import { WhySection } from "./why-section";
 import { DeveloperSection } from "./developer-section";
 import { OpenSourceSection } from "./opensource-section";
@@ -25,6 +26,7 @@ export default function HomePage({
       <DemoSection />
       <FeaturesSection />
       <UseCasesSection />
+      <InteropSection />
       <WhySection />
       <DeveloperSection />
       <OpenSourceSection />

--- a/packages/frontend/src/app/home/use-cases-section.tsx
+++ b/packages/frontend/src/app/home/use-cases-section.tsx
@@ -12,7 +12,7 @@ const USE_CASES: UseCase[] = [
     tag: "Internal tools",
     title: "Replace the 'export to Excel, edit, paste back' loop",
     body: "Embed an editable grid right inside your dashboard. Users get the spreadsheet they wanted; you keep the schema you wanted.",
-    href: "/docs/sheets/sheet",
+    href: "/docs/sheets/build-a-budget",
   },
   {
     tag: "Pitch decks & all-hands",

--- a/packages/frontend/src/app/slides/pptx-actions.ts
+++ b/packages/frontend/src/app/slides/pptx-actions.ts
@@ -1,11 +1,20 @@
 import {
+  exportPptx,
   importPptx,
   type ImportReport,
   type SlidesDocument,
   type UploadImage,
 } from "@wafflebase/slides";
-import { docsImageUploader } from "../docs/export-utils";
-import { pickFile } from "../docs/export-utils";
+import {
+  docsImageFetcher,
+  docsImageUploader,
+  downloadBlob,
+  pickFile,
+  safeFilename,
+} from "../docs/export-utils";
+
+const PPTX_MIME =
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation";
 
 const MIME_TO_EXT: Record<string, string> = {
   "image/png": "png",
@@ -57,4 +66,39 @@ export async function pickAndImportPptx(
       : undefined,
   });
   return { document, report, fileName: file.name };
+}
+
+/**
+ * Export the presentation to a `.pptx` archive and trigger a browser
+ * download.
+ *
+ * Unlike the PDF path, PPTX is vector DrawingML XML — there is no canvas
+ * raster step, so fonts need no preloading; PowerPoint resolves the family
+ * names at open time. Images are embedded as `ppt/media/` parts: `exportPptx`
+ * asks for each unique image `src`'s bytes through `fetchImage`, which we
+ * satisfy with the same credentialed `docsImageFetcher` used by the docs and
+ * slides PDF exporters (backend images are same-origin-fetched with cookies).
+ *
+ * `exportPptx` is re-exported from the browser entry of `@wafflebase/slides`
+ * and is DOM-free, so it is safe to call from the editor. `onProgress` is
+ * forwarded to the per-slide progress callback so the caller can drive an
+ * export toast, mirroring the PDF path.
+ */
+export async function exportSlidesPptxAndDownload(
+  doc: SlidesDocument,
+  title: string,
+  onProgress?: (done: number, total: number, phase: string) => void,
+): Promise<void> {
+  const bytes = await exportPptx(doc, {
+    fetchImage: async (src) => {
+      const blob = await docsImageFetcher(src);
+      return {
+        bytes: new Uint8Array(await blob.arrayBuffer()),
+        mime: blob.type || "image/png",
+      };
+    },
+    onProgress,
+  });
+  const blob = new Blob([bytes], { type: PPTX_MIME });
+  downloadBlob(blob, safeFilename(title, "pptx"));
 }

--- a/packages/frontend/src/app/slides/slides-export-button.tsx
+++ b/packages/frontend/src/app/slides/slides-export-button.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
-import { IconFileTypePdf, IconDownload, IconLoader2 } from "@tabler/icons-react";
+import {
+  IconFileTypePdf,
+  IconFileTypePpt,
+  IconDownload,
+  IconLoader2,
+} from "@tabler/icons-react";
 import { toast } from "sonner";
 import type { SlidesStore } from "@wafflebase/slides";
 import {
@@ -14,6 +19,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { exportSlidesPdfAndDownload } from "./pdf-actions";
+import { exportSlidesPptxAndDownload } from "./pptx-actions";
 import { updateExportToast } from "../docs/export-utils";
 
 interface SlidesExportButtonProps {
@@ -23,10 +29,10 @@ interface SlidesExportButtonProps {
 }
 
 /**
- * Header "Export" menu for the slides editor. P0 offers PDF only (one
- * slide per page, raster). The dynamic-imported pdf-lib + per-slide
- * canvas render can take a few seconds on large decks, so the trigger
- * shows a spinner and stays disabled until the download fires.
+ * Header "Export" menu for the slides editor. Offers PDF (one slide per
+ * page, raster) and PPTX (vector DrawingML round-trip). Either path can
+ * take a few seconds on large decks — the trigger shows a spinner and
+ * stays disabled until the download fires.
  */
 export function SlidesExportButton({
   store,
@@ -35,20 +41,27 @@ export function SlidesExportButton({
 }: SlidesExportButtonProps) {
   const [exporting, setExporting] = useState(false);
 
-  const handleExportPdf = async () => {
+  const runExport = async (
+    label: string,
+    fn: (
+      doc: ReturnType<SlidesStore["read"]>,
+      title: string,
+      onProgress: (done: number, total: number, phase: string) => void,
+    ) => Promise<void>,
+  ) => {
     if (!store || exporting) return;
     setExporting(true);
     const t = title || "presentation";
     let toastId: string | number | undefined;
     try {
-      await exportSlidesPdfAndDownload(store.read(), t, (done, total, phase) => {
+      await fn(store.read(), t, (done, total, phase) => {
         toastId = updateExportToast(toastId, t, done, total, phase);
       });
       const message = `Exported "${t}"`;
       if (toastId !== undefined) toast.success(message, { id: toastId });
       else toast.success(message);
     } catch (err) {
-      console.error("Slides PDF export failed", err);
+      console.error(`Slides ${label} export failed`, err);
       const message =
         err instanceof Error ? `Export failed: ${err.message}` : "Export failed";
       if (toastId !== undefined) toast.error(message, { id: toastId });
@@ -83,10 +96,18 @@ export function SlidesExportButton({
         <DropdownMenuItem
           className="cursor-pointer"
           disabled={exporting}
-          onSelect={handleExportPdf}
+          onSelect={() => runExport("PDF", exportSlidesPdfAndDownload)}
         >
           <IconFileTypePdf size={16} />
           PDF (.pdf)
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="cursor-pointer"
+          disabled={exporting}
+          onSelect={() => runExport("PPTX", exportSlidesPptxAndDownload)}
+        >
+          <IconFileTypePpt size={16} />
+          PowerPoint (.pptx)
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Summary

Brings the public-facing surfaces back in line with the product (which has grown well past its last content pass) and wires the existing PPTX writer into the slides editor.

**Homepage** (`packages/frontend/src/app/home/`)
- Fix a broken docs link (`/docs/sheets/sheet` → `/docs/sheets/build-a-budget`).
- Refresh feature cards to current capabilities (SQL datasources, comments/mentions, shapes, animations).
- New **Interop** section advertising XLSX/DOCX/PPTX import and DOCX/PPTX/PDF export.

**PPTX export in the slides editor** (`packages/frontend/src/app/slides/`)
- The PPTX writer already shipped in the slides package + CLI, but the editor's Export menu only offered PDF. Adds a **PowerPoint (.pptx)** menu item, reusing the credentialed image fetcher to embed media and folding PDF/PPTX into one `runExport` helper. Threads the per-slide progress toast added in #428.

**Documentation** (`packages/documentation/`)
- Drop the stale two-product framing (REST API surface now covers `slides` as a third document type; README + site description updated).
- New guides: **Import & Export** and **External Datasources**.
- Document shipped features that had no page: comments/mentions, spell check, docs images/headers & footers, and slide tables/connectors/animations; enumerate the 23 built-in slide themes.

Deferred/not-yet-shipped features (image options panel, spell-check toggle UI, mention notifications, connector arrowhead picker) were deliberately left undocumented.

## Test plan

- `pnpm verify:fast` — green (lint + architecture + all package unit suites).
- `pnpm --filter @wafflebase/frontend build` — green (PPTX path bundles jszip for the browser).
- `pnpm --filter @wafflebase/documentation build` — green (VitePress dead-link gate passes; all new pages + sidebar links resolve).
- Homepage rendered in dark theme via headless browser: Interop section + refreshed cards present.
- Manual smoke recommended before merge: open a deck → **Export → PowerPoint (.pptx)** and confirm the download + progress toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new homepage Interop section highlighting supported import and export formats.
  * Added PPTX export for slides.
  * Expanded documentation for importing/exporting, external datasources, images, spell check, comments, and slide building tools.

* **Bug Fixes**
  * Updated a homepage link to point to the correct getting-started guide.

* **Documentation**
  * Refreshed homepage, docs navigation, and API docs to reflect the latest Sheets, Docs, and Slides capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->