### PR TITLE
Add sorting, type filter, last-modified & owner to documents list

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| documents list sort search (2026-07-07) | [20260707-documents-list-sort-search-todo.md](./active/20260707-documents-list-sort-search-todo.md) | [20260707-documents-list-sort-search-lessons.md](./active/20260707-documents-list-sort-search-lessons.md) |
 | release v0.4.9 (2026-07-05) | [20260705-release-v0.4.9-todo.md](./active/20260705-release-v0.4.9-todo.md) | - |
 | docs collaboration convergence (2026-06-25) | [20260625-docs-collaboration-convergence-todo.md](./active/20260625-docs-collaboration-convergence-todo.md) | [20260625-docs-collaboration-convergence-lessons.md](./active/20260625-docs-collaboration-convergence-lessons.md) |
 | sheets bigquery connector (2026-06-25) | [20260625-sheets-bigquery-connector-todo.md](./active/20260625-sheets-bigquery-connector-todo.md) | - |
@@ -32,4 +33,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 342
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: release v0.4.9 (2026-07-05)
+Latest active task: documents list sort search (2026-07-07)

--- a/docs/tasks/active/20260707-documents-list-sort-search-lessons.md
+++ b/docs/tasks/active/20260707-documents-list-sort-search-lessons.md
@@ -1,0 +1,58 @@
+# Documents List — Sort, Filter & Last-Modified — Lessons
+
+Captured lessons for `20260707-documents-list-sort-search-todo.md`.
+
+## Design decisions
+- **Last-modified read from Yorkie, not Postgres.** Content edits bypass the
+  NestJS backend (frontend talks to Yorkie directly), so there is no
+  `updatedAt` write path. Rather than add a column + webhook/ping, we read
+  `updated_at` from the `AdminService/GetDocuments` `DocumentSummary` the
+  backend already fetches for presence. No schema change.
+- Favorites deferred: it is the only piece requiring a migration.
+- Thumbnails deferred: need render-to-image + blob storage (net-new).
+
+## Lessons (fill in as work lands)
+- **Yorkie admin `GetDocuments` JSON is camelCase, not snake_case.** The
+  request body uses snake_case (`document_keys`, `include_presences`) and
+  works only because connect-go protojson accepts both names on *input*. The
+  *response* marshals proto3 canonical camelCase, so `updated_at` arrives as
+  `updatedAt`. The existing presence code never exposed this because `key`
+  and `presences` are single-word fields. Reading `doc.updated_at` silently
+  returned undefined and the "Modified" column fell back to `createdAt` for
+  every row — the feature looked wired but did nothing. Caught only in code
+  review. Fix reads `updatedAt ?? updated_at` and a regression test
+  (`projectSummary`) locks the camelCase field. Confirm field casing against
+  the connect-es generated `.d.ts` (`@generated from field ... = N`), not the
+  request body.
+- **Overriding a service in an e2e stub is a maintenance trap.** Three
+  `authenticated`/`user-doc-styles`/`api-key` e2e specs stub
+  `YorkieAdminService` with `{ getEditors }`. Adding a new method the
+  controller calls (`getSummaries`) 500s the stubbed path until every stub is
+  updated. Grep all `overrideProvider(YorkieAdminService)` sites when the
+  interface grows.
+- **Widening a search predicate can regress UX.** Matching the search box on
+  document *type* as well as title floods results on type-name collisions
+  (a sheet titled "sheet plan"). With dedicated type chips, keep free-text
+  search title-only.
+
+## Thumbnail feasibility (scouted, for the follow-up PR)
+- **Blob storage already exists** — `ImageService` (S3/MinIO via
+  `@aws-sdk/client-s3`) + workspace-scoped `POST/GET/DELETE
+  /api/v1/workspaces/:wid/images` (`packages/backend/src/image/`). Doc/sheet/
+  slide images are stored there (URL in Yorkie), not as data URIs. A thumbnail
+  is just another blob — storage is **not** net-new.
+- **Real previews need the CRDT content** — the list has metadata only, so a
+  true thumbnail must be generated **client-side when a doc is already
+  attached** (open/edit/save), then uploaded.
+- **Slides = turnkey raster path**: reuse `renderThumbnail`/`drawSlide`
+  (`packages/slides/src/view/canvas/`) + `canvasToBytes`
+  (`packages/slides/src/export/pdf.ts`) → PNG Blob → existing images endpoint.
+  **Docs/Sheets = heavier**: must assemble `PaginatedLayout` / `Grid` and
+  drive `DocCanvas.render` / `GridCanvas.render`, no existing toBlob helper.
+- **One migration required**: add `Document.thumbnailUrl String?`
+  (schema has none today; `updatedAt` also absent).
+- Recommended follow-up sequencing: (a) grid/card view with **type-colored
+  placeholder cards** — low-cost, frontend-only, reuses the type→icon map
+  already in `document-list.tsx`; then (b) **slides-only real thumbnails**
+  first (placeholder fallback for docs/sheets), since slides is the only
+  package with a reusable raster path.

