### PR TITLE
Slides PPTX: inherit layout background + geometry across masters

### DIFF
--- a/docs/design/slides/slides-themes-layouts-import.md
+++ b/docs/design/slides/slides-themes-layouts-import.md
@@ -381,6 +381,82 @@ choice is **reuse existing**.
 A single toast summarizes lossy elements: "Imported with N tables
 flattened, M groups expanded, K shapes simplified."
 
+#### Multi-master decks and layout-background inheritance (2026-07-10)
+
+Real decks can carry **several slide masters**, each owning its own set
+of layouts (e.g. the Naver deck: `slideMaster1` owns `slideLayout1–9`,
+`slideMaster2` owns `slideLayout10–21`; slide 1 uses `slideLayout1`). The
+importer walks **every** master in `<p:sldMasterIdLst>` order via
+`orderedMasterTargets`, calling `loadMasterAndLayouts` per master and
+merging all layouts + `layoutMap` entries. The **first** master in that
+list is the *primary*: its color map, `<p:txStyles>`, background, and
+`meta.masterId` drive the deck (our model still stores a single master).
+Secondary masters contribute only their layouts, so every slide can
+resolve the real layout it references. (Previously the importer loaded a
+single master picked by rels-iteration order, silently dropping the other
+master's layouts and their placeholder sizes / backgrounds — which is why
+slide 1's background image went missing.)
+
+PPTX background inheritance is **slide → layout → master**. The runtime
+already resolves this at paint time (`resolveBackgroundFill` /
+`resolveBackgroundImage`), but only the *fill* / master image cascade
+faithfully because imported layouts **collapse onto the 11 built-in layout
+ids** (many OOXML layouts → one id), making a per-layout-id background
+ambiguous. So layout-level `<p:bg>` (a `blipFill` image such as slide 1's
+bottom gradient, or an explicit `solidFill`) is parsed by `parseLayout`,
+carried on `LayoutResolution.background` keyed by the **exact layout part
+path**, and **baked onto each slide that has no `<p:bg>` of its own** in
+`parseSlide` — unambiguous because the slide names its exact layout. A
+baked image keeps the slide's `fill` as the inheritable `background` role
+so theme fill changes still cascade; only the image is pinned. A
+`<p:bgRef>` style-matrix reference (unhandled) or a bare role fill is left
+off so it can't clobber the built-in layout it merges onto.
+
+The same slide → layout inheritance applies to **placeholder geometry**. A
+slide placeholder `<p:sp>` may omit its own `<p:spPr><a:xfrm>` and inherit
+position + size from the matching layout placeholder (e.g. slide 1's "2026
+년 3월" content placeholder `<p:ph idx="10"/>`, whose bottom-left frame lives
+only on `slideLayout1`). `parseLayout` records each layout placeholder's
+scaled frame in `LayoutResolution.placeholderFrames` (keyed
+`"{ooxmlType}:{idx}"`, parallel to the existing `placeholderSizes` font-size
+map), and `parseSp` (`resolvePlaceholderFrame`) fills in each axis the slide
+omits from it: no `<a:xfrm>` at all inherits the whole layout frame, while a
+partial override (offset-only or extent-only `<a:xfrm>`) keeps the slide's
+value on the present axis and inherits the other — otherwise `parseXfrm`
+collapses the missing axis to `0` (a top-left `(0,0,0,0)` box, or a zero-size
+invisible one). (This too only surfaced once multi-master loading actually
+imported `slideLayout1`.) Placeholder keys normalize OOXML type aliases
+(`ctrTitle` → `title`) via `phKey` so a slide `<p:ph type="title"/>` inherits
+a layout that stored its center title as `ctrTitle` (Google-Slides exports).
+
+Known limitations of the collapse (acceptable for v1):
+
+- **One color map for the whole deck.** All slides — and all baked layout
+  backgrounds — resolve `<a:schemeClr>` through the *primary* master's
+  `<p:clrMap>`. A secondary master whose `clrMap` remaps a scheme slot
+  differently will render a `solidFill` layout background off by that slot.
+  Image (`blipFill`) backgrounds are unaffected (no color resolution). The
+  common case (the gradient here) is a `blipFill`.
+- **Eager, per-layout background uploads.** Each layout's `<p:bg>` image is
+  uploaded during import even if no slide references that layout, so a
+  template-heavy deck can leave a few orphan image blobs. Bounded by the
+  layout count; a lazy/at-bake upload pass is deferred.
+- **Primary master = `<p:sldMasterIdLst>` first entry** (was: first
+  `slideMaster` rel, which was iteration-order-dependent and picked the
+  *wrong* master on this deck). Deterministic and matches PowerPoint's
+  canonical primary.
+- **An explicit layout `solidFill` of the `background` role (`schemeClr
+  bg1`) is not baked.** A bare `background`-role fill is, by model
+  definition (`isInheritableFill`), "inherit" — there is no way to mark
+  "explicitly the background role, don't inherit" without a model change.
+  In practice it resolves to the same theme background the master's `bgRef`
+  would, so the visible result matches except in the rare case of a
+  secondary master with a genuinely different (non-`bg1`) background.
+- **`phKey` alias collision.** A single (non-conformant) layout declaring
+  both `<p:ph type="title">` and `<p:ph type="ctrTitle">` at the same `idx`
+  collapses to one key (last wins). Conformant decks never pair them; the
+  alias is what lets the common title/ctrTitle mismatch inherit at all.
+
 #### EMU and slide size
 
 PPTX uses EMU (914 400 EMU = 1 inch). Our logical canvas is fixed at

--- a/docs/tasks/active/20260710-pptx-layout-background-lessons.md
+++ b/docs/tasks/active/20260710-pptx-layout-background-lessons.md
@@ -1,0 +1,41 @@
+# Lessons — PPTX layout background & placeholder geometry
+
+## The visible symptom was two layers away from the root cause
+
+"Slide 1's bottom gradient is missing" looked like a background-parsing
+bug. It was really: (1) the deck has **multiple slide masters** and the
+importer loaded only one (picked by nondeterministic rels-iteration order),
+so slide 1's whole layout (`slideLayout1`) was never imported; and (2) even
+once loaded, layout-level `<p:bg>` and placeholder frames weren't extracted.
+
+**Lesson:** when a fix "should work" but doesn't, instrument the *actual*
+pipeline (I appended per-iteration logs to the real loop) instead of
+re-reasoning. The loop dump — `slideLayout10–21, never slideLayout1` —
+exposed the multi-master truth in one run. Direct-call unit reproduction
+(calling `parseLayout` on the real file) confirmed the parser was fine and
+the bug was upstream in *which* master got loaded.
+
+## Don't trust a coincidental "correct" value
+
+slide 1's `layoutId` resolved to `title-body` — which *looked* right — but
+only because `slideLayout1` has no `type` token (→ `title-body` fallback)
+AND wasn't in `layoutMap` at all. A plausible-looking field masked a total
+layout-resolution miss. Verify the *path* was resolved, not just that the
+final value looks sensible.
+
+## Collapsed identities can't carry per-instance data
+
+Imported layouts collapse onto 11 built-in ids (many OOXML layouts → one
+id), so keying a background/frame by built-in id is ambiguous (a white-solid
+`title-body` layout won over the gradient one). Resolve per **exact layout
+part path** and **bake onto the slide** at import time instead.
+
+## Related: verify:fast doesn't need Docker; e2e proof used a local file
+
+The end-to-end proof imported the user's actual `.pptx` from `~/Downloads`
+via a `describe.skipIf` test — great for proving the fix, but not committed
+(references an uncommitted local file; would just skip in CI). Committed
+coverage is synthetic-fixture unit tests in `layout.test.ts` / `slide.test.ts`.
+
+See also [[project_packages_consume_built_dist]] — tests here run against
+`src` directly, so no rebuild was needed between edits.

--- a/docs/tasks/active/20260710-pptx-layout-background-todo.md
+++ b/docs/tasks/active/20260710-pptx-layout-background-todo.md
@@ -1,0 +1,118 @@
+# PPTX import: layout-level background images dropped
+
+## Problem
+
+Importing `260708_Naver_HQ_발표자료_draft2_KR.pptx`, slide 1 loses its
+bottom gradient. The gradient is not a shape — it is the layout's
+background **image** (`ppt/media/image6.png`, containing the BytePlus
+logo + purple→blue→cyan bottom gradient), referenced from
+`slideLayout1.xml` as `<p:bg><p:bgPr><a:blipFill>`.
+
+### Root cause
+
+PPTX background inheritance is `slide → layout → master`. The runtime
+renderer already implements this: `resolveBackgroundImage()` /
+`resolveBackgroundFill()` (`model/presentation.ts`) walk
+slide → layout → master and read `layout.background.image`.
+
+But the **importer never populates `layout.background`**:
+
+- `slide.ts` parses slide-level `<p:bg>` (only when present; slide1 has none).
+- `master.ts` parses master-level `<p:bg>` (slideMaster1 is a `<p:bgRef>`, no image).
+- `layout.ts` `parseLayout()` maps the OOXML layout onto a built-in layout
+  and reads placeholder font sizes — it **never reads `<p:bg>`**.
+
+So slide1's background resolves to the default theme role fill; the
+layout's gradient image is silently dropped.
+
+Compounding: imported layouts collapse onto the 11 built-in ids and are
+dropped by `dedupeLayouts` (built-ins listed first, first-wins), so the
+background must be overlaid onto the surviving built-in of the same id.
+
+### Deeper root cause found mid-implementation
+
+The background fix alone didn't work. Instrumenting the real import
+revealed the **actual** root cause: the deck has **two slide masters**
+(`slideMaster1` owns `slideLayout1–9`; `slideMaster2` owns
+`slideLayout10–21`). The importer called `loadMasterAndLayouts` **once**
+with `pickRelTarget(presRels, 'slideMaster')`, which returns whichever
+master is first in rels-iteration order — here master2 — so master1's
+layouts (**including slideLayout1**, slide 1's layout) were never loaded.
+slide1's `layoutId` fell back to `title-body` by coincidence, and both its
+layout background *and* placeholder geometry were dropped.
+
+A follow-up report ("2026년 3월" renders top-left instead of bottom-left)
+is the same family: the placeholder has an empty `<p:spPr/>` and inherits
+its frame from the layout placeholder, but the importer only read layout
+placeholder **font sizes**, never their **frames**.
+
+## Plan
+
+Fix 1 — multi-master + layout background:
+- [x] Load **all** masters (`orderedMasterTargets`, `<p:sldMasterIdLst>`
+      order), merge layouts + layoutMaps; first master is primary
+- [x] Export `parseSlideBackground` from `slide.ts` (reuse, no third copy)
+- [x] `layout.ts`: `parseLayout` → async, parse layout `<p:bg>` into
+      `ImportedLayout.background` (image / explicit solid only)
+- [x] Bake layout background onto slides without their own `<p:bg>` in
+      `parseSlide`, keyed on the exact layout part path (collapse-safe)
+- [x] Unit tests: `parseLayout` bg parse; `parseSlide` bakes it
+
+Fix 2 — layout placeholder frame inheritance:
+- [x] `parseLayout` extracts scaled placeholder frames →
+      `LayoutResolution.placeholderFrames`
+- [x] `parseSp` falls back to the layout frame when `<a:xfrm>` is absent
+- [x] Unit tests: layout frame extraction + slide frame inheritance
+
+Verify:
+- [x] `pnpm --filter @wafflebase/slides test` (2563 passing)
+- [x] E2E against the real Naver deck (local, not committed): slide 1
+      resolves the gradient image; "2026년 3월" lands at x=68, y=982
+- [ ] `pnpm verify:fast`
+
+## Review
+
+- Two distinct root causes behind one visible symptom; the background was a
+  red herring until multi-master loading was fixed.
+- Chose to **bake** layout backgrounds/frames onto slides (keyed by exact
+  layout part path) rather than rely on runtime layout inheritance, because
+  imported layouts collapse onto 11 built-in ids and can't carry per-layout
+  data unambiguously.
+- Known limitation (documented): per-master `clrMap` / theme still uses the
+  primary master for all slides. Out of scope; pre-existing.
+
+### Code review (high effort, workflow) — 7 findings, resolved
+
+Fixed:
+- **title/ctrTitle key mismatch** — added `phKey` normalization (shared by
+  layout size/frame storage + slide lookup); also improves font-size
+  inheritance. Test added.
+- **solidFill/failed-upload baking `DEFAULT_BACKGROUND`** — `parseLayoutBackground`
+  now gates on a resolved image OR a non-inheritable fill (exported
+  `isInheritableFill`), so unresolved/bgRef backgrounds keep inheritance
+  open instead of masking it. Removed the duplicated presence guard.
+- **Inherited frame aliasing** — clone the layout `Frame` in `parseSp`.
+
+Accepted as documented limitations (design doc):
+- One deck-wide `clrMap` (primary master) for slides + baked backgrounds —
+  affects only `solidFill` scheme-color backgrounds on a secondary master;
+  `blipFill` (this deck) is unaffected.
+- Eager per-layout background uploads → a few orphan blobs on template-heavy
+  decks; lazy upload deferred.
+
+Intentional (not a regression):
+- Primary master now = `<p:sldMasterIdLst>` first entry (deterministic,
+  canonical) instead of nondeterministic first-rel order.
+
+### Second code review (post-review-fixes) — 4 findings
+
+Fixed:
+- **Partial `<a:xfrm>` collapsing to zero size** — `resolvePlaceholderFrame`
+  now merges each axis (offset / extent) the slide omits from the layout
+  frame, not just the all-absent case. Test added.
+
+Accepted (documented in design doc):
+- Explicit layout `solidFill bg1` not baked — model can't represent an
+  explicit background-role fill vs inherit; resolves to the same theme bg.
+- `phKey` collision only on non-conformant `title`+`ctrTitle`-at-same-idx.
+- Eager per-layout background upload (efficiency; lazy pass deferred).

--- a/packages/slides/src/import/pptx/index.ts
+++ b/packages/slides/src/import/pptx/index.ts
@@ -113,29 +113,61 @@ export async function importPptx(
   const presRels = presRelsXml ? parseRels(presRelsXml) : new Map();
 
   const themeTarget = pickRelTarget(presRels, 'theme');
-  const masterTarget = pickRelTarget(presRels, 'slideMaster');
 
   const importedTheme = themeTarget
     ? await loadTheme(archive, 'ppt/presentation.xml', themeTarget)
     : undefined;
 
-  const masterAndLayouts = masterTarget
-    ? await loadMasterAndLayouts(
-        archive,
-        'ppt/presentation.xml',
-        masterTarget,
-        importedTheme?.id ?? 'default-light',
-        report,
-        upload,
-        scale,
-      )
-    : {
-        master: undefined,
-        layouts: [] as Layout[],
-        layoutMap: new Map() as LayoutPathToInfo,
-        clrMap: new Map() as ClrMap,
-        txStylesMarkers: new Map() as TxStylesMarkers,
+  // A deck can carry several slide masters, each owning its own set of
+  // layouts (e.g. this deck's slide 1 layout — with its gradient background
+  // image — lives under master 1, while another master owns the rest). Load
+  // every master in `<p:sldMasterIdLst>` order and merge their layouts /
+  // layoutMaps so every slide can resolve its real layout. The first master
+  // is the primary: its color map, txStyles, and background drive the deck
+  // (our model still stores a single `masterId`).
+  const masterTargets = orderedMasterTargets(presentation, presRels);
+  let masterAndLayouts: {
+    master: Master | undefined;
+    layouts: Layout[];
+    layoutMap: LayoutPathToInfo;
+    clrMap: ClrMap;
+    txStylesMarkers: TxStylesMarkers;
+  } = {
+    master: undefined,
+    layouts: [],
+    layoutMap: new Map(),
+    clrMap: new Map(),
+    txStylesMarkers: new Map(),
+  };
+  for (const masterTarget of masterTargets) {
+    const loaded = await loadMasterAndLayouts(
+      archive,
+      'ppt/presentation.xml',
+      masterTarget,
+      importedTheme?.id ?? 'default-light',
+      report,
+      upload,
+      scale,
+    );
+    if (!masterAndLayouts.master) {
+      // Primary master: keep its master/clrMap/txStyles; seed the merged
+      // layouts + layoutMap.
+      masterAndLayouts = {
+        master: loaded.master,
+        layouts: [...loaded.layouts],
+        layoutMap: new Map(loaded.layoutMap),
+        clrMap: loaded.clrMap,
+        txStylesMarkers: loaded.txStylesMarkers,
       };
+    } else {
+      // Secondary masters contribute only their layouts (paths are unique,
+      // so no layoutMap collision); slides under them still resolve.
+      masterAndLayouts.layouts.push(...loaded.layouts);
+      for (const [path, info] of loaded.layoutMap) {
+        masterAndLayouts.layoutMap.set(path, info);
+      }
+    }
+  }
 
   const themes: Theme[] = importedTheme
     ? [importedTheme, ...BUILT_IN_THEMES.filter((t) => t.id !== importedTheme.id)]
@@ -149,6 +181,12 @@ export async function importPptx(
   // as the picker's source of truth). Built-ins are rescaled to the deck's
   // logical height so their placeholders stay centred on a non-16:9 deck;
   // imported layouts already carry deck-space frames and are left as-is.
+  //
+  // Layout-level `<p:bg>` (e.g. slide 1's gradient background image) is NOT
+  // carried on these collapsed layouts: several OOXML layouts map to one
+  // built-in id, so a per-id background would be ambiguous. Instead each
+  // slide bakes its own layout's background at parse time (see `parseSlide`),
+  // keyed on the exact layout part path via `layoutMap`.
   const layouts = dedupeLayouts([
     ...scaleLayoutsToHeight(BUILT_IN_LAYOUTS, logicalHeight),
     ...masterAndLayouts.layouts,
@@ -217,6 +255,42 @@ function orderedSlidePaths(
     const rel = presRels.get(rid);
     if (!rel || rel.type !== 'slide') continue;
     out.push(resolveRelsTarget('ppt/presentation.xml', rel.target));
+  }
+  return out;
+}
+
+/**
+ * Slide-master part targets in `<p:sldMasterIdLst>` order (the first entry is
+ * the presentation's primary master). Falls back to every `slideMaster` rel
+ * in rels order when the list is absent. Returns raw rel targets (relative to
+ * `ppt/presentation.xml`), de-duplicated.
+ */
+function orderedMasterTargets(
+  presentation: Document,
+  presRels: Map<string, { type: string; target: string }>,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const lst = descendant(presentation, 'sldMasterIdLst');
+  if (lst) {
+    for (const sldMasterId of children(lst, 'sldMasterId')) {
+      const rid =
+        sldMasterId.getAttributeNS(NS.R, 'id') ||
+        sldMasterId.getAttribute('r:id') ||
+        undefined;
+      if (!rid) continue;
+      const rel = presRels.get(rid);
+      if (!rel || rel.type !== 'slideMaster' || seen.has(rel.target)) continue;
+      seen.add(rel.target);
+      out.push(rel.target);
+    }
+  }
+  if (out.length === 0) {
+    for (const rel of presRels.values()) {
+      if (rel.type !== 'slideMaster' || seen.has(rel.target)) continue;
+      seen.add(rel.target);
+      out.push(rel.target);
+    }
   }
   return out;
 }
@@ -310,11 +384,31 @@ async function loadMasterAndLayouts(
     const layoutPath = resolveRelsTarget(masterPath, rel.target);
     const layoutXml = await archive.readText(layoutPath);
     if (!layoutXml) continue;
-    const imported = parseLayout(layoutXml, layoutPath, report);
+    // A layout's own rels resolve its `<p:bg>` blipFill image (distinct
+    // from the master rels used to find the layout part itself).
+    const layoutRelsXml = await archive.readText(relsSiblingFor(layoutPath));
+    const layoutRels = layoutRelsXml ? parseRels(layoutRelsXml) : new Map();
+    const layoutImageCtx: ImageParseContext = {
+      archive,
+      slidePartPath: layoutPath,
+      rels: layoutRels,
+      uploadImage,
+      scale,
+      report,
+    };
+    const imported = await parseLayout(layoutXml, layoutPath, report, {
+      imageCtx: layoutImageCtx,
+      clrMap,
+    });
     layouts.push(imported.layout);
+    // Key the layout's background on its exact part path so the slide that
+    // references it can bake the right background (the collapsed built-in id
+    // is shared by several layouts and would be ambiguous).
     layoutMap.set(layoutPath, {
       builtInId: imported.layout.id,
       placeholderSizes: imported.placeholderSizes,
+      placeholderFrames: imported.placeholderFrames,
+      ...(imported.background && { background: imported.background }),
     });
   }
 

--- a/packages/slides/src/import/pptx/layout.ts
+++ b/packages/slides/src/import/pptx/layout.ts
@@ -1,6 +1,13 @@
+import type { Frame } from '../../model/element';
 import { BUILT_IN_LAYOUTS } from '../../model/layout';
-import type { Layout } from '../../model/presentation';
+import type { Background, Layout } from '../../model/presentation';
+import { isInheritableFill } from '../../model/presentation';
+import type { ClrMap } from './color';
+import { parseXfrm } from './geometry';
+import type { ImageParseContext } from './image';
+import { phKey } from './placeholder';
 import { ImportReport } from './report';
+import { parseSlideBackground } from './slide';
 import { attr, attrInt, child, children, descendant, parseXml } from './xml';
 
 /**
@@ -43,6 +50,34 @@ export interface ImportedLayout {
    * layout overrides to render titles faithfully.
    */
   placeholderSizes: Map<string, number>;
+  /**
+   * Frame (position + size, in px) per layout placeholder, keyed by
+   * `"{ooxmlType}:{idx}"`. A slide placeholder whose own `<p:spPr>` omits
+   * `<a:xfrm>` inherits this frame (PPTX slide → layout geometry); without
+   * it the placeholder collapses to `(0,0,0,0)` at the top-left. Only
+   * populated when the layout is parsed with a `bgCtx` (which carries the
+   * EMU→px scale); empty otherwise.
+   */
+  placeholderFrames: Map<string, Frame>;
+  /**
+   * Layout-level `<p:bg>` when it carries a real background — an image
+   * (`blipFill`) or an explicit `solidFill`. PPTX background inheritance is
+   * slide → layout → master; a slide with no `<p:bg>` of its own inherits
+   * this. Absent for layouts with no `<p:bg>`, a `<p:bgRef>` style-matrix
+   * reference, or a bare role fill (those must not clobber the built-in
+   * layout this collapses onto). Requires `bgCtx` to be resolved.
+   */
+  background?: Background;
+}
+
+/**
+ * Image + color-map context needed to resolve a layout's `<p:bg>` blipFill
+ * / solidFill. Optional on {@link parseLayout} so callers that only need the
+ * layout id + placeholder sizes (and test harnesses) can skip it.
+ */
+export interface LayoutBackgroundContext {
+  imageCtx: ImageParseContext;
+  clrMap: ClrMap;
 }
 
 /**
@@ -51,11 +86,12 @@ export interface ImportedLayout {
  * layouts; the design doc reserves that for v1.5 alongside theme builder
  * editing of master/layout placeholders.
  */
-export function parseLayout(
+export async function parseLayout(
   xml: string,
   ooxmlPartName: string,
   report: ImportReport,
-): ImportedLayout {
+  bgCtx?: LayoutBackgroundContext,
+): Promise<ImportedLayout> {
   const doc = parseXml(xml);
   const sldLayout = descendant(doc, 'sldLayout');
   const rawType = sldLayout ? attr(sldLayout, 'type') : undefined;
@@ -69,7 +105,76 @@ export function parseLayout(
     ? parsePlaceholderSizes(sldLayout)
     : new Map<string, number>();
 
-  return { ooxmlPartName, layout, placeholderSizes };
+  const placeholderFrames =
+    sldLayout && bgCtx
+      ? parsePlaceholderFrames(sldLayout, bgCtx.imageCtx.scale)
+      : new Map<string, Frame>();
+
+  const background = sldLayout ? await parseLayoutBackground(sldLayout, bgCtx) : undefined;
+
+  return {
+    ooxmlPartName,
+    layout,
+    placeholderSizes,
+    placeholderFrames,
+    ...(background && { background }),
+  };
+}
+
+/**
+ * Walk a layout's `<p:spTree>` for placeholder shapes and pull each one's
+ * `<p:spPr><a:xfrm>` frame (scaled to px), keyed by `"{ooxmlType}:{idx}"`.
+ * Placeholders with no `<a:xfrm>` are skipped (nothing to inherit).
+ */
+function parsePlaceholderFrames(
+  sldLayout: Element,
+  scale: ImageParseContext['scale'],
+): Map<string, Frame> {
+  const out = new Map<string, Frame>();
+  const cSld = child(sldLayout, 'cSld');
+  const spTree = cSld ? child(cSld, 'spTree') : undefined;
+  if (!spTree) return out;
+  for (const sp of children(spTree, 'sp')) {
+    const nvSpPr = child(sp, 'nvSpPr');
+    const nvPr = nvSpPr ? child(nvSpPr, 'nvPr') : undefined;
+    const ph = nvPr ? child(nvPr, 'ph') : undefined;
+    if (!ph) continue;
+    const type = attr(ph, 'type') ?? 'body';
+    const idx = attr(ph, 'idx') ?? '0';
+
+    const spPr = child(sp, 'spPr');
+    const xfrm = spPr ? child(spPr, 'xfrm') : undefined;
+    if (!xfrm) continue;
+    out.set(phKey(type, idx), parseXfrm(xfrm, scale));
+  }
+  return out;
+}
+
+/**
+ * Resolve a layout's `<p:cSld><p:bg>` into a {@link Background}, but only
+ * keep it when it carries an image or an explicit `solidFill`. A bare role
+ * fill / unhandled `<p:bgRef>` returns `undefined` so the caller leaves the
+ * built-in layout's (absent) background untouched instead of overriding it
+ * with a no-op fill.
+ */
+async function parseLayoutBackground(
+  sldLayout: Element,
+  bgCtx?: LayoutBackgroundContext,
+): Promise<Background | undefined> {
+  if (!bgCtx) return undefined;
+  const cSld = child(sldLayout, 'cSld');
+  const bgEl = cSld ? child(cSld, 'bg') : undefined;
+  if (!bgEl) return undefined;
+
+  const parsed = await parseSlideBackground(bgEl, bgCtx.clrMap, bgCtx.imageCtx);
+  // Keep only a *real* background: a resolved image, or an explicit
+  // (non-inheritable) fill override. A bare role fill — which is what
+  // `parseSlideBackground` returns for an unhandled `<p:bgRef>`, a
+  // `solidFill` whose scheme color didn't resolve, or a failed blip upload
+  // — is dropped so the slide keeps inheriting instead of baking the deck
+  // default and masking the theme / master background.
+  const hasRealFill = parsed.fill !== undefined && !isInheritableFill(parsed.fill);
+  return parsed.image || hasRealFill ? parsed : undefined;
 }
 
 /**
@@ -102,7 +207,7 @@ function parsePlaceholderSizes(sldLayout: Element): Map<string, number> {
     if (!defRPr) continue;
     const sz = attrInt(defRPr, 'sz');
     if (sz == null) continue;
-    out.set(`${type}:${idx}`, sz / 100);
+    out.set(phKey(type, idx), sz / 100);
   }
   return out;
 }

--- a/packages/slides/src/import/pptx/placeholder.ts
+++ b/packages/slides/src/import/pptx/placeholder.ts
@@ -1,0 +1,17 @@
+/**
+ * Placeholder inheritance key `"{type}:{idx}"`, shared by the layout parser
+ * (which stores per-placeholder font sizes / frames) and the slide parser
+ * (which looks them up). OOXML uses different `<p:ph type>` tokens for the
+ * same logical placeholder on the layout vs the slide — most commonly a
+ * title slide whose layout stores `ctrTitle` while the slide references
+ * `title`. Normalizing those aliases keeps storage and lookup keys aligned;
+ * otherwise the slide placeholder finds no layout default and collapses to
+ * the docs-renderer font fallback / a `(0,0,0,0)` frame.
+ */
+const PH_TYPE_ALIAS: Record<string, string> = {
+  ctrTitle: 'title',
+};
+
+export function phKey(rawType: string, idx: string): string {
+  return `${PH_TYPE_ALIAS[rawType] ?? rawType}:${idx}`;
+}

--- a/packages/slides/src/import/pptx/shape.ts
+++ b/packages/slides/src/import/pptx/shape.ts
@@ -1,6 +1,7 @@
 import type {
   Effects,
   Element as SlideElement,
+  Frame,
   FreeformPath,
   GroupElement,
   ImageElement,
@@ -36,6 +37,7 @@ import {
 import { parseCustGeomPath } from './freeform';
 import { parseBlipFill, parsePic, type ImageParseContext } from './image';
 import { CHART_URI, graphicFramePlaceholder, parseChartFrame } from './chart';
+import { phKey } from './placeholder';
 import { ImportReport } from './report';
 import { parseTable } from './table';
 import {
@@ -84,6 +86,13 @@ export interface SlideParseContext {
    * here when the parent shape has a matching `<p:ph>` reference.
    */
   placeholderSizes: Map<string, number>;
+  /**
+   * Frame (position + size, px) per layout placeholder, keyed by
+   * `"{ooxmlType}:{idx}"`. A placeholder `<p:sp>` whose own `<p:spPr>` omits
+   * `<a:xfrm>` inherits this frame instead of collapsing to `(0,0,0,0)`.
+   * Optional so bare test fixtures can omit it; absent ⇒ no layout frames.
+   */
+  placeholderFrames?: Map<string, Frame>;
   /**
    * Master-level `<p:clrMap>` — applied when resolving slide-level
    * `<a:schemeClr>` lookups so logical names like `bg2` route through
@@ -448,14 +457,38 @@ function withId(elem: SlideElement, ctx: SlideParseContext, sourceEl: Element): 
   return elem;
 }
 
+/**
+ * Resolve a placeholder `<p:sp>`'s frame, honoring PPTX slide → layout
+ * geometry inheritance. The slide's own `<a:off>` / `<a:ext>` win where
+ * present; each axis the slide omits falls back to the layout placeholder
+ * frame (whole frame when the slide has no `<a:xfrm>` at all). Returns a
+ * fresh object (never the shared `layoutFrame`) so callers can mutate it.
+ */
+function resolvePlaceholderFrame(
+  xfrm: Element | undefined,
+  layoutFrame: Frame | undefined,
+  scale: EmuScale,
+): Frame {
+  if (!xfrm) {
+    return layoutFrame ? { ...layoutFrame } : parseXfrm(undefined, scale);
+  }
+  const frame = parseXfrm(xfrm, scale);
+  if (!layoutFrame) return frame;
+  if (!child(xfrm, 'off')) {
+    frame.x = layoutFrame.x;
+    frame.y = layoutFrame.y;
+  }
+  if (!child(xfrm, 'ext')) {
+    frame.w = layoutFrame.w;
+    frame.h = layoutFrame.h;
+  }
+  return frame;
+}
+
 async function parseSp(sp: Element, ctx: SlideParseContext): Promise<SlideElement[]> {
   const nvSpPr = child(sp, 'nvSpPr');
   const cNvSpPr = nvSpPr ? child(nvSpPr, 'cNvSpPr') : undefined;
   const isTextBox = cNvSpPr ? attr(cNvSpPr, 'txBox') === '1' : false;
-
-  const spPr = child(sp, 'spPr');
-  const xfrm = spPr ? child(spPr, 'xfrm') : undefined;
-  const frame = parseXfrm(xfrm, ctx.scale);
 
   const txBody = child(sp, 'txBody');
   const hasText = !!txBody && hasVisibleText(txBody);
@@ -463,6 +496,17 @@ async function parseSp(sp: Element, ctx: SlideParseContext): Promise<SlideElemen
   const placeholderInfo = readPlaceholderInfo(nvSpPr);
   const placeholderRef = placeholderInfo?.ref;
   const layoutSizeKey = placeholderInfo?.ooxmlKey;
+
+  const spPr = child(sp, 'spPr');
+  const xfrm = spPr ? child(spPr, 'xfrm') : undefined;
+  // A placeholder `<p:sp>` may omit its `<a:xfrm>` entirely, or override only
+  // its offset or only its extent, inheriting the rest from the matching
+  // layout placeholder (PPTX slide → layout geometry). Resolve the layout
+  // frame first, then let the slide's own `<a:off>` / `<a:ext>` win where
+  // present — otherwise `parseXfrm` collapses the missing axis to 0 (a
+  // top-left `(0,0,0,0)` box, or a zero-size invisible one).
+  const layoutFrame = layoutSizeKey ? ctx.placeholderFrames?.get(layoutSizeKey) : undefined;
+  const frame = resolvePlaceholderFrame(xfrm, layoutFrame, ctx.scale);
 
   // Drop shadow / reflection (effects) and alt text are attached to every
   // element this `<p:sp>` emits by `parseChild`, which has the source
@@ -635,7 +679,7 @@ function readPlaceholderInfo(
   if (!ph) return undefined;
   const rawType = attr(ph, 'type') ?? 'body';
   const idxStr = attr(ph, 'idx') ?? '0';
-  const ooxmlKey = `${rawType}:${idxStr}`;
+  const ooxmlKey = phKey(rawType, idxStr);
   const type = OOXML_PH_TO_TYPE[rawType];
   let ref: PlaceholderRef | undefined;
   if (type) {

--- a/packages/slides/src/import/pptx/slide.ts
+++ b/packages/slides/src/import/pptx/slide.ts
@@ -1,4 +1,5 @@
 import type { Block } from '@wafflebase/docs';
+import type { Frame } from '../../model/element';
 import type { Background, Slide } from '../../model/presentation';
 import { DEFAULT_BACKGROUND } from '../../model/presentation';
 import { clone } from '../../model/clone';
@@ -21,6 +22,19 @@ export interface LayoutResolution {
   builtInId: string;
   /** Map of `"{ooxmlType}:{idx}"` → default fontSize in points. */
   placeholderSizes: Map<string, number>;
+  /**
+   * Map of `"{ooxmlType}:{idx}"` → layout placeholder frame (px). A slide
+   * placeholder with no own `<a:xfrm>` inherits this (slide → layout
+   * geometry). Optional so test harnesses can omit it.
+   */
+  placeholderFrames?: Map<string, Frame>;
+  /**
+   * Layout-level `<p:bg>` background (image / solid), when the layout defines
+   * a real one. A slide with no `<p:bg>` of its own bakes this at parse time
+   * (PPTX inheritance slide → layout). Keyed per layout part path so the
+   * collapse of many OOXML layouts onto one built-in id doesn't cross wires.
+   */
+  background?: Background;
 }
 
 /** Maps from imported OOXML layout part path → resolution data. */
@@ -63,8 +77,11 @@ export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undef
   const layoutId = layoutInfo?.builtInId ?? 'title-body';
   const placeholderSizes = layoutInfo?.placeholderSizes ?? new Map<string, number>();
 
-  // Background may be on the slide's `<p:cSld>` (override) or inherited
-  // from the master. v1 records an override only when present.
+  // Background: the slide's own `<p:cSld><p:bg>` wins; otherwise PPTX
+  // inheritance falls to the layout (slide → layout → master). We bake the
+  // layout's background here — keyed on the slide's exact layout part path —
+  // so a slide with no `<p:bg>` still renders its layout's gradient / image
+  // (the collapsed built-in id can't carry it unambiguously).
   const cSld = child(slideEl, 'cSld');
   const bgEl = cSld ? child(cSld, 'bg') : undefined;
   const imageCtx: ImageParseContext = {
@@ -77,7 +94,9 @@ export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undef
   };
   const background = bgEl
     ? await parseSlideBackground(bgEl, opts.clrMap, imageCtx)
-    : clone(DEFAULT_BACKGROUND);
+    : layoutInfo?.background
+      ? clone(layoutInfo.background)
+      : clone(DEFAULT_BACKGROUND);
 
   const spTree = cSld ? child(cSld, 'spTree') : undefined;
   const ctx: SlideParseContext = {
@@ -90,6 +109,7 @@ export async function parseSlide(opts: ParseSlideOptions): Promise<Slide | undef
     idMap: new Map(),
     shapeKindByPptxId: new Map(),
     placeholderSizes,
+    placeholderFrames: layoutInfo?.placeholderFrames ?? new Map(),
     clrMap: opts.clrMap,
     txStylesMarkers: opts.txStylesMarkers,
   };
@@ -128,7 +148,14 @@ function pickLayoutInfo(
   return undefined;
 }
 
-async function parseSlideBackground(
+/**
+ * Parse a `<p:bg>` element (from a slide, layout, or any `<p:cSld>`) into a
+ * {@link Background}. Handles `<p:bgPr>` with `blipFill` (image) or
+ * `solidFill` (color); `<p:bgRef>` style-matrix indices are unhandled and
+ * fall through to {@link DEFAULT_BACKGROUND}. Exported so the layout parser
+ * reuses the exact same semantics rather than keeping a third copy.
+ */
+export async function parseSlideBackground(
   bgEl: Element,
   clrMap: ClrMap,
   imageCtx: ImageParseContext,

--- a/packages/slides/src/model/presentation.ts
+++ b/packages/slides/src/model/presentation.ts
@@ -184,7 +184,7 @@ export const DEFAULT_BACKGROUND: Background = {
  * fill), not just freshly-created ones. A genuine custom override (an
  * srgb color, or the background role with a tint/shade) still wins.
  */
-function isInheritableFill(fill: ThemeColor): boolean {
+export function isInheritableFill(fill: ThemeColor): boolean {
   return (
     fill.kind === 'role' &&
     fill.role === 'background' &&

--- a/packages/slides/test/import/pptx/layout.test.ts
+++ b/packages/slides/test/import/pptx/layout.test.ts
@@ -12,31 +12,32 @@ function layoutXml(type: string): string {
 }
 
 describe('parseLayout', () => {
-  it('maps the four types used by the benchmark deck', () => {
+  it('maps the four types used by the benchmark deck', async () => {
     const r = new ImportReport();
-    expect(parseLayout(layoutXml('tx'), 'l1', r).layout.id).toBe('title-body');
-    expect(parseLayout(layoutXml('secHead'), 'l2', r).layout.id).toBe('section-header');
-    expect(parseLayout(layoutXml('body'), 'l3', r).layout.id).toBe('one-column-text');
-    expect(parseLayout(layoutXml('title'), 'l4', r).layout.id).toBe('title-slide');
+    expect((await parseLayout(layoutXml('tx'), 'l1', r)).layout.id).toBe('title-body');
+    expect((await parseLayout(layoutXml('secHead'), 'l2', r)).layout.id).toBe('section-header');
+    expect((await parseLayout(layoutXml('body'), 'l3', r)).layout.id).toBe('one-column-text');
+    expect((await parseLayout(layoutXml('title'), 'l4', r)).layout.id).toBe('title-slide');
     expect(r.unknownLayoutTypes).toBe(0);
   });
 
-  it('falls back to title-body and counts unknown types', () => {
+  it('falls back to title-body and counts unknown types', async () => {
     const r = new ImportReport();
-    const out = parseLayout(layoutXml('mediaText'), 'lx', r);
+    const out = await parseLayout(layoutXml('mediaText'), 'lx', r);
     expect(out.layout.id).toBe('title-body');
     expect(r.unknownLayoutTypes).toBe(1);
   });
 
-  it('preserves the OOXML part name for later rels resolution', () => {
+  it('preserves the OOXML part name for later rels resolution', async () => {
     const r = new ImportReport();
-    const out = parseLayout(layoutXml('blank'), 'ppt/slideLayouts/slideLayout11.xml', r);
+    const out = await parseLayout(layoutXml('blank'), 'ppt/slideLayouts/slideLayout11.xml', r);
     expect(out.ooxmlPartName).toBe('ppt/slideLayouts/slideLayout11.xml');
     expect(out.layout.id).toBe('blank');
     expect(out.placeholderSizes.size).toBe(0);
+    expect(out.background).toBeUndefined();
   });
 
-  it('extracts placeholder default font sizes from <a:lstStyle><a:lvl1pPr><a:defRPr sz>', () => {
+  it('extracts placeholder default font sizes from <a:lstStyle><a:lvl1pPr><a:defRPr sz>', async () => {
     // Mirrors the benchmark deck's slideLayout1.xml, where the ctrTitle
     // placeholder carries sz="5200" (52pt) as its default. Without
     // reading this, slide-level runs with no explicit sz collapse to
@@ -67,8 +68,103 @@ describe('parseLayout', () => {
     </p:spTree>
   </p:cSld>
 </p:sldLayout>`;
-    const out = parseLayout(xml, 'ppt/slideLayouts/slideLayout1.xml', new ImportReport());
-    expect(out.placeholderSizes.get('ctrTitle:0')).toBe(52);
+    const out = await parseLayout(xml, 'ppt/slideLayouts/slideLayout1.xml', new ImportReport());
+    // `ctrTitle` is normalized to `title` so a slide-level `<p:ph type="title"/>`
+    // (the common Google-Slides export) inherits this layout default.
+    expect(out.placeholderSizes.get('title:0')).toBe(52);
     expect(out.placeholderSizes.get('subTitle:1')).toBe(24);
+  });
+
+  it('parses a layout <p:bg> blipFill into layout.background.image', async () => {
+    // slideLayout1.xml of the Naver deck references image6.png (BytePlus
+    // logo + bottom gradient) as its background. Slide 1 has no <p:bg> of
+    // its own, so this layout background is what must render.
+    const xml = `<?xml version="1.0"?>
+<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" type="title">
+  <p:cSld name="Title Slide">
+    <p:bg><p:bgPr>
+      <a:blipFill dpi="0" rotWithShape="1">
+        <a:blip r:embed="rId2"/>
+        <a:stretch><a:fillRect/></a:stretch>
+      </a:blipFill>
+      <a:effectLst/>
+    </p:bgPr></p:bg>
+    <p:spTree/>
+  </p:cSld>
+</p:sldLayout>`;
+    const uploaded: string[] = [];
+    const imageCtx = {
+      archive: {
+        readText: async () => undefined,
+        readBytes: async () => new Uint8Array([1, 2, 3]),
+      },
+      slidePartPath: 'ppt/slideLayouts/slideLayout1.xml',
+      rels: new Map([
+        ['rId2', { type: 'image', target: '../media/image6.png' }],
+      ]),
+      uploadImage: async (_bytes: Uint8Array, mime: string) => {
+        uploaded.push(mime);
+        return 'blob:image6';
+      },
+      scale: { x: (v: number) => v, y: (v: number) => v },
+      report: new ImportReport(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const out = await parseLayout(xml, 'ppt/slideLayouts/slideLayout1.xml', new ImportReport(), {
+      imageCtx,
+      clrMap: new Map(),
+    });
+    expect(out.background?.image?.src).toBe('blob:image6');
+    expect(uploaded).toEqual(['image/png']);
+  });
+
+  it('extracts placeholder frames (scaled) when a bgCtx with scale is provided', async () => {
+    const xml = `<?xml version="1.0"?>
+<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" type="title">
+  <p:cSld name="Title Slide"><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="3" name="Content Placeholder 2"/><p:cNvSpPr/>
+        <p:nvPr><p:ph sz="quarter" idx="10"/></p:nvPr></p:nvSpPr>
+      <p:spPr><a:xfrm><a:off x="1000" y="2000"/><a:ext cx="4000" cy="500"/></a:xfrm></p:spPr>
+      <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t/></a:r></a:p></p:txBody>
+    </p:sp>
+  </p:spTree></p:cSld>
+</p:sldLayout>`;
+    const out = await parseLayout(xml, 'l', new ImportReport(), {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      imageCtx: { scale: { sx: 2, sy: 3 } } as any,
+      clrMap: new Map(),
+    });
+    expect(out.placeholderFrames.get('body:10')).toMatchObject({
+      x: 2000,
+      y: 6000,
+      w: 8000,
+      h: 1500,
+    });
+  });
+
+  it('yields empty placeholderFrames when no bgCtx (no scale) is provided', async () => {
+    const out = await parseLayout(layoutXml('title'), 'l', new ImportReport());
+    expect(out.placeholderFrames.size).toBe(0);
+  });
+
+  it('leaves layout.background undefined for a <p:bgRef> style-matrix reference', async () => {
+    const xml = `<?xml version="1.0"?>
+<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" type="title">
+  <p:cSld name="Title Slide">
+    <p:bg><p:bgRef idx="1001"><a:schemeClr val="bg1"/></p:bgRef></p:bg>
+    <p:spTree/>
+  </p:cSld>
+</p:sldLayout>`;
+    const out = await parseLayout(xml, 'l', new ImportReport(), {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      imageCtx: {} as any,
+      clrMap: new Map(),
+    });
+    expect(out.background).toBeUndefined();
   });
 });

--- a/packages/slides/test/import/pptx/slide.test.ts
+++ b/packages/slides/test/import/pptx/slide.test.ts
@@ -64,6 +64,222 @@ const SLIDE_BLIPFILL_NO_REL = `<?xml version="1.0"?>
   </p:cSld>
 </p:sld>`;
 
+const SLIDE_NO_BG = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld><p:spTree/></p:cSld>
+</p:sld>`;
+
+const SLIDE_LAYOUT_RELS = `<?xml version="1.0"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+</Relationships>`;
+
+describe('parseSlide — inherited layout background', () => {
+  it('bakes the layout background image onto a slide with no own <p:bg>', async () => {
+    // Mirrors the Naver deck: slide 1 has no <p:bg>; its layout
+    // (slideLayout1) carries a blipFill gradient background image. PPTX
+    // inheritance (slide → layout) must surface it on the slide.
+    const archive = makeArchive({
+      'ppt/slides/slide1.xml': SLIDE_NO_BG,
+      'ppt/slides/_rels/slide1.xml.rels': SLIDE_LAYOUT_RELS,
+    });
+    const layoutMap = new Map([
+      [
+        'ppt/slideLayouts/slideLayout1.xml',
+        {
+          builtInId: 'title-body',
+          placeholderSizes: new Map<string, number>(),
+          background: {
+            fill: { kind: 'role', role: 'background' } as const,
+            image: { src: 'cdn://layout-gradient.png' },
+          },
+        },
+      ],
+    ]);
+
+    const slide = await parseSlide({
+      archive,
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap,
+      uploadImage: async () => 'cdn://unused.png',
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+
+    expect(slide!.layoutId).toBe('title-body');
+    expect(slide!.background.image).toEqual({ src: 'cdn://layout-gradient.png' });
+    // Fill stays an inheritable role so theme changes still cascade.
+    expect(slide!.background.fill).toEqual({ kind: 'role', role: 'background' });
+  });
+
+  it('inherits the layout placeholder frame when the slide placeholder omits <a:xfrm>', async () => {
+    // Mirrors slide 1's "2026년 3월" content placeholder: `<p:ph idx="10"/>`
+    // with an empty `<p:spPr/>`. Its bottom-left position lives only on the
+    // layout placeholder, so without inheritance it collapses to (0,0).
+    const slideXml = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="3" name="Content Placeholder 2"/><p:cNvSpPr/>
+        <p:nvPr><p:ph sz="quarter" idx="10"/></p:nvPr></p:nvSpPr>
+      <p:spPr/>
+      <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>2026년 3월</a:t></a:r></a:p></p:txBody>
+    </p:sp>
+  </p:spTree></p:cSld>
+</p:sld>`;
+    const archive = makeArchive({
+      'ppt/slides/slide1.xml': slideXml,
+      'ppt/slides/_rels/slide1.xml.rels': SLIDE_LAYOUT_RELS,
+    });
+    const layoutMap = new Map([
+      [
+        'ppt/slideLayouts/slideLayout1.xml',
+        {
+          builtInId: 'title-body',
+          placeholderSizes: new Map<string, number>(),
+          placeholderFrames: new Map([
+            ['body:10', { x: 68, y: 982, w: 430, h: 49, rotation: 0 }],
+          ]),
+        },
+      ],
+    ]);
+
+    const slide = await parseSlide({
+      archive,
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap,
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+
+    expect(slide!.elements).toHaveLength(1);
+    expect(slide!.elements[0].frame).toMatchObject({ x: 68, y: 982, w: 430, h: 49 });
+  });
+
+  it('inherits a title frame across the ctrTitle→title alias', async () => {
+    // Layout stores its center title under `ctrTitle` → normalized key
+    // `title:0`; a slide `<p:ph type="title"/>` must still find it.
+    const slideXml = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="2" name="Title 1"/><p:cNvSpPr/>
+        <p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>
+      <p:spPr/>
+      <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Hi</a:t></a:r></a:p></p:txBody>
+    </p:sp>
+  </p:spTree></p:cSld>
+</p:sld>`;
+    const archive = makeArchive({
+      'ppt/slides/slide1.xml': slideXml,
+      'ppt/slides/_rels/slide1.xml.rels': SLIDE_LAYOUT_RELS,
+    });
+    const layoutMap = new Map([
+      [
+        'ppt/slideLayouts/slideLayout1.xml',
+        {
+          builtInId: 'title-slide',
+          placeholderSizes: new Map<string, number>(),
+          // Stored under the normalized key, as parseLayout would from ctrTitle.
+          placeholderFrames: new Map([
+            ['title:0', { x: 100, y: 200, w: 800, h: 300, rotation: 0 }],
+          ]),
+        },
+      ],
+    ]);
+
+    const slide = await parseSlide({
+      archive,
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap,
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+
+    expect(slide!.elements[0].frame).toMatchObject({ x: 100, y: 200, w: 800, h: 300 });
+  });
+
+  it('merges a partial (offset-only) slide xfrm with the layout extent', async () => {
+    // A placeholder that overrides only its position, inheriting width/height
+    // from the layout. Without the merge, parseXfrm yields w=0,h=0 (invisible).
+    const slideXml = `<?xml version="1.0"?>
+<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:cSld><p:spTree>
+    <p:sp>
+      <p:nvSpPr><p:cNvPr id="3" name="Content Placeholder 2"/><p:cNvSpPr/>
+        <p:nvPr><p:ph sz="quarter" idx="10"/></p:nvPr></p:nvSpPr>
+      <p:spPr><a:xfrm><a:off x="500" y="600"/></a:xfrm></p:spPr>
+      <p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>x</a:t></a:r></a:p></p:txBody>
+    </p:sp>
+  </p:spTree></p:cSld>
+</p:sld>`;
+    const archive = makeArchive({
+      'ppt/slides/slide1.xml': slideXml,
+      'ppt/slides/_rels/slide1.xml.rels': SLIDE_LAYOUT_RELS,
+    });
+    const layoutMap = new Map([
+      [
+        'ppt/slideLayouts/slideLayout1.xml',
+        {
+          builtInId: 'title-body',
+          placeholderSizes: new Map<string, number>(),
+          placeholderFrames: new Map([
+            ['body:10', { x: 68, y: 982, w: 430, h: 49, rotation: 0 }],
+          ]),
+        },
+      ],
+    ]);
+
+    const slide = await parseSlide({
+      archive,
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap,
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+
+    // Slide offset wins; layout extent fills in the missing width/height.
+    expect(slide!.elements[0].frame).toMatchObject({ x: 500, y: 600, w: 430, h: 49 });
+  });
+
+  it('leaves the default background when neither slide nor layout defines one', async () => {
+    const archive = makeArchive({
+      'ppt/slides/slide1.xml': SLIDE_NO_BG,
+      'ppt/slides/_rels/slide1.xml.rels': SLIDE_LAYOUT_RELS,
+    });
+    const layoutMap = new Map([
+      [
+        'ppt/slideLayouts/slideLayout1.xml',
+        { builtInId: 'title-body', placeholderSizes: new Map<string, number>() },
+      ],
+    ]);
+
+    const slide = await parseSlide({
+      archive,
+      partPath: 'ppt/slides/slide1.xml',
+      layoutMap,
+      scale: { sx: 1, sy: 1 },
+      report: new ImportReport(),
+      clrMap: new Map(),
+    });
+
+    expect(slide!.background.image).toBeUndefined();
+    expect(slide!.background.fill).toEqual({ kind: 'role', role: 'background' });
+  });
+});
+
 describe('parseSlide — blipFill background', () => {
   it('populates background.image when blipFill resolves and uploadImage is provided', async () => {
     const archive = makeArchive({


### PR DESCRIPTION
## Summary

Importing a multi-master PPTX deck, **slide 1 lost its bottom gradient** and its **"2026년 3월" placeholder jumped to the top-left**. Two root causes in the same family — layout data was never fully imported:

1. **Multi-master decks loaded only one master.** The importer resolved a single slide master via `pickRelTarget` (first `slideMaster` rel, iteration-order-dependent). The reproducing deck has two masters (`slideMaster1` owns `slideLayout1–9`, `slideMaster2` owns `10–21`); slide 1's layout (`slideLayout1`) was under the master that wasn't loaded, so its background and placeholder geometry were dropped and its `layoutId` fell back to `title-body` by coincidence. Now **every** master in `<p:sldMasterIdLst>` order is loaded and its layouts merged; the first is the primary (drives `clrMap` / `txStyles` / `masterId`).

2. **Layout `<p:bg>` and placeholder frames were never parsed.** Imported layouts collapse onto the 11 built-in ids, so a per-id background/frame is ambiguous. Instead `parseLayout` records each layout's background + placeholder frames keyed by **exact part path**, and `parseSlide` bakes them onto slides that omit their own `<p:bg>` / `<a:xfrm>` — matching PPTX `slide → layout` inheritance.

### Result (real deck)
- Slide 1 gradient (`image6.png`) resolves and renders.
- "2026년 3월" moves from `(0,0)` → **x=68, y=982** (bottom-left), matching the original.

### Review fixes folded in (two high-effort passes)
- Normalize `ctrTitle → title` placeholder keys (`phKey`) so a slide `<p:ph type="title"/>` inherits a layout that stored `ctrTitle` (Google-Slides exports).
- Gate layout backgrounds on a resolved image or non-inheritable fill (exported `isInheritableFill`) so a failed / `<p:bgRef>` fill keeps inheritance open instead of baking the deck default.
- `resolvePlaceholderFrame` merges partial `<a:xfrm>` (offset-only / extent-only) with the layout frame instead of collapsing the missing axis to 0.
- Clone inherited frames to avoid aliasing across slides.

### Known limitations (documented in the design doc)
- One deck-wide `clrMap` (primary master) for slides + baked backgrounds — affects only `solidFill` scheme-color backgrounds on a secondary master; `blipFill` unaffected.
- An explicit layout `solidFill bg1` isn't baked (the model can't represent an explicit vs inherited background role); resolves to the same theme background in practice.
- Eager per-layout background uploads can leave a few orphan blobs on template-heavy decks; a lazy pass is deferred.

## Test plan
- `pnpm --filter @wafflebase/slides test` — 2565 passing (added unit tests: layout `<p:bg>` + placeholder-frame extraction, slide bake, `ctrTitle→title` inheritance, partial-xfrm merge).
- `pnpm verify:fast` green; pre-push `verify:self` (all lanes) green.
- Manual smoke: imported the real deck; slide 1 gradient + "2026년 3월" position confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
