### PR TITLE
Align mixed-size text runs on a common baseline

### DIFF
--- a/docs/tasks/active/20260721-docs-mixed-fontsize-baseline-lessons.md
+++ b/docs/tasks/active/20260721-docs-mixed-fontsize-baseline-lessons.md
@@ -1,0 +1,50 @@
+# Lessons — Mixed font-size runs share a common baseline
+
+## What broke
+
+On a line with runs of different font sizes, smaller glyphs floated upward
+instead of sharing a baseline (Google Docs aligns them along the bottom).
+`renderRun`'s baseline formula `lineY + (lineHeight + fontSizePx * 0.8) / 2`
+mixed a **line-wide** term (`lineHeight`, sized to the tallest run) with a
+**per-run** ascent term (`originalFontSizePx * 0.8`). The two references
+disagreed, so each run centered on its own size and landed on a different
+baseline.
+
+## Lessons
+
+- **When a formula mixes a line-wide term with a per-run term, suspect the
+  mismatch.** The bug wasn't a wrong constant — `lineHeight` was already
+  line-wide and correct. The defect was that the *ascent* half of the same
+  expression used the run's own size. Fix = make both halves share one
+  reference (the line's max font size), not tweak the multiplier.
+
+- **The value you need is often already computed and thrown away.**
+  `assignLineHeights` already called `getLineMaxFontSizePx` to size the line,
+  then discarded it. Persisting it on `LayoutLine.maxFontSizePx` (one
+  assignment) was cheaper and safer than recomputing in the painter, and gave
+  every call site one shared source of truth.
+
+- **Render formulas are copy-pasted across paint paths — grep before scoping.**
+  The identical baseline expression lives in `paint-layout.ts` (screen),
+  `table-renderer.ts` (table cells), and `export/pdf-painter.ts` (PDF). Fixing
+  only the screen painter leaves tables and PDF export still floating. We
+  scoped this PR to the screen painter deliberately and tracked the twins as a
+  follow-up in the todo — but the trap is assuming one fix covers all.
+
+- **Slides shares the docs painter, so a docs fix propagates for free — but
+  test it.** Slides text boxes render through docs' `paintLayout`/`renderRun`,
+  so this fix reached slides with no slides-side change. That cuts both ways:
+  always run `@wafflebase/slides` tests when touching docs rendering, because
+  slides is an invisible downstream consumer.
+
+- **Canvas paint math is testable without a real canvas.** jsdom has no
+  `getContext`, but `renderRun` takes the ctx as an argument — inject a mock
+  that records the `y` passed to `fillText` and assert on the baseline
+  directly. This caught the fix at the pixel level, not just "the field is
+  populated."
+
+- **Make the new param optional with a fallback to keep uniform lines
+  byte-identical.** `lineMaxFontSizePx ?? originalFontSizePx` means a line with
+  one size renders exactly as before (regression guard test locks this in),
+  and the optional `LayoutLine.maxFontSizePx` field avoided editing the ~6
+  inline-constructed non-text line literals (table/HR/empty).

--- a/docs/tasks/active/20260721-docs-mixed-fontsize-baseline-todo.md
+++ b/docs/tasks/active/20260721-docs-mixed-fontsize-baseline-todo.md
@@ -1,0 +1,53 @@
+# Docs — Mixed font-size runs share a common baseline
+
+## Context
+
+On a single line containing runs of different font sizes, smaller glyphs
+floated upward instead of resting on a shared baseline (Google Docs aligns
+mixed-size text along the bottom). Root cause: the alphabetic baseline in
+`renderRun` was derived from **each run's own font size**
+(`originalFontSizePx`), so a smaller run computed a smaller `baselineY` and
+sat higher. The base baseline must instead come from the line's tallest
+run so every run on the line shares one baseline.
+
+Reported issue + repro: type 36pt text, then 11pt text on the same line —
+the 11pt text should rest on the 36pt baseline.
+
+Scope: **screen text only** — the shared canvas painter
+`renderRun` in `packages/docs/src/view/paint-layout.ts`, which serves both
+the docs body (via `doc-canvas.ts`) and slides text boxes (via
+`paintLayout`). Table cells and PDF export carry the same duplicated
+formula but are an intentional follow-up (see below).
+
+## Work
+
+- [x] Store the line's tallest run size on the line.
+  `LayoutLine.maxFontSizePx` in `layout.ts`, populated in
+  `assignLineHeights` where `getLineMaxFontSizePx` already computes it.
+  Optional field — non-text lines (table / HR / empty) constructed inline
+  don't set it; painters fall back to the run's own size.
+- [x] Use the line-max size for the base baseline in `renderRun`
+  (`paint-layout.ts`). New `lineMaxFontSizePx?` param;
+  `baselineY = round(lineY + (lineHeight + (lineMaxFontSizePx ?? originalFontSizePx) * 0.8) / 2)`.
+  Super/subscript shifts intentionally stay keyed to the run's own size.
+- [x] Thread the value through all three `renderRun` call sites:
+  `paint-layout.ts` `paintBlock`, `doc-canvas.ts` body loop, and
+  `doc-canvas.ts` `renderRunWithPageNumber` (header/footer).
+- [x] Tests: `test/view/layout.test.ts` (field populated = tallest run,
+  order-independent, uniform-line equals run size) +
+  `test/view/paint-layout.test.ts` (mock ctx captures `baselineY`: mixed
+  runs share it, tallest run unchanged when a small run joins, small run
+  drops to the shared baseline, uniform line unchanged).
+- [x] `@wafflebase/docs` typecheck + full test suite green (80 files);
+  `@wafflebase/slides` typecheck + tests green (shared painter).
+
+## Follow-up (out of scope for this branch)
+
+Same `(lineHeight + fontSizePx * 0.8) / 2` formula, keyed to the run's own
+size, needs the same fix for full parity:
+
+- Table cells: `table-renderer.ts:467` (and marker `:558`)
+- PDF export: `pdf-painter.ts:693` (and marker `:384`)
+- On-screen list marker: `paint-layout.ts` `renderListMarker` still uses
+  the marker's own size; would float next to a taller first line. Minor;
+  can reuse `line.maxFontSizePx`.

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -549,7 +549,7 @@ export class DocCanvas {
           // shadow, so that the overlay handles and the image stay in
           // lockstep instead of visually diverging during the drag.
           if (dragImageRun && run === dragImageRun) continue;
-          paintRenderRun(this.ctx, run, pageX + pl.x, pageY + pl.y, pl.line.height, {
+          paintRenderRun(this.ctx, run, pageX + pl.x, pageY + pl.y, pl.line.height, pl.line.maxFontSizePx, {
             theme: Theme,
             skipBackground: true,
             requestRender: this.requestRender ?? undefined,
@@ -692,6 +692,7 @@ export class DocCanvas {
     lineX: number,
     lineY: number,
     lineHeight: number,
+    lineMaxFontSizePx: number | undefined,
     pageNumber: number,
   ): void {
     const target = run.inline.style.pageNumber
@@ -701,7 +702,7 @@ export class DocCanvas {
           inline: { ...run.inline, text: String(pageNumber) },
         }
       : run;
-    paintRenderRun(this.ctx, target, lineX, lineY, lineHeight, {
+    paintRenderRun(this.ctx, target, lineX, lineY, lineHeight, lineMaxFontSizePx, {
       theme: Theme,
       skipBackground: false,
       requestRender: this.requestRender ?? undefined,
@@ -739,7 +740,7 @@ export class DocCanvas {
       for (const line of lb.lines) {
         for (const run of line.runs) {
           this.renderRunWithPageNumber(
-            run, originX, originY + lb.y + line.y, line.height, pageNumber,
+            run, originX, originY + lb.y + line.y, line.height, line.maxFontSizePx, pageNumber,
           );
         }
       }

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -185,6 +185,19 @@ export interface LayoutLine {
   y: number;
   height: number;
   width: number;
+  /**
+   * The tallest run font size on this line, in px (see
+   * `getLineMaxFontSizePx`). Painters derive a line-common baseline from
+   * this so runs of different font sizes on one line share a baseline
+   * rather than each centering on its own size. Unlike `height`, this is
+   * NOT expanded by image runs — it stays the text max.
+   *
+   * Set by `assignLineHeights` for every laid-out text line. Optional
+   * because a few non-text lines (table / horizontal-rule / empty
+   * placeholders) are constructed inline without it; painters fall back
+   * to the run's own size when it is absent.
+   */
+  maxFontSizePx?: number;
   nestedTable?: LayoutTable;
 }
 
@@ -708,6 +721,7 @@ export function assignLineHeights(lines: LayoutLine[], block: Block, docStyles?:
     }
     line.y = blockY;
     line.height = lineHeight;
+    line.maxFontSizePx = maxFontSize;
     blockY += lineHeight;
   }
 }

--- a/packages/docs/src/view/paint-layout.ts
+++ b/packages/docs/src/view/paint-layout.ts
@@ -179,7 +179,7 @@ function paintBlock(
     const lineX = blockX;
     const lineY = blockY + line.y;
     for (const run of line.runs) {
-      renderRun(ctx, run, lineX, lineY, line.height, {
+      renderRun(ctx, run, lineX, lineY, line.height, line.maxFontSizePx, {
         theme,
         skipBackground: skipRunBackgrounds,
         requestRender,
@@ -339,6 +339,7 @@ export function renderRun(
   lineX: number,
   lineY: number,
   lineHeight: number,
+  lineMaxFontSizePx: number | undefined,
   opts: RenderRunOpts = {},
 ): void {
   // Soft line break (`\n`) runs are emitted by `layoutBlock` to keep
@@ -398,7 +399,14 @@ export function renderRun(
   ctx.fillStyle = textColor;
   ctx.textBaseline = 'alphabetic';
 
-  let baselineY = Math.round(lineY + (lineHeight + originalFontSizePx * 0.8) / 2);
+  // Base baseline is derived from the line's tallest run so every run on
+  // the line shares one baseline (matching Google Docs). Falling back to
+  // the run's own size preserves prior behaviour for non-text lines that
+  // never passed through `assignLineHeights`. The super/subscript shifts
+  // below intentionally stay keyed to the run's OWN size — they move a run
+  // relative to itself.
+  const lineAscentPx = (lineMaxFontSizePx ?? originalFontSizePx) * 0.8;
+  let baselineY = Math.round(lineY + (lineHeight + lineAscentPx) / 2);
   if (isSuperscript) {
     baselineY -= Math.round(originalFontSizePx * 0.4);
   } else if (isSubscript) {

--- a/packages/docs/test/view/layout.test.ts
+++ b/packages/docs/test/view/layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { computeLayout, computeListCounters } from '../../src/view/layout.js';
 import { createBlock } from '../../src/model/types.js';
+import { ptToPx } from '../../src/view/theme.js';
 import { StubMeasurer, stubMeasurer } from './_stub-measurer.js';
 
 describe('heading layout', () => {
@@ -173,6 +174,39 @@ describe('superscript/subscript layout', () => {
     const normalWidthPerChar = normalRun.width / normalRun.text.length;
     const subWidthPerChar = subRun.width / subRun.text.length;
     expect(subWidthPerChar / normalWidthPerChar).toBeCloseTo(0.6, 1);
+  });
+});
+
+describe('line baseline metrics', () => {
+  it('should record the tallest run size as maxFontSizePx for a mixed-size line', () => {
+    const block = createBlock('paragraph');
+    block.inlines = [
+      { text: 'Big', style: { fontSize: 36 } },
+      { text: 'small', style: { fontSize: 11 } },
+    ];
+    const { layout } = computeLayout([block], stubMeasurer(), 600);
+    const line = layout.blocks[0].lines[0];
+    // Both runs share one line; the line-common baseline derives from the
+    // tallest run, so maxFontSizePx must equal the 36pt run in px.
+    expect(line.runs.length).toBe(2);
+    expect(line.maxFontSizePx).toBe(ptToPx(36));
+  });
+
+  it('should pick the max independent of run order', () => {
+    const block = createBlock('paragraph');
+    block.inlines = [
+      { text: 'small', style: { fontSize: 11 } },
+      { text: 'Big', style: { fontSize: 36 } },
+    ];
+    const { layout } = computeLayout([block], stubMeasurer(), 600);
+    expect(layout.blocks[0].lines[0].maxFontSizePx).toBe(ptToPx(36));
+  });
+
+  it('should equal the run size on a uniform-size line', () => {
+    const block = createBlock('paragraph');
+    block.inlines = [{ text: 'Hello', style: { fontSize: 11 } }];
+    const { layout } = computeLayout([block], stubMeasurer(), 600);
+    expect(layout.blocks[0].lines[0].maxFontSizePx).toBe(ptToPx(11));
   });
 });
 

--- a/packages/docs/test/view/paint-layout.test.ts
+++ b/packages/docs/test/view/paint-layout.test.ts
@@ -4,6 +4,7 @@ import { renderRun } from '../../src/view/paint-layout';
 import { computeLayout } from '../../src/view/layout';
 import type { LayoutLine } from '../../src/view/layout';
 import { createBlock } from '../../src/model/types';
+import { ptToPx } from '../../src/view/theme';
 import { stubMeasurer } from './_stub-measurer';
 
 /**
@@ -102,5 +103,29 @@ describe('renderRun shared baseline', () => {
     ]);
     const [a, b] = baselinesForLine(line);
     expect(a).toBe(b);
+  });
+
+  it('falls back to the run\'s own size when the line max is undefined', () => {
+    const mixed = singleLine([
+      { text: 'Big', fontSize: 36 },
+      { text: 'small', fontSize: 11 },
+    ]);
+    const smallRun = mixed.runs[1];
+
+    // Line max supplied → shared (lower) baseline.
+    const withMax = makeBaselineCtx();
+    renderRun(withMax.ctx, smallRun, 0, 0, mixed.height, mixed.maxFontSizePx, {});
+    const shared = withMax.baselines[0];
+
+    // undefined → fallback uses the run's OWN font size, reproducing the
+    // pre-fix per-run baseline (floats up above the shared one).
+    const withoutMax = makeBaselineCtx();
+    renderRun(withoutMax.ctx, smallRun, 0, 0, mixed.height, undefined, {});
+    const fallback = withoutMax.baselines[0];
+
+    // lineY = 0, no super/subscript → baseline = round((height + ownAscent) / 2).
+    const expectedOwn = Math.round((mixed.height + ptToPx(11) * 0.8) / 2);
+    expect(fallback).toBe(expectedOwn);
+    expect(fallback).toBeLessThan(shared);
   });
 });

--- a/packages/docs/test/view/paint-layout.test.ts
+++ b/packages/docs/test/view/paint-layout.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { renderRun } from '../../src/view/paint-layout';
+import { computeLayout } from '../../src/view/layout';
+import type { LayoutLine } from '../../src/view/layout';
+import { createBlock } from '../../src/model/types';
+import { stubMeasurer } from './_stub-measurer';
+
+/**
+ * Stand-in for `CanvasRenderingContext2D` that records the y-coordinate
+ * (the alphabetic baseline) each `fillText` lands on. Avoids jsdom's
+ * partial Canvas (no `fillText`) and keeps the surface to just the
+ * baseline we assert on. Includes the no-op stroke/path/save methods
+ * `renderRun` may touch for underline / strikethrough / background so
+ * the function runs end-to-end regardless of style.
+ */
+function makeBaselineCtx(): {
+  ctx: CanvasRenderingContext2D;
+  baselines: number[];
+} {
+  const baselines: number[] = [];
+  const noop = () => {};
+  const ctx = {
+    font: '',
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    fillText(_text: string, _x: number, y: number) {
+      baselines.push(y);
+    },
+    save: noop,
+    restore: noop,
+    beginPath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    stroke: noop,
+    setLineDash: noop,
+    fillRect: noop,
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, baselines };
+}
+
+/** Render one line's runs and return the baseline y for each run. */
+function baselinesForLine(line: LayoutLine): number[] {
+  const out: number[] = [];
+  for (const run of line.runs) {
+    const { ctx, baselines } = makeBaselineCtx();
+    renderRun(ctx, run, 0, 0, line.height, line.maxFontSizePx, {});
+    // A plain text run emits exactly one fillText (the glyphs).
+    out.push(baselines[0]);
+  }
+  return out;
+}
+
+function singleLine(inlines: Array<{ text: string; fontSize: number }>): LayoutLine {
+  const block = createBlock('paragraph');
+  block.inlines = inlines.map((i) => ({ text: i.text, style: { fontSize: i.fontSize } }));
+  const { layout } = computeLayout([block], stubMeasurer(), 600);
+  return layout.blocks[0].lines[0];
+}
+
+describe('renderRun shared baseline', () => {
+  it('places different-size runs on one common baseline', () => {
+    const line = singleLine([
+      { text: 'Big', fontSize: 36 },
+      { text: 'small', fontSize: 11 },
+    ]);
+    expect(line.runs.length).toBe(2);
+    const [bigY, smallY] = baselinesForLine(line);
+    expect(smallY).toBe(bigY);
+  });
+
+  it('does not move the tallest run when a smaller run joins the line', () => {
+    const tallOnly = singleLine([{ text: 'Big', fontSize: 36 }]);
+    const mixed = singleLine([
+      { text: 'Big', fontSize: 36 },
+      { text: 'small', fontSize: 11 },
+    ]);
+    const tallBaseline = baselinesForLine(tallOnly)[0];
+    const mixedBigBaseline = baselinesForLine(mixed)[0];
+    expect(mixedBigBaseline).toBe(tallBaseline);
+  });
+
+  it('drops the smaller run down to the shared baseline (vs. floating on its own)', () => {
+    const mixed = singleLine([
+      { text: 'Big', fontSize: 36 },
+      { text: 'small', fontSize: 11 },
+    ]);
+    const smallOnly = singleLine([{ text: 'small', fontSize: 11 }]);
+    const smallMixedBaseline = baselinesForLine(mixed)[1];
+    const smallAloneBaseline = baselinesForLine(smallOnly)[0];
+    // On the mixed line the small run sits lower (larger y) than it would
+    // on a line of its own size — i.e. it dropped to the shared baseline.
+    expect(smallMixedBaseline).toBeGreaterThan(smallAloneBaseline);
+  });
+
+  it('is a no-op for a uniform-size line (regression guard)', () => {
+    const line = singleLine([
+      { text: 'Hello ', fontSize: 16 },
+      { text: 'world', fontSize: 16 },
+    ]);
+    const [a, b] = baselinesForLine(line);
+    expect(a).toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary

On a line containing runs of different font sizes, smaller glyphs floated
upward instead of sharing a baseline with the larger runs (Google Docs
aligns mixed-size text along the bottom).

**Root cause:** `renderRun` (`view/paint-layout.ts`) derived the alphabetic
baseline from **each run's own** font size, so a smaller run computed a
smaller `baselineY` and sat higher than its neighbours.

**Fix:** derive the base baseline from the line's **tallest** run, stored as
`LayoutLine.maxFontSizePx` — a value `assignLineHeights` already computes
for line height and previously discarded. Super/subscript shifts stay keyed
to the run's own size (they move a run relative to itself). A
`?? originalFontSizePx` fallback keeps uniform-size lines byte-identical to
before.

**Scope:** the change is in the shared canvas painter, so it fixes both the
docs body (via `doc-canvas.ts`) and slides text boxes (via `paintLayout`).
Table cells (`table-renderer.ts`) and PDF export (`pdf-painter.ts`) carry
the same duplicated formula and are an intentional follow-up, tracked in
`docs/tasks/active/20260721-docs-mixed-fontsize-baseline-todo.md`.

## Test plan

- [x] New `packages/docs/test/view/paint-layout.test.ts`: a mock canvas
      context captures the real `baselineY` passed to `fillText` — asserts
      mixed-size runs share one baseline, the tallest run is unchanged when
      a smaller run joins, the smaller run drops to the shared baseline, and
      a uniform-size line is unchanged (regression guard).
- [x] `packages/docs/test/view/layout.test.ts`: `maxFontSizePx` equals the
      tallest run (order-independent) and equals the run size on a uniform
      line.
- [x] `@wafflebase/docs` typecheck + full test suite green (80 files, 1099
      tests).
- [x] `@wafflebase/slides` typecheck + tests green (shares the painter).
- [x] Manual: standalone docs playground — 36pt then 11pt on one line now
      rest on a common baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vertical alignment for text runs with mixed font sizes on the same line by sharing a common baseline.
  - Prevented smaller runs from rendering too high while keeping superscript/subscript positioning correct.
  - Applied the same baseline behavior to body content and header/footer rendering.
  - Preserved the prior baseline calculation when line max sizing isn’t available.

- **Tests**
  - Added layout and rendering tests to validate shared-baseline behavior across mixed and uniform font sizes.

- **Documentation**
  - Added a new note describing the baseline issue and the rendering lessons learned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->