### PR TITLE
Fix PPTX text-box line-break sizing and paragraph spacing on import

### DIFF
--- a/docs/tasks/active/20260704-pptx-br-empty-line-font-size-todo.md
+++ b/docs/tasks/active/20260704-pptx-br-empty-line-font-size-todo.md
@@ -34,11 +34,29 @@ also inflates the *preceding* content line (`max(8, 11) = 11`).
 - [x] Verified end-to-end against the real deck (all blank/newline
       inlines in the roadmap box now carry 8pt, no `undefined`).
 
-## Out of scope (separate fidelity gaps)
+## Follow-up: paragraph spacing (same box, second report)
 
-- Importer defaults `lineHeight` to docs `1.5` when `<a:lnSpc>` absent
-  (PPTX default is 1.0) — inflates all lines uniformly.
-- `<a:spcBef>` / `<a:spcAft>` / absolute `spcPts` line spacing unparsed.
+After the font-size fix the gap between "v0.3: SaaS 오픈" and
+"더 쉽고 빠른…" (which sandwich the empty paragraph) was still too wide.
+Measured the box's blocks: every block carried `lineHeight=1.5` and
+`marginBottom=8` — docs *word-processor* defaults inherited from
+`DEFAULT_BLOCK_STYLE`, even though the source sets `spcBef=0`/`spcAft=0`
+and no `<a:lnSpc>` (PPTX default is single spacing, zero para gap).
 
-These affect all imported text uniformly, not the reported
-disproportionate-newline symptom.
+- [x] Reset imported paragraph spacing to PPTX defaults: `lineHeight 1.2`
+      (PowerPoint "single" ≈ 1.2×, folds in the font's leading; 1.0 packs
+      body text too tight), `marginTop/marginBottom 0` (was 1.5 / 0 / 8).
+- [x] Parse `<a:spcBef>`/`<a:spcAft>` `spcPts` → `marginTop`/`marginBottom`
+      (points × 96/72 → px); honors an explicit `spcAft="0"`.
+- [x] Export inverse: emit `<a:spcBef>`/`<a:spcAft>` from margins (OOXML
+      order lnSpc → spcBef → spcAft) so round-trip holds.
+- [x] Tests: default single-spacing/zero-margin, spcBef/spcAft mapping,
+      explicit-zero, export emission + omission; round-trip suite green.
+- [x] Verified on the real deck: blocks now `lineHeight=1`, `mBot=0` on
+      the v0.3 line + blank line, `mBot=21.3px` (=16pt spcAft) on the
+      bullet paragraph.
+
+## Still out of scope
+
+- `<a:lnSpc>` absolute `spcPts` line spacing (docs lineHeight is a ratio).
+- `<a:spcBef>`/`<a:spcAft>` percent-of-line (`spcPct`) form (rare).

--- a/docs/tasks/active/20260704-pptx-br-empty-line-font-size-todo.md
+++ b/docs/tasks/active/20260704-pptx-br-empty-line-font-size-todo.md
@@ -1,0 +1,44 @@
+# PPTX `<a:br>` / blank-line font size — todo
+
+## Problem
+
+Imported PPTX text boxes drop `<a:br>` newlines and blank lines "too far
+down". Repro: `Yorkie_ 실시간 동시 편집 적용하기.pptx`, roadmap slide
+(slide31), "v0.3: SaaS 오픈" box — all body text is 8pt but the line
+breaks render ~37% too tall.
+
+## Root cause
+
+`packages/slides/src/import/pptx/text.ts`:
+
+- `<a:br>` was lifted to `{ text: '\n', style: {} }` — dropping the
+  `<a:rPr sz>` it carries.
+- Blank paragraphs (`<a:p/>` or `<a:r><a:t/></a:r>` + `<a:endParaRPr>`)
+  got a `{ text: '', style: {} }` placeholder — never reading
+  `<a:endParaRPr>`.
+
+Downstream, `docs` `getLineMaxFontSizePx` (layout.ts) falls back to
+`Theme.defaultFontSize` (11pt) for any run without `fontSize`, and
+`assignLineHeights` multiplies that by lineHeight. A `\n` run at 11pt
+also inflates the *preceding* content line (`max(8, 11) = 11`).
+
+## Fix
+
+- [x] Extract `parseRunStyle(rPr, fontScale, ctx)` from `parseRun`.
+- [x] `<a:br>` → `parseRunStyle(child(el,'rPr'), …)` on the `\n` inline.
+- [x] Blank paragraph (no visible-text inline) → collapse to one
+      placeholder sized from `<a:endParaRPr>`; covers bare `<a:p/>` and
+      empty `<a:t/>` runs.
+- [x] Unit tests: br carries size, empty `<a:p>` from endParaRPr, empty
+      `<a:t/>` run collapse.
+- [x] Verified end-to-end against the real deck (all blank/newline
+      inlines in the roadmap box now carry 8pt, no `undefined`).
+
+## Out of scope (separate fidelity gaps)
+
+- Importer defaults `lineHeight` to docs `1.5` when `<a:lnSpc>` absent
+  (PPTX default is 1.0) — inflates all lines uniformly.
+- `<a:spcBef>` / `<a:spcAft>` / absolute `spcPts` line spacing unparsed.
+
+These affect all imported text uniformly, not the reported
+disproportionate-newline symptom.

