### PR TITLE
Import DOCX text wrapped in content controls (w:sdt)

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| docx sdt text import (2026-07-21) | [20260721-docx-sdt-text-import-todo.md](./active/20260721-docx-sdt-text-import-todo.md) | [20260721-docx-sdt-text-import-lessons.md](./active/20260721-docx-sdt-text-import-lessons.md) |
 | documents bulk select move (2026-07-20) | [20260720-documents-bulk-select-move-todo.md](./active/20260720-documents-bulk-select-move-todo.md) | [20260720-documents-bulk-select-move-lessons.md](./active/20260720-documents-bulk-select-move-lessons.md) |
 | analytics dashboard viz (2026-07-19) | [20260719-analytics-dashboard-viz-todo.md](./active/20260719-analytics-dashboard-viz-todo.md) | [20260719-analytics-dashboard-viz-lessons.md](./active/20260719-analytics-dashboard-viz-lessons.md) |
 | image viewer (2026-07-19) | [20260719-image-viewer-todo.md](./active/20260719-image-viewer-todo.md) | [20260719-image-viewer-lessons.md](./active/20260719-image-viewer-lessons.md) |
@@ -40,4 +41,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 374
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: documents bulk select move (2026-07-20)
+Latest active task: docx sdt text import (2026-07-21)

--- a/docs/tasks/active/20260721-docx-sdt-text-import-lessons.md
+++ b/docs/tasks/active/20260721-docx-sdt-text-import-lessons.md
@@ -1,0 +1,42 @@
+# Lessons — DOCX inline `<w:sdt>` text import
+
+## What broke
+
+A Google-Docs-exported `.docx` imported with no visible body text. The
+paragraph parser only kept runs whose direct parent was the paragraph or a
+`<w:hyperlink>`; Google Docs wraps most body runs in inline content controls
+(`<w:p><w:sdt><w:sdtContent><w:r>`), so 63% of the text was silently dropped.
+
+## Lessons
+
+- **OOXML wrappers are not all transparent — classify them.** Once you descend
+  through inline wrappers, you inherit every wrapper, including ones whose
+  content must *not* import: tracked deletions (`w:del`), tracked-move source
+  (`w:moveFrom`), and ruby phonetic guides (`w:rt`). Broadening a "keep this
+  run" guard silently reverses a bunch of implicit filters. Enumerate the
+  wrappers you now let through and decide keep-vs-drop for each, rather than
+  assuming "inside the paragraph" means "visible text."
+
+- **`getElementsByTagNameNS(..)[0]` is a latent nested-content trap.** It
+  matches the first *descendant*, not the first child. `<w:pPr>`/`<w:rPr>` are
+  first children by schema, so it usually works — until a paragraph nests
+  another paragraph (drawing textbox) and the outer element has no property of
+  its own, at which point it adopts the nested one's style. Use a direct-child
+  scan for property lookups.
+
+- **A `<w:p>` *can* contain another `<w:p>`.** Not directly, but via
+  `<w:drawing><wps:txbx><w:txbxContent><w:p>`. The "a paragraph can't nest a
+  paragraph" intuition is wrong; the nested-block floor that stops the ancestor
+  walk is load-bearing (it keeps textbox runs out of the body), not defensive.
+
+- **Fixing the inline case leaves the block-level twin broken.** Inline
+  `<w:sdt>` lives inside a paragraph; block-level `<w:sdt>` wraps whole
+  paragraphs/tables at the body/cell/header level. The body/cell/header walks
+  matched only direct-child `w:p`/`w:tbl`, so block-wrapped content still
+  imported empty. Same root cause (sdt ignored), different enumeration site —
+  fix both, via one shared unwrapping helper.
+
+- **Reproduce against the real artifact, not just synthetic XML.** The
+  synthetic unit test proved the guard logic; running the actual 103-run report
+  file end-to-end (0 → 85 non-empty lines) proved the fix mattered and later
+  confirmed the review follow-ups dropped no legitimate content.

--- a/docs/tasks/active/20260721-docx-sdt-text-import-todo.md
+++ b/docs/tasks/active/20260721-docx-sdt-text-import-todo.md
@@ -23,14 +23,34 @@ text runs (63%) live under `<w:sdt>`, so the visible text vanished.
       asserting inline-sdt runs are included in document order, plus a
       hyperlink-inside-sdt case.
 
