### PR TITLE
Add image documents (upload, viewer, thumbnails)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -109,6 +109,7 @@ Static PDF documents — upload, store, and view (no CRDT editing).
 | Document          | Description                                                                                        |
 | ----------------- | -------------------------------------------------------------------------------------------------- |
 | [pdf.md](pdf.md)  | PDF viewer — fourth document type (`"pdf"`), blob-stored original (no Yorkie CRDT), document-permission-gated serving, pdf.js viewer at `/f/:id`; Phase 2 spec adds share-token file serving + `pdf-<id>` Yorkie comments (page-region pin anchors, shared comments module) + `activePage` presence |
+| [image-viewer.md](image-viewer.md) | Image viewer — `"image"` document type mirroring PDF's static blob spine (reuses `Document.fileId`, `wafflebase-files` bucket, type-agnostic `GET /documents/:id/file`); png/jpeg/gif/webp only, 25 MB cap; joins the multi-file upload queue; `<img>` viewer at `/f/:id` with zoom/download + workspace prev/next; inline lazy list thumbnails (client downscale). Comments/sharing + gallery/grid view deferred |
 
 ## Common
 

--- a/docs/design/image-viewer.md
+++ b/docs/design/image-viewer.md
@@ -107,10 +107,10 @@ already stores arbitrary blobs and streams them back with their stored
 - `packages/backend/src/file/file.constants.ts` — `VALID_FILE_ID_PATTERN`
   widens from `\.pdf$` to `\.(pdf|png|jpe?g|gif|webp)$`; add
   `MAX_IMAGE_UPLOAD_BYTES = 25 * 1024 * 1024`.
-- `POST /files` (`file.controller.ts`) — the Multer `fileSize` limit uses the
+- `POST /files` (`packages/backend/src/file/file.controller.ts`) — the Multer `fileSize` limit uses the
   new `maxFileSizeBytes` (50 MB). No other change; it stays JWT-gated
   upload-only.
-- `GET /documents/:id/file` (`document-file.controller.ts`) — **unchanged**.
+- `GET /documents/:id/file` (`packages/backend/src/document/document-file.controller.ts`) — **unchanged**.
   It already validates `fileId` against `VALID_FILE_ID_PATTERN` (now widened),
   streams the stored `ContentType`, and serves both members and valid
   share-token viewers. Deletion cleanup (delete blob when a document with a
@@ -181,6 +181,28 @@ For `type === "image"` rows only, the leading type icon is replaced by a small
   downloads their full bytes; acceptable for a first pass given lazy loading
   and the browser/HTTP `private` cache, and revisited only if it bites.
 
+### Rate limiting (bulk upload)
+
+The global NestJS throttler is `120 req / 60s` per IP
+(`packages/backend/src/app.module.ts`). Each image upload spends **2 requests**
+(`POST /files` blob + `POST /documents` create) plus a lazy thumbnail
+`GET /documents/:id/file` per rendered row, so a large drag-and-drop batch would
+trip `429 Too Many Requests` after only a few dozen files. Two mitigations ship
+with this feature:
+
+- **`POST /files` throttle raised to `600 / 60s`** (`packages/backend/src/file/file.controller.ts`,
+  `@Throttle`), matching the precedent already set for the inline-image routes
+  (`packages/backend/src/image/image.controller.ts`). The document-create route stays at the global
+  default — the client backoff below absorbs its ceiling.
+- **429-aware backoff retry in the upload queue.** `assertOk`/`uploadFile`
+  throw a typed `HttpError` carrying `status` + a parsed `Retry-After`; the
+  queue auto-retries a 429'd item with capped exponential backoff
+  (1→2→4→8→15s, ≤6 attempts, honoring `Retry-After`) instead of failing it.
+  The item holds its concurrency slot during backoff, so the whole queue
+  self-throttles. Retry is idempotent: `fileId`/`docId` are persisted before
+  the failing step and re-read from the live store on each attempt, so a 429 on
+  `createDoc` after a successful upload never re-uploads (orphans) the blob.
+
 ### TODO (follow-ups, not in this PR)
 
 - **Gallery/grid view (D2)** — a list-wide layout toggle showing large image
@@ -225,7 +247,7 @@ For `type === "image"` rows only, the leading type icon is replaced by a small
   `assertFileIdAllowed` accepts `fileId` for `image`+`pdf` and rejects it for
   `sheet`/`doc`/`slides`; `yorkieDocKeyPrefix("image")` returns `image-` and no
   longer throws.
-- **Upload queue** (`upload-queue.ts`, importers mocked): `png/jpg/jpeg/gif/webp`
+- **Upload queue** (`packages/frontend/src/app/documents/upload-queue.ts`, importers mocked): `png/jpg/jpeg/gif/webp`
   classify to `image`; the `image` item runs the upload→create branch (no
   `applyContent`); `fileId` persisted before create so retry doesn't re-upload;
   unsupported extensions still `skipped`.

--- a/docs/design/image-viewer.md
+++ b/docs/design/image-viewer.md
@@ -1,0 +1,240 @@
+---
+title: image-viewer
+target-version: 0.7.0
+---
+
+<!-- Make sure to append document link in design README.md after creating the document. -->
+
+# Image Viewer
+
+## Summary
+
+Add **image** as a fifth document type (`"image"`) alongside
+`sheet` / `doc` / `slides` / `pdf` / `note`. Like PDF, an image document has
+**static content**: the original file is stored as an S3/MinIO blob and the
+Postgres `Document` row references it via the existing `fileId` column — there
+is **no Yorkie CRDT**. This work is a near-exact mirror of PDF Phase 1
+([`pdf.md`](pdf.md)), so most of the backend blob/serving spine is reused
+unchanged.
+
+Users drop image files onto the documents list (or pick them from the "New"
+menu) and each becomes a first-class document, then open it in a lightweight
+`<img>`-based viewer at the existing `/f/:id` route. Two Google-Drive-inspired
+touches ship in the same PR: **inline row thumbnails** in the documents list
+and **prev/next navigation** through the workspace's images in the viewer.
+
+Comments/sharing (a `image-<id>` Yorkie doc, mirroring PDF Phase 2) and a
+full documents-list **gallery/grid view** are explicit Non-Goals here.
+
+### Goals
+
+- Upload image files (`.png` `.jpg`/`.jpeg` `.gif` `.webp`) from the documents
+  list — via drag-and-drop and the "New" menu — each created as an `image`
+  document. Integrates into the existing multi-file upload queue
+  ([`documents-multi-file-upload.md`](documents-multi-file-upload.md)).
+- Store the original bytes in the existing `wafflebase-files` blob layer and
+  reference them from `Document.fileId` (no new column, no new bucket).
+- Serve bytes **gated by the owning document's read policy**, reusing the
+  already-type-agnostic `GET /documents/:id/file` endpoint unchanged.
+- View in the `/f/:id` route: fit-to-screen, zoom, download; **prev/next**
+  across the workspace's images (arrow buttons + keyboard ←/→).
+- **Inline thumbnails** in the documents list for `image` rows — client-side
+  downscale (no server thumbnail generation), lazily loaded.
+
+### Non-Goals
+
+- **Comments / presence / sharing** for images (the `image-<id>` Yorkie doc,
+  mirroring PDF Phase 2). The `image-` key prefix is *reserved* so this stays
+  purely additive later, but nothing attaches it in this work.
+- **Documents-list gallery/grid view** (a list-wide layout toggle). Deferred —
+  tracked as a TODO below. This PR only adds a per-row inline thumbnail.
+- Server-side thumbnail generation (sharp) and stored thumbnail blobs.
+- Image editing / annotation / crop / rotate. Viewing only.
+- SVG, HEIC, AVIF, BMP, TIFF, RAW. Only the four safe raster formats above.
+  SVG is excluded on purpose (script-execution surface).
+- Public/unauthenticated image URLs — serving stays permission-gated exactly
+  like every other document type.
+
+## Proposal Details
+
+### Data model
+
+`Document.fileId` (added for PDF, migration `20260707000000_add_document_file_id`)
+is reused as-is — **no new migration**. Only the type enum and validation gates
+widen:
+
+- `packages/backend/src/document/document.dto.ts` — extend `DOCUMENT_TYPES`
+  to include `'image'`.
+- `packages/frontend/src/types/documents.ts` — extend `DocumentType` with
+  `"image"`.
+- `packages/backend/src/document/document.controller.ts` — `assertFileIdAllowed()`
+  currently rejects a `fileId` on any non-`pdf` type. Widen it to allow
+  `fileId` on `pdf` **or** `image`.
+- `packages/backend/src/yorkie/yorkie-doc-key.ts` — add `image: 'image-'` to
+  `YORKIE_DOC_KEY_PREFIXES` and the `yorkieDocKeyPrefix` switch. **Reserved
+  only** — nothing attaches an `image-<id>` document in this work; the prefix
+  exists so the "unknown type throws" guard never fires for an image document
+  and so comments can be added later without a schema change (same posture PDF
+  took in its Phase 1).
+
+### Storage & serving — reuse the `file/` module
+
+The `file/` module (`FileService` / `FileController` / `GET /documents/:id/file`)
+already stores arbitrary blobs and streams them back with their stored
+`ContentType`. Only its allow-list and id pattern need to admit images:
+
+- `packages/backend/src/file/file.service.ts` — extend `MIME_TO_EXT` with the
+  four image MIME types:
+
+  ```ts
+  const MIME_TO_EXT: Record<string, string> = {
+    'application/pdf': 'pdf',
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+  };
+  ```
+
+  `upload()` gains a **per-category size cap**: images capped at
+  `MAX_IMAGE_UPLOAD_BYTES` (25 MB), PDFs stay at `MAX_PDF_UPLOAD_BYTES`
+  (50 MB). `getObject()`/`delete()` are unchanged — already keyed by the
+  stored blob id and its stored `ContentType`.
+- `packages/backend/src/file/file.config.ts` — `allowedMimeTypes` gains the
+  four image types. `maxFileSizeBytes` becomes the **max of both caps** (50 MB)
+  so the Multer interceptor admits the largest allowed upload; the tighter
+  per-category cap is enforced inside `FileService.upload()`.
+- `packages/backend/src/file/file.constants.ts` — `VALID_FILE_ID_PATTERN`
+  widens from `\.pdf$` to `\.(pdf|png|jpe?g|gif|webp)$`; add
+  `MAX_IMAGE_UPLOAD_BYTES = 25 * 1024 * 1024`.
+- `POST /files` (`file.controller.ts`) — the Multer `fileSize` limit uses the
+  new `maxFileSizeBytes` (50 MB). No other change; it stays JWT-gated
+  upload-only.
+- `GET /documents/:id/file` (`document-file.controller.ts`) — **unchanged**.
+  It already validates `fileId` against `VALID_FILE_ID_PATTERN` (now widened),
+  streams the stored `ContentType`, and serves both members and valid
+  share-token viewers. Deletion cleanup (delete blob when a document with a
+  `fileId` is deleted) is already type-agnostic.
+
+*Per-category cap alternative considered*: a single 50 MB cap for both. Rejected
+— 50 MB images are almost always a mistake; the 25 MB image guard costs one
+constant and a branch.
+
+### Upload & create flow — extend the existing queue
+
+Images join the existing multi-file upload queue with the **same pipeline as
+PDF** (upload original bytes → create document → done; no client-side parse, no
+headless `applyContent`):
+
+- `packages/frontend/src/app/documents/upload-kind.ts` — extend `UploadKind`
+  with `"image"` and `EXT_TO_KIND` with
+  `png/jpg/jpeg/gif/webp → "image"`.
+- `packages/frontend/src/api/files.ts` — generalize `uploadPdf(file)` →
+  `uploadFile(file)` (same `POST /files` endpoint, same `{ id }` response).
+  `pdfFileUrl` stays (or is renamed `fileUrl`) — the serving URL is
+  type-agnostic already.
+- `packages/frontend/src/app/documents/upload-queue.ts` — `runItem()` routes
+  `image` down the **same branch as `pdf`**: `uploadFile(file)` → get `fileId`
+  → `createDoc({ title: <name w/o ext>, type: "image", fileId })`. `fileId` is
+  persisted on the item immediately so a retry never re-uploads the blob (the
+  existing PDF retry-safety, unchanged).
+- `packages/frontend/src/app/documents/document-list.tsx` — add an **"Upload
+  Image"** item to the "New" menu (picker `accept=".png,.jpg,.jpeg,.gif,.webp"`)
+  and a `image` entry to `TYPE_META` / `TYPE_OPTIONS` (icon, color, label) so
+  the type filter chip and row badge cover images.
+- `packages/frontend/src/app/documents/document-list-utils.ts` —
+  `getDocumentPath` returns `/f/:id` for `image` (reuses the file viewer route).
+
+### Viewer — `/f/:id` dispatches by type
+
+`/f/:id` → `FileDetail` currently mounts the PDF stack. It becomes a thin
+type-dispatcher:
+
+- `packages/frontend/src/app/files/file-detail.tsx` — after fetching document
+  metadata, branch on `doc.type`: `pdf → <PdfCollab>` (unchanged),
+  `image → <ImageViewer>`.
+- `packages/frontend/src/app/files/image-viewer.tsx` (new) — read-only shell.
+  Loads bytes with `fetchWithAuth` → `URL.createObjectURL` → `<img>` (the same
+  auth path PDF uses; a direct cross-origin `<img src>` would drop the JWT
+  cookie in dev where frontend :5173 ≠ backend :3000). Controls: fit-to-screen
+  (default), zoom in/out (buttons + Ctrl/⌘-wheel), download. `revokeObjectURL`
+  on unmount. Error state on load failure.
+- **Prev/next navigation** — `FileDetail` fetches the current workspace's
+  documents (existing list API), filters to `type === "image"`, sorts stably
+  (by `title`, then `id`), locates the current id. Left/right chevron buttons
+  and keyboard ←/→ navigate to the sibling `/f/:id`; the buttons hide at the
+  ends. The fetch is scoped to `doc.workspaceId` and only runs for image
+  documents.
+
+### Documents list — inline row thumbnails (D1)
+
+For `type === "image"` rows only, the leading type icon is replaced by a small
+**inline thumbnail** (e.g. a fixed ~40×40 box, `object-cover`, rounded):
+
+- `packages/frontend/src/app/documents/` — a small `ImageThumb` component
+  fetches bytes via `fetchWithAuth` → object URL, gated behind an
+  `IntersectionObserver` so only rows scrolled into view fetch (never the whole
+  list at once), and `revokeObjectURL` on unmount. Falls back to the generic
+  image icon while loading or on error.
+- Client-side downscale only (the box is small; the browser scales the full
+  image down). No server thumbnails. **Cost note:** a viewport of large images
+  downloads their full bytes; acceptable for a first pass given lazy loading
+  and the browser/HTTP `private` cache, and revisited only if it bites.
+
+### TODO (follow-ups, not in this PR)
+
+- **Gallery/grid view (D2)** — a list-wide layout toggle showing large image
+  tiles, à la Google Drive's grid. Bigger UI change affecting all document
+  types; deferred.
+- **Comments / presence / sharing** — attach the reserved `image-<id>` Yorkie
+  doc and reuse the shared comments module + presence pattern, mirroring PDF
+  Phase 2 slices 1–5.
+- **Server thumbnails / more formats (SVG, HEIC, AVIF)** — if list-download
+  cost or format demand warrants it.
+
+## Risks and Mitigation
+
+- **Cross-origin auth on `<img>`** — a naive `<img src=BACKEND/documents/:id/file>`
+  drops the session cookie across the dev origin boundary. Mitigation: fetch
+  bytes with `fetchWithAuth` (credentials) → object URL, both in the viewer and
+  the list thumbnail, matching the PDF viewer.
+- **List thumbnail download cost** — many large images in view download full
+  bytes (no server thumbnail). Mitigation: `IntersectionObserver`-gated lazy
+  fetch + `revokeObjectURL`; the `private` cache amortizes repeat views.
+  Server-side thumbnails remain an available follow-up.
+- **Oversized upload mid-batch** — an image > 25 MB is rejected by the backend.
+  Mitigation: the queue surfaces a per-row `error` with the reason; other items
+  continue (existing multi-file-upload behavior).
+- **Orphaned blobs** — upload-then-create can leak a blob if create fails; same
+  posture as PDF/embedded images today. Retry reuses the persisted `fileId`
+  rather than re-uploading. Orphan-sweep remains a general follow-up.
+- **`fileId` type coupling** — widening `assertFileIdAllowed()` must admit
+  `image` **and** `pdf` only; a test asserts a `fileId` on `sheet`/`doc`/`slides`
+  is still rejected so the contract can't silently loosen.
+- **Untrusted image content** — only the four raster formats are allowed; SVG
+  (script surface) is excluded. Bytes are served with their stored image
+  `Content-Type` and `X-Content-Type-Options: nosniff` (already set), and
+  rendered via `<img>`, which does not execute embedded content.
+
+## Testing
+
+- **`FileService`**: accepts each image MIME and stores it with the right
+  extension/`ContentType`; rejects an image > 25 MB; still rejects a non-allowed
+  MIME; PDF path unchanged (still 50 MB).
+- **Document type / gate**: `CreateDocumentDto` accepts `"image"`;
+  `assertFileIdAllowed` accepts `fileId` for `image`+`pdf` and rejects it for
+  `sheet`/`doc`/`slides`; `yorkieDocKeyPrefix("image")` returns `image-` and no
+  longer throws.
+- **Upload queue** (`upload-queue.ts`, importers mocked): `png/jpg/jpeg/gif/webp`
+  classify to `image`; the `image` item runs the upload→create branch (no
+  `applyContent`); `fileId` persisted before create so retry doesn't re-upload;
+  unsupported extensions still `skipped`.
+- **Frontend routing**: `getDocumentPath({ type: "image" })` → `/f/:id`.
+- **Viewer**: `FileDetail` mounts `ImageViewer` for an image doc and `PdfCollab`
+  for a pdf doc; prev/next disabled at list ends; keyboard ←/→ navigates.
+- **List thumbnail**: `ImageThumb` fetches only after intersection; falls back
+  to the icon on error.
+- **Manual smoke** (`pnpm dev`): drop a mixed batch (image + xlsx/pdf +
+  unsupported) → images land as `image` docs, unsupported skipped; open an
+  image, zoom/download, arrow-key through workspace images; list shows inline
+  thumbnails that lazy-load on scroll.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,7 +19,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | analytics dashboard viz (2026-07-19) | [20260719-analytics-dashboard-viz-todo.md](./active/20260719-analytics-dashboard-viz-todo.md) | [20260719-analytics-dashboard-viz-lessons.md](./active/20260719-analytics-dashboard-viz-lessons.md) |
-| image viewer (2026-07-19) | [20260719-image-viewer-todo.md](./active/20260719-image-viewer-todo.md) | - |
+| image viewer (2026-07-19) | [20260719-image-viewer-todo.md](./active/20260719-image-viewer-todo.md) | [20260719-image-viewer-lessons.md](./active/20260719-image-viewer-lessons.md) |
 | toolbar dropdown unification (2026-07-19) | [20260719-toolbar-dropdown-unification-todo.md](./active/20260719-toolbar-dropdown-unification-todo.md) | [20260719-toolbar-dropdown-unification-lessons.md](./active/20260719-toolbar-dropdown-unification-lessons.md) |
 | release v0.6.1 (2026-07-18) | [20260718-release-v0.6.1-todo.md](./active/20260718-release-v0.6.1-todo.md) | - |
 | shared core extraction (2026-07-14) | [20260714-shared-core-extraction-todo.md](./active/20260714-shared-core-extraction-todo.md) | [20260714-shared-core-extraction-lessons.md](./active/20260714-shared-core-extraction-lessons.md) |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,6 +19,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | analytics dashboard viz (2026-07-19) | [20260719-analytics-dashboard-viz-todo.md](./active/20260719-analytics-dashboard-viz-todo.md) | [20260719-analytics-dashboard-viz-lessons.md](./active/20260719-analytics-dashboard-viz-lessons.md) |
+| image viewer (2026-07-19) | [20260719-image-viewer-todo.md](./active/20260719-image-viewer-todo.md) | - |
 | toolbar dropdown unification (2026-07-19) | [20260719-toolbar-dropdown-unification-todo.md](./active/20260719-toolbar-dropdown-unification-todo.md) | [20260719-toolbar-dropdown-unification-lessons.md](./active/20260719-toolbar-dropdown-unification-lessons.md) |
 | release v0.6.1 (2026-07-18) | [20260718-release-v0.6.1-todo.md](./active/20260718-release-v0.6.1-todo.md) | - |
 | shared core extraction (2026-07-14) | [20260714-shared-core-extraction-todo.md](./active/20260714-shared-core-extraction-todo.md) | [20260714-shared-core-extraction-lessons.md](./active/20260714-shared-core-extraction-lessons.md) |

--- a/docs/tasks/active/20260719-image-viewer-lessons.md
+++ b/docs/tasks/active/20260719-image-viewer-lessons.md
@@ -1,0 +1,70 @@
+# Image Viewer — Lessons
+
+Task: add an `"image"` document type (upload, `<img>` viewer at `/f/:id` with
+zoom/download + workspace prev/next, lazy list thumbnails). Branch
+`image-documents`. Executed via subagent-driven development.
+
+## What went well
+
+- **Mirroring PDF was the right spine.** Reusing `Document.fileId`, the
+  `wafflebase-files` bucket, and the already-type-agnostic
+  `GET /documents/:id/file` meant no migration, no new bucket, and no serving
+  change. The bulk of each task was transcription; cheap models handled the
+  mechanical ones.
+- **Extracting `assertFileIdAllowed` into a pure util** made the security-
+  critical "fileId only on pdf/image" gate unit-testable and kept the final
+  review's cross-cutting trace clean (no path lets a sheet/doc/slides carry a
+  fileId or serve an arbitrary blob).
+
+## Lessons / mistakes caught in review
+
+- **A brief that says "Create <file>" can be wrong when the file already
+  exists.** `yorkie-doc-key.spec.ts` pre-existed (from the notes PR) with 10
+  tests; the Task-2 implementer took "Create" literally and overwrote it,
+  silently dropping unrelated coverage. The task review caught it; restored via
+  a fix commit. Lesson: when a plan says create a test file, the implementer
+  must still check for an existing one and append; and plan authors should
+  verify file existence before writing "Create".
+
+- **Immutable store + closed-over object = stale reads across retries.** The
+  upload queue's `patchItem` replaces the `items` array immutably
+  (`items.map(... {...it, ...patch})`). The first cut of the 429 retry loop
+  re-read `item.fileId`/`item.docId` off the object captured once at
+  `runItem` entry — which never updates. A 429 on `createDoc` *after* a
+  successful `uploadFile` would therefore re-upload (orphan a blob) and
+  re-create the document. The adversarial task review flagged it as PLAUSIBLE;
+  a RED test (uploadFile called 2×) confirmed the bug, and the fix (re-read the
+  live item each attempt) turned it GREEN. Lesson: with an immutable store,
+  never trust a long-lived local reference across `await` + mutation — re-read
+  from the source of truth.
+
+- **`.png` was load-bearing as the "unsupported" example.** Multiple existing
+  tests (`upload-kind`, `upload-queue`, `upload-panel`, `tests/api/files`) used
+  `.png` to mean "skipped/unsupported". Reclassifying png as a supported image
+  broke them; the plan pre-identified this and the implementer swept them to
+  `.zip`. Lesson: before widening an accept-list, grep the test suite for the
+  extension you're promoting.
+
+- **Feature-level rate limiting is easy to forget.** Bulk image upload tripped
+  the global 120/min throttler because the new `POST /files`/`POST /documents`
+  path never inherited the raised limit the inline-image routes already had.
+  Surfaced by the user mid-implementation, not by tests. Lesson: when a feature
+  adds a new high-fan-out request path, check the throttler config and the
+  precedent set by sibling features.
+
+- **A refactor must resolve type *before* mounting a provider.** `FileDetail`
+  gained an image branch, but the first cut fell through to the PDF layout
+  (attaching a `pdf-<id>` Yorkie doc) on a document-fetch *error*. Fixed by
+  short-circuiting on `docError || !documentData` before choosing a layout.
+  Lesson: when one route dispatches to provider-wrapped vs provider-free
+  subtrees, gate on the discriminator's resolved (and error) state, not just
+  its loading state.
+
+## Deferred (documented, not in this PR)
+
+- `FileDetail` dispatch render-test to lock "image never mounts
+  `PdfCollabProvider`" into CI (currently manual-smoke-only).
+- Gallery/grid list view (D2), image comments/sharing (`image-<id>` Yorkie),
+  server-side thumbnails, SVG/HEIC support.
+- Manual smoke (docker + `pnpm dev`): mixed-batch upload, >25 MB rejection,
+  lazy thumbnail on scroll, PDF no-regression, arrow-key nav.

