### PR TITLE
Add maintainer-controlled AGENT_ALLOWED_USERS opt-in for @claude kickoff

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -35,7 +35,8 @@ jobs:
        (github.event_name == 'issue_comment' &&
         !github.event.issue.pull_request &&
         contains(github.event.comment.body, '@claude') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)))
+        (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
+         contains(vars.AGENT_ALLOWED_USERS, github.event.comment.user.login))))
     runs-on: ubuntu-latest
     timeout-minutes: 90 # hard cost/time ceiling (implementation is turn-heavy)
     # Job-level concurrency (one run per issue). Placed on the job — not the
@@ -51,20 +52,32 @@ jobs:
       WAFFLEBASE_AGENT_AUTONOMOUS: "true"
     steps:
       # author_association in the `if` is a cheap pre-filter; this step is the
-      # authoritative gate — it fails the run unless the commenter actually has
-      # write/maintain/admin on THIS repo (org membership ≠ repo write). For
+      # authoritative gate. A commenter is authorized iff EITHER they have
+      # write/maintain/admin on THIS repo (org membership ≠ repo write), OR their
+      # EXACT login is on the maintainer-controlled `AGENT_ALLOWED_USERS` repo
+      # variable — a deliberate opt-in for trusted non-collaborators. That list
+      # is owned by the maintainer (only someone with repo admin can set a repo
+      # variable); it is NOT settable by contributors, and this step matches it
+      # exactly (the `if` above uses a loose substring only as a pre-filter). For
       # workflow_dispatch the actor already needs write to dispatch, so skip.
-      - name: Verify actor has write access
+      - name: Verify actor is authorized
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@v7
+        env:
+          ALLOWED: ${{ vars.AGENT_ALLOWED_USERS }}
         with:
           script: |
             const actor = context.payload.comment.user.login;
+            const allow = (process.env.ALLOWED || '').split(',').map((s) => s.trim()).filter(Boolean);
+            if (allow.includes(actor)) {
+              core.info(`@${actor} is on AGENT_ALLOWED_USERS — authorized.`);
+              return;
+            }
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner, repo: context.repo.repo, username: actor,
             });
             if (!['admin', 'maintain', 'write'].includes(data.permission)) {
-              core.setFailed(`@${actor} lacks write access (permission: ${data.permission}); refusing to run.`);
+              core.setFailed(`@${actor} is not on AGENT_ALLOWED_USERS and lacks write access (permission: ${data.permission}); refusing to run.`);
             }
 
       # Auth git ops as the Claude GitHub App so the branch push + PR creation


### PR DESCRIPTION
## Summary

Proposal (for maintainer decision): let a maintainer authorize specific trusted
**non-collaborators** to invoke `@claude` on an issue, without granting them full
repo write. Opening as a **draft** because *who* may trigger the budget-spending,
write-capable agent is a governance call that's yours to make — this PR only adds
the mechanism, not any membership.

## What changes (`agent-implement.yml` only)

Kickoff authorization becomes:

> authorized **iff** the commenter has real `write`/`maintain`/`admin` on this repo
> **OR** their exact login is on the `AGENT_ALLOWED_USERS` repo variable.

- The authoritative step matches `AGENT_ALLOWED_USERS` **exactly**; the `if:`
  pre-filter uses a loose substring only to let a candidate comment reach that step.
- Every other gate is untouched: `AGENT_PIPELINE_ENABLED`, issue-not-PR,
  fork rejection, and the branch-protection preflight all still apply.

## Why this is safe

- **Maintainer-owned list.** A repo variable can only be set by someone with repo
  admin, so contributors cannot self-add — that's the property that makes the
  allowlist trustworthy.
- **Opt-in and empty by default.** This PR ships the variable **unset**; nothing
  changes behavior until you populate it. An empty/absent variable = today's
  write-access-only rule exactly.
- **Not a substitute for the trust model.** Allowlisted users still can't reach
  `main` (branch protection), still can't self-approve, and a human review + merge
  remains required. It only widens *who can start a run*, deliberately, by name.

## How to use it

```bash
gh variable set AGENT_ALLOWED_USERS --repo wafflebase/wafflebase --body "alice,bob"
```

## Context / standing request

@harrykim8672 (author of the review-panel work in #508, currently a read-level
contributor) asked for trigger access to **test the issue→ready-PR loop** once it's
armed. This PR is the scoped way to grant that if you approve — add their username
to the variable rather than granting full repo write. Entirely your call; the code
change is a no-op until you set the variable.

## Not included (say the word)

The review-reply arm (`@claude` on a *PR*, `agent-review-reply.yml`) still uses the
association check, so an allowlisted user could kick off but not converse on PRs.
Happy to extend the same variable there for parity if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Expanded authorization controls for autonomous agent runs.
  * Added support for explicitly approved users through a maintainer-controlled allowlist.
  * Retained permission checks for other commenters, allowing only users with sufficient repository access.
  * Updated authorization failure messages to clarify the access requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->