### PR TITLE
Import legacy VML <w:pict> images on DOCX import

### DIFF
--- a/docs/tasks/active/20260705-docx-vml-image-import-lessons.md
+++ b/docs/tasks/active/20260705-docx-vml-image-import-lessons.md
@@ -1,0 +1,56 @@
+# DOCX VML image import — lessons
+
+## What broke
+
+`alice-in-wonderland.docx` imported with **zero** of its 42 images. The DOCX
+parser only recognized modern DrawingML images (`<w:drawing>` → `<wp:inline>`
+→ `<a:blip r:embed>`). This document — like many older Word / Google-Docs
+exports — embeds every image with **legacy VML** instead:
+
+```xml
+<w:pict><v:shape style="width:108pt;height:155.25pt">
+  <v:imagedata r:id="rId13"/>
+</v:shape></w:pict>
+```
+
+## Diagnosis notes
+
+- `grep -o '<w:drawing>' document.xml | wc -l` → 0, vs `<w:pict>` → 44. The
+  fastest signal for "which image encoding does this file use" is counting
+  the two element families directly in the unzipped `word/document.xml`.
+- The image **bytes were already uploaded** — `uploadImages` walks every
+  `image`-typed relationship keyed by rId regardless of how the document
+  references it. The bug was purely on the *placement* side (parser), so the
+  media was uploaded-but-orphaned. Splitting "upload" from "reference" this
+  way meant the fix touched only the parser.
+
+## VML vs DrawingML gotchas
+
+- rId lives in `<v:imagedata r:id>` (namespaced `id`), **not** `r:embed`.
+- Size comes from the shape's CSS `style` in **points** (`72pt`), not a
+  `<wp:extent cx/cy>` EMU pair. Convert pt→EMU (1pt = 12700 EMU) so the
+  existing `emusToPx` resolution path is reused unchanged. VML lengths can
+  also be `in`/`cm`/`mm`/`px`; handle them or the image falls back to its
+  (possibly huge) natural size.
+
+## Review findings that mattered
+
+- **Early `continue` = data loss.** The first cut did `if (pict) { …; continue }`
+  unconditionally. A `<w:pict>` is not always an image (VML rule, watermark,
+  textbox) and can share a run with `<w:t>` text — the blanket continue
+  swallowed that text. Fix: only skip the run's text when an inline image was
+  *actually emitted* (helper returns a boolean).
+- **Match the sibling path's gating.** DrawingML imports only `<wp:inline>`
+  and ignores floating `<wp:anchor>`. The VML branch must likewise skip
+  `position:absolute` shapes, or watermarks land as giant inline images.
+- **Deduplicate the placeholder contract.** Both branches emit the same
+  `￼` + `__pending__:<rId>` inline; a shared `pushPendingImage` keeps the
+  two image paths from silently desyncing.
+
+## Known limitations (accepted, symmetric with DrawingML)
+
+- Only the first `<v:imagedata>` per run is read (DrawingML also reads only
+  the first drawing/blip). Multi-image single runs are rare in real exports.
+- `getElementsByTagNameNS` is recursive, so an image nested in a VML textbox
+  would be matched against the outer run. We don't handle VML textboxes at
+  all, so this is out of scope.

--- a/docs/tasks/active/20260705-docx-vml-image-import-todo.md
+++ b/docs/tasks/active/20260705-docx-vml-image-import-todo.md
@@ -1,0 +1,46 @@
+# DOCX VML image import
+
+## Problem
+
+Importing `alice-in-wonderland.docx` drops all 42 images. The parser only
+detects modern DrawingML images (`<w:drawing>` → `<wp:inline>` →
+`<a:blip r:embed>`). This document embeds every image with **legacy VML**
+markup instead:
+
+```xml
+<w:pict>
+  <v:shape style="width:108pt;height:155.25pt">
+    <v:imagedata r:id="rId13" r:href="rId14"/>
+  </v:shape>
+</w:pict>
+```
+
+Because `parseParagraph` has no `<w:pict>` branch, no `imageRef`/placeholder
+inline is created and the run yields nothing. The image bytes are still
+uploaded by `uploadImages` (keyed by rId) but end up orphaned.
+
+## Fix
+
+Add a VML branch to `parseParagraph` (`docx-parser.ts`) that mirrors the
+DrawingML branch:
+
+- Read rId from `<v:imagedata r:id>` (namespaced `id`, not `r:embed`).
+- Parse size from the shape's CSS `style="width:..pt;height:..pt"` and
+  convert pt → EMU so the existing `convertParagraph` emusToPx path is reused.
+- Push `{ rId, cx, cy }` into `imageRefs` and emit the `￼`
+  `__pending__:rId` placeholder inline — identical downstream contract.
+
+Add `pointsToEmus` helper to `units.ts` (1pt = 12700 EMU).
+
+## Tasks
+
+- [ ] Add `pointsToEmus` to `units.ts`
+- [ ] Add VML `<w:pict>`/`<v:imagedata>` branch to `parseParagraph`
+- [ ] Failing test: VML image imports with correct src + pt→px dimensions
+- [ ] `pnpm --filter @wafflebase/docs test` green
+- [ ] `pnpm verify:fast`
+
+## Notes
+
+- Shared importer → fixes both web (`pending-imports.ts`) and CLI.
+- VML namespaces: `v = urn:schemas-microsoft-com:vml`.

