### PR TITLE
Add Google Docs named styles to the docs word processor

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -41,6 +41,7 @@ Word processor engine — rich text, tables, pagination, collaboration.
 | [docs-intent-preserving-edits.md](docs/docs-intent-preserving-edits.md)          | Intent-preserving Yorkie edits — character-level Tree editing for concurrent same-paragraph edits |
 | [docs-presence.md](docs/docs-presence.md)                                        | Docs presence — peer cursor carets + name labels and avatar click-to-jump in the collaborative docs editor |
 | [docs-wordprocessor-roadmap.md](docs/docs-wordprocessor-roadmap.md)              | Docs word processor roadmap — current state + remaining phases for Google Docs parity              |
+| [docs-named-styles.md](docs/docs-named-styles.md)                                | Docs named styles — Google-Docs paragraph-style model: redefinable per-document style registry (Normal/Title/Subtitle/Heading 1–6), "Update to match"/"Reset", refreshed GS built-in values, per-user default styles |
 | [docs-ruler.md](docs/docs-ruler.md)                                              | Docs ruler design                                                                                 |
 | [docs-comments.md](docs/docs-comments.md)                                        | Docs comments — text-range threads, CRDT-stable posRange anchors, orphan preservation, shared frontend module |
 | [docs-font-controls.md](docs/docs-font-controls.md)                              | Docs font controls — curated family picker (14 fonts), Google-Docs-style size input, line spacing, clear formatting, shared text-formatting components |

--- a/docs/design/docs/docs-named-styles.md
+++ b/docs/design/docs/docs-named-styles.md
@@ -1,6 +1,6 @@
 ---
 title: docs-named-styles
-target-version: 0.2.0
+target-version: 0.4.9
 ---
 
 # Docs Named Styles

--- a/docs/design/docs/docs-named-styles.md
+++ b/docs/design/docs/docs-named-styles.md
@@ -1,0 +1,213 @@
+---
+title: docs-named-styles
+target-version: 0.2.0
+---
+
+# Docs Named Styles
+
+## Summary
+
+Promote the docs word processor's hardcoded heading/title/subtitle style
+defaults into a **document-scoped, redefinable style registry** that matches
+Google Docs' "Paragraph styles" model. The fixed catalog (Normal text, Title,
+Subtitle, Heading 1–6) stays — users cannot invent arbitrary named styles
+(Google Docs parity) — but each style's *definition* becomes editable per
+document via "Update '<style>' to match" and resettable via "Reset styles".
+A per-user "default styles" blob (Save / Use my default styles) is persisted
+in the backend so a user's redefinitions carry across documents.
+
+This also refreshes the built-in style values to Google Docs defaults
+(non-bold headings, grayscale color hierarchy, paragraph spacing).
+
+Roadmap item: Phase **6.5 Named Styles** in
+[docs-wordprocessor-roadmap.md](docs-wordprocessor-roadmap.md).
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A document-level style registry stored in the Yorkie CRDT (root level,
+  beside `pageSetup`) holding **only overrides** of built-in style defs.
+- "Update '<style>' to match" — redefine a style from the caret block's
+  current formatting; all blocks of that style reflow.
+- "Reset '<style>'" and "Reset styles" — drop overrides back to built-ins.
+- Refine built-in Title/Subtitle/Heading 1–6 values to Google Docs defaults.
+- Expose Heading 4–6 in the Styles dropdown (currently H1–3 only).
+- Per-user default styles persisted in backend ("Save / Use my default
+  styles").
+
+**Non-Goals**
+
+- Arbitrary user-named custom styles (Word model). Out of scope by design.
+- Character-level cascade for *direct* formatting tracking (Google Docs'
+  "clear formatting reverts to style") beyond what already exists.
+- Changing the **Normal** text body defaults (line spacing 1.5, margins) —
+  kept as-is to avoid reflowing every existing document. Documented deviation
+  from Google Docs (which uses 1.15).
+
+## Proposal Details
+
+### Style catalog & block reference
+
+Nine styles keyed by a stable `StyleId`:
+
+```ts
+type StyleId =
+  | 'normal' | 'title' | 'subtitle'
+  | 'heading-1' | 'heading-2' | 'heading-3'
+  | 'heading-4' | 'heading-5' | 'heading-6';
+```
+
+A block's reference to its style is **derived from existing fields** — no block
+model change, full backward compatibility:
+
+| Block | StyleId |
+| --- | --- |
+| `paragraph`, `list-item` | `normal` |
+| `title` | `title` |
+| `subtitle` | `subtitle` |
+| `heading` + `headingLevel: N` | `heading-N` |
+| `horizontal-rule`, `table`, `page-break` | `normal` (no style applied) |
+
+`blockStyleId(block): StyleId` lives in `model/named-styles.ts`.
+
+### Data model
+
+```ts
+interface NamedStyleDef {
+  inline: Partial<InlineStyle>;   // bold, italic, fontSize, fontFamily, color
+  block: Partial<BlockStyle>;     // spacing only: marginTop, marginBottom, lineHeight
+}
+
+// Document registry — overrides only; an empty/absent entry means "built-in".
+type DocStyles = Partial<Record<StyleId, Partial<NamedStyleDef>>>;
+```
+
+`BUILTIN_STYLES: Record<StyleId, NamedStyleDef>` holds the refreshed defaults
+below. Resolution deep-merges override over built-in:
+
+```ts
+resolveStyleInline(id, docStyles) = { ...BUILTIN_STYLES[id].inline, ...docStyles?.[id]?.inline }
+resolveStyleBlock(id, docStyles)  = { ...BUILTIN_STYLES[id].block,  ...docStyles?.[id]?.block }
+```
+
+`Document` gains an optional `styles?: DocStyles` field, beside `pageSetup`.
+
+### Built-in values (Google Docs defaults)
+
+Font = Arial. Heading spacing converted pt→px at 96 dpi (`px = pt × 4/3`,
+rounded). Headings are **non-bold**; weight comes from size + grayscale color.
+
+| Style | size | weight | color | space-above / below (px) |
+| --- | --- | --- | --- | --- |
+| Normal | 11 | — | #000000 | (unchanged: marginBottom 8) |
+| Title | 26 | — | #000000 | 0 / 4 |
+| Subtitle | 15 | — | #666666 | 0 / 16 |
+| Heading 1 | 20 | — | #000000 | 27 / 8 |
+| Heading 2 | 16 | — | #000000 | 24 / 8 |
+| Heading 3 | 14 | — | #434343 | 21 / 5 |
+| Heading 4 | 12 | — | #666666 | 19 / 5 |
+| Heading 5 | 11 | — | #666666 | 16 / 5 |
+| Heading 6 | 11 | italic | #666666 | 16 / 5 |
+
+> Exact values re-verified against a live Google Docs DOCX export during
+> implementation. This is a visible change from the current bold/larger
+> headings — called out in the PR description as intentional.
+
+### Cascade resolution model
+
+Two distinct paths, mirroring the existing architecture:
+
+- **Inline (font / size / bold / italic / color) — lazy, registry-driven.**
+  `resolveBlockInlines(block, docStyles?)` uses
+  `resolveStyleInline(blockStyleId(block), docStyles)` as the base layer under
+  each inline's explicit style (replaces the hardcoded
+  `getHeadingDefaults` / `TITLE_DEFAULTS` / `SUBTITLE_DEFAULTS` constants).
+  Threaded through `computeLayout(..., docStyles?)` → `layoutBlock(..., docStyles?)`.
+  Default (no arg) = built-in resolution, so slides text-box editor, PDF
+  exporter, and CLI keep working unchanged; the docs editor and PDF exporter
+  pass `document.styles`. Result: "Update to match" reflows every block of the
+  style instantly with **no block rewrites**.
+
+- **Block spacing (marginTop / marginBottom / lineHeight) — eager, materialized.**
+  `block.style` stays full-value and authoritative for layout (no layout
+  change for spacing). The style's block defaults are written into
+  `block.style` at the moment of:
+  - **apply** (`setBlockType`) — when the *previous* and *next* `StyleId`
+    differ, re-materialize spacing (paragraph↔list-item, both `normal`, is a
+    no-op, so a bullet toggle never disturbs spacing);
+  - **update** (`updateStyleDefinition`) — re-materialize spacing for every
+    block whose `blockStyleId === styleId`;
+  - **reset** — re-materialize to built-in spacing.
+
+  Direct per-paragraph spacing edits remain on `block.style` and are treated as
+  direct formatting (Google Docs parity).
+
+### Store API (`DocStore`)
+
+```ts
+getDocStyles(): DocStyles;
+setDocStyles(styles: DocStyles): void;
+updateStyleDefinition(styleId: StyleId, def: NamedStyleDef): void; // "Update to match"
+resetStyle(styleId: StyleId): void;                                // "Reset this style"
+resetAllStyles(): void;                                            // "Reset styles"
+```
+
+`updateStyleDefinition` / `resetStyle` / `resetAllStyles` each run as one
+batched undo unit and re-materialize block spacing for affected blocks.
+Implemented in `MemStore` (plain `this.doc.styles`) and `YorkieDocStore`
+(root-level `root.styles`, mirroring the `pageSetup` getter/setter +
+`readDocStyles` proxy-unwrap helper). Backend `docs-tree.ts` `DocsYorkieRoot`
+serializes `styles` the same way (deep copy on write, delete on omission).
+
+### Per-user default styles (backend)
+
+New Prisma model + migration:
+
+```prisma
+model UserDocStyles {
+  userId    Int      @id
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  styles    Json
+  updatedAt DateTime @updatedAt
+}
+```
+
+Endpoints (JWT, `@CurrentUser`-style like `auth.controller.ts` `getMe`):
+
+| Method | Route | Description |
+| --- | --- | --- |
+| `GET` | `/auth/me/doc-styles` | Return saved `DocStyles` (or `{}`) |
+| `PUT` | `/auth/me/doc-styles` | Upsert the current user's `DocStyles` |
+
+Frontend wires these into the Styles dropdown "Options" submenu:
+- **Save as my default styles** → `PUT` current `getDocStyles()`.
+- **Use my default styles** → `GET`, then `setDocStyles(...)`.
+
+### UI (`text-style-group.tsx` / `text-style-options.ts`)
+
+- Add **Heading 4 / 5 / 6** rows (shortcuts ⌥4–⌥6).
+- Each style row gains a hover submenu (▸): *Apply* /
+  *Update '<style>' to match* (reads the caret block's effective formatting via
+  the same resolution used by the toolbar) / *Reset '<style>'*.
+- Bottom **Options** entry: *Save as my default styles* / *Use my default
+  styles* / *Reset styles* — mirrors Google Docs' Format → Paragraph styles.
+
+The docs formatting toolbar (`docs-formatting-toolbar.tsx`) wires the new
+callbacks to `EditorAPI` primitives that call the store methods above.
+
+## Risks and Mitigation
+
+- **Heading appearance change** (bold→non-bold, new colors) is visible on every
+  existing document. *Mitigation:* intentional Google Docs parity; called out
+  in the PR; built-in-only — no data migration, and a user who preferred bold
+  can "Update Heading 1 to match" a bold sample.
+- **Registry not understood by older clients / backend.** *Mitigation:*
+  `styles` is optional and additive at the Yorkie root, exactly like
+  `pageSetup`; absence resolves to built-ins.
+- **Eager spacing materialization clobbers custom paragraph spacing on style
+  switch.** *Mitigation:* only re-materialize when `StyleId` actually changes;
+  this matches Google Docs (applying a style resets paragraph formatting).
+- **Threading `docStyles` through layout** touches a hot path. *Mitigation:*
+  optional param defaulting to built-in; only the docs editor + PDF export pass
+  it; covered by layout unit tests asserting registry override wins.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| docs named styles (2026-06-29) | [20260629-docs-named-styles-todo.md](./active/20260629-docs-named-styles-todo.md) | [20260629-docs-named-styles-lessons.md](./active/20260629-docs-named-styles-lessons.md) |
 | color picker none swatch (2026-06-28) | [20260628-color-picker-none-swatch-todo.md](./active/20260628-color-picker-none-swatch-todo.md) | [20260628-color-picker-none-swatch-lessons.md](./active/20260628-color-picker-none-swatch-lessons.md) |
 | docs context menu (2026-06-28) | [20260628-docs-context-menu-todo.md](./active/20260628-docs-context-menu-todo.md) | [20260628-docs-context-menu-lessons.md](./active/20260628-docs-context-menu-lessons.md) |
 | docs shortcuts catalog (2026-06-28) | [20260628-docs-shortcuts-catalog-todo.md](./active/20260628-docs-shortcuts-catalog-todo.md) | [20260628-docs-shortcuts-catalog-lessons.md](./active/20260628-docs-shortcuts-catalog-lessons.md) |

--- a/docs/tasks/active/20260325-docs-wordprocessor-todo.md
+++ b/docs/tasks/active/20260325-docs-wordprocessor-todo.md
@@ -48,5 +48,5 @@ Design doc: [docs-wordprocessor-roadmap.md](../../design/docs/docs-wordprocessor
 - [ ] 6.2 Footnotes / Endnotes
 - [ ] 6.3 Spell Check
 - [x] 6.4 Print / PDF Export
-- [ ] 6.5 Named Styles
+- [x] **6.5 Named Styles** — Google Docs paragraph-style model: redefinable per-document registry (Normal/Title/Subtitle/Heading 1–6), Update to match / Reset, refreshed GS built-in values, per-user default styles. See [20260629-docs-named-styles-todo.md](20260629-docs-named-styles-todo.md)
 - [x] 6.6 Full Keyboard Shortcuts mapping — single catalog (`shortcuts-catalog.ts`) + shared help modal (⌘/Ctrl+/); catalog drift fixed (heading 1–6, paste-formatting, word nav/delete now exposed). See [20260628-docs-shortcuts-catalog-todo.md](20260628-docs-shortcuts-catalog-todo.md)

--- a/docs/tasks/active/20260629-docs-named-styles-lessons.md
+++ b/docs/tasks/active/20260629-docs-named-styles-lessons.md
@@ -3,4 +3,27 @@
 Capture patterns and corrections discovered while implementing named styles.
 
 ## Lessons
-(filled as work progresses)
+
+### Toolbar must show the *computed* style, not the raw run style
+Named-style inline defaults (font/size/color/bold/italic) are resolved **lazily
+at layout** via `resolveBlockInlines`; they are never stored on the inline run.
+So any UI that reads the raw run style (`getSelectionStyle` /
+`getRangeStyleSummary` → font-family/size pickers) shows the *document* default,
+not the style's effective value — a Heading 1 with no explicit run style read as
+Arial 11 instead of 20pt. This was latent for the old hardcoded heading defaults
+too; named styles made it visible.
+**Fix:** layer `resolveStyleInline(blockStyleId(block), doc.styles)` underneath
+the run style at the read-out boundary only. Keep the *apply/pending* path raw
+(`getSelectionStyleImpl(false)`) — baking a resolved default into a stored run
+would freeze it against later style redefinition (breaks the lazy cascade).
+
+### Eager block spacing must be re-materialized on every registry replace
+Block spacing is materialized into `block.style`, not resolved lazily. Any op
+that swaps the registry (`setDocStyles` for "Use my default styles", plus
+update/reset) must call `rematerializeDocSpacing` or existing blocks keep stale
+spacing. Inline defaults reflow on their own; spacing does not.
+
+### "Update to match" reads the caret run, not `inlines[0]`
+Capture formatting at `cursor.position.offset` (reuse `getSelectionStyleImpl`)
+and copy only character props, so a caret over a later/structural run doesn't
+capture the wrong or non-character (image/link) style.

--- a/docs/tasks/active/20260629-docs-named-styles-lessons.md
+++ b/docs/tasks/active/20260629-docs-named-styles-lessons.md
@@ -1,0 +1,6 @@
+# Docs Named Styles — Lessons
+
+Capture patterns and corrections discovered while implementing named styles.
+
+## Lessons
+(filled as work progresses)

--- a/docs/tasks/active/20260629-docs-named-styles-todo.md
+++ b/docs/tasks/active/20260629-docs-named-styles-todo.md
@@ -9,51 +9,53 @@ Heading 1–6) whose definitions are redefinable per document, plus per-user
 default styles. Single PR.
 
 ## Phase 1: Core model (`packages/docs/src/model`)
-- [ ] 1.1 `model/named-styles.ts` — `StyleId`, `NamedStyleDef`, `DocStyles`,
-      `BUILTIN_STYLES` (refreshed Google Docs values), `blockStyleId(block)`,
-      `resolveStyleInline` / `resolveStyleBlock`. Unit tests.
-- [ ] 1.2 Refresh built-in values: headings non-bold, grayscale colors,
-      spacing (Title/Subtitle/H1–6 per design table). Replace
-      `HEADING_DEFAULTS` / `TITLE_DEFAULTS` / `SUBTITLE_DEFAULTS` (keep thin
-      back-compat re-exports if still referenced).
-- [ ] 1.3 `Document.styles?: DocStyles` field in `model/types.ts`.
+- [x] 1.1 `model/named-styles.ts` — `StyleId`, `NamedStyleDef`, `DocStyles`,
+      `BUILTIN_STYLES`, `blockStyleId`, `resolveStyleInline/Block`,
+      `materializeBlockSpacing`, `rematerializeDocSpacing`. Unit tests.
+- [x] 1.2 Refresh built-in values: headings non-bold, grayscale colors,
+      spacing. Removed `HEADING_DEFAULTS` / `TITLE_DEFAULTS` / `SUBTITLE_DEFAULTS`
+      from `types.ts`; re-exports updated to named-styles.
+- [x] 1.3 `Document.styles?: DocStyles` field in `model/types.ts`.
 
 ## Phase 2: Layout cascade (`packages/docs/src/view/layout.ts`)