+## Review follow-ups (self code review, high effort)
+
+The broadened guard was a regression surface; the review surfaced adjacent
+correctness gaps addressed in the same PR:
+
+- [x] Exclude removed/alternate run wrappers so they no longer leak or
+      duplicate: tracked deletion (`w:del`), tracked-move source
+      (`w:moveFrom`), ruby phonetic guide (`w:rt`). Live counterparts
+      (`w:ins`/`w:moveTo`/`w:rubyBase`) stay visible.
+- [x] Fix the `pPr`/`rPr` property lookups from a descendant `[0]` match to a
+      direct-child scan, so a paragraph/run with no own properties no longer
+      adopts a nested drawing-textbox paragraph's style.
+- [x] Enumerate block-level `<w:sdt>`: a shared `blockChildElements` generator
+      unwraps `w:sdt`/`w:sdtContent` in the body, table-cell, and header/footer
+      walks so block-wrapped paragraphs/tables are no longer skipped.
+- [x] Clarify that the nested-block floor is load-bearing (drawing textboxes
+      legitimately nest paragraphs), not merely defensive.
+
 ## Verification
 
-- [x] `parseParagraph` unit tests green (7/7)
+- [x] `parseParagraph` unit tests green (11/11)
+- [x] Full docs import suite green (88/88)
 - [x] End-to-end import of the real file: 85 non-empty text lines restored
-      (was effectively none); "중간보고서", "개요", 멘티별 활동내역 all present
-- [x] Full docs import suite green (82/82)
-- [ ] `pnpm verify:fast`
-- [ ] Self code review over the branch diff
+      (was effectively none); title, overview, and per-mentee activity
+      sections all present. Count unchanged after the review follow-ups (no
+      legitimate content dropped).
+- [x] `pnpm verify:fast`
+- [x] Self code review over the branch diff (findings addressed above)
 - [ ] PR opened
 
 ## Note

--- a/docs/tasks/active/20260721-docx-sdt-text-import-todo.md
+++ b/docs/tasks/active/20260721-docx-sdt-text-import-todo.md
@@ -51,7 +51,10 @@ correctness gaps addressed in the same PR:
       legitimate content dropped).
 - [x] `pnpm verify:fast`
 - [x] Self code review over the branch diff (findings addressed above)
