### PR TITLE
Docs: update site for v0.6.0 — Notes, PDF, data validation

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| documentation 0.6.0 update (2026-07-17) | [20260717-documentation-0.6.0-update-todo.md](./active/20260717-documentation-0.6.0-update-todo.md) | [20260717-documentation-0.6.0-update-lessons.md](./active/20260717-documentation-0.6.0-update-lessons.md) |
 | notes cli (2026-07-16) | [20260716-notes-cli-todo.md](./active/20260716-notes-cli-todo.md) | [20260716-notes-cli-lessons.md](./active/20260716-notes-cli-lessons.md) |
 | release v0.6.0 (2026-07-16) | [20260716-release-v0.6.0-todo.md](./active/20260716-release-v0.6.0-todo.md) | - |
 | notes markdown type (2026-07-15) | [20260715-notes-markdown-type-todo.md](./active/20260715-notes-markdown-type-todo.md) | [20260715-notes-markdown-type-lessons.md](./active/20260715-notes-markdown-type-lessons.md) |
@@ -40,4 +41,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 363
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: notes cli (2026-07-16)
+Latest active task: documentation 0.6.0 update (2026-07-17)

--- a/docs/tasks/active/20260717-documentation-0.6.0-update-lessons.md
+++ b/docs/tasks/active/20260717-documentation-0.6.0-update-lessons.md
@@ -1,0 +1,35 @@
+# Lessons — Documentation Site Update for v0.6.0
+
+## The docs site drifts silently between releases
+The `packages/documentation` VitePress site is **not** in the `verify:fast`
+chain and has no CI typecheck, so it can lag the product by several releases
+with nothing flagging it. It had drifted to the v0.4.9 feature set — missing two
+whole document types (Notes, PDF) and Sheets data validation. When doing a
+release-based docs pass, diff the docs against the release-note highlights
+(`docs/tasks/**/release-*-todo.md`) rather than trusting the site to be current.
+
+## VitePress build is the real gate for docs changes
+`pnpm --filter @wafflebase/documentation build` fails on dead internal links by
+default, so a clean build proves every `[text](/path)` and sidebar `link:`
+resolves. This is the check that matters for a docs-only change — `verify:fast`
+doesn't exercise the documentation package at all.
+
+## verify:fast failing on `tsx: command not found` = missing node_modules
+The first `verify:fast` run died at `pnpm core build` with `sh: tsx: command not
+found` and "node_modules missing". This is an environment-setup failure, not a
+regression from the change (matches the existing memory note). `pnpm install`
+fixed it and the re-run was green. Always check for this root cause before
+suspecting the diff.
+
+## Verify UI facts against the frontend, not just design docs
+Design docs describe *intent* and often include deferred/roadmap phases. For
+user-facing docs, the exact menu items, toolbar buttons, and shortcuts must come
+from the shipped frontend (`document-list.tsx` New menu, `notes-toolbar.tsx`,
+`pdf-collab.tsx`, `data-validation-panel.tsx`). A survey subagent reading the
+frontend gave precise, current facts that the design docs alone would not.
+
+## Scope by tag, not by `main`
+"Update based on 0.6.0" means the v0.6.0 tag, not the tip of `main`. The notes
+CLI namespace (#483) had already merged to `main` but landed *after* the tag, so
+it was deliberately excluded from the developer docs to keep the pass aligned
+with the release.

--- a/docs/tasks/active/20260717-documentation-0.6.0-update-todo.md
+++ b/docs/tasks/active/20260717-documentation-0.6.0-update-todo.md
@@ -67,7 +67,8 @@ data validation** (checkboxes, dropdowns, date/number/text criteria).
 - [x] `pnpm --filter @wafflebase/documentation build` — site builds, no dead links
 - [x] `pnpm verify:fast` — green (initial failure was missing `node_modules`;
       `pnpm install` fixed it, then lint + unit all pass)
-- [ ] Self-review diff, open PR
+- [x] High-effort `/code-review` — 2 confirmed doc-accuracy findings, both
+      fixed (see Review); PR #485 opened
 
 ## Review
 
@@ -103,3 +104,13 @@ of v0.6.0.
 **Out of scope:** The notes CLI namespace + backend note content endpoint
 (#483) landed *after* the v0.6.0 tag, so `developers/cli.md` and
 `developers/rest-api.md` are left unchanged per the "based on 0.6.0" scope.
+
+**Code review (high effort):** Two confirmed doc-accuracy findings, both fixed:
+1. `self-hosting.md` claimed embedded images use `FILE_STORAGE_*`, but the
+   backend reads images from a separate `IMAGE_STORAGE_*` config (bucket
+   `wafflebase-images`). Documented both buckets.
+2. `data-validation.md` listed a nonexistent toolbar "Insert" menu as an entry
+   point. Replaced with the real paths (toolbar icon, right-click, mobile
+   overflow menu).
+
+**PR:** #485 — https://github.com/wafflebase/wafflebase/pull/485

--- a/docs/tasks/active/20260717-documentation-0.6.0-update-todo.md
+++ b/docs/tasks/active/20260717-documentation-0.6.0-update-todo.md
@@ -1,0 +1,105 @@
+# Documentation Site Update for v0.6.0
+
+**Goal:** Bring the `packages/documentation` VitePress site current with the
+v0.6.0 release. The site was last meaningfully refreshed around v0.4.9; three
+releases since (v0.5.0, v0.5.1, v0.6.0) added user-facing surface that is
+entirely absent from the docs: the **Notes** markdown document type, the **PDF**
+viewer document type (upload + view + Phase 2 comments/presence), and **Sheets
+data validation** (checkboxes, dropdowns, date/number/text criteria).
+
+**Scope:** User-facing guide content only. Developer API namespaces added
+*after* the v0.6.0 tag (notes CLI namespace #483) are out of scope.
+
+## Product facts (verified against the frontend as of v0.6.0)
+
+- **New menu** (`document-list.tsx`): New Sheet, New Document, **New Note**,
+  New Presentation, Import XLSX, Import DOCX, Import PPTX, **Upload PDF**.
+- **Notes** (`/n/:id`): CodeMirror 6 source + live preview. Toolbar: view-mode
+  toggle (Editor / Split / Preview, default Split), Bold/Italic/Strikethrough/
+  Link/Insert-table, keyboard-mode (Default / Vim). Preview: GFM tables, code
+  fences w/ highlight.js + copy button, task-list checkboxes, KaTeX math,
+  sanitized (no raw HTML). Real-time via Yorkie with remote carets. No
+  import/export.
+- **PDF** (`/f/:id`): upload a `.pdf`, read-only continuous fit-to-width viewer
+  (scroll nav, no zoom/page controls), rename in header. Phase 2: draw page
+  region → comment, comments side panel (Page N threads, reply/resolve/edit/
+  delete), share links (anonymous `/shared/:token` viewer), presence
+  (per-viewer active page). View-only, no re-export.
+- **Data validation** (Sheets): opened from toolbar "Data validation" icon,
+  Insert menu, or cell right-click. Right-docked panel; add rules, pick
+  criteria, apply-to-range, invalid behavior (warning vs reject). Criteria:
+  Dropdown (list, show-arrow switch), Checkbox (TRUE/FALSE), Date (8 operators
+  + calendar picker on double-click), Number (9 operators), Text (contains /
+  email / URL etc). In-cell: checkbox glyph + Space toggle, dropdown arrow +
+  Alt+Down, date calendar popover.
+
+## File plan
+
+### New files
+- [x] `notes/writing-a-note.md` — Notes editor guide
+- [x] `pdf/viewing-pdfs.md` — PDF upload/view/comment guide
+- [x] `sheets/data-validation.md` — Data validation guide
+
+### Modified files
+- [x] `.vitepress/config.ts` — add Notes (nav + sidebar) and PDF (sidebar)
+      sections; add Data Validation under Sheets
+- [x] `README.md` — add Notes / PDF / Data Validation to content tables
+- [x] `guide/getting-started.md` — New menu list (New Note + Upload PDF),
+      "Try a Note" subsection, What's Next links
+- [x] `guide/import-export.md` — add PDF upload; note Notes have no import/export
+- [x] `guide/collaboration.md` — PDF page-region comments + presence; notes sync
+- [x] `developers/self-hosting.md` — FILE_STORAGE_* env vars + PDF/image blob
+      storage note (self-hosters running PDF uploads)
+
+### Considered, out of scope
+- `developers/cli.md`, `developers/rest-api.md` — notes namespace / content
+  endpoint landed post-tag (#483). Leave as-is.
+- `developers/self-hosting.md` — FILE_STORAGE_* (PDF blobs) + Yorkie
+  auth-webhook env vars. Add a short optional note (self-hosters running PDF
+  uploads need blob storage).
+
+## Steps
+- [x] Write the three new pages
+- [x] Wire config.ts sidebar + nav
+- [x] Update getting-started, import-export, collaboration
+- [x] Update README content tables
+- [x] Optional self-hosting env note
+- [x] `pnpm --filter @wafflebase/documentation build` — site builds, no dead links
+- [x] `pnpm verify:fast` — green (initial failure was missing `node_modules`;
+      `pnpm install` fixed it, then lint + unit all pass)
+- [ ] Self-review diff, open PR
+
+## Review
+
+Brought the documentation site current with v0.6.0. The site had drifted to the
+v0.4.9 feature set; three releases since added user-facing surface absent from
+the docs.
+
+**Added (3 new pages):**
+- **Notes** (`notes/writing-a-note.md`) — new nav + sidebar section covering the
+  Markdown source/preview editor, view modes, formatting toolbar, GFM/KaTeX/
+  code-copy preview features, Vim mode, and real-time collaboration.
+- **PDF** (`pdf/viewing-pdfs.md`) — new sidebar section covering upload,
+  view-only continuous rendering, rename, page-region comments, the comments
+  panel, presence, and share links.
+- **Data Validation** (`sheets/data-validation.md`) — checkbox / dropdown /
+  date / number / text criteria, in-cell controls, and warning-vs-reject
+  behavior, linked under Sheets.
+
+**Updated:** getting-started (New menu now lists New Note + Upload PDF, added a
+"Try a Note" walkthrough and What's Next links), import-export (PDF upload row,
+Notes have no file I/O), collaboration (PDF page-region comments + presence,
+notes sync), README content tables, and self-hosting (`FILE_STORAGE_*` env vars
++ blob-storage note for PDF/image uploads).
+
+**Verification:** `pnpm --filter @wafflebase/documentation build` succeeds
+(VitePress fails on dead links by default, so all internal links resolve).
+`pnpm verify:fast` green.
+
+**Accuracy:** All content verified against the frontend (`document-list.tsx`
+New menu, `notes-toolbar.tsx`, `pdf-collab.tsx`, `data-validation-panel.tsx`) as
+of v0.6.0.
+
+**Out of scope:** The notes CLI namespace + backend note content endpoint
+(#483) landed *after* the v0.6.0 tag, so `developers/cli.md` and
+`developers/rest-api.md` are left unchanged per the "based on 0.6.0" scope.

--- a/packages/documentation/.vitepress/config.ts
+++ b/packages/documentation/.vitepress/config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
       { text: "Sheets", link: "/sheets/build-a-budget" },
       { text: "Docs", link: "/docs-editor/writing-a-document" },
       { text: "Slides", link: "/slides/build-a-deck" },
+      { text: "Notes", link: "/notes/writing-a-note" },
       { text: "Developers", link: "/developers/self-hosting" },
     ],
 
@@ -90,6 +91,7 @@ export default defineConfig({
           { text: "Build a Budget", link: "/sheets/build-a-budget" },
           { text: "Formulas", link: "/sheets/formulas" },
           { text: "Charts & Pivot Tables", link: "/sheets/charts" },
+          { text: "Data Validation", link: "/sheets/data-validation" },
           { text: "External Datasources", link: "/sheets/datasources" },
           {
             text: "Keyboard Shortcuts",
@@ -123,6 +125,16 @@ export default defineConfig({
             link: "/slides/keyboard-shortcuts",
           },
         ],
+      },
+      {
+        text: "Notes",
+        items: [
+          { text: "Writing a Note", link: "/notes/writing-a-note" },
+        ],
+      },
+      {
+        text: "PDF",
+        items: [{ text: "Viewing PDFs", link: "/pdf/viewing-pdfs" }],
       },
       {
         text: "Developers",

--- a/packages/documentation/README.md
+++ b/packages/documentation/README.md
@@ -8,9 +8,9 @@ VitePress-based documentation site for Wafflebase. Serves user guides and develo
 
 | Page | Description |
 |------|-------------|
-| [Getting Started](guide/getting-started.md) | Sign in, create sheets, docs, or slides, first steps |
-| [Collaboration](guide/collaboration.md) | Share documents, real-time editing, permissions |
-| [Import & Export](guide/import-export.md) | XLSX/DOCX/PPTX import, DOCX/PPTX/PDF export, CLI automation |
+| [Getting Started](guide/getting-started.md) | Sign in, create sheets, docs, slides, or notes, first steps |
+| [Collaboration](guide/collaboration.md) | Share documents, real-time editing, comments, permissions |
+| [Import & Export](guide/import-export.md) | XLSX/DOCX/PPTX import, PDF upload, DOCX/PPTX/PDF export, CLI automation |
 
 ### Sheets
 
@@ -19,6 +19,7 @@ VitePress-based documentation site for Wafflebase. Serves user guides and develo
 | [Build a Budget](sheets/build-a-budget.md) | Learn formulas, formatting, and layout |
 | [Formulas](sheets/formulas.md) | Formula syntax, function reference, examples |
 | [Charts](sheets/charts.md) | Chart types, creation, editing, pivot tables |
+| [Data Validation](sheets/data-validation.md) | Checkboxes, dropdowns, date/number/text rules |
 | [External Datasources](sheets/datasources.md) | Connect PostgreSQL, run SQL, read-only result tabs |
 | [Keyboard Shortcuts](sheets/keyboard-shortcuts.md) | Spreadsheet shortcut reference |
 
@@ -36,6 +37,18 @@ VitePress-based documentation site for Wafflebase. Serves user guides and develo
 | [Build a Deck](slides/build-a-deck.md) | Slides, elements, themes, presenting |
 | [Themes & Layouts](slides/themes-and-layouts.md) | Theme system and slide layouts |
 | [Keyboard Shortcuts](slides/keyboard-shortcuts.md) | Presentation editor shortcut reference |
+
+### Notes
+
+| Page | Description |
+|------|-------------|
+| [Writing a Note](notes/writing-a-note.md) | Markdown source editor, live preview, view modes, Vim |
+
+### PDF
+
+| Page | Description |
+|------|-------------|
+| [Viewing PDFs](pdf/viewing-pdfs.md) | Upload, read, page-anchored comments, presence |
 
 ### Developers
 
@@ -60,7 +73,7 @@ Site configuration is in `.vitepress/config.ts`:
 
 - **Base path**: `/docs/` (deployed as subpath of the main site)
 - **Search**: Local search provider (no external service)
-- **Navigation**: Five sidebar sections — Guide, Sheets, Docs, Slides, and Developers
+- **Navigation**: Seven sidebar sections — Guide, Sheets, Docs, Slides, Notes, PDF, and Developers
 - **Theme**: Default VitePress theme with custom CSS overrides
 
 ## Tech Stack

--- a/packages/documentation/developers/self-hosting.md
+++ b/packages/documentation/developers/self-hosting.md
@@ -46,7 +46,34 @@ FRONTEND_URL=http://localhost:5173
 PORT=3000
 JWT_ACCESS_EXPIRES_IN=1h
 JWT_REFRESH_EXPIRES_IN=7d
+
+# Optional — S3-compatible blob storage. PDF uploads and embedded images
+# use two separate buckets. In development both default to the MinIO
+# container (localhost:9000); in production every value must be set.
+FILE_STORAGE_ENDPOINT=http://localhost:9000    # PDF uploads
+FILE_STORAGE_BUCKET=wafflebase-files
+FILE_STORAGE_REGION=us-east-1
+FILE_STORAGE_ACCESS_KEY=minioadmin
+FILE_STORAGE_SECRET_KEY=minioadmin
+IMAGE_STORAGE_ENDPOINT=http://localhost:9000   # embedded images
+IMAGE_STORAGE_BUCKET=wafflebase-images
+IMAGE_STORAGE_REGION=us-east-1
+IMAGE_STORAGE_ACCESS_KEY=minioadmin
+IMAGE_STORAGE_SECRET_KEY=minioadmin
 ```
+
+### PDF & Image Storage
+
+Uploaded PDFs and embedded images are stored as blobs in an S3-compatible
+object store (MinIO in development, any S3 provider in production) rather than
+in Yorkie. They use **two separate buckets** with their own settings:
+
+- **`FILE_STORAGE_*`** — PDF uploads (default bucket `wafflebase-files`)
+- **`IMAGE_STORAGE_*`** — embedded images (default bucket `wafflebase-images`)
+
+In production every value must be set explicitly. If `FILE_STORAGE_*` is
+missing, PDF upload is unavailable; if `IMAGE_STORAGE_*` is missing, image
+insertion is unavailable — in each case the rest of the app runs normally.
 
 ### GitHub OAuth Setup
 
@@ -75,6 +102,7 @@ Browser ──── Frontend (React/Vite) ──── Backend (NestJS)
 All your data is stored in:
 
 - **PostgreSQL** — User profiles, document records, API keys
-- **Yorkie** — Spreadsheet content (cells, formulas, charts, styles)
+- **Yorkie** — Editable document content (cells, text, slides, notes, comments)
+- **Blob storage** — Uploaded PDFs and embedded images (S3-compatible)
 
-You control both services. There are no external dependencies or telemetry. Back up your PostgreSQL database and Yorkie data directory to preserve everything.
+You control all of these services. There are no external dependencies or telemetry. Back up your PostgreSQL database, Yorkie data directory, and blob store to preserve everything.

--- a/packages/documentation/guide/collaboration.md
+++ b/packages/documentation/guide/collaboration.md
@@ -1,6 +1,6 @@
 # Collaboration & Sharing
 
-Wafflebase lets multiple people edit the same sheet, document, or presentation at the same time. Share via link — no account required for recipients.
+Wafflebase lets multiple people edit the same sheet, document, presentation, or note at the same time — and read and comment on the same PDF. Share via link — no account required for recipients.
 
 ## Share a Document
 
@@ -31,7 +31,7 @@ In sheets, editors can also use formulas, insert/delete rows and columns, and re
 
 When a collaborator opens your shared link, you'll see:
 
-- **Their cursor** — In sheets, a colored highlight on their selected cell. In docs, a colored text cursor at their position.
+- **Their cursor** — In sheets, a colored highlight on their selected cell. In docs and notes, a colored text cursor at their position. In PDFs, presence follows the page they're reading.
 - **Their name** — Appears near their cursor so you know who's editing where
 - **Live changes** — Edits appear instantly with no need to refresh or save
 
@@ -61,6 +61,16 @@ and on selected text in documents.
 3. Type your comment and click **Comment**
 
 The commented text is highlighted so everyone can see where the discussion is.
+
+**In a PDF:**
+
+1. Click **Add comment** in the header
+2. Drag a rectangle over the region of the page you want to comment on
+3. Type your comment and post it
+
+The comment is pinned to that page and region. Open the comments panel from the
+header to browse every thread by page. See [Viewing PDFs](/pdf/viewing-pdfs) for
+more.
 
 ### Reply, resolve, edit
 

--- a/packages/documentation/guide/getting-started.md
+++ b/packages/documentation/guide/getting-started.md
@@ -12,6 +12,11 @@ After signing in, you'll see your workspace. Click the **New** dropdown button t
 
 - **New Sheet** — A spreadsheet for structured data, formulas, and charts
 - **New Document** — A word-processor-style editor for writing and formatting text
+- **New Note** — A Markdown editor with a live preview for quick notes and docs
+- **New Presentation** — A slide deck with themes, layouts, and shapes
+
+The same menu can import existing files (**Import XLSX / DOCX / PPTX**) or
+**Upload PDF** to store and view a PDF in your workspace.
 
 ## Try a Sheet
 
@@ -46,17 +51,38 @@ Select **New Document** to open a blank page. Start typing — the editor works 
 
 For a full walkthrough, see the [Writing a Document](/docs-editor/writing-a-document) guide.
 
+## Try a Note
+
+Select **New Note** for a Markdown editor with a live preview. Type Markdown on
+the left and watch it render on the right:
+
+```markdown
+# Meeting Notes
+- [x] Review the roadmap
+- [ ] Assign owners
+```
+
+Switch between **Split**, **Editor**, and **Preview** views from the toolbar.
+For more, see the [Writing a Note](/notes/writing-a-note) guide.
+
 ## What's Next
 
 **Sheets:**
 - [Build a Budget Spreadsheet](/sheets/build-a-budget) — Learn formulas, formatting, and layout
 - [Formulas](/sheets/formulas) — Full list of supported functions
 - [Charts & Pivot Tables](/sheets/charts) — Visualize your data
+- [Data Validation](/sheets/data-validation) — Checkboxes, dropdowns, and input rules
 - [Keyboard Shortcuts](/sheets/keyboard-shortcuts) — Speed up your workflow
 
 **Docs:**
 - [Writing a Document](/docs-editor/writing-a-document) — Text editing, formatting, and page layout
 - [Keyboard Shortcuts](/docs-editor/keyboard-shortcuts) — Document editor shortcuts
+
+**Notes:**
+- [Writing a Note](/notes/writing-a-note) — Markdown editor with live preview
+
+**PDF:**
+- [Viewing PDFs](/pdf/viewing-pdfs) — Upload, read, and comment on PDF files
 
 **Common:**
 - [Collaboration & Sharing](/guide/collaboration) — Share and edit together in real time

--- a/packages/documentation/guide/import-export.md
+++ b/packages/documentation/guide/import-export.md
@@ -11,9 +11,12 @@ the platform.
 | **Sheets** | Excel (`.xlsx`) | — *(CSV/JSON via [CLI](../developers/cli))* |
 | **Docs** | Word (`.docx`) | Word (`.docx`), PDF (`.pdf`) |
 | **Slides** | PowerPoint (`.pptx`) | PowerPoint (`.pptx`), PDF (`.pdf`) |
+| **Notes** | — | — |
+| **PDF** | Upload (`.pdf`) | — *(view-only)* |
 
 Import always creates a **new** document; it never overwrites an open one.
-Export downloads a file from the document you are editing.
+Export downloads a file from the document you are editing. Notes live entirely
+inside Wafflebase — they have no file import or export.
 
 ## Importing files
 
@@ -27,6 +30,9 @@ From your workspace, open the **New** menu and choose an import option:
 - **Import PPTX** — creates a new deck from a PowerPoint file: slides,
   text boxes, shapes, images, tables, and theme colors are converted to
   native Wafflebase elements.
+- **Upload PDF** — stores a PDF as a new document you can read and comment on.
+  Unlike the other imports, the file is kept intact and viewed as-is rather than
+  converted into an editable document. See [Viewing PDFs](../pdf/viewing-pdfs).
 
 Large files show a progress indicator while they are parsed and any embedded
 images are uploaded into your workspace.

--- a/packages/documentation/notes/writing-a-note.md
+++ b/packages/documentation/notes/writing-a-note.md
@@ -1,0 +1,113 @@
+# Writing a Note
+
+Notes are lightweight **Markdown** documents in Wafflebase. Unlike the
+word-processor Docs editor, a note is written as Markdown *source* on one side
+with a live rendered *preview* on the other — a fast way to jot down meeting
+notes, drafts, and technical documentation, with the same real-time
+collaboration as every other document type.
+
+## Create a Note
+
+1. Open your workspace
+2. Click the **New** dropdown button
+3. Select **New Note**
+
+A blank note opens with the editor and preview side by side.
+
+## The Editor
+
+The left pane is a Markdown source editor. Type standard Markdown and watch the
+right pane render it live as you go.
+
+```markdown
+# Project Kickoff
+
+## Agenda
+- Introductions
+- Timeline review
+- **Next steps**
+
+See the [design doc](https://example.com) for details.
+```
+
+### Choose Your View
+
+Use the **view** dropdown at the right of the toolbar to switch between three
+modes:
+
+- **Split** — source editor and preview side by side (the default)
+- **Editor** — Markdown source only, full width
+- **Preview** — rendered output only
+
+Your choice is remembered per browser, so the note opens the same way next time.
+
+## Formatting Toolbar
+
+When the editor is visible, a toolbar gives you one-click Markdown for the most
+common styles. Select some text first, then click a button to wrap it:
+
+| Button | Inserts | Result |
+|--------|---------|--------|
+| **B** | `**text**` | **Bold** |
+| *I* | `*text*` | *Italic* |
+| ~~S~~ | `~~text~~` | ~~Strikethrough~~ |
+| Link | `[text](url)` | A hyperlink |
+| Table | A GFM table skeleton | A Markdown table |
+
+::: tip
+The **Insert table** button shows a small grid — hover to choose the number of
+rows and columns, then click to drop in a ready-to-fill table.
+:::
+
+## What the Preview Renders
+
+The preview supports **GitHub-Flavored Markdown** plus a few extras:
+
+- **Tables** — standard `| col | col |` GFM tables
+- **Task lists** — `- [ ]` and `- [x]` render as checkboxes
+- **Code blocks** — fenced ``` blocks get syntax highlighting and a **Copy**
+  button in the corner
+- **Math** — inline `$…$` and block `$$…$$` render with KaTeX
+- **Links, headings, lists, blockquotes, images** — as you'd expect
+
+For safety, the preview does **not** render raw HTML embedded in your Markdown —
+only Markdown syntax is rendered.
+
+## Keyboard Mode
+
+Prefer modal editing? Open the **keyboard** dropdown in the toolbar and switch
+from **Default** to **Vim**. Vim keybindings then apply inside the source
+editor. Like the view mode, this is remembered per browser.
+
+Standard editing shortcuts work in Default mode:
+
+| Action | Shortcut |
+|--------|----------|
+| Undo | ⌘+Z / Ctrl+Z |
+| Redo | ⌘+Shift+Z / Ctrl+Shift+Z |
+| Select all | ⌘+A / Ctrl+A |
+| Copy / Cut / Paste | ⌘+C·X·V / Ctrl+C·X·V |
+
+## Collaborate in Real Time
+
+Notes sync live through Wafflebase's CRDT engine, just like sheets, docs, and
+slides. When a teammate opens the same note:
+
+- Their edits appear instantly as they type
+- You see their **cursor and text selection** in their own color
+- No saving, refreshing, or merge step is ever needed
+
+Share a note the same way as any document — click **Share** in the header to
+create a view or edit link. See
+[Collaboration & Sharing](/guide/collaboration) for the full sharing flow.
+
+## Rename a Note
+
+Click the note's title in the header to rename it. The new title appears in your
+workspace document list immediately.
+
+::: tip
+Notes are ideal for content you'd otherwise keep in a `README` or a Markdown
+scratchpad — release notes, runbooks, and specs — kept in sync with your team
+without leaving Wafflebase.
+:::

--- a/packages/documentation/pdf/viewing-pdfs.md
+++ b/packages/documentation/pdf/viewing-pdfs.md
@@ -1,0 +1,86 @@
+# Viewing PDFs
+
+Wafflebase stores and displays **PDF files** alongside your sheets, docs,
+slides, and notes. A PDF is a *view-only* document type — you upload the
+original file, read it in the browser, and collaborate through comments and
+presence, but the PDF's contents are never edited.
+
+## Upload a PDF
+
+1. Open your workspace
+2. Click the **New** dropdown button
+3. Select **Upload PDF**
+4. Choose a `.pdf` file from your computer
+
+The file uploads and opens in the viewer. It appears in your workspace document
+list with a PDF badge, and its title defaults to the file name (which you can
+rename).
+
+## Read a PDF
+
+The viewer renders every page in a single continuous scroll and fits each page
+to the width of your window. Resizing the window — or collapsing the sidebar —
+reflows the pages to match. A progress bar shows while the file downloads on
+first open.
+
+- **Scroll** to move through the pages
+- Pages render as you reach them, so large files stay responsive
+
+::: tip
+PDFs are read-only. To make changes, edit the source elsewhere and upload a new
+version.
+:::
+
+## Rename a PDF
+
+Click the title in the header to rename the document. The change is reflected in
+your workspace list right away.
+
+## Comment on a PDF
+
+Even though the PDF itself can't be edited, you and your teammates can hold a
+discussion pinned to specific regions of a page.
+
+### Add a comment
+
+1. Click **Add comment** in the header
+2. Drag a rectangle over the part of the page you want to comment on
+3. Type your comment in the composer that appears and post it
+
+The comment is anchored to that page and region, so it stays put as everyone
+scrolls.
+
+### The comments panel
+
+Click **Show comments** in the header to open the side panel. It lists every
+thread, labeled by page. Select a thread to:
+
+- **Reply** to continue the discussion
+- **Resolve** (or reopen) it once it's addressed
+- **Edit** or **Delete** your own comments
+
+## Collaborate in Real Time
+
+PDF documents carry the same live collaboration as the rest of Wafflebase — the
+file bytes stay static, but comments and presence sync instantly:
+
+- **Presence** — avatars in the header show who else is viewing, and follow each
+  person to the page they're currently reading
+- **Comments** — new threads and replies appear for everyone without a refresh
+
+### Share a PDF
+
+Click **Share** in the header to create a link. Recipients can open and read the
+PDF — and, with an edit link, comment on it — without signing in. Viewing is
+open to anyone with a valid link; commenting requires an edit link or workspace
+membership. See [Collaboration & Sharing](/guide/collaboration) for the full
+sharing flow.
+
+## Good to Know
+
+- PDFs are **view-only** — there is no in-app annotation or re-export; comments
+  live *over* the file and never change its bytes
+- The original file is stored intact and served only to people with permission
+  to read the document
+- Self-hosting? PDF uploads need blob storage configured — see
+  [Self-Hosting](/developers/self-hosting)

--- a/packages/documentation/sheets/data-validation.md
+++ b/packages/documentation/sheets/data-validation.md
@@ -1,0 +1,104 @@
+# Data Validation
+
+Data validation adds interactive **in-cell controls** — checkboxes, dropdown
+lists, and a date picker — and guards a range against bad input. A control is
+not a floating object on top of the grid; it's a special rendering of the cell's
+own value, so it survives sorting, filtering, and copying, and works directly in
+formulas.
+
+## Open the Data Validation Panel
+
+Open the right-side **Data validation** panel in either of these ways:
+
+- Click the **Data validation** icon in the toolbar
+- Right-click a cell and choose **Data validation**
+
+On a narrow screen, the toolbar collapses its extra tools into an overflow
+(**⋯**) menu — open it and choose **Data validation** there.
+
+## Add a Rule
+
+1. Click **Add** in the panel to create a rule
+2. Set **Apply to range** — type a range like `B2:B100`, or click **Use selected
+   range** to fill it from your current selection, then click **Apply**
+3. Pick a **Criteria** (see below)
+4. Choose what happens on invalid input — **Show a warning** or **Reject the
+   input**
+
+You can add several rules per sheet; each appears as a card you can edit or
+delete.
+
+## Criteria
+
+### Checkbox
+
+Turns each cell in the range into a checkbox storing `TRUE` or `FALSE`.
+
+- **Click** the box to toggle it
+- Select one or more cells and press **Space** to toggle them together
+- Because the value is a real boolean, `=COUNTIF(B2:B100, TRUE)` and similar
+  formulas work as expected
+
+### Dropdown
+
+Restricts the cell to a list of options you type, one per line. A dropdown arrow
+appears in the cell.
+
+- **Click** the arrow — or press **Alt+↓** — to open the option picker
+- Toggle **Show dropdown arrow** to hide the arrow while keeping the rule
+- Values outside the list are flagged (warning) or blocked (reject), per the
+  rule's invalid setting
+
+### Date
+
+Validates that the cell holds a date, with an operator:
+
+| Operator | Meaning |
+|----------|---------|
+| is a valid date | Any valid date |
+| date is | Equals a specific date |
+| is before / is on or before | Earlier than a date |
+| is after / is on or after | Later than a date |
+| is between / is not between | Within (or outside) two dates |
+
+**Double-click** a date-validated cell to pick a value from a calendar popover
+instead of typing it.
+
+### Number
+
+Validates numeric input with an operator:
+
+- is a valid number
+- is equal to / is not equal to
+- greater than / greater than or equal to
+- less than / less than or equal to
+- between / not between
+
+### Text
+
+Validates text input:
+
+- contains / does not contain
+- is exactly
+- is valid email
+- is valid URL
+
+## Handling Invalid Input
+
+Each rule chooses how to treat a value that fails validation:
+
+- **Show a warning** — the value is accepted but the cell gets a small red
+  marker in its corner, so you can spot it and fix it later
+- **Reject the input** — the entry is refused and the cell keeps its previous
+  value
+
+::: tip
+Use **warning** while cleaning up existing data so nothing is lost, and switch
+to **reject** once a column should only ever hold valid values.
+:::
+
+## Remove a Rule
+
+Open the **Data validation** panel and click the delete (trash) icon on the
+rule's card. The in-cell controls for that range are removed and the cells go
+back to plain values.


### PR DESCRIPTION
## Summary

The documentation site (`packages/documentation`) had drifted to the ~v0.4.9 feature set. Three releases since — v0.5.0, v0.5.1, v0.6.0 — added user-facing surface that was **entirely missing** from the docs. This brings it current with **v0.6.0**, verified against the shipped frontend.

**New pages (wired into sidebar/nav):**
- **Notes** (`notes/writing-a-note.md`) — the new Markdown document type: source/preview split, view modes (Editor/Split/Preview), formatting toolbar, GFM/KaTeX/code-copy preview, Vim mode, real-time collaboration.
- **PDF** (`pdf/viewing-pdfs.md`) — the new upload-and-view document type: continuous read-only rendering, rename, page-region comments, comments panel, presence, share links.
- **Data Validation** (`sheets/data-validation.md`) — checkbox / dropdown / date / number / text criteria, in-cell controls, warning-vs-reject behavior.

**Updated pages:**
- `guide/getting-started.md` — New menu now lists **New Note** + **Upload PDF**; added a "Try a Note" walkthrough and What's Next links.
- `guide/import-export.md` — PDF upload row; Notes have no file import/export.
- `guide/collaboration.md` — PDF page-region comments + presence; notes sync.
- `README.md` — content tables for the new sections.
- `developers/self-hosting.md` — `FILE_STORAGE_*` (PDFs) **and** `IMAGE_STORAGE_*` (images) blob-storage env vars + Data Ownership note.

**Out of scope:** the notes CLI namespace + backend content endpoint (#483) landed *after* the v0.6.0 tag, so `developers/cli.md` / `developers/rest-api.md` are unchanged.

## Test plan

- [x] `pnpm --filter @wafflebase/documentation build` — succeeds; VitePress fails on dead links by default, so all internal links and sidebar `link:` paths resolve.
- [x] `pnpm verify:fast` — green.
- [x] Content verified against the shipped frontend as of v0.6.0 (`document-list.tsx` New menu, `notes-toolbar.tsx`, `pdf-collab.tsx`, `data-validation-panel.tsx`).
- [x] High-effort code review — 2 confirmed doc-accuracy findings (image storage uses separate `IMAGE_STORAGE_*`; data-validation had a nonexistent "Insert menu" entry), both fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)