### PR TITLE
Cull off-screen docs decorations and index layout lookups

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,9 +18,14 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| docs cursor move relayout (2026-07-05) | [20260705-docs-cursor-move-relayout-todo.md](./active/20260705-docs-cursor-move-relayout-todo.md) | - |
+| docs decoration culling (2026-07-05) | [20260705-docs-decoration-culling-todo.md](./active/20260705-docs-decoration-culling-todo.md) | [20260705-docs-decoration-culling-lessons.md](./active/20260705-docs-decoration-culling-lessons.md) |
+| docx vml image import (2026-07-05) | [20260705-docx-vml-image-import-todo.md](./active/20260705-docx-vml-image-import-todo.md) | [20260705-docx-vml-image-import-lessons.md](./active/20260705-docx-vml-image-import-lessons.md) |
 | empty workspace slug (2026-07-04) | [20260704-empty-workspace-slug-todo.md](./active/20260704-empty-workspace-slug-todo.md) | [20260704-empty-workspace-slug-lessons.md](./active/20260704-empty-workspace-slug-lessons.md) |
 | pptx br empty line font size (2026-07-04) | [20260704-pptx-br-empty-line-font-size-todo.md](./active/20260704-pptx-br-empty-line-font-size-todo.md) | - |
 | slides freeform arrowheads (2026-07-04) | [20260704-slides-freeform-arrowheads-todo.md](./active/20260704-slides-freeform-arrowheads-todo.md) | - |
+| slides per deck size (2026-07-04) | [20260704-slides-per-deck-size-todo.md](./active/20260704-slides-per-deck-size-todo.md) | - |
+| slides rotated resize cursor (2026-07-04) | [20260704-slides-rotated-resize-cursor-todo.md](./active/20260704-slides-rotated-resize-cursor-todo.md) | - |
 | ungroup scale invariant (2026-07-04) | [20260704-ungroup-scale-invariant-todo.md](./active/20260704-ungroup-scale-invariant-todo.md) | [20260704-ungroup-scale-invariant-lessons.md](./active/20260704-ungroup-scale-invariant-lessons.md) |
 | pptx text body insets (2026-07-03) | [20260703-pptx-text-body-insets-todo.md](./active/20260703-pptx-text-body-insets-todo.md) | [20260703-pptx-text-body-insets-lessons.md](./active/20260703-pptx-text-body-insets-lessons.md) |
 | slides canvas black on resize (2026-07-02) | [20260702-slides-canvas-black-on-resize-todo.md](./active/20260702-slides-canvas-black-on-resize-todo.md) | [20260702-slides-canvas-black-on-resize-lessons.md](./active/20260702-slides-canvas-black-on-resize-lessons.md) |
@@ -38,4 +43,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 330
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: empty workspace slug (2026-07-04)
+Latest active task: docs cursor move relayout (2026-07-05)

--- a/docs/tasks/active/20260705-docs-decoration-culling-lessons.md
+++ b/docs/tasks/active/20260705-docs-decoration-culling-lessons.md
@@ -1,0 +1,46 @@
+# Lessons — docs decoration culling
+
+## What made the fix land cleanly
+
+- **Read the profile as a call graph, not a leaderboard.** The top self-time
+  entry (`findPageForPosition`) and the anonymous `pagination.ts:288` frame were
+  the *same* linear scan (`findIndex` callback). Grouping the hot frames by what
+  they actually do — resolve a block position — pointed straight at the two
+  scans to kill, instead of micro-optimizing one function.
+
+- **Verify object identity before memoizing.** WeakMap-on-the-layout only works
+  because `computeLayout` (layout.ts:427) and `paginateLayout` (pagination.ts)
+  return **fresh** objects each recompute. Confirmed that first; it's what makes
+  the cache auto-invalidate on real edits yet stay warm across paint-only
+  cursor/scroll renders. A stale-key WeakMap would have been a silent
+  correctness bug.
+
+## Traps avoided
+
+- **The decoration loops are in `paint()`, not `render()`.** `render()` =
+  `recomputeLayout(); paint()`. Scroll calls `renderPaintOnly() → paint()`,
+  which re-reads `scrollY`. If culling had lived in `render()`, scrolling would
+  have painted stale (culled) decorations. Locating the exact function that owns
+  the loop — and confirming it reruns on scroll — was the difference between a
+  correct cull and a scroll regression.
+
+- **Don't filter an array another index points into.** `activeMatchIndex`
+  indexes `searchHighlightRects` 1:1 with `searchMatches`. Culling had to map
+  off-screen matches to `[]`, not `.filter()` them out.
+
+## Review catch (unit mismatch)
+
+- The first cull band used `canvasHeight` (scaled screen px) against `scrollY` /
+  `blockYExtent` (logical doc px). On desktop `scaleFactor === 1` so it looked
+  fine; on mobile zoom-to-fit (`scaleFactor < 1`) the band was too short and
+  dropped bottom-of-screen decorations. **Lesson: whenever a threshold mixes a
+  viewport measurement with a document-space value, restate both in the same
+  space explicitly (`canvasHeight / scaleFactor`).** A same-coordinate-system
+  assertion is easy to eyeball; a mixed one hides behind `scaleFactor === 1`.
+
+## Follow-up ideas (not in this PR)
+
+- `cloneDocument` (`yorkie-doc-store.ts:472`) is `JSON.parse(JSON.stringify(doc))`
+  on every change for undo snapshots — O(document) per keystroke, ~4% of the
+  trace. Structural sharing / incremental snapshots would remove it. Deferred:
+  touches undo/redo correctness and wants its own test pass.