-- [ ] PR opened
+- [x] PR opened (#504)
+- [x] Address PR review: unwrap `w:sdt`-wrapped table rows/cells in
+      `convertTable`/`deriveColWidthsFromCells`; add a `w:ins`-inclusion
+      regression test
 
 ## Note
 

--- a/docs/tasks/active/20260721-docx-sdt-text-import-todo.md
+++ b/docs/tasks/active/20260721-docx-sdt-text-import-todo.md
@@ -1,0 +1,40 @@
+# DOCX import drops text wrapped in inline `<w:sdt>`
+
+## Problem
+
+A Google-Docs-exported `.docx` (2020 오픈소스 컨트리뷰톤 중간보고서) imported
+into Docs showed no body text — only table borders. Root cause: Google Docs
+wraps most exported body runs in inline content controls
+(`<w:p><w:sdt><w:sdtContent><w:r><w:t>…`). The paragraph parser's run guard
+only kept runs whose direct parent was the paragraph or a `<w:hyperlink>`, so
+every run nested inside `<w:sdt>` was dropped. In the sample file 65 of 103
+text runs (63%) live under `<w:sdt>`, so the visible text vanished.
+
+## Fix
+
+- [x] Replace the parent-restriction guard in `parseParagraph` with
+      `runBelongsToParagraph(r, pEl)`: walk ancestors, include the run when the
+      first block ancestor reached is the paragraph itself; inline wrappers
+      (`w:sdt`, `w:sdtContent`, `w:hyperlink`, `w:smartTag`, fields…) are
+      transparent, a nested block (`w:p`/`w:tbl`) reached first excludes it.
+      Document order is preserved because `getElementsByTagNameNS` returns
+      descendants in order.
+- [x] Replace the wrong "should skip runs nested inside w:sdt" test with tests
+      asserting inline-sdt runs are included in document order, plus a
+      hyperlink-inside-sdt case.
+
+## Verification
+
+- [x] `parseParagraph` unit tests green (7/7)
+- [x] End-to-end import of the real file: 85 non-empty text lines restored
+      (was effectively none); "중간보고서", "개요", 멘티별 활동내역 all present
+- [x] Full docs import suite green (82/82)
+- [ ] `pnpm verify:fast`
+- [ ] Self code review over the branch diff
+- [ ] PR opened
+
+## Note
+
+Documents already imported with the buggy code keep the dropped text in their
+stored CRDT — re-import is required to recover it. The fix only affects new
+imports.

--- a/packages/docs/src/import/docx-importer.ts
+++ b/packages/docs/src/import/docx-importer.ts
@@ -128,10 +128,7 @@ export class DocxImporter {
     const blocks: Block[] = [];
     let pageSetup: PageSetup | undefined;
     let sectPrEl: Element | undefined;
-    for (let i = 0; i < body.childNodes.length; i++) {
-      const node = body.childNodes[i];
-      if (node.nodeType !== 1) continue;
-      const el = node as Element;
+    for (const el of DocxImporter.blockChildElements(body)) {
       if (el.localName === 'p') {
         blocks.push(DocxImporter.convertParagraph(el, imageUrls));
       } else if (el.localName === 'tbl') {
@@ -415,10 +412,7 @@ export class DocxImporter {
 
         // Parse cell content blocks
         const cellBlocks: Block[] = [];
-        for (let k = 0; k < tcEl.childNodes.length; k++) {
-          const childNode = tcEl.childNodes[k];
-          if (childNode.nodeType !== 1) continue;
-          const childEl = childNode as Element;
+        for (const childEl of DocxImporter.blockChildElements(tcEl)) {
           if (childEl.localName === 'p') {
             cellBlocks.push(DocxImporter.convertParagraph(childEl, imageUrls));
           } else if (childEl.localName === 'tbl') {
@@ -624,6 +618,30 @@ export class DocxImporter {
   }
 
   /**
+   * Yield the effective block-level children of a container (body, table
+   * cell, or header/footer root), transparently unwrapping block-level
+   * content controls: a <w:sdt> wrapping block content exposes the
+   * <w:p>/<w:tbl>/<w:sectPr> inside its <w:sdtContent> as if they were direct
+   * children. Word forms and some Google Docs exports wrap whole paragraphs
+   * and tables this way; without unwrapping, the enclosed content would never
+   * be enumerated and the document would import empty. Nested block-level sdts
+   * are unwrapped recursively.
+   */
+  private static *blockChildElements(parent: Element): Iterable<Element> {
+    for (let i = 0; i < parent.childNodes.length; i++) {
+      const node = parent.childNodes[i];
+      if (node.nodeType !== 1) continue;
+      const el = node as Element;
+      if (el.localName === 'sdt') {
+        const content = DocxImporter.findDirectChild(el, 'sdtContent');
+        if (content) yield* DocxImporter.blockChildElements(content);
+        continue;
+      }
+      yield el;
+    }
+  }
+
+  /**
    * Return the first direct-child element with the given local name, or
    * null. Unlike getElementsByTagNameNS this does not recurse, which is
    * what we want for table structure lookups where nested tables must
@@ -722,10 +740,7 @@ export class DocxImporter {
     if (!root) return undefined;
 
     const blocks: Block[] = [];
-    for (let i = 0; i < root.childNodes.length; i++) {
-      const node = root.childNodes[i];
-      if (node.nodeType !== 1) continue;
-      const el = node as Element;
+    for (const el of DocxImporter.blockChildElements(root)) {
       if (el.localName === 'p') {
         blocks.push(DocxImporter.convertParagraph(el, partImageUrls));
       } else if (el.localName === 'tbl') {

--- a/packages/docs/src/import/docx-importer.ts
+++ b/packages/docs/src/import/docx-importer.ts
@@ -307,10 +307,8 @@ export class DocxImporter {
       }
     };
 
-    for (let i = 0; i < tblEl.childNodes.length; i++) {
-      const node = tblEl.childNodes[i];
-      if (node.nodeType !== 1 || (node as Element).localName !== 'tr') continue;
-      const trEl = node as Element;
+    for (const trEl of DocxImporter.blockChildElements(tblEl)) {
+      if (trEl.localName !== 'tr') continue;
 
       // <w:trPr> can declare w:gridBefore / w:gridAfter to leave N leading or
       // trailing grid columns empty. These rows ship fewer <w:tc> children
@@ -342,10 +340,8 @@ export class DocxImporter {
       const cells: TableCell[] = [];
       for (let s = 0; s < gridBefore; s++) cells.push(makeCoveredCell());
       let colIdx = gridBefore;
-      for (let j = 0; j < trEl.childNodes.length; j++) {
-        const tcNode = trEl.childNodes[j];
-        if (tcNode.nodeType !== 1 || (tcNode as Element).localName !== 'tc') continue;
-        const tcEl = tcNode as Element;
+      for (const tcEl of DocxImporter.blockChildElements(trEl)) {
+        if (tcEl.localName !== 'tc') continue;
 
         // Parse cell properties. Direct-child only: getElementsByTagNameNS
         // recurses, so an outer cell with no own <w:tcPr> would otherwise
@@ -557,15 +553,11 @@ export class DocxImporter {
    */
   private static deriveColWidthsFromCells(tblEl: Element, out: number[]): void {
     let best: number[] = [];
-    for (let i = 0; i < tblEl.childNodes.length; i++) {
-      const node = tblEl.childNodes[i];
-      if (node.nodeType !== 1 || (node as Element).localName !== 'tr') continue;
-      const trEl = node as Element;
+    for (const trEl of DocxImporter.blockChildElements(tblEl)) {
+      if (trEl.localName !== 'tr') continue;
       const weights: number[] = [];
-      for (let j = 0; j < trEl.childNodes.length; j++) {
-        const tcNode = trEl.childNodes[j];
-        if (tcNode.nodeType !== 1 || (tcNode as Element).localName !== 'tc') continue;
-        const tcEl = tcNode as Element;
+      for (const tcEl of DocxImporter.blockChildElements(trEl)) {
+        if (tcEl.localName !== 'tc') continue;
         // Direct-child only so a nested table's tcW/gridSpan never leaks into
         // the outer table's derived column widths.
         const tcPr = DocxImporter.findDirectChild(tcEl, 'tcPr');
@@ -618,14 +610,15 @@ export class DocxImporter {
   }
 
   /**
-   * Yield the effective block-level children of a container (body, table
-   * cell, or header/footer root), transparently unwrapping block-level
-   * content controls: a <w:sdt> wrapping block content exposes the
-   * <w:p>/<w:tbl>/<w:sectPr> inside its <w:sdtContent> as if they were direct
-   * children. Word forms and some Google Docs exports wrap whole paragraphs
-   * and tables this way; without unwrapping, the enclosed content would never
-   * be enumerated and the document would import empty. Nested block-level sdts
-   * are unwrapped recursively.
+   * Yield the effective children of a container, transparently unwrapping
+   * content controls: a <w:sdt> exposes whatever sits inside its
+   * <w:sdtContent> as if it were a direct child. Word forms and some Google
+   * Docs exports wrap block content (paragraphs/tables in the body, table
+   * cell, or header/footer root) as well as table rows (<w:tr>) and cells
+   * (<w:tc>) this way; without unwrapping, the enclosed content would never be
+   * enumerated and would vanish on import. Callers filter the yielded elements
+   * by local name (p/tbl/sectPr, tr, tc). Nested sdts are unwrapped
+   * recursively.
    */
   private static *blockChildElements(parent: Element): Iterable<Element> {
     for (let i = 0; i < parent.childNodes.length; i++) {

--- a/packages/docs/src/import/docx-parser.ts
+++ b/packages/docs/src/import/docx-parser.ts
@@ -123,22 +123,55 @@ export function parseRelationships(xml: string): Map<string, RelEntry> {
 }
 
 /**
+ * Return the first direct-child element with the given W-namespace local name,
+ * or null. Unlike getElementsByTagNameNS this does not recurse, so a
+ * paragraph/run that has no property element of its own does not adopt a
+ * nested paragraph's (e.g. a drawing textbox's <w:pPr>/<w:rPr>).
+ */
+function firstDirectChildNS(parent: Element, localName: string): Element | null {
+  for (let i = 0; i < parent.childNodes.length; i++) {
+    const n = parent.childNodes[i];
+    if (n.nodeType === 1) {
+      const el = n as Element;
+      if (el.namespaceURI === W && el.localName === localName) return el;
+    }
+  }
+  return null;
+}
+
+/**
+ * W-namespace wrappers whose runs must NOT be imported even though they sit
+ * inside the paragraph: tracked deletions (w:del) and the source side of a
+ * tracked move (w:moveFrom) are removed content, and the ruby phonetic guide
+ * (w:rt) would otherwise inline the reading next to the base text. Their live
+ * counterparts (w:ins, w:moveTo, w:rubyBase) are intentionally absent so their
+ * runs stay visible.
+ */
+const EXCLUDED_RUN_ANCESTORS = new Set(['del', 'moveFrom', 'rt']);
+
+/**
  * True when a <w:r> run is part of the given paragraph's own inline content.
  *
  * Walking up from the run, the first block ancestor we reach must be the
  * paragraph itself. Intermediate inline wrappers (w:hyperlink, w:sdt,
  * w:sdtContent, w:smartTag, w:fldSimple, w:ins…) are transparent — their runs
- * carry visible text that belongs to the paragraph. A nested block (another
- * w:p or a w:tbl) reached before the paragraph means the run lives in nested
- * structure and must not leak into this paragraph's inline list. In OOXML a
- * <w:p> cannot contain another <w:p>/<w:tbl>, so this is a defensive floor.
+ * carry visible text that belongs to the paragraph. Two categories stop the
+ * walk early and exclude the run:
+ *   - a nested block (w:p/w:tbl), which a paragraph legitimately contains via a
+ *     drawing textbox (<w:drawing><wps:txbx><w:txbxContent><w:p>); this floor
+ *     is load-bearing, not defensive — without it textbox runs would leak into
+ *     the enclosing paragraph's inline list.
+ *   - a removed/alternate wrapper (EXCLUDED_RUN_ANCESTORS: w:del, w:moveFrom,
+ *     w:rt) whose text should not import.
  */
 function runBelongsToParagraph(r: Element, pEl: Element): boolean {
   let node: Element | null = r.parentElement;
   while (node) {
     if (node === pEl) return true;
-    if (node.namespaceURI === W && (node.localName === 'p' || node.localName === 'tbl')) {
-      return false;
+    if (node.namespaceURI === W) {
+      const ln = node.localName;
+      if (ln === 'p' || ln === 'tbl') return false;
+      if (EXCLUDED_RUN_ANCESTORS.has(ln)) return false;
     }
     node = node.parentElement;
   }
@@ -160,7 +193,7 @@ export function parseParagraph(pEl: Element): {
   let headingLevel: number | undefined;
   const imageRefs: ImageRef[] = [];
 
-  const pPr = pEl.getElementsByTagNameNS(W, 'pPr')[0];
+  const pPr = firstDirectChildNS(pEl, 'pPr');
   if (pPr) {
     const mapped = mapParagraphProperties(pPr);
     blockStyle = mapped.blockStyle;
@@ -184,7 +217,7 @@ export function parseParagraph(pEl: Element): {
     }
 
     let style: InlineStyle = {};
-    const rPr = r.getElementsByTagNameNS(W, 'rPr')[0];
+    const rPr = firstDirectChildNS(r, 'rPr');
     if (rPr) {
       style = mapRunProperties(rPr);
     }

--- a/packages/docs/src/import/docx-parser.ts
+++ b/packages/docs/src/import/docx-parser.ts
@@ -123,6 +123,29 @@ export function parseRelationships(xml: string): Map<string, RelEntry> {
 }
 
 /**
+ * True when a <w:r> run is part of the given paragraph's own inline content.
+ *
+ * Walking up from the run, the first block ancestor we reach must be the
+ * paragraph itself. Intermediate inline wrappers (w:hyperlink, w:sdt,
+ * w:sdtContent, w:smartTag, w:fldSimple, w:ins…) are transparent — their runs
+ * carry visible text that belongs to the paragraph. A nested block (another
+ * w:p or a w:tbl) reached before the paragraph means the run lives in nested
+ * structure and must not leak into this paragraph's inline list. In OOXML a
+ * <w:p> cannot contain another <w:p>/<w:tbl>, so this is a defensive floor.
+ */
+function runBelongsToParagraph(r: Element, pEl: Element): boolean {
+  let node: Element | null = r.parentElement;
+  while (node) {
+    if (node === pEl) return true;
+    if (node.namespaceURI === W && (node.localName === 'p' || node.localName === 'tbl')) {
+      return false;
+    }
+    node = node.parentElement;
+  }
+  return false;
+}
+
+/**
  * Parse a <w:p> element into inlines and block metadata.
  */
 export function parseParagraph(pEl: Element): {
@@ -149,10 +172,14 @@ export function parseParagraph(pEl: Element): {
   const runs = pEl.getElementsByTagNameNS(W, 'r');
   for (let i = 0; i < runs.length; i++) {
     const r = runs[i];
-    // Skip runs that are not a direct child of the paragraph or a hyperlink.
-    // Without this guard, runs inside nested structures we don't handle
-    // (e.g. w:sdt) leak into the surrounding paragraph's inline list.
-    if (r.parentElement !== pEl && r.parentElement?.localName !== 'hyperlink') {
+    // Include only runs that belong directly to this paragraph — descending
+    // through inline wrappers (w:hyperlink, w:sdt/w:sdtContent, w:smartTag,
+    // fields) but never through a nested block (w:p/w:tbl). getElementsByTagNameNS
+    // returns descendants in document order, so a run inside an inline content
+    // control keeps its position relative to the paragraph's direct-child runs.
+    // Google Docs wraps most exported body text in <w:sdt>, so the earlier
+    // "direct child or hyperlink only" guard dropped the majority of the text.
+    if (!runBelongsToParagraph(r, pEl)) {
       continue;
     }
 

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -105,6 +105,36 @@ describe('DocxImporter', () => {
     ).toBe('Cell');
   });
 
+  it('should import table rows and cells wrapped in a w:sdt', async () => {
+    // Repeating-section content controls wrap <w:tr> at table level and <w:tc>
+    // at row level in <w:sdt>. The row and cell walks must unwrap them too, or
+    // the wrapped rows/cells vanish from the imported table.
+    const buffer = await createMinimalDocx(`
+      <w:tbl>
+        <w:tblGrid><w:gridCol w:w="100"/><w:gridCol w:w="100"/></w:tblGrid>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>A1</w:t></w:r></w:p></w:tc>
+          <w:sdt><w:sdtContent>
+            <w:tc><w:p><w:r><w:t>B1</w:t></w:r></w:p></w:tc>
+          </w:sdtContent></w:sdt>
+        </w:tr>
+        <w:sdt><w:sdtContent>
+          <w:tr>
+            <w:tc><w:p><w:r><w:t>A2</w:t></w:r></w:p></w:tc>
+            <w:tc><w:p><w:r><w:t>B2</w:t></w:r></w:p></w:tc>
+          </w:tr>
+        </w:sdtContent></w:sdt>
+      </w:tbl>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    const rows = doc.blocks[0].tableData?.rows ?? [];
+    const text = (r: number, c: number) =>
+      rows[r].cells[c].blocks[0].inlines[0].text;
+    expect(rows).toHaveLength(2);
+    expect([text(0, 0), text(0, 1)]).toEqual(['A1', 'B1']);
+    expect([text(1, 0), text(1, 1)]).toEqual(['A2', 'B2']);
+  });
+
   it('should import styled text runs', async () => {
     const buffer = await createMinimalDocx(`
       <w:p>

--- a/packages/docs/test/import/docx-importer.test.ts
+++ b/packages/docs/test/import/docx-importer.test.ts
@@ -67,6 +67,44 @@ describe('DocxImporter', () => {
     expect(doc.blocks[1].inlines[0].text).toBe('Second');
   });
 
+  it('should import paragraphs wrapped in a block-level w:sdt', async () => {
+    // Word forms and some Google Docs exports wrap block content in a
+    // block-level content control: <w:sdt><w:sdtContent><w:p>…</w:p>. The body
+    // walk must descend through w:sdt/w:sdtContent to reach the paragraphs.
+    const buffer = await createMinimalDocx(`
+      <w:p><w:r><w:t>Before</w:t></w:r></w:p>
+      <w:sdt><w:sdtContent>
+        <w:p><w:r><w:t>Inside SDT</w:t></w:r></w:p>
+        <w:p><w:r><w:t>Also inside</w:t></w:r></w:p>
+      </w:sdtContent></w:sdt>
+      <w:p><w:r><w:t>After</w:t></w:r></w:p>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks.map((b) => b.inlines.map((i) => i.text).join(''))).toEqual([
+      'Before',
+      'Inside SDT',
+      'Also inside',
+      'After',
+    ]);
+  });
+
+  it('should import a table wrapped in a block-level w:sdt', async () => {
+    const buffer = await createMinimalDocx(`
+      <w:sdt><w:sdtContent>
+        <w:tbl>
+          <w:tblGrid><w:gridCol w:w="100"/></w:tblGrid>
+          <w:tr><w:tc><w:p><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr>
+        </w:tbl>
+      </w:sdtContent></w:sdt>
+    `);
+    const doc = await DocxImporter.import(buffer);
+    expect(doc.blocks).toHaveLength(1);
+    expect(doc.blocks[0].type).toBe('table');
+    expect(
+      doc.blocks[0].tableData?.rows[0].cells[0].blocks[0].inlines[0].text,
+    ).toBe('Cell');
+  });
+
   it('should import styled text runs', async () => {
     const buffer = await createMinimalDocx(`
       <w:p>

--- a/packages/docs/test/import/docx-parser.test.ts
+++ b/packages/docs/test/import/docx-parser.test.ts
@@ -82,6 +82,63 @@ describe('parseParagraph', () => {
     const result = parseParagraph(el);
     expect(result.inlines.map((i) => i.text)).toEqual(['Link']);
   });
+
+  it('should drop runs inside a tracked-change w:del (deleted content)', () => {
+    // Deleted content must not reappear on import. Deleted text uses
+    // <w:delText> (not read anyway), but deleted <w:tab/>/<w:br/> glyphs would
+    // otherwise leak as spurious whitespace once w:del became transparent.
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:r><w:t>Kept</w:t></w:r>
+      <w:del>
+        <w:r><w:tab/><w:br/><w:delText>gone</w:delText></w:r>
+      </w:del>
+    </w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines.map((i) => i.text)).toEqual(['Kept']);
+  });
+
+  it('should drop the source runs of a tracked move (w:moveFrom)', () => {
+    // The move source (w:moveFrom) duplicates text that lives at the move
+    // destination (w:moveTo); only the destination should import.
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:moveFrom><w:r><w:t>Moved</w:t></w:r></w:moveFrom>
+      <w:moveTo><w:r><w:t>Moved</w:t></w:r></w:moveTo>
+    </w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines.map((i) => i.text)).toEqual(['Moved']);
+  });
+
+  it('should keep ruby base text but drop the phonetic guide (w:rt)', () => {
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:r><w:ruby>
+        <w:rt><w:r><w:t>かん</w:t></w:r></w:rt>
+        <w:rubyBase><w:r><w:t>漢</w:t></w:r></w:rubyBase>
+      </w:ruby></w:r>
+    </w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines.map((i) => i.text)).toEqual(['漢']);
+  });
+
+  it('should not adopt a nested textbox paragraph’s pPr', () => {
+    // The outer paragraph has no pPr of its own; a paragraph nested inside a
+    // drawing textbox does. A descendant [0] pPr lookup would wrongly promote
+    // the outer paragraph to the nested heading style — and the nested run
+    // must stay out of the outer paragraph's inlines (blocked by the w:p floor).
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:r><w:t>Body</w:t></w:r>
+      <w:r><w:drawing><w:txbxContent>
+        <w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Inner</w:t></w:r></w:p>
+      </w:txbxContent></w:drawing></w:r>
+    </w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines.map((i) => i.text)).toEqual(['Body']);
+    expect(result.blockType).toBe('paragraph');
+    expect(result.headingLevel).toBeUndefined();
+  });
 });
 
 describe('parsePageSetup', () => {

--- a/packages/docs/test/import/docx-parser.test.ts
+++ b/packages/docs/test/import/docx-parser.test.ts
@@ -98,6 +98,18 @@ describe('parseParagraph', () => {
     expect(result.inlines.map((i) => i.text)).toEqual(['Kept']);
   });
 
+  it('should keep runs inside a tracked-change w:ins (inserted content)', () => {
+    // w:ins is a live wrapper — inserted text must import. Guards against a
+    // regression that mistakenly excludes it alongside w:del/w:moveFrom.
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:r><w:t>Kept</w:t></w:r>
+      <w:ins><w:r><w:t xml:space="preserve"> Added</w:t></w:r></w:ins>
+    </w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines.map((i) => i.text)).toEqual(['Kept', ' Added']);
+  });
+
   it('should drop the source runs of a tracked move (w:moveFrom)', () => {
     // The move source (w:moveFrom) duplicates text that lives at the move
     // destination (w:moveTo); only the destination should import.

--- a/packages/docs/test/import/docx-parser.test.ts
+++ b/packages/docs/test/import/docx-parser.test.ts
@@ -52,21 +52,35 @@ describe('parseParagraph', () => {
     expect(result.inlines[0].text).toBe('A\tB\nC');
   });
 
-  it('should skip runs nested inside structures like w:sdt', () => {
-    // A run whose parent is neither the paragraph nor a hyperlink must be
-    // skipped so it does not leak into the inline list of the outer
-    // paragraph. Without the guard, nested w:sdt content bled through.
+  it('should include runs wrapped in an inline w:sdt in document order', () => {
+    // An inline <w:sdt> (content control) inside a paragraph carries real,
+    // visible text that belongs to that paragraph — Google Docs wraps most
+    // exported body content this way. Its runs must be collected in document
+    // order alongside the paragraph's direct-child runs, not dropped.
     const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
       <w:r><w:t>Outer</w:t></w:r>
       <w:sdt>
         <w:sdtContent>
-          <w:r><w:t>Nested</w:t></w:r>
+          <w:r><w:t xml:space="preserve"> Nested</w:t></w:r>
         </w:sdtContent>
       </w:sdt>
     </w:p>`;
     const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
     const result = parseParagraph(el);
-    expect(result.inlines.map((i) => i.text)).toEqual(['Outer']);
+    expect(result.inlines.map((i) => i.text)).toEqual(['Outer', ' Nested']);
+  });
+
+  it('should include runs wrapped in a hyperlink nested inside a w:sdt', () => {
+    const xml = `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+      <w:sdt>
+        <w:sdtContent>
+          <w:hyperlink><w:r><w:t>Link</w:t></w:r></w:hyperlink>
+        </w:sdtContent>
+      </w:sdt>
+    </w:p>`;
+    const el = new DOMParser().parseFromString(xml, 'text/xml').documentElement;
+    const result = parseParagraph(el);
+    expect(result.inlines.map((i) => i.text)).toEqual(['Link']);
   });
 });
 


### PR DESCRIPTION
## Summary

Importing a Google-Docs-exported `.docx` (a 2020 Korean 컨트리뷰톤 report)
produced a document with **no visible body text** — only table borders. Google
Docs wraps most exported body runs in **inline content controls**
(`<w:p><w:sdt><w:sdtContent><w:r><w:t>…`). The paragraph parser only kept runs
whose direct parent was the paragraph or a `<w:hyperlink>`, so every run nested
inside `<w:sdt>` was silently dropped. In the sample file **65 of 103 text runs
(63%)** live under `<w:sdt>`.

### Changes

- **`parseParagraph` run guard** — replace the "direct child or hyperlink only"
  parent check with `runBelongsToParagraph()`, which walks ancestors and keeps a
  run when the first block ancestor reached is the paragraph itself. Inline
  wrappers (`w:sdt`/`w:sdtContent`, `w:hyperlink`, `w:smartTag`, fields) are
  transparent; document order is preserved.
- **Removed/alternate wrappers excluded** — `w:del` (tracked deletion),
  `w:moveFrom` (tracked-move source), and `w:rt` (ruby phonetic guide) do **not**
  import, so deleted/moved text no longer reappears or duplicates. Live
  counterparts (`w:ins`, `w:moveTo`, `w:rubyBase`) stay visible.
- **Direct-child property lookups** — `pPr`/`rPr` read via a direct-child scan
  instead of a descendant `[0]` match, so a paragraph/run with no own properties
  no longer adopts a nested drawing-textbox paragraph's style.
- **Block-level `w:sdt`** — a shared `blockChildElements` generator unwraps
  `w:sdt`/`w:sdtContent` in the body, table-cell, and header/footer walks, so
  block-wrapped paragraphs/tables import instead of yielding an empty document.

### Note

Documents already imported with the buggy code keep the dropped text in their
stored CRDT — **re-import is required** to recover it. This fix only affects new
imports.

## Test plan

- `parseParagraph` unit tests (11/11): inline-sdt order, hyperlink-in-sdt,
  `w:del`/`w:moveFrom`/`w:rt` exclusion, nested-textbox `pPr` isolation.
- Importer tests (block-level `w:sdt` for paragraphs and tables).
- Full docs import suite green (88/88); `pnpm verify:fast` green.
- End-to-end import of the real report file: **0 → 85 non-empty text lines**
  restored; count unchanged after the review follow-ups (no legitimate content
  dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOCX imports for text and tables wrapped in Word content controls.
  * Preserved inline text, hyperlinks, paragraphs, and tables in their correct document order.
  * Prevented unrelated nested content and tracked deletions or moved text from being imported incorrectly.
  * Improved formatting detection for paragraph and run properties.

* **Tests**
  * Added regression coverage for content controls, nested hyperlinks, tables, tracked changes, ruby text, and nested paragraphs.

* **Documentation**
  * Documented the DOCX import issue, fix, lessons learned, and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->