### PR TITLE
Unify document permissions: share links + delete/move by manager tier

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -17,7 +17,8 @@ ownership and user accounts.
 
 - Authenticate users via GitHub OAuth2 and issue JWT session cookies.
 - Provide a REST API for creating, listing, and deleting spreadsheet documents.
-- Enforce document ownership — users can only access their own documents.
+- Enforce workspace-based access — members share their workspace's documents;
+  deleting or moving a document is reserved to its manager (owner or author).
 
 ### Non-Goals
 
@@ -106,40 +107,65 @@ flowchart TD
 
 All endpoints require `JwtAuthGuard`.
 
+Access follows the **workspace** model, not document authorship alone: every
+member of a document's workspace has `rw` on it. A document's **manager** —
+the workspace owner **or** the document's `authorID` — is additionally the tier
+allowed to delete or move it (`DocumentController.resolveDocManager`).
+
 **`GET /documents`**
-- Returns all documents where `authorID` matches the authenticated user.
+- Returns all documents across every workspace the user belongs to, each row
+  annotated with `canManage` (owner-of-workspace or author) so the client can
+  gate Delete/Move without re-deriving roles.
 
 **`GET /documents/:id`**
-- Returns the document if the authenticated user is the author.
-- Throws `ForbiddenException` if the user is not the owner.
+- Returns the document if the user is a member of its workspace.
+- Throws `ForbiddenException` (403) otherwise.
 
-**`POST /documents`**
-- Body: `{ title: string }`
-- Creates a document with `authorID` set to the authenticated user's ID.
+**`POST /documents` / `POST /workspaces/:workspaceId/documents`**
+- Body: `{ title: string, type?, workspaceId }`
+- Requires workspace membership. Creates a document with `authorID` set to the
+  caller.
+
+**`PATCH /documents/:id`**
+- Rename (`{ title }`) — any workspace member.
+- Move (`{ workspaceId }`) — manager only (owner or author); the caller must
+  also be a member of the destination workspace. `403` otherwise.
 
 **`DELETE /documents/:id`**
-- Deletes the document if the authenticated user is the author.
-- Throws `ForbiddenException` if the user is not the owner.
+- Deletes the document if the caller is its manager (workspace owner or author).
+- Throws `ForbiddenException` (403) for a non-manager member. Best-effort blob
+  cleanup for `pdf` documents.
+
+The REST v1 `DELETE /api/v1/workspaces/:wid/documents/:did` applies the same
+manager gate for JWT callers; API-key callers (workspace-scoped credentials
+minted by an owner) act with workspace authority but must carry the `write`
+scope — a read-only key is rejected.
 
 #### Share Links (`/documents/:id/share-links`, `/share-links`)
+
+Share-link authority mirrors the document model — see
+[sharing.md](sharing.md) for the full matrix. `isManager = isOwner || isAuthor`.
 
 **`POST /documents/:id/share-links`**
 - Guard: `JwtAuthGuard`
 - Body: `{ role: "viewer" | "editor", expiration: "1h" | "8h" | "24h" | "7d" | null }`
-- Creates a share link for the document. Only the document owner can create links.
-- Returns the created ShareLink (including `token`).
+- Any workspace member may create a `viewer` link; only a manager may create an
+  `editor` link. Returns the created ShareLink (including `token`).
 
 **`GET /documents/:id/share-links`**
 - Guard: `JwtAuthGuard`
-- Returns all share links for the document. Only the document owner can list links.
+- Any workspace member may list. Returns `{ links, permissions:
+  { canCreateEditorLink } }`, each link annotated with `canDelete`. Editor
+  links a non-manager did not create are omitted (a token is redistributable).
 
 **`DELETE /share-links/:id`**
 - Guard: `JwtAuthGuard`
-- Revokes (deletes) a share link. Only the link creator can delete it.
+- Revokes a share link. The link's creator may always revoke it; a manager may
+  revoke any link on the document.
 
 **`GET /share-links/:token/resolve`** *(public — no auth required)*
 - Resolves a share token to document info.
-- Returns `{ documentId, role, title }` if the token is valid and not expired.
+- Returns `{ documentId, role, title, type }` if the token is valid and not expired.
 - Returns `410 Gone` if the token has expired.
 - Returns `404 Not Found` if the token is invalid.
 
@@ -420,9 +446,10 @@ Deployment assumes frontend and backend share an eTLD+1
 (e.g. `*.wafflebase.com`). Cross-eTLD deployments would need
 `SameSite=None` paired with a CSRF token, not yet implemented.
 
-**Authorization checks** — Document endpoints verify that `req.user.id`
-matches the document's `authorID`. Unauthorized access throws
-`ForbiddenException` (HTTP 403).
+**Authorization checks** — Document endpoints verify workspace membership
+(`WorkspaceService.assertMember`) for read/edit, and additionally require the
+caller to be the document's **manager** (workspace owner or `authorID`) to
+delete or move it. Unauthorized access throws `ForbiddenException` (HTTP 403).
 
 **Middleware pipeline:**
 

--- a/docs/design/sharing.md
+++ b/docs/design/sharing.md
@@ -56,10 +56,12 @@ to the document and creator.
 The list endpoint returns `{ links, permissions: { canCreateEditorLink } }`,
 where each link is annotated with a server-computed `canDelete` flag, so the
 client gates the UI without re-deriving roles or knowing its own user id. It
-also **omits editor links from non-managers**: a plain member may not mint an
-editor link, so handing them an existing editor token (which they could copy
-and redistribute) would escalate anonymous write access they were never allowed
-to grant. The resolve endpoint returns `{ documentId, role, title, type }` on
+also **omits editor links a non-manager did not create**: a plain member may
+not mint an editor link, so handing them someone else's editor token (which
+they could copy and redistribute) would escalate anonymous write access they
+were never allowed to grant. Their own editor links stay visible so a demoted
+ex-manager can still find and revoke live links they minted. The resolve
+endpoint returns `{ documentId, role, title, type }` on
 success, `410 Gone` for expired tokens, and `404` for invalid tokens.
 
 ### Permission model

--- a/docs/design/sharing.md
+++ b/docs/design/sharing.md
@@ -8,9 +8,10 @@ target-version: 0.1.0
 ## Summary
 
 Documents in Wafflebase are shareable via URL-embedded tokens, similar to Google
-Docs' "Anyone with the link" feature. Document owners can generate share links
-with a specific role (`viewer` or `editor`) and optional expiration. Anyone with
-a valid link can access the document without logging in.
+Docs' "Anyone with the link" feature. Workspace members can generate share links
+with a specific role (`viewer` or `editor`) and optional expiration, subject to
+the permission matrix below. Anyone with a valid link can access the document
+without logging in.
 
 ### Goals
 
@@ -46,13 +47,47 @@ UUID token, a role (`viewer`/`editor`), an optional expiration, and references
 to the document and creator.
 
 **API endpoints:**
-- `POST /documents/:id/share-links` — Create link (JWT required, owner only)
-- `GET /documents/:id/share-links` — List links (JWT required, owner only)
-- `DELETE /share-links/:id` — Revoke link (JWT required, creator only)
+- `POST /documents/:id/share-links` — Create link (JWT required; see matrix)
+- `GET /documents/:id/share-links` — List links + caller capabilities (JWT
+  required, any workspace member)
+- `DELETE /share-links/:id` — Revoke link (JWT required; see matrix)
 - `GET /share-links/:token/resolve` — Resolve token (public, no auth)
 
