### PR TITLE
Slides: repaint mobile/presenter view on async asset load

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,9 +18,13 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
-| slides background (2026-07-12) | [20260712-slides-background-todo.md](./active/20260712-slides-background-todo.md) | [20260712-slides-background-lessons.md](./active/20260712-slides-background-lessons.md) |
+| slides mobile bg repaint (2026-07-14) | [20260714-slides-mobile-bg-repaint-todo.md](./active/20260714-slides-mobile-bg-repaint-todo.md) | [20260714-slides-mobile-bg-repaint-lessons.md](./active/20260714-slides-mobile-bg-repaint-lessons.md) |
+| checkbox parity (2026-07-12) | [20260712-checkbox-parity-todo.md](./active/20260712-checkbox-parity-todo.md) | [20260712-checkbox-parity-lessons.md](./active/20260712-checkbox-parity-lessons.md) |
+| checkbox validation bugfix (2026-07-12) | [20260712-checkbox-validation-bugfix-todo.md](./active/20260712-checkbox-validation-bugfix-todo.md) | [20260712-checkbox-validation-bugfix-lessons.md](./active/20260712-checkbox-validation-bugfix-lessons.md) |
 | release v0.5.1 (2026-07-12) | [20260712-release-v0.5.1-todo.md](./active/20260712-release-v0.5.1-todo.md) | - |
+| slides background (2026-07-12) | [20260712-slides-background-todo.md](./active/20260712-slides-background-todo.md) | [20260712-slides-background-lessons.md](./active/20260712-slides-background-lessons.md) |
 | slides font ooxml parity (2026-07-12) | [20260712-slides-font-ooxml-parity-todo.md](./active/20260712-slides-font-ooxml-parity-todo.md) | [20260712-slides-font-ooxml-parity-lessons.md](./active/20260712-slides-font-ooxml-parity-lessons.md) |
+| validation number text (2026-07-12) | [20260712-validation-number-text-todo.md](./active/20260712-validation-number-text-todo.md) | - |
 | yorkie auth webhook (2026-07-12) | [20260712-yorkie-auth-webhook-todo.md](./active/20260712-yorkie-auth-webhook-todo.md) | - |
 | sheets date validation (2026-07-11) | [20260711-sheets-date-validation-todo.md](./active/20260711-sheets-date-validation-todo.md) | [20260711-sheets-date-validation-lessons.md](./active/20260711-sheets-date-validation-lessons.md) |
 | slides gradient editing (2026-07-11) | [20260711-slides-gradient-editing-todo.md](./active/20260711-slides-gradient-editing-todo.md) | [20260711-slides-gradient-editing-lessons.md](./active/20260711-slides-gradient-editing-lessons.md) |
@@ -39,4 +43,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 356
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: release v0.5.1 (2026-07-12)
+Latest active task: slides mobile bg repaint (2026-07-14)

--- a/docs/tasks/active/20260714-slides-mobile-bg-repaint-lessons.md
+++ b/docs/tasks/active/20260714-slides-mobile-bg-repaint-lessons.md
@@ -1,0 +1,34 @@
+# Lessons — Slides mobile/presenter background repaint
+
+## The bug class: `markDirty()` only flips a flag
+
+`SlideRenderer.markDirty()` sets `this.dirty = true` — it does **not** repaint.
+A repaint only happens when a consumer re-calls `render()`. Consumers with a
+per-frame RAF loop (desktop editor) or a scheduler (thumbnails) self-heal an
+async image load; consumers that paint on discrete events (mobile view,
+presenter) do not, so a background image decoded after the first paint stays
+blank until an unrelated event.
+
+Takeaway: when wiring an async-asset callback, confirm the consumer actually
+re-drives `render()` — a bare `markDirty` is a silent no-op there.
+
+## Don't repaint on top of an active animation loop
+
+The first cut added `onAssetLoad → scheduleRepaint → paint()` and I commented
+"paint() handles the animation branches, so this is safe to fire at any time."
+That was wrong. `paint()` renders the **settled/resting** slide; firing it
+while a transition or object-animation RAF loop is mid-flight flashes the
+resting/next slide over the in-progress animation for one frame.
+
+Correct rule: a repaint scheduler must **defer to any running render loop**.
+Guard on `rafHandle !== null || transitionRafHandle !== null` — those loops
+already repaint every frame (and re-query the image cache), and the transition
+settles via its own `onDone` `paint()`. The high-effort code review caught
+both manifestations; they shared one guard.
+
+## Effect-scoped async callbacks outlive cleanup
+
+A callback subscribed into a module-level cache (here `image-cache`
+`pendingCallbacks`) is retained past the React effect's cleanup. Add a
+`cancelled` flag the callback checks, so a late fire can't schedule an
+uncancellable RAF against a torn-down scope.

