### PR TITLE
Post an agent effort/cost summary comment when a PR is marked ready

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -240,3 +240,14 @@ jobs:
           name: claude-execution-output
           path: ${{ runner.temp }}/claude-execution-output.json
           if-no-files-found: warn
+
+      # Record this session's effort into the PR metrics ledger. The kickoff
+      # created the PR mid-run, so resolve it by the `agent/<issue>-…` branch.
+      # Fail-safe: continue-on-error + the script exits 0 on any error.
+      - name: Record agent effort metrics
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE: ${{ github.event.issue.number || github.event.inputs.issue_number }}
+        run: node ./scripts/agent/metrics.mjs record --execution "$RUNNER_TEMP/claude-execution-output.json" --kind implement --issue "$ISSUE"

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -106,10 +106,22 @@ jobs:
                 body: `${PAGED}\n🛑 CI failed ${failedCi} times on this branch (limit ${max}) without going green. **A human needs to take a look** — the harness could not self-resolve it.`,
               });
               await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: ['agent:needs-human-review'] }).catch(() => {});
+              core.setOutput('paged', 'true');
               core.setOutput('proceed', 'false');
               return;
             }
             core.setOutput('proceed', 'true');
+
+      # Loop gave up and paged a human → still post the effort summary so the
+      # "needs human review" hand-off carries the cost/effort context. The repo
+      # is already checked out above; runs on the runner's system node.
+      - name: Post agent-effort summary (paged → needs human review)
+        if: steps.guard.outputs.paged == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.guard.outputs.pr }}
+        run: node ./scripts/agent/metrics.mjs summarize --pr "$PR"
 
       - uses: pnpm/action-setup@v4
         if: steps.guard.outputs.proceed == 'true'

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -189,4 +189,5 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: node ./scripts/agent/metrics.mjs record --execution "$RUNNER_TEMP/claude-execution-output.json" --kind ci-fix --pr "${{ steps.guard.outputs.pr }}"
+          PR: ${{ steps.guard.outputs.pr }}
+        run: node ./scripts/agent/metrics.mjs record --execution "$RUNNER_TEMP/claude-execution-output.json" --kind ci-fix --pr "$PR"

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -168,3 +168,13 @@ jobs:
             --max-turns 40
             --model claude-opus-4-8
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"
+
+      # Record this session's effort into the PR metrics ledger (fail-safe:
+      # continue-on-error + the script exits 0 on any error, so metrics never
+      # break the iterate loop).
+      - name: Record agent effort metrics
+        if: always() && steps.guard.outputs.proceed == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: node ./scripts/agent/metrics.mjs record --execution "$RUNNER_TEMP/claude-execution-output.json" --kind ci-fix --pr "${{ steps.guard.outputs.pr }}"

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -461,7 +461,8 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: node ./scripts/agent/metrics.mjs record --execution "$RUNNER_TEMP/claude-execution-output.json" --kind review-fix --pr "${{ needs.review-panel.outputs.pr }}"
+          PR: ${{ needs.review-panel.outputs.pr }}
+        run: node ./scripts/agent/metrics.mjs record --execution "$RUNNER_TEMP/claude-execution-output.json" --kind review-fix --pr "$PR"
 
   # Safety net: the pipeline stopped without promoting → page a human so the loop
   # never silently stalls. This must catch every terminal "no hand-off" shape:

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -327,6 +327,7 @@ jobs:
             const page = async (msg) => {
               await github.rest.issues.createComment({ owner, repo, issue_number: pr, body: `${PAGED}\n🛑 ${msg}` });
               await github.rest.issues.addLabels({ owner, repo, issue_number: pr, labels: ['agent:needs-human-review'] }).catch(() => {});
+              core.setOutput('paged', 'true');
               core.setOutput('proceed', 'false');
             };
             // Paginate: the PAGED latch must see ALL comments, not just the first
