### PR TITLE
Share one line-baseline helper across all docs renderers

### DIFF
--- a/docs/tasks/active/20260722-docs-baseline-dedup-lessons.md
+++ b/docs/tasks/active/20260722-docs-baseline-dedup-lessons.md
@@ -1,0 +1,38 @@
+# Lessons — De-duplicate the line baseline formula
+
+## What broke
+
+Nothing new broke — this is the structural fix for *why* the #507 bug was
+possible. The baseline formula lived in six copies across `paint-layout`,
+`table-renderer`, and `pdf-painter`, each with a comment like "matching
+doc-canvas's body path." Hand-synced duplication drifts; #507 was one copy
+being fixed while the others kept the old per-run behaviour.
+
+## Lessons
+
+- **Fix the duplication, not just the instances.** The reviewer could have
+  asked for the same three-line change pasted into two more files. Extracting
+  `lineBaselineY` means the next baseline change happens once, and the
+  "matching X" comments (which were load-bearing documentation of an invariant
+  the compiler didn't enforce) become an actual shared function.
+
+- **A shared helper must respect the callers' real differences.** The canvas
+  paths `Math.round` the baseline to hit the pixel grid; the PDF path
+  deliberately does not (continuous coords, rounding drifts between pages).
+  The helper returns the raw value and lets each caller decide — collapsing
+  the formula without collapsing that intentional difference.
+
+- **Separate "which font sizes the glyph" from "which font positions the
+  line."** For list markers the two had been the same value. The fix keeps the
+  marker drawn at its own size but positions its baseline from the line max —
+  a distinction that only surfaces when a marker sits beside a taller run.
+
+- **The earlier PR's data model paid off here for free.** `LayoutLine`
+  `maxFontSizePx` already reached table and PDF because they render the same
+  `LayoutLine` objects. The follow-up touched only painters — a sign the #507
+  field was placed at the right layer.
+
+- **Refactors need regression guards more than new assertions.** The value was
+  the existing table/PDF suites staying green (proving uniform content is
+  unchanged) plus a pure-function test pinning the formula and its unrounded
+  contract — not a large pile of new behavioural tests.

--- a/docs/tasks/active/20260722-docs-baseline-dedup-todo.md
+++ b/docs/tasks/active/20260722-docs-baseline-dedup-todo.md
@@ -1,0 +1,40 @@
+# Docs — De-duplicate the line baseline formula across renderers
+
+## Context
+
+Follow-up to the mixed-size baseline fix (PR #507), which was scoped to the
+screen text painter. The same alphabetic-baseline formula
+`lineY + (lineHeight + fontSizePx * 0.8) / 2` was copy-pasted across six
+sites in three files, keyed to each run's / marker's own font size — so table
+cells, PDF export, and list markers still floated smaller runs above a taller
+line. The duplication is what let the original bug exist and drift.
+
+This PR extracts one shared helper and routes every renderer through it,
+applying the line-common baseline everywhere.
+
+## Work
+
+- [x] Add `lineBaselineY(lineY, lineHeight, maxFontSizePx)` to `view/theme.ts`
+  — single source of truth, returns an UNROUNDED value (canvas rounds, PDF
+  must not).
+- [x] Route all six sites through it, passing `line.maxFontSizePx` (with a
+  `?? own size` fallback):
+  - `paint-layout.ts` — `renderRun` (dedupe) + `renderListMarker` (new
+    `lineMaxFontSizePx` param; marker font stays its own size, baseline uses
+    line max).
+  - `table-renderer.ts` — cell text run + list marker.
+  - `pdf-painter.ts` — `paintRun` (new param, threaded from caller) + two
+    marker sites; unrounded to preserve continuous PDF coords.
+  - `doc-canvas.ts` — pass `pl.line.maxFontSizePx` to the marker call.
+- [x] Tests: `theme.test.ts` (helper formula + unrounded contract),
+  `render-list-marker.test.ts` (marker baseline uses line max, not marker
+  size), existing table/PDF suites as regression guards.
+- [x] docs typecheck + suite green (81 files); slides typecheck + tests green.
+
+## Notes
+
+- Data was already in place: `LayoutLine.maxFontSizePx` (added in #507)
+  propagates to table/PDF because they render the same `LayoutLine` objects —
+  no layout changes needed, painters only.
+- Uniform-size content is unchanged: `maxFontSizePx ≈ own size` for a
+  single-size line, and the fallback preserves behaviour for non-text lines.

--- a/packages/docs/src/export/pdf-painter.ts
+++ b/packages/docs/src/export/pdf-painter.ts
@@ -12,7 +12,7 @@ import {
   computeMergedCellLineLayouts,
   getBlockIndexForLine,
 } from '../view/table-geometry.js';
-import { Theme, ptToPx } from '../view/theme.js';
+import { Theme, ptToPx, lineBaselineY } from '../view/theme.js';
 import { PdfFonts, customFontKey, type PdfFontKey, type FontUsage } from './pdf-fonts.js';
 import {
   resolveFontKey,
@@ -379,9 +379,12 @@ export class PdfPainter {
     const firstRun = pl.line.runs[0];
     const sizePt = firstRun?.inline.style.fontSize ?? Theme.defaultFontSize;
     const fontSizePx = ptToPx(sizePt);
-    // Same baseline formula as `paintRun` so the marker sits on the
-    // body's baseline.
-    const baselineYpx = pl.y + (pl.line.height + fontSizePx * 0.8) / 2;
+    // Same baseline as `paintRun` so the marker sits on the body's baseline.
+    const baselineYpx = lineBaselineY(
+      pl.y,
+      pl.line.height,
+      pl.line.maxFontSizePx ?? fontSizePx,
+    );
 
     const c = styleColor(firstRun?.inline.style.color);
     // Unordered markers (●, ○, ■) are in the U+25xx range and aren't
@@ -431,6 +434,7 @@ export class PdfPainter {
         lineXpx,
         lineYpx,
         lineHeightPx,
+        line.maxFontSizePx,
         pageHeightPt,
         fonts,
         ctx,
@@ -623,7 +627,11 @@ export class PdfPainter {
 
         const sizePt = cellBlock.inlines[0]?.style.fontSize ?? Theme.defaultFontSize;
         const fontSizePx = ptToPx(sizePt);
-        const baselineYpx = markerLineY + (firstLine.height + fontSizePx * 0.8) / 2;
+        const baselineYpx = lineBaselineY(
+          markerLineY,
+          firstLine.height,
+          firstLine.maxFontSizePx ?? fontSizePx,
+        );
         const c = styleColor(cellBlock.inlines[0]?.style.color);
         // Mirror the body painter at line ~330: unordered markers (●○■) live
         // in U+25xx and aren't in Helvetica's WinAnsi coverage, so route them
@@ -653,6 +661,7 @@ export class PdfPainter {
     lineXpx: number,
     lineYpx: number,
     lineHeightPx: number,
+    lineMaxFontSizePx: number | undefined,
     pageHeightPt: number,
     fonts: EmbeddedFonts,
     ctx: PaintContext,
@@ -685,12 +694,14 @@ export class PdfPainter {
     const sizePt = style.fontSize ?? Theme.defaultFontSize;
     const fontSizePx = ptToPx(sizePt);
 
-    // Match the canvas renderer's alphabetic baseline placement:
-    //   baselineY = lineY + (lineHeight + fontSizePx * 0.8) / 2
-    // (See doc-canvas.ts > renderRun.) We deliberately omit the
-    // Math.round() the canvas does — PDF coordinates are continuous
+    // Shared line-common baseline (see `lineBaselineY`). We deliberately
+    // omit the Math.round() the canvas does — PDF coordinates are continuous
     // and rounding causes vertical drift between pages.
-    const baselineYpx = lineYpx + (lineHeightPx + fontSizePx * 0.8) / 2;
+    const baselineYpx = lineBaselineY(
+      lineYpx,
+      lineHeightPx,
+      lineMaxFontSizePx ?? fontSizePx,
+    );
 
     const c = styleColor(style.color);
 

--- a/packages/docs/src/view/doc-canvas.ts
+++ b/packages/docs/src/view/doc-canvas.ts
@@ -585,7 +585,7 @@ export class DocCanvas {
             const marker = block.listKind === 'unordered'
               ? UNORDERED_MARKERS[level % UNORDERED_MARKERS.length]
               : (listCounters.get(block.id) ?? '1.');
-            paintRenderListMarker(this.ctx, block, pageY + pl.y, pl.line.height, markerX, marker, Theme);
+            paintRenderListMarker(this.ctx, block, pageY + pl.y, pl.line.height, pl.line.maxFontSizePx, markerX, marker, Theme);
           }
         }
       }

--- a/packages/docs/src/view/paint-layout.ts
+++ b/packages/docs/src/view/paint-layout.ts
@@ -5,7 +5,7 @@ import { defaultColorResolver } from '../model/color.js';
 import type { DocumentLayout, LayoutBlock, LayoutRun } from './layout.js';
 import { computeListCounters } from './layout.js';
 import type { LayoutPage } from './pagination.js';
-import { Theme as DefaultTheme, type DocTheme, buildFont, ptToPx } from './theme.js';
+import { Theme as DefaultTheme, type DocTheme, buildFont, ptToPx, lineBaselineY } from './theme.js';
 import { getOrLoadImage } from './image-cache.js';
 
 /**
@@ -196,7 +196,7 @@ function paintBlock(
         block.listKind === 'unordered'
           ? UNORDERED_MARKERS[level % UNORDERED_MARKERS.length]
           : (listCounters.get(block.id) ?? '1.');
-      renderListMarker(ctx, block, lineY, line.height, markerX, marker, theme, resolveColor);
+      renderListMarker(ctx, block, lineY, line.height, line.maxFontSizePx, markerX, marker, theme, resolveColor);
     }
   }
 }
@@ -405,8 +405,9 @@ export function renderRun(
   // never passed through `assignLineHeights`. The super/subscript shifts
   // below intentionally stay keyed to the run's OWN size — they move a run
   // relative to itself.
-  const lineAscentPx = (lineMaxFontSizePx ?? originalFontSizePx) * 0.8;
-  let baselineY = Math.round(lineY + (lineHeight + lineAscentPx) / 2);
+  let baselineY = Math.round(
+    lineBaselineY(lineY, lineHeight, lineMaxFontSizePx ?? originalFontSizePx),
+  );
   if (isSuperscript) {
     baselineY -= Math.round(originalFontSizePx * 0.4);
   } else if (isSubscript) {
@@ -506,6 +507,7 @@ export function renderListMarker(
   block: Block,
   lineY: number,
   lineHeight: number,
+  lineMaxFontSizePx: number | undefined,
   markerX: number,
   markerText: string,
   theme: DocTheme = DefaultTheme,
@@ -525,7 +527,11 @@ export function renderListMarker(
   // axes above.
   const colorSource = m?.color ?? firstInline?.color;
   const fontSizePx = ptToPx(fontSize);
-  const baselineY = Math.round(lineY + (lineHeight + fontSizePx * 0.8) / 2);
+  // Marker font stays the marker's own size, but the baseline uses the
+  // line-common max so the marker aligns with a taller first line.
+  const baselineY = Math.round(
+    lineBaselineY(lineY, lineHeight, lineMaxFontSizePx ?? fontSizePx),
+  );
   ctx.font = buildFont(fontSize, fontFamily, false, false);
   ctx.fillStyle = resolveColor(colorSource) ?? theme.defaultColor;
   ctx.fillText(markerText, markerX, baselineY);

--- a/packages/docs/src/view/table-renderer.ts
+++ b/packages/docs/src/view/table-renderer.ts
@@ -3,7 +3,7 @@ import type { LayoutRun } from './layout.js';
 import type { TableCell, TableData, BorderStyle } from '../model/types.js';
 import { DEFAULT_BORDER_STYLE, LIST_INDENT_PX, UNORDERED_MARKERS } from '../model/types.js';
 import { defaultColorResolver } from '../model/color.js';
-import { Theme, buildFont, ptToPx } from './theme.js';
+import { Theme, buildFont, ptToPx, lineBaselineY } from './theme.js';
 import { getOrLoadImage } from './image-cache.js';
 import {
   computeMergedCellLineLayouts,
@@ -464,7 +464,9 @@ export function renderTableContent(
           // tight line heights (lineHeight ≈ 1.0), so a line clipped
           // exactly at its top — the case at a paginated row split —
           // bled a sliver onto the previous page.
-          const baselineY = Math.round(runLineY + (line.height + fontSizePx * 0.8) / 2);
+          const baselineY = Math.round(
+            lineBaselineY(runLineY, line.height, line.maxFontSizePx ?? fontSizePx),
+          );
 
           // Inline run backgrounds (style.backgroundColor) were drawn
           // in `renderTableBackgrounds` before the selection layer, so
@@ -555,7 +557,9 @@ export function renderTableContent(
 
           const fontSize = cellBlock.inlines[0]?.style.fontSize ?? Theme.defaultFontSize;
           const fontSizePx = ptToPx(fontSize);
-          const baselineY = Math.round(markerLineY + (firstLine.height + fontSizePx * 0.8) / 2);
+          const baselineY = Math.round(
+            lineBaselineY(markerLineY, firstLine.height, firstLine.maxFontSizePx ?? fontSizePx),
+          );
           ctx.font = buildFont(fontSize, cellBlock.inlines[0]?.style.fontFamily, false, false);
           ctx.fillStyle = defaultColorResolver(cellBlock.inlines[0]?.style.color) ?? Theme.defaultColor;
           ctx.fillText(marker, markerX, baselineY);

--- a/packages/docs/src/view/theme.ts
+++ b/packages/docs/src/view/theme.ts
@@ -142,6 +142,28 @@ export function ptToPx(pt: number): number {
 }
 
 /**
+ * Y of the shared alphabetic baseline for a line, in the same units as
+ * `lineY` / `lineHeight`. Derived from the line's tallest run
+ * (`maxFontSizePx`, with ~0.8 taken as the ascent) so every run on the line
+ * — and the list marker — shares one baseline instead of each centring on
+ * its own font size (Google Docs behaviour).
+ *
+ * Returns an UNROUNDED value on purpose: canvas painters `Math.round` it to
+ * land on the pixel grid, while the PDF painter must NOT round (PDF uses
+ * continuous coordinates and rounding drifts the baseline between pages).
+ *
+ * Single source of truth for the formula that used to be copy-pasted across
+ * `paint-layout`, `table-renderer`, and `pdf-painter`.
+ */
+export function lineBaselineY(
+  lineY: number,
+  lineHeight: number,
+  maxFontSizePx: number,
+): number {
+  return lineY + (lineHeight + maxFontSizePx * 0.8) / 2;
+}
+
+/**
  * Build a CSS font string from inline style properties.
  * Font sizes are stored in pt; the CSS string uses px for Canvas compatibility.
  *

--- a/packages/docs/test/view/render-list-marker.test.ts
+++ b/packages/docs/test/view/render-list-marker.test.ts
@@ -8,6 +8,7 @@ interface FontCall {
   font?: string;
   fillStyle?: string;
   text?: string;
+  y?: number;
 }
 
 /**
@@ -30,8 +31,8 @@ function makeRecordingCtx(): {
     set fillStyle(v: string) { pendingFill = v; },
     get fillStyle() { return pendingFill ?? ''; },
     textBaseline: 'alphabetic' as CanvasTextBaseline,
-    fillText(text: string) {
-      calls.push({ font: pendingFont, fillStyle: pendingFill, text });
+    fillText(text: string, _x: number, y: number) {
+      calls.push({ font: pendingFont, fillStyle: pendingFill, text, y });
     },
   } as unknown as CanvasRenderingContext2D;
   return { ctx, calls };
@@ -59,7 +60,7 @@ describe('renderListMarker', () => {
       marker: { fontSize: 18, fontFamily: 'Arial', color: '#FF9900' },
       inline: { fontSize: 11, fontFamily: 'Noto Sans KR', color: '#000000' },
     });
-    renderListMarker(ctx, block, 0, 24, 10, '●');
+    renderListMarker(ctx, block, 0, 24, undefined, 10, '●');
     expect(calls).toHaveLength(1);
     // buildFont now routes the family through resolveFontFamily, which
     // splices a Korean-capable fallback before the trailing generic so
@@ -74,7 +75,7 @@ describe('renderListMarker', () => {
     const block = listItem({
       inline: { fontSize: 18, fontFamily: 'Noto Sans KR', color: '#1155cc' },
     });
-    renderListMarker(ctx, block, 0, 24, 10, '●');
+    renderListMarker(ctx, block, 0, 24, undefined, 10, '●');
     // Noto Sans KR is itself Korean-capable; resolveFontFamily must NOT
     // double-append it. The chain ends in the generic sans-serif token.
     expect(calls[0].font).toBe("24px 'Noto Sans KR', sans-serif");
@@ -87,11 +88,26 @@ describe('renderListMarker', () => {
       marker: { color: '#FF9900' },
       inline: { fontSize: 20, fontFamily: 'Arial' },
     });
-    renderListMarker(ctx, block, 0, 24, 10, '●');
+    renderListMarker(ctx, block, 0, 24, undefined, 10, '●');
     // pt → px: 20 * 96 / 72 = 26.6666… → "26.666…px '<family chain>'"
     expect(calls[0].font).toMatch(
       /^\d+(?:\.\d+)?px 'Arial', 'Noto Sans KR', sans-serif$/,
     );
     expect(calls[0].fillStyle).toBe('#FF9900');
+  });
+
+  it('derives the baseline from the line max font size, not the marker size', () => {
+    const block = listItem({ inline: { fontSize: 11 } });
+
+    // Line whose tallest run is 48px → marker drops to the shared line
+    // baseline, below where its own 11pt would place it.
+    const big = makeRecordingCtx();
+    renderListMarker(big.ctx, block, 0, 72, 48, 10, '●');
+
+    // undefined → falls back to the marker's own size (pre-fix behaviour).
+    const own = makeRecordingCtx();
+    renderListMarker(own.ctx, block, 0, 72, undefined, 10, '●');
+
+    expect(big.calls[0].y).toBeGreaterThan(own.calls[0].y!);
   });
 });

--- a/packages/docs/test/view/theme.test.ts
+++ b/packages/docs/test/view/theme.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { lineBaselineY, ptToPx } from '../../src/view/theme';
+
+describe('lineBaselineY', () => {
+  it('centers the baseline using the line max font size', () => {
+    // lineY=0, lineHeight=72, max=48 → (72 + 48*0.8) / 2 = 55.2
+    expect(lineBaselineY(0, 72, 48)).toBeCloseTo(55.2, 5);
+  });
+
+  it('is unrounded (PDF needs continuous coords)', () => {
+    // Not an integer — proves the helper does not round internally.
+    expect(Number.isInteger(lineBaselineY(0, 72, 48))).toBe(false);
+  });
+
+  it('offsets by lineY', () => {
+    expect(lineBaselineY(10, 72, 48) - lineBaselineY(0, 72, 48)).toBeCloseTo(10, 5);
+  });
+
+  it('a taller max font lowers the baseline (larger y = further down)', () => {
+    expect(lineBaselineY(0, 72, ptToPx(36))).toBeGreaterThan(
+      lineBaselineY(0, 72, ptToPx(11)),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #507 (mixed-size baseline fix), which was scoped to the screen
text painter. The same alphabetic-baseline formula
`lineY + (lineHeight + fontSizePx * 0.8) / 2` was copy-pasted across **six
sites in three files**, each keyed to the run's / marker's own font size — so
table cells, PDF export, and list markers still floated smaller runs above a
taller line on the same row.

This extracts one shared helper — `lineBaselineY(lineY, lineHeight,
maxFontSizePx)` in `view/theme.ts` — as the single source of truth, and routes
every renderer through it using the line's max font size:

- `paint-layout.ts` — `renderRun` (dedupe) + `renderListMarker` (new
  `lineMaxFontSizePx` param; the marker is still drawn at its own size, but its
  baseline now comes from the line max).
- `table-renderer.ts` — cell text run + list marker.
- `pdf-painter.ts` — `paintRun` (new param, threaded from the caller) + both
  marker sites. Kept **unrounded** (PDF uses continuous coords; rounding drifts
  the baseline between pages).
- `doc-canvas.ts` — passes `pl.line.maxFontSizePx` to the marker call.

`LayoutLine.maxFontSizePx` (added in #507) already reached these paths because
they render the same `LayoutLine` objects, so this touches painters only — no
layout changes. Uniform-size content is unchanged (`maxFontSizePx ≈ own size`
for a single-size line, plus a `?? own size` fallback).

## Test plan

- [x] `theme.test.ts` — `lineBaselineY` formula, the unrounded contract, and
      taller-max-lowers-baseline.
- [x] `render-list-marker.test.ts` — marker baseline now derives from the line
      max, not the marker's own size.
- [x] Existing `table-renderer` / `pdf-painter` suites pass unchanged
      (regression guard: uniform content renders identically).
- [x] `@wafflebase/docs` typecheck + full suite (81 files, 1105 tests).
- [x] `@wafflebase/slides` typecheck + tests (333 files, 2609) — consumes the
      painter via `paintLayout`.
- [x] Manual: docs standalone playground renders normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertical alignment of text and list markers across canvas, table, and PDF rendering.
  * Ensured lines containing mixed font sizes use the largest font size for consistent baseline positioning.
  * Preserved precise, unrounded positioning for PDF output.

* **Tests**
  * Added coverage for baseline calculations and list-marker alignment, including mixed-size text scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->