### PR TITLE
Harden pdfjs-assets dev middleware (dir guard + Content-Length)

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,4 +1,10 @@
-import { cpSync, createReadStream, existsSync, readFileSync } from "fs";
+import {
+  cpSync,
+  createReadStream,
+  existsSync,
+  readFileSync,
+  statSync,
+} from "fs";
 import { createRequire } from "module";
 import path from "path";
 import tailwindcss from "@tailwindcss/vite";
@@ -98,16 +104,29 @@ function pdfjsAssets(): Plugin {
         const mount = mounts.find((m) => url.startsWith(m.prefix));
         if (!mount) return next();
         const file = path.join(mount.dir, url.slice(mount.prefix.length));
-        // Contain reads to the mount directory (block `..` traversal). Append
-        // path.sep so a sibling dir sharing the prefix (…/cmaps_evil) can't
-        // match …/cmaps.
-        if (!file.startsWith(mount.dir + path.sep) || !existsSync(file)) {
+        // Require a regular file strictly inside the mount directory. The
+        // trailing path.sep blocks `..` traversal and sibling dirs sharing the
+        // prefix (…/cmaps_evil); isFile() rejects directory reads such as the
+        // mount root itself, which would otherwise EISDIR the stream and hang
+        // the request (an unhandled stream error can also take down the dev
+        // server).
+        const stat =
+          file.startsWith(mount.dir + path.sep) && existsSync(file)
+            ? statSync(file)
+            : null;
+        if (!stat || !stat.isFile()) {
           res.statusCode = 404;
           res.end();
           return;
         }
         res.setHeader("Content-Type", "application/octet-stream");
-        createReadStream(file).pipe(res);
+        res.setHeader("Content-Length", String(stat.size));
+        const stream = createReadStream(file);
+        stream.on("error", () => {
+          res.statusCode = 500;
+          res.end();
+        });
+        stream.pipe(res);
       }) as Connect.NextHandleFunction);
     },
     writeBundle() {


### PR DESCRIPTION
## Summary

Follow-up to #456 (which added the `pdfjs-assets` Vite plugin). This hardens
the plugin's **dev-server** middleware, addressing issues surfaced by a code
review of the PDF-viewer fix.

The middleware streamed any existing path with `createReadStream` and **no
error handler**. So a request whose resolved path is a *directory* — e.g. the
mount root `/pdfjs/cmaps/` — passed the `existsSync` check and then emitted an
unhandled `EISDIR`:

- the response never ended → the request **hangs forever**, and
- the unhandled stream `error` can **crash the Vite dev server**.

### Changes (`packages/frontend/vite.config.ts`, dev middleware only)

- Require a **regular file** via `statSync().isFile()` — rejects directory
  reads (mount root, etc.) with a 404 instead of EISDIR.
- Attach a stream `'error'` handler that responds `500` instead of leaving the
  socket open / throwing.
- Set `Content-Length` from the stat size.

The existing `..`/sibling-dir traversal guard (`mount.dir + path.sep`) is
unchanged. pdf.js never requests the bare directory, so this is
defense-in-depth; behavior for real `.bcmap`/font requests is unchanged.

> Note: the core "PDF text renders blank on older browsers" fix (legacy pdf.js
> build + `cMapUrl`/`standardFontDataUrl` wiring) already shipped in #456 — this
> PR is only the middleware hardening delta.

## Test plan

- `pnpm --filter @wafflebase/frontend exec tsc --noEmit` — passes
- `pnpm --filter @wafflebase/frontend exec eslint vite.config.ts` — passes
- `pnpm --filter @wafflebase/frontend exec vitest run tests/app/files/pdf-viewer.test.tsx` — passes
- Manual (dev server):
  - `GET /pdfjs/cmaps/Adobe-Korea1-UCS2.bcmap` → `200`, correct `Content-Length`
  - `GET /pdfjs/cmaps/` (directory) → `404` (previously hung)
  - `GET /pdfjs/cmaps/nope.bcmap` → `404`
  - Korean/CJK PDF renders text correctly in the viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnM2D7vrJzHfec8jgaBUM1
