### PR TITLE
Authenticate agent workflows via Claude OAuth token

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -206,7 +206,7 @@ jobs:
         # when bumping. github_token is the App token so pushes re-trigger CI.
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: ${{ steps.prep.outputs.prompt }}
           claude_args: >-

--- a/.github/workflows/agent-independent-review.yml
+++ b/.github/workflows/agent-independent-review.yml
@@ -95,7 +95,7 @@ jobs:
         # node/pnpm/Edit/push. The reviewer reads the diff statically only.
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
             --max-turns 30
             --model claude-opus-4-8
@@ -313,7 +313,7 @@ jobs:
         # github_token is the App token so the fix push re-triggers CI.
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |
             The independent reviewer requested changes on your PR. Findings:

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -150,7 +150,7 @@ jobs:
         # github_token is the App token so the fix push re-triggers CI.
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           prompt: |
             CI failed on your PR branch (${{ github.event.workflow_run.head_branch }}).

--- a/.github/workflows/agent-review-reply.yml
+++ b/.github/workflows/agent-review-reply.yml
@@ -114,7 +114,7 @@ jobs:
         # context. github_token is the App token so pushes re-trigger CI.
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
           claude_args: >-
             --max-turns 40

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -410,14 +410,15 @@ moves to the approving human reviewer.
 - **The high-value asset is the secrets, not the draft flag.** The verdict/ready
   architecture makes the *draft→ready* decision unforgeable, but that flag has no
   merge power (a human CODEOWNER must still approve). The real asset is
-  `ANTHROPIC_API_KEY` + the write-capable App token, held by the code-executing
+  the Claude auth secret (`ANTHROPIC_API_KEY`, or `CLAUDE_CODE_OAUTH_TOKEN` for
+  a `claude setup-token` subscription token) + the write-capable App token, held by the code-executing
   agent jobs (`agent-implement`, `agent-iterate-ci`, the review `fix` job) which
   run `pnpm install` (branch `postinstall`) and an unrestricted-`Bash` agent on
   the branch. An adversarially prompt-injected author agent could exfiltrate
   them there. This is inherent to running an autonomous coding agent with an API
   key; it is NOT defended by the review gate. Mitigations: the protected `agent`
   environment (optional per-run human approval), the enablement switch, fork-
-  origin rejection, and treating `ANTHROPIC_API_KEY` as least-privilege and
+  origin rejection, and treating the Claude auth secret as least-privilege and
   rotatable. Adopters must accept this risk consciously.
 - **LLM-reviewer prompt injection.** The independent reviewer reads an untrusted
   diff, so injected text can sway its severity classification. The human merge


### PR DESCRIPTION
## Summary

The agent pipeline's `claude-code-action` steps authenticated with `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`. For live use the maintainer provisioned a **Claude subscription OAuth token** via `claude setup-token` rather than an Anthropic API key; the two methods are mutually exclusive, so an OAuth-token deployment must switch the input name.

Swaps all five `claude-code-action` invocations across the four agent workflows to `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`:

- `agent-implement.yml`
- `agent-iterate-ci.yml`
- `agent-review-reply.yml`
- `agent-independent-review.yml` (review + fix jobs)

All these jobs run with `environment: agent`, so `CLAUDE_CODE_OAUTH_TOKEN` lives in that protected environment. Also notes the alternative auth secret in the `harness-engineering.md` threat model.

Ref: https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md

## Test plan

- No package source changed — workflow YAML + one doc line. `pnpm verify:fast` green locally; four workflow YAMLs parse.
- Maintainer sets `CLAUDE_CODE_OAUTH_TOKEN` in the `agent` environment. (The invalid `ANTHROPIC_API_KEY` produced a 401 `invalid x-api-key` on the first Phase A dispatch against #278.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)