--- a/docs/tasks/active/20260707-documents-list-sort-search-todo.md
+++ b/docs/tasks/active/20260707-documents-list-sort-search-todo.md
@@ -1,0 +1,113 @@
+# Documents List — Sort, Filter & Last-Modified
+
+Improve how users **sort and find** documents on the documents-list screen
+(`packages/frontend/src/app/documents/document-list.tsx`, shared by the
+global `/documents` page and per-workspace `workspace-documents.tsx`).
+
+Single PR. **No schema change, no migration.** Thumbnails / grid view and
+favorites are explicitly deferred to follow-up PRs.
+
+## Context — current state
+
+- One shared `DocumentList` (TanStack Table). Data is fetched whole and all
+  sorting/filtering/pagination is **client-side** over the full array.
+- Columns today: Title (+type icon), Editing (presence avatars), **Created
+  At** (relative), Actions. Rows poll every 5 s for presence.
+- Search: a single "Filter by title…" input, **title only** (NFC-normalized
+  lowercase substring).
+- Sorting: TanStack `getSortedRowModel` + `sorting` state are wired, but **no
+  header is clickable**, so sorting is unreachable in the UI. Default order is
+  `createdAt desc` (hardcoded server-side).
+- No `updatedAt` on the Prisma `Document` model; no owner column shown; no
+  favorites/folders/tags. Organizational unit = Workspace only.
+
+Backend list endpoints: `GET /documents` and
+`GET /workspaces/:id/documents` (`document.controller.ts`), both
+`orderBy: createdAt desc` then `attachEditors()` merges live Yorkie presence.
+
+## Key finding — last-modified comes from Yorkie, for free
+
+Content lives in Yorkie, not Postgres — frontend edits bypass NestJS, so
+there is no `updatedAt` write path and adding a column would need webhooks or
+a client ping (net-new, racy). **Not needed:** the backend already calls the
+Yorkie admin `AdminService/GetDocuments` RPC (in `attachEditors` via
+`YorkieAdminService`), and its `DocumentSummary` response already carries
+`updated_at` (field 6) alongside the `key`/`presences` we already parse.
+So "last modified" is **one extra field on a response we already fetch** —
+no schema change, no write path.
+
+- `updated_at` = bumped on document changes (use this).
+- `accessed_at` = bumped on any access (do **not** use for "modified").
+- Verify behaviorally that presence-only changes don't bump `updated_at`; if
+  they do, note it as a known limitation (acceptable for v1).
+
+## Scope — 4 features, one PR
+
+### 1. Expose sorting (frontend)
+- [ ] Make column headers clickable to toggle sort: **Title, Last modified,
+  Created, Type**. Presence column stays `enableSorting: false`.
+- [ ] Show sort-direction affordance (asc/desc arrow) on the active header.
+- [ ] Add a sort dropdown for discoverability/mobile: "Last modified /
+  Title A→Z / Created". Dropdown and header clicks drive the same `sorting`
+  state (single source of truth).
+- [ ] **Default sort = Last modified, desc** (matches Google Drive), instead
+  of the current created-desc.
+
+### 2. Broaden search + type filter (frontend)
+- [ ] Type filter chips next to the search box: Sheet / Doc / Slides,
+  multi-select toggle. Empty selection = all types.
+- [ ] Broaden the text filter to match **title + type keyword**, keeping the
+  existing NFC-normalized lowercase behavior.
+
+### 3. Last-modified column (backend read-only + frontend)
+- [ ] Extend `GetDocumentsResponse` in `yorkie-admin.service.ts` (types at
+  ~:20-26) to parse `updated_at` (and keep the door open for `accessed_at`).
+  Parse the RFC3339 / `google.protobuf.Timestamp` into a `Date`/ISO string.
+- [ ] Return `{ editors, updatedAt }` per doc key (extend `getEditors` or add
+  a sibling method); `attachEditors` attaches `updatedAt` to each list item.
+- [ ] **Fallback to `createdAt`** when Yorkie has no summary for a doc
+  (never-attached docs, or `YORKIE_SECRET_KEY` unset) — reuse the existing
+  silent-degrade path that presence already uses.
+- [ ] Frontend: add a **"Last modified"** column
+  (`formatDistanceToNow`), sortable, and make it the default sort key.
+- [ ] Keep the "Created" column (now a secondary, opt-in sort).
+
+### 4. Owner column (backend select + frontend)
+- [ ] Add the `author` relation (username, photo) to the `select` of both
+  list endpoints so it's returned without an extra round-trip.
+- [ ] Extend the frontend `Document`/list-item type with `author`.
+- [ ] Frontend: add an **Owner** column (avatar + name), sortable by name.
+- [ ] Handle null author gracefully (legacy docs with `authorID = null`).
+
+## Out of scope (follow-up PRs)
+- **Thumbnails / grid view** — needs render-to-image + storage; separate PR.
+  (Feasibility scouted; capture findings when that PR starts.)
+- **Favorites (starred)** — the only piece needing a new table
+  (`Favorite` user↔document join) + migration; deferred to keep this PR
+  migration-free.
+- Folders / tags; server-side sort/search/pagination query params (service
+  layer already supports `orderBy`/`where`/`skip`/`take` when scale demands).
+
+## Test plan
+- [ ] Unit: search/filter/sort predicates over a fixture doc set (title +
+  type match; type-chip filtering; each sort key + direction; default =
+  last-modified desc).
+- [ ] Backend: `YorkieAdminService` parses `updated_at` from a
+  `GetDocuments` response fixture; `attachEditors` falls back to `createdAt`
+  when a summary is missing / key unset. Owner `select` returns author.
+- [ ] Manual smoke (`pnpm dev`): create sheet/doc/slides, edit one, confirm
+  it jumps to the top under default sort; toggle each header + dropdown;
+  filter by type chips; search by title and by type; owner avatar renders;
+  works both on `/documents` and a workspace page; degrades cleanly with
+  `YORKIE_SECRET_KEY` unset.
+- [ ] `pnpm verify:fast` green before each commit.
+
+## Key files
+- `packages/frontend/src/app/documents/document-list.tsx` (table, sort,
+  filter, columns)
+- `packages/frontend/src/app/documents/page.tsx`,
+  `packages/frontend/src/app/workspaces/workspace-documents.tsx` (fetch)
+- `packages/frontend/src/types/documents.ts` (list-item type)
+- `packages/backend/src/yorkie/yorkie-admin.service.ts` (parse `updated_at`)
+- `packages/backend/src/document/document.controller.ts`
+  (`attachEditors`, list endpoints, author `select`)

--- a/docs/tasks/active/20260707-documents-list-sort-search-todo.md
+++ b/docs/tasks/active/20260707-documents-list-sort-search-todo.md
@@ -53,11 +53,12 @@ no schema change, no write path.
 - [ ] **Default sort = Last modified, desc** (matches Google Drive), instead
   of the current created-desc.
 
-### 2. Broaden search + type filter (frontend)
+### 2. Search + type filter (frontend)
 - [ ] Type filter chips next to the search box: Sheet / Doc / Slides,
   multi-select toggle. Empty selection = all types.
