### PR TITLE
Make agent state a single mutually-exclusive label

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -181,8 +181,10 @@ jobs:
              <=70 chars; body = why + test plan from the acceptance criteria +
              screenshots for UI; add "Fixes #__ISSUE_NUMBER__"; in "Notes for
              Reviewers" DISCLOSE autonomous Claude Code authorship and what you could
-             NOT verify). Add the label "agent:iterating" and comment on issue
-             #__ISSUE_NUMBER__ linking the PR.
+             NOT verify). Set the agent state by running
+             `node ./scripts/agent/set-state.mjs <pr> implementing` (use the PR
+             number you just opened), then comment on issue #__ISSUE_NUMBER__
+             linking the PR.
           5. LET CI VERIFY — do NOT run `pnpm verify:self`, `pnpm verify:fast`,
              `pnpm verify:integration:docker`, or full builds locally: they are slow
              and this is a one-shot headless run. The PR's CI runs the full lanes and

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -105,7 +105,8 @@ jobs:
                 owner, repo, issue_number: pr.number,
                 body: `${PAGED}\n🛑 CI failed ${failedCi} times on this branch (limit ${max}) without going green. **A human needs to take a look** — the harness could not self-resolve it.`,
               });
-              await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: ['agent:needs-human-review'] }).catch(() => {});
+              // The agent:blocked label is set by the "Set state → blocked" step
+              // below (single-value state via set-state), gated on this `paged`.
               core.setOutput('paged', 'true');
               core.setOutput('proceed', 'false');
               return;
@@ -122,6 +123,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.guard.outputs.pr }}
         run: node ./scripts/agent/metrics.mjs summarize --pr "$PR"
+
+      # Single-value state: the CI-fix loop paged a human → agent:blocked. The
+      # repo is already checked out above.
+      - name: Set state → blocked (paged)
+        if: steps.guard.outputs.paged == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.guard.outputs.pr }}
+        run: node ./scripts/agent/set-state.mjs "$PR" blocked
 
       - uses: pnpm/action-setup@v4
         if: steps.guard.outputs.proceed == 'true'
@@ -165,6 +176,16 @@ jobs:
         env:
           BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: echo "sha=$(git ls-remote origin "refs/heads/$BRANCH" | cut -f1)" >> "$GITHUB_OUTPUT"
+
+      # Single-value state: a CI-fix round is in flight → agent:fixing. Repo is
+      # already checked out above; best-effort, advisory.
+      - name: Set state → fixing
+        if: steps.guard.outputs.proceed == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.guard.outputs.pr }}
+        run: node ./scripts/agent/set-state.mjs "$PR" fixing
 
       - name: Run Claude Code
         if: steps.guard.outputs.proceed == 'true'
@@ -241,7 +262,7 @@ jobs:
               '<!-- agent-paged -->' \
               '🛑 The CI-fix round did not advance the branch head, so CI stays red and the loop cannot re-trigger itself (no new push → no new CI). This can mean the fixer produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, the branch head could not be determined, or an earlier step errored — see the run log and the `claude-ci-fix-execution-output` artifact. **A human should take over** on this PR.' \
               | gh pr comment "$PR" --body-file -
-            gh pr edit "$PR" --add-label "agent:needs-human-review" || true
+            node ./scripts/agent/set-state.mjs "$PR" blocked || true
           fi
 
       # Record this session's effort into the PR metrics ledger (fail-safe:

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -76,7 +76,11 @@ jobs:
     permissions:
       contents: read # read-only toward the PR
       checks: write # record per-lens verdicts
-      issues: read # design-fit lens reads the originating issue spec
+      # issues:write is used ONLY by the trusted "Set state → reviewing" run-step
+      # to set the advisory agent:reviewing label (labels use the issues API). The
+      # SDK step never receives a GitHub token (its env is CLAUDE_CODE_OAUTH_TOKEN
+      # only), so this does not widen what prompt-injected branch code can reach.
+      issues: write # design-fit reads the issue spec + set advisory agent:reviewing
       pull-requests: read
     outputs:
       pr: ${{ steps.pr.outputs.number }}
@@ -234,6 +238,17 @@ jobs:
             }
             fs.writeFileSync('/tmp/prior-findings.json', JSON.stringify(prior));
             core.info(`prior findings carried into re-check: ${prior.length}`);
+
+      # Advisory single-value state: mark the PR "under automated review" while the
+      # panel runs. Best-effort; the label is a projection, never a gate. Runs the
+      # TRUSTED copy from .trusted (checked out above), not the branch's copy.
+      - name: Set state → reviewing
+        if: steps.pr.outputs.number != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: node .trusted/scripts/agent/set-state.mjs "$PR" reviewing
 
       - name: Run review panel
         if: steps.pr.outputs.number != ''
@@ -407,7 +422,8 @@ jobs:
             const PAGED = '<!-- agent-review-paged -->';
             const page = async (msg) => {
               await github.rest.issues.createComment({ owner, repo, issue_number: pr, body: `${PAGED}\n🛑 ${msg}` });
-              await github.rest.issues.addLabels({ owner, repo, issue_number: pr, labels: ['agent:needs-human-review'] }).catch(() => {});
+              // The agent:blocked label is set by the "Set state → blocked" step
+              // below (single-value state via set-state), gated on this `paged`.
               core.setOutput('paged', 'true');
               core.setOutput('proceed', 'false');
             };
@@ -452,6 +468,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ needs.review-panel.outputs.pr }}
         run: node ./scripts/agent/metrics.mjs summarize --pr "$PR"
