### PR TITLE
Add Yorkie auth webhook for per-document access control

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -107,6 +107,7 @@ Infrastructure, frontend/backend, and cross-cutting concerns.
 | Document                                               | Description                                                                                        |
 | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
 | [documents-last-modified.md](documents-last-modified.md) | Documents-list last-modified ordering — stable Postgres `Document.updatedAt` fed by Yorkie `DocumentRootChanged` event webhook (HMAC-signed), replacing the flaky per-request admin call that made the list reshuffle every 5s |
+| [yorkie-auth-webhook.md](yorkie-auth-webhook.md)       | Yorkie auth webhook — server-enforced per-document read/write access at the Yorkie layer; backend-minted short-lived token via `authTokenInjector` (JWT session + anonymous share-link), reuses the event-webhook HMAC guard, resolves `WorkspaceMember`/`ShareLink` roles per docKey/verb; shadow→enforce rollout |
 | [frontend.md](frontend.md)                             | Frontend package — app architecture, Yorkie integration, presence system, auth flow                |
 | [backend.md](backend.md)                               | Backend package — NestJS modules, API reference, auth system, database schema, security            |
 | [sharing.md](sharing.md)                               | URL-based token sharing with anonymous access and role-based permissions                           |

--- a/docs/design/yorkie-auth-webhook.md
+++ b/docs/design/yorkie-auth-webhook.md
@@ -1,0 +1,204 @@
+---
+title: yorkie-auth-webhook
+target-version: 0.6.0
+---
+
+# Yorkie Auth Webhook — Per-Document Access Control
+
+## Summary
+
+Today the frontend attaches to Yorkie with only the project **public key** and
+a spoofable `metadata.userID`. Any client holding the public key can attach to
+**any** document key (`sheet-<id>`, `doc-<id>`, `slides-<id>`, `pdf-<id>`) and
+read or write it — the Postgres permission model (`WorkspaceMember`,
+`ShareLink`) is invisible to Yorkie, and read-only is only self-enforced by the
+frontend `syncMode`. This is the real authorization boundary today, and it is
+open.
+
+Yorkie's **auth webhook** closes this: on privileged RPCs Yorkie forwards
+`{ token, method, attributes:[{ key, verb }] }` to a backend endpoint, which
+answers `{ allowed }` (HTTP `200`/`401`/`403`). We plug our existing permission
+logic into that endpoint so Yorkie enforces workspace membership and share-link
+roles per document, per verb.
+
+## Goals / Non-Goals
+
+**Goals**
+- Server-enforced per-document read/write authorization at the Yorkie layer,
+  backed by the existing `WorkspaceMember` / `ShareLink` model.
+- Identity that cannot be spoofed by the client — authorization derives from a
+  backend-minted token, not from `metadata`.
+- Works for both authenticated users (JWT session) and anonymous share-link
+  visitors (viewer / editor).
+- Safe, reversible rollout (shadow/log-only before enforcing).
+
+**Non-Goals**
+- Replacing the Postgres permission model — the webhook *reads* it, doesn't
+  change it.
+- Field/cell-level or tab-level authorization — grain is the whole document key.
+- Changing the presence/`metadata.userID` path — it stays for avatars; it is
+  simply no longer trusted for authorization.
+- Fixing the `pdf` no-CRDT case — PDFs still attach a `pdf-<id>` Yorkie doc for
+  comments/presence and go through the webhook like any other type.
+
+## Proposal Details
+
+### Webhook contract (yorkie 0.7.12, `api/types/auth_webhook.go`)
+
+Request body Yorkie POSTs to us:
+
+```json
+{
+  "token": "<opaque token from authTokenInjector>",
+  "method": "PushPull",
+  "attributes": [{ "key": "sheet-<uuid>", "verb": "r" }]
+}
+```
+
+- `verb`: `"r"` (read) or `"rw"` (read-write).
+- Response: `{ "allowed": true, "reason": "ok" }`.
+- Status semantics (from yorkie `pkg/webhook/client.go`): `200` → allowed;
+  `401 Unauthenticated` → token invalid/expired, triggers the client's
+  `authTokenInjector('token expired')` refresh + retry; `403 PermissionDenied`
+  → valid token, insufficient rights, rejected without retry.
+
+`AuthMethods()` (methods that hit the webhook when registered). We only need to
+enforce a subset:
+
+| Method | Handling |
+| --- | --- |
+| `ActivateClient` / `DeactivateClient` | No document. Validate token only (is it a live session / valid share?). |
+| `AttachDocument` | Enforce: resolve docKey → doc; require access; `rw` needs write role. |
+| `PushPull` | Enforce (the real read/write gate; `verb` reflects sync mode). |
+| `Watch` (+ deprecated `WatchDocument`) | Enforce read access. |
+| `Broadcast` | Enforce read access (presence). |
+| `DetachDocument` | **Always allow** — detach/GC must succeed even after a role is revoked. |
+| `RemoveDocument` | Enforce write access (document deletion). |
+
+### Webhook authentication — reuse the HMAC guard
+
+The auth webhook is signed by the **same** yorkie webhook client as the event
+webhook: `X-Signature-256: sha256=HMAC-SHA256(rawBody, project.SecretKey)`. The
+existing `YorkieSignatureGuard` (`document/yorkie-signature.guard.ts`) and the
+`main.ts` rawBody-capture hook therefore apply **unchanged** — no new secret.
+The guard authenticates *Yorkie* as the caller; the `token` in the body then
+authenticates the *end user*.
+
+The rawBody `verify` hook in `main.ts` is currently path-scoped to
+`/internal/yorkie/events`; extend it to also cover `/internal/yorkie/auth`.
+
+### Token strategy (the hard part)
+
+The JWT session lives in an **httpOnly** cookie, so `authTokenInjector` (browser
+JS) cannot read it. We mint a separate, short-lived **Yorkie access token** the
+injector *can* hold:
+
+- `GET /auth/yorkie-token` — JWT-cookie-guarded. The browser sends the session
+  cookie automatically (`credentials: 'include'`); the endpoint returns a signed
+  short-lived token (≈10 min) in the body, e.g. a JWT
+  `{ typ: 'yorkie', sub: <userId>, exp }` signed with a backend secret.
+- Anonymous share visitors have no session. `GET /auth/yorkie-token?shareToken=<t>`
+  (no JWT guard) validates the share token via `ShareLinkService.findByToken`
+  and returns a token `{ typ: 'yorkie-share', shareToken, exp }`.
+
+The webhook decodes the token to `{ userId }` or `{ shareToken }` and resolves
+access from there. Identity is thus **backend-signed**, not client-asserted.
+
+### Permission resolution
+
+For each attribute `{ key, verb }`:
+
+1. `parseYorkieDocKey(key)` → `{ type, id }`. Unknown prefix → `allowed:false`
+   (`403`).
+2. Load `Document(id)` → its `workspaceId`. Missing doc → `403`.
+3. Determine the caller's role on that document:
+   - **User token**: `WorkspaceService.assertMember(workspaceId, userId)` → a
+     member gets `rw` (current model has no per-doc viewer role for members).
+   - **Share token**: `ShareLinkService.findByToken(shareToken)`; require
+     `link.documentId === id` and not expired. `role === 'editor'` → `rw`,
+     `role === 'viewer'` → `r`.
+4. Compare to requested `verb`: grant if `verb === 'r'` and role allows read, or
+   `verb === 'rw'` and role allows write. Else `403`.
+
+Token invalid/expired/malformed → `401` (so the client refreshes). Valid token
+but no access → `403`.
+
+A single request may carry multiple attributes; **all** must pass.
+
+### Frontend wiring
+
+`YorkieProvider` accepts `authTokenInjector` (it spreads `ClientOptions`).
+Add it in both mount points, keeping `apiKey` + `metadata` as-is:
+
+```tsx
+// PrivateRoute.tsx (authenticated)
+<YorkieProvider
+  rpcAddr={...} apiKey={...}
+  metadata={{ userID: encodeURIComponent(me.username || 'anonymous-user') }}
+  authTokenInjector={async () => fetchYorkieToken()}       // GET /auth/yorkie-token
+/>
+
+// shared-document.tsx (anonymous share)
+authTokenInjector={async () => fetchYorkieToken(resolved.token)}  // ?shareToken=
+```
+
+The injector caches the token and re-fetches when yorkie calls it with
+`reason === 'token expired'`. For the authenticated case a refetch may itself
+`401` (session expired) → fall through to the existing `/auth/refresh` flow.
+
+### Ops — register the webhook on the project
+
+Auth webhook is a **per-project** setting (not a server flag), configured via
+the yorkie CLI (mirrors the event-webhook step in
+[`documents-last-modified.md`](documents-last-modified.md)):
+
+```shell
+yorkie project update <project> \
+  --auth-webhook-url http://wafflebase.wafflebase.svc.cluster.local:3000/internal/yorkie/auth \
+  --auth-webhook-method-add AttachDocument \
+  --auth-webhook-method-add PushPull \
+  --auth-webhook-method-add Watch \
+  --auth-webhook-method-add DetachDocument \
+  --auth-webhook-method-add Broadcast \
+  --auth-webhook-method-add RemoveDocument
+```
+
+Local dev (`docker compose`) uses the default project; add a one-shot setup
+script that `yorkie login`s and runs the above against `localhost:8080` so
+contributors can opt in. Leaving the URL unset keeps today's behavior.
+
+### Rollout
+
+1. **Ship the endpoint + token endpoint + frontend injector** with the webhook
+   URL **unregistered** — no enforcement, but tokens now flow.
+2. **Shadow mode**: register the webhook but have the handler always return
+   `allowed:true` while logging the decision it *would* have made. Watch for
+   false denials (token gaps, key-parse misses, share edge cases).
+3. **Enforce**: flip the handler to honor the computed decision.
+4. Reversible at every step: unregister the webhook methods to fully disable.
+
+## Risks and Mitigation
+
+- **Bug denies all access** → staged shadow→enforce rollout; `DetachDocument`
+  always allowed; instant rollback by unregistering webhook methods.
+- **Token/session expiry mid-session** → short-lived token + `401`-driven
+  `authTokenInjector` refresh; authenticated refetch chains into the existing
+  `/auth/refresh`. Needs an integration test for the expiry→refresh→retry path.
+- **Webhook latency on the hot path** → the webhook is on every PushPull; keep
+  it a single indexed Postgres read (Document + membership/share), cache
+  token-decode, and rely on yorkie's retry/backoff (`--auth-webhook-*` tunables)
+  rather than blocking. Consider a short in-process cache keyed by
+  `(tokenHash, docId, verb)`.
+- **Spoofed identity** → authorization uses only the backend-signed token;
+  `metadata.userID` is never trusted for access decisions.
+- **Forged webhook calls** → mandatory HMAC via `YorkieSignatureGuard`; endpoint
+  refuses when `YORKIE_SECRET_KEY` is unset (same posture as the event webhook).
+- **Member vs viewer granularity** → current model grants members `rw` and only
+  distinguishes viewer/editor on share links. Per-member viewer roles are a
+  model change, out of scope here; noted so the resolver has a clear extension
+  point.
+- **Comment/side documents sharing a key** → they resolve to the same
+  `Document.id`, so the same access decision applies; no special-casing needed.
+- **Deploy sequencing** → the token endpoint and frontend injector must ship
+  before the webhook is registered, or clients send no token and every call
+  `401`s. Registration is the last, explicitly-gated step.

