### PR TITLE
Fix loops: page a human on a no-commit round; bump fixer turns 40->80

### DIFF
--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -156,6 +156,14 @@ jobs:
             echo "HARNESS_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # Record the branch tip before the fixer runs, so the step after it can
+      # detect a fix round that produced NO commit (see "Page if the fix
+      # produced no commit").
+      - name: Record branch head before fix
+        id: before-fix
+        if: steps.guard.outputs.proceed == 'true'
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code
         if: steps.guard.outputs.proceed == 'true'
         # Pinned to the v1 release commit (immutable) for supply-chain safety.
@@ -183,9 +191,46 @@ jobs:
             trailer "Assisted-by: Claude Code (autonomous)". Then reply in the
             PR's verification thread noting what you fixed. Do not merge.
           claude_args: >-
-            --max-turns 40
+            --max-turns 80
             --model claude-opus-4-8
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"
+
+      # Diagnostics: keep the fixer's transcript (turns, tool calls, permission
+      # denials, token/cost) so a round that didn't converge is debuggable.
+      # always() so it's captured even when the fixer errored.
+      - name: Upload fix execution log
+        if: always() && steps.guard.outputs.proceed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-ci-fix-execution-output
+          path: ${{ runner.temp }}/claude-execution-output.json
+          if-no-files-found: warn
+
+      # GAP FIX: a CI-fix round that pushes NO commit dead-ends the loop silently
+      # — no new commit → no new CI → no next round, and the attempts guard's
+      # failed-CI counter never advances, so it never trips. Detect "fixer ran
+      # but the branch head didn't advance" and page a human via the same
+      # agent-paged latch. always(): this loop has no stalled net, so a hard
+      # fixer error must page here too. We do NOT blind-retry — the fixer just
+      # failed to converge, so re-running the same config would burn budget.
+      - name: Page if the fix produced no commit
+        if: always() && steps.guard.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.guard.outputs.pr }}
+          BEFORE: ${{ steps.before-fix.outputs.sha }}
+        run: |
+          AFTER="$(git rev-parse HEAD)"
+          if [ "$AFTER" = "$BEFORE" ]; then
+            echo "CI-fix ran but pushed no commit (HEAD still $BEFORE) — paging a human." >&2
+            printf '%s\n' \
+              '<!-- agent-paged -->' \
+              '🛑 The CI-fix agent ran but produced **no commit**, so CI stays red and the loop cannot re-trigger itself (no new commit → no new CI). It likely did not converge within its turn budget or hit tool-permission denials (see the `claude-ci-fix-execution-output` artifact). **A human should take over** on this PR.' \
+              | gh pr comment "$PR" --body-file -
+            gh pr edit "$PR" --add-label "agent:needs-human-review" || true
+          else
+            echo "CI-fix pushed a new commit ($AFTER) — CI will re-run."
+          fi
 
       # Record this session's effort into the PR metrics ledger (fail-safe:
       # continue-on-error + the script exits 0 on any error, so metrics never

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -156,13 +156,15 @@ jobs:
             echo "HARNESS_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      # Record the branch tip before the fixer runs, so the step after it can
-      # detect a fix round that produced NO commit (see "Page if the fix
-      # produced no commit").
+      # Record the REMOTE branch tip before the fixer runs (ls-remote, not local
+      # HEAD): the loop only re-triggers on a PUSH, so a fixer that commits
+      # locally but never pushes must still count as no progress.
       - name: Record branch head before fix
         id: before-fix
         if: steps.guard.outputs.proceed == 'true'
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: echo "sha=$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code
         if: steps.guard.outputs.proceed == 'true'
