### PR TITLE
Harden the review panel against false negatives (sampling + cross-round re-check)

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -196,6 +196,45 @@ jobs:
         if: steps.pr.outputs.number != ''
         run: rm -rf "$GITHUB_WORKSPACE/.claude" "$GITHUB_WORKSPACE/.mcp.json"
 
+      # Part 2: carry the PREVIOUS round's blocking findings into this run so the
+      # panel can re-check they were actually resolved (not just missed). Each
+      # lens's findings were persisted in its check run's output.text; take the
+      # latest agent-review-<lens> check per lens across the PR's commits (ours
+      # only). This runs BEFORE the panel posts its checks, so all existing ones
+      # are prior rounds. Never fails the job (best-effort; empty on round 1).
+      - name: Read prior findings
+        if: steps.pr.outputs.number != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const pr = Number('${{ steps.pr.outputs.number }}');
+            const manifest = JSON.parse(fs.readFileSync('.trusted/scripts/agent/lenses/lenses.json', 'utf8'));
+            const wantNames = new Set(manifest.map((l) => `agent-review-${l.id}`));
+            const commits = await github.paginate(github.rest.pulls.listCommits, { owner, repo, pull_number: pr, per_page: 100 });
+            const latest = {}; // check name -> { id, t }
+            for (const c of commits) {
+              const runs = await github.paginate(github.rest.checks.listForRef, { owner, repo, ref: c.sha, per_page: 100 });
+              for (const r of runs) {
+                if (!wantNames.has(r.name) || !r.app || r.app.slug !== 'github-actions') continue;
+                const t = new Date(r.started_at || 0).getTime();
+                if (!latest[r.name] || t > latest[r.name].t) latest[r.name] = { id: r.id, t };
+              }
+            }
+            const prior = [];
+            for (const [name, { id }] of Object.entries(latest)) {
+              const lens = name.replace(/^agent-review-/, '');
+              let text = '';
+              try { const { data } = await github.rest.checks.get({ owner, repo, check_run_id: id }); text = (data.output && data.output.text) || ''; } catch {}
+              let findings = [];
+              try { findings = JSON.parse(text); } catch {}
+              if (Array.isArray(findings)) for (const f of findings) if (f && typeof f === 'object') prior.push({ ...f, lens });
+            }
+            fs.writeFileSync('/tmp/prior-findings.json', JSON.stringify(prior));
+            core.info(`prior findings carried into re-check: ${prior.length}`);
+
       - name: Run review panel
         if: steps.pr.outputs.number != ''
         # continue-on-error: a crash must not skip the needs-gated promote/fix
@@ -214,6 +253,7 @@ jobs:
           --diff-file /tmp/pr.diff
           --issue-file /tmp/issue.txt
           --changed-files /tmp/changed.txt
+          --prior-findings /tmp/prior-findings.json
           --repo "$GITHUB_WORKSPACE"
           --lenses-dir .trusted/scripts/agent/lenses
           --out .agent-review
@@ -250,10 +290,22 @@ jobs:
               }
               let summary = '_No summary produced (failing closed)._';
               try { summary = fs.readFileSync(`.agent-review/${lens.id}/summary.md`, 'utf8'); } catch {}