--- a/docs/tasks/active/20260705-docs-decoration-culling-todo.md
+++ b/docs/tasks/active/20260705-docs-decoration-culling-todo.md
@@ -1,0 +1,59 @@
+# Docs: stop typing from re-scanning the whole document for decorations
+
+## Problem
+
+Profiling "Hello World" typing on page 1 of a long document shows ~25% of the
+trace in `computeSelectionRects` (478 ms) plus ~187 ms in `findPageForPosition`
+and its `findIndex` callback. Commit #444 made caret *movement* paint-only, but
+*typing* mutates the document and still runs a full `render()`.
+
+Inside `render()` (`editor.ts:1503–1573`) the decoration loops compute rects for
+**every** peer selection, search match, comment marker and spell error in the
+whole document, with no viewport culling. Each `computeSelectionRects` call then:
+
+1. runs `layout.blocks.findIndex(...)` — O(blocks) linear scan
+   (`selection.ts:435/438`, `pagination.ts:287`), and
+2. `findPageForPosition` scans every page × every line — O(pages·lines)
+   (`pagination.ts:325`).
+
+Cost is `N_decorations × (O(blocks) + O(pages·lines))` — grows with document
+length even when typing on page 1. Spell errors (hundreds in a long doc) dominate.
+
+## Approach
+
+- **B — block-id → index map**: memoized `getBlockIndex(layout, id)` keyed on the
+  layout object (fresh per recompute → auto-invalidates). Removes the findIndex scans.
+- **C — paginated line index**: memoized `getBlockPageLines(paginatedLayout)` →
+  `blockIndex → PageLine[]`. `findPageForPosition` iterates only that block's lines.
+- **A — viewport culling**: memoized `getBlockYExtent(paginatedLayout)` → per-block
+  absolute Y bounds. In `render()`, skip decorations whose block range doesn't
+  intersect the visible window (± one screenful margin).
+
+All memoization uses `WeakMap` keyed on the layout/paginatedLayout objects, which
+`computeLayout`/`paginateLayout` return fresh on every recompute and reuse across
+paint-only cursor renders. No public signatures change.
+
+## Tasks
+
+- [x] Test: index helpers (`getBlockIndex`, `getBlockPageLines`, `getBlockYExtent`) correctness on a multi-block, multi-page fixture
+- [x] Test: `findPageForPosition` returns identical results after refactor (characterization)
+- [x] Test: `getBlockYExtent`-based visibility predicate keeps visible / drops offscreen blocks
+- [x] Impl B+C: add memoized indexes to `pagination.ts`; rewrite `findPageForPosition`
+- [x] Impl B: `selection.ts buildRects` uses `getBlockIndex`
+- [x] Impl A: cull decoration loops in `editor.ts` `paint()` (preserve search-match array indices; runs on scroll via `renderPaintOnly`)
+- [x] `pnpm verify:fast` green
+- [ ] Self code-review over branch diff (running)
+- [ ] Manual smoke: `pnpm dev`, type in a long doc with spell errors + comments; caret/selection/peer/search/comment/spell all correct on and across page boundaries
+- [ ] Capture lessons; archive; PR
+
+## Key finding during impl
+
+The decoration loops live in `paint()` (editor.ts:1331), **not** the layout-
+recomputing `render()`. `paint()` re-reads `scrollY` and reruns on every scroll
+via `handleScroll → renderPaintOnly → paint`. So culling by the current viewport
+is correct for scrolling: blocks scrolled into view get their decorations
+computed on the scroll repaint, not left stale from the last full render.
+
+## Review
+
+(filled at completion)

