### PR TITLE
Fix promotion: flip PR to ready with an App token; surface flip failures

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -342,7 +342,10 @@ jobs:
       # Scoped to just the promotion mutations (ready / labels / hand-off comment).
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        # Pinned to an immutable commit SHA (not the movable @v1 tag) for
+        # supply-chain safety — this action handles the App private key.
+        # Dependabot updates the pin. Renovate/Dependabot track the # comment.
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.AGENT_APP_ID }}
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
@@ -475,7 +478,10 @@ jobs:
       - name: Generate GitHub App token
         id: app-token
         if: steps.guard.outputs.proceed == 'true'
-        uses: actions/create-github-app-token@v1
+        # Pinned to an immutable commit SHA (not the movable @v1 tag) for
+        # supply-chain safety — this action handles the App private key.
+        # Dependabot updates the pin. Renovate/Dependabot track the # comment.
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.AGENT_APP_ID }}
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -336,10 +336,25 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
+      # The default GITHUB_TOKEN cannot mark a PR ready for review
+      # (markPullRequestReadyForReview → "Resource not accessible by
+      # integration"), so mark-ready flips the PR with this App token instead.
+      # Scoped to just the promotion mutations (ready / labels / hand-off comment).
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+          permission-issues: write
       - name: Run ready gate
         id: gate
         env:
+          # GITHUB_TOKEN does the READS (CI runs via actions:read, check runs via
+          # checks:read); the App token does the WRITES that GITHUB_TOKEN can't.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_MUTATION_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ needs.review-panel.outputs.pr }}
           REQUIRED: ${{ needs.review-panel.outputs.required_checks }}
         run: |
@@ -348,6 +363,9 @@ jobs:
           code=$?
           set -e
           if [ "$code" -eq 2 ]; then echo "mark-ready tooling error" >&2; exit 2; fi
+          # exit 3 = gates passed but the flip-to-ready FAILED (permission/tooling).
+          # Fail the job loudly so the stalled net pages a human — never silent.
+          if [ "$code" -eq 3 ]; then echo "Promotion failed after gates passed (see log)." >&2; exit 3; fi
           if [ "$code" -eq 1 ]; then echo "Not all ready-gates satisfied; leaving as draft."; fi
           if [ "$code" -eq 0 ]; then echo "ready=true" >> "$GITHUB_OUTPUT"; fi
 

--- a/scripts/agent/mark-ready.mjs
+++ b/scripts/agent/mark-ready.mjs
@@ -84,6 +84,18 @@ function ghJson(args) {
   return JSON.parse(gh(args));
 }
 
+// The promotion mutations (mark ready / labels / hand-off comment) need a token
+// that can perform markPullRequestReadyForReview. The default GITHUB_TOKEN
+// CANNOT — it returns "Resource not accessible by integration", which silently
+// left gate-passing PRs stuck as drafts. Use GH_MUTATION_TOKEN (a GitHub App
+// token) for these calls when provided; otherwise fall back to the default `gh`
+// token (e.g. local dry runs).
+function ghMutate(args) {
+  const token = process.env.GH_MUTATION_TOKEN;
+  const env = token ? { ...process.env, GH_TOKEN: token } : process.env;
+  return execFileSync("gh", args, { encoding: "utf8", env });
+}
+
 // --- gather PR state -------------------------------------------------------
 
 let pr;
@@ -186,17 +198,32 @@ if (!pr.isDraft) {
 
 // --- promote ---------------------------------------------------------------
 
-gh(["pr", "ready", prNumber]);
+// Flip draft → ready. This is the one mutation the default GITHUB_TOKEN can't
+// do; a failure here is a permission/tooling problem, NOT a gate failure — exit
+// 3 (distinct from the exit-1 "gates not satisfied") with a clear message so the
+// workflow surfaces it loudly (and the stalled net pages a human) instead of
+// silently leaving the PR a draft.
+try {
+  ghMutate(["pr", "ready", prNumber]);
+} catch (err) {
+  console.error(
+    `\nAll ready-gates passed, but flipping PR #${prNumber} to ready FAILED: ${err.message}\n` +
+      "This is a permission/tooling problem, not a gate failure. The promote job " +
+      "must pass a GitHub App token via GH_MUTATION_TOKEN that can mark a PR ready — " +
+      "the default GITHUB_TOKEN cannot (markPullRequestReadyForReview).",
+  );
+  process.exit(3);
+}
 
 // Swap labels (best-effort; a missing label must not abort the promotion or
 // block the hand-off comment below). `gh` will not create an absent label.
 try {
-  gh(["pr", "edit", prNumber, "--remove-label", "agent:iterating"]);
+  ghMutate(["pr", "edit", prNumber, "--remove-label", "agent:iterating"]);
 } catch {
   /* label may not be present */
 }
 try {
-  gh(["pr", "edit", prNumber, "--add-label", "agent:needs-human-review"]);
+  ghMutate(["pr", "edit", prNumber, "--add-label", "agent:needs-human-review"]);
 } catch {
   console.warn(
     "Could not add 'agent:needs-human-review' label — create it in the repo's " +
@@ -220,6 +247,12 @@ const handoff = [
   "requires. Merge, release, and deploy remain manual.",
 ].join("\n");
 
-gh(["pr", "comment", prNumber, "--body", handoff]);
+// Best-effort: the PR is already flipped to ready; don't fail the promotion if
+// the hand-off comment can't be posted.
+try {
+  ghMutate(["pr", "comment", prNumber, "--body", handoff]);
+} catch (err) {
+  console.warn(`PR flipped to ready, but posting the hand-off comment failed: ${err.message}`);
+}
 
 console.log(`\nPromoted PR #${prNumber} to ready and requested human review.`);


### PR DESCRIPTION
## Summary

Fix the promotion step, which silently fails to flip approved agent PRs to
ready. Found on #521: all ready-gates passed, but `mark-ready`'s `gh pr ready`
(`markPullRequestReadyForReview`) failed with *"Resource not accessible by
integration"* — the default `GITHUB_TOKEN` can't perform that mutation — and the
thrown error was mislabeled as "gates not satisfied; leaving as draft", paging
no one.

## Changes
- **`mark-ready.mjs`**: perform the promotion mutations (mark ready / labels /
  hand-off comment) via a new `ghMutate()` that uses `GH_MUTATION_TOKEN` (a
  GitHub App token) when set; the gate *reads* stay on the default token. A flip
  failure now exits **3** (distinct from exit-1 "gates not satisfied") with a
  clear message; the hand-off comment is best-effort.
- **`agent-review-panel.yml` promote job**: mint an App token (scoped to
  pull-requests + issues write) and pass it as `GH_MUTATION_TOKEN`. Treat exit 3
  as a loud job failure so the `stalled` net pages a human instead of a silent
  draft.

## Merge note
Union-merged with `main` (post-#522): the promote job now carries the App-token
step + `GH_MUTATION_TOKEN` + exit-3 handling **alongside** #522's `id: gate` /
`ready` output / effort-summary step — verified the combined job is coherent, not
just conflict-free.

## Validation
`node --check`, both workflow YAMLs parse, 19/19 agent tests, dead-code +
doc-staleness clean. The end-to-end proof is a real armed promotion (a gate-passing
PR flips to ready; a flip failure exits 3 → stalled pages).

CODEOWNERS-protected (`.github/workflows/agent-*.yml`, `scripts/agent/`) → @hackerwins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved promotion reliability by using dedicated credentials for status changes, labels, and hand-off comments.
  * Promotion now clearly reports when a pull request cannot be marked ready due to permissions or tooling issues.
  * Prevented optional label and comment updates from blocking otherwise successful promotion checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->