### PR TITLE
Enable document rename in the PDF viewer detail view

### DIFF
--- a/packages/frontend/src/app/files/file-detail.tsx
+++ b/packages/frontend/src/app/files/file-detail.tsx
@@ -1,8 +1,8 @@
 import { Navigate, useNavigate, useParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo } from "react";
 import { fetchMe } from "@/api/auth";
-import { fetchDocument } from "@/api/documents";
+import { fetchDocument, renameDocument } from "@/api/documents";
 import { toast } from "sonner";
 import { Loader } from "@/components/loader";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
@@ -15,6 +15,7 @@ import { PdfViewer } from "./pdf-viewer";
 
 function FileLayout({ documentId }: { documentId: string }) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const { data: documentData, isError: isDocumentError } = useQuery({
     queryKey: ["document", documentId],
@@ -84,6 +85,19 @@ function FileLayout({ documentId }: { documentId: string }) {
     [navigate],
   );
 
+  const handleRenameDocument = useCallback(
+    async (newTitle: string) => {
+      try {
+        await renameDocument(documentId, newTitle);
+        queryClient.invalidateQueries({ queryKey: ["document", documentId] });
+        queryClient.invalidateQueries({ queryKey: ["documents"] });
+      } catch {
+        toast.error("Failed to rename document");
+      }
+    },
+    [documentId, queryClient],
+  );
+
   return (
     <SidebarProvider>
       <AppSidebar
@@ -94,7 +108,11 @@ function FileLayout({ documentId }: { documentId: string }) {
         onWorkspaceChange={handleWorkspaceChange}
       />
       <SidebarInset>
-        <SiteHeader title={documentData?.title ?? "Loading..."} />
+        <SiteHeader
+          title={documentData?.title ?? "Loading..."}
+          editable
+          onRename={handleRenameDocument}
+        />
         <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
           <PdfViewer fileUrl={pdfFileUrl(documentId)} />
         </div>


### PR DESCRIPTION
## Summary

The PDF viewer (`/f/:id`) rendered its title as a static, non-interactive `<h1>` — unlike the sheets/docs/slides detail views, users could not rename a PDF document from its detail screen.

Root cause: `file-detail.tsx` omitted the `editable` / `onRename` props that the other three detail views pass to the shared `SiteHeader`. The backend `PATCH /documents/:id` and the `renameDocument` client already work for PDF documents (a PDF is an ordinary `Document` row; only blob storage/serving differs) — the rename affordance was simply never wired up.

Changes in `packages/frontend/src/app/files/file-detail.tsx`:
- Import `renameDocument` + `useQueryClient`, add a `handleRenameDocument` callback mirroring the other viewers (invalidates the `["document", id]` and `["documents"]` caches on success).
- Pass `editable` + `onRename` to `SiteHeader` so the title becomes click-to-edit (commit on Enter/blur).
- Wrap the PATCH in a `try/catch` that surfaces a `toast.error` on failure instead of swallowing the rejection (a gap flagged in code review; `toast` was already imported).

## Test plan

- [x] `pnpm verify:fast` green (lint + 1083 unit tests pass)
- [x] `tsc --noEmit` on the frontend package passes
- [x] Manual: open a PDF document, click the title in the header, edit and press Enter → title persists and updates the documents list

🤖 Generated with [Claude Code](https://claude.com/claude-code)