### PR TITLE
Stop native selection bleed when dragging slide handles

### DIFF
--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -3300,6 +3300,12 @@ class SlidesEditorImpl implements SlidesEditor {
     }
     const handle = this.handleAtClient(e.clientX, e.clientY);
     if (handle !== null) {
+      // Suppress the browser's native selection start so dragging a
+      // resize / rotate / adjustment handle never bleeds a text selection
+      // onto the canvas (notably on iPad Safari trackpad). The handle DOM
+      // also carries `user-select: none`; this covers the mouse-like
+      // pointer path the same way the move-drag branches below do.
+      e.preventDefault();
       this.onPointerDownHandle(handle, e.clientX, e.clientY);
       return;
     }

--- a/packages/slides/src/view/editor/overlay-handle-selection.test.ts
+++ b/packages/slides/src/view/editor/overlay-handle-selection.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { renderOverlay } from './overlay';
+import type { Element, Frame } from '../../model/element';
+import type { OverlayOptions } from './overlay';
+
+/**
+ * Regression guard for the iPad Safari selection-bleed bug: dragging a
+ * shape's control handles (resize / rotate / yellow-diamond adjustment,
+ * connector endpoints / bend, crop handles) must never let the browser
+ * start a native text/element selection that "bleeds" over the canvas.
+ * The cure lives on the handle DOM itself — every interactive handle
+ * carries `user-select: none` (+ WebKit) and `touch-action: none` via
+ * `styleHandleInteraction`. See `startAdjustmentDrag` / `onPointerDownHandle`.
+ *
+ * Each fixture below exercises a distinct handle factory so that dropping
+ * the styling from any one of them fails CI:
+ *   - smileyFace shape → makeHandle (resize/rotate) + makeAdjustmentHandle
+ *   - curved connector → makeEndpointHandle (start/end) + makeBendHandle
+ *   - crop session     → renderCropHandles' crop handles
+ */
+
+const BASE_OPTIONS: OverlayOptions = {
+  scale: 1,
+  slideWidth: 960,
+  slideHeight: 540,
+};
+
+function expectAllHandlesInert(overlay: HTMLDivElement): void {
+  const handles = overlay.querySelectorAll<HTMLElement>('[data-handle]');
+  expect(handles.length).toBeGreaterThan(0);
+  for (const handle of handles) {
+    // `-webkit-user-select` is also set in code for older iOS Safari,
+    // but jsdom's CSSOM drops vendor-prefixed properties, so only the
+    // standard properties are asserted here.
+    expect(handle.style.userSelect).toBe('none');
+    expect(handle.style.touchAction).toBe('none');
+  }
+}
+
+describe('selection-handle interaction styles', () => {
+  it('marks shape resize/rotate + adjustment handles non-selectable', () => {
+    const smiley = {
+      id: 'e1',
+      type: 'shape',
+      frame: { x: 100, y: 100, w: 200, h: 200, rotation: 0 },
+      data: { kind: 'smileyFace' },
+    } as unknown as Element;
+
+    const overlay = document.createElement('div');
+    renderOverlay(overlay, [smiley], BASE_OPTIONS);
+
+    expectAllHandlesInert(overlay);
+  });
+
+  it('marks connector endpoint + bend handles non-selectable', () => {
+    // A curved connector renders both endpoint handles plus the
+    // yellow-diamond bend handle (bendHandlePosition is non-null for a
+    // bezier routing), covering makeEndpointHandle + makeBendHandle.
+    const connector = {
+      id: 'c1',
+      type: 'connector',
+      routing: 'curved',
+      frame: { x: 0, y: 0, w: 300, h: 200, rotation: 0 },
+      start: { kind: 'free', x: 100, y: 100 },
+      end: { kind: 'free', x: 400, y: 300 },
+      arrowheads: {},
+    } as unknown as Element;
+
+    const overlay = document.createElement('div');
+    renderOverlay(overlay, [connector], BASE_OPTIONS);
+
+    expectAllHandlesInert(overlay);
+  });
+
+  it('marks crop-session handles non-selectable', () => {
+    const cropWindow: Frame = { x: 100, y: 100, w: 200, h: 200, rotation: 0 };
+    const overlay = document.createElement('div');
+    renderOverlay(overlay, [], { ...BASE_OPTIONS, cropWindow });
+
+    expectAllHandlesInert(overlay);
+  });
+});

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -445,6 +445,21 @@ function renderConnectorEndpointHandles(
   }
 }
 
