### PR TITLE
Stop docs cursor movement from re-measuring the whole document

### DIFF
--- a/docs/design/docs/docs-rendering-optimization.md
+++ b/docs/design/docs/docs-rendering-optimization.md
@@ -111,12 +111,39 @@ function cachedMeasureText(
 ```
 
 The cache key is `font\ttext`. Font strings include size, family, weight, and
-style — so identical visual text always hits the cache. The cache is never
-invalidated because `measureText` results are deterministic for a given
-font+text combination.
+style — so identical visual text always hits the cache. The cache is
+deterministic for a given font+text combination, but see the font-load caveat
+below.
 
 `measureSegments()` calls `cachedMeasureText()` instead of `ctx.measureText()`
 directly.
+
+#### Char-offset cache
+
+`computeCharOffsets()` (per-character caret x within a run) originally
+re-measured every character prefix on every layout, uncached — the dominant
+remaining `measureText` cost once cursor moves stopped forcing a full
+re-layout. It now memoises the whole offsets array per `(measurer, font,
+text)`, keyed like `cachedMeasureText` and drained by the same
+`clearMeasureCache`. Offsets depend only on font+text (not layout width), so
+the cache survives resizes. Effect: re-laying-out unchanged content (every
+structural edit, remote change, undo/redo, resize) costs zero canvas
+measurements.
+
+Caret/selection pixel resolvers (`peer-cursor.ts`, `selection.ts`, header/
+footer/table paths in `editor.ts`) read the run's precomputed
+`LayoutRun.charOffsets` via `caretOffsetX()` instead of re-measuring a slice
+each paint frame; the measurer is only consulted on a defensive fallback.
+
+#### Font-load invalidation
+
+Because both caches key by `(font, text)` with no load-state key, the initial
+layout of a not-yet-loaded web font pins run positions and caret offsets to
+the fallback face's metrics. The docs editor's `initialize()` therefore
+subscribes to `document.fonts` `'loadingdone'` and, on fire, calls
+`clearMeasureCache()` + `invalidateLayout()` + `render()` so layout and caret
+snap onto the real glyph advances once the face arrives (the same wiring
+slides uses). The listener is removed in `dispose()`.
 
 ### 5. Incremental Layout (Dirty Block Tracking)
 
@@ -205,8 +232,9 @@ recomputed (backward-compatible behavior).
 | Risk | Mitigation |
 |------|-----------|
 | Stale layout cache after structural edits | invalidateLayout() clears cache on splitBlock/mergeBlocks/multi-block delete; undo/redo also clears cache |
-| measureText cache unbounded growth | For typical documents, cache stays small (unique word+font combos). Monitor and add LRU eviction if needed. |
+| measureText / char-offset cache unbounded growth | For typical documents, caches stay small (unique word+font combos). The font-load `loadingdone` handler drains both. Monitor and add LRU eviction to both together if needed. |
 | Y-offset drift after incremental layout | Always recompute all Y offsets cumulatively — only block-internal layout is cached |
 | Race between dirty tracking and render | dirtyBlockIds is reset synchronously inside recomputeLayout |
 | Remote edits (future YorkieDocStore) bypass dirty tracking | When Yorkie integration is added, external mutations must clear layoutCache or mark affected blocks dirty |
 | DPI change / monitor switch invalidates measureText cache | Clear measureCache on `window.devicePixelRatio` change if needed (deferred — rare edge case) |
+| Async web-font load leaves layout/caret on fallback metrics | `document.fonts` `'loadingdone'` handler clears both caches and forces a full re-layout (see Font-load invalidation) |

--- a/docs/design/docs/docs-rendering-optimization.md
+++ b/docs/design/docs/docs-rendering-optimization.md
@@ -143,7 +143,16 @@ the fallback face's metrics. The docs editor's `initialize()` therefore
 subscribes to `document.fonts` `'loadingdone'` and, on fire, calls
 `clearMeasureCache()` + `invalidateLayout()` + `render()` so layout and caret
 snap onto the real glyph advances once the face arrives (the same wiring
-slides uses). The listener is removed in `dispose()`.
+slides uses). Because `'loadingdone'` is unreliable on WebKit/Safari, when
+fonts are still loading at mount it *also* settles via the Promise-based
+`document.fonts.ready` (armed only while `status === 'loading'`, so an
+already-loaded document pays no extra relayout). The listener is removed and
+the `ready` continuation guarded in `dispose()`.
+
+`dispose()` also calls `disposeMeasureCache(measurer)` to release this
+editor's cache maps from the module-level `knownCaches` registry — otherwise
+the registry's strong references would keep every disposed editor's caches
+alive for the process lifetime (`clearMeasureCache` only empties the maps).
 
 ### 5. Incremental Layout (Dirty Block Tracking)
 

--- a/docs/tasks/active/20260705-docs-cursor-move-relayout-todo.md
+++ b/docs/tasks/active/20260705-docs-cursor-move-relayout-todo.md
@@ -107,6 +107,24 @@ load, drifting from the painted glyphs until reload.
       fixes both the word-width and char-offset staleness.
 - [x] docs suite green (1071 pass); typecheck clean.
 
+### PR #444 CodeRabbit round
+
+- [x] **`knownCaches` retains dead Maps (Major).** The drain registry strongly
+      held every per-measurer Map forever, defeating the WeakMaps' GC intent —
+      one leaked cache pair per disposed editor (pre-existing for the width
+      cache, doubled by the offset cache). Added `disposeMeasureCache(measurer)`
+      to `layout.ts`, called from `editor.dispose()`; exported from the package
+      index.
+- [x] **`document.fonts.ready` fallback (Major).** `loadingdone` is unreliable
+      on WebKit/Safari. `initialize()` now also settles via `fonts.ready`,
+      armed only when `status === 'loading'` at mount, guarded on dispose.
+      (Mid-session Safari font picks would still want the slides-style per-apply
+      `fonts.load().then()` in the frontend picker — noted as follow-up.)
+- [x] **Stale task-doc `#2` "Still open" entry (Minor).** Removed.
+- [ ] Declined: extract shared `installCanvasShim` into `test-utils.ts` — CR
+      marked "Low value / Trivial"; the shims carry per-test variations and the
+      duplication is contained. Left to keep the PR focused.
+
 **Second finding (unbounded cache growth) — accepted as known limitation.**
 The offset cache shares the exact lifecycle of the pre-existing word-width
 cache, whose unbounded growth `docs-rendering-optimization.md` explicitly
@@ -143,7 +161,7 @@ mutation). Tables are not the perf-sensitive path, so this is a safe, minimal
 boundary.
 
 **Still open (separate fixes):**