--- a/docs/tasks/active/20260705-docx-vml-image-import-todo.md
+++ b/docs/tasks/active/20260705-docx-vml-image-import-todo.md
@@ -34,13 +34,26 @@ Add `pointsToEmus` helper to `units.ts` (1pt = 12700 EMU).
 
 ## Tasks
 
-- [ ] Add `pointsToEmus` to `units.ts`
-- [ ] Add VML `<w:pict>`/`<v:imagedata>` branch to `parseParagraph`
-- [ ] Failing test: VML image imports with correct src + pt→px dimensions
-- [ ] `pnpm --filter @wafflebase/docs test` green
-- [ ] `pnpm verify:fast`
+- [x] Add `pointsToEmus` to `units.ts`
+- [x] Add VML `<w:pict>`/`<v:imagedata>` branch to `parseParagraph`
+- [x] Failing test: VML image imports with correct src + pt→px dimensions
+- [x] `pnpm --filter @wafflebase/docs test` green
+- [x] `pnpm verify:fast`
+
+## Review follow-ups (high-effort code review)
+
+- [x] #1 Only skip run text when an image was emitted (non-image `<w:pict>`
+      with sibling text no longer drops the text) — `tryImportVmlImage` returns bool
+- [x] #2 Skip floating `position:absolute` VML shapes (match DrawingML inline-only)
+- [x] #5 Support `in`/`cm`/`mm`/`px` VML CSS units, not just `pt`
+- [x] #6 Extract shared `pushPendingImage` helper (both image branches)
+- [x] #7 Add paired `-lessons.md`
+- [ ] #3/#4 first-imagedata-only + recursive lookup — accepted as known
+      limitations (symmetric with DrawingML); see lessons
 
 ## Notes
 
 - Shared importer → fixes both web (`pending-imports.ts`) and CLI.
 - VML namespaces: `v = urn:schemas-microsoft-com:vml`.
+- Verified end-to-end on the real file: **0 → 43 images placed** (43
+  `<v:imagedata>` refs, 42 unique media).

--- a/packages/docs/src/import/docx-parser.ts
+++ b/packages/docs/src/import/docx-parser.ts
@@ -1,7 +1,7 @@
 import type { Inline, InlineStyle, BlockStyle, PageSetup, PageMargins, PaperSize } from '../model/types.js';
 import { DEFAULT_BLOCK_STYLE } from '../model/types.js';
 import { mapRunProperties, mapParagraphProperties } from './docx-style-map.js';
-import { twipsToPx, pointsToEmus } from './units.js';
+import { twipsToPx, pointsToEmus, pxToEmus } from './units.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
@@ -10,20 +10,92 @@ const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
 const V = 'urn:schemas-microsoft-com:vml';
 const RELS = 'http://schemas.openxmlformats.org/package/2006/relationships';
 
