### PR TITLE
Notes: wafflebase CLI namespace + backend note content endpoint

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -307,19 +307,36 @@ wafflebase
   │     └── export <doc-id> <file>
   │           [--tab <tab-id>] [--range A1:C10] [--file-format csv|json]
   │
-  └── slides (aliases: slide, deck)
-        ├── list                             List slide decks (type: slides)
-        ├── create <title>                   Create a new deck
-        ├── get <doc-id>                      Show deck metadata
-        ├── rename <doc-id> <title>          Rename a deck
-        ├── delete <doc-id>                   Delete a deck
+  ├── slides (aliases: slide, deck)
+  │     ├── list                             List slide decks (type: slides)
+  │     ├── create <title>                   Create a new deck
+  │     ├── get <doc-id>                      Show deck metadata
+  │     ├── rename <doc-id> <title>          Rename a deck
+  │     ├── delete <doc-id>                   Delete a deck
+  │     ├── content <doc-id>
+  │     │     [--format json|md|text]        (default: json)
+  │     │     [--notes]                       (include speaker notes; md/text)
+  │     │     [--out <file>|-]                (default: stdout)
+  │     │     [--force]
+  │     ├── export <doc-id> <file>
+  │     │     [--format pptx]                (default: from extension)
+  │     │     [--force]                       (overwrite existing file)
+  │     └── import <file>
+  │           [--title <title>]               (default: file basename)
+  │           [--replace <doc-id> --yes]      (destructive; required together)
+  │
+  └── notes (alias: note)
+        ├── list                             List notes (type: note)
+        ├── create <title>                   Create a new note
+        ├── get <doc-id>                      Show note metadata
+        ├── rename <doc-id> <title>          Rename a note
+        ├── delete <doc-id>                   Delete a note
         ├── content <doc-id>
         │     [--format json|md|text]        (default: json)
-        │     [--notes]                       (include speaker notes; md/text)
         │     [--out <file>|-]                (default: stdout)
         │     [--force]
         ├── export <doc-id> <file>
-        │     [--format pptx]                (default: from extension)
+        │     [--format md]                  (default: from extension)
         │     [--force]                       (overwrite existing file)
         └── import <file>
               [--title <title>]               (default: file basename)
@@ -339,6 +356,18 @@ three documented v1 limitations: inline href links on text runs,
 connector attached-endpoints are not yet wired in the exporter, and
 group-targeted animation coupling is a documented v1 gap. PDF
 export remains deferred (requires Canvas rasterization).
+
+The Notes commands are the thinnest of the three document namespaces: a
+note's entire content *is* a single markdown string held in one Yorkie
+`Text` CRDT at `root.content` (byte-compatible with CodePair), so there is
+no lossy serialization. `notes content` returns `{ "content": "…" }` for
+`--format json` and the raw markdown for `md`/`text`; `notes export`
+writes markdown only (a note is already markdown — PDF/HTML export is
+deferred). `notes import` reads a `.md` file (or stdin) straight into the
+content string. The backend content endpoint dispatches on the persisted
+type (`doc` → docs tree, `slides` → slides tree, `note` → `Text`); the
+CLI-side `getNoteContent`/`putNoteContent` reuse the same
+`GET`/`PUT /documents/:id/content` route.
 
 **Global flags**: `--server`, `--api-key`, `--workspace`, `--profile`,
 `--format json|table|csv|yaml` (default: json), `--quiet`, `--verbose`,
@@ -570,6 +599,7 @@ packages/cli/
       ctx.ts             ctx list/switch
       docs.ts            docs list/create/get/rename/delete + content/export/import
       slides.ts          slides list/create/get/rename/delete + content/export/import
+      notes.ts           notes list/create/get/rename/delete + content/export/import
       sheets.ts          Dispatcher: sheets {tabs,cells,import,export}
       tabs.ts            sheets tabs list
       cells.ts           sheets cells get/set/batch/delete
@@ -588,6 +618,9 @@ packages/cli/
       content.ts         runSlidesContent orchestrator (json + per-slide md/text)
       import.ts          runSlidesImport orchestrator (POST + PUT, --replace flow)
       pptx-import.ts     importPptx wrapper + base64 image uploader
+    notes/               Markdown-note pipeline
+      content.ts         runNotesContent orchestrator (json {content} + raw md/text)
+      import.ts          runNotesImport orchestrator (POST + PUT, --replace flow)
       page-range.ts      parsePageRange (1-3,5,7-9 + clamp warnings)
       page-slice.ts      sliceBlocksByPages
       fontkit-measurer.ts FontkitMeasurer (TextMeasurer for Node)
@@ -782,6 +815,14 @@ Schema entries by command (canonical plural names):
 | `slides.content`         | read-only     | `json` lossless; `md`/`text` text-only                 |
 | `slides.export`          | read-only     | file write is local; PPTX only                         |
 | `slides.import`          | write         | `safety` becomes `destructive` with `--replace`        |
+| `notes.list`             | read-only     | filtered to `type: note`                               |
+| `notes.create`           | write         |                                                        |
+| `notes.get`              | read-only     | metadata only                                          |
+| `notes.rename`           | write         |                                                        |
+| `notes.delete`           | destructive   |                                                        |
+| `notes.content`          | read-only     | `json` → `{content}`; `md`/`text` raw markdown         |
+| `notes.export`           | read-only     | file write is local; Markdown only                     |
+| `notes.import`           | write         | `safety` becomes `destructive` with `--replace`        |
 | `login`                  | write         | OAuth login, writes session file                       |
 | `logout`                 | write         | Deletes session file                                   |
 | `status`                 | read-only     | Shows current auth state                               |

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -335,8 +335,8 @@ wafflebase
         │     [--format json|md|text]        (default: json)
         │     [--out <file>|-]                (default: stdout)
         │     [--force]
-        ├── export <doc-id> <file>
-        │     [--format md]                  (default: from extension)
+        ├── export <doc-id> <file>|-         (- writes Markdown to stdout)
+        │     [--format md]                  (default: from extension; - ⇒ md)
         │     [--force]                       (overwrite existing file)
         └── import <file>
               [--title <title>]               (default: file basename)

--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -238,6 +238,26 @@ paste/drop → `![](url)` insertion), export (PDF/HTML/Markdown via
 `markdown-it`), revision history panel, and vim mode. Each is additive and
 route-local.
 
+**CLI (shipped).** A `notes` namespace (alias `note`) in `@wafflebase/cli`
+brings notes to parity with the `docs`/`slides` namespaces:
+`list / create / get / rename / delete / content / export / import`. Because a
+note's content *is* its markdown string in one Yorkie `Text` at `root.content`,
+the pipeline is the thinnest of the three — no lossy serialization:
+
+- `notes content <id>` → `{ "content": "…" }` for `--format json`, raw markdown
+  for `md`/`text`.
+- `notes export <id> <file.md>` → markdown only (PDF/HTML export still deferred
+  above).
+- `notes import <file.md>` → creates (or `--replace`s) a note from a markdown
+  file or stdin.
+
+The backend reuses the shared `GET`/`PUT /api/v1/.../documents/:id/content`
+endpoint, adding a `note` arm that reads/writes the `Text` via
+`packages/backend/src/yorkie/note-content.ts` (mirrors the `doc`/`slides`
+tree readers/writers). The v1 `POST /documents` create path also learned to
+accept `type: 'note'` (it previously downgraded unknown types to `sheet`).
+See [cli.md](../cli.md).
+
 ### P3 — CodePair → Wafflebase migration
 
 Because note content lives **only in Yorkie** and the schema is identical:

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| notes cli (2026-07-16) | [20260716-notes-cli-todo.md](./active/20260716-notes-cli-todo.md) | [20260716-notes-cli-lessons.md](./active/20260716-notes-cli-lessons.md) |
 | release v0.6.0 (2026-07-16) | [20260716-release-v0.6.0-todo.md](./active/20260716-release-v0.6.0-todo.md) | - |
 | notes markdown type (2026-07-15) | [20260715-notes-markdown-type-todo.md](./active/20260715-notes-markdown-type-todo.md) | [20260715-notes-markdown-type-lessons.md](./active/20260715-notes-markdown-type-lessons.md) |
 | shared core extraction (2026-07-14) | [20260714-shared-core-extraction-todo.md](./active/20260714-shared-core-extraction-todo.md) | [20260714-shared-core-extraction-lessons.md](./active/20260714-shared-core-extraction-lessons.md) |
@@ -39,4 +40,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 363
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: release v0.6.0 (2026-07-16)
+Latest active task: notes cli (2026-07-16)

--- a/docs/tasks/active/20260716-notes-cli-lessons.md
+++ b/docs/tasks/active/20260716-notes-cli-lessons.md
@@ -1,0 +1,77 @@
+# Notes CLI — lessons
+
+## What was non-obvious
+
+- **Notes are structurally unlike docs/slides.** A note's whole content is a
+  single markdown string in one Yorkie `Text` at `root.content` (CodePair
+  byte-compatible), not a block/tree. So the CLI/REST content shape is just
+  `{ content: string }` and there is **no lossy serialization** — the thinnest
+  of the three document pipelines. Don't reach for a serializer; the file bytes
+  *are* the content.
+
+- **The v1 REST create endpoint silently downgraded unknown types to `sheet`.**
+  `api/v1/documents.controller.ts` coerced anything not `doc`/`slides` to
+  `sheet`, so `type: 'note'` never created a note over the public API. Any new
+  document type needs this allow-list widened, not just the docKey prefix.
+
+- **The shared content controller only dispatched `doc`/`slides`.** Notes
+  needed a third arm in `docs-content.controller.ts` (`loadContentType`, GET,
+  PUT, `sniffBodyShape`, a validator) plus a tiny `note-content.ts` Text
+  reader/writer. `note-<id>` docKey + `parseYorkieDocKey` already knew notes,
+  but nothing read/wrote the content.
+
+- **Body-shape sniffing order matters.** Note bodies are `{ content: string }`.
+  Sniff `slides`/`blocks` arrays *first*, then `typeof content === 'string'`
+  last — docs/slides bodies never carry a top-level string `content`, so it's a
+  safe discriminator only when checked last. Consequence: a non-string
+  `content` never routes to the note arm, so `assertValidNoteBody`'s string
+  check is defensive/unreachable via sniff — the test had to assert the generic
+  "must contain blocks/slides/content" 400, not the note-specific message.
+
+## Guard on capability, not `toString` (review F2)
+
+`readNoteRoot` first guarded `typeof text.toString !== 'function'` — true for
+**every** object, so a mis-materialized content value (the `@yorkie-js/sdk` vs
+`@yorkie-js/react` class-identity gap the frontend's `ensureText` repairs)
+would serialize as `"[object Object]"`. Guard on the **distinguishing
+capability** (`.edit`, which only a real Yorkie `Text` has), matching
+`writeNoteRoot` and the frontend. Rule: when guarding "is this the CRDT I
+expect?", check a method unique to that CRDT, never `toString`.
+
+## The create branch needs a live-Yorkie test (review F4)
+
+`writeNoteRoot`'s create branch (`root.content = new Text()` then
+`text.edit(...)` in the **same** `doc.update`) is the primary path for
+importing a brand-new note, but it cannot be unit-tested: a real `Text` needs a
+live document context, and a fake stub only exercises the edit branch. The only
+honest coverage is a Yorkie-attached e2e (`RUN_YORKIE_INTEGRATION_TESTS`),
+modeled on `docs-cli-roundtrip.e2e-spec.ts`. The create+edit-in-one-update
+pattern is idiomatic Yorkie and verified working — but prove it with an attach,
+don't assume it from a green unit suite.
+
+## Local env drift bites integration tests
+
+The notes e2e (and the pre-existing docs e2e) failed locally with
+`project not found: PVdXqunTdAkBFpANyxDQaS` — a stale `YORKIE_PUBLIC_KEY` in
+`packages/backend/.env` pointing at a project absent from the freshly-restarted
+docker Yorkie. **Before diagnosing a new e2e as broken, run a sibling e2e**:
+if the existing one fails identically, it's env drift, not your code. Override
+with `YORKIE_PUBLIC_KEY= YORKIE_SECRET_KEY=` to use docker Yorkie's default
+project. (Ties to [[feedback_dont_overdiagnose_env]].)
+
+## Mirror the newest sibling namespace
+
+`slides` (the most recent parallel doc type) was the right template for the
+CLI wiring: `register*Command` shape, `--format` funneled to the global option
+(never redeclared per-command), `getOptionValueSourceWithGlobals('format')` to
+tell an explicit flag from the default in export, the IO-surface split for
+testable orchestrators, and the `--replace`/`--yes` confirm gate. Copying the
+established shape kept the diff reviewable and the tests parallel.
+
+## Known duplication accepted (review F5/F6)
+
+`NotesContentIO`/`NotesImportIO` triplicate the docs/slides IO helpers. This
+is the codebase's *existing* per-type duplication — not new debt introduced
+here. Extracting a shared helper is a real cleanup but touches docs+slides too,
+so it belongs in a batched CLI-internals refactor, not smuggled into a feature
+PR. (Ties to [[feedback_batch_larger_work_units]].)

