### PR TITLE
Fix review-panel SDK binary launch (preserve exec bits across the artifact)

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -51,12 +51,17 @@ jobs:
         with:
           node-version: 22.x
       - run: cd scripts/agent && npm ci --no-audit --no-fund # reproducible: exact tree from the committed lockfile
+      # Tar before uploading. actions/upload-artifact does NOT preserve Unix file
+      # permissions (or symlinks), so a raw node_modules upload strips the +x bit
+      # from the SDK's bundled native binaries (the `claude` CLI, ripgrep). The
+      # review job then finds the binary present but non-executable → "binary
+      # exists but failed to launch". A tarball round-trips perms + symlinks intact.
+      - run: cd scripts/agent && tar -czf /tmp/agent-sdk-node-modules.tgz node_modules
       - uses: actions/upload-artifact@v4
         with:
           name: agent-sdk-node-modules
-          path: scripts/agent/node_modules
+          path: /tmp/agent-sdk-node-modules.tgz
           retention-days: 1
-          include-hidden-files: true
 
   review-panel:
     needs: deps
@@ -171,7 +176,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: agent-sdk-node-modules
-          path: .trusted/scripts/agent/node_modules
+          path: /tmp/agent-sdk
+      # Untar restores the exec bits the artifact upload drops, so the SDK's
+      # native `claude` binary is launchable in the review job.
+      - name: Unpack the Agent SDK into the trusted tree
+        if: steps.pr.outputs.number != ''
+        run: |
+          mkdir -p .trusted/scripts/agent
+          tar -xzf /tmp/agent-sdk/agent-sdk-node-modules.tgz -C .trusted/scripts/agent
 
       # SECURITY: the SDK cwd is the untrusted branch checkout. Strip its
       # executable agent config — `.claude/` (settings + hooks the SDK could load


### PR DESCRIPTION
## Summary

Fixes the review panel's first real run. On PR #513 the `review-panel` job ran
end-to-end but **every lens failed closed** with:

> `Claude Code native binary at …/@anthropic-ai/claude-agent-sdk-linux-x64/claude exists but failed to launch`

so no lens produced a verdict and the panel paged instead of reviewing.

## Root cause

`actions/upload-artifact` **does not preserve Unix file permissions**. The `deps`
job uploads `scripts/agent/node_modules` raw, which strips the `+x` bit from the
SDK's bundled native binaries (the `claude` CLI, ripgrep). The `review-panel` job
downloads a binary that is *present but non-executable* → spawn fails → the SDK
emits its generic "libc mismatch?" guess, but it's actually the lost exec bit.

Evidence it's **not** a wrong-variant problem: the lockfile pins per-libc variants
(`linux-x64` = glibc, `linux-x64-musl` = musl), and the failing binary is at the
**glibc** `linux-x64` path — i.e. the correct binary for `ubuntu-latest` was
installed. Only its permission bit was dropped in transit.

## Fix

Tar `node_modules` in the `deps` job (tar preserves perms **and** symlinks),
upload the tarball, and untar it in the `review-panel` job. No change to the
no-install-with-secrets rule — install still happens only in the unprivileged
`deps` job.

## Verification

- `node -c` / YAML parse clean.
- The definitive proof is the next armed run: the `agent-review-*` checks should
  post real verdicts (approved / changes-requested with findings) instead of
  "Reviewer did not produce a valid verdict."

## Context

Found while validating the merged pipeline (#508) on agent PR #513: environment
gate cleared, panel triggered, checks posted, fail-closed worked — the only
defect was this binary-launch issue. This unblocks the panel producing real
verdicts (and, in turn, the auto-fix loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Agent SDK setup in review workflows by preserving executable permissions and symbolic links.
  * Increased reliability when preparing the review panel environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->