@@ -219,17 +221,21 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ steps.guard.outputs.pr }}
           BEFORE: ${{ steps.before-fix.outputs.sha }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          AFTER="$(git rev-parse HEAD)"
+          AFTER="$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)"
           if [ "$AFTER" = "$BEFORE" ]; then
-            echo "CI-fix ran but pushed no commit (HEAD still $BEFORE) — paging a human." >&2
+            echo "No new commit reached the branch — paging a human." >&2
+            # This step runs under always(), so it also covers a hard fixer error
+            # or an earlier failed step — keep the cause generic, don't assert
+            # turn-budget/denials (which would mislabel those cases).
             printf '%s\n' \
               '<!-- agent-paged -->' \
-              '🛑 The CI-fix agent ran but produced **no commit**, so CI stays red and the loop cannot re-trigger itself (no new commit → no new CI). It likely did not converge within its turn budget or hit tool-permission denials (see the `claude-ci-fix-execution-output` artifact). **A human should take over** on this PR.' \
+              '🛑 The CI-fix round produced **no new commit** on the branch, so CI stays red and the loop cannot re-trigger itself (no push → no new CI). This can mean the fixer did not converge within its turn budget, hit tool-permission denials, could not push, or an earlier step errored — see the run log and the `claude-ci-fix-execution-output` artifact. **A human should take over** on this PR.' \
               | gh pr comment "$PR" --body-file -
             gh pr edit "$PR" --add-label "agent:needs-human-review" || true
           else
-            echo "CI-fix pushed a new commit ($AFTER) — CI will re-run."
+            echo "A new commit reached the branch ($AFTER) — CI will re-run."
           fi
 
       # Record this session's effort into the PR metrics ledger (fail-safe:

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -224,18 +224,24 @@ jobs:
           BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           AFTER="$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)"
-          if [ "$AFTER" = "$BEFORE" ]; then
-            echo "No new commit reached the branch — paging a human." >&2
+          # Only trust a "CI will re-run" conclusion when BOTH remote heads
+          # resolved AND they differ. `git ls-remote | cut` masks a failed
+          # lookup (network error, missing branch) as an empty string and the
+          # before-fix step may have been skipped, so an empty BEFORE or AFTER
+          # means we could NOT establish that a new commit landed — fail safe
+          # and page rather than assume progress and let the loop dead-end.
+          if [ -n "$BEFORE" ] && [ -n "$AFTER" ] && [ "$AFTER" != "$BEFORE" ]; then
+            echo "A new commit reached the branch ($AFTER) — CI will re-run."
+          else
+            echo "Branch head did not advance (before='$BEFORE' after='$AFTER') — paging a human." >&2
             # This step runs under always(), so it also covers a hard fixer error
             # or an earlier failed step — keep the cause generic, don't assert
             # turn-budget/denials (which would mislabel those cases).
             printf '%s\n' \
               '<!-- agent-paged -->' \
-              '🛑 The CI-fix round produced **no new commit** on the branch, so CI stays red and the loop cannot re-trigger itself (no push → no new CI). This can mean the fixer did not converge within its turn budget, hit tool-permission denials, could not push, or an earlier step errored — see the run log and the `claude-ci-fix-execution-output` artifact. **A human should take over** on this PR.' \
+              '🛑 The CI-fix round did not advance the branch head, so CI stays red and the loop cannot re-trigger itself (no new push → no new CI). This can mean the fixer produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, the branch head could not be determined, or an earlier step errored — see the run log and the `claude-ci-fix-execution-output` artifact. **A human should take over** on this PR.' \
               | gh pr comment "$PR" --body-file -
             gh pr edit "$PR" --add-label "agent:needs-human-review" || true
-          else
-            echo "A new commit reached the branch ($AFTER) — CI will re-run."
           fi
 
       # Record this session's effort into the PR metrics ledger (fail-safe:

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -562,15 +562,21 @@ jobs:
           BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           AFTER="$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)"
-          if [ "$AFTER" = "$BEFORE" ]; then
-            echo "Fixer pushed no new commit to the remote branch — paging a human." >&2
+          # Only trust a "re-triggered" conclusion when BOTH remote heads
+          # resolved AND they differ. `git ls-remote | cut` masks a failed
+          # lookup (network error, missing branch) as an empty string and the
+          # before-fix step may have been skipped, so an empty BEFORE or AFTER
+          # means we could NOT establish that a new commit landed — fail safe
+          # and page rather than assume the fix pushed.
+          if [ -n "$BEFORE" ] && [ -n "$AFTER" ] && [ "$AFTER" != "$BEFORE" ]; then
+            echo "Fixer pushed a new commit ($AFTER) — CI + a fresh panel will re-trigger."
+          else
+            echo "Branch head did not advance (before='$BEFORE' after='$AFTER') — paging a human." >&2
             printf '%s\n' \
               '<!-- agent-review-paged -->' \
-              '🛑 The fix agent produced **no new commit** on the branch, so the requested changes were not applied and the loop cannot re-trigger itself (no push → no new CI → no new panel). Likely causes: it did not converge within its turn budget, hit tool-permission denials, or could not push — see the `claude-fix-execution-output` artifact and the run log. **A human should take over** on this PR.' \
+              '🛑 The fix agent did not advance the branch head, so the requested changes were not applied and the loop cannot re-trigger itself (no push → no new CI → no new panel). Likely causes: it produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, or the branch head could not be determined — see the `claude-fix-execution-output` artifact and the run log. **A human should take over** on this PR.' \
               | gh pr comment "$PR" --body-file -
             gh pr edit "$PR" --add-label "agent:needs-human-review" || true
-          else
-            echo "Fixer pushed a new commit ($AFTER) — CI + a fresh panel will re-trigger."
           fi
 
       # Record this review-fix session's effort into the PR metrics ledger

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -196,6 +196,45 @@ jobs:
         if: steps.pr.outputs.number != ''
         run: rm -rf "$GITHUB_WORKSPACE/.claude" "$GITHUB_WORKSPACE/.mcp.json"
 
+      # Part 2: carry the PREVIOUS round's blocking findings into this run so the
+      # panel can re-check they were actually resolved (not just missed). Each
+      # lens's findings were persisted in its check run's output.text; take the
+      # latest agent-review-<lens> check per lens across the PR's commits (ours
+      # only). This runs BEFORE the panel posts its checks, so all existing ones
+      # are prior rounds. Never fails the job (best-effort; empty on round 1).
+      - name: Read prior findings
+        if: steps.pr.outputs.number != ''
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const pr = Number('${{ steps.pr.outputs.number }}');
+            const manifest = JSON.parse(fs.readFileSync('.trusted/scripts/agent/lenses/lenses.json', 'utf8'));
+            const wantNames = new Set(manifest.map((l) => `agent-review-${l.id}`));
+            const commits = await github.paginate(github.rest.pulls.listCommits, { owner, repo, pull_number: pr, per_page: 100 });
+            const latest = {}; // check name -> { id, t }
+            for (const c of commits) {
+              const runs = await github.paginate(github.rest.checks.listForRef, { owner, repo, ref: c.sha, per_page: 100 });
+              for (const r of runs) {
+                if (!wantNames.has(r.name) || !r.app || r.app.slug !== 'github-actions') continue;
+                const t = new Date(r.started_at || 0).getTime();
+                if (!latest[r.name] || t > latest[r.name].t) latest[r.name] = { id: r.id, t };
+              }
+            }
+            const prior = [];
+            for (const [name, { id }] of Object.entries(latest)) {
+              const lens = name.replace(/^agent-review-/, '');
+              let text = '';
+              try { const { data } = await github.rest.checks.get({ owner, repo, check_run_id: id }); text = (data.output && data.output.text) || ''; } catch {}
+              let findings = [];
+              try { findings = JSON.parse(text); } catch {}
+              if (Array.isArray(findings)) for (const f of findings) if (f && typeof f === 'object') prior.push({ ...f, lens });
+            }
+            fs.writeFileSync('/tmp/prior-findings.json', JSON.stringify(prior));
+            core.info(`prior findings carried into re-check: ${prior.length}`);
+
       - name: Run review panel
         if: steps.pr.outputs.number != ''
         # continue-on-error: a crash must not skip the needs-gated promote/fix
@@ -214,6 +253,7 @@ jobs:
           --diff-file /tmp/pr.diff
           --issue-file /tmp/issue.txt
           --changed-files /tmp/changed.txt
+          --prior-findings /tmp/prior-findings.json
           --repo "$GITHUB_WORKSPACE"
           --lenses-dir .trusted/scripts/agent/lenses
           --out .agent-review
@@ -250,10 +290,30 @@ jobs:
               }
               let summary = '_No summary produced (failing closed)._';
               try { summary = fs.readFileSync(`.agent-review/${lens.id}/summary.md`, 'utf8'); } catch {}