+/**
+ * Suppress native text/element selection and touch gestures on a drag
+ * handle. Handles float over the canvas with `pointer-events: auto`; on
+ * iPad Safari a trackpad drag that crosses a handle would otherwise let
+ * the browser start a selection that visually bleeds onto the canvas.
+ * `user-select: none` (+ the `-webkit-` alias iOS Safari still needs)
+ * kills the selection highlight; `touch-action: none` keeps a touch-drag
+ * on the handle from scrolling the page instead of dragging.
+ */
+function styleHandleInteraction(el: HTMLElement): void {
+  el.style.userSelect = 'none';
+  el.style.setProperty('-webkit-user-select', 'none');
+  el.style.touchAction = 'none';
+}
+
 function makeEndpointHandle(
   kind: 'start' | 'end',
   endpoint: Endpoint,
@@ -453,6 +468,7 @@ function makeEndpointHandle(
 ): HTMLDivElement {
   const el = document.createElement('div');
   el.dataset.handle = kind;
+  styleHandleInteraction(el);
   const attached = endpoint.kind === 'attached';
   el.className = `wfb-slides-handle wfb-slides-endpoint wfb-slides-endpoint-${kind} ${
     attached ? 'wfb-slides-endpoint-attached' : 'wfb-slides-endpoint-free'
@@ -600,6 +616,7 @@ function renderCropHandles(
 function makeCropHandle(kind: string, cx: number, cy: number): HTMLDivElement {
   const el = document.createElement('div');
   el.dataset.handle = kind;
+  styleHandleInteraction(el);
   el.className = `wfb-slides-handle wfb-slides-crop-handle ${kind}`;
   el.style.position = 'absolute';
   el.style.left = `${cx - HANDLE_SIZE / 2}px`;
@@ -864,6 +881,7 @@ function renderPeerOverlays(
 function makeHandle(kind: string, cx: number, cy: number): HTMLDivElement {
   const el = document.createElement('div');
   el.dataset.handle = kind;
+  styleHandleInteraction(el);
   el.className = `wfb-slides-handle wfb-slides-handle-${kind}`;
   el.style.position = 'absolute';
   el.style.left = `${cx - HANDLE_SIZE / 2}px`;
@@ -1144,6 +1162,7 @@ function renderAdjustmentHandles(
 function makeAdjustmentHandle(kind: string, cx: number, cy: number): HTMLDivElement {
   const el = document.createElement('div');
   el.dataset.handle = kind;
+  styleHandleInteraction(el);
   el.className = `wfb-slides-handle wfb-slides-adjust ${kind}`;
   el.style.position = 'absolute';
   el.style.left = `${cx - ADJUST_HANDLE_SIZE / 2}px`;
@@ -1160,6 +1179,7 @@ function makeAdjustmentHandle(kind: string, cx: number, cy: number): HTMLDivElem
 function makeBendHandle(cx: number, cy: number): HTMLDivElement {
   const el = document.createElement('div');
   el.dataset.handle = 'bend';
+  styleHandleInteraction(el);
   el.className = 'wfb-slides-handle wfb-slides-bend';
   el.style.position = 'absolute';
   el.style.left = `${cx - ADJUST_HANDLE_SIZE / 2}px`;


### PR DESCRIPTION
## Summary

On iPad Safari, dragging a shape's control handle with a trackpad let the
browser start a native text/element selection that visually **bled onto the
canvas** as the pointer crossed a handle (e.g. dragging the smiley's
adjustment handle past the origin handle).

Root cause: the handle-drag path suppressed the default selection **nowhere**.
`onPointerDown` dropped the event when it hit a handle (forwarding only
coordinates to `onPointerDownHandle`, so it could never `preventDefault`), and
the overlay handle elements carried no `user-select` / `touch-action`. The
move-drag path at least reaches code that can `preventDefault`; the
adjustment/resize/rotate/bend/endpoint/crop handle paths had zero suppression.

### Changes
- **`overlay.ts`** — add a shared `styleHandleInteraction()` applied by all five
  handle factories (resize/rotate, adjustment, bend, connector endpoint, crop),
  so every handle is `user-select: none` (+ `-webkit-` for older iOS) and
  `touch-action: none`. This kills the selection highlight at the source.
- **`editor.ts`** — call `e.preventDefault()` on the handle branch of
  `onPointerDown`, matching the existing move-drag pattern (defense-in-depth for
  the mouse-like pointer path).

## Test plan
- New `overlay-handle-selection.test.ts` (jsdom): renders three fixtures —
  smileyFace shape, curved connector, crop session — to exercise **all five**
  handle factories, asserting every `[data-handle]` element is
  `user-select: none` + `touch-action: none`. Fails before the fix.
- `pnpm verify:fast` green (slides 2484 passed).
- Manual smoke on an iPad Safari device still recommended before merge — the
  native-selection rendering can't be reproduced in jsdom; the unit test guards
  the mechanism (handles are non-selectable / gesture-inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)