-- #2 — `computeCharOffsets` bypasses `cachedMeasureText`; caret/selection
-  resolvers re-measure instead of reusing `LayoutRun.charOffsets`. Makes the
-  full-relayout paths (remote edits, undo/redo, resize) cheaper.
-- #3 — remote-edit / undo-redo / resize still force a full re-layout.
+- #3 — remote-edit / undo-redo / resize still force a full re-layout pass
+  (now measurement-free after #2, but still an O(blocks) walk).
+
+_(#2 and #2-B are completed above; see their sections.)_

--- a/docs/tasks/active/20260705-docs-cursor-move-relayout-todo.md
+++ b/docs/tasks/active/20260705-docs-cursor-move-relayout-todo.md
@@ -50,12 +50,35 @@ Pure caret navigation changes no document content, so it should paint-only
 - [x] `pnpm --filter @wafflebase/docs test` green (1064 pass); `pnpm
       verify:fast` green (exit 0).
 
+## Fix #2: make full re-layouts measurement-free (computeCharOffsets cache)
+
+After fix #1, a full re-layout still happens on every structural edit (Enter,
+paste, multi-block delete), remote collaborative edit, undo/redo, and resize.
+Word widths are already cached (`cachedMeasureText` in `measureSegments`), but
+`computeCharOffsets` (`layout.ts:403`) measured every character prefix
+uncached on every full re-layout — the remaining `measureText` hotspot.
+
+- [x] Failing test: a second `computeLayout` of unchanged blocks (full
+      recompute) must perform zero `measureWidth` calls.
+      → `test/view/char-offsets-cache.test.ts`. Before: 63 calls; after: 0.
+- [x] Memoise `computeCharOffsets` per `(measurer, font, text)` — whole
+      offsets array cached, keyed like `cachedMeasureText`. Offsets depend
+      only on font+text (not layout width), so the cache survives resizes.
+      Registered in the shared `knownCaches` drain so `clearMeasureCache`
+      clears it too. Returned array is shared and treated read-only (no
+      callsite mutates `LayoutRun.charOffsets`; verified by grep).
+- [x] `pnpm --filter @wafflebase/docs test` green (1067 pass).
+
 ## Non-goals here
 
-- `computeCharOffsets` caching / caret resolver reuse of `LayoutRun.charOffsets`
-  (fix #2).
-- Remote-edit full-relayout, undo/redo, resize (separate follow-ups).
-- Layout-level virtualization.
+- Part B — caret/selection resolvers still re-measure a slice per paint frame
+  instead of reusing `LayoutRun.charOffsets` (`selection.ts:216`,
+  `peer-cursor.ts:369`, header/footer/table variants). Small per-frame cost;
+  delicate caret math across 6+ callsites → separate, carefully-tested
+  follow-up.
+- Fix #3 — remote-edit / undo-redo / structural-edit still force a full
+  re-layout pass (now cheap thanks to fix #2, but still O(blocks) walk).
+- Layout-level virtualization (explicit design Non-Goal).
 
 ## Review
 

--- a/docs/tasks/active/20260705-docs-cursor-move-relayout-todo.md
+++ b/docs/tasks/active/20260705-docs-cursor-move-relayout-todo.md
@@ -69,13 +69,27 @@ uncached on every full re-layout — the remaining `measureText` hotspot.
       callsite mutates `LayoutRun.charOffsets`; verified by grep).
 - [x] `pnpm --filter @wafflebase/docs test` green (1067 pass).
 
+## Fix #2-B: caret/selection resolvers reuse charOffsets (no per-frame measure)
+
+The caret- and selection-pixel resolvers re-measured `run.text.slice(0, n)`
+on every paint frame instead of reading the run's already-computed
+`charOffsets`. Small per-frame cost, but redundant and a latent inconsistency
+(they re-resolved the font, which can differ from the layout's `seg.font`).
+
+- [x] Failing test for the shared helper: `caretOffsetX(run, n, measurer)`
+      returns `charOffsets[n-1]` (0 at n=0) with no `measureWidth` call, and
+      falls back to measuring only when offsets are missing/short.
+      → `test/view/caret-offset-x.test.ts`.
+- [x] Add `caretOffsetX` to `layout.ts`; route all 8 offset→x callsites
+      through it: `peer-cursor.ts` (body + table caret), `selection.ts` (body
+      selection), `editor.ts` (header/footer/table caret + selection rects,
+      5 sites). Image runs keep their own width handling. `measurer` stays in
+      the signatures (used by the fallback), so no API churn.
+- [x] `pnpm --filter @wafflebase/docs test` green (1069 pass); typecheck
+      clean.
+
 ## Non-goals here
 
-- Part B — caret/selection resolvers still re-measure a slice per paint frame
-  instead of reusing `LayoutRun.charOffsets` (`selection.ts:216`,
-  `peer-cursor.ts:369`, header/footer/table variants). Small per-frame cost;
-  delicate caret math across 6+ callsites → separate, carefully-tested
-  follow-up.
 - Fix #3 — remote-edit / undo-redo / structural-edit still force a full
   re-layout pass (now cheap thanks to fix #2, but still O(blocks) walk).
 - Layout-level virtualization (explicit design Non-Goal).

--- a/docs/tasks/active/20260705-docs-cursor-move-relayout-todo.md
+++ b/docs/tasks/active/20260705-docs-cursor-move-relayout-todo.md
@@ -88,10 +88,37 @@ on every paint frame instead of reading the run's already-computed
 - [x] `pnpm --filter @wafflebase/docs test` green (1069 pass); typecheck
       clean.
 
+## Code review follow-up: font-load cache invalidation
+
+High-effort review flagged that caching `computeCharOffsets` made a
+**pre-existing** docs bug observable: the measure cache keys by `(font, text)`
+with no load-state key, and docs — unlike slides — never cleared it when a web
+font finished loading. So layout (already, via the older word-width cache) and
+now caret offsets stayed pinned to fallback-font metrics after an async font
+load, drifting from the painted glyphs until reload.
+
+- [x] Failing test: dispatching `document.fonts` `loadingdone` on a warm
+      editor must re-measure the document; the listener must be removed on
+      dispose. → `test/view/font-load-invalidation.test.ts`.
+- [x] `editor.ts` `initialize`: add a `document.fonts` `loadingdone` listener
+      → `clearMeasureCache()` + `invalidateLayout()` + `render()` (mirrors
+      slides `editor.ts`), removed in `dispose`. `clearMeasureCache` already
+      drains the new offset cache via the shared `knownCaches`, so one wiring
+      fixes both the word-width and char-offset staleness.
+- [x] docs suite green (1071 pass); typecheck clean.
+
+**Second finding (unbounded cache growth) — accepted as known limitation.**
+The offset cache shares the exact lifecycle of the pre-existing word-width
+cache, whose unbounded growth `docs-rendering-optimization.md` explicitly
+deferred ("monitor and add LRU if needed"). The new font-load clearing also
+drains it periodically. Adding LRU to one cache but not its twin would be
+inconsistent; deferred to a joint follow-up if profiling shows real pressure.
+
 ## Non-goals here
 
 - Fix #3 — remote-edit / undo-redo / structural-edit still force a full
   re-layout pass (now cheap thanks to fix #2, but still O(blocks) walk).
+- Cache LRU eviction (see above; consistent with existing width-cache design).
 - Layout-level virtualization (explicit design Non-Goal).
 
 ## Review

--- a/docs/tasks/active/20260705-docs-cursor-move-relayout-todo.md
+++ b/docs/tasks/active/20260705-docs-cursor-move-relayout-todo.md
@@ -1,0 +1,85 @@
+# Docs: cursor movement forces full-document re-layout
+
+## Problem
+
+As the docs body grows, cursor movement (arrow keys, Home/End) and scrolling
+feel progressively slower. Profiling a large shared document shows
+`measureText` / `measureWidth` dominating (~57% in `measureWidth`).
+
+Root cause (verified):
+
+1. **Cursor movement triggers a full re-layout.** Arrow keys route through
+   `TextEditor.requestRender` → `renderWithScroll` → `render()` →
+   `recomputeLayout()`. The navigation handlers never call `markDirty`, so
+   `dirtyBlockIds === undefined` at layout time, which disables the
+   incremental cache (`canUseCache` requires `dirtyBlockIds != null`,
+   `layout.ts:311`). Every caret move re-lays-out and re-measures **all**
+   blocks.
+2. **The re-measure is expensive** because `computeCharOffsets`
+   (`layout.ts:403`) is O(chars)-per-run and bypasses the `cachedMeasureText`
+   cache. (Addressed separately in fix #2.)
+
+Partial/viewport rendering does not help: it only culls the *paint* step
+(`doc-canvas.ts:248-252`); measurement happens at *layout* time over all
+blocks regardless of what is visible. Layout-level virtualization is an
+explicit Non-Goal in `docs-rendering-optimization.md`.
+
+## Fix #1 (this task): cursor moves must not re-layout
+
+Pure caret navigation changes no document content, so it should paint-only
+(reuse the cached layout) instead of recomputing layout.
+
+- [x] Write a failing editor-level test: after initial render, an ArrowRight
+      keypress on a multi-block document must not re-measure the whole
+      document (count `measureText` calls; must not scale with block count).
+      → `test/view/cursor-move-no-relayout.test.ts`. Before fix: **1991**
+      `measureText` calls on one ArrowRight; asserts `< 40`.
+- [x] In `editor.ts`, factor the post-render cursor side-effects
+      (`fireCursorMoveCallbacks` + link detection) out of `renderWithScroll`
+      into a shared helper (`afterCursorRender`), and add a `renderCursorMove`
+      that runs those side-effects with `renderPaintOnly()` instead of
+      `render()`.
+- [x] Thread a new `requestCursorRender` callback into `TextEditor`
+      (public property, fallback to `requestRender` via `requestCaretRender()`
+      when unset, so slides text boxes stay correct).
+- [x] Use `requestCursorRender` from the guaranteed non-mutating navigation
+      paths only: non-table `handleArrow` tail, `handleHome`, `handleEnd`,
+      `handleDocStart`, `handleDocEnd`. Table navigation stays on the full
+      `requestRender` (its table-exit path can call `ensureBlockAfter`, which
+      mutates the document).
+- [x] `pnpm --filter @wafflebase/docs test` green (1064 pass); `pnpm
+      verify:fast` green (exit 0).
+
+## Non-goals here
+
+- `computeCharOffsets` caching / caret resolver reuse of `LayoutRun.charOffsets`
+  (fix #2).
+- Remote-edit full-relayout, undo/redo, resize (separate follow-ups).
+- Layout-level virtualization.
+
+## Review
+
+**Result:** A single arrow keypress on a 40-block document dropped from
+**1991** `measureText` calls to **< 40** (caret-only). The caret move now
+repaints from the cached layout instead of re-measuring every block, so
+navigation cost is independent of body length.
+
+**Changed files**
+- `src/view/editor.ts` — split `renderWithScroll` into `afterCursorRender`
+  (shared side effects) + `renderCursorMove` (paint-only variant); wired
+  `textEditor.requestCursorRender = renderCursorMove`.
+- `src/view/text-editor.ts` — added optional `requestCursorRender` property +
+  `requestCaretRender()` helper; routed the 5 non-mutating navigation paths
+  through it.
+- `test/view/cursor-move-no-relayout.test.ts` — new perf-guard test.
+
+**Scope guard:** table arrow navigation intentionally still does a full
+render because its table-exit branch can call `ensureBlockAfter` (a document
+mutation). Tables are not the perf-sensitive path, so this is a safe, minimal
+boundary.
+
+**Still open (separate fixes):**
+- #2 — `computeCharOffsets` bypasses `cachedMeasureText`; caret/selection
+  resolvers re-measure instead of reusing `LayoutRun.charOffsets`. Makes the
+  full-relayout paths (remote edits, undo/redo, resize) cheaper.
+- #3 — remote-edit / undo-redo / resize still force a full re-layout.

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -98,7 +98,7 @@ export {
 export { paintLayout, type PaintLayoutOpts } from './view/paint-layout.js';
 export { findPositionAtPixel, type PixelPosition } from './view/find-position-at-pixel.js';
 export type { TableMergeContext } from './view/table-merge-context.js';
-export { computeLayout, computeListCounters, clearMeasureCache } from './view/layout.js';
+export { computeLayout, computeListCounters, clearMeasureCache, disposeMeasureCache } from './view/layout.js';
 export type {
   DocumentLayout,
   LayoutBlock,

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -9,7 +9,7 @@ import { DocCanvas } from './doc-canvas.js';
 import { Cursor } from './cursor.js';
 import { Selection, computeSelectionRects } from './selection.js';
 import { TextEditor } from './text-editor.js';
-import { computeLayout, caretOffsetX, clearMeasureCache, type ComposingContext, type DocumentLayout, type LayoutCache, type LayoutRun } from './layout.js';
+import { computeLayout, caretOffsetX, clearMeasureCache, disposeMeasureCache, type ComposingContext, type DocumentLayout, type LayoutCache, type LayoutRun } from './layout.js';
 import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getPageYOffset, getHeaderYStart, getFooterYStart, paginatedPixelToPosition, type PaginatedLayout } from './pagination.js';
 import { CanvasTextMeasurer } from './canvas-measurer.js';
 import type { TextMeasurer } from './measurer.js';
@@ -2440,12 +2440,29 @@ export function initialize(
   // recompute so layout and caret match the painted glyphs (mirrors slides).
   const fontsTarget: EventTarget | undefined =
     typeof document !== 'undefined' ? document.fonts : undefined;
+  let fontsDisposed = false;
   const handleFontsLoaded = () => {
     clearMeasureCache();
     invalidateLayout();
     render();
   };
   fontsTarget?.addEventListener('loadingdone', handleFontsLoaded);
+  // `loadingdone` is unreliable on WebKit/Safari, so also settle via the
+  // Promise-based `fonts.ready` (broadly supported). Armed only when fonts
+  // are still loading at mount, so an already-loaded document pays no extra
+  // relayout. Covers the common case of opening a document whose web fonts
+  // are still arriving; mid-session picks rely on the `loadingdone` listener.
+  if (
+    typeof document !== 'undefined' &&
+    document.fonts &&
+    document.fonts.status === 'loading'
+  ) {
+    document.fonts.ready
+      .then(() => {
+        if (!fontsDisposed) handleFontsLoaded();
+      })
+      .catch(() => {});
+  }
 
   // Focus/blur handling
   const handleFocus = () => {
@@ -3514,7 +3531,11 @@ export function initialize(
       container.removeEventListener('scroll', handleScroll);
       container.removeEventListener('contextmenu', handleEditorContextMenu);
       document.removeEventListener('transitionend', handleTransitionEnd);
+      fontsDisposed = true;
       fontsTarget?.removeEventListener('loadingdone', handleFontsLoaded);
+      // Release this editor's measurer caches so the module-level knownCaches
+      // registry doesn't retain them for the process lifetime.
+      disposeMeasureCache(measurer);
       if (spellTimer) {
         clearTimeout(spellTimer);
         spellTimer = null;

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -1909,9 +1909,10 @@ export function initialize(
   let cursorLinkChangeCallback: ((info: { href: string; rect: { x: number; y: number; width: number; height: number } } | undefined) => void) | null = null;
   let textEditorRef: TextEditor | null = null;
 
-  const renderWithScroll = () => {
-    needsScrollIntoView = true;
-    render();
+  // Post-render side effects that must fire after any caret-moving render,
+  // whether it recomputed layout or only repainted: toolbar/presence cursor
+  // sync and link-under-cursor detection.
+  const afterCursorRender = () => {
     const selRange = selection.hasSelection() && selection.range
       ? {
           anchor: selection.range.anchor,
@@ -1941,6 +1942,23 @@ export function initialize(
         cursorLinkChangeCallback(undefined);
       }
     }
+  };
+
+  const renderWithScroll = () => {
+    needsScrollIntoView = true;
+    render();
+    afterCursorRender();
+  };
+
+  // Caret-only render: the caret/selection moved but no document content
+  // changed, so the cached layout is still valid. Repaint (which recomputes
+  // the caret pixel and selection rects from the cached layout and honors
+  // needsScrollIntoView) instead of re-measuring every block. This is what
+  // keeps arrow-key navigation O(1) instead of O(document) as the body grows.
+  const renderCursorMove = () => {
+    needsScrollIntoView = true;
+    renderPaintOnly();
+    afterCursorRender();
   };
 
   const textEditor = readOnly ? null : new TextEditor(
@@ -2001,6 +2019,9 @@ export function initialize(
     // Used by table border resize so resizing on page 2 with the caret
     // on page 1 doesn't snap the viewport back to page 1.
     textEditor.requestRenderNoCursorScroll = render;
+    // Caret-only navigation repaints from the cached layout instead of
+    // re-measuring the whole document (arrow keys, Home/End).
+    textEditor.requestCursorRender = renderCursorMove;
 
     // Image selection key routing. Delete/Backspace delete the selected
     // image inline and return to text mode; Escape clears the image

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -9,7 +9,7 @@ import { DocCanvas } from './doc-canvas.js';
 import { Cursor } from './cursor.js';
 import { Selection, computeSelectionRects } from './selection.js';
 import { TextEditor } from './text-editor.js';
-import { computeLayout, caretOffsetX, type ComposingContext, type DocumentLayout, type LayoutCache, type LayoutRun } from './layout.js';
+import { computeLayout, caretOffsetX, clearMeasureCache, type ComposingContext, type DocumentLayout, type LayoutCache, type LayoutRun } from './layout.js';
 import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getPageYOffset, getHeaderYStart, getFooterYStart, paginatedPixelToPosition, type PaginatedLayout } from './pagination.js';
 import { CanvasTextMeasurer } from './canvas-measurer.js';
 import type { TextMeasurer } from './measurer.js';
@@ -2433,6 +2433,20 @@ export function initialize(
   // Attach to the document so we catch transitions anywhere in the tree.
   document.addEventListener('transitionend', handleTransitionEnd);
 
+  // Re-layout when a web font finishes loading. The measure cache keys widths
+  // and char offsets by (font, text) with no load-state key, so the initial
+  // layout against a not-yet-loaded face pins run positions and caret offsets
+  // to the fallback metrics. Once the real face arrives, drop the cache and
+  // recompute so layout and caret match the painted glyphs (mirrors slides).
+  const fontsTarget: EventTarget | undefined =
+    typeof document !== 'undefined' ? document.fonts : undefined;
+  const handleFontsLoaded = () => {
+    clearMeasureCache();
+    invalidateLayout();
+    render();
+  };
+  fontsTarget?.addEventListener('loadingdone', handleFontsLoaded);
+
   // Focus/blur handling
   const handleFocus = () => {
     focused = true;
@@ -3500,6 +3514,7 @@ export function initialize(
       container.removeEventListener('scroll', handleScroll);
       container.removeEventListener('contextmenu', handleEditorContextMenu);
       document.removeEventListener('transitionend', handleTransitionEnd);
+      fontsTarget?.removeEventListener('loadingdone', handleFontsLoaded);
       if (spellTimer) {
         clearTimeout(spellTimer);
         spellTimer = null;

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -9,7 +9,7 @@ import { DocCanvas } from './doc-canvas.js';
 import { Cursor } from './cursor.js';
 import { Selection, computeSelectionRects } from './selection.js';
 import { TextEditor } from './text-editor.js';
-import { computeLayout, resolveInlineFont, type ComposingContext, type DocumentLayout, type LayoutCache, type LayoutRun } from './layout.js';
+import { computeLayout, caretOffsetX, type ComposingContext, type DocumentLayout, type LayoutCache, type LayoutRun } from './layout.js';
 import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getPageYOffset, getHeaderYStart, getFooterYStart, paginatedPixelToPosition, type PaginatedLayout } from './pagination.js';
 import { CanvasTextMeasurer } from './canvas-measurer.js';
 import type { TextMeasurer } from './measurer.js';
@@ -418,10 +418,7 @@ function computeHFTableCellCaretPixel(
           const localOff = remaining - chars;
           cursorXInCell = run.x + (run.imageHeight !== undefined
             ? (localOff > 0 ? run.width : 0)
-            : measurer.measureWidth(
-                run.text.slice(0, localOff),
-                resolveInlineFont(run.inline.style),
-              ));
+            : caretOffsetX(run, localOff, measurer));
           break;
         }
         chars += run.text.length;
@@ -510,11 +507,7 @@ export function computeHFCursorPixel(
           if (run.imageHeight !== undefined) {
             cursorX = run.x + (localOff > 0 ? run.width : 0);
           } else {
-            const textBefore = run.text.slice(0, localOff);
-            cursorX = run.x + measurer.measureWidth(
-              textBefore,
-              resolveInlineFont(run.inline.style),
-            );
+            cursorX = run.x + caretOffsetX(run, localOff, measurer);
           }
           break;
         }
@@ -618,11 +611,10 @@ function computeHFTableCellSelectionRects(
         const lineSelEnd = Math.min(lineChars, selEnd - lineStart);
         let x0 = 0, x1 = 0, chars = 0;
         for (const run of line.runs) {
-          const font = resolveInlineFont(run.inline.style);
           const runOffsetX = (n: number): number =>
             run.x + (run.imageHeight !== undefined
               ? (n > 0 ? run.width : 0)
-              : measurer.measureWidth(run.text.slice(0, n), font));
+              : caretOffsetX(run, n, measurer));
           if (chars <= lineSelStart && lineSelStart <= chars + run.text.length) {
             x0 = runOffsetX(lineSelStart - chars);
           }
@@ -734,10 +726,7 @@ function hfFlatLayoutRects(
             if (run.imageHeight !== undefined) {
               x0 = run.x + (localOff > 0 ? run.width : 0);
             } else {
-              x0 = run.x + measurer.measureWidth(
-                run.text.slice(0, localOff),
-                resolveInlineFont(run.inline.style),
-              );
+              x0 = run.x + caretOffsetX(run, localOff, measurer);
             }
           }
           if (chars + runLen >= lineSelEnd) {
@@ -745,10 +734,7 @@ function hfFlatLayoutRects(
             if (run.imageHeight !== undefined) {
               x1 = run.x + (localOff > 0 ? run.width : 0);
             } else {
-              x1 = run.x + measurer.measureWidth(
-                run.text.slice(0, localOff),
-                resolveInlineFont(run.inline.style),
-              );
+              x1 = run.x + caretOffsetX(run, localOff, measurer);
             }
             break;
           }

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -34,13 +34,27 @@ function fontKey(font: ResolvedFont): string {
  * per-measurer Map so we can drain them all at once.
  */
 const perMeasurerCache = new WeakMap<TextMeasurer, Map<string, number>>();
-const knownCaches = new Set<Map<string, number>>();
+const perMeasurerOffsetCache = new WeakMap<TextMeasurer, Map<string, number[]>>();
+// Tracks every per-measurer Map we've handed out so `clearMeasureCache` can
+// drain them all (a WeakMap is not iterable). Both the width cache and the
+// char-offset cache register here.
+const knownCaches = new Set<{ clear(): void }>();
 
 function cacheFor(measurer: TextMeasurer): Map<string, number> {
   let cache = perMeasurerCache.get(measurer);
   if (!cache) {
     cache = new Map<string, number>();
     perMeasurerCache.set(measurer, cache);
+    knownCaches.add(cache);
+  }
+  return cache;
+}
+
+function offsetCacheFor(measurer: TextMeasurer): Map<string, number[]> {
+  let cache = perMeasurerOffsetCache.get(measurer);
+  if (!cache) {
+    cache = new Map<string, number[]>();
+    perMeasurerOffsetCache.set(measurer, cache);
     knownCaches.add(cache);
   }
   return cache;
@@ -399,6 +413,16 @@ export function computeLayout(
 /**
  * Compute cumulative character pixel offsets for a run.
  * charOffsets[i] = width of text.slice(0, i + 1).
+ *
+ * Measured as growing prefixes (not a sum of per-char widths) so kerning and
+ * ligatures stay correct. The whole array is memoised per (measurer, font,
+ * text): re-laying-out unchanged content — every structural edit, remote
+ * change, undo/redo, and resize triggers a full recompute — then costs no
+ * canvas measurements. The offsets depend only on font + text, not on layout
+ * width, so the cache survives width changes too.
+ *
+ * The returned array is shared with the cache; callers store it in
+ * `LayoutRun.charOffsets` and must treat it as read-only.
  */
 export function computeCharOffsets(
   measurer: TextMeasurer,
@@ -406,9 +430,15 @@ export function computeCharOffsets(
   font: ResolvedFont,
 ): number[] {
   if (text.length === 0) return [];
-  const offsets = new Array<number>(text.length);
-  for (let i = 0; i < text.length; i++) {
-    offsets[i] = measurer.measureWidth(text.slice(0, i + 1), font);
+  const cache = offsetCacheFor(measurer);
+  const key = `${fontKey(font)}\t${text}`;
+  let offsets = cache.get(key);
+  if (offsets === undefined) {
+    offsets = new Array<number>(text.length);
+    for (let i = 0; i < text.length; i++) {
+      offsets[i] = measurer.measureWidth(text.slice(0, i + 1), font);
+    }
+    cache.set(key, offsets);
   }
   return offsets;
 }

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -84,6 +84,25 @@ export function clearMeasureCache(): void {
 }
 
 /**
+ * Release a measurer's caches entirely. `clearMeasureCache` only empties the
+ * maps; the `knownCaches` set still strongly references them, so without this
+ * a per-editor measurer's cache maps would live for the module's lifetime —
+ * one leaked pair per disposed editor. Call from a host's dispose path.
+ */
+export function disposeMeasureCache(measurer: TextMeasurer): void {
+  const width = perMeasurerCache.get(measurer);
+  if (width) {
+    knownCaches.delete(width);
+    perMeasurerCache.delete(measurer);
+  }
+  const offsets = perMeasurerOffsetCache.get(measurer);
+  if (offsets) {
+    knownCaches.delete(offsets);
+    perMeasurerOffsetCache.delete(measurer);
+  }
+}
+
+/**
  * Convert an `InlineStyle` into the `ResolvedFont` measurement structure
  * used by `TextMeasurer`. Centralised here so layout, table-layout, and
  * hit-testing share the same conversion rules — getting these

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -444,6 +444,34 @@ export function computeCharOffsets(
 }
 
 /**
+ * Pixel x of a caret `localOffset` characters into a run, from the run's left
+ * edge. Reuses the run's precomputed cumulative `charOffsets`
+ * (charOffsets[i] = width of the first i+1 chars) instead of re-measuring
+ * `run.text.slice(0, localOffset)` — the same value with no canvas call, so
+ * caret and selection painting stays measurement-free every frame.
+ *
+ * `measurer` is only consulted on the fallback path — a run that somehow
+ * lacks a matching offset entry — so callers keep exactly the correctness
+ * they had before this optimization. Image runs are resolved by callers
+ * (they map the offset to the display width); pass only text runs here.
+ */
+export function caretOffsetX(
+  run: LayoutRun,
+  localOffset: number,
+  measurer: TextMeasurer,
+): number {
+  if (localOffset <= 0) return 0;
+  const offsets = run.charOffsets;
+  if (offsets.length >= localOffset) {
+    return offsets[localOffset - 1];
+  }
+  return measurer.measureWidth(
+    run.text.slice(0, localOffset),
+    resolveInlineFont(run.inline.style),
+  );
+}
+
+/**
  * Layout a single block into wrapped lines.
  */
 export function layoutBlock(

--- a/packages/docs/src/view/peer-cursor.ts
+++ b/packages/docs/src/view/peer-cursor.ts
@@ -3,7 +3,7 @@ import { LIST_INDENT_PX } from '../model/types.js';
 import type { PageLine, PaginatedLayout } from './pagination.js';
 import { findPageForPosition, getPageYOffset, getPageXOffset } from './pagination.js';
 import type { DocumentLayout } from './layout.js';
-import { resolveInlineFont } from './layout.js';
+import { caretOffsetX } from './layout.js';
 import type { TextMeasurer } from './measurer.js';
 import { computeMergedCellLineLayouts } from './table-renderer.js';
 
@@ -212,10 +212,7 @@ export function resolvePositionPixel(
                 if (run.imageHeight !== undefined) {
                   cursorX = run.x + (localOff > 0 ? run.width : 0);
                 } else {
-                  const textBefore = run.text.slice(0, localOff);
-                  cursorX = run.x + measurer.measureWidth(
-                    textBefore, resolveInlineFont(run.inline.style),
-                  );
+                  cursorX = run.x + caretOffsetX(run, localOff, measurer);
                 }
                 break;
               }
@@ -365,10 +362,7 @@ export function resolvePositionPixel(
         // Image run: use display width, not measureText of the placeholder char
         xOffset = localOffset > 0 ? run.width : 0;
       } else {
-        const textBefore = run.text.slice(0, localOffset);
-        xOffset = measurer.measureWidth(
-          textBefore, resolveInlineFont(run.inline.style),
-        );
+        xOffset = caretOffsetX(run, localOffset, measurer);
       }
       const x = pageX + pageLine.x + run.x + xOffset;
       return { x, y: pageY + pageLine.y, height: pageLine.line.height };

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -1,7 +1,7 @@
 import type { DocPosition, DocRange, TableCellRange, TableData, CellAddress } from '../model/types.js';
 import { getBlockTextLength } from '../model/types.js';
 import type { DocumentLayout, LayoutLine } from './layout.js';
-import { resolveInlineFont } from './layout.js';
+import { caretOffsetX } from './layout.js';
 import type { PaginatedLayout } from './pagination.js';
 import { findPageForPosition, findPageLine, getPageYOffset, getPageXOffset } from './pagination.js';
 import { resolvePositionPixel } from './peer-cursor.js';
@@ -213,10 +213,7 @@ function positionToPagePixel(
       if (run.imageHeight !== undefined) {
         xOffset = localOff > 0 ? run.width : 0;
       } else {
-        xOffset = measurer.measureWidth(
-          run.text.slice(0, localOff),
-          resolveInlineFont(run.inline.style),
-        );
+        xOffset = caretOffsetX(run, localOff, measurer);
       }
       const x = pageX + pageLine.x + run.x + xOffset;
       return { x, y: pageY + pageLine.y, height: pageLine.line.height };

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -124,6 +124,18 @@ export class TextEditor {
    * `editor.ts`.
    */
   requestRenderNoCursorScroll?: () => void;
+  /**
+   * Render variant for pure caret navigation (arrow keys, Home/End) that
+   * moves the cursor/selection without changing any document content. The
+   * cached layout is still valid, so this can repaint instead of
+   * re-measuring the whole document — the difference between O(1) and
+   * O(document) per keypress on a large body.
+   *
+   * Falls back to `requestRender` when a host does not wire it (e.g. slides
+   * text boxes), which is always correct, just not optimized. Only wire it
+   * from callsites that are guaranteed not to mutate the document.
+   */
+  requestCursorRender?: () => void;
   private saveSnapshot: () => void;
   private undoAction: () => void;
   private redoAction: () => void;
@@ -2226,6 +2238,16 @@ export class TextEditor {
     this.markDirty(blockId);
   }
 
+  /**
+   * Repaint after a caret-only move (no document mutation). Prefers the
+   * host's paint-only `requestCursorRender` (reuses cached layout) and falls
+   * back to a full `requestRender` when unwired. Only call from paths that
+   * are guaranteed not to change document content.
+   */
+  private requestCaretRender(): void {
+    (this.requestCursorRender ?? this.requestRender)();
+  }
+
   private handleArrow(
     direction: 'left' | 'right' | 'up' | 'down',
     shiftKey: boolean,
@@ -2586,7 +2608,9 @@ export class TextEditor {
       this.cursor.moveTo(newPos, isVertical ? this.cursor.lineAffinity : hAffinity);
     }
 
-    this.requestRender();
+    // Non-table caret move: no document content changed, so reuse the cached
+    // layout instead of re-measuring the whole body.
+    this.requestCaretRender();
   }
 
   private handleHome(shiftKey: boolean): void {
@@ -2599,7 +2623,7 @@ export class TextEditor {
       this.selection.setRange(null);
     }
     this.cursor.moveTo(newPos, 'forward');
-    this.requestRender();
+    this.requestCaretRender();
   }
 
   private handleEnd(shiftKey: boolean): void {
@@ -2612,7 +2636,7 @@ export class TextEditor {
       this.selection.setRange(null);
     }
     this.cursor.moveTo(newPos);
-    this.requestRender();
+    this.requestCaretRender();
   }
 
   private handleDocStart(shiftKey: boolean): void {
@@ -2627,7 +2651,7 @@ export class TextEditor {
       this.selection.setRange(null);
     }
     this.cursor.moveTo(newPos);
-    this.requestRender();
+    this.requestCaretRender();
   }
 
   private handleDocEnd(shiftKey: boolean): void {
@@ -2643,7 +2667,7 @@ export class TextEditor {
       this.selection.setRange(null);
     }
     this.cursor.moveTo(newPos);
-    this.requestRender();
+    this.requestCaretRender();
   }
 
   private handleLineBackspace(): void {

--- a/packages/docs/test/view/caret-offset-x.test.ts
+++ b/packages/docs/test/view/caret-offset-x.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { caretOffsetX } from '../../src/view/layout.js';
+import type { LayoutRun } from '../../src/view/layout.js';
+import type { TextMeasurer } from '../../src/view/measurer.js';
+
+function run(text: string, charOffsets: number[]): LayoutRun {
+  return {
+    inline: { text, style: {} },
+    text,
+    x: 0,
+    width: charOffsets[charOffsets.length - 1] ?? 0,
+    inlineIndex: 0,
+    charStart: 0,
+    charEnd: text.length,
+    charOffsets,
+  };
+}
+
+describe('caretOffsetX', () => {
+  it('reads the precomputed charOffsets without measuring', () => {
+    let calls = 0;
+    const measurer: TextMeasurer = {
+      measureWidth() {
+        calls++;
+        return -1;
+      },
+    };
+    const r = run('abcd', [8, 16, 24, 32]);
+
+    expect(caretOffsetX(r, 0, measurer)).toBe(0); // before first char
+    expect(caretOffsetX(r, 1, measurer)).toBe(8);
+    expect(caretOffsetX(r, 3, measurer)).toBe(24);
+    expect(caretOffsetX(r, 4, measurer)).toBe(32); // caret at run end
+    expect(calls).toBe(0);
+  });
+
+  it('falls back to measuring when offsets are missing/short', () => {
+    let calls = 0;
+    const measurer: TextMeasurer = {
+      measureWidth(text: string) {
+        calls++;
+        return text.length * 5;
+      },
+    };
+    // charOffsets shorter than the requested offset (should not happen in
+    // normal layout, but the fallback preserves correctness if it does).
+    const r = run('abcd', [8]);
+    expect(caretOffsetX(r, 3, measurer)).toBe(15); // 'abc'.length * 5
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/docs/test/view/char-offsets-cache.test.ts
+++ b/packages/docs/test/view/char-offsets-cache.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  computeLayout,
+  computeCharOffsets,
+  clearMeasureCache,
+} from '../../src/view/layout.js';
+import { createEmptyBlock } from '../../src/model/types.js';
+import type { Block } from '../../src/model/types.js';
+import type { ResolvedFont, TextMeasurer } from '../../src/view/measurer.js';
+
+const font: ResolvedFont = {
+  family: 'sans-serif', size: 16, weight: 'normal', style: 'normal',
+};
+
+function makeBlock(text: string): Block {
+  const block = createEmptyBlock();
+  block.inlines = [{ text, style: {} }];
+  return block;
+}
+
+describe('char offset caching', () => {
+  let calls: number;
+  let measurer: TextMeasurer;
+
+  beforeEach(() => {
+    clearMeasureCache();
+    calls = 0;
+    measurer = {
+      measureWidth(text: string) {
+        calls++;
+        return text.length * 8;
+      },
+    };
+  });
+
+  it('computeCharOffsets caches its result per (font, text)', () => {
+    const first = computeCharOffsets(measurer, 'abcd', font);
+    expect(calls).toBeGreaterThan(0);
+    calls = 0;
+    const second = computeCharOffsets(measurer, 'abcd', font);
+    expect(calls).toBe(0);
+    expect(second).toEqual(first);
+  });
+
+  it('a full re-layout after a warm cache performs no measurement', () => {
+    // Both word widths (measureSegments) and per-character caret offsets
+    // (computeCharOffsets) must be cached, so re-laying-out unchanged content
+    // — as happens on every structural edit, remote change, undo/redo, and
+    // resize — costs zero canvas measurements.
+    const blocks = [
+      makeBlock('Hello world of measurement'),
+      makeBlock('A second paragraph with several words'),
+    ];
+    computeLayout(blocks, measurer, 500); // warm the caches
+    calls = 0;
+    // dirtyBlockIds undefined => full recompute of every block.
+    computeLayout(blocks, measurer, 500);
+    expect(calls).toBe(0);
+  });
+
+  it('re-measures when the text changes', () => {
+    computeCharOffsets(measurer, 'abcd', font);
+    calls = 0;
+    computeCharOffsets(measurer, 'abce', font);
+    expect(calls).toBeGreaterThan(0);
+  });
+});

--- a/packages/docs/test/view/cursor-move-no-relayout.test.ts
+++ b/packages/docs/test/view/cursor-move-no-relayout.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initialize, type EditorAPI } from '../../src/view/editor.js';
+import { MemDocStore } from '../../src/store/memory.js';
+import { createEmptyBlock } from '../../src/model/types.js';
+import type { Block } from '../../src/model/types.js';
+
+/**
+ * Perf guard for issue: cursor movement forces a full-document re-layout.
+ *
+ * Pure caret navigation (arrow keys, Home/End) changes no document content,
+ * so it must paint-only and reuse the cached layout. Before the fix, every
+ * arrow keypress routed through a full `render()` → `recomputeLayout()` with
+ * `dirtyBlockIds === undefined`, which re-measured every block in the
+ * document. We assert here that a caret move does not re-measure the whole
+ * body — the number of `measureText` calls during an ArrowRight must stay
+ * small and independent of block count.
+ *
+ * `CanvasTextMeasurer` measures via an `OffscreenCanvas` context, so the
+ * counter lives on the OffscreenCanvas stub (not the visible-canvas shim).
+ */
+
+let measureTextCalls = 0;
+
+function installCanvasShim(): void {
+  const measureText = (text: string) => {
+    measureTextCalls++;
+    return {
+      width: typeof text === 'string' ? text.length * 8 : 0,
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
+    };
+  };
+  const ctxHandler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'measureText') return measureText;
+      if (prop === 'canvas') return null;
+      if (prop === 'font') return '12px sans-serif';
+      return () => {};
+    },
+    set() {
+      return true;
+    },
+  };
+  const fakeCtx = new Proxy({}, ctxHandler) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as {
+    getContext: (kind: string) => unknown;
+  }).getContext = (kind: string) => (kind === '2d' ? fakeCtx : null);
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+  // The measurer prefers OffscreenCanvas; route its measureText through the
+  // same counter so layout measurement is what we observe.
+  (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+    constructor(public width: number, public height: number) {}
+    getContext(): unknown {
+      return { font: '12px sans-serif', measureText };
+    }
+  };
+}
+
+function makeBlock(text: string): Block {
+  const block = createEmptyBlock();
+  block.inlines = [{ text, style: {} }];
+  return block;
+}
+
+describe('docs editor — cursor movement does not re-layout the whole document', () => {
+  let container: HTMLElement;
+  let editor: EditorAPI;
+  let origGetContext: HTMLCanvasElement['getContext'];
+  let origRAF: typeof window.requestAnimationFrame;
+  let origResizeObserver: unknown;
+  let origOffscreenCanvas: unknown;
+
+  beforeEach(() => {
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    origRAF = window.requestAnimationFrame;
+    origResizeObserver = (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+    origOffscreenCanvas = (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas;
+    installCanvasShim();
+    window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      queueMicrotask(() => cb(performance.now()));
+      return 0;
+    };
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    const store = new MemDocStore();
+    // A multi-block body: a full re-layout would measure every block.
+    const blocks: Block[] = [];
+    for (let i = 0; i < 40; i++) {
+      blocks.push(makeBlock(`Paragraph number ${i} with several words to measure.`));
+    }
+    store.setDocument({ blocks });
+    editor = initialize(container, store);
+  });
+
+  afterEach(() => {
+    editor.dispose();
+    document.body.removeChild(container);
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+    window.requestAnimationFrame = origRAF;
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = origResizeObserver;
+    (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas = origOffscreenCanvas;
+  });
+
+  function textarea(): HTMLTextAreaElement {
+    const el = container.querySelector('textarea');
+    if (!el) throw new Error('textarea not mounted');
+    return el;
+  }
+
+  function pressArrow(key: string): void {
+    textarea().dispatchEvent(
+      new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }),
+    );
+  }
+
+  it('ArrowRight does not re-measure every block', () => {
+    // Cursor starts at block 0, offset 0 (set by initialize). Reset the
+    // counter after the initial full layout so we observe only the move.
+    measureTextCalls = 0;
+    pressArrow('ArrowRight');
+
+    // A paint-only caret move measures at most the caret's own run. A full
+    // re-layout of 40 multi-word blocks measures hundreds of times. 40 is a
+    // generous ceiling that the caret-only path clears and the full-relayout
+    // path blows past.
+    expect(measureTextCalls).toBeLessThan(40);
+  });
+
+  it('ArrowDown does not re-measure every block', () => {
+    measureTextCalls = 0;
+    pressArrow('ArrowDown');
+    expect(measureTextCalls).toBeLessThan(40);
+  });
+});

--- a/packages/docs/test/view/font-load-invalidation.test.ts
+++ b/packages/docs/test/view/font-load-invalidation.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initialize, type EditorAPI } from '../../src/view/editor.js';
+import { MemDocStore } from '../../src/store/memory.js';
+import { createEmptyBlock } from '../../src/model/types.js';
+import type { Block } from '../../src/model/types.js';
+
+/**
+ * The text-measurement cache (word widths + char offsets) is keyed by
+ * (font, text) with no load-state key, so the initial layout of a not-yet-
+ * loaded web font pins run positions and caret offsets against the fallback
+ * face's metrics. When the real face loads asynchronously, docs must clear
+ * the cache and re-layout — otherwise the layout and caret stay on fallback
+ * metrics and drift from the painted glyphs until a reload. Slides already
+ * wires this via a `document.fonts` `loadingdone` listener; this guards the
+ * matching docs wiring.
+ */
+
+let measureTextCalls = 0;
+
+function installCanvasShim(): void {
+  const measureText = (text: string) => {
+    measureTextCalls++;
+    return {
+      width: typeof text === 'string' ? text.length * 8 : 0,
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
+    };
+  };
+  const ctxHandler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'measureText') return measureText;
+      if (prop === 'canvas') return null;
+      if (prop === 'font') return '12px sans-serif';
+      return () => {};
+    },
+    set() {
+      return true;
+    },
+  };
+  const fakeCtx = new Proxy({}, ctxHandler) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as {
+    getContext: (kind: string) => unknown;
+  }).getContext = (kind: string) => (kind === '2d' ? fakeCtx : null);
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+  (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = class {
+    constructor(public width: number, public height: number) {}
+    getContext(): unknown {
+      return { font: '12px sans-serif', measureText };
+    }
+  };
+}
+
+function makeBlock(text: string): Block {
+  const block = createEmptyBlock();
+  block.inlines = [{ text, style: {} }];
+  return block;
+}
+
+describe('docs editor — clears the measure cache and re-layouts on font load', () => {
+  let container: HTMLElement;
+  let editor: EditorAPI;
+  let origGetContext: HTMLCanvasElement['getContext'];
+  let origRAF: typeof window.requestAnimationFrame;
+  let origResizeObserver: unknown;
+  let origOffscreenCanvas: unknown;
+  let origFonts: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    origRAF = window.requestAnimationFrame;
+    origResizeObserver = (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+    origOffscreenCanvas = (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas;
+    installCanvasShim();
+    window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      queueMicrotask(() => cb(performance.now()));
+      return 0;
+    };
+    // jsdom omits document.fonts; install a stub EventTarget so the editor's
+    // listener wiring runs the same addEventListener path as the browser.
+    origFonts = Object.getOwnPropertyDescriptor(document, 'fonts');
+    Object.defineProperty(document, 'fonts', {
+      value: new EventTarget(),
+      configurable: true,
+      writable: true,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    const store = new MemDocStore();
+    store.setDocument({
+      blocks: [
+        makeBlock('Paragraph one with several words to measure'),
+        makeBlock('Paragraph two also with several words here'),
+      ],
+    });
+    editor = initialize(container, store);
+  });
+
+  afterEach(() => {
+    editor.dispose();
+    document.body.removeChild(container);
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+    window.requestAnimationFrame = origRAF;
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = origResizeObserver;
+    (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas = origOffscreenCanvas;
+    if (origFonts) {
+      Object.defineProperty(document, 'fonts', origFonts);
+    } else {
+      // @ts-expect-error — removing a configurable stub we installed.
+      delete document.fonts;
+    }
+  });
+
+  it('re-measures the document when a web font finishes loading', () => {
+    // Caches are warm from the initial render. A no-op event would leave the
+    // stale fallback-metric layout in place (0 re-measures).
+    measureTextCalls = 0;
+    document.fonts.dispatchEvent(new Event('loadingdone'));
+    expect(measureTextCalls).toBeGreaterThan(0);
+  });
+
+  it('stops re-measuring after dispose (listener removed)', () => {
+    editor.dispose();
+    measureTextCalls = 0;
+    document.fonts.dispatchEvent(new Event('loadingdone'));
+    expect(measureTextCalls).toBe(0);
+    // Re-create so afterEach's dispose() has a live editor to tear down.
+    editor = initialize(container, new MemDocStore());
+  });
+});

--- a/packages/docs/test/view/font-load-invalidation.test.ts
+++ b/packages/docs/test/view/font-load-invalidation.test.ts
@@ -132,3 +132,92 @@ describe('docs editor — clears the measure cache and re-layouts on font load',
     editor = initialize(container, new MemDocStore());
   });
 });
+
+/**
+ * `loadingdone` is unreliable on WebKit/Safari, so the editor also settles via
+ * the Promise-based `document.fonts.ready` when fonts are still loading at
+ * mount. This suite installs a richer `FontFaceSet` stub with `status`/`ready`.
+ */
+class FakeFontFaceSet extends EventTarget {
+  status: 'loading' | 'loaded' = 'loading';
+  ready: Promise<void>;
+  private resolveReady!: () => void;
+  constructor() {
+    super();
+    this.ready = new Promise<void>((resolve) => {
+      this.resolveReady = resolve;
+    });
+  }
+  finish(): void {
+    this.status = 'loaded';
+    this.resolveReady();
+  }
+}
+
+describe('docs editor — fonts.ready fallback for browsers that miss loadingdone', () => {
+  let container: HTMLElement;
+  let editor: EditorAPI;
+  let origGetContext: HTMLCanvasElement['getContext'];
+  let origRAF: typeof window.requestAnimationFrame;
+  let origResizeObserver: unknown;
+  let origOffscreenCanvas: unknown;
+  let origFonts: PropertyDescriptor | undefined;
+  let fonts: FakeFontFaceSet;
+
+  beforeEach(() => {
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    origRAF = window.requestAnimationFrame;
+    origResizeObserver = (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+    origOffscreenCanvas = (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas;
+    installCanvasShim();
+    window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      queueMicrotask(() => cb(performance.now()));
+      return 0;
+    };
+    origFonts = Object.getOwnPropertyDescriptor(document, 'fonts');
+    fonts = new FakeFontFaceSet();
+    Object.defineProperty(document, 'fonts', {
+      value: fonts,
+      configurable: true,
+      writable: true,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    const store = new MemDocStore();
+    store.setDocument({ blocks: [makeBlock('Paragraph with several words here')] });
+    editor = initialize(container, store);
+  });
+
+  afterEach(() => {
+    editor.dispose();
+    document.body.removeChild(container);
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+    window.requestAnimationFrame = origRAF;
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = origResizeObserver;
+    (globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas = origOffscreenCanvas;
+    if (origFonts) {
+      Object.defineProperty(document, 'fonts', origFonts);
+    } else {
+      // @ts-expect-error — removing a configurable stub we installed.
+      delete document.fonts;
+    }
+  });
+
+  it('re-measures when fonts.ready settles (no loadingdone dispatched)', async () => {
+    measureTextCalls = 0;
+    fonts.finish();
+    await fonts.ready;
+    await Promise.resolve();
+    expect(measureTextCalls).toBeGreaterThan(0);
+  });
+
+  it('does not fire the ready fallback after dispose', async () => {
+    editor.dispose();
+    measureTextCalls = 0;
+    fonts.finish();
+    await fonts.ready;
+    await Promise.resolve();
+    expect(measureTextCalls).toBe(0);
+    editor = initialize(container, new MemDocStore());
+  });
+});

--- a/packages/docs/test/view/measure-cache.test.ts
+++ b/packages/docs/test/view/measure-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { cachedMeasureText, clearMeasureCache } from '../../src/view/layout.js';
+import { cachedMeasureText, clearMeasureCache, disposeMeasureCache } from '../../src/view/layout.js';
 import type { ResolvedFont, TextMeasurer } from '../../src/view/measurer.js';
 
 const baseFont: ResolvedFont = {
@@ -80,6 +80,20 @@ describe('cachedMeasureText', () => {
     expect(cachedMeasureText(measurerB, 'hello', baseFont)).toBe(60);
     expect(aCalls).toBe(1);
     expect(bCalls).toBe(1);
+  });
+
+  it('disposeMeasureCache drops a measurer scope so it stops retaining maps', () => {
+    // Warm the cache, then dispose it: the next read must miss (re-measure),
+    // proving the measurer's map was released from the drain registry rather
+    // than merely emptied.
+    cachedMeasureText(measurer, 'hello', baseFont);
+    cachedMeasureText(measurer, 'hello', baseFont);
+    expect(callCount).toBe(1);
+
+    disposeMeasureCache(measurer);
+
+    cachedMeasureText(measurer, 'hello', baseFont);
+    expect(callCount).toBe(2);
   });
 
   it('clearMeasureCache clears every measurer scope', () => {


### PR DESCRIPTION
## Summary

As the docs body grows, cursor movement and scrolling got progressively slower; profiling a large document showed `measureText`/`measureWidth` dominating (~57%). The cost was **text measurement at layout time**, which viewport/partial rendering can't help — paint is already viewport-culled, but layout measures all blocks regardless of what's visible. Root causes and fixes:

1. **Caret moves forced a full re-layout.** Arrow keys / Home / End routed through `render() → recomputeLayout()` with `dirtyBlockIds` undefined, disabling the incremental cache and re-measuring every block. Now pure caret navigation repaints from the cached layout via a paint-only `renderCursorMove` (`requestCursorRender`). Table navigation stays on the full render because its table-exit branch can call `ensureBlockAfter` (a mutation). → *ArrowRight on a 40-block doc: 1991 → <40 `measureText` calls.*

2. **Full re-layouts re-measured char offsets uncached.** Word widths were already cached, but `computeCharOffsets` measured every character prefix on every full re-layout (still fired by Enter/paste, remote edits, undo/redo, resize). Now memoised per `(measurer, font, text)`. → *Full recompute of a warm layout: 63 → 0 `measureText` calls.*

3. **Caret/selection resolvers re-measured per frame.** They re-measured `run.text.slice(0, n)` each paint instead of reading the precomputed `LayoutRun.charOffsets`. Now read via a shared `caretOffsetX()` helper (measurer kept only as a defensive fallback, so no API churn).

4. **Font-load staleness (from code review).** The caches key by `(font, text)` with no load-state key, so layout/caret stayed on fallback-font metrics after an async web-font load — a pre-existing docs gap that caching char offsets made reach the caret. `initialize()` now subscribes to `document.fonts` `loadingdone` → `clearMeasureCache()` + `invalidateLayout()` + `render()` (mirrors slides), removed on `dispose()`.

Net: the `measureText` hotspot now only fires on the first layout of content that actually changed.

### Known limitation
The char-offset cache shares the exact lifecycle of the pre-existing word-width cache, whose unbounded growth `docs-rendering-optimization.md` explicitly deferred (LRU "if needed"); the new font-load handler drains both. Adding LRU to one but not its twin would be inconsistent — deferred to a joint follow-up if profiling shows pressure.

## Test plan

- New tests:
  - `cursor-move-no-relayout.test.ts` — ArrowRight/Down don't re-measure the body.
  - `char-offsets-cache.test.ts` — warm full re-layout does zero measurement.
  - `caret-offset-x.test.ts` — helper reads `charOffsets`, falls back correctly.
  - `font-load-invalidation.test.ts` — `loadingdone` re-measures; listener removed on dispose.
- `pnpm --filter @wafflebase/docs test` — 1071 pass, typecheck clean.
- `pnpm verify:fast` — green (pre-commit hook on every commit).
- Manual smoke in `pnpm dev`: cursor movement, shift-selection, and cross-page scrolling on a long document confirmed by the author.
- Design doc updated: `docs/design/docs/docs-rendering-optimization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EPywatWADMR2iYrwauVNL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cursor movement performance by reducing unnecessary full-document re-layouts.
  * Added better handling for web font loading so text positions update correctly when fonts finish loading.

* **Bug Fixes**
  * Fixed caret and selection placement in headers, footers, and table cells by reusing cached text offsets.
  * Reduced repeated text measurement during editing, which can improve responsiveness on larger documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->