+
+      # Single-value state: the loop paged a human → agent:blocked. Uses the
+      # trusted main checkout above.
+      - name: Set state → blocked (paged)
+        if: steps.guard.outputs.paged == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+        run: node ./scripts/agent/set-state.mjs "$PR" blocked
 
       - name: Gather failing lens findings
         id: findings
@@ -509,6 +535,17 @@ jobs:
       - name: Install dependencies
         if: steps.guard.outputs.proceed == 'true'
         run: pnpm install --frozen-lockfile
+
+      # Single-value state: a fix round is in flight → agent:fixing. Uses the
+      # branch's own checkout (this job is author-side and already runs branch
+      # code). Best-effort; advisory only.
+      - name: Set state → fixing
+        if: steps.guard.outputs.proceed == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+        run: node ./scripts/agent/set-state.mjs "$PR" fixing
 
       # Record the REMOTE branch tip before the fixer runs, so the step after it
       # can detect a fix round that pushed NO new commit. We read the remote
@@ -600,7 +637,7 @@ jobs:
               '<!-- agent-review-paged -->' \
               '🛑 The fix agent did not advance the branch head, so the requested changes were not applied and the loop cannot re-trigger itself (no push → no new CI → no new panel). Likely causes: it produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, or the branch head could not be determined — see the `claude-fix-execution-output` artifact and the run log. **A human should take over** on this PR.' \
               | gh pr comment "$PR" --body-file -
-            gh pr edit "$PR" --add-label "agent:needs-human-review" || true
+            node ./scripts/agent/set-state.mjs "$PR" blocked || true
           fi
 
       # Record this review-fix session's effort into the PR metrics ledger
@@ -645,6 +682,8 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      actions: read # set-state reconcile reads the CI workflow-run conclusion
+      checks: read # set-state reconcile reads the lens check-run conclusions
     steps:
       - name: Page a human
         id: page
@@ -681,10 +720,9 @@ jobs:
               owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number,
               body: `<!-- agent-review-paged -->\n🛑 The autonomous pipeline stopped without handing off this PR — ${reason}. **A human should review** this PR.`,
             });
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number,
-              labels: ['agent:needs-human-review'],
-            }).catch(() => {});
+            // The single-value label is set by the "Reconcile agent state" step
+            // below — it re-derives state from the unforgeable signals (the paged
+            // comment just posted → agent:blocked) and self-heals any drift.
 
       # The panel died before producing verdicts, but earlier sessions
       # (kickoff / ci-fix) recorded effort — post the summary so the hand-off
@@ -701,3 +739,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.page.outputs.pr }}
         run: node ./scripts/agent/metrics.mjs summarize --pr "$PR"
+
+      # Self-heal the single-value state from the unforgeable signals (CI
+      # conclusion, lens checks, draft flag, paged latch). On the stalled path
+      # this normally resolves to agent:blocked, but deriving it (rather than
+      # hardcoding) also corrects any drift left by a mid-transition crash.
+      - name: Reconcile agent state
+        if: steps.page.outputs.pr != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node ./scripts/agent/set-state.mjs reconcile "${{ steps.page.outputs.pr }}"

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -423,6 +423,21 @@ Components:
   the pipeline's *own* files, so it additionally requires an owner's review for
   changes to the harness itself, but the repo-wide agent-PR gate is the
   branch-protection approval, not CODEOWNERS.
+- **Agent state (advisory single-value label)** — `scripts/agent/set-state.mjs`
+  keeps **exactly one** `agent:<state>` label on the PR at a time
+  (`implementing → awaiting-ci → reviewing → fixing → ready | blocked`), replacing
+  the old additive `agent:iterating` / `agent:needs-human-review` labels (which
+  could co-exist, and where `needs-human-review` ambiguously meant both "promoted"
+  and "gave up"). `computeLabelSet` replaces the whole label set (atomic PUT),
+  stripping every lifecycle *and* legacy label while preserving non-agent labels
+  and the issue-side `agent:candidate` provenance. States are set inline by the
+  trusted steps that already run — `reviewing` (review-panel), `fixing` (fix /
+  iterate-ci), `ready` (mark-ready on promotion), `blocked` (every paging path);
+  `implementing` is set by the kickoff agent and `awaiting-ci` is derived-only.
+  **The label is a projection, never a gate** — no `if:` reads it (gates stay on
+  check runs / CI conclusion / job results / the paged-comment latch). `set-state
+  reconcile` re-derives the state from those unforgeable signals and overwrites
+  drift; it runs on the stalled path and can be invoked manually.
 - **Provenance** — `scripts/hooks/require-ai-disclosure.sh` (PreToolUse Bash,
   gated on `WAFFLEBASE_AGENT_AUTONOMOUS`) enforces an
   `Assisted-by: Claude Code (autonomous)` commit trailer on autonomous runs.
@@ -455,6 +470,12 @@ moves to the approving human reviewer.
   environment (optional per-run human approval), the enablement switch, fork-
   origin rejection, and treating the Claude auth secret as least-privilege and
   rotatable. Adopters must accept this risk consciously.
+- **The agent-state label is forgeable and advisory.** The author agent holds
+  `issues:write`, so it can set any `agent:<state>` (e.g. a fake `agent:ready`).
+  This is acceptable because **nothing gates on the label** — it is a human-facing
+  projection only — and `set-state reconcile` re-derives the true state from the
+  unforgeable signals (CI conclusion, lens check runs, draft flag, paged latch) and
+  overwrites drift. Never wire a workflow `if:` to read `agent:<state>`.
 - **LLM-reviewer prompt injection.** The panel's lens subagents read an untrusted
   diff (and, for design-fit, the issue), so injected text can sway their severity
   classification; the per-finding verifier reduces but doesn't eliminate this. The

