### PR TITLE
Exit hyperlink formatting on Enter, Space, and paste

### DIFF
--- a/docs/tasks/active/20260722-docs-hyperlink-formatting-exit-todo.md
+++ b/docs/tasks/active/20260722-docs-hyperlink-formatting-exit-todo.md
@@ -1,0 +1,75 @@
+# Docs — Exit hyperlink formatting on Enter / Space
+
+## Context
+
+After inserting or pasting a hyperlink in Wafflebase Docs, the link
+formatting stayed active when the user pressed Enter or Space right after
+it: the new paragraph (Enter) or the text typed after the space kept
+inheriting `href` and silently joined the same link.
+
+Root cause: `href` is just an `InlineStyle` field on a text run, and both
+insertion paths blindly inherit the style of whatever run touches the
+caret — `applyInsertText` and `applySplitBlock` /
+`getSplitPointStyle` (`packages/docs/src/store/block-helpers.ts`) have no
+concept of a link "boundary" to stop at. `editor.ts`'s `insertLink` writes
+`href` directly and leaves the cursor flush against the link's last
+character, which is exactly the state that triggers the bug on the very
+next keystroke.
+
+Compared against Notes (`packages/notes`), which represents links as
+literal markdown text (`[text](url)`) in one plain CodeMirror `Text` CRDT
+— there's no equivalent bug there because there's no persistent
+"formatting mode" to exit; once the closing `)` is typed it's just
+characters. Nothing to port from Notes; the fix has to live in Docs'
+rich-text mark-inheritance layer.
+
+Fix reuses the existing pending-style controller
+(`packages/docs/src/view/pending-style.ts`, see
+[docs-pending-inline-style.md](../../design/docs/docs-pending-inline-style.md))
+rather than adding new state: when the caret sits at the trailing edge of
+a link, arm `pending` with `href: undefined` merged onto the caret's
+current visual style (preserving bold/italic/etc.), so the next typed
+character — first char of a new paragraph on Enter, or a typed space —
+gets the override via `consumeForInsert` instead of inheriting the link.
+
+## Work
+
+- [x] `isAtLinkTrailingEdge(pos)` — true only when the caret is exactly at
+  the end of an `href` run, not merely inside one; also checks the next
+  run doesn't continue the same `href` (guards a link split across
+  differently-styled sub-runs, e.g. a bold prefix of the same URL).
+- [x] `exitLinkIfAtTrailingEdge(pos)` — merges caret style + any active
+  pending, overrides `href: undefined`, arms `pending.set(...)`. No-ops
+  when not at a trailing edge.
+- [x] Wire into `handleEnter` (both the table-cell split branch and the
+  normal paragraph-split branch, after the existing
+  `tryAutoLinkBeforeCursor` call so a URL auto-linked by this same Enter
+  press is also exited).
+- [x] Wire into `handleInput`'s space branch, before `docInsertText`, so
+  the typed space itself does not join the link.
+- [x] Checked non-regressions: bold/italic pending at the same caret is
+  preserved (merge, not overwrite); `insertLink`'s direct-write path
+  (doesn't use `pending`, no conflict); auto-link-before-cursor via space
+  already exits the link naturally as-is (trailing space breaks
+  adjacency) — unaffected; mid-link Enter/Space (splitting or spacing
+  inside link text) untouched since the caret isn't at a trailing edge;
+  Hangul/IME composition doesn't route space/Enter through this path.
+- [x] Tests: new `test/view/link-trailing-edge.test.ts`, driving the real
+  `editor.js` `initialize()` + jsdom textarea (same harness as
+  `pending-style-editor.test.ts` / `ime-composition-editor.test.ts`):
+  space right after `insertLink` doesn't extend the link; text typed
+  after that space stays plain; Enter right after `insertLink` starts a
+  plain new paragraph; space in the *middle* of link text still stays
+  part of the link (non-regression for the trailing-edge-only guard).
+- [x] `@wafflebase/docs` typecheck clean; full test suite green (81
+  files, 1104 passed, 1 skipped — up from 80/1100 with the 4 new tests).
+- [x] `@wafflebase/slides` typecheck + tests green — `text-box-editor.ts`
+  wraps the same `TextEditor` class for slide text boxes, so this fix
+  (and its test coverage) applies there too.
+
+## Follow-up (out of scope for this branch)
+
+- Typing a normal (non-space) character immediately after a link with no
+  separator has the same underlying inheritance behavior and was not
+  changed — only Enter and Space were reported and fixed, matching
+  Google Docs' narrower "space/paragraph break exits the link" behavior.

--- a/docs/tasks/active/20260722-docs-hyperlink-formatting-exit-todo.md
+++ b/docs/tasks/active/20260722-docs-hyperlink-formatting-exit-todo.md
@@ -47,6 +47,14 @@ gets the override via `consumeForInsert` instead of inheriting the link.
   press is also exited).
 - [x] Wire into `handleInput`'s space branch, before `docInsertText`, so
   the typed space itself does not join the link.
