### PR TITLE
Honor PPTX <a:bodyPr> text insets so glyphs stay centered

### DIFF
--- a/docs/design/slides/slides-shapes.md
+++ b/docs/design/slides/slides-shapes.md
@@ -156,6 +156,21 @@ in that order, where `paintTextBody` is exported from
 `<a:bodyPr lIns="91440" tIns="45720">` converted at the deck scale)
 and `defaultVerticalAnchor: 'middle'`.
 
+**Imported per-body insets.** When a PPTX `<a:bodyPr>` sets explicit
+`lIns/tIns/rIns/bIns`, `import/pptx/text.ts:detectBodyInset` converts them
+to deck px (per-axis `scale.sx/sy`, OOXML defaults filling absent sides)
+and stores them on `TextBody.inset`. The renderer prefers this over its
+default padding: shape callers thread it through `shapeTextInset(kind, w,
+h, pad)` (composed with the preset text rect), and text-element callers
+let `paintTextBody` fall back to `body.inset` (its native inset is
+otherwise `0`). This is what keeps Google-Slides-style number-in-circle
+labels — tiny `txBox="1"` boxes centered purely by large symmetric insets
+— centered instead of pinned to the top-left corner. Absent ⇒ prior
+per-kind default. The in-place editor stays consistent: `buildEditTarget`
+threads the same inset into the edit frame (`shapeTextFrame(kind, frame,
+inset)` for shapes, `insetFrame(frame, inset)` for text elements), so the
+caret and glyphs land where the committed paint puts them.
+
 **Editor entry.** Double-click and the type-to-edit / F2 / Enter
 keyboard rules accept `el.type === 'shape'` in addition to
 `'text'`. `enterEditMode` builds an `EditTarget` descriptor that

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| pptx text body insets (2026-07-03) | [20260703-pptx-text-body-insets-todo.md](./active/20260703-pptx-text-body-insets-todo.md) | [20260703-pptx-text-body-insets-lessons.md](./active/20260703-pptx-text-body-insets-lessons.md) |
 | slides canvas black on resize (2026-07-02) | [20260702-slides-canvas-black-on-resize-todo.md](./active/20260702-slides-canvas-black-on-resize-todo.md) | [20260702-slides-canvas-black-on-resize-lessons.md](./active/20260702-slides-canvas-black-on-resize-lessons.md) |
 | pivot format inheritance (2026-07-01) | [20260701-pivot-format-inheritance-todo.md](./active/20260701-pivot-format-inheritance-todo.md) | [20260701-pivot-format-inheritance-lessons.md](./active/20260701-pivot-format-inheritance-lessons.md) |
 | docs collaboration convergence (2026-06-25) | [20260625-docs-collaboration-convergence-todo.md](./active/20260625-docs-collaboration-convergence-todo.md) | [20260625-docs-collaboration-convergence-lessons.md](./active/20260625-docs-collaboration-convergence-lessons.md) |
@@ -28,4 +29,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 330
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides canvas black on resize (2026-07-02)
+Latest active task: pptx text body insets (2026-07-03)

