### PR TITLE
Fix rotated shapes distorting when a group is ungrouped

### DIFF
--- a/docs/design/slides/slides-group.md
+++ b/docs/design/slides/slides-group.md
@@ -359,6 +359,94 @@ children within that group.
 All drags broadcast intermediate frames via presence and commit a
 single `store.batch` on `mouseup` — the existing pattern.
 
+#### 6.1 Resting-scale invariant (no residual non-uniform scale)
+
+**Invariant.** After any *committed* edit, every group at every nesting
+depth satisfies `data.refSize == { w: frame.w, h: frame.h }` — i.e. its
+render scale factor is exactly `1`. A non-uniform scale (`refSize !=
+frame`) is allowed to exist **only transiently during an active resize
+drag**, where it drives the renderer's proportional child scaling
+(`element-renderer.ts` applies `ctx.scale(frame.w/refSize.w,
+frame.h/refSize.h)`). On commit the scale is baked into the children via
+`store.bakeGroupResize` (→ `bakeGroupScale`), which multiplies every
+child frame by `(sx, sy)` and resets `refSize = frame`.
+
+**Why it matters (the ungroup-distortion bug).** The renderer composes
+the group scale *outside* a child's own rotation — a rotated child's
+geometry sees `Scale(sx,sy) · Rotate(φ)`, which for non-uniform `(sx,sy)`
+is a **shear** (a circle becomes a tilted ellipse). `ungroup()` bakes a
+child back to world space with `applyGroupTransform` →
+`scaleRotatedFrame`, an axis-aligned bbox-preserving rectangle that can
+only represent `Rotate(φ) · Scale(sx',sy')` — **no shear**. `Scale` and
+`Rotate` commute only when the scale is uniform *or* the child is
+unrotated, so a rotated child under a residual non-uniform group scale
+**visibly changes shape the instant it is ungrouped** (measured
+Frobenius Δ of the two 2×2 maps ≈ 0.71 for a 2:1 scale + 30° child).
+The classic symptom is a "smiley face" that squishes on ungroup.
+
+Holding the invariant makes this class of bug impossible: at rest every
+group has scale `1`, so the renderer applies no scale (no shear) and
+`ungroup` bakes only translate/rotate — a child's geometry is identical
+before and after ungroup, rotated or not, at any depth.
+
+**Enforcement.** `refSize` is seeded equal to `frame` at group creation
+(`store.group()`) and PPTX import already bakes `<a:chExt>/<a:ext>` into
+child world frames so imported groups also rest at scale `1`. The
+invariant only leaks through commit paths that change a group's `frame.w
+/ h` without baking. Every such path must call `bakeGroupResize` in the
+same `batch`:
+
+| Commit path | Site | Status before | Fix |
+| --- | --- | --- | --- |
+| Single-element resize | `editor.ts` `startResize` `onUp` | bakes ✓ | — |
+| Multi-select resize | `editor.ts` `startMultiResize` `onUp` | **no bake** | bake each group in selection |
+| Format panel W/H (`commitFrame`) | `format-panel/index.tsx` | **no bake** | bake if target is a group |
+| Format panel W/H (`lockedResize`) | `format-panel/index.tsx` | **no bake** | bake if target is a group |
+| Align / distribute / arrange / rotate / move / nudge / crop / autofit | various | x/y/rotation only — no scale | — (no bake needed) |
+
+`bakeGroupResize` is made **recursive**: after baking a group's scale
+into its direct children, any child that is itself a group now has a
+non-`1` scale (its `frame` was scaled but its `refSize` was not), so the
+bake descends into it (DFS). This keeps the per-level `bakeGroupScale`
+contract unchanged while holding the invariant through nested groups.
+The added subtree rewrite only happens at resize *commit* (not per
+`mousemove`), so CRDT churn stays bounded; nested groups are rare.
+
+**Ungroup settles first.** `ungroup()` calls the recursive bake on the
+target group *before* baking translate/rotate into its children. This is
+both a correctness step (child frames end up sensibly scaled) and a
+safety net: even if a future commit path forgets to bake, ungroup will
+not distort. It also fixes the **nested-child-group `refSize` leak** —
+previously a child group emerged from `ungroup` with `frame != refSize`
+because `applyGroupTransform` scaled its `frame` while `clone()` copied
+its stale `refSize`; settling to scale `1` first removes the scale that
+would have leaked.
+
+**Guard.** A DEV/test-only helper `assertGroupsSettled(elements)` walks
+the tree and asserts `refSize ≈ frame` for every group; regression tests
+call it after resize/ungroup commits so a future un-baked commit path
+fails loudly. Both stores implement the fix: `MemSlidesStore`
+(`store/memory.ts`, unit-tested) and `YorkieSlidesStore`
+(`frontend/.../yorkie-slides-store.ts`, live app); the shared math stays
+in `model/group.ts`.
+
+**Accepted trade-off — nested rotated children flatten on resize.**
+Because the bake is recursive, non-uniformly resizing an *outer* group
+now bakes the scale into a *nested* subgroup's rotated child as an
+axis-aligned rotated rect (`Rotate·Scale`), rather than leaving the
+subgroup with a residual scale that the renderer would compose as a
+shear (`Scale·Rotate`). The data model has no shear field, so a shape
+cannot be both a stored element and a sheared silhouette — this is the
+same "no shear at rest" limitation the single-level bake already accepts
+(the pre-existing single-resize commit at `editor.ts` already flattens a
+rotated *direct* child on resize). Extending it to nested children keeps
+the behavior consistent at every depth; the alternative (leave nested
+subgroups non-uniform) is exactly the residual-scale state that distorts
+those children the moment they are ungrouped. A legacy child group with
+no `refSize` is seeded with its pre-scale frame before baking so the
+recursion scales its grandchildren correctly instead of dropping the
+parent's scale for that subtree.
+
 ### 7. Connectors
 
 ConnectorElements can endpoint-reference other elements by id.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,10 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| empty workspace slug (2026-07-04) | [20260704-empty-workspace-slug-todo.md](./active/20260704-empty-workspace-slug-todo.md) | [20260704-empty-workspace-slug-lessons.md](./active/20260704-empty-workspace-slug-lessons.md) |
+| pptx br empty line font size (2026-07-04) | [20260704-pptx-br-empty-line-font-size-todo.md](./active/20260704-pptx-br-empty-line-font-size-todo.md) | - |
 | slides freeform arrowheads (2026-07-04) | [20260704-slides-freeform-arrowheads-todo.md](./active/20260704-slides-freeform-arrowheads-todo.md) | - |
+| ungroup scale invariant (2026-07-04) | [20260704-ungroup-scale-invariant-todo.md](./active/20260704-ungroup-scale-invariant-todo.md) | [20260704-ungroup-scale-invariant-lessons.md](./active/20260704-ungroup-scale-invariant-lessons.md) |
 | pptx text body insets (2026-07-03) | [20260703-pptx-text-body-insets-todo.md](./active/20260703-pptx-text-body-insets-todo.md) | [20260703-pptx-text-body-insets-lessons.md](./active/20260703-pptx-text-body-insets-lessons.md) |
 | slides canvas black on resize (2026-07-02) | [20260702-slides-canvas-black-on-resize-todo.md](./active/20260702-slides-canvas-black-on-resize-todo.md) | [20260702-slides-canvas-black-on-resize-lessons.md](./active/20260702-slides-canvas-black-on-resize-lessons.md) |
 | pivot format inheritance (2026-07-01) | [20260701-pivot-format-inheritance-todo.md](./active/20260701-pivot-format-inheritance-todo.md) | [20260701-pivot-format-inheritance-lessons.md](./active/20260701-pivot-format-inheritance-lessons.md) |
@@ -35,4 +38,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 330
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: slides freeform arrowheads (2026-07-04)
+Latest active task: empty workspace slug (2026-07-04)

--- a/docs/tasks/active/20260704-ungroup-scale-invariant-lessons.md
+++ b/docs/tasks/active/20260704-ungroup-scale-invariant-lessons.md
@@ -1,0 +1,55 @@
+# Lessons — ungroup scale invariant
+
+## Investigation
+
+- The symptom "looks fine grouped, distorts on ungroup" is only possible
+  when a rotated child sits under a **residual non-uniform group scale**.
+  Proven by comparing the two 2×2 maps the shape geometry sees:
+  renderer = `Scale(sx,sy)·Rotate(φ)` vs ungroup bake =
+  `Rotate(φ)·Scale`. They commute (Δ = 0) iff scale is uniform or the
+  child is unrotated; otherwise Δ ≈ 0.71 (2:1 scale, 30°). Rotation is a
+  *necessary* condition — a throwaway test at rotation 0 and at uniform
+  scale both showed Δ = 0.
+
+- Watch out for coincidental matches when reproducing: at exactly 45°,
+  `scaleRotatedFrame`'s degenerate fallback returns per-axis
+  `(w·sx, h·sy)` whose aspect equals the renderer's singular-value aspect
+  `{sx,sy}` — the mismatch is in *orientation*, not aspect, for a square
+  child. Compare the full 2×2 map, not just the width:height ratio.
+
+- Two parallel store implementations exist (`MemSlidesStore`,
+  `YorkieSlidesStore`); a store-level fix must be applied to both, with
+  shared math kept in `model/group.ts`. `bakeGroupResize` also has a
+  no-op stub in `layout-edit-store.ts`.
+
+- PPTX import does **not** leak residual scale: it bakes `chExt/ext` into
+  child world frames and sets `refSize = frame`. Don't assume "imported →
+  non-uniform group"; verify.
+
+## Implementation
+
+- An existing test (`multi-resize.test.ts` Test A) asserted the group's
+  `refSize` is **unchanged** after multi-resize — it encoded the old
+  no-bake behavior. Fixing the bug flips that expectation; the test had
+  to be rewritten to assert the group is baked (`refSize == frame`,
+  child frames scaled). Search for tests that lock in the buggy behavior
+  before assuming a green suite means "no behavior change".
+
+- Regression tests must use a **non-square** rotated child with a
+  **mild** non-uniform scale (e.g. 60×40 @ 20°, sx=1.5). A square child
+  or a large stretch drives `scaleRotatedFrame` into its degenerate
+  fallback (`w·sx, h·sy`), which coincidentally equals the per-axis bake
+  and masks the divergence. Verified the equivalence test fails with the
+  settle-first line removed, and passes with it — a real guard.
+
+- `bakeGroupResize` recursion in the Yorkie store must run **inside the
+  single `withUpdate`** on the proxies (`bakeProxyGroupTree`); you can't
+  recurse by calling `this.bakeGroupResize(childId)` because that opens a
+  nested `withUpdate`/`doc.update`. `bakeGroupScale` stays a pure
+  per-level model function; recursion lives in the store layer so its
+  contract (and its tests) are untouched.
+
+- `bakeGroupScale` scales a child group's `frame` but not its `refSize`
+  (documented non-recursive contract), so after baking a parent the
+  child group carries the parent's scale — which is exactly why the
+  store-layer recursion is needed to hold the invariant through nesting.

--- a/docs/tasks/active/20260704-ungroup-scale-invariant-todo.md
+++ b/docs/tasks/active/20260704-ungroup-scale-invariant-todo.md
@@ -1,0 +1,111 @@
+# Ungroup scale invariant — fix smiley distortion on ungroup
+
+## Problem
+
+Ungrouping a group in the slides editor distorts a rotated shape child
+(reported: a smiley face squishes on ungroup).
+
+Root cause: a group can **rest with a non-uniform render scale**
+(`data.refSize != frame`). The renderer applies that scale *outside* a
+child's own rotation (`Scale(sx,sy)·Rotate(φ)` — a shear for non-uniform
+scale), but `ungroup()` bakes the child as an axis-aligned rotated rect
+(`Rotate(φ)·Scale`, no shear). The two agree only when scale is uniform
+or the child is unrotated; otherwise the child's geometry changes the
+instant it is ungrouped (Frobenius Δ of the 2×2 maps ≈ 0.71 for 2:1
+scale + 30° child — proven with the real transform functions).
+
+Residual non-uniform scale is not created by PPTX import (it bakes
+`chExt/ext` into child world frames) or by group creation (`refSize`
+seeded = `frame`). It leaks in through commit paths that change a
+group's `frame.w/h` without baking.
+
+Design: `docs/design/slides/slides-group.md` §6.1 (resting-scale
+invariant).
+
+## Approach
+
+Enforce the invariant: **after any committed edit, every group at every
+depth has `refSize == frame` (scale 1).** Non-uniform scale exists only
+transiently during a resize drag; it is baked on commit.
+
+## Checklist
+
+### Store / model
+- [ ] Make `bakeGroupResize` **recursive** in `store/memory.ts` (DFS into
+      child groups after baking direct children). Keep `bakeGroupScale`
+      (`model/group.ts`) per-level contract unchanged.
+- [ ] Mirror the recursive `bakeGroupResize` in
+      `frontend/.../yorkie-slides-store.ts`.
+- [ ] `ungroup()` (both stores) settles the target group's scale to 1
+      (recursive bake) **before** baking translate/rotate into children.
+      Confirm this removes the nested-child-group `refSize` leak.
+- [ ] Add `assertGroupsSettled(elements)` DEV/test helper (walks tree,
+      asserts `refSize ≈ frame` for every group).
+
+### Editor / panel commit sites
+- [ ] Multi-select resize `onUp` (`editor.ts` `startMultiResize`): call
+      `store.bakeGroupResize` for each selected element that is a group,
+      inside the existing commit `batch`.
+- [ ] Format panel `commitFrame` (`format-panel/index.tsx`): bake if the
+      target element is a group.
+- [ ] Format panel `lockedResize` (`format-panel/index.tsx`): bake if the
+      target element is a group.
+
+### Tests (packages/slides, MemSlidesStore)
+- [ ] Regression: group resting with non-uniform scale + rotated shape
+      child → `ungroup` → assert (a) no output group has residual scale,
+      (b) rotated child's post-ungroup transform == its pre-ungroup
+      *rendered* transform within eps (render-map == ungroup-map).
+- [ ] Multi-resize a group → assert `refSize == frame` after commit.
+- [ ] Nested: resize outer group → assert inner group also settled
+      (recursive bake).
+- [ ] Format panel `commitFrame` / `lockedResize` on a group → settled.
+- [ ] `assertGroupsSettled` used as the shared guard in the above.
+
+### Verify
+- [ ] `pnpm verify:fast` green.
+- [ ] Manual smoke in `pnpm dev`: group a smiley (rotated) with another
+      shape, resize the group non-uniformly (single + multi + panel),
+      ungroup → smiley unchanged.
+
+## Review
+
+Implemented on branch `fix/ungroup-scale-invariant` (commit
+`Bake group render-scale on every resize commit and ungroup`).
+
+- Store: `bakeGroupResize` → recursive `bakeGroupTree` (memory) /
+  `bakeProxyGroupTree` (Yorkie); `ungroup` settles scale first.
+- Commit sites baked: multi-resize `onUp`, Format panel `commitFrame` /
+  `lockedResize`. (single-resize already baked; align/distribute/rotate/
+  move/crop/autofit don't change w/h — confirmed by enumeration.)
+- Guard `collectUnsettledGroups` / `isGroupSettled` live in
+  `test/support/group-invariant.ts` (test-only).
+- Tests: recursive nested settle, ungroup settle-equivalence (verified to
+  FAIL pre-fix), legacy-nested-group grandchild scaling, editor
+  multi-resize integration. `pnpm verify:fast` green.
+
+High-effort code review (workflow) — 4 findings, all resolved:
+
+1. **Legacy nested group w/ `undefined refSize`** (correctness, confirmed)
+   — child group frame scaled but grandchildren dropped the parent scale.
+   Fixed: seed missing child-group `refSize` with pre-scale frame before
+   baking (both stores) + regression test.
+2. **Recursion flattens nested rotated children on resize** (contested)
+   — kept recursion (the approved invariant requires it; consistent with
+   the existing single-level bake) and documented the trade-off in
+   slides-group.md §6.1 (no shear at rest — data model has no shear).
+3. **Duplicated recursion across stores** (cleanup) — added reciprocal
+   "keep in sync" cross-reference comments; per-level math already shared
+   via `bakeGroupScale`.
+4. **Test-only predicates in production source** (cleanup) — moved to
+   `test/support/group-invariant.ts`.
+
+Smoke test: the editable browser editor needs GitHub OAuth (backend
+returned 401 headless), so the live-app path was smoked by driving the
+real `YorkieSlidesStore` against a local Yorkie document
+(`yorkie-slides-equivalence.test.ts`) — group → dirty non-uniform resize
+→ ungroup, asserting the Yorkie proxy result matches the proven-correct
+Mem path and every group rests settled. Verified to FAIL with the Yorkie
+ungroup-settle removed.
+
+PR: https://github.com/wafflebase/wafflebase/pull/441

--- a/packages/frontend/src/app/slides/format-panel/index.tsx
+++ b/packages/frontend/src/app/slides/format-panel/index.tsx
@@ -101,8 +101,21 @@ export function FormatPanel({
       const slideId =
         selection.kind === 'object' ? selection.slideId : undefined;
       if (!slideId) return;
+      // A W/H change on a group leaves a residual non-uniform scale; bake
+      // it so the group rests at scale 1 (resting-scale invariant, see
+      // docs/design/slides/slides-group.md §6.1). x/y-only patches don't
+      // change scale, so only bake when the size actually changed.
+      const changesSize = patch.w !== undefined || patch.h !== undefined;
+      const groupIds =
+        changesSize && selection.kind === 'object'
+          ? ids.filter(
+              (id) =>
+                selection.elements.find((e) => e.id === id)?.type === 'group',
+            )
+          : [];
       store.batch(() => {
         for (const id of ids) store.updateElementFrame(slideId, id, patch);
+        for (const gid of groupIds) store.bakeGroupResize(slideId, gid);
       });
     },
     [store, selection],
@@ -199,6 +212,13 @@ export function FormatPanel({
               ? { w: newPx, h: newPx * ratio }
               : { h: newPx, w: ratio === 0 ? el.frame.w : newPx / ratio };
           store.updateElementFrame(selection.slideId, el.id, patch);
+        }
+        // Bake any resized group so it rests at scale 1 (resting-scale
+        // invariant, docs/design/slides/slides-group.md §6.1).
+        for (const el of elems) {
+          if (el.type === 'group') {
+            store.bakeGroupResize(selection.slideId, el.id);
+          }
         }
       });
     },

--- a/packages/frontend/src/app/slides/yorkie-slides-store.ts
+++ b/packages/frontend/src/app/slides/yorkie-slides-store.ts
@@ -1962,37 +1962,47 @@ export class YorkieSlidesStore implements SlidesStore {
     });
   }
 
-  bakeGroupResize(slideId: string, groupId: string): void {
-    this.requireBatch();
-    this.withUpdate((r) => {
-      const s = r.slides.find((s) => s.id === slideId);
-      if (!s) return;
+  /**
+   * Bake a proxy group's render-scale into its children and recurse into
+   * any child group so the whole subtree rests at scale 1 (resting-scale
+   * invariant, docs/design/slides/slides-group.md §6.1). Mirrors
+   * `bakeGroupTree` in the in-memory store. Must be called inside an
+   * active `withUpdate`.
+   */
+  private bakeProxyGroupTree(group: YorkieElement): void {
+    const plainGroup = unwrapElement(group) as unknown as GroupElement;
+    const gAny = group as unknown as {
+      frame: Frame;
+      data: { refSize: { w: number; h: number }; children: ProxyArray };
+    };
 
-      const proxyElements = s.elements as unknown as ProxyArray;
-      const path = yorkieFindElementPath(proxyElements, groupId);
-      if (!path) return;
+    if (plainGroup.data.children.length === 0) {
+      gAny.data.refSize = { w: plainGroup.frame.w, h: plainGroup.frame.h };
+      return;
+    }
 
-      const group = path[path.length - 1];
-      if (group.type !== 'group') return;
+    // Seed a missing child-group refSize with its pre-scale frame before
+    // baking, so the DFS below computes the child's scale correctly for
+    // legacy documents. See the matching comment in memory.ts
+    // `bakeGroupTree` — keep the two in sync.
+    const pRefW = plainGroup.data.refSize?.w ?? plainGroup.frame.w;
+    const pRefH = plainGroup.data.refSize?.h ?? plainGroup.frame.h;
+    const psx = pRefW > 0 ? plainGroup.frame.w / pRefW : 1;
+    const psy = pRefH > 0 ? plainGroup.frame.h / pRefH : 1;
+    if (psx !== 1 || psy !== 1) {
+      gAny.data.children.forEach((ch, i) => {
+        const plainCh = plainGroup.data.children[i];
+        if (plainCh.type === 'group' && !plainCh.data.refSize) {
+          (ch as unknown as { data: { refSize: { w: number; h: number } } }).data.refSize = {
+            w: plainCh.frame.w,
+            h: plainCh.frame.h,
+          };
+        }
+      });
+    }
 
-      const plainGroup = unwrapElement(group) as unknown as GroupElement;
-      const gAny = group as unknown as {
-        frame: Frame;
-        data: { refSize: { w: number; h: number }; children: ProxyArray };
-      };
-
-      if (plainGroup.data.children.length === 0) {
-        gAny.data.refSize = { w: plainGroup.frame.w, h: plainGroup.frame.h };
-        return;
-      }
-
-      const { children: bakedChildren, refSize } = bakeGroupScale(plainGroup);
-      if (bakedChildren === plainGroup.data.children) {
-        // bakeGroupScale returned identity — sync refSize defensively.
-        gAny.data.refSize = refSize;
-        return;
-      }
-
+    const { children: bakedChildren, refSize } = bakeGroupScale(plainGroup);
+    if (bakedChildren !== plainGroup.data.children) {
       gAny.data.children.forEach((ch, i) => {
         const next = bakedChildren[i];
         const chAny = ch as unknown as {
@@ -2007,7 +2017,32 @@ export class YorkieSlidesStore implements SlidesStore {
           (chAny as unknown as Record<'start' | 'end', Endpoint>).end = next.end;
         }
       });
-      gAny.data.refSize = refSize;
+    }
+    gAny.data.refSize = refSize;
+
+    // Child groups were frame-scaled but keep their stale refSize, so they
+    // now carry the parent's scale — settle them too (DFS).
+    gAny.data.children.forEach((ch) => {
+      if ((ch as unknown as { type: string }).type === 'group') {
+        this.bakeProxyGroupTree(ch as unknown as YorkieElement);
+      }
+    });
+  }
+
+  bakeGroupResize(slideId: string, groupId: string): void {
+    this.requireBatch();
+    this.withUpdate((r) => {
+      const s = r.slides.find((s) => s.id === slideId);
+      if (!s) return;
+
+      const proxyElements = s.elements as unknown as ProxyArray;
+      const path = yorkieFindElementPath(proxyElements, groupId);
+      if (!path) return;
+
+      const group = path[path.length - 1];
+      if (group.type !== 'group') return;
+
+      this.bakeProxyGroupTree(group as unknown as YorkieElement);
     });
   }
 
@@ -2040,6 +2075,13 @@ export class YorkieSlidesStore implements SlidesStore {
       }
 
       const groupIndex = parentArray.findIndex(e => e.id === groupId);
+
+      // Settle any residual render-scale to 1 first (recursively) so the
+      // bake below applies only translate/rotate. Otherwise a rotated
+      // child under a non-uniform group scale would distort on ungroup
+      // (the "smiley squishes" bug; see slides-group.md §6.1). No-op when
+      // the invariant already holds.
+      this.bakeProxyGroupTree(group as unknown as YorkieElement);
 
       // Unwrap the group proxy to a plain GroupElement so we can do math.
       const plainGroup = unwrapElement(group) as unknown as GroupElement;

--- a/packages/frontend/tests/app/slides/yorkie-slides-equivalence.test.ts
+++ b/packages/frontend/tests/app/slides/yorkie-slides-equivalence.test.ts
@@ -415,3 +415,113 @@ describe('YorkieSlidesStore ≡ MemSlidesStore (group / ungroup)', () => {
     expect(yo.slides[0].elements).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Resting-scale invariant on the REAL Yorkie proxy path — smoke coverage for
+// bakeProxyGroupTree + ungroup settle (docs/design/slides/slides-group.md
+// §6.1). The in-memory store is unit-tested exhaustively; these prove the
+// live-app store produces identical results on Yorkie proxies.
+// ---------------------------------------------------------------------------
+
+/** True when every group in the tree rests at scale 1 (refSize ≈ frame). */
+function allGroupsSettled(doc: SlidesDocument): boolean {
+  const eps = 0.01;
+  const walk = (
+    els: readonly { type: string; frame: { w: number; h: number }; data?: unknown }[],
+  ): boolean =>
+    els.every((el) => {
+      if (el.type !== 'group') return true;
+      const g = el as unknown as {
+        frame: { w: number; h: number };
+        data: { refSize?: { w: number; h: number }; children: typeof els };
+      };
+      const ref = g.data.refSize;
+      const settled =
+        !ref ||
+        (Math.abs(ref.w - g.frame.w) <= eps && Math.abs(ref.h - g.frame.h) <= eps);
+      return settled && walk(g.data.children);
+    });
+  return doc.slides.every((s) => walk(s.elements as never));
+}
+
+/**
+ * Group a rotated 60×40 "smiley" + a plain rect, force a residual
+ * non-uniform scale (updateElementFrame WITHOUT bake — the dirty state a
+ * pre-fix commit left behind), then ungroup. Returns the final snapshot.
+ */
+function dirtyGroupThenUngroup(store: SlidesStore): SlidesDocument {
+  let sid!: string;
+  store.batch(() => { sid = store.addSlide('blank'); });
+  let aId!: string; let bId!: string;
+  store.batch(() => {
+    aId = store.addElement(sid, {
+      type: 'shape',
+      frame: { x: 0, y: 0, w: 60, h: 40, rotation: Math.PI / 9 },
+      data: { kind: 'smileyFace' },
+    });
+    bId = store.addElement(sid, {
+      type: 'shape',
+      frame: { x: 160, y: 0, w: 50, h: 50, rotation: 0 },
+      data: { kind: 'rect' },
+    });
+  });
+  let groupId!: string;
+  store.batch(() => { ({ groupId } = store.group(sid, [aId, bId])); });
+  const g0 = store.read().slides[0].elements.find((e) => e.id === groupId)!;
+  store.batch(() =>
+    store.updateElementFrame(sid, groupId, { w: g0.frame.w * 1.5, h: g0.frame.h }),
+  );
+  store.batch(() => store.ungroup(sid, groupId));
+  return store.read();
+}
+
+describe('YorkieSlidesStore resting-scale invariant (live proxy path)', () => {
+  it('ungroup settles a dirty non-uniform group identically to MemSlidesStore', () => {
+    const mem = dirtyGroupThenUngroup(new MemSlidesStore());
+    const yo = dirtyGroupThenUngroup(makeYorkie());
+
+    // No group survives (was flat) and nothing leaked a residual scale.
+    expect(allGroupsSettled(yo)).toBe(true);
+    expect(yo.slides[0].elements.some((e) => e.type === 'group')).toBe(false);
+
+    // The rotated smiley's baked frame matches the proven-correct Mem path
+    // (same rotation identifies it — ids differ per store).
+    const rot = (d: SlidesDocument) =>
+      d.slides[0].elements.find(
+        (e) => e.type === 'shape' && Math.abs(e.frame.rotation - Math.PI / 9) < 1e-9,
+      )!;
+    const yChild = rot(yo);
+    const mChild = rot(mem);
+    expect(yChild).toBeTruthy();
+    expect(yChild.frame.w).toBeCloseTo(mChild.frame.w, 4);
+    expect(yChild.frame.h).toBeCloseTo(mChild.frame.h, 4);
+    expect(yChild.frame.x).toBeCloseTo(mChild.frame.x, 4);
+    expect(yChild.frame.y).toBeCloseTo(mChild.frame.y, 4);
+    expect(yChild.frame.rotation).toBeCloseTo(Math.PI / 9, 6);
+  });
+
+  it('bakeGroupResize settles a group on the Yorkie proxy path', () => {
+    const store = makeYorkie();
+    let sid!: string;
+    store.batch(() => { sid = store.addSlide('blank'); });
+    let aId!: string; let bId!: string;
+    store.batch(() => {
+      aId = store.addElement(sid, {
+        type: 'shape', frame: { x: 0, y: 0, w: 40, h: 40, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+      bId = store.addElement(sid, {
+        type: 'shape', frame: { x: 60, y: 0, w: 40, h: 40, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+    });
+    let groupId!: string;
+    store.batch(() => { ({ groupId } = store.group(sid, [aId, bId])); });
+    const g0 = store.read().slides[0].elements.find((e) => e.id === groupId)!;
+    store.batch(() => {
+      store.updateElementFrame(sid, groupId, { w: g0.frame.w * 2, h: g0.frame.h });
+      store.bakeGroupResize(sid, groupId);
+    });
+    expect(allGroupsSettled(store.read())).toBe(true);
+  });
+});

--- a/packages/slides/src/store/memory.ts
+++ b/packages/slides/src/store/memory.ts
@@ -1138,6 +1138,19 @@ export class MemSlidesStore implements SlidesStore {
     // Unreachable: findElementPath succeeded, so the group must be in the
     // parent array we derived from the same path.
 
+    // Step 4.5: settle the group's render-scale to 1 before baking.
+    // If the group rests with a non-uniform scale (refSize != frame),
+    // `applyGroupTransform` below would bake that scale as an
+    // axis-aligned bbox-preserving rect — which cannot reproduce the
+    // sheared way the renderer draws a ROTATED child under non-uniform
+    // scale, so the child would visibly distort on ungroup (the "smiley
+    // squishes" bug; see docs/design/slides/slides-group.md §6.1).
+    // Baking the scale into the children first (recursively, so nested
+    // child groups don't leak a residual scale either) makes the group
+    // scale identity, so the step below only applies translate/rotate.
+    // In the common case (invariant already held) this is a no-op.
+    bakeGroupTree(group as GroupElement);
+
     // Step 5: bake the group's transform into each child's frame.
     // applyGroupTransform converts a child's group-local frame into the
     // group's parent (= "one level up") coordinate space — exactly what we
@@ -1239,33 +1252,10 @@ export class MemSlidesStore implements SlidesStore {
     if (!path) return; // Stale group id — tolerate.
     const group = path[path.length - 1];
     if (group.type !== 'group') return;
-    if (group.data.children.length === 0) {
-      // No children to bake; just sync refSize to the current frame so
-      // subsequent renders read scale=1.
-      group.data.refSize = { w: group.frame.w, h: group.frame.h };
-      return;
-    }
-
-    const { children, refSize } = bakeGroupScale(group);
-    if (children === group.data.children) {
-      // bakeGroupScale returned identity (scale was already 1) — sync
-      // refSize defensively in case it was undefined.
-      group.data.refSize = refSize;
-      return;
-    }
-    // Mutate children in place (preserve object identity per ungroup /
-    // refitGroup convention so Yorkie path stability holds inside a
-    // batch).
-    for (let i = 0; i < group.data.children.length; i++) {
-      const next = children[i];
-      const cur = group.data.children[i];
-      cur.frame = { ...next.frame };
-      if (cur.type === 'connector' && next.type === 'connector') {
-        cur.start = next.start;
-        cur.end = next.end;
-      }
-    }
-    group.data.refSize = refSize;
+    // Bake this group's render-scale into its children and settle every
+    // descendant group so the whole subtree rests at scale 1
+    // (resting-scale invariant, docs/design/slides/slides-group.md §6.1).
+    bakeGroupTree(group);
   }
 
   // --- text bridges ---
@@ -1936,6 +1926,70 @@ function resolveAncestorTransform(
  */
 function applyFrameWithTransform(frame: Frame, t: GroupTransform): Frame {
   return applyMatrix(frame, t);
+}
+
+/**
+ * Bake a group's render-scale into its children in place, then recurse
+ * into any child that is itself a group. After this returns, `group`
+ * and every descendant group rest at scale 1 (`refSize == frame`) — the
+ * resting-scale invariant (docs/design/slides/slides-group.md §6.1).
+ *
+ * `bakeGroupScale` scales a child group's `frame` by the parent's
+ * `(sx, sy)` but leaves that child's own `refSize` untouched (its
+ * per-level contract is non-recursive), so a scaled child group emerges
+ * with `frame != refSize`. Recursing settles it: its scale is exactly
+ * `(sx, sy)` and baking pushes it down into ITS children, and so on.
+ *
+ * Object identity of every child is preserved (mutate-in-place), which
+ * matters for Yorkie path stability inside a batch — matching the
+ * conventions in `ungroup` / `refitGroup`.
+ *
+ * NOTE: `YorkieSlidesStore.bakeProxyGroupTree` is a line-for-line mirror
+ * of this over Yorkie proxies. Keep the two in sync — any change here
+ * (recursion, refSize seeding, connector handling) must be applied there.
+ */
+function bakeGroupTree(group: GroupElement): void {
+  if (group.data.children.length === 0) {
+    group.data.refSize = { w: group.frame.w, h: group.frame.h };
+    return;
+  }
+  // When this group carries a real scale, seed any child GROUP that lacks
+  // a `refSize` (legacy / backward-compat documents) with its CURRENT
+  // frame first. `bakeGroupScale` is about to scale that child's frame; if
+  // its `refSize` stayed absent it would default to the already-scaled
+  // frame, making the recursion below read scale = 1 and never scale the
+  // grandchildren — the child group's box would grow while its contents
+  // stayed put. Capturing the pre-scale frame keeps the child's scale
+  // ratio correct so the DFS settles it properly.
+  const refW = group.data.refSize?.w ?? group.frame.w;
+  const refH = group.data.refSize?.h ?? group.frame.h;
+  const sx = refW > 0 ? group.frame.w / refW : 1;
+  const sy = refH > 0 ? group.frame.h / refH : 1;
+  if (sx !== 1 || sy !== 1) {
+    for (const child of group.data.children) {
+      if (child.type === 'group' && !child.data.refSize) {
+        child.data.refSize = { w: child.frame.w, h: child.frame.h };
+      }
+    }
+  }
+  const { children, refSize } = bakeGroupScale(group);
+  if (children !== group.data.children) {
+    for (let i = 0; i < group.data.children.length; i++) {
+      const next = children[i];
+      const cur = group.data.children[i];
+      cur.frame = { ...next.frame };
+      if (cur.type === 'connector' && next.type === 'connector') {
+        cur.start = next.start;
+        cur.end = next.end;
+      }
+    }
+  }
+  group.data.refSize = refSize;
+  // Child groups were frame-scaled but keep their stale refSize, so they
+  // now carry the parent's scale — settle them too (DFS).
+  for (const child of group.data.children) {
+    if (child.type === 'group') bakeGroupTree(child);
+  }
 }
 
 /**

--- a/packages/slides/src/view/editor/editor.ts
+++ b/packages/slides/src/view/editor/editor.ts
@@ -6233,6 +6233,21 @@ class SlidesEditorImpl implements SlidesEditor {
         this.repaintOverlay();
         return;
       }
+      // Groups in the selection had their frame.w/h changed above without
+      // baking, leaving a residual non-uniform scale. Bake it into their
+      // children so they rest at scale 1 — same as the single-resize path
+      // (startResize onUp) and required by the resting-scale invariant
+      // (docs/design/slides/slides-group.md §6.1). Without this, ungrouping
+      // a multi-resized group would distort rotated children (the "smiley
+      // squishes" bug).
+      const resizedGroupIds = snapshots
+        .filter(
+          (s) =>
+            s.kind === 'frame' &&
+            frames.has(s.id) &&
+            findElement(startSlide.elements, s.id)?.type === 'group',
+        )
+        .map((s) => s.id);
       this.options.store.batch(() => {
         for (const snap of snapshots) {
           const wf = frames.get(snap.id);
@@ -6248,6 +6263,9 @@ class SlidesEditorImpl implements SlidesEditor {
             snap.id,
             fromWorldFrame(wf, scope, startSlide),
           );
+        }
+        for (const gid of resizedGroupIds) {
+          this.options.store.bakeGroupResize(startSlide.id, gid);
         }
         for (const [id, eps] of connectorEndpoints) {
           this.options.store.updateConnectorEndpoint(startSlide.id, id, 'start', eps.start);

--- a/packages/slides/test/store/group-mutations.test.ts
+++ b/packages/slides/test/store/group-mutations.test.ts
@@ -3,6 +3,8 @@ import { MemSlidesStore } from '../../src/store/memory';
 import type { GroupElement } from '../../src/model/element';
 import type { ConnectorElement } from '../../src/model/connector';
 import { applyGroupTransform } from '../../src/model/group';
+import type { Element } from '../../src/model/element';
+import { collectUnsettledGroups } from '../support/group-invariant';
 
 describe('group()', () => {
   it('requires at least two elements', () => {
@@ -1010,5 +1012,187 @@ describe('refitGroup()', () => {
         store.refitGroup(sid, aId);
       }),
     ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resting-scale invariant — regression for the "smiley squishes on ungroup"
+// bug. See docs/design/slides/slides-group.md §6.1 and
+// docs/tasks/active/20260704-ungroup-scale-invariant-todo.md.
+// ---------------------------------------------------------------------------
+
+describe('resting-scale invariant', () => {
+  function findDeep(els: Element[], id: string): Element | undefined {
+    for (const e of els) {
+      if (e.id === id) return e;
+      if (e.type === 'group') {
+        const r = findDeep(e.data.children, id);
+        if (r) return r;
+      }
+    }
+    return undefined;
+  }
+
+  it('bakeGroupResize recursively settles nested child groups', () => {
+    const store = new MemSlidesStore();
+    let sid!: string;
+    store.batch(() => { sid = store.addSlide('blank', 0); });
+    let a!: string; let b!: string; let c!: string;
+    store.batch(() => {
+      a = store.addElement(sid, {
+        type: 'shape', frame: { x: 0, y: 0, w: 40, h: 40, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+      b = store.addElement(sid, {
+        type: 'shape', frame: { x: 60, y: 0, w: 40, h: 40, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+      c = store.addElement(sid, {
+        type: 'shape', frame: { x: 0, y: 120, w: 40, h: 40, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+    });
+    let inner!: string;
+    store.batch(() => { inner = store.group(sid, [a, b]).groupId; });
+    let outer!: string;
+    store.batch(() => { outer = store.group(sid, [inner, c]).groupId; });
+
+    const g0 = findDeep(store.read().slides[0].elements, outer)! as GroupElement;
+    const w0 = g0.frame.w; const h0 = g0.frame.h;
+    const innerW0 = (findDeep(store.read().slides[0].elements, inner)! as GroupElement).frame.w;
+
+    // Non-uniform resize commit (updateElementFrame + bakeGroupResize),
+    // exactly the pattern the editor uses at resize onUp.
+    store.batch(() => {
+      store.updateElementFrame(sid, outer, { w: w0 * 2, h: h0 });
+      store.bakeGroupResize(sid, outer);
+    });
+
+    const els = store.read().slides[0].elements;
+    // The whole tree — outer AND inner — rests at scale 1.
+    expect(collectUnsettledGroups(els)).toEqual([]);
+    const innerG = findDeep(els, inner)! as GroupElement;
+    expect(innerG.data.refSize).toEqual({ w: innerG.frame.w, h: innerG.frame.h });
+    // The inner group's width was scaled by the outer's 2× (children
+    // follow the group), proving the bake actually descended.
+    expect(innerG.frame.w).toBeCloseTo(innerW0 * 2, 4);
+  });
+
+  // Build a group of a rotated "smiley" + a plain rect, then force a
+  // residual non-uniform scale WITHOUT baking — the exact state a pre-fix
+  // multi-resize / format-panel commit leaves behind.
+  function buildDirtyGroup(): {
+    store: MemSlidesStore; sid: string; groupId: string; aId: string;
+  } {
+    const store = new MemSlidesStore();
+    let sid!: string;
+    store.batch(() => { sid = store.addSlide('blank', 0); });
+    let a!: string; let b!: string;
+    store.batch(() => {
+      // Non-square (60×40) rotated 20° so scaleRotatedFrame's bbox solver
+      // produces a genuinely different result from the per-axis bake — a
+      // square child would hit the solver's degenerate fallback (which
+      // equals per-axis) and mask the bug.
+      a = store.addElement(sid, {
+        type: 'shape',
+        frame: { x: 0, y: 0, w: 60, h: 40, rotation: Math.PI / 9 },
+        data: { kind: 'smileyFace' },
+      });
+      b = store.addElement(sid, {
+        type: 'shape', frame: { x: 160, y: 0, w: 50, h: 50, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+    });
+    let groupId!: string;
+    store.batch(() => { groupId = store.group(sid, [a, b]).groupId; });
+    const g0 = store.read().slides[0].elements.find(
+      (e) => e.id === groupId,
+    ) as GroupElement;
+    // Mild 1.5× horizontal stretch (sx=1.5, sy=1) — keeps the solver in
+    // its positive-root branch instead of the degenerate fallback.
+    store.batch(() => {
+      store.updateElementFrame(sid, groupId, { w: g0.frame.w * 1.5, h: g0.frame.h });
+    });
+    return { store, sid, groupId, aId: a };
+  }
+
+  it('ungroup leaves no residual group scale even from a dirty group', () => {
+    const { store, sid, groupId } = buildDirtyGroup();
+    // Precondition: the group is genuinely dirty (scale ≈ 2×1).
+    expect(collectUnsettledGroups(store.read().slides[0].elements)).toHaveLength(1);
+
+    store.batch(() => { store.ungroup(sid, groupId); });
+    expect(collectUnsettledGroups(store.read().slides[0].elements)).toEqual([]);
+  });
+
+  it('ungroup(dirty) equals bakeGroupResize + ungroup (settle-first, no distortion)', () => {
+    // Path A: ungroup the dirty group directly.
+    const A = buildDirtyGroup();
+    A.store.batch(() => { A.store.ungroup(A.sid, A.groupId); });
+    const childA = A.store.read().slides[0].elements.find((e) => e.id === A.aId)!;
+
+    // Path B: bake the residual scale first, then ungroup.
+    const B = buildDirtyGroup();
+    B.store.batch(() => {
+      B.store.bakeGroupResize(B.sid, B.groupId);
+      B.store.ungroup(B.sid, B.groupId);
+    });
+    const childB = B.store.read().slides[0].elements.find((e) => e.id === B.aId)!;
+
+    // The rotated smiley's baked frame is identical either way — ungroup
+    // settles the scale internally instead of shearing it into a
+    // bbox-preserving rect.
+    expect(childA.frame.x).toBeCloseTo(childB.frame.x, 6);
+    expect(childA.frame.y).toBeCloseTo(childB.frame.y, 6);
+    expect(childA.frame.w).toBeCloseTo(childB.frame.w, 6);
+    expect(childA.frame.h).toBeCloseTo(childB.frame.h, 6);
+    expect(childA.frame.rotation).toBeCloseTo(childB.frame.rotation, 6);
+    // Rotation is preserved (not folded into a bbox).
+    expect(childA.frame.rotation).toBeCloseTo(Math.PI / 9, 6);
+  });
+
+  it('recursive bake scales grandchildren of a LEGACY nested group (no refSize)', () => {
+    const store = new MemSlidesStore();
+    let sid!: string;
+    store.batch(() => { sid = store.addSlide('blank', 0); });
+    let a!: string; let b!: string; let c!: string;
+    store.batch(() => {
+      a = store.addElement(sid, {
+        type: 'shape', frame: { x: 0, y: 0, w: 40, h: 40, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+      b = store.addElement(sid, {
+        type: 'shape', frame: { x: 60, y: 0, w: 40, h: 40, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+      c = store.addElement(sid, {
+        type: 'shape', frame: { x: 0, y: 120, w: 40, h: 40, rotation: 0 },
+        data: { kind: 'rect' },
+      });
+    });
+    let inner!: string;
+    store.batch(() => { inner = store.group(sid, [a, b]).groupId; });
+    // Simulate a legacy inner group created before the refSize field
+    // existed (the model documents refSize as optional / backward-compat).
+    store.batch(() => store.updateElementData(sid, inner, { refSize: undefined }));
+    let outer!: string;
+    store.batch(() => { outer = store.group(sid, [inner, c]).groupId; });
+
+    const grandBefore = (findDeep(store.read().slides[0].elements, a) as Element).frame.w;
+    const g0 = findDeep(store.read().slides[0].elements, outer) as GroupElement;
+
+    // Non-uniform 2× horizontal resize of the OUTER group + commit.
+    store.batch(() => {
+      store.updateElementFrame(sid, outer, { w: g0.frame.w * 2, h: g0.frame.h });
+      store.bakeGroupResize(sid, outer);
+    });
+
+    const els = store.read().slides[0].elements;
+    expect(collectUnsettledGroups(els)).toEqual([]);
+    // The grandchild inside the legacy inner group must have scaled with
+    // the group (width ×2), not been left at its original size inside a
+    // doubled inner frame.
+    const grandAfter = (findDeep(els, a) as Element).frame.w;
+    expect(grandAfter).toBeCloseTo(grandBefore * 2, 3);
   });
 });

--- a/packages/slides/test/support/group-invariant.ts
+++ b/packages/slides/test/support/group-invariant.ts
@@ -1,0 +1,41 @@
+/**
+ * Test-only helpers for the group resting-scale invariant
+ * (docs/design/slides/slides-group.md §6.1): after any committed edit,
+ * every group at every depth must satisfy `refSize == frame` (scale 1).
+ *
+ * These live under test/ rather than src/ because nothing in production
+ * enforces the invariant at runtime — it is upheld by the commit paths
+ * baking on commit. Regression tests use these to assert that.
+ */
+import type { Element, GroupElement } from '../../src/model/element';
+
+/** True when `group` rests at scale 1 (`refSize` absent or ≈ `frame`). */
+export function isGroupSettled(group: GroupElement, eps = 0.01): boolean {
+  const ref = group.data.refSize;
+  if (!ref) return true; // absent ⇒ defaults to frame ⇒ scale 1.
+  return (
+    Math.abs(ref.w - group.frame.w) <= eps &&
+    Math.abs(ref.h - group.frame.h) <= eps
+  );
+}
+
+/**
+ * Every group in `elements` (all depths) that violates the invariant.
+ * Empty array ⇒ the whole tree is settled.
+ */
+export function collectUnsettledGroups(
+  elements: readonly Element[],
+  eps = 0.01,
+): GroupElement[] {
+  const out: GroupElement[] = [];
+  const walk = (els: readonly Element[]): void => {
+    for (const el of els) {
+      if (el.type === 'group') {
+        if (!isGroupSettled(el, eps)) out.push(el);
+        walk(el.data.children);
+      }
+    }
+  };
+  walk(elements);
+  return out;
+}

--- a/packages/slides/test/view/editor/interactions/multi-resize.test.ts
+++ b/packages/slides/test/view/editor/interactions/multi-resize.test.ts
@@ -10,6 +10,7 @@ import '../../../../src/view/canvas/test-canvas-env';
 import { MemSlidesStore } from '../../../../src/store/memory';
 import { initialize, type SlidesEditor } from '../../../../src/view/editor/editor';
 import type { Selection } from '../../../../src/view/editor/selection';
+import { collectUnsettledGroups } from '../../../support/group-invariant';
 
 // ---------------------------------------------------------------------------
 // Shared fixture helpers (inlined — no new shared helpers per plan)
@@ -77,13 +78,17 @@ describe('Multi-resize integration — non-trivial selections', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Test A: Group + shape multi-resize — group's refSize is unchanged
+  // Test A: Group + shape multi-resize — the group is baked to scale 1 on
+  // commit (resting-scale invariant, slides-group.md §6.1). Children scale
+  // into their frames and refSize is re-anchored to the new frame, matching
+  // the single-resize path — so a later ungroup can't distort them.
   // -------------------------------------------------------------------------
-  it("group child scales as a frame; its refSize is unchanged after multi-resize", () => {
+  it("bakes a group's render-scale into its children after multi-resize", () => {
     const { canvas, overlay, store } = makeFixture();
     let sid!: string;
     let aId!: string;
     let groupId!: string;
+    let g1Id!: string;
 
     store.batch(() => {
       sid = store.read().slides[0].id;
@@ -97,7 +102,7 @@ describe('Multi-resize integration — non-trivial selections', () => {
 
       // Two shapes that will be grouped to create group 'g' at roughly
       // (200, 100, 100, 100). Use two shapes that produce that AABB.
-      const g1 = store.addElement(sid, {
+      g1Id = store.addElement(sid, {
         type: 'shape',
         frame: { x: 200, y: 100, w: 100, h: 50, rotation: 0 },
         data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#0f0' } },
@@ -107,16 +112,14 @@ describe('Multi-resize integration — non-trivial selections', () => {
         frame: { x: 200, y: 150, w: 100, h: 50, rotation: 0 },
         data: { kind: 'rect', fill: { kind: 'srgb' as const, value: '#00f' } },
       });
-      ({ groupId } = store.group(sid, [g1, g2]));
+      ({ groupId } = store.group(sid, [g1Id, g2]));
     });
 
-    // The group's frame and refSize are now set. Capture refSize before.
     const groupBefore = store.read().slides[0].elements.find((e) => e.id === groupId)!;
     expect(groupBefore.type).toBe('group');
     if (groupBefore.type !== 'group') throw new Error('unreachable');
-    const refSizeBefore = { ...groupBefore.data.refSize! };
-    expect(refSizeBefore.w).toBeGreaterThan(0);
-    expect(refSizeBefore.h).toBeGreaterThan(0);
+    const childBefore = groupBefore.data.children.find((c) => c.id === g1Id)!;
+    const childWBefore = childBefore.frame.w;
 
     editor = initialize({ canvas, overlay, store, hostWidth: 1920, hostHeight: 1080, dpr: 1 });
     editor.setSelection([aId, groupId]);
@@ -125,17 +128,25 @@ describe('Multi-resize integration — non-trivial selections', () => {
     // Drag the SE handle to grow the multi-selection bounding box.
     dragHandle(canvas, overlay, 'se', 40, 30);
 
-    const groupAfter = store.read().slides[0].elements.find((e) => e.id === groupId)!;
+    const els = store.read().slides[0].elements;
+    const groupAfter = els.find((e) => e.id === groupId)!;
     expect(groupAfter.type).toBe('group');
     if (groupAfter.type !== 'group') throw new Error('unreachable');
 
     // The group's frame width should have grown (SE drag).
     expect(groupAfter.frame.w).toBeGreaterThan(groupBefore.frame.w);
 
-    // The refSize must NOT change — it is the stable anchor for child scaling.
-    expect(groupAfter.data.refSize).toBeDefined();
-    expect(groupAfter.data.refSize!.w).toBeCloseTo(refSizeBefore.w, 3);
-    expect(groupAfter.data.refSize!.h).toBeCloseTo(refSizeBefore.h, 3);
+    // Invariant: the group now rests at scale 1 (refSize == frame), i.e.
+    // the render-scale was baked into the children on commit.
+    expect(collectUnsettledGroups(els)).toEqual([]);
+    expect(groupAfter.data.refSize!.w).toBeCloseTo(groupAfter.frame.w, 3);
+    expect(groupAfter.data.refSize!.h).toBeCloseTo(groupAfter.frame.h, 3);
+
+    // The child's own frame grew by the same horizontal ratio (baked),
+    // rather than staying fixed with a live scale on the group.
+    const childAfter = groupAfter.data.children.find((c) => c.id === g1Id)!;
+    const ratio = groupAfter.frame.w / groupBefore.frame.w;
+    expect(childAfter.frame.w).toBeCloseTo(childWBefore * ratio, 2);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A group could rest with a non-uniform render scale (`data.refSize != frame`) after being resized as part of a **multi-selection** or via the **Format panel W/H** inputs — both changed `frame.w/h` without baking. The renderer applies that scale *outside* a child's own rotation (`Scale·Rotate`, a shear), while `ungroup` bakes the child back as an axis-aligned rotated rect (`Rotate·Scale`, no shear). The two disagree whenever the scale is non-uniform **and** the child is rotated, so a rotated shape (e.g. a smiley face) visibly distorts the instant the group is ungrouped.

Root cause proven deterministically: the two 2×2 maps the shape geometry sees have Frobenius Δ ≈ 0.71 for a 2:1 scale + 30° child, and Δ = 0 whenever the scale is uniform or the child is unrotated.

### Fix — enforce the resting-scale invariant

After any committed edit, every group at every depth has `refSize == frame` (scale 1). A non-uniform scale exists only transiently during a live resize drag and is baked on commit.

- `bakeGroupResize` is now **recursive** (`bakeGroupTree` / `bakeProxyGroupTree`), settling nested descendant groups.
- The missing commit paths now bake: **multi-resize** `onUp` and **Format panel** `commitFrame` / `lockedResize` (single-resize already baked; align/distribute/rotate/move/crop/autofit don't change w/h).
- `ungroup` settles the group's scale to 1 **before** baking translate/rotate — a safety net that also fixes a nested-child-group `refSize` leak.
- A legacy child group with no `refSize` is seeded with its pre-scale frame before baking so the recursion scales its grandchildren correctly.
- Applied to **both** stores: `MemSlidesStore` and the live-app `YorkieSlidesStore`.

Design: `docs/design/slides/slides-group.md` §6.1 (includes the accepted "no shear at rest" trade-off for nested rotated children).

A high-effort multi-agent code review surfaced 4 findings — all addressed (legacy-refSize bug fixed with a test; recursion trade-off documented; store-drift cross-references added; test-only predicates moved to `test/support/`).

## Test plan

- `pnpm verify:fast` — green (slides 322 test files, frontend lint + tests, backend, cli, docs).
- **Store regression** (`group-mutations.test.ts`): recursive nested settle, ungroup settle-equivalence (**verified to FAIL pre-fix**), legacy-nested-group grandchild scaling.
- **Editor integration** (`multi-resize.test.ts`): drives the real `onUp → bake` path; asserts the group is settled after a multi-resize.
- **Live-app smoke** (`yorkie-slides-equivalence.test.ts`): exercises the real `YorkieSlidesStore` proxy path (`bakeProxyGroupTree` + ungroup settle) against a local Yorkie document and asserts it matches the proven-correct Mem path — **verified to FAIL pre-fix**. (The browser editor smoke needs GitHub OAuth, so this drives the production store directly instead.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ungrouping grouped content now preserves appearance more reliably, avoiding distortion from leftover group scaling.
  * Group resizing now settles the group back to a stable state after the edit, including nested groups.

* **Tests**
  * Added regression coverage for group resize and ungroup behavior, including nested and legacy group scenarios.

* **Documentation**
  * Updated design notes and task docs to describe the new group scale invariant and related workflow updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->