### PR TITLE
Rotate slides resize-handle cursors with the element

### DIFF
--- a/docs/tasks/active/20260704-slides-rotated-resize-cursor-todo.md
+++ b/docs/tasks/active/20260704-slides-rotated-resize-cursor-todo.md
@@ -1,0 +1,40 @@
+# Slides: rotated resize-handle cursors
+
+## Problem
+
+When a single slide element is rotated, its 8 resize handles still show
+axis-aligned CSS cursors (`ns-resize` / `ew-resize` / `nwse-resize` /
+`nesw-resize`) keyed only by handle direction. So a 90°-rotated element's
+top (`n`) handle shows a vertical `ns-resize` cursor even though the handle
+now stretches the element horizontally. The cursor should follow the
+element's rotation.
+
+Note: the resize *math* already handles rotation
+(`resize.ts` `resizeFrameWorld` projects the drag delta into the frame's
+local axes). Only the **cursor hint** is missing.
+
+## Approach
+
+Resize cursors repeat every 45° and are symmetric across 180°, so there are
+only 4 distinct cursors. Take each handle's base outward-normal angle, add
+the frame rotation, quantise to the nearest 45° bucket (mod 180°), map to a
+cursor. At rotation 0 this reproduces `RESIZE_HANDLE_CURSORS` exactly.
+
+## Tasks
+
+- [ ] Add `rotatedResizeCursor(handle, rotation)` to `hit-test.ts` with a
+      base-angle map, `mod 180 → 45° bucket` quantisation.
+- [ ] Thread `rotation` into `overlay.ts` `handleCursor` / `makeHandle`;
+      pass `frame.rotation` from `renderRotatedHandles`.
+- [ ] Apply the same rotated cursor to crop handles (`makeCropHandle`,
+      `renderCropHandles` already has the rotated frame).
+- [ ] Unit test: rotated helper agrees with `RESIZE_HANDLE_CURSORS` at
+      rotation 0, and rotates correctly at 45°/90°.
+- [ ] `pnpm verify:fast` green.
+
+## Out of scope
+
+- Edge-zone hover cursor beyond the 5° cap: `edgeZoneAt` uses axis-aligned
+  geometry for the hover-band detection, so un-capping it needs rotated
+  hit-band math, not just a rotated cursor. Separate change.
+- Multi-select rotated resize (v2 item, axis-aligned bbox).