--- a/docs/tasks/active/20260705-docs-decoration-culling-todo.md
+++ b/docs/tasks/active/20260705-docs-decoration-culling-todo.md
@@ -43,7 +43,7 @@ paint-only cursor renders. No public signatures change.
 - [x] Impl A: cull decoration loops in `editor.ts` `paint()` (preserve search-match array indices; runs on scroll via `renderPaintOnly`)
 - [x] `pnpm verify:fast` green
 - [x] Self code-review over branch diff (high effort; 2 findings, both fixed)
-- [ ] Manual smoke: `pnpm dev`, type in a long doc with spell errors + comments; caret/selection/peer/search/comment/spell all correct on and across page boundaries (incl. mobile zoom-to-fit)
+- [x] Manual smoke: `pnpm dev`, type in a long doc with spell errors + comments; caret/selection/peer/search/comment/spell all correct on and across page boundaries (incl. mobile zoom-to-fit) — confirmed by author
 - [x] Capture lessons; PR opened (#445) — archive after merge
 
 ## Key finding during impl
@@ -76,5 +76,6 @@ Shipped in PR #445 (branch `perf/docs-decoration-culling`).
   green; typecheck clean. No public signatures changed.
 
 **Outstanding**
-- Manual `pnpm dev` smoke (UI change) — pending.
+- Manual `pnpm dev` smoke — done (author-confirmed). Awaiting CI green + review
+  approval on #445, then archive.
 - Deferred: `cloneDocument` full-doc JSON clone per keystroke (see lessons).

--- a/docs/tasks/active/20260705-docs-decoration-culling-todo.md
+++ b/docs/tasks/active/20260705-docs-decoration-culling-todo.md
@@ -42,9 +42,9 @@ paint-only cursor renders. No public signatures change.
 - [x] Impl B: `selection.ts buildRects` uses `getBlockIndex`
 - [x] Impl A: cull decoration loops in `editor.ts` `paint()` (preserve search-match array indices; runs on scroll via `renderPaintOnly`)
 - [x] `pnpm verify:fast` green
-- [ ] Self code-review over branch diff (running)
-- [ ] Manual smoke: `pnpm dev`, type in a long doc with spell errors + comments; caret/selection/peer/search/comment/spell all correct on and across page boundaries
-- [ ] Capture lessons; archive; PR
+- [x] Self code-review over branch diff (high effort; 2 findings, both fixed)
+- [ ] Manual smoke: `pnpm dev`, type in a long doc with spell errors + comments; caret/selection/peer/search/comment/spell all correct on and across page boundaries (incl. mobile zoom-to-fit)
+- [x] Capture lessons; PR opened (#445) — archive after merge
 
 ## Key finding during impl
 
@@ -56,4 +56,25 @@ computed on the scroll repaint, not left stale from the last full render.
 
 ## Review
 
-(filled at completion)
+Shipped in PR #445 (branch `perf/docs-decoration-culling`).
+
+**Changes**
+- `pagination.ts`: `getBlockIndex` / `getBlockPageLines` / `getBlockYExtent`
+  (WeakMap-memoized per layout object); `findPageForPosition` rewritten off the
+  `findIndex` + full page/line scan. `getBlockYExtent` reuses `getBlockPageLines`
+  (no second pages×lines pass — review finding #2).
+- `selection.ts`: `buildRects` uses `getBlockIndex`.
+- `editor.ts`: `paint()` culls peer/search/comment/spell decoration loops to the
+  visible band, sized in logical coords (`canvasHeight / scaleFactor`) so mobile
+  zoom-to-fit is correct (review finding #1). Search matches map to `[]` to keep
+  `activeMatchIndex` valid.
+
+**Result**
+- Decoration cost `O(N_decorations × doc_size)` → `O(N_visible × small)`; 1-page
+  typing latency decoupled from document length.
+- New tests: `test/view/decoration-index.test.ts` (9 cases). `pnpm verify:fast`
+  green; typecheck clean. No public signatures changed.
+
+**Outstanding**
+- Manual `pnpm dev` smoke (UI change) — pending.
+- Deferred: `cloneDocument` full-doc JSON clone per keystroke (see lessons).

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -10,7 +10,7 @@ import { Cursor } from './cursor.js';
 import { Selection, computeSelectionRects } from './selection.js';
 import { TextEditor } from './text-editor.js';
 import { computeLayout, caretOffsetX, clearMeasureCache, disposeMeasureCache, type ComposingContext, type DocumentLayout, type LayoutCache, type LayoutRun } from './layout.js';
-import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getPageYOffset, getHeaderYStart, getFooterYStart, paginatedPixelToPosition, type PaginatedLayout } from './pagination.js';
+import { paginateLayout, getTotalHeight, findPageForPosition, getPageXOffset, getPageYOffset, getHeaderYStart, getFooterYStart, paginatedPixelToPosition, getBlockIndex, getBlockYExtent, type PaginatedLayout } from './pagination.js';
 import { CanvasTextMeasurer } from './canvas-measurer.js';
 import type { TextMeasurer } from './measurer.js';
 import type { DocPosition, DocRange, HeaderFooter } from '../model/types.js';
@@ -1425,6 +1425,31 @@ export function initialize(
 
     const scrollY = container.scrollTop / scaleFactor;
 
+    // Viewport culling for decorations. Peer selections, search matches,
+    // comment markers and spell errors are laid out for the whole document,
+    // but only those intersecting the visible band can be painted or hit-
+    // tested. Skip the rest so typing in a long document does not recompute
+    // rects for hundreds of off-screen decorations every keystroke. Keep one
+    // screenful of margin above/below to avoid edge popping during scroll.
+    // `scrollY` and `blockYExtent` are in logical (unscaled) document
+    // coordinates, so the band must be too: on mobile zoom-to-fit
+    // (scaleFactor < 1) the visible region spans canvasHeight/scaleFactor
+    // logical pixels, not canvasHeight.
+    const viewportLogicalHeight = canvasHeight / scaleFactor;
+    const cullTop = scrollY - viewportLogicalHeight;
+    const cullBottom = scrollY + viewportLogicalHeight * 2;
+    const blockYExtent = getBlockYExtent(paginatedLayout);
+    const isRangeVisible = (startBlockId: string, endBlockId: string): boolean => {
+      const a = getBlockIndex(layout, startBlockId);
+      const b = getBlockIndex(layout, endBlockId);
+      if (a < 0 || b < 0) return true; // unknown block: keep (defensive)
+      const top = blockYExtent.get(Math.min(a, b));
+      const bottom = blockYExtent.get(Math.max(a, b));
+      if (!top || !bottom) return true;
+      return bottom.bottom >= cullTop && top.top <= cullBottom;
+    };
+    const isBlockVisible = (blockId: string): boolean => isRangeVisible(blockId, blockId);
+
     // Keep the hidden textarea at the cursor's screen position so the
     // browser doesn't scroll the container to bring it into view.
     if (cursorPixel) {
@@ -1507,6 +1532,9 @@ export function initialize(
     }> = [];
     for (const peer of peerCursors) {
       if (peer.selection) {
+        if (!isRangeVisible(peer.selection.anchor.blockId, peer.selection.focus.blockId)) {
+          continue;
+        }
         const rects = computeSelectionRects(
           peer.selection,
           paginatedLayout,
@@ -1523,17 +1551,21 @@ export function initialize(
     // Compute search highlight rectangles
     let searchHighlightRects: Array<{ x: number; y: number; width: number; height: number }>[] | undefined;
     if (searchMatches.length > 0) {
+      // Return [] for off-screen matches rather than filtering the array so
+      // `activeMatchIndex` keeps indexing into it.
       searchHighlightRects = searchMatches.map((match) =>
-        computeSelectionRects(
-          {
-            anchor: { blockId: match.blockId, offset: match.startOffset },
-            focus: { blockId: match.blockId, offset: match.endOffset },
-          },
-          paginatedLayout,
-          layout,
-          measurer,
-          logicalCanvasWidth,
-        ),
+        isBlockVisible(match.blockId)
+          ? computeSelectionRects(
+              {
+                anchor: { blockId: match.blockId, offset: match.startOffset },
+                focus: { blockId: match.blockId, offset: match.endOffset },
+              },
+              paginatedLayout,
+              layout,
+              measurer,
+              logicalCanvasWidth,
+            )
+          : [],
       );
     }
 
@@ -1541,6 +1573,7 @@ export function initialize(
     // getCommentMarkerAt can hit-test the rects the user actually sees.
     commentMarkerRects = [];
     for (const marker of commentMarkers) {
+      if (!isRangeVisible(marker.anchor.blockId, marker.focus.blockId)) continue;
       const rects = computeSelectionRects(
         { anchor: marker.anchor, focus: marker.focus },
         paginatedLayout,
@@ -1557,6 +1590,7 @@ export function initialize(
     let spellErrorRects: Array<{ x: number; y: number; width: number; height: number }> = [];
     if (spellSession) {
       for (const err of spellSession.errors) {
+        if (!isBlockVisible(err.blockId)) continue;
         const rects = computeSelectionRects(
           {
             anchor: { blockId: err.blockId, offset: err.start },

--- a/packages/docs/src/view/pagination.ts
+++ b/packages/docs/src/view/pagination.ts
@@ -274,6 +274,106 @@ export function getFooterYStart(
   return pageY + pageHeight - marginFromEdge - footerHeight;
 }
 
+// ---------------------------------------------------------------------------
+// Memoized layout indexes
+//
+// Typing runs a full render() that recomputes decoration rects for every peer
+// selection / search match / comment marker / spell error in the document.
+// Each rect lookup used to `findIndex` over all blocks (O(blocks)) and scan
+// every page × line (O(pages·lines)). These indexes turn those scans into map
+// lookups. They are keyed on the layout / paginatedLayout objects, which
+// `computeLayout` / `paginateLayout` return fresh on every recompute, so a new
+// object automatically invalidates the cache while paint-only cursor renders
+// (which reuse the same objects) hit the warm cache. See #444 follow-up.
+// ---------------------------------------------------------------------------
+
+const blockIndexCache = new WeakMap<DocumentLayout, Map<string, number>>();
+
+/** Block id → document-order block index. Memoized per layout object. */
+export function getBlockIndex(layout: DocumentLayout, blockId: string): number {
+  let map = blockIndexCache.get(layout);
+  if (!map) {
+    map = new Map();
+    for (let i = 0; i < layout.blocks.length; i++) {
+      map.set(layout.blocks[i].block.id, i);
+    }
+    blockIndexCache.set(layout, map);
+  }
+  return map.get(blockId) ?? -1;
+}
+
+export interface BlockPageLine {
+  pageIndex: number;
+  pageLine: PageLine;
+}
+
+const blockPageLinesCache = new WeakMap<
+  PaginatedLayout,
+  Map<number, BlockPageLine[]>
+>();
+
+/**
+ * Block index → its PageLine occurrences in page order. A block spans multiple
+ * entries when it wraps across lines or a table row splits across pages.
+ * Memoized per paginatedLayout object.
+ */
+export function getBlockPageLines(
+  paginatedLayout: PaginatedLayout,
+): Map<number, BlockPageLine[]> {
+  let map = blockPageLinesCache.get(paginatedLayout);
+  if (!map) {
+    map = new Map();
+    for (const page of paginatedLayout.pages) {
+      for (const pl of page.lines) {
+        let arr = map.get(pl.blockIndex);
+        if (!arr) {
+          arr = [];
+          map.set(pl.blockIndex, arr);
+        }
+        arr.push({ pageIndex: page.pageIndex, pageLine: pl });
+      }
+    }
+    blockPageLinesCache.set(paginatedLayout, map);
+  }
+  return map;
+}
+
+const blockYExtentCache = new WeakMap<
+  PaginatedLayout,
+  Map<number, { top: number; bottom: number }>
+>();
+
+/**
+ * Block index → absolute [top, bottom] canvas Y bounds. Used to viewport-cull
+ * decorations before computing their rects. Memoized per paginatedLayout.
+ */
+export function getBlockYExtent(
+  paginatedLayout: PaginatedLayout,
+): Map<number, { top: number; bottom: number }> {
+  let map = blockYExtentCache.get(paginatedLayout);
+  if (!map) {
+    map = new Map();
+    // Reuse the memoized block → page-line grouping rather than making a
+    // second independent pass over pages × lines.
+    for (const [blockIndex, occurrences] of getBlockPageLines(paginatedLayout)) {
+      for (const { pageIndex, pageLine } of occurrences) {
+        const pageY = getPageYOffset(paginatedLayout, pageIndex);
+        const top = pageY + pageLine.y;
+        const bottom = top + (pageLine.rowSplitHeight ?? pageLine.line.height);
+        const cur = map.get(blockIndex);
+        if (!cur) {
+          map.set(blockIndex, { top, bottom });
+        } else {
+          if (top < cur.top) cur.top = top;
+          if (bottom > cur.bottom) cur.bottom = bottom;
+        }
+      }
+    }
+    blockYExtentCache.set(paginatedLayout, map);
+  }
+  return map;
+}
+
 /**
  * Find which page a given blockId + offset falls on.
  */
@@ -284,9 +384,7 @@ export function findPageForPosition(
   layout: DocumentLayout,
   lineAffinity: 'forward' | 'backward' = 'backward',
 ): { pageIndex: number; pageLine: PageLine } | undefined {
-  const blockIndex = layout.blocks.findIndex(
-    (lb) => lb.block.id === blockId,
-  );
+  const blockIndex = getBlockIndex(layout, blockId);
   if (blockIndex === -1) return undefined;
 
   const lb = layout.blocks[blockIndex];
@@ -322,14 +420,15 @@ export function findPageForPosition(
   const isTableBlock = lb.block.type === 'table';
   let result: { pageIndex: number; pageLine: PageLine } | undefined;
 
-  for (const page of paginatedLayout.pages) {
-    for (const pl of page.lines) {
-      if (pl.blockIndex === blockIndex && pl.lineIndex === targetLineIndex) {
+  const occurrences = getBlockPageLines(paginatedLayout).get(blockIndex);
+  if (occurrences) {
+    for (const { pageIndex, pageLine } of occurrences) {
+      if (pageLine.lineIndex === targetLineIndex) {
         if (!isTableBlock) {
-          return { pageIndex: page.pageIndex, pageLine: pl };
+          return { pageIndex, pageLine };
         }
         // For table blocks, keep scanning to find the last fragment.
-        result = { pageIndex: page.pageIndex, pageLine: pl };
+        result = { pageIndex, pageLine };
       }
     }
   }

--- a/packages/docs/src/view/selection.ts
+++ b/packages/docs/src/view/selection.ts
@@ -3,7 +3,7 @@ import { getBlockTextLength } from '../model/types.js';
 import type { DocumentLayout, LayoutLine } from './layout.js';
 import { caretOffsetX } from './layout.js';
 import type { PaginatedLayout } from './pagination.js';
-import { findPageForPosition, findPageLine, getPageYOffset, getPageXOffset } from './pagination.js';
+import { findPageForPosition, findPageLine, getPageYOffset, getPageXOffset, getBlockIndex } from './pagination.js';
 import { resolvePositionPixel } from './peer-cursor.js';
 import { computeMergedCellLineLayouts } from './table-renderer.js';
 import { resolveNestedTableLayout } from './table-layout.js';
@@ -432,12 +432,8 @@ function buildRects(
 
   const rects: Array<{ x: number; y: number; width: number; height: number }> = [];
 
-  const startBlockIdx = layout.blocks.findIndex(
-    (lb) => lb.block.id === start.blockId,
-  );
-  const endBlockIdx = layout.blocks.findIndex(
-    (lb) => lb.block.id === end.blockId,
-  );
+  const startBlockIdx = getBlockIndex(layout, start.blockId);
+  const endBlockIdx = getBlockIndex(layout, end.blockId);
   if (startBlockIdx === -1 || endBlockIdx === -1) return [];
 
   for (let bi = startBlockIdx; bi <= endBlockIdx; bi++) {

--- a/packages/docs/test/view/decoration-index.test.ts
+++ b/packages/docs/test/view/decoration-index.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { computeLayout, clearMeasureCache } from '../../src/view/layout.js';
+import {
+  paginateLayout,
+  findPageForPosition,
+  getBlockIndex,
+  getBlockPageLines,
+  getBlockYExtent,
+  getPageYOffset,
+} from '../../src/view/pagination.js';
+import { DEFAULT_PAGE_SETUP, getEffectiveDimensions } from '../../src/model/types.js';
+import type { Block } from '../../src/model/types.js';
+import { createEmptyBlock } from '../../src/model/types.js';
+import { stubMeasurer } from './_stub-measurer.js';
+
+function makeBlock(text: string): Block {
+  const block = createEmptyBlock();
+  block.inlines = [{ text, style: {} }];
+  return block;
+}
+
+function buildDoc(nBlocks: number) {
+  const blocks = Array.from({ length: nBlocks }, (_, i) =>
+    makeBlock(`Block number ${i} content`),
+  );
+  const setup = DEFAULT_PAGE_SETUP;
+  const { width } = getEffectiveDimensions(setup);
+  const contentWidth = width - setup.margins.left - setup.margins.right;
+  const layout = computeLayout(blocks, stubMeasurer(), contentWidth).layout;
+  const paginated = paginateLayout(layout, setup);
+  return { blocks, layout, paginated };
+}
+
+describe('decoration index helpers', () => {
+  beforeEach(() => clearMeasureCache());
+
+  it('builds a multi-page fixture', () => {
+    const { paginated } = buildDoc(200);
+    expect(paginated.pages.length).toBeGreaterThan(1);
+  });
+
+  describe('getBlockIndex', () => {
+    it('maps every block id to its document-order index', () => {
+      const { blocks, layout } = buildDoc(50);
+      blocks.forEach((b, i) => {
+        expect(getBlockIndex(layout, b.id)).toBe(i);
+      });
+    });
+
+    it('returns -1 for unknown ids', () => {
+      const { layout } = buildDoc(10);
+      expect(getBlockIndex(layout, 'no-such-block')).toBe(-1);
+    });
+
+    it('memoizes per layout object (same Map instance reused)', () => {
+      const { layout } = buildDoc(10);
+      // Prime the cache, then a second lookup must hit the same structure —
+      // observable only via correctness, so assert repeated calls agree.
+      const first = getBlockIndex(layout, layout.blocks[3].block.id);
+      const second = getBlockIndex(layout, layout.blocks[3].block.id);
+      expect(first).toBe(3);
+      expect(second).toBe(3);
+    });
+  });
+
+  describe('getBlockPageLines', () => {
+    it('groups every page line under its block index in page order', () => {
+      const { layout, paginated } = buildDoc(200);
+      const map = getBlockPageLines(paginated);
+
+      // Reconstruct the same grouping by brute force and compare.
+      const expected = new Map<number, Array<{ pageIndex: number; lineIndex: number }>>();
+      for (const page of paginated.pages) {
+        for (const pl of page.lines) {
+          const arr = expected.get(pl.blockIndex) ?? [];
+          arr.push({ pageIndex: page.pageIndex, lineIndex: pl.lineIndex });
+          expected.set(pl.blockIndex, arr);
+        }
+      }
+
+      expect(map.size).toBe(expected.size);
+      for (const [blockIndex, entries] of expected) {
+        const got = map.get(blockIndex);
+        expect(got).toBeDefined();
+        expect(got!.map((e) => ({ pageIndex: e.pageIndex, lineIndex: e.pageLine.lineIndex }))).toEqual(
+          entries,
+        );
+      }
+      // Every block that has layout lines is represented.
+      expect(map.has(0)).toBe(true);
+      expect(map.has(layout.blocks.length - 1)).toBe(true);
+    });
+  });
+
+  describe('getBlockYExtent', () => {
+    it('returns absolute top/bottom Y bounds per block', () => {
+      const { paginated } = buildDoc(200);
+      const extent = getBlockYExtent(paginated);
+
+      for (const page of paginated.pages) {
+        const pageY = getPageYOffset(paginated, page.pageIndex);
+        for (const pl of page.lines) {
+          const top = pageY + pl.y;
+          const bottom = top + (pl.rowSplitHeight ?? pl.line.height);
+          const ext = extent.get(pl.blockIndex);
+          expect(ext).toBeDefined();
+          expect(ext!.top).toBeLessThanOrEqual(top);
+          expect(ext!.bottom).toBeGreaterThanOrEqual(bottom);
+        }
+      }
+    });
+
+    it('orders block extents monotonically down the document', () => {
+      const { layout, paginated } = buildDoc(200);
+      const extent = getBlockYExtent(paginated);
+      let prevTop = -Infinity;
+      for (let i = 0; i < layout.blocks.length; i++) {
+        const ext = extent.get(i);
+        if (!ext) continue;
+        expect(ext.top).toBeGreaterThanOrEqual(prevTop);
+        prevTop = ext.top;
+      }
+    });
+  });
+
+  describe('findPageForPosition (refactored, behavior preserved)', () => {
+    it('resolves each block start to the page whose extent contains it', () => {
+      const { layout, paginated } = buildDoc(200);
+      const extent = getBlockYExtent(paginated);
+      for (let i = 0; i < layout.blocks.length; i++) {
+        const blockId = layout.blocks[i].block.id;
+        const found = findPageForPosition(paginated, blockId, 0, layout);
+        expect(found).toBeDefined();
+        const pageY = getPageYOffset(paginated, found!.pageIndex);
+        const absY = pageY + found!.pageLine.y;
+        const ext = extent.get(i)!;
+        expect(absY).toBeGreaterThanOrEqual(ext.top - 0.5);
+        expect(absY).toBeLessThanOrEqual(ext.bottom + 0.5);
+      }
+    });
+
+    it('returns undefined for unknown block ids', () => {
+      const { layout, paginated } = buildDoc(10);
+      expect(findPageForPosition(paginated, 'nope', 0, layout)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Profiling `Hello World` typing on page 1 of a long document showed ~25% of the
trace in `computeSelectionRects` (478 ms) plus ~187 ms in `findPageForPosition`
and its `findIndex` callback. Commit #444 made caret *movement* paint-only, but
*typing* mutates the document and still runs a full `paint()`.

Inside `paint()` the decoration loops recomputed rects for **every** peer
selection, search match, comment marker and spell error in the whole document,
with no viewport culling. Each `computeSelectionRects` then ran an `O(blocks)`
`findIndex` and an `O(pages·lines)` scan in `findPageForPosition`, so cost grew
with document length even when editing page 1. Spell errors (hundreds in a long
doc) dominated.

This PR removes both the per-decoration scans and the whole-document iteration:

- **`pagination.ts`** — add `WeakMap`-memoized indexes keyed on the
  layout / paginatedLayout objects (which `computeLayout` / `paginateLayout`
  return fresh per recompute, so they auto-invalidate and are reused across
  paint-only cursor/scroll renders):
  - `getBlockIndex(layout, id)` — block id → document index
  - `getBlockPageLines(paginatedLayout)` — block index → its `PageLine`s
  - `getBlockYExtent(paginatedLayout)` — block index → absolute `{top, bottom}` Y
  - `findPageForPosition` rewritten to use them instead of `findIndex` + full scan.
- **`selection.ts`** — `buildRects` resolves block indices via `getBlockIndex`.
- **`editor.ts`** — viewport-cull the decoration loops in `paint()`: skip any
  decoration whose block range does not intersect the visible band (± one
  screenful margin). Because `paint()` re-reads `scrollY` and reruns on every
  scroll (`renderPaintOnly`), blocks scrolled into view get their decorations
  computed on that repaint, not left stale. Search matches map to `[]` rather
  than being filtered so `activeMatchIndex` stays valid. The band is sized in
  logical coordinates (`canvasHeight / scaleFactor`) so mobile zoom-to-fit keeps
  bottom-of-screen decorations.

Net effect: decoration cost drops from `O(N_decorations × document_size)` to
`O(N_visible × small)`, so 1-page typing latency no longer scales with document
length.

## Test plan

- [x] New unit tests (`test/view/decoration-index.test.ts`, 9 cases): index
  helper correctness on a multi-block/multi-page fixture + `findPageForPosition`
  characterization.
- [x] `pnpm verify:fast` green (docs 1083 tests + all package suites, typecheck clean).
- [x] Self code-review (high effort) — fixed the two confirmed findings (logical-unit
  cull band for mobile scale; `getBlockYExtent` reuses `getBlockPageLines`).
- [ ] Manual smoke in `pnpm dev`: type on page 1 of a long doc with spell errors
  and comments; confirm caret / selection / peer / search / comment / spell
  render correctly on-screen and across page boundaries, including on mobile
  zoom-to-fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added viewport-aware rendering optimizations so off-screen decoration work is skipped during typing and scrolling.
  * Introduced faster document/page lookup helpers to improve rendering and hit-testing performance.

* **Bug Fixes**
  * Reduced unnecessary recomputation for peer selections, search matches, comments, and spell errors.
  * Preserved correct match indexing and on-screen behavior while culling hidden content.

* **Tests**
  * Added coverage for the new indexing and layout-extent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->