### PR TITLE
Fix intermittent black slides canvas on sidebar toggle

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides canvas black on resize (2026-07-02) | [20260702-slides-canvas-black-on-resize-todo.md](./active/20260702-slides-canvas-black-on-resize-todo.md) | [20260702-slides-canvas-black-on-resize-lessons.md](./active/20260702-slides-canvas-black-on-resize-lessons.md) |
 | pivot format inheritance (2026-07-01) | [20260701-pivot-format-inheritance-todo.md](./active/20260701-pivot-format-inheritance-todo.md) | [20260701-pivot-format-inheritance-lessons.md](./active/20260701-pivot-format-inheritance-lessons.md) |
 | docs collaboration convergence (2026-06-25) | [20260625-docs-collaboration-convergence-todo.md](./active/20260625-docs-collaboration-convergence-todo.md) | [20260625-docs-collaboration-convergence-lessons.md](./active/20260625-docs-collaboration-convergence-lessons.md) |
 | docs wordprocessor (2026-03-25) | [20260325-docs-wordprocessor-todo.md](./active/20260325-docs-wordprocessor-todo.md) | [20260325-docs-wordprocessor-lessons.md](./active/20260325-docs-wordprocessor-lessons.md) |
@@ -27,4 +28,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 330
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: pivot format inheritance (2026-07-01)
+Latest active task: slides canvas black on resize (2026-07-02)

