### PR TITLE
Add maintainer-merge skill for squash-merging PRs

### DIFF
--- a/.claude/skills/maintainer-merge/SKILL.md
+++ b/.claude/skills/maintainer-merge/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: maintainer-merge
+description: Use when a maintainer needs to squash-merge a wafflebase PR (often a fork / agent-pipeline PR) that has merge conflicts, requires folding the pipeline's combined effort/cost into the squash commit message, is BLOCKED by branch protection, or fails to merge with "refusing to allow an OAuth App to create or update workflow ... without workflow scope".
+---
+
+# Maintainer Merge
+
+## Overview
+
+Squash-merge a PR the way a wafflebase maintainer does: resolve conflicts on
+the (possibly fork) branch, wait for the *real* required checks, fold every
+commit into one honest squash message — with the pipeline's **combined
+effort/cost** appended when the PR carries it — and merge, bypassing branch
+protection only as the repo owner.
+
+**Core principle: never fabricate. Effort/cost is aggregated data that already
+exists in the PR's comments — you copy it, you don't invent it. If it isn't
+there, omit it.**
+
+## When to Use
+
+- Merging an agent-pipeline PR (`agent/*` branch), especially from a **fork**.
+- PR is `CONFLICTING` / `DIRTY` and needs conflict resolution before merge.
+- You want the squash commit to carry the **combined effort/cost** of all the
+  agent sessions (turns / tokens / time), not just the diff.
+- Merge is `BLOCKED` (branch protection) or fails with the `workflow` scope error.
+
+Not for: your own working-branch review (`/code-review`), or trivial no-conflict
+PRs you can merge from the GitHub UI.
+
+## Prerequisite: the `workflow` scope pitfall
+
+If the PR touches `.github/workflows/*`, `gh pr merge` fails with:
+
+```
+refusing to allow an OAuth App to create or update workflow `.github/workflows/...`
+without `workflow` scope
+```
+
+`gh`'s default token lacks it. Check and fix **before** you start:
+
+```bash
+gh auth status | grep -i scopes           # want: ... 'workflow' ...
+gh auth refresh -h github.com -s workflow  # interactive; run in a real terminal
+```
+
+The refresh is interactive (browser/device code) — it cannot run inside a
+non-interactive tool call. Have the human run it, then continue.
+
+## Procedure
+
+1. **Inspect.** Capture the facts that decide the path:
+   ```bash
+   gh pr view <N> --json mergeable,mergeStateStatus,isCrossRepository,files,\
+   headRefName,headRepositoryOwner,baseRefName
+   gh api repos/{owner}/{repo}/pulls/<N> -q '.maintainer_can_modify, .head.repo.full_name, .head.ref'
+   ```
+   Fork PR? You can push to its branch only if `maintainer_can_modify == true`.
+
+2. **Resolve conflicts** on the PR branch. `gh pr checkout <N>`, then merge with
+   an **explicit short subject** — the auto-generated merge subject is ~71 chars
+   and the repo's commit-msg hook rejects >70, silently leaving the merge
+   *uncommitted* (see pitfalls):
+   ```bash
+   git merge origin/main -m "Merge main into <branch> (resolve conflict)"
+   ```
+   A merge commit is fine — squash flattens it, and it preserves the
+   contributor's original commits (unlike a rebase force-push). Then **verify
+   the resolution** — don't just delete markers:
+   - `grep -rnE '^(<<<<<<<|=======|>>>>>>>)'` returns nothing.
+   - Union-merge when both sides added complementary things (keep both).
+   - Run the affected tests + validate YAML for workflow files
+     (`ruby -ryaml -e "YAML.load_file('f.yml')"`).
+   - Sanity-check that step IDs / `outputs` referenced downstream still line up.
+
+3. **Push the resolution to the PR branch, then CONFIRM it advanced.** For a
+   fork, push by URL (there is no configured remote):
+   ```bash
+   git push git@github.com:<forkOwner>/<repo>.git HEAD:<head.ref>
+   git ls-remote git@github.com:<forkOwner>/<repo>.git refs/heads/<head.ref>
+   ```
+   The remote SHA must equal your **new merge commit**. If it equals the old
+   head, your merge never committed (hook rejected it) and you pushed a no-op —
+   fix step 2 and repush. SSH can also hang open after a successful push and
+   time the command out, so always confirm with `ls-remote`.
+
+4. **Wait for the REAL required checks — not "CI".** GitHub reruns CI on an
+   ephemeral merge-test SHA (`refs/pull/N/merge`), so the run's head SHA won't
+   match your branch tip — that's expected. Read branch protection to learn what
+   is actually required, then confirm those exact contexts are green:
+   ```bash
+   gh api repos/{owner}/{repo}/branches/<base>/protection \
+     -q '.required_status_checks.contexts, .required_pull_request_reviews, .enforce_admins.enabled'
+   gh pr view <N> --json statusCheckRollup \
+     -q '.statusCheckRollup[] | "\((.name//.context))\t\(.conclusion//.state)"'
+   ```
+   For wafflebase `main` the required contexts are `verify-self (22.x)`,
+   `verify-browser (22.x)`, `verify-integration (22.x)` — a green "CI" run alone
+   is **not** sufficient. `mergeable=MERGEABLE state=BLOCKED` almost always means
+   the required *review* is missing, not a check.
+
+5. **Assemble the squash message.** Subject ≤70 chars, ends with `(#N)`; body
+   explains WHY, folding all commits into one coherent narrative (see the repo's
+   commit-message rules in `CLAUDE.md`). Append the effort/cost block — below.
+
+6. **Merge.** Owner bypass is only allowed when `enforce_admins == false`:
+   ```bash
+   gh pr merge <N> --squash --admin \
+     --subject "<subject> (#N)" --body-file <path>
+   ```
+   `--admin` skips the required review; drop it and `gh pr review --approve`
+   instead if you'd rather record an approval. Squash auto-dedupes
+   `Co-Authored-By` trailers, so keep them in the body. The local merge commit
+   from step 2 disappears — squash collapses the branch-vs-main diff into one.
+
+## Combining effort/cost into the squash message
+
+The per-session effort is **not** in the git commits. Each agent session
+(`implement` / `ci-fix` / `review-fix`) posts a hidden append-only ledger
+comment `<!-- agent-metric {json} -->`, and the pipeline renders one aggregated
+summary comment marked `<!-- agent-metrics-summary -->` (heading `## 🤖 Agent
+effort`) via `scripts/agent/metrics.mjs summarize`. **That summary already IS
+the combined effort of every commit** (turns/tokens/time summed, sessions
+counted). To fold it into the squash body, copy it — don't recompute:
+
+```bash
+# Pull the rendered summary (aggregate of all sessions) and strip the marker.
+gh api --paginate repos/{owner}/{repo}/issues/<N>/comments \
+  -q '.[] | select(.body | contains("<!-- agent-metrics-summary -->")) | .body' \
+  | sed '/agent-metrics-summary/d'
+```
+
+Paste that bullet block near the end of the squash body (above the
+`Co-Authored-By` trailers). If **no** summary comment exists — e.g. the PR
+predates the metrics feature, or the pipeline never promoted it — **omit the
+block entirely. Never write plausible-looking numbers.** If you want the raw
+ledger instead of the rendered summary, aggregate the `<!-- agent-metric -->`
+records the same way `aggregate()` in `scripts/agent/metrics.mjs` does (sum
+turns/tokens/durationMs; sessions = count; attempt = review-fix rounds + 1).
+
+## Pitfalls
+
+| Symptom | Cause / Fix |
+|---|---|
+| `refusing to allow an OAuth App ... without workflow scope` | `gh` token lacks `workflow`. `gh auth refresh -h github.com -s workflow` (interactive — have the human run it). |
+| Conflict "resolved" but PR still `CONFLICTING`; `.git/MERGE_HEAD` present, resolution only *staged* | The commit-msg hook rejected the >70-char auto-merge subject, so the merge never committed. Re-run the merge with `-m "Merge main into <branch> (resolve conflict)"` (≤70 chars). |
+| `mergeable=MERGEABLE` but `state=BLOCKED` | Branch protection: usually a required **review** (`REVIEW_REQUIRED`), sometimes a pending required check. Approve, wait, or `--admin` (only if `enforce_admins=false`). |
+| Green "CI" but still can't merge | "CI" ≠ the required contexts. Verify `verify-self/browser/integration` specifically. |
+| Can't push to a fork PR branch | Needs `maintainer_can_modify == true`; push by fork URL, not `origin`. |
+| `git push` times out but the ref updated | SSH lingers after a successful push; confirm with `git ls-remote`. Don't re-push. |
+| Remote head == old head after your "push" | Your merge never committed (see the hook row); you pushed a no-op. Fix and repush. |
+| Local branch looks stalled / diverged from the PR head | A concurrent session may have already resolved + pushed. Fetch `refs/pull/<N>/head`, verify it has the resolution, and recover — don't redo. |
+| Effort numbers look made up | You invented them. Only ever copy the `agent-metrics-summary` comment; omit if absent. |
+
+## Quick Reference
+
+```bash
+gh pr view <N> --json mergeable,mergeStateStatus,isCrossRepository,files
+gh pr checkout <N>
+git merge origin/main -m "Merge main into <branch> (resolve conflict)"  # ≤70 chars
+git push git@github.com:<fork>/<repo>.git HEAD:<ref> && git ls-remote <fork-url> refs/heads/<ref>
+gh api .../branches/<base>/protection -q .required_status_checks.contexts
+gh pr merge <N> --squash --admin --subject "... (#N)" --body-file msg.txt
+```

