### PR TITLE
Bundle private workspace deps into the CLI to fix npm install

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,23 +34,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build CLI (and workspace deps)
+      - name: Build CLI (bundles private workspace deps inline)
         run: pnpm --filter @wafflebase/cli... build
 
       - name: Run CLI tests
         run: pnpm --filter @wafflebase/cli test
 
-      - name: Publish @wafflebase/docs to npm
-        run: |
-          VERSION=$(node -p "require('./packages/docs/package.json').version")
-          if npm view "@wafflebase/docs@${VERSION}" version > /dev/null 2>&1; then
-            echo "@wafflebase/docs@${VERSION} already published, skipping"
-          else
-            pnpm --filter @wafflebase/docs publish --access public --no-git-checks
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+      # @wafflebase/docs, @wafflebase/slides and @wafflebase/tokens are private
+      # workspace packages bundled directly into dist/bin.js by the CLI build,
+      # so the CLI is the only npm artifact we publish.
       - name: Publish @wafflebase/cli to npm
         run: |
           VERSION=$(node -p "require('./packages/cli/package.json').version")

--- a/docs/tasks/active/20260707-cli-bundle-workspace-deps-lessons.md
+++ b/docs/tasks/active/20260707-cli-bundle-workspace-deps-lessons.md
@@ -1,0 +1,54 @@
+# Lessons — CLI bundle workspace deps
+
+## `workspace:*` + `private: true` = unpublishable dependency
+
+`pnpm publish` rewrites `workspace:*` to the concrete version. If that
+dependency is `"private": true` (never published), the published package
+declares a version that 404s on `npm install`. Any runtime `dependencies`
+entry pointing at a private workspace package is a publish-time landmine.
+Rule: a publishable package's `dependencies` must contain only
+registry-resolvable packages — bundle private workspace deps inline instead.
+
+## Check whether the built dist is already self-contained before adding deps
+
+The instinct was to compute the union of transitive third-party deps and add
+them to the CLI. But the docs/slides **Vite library builds inline all their
+deps** (zero bare imports in `dist/*.js`). Verifying that first
+(`grep` for bare `import ... from` in the dist) saved adding jszip/nspell/etc.
+Always inspect the actual build output before reasoning about its deps.
+
+## Bundling flattens the output tree — runtime path resolution breaks
+
+`createRequire(import.meta.url)` + `require('../../package.json')` worked under
+`tsc` (output mirrored `src/`, so `dist/commands/root.js` → `../../` = pkg root)
+and under `tsx` dev (`src/commands/root.ts` → `../../` = pkg root). After tsup
+bundles everything into a flat `dist/bin.js`, `../../` points one level too high.
+
+Fix: replace the **runtime** resolution with a **static** `import pkg from
+'../../package.json' with { type: 'json' }`. esbuild resolves static imports at
+build time relative to the *source* file and inlines the value, so it's correct
+regardless of where the bundled output lands. Reserve `createRequire`/
+`import.meta.url` path math for things that must be read from disk at runtime —
+and remember a bundler moves that "runtime location."
+
+## esbuild JSON: default import inlines the whole file; named import tree-shakes
+
+`import pkg from './package.json'` (default) makes esbuild embed the *entire*
+manifest into the bundle — including `devDependencies` with `workspace:*`
+strings, which is confusing residue in a published single-file CLI. Use a
+**named** import — `import { version } from './package.json'` — and esbuild's
+JSON loader inlines only that key.
+
+Gotcha: the import attribute forces the opposite. `import { version } from
+'./package.json' with { type: 'json' }` fails to build — under the
+`type: 'json'` spec assertion esbuild exposes only a *default* export, so the
+named import has "No matching export." TypeScript's `resolveJsonModule` happily
+typechecks it (it synthesizes named exports), so the error only shows at bundle
+time. Drop the attribute to get tree-shakeable named JSON imports.
+
+## Verify the bundle by executing a bundled code path, not just grepping
+
+Grepping `dist/bin.js` for `@wafflebase` proves no import remains, but minified
+symbol renaming (`BUILT_IN_LAYOUTS` → gone) means grep can't confirm the code
+*works*. Running `slides import --dry-run` against a real `.pptx` exercised the
+inlined `importPptx` end-to-end — the real proof.

