### PR TITLE
Close out the v0.4.9 release todo

### DIFF
--- a/docs/tasks/active/20260705-release-v0.4.9-todo.md
+++ b/docs/tasks/active/20260705-release-v0.4.9-todo.md
@@ -53,12 +53,12 @@ inheritance plus external-data-source design docs / connector plans.
 
 ## Post-merge release
 
-- [ ] Sync `main`; confirm `main` at `0.4.9`.
-- [ ] Annotated tag `v0.4.9` on the merge commit, pushed.
-- [ ] GitHub Release `v0.4.9` published with hand-categorised highlights
-      + Contributors.
-- [ ] `npm-publish.yml` + `docker-publish.yml` workflows succeed.
-- [ ] Confirm `@wafflebase/cli@0.4.9` + `@wafflebase/docs@0.4.9` on npm,
+- [x] Sync `main`; confirm `main` at `0.4.9` (merge commit `bb062928f`).
+- [x] Annotated tag `v0.4.9` on the merge commit, pushed.
+- [x] GitHub Release `v0.4.9` published with hand-categorised highlights
+      + Contributors (both maintainers tagged).
+- [x] `npm-publish.yml` + `docker-publish.yml` workflows succeed.
+- [x] Confirm `@wafflebase/cli@0.4.9` + `@wafflebase/docs@0.4.9` on npm,
       and `yorkieteam/wafflebase:v0.4.9` in the registry.
 
 ## Tasks staying active (genuine remaining work)
@@ -97,4 +97,25 @@ inheritance plus external-data-source design docs / connector plans.
 
 ## Review
 
-(filled in at completion)
+Shipped as PR #446 (squash `bb062928f`, "Bump version to v0.4.9"). Root +
+8 packages bumped `0.4.8 → 0.4.9`; 12 shipped task docs archived into
+`archive/2026/07/` (330 → 342 archived, 8 active). Six Group-B docs
+needed checklist reconciliation (shipped this window but boxes left
+unticked); `slides-rotated-resize-cursor` gained a missing Review + PR
+link and `slides-freeform-arrowheads` had its stale placeholder Review
+replaced.
+
+Post-merge, all verified:
+- Tag `v0.4.9` (annotated, "Release v0.4.9") on `bb062928f`, pushed.
+- GitHub Release `v0.4.9` published (marked latest), categorised
+  highlights + both maintainers as Contributors.
+- `Publish to npm` + `Docker Publish` release-triggered runs succeeded.
+- Live: `@wafflebase/cli@0.4.9`, `@wafflebase/docs@0.4.9` on npm;
+  `yorkieteam/wafflebase:v0.4.9` on Docker Hub.
+
+Per the established pattern (the v0.4.8 release todo was archived in
+#431, one cycle later), this release todo stays active until the next
+release's archive sweep.
+
+Out of scope (external repo): bumping the server image in
+`yorkie-team/devops`.


### PR DESCRIPTION
## Summary

Doc-only follow-up to PR #446. Marks the v0.4.9 release todo's post-merge steps complete and adds its Review section.

Post-merge steps, all verified:
- Annotated tag `v0.4.9` ("Release v0.4.9") on merge commit `bb062928f`, pushed.
- GitHub Release `v0.4.9` published (latest), categorised highlights + both maintainers as Contributors.
- `Publish to npm` + `Docker Publish` release-triggered runs succeeded.
- Live: `@wafflebase/cli@0.4.9`, `@wafflebase/docs@0.4.9` on npm; `yorkieteam/wafflebase:v0.4.9` on Docker Hub.

The release todo stays active until the next release's archive sweep (mirrors the v0.4.8 todo, archived in #431).

## Test plan

- No executable code changed — single task-doc edit. `pnpm verify:fast` unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v0.4.9 release notes checklist to reflect completed post-release steps.
  * Added a review summary covering the release outcome, version updates, archived task tracking, and verification status for published package and container versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->