--- a/.claude/skills/maintainer-merge/SKILL.md
+++ b/.claude/skills/maintainer-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintainer-merge
-description: Use when a maintainer needs to squash-merge a wafflebase PR (often a fork / agent-pipeline PR) that has merge conflicts, requires folding the pipeline's combined effort/cost into the squash commit message, is BLOCKED by branch protection, or fails to merge with "refusing to allow an OAuth App to create or update workflow ... without workflow scope".
+description: Use when a maintainer needs to squash-merge a wafflebase PR (often a fork / agent-pipeline PR) that has merge conflicts, requires folding the pipeline's combined effort (time/turns/tokens/sessions) into the squash commit message, is BLOCKED by branch protection, or fails to merge with "refusing to allow an OAuth App to create or update workflow ... without workflow scope".
 ---
 
 # Maintainer Merge
@@ -10,10 +10,10 @@ description: Use when a maintainer needs to squash-merge a wafflebase PR (often 
 Squash-merge a PR the way a wafflebase maintainer does: resolve conflicts on
 the (possibly fork) branch, wait for the *real* required checks, fold every
 commit into one honest squash message — with the pipeline's **combined
-effort/cost** appended when the PR carries it — and merge, bypassing branch
+effort** appended when the PR carries it — and merge, bypassing branch
 protection only as the repo owner.
 
-**Core principle: never fabricate. Effort/cost is aggregated data that already
+**Core principle: never fabricate. Effort is aggregated data that already
 exists in the PR's comments — you copy it, you don't invent it. If it isn't
 there, omit it.**
 
@@ -21,7 +21,7 @@ there, omit it.**
 
 - Merging an agent-pipeline PR (`agent/*` branch), especially from a **fork**.
 - PR is `CONFLICTING` / `DIRTY` and needs conflict resolution before merge.
-- You want the squash commit to carry the **combined effort/cost** of all the
+- You want the squash commit to carry the **combined effort** of all the
   agent sessions (turns / tokens / time), not just the diff.
 - Merge is `BLOCKED` (branch protection) or fails with the `workflow` scope error.
 
@@ -60,9 +60,10 @@ non-interactive tool call. Have the human run it, then continue.
 2. **Resolve conflicts** on the PR branch. `gh pr checkout <N>`, then merge with
    an **explicit short subject** — the auto-generated merge subject is ~71 chars
    and the repo's commit-msg hook rejects >70, silently leaving the merge
-   *uncommitted* (see pitfalls):
+   *uncommitted* (see pitfalls). Keep the subject **length-bounded** (reference
+   the PR number, not the branch name, so it can't grow past 70):
    ```bash
-   git merge origin/main -m "Merge main into <branch> (resolve conflict)"
+   git merge origin/main -m "Merge main into PR #<N> (resolve conflict)"
    ```
    A merge commit is fine — squash flattens it, and it preserves the
    contributor's original commits (unlike a rebase force-push). Then **verify
@@ -101,7 +102,7 @@ non-interactive tool call. Have the human run it, then continue.
 
 5. **Assemble the squash message.** Subject ≤70 chars, ends with `(#N)`; body
    explains WHY, folding all commits into one coherent narrative (see the repo's
-   commit-message rules in `CLAUDE.md`). Append the effort/cost block — below.
+   commit-message rules in `CLAUDE.md`). Append the effort block — below.
 
 6. **Merge.** Owner bypass is only allowed when `enforce_admins == false`:
    ```bash
@@ -113,15 +114,18 @@ non-interactive tool call. Have the human run it, then continue.
    `Co-Authored-By` trailers, so keep them in the body. The local merge commit
    from step 2 disappears — squash collapses the branch-vs-main diff into one.
 
-## Combining effort/cost into the squash message
+## Combining effort into the squash message
 
 The per-session effort is **not** in the git commits. Each agent session
 (`implement` / `ci-fix` / `review-fix`) posts a hidden append-only ledger
 comment `<!-- agent-metric {json} -->`, and the pipeline renders one aggregated
 summary comment marked `<!-- agent-metrics-summary -->` (heading `## 🤖 Agent
 effort`) via `scripts/agent/metrics.mjs summarize`. **That summary already IS
-the combined effort of every commit** (turns/tokens/time summed, sessions
-counted). To fold it into the squash body, copy it — don't recompute:
+the combined effort of every commit** — `renderSummary()` emits Agents,
+Scope-size, Attempt, Sessions, Total-time, Turns, and Tokens (summed across
+sessions). Note it does **not** render a dollar cost: `aggregate()` sums
+`costUsd` internally but `renderSummary()` never prints it, so the summary you
+copy is effort-only. To fold it into the squash body, copy it — don't recompute:
 
 ```bash
 # Pull the rendered summary (aggregate of all sessions) and strip the marker.
@@ -136,14 +140,16 @@ predates the metrics feature, or the pipeline never promoted it — **omit the
 block entirely. Never write plausible-looking numbers.** If you want the raw
 ledger instead of the rendered summary, aggregate the `<!-- agent-metric -->`
 records the same way `aggregate()` in `scripts/agent/metrics.mjs` does (sum
-turns/tokens/durationMs; sessions = count; attempt = review-fix rounds + 1).
+turns/tokens/durationMs; sessions = count; attempt = review-fix rounds + 1) —
+`costUsd` is summed there too, but keep it out of the message unless the
+renderer starts emitting it.
 
 ## Pitfalls
 
 | Symptom | Cause / Fix |
 |---|---|
 | `refusing to allow an OAuth App ... without workflow scope` | `gh` token lacks `workflow`. `gh auth refresh -h github.com -s workflow` (interactive — have the human run it). |