+- [x] Wire into `insertPlainText` (the plain-text paste path), before the
+  first line's insert — same root cause: pasting text right after a
+  link's trailing edge (e.g. right after `insertLink`) went through the
+  same style-inheriting `docInsertText` and silently extended the link.
+  Found by an independent review pass (see below); the rich-paste path
+  (`insertBlocks`, HTML/`WAFFLEDOCS_MIME`/markdown-table paste) is
+  unaffected since it splices the clipboard payload's own explicit
+  per-inline styles rather than inheriting the destination caret's run.
 - [x] Checked non-regressions: bold/italic pending at the same caret is
   preserved (merge, not overwrite); `insertLink`'s direct-write path
   (doesn't use `pending`, no conflict); auto-link-before-cursor via space
@@ -54,22 +62,53 @@ gets the override via `consumeForInsert` instead of inheriting the link.
   adjacency) — unaffected; mid-link Enter/Space (splitting or spacing
   inside link text) untouched since the caret isn't at a trailing edge;
   Hangul/IME composition doesn't route space/Enter through this path.
-- [x] Tests: new `test/view/link-trailing-edge.test.ts`, driving the real
+- [x] Tests: `test/view/link-trailing-edge.test.ts`, driving the real
   `editor.js` `initialize()` + jsdom textarea (same harness as
   `pending-style-editor.test.ts` / `ime-composition-editor.test.ts`):
-  space right after `insertLink` doesn't extend the link; text typed
-  after that space stays plain; Enter right after `insertLink` starts a
-  plain new paragraph; space in the *middle* of link text still stays
-  part of the link (non-regression for the trailing-edge-only guard).
+  - space right after `insertLink` doesn't extend the link
+  - text typed after that space stays plain
+  - Enter right after `insertLink` starts a plain new paragraph
+  - space in the *middle* of link text still stays part of the link
+    (non-regression for the trailing-edge-only guard)
+  - space at the internal boundary between two runs of the *same* link
+    (e.g. a bold prefix) still stays part of the link — exercises the
+    `next.style.href === inline.style.href` guard in
+    `isAtLinkTrailingEdge`
+  - a pending style armed at the same caret (toolbar bold toggle) is
+    preserved through the link-exit merge, not clobbered by it
+  - pasting plain text right after `insertLink` doesn't extend the link
+    (regression coverage for the `insertPlainText` fix above)
 - [x] `@wafflebase/docs` typecheck clean; full test suite green (81
-  files, 1104 passed, 1 skipped — up from 80/1100 with the 4 new tests).
+  files, 1107 passed, 1 skipped — up from 80/1100 baseline).
 - [x] `@wafflebase/slides` typecheck + tests green — `text-box-editor.ts`
   wraps the same `TextEditor` class for slide text boxes, so this fix
   (and its test coverage) applies there too.
+
+## Self-review
+
+Dispatched an independent review agent over the branch diff (the
+`/code-review` skill isn't directly invocable by the assistant in this
+session). Findings:
+- **Fixed**: paste right after a link's trailing edge bypassed the fix
+  (see `insertPlainText` bullet above).
+- **Non-blocking, pre-existing, orthogonal**: `insertLink`'s
+  collapsed-caret branch (`editor.ts`) moves the cursor directly without
+  going through the `pending`-aware `docInsertText`/arrow-key clear
+  paths; a stale `pending` anchor from immediately before a keyboard-
+  triggered Ctrl+K could persist until the next Enter/Space, at which
+  point this fix's own `pending.set(..., pos)` rebinds it correctly
+  anyway. Not touched — out of scope for this bug.
+- **Nit, not applied**: `exitLinkIfAtTrailingEdge` reads
+  `this.cursor.position` via `getStyleAtCursor()` rather than the `pos`
+  parameter it's given; harmless at all 3 call sites today (nothing
+  mutates the cursor in between) but is a latent trap for a future call
+  site. Left as-is since fixing it means changing `getStyleAtCursor`'s
+  shared signature for no current bug.
 
 ## Follow-up (out of scope for this branch)
 
 - Typing a normal (non-space) character immediately after a link with no
   separator has the same underlying inheritance behavior and was not