--- a/docs/design/yorkie-auth-webhook.md
+++ b/docs/design/yorkie-auth-webhook.md
@@ -79,13 +79,15 @@ enforce a subset:
 
 The auth webhook is signed by the **same** yorkie webhook client as the event
 webhook: `X-Signature-256: sha256=HMAC-SHA256(rawBody, project.SecretKey)`. The
-existing `YorkieSignatureGuard` (`document/yorkie-signature.guard.ts`) and the
-`main.ts` rawBody-capture hook therefore apply **unchanged** — no new secret.
-The guard authenticates *Yorkie* as the caller; the `token` in the body then
-authenticates the *end user*.
+existing `YorkieSignatureGuard`
+(`packages/backend/src/document/yorkie-signature.guard.ts`) and the
+`packages/backend/src/main.ts` rawBody-capture hook therefore apply
+**unchanged** — no new secret. The guard authenticates *Yorkie* as the caller;
+the `token` in the body then authenticates the *end user*.
 
-The rawBody `verify` hook in `main.ts` is currently path-scoped to
-`/internal/yorkie/events`; extend it to also cover `/internal/yorkie/auth`.
+The rawBody `verify` hook in `packages/backend/src/main.ts` is currently
+path-scoped to `/internal/yorkie/events`; extend it to also cover
+`/internal/yorkie/auth`.
 
 ### Token strategy (the hard part)
 
@@ -97,9 +99,11 @@ injector *can* hold:
   cookie automatically (`credentials: 'include'`); the endpoint returns a signed
   short-lived token (≈10 min) in the body, e.g. a JWT
   `{ typ: 'yorkie', sub: <userId>, exp }` signed with a backend secret.
-- Anonymous share visitors have no session. `GET /auth/yorkie-token?shareToken=<t>`
-  (no JWT guard) validates the share token via `ShareLinkService.findByToken`
-  and returns a token `{ typ: 'yorkie-share', shareToken, exp }`.
+- Anonymous share visitors have no session. `POST /auth/yorkie-token/share`
+  (no JWT guard) takes the share token in the body — kept out of URLs/logs since
+  it grants access — and returns a token `{ typ: 'yorkie-share', shareToken, exp }`.
+  The webhook, not this endpoint, does the real validation
+  (`ShareLinkService.findByToken`: existence, expiry, document match, role).
 
 The webhook decodes the token to `{ userId }` or `{ shareToken }` and resolves
 access from there. Identity is thus **backend-signed**, not client-asserted.
@@ -193,11 +197,16 @@ contributors can opt in. Leaving the URL unset keeps today's behavior.
 - **Token/session expiry mid-session** → short-lived token + `401`-driven
   `authTokenInjector` refresh; authenticated refetch chains into the existing
   `/auth/refresh`. Needs an integration test for the expiry→refresh→retry path.
-- **Webhook latency on the hot path** → the webhook is on every PushPull; keep
-  it a single indexed Postgres read (Document + membership/share), cache
-  token-decode, and rely on yorkie's retry/backoff (`--auth-webhook-*` tunables)
-  rather than blocking. Consider a short in-process cache keyed by
-  `(tokenHash, docId, verb)`.
+- **Webhook latency on the hot path** → the webhook fires on every PushPull, and
+  the current handler is not free: a user token does a Document read *then* a
+  membership read (two sequential indexed queries), a share token does one
+  `findByToken` (join-loaded), and multiple attributes are checked sequentially.
+  That is acceptable for the shadow phase and typical single-attribute traffic,
+  but before enabling enforcement at scale the mitigation is: collapse the
+  user-token path to one indexed join (document ⋈ membership), check attributes
+  concurrently, and add a short in-process cache keyed by `(tokenHash, docId,
+  verb)`. Yorkie's retry/backoff (`--auth-webhook-*` tunables) covers transient
+  blips.
 - **Spoofed identity** → authorization uses only the backend-signed token;
   `metadata.userID` is never trusted for access decisions.
 - **Forged webhook calls** → mandatory HMAC via `YorkieSignatureGuard`; endpoint

--- a/docs/design/yorkie-auth-webhook.md
+++ b/docs/design/yorkie-auth-webhook.md
@@ -104,6 +104,15 @@ injector *can* hold:
 The webhook decodes the token to `{ userId }` or `{ shareToken }` and resolves
 access from there. Identity is thus **backend-signed**, not client-asserted.
 
+**Token-replay hardening.** The Yorkie token is signed with `JWT_SECRET` (same
+key as the session access token) but, unlike the httpOnly session cookie, it is
+readable by client JS. So `JwtStrategy.validate` must reject anything that isn't
+an access token: it now requires `tokenType === 'access'`, which blocks both a
+captured Yorkie token (`typ: 'yorkie'`) and a refresh token (`tokenType:
+'refresh'`, which shares `JWT_SECRET` when `JWT_REFRESH_SECRET` is unset) from
+being replayed as a `Bearer` session. `verifyYorkieToken` conversely rejects
+access/refresh tokens, so the two token families can't cross over.
+
 ### Permission resolution
 
 For each attribute `{ key, verb }`:
@@ -193,6 +202,27 @@ contributors can opt in. Leaving the URL unset keeps today's behavior.
   `metadata.userID` is never trusted for access decisions.
 - **Forged webhook calls** → mandatory HMAC via `YorkieSignatureGuard`; endpoint
   refuses when `YORKIE_SECRET_KEY` is unset (same posture as the event webhook).
+- **Read-only viewers and the attach/PushPull verb** → yorkie derives the verb
+  from the client's change pack, not the sync mode: `AccessAttributes(pack)` is
+  `r` when `pack.HasChanges()` is false, `rw` otherwise
+  (`server/rpc/auth/auth.go`). A viewer who never edits a doc that already has
+  content pushes no changes → verb `r` → allowed. The risk is a "read-only"
+  client that still emits a local change on load (e.g. a lazy data migration or
+  field initialization) → verb `rw` → the webhook denies it under enforcement.
+  The React `DocumentProvider` does not currently expose a read-only/`syncMode`
+  attach option, so this can't be forced from the frontend today. **Mitigation:**
+  shadow mode is exactly the instrument for this — the rollout must confirm
+  viewer-link attach/PushPull requests actually carry verb `r` (watch the shadow
+  logs) before flipping `YORKIE_AUTH_WEBHOOK_ENFORCE=true`. If viewers do emit
+  `rw`, the fix is a read-only attach path in the SDK wrapper (follow-up), not a
+  webhook change.
+- **Authenticated access is workspace-membership only** → the `PrivateRoute`
+  path injects a *user* token, so the webhook authorizes canonical document URLs
+  purely by `assertMember`. A logged-in non-member opening a canonical URL is
+  denied — which matches today's behavior (canonical document reads already
+  require membership; share access flows through the `/share/:token` route and
+  its share token). This is intended, not a regression, but is called out so the
+  two entry points (member vs share) stay distinct.
 - **Member vs viewer granularity** → current model grants members `rw` and only
   distinguishes viewer/editor on share links. Per-member viewer roles are a
   model change, out of scope here; noted so the resolver has a clear extension