+              // Persist this lens's BLOCKING findings as machine-readable JSON in
+              // output.text so the NEXT round's "Read prior findings" step can
+              // re-check them (Part 2). output.summary stays the human-readable body.
+              let findingsText = '[]';
+              try {
+                const v = JSON.parse(fs.readFileSync(`.agent-review/${lens.id}/verdict.json`, 'utf8'));
+                const norm = (s) => { const x = String(s ?? '').toLowerCase().trim(); return ['critical', 'major', 'minor', 'nit'].includes(x) ? x : 'major'; };
+                const blockers = (Array.isArray(v.findings) ? v.findings : [])
+                  .filter((f) => norm(f.severity) === 'critical' || norm(f.severity) === 'major')
+                  .map((f) => ({ severity: norm(f.severity), file: f.file, summary: f.summary, evidence: f.evidence }));
+                findingsText = JSON.stringify(blockers);
+              } catch {}
               await github.rest.checks.create({
                 owner: context.repo.owner, repo: context.repo.repo,
                 name: `agent-review-${lens.id}`, head_sha: sha, status: 'completed', conclusion,
-                output: { title: `${lens.id}: ${conclusion}`, summary: summary.slice(0, 60000) },
+                output: { title: `${lens.id}: ${conclusion}`, summary: summary.slice(0, 60000), text: findingsText.slice(0, 60000) },
               });
             }
             core.setOutput('blocked', String(blocked));

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -297,15 +297,23 @@ jobs:
               try {
                 const v = JSON.parse(fs.readFileSync(`.agent-review/${lens.id}/verdict.json`, 'utf8'));
                 const norm = (s) => { const x = String(s ?? '').toLowerCase().trim(); return ['critical', 'major', 'minor', 'nit'].includes(x) ? x : 'major'; };
-                const blockers = (Array.isArray(v.findings) ? v.findings : [])
+                const trim = (s, n) => (typeof s === 'string' && s.length > n ? s.slice(0, n) : s);
+                let blockers = (Array.isArray(v.findings) ? v.findings : [])
                   .filter((f) => norm(f.severity) === 'critical' || norm(f.severity) === 'major')
-                  .map((f) => ({ severity: norm(f.severity), file: f.file, summary: f.summary, evidence: f.evidence }));
+                  .map((f) => ({ severity: norm(f.severity), file: trim(f.file, 300), summary: trim(f.summary, 2000), evidence: trim(f.evidence, 2000) }));
+                // Keep output.text VALID JSON within the 60k limit: NEVER slice the
+                // serialized string (that yields JSON the next round can't parse).
+                // Fields are trimmed above; drop trailing findings until it fits.
                 findingsText = JSON.stringify(blockers);
+                while (findingsText.length > 60000 && blockers.length > 0) {
+                  blockers = blockers.slice(0, -1);
+                  findingsText = JSON.stringify(blockers);
+                }
               } catch {}
               await github.rest.checks.create({
                 owner: context.repo.owner, repo: context.repo.repo,
                 name: `agent-review-${lens.id}`, head_sha: sha, status: 'completed', conclusion,
-                output: { title: `${lens.id}: ${conclusion}`, summary: summary.slice(0, 60000), text: findingsText.slice(0, 60000) },
+                output: { title: `${lens.id}: ${conclusion}`, summary: summary.slice(0, 60000), text: findingsText },
               });
             }
             core.setOutput('blocked', String(blocked));

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -386,6 +386,28 @@ Components:
   and an LLM reviewer can still be swayed by prompt injection — the human merge
   gate is the backstop. Same model across lenses for now; a per-lens `model`
   field makes diversity a one-field change.