-| Conflict "resolved" but PR still `CONFLICTING`; `.git/MERGE_HEAD` present, resolution only *staged* | The commit-msg hook rejected the >70-char auto-merge subject, so the merge never committed. Re-run the merge with `-m "Merge main into <branch> (resolve conflict)"` (≤70 chars). |
+| Conflict "resolved" but PR still `CONFLICTING`; `.git/MERGE_HEAD` present, resolution only *staged* | The commit-msg hook rejected the >70-char auto-merge subject, so the merge never committed. Re-run the merge with a length-bounded `-m "Merge main into PR #<N> (resolve conflict)"` (≤70 chars). |
 | `mergeable=MERGEABLE` but `state=BLOCKED` | Branch protection: usually a required **review** (`REVIEW_REQUIRED`), sometimes a pending required check. Approve, wait, or `--admin` (only if `enforce_admins=false`). |
 | Green "CI" but still can't merge | "CI" ≠ the required contexts. Verify `verify-self/browser/integration` specifically. |
 | Can't push to a fork PR branch | Needs `maintainer_can_modify == true`; push by fork URL, not `origin`. |
@@ -157,7 +163,7 @@ turns/tokens/durationMs; sessions = count; attempt = review-fix rounds + 1).
 ```bash
 gh pr view <N> --json mergeable,mergeStateStatus,isCrossRepository,files
 gh pr checkout <N>
-git merge origin/main -m "Merge main into <branch> (resolve conflict)"  # ≤70 chars
+git merge origin/main -m "Merge main into PR #<N> (resolve conflict)"  # ≤70 chars
 git push git@github.com:<fork>/<repo>.git HEAD:<ref> && git ls-remote <fork-url> refs/heads/<ref>
 gh api .../branches/<base>/protection -q .required_status_checks.contexts
 gh pr merge <N> --squash --admin --subject "... (#N)" --body-file msg.txt

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,7 +18,14 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| maintainer merge skill (2026-07-23) | [20260723-maintainer-merge-skill-todo.md](./active/20260723-maintainer-merge-skill-todo.md) | [20260723-maintainer-merge-skill-lessons.md](./active/20260723-maintainer-merge-skill-lessons.md) |
+| docs baseline dedup (2026-07-22) | [20260722-docs-baseline-dedup-todo.md](./active/20260722-docs-baseline-dedup-todo.md) | [20260722-docs-baseline-dedup-lessons.md](./active/20260722-docs-baseline-dedup-lessons.md) |
+| docs hyperlink formatting exit (2026-07-22) | [20260722-docs-hyperlink-formatting-exit-todo.md](./active/20260722-docs-hyperlink-formatting-exit-todo.md) | - |
+| byte text functions (2026-07-21) | [20260721-byte-text-functions-todo.md](./active/20260721-byte-text-functions-todo.md) | [20260721-byte-text-functions-lessons.md](./active/20260721-byte-text-functions-lessons.md) |
+| docs mixed fontsize baseline (2026-07-21) | [20260721-docs-mixed-fontsize-baseline-todo.md](./active/20260721-docs-mixed-fontsize-baseline-todo.md) | [20260721-docs-mixed-fontsize-baseline-lessons.md](./active/20260721-docs-mixed-fontsize-baseline-lessons.md) |
 | docx sdt text import (2026-07-21) | [20260721-docx-sdt-text-import-todo.md](./active/20260721-docx-sdt-text-import-todo.md) | [20260721-docx-sdt-text-import-lessons.md](./active/20260721-docx-sdt-text-import-lessons.md) |
+| xlsx style tiling (2026-07-21) | [20260721-xlsx-style-tiling-todo.md](./active/20260721-xlsx-style-tiling-todo.md) | - |
+| autonomous issue to pr pipeline (2026-07-20) | [20260720-autonomous-issue-to-pr-pipeline-todo.md](./active/20260720-autonomous-issue-to-pr-pipeline-todo.md) | [20260720-autonomous-issue-to-pr-pipeline-lessons.md](./active/20260720-autonomous-issue-to-pr-pipeline-lessons.md) |
 | documents bulk select move (2026-07-20) | [20260720-documents-bulk-select-move-todo.md](./active/20260720-documents-bulk-select-move-todo.md) | [20260720-documents-bulk-select-move-lessons.md](./active/20260720-documents-bulk-select-move-lessons.md) |
 | analytics dashboard viz (2026-07-19) | [20260719-analytics-dashboard-viz-todo.md](./active/20260719-analytics-dashboard-viz-todo.md) | [20260719-analytics-dashboard-viz-lessons.md](./active/20260719-analytics-dashboard-viz-lessons.md) |
 | image viewer (2026-07-19) | [20260719-image-viewer-todo.md](./active/20260719-image-viewer-todo.md) | [20260719-image-viewer-lessons.md](./active/20260719-image-viewer-lessons.md) |
@@ -41,4 +48,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 374
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: docx sdt text import (2026-07-21)
+Latest active task: maintainer merge skill (2026-07-23)

--- a/docs/tasks/active/20260723-maintainer-merge-skill-lessons.md
+++ b/docs/tasks/active/20260723-maintainer-merge-skill-lessons.md
@@ -1,0 +1,45 @@
+# Maintainer Merge skill — lessons
+
+## The commit-msg hook can silently swallow a merge
+
+`git merge origin/main` with no `-m` generates a ~71-char subject
+("Merge remote-tracking branch 'origin/main' into <branch>"). The repo's
+commit-msg hook enforces `subject ≤ 70`, so the commit is **rejected** — but the
+merge stays half-applied: `.git/MERGE_HEAD` present, the resolution only
+*staged*, HEAD unchanged. A follow-up `git push HEAD:branch` then pushes the old
+head (a no-op), and the PR stays `CONFLICTING` while everything *looks* done.
+
+**Rule:** always merge with an explicit ≤70-char subject
+(`git merge origin/main -m "Merge main into <branch> (resolve conflict)"`), and
+after pushing, `git ls-remote` to confirm the remote advanced to the *new merge
+commit*, not the old head.
+
+## Effort/cost lives in PR comments, not commits
+
+The agent pipeline's effort summary is aggregated from hidden per-session
+`<!-- agent-metric -->` ledger comments into one `<!-- agent-metrics-summary -->`
+comment. Squash merge concatenates *commit messages* and dedupes
+`Co-Authored-By` — it never pulls comment data. To carry combined effort into
+the squash message you copy the summary comment. When the PR has none (the
+feature wasn't live), omit it — do not invent numbers.
+
+## "CI green" ≠ mergeable
+
+Branch protection required `verify-self/browser/integration (22.x)`, distinct
+from the "CI" workflow run. `mergeable=MERGEABLE state=BLOCKED` was the required
+*review*, not a check. Read `branches/<base>/protection` to know the real gate.
+
+## Recover from a concurrent session; don't redo
+
+A parallel session had already resolved + pushed the correct merge commit
+(`c7b1c8725`, a proper ≤70-char merge). The local session's rejected merge
+looked like lost work. Ground truth came from `refs/pull/<N>/head` + raw git
+(bypassing the RTK output proxy, which reformats `git status`/`ls`). The remote
+was correct; re-pushing would have been wasted effort.
+
+## Skill placement
+
+Kept the skill out of the repo autonomous-pipeline path by scoping its
+description to "a maintainer needs to squash-merge"; lives at
+`.claude/skills/maintainer-merge/` so both maintainers share it, versioned with
+the code that it references (`scripts/agent/metrics.mjs`).

--- a/docs/tasks/active/20260723-maintainer-merge-skill-lessons.md
+++ b/docs/tasks/active/20260723-maintainer-merge-skill-lessons.md
@@ -9,12 +9,13 @@ merge stays half-applied: `.git/MERGE_HEAD` present, the resolution only
 *staged*, HEAD unchanged. A follow-up `git push HEAD:branch` then pushes the old
 head (a no-op), and the PR stays `CONFLICTING` while everything *looks* done.
 
-**Rule:** always merge with an explicit ≤70-char subject
-(`git merge origin/main -m "Merge main into <branch> (resolve conflict)"`), and
+**Rule:** always merge with an explicit ≤70-char subject that references the PR
+number rather than the branch name, so length can't drift past the hook
+(`git merge origin/main -m "Merge main into PR #<N> (resolve conflict)"`), and
 after pushing, `git ls-remote` to confirm the remote advanced to the *new merge
 commit*, not the old head.
 
-## Effort/cost lives in PR comments, not commits
+## Effort lives in PR comments, not commits
 
 The agent pipeline's effort summary is aggregated from hidden per-session
 `<!-- agent-metric -->` ledger comments into one `<!-- agent-metrics-summary -->`
@@ -22,6 +23,11 @@ comment. Squash merge concatenates *commit messages* and dedupes
 `Co-Authored-By` — it never pulls comment data. To carry combined effort into
 the squash message you copy the summary comment. When the PR has none (the
 feature wasn't live), omit it — do not invent numbers.
+
+`renderSummary()` in `scripts/agent/metrics.mjs` emits effort only (Agents,
+Scope-size, Attempt, Sessions, Total-time, Turns, Tokens). `aggregate()` sums
+`costUsd` internally but the renderer never prints it, so the copied summary
+carries no dollar cost — describe the block as *effort*, not *effort/cost*.
 
 ## "CI green" ≠ mergeable
 

--- a/docs/tasks/active/20260723-maintainer-merge-skill-todo.md
+++ b/docs/tasks/active/20260723-maintainer-merge-skill-todo.md
@@ -1,0 +1,35 @@
+# Maintainer Merge skill
+
+Add a project skill that documents the maintainer squash-merge flow for
+(fork / agent-pipeline) PRs: resolve conflicts, wait for the real required
+checks, fold combined effort/cost into the squash message, and merge past
+branch protection as the repo owner.
+
+## Motivation
+
+Merging PR #522 (a fork agent-pipeline PR, `agent/pr-effort-metrics`, touching
+`.github/workflows/*`) surfaced several non-obvious steps that cost real time:
+
+- `gh pr merge` refuses workflow-file changes without the `workflow` token scope.
+- The commit-msg hook (`subject ≤ 70`) silently rejects the ~71-char
+  auto-generated merge subject, leaving the resolution staged but uncommitted.
+- Branch-protection `BLOCKED` almost always means the required *review*, not a
+  failing check; the required contexts are `verify-self/browser/integration`,
+  not the "CI" run.
+- The combined effort/cost is aggregated data in the PR's
+  `<!-- agent-metrics-summary -->` comment (rendered by `scripts/agent/metrics.mjs`)
+  — it must be copied, never fabricated, and omitted when absent.
+
+## Plan
+
+- [x] Draft the skill as a personal skill and validate the flow end-to-end on #522.
+- [x] Promote to a repo skill at `.claude/skills/maintainer-merge/SKILL.md`.
+- [x] Encode the hard-won pitfalls (workflow scope, 70-char merge-subject hook,
+      CI-vs-required-checks, effort-from-comments, fork push, concurrent-session
+      recovery).
+- [ ] `pnpm verify:fast` green.
+- [ ] Open PR from `add-maintainer-merge-skill`.
+
+## Review
+
+(to fill after PR)

--- a/docs/tasks/active/20260723-maintainer-merge-skill-todo.md
+++ b/docs/tasks/active/20260723-maintainer-merge-skill-todo.md
@@ -2,7 +2,7 @@
 
 Add a project skill that documents the maintainer squash-merge flow for
 (fork / agent-pipeline) PRs: resolve conflicts, wait for the real required
-checks, fold combined effort/cost into the squash message, and merge past
+checks, fold combined effort into the squash message, and merge past
 branch protection as the repo owner.
 
 ## Motivation
@@ -16,9 +16,11 @@ Merging PR #522 (a fork agent-pipeline PR, `agent/pr-effort-metrics`, touching
 - Branch-protection `BLOCKED` almost always means the required *review*, not a
   failing check; the required contexts are `verify-self/browser/integration`,
   not the "CI" run.
-- The combined effort/cost is aggregated data in the PR's
+- The combined effort is aggregated data in the PR's
   `<!-- agent-metrics-summary -->` comment (rendered by `scripts/agent/metrics.mjs`)
-  — it must be copied, never fabricated, and omitted when absent.
+  — it must be copied, never fabricated, and omitted when absent. The renderer
+  emits effort only (time/turns/tokens/sessions); `costUsd` is summed in
+  `aggregate()` but never printed, so the copied block carries no dollar cost.
 
 ## Plan
 
@@ -27,9 +29,23 @@ Merging PR #522 (a fork agent-pipeline PR, `agent/pr-effort-metrics`, touching
 - [x] Encode the hard-won pitfalls (workflow scope, 70-char merge-subject hook,
       CI-vs-required-checks, effort-from-comments, fork push, concurrent-session
       recovery).
-- [ ] `pnpm verify:fast` green.
-- [ ] Open PR from `add-maintainer-merge-skill`.
+- [x] `pnpm verify:fast` green.
+- [x] Open PR from `add-maintainer-merge-skill` (#529).
 
 ## Review
 
-(to fill after PR)
+Opened as #529. `verify:self` green (244.7s); Codecov clean. CodeRabbit raised
+three doc-accuracy findings, all addressed:
+
+1. **effort/cost mismatch (Major)** — `renderSummary()` in
+   `scripts/agent/metrics.mjs` emits effort only (Agents/Scope/Attempt/Sessions/
+   Total-time/Turns/Tokens); `costUsd` is summed in `aggregate()` but never
+   printed. Reworded the skill, lessons, and this todo from "effort/cost" to
+   "effort" and noted cost is aggregated-but-unrendered.
+2. **merge-subject length (Major)** — the example subject embedded `<branch>`,
+   which could exceed the 70-char hook the skill itself warns about. Switched to
+   a length-bounded `Merge main into PR #<N> (resolve conflict)`. Kept
+   `origin/main` (wafflebase PRs always target `main`; a generic
+   `origin/<base>` adds no value here).
+3. **task record (Minor)** — checked off the completed plan items and wrote this
+   Review section before merge.


### PR DESCRIPTION
## Summary

Adds a project skill at `.claude/skills/maintainer-merge/SKILL.md` documenting the maintainer squash-merge flow for (fork / agent-pipeline) PRs. Merging PR #522 surfaced several non-obvious steps worth encoding so both maintainers share one procedure:

- `gh pr merge` refuses `.github/workflows/*` changes without the `workflow` token scope.
- The commit-msg 70-char hook silently rejects the auto-generated merge subject, leaving the resolution staged-but-uncommitted (and a following push a no-op).
- Branch-protection `BLOCKED` is usually the required *review*, not a check; the required contexts are `verify-self/browser/integration`, not the "CI" run.
- Combined effort/cost lives in the PR's `agent-metrics-summary` comment (rendered by `scripts/agent/metrics.mjs`) — copy it into the squash body, never fabricate, omit when absent.

The skill's description is scoped to "a maintainer needs to squash-merge" so it doesn't intrude on the autonomous pipeline's context.

## Test plan

- `pnpm verify:fast` green.
- Docs/skill-only change; no runtime surface. Skill flow validated end-to-end against #522 during authoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added maintainer guidance for resolving conflicts and completing squash merges.
  * Documented required checks, commit message rules, merge recovery steps, and effort/cost summary handling.
  * Added lessons learned and a checklist for the maintainer merge workflow.
  * Updated the task index and archive to reflect the latest maintainer merge documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->