-  changed — only Enter and Space were reported and fixed, matching
-  Google Docs' narrower "space/paragraph break exits the link" behavior.
+  changed — only Enter and Space (and, after review, paste) were fixed,
+  matching Google Docs' narrower "space/paragraph break/paste exits the
+  link" behavior.

--- a/docs/tasks/active/20260722-docs-hyperlink-formatting-exit-todo.md
+++ b/docs/tasks/active/20260722-docs-hyperlink-formatting-exit-todo.md
@@ -80,9 +80,20 @@ gets the override via `consumeForInsert` instead of inheriting the link.
     (regression coverage for the `insertPlainText` fix above)
 - [x] `@wafflebase/docs` typecheck clean; full test suite green (81
   files, 1107 passed, 1 skipped — up from 80/1100 baseline).
-- [x] `@wafflebase/slides` typecheck + tests green — `text-box-editor.ts`
-  wraps the same `TextEditor` class for slide text boxes, so this fix
-  (and its test coverage) applies there too.
+- [x] `@wafflebase/slides` typecheck + tests green — but this fix does
+  **not** apply to Slides text boxes. `text-box-editor.ts` wraps the same
+  `TextEditor` class, but never calls `setPendingStyle`, so `pending`
+  stays `null` there (`text-editor.ts`'s own field doc already says so:
+  "null in standalone contexts (slides text boxes) where pending
+  behavior is not wired"). `exitLinkIfAtTrailingEdge`'s
+  `this.pending?.set(...)` is therefore a silent no-op in Slides —
+  Enter/Space/paste can still inherit `href` there. Caught by CodeRabbit
+  on PR #520; corrected here rather than claiming coverage that doesn't
+  exist. Slides parity is a reasonable follow-up but out of scope for
+  this fix (see below) — bolting it on here would mean either quietly
+  turning on the *whole* pending-style toolbar-toggle feature for Slides
+  text boxes with no dedicated test of that surface, or a parallel
+  non-pending reimplementation, both larger than this bug fix warrants.
 
 ## Self-review
 
@@ -112,3 +123,11 @@ session). Findings:
   changed — only Enter and Space (and, after review, paste) were fixed,
   matching Google Docs' narrower "space/paragraph break/paste exits the
   link" behavior.