-The resolve endpoint returns `{ documentId, role, title }` on success,
-`410 Gone` for expired tokens, and `404` for invalid tokens.
+The list endpoint returns `{ links, permissions: { canCreateEditorLink } }`,
+where each link is annotated with a server-computed `canDelete` flag, so the
+client gates the UI without re-deriving roles or knowing its own user id. It
+also **omits editor links from non-managers**: a plain member may not mint an
+editor link, so handing them an existing editor token (which they could copy
+and redistribute) would escalate anonymous write access they were never allowed
+to grant. The resolve endpoint returns `{ documentId, role, title, type }` on
+success, `410 Gone` for expired tokens, and `404` for invalid tokens.
+
+### Permission model
+
+Share-link authority follows the workspace access model rather than document
+authorship alone. Every workspace member has `rw` on the document
+(see [yorkie-auth-webhook.md](yorkie-auth-webhook.md)), so any member may hand
+out a read (`viewer`) link; issuing a write (`editor`) link — a broader
+escalation to anonymous users — is reserved for the workspace **owner** or the
+document **author** (`isManager`). `ShareLinkService.resolveCapability` computes
+this once from the document (`authorID`, `workspaceId`) and the caller's
+`WorkspaceMember.role`, and create / list / delete all consume it:
+
+| Actor        | create viewer | create editor | list | revoke         |
+| ------------ | :-----------: | :-----------: | :--: | -------------- |
+| WS owner     | ✅            | ✅            | ✅   | any link       |
+| Doc author   | ✅            | ✅            | ✅   | any link       |
+| WS member    | ✅            | ❌            | ✅   | own links only |
+| Non-member   | ❌            | ❌            | ❌   | ❌             |
+
+Access requires `isMember || isAuthor` (else `403`); `isManager = isOwner ||
+isAuthor` gates editor-link creation and managing others' links. A link's
+**creator can always revoke it**, even after leaving the workspace, so `delete`
+short-circuits on `createdBy === userId` before the manager check. Rejections
+raise a specific `403` (e.g. "Only the workspace owner or document owner can
+create editor links") which the frontend surfaces verbatim; the UI additionally
+disables the editor option and hides revoke buttons the caller cannot use, so a
+permitted user never hits the error path.
 
 ### Frontend
 

--- a/docs/tasks/active/20260717-share-link-permissions-lessons.md
+++ b/docs/tasks/active/20260717-share-link-permissions-lessons.md
@@ -1,0 +1,43 @@
+# Share Link Permissions — lessons
+
+## A "list" endpoint is part of the permission surface, not just a read
+
+The first cut gated *creation* correctly (members can't mint editor links) but
+`findByDocument` still returned every link — including editor tokens — to plain
+members. Since a share token is copy-and-paste redistributable, exposing an
+editor token to someone who can't create one re-opens the exact escalation the
+create-gate closed. Lesson: when a resource is a bearer credential, listing it
+grants the same power as creating it. Gate reads by the same matrix as writes.
+
+## Preserve the invariant you're replacing, don't just add checks
+
+Adding `resolveCapability` at the top of `delete` silently dropped the original
+invariant "a link's creator can always revoke it" — a creator who left the
+workspace lost the ability to clean up their own live anonymous link. When
+tightening an authorization path, enumerate the *existing* allow-paths and keep
+each one, rather than layering a new gate in front of all of them.
+
+## Push per-item authorization to the server; don't re-derive identity on the client
+
+The revoke button first depended on `fetchMe` + `link.createdBy === me.id`. That
+made a security-relevant control depend on an async query that can be pending or
+(with `retry:false`) permanently failed, hiding the button from users who
+legitimately own the link. Returning a server-computed `canDelete` per link
+removed the whole class of bug and kept the client dumb. If the server already
+knows the answer, send the answer, not the inputs.
+
+## Client gating driven by async state needs a `loaded` gate + reset-on-key-change
+
+Defaulting permissions to "all false" and flipping them after fetch produced two
+opposite glitches: managers briefly saw the editor option disabled, and stale
+perms from a previously-opened document leaked across a `documentId` change.
+Fix pattern: a `loaded` flag that suppresses gating hints and disables the
+action button until the fetch resolves, plus resetting state at the start of
+each fetch with a cancellation guard.
+
+## Adversarial self-review earns its keep on permission changes
+
+A high-effort workflow review found the token-exposure escalation and the
+delete regression that the passing unit + integration tests did not — the tests
+asserted the new behavior worked, not that the *old* guarantees survived. For
+authorization work, run the adversarial pass before pushing.

--- a/docs/tasks/active/20260717-share-link-permissions-todo.md
+++ b/docs/tasks/active/20260717-share-link-permissions-todo.md
@@ -89,3 +89,15 @@ Workflow-backed review surfaced 8 findings; all addressed:
    query with a justifying comment: `doc.workspaceId` is already canonical (no
    slug resolution) and we need a non-throwing, author-aware lookup that
    `assertMember` does not provide.
+
+### Round 2 (re-review after applying the above)
+
+9. **[correctness] demoted ex-manager can't revoke own editor link** — the
+   editor-link filter hid *all* editor links from a non-manager, including ones
+   they created while still an owner, so a live anonymous write link became
+   unrevocable via the UI. Fixed: filter keeps `role !== 'editor' ||
+   createdBy === userId`.
+10. **[correctness] list-fetch failure locks the Create button** — a swallowed
+    `getShareLinks` rejection left `loaded=false`, permanently disabling Create
+    with no feedback. Fixed: set `loaded` in `finally`, surface the error via
+    toast, and fall back to viewer-only perms (backend stays the real gate).

--- a/docs/tasks/active/20260717-share-link-permissions-todo.md
+++ b/docs/tasks/active/20260717-share-link-permissions-todo.md
@@ -1,0 +1,91 @@
+# Share Link Permissions — todo
+
+Rework share-link authorization so it respects workspace ownership and
+document authorship instead of the current document-author-only gate. A
+workspace owner (or the document author) who did not personally create the
+document currently gets a 403 → generic "Failed to create share link" toast,
+even though they have full `rw` access to the document.
+
+## Policy matrix (approved)
+
+| Actor        | create viewer | create editor | list | revoke        |
+| ------------ | :-----------: | :-----------: | :--: | ------------- |
+| WS owner     | ✅            | ✅            | ✅   | any link      |
+| Doc author   | ✅            | ✅            | ✅   | any link      |
+| WS member    | ✅            | ❌            | ✅   | own links only|
+| Non-member   | ❌            | ❌            | ❌   | ❌            |
+
+Capability derivation (single source in backend, post-review):
+- access requires `isMember || isAuthor` (else 403)
+- `isManager` = `isOwner || isAuthor` — gates editor creation + managing
+  others' links (the two authorities coincide today, so one flag)
+- viewer creation needs only access; a link's creator may always revoke it
+
+## Backend
+
+- [x] `share-link.service.ts` — add a private `resolveCapability(documentId, userId)`
+      helper (loads doc, resolves workspace membership via non-throwing
+      `findUnique`, combines with `isAuthor`). Returns `{ isAuthor, isOwner,
+      hasAccess, canCreateEditor, canManageAllLinks }`.
+- [x] `create` — validate `role ∈ {viewer, editor}`; gate `editor` on
+      `canCreateEditor`, `viewer` on `hasAccess`; specific 403 messages.
+- [x] `findByDocument` — relax to `hasAccess`; return
+      `{ links, permissions: { canCreateEditorLink, canManageAllLinks } }`.
+- [x] `delete` — allow `canManageAllLinks || link.createdBy === userId`.
+- [x] Inject/reuse workspace membership lookup (avoid a hard dependency cycle;
+      query `prisma.workspaceMember` directly in the service).
+- [x] Unit tests: owner-not-author create editor ✅, member create editor 403,
+      member create viewer ✅, non-member 403, delete-any vs delete-own.
+
+## Frontend
+
+- [x] `share-links.ts` — `getShareLinks` returns `{ links, permissions }`;
+      update `createShareLink` callers. Keep `assertOk` server message usable.
+- [x] `share-dialog.tsx` — consume `permissions`; disable `editor` option +
+      tooltip when `!canCreateEditorLink`; gate per-link delete button by
+      `canManageAllLinks || link.createdBy === me`.
+- [x] `handleCreate` catch — surface the server error message instead of the
+      hardcoded generic toast.
+
+## Docs
+
+- [x] Update `docs/design/sharing.md` "owner only" wording → this matrix.
+
+## Verify
+
+- [x] `pnpm verify:fast` (EXIT=0)
+- [x] DB integration (`ShareLinkService` + authenticated-http share-link): 16 passed
+- [ ] Manual smoke: workspace owner (non-author) creates a link in `pnpm dev`.
+
+## Review (self code-review, high effort)
+
+Workflow-backed review surfaced 8 findings; all addressed:
+
+1. **[security] editor token exposure** — `findByDocument` handed editor tokens
+   to plain members, who could copy + redistribute them (bypassing "members
+   can't mint editor links"). Fixed: non-managers no longer receive editor
+   links in the list.
+2. **[correctness] creator locked out of own link** — `delete` ran
+   `resolveCapability` (needs current membership) before the creator check, so
+   a creator who left the workspace couldn't revoke their own link. Fixed:
+   short-circuit on `createdBy === userId` first.
+3. **[correctness] revoke button hidden during load** — gating on `fetchMe`
+   left members unable to revoke their own links while `["me"]` was unresolved
+   / failed. Fixed: backend now returns a per-link `canDelete`; `fetchMe`
+   removed from the dialog entirely.
+4. **[correctness] editor option disabled for managers on open** — default
+   perms (all false) briefly disabled the editor option + showed the hint to an
+   owner. Fixed: `loaded` flag gates the hint, editor `disabled`, and the
+   Create button until the fetch resolves.
+5. **[cleanup] stale perms across documentId** — dialog reused a prior
+   document's perms during the async gap. Fixed: reset links/perms/`loaded` at
+   the start of each fetch, with cancellation.
+6. **[cleanup] duplicate capability flags** — `canCreateEditor` and
+   `canManageAllLinks` were always identical. Collapsed to one `isManager`;
+   wire sends only `canCreateEditorLink` + per-link `canDelete`.
+7. **[cleanup] dead `hasAccess` field** — removed from the returned struct
+   (access is enforced by the throw inside `resolveCapability`).
+8. **[cleanup] bypasses WorkspaceService** — kept the direct `workspaceMember`
+   query with a justifying comment: `doc.workspaceId` is already canonical (no
+   slug resolution) and we need a non-throwing, author-aware lookup that
+   `assertMember` does not provide.

--- a/docs/tasks/active/20260717-share-link-permissions-todo.md
+++ b/docs/tasks/active/20260717-share-link-permissions-todo.md
@@ -47,6 +47,30 @@ Capability derivation (single source in backend, post-review):
 - [x] `handleCreate` catch — surface the server error message instead of the
       hardcoded generic toast.
 
+## Document Delete / Move (follow-on, same PR)
+
+Delete/Move had the *inverse* gap: gated only on `assertMember`, so any plain
+member could delete or move another member's (incl. the owner's) document.
+Tightened to the same manager tier (`isOwner || isAuthor`); Rename stays
+member-level (it's an edit).
+
+- [x] `DocumentController.resolveDocManager` helper (member + owner-role/author).
+- [x] Legacy `DELETE /documents/:id` → manager only.
+- [x] Legacy `PATCH /documents/:id` → rename any member; move manager only
+      (+ destination membership).
+- [x] v1 `DELETE /api/v1/.../documents/:did` → manager gate for JWT callers;
+      API keys require `write` scope (read-only keys rejected — review R3 F1).
+- [x] Extract shared `isDocumentManager` helper (review R3 F4) reused by the
+      legacy gate, v1 gate, list `canManage`, and share-link `resolveCapability`.
+- [x] `WorkspaceService.findMembershipsByUser` + list `canManage` annotation on
+      `GET /documents` and `GET /workspaces/:id/documents`.
+- [x] Frontend: `Document.canManage`; hide Delete/Move in the list dropdown
+      when `!canManage` (Rename stays).
+- [x] Unit tests: `document.controller.spec.ts` (12), `documents.controller.spec.ts` (4).
+- [x] HTTP e2e: member can rename, cannot move/delete; owner can delete;
+      `canManage` flag per row.
+- [x] Docs: `backend.md` stale author-only claims → workspace + manager model.
+
 ## Docs
 
 - [x] Update `docs/design/sharing.md` "owner only" wording → this matrix.
@@ -101,3 +125,18 @@ Workflow-backed review surfaced 8 findings; all addressed:
     `getShareLinks` rejection left `loaded=false`, permanently disabling Create
     with no feedback. Fixed: set `loaded` in `finally`, surface the error via
     toast, and fall back to viewer-only perms (backend stays the real gate).
+
+### Round 3 (review of the delete/move commit)
+
+11. **[security] v1 DELETE exempted all API keys** — a read-only key could
+    delete documents (my exemption skipped the scope check). Fixed: API keys
+    now require the `write` scope; read-only keys get 403.
+12. **[cleanup] manager predicate duplicated ×4** — extracted
+    `document/document-access.ts#isDocumentManager`, reused by the legacy gate,
+    v1 gate, list `canManage`, and share-link `resolveCapability`.
+- **F2 (null authorID → owner-only manage)**: accepted as by-design — there is
+  always a workspace owner who can manage, so no document is unmanageable;
+  documented in the `isDocumentManager` doc-comment.
+- **F3 (redundant `assertMember` on the v1 JWT path)**: left as-is; threading
+  the role through the shared `WorkspaceScopeGuard` would couple every v1 route
+  for one avoidable `findUnique` on the delete path only.

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -156,10 +156,11 @@ All document endpoints require JWT authentication.
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| `GET` | `/documents` | List all documents for authenticated user |
-| `GET` | `/documents/:id` | Get document by ID (owner only) |
+| `GET` | `/documents` | List documents across the user's workspaces (each row carries `canManage`) |
+| `GET` | `/documents/:id` | Get document by ID (workspace member) |
 | `POST` | `/documents` | Create a new document (`{ title }`) |
-| `DELETE` | `/documents/:id` | Delete document (owner only) |
+| `PATCH` | `/documents/:id` | Rename (any member) or move (`{ workspaceId }`, manager only) |
+| `DELETE` | `/documents/:id` | Delete document (manager: workspace owner or author) |
 
 ### API Keys (`/workspaces/:workspaceId/api-keys`)
 

--- a/packages/backend/src/api/v1/documents.controller.spec.ts
+++ b/packages/backend/src/api/v1/documents.controller.spec.ts
@@ -1,0 +1,72 @@
+import { ForbiddenException } from '@nestjs/common';
+import { ApiV1DocumentsController } from './documents.controller';
+
+const WS = 'ws-1';
+const AUTHOR = 1;
+const OWNER = 2;
+const MEMBER = 3;
+
+describe('ApiV1DocumentsController.remove permissions', () => {
+  let controller: ApiV1DocumentsController;
+  let documentService: {
+    getDocumentOrThrow: jest.Mock;
+    deleteDocument: jest.Mock;
+  };
+  let workspaceService: { assertMember: jest.Mock };
+
+  beforeEach(() => {
+    documentService = {
+      getDocumentOrThrow: jest
+        .fn()
+        .mockResolvedValue({ id: 'doc-1', workspaceId: WS, authorID: AUTHOR }),
+      deleteDocument: jest.fn().mockResolvedValue({ id: 'doc-1' }),
+    };
+    workspaceService = {
+      assertMember: jest.fn().mockResolvedValue({ role: 'member' }),
+    };
+    controller = new ApiV1DocumentsController(
+      documentService as never,
+      { getEditors: jest.fn() } as never,
+      workspaceService as never,
+    );
+  });
+
+  const req = (userId: number, isApiKey = false, scopes?: string[]) =>
+    ({ user: { id: userId, isApiKey, scopes } }) as never;
+
+  it('forbids a plain member from deleting a document they do not own', async () => {
+    workspaceService.assertMember.mockResolvedValue({ role: 'member' });
+    await expect(
+      controller.remove(WS, 'doc-1', req(MEMBER)),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(documentService.deleteDocument).not.toHaveBeenCalled();
+  });
+
+  it('lets the workspace owner delete any document', async () => {
+    workspaceService.assertMember.mockResolvedValue({ role: 'owner' });
+    await expect(
+      controller.remove(WS, 'doc-1', req(OWNER)),
+    ).resolves.toMatchObject({ id: 'doc-1' });
+  });
+
+  it('lets the document author delete their own document', async () => {
+    workspaceService.assertMember.mockResolvedValue({ role: 'member' });
+    await expect(
+      controller.remove(WS, 'doc-1', req(AUTHOR)),
+    ).resolves.toMatchObject({ id: 'doc-1' });
+  });
+
+  it('allows a write-scoped API key without a membership check', async () => {
+    await expect(
+      controller.remove(WS, 'doc-1', req(0, true, ['read', 'write'])),
+    ).resolves.toMatchObject({ id: 'doc-1' });
+    expect(workspaceService.assertMember).not.toHaveBeenCalled();
+  });
+
+  it('forbids a read-only API key from deleting', async () => {
+    await expect(
+      controller.remove(WS, 'doc-1', req(0, true, ['read'])),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(documentService.deleteDocument).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/api/v1/documents.controller.ts
+++ b/packages/backend/src/api/v1/documents.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   Param,
   Patch,
@@ -12,6 +13,8 @@ import {
 import { CombinedAuthGuard } from '../../api-key/combined-auth.guard';
 import { WorkspaceScopeGuard } from './workspace-scope.guard';
 import { DocumentService } from '../../document/document.service';
+import { isDocumentManager } from '../../document/document-access';
+import { WorkspaceService } from '../../workspace/workspace.service';
 import { AuthenticatedRequest } from '../../auth/auth.types';
 import { YorkieAdminService } from '../../yorkie/yorkie-admin.service';
 import { yorkieDocKey } from '../../yorkie/yorkie-doc-key';
@@ -22,6 +25,7 @@ export class ApiV1DocumentsController {
   constructor(
     private readonly documentService: DocumentService,
     private readonly yorkieAdminService: YorkieAdminService,
+    private readonly workspaceService: WorkspaceService,
   ) {}
 
   @Get()
@@ -86,11 +90,34 @@ export class ApiV1DocumentsController {
   async remove(
     @Param('workspaceId') workspaceId: string,
     @Param('documentId') documentId: string,
+    @Req() req: AuthenticatedRequest,
   ) {
-    await this.documentService.getDocumentOrThrow({
+    const doc = await this.documentService.getDocumentOrThrow({
       id: documentId,
       workspaceId,
     });
+    if (req.user.isApiKey) {
+      // API keys are workspace-scoped credentials minted by an owner; they act
+      // with workspace authority but must carry the `write` scope to mutate.
+      if (!req.user.scopes?.includes('write')) {
+        throw new ForbiddenException(
+          'This API key does not have write access',
+        );
+      }
+    } else {
+      // A human (JWT) caller may only delete a document they manage — as the
+      // workspace owner or the document's author.
+      const userId = Number(req.user.id);
+      const member = await this.workspaceService.assertMember(
+        workspaceId,
+        userId,
+      );
+      if (!isDocumentManager(member.role, doc.authorID, userId)) {
+        throw new ForbiddenException(
+          'Only the workspace owner or document owner can delete this document',
+        );
+      }
+    }
     return this.documentService.deleteDocument({ id: documentId });
   }
 }

--- a/packages/backend/src/document/document-access.ts
+++ b/packages/backend/src/document/document-access.ts
@@ -1,0 +1,22 @@
+/**
+ * A document's "manager" — the workspace **owner** or the document's **author**
+ * — is the tier allowed to delete or move a document and to mint/manage editor
+ * share links (a plain member has `rw` on the content but not these
+ * administrative actions). See docs/design/sharing.md and docs/design/backend.md.
+ *
+ * This is the single source of the predicate so the legacy delete/move gate,
+ * the REST v1 delete gate, the documents-list `canManage` annotation, and the
+ * share-link capability check never diverge.
+ *
+ * `memberRole` is the caller's role in the document's workspace (`undefined`
+ * when they are not a member); `authorID` is the document's author (`null` for
+ * legacy/orphaned documents, which therefore only the workspace owner can
+ * manage — there is always an owner, so no document becomes unmanageable).
+ */
+export function isDocumentManager(
+  memberRole: string | undefined,
+  authorID: number | null,
+  userId: number,
+): boolean {
+  return memberRole === 'owner' || authorID === userId;
+}

--- a/packages/backend/src/document/document.controller.spec.ts
+++ b/packages/backend/src/document/document.controller.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { DocumentController } from './document.controller';
 
 const req = { user: { id: '1' } } as never;
@@ -58,5 +62,148 @@ describe('DocumentController.createDocument fileId gating', () => {
         fileId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.pdf',
       }),
     );
+  });
+});
+
+const WS = 'ws-1';
+const AUTHOR = 1;
+const OWNER = 2;
+const MEMBER = 3;
+
+function reqAs(userId: number) {
+  return { user: { id: userId } } as never;
+}
+
+describe('DocumentController delete/move/rename permissions', () => {
+  let controller: DocumentController;
+  let documentService: {
+    document: jest.Mock;
+    deleteDocument: jest.Mock;
+    updateDocument: jest.Mock;
+    listDocumentsWithAuthor: jest.Mock;
+  };
+  let workspaceService: {
+    assertMember: jest.Mock;
+    findMembershipsByUser: jest.Mock;
+    resolveId: jest.Mock;
+  };
+
+  beforeEach(() => {
+    documentService = {
+      document: jest.fn().mockResolvedValue({
+        id: 'doc-1',
+        workspaceId: WS,
+        authorID: AUTHOR,
+        fileId: null,
+      }),
+      deleteDocument: jest.fn().mockResolvedValue({ id: 'doc-1' }),
+      updateDocument: jest.fn().mockResolvedValue({ id: 'doc-1' }),
+      listDocumentsWithAuthor: jest.fn(),
+    };
+    workspaceService = {
+      // Default: caller is a plain member. Individual tests override the role.
+      assertMember: jest.fn().mockResolvedValue({ role: 'member' }),
+      findMembershipsByUser: jest.fn(),
+      resolveId: jest.fn((id: string) => Promise.resolve(id)),
+    };
+    controller = new DocumentController(
+      documentService as never,
+      workspaceService as never,
+      { getEditors: jest.fn().mockResolvedValue(new Map()) } as never,
+      { delete: jest.fn().mockResolvedValue(undefined) } as never,
+    );
+  });
+
+  describe('deleteDocument', () => {
+    it('forbids a plain member from deleting a document they do not own', async () => {
+      workspaceService.assertMember.mockResolvedValue({ role: 'member' });
+      await expect(
+        controller.deleteDocument(reqAs(MEMBER), 'doc-1'),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(documentService.deleteDocument).not.toHaveBeenCalled();
+    });
+
+    it('lets the workspace owner delete any document', async () => {
+      workspaceService.assertMember.mockResolvedValue({ role: 'owner' });
+      await expect(
+        controller.deleteDocument(reqAs(OWNER), 'doc-1'),
+      ).resolves.toMatchObject({ id: 'doc-1' });
+    });
+
+    it('lets the document author delete their own document', async () => {
+      workspaceService.assertMember.mockResolvedValue({ role: 'member' });
+      await expect(
+        controller.deleteDocument(reqAs(AUTHOR), 'doc-1'),
+      ).resolves.toMatchObject({ id: 'doc-1' });
+    });
+
+    it('propagates the 403 when the caller is not a member', async () => {
+      workspaceService.assertMember.mockRejectedValue(new ForbiddenException());
+      await expect(
+        controller.deleteDocument(reqAs(999), 'doc-1'),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('throws NotFound for a missing document', async () => {
+      documentService.document.mockResolvedValue(null);
+      await expect(
+        controller.deleteDocument(reqAs(OWNER), 'doc-1'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('updateDocument', () => {
+    it('lets a plain member rename a document', async () => {
+      workspaceService.assertMember.mockResolvedValue({ role: 'member' });
+      await controller.updateDocument(reqAs(MEMBER), 'doc-1', {
+        title: 'Renamed',
+      } as never);
+      expect(documentService.updateDocument).toHaveBeenCalledWith({
+        where: { id: 'doc-1' },
+        data: { title: 'Renamed' },
+      });
+    });
+
+    it('forbids a plain member from moving a document', async () => {
+      workspaceService.assertMember.mockResolvedValue({ role: 'member' });
+      await expect(
+        controller.updateDocument(reqAs(MEMBER), 'doc-1', {
+          workspaceId: 'ws-2',
+        } as never),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(documentService.updateDocument).not.toHaveBeenCalled();
+    });
+
+    it('lets the owner move a document (checking destination membership)', async () => {
+      workspaceService.assertMember.mockResolvedValue({ role: 'owner' });
+      await controller.updateDocument(reqAs(OWNER), 'doc-1', {
+        workspaceId: 'ws-2',
+      } as never);
+      expect(workspaceService.assertMember).toHaveBeenCalledWith(WS, OWNER);
+      expect(workspaceService.assertMember).toHaveBeenCalledWith('ws-2', OWNER);
+      expect(documentService.updateDocument).toHaveBeenCalledWith({
+        where: { id: 'doc-1' },
+        data: { workspace: { connect: { id: 'ws-2' } } },
+      });
+    });
+  });
+
+  describe('getDocuments (canManage annotation)', () => {
+    it('flags canManage per row from workspace role and authorship', async () => {
+      documentService.listDocumentsWithAuthor.mockResolvedValue([
+        { id: 'a', type: 'sheet', workspaceId: WS, authorID: AUTHOR, updatedAt: new Date(0) },
+        { id: 'b', type: 'sheet', workspaceId: WS, authorID: 999, updatedAt: new Date(0) },
+        { id: 'c', type: 'sheet', workspaceId: 'ws-owned', authorID: 999, updatedAt: new Date(0) },
+      ]);
+      workspaceService.findMembershipsByUser.mockResolvedValue([
+        { workspaceId: WS, role: 'member' },
+        { workspaceId: 'ws-owned', role: 'owner' },
+      ]);
+
+      const rows = await controller.getDocuments(reqAs(AUTHOR));
+      const byId = Object.fromEntries(rows.map((r) => [r.id, r.canManage]));
+      // a: authored by caller → manage; b: member, not author → no; c: owner → manage.
+      expect(byId).toEqual({ a: true, b: false, c: true });
+    });
   });
 });

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   NotFoundException,
   Param,
@@ -28,6 +29,7 @@ import {
 import { yorkieDocKey } from '../yorkie/yorkie-doc-key';
 import { FileService } from '../file/file.service';
 import { VALID_FILE_ID_PATTERN } from '../file/file.constants';
+import { isDocumentManager } from './document-access';
 
 type DocumentListItem = Omit<DocumentWithAuthor, 'updatedAt'> & {
   editors?: PresenceUser[];
@@ -37,6 +39,10 @@ type DocumentListItem = Omit<DocumentWithAuthor, 'updatedAt'> & {
   // the per-request Yorkie admin call — so the list order no longer flips when
   // that call times out.
   updatedAt: string;
+  // Whether the caller may delete or move this document — workspace owner or
+  // the document's author (see `resolveDocManager`). Lets the client gate the
+  // Delete/Move menu items without re-deriving roles per workspace.
+  canManage: boolean;
 };
 
 @Controller()
@@ -51,6 +57,8 @@ export class DocumentController {
 
   private async attachMeta(
     docs: DocumentWithAuthor[],
+    roleByWorkspace: Map<string, string>,
+    userId: number,
   ): Promise<DocumentListItem[]> {
     if (docs.length === 0) return [];
     // The Yorkie admin call now supplies only the decorative "currently
@@ -62,11 +70,34 @@ export class DocumentController {
       const item: DocumentListItem = {
         ...d,
         updatedAt: d.updatedAt.toISOString(),
+        canManage: isDocumentManager(
+          roleByWorkspace.get(d.workspaceId),
+          d.authorID,
+          userId,
+        ),
       };
       const editors = editorsByKey.get(keys[i]);
       if (editors?.length) item.editors = editors;
       return item;
     });
+  }
+
+  /**
+   * A document's "manager" — the workspace owner or the document's author — is
+   * the tier allowed to delete or move it (parity with the share-link
+   * `isManager` gate; see docs/design/sharing.md). Plain members have `rw` on
+   * the content but may not destroy or relocate a document they do not own.
+   * Requires workspace membership first, so a removed author cannot act.
+   */
+  private async resolveDocManager(
+    doc: { workspaceId: string; authorID: number | null },
+    userId: number,
+  ): Promise<boolean> {
+    const member = await this.workspaceService.assertMember(
+      doc.workspaceId,
+      userId,
+    );
+    return isDocumentManager(member.role, doc.authorID, userId);
   }
 
   /**
@@ -110,12 +141,12 @@ export class DocumentController {
     const userId = Number(req.user.id);
     const workspaceId =
       await this.workspaceService.resolveId(workspaceIdOrSlug);
-    await this.workspaceService.assertMember(workspaceId, userId);
+    const member = await this.workspaceService.assertMember(workspaceId, userId);
     const docs = await this.documentService.listDocumentsWithAuthor({
       where: { workspaceId },
       orderBy: [{ updatedAt: 'desc' }, { createdAt: 'desc' }],
     });
-    return this.attachMeta(docs);
+    return this.attachMeta(docs, new Map([[workspaceId, member.role]]), userId);
   }
 
   // --- Legacy / backward-compatible endpoints ---
@@ -141,13 +172,16 @@ export class DocumentController {
     @Req() req: AuthenticatedRequest,
   ): Promise<DocumentListItem[]> {
     const userId = Number(req.user.id);
-    const workspaces = await this.workspaceService.findAllByUser(userId);
-    const workspaceIds = workspaces.map((w) => w.id);
+    const memberships = await this.workspaceService.findMembershipsByUser(userId);
+    const roleByWorkspace = new Map(
+      memberships.map((m) => [m.workspaceId, m.role]),
+    );
+    const workspaceIds = memberships.map((m) => m.workspaceId);
     const docs = await this.documentService.listDocumentsWithAuthor({
       where: { workspaceId: { in: workspaceIds } },
       orderBy: [{ updatedAt: 'desc' }, { createdAt: 'desc' }],
     });
-    return this.attachMeta(docs);
+    return this.attachMeta(docs, roleByWorkspace, userId);
   }
 
   @Post('documents')
@@ -178,7 +212,8 @@ export class DocumentController {
       throw new NotFoundException('Document not found');
     }
     const userId = Number(req.user.id);
-    await this.workspaceService.assertMember(doc.workspaceId, userId);
+    // Renaming is an edit any member may do; moving is a manager-only action.
+    const isManager = await this.resolveDocManager(doc, userId);
 
     const data: { title?: string; workspace?: { connect: { id: string } } } =
       {};
@@ -186,6 +221,11 @@ export class DocumentController {
       data.title = body.title;
     }
     if (body.workspaceId !== undefined) {
+      if (!isManager) {
+        throw new ForbiddenException(
+          'Only the workspace owner or document owner can move this document',
+        );
+      }
       await this.workspaceService.assertMember(body.workspaceId, userId);
       data.workspace = { connect: { id: body.workspaceId } };
     }
@@ -205,10 +245,11 @@ export class DocumentController {
     if (!doc) {
       throw new NotFoundException('Document not found');
     }
-    await this.workspaceService.assertMember(
-      doc.workspaceId,
-      Number(req.user.id),
-    );
+    if (!(await this.resolveDocManager(doc, Number(req.user.id)))) {
+      throw new ForbiddenException(
+        'Only the workspace owner or document owner can delete this document',
+      );
+    }
     const deleted = await this.documentService.deleteDocument({ id });
     if (doc.fileId && VALID_FILE_ID_PATTERN.test(doc.fileId)) {
       // Best-effort: a failed blob cleanup must not fail the delete, but log

--- a/packages/backend/src/share-link/share-link.service.spec.ts
+++ b/packages/backend/src/share-link/share-link.service.spec.ts
@@ -131,6 +131,17 @@ describe('ShareLinkService', () => {
       expect(result.permissions).toEqual({ canCreateEditorLink: false });
     });
 
+    it('keeps a non-manager\'s own editor link visible (demoted ex-manager)', async () => {
+      // MEMBER_ID minted this editor link while still an owner, then was demoted.
+      const ownEditor = { id: 'l-own-editor', role: 'editor', createdBy: MEMBER_ID };
+      asMember('member');
+      prisma.shareLink.findMany.mockResolvedValue([OWNER_EDITOR, ownEditor]);
+      const result = await service.findByDocument(DOC_ID, MEMBER_ID);
+      // Someone else's editor link is hidden; their own stays so they can revoke it.
+      expect(result.links.map((l) => l.id)).toEqual(['l-own-editor']);
+      expect(result.links[0].canDelete).toBe(true);
+    });
+
     it('marks a member as able to delete only their own links', async () => {
       asMember('member');
       prisma.shareLink.findMany.mockResolvedValue([

--- a/packages/backend/src/share-link/share-link.service.spec.ts
+++ b/packages/backend/src/share-link/share-link.service.spec.ts
@@ -1,0 +1,215 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  GoneException,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from 'src/database/prisma.service';
+import { ShareLinkService } from './share-link.service';
+
+const DOC_ID = 'doc-1';
+const WS_ID = 'ws-1';
+const AUTHOR_ID = 1;
+const OWNER_ID = 2;
+const MEMBER_ID = 3;
+const OUTSIDER_ID = 4;
+
+function createMockPrisma() {
+  return {
+    document: {
+      findUnique: jest.fn(),
+    },
+    workspaceMember: {
+      findUnique: jest.fn(),
+    },
+    shareLink: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+}
+
+describe('ShareLinkService', () => {
+  let service: ShareLinkService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new ShareLinkService(prisma as unknown as PrismaService);
+    // Document authored by AUTHOR_ID, living in workspace WS_ID.
+    prisma.document.findUnique.mockResolvedValue({
+      id: DOC_ID,
+      workspaceId: WS_ID,
+      authorID: AUTHOR_ID,
+    });
+    prisma.shareLink.create.mockImplementation(({ data }: any) => ({
+      id: 'link-1',
+      token: 'tok',
+      ...data,
+    }));
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  /** Wire the membership lookup for a given caller. */
+  function asMember(role: 'owner' | 'member' | null) {
+    prisma.workspaceMember.findUnique.mockResolvedValue(
+      role ? { role, userId: 0, workspaceId: WS_ID } : null,
+    );
+  }
+
+  describe('create', () => {
+    it('rejects an unknown role before any lookup', async () => {
+      await expect(
+        service.create(DOC_ID, 'commenter', OWNER_ID, null),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws NotFound when the document is missing', async () => {
+      prisma.document.findUnique.mockResolvedValue(null);
+      await expect(
+        service.create(DOC_ID, 'viewer', AUTHOR_ID, null),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('lets a workspace owner (not author) create an editor link', async () => {
+      asMember('owner');
+      await expect(
+        service.create(DOC_ID, 'editor', OWNER_ID, null),
+      ).resolves.toMatchObject({ role: 'editor', documentId: DOC_ID });
+    });
+
+    it('lets the document author create an editor link even without membership', async () => {
+      asMember(null);
+      await expect(
+        service.create(DOC_ID, 'editor', AUTHOR_ID, null),
+      ).resolves.toMatchObject({ role: 'editor' });
+    });
+
+    it('lets a plain member create a viewer link', async () => {
+      asMember('member');
+      await expect(
+        service.create(DOC_ID, 'viewer', MEMBER_ID, null),
+      ).resolves.toMatchObject({ role: 'viewer' });
+    });
+
+    it('forbids a plain member from creating an editor link', async () => {
+      asMember('member');
+      await expect(
+        service.create(DOC_ID, 'editor', MEMBER_ID, null),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('forbids a non-member from creating any link', async () => {
+      asMember(null);
+      await expect(
+        service.create(DOC_ID, 'viewer', OUTSIDER_ID, null),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('findByDocument', () => {
+    const OWNER_EDITOR = {
+      id: 'l-editor',
+      role: 'editor',
+      createdBy: OWNER_ID,
+    };
+    const MEMBER_VIEWER = {
+      id: 'l-viewer',
+      role: 'viewer',
+      createdBy: MEMBER_ID,
+    };
+
+    it('hides editor links from a plain member and flags no editor rights', async () => {
+      asMember('member');
+      prisma.shareLink.findMany.mockResolvedValue([OWNER_EDITOR, MEMBER_VIEWER]);
+      const result = await service.findByDocument(DOC_ID, MEMBER_ID);
+      // The owner's editor link is filtered out; only the member's viewer link remains.
+      expect(result.links.map((l) => l.id)).toEqual(['l-viewer']);
+      expect(result.permissions).toEqual({ canCreateEditorLink: false });
+    });
+
+    it('marks a member as able to delete only their own links', async () => {
+      asMember('member');
+      prisma.shareLink.findMany.mockResolvedValue([
+        MEMBER_VIEWER,
+        { id: 'other', role: 'viewer', createdBy: OUTSIDER_ID },
+      ]);
+      const result = await service.findByDocument(DOC_ID, MEMBER_ID);
+      const byId = Object.fromEntries(result.links.map((l) => [l.id, l.canDelete]));
+      expect(byId).toEqual({ 'l-viewer': true, other: false });
+    });
+
+    it('gives the owner every link with full delete + editor rights', async () => {
+      asMember('owner');
+      prisma.shareLink.findMany.mockResolvedValue([OWNER_EDITOR, MEMBER_VIEWER]);
+      const result = await service.findByDocument(DOC_ID, OWNER_ID);
+      expect(result.links.map((l) => l.id)).toEqual(['l-editor', 'l-viewer']);
+      expect(result.links.every((l) => l.canDelete)).toBe(true);
+      expect(result.permissions).toEqual({ canCreateEditorLink: true });
+    });
+
+    it('forbids a non-member from listing links', async () => {
+      asMember(null);
+      await expect(
+        service.findByDocument(DOC_ID, OUTSIDER_ID),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('delete', () => {
+    beforeEach(() => {
+      prisma.shareLink.findUnique.mockResolvedValue({
+        id: 'link-1',
+        documentId: DOC_ID,
+        createdBy: MEMBER_ID,
+      });
+      prisma.shareLink.delete.mockResolvedValue({ id: 'link-1' });
+    });
+
+    it('lets the owner revoke a link created by someone else', async () => {
+      asMember('owner');
+      await expect(service.delete('link-1', OWNER_ID)).resolves.toMatchObject({
+        id: 'link-1',
+      });
+    });
+
+    it('lets a member revoke their own link', async () => {
+      asMember('member');
+      await expect(service.delete('link-1', MEMBER_ID)).resolves.toMatchObject({
+        id: 'link-1',
+      });
+    });
+
+    it('lets the creator revoke their own link even after losing access', async () => {
+      asMember(null); // creator was removed from the workspace
+      await expect(service.delete('link-1', MEMBER_ID)).resolves.toMatchObject({
+        id: 'link-1',
+      });
+      // The access lookup is skipped entirely for the creator.
+      expect(prisma.workspaceMember.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("forbids a member from revoking another member's link", async () => {
+      asMember('member');
+      await expect(
+        service.delete('link-1', OUTSIDER_ID + 100),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('findByToken', () => {
+    it('throws Gone for an expired link', async () => {
+      prisma.shareLink.findUnique.mockResolvedValue({
+        id: 'link-1',
+        expiresAt: new Date(Date.now() - 1000),
+        document: {},
+      });
+      await expect(service.findByToken('tok')).rejects.toBeInstanceOf(
+        GoneException,
+      );
+    });
+  });
+});

--- a/packages/backend/src/share-link/share-link.service.ts
+++ b/packages/backend/src/share-link/share-link.service.ts
@@ -6,6 +6,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
+import { isDocumentManager } from '../document/document-access';
 
 const SHARE_LINK_ROLES = ['viewer', 'editor'] as const;
 type ShareLinkRole = (typeof SHARE_LINK_ROLES)[number];
@@ -62,7 +63,9 @@ export class ShareLinkService {
       throw new ForbiddenException('You do not have access to this document');
     }
 
-    return { isManager: membership?.role === 'owner' || isAuthor };
+    return {
+      isManager: isDocumentManager(membership?.role, doc.authorID, userId),
+    };
   }
 
   async create(

--- a/packages/backend/src/share-link/share-link.service.ts
+++ b/packages/backend/src/share-link/share-link.service.ts
@@ -3,23 +3,87 @@ import {
   NotFoundException,
   ForbiddenException,
   GoneException,
+  BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
+
+const SHARE_LINK_ROLES = ['viewer', 'editor'] as const;
+type ShareLinkRole = (typeof SHARE_LINK_ROLES)[number];
+
+/**
+ * The caller's authority over a document's share links, resolved once so
+ * create / list / delete share the same source of truth.
+ *
+ * `isManager` (workspace owner or document author) is the single privilege
+ * tier that today governs both minting editor links and revoking links the
+ * caller did not create — see docs/design/sharing.md. Plain members have
+ * document access (guaranteed by `resolveCapability` throwing otherwise) but
+ * are not managers.
+ */
+interface ShareCapability {
+  isManager: boolean;
+}
 
 @Injectable()
 export class ShareLinkService {
   constructor(private prisma: PrismaService) {}
 
-  async create(documentId: string, role: string, createdBy: number, expiresAt: Date | null) {
-    // Verify document exists and user owns it
+  /**
+   * Resolve the caller's share-link authority for a document, throwing if the
+   * caller has no access at all (neither a workspace member nor the author).
+   *
+   * Access follows the workspace model (see docs/design/sharing.md): every
+   * workspace member has `rw` on the document, so any member may create viewer
+   * links; only the workspace owner or the document author (`isManager`) may
+   * create editor links or manage links they did not create.
+   *
+   * Queries `workspaceMember` directly rather than via `WorkspaceService`: we
+   * pass the already-canonical `doc.workspaceId` (no slug resolution needed)
+   * and require a non-throwing lookup so the author-but-not-member case still
+   * resolves — neither of which `assertMember` provides.
+   */
+  private async resolveCapability(
+    documentId: string,
+    userId: number,
+  ): Promise<ShareCapability> {
     const doc = await this.prisma.document.findUnique({
       where: { id: documentId },
     });
     if (!doc) {
       throw new NotFoundException('Document not found');
     }
-    if (doc.authorID !== createdBy) {
-      throw new ForbiddenException('Only the document owner can create share links');
+
+    const membership = await this.prisma.workspaceMember.findUnique({
+      where: { workspaceId_userId: { workspaceId: doc.workspaceId, userId } },
+    });
+
+    const isAuthor = doc.authorID === userId;
+    if (membership === null && !isAuthor) {
+      throw new ForbiddenException('You do not have access to this document');
+    }
+
+    return { isManager: membership?.role === 'owner' || isAuthor };
+  }
+
+  async create(
+    documentId: string,
+    role: string,
+    createdBy: number,
+    expiresAt: Date | null,
+  ) {
+    if (!SHARE_LINK_ROLES.includes(role as ShareLinkRole)) {
+      throw new BadRequestException(
+        `Invalid share link role: ${role}. Expected 'viewer' or 'editor'.`,
+      );
+    }
+
+    // Access is enforced here; a plain member reaching this point may create
+    // viewer links, but only a manager may mint an editor (write) link.
+    const { isManager } = await this.resolveCapability(documentId, createdBy);
+    if (role === 'editor' && !isManager) {
+      throw new ForbiddenException(
+        'Only the workspace owner or document owner can create editor links',
+      );
     }
 
     return this.prisma.shareLink.create({
@@ -50,21 +114,29 @@ export class ShareLinkService {
   }
 
   async findByDocument(documentId: string, userId: number) {
-    // Verify document exists and user owns it
-    const doc = await this.prisma.document.findUnique({
-      where: { id: documentId },
-    });
-    if (!doc) {
-      throw new NotFoundException('Document not found');
-    }
-    if (doc.authorID !== userId) {
-      throw new ForbiddenException('Only the document owner can view share links');
-    }
+    const { isManager } = await this.resolveCapability(documentId, userId);
 
-    return this.prisma.shareLink.findMany({
+    const links = await this.prisma.shareLink.findMany({
       where: { documentId },
       orderBy: { createdAt: 'desc' },
     });
+
+    // A plain member cannot mint editor links, so they must not be handed an
+    // existing editor token either (they could copy and redistribute it,
+    // escalating anonymous write access they were never allowed to grant).
+    const visible = isManager
+      ? links
+      : links.filter((link) => link.role !== 'editor');
+
+    return {
+      links: visible.map((link) => ({
+        ...link,
+        canDelete: isManager || link.createdBy === userId,
+      })),
+      permissions: {
+        canCreateEditorLink: isManager,
+      },
+    };
   }
 
   async delete(id: string, userId: number) {
@@ -74,8 +146,17 @@ export class ShareLinkService {
     if (!link) {
       throw new NotFoundException('Share link not found');
     }
-    if (link.createdBy !== userId) {
-      throw new ForbiddenException('Only the creator can delete this share link');
+
+    // A link's creator may always revoke it, even after leaving the workspace.
+    if (link.createdBy === userId) {
+      return this.prisma.shareLink.delete({ where: { id } });
+    }
+
+    const { isManager } = await this.resolveCapability(link.documentId, userId);
+    if (!isManager) {
+      throw new ForbiddenException(
+        'You can only revoke share links you created',
+      );
     }
 
     return this.prisma.shareLink.delete({

--- a/packages/backend/src/share-link/share-link.service.ts
+++ b/packages/backend/src/share-link/share-link.service.ts
@@ -121,12 +121,15 @@ export class ShareLinkService {
       orderBy: { createdAt: 'desc' },
     });
 
-    // A plain member cannot mint editor links, so they must not be handed an
-    // existing editor token either (they could copy and redistribute it,
-    // escalating anonymous write access they were never allowed to grant).
+    // A non-manager must not be handed an editor token they did not create
+    // (they could copy and redistribute it, escalating anonymous write access
+    // they were never allowed to grant). Their own editor links stay visible
+    // so a demoted ex-manager can still find and revoke live links they minted.
     const visible = isManager
       ? links
-      : links.filter((link) => link.role !== 'editor');
+      : links.filter(
+          (link) => link.role !== 'editor' || link.createdBy === userId,
+        );
 
     return {
       links: visible.map((link) => ({

--- a/packages/backend/src/workspace/workspace.service.ts
+++ b/packages/backend/src/workspace/workspace.service.ts
@@ -30,6 +30,19 @@ export class WorkspaceService {
     return memberships.map((m) => m.workspace);
   }
 
+  /**
+   * The user's `(workspaceId, role)` across every workspace they belong to.
+   * Lets callers resolve per-workspace ownership without an N+1 of
+   * `assertMember` — e.g. the documents list annotating each row with whether
+   * the caller may manage (delete/move) it.
+   */
+  async findMembershipsByUser(userId: number) {
+    return this.prisma.workspaceMember.findMany({
+      where: { userId },
+      select: { workspaceId: true, role: true },
+    });
+  }
+
   async findOne(idOrSlug: string, userId: number) {
     const isUUID =
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(

--- a/packages/backend/test/authenticated-http.e2e-spec.ts
+++ b/packages/backend/test/authenticated-http.e2e-spec.ts
@@ -124,6 +124,64 @@ describeDb('Authenticated HTTP integration (JWT + controllers + Prisma)', () => 
       .expect(403);
   });
 
+  it('reserves document delete/move to owner or author, but rename to any member', async () => {
+    const owner = await createUser();
+    const member = await createUser();
+    const workspace = await createWorkspace(prisma, owner.id);
+    await prisma.workspaceMember.create({
+      data: { workspaceId: workspace.id, userId: member.id, role: 'member' },
+    });
+    const other = await createWorkspace(prisma, member.id); // move destination
+
+    const doc = await prisma.document.create({
+      data: {
+        title: 'Owner roadmap',
+        authorID: owner.id,
+        workspaceId: workspace.id,
+      },
+    });
+
+    // The list annotates canManage per row: true for the owner, false for a
+    // plain member who is not the author.
+    const ownerList = await request(app.getHttpServer())
+      .get('/documents')
+      .set('Cookie', authCookie(owner))
+      .expect(200);
+    expect(ownerList.body.find((d: { id: string }) => d.id === doc.id).canManage).toBe(true);
+
+    const memberList = await request(app.getHttpServer())
+      .get('/documents')
+      .set('Cookie', authCookie(member))
+      .expect(200);
+    expect(memberList.body.find((d: { id: string }) => d.id === doc.id).canManage).toBe(false);
+
+    // A plain member may rename…
+    await request(app.getHttpServer())
+      .patch(`/documents/${doc.id}`)
+      .set('Cookie', authCookie(member))
+      .send({ title: 'Renamed by member' })
+      .expect(200);
+
+    // …but not move…
+    await request(app.getHttpServer())
+      .patch(`/documents/${doc.id}`)
+      .set('Cookie', authCookie(member))
+      .send({ workspaceId: other.id })
+      .expect(403);
+
+    // …nor delete.
+    await request(app.getHttpServer())
+      .delete(`/documents/${doc.id}`)
+      .set('Cookie', authCookie(member))
+      .expect(403);
+
+    // The owner can delete.
+    await request(app.getHttpServer())
+      .delete(`/documents/${doc.id}`)
+      .set('Cookie', authCookie(owner))
+      .expect(200);
+  });
+
   it('enforces share-link owner permissions and supports public token resolve', async () => {
     const owner = await createUser();
     const other = await createUser();

--- a/packages/backend/test/database.e2e-spec.ts
+++ b/packages/backend/test/database.e2e-spec.ts
@@ -493,5 +493,79 @@ describeDb('Database-backed integration', () => {
       const deleted = await shareLinkService.delete(link.id, owner.id);
       expect(deleted.id).toBe(link.id);
     });
+
+    it('lets a workspace owner who is not the author create an editor link', async () => {
+      const author = await createUser();
+      const wsOwner = await createUser();
+      const workspace = await createWorkspace(prisma, wsOwner.id);
+      const doc = await prisma.document.create({
+        data: {
+          title: 'Team doc',
+          authorID: author.id,
+          workspaceId: workspace.id,
+        },
+      });
+
+      const link = await shareLinkService.create(
+        doc.id,
+        'editor',
+        wsOwner.id,
+        null,
+      );
+      expect(link.role).toBe('editor');
+    });
+
+    it('lets a plain member create a viewer link but not an editor link', async () => {
+      const owner = await createUser();
+      const member = await createUser();
+      const workspace = await createWorkspace(prisma, owner.id);
+      await prisma.workspaceMember.create({
+        data: { workspaceId: workspace.id, userId: member.id, role: 'member' },
+      });
+      const doc = await prisma.document.create({
+        data: {
+          title: 'Member doc',
+          authorID: owner.id,
+          workspaceId: workspace.id,
+        },
+      });
+
+      const viewer = await shareLinkService.create(
+        doc.id,
+        'viewer',
+        member.id,
+        null,
+      );
+      expect(viewer.role).toBe('viewer');
+
+      await expect(
+        shareLinkService.create(doc.id, 'editor', member.id, null),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('lets a workspace owner revoke a link created by a member', async () => {
+      const owner = await createUser();
+      const member = await createUser();
+      const workspace = await createWorkspace(prisma, owner.id);
+      await prisma.workspaceMember.create({
+        data: { workspaceId: workspace.id, userId: member.id, role: 'member' },
+      });
+      const doc = await prisma.document.create({
+        data: {
+          title: 'Owned doc',
+          authorID: owner.id,
+          workspaceId: workspace.id,
+        },
+      });
+      const link = await shareLinkService.create(
+        doc.id,
+        'viewer',
+        member.id,
+        null,
+      );
+
+      const deleted = await shareLinkService.delete(link.id, owner.id);
+      expect(deleted.id).toBe(link.id);
+    });
   });
 });

--- a/packages/frontend/src/api/share-links.ts
+++ b/packages/frontend/src/api/share-links.ts
@@ -19,6 +19,28 @@ export type ResolvedShareLink = {
 };
 
 /**
+ * The caller's share-link capabilities for a document, resolved server-side
+ * from workspace ownership + document authorship (see docs/design/sharing.md).
+ */
+export type ShareLinkPermissions = {
+  /** Workspace owner or document author — may create `editor` links. */
+  canCreateEditorLink: boolean;
+};
+
+/**
+ * A listed share link, annotated server-side with whether the caller may
+ * revoke it (manager of the document, or its creator).
+ */
+export type ShareLinkListItem = ShareLink & {
+  canDelete: boolean;
+};
+
+export type ShareLinksResponse = {
+  links: ShareLinkListItem[];
+  permissions: ShareLinkPermissions;
+};
+
+/**
  * Creates share link.
  */
 export async function createShareLink(
@@ -43,7 +65,7 @@ export async function createShareLink(
  */
 export async function getShareLinks(
   documentId: string
-): Promise<ShareLink[]> {
+): Promise<ShareLinksResponse> {
   const response = await fetchWithAuth(
     `${import.meta.env.VITE_BACKEND_API_URL}/documents/${documentId}/share-links`
   );

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -293,32 +293,36 @@ export function DocumentList({
                 <Pencil className="mr-2 h-4 w-4" />
                 Rename
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={(e: MouseEvent<HTMLElement>) => {
-                  e.stopPropagation();
-                  setMovingDoc({
-                    id: String(row.getValue("id")),
-                    title: row.getValue("title"),
-                    workspaceId: row.original.workspaceId,
-                  });
-                }}
-              >
-                <FolderOutput className="mr-2 h-4 w-4" />
-                Move to...
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                className="text-destructive focus:text-destructive"
-                onClick={(e: MouseEvent<HTMLElement>) => {
-                  e.stopPropagation();
-                  setDeletingDoc({
-                    id: String(row.getValue("id")),
-                    title: row.getValue("title"),
-                  });
-                }}
-              >
-                <Trash2 className="mr-2 h-4 w-4" />
-                Delete
-              </DropdownMenuItem>
+              {row.original.canManage && (
+                <DropdownMenuItem
+                  onClick={(e: MouseEvent<HTMLElement>) => {
+                    e.stopPropagation();
+                    setMovingDoc({
+                      id: String(row.getValue("id")),
+                      title: row.getValue("title"),
+                      workspaceId: row.original.workspaceId,
+                    });
+                  }}
+                >
+                  <FolderOutput className="mr-2 h-4 w-4" />
+                  Move to...
+                </DropdownMenuItem>
+              )}
+              {row.original.canManage && (
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={(e: MouseEvent<HTMLElement>) => {
+                    e.stopPropagation();
+                    setDeletingDoc({
+                      id: String(row.getValue("id")),
+                      title: row.getValue("title"),
+                    });
+                  }}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         );

--- a/packages/frontend/src/components/share-dialog.tsx
+++ b/packages/frontend/src/components/share-dialog.tsx
@@ -28,9 +28,14 @@ import {
   createShareLink,
   getShareLinks,
   deleteShareLink,
-  ShareLink,
+  ShareLinkListItem,
+  ShareLinkPermissions,
 } from "@/api/share-links";
 import { isAuthExpiredError } from "@/api/auth";
+
+const DEFAULT_PERMISSIONS: ShareLinkPermissions = {
+  canCreateEditorLink: false,
+};
 
 const EXPIRATION_OPTIONS = [
   { value: "none", label: "No limit" },
@@ -61,16 +66,40 @@ export function ShareDialog({ documentId }: { documentId: string }) {
   const [open, setOpen] = useState(false);
   const [role, setRole] = useState("viewer");
   const [expiration, setExpiration] = useState("none");
-  const [links, setLinks] = useState<ShareLink[]>([]);
+  const [links, setLinks] = useState<ShareLinkListItem[]>([]);
+  const [permissions, setPermissions] =
+    useState<ShareLinkPermissions>(DEFAULT_PERMISSIONS);
+  const [loaded, setLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
 
+  // Refetch links + capabilities whenever the dialog opens or the document
+  // changes, resetting first so stale permissions from a previous document
+  // never leak into the gating below.
   useEffect(() => {
-    if (open) {
-      getShareLinks(documentId)
-        .then(setLinks)
-        .catch(() => {});
-    }
+    if (!open) return;
+    setLoaded(false);
+    setLinks([]);
+    setPermissions(DEFAULT_PERMISSIONS);
+    let cancelled = false;
+    getShareLinks(documentId)
+      .then((res) => {
+        if (cancelled) return;
+        setLinks(res.links);
+        setPermissions(res.permissions);
+        setLoaded(true);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, [open, documentId]);
+
+  // A member who cannot create editor links must fall back to a viewer link.
+  useEffect(() => {
+    if (loaded && !permissions.canCreateEditorLink && role === "editor") {
+      setRole("viewer");
+    }
+  }, [loaded, permissions.canCreateEditorLink, role]);
 
   const handleCreate = async () => {
     setLoading(true);
@@ -80,13 +109,16 @@ export function ShareDialog({ documentId }: { documentId: string }) {
         role,
         expiration === "none" ? null : expiration,
       );
-      setLinks((prev) => [link, ...prev]);
+      // The creator can always revoke a link they just made.
+      setLinks((prev) => [{ ...link, canDelete: true }, ...prev]);
       const url = `${window.location.origin}/shared/${link.token}`;
       await navigator.clipboard.writeText(url);
       toast.success("Link created and copied to clipboard");
     } catch (error) {
       if (isAuthExpiredError(error)) return;
-      toast.error("Failed to create share link");
+      toast.error(
+        error instanceof Error ? error.message : "Failed to create share link",
+      );
     } finally {
       setLoading(false);
     }
@@ -143,9 +175,20 @@ export function ShareDialog({ documentId }: { documentId: string }) {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="viewer">Viewer</SelectItem>
-                  <SelectItem value="editor">Editor</SelectItem>
+                  <SelectItem
+                    value="editor"
+                    disabled={!loaded || !permissions.canCreateEditorLink}
+                  >
+                    Editor
+                  </SelectItem>
                 </SelectContent>
               </Select>
+              {loaded && !permissions.canCreateEditorLink && (
+                <p className="text-muted-foreground text-xs">
+                  Only the document owner or a workspace owner can create editor
+                  links.
+                </p>
+              )}
             </div>
             <div className="grid gap-2">
               <Label htmlFor="share-expiration">Expiration</Label>
@@ -192,15 +235,17 @@ export function ShareDialog({ documentId }: { documentId: string }) {
                         >
                           <IconCopy className="h-3.5 w-3.5" />
                         </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-7 w-7 text-destructive"
-                          aria-label="Revoke link"
-                          onClick={() => handleDelete(link.id)}
-                        >
-                          <IconTrash className="h-3.5 w-3.5" />
-                        </Button>
+                        {link.canDelete && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-destructive"
+                            aria-label="Revoke link"
+                            onClick={() => handleDelete(link.id)}
+                          >
+                            <IconTrash className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
                       </div>
                     </div>
                   ))}
@@ -210,7 +255,7 @@ export function ShareDialog({ documentId }: { documentId: string }) {
           )}
         </div>
         <div className="flex justify-end">
-          <Button onClick={handleCreate} disabled={loading}>
+          <Button onClick={handleCreate} disabled={loading || !loaded}>
             {loading ? "Creating..." : "Create Link"}
           </Button>
         </div>

--- a/packages/frontend/src/components/share-dialog.tsx
+++ b/packages/frontend/src/components/share-dialog.tsx
@@ -86,9 +86,19 @@ export function ShareDialog({ documentId }: { documentId: string }) {
         if (cancelled) return;
         setLinks(res.links);
         setPermissions(res.permissions);
-        setLoaded(true);
       })
-      .catch(() => {});
+      .catch((error) => {
+        if (cancelled || isAuthExpiredError(error)) return;
+        // Surface the failure and still unblock the form: permissions stay at
+        // their viewer-only default and the backend remains the real gate, so
+        // the user can retry rather than facing a permanently disabled button.
+        toast.error(
+          error instanceof Error ? error.message : "Failed to load share links",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
     return () => {
       cancelled = true;
     };

--- a/packages/frontend/src/types/documents.ts
+++ b/packages/frontend/src/types/documents.ts
@@ -33,4 +33,8 @@ export type Document = {
   workspaceId: string;
   author?: DocumentAuthor | null;
   editors?: DocumentEditor[];
+  // Whether the current user may delete or move this document (workspace owner
+  // or the document's author). Set only by the documents-list endpoints; the
+  // backend stays the real gate. Absent → treat as not manageable.
+  canManage?: boolean;
 };


### PR DESCRIPTION
## Summary

Unifies document-level permissions around one **manager** tier — the workspace **owner** or the document's **author** (`isDocumentManager`) — fixing gaps in two opposite directions.

### 1. Share links were too restrictive (the reported bug)

Creating a share link required `doc.authorID === userId`, so a **workspace owner** (or any collaborator) who did not personally create the document got a `403` rendered as a generic **"Failed to create share link"** toast — even though every workspace member has `rw` access.

| Actor        | create viewer | create editor | list                       | revoke         |
| ------------ | :-----------: | :-----------: | -------------------------- | -------------- |
| WS owner     | ✅            | ✅            | ✅                         | any link       |
| Doc author   | ✅            | ✅            | ✅                         | any link       |
| WS member    | ✅            | ❌            | ✅ (others' editor hidden) | own links only |
| Non-member   | ❌            | ❌            | ❌                         | ❌             |

- Any member may mint a `viewer` link; only a manager may mint an `editor` link. A link's **creator can always revoke it**, even after leaving the workspace.
- The list returns a per-link **`canDelete`** flag and **omits editor links a non-manager did not create** (a token is redistributable — exposing an editor token to a member who can't mint one would re-open the escalation). A non-manager's *own* editor links stay visible (demoted ex-manager can still revoke).
- The dialog gates the editor option / hint / Create button / revoke buttons on server capabilities behind a `loaded` flag, resets on document change, recovers from a failed list-fetch, and surfaces the server's specific `403`.

### 2. Delete / Move were too permissive

`DELETE /documents/:id` and the move branch of `PATCH /documents/:id` only checked `assertMember`, so **any plain member could delete or relocate the owner's document**. Both are now **manager-gated**; **Rename stays member-level** (it's an edit). The v1 `DELETE` applies the same gate for JWT callers, and **API-key callers must carry the `write` scope** (read-only keys rejected — a pre-existing gap the exemption surfaced). The documents list annotates each row with `canManage` and hides Delete/Move when the caller can't manage it.

Design/model: `docs/design/sharing.md` + `docs/design/backend.md` updated (the old "author-only" wording never matched the shipped workspace model). Three rounds of adversarial code review (high effort) informed the final shape; see `docs/tasks/active/20260717-share-link-permissions-todo.md` for the finding-by-finding log.

## Test plan

- `pnpm verify:fast` → green
- Backend unit: `share-link.service.spec.ts` (17), `document.controller.spec.ts` (+delete/move/rename/canManage), `documents.controller.spec.ts` (v1 delete + API-key write-scope)
- DB integration (`RUN_DB_INTEGRATION_TESTS=true`): `database.e2e-spec.ts` ShareLinkService + `authenticated-http.e2e-spec.ts` (member can rename, cannot move/delete; owner can delete; per-row `canManage`) — 17 passed
- [ ] Manual smoke: workspace owner (non-author) creates a share link + a member sees no Delete/Move in `pnpm dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKrXRKZGq3Ny7MWN19EbV5