--- a/docs/tasks/active/20260704-pptx-br-empty-line-font-size-todo.md
+++ b/docs/tasks/active/20260704-pptx-br-empty-line-font-size-todo.md
@@ -56,7 +56,25 @@ and no `<a:lnSpc>` (PPTX default is single spacing, zero para gap).
       the v0.3 line + blank line, `mBot=21.3px` (=16pt spcAft) on the
       bullet paragraph.
 
+## Code review (high effort, workflow) — findings addressed
+
+- [x] **Empty-paragraph round-trip regression (blocking).** The collapse
+      guard read size only from `<a:endParaRPr>`, discarding an empty run's
+      own `sz`; since export writes a blank line as `<a:r sz=…/>` (no
+      endParaRPr), the second import lost the size. Fixed: prefer a size an
+      empty run already carries, fall back to endParaRPr.
+- [x] **Soft break exported as literal `\n`.** `runToXml` emitted `\n`
+      inside `<a:t>` (PowerPoint collapses it, dropping the break). Fixed:
+      split on `\n` and emit `<a:br>` (with the run's `<a:rPr>`) between
+      segments — the exact inverse of the importer.
+- [x] **Bare `<a:br/>` (no rPr).** Now inherits the preceding run's font
+      size instead of falling back to the docs 11 pt default.
+- [x] Regression tests for all three (import + export + a full
+      export→re-import blank-line size round-trip).
+
 ## Still out of scope
 
 - `<a:lnSpc>` absolute `spcPts` line spacing (docs lineHeight is a ratio).
-- `<a:spcBef>`/`<a:spcAft>` percent-of-line (`spcPct`) form (rare).
+- `<a:spcBef>`/`<a:spcAft>` percent-of-line (`spcPct`) form — can't be a
+  faithful fixed-px margin without per-run line height, so left at 0 (a
+  documented review finding; rare in practice).

--- a/packages/slides/src/export/pptx/text.ts
+++ b/packages/slides/src/export/pptx/text.ts
@@ -74,6 +74,16 @@ function blockToXml(block: Block): string {
       ? `<a:lnSpc><a:spcPct val="${Math.round(block.style.lineHeight * 100_000)}"/></a:lnSpc>`
       : '';
 
+  // spcBef / spcAft — importer reads <a:spcPts val> (hundredths of a point)
+  // and scales by 96/72 into px. Invert: px → points × 100. Emit only when
+  // non-zero (zero is the PPTX default). OOXML pPr order: lnSpc, spcBef, spcAft.
+  const spcBef = block.style.marginTop
+    ? `<a:spcBef><a:spcPts val="${Math.round((block.style.marginTop * 72) / 96 * 100)}"/></a:spcBef>`
+    : '';
+  const spcAft = block.style.marginBottom
+    ? `<a:spcAft><a:spcPts val="${Math.round((block.style.marginBottom * 72) / 96 * 100)}"/></a:spcAft>`
+    : '';
+
   // Bullet marker style — emit buClr, buSzPts, buFont BEFORE buAutoNum/buChar
   // per OOXML pPr child order. Only meaningful on list items; only emit when present.
   const markerXml = block.listKind ? markerToXml(block.marker) : '';
@@ -82,7 +92,7 @@ function blockToXml(block: Block): string {
   if (block.listKind === 'ordered') buType = '<a:buAutoNum type="arabicPeriod"/>';
   else if (block.listKind === 'unordered') buType = '<a:buChar char="•"/>';
 
-  const pPr = `<a:pPr algn="${algn}"${lvl}${marLAttr}${indentAttr}>${lnSpc}${markerXml}${buType}</a:pPr>`;
+  const pPr = `<a:pPr algn="${algn}"${lvl}${marLAttr}${indentAttr}>${lnSpc}${spcBef}${spcAft}${markerXml}${buType}</a:pPr>`;
   const runs = block.inlines.map(runToXml).join('');
   return `<a:p>${pPr}${runs}</a:p>`;
 }

--- a/packages/slides/src/export/pptx/text.ts
+++ b/packages/slides/src/export/pptx/text.ts
@@ -162,7 +162,25 @@ function storedColorToThemeColor(c: StoredColor): ThemeColor {
 }
 
 function runToXml(inline: Inline): string {
-  const s = inline.style;
+  const rPr = rPrXml(inline.style);
+  // Soft line breaks (`\n`, imported from `<a:br>`) must round-trip back to
+  // `<a:br>`, not a literal newline in `<a:t>` — PowerPoint collapses raw
+  // newlines as insignificant whitespace, losing the break. Split on `\n`
+  // and emit an `<a:br>` (carrying the run's props) between text segments.
+  if (inline.text.includes('\n')) {
+    const segs = inline.text.split('\n');
+    const parts: string[] = [];
+    segs.forEach((seg, i) => {
+      if (i > 0) parts.push(`<a:br>${rPr}</a:br>`);
+      if (seg) parts.push(`<a:r>${rPr}<a:t>${escapeXmlText(seg)}</a:t></a:r>`);
+    });
+    return parts.join('');
+  }
+  return `<a:r>${rPr}<a:t>${escapeXmlText(inline.text)}</a:t></a:r>`;
+}
+
+/** Build the `<a:rPr>` node for a run/break from an inline style. */
+function rPrXml(s: Inline['style']): string {
   const attrs: string[] = [];
   if (s.bold) attrs.push('b="1"');
   if (s.italic) attrs.push('i="1"');
@@ -187,9 +205,7 @@ function runToXml(inline: Inline): string {
   }
   // s.href: hyperlink wiring is deferred (Phase 2). Do not emit any
   // <a:hlinkClick> node — an empty r:id="" produces an invalid relationship.
-  const rPr =
-    attrs.length || children.length
-      ? `<a:rPr${attrs.length ? ' ' + attrs.join(' ') : ''}>${children.join('')}</a:rPr>`
-      : `<a:rPr/>`;
-  return `<a:r>${rPr}<a:t>${escapeXmlText(inline.text)}</a:t></a:r>`;
+  return attrs.length || children.length
+    ? `<a:rPr${attrs.length ? ' ' + attrs.join(' ') : ''}>${children.join('')}</a:rPr>`
+    : `<a:rPr/>`;
 }

--- a/packages/slides/src/import/pptx/text.ts
+++ b/packages/slides/src/import/pptx/text.ts
@@ -182,19 +182,28 @@ function parseParagraph(
   const { style, list, marker } = parseParagraphProperties(pPr, ctx);
 
   const inlines: Inline[] = [];
+  // Font size of the most recent real run — a bare `<a:br/>` inherits it so
+  // the break line matches the surrounding text (PowerPoint sizes the break
+  // from the adjacent run's formatting).
+  let lastRunFontSize: number | undefined;
   for (let i = 0; i < p.childNodes.length; i++) {
     const n = p.childNodes[i];
     if (n.nodeType !== 1) continue;
     const el = n as Element;
-    if (el.localName === 'r') inlines.push(parseRun(el, fontScale, ctx));
-    else if (el.localName === 'br') {
+    if (el.localName === 'r') {
+      const inline = parseRun(el, fontScale, ctx);
+      inlines.push(inline);
+      if (inline.style.fontSize != null) lastRunFontSize = inline.style.fontSize;
+    } else if (el.localName === 'br') {
       // `<a:br>` carries its own `<a:rPr>` (font size, weight, …). Lift it
       // onto the soft-break inline so the blank/broken line is sized to the
       // surrounding text — a bare `{}` style would fall back to the docs
       // default (11 pt) and drop the newline visibly too far below small text.
-      inlines.push({ text: '\n', style: parseRunStyle(child(el, 'rPr'), fontScale, ctx) });
-    }
-    else if (el.localName === 'fld') {
+      // When the break has no explicit size, inherit the preceding run's.
+      const style = parseRunStyle(child(el, 'rPr'), fontScale, ctx);
+      if (style.fontSize == null && lastRunFontSize != null) style.fontSize = lastRunFontSize;
+      inlines.push({ text: '\n', style });
+    } else if (el.localName === 'fld') {
       // `<a:fld>` is a field (slide number, date, …). v1 dumps the
       // pre-rendered text and ignores the field semantics.
       const t = child(el, 't');
@@ -202,20 +211,24 @@ function parseParagraph(
     }
   }
 
-  // A blank paragraph — no runs at all, or only empty `<a:t/>` runs — is
-  // one empty visual line whose height PowerPoint takes from
-  // `<a:endParaRPr>` (the paragraph-mark run). Collapse it to a single
-  // placeholder carrying that size: docs's `computeLayout` needs at least
-  // one inline per block, and without the endParaRPr size the line falls
-  // back to the docs default (11 pt), opening a gap that's too large next
-  // to small-point body text. Paragraphs that hold a `<a:br>` newline keep
+  // A blank paragraph — no runs at all, or only empty `<a:t/>` runs — is one
+  // empty visual line that still needs a height. Collapse it to a single
+  // placeholder (docs's `computeLayout` needs at least one inline per block)
+  // and give it a font size, else the line falls back to the docs default
+  // (11 pt) and opens a gap that's too large next to small-point body text.
+  // Prefer a size an empty run already carries — this is what an exported
+  // blank line round-trips as (`<a:r sz=…/>` with no `<a:endParaRPr>`), so
+  // reading only endParaRPr here would drop the size on the second import.
+  // Otherwise fall back to `<a:endParaRPr>`, the paragraph-mark run PowerPoint
+  // uses to size a blank line. Paragraphs holding a `<a:br>` newline keep
   // their own already-sized inlines and are untouched here.
   if (!inlines.some((i) => i.text !== '')) {
+    const sized = inlines.find((i) => i.style.fontSize != null);
+    const style = sized
+      ? sized.style
+      : parseRunStyle(child(p, 'endParaRPr'), fontScale, ctx);
     inlines.length = 0;
-    inlines.push({
-      text: '',
-      style: parseRunStyle(child(p, 'endParaRPr'), fontScale, ctx),
-    });
+    inlines.push({ text: '', style });
   }
 
   const block: Block = {

--- a/packages/slides/src/import/pptx/text.ts
+++ b/packages/slides/src/import/pptx/text.ts
@@ -156,7 +156,13 @@ function parseParagraph(
     if (n.nodeType !== 1) continue;
     const el = n as Element;
     if (el.localName === 'r') inlines.push(parseRun(el, fontScale, ctx));
-    else if (el.localName === 'br') inlines.push({ text: '\n', style: {} });
+    else if (el.localName === 'br') {
+      // `<a:br>` carries its own `<a:rPr>` (font size, weight, …). Lift it
+      // onto the soft-break inline so the blank/broken line is sized to the
+      // surrounding text — a bare `{}` style would fall back to the docs
+      // default (11 pt) and drop the newline visibly too far below small text.
+      inlines.push({ text: '\n', style: parseRunStyle(child(el, 'rPr'), fontScale, ctx) });
+    }
     else if (el.localName === 'fld') {
       // `<a:fld>` is a field (slide number, date, …). v1 dumps the
       // pre-rendered text and ignores the field semantics.
@@ -165,9 +171,21 @@ function parseParagraph(
     }
   }
 
-  // Empty paragraphs need a placeholder inline so layout doesn't NaN —
-  // docs's `computeLayout` requires at least one inline per block.
-  if (inlines.length === 0) inlines.push({ text: '', style: {} });
+  // A blank paragraph — no runs at all, or only empty `<a:t/>` runs — is
+  // one empty visual line whose height PowerPoint takes from
+  // `<a:endParaRPr>` (the paragraph-mark run). Collapse it to a single
+  // placeholder carrying that size: docs's `computeLayout` needs at least
+  // one inline per block, and without the endParaRPr size the line falls
+  // back to the docs default (11 pt), opening a gap that's too large next
+  // to small-point body text. Paragraphs that hold a `<a:br>` newline keep
+  // their own already-sized inlines and are untouched here.
+  if (!inlines.some((i) => i.text !== '')) {
+    inlines.length = 0;
+    inlines.push({
+      text: '',
+      style: parseRunStyle(child(p, 'endParaRPr'), fontScale, ctx),
+    });
+  }
 
   const block: Block = {
     id: generateBlockId(),
@@ -320,7 +338,34 @@ function parseRun(
   ctx: TextParseContext,
   textOverride?: string,
 ): Inline {
-  const rPr = child(r, 'rPr');
+  const style = parseRunStyle(child(r, 'rPr'), fontScale, ctx);
+  const text = textOverride ?? textOf(child(r, 't') ?? r);
+
+  // No script-specific fontFamily override here. The renderer
+  // (`@wafflebase/docs` `resolveFontFamily`) splices a Korean-capable
+  // family into every non-monospace fallback chain, so the browser picks
+  // a Hangul face per-glyph even when this run's typeface (e.g. Arial or
+  // a brand font we don't have) carries no Korean glyphs.
+
+  return { text, style };
+}
+
+/**
+ * Parse an `<a:rPr>`-shaped element into an `InlineStyle`.
+ *
+ * The element is the run-property container itself: `<a:rPr>` for a run,
+ * the `<a:rPr>` child of an `<a:br>`, or the paragraph's `<a:endParaRPr>`
+ * (whose attributes/children mirror `<a:rPr>` exactly). Sharing this path
+ * is what lets line breaks and empty paragraphs carry their real font
+ * size instead of collapsing to the docs default — a blank line sized at
+ * 11 pt next to 8 pt body text is what makes an imported `<a:br>` drop
+ * visibly too far.
+ */
+function parseRunStyle(
+  rPr: Element | undefined,
+  fontScale: number,
+  ctx: TextParseContext,
+): InlineStyle {
   const style: InlineStyle = {};
 
   // Apply placeholder-derived default first so an explicit `sz` below
@@ -383,15 +428,7 @@ function parseRun(
     }
   }
 
-  const text = textOverride ?? textOf(child(r, 't') ?? r);
-
-  // No script-specific fontFamily override here. The renderer
-  // (`@wafflebase/docs` `resolveFontFamily`) splices a Korean-capable
-  // family into every non-monospace fallback chain, so the browser picks
-  // a Hangul face per-glyph even when this run's typeface (e.g. Arial or
-  // a brand font we don't have) carries no Korean glyphs.
-
-  return { text, style };
+  return style;
 }
 
 /**

--- a/packages/slides/src/import/pptx/text.ts
+++ b/packages/slides/src/import/pptx/text.ts
@@ -87,6 +87,37 @@ export function detectVerticalAnchor(txBody: Element): VerticalAnchorMode | unde
 const DEFAULT_INS = { l: 91_440, t: 45_720, r: 91_440, b: 45_720 } as const;
 
 /**
+ * Points → CSS px at 96 dpi. The docs layout engine renders `fontSize`
+ * (points) via the same 96/72 factor, so paragraph margins derived from
+ * point-valued `<a:spcBef>`/`<a:spcAft>` must use it too to scale in step
+ * with the text they space.
+ */
+const PX_PER_PT = 96 / 72;
+
+/**
+ * Line-height multiplier for PowerPoint "single" line spacing (a paragraph
+ * with no `<a:lnSpc>`). PowerPoint's single spacing includes the font's
+ * natural leading, rendering at roughly 1.2× the em — so 1.0 packs text too
+ * tight and the docs 1.5 word-processor default spreads it too far. Explicit
+ * `<a:lnSpc>` percentages still override this per paragraph.
+ */
+const PPTX_SINGLE_LINE_HEIGHT = 1.2;
+
+/**
+ * Convert an `<a:spcBef>` / `<a:spcAft>` container to a px margin. Reads
+ * absolute `<a:spcPts>` (hundredths of a point) only; returns `undefined`
+ * when the element is absent or uses the rare percent-of-line form so the
+ * caller can leave the axis at its default.
+ */
+function parseSpacingPx(spc: Element | undefined): number | undefined {
+  if (!spc) return undefined;
+  const pts = child(spc, 'spcPts');
+  if (!pts) return undefined;
+  const v = attrInt(pts, 'val');
+  return v != null ? (v / 100) * PX_PER_PT : undefined;
+}
+
+/**
  * Read `<a:bodyPr lIns/tIns/rIns/bIns>` and convert EMU → deck-canvas px via
  * the per-axis scale (horizontal insets use `sx`, vertical use `sy`), exactly
  * like table-cell padding. Returns `undefined` when `<a:bodyPr>` declares no
@@ -220,7 +251,21 @@ function parseParagraphProperties(
   list: ListInfo | undefined;
   marker: BlockMarker | undefined;
 } {
-  const style: BlockStyle = { ...DEFAULT_BLOCK_STYLE };
+  // PPTX paragraphs carry no implicit inter-paragraph gap, and their
+  // default line spacing is PowerPoint "single" — which renders at ~1.2×
+  // the font size (it folds in the font's natural leading), NOT 1.0.
+  // `DEFAULT_BLOCK_STYLE` is the docs *word-processor* default (1.5 line
+  // height, 8 px bottom margin); inheriting it made every imported line
+  // 25 % too tall and injected an 8 px gap the source never asked for —
+  // visible as over-wide blank lines. But 1.0 is the opposite error: it
+  // strips the leading and packs body text too tight. Reset to the PPTX
+  // single-spacing defaults, then layer on whatever the deck specifies.
+  const style: BlockStyle = {
+    ...DEFAULT_BLOCK_STYLE,
+    lineHeight: PPTX_SINGLE_LINE_HEIGHT,
+    marginTop: 0,
+    marginBottom: 0,
+  };
   if (!pPr) return { style, list: undefined, marker: undefined };
 
   const algn = attr(pPr, 'algn');
@@ -237,10 +282,20 @@ function parseParagraphProperties(
       const v = attrInt(pct, 'val');
       if (v != null) style.lineHeight = v / 100_000;
     }
-    // spcPts (absolute points) is rare; ignore for v1 — design doc says
-    // docs's lineHeight is a ratio, not an absolute, so the closest
-    // faithful translation is keeping the default 1.5.
+    // spcPts (absolute points) is rare; ignore for v1 — docs's lineHeight is
+    // a ratio, not an absolute, so the closest faithful translation is
+    // keeping the single-spacing default.
   }
+
+  // Paragraph spacing — `<a:spcBef>`/`<a:spcAft>` map to the block's top /
+  // bottom margins. Reading these is also what stops a source `spcAft="0"`
+  // from silently keeping the docs 8 px default. Absolute `<a:spcPts>` is the
+  // common form and the only one docs px margins can represent faithfully;
+  // `<a:spcPct>` (percent of a line) is rare and skipped.
+  const before = parseSpacingPx(child(pPr, 'spcBef'));
+  if (before != null) style.marginTop = before;
+  const after = parseSpacingPx(child(pPr, 'spcAft'));
+  if (after != null) style.marginBottom = after;
 
   // Indent / left margin — PPTX values are in EMU; docs values are px.
   // We don't have the slide scale at parse time, so we approximate with

--- a/packages/slides/test/export/pptx/text.test.ts
+++ b/packages/slides/test/export/pptx/text.test.ts
@@ -98,6 +98,31 @@ describe('textBodyToXml', () => {
     expect(xml).toContain('algn="ctr"');
   });
 
+  it('emits spcBef/spcAft from top/bottom margins (px → spcPts)', () => {
+    const block: Block = {
+      id: 'b',
+      type: 'paragraph',
+      inlines: [{ text: 'A', style: {} }],
+      // 8 px → 6pt (val 600); 21.333 px → 16pt (val 1600).
+      style: { ...DEFAULT_BLOCK_STYLE, marginTop: 8, marginBottom: 21.3333 },
+    };
+    const xml = textBodyToXml({ blocks: [block] });
+    expect(xml).toContain('<a:spcBef><a:spcPts val="600"/></a:spcBef>');
+    expect(xml).toContain('<a:spcAft><a:spcPts val="1600"/></a:spcAft>');
+  });
+
+  it('omits spcBef/spcAft when margins are zero', () => {
+    const block: Block = {
+      id: 'b',
+      type: 'paragraph',
+      inlines: [{ text: 'A', style: {} }],
+      style: { ...DEFAULT_BLOCK_STYLE, marginTop: 0, marginBottom: 0 },
+    };
+    const xml = textBodyToXml({ blocks: [block] });
+    expect(xml).not.toContain('<a:spcBef>');
+    expect(xml).not.toContain('<a:spcAft>');
+  });
+
   it('emits ordered list bullet', () => {
     const block: Block = {
       id: 'b',

--- a/packages/slides/test/export/pptx/text.test.ts
+++ b/packages/slides/test/export/pptx/text.test.ts
@@ -1,5 +1,9 @@
+// @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
 import { textBodyToXml } from '../../../src/export/pptx/text.js';
+import { parseTextBody } from '../../../src/import/pptx/text.js';
+import { ImportReport } from '../../../src/import/pptx/report.js';
+import { parseXml } from '../../../src/import/pptx/xml.js';
 import { DEFAULT_BLOCK_STYLE, type Block } from '@wafflebase/docs';
 
 function para(text: string, style: Record<string, unknown> = {}): Block {
@@ -121,6 +125,44 @@ describe('textBodyToXml', () => {
     const xml = textBodyToXml({ blocks: [block] });
     expect(xml).not.toContain('<a:spcBef>');
     expect(xml).not.toContain('<a:spcAft>');
+  });
+
+  it('exports a soft break (\\n) as <a:br>, not a literal newline', () => {
+    // A literal newline in <a:t> is collapsed by PowerPoint as insignificant
+    // whitespace, dropping the break; it must round-trip through <a:br>.
+    const block: Block = {
+      id: 'b',
+      type: 'paragraph',
+      inlines: [
+        { text: 'line1', style: { fontSize: 8 } },
+        { text: '\n', style: { fontSize: 8 } },
+        { text: 'line2', style: { fontSize: 8 } },
+      ],
+      style: { ...DEFAULT_BLOCK_STYLE },
+    };
+    const xml = textBodyToXml({ blocks: [block] });
+    expect(xml).toContain('<a:br><a:rPr sz="800"></a:rPr></a:br>');
+    expect(xml).toContain('<a:t>line1</a:t>');
+    expect(xml).toContain('<a:t>line2</a:t>');
+    expect(xml).not.toContain('<a:t>\n</a:t>');
+  });
+
+  it('round-trips a blank-line font size through export → re-import', () => {
+    // Blank paragraph sized at 8pt (as an empty run) must survive a full
+    // export → import cycle without collapsing to the docs default.
+    const block: Block = {
+      id: 'b',
+      type: 'paragraph',
+      inlines: [{ text: '', style: { fontSize: 8 } }],
+      style: { ...DEFAULT_BLOCK_STYLE },
+    };
+    const xml = textBodyToXml({ blocks: [block] }, 'p:txBody');
+    const el = parseXml(
+      `<root xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ` +
+        `xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">${xml}</root>`,
+    ).documentElement.firstElementChild!;
+    const reimported = parseTextBody(el, { report: new ImportReport() });
+    expect(reimported[0].inlines[0].style.fontSize).toBe(8);
   });
 
   it('emits ordered list bullet', () => {

--- a/packages/slides/test/import/pptx/text.test.ts
+++ b/packages/slides/test/import/pptx/text.test.ts
@@ -125,6 +125,41 @@ describe('parseTextBody — paragraphs', () => {
     expect(block.style.textIndent).toBe(-48);
   });
 
+  it('defaults to PowerPoint single spacing and no paragraph margins', () => {
+    // The docs word-processor defaults (1.5 line height, 8 px bottom margin)
+    // must not leak into imported slides. PPTX single spacing renders at
+    // ~1.2× (not 1.0, which packs body text too tight), with no implicit
+    // inter-paragraph gap.
+    const t = txBody(`<a:txBody><a:bodyPr/><a:p><a:r><a:t>x</a:t></a:r></a:p></a:txBody>`);
+    const block = parseTextBody(t, { report: new ImportReport() })[0];
+    expect(block.style.lineHeight).toBe(1.2);
+    expect(block.style.marginTop).toBe(0);
+    expect(block.style.marginBottom).toBe(0);
+  });
+
+  it('maps <a:spcBef>/<a:spcAft> spcPts to top/bottom margins in px', () => {
+    const t = txBody(`<a:txBody><a:bodyPr/><a:p>
+      <a:pPr>
+        <a:spcBef><a:spcPts val="600"/></a:spcBef>
+        <a:spcAft><a:spcPts val="1600"/></a:spcAft>
+      </a:pPr>
+      <a:r><a:t>x</a:t></a:r>
+    </a:p></a:txBody>`);
+    const block = parseTextBody(t, { report: new ImportReport() })[0];
+    // 6pt × 96/72 = 8; 16pt × 96/72 = 21.333…
+    expect(block.style.marginTop).toBeCloseTo(8, 6);
+    expect(block.style.marginBottom).toBeCloseTo(21.3333, 3);
+  });
+
+  it('honors an explicit <a:spcAft val="0"> instead of the docs 8 px default', () => {
+    const t = txBody(`<a:txBody><a:bodyPr/><a:p>
+      <a:pPr><a:spcAft><a:spcPts val="0"/></a:spcAft></a:pPr>
+      <a:r><a:t>x</a:t></a:r>
+    </a:p></a:txBody>`);
+    const block = parseTextBody(t, { report: new ImportReport() })[0];
+    expect(block.style.marginBottom).toBe(0);
+  });
+
   it('classifies bulleted and numbered paragraphs as list-items', () => {
     const t = txBody(`<a:txBody>
       <a:bodyPr/>

--- a/packages/slides/test/import/pptx/text.test.ts
+++ b/packages/slides/test/import/pptx/text.test.ts
@@ -362,6 +362,31 @@ describe('parseTextBody — paragraphs', () => {
     expect(br?.style.fontSize).toBe(8);
   });
 
+  it('inherits the preceding run size for a bare <a:br/> (no rPr)', () => {
+    // PowerPoint sizes a bare break from the adjacent run; without this the
+    // break line jumps to the docs 11 pt default above small body text.
+    const t = txBody(`<a:txBody><a:bodyPr/><a:p>
+      <a:r><a:rPr sz="800"/><a:t>x</a:t></a:r>
+      <a:br/>
+    </a:p></a:txBody>`);
+    const blocks = parseTextBody(t, { report: new ImportReport() });
+    const br = blocks[0].inlines.find((i) => i.text === '\n');
+    expect(br?.style.fontSize).toBe(8);
+  });
+
+  it('keeps an empty run’s own size over an absent endParaRPr', () => {
+    // Round-trip guard: an exported blank line comes back as `<a:r sz=…/>`
+    // with no endParaRPr. The size must survive the second import, not
+    // collapse to the docs default.
+    const t = txBody(
+      `<a:txBody><a:bodyPr/><a:p><a:r><a:rPr sz="800"/><a:t></a:t></a:r></a:p></a:txBody>`,
+    );
+    const blocks = parseTextBody(t, { report: new ImportReport() });
+    expect(blocks[0].inlines).toHaveLength(1);
+    expect(blocks[0].inlines[0].text).toBe('');
+    expect(blocks[0].inlines[0].style.fontSize).toBe(8);
+  });
+
   it('sizes an empty paragraph from <a:endParaRPr>', () => {
     const t = txBody(
       `<a:txBody><a:bodyPr/><a:p><a:endParaRPr sz="800"/></a:p></a:txBody>`,

--- a/packages/slides/test/import/pptx/text.test.ts
+++ b/packages/slides/test/import/pptx/text.test.ts
@@ -314,6 +314,42 @@ describe('parseTextBody — paragraphs', () => {
     expect(blocks).toHaveLength(1);
     expect(blocks[0].inlines.map((i) => i.text)).toEqual(['line1', '\n', 'line2']);
   });
+
+  it('carries the <a:br> font size onto the soft-break inline', () => {
+    // Without this the blank/broken line falls back to the docs default
+    // (11 pt) and drops visibly too far below small-point body text.
+    const t = txBody(`<a:txBody><a:bodyPr/><a:p>
+      <a:r><a:rPr sz="800"/><a:t>x</a:t></a:r>
+      <a:br><a:rPr sz="800"/></a:br>
+    </a:p></a:txBody>`);
+    const blocks = parseTextBody(t, { report: new ImportReport() });
+    const br = blocks[0].inlines.find((i) => i.text === '\n');
+    expect(br?.style.fontSize).toBe(8);
+  });
+
+  it('sizes an empty paragraph from <a:endParaRPr>', () => {
+    const t = txBody(
+      `<a:txBody><a:bodyPr/><a:p><a:endParaRPr sz="800"/></a:p></a:txBody>`,
+    );
+    const blocks = parseTextBody(t, { report: new ImportReport() });
+    expect(blocks[0].inlines).toHaveLength(1);
+    expect(blocks[0].inlines[0].text).toBe('');
+    expect(blocks[0].inlines[0].style.fontSize).toBe(8);
+  });
+
+  it('collapses an empty <a:t/> run to one endParaRPr-sized placeholder', () => {
+    // Google Slides exports blank lines as `<a:r><a:t/></a:r>` + endParaRPr,
+    // not a bare `<a:p/>`. The empty run carries no size, so the line must
+    // still take its height from endParaRPr rather than the docs default.
+    const t = txBody(
+      `<a:txBody><a:bodyPr/><a:p><a:r><a:t></a:t></a:r>` +
+        `<a:endParaRPr sz="800"/></a:p></a:txBody>`,
+    );
+    const blocks = parseTextBody(t, { report: new ImportReport() });
+    expect(blocks[0].inlines).toHaveLength(1);
+    expect(blocks[0].inlines[0].text).toBe('');
+    expect(blocks[0].inlines[0].style.fontSize).toBe(8);
+  });
 });
 
 describe('detectAutofitMode', () => {


### PR DESCRIPTION
## Summary

Imported PPTX text boxes rendered line breaks and blank lines far too
far apart, then (after a first pass) too tight — the roadmap slide's
"v0.3: SaaS 오픈" box was the repro. Three root causes in the slides
PPTX text import/export path:

1. **`<a:br>` / blank lines dropped their font size.** `<a:br>` was
   lifted to a `\n` inline with empty style, and blank paragraphs got a
   styleless placeholder, so the docs layout fell back to the 11 pt theme
   default (× lineHeight) — inflating blank/broken lines above small body
   text, and inflating the *preceding* line too via `max(size, 11)`.
   Fixed by carrying the real size from the `<a:br>`'s own `<a:rPr>`, the
   paragraph's `<a:endParaRPr>`, or (bare `<a:br/>`) the preceding run.

2. **Paragraph spacing came from docs word-processor defaults.** Every
   imported paragraph inherited `lineHeight 1.5` + `marginBottom 8px`
   even though the source set `spcBef=0`/`spcAft=0` with no `<a:lnSpc>`.
   Reset imports to PowerPoint single spacing (`lineHeight 1.2`, zero
   margins) and parse `<a:spcBef>`/`<a:spcAft>` `spcPts` →
   `marginTop`/`marginBottom` (pt × 96/72 → px), honoring an explicit
   `spcAft="0"`. Export emits the inverse (OOXML order lnSpc → spcBef →
   spcAft).

3. **Round-trip correctness (from code review).** Empty-paragraph import
   now prefers a size an empty run already carries (so an exported
   `<a:r sz=…/>` blank line survives re-import), and soft breaks export
   as `<a:br>` rather than a literal newline in `<a:t>` (which PowerPoint
   collapses).

Verified end-to-end on the source deck: the v0.3 line + blank line sit at
`lineHeight 1.2` with no injected margin, the bullet paragraph keeps its
16 pt `spcAft` (21.3 px), and slide 2's TOC list (source `spcAft=0`) is
single-spaced rather than cramped.

Known limitation: `<a:spcBef>`/`<a:spcAft>` percent-of-line (`spcPct`)
spacing is left at 0 — it can't map to a fixed px margin without per-run
line height (same reason `<a:lnSpc>` absolute `spcPts` is skipped).

## Test plan

- `pnpm --filter @wafflebase/slides test` — 2472 pass (new cases: br/empty
  size, spcBef/spcAft mapping, explicit-zero, bare `<a:br/>` inheritance,
  soft-break `<a:br>` export, full export→re-import blank-line round-trip).
- `pnpm verify:fast` — green.
- Manual smoke: re-imported the deck in `pnpm dev`; roadmap and TOC
  spacing confirmed by the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)