+  - **False-negative hardening (the verifier only fights false *positives* — it
+    drops findings, it can't add a missed one).** Two measures raise recall so a
+    real issue isn't silently missed, motivated by a live case where the
+    correctness lens flagged a regression, then reviewed the *same unchanged code*
+    clean on a re-run:
+    1. **Sampling + union.** Each lens runs `samples` times (per-lens field in
+       `scripts/agent/lenses/lenses.json`, default 2) and the findings are UNIONed — any sample's
+       finding enters the gate. The union goes through the same conservative
+       `coerceFindings`/`dedupeFindings` (identical file+summary collapse to the
+       highest severity; distinct bugs never merge), and the verifier refute pass
+       is the precision counterweight. No LLM/semantic merge — that could
+       over-merge two distinct bugs into one, reintroducing the miss.
+    2. **Cross-round re-check.** Each round persists its blocking findings in the
+       per-lens check run's `output.text`; the next round reads the latest prior
+       `agent-review-<lens>` findings (`--prior-findings`) and re-verifies each
+       against the *current* diff with the same biased-to-keep refute pass. A
+       prior finding survives unless it is confidently *resolved* — so it can't
+       vanish just because a later fresh pass missed it (only because it was
+       actually fixed). Unresolved priors merge (deduped) into the round's findings.
+
+    Both lower false-negative odds; neither makes the panel safe to self-promote —
+    the human review gate stays the backstop.
 - **Ready gate** — `scripts/agent/mark-ready.mjs`, invoked by the review-panel
   workflow on all-pass: promotes draft → ready only when the **"CI" workflow run**
   for the head SHA concluded `success` (read via the Actions API, not the

--- a/scripts/agent/lenses/lenses.json
+++ b/scripts/agent/lenses/lenses.json
@@ -5,7 +5,8 @@
     "gating": "blocking",
     "needsIssueSpec": false,
     "appliesWhen": ["**"],
-    "model": "claude-opus-4-8"
+    "model": "claude-opus-4-8",
+    "samples": 2
   },
   {
     "id": "security",
@@ -13,7 +14,8 @@
     "gating": "blocking",
     "needsIssueSpec": false,
     "appliesWhen": ["**"],
-    "model": "claude-opus-4-8"
+    "model": "claude-opus-4-8",
+    "samples": 2
   },
   {
     "id": "design-fit",
@@ -21,7 +23,8 @@
     "gating": "blocking",
     "needsIssueSpec": true,
     "appliesWhen": ["**"],
-    "model": "claude-opus-4-8"
+    "model": "claude-opus-4-8",
+    "samples": 2
   },
   {
     "id": "test-adequacy",
@@ -29,6 +32,7 @@
     "gating": "blocking",
     "needsIssueSpec": false,
     "appliesWhen": ["**"],
-    "model": "claude-opus-4-8"
+    "model": "claude-opus-4-8",
+    "samples": 2
   }
 ]

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -147,6 +147,39 @@ export function applyVerifications(findings, verdictsByIndex) {
   });
 }
 