@@ -354,6 +355,22 @@ jobs:
               return page(`The review panel requested changes ${failedRounds} times (limit ${max}) without converging. A human should take over on PR #${pr}.`);
             }
             core.setOutput('proceed', 'true');
+
+      # Loop gave up (round cap, or a lens failed closed) and paged a human →
+      # post the effort summary too. The fix job's normal checkout is gated on
+      # `proceed`, so check out the TRUSTED main copy here to run summarize.
+      - name: Check out gate script (paged summary)
+        if: steps.guard.outputs.paged == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Post agent-effort summary (paged → needs human review)
+        if: steps.guard.outputs.paged == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+        run: node ./scripts/agent/metrics.mjs summarize --pr "$PR"
 
       - name: Gather failing lens findings
         id: findings
@@ -475,7 +492,9 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/github-script@v7
+      - name: Page a human
+        id: page
+        uses: actions/github-script@v7
         with:
           script: |
             const branch = context.payload.workflow_run.head_branch;
@@ -485,6 +504,7 @@ jobs:
             });
             const pr = prs.data[0];
             if (!pr) return;
+            core.setOutput('pr', String(pr.number));
             await github.rest.issues.createComment({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number,
               body: '<!-- agent-review-paged -->\n🛑 The review-panel job failed to complete. **A human should review** this PR — the automated panel did not produce verdicts.',
@@ -493,3 +513,19 @@ jobs:
               owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number,
               labels: ['agent:needs-human-review'],
             }).catch(() => {});
+
+      # The panel died before producing verdicts, but earlier sessions
+      # (kickoff / ci-fix) recorded effort — post the summary so the hand-off
+      # carries the cost/effort context too. Trusted main checkout for the script.
+      - name: Check out gate script (paged summary)
+        if: steps.page.outputs.pr != ''
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Post agent-effort summary
+        if: steps.page.outputs.pr != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.page.outputs.pr }}
+        run: node ./scripts/agent/metrics.mjs summarize --pr "$PR"

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -277,6 +277,7 @@ jobs:
         with:
           node-version: 22.x
       - name: Run ready gate
+        id: gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ needs.review-panel.outputs.pr }}
@@ -288,6 +289,17 @@ jobs:
           set -e
           if [ "$code" -eq 2 ]; then echo "mark-ready tooling error" >&2; exit 2; fi
           if [ "$code" -eq 1 ]; then echo "Not all ready-gates satisfied; leaving as draft."; fi
+          if [ "$code" -eq 0 ]; then echo "ready=true" >> "$GITHUB_OUTPUT"; fi
+
+      # PR is (or already was) ready → post the aggregated agent-effort summary
+      # from the metrics ledger. Fail-safe: never blocks promotion.
+      - name: Post agent-effort summary
+        if: steps.gate.outputs.ready == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+        run: node ./scripts/agent/metrics.mjs summarize --pr "$PR"
 
   fix:
     needs: review-panel
