### PR TITLE
Redirect already-members to the workspace on invite accept

### DIFF
--- a/packages/backend/src/workspace/workspace.service.spec.ts
+++ b/packages/backend/src/workspace/workspace.service.spec.ts
@@ -2,8 +2,8 @@ import {
   ForbiddenException,
   NotFoundException,
   GoneException,
-  ConflictException,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from 'src/database/prisma.service';
 import { WorkspaceService } from './workspace.service';
 
@@ -423,7 +423,9 @@ describe('WorkspaceService', () => {
 
       const result = await service.acceptInvite('tok-1', 5);
 
-      expect(result).toEqual({ workspaceId: '11111111-1111-1111-1111-111111111111' });
+      expect(result).toEqual({
+        workspaceId: '11111111-1111-1111-1111-111111111111',
+      });
       expect(prisma.workspaceMember.create).toHaveBeenCalledWith({
         data: { workspaceId: '11111111-1111-1111-1111-111111111111', userId: 5, role: 'member' },
       });
@@ -450,7 +452,7 @@ describe('WorkspaceService', () => {
       ).rejects.toBeInstanceOf(GoneException);
     });
 
-    it('throws ConflictException if user is already a member', async () => {
+    it('is idempotent: returns the workspace if already a member', async () => {
       prisma.workspaceInvite.findUnique.mockResolvedValue({
         token: 'tok-1',
         workspaceId: '11111111-1111-1111-1111-111111111111',
@@ -461,9 +463,47 @@ describe('WorkspaceService', () => {
         role: 'member',
       });
 
-      await expect(
-        service.acceptInvite('tok-1', 5),
-      ).rejects.toBeInstanceOf(ConflictException);
+      await expect(service.acceptInvite('tok-1', 5)).resolves.toEqual({
+        workspaceId: '11111111-1111-1111-1111-111111111111',
+      });
+      expect(prisma.workspaceMember.create).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent under a concurrent create race (P2002)', async () => {
+      prisma.workspaceInvite.findUnique.mockResolvedValue({
+        token: 'tok-1',
+        workspaceId: '11111111-1111-1111-1111-111111111111',
+        role: 'member',
+        expiresAt: null,
+      });
+      // A concurrent accept created the row after this request's check,
+      // so create() rejects with a unique-constraint violation.
+      prisma.workspaceMember.findUnique.mockResolvedValue(null);
+      prisma.workspaceMember.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('Unique constraint', {
+          code: 'P2002',
+          clientVersion: 'test',
+        }),
+      );
+
+      await expect(service.acceptInvite('tok-1', 5)).resolves.toEqual({
+        workspaceId: '11111111-1111-1111-1111-111111111111',
+      });
+    });
+
+    it('rethrows non-unique-constraint create errors', async () => {
+      prisma.workspaceInvite.findUnique.mockResolvedValue({
+        token: 'tok-1',
+        workspaceId: '11111111-1111-1111-1111-111111111111',
+        role: 'member',
+        expiresAt: null,
+      });
+      prisma.workspaceMember.findUnique.mockResolvedValue(null);
+      prisma.workspaceMember.create.mockRejectedValue(new Error('db down'));
+
+      await expect(service.acceptInvite('tok-1', 5)).rejects.toThrow(
+        'db down',
+      );
     });
   });
 

--- a/packages/backend/src/workspace/workspace.service.ts
+++ b/packages/backend/src/workspace/workspace.service.ts
@@ -3,8 +3,8 @@ import {
   ForbiddenException,
   NotFoundException,
   GoneException,
-  ConflictException,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../database/prisma.service';
 
 @Injectable()
@@ -139,14 +139,32 @@ export class WorkspaceService {
         workspaceId_userId: { workspaceId: invite.workspaceId, userId },
       },
     });
-    if (existing) throw new ConflictException('Already a member');
-    await this.prisma.workspaceMember.create({
-      data: {
-        workspaceId: invite.workspaceId,
-        userId,
-        role: invite.role,
-      },
-    });
+    // Accepting is idempotent: an already-member is sent to the workspace
+    // rather than erroring, so a re-visited invite link just opens it. The
+    // invite never changes the role of an existing member.
+    if (existing) {
+      return { workspaceId: invite.workspaceId };
+    }
+    try {
+      await this.prisma.workspaceMember.create({
+        data: {
+          workspaceId: invite.workspaceId,
+          userId,
+          role: invite.role,
+        },
+      });
+    } catch (err) {
+      // A concurrent accept (double-click, two tabs) can create the row
+      // between the check above and here; treat the unique-constraint clash
+      // as an idempotent success rather than surfacing a 500.
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === 'P2002'
+      ) {
+        return { workspaceId: invite.workspaceId };
+      }
+      throw err;
+    }
     return { workspaceId: invite.workspaceId };
   }
 


### PR DESCRIPTION
## Summary

Clicking a workspace invite link you have **already accepted** dead-ended
on a red **"Already a member"** message instead of taking you into the
workspace.

Root cause: `acceptInvite` threw a `409 ConflictException` for existing
members, and that error carried no `workspaceId`, so the invite-accept
page had nothing to redirect with.

This makes invite acceptance **idempotent**:

- An existing member now returns `{ workspaceId }` instead of throwing, so
  the invite-accept page's existing `navigate('/w/:id')` runs for both
  first-time and repeat accepts — a re-visited link just opens the workspace.
- A concurrent accept (double-click, two open tabs) that loses the
  check-then-create race is caught via the Prisma `P2002` unique-constraint
  code and also treated as an idempotent success rather than a 500.
- `invite-accept.tsx` needs no change; its `.catch` now only fires for
  genuine errors (invite not found / expired).

Fixes #458 

### Known limitation (out of scope)

A re-issued invite with a **different role** does not upgrade an existing
member — the accept is a no-op redirect. This matches prior behavior
(the old 409 path never applied a role change either); only the error
surface changed. Role-change-via-invite is a separate feature.

## Test plan

- `pnpm --filter @wafflebase/backend test -- workspace.service` — 34 passing,
  including new cases: idempotent re-accept, idempotent concurrent-race
  (`P2002`), and rethrow of non-unique-constraint create errors.
- `pnpm verify:fast` — green.
- Manual smoke in `pnpm dev`: re-visiting an already-accepted invite link
  now redirects into `/w/:workspaceId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Accepting a workspace invite is now idempotent when the user is already a member.
  - Concurrent invite acceptance no longer fails when membership is created simultaneously.
  - Unexpected membership creation errors continue to be reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->