--- a/docs/tasks/active/20260714-slides-mobile-bg-repaint-todo.md
+++ b/docs/tasks/active/20260714-slides-mobile-bg-repaint-todo.md
@@ -1,0 +1,63 @@
+# Slides mobile/presenter background repaint on async image load
+
+## Problem
+
+On mobile, opening a slide deck can render the slide background white when
+the background **image** hasn't finished decoding yet. Navigating to another
+slide and back fixes it (the image is cached and drawn synchronously on the
+revisit).
+
+## Root cause
+
+`SlideRenderer` draws background images asynchronously. On the first paint the
+image is not decoded, so only the background *fill* (theme color, often white)
+is painted. When the image finishes loading, the `drawSlide` asset-load
+callback resolves to `SlideRenderer.markDirty()` — which only flips a boolean.
+Something must re-call `render()` for the repaint to happen.
+
+- Desktop editor: continuous RAF loop → repaints next frame. OK.
+- Thumbnails: `ThumbnailScheduler` re-flushes via explicit `onAssetLoad`. OK.
+- **Mobile view mode**: no RAF loop; `paint()` only runs on resize /
+  `store.onChange` / slide change → background image dropped. BUG.
+- **Presenter mode**: event-driven `paint()`, no RAF on a static slide. Same BUG.
+
+## Fix
+
+Add an optional `onAssetLoad` callback to `SlideRendererOptions`. On async
+asset load the renderer calls `markDirty()` **and** `options.onAssetLoad?.()`,
+so consumers without a per-frame loop can schedule a repaint. Editor keeps
+relying on its RAF loop (omits the callback).
+
+- [x] `packages/slides/src/view/canvas/slide-renderer.ts` — add `onAssetLoad`
+      option + private `handleAssetLoad()` used by `render()`/`forceRender()`.
+- [x] `packages/frontend/src/app/slides/mobile-slides-view.tsx` — RAF-coalesced
+      `scheduleRepaint`, pass as `onAssetLoad` when building the view renderer.
+- [x] `packages/slides/src/view/present/presenter.ts` — RAF-coalesced
+      `scheduleRepaint` (+ cancel on dispose), pass as `onAssetLoad`.
+
+## Verification
+
+- [x] `pnpm verify:fast` green.
+- [x] Regression test: `slide-renderer.test.ts` — `onAssetLoad` fires when a
+      background image finishes loading (fails on pre-fix `markDirty`-only wiring).
+- [ ] Manual: mobile Slides view — first open paints the background image
+      without needing to navigate away and back.
+
+## Code review (high effort, workflow-backed)
+
+Two CONFIRMED correctness findings, same root cause — the presenter's
+`scheduleRepaint` fired `paint()` unconditionally:
+
+- A late-decoding asset during an **in-flight transition** force-painted the
+  settled next slide over the transition composite (one-frame flash).
+- A late asset during a **running object-animation** step force-painted the
+  resting state, stuttering the animation.
+
+Fix: `scheduleRepaint` skips while `rafHandle` or `transitionRafHandle` is
+active — those loops already repaint every frame (and the transition settles
+via its own `onDone` `paint()`). Regression tests added in
+`presenter-transition.test.ts` and `presenter-anim.test.ts`.
+
+One PLAUSIBLE cleanup: the mobile view retained a stale `onAssetLoad` after a
+slide switch. Fixed with a `cancelled` flag so the stale callback can't
+schedule an uncancellable RAF.

