### PR TITLE
Notes: Tab indent (default+vim) and toolbar Undo/Redo

### DIFF
--- a/packages/frontend/src/app/notes/notes-toolbar.tsx
+++ b/packages/frontend/src/app/notes/notes-toolbar.tsx
@@ -34,6 +34,8 @@ import {
   IconLink,
   IconTable,
   IconKeyboard,
+  IconArrowBackUp,
+  IconArrowForwardUp,
 } from "@tabler/icons-react";
 
 const KEYMAPS: { key: NoteKeymap; label: string }[] = [
@@ -77,6 +79,34 @@ function TooltipToggle({
         >
           {children}
         </Toggle>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** Plain (non-toggle) toolbar action with a tooltip and disabled state. */
+function TooltipButton({
+  label,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <ToolbarButton
+          aria-label={label}
+          disabled={disabled}
+          onClick={onClick}
+        >
+          {children}
+        </ToolbarButton>
       </TooltipTrigger>
       <TooltipContent>{label}</TooltipContent>
     </Tooltip>
@@ -147,14 +177,23 @@ export function NotesToolbar({
   readOnly?: boolean;
 }) {
   const [formats, setFormats] = useState<NoteInlineFormats>(EMPTY_FORMATS);
+  const [history, setHistory] = useState({ canUndo: false, canRedo: false });
 
   useEffect(() => {
     if (!editor) {
       setFormats(EMPTY_FORMATS);
+      setHistory({ canUndo: false, canRedo: false });
       return;
     }
-    setFormats(editor.getActiveFormats());
-    editor.onSelectionChange(setFormats);
+    // The selection-change callback fires on every doc/selection change, which
+    // is exactly when both inline formats and undo/redo depth can change — so
+    // we refresh both from the one subscription.
+    const refresh = (f: NoteInlineFormats) => {
+      setFormats(f);
+      setHistory({ canUndo: editor.canUndo(), canRedo: editor.canRedo() });
+    };
+    refresh(editor.getActiveFormats());
+    editor.onSelectionChange(refresh);
     return () => editor.onSelectionChange(null);
   }, [editor]);
 
@@ -165,6 +204,21 @@ export function NotesToolbar({
     <Toolbar aria-label="Note toolbar">
       {canFormat && editor && (
         <>
+          <TooltipButton
+            label="Undo"
+            disabled={!history.canUndo}
+            onClick={() => editor.undo()}
+          >
+            <IconArrowBackUp size={16} />
+          </TooltipButton>
+          <TooltipButton
+            label="Redo"
+            disabled={!history.canRedo}
+            onClick={() => editor.redo()}
+          >
+            <IconArrowForwardUp size={16} />
+          </TooltipButton>
+          <ToolbarSeparator />
           <TooltipToggle
             label="Bold"
             pressed={formats.bold}

--- a/packages/notes/src/view/editor.ts
+++ b/packages/notes/src/view/editor.ts
@@ -1,6 +1,13 @@
+import {
+  indentWithTab,
+  redo,
+  redoDepth,
+  undo,
+  undoDepth,
+} from '@codemirror/commands';
 import { markdown } from '@codemirror/lang-markdown';
 import { EditorState, type Extension } from '@codemirror/state';
-import { EditorView } from '@codemirror/view';
+import { EditorView, keymap } from '@codemirror/view';
 import { vim } from '@replit/codemirror-vim';
 import { basicSetup } from '@uiw/codemirror-extensions-basic-setup';
 import { xcodeDark, xcodeLight } from '@uiw/codemirror-theme-xcode';
@@ -58,6 +65,14 @@ export interface NoteEditorAPI {
   toggleLink(): void;
   /** Insert a `rows`×`cols` markdown table skeleton at the cursor. */
   insertTable(rows: number, cols: number): void;
+  /** Undo the last local edit. */
+  undo(): void;
+  /** Redo the last undone local edit. */
+  redo(): void;
+  /** Whether there is a local edit to undo. */
+  canUndo(): boolean;
+  /** Whether there is an undone local edit to redo. */
+  canRedo(): boolean;
   /** Inline markdown formats active at the current selection. */
   getActiveFormats(): NoteInlineFormats;
   /**
@@ -144,6 +159,13 @@ export function initialize(
 
   const buildExtensions = (mode: ThemeMode): Extension[] => [
     currentKeymap === 'vim' ? vim() : [],
+    // CodeMirror deliberately leaves Tab out of the default keymap (so keyboard
+    // users can tab out of the editor). Bind it explicitly for indent/outdent.
+    // Registered unconditionally: @replit/codemirror-vim binds no Tab key and
+    // lets it fall through (it only preventDefaults keys it actually handles),
+    // so this also drives Tab indent in vim mode. `vim()` sits ahead of this in
+    // the list, so vim still wins for every key it does handle.
+    keymap.of([indentWithTab]),
     basicSetup({ highlightSelectionMatches: false }),
     markdown(),
     themeExt(mode),
@@ -303,6 +325,16 @@ export function initialize(
     toggleStrikethrough: () => toggleStrikethrough(view),
     toggleLink: () => toggleLink(view),
     insertTable: (rows, cols) => insertTable(view, rows, cols),
+    undo: () => {
+      undo(view);
+      view.focus();
+    },
+    redo: () => {
+      redo(view);
+      view.focus();
+    },
+    canUndo: () => undoDepth(view.state) > 0,
+    canRedo: () => redoDepth(view.state) > 0,
     getActiveFormats: () => computeActiveFormats(view.state),
     onSelectionChange: (cb) => {
       selectionCb = cb;

--- a/packages/notes/src/view/editor.ts
+++ b/packages/notes/src/view/editor.ts
@@ -6,7 +6,7 @@ import {
   undoDepth,
 } from '@codemirror/commands';
 import { markdown } from '@codemirror/lang-markdown';
-import { EditorState, type Extension } from '@codemirror/state';
+import { Compartment, EditorState, Prec, type Extension } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
 import { vim } from '@replit/codemirror-vim';
 import { basicSetup } from '@uiw/codemirror-extensions-basic-setup';
@@ -157,18 +157,48 @@ export function initialize(
   // list (before the default keymaps) to take precedence.
   let currentKeymap: NoteKeymap = 'default';
 
-  const buildExtensions = (mode: ThemeMode): Extension[] => [
-    currentKeymap === 'vim' ? vim() : [],
+  // Compartments so theme / keymap switches reconfigure in place instead of
+  // rebuilding the whole EditorState — a full rebuild would drop the undo
+  // history (basicSetup's history()), silently disabling undo after a toggle.
+  const themeCompartment = new Compartment();
+  const keymapCompartment = new Compartment();
+
+  const keymapExt = (): Extension => {
     // CodeMirror deliberately leaves Tab out of the default keymap (so keyboard
     // users can tab out of the editor). Bind it explicitly for indent/outdent.
-    // Registered unconditionally: @replit/codemirror-vim binds no Tab key and
-    // lets it fall through (it only preventDefaults keys it actually handles),
-    // so this also drives Tab indent in vim mode. `vim()` sits ahead of this in
-    // the list, so vim still wins for every key it does handle.
-    keymap.of([indentWithTab]),
+    // @replit/codemirror-vim binds no Tab key and lets it fall through (it only
+    // preventDefaults keys it actually handles), so indentWithTab drives Tab
+    // indent in both modes; `vim()` sits ahead of it so vim still wins for every
+    // key it does handle.
+    if (currentKeymap === 'vim') {
+      return [vim(), keymap.of([indentWithTab])];
+    }
+    return [
+      keymap.of([indentWithTab]),
+      // Escape releases the Tab-indent focus trap (WCAG 2.1.2): with Tab bound
+      // to indent it no longer moves focus out, so give keyboard users an
+      // explicit exit. Low precedence so autocomplete / tooltip Escape handlers
+      // still win first; only blurs when nothing else consumes Escape. (Vim owns
+      // Escape itself, so this is default-mode only.)
+      Prec.low(
+        keymap.of([
+          {
+            key: 'Escape',
+            run: (v) => {
+              v.contentDOM.blur();
+              return true;
+            },
+          },
+        ]),
+      ),
+    ];
+  };
+
+  const buildExtensions = (mode: ThemeMode): Extension[] => [
+    keymapCompartment.of(keymapExt()),
     basicSetup({ highlightSelectionMatches: false }),
     markdown(),
-    themeExt(mode),
+    themeCompartment.of(themeExt(mode)),
     EditorView.lineWrapping,
     EditorView.editable.of(!readOnly),
     // Fill the wrapper's full height (so an empty note starts full-height, not
@@ -287,18 +317,11 @@ export function initialize(
     setTheme: (mode: ThemeMode) => {
       if (mode === currentTheme) return;
       currentTheme = mode;
-      // Rebuild state to swap the (non-compartmentalized) theme extension.
-      // Simplicity over a Compartment: notes have a single theme extension.
-      const doc = view.state.doc.toString();
-      const sel = view.state.selection;
-      view.setState(
-        EditorState.create({
-          doc,
-          selection: sel,
-          extensions: buildExtensions(mode),
-        }),
-      );
-      renderPreview();
+      // Reconfigure the theme compartment in place; a full state rebuild would
+      // discard the undo history (see the compartment comment above).
+      view.dispatch({
+        effects: themeCompartment.reconfigure(themeExt(mode)),
+      });
     },
     setViewMode: (mode: NoteViewMode) => {
       if (mode === currentViewMode) return;
@@ -308,15 +331,11 @@ export function initialize(
     setKeymap: (mode: NoteKeymap) => {
       if (mode === currentKeymap) return;
       currentKeymap = mode;
-      const doc = view.state.doc.toString();
-      const sel = view.state.selection;
-      view.setState(
-        EditorState.create({
-          doc,
-          selection: sel,
-          extensions: buildExtensions(currentTheme),
-        }),
-      );
+      // Reconfigure the keymap compartment in place so the undo history (and
+      // the current selection) survive a Default <-> Vim switch.
+      view.dispatch({
+        effects: keymapCompartment.reconfigure(keymapExt()),
+      });
       view.focus();
     },
     getKeymap: () => currentKeymap,


### PR DESCRIPTION
## Summary

Two Notes markdown-editor gaps, plus the fixes surfaced by a high-effort code review.

- **Tab / Shift+Tab indentation** — CodeMirror deliberately omits Tab from the default keymap (so keyboard users can tab out), and `@replit/codemirror-vim` binds no Tab key either, so Tab did nothing. Register `indentWithTab` so Tab indents / Shift+Tab outdents in **both** default and vim modes (`vim()` stays ahead in the extension list, so it still wins for every key it handles).
- **Toolbar Undo/Redo buttons** — `history()` + keyboard shortcuts already worked via `basicSetup`; this exposes `undo/redo/canUndo/canRedo` on `NoteEditorAPI` and adds two toolbar buttons (leftmost, with disabled state). Remote edits are already excluded from local history in `note-sync`, so a button undo reverts only the local user's edits.

### Code-review fixes (high-effort review, 3 confirmed findings)

- **Undo history no longer wiped on theme/keymap switch** — `setTheme`/`setKeymap` rebuilt the `EditorState` via `view.setState`, dropping `basicSetup`'s `history()`. Toggling light/dark (fires on every theme change) or Default↔Vim silently discarded the undo stack and left the toolbar state stale. Theme and keymap now live in CodeMirror **Compartments** and reconfigure in place, so history and selection survive the switch. This fixes both the history-loss finding and the stale-button finding.
- **Tab focus trap (WCAG 2.1.2)** — with Tab bound to indent it no longer moves focus out. Added a low-precedence `Escape`→blur binding in default mode (vim owns Escape) so keyboard users have an exit; low precedence keeps autocomplete/tooltip Escape handlers winning first.

## Test plan

- `pnpm verify:fast` — lint + all unit tests green (notes 27 tests pass; frontend `tsc --noEmit` clean).
- Manual (`pnpm dev`, Notes doc):
  - [ ] Default mode: Tab indents, Shift+Tab outdents (cursor and multi-line selection).
  - [ ] Vim mode: Tab/Shift+Tab indent/outdent.
  - [ ] Toolbar Undo/Redo work, disable at history bounds, and reflect keyboard undo.
  - [ ] Type text → toggle light/dark theme and Default↔Vim → undo still recovers the pre-toggle text (history preserved).
  - [ ] Default mode: Escape releases focus from the editor so Tab reaches the next control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added undo and redo buttons to the notes toolbar, with tooltips and disabled states when unavailable.
  * Undo/redo availability now updates automatically as you edit and select content.
  * Improved editor switching between themes and keybinding modes while preserving the current document and selection.
  * Added support for Vim and standard keybindings, including consistent Tab indentation behavior.

* **Bug Fixes**
  * Editor undo and redo actions now return focus to the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->