--- a/docs/tasks/active/20260707-cli-bundle-workspace-deps-todo.md
+++ b/docs/tasks/active/20260707-cli-bundle-workspace-deps-todo.md
@@ -1,0 +1,90 @@
+# CLI: bundle private workspace deps to fix npm install 404
+
+## Problem
+
+`npm install -g @wafflebase/cli` fails:
+
+```
+404 '@wafflebase/slides@0.4.9' is not in this registry.
+```
+
+Root cause: the published `@wafflebase/cli` declares `@wafflebase/slides`
+(and transitively `@wafflebase/tokens`) as runtime deps via `workspace:*`,
+but both are `"private": true` and never published to npm. `pnpm publish`
+rewrites `workspace:*` to the concrete version `0.4.9`, which does not
+exist on the registry.
+
+Note: `@wafflebase/docs` is self-contained (no workspace deps) and IS
+published by the release workflow — it stays external. Only `slides` and
+`tokens` are broken.
+
+## Approach — bundle the private packages into CLI dist
+
+Bundle `@wafflebase/slides` + `@wafflebase/tokens` inline into the CLI
+output with tsup (esbuild). Keep `@wafflebase/docs` and all third-party
+deps external.
+
+## Tasks
+
+- [x] Add `tsup` devDependency + `tsup.config.ts` (entry `src/bin.ts`,
+      ESM, node20, `noExternal: [/^@wafflebase\//]`, shebang preserved,
+      dts off).
+- [x] Switch `build` script to tsup; keep `typecheck` on `tsc --noEmit`.
+- [x] Confirm bundled workspace dists are fully self-contained (docs +
+      slides Vite libs already inline all third-party deps) → no new CLI
+      third-party deps required.
+- [x] Update `package.json`: move `@wafflebase/docs` + `@wafflebase/slides`
+      to `devDependencies` (build-time only); no `@wafflebase/*` runtime deps.
+- [x] Fix `root.ts` version read: `createRequire('../../package.json')`
+      resolved at runtime against the (now flattened) output path → switch to
+      a static `import pkg from '../../package.json'`, resolved by esbuild
+      at build time relative to the source file.
+- [x] Drop the redundant `@wafflebase/docs` publish step from
+      `npm-publish.yml`; mark `@wafflebase/docs` `private: true`.
+- [x] Verify: `--version`/`--help` run; `slides import --dry-run` parses a
+      real `.pptx` through the bundled slides code; zero `import '@wafflebase/*'`
+      in `dist/bin.js`.
+- [x] `npm pack` shows only `README.md, dist/bin.js, package.json`, deps free
+      of `@wafflebase/*`.
+- [x] `pnpm cli typecheck && pnpm cli test` (208 pass); docs/slides
+      typecheck+test green; `verify:architecture` green; `--frozen-lockfile` ok.
+
+## Review
+
+Root cause was a published `@wafflebase/cli` whose `workspace:*` deps
+(`@wafflebase/slides` → `@wafflebase/tokens`) were `private: true` and never
+on npm; pnpm rewrote them to `0.4.9` at publish → `npm install` 404.
+
+Fix: bundle every `@wafflebase/*` package inline via tsup (esbuild) into a
+single `dist/bin.js`. Because the docs/slides Vite library builds already
+inline all their third-party deps, the CLI gained **no** new runtime deps —
+the published package now declares only registry-resolvable third-party deps
+and ships as `README.md + dist/bin.js + package.json`.
+
+Notable gotcha captured in lessons: bundling flattens the output tree, so any
+**runtime** relative-path resolution (`createRequire(import.meta.url)` +
+`../../package.json`) breaks; use a static import so the bundler resolves it
+at build time against the source location instead.
+
+Bundle size: 4.31 MB single file (acceptable for a CLI; contains docs+slides
+engines). `docs` is now `private` like the other internal packages, and the
+CLI is the sole npm artifact.
+
+## Code review dispositions (workflow review, high effort)
+
+- **[fixed] `root.ts` whole-manifest inline** — default JSON import embedded the
+  entire package.json (incl. `workspace:*` devDeps) in the bundle. Switched to a
+  named import `import { version }` → esbuild tree-shakes; bundle now has no
+  `workspace:*` / `@wafflebase/*` manifest strings. (Attribute `with { type:
+  'json' }` had to be dropped — see lessons.)
+- **[known limitation] published devDependencies show `@wafflebase/{docs,slides}@0.4.9`**
+  — pnpm rewrites `workspace:*` at publish. These are `devDependencies`, which
+  `npm install @wafflebase/cli` does not fetch, so the reported install path is
+  unaffected; only dev-dep-walking tooling would 404. They must stay declared so
+  pnpm symlinks them for the build-time tsup resolution. Inherent to publishing a
+  monorepo leaf that build-depends on private siblings.
+- **[intended] docs no longer published to npm** — it was only ever a transitive
+  CLI dep with no external consumer; now bundled + marked private.
+- **[intentional] `sourcemap: false`** — the 4.3 MB bundle is mostly minified
+  third-party; shipping a same-size map (unused without `--enable-source-maps`)
+  isn't worth the published-artifact weight.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsup",
     "dev": "tsx src/bin.ts",
     "test": "vitest --run",
     "test:watch": "vitest",