+/** An image placement parsed from a run: rId + EMU extent (0 = natural size). */
+type ImageRef = { rId: string; cx: number; cy: number };
+
+/**
+ * Convert a VML CSS length (e.g. "108pt", "2in", "3cm", "96px") to EMUs.
+ * A bare number defaults to points, matching VML's implicit unit. Unknown
+ * or unparseable values yield 0 so the natural image size is used instead.
+ */
+function vmlLengthToEmus(raw: string | undefined): number {
+  if (!raw) return 0;
+  const m = /^([0-9.]+)\s*(pt|in|cm|mm|px)?$/i.exec(raw.trim());
+  if (!m) return 0;
+  const value = parseFloat(m[1]);
+  switch ((m[2] || 'pt').toLowerCase()) {
+    case 'in':
+      return Math.round(value * 914400);
+    case 'cm':
+      return Math.round(value * 360000);
+    case 'mm':
+      return Math.round(value * 36000);
+    case 'px':
+      return pxToEmus(value);
+    default:
+      return pointsToEmus(value);
+  }
+}
+
 /**
  * Parse a legacy VML shape's CSS `style` attribute into an EMU extent so it
- * shares the DrawingML `<wp:extent>` contract downstream. VML sizes are in
- * points (e.g. "width:108pt;height:155.25pt"); anything without an explicit
- * `pt` unit degrades to 0 so the natural image size is used instead.
+ * shares the DrawingML `<wp:extent>` contract downstream (e.g.
+ * "width:108pt;height:155.25pt").
  */
 function parseVmlExtent(styleAttr: string | null): { cx: number; cy: number } {
   if (!styleAttr) return { cx: 0, cy: 0 };
-  const w = /(?:^|;)\s*width:\s*([0-9.]+)pt/i.exec(styleAttr);
-  const h = /(?:^|;)\s*height:\s*([0-9.]+)pt/i.exec(styleAttr);
-  return {
-    cx: w ? pointsToEmus(parseFloat(w[1])) : 0,
-    cy: h ? pointsToEmus(parseFloat(h[1])) : 0,
-  };
+  const w = /(?:^|;)\s*width:\s*([^;]+)/i.exec(styleAttr);
+  const h = /(?:^|;)\s*height:\s*([^;]+)/i.exec(styleAttr);
+  return { cx: vmlLengthToEmus(w?.[1]), cy: vmlLengthToEmus(h?.[1]) };
+}
+
+/**
+ * Emit a pending image inline plus its extent ref using the shared contract
+ * the importer resolves after upload: an OBJECT REPLACEMENT CHARACTER inline
+ * carrying a `__pending__:<rId>` src that convertParagraph later swaps for the
+ * uploaded URL, sized from the EMU extent. Shared by the DrawingML and VML
+ * paths so the placeholder contract lives in one place.
+ */
+function pushPendingImage(
+  inlines: Inline[],
+  imageRefs: ImageRef[],
+  rId: string,
+  cx: number,
+  cy: number,
+  style: InlineStyle,
+): void {
+  imageRefs.push({ rId, cx, cy });
+  inlines.push({
+    text: '\uFFFC',
+    style: { ...style, image: { src: `__pending__:${rId}`, width: 0, height: 0 } },
+  });
+}
+
+/**
+ * Import a legacy VML inline image from a `<w:pict>`. Returns true when an
+ * image inline was emitted (so the caller may skip the run's text). Returns
+ * false when the pict is not an embedded inline image — no `<v:imagedata>`,
+ * an empty rId, or a floating/absolutely-positioned shape (watermark,
+ * behind-text). This mirrors the DrawingML path, which imports only
+ * `<wp:inline>` and skips floating `<wp:anchor>` shapes; returning false lets
+ * the caller preserve any sibling text such non-image picts may carry.
+ */
+function tryImportVmlImage(
+  pict: Element,
+  style: InlineStyle,
+  inlines: Inline[],
+  imageRefs: ImageRef[],
+): boolean {
+  const imagedata = pict.getElementsByTagNameNS(V, 'imagedata')[0];
+  if (!imagedata) return false;
+  const rId = imagedata.getAttributeNS(R_NS, 'id') || imagedata.getAttribute('r:id') || '';
+  if (!rId) return false;
+  const styleAttr = imagedata.parentElement?.getAttribute('style') ?? null;
+  // Skip floating shapes to match the DrawingML inline-only behavior.
+  if (styleAttr && /position:\s*absolute/i.test(styleAttr)) return false;
+  const { cx, cy } = parseVmlExtent(styleAttr);
+  pushPendingImage(inlines, imageRefs, rId, cx, cy, style);
+  return true;
 }
 
 export interface RelEntry {
@@ -58,12 +130,12 @@ export function parseParagraph(pEl: Element): {
   blockStyle: BlockStyle;
   blockType: string;
   headingLevel?: number;
-  imageRefs: Array<{ rId: string; cx: number; cy: number }>;
+  imageRefs: ImageRef[];
 } {
   let blockStyle: BlockStyle = { ...DEFAULT_BLOCK_STYLE };
   let blockType = 'paragraph';
   let headingLevel: number | undefined;
-  const imageRefs: Array<{ rId: string; cx: number; cy: number }> = [];
+  const imageRefs: ImageRef[] = [];
 
   const pPr = pEl.getElementsByTagNameNS(W, 'pPr')[0];
   if (pPr) {
@@ -90,7 +162,7 @@ export function parseParagraph(pEl: Element): {
       style = mapRunProperties(rPr);
     }
 
-    // Check for drawing (image)
+    // Check for DrawingML image (<w:drawing> → <wp:inline> → <a:blip>).
     const drawing = r.getElementsByTagNameNS(W, 'drawing')[0];
     if (drawing) {
       const inlineDrawing = drawing.getElementsByTagNameNS(WP, 'inline')[0];
@@ -102,38 +174,19 @@ export function parseParagraph(pEl: Element): {
         const blip = inlineDrawing.getElementsByTagNameNS(A, 'blip')[0];
         const rId = blip?.getAttributeNS(R_NS, 'embed') || blip?.getAttribute('r:embed') || '';
 
-        if (rId) {
-          imageRefs.push({ rId, cx, cy });
-          // Placeholder — the importer will fill in the actual URL after upload
-          inlines.push({
-            text: '\uFFFC',
-            style: { ...style, image: { src: `__pending__:${rId}`, width: 0, height: 0 } },
-          });
-        }
+        if (rId) pushPendingImage(inlines, imageRefs, rId, cx, cy, style);
       }
+      // A <w:drawing> run carries no sibling text, so always skip it.
       continue;
     }
 
     // Check for legacy VML image (<w:pict> → <v:shape> → <v:imagedata>).
     // Older Word / Google-Docs exports embed pictures this way instead of
-    // DrawingML. The rId lives in <v:imagedata r:id> (namespaced `id`, not
-    // `r:embed`) and the size in the shape's CSS `style` (points).
+    // DrawingML. Only skip the run's text when an inline image was actually
+    // emitted — a <w:pict> can also be a non-image VML shape (rule, watermark)
+    // that carries sibling text which must survive.
     const pict = r.getElementsByTagNameNS(W, 'pict')[0];
-    if (pict) {
-      const imagedata = pict.getElementsByTagNameNS(V, 'imagedata')[0];
-      if (imagedata) {
-        const rId =
-          imagedata.getAttributeNS(R_NS, 'id') || imagedata.getAttribute('r:id') || '';
-        if (rId) {
-          const shape = imagedata.parentElement;
-          const { cx, cy } = parseVmlExtent(shape?.getAttribute('style') ?? null);
-          imageRefs.push({ rId, cx, cy });
-          inlines.push({
-            text: '\uFFFC',
-            style: { ...style, image: { src: `__pending__:${rId}`, width: 0, height: 0 } },
-          });
-        }
-      }
+    if (pict && tryImportVmlImage(pict, style, inlines, imageRefs)) {
       continue;
     }
 

--- a/packages/docs/src/import/docx-parser.ts
+++ b/packages/docs/src/import/docx-parser.ts
@@ -1,13 +1,30 @@
 import type { Inline, InlineStyle, BlockStyle, PageSetup, PageMargins, PaperSize } from '../model/types.js';
 import { DEFAULT_BLOCK_STYLE } from '../model/types.js';
 import { mapRunProperties, mapParagraphProperties } from './docx-style-map.js';
-import { twipsToPx } from './units.js';
+import { twipsToPx, pointsToEmus } from './units.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
 const WP = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
 const A = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const V = 'urn:schemas-microsoft-com:vml';
 const RELS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+/**
+ * Parse a legacy VML shape's CSS `style` attribute into an EMU extent so it
+ * shares the DrawingML `<wp:extent>` contract downstream. VML sizes are in
+ * points (e.g. "width:108pt;height:155.25pt"); anything without an explicit
+ * `pt` unit degrades to 0 so the natural image size is used instead.
+ */
+function parseVmlExtent(styleAttr: string | null): { cx: number; cy: number } {
+  if (!styleAttr) return { cx: 0, cy: 0 };
+  const w = /(?:^|;)\s*width:\s*([0-9.]+)pt/i.exec(styleAttr);
+  const h = /(?:^|;)\s*height:\s*([0-9.]+)pt/i.exec(styleAttr);
+  return {
+    cx: w ? pointsToEmus(parseFloat(w[1])) : 0,
+    cy: h ? pointsToEmus(parseFloat(h[1])) : 0,
+  };
+}
 
 export interface RelEntry {
   target: string;
@@ -88,6 +105,29 @@ export function parseParagraph(pEl: Element): {
         if (rId) {
           imageRefs.push({ rId, cx, cy });
           // Placeholder — the importer will fill in the actual URL after upload
+          inlines.push({
+            text: '\uFFFC',
+            style: { ...style, image: { src: `__pending__:${rId}`, width: 0, height: 0 } },
+          });
+        }
+      }
+      continue;
+    }
+
+    // Check for legacy VML image (<w:pict> → <v:shape> → <v:imagedata>).
+    // Older Word / Google-Docs exports embed pictures this way instead of
+    // DrawingML. The rId lives in <v:imagedata r:id> (namespaced `id`, not
+    // `r:embed`) and the size in the shape's CSS `style` (points).
+    const pict = r.getElementsByTagNameNS(W, 'pict')[0];
+    if (pict) {
+      const imagedata = pict.getElementsByTagNameNS(V, 'imagedata')[0];
+      if (imagedata) {
+        const rId =
+          imagedata.getAttributeNS(R_NS, 'id') || imagedata.getAttribute('r:id') || '';
+        if (rId) {
+          const shape = imagedata.parentElement;
+          const { cx, cy } = parseVmlExtent(shape?.getAttribute('style') ?? null);
+          imageRefs.push({ rId, cx, cy });
           inlines.push({
             text: '\uFFFC',
             style: { ...style, image: { src: `__pending__:${rId}`, width: 0, height: 0 } },

--- a/packages/docs/src/import/units.ts
+++ b/packages/docs/src/import/units.ts
@@ -29,6 +29,14 @@ export function pxToEmus(px: number): number {
   return Math.round(px * 914400 / 96);
 }
 
+/**
+ * Points → EMUs. Used to normalize legacy VML shape sizes (CSS points) onto
+ * the same EMU extent contract as DrawingML `<wp:extent>`.
+ */
+export function pointsToEmus(points: number): number {
+  return Math.round(points * 914400 / 72);
+}
+
 /** OOXML half-points → points. */
 export function halfPointsToPoints(halfPts: number): number {
   return halfPts / 2;

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -866,6 +866,75 @@ describe('DocxImporter', () => {
     expect(inline!.style.image!.height).toBe(48);
   });
 
+  it('should size VML images from non-pt CSS units', async () => {
+    // 1in x 0.5in → 96 x 48 px. Verifies parseVmlExtent handles inch units,
+    // not just points.
+    const pictXml = `
+      <w:r>
+        <w:pict xmlns:v="urn:schemas-microsoft-com:vml">
+          <v:shape style="width:1in;height:0.5in">
+            <v:imagedata r:id="rId5"/>
+          </v:shape>
+        </w:pict>
+      </w:r>`;
+    const relsXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+      </Relationships>`;
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const buffer = await createMinimalDocx(`<w:p>${pictXml}</w:p>`, {
+      relsXml,
+      extraFiles: { 'word/media/image1.png': pngBytes },
+    });
+    const doc = await DocxImporter.import(buffer, async () => 'https://example.com/image1.png');
+    const inline = doc.blocks[0].inlines.find((i) => !!i.style.image);
+    expect(inline).toBeDefined();
+    expect(inline!.style.image!.width).toBe(96);
+    expect(inline!.style.image!.height).toBe(48);
+  });
+
+  it('should keep sibling text when a <w:pict> is not an embedded image', async () => {
+    // A VML shape with no <v:imagedata> (e.g. a horizontal rule) plus text in
+    // the same run: the text must survive rather than be swallowed by the
+    // image branch's early continue.
+    const pictXml = `
+      <w:r>
+        <w:pict xmlns:v="urn:schemas-microsoft-com:vml">
+          <v:rect style="width:400pt;height:1pt"/>
+        </w:pict>
+        <w:t>Visible text</w:t>
+      </w:r>`;
+    const buffer = await createMinimalDocx(`<w:p>${pictXml}</w:p>`);
+    const doc = await DocxImporter.import(buffer);
+    const text = doc.blocks[0].inlines.map((i) => i.text).join('');
+    expect(text).toContain('Visible text');
+    expect(doc.blocks[0].inlines.some((i) => !!i.style.image)).toBe(false);
+  });
+
+  it('should skip floating (position:absolute) VML images', async () => {
+    // Watermark / behind-text VML images are absolutely positioned. Mirroring
+    // the DrawingML inline-only path, these are not imported inline.
+    const pictXml = `
+      <w:r>
+        <w:pict xmlns:v="urn:schemas-microsoft-com:vml">
+          <v:shape style="position:absolute;width:72pt;height:72pt">
+            <v:imagedata r:id="rId5"/>
+          </v:shape>
+        </w:pict>
+      </w:r>`;
+    const relsXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+      </Relationships>`;
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const buffer = await createMinimalDocx(`<w:p>${pictXml}</w:p>`, {
+      relsXml,
+      extraFiles: { 'word/media/image1.png': pngBytes },
+    });
+    const doc = await DocxImporter.import(buffer, async () => 'https://example.com/image1.png');
+    expect(doc.blocks[0].inlines.some((i) => !!i.style.image)).toBe(false);
+  });
+
   it('should pass a typed image Blob to the uploader', async () => {
     // Regression for DOCX import failing with 400 from /images because the
     // Blob returned by JSZip has an empty `type`, which FormData then sends

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -826,6 +826,46 @@ describe('DocxImporter', () => {
     expect(inline!.style.image!.height).toBe(48);
   });
 
+  it('should import legacy VML <w:pict> images with pt-based dimensions', async () => {
+    // Some real-world .docx files (e.g. Google-Docs / older Word exports)
+    // embed images via legacy VML markup instead of DrawingML. The image
+    // reference lives in <v:imagedata r:id> and its size in the shape's CSS
+    // style (points), not in a <wp:extent> EMU pair. 72pt x 36pt → 96 x 48 px.
+    const pictXml = `
+      <w:r>
+        <w:pict xmlns:v="urn:schemas-microsoft-com:vml">
+          <v:shape id="_x0000_i1025" type="#_x0000_t75" style="width:72pt;height:36pt">
+            <v:imagedata r:id="rId5" r:href="rId6"/>
+          </v:shape>
+        </w:pict>
+      </w:r>`;
+    const relsXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+      </Relationships>`;
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+      0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+      0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
+      0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+      0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+    const buffer = await createMinimalDocx(
+      `<w:p>${pictXml}</w:p>`,
+      {
+        relsXml,
+        extraFiles: { 'word/media/image1.png': pngBytes },
+      },
+    );
+    const doc = await DocxImporter.import(buffer, async () => 'https://example.com/image1.png');
+    const inline = doc.blocks[0].inlines.find((i) => !!i.style.image);
+    expect(inline).toBeDefined();
+    expect(inline!.style.image!.src).toBe('https://example.com/image1.png');
+    expect(inline!.style.image!.width).toBe(96);
+    expect(inline!.style.image!.height).toBe(48);
+  });
+
   it('should pass a typed image Blob to the uploader', async () => {
     // Regression for DOCX import failing with 400 from /images because the
     // Blob returned by JSZip has an empty `type`, which FormData then sends


### PR DESCRIPTION
## Summary

Importing `alice-in-wonderland.docx` dropped all 42 of its images. The DOCX
parser only recognized modern **DrawingML** images (`<w:drawing>` →
`<wp:inline>` → `<a:blip r:embed>`), but this file — like many older Word and
Google-Docs exports — embeds every image with **legacy VML** instead:

```xml
<w:pict><v:shape style="width:108pt;height:155.25pt">
  <v:imagedata r:id="rId13"/>
</v:shape></w:pict>
```

With no VML branch in `parseParagraph`, no placeholder inline was created and
each image was silently dropped — even though `uploadImages` had already
uploaded the bytes, leaving them orphaned.

### Changes
- Add a `<w:pict>`/`<v:imagedata>` branch to `parseParagraph` mirroring the
  DrawingML path: reads the rId from `r:id` (not `r:embed`) and the size from
  the shape's CSS `style`, converting to EMU so the existing
  `convertParagraph` → `emusToPx` resolution is reused unchanged.
- New `pointsToEmus` unit helper; `parseVmlExtent` also handles `in`/`cm`/`mm`/`px`.
- Only skip a run's text when an image was actually emitted, so a non-image
  `<w:pict>` (VML rule/watermark) sharing a run with `<w:t>` keeps its text.
- Skip floating `position:absolute` VML shapes, matching the DrawingML
  inline-only behavior.
- Shared `pushPendingImage` helper so the placeholder contract lives in one place.

Shared importer → fixes both web (`pending-imports.ts`) and CLI import.

## Test plan
- New unit tests: VML image import (pt + inch dimensions), sibling-text
  survival for non-image picts, floating-image skip.
- Verified end-to-end against the real `alice-in-wonderland.docx`:
  **0 → 43 images placed** (43 `<v:imagedata>` refs, 42 unique media).
- `pnpm verify:fast` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