--- a/docs/tasks/active/20260712-yorkie-auth-webhook-todo.md
+++ b/docs/tasks/active/20260712-yorkie-auth-webhook-todo.md
@@ -1,0 +1,50 @@
+# Yorkie Auth Webhook — TODO
+
+Design: `docs/design/yorkie-auth-webhook.md`. Branch: `feat/yorkie-auth-webhook`.
+
+Goal: server-enforced per-document read/write access at the Yorkie layer, via a
+backend-minted short-lived token + Yorkie auth webhook that reuses the existing
+event-webhook HMAC guard.
+
+## Backend
+
+- [ ] `AuthService`: add Yorkie token issue/verify
+  - `issueYorkieUserToken(userId)` — JWT `{ typ: 'yorkie', sub }`, exp `YORKIE_TOKEN_EXPIRES_IN` (default 10m)
+  - `issueYorkieShareToken(shareToken)` — JWT `{ typ: 'yorkie-share', shareToken }`
+  - `verifyYorkieToken(token)` → discriminated union, throws on invalid/expired
+  - signed with `JWT_SECRET` (reuse accessSecret)
+- [ ] `AuthController`: token endpoints
+  - `GET /auth/yorkie-token` (JwtAuthGuard) → `{ token }` (user)
+  - `GET /auth/yorkie-token/share?token=<shareToken>` (public) → `{ token }` (share)
+  - throttle both
+- [ ] `AuthModule`: `exports: [AuthService]`
+- [ ] `document/yorkie-auth.controller.ts` — `POST /internal/yorkie/auth`
+  - `@UseGuards(YorkieSignatureGuard)`, `@SkipThrottle()`
+  - decide(): DetachDocument → always allow; verify token (else 401);
+    Activate/Deactivate → allow; doc methods → per-attribute access check
+  - response: explicit status (200/401/403) + `{ allowed, reason }` body
+  - shadow mode: `YORKIE_AUTH_WEBHOOK_ENFORCE` (default false) → log decision, return allow
+- [ ] `DocumentModule`: import `AuthModule`, register `YorkieAuthController`
+- [ ] `main.ts`: extend rawBody capture to `/internal/yorkie/` prefix (covers auth + events)
+
+## Frontend
+
+- [ ] `api/auth.ts` (or new): `fetchYorkieToken()` / `fetchYorkieShareToken(token)`
+- [ ] `PrivateRoute.tsx`: `authTokenInjector` → user token
+- [ ] `shared-document.tsx`: `authTokenInjector` → share token (all YorkieProvider mounts)
+
+## Ops / Docs
+
+- [ ] `.env.example` / backend README: `YORKIE_TOKEN_EXPIRES_IN`, `YORKIE_AUTH_WEBHOOK_ENFORCE`
+- [ ] Local setup note: `yorkie project update` with `--auth-webhook-url` + methods
+
+## Tests
+
+- [ ] AuthService yorkie-token round-trip (issue → verify, expiry, wrong typ)
+- [ ] YorkieAuthController decide(): member rw, share viewer r-only, unknown key, bad token → 401, detach always allow, shadow mode
+- [ ] `pnpm verify:fast` green
+
+## Verify
+
+- [ ] Self code-review over branch diff
+- [ ] Manual smoke in `pnpm dev` (shadow mode logs, then enforce)

--- a/docs/tasks/active/20260712-yorkie-auth-webhook-todo.md
+++ b/docs/tasks/active/20260712-yorkie-auth-webhook-todo.md
@@ -15,7 +15,7 @@ event-webhook HMAC guard.
   - signed with `JWT_SECRET` (reuse accessSecret)
 - [x] `AuthController`: token endpoints
   - `GET /auth/yorkie-token` (JwtAuthGuard) → `{ token }` (user)
-  - `GET /auth/yorkie-token/share?token=<shareToken>` (public) → `{ token }` (share)
+  - `POST /auth/yorkie-token/share` (public, token in body) → `{ token }` (share)
   - throttle both
 - [x] `AuthModule`: `exports: [AuthService]`
 - [x] `document/yorkie-auth.controller.ts` — `POST /internal/yorkie/auth`
@@ -40,7 +40,7 @@ event-webhook HMAC guard.
 
 ## Tests
 
-- [x] AuthService yorkie-token round-trip (issue → verify, expiry, wrong typ)
+- [x] AuthService yorkie-token round-trip (issue → verify, expiry, wrong type)
 - [x] YorkieAuthController decide(): member rw, share viewer r-only, unknown key, bad token → 401, detach always allow, shadow mode
 - [x] `pnpm verify:fast` green
 

--- a/docs/tasks/active/20260712-yorkie-auth-webhook-todo.md
+++ b/docs/tasks/active/20260712-yorkie-auth-webhook-todo.md
@@ -8,43 +8,60 @@ event-webhook HMAC guard.
 
 ## Backend
 
-- [ ] `AuthService`: add Yorkie token issue/verify
+- [x] `AuthService`: add Yorkie token issue/verify
   - `issueYorkieUserToken(userId)` — JWT `{ typ: 'yorkie', sub }`, exp `YORKIE_TOKEN_EXPIRES_IN` (default 10m)
   - `issueYorkieShareToken(shareToken)` — JWT `{ typ: 'yorkie-share', shareToken }`
   - `verifyYorkieToken(token)` → discriminated union, throws on invalid/expired
   - signed with `JWT_SECRET` (reuse accessSecret)
-- [ ] `AuthController`: token endpoints
+- [x] `AuthController`: token endpoints
   - `GET /auth/yorkie-token` (JwtAuthGuard) → `{ token }` (user)
   - `GET /auth/yorkie-token/share?token=<shareToken>` (public) → `{ token }` (share)
   - throttle both
-- [ ] `AuthModule`: `exports: [AuthService]`
-- [ ] `document/yorkie-auth.controller.ts` — `POST /internal/yorkie/auth`
+- [x] `AuthModule`: `exports: [AuthService]`
+- [x] `document/yorkie-auth.controller.ts` — `POST /internal/yorkie/auth`
   - `@UseGuards(YorkieSignatureGuard)`, `@SkipThrottle()`
   - decide(): DetachDocument → always allow; verify token (else 401);
     Activate/Deactivate → allow; doc methods → per-attribute access check
   - response: explicit status (200/401/403) + `{ allowed, reason }` body
   - shadow mode: `YORKIE_AUTH_WEBHOOK_ENFORCE` (default false) → log decision, return allow
-- [ ] `DocumentModule`: import `AuthModule`, register `YorkieAuthController`
-- [ ] `main.ts`: extend rawBody capture to `/internal/yorkie/` prefix (covers auth + events)
+- [x] `DocumentModule`: import `AuthModule`, register `YorkieAuthController`
+- [x] `main.ts`: extend rawBody capture to `/internal/yorkie/` prefix (covers auth + events)
 
 ## Frontend
 
-- [ ] `api/auth.ts` (or new): `fetchYorkieToken()` / `fetchYorkieShareToken(token)`
-- [ ] `PrivateRoute.tsx`: `authTokenInjector` → user token
-- [ ] `shared-document.tsx`: `authTokenInjector` → share token (all YorkieProvider mounts)
+- [x] `api/auth.ts` (or new): `fetchYorkieToken()` / `fetchYorkieShareToken(token)`
+- [x] `PrivateRoute.tsx`: `authTokenInjector` → user token
+- [x] `shared-document.tsx`: `authTokenInjector` → share token (all YorkieProvider mounts)
 
 ## Ops / Docs
 
-- [ ] `.env.example` / backend README: `YORKIE_TOKEN_EXPIRES_IN`, `YORKIE_AUTH_WEBHOOK_ENFORCE`
-- [ ] Local setup note: `yorkie project update` with `--auth-webhook-url` + methods
+- [x] `.env.example` / backend README: `YORKIE_TOKEN_EXPIRES_IN`, `YORKIE_AUTH_WEBHOOK_ENFORCE`
+- [x] Local setup note: `yorkie project update` with `--auth-webhook-url` + methods
 
 ## Tests
 
-- [ ] AuthService yorkie-token round-trip (issue → verify, expiry, wrong typ)
-- [ ] YorkieAuthController decide(): member rw, share viewer r-only, unknown key, bad token → 401, detach always allow, shadow mode
-- [ ] `pnpm verify:fast` green
+- [x] AuthService yorkie-token round-trip (issue → verify, expiry, wrong typ)
+- [x] YorkieAuthController decide(): member rw, share viewer r-only, unknown key, bad token → 401, detach always allow, shadow mode
+- [x] `pnpm verify:fast` green
 
 ## Verify
 
-- [ ] Self code-review over branch diff
+- [x] Self code-review over branch diff (workflow, high effort)
 - [ ] Manual smoke in `pnpm dev` (shadow mode logs, then enforce)