@@ -424,6 +436,15 @@ jobs:
             --max-turns 40
             --model claude-opus-4-8
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"
+
+      # Record this review-fix session's effort into the PR metrics ledger
+      # (fail-safe: continue-on-error + the script exits 0 on any error).
+      - name: Record agent effort metrics
+        if: always() && steps.guard.outputs.proceed == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: node ./scripts/agent/metrics.mjs record --execution "$RUNNER_TEMP/claude-execution-output.json" --kind review-fix --pr "${{ needs.review-panel.outputs.pr }}"
 
   # Safety net: the pipeline stopped without promoting → page a human so the loop
   # never silently stalls. This must catch every terminal "no hand-off" shape:

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -1,0 +1,234 @@
+// Agent effort/cost metrics for the autonomous issue→PR pipeline.
+//
+// Each agent session (kickoff `implement` / `ci-fix` / `review-fix`) appends a
+// machine-readable record to a hidden LEDGER comment on the PR. When the PR is
+// promoted to ready-for-review, the promote job renders one aggregated,
+// human-readable SUMMARY comment:
+//
+//   - Agents: claude-opus-4-8
+//   - Scope-size: M
+//   - Attempt: 1
+//   - Sessions: 1
+//   - Total-time: 89m
+//   - Turns: 27
+//   - Tokens: ~1.0M
+//
+// Data source: `claude-execution-output.json` (the claude-code-action transcript)
+// — its final `result` message carries num_turns / duration_ms / usage / modelUsage.
+// Tokens = input+output+cache (total processed). Scope-size = PR diff lines.
+//
+// Pure helpers are exported and unit-tested (no gh). The CLI (`record` /
+// `summarize`) talks to GitHub via the `gh` CLI (GH_TOKEN / GITHUB_TOKEN).
+// Recording is FAIL-SAFE: any error exits 0 so metrics can never break the
+// pipeline (the workflow steps are also continue-on-error).
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const LEDGER_MARKER = "<!-- agent-metrics-ledger -->";
+export const SUMMARY_MARKER = "<!-- agent-metrics-summary -->";
+const REC_PREFIX = "<!--m-->";
+
+// --- pure helpers (exported for tests; no gh) ------------------------------
+
+/** Extract one session record from a parsed claude-execution-output.json array. */
+export function parseExecution(messages, kind = "implement") {
+  const arr = Array.isArray(messages) ? messages : [];
+  const result = [...arr].reverse().find((m) => m && m.type === "result");
+  if (!result) return null;
+  const u = result.usage || {};
+  const tokens =
+    (u.input_tokens || 0) +
+    (u.output_tokens || 0) +
+    (u.cache_creation_input_tokens || 0) +
+    (u.cache_read_input_tokens || 0);
+  return {
+    kind,
+    models: Object.keys(result.modelUsage || {}),
+    turns: result.num_turns || 0,
+    tokens,
+    durationMs: result.duration_ms || 0,
+    costUsd: result.total_cost_usd || 0,
+    sessionId: result.session_id || "",
+  };
+}
+
+/** Aggregate an array of session records into pipeline-wide totals. */
+export function aggregate(records) {
+  const list = Array.isArray(records) ? records : [];
+  const agents = [...new Set(list.flatMap((r) => r.models || []))].sort();
+  // Attempt = review cycles: 1 = approved on the first review; +1 per review-fix
+  // round. (Distinct from Sessions, which also counts CI-fix runs.)
+  const reviewFixes = list.filter((r) => r.kind === "review-fix").length;
+  const sum = (f) => list.reduce((s, r) => s + (Number(r[f]) || 0), 0);
+  return {
+    agents,
+    sessions: list.length,
+    attempt: reviewFixes + 1,
+    turns: sum("turns"),
+    tokens: sum("tokens"),
+    durationMs: sum("durationMs"),
+    costUsd: sum("costUsd"),
+  };
+}
+
+/** S/M/L from total lines changed in the PR diff. */
+export function scopeSize(additions = 0, deletions = 0) {
+  const changed = (Number(additions) || 0) + (Number(deletions) || 0);
+  if (changed <= 50) return "S";
+  if (changed <= 300) return "M";
+  return "L";
+}
+
+export function formatTokens(n) {
+  const v = Number(n) || 0;
+  if (v >= 1e6) return `~${(v / 1e6).toFixed(1)}M`;
+  if (v >= 1e3) return `~${Math.round(v / 1e3)}K`;
+  return `~${v}`;
+}
+
+export function formatMinutes(ms) {
+  return `${Math.max(1, Math.round((Number(ms) || 0) / 60000))}m`;
+}
+
+/** Render the human-readable summary comment body. */
+export function renderSummary({ agg, scope }) {
+  return [
+    SUMMARY_MARKER,
+    "## 🤖 Agent effort",
+    "",
+    `- Agents: ${agg.agents.length ? agg.agents.join(", ") : "unknown"}`,
+    `- Scope-size: ${scope}`,
+    `- Attempt: ${agg.attempt}`,
+    `- Sessions: ${agg.sessions}`,
+    `- Total-time: ${formatMinutes(agg.durationMs)}`,
+    `- Turns: ${agg.turns}`,
+    `- Tokens: ${formatTokens(agg.tokens)}`,
+  ].join("\n");
+}
+
+export function serializeRecord(rec) {
+  return `${REC_PREFIX}${JSON.stringify(rec)}`;
+}
+
+/** Parse the machine-readable records out of a ledger comment body. */
+export function parseLedger(body) {
+  if (!body) return [];
+  return body
+    .split("\n")
+    .filter((l) => l.startsWith(REC_PREFIX))
+    .map((l) => {
+      try {
+        return JSON.parse(l.slice(REC_PREFIX.length));
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+// --- gh-backed CLI ---------------------------------------------------------
+
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8" });
+}
+function ghJson(args) {
+  return JSON.parse(gh(args));
+}
+
+function resolvePrByIssue(issue) {
+  // The kickoff creates a branch `agent/<issue>-<slug>`; find the open PR for it.
+  const prs = ghJson(["pr", "list", "--state", "open", "--json", "number,headRefName"]);
+  const prefix = `agent/${issue}-`;
+  const hit = prs.find((p) => (p.headRefName || "").startsWith(prefix));
+  return hit ? String(hit.number) : "";
+}
+
+function findComment(pr, marker) {
+  const comments = ghJson(["api", `repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`]);
+  return comments.find((c) => (c.body || "").includes(marker));
+}
+
+function upsertComment(pr, marker, body) {
+  const existing = findComment(pr, marker);
+  if (existing) {
+    gh(["api", "-X", "PATCH", `repos/{owner}/{repo}/issues/comments/${existing.id}`, "-f", `body=${body}`]);
+  } else {
+    gh(["api", "-X", "POST", `repos/{owner}/{repo}/issues/${pr}/comments`, "-f", `body=${body}`]);
+  }
+}
+
+function parseArgs(argv) {
+  const a = {};
+  for (let i = 3; i < argv.length; i++) {
+    if (argv[i].startsWith("--")) {
+      a[argv[i].slice(2)] = argv[i + 1];
+      i++;
+    }
+  }
+  return a;
+}
+
+// Metrics must NEVER fail the pipeline: log and exit 0 on any problem.
+function bail(msg) {
+  console.error(`metrics: ${msg}`);
+  process.exit(0);
+}
+
+function cmdRecord(args) {
+  const pr = args.pr || (args.issue ? resolvePrByIssue(args.issue) : "");
+  if (!pr) return bail("no PR resolved (need --pr, or --issue with an open agent/<issue>- PR)");
+  let messages;
+  try {
+    messages = JSON.parse(readFileSync(args.execution, "utf8"));
+  } catch (e) {
+    return bail(`cannot read execution log ${args.execution}: ${e.message}`);
+  }
+  const rec = parseExecution(messages, args.kind || "implement");
+  if (!rec) return bail("no result message in the execution log");
+  let ledger;
+  try {
+    ledger = findComment(pr, LEDGER_MARKER);
+    const prevBody = ledger ? ledger.body : LEDGER_MARKER;
+    upsertComment(pr, LEDGER_MARKER, `${prevBody}\n${serializeRecord(rec)}`);
+  } catch (e) {
+    return bail(`could not update ledger for PR #${pr}: ${e.message}`);
+  }
+  console.log(`recorded ${rec.kind} for PR #${pr}: turns=${rec.turns} tokens=${rec.tokens} ${formatMinutes(rec.durationMs)}`);
+}
+
+function cmdSummarize(args) {
+  const pr = args.pr;
+  if (!pr) return bail("summarize needs --pr");
+  let records, prInfo;
+  try {
+    const ledger = findComment(pr, LEDGER_MARKER);
+    records = parseLedger(ledger ? ledger.body : "");
+    if (records.length === 0) return bail(`no metrics recorded for PR #${pr}; skipping summary`);
+    prInfo = ghJson(["pr", "view", pr, "--json", "additions,deletions"]);
+  } catch (e) {
+    return bail(`could not read metrics/PR for #${pr}: ${e.message}`);
+  }
+  const agg = aggregate(records);
+  const scope = scopeSize(prInfo.additions, prInfo.deletions);
+  try {
+    upsertComment(pr, SUMMARY_MARKER, renderSummary({ agg, scope }));
+  } catch (e) {
+    return bail(`could not post summary for PR #${pr}: ${e.message}`);
+  }
+  console.log(`posted agent-effort summary for PR #${pr} (sessions=${agg.sessions} turns=${agg.turns} tokens=${agg.tokens})`);
+}
+
+// Only run the CLI when executed directly (not when imported for tests).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const cmd = process.argv[2];
+  const args = parseArgs(process.argv);
+  if (cmd === "record") cmdRecord(args);
+  else if (cmd === "summarize") cmdSummarize(args);
+  else {
+    console.error("usage: metrics.mjs <record|summarize> [--pr N | --issue N] [--execution PATH] [--kind implement|ci-fix|review-fix]");
+    process.exit(2);
+  }
+}

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -27,9 +27,12 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const LEDGER_MARKER = "<!-- agent-metrics-ledger -->";
+// Each session posts its OWN hidden metric comment (append-only) — no shared
+// ledger to read-modify-write, so concurrent sessions can't overwrite each
+// other's records. SUMMARY is the single aggregated comment, upserted by the
+// promote job (one writer, no race).
+const METRIC_PREFIX = "<!-- agent-metric ";
 export const SUMMARY_MARKER = "<!-- agent-metrics-summary -->";
-const REC_PREFIX = "<!--m-->";
 
 // --- pure helpers (exported for tests; no gh) ------------------------------
 
@@ -109,24 +112,22 @@ export function renderSummary({ agg, scope }) {
   ].join("\n");
 }
 
+/** One session's record as a self-contained HIDDEN comment (renders invisibly).
+ * The record fields are machine-generated (no free text), so the JSON never
+ * contains the ` -->` terminator the parser splits on. */
 export function serializeRecord(rec) {
-  return `${REC_PREFIX}${JSON.stringify(rec)}`;
+  return `${METRIC_PREFIX}${JSON.stringify(rec)} -->`;
 }
 
-/** Parse the machine-readable records out of a ledger comment body. */
-export function parseLedger(body) {
-  if (!body) return [];
-  return body
-    .split("\n")
-    .filter((l) => l.startsWith(REC_PREFIX))
-    .map((l) => {
-      try {
-        return JSON.parse(l.slice(REC_PREFIX.length));
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean);
+/** Recover the record from a single metric comment body; null if not one. */
+export function parseMetricComment(body) {
+  const m = /<!-- agent-metric ([\s\S]*?) -->/.exec(body || "");
+  if (!m) return null;
+  try {
+    return JSON.parse(m[1]);
+  } catch {
+    return null;
+  }
 }
 
 // --- gh-backed CLI ---------------------------------------------------------
@@ -140,15 +141,24 @@ function ghJson(args) {
 
 function resolvePrByIssue(issue) {
   // The kickoff creates a branch `agent/<issue>-<slug>`; find the open PR for it.
-  const prs = ghJson(["pr", "list", "--state", "open", "--json", "number,headRefName"]);
+  // --limit well above the default 30 so a busy repo's PR list isn't truncated
+  // before ours is seen.
+  const prs = ghJson(["pr", "list", "--state", "open", "--limit", "500", "--json", "number,headRefName"]);
   const prefix = `agent/${issue}-`;
   const hit = prs.find((p) => (p.headRefName || "").startsWith(prefix));
   return hit ? String(hit.number) : "";
 }
 
+// ALL comment pages, not just the first 100 — a chatty PR exceeds one page, and
+// missing pages would drop metric records or the summary marker. `--slurp` wraps
+// the paginated responses in a JSON array of pages, which we flatten.
+function listAllComments(pr) {
+  const pages = ghJson(["api", "--paginate", "--slurp", `repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`]);
+  return Array.isArray(pages) ? pages.flat() : [];
+}
+
 function findComment(pr, marker) {
-  const comments = ghJson(["api", `repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`]);
-  return comments.find((c) => (c.body || "").includes(marker));
+  return listAllComments(pr).find((c) => (c.body || "").includes(marker));
 }
 
 function upsertComment(pr, marker, body) {
@@ -188,13 +198,12 @@ function cmdRecord(args) {
   }
   const rec = parseExecution(messages, args.kind || "implement");
   if (!rec) return bail("no result message in the execution log");
-  let ledger;
   try {
-    ledger = findComment(pr, LEDGER_MARKER);
-    const prevBody = ledger ? ledger.body : LEDGER_MARKER;
-    upsertComment(pr, LEDGER_MARKER, `${prevBody}\n${serializeRecord(rec)}`);
+    // Append-only: POST this session's own metric comment. No read-modify-write,
+    // so concurrent sessions can't clobber each other's records.
+    gh(["api", "-X", "POST", `repos/{owner}/{repo}/issues/${pr}/comments`, "-f", `body=${serializeRecord(rec)}`]);
   } catch (e) {
-    return bail(`could not update ledger for PR #${pr}: ${e.message}`);
+    return bail(`could not record metrics for PR #${pr}: ${e.message}`);
   }
   console.log(`recorded ${rec.kind} for PR #${pr}: turns=${rec.turns} tokens=${rec.tokens} ${formatMinutes(rec.durationMs)}`);
 }
@@ -204,8 +213,7 @@ function cmdSummarize(args) {
   if (!pr) return bail("summarize needs --pr");
   let records, prInfo;
   try {
-    const ledger = findComment(pr, LEDGER_MARKER);
-    records = parseLedger(ledger ? ledger.body : "");
+    records = listAllComments(pr).map((c) => parseMetricComment(c.body || "")).filter(Boolean);
     if (records.length === 0) return bail(`no metrics recorded for PR #${pr}; skipping summary`);
     prInfo = ghJson(["pr", "view", pr, "--json", "additions,deletions"]);
   } catch (e) {

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseExecution,
+  aggregate,
+  scopeSize,
+  formatTokens,
+  formatMinutes,
+  renderSummary,
+  serializeRecord,
+  parseLedger,
+} from "./metrics.mjs";
+
+const resultMsg = (over = {}) => ({
+  type: "result",
+  num_turns: 27,
+  duration_ms: 89 * 60000,
+  total_cost_usd: 1.23,
+  session_id: "s1",
+  modelUsage: { "claude-opus-4-8": {} },
+  usage: {
+    input_tokens: 100,
+    output_tokens: 34633,
+    cache_creation_input_tokens: 136293,
+    cache_read_input_tokens: 800000,
+  },
+  ...over,
+});
+
+test("parseExecution: pulls turns/tokens(incl cache)/time/model from the last result", () => {
+  const rec = parseExecution([{ type: "assistant" }, resultMsg()], "implement");
+  assert.equal(rec.kind, "implement");
+  assert.deepEqual(rec.models, ["claude-opus-4-8"]);
+  assert.equal(rec.turns, 27);
+  assert.equal(rec.tokens, 100 + 34633 + 136293 + 800000); // total incl. cache
+  assert.equal(rec.durationMs, 89 * 60000);
+  // no result message → null (caller treats as nothing to record)
+  assert.equal(parseExecution([{ type: "assistant" }]), null);
+  assert.equal(parseExecution("garbage"), null);
+});
+
+test("aggregate: sums across sessions; attempt counts review-fix rounds + 1", () => {
+  const recs = [
+    { kind: "implement", models: ["claude-opus-4-8"], turns: 10, tokens: 500000, durationMs: 600000 },
+    { kind: "ci-fix", models: ["claude-opus-4-8"], turns: 5, tokens: 200000, durationMs: 120000 },
+    { kind: "review-fix", models: ["claude-sonnet-5"], turns: 8, tokens: 300000, durationMs: 300000 },
+  ];
+  const agg = aggregate(recs);
+  assert.deepEqual(agg.agents, ["claude-opus-4-8", "claude-sonnet-5"]); // unique, sorted
+  assert.equal(agg.sessions, 3);
+  assert.equal(agg.attempt, 2); // one review-fix → attempt 2
+  assert.equal(agg.turns, 23);
+  assert.equal(agg.tokens, 1000000);
+  assert.equal(agg.durationMs, 1020000);
+  // no review-fix → attempt 1
+  assert.equal(aggregate([{ kind: "implement" }]).attempt, 1);
+  assert.equal(aggregate([]).sessions, 0);
+});
+
+test("scopeSize: S/M/L thresholds on total diff lines", () => {
+  assert.equal(scopeSize(10, 5), "S");
+  assert.equal(scopeSize(50, 0), "S");
+  assert.equal(scopeSize(60, 100), "M");
+  assert.equal(scopeSize(300, 0), "M");
+  assert.equal(scopeSize(400, 200), "L");
+});
+
+test("formatTokens / formatMinutes: human-friendly", () => {
+  assert.equal(formatTokens(1_000_000), "~1.0M");
+  assert.equal(formatTokens(6_200_000), "~6.2M");
+  assert.equal(formatTokens(34_733), "~35K");
+  assert.equal(formatTokens(0), "~0");
+  assert.equal(formatMinutes(89 * 60000), "89m");
+  assert.equal(formatMinutes(5000), "1m"); // floor at 1m
+});
+
+test("renderSummary: matches the requested bullet format", () => {
+  const md = renderSummary({
+    agg: { agents: ["claude-opus-4-8"], sessions: 1, attempt: 1, turns: 27, tokens: 1_000_000, durationMs: 89 * 60000 },
+    scope: "M",
+  });
+  assert.match(md, /- Agents: claude-opus-4-8/);
+  assert.match(md, /- Scope-size: M/);
+  assert.match(md, /- Attempt: 1/);
+  assert.match(md, /- Sessions: 1/);
+  assert.match(md, /- Total-time: 89m/);
+  assert.match(md, /- Turns: 27/);
+  assert.match(md, /- Tokens: ~1\.0M/);
+});
+
+test("ledger round-trip: serialize then parse recovers records; ignores prose", () => {
+  const recs = [
+    { kind: "implement", models: ["claude-opus-4-8"], turns: 10, tokens: 5, durationMs: 1 },
+    { kind: "review-fix", models: ["claude-opus-4-8"], turns: 3, tokens: 2, durationMs: 1 },
+  ];
+  const body = ["<!-- agent-metrics-ledger -->", ...recs.map(serializeRecord), "some human note"].join("\n");
+  assert.deepEqual(parseLedger(body), recs);
+  assert.deepEqual(parseLedger(""), []);
+});

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -8,7 +8,7 @@ import {
   formatMinutes,
   renderSummary,
   serializeRecord,
-  parseLedger,
+  parseMetricComment,
 } from "./metrics.mjs";
 
 const resultMsg = (over = {}) => ({
@@ -88,12 +88,13 @@ test("renderSummary: matches the requested bullet format", () => {
   assert.match(md, /- Tokens: ~1\.0M/);
 });
 
-test("ledger round-trip: serialize then parse recovers records; ignores prose", () => {
-  const recs = [
-    { kind: "implement", models: ["claude-opus-4-8"], turns: 10, tokens: 5, durationMs: 1 },
-    { kind: "review-fix", models: ["claude-opus-4-8"], turns: 3, tokens: 2, durationMs: 1 },
-  ];
-  const body = ["<!-- agent-metrics-ledger -->", ...recs.map(serializeRecord), "some human note"].join("\n");
-  assert.deepEqual(parseLedger(body), recs);
-  assert.deepEqual(parseLedger(""), []);
+test("metric comment round-trip: hidden, self-contained, parses back; junk → null", () => {
+  const rec = { kind: "review-fix", models: ["claude-opus-4-8"], turns: 3, tokens: 2, durationMs: 1 };
+  const body = serializeRecord(rec);
+  assert.match(body, /^<!-- agent-metric /); // a hidden HTML comment (renders invisibly)
+  assert.match(body, / -->$/);
+  assert.deepEqual(parseMetricComment(body), rec); // round-trips
+  // not a metric comment / unparseable → null (so summarize just skips it)
+  assert.equal(parseMetricComment("a normal human comment"), null);
+  assert.equal(parseMetricComment(""), null);
 });


### PR DESCRIPTION
## Summary

When an agent PR is promoted to **ready-for-review**, post a summary of how much
effort the pipeline spent producing it:

```
## 🤖 Agent effort
- Agents: claude-opus-4-8
- Scope-size: M
- Attempt: 1
- Sessions: 1
- Total-time: 89m
- Turns: 27
- Tokens: ~1.0M
```

## How it works

- **Each agent session records its own effort.** After every Claude Code run —
  kickoff (`implement`), CI-fix (`ci-fix`), and review-fix (`review-fix`) — a step
  parses that session's `claude-execution-output.json` (`num_turns`,
  `duration_ms`, `usage`, `modelUsage`) and appends a machine-readable record to a
  hidden **ledger** comment on the PR.
- **The promote job renders the summary.** When the ready gate passes,
  `metrics summarize` aggregates all ledger records and posts/updates one
  human-readable comment.

## Design decisions (confirmed with the mentor)

- **Aggregation:** all sessions. `Sessions` = every agent run; `Attempt` =
  review-fix rounds + 1; time/turns/tokens summed across the whole pipeline.
- **Tokens:** total processed = input + output + cache-read + cache-creation.
- **Scope-size:** derived from PR diff lines (S ≤ 50, M ≤ 300, L > 300).

## Safety

Metrics can **never break the pipeline**: `scripts/agent/metrics.mjs` exits 0 on
any error (missing log, no PR, API hiccup) and every workflow step is
`continue-on-error`. Ledger/summary comments are hidden-marker upserts (no
duplication, no `@claude`, so they don't re-trigger anything).

## Files

- `scripts/agent/metrics.mjs` — pure helpers + `record`/`summarize` CLI (gh-backed).
- `scripts/agent/metrics.test.mjs` — 6 unit tests (run by the `agent:tests` lane).
- `agent-implement.yml`, `agent-iterate-ci.yml`, `agent-review-panel.yml` — one
  `record` step per agent entry point; `summarize` in the promote job.

## Validation

`node --check`, YAML parse (all 3 workflows), 19/19 agent unit tests, entropy
(dead-code + doc-staleness) clean. The end-to-end comment is proven on the next
armed agent PR that reaches ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated agent effort tracking for autonomous workflows, capturing tokens, duration, model, and session details.
  * Automatically posts aggregated effort summaries to pull requests for implementation, CI-fix, and review-fix activity, including during human hand-off and promotion.
  * Introduced scope-size classification based on change volume.
* **Reliability**
  * Metrics recording and summarization are fail-safe and won’t block workflow progress.
* **Tests**
  * Added unit coverage for metric parsing, aggregation, formatting, summary rendering, and hidden ledger handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->