--- a/packages/slides/src/view/editor/hit-test-cursor.test.ts
+++ b/packages/slides/src/view/editor/hit-test-cursor.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { RESIZE_HANDLE_CURSORS, rotatedResizeCursor } from './hit-test';
+import type { ResizeHandle } from './hit-test';
+import { renderOverlay } from './overlay';
+import type { Element } from '../../model/element';
+import type { OverlayOptions } from './overlay';
+
+const HANDLES: ResizeHandle[] = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
+const deg = (d: number) => (d * Math.PI) / 180;
+
+describe('rotatedResizeCursor', () => {
+  it('reproduces the static cursor map at rotation 0', () => {
+    for (const h of HANDLES) {
+      expect(rotatedResizeCursor(h, 0)).toBe(RESIZE_HANDLE_CURSORS[h]);
+    }
+  });
+
+  it('is invariant under full turns and 180° flips', () => {
+    for (const h of HANDLES) {
+      const base = RESIZE_HANDLE_CURSORS[h];
+      expect(rotatedResizeCursor(h, deg(180))).toBe(base);
+      expect(rotatedResizeCursor(h, deg(360))).toBe(base);
+      expect(rotatedResizeCursor(h, deg(-180))).toBe(base);
+    }
+  });
+
+  it('rotates the cursor axis with a 90° turn', () => {
+    // A quarter turn swaps horizontal/vertical and both diagonals.
+    expect(rotatedResizeCursor('n', deg(90))).toBe('ew-resize');
+    expect(rotatedResizeCursor('e', deg(90))).toBe('ns-resize');
+    expect(rotatedResizeCursor('ne', deg(90))).toBe('nwse-resize');
+    expect(rotatedResizeCursor('se', deg(90))).toBe('nesw-resize');
+  });
+
+  it('maps a 45° turn to the neighbouring bucket', () => {
+    // 45° shifts every handle one 45°-step: n's vertical axis becomes a
+    // diagonal, e's horizontal axis becomes the other diagonal.
+    expect(rotatedResizeCursor('n', deg(45))).toBe('nesw-resize');
+    expect(rotatedResizeCursor('e', deg(45))).toBe('nwse-resize');
+    expect(rotatedResizeCursor('ne', deg(45))).toBe('ew-resize');
+    expect(rotatedResizeCursor('se', deg(45))).toBe('ns-resize');
+  });
+
+  it('snaps within a 45° bucket (±22° stays on the same cursor)', () => {
+    expect(rotatedResizeCursor('n', deg(20))).toBe('ns-resize');
+    expect(rotatedResizeCursor('n', deg(-20))).toBe('ns-resize');
+  });
+});
+
+describe('renderOverlay wires rotated handle cursors', () => {
+  const OPTIONS: OverlayOptions = { scale: 1, slideWidth: 960, slideHeight: 540 };
+
+  const cursorOf = (overlay: HTMLDivElement, kind: string) =>
+    overlay
+      .querySelector<HTMLElement>(`[data-handle="${kind}"]`)!
+      .style.cursor;
+
+  it('keeps axis-aligned cursors when the element is not rotated', () => {
+    const el = {
+      id: 'e1',
+      type: 'shape',
+      frame: { x: 100, y: 100, w: 200, h: 200, rotation: 0 },
+      data: { kind: 'rect' },
+    } as unknown as Element;
+    const overlay = document.createElement('div');
+    renderOverlay(overlay, [el], OPTIONS);
+    expect(cursorOf(overlay, 'n')).toBe('ns-resize');
+    expect(cursorOf(overlay, 'e')).toBe('ew-resize');
+  });
+
+  it('rotates handle cursors with a 90° rotated element', () => {
+    const el = {
+      id: 'e1',
+      type: 'shape',
+      frame: { x: 100, y: 100, w: 200, h: 200, rotation: Math.PI / 2 },
+      data: { kind: 'rect' },
+    } as unknown as Element;
+    const overlay = document.createElement('div');
+    renderOverlay(overlay, [el], OPTIONS);
+    // Rotated path is taken (single rotated element); n now stretches
+    // horizontally, e vertically.
+    expect(cursorOf(overlay, 'n')).toBe('ew-resize');
+    expect(cursorOf(overlay, 'e')).toBe('ns-resize');
+  });
+});

--- a/packages/slides/src/view/editor/hit-test.ts
+++ b/packages/slides/src/view/editor/hit-test.ts
@@ -45,6 +45,51 @@ export const RESIZE_HANDLE_CURSORS: Readonly<Record<ResizeHandle, string>> = {
   w: 'ew-resize',
 };
 