--- a/packages/frontend/src/app/slides/mobile-slides-view.tsx
+++ b/packages/frontend/src/app/slides/mobile-slides-view.tsx
@@ -249,6 +249,12 @@ export function MobileSlidesView({
 
     let renderer: SlideRenderer | null = null;
     let lastDoc: SlidesDocument = store.read();
+    let repaintRaf = 0;
+    // Set on cleanup. A background image still loading when the effect
+    // re-runs keeps this renderer's onAssetLoad subscribed in the image
+    // cache; the flag makes that stale callback a no-op instead of
+    // scheduling a RAF the (already-run) cleanup can no longer cancel.
+    let cancelled = false;
 
     function paint() {
       if (!renderer) return;
@@ -256,6 +262,18 @@ export function MobileSlidesView({
       if (!slide) return;
       renderer.markDirty();
       renderer.render(slide, lastDoc);
+    }
+
+    // View mode has no per-frame RAF loop, so a background/element image
+    // that finishes decoding after the first paint would stay blank until
+    // an unrelated event (slide change, store.onChange) re-ran paint().
+    // Schedule a coalesced repaint when the renderer reports an async load.
+    function scheduleRepaint() {
+      if (cancelled || repaintRaf) return;
+      repaintRaf = requestAnimationFrame(() => {
+        repaintRaf = 0;
+        paint();
+      });
     }
 
     function applyFit() {
@@ -272,6 +290,7 @@ export function MobileSlidesView({
         hostWidth: cssW,
         hostHeight: cssH,
         dpr,
+        onAssetLoad: scheduleRepaint,
       });
       paint();
     }
@@ -296,6 +315,8 @@ export function MobileSlidesView({
     return () => {
       ro.disconnect();
       unsubscribe();
+      cancelled = true;
+      if (repaintRaf) cancelAnimationFrame(repaintRaf);
       renderer = null;
     };
   }, [mode, store, currentSlideId]);

--- a/packages/frontend/src/app/slides/mobile-slides-view.tsx
+++ b/packages/frontend/src/app/slides/mobile-slides-view.tsx
@@ -249,14 +249,14 @@ export function MobileSlidesView({
 
     let renderer: SlideRenderer | null = null;
     let lastDoc: SlidesDocument = store.read();
-    let repaintRaf = 0;
+    let repaintRaf: number | null = null;
     // Set on cleanup. A background image still loading when the effect
     // re-runs keeps this renderer's onAssetLoad subscribed in the image
     // cache; the flag makes that stale callback a no-op instead of
     // scheduling a RAF the (already-run) cleanup can no longer cancel.
     let cancelled = false;
 
-    function paint() {
+    function paint(): void {
       if (!renderer) return;
       const slide = lastDoc.slides.find((s) => s.id === currentSlideId);
       if (!slide) return;
@@ -268,15 +268,15 @@ export function MobileSlidesView({
     // that finishes decoding after the first paint would stay blank until
     // an unrelated event (slide change, store.onChange) re-ran paint().
     // Schedule a coalesced repaint when the renderer reports an async load.
-    function scheduleRepaint() {
-      if (cancelled || repaintRaf) return;
+    function scheduleRepaint(): void {
+      if (cancelled || repaintRaf !== null) return;
       repaintRaf = requestAnimationFrame(() => {
-        repaintRaf = 0;
+        repaintRaf = null;
         paint();
       });
     }
 
-    function applyFit() {
+    function applyFit(): void {
       const rect = host!.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return;
       const fit = computeFitSize(rect.width, rect.height, deckAspect(store));
@@ -295,12 +295,11 @@ export function MobileSlidesView({
       paint();
     }
 
-    let rafScheduled = false;
+    let resizeRaf: number | null = null;
     const ro = new ResizeObserver(() => {
-      if (rafScheduled) return;
-      rafScheduled = true;
-      requestAnimationFrame(() => {
-        rafScheduled = false;
+      if (resizeRaf !== null) return;
+      resizeRaf = requestAnimationFrame(() => {
+        resizeRaf = null;
         applyFit();
       });
     });
@@ -316,7 +315,11 @@ export function MobileSlidesView({
       ro.disconnect();
       unsubscribe();
       cancelled = true;
-      if (repaintRaf) cancelAnimationFrame(repaintRaf);
+      // Cancel both pending RAFs so neither an asset-load repaint nor a
+      // resize-driven applyFit() (which would recreate the renderer) fires
+      // after teardown.
+      if (repaintRaf !== null) cancelAnimationFrame(repaintRaf);
+      if (resizeRaf !== null) cancelAnimationFrame(resizeRaf);
       renderer = null;
     };
   }, [mode, store, currentSlideId]);

--- a/packages/slides/src/view/canvas/slide-renderer.ts
+++ b/packages/slides/src/view/canvas/slide-renderer.ts
@@ -38,6 +38,14 @@ export interface SlideRendererOptions {
    */
   slideOffsetLogicalX?: number;
   slideOffsetLogicalY?: number;
+  /**
+   * Called after an async asset (e.g. a background or element image)
+   * finishes loading, in addition to the internal dirty flag. Consumers
+   * without a continuous render loop (mobile single-slide view, presenter)
+   * use this to schedule a repaint; the desktop editor's RAF loop repaints
+   * from the dirty flag alone and can omit it.
+   */
+  onAssetLoad?: () => void;
 }
 
 /**
@@ -76,6 +84,18 @@ export class SlideRenderer {
   }
 
   /**
+   * Asset-load callback handed to `drawSlide`. Marks the slide dirty and
+   * notifies the consumer so paths without a per-frame render loop (mobile
+   * view, presenter) can schedule a repaint. Consumers that re-drive
+   * `render()` every frame (desktop editor) leave `onAssetLoad` unset — the
+   * dirty flag alone repaints them on the next frame.
+   */
+  private handleAssetLoad(): void {
+    this.markDirty();
+    this.options.onAssetLoad?.();
+  }
+
+  /**
    * Paint `slide` onto the bound ctx if dirty. No-op otherwise.
    *
    * `doc` provides the active theme via `getActiveTheme(doc)`; every
@@ -85,7 +105,7 @@ export class SlideRenderer {
    */
   render(slide: Slide, doc: SlidesDocument): void {
     if (!this.dirty) return;
-    drawSlide(this.ctx, slide, doc, this.options, () => this.markDirty());
+    drawSlide(this.ctx, slide, doc, this.options, () => this.handleAssetLoad());
     this.dirty = false;
   }
 
@@ -121,7 +141,7 @@ export class SlideRenderer {
       slide,
       doc,
       this.options,
-      () => this.markDirty(),
+      () => this.handleAssetLoad(),
       ghosts,
       animStates,
       cropPreview,

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -110,6 +110,12 @@ export function startPresenter(options: PresenterOptions): Presenter {
   // on dispose() and before any slide change.
   let transitionRafHandle: number | null = null;
 
+  // Repaint RAF handle — a static (non-animated) slide has no render loop,
+  // so an async-loaded background/element image would otherwise stay blank
+  // until the next navigation. Coalesces asset-load repaints; cancelled on
+  // dispose.
+  let repaintRafHandle: number | null = null;
+
   // Current CSS size of the canvas slot. Updated by applyFit() and read
   // by playTransition() to build offscreen SlideRenderers at the same
   // scale as the main renderer.
@@ -160,9 +166,28 @@ export function startPresenter(options: PresenterOptions): Presenter {
       hostWidth: cssWidth,
       hostHeight: cssHeight,
       dpr,
+      onAssetLoad: scheduleRepaint,
     });
     renderer.markDirty();
     paint();
+  }
+
+  // Schedule a coalesced repaint when the renderer reports an async asset
+  // load (e.g. a background image that finished decoding after the initial
+  // paint). Only fires when the slide is otherwise static: a running
+  // object-animation loop (rafHandle) already re-draws every frame via
+  // forceRender (re-querying the image cache), and a running transition
+  // (transitionRafHandle) composites frozen offscreen bitmaps and settles
+  // with its own onDone paint() — forcing a settled paint() on top of
+  // either would flash the resting/next slide over the in-progress
+  // animation for one frame.
+  function scheduleRepaint(): void {
+    if (disposed || repaintRafHandle !== null) return;
+    if (rafHandle !== null || transitionRafHandle !== null) return;
+    repaintRafHandle = requestAnimationFrame(() => {
+      repaintRafHandle = null;
+      paint();
+    });
   }
 
   // observe documentElement as a viewport proxy — it works pre-fullscreen and post-overlay-fallback alike
@@ -694,6 +719,10 @@ export function startPresenter(options: PresenterOptions): Presenter {
     // ensure no further ticks fire even if cancelAnimationFrame races.
     cancelRaf();
     cancelTransitionRaf();
+    if (repaintRafHandle !== null) {
+      cancelAnimationFrame(repaintRafHandle);
+      repaintRafHandle = null;
+    }
     animPlayer = null;
 
     // Detach the fullscreenchange listener FIRST so the
@@ -766,6 +795,8 @@ export function startPresenter(options: PresenterOptions): Presenter {
       getResources: () => ({ canvas, ctx, prevCssText, resizeObserver, mountMode }),
       getAnimPlayer: () => animPlayer,
       getTransitionRafHandle: () => transitionRafHandle,
+      scheduleRepaint,
+      getRepaintRafHandle: () => repaintRafHandle,
     },
   });
 

--- a/packages/slides/src/view/present/presenter.ts
+++ b/packages/slides/src/view/present/presenter.ts
@@ -186,6 +186,12 @@ export function startPresenter(options: PresenterOptions): Presenter {
     if (rafHandle !== null || transitionRafHandle !== null) return;
     repaintRafHandle = requestAnimationFrame(() => {
       repaintRafHandle = null;
+      // A navigation may have started a transition or animation loop between
+      // scheduling and now (nav paths cancel rafHandle/transitionRafHandle but
+      // not this one). Re-check: that loop already repaints every frame, and a
+      // transition settles via its own onDone paint(), so a settled paint()
+      // here would flash the resting/next slide over the in-progress animation.
+      if (disposed || rafHandle !== null || transitionRafHandle !== null) return;
       paint();
     });
   }

--- a/packages/slides/test/view/canvas/slide-renderer.test.ts
+++ b/packages/slides/test/view/canvas/slide-renderer.test.ts
@@ -193,6 +193,34 @@ describe('SlideRenderer.render', () => {
       renderer.render(blankSlide(), DOC);
       expect(ctx.drawImage).not.toHaveBeenCalled();
     });
+
+    it('invokes onAssetLoad when a background image finishes loading so loop-less consumers can repaint', async () => {
+      // Regression: mobile view mode / presenter have no per-frame RAF loop,
+      // so the background image loaded after the first paint stayed blank
+      // until an unrelated event. The renderer must notify the consumer via
+      // onAssetLoad (not just flip its internal dirty flag) on async load.
+      const ctx = createCtxSpy();
+      const onAssetLoad = vi.fn();
+      const renderer = new SlideRenderer(asCtx(ctx), {
+        hostWidth: 960, hostHeight: 540, dpr: 1, onAssetLoad,
+      });
+      const slide: Slide = {
+        ...blankSlide(),
+        background: {
+          fill: { kind: 'srgb', value: '#fff' },
+          image: { src: 'late-bg.png' },
+        },
+      };
+      renderer.render(slide, DOC);
+      // First paint kicks off the load; nothing drawn, callback not yet fired.
+      expect(ctx.drawImage).not.toHaveBeenCalled();
+      expect(onAssetLoad).not.toHaveBeenCalled();
+
+      await flushMicrotasks();
+
+      // Image finished decoding → renderer notifies the consumer.
+      expect(onAssetLoad).toHaveBeenCalled();
+    });
   });
 
   it('forceRender paints even when not dirty', () => {

--- a/packages/slides/test/view/present/presenter-anim.test.ts
+++ b/packages/slides/test/view/present/presenter-anim.test.ts
@@ -18,6 +18,8 @@ interface TestHandle {
   getCanvas: () => HTMLCanvasElement;
   getLastPaintKind: () => 'slide' | 'end' | null;
   getAnimPlayer: () => AnimationPlayer | null;
+  scheduleRepaint: () => void;
+  getRepaintRafHandle: () => number | null;
 }
 
 function testApi(presenter: Presenter): TestHandle {
@@ -400,6 +402,35 @@ describe('presenter — RAF loop fires forceRender during animation', () => {
       // Slide A is still current — the RAF loop doesn't change slides.
       expect(presenter.getCurrentSlideId()).toBe(aId);
       expect(presenter.isAtEndScreen()).toBe(false);
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('does NOT schedule an asset-load repaint while an animation step is playing', () => {
+    const { doc, aId } = makeDocWithAnimations();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    try {
+      // On the resting slide (no step playing) an asset load schedules a
+      // repaint as normal.
+      testApi(presenter).scheduleRepaint();
+      expect(testApi(presenter).getRepaintRafHandle()).not.toBeNull();
+      flushRaf(500);
+      expect(testApi(presenter).getRepaintRafHandle()).toBeNull();
+
+      testApi(presenter).next(); // advance step 0 → object-animation loop running
+
+      // An asset finishing while the animation is mid-flight must not force a
+      // resting-state paint() that flashes the element to its end position —
+      // the running forceRender loop already repaints (and re-queries the
+      // image cache) every frame.
+      testApi(presenter).scheduleRepaint();
+      expect(testApi(presenter).getRepaintRafHandle()).toBeNull();
     } finally {
       presenter.dispose();
     }

--- a/packages/slides/test/view/present/presenter-transition.test.ts
+++ b/packages/slides/test/view/present/presenter-transition.test.ts
@@ -19,6 +19,8 @@ interface TestHandle {
   getLastPaintKind: () => 'slide' | 'end' | null;
   getAnimPlayer: () => AnimationPlayer | null;
   getTransitionRafHandle: () => number | null;
+  scheduleRepaint: () => void;
+  getRepaintRafHandle: () => number | null;
 }
 
 function testApi(presenter: Presenter): TestHandle {
@@ -602,5 +604,77 @@ describe('presenter — cancel in-flight transition on back/jump navigation', ()
     } finally {
       presenter.dispose();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 5: Asset-load repaint (scheduleRepaint) must not fight an active loop
+// ---------------------------------------------------------------------------
+
+describe('presenter — async asset-load repaint scheduling', () => {
+  it('schedules a coalesced repaint when the slide is static (no loop running)', () => {
+    const { doc, ids } = makeDocNoTransitions();
+    const [aId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    try {
+      // No transition or animation loop is running on the resting slide.
+      expect(testApi(presenter).getTransitionRafHandle()).toBeNull();
+      expect(testApi(presenter).getRepaintRafHandle()).toBeNull();
+
+      testApi(presenter).scheduleRepaint();
+      // A repaint RAF is now armed…
+      expect(testApi(presenter).getRepaintRafHandle()).not.toBeNull();
+
+      // …and a second call coalesces (does not double-schedule).
+      const first = testApi(presenter).getRepaintRafHandle();
+      testApi(presenter).scheduleRepaint();
+      expect(testApi(presenter).getRepaintRafHandle()).toBe(first);
+
+      // Flushing runs paint() and clears the handle.
+      flushRaf(500);
+      expect(testApi(presenter).getRepaintRafHandle()).toBeNull();
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('does NOT schedule a repaint while a slide transition is in flight', () => {
+    const { doc, aId } = makeDocWithFadeTransition();
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    try {
+      testApi(presenter).next(); // transition A→B in flight
+      expect(testApi(presenter).getTransitionRafHandle()).not.toBeNull();
+
+      // An asset finishing mid-transition must not force a settled paint()
+      // over the transition composite — scheduleRepaint is a no-op here.
+      testApi(presenter).scheduleRepaint();
+      expect(testApi(presenter).getRepaintRafHandle()).toBeNull();
+    } finally {
+      presenter.dispose();
+    }
+  });
+
+  it('does NOT schedule a repaint after dispose()', () => {
+    const { doc, ids } = makeDocNoTransitions();
+    const [aId] = ids;
+    const presenter = startPresenter({
+      container: makeContainer(),
+      doc,
+      startSlideId: aId,
+      onExit: vi.fn(),
+    });
+    presenter.dispose();
+    testApi(presenter).scheduleRepaint();
+    expect(testApi(presenter).getRepaintRafHandle()).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

On mobile, opening a slide deck could render the slide background **white**
when the background *image* had not finished decoding yet. Navigating to
another slide and back fixed it (the image is cached and drawn synchronously
on the revisit).

**Root cause.** `SlideRenderer` draws background images asynchronously; on the
first paint only the background *fill* (theme color, often white) is drawn. On
image load, the `drawSlide` asset-load callback resolved to
`SlideRenderer.markDirty()` — which only flips a boolean. A repaint happens
only when a consumer re-calls `render()`:

- Desktop editor: continuous RAF loop → repaints next frame. OK.
- Thumbnails: `ThumbnailScheduler` re-flushes via explicit `onAssetLoad`. OK.
- **Mobile view mode / presenter**: paint on discrete events only, no RAF loop
  → the background image was dropped until an unrelated event. Bug.

**Fix.** Add an optional `onAssetLoad` callback to `SlideRendererOptions`. On
async asset load the renderer now calls `markDirty()` **and**
`options.onAssetLoad?.()`, so loop-less consumers can schedule a coalesced
repaint. The editor keeps relying on its RAF loop and omits the callback
(unchanged behavior).

The presenter's `scheduleRepaint` **defers to any running render loop** — it
skips while an object-animation (`rafHandle`) or transition
(`transitionRafHandle`) loop is active, since those repaint every frame and the
transition settles via its own `onDone` `paint()`. Without this guard a late
asset would flash the resting/next slide over the in-progress animation for one
frame (caught by high-effort code review). The mobile view guards a stale
`onAssetLoad` after teardown with a `cancelled` flag.

## Test plan

- `pnpm verify:fast` green (ran as the pre-commit gate).
- New regression tests:
  - `slide-renderer.test.ts` — `onAssetLoad` fires when a background image
    finishes loading (fails on the pre-fix `markDirty`-only wiring).
  - `presenter-transition.test.ts` — `scheduleRepaint` schedules on a static
    slide, is a no-op during an in-flight transition, and after `dispose()`.
  - `presenter-anim.test.ts` — `scheduleRepaint` is a no-op while an animation
    step is playing.
- [ ] Manual: mobile Slides view — first open paints the background image
  without needing to navigate away and back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed mobile and presenter slide backgrounds staying blank/white after async image decoding completes.
  - Added coalesced repaint scheduling for late-loading assets while respecting ongoing animation/transition RAF loops to avoid flicker.
  - Improved cleanup/cancellation so late asset-load callbacks don’t trigger paints after a view is closed.

- **Tests**
  - Added regression tests covering `onAssetLoad` firing, repaint coalescing, and repaint suppression during animations/transitions and after disposal.

- **Documentation**
  - Updated task docs and added new entries describing the rendering failure modes and verification/follow-up guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->