### PR TITLE
Inherit source number format in pivot tables and charts

### DIFF
--- a/docs/design/sheets/charts.md
+++ b/docs/design/sheets/charts.md
@@ -105,6 +105,21 @@ Scatter reuses the existing `ChartDataset` structure. Both X and Y values
 are numeric. The `xKey` field references numeric X values instead of
 categorical labels.
 
+#### Label Formatting
+
+Category / x-axis labels, pie slice names, and series header labels are
+produced with `getCellDisplayValue` in `chart-utils.ts`, which resolves the
+cell's effective number/date format (sheet → col → row → range → cell via
+`resolveWorksheetCellStyle`) and applies `formatValue`. This makes a date
+column with a Locale Date format show the formatted date rather than the raw
+value, matching the on-sheet appearance.
+
+Numeric **series values** instead use `getCellRawValue` (raw `cell.v`): they
+are parsed by `toNumeric`, so a formatted string like `"$300.00"` or `"1,234"`
+must not reach the parser. Labels are formatted; values stay raw. The Recharts
+category `XAxis` has no `tickFormatter`, so the formatting must happen in this
+extraction layer.
+
 ### 3. Chart Registry
 
 A central registry maps each `ChartType` to its renderer component,

--- a/docs/design/sheets/pivot-table.md
+++ b/docs/design/sheets/pivot-table.md
@@ -187,8 +187,20 @@ type PivotRecord = string[];  // values indexed by source column
 function parseSourceData(
   grid: Grid,
   sourceRange: Range,
-): { headers: string[]; records: PivotRecord[] };
+): {
+  headers: string[];
+  records: PivotRecord[];
+  columnFormats: (PivotCellFormat | undefined)[];  // per source column
+};
 ```
+
+`columnFormats[i]` is the number format (`nf`/`dp`/`cu`) of source column
+`i`, taken from the first data cell carrying one. It drives format
+inheritance (see Step 6). The input `grid` must hold the **resolved
+effective style** per cell: number/date formats are usually stored as a
+range-style (or column/row/sheet) layer rather than on `cell.s`, so the
+caller builds the source grid with `resolveWorksheetCellStyle(ws, ref)`
+(sheet → col → row → range → cell merge) instead of reading `cell.s` alone.
 
 #### Step 2: Apply Filters
 
@@ -238,9 +250,12 @@ type PivotCellType =
   | 'total'
   | 'empty';
 
+type PivotCellFormat = Pick<CellStyle, 'nf' | 'dp' | 'cu'>;
+
 type PivotCell = {
   value: string;
   type: PivotCellType;
+  format?: PivotCellFormat;  // inherited from the source column
 };
 
 type PivotResult = {
@@ -258,6 +273,16 @@ starting at A1. Apply default styling:
 - Row/column headers: bold
 - Grand total row/column: bold
 - Value cells: plain (no styling)
+
+**Format inheritance** (matches Google Sheets / Excel): a `PivotCell.format`
+is merged into the output cell style so labels and values render with the
+source's number/date format rather than the raw value:
+
+- Single-field row/column **labels** inherit that field's source column
+  format (composite "A / B" multi-field labels stay plain — no single format
+  applies).
+- **Value / total** cells inherit the value field's source column format,
+  except `COUNT`/`COUNTA`, which stay plain (a count is a plain integer).
 
 All writes are wrapped in a single batch transaction for atomic undo/redo.
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| pivot format inheritance (2026-07-01) | [20260701-pivot-format-inheritance-todo.md](./active/20260701-pivot-format-inheritance-todo.md) | [20260701-pivot-format-inheritance-lessons.md](./active/20260701-pivot-format-inheritance-lessons.md) |
 | docs collaboration convergence (2026-06-25) | [20260625-docs-collaboration-convergence-todo.md](./active/20260625-docs-collaboration-convergence-todo.md) | [20260625-docs-collaboration-convergence-lessons.md](./active/20260625-docs-collaboration-convergence-lessons.md) |
 | docs wordprocessor (2026-03-25) | [20260325-docs-wordprocessor-todo.md](./active/20260325-docs-wordprocessor-todo.md) | [20260325-docs-wordprocessor-lessons.md](./active/20260325-docs-wordprocessor-lessons.md) |
 
@@ -26,4 +27,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 330
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: docs collaboration convergence (2026-06-25)
+Latest active task: pivot format inheritance (2026-07-01)

--- a/docs/tasks/active/20260701-pivot-format-inheritance-lessons.md
+++ b/docs/tasks/active/20260701-pivot-format-inheritance-lessons.md
@@ -48,3 +48,22 @@
   skip a redundant `getWorksheetCell` (mirrors `Sheet.resolveEffectiveStyle`).
   The per-cell range-style scan over the configured source range is inherent
   (same pattern the renderer uses for the viewport).
+
+## Charts: the same bug in a second derived view
+
+- The original report said "표" (table) but the actual surface was **charts**.
+  Every view that re-reads source cells and re-emits values (pivot, chart, and
+  likely export) repeats the "read `cell.v`, drop the format" mistake. When one
+  is reported, check the siblings — `resolveWorksheetCellStyle` + `formatValue`
+  is the shared fix.
+- In charts, the SAME extraction helper fed both **labels** and **numeric
+  values**. Formatting must apply to labels only — a currency/number format on
+  the value column would turn `"100"` into `"$100.00"`/`"1,234"` and break
+  `toNumeric`, silently dropping data points. Split label vs value getters.
+- `formatValue` was internal to the sheets package; the chart fix required
+  exporting it from the package index (it's the canonical formatter the grid
+  and pivot already use internally). Runtime symptom of a missing export is
+  `formatValue is not a function` — the dist simply doesn't re-export it.
+- Frontend vitest only runs `tests/**/*.test.ts` (see `vite.config.ts` →
+  `test.include`); a `*.test.ts` placed under `src/` is NOT executed. Put
+  frontend tests under `packages/frontend/tests/`.

--- a/docs/tasks/active/20260701-pivot-format-inheritance-lessons.md
+++ b/docs/tasks/active/20260701-pivot-format-inheritance-lessons.md
@@ -1,0 +1,50 @@
+# Pivot table format inheritance — lessons
+
+- Cell number/date formats in this codebase are usually stored as a
+  **range-style layer** (`ws.rangeStyles`) or column/row/sheet layer, not on
+  `cell.s`. A grid built from `getWorksheetCell` alone (per-cell style only)
+  cannot see them — resolve the effective style (sheet → col → row → range →
+  cell) when you need the format outside the live `Sheet` instance.
+- `colStyles`/`rowStyles` on the worksheet document are keyed by **index**
+  (`String(col)`), and `rangeStyles` ranges are in index space — so the
+  effective-style merge can be reproduced on the raw document without axis-id
+  mapping.
+- `formatValue` returns the raw value for a falsy/`'plain'` format, so a
+  missing `nf` silently shows the unformatted source value.
+
+- Thread inherited data through the **pure pivot model** as plain data
+  (`PivotCell.format`) and merge it only at `materialize`. This keeps the
+  model testable with a `Grid` whose `cell.s` carries formats, independent of
+  where the frontend actually stores them.
+- Only inherit a label format when the axis has exactly one grouping field —
+  composite "A / B" labels join multiple columns, so no single format applies.
+- Counts (`COUNT`/`COUNTA`) must NOT inherit the source format; the result is
+  a plain integer regardless of whether the source column was currency/date.
+- After cross-package API changes, rebuild the **producer** dist before
+  verifying consumers. A stale `packages/docs/dist` (from an earlier commit)
+  surfaced as a `cli typecheck` error in an unrelated file — rebuilding docs
+  cleared it. Confirm such failures are pre-existing before treating them as
+  your regression. (See [[project_packages_consume_built_dist]].)
+- `pnpm verify:fast` runs `frontend lint`/`test` but no `frontend typecheck`;
+  type-check a frontend-only change explicitly with
+  `npx tsc --noEmit -p packages/frontend/tsconfig.json`.
+
+## Known limitations (from self code review)
+
+- **First-formatted-cell-per-column wins.** `parseSourceData` picks each
+  column's format from the first data cell that carries an `nf`. With the
+  effective-style resolution this is uniform for the common whole-column /
+  range-format case; a column with genuinely *mixed per-cell* formats collapses
+  to the first one. Acceptable — matches how a single column format reads.
+- **Numeric grouping labels render formatted.** Grouping rows by a currency /
+  number column shows formatted group keys (e.g. `$300.00`) — intentional GS /
+  Excel parity, not a bug. Text labels are unaffected (`formatValue` returns
+  non-numeric values unchanged).
+- **Merged source cells.** `resolveWorksheetCellStyle` does not normalize to the
+  merge anchor, so a pivot source over a merged region may read per-cell style
+  only from the anchor. Edge case; pivoting over merged source data is already
+  unusual.
+- **`resolveWorksheetCellStyle` takes an optional pre-fetched `cellStyle`** to
+  skip a redundant `getWorksheetCell` (mirrors `Sheet.resolveEffectiveStyle`).
+  The per-cell range-style scan over the configured source range is inherent
+  (same pattern the renderer uses for the viewport).

--- a/docs/tasks/active/20260701-pivot-format-inheritance-todo.md
+++ b/docs/tasks/active/20260701-pivot-format-inheritance-todo.md
@@ -65,6 +65,25 @@ Both inherit source data formatting into the pivot output:
       merges layers.
 - [x] `pnpm verify:fast` green.
 
+## Follow-up: charts have the same bug
+
+Charts ("차트") render the same way: `getCellDisplayValue` in
+`packages/frontend/src/app/spreadsheet/chart-utils.ts` read only `cell.v`, so
+date/number category labels showed raw values. The Recharts category `XAxis`
+has no `tickFormatter`, so the fix belongs in the extraction layer.
+
+- [x] **chart-utils.ts** — split into `getCellRawValue` (raw, for numeric
+      series values fed to `toNumeric`) and `getCellDisplayValue` (resolves
+      effective style + `formatValue`, for category / pie / series labels).
+- [x] **chart-utils.ts** — labels use the formatted getter; numeric series
+      values use the raw getter (formatted `"$300.00"` would break parsing).
+- [x] **sheets index** — export `formatValue` (the chart path needs it; it was
+      previously internal-only).
+- [x] Tests in `packages/frontend/tests/spreadsheet/chart-utils.test.ts`:
+      labels inherit number/date format; currency-formatted value columns stay
+      numeric (rows not dropped); pie labels formatted + values numeric.
+- [x] `pnpm verify:fast` green.
+
 ## Non-goals
 
 - Field-level format override UI (Excel "Value Field Settings" number format).

--- a/docs/tasks/active/20260701-pivot-format-inheritance-todo.md
+++ b/docs/tasks/active/20260701-pivot-format-inheritance-todo.md
@@ -1,0 +1,97 @@
+# Pivot table format inheritance
+
+## Problem
+
+In the spreadsheet, when a pivot table ("표") is created from source data,
+row/column **labels** and aggregated **value** cells render the raw source
+value instead of the formatted value. The reported symptom: a date column
+with a Locale Date format shows the raw ISO value (e.g. `2026-07-01`) in the
+pivot labels rather than the formatted date.
+
+## Root cause
+
+The pivot pipeline drops the source cell's number format (`CellStyle.nf`,
+`dp`, `cu`) at three points:
+
+1. `packages/sheets/src/model/pivot/parse.ts` reads only `cell.v`; the
+   cell style (including `nf`) is discarded — records become plain strings.
+2. `packages/sheets/src/model/pivot/calculate.ts` builds labels / value
+   cells from those raw strings, carrying no format.
+3. `packages/sheets/src/model/pivot/materialize.ts` hardcodes the output
+   cell style to `{ b: true }` (headers) / no style (values), so no `nf`
+   ever reaches the rendered cell.
+
+At render time `formatValue(value, style?.nf, ...)` (`format.ts`) sees an
+undefined `nf` and returns the raw value (early return for falsy format).
+
+Additionally, formats are usually stored as a **range-style layer**
+(`ws.rangeStyles`) or column/row/sheet layer, NOT per-cell. The frontend
+`buildSourceGrid` (`use-pivot-table.ts`) reads only `cell.s`, so even the
+existing per-cell read would miss layered formats. The source grid must be
+built from the **resolved effective style**.
+
+## Reference behavior (Google Sheets / Excel)
+
+Both inherit source data formatting into the pivot output:
+
+- **Labels**: a date grouping field's labels keep the source column's date
+  format.
+- **Value cells**: SUM / AVERAGE / MIN / MAX inherit the source value
+  column's number/currency format; COUNT / COUNTA stay plain (a count is a
+  plain integer regardless of source format).
+
+## Plan
+
+- [x] Investigate root cause (parse → group → calculate → materialize → render)
+- [x] Confirm where formats are stored (range-style layer, not per-cell)
+- [x] Research GS/Excel reference behavior
+- [x] **types.ts** — add `PivotCellFormat = Pick<CellStyle,'nf'|'dp'|'cu'>`;
+      add optional `format?: PivotCellFormat` to `PivotCell`.
+- [x] **parse.ts** — also return `columnFormats: (PivotCellFormat|undefined)[]`,
+      one per source column, taken from the first data cell with a defined `nf`.
+- [x] **calculate.ts** — attach `format` to:
+      - row/col header labels when the axis has exactly one field
+        (composite "A / B" joins get no format), using that field's column.
+      - value + total cells using the value field's column format, unless the
+        aggregation is COUNT/COUNTA.
+- [x] **materialize.ts** — merge `pivotCell.format` into the output cell style.
+- [x] **worksheet-grid.ts** — export `resolveWorksheetCellStyle(ws, ref)`
+      mirroring `Sheet.resolveEffectiveStyle` (sheet → col → row → range →
+      cell) for a raw worksheet document.
+- [x] **use-pivot-table.ts** — `buildSourceGrid` attaches the resolved
+      effective style to each source cell so layered formats reach the pivot.
+- [x] Unit tests: pivot model carries `nf` to labels + value cells; COUNT
+      stays plain; multi-field axis labels stay plain; `resolveWorksheetCellStyle`
+      merges layers.
+- [x] `pnpm verify:fast` green.
+
+## Non-goals
+
+- Field-level format override UI (Excel "Value Field Settings" number format).
+- Date grouping (Year/Month) — separate feature.
+
+## Review
+
+Implemented across the pivot model + the frontend source-grid builder:
+
+- `PivotCellFormat` + `PivotCell.format` carry an inherited number format
+  through the pure pivot pipeline.
+- `parseSourceData` now returns `columnFormats` (first formatted data cell
+  per source column).
+- `calculatePivot` attaches the format to single-field row/column labels and
+  to value/total cells (skipping COUNT/COUNTA), composite labels stay plain.
+- `materialize` merges the format into the output cell style.
+- `resolveWorksheetCellStyle` (new export) resolves the effective style
+  (sheet → col → row → range → cell) from a raw worksheet document;
+  `buildSourceGrid` uses it so formats stored as range/column layers — the
+  common case — reach the pivot, not just per-cell `cell.s`.
+
+Verification: 32 pivot/effective-style unit tests pass; `pnpm verify:fast`
+green (frontend `tsc --noEmit` clean for the new import). Existing 20 pivot
+tests unchanged.
+
+Why the symptom appeared: commit timestamps (e.g.
+`2026-07-01T09:30:00.000Z`) formatted to date-only via `nf: 'date'` showed
+the full raw timestamp in pivot labels because the format was dropped. With
+the format inherited, labels render date-only again. (Grouping distinct
+timestamps into one date is a separate date-grouping feature — out of scope.)

--- a/packages/frontend/src/app/spreadsheet/chart-utils.ts
+++ b/packages/frontend/src/app/spreadsheet/chart-utils.ts
@@ -1,4 +1,10 @@
-import { getWorksheetCell, parseRef, toSref } from "@wafflebase/sheets";
+import {
+  formatValue,
+  getWorksheetCell,
+  parseRef,
+  resolveWorksheetCellStyle,
+  toSref,
+} from "@wafflebase/sheets";
 import type { SheetChart, SpreadsheetDocument } from "@/types/worksheet";
 export { COLOR_PALETTES, getSeriesColor } from "./chart-colors";
 import { getSeriesColor } from "./chart-colors";
@@ -124,7 +130,9 @@ export function resolveChartColumns(
     columns.push({
       column,
       index: c,
-      label: getCellDisplayValue(sourceSheet, from.r, c) || column,
+      // Header cell = series/column title (an identifier), kept raw so a
+      // numeric-looking header in a formatted column isn't reformatted.
+      label: getCellRawValue(sourceSheet, from.r, c) || column,
     });
   }
 
@@ -217,7 +225,8 @@ export function buildChartDataset(
       continue;
     }
 
-    const label = getCellDisplayValue(sourceSheet, from.r, colIndex) || column;
+    // Header cell = series title (an identifier), kept raw like the axis label.
+    const label = getCellRawValue(sourceSheet, from.r, colIndex) || column;
     const key = `series_${column}`;
     const chartSeries: ChartSeries = { key, label };
     series.push(chartSeries);
@@ -242,7 +251,7 @@ export function buildChartDataset(
     let hasNumericSeries = false;
     for (const seriesInfo of resolvedSeries) {
       const numeric = toNumeric(
-        getCellDisplayValue(sourceSheet, r, seriesInfo.index),
+        getCellRawValue(sourceSheet, r, seriesInfo.index),
       );
       if (numeric !== null) {
         row[seriesInfo.key] = numeric;
@@ -293,7 +302,7 @@ export function buildPieDataset(
   for (let r = from.r + 1; r <= to.r; r++) {
     const label = getCellDisplayValue(sourceSheet, r, labelColIndex);
     const numeric = toNumeric(
-      getCellDisplayValue(sourceSheet, r, valueColIndex),
+      getCellRawValue(sourceSheet, r, valueColIndex),
     );
 
     if (numeric === null || numeric <= 0) {
@@ -310,7 +319,12 @@ export function buildPieDataset(
   return { entries };
 }
 
-function getCellDisplayValue(
+/**
+ * Returns the raw stored cell value as a string. Use this for values fed into
+ * `toNumeric` (series data), which must stay numeric-parseable — a formatted
+ * string like "$300.00" or "1,234" would break parsing in unexpected ways.
+ */
+function getCellRawValue(
   sheet: ChartSourceSheet,
   row: number,
   col: number,
@@ -324,6 +338,30 @@ function getCellDisplayValue(
   }
 
   return String(value);
+}
+
+/**
+ * Returns the formatted display value of a cell, applying the resolved
+ * effective number/date format (sheet/col/row/range/cell layers). Use this for
+ * data labels — axis/category values and pie slice names — so a date column
+ * with a Locale Date format shows the formatted date rather than the raw value.
+ * Non-numeric values (e.g. text labels) pass through `formatValue` unchanged.
+ * (Header cells — series/column titles — use `getCellRawValue` instead.)
+ */
+function getCellDisplayValue(
+  sheet: ChartSourceSheet,
+  row: number,
+  col: number,
+): string {
+  const cell = getWorksheetCell(sheet, { r: row, c: col });
+  const value = cell?.v;
+  if (value === undefined || value === null || value === "") {
+    return "";
+  }
+
+  const raw = typeof value === "string" ? value : String(value);
+  const style = resolveWorksheetCellStyle(sheet, { r: row, c: col }, cell?.s);
+  return formatValue(raw, style?.nf, style?.dp, { currency: style?.cu });
 }
 
 function toNumeric(value: unknown): number | null {

--- a/packages/frontend/src/app/spreadsheet/pivot/use-pivot-table.ts
+++ b/packages/frontend/src/app/spreadsheet/pivot/use-pivot-table.ts
@@ -18,6 +18,7 @@ import {
   parseRange,
   parseRef,
   replaceWorksheetCells,
+  resolveWorksheetCellStyle,
   toSref,
 } from "@wafflebase/sheets";
 import type { SpreadsheetDocument } from "@/types/worksheet";
@@ -148,7 +149,13 @@ export function usePivotTable({ doc, tabId }: UsePivotTableProps) {
             const plain: Cell = {};
             if (cell.v !== undefined) plain.v = cell.v;
             if (cell.f !== undefined) plain.f = cell.f;
-            if (cell.s !== undefined) plain.s = { ...cell.s };
+            // Resolve the effective style (sheet/col/row/range/cell layers) so
+            // number/date formats stored as range or column layers — not just
+            // per-cell — are inherited by pivot labels and value cells. Pass
+            // the already-read `cell.s` to avoid a second cell lookup. The
+            // result is a fresh plain object, detached from the CRDT proxy.
+            const style = resolveWorksheetCellStyle(sourceWs, { r, c }, cell.s);
+            if (style !== undefined) plain.s = style;
             grid.set(sref, plain);
           }
         }

--- a/packages/frontend/tests/spreadsheet/chart-utils.test.ts
+++ b/packages/frontend/tests/spreadsheet/chart-utils.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "vitest";
+import {
+  createWorksheet,
+  formatValue,
+  writeWorksheetCell,
+  type Cell,
+  type CellStyle,
+} from "@wafflebase/sheets";
+import type { SpreadsheetDocument } from "@/types/worksheet";
+import {
+  buildChartDataset,
+  buildPieDataset,
+} from "../../src/app/spreadsheet/chart-utils";
+
+function makeDoc(
+  cells: Array<[{ r: number; c: number }, Cell]>,
+  colStyles?: Record<string, CellStyle>,
+): SpreadsheetDocument {
+  const ws = createWorksheet();
+  for (const [ref, cell] of cells) {
+    writeWorksheetCell(ws, ref, cell);
+  }
+  if (colStyles) {
+    ws.colStyles = colStyles;
+  }
+  return {
+    tabs: { "tab-1": { id: "tab-1", name: "Sheet1", type: "sheet" } },
+    tabOrder: ["tab-1"],
+    sheets: { "tab-1": ws },
+  };
+}
+
+const chart = {
+  sourceTabId: "tab-1",
+  sourceRange: "A1:B3",
+  xAxisColumn: "A",
+  seriesColumns: ["B"],
+};
+
+describe("chart category/label formatting", () => {
+  test("category labels inherit the source column number format", () => {
+    const doc = makeDoc(
+      [
+        [{ r: 1, c: 1 }, { v: "Score" }],
+        [{ r: 2, c: 1 }, { v: "100" }],
+        [{ r: 3, c: 1 }, { v: "200" }],
+        [{ r: 1, c: 2 }, { v: "Count" }],
+        [{ r: 2, c: 2 }, { v: "10" }],
+        [{ r: 3, c: 2 }, { v: "20" }],
+      ],
+      { "1": { nf: "number", dp: 2 } },
+    );
+    const dataset = buildChartDataset(doc, chart);
+    // Label column A is number-formatted → "100.00", not the raw "100".
+    expect(dataset.rows[0].category).toBe("100.00");
+    expect(dataset.rows[1].category).toBe("200.00");
+    // Series values remain numeric.
+    expect(dataset.rows[0].series_B).toBe(10);
+  });
+
+  test("category labels inherit a date format via column style", () => {
+    const doc = makeDoc(
+      [
+        [{ r: 1, c: 1 }, { v: "Date" }],
+        [{ r: 2, c: 1 }, { v: "2026-07-01" }],
+        [{ r: 3, c: 1 }, { v: "2026-07-02" }],
+        [{ r: 1, c: 2 }, { v: "Count" }],
+        [{ r: 2, c: 2 }, { v: "5" }],
+        [{ r: 3, c: 2 }, { v: "8" }],
+      ],
+      { "1": { nf: "date" } },
+    );
+    const dataset = buildChartDataset(doc, chart);
+    // Delegates to formatValue with the resolved date format.
+    expect(dataset.rows[0].category).toBe(
+      formatValue("2026-07-01", "date"),
+    );
+    expect(dataset.rows[0].series_B).toBe(5);
+  });
+
+  test("series values stay numeric when the value column is formatted", () => {
+    // Regression: a currency-formatted VALUE column must not be run through
+    // formatValue, or "$100.00" would fail numeric parsing and drop the row.
+    const doc = makeDoc(
+      [
+        [{ r: 1, c: 1 }, { v: "Region" }],
+        [{ r: 2, c: 1 }, { v: "East" }],
+        [{ r: 3, c: 1 }, { v: "West" }],
+        [{ r: 1, c: 2 }, { v: "Revenue" }],
+        [{ r: 2, c: 2 }, { v: "100" }],
+        [{ r: 3, c: 2 }, { v: "200" }],
+      ],
+      { "2": { nf: "currency", cu: "USD" } },
+    );
+    const dataset = buildChartDataset(doc, chart);
+    expect(dataset.rows).toHaveLength(2);
+    expect(dataset.rows[0]).toMatchObject({ category: "East", series_B: 100 });
+    expect(dataset.rows[1]).toMatchObject({ category: "West", series_B: 200 });
+  });
+
+  test("series/header titles stay raw even in a formatted column", () => {
+    // A numeric-looking header in a number-formatted column must NOT be
+    // reformatted — it's an identifier, not a data label.
+    const doc = makeDoc(
+      [
+        [{ r: 1, c: 1 }, { v: "Region" }],
+        [{ r: 2, c: 1 }, { v: "East" }],
+        [{ r: 3, c: 1 }, { v: "West" }],
+        [{ r: 1, c: 2 }, { v: "2025" }],
+        [{ r: 2, c: 2 }, { v: "100" }],
+        [{ r: 3, c: 2 }, { v: "200" }],
+      ],
+      { "2": { nf: "number", dp: 2 } },
+    );
+    const dataset = buildChartDataset(doc, chart);
+    // Series label is the raw header "2025", not "2,025.00".
+    expect(dataset.series[0].label).toBe("2025");
+    // But the numeric values are still charted.
+    expect(dataset.rows[0].series_B).toBe(100);
+  });
+
+  test("pie labels are formatted while values stay numeric", () => {
+    const doc = makeDoc(
+      [
+        [{ r: 1, c: 1 }, { v: "Date" }],
+        [{ r: 2, c: 1 }, { v: "2026-07-01" }],
+        [{ r: 3, c: 1 }, { v: "2026-07-02" }],
+        [{ r: 1, c: 2 }, { v: "Count" }],
+        [{ r: 2, c: 2 }, { v: "5" }],
+        [{ r: 3, c: 2 }, { v: "8" }],
+      ],
+      { "1": { nf: "date" } },
+    );
+    const pie = buildPieDataset(doc, chart);
+    expect(pie.entries).toHaveLength(2);
+    expect(pie.entries[0]).toMatchObject({
+      name: formatValue("2026-07-01", "date"),
+      value: 5,
+    });
+  });
+});

--- a/packages/sheets/src/index.ts
+++ b/packages/sheets/src/index.ts
@@ -24,6 +24,7 @@ import {
   type GroupNode,
   type PivotCellType,
   type PivotCell,
+  type PivotCellFormat,
   type PivotResult,
   type Ref,
   type Sref,
@@ -134,6 +135,7 @@ import {
   writeWorksheetCell,
   updateWorksheetCell,
   replaceWorksheetCells,
+  resolveWorksheetCellStyle,
 } from './model/workbook/worksheet-grid';
 import {
   safeWorksheetRecordKeys,
@@ -263,6 +265,7 @@ export {
   writeWorksheetCell,
   updateWorksheetCell,
   replaceWorksheetCells,
+  resolveWorksheetCellStyle,
   safeWorksheetRecordKeys,
   safeWorksheetRecordEntries,
   safeWorksheetRecordValues,
@@ -318,6 +321,7 @@ export type {
   GroupNode,
   PivotCellType,
   PivotCell,
+  PivotCellFormat,
   PivotResult,
   Ref,
   Sref,

--- a/packages/sheets/src/index.ts
+++ b/packages/sheets/src/index.ts
@@ -119,7 +119,10 @@ import {
   resolveSystemLocale,
   type LocaleFormatPreview,
 } from './model/core/locale';
-import { type FormatValueOptions } from './model/worksheet/format';
+import {
+  formatValue,
+  type FormatValueOptions,
+} from './model/worksheet/format';
 import {
   inferInput,
   defaultAlign,
@@ -256,6 +259,7 @@ export {
   resolveSystemLocale,
   resolveCurrencyForLocale,
   buildLocaleFormatPreview,
+  formatValue,
   inferInput,
   defaultAlign,
   getWorksheetCell,

--- a/packages/sheets/src/model/core/types.ts
+++ b/packages/sheets/src/model/core/types.ts
@@ -278,11 +278,22 @@ export type PivotCellType =
   | 'empty';
 
 /**
+ * PivotCellFormat is the subset of CellStyle that a pivot cell inherits from
+ * its source column (number format, decimal places, currency code).
+ */
+export type PivotCellFormat = Pick<CellStyle, 'nf' | 'dp' | 'cu'>;
+
+/**
  * PivotCell represents a single cell in the pivot table output.
  */
 export type PivotCell = {
   value: string;
   type: PivotCellType;
+  /**
+   * Format inherited from the source column, applied to the materialized
+   * cell so labels/values render with the source's number/date format.
+   */
+  format?: PivotCellFormat;
 };
 
 /**

--- a/packages/sheets/src/model/pivot/calculate.ts
+++ b/packages/sheets/src/model/pivot/calculate.ts
@@ -3,8 +3,10 @@ import type {
   Grid,
   GroupNode,
   PivotCell,
+  PivotCellFormat,
   PivotResult,
   PivotTableDefinition,
+  PivotValueField,
 } from '../core/types';
 import { parseSourceData } from './parse';
 import { applyFilters, buildGroups } from './group';
@@ -64,7 +66,27 @@ export function calculatePivot(
 ): PivotResult {
   // 1. Parse source range and extract data.
   const range = parseRange(def.sourceRange);
-  const { records } = parseSourceData(sourceGrid, range);
+  const { records, columnFormats } = parseSourceData(sourceGrid, range);
+
+  // Label format is inherited only when an axis has a single grouping field;
+  // composite "A / B" labels join multiple columns and have no single format.
+  const rowFormat =
+    def.rowFields.length === 1
+      ? columnFormats[def.rowFields[0].sourceColumn]
+      : undefined;
+  const colFormat =
+    def.columnFields.length === 1
+      ? columnFormats[def.columnFields[0].sourceColumn]
+      : undefined;
+
+  // Value cells inherit their source column's format, except counts, which are
+  // plain integers regardless of the source format.
+  const valueFormat = (vf: PivotValueField): PivotCellFormat | undefined => {
+    if (vf.aggregation === 'COUNT' || vf.aggregation === 'COUNTA') {
+      return undefined;
+    }
+    return columnFormats[vf.sourceColumn];
+  };
 
   // 2. Apply filters.
   const filtered = applyFilters(records, def.filterFields);
@@ -113,7 +135,11 @@ export function calculatePivot(
       // Single value field with columns: column header shows group value.
       const headerRow: PivotCell[] = [{ value: '', type: 'empty' }];
       for (const colLeaf of colLeaves) {
-        headerRow.push({ value: colLeaf.label, type: 'colHeader' });
+        headerRow.push({
+          value: colLeaf.label,
+          type: 'colHeader',
+          format: colFormat,
+        });
       }
       if (def.showTotals.columns) {
         headerRow.push({ value: 'Grand Total', type: 'colHeader' });
@@ -135,7 +161,7 @@ export function calculatePivot(
   // 6. Build data rows.
   for (const rowLeaf of rowLeaves) {
     const dataRow: PivotCell[] = [
-      { value: rowLeaf.label, type: 'rowHeader' },
+      { value: rowLeaf.label, type: 'rowHeader', format: rowFormat },
     ];
 
     if (hasColumns) {
@@ -149,12 +175,14 @@ export function calculatePivot(
             dataRow.push({
               value: aggregateValues(filtered, intersection, vf),
               type: 'value',
+              format: valueFormat(vf),
             });
           }
         } else {
           dataRow.push({
             value: aggregateValues(filtered, intersection, valueFields[0]),
             type: 'value',
+            format: valueFormat(valueFields[0]),
           });
         }
       }
@@ -166,12 +194,14 @@ export function calculatePivot(
             dataRow.push({
               value: aggregateValues(filtered, rowLeaf.indices, vf),
               type: 'total',
+              format: valueFormat(vf),
             });
           }
         } else {
           dataRow.push({
             value: aggregateValues(filtered, rowLeaf.indices, valueFields[0]),
             type: 'total',
+            format: valueFormat(valueFields[0]),
           });
         }
       }
@@ -181,6 +211,7 @@ export function calculatePivot(
         dataRow.push({
           value: aggregateValues(filtered, rowLeaf.indices, vf),
           type: 'value',
+          format: valueFormat(vf),
         });
       }
     }
@@ -202,6 +233,7 @@ export function calculatePivot(
             totalRow.push({
               value: aggregateValues(filtered, colLeaf.indices, vf),
               type: 'total',
+              format: valueFormat(vf),
             });
           }
         } else {
@@ -212,6 +244,7 @@ export function calculatePivot(
               valueFields[0],
             ),
             type: 'total',
+            format: valueFormat(valueFields[0]),
           });
         }
       }
@@ -223,6 +256,7 @@ export function calculatePivot(
             totalRow.push({
               value: aggregateValues(filtered, allRowIndices, vf),
               type: 'total',
+              format: valueFormat(vf),
             });
           }
         } else {
@@ -233,6 +267,7 @@ export function calculatePivot(
               valueFields[0],
             ),
             type: 'total',
+            format: valueFormat(valueFields[0]),
           });
         }
       }
@@ -241,6 +276,7 @@ export function calculatePivot(
         totalRow.push({
           value: aggregateValues(filtered, allRowIndices, vf),
           type: 'total',
+          format: valueFormat(vf),
         });
       }
     }

--- a/packages/sheets/src/model/pivot/materialize.ts
+++ b/packages/sheets/src/model/pivot/materialize.ts
@@ -4,9 +4,11 @@ import type { Cell, Grid, PivotResult } from '../core/types';
 /**
  * `materialize` converts a PivotResult into a Grid (Map<Sref, Cell>).
  *
- * - rowHeader / colHeader / empty cells get bold styling.
- * - total cells get bold styling.
- * - value cells are plain (no styling); empty value cells are skipped.
+ * - rowHeader / colHeader / empty / total cells get bold styling.
+ * - value cells are plain unless they carry an inherited format.
+ * - cells with an inherited source format (`pivotCell.format`) merge it into
+ *   the style so labels/values render with the source's number/date format.
+ * - empty value cells are skipped.
  *
  * Grid positions are 1-based: cells[r][c] maps to {r: r+1, c: c+1}.
  */
@@ -24,14 +26,14 @@ export function materialize(result: PivotResult): Grid {
         case 'rowHeader':
         case 'colHeader':
         case 'empty':
-          cell = { v: pivotCell.value, s: { b: true } };
-          break;
         case 'total':
-          cell = { v: pivotCell.value, s: { b: true } };
+          cell = { v: pivotCell.value, s: { b: true, ...pivotCell.format } };
           break;
         case 'value':
           if (pivotCell.value !== '') {
-            cell = { v: pivotCell.value };
+            cell = pivotCell.format
+              ? { v: pivotCell.value, s: { ...pivotCell.format } }
+              : { v: pivotCell.value };
           }
           break;
       }

--- a/packages/sheets/src/model/pivot/parse.ts
+++ b/packages/sheets/src/model/pivot/parse.ts
@@ -1,19 +1,54 @@
 import { toSref } from '../core/coordinates';
-import type { Grid, PivotRecord, Range } from '../core/types';
+import type {
+  CellStyle,
+  Grid,
+  PivotCellFormat,
+  PivotRecord,
+  Range,
+} from '../core/types';
 
 /**
- * `parseSourceData` extracts headers and records from a grid within the given range.
+ * Extract the format-only subset of a cell style, or undefined when the cell
+ * has no number format applied.
+ */
+function extractFormat(style?: CellStyle): PivotCellFormat | undefined {
+  if (!style || !style.nf) {
+    return undefined;
+  }
+  const format: PivotCellFormat = { nf: style.nf };
+  if (style.dp !== undefined) format.dp = style.dp;
+  if (style.cu !== undefined) format.cu = style.cu;
+  return format;
+}
+
+/**
+ * `parseSourceData` extracts headers, records, and per-column formats from a
+ * grid within the given range.
  *
  * - The first row of the range is treated as headers.
  * - Remaining rows become records (arrays of string values).
  * - Empty cells are represented as ''.
  * - Trailing rows where all values are '' are trimmed.
+ * - `columnFormats[i]` is the number format of source column `i`, taken from
+ *   the first data cell in that column that carries one (so a date/currency
+ *   column's format can be inherited by pivot labels and values). The grid's
+ *   cell styles are expected to be the resolved effective styles (including
+ *   range/row/column layers), built by the caller.
  */
 export function parseSourceData(
   grid: Grid,
   range: Range,
-): { headers: string[]; records: PivotRecord[] } {
+): {
+  headers: string[];
+  records: PivotRecord[];
+  columnFormats: (PivotCellFormat | undefined)[];
+} {
   const [from, to] = range;
+
+  const colCount = to.c - from.c + 1;
+  const columnFormats: (PivotCellFormat | undefined)[] = new Array(
+    colCount,
+  ).fill(undefined);
 
   // Extract headers from the first row of the range.
   const headers: string[] = [];
@@ -29,6 +64,12 @@ export function parseSourceData(
     for (let c = from.c; c <= to.c; c++) {
       const cell = grid.get(toSref({ r, c }));
       row.push(cell?.v ?? '');
+
+      // Capture the first defined format per column from its data cells.
+      const ci = c - from.c;
+      if (columnFormats[ci] === undefined) {
+        columnFormats[ci] = extractFormat(cell?.s);
+      }
     }
     records.push(row);
   }
@@ -43,5 +84,5 @@ export function parseSourceData(
     }
   }
 
-  return { headers, records };
+  return { headers, records, columnFormats };
 }

--- a/packages/sheets/src/model/workbook/worksheet-grid.ts
+++ b/packages/sheets/src/model/workbook/worksheet-grid.ts
@@ -1,5 +1,7 @@
 import { toSref } from '../core/coordinates';
-import type { Axis, Cell, Ref, Sref } from '../core/types';
+import type { Axis, Cell, CellStyle, Ref, Sref } from '../core/types';
+import { resolveRangeStyleAt } from '../worksheet/range-styles';
+import type { RangeStylePatch } from '../worksheet/range-styles';
 import {
   createWorksheetAxisId,
   createWorksheetCellKey,
@@ -8,6 +10,17 @@ import {
   safeWorksheetRecordKeys,
   type WorksheetGridShape,
 } from './worksheet-record';
+
+/**
+ * WorksheetStyleShape augments the grid shape with the style layers stored on
+ * a worksheet document (keyed by index, mirroring `Sheet`'s in-memory maps).
+ */
+export type WorksheetStyleShape = WorksheetGridShape & {
+  sheetStyle?: CellStyle;
+  colStyles?: Record<string, CellStyle>;
+  rowStyles?: Record<string, CellStyle>;
+  rangeStyles?: RangeStylePatch[];
+};
 
 function ensureAxisLength(
   ws: WorksheetGridShape,
@@ -51,6 +64,38 @@ export function getWorksheetCell(
     return undefined;
   }
   return ws.cells?.[createWorksheetCellKey(rowId, colId)];
+}
+
+/**
+ * `resolveWorksheetCellStyle` computes the effective style of a cell from a raw
+ * worksheet document, merging sheet → column → row → range → cell layers (later
+ * layers win), mirroring `Sheet.resolveEffectiveStyle`.
+ *
+ * Use this when you need a cell's resolved format outside the live `Sheet`
+ * instance — e.g. building a source grid for a pivot table from a different
+ * tab, where number formats often live in `rangeStyles`/`colStyles` rather
+ * than on `cell.s`.
+ *
+ * Pass `cellStyle` when the caller has already read the cell (e.g. in a grid
+ * build loop) to skip a redundant `getWorksheetCell` lookup, matching
+ * `Sheet.resolveEffectiveStyle(row, col, cellStyle)`.
+ */
+export function resolveWorksheetCellStyle(
+  ws: WorksheetStyleShape,
+  ref: Ref,
+  cellStyle?: CellStyle,
+): CellStyle | undefined {
+  const cell = cellStyle ?? getWorksheetCell(ws, ref)?.s;
+  const sheetStyle = ws.sheetStyle;
+  const colStyle = ws.colStyles?.[String(ref.c)];
+  const rowStyle = ws.rowStyles?.[String(ref.r)];
+  const rangeStyle = ws.rangeStyles
+    ? resolveRangeStyleAt(ws.rangeStyles, ref.r, ref.c)
+    : undefined;
+  if (!sheetStyle && !colStyle && !rowStyle && !rangeStyle && !cell) {
+    return undefined;
+  }
+  return { ...sheetStyle, ...colStyle, ...rowStyle, ...rangeStyle, ...cell };
 }
 
 function setWorksheetGridCell(

--- a/packages/sheets/test/model/worksheet-effective-style.test.ts
+++ b/packages/sheets/test/model/worksheet-effective-style.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveWorksheetCellStyle,
+  writeWorksheetCell,
+} from '../../src/model/workbook/worksheet-grid';
+import { createWorksheet } from '../../src/model/workbook/worksheet-document';
+
+describe('resolveWorksheetCellStyle', () => {
+  it('returns undefined when no layer applies', () => {
+    const ws = createWorksheet();
+    writeWorksheetCell(ws, { r: 1, c: 1 }, { v: 'x' });
+    expect(resolveWorksheetCellStyle(ws, { r: 1, c: 1 })).toBeUndefined();
+  });
+
+  it('resolves a format stored as a column-level style', () => {
+    const ws = createWorksheet();
+    writeWorksheetCell(ws, { r: 2, c: 1 }, { v: '2026-07-01' });
+    ws.colStyles['1'] = { nf: 'date' };
+    expect(resolveWorksheetCellStyle(ws, { r: 2, c: 1 })).toMatchObject({
+      nf: 'date',
+    });
+  });
+
+  it('resolves a format stored as a range-style layer', () => {
+    const ws = createWorksheet();
+    writeWorksheetCell(ws, { r: 2, c: 1 }, { v: '2026-07-01' });
+    ws.rangeStyles = [
+      { range: [{ r: 2, c: 1 }, { r: 5, c: 1 }], style: { nf: 'date' } },
+    ];
+    expect(resolveWorksheetCellStyle(ws, { r: 2, c: 1 })).toMatchObject({
+      nf: 'date',
+    });
+    // Outside the patched range, no format resolves.
+    writeWorksheetCell(ws, { r: 9, c: 1 }, { v: 'x' });
+    expect(resolveWorksheetCellStyle(ws, { r: 9, c: 1 })).toBeUndefined();
+  });
+
+  it('uses a passed cellStyle without re-reading the cell', () => {
+    const ws = createWorksheet();
+    // No cell written at (2,1); the column carries the format.
+    ws.colStyles['1'] = { nf: 'date' };
+    // Caller passes the already-read per-cell style explicitly.
+    expect(
+      resolveWorksheetCellStyle(ws, { r: 2, c: 1 }, { b: true }),
+    ).toEqual({ nf: 'date', b: true });
+  });
+
+  it('merges layers with later layers winning (cell over range)', () => {
+    const ws = createWorksheet();
+    writeWorksheetCell(ws, { r: 2, c: 1 }, { v: '100', s: { nf: 'currency' } });
+    ws.rangeStyles = [
+      { range: [{ r: 1, c: 1 }, { r: 9, c: 1 }], style: { nf: 'number' } },
+    ];
+    ws.sheetStyle = { b: true };
+    const resolved = resolveWorksheetCellStyle(ws, { r: 2, c: 1 });
+    // sheet style contributes bold; cell style overrides the range's nf.
+    expect(resolved).toEqual({ b: true, nf: 'currency' });
+  });
+});

--- a/packages/sheets/test/sheet/pivot-calculate.test.ts
+++ b/packages/sheets/test/sheet/pivot-calculate.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { calculatePivot } from '../../src/model/pivot/calculate';
-import type { Grid, PivotTableDefinition } from '../../src/model/core/types';
+import type {
+  Cell,
+  Grid,
+  PivotTableDefinition,
+} from '../../src/model/core/types';
 import { toSref } from '../../src/model/core/coordinates';
 
 function buildGrid(data: string[][]): Grid {
@@ -93,5 +97,119 @@ describe('calculatePivot', () => {
     expect(result.cells[0][2].value).toBe('COUNT of Revenue');
     expect(result.cells[1][1].value).toBe('250');
     expect(result.cells[1][2].value).toBe('2');
+  });
+});
+
+describe('calculatePivot format inheritance', () => {
+  // Date row field (col 0, formatted), currency value field (col 2, formatted).
+  const styledGrid: Grid = new Map();
+  const rows: Array<[string, string, string]> = [
+    ['Date', 'Region', 'Amount'],
+    ['2026-07-01', 'East', '100'],
+    ['2026-07-01', 'West', '200'],
+    ['2026-07-02', 'East', '150'],
+  ];
+  for (let r = 0; r < rows.length; r++) {
+    const styleFor = (c: number): Cell['s'] => {
+      if (r === 0) return undefined; // headers unformatted
+      if (c === 0) return { nf: 'date' };
+      if (c === 2) return { nf: 'currency', cu: 'USD' };
+      return undefined;
+    };
+    for (let c = 0; c < rows[r].length; c++) {
+      const s = styleFor(c);
+      styledGrid.set(
+        toSref({ r: r + 1, c: c + 1 }),
+        s ? { v: rows[r][c], s } : { v: rows[r][c] },
+      );
+    }
+  }
+
+  it('inherits the source date format on single row-field labels', () => {
+    const def: PivotTableDefinition = {
+      id: 'f1', sourceTabId: 'tab-1', sourceRange: 'A1:C4',
+      rowFields: [{ sourceColumn: 0, label: 'Date' }],
+      columnFields: [],
+      valueFields: [{ sourceColumn: 2, label: 'Amount', aggregation: 'SUM' }],
+      filterFields: [],
+      showTotals: { rows: false, columns: false },
+    };
+    const result = calculatePivot(styledGrid, def);
+    // Row 0 is the header row; data rows start at index 1.
+    expect(result.cells[1][0]).toMatchObject({
+      value: '2026-07-01',
+      type: 'rowHeader',
+      format: { nf: 'date' },
+    });
+    expect(result.cells[2][0].format).toEqual({ nf: 'date' });
+  });
+
+  it('inherits the source currency format on SUM value cells', () => {
+    const def: PivotTableDefinition = {
+      id: 'f2', sourceTabId: 'tab-1', sourceRange: 'A1:C4',
+      rowFields: [{ sourceColumn: 0, label: 'Date' }],
+      columnFields: [],
+      valueFields: [{ sourceColumn: 2, label: 'Amount', aggregation: 'SUM' }],
+      filterFields: [],
+      showTotals: { rows: true, columns: false },
+    };
+    const result = calculatePivot(styledGrid, def);
+    expect(result.cells[1][1]).toMatchObject({
+      type: 'value',
+      format: { nf: 'currency', cu: 'USD' },
+    });
+    // Grand total row inherits the value format too.
+    const totalRow = result.cells[result.cells.length - 1];
+    expect(totalRow[0].value).toBe('Grand Total');
+    expect(totalRow[1].format).toEqual({ nf: 'currency', cu: 'USD' });
+  });
+
+  it('keeps COUNT value cells plain (no inherited format)', () => {
+    const def: PivotTableDefinition = {
+      id: 'f3', sourceTabId: 'tab-1', sourceRange: 'A1:C4',
+      rowFields: [{ sourceColumn: 0, label: 'Date' }],
+      columnFields: [],
+      valueFields: [{ sourceColumn: 2, label: 'Amount', aggregation: 'COUNT' }],
+      filterFields: [],
+      showTotals: { rows: false, columns: false },
+    };
+    const result = calculatePivot(styledGrid, def);
+    expect(result.cells[1][1].type).toBe('value');
+    expect(result.cells[1][1].format).toBeUndefined();
+  });
+
+  it('does not format composite labels from multiple row fields', () => {
+    const def: PivotTableDefinition = {
+      id: 'f4', sourceTabId: 'tab-1', sourceRange: 'A1:C4',
+      rowFields: [
+        { sourceColumn: 0, label: 'Date' },
+        { sourceColumn: 1, label: 'Region' },
+      ],
+      columnFields: [],
+      valueFields: [{ sourceColumn: 2, label: 'Amount', aggregation: 'SUM' }],
+      filterFields: [],
+      showTotals: { rows: false, columns: false },
+    };
+    const result = calculatePivot(styledGrid, def);
+    // Composite "2026-07-01 / East" label must not carry a date format.
+    expect(result.cells[1][0].value).toContain(' / ');
+    expect(result.cells[1][0].format).toBeUndefined();
+  });
+
+  it('inherits the date format on single column-field headers', () => {
+    const def: PivotTableDefinition = {
+      id: 'f5', sourceTabId: 'tab-1', sourceRange: 'A1:C4',
+      rowFields: [{ sourceColumn: 1, label: 'Region' }],
+      columnFields: [{ sourceColumn: 0, label: 'Date' }],
+      valueFields: [{ sourceColumn: 2, label: 'Amount', aggregation: 'SUM' }],
+      filterFields: [],
+      showTotals: { rows: false, columns: false },
+    };
+    const result = calculatePivot(styledGrid, def);
+    // Header row, first column is the empty corner; col headers follow.
+    expect(result.cells[0][1]).toMatchObject({
+      type: 'colHeader',
+      format: { nf: 'date' },
+    });
   });
 });

--- a/packages/sheets/test/sheet/pivot-materialize.test.ts
+++ b/packages/sheets/test/sheet/pivot-materialize.test.ts
@@ -53,6 +53,34 @@ describe('materialize', () => {
     expect(cell?.s).toEqual({ b: true });
   });
 
+  it('merges inherited format into header and value cell styles', () => {
+    const result: PivotResult = {
+      cells: [
+        [
+          { value: '2026-07-01', type: 'rowHeader', format: { nf: 'date' } },
+          {
+            value: '100',
+            type: 'value',
+            format: { nf: 'currency', cu: 'USD' },
+          },
+        ],
+      ],
+      rowCount: 1,
+      colCount: 2,
+    };
+    const grid = materialize(result);
+    // Header keeps bold and gains the date format.
+    expect(grid.get(toSref({ r: 1, c: 1 }))).toEqual({
+      v: '2026-07-01',
+      s: { b: true, nf: 'date' },
+    });
+    // Value cell (no bold) gains the currency format.
+    expect(grid.get(toSref({ r: 1, c: 2 }))).toEqual({
+      v: '100',
+      s: { nf: 'currency', cu: 'USD' },
+    });
+  });
+
   it('skips value cells with empty value', () => {
     const result: PivotResult = {
       cells: [

--- a/packages/sheets/test/sheet/pivot-parse.test.ts
+++ b/packages/sheets/test/sheet/pivot-parse.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { parseSourceData } from '../../src/model/pivot/parse';
-import type { Grid, Range } from '../../src/model/core/types';
+import type { Cell, Grid, Range } from '../../src/model/core/types';
 import { toSref } from '../../src/model/core/coordinates';
 
 function buildGrid(data: string[][]): Grid {
@@ -48,5 +48,35 @@ describe('parseSourceData', () => {
     const { headers, records } = parseSourceData(grid, range);
     expect(headers).toEqual(['A', 'B']);
     expect(records).toEqual([]);
+  });
+
+  it('extracts per-column number formats from data cells', () => {
+    const grid: Grid = new Map();
+    const set = (r: number, c: number, cell: Cell) =>
+      grid.set(toSref({ r, c }), cell);
+    // Headers (no format).
+    set(1, 1, { v: 'Date' });
+    set(1, 2, { v: 'Amount' });
+    set(1, 3, { v: 'Name' });
+    // Data: date column, currency column, plain text column.
+    set(2, 1, { v: '2026-07-01', s: { nf: 'date' } });
+    set(2, 2, { v: '100', s: { nf: 'currency', cu: 'USD', dp: 2 } });
+    set(2, 3, { v: 'Alice' });
+    const range: Range = [{ r: 1, c: 1 }, { r: 2, c: 3 }];
+    const { columnFormats } = parseSourceData(grid, range);
+    expect(columnFormats[0]).toEqual({ nf: 'date' });
+    expect(columnFormats[1]).toEqual({ nf: 'currency', cu: 'USD', dp: 2 });
+    expect(columnFormats[2]).toBeUndefined();
+  });
+
+  it('uses the first data cell that carries a format per column', () => {
+    const grid: Grid = new Map();
+    grid.set(toSref({ r: 1, c: 1 }), { v: 'Date' });
+    // First data cell has no format; second one does.
+    grid.set(toSref({ r: 2, c: 1 }), { v: '2026-07-01' });
+    grid.set(toSref({ r: 3, c: 1 }), { v: '2026-07-02', s: { nf: 'date' } });
+    const range: Range = [{ r: 1, c: 1 }, { r: 3, c: 1 }];
+    const { columnFormats } = parseSourceData(grid, range);
+    expect(columnFormats[0]).toEqual({ nf: 'date' });
   });
 });


### PR DESCRIPTION
## Summary

Pivot tables and charts rendered the **raw** source value for labels instead of the cell's formatted value — a date column with a Locale Date format showed the raw ISO value (e.g. a commit timestamp) in pivot row/column labels and in chart axis/category labels. Both views re-read source cells and dropped the number/date format.

This matches Google Sheets / Excel behavior, which inherit source data formatting into derived views.

### Pivot tables (`packages/sheets/src/model/pivot/*`)
- New `PivotCellFormat` + `PivotCell.format`; the format flows through the pure pivot model.
- `parseSourceData` extracts a per-column format; `calculatePivot` attaches it to single-field row/column labels and to value/total cells (skipping COUNT/COUNTA); `materialize` merges it into the output cell style.
- Composite multi-field labels (`"A / B"`) stay plain.

### Charts (`packages/frontend/src/app/spreadsheet/chart-utils.ts`)
- Split extraction into `getCellDisplayValue` (resolves effective style + `formatValue`, for **data labels**: category / pie slice) and `getCellRawValue` (raw, for **numeric series values** parsed by `toNumeric`).
- Header cells (series/column titles) stay raw so a numeric-looking header isn't reformatted.

### Shared
- New `resolveWorksheetCellStyle(ws, ref, cellStyle?)` merges the effective style (sheet → col → row → range → cell) from a raw worksheet document — needed because formats are usually stored as a **range/column style layer**, not on `cell.s`. `buildSourceGrid` uses it.
- Export `formatValue` and `resolveWorksheetCellStyle` from `@wafflebase/sheets`.

## Test plan
- New unit tests: pivot format inheritance (labels + values, COUNT stays plain, composite labels plain, single column-field headers), `resolveWorksheetCellStyle` layer merge, and chart label formatting (number/date labels, currency-formatted value columns stay numeric, pie labels formatted, headers stay raw).
- `pnpm verify:self` green (lint, all package tests, typechecks, builds, entropy/doc-ref check).
- Manual smoke test in `pnpm dev` on the reported document (charts + pivot).

Self-reviewed at high effort; findings that were correct spreadsheet behavior (numeric group labels, AVERAGE display rounding) are noted as known limitations; the one real regression (header reformatting) was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart labels, axis/category names, and pie slice names now use cell display formatting, while numeric chart values stay numeric for plotting.
  * Pivot tables now preserve source number/date/currency formatting in labels, values, and totals where appropriate.

* **Bug Fixes**
  * Fixed cases where formatted source cells were shown or parsed incorrectly in charts and pivot tables.
  * Improved style resolution so inherited worksheet formatting is applied consistently across grid-derived views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->