--- a/docs/tasks/active/20260719-image-viewer-todo.md
+++ b/docs/tasks/active/20260719-image-viewer-todo.md
@@ -1,0 +1,1257 @@
+# Image Viewer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `"image"` document type — upload png/jpeg/gif/webp files from the documents list, view them in an `<img>` viewer at `/f/:id` with zoom/download and workspace prev/next, and show inline lazy thumbnails in the list.
+
+**Architecture:** Mirror the PDF static-blob spine. Images reuse `Document.fileId`, the `wafflebase-files` bucket, and the already-type-agnostic `GET /documents/:id/file` serving endpoint. No new migration, no new bucket, no Yorkie CRDT (comments/sharing deferred). The multi-file upload queue gains an `image` branch identical to `pdf`. The `/f/:id` route dispatches by `doc.type` to a PDF or image shell.
+
+**Tech Stack:** NestJS + `@aws-sdk/client-s3` (MinIO) backend; React + TanStack Query + Tailwind/shadcn frontend; Vitest (frontend) / Jest (backend).
+
+## Global Constraints
+
+- Design spec: `docs/design/image-viewer.md`. Target version 0.7.0.
+- Allowed image formats **only**: `png`, `jpg`/`jpeg`, `gif`, `webp`. No SVG/HEIC/AVIF/BMP/TIFF.
+- Image size cap: **25 MB** (`MAX_IMAGE_UPLOAD_BYTES`). PDF stays **50 MB** (`MAX_PDF_UPLOAD_BYTES`). The `POST /files` Multer ceiling is the max of both (50 MB); the tighter per-category cap is enforced in `FileService.upload()`.
+- `fileId` is allowed on `pdf` **and** `image` documents only — never on `sheet`/`doc`/`slides`.
+- Image bytes are always loaded via `fetchWithAuth` → `URL.createObjectURL` (never a direct cross-origin `<img src>`), matching the PDF viewer's auth path. Always `revokeObjectURL` on unmount.
+- Commit format: subject ≤ 70 chars, blank line 2, body wrapped ≤ 80 chars/line (a commit-msg hook enforces this). Each commit must pass `pnpm verify:fast`.
+- Reserve the `image-` Yorkie key prefix but attach nothing (comments deferred).
+- Out of scope this PR: comments/presence/sharing (`image-<id>` Yorkie doc), documents-list gallery/grid view (D2), server-side thumbnails.
+
+---
+
+## File Structure
+
+- `packages/backend/src/file/file.constants.ts` — widen id pattern, add image cap (modify)
+- `packages/backend/src/file/file.config.ts` — allow image MIMEs (modify)
+- `packages/backend/src/file/file.service.ts` — image ext map + per-category cap (modify)
+- `packages/backend/src/file/file.service.spec.ts` — image validation tests (modify)
+- `packages/backend/src/document/document.dto.ts` — add `'image'` to `DOCUMENT_TYPES` (modify)
+- `packages/backend/src/document/document-file-id.util.ts` — extracted `assertFileIdAllowed` (create)
+- `packages/backend/src/document/document-file-id.util.spec.ts` — gate tests (create)
+- `packages/backend/src/document/document.controller.ts` — call the extracted util (modify)
+- `packages/backend/src/yorkie/yorkie-doc-key.ts` — reserve `image-` prefix (modify)
+- `packages/backend/src/yorkie/yorkie-doc-key.spec.ts` — prefix tests (create)
+- `packages/frontend/src/types/documents.ts` — add `"image"` to `DocumentType` (modify)
+- `packages/frontend/src/app/documents/upload-kind.ts` — classify image extensions (modify)
+- `packages/frontend/src/app/documents/__tests__/upload-kind.test.ts` — image classify tests (modify)
+- `packages/frontend/src/api/files.ts` — `uploadPdf`→`uploadFile`, `pdfFileUrl`→`fileUrl` (modify)
+- `packages/frontend/src/app/documents/upload-queue.ts` — merged image/pdf branch (modify)
+- `packages/frontend/src/app/documents/__tests__/upload-queue.test.ts` — swap `.png` example (modify)
+- `packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts` — image branch + dep rename (modify)
+- `packages/frontend/src/app/documents/document-list-utils.ts` — `image`→`/f/:id` (modify)
+- `packages/frontend/src/app/documents/document-list.tsx` — TYPE_META, filter, Upload Image menu, thumbnail cell (modify)
+- `packages/frontend/src/app/documents/image-thumb.tsx` — lazy row thumbnail (create)
+- `packages/frontend/src/app/files/file-shell.tsx` — shared sidebar/header shell (create)
+- `packages/frontend/src/app/files/image-viewer.tsx` — image viewer + prev/next (create)
+- `packages/frontend/src/app/files/file-detail.tsx` — dispatch pdf vs image (modify)
+- `packages/frontend/src/app/files/pdf-collab.tsx` — `pdfFileUrl`→`fileUrl` import (modify)
+
+---
+
+## Task 1: Backend blob storage accepts images
+
+**Files:**
+- Modify: `packages/backend/src/file/file.constants.ts`
+- Modify: `packages/backend/src/file/file.config.ts`
+- Modify: `packages/backend/src/file/file.service.ts`
+- Test: `packages/backend/src/file/file.service.spec.ts`
+
+**Interfaces:**
+- Produces: `MAX_IMAGE_UPLOAD_BYTES` constant; widened `VALID_FILE_ID_PATTERN`; `FileService.upload(buffer, mimeType)` now accepts image MIMEs (per-category cap).
+
+- [ ] **Step 1: Widen constants**
+
+In `packages/backend/src/file/file.constants.ts`, replace the pdf-only pattern and add the image cap:
+
+```ts
+export const VALID_FILE_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(pdf|png|jpe?g|gif|webp)$/i;
+
+/** Max PDF upload size (50 MB). Shared by the Multer limit and FileService. */
+export const MAX_PDF_UPLOAD_BYTES = 50 * 1024 * 1024;
+
+/** Max image upload size (25 MB). Enforced per-category in FileService. */
+export const MAX_IMAGE_UPLOAD_BYTES = 25 * 1024 * 1024;
+```
+
+- [ ] **Step 2: Allow image MIMEs in config**
+
+In `packages/backend/src/file/file.config.ts`, extend `allowedMimeTypes` (leave `maxFileSizeBytes: MAX_PDF_UPLOAD_BYTES` — it is the Multer ceiling / max of both caps):
+
+```ts
+  maxFileSizeBytes: MAX_PDF_UPLOAD_BYTES,
+  allowedMimeTypes: [
+    'application/pdf',
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+  ],
+```
+
+- [ ] **Step 3: Write failing service tests**
+
+Append to `packages/backend/src/file/file.service.spec.ts`. First extend `makeService` to allow images, then add image cases. Replace the `makeService` body's two config values:
+
+```ts
+    'file.maxFileSizeBytes': 50 * 1024 * 1024,
+    'file.allowedMimeTypes': [
+      'application/pdf',
+      'image/png',
+      'image/jpeg',
+      'image/gif',
+      'image/webp',
+    ],
+```
+
+Then add a new describe block:
+
+```ts
+import { MAX_IMAGE_UPLOAD_BYTES } from './file.constants';
+
+describe('FileService.upload image support', () => {
+  it('rejects an image over the 25 MB cap even though Multer allows 50 MB', async () => {
+    const svc = makeService();
+    const tooBig = Buffer.alloc(MAX_IMAGE_UPLOAD_BYTES + 1);
+    await expect(svc.upload(tooBig, 'image/png')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('rejects an unknown mime type not in the allow-list', async () => {
+    const svc = makeService();
+    await expect(
+      svc.upload(Buffer.from('x'), 'image/svg+xml'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});
+```
+
+Note: the existing `rejects a non-pdf mime type` test constructs a service whose config is now image-allowing via the shared `makeService`. Change that one test to use a still-disallowed type so it keeps asserting the allow-list:
+
+```ts
+  it('rejects a disallowed mime type', async () => {
+    const svc = makeService();
+    await expect(
+      svc.upload(Buffer.from('x'), 'application/zip'),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `pnpm --filter @wafflebase/backend test -- file.service`
+Expected: FAIL — `image/png` currently rejected (not in `MIME_TO_EXT`), 25 MB cap not enforced.
+
+- [ ] **Step 5: Extend the service**
+
+In `packages/backend/src/file/file.service.ts`, extend the MIME→ext map and add a per-category cap. Update the import and `MIME_TO_EXT`:
+
+```ts
+import { MAX_IMAGE_UPLOAD_BYTES } from './file.constants';
+
+const MIME_TO_EXT: Record<string, string> = {
+  'application/pdf': 'pdf',
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+```
+
+Replace the size check inside `upload()`:
+
+```ts
+    // Images get a tighter cap than the Multer ceiling (which admits the
+    // largest allowed upload, i.e. a 50 MB PDF).
+    const cap = mimeType.startsWith('image/')
+      ? MAX_IMAGE_UPLOAD_BYTES
+      : this.maxFileSize;
+    if (file.length > cap) {
+      throw new BadRequestException(
+        `File too large (max ${cap / 1024 / 1024} MB)`,
+      );
+    }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm --filter @wafflebase/backend test -- file.service`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/backend/src/file/
+git commit -m "Accept image blobs in the file storage service"
+```
+
+---
+
+## Task 2: Backend accepts the `image` document type
+
+**Files:**
+- Modify: `packages/backend/src/document/document.dto.ts`
+- Create: `packages/backend/src/document/document-file-id.util.ts`
+- Test: `packages/backend/src/document/document-file-id.util.spec.ts`
+- Modify: `packages/backend/src/document/document.controller.ts`
+- Modify: `packages/backend/src/yorkie/yorkie-doc-key.ts`
+- Test: `packages/backend/src/yorkie/yorkie-doc-key.spec.ts`
+
+**Interfaces:**
+- Consumes: `VALID_FILE_ID_PATTERN` (Task 1).
+- Produces: `assertFileIdAllowed(type, fileId)` exported from `document-file-id.util.ts`; `DOCUMENT_TYPES` includes `'image'`; `yorkieDocKeyPrefix('image')` → `'image-'`.
+
+- [ ] **Step 1: Add `image` to the DTO type union**
+
+In `packages/backend/src/document/document.dto.ts`:
+
+```ts
+const DOCUMENT_TYPES = ['sheet', 'doc', 'slides', 'pdf', 'note', 'image'] as const;
+```
+
+- [ ] **Step 2: Write failing gate util test**
+
+Create `packages/backend/src/document/document-file-id.util.spec.ts`:
+
+```ts
+import { BadRequestException } from '@nestjs/common';
+import { assertFileIdAllowed } from './document-file-id.util';
+
+describe('assertFileIdAllowed', () => {
+  it('allows a fileId on pdf and image documents', () => {
+    expect(() => assertFileIdAllowed('pdf', 'blob.pdf')).not.toThrow();
+    expect(() => assertFileIdAllowed('image', 'blob.png')).not.toThrow();
+  });
+
+  it('rejects a fileId on non-blob types', () => {
+    for (const type of ['sheet', 'doc', 'slides', 'note', undefined]) {
+      expect(() => assertFileIdAllowed(type, 'blob.png')).toThrow(
+        BadRequestException,
+      );
+    }
+  });
+
+  it('is a no-op when no fileId is provided', () => {
+    expect(() => assertFileIdAllowed('sheet', undefined)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter @wafflebase/backend test -- document-file-id`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 4: Create the util**
+
+Create `packages/backend/src/document/document-file-id.util.ts`:
+
+```ts
+import { BadRequestException } from '@nestjs/common';
+
+/** Types whose documents may carry a stored-blob `fileId`. */
+const FILE_ID_TYPES = new Set(['pdf', 'image']);
+
+/**
+ * Contract guard: only pdf/image documents reference a stored blob. Reject a
+ * `fileId` on any other type so the coupling can't silently loosen.
+ */
+export function assertFileIdAllowed(
+  type: string | undefined,
+  fileId: string | undefined,
+): void {
+  if (fileId && !FILE_ID_TYPES.has(type ?? 'sheet')) {
+    throw new BadRequestException('fileId is only allowed for pdf/image documents');
+  }
+}
+```
+
+- [ ] **Step 5: Use the util in the controller**
+
+In `packages/backend/src/document/document.controller.ts`, delete the private `assertFileIdAllowed` method (around lines 104-112) and import the util:
+
+```ts
+import { assertFileIdAllowed } from './document-file-id.util';
+```
+
+Replace the two call sites `this.assertFileIdAllowed(body.type, body.fileId);` with:
+
+```ts
+    assertFileIdAllowed(body.type, body.fileId);
+```
+
+- [ ] **Step 6: Write failing doc-key test**
+
+Create `packages/backend/src/yorkie/yorkie-doc-key.spec.ts`:
+
+```ts
+import {
+  yorkieDocKeyPrefix,
+  yorkieDocKey,
+  parseYorkieDocKey,
+} from './yorkie-doc-key';
+
+describe('yorkie-doc-key image prefix', () => {
+  it('maps image to the image- prefix', () => {
+    expect(yorkieDocKeyPrefix('image')).toBe('image-');
+    expect(yorkieDocKey('image', 'abc')).toBe('image-abc');
+  });
+
+  it('round-trips an image key', () => {
+    expect(parseYorkieDocKey('image-abc')).toEqual({ type: 'image', id: 'abc' });
+  });
+
+  it('still throws on an unknown type', () => {
+    expect(() => yorkieDocKeyPrefix('bogus')).toThrow();
+  });
+});
+```
+
+- [ ] **Step 7: Run test to verify it fails**
+
+Run: `pnpm --filter @wafflebase/backend test -- yorkie-doc-key`
+Expected: FAIL — `yorkieDocKeyPrefix('image')` throws (unknown type).
+
+- [ ] **Step 8: Reserve the image prefix**
+
+In `packages/backend/src/yorkie/yorkie-doc-key.ts`:
+
+```ts
+export type DocumentTypeLike =
+  | 'sheet' | 'doc' | 'slides' | 'pdf' | 'note' | 'image';
+
+export const YORKIE_DOC_KEY_PREFIXES = {
+  sheet: 'sheet-',
+  doc: 'doc-',
+  slides: 'slides-',
+  pdf: 'pdf-',
+  note: 'note-',
+  image: 'image-',
+} as const;
+```
+
+And add the switch case before `default:`:
+
+```ts
+    case 'image':
+      return YORKIE_DOC_KEY_PREFIXES.image;
+```
+
+- [ ] **Step 9: Run tests to verify they pass**
+
+Run: `pnpm --filter @wafflebase/backend test -- "document-file-id|yorkie-doc-key"`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/backend/src/document/ packages/backend/src/yorkie/
+git commit -m "Allow the image document type in the backend"
+```
+
+---
+
+## Task 3: Frontend classify + upload queue image branch
+
+**Files:**
+- Modify: `packages/frontend/src/types/documents.ts`
+- Modify: `packages/frontend/src/app/documents/upload-kind.ts`
+- Test: `packages/frontend/src/app/documents/__tests__/upload-kind.test.ts`
+- Modify: `packages/frontend/src/api/files.ts`
+- Modify: `packages/frontend/src/app/files/pdf-collab.tsx`
+- Modify: `packages/frontend/src/app/documents/upload-queue.ts`
+- Modify: `packages/frontend/src/app/documents/document-list-utils.ts`
+- Test: `packages/frontend/src/app/documents/__tests__/upload-queue.test.ts`
+- Test: `packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts`
+
+**Interfaces:**
+- Consumes: `assertFileIdAllowed` semantics (Task 2) — the frontend creates `image` docs with a `fileId`.
+- Produces: `UploadKind` includes `"image"`; `uploadFile(file)` and `fileUrl(id, token?)` in `api/files.ts`; `getDocumentPath({type:"image"})` → `/f/:id`.
+
+- [ ] **Step 1: Add `"image"` to `DocumentType`**
+
+In `packages/frontend/src/types/documents.ts`:
+
+```ts
+export type DocumentType = "sheet" | "doc" | "slides" | "pdf" | "note" | "image";
+```
+
+- [ ] **Step 2: Update classify tests (png is now supported)**
+
+Replace `packages/frontend/src/app/documents/__tests__/upload-kind.test.ts` body:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { classifyUploadKind } from "@/app/documents/upload-kind";
+
+describe("classifyUploadKind", () => {
+  it("maps supported extensions case-insensitively", () => {
+    expect(classifyUploadKind("Budget.XLSX")).toBe("sheet");
+    expect(classifyUploadKind("notes.docx")).toBe("doc");
+    expect(classifyUploadKind("deck.pptx")).toBe("slides");
+    expect(classifyUploadKind("report.pdf")).toBe("pdf");
+  });
+  it("maps image extensions to image", () => {
+    expect(classifyUploadKind("photo.png")).toBe("image");
+    expect(classifyUploadKind("pic.JPG")).toBe("image");
+    expect(classifyUploadKind("pic.jpeg")).toBe("image");
+    expect(classifyUploadKind("anim.gif")).toBe("image");
+    expect(classifyUploadKind("shot.webp")).toBe("image");
+  });
+  it("returns null for unsupported types", () => {
+    expect(classifyUploadKind("archive.zip")).toBeNull();
+    expect(classifyUploadKind("vector.svg")).toBeNull();
+    expect(classifyUploadKind("noext")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter @wafflebase/frontend test -- upload-kind`
+Expected: FAIL — `photo.png` is `null`, not `"image"`.
+
+- [ ] **Step 4: Extend the classifier**
+
+In `packages/frontend/src/app/documents/upload-kind.ts`:
+
+```ts
+export type UploadKind = "sheet" | "doc" | "slides" | "pdf" | "image";
+
+export const SKIP_REASON = "Unsupported file type";
+
+const EXT_TO_KIND: Record<string, UploadKind> = {
+  xlsx: "sheet",
+  docx: "doc",
+  pptx: "slides",
+  pdf: "pdf",
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  gif: "image",
+  webp: "image",
+};
+```
+
+(Leave `classifyUploadKind` unchanged.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter @wafflebase/frontend test -- upload-kind`
+Expected: PASS.
+
+- [ ] **Step 6: Generalize the file API**
+
+In `packages/frontend/src/api/files.ts`, rename both exports to be type-agnostic (the endpoint already is):
+
+```ts
+import { fetchWithAuth } from "./auth";
+
+const BACKEND_BASE = import.meta.env.VITE_BACKEND_API_URL ?? "";
+
+/** Upload a blob (pdf or image); returns the stored blob id. */
+export async function uploadFile(file: File): Promise<{ id: string }> {
+  const formData = new FormData();
+  formData.append("file", file, file.name);
+  const res = await fetchWithAuth(`${BACKEND_BASE}/files`, {
+    method: "POST",
+    body: formData,
+  });
+  if (!res.ok) {
+    throw new Error(`File upload failed: ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as { id: string };
+}
+
+/** Document-scoped, permission-gated URL that streams the stored blob. */
+export function fileUrl(documentId: string, token?: string): string {
+  const base = `${BACKEND_BASE}/documents/${documentId}/file`;
+  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+}
+```
+
+- [ ] **Step 7: Update the pdf-collab import**
+
+In `packages/frontend/src/app/files/pdf-collab.tsx`, line ~34 and ~136:
+
+```ts
+import { fileUrl } from '@/api/files.ts';
+```
+```ts
+    fileUrl: fileUrl(documentId, token),
+```
+
+- [ ] **Step 8: Merge the pdf/image branch in the upload queue**
+
+In `packages/frontend/src/app/documents/upload-queue.ts`:
+
+Update the import (line 6):
+
+```ts
+import { uploadFile } from "@/api/files";
+```
+
+Rename the `UploadDeps` field and default (lines 150, 164):
+
+```ts
+  uploadFile: typeof uploadFile;
+```
+```ts
+  uploadFile,
+```
+
+Replace the `else if (item.kind === "pdf") { ... }` block (lines 264-276) with a merged branch:
+
+```ts
+    } else if (item.kind === "pdf" || item.kind === "image") {
+      patchItem(item.id, { status: "uploading" });
+      const dot = item.fileName.lastIndexOf(".");
+      const ext = dot >= 0 ? item.fileName.slice(dot + 1).toLowerCase() : "";
+      const fallback = item.kind === "pdf" ? "Untitled PDF" : "Untitled Image";
+      const title = stripExt(item.fileName, ext, fallback);
+      // Upload the blob at most once per item: persist the returned fileId
+      // immediately so a retry whose earlier failure was in createDoc reuses
+      // the blob instead of orphaning it with a second upload.
+      let fileId = item.fileId;
+      if (!fileId) {
+        ({ id: fileId } = await d.uploadFile(file));
+        patchItem(item.id, { fileId });
+      }
+      const created = await getOrCreateDoc(item, {
+        title,
+        type: item.kind,
+        fileId,
+      });
+      finish(item.id, created);
+    }
+```
+
+- [ ] **Step 9: Route image to the file viewer**
+
+In `packages/frontend/src/app/documents/document-list-utils.ts`, add a case in the `getDocumentPath` switch alongside `pdf`:
+
+```ts
+    case "pdf":
+    case "image":
+      return `/f/${doc.id}`;
+```
+
+- [ ] **Step 10: Fix the existing worker/queue tests**
+
+In `packages/frontend/src/app/documents/__tests__/upload-queue.test.ts` (lines 12-16), swap the now-supported `.png` for an unsupported type:
+
+```ts
+    const items = q.enqueue([file("a.xlsx"), file("b.zip")], "ws1");
+    expect(items.map((i) => i.status)).toEqual(["pending", "skipped"]);
+```
+(Keep the `reason` assertion referencing `items[1]`.)
+
+In `packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts`:
+
+- Rename every `uploadPdf:` in the inline deps objects (lines 24, 64, 101, 150, 193, 237, 268, 312) to `uploadFile:`, and the two assertions `deps.uploadPdf` (lines 210, 222) to `deps.uploadFile`.
+- In the "processes a mixed batch" test (line 33), the `b.png` file now uploads as an image. Update the batch and assertions:
+
+```ts
+    q.enqueue([file("a.xlsx"), file("b.png"), file("c.pdf")], "ws1");
+```
+```ts
+    expect(snap.find((i) => i.fileName === "a.xlsx")?.status).toBe("done");
+    expect(snap.find((i) => i.fileName === "c.pdf")?.status).toBe("done");
+    expect(snap.find((i) => i.fileName === "b.png")?.status).toBe("done");
+    // xlsx + png + pdf all create a document now.
+    expect(deps.createDoc).toHaveBeenCalledTimes(3);
+    // Content is applied only for the parsed sheet; the png and pdf store
+    // their bytes server-side at create time.
+    expect(deps.applyContent).toHaveBeenCalledTimes(1);
+```
+
+- Add a focused test that the image path uploads a blob and creates an `image` doc (place after the mixed-batch test):
+
+```ts
+  it("uploads an image blob and creates an image document", async () => {
+    const deps = makeWorkerDeps();
+    deps.uploadFile = vi.fn(async () => ({ id: "img-1" }));
+    q.enqueue([file("cat.png")], "ws1");
+    q.startUploads(undefined, deps as never);
+    await flush();
+    await flush();
+    expect(deps.uploadFile).toHaveBeenCalledTimes(1);
+    expect(deps.createDoc).toHaveBeenCalledWith(
+      "ws1",
+      expect.objectContaining({ type: "image", fileId: "img-1" }),
+    );
+    expect(deps.applyContent).not.toHaveBeenCalled();
+  });
+```
+
+> If the file has no shared `makeWorkerDeps()` helper, copy the inline deps
+> object shape used by the mixed-batch test (with `uploadFile` instead of
+> `uploadPdf`) rather than referencing a helper that doesn't exist.
+
+- [ ] **Step 11: Run the frontend queue tests**
+
+Run: `pnpm --filter @wafflebase/frontend test -- upload-queue upload-kind`
+Expected: PASS.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add packages/frontend/src/types/documents.ts \
+  packages/frontend/src/app/documents/upload-kind.ts \
+  packages/frontend/src/api/files.ts \
+  packages/frontend/src/app/files/pdf-collab.tsx \
+  packages/frontend/src/app/documents/upload-queue.ts \
+  packages/frontend/src/app/documents/document-list-utils.ts \
+  packages/frontend/src/app/documents/__tests__/
+git commit -m "Route image uploads through the document queue"
+```
+
+---
+
+## Task 4: Documents list — image filter, menu, and inline thumbnails
+
+**Files:**
+- Create: `packages/frontend/src/app/documents/image-thumb.tsx`
+- Modify: `packages/frontend/src/app/documents/document-list.tsx`
+
+**Interfaces:**
+- Consumes: `fileUrl` (Task 3), `TYPE_META` shape, `classifyUploadKind` accept list.
+- Produces: `ImageThumb({ documentId })` React component; `image` entry in `TYPE_META`/`TYPE_OPTIONS`; "Upload Image" New-menu item.
+
+- [ ] **Step 1: Write the ImageThumb component**
+
+Create `packages/frontend/src/app/documents/image-thumb.tsx`. It lazily fetches bytes only after the row scrolls into view (`IntersectionObserver`), builds an object URL, and revokes it on unmount. Falls back to the generic icon while loading or on error:
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import { Image as ImageIcon } from "lucide-react";
+import { fetchWithAuth } from "@/api/auth";
+import { fileUrl } from "@/api/files";
+
+/**
+ * Small inline thumbnail for an `image` document row. Client-side downscale
+ * (no server thumbnails): the full blob is fetched — but only once the row is
+ * scrolled into view — and the browser scales it into the fixed box. The
+ * object URL is revoked on unmount to avoid leaks across list re-renders.
+ */
+export function ImageThumb({ documentId }: { documentId: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [src, setSrc] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    let objectUrl: string | null = null;
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const res = await fetchWithAuth(fileUrl(documentId));
+        if (!res.ok) throw new Error(String(res.status));
+        const blob = await res.blob();
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) {
+        observer.disconnect();
+        void load();
+      }
+    });
+    observer.observe(el);
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [documentId]);
+
+  return (
+    <div
+      ref={ref}
+      className="h-4 w-4 shrink-0 overflow-hidden rounded-sm bg-muted"
+    >
+      {src && !failed ? (
+        <img src={src} alt="" className="h-full w-full object-cover" />
+      ) : (
+        <ImageIcon className="h-4 w-4 text-pink-500" />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Register the image type in the list**
+
+In `packages/frontend/src/app/documents/document-list.tsx`:
+
+Add the lucide import near the other icon imports:
+
+```ts
+import { Image as ImageIcon } from "lucide-react";
+import { ImageThumb } from "./image-thumb";
+```
+
+Add the `image` entry to `TYPE_META`:
+
+```ts
+  image: { label: "Images", Icon: ImageIcon, color: "text-pink-500" },
+```
+
+Add `"image"` to `TYPE_OPTIONS` (after `"pdf"`):
+
+```ts
+const TYPE_OPTIONS: ReadonlyArray<DocumentType> = [
+  "sheet",
+  "doc",
+  "note",
+  "slides",
+  "pdf",
+  "image",
+];
+```
+
+- [ ] **Step 3: Render the thumbnail in the title cell**
+
+In the title cell (around line 256), swap the plain icon for the thumbnail when the row is an image:
+
+```tsx
+      cell: ({ row }) => {
+        const { Icon, color } = TYPE_META[row.original.type];
+        return (
+          <div className="flex items-center gap-2">
+            {row.original.type === "image" ? (
+              <ImageThumb documentId={String(row.original.id)} />
+            ) : (
+              <Icon className={`h-4 w-4 shrink-0 ${color}`} />
+            )}
+            <span className="capitalize">{row.getValue("title")}</span>
+```
+
+(Leave the rest of the cell — presence avatars, etc. — unchanged.)
+
+- [ ] **Step 4: Add the "Upload Image" New-menu item**
+
+In `ImportMenuItems` (around line 222, after the Upload PDF item):
+
+```tsx
+        <DropdownMenuItem
+          onClick={() => onImport(".png,.jpg,.jpeg,.gif,.webp")}
+        >
+          <ImageIcon className="mr-2 h-4 w-4 text-pink-500" />
+          Upload Image
+        </DropdownMenuItem>
+```
+
+- [ ] **Step 5: Verify lint + build**
+
+Run: `pnpm --filter @wafflebase/frontend lint && pnpm --filter @wafflebase/frontend test`
+Expected: PASS (no test asserts the exact menu list; TYPE_META now exhaustively covers `DocumentType`, satisfying the `Record<DocumentType, …>` type).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/src/app/documents/image-thumb.tsx \
+  packages/frontend/src/app/documents/document-list.tsx
+git commit -m "Show image type filter and inline row thumbnails"
+```
+
+---
+
+## Task 5: Image viewer + `/f/:id` dispatch + prev/next
+
+**Files:**
+- Create: `packages/frontend/src/app/files/file-shell.tsx`
+- Create: `packages/frontend/src/app/files/image-viewer.tsx`
+- Modify: `packages/frontend/src/app/files/file-detail.tsx`
+
+**Interfaces:**
+- Consumes: `fetchDocument`, `fetchDocuments`, `fetchWorkspaces`, `fileUrl` (Task 3), existing `PdfCollabProvider`/`PdfHeaderActions`/`PdfCollabBody`.
+- Produces: `FileShell` (shared sidebar/header), `ImageViewer` (viewer + nav); `FileDetail` dispatches by `doc.type`.
+
+- [ ] **Step 1: Extract the shared shell**
+
+Create `packages/frontend/src/app/files/file-shell.tsx` by lifting the sidebar/header/rename/workspace logic currently inline in `file-detail.tsx`'s `FileLayout`. It takes the header actions and body as props and does NOT own any Yorkie provider:
+
+```tsx
+import { useNavigate } from "react-router-dom";
+import { useCallback, useEffect, useMemo, type ReactNode } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { fetchDocument, renameDocument } from "@/api/documents";
+import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/app-sidebar";
+import { SiteHeader } from "@/components/site-header";
+import { IconFolder, IconSettings, IconDatabase } from "@tabler/icons-react";
+
+/**
+ * Shared app shell for the `/f/:id` file routes (pdf + image). Owns the
+ * sidebar, the editable title header, workspace nav, and the not-found
+ * redirect. The Yorkie provider (if any) is supplied by the caller wrapping
+ * this shell — image documents have none.
+ */
+export function FileShell({
+  documentId,
+  headerActions,
+  children,
+}: {
+  documentId: string;
+  headerActions: ReactNode;
+  children: ReactNode;
+}) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data: documentData, isError: isDocumentError } = useQuery({
+    queryKey: ["document", documentId],
+    queryFn: () => fetchDocument(documentId),
+    retry: false,
+  });
+
+  useEffect(() => {
+    document.title = documentData?.title
+      ? `${documentData.title} — Wafflebase`
+      : "Wafflebase";
+  }, [documentData?.title]);
+
+  const { data: workspaces = [] } = useQuery<Workspace[]>({
+    queryKey: ["workspaces"],
+    queryFn: fetchWorkspaces,
+  });
+
+  const currentWorkspace = workspaces.find(
+    (w) => w.id === documentData?.workspaceId,
+  );
+  const workspaceSlug = currentWorkspace?.slug;
+  const fallbackSlug = workspaceSlug ?? workspaces[0]?.slug;
+
+  useEffect(() => {
+    if (isDocumentError) {
+      toast.error("Document not found");
+      navigate(fallbackSlug ? `/w/${fallbackSlug}` : "/documents", {
+        replace: true,
+      });
+    }
+  }, [isDocumentError, navigate, fallbackSlug]);
+
+  const items = useMemo(() => {
+    const base = workspaceSlug
+      ? {
+          docs: `/w/${workspaceSlug}`,
+          data: `/w/${workspaceSlug}/datasources`,
+          settings: `/w/${workspaceSlug}/settings`,
+        }
+      : { docs: "/documents", data: "/datasources", settings: "/settings" };
+    return {
+      main: [
+        { title: "Documents", url: base.docs, icon: IconFolder },
+        { title: "Data Sources", url: base.data, icon: IconDatabase },
+        { title: "Settings", url: base.settings, icon: IconSettings },
+      ],
+      secondary: [],
+    };
+  }, [workspaceSlug]);
+
+  const handleWorkspaceChange = useCallback(
+    (slug: string) => navigate(`/w/${slug}`),
+    [navigate],
+  );
+
+  const handleRenameDocument = useCallback(
+    async (newTitle: string) => {
+      try {
+        await renameDocument(documentId, newTitle);
+        queryClient.invalidateQueries({ queryKey: ["document", documentId] });
+        queryClient.invalidateQueries({ queryKey: ["documents"] });
+      } catch {
+        toast.error("Failed to rename document");
+      }
+    },
+    [documentId, queryClient],
+  );
+
+  return (
+    <SidebarProvider>
+      <AppSidebar
+        variant="inset"
+        items={items}
+        workspaces={workspaces}
+        currentWorkspace={currentWorkspace}
+        onWorkspaceChange={handleWorkspaceChange}
+      />
+      <SidebarInset>
+        <SiteHeader
+          title={documentData?.title ?? "Loading..."}
+          editable
+          onRename={handleRenameDocument}
+        >
+          <div className="flex items-center gap-2">{headerActions}</div>
+        </SiteHeader>
+        <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
+          {children}
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}
+```
+
+- [ ] **Step 2: Write the image viewer with prev/next**
+
+Create `packages/frontend/src/app/files/image-viewer.tsx`:
+
+```tsx
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronLeft, ChevronRight, Download, ZoomIn, ZoomOut } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { fetchWithAuth } from "@/api/auth";
+import { fetchDocument, fetchDocuments } from "@/api/documents";
+import { fileUrl } from "@/api/files";
+
+const ZOOM_STEP = 0.25;
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 5;
+
+export function ImageViewer({ documentId }: { documentId: string }) {
+  const navigate = useNavigate();
+  const [src, setSrc] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+  const [zoom, setZoom] = useState(1);
+  const downloadName = useRef<string>("image");
+
+  // Load the current image bytes via the authed endpoint → object URL.
+  useEffect(() => {
+    let objectUrl: string | null = null;
+    let cancelled = false;
+    setSrc(null);
+    setError(false);
+    setZoom(1);
+    (async () => {
+      try {
+        const res = await fetchWithAuth(fileUrl(documentId));
+        if (!res.ok) throw new Error(String(res.status));
+        const blob = await res.blob();
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
+      } catch {
+        if (!cancelled) setError(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [documentId]);
+
+  const { data: current } = useQuery({
+    queryKey: ["document", documentId],
+    queryFn: () => fetchDocument(documentId),
+    retry: false,
+  });
+  useEffect(() => {
+    if (current?.title) downloadName.current = current.title;
+  }, [current?.title]);
+
+  // Sibling images in the same workspace, stably ordered, for prev/next.
+  const { data: allDocs = [] } = useQuery({
+    queryKey: ["documents"],
+    queryFn: fetchDocuments,
+  });
+  const siblings = useMemo(() => {
+    if (!current) return [] as string[];
+    return allDocs
+      .filter(
+        (d) => d.type === "image" && d.workspaceId === current.workspaceId,
+      )
+      .sort((a, b) =>
+        a.title === b.title
+          ? String(a.id).localeCompare(String(b.id))
+          : a.title.localeCompare(b.title),
+      )
+      .map((d) => String(d.id));
+  }, [allDocs, current]);
+
+  const index = siblings.indexOf(documentId);
+  const prevId = index > 0 ? siblings[index - 1] : undefined;
+  const nextId =
+    index >= 0 && index < siblings.length - 1 ? siblings[index + 1] : undefined;
+
+  const go = useCallback(
+    (id?: string) => id && navigate(`/f/${id}`),
+    [navigate],
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") go(prevId);
+      else if (e.key === "ArrowRight") go(nextId);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [go, prevId, nextId]);
+
+  const download = useCallback(() => {
+    if (!src) return;
+    const a = document.createElement("a");
+    a.href = src;
+    a.download = downloadName.current;
+    a.click();
+  }, [src]);
+
+  return (
+    <div className="relative flex flex-1 items-center justify-center overflow-auto bg-muted/30">
+      {error ? (
+        <p className="text-sm text-muted-foreground">Failed to load image.</p>
+      ) : src ? (
+        <img
+          src={src}
+          alt={downloadName.current}
+          style={{ transform: `scale(${zoom})` }}
+          className="max-h-full max-w-full object-contain transition-transform"
+        />
+      ) : (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      )}
+
+      {prevId && (
+        <Button
+          variant="secondary"
+          size="icon"
+          aria-label="Previous image"
+          className="absolute left-4 top-1/2 -translate-y-1/2"
+          onClick={() => go(prevId)}
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </Button>
+      )}
+      {nextId && (
+        <Button
+          variant="secondary"
+          size="icon"
+          aria-label="Next image"
+          className="absolute right-4 top-1/2 -translate-y-1/2"
+          onClick={() => go(nextId)}
+        >
+          <ChevronRight className="h-5 w-5" />
+        </Button>
+      )}
+
+      <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background p-1 shadow-sm">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Zoom out"
+          onClick={() => setZoom((z) => Math.max(MIN_ZOOM, z - ZOOM_STEP))}
+        >
+          <ZoomOut className="h-4 w-4" />
+        </Button>
+        <span className="w-12 text-center text-xs tabular-nums">
+          {Math.round(zoom * 100)}%
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Zoom in"
+          onClick={() => setZoom((z) => Math.min(MAX_ZOOM, z + ZOOM_STEP))}
+        >
+          <ZoomIn className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Download image"
+          onClick={download}
+        >
+          <Download className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Dispatch by type in FileDetail**
+
+Rewrite `packages/frontend/src/app/files/file-detail.tsx` so `FileLayout` becomes two thin layouts selected by `doc.type`, both built on `FileShell`. The PDF layout keeps the `PdfCollabProvider`; the image layout has none:
+
+```tsx
+import { Navigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { fetchMe } from "@/api/auth";
+import { fetchDocument } from "@/api/documents";
+import { Loader } from "@/components/loader";
+import { ShareDialog } from "@/components/share-dialog";
+import { UserPresence } from "@/components/user-presence";
+import type { User } from "@/types/users";
+import { FileShell } from "./file-shell";
+import { ImageViewer } from "./image-viewer";
+import {
+  PdfCollabProvider,
+  PdfHeaderActions,
+  PdfCollabBody,
+} from "./pdf-collab";
+
+function PdfFileLayout({
+  documentId,
+  currentUser,
+}: {
+  documentId: string;
+  currentUser: User;
+}) {
+  return (
+    <PdfCollabProvider
+      documentId={documentId}
+      readOnly={false}
+      presenceUser={{
+        userId: String(currentUser.id),
+        username: currentUser.username,
+        email: currentUser.email,
+        photo: currentUser.photo,
+      }}
+    >
+      <FileShell
+        documentId={documentId}
+        headerActions={
+          <>
+            <PdfHeaderActions />
+            <ShareDialog documentId={documentId} />
+            <UserPresence />
+          </>
+        }
+      >
+        <PdfCollabBody />
+      </FileShell>
+    </PdfCollabProvider>
+  );
+}
+
+function ImageFileLayout({ documentId }: { documentId: string }) {
+  return (
+    <FileShell
+      documentId={documentId}
+      headerActions={<ShareDialog documentId={documentId} />}
+    >
+      <ImageViewer documentId={documentId} />
+    </FileShell>
+  );
+}
+
+/**
+ * FileDetail is the `/f/:id` route shared by static blob documents. It
+ * auth-gates on the current user, resolves the document `type`, then mounts
+ * the matching layout: pdf → collaborative PDF (comments + presence over the
+ * `pdf-<id>` Yorkie doc); image → a plain viewer with no Yorkie attachment.
+ */
+export function FileDetail() {
+  const { id } = useParams();
+
+  const {
+    data: currentUser,
+    isLoading: userLoading,
+    isError: userError,
+  } = useQuery({
+    queryKey: ["me"],
+    queryFn: fetchMe,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const { data: documentData, isLoading: docLoading } = useQuery({
+    queryKey: ["document", id],
+    queryFn: () => fetchDocument(id!),
+    retry: false,
+    enabled: !!id,
+  });
+
+  if (userLoading || docLoading) return <Loader />;
+  if (userError || !currentUser) return <Navigate to="/login" replace />;
+
+  if (documentData?.type === "image") {
+    return <ImageFileLayout documentId={id!} />;
+  }
+  return <PdfFileLayout documentId={id!} currentUser={currentUser} />;
+}
+
+export default FileDetail;
+```
+
+- [ ] **Step 4: Typecheck + lint + test**
+
+Run: `pnpm --filter @wafflebase/frontend lint && pnpm --filter @wafflebase/frontend test`
+Expected: PASS. (No unit test drives the viewer; it is covered by manual smoke below. If the repo has a route smoke test that mounts `FileDetail`, ensure it still renders the PDF path.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/app/files/
+git commit -m "Add the image viewer with workspace prev/next navigation"
+```
+
+---
+
+## Task 6: Full verify + manual smoke + finish
+
+- [ ] **Step 1: Run the full fast gate**
+
+Run: `pnpm verify:fast`
+Expected: PASS (lint + all unit suites across packages).
+
+- [ ] **Step 2: Manual smoke in `pnpm dev`**
+
+Prereq: `docker compose up -d` (Postgres + Yorkie + MinIO). Then `pnpm dev`.
+
+- Drop a mixed batch onto the documents list: a `.png`, a `.pdf`, an `.xlsx`, and a `.zip`. Confirm: png + pdf + xlsx land as their types, `.zip` is skipped with a reason in the upload panel.
+- Confirm the list shows an inline thumbnail for the image row (scroll to force lazy load) and the "Images" filter chip works.
+- Open the image (`/f/:id`): it renders, zoom in/out and download work, arrow keys ←/→ move between the workspace's images, and the chevrons hide at the ends.
+- Confirm a PDF still opens with comments/presence (no regression from the FileDetail refactor).
+- Try uploading a > 25 MB image → the upload panel row shows an error with the size reason; other items continue.
+
+- [ ] **Step 3: Self-review the branch diff**
+
+Dispatch a code review over the full branch diff (`/code-review` or `superpowers:requesting-code-review`). Apply blocking findings; note non-blocking ones as known limitations.
+
+- [ ] **Step 4: Capture lessons + index**
+
+Create `docs/tasks/active/20260719-image-viewer-lessons.md` with anything non-obvious found during implementation (e.g. the `.png`-as-skipped test coupling, the FileDetail provider-before-type ordering). Then:
+
+```bash
+pnpm tasks:index
+git add docs/tasks/
+git commit -m "Add image-viewer task lessons"
+```
+
+- [ ] **Step 5: Rebase, push, open PR**
+
+```bash
+git fetch && git rebase origin/main
+git push -u origin image-documents
+```
+Open a PR titled `Add image documents (upload, viewer, thumbnails)` with a Summary + Test plan body. After merge, `pnpm tasks:archive && pnpm tasks:index`.
+
+---
+
+## Self-Review (author check against `docs/design/image-viewer.md`)
+
+- **Data model** (image type, reuse `fileId`, widen `assertFileIdAllowed`, reserve `image-`) → Task 2. ✅
+- **Storage & serving** (MIME_TO_EXT, per-category cap, id pattern, allow-list; serving unchanged) → Task 1. ✅
+- **Upload flow** (classify, `uploadFile`, queue branch, `getDocumentPath`, Upload Image menu, TYPE_META) → Tasks 3 + 4. ✅
+- **Viewer** (`/f/:id` dispatch, `ImageViewer` fetch→objectURL→`<img>`, fit/zoom/download, prev/next + keyboard) → Task 5. ✅
+- **List thumbnails** (D1, IntersectionObserver lazy, client downscale, icon fallback) → Task 4. ✅
+- **Non-goals** honored: no `image-<id>` Yorkie doc, no gallery/grid view, no server thumbnails, no SVG/HEIC. ✅
+- **Regression guard**: existing `.png`-as-skipped tests updated (Task 3, Step 10). ✅
+- Type consistency: `uploadFile`/`fileUrl` names used identically in Tasks 3 & 5; `assertFileIdAllowed(type, fileId)` signature identical in Task 2 def and controller call.
+```

--- a/packages/backend/src/document/document-file-id.util.spec.ts
+++ b/packages/backend/src/document/document-file-id.util.spec.ts
@@ -1,0 +1,21 @@
+import { BadRequestException } from '@nestjs/common';
+import { assertFileIdAllowed } from './document-file-id.util';
+
+describe('assertFileIdAllowed', () => {
+  it('allows a fileId on pdf and image documents', () => {
+    expect(() => assertFileIdAllowed('pdf', 'blob.pdf')).not.toThrow();
+    expect(() => assertFileIdAllowed('image', 'blob.png')).not.toThrow();
+  });
+
+  it('rejects a fileId on non-blob types', () => {
+    for (const type of ['sheet', 'doc', 'slides', 'note', undefined]) {
+      expect(() => assertFileIdAllowed(type, 'blob.png')).toThrow(
+        BadRequestException,
+      );
+    }
+  });
+
+  it('is a no-op when no fileId is provided', () => {
+    expect(() => assertFileIdAllowed('sheet', undefined)).not.toThrow();
+  });
+});

--- a/packages/backend/src/document/document-file-id.util.ts
+++ b/packages/backend/src/document/document-file-id.util.ts
@@ -1,0 +1,17 @@
+import { BadRequestException } from '@nestjs/common';
+
+/** Types whose documents may carry a stored-blob `fileId`. */
+const FILE_ID_TYPES = new Set(['pdf', 'image']);
+
+/**
+ * Contract guard: only pdf/image documents reference a stored blob. Reject a
+ * `fileId` on any other type so the coupling can't silently loosen.
+ */
+export function assertFileIdAllowed(
+  type: string | undefined,
+  fileId: string | undefined,
+): void {
+  if (fileId && !FILE_ID_TYPES.has(type ?? 'sheet')) {
+    throw new BadRequestException('fileId is only allowed for pdf/image documents');
+  }
+}

--- a/packages/backend/src/document/document.controller.ts
+++ b/packages/backend/src/document/document.controller.ts
@@ -1,7 +1,6 @@
 import {
   Req,
   Body,
-  BadRequestException,
   Controller,
   Delete,
   ForbiddenException,
@@ -30,6 +29,7 @@ import { yorkieDocKey } from '../yorkie/yorkie-doc-key';
 import { FileService } from '../file/file.service';
 import { VALID_FILE_ID_PATTERN } from '../file/file.constants';
 import { isDocumentManager } from './document-access';
+import { assertFileIdAllowed } from './document-file-id.util';
 
 type DocumentListItem = Omit<DocumentWithAuthor, 'updatedAt'> & {
   editors?: PresenceUser[];
@@ -100,17 +100,6 @@ export class DocumentController {
     return isDocumentManager(member.role, doc.authorID, userId);
   }
 
-  /**
-   * Phase-1 contract: only PDF documents carry a `fileId`. Reject a `fileId`
-   * on any other type (including the defaulted `sheet`) so blob references
-   * can't be attached to editor documents.
-   */
-  private assertFileIdAllowed(type: string | undefined, fileId?: string): void {
-    if (fileId && (type ?? 'sheet') !== 'pdf') {
-      throw new BadRequestException('fileId is only allowed for pdf documents');
-    }
-  }
-
   // --- Workspace-scoped endpoints ---
 
   @Post('workspaces/:workspaceId/documents')
@@ -123,7 +112,7 @@ export class DocumentController {
     const workspaceId =
       await this.workspaceService.resolveId(workspaceIdOrSlug);
     await this.workspaceService.assertMember(workspaceId, userId);
-    this.assertFileIdAllowed(body.type, body.fileId);
+    assertFileIdAllowed(body.type, body.fileId);
     return this.documentService.createDocument({
       title: body.title,
       type: body.type ?? 'sheet',
@@ -191,7 +180,7 @@ export class DocumentController {
   ): Promise<DocumentModel> {
     const userId = Number(req.user.id);
     await this.workspaceService.assertMember(body.workspaceId, userId);
-    this.assertFileIdAllowed(body.type, body.fileId);
+    assertFileIdAllowed(body.type, body.fileId);
     return this.documentService.createDocument({
       title: body.title,
       type: body.type ?? 'sheet',

--- a/packages/backend/src/document/document.dto.ts
+++ b/packages/backend/src/document/document.dto.ts
@@ -8,7 +8,7 @@ import {
 } from 'class-validator';
 import { VALID_FILE_ID_PATTERN } from '../file/file.constants';
 
-const DOCUMENT_TYPES = ['sheet', 'doc', 'slides', 'pdf', 'note'] as const;
+const DOCUMENT_TYPES = ['sheet', 'doc', 'slides', 'pdf', 'note', 'image'] as const;
 export type DocumentType = (typeof DOCUMENT_TYPES)[number];
 
 export class CreateDocumentDto {

--- a/packages/backend/src/file/file.config.ts
+++ b/packages/backend/src/file/file.config.ts
@@ -15,5 +15,11 @@ export const fileConfig = registerAs('file', () => ({
   accessKey: process.env.FILE_STORAGE_ACCESS_KEY || (isDev ? 'minioadmin' : ''),
   secretKey: process.env.FILE_STORAGE_SECRET_KEY || (isDev ? 'minioadmin' : ''),
   maxFileSizeBytes: MAX_PDF_UPLOAD_BYTES,
-  allowedMimeTypes: ['application/pdf'],
+  allowedMimeTypes: [
+    'application/pdf',
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+  ],
 }));

--- a/packages/backend/src/file/file.constants.ts
+++ b/packages/backend/src/file/file.constants.ts
@@ -1,5 +1,8 @@
 export const VALID_FILE_ID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.pdf$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.(pdf|png|jpe?g|gif|webp)$/i;
 
 /** Max PDF upload size (50 MB). Shared by the Multer limit and FileService. */
 export const MAX_PDF_UPLOAD_BYTES = 50 * 1024 * 1024;
+
+/** Max image upload size (25 MB). Enforced per-category in FileService. */
+export const MAX_IMAGE_UPLOAD_BYTES = 25 * 1024 * 1024;

--- a/packages/backend/src/file/file.controller.ts
+++ b/packages/backend/src/file/file.controller.ts
@@ -7,11 +7,17 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { Throttle } from '@nestjs/throttler';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { FileService } from './file.service';
 import { MAX_PDF_UPLOAD_BYTES } from './file.constants';
 
+// Bulk uploads (dropping many files at once) burst past the global 120/min
+// default; match the inline-image routes' raised bucket.
+const FILE_THROTTLE = { default: { limit: 600, ttl: 60_000 } } as const;
+
 @Controller('files')
+@Throttle(FILE_THROTTLE)
 export class FileController {
   constructor(private readonly fileService: FileService) {}
 

--- a/packages/backend/src/file/file.service.spec.ts
+++ b/packages/backend/src/file/file.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { FileService } from './file.service';
+import { MAX_IMAGE_UPLOAD_BYTES } from './file.constants';
 
 function makeService(): FileService {
   const values: Record<string, unknown> = {
@@ -10,17 +11,23 @@ function makeService(): FileService {
     'file.secretKey': 'minioadmin',
     'file.bucket': 'wafflebase-files',
     'file.maxFileSizeBytes': 50 * 1024 * 1024,
-    'file.allowedMimeTypes': ['application/pdf'],
+    'file.allowedMimeTypes': [
+      'application/pdf',
+      'image/png',
+      'image/jpeg',
+      'image/gif',
+      'image/webp',
+    ],
   };
   const config = { get: (k: string) => values[k] } as unknown as ConfigService;
   return new FileService(config);
 }
 
 describe('FileService.upload validation', () => {
-  it('rejects a non-pdf mime type', async () => {
+  it('rejects a disallowed mime type', async () => {
     const svc = makeService();
     await expect(
-      svc.upload(Buffer.from('x'), 'image/png'),
+      svc.upload(Buffer.from('x'), 'application/zip'),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
@@ -30,5 +37,22 @@ describe('FileService.upload validation', () => {
     await expect(svc.upload(tooBig, 'application/pdf')).rejects.toBeInstanceOf(
       BadRequestException,
     );
+  });
+});
+
+describe('FileService.upload image support', () => {
+  it('rejects an image over the 25 MB cap even though Multer allows 50 MB', async () => {
+    const svc = makeService();
+    const tooBig = Buffer.alloc(MAX_IMAGE_UPLOAD_BYTES + 1);
+    await expect(svc.upload(tooBig, 'image/png')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('rejects an unknown mime type not in the allow-list', async () => {
+    const svc = makeService();
+    await expect(
+      svc.upload(Buffer.from('x'), 'image/svg+xml'),
+    ).rejects.toBeInstanceOf(BadRequestException);
   });
 });

--- a/packages/backend/src/file/file.service.ts
+++ b/packages/backend/src/file/file.service.ts
@@ -9,9 +9,14 @@ import {
   HeadBucketCommand,
 } from '@aws-sdk/client-s3';
 import { randomUUID } from 'crypto';
+import { MAX_IMAGE_UPLOAD_BYTES } from './file.constants';
 
 const MIME_TO_EXT: Record<string, string> = {
   'application/pdf': 'pdf',
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
 };
 
 @Injectable()
@@ -57,9 +62,14 @@ export class FileService implements OnModuleInit {
     if (!this.allowedMimeTypes.includes(mimeType)) {
       throw new BadRequestException(`Unsupported file type: ${mimeType}`);
     }
-    if (file.length > this.maxFileSize) {
+    // Images get a tighter cap than the Multer ceiling (which admits the
+    // largest allowed upload, i.e. a 50 MB PDF).
+    const cap = mimeType.startsWith('image/')
+      ? MAX_IMAGE_UPLOAD_BYTES
+      : this.maxFileSize;
+    if (file.length > cap) {
       throw new BadRequestException(
-        `File too large (max ${this.maxFileSize / 1024 / 1024} MB)`,
+        `File too large (max ${cap / 1024 / 1024} MB)`,
       );
     }
     const ext = MIME_TO_EXT[mimeType];

--- a/packages/backend/src/yorkie/yorkie-doc-key.spec.ts
+++ b/packages/backend/src/yorkie/yorkie-doc-key.spec.ts
@@ -4,57 +4,17 @@ import {
   parseYorkieDocKey,
 } from './yorkie-doc-key';
 
-describe('yorkie-doc-key', () => {
-  it('maps each known type to its prefix', () => {
-    expect(yorkieDocKeyPrefix('sheet')).toBe('sheet-');
-    expect(yorkieDocKeyPrefix('doc')).toBe('doc-');
-    expect(yorkieDocKeyPrefix('slides')).toBe('slides-');
+describe('yorkie-doc-key image prefix', () => {
+  it('maps image to the image- prefix', () => {
+    expect(yorkieDocKeyPrefix('image')).toBe('image-');
+    expect(yorkieDocKey('image', 'abc')).toBe('image-abc');
   });
 
-  it('reserves the pdf prefix (Phase 1: registered but unused)', () => {
-    expect(yorkieDocKeyPrefix('pdf')).toBe('pdf-');
-    expect(yorkieDocKey('pdf', 'abc')).toBe('pdf-abc');
+  it('round-trips an image key', () => {
+    expect(parseYorkieDocKey('image-abc')).toEqual({ type: 'image', id: 'abc' });
   });
 
-  it('throws for unknown types', () => {
-    expect(() => yorkieDocKeyPrefix('bogus')).toThrow('Unknown document type');
-  });
-});
-
-describe('parseYorkieDocKey', () => {
-  it('round-trips every known type', () => {
-    for (const type of ['sheet', 'doc', 'slides', 'pdf'] as const) {
-      const id = 'a1b2-c3d4';
-      expect(parseYorkieDocKey(yorkieDocKey(type, id))).toEqual({ type, id });
-    }
-  });
-
-  it('keeps an id that itself contains a hyphen intact', () => {
-    // Document ids are UUIDs (hyphen-rich); only the first prefix is stripped.
-    expect(parseYorkieDocKey('slides-dc73f0ca-f267-441c-8ecb-8ed975515cf8')).toEqual(
-      { type: 'slides', id: 'dc73f0ca-f267-441c-8ecb-8ed975515cf8' },
-    );
-  });
-
-  it('returns null for an unknown prefix', () => {
-    expect(parseYorkieDocKey('unknown-123')).toBeNull();
-  });
-
-  it('returns null for a bare prefix with no id', () => {
-    expect(parseYorkieDocKey('sheet-')).toBeNull();
-  });
-
-  it('returns null for an empty string', () => {
-    expect(parseYorkieDocKey('')).toBeNull();
-  });
-});
-
-describe('yorkie-doc-key notes', () => {
-  it('builds a note- prefixed key', () => {
-    expect(yorkieDocKey('note', 'abc')).toBe('note-abc');
-    expect(yorkieDocKeyPrefix('note')).toBe('note-');
-  });
-  it('parses a note- key back to type note', () => {
-    expect(parseYorkieDocKey('note-abc')).toEqual({ type: 'note', id: 'abc' });
+  it('still throws on an unknown type', () => {
+    expect(() => yorkieDocKeyPrefix('bogus')).toThrow();
   });
 });

--- a/packages/backend/src/yorkie/yorkie-doc-key.spec.ts
+++ b/packages/backend/src/yorkie/yorkie-doc-key.spec.ts
@@ -4,6 +4,61 @@ import {
   parseYorkieDocKey,
 } from './yorkie-doc-key';
 
+describe('yorkie-doc-key', () => {
+  it('maps each known type to its prefix', () => {
+    expect(yorkieDocKeyPrefix('sheet')).toBe('sheet-');
+    expect(yorkieDocKeyPrefix('doc')).toBe('doc-');
+    expect(yorkieDocKeyPrefix('slides')).toBe('slides-');
+  });
+
+  it('reserves the pdf prefix (Phase 1: registered but unused)', () => {
+    expect(yorkieDocKeyPrefix('pdf')).toBe('pdf-');
+    expect(yorkieDocKey('pdf', 'abc')).toBe('pdf-abc');
+  });
+
+  it('throws for unknown types', () => {
+    expect(() => yorkieDocKeyPrefix('bogus')).toThrow('Unknown document type');
+  });
+});
+
+describe('parseYorkieDocKey', () => {
+  it('round-trips every known type', () => {
+    for (const type of ['sheet', 'doc', 'slides', 'pdf'] as const) {
+      const id = 'a1b2-c3d4';
+      expect(parseYorkieDocKey(yorkieDocKey(type, id))).toEqual({ type, id });
+    }
+  });
+
+  it('keeps an id that itself contains a hyphen intact', () => {
+    // Document ids are UUIDs (hyphen-rich); only the first prefix is stripped.
+    expect(parseYorkieDocKey('slides-dc73f0ca-f267-441c-8ecb-8ed975515cf8')).toEqual(
+      { type: 'slides', id: 'dc73f0ca-f267-441c-8ecb-8ed975515cf8' },
+    );
+  });
+
+  it('returns null for an unknown prefix', () => {
+    expect(parseYorkieDocKey('unknown-123')).toBeNull();
+  });
+
+  it('returns null for a bare prefix with no id', () => {
+    expect(parseYorkieDocKey('sheet-')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseYorkieDocKey('')).toBeNull();
+  });
+});
+
+describe('yorkie-doc-key notes', () => {
+  it('builds a note- prefixed key', () => {
+    expect(yorkieDocKey('note', 'abc')).toBe('note-abc');
+    expect(yorkieDocKeyPrefix('note')).toBe('note-');
+  });
+  it('parses a note- key back to type note', () => {
+    expect(parseYorkieDocKey('note-abc')).toEqual({ type: 'note', id: 'abc' });
+  });
+});
+
 describe('yorkie-doc-key image prefix', () => {
   it('maps image to the image- prefix', () => {
     expect(yorkieDocKeyPrefix('image')).toBe('image-');

--- a/packages/backend/src/yorkie/yorkie-doc-key.spec.ts
+++ b/packages/backend/src/yorkie/yorkie-doc-key.spec.ts
@@ -68,8 +68,4 @@ describe('yorkie-doc-key image prefix', () => {
   it('round-trips an image key', () => {
     expect(parseYorkieDocKey('image-abc')).toEqual({ type: 'image', id: 'abc' });
   });
-
-  it('still throws on an unknown type', () => {
-    expect(() => yorkieDocKeyPrefix('bogus')).toThrow();
-  });
 });

--- a/packages/backend/src/yorkie/yorkie-doc-key.ts
+++ b/packages/backend/src/yorkie/yorkie-doc-key.ts
@@ -9,7 +9,8 @@
  * mistake surfaces at request time instead of silently falling through to
  * a wrong key.
  */
-export type DocumentTypeLike = 'sheet' | 'doc' | 'slides' | 'pdf' | 'note';
+export type DocumentTypeLike =
+  | 'sheet' | 'doc' | 'slides' | 'pdf' | 'note' | 'image';
 
 export const YORKIE_DOC_KEY_PREFIXES = {
   sheet: 'sheet-',
@@ -17,6 +18,7 @@ export const YORKIE_DOC_KEY_PREFIXES = {
   slides: 'slides-',
   pdf: 'pdf-',
   note: 'note-',
+  image: 'image-',
 } as const;
 
 export function yorkieDocKeyPrefix(type: string): string {
@@ -31,6 +33,8 @@ export function yorkieDocKeyPrefix(type: string): string {
       return YORKIE_DOC_KEY_PREFIXES.pdf;
     case 'note':
       return YORKIE_DOC_KEY_PREFIXES.note;
+    case 'image':
+      return YORKIE_DOC_KEY_PREFIXES.image;
     default:
       throw new Error(`Unknown document type: ${type}`);
   }

--- a/packages/frontend/src/api/files.ts
+++ b/packages/frontend/src/api/files.ts
@@ -1,4 +1,5 @@
 import { fetchWithAuth } from "./auth";
+import { assertOk } from "./http-error";
 
 const BACKEND_BASE = import.meta.env.VITE_BACKEND_API_URL ?? "";
 
@@ -10,9 +11,7 @@ export async function uploadFile(file: File): Promise<{ id: string }> {
     method: "POST",
     body: formData,
   });
-  if (!res.ok) {
-    throw new Error(`File upload failed: ${res.status} ${res.statusText}`);
-  }
+  await assertOk(res, "File upload failed");
   return (await res.json()) as { id: string };
 }
 

--- a/packages/frontend/src/api/files.ts
+++ b/packages/frontend/src/api/files.ts
@@ -2,8 +2,8 @@ import { fetchWithAuth } from "./auth";
 
 const BACKEND_BASE = import.meta.env.VITE_BACKEND_API_URL ?? "";
 
-/** Upload a PDF blob; returns the stored blob id. */
-export async function uploadPdf(file: File): Promise<{ id: string }> {
+/** Upload a blob (pdf or image); returns the stored blob id. */
+export async function uploadFile(file: File): Promise<{ id: string }> {
   const formData = new FormData();
   formData.append("file", file, file.name);
   const res = await fetchWithAuth(`${BACKEND_BASE}/files`, {
@@ -11,13 +11,13 @@ export async function uploadPdf(file: File): Promise<{ id: string }> {
     body: formData,
   });
   if (!res.ok) {
-    throw new Error(`PDF upload failed: ${res.status} ${res.statusText}`);
+    throw new Error(`File upload failed: ${res.status} ${res.statusText}`);
   }
   return (await res.json()) as { id: string };
 }
 
-/** Document-scoped, permission-gated URL that streams the stored PDF. */
-export function pdfFileUrl(documentId: string, token?: string): string {
+/** Document-scoped, permission-gated URL that streams the stored blob. */
+export function fileUrl(documentId: string, token?: string): string {
   const base = `${BACKEND_BASE}/documents/${documentId}/file`;
   return token ? `${base}?token=${encodeURIComponent(token)}` : base;
 }

--- a/packages/frontend/src/api/http-error.ts
+++ b/packages/frontend/src/api/http-error.ts
@@ -1,3 +1,25 @@
+export class HttpError extends Error {
+  readonly status: number;
+  readonly retryAfterMs?: number;
+  constructor(message: string, status: number, retryAfterMs?: number) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/** Parse a `Retry-After` header (delta-seconds or HTTP-date) to ms. */
+function parseRetryAfterMs(response: Response): number | undefined {
+  const raw = response.headers.get("retry-after");
+  if (!raw) return undefined;
+  const secs = Number(raw);
+  if (Number.isFinite(secs)) return Math.max(0, secs * 1000);
+  const when = Date.parse(raw);
+  if (!Number.isNaN(when)) return Math.max(0, when - Date.now());
+  return undefined;
+}
+
 type StatusMessages = Record<number, string>;
 
 type AssertOkOptions = {
@@ -88,11 +110,16 @@ export async function assertOk(
     return;
   }
 
+  const retryAfterMs = parseRetryAfterMs(response);
   const override = options.statusMessages?.[response.status];
   if (override) {
-    throw new Error(override);
+    throw new HttpError(override, response.status, retryAfterMs);
   }
 
   const bodyMessage = await readResponseErrorMessage(response);
-  throw new Error(bodyMessage || fallbackMessage);
+  throw new HttpError(
+    bodyMessage || fallbackMessage,
+    response.status,
+    retryAfterMs,
+  );
 }

--- a/packages/frontend/src/api/http-error.ts
+++ b/packages/frontend/src/api/http-error.ts
@@ -10,7 +10,7 @@ export class HttpError extends Error {
 }
 
 /** Parse a `Retry-After` header (delta-seconds or HTTP-date) to ms. */
-function parseRetryAfterMs(response: Response): number | undefined {
+export function parseRetryAfterMs(response: Response): number | undefined {
   const raw = response.headers.get("retry-after");
   if (!raw) return undefined;
   const secs = Number(raw);

--- a/packages/frontend/src/app/documents/__tests__/upload-kind.test.ts
+++ b/packages/frontend/src/app/documents/__tests__/upload-kind.test.ts
@@ -8,9 +8,16 @@ describe("classifyUploadKind", () => {
     expect(classifyUploadKind("deck.pptx")).toBe("slides");
     expect(classifyUploadKind("report.pdf")).toBe("pdf");
   });
+  it("maps image extensions to image", () => {
+    expect(classifyUploadKind("photo.png")).toBe("image");
+    expect(classifyUploadKind("pic.JPG")).toBe("image");
+    expect(classifyUploadKind("pic.jpeg")).toBe("image");
+    expect(classifyUploadKind("anim.gif")).toBe("image");
+    expect(classifyUploadKind("shot.webp")).toBe("image");
+  });
   it("returns null for unsupported types", () => {
-    expect(classifyUploadKind("photo.png")).toBeNull();
     expect(classifyUploadKind("archive.zip")).toBeNull();
+    expect(classifyUploadKind("vector.svg")).toBeNull();
     expect(classifyUploadKind("noext")).toBeNull();
   });
 });

--- a/packages/frontend/src/app/documents/__tests__/upload-panel.test.tsx
+++ b/packages/frontend/src/app/documents/__tests__/upload-panel.test.tsx
@@ -14,13 +14,13 @@ describe("UploadPanel", () => {
 
   it("shows a row per file with its status", () => {
     q.enqueue([new File([new Uint8Array([1])], "deck.pptx"),
-               new File([new Uint8Array([1])], "photo.png")]);
+               new File([new Uint8Array([1])], "archive.zip")]);
     render(<MemoryRouter><UploadPanel /></MemoryRouter>);
     // No @testing-library/jest-dom in this repo (not installed anywhere in
     // the monorepo) — getByText already throws if no match is found, so
     // toBeTruthy() gives the same assertion strength as toBeInTheDocument().
     expect(screen.getByText("deck.pptx")).toBeTruthy();
-    expect(screen.getByText("photo.png")).toBeTruthy();
+    expect(screen.getByText("archive.zip")).toBeTruthy();
     expect(screen.getByText(/unsupported/i)).toBeTruthy();
   });
 });

--- a/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
+++ b/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
@@ -21,7 +21,7 @@ describe("upload-queue worker", () => {
         report: { summary: () => "" },
         fileName: f.name,
       })),
-      uploadPdf: vi.fn(async () => ({ id: "file1" })),
+      uploadFile: vi.fn(async () => ({ id: "file1" })),
       createDoc: vi.fn(async (_ws, p) => ({
         id: "d" + p.title,
         title: p.title,
@@ -39,16 +39,43 @@ describe("upload-queue worker", () => {
     const snap = q.getSnapshot();
     expect(snap.find((i) => i.fileName === "a.xlsx")?.status).toBe("done");
     expect(snap.find((i) => i.fileName === "c.pdf")?.status).toBe("done");
-    expect(snap.find((i) => i.fileName === "b.png")?.status).toBe("skipped");
-    expect(deps.createDoc).toHaveBeenCalledTimes(2); // xlsx + pdf, not png
-    // Content is applied for the parsed sheet, never for the skipped png or
-    // the PDF (whose bytes are stored server-side at create time).
+    expect(snap.find((i) => i.fileName === "b.png")?.status).toBe("done");
+    // xlsx + png + pdf all create a document now.
+    expect(deps.createDoc).toHaveBeenCalledTimes(3);
+    // Content is applied only for the parsed sheet; the png and pdf store
+    // their bytes server-side at create time.
     expect(deps.applyContent).toHaveBeenCalledTimes(1);
     // docId = "d" + stripExt("a.xlsx") = "d" + "a" = "da"
     expect(deps.applyContent).toHaveBeenCalledWith(
       "da",
       expect.objectContaining({ type: "sheet" }),
     );
+  });
+
+  it("uploads an image blob and creates an image document", async () => {
+    const deps = {
+      importXlsx: vi.fn(),
+      importDocx: vi.fn(),
+      importPptxFile: vi.fn(),
+      uploadFile: vi.fn(async () => ({ id: "img-1" })),
+      createDoc: vi.fn(async (_ws, p) => ({
+        id: "d" + p.title,
+        title: p.title,
+        type: p.type,
+      })),
+      getDocumentPath: (d: { id: string }) => `/path/${d.id}`,
+      applyContent: vi.fn(async () => {}),
+    };
+    q.enqueue([file("cat.png")], "ws1");
+    q.startUploads(undefined, deps as never);
+    await flush();
+    await flush();
+    expect(deps.uploadFile).toHaveBeenCalledTimes(1);
+    expect(deps.createDoc).toHaveBeenCalledWith(
+      "ws1",
+      expect.objectContaining({ type: "image", fileId: "img-1" }),
+    );
+    expect(deps.applyContent).not.toHaveBeenCalled();
   });
 
   it("marks an item error when its importer throws and keeps others going", async () => {
@@ -61,7 +88,7 @@ describe("upload-queue worker", () => {
         fileName: f.name,
       })),
       importPptxFile: vi.fn(),
-      uploadPdf: vi.fn(),
+      uploadFile: vi.fn(),
       createDoc: vi.fn(async (_ws, p) => ({
         id: "d",
         title: p.title,
@@ -98,7 +125,7 @@ describe("upload-queue worker", () => {
       }),
       importDocx: vi.fn(),
       importPptxFile: vi.fn(),
-      uploadPdf: vi.fn(),
+      uploadFile: vi.fn(),
       createDoc: vi.fn(async (_ws, p) => ({
         id: "d" + p.title,
         title: p.title,
@@ -147,7 +174,7 @@ describe("upload-queue worker", () => {
       })),
       importDocx: vi.fn(),
       importPptxFile: vi.fn(),
-      uploadPdf: vi.fn(),
+      uploadFile: vi.fn(),
       createDoc: vi.fn(async (_ws, p) => ({
         id: "doc-" + p.title,
         title: p.title,
@@ -190,7 +217,7 @@ describe("upload-queue worker", () => {
       importXlsx: vi.fn(),
       importDocx: vi.fn(),
       importPptxFile: vi.fn(),
-      uploadPdf: vi.fn(async () => ({ id: "blob-1" })),
+      uploadFile: vi.fn(async () => ({ id: "blob-1" })),
       createDoc: vi.fn(async (_ws, p) => {
         createCalls++;
         if (createCalls === 1) throw new Error("create failed");
@@ -207,7 +234,7 @@ describe("upload-queue worker", () => {
     let snap = q.getSnapshot();
     let current = snap.find((i) => i.id === item.id);
     expect(current?.status).toBe("error");
-    expect(deps.uploadPdf).toHaveBeenCalledTimes(1);
+    expect(deps.uploadFile).toHaveBeenCalledTimes(1);
     expect(current?.fileId).toBe("blob-1"); // fileId persisted for resume
 
     q.retry(item.id);
@@ -219,7 +246,7 @@ describe("upload-queue worker", () => {
     expect(current?.status).toBe("done");
     // The blob was uploaded exactly once across the failure + retry; the
     // second attempt reused the persisted fileId instead of orphaning a copy.
-    expect(deps.uploadPdf).toHaveBeenCalledTimes(1);
+    expect(deps.uploadFile).toHaveBeenCalledTimes(1);
     expect(deps.createDoc).toHaveBeenCalledTimes(2);
   });
 
@@ -234,7 +261,7 @@ describe("upload-queue worker", () => {
         throw new Error("boom");
       }),
       importPptxFile: vi.fn(),
-      uploadPdf: vi.fn(),
+      uploadFile: vi.fn(),
       createDoc: vi.fn(async (_ws, p) => ({
         id: "d" + p.title,
         title: p.title,
@@ -265,7 +292,7 @@ describe("upload-queue worker", () => {
       })),
       importDocx: vi.fn(),
       importPptxFile: vi.fn(),
-      uploadPdf: vi.fn(),
+      uploadFile: vi.fn(),
       createDoc: vi.fn(async (_ws, p) => ({
         id: "doc-x",
         title: p.title,
@@ -309,7 +336,7 @@ describe("upload-queue worker", () => {
         report: { summary: () => "2 fallbacks applied." },
         fileName: f.name,
       })),
-      uploadPdf: vi.fn(),
+      uploadFile: vi.fn(),
       createDoc: vi.fn(async (_ws, p) => ({
         id: "d",
         title: p.title,

--- a/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
+++ b/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
@@ -112,6 +112,69 @@ describe("upload-queue worker", () => {
     expect(snap.find((i) => i.fileName === "cat.png")?.status).toBe("done");
   });
 
+  it("marks the item error after 429 retries are exhausted", async () => {
+    const rateLimited = Object.assign(new Error("Too Many Requests"), {
+      status: 429,
+    });
+    const deps = {
+      importXlsx: vi.fn(),
+      importDocx: vi.fn(),
+      importPptxFile: vi.fn(),
+      uploadFile: vi.fn(async () => {
+        throw rateLimited; // always 429
+      }),
+      createDoc: vi.fn(async (_ws, p) => ({
+        id: "d" + p.title,
+        title: p.title,
+        type: p.type,
+      })),
+      getDocumentPath: (d: { id: string }) => `/path/${d.id}`,
+      applyContent: vi.fn(async () => {}),
+      sleep: vi.fn(async () => {}),
+    };
+    q.enqueue([file("cat.png")], "ws1");
+    q.startUploads(undefined, deps as never);
+    // Flush enough microtask turns for all 6 backoff attempts to settle.
+    for (let i = 0; i < 10; i++) await flush();
+    const snap = q.getSnapshot();
+    expect(deps.sleep).toHaveBeenCalledTimes(6); // MAX_RATE_RETRIES
+    expect(deps.uploadFile).toHaveBeenCalledTimes(7); // initial + 6 retries
+    expect(snap.find((i) => i.fileName === "cat.png")?.status).toBe("error");
+  });
+
+  it("honors Retry-After (retryAfterMs) for the backoff delay", async () => {
+    const rateLimited = Object.assign(new Error("Too Many Requests"), {
+      status: 429,
+      retryAfterMs: 1234,
+    });
+    let calls = 0;
+    const deps = {
+      importXlsx: vi.fn(),
+      importDocx: vi.fn(),
+      importPptxFile: vi.fn(),
+      uploadFile: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) throw rateLimited;
+        return { id: "img-1" };
+      }),
+      createDoc: vi.fn(async (_ws, p) => ({
+        id: "d" + p.title,
+        title: p.title,
+        type: p.type,
+      })),
+      getDocumentPath: (d: { id: string }) => `/path/${d.id}`,
+      applyContent: vi.fn(async () => {}),
+      sleep: vi.fn(async () => {}),
+    };
+    q.enqueue([file("cat.png")], "ws1");
+    q.startUploads(undefined, deps as never);
+    for (let i = 0; i < 6; i++) await flush();
+    expect(deps.sleep).toHaveBeenCalledWith(1234); // header value, not exp fallback
+    expect(q.getSnapshot().find((i) => i.fileName === "cat.png")?.status).toBe(
+      "done",
+    );
+  });
+
   it("retries a 429 on createDoc without re-uploading the blob", async () => {
     const rateLimited = Object.assign(new Error("Too Many Requests"), {
       status: 429,

--- a/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
+++ b/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
@@ -78,6 +78,40 @@ describe("upload-queue worker", () => {
     expect(deps.applyContent).not.toHaveBeenCalled();
   });
 
+  it("retries a rate-limited (429) image upload with backoff", async () => {
+    const rateLimited = Object.assign(new Error("Too Many Requests"), {
+      status: 429,
+    });
+    let calls = 0;
+    const deps = {
+      importXlsx: vi.fn(),
+      importDocx: vi.fn(),
+      importPptxFile: vi.fn(),
+      uploadFile: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) throw rateLimited;
+        return { id: "img-1" };
+      }),
+      createDoc: vi.fn(async (_ws, p) => ({
+        id: "d" + p.title,
+        title: p.title,
+        type: p.type,
+      })),
+      getDocumentPath: (d: { id: string }) => `/path/${d.id}`,
+      applyContent: vi.fn(async () => {}),
+      sleep: vi.fn(async () => {}),
+    };
+    q.enqueue([file("cat.png")], "ws1");
+    q.startUploads(undefined, deps as never);
+    await flush();
+    await flush();
+    await flush();
+    const snap = q.getSnapshot();
+    expect(deps.uploadFile).toHaveBeenCalledTimes(2); // failed once, retried
+    expect(deps.sleep).toHaveBeenCalledTimes(1);
+    expect(snap.find((i) => i.fileName === "cat.png")?.status).toBe("done");
+  });
+
   it("marks an item error when its importer throws and keeps others going", async () => {
     const deps = {
       importDocx: vi.fn(async () => {

--- a/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
+++ b/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
@@ -112,6 +112,37 @@ describe("upload-queue worker", () => {
     expect(snap.find((i) => i.fileName === "cat.png")?.status).toBe("done");
   });
 
+  it("retries a 429 on createDoc without re-uploading the blob", async () => {
+    const rateLimited = Object.assign(new Error("Too Many Requests"), {
+      status: 429,
+    });
+    let createCalls = 0;
+    const deps = {
+      importXlsx: vi.fn(),
+      importDocx: vi.fn(),
+      importPptxFile: vi.fn(),
+      uploadFile: vi.fn(async () => ({ id: "img-1" })),
+      createDoc: vi.fn(async (_ws, p) => {
+        createCalls += 1;
+        if (createCalls === 1) throw rateLimited;
+        return { id: "d" + p.title, title: p.title, type: p.type };
+      }),
+      getDocumentPath: (d: { id: string }) => `/path/${d.id}`,
+      applyContent: vi.fn(async () => {}),
+      sleep: vi.fn(async () => {}),
+    };
+    q.enqueue([file("cat.png")], "ws1");
+    q.startUploads(undefined, deps as never);
+    await flush();
+    await flush();
+    await flush();
+    await flush();
+    const snap = q.getSnapshot();
+    expect(deps.uploadFile).toHaveBeenCalledTimes(1); // blob NOT re-uploaded
+    expect(deps.createDoc).toHaveBeenCalledTimes(2); // failed once, retried
+    expect(snap.find((i) => i.fileName === "cat.png")?.status).toBe("done");
+  });
+
   it("marks an item error when its importer throws and keeps others going", async () => {
     const deps = {
       importDocx: vi.fn(async () => {

--- a/packages/frontend/src/app/documents/__tests__/upload-queue.test.ts
+++ b/packages/frontend/src/app/documents/__tests__/upload-queue.test.ts
@@ -9,7 +9,7 @@ describe("upload-queue store", () => {
   beforeEach(() => q.__resetForTest());
 
   it("enqueues supported files as pending and unsupported as skipped", () => {
-    const items = q.enqueue([file("a.xlsx"), file("b.png")], "ws1");
+    const items = q.enqueue([file("a.xlsx"), file("b.zip")], "ws1");
     expect(items.map((i) => i.status)).toEqual(["pending", "skipped"]);
     expect(items[0].kind).toBe("sheet");
     expect(items[0].workspaceId).toBe("ws1");
@@ -40,7 +40,7 @@ describe("upload-queue store", () => {
   it("clearFinished prunes done and skipped items but retains pending/in-flight/error items", () => {
     const [done, skipped, pending, uploading, errored] = q.enqueue([
       file("a.pptx"),
-      file("b.png"), // unsupported -> auto "skipped"
+      file("b.zip"), // unsupported -> auto "skipped"
       file("c.docx"),
       file("d.xlsx"),
       file("e.pdf"),

--- a/packages/frontend/src/app/documents/document-list-utils.ts
+++ b/packages/frontend/src/app/documents/document-list-utils.ts
@@ -88,6 +88,7 @@ export function getDocumentPath(doc: {
     case "slides":
       return `/p/${doc.id}`;
     case "pdf":
+    case "image":
       return `/f/${doc.id}`;
     case "note":
       return `/n/${doc.id}`;

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -32,6 +32,7 @@ import {
   FileDown,
   FileText,
   FolderOutput,
+  Image as ImageIcon,
   MoreHorizontal,
   NotebookPen,
   Pencil,
@@ -106,6 +107,7 @@ import { UploadPanel } from "./upload-panel";
 import { useWindowFileDrop } from "./use-window-file-drop";
 import { enqueue, startUploads } from "./upload-queue";
 import { pickFiles } from "./pick-files";
+import { ImageThumb } from "./image-thumb";
 
 /**
  * Single source of truth for each document type's label, icon, and color.
@@ -121,6 +123,7 @@ const TYPE_META: Record<
   note: { label: "Note", Icon: NotebookPen, color: "text-purple-500" },
   slides: { label: "Slides", Icon: Presentation, color: "text-orange-500" },
   pdf: { label: "PDF", Icon: IconFileTypePdf, color: "text-red-500" },
+  image: { label: "Images", Icon: ImageIcon, color: "text-pink-500" },
 };
 
 /** Document types offered as filter chips, in display order. */
@@ -130,6 +133,7 @@ const TYPE_OPTIONS: ReadonlyArray<DocumentType> = [
   "note",
   "slides",
   "pdf",
+  "image",
 ];
 
 /**
@@ -223,6 +227,12 @@ function ImportMenuItems({
         <IconFileTypePdf className="mr-2 h-4 w-4 text-red-500" />
         Upload PDF
       </DropdownMenuItem>
+      <DropdownMenuItem
+        onClick={() => onImport(".png,.jpg,.jpeg,.gif,.webp")}
+      >
+        <ImageIcon className="mr-2 h-4 w-4 text-pink-500" />
+        Upload Image
+      </DropdownMenuItem>
     </>
   );
 }
@@ -256,7 +266,11 @@ export function DocumentList({
         const { Icon, color } = TYPE_META[row.original.type];
         return (
           <div className="flex items-center gap-2">
-            <Icon className={`h-4 w-4 shrink-0 ${color}`} />
+            {row.original.type === "image" ? (
+              <ImageThumb documentId={String(row.original.id)} />
+            ) : (
+              <Icon className={`h-4 w-4 shrink-0 ${color}`} />
+            )}
             <span className="capitalize">{row.getValue("title")}</span>
             {/* Live "currently editing" avatars sit next to the title rather
                 than in their own column. Presentational only — Title still

--- a/packages/frontend/src/app/documents/image-thumb.tsx
+++ b/packages/frontend/src/app/documents/image-thumb.tsx
@@ -19,10 +19,13 @@ export function ImageThumb({ documentId }: { documentId: string }) {
     if (!el) return;
     let objectUrl: string | null = null;
     let cancelled = false;
+    const controller = new AbortController();
 
     const load = async () => {
       try {
-        const res = await fetchWithAuth(fileUrl(documentId));
+        const res = await fetchWithAuth(fileUrl(documentId), {
+          signal: controller.signal,
+        });
         if (!res.ok) throw new Error(String(res.status));
         const blob = await res.blob();
         if (cancelled) return;
@@ -43,6 +46,7 @@ export function ImageThumb({ documentId }: { documentId: string }) {
 
     return () => {
       cancelled = true;
+      controller.abort();
       observer.disconnect();
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };

--- a/packages/frontend/src/app/documents/image-thumb.tsx
+++ b/packages/frontend/src/app/documents/image-thumb.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from "react";
+import { Image as ImageIcon } from "lucide-react";
+import { fetchWithAuth } from "@/api/auth";
+import { fileUrl } from "@/api/files";
+
+/**
+ * Small inline thumbnail for an `image` document row. Client-side downscale
+ * (no server thumbnails): the full blob is fetched — but only once the row is
+ * scrolled into view — and the browser scales it into the fixed box. The
+ * object URL is revoked on unmount to avoid leaks across list re-renders.
+ */
+export function ImageThumb({ documentId }: { documentId: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [src, setSrc] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    let objectUrl: string | null = null;
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const res = await fetchWithAuth(fileUrl(documentId));
+        if (!res.ok) throw new Error(String(res.status));
+        const blob = await res.blob();
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) {
+        observer.disconnect();
+        void load();
+      }
+    });
+    observer.observe(el);
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [documentId]);
+
+  return (
+    <div
+      ref={ref}
+      className="h-4 w-4 shrink-0 overflow-hidden rounded-sm bg-muted"
+    >
+      {src && !failed ? (
+        <img src={src} alt="" className="h-full w-full object-cover" />
+      ) : (
+        <ImageIcon className="h-4 w-4 text-pink-500" />
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/app/documents/upload-kind.ts
+++ b/packages/frontend/src/app/documents/upload-kind.ts
@@ -1,4 +1,4 @@
-export type UploadKind = "sheet" | "doc" | "slides" | "pdf";
+export type UploadKind = "sheet" | "doc" | "slides" | "pdf" | "image";
 
 export const SKIP_REASON = "Unsupported file type";
 
@@ -7,6 +7,11 @@ const EXT_TO_KIND: Record<string, UploadKind> = {
   docx: "doc",
   pptx: "slides",
   pdf: "pdf",
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+  gif: "image",
+  webp: "image",
 };
 
 export function classifyUploadKind(fileName: string): UploadKind | null {

--- a/packages/frontend/src/app/documents/upload-queue.ts
+++ b/packages/frontend/src/app/documents/upload-queue.ts
@@ -156,6 +156,7 @@ export interface UploadDeps {
   getDocumentPath: (doc: DocRef) => string;
   applyContent: typeof applyImportedContentDefault;
   deleteDoc: typeof deleteDocument;
+  sleep: (ms: number) => Promise<void>;
 }
 
 const defaultDeps: UploadDeps = {
@@ -168,6 +169,7 @@ const defaultDeps: UploadDeps = {
   getDocumentPath: getDocumentPathDefault,
   applyContent: applyImportedContentDefault,
   deleteDoc: deleteDocument,
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 };
 
 let activeDeps: UploadDeps = defaultDeps;
@@ -221,67 +223,94 @@ function settle(id: string): void {
   if (item && onItemSettledCb) onItemSettledCb(item);
 }
 
+const MAX_RATE_RETRIES = 6;
+
+/** Backoff (ms) for a rate-limited (429) request, or null if not a 429. */
+function rateLimitBackoffMs(err: unknown, attempt: number): number | null {
+  const status = (err as { status?: number } | null | undefined)?.status;
+  if (status !== 429) return null;
+  const retryAfter = (err as { retryAfterMs?: number }).retryAfterMs;
+  if (typeof retryAfter === "number" && retryAfter >= 0) return retryAfter;
+  // Exponential backoff capped at 15s: 1s, 2s, 4s, 8s, 15s, 15s.
+  return Math.min(1000 * 2 ** attempt, 15000);
+}
+
 async function runItem(item: UploadItem): Promise<void> {
   const d = activeDeps;
   const file = item.file!;
+  let attempt = 0;
   try {
-    if (item.kind === "sheet") {
-      patchItem(item.id, { status: "parsing" });
-      const { document } = await d.importXlsx(file);
-      const title = stripExt(item.fileName, "xlsx", "Imported Sheet");
-      const created = await getOrCreateDoc(item, { title, type: "sheet" });
-      // Persist the parsed content into the Yorkie doc now (see
-      // apply-imported-content.ts) so "done" means it is actually saved —
-      // not merely stashed in memory awaiting an editor mount.
-      patchItem(item.id, { status: "uploading" });
-      await d.applyContent(created.id, { type: "sheet", document });
-      finish(item.id, created);
-    } else if (item.kind === "doc") {
-      patchItem(item.id, { status: "parsing" });
-      const { doc } = await d.importDocx(file, ({ done, total }) =>
-        patchItem(item.id, { status: "uploading", done, total }),
-      );
-      const title = stripExt(item.fileName, "docx", "Imported Document");
-      const created = await getOrCreateDoc(item, { title, type: "doc" });
-      patchItem(item.id, { status: "uploading" });
-      await d.applyContent(created.id, { type: "doc", document: doc });
-      finish(item.id, created);
-    } else if (item.kind === "slides") {
-      patchItem(item.id, { status: "parsing" });
-      const { document, report } = await d.importPptxFile(
-        file,
-        ({ done, total }) =>
-          patchItem(item.id, { status: "uploading", done, total }),
-      );
-      const title = stripExt(item.fileName, "pptx", "Imported Presentation");
-      const created = await getOrCreateDoc(item, { title, type: "slides" });
-      patchItem(item.id, { status: "uploading" });
-      await d.applyContent(created.id, { type: "slides", document });
-      // Surface lossy-conversion fallbacks the same way the old flow did.
-      const summary = report.summary();
-      const warning =
-        summary && summary !== "Imported with no fallbacks." ? summary : undefined;
-      finish(item.id, created, warning);
-    } else if (item.kind === "pdf" || item.kind === "image") {
-      patchItem(item.id, { status: "uploading" });
-      const dot = item.fileName.lastIndexOf(".");
-      const ext = dot >= 0 ? item.fileName.slice(dot + 1).toLowerCase() : "";
-      const fallback = item.kind === "pdf" ? "Untitled PDF" : "Untitled Image";
-      const title = stripExt(item.fileName, ext, fallback);
-      // Upload the blob at most once per item: persist the returned fileId
-      // immediately so a retry whose earlier failure was in createDoc reuses
-      // the blob instead of orphaning it with a second upload.
-      let fileId = item.fileId;
-      if (!fileId) {
-        ({ id: fileId } = await d.uploadFile(file));
-        patchItem(item.id, { fileId });
+    // Retry loop: a 429 (bulk-upload rate limit) backs off and retries the
+    // same item. Re-entry is safe because fileId/docId are persisted before
+    // the failing step, so uploadFile/getOrCreateDoc never duplicate work.
+    for (;;) {
+      try {
+        if (item.kind === "sheet") {
+          patchItem(item.id, { status: "parsing" });
+          const { document } = await d.importXlsx(file);
+          const title = stripExt(item.fileName, "xlsx", "Imported Sheet");
+          const created = await getOrCreateDoc(item, { title, type: "sheet" });
+          // Persist the parsed content into the Yorkie doc now (see
+          // apply-imported-content.ts) so "done" means it is actually saved —
+          // not merely stashed in memory awaiting an editor mount.
+          patchItem(item.id, { status: "uploading" });
+          await d.applyContent(created.id, { type: "sheet", document });
+          finish(item.id, created);
+        } else if (item.kind === "doc") {
+          patchItem(item.id, { status: "parsing" });
+          const { doc } = await d.importDocx(file, ({ done, total }) =>
+            patchItem(item.id, { status: "uploading", done, total }),
+          );
+          const title = stripExt(item.fileName, "docx", "Imported Document");
+          const created = await getOrCreateDoc(item, { title, type: "doc" });
+          patchItem(item.id, { status: "uploading" });
+          await d.applyContent(created.id, { type: "doc", document: doc });
+          finish(item.id, created);
+        } else if (item.kind === "slides") {
+          patchItem(item.id, { status: "parsing" });
+          const { document, report } = await d.importPptxFile(
+            file,
+            ({ done, total }) =>
+              patchItem(item.id, { status: "uploading", done, total }),
+          );
+          const title = stripExt(item.fileName, "pptx", "Imported Presentation");
+          const created = await getOrCreateDoc(item, { title, type: "slides" });
+          patchItem(item.id, { status: "uploading" });
+          await d.applyContent(created.id, { type: "slides", document });
+          // Surface lossy-conversion fallbacks the same way the old flow did.
+          const summary = report.summary();
+          const warning =
+            summary && summary !== "Imported with no fallbacks." ? summary : undefined;
+          finish(item.id, created, warning);
+        } else if (item.kind === "pdf" || item.kind === "image") {
+          patchItem(item.id, { status: "uploading" });
+          const dot = item.fileName.lastIndexOf(".");
+          const ext = dot >= 0 ? item.fileName.slice(dot + 1).toLowerCase() : "";
+          const fallback = item.kind === "pdf" ? "Untitled PDF" : "Untitled Image";
+          const title = stripExt(item.fileName, ext, fallback);
+          // Upload the blob at most once per item: persist the returned fileId
+          // immediately so a retry whose earlier failure was in createDoc reuses
+          // the blob instead of orphaning it with a second upload.
+          let fileId = item.fileId;
+          if (!fileId) {
+            ({ id: fileId } = await d.uploadFile(file));
+            patchItem(item.id, { fileId });
+          }
+          const created = await getOrCreateDoc(item, {
+            title,
+            type: item.kind,
+            fileId,
+          });
+          finish(item.id, created);
+        }
+        break;
+      } catch (err) {
+        const backoff =
+          attempt < MAX_RATE_RETRIES ? rateLimitBackoffMs(err, attempt) : null;
+        if (backoff === null) throw err;
+        attempt += 1;
+        await d.sleep(backoff);
       }
-      const created = await getOrCreateDoc(item, {
-        title,
-        type: item.kind,
-        fileId,
-      });
-      finish(item.id, created);
     }
   } catch (err) {
     patchItem(item.id, {

--- a/packages/frontend/src/app/documents/upload-queue.ts
+++ b/packages/frontend/src/app/documents/upload-queue.ts
@@ -28,7 +28,8 @@ export interface UploadItem {
   total: number;
   docId?: string;
   docPath?: string;
-  /** PDF: the uploaded blob id, persisted so a retry never re-uploads it. */
+  /** Uploaded blob id (pdf/image). Set before createDoc so a retry reuses the
+   *  blob instead of re-uploading/orphaning it. */
   fileId?: string;
   reason?: string;
   /** Non-fatal note surfaced on success (e.g. lossy PPTX import fallbacks). */

--- a/packages/frontend/src/app/documents/upload-queue.ts
+++ b/packages/frontend/src/app/documents/upload-queue.ts
@@ -244,6 +244,10 @@ async function runItem(item: UploadItem): Promise<void> {
     // same item. Re-entry is safe because fileId/docId are persisted before
     // the failing step, so uploadFile/getOrCreateDoc never duplicate work.
     for (;;) {
+      // patchItem replaces items immutably, so the captured `item` goes stale
+      // after a persist. Re-read it each attempt so a retry sees the fileId/
+      // docId a prior attempt already persisted (idempotent re-entry).
+      item = items.find((it) => it.id === item.id) ?? item;
       try {
         if (item.kind === "sheet") {
           patchItem(item.id, { status: "parsing" });

--- a/packages/frontend/src/app/documents/upload-queue.ts
+++ b/packages/frontend/src/app/documents/upload-queue.ts
@@ -3,7 +3,7 @@ import { getDocumentPath as getDocumentPathDefault } from "./document-list-utils
 import { importXlsx } from "@/app/spreadsheet/xlsx-actions";
 import { importDocx } from "@/app/docs/docx-actions";
 import { importPptxFile } from "@/app/slides/pptx-actions";
-import { uploadPdf } from "@/api/files";
+import { uploadFile } from "@/api/files";
 import { createDocument, deleteDocument } from "@/api/documents";
 import { createWorkspaceDocument } from "@/api/workspaces";
 import { applyImportedContent as applyImportedContentDefault } from "./apply-imported-content";
@@ -147,7 +147,7 @@ export interface UploadDeps {
   importXlsx: typeof importXlsx;
   importDocx: typeof importDocx;
   importPptxFile: typeof importPptxFile;
-  uploadPdf: typeof uploadPdf;
+  uploadFile: typeof uploadFile;
   createDoc: (
     workspaceId: string | undefined,
     payload: { title: string; type: DocumentType; fileId?: string },
@@ -161,7 +161,7 @@ const defaultDeps: UploadDeps = {
   importXlsx,
   importDocx,
   importPptxFile,
-  uploadPdf,
+  uploadFile,
   createDoc: (ws, payload) =>
     ws ? createWorkspaceDocument(ws, payload) : createDocument(payload),
   getDocumentPath: getDocumentPathDefault,
@@ -261,18 +261,25 @@ async function runItem(item: UploadItem): Promise<void> {
       const warning =
         summary && summary !== "Imported with no fallbacks." ? summary : undefined;
       finish(item.id, created, warning);
-    } else if (item.kind === "pdf") {
+    } else if (item.kind === "pdf" || item.kind === "image") {
       patchItem(item.id, { status: "uploading" });
-      const title = stripExt(item.fileName, "pdf", "Untitled PDF");
+      const dot = item.fileName.lastIndexOf(".");
+      const ext = dot >= 0 ? item.fileName.slice(dot + 1).toLowerCase() : "";
+      const fallback = item.kind === "pdf" ? "Untitled PDF" : "Untitled Image";
+      const title = stripExt(item.fileName, ext, fallback);
       // Upload the blob at most once per item: persist the returned fileId
       // immediately so a retry whose earlier failure was in createDoc reuses
       // the blob instead of orphaning it with a second upload.
       let fileId = item.fileId;
       if (!fileId) {
-        ({ id: fileId } = await d.uploadPdf(file));
+        ({ id: fileId } = await d.uploadFile(file));
         patchItem(item.id, { fileId });
       }
-      const created = await getOrCreateDoc(item, { title, type: "pdf", fileId });
+      const created = await getOrCreateDoc(item, {
+        title,
+        type: item.kind,
+        fileId,
+      });
       finish(item.id, created);
     }
   } catch (err) {

--- a/packages/frontend/src/app/files/file-detail.tsx
+++ b/packages/frontend/src/app/files/file-detail.tsx
@@ -79,7 +79,11 @@ export function FileDetail() {
     staleTime: 5 * 60 * 1000,
   });
 
-  const { data: documentData, isLoading: docLoading } = useQuery({
+  const {
+    data: documentData,
+    isLoading: docLoading,
+    isError: docError,
+  } = useQuery({
     queryKey: ["document", id],
     queryFn: () => fetchDocument(id!),
     retry: false,
@@ -89,7 +93,12 @@ export function FileDetail() {
   if (userLoading || docLoading) return <Loader />;
   if (userError || !currentUser) return <Navigate to="/login" replace />;
 
-  if (documentData?.type === "image") {
+  // A failed document fetch must not fall through to the PDF layout, which
+  // would attach a pdf-<id> Yorkie doc for what may be an image document.
+  // Redirect before any layout (and its Yorkie provider) mounts.
+  if (docError || !documentData) return <Navigate to="/documents" replace />;
+
+  if (documentData.type === "image") {
     return <ImageFileLayout documentId={id!} />;
   }
   return <PdfFileLayout documentId={id!} currentUser={currentUser} />;

--- a/packages/frontend/src/app/files/file-detail.tsx
+++ b/packages/frontend/src/app/files/file-detail.tsx
@@ -1,5 +1,5 @@
 import { Navigate, useParams } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { fetchMe } from "@/api/auth";
 import { fetchDocument } from "@/api/documents";
 import { Loader } from "@/components/loader";
@@ -88,6 +88,8 @@ export function FileDetail() {
     queryFn: () => fetchDocument(id!),
     retry: false,
     enabled: !!id,
+    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
   });
 
   if (userLoading || docLoading) return <Loader />;

--- a/packages/frontend/src/app/files/file-detail.tsx
+++ b/packages/frontend/src/app/files/file-detail.tsx
@@ -1,115 +1,26 @@
-import { Navigate, useNavigate, useParams } from "react-router-dom";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo } from "react";
+import { Navigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import { fetchMe } from "@/api/auth";
-import { fetchDocument, renameDocument } from "@/api/documents";
-import { toast } from "sonner";
+import { fetchDocument } from "@/api/documents";
 import { Loader } from "@/components/loader";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
-import { AppSidebar } from "@/components/app-sidebar";
-import { SiteHeader } from "@/components/site-header";
 import { ShareDialog } from "@/components/share-dialog";
 import { UserPresence } from "@/components/user-presence";
-import { IconFolder, IconSettings, IconDatabase } from "@tabler/icons-react";
-import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
 import type { User } from "@/types/users";
+import { FileShell } from "./file-shell";
+import { ImageViewer } from "./image-viewer";
 import {
   PdfCollabProvider,
   PdfHeaderActions,
   PdfCollabBody,
 } from "./pdf-collab";
 
-function FileLayout({
+function PdfFileLayout({
   documentId,
   currentUser,
 }: {
   documentId: string;
   currentUser: User;
 }) {
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
-
-  const { data: documentData, isError: isDocumentError } = useQuery({
-    queryKey: ["document", documentId],
-    queryFn: () => fetchDocument(documentId),
-    retry: false,
-  });
-
-  useEffect(() => {
-    document.title = documentData?.title
-      ? `${documentData.title} — Wafflebase`
-      : "Wafflebase";
-  }, [documentData?.title]);
-
-  const { data: workspaces = [] } = useQuery<Workspace[]>({
-    queryKey: ["workspaces"],
-    queryFn: fetchWorkspaces,
-  });
-
-  const currentWorkspace = workspaces.find(
-    (w) => w.id === documentData?.workspaceId,
-  );
-  const workspaceSlug = currentWorkspace?.slug;
-  const fallbackSlug = workspaceSlug ?? workspaces[0]?.slug;
-
-  useEffect(() => {
-    if (isDocumentError) {
-      toast.error("Document not found");
-      navigate(fallbackSlug ? `/w/${fallbackSlug}` : "/documents", {
-        replace: true,
-      });
-    }
-  }, [isDocumentError, navigate, fallbackSlug]);
-
-  const items = useMemo(() => {
-    if (workspaceSlug) {
-      return {
-        main: [
-          { title: "Documents", url: `/w/${workspaceSlug}`, icon: IconFolder },
-          {
-            title: "Data Sources",
-            url: `/w/${workspaceSlug}/datasources`,
-            icon: IconDatabase,
-          },
-          {
-            title: "Settings",
-            url: `/w/${workspaceSlug}/settings`,
-            icon: IconSettings,
-          },
-        ],
-        secondary: [],
-      };
-    }
-    return {
-      main: [
-        { title: "Documents", url: "/documents", icon: IconFolder },
-        { title: "Data Sources", url: "/datasources", icon: IconDatabase },
-        { title: "Settings", url: "/settings", icon: IconSettings },
-      ],
-      secondary: [],
-    };
-  }, [workspaceSlug]);
-
-  const handleWorkspaceChange = useCallback(
-    (slug: string) => {
-      navigate(`/w/${slug}`);
-    },
-    [navigate],
-  );
-
-  const handleRenameDocument = useCallback(
-    async (newTitle: string) => {
-      try {
-        await renameDocument(documentId, newTitle);
-        queryClient.invalidateQueries({ queryKey: ["document", documentId] });
-        queryClient.invalidateQueries({ queryKey: ["documents"] });
-      } catch {
-        toast.error("Failed to rename document");
-      }
-    },
-    [documentId, queryClient],
-  );
-
   return (
     <PdfCollabProvider
       documentId={documentId}
@@ -121,51 +32,46 @@ function FileLayout({
         photo: currentUser.photo,
       }}
     >
-      <SidebarProvider>
-        <AppSidebar
-          variant="inset"
-          items={items}
-          workspaces={workspaces}
-          currentWorkspace={currentWorkspace}
-          onWorkspaceChange={handleWorkspaceChange}
-        />
-        <SidebarInset>
-          <SiteHeader
-            title={documentData?.title ?? "Loading..."}
-            editable
-            onRename={handleRenameDocument}
-          >
-            <div className="flex items-center gap-2">
-              <PdfHeaderActions />
-              <ShareDialog documentId={documentId} />
-              <UserPresence />
-            </div>
-          </SiteHeader>
-          <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
-            <PdfCollabBody />
-          </div>
-        </SidebarInset>
-      </SidebarProvider>
+      <FileShell
+        documentId={documentId}
+        headerActions={
+          <>
+            <PdfHeaderActions />
+            <ShareDialog documentId={documentId} />
+            <UserPresence />
+          </>
+        }
+      >
+        <PdfCollabBody />
+      </FileShell>
     </PdfCollabProvider>
   );
 }
 
+function ImageFileLayout({ documentId }: { documentId: string }) {
+  return (
+    <FileShell
+      documentId={documentId}
+      headerActions={<ShareDialog documentId={documentId} />}
+    >
+      <ImageViewer documentId={documentId} />
+    </FileShell>
+  );
+}
+
 /**
- * FileDetail is the collaborative PDF route. Auth-gates on the current
- * user, then mounts the app shell wrapped in `PdfCollabProvider` (comments +
- * presence over the `pdf-<id>` Yorkie document). The ambient `YorkieProvider`
- * comes from `PrivateRoute` — this route does not mount its own, matching the
- * docs/slides/sheets owner routes. The PDF bytes stay static, served
- * (permission-gated) from the blob store; only comments + presence flow
- * through Yorkie.
+ * FileDetail is the `/f/:id` route shared by static blob documents. It
+ * auth-gates on the current user, resolves the document `type`, then mounts
+ * the matching layout: pdf → collaborative PDF (comments + presence over the
+ * `pdf-<id>` Yorkie doc); image → a plain viewer with no Yorkie attachment.
  */
 export function FileDetail() {
   const { id } = useParams();
 
   const {
     data: currentUser,
-    isLoading,
-    isError,
+    isLoading: userLoading,
+    isError: userError,
   } = useQuery({
     queryKey: ["me"],
     queryFn: fetchMe,
@@ -173,10 +79,20 @@ export function FileDetail() {
     staleTime: 5 * 60 * 1000,
   });
 
-  if (isLoading) return <Loader />;
-  if (isError || !currentUser) return <Navigate to="/login" replace />;
+  const { data: documentData, isLoading: docLoading } = useQuery({
+    queryKey: ["document", id],
+    queryFn: () => fetchDocument(id!),
+    retry: false,
+    enabled: !!id,
+  });
 
-  return <FileLayout documentId={id!} currentUser={currentUser} />;
+  if (userLoading || docLoading) return <Loader />;
+  if (userError || !currentUser) return <Navigate to="/login" replace />;
+
+  if (documentData?.type === "image") {
+    return <ImageFileLayout documentId={id!} />;
+  }
+  return <PdfFileLayout documentId={id!} currentUser={currentUser} />;
 }
 
 export default FileDetail;

--- a/packages/frontend/src/app/files/file-shell.tsx
+++ b/packages/frontend/src/app/files/file-shell.tsx
@@ -1,0 +1,121 @@
+import { useNavigate } from "react-router-dom";
+import { useCallback, useEffect, useMemo, type ReactNode } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { fetchDocument, renameDocument } from "@/api/documents";
+import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/app-sidebar";
+import { SiteHeader } from "@/components/site-header";
+import { IconFolder, IconSettings, IconDatabase } from "@tabler/icons-react";
+
+/**
+ * Shared app shell for the `/f/:id` file routes (pdf + image). Owns the
+ * sidebar, the editable title header, workspace nav, and the not-found
+ * redirect. The Yorkie provider (if any) is supplied by the caller wrapping
+ * this shell — image documents have none.
+ */
+export function FileShell({
+  documentId,
+  headerActions,
+  children,
+}: {
+  documentId: string;
+  headerActions: ReactNode;
+  children: ReactNode;
+}) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { data: documentData, isError: isDocumentError } = useQuery({
+    queryKey: ["document", documentId],
+    queryFn: () => fetchDocument(documentId),
+    retry: false,
+  });
+
+  useEffect(() => {
+    document.title = documentData?.title
+      ? `${documentData.title} — Wafflebase`
+      : "Wafflebase";
+  }, [documentData?.title]);
+
+  const { data: workspaces = [] } = useQuery<Workspace[]>({
+    queryKey: ["workspaces"],
+    queryFn: fetchWorkspaces,
+  });
+
+  const currentWorkspace = workspaces.find(
+    (w) => w.id === documentData?.workspaceId,
+  );
+  const workspaceSlug = currentWorkspace?.slug;
+  const fallbackSlug = workspaceSlug ?? workspaces[0]?.slug;
+
+  useEffect(() => {
+    if (isDocumentError) {
+      toast.error("Document not found");
+      navigate(fallbackSlug ? `/w/${fallbackSlug}` : "/documents", {
+        replace: true,
+      });
+    }
+  }, [isDocumentError, navigate, fallbackSlug]);
+
+  const items = useMemo(() => {
+    const base = workspaceSlug
+      ? {
+          docs: `/w/${workspaceSlug}`,
+          data: `/w/${workspaceSlug}/datasources`,
+          settings: `/w/${workspaceSlug}/settings`,
+        }
+      : { docs: "/documents", data: "/datasources", settings: "/settings" };
+    return {
+      main: [
+        { title: "Documents", url: base.docs, icon: IconFolder },
+        { title: "Data Sources", url: base.data, icon: IconDatabase },
+        { title: "Settings", url: base.settings, icon: IconSettings },
+      ],
+      secondary: [],
+    };
+  }, [workspaceSlug]);
+
+  const handleWorkspaceChange = useCallback(
+    (slug: string) => navigate(`/w/${slug}`),
+    [navigate],
+  );
+
+  const handleRenameDocument = useCallback(
+    async (newTitle: string) => {
+      try {
+        await renameDocument(documentId, newTitle);
+        queryClient.invalidateQueries({ queryKey: ["document", documentId] });
+        queryClient.invalidateQueries({ queryKey: ["documents"] });
+      } catch {
+        toast.error("Failed to rename document");
+      }
+    },
+    [documentId, queryClient],
+  );
+
+  return (
+    <SidebarProvider>
+      <AppSidebar
+        variant="inset"
+        items={items}
+        workspaces={workspaces}
+        currentWorkspace={currentWorkspace}
+        onWorkspaceChange={handleWorkspaceChange}
+      />
+      <SidebarInset>
+        <SiteHeader
+          title={documentData?.title ?? "Loading..."}
+          editable
+          onRename={handleRenameDocument}
+        >
+          <div className="flex items-center gap-2">{headerActions}</div>
+        </SiteHeader>
+        <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
+          {children}
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/packages/frontend/src/app/files/file-shell.tsx
+++ b/packages/frontend/src/app/files/file-shell.tsx
@@ -1,7 +1,12 @@
 import { useNavigate } from "react-router-dom";
 import { useCallback, useEffect, useMemo, type ReactNode } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
+import { isAuthExpiredError } from "@/api/auth";
 import { fetchDocument, renameDocument } from "@/api/documents";
 import { fetchWorkspaces, type Workspace } from "@/api/workspaces";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
@@ -31,6 +36,8 @@ export function FileShell({
     queryKey: ["document", documentId],
     queryFn: () => fetchDocument(documentId),
     retry: false,
+    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
   });
 
   useEffect(() => {
@@ -88,7 +95,8 @@ export function FileShell({
         await renameDocument(documentId, newTitle);
         queryClient.invalidateQueries({ queryKey: ["document", documentId] });
         queryClient.invalidateQueries({ queryKey: ["documents"] });
-      } catch {
+      } catch (error) {
+        if (isAuthExpiredError(error)) return;
         toast.error("Failed to rename document");
       }
     },

--- a/packages/frontend/src/app/files/image-viewer.tsx
+++ b/packages/frontend/src/app/files/image-viewer.tsx
@@ -53,6 +53,7 @@ export function ImageViewer({ documentId }: { documentId: string }) {
     queryKey: ["document", documentId],
     queryFn: () => fetchDocument(documentId),
     retry: false,
+    staleTime: 5 * 60 * 1000,
   });
   useEffect(() => {
     if (!current?.title) return;

--- a/packages/frontend/src/app/files/image-viewer.tsx
+++ b/packages/frontend/src/app/files/image-viewer.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { fetchWithAuth } from "@/api/auth";
+import { fetchDocument, fetchDocuments } from "@/api/documents";
+import { fileUrl } from "@/api/files";
+
+const ZOOM_STEP = 0.25;
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 5;
+
+export function ImageViewer({ documentId }: { documentId: string }) {
+  const navigate = useNavigate();
+  const [src, setSrc] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+  const [zoom, setZoom] = useState(1);
+  const downloadName = useRef<string>("image");
+
+  // Load the current image bytes via the authed endpoint → object URL.
+  useEffect(() => {
+    let objectUrl: string | null = null;
+    let cancelled = false;
+    setSrc(null);
+    setError(false);
+    setZoom(1);
+    (async () => {
+      try {
+        const res = await fetchWithAuth(fileUrl(documentId));
+        if (!res.ok) throw new Error(String(res.status));
+        const blob = await res.blob();
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setSrc(objectUrl);
+      } catch {
+        if (!cancelled) setError(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [documentId]);
+
+  const { data: current } = useQuery({
+    queryKey: ["document", documentId],
+    queryFn: () => fetchDocument(documentId),
+    retry: false,
+  });
+  useEffect(() => {
+    if (current?.title) downloadName.current = current.title;
+  }, [current?.title]);
+
+  // Sibling images in the same workspace, stably ordered, for prev/next.
+  const { data: allDocs = [] } = useQuery({
+    queryKey: ["documents"],
+    queryFn: fetchDocuments,
+  });
+  const siblings = useMemo(() => {
+    if (!current) return [] as string[];
+    return allDocs
+      .filter(
+        (d) => d.type === "image" && d.workspaceId === current.workspaceId,
+      )
+      .sort((a, b) =>
+        a.title === b.title
+          ? String(a.id).localeCompare(String(b.id))
+          : a.title.localeCompare(b.title),
+      )
+      .map((d) => String(d.id));
+  }, [allDocs, current]);
+
+  const index = siblings.indexOf(documentId);
+  const prevId = index > 0 ? siblings[index - 1] : undefined;
+  const nextId =
+    index >= 0 && index < siblings.length - 1
+      ? siblings[index + 1]
+      : undefined;
+
+  const go = useCallback(
+    (id?: string) => id && navigate(`/f/${id}`),
+    [navigate],
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") go(prevId);
+      else if (e.key === "ArrowRight") go(nextId);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [go, prevId, nextId]);
+
+  const download = useCallback(() => {
+    if (!src) return;
+    const a = document.createElement("a");
+    a.href = src;
+    a.download = downloadName.current;
+    a.click();
+  }, [src]);
+
+  return (
+    <div className="relative flex flex-1 items-center justify-center overflow-auto bg-muted/30">
+      {error ? (
+        <p className="text-sm text-muted-foreground">Failed to load image.</p>
+      ) : src ? (
+        <img
+          src={src}
+          alt={downloadName.current}
+          style={{ transform: `scale(${zoom})` }}
+          className="max-h-full max-w-full object-contain transition-transform"
+        />
+      ) : (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      )}
+
+      {prevId && (
+        <Button
+          variant="secondary"
+          size="icon"
+          aria-label="Previous image"
+          className="absolute left-4 top-1/2 -translate-y-1/2"
+          onClick={() => go(prevId)}
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </Button>
+      )}
+      {nextId && (
+        <Button
+          variant="secondary"
+          size="icon"
+          aria-label="Next image"
+          className="absolute right-4 top-1/2 -translate-y-1/2"
+          onClick={() => go(nextId)}
+        >
+          <ChevronRight className="h-5 w-5" />
+        </Button>
+      )}
+
+      <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 items-center gap-1 rounded-lg border bg-background p-1 shadow-sm">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Zoom out"
+          onClick={() => setZoom((z) => Math.max(MIN_ZOOM, z - ZOOM_STEP))}
+        >
+          <ZoomOut className="h-4 w-4" />
+        </Button>
+        <span className="w-12 text-center text-xs tabular-nums">
+          {Math.round(zoom * 100)}%
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Zoom in"
+          onClick={() => setZoom((z) => Math.min(MAX_ZOOM, z + ZOOM_STEP))}
+        >
+          <ZoomIn className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Download image"
+          onClick={download}
+        >
+          <Download className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/app/files/image-viewer.tsx
+++ b/packages/frontend/src/app/files/image-viewer.tsx
@@ -91,6 +91,15 @@ export function ImageViewer({ documentId }: { documentId: string }) {
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (
+        t &&
+        (t.tagName === "INPUT" ||
+          t.tagName === "TEXTAREA" ||
+          t.isContentEditable)
+      ) {
+        return;
+      }
       if (e.key === "ArrowLeft") go(prevId);
       else if (e.key === "ArrowRight") go(nextId);
     };

--- a/packages/frontend/src/app/files/image-viewer.tsx
+++ b/packages/frontend/src/app/files/image-viewer.tsx
@@ -55,8 +55,13 @@ export function ImageViewer({ documentId }: { documentId: string }) {
     retry: false,
   });
   useEffect(() => {
-    if (current?.title) downloadName.current = current.title;
-  }, [current?.title]);
+    if (!current?.title) return;
+    const ext = current.fileId?.split(".").pop();
+    downloadName.current =
+      ext && !current.title.toLowerCase().endsWith(`.${ext.toLowerCase()}`)
+        ? `${current.title}.${ext}`
+        : current.title;
+  }, [current?.title, current?.fileId]);
 
   // Sibling images in the same workspace, stably ordered, for prev/next.
   const { data: allDocs = [] } = useQuery({

--- a/packages/frontend/src/app/files/pdf-collab.tsx
+++ b/packages/frontend/src/app/files/pdf-collab.tsx
@@ -31,7 +31,7 @@ import type {
   Thread,
   PdfRegionAnchor,
 } from '@/types/comments.ts';
-import { pdfFileUrl } from '@/api/files.ts';
+import { fileUrl } from '@/api/files.ts';
 
 export type PdfPresenceUser = {
   username: string;
@@ -133,7 +133,7 @@ export function PdfCollabStateProvider({
 
   const value: PdfCollabContextValue = {
     readOnly,
-    fileUrl: pdfFileUrl(documentId, token),
+    fileUrl: fileUrl(documentId, token),
     threads,
     panelOpen,
     setPanelOpen,

--- a/packages/frontend/src/types/documents.ts
+++ b/packages/frontend/src/types/documents.ts
@@ -1,4 +1,4 @@
-export type DocumentType = "sheet" | "doc" | "slides" | "pdf" | "note";
+export type DocumentType = "sheet" | "doc" | "slides" | "pdf" | "note" | "image";
 
 /**
  * Backend-projected "currently editing" user. The server unwraps Yorkie's

--- a/packages/frontend/tests/api/files.test.ts
+++ b/packages/frontend/tests/api/files.test.ts
@@ -5,7 +5,7 @@ vi.mock("../../src/api/auth", () => ({
   fetchWithAuth: (...a: unknown[]) => fetchWithAuth(...a),
 }));
 
-import { uploadPdf, pdfFileUrl } from "../../src/api/files";
+import { uploadFile, fileUrl } from "../../src/api/files";
 
 describe("files api", () => {
   beforeEach(() => fetchWithAuth.mockReset());
@@ -13,7 +13,7 @@ describe("files api", () => {
   it("POSTs multipart form data and returns the id", async () => {
     fetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({ id: "x.pdf" }) });
     const file = new File([new Uint8Array([1])], "a.pdf", { type: "application/pdf" });
-    const res = await uploadPdf(file);
+    const res = await uploadFile(file);
     expect(res).toEqual({ id: "x.pdf" });
     const [url, opts] = fetchWithAuth.mock.calls[0];
     expect(String(url)).toMatch(/\/files$/);
@@ -24,10 +24,10 @@ describe("files api", () => {
   it("throws on a non-ok response", async () => {
     fetchWithAuth.mockResolvedValue({ ok: false, status: 413, statusText: "Too Large" });
     const file = new File([new Uint8Array([1])], "a.pdf", { type: "application/pdf" });
-    await expect(uploadPdf(file)).rejects.toThrow(/413/);
+    await expect(uploadFile(file)).rejects.toThrow(/413/);
   });
 
   it("builds a document-scoped file url", () => {
-    expect(pdfFileUrl("d1")).toMatch(/\/documents\/d1\/file$/);
+    expect(fileUrl("d1")).toMatch(/\/documents\/d1\/file$/);
   });
 });

--- a/packages/frontend/tests/api/files.test.ts
+++ b/packages/frontend/tests/api/files.test.ts
@@ -22,9 +22,15 @@ describe("files api", () => {
   });
 
   it("throws on a non-ok response", async () => {
-    fetchWithAuth.mockResolvedValue({ ok: false, status: 413, statusText: "Too Large" });
+    fetchWithAuth.mockResolvedValue({
+      ok: false,
+      status: 413,
+      statusText: "Too Large",
+      headers: { get: () => null },
+      text: async () => "",
+    });
     const file = new File([new Uint8Array([1])], "a.pdf", { type: "application/pdf" });
-    await expect(uploadFile(file)).rejects.toThrow(/413/);
+    await expect(uploadFile(file)).rejects.toThrow(/File upload failed/);
   });
 
   it("builds a document-scoped file url", () => {

--- a/packages/frontend/tests/api/http-error.test.ts
+++ b/packages/frontend/tests/api/http-error.test.ts
@@ -1,6 +1,8 @@
-import { test, expect } from 'vitest';
+import { test, expect, describe, it } from 'vitest';
 import {
+  HttpError,
   assertOk,
+  parseRetryAfterMs,
   readResponseErrorMessage,
 } from "../../src/api/http-error.ts";
 
@@ -58,4 +60,41 @@ test("assertOk uses body message then fallback", async () => {
 test("assertOk does not throw for OK responses", async () => {
   const response = new Response(JSON.stringify({ ok: true }), { status: 200 });
   await expect(assertOk(response, "fallback")).resolves.not.toThrow();
+});
+
+function res(retryAfter?: string): Response {
+  const headers = new Headers();
+  if (retryAfter !== undefined) headers.set("retry-after", retryAfter);
+  return new Response(null, { status: 429, headers });
+}
+
+describe("parseRetryAfterMs", () => {
+  it("returns undefined when the header is absent", () => {
+    expect(parseRetryAfterMs(res())).toBeUndefined();
+  });
+  it("parses delta-seconds to milliseconds", () => {
+    expect(parseRetryAfterMs(res("5"))).toBe(5000);
+  });
+  it("clamps a negative delta to 0", () => {
+    expect(parseRetryAfterMs(res("-3"))).toBe(0);
+  });
+  it("parses an HTTP-date to a non-negative delay", () => {
+    const future = new Date(Date.now() + 10_000).toUTCString();
+    const ms = parseRetryAfterMs(res(future));
+    expect(ms).toBeGreaterThan(0);
+    expect(ms).toBeLessThanOrEqual(10_000);
+  });
+  it("returns undefined for a garbage value", () => {
+    expect(parseRetryAfterMs(res("not-a-date"))).toBeUndefined();
+  });
+});
+
+describe("HttpError", () => {
+  it("is an Error carrying status and retryAfterMs", () => {
+    const err = new HttpError("boom", 429, 1234);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("boom");
+    expect(err.status).toBe(429);
+    expect(err.retryAfterMs).toBe(1234);
+  });
 });


### PR DESCRIPTION
## Summary

Adds an **image** document type (`"image"`) alongside sheet/doc/slides/pdf/note, mirroring PDF's static-blob spine. Design: `docs/design/image-viewer.md`.

- **Upload** png/jpeg/gif/webp (25 MB cap) from the documents list via the existing multi-file drag-and-drop queue; bytes stored in the `wafflebase-files` blob layer, referenced by the reused `Document.fileId` (no migration, no new bucket).
- **Serving** reuses the already type-agnostic `GET /documents/:id/file`; the `fileId` gate is extended to allow **pdf + image only** (never sheet/doc/slides/note), and the `image-` Yorkie key prefix is reserved.
- **Viewer** at `/f/:id` dispatches by `doc.type`: images render in a lightweight `<img>` viewer (fit / zoom / download) with **workspace prev/next** (arrow buttons + keyboard ←/→). Image docs never mount the PDF Yorkie provider, even on a fetch error.
- **List** shows inline **lazy thumbnails** for image rows (IntersectionObserver-gated, client-side downscale, object URLs revoked on unmount).
- **Bulk-upload rate limiting**: `POST /files` throttle raised 120→600/60s (matching the inline-image routes); `assertOk`/`uploadFile` throw a typed `HttpError` carrying status + `Retry-After`, and the upload queue auto-retries 429s with capped exponential backoff. Retry is idempotent (persisted `fileId`/`docId` re-read from the live store each attempt).

**Non-goals (deferred):** image comments/presence/sharing (`image-<id>` Yorkie doc), documents-list gallery/grid view, server-side thumbnails, SVG/HEIC.

## Test plan

- `pnpm verify:fast` green (all package lint + unit suites); frontend build + chunk gate pass.
- New/updated unit tests: `FileService` image MIME + 25 MB cap; `assertFileIdAllowed` (pdf/image allowed, others rejected); `yorkie-doc-key` image prefix (+ restored pre-existing coverage); `classifyUploadKind` image extensions; upload-queue image branch, 429 backoff-retry, and 429-after-upload idempotency (no re-upload); `getDocumentPath("image") → /f/:id`.
- **Manual smoke (recommended before merge, not yet run):** `docker compose up -d` + `pnpm dev` → drop a mixed batch (image/pdf/xlsx/unsupported) → images land as `image` docs, unsupported skipped; open an image (zoom/download, arrow-key nav across workspace images); list thumbnails lazy-load on scroll; PDF still opens with comments (no regression); a >25 MB image is rejected with a per-row reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “image” document type with PNG/JPEG/GIF/WebP upload support.
  * Added image thumbnails to document lists (lazy-loaded) and an image viewer at `/f/:id` with zoom, download, keyboard navigation, and workspace prev/next.
  * Added image filtering and a dedicated image upload option.
* **Bug Fixes**
  * Improved rate-limited upload handling (HTTP 429) with backoff/retry-after aware retries, plus clearer validation and per-image size limits (25MB).
* **Documentation**
  * Updated design and task tracking notes for end-to-end image support and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->