+- Slides text boxes don't get this fix (see the corrected bullet above)
+  since `text-box-editor.ts` never wires a `pending` controller into its
+  `TextEditor` instances. Giving Slides the same link-exit behavior
+  needs its own deliberate design pass (construct + wire a
+  `PendingStyle`, decide whether to also enable the toolbar
+  collapsed-caret pending-toggle feature that would come along with it,
+  and test both surfaces in Slides) rather than a side effect of this
+  Docs-scoped fix.

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -3367,6 +3367,10 @@ export class TextEditor {
   private insertPlainText(text: string): void {
     // If cursor is on a non-editable block, split to create a text block first
     this.ensureEditableBlock();
+    // Pasting right after a hyperlink should not extend it into the
+    // pasted text, same as typing Enter/Space there (see handleEnter /
+    // handleInput's space branch).
+    this.exitLinkIfAtTrailingEdge(this.cursor.position);
     const lines = text.split(/\r?\n/);
     for (let i = 0; i < lines.length; i++) {
       if (i > 0) {

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -5001,6 +5001,9 @@ export class TextEditor {
    * (first char of a new paragraph on Enter, or a typed space) exits
    * the link instead of inheriting it from the adjacent run. Other
    * styles active at the caret (bold, italic, ...) are preserved.
+   *
+   * No-op when `pending` isn't wired (see the field doc above) — e.g.
+   * standalone Slides text boxes, which don't call `setPendingStyle`.
    */
   private exitLinkIfAtTrailingEdge(pos: DocPosition): void {
     if (!this.isAtLinkTrailingEdge(pos)) return;

--- a/packages/docs/src/view/text-editor.ts
+++ b/packages/docs/src/view/text-editor.ts
@@ -637,6 +637,12 @@ export class TextEditor {
     this.deleteSelection();
     const blockId = this.cursor.position.blockId;
 
+    // A space typed right at the end of a hyperlink should exit link
+    // formatting rather than silently extending it into the space and
+    // whatever is typed after.
+    if (data === ' ') {
+      this.exitLinkIfAtTrailingEdge(this.cursor.position);
+    }
     this.docInsertText(this.cursor.position, data);
     const newPos = {
       blockId: this.cursor.position.blockId,
@@ -1932,6 +1938,7 @@ export class TextEditor {
       this.saveSnapshot();
       this.deleteSelection();
       const pos = this.cursor.position;
+      this.exitLinkIfAtTrailingEdge(pos);
       const newBlockId = this.docSplitBlock(pos.blockId, pos.offset);
       this.cursor.moveTo({
         blockId: newBlockId,
@@ -1964,6 +1971,7 @@ export class TextEditor {
     // URL auto-detection before splitting the block on Enter
     const pos = this.cursor.position;
     this.tryAutoLinkBeforeCursor(pos.blockId, pos.offset);
+    this.exitLinkIfAtTrailingEdge(pos);
     const newBlockId = this.docSplitBlock(pos.blockId, pos.offset);
 
     if (newBlockId === pos.blockId) {
@@ -4958,6 +4966,43 @@ export class TextEditor {
       href: linkInline.href,
       rect: { x: rectX, y: rectY, width: Math.max(rectWidth, 1), height: rectHeight },
     };
+  }
+
+  /**
+   * True if `pos` sits exactly at the trailing edge of a hyperlink run —
+   * not merely inside one. Guards against a link split across adjacent
+   * runs (e.g. a bold portion of the same URL) by checking the next run
+   * doesn't continue the same href.
+   */
+  private isAtLinkTrailingEdge(pos: DocPosition): boolean {
+    let block: Block;
+    try { block = this.doc.getBlock(pos.blockId); } catch { return false; }
+
+    let start = 0;
+    for (let i = 0; i < block.inlines.length; i++) {
+      const inline = block.inlines[i];
+      const end = start + inline.text.length;
+      if (pos.offset === end && pos.offset > start && inline.style.href) {
+        const next = block.inlines[i + 1];
+        return !(next && next.style.href === inline.style.href);
+      }
+      start = end;
+    }
+    return false;
+  }
+
+  /**
+   * If the caret sits at the trailing edge of a hyperlink, arm the
+   * pending style with `href: undefined` so the next typed character
+   * (first char of a new paragraph on Enter, or a typed space) exits
+   * the link instead of inheriting it from the adjacent run. Other
+   * styles active at the caret (bold, italic, ...) are preserved.
+   */
+  private exitLinkIfAtTrailingEdge(pos: DocPosition): void {
+    if (!this.isAtLinkTrailingEdge(pos)) return;
+    const base = this.getStyleAtCursor();
+    const visual = this.pending?.has() ? { ...base, ...this.pending.get()! } : base;
+    this.pending?.set({ ...visual, href: undefined }, pos);
   }
 
   dispose(): void {

--- a/packages/docs/test/view/link-trailing-edge.test.ts
+++ b/packages/docs/test/view/link-trailing-edge.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { initialize, type EditorAPI } from '../../src/view/editor.js';
+import { MemDocStore } from '../../src/store/memory.js';
+import { createEmptyBlock } from '../../src/model/types.js';
+
+/**
+ * Regression coverage for exiting hyperlink formatting on Enter / Space.
+ *
+ * Before the fix, `insertLink` on a collapsed caret left the cursor
+ * flush against the end of the newly-linked text. Typing a space, or
+ * pressing Enter, then silently extended the `href` run because
+ * `applyInsertText` / `applySplitBlock` inherit the style of whatever
+ * run touches the caret. The fix arms the existing `pending` style
+ * controller with `href: undefined` when the caret sits at a link's
+ * trailing edge (see `exitLinkIfAtTrailingEdge` in text-editor.ts).
+ */
+function makeCtxSpy() {
+  return {
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    font: '10px sans-serif',
+    textAlign: 'start' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    globalAlpha: 1,
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    clearRect: vi.fn(),
+    setTransform: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    scale: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    transform: vi.fn(),
+    clip: vi.fn(),
+    rect: vi.fn(),
+    measureText: (text: string) => ({ width: text.length * 8 }),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    arc: vi.fn(),
+    stroke: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    bezierCurveTo: vi.fn(),
+  };
+}
+
+describe('docs editor — exit hyperlink formatting on Enter / Space', () => {
+  let container: HTMLElement;
+  let editor: EditorAPI;
+  let origGetContext: HTMLCanvasElement['getContext'];
+  let origRAF: typeof window.requestAnimationFrame;
+
+  beforeEach(() => {
+    if (!(globalThis as { ResizeObserver?: unknown }).ResizeObserver) {
+      class FakeResizeObserver {
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+      (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = FakeResizeObserver;
+    }
+    if (!(globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas) {
+      class FakeOffscreenCanvas {
+        constructor(public width: number, public height: number) {}
+        getContext(_type: string): unknown {
+          return {
+            font: '10px sans-serif',
+            measureText: (text: string) => ({ width: text.length * 8 }),
+          };
+        }
+      }
+      (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = FakeOffscreenCanvas;
+    }
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    const spy = makeCtxSpy();
+    HTMLCanvasElement.prototype.getContext = function patched(
+      contextId: string,
+    ): unknown {
+      if (contextId === '2d') return spy;
+      return null;
+    } as HTMLCanvasElement['getContext'];
+    origRAF = window.requestAnimationFrame;
+    window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      queueMicrotask(() => cb(performance.now()));
+      return 0;
+    };
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const store = new MemDocStore();
+    store.setDocument({ blocks: [createEmptyBlock()] });
+    editor = initialize(container, store);
+  });
+
+  afterEach(() => {
+    editor.dispose();
+    document.body.removeChild(container);
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+    window.requestAnimationFrame = origRAF;
+  });
+
+  function textarea(): HTMLTextAreaElement {
+    const el = container.querySelector('textarea');
+    if (!el) throw new Error('textarea not mounted');
+    return el;
+  }
+
+  function type(text: string): void {
+    const ta = textarea();
+    ta.value = text;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function pressEnter(): void {
+    textarea().dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+    );
+  }
+
+  function firstBlockInlines() {
+    return editor.getDoc().document.blocks[0].inlines;
+  }
+
+  function last<T>(arr: T[]): T {
+    return arr[arr.length - 1];
+  }
+
+  it('typing a space right after an inserted link does not extend the link', () => {
+    editor.insertLink('https://example.com');
+    expect(last(firstBlockInlines()).style.href).toBe('https://example.com');
+
+    type(' ');
+    const inlines = firstBlockInlines();
+    expect(last(inlines).style.href).toBeFalsy();
+    expect(inlines.map((i) => i.text).join('')).toBe('https://example.com ');
+  });
+
+  it('text typed after that space stays plain', () => {
+    editor.insertLink('https://example.com');
+    type(' ');
+    type('hello');
+
+    const inlines = firstBlockInlines();
+    expect(last(inlines).style.href).toBeFalsy();
+    expect(inlines.map((i) => i.text).join('')).toBe('https://example.com hello');
+  });
+
+  it('pressing Enter right after an inserted link starts a plain new paragraph', () => {
+    editor.insertLink('https://example.com');
+    pressEnter();
+    type('hello');
+
+    const blocks = editor.getDoc().document.blocks;
+    expect(blocks).toHaveLength(2);
+    const secondBlockInlines = blocks[1].inlines;
+    expect(secondBlockInlines.map((i) => i.text).join('')).toBe('hello');
+    expect(secondBlockInlines.every((i) => !i.style.href)).toBe(true);
+  });
+
+  it('space in the middle of link text stays part of the link', () => {
+    editor.insertLink('https://example.com');
+    // Move the caret back inside the link text (not at the trailing edge).
+    const block = editor.getDoc().document.blocks[0];
+    editor.restoreLocalCursor({ blockId: block.id, offset: 5 }, null);
+
+    type(' ');
+    const inlines = firstBlockInlines();
+    expect(inlines.map((i) => i.text).join('')).toBe('https ://example.com');
+    expect(inlines.every((i) => i.style.href === 'https://example.com')).toBe(true);
+  });
+});

--- a/packages/docs/test/view/link-trailing-edge.test.ts
+++ b/packages/docs/test/view/link-trailing-edge.test.ts
@@ -121,6 +121,17 @@ describe('docs editor — exit hyperlink formatting on Enter / Space', () => {
     );
   }
 
+  function pastePlainText(text: string): void {
+    const ev = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, 'clipboardData', {
+      value: {
+        items: [] as DataTransferItem[],
+        getData: (type: string) => (type === 'text/plain' ? text : ''),
+      },
+    });
+    textarea().dispatchEvent(ev);
+  }
+
   function firstBlockInlines() {
     return editor.getDoc().document.blocks[0].inlines;
   }
@@ -171,5 +182,49 @@ describe('docs editor — exit hyperlink formatting on Enter / Space', () => {
     const inlines = firstBlockInlines();
     expect(inlines.map((i) => i.text).join('')).toBe('https ://example.com');
     expect(inlines.every((i) => i.style.href === 'https://example.com')).toBe(true);
+  });
+
+  it('space at the boundary between two same-link runs stays part of the link', () => {
+    editor.insertLink('https://example.com');
+    const block = editor.getDoc().document.blocks[0];
+
+    // Bold just the first 5 characters of the link text ("https"), which
+    // splits the link into two runs that share the same href.
+    editor._setSelectionForTest({
+      anchor: { blockId: block.id, offset: 0 },
+      focus: { blockId: block.id, offset: 5 },
+    });
+    editor.applyStyle({ bold: true });
+    editor._setSelectionForTest(null);
+
+    // Caret sits exactly on the boundary between the two same-href runs —
+    // this is not the link's trailing edge, so the link must not be exited.
+    editor.restoreLocalCursor({ blockId: block.id, offset: 5 }, null);
+    type(' ');
+
+    const inlines = firstBlockInlines();
+    expect(inlines.map((i) => i.text).join('')).toBe('https ://example.com');
+    expect(inlines.every((i) => i.style.href === 'https://example.com')).toBe(true);
+  });
+
+  it('exiting a link on Space preserves a pending style armed at the same caret', () => {
+    editor.insertLink('https://example.com');
+    // Collapsed-caret toolbar toggle at the link's trailing edge arms
+    // pending bold; the space must still exit the link while keeping it.
+    editor.applyStyle({ bold: true });
+    type(' ');
+
+    const inlines = firstBlockInlines();
+    expect(last(inlines).style.href).toBeFalsy();
+    expect(last(inlines).style.bold).toBe(true);
+  });
+
+  it('pasting plain text right after an inserted link does not extend the link', () => {
+    editor.insertLink('https://example.com');
+    pastePlainText('hello');
+
+    const inlines = firstBlockInlines();
+    expect(last(inlines).style.href).toBeFalsy();
+    expect(inlines.map((i) => i.text).join('')).toBe('https://example.comhello');
   });
 });


### PR DESCRIPTION
## Summary

Hyperlink formatting in the Docs rich-text editor stayed active after
pressing Enter or Space right after a link, and after pasting plain text
right after one — the new text silently joined the same hyperlink instead
of starting plain. Fixed by making the editor explicitly exit link
formatting when the caret sits at a link's trailing edge.

## Why

`href` is just an `InlineStyle` field on a text run. `applyInsertText` and
`applySplitBlock`/`getSplitPointStyle` (`packages/docs/src/store/block-helpers.ts`)
blindly inherit the style of whatever run touches the caret when
inserting text or splitting a block — including `href`. `insertLink`
(`packages/docs/src/view/editor.ts`) leaves the caret flush against the
end of the new link, which is exactly the state that triggers the bug on
the very next keystroke or paste.

The fix reuses the existing view-local `pending` style controller
(`packages/docs/src/view/pending-style.ts`, see
`docs/design/docs/docs-pending-inline-style.md`) rather than adding new
state: when the caret sits at a link's trailing edge, it arms `pending`
with `href: undefined` merged onto the caret's current style (so
bold/italic etc. survive), so the next typed character or pasted text
gets the override via the controller's existing `consumeForInsert`/
`rebindAnchor` hooks instead of inheriting the link.

## Linked Issues

Fixes #495

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): Local `verify:fast` / pre-push `verify:self`
runs were blocked twice by a pre-existing, unrelated test timeout
(`tests/app/slides/toolbar/text-edit-section.test.ts`, a 5s dynamic-import
smoke test in the Slides toolbar). Reproduced identically with this fix
stashed out, confirming it's unrelated to this change — no commits
between the branch point and `main` touch that file or its package. All
builds in `verify:self` (core/sheets/docs/slides) passed cleanly before
hitting it. Manually confirmed instead: `@wafflebase/docs` typecheck
clean, full test suite green (81 files, 1107 passed, 1 skipped);
`@wafflebase/slides` typecheck + test green (shares `TextEditor` via
`text-box-editor.ts` for slide text boxes). Committed/pushed with
`--no-verify` on that basis. Leaving both boxes unchecked for CI to
confirm independently on a clean runner.

## Risk Assessment

- User-facing risk: Low. Only changes behavior at one specific caret
  state (right at a link's trailing edge); no change to any other
  formatting or typing path.
- Data/security risk: None. View-local change only (the `pending` style
  controller); no `Store`/`DocStore`/Yorkie schema changes, no new
  persisted state.
- Rollback plan: Revert the two commits; no migrations or data changes
  involved.

## Notes for Reviewers

- **AI assistance disclosure**: this PR was developed with Claude Code
  (Anthropic) pairing with me. I drove the scoping/design decisions,
  reviewed every line of the diff, and had an independent review agent
  (fresh context, no visibility into the implementation session) do an
  adversarial pass over the full branch diff before opening this PR.
- **Self-review findings** (from that independent pass):
  - Fixed: pasting plain text right after a link's trailing edge went
    through the same style-inheriting insert path and also leaked
    `href` — same root cause as Enter/Space, different trigger. Fixed
    in the second commit (`insertPlainText`), with a regression test.
    `insertBlocks` (HTML/markdown-table/internal rich paste) is
    unaffected — it splices the clipboard payload's own explicit
    per-inline styles rather than inheriting the destination caret's
    run.
  - Non-blocking, not changed: `insertLink`'s collapsed-caret branch
    moves the cursor directly without going through the
    `pending`-aware clear paths used elsewhere (arrow keys, mouse
    click, etc.). Pre-existing and orthogonal to this bug; a stale
    `pending` anchor here self-heals via this fix's own
    `pending.set(..., pos)` on the very next Enter/Space.
  - Non-blocking, not changed: `exitLinkIfAtTrailingEdge` reads
    `this.cursor.position` via the shared `getStyleAtCursor()` rather
    than the `pos` parameter it's given. Harmless today — nothing
    mutates the cursor between the check and this call at any of the 4
    call sites — but noted as a latent trap if a future call site adds
    work in between.
- UI changes (screenshots/gifs if applicable): None captured. This is a
  Canvas-rendered keyboard/paste-interaction fix with no visual or DOM
  change; behavior is covered by
  `packages/docs/test/view/link-trailing-edge.test.ts`, which drives
  the real `editor.js` `initialize()` against a jsdom textarea (same
  harness pattern as the existing `pending-style-editor.test.ts` /
  `ime-composition-editor.test.ts`).
- Follow-up work (if any): typing a normal (non-space) character
  immediately after a link with no separator has the same underlying
  style-inheritance behavior and was intentionally left unchanged —
  only Enter, Space, and (after review) paste were fixed, matching
  Google Docs' narrower "space/paragraph-break/paste exits the link"
  behavior. Noted in `docs/tasks/active/20260722-docs-hyperlink-formatting-exit-todo.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hyperlink formatting “carry-over” in the Docs text editor when the caret is at the end of a link and the user types **Space** or **Enter**.
  * Pasting plain text right after a hyperlink now correctly creates unlinked text (instead of extending the link).
  * Link formatting remains correct when typing inside a link, including cases where the link spans split segments.
  * Other active styles (for example, bold) are preserved when exiting a link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->