### PR TITLE
Close out the v0.5.0 release todo

### DIFF
--- a/docs/tasks/active/20260707-release-v0.5.0-todo.md
+++ b/docs/tasks/active/20260707-release-v0.5.0-todo.md
@@ -36,18 +36,18 @@ the `POST /files` + `GET /documents/:id/file` endpoints.
 - [x] Commit on `release/v0.5.0`.
 - [x] `/code-review` skipped — diff is version-bump + doc-archive/reconcile
       only (no executable code), same as prior releases.
-- [ ] Push + open PR (Summary + Test plan).
+- [x] Push + open PR (Summary + Test plan) — PR #452 (squash `ade64124e`).
 
 ## Post-merge release
 
-- [ ] Sync `main`; confirm `main` at `0.5.0`.
-- [ ] Annotated tag `v0.5.0` on the merge commit, pushed.
-- [ ] GitHub Release `v0.5.0` published with categorised highlights +
-      Contributors.
-- [ ] `npm-publish.yml` + `docker-publish.yml` workflows succeed.
-- [ ] Confirm `@wafflebase/cli@0.5.0` on npm (docs is now `private`; see
-      #449) and `yorkieteam/wafflebase:v0.5.0` in the registry.
-- [ ] **New infra** — flag to devops: the PDF viewer needs a blob store.
+- [x] Sync `main`; confirm `main` at `0.5.0` (merge commit `ade64124e`).
+- [x] Annotated tag `v0.5.0` ("Release v0.5.0") on the merge commit, pushed.
+- [x] GitHub Release `v0.5.0` published (marked latest) with categorised
+      highlights + both maintainers as Contributors.
+- [x] `Publish to npm` + `Docker Publish` release-triggered runs succeeded.
+- [x] Confirm `@wafflebase/cli@0.5.0` on npm (docs 404s as intended — now
+      `private`; see #449) and `yorkieteam/wafflebase:v0.5.0` in the registry.
+- [x] **New infra** — flag to devops: the PDF viewer needs a blob store.
       Set `FILE_STORAGE_ENDPOINT` / `_BUCKET` / `_REGION` / `_ACCESS_KEY` /
       `_SECRET_KEY` (dev defaults to MinIO on `:9000`) in the deploy env, or
       PDF upload/serving fails in production (dev-default creds are refused
@@ -71,4 +71,26 @@ the `POST /files` + `GET /documents/:id/file` endpoints.
 
 ## Review
 
-_(fill in after the release ships)_
+Shipped as PR #452 (squash `ade64124e`, "Bump version to v0.5.0"). Root +
+8 packages bumped `0.4.9 → 0.5.0`; 4 shipped task docs (7 files) archived
+into `archive/2026/07/` (8 active, 346 archived). Two docs shipped this
+window with boxes left unticked and were reconciled: `documents-list-sort-
+search` (#448) gained ticked boxes + an as-shipped Review, and `pdf-viewer`
+(#451) had its placeholder Review replaced with the as-shipped writeup.
+
+Post-merge, all verified:
+- Tag `v0.5.0` (annotated, "Release v0.5.0") on `ade64124e`, pushed.
+- GitHub Release `v0.5.0` published (marked latest), categorised highlights
+  + both maintainers as Contributors.
+- `Publish to npm` + `Docker Publish` release-triggered runs succeeded.
+- Live: `@wafflebase/cli@0.5.0` on npm (`@wafflebase/docs` now `private`,
+  404s as intended per #449); `yorkieteam/wafflebase:v0.5.0` on Docker Hub.
+
+Per the established pattern (the v0.4.9 release todo was closed out in #447,
+one cycle later), this release todo stays active until the next release's
+archive sweep.
+
+Out of scope (external repo): bumping the server image in
+`yorkie-team/devops` — but note this release introduces a **new** blob-store
+dependency (`FILE_STORAGE_*` env + MinIO/S3) that the deploy env must
+provide, not just a version bump.


### PR DESCRIPTION
## Summary

Doc-only follow-up to #452: v0.5.0 is now tagged, released, and published, so this ticks the push/PR + post-merge boxes in the release todo and adds the as-shipped **Review**.

Verified post-merge:
- `main` at `0.5.0` (merge `ade64124e`); annotated tag `v0.5.0` pushed.
- GitHub Release `v0.5.0` published (latest).
- `Publish to npm` + `Docker Publish` release runs succeeded.
- Live: `@wafflebase/cli@0.5.0` on npm (`@wafflebase/docs` 404s as intended — now `private` per #449); `yorkieteam/wafflebase:v0.5.0` on Docker Hub.

The release todo stays active until the next release's archive sweep, matching the v0.4.9 → #447 pattern.

## Test plan

No executable code — task-doc bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)