--- a/scripts/agent/mark-ready.mjs
+++ b/scripts/agent/mark-ready.mjs
@@ -19,9 +19,10 @@
 // It is belt-and-suspenders with the commit-trailer hook:
 //   3. The PR body discloses autonomous authorship.
 //
-// It NEVER merges. After promotion it flips draft → ready, swaps the
-// `agent:iterating` label for `agent:needs-human-review`, and posts a hand-off
-// comment. The final review + merge stay human, enforced by branch protection.
+// It NEVER merges. After promotion it flips draft → ready, sets the single
+// `agent:ready` lifecycle label (via set-state's computeLabelSet), and posts a
+// hand-off comment. The final review + merge stay human, enforced by branch
+// protection.
 //
 // Usage:
 //   node ./scripts/agent/mark-ready.mjs <pr-number> [--promote] [--require-checks a,b,c]
@@ -34,6 +35,7 @@
 
 import { execFileSync } from "node:child_process";
 import { allRequiredPassed } from "./checks.mjs";
+import { computeLabelSet } from "./set-state.mjs";
 
 const prNumber = process.argv[2];
 const promote = process.argv.includes("--promote");
@@ -215,19 +217,19 @@ try {
   process.exit(3);
 }
 
-// Swap labels (best-effort; a missing label must not abort the promotion or
-// block the hand-off comment below). `gh` will not create an absent label.
+// Single-value state → `agent:ready` (best-effort; a label hiccup must not abort
+// the promotion or block the hand-off comment). REPLACE the whole label set so
+// exactly one lifecycle label survives and non-agent labels (and the issue-side
+// agent:candidate, if present) are preserved.
 try {
-  ghMutate(["pr", "edit", prNumber, "--remove-label", "agent:iterating"]);
-} catch {
-  /* label may not be present */
-}
-try {
-  ghMutate(["pr", "edit", prNumber, "--add-label", "agent:needs-human-review"]);
-} catch {
+  const labels = computeLabelSet(pr.labels || [], "ready");
+  const args = ["api", "-X", "PUT", `repos/{owner}/{repo}/issues/${prNumber}/labels`];
+  for (const l of labels) args.push("-f", `labels[]=${l}`);
+  ghMutate(args);
+} catch (err) {
   console.warn(
-    "Could not add 'agent:needs-human-review' label — create it in the repo's " +
-      "label settings so provenance stays queryable.",
+    `Could not set the 'agent:ready' label: ${err.message} — ensure the agent:* ` +
+      "state labels exist in the repo's label settings.",
   );
 }
 