-- [ ] 2.1 `resolveBlockInlines(block, docStyles?)` uses registry; default =
-      built-in. Update the empty-block `fallbackSize` branch too.
-- [ ] 2.2 Thread `docStyles?` through `computeLayout` → `layoutBlock`.
-- [ ] 2.3 Editor `recomputeLayout` + `pdf-exporter` pass `document.styles`.
-      Slides text-box editor stays on built-ins. Tests: override wins.
+- [x] 2.1 `resolveBlockInlines(block, docStyles?)` uses registry; empty-block
+      `getLineMaxFontSizePx` fallback uses it too.
+- [x] 2.2 Thread `docStyles?` through `computeLayout` → `layoutBlock` →
+      `assignLineHeights` and the table-layout path.
+- [x] 2.3 Editor `recomputeLayout` (body/header/footer) + `pdf-exporter` pass
+      `document.styles`. Slides text-box stays on built-ins. Tests: override wins.
 
 ## Phase 3: Store API
-- [ ] 3.1 `DocStore`: `getDocStyles` / `setDocStyles` /
+- [x] 3.1 `DocStore`: `getDocStyles` / `setDocStyles` /
       `updateStyleDefinition` / `resetStyle` / `resetAllStyles`.
-- [ ] 3.2 `MemStore` impl (plain `this.doc.styles`) + eager block-spacing
-      re-materialization helper shared with apply path.
-- [ ] 3.3 `setBlockType` re-materializes block spacing when `StyleId` changes.
-- [ ] 3.4 `YorkieDocStore` impl — root `styles` getter/setter + `readDocStyles`
-      proxy-unwrap; `writeFullDocument`; cache invalidation.
-- [ ] 3.5 Backend `docs-tree.ts` `DocsYorkieRoot.styles` serialize/deserialize.
-- [ ] 3.6 Store + collaboration round-trip tests.
+- [x] 3.2 `MemStore` impl + eager block-spacing re-materialization helper.
+- [x] 3.3 `setBlockType` re-materializes block spacing when `StyleId` changes.
+- [x] 3.4 `YorkieDocStore` impl — root `stylesJson` (JSON string) getter/setter;
+      batched single-undo re-materialization; cache invalidation.
+- [x] 3.5 Backend `docs-tree.ts` `DocsYorkieRoot.stylesJson` serialize/clear.
+- [x] 3.6 Store + collaboration round-trip tests (MemStore 8, docs-tree 2).
+- [x] 3.7 EditorAPI: getDocStyles/setDocStyles/updateStyleToMatch/
+      resetNamedStyle/resetAllNamedStyles.
 
 ## Phase 4: Frontend UI
-- [ ] 4.1 `text-style-options.ts` — add Heading 4–6 (⌥4–⌥6).
-- [ ] 4.2 `text-style-group.tsx` — per-style submenu (Apply / Update to match /
-      Reset) + Options (Save / Use my default styles / Reset styles).
-- [ ] 4.3 `docs-formatting-toolbar.tsx` — wire callbacks to store via EditorAPI.
-- [ ] 4.4 "Update to match" reads caret block effective formatting.
+- [x] 4.1 `text-style-options.ts` — add Heading 4–6 (⌥4–⌥6) + `styleId` +
+      `blockTypeToStyleId`.
+- [x] 4.2 `text-style-group.tsx` — capability-gated Options submenu (Update to
+      match / Reset / Save / Use / Reset styles). One-click apply preserved.
+- [x] 4.3 `docs-formatting-toolbar.tsx` — wire Save/Use via new api client.
+- [x] 4.4 "Update to match" reads caret block formatting in editor.ts.
 
 ## Phase 5: Per-user default styles (backend)
-- [ ] 5.1 Prisma `UserDocStyles` model + migration.
-- [ ] 5.2 `GET` / `PUT` `/auth/me/doc-styles` (JWT) + service.
-- [ ] 5.3 Frontend client + wire Save / Use my default styles.
-- [ ] 5.4 Backend e2e for the endpoints.
+- [x] 5.1 Prisma `UserDocStyles` model + migration.
+- [x] 5.2 `GET` / `PUT` `/auth/me/doc-styles` (JWT) + service.
+- [x] 5.3 Frontend client (`api/doc-styles.ts`) + wire Save / Use.
+- [x] 5.4 Backend e2e for the endpoints (gated, DB required).
 
 ## Verification
-- [ ] `pnpm verify:fast` green.
+- [x] `pnpm verify:fast` green (EXIT=0).
 - [ ] `pnpm dev` manual smoke: apply each style, Update to match, Reset,
       Save/Use my default styles, collaboration sync, PDF export fidelity.
-- [ ] Update Phase 6.5 checkbox in the wordprocessor todo.
+- [x] Update Phase 6.5 checkbox in the wordprocessor todo.
 
 ## Review
 (filled at completion)

--- a/docs/tasks/active/20260629-docs-named-styles-todo.md
+++ b/docs/tasks/active/20260629-docs-named-styles-todo.md
@@ -1,0 +1,59 @@
+# Docs Named Styles — Task Tracking
+
+Design doc: [docs-named-styles.md](../../design/docs/docs-named-styles.md)
+Roadmap item: Phase 6.5 in
+[docs-wordprocessor-roadmap.md](../../design/docs/docs-wordprocessor-roadmap.md).
+
+Google Docs paragraph-style model: a fixed catalog (Normal / Title / Subtitle /
+Heading 1–6) whose definitions are redefinable per document, plus per-user
+default styles. Single PR.
+
+## Phase 1: Core model (`packages/docs/src/model`)
+- [ ] 1.1 `model/named-styles.ts` — `StyleId`, `NamedStyleDef`, `DocStyles`,
+      `BUILTIN_STYLES` (refreshed Google Docs values), `blockStyleId(block)`,
+      `resolveStyleInline` / `resolveStyleBlock`. Unit tests.
+- [ ] 1.2 Refresh built-in values: headings non-bold, grayscale colors,
+      spacing (Title/Subtitle/H1–6 per design table). Replace
+      `HEADING_DEFAULTS` / `TITLE_DEFAULTS` / `SUBTITLE_DEFAULTS` (keep thin
+      back-compat re-exports if still referenced).
+- [ ] 1.3 `Document.styles?: DocStyles` field in `model/types.ts`.
+
+## Phase 2: Layout cascade (`packages/docs/src/view/layout.ts`)
+- [ ] 2.1 `resolveBlockInlines(block, docStyles?)` uses registry; default =
+      built-in. Update the empty-block `fallbackSize` branch too.
+- [ ] 2.2 Thread `docStyles?` through `computeLayout` → `layoutBlock`.
+- [ ] 2.3 Editor `recomputeLayout` + `pdf-exporter` pass `document.styles`.
+      Slides text-box editor stays on built-ins. Tests: override wins.
+
+## Phase 3: Store API
+- [ ] 3.1 `DocStore`: `getDocStyles` / `setDocStyles` /
+      `updateStyleDefinition` / `resetStyle` / `resetAllStyles`.
+- [ ] 3.2 `MemStore` impl (plain `this.doc.styles`) + eager block-spacing
+      re-materialization helper shared with apply path.
+- [ ] 3.3 `setBlockType` re-materializes block spacing when `StyleId` changes.
+- [ ] 3.4 `YorkieDocStore` impl — root `styles` getter/setter + `readDocStyles`
+      proxy-unwrap; `writeFullDocument`; cache invalidation.
+- [ ] 3.5 Backend `docs-tree.ts` `DocsYorkieRoot.styles` serialize/deserialize.
+- [ ] 3.6 Store + collaboration round-trip tests.
+
+## Phase 4: Frontend UI
+- [ ] 4.1 `text-style-options.ts` — add Heading 4–6 (⌥4–⌥6).
+- [ ] 4.2 `text-style-group.tsx` — per-style submenu (Apply / Update to match /
+      Reset) + Options (Save / Use my default styles / Reset styles).
+- [ ] 4.3 `docs-formatting-toolbar.tsx` — wire callbacks to store via EditorAPI.
+- [ ] 4.4 "Update to match" reads caret block effective formatting.
+
+## Phase 5: Per-user default styles (backend)
+- [ ] 5.1 Prisma `UserDocStyles` model + migration.
+- [ ] 5.2 `GET` / `PUT` `/auth/me/doc-styles` (JWT) + service.
+- [ ] 5.3 Frontend client + wire Save / Use my default styles.
+- [ ] 5.4 Backend e2e for the endpoints.
+
+## Verification
+- [ ] `pnpm verify:fast` green.
+- [ ] `pnpm dev` manual smoke: apply each style, Update to match, Reset,
+      Save/Use my default styles, collaboration sync, PDF export fidelity.
+- [ ] Update Phase 6.5 checkbox in the wordprocessor todo.
+
+## Review
+(filled at completion)

--- a/packages/backend/prisma/migrations/20260629000000_add_user_doc_styles/migration.sql
+++ b/packages/backend/prisma/migrations/20260629000000_add_user_doc_styles/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "UserDocStyles" (
+    "userId" INTEGER NOT NULL,
+    "styles" JSONB NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserDocStyles_pkey" PRIMARY KEY ("userId")
+);
+
+-- AddForeignKey
+ALTER TABLE "UserDocStyles" ADD CONSTRAINT "UserDocStyles_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -10,6 +10,14 @@ model User {
   workspaceMembers  WorkspaceMember[]
   workspaceInvites  WorkspaceInvite[]
   apiKeys           ApiKey[]