--- a/docs/tasks/active/20260716-notes-cli-todo.md
+++ b/docs/tasks/active/20260716-notes-cli-todo.md
@@ -1,0 +1,108 @@
+# Notes CLI — todo
+
+Add first-class `notes` support to the `wafflebase` CLI, at parity with the
+`slides` / `docs` namespaces. Notes shipped in v0.6.0 as a collaborative
+markdown document type (`type: 'note'`, docKey `note-<id>`), whose entire
+content is a single Yorkie `Text` CRDT at `root.content`. The CLI talks only
+to REST v1, so the backend needs a note content read/write path first.
+
+## Scope (confirmed)
+
+- **Full parity CLI**: `list / create / get / rename / delete / content /
+  import / export`.
+- **Export = Markdown only** (a note's content *is* markdown; PDF/HTML deferred
+  to a later P2 pass).
+- **Backend**: extend the existing content controller with a `note` branch
+  (no separate controller) + a tiny `note-content.ts` Text reader/writer.
+
+## Backend
+
+- [x] `api/v1/documents.controller.ts` — allow `type: 'note'` in the `create`
+      coercion (currently silently downgrades `note` → `sheet`).
+- [x] New `yorkie/note-content.ts` — `NoteDocument = { content: string }`,
+      `NoteYorkieRoot`, `readNoteRoot` (`content?.toString() ?? ''`),
+      `writeNoteRoot` (create `new Text()` if missing, then
+      `edit(0, length, content)`).
+- [x] `api/v1/docs-content.controller.ts` — add `note` arm:
+  - [x] `loadContentType` returns `'doc' | 'slides' | 'note'`.
+  - [x] GET → `readNoteRoot` with `note-` prefix, `syncMode: 'readonly'`.
+  - [x] `sniffBodyShape` → `'note'` when `typeof body.content === 'string'`
+        (checked after `slides`/`blocks`).
+  - [x] `assertValidNoteBody` (content must be a string; defensive — sniff
+        already guarantees string).
+  - [x] PUT → `writeNoteRoot` with `note-` prefix; echo body back.
+- [x] Backend spec: `note-content.spec.ts` (read/write round-trip on a
+      fake-Text Yorkie root) + extended `docs-content.controller.spec.ts`
+      type dispatch (GET note, PUT note, shape-mismatch, non-string content).
+
+## CLI
+
+- [x] `client/http-client.ts` — `createDocument` type union `+ 'note'`;
+      `getNoteContent(id)` / `putNoteContent(id, {content})`; `NoteContent` type.
+- [x] New `commands/notes.ts` — `registerNotesCommand` mirroring `slides.ts`
+      (`note` / `notes` aliases): list/create/get/rename/delete/content/
+      export/import.
+- [x] New `notes/content.ts` — `parseNotesContentFormat` (`json|md|text`),
+      `runNotesContent` + `NotesContentIO` (json → `{content}`, md/text → raw
+      markdown), `--out`/`--force`.
+- [x] New `notes/import.ts` — `runNotesImport` (read `.md`/text file or stdin →
+      create-or-`--replace` → PUT content), `--title`/`--replace`/`--yes`.
+- [x] `commands/notes.ts` export — `notes export <id> <file.md>` → GET content,
+      write markdown (markdown-only; reject non-md `--format`).
+- [x] `bin.ts` — `registerNotesCommand(program)`.
+- [x] `schema/registry.ts` — `notes.*` entries + `note.*` aliases.
+
+## Tests
+
+- [x] `cli/test/namespaces.test.ts` — assert `notes` namespace + aliases +
+      subcommands.
+- [x] `cli/test/notes-content.test.ts` — json/md/text + `--out`.
+- [x] `cli/test/notes-import.test.ts` — create + `--replace` + confirm gate +
+      `--dry-run`.
+- [x] `backend/test/notes-cli-roundtrip.e2e-spec.ts` — live Yorkie round-trip
+      exercising `writeNoteRoot`'s **create branch** (fresh-note import →
+      content read-back → export → `--replace`). Gated on
+      `RUN_YORKIE_INTEGRATION_TESTS`; verified passing locally against docker
+      Yorkie's default project.
+
+## Docs
+
+- [x] `docs/design/cli.md` — added `notes` to the command tree + a "Notes
+      content internals" note + schema safety table rows + project structure.
+- [x] `docs/design/notes/notes.md` — folded in a "CLI (shipped)" subsection.
+- [ ] `packages/backend/README.md` — skipped (README v1 table doesn't
+      enumerate document `type` values; nothing to change).
+
+## Verify
+
+- [x] `pnpm verify:fast` green; CLI + backend builds + CLI `tsc --noEmit` clean.
+- [x] Smoke: `notes --help` + `schema notes.content` list the wired commands.
+- [ ] Manual smoke against `pnpm dev`: create note, import `.md`, read content,
+      export `.md`, round-trip in the editor.
+
+## Review
+
+High-effort workflow code review (14 agents) surfaced 6 findings:
+
+| # | Finding | Verdict | Action |
+| - | ------- | ------- | ------ |
+| F1 | `notes export <id> -` blocked by the `.md` extension guard (schema advertises `-` for stdout) | CONFIRMED | **Fixed** — skip extension check when `file === '-'` |
+| F2 | `readNoteRoot` guarded on `toString` (true for every object), leaking `"[object Object]"` for a mis-materialized `Text` | CONFIRMED | **Fixed** — guard on `.edit` like `writeNoteRoot`/frontend `ensureText` + unit test |
+| F3 | `runNotesContent` deref'd `note.content` without null-guarding a 2xx empty body | PLAUSIBLE | **Fixed** — tolerate `null`/`undefined` note → empty + unit test |
+| F4 | `writeNoteRoot` create branch (fresh-note import) untested | CONFIRMED | **Fixed** — added live-Yorkie `notes-cli-roundtrip.e2e-spec.ts`, verified passing |
+| F5 | `NotesContentIO` triplicates docs/slides content IO | cleanup | **Known limitation** (follow-up) — this is the established per-type duplication pattern; extracting a shared helper touches docs+slides and is out of scope for this PR |
+| F6 | `NotesImportIO` duplicates `SlidesImportIO` stdin/confirm | cleanup | **Known limitation** (follow-up) — same rationale as F5 |
+
+Two findings were correctly refuted by the verify pass (global `--format`
+value into `parseNotesContentFormat`; `--replace -` stdin double-drain).
+
+**Follow-up (non-blocking):** extract a shared `content-io` +
+`import-io` helper used by docs/slides/notes to collapse F5/F6 duplication.
+Tracked as a design-system / CLI-internals cleanup, batched with other
+CLI refactors rather than shipped piecemeal here.
+
+## Manual smoke
+
+- `notes --help`, `schema notes.content` — commands wired.
+- Live e2e round-trip (create branch) passes against docker Yorkie.
+- `pnpm verify:fast` green; CLI + backend builds + CLI `tsc --noEmit` clean.

--- a/docs/tasks/active/20260716-notes-cli-todo.md
+++ b/docs/tasks/active/20260716-notes-cli-todo.md
@@ -1,10 +1,11 @@
 # Notes CLI — todo
 
-Add first-class `notes` support to the `wafflebase` CLI, at parity with the
-`slides` / `docs` namespaces. Notes shipped in v0.6.0 as a collaborative
-markdown document type (`type: 'note'`, docKey `note-<id>`), whose entire
-content is a single Yorkie `Text` CRDT at `root.content`. The CLI talks only
-to REST v1, so the backend needs a note content read/write path first.
+This task adds first-class `notes` support to the `wafflebase` CLI, at parity
+with the `slides` / `docs` namespaces. The note *document type* shipped in
+v0.6.0 (a collaborative markdown type, `type: 'note'`, docKey `note-<id>`,
+whose entire content is a single Yorkie `Text` CRDT at `root.content`) but was
+unreachable from the CLI. The CLI talks only to REST v1, so the backend needs
+a note content read/write path first.
 
 ## Scope (confirmed)
 
@@ -20,9 +21,10 @@ to REST v1, so the backend needs a note content read/write path first.
 - [x] `api/v1/documents.controller.ts` — allow `type: 'note'` in the `create`
       coercion (currently silently downgrades `note` → `sheet`).
 - [x] New `yorkie/note-content.ts` — `NoteDocument = { content: string }`,
-      `NoteYorkieRoot`, `readNoteRoot` (`content?.toString() ?? ''`),
-      `writeNoteRoot` (create `new Text()` if missing, then
-      `edit(0, length, content)`).
+      `NoteYorkieRoot`, `readNoteRoot` (guards on the distinguishing
+      `text.edit` capability — not `toString`, which every object has — then
+      `text.toString()`, else `{ content: '' }`; see F2), `writeNoteRoot`
+      (create `new Text()` if missing, then `edit(0, length, content)`).
 - [x] `api/v1/docs-content.controller.ts` — add `note` arm:
   - [x] `loadContentType` returns `'doc' | 'slides' | 'note'`.
   - [x] GET → `readNoteRoot` with `note-` prefix, `syncMode: 'readonly'`.
@@ -47,8 +49,9 @@ to REST v1, so the backend needs a note content read/write path first.
       markdown), `--out`/`--force`.
 - [x] New `notes/import.ts` — `runNotesImport` (read `.md`/text file or stdin →
       create-or-`--replace` → PUT content), `--title`/`--replace`/`--yes`.
-- [x] `commands/notes.ts` export — `notes export <id> <file.md>` → GET content,
-      write markdown (markdown-only; reject non-md `--format`).
+- [x] `commands/notes.ts` export — `notes export <id> <file.md>|-` → GET
+      content, write markdown (`-` ⇒ stdout; markdown-only; reject non-md
+      `--format`).
 - [x] `bin.ts` — `registerNotesCommand(program)`.
 - [x] `schema/registry.ts` — `notes.*` entries + `note.*` aliases.
 

--- a/packages/backend/src/api/v1/docs-content.controller.spec.ts
+++ b/packages/backend/src/api/v1/docs-content.controller.spec.ts
@@ -133,6 +133,27 @@ describe('ApiV1DocsContentController', () => {
       );
     });
 