--- a/scripts/agent/mark-ready.mjs
+++ b/scripts/agent/mark-ready.mjs
@@ -222,7 +222,17 @@ try {
 // exactly one lifecycle label survives and non-agent labels (and the issue-side
 // agent:candidate, if present) are preserved.
 try {
-  const labels = computeLabelSet(pr.labels || [], "ready");
+  // Re-read labels immediately before the full-set PUT: the `pr.labels` fetched
+  // at the top of this run is stale by now, and a REPLACE built from it could
+  // drop a label added since. This shrinks (doesn't eliminate) that window; the
+  // advisory label + set-state reconcile remain the backstop for a lost race.
+  let current;
+  try {
+    current = ghJson(["pr", "view", prNumber, "--json", "labels"]).labels;
+  } catch {
+    current = pr.labels; // fall back to the initial snapshot
+  }
+  const labels = computeLabelSet(current || [], "ready");
   const args = ["api", "-X", "PUT", `repos/{owner}/{repo}/issues/${prNumber}/labels`];
   for (const l of labels) args.push("-f", `labels[]=${l}`);
   ghMutate(args);

--- a/scripts/agent/set-state.mjs
+++ b/scripts/agent/set-state.mjs
@@ -1,0 +1,267 @@
+// Single-value agent STATE for the autonomous issue→PR pipeline.
+//
+// The pipeline's lifecycle used to be an additive pile of labels
+// (`agent:iterating`, `agent:needs-human-review`) with nothing enforcing mutual
+// exclusion — a PR could sit in two states at once, and `needs-human-review` was
+// overloaded (it meant BOTH "promoted, please merge" AND "gave up, please
+// rescue"). This module makes state a SINGLE value: exactly one `agent:<state>`
+// label at a time, out of:
+//
+//   implementing → awaiting-ci → reviewing → fixing → ready | blocked
+//
+// IMPORTANT — the label is an ADVISORY PROJECTION, never a gate. No workflow
+// `if:` and no script decision may read it: the author agent holds issues:write,
+// so the label is forgeable. Gates stay on unforgeable signals (lens check runs,
+// CI conclusion, job results, the `<!-- agent(-review)-paged -->` comment
+// latch). The `reconcile` command re-derives the state from those signals and
+// overwrites drift, so a stale/forged label self-heals.
+//
+// `agent:candidate` (issue provenance) is deliberately NOT a lifecycle label and
+// is never stripped.
+//
+// Usage:
+//   node ./scripts/agent/set-state.mjs <pr> <state> [--force] [--dry-run]
+//   node ./scripts/agent/set-state.mjs reconcile <pr> [--dry-run]
+//
+// Pure helpers are exported and unit-tested (no gh). The CLI talks to GitHub via
+// the `gh` CLI. Writing labels is FAIL-SAFE: any gh/API error logs and exits 0
+// so an advisory label write can never break the pipeline (mirrors metrics.mjs).
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// --- pure helpers (exported for tests; no gh) ------------------------------
+
+/** The lifecycle states, in rough forward order. */
+export const STATES = ["implementing", "awaiting-ci", "reviewing", "fixing", "ready", "blocked"];
+export const LABEL_PREFIX = "agent:";
+/** The current lifecycle labels. */
+export const LIFECYCLE_LABELS = STATES.map((s) => `${LABEL_PREFIX}${s}`);
+/** Pre-cutover labels that this machine replaces; stripped alongside the current
+ * lifecycle labels so an in-flight PR ends up with exactly one new state label
+ * (clean cutover). `agent:candidate` is intentionally absent from BOTH sets so
+ * issue provenance is preserved. */
+export const LEGACY_LIFECYCLE_LABELS = ["agent:iterating", "agent:needs-human-review"];
+/** Every label computeLabelSet strips before adding the one new state label. */
+export const MANAGED_LABELS = [...LIFECYCLE_LABELS, ...LEGACY_LIFECYCLE_LABELS];
+
+/** "reviewing" → "agent:reviewing"; null for an unknown state. */
+export function labelFor(state) {
+  return STATES.includes(state) ? `${LABEL_PREFIX}${state}` : null;
+}
+
+/** "agent:reviewing" → "reviewing"; null if not a lifecycle label. */
+export function stateFor(label) {
+  const name = typeof label === "string" ? label : label && label.name;
+  if (typeof name !== "string" || !name.startsWith(LABEL_PREFIX)) return null;
+  const s = name.slice(LABEL_PREFIX.length);
+  return STATES.includes(s) ? s : null;
+}
+
+/** Normalize a label (string or {name}) to its string name. */
+function labelName(label) {
+  return typeof label === "string" ? label : label && label.name;
+}
+
+/**
+ * Mutual-exclusion core: the exact label set to apply for `newState` — strip
+ * EVERY lifecycle label, keep everything else (non-agent labels, agent:candidate),
+ * add exactly the one new state label. Idempotent; de-duplicated. Throws on an
+ * unknown state (a wiring bug worth catching, not silencing).
+ */
+export function computeLabelSet(currentLabels, newState) {
+  const label = labelFor(newState);
+  if (!label) throw new Error(`unknown state: ${newState}`);
+  const kept = (Array.isArray(currentLabels) ? currentLabels : [])
+    .map(labelName)
+    .filter((n) => typeof n === "string" && !MANAGED_LABELS.includes(n));
+  return [...new Set([...kept, label])];
+}
+
+// Best-effort legality (NOT a gate): guards against downgrading a PR through a
+// stale/racy inline call. reconcile always --forces past this.
+const TRANSITIONS = {
+  implementing: ["awaiting-ci", "reviewing", "fixing", "blocked"],
+  "awaiting-ci": ["reviewing", "fixing", "blocked"],
+  reviewing: ["fixing", "ready", "blocked"],
+  fixing: ["awaiting-ci", "reviewing", "blocked"],
+  ready: ["blocked"], // ready→fixing needs an intervening push (→ --force/reconcile)
+  blocked: [], // terminal: leaving `blocked` needs --force (human re-engaged) or reconcile
+};
+
+/** Is from→to a legal transition? `null`/unknown `from` → any (first assignment).
+ * Same-state re-assert is always legal (idempotent). */
+export function isValidTransition(from, to) {
+  if (!STATES.includes(to)) return false;
+  if (from == null || !STATES.includes(from)) return true;
+  if (from === to) return true;
+  return (TRANSITIONS[from] || []).includes(to);
+}
+
+/**
+ * Pure projection from unforgeable signals → state, for reconcile. Precedence
+ * (first match wins) mirrors the pipeline's own gate order.
+ * signals: { isDraft, ciConclusion, lensBlocked, reviewChecksPresent,
+ *            ciPagedLatch, reviewPagedLatch }
+ */
+export function deriveState(signals = {}) {
+  const s = signals || {};
+  if (s.ciPagedLatch || s.reviewPagedLatch) return "blocked";
+  if (s.isDraft === false) return "ready"; // draft→ready flip is the promotion signal
+  if (s.lensBlocked === true) return "fixing"; // a blocking lens failed, not yet paged
+  if (s.reviewChecksPresent === true) return "reviewing"; // panel ran, not blocked, still draft
+  if (s.ciConclusion === "success") return "reviewing"; // green → panel imminent
+  if (s.isDraft === true) return "awaiting-ci"; // draft, CI pending/failed
+  return "implementing";
+}
+
+// --- gh-backed CLI ---------------------------------------------------------
+
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8" });
+}
+function ghJson(args) {
+  return JSON.parse(gh(args));
+}
+
+// Label writes need a token that can edit the PR. Prefer GH_MUTATION_TOKEN (a
+// GitHub App token) when provided; fall back to the ambient `gh` token (local
+// dry runs). Same pattern as mark-ready.mjs.
+function ghMutate(args) {
+  const token = process.env.GH_MUTATION_TOKEN;
+  const env = token ? { ...process.env, GH_TOKEN: token } : process.env;
+  return execFileSync("gh", args, { encoding: "utf8", env });
+}
+
+// Advisory: never break the pipeline. Log and exit 0 on any operational problem.
+function bail(msg) {
+  console.error(`set-state: ${msg}`);
+  process.exit(0);
+}
+
+/** Current PR label names (strings). */
+function readLabels(pr) {
+  const data = ghJson(["pr", "view", pr, "--json", "labels"]);
+  return (data.labels || []).map((l) => l.name).filter(Boolean);
+}
+
+/** Apply `newState` to the PR by REPLACING the full label set (atomic — the
+ * computed set becomes the post-state, so exactly one lifecycle label survives,
+ * and non-agent labels are carried through). */
+function applyLabels(pr, labels, dryRun) {
+  if (dryRun) {
+    console.log(`[dry-run] would set PR #${pr} labels → ${labels.join(", ")}`);
+    return;
+  }
+  const args = ["api", "-X", "PUT", `repos/{owner}/{repo}/issues/${pr}/labels`];
+  for (const l of labels) args.push("-f", `labels[]=${l}`);
+  ghMutate(args);
+}
+
+function cmdSet(pr, state, force, dryRun) {
+  if (!pr || !state) return bailUsage();
+  if (!STATES.includes(state)) {
+    console.error(`set-state: unknown state '${state}' (expected: ${STATES.join(", ")})`);
+    process.exit(2);
+  }
+  let current;
+  try {
+    current = readLabels(pr);
+  } catch (e) {
+    return bail(`could not read labels for PR #${pr}: ${e.message}`);
+  }
+  const from = current.map(stateFor).find((s) => s != null) ?? null;
+  if (!force && !isValidTransition(from, state)) {
+    console.log(`set-state: skipping illegal transition ${from} → ${state} for PR #${pr} (use --force / reconcile)`);
+    process.exit(0);
+  }
+  try {
+    applyLabels(pr, computeLabelSet(current, state), dryRun);
+  } catch (e) {
+    return bail(`could not set state '${state}' on PR #${pr}: ${e.message}`);
+  }
+  console.log(`set PR #${pr} → ${state}${from ? ` (was ${from})` : ""}`);
+}
+
+/** Gather the unforgeable signals reconcile projects from. Every sub-fetch is
+ * defensive: a partial failure just yields a partial (still-sane) projection. */
+function gatherSignals(pr) {
+  const sig = {};
+  let sha;
+  try {
+    const view = ghJson(["pr", "view", pr, "--json", "isDraft,headRefOid"]);
+    sig.isDraft = view.isDraft;
+    sha = view.headRefOid;
+  } catch {
+    /* leave isDraft undefined */
+  }
+  if (sha) {
+    try {
+      const runs = ghJson(["api", `repos/{owner}/{repo}/actions/runs?head_sha=${sha}&per_page=100`]).workflow_runs || [];
+      const ci = runs.filter((r) => r.name === "CI").sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+      sig.ciConclusion = ci ? ci.conclusion : null; // null while in progress
+    } catch {
+      sig.ciConclusion = null;
+    }
+    try {
+      const checks = ghJson(["api", `repos/{owner}/{repo}/commits/${sha}/check-runs?per_page=100`]).check_runs || [];
+      const lens = checks.filter((c) => (c.name || "").startsWith("agent-review-"));
+      sig.reviewChecksPresent = lens.length > 0;
+      sig.lensBlocked = lens.some((c) => c.conclusion === "failure");
+    } catch {
+      /* leave review signals undefined */
+    }
+  }
+  try {
+    const pages = ghJson(["api", "--paginate", "--slurp", `repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`]);
+    const comments = Array.isArray(pages) ? pages.flat() : [];
+    sig.ciPagedLatch = comments.some((c) => (c.body || "").includes("<!-- agent-paged -->"));
+    sig.reviewPagedLatch = comments.some((c) => (c.body || "").includes("<!-- agent-review-paged -->"));
+  } catch {
+    /* leave latches undefined */
+  }
+  return sig;
+}
+
+function cmdReconcile(pr, dryRun) {
+  if (!pr) return bailUsage();
+  let current, state;
+  try {
+    current = readLabels(pr);
+    state = deriveState(gatherSignals(pr));
+  } catch (e) {
+    return bail(`could not reconcile PR #${pr}: ${e.message}`);
+  }
+  const from = current.map(stateFor).find((s) => s != null) ?? null;
+  if (from === state) {
+    console.log(`reconcile: PR #${pr} already ${state}; nothing to do.`);
+    return;
+  }
+  try {
+    applyLabels(pr, computeLabelSet(current, state), dryRun); // reconcile always forces
+  } catch (e) {
+    return bail(`could not reconcile PR #${pr} to '${state}': ${e.message}`);
+  }
+  console.log(`reconciled PR #${pr} → ${state}${from ? ` (was ${from})` : ""}`);
+}
+
+function bailUsage() {
+  console.error(
+    "usage: set-state.mjs <pr> <state> [--force] [--dry-run]\n" +
+      "       set-state.mjs reconcile <pr> [--dry-run]\n" +
+      `       state ∈ {${STATES.join(", ")}}`,
+  );
+  process.exit(2);
+}
+
+// Only run the CLI when executed directly (not when imported for tests).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const argv = process.argv;
+  const dryRun = argv.includes("--dry-run");
+  if (argv[2] === "reconcile") {
+    cmdReconcile(argv[3], dryRun);
+  } else {
+    cmdSet(argv[2], argv[3], argv.includes("--force"), dryRun);
+  }
+}