+              // Persist this lens's BLOCKING findings as machine-readable JSON in
+              // output.text so the NEXT round's "Read prior findings" step can
+              // re-check them (Part 2). output.summary stays the human-readable body.
+              let findingsText = '[]';
+              try {
+                const v = JSON.parse(fs.readFileSync(`.agent-review/${lens.id}/verdict.json`, 'utf8'));
+                const norm = (s) => { const x = String(s ?? '').toLowerCase().trim(); return ['critical', 'major', 'minor', 'nit'].includes(x) ? x : 'major'; };
+                const trim = (s, n) => (typeof s === 'string' && s.length > n ? s.slice(0, n) : s);
+                let blockers = (Array.isArray(v.findings) ? v.findings : [])
+                  .filter((f) => norm(f.severity) === 'critical' || norm(f.severity) === 'major')
+                  .map((f) => ({ severity: norm(f.severity), file: trim(f.file, 300), summary: trim(f.summary, 2000), evidence: trim(f.evidence, 2000) }));
+                // Keep output.text VALID JSON within the 60k limit: NEVER slice the
+                // serialized string (that yields JSON the next round can't parse).
+                // Fields are trimmed above; drop trailing findings until it fits.
+                findingsText = JSON.stringify(blockers);
+                while (findingsText.length > 60000 && blockers.length > 0) {
+                  blockers = blockers.slice(0, -1);
+                  findingsText = JSON.stringify(blockers);
+                }
+              } catch {}
               await github.rest.checks.create({
                 owner: context.repo.owner, repo: context.repo.repo,
                 name: `agent-review-${lens.id}`, head_sha: sha, status: 'completed', conclusion,
-                output: { title: `${lens.id}: ${conclusion}`, summary: summary.slice(0, 60000) },
+                output: { title: `${lens.id}: ${conclusion}`, summary: summary.slice(0, 60000), text: findingsText },
               });
             }
             core.setOutput('blocked', String(blocked));

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -486,13 +486,17 @@ jobs:
         if: steps.guard.outputs.proceed == 'true'
         run: pnpm install --frozen-lockfile
 