--- a/docs/tasks/active/20260703-pptx-text-body-insets-lessons.md
+++ b/docs/tasks/active/20260703-pptx-text-body-insets-lessons.md
@@ -1,0 +1,48 @@
+# Lessons — PPTX text body insets
+
+## What the bug actually was
+
+"Text shifted to top-left inside circles" looked like a vertical-anchor or
+centering bug, but the real cause was **dropped `<a:bodyPr>` insets**. The
+labels were separate `txBox="1"` boxes (not text inside the ellipses), and the
+source centered a single glyph purely with large symmetric insets
+(`lIns=tIns=rIns=bIns=91425` EMU). With insets ignored, a text element renders
+at inset `0` → glyph at the exact (0,0) corner.
+
+## Debugging patterns that paid off
+
+- **Read the source XML before touching code.** Confirming the label was a
+  `txBox="1"` (→ TextElement path, inset `0`) vs a shape (→ `SHAPE_TEXT_PADDING`
+  path) changed which render path the fix had to target. An early wrong
+  assumption (shape padding) would have produced a smaller, still-wrong shift.
+- **Map the display order → rId → file** via `presentation.xml` `sldIdLst`
+  before trusting `slide13.xml` == "13th slide". Here it matched, but the rels
+  numbering is not the display order in general.
+- **Verify against the real artifact**, not just synthetic fixtures: parsing
+  the actual `slide13.xml` and asserting all 5 labels gained a ~19.2 px inset
+  proved the end-to-end fix, then the throwaway `/tmp`-referencing test was
+  removed so CI stays hermetic.
+
+## Design choices
+
+- **Bounded blast radius:** only store `inset` when `<a:bodyPr>` explicitly
+  declares one. Empty `<a:bodyPr/>` (the common case — insets inherited from
+  master) keeps the prior renderer default, so existing decks don't shift.
+- **Reused the existing pattern:** table cells already convert `marL/R/T/B`
+  EMU → px via `ctx.scale.sx/sy`. Mirroring that (not inventing a 96-dpi
+  constant) kept the conversion consistent with how frames are scaled.
+- **Compose, don't replace:** shapes thread the imported inset through
+  `shapeTextInset(kind, w, h, pad)` so it still composes with the per-kind
+  preset text rect (ellipse silhouette inset), rather than bypassing it.
+
+## Self-review caught a paint/edit divergence
+
+A `/code-review high` pass over the branch flagged that changing only the paint
+path broke the invariant that the in-place editor mounts exactly where the
+committed glyphs land: `buildEditTarget` still inset text elements by `0` and
+shapes by the default padding. Fixed in the same PR by threading the imported
+inset through `shapeTextFrame(kind, frame, inset)` (shapes) and a new
+`insetFrame(frame, inset)` (text elements). Lesson: when a fix touches a
+render path that has a mirrored editor/measurement path, change both together —
+grep for other callers of the shared geometry (`shapeTextInset`,
+`shapeTextFrame`) before declaring done.