--- a/scripts/agent/set-state.mjs
+++ b/scripts/agent/set-state.mjs
@@ -79,6 +79,19 @@ export function computeLabelSet(currentLabels, newState) {
   return [...new Set([...kept, label])];
 }
 
+/** True iff two label collections hold the same SET of names (order-independent;
+ * accepts string- or {name}-shaped labels). Used to decide whether a PR's labels
+ * already match the desired normalized set — a first-label-equality check would
+ * miss leftover duplicate lifecycle labels (drift) that still need collapsing. */
+export function sameLabelSet(a, b) {
+  const norm = (xs) => new Set((Array.isArray(xs) ? xs : []).map(labelName).filter(Boolean));
+  const sa = norm(a);
+  const sb = norm(b);
+  if (sa.size !== sb.size) return false;
+  for (const x of sa) if (!sb.has(x)) return false;
+  return true;
+}
+
 // Best-effort legality (NOT a gate): guards against downgrading a PR through a
 // stale/racy inline call. reconcile always --forces past this.
 const TRANSITIONS = {
@@ -184,25 +197,31 @@ function cmdSet(pr, state, force, dryRun) {
   console.log(`set PR #${pr} → ${state}${from ? ` (was ${from})` : ""}`);
 }
 
-/** Gather the unforgeable signals reconcile projects from. Every sub-fetch is
- * defensive: a partial failure just yields a partial (still-sane) projection. */
+/** Gather the unforgeable signals reconcile projects from, and report whether the
+ * evidence is COMPLETE. A failed fetch must NOT masquerade as "absent"/"pending":
+ * that could make deriveState downgrade a correct blocked/fixing/reviewing to
+ * awaiting-ci on a transient API error. On any fetch failure, `complete` is false
+ * and the caller leaves the label untouched. Returns `{ complete, signals }`. */
 function gatherSignals(pr) {
   const sig = {};
+  let complete = true;
   let sha;
   try {
     const view = ghJson(["pr", "view", pr, "--json", "isDraft,headRefOid"]);
     sig.isDraft = view.isDraft;
     sha = view.headRefOid;
   } catch {
-    /* leave isDraft undefined */
+    complete = false;
   }
-  if (sha) {
+  if (!sha) {
+    complete = false; // without the head SHA we can't read CI / lens checks
+  } else {
     try {
       const runs = ghJson(["api", `repos/{owner}/{repo}/actions/runs?head_sha=${sha}&per_page=100`]).workflow_runs || [];
       const ci = runs.filter((r) => r.name === "CI").sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
-      sig.ciConclusion = ci ? ci.conclusion : null; // null while in progress
+      sig.ciConclusion = ci ? ci.conclusion : null; // genuinely null while in progress
     } catch {
-      sig.ciConclusion = null;
+      complete = false; // do NOT coerce a failed fetch to null (would read as "pending")
     }
     try {
       const checks = ghJson(["api", `repos/{owner}/{repo}/commits/${sha}/check-runs?per_page=100`]).check_runs || [];
@@ -210,7 +229,7 @@ function gatherSignals(pr) {
       sig.reviewChecksPresent = lens.length > 0;
       sig.lensBlocked = lens.some((c) => c.conclusion === "failure");
     } catch {
-      /* leave review signals undefined */
+      complete = false;
     }
   }
   try {
@@ -219,27 +238,37 @@ function gatherSignals(pr) {
     sig.ciPagedLatch = comments.some((c) => (c.body || "").includes("<!-- agent-paged -->"));
     sig.reviewPagedLatch = comments.some((c) => (c.body || "").includes("<!-- agent-review-paged -->"));
   } catch {
-    /* leave latches undefined */
+    complete = false; // the paged latch dominates deriveState — never guess it
   }
-  return sig;
+  return { complete, signals: sig };
 }
 
 function cmdReconcile(pr, dryRun) {
   if (!pr) return bailUsage();
-  let current, state;
+  let current, complete, signals;
   try {
     current = readLabels(pr);
-    state = deriveState(gatherSignals(pr));
+    ({ complete, signals } = gatherSignals(pr));
   } catch (e) {
     return bail(`could not reconcile PR #${pr}: ${e.message}`);
   }
-  const from = current.map(stateFor).find((s) => s != null) ?? null;
-  if (from === state) {
-    console.log(`reconcile: PR #${pr} already ${state}; nothing to do.`);
+  // Incomplete evidence → do NOT risk overwriting a correct label with a guess.
+  // reconcile is best-effort and re-runs, so skipping just defers the self-heal.
+  if (!complete) {
+    console.log(`reconcile: incomplete signals for PR #${pr}; leaving the state label unchanged.`);
     return;
   }
+  const state = deriveState(signals);
+  const desired = computeLabelSet(current, state);
+  // Compare the FULL set, not just the first lifecycle label — otherwise leftover
+  // duplicate lifecycle labels (drift) would be skipped instead of collapsed.
+  if (sameLabelSet(current, desired)) {
+    console.log(`reconcile: PR #${pr} already normalized to ${state}; nothing to do.`);
+    return;
+  }
+  const from = current.map(stateFor).find((s) => s != null) ?? null;
   try {
-    applyLabels(pr, computeLabelSet(current, state), dryRun); // reconcile always forces
+    applyLabels(pr, desired, dryRun); // reconcile always forces
   } catch (e) {
     return bail(`could not reconcile PR #${pr} to '${state}': ${e.message}`);
   }

--- a/scripts/agent/set-state.test.mjs
+++ b/scripts/agent/set-state.test.mjs
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  STATES,
+  LIFECYCLE_LABELS,
+  labelFor,
+  stateFor,
+  computeLabelSet,
+  isValidTransition,
+  deriveState,
+} from "./set-state.mjs";
+
+test("labelFor / stateFor: round-trip; non-lifecycle labels → null", () => {
+  assert.equal(labelFor("reviewing"), "agent:reviewing");
+  assert.equal(labelFor("nope"), null);
+  assert.equal(stateFor("agent:blocked"), "blocked");
+  assert.equal(stateFor({ name: "agent:fixing" }), "fixing"); // object-shaped (gh json)
+  assert.equal(stateFor("bug"), null);
+  assert.equal(stateFor("agent:candidate"), null); // provenance is NOT a lifecycle label
+  // every state round-trips
+  for (const s of STATES) assert.equal(stateFor(labelFor(s)), s);
+});
+
+test("computeLabelSet: swaps the lifecycle label, exactly one out", () => {
+  const out = computeLabelSet(["agent:reviewing"], "fixing");
+  assert.deepEqual(out, ["agent:fixing"]);
+  // exactly one lifecycle label in the result
+  assert.equal(out.filter((l) => LIFECYCLE_LABELS.includes(l)).length, 1);
+});
+
+test("computeLabelSet: preserves non-agent labels AND agent:candidate; strips legacy labels", () => {
+  const out = computeLabelSet(
+    ["bug", "enhancement", "agent:candidate", "agent:iterating", "agent:needs-human-review"],
+    "reviewing",
+  );
+  assert.ok(out.includes("bug"));
+  assert.ok(out.includes("enhancement"));
+  assert.ok(out.includes("agent:candidate")); // provenance survives
+  assert.ok(out.includes("agent:reviewing"));
+  // clean cutover: pre-cutover labels are stripped so no PR keeps two states
+  assert.ok(!out.includes("agent:iterating"));
+  assert.ok(!out.includes("agent:needs-human-review"));
+});
+
+test("computeLabelSet: accepts object-shaped labels and de-dupes; empty → one label", () => {
+  const out = computeLabelSet([{ name: "bug" }, { name: "agent:reviewing" }], "fixing");
+  assert.deepEqual(out.sort(), ["agent:fixing", "bug"].sort());
+  assert.deepEqual(computeLabelSet([], "implementing"), ["agent:implementing"]);
+  // idempotent: applying the same state twice yields the same set
+  assert.deepEqual(computeLabelSet(["agent:ready", "bug"], "ready"), computeLabelSet(computeLabelSet(["agent:ready", "bug"], "ready"), "ready"));
+});
+
+test("computeLabelSet: collapses multiple stray lifecycle labels (drift) to one", () => {
+  const out = computeLabelSet(["agent:reviewing", "agent:fixing", "agent:blocked", "bug"], "ready");
+  assert.deepEqual(out.filter((l) => LIFECYCLE_LABELS.includes(l)), ["agent:ready"]);
+  assert.ok(out.includes("bug"));
+});
+
+test("computeLabelSet: unknown state throws (wiring bug, not silenced)", () => {
+  assert.throws(() => computeLabelSet(["bug"], "bogus"));
+});
+
+test("isValidTransition: first assignment + representative legal edges", () => {
+  assert.equal(isValidTransition(null, "implementing"), true); // no prior state
+  assert.equal(isValidTransition(undefined, "reviewing"), true);
+  assert.equal(isValidTransition("implementing", "fixing"), true);
+  assert.equal(isValidTransition("fixing", "reviewing"), true);
+  assert.equal(isValidTransition("reviewing", "ready"), true);
+  assert.equal(isValidTransition("ready", "blocked"), true);
+  assert.equal(isValidTransition("reviewing", "reviewing"), true); // self-assert
+});
+
+test("isValidTransition: illegal edges are refused", () => {
+  assert.equal(isValidTransition("ready", "fixing"), false); // needs an intervening push
+  assert.equal(isValidTransition("blocked", "reviewing"), false); // terminal without --force
+  assert.equal(isValidTransition("blocked", "ready"), false);
+  assert.equal(isValidTransition("reviewing", "bogus"), false); // unknown target
+});
+
+test("deriveState: paged latch dominates everything", () => {
+  assert.equal(deriveState({ ciPagedLatch: true, isDraft: false, lensBlocked: true }), "blocked");
+  assert.equal(deriveState({ reviewPagedLatch: true, ciConclusion: "success" }), "blocked");
+});
+
+test("deriveState: draft→ready flip beats lens/CI signals", () => {
+  assert.equal(deriveState({ isDraft: false, ciConclusion: "success" }), "ready");
+  assert.equal(deriveState({ isDraft: false, lensBlocked: true }), "ready"); // precedence: ready over fixing
+});
+
+test("deriveState: lensBlocked → fixing; review checks / green CI → reviewing", () => {
+  assert.equal(deriveState({ isDraft: true, lensBlocked: true }), "fixing");
+  assert.equal(deriveState({ isDraft: true, reviewChecksPresent: true }), "reviewing");
+  assert.equal(deriveState({ isDraft: true, ciConclusion: "success" }), "reviewing");
+});
+
+test("deriveState: draft + CI pending/failed → awaiting-ci; empty → implementing", () => {
+  assert.equal(deriveState({ isDraft: true, ciConclusion: null }), "awaiting-ci");
+  assert.equal(deriveState({ isDraft: true, ciConclusion: "failure" }), "awaiting-ci");
+  assert.equal(deriveState({}), "implementing"); // no signals at all
+});

--- a/scripts/agent/set-state.test.mjs
+++ b/scripts/agent/set-state.test.mjs
@@ -6,6 +6,7 @@ import {
   labelFor,
   stateFor,
   computeLabelSet,
+  sameLabelSet,
   isValidTransition,
   deriveState,
 } from "./set-state.mjs";
@@ -97,4 +98,23 @@ test("deriveState: draft + CI pending/failed → awaiting-ci; empty → implemen
   assert.equal(deriveState({ isDraft: true, ciConclusion: null }), "awaiting-ci");
   assert.equal(deriveState({ isDraft: true, ciConclusion: "failure" }), "awaiting-ci");
   assert.equal(deriveState({}), "implementing"); // no signals at all
+});
+
+test("sameLabelSet: order-independent set equality; shape-agnostic", () => {
+  assert.ok(sameLabelSet(["agent:fixing", "bug"], ["bug", "agent:fixing"]));
+  assert.ok(sameLabelSet([{ name: "bug" }, "agent:ready"], ["agent:ready", "bug"]));
+  assert.ok(!sameLabelSet(["agent:fixing"], ["agent:fixing", "bug"])); // size differs
+  assert.ok(!sameLabelSet(["agent:reviewing"], ["agent:fixing"]));
+  assert.ok(sameLabelSet([], []));
+});
+
+// Reconcile drift-collapse: when a PR carries the derived state AND a stray
+// second lifecycle label, the desired (normalized) set differs from current, so
+// reconcile must act — a first-label-equality check would wrongly skip it.
+test("reconcile guard: desired set differs from a drifted current → not skipped", () => {
+  const current = ["agent:fixing", "agent:reviewing", "bug"]; // drift: two lifecycle labels
+  const desired = computeLabelSet(current, "fixing"); // → ["bug", "agent:fixing"]
+  assert.ok(!sameLabelSet(current, desired)); // reconcile applies (collapses the stray)
+  // once normalized, reconcile is a no-op
+  assert.ok(sameLabelSet(desired, computeLabelSet(desired, "fixing")));
 });


### PR DESCRIPTION
## Summary

The pipeline used **additive** labels as a state machine with nothing enforcing
mutual exclusion: a PR could carry `agent:iterating` **and**
`agent:needs-human-review` at the same time (e.g. #521), and
`agent:needs-human-review` was overloaded — it meant both "promoted, please
merge" *and* "gave up, please rescue". A human (or a query) couldn't tell
whether a PR was still working or waiting for them.

This makes agent state a **single value**: exactly one `agent:<state>` label at a
time, via a new `scripts/agent/set-state.mjs`.

```
implementing → awaiting-ci → reviewing → fixing → ready | blocked
```

- **`computeLabelSet`** replaces the whole label set atomically (`PUT
  issues/<pr>/labels`), stripping every lifecycle **and** legacy label while
  preserving non-agent labels and the issue-side `agent:candidate` provenance.
- **Set inline by the trusted steps that already run:** `reviewing` (review
  panel), `fixing` (review-fix + CI-fix), `ready` (mark-ready on promotion),
  `blocked` (every paging path). `implementing` is set by the kickoff agent;
  `awaiting-ci` is derived-only.
- **The label is advisory — never a gate.** No `if:` reads it (gates stay on lens
  check runs / CI conclusion / job results / the paged-comment latch). Because the
  author agent holds `issues:write` the label is forgeable, so `set-state
  reconcile` re-derives the true state from those unforgeable signals and
  self-heals drift (wired into the `stalled` path; also invokable manually).
- **Clean cutover:** the pipeline stops writing `agent:iterating` /
  `agent:needs-human-review` entirely, disambiguating the old overloaded label
  into `ready` vs `blocked`.

### Note on permissions
The review-panel job gains `issues: write` — used **only** by the trusted "Set
state → reviewing" run-step. The SDK step never receives a GitHub token (its env
is `CLAUDE_CODE_OAUTH_TOKEN` only), so this does not widen what prompt-injected
branch code can reach. The `stalled` job gains read-only `actions`/`checks` for
`reconcile`'s signal-gathering.

### ⚠️ Prerequisite before arming
Create the six labels in repo settings — `agent:implementing`, `agent:awaiting-ci`,
`agent:reviewing`, `agent:fixing`, `agent:ready`, `agent:blocked`. `set-state.mjs`
is fail-safe if a label is missing. This is a **breaking change** for any saved
filters / project-board automations keyed on the old labels (`agent:candidate`
issue provenance is unaffected).

## Test plan

- [x] `node --check` on `set-state.mjs` + `mark-ready.mjs`
- [x] `cd scripts/agent && node --test *.test.mjs` — 34/34 (12 new: mutual
  exclusion, provenance/non-agent preservation, legacy-label stripping,
  transition legality, derivation precedence)
- [x] Both workflow YAMLs parse
- [x] `pnpm verify:entropy` — dead-code 0, doc-staleness 0
- [x] pre-commit `verify:fast` green
- [x] **End-to-end (maintainer, armed):** confirm exactly one `agent:<state>`
  label at each stage and never two at once; a paged path → `agent:blocked`;
  a successful promotion → `agent:ready`; add a bogus second lifecycle label →
  next `reconcile` collapses it; `agent:candidate` + non-agent labels survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified agent lifecycle status for pull requests, covering implementation, CI, review, fixing, readiness, and blocked states.
  * Automatically reconciles lifecycle status based on workflow signals.
  * Preserves existing non-lifecycle labels while preventing conflicting status labels.

* **Documentation**
  * Documented lifecycle status behavior, reconciliation, and governance considerations.

* **Tests**
  * Added coverage for status transitions, label handling, reconciliation rules, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->