--- a/docs/tasks/active/20260702-slides-canvas-black-on-resize-lessons.md
+++ b/docs/tasks/active/20260702-slides-canvas-black-on-resize-lessons.md
@@ -1,0 +1,44 @@
+# Lessons — slides canvas black on sidebar toggle
+
+## Bug shape: unconditional clear + conditional redraw
+
+The class of bug: a destructive operation (reassigning `canvas.width`
+clears the backing store) paired with a redraw that is delegated to
+change-detecting setters. When the setters' inputs don't change they
+early-return without repainting, so the cleared surface is never
+redrawn. Whenever you clear a canvas, the repaint after it must be
+unconditional (or gated on "did I clear?", not on "did some unrelated
+input change?").
+
+## Why the fix is surgical, not a blanket repaint
+
+A blanket `markDirty(); render()` after every refit would double-paint
+on host-change frames (setHostSize already repaints them). The predicate
+`canvasChanged && !hostChanged && !offsetChanged` fires on exactly the
+frame where neither setter repaints — single paint in all cases, no perf
+regression during the 200ms sidebar transition (which drives many
+ResizeObserver frames).
+
+## Known test-coverage gap (accepted)
+
+The load-bearing logic is the call-site wiring in `refitCanvas`
+(slides-view.tsx): capturing `offsetChanged` *before* the offset
+reassignment, and the `!sameCanvas`/`!sameSlide` mapping. That closure
+is not cheaply unit-testable — it captures ~10 mutable outer bindings and
+many DOM refs, and jsdom returns `null` from `canvas.getContext('2d')`
+(the frontend test env has no `test-canvas-env` shim, unlike the slides
+package). Mounting the full `SlidesView` would need a Yorkie doc + canvas
+context stub — disproportionate to the fix.
+
+We extracted the non-obvious repaint condition into a documented,
+unit-tested predicate (`needsForcedRepaintAfterRefit`). The predicate
+test locks the intent; the call-site wiring is verified by manual smoke
+(Fit zoom + repeated sidebar toggle). If this closure is ever refactored,
+that is the moment to add a jsdom `refitCanvas` test with a mock editor.
+
+## Latent follow-up (out of scope)
+
+`dpr` is captured once at mount (slides-view.tsx `window.devicePixelRatio`)
+and never re-read, so the host bitmap scale can diverge from the engine's
+`options.dpr` when a window moves between monitors of different DPR.
+Untouched here; worth a separate task.

--- a/docs/tasks/active/20260702-slides-canvas-black-on-resize-todo.md
+++ b/docs/tasks/active/20260702-slides-canvas-black-on-resize-todo.md
@@ -1,0 +1,80 @@
+# Slides canvas goes black on global sidebar toggle
+
+## Problem
+
+Toggling the global app sidebar intermittently leaves the slides editor
+canvas fully black (blank) until an unrelated event repaints it.
+
+## Root cause (verified by reading the code)
+
+`refitCanvas` in `packages/frontend/src/app/slides/slides-view.tsx`
+(707–842):
+
+- **Guard (809):** `if (sameSlide && sameCanvas) return;` — only skips
+  when both the fitted-slide size AND the pasteboard-canvas size are
+  unchanged.
+- **Unconditional clear (816–817):** assigning `canvas.width` /
+  `canvas.height` resets the backing store to transparent every time we
+  pass the guard.
+- **Conditional redraw (830, 832):** the redraw after the clear is
+  delegated to `editor.setHostSize` and `editor.setSlideOffset`
+  (`packages/slides/src/view/editor/editor.ts:1452`, `1466`), each of
+  which **early-returns without `markDirty()`** when its inputs are
+  unchanged.
+
+Failure combo: `sameSlide === true` (fitted slide size unchanged — common
+at Fit zoom when height-constrained or `MAX_HOST_W`-clamped) while
+`sameCanvas === false` (pasteboard width changed). Then the bitmap is
+cleared, `setHostSize` early-returns (host unchanged), and `setSlideOffset`
+also early-returns when the centered offset happens to be unchanged
+(`Math.floor` absorbs small deltas). Nobody calls `markDirty()`, so the
+rAF `tick()` (1055–1068) no-ops and the cleared canvas stays black.
+
+The 200ms sidebar width CSS transition fires the `ResizeObserver`
+(848–849) many times; whether the settle frame lands on the
+host-invariant + offset-invariant combo determines whether it goes black —
+hence "intermittent".
+
+## Fix
+
+Force exactly one repaint after the destructive resize **only** on the
+frame where nothing else repaints: canvas size changed, but host size and
+offset both unchanged. Single paint in every case (no double-paint on
+host-change frames, no perf regression), fixes the blank-canvas frame.
+
+Extract the non-obvious condition into a named, documented, tested
+predicate `needsForcedRepaintAfterRefit`.
+
+## Tasks
+
+- [x] Add `refit-repaint.ts` helper with `needsForcedRepaintAfterRefit`
+- [x] Wire it into `refitCanvas` (compute the 3 change flags before the
+      offset reassignment; force repaint when the predicate is true)
+- [x] Unit test the predicate incl. the exact bug case (failing-first)
+- [x] `pnpm verify:fast`
+- [ ] Manual smoke in `pnpm dev`: Fit zoom + toggle sidebar repeatedly
+- [x] Self review over branch diff (code-reviewer subagent)
+- [ ] PR
+
+## Review
+
+Code-reviewer subagent verdict: **merge with (non-blocking) fixes**. No
+Critical/Important correctness issues. Confirmed:
+
+- Predicate fires on exactly the frames where both `setHostSize` and
+  `setSlideOffset` no-op → single paint, no double-paint, no perf
+  regression during the sidebar transition.
+- `offsetChanged` captured before the offset reassignment (correct).
+- CSS↔logical offset equivalence holds because the forced repaint is
+  skipped when the host is unchanged (scale invariant).
+- `markDirty()` + `render()` matches the existing store-change path.
+
+Applied from review:
+- Added the CSS↔logical equivalence rationale as a comment at the
+  `setSlideOffset` call site.
+- Documented the call-site test-coverage gap in the lessons file (the
+  `refitCanvas` closure is not cheaply unit-testable; predicate is
+  extracted + tested, wiring verified by manual smoke).
+
+Latent follow-up (out of scope): `dpr` captured once at mount can diverge
+from the engine's `options.dpr` across monitors — separate task.

--- a/packages/frontend/src/app/slides/refit-repaint.ts
+++ b/packages/frontend/src/app/slides/refit-repaint.ts
@@ -1,0 +1,39 @@
+/**
+ * Repaint decision for the slides canvas after a viewport refit.
+ *
+ * `refitCanvas` reassigns `canvas.width` / `canvas.height` on every size
+ * change, which resets the backing store to transparent (the "black
+ * slide" symptom). The redraw after that clear is delegated to
+ * `editor.setHostSize` and `editor.setSlideOffset`, each of which
+ * early-returns without repainting when its own inputs are unchanged.
+ *
+ * There is exactly one frame where the bitmap is wiped yet neither
+ * setter repaints it: the pasteboard-canvas size changed while the
+ * fitted-slide (host) size AND the slide offset both stayed the same —
+ * common at Fit zoom when the slide is height-constrained or
+ * `MAX_HOST_W`-clamped, so a right-pane resize (e.g. the global sidebar
+ * collapsing) shifts only the surrounding pasteboard band. On that frame
+ * the caller must force a repaint itself, otherwise the cleared canvas
+ * stays black until an unrelated event re-dirties the renderer.
+ */
+export interface RefitChangeFlags {
+  /** The canvas backing-store size changed (so the bitmap was cleared). */
+  canvasChanged: boolean;
+  /** The fitted-slide (host) size changed (so `setHostSize` repainted). */
+  hostChanged: boolean;
+  /** The centered slide offset changed (so `setSlideOffset` repainted). */
+  offsetChanged: boolean;
+}
+
+/**
+ * True when the refit cleared the backing store but neither the host
+ * size nor the offset changed — the only case where `setHostSize` /
+ * `setSlideOffset` both no-op and the caller must repaint explicitly.
+ */
+export function needsForcedRepaintAfterRefit({
+  canvasChanged,
+  hostChanged,
+  offsetChanged,
+}: RefitChangeFlags): boolean {
+  return canvasChanged && !hostChanged && !offsetChanged;
+}

--- a/packages/frontend/src/app/slides/slides-view.tsx
+++ b/packages/frontend/src/app/slides/slides-view.tsx
@@ -26,6 +26,7 @@ import { YorkieSlidesStore, ensureSlidesRoot } from "./yorkie-slides-store";
 import { setupSlidesImagePaths } from "./slides-image-input";
 import { mapPresenceToPeerView } from "./peer-view";
 import { FIT_ZOOM, type ZoomController } from "./zoom-controller";
+import { needsForcedRepaintAfterRefit } from "./refit-repaint";
 import { useGoogleFontsLink } from "@/components/text-formatting/font-catalog";
 
 export type { SlidesEditor } from "@wafflebase/slides";
@@ -798,6 +799,11 @@ export function SlidesView({
       const sameSlide = nextW === hostW && nextH === hostH;
       const sameCanvas =
         nextCanvasW === canvasFullW && nextCanvasH === canvasFullH;
+      // Captured against the *previous* offsets, before the reassignment
+      // below, to decide whether `setSlideOffset` will repaint the
+      // freshly-cleared bitmap or early-return.
+      const offsetChanged =
+        nextOffsetX !== slideOffsetCssX || nextOffsetY !== slideOffsetCssY;
       // Resync the ruler even when sizes match: a right-pane resize
       // (devtools open/close, sidebar collapse, notes-pane drag) can
       // shrink scrollHost without changing the canvas, leaving the
@@ -833,6 +839,28 @@ export function SlidesView({
         slideOffsetCssX / scaleCssPerLogical,
         slideOffsetCssY / scaleCssPerLogical,
       );
+      // Reassigning `canvas.width`/`canvas.height` above wiped the
+      // backing store to transparent. On a pasteboard-only resize (canvas
+      // grew/shrank while the fitted slide + offset held steady — e.g. the
+      // global sidebar collapsing at Fit zoom) both setters early-return
+      // and nothing repaints the cleared bitmap, leaving it black until an
+      // unrelated event re-dirties the renderer. Force one repaint here.
+      //
+      // `offsetChanged` is measured in CSS px while `setSlideOffset`
+      // compares logical units (cssOffset / scaleCssPerLogical). That is
+      // sound only because we skip the forced repaint when the host is
+      // unchanged: host-invariant ⇒ `scaleCssPerLogical` invariant, so
+      // CSS-offset equality tracks logical-offset equality exactly.
+      if (
+        needsForcedRepaintAfterRefit({
+          canvasChanged: !sameCanvas,
+          hostChanged: !sameSlide,
+          offsetChanged,
+        })
+      ) {
+        editor.markDirty();
+        editor.render();
+      }
       // After a size change the browser may or may not emit a scroll
       // event (e.g. shrinking back to Fit clamps scrollLeft to 0
       // implicitly). Sync the ruler explicitly so its tick origin

--- a/packages/frontend/tests/app/slides/refit-repaint.test.ts
+++ b/packages/frontend/tests/app/slides/refit-repaint.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { needsForcedRepaintAfterRefit } from "../../../src/app/slides/refit-repaint";
+
+describe("needsForcedRepaintAfterRefit", () => {
+  it("forces a repaint when the bitmap was cleared but host+offset are unchanged", () => {
+    // The black-canvas bug: pasteboard width changed (canvas cleared),
+    // fitted slide stayed the same size, offset absorbed by Math.floor.
+    // setHostSize + setSlideOffset both early-return → nobody repaints.
+    expect(
+      needsForcedRepaintAfterRefit({
+        canvasChanged: true,
+        hostChanged: false,
+        offsetChanged: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not double-paint when the host size changed (setHostSize repaints)", () => {
+    expect(
+      needsForcedRepaintAfterRefit({
+        canvasChanged: true,
+        hostChanged: true,
+        offsetChanged: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not double-paint when the offset changed (setSlideOffset repaints)", () => {
+    expect(
+      needsForcedRepaintAfterRefit({
+        canvasChanged: true,
+        hostChanged: false,
+        offsetChanged: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does nothing when the canvas size did not change (no clear happened)", () => {
+    // Host-only change with the same pasteboard: setHostSize repaints and
+    // the bitmap was never wiped, so no forced repaint is warranted.
+    expect(
+      needsForcedRepaintAfterRefit({
+        canvasChanged: false,
+        hostChanged: true,
+        offsetChanged: false,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Toggling the global app sidebar occasionally left the slides editor canvas fully **black** until an unrelated event repainted it.

**Root cause.** `refitCanvas` (`packages/frontend/src/app/slides/slides-view.tsx`) unconditionally clears the canvas backing store — reassigning `canvas.width`/`canvas.height` — whenever it passes its size guard, but delegates the redraw to `editor.setHostSize` and `editor.setSlideOffset`. Both of those **early-return without `markDirty()`** when their inputs are unchanged (`packages/slides/src/view/editor/editor.ts:1452-1478`).

On a *pasteboard-only* resize — the canvas/pasteboard size changes while the fitted-slide (host) size **and** the centered offset both stay the same, common at Fit zoom when the slide is height-constrained or `MAX_HOST_W`-clamped — the bitmap is cleared and nothing repaints it. The 200ms sidebar width CSS transition drives many `ResizeObserver` frames, so whether the settle frame lands on that host-invariant + offset-invariant combo determines whether it goes black. Hence *intermittent*.

**Fix.** Force exactly one repaint on precisely that frame, via an extracted, documented predicate `needsForcedRepaintAfterRefit(canvasChanged && !hostChanged && !offsetChanged)`. Because the predicate is mutually exclusive with the frames where either setter already repaints, it is a **single paint in every case** — no double-paint on host-change frames, no perf regression during the transition.

## Changes

- `packages/frontend/src/app/slides/refit-repaint.ts` — new documented predicate capturing the non-obvious repaint condition.
- `packages/frontend/src/app/slides/slides-view.tsx` — compute the three change flags (offset captured *before* reassignment) and force one repaint when the predicate is true; comment explaining the CSS↔logical offset equivalence.
- `packages/frontend/tests/app/slides/refit-repaint.test.ts` — predicate unit tests incl. the exact bug case.

## Test plan

- `pnpm verify:fast` — green (exit 0).
- New predicate test: 4 passing (incl. the black-canvas frame).
- Self-review via code-reviewer subagent: no Critical/Important correctness issues; confirmed single-paint, correct `offsetChanged` capture ordering, and CSS↔logical equivalence.
- Manual smoke pending: Fit zoom + repeatedly toggle sidebar, confirm the canvas never blanks.

### Known limitation
The load-bearing wiring lives in the `refitCanvas` closure, which is not cheaply unit-testable (captures ~10 mutable bindings + DOM refs; jsdom returns `null` from `getContext`). The predicate is extracted and tested; the wiring is covered by manual smoke. Documented in the task lessons file.

### Latent follow-up (out of scope)
`dpr` is captured once at mount and never re-read, so the host bitmap scale can diverge from the engine's `options.dpr` across monitors of different DPR. Left for a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a slide canvas issue where the editor could turn black after resizing or toggling the sidebar.
  * Improved repaint behavior so the canvas is redrawn immediately when a resize clears the drawing surface, preventing blank frames.
* **Documentation**
  * Added and updated task notes documenting the issue, fix, and verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->