### PR TITLE
Render PPTX freeform line-end arrowheads on slides

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| slides freeform arrowheads (2026-07-04) | [20260704-slides-freeform-arrowheads-todo.md](./active/20260704-slides-freeform-arrowheads-todo.md) | - |
 | pptx text body insets (2026-07-03) | [20260703-pptx-text-body-insets-todo.md](./active/20260703-pptx-text-body-insets-todo.md) | [20260703-pptx-text-body-insets-lessons.md](./active/20260703-pptx-text-body-insets-lessons.md) |
 | slides canvas black on resize (2026-07-02) | [20260702-slides-canvas-black-on-resize-todo.md](./active/20260702-slides-canvas-black-on-resize-todo.md) | [20260702-slides-canvas-black-on-resize-lessons.md](./active/20260702-slides-canvas-black-on-resize-lessons.md) |
 | pivot format inheritance (2026-07-01) | [20260701-pivot-format-inheritance-todo.md](./active/20260701-pivot-format-inheritance-todo.md) | [20260701-pivot-format-inheritance-lessons.md](./active/20260701-pivot-format-inheritance-lessons.md) |
@@ -29,4 +30,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 330
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: pptx text body insets (2026-07-03)
+Latest active task: slides freeform arrowheads (2026-07-04)

--- a/docs/tasks/active/20260704-slides-freeform-arrowheads-todo.md
+++ b/docs/tasks/active/20260704-slides-freeform-arrowheads-todo.md
@@ -67,6 +67,25 @@ Verification: `pnpm verify:fast` EXIT=0 (lint + typecheck + all unit tests;
 slides +3 tests). Real deck `slide10.xml` re-parse confirmed ≥2 freeform
 shapes now carry an end triangle arrowhead.
 
+### Review round 2 (post smoke test — code-review: high, 4 findings + 1 refuted)
+
+- **Compound / multi-subpath freeform** (correctness, 2 findings) — the
+  import "open" check only looked at the last command and the renderer
+  anchored the start arrowhead to the first `M` regardless of subpath, so a
+  freeform with >1 subpath could drop (import) or misplace (render) tips.
+  Fixed by gating arrowheads to a **single open subpath** (exactly one `M`,
+  no trailing `Z`); compound arrowed freeforms are a documented best-effort
+  limitation (dropped, not misplaced). Test added.
+- **Inline arrowhead-pair type duplicated** (cleanup) — extracted
+  `ArrowheadPair` in `model/connector.ts`, used by both `ConnectorElement`
+  and freeform `ShapeElement.data`.
+- **Duplicated endpoint-tangent logic** (cleanup) — *declined again*: same
+  reasoning (unifying means rewriting the stable connector `endpointPose`
+  path, different data shape). Non-blocking.
+- **`Pt` vs `Point`** — refuted by the verifier; left as the local helper type.
+
+Verification: `pnpm verify:fast` EXIT=0 (slides +1 test = 2469 pass).
+
 ## Notes / decisions
 
 - Arrowhead size stays the fixed `sm/md/lg` (8/12/18px) model shared with