-      # Record the branch tip before the fixer runs, so the step after it can
-      # detect a fix round that produced NO commit (see "Page if the fix
-      # produced no commit").
+      # Record the REMOTE branch tip before the fixer runs, so the step after it
+      # can detect a fix round that pushed NO new commit. We read the remote
+      # (ls-remote), not local HEAD: the loop only re-triggers on a PUSH, so a
+      # fixer that commits locally but never pushes (turn budget exhausted after
+      # commit, or a push denial) must still count as no progress.
       - name: Record branch head before fix
         id: before-fix
         if: steps.guard.outputs.proceed == 'true'
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: echo "sha=$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Address panel findings
         if: steps.guard.outputs.proceed == 'true'
@@ -555,13 +559,14 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ needs.review-panel.outputs.pr }}
           BEFORE: ${{ steps.before-fix.outputs.sha }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          AFTER="$(git rev-parse HEAD)"
+          AFTER="$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)"
           if [ "$AFTER" = "$BEFORE" ]; then
-            echo "Fixer ran but pushed no commit (HEAD still $BEFORE) — paging a human." >&2
+            echo "Fixer pushed no new commit to the remote branch — paging a human." >&2
             printf '%s\n' \
               '<!-- agent-review-paged -->' \
-              '🛑 The fix agent ran but produced **no commit**, so the requested changes were not applied — and the loop cannot re-trigger itself (no new commit → no new CI). It likely did not converge within its turn budget or hit tool-permission denials (see the `claude-fix-execution-output` artifact). **A human should take over** on this PR.' \
+              '🛑 The fix agent produced **no new commit** on the branch, so the requested changes were not applied and the loop cannot re-trigger itself (no push → no new CI → no new panel). Likely causes: it did not converge within its turn budget, hit tool-permission denials, or could not push — see the `claude-fix-execution-output` artifact and the run log. **A human should take over** on this PR.' \
               | gh pr comment "$PR" --body-file -
             gh pr edit "$PR" --add-label "agent:needs-human-review" || true
           else

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -486,6 +486,14 @@ jobs:
         if: steps.guard.outputs.proceed == 'true'
         run: pnpm install --frozen-lockfile
 
+      # Record the branch tip before the fixer runs, so the step after it can
+      # detect a fix round that produced NO commit (see "Page if the fix
+      # produced no commit").
+      - name: Record branch head before fix
+        id: before-fix
+        if: steps.guard.outputs.proceed == 'true'
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Address panel findings
         if: steps.guard.outputs.proceed == 'true'
         # Pinned to the v1 release commit (immutable). github_token is the App
@@ -516,9 +524,49 @@ jobs:
             end with the trailer "Assisted-by: Claude Code (autonomous)". Do not
             merge. Pushing re-runs CI and a fresh review panel.
           claude_args: >-
-            --max-turns 40
+            --max-turns 80
             --model claude-opus-4-8
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"
+
+      # Diagnostics: keep the fixer's transcript (turns, tool calls, permission
+      # denials, token/cost) so a round that didn't converge is debuggable —
+      # e.g. why it hit the turn budget or what a denial blocked. always() so
+      # it's captured even when the fixer errored.
+      - name: Upload fix execution log
+        if: always() && steps.guard.outputs.proceed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-fix-execution-output
+          path: ${{ runner.temp }}/claude-execution-output.json
+          if-no-files-found: warn
+
+      # GAP FIX: a fix round that pushes NO commit dead-ends the loop silently —
+      # no new commit → no new CI → no new panel → no next round — yet the fix
+      # job still reports success, so nothing pages. Detect "fixer ran but the
+      # branch head didn't advance" and page a human via the same latch the guard
+      # uses. No `always()`: this runs only when the fixer step SUCCEEDED but
+      # committed nothing; if the fixer hard-errored, the job fails and the
+      # stalled net pages instead (no double-page). We deliberately do NOT
+      # blind-retry — the fixer just failed to converge (turn budget / denials),
+      # so re-running the same config would burn budget and likely fail again.
+      - name: Page if the fix produced no commit
+        if: steps.guard.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+          BEFORE: ${{ steps.before-fix.outputs.sha }}
+        run: |
+          AFTER="$(git rev-parse HEAD)"
+          if [ "$AFTER" = "$BEFORE" ]; then
+            echo "Fixer ran but pushed no commit (HEAD still $BEFORE) — paging a human." >&2
+            printf '%s\n' \
+              '<!-- agent-review-paged -->' \
+              '🛑 The fix agent ran but produced **no commit**, so the requested changes were not applied — and the loop cannot re-trigger itself (no new commit → no new CI). It likely did not converge within its turn budget or hit tool-permission denials (see the `claude-fix-execution-output` artifact). **A human should take over** on this PR.' \
+              | gh pr comment "$PR" --body-file -
+            gh pr edit "$PR" --add-label "agent:needs-human-review" || true
+          else
+            echo "Fixer pushed a new commit ($AFTER) — CI + a fresh panel will re-trigger."
+          fi
 
       # Record this review-fix session's effort into the PR metrics ledger
       # (fail-safe: continue-on-error + the script exits 0 on any error).

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -386,6 +386,28 @@ Components:
   and an LLM reviewer can still be swayed by prompt injection — the human merge
   gate is the backstop. Same model across lenses for now; a per-lens `model`
   field makes diversity a one-field change.
+  - **False-negative hardening (the verifier only fights false *positives* — it
+    drops findings, it can't add a missed one).** Two measures raise recall so a
+    real issue isn't silently missed, motivated by a live case where the
+    correctness lens flagged a regression, then reviewed the *same unchanged code*
+    clean on a re-run:
+    1. **Sampling + union.** Each lens runs `samples` times (per-lens field in
+       `scripts/agent/lenses/lenses.json`, default 2) and the findings are UNIONed — any sample's
+       finding enters the gate. The union goes through the same conservative
+       `coerceFindings`/`dedupeFindings` (identical file+summary collapse to the
+       highest severity; distinct bugs never merge), and the verifier refute pass
+       is the precision counterweight. No LLM/semantic merge — that could
+       over-merge two distinct bugs into one, reintroducing the miss.
+    2. **Cross-round re-check.** Each round persists its blocking findings in the
+       per-lens check run's `output.text`; the next round reads the latest prior
+       `agent-review-<lens>` findings (`--prior-findings`) and re-verifies each
+       against the *current* diff with the same biased-to-keep refute pass. A
+       prior finding survives unless it is confidently *resolved* — so it can't
+       vanish just because a later fresh pass missed it (only because it was
+       actually fixed). Unresolved priors merge (deduped) into the round's findings.
+
+    Both lower false-negative odds; neither makes the panel safe to self-promote —
+    the human review gate stays the backstop.
 - **Ready gate** — `scripts/agent/mark-ready.mjs`, invoked by the review-panel
   workflow on all-pass: promotes draft → ready only when the **"CI" workflow run**
   for the head SHA concluded `success` (read via the Actions API, not the

--- a/scripts/agent/lenses/lenses.json
+++ b/scripts/agent/lenses/lenses.json
@@ -5,7 +5,8 @@
     "gating": "blocking",
     "needsIssueSpec": false,
     "appliesWhen": ["**"],
-    "model": "claude-opus-4-8"
+    "model": "claude-opus-4-8",
+    "samples": 2
   },
   {
     "id": "security",
@@ -13,7 +14,8 @@
     "gating": "blocking",
     "needsIssueSpec": false,
     "appliesWhen": ["**"],
-    "model": "claude-opus-4-8"
+    "model": "claude-opus-4-8",
+    "samples": 2
   },
   {
     "id": "design-fit",
@@ -21,7 +23,8 @@
     "gating": "blocking",
     "needsIssueSpec": true,
     "appliesWhen": ["**"],
-    "model": "claude-opus-4-8"
+    "model": "claude-opus-4-8",
+    "samples": 2
   },
   {
     "id": "test-adequacy",
@@ -29,6 +32,7 @@
     "gating": "blocking",
     "needsIssueSpec": false,
     "appliesWhen": ["**"],
-    "model": "claude-opus-4-8"
+    "model": "claude-opus-4-8",
+    "samples": 2
   }
 ]

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -147,6 +147,44 @@ export function applyVerifications(findings, verdictsByIndex) {
   });
 }
 