+
+## Code-review findings (applied)
+
+- [x] **Finding 1 (critical, privilege escalation)** — client-readable Yorkie
+  token signed with `JWT_SECRET` was replayable as a Bearer session because
+  `JwtStrategy.validate` never checked the token type. Fixed: require
+  `tokenType === 'access'` (also closes the pre-existing refresh-token replay
+  when `JWT_REFRESH_SECRET` is unset). Updated 4 e2e token helpers.
+- [ ] **Finding 2 (viewer verb)** — NOT a code fix: yorkie's verb is
+  change-pack-derived, so non-editing viewers get `r`. Documented as a
+  shadow-mode rollout validation item (design doc Risks).
+- [ ] **Finding 3 (direct URL / non-member)** — by design (canonical URLs need
+  membership; share uses the share route). Documented, no change.
+- [x] **Finding 4 (fail-open)** — doc method with empty attributes now fails
+  closed (403) instead of allow.
+- [x] **Finding 5 (cleanup)** — dropped the redundant Document read on the
+  share hot path (`findByToken` already loads it).

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -39,7 +39,41 @@ YORKIE_SECRET_KEY=                      # Optional, project secret key; enables
                                         # "currently editing" presence on
                                         # the documents list. Omit and the
                                         # list still works without avatars.
+                                        # Also the HMAC key for the Yorkie
+                                        # event + auth webhook signature guard.
+YORKIE_TOKEN_EXPIRES_IN=10m             # Optional, lifetime of the short-lived
+                                        # Yorkie auth-webhook token minted by
+                                        # GET /auth/yorkie-token.
+YORKIE_AUTH_WEBHOOK_ENFORCE=false       # Optional. false (default) = shadow
+                                        # mode: log the access decision but
+                                        # never deny. true = enforce per-doc
+                                        # access at the Yorkie auth webhook.
 ```
+
+### Yorkie auth webhook (per-document access control)
+
+`POST /internal/yorkie/auth` enforces per-document read/write access at the
+Yorkie layer (design: [`docs/design/yorkie-auth-webhook.md`](../../docs/design/yorkie-auth-webhook.md)).
+It is HMAC-verified with `YORKIE_SECRET_KEY` (same guard as the event webhook)
+and reads the caller's identity from a backend-minted token supplied by the
+frontend via `authTokenInjector`. Register it on the Yorkie project (auth
+webhook is a per-project setting, not a server flag):
+
+```bash
+yorkie login --rpc-addr localhost:8080          # once, as the project admin
+yorkie project update <project> \
+  --auth-webhook-url http://host.docker.internal:3000/internal/yorkie/auth \
+  --auth-webhook-method-add AttachDocument \
+  --auth-webhook-method-add PushPull \
+  --auth-webhook-method-add Watch \
+  --auth-webhook-method-add DetachDocument \
+  --auth-webhook-method-add Broadcast \
+  --auth-webhook-method-add RemoveDocument
+```
+
+Roll out with `YORKIE_AUTH_WEBHOOK_ENFORCE=false` first (shadow mode — logs the
+decision it *would* make), confirm no false denials, then flip to `true`.
+Unregister the methods (`--auth-webhook-method-rm ALL`) to disable.
 
 ### Development
 

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -43,6 +43,33 @@ export class AuthController {
     return req.user;
   }
 
+  /**
+   * Mint a short-lived token for the Yorkie client's `authTokenInjector`. The
+   * session JWT lives in an httpOnly cookie the browser can't read, so the
+   * frontend fetches this instead (the cookie authenticates the call). The
+   * Yorkie auth webhook resolves document access from the returned token.
+   */
+  @Get('yorkie-token')
+  @UseGuards(JwtAuthGuard)
+  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  async getYorkieToken(@Req() req: AuthenticatedRequest) {
+    return { token: this.authService.issueYorkieUserToken(req.user.id) };
+  }
+
+  /**
+   * Yorkie token for an anonymous share-link visitor (no session). Public: the
+   * token only wraps the share token; the webhook does the real validation
+   * (existence, expiry, document match, role) via `ShareLinkService`.
+   */
+  @Get('yorkie-token/share')
+  @Throttle({ default: { limit: 60, ttl: 60_000 } })
+  async getYorkieShareToken(@Query('token') shareToken: string | undefined) {
+    if (!shareToken) {
+      throw new BadRequestException('Missing share token');
+    }
+    return { token: this.authService.issueYorkieShareToken(shareToken) };
+  }
+
   @Post('logout')
   async logout(@Res() res: Response) {
     this.clearAuthCookies(res);

--- a/packages/backend/src/auth/auth.controller.ts
+++ b/packages/backend/src/auth/auth.controller.ts
@@ -59,11 +59,14 @@ export class AuthController {
   /**
    * Yorkie token for an anonymous share-link visitor (no session). Public: the
    * token only wraps the share token; the webhook does the real validation
-   * (existence, expiry, document match, role) via `ShareLinkService`.
+   * (existence, expiry, document match, role) via `ShareLinkService`. Uses POST
+   * with the share token in the body so the (access-granting) token stays out
+   * of request URLs and access logs.
    */
-  @Get('yorkie-token/share')
+  @Post('yorkie-token/share')
+  @HttpCode(200)
   @Throttle({ default: { limit: 60, ttl: 60_000 } })
-  async getYorkieShareToken(@Query('token') shareToken: string | undefined) {
+  async getYorkieShareToken(@Body('token') shareToken: string | undefined) {
     if (!shareToken) {
       throw new BadRequestException('Missing share token');
     }

--- a/packages/backend/src/auth/auth.module.ts
+++ b/packages/backend/src/auth/auth.module.ts
@@ -28,5 +28,6 @@ import { JwtStrategy } from './jwt.strategy';
   ],
   controllers: [AuthController],
   providers: [AuthService, CliAuthStore, GitHubAuthGuard, JwtStrategy, GitHubStrategy],
+  exports: [AuthService],
 })
 export class AuthModule {}

--- a/packages/backend/src/auth/auth.service.spec.ts
+++ b/packages/backend/src/auth/auth.service.spec.ts
@@ -55,4 +55,52 @@ describe('AuthService', () => {
       UnauthorizedException,
     );
   });
+
+  describe('Yorkie tokens', () => {
+    function makeService() {
+      const configService = createMockConfig({ JWT_SECRET: 'access-secret' });
+      return new AuthService(new JwtService(), configService);
+    }
+
+    it('round-trips a user token', () => {
+      const service = makeService();
+      const payload = service.verifyYorkieToken(
+        service.issueYorkieUserToken(42),
+      );
+      expect(payload).toMatchObject({ typ: 'yorkie', sub: 42 });
+    });
+
+    it('round-trips a share token', () => {
+      const service = makeService();
+      const payload = service.verifyYorkieToken(
+        service.issueYorkieShareToken('share-abc'),
+      );
+      expect(payload).toMatchObject({
+        typ: 'yorkie-share',
+        shareToken: 'share-abc',
+      });
+    });
+
+    it('rejects a session access token replayed as a Yorkie token', () => {
+      const service = makeService();
+      const { accessToken } = service.createTokens(user);
+      expect(() => service.verifyYorkieToken(accessToken)).toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws on a garbage token', () => {
+      const service = makeService();
+      expect(() => service.verifyYorkieToken('not-a-jwt')).toThrow();
+    });
+
+    it('throws on an expired token', () => {
+      const configService = createMockConfig({
+        JWT_SECRET: 'access-secret',
+        YORKIE_TOKEN_EXPIRES_IN: '-1s',
+      });
+      const service = new AuthService(new JwtService(), configService);
+      expect(() => service.verifyYorkieToken(service.issueYorkieUserToken(1))).toThrow();
+    });
+  });
 });

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -24,12 +24,25 @@ export type AuthTokens = {
   refreshToken: string;
 };
 
+/**
+ * Short-lived token handed to the Yorkie client's `authTokenInjector`, echoed
+ * back to us verbatim in the auth-webhook request body. It carries only the
+ * caller's identity — the webhook resolves document access from it. Two shapes:
+ * an authenticated user (`sub`), or an anonymous share-link visitor whose rights
+ * come from the link (`shareToken`). Never the raw session JWT — that is
+ * httpOnly and must not reach client JS.
+ */
+export type YorkieTokenPayload =
+  | { typ: 'yorkie'; sub: number }
+  | { typ: 'yorkie-share'; shareToken: string };
+
 @Injectable()
 export class AuthService {
   private readonly accessSecret: string;
   private readonly refreshSecret: string;
   private readonly accessExpiresIn: ms.StringValue;
   private readonly refreshExpiresIn: ms.StringValue;
+  private readonly yorkieTokenExpiresIn: ms.StringValue;
 
   constructor(
     private readonly jwtService: JwtService,
@@ -42,6 +55,44 @@ export class AuthService {
       (this.configService.get<string>('JWT_ACCESS_EXPIRES_IN') ?? '1h') as ms.StringValue;
     this.refreshExpiresIn =
       (this.configService.get<string>('JWT_REFRESH_EXPIRES_IN') ?? '7d') as ms.StringValue;
+    // Short by design: the webhook re-checks Postgres on every use, so a stale
+    // token only widens the window before a revoked role stops working. On
+    // expiry Yorkie 401s and the client silently re-fetches via authTokenInjector.
+    this.yorkieTokenExpiresIn =
+      (this.configService.get<string>('YORKIE_TOKEN_EXPIRES_IN') ??
+        '10m') as ms.StringValue;
+  }
+
+  /** Mint a Yorkie auth-webhook token for an authenticated user. */
+  issueYorkieUserToken(userId: number): string {
+    return this.jwtService.sign(
+      { typ: 'yorkie', sub: userId } satisfies YorkieTokenPayload,
+      { secret: this.accessSecret, expiresIn: this.yorkieTokenExpiresIn },
+    );
+  }
+
+  /** Mint a Yorkie auth-webhook token for an anonymous share-link visitor. */
+  issueYorkieShareToken(shareToken: string): string {
+    return this.jwtService.sign(
+      { typ: 'yorkie-share', shareToken } satisfies YorkieTokenPayload,
+      { secret: this.accessSecret, expiresIn: this.yorkieTokenExpiresIn },
+    );
+  }
+
+  /**
+   * Verify a Yorkie auth-webhook token. Throws (JsonWebTokenError /
+   * TokenExpiredError) on any invalid/expired/foreign token, which the webhook
+   * maps to a 401 so the client refreshes. Rejects other token types (access/
+   * refresh) so a leaked session JWT can't be replayed here.
+   */
+  verifyYorkieToken(token: string): YorkieTokenPayload {
+    const payload = this.jwtService.verify<YorkieTokenPayload & object>(token, {
+      secret: this.accessSecret,
+    });
+    if (payload.typ !== 'yorkie' && payload.typ !== 'yorkie-share') {
+      throw new UnauthorizedException('Invalid Yorkie token type');
+    }
+    return payload;
   }
 
   createTokens(user: User): AuthTokens {

--- a/packages/backend/src/auth/jwt.strategy.spec.ts
+++ b/packages/backend/src/auth/jwt.strategy.spec.ts
@@ -18,7 +18,10 @@ describe('JwtStrategy.validate', () => {
   };
 
   it('accepts an access token', async () => {
-    const user = await makeStrategy().validate({ ...base, tokenType: 'access' });
+    const user = await makeStrategy().validate({
+      ...base,
+      tokenType: 'access',
+    });
     expect(user).toEqual({
       id: 1,
       username: 'alice',

--- a/packages/backend/src/auth/jwt.strategy.spec.ts
+++ b/packages/backend/src/auth/jwt.strategy.spec.ts
@@ -1,0 +1,47 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtStrategy } from './jwt.strategy';
+
+function makeStrategy() {
+  const config = {
+    get: jest.fn((k: string) => (k === 'JWT_SECRET' ? 'secret' : undefined)),
+  } as unknown as ConfigService;
+  return new JwtStrategy(config);
+}
+
+describe('JwtStrategy.validate', () => {
+  const base = {
+    sub: 1,
+    username: 'alice',
+    email: 'alice@example.com',
+    photo: null,
+  };
+
+  it('accepts an access token', async () => {
+    const user = await makeStrategy().validate({ ...base, tokenType: 'access' });
+    expect(user).toEqual({
+      id: 1,
+      username: 'alice',
+      email: 'alice@example.com',
+      photo: null,
+    });
+  });
+
+  it('rejects a refresh token replayed as a Bearer session', async () => {
+    await expect(
+      makeStrategy().validate({ ...base, tokenType: 'refresh' }),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('rejects a client-readable Yorkie token replayed as a session', async () => {
+    await expect(
+      makeStrategy().validate({ typ: 'yorkie', sub: 1 }),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('rejects a token with no token type', async () => {
+    await expect(makeStrategy().validate(base)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+});

--- a/packages/backend/src/auth/jwt.strategy.ts
+++ b/packages/backend/src/auth/jwt.strategy.ts
@@ -1,6 +1,6 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
 
@@ -20,6 +20,16 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
+    // Only an access token grants an API session. Other JWTs signed with the
+    // same secret — the refresh token (`tokenType: 'refresh'`, which shares
+    // JWT_SECRET when JWT_REFRESH_SECRET is unset) and the client-readable
+    // Yorkie auth-webhook token (`typ: 'yorkie'`) — must not be replayable as a
+    // Bearer session. The Yorkie token in particular is exposed to client JS
+    // (unlike the httpOnly session cookie), so accepting it here would be a
+    // privilege escalation.
+    if (payload?.tokenType !== 'access') {
+      throw new UnauthorizedException('Invalid token type');
+    }
     return {
       id: payload.sub,
       username: payload.username,

--- a/packages/backend/src/document/document.module.ts
+++ b/packages/backend/src/document/document.module.ts
@@ -2,20 +2,23 @@ import { Module } from '@nestjs/common';
 import { DocumentController } from './document.controller';
 import { DocumentFileController } from './document-file.controller';
 import { YorkieEventController } from './yorkie-event.controller';
+import { YorkieAuthController } from './yorkie-auth.controller';
 import { YorkieSignatureGuard } from './yorkie-signature.guard';
 import { DocumentService } from './document.service';
 import { UserService } from 'src/user/user.service';
 import { PrismaService } from 'src/database/prisma.service';
+import { AuthModule } from '../auth/auth.module';
 import { WorkspaceModule } from '../workspace/workspace.module';
 import { FileModule } from '../file/file.module';
 import { ShareLinkModule } from '../share-link/share-link.module';
 
 @Module({
-  imports: [WorkspaceModule, FileModule, ShareLinkModule],
+  imports: [AuthModule, WorkspaceModule, FileModule, ShareLinkModule],
   controllers: [
     DocumentController,
     DocumentFileController,
     YorkieEventController,
+    YorkieAuthController,
   ],
   providers: [
     DocumentService,

--- a/packages/backend/src/document/yorkie-auth.controller.spec.ts
+++ b/packages/backend/src/document/yorkie-auth.controller.spec.ts
@@ -33,7 +33,7 @@ function makeController(opts: {
   } as unknown as DocumentService;
 
   const workspaceService = {
-    assertMember: jest.fn(async (_ws: string, userId: number) => {
+    assertMember: jest.fn((_ws: string, userId: number) => {
       if (!opts.members?.has(userId)) {
         throw new ForbiddenException('not a member');
       }
@@ -42,7 +42,7 @@ function makeController(opts: {
   } as unknown as WorkspaceService;
 
   const shareLinkService = {
-    findByToken: jest.fn(async () => {
+    findByToken: jest.fn(() => {
       if (!opts.share || opts.share === 'throw') {
         throw new Error('not found');
       }
@@ -87,7 +87,9 @@ describe('YorkieAuthController.decide', () => {
 
   it('allows ActivateClient with only a valid token', async () => {
     const c = makeController({ identity: { typ: 'yorkie', sub: 1 } });
-    expect(await c.decide({ method: 'ActivateClient', token: 't' })).toMatchObject({
+    expect(
+      await c.decide({ method: 'ActivateClient', token: 't' }),
+    ).toMatchObject({
       status: 200,
       allowed: true,
     });
@@ -181,7 +183,11 @@ describe('YorkieAuthController.decide', () => {
         token: 't',
         attributes: [{ key: 'bogus-1', verb: 'r' }],
       }),
-    ).toMatchObject({ status: 403, allowed: false, reason: 'unknown document key' });
+    ).toMatchObject({
+      status: 403,
+      allowed: false,
+      reason: 'unknown document key',
+    });
   });
 
   it('fails closed (403) on a document method with no attributes', async () => {
@@ -209,29 +215,40 @@ describe('YorkieAuthController.decide', () => {
 
 describe('YorkieAuthController.handleAuth (shadow vs enforce)', () => {
   function mockRes() {
-    const res = { status: jest.fn() } as unknown as Response;
-    return res;
+    // Return the status spy separately so assertions reference the bound spy,
+    // not `res.status` as an unbound method.
+    const status = jest.fn();
+    const res = { status } as unknown as Response;
+    return { res, status };
   }
 
   it('returns the real deny status when enforcing', async () => {
     const c = makeController({ enforce: true, identity: 'throw' });
-    const res = mockRes();
+    const { res, status } = mockRes();
     const body = await c.handleAuth(
-      { method: 'PushPull', token: 'bad', attributes: [{ key: 'sheet-1', verb: 'r' }] },
+      {
+        method: 'PushPull',
+        token: 'bad',
+        attributes: [{ key: 'sheet-1', verb: 'r' }],
+      },
       res,
     );
-    expect(res.status).toHaveBeenCalledWith(401);
+    expect(status).toHaveBeenCalledWith(401);
     expect(body.allowed).toBe(false);
   });
 
   it('lets denied traffic through (200) in shadow mode', async () => {
     const c = makeController({ enforce: false, identity: 'throw' });
-    const res = mockRes();
+    const { res, status } = mockRes();
     const body = await c.handleAuth(
-      { method: 'PushPull', token: 'bad', attributes: [{ key: 'sheet-1', verb: 'r' }] },
+      {
+        method: 'PushPull',
+        token: 'bad',
+        attributes: [{ key: 'sheet-1', verb: 'r' }],
+      },
       res,
     );
-    expect(res.status).toHaveBeenCalledWith(200);
+    expect(status).toHaveBeenCalledWith(200);
     expect(body.allowed).toBe(true);
   });
 });

--- a/packages/backend/src/document/yorkie-auth.controller.spec.ts
+++ b/packages/backend/src/document/yorkie-auth.controller.spec.ts
@@ -1,0 +1,230 @@
+import { ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { Response } from 'express';
+import { YorkieAuthController } from './yorkie-auth.controller';
+import { AuthService, YorkieTokenPayload } from '../auth/auth.service';
+import { DocumentService } from './document.service';
+import { ShareLinkService } from '../share-link/share-link.service';
+import { WorkspaceService } from '../workspace/workspace.service';
+
+/**
+ * Builds a controller with configurable stubs. `token` is decoded straight to
+ * the given identity (or throws for the token `'bad'`); the DB is a couple of
+ * in-memory maps.
+ */
+function makeController(opts: {
+  enforce?: boolean;
+  identity?: YorkieTokenPayload | 'throw';
+  doc?: { id: string; workspaceId: string } | null;
+  members?: Set<number>;
+  share?: { documentId: string; role: string } | 'throw';
+}) {
+  const authService = {
+    verifyYorkieToken: jest.fn((): YorkieTokenPayload => {
+      if (!opts.identity || opts.identity === 'throw') {
+        throw new Error('invalid');
+      }
+      return opts.identity;
+    }),
+  } as unknown as AuthService;
+
+  const documentService = {
+    document: jest.fn().mockResolvedValue(opts.doc ?? null),
+  } as unknown as DocumentService;
+
+  const workspaceService = {
+    assertMember: jest.fn(async (_ws: string, userId: number) => {
+      if (!opts.members?.has(userId)) {
+        throw new ForbiddenException('not a member');
+      }
+      return {} as never;
+    }),
+  } as unknown as WorkspaceService;
+
+  const shareLinkService = {
+    findByToken: jest.fn(async () => {
+      if (!opts.share || opts.share === 'throw') {
+        throw new Error('not found');
+      }
+      return opts.share as never;
+    }),
+  } as unknown as ShareLinkService;
+
+  const configService = {
+    get: jest.fn((k: string) =>
+      k === 'YORKIE_AUTH_WEBHOOK_ENFORCE' && opts.enforce ? 'true' : undefined,
+    ),
+  } as unknown as ConfigService;
+
+  return new YorkieAuthController(
+    authService,
+    documentService,
+    workspaceService,
+    shareLinkService,
+    configService,
+  );
+}
+
+describe('YorkieAuthController.decide', () => {
+  it('always allows DetachDocument, even with a bad token', async () => {
+    const c = makeController({ identity: 'throw' });
+    expect(await c.decide({ method: 'DetachDocument', token: 'bad' })).toEqual({
+      status: 200,
+      allowed: true,
+      reason: 'ok',
+    });
+  });
+
+  it('401s on an invalid/expired token for a doc method', async () => {
+    const c = makeController({ identity: 'throw' });
+    const d = await c.decide({
+      method: 'PushPull',
+      token: 'bad',
+      attributes: [{ key: 'sheet-1', verb: 'r' }],
+    });
+    expect(d).toMatchObject({ status: 401, allowed: false });
+  });
+
+  it('allows ActivateClient with only a valid token', async () => {
+    const c = makeController({ identity: { typ: 'yorkie', sub: 1 } });
+    expect(await c.decide({ method: 'ActivateClient', token: 't' })).toMatchObject({
+      status: 200,
+      allowed: true,
+    });
+  });
+
+  it('grants a workspace member read+write', async () => {
+    const c = makeController({
+      identity: { typ: 'yorkie', sub: 7 },
+      doc: { id: '1', workspaceId: 'ws' },
+      members: new Set([7]),
+    });
+    expect(
+      await c.decide({
+        method: 'PushPull',
+        token: 't',
+        attributes: [{ key: 'sheet-1', verb: 'rw' }],
+      }),
+    ).toMatchObject({ status: 200, allowed: true });
+  });
+
+  it('403s a non-member', async () => {
+    const c = makeController({
+      identity: { typ: 'yorkie', sub: 9 },
+      doc: { id: '1', workspaceId: 'ws' },
+      members: new Set([7]),
+    });
+    expect(
+      await c.decide({
+        method: 'PushPull',
+        token: 't',
+        attributes: [{ key: 'sheet-1', verb: 'r' }],
+      }),
+    ).toMatchObject({ status: 403, allowed: false });
+  });
+
+  it('lets a share viewer read but not write', async () => {
+    const base = {
+      identity: { typ: 'yorkie-share', shareToken: 's' } as YorkieTokenPayload,
+      doc: { id: '1', workspaceId: 'ws' },
+      share: { documentId: '1', role: 'viewer' },
+    };
+    const read = await makeController(base).decide({
+      method: 'PushPull',
+      token: 't',
+      attributes: [{ key: 'sheet-1', verb: 'r' }],
+    });
+    const write = await makeController(base).decide({
+      method: 'PushPull',
+      token: 't',
+      attributes: [{ key: 'sheet-1', verb: 'rw' }],
+    });
+    expect(read).toMatchObject({ status: 200, allowed: true });
+    expect(write).toMatchObject({ status: 403, allowed: false });
+  });
+
+  it('lets a share editor write', async () => {
+    const c = makeController({
+      identity: { typ: 'yorkie-share', shareToken: 's' },
+      doc: { id: '1', workspaceId: 'ws' },
+      share: { documentId: '1', role: 'editor' },
+    });
+    expect(
+      await c.decide({
+        method: 'PushPull',
+        token: 't',
+        attributes: [{ key: 'sheet-1', verb: 'rw' }],
+      }),
+    ).toMatchObject({ status: 200, allowed: true });
+  });
+
+  it('403s a share token bound to a different document', async () => {
+    const c = makeController({
+      identity: { typ: 'yorkie-share', shareToken: 's' },
+      doc: { id: '1', workspaceId: 'ws' },
+      share: { documentId: 'other', role: 'editor' },
+    });
+    expect(
+      await c.decide({
+        method: 'PushPull',
+        token: 't',
+        attributes: [{ key: 'sheet-1', verb: 'r' }],
+      }),
+    ).toMatchObject({ status: 403, allowed: false });
+  });
+
+  it('403s an unknown document-key prefix', async () => {
+    const c = makeController({ identity: { typ: 'yorkie', sub: 1 } });
+    expect(
+      await c.decide({
+        method: 'PushPull',
+        token: 't',
+        attributes: [{ key: 'bogus-1', verb: 'r' }],
+      }),
+    ).toMatchObject({ status: 403, allowed: false, reason: 'unknown document key' });
+  });
+
+  it('403s when the document does not exist', async () => {
+    const c = makeController({
+      identity: { typ: 'yorkie', sub: 1 },
+      doc: null,
+      members: new Set([1]),
+    });
+    expect(
+      await c.decide({
+        method: 'PushPull',
+        token: 't',
+        attributes: [{ key: 'sheet-missing', verb: 'r' }],
+      }),
+    ).toMatchObject({ status: 403, allowed: false });
+  });
+});
+
+describe('YorkieAuthController.handleAuth (shadow vs enforce)', () => {
+  function mockRes() {
+    const res = { status: jest.fn() } as unknown as Response;
+    return res;
+  }
+
+  it('returns the real deny status when enforcing', async () => {
+    const c = makeController({ enforce: true, identity: 'throw' });
+    const res = mockRes();
+    const body = await c.handleAuth(
+      { method: 'PushPull', token: 'bad', attributes: [{ key: 'sheet-1', verb: 'r' }] },
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(body.allowed).toBe(false);
+  });
+
+  it('lets denied traffic through (200) in shadow mode', async () => {
+    const c = makeController({ enforce: false, identity: 'throw' });
+    const res = mockRes();
+    const body = await c.handleAuth(
+      { method: 'PushPull', token: 'bad', attributes: [{ key: 'sheet-1', verb: 'r' }] },
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(body.allowed).toBe(true);
+  });
+});

--- a/packages/backend/src/document/yorkie-auth.controller.spec.ts
+++ b/packages/backend/src/document/yorkie-auth.controller.spec.ts
@@ -184,6 +184,13 @@ describe('YorkieAuthController.decide', () => {
     ).toMatchObject({ status: 403, allowed: false, reason: 'unknown document key' });
   });
 
+  it('fails closed (403) on a document method with no attributes', async () => {
+    const c = makeController({ identity: { typ: 'yorkie', sub: 1 } });
+    expect(
+      await c.decide({ method: 'PushPull', token: 't', attributes: [] }),
+    ).toMatchObject({ status: 403, allowed: false });
+  });
+
   it('403s when the document does not exist', async () => {
     const c = makeController({
       identity: { typ: 'yorkie', sub: 1 },

--- a/packages/backend/src/document/yorkie-auth.controller.ts
+++ b/packages/backend/src/document/yorkie-auth.controller.ts
@@ -134,8 +134,20 @@ export class YorkieAuthController {
     }
 
     // Client-scoped methods carry no document; a valid token is enough.
-    if (CLIENT_METHODS.has(method) || !body?.attributes?.length) {
+    if (CLIENT_METHODS.has(method)) {
       return ALLOW;
+    }
+
+    // A document-scoped method must name the document(s) it targets. An empty
+    // attribute list leaves nothing to authorize, so fail closed rather than
+    // blanket-allow — a would-be bypass then surfaces as a shadow-mode log
+    // before enforcement is turned on.
+    if (!body?.attributes?.length) {
+      return {
+        status: 403,
+        allowed: false,
+        reason: 'missing document attributes',
+      };
     }
 
     for (const attr of body.attributes) {
@@ -168,14 +180,14 @@ export class YorkieAuthController {
     documentId: string,
     needWrite: boolean,
   ): Promise<boolean> {
-    const doc = await this.documentService.document({ id: documentId });
-    if (!doc) {
-      return false;
-    }
-
     if (identity.typ === 'yorkie') {
-      // Workspace membership grants read+write; the model has no per-member
-      // viewer role today (see design doc's granularity note).
+      // Need the document's workspace to check membership. Membership grants
+      // read+write; the model has no per-member viewer role today (see design
+      // doc's granularity note).
+      const doc = await this.documentService.document({ id: documentId });
+      if (!doc) {
+        return false;
+      }
       try {
         await this.workspaceService.assertMember(doc.workspaceId, identity.sub);
         return true;
@@ -185,6 +197,8 @@ export class YorkieAuthController {
     }
 
     // Anonymous share visitor: the link decides the role and the document.
+    // `findByToken` already loads + validates the document (FK, expiry), so no
+    // separate document read is needed here.
     try {
       const link = await this.shareLinkService.findByToken(identity.shareToken);
       if (link.documentId !== documentId) {

--- a/packages/backend/src/document/yorkie-auth.controller.ts
+++ b/packages/backend/src/document/yorkie-auth.controller.ts
@@ -1,0 +1,198 @@
+import {
+  Body,
+  Controller,
+  Logger,
+  Post,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SkipThrottle } from '@nestjs/throttler';
+import type { Response } from 'express';
+import { AuthService, YorkieTokenPayload } from '../auth/auth.service';
+import { DocumentService } from './document.service';
+import { ShareLinkService } from '../share-link/share-link.service';
+import { WorkspaceService } from '../workspace/workspace.service';
+import { parseYorkieDocKey } from '../yorkie/yorkie-doc-key';
+import { YorkieSignatureGuard } from './yorkie-signature.guard';
+
+/**
+ * Yorkie auth-webhook request body (yorkie 0.7.12,
+ * `api/types/auth_webhook.go`). `verb` is `"r"` (read) or `"rw"` (read-write).
+ */
+type Verb = 'r' | 'rw';
+interface AuthAttribute {
+  key?: string;
+  verb?: Verb;
+}
+interface YorkieAuthBody {
+  token?: string;
+  method?: string;
+  attributes?: AuthAttribute[];
+}
+
+/**
+ * The decision, before the shadow/enforce gate. `status`/`allowed` must stay
+ * consistent because yorkie only accepts three (status, allowed) pairs
+ * (`server/rpc/auth/webhook.go#handleWebhookResponse`): `200 + true` (allow),
+ * `403 + false` (permission denied), `401 + false` (unauthenticated → the
+ * client refreshes its token via `authTokenInjector` and retries). Any other
+ * pair is treated by yorkie as an invalid response.
+ */
+interface AuthDecision {
+  status: 200 | 401 | 403;
+  allowed: boolean;
+  reason: string;
+}
+
+const ALLOW: AuthDecision = { status: 200, allowed: true, reason: 'ok' };
+const UNAUTHENTICATED: AuthDecision = {
+  status: 401,
+  allowed: false,
+  reason: 'invalid or expired token',
+};
+
+/**
+ * `DetachDocument` is always allowed: a client must be able to detach (and let
+ * Yorkie GC its tombstones) even after its access was revoked or its token
+ * expired mid-session. See `docs/design/yorkie-auth-webhook.md`.
+ */
+const ALWAYS_ALLOWED_METHOD = 'DetachDocument';
+
+/** Methods with no document context — a valid token is sufficient. */
+const CLIENT_METHODS = new Set(['ActivateClient', 'DeactivateClient']);
+
+/**
+ * Yorkie **auth** webhook: server-enforced per-document read/write access. On
+ * privileged RPCs Yorkie POSTs `{ token, method, attributes:[{key, verb}] }`
+ * here; we resolve the token to an identity and check it against the Postgres
+ * permission model (`WorkspaceMember` / `ShareLink`) per document key + verb.
+ *
+ * Authenticated by HMAC signature ({@link YorkieSignatureGuard}, shared with
+ * the event webhook) — the signature proves the caller is Yorkie; the `token`
+ * in the body proves who the end user is.
+ *
+ * Rollout: while `YORKIE_AUTH_WEBHOOK_ENFORCE` is not `true`, the computed
+ * decision is logged but never enforced (always returns allow), so the webhook
+ * can be registered and observed before it starts denying traffic.
+ */
+@Controller('internal/yorkie')
+@SkipThrottle()
+@UseGuards(YorkieSignatureGuard)
+export class YorkieAuthController {
+  private readonly logger = new Logger(YorkieAuthController.name);
+  private readonly enforce: boolean;
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly documentService: DocumentService,
+    private readonly workspaceService: WorkspaceService,
+    private readonly shareLinkService: ShareLinkService,
+    configService: ConfigService,
+  ) {
+    this.enforce =
+      configService.get<string>('YORKIE_AUTH_WEBHOOK_ENFORCE') === 'true';
+  }
+
+  @Post('auth')
+  async handleAuth(
+    @Body() body: YorkieAuthBody,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<{ allowed: boolean; reason: string }> {
+    const decision = await this.decide(body);
+
+    if (!this.enforce && !decision.allowed) {
+      // Shadow mode: surface what we *would* have done, but let the request
+      // through so a resolver bug can't lock everyone out during rollout.
+      this.logger.warn(
+        `[shadow] would deny method=${body?.method} status=${decision.status} reason=${decision.reason}`,
+      );
+      res.status(ALLOW.status);
+      return { allowed: ALLOW.allowed, reason: 'shadow' };
+    }
+
+    res.status(decision.status);
+    return { allowed: decision.allowed, reason: decision.reason };
+  }
+
+  /**
+   * Pure-ish authorization decision (no HTTP concerns), so it can be unit
+   * tested directly. Unknown methods fall through to the generic
+   * verify-token-then-check-attributes path.
+   */
+  async decide(body: YorkieAuthBody): Promise<AuthDecision> {
+    const method = body?.method ?? '';
+    if (method === ALWAYS_ALLOWED_METHOD) {
+      return ALLOW;
+    }
+
+    let identity: YorkieTokenPayload;
+    try {
+      identity = this.authService.verifyYorkieToken(body?.token ?? '');
+    } catch {
+      return UNAUTHENTICATED;
+    }
+
+    // Client-scoped methods carry no document; a valid token is enough.
+    if (CLIENT_METHODS.has(method) || !body?.attributes?.length) {
+      return ALLOW;
+    }
+
+    for (const attr of body.attributes) {
+      const denied = await this.checkAttribute(identity, attr);
+      if (denied) {
+        return denied;
+      }
+    }
+    return ALLOW;
+  }
+
+  /** Returns a deny decision, or `null` when the attribute is allowed. */
+  private async checkAttribute(
+    identity: YorkieTokenPayload,
+    attr: AuthAttribute,
+  ): Promise<AuthDecision | null> {
+    const parsed = attr.key ? parseYorkieDocKey(attr.key) : null;
+    if (!parsed) {
+      return { status: 403, allowed: false, reason: 'unknown document key' };
+    }
+    const needWrite = attr.verb === 'rw';
+    const ok = await this.hasAccess(identity, parsed.id, needWrite);
+    return ok
+      ? null
+      : { status: 403, allowed: false, reason: 'no access to document' };
+  }
+
+  private async hasAccess(
+    identity: YorkieTokenPayload,
+    documentId: string,
+    needWrite: boolean,
+  ): Promise<boolean> {
+    const doc = await this.documentService.document({ id: documentId });
+    if (!doc) {
+      return false;
+    }
+
+    if (identity.typ === 'yorkie') {
+      // Workspace membership grants read+write; the model has no per-member
+      // viewer role today (see design doc's granularity note).
+      try {
+        await this.workspaceService.assertMember(doc.workspaceId, identity.sub);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    // Anonymous share visitor: the link decides the role and the document.
+    try {
+      const link = await this.shareLinkService.findByToken(identity.shareToken);
+      if (link.documentId !== documentId) {
+        return false;
+      }
+      return needWrite ? link.role === 'editor' : true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/backend/src/document/yorkie-auth.controller.ts
+++ b/packages/backend/src/document/yorkie-auth.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Body,
-  Controller,
-  Logger,
-  Post,
-  Res,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Logger, Post, Res, UseGuards } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SkipThrottle } from '@nestjs/throttler';
 import type { Response } from 'express';

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -20,11 +20,12 @@ import { AppModule } from './app.module';
 const JSON_BODY_LIMIT = process.env.BACKEND_JSON_BODY_LIMIT ?? '25mb';
 
 /**
- * The only route whose raw request bytes must be retained (for the Yorkie
- * event-webhook HMAC check). Must match the controller path in
- * `document/yorkie-event.controller.ts`.
+ * Routes whose raw request bytes must be retained for the Yorkie webhook HMAC
+ * check — the event webhook (`document/yorkie-event.controller.ts`) and the
+ * auth webhook (`document/yorkie-auth.controller.ts`). Both live under
+ * `/internal/yorkie/`, so a prefix match covers them (and any future one).
  */
-const YORKIE_WEBHOOK_PATH = '/internal/yorkie/events';
+const YORKIE_WEBHOOK_PATH_PREFIX = '/internal/yorkie/';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -48,7 +49,7 @@ async function bootstrap() {
     bodyParser.json({
       limit: JSON_BODY_LIMIT,
       verify: (req: IncomingMessage & { rawBody?: Buffer }, _res, buf) => {
-        if (req.url?.split('?', 1)[0] === YORKIE_WEBHOOK_PATH) {
+        if (req.url?.split('?', 1)[0].startsWith(YORKIE_WEBHOOK_PATH_PREFIX)) {
           req.rawBody = buf;
         }
       },

--- a/packages/backend/test/api-key-http.e2e-spec.ts
+++ b/packages/backend/test/api-key-http.e2e-spec.ts
@@ -32,6 +32,7 @@ describeDb('API Key HTTP integration', () => {
   }) {
     const token = jwtService.sign(
       {
+        tokenType: 'access',
         sub: user.id,
         username: user.username,
         email: user.email,

--- a/packages/backend/test/authenticated-http.e2e-spec.ts
+++ b/packages/backend/test/authenticated-http.e2e-spec.ts
@@ -33,6 +33,7 @@ describeDb('Authenticated HTTP integration (JWT + controllers + Prisma)', () => 
   }) {
     const token = jwtService.sign(
       {
+        tokenType: 'access',
         sub: user.id,
         username: user.username,
         email: user.email,

--- a/packages/backend/test/document-file-serving.e2e-spec.ts
+++ b/packages/backend/test/document-file-serving.e2e-spec.ts
@@ -35,6 +35,7 @@ describeDb('GET /documents/:id/file (member OR share token)', () => {
   }) {
     const token = jwtService.sign(
       {
+        tokenType: 'access',
         sub: user.id,
         username: user.username,
         email: user.email,

--- a/packages/backend/test/user-doc-styles.e2e-spec.ts
+++ b/packages/backend/test/user-doc-styles.e2e-spec.ts
@@ -31,6 +31,7 @@ describeDb('User doc styles HTTP integration (JWT + controller + Prisma)', () =>
   }) {
     const token = jwtService.sign(
       {
+        tokenType: 'access',
         sub: user.id,
         username: user.username,
         email: user.email,

--- a/packages/frontend/src/PrivateRoute.tsx
+++ b/packages/frontend/src/PrivateRoute.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from "react";
 import { Navigate, Outlet } from "react-router-dom";
 import { Loader } from "./components/loader";
 import { useQuery } from "@tanstack/react-query";
-import { fetchMe } from "./api/auth";
+import { fetchMe, fetchYorkieToken } from "./api/auth";
 import { YorkieProvider } from "@yorkie-js/react";
 
 /**
@@ -24,6 +24,7 @@ export const PrivateRoute = (): ReactElement => {
       rpcAddr={import.meta.env.VITE_YORKIE_RPC_ADDR}
       apiKey={import.meta.env.VITE_YORKIE_PUBLIC_KEY}
       metadata={{ userID: encodeURIComponent(me.username || "anonymous-user") }}
+      authTokenInjector={fetchYorkieToken}
     >
       <Outlet />
     </YorkieProvider>

--- a/packages/frontend/src/api/auth.ts
+++ b/packages/frontend/src/api/auth.ts
@@ -187,11 +187,15 @@ export async function fetchYorkieToken(): Promise<string> {
 export async function fetchYorkieShareToken(
   shareToken: string
 ): Promise<string> {
+  // POST with the token in the body (not the URL) so this access-granting
+  // token stays out of request URLs and server access logs.
   const res = await fetch(
-    `${import.meta.env.VITE_BACKEND_API_URL}/auth/yorkie-token/share?token=${encodeURIComponent(
-      shareToken
-    )}`,
-    { method: "GET" }
+    `${import.meta.env.VITE_BACKEND_API_URL}/auth/yorkie-token/share`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: shareToken }),
+    }
   );
   if (!res.ok) {
     throw new Error("Failed to fetch Yorkie share token");

--- a/packages/frontend/src/api/auth.ts
+++ b/packages/frontend/src/api/auth.ts
@@ -162,3 +162,40 @@ export async function fetchWithAuth(
 
   return response;
 }
+
+/**
+ * Fetches a short-lived Yorkie auth-webhook token for the current session,
+ * for the Yorkie client's `authTokenInjector`. Routes through `fetchWithAuth`
+ * so an expired session refreshes (or redirects to login) transparently.
+ */
+export async function fetchYorkieToken(): Promise<string> {
+  const res = await fetchWithAuth(
+    `${import.meta.env.VITE_BACKEND_API_URL}/auth/yorkie-token`,
+    { method: "GET", credentials: "include" }
+  );
+  if (!res.ok) {
+    throw new Error("Failed to fetch Yorkie token");
+  }
+  const { token } = (await res.json()) as { token: string };
+  return token;
+}
+
+/**
+ * Fetches a Yorkie auth-webhook token for an anonymous share-link visitor.
+ * The webhook validates the wrapped share token (existence, expiry, role).
+ */
+export async function fetchYorkieShareToken(
+  shareToken: string
+): Promise<string> {
+  const res = await fetch(
+    `${import.meta.env.VITE_BACKEND_API_URL}/auth/yorkie-token/share?token=${encodeURIComponent(
+      shareToken
+    )}`,
+    { method: "GET" }
+  );
+  if (!res.ok) {
+    throw new Error("Failed to fetch Yorkie share token");
+  }
+  const { token } = (await res.json()) as { token: string };
+  return token;
+}

--- a/packages/frontend/src/app/shared/shared-document.tsx
+++ b/packages/frontend/src/app/shared/shared-document.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { YorkieProvider, DocumentProvider, useDocument } from "@yorkie-js/react";
 import { toast } from "sonner";
 import { resolveShareLink, ResolvedShareLink } from "@/api/share-links";
-import { fetchMeOptional } from "@/api/auth";
+import { fetchMeOptional, fetchYorkieShareToken } from "@/api/auth";
 import { Loader } from "@/components/loader";
 import SheetView from "@/app/spreadsheet/sheet-view";
 import {
@@ -576,6 +576,7 @@ function SharedPdfLayout({
       rpcAddr={import.meta.env.VITE_YORKIE_RPC_ADDR}
       apiKey={import.meta.env.VITE_YORKIE_PUBLIC_KEY}
       metadata={{ userID: presenceUser.username }}
+      authTokenInjector={token ? () => fetchYorkieShareToken(token) : undefined}
     >
       <PdfCollabProvider
         documentId={resolved.documentId}
@@ -667,6 +668,7 @@ function SharedDocumentInner({
       rpcAddr={import.meta.env.VITE_YORKIE_RPC_ADDR}
       apiKey={import.meta.env.VITE_YORKIE_PUBLIC_KEY}
       metadata={{ userID: presence.username }}
+      authTokenInjector={token ? () => fetchYorkieShareToken(token) : undefined}
     >
       {resolved.type === "doc" ? (
         <DocumentProvider<YorkieDocsRoot>


### PR DESCRIPTION
## Summary

Yorkie clients attach with only the project **public key** today, so anyone holding it can read or write **any** document key (`sheet-*`, `doc-*`, `slides-*`, `pdf-*`) — the Postgres permission model (`WorkspaceMember` / `ShareLink`) is invisible to Yorkie and read-only is merely self-enforced by the frontend. This wires Yorkie's **auth webhook** to enforce per-document read/write access at the Yorkie layer.

- **Token** — the backend mints a short-lived, client-readable identity token (`GET /auth/yorkie-token`, plus a public `?token=` share variant) that the frontend feeds to the Yorkie client via `authTokenInjector`. Never the httpOnly session JWT.
- **Webhook** — Yorkie echoes the token to `POST /internal/yorkie/auth`, which reuses the event-webhook **HMAC guard**, decodes the token, and checks workspace membership / share-link role against the requested doc key + verb.
- **Rollout** — gated by `YORKIE_AUTH_WEBHOOK_ENFORCE` (default **false** = shadow mode: logs the decision but never denies). `DetachDocument` is always allowed so GC survives revocation.
- **Replay hardening** — the Yorkie token shares `JWT_SECRET` but is readable by client JS, so `JwtStrategy` now requires `tokenType === 'access'`; this blocks replaying a Yorkie token (or a refresh token when `JWT_REFRESH_SECRET` is unset) as a Bearer session.

Design: `docs/design/yorkie-auth-webhook.md`. Self-reviewed (high-effort multi-agent); findings applied — see `docs/tasks/active/20260712-yorkie-auth-webhook-todo.md`.

## Test plan

- [x] `pnpm backend test` — 255 existing + 24 new unit tests green (AuthService token round-trip/expiry/replay, `JwtStrategy` tokenType gate, webhook `decide()` across member/viewer/editor/unknown-key/missing-doc/empty-attributes/shadow-vs-enforce).
- [x] `pnpm backend build` clean; frontend lint green.
- [ ] **Manual smoke (before enabling enforcement):** register the webhook (`yorkie project update … --auth-webhook-url … --auth-webhook-method-add …`), run in shadow mode, and confirm from the shadow logs that read-only share-link visitors request verb `r` (not `rw`) before flipping `YORKIE_AUTH_WEBHOOK_ENFORCE=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-document read and write access controls for collaborative documents.
  * Workspace members and shared-link visitors now receive permissions based on their roles.
  * Added secure authentication for both signed-in and shared-link access, including short-lived tokens.
  * Yorkie connections now authenticate automatically for private and shared documents.

* **Bug Fixes**
  * Prevented refresh or unrelated tokens from being accepted as active sessions.
  * Added fail-closed handling for invalid, expired, or unauthorized document requests.

* **Documentation**
  * Documented configuration, webhook setup, rollout options, and implementation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->