+/**
+ * Union the findings from N independent samples of one lens (Part 1: fight
+ * false negatives from single-sample non-determinism). We take the UNION, not a
+ * vote — a finding raised by any sample enters the gate (the verifier refute
+ * pass is the precision counterweight). coerceFindings keeps malformed entries;
+ * dedupeFindings collapses identical file+summary and keeps the highest severity,
+ * so it never merges two distinct bugs. `results` are raw lens outputs (or nulls
+ * from failed samples).
+ */
+export function unionSamples(results) {
+  const all = (Array.isArray(results) ? results : [])
+    .filter((r) => r && Array.isArray(r.findings))
+    .flatMap((r) => r.findings);
+  return dedupeFindings(coerceFindings(all));
+}
+
+/**
+ * Parse the prior-round findings file (Part 2: cross-round re-check). Tolerant —
+ * bad/empty/missing input yields [] (no prior findings to re-check, safe). Keeps
+ * only object entries; each is expected to carry {lens, severity, file, summary,
+ * evidence} (the workflow tags `lens` when reading prior check runs).
+ */
+export function parsePriorFindings(text) {
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+  return data.filter((f) => f && typeof f === "object");
+}
+
 // --- SDK wrapper (lazy import) ----------------------------------------------
 
 async function askStructured({ systemPrompt, prompt, model, repo, schema }) {
@@ -274,6 +307,12 @@ async function main() {
   const changedFiles = args["changed-files"] && existsSync(args["changed-files"])
     ? readFileSync(args["changed-files"], "utf8").split("\n").map((s) => s.trim()).filter(Boolean)
     : [];
+  // Part 2: blocking findings from the PREVIOUS review round (tagged with their
+  // lens id by the workflow). Absent/empty on the first round. Re-checked per
+  // lens below so a still-present issue can't vanish if this round's pass misses it.
+  const priorFindings = args["prior-findings"] && existsSync(args["prior-findings"])
+    ? parsePriorFindings(readFileSync(args["prior-findings"], "utf8"))
+    : [];
 
   const allLenses = loadLenses(lensesDir);
   // panel[] is the AUTHORITATIVE lens list the workflow + mark-ready consume —
@@ -295,13 +334,24 @@ async function main() {
 
     let findings, summary;
     try {
-      const res = await runLens(lens, { rubric: lens.rubric, diff, issue, repo });
-      // The SDK schema is REQUESTED of the model but the harness must not trust
-      // it blindly. COERCE (never drop) so a malformed finding fails toward
-      // blocking instead of vanishing off the gate path, then dedupe so
-      // duplicates don't get double-verified / double-counted.
-      findings = dedupeFindings(coerceFindings(res.findings));
-      summary = typeof res.summary === "string" ? res.summary : "";
+      // Part 1: sample the lens N times (default 2) and UNION the findings, to
+      // fight single-sample non-determinism (the #521 false negative). Each
+      // sample is independent and individually caught: a sample that throws
+      // contributes nothing, but if ALL samples fail we fall through to the
+      // catch below (fail-closed, same as the old single-run crash path).
+      const samples = Math.max(1, Number(lens.samples) || 2);
+      const results = await Promise.all(
+        Array.from({ length: samples }, async () => {
+          try { return await runLens(lens, { rubric: lens.rubric, diff, issue, repo }); }
+          catch (e) { return { __error: e.message }; }
+        }),
+      );
+      const ok = results.filter((r) => r && !r.__error);
+      if (ok.length === 0) throw new Error((results[0] && results[0].__error) || "all lens samples failed");
+      // unionSamples coerces (never drops) + dedupes (collapses identical
+      // file+summary, keeps highest severity, never merges distinct bugs).
+      findings = unionSamples(ok);
+      summary = ok.map((r) => (typeof r.summary === "string" ? r.summary : "")).filter(Boolean).join("\n\n");
     } catch (err) {
       const failFindings = [{ severity: "major", summary: `Reviewer did not produce a valid verdict: ${err.message}` }];
       writeVerdict(lensOut, lens, failFindings, "(no valid verdict — failing closed)", { valid: false });
@@ -318,8 +368,25 @@ async function main() {
     }));
     const kept = applyVerifications(findings, verdicts);
 
+    // Part 2: re-check this lens's blocking findings from the PREVIOUS round
+    // against the CURRENT diff, biased-to-keep. verifyFinding asks "is this
+    // genuinely present in the diff?" — so a fixed finding is refuted (dropped)
+    // and a still-present one is confirmed (kept). Because applyVerifications
+    // drops only on high-confidence `refuted`, a prior finding survives unless
+    // it's confidently resolved — even if this round's fresh pass missed it.
+    const priorForLens = priorFindings.filter((p) => p.lens === lens.id);
+    const priorVerdicts = await Promise.all(priorForLens.map(async (f) => {
+      if (!BLOCKING.has(normalizeSeverity(f.severity))) return null;
+      try { return await verifyFinding(f, { rubric: lens.rubric, diff, repo, model: lens.model }); }
+      catch { return null; } // error → keep (fail toward blocking)
+    }));
+    const priorKept = applyVerifications(priorForLens, priorVerdicts);
+    // Merge fresh + still-open prior findings; dedupe collapses a prior finding
+    // the fresh pass also re-found (and never merges two distinct bugs).
+    const merged = dedupeFindings([...kept, ...priorKept]);
+
     // Advisory lenses report findings but never block.
-    const { conclusion } = writeVerdict(lensOut, lens, kept, summary, {
+    const { conclusion } = writeVerdict(lensOut, lens, merged, summary, {
       valid: true,
       conclusion: blocking ? undefined : "success",
       advisory: !blocking,

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -157,10 +157,15 @@ export function applyVerifications(findings, verdictsByIndex) {
  * from failed samples).
  */
 export function unionSamples(results) {
-  const all = (Array.isArray(results) ? results : [])
-    .filter((r) => r && Array.isArray(r.findings))
-    .flatMap((r) => r.findings);
-  return dedupeFindings(coerceFindings(all));
+  // Coerce EACH successful sample's findings individually — do NOT pre-filter to
+  // array payloads. coerceFindings turns a malformed/non-array payload into a
+  // synthetic blocking finding, so a malformed successful sample fails toward
+  // blocking instead of silently contributing nothing (which could yield a clean
+  // verdict). Nullish/error sentinels are dropped (main only passes successful
+  // samples, and throws before calling this if ALL failed).
+  const list = (Array.isArray(results) ? results : []).filter((r) => r && !r.__error);
+  const all = list.flatMap((r) => coerceFindings(r.findings));
+  return dedupeFindings(all);
 }
 
 /**

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -6,6 +6,8 @@ import {
   dedupeFindings,
   applyVerifications,
   coerceFindings,
+  unionSamples,
+  parsePriorFindings,
 } from "./review-panel.mjs";
 import { classify } from "./severity.mjs";
 
@@ -69,6 +71,50 @@ test("coerceFindings + dedupeFindings (main pipeline): a critical is never maske
     ]).conclusion,
     "failure",
   );
+});
+
+test("unionSamples: union across N samples; recall gained, dups collapse fail-toward-blocking", () => {
+  // Part 1: sample A finds X; sample B finds X (same) + Y (new) → union {X, Y}.
+  const a = { findings: [{ severity: "major", file: "a.ts", summary: "X" }] };
+  const b = { findings: [{ severity: "major", file: "a.ts", summary: "X" }, { severity: "critical", file: "b.ts", summary: "Y" }] };
+  const u = unionSamples([a, b]);
+  assert.equal(u.length, 2); // X deduped, Y added (recall from sampling)
+  assert.ok(u.some((f) => f.summary === "Y" && f.severity === "critical"));
+  // same finding at two severities across samples → highest wins (fail toward blocking)
+  const s1 = { findings: [{ severity: "nit", file: "a.ts", summary: "Z" }] };
+  const s2 = { findings: [{ severity: "critical", file: "a.ts", summary: "Z" }] };
+  const uz = unionSamples([s1, s2]);
+  assert.equal(uz.length, 1);
+  assert.equal(uz[0].severity, "critical");
+  // failed samples (null / {__error}) contribute nothing; a well-formed one still counts
+  assert.equal(unionSamples([null, { __error: "boom" }, a]).length, 1);
+  assert.equal(unionSamples([]).length, 0);
+});
+
+test("parsePriorFindings: tolerant — valid array round-trips, junk → []", () => {
+  const recs = [{ lens: "correctness", severity: "major", file: "a.ts", summary: "prior" }];
+  assert.deepEqual(parsePriorFindings(JSON.stringify(recs)), recs);
+  assert.deepEqual(parsePriorFindings(""), []);
+  assert.deepEqual(parsePriorFindings("not json"), []);
+  assert.deepEqual(parsePriorFindings('{"not":"an array"}'), []);
+  // non-object entries are dropped
+  assert.deepEqual(parsePriorFindings('[null, 3, {"severity":"major","summary":"ok"}]'), [{ severity: "major", summary: "ok" }]);
+});
+
+// Part 2: a prior blocking finding that this round's fresh pass MISSED must
+// still block after being re-checked (verifier didn't refute it) and merged.
+// This is the #521 false-negative, guarded at the composition level.
+test("cross-round merge: an unresolved prior finding the fresh pass missed still blocks", () => {
+  const freshKept = []; // this round's lens returned nothing (missed it)
+  const priorForLens = [{ lens: "correctness", severity: "major", file: "s.ts", summary: "MIN/MAX all-blank returns #NUM!" }];
+  // re-check couldn't refute it (null verdict = kept, biased-to-block)
+  const priorKept = applyVerifications(priorForLens, [null]);
+  const merged = dedupeFindings([...freshKept, ...priorKept]);
+  assert.equal(merged.length, 1);
+  assert.equal(classify(merged).conclusion, "failure");
+  // but if the re-check confidently refutes it (genuinely resolved) → dropped
+  const resolved = applyVerifications(priorForLens, [{ verdict: "refuted", confidence: "high" }]);
+  assert.equal(classify(dedupeFindings([...freshKept, ...resolved])).conclusion, "success");
 });
 
 test("applyVerifications: drops ONLY on high-confidence refuted; keeps on any doubt", () => {

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -89,6 +89,12 @@ test("unionSamples: union across N samples; recall gained, dups collapse fail-to
   // failed samples (null / {__error}) contribute nothing; a well-formed one still counts
   assert.equal(unionSamples([null, { __error: "boom" }, a]).length, 1);
   assert.equal(unionSamples([]).length, 0);
+  // a MALFORMED successful sample (findings not an array, or missing) must fail
+  // toward blocking via coerceFindings — never be dropped into a clean verdict
+  assert.equal(classify(unionSamples([{ summary: "x", findings: "oops" }])).conclusion, "failure");
+  assert.equal(classify(unionSamples([{ summary: "x" }])).conclusion, "failure");
+  // a legitimately empty sample (findings: []) contributes nothing (not blocking)
+  assert.equal(unionSamples([{ findings: [] }]).length, 0);
 });
 
 test("parsePriorFindings: tolerant — valid array round-trips, junk → []", () => {


### PR DESCRIPTION
## Summary

Harden the review panel against **false negatives** — a lens missing a real
finding on a given run. Motivated by a live case (#521): the correctness lens
flagged a real regression, then reviewed the **same unchanged code clean** on a
re-run. The verifier refute pass can't help here — it only *drops* findings
(fights false *positives*); it can't add back a missed one.

Two complementary measures:

### Part 1 — sample each lens, union findings
Each lens now runs `samples` times (per-lens field in
`scripts/agent/lenses/lenses.json`, default 2) and the findings are **unioned**.
Any sample's finding enters the gate. The union goes through the existing
conservative `coerceFindings`/`dedupeFindings` (identical file+summary collapse
to the highest severity; distinct bugs never merge), and the existing verifier
refute pass is the precision counterweight. If **all** samples of a lens error,
it still fails closed. No LLM/semantic merge — that could over-merge two distinct
bugs into one, reintroducing the miss.

### Part 2 — re-check prior findings across rounds
Each round persists its blocking findings in the per-lens check run's
`output.text`. The next round reads the latest prior `agent-review-<lens>`
findings (`--prior-findings`) and re-verifies each against the **current** diff
with the same **biased-to-keep** refute pass: a prior finding survives unless it
is confidently *resolved*, so it can't vanish just because a later fresh pass
missed it. Unresolved priors merge (deduped) into the round's findings.
Persistence rides on the check-run output — **no new PR comment, no new
permission** (the review job keeps `issues: read`).

## Design notes
- Reuses `dedupeFindings`/`coerceFindings`/`verifyFinding`/`applyVerifications`
  unchanged; `review-panel.mjs` still never touches GitHub (the workflow feeds it
  the prior findings as a file).
- New exported helpers `unionSamples` / `parsePriorFindings`, unit-tested.

## Validation
`node --check`; `lenses.json` + workflow YAML parse; **16/16** agent unit tests
(3 new: `unionSamples`, `parsePriorFindings`, and a composition test guarding the
#521 miss — an unresolved prior finding a fresh pass "missed" still blocks);
dead-code + doc-staleness clean. The SDK sampling/re-check paths run only in real
CI; the pure merge/parse logic is unit-tested.

## Caveat (documented in `harness-engineering.md`)
Both measures **lower** false-negative odds; neither makes the panel safe to
self-promote. The required human review remains the backstop — #521 is the proof.

CODEOWNERS-protected (`scripts/agent/`, `.github/workflows/agent-*.yml`,
harness-engineering.md) → requests @hackerwins' review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Review checks now run each analysis lens multiple times (configurable via lens settings) and merge results for higher reliability.
  * Prior blocking findings are carried forward into the next run and re-verified against the latest changes, so missed issues don’t disappear.
  * Consolidated results are deduplicated and prioritized by severity, with machine-readable findings output for review panel processing.
* **Documentation**
  * Updated the design document to describe repeated sampling and cross-run verification (including false-negative hardening).
* **Tests**
  * Added coverage for result merging and prior-finding parsing/merging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->