+/**
+ * Union the findings from N independent samples of one lens (Part 1: fight
+ * false negatives from single-sample non-determinism). We take the UNION, not a
+ * vote — a finding raised by any sample enters the gate (the verifier refute
+ * pass is the precision counterweight). coerceFindings keeps malformed entries;
+ * dedupeFindings collapses identical file+summary and keeps the highest severity,
+ * so it never merges two distinct bugs. `results` are raw lens outputs (or nulls
+ * from failed samples).
+ */
+export function unionSamples(results) {
+  // Coerce EACH successful sample's findings individually — do NOT pre-filter to
+  // array payloads. coerceFindings turns a malformed/non-array payload into a
+  // synthetic blocking finding, so a malformed successful sample fails toward
+  // blocking instead of silently contributing nothing (which could yield a clean
+  // verdict). Nullish/error sentinels are dropped (main only passes successful
+  // samples, and throws before calling this if ALL failed).
+  const list = (Array.isArray(results) ? results : []).filter((r) => r && !r.__error);
+  const all = list.flatMap((r) => coerceFindings(r.findings));
+  return dedupeFindings(all);
+}
+
+/**
+ * Parse the prior-round findings file (Part 2: cross-round re-check). Tolerant —
+ * bad/empty/missing input yields [] (no prior findings to re-check, safe). Keeps
+ * only object entries; each is expected to carry {lens, severity, file, summary,
+ * evidence} (the workflow tags `lens` when reading prior check runs).
+ */
+export function parsePriorFindings(text) {
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+  return data.filter((f) => f && typeof f === "object");
+}
+
 // --- SDK wrapper (lazy import) ----------------------------------------------
 
 async function askStructured({ systemPrompt, prompt, model, repo, schema }) {
@@ -274,6 +312,12 @@ async function main() {
   const changedFiles = args["changed-files"] && existsSync(args["changed-files"])
     ? readFileSync(args["changed-files"], "utf8").split("\n").map((s) => s.trim()).filter(Boolean)
     : [];
+  // Part 2: blocking findings from the PREVIOUS review round (tagged with their
+  // lens id by the workflow). Absent/empty on the first round. Re-checked per
+  // lens below so a still-present issue can't vanish if this round's pass misses it.
+  const priorFindings = args["prior-findings"] && existsSync(args["prior-findings"])
+    ? parsePriorFindings(readFileSync(args["prior-findings"], "utf8"))
+    : [];
 
   const allLenses = loadLenses(lensesDir);
   // panel[] is the AUTHORITATIVE lens list the workflow + mark-ready consume —
@@ -295,13 +339,24 @@ async function main() {
 
     let findings, summary;
     try {
-      const res = await runLens(lens, { rubric: lens.rubric, diff, issue, repo });
-      // The SDK schema is REQUESTED of the model but the harness must not trust
-      // it blindly. COERCE (never drop) so a malformed finding fails toward
-      // blocking instead of vanishing off the gate path, then dedupe so
-      // duplicates don't get double-verified / double-counted.
-      findings = dedupeFindings(coerceFindings(res.findings));
-      summary = typeof res.summary === "string" ? res.summary : "";
+      // Part 1: sample the lens N times (default 2) and UNION the findings, to
+      // fight single-sample non-determinism (the #521 false negative). Each
+      // sample is independent and individually caught: a sample that throws
+      // contributes nothing, but if ALL samples fail we fall through to the
+      // catch below (fail-closed, same as the old single-run crash path).
+      const samples = Math.max(1, Number(lens.samples) || 2);
+      const results = await Promise.all(
+        Array.from({ length: samples }, async () => {
+          try { return await runLens(lens, { rubric: lens.rubric, diff, issue, repo }); }
+          catch (e) { return { __error: e.message }; }
+        }),
+      );
+      const ok = results.filter((r) => r && !r.__error);
+      if (ok.length === 0) throw new Error((results[0] && results[0].__error) || "all lens samples failed");
+      // unionSamples coerces (never drops) + dedupes (collapses identical
+      // file+summary, keeps highest severity, never merges distinct bugs).
+      findings = unionSamples(ok);
+      summary = ok.map((r) => (typeof r.summary === "string" ? r.summary : "")).filter(Boolean).join("\n\n");
     } catch (err) {
       const failFindings = [{ severity: "major", summary: `Reviewer did not produce a valid verdict: ${err.message}` }];
       writeVerdict(lensOut, lens, failFindings, "(no valid verdict — failing closed)", { valid: false });
@@ -318,8 +373,25 @@ async function main() {
     }));
     const kept = applyVerifications(findings, verdicts);
 
+    // Part 2: re-check this lens's blocking findings from the PREVIOUS round
+    // against the CURRENT diff, biased-to-keep. verifyFinding asks "is this
+    // genuinely present in the diff?" — so a fixed finding is refuted (dropped)
+    // and a still-present one is confirmed (kept). Because applyVerifications
+    // drops only on high-confidence `refuted`, a prior finding survives unless
+    // it's confidently resolved — even if this round's fresh pass missed it.
+    const priorForLens = priorFindings.filter((p) => p.lens === lens.id);
+    const priorVerdicts = await Promise.all(priorForLens.map(async (f) => {
+      if (!BLOCKING.has(normalizeSeverity(f.severity))) return null;
+      try { return await verifyFinding(f, { rubric: lens.rubric, diff, repo, model: lens.model }); }
+      catch { return null; } // error → keep (fail toward blocking)
+    }));
+    const priorKept = applyVerifications(priorForLens, priorVerdicts);
+    // Merge fresh + still-open prior findings; dedupe collapses a prior finding
+    // the fresh pass also re-found (and never merges two distinct bugs).
+    const merged = dedupeFindings([...kept, ...priorKept]);
+
     // Advisory lenses report findings but never block.
-    const { conclusion } = writeVerdict(lensOut, lens, kept, summary, {
+    const { conclusion } = writeVerdict(lensOut, lens, merged, summary, {
       valid: true,
       conclusion: blocking ? undefined : "success",
       advisory: !blocking,

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -6,6 +6,8 @@ import {
   dedupeFindings,
   applyVerifications,
   coerceFindings,
+  unionSamples,
+  parsePriorFindings,
 } from "./review-panel.mjs";
 import { classify } from "./severity.mjs";
 
@@ -69,6 +71,56 @@ test("coerceFindings + dedupeFindings (main pipeline): a critical is never maske
     ]).conclusion,
     "failure",
   );
+});
+
+test("unionSamples: union across N samples; recall gained, dups collapse fail-toward-blocking", () => {
+  // Part 1: sample A finds X; sample B finds X (same) + Y (new) → union {X, Y}.
+  const a = { findings: [{ severity: "major", file: "a.ts", summary: "X" }] };
+  const b = { findings: [{ severity: "major", file: "a.ts", summary: "X" }, { severity: "critical", file: "b.ts", summary: "Y" }] };
+  const u = unionSamples([a, b]);
+  assert.equal(u.length, 2); // X deduped, Y added (recall from sampling)
+  assert.ok(u.some((f) => f.summary === "Y" && f.severity === "critical"));
+  // same finding at two severities across samples → highest wins (fail toward blocking)
+  const s1 = { findings: [{ severity: "nit", file: "a.ts", summary: "Z" }] };
+  const s2 = { findings: [{ severity: "critical", file: "a.ts", summary: "Z" }] };
+  const uz = unionSamples([s1, s2]);
+  assert.equal(uz.length, 1);
+  assert.equal(uz[0].severity, "critical");
+  // failed samples (null / {__error}) contribute nothing; a well-formed one still counts
+  assert.equal(unionSamples([null, { __error: "boom" }, a]).length, 1);
+  assert.equal(unionSamples([]).length, 0);
+  // a MALFORMED successful sample (findings not an array, or missing) must fail
+  // toward blocking via coerceFindings — never be dropped into a clean verdict
+  assert.equal(classify(unionSamples([{ summary: "x", findings: "oops" }])).conclusion, "failure");
+  assert.equal(classify(unionSamples([{ summary: "x" }])).conclusion, "failure");
+  // a legitimately empty sample (findings: []) contributes nothing (not blocking)
+  assert.equal(unionSamples([{ findings: [] }]).length, 0);
+});
+
+test("parsePriorFindings: tolerant — valid array round-trips, junk → []", () => {
+  const recs = [{ lens: "correctness", severity: "major", file: "a.ts", summary: "prior" }];
+  assert.deepEqual(parsePriorFindings(JSON.stringify(recs)), recs);
+  assert.deepEqual(parsePriorFindings(""), []);
+  assert.deepEqual(parsePriorFindings("not json"), []);
+  assert.deepEqual(parsePriorFindings('{"not":"an array"}'), []);
+  // non-object entries are dropped
+  assert.deepEqual(parsePriorFindings('[null, 3, {"severity":"major","summary":"ok"}]'), [{ severity: "major", summary: "ok" }]);
+});
+
+// Part 2: a prior blocking finding that this round's fresh pass MISSED must
+// still block after being re-checked (verifier didn't refute it) and merged.
+// This is the #521 false-negative, guarded at the composition level.
+test("cross-round merge: an unresolved prior finding the fresh pass missed still blocks", () => {
+  const freshKept = []; // this round's lens returned nothing (missed it)
+  const priorForLens = [{ lens: "correctness", severity: "major", file: "s.ts", summary: "MIN/MAX all-blank returns #NUM!" }];
+  // re-check couldn't refute it (null verdict = kept, biased-to-block)
+  const priorKept = applyVerifications(priorForLens, [null]);
+  const merged = dedupeFindings([...freshKept, ...priorKept]);
+  assert.equal(merged.length, 1);
+  assert.equal(classify(merged).conclusion, "failure");
+  // but if the re-check confidently refutes it (genuinely resolved) → dropped
+  const resolved = applyVerifications(priorForLens, [{ verdict: "refuted", confidence: "high" }]);
+  assert.equal(classify(dedupeFindings([...freshKept, ...resolved])).conclusion, "success");
 });
 
 test("applyVerifications: drops ONLY on high-confidence refuted; keeps on any doubt", () => {


### PR DESCRIPTION
## Summary

Stop the autonomous fix loops from **silently dead-ending** when a fix round
produces no commit, and give the fixer more room to converge.

Found on #521: the review-fix loop ran, the fixer was fed the correctness
finding, but it burned its 40-turn budget (with 3 permission denials) and pushed
**no commit**. No commit → no new CI → no new panel → no next round — and the
fix job still reported `success`, so nothing paged. The PR sat blocked, unfixed,
and un-escalated.

## Changes (both fix loops: `agent-review-panel.yml` + `agent-iterate-ci.yml`)

1. **Page a human on a no-commit round.** Record the branch head before the
   fixer; after it, if the head didn't advance, post the loop's paged latch +
   `agent:needs-human-review` label. Deliberately **not** a blind retry — the
   fixer just failed to converge (turn budget / denials), so re-running the same
   config would burn budget and likely fail again; a human should take over.
2. **Bump `--max-turns` 40 → 80.** A fix that must keep `verify:fast` (build +
   tests) green needs more room than 40 — #521's fixer hit exactly 40.
3. **Upload the fixer's execution log** as an artifact so turn usage and
   permission denials are debuggable (they weren't visible in the plain job
   log on #521).

## One deliberate difference between the two loops
- **Review-fix** page step omits `always()`: a *hard* fixer error falls through
  to that workflow's existing `stalled` net (avoids a double-page).
- **CI-fix** page step uses `always()`: `agent-iterate-ci.yml` has **no** stalled
  net, so a hard fixer error must page there directly.

## Validation
Both workflow YAMLs parse; `verify:fast` pre-commit hook green; the SDK/agent
paths run only in real CI. The end-to-end proof is a blocked PR whose fixer
commits nothing → it should now page instead of stalling, with the transcript
artifact attached.

CODEOWNERS-protected (`.github/workflows/agent-*.yml`) → requests @hackerwins'
review.

## Note
Touches `agent-review-panel.yml`, which the `agent/fix-promote-token` branch also
edits — whichever merges second will need a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated fix workflows to detect stalled runs by checking whether the branch head advances after the fixer.
  - Added automatic “needs human review” paging when no new commit is produced, preventing silent dead ends.
  - Enhanced review-panel convergence by re-checking and merging prior blocking findings across rounds, reducing false negatives.

- **Chores**
  - Improved CI and review-panel observability with always-uploaded fixer transcripts and more machine-readable per-lens outputs.
  - Increased fixer capacity and expanded lens sampling to reduce single-run non-determinism.
  - Updated documentation to reflect the review verifier’s false-negative hardening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->