+  userDocStyles     UserDocStyles?
+}
+
+model UserDocStyles {
+  userId    Int      @id
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  styles    Json
+  updatedAt DateTime @updatedAt
 }
 
 model DataSource {

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { YorkieModule } from './yorkie/yorkie.module';
 import { ApiV1Module } from './api/v1/api-v1.module';
 import { ImageModule } from './image/image.module';
 import { HealthModule } from './health/health.module';
+import { UserDocStylesModule } from './user-doc-styles/user-doc-styles.module';
 
 @Module({
   imports: [
@@ -102,6 +103,7 @@ import { HealthModule } from './health/health.module';
     ApiV1Module,
     ImageModule,
     HealthModule,
+    UserDocStylesModule,
   ],
   controllers: [],
   providers: [

--- a/packages/backend/src/user-doc-styles/user-doc-styles.controller.ts
+++ b/packages/backend/src/user-doc-styles/user-doc-styles.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Get, Put, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { AuthenticatedRequest } from 'src/auth/auth.types';
+import { UserDocStylesService } from './user-doc-styles.service';
+import { UpdateUserDocStylesDto } from './user-doc-styles.dto';
+
+@Controller('auth/me/doc-styles')
+@UseGuards(JwtAuthGuard)
+export class UserDocStylesController {
+  constructor(private readonly userDocStylesService: UserDocStylesService) {}
+
+  @Get()
+  async getDocStyles(
+    @Req() req: AuthenticatedRequest,
+  ): Promise<{ styles: unknown }> {
+    const styles = await this.userDocStylesService.get(Number(req.user.id));
+    return { styles };
+  }
+
+  @Put()
+  async updateDocStyles(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: UpdateUserDocStylesDto,
+  ): Promise<{ styles: unknown }> {
+    const userId = Number(req.user.id);
+    await this.userDocStylesService.upsert(userId, body.styles);
+    return { styles: body.styles };
+  }
+}

--- a/packages/backend/src/user-doc-styles/user-doc-styles.dto.ts
+++ b/packages/backend/src/user-doc-styles/user-doc-styles.dto.ts
@@ -1,0 +1,6 @@
+import { IsObject } from 'class-validator';
+
+export class UpdateUserDocStylesDto {
+  @IsObject()
+  styles: Record<string, unknown>;
+}

--- a/packages/backend/src/user-doc-styles/user-doc-styles.module.ts
+++ b/packages/backend/src/user-doc-styles/user-doc-styles.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { UserDocStylesController } from './user-doc-styles.controller';
+import { UserDocStylesService } from './user-doc-styles.service';
+import { PrismaService } from 'src/database/prisma.service';
+
+@Module({
+  controllers: [UserDocStylesController],
+  providers: [UserDocStylesService, PrismaService],
+  exports: [UserDocStylesService],
+})
+export class UserDocStylesModule {}

--- a/packages/backend/src/user-doc-styles/user-doc-styles.service.ts
+++ b/packages/backend/src/user-doc-styles/user-doc-styles.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from 'src/database/prisma.service';
+
+@Injectable()
+export class UserDocStylesService {
+  constructor(private prisma: PrismaService) {}
+
+  async get(userId: number): Promise<unknown> {
+    const row = await this.prisma.userDocStyles.findUnique({
+      where: { userId },
+    });
+    return row?.styles ?? {};
+  }
+
+  async upsert(userId: number, styles: unknown): Promise<void> {
+    const value = styles as Prisma.InputJsonValue;
+    await this.prisma.userDocStyles.upsert({
+      where: { userId },
+      create: { userId, styles: value },
+      update: { styles: value },
+    });
+  }
+}

--- a/packages/backend/src/yorkie/docs-tree.spec.ts
+++ b/packages/backend/src/yorkie/docs-tree.spec.ts
@@ -183,6 +183,35 @@ describe('docs-tree', () => {
     expect(result).toEqual(withoutPageSetup);
   });
 
+  it('round-trips the named-style overrides registry', () => {
+    const original: DocsDocument = {
+      ...makeDoc(),
+      styles: {
+        'heading-1': { inline: { fontSize: 30, bold: true }, block: { marginTop: 40, marginBottom: 12 } },
+        'title': { inline: { color: '#ff0000' } },
+      },
+    };
+
+    doc.update((root) => writeDocsRoot(root, original));
+    const result = readDocsRoot(doc.getRoot());
+
+    expect(result.styles).toEqual(original.styles);
+  });
+
+  it('clears the style registry on the root when a follow-up write omits it', () => {
+    const withStyles: DocsDocument = {
+      ...makeDoc(),
+      styles: { 'heading-1': { inline: { fontSize: 30 } } },
+    };
+    const withoutStyles: DocsDocument = { ...makeDoc() };
+
+    doc.update((root) => writeDocsRoot(root, withStyles));
+    doc.update((root) => writeDocsRoot(root, withoutStyles));
+    const result = readDocsRoot(doc.getRoot());
+
+    expect(result.styles).toBeUndefined();
+  });
+
   it('preserves pageSetup and header/footer regions', () => {
     const original: DocsDocument = {
       ...makeDoc(),

--- a/packages/backend/src/yorkie/docs-tree.ts
+++ b/packages/backend/src/yorkie/docs-tree.ts
@@ -47,6 +47,8 @@ import type {
 export interface DocsYorkieRoot extends Record<string, unknown> {
   content?: Tree;
   pageSetup?: DocsPageSetup;
+  /** Named-style overrides registry serialized as JSON (see frontend root). */
+  stylesJson?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -455,6 +457,13 @@ export function readDocsRoot(root: DocsYorkieRoot): DocsDocument {
   if (root.pageSetup) {
     doc.pageSetup = readPageSetup(root.pageSetup);
   }
+  if (typeof root.stylesJson === 'string' && root.stylesJson.length > 0) {
+    try {
+      doc.styles = JSON.parse(root.stylesJson);
+    } catch {
+      // Malformed registry → fall back to built-in styles.
+    }
+  }
   return doc;
 }
 
@@ -545,5 +554,12 @@ export function writeDocsRoot(
     // editByPath/editBulkByPath replacement above, so they don't need an
     // explicit clear here.
     delete root.pageSetup;
+  }
+
+  // Named-style registry — same destructive-replace contract as pageSetup.
+  if (document.styles && Object.keys(document.styles).length > 0) {
+    root.stylesJson = JSON.stringify(document.styles);
+  } else if (root.stylesJson !== undefined) {
+    delete root.stylesJson;
   }
 }

--- a/packages/backend/test/user-doc-styles.e2e-spec.ts
+++ b/packages/backend/test/user-doc-styles.e2e-spec.ts
@@ -1,0 +1,150 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import * as request from 'supertest';
+import { AppModule } from 'src/app.module';
+import { PrismaService } from 'src/database/prisma.service';
+import { YorkieService } from 'src/yorkie/yorkie.service';
+import { YorkieAdminService } from 'src/yorkie/yorkie-admin.service';
+import * as cookieParser from 'cookie-parser';
+import {
+  applyGlobalBootstrap,
+  describeDb,
+  clearDatabase,
+  createUserFactory,
+  setIntegrationEnvDefaults,
+  setAuthEnvDefaults,
+} from './helpers/integration-helpers';
+
+describeDb('User doc styles HTTP integration (JWT + controller + Prisma)', () => {
+  let app: INestApplication;
+  let moduleRef: TestingModule;
+  let prisma: PrismaService;
+  let jwtService: JwtService;
+  let createUser: ReturnType<typeof createUserFactory>;
+
+  function authCookie(user: {
+    id: number;
+    username: string;
+    email: string;
+    photo: string | null;
+  }) {
+    const token = jwtService.sign(
+      {
+        sub: user.id,
+        username: user.username,
+        email: user.email,
+        photo: user.photo,
+      },
+      {
+        secret: process.env.JWT_SECRET!,
+        expiresIn: '1h',
+      },
+    );
+
+    return `wafflebase_session=${token}`;
+  }
+
+  beforeAll(async () => {
+    setIntegrationEnvDefaults();
+    setAuthEnvDefaults();
+
+    const yorkieStub = {
+      onModuleInit: () => Promise.resolve(),
+      onModuleDestroy: () => Promise.resolve(),
+      withDocument: () => Promise.resolve(null),
+    };
+
+    moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(YorkieService)
+      .useValue(yorkieStub)
+      .overrideProvider(YorkieAdminService)
+      .useValue({ getEditors: async () => new Map() })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    applyGlobalBootstrap(app);
+    await app.init();
+
+    prisma = moduleRef.get(PrismaService);
+    jwtService = moduleRef.get(JwtService);
+    createUser = createUserFactory(prisma, 'doc-styles');
+    await prisma.$connect();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase(prisma);
+  });
+
+  afterAll(async () => {
+    await clearDatabase(prisma);
+    await app.close();
+    await moduleRef.close();
+  });
+
+  it('rejects doc-styles routes without a JWT cookie', async () => {
+    await request(app.getHttpServer()).get('/auth/me/doc-styles').expect(401);
+    await request(app.getHttpServer())
+      .put('/auth/me/doc-styles')
+      .send({ styles: {} })
+      .expect(401);
+  });
+
+  it('returns an empty object when nothing is saved', async () => {
+    const user = await createUser();
+
+    const response = await request(app.getHttpServer())
+      .get('/auth/me/doc-styles')
+      .set('Cookie', authCookie(user))
+      .expect(200);
+
+    expect(response.body).toEqual({ styles: {} });
+  });
+
+  it('round-trips a saved styles blob through PUT then GET', async () => {
+    const user = await createUser();
+    const styles = { 'heading-1': { inline: { fontSize: 30 } } };
+
+    const putResponse = await request(app.getHttpServer())
+      .put('/auth/me/doc-styles')
+      .set('Cookie', authCookie(user))
+      .send({ styles })
+      .expect(200);
+
+    expect(putResponse.body).toEqual({ styles });
+
+    const getResponse = await request(app.getHttpServer())
+      .get('/auth/me/doc-styles')
+      .set('Cookie', authCookie(user))
+      .expect(200);
+
+    expect(getResponse.body).toEqual({ styles });
+  });
+
+  it('overwrites an existing styles blob on a second PUT', async () => {
+    const user = await createUser();
+
+    await request(app.getHttpServer())
+      .put('/auth/me/doc-styles')
+      .set('Cookie', authCookie(user))
+      .send({ styles: { 'heading-1': { inline: { fontSize: 30 } } } })
+      .expect(200);
+
+    const updated = { 'heading-2': { inline: { fontSize: 18 } } };
+    await request(app.getHttpServer())
+      .put('/auth/me/doc-styles')
+      .set('Cookie', authCookie(user))
+      .send({ styles: updated })
+      .expect(200);
+
+    const getResponse = await request(app.getHttpServer())
+      .get('/auth/me/doc-styles')
+      .set('Cookie', authCookie(user))
+      .expect(200);
+
+    expect(getResponse.body).toEqual({ styles: updated });
+  });
+});

--- a/packages/backend/test/user-doc-styles.e2e-spec.ts
+++ b/packages/backend/test/user-doc-styles.e2e-spec.ts
@@ -124,6 +124,24 @@ describeDb('User doc styles HTTP integration (JWT + controller + Prisma)', () =>
     expect(getResponse.body).toEqual({ styles });
   });
 
+  it('rejects a PUT whose body is missing the styles field', async () => {
+    const user = await createUser();
+    await request(app.getHttpServer())
+      .put('/auth/me/doc-styles')
+      .set('Cookie', authCookie(user))
+      .send({})
+      .expect(400);
+  });
+
+  it('rejects a PUT whose styles is not a plain object', async () => {
+    const user = await createUser();
+    await request(app.getHttpServer())
+      .put('/auth/me/doc-styles')
+      .set('Cookie', authCookie(user))
+      .send({ styles: [] })
+      .expect(400);
+  });
+
   it('overwrites an existing styles blob on a second PUT', async () => {
     const user = await createUser();
 

--- a/packages/cli/src/docs/paginate.ts
+++ b/packages/cli/src/docs/paginate.ts
@@ -27,6 +27,8 @@ export function paginateForCli(
   const { width: paperWidth } = getEffectiveDimensions(pageSetup);
   const contentWidth =
     paperWidth - pageSetup.margins.left - pageSetup.margins.right;
-  const { layout } = computeLayout(doc.blocks, measurer, contentWidth);
+  const { layout } = computeLayout(
+    doc.blocks, measurer, contentWidth, undefined, undefined, undefined, doc.styles,
+  );
   return paginateLayout(layout, pageSetup);
 }

--- a/packages/docs/src/export/pdf-exporter.ts
+++ b/packages/docs/src/export/pdf-exporter.ts
@@ -79,7 +79,7 @@ export class PdfExporter {
     const { width: wPx } = getEffectiveDimensions(setup);
     const contentWidth = wPx - setup.margins.left - setup.margins.right;
     const measurer = opts.measurer;
-    const { layout } = computeLayout(doc.blocks, measurer, contentWidth);
+    const { layout } = computeLayout(doc.blocks, measurer, contentWidth, undefined, undefined, undefined, doc.styles);
     const pagination = paginateLayout(layout, setup);
 
     // Header/footer block lists are independent of body pagination —
@@ -87,10 +87,10 @@ export class PdfExporter {
     // headers/footers appear identically across the document (with only
     // `pageNumber` substituted per page in the painter).
     const headerLayout = doc.header && doc.header.blocks.length > 0
-      ? computeLayout(doc.header.blocks, measurer, contentWidth).layout
+      ? computeLayout(doc.header.blocks, measurer, contentWidth, undefined, undefined, undefined, doc.styles).layout
       : null;
     const footerLayout = doc.footer && doc.footer.blocks.length > 0
-      ? computeLayout(doc.footer.blocks, measurer, contentWidth).layout
+      ? computeLayout(doc.footer.blocks, measurer, contentWidth, undefined, undefined, undefined, doc.styles).layout
       : null;
 
     // 3. Ordered list counters: computed once over the body block list

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -57,6 +57,8 @@ export {
   blockStyleId,
   resolveStyleInline,
   resolveStyleBlock,
+  materializeBlockSpacing,
+  rematerializeDocSpacing,
 } from './model/named-styles.js';
 export { Doc } from './model/document.js';
 export type { EditContext } from './model/document.js';

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -39,9 +39,6 @@ export {
   generateBlockId,
   getBlockText,
   getBlockTextLength,
-  getHeadingDefaults,
-  TITLE_DEFAULTS,
-  SUBTITLE_DEFAULTS,
   inlineStylesEqual,
   resolvePageSetup,
   getEffectiveDimensions,
@@ -53,6 +50,14 @@ export {
   getCellText,
   DEFAULT_HEADER_MARGIN_FROM_EDGE,
 } from './model/types.js';
+export type { StyleId, NamedStyleDef, DocStyles } from './model/named-styles.js';
+export {
+  BUILTIN_STYLES,
+  STYLE_IDS,
+  blockStyleId,
+  resolveStyleInline,
+  resolveStyleBlock,
+} from './model/named-styles.js';
 export { Doc } from './model/document.js';
 export type { EditContext } from './model/document.js';
 export type { StoredColor, ColorResolver } from './model/color.js';

--- a/packages/docs/src/model/named-styles.ts
+++ b/packages/docs/src/model/named-styles.ts
@@ -1,0 +1,131 @@
+/**
+ * Named paragraph styles — the Google Docs "Paragraph styles" model.
+ *
+ * A fixed catalog of nine styles (Normal text, Title, Subtitle, Heading 1–6)
+ * whose definitions are redefinable per document. Users cannot create
+ * arbitrary named styles (Google Docs parity).
+ *
+ * A block references its style implicitly through its existing `type` /
+ * `headingLevel` fields (see `blockStyleId`), so no block-model change is
+ * needed. The document carries a `styles` registry (`DocStyles`) holding only
+ * *overrides* of the built-in definitions below; resolution deep-merges the
+ * override over the built-in.
+ *
+ * Two resolution paths (see `docs/design/docs/docs-named-styles.md`):
+ *  - Inline defaults (font/size/bold/italic/color) are applied lazily at
+ *    layout time via `resolveStyleInline` (threaded into `resolveBlockInlines`).
+ *  - Block spacing (marginTop/marginBottom) is materialized eagerly into
+ *    `block.style` by the store when a style is applied/updated/reset, via
+ *    `resolveStyleBlock`.
+ */
+
+import type { Block, BlockStyle, HeadingLevel, InlineStyle } from './types.js';
+
+/**
+ * Stable identifier for each built-in named style.
+ */
+export type StyleId =
+  | 'normal'
+  | 'title'
+  | 'subtitle'
+  | 'heading-1'
+  | 'heading-2'
+  | 'heading-3'
+  | 'heading-4'
+  | 'heading-5'
+  | 'heading-6';
+
+/**
+ * Ordered list of all style ids — drives "reset all" and UI enumeration.
+ */
+export const STYLE_IDS: readonly StyleId[] = [
+  'normal',
+  'title',
+  'subtitle',
+  'heading-1',
+  'heading-2',
+  'heading-3',
+  'heading-4',
+  'heading-5',
+  'heading-6',
+];
+
+/**
+ * A named-style definition: the inline (character) defaults and the block
+ * (paragraph spacing) defaults that the style contributes.
+ */
+export interface NamedStyleDef {
+  /** Character defaults — base layer under each inline's explicit style. */
+  inline: Partial<InlineStyle>;
+  /** Paragraph spacing materialized into `block.style` on apply. */
+  block: Partial<BlockStyle>;
+}
+
+/**
+ * Per-document style registry — overrides only. An absent entry (or an absent
+ * `inline`/`block` sub-key) resolves to the built-in default.
+ */
+export type DocStyles = Partial<Record<StyleId, Partial<NamedStyleDef>>>;
+
+/**
+ * Built-in style definitions, refreshed to Google Docs defaults.
+ *
+ * Headings are intentionally **non-bold**: visual hierarchy comes from size
+ * and grayscale color, matching Google Docs. Spacing values are Google Docs
+ * point spacing converted to px at 96 dpi (`px = pt × 4/3`, rounded).
+ *
+ * `normal` carries no inline defaults — Arial 11pt #000000 comes from
+ * `DEFAULT_INLINE_STYLE` / theme defaults at paint time — but it does carry
+ * block spacing so that converting a heading back to a paragraph resets the
+ * paragraph spacing.
+ */
+export const BUILTIN_STYLES: Record<StyleId, NamedStyleDef> = {
+  'normal': { inline: {}, block: { marginTop: 0, marginBottom: 8 } },
+  'title': { inline: { fontSize: 26 }, block: { marginTop: 0, marginBottom: 4 } },
+  'subtitle': { inline: { fontSize: 15, color: '#666666' }, block: { marginTop: 0, marginBottom: 16 } },
+  'heading-1': { inline: { fontSize: 20 }, block: { marginTop: 27, marginBottom: 8 } },
+  'heading-2': { inline: { fontSize: 16 }, block: { marginTop: 24, marginBottom: 8 } },
+  'heading-3': { inline: { fontSize: 14, color: '#434343' }, block: { marginTop: 21, marginBottom: 5 } },
+  'heading-4': { inline: { fontSize: 12, color: '#666666' }, block: { marginTop: 19, marginBottom: 5 } },
+  'heading-5': { inline: { fontSize: 11, color: '#666666' }, block: { marginTop: 16, marginBottom: 5 } },
+  'heading-6': { inline: { fontSize: 11, color: '#666666', italic: true }, block: { marginTop: 16, marginBottom: 5 } },
+};
+
+/**
+ * Map a block to the style that governs it. Derived from existing fields, so
+ * no block-model migration is required. Non-text structural blocks
+ * (horizontal-rule, table, page-break) and list items map to `normal`.
+ */
+export function blockStyleId(block: Block): StyleId {
+  switch (block.type) {
+    case 'title':
+      return 'title';
+    case 'subtitle':
+      return 'subtitle';
+    case 'heading':
+      return `heading-${(block.headingLevel ?? 1) as HeadingLevel}` as StyleId;
+    default:
+      return 'normal';
+  }
+}
+
+/**
+ * Effective inline defaults for a style: built-in merged under any override.
+ */
+export function resolveStyleInline(
+  id: StyleId,
+  docStyles?: DocStyles,
+): Partial<InlineStyle> {
+  return { ...BUILTIN_STYLES[id].inline, ...docStyles?.[id]?.inline };
+}
+
+/**
+ * Effective block (spacing) defaults for a style: built-in merged under any
+ * override.
+ */
+export function resolveStyleBlock(
+  id: StyleId,
+  docStyles?: DocStyles,
+): Partial<BlockStyle> {
+  return { ...BUILTIN_STYLES[id].block, ...docStyles?.[id]?.block };
+}

--- a/packages/docs/src/model/named-styles.ts
+++ b/packages/docs/src/model/named-styles.ts
@@ -19,7 +19,7 @@
  *    `resolveStyleBlock`.
  */
 
-import type { Block, BlockStyle, HeadingLevel, InlineStyle } from './types.js';
+import type { Block, BlockStyle, Document, HeadingLevel, InlineStyle } from './types.js';
 
 /**
  * Stable identifier for each built-in named style.
@@ -128,4 +128,38 @@ export function resolveStyleBlock(
   docStyles?: DocStyles,
 ): Partial<BlockStyle> {
   return { ...BUILTIN_STYLES[id].block, ...docStyles?.[id]?.block };
+}
+
+/**
+ * Materialize a single block's spacing from its style. Returns a new
+ * `BlockStyle` with the style's block (spacing) defaults applied over the
+ * block's current style — preserving direct paragraph formatting (alignment,
+ * indent, lineHeight) while resetting the style-owned spacing fields.
+ */
+export function materializeBlockSpacing(
+  block: Block,
+  docStyles?: DocStyles,
+): BlockStyle {
+  return { ...block.style, ...resolveStyleBlock(blockStyleId(block), docStyles) };
+}
+
+/**
+ * Re-materialize block spacing in place across a document's top-level body
+ * and header/footer blocks. Pass a `styleId` to limit it to blocks governed
+ * by that style; omit it to re-materialize every styled block (used by
+ * "Reset styles"). Reads the spacing from `doc.styles`.
+ *
+ * Table-cell blocks are not walked in v1 — cell content is overwhelmingly
+ * Normal text and cell paragraph spacing is rarely style-authored.
+ */
+export function rematerializeDocSpacing(doc: Document, styleId?: StyleId): void {
+  const apply = (blocks: Block[]) => {
+    for (const block of blocks) {
+      if (styleId && blockStyleId(block) !== styleId) continue;
+      block.style = materializeBlockSpacing(block, doc.styles);
+    }
+  };
+  apply(doc.blocks);
+  if (doc.header) apply(doc.header.blocks);
+  if (doc.footer) apply(doc.footer.blocks);
 }

--- a/packages/docs/src/model/named-styles.ts
+++ b/packages/docs/src/model/named-styles.ts
@@ -102,8 +102,12 @@ export function blockStyleId(block: Block): StyleId {
       return 'title';
     case 'subtitle':
       return 'subtitle';
-    case 'heading':
-      return `heading-${(block.headingLevel ?? 1) as HeadingLevel}` as StyleId;
+    case 'heading': {
+      // Clamp to 1–6: DOCX import (`docx-style-map.ts`) reads `Heading N` from
+      // Word where N can be 7–9, so the raw level may fall outside our catalog.
+      const level = Math.min(6, Math.max(1, block.headingLevel ?? 1)) as HeadingLevel;
+      return `heading-${level}` as StyleId;
+    }
     default:
       return 'normal';
   }
@@ -116,7 +120,10 @@ export function resolveStyleInline(
   id: StyleId,
   docStyles?: DocStyles,
 ): Partial<InlineStyle> {
-  return { ...BUILTIN_STYLES[id].inline, ...docStyles?.[id]?.inline };
+  // `?.` guards an unknown id (e.g. a corrupt persisted registry key) so
+  // resolution degrades to built-in/empty instead of throwing in the layout
+  // hot path. `blockStyleId` already clamps heading levels into range.
+  return { ...BUILTIN_STYLES[id]?.inline, ...docStyles?.[id]?.inline };
 }
 
 /**
@@ -127,7 +134,7 @@ export function resolveStyleBlock(
   id: StyleId,
   docStyles?: DocStyles,
 ): Partial<BlockStyle> {
-  return { ...BUILTIN_STYLES[id].block, ...docStyles?.[id]?.block };
+  return { ...BUILTIN_STYLES[id]?.block, ...docStyles?.[id]?.block };
 }
 
 /**

--- a/packages/docs/src/model/named-styles.ts
+++ b/packages/docs/src/model/named-styles.ts
@@ -151,19 +151,28 @@ export function materializeBlockSpacing(
 }
 
 /**
- * Re-materialize block spacing in place across a document's top-level body
- * and header/footer blocks. Pass a `styleId` to limit it to blocks governed
- * by that style; omit it to re-materialize every styled block (used by
- * "Reset styles"). Reads the spacing from `doc.styles`.
+ * Re-materialize block spacing in place across a document's body, header/footer,
+ * and table-cell blocks (recursively, including nested tables). Pass a `styleId`
+ * to limit it to blocks governed by that style; omit it to re-materialize every
+ * styled block (used by "Reset styles"). Reads the spacing from `doc.styles`.
  *
- * Table-cell blocks are not walked in v1 — cell content is overwhelmingly
- * Normal text and cell paragraph spacing is rarely style-authored.
+ * Cells are walked so a styled paragraph inside a table cell tracks spacing
+ * changes the same way its inline defaults already reflow (the inline cascade
+ * reaches cells via `computeTableLayout`).
  */
 export function rematerializeDocSpacing(doc: Document, styleId?: StyleId): void {
   const apply = (blocks: Block[]) => {
     for (const block of blocks) {
-      if (styleId && blockStyleId(block) !== styleId) continue;
-      block.style = materializeBlockSpacing(block, doc.styles);
+      if (!styleId || blockStyleId(block) === styleId) {
+        block.style = materializeBlockSpacing(block, doc.styles);
+      }
+      if (block.tableData) {
+        for (const row of block.tableData.rows) {
+          for (const cell of row.cells) {
+            apply(cell.blocks);
+          }
+        }
+      }
     }
   };
   apply(doc.blocks);

--- a/packages/docs/src/model/types.ts
+++ b/packages/docs/src/model/types.ts
@@ -7,6 +7,7 @@
 
 import type { StoredColor } from './color.js';
 import { storedColorsEqual } from './color.js';
+import type { DocStyles } from './named-styles.js';
 
 /**
  * Top-level document container.
@@ -16,6 +17,12 @@ export interface Document {
   pageSetup?: PageSetup;
   header?: HeaderFooter;
   footer?: HeaderFooter;
+  /**
+   * Per-document named-style overrides (Google Docs "Paragraph styles").
+   * Absent → all styles resolve to their built-in definitions. See
+   * `model/named-styles.ts`.
+   */
+  styles?: DocStyles;
 }
 
 /**
@@ -254,25 +261,9 @@ export function createEmptyBlock(): Block {
   };
 }
 
-// --- Heading defaults ---
-
-const HEADING_DEFAULTS: Record<HeadingLevel, Partial<InlineStyle>> = {
-  1: { fontSize: 24, bold: true },
-  2: { fontSize: 20, bold: true },
-  3: { fontSize: 16, bold: true },
-  4: { fontSize: 14, bold: true },
-  5: { fontSize: 12 },
-  6: { fontSize: 11 },
-};
-
-export function getHeadingDefaults(level: HeadingLevel): Partial<InlineStyle> {
-  return { ...HEADING_DEFAULTS[level] };
-}
-
-// --- Title / Subtitle defaults ---
-
-export const TITLE_DEFAULTS: Partial<InlineStyle> = { fontSize: 26 };
-export const SUBTITLE_DEFAULTS: Partial<InlineStyle> = { fontSize: 15, color: '#666666' };
+// Named-style defaults live in `model/named-styles.ts` (the redefinable
+// Google Docs paragraph-style registry). Use `resolveStyleInline` /
+// `resolveStyleBlock` there instead of hardcoded per-type constants.
 
 // --- List constants ---
 

--- a/packages/docs/src/node.ts
+++ b/packages/docs/src/node.ts
@@ -69,9 +69,6 @@ export {
   generateBlockId,
   getBlockText,
   getBlockTextLength,
-  getHeadingDefaults,
-  TITLE_DEFAULTS,
-  SUBTITLE_DEFAULTS,
   inlineStylesEqual,
   resolvePageSetup,
   getEffectiveDimensions,
@@ -83,6 +80,14 @@ export {
   getCellText,
   DEFAULT_HEADER_MARGIN_FROM_EDGE,
 } from './model/types.js';
+export type { StyleId, NamedStyleDef, DocStyles } from './model/named-styles.js';
+export {
+  BUILTIN_STYLES,
+  STYLE_IDS,
+  blockStyleId,
+  resolveStyleInline,
+  resolveStyleBlock,
+} from './model/named-styles.js';
 
 // Block-level edit helpers. These are pure data-model transforms — the
 // source module only imports from `model/types.js`, so it carries no

--- a/packages/docs/src/node.ts
+++ b/packages/docs/src/node.ts
@@ -87,6 +87,8 @@ export {
   blockStyleId,
   resolveStyleInline,
   resolveStyleBlock,
+  materializeBlockSpacing,
+  rematerializeDocSpacing,
 } from './model/named-styles.js';
 
 // Block-level edit helpers. These are pure data-model transforms — the

--- a/packages/docs/src/store/memory.ts
+++ b/packages/docs/src/store/memory.ts
@@ -1,5 +1,7 @@
 import type { Block, BlockStyle, CellStyle, Document, HeadingLevel, HeaderFooter, Inline, InlineStyle, PageSetup, TableRow, TableCell, BlockType } from '../model/types.js';
 import { resolvePageSetup, normalizeBlockStyle } from '../model/types.js';
+import type { DocStyles, NamedStyleDef, StyleId } from '../model/named-styles.js';
+import { blockStyleId, materializeBlockSpacing, rematerializeDocSpacing } from '../model/named-styles.js';
 import type { DocStore } from './store.js';
 import { applyInsertText, applyDeleteText, applyInlineStyle as applyInlineStyleHelper, applyInsertInline, applySplitBlock, applyMergeBlocks } from './block-helpers.js';
 
@@ -89,6 +91,30 @@ export class MemDocStore implements DocStore {
 
   setPageSetup(setup: PageSetup): void {
     this.doc.pageSetup = JSON.parse(JSON.stringify(setup));
+  }
+
+  getDocStyles(): DocStyles {
+    return this.doc.styles ? JSON.parse(JSON.stringify(this.doc.styles)) : {};
+  }
+
+  setDocStyles(styles: DocStyles): void {
+    this.doc.styles = JSON.parse(JSON.stringify(styles));
+  }
+
+  updateStyleDefinition(styleId: StyleId, def: NamedStyleDef): void {
+    if (!this.doc.styles) this.doc.styles = {};
+    this.doc.styles[styleId] = JSON.parse(JSON.stringify(def));
+    rematerializeDocSpacing(this.doc, styleId);
+  }
+
+  resetStyle(styleId: StyleId): void {
+    if (this.doc.styles) delete this.doc.styles[styleId];
+    rematerializeDocSpacing(this.doc, styleId);
+  }
+
+  resetAllStyles(): void {
+    this.doc.styles = {};
+    rematerializeDocSpacing(this.doc);
   }
 
   getHeader(): HeaderFooter | undefined {
@@ -208,6 +234,7 @@ export class MemDocStore implements DocStore {
     opts?: { headingLevel?: HeadingLevel; listKind?: 'ordered' | 'unordered'; listLevel?: number },
   ): void {
     const block = this.findBlock(blockId);
+    const prevStyleId = blockStyleId(block);
     block.type = type;
     delete block.headingLevel;
     delete block.listKind;
@@ -223,6 +250,12 @@ export class MemDocStore implements DocStore {
       block.inlines = [];
     } else if (block.inlines.length === 0) {
       block.inlines = [{ text: '', style: {} }];
+    }
+    // Applying a different named style resets the block's style-owned spacing
+    // to that style's definition (Google Docs parity). A bullet toggle
+    // (paragraph↔list-item, both 'normal') leaves spacing untouched.
+    if (blockStyleId(block) !== prevStyleId) {
+      block.style = materializeBlockSpacing(block, this.doc.styles);
     }
   }
 

--- a/packages/docs/src/store/memory.ts
+++ b/packages/docs/src/store/memory.ts
@@ -99,6 +99,9 @@ export class MemDocStore implements DocStore {
 
   setDocStyles(styles: DocStyles): void {
     this.doc.styles = JSON.parse(JSON.stringify(styles));
+    // Re-materialize spacing across all styled blocks so "Use my default
+    // styles" applies paragraph spacing too (inline defaults reflow lazily).
+    rematerializeDocSpacing(this.doc);
   }
 
   updateStyleDefinition(styleId: StyleId, def: NamedStyleDef): void {

--- a/packages/docs/src/store/store.ts
+++ b/packages/docs/src/store/store.ts
@@ -1,4 +1,5 @@
 import type { Block, BlockStyle, CellStyle, Document, HeadingLevel, HeaderFooter, Inline, InlineStyle, PageSetup, TableRow, TableCell, BlockType } from '../model/types.js';
+import type { DocStyles, NamedStyleDef, StyleId } from '../model/named-styles.js';
 
 /**
  * DocStore interface — persistence abstraction for documents.
@@ -25,6 +26,21 @@ export interface DocStore {
   deleteBlockByIndex(index: number): void;
   getPageSetup(): PageSetup;
   setPageSetup(setup: PageSetup): void;
+
+  // --- Named styles (Google Docs paragraph styles) ---
+  /** Return the document's named-style overrides registry (built-ins omitted). */
+  getDocStyles(): DocStyles;
+  /** Replace the named-style overrides registry wholesale. */
+  setDocStyles(styles: DocStyles): void;
+  /**
+   * Redefine a style ("Update '<style>' to match"): store the override and
+   * re-materialize block spacing onto every block governed by it.
+   */
+  updateStyleDefinition(styleId: StyleId, def: NamedStyleDef): void;
+  /** Reset a single style to its built-in definition. */
+  resetStyle(styleId: StyleId): void;
+  /** Reset every style to its built-in definition. */
+  resetAllStyles(): void;
   getHeader(): HeaderFooter | undefined;
   getFooter(): HeaderFooter | undefined;
   setHeader(header: HeaderFooter | undefined): void;

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -2735,11 +2735,14 @@ export function initialize(
     updateStyleToMatch(styleId: StyleId) {
       const block = doc.findBlock(cursor.position.blockId);
       if (!block) return;
-      // Capture the run at the caret (not blindly the first run) plus the
-      // block spacing as the new definition. Only character props are copied
+      // Capture the *computed* style at the caret (run style layered over the
+      // current named-style defaults) so a redefine preserves values the run
+      // inherited rather than reverting them to the built-in — e.g. updating a
+      // Heading 1 already redefined to 30pt, after changing only its color,
+      // must keep 30pt, not fall back to 20pt. Only character props are copied
       // below, so structural inline kinds (href / pageNumber / image) never
       // leak into a paragraph style.
-      const s = getSelectionStyleImpl();
+      const s = getSelectionStyleImpl(true);
       const def: NamedStyleDef = {
         inline: {
           bold: s.bold,

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1161,6 +1161,7 @@ export function initialize(
       dirtyBlockIds,
       layoutCache,
       composingContext ?? undefined,
+      doc.document.styles,
     );
     layout = result.layout;
     layoutCache = result.cache;
@@ -1176,6 +1177,7 @@ export function initialize(
         undefined,
         undefined,
         composingContext ?? undefined,
+        doc.document.styles,
       ).layout;
     } else {
       headerLayout = null;
@@ -1188,6 +1190,7 @@ export function initialize(
         undefined,
         undefined,
         composingContext ?? undefined,
+        doc.document.styles,
       ).layout;
     } else {
       footerLayout = null;

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -998,9 +998,9 @@ export function initialize(
    * break the lazy cascade when the style is later redefined).
    */
   function getSelectionStyleImpl(withStyleDefaults = false): Partial<InlineStyle> {
-    const block = layout.blockParentMap.has(cursor.position.blockId)
-      ? doc.getBlock(cursor.position.blockId)
-      : doc.document.blocks.find((b) => b.id === cursor.position.blockId);
+    // `findBlock` walks body + header + footer + table cells, so a caret in a
+    // header/footer block resolves too (a body-only lookup returned {}).
+    const block = doc.findBlock(cursor.position.blockId);
     if (!block) return {};
     const defaults = withStyleDefaults ? styleDefaultsForBlock(block) : undefined;
     let pos = 0;
@@ -2731,6 +2731,7 @@ export function initialize(
       doc.refresh();
       invalidateLayout();
       render();
+      notifyStyleApplied();
     },
     updateStyleToMatch(styleId: StyleId) {
       const block = doc.findBlock(cursor.position.blockId);
@@ -2763,6 +2764,7 @@ export function initialize(
       doc.refresh();
       invalidateLayout();
       render();
+      notifyStyleApplied();
     },
     resetNamedStyle(styleId: StyleId) {
       docStore.snapshot();
@@ -2770,6 +2772,7 @@ export function initialize(
       doc.refresh();
       invalidateLayout();
       render();
+      notifyStyleApplied();
     },
     resetAllNamedStyles() {
       docStore.snapshot();
@@ -2777,6 +2780,7 @@ export function initialize(
       doc.refresh();
       invalidateLayout();
       render();
+      notifyStyleApplied();
     },
     toggleList(kind: 'ordered' | 'unordered') {
       docStore.snapshot();

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -3,6 +3,7 @@ import type { Block, InlineStyle, BlockStyle, BlockType, HeadingLevel, SearchMat
 import { resolvePageSetup, getEffectiveDimensions, getBlockTextLength, getBlockText, findImageAtOffset, clampImageToWidth, CLEAR_INLINE_STYLE } from '../model/types.js';
 import { MemDocStore } from '../store/memory.js';
 import type { DocStore } from '../store/store.js';
+import type { DocStyles, NamedStyleDef, StyleId } from '../model/named-styles.js';
 import { DocCanvas } from './doc-canvas.js';
 import { Cursor } from './cursor.js';
 import { Selection, computeSelectionRects } from './selection.js';
@@ -137,6 +138,20 @@ export interface EditorAPI {
   getBlockStyle(): Partial<BlockStyle>;
   /** Set the block type for the block at cursor */
   setBlockType(type: BlockType, opts?: { headingLevel?: HeadingLevel; listKind?: 'ordered' | 'unordered'; listLevel?: number }): void;
+  /** Read the document's named-style overrides registry (built-ins omitted). */
+  getDocStyles(): DocStyles;
+  /** Replace the whole named-style registry (e.g. "Use my default styles"). */
+  setDocStyles(styles: DocStyles): void;
+  /**
+   * Redefine a named style from the caret block's current formatting
+   * ("Update '<style>' to match"). One undo unit; reflows every block of
+   * that style.
+   */
+  updateStyleToMatch(styleId: StyleId): void;
+  /** Reset a single named style to its built-in definition. */
+  resetNamedStyle(styleId: StyleId): void;
+  /** Reset every named style to its built-in definition. */
+  resetAllNamedStyles(): void;
   /** Toggle list type on the block at cursor */
   toggleList(kind: 'ordered' | 'unordered'): void;
   /** Increase indent of the block at cursor */
@@ -2678,6 +2693,56 @@ export function initialize(
     setBlockType(type: BlockType, opts?: { headingLevel?: HeadingLevel; listKind?: 'ordered' | 'unordered'; listLevel?: number }) {
       docStore.snapshot();
       doc.setBlockType(cursor.position.blockId, type, opts);
+      invalidateLayout();
+      render();
+    },
+    getDocStyles: () => docStore.getDocStyles(),
+    setDocStyles(styles: DocStyles) {
+      docStore.snapshot();
+      docStore.setDocStyles(styles);
+      doc.refresh();
+      invalidateLayout();
+      render();
+    },
+    updateStyleToMatch(styleId: StyleId) {
+      const block = doc.findBlock(cursor.position.blockId);
+      if (!block) return;
+      // Capture the caret block's direct character formatting + spacing as
+      // the new definition. Character props only — structural inline kinds
+      // (href / pageNumber / image) never belong to a paragraph style.
+      const s = block.inlines[0]?.style ?? {};
+      const def: NamedStyleDef = {
+        inline: {
+          bold: s.bold,
+          italic: s.italic,
+          underline: s.underline,
+          strikethrough: s.strikethrough,
+          fontSize: s.fontSize,
+          fontFamily: s.fontFamily,
+          color: s.color,
+          backgroundColor: s.backgroundColor,
+          superscript: s.superscript,
+          subscript: s.subscript,
+        },
+        block: { marginTop: block.style.marginTop, marginBottom: block.style.marginBottom },
+      };
+      docStore.snapshot();
+      docStore.updateStyleDefinition(styleId, def);
+      doc.refresh();
+      invalidateLayout();
+      render();
+    },
+    resetNamedStyle(styleId: StyleId) {
+      docStore.snapshot();
+      docStore.resetStyle(styleId);
+      doc.refresh();
+      invalidateLayout();
+      render();
+    },
+    resetAllNamedStyles() {
+      docStore.snapshot();
+      docStore.resetAllStyles();
+      doc.refresh();
       invalidateLayout();
       render();
     },

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -2735,10 +2735,11 @@ export function initialize(
     updateStyleToMatch(styleId: StyleId) {
       const block = doc.findBlock(cursor.position.blockId);
       if (!block) return;
-      // Capture the caret block's direct character formatting + spacing as
-      // the new definition. Character props only — structural inline kinds
-      // (href / pageNumber / image) never belong to a paragraph style.
-      const s = block.inlines[0]?.style ?? {};
+      // Capture the run at the caret (not blindly the first run) plus the
+      // block spacing as the new definition. Only character props are copied
+      // below, so structural inline kinds (href / pageNumber / image) never
+      // leak into a paragraph style.
+      const s = getSelectionStyleImpl();
       const def: NamedStyleDef = {
         inline: {
           bold: s.bold,

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -4,6 +4,7 @@ import { resolvePageSetup, getEffectiveDimensions, getBlockTextLength, getBlockT
 import { MemDocStore } from '../store/memory.js';
 import type { DocStore } from '../store/store.js';
 import type { DocStyles, NamedStyleDef, StyleId } from '../model/named-styles.js';
+import { blockStyleId, resolveStyleInline } from '../model/named-styles.js';
 import { DocCanvas } from './doc-canvas.js';
 import { Cursor } from './cursor.js';
 import { Selection, computeSelectionRects } from './selection.js';
@@ -979,21 +980,39 @@ export function initialize(
    * Used by both the public getSelectionStyle (which layers pending on
    * top) and applyStyleImpl (which seeds the pending merge base).
    */
-  function getSelectionStyleImpl(): Partial<InlineStyle> {
+  /**
+   * Effective inline defaults a block inherits from its named style. Used to
+   * present the *computed* style (what the user sees rendered) in the toolbar
+   * pickers — a Heading 1 with no explicit run style still reads as 20pt.
+   */
+  function styleDefaultsForBlock(block: Block): Partial<InlineStyle> {
+    return resolveStyleInline(blockStyleId(block), doc.document.styles);
+  }
+
+  /**
+   * Read the inline style at the caret. With `withStyleDefaults`, the block's
+   * named-style inline defaults are layered underneath the explicit run style
+   * so the toolbar reflects the rendered (computed) style. Without it — the
+   * default — the raw explicit style is returned, so pending-style capture and
+   * style application never bake a style default into a stored run (which would
+   * break the lazy cascade when the style is later redefined).
+   */
+  function getSelectionStyleImpl(withStyleDefaults = false): Partial<InlineStyle> {
     const block = layout.blockParentMap.has(cursor.position.blockId)
       ? doc.getBlock(cursor.position.blockId)
       : doc.document.blocks.find((b) => b.id === cursor.position.blockId);
     if (!block) return {};
+    const defaults = withStyleDefaults ? styleDefaultsForBlock(block) : undefined;
     let pos = 0;
     for (const inline of block.inlines) {
       const inlineEnd = pos + inline.text.length;
       if (cursor.position.offset <= inlineEnd) {
-        return { ...inline.style };
+        return { ...defaults, ...inline.style };
       }
       pos = inlineEnd;
     }
     const last = block.inlines[block.inlines.length - 1];
-    return last ? { ...last.style } : {};
+    return last ? { ...defaults, ...last.style } : { ...defaults };
   }
 
   function applyStyleImpl(style: Partial<InlineStyle>): void {
@@ -2433,7 +2452,7 @@ export function initialize(
     getDoc: () => doc,
     getStore: () => docStore,
     getSelectionStyle: (): Partial<InlineStyle> => {
-      const base = getSelectionStyleImpl();
+      const base = getSelectionStyleImpl(true);
       if (pending.has() && !selection.hasSelection()) {
         return { ...base, ...pending.get()! };
       }
@@ -2455,16 +2474,19 @@ export function initialize(
       const styleAtCaret = (): Partial<InlineStyle> => {
         const block = doc.findBlock(cursor.position.blockId);
         if (!block) return {};
+        // Layer the block's named-style inline defaults underneath the run
+        // style so the pickers show the computed (rendered) value.
+        const defaults = styleDefaultsForBlock(block);
         let pos = 0;
         for (const inline of block.inlines) {
           const inlineEnd = pos + inline.text.length;
           if (cursor.position.offset <= inlineEnd) {
-            return { ...inline.style };
+            return { ...defaults, ...inline.style };
           }
           pos = inlineEnd;
         }
         const last = block.inlines[block.inlines.length - 1];
-        return last ? { ...last.style } : {};
+        return last ? { ...defaults, ...last.style } : { ...defaults };
       };
 
       // No range — return the caret style, layered with any pending
@@ -2506,6 +2528,11 @@ export function initialize(
       ): void => {
         const block = doc.findBlock(blockId);
         if (!block) return;
+        // Effective style per run = the block's named-style inline defaults
+        // under the run's explicit style, so the summary reflects the
+        // computed (rendered) formatting — and a selection spanning blocks of
+        // different styles correctly reads as 'mixed'.
+        const defaults = styleDefaultsForBlock(block);
         let pos = 0;
         for (const inline of block.inlines) {
           const inlineEnd = pos + inline.text.length;
@@ -2513,8 +2540,9 @@ export function initialize(
           // zero-width inlines (empty placeholder runs) as out of
           // range — they don't contribute style information.
           if (inlineEnd > from && pos < to && inline.text.length > 0) {
+            const effective = { ...defaults, ...inline.style };
             for (const key of KEYS) {
-              const raw = (inline.style as Record<string, unknown>)[key];
+              const raw = (effective as Record<string, unknown>)[key];
               const token = tokenize(raw);
               if (!seen[key].has(token)) {
                 seen[key].add(token);

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -1,14 +1,15 @@
 import {
-  getHeadingDefaults,
-  TITLE_DEFAULTS,
-  SUBTITLE_DEFAULTS,
   LIST_INDENT_PX,
   type Block,
   type BlockCellInfo,
-  type HeadingLevel,
   type Inline,
   type InlineStyle,
 } from '../model/types.js';
+import {
+  blockStyleId,
+  resolveStyleInline,
+  type DocStyles,
+} from '../model/named-styles.js';
 import { Theme, ptToPx } from './theme.js';
 import type { ResolvedFont, TextMeasurer } from './measurer.js';
 import { computeTableLayout, type LayoutTable } from './table-layout.js';
@@ -100,25 +101,21 @@ export function resolveInlineFont(style: InlineStyle): ResolvedFont {
 }
 
 /**
- * For heading blocks, return inlines with heading default styles merged in.
- * Heading defaults act as a base layer; explicit inline styles override them.
+ * Return a block's inlines with its named-style inline defaults merged in as
+ * a base layer; explicit inline styles override them. The style's definition
+ * comes from the document `docStyles` registry (falling back to the built-in
+ * defaults), so a redefined style reflows every block using it without any
+ * stored-inline rewrite.
  */
-export function resolveBlockInlines(block: Block): Inline[] {
-  let defaults: Partial<InlineStyle> | undefined;
-  if (block.type === 'heading' && block.headingLevel) {
-    defaults = getHeadingDefaults(block.headingLevel as HeadingLevel);
-  } else if (block.type === 'title') {
-    defaults = TITLE_DEFAULTS;
-  } else if (block.type === 'subtitle') {
-    defaults = SUBTITLE_DEFAULTS;
+export function resolveBlockInlines(block: Block, docStyles?: DocStyles): Inline[] {
+  const defaults = resolveStyleInline(blockStyleId(block), docStyles);
+  if (Object.keys(defaults).length === 0) {
+    return block.inlines;
   }
-  if (defaults) {
-    return block.inlines.map((inline) => ({
-      text: inline.text,
-      style: { ...defaults, ...inline.style },
-    }));
-  }
-  return block.inlines;
+  return block.inlines.map((inline) => ({
+    text: inline.text,
+    style: { ...defaults, ...inline.style },
+  }));
 }
 
 /**
@@ -299,6 +296,7 @@ export function computeLayout(
   dirtyBlockIds?: Set<string>,
   cache?: LayoutCache,
   composingContext?: ComposingContext,
+  docStyles?: DocStyles,
 ): { layout: DocumentLayout; cache: LayoutCache } {
   const availableWidth = contentWidth;
   const canUseCache = cache != null
@@ -330,7 +328,7 @@ export function computeLayout(
 
     if (block.type === 'table' && block.tableData) {
       const tableLayout = computeTableLayout(
-        block.tableData, block.id, measurer, availableWidth, composingContext,
+        block.tableData, block.id, measurer, availableWidth, composingContext, docStyles,
       );
       // Merge per-table blockParentMap into document-level map
       for (const [k, v] of tableLayout.blockParentMap) {
@@ -358,8 +356,8 @@ export function computeLayout(
     } else if (canUseCache && !dirtyBlockIds!.has(block.id) && cache!.blocks.has(block.id)) {
       lines = cache!.blocks.get(block.id)!.lines;
     } else {
-      lines = layoutBlock(effectiveBlock, measurer, availableWidth, composingContext);
-      assignLineHeights(lines, effectiveBlock);
+      lines = layoutBlock(effectiveBlock, measurer, availableWidth, composingContext, docStyles);
+      assignLineHeights(lines, effectiveBlock, docStyles);
 
       const alignWidth = availableWidth - effectiveBlock.style.marginLeft;
       for (let li = 0; li < lines.length; li++) {
@@ -413,9 +411,10 @@ export function layoutBlock(
   measurer: TextMeasurer,
   maxWidth: number,
   composingContext?: ComposingContext,
+  docStyles?: DocStyles,
 ): LayoutLine[] {
-  // Resolve heading defaults into inlines before measurement
-  const resolved = resolveBlockInlines(block);
+  // Resolve named-style inline defaults into inlines before measurement
+  const resolved = resolveBlockInlines(block, docStyles);
   // Splice in view-local IME composing text for this block, if any, so it
   // reflows like real text without being written to the document model.
   const inlines = composingContext?.blockId === block.id
@@ -599,7 +598,7 @@ export function layoutBlock(
  * Body paragraphs and cell paragraphs both use this so wrapped-line
  * heights are computed identically.
  */
-export function assignLineHeights(lines: LayoutLine[], block: Block): void {
+export function assignLineHeights(lines: LayoutLine[], block: Block, docStyles?: DocStyles): void {
   // Floor at 1.0: a sub-1.0 multiplier collapses the line below the font's
   // own pixel height, so characters from adjacent lines overlap. The DOCX
   // import path can plant such values when <w:spacing w:line="N"
@@ -607,7 +606,7 @@ export function assignLineHeights(lines: LayoutLine[], block: Block): void {
   const lineHeightMultiplier = Math.max(1, block.style.lineHeight ?? 1.5);
   let blockY = 0;
   for (const line of lines) {
-    const maxFontSize = getLineMaxFontSizePx(line, block);
+    const maxFontSize = getLineMaxFontSizePx(line, block, docStyles);
     let lineHeight = lineHeightMultiplier * maxFontSize;
     for (const run of line.runs) {
       if (run.imageHeight !== undefined && run.imageHeight > lineHeight) {
@@ -785,7 +784,7 @@ export function applyAlignment(
  * Get the maximum font size across all runs in a line.
  * Falls back to the block's first inline or the theme default.
  */
-function getLineMaxFontSizePx(line: LayoutLine, block: Block): number {
+function getLineMaxFontSizePx(line: LayoutLine, block: Block, docStyles?: DocStyles): number {
   let max = 0;
   for (const run of line.runs) {
     const size = ptToPx(run.inline.style.fontSize ?? Theme.defaultFontSize);
@@ -793,15 +792,9 @@ function getLineMaxFontSizePx(line: LayoutLine, block: Block): number {
   }
   if (max > 0) return max;
 
-  // For empty lines, resolve font size from block type defaults
-  let fallbackSize: number | undefined;
-  if (block.type === 'title') {
-    fallbackSize = TITLE_DEFAULTS.fontSize;
-  } else if (block.type === 'subtitle') {
-    fallbackSize = SUBTITLE_DEFAULTS.fontSize;
-  } else if (block.type === 'heading' && block.headingLevel) {
-    fallbackSize = getHeadingDefaults(block.headingLevel as HeadingLevel).fontSize;
-  }
+  // For empty lines, resolve font size from the block's named-style default,
+  // overridden by an explicit size on the (empty) first inline.
+  let fallbackSize = resolveStyleInline(blockStyleId(block), docStyles).fontSize;
   if (block.inlines.length > 0 && block.inlines[0].style.fontSize) {
     fallbackSize = block.inlines[0].style.fontSize;
   }

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -177,6 +177,14 @@ export interface DocumentLayout {
 export interface LayoutCache {
   blocks: Map<string, LayoutBlock>;
   contentWidth: number;
+  /**
+   * Fingerprint of the named-style registry the cached lines were resolved
+   * against. A named-style redefinition changes the inline defaults baked into
+   * cached runs without dirtying any block, so the cache must invalidate when
+   * this changes (the editor also calls `invalidateLayout`, but this keeps the
+   * function self-consistent for any caller that reuses a cache).
+   */
+  docStylesKey?: string;
 }
 
 /**
@@ -299,9 +307,11 @@ export function computeLayout(
   docStyles?: DocStyles,
 ): { layout: DocumentLayout; cache: LayoutCache } {
   const availableWidth = contentWidth;
+  const docStylesKey = JSON.stringify(docStyles ?? {});
   const canUseCache = cache != null
     && dirtyBlockIds != null
-    && cache.contentWidth === contentWidth;
+    && cache.contentWidth === contentWidth
+    && cache.docStylesKey === docStylesKey;
 
   const newCacheBlocks = new Map<string, LayoutBlock>();
   const layoutBlocks: LayoutBlock[] = [];
@@ -382,7 +392,7 @@ export function computeLayout(
 
   return {
     layout: { blocks: layoutBlocks, totalHeight: y, blockParentMap },
-    cache: { blocks: newCacheBlocks, contentWidth },
+    cache: { blocks: newCacheBlocks, contentWidth, docStylesKey },
   };
 }
 

--- a/packages/docs/src/view/table-layout.ts
+++ b/packages/docs/src/view/table-layout.ts
@@ -1,5 +1,6 @@
 import type { TableData, Block, BlockCellInfo } from '../model/types.js';
 import { LIST_INDENT_PX } from '../model/types.js';
+import type { DocStyles } from '../model/named-styles.js';
 import type { ComposingContext, LayoutLine } from './layout.js';
 import { applyAlignment, assignLineHeights, layoutBlock } from './layout.js';
 import { ptToPx, Theme } from './theme.js';
@@ -40,6 +41,7 @@ function layoutCellBlocks(
   maxWidth: number,
   blockParentMap?: Map<string, BlockCellInfo>,
   composingContext?: ComposingContext,
+  docStyles?: DocStyles,
 ): { lines: LayoutLine[]; blockBoundaries: number[] } {
   if (blocks.length === 0) {
     const defaultHeight = ptToPx(Theme.defaultFontSize) * 1.5;
@@ -62,6 +64,7 @@ function layoutCellBlocks(
         measurer,
         maxWidth,
         composingContext,
+        docStyles,
       );
       if (blockParentMap) {
         for (const [k, v] of nestedLayout.blockParentMap) {
@@ -92,8 +95,8 @@ function layoutCellBlocks(
           },
         };
 
-    const blockLines = layoutBlock(effectiveBlock, measurer, maxWidth, composingContext);
-    assignLineHeights(blockLines, effectiveBlock);
+    const blockLines = layoutBlock(effectiveBlock, measurer, maxWidth, composingContext, docStyles);
+    assignLineHeights(blockLines, effectiveBlock, docStyles);
 
     const alignWidth = maxWidth - (effectiveBlock.style.marginLeft ?? 0);
     const alignment = effectiveBlock.style.alignment ?? 'left';
@@ -127,6 +130,7 @@ export function computeTableLayout(
   measurer: TextMeasurer,
   contentWidth: number,
   composingContext?: ComposingContext,
+  docStyles?: DocStyles,
 ): LayoutTable {
   const { rows, columnWidths } = tableData;
   const numCols = columnWidths.length;
@@ -169,7 +173,7 @@ export function computeTableLayout(
       const innerWidth = Math.max(cellWidth - padding * 2, 0);
 
       const { lines, blockBoundaries } = layoutCellBlocks(
-        cell?.blocks ?? [], measurer, innerWidth, blockParentMap, composingContext,
+        cell?.blocks ?? [], measurer, innerWidth, blockParentMap, composingContext, docStyles,
       );
       const cellHeight = lines.reduce((sum, l) => sum + l.height, 0) + padding * 2;
 

--- a/packages/docs/test/model/named-styles.test.ts
+++ b/packages/docs/test/model/named-styles.test.ts
@@ -5,9 +5,11 @@ import {
   blockStyleId,
   resolveStyleInline,
   resolveStyleBlock,
+  rematerializeDocSpacing,
   type DocStyles,
 } from '../../src/model/named-styles.js';
-import { createBlock } from '../../src/model/types.js';
+import { createBlock, createTableBlock } from '../../src/model/types.js';
+import type { Document } from '../../src/model/types.js';
 
 describe('blockStyleId', () => {
   it('maps paragraph and list-item to normal', () => {
@@ -64,6 +66,21 @@ describe('built-in style values (Google Docs defaults)', () => {
     expect(BUILTIN_STYLES['heading-1'].inline.fontSize).toBe(20);
     expect(BUILTIN_STYLES['heading-3'].inline.color).toBe('#434343');
     expect(BUILTIN_STYLES['heading-6'].inline.italic).toBe(true);
+  });
+});
+
+describe('rematerializeDocSpacing', () => {
+  it('recurses into table-cell blocks', () => {
+    const cellHeading = createBlock('heading', { headingLevel: 1 });
+    const table = createTableBlock(1, 1);
+    table.tableData!.rows[0].cells[0].blocks = [cellHeading];
+    const doc: Document = {
+      blocks: [table],
+      styles: { 'heading-1': { block: { marginTop: 44, marginBottom: 7 } } },
+    };
+    rematerializeDocSpacing(doc);
+    expect(cellHeading.style.marginTop).toBe(44);
+    expect(cellHeading.style.marginBottom).toBe(7);
   });
 });
 

--- a/packages/docs/test/model/named-styles.test.ts
+++ b/packages/docs/test/model/named-styles.test.ts
@@ -31,6 +31,15 @@ describe('blockStyleId', () => {
     expect(blockStyleId(b)).toBe('heading-1');
   });
 
+  it('clamps an out-of-range heading level (e.g. DOCX Heading 7–9) into the catalog', () => {
+    const b = createBlock('heading');
+    (b as { headingLevel?: number }).headingLevel = 9;
+    expect(blockStyleId(b)).toBe('heading-6');
+    // Resolution must not throw even if a corrupt registry key sneaks through.
+    expect(resolveStyleInline('heading-9' as never)).toEqual({});
+    expect(resolveStyleBlock('heading-9' as never)).toEqual({});
+  });
+
   it('maps structural blocks to normal', () => {
     expect(blockStyleId(createBlock('horizontal-rule'))).toBe('normal');
     expect(blockStyleId(createBlock('page-break'))).toBe('normal');

--- a/packages/docs/test/model/named-styles.test.ts
+++ b/packages/docs/test/model/named-styles.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BUILTIN_STYLES,
+  STYLE_IDS,
+  blockStyleId,
+  resolveStyleInline,
+  resolveStyleBlock,
+  type DocStyles,
+} from '../../src/model/named-styles.js';
+import { createBlock } from '../../src/model/types.js';
+
+describe('blockStyleId', () => {
+  it('maps paragraph and list-item to normal', () => {
+    expect(blockStyleId(createBlock('paragraph'))).toBe('normal');
+    expect(blockStyleId(createBlock('list-item'))).toBe('normal');
+  });
+
+  it('maps title / subtitle', () => {
+    expect(blockStyleId(createBlock('title'))).toBe('title');
+    expect(blockStyleId(createBlock('subtitle'))).toBe('subtitle');
+  });
+
+  it('maps headings by level', () => {
+    expect(blockStyleId(createBlock('heading', { headingLevel: 1 }))).toBe('heading-1');
+    expect(blockStyleId(createBlock('heading', { headingLevel: 6 }))).toBe('heading-6');
+  });
+
+  it('defaults heading without level to heading-1', () => {
+    const b = createBlock('heading');
+    delete b.headingLevel;
+    expect(blockStyleId(b)).toBe('heading-1');
+  });
+
+  it('maps structural blocks to normal', () => {
+    expect(blockStyleId(createBlock('horizontal-rule'))).toBe('normal');
+    expect(blockStyleId(createBlock('page-break'))).toBe('normal');
+  });
+});
+
+describe('built-in style values (Google Docs defaults)', () => {
+  it('covers every style id', () => {
+    for (const id of STYLE_IDS) {
+      expect(BUILTIN_STYLES[id]).toBeDefined();
+    }
+  });
+
+  it('headings are non-bold', () => {
+    for (const id of STYLE_IDS) {
+      expect(BUILTIN_STYLES[id].inline.bold).toBeUndefined();
+    }
+  });
+
+  it('uses the Google Docs size + color hierarchy', () => {
+    expect(BUILTIN_STYLES['title'].inline.fontSize).toBe(26);
+    expect(BUILTIN_STYLES['heading-1'].inline.fontSize).toBe(20);
+    expect(BUILTIN_STYLES['heading-3'].inline.color).toBe('#434343');
+    expect(BUILTIN_STYLES['heading-6'].inline.italic).toBe(true);
+  });
+});
+
+describe('resolveStyleInline / resolveStyleBlock', () => {
+  it('returns built-in when no overrides', () => {
+    expect(resolveStyleInline('heading-1')).toEqual({ fontSize: 20 });
+    expect(resolveStyleBlock('heading-1')).toEqual({ marginTop: 27, marginBottom: 8 });
+  });
+
+  it('merges an override over the built-in', () => {
+    const docStyles: DocStyles = {
+      'heading-1': { inline: { fontSize: 28, bold: true } },
+    };
+    expect(resolveStyleInline('heading-1', docStyles)).toEqual({ fontSize: 28, bold: true });
+    // block sub-key absent in the override → still built-in
+    expect(resolveStyleBlock('heading-1', docStyles)).toEqual({ marginTop: 27, marginBottom: 8 });
+  });
+
+  it('does not mutate the built-in definition', () => {
+    const docStyles: DocStyles = { 'title': { inline: { color: '#ff0000' } } };
+    resolveStyleInline('title', docStyles);
+    expect(BUILTIN_STYLES['title'].inline.color).toBeUndefined();
+  });
+});

--- a/packages/docs/test/model/types.test.ts
+++ b/packages/docs/test/model/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { HeadingLevel, Document, Inline, InlineStyle, Block } from '../../src/model/types.js';
+import type { Document, Inline, InlineStyle, Block } from '../../src/model/types.js';
 import {
   DEFAULT_BLOCK_STYLE,
   DEFAULT_PAGE_SETUP,
@@ -9,7 +9,6 @@ import {
   getEffectiveDimensions,
   createBlock,
   createEmptyBlock,
-  getHeadingDefaults,
   inlineStylesEqual,
   createTableCell,
   createTableBlock,
@@ -109,27 +108,6 @@ describe('createBlock', () => {
     expect(block.type).toBe('list-item');
     expect(block.listKind).toBe('unordered');
     expect(block.listLevel).toBe(0);
-  });
-});
-
-describe('getHeadingDefaults', () => {
-  it('returns fontSize 24 and bold for level 1', () => {
-    expect(getHeadingDefaults(1)).toEqual({ fontSize: 24, bold: true });
-  });
-
-  it('returns fontSize 11 (no bold) for level 6', () => {
-    expect(getHeadingDefaults(6)).toEqual({ fontSize: 11 });
-  });
-
-  it.each([
-    [1, { fontSize: 24, bold: true }],
-    [2, { fontSize: 20, bold: true }],
-    [3, { fontSize: 16, bold: true }],
-    [4, { fontSize: 14, bold: true }],
-    [5, { fontSize: 12 }],
-    [6, { fontSize: 11 }],
-  ] as const)('returns correct defaults for level %i', (level, expected) => {
-    expect(getHeadingDefaults(level as HeadingLevel)).toEqual(expected);
   });
 });
 

--- a/packages/docs/test/store/named-styles.test.ts
+++ b/packages/docs/test/store/named-styles.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { MemDocStore } from '../../src/store/memory.js';
+import { createBlock, DEFAULT_BLOCK_STYLE } from '../../src/model/types.js';
+import type { Block, Document } from '../../src/model/types.js';
+import { BUILTIN_STYLES } from '../../src/model/named-styles.js';
+
+function para(id: string): Block {
+  return { id, type: 'paragraph', inlines: [{ text: 'x', style: {} }], style: { ...DEFAULT_BLOCK_STYLE } };
+}
+
+function docWith(...blocks: Block[]): Document {
+  return { blocks };
+}
+
+describe('MemDocStore named styles', () => {
+  it('returns an empty registry by default', () => {
+    const store = new MemDocStore(docWith(para('a')));
+    expect(store.getDocStyles()).toEqual({});
+  });
+
+  it('setBlockType materializes the style spacing when the style changes', () => {
+    const store = new MemDocStore(docWith(para('a')));
+    store.setBlockType('a', 'heading', { headingLevel: 1 });
+    const block = store.getBlock('a')!;
+    expect(block.style.marginTop).toBe(BUILTIN_STYLES['heading-1'].block.marginTop);
+    expect(block.style.marginBottom).toBe(BUILTIN_STYLES['heading-1'].block.marginBottom);
+  });
+
+  it('setBlockType back to paragraph resets heading spacing', () => {
+    const store = new MemDocStore(docWith(para('a')));
+    store.setBlockType('a', 'heading', { headingLevel: 1 });
+    store.setBlockType('a', 'paragraph');
+    const block = store.getBlock('a')!;
+    expect(block.style.marginTop).toBe(BUILTIN_STYLES['normal'].block.marginTop);
+    expect(block.style.marginBottom).toBe(BUILTIN_STYLES['normal'].block.marginBottom);
+  });
+
+  it('a bullet toggle (paragraph↔list-item) does not disturb custom spacing', () => {
+    const store = new MemDocStore(docWith(para('a')));
+    store.applyBlockStyle('a', { marginTop: 99, marginBottom: 99 });
+    store.setBlockType('a', 'list-item', { listKind: 'unordered', listLevel: 0 });
+    const block = store.getBlock('a')!;
+    expect(block.style.marginTop).toBe(99);
+    expect(block.style.marginBottom).toBe(99);
+  });
+
+  it('updateStyleDefinition stores the override and re-materializes block spacing', () => {
+    const h1 = createBlock('heading', { headingLevel: 1 });
+    h1.id = 'h';
+    const store = new MemDocStore(docWith(h1 as Block));
+    store.updateStyleDefinition('heading-1', {
+      inline: { fontSize: 30, bold: true },
+      block: { marginTop: 40, marginBottom: 12 },
+    });
+    expect(store.getDocStyles()['heading-1']?.inline?.fontSize).toBe(30);
+    const block = store.getBlock('h')!;
+    expect(block.style.marginTop).toBe(40);
+    expect(block.style.marginBottom).toBe(12);
+  });
+
+  it('resetStyle drops the override and restores built-in spacing', () => {
+    const h1 = createBlock('heading', { headingLevel: 1 });
+    h1.id = 'h';
+    const store = new MemDocStore(docWith(h1 as Block));
+    store.updateStyleDefinition('heading-1', { inline: {}, block: { marginTop: 40, marginBottom: 12 } });
+    store.resetStyle('heading-1');
+    expect(store.getDocStyles()['heading-1']).toBeUndefined();
+    const block = store.getBlock('h')!;
+    expect(block.style.marginTop).toBe(BUILTIN_STYLES['heading-1'].block.marginTop);
+  });
+
+  it('resetAllStyles clears the whole registry', () => {
+    const store = new MemDocStore(docWith(para('a')));
+    store.updateStyleDefinition('title', { inline: { color: '#ff0000' }, block: {} });
+    store.resetAllStyles();
+    expect(store.getDocStyles()).toEqual({});
+  });
+
+  it('snapshot + undo restores the prior registry and spacing', () => {
+    const h1 = createBlock('heading', { headingLevel: 1 });
+    h1.id = 'h';
+    const store = new MemDocStore(docWith(h1 as Block));
+    store.snapshot();
+    store.updateStyleDefinition('heading-1', { inline: { fontSize: 30 }, block: { marginTop: 40, marginBottom: 12 } });
+    store.undo();
+    expect(store.getDocStyles()).toEqual({});
+    // Pre-snapshot the block was created at DEFAULT_BLOCK_STYLE (marginTop 0);
+    // undo restores that, not the built-in heading spacing.
+    expect(store.getBlock('h')!.style.marginTop).toBe(DEFAULT_BLOCK_STYLE.marginTop);
+  });
+});

--- a/packages/docs/test/store/named-styles.test.ts
+++ b/packages/docs/test/store/named-styles.test.ts
@@ -69,6 +69,17 @@ describe('MemDocStore named styles', () => {
     expect(block.style.marginTop).toBe(BUILTIN_STYLES['heading-1'].block.marginTop);
   });
 
+  it('setDocStyles re-materializes block spacing across styled blocks', () => {
+    const h1 = createBlock('heading', { headingLevel: 1 });
+    h1.id = 'h';
+    const store = new MemDocStore(docWith(h1 as Block));
+    store.setDocStyles({ 'heading-1': { block: { marginTop: 50, marginBottom: 9 } } });
+    expect(store.getBlock('h')!.style.marginTop).toBe(50);
+    // Clearing the registry re-materializes back to the built-in H1 spacing.
+    store.setDocStyles({});
+    expect(store.getBlock('h')!.style.marginTop).toBe(BUILTIN_STYLES['heading-1'].block.marginTop);
+  });
+
   it('resetAllStyles clears the whole registry', () => {
     const store = new MemDocStore(docWith(para('a')));
     store.updateStyleDefinition('title', { inline: { color: '#ff0000' }, block: {} });

--- a/packages/docs/test/view/editor-range-style-summary.test.ts
+++ b/packages/docs/test/view/editor-range-style-summary.test.ts
@@ -319,6 +319,34 @@ describe('getRangeStyleSummary reflects named-style defaults', () => {
     editor.dispose();
   });
 
+  test('reports a document-level style override over the built-in default', () => {
+    const blockId = 'h1';
+    const store = new MemDocStore();
+    store.setDocument({
+      blocks: [
+        {
+          id: blockId,
+          type: 'heading',
+          headingLevel: 1,
+          inlines: [{ text: 'Title', style: {} }],
+          style: EMPTY_BLOCK_STYLE,
+        },
+      ],
+      styles: { 'heading-1': { inline: { fontSize: 30 } } },
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const editor = initialize(container, store);
+    editor._setSelectionForTest({
+      anchor: { blockId, offset: 0 },
+      focus: { blockId, offset: 5 },
+    });
+    // The H1 run has no explicit size; the doc override (30) must win over the
+    // built-in (20).
+    expect(editor.getRangeStyleSummary().fontSize).toBe(30);
+    editor.dispose();
+  });
+
   test('a collapsed caret in a styled paragraph reports the effective size', () => {
     const blockId = 'h2';
     const { editor } = setupEditor([

--- a/packages/docs/test/view/editor-range-style-summary.test.ts
+++ b/packages/docs/test/view/editor-range-style-summary.test.ts
@@ -268,3 +268,74 @@ describe('getRangeStyleSummary', () => {
     editor.dispose();
   });
 });
+
+describe('getRangeStyleSummary reflects named-style defaults', () => {
+  beforeEach(() => {
+    installCanvasShim();
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('a Heading 1 with no explicit run style reports the built-in H1 size', () => {
+    const blockId = 'h1';
+    const { editor } = setupEditor([
+      {
+        id: blockId,
+        type: 'heading',
+        headingLevel: 1,
+        inlines: [{ text: 'Title', style: {} }],
+        style: EMPTY_BLOCK_STYLE,
+      },
+    ]);
+    editor._setSelectionForTest({
+      anchor: { blockId, offset: 0 },
+      focus: { blockId, offset: 5 },
+    });
+    const summary = editor.getRangeStyleSummary();
+    // Built-in Heading 1 is 20pt, non-bold (Google Docs).
+    expect(summary.fontSize).toBe(20);
+    expect(summary.bold).toBeUndefined();
+    editor.dispose();
+  });
+
+  test('an explicit run size overrides the named-style default', () => {
+    const blockId = 'h1';
+    const { editor } = setupEditor([
+      {
+        id: blockId,
+        type: 'heading',
+        headingLevel: 1,
+        inlines: [{ text: 'Title', style: { fontSize: 30 } }],
+        style: EMPTY_BLOCK_STYLE,
+      },
+    ]);
+    editor._setSelectionForTest({
+      anchor: { blockId, offset: 0 },
+      focus: { blockId, offset: 5 },
+    });
+    expect(editor.getRangeStyleSummary().fontSize).toBe(30);
+    editor.dispose();
+  });
+
+  test('a collapsed caret in a styled paragraph reports the effective size', () => {
+    const blockId = 'h2';
+    const { editor } = setupEditor([
+      {
+        id: blockId,
+        type: 'heading',
+        headingLevel: 2,
+        inlines: [{ text: 'Sub', style: {} }],
+        style: EMPTY_BLOCK_STYLE,
+      },
+    ]);
+    editor._setSelectionForTest({
+      anchor: { blockId, offset: 2 },
+      focus: { blockId, offset: 2 },
+    });
+    // Built-in Heading 2 is 16pt.
+    expect(editor.getRangeStyleSummary().fontSize).toBe(16);
+    editor.dispose();
+  });
+});

--- a/packages/docs/test/view/layout.test.ts
+++ b/packages/docs/test/view/layout.test.ts
@@ -9,18 +9,30 @@ describe('heading layout', () => {
     block.inlines = [{ text: 'Title', style: {} }];
     const { layout } = computeLayout([block], stubMeasurer(), 600);
     const run = layout.blocks[0].lines[0].runs[0];
-    // The run's inline should have heading defaults applied
-    expect(run.inline.style.fontSize).toBe(24);
-    expect(run.inline.style.bold).toBe(true);
+    // The run's inline should have the Google Docs H1 default (20pt, non-bold)
+    expect(run.inline.style.fontSize).toBe(20);
+    expect(run.inline.style.bold).toBeUndefined();
   });
 
   it('should let explicit inline styles override heading defaults', () => {
     const block = createBlock('heading', { headingLevel: 1 });
-    block.inlines = [{ text: 'Custom', style: { fontSize: 30 } }];
+    block.inlines = [{ text: 'Custom', style: { fontSize: 30, bold: true } }];
     const { layout } = computeLayout([block], stubMeasurer(), 600);
     const run = layout.blocks[0].lines[0].runs[0];
-    expect(run.inline.style.fontSize).toBe(30);
-    expect(run.inline.style.bold).toBe(true); // still gets bold from defaults
+    expect(run.inline.style.fontSize).toBe(30); // explicit size wins
+    expect(run.inline.style.bold).toBe(true); // explicit bold wins
+  });
+
+  it('should apply a document style override over the built-in default', () => {
+    const block = createBlock('heading', { headingLevel: 1 });
+    block.inlines = [{ text: 'Title', style: {} }];
+    const { layout } = computeLayout(
+      [block], stubMeasurer(), 600, undefined, undefined, undefined,
+      { 'heading-1': { inline: { fontSize: 32, bold: true } } },
+    );
+    const run = layout.blocks[0].lines[0].runs[0];
+    expect(run.inline.style.fontSize).toBe(32);
+    expect(run.inline.style.bold).toBe(true);
   });
 
   it('should produce larger line height for H1 than paragraph', () => {

--- a/packages/frontend/src/api/doc-styles.ts
+++ b/packages/frontend/src/api/doc-styles.ts
@@ -1,0 +1,34 @@
+import type { DocStyles } from "@wafflebase/docs";
+import { fetchWithAuth } from "./auth";
+
+/**
+ * Per-user "default document styles" — the Google Docs "Save as my default
+ * styles" blob. Backed by `GET/PUT /auth/me/doc-styles`.
+ */
+
+export async function fetchMyDocStyles(): Promise<DocStyles> {
+  const res = await fetchWithAuth(
+    `${import.meta.env.VITE_BACKEND_API_URL}/auth/me/doc-styles`,
+    { method: "GET", credentials: "include" }
+  );
+  if (!res.ok) {
+    throw new Error("Failed to load default styles");
+  }
+  const body = (await res.json()) as { styles?: DocStyles };
+  return body.styles ?? {};
+}
+
+export async function saveMyDocStyles(styles: DocStyles): Promise<void> {
+  const res = await fetchWithAuth(
+    `${import.meta.env.VITE_BACKEND_API_URL}/auth/me/doc-styles`,
+    {
+      method: "PUT",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ styles }),
+    }
+  );
+  if (!res.ok) {
+    throw new Error("Failed to save default styles");
+  }
+}

--- a/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
+++ b/packages/frontend/src/app/docs/docs-formatting-toolbar.tsx
@@ -58,6 +58,8 @@ import {
   ensureFontLink,
 } from "@/components/text-formatting";
 import { STYLE_OPTIONS } from "@/components/text-formatting/text-style-options";
+import { fetchMyDocStyles, saveMyDocStyles } from "@/api/doc-styles";
+import { toast } from "sonner";
 import { isMac, modKey } from "@/components/text-formatting/platform";
 
 // ─── Docs-specific sub-components ────────────────────────────────────────────
@@ -261,6 +263,27 @@ export function DocsFormattingToolbar({ editor, editContext = 'body' }: DocsForm
 
   const handleUndo = useCallback(() => editor?.undo(), [editor]);
   const handleRedo = useCallback(() => editor?.redo(), [editor]);
+
+  const handleSaveDefaultStyles = useCallback(async () => {
+    if (!editor) return;
+    try {
+      await saveMyDocStyles(editor.getDocStyles());
+      toast.success("Saved as your default styles");
+    } catch {
+      toast.error("Failed to save default styles");
+    }
+  }, [editor]);
+
+  const handleUseDefaultStyles = useCallback(async () => {
+    if (!editor) return;
+    try {
+      const styles = await fetchMyDocStyles();
+      editor.setDocStyles(styles);
+      toast.success("Applied your default styles");
+    } catch {
+      toast.error("Failed to load default styles");
+    }
+  }, [editor]);
 
   const handleInsertPageNumber = useCallback(() => {
     editor?.insertPageNumber();
@@ -584,7 +607,11 @@ export function DocsFormattingToolbar({ editor, editContext = 'body' }: DocsForm
       {/* ── Styles (desktop only) ── */}
       {!isMobile && (
         <>
-          <TextStyleGroup editor={editor} />
+          <TextStyleGroup
+            editor={editor}
+            onSaveDefaultStyles={handleSaveDefaultStyles}
+            onUseDefaultStyles={handleUseDefaultStyles}
+          />
           <ToolbarSeparator />
           <FontFamilyPicker
             value={familyValue}

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -2524,11 +2524,10 @@ export class YorkieDocStore implements DocStore {
   }
 
   setDocStyles(styles: DocStyles): void {
-    this.doc.update((root) => {
-      root.stylesJson = JSON.stringify(styles ?? {});
-    });
-    this.dirty = true;
-    this.cachedDoc = null;
+    // Re-materialize spacing across every styled block (one undo unit) so
+    // "Use my default styles" applies paragraph spacing too — inline defaults
+    // reflow lazily, but block spacing is materialized.
+    this.writeStylesAndRematerialize(styles ?? {}, undefined);
   }
 
   updateStyleDefinition(styleId: StyleId, def: NamedStyleDef): void {

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -2547,20 +2547,30 @@ export class YorkieDocStore implements DocStore {
 
   /**
    * Persist the registry and re-materialize block spacing onto every affected
-   * top-level block (body + header + footer) in a single `doc.update` so the
-   * whole change is one undo unit. Pass `styleId` to limit re-materialization
-   * to one style; omit it to re-materialize every styled block ("Reset all").
+   * block — body, header/footer, and table cells (recursively) — in a single
+   * `doc.update` so the whole change is one undo unit. Pass `styleId` to limit
+   * re-materialization to one style; omit it to re-materialize every styled
+   * block ("Reset all"). Mirrors `rematerializeDocSpacing` in the model so the
+   * Mem and Yorkie stores agree on which blocks are touched.
    */
   private writeStylesAndRematerialize(next: DocStyles, styleId: StyleId | undefined): void {
     const currentDoc = this.getDocument();
     const edits: Array<{ path: number[]; attrs: Record<string, string> }> = [];
     const collect = (blocks: Block[]) => {
       for (const block of blocks) {
-        if (styleId && blockStyleId(block) !== styleId) continue;
-        const merged = normalizeBlockStyle(materializeBlockSpacing(block, next));
-        const { path } = this.resolveBlockTreePath(block.id, currentDoc);
-        edits.push({ path, attrs: serializeBlockStyle(merged) });
-        block.style = merged;
+        if (!styleId || blockStyleId(block) === styleId) {
+          const merged = normalizeBlockStyle(materializeBlockSpacing(block, next));
+          const { path } = this.resolveBlockTreePath(block.id, currentDoc);
+          edits.push({ path, attrs: serializeBlockStyle(merged) });
+          block.style = merged;
+        }
+        if (block.tableData) {
+          for (const row of block.tableData.rows) {
+            for (const cell of row.cells) {
+              collect(cell.blocks);
+            }
+          }
+        }
       }
     };
     collect(currentDoc.blocks);
@@ -2644,6 +2654,17 @@ export class YorkieDocStore implements DocStore {
         return children;
       };
 
+      // Named-style registry (a JSON string outside the tree) — written in
+      // every full-document path, including the treeless initial-load branch
+      // below, so a styled document isn't silently dropped on first write.
+      const writeStylesJson = (): void => {
+        if (document.styles && Object.keys(document.styles).length > 0) {
+          root.stylesJson = JSON.stringify(document.styles);
+        } else if (root.stylesJson !== undefined) {
+          delete root.stylesJson;
+        }
+      };
+
       // If tree isn't a Tree CRDT yet, create one with the document content.
       if (!tree || typeof tree.getRootTreeNode !== 'function') {
         const children = buildTreeChildren();
@@ -2659,6 +2680,7 @@ export class YorkieDocStore implements DocStore {
             margins: { ...document.pageSetup.margins },
           };
         }
+        writeStylesJson();
         return;
       }
 
@@ -2685,10 +2707,7 @@ export class YorkieDocStore implements DocStore {
         };
       }
 
-      // Named-style registry (stored as a JSON string outside the tree).
-      if (document.styles && Object.keys(document.styles).length > 0) {
-        root.stylesJson = JSON.stringify(document.styles);
-      }
+      writeStylesJson();
     });
   }
 

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -36,7 +36,7 @@ import {
   applySplitBlock,
   applyMergeBlocks,
   blockStyleId,
-  resolveStyleBlock,
+  materializeBlockSpacing,
 } from '@wafflebase/docs';
 import type { YorkieDocsRoot } from '@/types/docs-document';
 import type { DocsPresence } from '@/types/users';
@@ -1392,13 +1392,13 @@ export class YorkieDocStore implements DocStore {
     // spacing into the same styleByPath write (Google Docs parity). A bullet
     // toggle (both 'normal') leaves spacing untouched.
     const nextHeadingLevel = type === 'heading' ? (opts?.headingLevel ?? 1) : undefined;
-    const nextStyleId = blockStyleId({ ...block, type, headingLevel: nextHeadingLevel } as Block);
+    const nextBlock = { ...block, type, headingLevel: nextHeadingLevel } as Block;
+    const nextStyleId = blockStyleId(nextBlock);
     let materializedStyle: BlockStyle | undefined;
     if (nextStyleId !== prevStyleId) {
-      materializedStyle = normalizeBlockStyle({
-        ...block.style,
-        ...resolveStyleBlock(nextStyleId, this.readDocStyles()),
-      });
+      materializedStyle = normalizeBlockStyle(
+        materializeBlockSpacing(nextBlock, this.readDocStyles()),
+      );
       Object.assign(attrs, serializeBlockStyle(materializedStyle));
     }
 
@@ -2556,9 +2556,8 @@ export class YorkieDocStore implements DocStore {
     const edits: Array<{ path: number[]; attrs: Record<string, string> }> = [];
     const collect = (blocks: Block[]) => {
       for (const block of blocks) {
-        const id = blockStyleId(block);
-        if (styleId && id !== styleId) continue;
-        const merged = normalizeBlockStyle({ ...block.style, ...resolveStyleBlock(id, next) });
+        if (styleId && blockStyleId(block) !== styleId) continue;
+        const merged = normalizeBlockStyle(materializeBlockSpacing(block, next));
         const { path } = this.resolveBlockTreePath(block.id, currentDoc);
         edits.push({ path, attrs: serializeBlockStyle(merged) });
         block.style = merged;

--- a/packages/frontend/src/app/docs/yorkie-doc-store.ts
+++ b/packages/frontend/src/app/docs/yorkie-doc-store.ts
@@ -20,6 +20,9 @@ import type {
   BorderStyle,
   DocPosition,
   DocRange,
+  DocStyles,
+  NamedStyleDef,
+  StyleId,
 } from '@wafflebase/docs';
 import {
   resolvePageSetup,
@@ -32,6 +35,8 @@ import {
   applyInsertInline,
   applySplitBlock,
   applyMergeBlocks,
+  blockStyleId,
+  resolveStyleBlock,
 } from '@wafflebase/docs';
 import type { YorkieDocsRoot } from '@/types/docs-document';
 import type { DocsPresence } from '@/types/users';
@@ -551,9 +556,29 @@ export class YorkieDocStore implements DocStore {
     parsed.pageSetup = root.pageSetup
       ? readPageSetup(root.pageSetup)
       : undefined;
+    const styles = this.readDocStyles();
+    parsed.styles = Object.keys(styles).length > 0 ? styles : undefined;
     this.cachedDoc = parsed;
     this.dirty = false;
     return cloneDocument(parsed);
+  }
+
+  /**
+   * Read the named-style registry from the Yorkie root. The registry is
+   * stored as a single JSON string (`root.stylesJson`) rather than a nested
+   * CRDT object: it is tiny and rarely concurrently edited, so whole-blob LWW
+   * is acceptable, and a scalar string sidesteps Yorkie proxy double-encoding
+   * and the variable/`StoredColor` key shapes inside a style definition.
+   */
+  private readDocStyles(): DocStyles {
+    const root = this.doc.getRoot();
+    const json = root.stylesJson;
+    if (!json) return {};
+    try {
+      return JSON.parse(json) as DocStyles;
+    } catch {
+      return {};
+    }
   }
 
   private findBlockRecursive(blocks: Block[], id: string): Block | undefined {
@@ -590,6 +615,10 @@ export class YorkieDocStore implements DocStore {
     return resolvePageSetup(
       root.pageSetup ? readPageSetup(root.pageSetup) : undefined,
     );
+  }
+
+  getDocStyles(): DocStyles {
+    return this.readDocStyles();
   }
 
   getHeader(): HeaderFooter | undefined {
@@ -1346,8 +1375,10 @@ export class YorkieDocStore implements DocStore {
     const currentDoc = this.getDocument();
     const { path: blockPath, region } = this.resolveBlockTreePath(blockId, currentDoc);
     const block = this.getBlockByRegion(currentDoc, blockPath, region);
+    const prevStyleId = blockStyleId(block);
 
-    // Build only type-specific attributes (not style — it's unchanged)
+    // Build only type-specific attributes (style is added below only when the
+    // named style changes).
     const attrs: Record<string, string> = { type };
     if (type === 'heading') {
       attrs.headingLevel = String(opts?.headingLevel ?? 1);
@@ -1355,6 +1386,20 @@ export class YorkieDocStore implements DocStore {
     if (type === 'list-item') {
       attrs.listKind = opts?.listKind ?? 'unordered';
       attrs.listLevel = String(opts?.listLevel ?? 0);
+    }
+
+    // Applying a different named style re-materializes the block's style-owned
+    // spacing into the same styleByPath write (Google Docs parity). A bullet
+    // toggle (both 'normal') leaves spacing untouched.
+    const nextHeadingLevel = type === 'heading' ? (opts?.headingLevel ?? 1) : undefined;
+    const nextStyleId = blockStyleId({ ...block, type, headingLevel: nextHeadingLevel } as Block);
+    let materializedStyle: BlockStyle | undefined;
+    if (nextStyleId !== prevStyleId) {
+      materializedStyle = normalizeBlockStyle({
+        ...block.style,
+        ...resolveStyleBlock(nextStyleId, this.readDocStyles()),
+      });
+      Object.assign(attrs, serializeBlockStyle(materializedStyle));
     }
 
     // Determine stale attributes to remove (styleByPath merges, not replaces)
@@ -1414,6 +1459,7 @@ export class YorkieDocStore implements DocStore {
     } else if (block.inlines.length === 0) {
       block.inlines = [{ text: '', style: {} }];
     }
+    if (materializedStyle) block.style = materializedStyle;
     this.setBlockByRegion(currentDoc, blockPath, region, block);
     this.cachedDoc = currentDoc;
     this.dirty = false;
@@ -2477,6 +2523,65 @@ export class YorkieDocStore implements DocStore {
     this.cachedDoc = null;
   }
 
+  setDocStyles(styles: DocStyles): void {
+    this.doc.update((root) => {
+      root.stylesJson = JSON.stringify(styles ?? {});
+    });
+    this.dirty = true;
+    this.cachedDoc = null;
+  }
+
+  updateStyleDefinition(styleId: StyleId, def: NamedStyleDef): void {
+    const next: DocStyles = { ...this.readDocStyles(), [styleId]: def };
+    this.writeStylesAndRematerialize(next, styleId);
+  }
+
+  resetStyle(styleId: StyleId): void {
+    const next: DocStyles = { ...this.readDocStyles() };
+    delete next[styleId];
+    this.writeStylesAndRematerialize(next, styleId);
+  }
+
+  resetAllStyles(): void {
+    this.writeStylesAndRematerialize({}, undefined);
+  }
+
+  /**
+   * Persist the registry and re-materialize block spacing onto every affected
+   * top-level block (body + header + footer) in a single `doc.update` so the
+   * whole change is one undo unit. Pass `styleId` to limit re-materialization
+   * to one style; omit it to re-materialize every styled block ("Reset all").
+   */
+  private writeStylesAndRematerialize(next: DocStyles, styleId: StyleId | undefined): void {
+    const currentDoc = this.getDocument();
+    const edits: Array<{ path: number[]; attrs: Record<string, string> }> = [];
+    const collect = (blocks: Block[]) => {
+      for (const block of blocks) {
+        const id = blockStyleId(block);
+        if (styleId && id !== styleId) continue;
+        const merged = normalizeBlockStyle({ ...block.style, ...resolveStyleBlock(id, next) });
+        const { path } = this.resolveBlockTreePath(block.id, currentDoc);
+        edits.push({ path, attrs: serializeBlockStyle(merged) });
+        block.style = merged;
+      }
+    };
+    collect(currentDoc.blocks);
+    if (currentDoc.header) collect(currentDoc.header.blocks);
+    if (currentDoc.footer) collect(currentDoc.footer.blocks);
+
+    this.doc.update((root) => {
+      root.stylesJson = JSON.stringify(next);
+      const tree = root.content;
+      if (tree && typeof tree.getRootTreeNode === 'function') {
+        for (const edit of edits) tree.styleByPath(edit.path, edit.attrs);
+      }
+    });
+
+    currentDoc.styles = Object.keys(next).length > 0 ? next : undefined;
+    this.cachedDoc = currentDoc;
+    this.dirty = false;
+  }
+
   // -----------------------------------------------------------------------
   // Undo / Redo (Yorkie-native via doc.history)
   // -----------------------------------------------------------------------
@@ -2580,6 +2685,11 @@ export class YorkieDocStore implements DocStore {
           orientation: document.pageSetup.orientation,
           margins: { ...document.pageSetup.margins },
         };
+      }
+
+      // Named-style registry (stored as a JSON string outside the tree).
+      if (document.styles && Object.keys(document.styles).length > 0) {
+        root.stylesJson = JSON.stringify(document.styles);
       }
     });
   }

--- a/packages/frontend/src/components/text-formatting/text-style-group.tsx
+++ b/packages/frontend/src/components/text-formatting/text-style-group.tsx
@@ -1,7 +1,12 @@
 /**
- * Shared text style controls: block-type dropdown (Normal text, Heading 1–3,
- * Title, Subtitle). Shared between the docs toolbar and the slides text-edit
- * state toolbar.
+ * Shared text style controls: block-type dropdown (Normal text, Title,
+ * Subtitle, Heading 1–6). Shared between the docs toolbar and the slides
+ * text-edit state toolbar.
+ *
+ * When the editor supports named styles (docs `EditorAPI`), an "Options"
+ * submenu adds Google-Docs-style redefine / reset / save-default actions.
+ * Slides text-box editors omit those methods, so the submenu is hidden and
+ * the dropdown stays a plain one-click block-type picker.
  */
 
 import { useRef } from "react";
@@ -12,6 +17,10 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
   DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 } from "@/components/ui/dropdown-menu";
 import {
   Tooltip,
@@ -19,7 +28,11 @@ import {
   TooltipContent,
 } from "@/components/ui/tooltip";
 import { IconChevronDown } from "@tabler/icons-react";
-import { getFilteredStyleOptions, getBlockLabel } from "./text-style-options";
+import {
+  getFilteredStyleOptions,
+  getBlockLabel,
+  blockTypeToStyleId,
+} from "./text-style-options";
 import { modKey } from "./platform";
 
 interface TextStyleGroupProps {
@@ -32,13 +45,27 @@ interface TextStyleGroupProps {
    * have no Title/Subtitle); pass `['paragraph', 'heading']` to hide them.
    */
   allowedBlockTypes?: ReadonlyArray<BlockType>;
+  /**
+   * "Save as my default styles" — persist the current document registry to
+   * the user account. Omit to hide the entry (e.g. when unauthenticated).
+   */
+  onSaveDefaultStyles?: () => void;
+  /** "Use my default styles" — load the saved registry into the document. */
+  onUseDefaultStyles?: () => void;
 }
 
 export function TextStyleGroup({
   editor,
   disabled = false,
   allowedBlockTypes,
+  onSaveDefaultStyles,
+  onUseDefaultStyles,
 }: TextStyleGroupProps) {
+  // Stash the action on click, replay it from `onCloseAutoFocus` so the
+  // caller's `editor.focus()` runs after Radix's FocusScope teardown and
+  // sticks (same deferral pattern as FontFamilyPicker).
+  const pendingActionRef = useRef<(() => void) | null>(null);
+
   const handleBlockType = (
     type: BlockType,
     opts?: { headingLevel?: HeadingLevel }
@@ -48,16 +75,18 @@ export function TextStyleGroup({
     editor.focus();
   };
 
-  // Same deferral pattern as FontFamilyPicker: stash the pick on click,
-  // replay it from `onCloseAutoFocus` so the caller's `editor.focus()`
-  // runs after Radix's FocusScope teardown and sticks.
-  const pendingPickRef = useRef<{
-    type: BlockType;
-    headingLevel?: HeadingLevel;
-  } | null>(null);
-
   const blockType = editor ? editor.getBlockType() : null;
   const visibleOptions = getFilteredStyleOptions(allowedBlockTypes);
+
+  // Named-style redefinition is docs-only (slides text-boxes omit the
+  // methods). Gate the whole Options submenu on capability detection.
+  const supportsNamedStyles = !!editor?.updateStyleToMatch;
+  const currentLabel = blockType
+    ? getBlockLabel(blockType.type, blockType.headingLevel)
+    : "Normal text";
+  const currentStyleId = blockType
+    ? blockTypeToStyleId(blockType.type, blockType.headingLevel)
+    : "normal";
 
   return (
     <DropdownMenu>
@@ -70,11 +99,7 @@ export function TextStyleGroup({
               disabled={disabled || !editor}
               data-text-edit-keepalive
             >
-              <span className="truncate">
-                {blockType
-                  ? getBlockLabel(blockType.type, blockType.headingLevel)
-                  : "Normal text"}
-              </span>
+              <span className="truncate">{currentLabel}</span>
               <IconChevronDown size={12} className="ml-1 shrink-0 opacity-50" />
             </button>
           </DropdownMenuTrigger>
@@ -82,21 +107,18 @@ export function TextStyleGroup({
         <TooltipContent>Styles</TooltipContent>
       </Tooltip>
       <DropdownMenuContent
-        className="w-[210px]"
+        className="w-[230px]"
         data-text-edit-keepalive
         onCloseAutoFocus={(e) => {
-          const pick = pendingPickRef.current;
-          if (pick === null) {
+          const action = pendingActionRef.current;
+          if (action === null) {
             // No pick — let Radix restore focus to the trigger so Esc /
             // outside-click dismiss does not strand focus on <body>.
             return;
           }
           e.preventDefault();
-          pendingPickRef.current = null;
-          handleBlockType(
-            pick.type,
-            pick.headingLevel ? { headingLevel: pick.headingLevel } : undefined,
-          );
+          pendingActionRef.current = null;
+          action();
         }}
       >
         {visibleOptions.map((opt) => (
@@ -104,10 +126,13 @@ export function TextStyleGroup({
             key={opt.label}
             className="flex items-center justify-between py-1"
             onClick={() => {
-              pendingPickRef.current = {
-                type: opt.type,
-                headingLevel: opt.headingLevel,
-              };
+              pendingActionRef.current = () =>
+                handleBlockType(
+                  opt.type,
+                  opt.headingLevel
+                    ? { headingLevel: opt.headingLevel }
+                    : undefined
+                );
             }}
           >
             <span className={opt.className}>{opt.label}</span>
@@ -118,6 +143,75 @@ export function TextStyleGroup({
             )}
           </DropdownMenuItem>
         ))}
+
+        {supportsNamedStyles && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>Options</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-[230px]">
+                <DropdownMenuItem
+                  onClick={() => {
+                    pendingActionRef.current = () => {
+                      editor?.updateStyleToMatch?.(currentStyleId);
+                      editor?.focus();
+                    };
+                  }}
+                >
+                  {`Update '${currentLabel}' to match`}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => {
+                    pendingActionRef.current = () => {
+                      editor?.resetNamedStyle?.(currentStyleId);
+                      editor?.focus();
+                    };
+                  }}
+                >
+                  {`Reset '${currentLabel}'`}
+                </DropdownMenuItem>
+                {(onSaveDefaultStyles || onUseDefaultStyles) && (
+                  <DropdownMenuSeparator />
+                )}
+                {onSaveDefaultStyles && (
+                  <DropdownMenuItem
+                    onClick={() => {
+                      pendingActionRef.current = () => {
+                        onSaveDefaultStyles();
+                        editor?.focus();
+                      };
+                    }}
+                  >
+                    Save as my default styles
+                  </DropdownMenuItem>
+                )}
+                {onUseDefaultStyles && (
+                  <DropdownMenuItem
+                    onClick={() => {
+                      pendingActionRef.current = () => {
+                        onUseDefaultStyles();
+                        editor?.focus();
+                      };
+                    }}
+                  >
+                    Use my default styles
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => {
+                    pendingActionRef.current = () => {
+                      editor?.resetAllNamedStyles?.();
+                      editor?.focus();
+                    };
+                  }}
+                >
+                  Reset styles
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/frontend/src/components/text-formatting/text-style-options.ts
+++ b/packages/frontend/src/components/text-formatting/text-style-options.ts
@@ -4,55 +4,91 @@
  * DOM / JSX environment.
  */
 
-import type { BlockType, HeadingLevel } from "@wafflebase/docs";
+import type { BlockType, HeadingLevel, StyleId } from "@wafflebase/docs";
 
 /** A single entry in the block-type dropdown. */
 export interface StyleOption {
   label: string;
   type: BlockType;
   headingLevel?: HeadingLevel;
+  /** The named style this option applies/redefines. */
+  styleId: StyleId;
   className: string;
   shortcut?: string;
 }
 
-/** Full ordered list of block-type options (Google Docs style). */
+/**
+ * Full ordered list of block-type options (Google Docs style). Preview
+ * classNames mirror the refreshed built-in look — non-bold headings with a
+ * size + grayscale hierarchy (see `model/named-styles.ts`).
+ */
 export const STYLE_OPTIONS: StyleOption[] = [
   {
     label: "Normal text",
     type: "paragraph",
+    styleId: "normal",
     className: "text-[13px]",
     shortcut: "⌥0",
   },
   {
     label: "Title",
     type: "title",
+    styleId: "title",
     className: "text-[22px] leading-tight",
   },
   {
     label: "Subtitle",
     type: "subtitle",
+    styleId: "subtitle",
     className: "text-[13px] text-muted-foreground",
   },
   {
     label: "Heading 1",
     type: "heading",
     headingLevel: 1,
-    className: "text-[18px] font-bold",
+    styleId: "heading-1",
+    className: "text-[18px]",
     shortcut: "⌥1",
   },
   {
     label: "Heading 2",
     type: "heading",
     headingLevel: 2,
-    className: "text-[16px] font-bold",
+    styleId: "heading-2",
+    className: "text-[15px]",
     shortcut: "⌥2",
   },
   {
     label: "Heading 3",
     type: "heading",
     headingLevel: 3,
-    className: "text-[14px] font-bold",
+    styleId: "heading-3",
+    className: "text-[14px] text-muted-foreground",
     shortcut: "⌥3",
+  },
+  {
+    label: "Heading 4",
+    type: "heading",
+    headingLevel: 4,
+    styleId: "heading-4",
+    className: "text-[13px] text-muted-foreground",
+    shortcut: "⌥4",
+  },
+  {
+    label: "Heading 5",
+    type: "heading",
+    headingLevel: 5,
+    styleId: "heading-5",
+    className: "text-[12px] text-muted-foreground",
+    shortcut: "⌥5",
+  },
+  {
+    label: "Heading 6",
+    type: "heading",
+    headingLevel: 6,
+    styleId: "heading-6",
+    className: "text-[12px] italic text-muted-foreground",
+    shortcut: "⌥6",
   },
 ];
 
@@ -75,4 +111,19 @@ export function getBlockLabel(
   if (type === "subtitle") return "Subtitle";
   if (type === "heading" && headingLevel) return `Heading ${headingLevel}`;
   return "Normal text";
+}
+
+/**
+ * Map a block type (+ heading level) to the named `StyleId` that governs it.
+ * Mirrors `blockStyleId` in `@wafflebase/docs` for non-block inputs the
+ * toolbar deals in (paragraph / list-item / title / subtitle / heading).
+ */
+export function blockTypeToStyleId(
+  type: BlockType,
+  headingLevel?: HeadingLevel
+): StyleId {
+  if (type === "title") return "title";
+  if (type === "subtitle") return "subtitle";
+  if (type === "heading") return `heading-${headingLevel ?? 1}` as StyleId;
+  return "normal";
 }

--- a/packages/frontend/src/components/text-formatting/types.ts
+++ b/packages/frontend/src/components/text-formatting/types.ts
@@ -12,7 +12,7 @@
  * full `EditorAPI` and are not part of this interface.
  */
 
-import type { InlineStyle, BlockStyle, BlockType, HeadingLevel } from "@wafflebase/docs";
+import type { InlineStyle, BlockStyle, BlockType, HeadingLevel, DocStyles, StyleId } from "@wafflebase/docs";
 
 export interface TextFormattingEditor {
   /** Focus the underlying editor after a toolbar click. */
@@ -90,6 +90,20 @@ export interface TextFormattingEditor {
 
   /** Programmatically trigger the link request (same as Ctrl+K). */
   requestLink(): void;
+
+  // --- Named styles (Google Docs paragraph styles) ---
+  // Optional: only the docs `EditorAPI` implements these. Slides text-box
+  // editors omit them, so the Styles dropdown hides the redefine/reset UI.
+  /** Read the document's named-style overrides registry. */
+  getDocStyles?(): DocStyles;
+  /** Replace the whole registry (e.g. "Use my default styles"). */
+  setDocStyles?(styles: DocStyles): void;
+  /** Redefine a style from the caret block ("Update '<style>' to match"). */
+  updateStyleToMatch?(styleId: StyleId): void;
+  /** Reset a single style to its built-in definition. */
+  resetNamedStyle?(styleId: StyleId): void;
+  /** Reset every style to its built-in definition. */
+  resetAllNamedStyles?(): void;
 
   /**
    * Strip all character-level inline styles (bold, italic, underline,

--- a/packages/frontend/src/types/docs-document.ts
+++ b/packages/frontend/src/types/docs-document.ts
@@ -6,6 +6,10 @@ import type { DocsRangeAnchor, Thread } from '@/types/comments.ts';
  *
  * - `content`: yorkie.Tree holding the block/inline structure
  * - `pageSetup`: document-level metadata (paper size, margins)
+ * - `stylesJson`: named-style overrides registry (`DocStyles`) serialized as
+ *   a JSON string. A tiny, rarely-concurrent registry — whole-blob LWW is
+ *   acceptable and a scalar string avoids Yorkie proxy double-encoding.
+ *   Existing documents without the field resolve to built-in styles.
  * - `comments`: threaded comments keyed by thread id, materialized on
  *   first insertion. Existing documents without the field stay valid.
  */
@@ -16,6 +20,7 @@ export type YorkieDocsRoot = {
     orientation: 'portrait' | 'landscape';
     margins: { top: number; bottom: number; left: number; right: number };
   };
+  stylesJson?: string;
   comments?: { [threadId: string]: Thread<DocsRangeAnchor> };
 };
 

--- a/packages/frontend/tests/components/text-formatting/text-style-options.test.ts
+++ b/packages/frontend/tests/components/text-formatting/text-style-options.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  STYLE_OPTIONS,
+  blockTypeToStyleId,
+  getBlockLabel,
+} from "../../../src/components/text-formatting/text-style-options.ts";
+
+describe("STYLE_OPTIONS", () => {
+  it("exposes Normal, Title, Subtitle and Heading 1–6", () => {
+    const labels = STYLE_OPTIONS.map((o) => o.label);
+    expect(labels).toEqual([
+      "Normal text",
+      "Title",
+      "Subtitle",
+      "Heading 1",
+      "Heading 2",
+      "Heading 3",
+      "Heading 4",
+      "Heading 5",
+      "Heading 6",
+    ]);
+  });
+
+  it("carries a matching styleId on every option", () => {
+    expect(STYLE_OPTIONS.find((o) => o.label === "Heading 4")?.styleId).toBe(
+      "heading-4"
+    );
+    expect(STYLE_OPTIONS.find((o) => o.label === "Normal text")?.styleId).toBe(
+      "normal"
+    );
+  });
+});
+
+describe("blockTypeToStyleId", () => {
+  it("maps each toolbar block type to its style id", () => {
+    expect(blockTypeToStyleId("paragraph")).toBe("normal");
+    expect(blockTypeToStyleId("list-item")).toBe("normal");
+    expect(blockTypeToStyleId("title")).toBe("title");
+    expect(blockTypeToStyleId("subtitle")).toBe("subtitle");
+    expect(blockTypeToStyleId("heading", 2)).toBe("heading-2");
+    expect(blockTypeToStyleId("heading")).toBe("heading-1");
+  });
+});
+
+describe("getBlockLabel", () => {
+  it("labels headings by level", () => {
+    expect(getBlockLabel("heading", 5)).toBe("Heading 5");
+    expect(getBlockLabel("paragraph")).toBe("Normal text");
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Named Styles** (Phase 6.5) for the docs word processor, following the Google Docs "Paragraph styles" model. Design: `docs/design/docs/docs-named-styles.md`.

- **Redefinable per-document style registry.** A fixed catalog (Normal text / Title / Subtitle / Heading 1–6) whose definitions are overridable per document — `Document.styles?: DocStyles` (overrides only; absent → built-in). Users can't invent arbitrary named styles (Google Docs parity).
- **Refreshed built-in values** to Google Docs defaults: non-bold headings, grayscale color hierarchy (#434343 / #666666), paragraph spacing.
- **Two-path cascade:** inline defaults (font/size/color/bold/italic) resolve **lazily** at layout via `resolveBlockInlines(block, docStyles?)` — so a redefine reflows every block of that style with no stored-run rewrite; block spacing materializes **eagerly** into `block.style` on apply / update / reset.
- **Store API:** `getDocStyles` / `setDocStyles` / `updateStyleDefinition` / `resetStyle` / `resetAllStyles` on `DocStore`, implemented in `MemDocStore` and `YorkieDocStore`. Yorkie persists the registry as a JSON string at `root.stylesJson`; update/reset re-materialize affected blocks in one `doc.update` (one undo unit). Backend `docs-tree.ts` serializes it with the same destructive-replace contract as `pageSetup`.
- **UI:** Heading 4–6 added to the Styles dropdown; capability-gated **Options** submenu (Update '<style>' to match · Reset '<style>' · Save / Use my default styles · Reset styles). One-click apply preserved; toolbar pickers now show the **computed** style of a styled paragraph.
- **Per-user default styles:** `UserDocStyles` table + `GET/PUT /auth/me/doc-styles`, wired to Save/Use my default styles.

## Test plan

- `pnpm verify:fast` green.
- Docs unit tests: model resolution + heading-level clamp, MemStore behavior + spacing materialization, layout cascade (override wins), backend `docs-tree` JSON round-trip, toolbar computed-style readout (`editor-range-style-summary`), frontend option mapping.
- Self-review (high-effort, multi-agent) run over the branch; findings fixed: DOCX Heading 7–9 layout crash (clamp), CLI pagination dropped `doc.styles`, `updateStyleToMatch` reverting inherited overrides, `setDocStyles` not re-materializing spacing, store-divergence via shared `materializeBlockSpacing`.
- Manual smoke (docs editor): apply each style, Update to match, Reset, Save/Use my default styles.

## Known limitations (v1)

- DOCX export does not carry per-document style overrides (PDF export does).
- Concurrent redefinition of *different* styles is whole-blob LWW (tiny registry; one redefinition can be lost) — accepted tradeoff vs the fine-grained CRDT used elsewhere.
- Table-cell block *spacing* is not eagerly re-materialized on redefine (cell inline defaults still reflow lazily).
- Heading appearance changes on existing documents (bold→non-bold, new sizes/colors) — intentional Google Docs parity, no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document-scoped named paragraph styles (Normal, Title, Subtitle, Heading 1–6) with save/reset and “update to match” behavior.
  * Added personal default document styles that can be saved and applied from the formatting toolbar.
  * Ensured named styles are reflected consistently in editor rendering and layout-related views (including pagination/export).
* **Bug Fixes**
  * Fixed style consistency and spacing updates across style changes, resets, and document save/restore.
* **Documentation**
  * Added design notes, task updates, and implementation lessons for named styles behavior.
* **Tests**
  * Added/updated tests for style resolution, persistence, toolbar options/labels, and layout expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->