-- [ ] Broaden the text filter to match **title + type keyword**, keeping the
-  existing NFC-normalized lowercase behavior.
+- [ ] Keep the text filter **title-only** (NFC-normalized, lowercase) — type
+  filtering is the chips' job, so widening search to type keywords would
+  flood results on type-name collisions.
 
 ### 3. Last-modified column (backend read-only + frontend)
 - [ ] Extend `GetDocumentsResponse` in `yorkie-admin.service.ts` (types at

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "packageManager": "pnpm@10.5.2",
   "pnpm": {
     "overrides": {
+      "@xhmikosr/decompress@<10.2.1": "10.2.1",
       "minimatch@<3.1.4": "3.1.4",
       "minimatch@>=5.0.0 <5.1.8": "5.1.8",
       "minimatch@>=9.0.0 <9.0.7": "9.0.7",

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -10,7 +10,7 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common';
-import { DocumentService } from './document.service';
+import { DocumentService, DocumentWithAuthor } from './document.service';
 import { Document as DocumentModel } from '@prisma/client';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { AuthenticatedRequest } from 'src/auth/auth.types';
@@ -26,8 +26,11 @@ import {
 } from '../yorkie/yorkie-admin.service';
 import { yorkieDocKey } from '../yorkie/yorkie-doc-key';
 
-type DocumentListItem = DocumentModel & {
+type DocumentListItem = DocumentWithAuthor & {
   editors?: PresenceUser[];
+  // Last-modified time (ISO). Read from Yorkie's `updated_at`, falling back
+  // to the Postgres `createdAt` when Yorkie has no record of the document.
+  updatedAt: string;
 };
 
 @Controller()
@@ -39,15 +42,20 @@ export class DocumentController {
     private readonly yorkieAdminService: YorkieAdminService,
   ) {}
 
-  private async attachEditors(
-    docs: DocumentModel[],
+  private async attachMeta(
+    docs: DocumentWithAuthor[],
   ): Promise<DocumentListItem[]> {
     if (docs.length === 0) return [];
     const keys = docs.map((d) => yorkieDocKey(d.type, d.id));
-    const editorsByKey = await this.yorkieAdminService.getEditors(keys);
+    const summaries = await this.yorkieAdminService.getSummaries(keys);
     return docs.map((d, i) => {
-      const editors = editorsByKey.get(keys[i]);
-      return editors ? { ...d, editors } : d;
+      const summary = summaries.get(keys[i]);
+      const item: DocumentListItem = {
+        ...d,
+        updatedAt: summary?.updatedAt ?? d.createdAt.toISOString(),
+      };
+      if (summary?.editors.length) item.editors = summary.editors;
+      return item;
     });
   }
 
@@ -80,11 +88,11 @@ export class DocumentController {
     const workspaceId =
       await this.workspaceService.resolveId(workspaceIdOrSlug);
     await this.workspaceService.assertMember(workspaceId, userId);
-    const docs = await this.documentService.documents({
+    const docs = await this.documentService.listDocumentsWithAuthor({
       where: { workspaceId },
       orderBy: { createdAt: 'desc' },
     });
-    return this.attachEditors(docs);
+    return this.attachMeta(docs);
   }
 
   // --- Legacy / backward-compatible endpoints ---
@@ -112,11 +120,11 @@ export class DocumentController {
     const userId = Number(req.user.id);
     const workspaces = await this.workspaceService.findAllByUser(userId);
     const workspaceIds = workspaces.map((w) => w.id);
-    const docs = await this.documentService.documents({
+    const docs = await this.documentService.listDocumentsWithAuthor({
       where: { workspaceId: { in: workspaceIds } },
       orderBy: { createdAt: 'desc' },
     });
-    return this.attachEditors(docs);
+    return this.attachMeta(docs);
   }
 
   @Post('documents')

--- a/packages/backend/src/document/document.service.ts
+++ b/packages/backend/src/document/document.service.ts
@@ -2,6 +2,18 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { Document, Prisma } from '@prisma/client';
 import { PrismaService } from 'src/database/prisma.service';
 
+/**
+ * Author fields surfaced on the documents-list rows. `select`ed (not the
+ * whole User) so we never leak auth-provider internals to the client.
+ */
+export const documentListInclude = {
+  author: { select: { id: true, username: true, photo: true } },
+} satisfies Prisma.DocumentInclude;
+
+export type DocumentWithAuthor = Prisma.DocumentGetPayload<{
+  include: typeof documentListInclude;
+}>;
+
 @Injectable()
 export class DocumentService {
   constructor(private prisma: PrismaService) {}
@@ -36,6 +48,29 @@ export class DocumentService {
       cursor,
       where,
       orderBy,
+    });
+  }
+
+  /**
+   * Like {@link documents} but eager-loads the author for the documents-list
+   * "Owner" column. Kept separate so callers that don't need the join
+   * (e.g. the REST v1 listing) stay lean.
+   */
+  async listDocumentsWithAuthor(params: {
+    skip?: number;
+    take?: number;
+    cursor?: Prisma.DocumentWhereUniqueInput;
+    where?: Prisma.DocumentWhereInput;
+    orderBy?: Prisma.DocumentOrderByWithRelationInput;
+  }): Promise<DocumentWithAuthor[]> {
+    const { skip, take, cursor, where, orderBy } = params;
+    return this.prisma.document.findMany({
+      skip,
+      take,
+      cursor,
+      where,
+      orderBy,
+      include: documentListInclude,
     });
   }
 

--- a/packages/backend/src/yorkie/yorkie-admin.service.spec.ts
+++ b/packages/backend/src/yorkie/yorkie-admin.service.spec.ts
@@ -1,0 +1,64 @@
+import { parseTimestamp, projectSummary } from './yorkie-admin.service';
+
+describe('projectSummary', () => {
+  it('reads the last-modified time from camelCase `updatedAt`', () => {
+    // Yorkie's connect-go protojson response marshals fields as camelCase.
+    // Regression guard: reading snake_case here silently loses the value.
+    const summary = projectSummary({
+      key: 'doc-1',
+      updatedAt: '2024-03-04T05:06:07.000Z',
+    });
+    expect(summary.updatedAt).toBe('2024-03-04T05:06:07.000Z');
+  });
+
+  it('falls back to snake_case `updated_at` when present', () => {
+    const summary = projectSummary({
+      key: 'doc-1',
+      updated_at: '2024-03-04T05:06:07.000Z',
+    });
+    expect(summary.updatedAt).toBe('2024-03-04T05:06:07.000Z');
+  });
+
+  it('leaves updatedAt undefined when the document has no timestamp', () => {
+    expect(projectSummary({ key: 'doc-1' }).updatedAt).toBeUndefined();
+  });
+
+  it('projects the currently-editing users from presences', () => {
+    const summary = projectSummary({
+      key: 'doc-1',
+      presences: {
+        c1: { data: { username: '"alice"', email: '"a@x.io"' } },
+      },
+    });
+    expect(summary.editors).toEqual([
+      { username: 'alice', email: 'a@x.io', photo: undefined },
+    ]);
+  });
+});
+
+describe('parseTimestamp', () => {
+  it('normalizes an RFC3339 timestamp to an ISO string', () => {
+    expect(parseTimestamp('2024-01-02T03:04:05.678Z')).toBe(
+      '2024-01-02T03:04:05.678Z',
+    );
+  });
+
+  it('normalizes a non-UTC offset to UTC ISO', () => {
+    expect(parseTimestamp('2024-01-02T12:00:00+09:00')).toBe(
+      '2024-01-02T03:00:00.000Z',
+    );
+  });
+
+  it('returns undefined for missing or empty values', () => {
+    expect(parseTimestamp(undefined)).toBeUndefined();
+    expect(parseTimestamp('')).toBeUndefined();
+  });
+
+  it('returns undefined for epoch-zero (Yorkie "unset") timestamps', () => {
+    expect(parseTimestamp('1970-01-01T00:00:00Z')).toBeUndefined();
+  });
+
+  it('returns undefined for unparseable values', () => {
+    expect(parseTimestamp('not-a-date')).toBeUndefined();
+  });
+});

--- a/packages/backend/src/yorkie/yorkie-admin.service.ts
+++ b/packages/backend/src/yorkie/yorkie-admin.service.ts
@@ -17,12 +17,29 @@ type RawPresences = {
   [clientId: string]: { data: { [key: string]: string } };
 };
 
+type RawDocumentSummary = {
+  key: string;
+  presences?: RawPresences;
+  // RFC3339 timestamp of the last document change. Yorkie's connect-go
+  // protojson response emits camelCase (`updatedAt`); the snake_case name is
+  // accepted too for resilience across gateway/transcoding configs.
+  updatedAt?: string;
+  updated_at?: string;
+};
+
 type GetDocumentsResponse = {
-  documents?: Array<{
-    key: string;
-    presences?: RawPresences;
-  }>;
+  documents?: Array<RawDocumentSummary>;
   error?: { message?: string; code?: string };
+};
+
+/**
+ * Per-document metadata read from Yorkie's admin `GetDocuments`: the live
+ * editors and the last-modified time. `updatedAt` is an ISO string, or
+ * undefined when Yorkie has no valid timestamp for the document.
+ */
+export type DocumentSummary = {
+  editors: PresenceUser[];
+  updatedAt?: string;
 };
 
 const REQUEST_TIMEOUT_MS = 800;
@@ -54,14 +71,15 @@ export class YorkieAdminService implements OnModuleDestroy {
   }
 
   /**
-   * Fetch "currently editing" users for the given Yorkie document keys.
-   * Returns a map keyed by document key. Documents with no active clients
-   * are absent.
+   * Fetch per-document metadata (live editors + last-modified time) for the
+   * given Yorkie document keys. Returns a map keyed by document key;
+   * documents Yorkie has never seen (or when no admin key is configured)
+   * are absent, letting callers fall back to Postgres data.
    */
-  async getEditors(
+  async getSummaries(
     documentKeys: ReadonlyArray<string>,
-  ): Promise<Map<string, PresenceUser[]>> {
-    const out = new Map<string, PresenceUser[]>();
+  ): Promise<Map<string, DocumentSummary>> {
+    const out = new Map<string, DocumentSummary>();
     if (documentKeys.length === 0) return out;
     if (!this.secretKey) {
       // No admin key configured — degrade silently. Expected for local
@@ -72,13 +90,27 @@ export class YorkieAdminService implements OnModuleDestroy {
     try {
       const response = await this.requestGetDocuments(documentKeys);
       for (const doc of response.documents ?? []) {
-        const users = projectUsers(doc.presences);
-        if (users.length > 0) out.set(doc.key, users);
+        out.set(doc.key, projectSummary(doc));
       }
     } catch (err) {
       this.logger.warn(
-        `Yorkie admin getEditors failed: ${(err as Error).message}`,
+        `Yorkie admin getSummaries failed: ${(err as Error).message}`,
       );
+    }
+    return out;
+  }
+
+  /**
+   * Fetch "currently editing" users for the given Yorkie document keys.
+   * Returns a map keyed by document key. Documents with no active clients
+   * are absent. Thin projection over {@link getSummaries}.
+   */
+  async getEditors(
+    documentKeys: ReadonlyArray<string>,
+  ): Promise<Map<string, PresenceUser[]>> {
+    const out = new Map<string, PresenceUser[]>();
+    for (const [key, summary] of await this.getSummaries(documentKeys)) {
+      if (summary.editors.length > 0) out.set(key, summary.editors);
     }
     return out;
   }
@@ -217,6 +249,30 @@ function unwrap(value: string | undefined): string | undefined {
   }
   if (typeof next !== 'string') return undefined;
   return next;
+}
+
+/**
+ * Project a raw Yorkie `GetDocuments` entry into our backend-shaped summary.
+ * Reads the last-modified timestamp from camelCase `updatedAt` (protojson's
+ * output form), falling back to snake_case for resilience.
+ */
+export function projectSummary(doc: RawDocumentSummary): DocumentSummary {
+  return {
+    editors: projectUsers(doc.presences),
+    updatedAt: parseTimestamp(doc.updatedAt ?? doc.updated_at),
+  };
+}
+
+/**
+ * Normalize a Yorkie RFC3339 timestamp into an ISO string. Returns
+ * undefined for missing, empty, epoch-zero (Yorkie's "unset"), or
+ * unparseable values so callers can fall back to Postgres data.
+ */
+export function parseTimestamp(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms) || ms <= 0) return undefined;
+  return new Date(ms).toISOString();
 }
 
 function projectUsers(presences: RawPresences | undefined): PresenceUser[] {

--- a/packages/backend/test/api-key-http.e2e-spec.ts
+++ b/packages/backend/test/api-key-http.e2e-spec.ts
@@ -61,7 +61,10 @@ describeDb('API Key HTTP integration', () => {
       .overrideProvider(YorkieService)
       .useValue(yorkieStub)
       .overrideProvider(YorkieAdminService)
-      .useValue({ getEditors: async () => new Map() })
+      .useValue({
+        getEditors: async () => new Map(),
+        getSummaries: async () => new Map(),
+      })
       .compile();
 
     app = moduleRef.createNestApplication();

--- a/packages/backend/test/authenticated-http.e2e-spec.ts
+++ b/packages/backend/test/authenticated-http.e2e-spec.ts
@@ -63,7 +63,10 @@ describeDb('Authenticated HTTP integration (JWT + controllers + Prisma)', () => 
       .overrideProvider(YorkieService)
       .useValue(yorkieStub)
       .overrideProvider(YorkieAdminService)
-      .useValue({ getEditors: async () => new Map() })
+      .useValue({
+        getEditors: async () => new Map(),
+        getSummaries: async () => new Map(),
+      })
       .compile();
 
     app = moduleRef.createNestApplication();

--- a/packages/backend/test/user-doc-styles.e2e-spec.ts
+++ b/packages/backend/test/user-doc-styles.e2e-spec.ts
@@ -61,7 +61,10 @@ describeDb('User doc styles HTTP integration (JWT + controller + Prisma)', () =>
       .overrideProvider(YorkieService)
       .useValue(yorkieStub)
       .overrideProvider(YorkieAdminService)
-      .useValue({ getEditors: async () => new Map() })
+      .useValue({
+        getEditors: async () => new Map(),
+        getSummaries: async () => new Map(),
+      })
       .compile();
 
     app = moduleRef.createNestApplication();

--- a/packages/frontend/src/app/documents/document-list-utils.ts
+++ b/packages/frontend/src/app/documents/document-list-utils.ts
@@ -1,3 +1,5 @@
+import { formatDistanceToNow } from "date-fns";
+
 import type { Document, DocumentType } from "@/types/documents";
 
 /**
@@ -46,11 +48,31 @@ export function lastModified(
 }
 
 /**
- * Compare two ISO date strings chronologically. Undefined/empty sorts oldest.
+ * Compare two ISO date strings chronologically. Undefined/empty/unparseable
+ * values sort oldest, and the comparator always returns a real number so the
+ * sort stays stable even on malformed input.
  */
 export function compareDates(
   a: string | undefined,
   b: string | undefined,
 ): number {
-  return (a ? Date.parse(a) : 0) - (b ? Date.parse(b) : 0);
+  return toEpoch(a) - toEpoch(b);
+}
+
+function toEpoch(value: string | undefined): number {
+  if (!value) return 0;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? 0 : ms;
+}
+
+/**
+ * Render a relative timestamp (e.g. "3 days ago"). Guards against invalid or
+ * missing dates — `formatDistanceToNow` throws a RangeError on an invalid
+ * Date, which would blank the whole list — returning an em dash instead.
+ */
+export function formatRelativeTime(value: string | undefined): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return formatDistanceToNow(date, { includeSeconds: true, addSuffix: true });
 }

--- a/packages/frontend/src/app/documents/document-list-utils.ts
+++ b/packages/frontend/src/app/documents/document-list-utils.ts
@@ -1,0 +1,56 @@
+import type { Document, DocumentType } from "@/types/documents";
+
+/**
+ * Pure search/sort helpers for the documents list. Extracted from the table
+ * component so the filtering and ordering rules can be unit-tested without a
+ * DOM.
+ */
+
+/**
+ * Whether a document matches the free-text search box, by title
+ * (NFC-normalized, case-insensitive). Empty query matches everything.
+ * Filtering by document type is handled separately by the type chips, so a
+ * title search stays precise instead of flooding on type-name collisions.
+ */
+export function matchesSearch(
+  doc: Pick<Document, "title">,
+  query: string,
+): boolean {
+  const search = query.normalize("NFC").toLowerCase().trim();
+  if (!search) return true;
+  const title = String(doc.title ?? "")
+    .normalize("NFC")
+    .toLowerCase();
+  return title.includes(search);
+}
+
+/**
+ * Whether a document passes the active type-chip filter. An empty selection
+ * means "all types".
+ */
+export function matchesTypes(
+  doc: Pick<Document, "type">,
+  types: ReadonlySet<DocumentType>,
+): boolean {
+  return types.size === 0 || types.has(doc.type);
+}
+
+/**
+ * The value used for the "Last modified" column: Yorkie's `updatedAt`,
+ * falling back to `createdAt` when the server had no Yorkie record.
+ */
+export function lastModified(
+  doc: Pick<Document, "updatedAt" | "createdAt">,
+): string {
+  return doc.updatedAt ?? doc.createdAt;
+}
+
+/**
+ * Compare two ISO date strings chronologically. Undefined/empty sorts oldest.
+ */
+export function compareDates(
+  a: string | undefined,
+  b: string | undefined,
+): number {
+  return (a ? Date.parse(a) : 0) - (b ? Date.parse(b) : 0);
+}

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -1,7 +1,8 @@
-import { FormEvent, MouseEvent, useState } from "react";
+import { FormEvent, MouseEvent, ReactNode, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  Column,
   ColumnDef,
   ColumnFiltersState,
   SortingState,
@@ -16,6 +17,9 @@ import {
 import { formatDistanceToNow } from "date-fns";
 import { toast } from "sonner";
 import {
+  ArrowDown,
+  ArrowUp,
+  ChevronsUpDown,
   FileDown,
   FileText,
   FolderOutput,
@@ -27,6 +31,7 @@ import {
   Trash2,
 } from "lucide-react";
 
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -59,9 +64,20 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 import type { Document, DocumentType } from "@/types/documents";
 import { DocumentPresenceAvatars } from "./document-presence-avatars";
+import {
+  compareDates,
+  lastModified,
+  matchesSearch,
+  matchesTypes,
+} from "./document-list-utils";
 import {
   createDocument,
   deleteDocument,
@@ -92,6 +108,88 @@ function getDocumentPath(doc: { id: number | string; type?: DocumentType }) {
   }
 }
 
+/** Document types offered as filter chips, with their list-row icons. */
+const TYPE_OPTIONS: ReadonlyArray<{
+  type: DocumentType;
+  label: string;
+  Icon: typeof Sheet;
+  color: string;
+}> = [
+  { type: "sheet", label: "Sheets", Icon: Sheet, color: "text-green-600" },
+  { type: "doc", label: "Docs", Icon: FileText, color: "text-blue-500" },
+  {
+    type: "slides",
+    label: "Slides",
+    Icon: Presentation,
+    color: "text-orange-500",
+  },
+];
+
+/**
+ * Clickable column header that toggles this column's sort and shows the
+ * active direction. Reused across the sortable columns.
+ */
+function SortableHeader<TData>({
+  column,
+  children,
+  align = "left",
+}: {
+  column: Column<TData, unknown>;
+  children: ReactNode;
+  align?: "left" | "right";
+}) {
+  const sorted = column.getIsSorted();
+  return (
+    <div className={align === "right" ? "text-right" : ""}>
+      <Button
+        variant="ghost"
+        size="sm"
+        className={`h-8 ${align === "right" ? "-mr-3" : "-ml-3"}`}
+        onClick={column.getToggleSortingHandler()}
+      >
+        {children}
+        {sorted === "asc" ? (
+          <ArrowUp className="ml-1 h-3.5 w-3.5" />
+        ) : sorted === "desc" ? (
+          <ArrowDown className="ml-1 h-3.5 w-3.5" />
+        ) : (
+          <ChevronsUpDown className="ml-1 h-3.5 w-3.5 opacity-40" />
+        )}
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * A right-aligned, time-based sortable column rendering a relative timestamp
+ * (e.g. "3 days ago"). Shared by the Created and Modified columns.
+ */
+function dateColumn(
+  id: string,
+  label: string,
+  accessor: (doc: Document) => string,
+): ColumnDef<Document> {
+  return {
+    id,
+    accessorFn: accessor,
+    header: ({ column }) => (
+      <SortableHeader column={column} align="right">
+        {label}
+      </SortableHeader>
+    ),
+    sortingFn: (a, b, colId) =>
+      compareDates(a.getValue<string>(colId), b.getValue<string>(colId)),
+    cell: ({ row }) => (
+      <div className="text-right font-medium">
+        {formatDistanceToNow(new Date(row.getValue<string>(id)), {
+          includeSeconds: true,
+          addSuffix: true,
+        })}
+      </div>
+    ),
+  };
+}
+
 /**
  * Renders the DocumentList component.
  */
@@ -112,16 +210,11 @@ export function DocumentList({
     },
     {
       accessorKey: "title",
-      header: "Title",
-      filterFn: (row, columnId, filterValue) => {
-        const cellValue = String(row.getValue(columnId) ?? "")
-          .normalize("NFC")
-          .toLowerCase();
-        const search = String(filterValue ?? "")
-          .normalize("NFC")
-          .toLowerCase();
-        return cellValue.includes(search);
-      },
+      header: ({ column }) => (
+        <SortableHeader column={column}>Title</SortableHeader>
+      ),
+      filterFn: (row, _columnId, filterValue) =>
+        matchesSearch(row.original, String(filterValue ?? "")),
       cell: ({ row }) => {
         const docType = row.original.type;
         return (
@@ -134,32 +227,44 @@ export function DocumentList({
               <Sheet className="h-4 w-4 shrink-0 text-green-600" />
             )}
             <span className="capitalize">{row.getValue("title")}</span>
+            {/* Live "currently editing" avatars sit next to the title rather
+                than in their own column. Presentational only — Title still
+                sorts by its own value. */}
+            <DocumentPresenceAvatars editors={row.original.editors} />
           </div>
         );
       },
     },
     {
-      id: "editors",
-      header: () => <div className="text-left">Editing</div>,
-      cell: ({ row }) => (
-        <div className="flex items-center">
-          <DocumentPresenceAvatars editors={row.original.editors} />
-        </div>
+      id: "owner",
+      accessorFn: (doc) => doc.author?.username ?? "",
+      header: ({ column }) => (
+        <SortableHeader column={column}>Owner</SortableHeader>
       ),
-      enableSorting: false,
-    },
-    {
-      accessorKey: "createdAt",
-      header: () => <div className="text-right">Created At</div>,
       cell: ({ row }) => {
-        const createdAt = row.getValue<string>("createdAt");
-        const formatted = formatDistanceToNow(new Date(createdAt), {
-          includeSeconds: true,
-          addSuffix: true,
-        });
-        return <div className="text-right font-medium">{formatted}</div>;
+        const author = row.original.author;
+        if (!author) {
+          return <span className="text-muted-foreground">—</span>;
+        }
+        return (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Avatar className="h-6 w-6">
+                {author.photo && (
+                  <AvatarImage src={author.photo} alt={author.username} />
+                )}
+                <AvatarFallback className="text-[10px]">
+                  {author.username.slice(0, 2).toUpperCase() || "??"}
+                </AvatarFallback>
+              </Avatar>
+            </TooltipTrigger>
+            <TooltipContent>{author.username}</TooltipContent>
+          </Tooltip>
+        );
       },
     },
+    dateColumn("updatedAt", "Modified", (doc) => lastModified(doc)),
+    dateColumn("createdAt", "Created", (doc) => doc.createdAt),
     {
       id: "actions",
       enableHiding: false,
@@ -421,15 +526,35 @@ export function DocumentList({
     },
   });
 
-  const [sorting, setSorting] = useState<SortingState>([]);
+  // Default to most-recently-modified first (Google-Drive-style).
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "updatedAt", desc: true },
+  ]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
     id: false,
   });
   const [rowSelection, setRowSelection] = useState({});
+  const [typeFilters, setTypeFilters] = useState<Set<DocumentType>>(new Set());
+
+  const toggleType = (type: DocumentType) => {
+    setTypeFilters((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
+      return next;
+    });
+  };
+
+  // Type-chip filtering happens before the table so it composes cleanly with
+  // the text search and column sorting the table already owns.
+  const filteredData = useMemo(
+    () => data.filter((doc) => matchesTypes(doc, typeFilters)),
+    [data, typeFilters],
+  );
 
   const table = useReactTable({
-    data,
+    data: filteredData,
     columns,
     // Stabilize row identity across the presence-driven 5 s poll so React
     // reconciles rows by document id instead of array index — keeps any
@@ -453,19 +578,39 @@ export function DocumentList({
 
   return (
     <div className="w-full">
-      <div className="flex items-center justify-between py-4">
+      <div className="flex flex-wrap items-center gap-2 py-4">
         <Input
-          placeholder="Filter by title..."
-          aria-label="Filter documents by title"
+          placeholder="Search by title..."
+          aria-label="Search documents by title"
           value={(table.getColumn("title")?.getFilterValue() as string) ?? ""}
           onChange={(e) =>
             table.getColumn("title")?.setFilterValue(e.target.value)
           }
-          className="max-w-sm"
+          className="w-full max-w-xs"
         />
+        <div className="flex items-center gap-1">
+          {TYPE_OPTIONS.map(({ type, label, Icon, color }) => {
+            const active = typeFilters.has(type);
+            return (
+              <Button
+                key={type}
+                type="button"
+                variant={active ? "secondary" : "outline"}
+                size="icon"
+                aria-pressed={active}
+                aria-label={`Filter by ${label}`}
+                title={label}
+                onClick={() => toggleType(type)}
+                className={active ? undefined : "text-muted-foreground"}
+              >
+                <Icon className={`h-4 w-4 ${color}`} />
+              </Button>
+            );
+          })}
+        </div>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button className="flex items-center gap-2">
+            <Button className="ml-auto flex items-center gap-2">
               <Plus className="w-4 h-4" />
               New
             </Button>

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -14,7 +14,6 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { formatDistanceToNow } from "date-fns";
 import { toast } from "sonner";
 import {
   ArrowDown,
@@ -74,6 +73,7 @@ import type { Document, DocumentType } from "@/types/documents";
 import { DocumentPresenceAvatars } from "./document-presence-avatars";
 import {
   compareDates,
+  formatRelativeTime,
   lastModified,
   matchesSearch,
   matchesTypes,
@@ -108,22 +108,22 @@ function getDocumentPath(doc: { id: number | string; type?: DocumentType }) {
   }
 }
 
-/** Document types offered as filter chips, with their list-row icons. */
-const TYPE_OPTIONS: ReadonlyArray<{
-  type: DocumentType;
-  label: string;
-  Icon: typeof Sheet;
-  color: string;
-}> = [
-  { type: "sheet", label: "Sheets", Icon: Sheet, color: "text-green-600" },
-  { type: "doc", label: "Docs", Icon: FileText, color: "text-blue-500" },
-  {
-    type: "slides",
-    label: "Slides",
-    Icon: Presentation,
-    color: "text-orange-500",
-  },
-];
+/**
+ * Single source of truth for each document type's label, icon, and color.
+ * The title cell and the filter chips both derive from this so a new type
+ * needs one edit, not several.
+ */
+const TYPE_META: Record<
+  DocumentType,
+  { label: string; Icon: typeof Sheet; color: string }
+> = {
+  sheet: { label: "Sheets", Icon: Sheet, color: "text-green-600" },
+  doc: { label: "Docs", Icon: FileText, color: "text-blue-500" },
+  slides: { label: "Slides", Icon: Presentation, color: "text-orange-500" },
+};
+
+/** Document types offered as filter chips, in display order. */
+const TYPE_OPTIONS: ReadonlyArray<DocumentType> = ["sheet", "doc", "slides"];
 
 /**
  * Clickable column header that toggles this column's sort and shows the
@@ -181,10 +181,7 @@ function dateColumn(
       compareDates(a.getValue<string>(colId), b.getValue<string>(colId)),
     cell: ({ row }) => (
       <div className="text-right font-medium">
-        {formatDistanceToNow(new Date(row.getValue<string>(id)), {
-          includeSeconds: true,
-          addSuffix: true,
-        })}
+        {formatRelativeTime(row.getValue<string>(id))}
       </div>
     ),
   };
@@ -216,16 +213,10 @@ export function DocumentList({
       filterFn: (row, _columnId, filterValue) =>
         matchesSearch(row.original, String(filterValue ?? "")),
       cell: ({ row }) => {
-        const docType = row.original.type;
+        const { Icon, color } = TYPE_META[row.original.type];
         return (
           <div className="flex items-center gap-2">
-            {docType === "doc" ? (
-              <FileText className="h-4 w-4 shrink-0 text-blue-500" />
-            ) : docType === "slides" ? (
-              <Presentation className="h-4 w-4 shrink-0 text-orange-500" />
-            ) : (
-              <Sheet className="h-4 w-4 shrink-0 text-green-600" />
-            )}
+            <Icon className={`h-4 w-4 shrink-0 ${color}`} />
             <span className="capitalize">{row.getValue("title")}</span>
             {/* Live "currently editing" avatars sit next to the title rather
                 than in their own column. Presentational only — Title still
@@ -249,7 +240,12 @@ export function DocumentList({
         return (
           <Tooltip>
             <TooltipTrigger asChild>
-              <Avatar className="h-6 w-6">
+              <Avatar
+                className="h-6 w-6"
+                role="img"
+                aria-label={author.username}
+                title={author.username}
+              >
                 {author.photo && (
                   <AvatarImage src={author.photo} alt={author.username} />
                 )}
@@ -589,7 +585,8 @@ export function DocumentList({
           className="w-full max-w-xs"
         />
         <div className="flex items-center gap-1">
-          {TYPE_OPTIONS.map(({ type, label, Icon, color }) => {
+          {TYPE_OPTIONS.map((type) => {
+            const { label, Icon, color } = TYPE_META[type];
             const active = typeFilters.has(type);
             return (
               <Button

--- a/packages/frontend/src/types/documents.ts
+++ b/packages/frontend/src/types/documents.ts
@@ -11,13 +11,26 @@ export type DocumentEditor = {
   email?: string;
 };
 
+/**
+ * Document owner surfaced on the documents list. `select`ed server-side
+ * (never the full User). Null for legacy documents with no author.
+ */
+export type DocumentAuthor = {
+  id: number;
+  username: string;
+  photo?: string | null;
+};
+
 export type Document = {
   id: string;
   title: string;
   type: DocumentType;
   description: string;
   createdAt: string;
-  updatedAt: string;
+  // Last-modified time (ISO), populated only by the documents-list endpoints
+  // (from Yorkie). Absent on single-document / REST v1 responses.
+  updatedAt?: string;
   workspaceId: string;
+  author?: DocumentAuthor | null;
   editors?: DocumentEditor[];
 };

--- a/packages/frontend/tests/app/documents/document-list-utils.test.ts
+++ b/packages/frontend/tests/app/documents/document-list-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { Document, DocumentType } from "@/types/documents";
 import {
   compareDates,
+  formatRelativeTime,
   lastModified,
   matchesSearch,
   matchesTypes,
@@ -90,5 +91,29 @@ describe("compareDates", () => {
   it("sorts undefined/empty as oldest", () => {
     expect(compareDates(undefined, "2024-01-01T00:00:00Z")).toBeLessThan(0);
     expect(compareDates("2024-01-01T00:00:00Z", undefined)).toBeGreaterThan(0);
+  });
+
+  it("treats an unparseable date as oldest, never returning NaN", () => {
+    const result = compareDates("not-a-date", "2024-01-01T00:00:00Z");
+    expect(Number.isNaN(result)).toBe(false);
+    expect(result).toBeLessThan(0);
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("returns an em dash for missing values", () => {
+    expect(formatRelativeTime(undefined)).toBe("—");
+    expect(formatRelativeTime("")).toBe("—");
+  });
+
+  it("returns an em dash for an invalid date instead of throwing", () => {
+    // formatDistanceToNow throws RangeError on an invalid Date; the guard
+    // must swallow it so one bad row cannot blank the whole list.
+    expect(() => formatRelativeTime("not-a-date")).not.toThrow();
+    expect(formatRelativeTime("not-a-date")).toBe("—");
+  });
+
+  it("formats a valid date as a relative time", () => {
+    expect(formatRelativeTime("2024-01-01T00:00:00.000Z")).toMatch(/ago$/);
   });
 });

--- a/packages/frontend/tests/app/documents/document-list-utils.test.ts
+++ b/packages/frontend/tests/app/documents/document-list-utils.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import type { Document, DocumentType } from "@/types/documents";
+import {
+  compareDates,
+  lastModified,
+  matchesSearch,
+  matchesTypes,
+} from "@/app/documents/document-list-utils";
+
+function doc(partial: Partial<Document>): Document {
+  return {
+    id: "1",
+    title: "Untitled",
+    type: "sheet",
+    description: "",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    workspaceId: "w1",
+    ...partial,
+  };
+}
+
+describe("matchesSearch", () => {
+  it("matches everything for an empty query", () => {
+    expect(matchesSearch(doc({ title: "Budget" }), "")).toBe(true);
+    expect(matchesSearch(doc({ title: "Budget" }), "   ")).toBe(true);
+  });
+
+  it("matches on the title, case-insensitively", () => {
+    expect(matchesSearch(doc({ title: "Q3 Budget" }), "budget")).toBe(true);
+    expect(matchesSearch(doc({ title: "Q3 Budget" }), "sales")).toBe(false);
+  });
+
+  it("does not match on the document type (that is the chips' job)", () => {
+    // A sheet titled "Deck" must not surface when searching "sheet",
+    // otherwise a type-name collision floods the list.
+    expect(matchesSearch(doc({ title: "Deck", type: "sheet" }), "sheet")).toBe(
+      false,
+    );
+  });
+
+  it("normalizes NFC so decomposed input still matches", () => {
+    // "é" composed vs decomposed (e + combining acute).
+    expect(matchesSearch(doc({ title: "Café" }), "Café")).toBe(true);
+  });
+});
+
+describe("matchesTypes", () => {
+  const all = new Set<DocumentType>();
+  it("passes everything when no type is selected", () => {
+    expect(matchesTypes(doc({ type: "doc" }), all)).toBe(true);
+  });
+
+  it("filters to the selected types", () => {
+    const selected = new Set<DocumentType>(["sheet", "slides"]);
+    expect(matchesTypes(doc({ type: "sheet" }), selected)).toBe(true);
+    expect(matchesTypes(doc({ type: "slides" }), selected)).toBe(true);
+    expect(matchesTypes(doc({ type: "doc" }), selected)).toBe(false);
+  });
+});
+
+describe("lastModified", () => {
+  it("prefers updatedAt", () => {
+    expect(
+      lastModified({
+        updatedAt: "2024-05-01T00:00:00.000Z",
+        createdAt: "2024-01-01T00:00:00.000Z",
+      }),
+    ).toBe("2024-05-01T00:00:00.000Z");
+  });
+
+  it("falls back to createdAt when updatedAt is absent", () => {
+    expect(
+      lastModified({
+        updatedAt: undefined as unknown as string,
+        createdAt: "2024-01-01T00:00:00.000Z",
+      }),
+    ).toBe("2024-01-01T00:00:00.000Z");
+  });
+});
+
+describe("compareDates", () => {
+  it("orders older before newer", () => {
+    expect(
+      compareDates("2024-01-01T00:00:00Z", "2024-02-01T00:00:00Z"),
+    ).toBeLessThan(0);
+  });
+
+  it("sorts undefined/empty as oldest", () => {
+    expect(compareDates(undefined, "2024-01-01T00:00:00Z")).toBeLessThan(0);
+    expect(compareDates("2024-01-01T00:00:00Z", undefined)).toBeGreaterThan(0);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@xhmikosr/decompress@<10.2.1': 10.2.1
   minimatch@<3.1.4: 3.1.4
   minimatch@>=5.0.0 <5.1.8: 5.1.8
   minimatch@>=9.0.0 <9.0.7: 9.0.7
@@ -4508,24 +4509,24 @@ packages:
     resolution: {integrity: sha512-DT2SAuHDeOw0G5bs7wZbQTbf4hd8pJ14tO0i4cWhRkIJfgRdKmMfkDilpaJ8uZyPA0NVRwasCNAmMJcWA67osw==}
     engines: {node: '>=18'}
 
-  '@xhmikosr/decompress-tar@8.0.1':
-    resolution: {integrity: sha512-dpEgs0cQKJ2xpIaGSO0hrzz3Kt8TQHYdizHsgDtLorWajuHJqxzot9Hbi0huRxJuAGG2qiHSQkwyvHHQtlE+fg==}
+  '@xhmikosr/decompress-tar@8.1.0':
+    resolution: {integrity: sha512-m0q8x6lwxenh1CrsTby0Jrjq4vzW/QU1OLhTHMQLEdHpmjR1lgahGz++seZI0bXF3XcZw3U3xHfqZSz+JPP2Gg==}
     engines: {node: '>=18'}
 
-  '@xhmikosr/decompress-tarbz2@8.0.2':
-    resolution: {integrity: sha512-p5A2r/AVynTQSsF34Pig6olt9CvRj6J5ikIhzUd3b57pUXyFDGtmBstcw+xXza0QFUh93zJsmY3zGeNDlR2AQQ==}
+  '@xhmikosr/decompress-tarbz2@8.1.0':
+    resolution: {integrity: sha512-aCLfr3A/FWZnOu5eqnJfme1Z1aumai/WRw55pCvBP+hCGnTFrcpsuiaVN5zmWTR53a8umxncY2JuYsD42QQEbw==}
     engines: {node: '>=18'}
 
-  '@xhmikosr/decompress-targz@8.0.1':
-    resolution: {integrity: sha512-mvy5AIDIZjQ2IagMI/wvauEiSNHhu/g65qpdM4EVoYHUJBAmkQWqcPJa8Xzi1aKVTmOA5xLJeDk7dqSjlHq8Mg==}
+  '@xhmikosr/decompress-targz@8.1.0':
+    resolution: {integrity: sha512-fhClQ2wTmzxzdz2OhSQNo9ExefrAagw93qaG1YggoIz/QpI7atSRa7eOHv4JZkpHWs91XNn8Hry3CwUlBQhfPA==}
     engines: {node: '>=18'}
 
-  '@xhmikosr/decompress-unzip@7.0.0':
-    resolution: {integrity: sha512-GQMpzIpWTsNr6UZbISawsGI0hJ4KA/mz5nFq+cEoPs12UybAqZWKbyIaZZyLbJebKl5FkLpsGBkrplJdjvUoSQ==}
+  '@xhmikosr/decompress-unzip@7.1.0':
+    resolution: {integrity: sha512-oqTYAcObqTlg8owulxFTqiaJkfv2SHsxxxz9Wg4krJAHVzGWlZsU8tAB30R6ow+aHrfv4Kub6WQ8u04NWVPUpA==}
     engines: {node: '>=18'}
 
-  '@xhmikosr/decompress@10.0.1':
-    resolution: {integrity: sha512-6uHnEEt5jv9ro0CDzqWlFgPycdE+H+kbJnwyxgZregIMLQ7unQSCNVsYG255FoqU8cP46DyggI7F7LohzEl8Ag==}
+  '@xhmikosr/decompress@10.2.1':
+    resolution: {integrity: sha512-ceGT3K2JR73Usj5o+HM2RRZw0XPUes4rhb7uVTY9PefUQQMpuj8x+V29XVG09JnS7EOj9SIBhHn3K4bFNNb7hA==}
     engines: {node: '>=18'}
 
   '@xhmikosr/downloader@15.0.1':
@@ -12642,7 +12643,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@xhmikosr/decompress-tar@8.0.1':
+  '@xhmikosr/decompress-tar@8.1.0':
     dependencies:
       file-type: 21.3.2
       is-stream: 2.0.1
@@ -12650,9 +12651,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@xhmikosr/decompress-tarbz2@8.0.2':
+  '@xhmikosr/decompress-tarbz2@8.1.0':
     dependencies:
-      '@xhmikosr/decompress-tar': 8.0.1
+      '@xhmikosr/decompress-tar': 8.1.0
       file-type: 21.3.2
       is-stream: 2.0.1
       seek-bzip: 2.0.0
@@ -12660,15 +12661,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@xhmikosr/decompress-targz@8.0.1':
+  '@xhmikosr/decompress-targz@8.1.0':
     dependencies:
-      '@xhmikosr/decompress-tar': 8.0.1
+      '@xhmikosr/decompress-tar': 8.1.0
       file-type: 21.3.2
       is-stream: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@xhmikosr/decompress-unzip@7.0.0':
+  '@xhmikosr/decompress-unzip@7.1.0':
     dependencies:
       file-type: 21.3.2
       get-stream: 6.0.1
@@ -12676,14 +12677,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@xhmikosr/decompress@10.0.1':
+  '@xhmikosr/decompress@10.2.1':
     dependencies:
-      '@xhmikosr/decompress-tar': 8.0.1
-      '@xhmikosr/decompress-tarbz2': 8.0.2
-      '@xhmikosr/decompress-targz': 8.0.1
-      '@xhmikosr/decompress-unzip': 7.0.0
+      '@xhmikosr/decompress-tar': 8.1.0
+      '@xhmikosr/decompress-tarbz2': 8.1.0
+      '@xhmikosr/decompress-targz': 8.1.0
+      '@xhmikosr/decompress-unzip': 7.1.0
       graceful-fs: 4.2.11
-      make-dir: 4.0.0
       strip-dirs: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -12691,7 +12691,7 @@ snapshots:
   '@xhmikosr/downloader@15.0.1':
     dependencies:
       '@xhmikosr/archive-type': 7.0.0
-      '@xhmikosr/decompress': 10.0.1
+      '@xhmikosr/decompress': 10.2.1
       content-disposition: 0.5.4
       defaults: 3.0.0
       ext-name: 5.0.0


### PR DESCRIPTION
## Summary

Improves how users sort and find documents on the documents-list screen
(`document-list.tsx`, shared by `/documents` and per-workspace pages).
**No schema change, no migration.**

- **Sorting exposed** — column headers (Title, Owner, Modified, Created) are
  now clickable to sort, with a direction arrow. Default is
  most-recently-modified first (Google-Drive-style).
- **Modified column** — last-modified time read from Yorkie's per-document
  `updatedAt`, surfaced via the admin `GetDocuments` call the backend already
  makes for presence. protojson emits camelCase (`updatedAt`); snake_case is
  accepted as a fallback. Falls back to `createdAt` when Yorkie has no record
  (never-attached docs, or `YORKIE_SECRET_KEY` unset). No edit-path work.
- **Owner column** — the document author (avatar-only, name on hover) via an
  eager-loaded `author` relation on the list endpoints.
- **Type filter chips** (Sheets / Docs / Slides, icon-only) next to a
  title-only search box.
- Currently-editing avatars move inline next to the title.

Search/sort predicates live in `document-list-utils`; date columns share a
`dateColumn` factory. Timestamp + summary parsing are unit-tested in
`yorkie-admin.service`.

### Deferred to follow-up PRs
- **Thumbnails / grid view** (feasibility scouted — slides has a turnkey
  raster path, S3/MinIO storage already exists).
- **Favorites (starred)** — the only piece needing a new table + migration.

### Known behavior
The default sort is live last-modified: when a collaborator edits a document,
its row moves to the top on the next 5s presence refetch. This is the
intended Drive-style behavior; flagged here as it changes the previously
fixed `createdAt`-desc order.

## Test plan

- `pnpm verify:fast` green (lint + all package unit tests).
- Backend unit tests: `projectSummary` (camelCase `updatedAt`, snake fallback,
  presence projection) and `parseTimestamp` (RFC3339 / offset / epoch-0 /
  unparseable).
- Frontend unit tests: `matchesSearch` / `matchesTypes` / `lastModified` /
  `compareDates`.
- e2e `YorkieAdminService` stubs gained `getSummaries` so the documents-list
  path stays green.
- Manual smoke (`pnpm dev`): sort via headers, type chips, search, owner
  hover, Modified updates after an edit; degrades cleanly when
  `YORKIE_SECRET_KEY` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents list now supports sorting by last modified, type-based filters, and a new Owner column.
  * Search now matches document titles more reliably, including accented characters.
  * Timestamps now show the most relevant last-modified value when available.

* **Bug Fixes**
  * Improved ordering and filtering behavior in the documents list.
  * Preserves row state better while the list refreshes.

* **Documentation**
  * Added notes for the new documents list workflow and implementation lessons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->