@@ -22,8 +22,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@wafflebase/docs": "workspace:*",
-    "@wafflebase/slides": "workspace:*",
     "@xmldom/xmldom": "^0.9.10",
     "commander": "^13.0.0",
     "fontkit": "^2.0.4",
@@ -35,8 +33,11 @@
     "@types/fontkit": "^2.0.0",
     "@types/node": "^25.4.0",
     "@vitest/coverage-v8": "4.1.8",
+    "@wafflebase/docs": "workspace:*",
+    "@wafflebase/slides": "workspace:*",
     "eslint": "^9.18.0",
     "jszip": "^3.10.1",
+    "tsup": "^8.5.1",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.8"

--- a/packages/cli/src/commands/root.ts
+++ b/packages/cli/src/commands/root.ts
@@ -1,11 +1,14 @@
-import { createRequire } from 'node:module';
 import { Command } from 'commander';
 import { resolveConfig, type CliConfig } from '../config/config.js';
 import { HttpClient } from '../client/http-client.js';
 import type { OutputFormat } from '../output/formatter.js';
-
-const require = createRequire(import.meta.url);
-const { version } = require('../../package.json') as { version: string };
+// Named import so esbuild's JSON loader inlines only the `version` string
+// (tree-shaking the rest of the manifest, incl. workspace:* devDependencies,
+// out of the bundle) and resolves it at build time relative to this source
+// file — the bundled single-file `dist/bin.js` then has no runtime dependency
+// on package.json's on-disk location. No `with { type: 'json' }` attribute:
+// under that spec assertion esbuild exposes only a default export.
+import { version } from '../../package.json';
 
 export interface GlobalOpts {
   server?: string;

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+// The CLI depends on the private workspace packages `@wafflebase/docs`,
+// `@wafflebase/slides` (and transitively `@wafflebase/tokens`). Those are
+// never published to npm, so a plain `tsc` build leaves the published CLI
+// with `workspace:*`-derived deps that 404 on `npm install`. Bundle every
+// `@wafflebase/*` package inline so the published CLI is self-contained and
+// carries no private workspace deps. Third-party deps stay external and are
+// declared in package.json `dependencies`.
+export default defineConfig({
+  entry: { bin: 'src/bin.ts' },
+  format: 'esm',
+  platform: 'node',
+  target: 'node20',
+  noExternal: [/^@wafflebase\//],
+  clean: true,
+  dts: false,
+  splitting: false,
+  sourcemap: false,
+});

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@wafflebase/docs",
   "version": "0.4.9",
+  "private": true,
   "license": "Apache-2.0",
   "description": "Canvas-based document editor for Wafflebase",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,12 +262,6 @@ importers:
 
   packages/cli:
     dependencies:
-      '@wafflebase/docs':
-        specifier: workspace:*
-        version: link:../docs
-      '@wafflebase/slides':
-        specifier: workspace:*
-        version: link:../slides
       '@xmldom/xmldom':
         specifier: ^0.9.10
         version: 0.9.10
@@ -296,12 +290,21 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.8
         version: 4.1.8(vitest@4.1.8)
+      '@wafflebase/docs':
+        specifier: workspace:*
+        version: link:../docs
+      '@wafflebase/slides':
+        specifier: workspace:*
+        version: link:../slides
       eslint:
         specifier: ^9.18.0
         version: 9.24.0(jiti@2.6.1)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@microsoft/api-extractor@7.52.4(@types/node@25.4.0))(@swc/core@1.11.20(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -4682,6 +4685,9 @@ packages:
   antlr4ts@0.5.0-alpha.4:
     resolution: {integrity: sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -4858,6 +4864,12 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: 0.25.0
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -4865,6 +4877,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
@@ -5716,6 +5732,9 @@ packages:
     resolution: {integrity: sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==}
     engines: {node: '>=12'}
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -6494,6 +6513,10 @@ packages:
     resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
     engines: {node: '>=13.2.0'}
 
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
@@ -6742,6 +6765,9 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -7090,6 +7116,24 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: 8.5.10
+      tsx: ^4.8.1
+      yaml: 2.8.3
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -7609,6 +7653,10 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
@@ -7715,6 +7763,11 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
     engines: {node: '>=14.18.0'}
@@ -7798,6 +7851,13 @@ packages:
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
     engines: {node: '>=20'}
@@ -7813,6 +7873,9 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
@@ -7873,6 +7936,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   ts-jest@29.3.1:
     resolution: {integrity: sha512-FT2PIRtZABwl6+ZCry8IY7JZ3xMuppsEV9qFVHOVe8jDzggwUZ9TsM4chyJxL9yi6LvkqcZYU3LmapEE454zBQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
@@ -7931,6 +7997,25 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: 8.5.10
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -9073,7 +9158,7 @@ snapshots:
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
-      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
@@ -10145,7 +10230,7 @@ snapshots:
 
   '@jridgewell/source-map@0.3.6':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -12831,6 +12916,8 @@ snapshots:
 
   antlr4ts@0.5.0-alpha.4: {}
 
+  any-promise@1.3.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -13056,11 +13143,18 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bundle-require@5.1.0(esbuild@0.28.1):
+    dependencies:
+      esbuild: 0.28.1
+      load-tsconfig: 0.2.5
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
 
   bytes@3.1.2: {}
+
+  cac@6.7.14: {}
 
   cacheable-lookup@7.0.0: {}
 
@@ -13960,6 +14054,12 @@ snapshots:
   find-versions@5.1.0:
     dependencies:
       semver-regex: 4.0.5
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.7.4
+      rollup: 4.59.0
 
   flat-cache@4.0.1:
     dependencies:
@@ -14944,6 +15044,8 @@ snapshots:
 
   load-esm@1.0.3: {}
 
+  load-tsconfig@0.2.5: {}
+
   loader-runner@4.3.1: {}
 
   local-pkg@1.1.1:
@@ -15164,6 +15266,12 @@ snapshots:
       type-is: 1.6.18
 
   mute-stream@2.0.0: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
 
@@ -15533,6 +15641,15 @@ snapshots:
   pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.10
+      tsx: 4.21.0
+      yaml: 2.8.3
 
   postcss@8.5.10:
     dependencies:
@@ -16073,6 +16190,8 @@ snapshots:
 
   source-map@0.7.4: {}
 
+  source-map@0.7.6: {}
+
   space-separated-tokens@2.0.2: {}
 
   speakingurl@14.0.1: {}
@@ -16165,6 +16284,16 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
   superagent@10.3.0:
     dependencies:
       component-emitter: 1.3.1
@@ -16255,6 +16384,14 @@ snapshots:
     dependencies:
       b4a: 1.6.7
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   thread-stream@4.2.0:
     dependencies:
       real-require: 1.0.0
@@ -16266,6 +16403,8 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.2.4: {}
 
@@ -16313,6 +16452,8 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-interface-checker@0.1.13: {}
 
   ts-jest@29.3.1(@babel/core@7.29.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.6))(esbuild@0.25.0)(jest@29.7.0(@types/node@22.14.1)(ts-node@10.9.2(@swc/core@1.11.20(@swc/helpers@0.5.21))(@types/node@22.14.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
@@ -16381,6 +16522,36 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(@microsoft/api-extractor@7.52.4(@types/node@25.4.0))(@swc/core@1.11.20(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.28.1)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.28.1
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
+      resolve-from: 5.0.0
+      rollup: 4.59.0
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.52.4(@types/node@25.4.0)
+      '@swc/core': 1.11.20(@swc/helpers@0.5.21)
+      postcss: 8.5.10
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsx@4.21.0:
     dependencies:


### PR DESCRIPTION
## Summary

`npm install -g @wafflebase/cli` fails with a 404:

```
404 '@wafflebase/slides@0.4.9' is not in this registry.
```

**Root cause:** the published `@wafflebase/cli` declares `@wafflebase/slides`
(and transitively `@wafflebase/tokens`) as runtime deps via `workspace:*`.
`pnpm publish` rewrites those to the concrete `0.4.9`, but both packages are
`"private": true` and never reach the npm registry, so the install can't
resolve them. (`@wafflebase/docs` is self-contained and was published, but
the resolution fails at `slides` first.)

**Fix:** bundle every `@wafflebase/*` package inline with tsup (esbuild) so the
published CLI is a single self-contained `dist/bin.js` carrying no private
workspace deps. The `docs`/`slides` Vite library builds already inline all of
their third-party deps, so the CLI gains **no** new runtime dependencies — its
published `dependencies` now list only registry-resolvable packages, and the
tarball ships as `README.md + dist/bin.js + package.json`.

Additional cleanups:
- `root.ts` reads `version` via a **named** JSON import so esbuild tree-shakes
  the rest of the manifest (incl. `workspace:*` devDep strings) out of the
  bundle. Switching from the old runtime `createRequire('../../package.json')`
  was required because bundling flattens the output tree and broke that
  runtime relative path.
- Drop the now-redundant `@wafflebase/docs` publish step from `npm-publish.yml`
  and mark `docs` `private`, leaving the CLI as the sole npm artifact.

> Note: the already-published `0.4.9` on npm can't be repaired retroactively —
> this fix takes effect on the next release.

## Known limitation

The published manifest's **devDependencies** still show
`@wafflebase/{docs,slides}@0.4.9` (pnpm rewrites `workspace:*` at publish).
`npm install @wafflebase/cli` does not fetch a dependency's devDependencies, so
the install/run path is unaffected; they must stay declared so pnpm symlinks
them for the build-time tsup resolution.

## Test plan

- [x] `pnpm verify:fast` — green (frontend/backend/sheets/slides/cli/docs)
- [x] `npm pack` → tarball = `README.md, dist/bin.js, package.json`; runtime
      `dependencies` free of `@wafflebase/*`
- [x] `dist/bin.js` has zero `import '@wafflebase/*'`; no `workspace:*` residue
- [x] `wafflebase --version` / `--help` run from the bundle
- [x] `wafflebase slides import --dry-run <sample>.pptx` parses a real PPTX
      through the inlined slides engine
- [x] cli 208 / docs 1083 / slides 2513 tests pass; tsx dev mode works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bundled CLI build so the published command includes its required internal packages and installs more reliably.
  * Added new documentation about safely packaging a CLI with workspace dependencies.

* **Bug Fixes**
  * Fixed publish/install issues caused by unpublished workspace dependencies.
  * Updated CLI startup to read package version information in a way that works correctly in the bundled output.

* **Chores**
  * Stopped publishing the docs package to npm and limited publishing to the CLI artifact only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->