### PR TITLE
Underline composing (uncommitted) IME text in Docs (issue #342)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -55,6 +55,7 @@ Word processor engine — rich text, tables, pagination, collaboration.
 | [docs-local-caret-anchoring.md](docs/docs-local-caret-anchoring.md)              | Local caret anchoring — Yorkie Tree-anchored caret/selection, resolves to DocPosition at render time (issue #237) |
 | [docs-spell-check.md](docs/docs-spell-check.md)                                  | Docs spell check — red-squiggle decoration via the search/comment highlight path, pluggable `SpellChecker` (local nspell/en_US + wired-deferred backend), per-word script-based language routing, view-local session state, suggestions in the unified context menu |
 | [docs-context-menu.md](docs/docs-context-menu.md)                                | Docs unified context menu — one Google-Docs-style body right-click menu (spell suggestions + clipboard + add link/comment) as a non-Radix positioned overlay; docs-package `EditorAPI` primitives, table menu kept separate |
+| [docs-ime-composing-underline.md](docs/docs-ime-composing-underline.md)          | IME composing underline — thin solid underline under uncommitted composing text via a view-local `composing` marker on the injected preview run, painted in `renderRun` (issue #342) |
 
 ## Slides
 

--- a/docs/design/docs/docs-ime-composing-underline.md
+++ b/docs/design/docs/docs-ime-composing-underline.md
@@ -111,8 +111,10 @@ through `injectComposingInline`, so both are covered.
 In `renderRun`, after the existing `style.underline` block, draw a composing
 underline when `run.composing` is set:
 
-- A solid line (2px, matching the caret's `cursorWidth`), in the run's
-  resolved text color.
+- A solid line (2px), in the run's resolved text color. A 1px line was tried
+  first but read as too faint against text; 2px matches the caret's
+  `cursorWidth`, so the composing cue sits at the same visual weight as the
+  caret already in view.
 - Positioned at the same `baselineY + 2` the normal underline uses.
 - Reuses the run's already-computed `x` and `width`, so a composing string that
   wraps across lines paints one underline segment per sub-run and the underline

--- a/docs/design/docs/docs-ime-composing-underline.md
+++ b/docs/design/docs/docs-ime-composing-underline.md
@@ -69,37 +69,47 @@ only thing missing is the underline decoration.
 
 ### View-Local `composing` Marker
 
-Add an optional, view-local `composing` flag to `InlineStyle`:
+The marker must NOT live on `InlineStyle` (nor on `Inline`). Both are the
+persisted model types (`packages/docs/src/model/types.ts`); adding a field there
+— even one documented as view-local — makes it type-reachable from every
+document, clipboard, clone, and DOCX/PDF export path, inviting accidental
+persistence. Instead the marker lives on `LayoutRun`, the view-only run type in
+`packages/docs/src/view/layout.ts` that already carries all other paint-time
+state (`x`, `width`, `charOffsets`, `imageHeight`) and is never persisted:
 
 ```ts
-interface InlineStyle {
+interface LayoutRun {
   // ...existing fields...
 
   /**
-   * View-local marker set only by `composingStyleFrom` while an IME
-   * composition is in progress. Runs carrying it are painted with an IME
-   * composing underline. Never persisted to the document model.
+   * True for runs produced by the IME composing-text injection
+   * (`injectComposingInline`). Painted with a composing underline. View-only —
+   * lives on the layout run, never on the persisted Inline / InlineStyle.
    */
   composing?: boolean;
 }
 ```
 
-`InlineStyle` is the persisted model style type, but this flag is only ever set
-on the synthetic inline that `injectComposingInline` builds for the composing
-preview — which lives entirely inside the layout pass and is never written back
-to Yorkie. The flag is documented as view-local so no persistence or
-import/export path picks it up.
+`composingStyleFrom` stays exactly as is (it inherits only visual style and
+drops structural metadata like `image` / `pageNumber`); it does **not** gain a
+`composing` field. The tagging happens one level up, in the layout pass:
 
-`composingStyleFrom` (which already strips structural metadata like `image` and
-`pageNumber` from the inherited style) sets `composing: true` on the style it
-returns. Both the browser IME path and the software-Hangul assembler path build
-their preview through `injectComposingInline`, so both are covered by this one
-change.
+- `injectComposingInline` returns the index of the synthetic inline it spliced
+  in (alongside the new inlines array), so callers know which inline is the
+  composing preview.
+- `layoutBlock` already builds each `LayoutRun` from `inlines[seg.inlineIndex]`.
+  When `seg.inlineIndex` is the composing inline's index, it sets
+  `composing: true` on the run.
+
+Because `LayoutRun` is discarded and rebuilt on every layout pass and never
+crosses into the model, the marker is leak-proof by construction rather than by
+convention. Both the browser IME path and the software-Hangul assembler path go
+through `injectComposingInline`, so both are covered.
 
 ### Painting The Underline
 
 In `renderRun`, after the existing `style.underline` block, draw a composing
-underline when `style.composing` is set:
+underline when `run.composing` is set:
 
 - A thin solid line (1px), in the run's resolved text color.
 - Positioned at the same `baselineY + 2` the normal underline uses.
@@ -121,35 +131,49 @@ existing path already manages:
 compositionstart / first jamo
   -> TextEditor publishes composing text via onComposingContextChange
   -> editor sets composingContext, recomputes layout
-  -> injectComposingInline splices a run with style.composing = true
+  -> layoutBlock tags the injected run with composing = true
   -> renderRun paints the composing underline
 
 compositionupdate
   -> new composing text republished; run (and underline) re-laid out
 
 compositionend / commit / abort / blur
-  -> composing text committed to the model (no `composing` flag) or dropped
+  -> composing text committed to the model as a normal inline, or dropped
   -> composingContext cleared -> the synthetic run disappears
   -> the underline is gone on the next paint
 ```
 
 No explicit teardown is needed: when the composition ends, the committed text
-is a normal model inline with no `composing` flag, and the synthetic run that
-carried the underline no longer exists.
+is a normal model inline, laid out into runs with no `composing` flag, and the
+synthetic run that carried the underline no longer exists.
 
 ## Testing Strategy
 
 ### Unit Tests
 
-- `injectComposingInline` output: the spliced composing run's style has
-  `composing: true`, and the surrounding (non-composing) runs do not.
-- `composingStyleFrom` sets `composing: true` while still dropping `image` and
-  `pageNumber`.
-- `renderRun` with a `composing` run strokes an underline (asserted via a mock
-  canvas context recording `moveTo` / `lineTo` / `stroke` at `baselineY + 2`);
-  a run without the flag and without `style.underline` strokes none.
-- A committed inline (no `composing` flag) is painted without a composing
-  underline.
+- `injectComposingInline` returns the index of the spliced composing inline
+  (left-biased at an inline boundary, offset-at-end, and empty-block cases).
+- `layoutBlock` with a `ComposingContext` tags exactly the composing run(s)
+  with `composing: true` and leaves the surrounding runs untagged; when the
+  composing text wraps, every sub-run of the composing string is tagged.
+- `composingStyleFrom` still inherits visual style and drops `image` /
+  `pageNumber`, and does not introduce a `composing` field.
+- `renderRun` with a `composing` run strokes a single underline at
+  `baselineY + 2` with `lineWidth === 1` and `strokeStyle` equal to the run's
+  resolved text color (asserted via a mock canvas context recording
+  `moveTo` / `lineTo` / `stroke` and the set properties); a run without the
+  flag and without `style.underline` strokes none.
+
+### Lifecycle / Teardown
+
+- After `compositionend` (commit), `compositionabort`, and `blur`, the
+  recomputed layout has no run with `composing: true`, so `renderRun` issues no
+  composing-underline stroke — assert no further underline draw calls once the
+  composing context is cleared.
+- A committed inline is a normal model inline: it round-trips through
+  serialize / clipboard / DOCX-PDF export with no `composing` field anywhere
+  (the field type-only exists on `LayoutRun`, so this is guaranteed by
+  construction; a serialization test documents the guarantee).
 
 ### Reuse
 
@@ -161,7 +185,7 @@ composing-context injection path.
 
 | Risk | Mitigation |
 |------|------------|
-| The `composing` flag leaks into persisted content, DOCX/PDF export, or clipboard | The flag is only set by `composingStyleFrom` on the view-local injected run, which is never written to the model; documented as view-local. Add a test asserting committed text has no `composing` flag |
+| The `composing` marker leaks into persisted content, DOCX/PDF export, or clipboard | The marker lives on `LayoutRun` (view-only), not on `Inline` / `InlineStyle`, so it is not type-reachable from any model, clone, serialize, or export path. Leak-proof by construction; a serialization test documents the guarantee |
 | Composing over already-underlined text draws a double line | Both lines land at the same `y` and coincide; visually harmless, so no special-casing |
-| Underline is left behind if composition ends without clearing the context | The underline is a pure function of the run's presence; when `composingContext` clears, the run and its underline disappear on the next paint. No separate teardown to get wrong |
-| Software-Hangul assembler path renders without an underline | Both IME and assembler previews go through `injectComposingInline` / `composingStyleFrom`, so the single marker covers both |
+| Underline is left behind if composition ends without clearing the context | The underline is a pure function of the run's presence; when `composingContext` clears, the recomputed layout has no `composing` run and the underline disappears on the next paint. Covered by the lifecycle/teardown tests |
+| Software-Hangul assembler path renders without an underline | Both IME and assembler previews go through `injectComposingInline`, so tagging in `layoutBlock` covers both |

--- a/docs/design/docs/docs-ime-composing-underline.md
+++ b/docs/design/docs/docs-ime-composing-underline.md
@@ -59,7 +59,7 @@ only thing missing is the underline decoration.
 ## Non-Goals
 
 - Underline color / style customization for composing text. The underline is a
-  fixed thin solid line in the text color.
+  fixed 2px solid line in the text color.
 - A background highlight or any other composing decoration beyond the
   underline.
 - Changing how composing text is measured, wrapped, or committed.
@@ -111,7 +111,8 @@ through `injectComposingInline`, so both are covered.
 In `renderRun`, after the existing `style.underline` block, draw a composing
 underline when `run.composing` is set:
 
-- A thin solid line (1px), in the run's resolved text color.
+- A solid line (2px, matching the caret's `cursorWidth`), in the run's
+  resolved text color.
 - Positioned at the same `baselineY + 2` the normal underline uses.
 - Reuses the run's already-computed `x` and `width`, so a composing string that
   wraps across lines paints one underline segment per sub-run and the underline
@@ -159,7 +160,7 @@ synthetic run that carried the underline no longer exists.
 - `composingStyleFrom` still inherits visual style and drops `image` /
   `pageNumber`, and does not introduce a `composing` field.
 - `renderRun` with a `composing` run strokes a single underline at
-  `baselineY + 2` with `lineWidth === 1` and `strokeStyle` equal to the run's
+  `baselineY + 2` with `lineWidth === 2` and `strokeStyle` equal to the run's
   resolved text color (asserted via a mock canvas context recording
   `moveTo` / `lineTo` / `stroke` and the set properties); a run without the
   flag and without `style.underline` strokes none.

--- a/docs/design/docs/docs-ime-composing-underline.md
+++ b/docs/design/docs/docs-ime-composing-underline.md
@@ -1,0 +1,167 @@
+---
+title: docs-ime-composing-underline
+target-version: 0.6.2
+---
+
+# Docs IME Composing Underline
+
+## Summary
+
+Draw an underline beneath uncommitted (composing) IME text in the docs
+editor, and remove it when the composition commits.
+
+While composing text with an IME (e.g. Korean), the docs editor renders the
+interim composition glyphs plainly, with no underline. Every native text
+field and Google Docs underlines composing text to signal that it is not yet
+committed. Wafflebase gives no such visual cue, so the user cannot tell
+mid-composition text apart from committed text.
+
+The composing text already lives on a view-local render path (see
+[docs-ime-undo-history.md](docs-ime-undo-history.md) and
+[docs-intent-preserving-edits.md](docs-intent-preserving-edits.md)): during
+composition it is *not* written to the document model, but spliced into the
+block's layout as a synthetic inline run by `injectComposingInline`. This note
+adds the underline on top of that existing path — the underline is purely a
+paint-time decoration of the injected run and never touches the model.
+
+## Background
+
+Issue #342 reports that composing IME text is drawn with no underline. The
+issue notes that the fix is cleanest *after* #318, which moved composing text
+off the model-drawn path onto a view-local temporary render path. #318 (PR
+#332) and the composing-preview wiring (PR #346) have both landed, so the new
+render path now exists:
+
+- `TextEditor` tracks the composing string view-locally and publishes it via
+  `onComposingContextChange` (`packages/docs/src/view/text-editor.ts`).
+- The editor forwards it as a `ComposingContext` into the layout pass
+  (`packages/docs/src/view/editor.ts`).
+- `injectComposingInline` splices the composing string into the block's
+  inlines at the composition offset, inheriting the surrounding *visual* style
+  via `composingStyleFrom` (`packages/docs/src/view/layout.ts`).
+- The resulting runs are painted by `renderRun`
+  (`packages/docs/src/view/paint-layout.ts`), which already knows how to draw
+  a per-run underline for `style.underline`.
+
+Because the composing run flows through the normal layout and paint pipeline,
+wrapping, following-text reflow, and caret placement are already correct. The
+only thing missing is the underline decoration.
+
+## Goals
+
+- Render uncommitted (composing) IME text with an underline.
+- Remove the underline automatically when the composition commits or aborts.
+- Keep the underline view-local: it is never persisted to the document model
+  and produces no Yorkie change or undo unit.
+- Cover both the browser IME path and the software-Hangul assembler path
+  (both go through `injectComposingInline`).
+
+## Non-Goals
+
+- Underline color / style customization for composing text. The underline is a
+  fixed thin solid line in the text color.
+- A background highlight or any other composing decoration beyond the
+  underline.
+- Changing how composing text is measured, wrapped, or committed.
+- Any change to the committed-text underline (`style.underline`) behavior.
+
+## Proposal Details
+
+### View-Local `composing` Marker
+
+Add an optional, view-local `composing` flag to `InlineStyle`:
+
+```ts
+interface InlineStyle {
+  // ...existing fields...
+
+  /**
+   * View-local marker set only by `composingStyleFrom` while an IME
+   * composition is in progress. Runs carrying it are painted with an IME
+   * composing underline. Never persisted to the document model.
+   */
+  composing?: boolean;
+}
+```
+
+`InlineStyle` is the persisted model style type, but this flag is only ever set
+on the synthetic inline that `injectComposingInline` builds for the composing
+preview — which lives entirely inside the layout pass and is never written back
+to Yorkie. The flag is documented as view-local so no persistence or
+import/export path picks it up.
+
+`composingStyleFrom` (which already strips structural metadata like `image` and
+`pageNumber` from the inherited style) sets `composing: true` on the style it
+returns. Both the browser IME path and the software-Hangul assembler path build
+their preview through `injectComposingInline`, so both are covered by this one
+change.
+
+### Painting The Underline
+
+In `renderRun`, after the existing `style.underline` block, draw a composing
+underline when `style.composing` is set:
+
+- A thin solid line (1px), in the run's resolved text color.
+- Positioned at the same `baselineY + 2` the normal underline uses.
+- Reuses the run's already-computed `x` and `width`, so a composing string that
+  wraps across lines paints one underline segment per sub-run and the underline
+  follows the text across the wrap.
+
+The composing underline is drawn independently of `style.underline`. If the
+surrounding text is itself underlined, the composing run inherits that style and
+both lines are drawn at the same `y`; they coincide visually, which is
+harmless.
+
+### Lifecycle
+
+The underline's lifetime is tied to the composing run's lifetime, which the
+existing path already manages:
+
+```text
+compositionstart / first jamo
+  -> TextEditor publishes composing text via onComposingContextChange
+  -> editor sets composingContext, recomputes layout
+  -> injectComposingInline splices a run with style.composing = true
+  -> renderRun paints the composing underline
+
+compositionupdate
+  -> new composing text republished; run (and underline) re-laid out
+
+compositionend / commit / abort / blur
+  -> composing text committed to the model (no `composing` flag) or dropped
+  -> composingContext cleared -> the synthetic run disappears
+  -> the underline is gone on the next paint
+```
+
+No explicit teardown is needed: when the composition ends, the committed text
+is a normal model inline with no `composing` flag, and the synthetic run that
+carried the underline no longer exists.
+
+## Testing Strategy
+
+### Unit Tests
+
+- `injectComposingInline` output: the spliced composing run's style has
+  `composing: true`, and the surrounding (non-composing) runs do not.
+- `composingStyleFrom` sets `composing: true` while still dropping `image` and
+  `pageNumber`.
+- `renderRun` with a `composing` run strokes an underline (asserted via a mock
+  canvas context recording `moveTo` / `lineTo` / `stroke` at `baselineY + 2`);
+  a run without the flag and without `style.underline` strokes none.
+- A committed inline (no `composing` flag) is painted without a composing
+  underline.
+
+### Reuse
+
+Extend the existing `packages/docs/test/view/text-box-composing.test.ts`
+coverage rather than adding a parallel suite, since it already exercises the
+composing-context injection path.
+
+## Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| The `composing` flag leaks into persisted content, DOCX/PDF export, or clipboard | The flag is only set by `composingStyleFrom` on the view-local injected run, which is never written to the model; documented as view-local. Add a test asserting committed text has no `composing` flag |
+| Composing over already-underlined text draws a double line | Both lines land at the same `y` and coincide; visually harmless, so no special-casing |
+| Underline is left behind if composition ends without clearing the context | The underline is a pure function of the run's presence; when `composingContext` clears, the run and its underline disappear on the next paint. No separate teardown to get wrong |
+| Software-Hangul assembler path renders without an underline | Both IME and assembler previews go through `injectComposingInline` / `composingStyleFrom`, so the single marker covers both |

--- a/docs/design/docs/docs-ime-composing-underline.md
+++ b/docs/design/docs/docs-ime-composing-underline.md
@@ -174,6 +174,11 @@ synthetic run that carried the underline no longer exists.
   serialize / clipboard / DOCX-PDF export with no `composing` field anywhere
   (the field type-only exists on `LayoutRun`, so this is guaranteed by
   construction; a serialization test documents the guarantee).
+- Serialize / clipboard-copy / export the document *while a composition is
+  still active* (`ComposingContext` non-empty): the persisted, clipboard, and
+  export inputs are byte-identical to the pre-composition model and carry no
+  composing marker. This proves the live preview never mutates model or export
+  data mid-composition, not just after it commits.
 
 ### Reuse
 

--- a/docs/tasks/active/20260722-docs-ime-composing-underline-todo.md
+++ b/docs/tasks/active/20260722-docs-ime-composing-underline-todo.md
@@ -1,0 +1,42 @@
+# IME Composing Underline (issue #342)
+
+Design note: `docs/design/docs/docs-ime-composing-underline.md`
+PR: #514 (implement in same PR, per maintainer request)
+
+## Goal
+
+Draw a thin solid underline under uncommitted (composing) IME text in the
+docs editor; remove it automatically on commit / abort / blur. View-local
+only — never persisted.
+
+## Approach (per design note)
+
+View-local `composing` marker on `LayoutRun` (NOT on the persisted
+`Inline` / `InlineStyle`). `injectComposingInline` returns the injected
+inline's index; `layoutBlock` tags runs whose `inlineIndex` matches;
+`renderRun` paints a 1px solid underline in the resolved text color when
+`run.composing` is set.
+
+## Tasks (TDD)
+
+- [ ] `injectComposingInline` returns `{ inlines, composingIndex }`
+  - [ ] RED: index points at the spliced composing inline (mid-inline,
+        boundary, end-of-block, empty-block); `-1` for empty text
+  - [ ] Update the one production caller (`layoutBlock`)
+  - [ ] Update existing `composing-injection.test.ts` call sites
+- [ ] `LayoutRun.composing?: boolean` field
+- [ ] `layoutBlock` tags composing runs
+  - [ ] RED: exactly the composing run(s) tagged; wrap → every sub-run
+        tagged; no `ComposingContext` → none tagged
+- [ ] `renderRun` composing underline
+  - [ ] RED: composing run strokes 1px solid at `baselineY + 2` in text
+        color; non-composing run without `style.underline` strokes none
+- [ ] Lifecycle: re-layout without composingContext → no tagged run → no
+      underline (covered by the "none tagged" + renderRun tests)
+- [ ] `pnpm verify:fast` green
+- [ ] Manual smoke in `pnpm dev` (Korean IME shows underline, gone on commit)
+
+## Out of scope (per note)
+
+Underline color/style customization, composing background highlight,
+changes to committed-text underline or composing measurement/commit.

--- a/packages/docs/src/view/layout.ts
+++ b/packages/docs/src/view/layout.ts
@@ -175,6 +175,14 @@ export interface LayoutRun {
    * Line height must grow to accommodate this. Undefined for text runs.
    */
   imageHeight?: number;
+  /**
+   * True for runs produced by the IME composing-text injection
+   * (`injectComposingInline`). Painted with a composing underline. View-only —
+   * this marker lives on the layout run, never on the persisted
+   * `Inline` / `InlineStyle`, so it cannot leak into the model, clipboard,
+   * clone, or DOCX/PDF export.
+   */
+  composing?: boolean;
 }
 
 /**
@@ -267,37 +275,38 @@ export function injectComposingInline(
   inlines: Inline[],
   offset: number,
   text: string,
-): Inline[] {
-  if (text.length === 0) return inlines;
+): { inlines: Inline[]; composingIndex: number } {
+  if (text.length === 0) return { inlines, composingIndex: -1 };
 
   const result: Inline[] = [];
   let pos = 0;
-  let inserted = false;
+  let composingIndex = -1;
 
   for (const inline of inlines) {
     const len = inline.text.length;
-    if (!inserted && offset <= pos + len) {
+    if (composingIndex === -1 && offset <= pos + len) {
       const localOffset = offset - pos;
       const before = inline.text.slice(0, localOffset);
       const after = inline.text.slice(localOffset);
       if (before.length > 0) result.push({ ...inline, text: before });
+      composingIndex = result.length;
       result.push({ text, style: composingStyleFrom(inline.style) });
       if (after.length > 0) result.push({ ...inline, text: after });
-      inserted = true;
     } else {
       result.push(inline);
     }
     pos += len;
   }
 
-  if (!inserted) {
+  if (composingIndex === -1) {
     // Offset at/after the end, or an empty block: append, inheriting the
     // trailing inline's style when there is one.
     const style = inlines.length > 0 ? inlines[inlines.length - 1].style : {};
+    composingIndex = result.length;
     result.push({ text, style: composingStyleFrom(style) });
   }
 
-  return result;
+  return { inlines: result, composingIndex };
 }
 
 /**
@@ -523,9 +532,17 @@ export function layoutBlock(
   const resolved = resolveBlockInlines(block, docStyles);
   // Splice in view-local IME composing text for this block, if any, so it
   // reflows like real text without being written to the document model.
-  const inlines = composingContext?.blockId === block.id
-    ? injectComposingInline(resolved, composingContext.offset, composingContext.text)
-    : resolved;
+  // `composingIndex` is the index of the injected inline within `inlines`;
+  // runs derived from it are tagged `composing` below (-1 when none).
+  let inlines = resolved;
+  let composingIndex = -1;
+  if (composingContext?.blockId === block.id) {
+    const injected = injectComposingInline(
+      resolved, composingContext.offset, composingContext.text,
+    );
+    inlines = injected.inlines;
+    composingIndex = injected.composingIndex;
+  }
   // Measure all segments (word-level)
   const segments = measureSegments(inlines, measurer);
 
@@ -692,6 +709,18 @@ export function layoutBlock(
     });
   } else if (lastWasSoftBreak) {
     lines.push({ runs: [], y: 0, height: 0, width: 0 });
+  }
+
+  // Tag every run derived from the injected composing inline (view-local).
+  // A composing string that wraps produces several runs, all sharing the
+  // same `inlineIndex`, so each piece stays tagged and painted with the
+  // composing underline.
+  if (composingIndex >= 0) {
+    for (const line of lines) {
+      for (const run of line.runs) {
+        if (run.inlineIndex === composingIndex) run.composing = true;
+      }
+    }
   }
 
   return lines;

--- a/packages/docs/src/view/paint-layout.ts
+++ b/packages/docs/src/view/paint-layout.ts
@@ -471,6 +471,23 @@ export function renderRun(
     ctx.restore();
   }
 
+  // IME composing underline: a thin solid line under uncommitted (composing)
+  // text, signalling it is not yet committed (matching native fields and
+  // Google Docs). `run.composing` is a view-local marker set by the layout
+  // pass; it disappears — along with this underline — when the composition
+  // commits or aborts and the synthetic run is no longer laid out.
+  if (run.composing) {
+    const underlineY = baselineY + 2;
+    ctx.save();
+    ctx.beginPath();
+    ctx.strokeStyle = textColor;
+    ctx.lineWidth = 2;
+    ctx.moveTo(x, underlineY);
+    ctx.lineTo(x + run.width, underlineY);
+    ctx.stroke();
+    ctx.restore();
+  }
+
   if (style.strikethrough) {
     const renderFontSizePx = ptToPx(
       (isSuperscript || isSubscript)

--- a/packages/docs/test/view/composing-injection.test.ts
+++ b/packages/docs/test/view/composing-injection.test.ts
@@ -5,7 +5,7 @@ import {
   type ComposingContext,
 } from '../../src/view/layout.js';
 import { createBlock } from '../../src/model/types.js';
-import type { LayoutBlock } from '../../src/view/layout.js';
+import type { LayoutBlock, LayoutRun } from '../../src/view/layout.js';
 import type { Inline } from '../../src/model/types.js';
 import { stubMeasurer } from './_stub-measurer.js';
 
@@ -14,11 +14,17 @@ function blockText(lb: LayoutBlock): string {
   return lb.lines.flatMap((l) => l.runs.map((r) => r.text)).join('');
 }
 
+/** All runs across a laid-out block, in visual order. */
+function blockRuns(lb: LayoutBlock): LayoutRun[] {
+  return lb.lines.flatMap((l) => l.runs);
+}
+
 describe('injectComposingInline', () => {
   it('splices composing text mid-inline, splitting the inline', () => {
     const inlines: Inline[] = [{ text: 'ABCD', style: {} }];
-    const result = injectComposingInline(inlines, 2, 'X');
-    expect(result.map((i) => i.text)).toEqual(['AB', 'X', 'CD']);
+    const { inlines: out, composingIndex } = injectComposingInline(inlines, 2, 'X');
+    expect(out.map((i) => i.text)).toEqual(['AB', 'X', 'CD']);
+    expect(composingIndex).toBe(1); // 'X' sits at index 1
   });
 
   it('inherits the style at the insertion point (left-biased at a boundary)', () => {
@@ -28,26 +34,31 @@ describe('injectComposingInline', () => {
     ];
     // Offset 2 is the boundary; left bias means the composing text inherits
     // the preceding bold inline's style.
-    const result = injectComposingInline(inlines, 2, 'X');
-    const composing = result.find((i) => i.text === 'X');
-    expect(composing?.style).toEqual({ bold: true });
+    const { inlines: out, composingIndex } = injectComposingInline(inlines, 2, 'X');
+    expect(out[composingIndex].text).toBe('X');
+    expect(out[composingIndex].style).toEqual({ bold: true });
+    expect(composingIndex).toBe(1); // 'AB' | 'X' | 'CD'
   });
 
   it('appends at end-of-block, inheriting the trailing style', () => {
     const inlines: Inline[] = [{ text: 'AB', style: { bold: true } }];
-    const result = injectComposingInline(inlines, 2, 'Z');
-    expect(result.map((i) => i.text)).toEqual(['AB', 'Z']);
-    expect(result[1].style).toEqual({ bold: true });
+    const { inlines: out, composingIndex } = injectComposingInline(inlines, 2, 'Z');
+    expect(out.map((i) => i.text)).toEqual(['AB', 'Z']);
+    expect(composingIndex).toBe(1);
+    expect(out[1].style).toEqual({ bold: true });
   });
 
   it('injects into an empty block', () => {
-    const result = injectComposingInline([], 0, 'Q');
-    expect(result.map((i) => i.text)).toEqual(['Q']);
+    const { inlines: out, composingIndex } = injectComposingInline([], 0, 'Q');
+    expect(out.map((i) => i.text)).toEqual(['Q']);
+    expect(composingIndex).toBe(0);
   });
 
-  it('returns the input unchanged for empty composing text', () => {
+  it('returns the input unchanged with index -1 for empty composing text', () => {
     const inlines: Inline[] = [{ text: 'AB', style: {} }];
-    expect(injectComposingInline(inlines, 1, '')).toBe(inlines);
+    const result = injectComposingInline(inlines, 1, '');
+    expect(result.inlines).toBe(inlines);
+    expect(result.composingIndex).toBe(-1);
   });
 
   it('does not mutate the input inlines', () => {
@@ -62,19 +73,22 @@ describe('injectComposingInline', () => {
     const inlines: Inline[] = [
       { text: '￼', style: { image: { src: 'x', width: 10, height: 10 } } as Inline['style'] },
     ];
-    const result = injectComposingInline(inlines, 1, '가');
-    const composing = result.find((i) => i.text === '가');
-    expect(composing?.style.image).toBeUndefined();
-    expect(composing?.style.pageNumber).toBeUndefined();
+    const { inlines: out, composingIndex } = injectComposingInline(inlines, 1, '가');
+    const composing = out[composingIndex];
+    expect(composing.text).toBe('가');
+    expect(composing.style.image).toBeUndefined();
+    expect(composing.style.pageNumber).toBeUndefined();
   });
 
   it('keeps visual style (bold) while dropping structural metadata', () => {
     const inlines: Inline[] = [
       { text: 'A', style: { bold: true, pageNumber: true } as Inline['style'] },
     ];
-    const composing = injectComposingInline(inlines, 1, 'X').find((i) => i.text === 'X');
-    expect(composing?.style.bold).toBe(true);
-    expect(composing?.style.pageNumber).toBeUndefined();
+    const { inlines: out, composingIndex } = injectComposingInline(inlines, 1, 'X');
+    const composing = out[composingIndex];
+    expect(composing.text).toBe('X');
+    expect(composing.style.bold).toBe(true);
+    expect(composing.style.pageNumber).toBeUndefined();
   });
 });
 
@@ -132,5 +146,51 @@ describe('computeLayout with composingContext', () => {
     const composing: ComposingContext = { blockId: 'ghost', offset: 0, text: 'oo' };
     const { layout } = computeLayout([a], measurer, 600, undefined, undefined, composing);
     expect(blockText(layout.blocks[0])).toBe('ABCD');
+  });
+});
+
+describe('computeLayout tags composing runs (view-local marker)', () => {
+  const measurer = stubMeasurer(8);
+
+  function paragraph(id: string, text: string) {
+    const block = createBlock('paragraph');
+    block.id = id;
+    block.inlines = [{ text, style: {} }];
+    return block;
+  }
+
+  it('tags exactly the composing run, leaving surrounding runs untagged', () => {
+    const a = paragraph('a', 'ABCD');
+    const composing: ComposingContext = { blockId: 'a', offset: 2, text: 'oo' };
+    const { layout } = computeLayout([a], measurer, 600, undefined, undefined, composing);
+    const runs = blockRuns(layout.blocks[0]);
+    const composingRuns = runs.filter((r) => r.composing);
+    expect(composingRuns.map((r) => r.text)).toEqual(['oo']);
+    // Surrounding text is not tagged.
+    for (const r of runs.filter((r) => r.text !== 'oo')) {
+      expect(r.composing).toBeFalsy();
+    }
+  });
+
+  it('tags every sub-run when the composing text wraps across lines', () => {
+    // Width fits 5 chars (40px). Injecting "XXXX" at offset 2 of "ABCD"
+    // makes "ABXXXXCD" (8 chars) which wraps; the composing run itself is
+    // split across the wrap and every piece must stay tagged.
+    const a = paragraph('a', 'ABCD');
+    const composing: ComposingContext = { blockId: 'a', offset: 2, text: 'XXXX' };
+    const { layout } = computeLayout([a], measurer, 40, undefined, undefined, composing);
+    const composingText = blockRuns(layout.blocks[0])
+      .filter((r) => r.composing)
+      .map((r) => r.text)
+      .join('');
+    expect(composingText).toBe('XXXX');
+  });
+
+  it('tags no run when there is no composing context', () => {
+    const a = paragraph('a', 'ABCD');
+    const { layout } = computeLayout([a], measurer, 600);
+    for (const r of blockRuns(layout.blocks[0])) {
+      expect(r.composing).toBeFalsy();
+    }
   });
 });

--- a/packages/docs/test/view/paint-layout.test.ts
+++ b/packages/docs/test/view/paint-layout.test.ts
@@ -4,7 +4,7 @@ import { renderRun } from '../../src/view/paint-layout';
 import { computeLayout } from '../../src/view/layout';
 import type { LayoutLine } from '../../src/view/layout';
 import { createBlock } from '../../src/model/types';
-import { ptToPx } from '../../src/view/theme';
+import { ptToPx, Theme } from '../../src/view/theme';
 import { stubMeasurer } from './_stub-measurer';
 
 /**
@@ -60,6 +60,91 @@ function singleLine(inlines: Array<{ text: string; fontSize: number }>): LayoutL
   const { layout } = computeLayout([block], stubMeasurer(), 600);
   return layout.blocks[0].lines[0];
 }
+
+/**
+ * Records each stroked line segment so composing-underline geometry can be
+ * asserted. Captures the current `strokeStyle` / `lineWidth` at `stroke()`
+ * time along with the last `moveTo` → `lineTo` pair.
+ */
+function makeStrokeCtx(): {
+  ctx: CanvasRenderingContext2D;
+  strokes: Array<{ x0: number; y0: number; x1: number; y1: number; color: string; width: number }>;
+} {
+  const strokes: Array<{ x0: number; y0: number; x1: number; y1: number; color: string; width: number }> = [];
+  let from = { x: 0, y: 0 };
+  let to = { x: 0, y: 0 };
+  let strokeStyle = '';
+  let lineWidth = 1;
+  const noop = () => {};
+  const ctx = {
+    font: '',
+    fillStyle: '',
+    get strokeStyle() { return strokeStyle; },
+    set strokeStyle(v: string) { strokeStyle = v; },
+    get lineWidth() { return lineWidth; },
+    set lineWidth(v: number) { lineWidth = v; },
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    fillText: noop,
+    save: noop,
+    restore: noop,
+    beginPath: noop,
+    moveTo(x: number, y: number) {
+      from = { x, y };
+    },
+    lineTo(x: number, y: number) {
+      to = { x, y };
+    },
+    stroke() {
+      strokes.push({ x0: from.x, y0: from.y, x1: to.x, y1: to.y, color: strokeStyle, width: lineWidth });
+    },
+    setLineDash: noop,
+    fillRect: noop,
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, strokes };
+}
+
+/** Lay out a single composing run (IME preview) and its plain neighbour. */
+function composingLine(): LayoutLine {
+  const block = createBlock('paragraph');
+  block.id = 'a';
+  block.inlines = [{ text: 'ABCD', style: {} }];
+  const { layout } = computeLayout(
+    [block], stubMeasurer(), 600, undefined, undefined,
+    { blockId: 'a', offset: 2, text: 'oo' },
+  );
+  return layout.blocks[0].lines[0];
+}
+
+describe('renderRun composing underline', () => {
+  it('strokes a 2px solid underline in the text color under a composing run', () => {
+    const line = composingLine();
+    const run = line.runs.find((r) => r.composing);
+    expect(run).toBeDefined();
+
+    const { ctx, strokes } = makeStrokeCtx();
+    renderRun(ctx, run!, 0, 0, line.height, line.maxFontSizePx, {});
+
+    // Exactly one underline stroke, spanning the run width, 2px solid.
+    expect(strokes.length).toBe(1);
+    const s = strokes[0];
+    expect(s.width).toBe(2);
+    expect(s.y0).toBe(s.y1); // horizontal
+    expect(s.x0).toBe(Math.round(run!.x));
+    expect(s.x1).toBe(Math.round(run!.x) + run!.width);
+    // Default theme text color (no explicit color on the run).
+    expect(s.color).toBe(Theme.defaultColor);
+  });
+
+  it('does not stroke an underline under a plain (non-composing) run', () => {
+    const line = composingLine();
+    const plain = line.runs.find((r) => !r.composing && r.text !== '\n');
+    expect(plain).toBeDefined();
+
+    const { ctx, strokes } = makeStrokeCtx();
+    renderRun(ctx, plain!, 0, 0, line.height, line.maxFontSizePx, {});
+    expect(strokes.length).toBe(0);
+  });
+});
 
 describe('renderRun shared baseline', () => {
   it('places different-size runs on one common baseline', () => {


### PR DESCRIPTION
## Summary

Draw an underline under uncommitted (composing) IME text in the Docs editor,
and remove it automatically when the composition commits or aborts — matching
native text fields and Google Docs (issue #342).

This PR lands both the design note and its implementation on the same branch.

**Design** (`docs/design/docs/docs-ime-composing-underline.md`): the composing
text already lives on a view-local render path (spliced into the block layout by
`injectComposingInline`, never written to the model — see #332/#346). The
underline is a paint-time decoration of that injected run, keyed off a
view-local marker that lives on `LayoutRun` (NOT on the persisted
`Inline` / `InlineStyle`), so it is leak-proof by construction.

**Implementation:**

- `injectComposingInline` now returns `{ inlines, composingIndex }` — the index
  of the spliced composing inline.
- `LayoutRun` gains a view-local `composing?: boolean`; `layoutBlock` tags every
  run derived from the composing inline (so a wrapped composition tags each
  sub-run).
- `renderRun` paints a 2px solid underline in the run's resolved text color at
  `baselineY + 2` when `run.composing` is set. (A 1px line was tried first but
  read as too faint against text; 2px matches the caret's `cursorWidth`, so the
  composing cue carries the same visual weight as the caret already on screen.)
- `composingStyleFrom` is unchanged; the marker never touches the model,
  clipboard, clone, or DOCX/PDF export.

Both the browser IME path and the software-Hangul assembler path go through
`injectComposingInline`, so both are covered.

## Why

Composing IME text was drawn plainly, with no cue that it is mid-composition.
Every native field and Google Docs underline composing text. The fix is small
and isolated because #318 (PR #332) and the composing-preview wiring (PR #346)
already moved composing text onto the view-local render path; this PR only adds
the underline decoration on top.

Keeping the marker on `LayoutRun` (a per-render view structure) rather than on
the persisted style types means it cannot leak into the model or any export
path — addressing the review feedback on the design note.

## Linked Issues

Fixes #342

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅

Local `pnpm verify:fast` runs green.

## Test plan

Unit tests (Vitest, `packages/docs`):

- `injectComposingInline` returns the index of the spliced composing inline
  (mid-inline, boundary, end-of-block, empty block; `-1` for empty text).
- `layoutBlock` tags exactly the composing run(s); a composition that wraps
  across lines tags every sub-run; no composing context → no run tagged.
- `renderRun` strokes a single 2px solid underline in the resolved text color at
  `baselineY + 2` for a composing run; a plain run strokes none.

Manual smoke (`pnpm dev` / docs demo): type Korean; the composing syllable shows
a 2px underline that disappears on commit.

## Risk Assessment

- User-facing risk: additive visual cue on composing text only; no change to
  committed text, other formatting, or measurement/wrapping. Scoped to docs.
- Data/security risk: none. The `composing` marker is view-local (`LayoutRun`)
  and never persisted or exported.
- Rollback plan: revert the implementation commit; the design note can stay.

## Notes for Reviewers

- UI changes: a 2px underline appears under composing IME text and clears on
  commit/abort. See the attached screen recording (Korean IME) for the live
  behavior; the paint-layout unit test asserts the stroke geometry/width/color.
  Width note: 1px looked too faint, so it was set to 2px to match the caret.
- Follow-up: underline color/style customization and composing background
  highlight are intentionally out of scope (see the note's Non-Goals).
- AI assistance: the investigation, design note, and implementation were done
  with Claude Code (Claude Opus 4.8). I reviewed every line and own the
  technical choices.