+    it('returns the note content JSON for a note-typed document', async () => {
+      documentService.getDocumentOrThrow.mockResolvedValue({
+        id: 'd1',
+        workspaceId: 'ws-1',
+        type: 'note',
+      });
+      yorkieService.withDocument.mockResolvedValue({ content: '# Hi' });
+
+      const result = await controller.getContent('ws-1', 'd1');
+
+      expect(result).toEqual({ content: '# Hi' });
+      expect(yorkieService.withDocument).toHaveBeenCalledWith(
+        'd1',
+        expect.any(Function),
+        expect.objectContaining({
+          docKeyPrefix: 'note-',
+          syncMode: 'readonly',
+        }),
+      );
+    });
+
     it('propagates NotFoundException when the document does not exist', async () => {
       documentService.getDocumentOrThrow.mockRejectedValue(
         new NotFoundException('Document not found'),
@@ -237,6 +258,85 @@ describe('ApiV1DocsContentController', () => {
         expect.any(Function),
         { docKeyPrefix: 'slides-' },
       );
+    });
+
+    it('writes a note body via doc.update and echoes it back', async () => {
+      documentService.getDocumentOrThrow.mockResolvedValue({
+        id: 'd1',
+        workspaceId: 'ws-1',
+        type: 'note',
+      });
+
+      // Seed a fake `Text` on the root so writeNoteRoot takes the
+      // existing-text (edit) branch rather than constructing a real
+      // Yorkie `Text` — which would need a live document context.
+      const edits: Array<[number, number, string]> = [];
+      let value = 'stale';
+      const fakeText = {
+        get length() {
+          return value.length;
+        },
+        toString: () => value,
+        edit: (from: number, to: number, content: string) => {
+          edits.push([from, to, content]);
+          value = value.slice(0, from) + content + value.slice(to);
+        },
+      };
+      const capturedRoot: Record<string, unknown> = { content: fakeText };
+      type FakeDoc = {
+        update: (fn: (root: Record<string, unknown>) => void) => void;
+        getRoot: () => Record<string, unknown>;
+      };
+      type Cb = (doc: FakeDoc) => unknown;
+      yorkieService.withDocument.mockImplementation((_id: string, cb: Cb) => {
+        const fakeDoc: FakeDoc = {
+          update: (fn) => fn(capturedRoot),
+          getRoot: () => capturedRoot,
+        };
+        return Promise.resolve(cb(fakeDoc));
+      });
+
+      const result = await controller.putContent('ws-1', 'd1', {
+        content: 'new markdown',
+      } as never);
+
+      expect(result).toEqual({ content: 'new markdown' });
+      expect(edits).toEqual([[0, 'stale'.length, 'new markdown']]);
+      expect(yorkieService.withDocument).toHaveBeenCalledWith(
+        'd1',
+        expect.any(Function),
+        { docKeyPrefix: 'note-' },
+      );
+    });
+
+    it('rejects a note payload whose content is not a string', async () => {
+      // Only a *string* `content` routes to the note arm, so a non-string
+      // value is an unrecognised shape and hits the generic 400 before any
+      // metadata/Yorkie work.
+      await expect(
+        controller.putContent('ws-1', 'd1', { content: 123 } as never),
+      ).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: expect.stringMatching(/'blocks'.*'slides'.*'content'/),
+      });
+      expect(documentService.getDocumentOrThrow).not.toHaveBeenCalled();
+      expect(yorkieService.withDocument).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when a note body targets a slides document', async () => {
+      documentService.getDocumentOrThrow.mockResolvedValue({
+        id: 'd1',
+        workspaceId: 'ws-1',
+        type: 'slides',
+      });
+
+      await expect(
+        controller.putContent('ws-1', 'd1', { content: '# hi' } as never),
+      ).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: expect.stringMatching(/shape 'note'.*type 'slides'/),
+      });
+      expect(yorkieService.withDocument).not.toHaveBeenCalled();
     });
 
     it('returns 400 when body shape does not match document type', async () => {

--- a/packages/backend/src/api/v1/docs-content.controller.ts
+++ b/packages/backend/src/api/v1/docs-content.controller.ts
@@ -84,11 +84,7 @@ export class ApiV1DocsContentController {
       id: documentId,
       workspaceId,
     });
-    if (
-      meta.type !== 'doc' &&
-      meta.type !== 'slides' &&
-      meta.type !== 'note'
-    ) {
+    if (meta.type !== 'doc' && meta.type !== 'slides' && meta.type !== 'note') {
       throw new ConflictException(TYPE_MISMATCH_BODY);
     }
     return meta.type;
@@ -229,7 +225,9 @@ function sniffBodyShape(body: unknown): 'doc' | 'slides' | 'note' | null {
  */
 function assertValidNoteBody(body: unknown): asserts body is NoteDocument {
   if (!body || typeof body !== 'object') {
-    throw new BadRequestException('Invalid note content payload: not an object');
+    throw new BadRequestException(
+      'Invalid note content payload: not an object',
+    );
   }
   if (typeof (body as { content?: unknown }).content !== 'string') {
     throw new BadRequestException(

--- a/packages/backend/src/api/v1/docs-content.controller.ts
+++ b/packages/backend/src/api/v1/docs-content.controller.ts
@@ -22,6 +22,12 @@ import {
   readSlidesRoot,
   writeSlidesRoot,
 } from '../../yorkie/slides-tree';
+import {
+  NoteDocument,
+  NoteYorkieRoot,
+  readNoteRoot,
+  writeNoteRoot,
+} from '../../yorkie/note-content';
 import type {
   DocsDocument,
   SlidesDocument,
@@ -31,6 +37,7 @@ import { YORKIE_DOC_KEY_PREFIXES } from '../../yorkie/yorkie-doc-key';
 
 const DOC_KEY_PREFIX = YORKIE_DOC_KEY_PREFIXES.doc;
 const SLIDES_KEY_PREFIX = YORKIE_DOC_KEY_PREFIXES.slides;
+const NOTE_KEY_PREFIX = YORKIE_DOC_KEY_PREFIXES.note;
 
 const TYPE_MISMATCH_BODY = {
   error: {
@@ -39,21 +46,22 @@ const TYPE_MISMATCH_BODY = {
   },
 };
 
-type ContentDocument = DocsDocument | SlidesDocument;
+type ContentDocument = DocsDocument | SlidesDocument | NoteDocument;
 
 /**
- * Read/write the canonical content JSON for word-processor (`doc`) and
- * slides (`slides`) documents.
+ * Read/write the canonical content JSON for word-processor (`doc`), slides
+ * (`slides`), and note (`note`) documents.
  *
  * The PUT body shape is determined by the persisted document type — the
  * controller loads the document's `type` from Postgres and dispatches to
  * the matching writer. Sheets are rejected with `TYPE_MISMATCH` because
  * they expose the `cells` endpoints instead.
  *
- * Both flows attach to the same Yorkie document the editor uses (key
- * `doc-<id>` for word-processor docs, `slides-<id>` for decks — see
- * `packages/frontend/src/app/docs/docs-detail.tsx` and
- * `packages/frontend/src/app/slides/slides-detail.tsx`). The CLI consumes
+ * All flows attach to the same Yorkie document the editor uses (key
+ * `doc-<id>` for word-processor docs, `slides-<id>` for decks, `note-<id>`
+ * for notes — see `packages/frontend/src/app/docs/docs-detail.tsx`,
+ * `packages/frontend/src/app/slides/slides-detail.tsx`, and
+ * `packages/frontend/src/app/notes/notes-detail.tsx`). The CLI consumes
  * these endpoints so it never needs to ship a Yorkie SDK dependency.
  */
 @Controller('api/v1/workspaces/:workspaceId/documents/:documentId/content')
@@ -71,12 +79,16 @@ export class ApiV1DocsContentController {
   private async loadContentType(
     workspaceId: string,
     documentId: string,
-  ): Promise<'doc' | 'slides'> {
+  ): Promise<'doc' | 'slides' | 'note'> {
     const meta = await this.documentService.getDocumentOrThrow({
       id: documentId,
       workspaceId,
     });
-    if (meta.type !== 'doc' && meta.type !== 'slides') {
+    if (
+      meta.type !== 'doc' &&
+      meta.type !== 'slides' &&
+      meta.type !== 'note'
+    ) {
       throw new ConflictException(TYPE_MISMATCH_BODY);
     }
     return meta.type;
@@ -93,6 +105,13 @@ export class ApiV1DocsContentController {
         documentId,
         (doc) => readDocsRoot(doc.getRoot()),
         { docKeyPrefix: DOC_KEY_PREFIX, syncMode: 'readonly' },
+      );
+    }
+    if (type === 'note') {
+      return this.yorkieService.withDocument<NoteDocument, NoteYorkieRoot>(
+        documentId,
+        (doc) => readNoteRoot(doc.getRoot()),
+        { docKeyPrefix: NOTE_KEY_PREFIX, syncMode: 'readonly' },
       );
     }
     return this.yorkieService.withDocument<SlidesDocument, SlidesYorkieRoot>(
@@ -121,11 +140,13 @@ export class ApiV1DocsContentController {
     const shape = sniffBodyShape(body);
     if (shape === null) {
       throw new BadRequestException(
-        "Invalid content payload: must contain 'blocks' (docs) or 'slides' (slides)",
+        "Invalid content payload: must contain 'blocks' (docs), 'slides' (slides), or 'content' (note)",
       );
     }
     if (shape === 'doc') {
       assertValidDocsBody(body);
+    } else if (shape === 'note') {
+      assertValidNoteBody(body);
     } else {
       assertValidSlidesBody(body);
     }
@@ -151,6 +172,18 @@ export class ApiV1DocsContentController {
       );
       return body as DocsDocument;
     }
+    if (type === 'note') {
+      await this.yorkieService.withDocument<void, NoteYorkieRoot>(
+        documentId,
+        (doc) => {
+          doc.update((root) => {
+            writeNoteRoot(root as NoteYorkieRoot, body as NoteDocument);
+          });
+        },
+        { docKeyPrefix: NOTE_KEY_PREFIX },
+      );
+      return body as NoteDocument;
+    }
     await this.yorkieService.withDocument<void, SlidesYorkieRoot>(
       documentId,
       (doc) => {
@@ -169,7 +202,7 @@ export class ApiV1DocsContentController {
  * than the document's persisted type. Returns `null` if neither anchor
  * field is recognisable; the caller surfaces this as a 400.
  */
-function sniffBodyShape(body: unknown): 'doc' | 'slides' | null {
+function sniffBodyShape(body: unknown): 'doc' | 'slides' | 'note' | null {
   if (!body || typeof body !== 'object') return null;
   const b = body as Record<string, unknown>;
   // `slides` is the unambiguous anchor for slides decks — docs bodies
@@ -178,6 +211,10 @@ function sniffBodyShape(body: unknown): 'doc' | 'slides' | null {
   // `meta` and the other required arrays).
   if (Array.isArray(b.slides)) return 'slides';
   if (Array.isArray(b.blocks)) return 'doc';
+  // A note body is just `{ content: <markdown string> }`. Checked last so
+  // the array anchors above win; docs/slides bodies never carry a
+  // top-level string `content` field.
+  if (typeof b.content === 'string') return 'note';
   return null;
 }
 
@@ -186,6 +223,21 @@ function sniffBodyShape(body: unknown): 'doc' | 'slides' | null {
  * we find. Stops at the first failure to keep the response small —
  * fix-and-retry workflows don't gain much from a list of every error.
  */
+/**
+ * A note payload is minimal: `{ content: string }`. The whole markdown doc
+ * lives in one string, so there is nothing else to validate.
+ */
+function assertValidNoteBody(body: unknown): asserts body is NoteDocument {
+  if (!body || typeof body !== 'object') {
+    throw new BadRequestException('Invalid note content payload: not an object');
+  }
+  if (typeof (body as { content?: unknown }).content !== 'string') {
+    throw new BadRequestException(
+      "Invalid note content payload: 'content' must be a string",
+    );
+  }
+}
+
 function assertValidDocsBody(body: unknown): asserts body is DocsDocument {
   if (!body || typeof body !== 'object') {
     throw new BadRequestException('Invalid docs content payload: not an object');

--- a/packages/backend/src/api/v1/documents.controller.ts
+++ b/packages/backend/src/api/v1/documents.controller.ts
@@ -47,7 +47,11 @@ export class ApiV1DocumentsController {
     return this.documentService.createDocument({
       title: body.title,
       type:
-        body.type === 'doc' || body.type === 'slides' ? body.type : 'sheet',
+        body.type === 'doc' ||
+        body.type === 'slides' ||
+        body.type === 'note'
+          ? body.type
+          : 'sheet',
       workspace: { connect: { id: workspaceId } },
       author: { connect: { id: Number(req.user.id) } },
     });

--- a/packages/backend/src/api/v1/documents.controller.ts
+++ b/packages/backend/src/api/v1/documents.controller.ts
@@ -47,9 +47,7 @@ export class ApiV1DocumentsController {
     return this.documentService.createDocument({
       title: body.title,
       type:
-        body.type === 'doc' ||
-        body.type === 'slides' ||
-        body.type === 'note'
+        body.type === 'doc' || body.type === 'slides' || body.type === 'note'
           ? body.type
           : 'sheet',
       workspace: { connect: { id: workspaceId } },

--- a/packages/backend/src/yorkie/note-content.spec.ts
+++ b/packages/backend/src/yorkie/note-content.spec.ts
@@ -1,0 +1,64 @@
+import { readNoteRoot, writeNoteRoot, type NoteYorkieRoot } from './note-content';
+
+/**
+ * Minimal stand-in for a Yorkie `Text` proxy. `writeNoteRoot` only touches
+ * `edit` / `length`, and `readNoteRoot` only `toString`, so a plain object
+ * with those members exercises both without a live Yorkie document.
+ */
+function fakeText(initial: string) {
+  let value = initial;
+  const edits: Array<[number, number, string]> = [];
+  return {
+    edits,
+    get length() {
+      return value.length;
+    },
+    toString: () => value,
+    edit(from: number, to: number, content: string) {
+      edits.push([from, to, content]);
+      value = value.slice(0, from) + content + value.slice(to);
+    },
+  };
+}
+
+describe('readNoteRoot', () => {
+  it('returns empty content for an unwritten root', () => {
+    expect(readNoteRoot({} as NoteYorkieRoot)).toEqual({ content: '' });
+  });
+
+  it('returns the markdown string held in the content Text', () => {
+    const text = fakeText('# Hello\n\nWorld');
+    const root = { content: text } as unknown as NoteYorkieRoot;
+    expect(readNoteRoot(root)).toEqual({ content: '# Hello\n\nWorld' });
+  });
+
+  it('reads empty for a mis-materialized content lacking edit', () => {
+    // A plain object still has Object.prototype.toString → "[object Object]".
+    // The `.edit` guard must reject it rather than leak that string.
+    const root = { content: { text: 'x' } } as unknown as NoteYorkieRoot;
+    expect(readNoteRoot(root)).toEqual({ content: '' });
+  });
+});
+
+describe('writeNoteRoot', () => {
+  it('replaces the whole existing Text with the new markdown', () => {
+    const text = fakeText('old body');
+    const root = { content: text } as unknown as NoteYorkieRoot;
+
+    writeNoteRoot(root, { content: 'brand new markdown' });
+
+    // Wipe-and-rewrite: a single edit spanning the full prior length.
+    expect(text.edits).toEqual([[0, 'old body'.length, 'brand new markdown']]);
+    expect(text.toString()).toBe('brand new markdown');
+  });
+
+  it('clears content when given an empty string', () => {
+    const text = fakeText('something');
+    const root = { content: text } as unknown as NoteYorkieRoot;
+
+    writeNoteRoot(root, { content: '' });
+
+    expect(text.edits).toEqual([[0, 'something'.length, '']]);
+    expect(text.toString()).toBe('');
+  });
+});

--- a/packages/backend/src/yorkie/note-content.spec.ts
+++ b/packages/backend/src/yorkie/note-content.spec.ts
@@ -1,4 +1,8 @@
-import { readNoteRoot, writeNoteRoot, type NoteYorkieRoot } from './note-content';
+import {
+  readNoteRoot,
+  writeNoteRoot,
+  type NoteYorkieRoot,
+} from './note-content';
 
 /**
  * Minimal stand-in for a Yorkie `Text` proxy. `writeNoteRoot` only touches

--- a/packages/backend/src/yorkie/note-content.ts
+++ b/packages/backend/src/yorkie/note-content.ts
@@ -1,0 +1,68 @@
+/**
+ * Yorkie `Text` <-> note markdown serialization for the backend.
+ *
+ * A note's entire content is a single markdown string held in one Yorkie
+ * `Text` CRDT at `root.content` (byte-compatible with CodePair — see
+ * `packages/frontend/src/types/notes-document.ts` and
+ * `packages/frontend/src/app/notes/yorkie-note-store.ts`). Unlike docs/slides
+ * there is no block/tree structure to serialize, so the canonical content
+ * shape the CLI/REST layer exchanges is just `{ content: string }`.
+ *
+ * The CLI consumes these through the shared content endpoint so it never
+ * needs to ship a Yorkie SDK dependency.
+ */
+import { Text } from '@yorkie-js/sdk';
+
+/**
+ * Canonical note content JSON. The whole note *is* its markdown string.
+ */
+export interface NoteDocument {
+  content: string;
+}
+
+/**
+ * The Yorkie root shape used by note documents. Mirrors
+ * `frontend/src/types/notes-document.ts#YorkieNotesRoot`.
+ */
+export interface NoteYorkieRoot extends Record<string, unknown> {
+  content?: Text;
+}
+
+/**
+ * Read the Yorkie root for a note and return the canonical `NoteDocument`.
+ * Returns `{ content: '' }` if `content` is missing (an as-yet-unwritten
+ * document — the frontend seeds the `Text` lazily on first attach).
+ */
+export function readNoteRoot(root: NoteYorkieRoot): NoteDocument {
+  const text = root.content;
+  // Guard on `.edit`, not `.toString` — every object has a `toString`, so a
+  // mis-materialized content value (e.g. a plain `{context,text}` object from
+  // the @yorkie-js/sdk vs @yorkie-js/react class-identity gap the frontend's
+  // `ensureText` repairs) would otherwise serialize as "[object Object]". A
+  // real Yorkie `Text` always carries `edit`; anything else reads as empty.
+  if (!text || typeof text.edit !== 'function') {
+    return { content: '' };
+  }
+  return { content: text.toString() };
+}
+
+/**
+ * Replace the entire `content` Text on the Yorkie root with the note's
+ * markdown. Caller must invoke this inside a `doc.update(root => …)` block.
+ *
+ * **Destructive contract:** this is a wipe-and-rewrite last-write-wins
+ * primitive, mirroring `writeDocsRoot` / `writeSlidesRoot`. Concurrent
+ * collaborator edits made between the read and the write may be lost; the
+ * CLI import flow opts into this explicitly (`safety: destructive` upstream).
+ *
+ * If `content` is missing it is created via `new Text()`, mirroring the
+ * frontend's `ensureText` seed in `notes-view.tsx`.
+ */
+export function writeNoteRoot(root: NoteYorkieRoot, doc: NoteDocument): void {
+  let text = root.content;
+  if (!text || typeof text.edit !== 'function') {
+    root.content = new Text();
+    text = root.content;
+  }
+  text.edit(0, text.length, doc.content);
+}

--- a/packages/backend/test/notes-cli-roundtrip.e2e-spec.ts
+++ b/packages/backend/test/notes-cli-roundtrip.e2e-spec.ts
@@ -20,7 +20,12 @@
  * auth), mirroring `docs-cli-roundtrip.e2e-spec.ts`.
  */
 import { spawn } from 'node:child_process';
-import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { AddressInfo } from 'node:net';
@@ -201,10 +206,16 @@ describeFull('notes CLI round-trip', () => {
     expect(existsSync(mdPath)).toBe(true);
     expect(readFileSync(mdPath, 'utf-8')).toContain('# Integration Note');
 
-    // 5. `notes import --replace` round-trips the exported markdown back into
-    //    the existing note (the edit branch), and the content survives.
+    // 5. `notes import --replace` with *different* content exercises the edit
+    //    branch (existing Text → wipe-and-rewrite). Write a distinct markdown
+    //    body so a broken/no-op replacement can't pass, then assert the new
+    //    content replaced the old exactly (json envelope, not a substring).
+    const replacedMd = '# Replaced Note\n\nCompletely different body.';
+    const replacePath = join(tempDir, `replace-${docId}.md`);
+    writeFileSync(replacePath, replacedMd, 'utf-8');
+
     const replaceResult = await runCli(
-      ['notes', 'import', mdPath, '--replace', docId, '--yes'],
+      ['notes', 'import', replacePath, '--replace', docId, '--yes'],
       cliEnv(),
     );
     expect(replaceResult.exitCode).toBe(0);
@@ -214,10 +225,10 @@ describeFull('notes CLI round-trip', () => {
     });
 
     const reReadResult = await runCli(
-      ['notes', 'content', docId, '--format', 'md'],
+      ['notes', 'content', docId, '--format', 'json'],
       cliEnv(),
     );
     expect(reReadResult.exitCode).toBe(0);
-    expect(reReadResult.stdout).toContain('# Integration Note');
+    expect(JSON.parse(reReadResult.stdout).content).toBe(replacedMd);
   }, 60_000);
 });

--- a/packages/backend/test/notes-cli-roundtrip.e2e-spec.ts
+++ b/packages/backend/test/notes-cli-roundtrip.e2e-spec.ts
@@ -1,0 +1,223 @@
+/**
+ * End-to-end notes CLI round-trip against a live backend + Yorkie.
+ *
+ * Exercises the note content path the unit tests cannot cover — in
+ * particular `writeNoteRoot`'s create branch (fresh `new Text()` seeded and
+ * edited inside a single `doc.update` for a brand-new note whose Yorkie
+ * document does not yet exist):
+ *
+ *   notes import - (stdin markdown) → notes content --format md →
+ *   notes export <id> /tmp/out.md → notes import /tmp/out.md --replace <id>
+ *   --yes → re-read content, confirm the markdown survives the round-trip.
+ *
+ * Gated on the same `RUN_YORKIE_INTEGRATION_TESTS=true` switch as
+ * `docs-cli-roundtrip.e2e-spec.ts`. Requires both Postgres and a running
+ * Yorkie. Locally: `docker compose up -d`. In CI: the `verify-integration`
+ * job runs Postgres as a service and starts the Yorkie container, with both
+ * gates set, so this test runs there too.
+ *
+ * The CLI is spawned via `tsx` from this repository's checkout (API-key
+ * auth), mirroring `docs-cli-roundtrip.e2e-spec.ts`.
+ */
+import { spawn } from 'node:child_process';
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AddressInfo } from 'node:net';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as cookieParser from 'cookie-parser';
+import { AppModule } from 'src/app.module';
+import { PrismaService } from 'src/database/prisma.service';
+import {
+  applyGlobalBootstrap,
+  clearDatabase,
+  createUserFactory,
+  createWorkspace,
+  setIntegrationEnvDefaults,
+  setAuthEnvDefaults,
+} from './helpers/integration-helpers';
+
+const runYorkieIntegrationTests =
+  process.env.RUN_YORKIE_INTEGRATION_TESTS === 'true';
+const runDbIntegrationTests = process.env.RUN_DB_INTEGRATION_TESTS === 'true';
+const describeFull =
+  runYorkieIntegrationTests && runDbIntegrationTests
+    ? describe
+    : describe.skip;
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+const CLI_BIN = resolve(REPO_ROOT, 'packages/cli/src/bin.ts');
+
+const NOTE_MD = '# Integration Note\n\n- one\n- two\n\nBody paragraph.';
+
+interface CliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(
+  args: string[],
+  env: Record<string, string>,
+  stdin?: Buffer,
+): Promise<CliResult> {
+  return new Promise((resolveResult) => {
+    const tsxBin = resolve(REPO_ROOT, 'packages/cli/node_modules/.bin/tsx');
+    const child = spawn(tsxBin, [CLI_BIN, ...args], {
+      env: { ...process.env, ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => {
+      stdout += c.toString();
+    });
+    child.stderr.on('data', (c: Buffer) => {
+      stderr += c.toString();
+    });
+    child.on('error', (err) => {
+      resolveResult({ exitCode: 1, stdout, stderr: stderr + String(err) });
+    });
+    child.on('exit', (code, signal) => {
+      resolveResult({ exitCode: signal ? 1 : (code ?? 1), stdout, stderr });
+    });
+    if (stdin) {
+      child.stdin.write(stdin);
+      child.stdin.end();
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+describeFull('notes CLI round-trip', () => {
+  let app: INestApplication;
+  let moduleRef: TestingModule;
+  let prisma: PrismaService;
+  let createUser: ReturnType<typeof createUserFactory>;
+  let port: number;
+
+  let workspaceId: string;
+  let apiKey: string;
+  let tempDir: string;
+
+  beforeAll(async () => {
+    setIntegrationEnvDefaults();
+    setAuthEnvDefaults();
+    process.env.YORKIE_RPC_ADDR ??= 'http://localhost:8080';
+
+    moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.use(cookieParser());
+    applyGlobalBootstrap(app);
+    await app.init();
+    await app.listen(0);
+    const server = app.getHttpServer();
+    const addr = server.address() as AddressInfo;
+    port = addr.port;
+
+    prisma = moduleRef.get(PrismaService);
+    createUser = createUserFactory(prisma, 'notes-cli');
+    await prisma.$connect();
+
+    tempDir = mkdtempSync(join(tmpdir(), 'wfb-notes-cli-'));
+  }, 30_000);
+
+  beforeEach(async () => {
+    await clearDatabase(prisma);
+    const owner = await createUser();
+    const workspace = await createWorkspace(prisma, owner.id);
+    workspaceId = workspace.id;
+
+    const { ApiKeyService } = await import('src/api-key/api-key.service');
+    const service = moduleRef.get(ApiKeyService);
+    const created = await service.create(
+      owner.id,
+      workspaceId,
+      'notes-cli-roundtrip',
+    );
+    apiKey = created.key;
+  });
+
+  afterAll(async () => {
+    await clearDatabase(prisma).catch(() => {});
+    await app.close();
+    await moduleRef.close();
+  });
+
+  function cliEnv(): Record<string, string> {
+    return {
+      WAFFLEBASE_SERVER: `http://127.0.0.1:${port}`,
+      WAFFLEBASE_API_KEY: apiKey,
+      WAFFLEBASE_WORKSPACE: workspaceId,
+      WAFFLEBASE_CONFIG: join(tempDir, 'config.yaml'),
+    };
+  }
+
+  it('imports (create branch) → reads content → exports md → re-imports with --replace', async () => {
+    // 1. `notes import -` streams markdown through stdin, creating a brand-new
+    //    note. This is the sole exercise of writeNoteRoot's create branch
+    //    (fresh `new Text()` + edit for a not-yet-existing Yorkie document).
+    const importResult = await runCli(
+      ['notes', 'import', '-', '--title', 'NT'],
+      cliEnv(),
+      Buffer.from(NOTE_MD, 'utf-8'),
+    );
+    expect(importResult.exitCode).toBe(0);
+    const importBody = JSON.parse(importResult.stdout);
+    expect(importBody.id).toBeTruthy();
+    expect(importBody.title).toBe('NT');
+    const docId = importBody.id as string;
+
+    // 2. `notes content --format md` should reproduce the markdown verbatim,
+    //    proving the create-branch write actually persisted the Text.
+    const contentResult = await runCli(
+      ['notes', 'content', docId, '--format', 'md'],
+      cliEnv(),
+    );
+    expect(contentResult.exitCode).toBe(0);
+    expect(contentResult.stdout).toContain('# Integration Note');
+    expect(contentResult.stdout).toContain('- one');
+
+    // 3. `notes content --format json` returns the { content } envelope.
+    const jsonResult = await runCli(
+      ['notes', 'content', docId, '--format', 'json'],
+      cliEnv(),
+    );
+    expect(jsonResult.exitCode).toBe(0);
+    expect(JSON.parse(jsonResult.stdout).content).toBe(NOTE_MD);
+
+    // 4. `notes export` writes the markdown to a file.
+    const mdPath = join(tempDir, `out-${docId}.md`);
+    const exportResult = await runCli(
+      ['notes', 'export', docId, mdPath],
+      cliEnv(),
+    );
+    expect(exportResult.exitCode).toBe(0);
+    expect(existsSync(mdPath)).toBe(true);
+    expect(readFileSync(mdPath, 'utf-8')).toContain('# Integration Note');
+
+    // 5. `notes import --replace` round-trips the exported markdown back into
+    //    the existing note (the edit branch), and the content survives.
+    const replaceResult = await runCli(
+      ['notes', 'import', mdPath, '--replace', docId, '--yes'],
+      cliEnv(),
+    );
+    expect(replaceResult.exitCode).toBe(0);
+    expect(JSON.parse(replaceResult.stdout)).toEqual({
+      id: docId,
+      replaced: true,
+    });
+
+    const reReadResult = await runCli(
+      ['notes', 'content', docId, '--format', 'md'],
+      cliEnv(),
+    );
+    expect(reReadResult.exitCode).toBe(0);
+    expect(reReadResult.stdout).toContain('# Integration Note');
+  }, 60_000);
+});

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -3,6 +3,7 @@ import { createProgram } from './commands/root.js';
 import { registerDocsCommand } from './commands/docs.js';
 import { registerSheetsCommand } from './commands/sheets.js';
 import { registerSlidesCommand } from './commands/slides.js';
+import { registerNotesCommand } from './commands/notes.js';
 import { registerApiKeysCommand } from './commands/api-keys.js';
 import { registerSchemaCommand } from './commands/schema.js';
 import { registerLoginCommand } from './commands/login.js';
@@ -19,6 +20,7 @@ registerCtxCommand(program);
 registerDocsCommand(program);
 registerSheetsCommand(program);
 registerSlidesCommand(program);
+registerNotesCommand(program);
 registerApiKeysCommand(program);
 registerSchemaCommand(program);
 

--- a/packages/cli/src/client/http-client.ts
+++ b/packages/cli/src/client/http-client.ts
@@ -7,6 +7,15 @@ import {
   decodeJwtExpiry,
 } from '../config/session.js';
 
+/**
+ * Canonical note content JSON exchanged with the content endpoint. A note's
+ * whole content is a single markdown string — mirrors the backend's
+ * `NoteDocument` (`packages/backend/src/yorkie/note-content.ts`).
+ */
+export interface NoteContent {
+  content: string;
+}
+
 export interface ApiResponse<T = unknown> {
   ok: boolean;
   status: number;
@@ -135,8 +144,9 @@ export class HttpClient {
   listDocuments() {
     return this.request<unknown[]>('GET', '/documents');
   }
-  createDocument(title: string, type?: 'doc' | 'sheet' | 'slides') {
-    const body: { title: string; type?: 'doc' | 'sheet' | 'slides' } = { title };
+  createDocument(title: string, type?: 'doc' | 'sheet' | 'slides' | 'note') {
+    const body: { title: string; type?: 'doc' | 'sheet' | 'slides' | 'note' } =
+      { title };
     if (type) body.type = type;
     return this.request('POST', '/documents', body);
   }
@@ -179,6 +189,23 @@ export class HttpClient {
       'PUT',
       `/documents/${docId}/content`,
       deck,
+    );
+  }
+
+  // Notes content — same endpoint as docs/slides; the backend dispatches
+  // on the persisted document type, picking the note writer for `'note'`.
+  // A note's content is a single markdown string (`{ content }`).
+  getNoteContent(docId: string) {
+    return this.request<NoteContent>(
+      'GET',
+      `/documents/${docId}/content`,
+    );
+  }
+  putNoteContent(docId: string, note: NoteContent) {
+    return this.request<NoteContent>(
+      'PUT',
+      `/documents/${docId}/content`,
+      note,
     );
   }
 

--- a/packages/cli/src/commands/notes.ts
+++ b/packages/cli/src/commands/notes.ts
@@ -1,0 +1,251 @@
+import { Command } from 'commander';
+import { extname } from 'node:path';
+import { getGlobalOpts, getClient, getConfig } from './root.js';
+import { output, outputError } from '../output/formatter.js';
+import { printDryRun } from '../client/dry-run.js';
+import { runNotesImport } from '../notes/import.js';
+import {
+  parseNotesContentFormat,
+  runNotesContent,
+} from '../notes/content.js';
+
+interface NotesImportOpts {
+  title?: string;
+  replace?: string;
+  yes: boolean;
+}
+
+interface NotesContentOpts {
+  out?: string;
+  force: boolean;
+}
+
+export function registerNotesCommand(program: Command) {
+  const notes = program
+    .command('notes')
+    .alias('note')
+    .description('Manage markdown notes');
+
+  notes
+    .command('list')
+    .description('List notes in workspace')
+    .action(async function (this: Command) {
+      const opts = getGlobalOpts(this);
+      try {
+        const res = await getClient(opts).listDocuments();
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        let data = res.data as unknown;
+        if (Array.isArray(data)) {
+          data = (data as Array<{ type?: string }>).filter(
+            (d) => d.type === 'note',
+          );
+        }
+        output(data, opts.format, opts.quiet);
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  notes
+    .command('create <title>')
+    .description('Create a new note')
+    .action(async function (this: Command, title: string) {
+      const opts = getGlobalOpts(this);
+      try {
+        if (opts.dryRun) {
+          printDryRun(getConfig(opts), 'POST', '/documents', {
+            title,
+            type: 'note',
+          });
+          return;
+        }
+        const res = await getClient(opts).createDocument(title, 'note');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        output(res.data, opts.format, opts.quiet);
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  notes
+    .command('get <doc-id>')
+    .description('Show note metadata')
+    .action(async function (this: Command, docId: string) {
+      const opts = getGlobalOpts(this);
+      try {
+        const res = await getClient(opts).getDocument(docId);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        output(res.data, opts.format, opts.quiet);
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  notes
+    .command('rename <doc-id> <title>')
+    .description('Rename a note')
+    .action(async function (this: Command, docId: string, title: string) {
+      const opts = getGlobalOpts(this);
+      if (opts.dryRun) {
+        printDryRun(getConfig(opts), 'PATCH', `/documents/${docId}`, { title });
+        return;
+      }
+      try {
+        const res = await getClient(opts).updateDocument(docId, title);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        output(res.data, opts.format, opts.quiet);
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  notes
+    .command('delete <doc-id>')
+    .description('Delete a note')
+    .action(async function (this: Command, docId: string) {
+      const opts = getGlobalOpts(this);
+      if (opts.dryRun) {
+        printDryRun(getConfig(opts), 'DELETE', `/documents/${docId}`);
+        return;
+      }
+      try {
+        const res = await getClient(opts).deleteDocument(docId);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        output(res.data, opts.format, opts.quiet);
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  notes
+    .command('content <doc-id>')
+    .description('Read note content as JSON or Markdown')
+    // NOTE: `--format` is intentionally not redeclared here — the global
+    // `--format` option catches the user's value (see the same comment on
+    // `docs content` / `slides content`). We read `opts.format` and validate
+    // it through `parseNotesContentFormat`.
+    .option('--out <file>', 'Output file (- for stdout)')
+    .option('--force', 'Overwrite existing output file', false)
+    .action(async function (this: Command, docId: string) {
+      const opts = getGlobalOpts(this);
+      const local = this.opts<NotesContentOpts>();
+      try {
+        const format = parseNotesContentFormat(opts.format);
+
+        if (opts.dryRun) {
+          printDryRun(getConfig(opts), 'GET', `/documents/${docId}/content`);
+          return;
+        }
+
+        const res = await getClient(opts).getNoteContent(docId);
+        if (!res.ok) {
+          const body = res.data as
+            | { error?: { code?: string; message?: string } }
+            | null;
+          if (body?.error) {
+            // Surface backend-shaped errors (e.g., TYPE_MISMATCH) verbatim
+            // so agents reading stderr can act on the `code` field.
+            console.error(JSON.stringify(body, null, 2));
+            process.exitCode = 1;
+            return;
+          }
+          throw new Error(`HTTP ${res.status}`);
+        }
+
+        runNotesContent({
+          note: res.data,
+          format,
+          out: local.out,
+          force: local.force,
+          quiet: opts.quiet,
+        });
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  notes
+    .command('export <doc-id> <file>')
+    .description('Export a note to Markdown')
+    // NOTE: `--format` is intentionally not redeclared here — the global
+    // `--format` option catches the user's value. We read it via
+    // `getOptionValueSourceWithGlobals` to tell an explicit CLI flag from
+    // the default, then validate that only "md" is accepted.
+    .option('--force', 'Overwrite existing output file', false)
+    .action(async function (this: Command, docId: string, file: string) {
+      const opts = getGlobalOpts(this);
+      const local = this.opts<{ force: boolean }>();
+      try {
+        const formatSource = this.getOptionValueSourceWithGlobals('format');
+        // Widen to `string` — `opts.format` is the global `OutputFormat`
+        // union (json|table|csv|yaml), which has no overlap with the
+        // export-only `md` value, so a direct comparison is a tsc error.
+        const fmt: string | undefined =
+          formatSource === 'cli' ? opts.format : undefined;
+        if (fmt && fmt !== 'md' && fmt !== 'markdown') {
+          throw new Error(`Invalid --format "${fmt}". Only "md" is supported.`);
+        }
+        // `-` is stdout (advertised in the schema); no extension to infer.
+        const ext = extname(file).toLowerCase();
+        if (!fmt && file !== '-' && ext !== '.md' && ext !== '.markdown') {
+          throw new Error(
+            `Cannot infer format from "${file}". Use a .md extension or --format md.`,
+          );
+        }
+        if (opts.dryRun) {
+          printDryRun(getConfig(opts), 'GET', `/documents/${docId}/content`);
+          return;
+        }
+        const res = await getClient(opts).getNoteContent(docId);
+        if (!res.ok) {
+          const body = res.data as { error?: { code?: string } } | null;
+          if (body?.error) {
+            console.error(JSON.stringify(body, null, 2));
+            process.exitCode = 1;
+            return;
+          }
+          throw new Error(`HTTP ${res.status}`);
+        }
+        runNotesContent({
+          note: res.data,
+          format: 'md',
+          out: file,
+          force: local.force,
+          quiet: opts.quiet,
+        });
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+
+  registerNotesImportCommand(notes);
+}
+
+export function registerNotesImportCommand(notes: Command) {
+  notes
+    .command('import <file>')
+    .description('Import a Markdown file as a new (or replacement) note')
+    .option('--title <title>', 'Note title (default: file basename)')
+    .option('--replace <doc-id>', 'Replace content of an existing note')
+    .option('--yes', 'Skip --replace confirmation prompt', false)
+    .action(async function (this: Command, file: string) {
+      const opts = getGlobalOpts(this);
+      const local = this.opts<NotesImportOpts>();
+      try {
+        const result = await runNotesImport(
+          {
+            file,
+            title: local.title,
+            replace: local.replace,
+            yes: local.yes,
+            quiet: opts.quiet,
+            dryRun: opts.dryRun,
+          },
+          getClient(opts),
+        );
+        if (result.exitCode !== 0) process.exitCode = result.exitCode;
+      } catch (e) {
+        outputError(e, opts.quiet);
+      }
+    });
+}

--- a/packages/cli/src/notes/content.ts
+++ b/packages/cli/src/notes/content.ts
@@ -1,0 +1,86 @@
+import { writeFileSync, existsSync } from 'node:fs';
+import type { NoteContent } from '../client/http-client.js';
+
+export const VALID_NOTES_CONTENT_FORMATS = ['json', 'md', 'text'] as const;
+export type NotesContentFormat = (typeof VALID_NOTES_CONTENT_FORMATS)[number];
+
+export function parseNotesContentFormat(value: string): NotesContentFormat {
+  if (!VALID_NOTES_CONTENT_FORMATS.includes(value as NotesContentFormat)) {
+    throw new Error(
+      `Invalid --format "${value}". Use one of: ${VALID_NOTES_CONTENT_FORMATS.join(', ')}.`,
+    );
+  }
+  return value as NotesContentFormat;
+}
+
+/**
+ * Surface for `runNotesContent` to talk back to the CLI without taking a
+ * direct dependency on `process.stdout` / `process.stderr` / `fs`. Mirrors
+ * `SlidesContentIO`; the command wires the real implementations, tests
+ * inject in-memory collectors.
+ */
+export interface NotesContentIO {
+  stdout: (text: string) => void;
+  stderr: (line: string) => void;
+  /** Write `text` to `path`. Throws if the file exists and `force` is false. */
+  writeFile: (path: string, text: string, force: boolean) => void;
+}
+
+export const defaultNotesContentIO: NotesContentIO = {
+  stdout: (text) => {
+    process.stdout.write(text);
+    if (!text.endsWith('\n')) process.stdout.write('\n');
+  },
+  stderr: (line) => {
+    console.error(line);
+  },
+  writeFile: (path, text, force) => {
+    if (existsSync(path) && !force) {
+      throw new Error(
+        `Refusing to overwrite "${path}". Pass --force to allow overwrite.`,
+      );
+    }
+    writeFileSync(path, text.endsWith('\n') ? text : text + '\n', 'utf-8');
+  },
+};
+
+export interface RunNotesContentArgs {
+  /** May be null/undefined if the backend returned a 2xx with an empty body. */
+  note: NoteContent | null | undefined;
+  format: NotesContentFormat;
+  out?: string;
+  force?: boolean;
+  quiet?: boolean;
+}
+
+/**
+ * Pure orchestration for `notes content`: takes an already-fetched
+ * `NoteContent` plus user flags, produces the rendered output, and routes it
+ * through the supplied IO surface.
+ *
+ * A note's content *is* its markdown string, so there is no lossy
+ * conversion:
+ * - `json`: `{ "content": "…" }` — the raw endpoint shape.
+ * - `md` / `text`: the markdown string verbatim.
+ */
+export function runNotesContent(
+  args: RunNotesContentArgs,
+  io: NotesContentIO = defaultNotesContentIO,
+): void {
+  const { note, format, out, force = false, quiet = false } = args;
+
+  // Tolerate a null/empty 2xx body — treat it as an empty note rather than
+  // dereferencing null.
+  const safeNote: NoteContent = note ?? { content: '' };
+  const text =
+    format === 'json'
+      ? JSON.stringify(safeNote, null, 2)
+      : (safeNote.content ?? '');
+
+  if (!out || out === '-') {
+    io.stdout(text);
+    return;
+  }
+  io.writeFile(out, text, force);
+  if (!quiet) io.stderr(`Wrote to ${out}`);
+}

--- a/packages/cli/src/notes/import.ts
+++ b/packages/cli/src/notes/import.ts
@@ -1,0 +1,221 @@
+import { readFileSync } from 'node:fs';
+import { basename, extname } from 'node:path';
+import { createInterface } from 'node:readline';
+import type { NoteContent } from '../client/http-client.js';
+
+/**
+ * Minimal HTTP surface `runNotesImport` needs from the CLI's `HttpClient`.
+ * Spelled out so tests can pass a stub without depending on the full client.
+ * Mirrors `SlidesImportClient` in `../slides/import.ts`.
+ */
+export interface NotesImportClient {
+  createDocument: (
+    title: string,
+    type?: 'doc' | 'sheet' | 'slides' | 'note',
+  ) => Promise<{ ok: boolean; status: number; data: unknown }>;
+  putNoteContent: (
+    docId: string,
+    note: NoteContent,
+  ) => Promise<{ ok: boolean; status: number; data: unknown }>;
+}
+
+export interface NotesImportIO {
+  /** Final structured payload — written to stdout as JSON. */
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+  /** Read the markdown text for `path`. `'-'` reads from stdin. */
+  readText: (path: string) => Promise<string>;
+  /**
+   * Prompt the user for a yes/no answer when running interactively.
+   * Returns `true` for affirmative responses (case-insensitive `y` / `yes`);
+   * anything else (including end-of-stream) → `false`.
+   */
+  confirm: (prompt: string) => Promise<boolean>;
+  /** Whether the current process is interactive (a TTY on stdin). */
+  isTTY: boolean;
+}
+
+export const defaultNotesImportIO: NotesImportIO = {
+  stdout: (line) => {
+    process.stdout.write(line);
+    if (!line.endsWith('\n')) process.stdout.write('\n');
+  },
+  stderr: (line) => {
+    console.error(line);
+  },
+  readText: async (path) => {
+    if (path === '-') {
+      return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        process.stdin.on('data', (c: Buffer) => chunks.push(c));
+        process.stdin.on('end', () =>
+          resolve(Buffer.concat(chunks).toString('utf-8')),
+        );
+        process.stdin.on('error', reject);
+      });
+    }
+    return readFileSync(path, 'utf-8');
+  },
+  confirm: (prompt) => {
+    return new Promise((resolve) => {
+      const rl = createInterface({
+        input: process.stdin,
+        output: process.stderr,
+      });
+      rl.question(prompt, (answer) => {
+        rl.close();
+        const a = answer.trim().toLowerCase();
+        resolve(a === 'y' || a === 'yes');
+      });
+    });
+  },
+  isTTY: process.stdin.isTTY ?? false,
+};
+
+export interface RunNotesImportArgs {
+  /** Source path. `'-'` reads from stdin. */
+  file: string;
+  /** Override the note title. Falls back to the file basename. */
+  title?: string;
+  /** Existing document ID to overwrite. Pairs with `--yes`. */
+  replace?: string;
+  /** Skip the interactive `--replace` confirmation. */
+  yes?: boolean;
+  /** Suppress informational stderr output (errors still reported). */
+  quiet?: boolean;
+  /** Print the request that *would* fire instead of issuing it. */
+  dryRun?: boolean;
+}
+
+export interface RunNotesImportResult {
+  /** Process exit code. The action sets `process.exitCode` accordingly. */
+  exitCode: number;
+}
+
+/**
+ * Pure orchestration for `notes import`. Reads the source markdown, then
+ * either creates a new note (default) or overwrites an existing one
+ * (`--replace`). A note's content *is* its markdown, so there is no parse
+ * step — the file bytes become `{ content }` directly. Mirrors
+ * `runSlidesImport` — see that file for the rationale behind the split
+ * between this function and the Commander action.
+ */
+export async function runNotesImport(
+  args: RunNotesImportArgs,
+  client: NotesImportClient,
+  io: NotesImportIO = defaultNotesImportIO,
+): Promise<RunNotesImportResult> {
+  const { file, replace, yes = false, quiet = false, dryRun = false } = args;
+
+  const inferredTitle = args.title ?? defaultTitleFor(file);
+
+  if (replace) {
+    // `--replace` is destructive: confirm interactively unless `--yes`.
+    if (!yes) {
+      if (!io.isTTY) {
+        io.stderr(
+          JSON.stringify(
+            {
+              error: {
+                code: 'CONFIRMATION_REQ',
+                message: `Pass --yes to confirm replacing note "${replace}".`,
+              },
+            },
+            null,
+            2,
+          ),
+        );
+        return { exitCode: 1 };
+      }
+      const ok = await io.confirm(
+        `This will replace content of ${replace}. Continue? [y/N] `,
+      );
+      if (!ok) {
+        if (!quiet) io.stderr('Aborted.');
+        return { exitCode: 0 };
+      }
+    }
+    const content = await io.readText(file);
+    if (dryRun) {
+      io.stdout(
+        JSON.stringify(
+          {
+            method: 'PUT',
+            path: `/documents/${replace}/content`,
+            body: { content },
+          },
+          null,
+          2,
+        ),
+      );
+      return { exitCode: 0 };
+    }
+    const res = await client.putNoteContent(replace, { content });
+    if (!res.ok) {
+      io.stderr(
+        JSON.stringify(res.data ?? { error: { code: 'HTTP_ERROR' } }, null, 2),
+      );
+      return { exitCode: 1 };
+    }
+    io.stdout(JSON.stringify({ id: replace, replaced: true }, null, 2));
+    return { exitCode: 0 };
+  }
+
+  // Default flow: POST + PUT.
+  const content = await io.readText(file);
+  if (dryRun) {
+    io.stdout(
+      JSON.stringify(
+        {
+          method: 'POST',
+          path: '/documents',
+          body: { title: inferredTitle, type: 'note' },
+          followUp: { method: 'PUT', path: '/documents/<new-id>/content' },
+        },
+        null,
+        2,
+      ),
+    );
+    return { exitCode: 0 };
+  }
+
+  const created = await client.createDocument(inferredTitle, 'note');
+  if (!created.ok) {
+    io.stderr(
+      JSON.stringify(created.data ?? { error: { code: 'HTTP_ERROR' } }, null, 2),
+    );
+    return { exitCode: 1 };
+  }
+  const newId = (created.data as { id?: string } | null)?.id;
+  if (!newId) {
+    io.stderr(
+      JSON.stringify(
+        {
+          error: {
+            code: 'INVALID_RESPONSE',
+            message: 'Server did not return an id',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    return { exitCode: 1 };
+  }
+
+  const put = await client.putNoteContent(newId, { content });
+  if (!put.ok) {
+    io.stderr(
+      JSON.stringify(put.data ?? { error: { code: 'HTTP_ERROR' } }, null, 2),
+    );
+    return { exitCode: 1 };
+  }
+
+  io.stdout(JSON.stringify({ id: newId, title: inferredTitle }, null, 2));
+  return { exitCode: 0 };
+}
+
+function defaultTitleFor(file: string): string {
+  if (file === '-') return 'Untitled';
+  return basename(file, extname(file)) || 'Untitled';
+}

--- a/packages/cli/src/schema/registry.ts
+++ b/packages/cli/src/schema/registry.ts
@@ -280,6 +280,102 @@ const registry: CommandSchema[] = [
     aliases: ['slide.export', 'deck.export', 'decks.export'],
   },
 
+  // Notes (markdown) namespace
+  {
+    name: 'notes.list',
+    description: 'List notes in workspace',
+    safety: 'read-only',
+    parameters: {},
+    response: { type: 'array', items: { id: 'string', title: 'string', type: 'string', createdAt: 'string' } },
+    aliases: ['note.list'],
+  },
+  {
+    name: 'notes.create',
+    description: 'Create a new note',
+    safety: 'write',
+    parameters: {
+      title: { type: 'string', required: true, description: 'Note title' },
+    },
+    response: { id: 'string', title: 'string', type: 'string' },
+    aliases: ['note.create'],
+  },
+  {
+    name: 'notes.get',
+    description: 'Show note metadata',
+    safety: 'read-only',
+    parameters: {
+      'doc-id': { type: 'string', required: true, description: 'Document ID' },
+    },
+    response: { id: 'string', title: 'string', type: 'string', createdAt: 'string' },
+    aliases: ['note.get'],
+  },
+  {
+    name: 'notes.rename',
+    description: 'Rename a note',
+    safety: 'write',
+    parameters: {
+      'doc-id': { type: 'string', required: true, description: 'Document ID' },
+      title: { type: 'string', required: true, description: 'New title' },
+    },
+    response: { id: 'string', title: 'string' },
+    aliases: ['note.rename'],
+  },
+  {
+    name: 'notes.delete',
+    description: 'Delete a note',
+    safety: 'destructive',
+    parameters: {
+      'doc-id': { type: 'string', required: true, description: 'Document ID' },
+    },
+    response: { id: 'string' },
+    aliases: ['note.delete'],
+  },
+  {
+    name: 'notes.content',
+    description: 'Read note content as JSON or Markdown',
+    safety: 'read-only',
+    parameters: {
+      'doc-id': { type: 'string', required: true, description: 'Document ID' },
+      '--format': { type: 'string', required: false, description: 'Output format (json|md|text)', default: 'json' },
+      '--out': { type: 'string', required: false, description: 'Output file (- for stdout)' },
+      '--force': { type: 'boolean', required: false, description: 'Overwrite existing output file', default: 'false' },
+    },
+    response: { type: 'object', description: 'Note JSON ({content}) or raw Markdown per --format' },
+    aliases: ['note.content'],
+  },
+  {
+    name: 'notes.import',
+    description: 'Import a Markdown file as a new (or replacement) note',
+    // Default safety is `write` (create new note); `--replace` flips it to
+    // destructive, mirroring `docs.import` / `slides.import`.
+    safety: 'write',
+    parameters: {
+      file: { type: 'string', required: true, description: 'Source .md path or - for stdin' },
+      '--title': { type: 'string', required: false, description: 'Note title (default: file basename)' },
+      '--replace': { type: 'string', required: false, description: 'Existing note ID to replace' },
+      '--yes': { type: 'boolean', required: false, description: 'Skip --replace confirmation', default: 'false' },
+    },
+    response: { id: 'string', title: 'string', replaced: 'boolean' },
+    variants: [
+      { when: 'default', safety: 'write', creates: 'new note' },
+      { when: '--replace given', safety: 'destructive', modifies: 'existing note content' },
+    ],
+    aliases: ['note.import'],
+  },
+  {
+    name: 'notes.export',
+    description: 'Export a note to Markdown',
+    safety: 'read-only',
+    parameters: {
+      'doc-id': { type: 'string', required: true, description: 'Document ID' },
+      file: { type: 'string', required: true, description: 'Output path or - for stdout' },
+      '--format': { type: 'string', required: false, description: 'Output format (md); default from extension' },
+      '--force': { type: 'boolean', required: false, description: 'Overwrite existing output file', default: 'false' },
+    },
+    response: { type: 'string', description: 'Markdown text' },
+    aliases: ['note.export'],
+  },
+
   // Sheets namespace — canonical names live under sheets.*
   {
     name: 'sheets.tabs.list',

--- a/packages/cli/test/namespaces.test.ts
+++ b/packages/cli/test/namespaces.test.ts
@@ -4,6 +4,7 @@ import { createProgram } from '../src/commands/root.js';
 import { registerDocsCommand } from '../src/commands/docs.js';
 import { registerSheetsCommand } from '../src/commands/sheets.js';
 import { registerSlidesCommand } from '../src/commands/slides.js';
+import { registerNotesCommand } from '../src/commands/notes.js';
 import { registerApiKeysCommand } from '../src/commands/api-keys.js';
 
 function buildProgram(): Command {
@@ -11,6 +12,7 @@ function buildProgram(): Command {
   registerDocsCommand(p);
   registerSheetsCommand(p);
   registerSlidesCommand(p);
+  registerNotesCommand(p);
   registerApiKeysCommand(p);
   return p;
 }
@@ -120,6 +122,31 @@ describe('CLI namespace structure', () => {
       'export',
     ]) {
       expect(findChild(slides!, sub)?.name()).toBe(sub);
+    }
+  });
+
+  it('exposes the notes namespace with the note alias', () => {
+    const program = buildProgram();
+    const notes = findChild(program, 'notes');
+    expect(notes?.name()).toBe('notes');
+    expect(notes?.aliases()).toEqual(expect.arrayContaining(['note']));
+  });
+
+  it('notes contains list/create/get/rename/delete/content/import/export', () => {
+    const program = buildProgram();
+    const notes = findChild(program, 'notes');
+    expect(notes).toBeDefined();
+    for (const sub of [
+      'list',
+      'create',
+      'get',
+      'rename',
+      'delete',
+      'content',
+      'import',
+      'export',
+    ]) {
+      expect(findChild(notes!, sub)?.name()).toBe(sub);
     }
   });
 });

--- a/packages/cli/test/notes-content.test.ts
+++ b/packages/cli/test/notes-content.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseNotesContentFormat,
+  runNotesContent,
+  type NotesContentIO,
+} from '../src/notes/content.js';
+
+interface Capture {
+  stdout: string;
+  stderr: string[];
+  files: Record<string, string>;
+  io: NotesContentIO;
+}
+
+function makeCapture(): Capture {
+  const cap: Capture = {
+    stdout: '',
+    stderr: [],
+    files: {},
+    io: {
+      stdout: (text) => {
+        cap.stdout += text;
+      },
+      stderr: (line) => {
+        cap.stderr.push(line);
+      },
+      writeFile: (path, text) => {
+        cap.files[path] = text;
+      },
+    },
+  };
+  return cap;
+}
+
+describe('parseNotesContentFormat', () => {
+  it('accepts json/md/text', () => {
+    expect(parseNotesContentFormat('json')).toBe('json');
+    expect(parseNotesContentFormat('md')).toBe('md');
+    expect(parseNotesContentFormat('text')).toBe('text');
+  });
+
+  it('rejects anything else', () => {
+    expect(() => parseNotesContentFormat('pdf')).toThrow(/Invalid --format/);
+    expect(() => parseNotesContentFormat('')).toThrow(/Invalid --format/);
+  });
+});
+
+describe('runNotesContent (json)', () => {
+  it('emits the raw note JSON shape', () => {
+    const cap = makeCapture();
+    runNotesContent({ note: { content: '# Hello\n\nWorld' }, format: 'json' }, cap.io);
+    const parsed = JSON.parse(cap.stdout);
+    expect(parsed.content).toBe('# Hello\n\nWorld');
+  });
+});
+
+describe('runNotesContent (md/text)', () => {
+  it('emits the markdown string verbatim', () => {
+    const cap = makeCapture();
+    runNotesContent({ note: { content: '# Title\n\n- a\n- b' }, format: 'md' }, cap.io);
+    expect(cap.stdout).toContain('# Title');
+    expect(cap.stdout).toContain('- a');
+    // No JSON wrapping.
+    expect(cap.stdout.trim().startsWith('{')).toBe(false);
+  });
+
+  it('treats text identically to md (raw markdown)', () => {
+    const cap = makeCapture();
+    runNotesContent({ note: { content: 'plain body' }, format: 'text' }, cap.io);
+    expect(cap.stdout.trim()).toBe('plain body');
+  });
+
+  it('handles empty content', () => {
+    const cap = makeCapture();
+    runNotesContent({ note: { content: '' }, format: 'md' }, cap.io);
+    expect(cap.stdout.trim()).toBe('');
+  });
+
+  it('tolerates a null note body (empty 2xx response)', () => {
+    const capMd = makeCapture();
+    runNotesContent({ note: null, format: 'md' }, capMd.io);
+    expect(capMd.stdout.trim()).toBe('');
+
+    const capJson = makeCapture();
+    runNotesContent({ note: undefined, format: 'json' }, capJson.io);
+    expect(JSON.parse(capJson.stdout)).toEqual({ content: '' });
+  });
+});
+
+describe('runNotesContent --out', () => {
+  it('writes to the given file via the IO surface', () => {
+    const cap = makeCapture();
+    runNotesContent(
+      { note: { content: '# Doc' }, format: 'md', out: 'note.md' },
+      cap.io,
+    );
+    expect(cap.stdout).toBe('');
+    expect(cap.files['note.md']).toContain('# Doc');
+    expect(cap.stderr).toContain('Wrote to note.md');
+  });
+
+  it('passes the force flag through to writeFile', () => {
+    const calls: Array<{ path: string; force: boolean }> = [];
+    const io: NotesContentIO = {
+      stdout: () => {},
+      stderr: () => {},
+      writeFile: (path, _text, force) => {
+        calls.push({ path, force });
+      },
+    };
+    runNotesContent({ note: { content: 'x' }, format: 'md', out: 'a.md' }, io);
+    runNotesContent(
+      { note: { content: 'x' }, format: 'md', out: 'a.md', force: true },
+      io,
+    );
+    expect(calls).toEqual([
+      { path: 'a.md', force: false },
+      { path: 'a.md', force: true },
+    ]);
+  });
+
+  it('treats "-" as stdout', () => {
+    const cap = makeCapture();
+    runNotesContent(
+      { note: { content: 'hello' }, format: 'text', out: '-' },
+      cap.io,
+    );
+    expect(cap.stdout).toContain('hello');
+  });
+});

--- a/packages/cli/test/notes-import.test.ts
+++ b/packages/cli/test/notes-import.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import {
+  runNotesImport,
+  type NotesImportClient,
+  type NotesImportIO,
+} from '../src/notes/import.js';
+
+interface Capture {
+  io: NotesImportIO;
+  stdoutLines: string[];
+  stderrLines: string[];
+  reads: string[];
+  confirmAnswers: boolean[];
+}
+
+function captureIO(opts: {
+  text: string;
+  isTTY: boolean;
+  confirmReply?: boolean;
+}): Capture {
+  const cap: Capture = {
+    stdoutLines: [],
+    stderrLines: [],
+    reads: [],
+    confirmAnswers: [],
+    io: undefined as unknown as NotesImportIO,
+  };
+  cap.io = {
+    stdout: (line) => {
+      cap.stdoutLines.push(line);
+    },
+    stderr: (line) => {
+      cap.stderrLines.push(line);
+    },
+    readText: async (path) => {
+      cap.reads.push(path);
+      return opts.text;
+    },
+    confirm: async () => {
+      const answer = opts.confirmReply ?? false;
+      cap.confirmAnswers.push(answer);
+      return answer;
+    },
+    isTTY: opts.isTTY,
+  };
+  return cap;
+}
+
+interface ClientCapture extends NotesImportClient {
+  createCalls: Array<{ title: string; type?: 'doc' | 'sheet' | 'slides' | 'note' }>;
+  putCalls: Array<{ id: string; content: string }>;
+}
+
+function makeClient(opts: {
+  createOk?: boolean;
+  putOk?: boolean;
+  newId?: string;
+}): ClientCapture {
+  const createCalls: ClientCapture['createCalls'] = [];
+  const putCalls: ClientCapture['putCalls'] = [];
+  const createOk = opts.createOk ?? true;
+  const putOk = opts.putOk ?? true;
+  const newId = opts.newId ?? 'note-new-id';
+  return {
+    createCalls,
+    putCalls,
+    createDocument: async (title, type) => {
+      createCalls.push({ title, type });
+      return {
+        ok: createOk,
+        status: createOk ? 200 : 500,
+        data: createOk
+          ? { id: newId, title }
+          : { error: { code: 'CREATE_FAILED', message: 'boom' } },
+      };
+    },
+    putNoteContent: async (id, note) => {
+      putCalls.push({ id, content: note.content });
+      return {
+        ok: putOk,
+        status: putOk ? 200 : 500,
+        data: putOk ? note : { error: { code: 'PUT_FAILED', message: 'boom' } },
+      };
+    },
+  };
+}
+
+const MD = '# Notes\n\nSome markdown body.';
+
+describe('runNotesImport (new note)', () => {
+  it('POSTs then PUTs for a new note', async () => {
+    const cap = captureIO({ text: MD, isTTY: true });
+    const client = makeClient({});
+
+    const result = await runNotesImport(
+      { file: 'sample.md' },
+      client,
+      cap.io,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(client.createCalls).toEqual([{ title: 'sample', type: 'note' }]);
+    expect(client.putCalls).toEqual([{ id: 'note-new-id', content: MD }]);
+    const out = JSON.parse(cap.stdoutLines.join(''));
+    expect(out.id).toBe('note-new-id');
+    expect(out.title).toBe('sample');
+  });
+
+  it('honors --title over the file basename', async () => {
+    const cap = captureIO({ text: MD, isTTY: true });
+    const client = makeClient({});
+    await runNotesImport(
+      { file: 'sample.md', title: 'My Note' },
+      client,
+      cap.io,
+    );
+    expect(client.createCalls[0].title).toBe('My Note');
+  });
+
+  it('reads from stdin when file is "-"', async () => {
+    const cap = captureIO({ text: MD, isTTY: false });
+    const client = makeClient({});
+    await runNotesImport({ file: '-' }, client, cap.io);
+    expect(cap.reads).toEqual(['-']);
+    expect(client.createCalls[0].title).toBe('Untitled');
+  });
+
+  it('exits 1 when create fails and skips PUT', async () => {
+    const cap = captureIO({ text: MD, isTTY: true });
+    const client = makeClient({ createOk: false });
+    const result = await runNotesImport({ file: 'sample.md' }, client, cap.io);
+    expect(result.exitCode).toBe(1);
+    expect(client.putCalls).toEqual([]);
+    const errBody = JSON.parse(cap.stderrLines[0]);
+    expect(errBody.error.code).toBe('CREATE_FAILED');
+  });
+
+  it('exits 1 when create returns no id', async () => {
+    const cap = captureIO({ text: MD, isTTY: true });
+    const client: ClientCapture = {
+      createCalls: [],
+      putCalls: [],
+      createDocument: async () => ({ ok: true, status: 200, data: {} }),
+      putNoteContent: async () => ({ ok: true, status: 200, data: { content: MD } }),
+    };
+    const result = await runNotesImport({ file: 'sample.md' }, client, cap.io);
+    expect(result.exitCode).toBe(1);
+    expect(client.putCalls).toEqual([]);
+    const errBody = JSON.parse(cap.stderrLines[0]);
+    expect(errBody.error.code).toBe('INVALID_RESPONSE');
+  });
+
+  it('exits 1 when PUT fails', async () => {
+    const cap = captureIO({ text: MD, isTTY: true });
+    const client = makeClient({ putOk: false });
+    const result = await runNotesImport({ file: 'sample.md' }, client, cap.io);
+    expect(result.exitCode).toBe(1);
+    const errBody = JSON.parse(cap.stderrLines[0]);
+    expect(errBody.error.code).toBe('PUT_FAILED');
+  });
+
+  it('--dry-run prints the plan and makes no requests', async () => {
+    const cap = captureIO({ text: MD, isTTY: true });
+    const client = makeClient({});
+    const result = await runNotesImport(
+      { file: 'sample.md', dryRun: true },
+      client,
+      cap.io,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(client.createCalls).toEqual([]);
+    expect(client.putCalls).toEqual([]);
+    const plan = JSON.parse(cap.stdoutLines.join(''));
+    expect(plan.method).toBe('POST');
+    expect(plan.body.type).toBe('note');
+  });
+});
+
+describe('runNotesImport (--replace)', () => {
+  it('confirms then PUTs when interactive and user accepts', async () => {
+    const cap = captureIO({ text: MD, isTTY: true, confirmReply: true });
+    const client = makeClient({});
+    const result = await runNotesImport(
+      { file: 'sample.md', replace: 'note-existing' },
+      client,
+      cap.io,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(client.createCalls).toEqual([]);
+    expect(client.putCalls).toEqual([{ id: 'note-existing', content: MD }]);
+    const body = JSON.parse(cap.stdoutLines.join(''));
+    expect(body.id).toBe('note-existing');
+    expect(body.replaced).toBe(true);
+  });
+
+  it('aborts when interactive user declines', async () => {
+    const cap = captureIO({ text: MD, isTTY: true, confirmReply: false });
+    const client = makeClient({});
+    const result = await runNotesImport(
+      { file: 'sample.md', replace: 'note-existing' },
+      client,
+      cap.io,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(client.putCalls).toEqual([]);
+  });
+
+  it('--yes skips the confirm prompt', async () => {
+    const cap = captureIO({ text: MD, isTTY: true });
+    const client = makeClient({});
+    const result = await runNotesImport(
+      { file: 'sample.md', replace: 'note-existing', yes: true },
+      client,
+      cap.io,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(cap.confirmAnswers).toEqual([]);
+    expect(client.putCalls).toEqual([{ id: 'note-existing', content: MD }]);
+  });
+
+  it('exits 1 + CONFIRMATION_REQ when non-TTY without --yes', async () => {
+    const cap = captureIO({ text: MD, isTTY: false });
+    const client = makeClient({});
+    const result = await runNotesImport(
+      { file: 'sample.md', replace: 'note-existing' },
+      client,
+      cap.io,
+    );
+    expect(result.exitCode).toBe(1);
+    expect(client.putCalls).toEqual([]);
+    const errBody = JSON.parse(cap.stderrLines[0]);
+    expect(errBody.error.code).toBe('CONFIRMATION_REQ');
+  });
+});


### PR DESCRIPTION
## Summary

v0.6.0 shipped the collaborative markdown **note** document type (`type: 'note'`, docKey `note-<id>`) but left it unreachable from the `wafflebase` CLI. A note's entire content is a single markdown string in one Yorkie `Text` at `root.content` (CodePair byte-compatible), so it needs a content read/write path distinct from the docs/slides tree readers.

This adds a `notes` CLI namespace at full parity with `docs`/`slides`, plus the backend content endpoint it needs.

### Backend
- **`note` arm in the shared content controller** (`docs-content.controller.ts`): `GET` reads the `Text` (`{ content }`), `PUT` writes it; body-shape sniffing recognises `{ content: string }` (checked *after* the `blocks`/`slides` array anchors so it can't misfire).
- **New `yorkie/note-content.ts`** — `readNoteRoot` / `writeNoteRoot` (mirrors the docs/slides tree readers/writers). Writer creates `new Text()` + edits in one `doc.update` for a fresh note, else replaces the existing `Text`.
- **v1 create** (`documents.controller.ts`) now accepts `type: 'note'` — it previously downgraded unknown types to `sheet`, so programmatic note creation was impossible.

### CLI
- **New `notes` namespace** (alias `note`): `list / create / get / rename / delete / content / export / import`, mirroring `slides.ts`.
- Content **is** markdown → no lossy serialization: `content` emits `{content}` for `--format json` and raw markdown for `md`/`text`; `export` is markdown-only; `import` reads a `.md` file/stdin straight into the content string.
- `http-client` `getNoteContent`/`putNoteContent` + `note` create type; `schema` registry entries (`note.*` aliases).

## Test plan
- `pnpm verify:fast` green (ran as the pre-commit gate); CLI + backend builds + CLI `tsc --noEmit` clean.
- **CLI unit**: `notes-content` (json/md/text, `--out`, null-body tolerance), `notes-import` (create / `--replace` / confirm gate / `--dry-run`), namespace structure.
- **Backend unit**: `note-content.spec.ts` (read/write, `.edit`-guard for mis-materialized `Text`), extended `docs-content.controller.spec.ts` (GET/PUT note, shape mismatch).
- **Live-Yorkie e2e**: `notes-cli-roundtrip.e2e-spec.ts` exercises `writeNoteRoot`'s **create branch** (fresh-note import → content read-back → export → `--replace`); gated on `RUN_YORKIE_INTEGRATION_TESTS`, verified passing locally against docker Yorkie.

## Review
A high-effort multi-agent review ran on the branch; 4 findings fixed (stdout export guard, `readNoteRoot` `.edit` guard, null-body deref, create-branch e2e coverage), 2 cleanup findings (content-IO/import-IO duplication) noted as a batched follow-up since they're the codebase's existing per-type pattern. Details in `docs/tasks/active/20260716-notes-cli-todo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `notes` CLI namespace, with `note` alias, for listing, creating, viewing, renaming, and deleting notes.
  * Added Markdown content viewing, export, import, replacement, JSON/text output, file output, and dry-run support.
  * Added backend support for creating and reading note documents with Markdown content.
  * Added validation and confirmation safeguards for note replacement operations.

* **Documentation**
  * Updated CLI design, task records, and notes documentation to describe supported commands and workflows.

* **Tests**
  * Added coverage for note content handling, imports, replacements, and end-to-end round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->