--- a/docs/tasks/active/20260703-pptx-text-body-insets-todo.md
+++ b/docs/tasks/active/20260703-pptx-text-body-insets-todo.md
@@ -1,0 +1,75 @@
+# PPTX text body insets — center text inside imported boxes/shapes
+
+## Problem
+
+Shared deck slide 13 (`Yorkie 실시간 동시 편집 적용하기.pptx`) renders the
+numbers (1–5) inside the right-hand diagram circles shifted to the **top-left**
+corner instead of centered.
+
+## Root cause
+
+The number labels are `<p:sp txBox="1">` text boxes overlapping decorative
+ellipses. In the source each label's `<a:bodyPr>` sets **symmetric insets**
+`lIns=tIns=rIns=bIns=91425` EMU (≈ 19.2 px per side at this deck's scale) with
+`anchor="t"` / `algn="l"`. Those large symmetric insets are exactly what
+visually centers a single glyph inside the ~56×68 px box.
+
+The PPTX importer **never reads `lIns/tIns/rIns/bIns`** (`src/import/pptx/`
+only parses image `fillRect` insets and table-cell `marL/R/T/B`). `TextBody`
+has no inset field. So:
+
+- `txBox="1"` → imports as a **TextElement** → renders via `drawText →
+  paintTextBody` with **zero inset** → glyph paints at (0,0), the exact
+  top-left corner. ← the reported symptom.
+- (Shapes with folded `data.text` use a hardcoded `SHAPE_TEXT_PADDING`
+  {14.4, 7.2}px, also ignoring the source insets.)
+
+## Fix
+
+Parse `<a:bodyPr>` insets on import and honor them at render time.
+
+- [x] **Model** (`src/model/element.ts`): add `inset?: { left; top; right;
+      bottom }` (deck-canvas px) to `TextBody`, documented as `<a:bodyPr
+      lIns/tIns/rIns/bIns>`. Absent ⇒ renderer default (unchanged behavior).
+- [x] **Import** (`src/import/pptx/text.ts`): `detectBodyInset(txBody, scale)`
+      reads the four inset attrs, converts EMU→px via `scale.sx/sy`, fills
+      absent sides with OOXML defaults (lIns/rIns=91440, tIns/bIns=45720)
+      **only when at least one inset attr is explicitly present** (so empty
+      `<a:bodyPr/>` boxes keep current behavior — bounded blast radius).
+      Attach in `buildTextBody` (`src/import/pptx/shape.ts`).
+- [x] **Render — text elements** (`src/view/canvas/text-renderer.ts`):
+      `paintTextBody` inset precedence `opts.inset ?? body.inset ?? padding/0`.
+- [x] **Render — shapes** (`src/view/canvas/shape-renderer.ts`):
+      `shapeTextInset` takes an optional `pad` override; `paintShapeText`
+      passes `data.text.inset` so stored insets compose with the preset rect.
+- [x] Editor parity: `buildEditTarget` threads the same inset into the edit
+      frame (`shapeTextFrame(kind, frame, inset)` for shapes, new `insetFrame`
+      for text elements) so the caret matches the committed paint.
+
+## Tests (TDD — write failing first)
+
+- [x] Import: `txBox="1"` with explicit `bodyPr` insets → TextElement with
+      `data.inset` = scaled px (per-side).
+- [x] Import: empty `<a:bodyPr/>` → no `inset` stored (unchanged).
+- [x] Import: shape (`prstGeom` non-txBox) with explicit insets → `data.text.inset`.
+- [x] Render: `shapeTextInset` pad override + preset-rect composition unit tests.
+
+## Verify
+
+- [x] `pnpm test` (slides) green — 2459 pass
+- [x] `pnpm verify:fast` — EXIT=0
+- [x] Real deck: parsed the actual `slide13.xml`; all 5 circle labels now carry
+      an inset ≈ 19.2 px (was absent → painted at top-left).
+
+## Review
+
+Root cause: the `txBox="1"` number labels overlapping the diagram circles rely
+on large symmetric `<a:bodyPr>` insets (91425 EMU ≈ 19.2 px/side) to center a
+single glyph. The importer never read `lIns/tIns/rIns/bIns`, so text elements
+rendered at **zero inset** → glyph pinned to the top-left corner. Fix parses
+the insets into `TextBody.inset` and honors them in both the text-element and
+shape render paths, guarded to only activate when the source declares an inset
+(empty `<a:bodyPr/>` unaffected → bounded blast radius). A self code-review
+flagged that the in-place editor would otherwise mount at a different inset than
+the committed paint, so `buildEditTarget` now threads the same inset into the
+edit frame — caret and glyphs stay consistent on edit entry / commit.

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -37,7 +37,12 @@ import { parseCustGeomPath } from './freeform';
 import { parseBlipFill, parsePic, type ImageParseContext } from './image';
 import { ImportReport } from './report';
 import { parseTable } from './table';
-import { parseTextBody, detectAutofitMode, detectVerticalAnchor } from './text';
+import {
+  parseTextBody,
+  detectAutofitMode,
+  detectVerticalAnchor,
+  detectBodyInset,
+} from './text';
 import type { PptxArchive } from './unzip';
 import type { PptxRel } from './rels';
 import type { UploadImage } from './index';
@@ -683,9 +688,11 @@ function buildTextBody(
     placeholderTypeToTxStylesSlot(placeholderRef?.type),
   );
   const verticalAnchor = detectVerticalAnchor(txBody);
+  const inset = detectBodyInset(txBody, ctx.scale);
   return {
     autofit: detectAutofitMode(txBody),
     ...(verticalAnchor !== undefined ? { verticalAnchor } : {}),
+    ...(inset !== undefined ? { inset } : {}),
     blocks: parseTextBody(txBody, {
       rels: ctx.rels,
       report: ctx.report,

--- a/packages/slides/src/import/pptx/text.ts
+++ b/packages/slides/src/import/pptx/text.ts
@@ -79,6 +79,41 @@ export function detectVerticalAnchor(txBody: Element): VerticalAnchorMode | unde
 }
 
 /**
+ * OOXML default `<a:bodyPr>` insets (EMU): 0.1" left/right, 0.05" top/bottom.
+ * PowerPoint applies these when the corresponding attribute is omitted; we
+ * mirror that so a box that sets, say, only `lIns` stays symmetric with the
+ * source rather than collapsing the unset sides to zero.
+ */
+const DEFAULT_INS = { l: 91_440, t: 45_720, r: 91_440, b: 45_720 } as const;
+
+/**
+ * Read `<a:bodyPr lIns/tIns/rIns/bIns>` and convert EMU → deck-canvas px via
+ * the per-axis scale (horizontal insets use `sx`, vertical use `sy`), exactly
+ * like table-cell padding. Returns `undefined` when `<a:bodyPr>` declares no
+ * inset attribute at all — leaving the box on the renderer's per-kind default
+ * so plain imported text boxes are unaffected. When at least one inset is
+ * present, absent sides are filled with the OOXML defaults above.
+ */
+export function detectBodyInset(
+  txBody: Element,
+  scale: { sx: number; sy: number },
+): { left: number; top: number; right: number; bottom: number } | undefined {
+  const bodyPr = child(txBody, 'bodyPr');
+  if (!bodyPr) return undefined;
+  const l = attrInt(bodyPr, 'lIns');
+  const t = attrInt(bodyPr, 'tIns');
+  const r = attrInt(bodyPr, 'rIns');
+  const b = attrInt(bodyPr, 'bIns');
+  if (l == null && t == null && r == null && b == null) return undefined;
+  return {
+    left: (l ?? DEFAULT_INS.l) * scale.sx,
+    top: (t ?? DEFAULT_INS.t) * scale.sy,
+    right: (r ?? DEFAULT_INS.r) * scale.sx,
+    bottom: (b ?? DEFAULT_INS.b) * scale.sy,
+  };
+}
+
+/**
  * Parse `<p:txBody>` into a docs `Block[]`.
  *
  * Honors `<a:bodyPr><a:normAutofit fontScale=...>`: each run's `fontSize`

--- a/packages/slides/src/model/element.ts
+++ b/packages/slides/src/model/element.ts
@@ -229,6 +229,14 @@ export type PlaceholderRef = {
  */
 export type VerticalAnchorMode = 'top' | 'middle' | 'bottom';
 
+/** Per-side text insets, in deck-canvas px (left/top/right/bottom). */
+export type TextInset = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+
 /**
  * Text-box autofit behavior, mirroring OOXML `<a:bodyPr>` children:
  * - 'none'   ↔ <a:noAutofit/>   — box fixed, text overflows
@@ -275,6 +283,15 @@ export type TextBody = {
    * top / middle / bottom of the frame.
    */
   verticalAnchor?: VerticalAnchorMode;
+  /**
+   * Per-side text insets in deck-canvas px, mirroring OOXML
+   * `<a:bodyPr lIns/tIns/rIns/bIns>`. When present the renderer uses these
+   * instead of its per-kind default padding — decks that set large symmetric
+   * insets (e.g. Google-Slides number-in-circle labels) rely on them to
+   * center a single glyph. **Absent ⇒ renderer default** (0 for text
+   * elements, `SHAPE_TEXT_PADDING` for shapes), preserving prior behavior.
+   */
+  inset?: TextInset;
 };
 
 export type TextElement = ElementBase & {

--- a/packages/slides/src/view/canvas/shape-renderer.ts
+++ b/packages/slides/src/view/canvas/shape-renderer.ts
@@ -1,4 +1,4 @@
-import type { ShapeElement, ShapeKind } from '../../model/element';
+import type { ShapeElement, ShapeKind, TextInset } from '../../model/element';
 import { applyShade, resolveColor, type Theme } from '../../model/theme';
 import { drawActionButton } from './shape-special';
 import { resolveStrokeColor } from './render-context';
@@ -15,6 +15,9 @@ import { GENERATED_SHAPE_TEXT_RECTS } from './shapes/shape-text-rects.generated'
 import { paintTextBody } from './text-renderer';
 
 export type { FrameSize } from './shapes/builder';
+// `TextInset` lives in the model layer (used by `TextBody.inset`); re-exported
+// here so existing view/editor callers keep importing it from the renderer.
+export type { TextInset } from '../../model/element';
 
 /**
  * Insets (in deck-canvas px at the default 1920×1080 size) applied when
@@ -31,14 +34,6 @@ export type { FrameSize } from './shapes/builder';
  * a visible "shift" on commit.
  */
 export const SHAPE_TEXT_PADDING = { x: 14.4, y: 7.2 } as const;
-
-/** Per-side text insets, in deck-canvas px (left/top/right/bottom). */
-export type TextInset = {
-  left: number;
-  top: number;
-  right: number;
-  bottom: number;
-};
 
 /**
  * Per-`ShapeKind` text rectangle from the OOXML preset geometry's
@@ -69,21 +64,30 @@ export const SHAPE_TEXT_RECTS: Partial<
 // text box to zero width/height at small frame sizes — `paintTextBody` clamps
 // to `Math.max(0, …)`, so text simply doesn't render, matching PowerPoint's own
 // confinement of inline text to that narrow band rather than overflowing.
-export function shapeTextInset(kind: ShapeKind, w: number, h: number): TextInset {
+// `pad` overrides the default `SHAPE_TEXT_PADDING` term when supplied — used
+// to honor a shape's imported `<a:bodyPr>` insets (`data.text.inset`) while
+// still composing them with the kind's preset text rectangle.
+export function shapeTextInset(
+  kind: ShapeKind,
+  w: number,
+  h: number,
+  pad?: TextInset,
+): TextInset {
+  const p = pad ?? {
+    left: SHAPE_TEXT_PADDING.x,
+    top: SHAPE_TEXT_PADDING.y,
+    right: SHAPE_TEXT_PADDING.x,
+    bottom: SHAPE_TEXT_PADDING.y,
+  };
   const rect = SHAPE_TEXT_RECTS[kind];
   if (!rect) {
-    return {
-      left: SHAPE_TEXT_PADDING.x,
-      top: SHAPE_TEXT_PADDING.y,
-      right: SHAPE_TEXT_PADDING.x,
-      bottom: SHAPE_TEXT_PADDING.y,
-    };
+    return { ...p };
   }
   return {
-    left: rect.l * w + SHAPE_TEXT_PADDING.x,
-    top: rect.t * h + SHAPE_TEXT_PADDING.y,
-    right: (1 - rect.r) * w + SHAPE_TEXT_PADDING.x,
-    bottom: (1 - rect.b) * h + SHAPE_TEXT_PADDING.y,
+    left: rect.l * w + p.left,
+    top: rect.t * h + p.top,
+    right: (1 - rect.r) * w + p.right,
+    bottom: (1 - rect.b) * h + p.bottom,
   };
 }
 
@@ -95,8 +99,9 @@ export function shapeTextInset(kind: ShapeKind, w: number, h: number): TextInset
 export function shapeTextFrame(
   kind: ShapeKind,
   frame: { x: number; y: number; w: number; h: number; rotation: number },
+  pad?: TextInset,
 ): { x: number; y: number; w: number; h: number; rotation: number } {
-  const ins = shapeTextInset(kind, frame.w, frame.h);
+  const ins = shapeTextInset(kind, frame.w, frame.h, pad);
   return {
     x: frame.x + ins.left,
     y: frame.y + ins.top,
@@ -319,7 +324,9 @@ export function paintShapeText(
 ): void {
   if (!data.text) return;
   paintTextBody(ctx, size, data.text, theme, {
-    inset: shapeTextInset(data.kind, size.w, size.h),
+    // A shape's imported `<a:bodyPr>` insets (if any) replace the default
+    // per-kind padding while still composing with the preset text rect.
+    inset: shapeTextInset(data.kind, size.w, size.h, data.text.inset),
     defaultVerticalAnchor: 'middle',
     fontScale,
   });

--- a/packages/slides/src/view/canvas/text-renderer.ts
+++ b/packages/slides/src/view/canvas/text-renderer.ts
@@ -207,12 +207,17 @@ export function paintTextBody(
   } = {},
 ): void {
   if (isTextBodyEmpty(body)) return;
-  const inset = opts.inset ?? {
-    left: opts.padding?.x ?? 0,
-    right: opts.padding?.x ?? 0,
-    top: opts.padding?.y ?? 0,
-    bottom: opts.padding?.y ?? 0,
-  };
+  // Precedence: an explicit caller inset (shapes pass `shapeTextInset`) wins;
+  // otherwise honor the body's own imported `<a:bodyPr>` inset (text elements
+  // pass no inset, so this is where number-in-circle labels get centered);
+  // finally fall back to the symmetric `padding` / zero.
+  const inset = opts.inset ??
+    body.inset ?? {
+      left: opts.padding?.x ?? 0,
+      right: opts.padding?.x ?? 0,
+      top: opts.padding?.y ?? 0,
+      bottom: opts.padding?.y ?? 0,
+    };
   const innerW = Math.max(0, size.w - inset.left - inset.right);
   const innerH = Math.max(0, size.h - inset.top - inset.bottom);
 

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -26,7 +26,7 @@ import {
 } from '../../model/image-crop';
 import type { Block } from '@wafflebase/docs';
 import { clearMeasureCache } from '@wafflebase/docs';
-import { shapeTextFrame } from '../canvas/shape-renderer';
+import { shapeTextFrame, type TextInset } from '../canvas/shape-renderer';
 import {
   computeTableLayout,
   nextCellInDirection,
@@ -6564,21 +6564,44 @@ type EditTarget = {
   cell?: { row: number; col: number };
 };
 
+/**
+ * Shrink a frame by per-side insets (deck px), keeping width/height
+ * non-negative. Mirrors `shapeTextFrame` for the text-element path, which
+ * has no preset text rectangle — only the imported `<a:bodyPr>` inset.
+ */
+function insetFrame(frame: Frame, inset?: TextInset): Frame {
+  if (!inset) return frame;
+  return {
+    x: frame.x + inset.left,
+    y: frame.y + inset.top,
+    w: Math.max(0, frame.w - inset.left - inset.right),
+    h: Math.max(0, frame.h - inset.top - inset.bottom),
+    rotation: frame.rotation,
+  };
+}
+
 function buildEditTarget(element: TextElement | ShapeElement): EditTarget {
   if (element.type === 'text') {
+    // A text element paints at `body.inset` when the source `<a:bodyPr>`
+    // declared one (else 0); inset the edit frame the same way so the
+    // caret + glyphs land where `paintTextBody` commits them.
     return {
       kind: 'text',
       blocks: element.data.blocks,
       autofit: element.data.autofit,
       verticalAnchor: element.data.verticalAnchor,
-      editFrame: element.frame,
+      editFrame: insetFrame(element.frame, element.data.inset),
     };
   }
   const body = element.data.text;
-  // Inset by the shape's text rectangle (preset `<rect>` + default
-  // padding) so the in-place editing box and caret land exactly where
-  // `paintShapeText` paints the committed glyphs.
-  const innerFrame: Frame = shapeTextFrame(element.data.kind, element.frame);
+  // Inset by the shape's text rectangle (preset `<rect>` + the imported
+  // `<a:bodyPr>` inset, or the default padding) so the in-place editing box
+  // and caret land exactly where `paintShapeText` paints the committed glyphs.
+  const innerFrame: Frame = shapeTextFrame(
+    element.data.kind,
+    element.frame,
+    body?.inset,
+  );
   return {
     kind: 'shape',
     blocks: body?.blocks ?? [makeDefaultSlidesTextBlock()],

--- a/packages/slides/test/import/pptx/shape.test.ts
+++ b/packages/slides/test/import/pptx/shape.test.ts
@@ -112,6 +112,63 @@ const SLIDE_WITH_FILLED_TEXTBOX = `<?xml version="1.0"?>
   </p:cSld>
 </p:sld>`;
 
+/**
+ * A `txBox="1"` text box whose `<a:bodyPr>` sets explicit symmetric insets
+ * (`lIns=tIns=rIns=bIns`). Google-Slides-style number-in-circle labels rely
+ * on these large insets to visually center a single glyph; the importer must
+ * carry them into `TextBody.inset` so the renderer reproduces the centering
+ * instead of painting at the top-left corner.
+ */
+const SLIDE_WITH_TEXTBOX_INSETS = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Num"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="267900" cy="323100"/></a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr anchor="t" lIns="91425" tIns="91425" rIns="91425" bIns="91425"/>
+          <a:lstStyle/>
+          <a:p><a:r><a:rPr lang="en-US"/><a:t>1</a:t></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
+/**
+ * A prstGeom shape (not a text box) whose folded `<p:txBody>` carries explicit
+ * `<a:bodyPr>` insets. The importer must attach them to `data.text.inset`.
+ */
+const SLIDE_WITH_SHAPE_INSETS = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Box"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="1000000"/></a:xfrm>
+          <a:prstGeom prst="roundRect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr lIns="45720" tIns="9144"/>
+          <a:lstStyle/>
+          <a:p><a:r><a:rPr lang="en-US"/><a:t>Hi</a:t></a:r></a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
 describe('parseSlide — shape inline text', () => {
   it('folds <p:txBody> inside a prstGeom <p:sp> into ShapeElement.data.text', async () => {
     const slide = await parseSlide({
@@ -178,5 +235,71 @@ describe('parseSlide — shape inline text', () => {
     expect(el.data.blocks[0].inlines.map((i) => i.text).join('')).toBe(
       'Network Interruption',
     );
+  });
+
+  it('does not attach an inset when <a:bodyPr> declares none', async () => {
+    const slide = await parseSlide({
+      archive: makeArchive({
+        'ppt/slides/slide1.xml': SLIDE_WITH_FILLED_TEXTBOX,
+      }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    const el = slide!.elements[0];
+    expect(el.type).toBe('text');
+    if (el.type !== 'text') return;
+    // Empty `<a:bodyPr/>` — the renderer keeps its default; storing an inset
+    // here would shift every plain imported text box.
+    expect(el.data.inset).toBeUndefined();
+  });
+
+  it('carries explicit <a:bodyPr> insets into a text box\'s TextBody.inset', async () => {
+    const slide = await parseSlide({
+      archive: makeArchive({
+        'ppt/slides/slide1.xml': SLIDE_WITH_TEXTBOX_INSETS,
+      }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      // sx=sy=1 → inset px equals the raw EMU inset for easy assertion.
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    const el = slide!.elements[0];
+    expect(el.type).toBe('text');
+    if (el.type !== 'text') return;
+    expect(el.data.inset).toEqual({
+      left: 91425,
+      top: 91425,
+      right: 91425,
+      bottom: 91425,
+    });
+  });
+
+  it('carries explicit <a:bodyPr> insets into a shape\'s data.text.inset, filling absent sides with OOXML defaults', async () => {
+    const slide = await parseSlide({
+      archive: makeArchive({
+        'ppt/slides/slide1.xml': SLIDE_WITH_SHAPE_INSETS,
+      }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    const el = slide!.elements[0];
+    expect(el.type).toBe('shape');
+    if (el.type !== 'shape') return;
+    // lIns / tIns explicit; rIns / bIns fall back to OOXML defaults
+    // (91440 / 45720) so the box stays symmetric with PowerPoint.
+    expect(el.data.text?.inset).toEqual({
+      left: 45720,
+      top: 9144,
+      right: 91440,
+      bottom: 45720,
+    });
   });
 });

--- a/packages/slides/test/view/canvas/shape-renderer.test.ts
+++ b/packages/slides/test/view/canvas/shape-renderer.test.ts
@@ -4,7 +4,12 @@ import type { Theme } from '../../../src/model/theme';
 import { asCtx, createCtxSpy } from '../../../src/view/canvas/ctx-spy';
 // Install Path2D global before importing the renderer/builders.
 import '../../../src/view/canvas/test-canvas-env';
-import { drawShape } from '../../../src/view/canvas/shape-renderer';
+import {
+  drawShape,
+  shapeTextInset,
+  shapeTextFrame,
+  SHAPE_TEXT_PADDING,
+} from '../../../src/view/canvas/shape-renderer';
 
 const THEME: Theme = {
   id: 't', name: 't',
@@ -142,5 +147,48 @@ describe('drawShape — donut (evenodd fill rule)', () => {
     expect(ctx.fill).toHaveBeenCalledTimes(1);
     expect(ctx.fill.mock.calls[0][0]).toBeInstanceOf(Path2D);
     expect(ctx.fill.mock.calls[0][1]).toBe('evenodd');
+  });
+});
+
+describe('shapeTextInset', () => {
+  it('defaults to the uniform SHAPE_TEXT_PADDING for a rect (no preset rect)', () => {
+    expect(shapeTextInset('rect', 200, 100)).toEqual({
+      left: SHAPE_TEXT_PADDING.x,
+      top: SHAPE_TEXT_PADDING.y,
+      right: SHAPE_TEXT_PADDING.x,
+      bottom: SHAPE_TEXT_PADDING.y,
+    });
+  });
+
+  it('uses a per-side pad override in place of SHAPE_TEXT_PADDING', () => {
+    const pad = { left: 20, top: 20, right: 20, bottom: 20 };
+    expect(shapeTextInset('rect', 200, 100, pad)).toEqual(pad);
+  });
+
+  it('composes the pad override with a shape preset rect', () => {
+    // A kind with a preset text rect insets by rect fractions plus the pad.
+    const pad = { left: 5, top: 5, right: 5, bottom: 5 };
+    const withPad = shapeTextInset('ellipse', 200, 100, pad);
+    const withDefault = shapeTextInset('ellipse', 200, 100);
+    // The preset-rect portion is identical; only the additive pad differs.
+    expect(withPad.left).toBeCloseTo(
+      withDefault.left - SHAPE_TEXT_PADDING.x + pad.left,
+    );
+    expect(withPad.top).toBeCloseTo(
+      withDefault.top - SHAPE_TEXT_PADDING.y + pad.top,
+    );
+  });
+
+  it('shapeTextFrame threads the pad override so edit frame matches paint', () => {
+    const frame = { x: 10, y: 20, w: 200, h: 100, rotation: 0 };
+    const pad = { left: 30, top: 30, right: 30, bottom: 30 };
+    // rect has no preset text rect, so the inner frame is the pad inset.
+    expect(shapeTextFrame('rect', frame, pad)).toEqual({
+      x: 40,
+      y: 50,
+      w: 140,
+      h: 40,
+      rotation: 0,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Imported PPTX text boxes and shapes dropped the source `<a:bodyPr>` text
insets (`lIns/tIns/rIns/bIns`): the importer never read them and `TextBody`
had no inset field. Text elements then rendered at **zero inset**, so a label
centered purely by large symmetric insets — e.g. the Google-Slides
number-in-circle diagram labels on slide 13 of a real deck — painted at the
**top-left corner** instead of the center.

Root cause: the number labels are `txBox="1"` boxes overlapping decorative
ellipses, centered only by `lIns=tIns=rIns=bIns=91425` EMU (~19.2 px/side).
With insets ignored, the single glyph landed at (0,0).

### Change

- **Import** — `detectBodyInset` (`import/pptx/text.ts`) parses the four
  inset attrs (EMU → deck px via the per-axis scale, OOXML defaults filling
  absent sides). Stored on `TextBody.inset` **only when the source declares
  at least one** inset, so plain boxes with an empty `<a:bodyPr/>` are
  unchanged — bounded blast radius.
- **Render** — shapes compose the inset with their preset text rect via
  `shapeTextInset(kind, w, h, pad)`; text elements fall back to `body.inset`
  in `paintTextBody` (precedence `opts.inset ?? body.inset ?? padding`, so no
  double-application).
- **Editor** — `buildEditTarget` threads the same inset into the in-place
  edit frame (`shapeTextFrame(kind, frame, inset)` / new `insetFrame`) so the
  caret and glyphs land where the committed paint puts them.
- `TextInset` hoisted to the model layer (used by `TextBody.inset`),
  re-exported from the renderer for existing callers.

Tables are unaffected (cell bodies are built via `parseTextBody`, not
`buildTextBody`, and the renderer passes its own cell padding).

## Test plan

- New unit tests: import (`txBox="1"` + shape with explicit insets → scaled
  `inset`; empty `<a:bodyPr/>` → none) and `shapeTextInset` / `shapeTextFrame`
  pad-override + preset-rect composition.
- Parsed the real `slide13.xml`: all 5 circle labels now carry a ~19.2 px
  inset (previously absent → top-left corner).
- `pnpm verify:fast` green; full slides suite (2460) passes.
- Manual smoke: re-imported the deck; slide 13 numbers centered in the circles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PPTX text boxes and shapes now preserve imported text insets, improving text positioning and spacing.
  * Editor and renderer now use the same inset values, so caret placement and on-canvas text alignment match more closely.

* **Bug Fixes**
  * Fixed text inside certain PPTX shapes appearing shifted toward the top-left when body padding was defined.
  * Missing inset values now fall back to the usual defaults when not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->