+/**
+ * Each resize handle's outward-normal angle in screen space (x→right,
+ * y→down), degrees. Used to rotate the cursor with the element: opposing
+ * directions share a cursor, so the values below reduce mod 180° to the
+ * same four buckets as `RESIZE_HANDLE_CURSORS`.
+ */
+const RESIZE_HANDLE_BASE_ANGLE_DEG: Readonly<Record<ResizeHandle, number>> = {
+  e: 0,
+  se: 45,
+  s: 90,
+  sw: 135,
+  w: 180,
+  nw: 225,
+  n: 270,
+  ne: 315,
+};
+
+/** Cursors indexed by 45° bucket over [0, 180): 0°, 45°, 90°, 135°. */
+const ANGLE_BUCKET_CURSORS: readonly string[] = [
+  'ew-resize',
+  'nwse-resize',
+  'ns-resize',
+  'nesw-resize',
+];
+
+/**
+ * CSS resize cursor for a handle on a frame rotated by `rotation` radians.
+ * The eight handles map to four cursors that repeat every 45°, so we add
+ * the frame rotation to the handle's base normal angle and quantise to the
+ * nearest 45° bucket (mod 180°, since opposing directions share a cursor).
+ *
+ * At `rotation === 0` this returns exactly `RESIZE_HANDLE_CURSORS[handle]`
+ * (asserted by the unit test) — the static map stays the single source of
+ * truth for the axis-aligned / edge-zone paths, and this is its rotated
+ * generalisation for the single-element rotated overlay.
+ */
+export function rotatedResizeCursor(
+  handle: ResizeHandle,
+  rotation: number,
+): string {
+  const deg = RESIZE_HANDLE_BASE_ANGLE_DEG[handle] + (rotation * 180) / Math.PI;
+  const bucket = Math.round((((deg % 180) + 180) % 180) / 45) % 4;
+  return ANGLE_BUCKET_CURSORS[bucket];
+}
+
 /** Fold an arbitrary rotation (radians) into `[-π, π]`. */
 function normalizeRotation(rotation: number): number {
   const twoPi = 2 * Math.PI;

--- a/packages/slides/src/view/editor/overlay.ts
+++ b/packages/slides/src/view/editor/overlay.ts
@@ -20,7 +20,11 @@ import {
   SHAPE_HOVER_RADIUS,
   SITE_SNAP_RADIUS,
 } from './interactions/insert-connector';
-import { RESIZE_HANDLE_CURSORS, type ResizeHandle } from './hit-test';
+import {
+  RESIZE_HANDLE_CURSORS,
+  rotatedResizeCursor,
+  type ResizeHandle,
+} from './hit-test';
 import type { PeerOverlays } from './peers';
 
 const HANDLE_SIZE = 8;             // px
@@ -609,11 +613,18 @@ function renderCropHandles(
 
   for (const [kind, lx, ly] of handleLocalPositions(frame)) {
     const w = localToWorld(lx, ly);
-    overlay.appendChild(makeCropHandle(kind, w.x * scale, w.y * scale));
+    overlay.appendChild(
+      makeCropHandle(kind, w.x * scale, w.y * scale, frame.rotation),
+    );
   }
 }
 
-function makeCropHandle(kind: string, cx: number, cy: number): HTMLDivElement {
+function makeCropHandle(
+  kind: string,
+  cx: number,
+  cy: number,
+  rotation = 0,
+): HTMLDivElement {
   const el = document.createElement('div');
   el.dataset.handle = kind;
   styleHandleInteraction(el);
@@ -626,7 +637,10 @@ function makeCropHandle(kind: string, cx: number, cy: number): HTMLDivElement {
   el.style.background = '#000';
   el.style.border = '1px solid #fff';
   el.style.boxSizing = 'border-box';
-  el.style.cursor = RESIZE_HANDLE_CURSORS[kind as ResizeHandle] ?? 'default';
+  el.style.cursor =
+    kind in RESIZE_HANDLE_CURSORS
+      ? handleCursor(kind, rotation)
+      : 'default';
   return el;
 }
 
@@ -656,10 +670,11 @@ function renderRotatedHandles(
   outline.style.border = '1px solid #3a7';
   overlay.appendChild(outline);
 
-  // Eight resize handles at the rotated corners / edge midpoints.
+  // Eight resize handles at the rotated corners / edge midpoints. The
+  // cursor rotates with the frame so it matches the handle's real axis.
   for (const [kind, lx, ly] of handleLocalPositions(frame)) {
     const w = localToWorld(lx, ly);
-    overlay.appendChild(makeHandle(kind, w.x * scale, w.y * scale));
+    overlay.appendChild(makeHandle(kind, w.x * scale, w.y * scale, frame.rotation));
   }
 
   // Rotate handle: ROTATE_HANDLE_OFFSET (host px) above the rotated
@@ -878,7 +893,12 @@ function renderPeerOverlays(
   }
 }
 
-function makeHandle(kind: string, cx: number, cy: number): HTMLDivElement {
+function makeHandle(
+  kind: string,
+  cx: number,
+  cy: number,
+  rotation = 0,
+): HTMLDivElement {
   const el = document.createElement('div');
   el.dataset.handle = kind;
   styleHandleInteraction(el);
@@ -891,7 +911,7 @@ function makeHandle(kind: string, cx: number, cy: number): HTMLDivElement {
   el.style.background = kind === 'rotate' ? '#fff' : '#3a7';
   el.style.border = kind === 'rotate' ? '1px solid #3a7' : '1px solid #fff';
   el.style.borderRadius = kind === 'rotate' ? '50%' : '0';
-  el.style.cursor = handleCursor(kind);
+  el.style.cursor = handleCursor(kind, rotation);
   return el;
 }
 
@@ -1122,13 +1142,17 @@ function makePermanentGuide(
  */
 const GUIDE_EXTEND_PX = 10_000;
 
-function handleCursor(kind: string): string {
+function handleCursor(kind: string, rotation = 0): string {
   // Resize cursors route through the single source of truth in
   // `hit-test.ts` so the P2.7 edge-zone affordance and the 8-px handle
   // DOM elements can never drift apart on a designer-driven cursor
-  // convention change. `rotate` and the fallback live here.
+  // convention change. When the element is rotated, the cursor rotates
+  // with it (`rotatedResizeCursor` reduces to the static map at 0).
+  // `rotate` and the fallback live here.
   if (kind in RESIZE_HANDLE_CURSORS) {
-    return RESIZE_HANDLE_CURSORS[kind as ResizeHandle];
+    return rotation === 0
+      ? RESIZE_HANDLE_CURSORS[kind as ResizeHandle]
+      : rotatedResizeCursor(kind as ResizeHandle, rotation);
   }
   if (kind === 'rotate') return 'crosshair';
   return 'default';


### PR DESCRIPTION
## Summary

A rotated single slide element's 8 resize handles still showed axis-aligned CSS cursors keyed only by handle direction. A 90°-rotated element's top (`n`) handle showed a vertical `ns-resize` cursor even though the handle now stretches the element horizontally.

The resize *math* was already rotation-aware — `resizeFrameWorld` projects the drag delta into the frame's local axes. Only the **cursor hint** lagged.

- Add `rotatedResizeCursor(handle, rotation)` in `hit-test.ts`. Resize cursors repeat every 45° and are symmetric across 180°, so it adds the frame rotation to each handle's base normal angle and quantises to the nearest 45° bucket. At rotation 0 it reproduces `RESIZE_HANDLE_CURSORS` exactly, so the static map stays the single source of truth for the axis-aligned / edge-zone paths.
- Thread `rotation` through `makeHandle` / `handleCursor` from `renderRotatedHandles`, and apply the same to crop handles (`renderCropHandles` already carries the rotated frame).

### Out of scope
- Edge-zone hover cursor beyond the 5° cap: `edgeZoneAt` uses axis-aligned geometry for the hover-band detection, so un-capping it needs rotated hit-band math, not just a rotated cursor.
- Multi-select rotated resize (axis-aligned bbox, existing v2 item).

## Test plan

- New `hit-test-cursor.test.ts`: pure helper agrees with `RESIZE_HANDLE_CURSORS` at rotation 0; correct rotation at 45°/90°/180°/360°; ±22° stays in-bucket; `renderOverlay` wiring applies rotated cursors to the actual handle DOM.
- `pnpm verify:fast` green.
- High-effort workflow code review: no findings survived verification.
- Manual smoke in `pnpm dev`: rotated element handle cursors follow the rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rotated slides now show resize cursors that match the actual handle direction.
  * Crop handles also use rotation-aware cursor styling for a more consistent editing experience.

* **Documentation**
  * Added a task note describing the rotated resize-cursor behavior and follow-up work.

* **Tests**
  * Added coverage for cursor behavior across rotations, including 90°, 180°, and 45° snapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->