### PR TITLE
Upload dropped files into the current folder, not Home

### DIFF
--- a/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
+++ b/packages/frontend/src/app/documents/__tests__/upload-queue-worker.test.ts
@@ -52,6 +52,41 @@ describe("upload-queue worker", () => {
     );
   });
 
+  it("creates dropped documents in the folder the list is viewing", async () => {
+    const deps = {
+      importXlsx: vi.fn(async (f: File) => ({
+        document: { tabOrder: ["t"] },
+        fileName: f.name,
+      })),
+      importDocx: vi.fn(),
+      importPptxFile: vi.fn(),
+      uploadFile: vi.fn(async () => ({ id: "blob-1" })),
+      createDoc: vi.fn(async (_ws, p) => ({
+        id: "d" + p.title,
+        title: p.title,
+        type: p.type,
+      })),
+      getDocumentPath: (d: { id: string }) => `/path/${d.id}`,
+      applyContent: vi.fn(async () => {}),
+    };
+    // Enqueue while viewing folder "folder-7": the created document must land
+    // in that folder, not the workspace root.
+    q.enqueue([file("a.xlsx"), file("c.pdf")], "ws1", "folder-7");
+    q.startUploads(undefined, deps as never);
+    await flush();
+    await flush();
+    await flush();
+
+    expect(deps.createDoc).toHaveBeenCalledWith(
+      "ws1",
+      expect.objectContaining({ type: "sheet", folderId: "folder-7" }),
+    );
+    expect(deps.createDoc).toHaveBeenCalledWith(
+      "ws1",
+      expect.objectContaining({ type: "pdf", folderId: "folder-7" }),
+    );
+  });
+
   it("uploads an image blob and creates an image document", async () => {
     const deps = {
       importXlsx: vi.fn(),

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -478,7 +478,9 @@ export function DocumentList({
   const startBatch = useCallback(
     (files: File[]) => {
       if (files.length === 0) return;
-      enqueue(files, workspaceId);
+      // Pass the folder the list is currently viewing so dropped/picked files
+      // land here, not the workspace root (matches the manual "New …" path).
+      enqueue(files, workspaceId, folderId ?? undefined);
       // The settled callback keys off each item's OWN captured workspaceId,
       // not the closed-over one — a batch may finish after the user has
       // switched the list to another workspace, and startUploads keeps only
@@ -498,7 +500,7 @@ export function DocumentList({
         }
       });
     },
-    [workspaceId, scheduleListRefresh],
+    [workspaceId, folderId, scheduleListRefresh],
   );
 
   // Google-Drive-style whole-window drop: a file dropped anywhere (not just on

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -1067,10 +1067,10 @@ export function DocumentList({
                 }
               >
                 <SelectTrigger id="move-folder">
-                  <SelectValue placeholder="(workspace root)" />
+                  <SelectValue placeholder="Home" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="__root__">(workspace root)</SelectItem>
+                  <SelectItem value="__root__">Home</SelectItem>
                   {moveTargetFolders.map((f) => {
                     const depth = folderPath(moveTargetFolders, f.id).length - 1;
                     return (

--- a/packages/frontend/src/app/documents/upload-queue.ts
+++ b/packages/frontend/src/app/documents/upload-queue.ts
@@ -23,6 +23,10 @@ export interface UploadItem {
   fileName: string;
   kind: UploadKind | null;
   workspaceId?: string;
+  /** Folder the list was viewing when the file was enqueued (null = workspace
+   *  root). Threaded into createDoc so a dropped file lands where the user is,
+   *  matching the manual "New …" path. */
+  folderId?: string | null;
   status: UploadStatus;
   done: number;
   total: number;
@@ -60,7 +64,11 @@ export function subscribe(cb: () => void): () => void {
   };
 }
 
-export function enqueue(files: File[], workspaceId?: string): UploadItem[] {
+export function enqueue(
+  files: File[],
+  workspaceId?: string,
+  folderId?: string | null,
+): UploadItem[] {
   const created: UploadItem[] = files.map((file) => {
     const kind = classifyUploadKind(file.name);
     return {
@@ -71,6 +79,7 @@ export function enqueue(files: File[], workspaceId?: string): UploadItem[] {
       fileName: file.name,
       kind,
       workspaceId,
+      folderId,
       status: kind ? "pending" : "skipped",
       done: 0,
       total: 0,
@@ -151,7 +160,12 @@ export interface UploadDeps {
   uploadFile: typeof uploadFile;
   createDoc: (
     workspaceId: string | undefined,
-    payload: { title: string; type: DocumentType; fileId?: string },
+    payload: {
+      title: string;
+      type: DocumentType;
+      fileId?: string;
+      folderId?: string | null;
+    },
   ) => Promise<Document>;
   getDocumentPath: (doc: DocRef) => string;
   applyContent: typeof applyImportedContentDefault;
@@ -194,7 +208,12 @@ async function getOrCreateDoc(
   if (item.docId) {
     return { id: item.docId, type: payload.type };
   }
-  const created = await activeDeps.createDoc(item.workspaceId, payload);
+  // Route the document into the folder the list was viewing at enqueue time
+  // (null/undefined = workspace root), mirroring the manual "New …" path.
+  const created = await activeDeps.createDoc(item.workspaceId, {
+    ...payload,
+    folderId: item.folderId,
+  });
   const id = String(created.id);
   // Persist the docId as soon as the document exists, *before* the stash
   // step runs. If stash throws, the item lands in "error" with docId


### PR DESCRIPTION
## Summary

Fixes two folder-related UX issues on the documents list:

1. **Drag-and-drop / import uploads ignored the current folder.** When viewing a folder, dropping (or picking) files created the documents at the workspace root (Home) instead of the folder in view. The manual "New …" path already honored the folder — only the upload queue didn't.

   Root cause: the upload queue never threaded `folderId`. `startBatch` called `enqueue` with only `workspaceId`, `UploadItem` had no `folderId` field, and the `getOrCreateDoc` payload omitted it — so `createWorkspaceDocument` (which already accepts `folderId`) received `undefined` and the backend filed the doc at the root.

   Fix: thread `folderId` from the viewing folder through `enqueue → UploadItem → getOrCreateDoc`. The `handleImportPick` path routes through the same `startBatch`, so it is fixed too.

2. **Move Document dialog naming.** The dialog labeled the workspace root `(workspace root)` while the folder breadcrumb calls the same place "Home". Renamed the placeholder and select item to "Home" for consistency.

## Test plan

- Added `upload-queue-worker.test.ts` case asserting a dropped batch enqueued while viewing a folder creates its documents with that `folderId` (fails before the fix, passes after).
- `pnpm verify:fast` green (lint + all unit tests).
- Workflow-backed code review at high effort: no findings.
- Manual: drop a file inside a folder → document appears in that folder, not Home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uploaded files are now created in the folder currently being viewed, including during retries.
  * Batch imports correctly preserve their selected folder destination.
  * Updated the move dialog’s root location label to “Home.”
* **Tests**
  * Added coverage confirming spreadsheet and PDF uploads are placed in the selected folder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->