### PR TITLE
Upload agent execution log as an artifact for diagnosis

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -216,3 +216,14 @@ jobs:
             --max-turns 150
             --model claude-opus-4-8
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"
+
+      # Capture the full agent transcript (every turn + tool call + any
+      # permission denial) so a run that finishes without pushing a branch/PR
+      # is diagnosable. always(): upload even when Claude Code failed.
+      - name: Upload agent execution log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-output
+          path: ${{ runner.temp }}/claude-execution-output.json
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

The Phase A run on #278 finished `success` (59/150 turns, ~28 min, `permission_denials_count=1`) but produced **no branch, commit, PR, or issue comment** — the agent did real work then ended without landing the git finalization. `claude-code-action` writes a full transcript to `$RUNNER_TEMP/claude-execution-output.json`, but nothing uploaded it, so the runner-local file was lost and the failure mode is unobservable after the fact.

Adds an `always()` `upload-artifact` step after Run Claude Code so the next run's transcript (every turn + tool call + the denied call) survives for root-cause analysis — debugging with data instead of guessing whether the AI-disclosure commit hook or the self-review skill's tool scope blocked it.

## Test plan

- Workflow YAML only; `agent-implement.yml` parses; `pnpm verify:fast` green.
- Validated by the next #278 re-dispatch: the run's Artifacts should now contain `claude-execution-output`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)