--- a/docs/tasks/active/20260704-slides-freeform-arrowheads-todo.md
+++ b/docs/tasks/active/20260704-slides-freeform-arrowheads-todo.md
@@ -1,0 +1,81 @@
+# Slides — Freeform (custGeom) line-end arrowheads
+
+## Problem
+
+PPTX freeform shapes (`<p:sp>` + `<a:custGeom>`) can carry line-end
+arrowheads on their `<a:ln>` (`<a:headEnd>` / `<a:tailEnd>`), exactly like
+connectors. Wafflebase drops them entirely:
+
+- Import: `buildFreeformElement()` (`import/pptx/shape.ts`) reads only
+  `fill` + `stroke`; `headEnd`/`tailEnd` are ignored.
+- Model: `ShapeElement.data` has no `arrowheads` field.
+- Render: `shape-renderer.ts` / `shapes/freeform.ts` never draw arrowheads.
+
+Repro: the shared "Yorkie 실시간 동시 편집 적용하기" deck, slide 10
+("Local First Remote Later"). The teal (`accent5`) and orange (`FFAB40`)
+curves around the "Asynchronous" cloud are freeform cubic-bezier shapes
+with `<a:tailEnd type="triangle" len="med" w="med"/>`; their arrow tips
+are missing in Wafflebase (present in Keynote/Google Slides). Slide 5's
+`<p:cxnSp>` connectors are unaffected — they already render arrowheads.
+
+## Goal
+
+Import, model, render, and export line-end arrowheads for `freeform`
+shapes, reusing the existing connector arrowhead primitives
+(`parseArrowhead`, `drawArrowhead`, export `arrowXml`). No behaviour
+change for connectors or parametric shapes.
+
+## Plan (TDD — failing test first for each layer)
+
+- [x] Model: add `arrowheads?: { start?: ArrowheadStyle; end?: ArrowheadStyle }`
+      to `ShapeElement.data` (`import type { ArrowheadStyle } from './connector'`).
+- [x] Import: `buildFreeformElement` parses `<a:ln>` `headEnd`/`tailEnd`
+      via `parseArrowhead`; only sets `data.arrowheads` when start or end present.
+- [x] Render: in `drawShape` freeform branch, after `paintFillStroke`,
+      compute the path start/end tip + tangent (in scaled local coords) and
+      call `drawArrowhead` with the resolved stroke color. Tangent mirrors
+      `connector-renderer`'s `endpointPose` (reverse at start).
+- [x] Export: `shapeToXml` freeform `<a:ln>` emits `headEnd`/`tailEnd`;
+      reuse/export `arrowXml` from `export/pptx/connector.ts`; extend
+      `lineXml` to accept optional arrowheads.
+- [x] Round-trip: freeform + tailEnd triangle survives export→import.
+- [x] `pnpm verify:fast` green (EXIT=0). Real deck slide 10 re-parsed:
+      ≥2 freeform shapes now carry an end triangle arrowhead (throwaway test).
+- [ ] Manual smoke on slide 10 via `pnpm dev` (re-upload the .pptx — the
+      already-stored shared doc won't re-import). Left for merge time.
+- [x] Address code-review findings (high, workflow-backed).
+
+## Review (code-review: high, 5 findings)
+
+- **Arrowheads dropped on export without a stroke** (correctness) — fixed at
+  import: only attach `arrowheads` when a stroke is present, so import /
+  render / export all gate on stroke symmetrically.
+- **Stray arrowheads on closed (`Z`) freeforms** (correctness) — fixed at
+  import: skip arrowheads when the path is closed (a loop has no open ends,
+  matching PowerPoint). Test added.
+- **Arc endpoint tangent used the chord** (correctness) — replaced with the
+  true ellipse tangent `dP/dθ = (−rx·sinθ·w, ry·cosθ·h)`, sweep-sign aware.
+  Test added (quarter arc → base at x≈62, not the 135° chord).
+- **`lineXml` called for all kinds** (cleanup) — guard so only `freeform`
+  passes `arrowheads` to export.
+- **Duplicated bezier-tangent logic** (cleanup) — *declined*: unifying with
+  `connector-renderer`'s `endpointPose` would mean rewriting the stable
+  connector path (different data shape: `BezierPath` vs command walk); the
+  shared essence is a 3-line `atan2` fallback. Net risk > value.
+
+Verification: `pnpm verify:fast` EXIT=0 (lint + typecheck + all unit tests;
+slides +3 tests). Real deck `slide10.xml` re-parse confirmed ≥2 freeform
+shapes now carry an end triangle arrowhead.
+
+## Notes / decisions
+
+- Arrowhead size stays the fixed `sm/md/lg` (8/12/18px) model shared with
+  connectors — the separate "fixed vs line-width-proportional sizing"
+  question (slide 5) is out of scope here.
+- Closed paths (`Z`) with arrowheads are unusual; draw at the raw
+  first/last anchors regardless (matches OOXML semantics; deck shapes are open).
+- Arc (`A`) end tangent falls back to chord direction; deck curves are cubic.
+
+## Review
+
+(to fill in after implementation)

--- a/packages/slides/src/export/pptx/connector.ts
+++ b/packages/slides/src/export/pptx/connector.ts
@@ -50,7 +50,7 @@ const SIZE_TO_OOXML: Record<string, string> = {
   lg: 'lg',
 };
 
-function arrowXml(tag: 'headEnd' | 'tailEnd', a: ArrowheadStyle | undefined): string {
+export function arrowXml(tag: 'headEnd' | 'tailEnd', a: ArrowheadStyle | undefined): string {
   if (!a) return '';
   const type = KIND_TO_OOXML[a.kind] ?? 'triangle';
   const sz = SIZE_TO_OOXML[a.size] ?? 'med';

--- a/packages/slides/src/export/pptx/shape.ts
+++ b/packages/slides/src/export/pptx/shape.ts
@@ -4,6 +4,7 @@ import { solidFillXml, colorFromStringOrTheme } from './color.js';
 import { textBodyToXml } from './text.js';
 import { effectsToXml } from './effects.js';
 import { freeformToCustGeom } from './freeform.js';
+import { arrowXml } from './connector.js';
 import { attr, escapeXmlAttr } from './xml.js';
 
 /**
@@ -45,8 +46,15 @@ const DASH_VAL: Record<string, string> = {
 
 /**
  * Serialize a {@link Stroke} to an `<a:ln>` element, or `''` if absent.
+ *
+ * `arrowheads` (freeform line ends) map to `<a:headEnd>`/`<a:tailEnd>`,
+ * inverse of the importer — see {@link arrowXml}. Emitted only when a
+ * stroke is present, since arrowheads have no meaning without a line.
  */
-export function lineXml(stroke: Stroke | undefined): string {
+export function lineXml(
+  stroke: Stroke | undefined,
+  arrowheads?: ShapeElement['data']['arrowheads'],
+): string {
   if (!stroke) return '';
   const w = pxToEmuX(stroke.width);
   const fill = solidFillXml(colorFromStringOrTheme(stroke.color));
@@ -54,7 +62,9 @@ export function lineXml(stroke: Stroke | undefined): string {
     stroke.dash && stroke.dash !== 'solid'
       ? `<a:prstDash val="${DASH_VAL[stroke.dash] ?? 'dash'}"/>`
       : '';
-  return `<a:ln w="${w}">${fill}${dash}</a:ln>`;
+  const head = arrowXml('headEnd', arrowheads?.start);
+  const tail = arrowXml('tailEnd', arrowheads?.end);
+  return `<a:ln w="${w}">${fill}${dash}${head}${tail}</a:ln>`;
 }
 
 /**
@@ -87,7 +97,10 @@ export function shapeToXml(el: ShapeElement): string {
     xfrmXml(frame) +
     geom +
     fill +
-    lineXml(data.stroke) +
+    // Arrowheads are a freeform-only concept (only freeform import populates
+    // them and only freeform rendering draws them); don't emit head/tailEnd
+    // onto a parametric shape's line even if the field were somehow set.
+    lineXml(data.stroke, data.kind === 'freeform' ? data.arrowheads : undefined) +
     effectsToXml(data.effects) +
     `</p:spPr>`;
 

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -766,6 +766,20 @@ function buildFreeformElement(
   const fill = parseShapeFill(spPr, ctx);
   const stroke = parseShapeStroke(spPr, ctx);
 
+  // Line-end arrowheads live on `<a:ln>` (`<a:headEnd>`/`<a:tailEnd>`),
+  // exactly like connectors. PowerPoint exports arrowed curves as freeform
+  // `<p:sp>` custGeom, so parse them here rather than dropping the tips.
+  // Only meaningful on a *stroked* *open* path: no stroke ⇒ no visible line
+  // to decorate; a closed outline (`<a:close/>` ⇒ trailing 'Z') has no open
+  // ends, so PowerPoint draws nothing there. Gating here keeps import,
+  // render, and export symmetric (all three require a stroke).
+  const cmds = path.commands;
+  const open = cmds.length > 0 && cmds[cmds.length - 1].c !== 'Z';
+  const ln = stroke && open && spPr ? child(spPr, 'ln') : undefined;
+  const start = ln ? parseArrowhead(child(ln, 'headEnd')) : undefined;
+  const end = ln ? parseArrowhead(child(ln, 'tailEnd')) : undefined;
+  const arrowheads = start || end ? { ...(start ? { start } : {}), ...(end ? { end } : {}) } : undefined;
+
   return {
     id,
     type: 'shape',
@@ -775,6 +789,7 @@ function buildFreeformElement(
       path,
       ...(fill ? { fill } : {}),
       ...(stroke ? { stroke } : {}),
+      ...(arrowheads ? { arrowheads } : {}),
     },
   };
 }

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -769,12 +769,16 @@ function buildFreeformElement(
   // Line-end arrowheads live on `<a:ln>` (`<a:headEnd>`/`<a:tailEnd>`),
   // exactly like connectors. PowerPoint exports arrowed curves as freeform
   // `<p:sp>` custGeom, so parse them here rather than dropping the tips.
-  // Only meaningful on a *stroked* *open* path: no stroke ⇒ no visible line
-  // to decorate; a closed outline (`<a:close/>` ⇒ trailing 'Z') has no open
-  // ends, so PowerPoint draws nothing there. Gating here keeps import,
-  // render, and export symmetric (all three require a stroke).
+  // Only meaningful on a *stroked*, *single open subpath*:
+  //   - no stroke ⇒ no visible line to decorate;
+  //   - a closed outline (`<a:close/>` ⇒ trailing 'Z') has no open ends;
+  //   - a compound path (>1 `M` subpath) has an ambiguous "the start"/"the
+  //     end", so we drop rather than anchor a tip to the wrong subpath.
+  // Gating here keeps import, render, and export symmetric and matches how
+  // arrowed freeforms are actually authored (a single open path).
   const cmds = path.commands;
-  const open = cmds.length > 0 && cmds[cmds.length - 1].c !== 'Z';
+  const subpaths = cmds.reduce((n, c) => (c.c === 'M' ? n + 1 : n), 0);
+  const open = subpaths === 1 && cmds.length > 0 && cmds[cmds.length - 1].c !== 'Z';
   const ln = stroke && open && spPr ? child(spPr, 'ln') : undefined;
   const start = ln ? parseArrowhead(child(ln, 'headEnd')) : undefined;
   const end = ln ? parseArrowhead(child(ln, 'tailEnd')) : undefined;

--- a/packages/slides/src/model/connector.ts
+++ b/packages/slides/src/model/connector.ts
@@ -17,12 +17,19 @@ export type ArrowheadStyle = {
   size: 'sm' | 'md' | 'lg';
 };
 
+/**
+ * Line-end arrowhead pair — `start` decorates the first anchor, `end` the
+ * last. Shared by {@link ConnectorElement} and freeform `ShapeElement`s so
+ * the renderer and PPTX round-trip treat both identically.
+ */
+export type ArrowheadPair = { start?: ArrowheadStyle; end?: ArrowheadStyle };
+
 export type ConnectorElement = ElementBase & {
   type: 'connector';
   routing: ConnectorRouting;
   start: Endpoint;
   end: Endpoint;
-  arrowheads: { start?: ArrowheadStyle; end?: ArrowheadStyle };
+  arrowheads: ArrowheadPair;
   stroke?: ShapeStroke;
   /** Present only when the user manually dragged the elbow handle. */
   elbowBend?: number;

--- a/packages/slides/src/model/element.ts
+++ b/packages/slides/src/model/element.ts
@@ -1,5 +1,5 @@
 import type { Block } from '@wafflebase/docs';
-import type { ConnectorElement } from './connector';
+import type { ArrowheadStyle, ConnectorElement } from './connector';
 import type { ThemeColor } from './theme';
 
 export type Frame = {
@@ -366,6 +366,15 @@ export type ShapeElement = ElementBase & {
     path?: FreeformPath;
     fill?: ThemeColor;
     stroke?: Stroke;
+    /**
+     * Line-end arrowheads for an open `kind === 'freeform'` path, mirroring
+     * OOXML `<a:ln><a:headEnd>/<a:tailEnd>`. `start` decorates the path's
+     * first anchor, `end` the last. Only meaningful on stroked open
+     * freeforms (PowerPoint exports arrowed curves as `<p:sp>` custGeom, not
+     * `<p:cxnSp>`); parametric kinds ignore it. Shares the connector
+     * {@link ArrowheadStyle} model and renderer.
+     */
+    arrowheads?: { start?: ArrowheadStyle; end?: ArrowheadStyle };
     /**
      * Inline text body painted on top of the shape's fill/stroke.
      * Absent on freshly-inserted shapes; lazily initialised when the

--- a/packages/slides/src/model/element.ts
+++ b/packages/slides/src/model/element.ts
@@ -1,5 +1,5 @@
 import type { Block } from '@wafflebase/docs';
-import type { ArrowheadStyle, ConnectorElement } from './connector';
+import type { ArrowheadPair, ConnectorElement } from './connector';
 import type { ThemeColor } from './theme';
 
 export type Frame = {
@@ -372,9 +372,9 @@ export type ShapeElement = ElementBase & {
      * first anchor, `end` the last. Only meaningful on stroked open
      * freeforms (PowerPoint exports arrowed curves as `<p:sp>` custGeom, not
      * `<p:cxnSp>`); parametric kinds ignore it. Shares the connector
-     * {@link ArrowheadStyle} model and renderer.
+     * {@link ArrowheadPair} model and renderer.
      */
-    arrowheads?: { start?: ArrowheadStyle; end?: ArrowheadStyle };
+    arrowheads?: ArrowheadPair;
     /**
      * Inline text body painted on top of the shape's fill/stroke.
      * Absent on freshly-inserted shapes; lazily initialised when the

--- a/packages/slides/src/view/canvas/shape-renderer.ts
+++ b/packages/slides/src/view/canvas/shape-renderer.ts
@@ -253,6 +253,10 @@ type Pt = { x: number; y: number };
  * so the tip lands exactly on the stroked endpoint and the tangent matches
  * the drawn curve. The start tangent is reversed to point out of the body,
  * mirroring `connector-renderer`'s `endpointPose`.
+ *
+ * Assumes a single open subpath: the importer only sets `arrowheads` for a
+ * one-`M`, non-`Z` path (see `buildFreeformElement`), so `first` is the
+ * subpath's start and `endTip` its end with no interior `M` to straddle.
  */
 function drawFreeformArrowheads(
   ctx: CanvasRenderingContext2D,

--- a/packages/slides/src/view/canvas/shape-renderer.ts
+++ b/packages/slides/src/view/canvas/shape-renderer.ts
@@ -1,6 +1,7 @@
-import type { ShapeElement, ShapeKind, TextInset } from '../../model/element';
+import type { FreeformPath, ShapeElement, ShapeKind, TextInset } from '../../model/element';
 import { applyShade, resolveColor, type Theme } from '../../model/theme';
 import { drawActionButton } from './shape-special';
+import { drawArrowhead } from './arrowhead-renderer';
 import { resolveStrokeColor } from './render-context';
 import {
   FACE_BUILDERS,
@@ -184,6 +185,18 @@ export function drawShape(
       return;
     }
     paintFillStroke(ctx, buildFreeformPath(size, data.path), data, theme);
+    // Line-end arrowheads on an open freeform path (OOXML `<a:tailEnd>` /
+    // `<a:headEnd>`). Painted after the stroke so the triangle sits on top,
+    // filled with the stroke color — same primitive as connectors.
+    if (data.arrowheads && data.stroke) {
+      drawFreeformArrowheads(
+        ctx,
+        size,
+        data.path,
+        data.arrowheads,
+        resolveStrokeColor(data.stroke.color, theme),
+      );
+    }
     return;
   }
 
@@ -229,6 +242,105 @@ export function drawShape(
     ctx.lineJoin = 'round';
     ctx.stroke(leaderBuilder(size, data.adjustments));
   }
+}
+
+type Pt = { x: number; y: number };
+
+/**
+ * Draw the start/end arrowheads of an open freeform path. Coordinates are
+ * the path's normalized `[0,1]` commands scaled anisotropically by the
+ * frame (`x*w`, `y*h`) — the same space `buildFreeformPath` strokes into —
+ * so the tip lands exactly on the stroked endpoint and the tangent matches
+ * the drawn curve. The start tangent is reversed to point out of the body,
+ * mirroring `connector-renderer`'s `endpointPose`.
+ */
+function drawFreeformArrowheads(
+  ctx: CanvasRenderingContext2D,
+  { w, h }: FrameSize,
+  path: FreeformPath,
+  arrowheads: NonNullable<ShapeElement['data']['arrowheads']>,
+  fillColor: string,
+): void {
+  let first: Pt | undefined; // path's very first anchor (M)
+  let startCtrl: Pt | undefined; // outgoing tangent handle of the first segment
+  let endTip: Pt | undefined; // last segment's endpoint
+  let endCtrl: Pt | undefined; // incoming tangent handle at the last endpoint
+  let cur: Pt | undefined; // running current point
+  const s = (x: number, y: number): Pt => ({ x: x * w, y: y * h });
+
+  for (const cmd of path.commands) {
+    switch (cmd.c) {
+      case 'M':
+        cur = s(cmd.x, cmd.y);
+        if (!first) first = cur;
+        break;
+      case 'L': {
+        const to = s(cmd.x, cmd.y);
+        if (!startCtrl) startCtrl = to;
+        endCtrl = cur;
+        endTip = cur = to;
+        break;
+      }
+      case 'Q': {
+        const c1 = s(cmd.x1, cmd.y1);
+        const to = s(cmd.x, cmd.y);
+        if (!startCtrl) startCtrl = c1;
+        endCtrl = c1;
+        endTip = cur = to;
+        break;
+      }
+      case 'C': {
+        const c1 = s(cmd.x1, cmd.y1);
+        const to = s(cmd.x, cmd.y);
+        if (!startCtrl) startCtrl = c1;
+        endCtrl = s(cmd.x2, cmd.y2);
+        endTip = cur = to;
+        break;
+      }
+      case 'A': {
+        // True ellipse tangent at each endpoint (not the chord). For the
+        // centre-parametric arc P(θ)=(cx+rx·cosθ, cy+ry·sinθ) scaled by the
+        // frame, dP/dθ = (−rx·sinθ·w, ry·cosθ·h); the direction of travel
+        // flips with the sweep sign. Synthesize a control point one tangent
+        // step behind the anchor so `arrowPose` yields the curve tangent.
+        const a0 = cmd.start;
+        const a1 = cmd.start + cmd.sweep;
+        const dir = cmd.sweep >= 0 ? 1 : -1;
+        const end = { x: (cmd.cx + cmd.rx * Math.cos(a1)) * w, y: (cmd.cy + cmd.ry * Math.sin(a1)) * h };
+        // Outgoing tangent at the arc start (into the body from `cur`).
+        const t0 = { x: dir * -cmd.rx * Math.sin(a0) * w, y: dir * cmd.ry * Math.cos(a0) * h };
+        // Direction of travel at the arc end (out of `end`).
+        const t1 = { x: dir * -cmd.rx * Math.sin(a1) * w, y: dir * cmd.ry * Math.cos(a1) * h };
+        if (!startCtrl && cur) startCtrl = { x: cur.x + t0.x, y: cur.y + t0.y };
+        endCtrl = { x: end.x - t1.x, y: end.y - t1.y };
+        endTip = cur = end;
+        break;
+      }
+      // 'Z' closes the outline; arrowheads decorate open ends, so ignore it.
+    }
+  }
+
+  // Both ends resolve the same way: the tip sits on the anchor and the angle
+  // points from the tangent handle toward the tip, which is "away from the
+  // body" at the start (handle = outgoing control) and "direction of travel"
+  // at the end (handle = incoming control).
+  if (arrowheads.start && first && startCtrl) {
+    drawArrowhead(ctx, arrowPose(first, startCtrl, endTip ?? startCtrl), arrowheads.start, fillColor);
+  }
+  if (arrowheads.end && endTip && endCtrl) {
+    drawArrowhead(ctx, arrowPose(endTip, endCtrl, first ?? endCtrl), arrowheads.end, fillColor);
+  }
+}
+
+/** Tip at `p`, angle from `ctrl` → `p`; `fallback` covers a degenerate handle. */
+function arrowPose(p: Pt, ctrl: Pt, fallback: Pt): { x: number; y: number; angle: number } {
+  let dx = p.x - ctrl.x;
+  let dy = p.y - ctrl.y;
+  if (dx === 0 && dy === 0) {
+    dx = p.x - fallback.x;
+    dy = p.y - fallback.y;
+  }
+  return { x: p.x, y: p.y, angle: Math.atan2(dy, dx) };
 }
 
 /**

--- a/packages/slides/test/export/pptx/shape.test.ts
+++ b/packages/slides/test/export/pptx/shape.test.ts
@@ -25,6 +25,23 @@ describe('shape', () => {
     const el: ShapeElement = { id: 's', frame, type: 'shape', data: { kind: 'freeform', path: { commands: [{ c: 'M', x: 0, y: 0 }, { c: 'L', x: 1, y: 1 }, { c: 'Z' }] } } };
     expect(shapeToXml(el)).toContain('<a:custGeom>');
   });
+  it('emits tailEnd/headEnd on a freeform shape with arrowheads', () => {
+    const el: ShapeElement = {
+      id: 's', frame, type: 'shape',
+      data: {
+        kind: 'freeform',
+        path: { commands: [{ c: 'M', x: 0, y: 0 }, { c: 'C', x1: 0.3, y1: 0, x2: 0.7, y2: 0, x: 1, y: 0 }] },
+        stroke: { color: { kind: 'srgb', value: '#292929' }, width: 1 },
+        arrowheads: { end: { kind: 'triangle', size: 'md' } },
+      },
+    };
+    const xml = shapeToXml(el);
+    expect(xml).toContain('<a:tailEnd');
+    expect(xml).toContain('type="triangle"');
+    expect(xml).toContain('len="med"');
+    // No start arrowhead → no headEnd emitted.
+    expect(xml).not.toContain('<a:headEnd');
+  });
   it('emits empty p:txBody when shape has no text', () => {
     const el: ShapeElement = { id: 's', frame, type: 'shape', data: { kind: 'ellipse' } };
     const xml = shapeToXml(el);

--- a/packages/slides/test/import/pptx/freeform.test.ts
+++ b/packages/slides/test/import/pptx/freeform.test.ts
@@ -235,6 +235,51 @@ describe('parseSlide — freeform line-end arrowheads', () => {
     expect(el.data.arrowheads).toBeUndefined();
   });
 
+  it('drops arrowheads on a compound (multi-subpath) freeform — ambiguous ends', async () => {
+    // Two subpaths (closed triangle, then an open line). "The start"/"the end"
+    // is ambiguous, so arrowheads are not anchored to a guessed subpath.
+    const compound = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld><p:spTree>
+    <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+    <p:grpSpPr/>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="2" name="Compound freeform"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+      <p:spPr>
+        <a:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="1000000"/></a:xfrm>
+        <a:custGeom><a:pathLst><a:path w="200" h="100">
+          <a:moveTo><a:pt x="0" y="0"/></a:moveTo>
+          <a:lnTo><a:pt x="50" y="100"/></a:lnTo>
+          <a:lnTo><a:pt x="0" y="100"/></a:lnTo>
+          <a:close/>
+          <a:moveTo><a:pt x="100" y="0"/></a:moveTo>
+          <a:lnTo><a:pt x="200" y="100"/></a:lnTo>
+        </a:path></a:pathLst></a:custGeom>
+        <a:ln w="9525">
+          <a:solidFill><a:srgbClr val="292929"/></a:solidFill>
+          <a:tailEnd len="med" w="med" type="triangle"/>
+        </a:ln>
+      </p:spPr>
+    </p:sp>
+  </p:spTree></p:cSld>
+</p:sld>`;
+    const slide = await parseSlide({
+      archive: makeArchive({ 'ppt/slides/slide1.xml': compound }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    const el = slide!.elements[0];
+    expect(el.type).toBe('shape');
+    if (el.type !== 'shape') return;
+    const ms = (el.data.path?.commands ?? []).filter((c) => c.c === 'M');
+    expect(ms.length).toBe(2);
+    expect(el.data.arrowheads).toBeUndefined();
+  });
+
   it('drops arrowheads when the line has no stroke (noFill) — nothing to decorate', async () => {
     const noStroke = SLIDE_WITH_ARROWED_FREEFORM.replace(
       '<a:solidFill><a:srgbClr val="292929"/></a:solidFill>',

--- a/packages/slides/test/import/pptx/freeform.test.ts
+++ b/packages/slides/test/import/pptx/freeform.test.ts
@@ -5,6 +5,8 @@ import { parseSlide } from '../../../src/import/pptx/slide';
 import { ImportReport } from '../../../src/import/pptx/report';
 import { parseXml } from '../../../src/import/pptx/xml';
 import type { PptxArchive } from '../../../src/import/pptx/unzip';
+import { shapeToXml } from '../../../src/export/pptx/shape';
+import type { ShapeElement } from '../../../src/model/element';
 
 function makeArchive(files: Record<string, string>): PptxArchive {
   return {
@@ -137,5 +139,153 @@ describe('parseSlide — custGeom freeform dispatch', () => {
     expect(el.data.fill).toBeDefined();
     expect(el.data.path?.commands.length).toBe(5);
     expect(el.data.path?.commands[0]).toEqual({ c: 'M', x: 0, y: 0 });
+  });
+});
+
+const SLIDE_WITH_ARROWED_FREEFORM = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="2" name="Freeform 9"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr>
+          <a:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="1000000"/></a:xfrm>
+          <a:custGeom>
+            <a:pathLst>
+              <a:path w="200" h="100">
+                <a:moveTo><a:pt x="0" y="0"/></a:moveTo>
+                <a:cubicBezTo>
+                  <a:pt x="50" y="100"/><a:pt x="150" y="100"/><a:pt x="200" y="0"/>
+                </a:cubicBezTo>
+              </a:path>
+            </a:pathLst>
+          </a:custGeom>
+          <a:noFill/>
+          <a:ln w="9525">
+            <a:solidFill><a:srgbClr val="292929"/></a:solidFill>
+            <a:headEnd len="med" w="med" type="none"/>
+            <a:tailEnd len="med" w="med" type="triangle"/>
+          </a:ln>
+        </p:spPr>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
+describe('parseSlide — freeform line-end arrowheads', () => {
+  it('parses <a:tailEnd> on a custGeom shape into data.arrowheads.end', async () => {
+    const slide = await parseSlide({
+      archive: makeArchive({ 'ppt/slides/slide1.xml': SLIDE_WITH_ARROWED_FREEFORM }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    const el = slide!.elements[0];
+    expect(el.type).toBe('shape');
+    if (el.type !== 'shape') return;
+    expect(el.data.kind).toBe('freeform');
+    // headEnd type="none" → no start arrowhead; tailEnd triangle → end.
+    expect(el.data.arrowheads?.start).toBeUndefined();
+    expect(el.data.arrowheads?.end).toEqual({ kind: 'triangle', size: 'md' });
+  });
+
+  it('drops arrowheads on a closed (Z) custGeom — a loop has no open ends', async () => {
+    const closed = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <p:cSld><p:spTree>
+    <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+    <p:grpSpPr/>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="2" name="Closed freeform"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+      <p:spPr>
+        <a:xfrm><a:off x="0" y="0"/><a:ext cx="2000000" cy="1000000"/></a:xfrm>
+        <a:custGeom><a:pathLst><a:path w="200" h="100">
+          <a:moveTo><a:pt x="0" y="0"/></a:moveTo>
+          <a:lnTo><a:pt x="200" y="0"/></a:lnTo>
+          <a:lnTo><a:pt x="200" y="100"/></a:lnTo>
+          <a:close/>
+        </a:path></a:pathLst></a:custGeom>
+        <a:ln w="9525">
+          <a:solidFill><a:srgbClr val="292929"/></a:solidFill>
+          <a:tailEnd len="med" w="med" type="triangle"/>
+        </a:ln>
+      </p:spPr>
+    </p:sp>
+  </p:spTree></p:cSld>
+</p:sld>`;
+    const slide = await parseSlide({
+      archive: makeArchive({ 'ppt/slides/slide1.xml': closed }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    const el = slide!.elements[0];
+    expect(el.type).toBe('shape');
+    if (el.type !== 'shape') return;
+    const cmds = el.data.path?.commands ?? [];
+    expect(cmds[cmds.length - 1]?.c).toBe('Z');
+    expect(el.data.arrowheads).toBeUndefined();
+  });
+
+  it('drops arrowheads when the line has no stroke (noFill) — nothing to decorate', async () => {
+    const noStroke = SLIDE_WITH_ARROWED_FREEFORM.replace(
+      '<a:solidFill><a:srgbClr val="292929"/></a:solidFill>',
+      '<a:noFill/>',
+    );
+    const slide = await parseSlide({
+      archive: makeArchive({ 'ppt/slides/slide1.xml': noStroke }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    const el = slide!.elements[0];
+    expect(el.type).toBe('shape');
+    if (el.type !== 'shape') return;
+    expect(el.data.stroke).toBeUndefined();
+    expect(el.data.arrowheads).toBeUndefined();
+  });
+
+  it('round-trips a freeform arrowhead through export → import', async () => {
+    const el: ShapeElement = {
+      id: 'f', type: 'shape',
+      frame: { x: 0, y: 0, w: 200, h: 100, rotation: 0 },
+      data: {
+        kind: 'freeform',
+        path: { commands: [{ c: 'M', x: 0, y: 0 }, { c: 'C', x1: 0.3, y1: 1, x2: 0.7, y2: 1, x: 1, y: 0 }] },
+        stroke: { color: { kind: 'srgb', value: '#292929' }, width: 1 },
+        arrowheads: { end: { kind: 'triangle', size: 'md' } },
+      },
+    };
+    const slideXml = `<?xml version="1.0"?>
+      <p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:cSld><p:spTree>
+          <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+          <p:grpSpPr/>
+          ${shapeToXml(el)}
+        </p:spTree></p:cSld>
+      </p:sld>`;
+    const slide = await parseSlide({
+      archive: makeArchive({ 'ppt/slides/slide1.xml': slideXml }),
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap: new Map(),
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+    const back = slide!.elements[0];
+    expect(back.type).toBe('shape');
+    if (back.type !== 'shape') return;
+    expect(back.data.arrowheads?.end).toEqual({ kind: 'triangle', size: 'md' });
   });
 });

--- a/packages/slides/test/view/canvas/shape-renderer.test.ts
+++ b/packages/slides/test/view/canvas/shape-renderer.test.ts
@@ -138,6 +138,69 @@ describe('drawShape — freeform', () => {
     drawShape(asCtx(ctx), size, shape({ kind: 'freeform', fill: srgb('#abc') }), THEME);
     expect(ctx.fillRect).toHaveBeenCalledWith(0, 0, 100, 60);
   });
+
+  // Open path along +x so the end tangent is unambiguous: the tip lands on
+  // the last anchor (scaled to frame) and the arrowhead is filled with the
+  // stroke color.
+  const openLine = {
+    commands: [
+      { c: 'M' as const, x: 0, y: 0.5 },
+      { c: 'C' as const, x1: 0.3, y1: 0.5, x2: 0.7, y2: 0.5, x: 1, y: 0.5 },
+    ],
+  };
+
+  it('draws the end arrowhead tip at the last anchor, filled with stroke color', () => {
+    const ctx = createCtxSpy();
+    drawShape(asCtx(ctx), size, shape({
+      kind: 'freeform', path: openLine,
+      stroke: { color: srgb('#292929'), width: 1 },
+      arrowheads: { end: { kind: 'triangle', size: 'md' } },
+    }), THEME);
+    // Only the arrowhead uses ctx.fill (freeform body has no fill here);
+    // the triangle tip is moveTo'd at the scaled last anchor (100, 30).
+    expect(ctx.fill).toHaveBeenCalledTimes(1);
+    expect(ctx.fillStyle).toBe('#292929');
+    const tip = ctx.moveTo.mock.calls.find(
+      (c: number[]) => Math.abs(c[0] - 100) < 1e-6 && Math.abs(c[1] - 30) < 1e-6,
+    );
+    expect(tip).toBeTruthy();
+  });
+
+  it('draws no arrowhead when arrowheads is absent', () => {
+    const ctx = createCtxSpy();
+    drawShape(asCtx(ctx), size, shape({
+      kind: 'freeform', path: openLine, stroke: { color: srgb('#292929'), width: 1 },
+    }), THEME);
+    expect(ctx.fill).not.toHaveBeenCalled();
+  });
+
+  it('uses the true ellipse tangent (not the chord) for an arc endpoint', () => {
+    // Quarter arc, isotropic 100x100 frame: start θ=0 at (100,50), end θ=π/2
+    // at (50,100). True travel tangent at the end points -x (angle π), so the
+    // triangle base extends back toward +x (baseX = 100 - cos(π)*12 = 62).
+    const ctx = createCtxSpy();
+    drawShape(asCtx(ctx), { w: 100, h: 100 }, shape({
+      kind: 'freeform',
+      path: {
+        commands: [
+          { c: 'M', x: 1, y: 0.5 },
+          { c: 'A', cx: 0.5, cy: 0.5, rx: 0.5, ry: 0.5, start: 0, sweep: Math.PI / 2 },
+        ],
+      },
+      stroke: { color: srgb('#292929'), width: 1 },
+      arrowheads: { end: { kind: 'triangle', size: 'md' } },
+    }), THEME);
+    // Tip on the arc end (50,100).
+    const tip = ctx.moveTo.mock.calls.find(
+      (c: number[]) => Math.abs(c[0] - 50) < 1e-6 && Math.abs(c[1] - 100) < 1e-6,
+    );
+    expect(tip).toBeTruthy();
+    // A chord approximation would give angle ≈ atan2(50,-50)=135°, base to the
+    // lower-right; the true tangent puts both base corners at x≈62 (>50).
+    const [c1, c2] = ctx.lineTo.mock.calls as number[][];
+    expect(c1[0]).toBeCloseTo(62);
+    expect(c2[0]).toBeCloseTo(62);
+  });
 });
 
 describe('drawShape — donut (evenodd fill rule)', () => {


### PR DESCRIPTION
## Summary

Freeform shapes (`<p:sp>` + `<a:custGeom>`) can carry line-end arrowheads on their `<a:ln>` (`<a:headEnd>`/`<a:tailEnd>`), exactly like connectors. PowerPoint and Google Slides export **arrowed curves as freeform paths**, not `<p:cxnSp>` — so decks such as the shared "Yorkie 실시간 동시 편집 적용하기" deck lost their arrow tips entirely.

Repro: slide 10 ("Local First Remote Later"), the teal (`accent5`) and orange (`FFAB40`) cubic-bezier curves around the "Asynchronous" cloud carry `<a:tailEnd type="triangle" len="med" w="med"/>`; their tips were missing in Wafflebase (present in Keynote/Google Slides). Root cause: import `buildFreeformElement` read only fill+stroke, the model had no `arrowheads` field, and the renderer drew none — arrowheads were only ever wired for `ConnectorElement`.

## Changes

Arrowhead support across the freeform pipeline, reusing the connector primitives so behavior stays consistent:

- **model** — `ShapeElement.data` gains optional `arrowheads { start?, end? }` (shares the connector `ArrowheadStyle`).
- **import** — `buildFreeformElement` parses `headEnd`/`tailEnd` via `parseArrowhead`, gated to a **stroked, open** path (no stroke or a closed `Z` loop has nothing to decorate) so import/render/export stay symmetric.
- **render** — `drawShape` draws start/end arrowheads at the path's first/last anchor; tangent from the adjacent bezier/line control (start reversed to point out of the body) or, for arc segments, the **true ellipse tangent**.
- **export** — freeform-only `<a:ln>` emits `headEnd`/`tailEnd` via the shared `arrowXml`.

Connectors and parametric shapes are unaffected. Arrowhead **size** stays the existing fixed `sm/md/lg` model (the separate slide-5 "fixed vs line-width-proportional sizing" question is out of scope).

## Test plan

- TDD: failing import/render/export tests → implementation → green, plus an export→import round-trip test.
- Review fixes (high, workflow-backed): stroke/closed-path gating + true arc tangent, each with a test.
- `pnpm verify:fast` — EXIT=0 (lint + typecheck + all unit tests; slides +6 tests).
- Verified against the **real deck** `slide10.xml`: ≥2 freeform shapes now carry an end triangle arrowhead.
- Manual smoke (re-upload the .pptx in `pnpm dev`) recommended before merge — the already-stored shared doc won't re-import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Freeform shapes in slides can now preserve and render line-end arrowheads when opened, edited, or exported.
  * Arrowheads are now supported for supported open freeform paths, including curved segments.

* **Bug Fixes**
  * Arrowheads are no longer applied to closed freeform shapes or shapes without a stroke.
  * Arrowhead positioning for arc-based freeforms is now aligned more accurately with the curve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->