### PR TITLE
use `ToolTip` for type filter buttons

### DIFF
--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -623,19 +623,22 @@ export function DocumentList({
             const { label, Icon, color } = TYPE_META[type];
             const active = typeFilters.has(type);
             return (
-              <Button
-                key={type}
-                type="button"
-                variant={active ? "secondary" : "outline"}
-                size="icon"
-                aria-pressed={active}
-                aria-label={`Filter by ${label}`}
-                title={label}
-                onClick={() => toggleType(type)}
-                className={active ? undefined : "text-muted-foreground"}
-              >
-                <Icon className={`h-4 w-4 ${color}`} />
-              </Button>
+              <Tooltip key={type}>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant={active ? "secondary" : "outline"}
+                    size="icon"
+                    aria-pressed={active}
+                    aria-label={`Filter by ${label}`}
+                    onClick={() => toggleType(type)}
+                    className={active ? undefined : "text-muted-foreground"}
+                  >
+                    <Icon className={`h-4 w-4 ${color}`} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{label}</TooltipContent>
+              </Tooltip>
             );
           })}
         </div>


### PR DESCRIPTION
## Summary

Replace the native HTML `title` tooltip on the document-type filter buttons
(Sheets / Docs / Note / Slides / PDF) in the Documents list with the shared
Radix `Tooltip` component.

- Wrap each icon-only filter `<Button>` in `Tooltip` / `TooltipTrigger asChild`
  / `TooltipContent`, and drop the `title={label}` attribute.
- No new provider: these ride the root `<TooltipProvider delayDuration={0}>`
  already mounted in `App.tsx`, so the label now appears instantly and matches
  the rest of the page.
- `aria-label={`Filter by ${label}`}` is kept for accessibility.

Only `packages/frontend/src/app/documents/document-list.tsx` changes (one
JSX block). The `Tooltip` import already existed in this file.

## Why

These are icon-only buttons, so the hover label is the only way to confirm what
each icon filters. The native `title` tooltip has a long, inconsistent
browser-controlled delay, which makes the buttons feel unresponsive and slows
discovery for new users — inconsistent with every other tooltip on the page,
which uses the shared component with zero delay.

## Linked Issues

Fixes https://github.com/wafflebase/wafflebase/issues/487

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): frontend-only presentational change; no
backend/DB/integration surface touched.

## Risk Assessment

- User-facing risk: Very low. Presentational only — the same label text now
  renders via the shared tooltip instead of the native `title`. Toggle/filter
  behavior is unchanged.
- Data/security risk: None.
- Rollback plan: Revert this single-file commit.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable):
#### as-is

https://github.com/user-attachments/assets/c272c181-33bd-4da4-b543-519fa7bdef7d

#### to-be

https://github.com/user-attachments/assets/5eb70c64-5782-4da5-9dc5-a547cf9e3234

- Follow-up (out of scope for this PR): Owner avatar renders two overlapping tooltips

While smoke-testing this change I found a separate, pre-existing bug in the same file. In the Owner column, the author avatar is wrapped in the shared Radix Tooltip and also carries a native HTML title attribute on the same <Avatar> element:

```tsx
// packages/frontend/src/app/documents/document-list.tsx (~L249–266)
<Tooltip>
  <TooltipTrigger asChild>
    <Avatar
      role="img"
      aria-label={author.username}
      title={author.username}   // ← redundant native tooltip
    >
      ...
    </Avatar>
  </TooltipTrigger>
  <TooltipContent>{author.username}</TooltipContent>
</Tooltip>
```

Because both are active, hovering the avatar shows two tooltips at once: the shared component's tooltip (instant) plus the browser's native title bubble (after its own delay). It's easiest to reproduce by first hovering one of the type-filter buttons and then moving onto an owner avatar — both labels end up visible simultaneously.

https://github.com/user-attachments/assets/bc3761a3-1e9a-4cee-b454-a2d194499b08

The fix is a one-line removal of the title={author.username} attribute (keeping aria-label + role="img" for accessibility; the label is already provided by TooltipContent). I deliberately left it out of this PR so it can be reviewed as its own change rather than bundled with the filter-button fix. If you'd like this addressed, let me know whether to include it in this PR or track it as a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added visible tooltips to document type filter buttons.
  * Improved screen reader labels for document type filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->