### PR TITLE
Exclude merge commits from the review-round guard's fail count

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -411,56 +411,30 @@ jobs:
     env:
       WAFFLEBASE_AGENT_AUTONOMOUS: "true"
     steps:
-      - name: Review-round guard
-        id: guard
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = context.repo.owner, repo = context.repo.repo;
-            const pr = Number('${{ needs.review-panel.outputs.pr }}');
-            const max = parseInt(process.env.MAX_REVIEW_ROUNDS, 10);
-            const PAGED = '<!-- agent-review-paged -->';
-            const page = async (msg) => {
-              await github.rest.issues.createComment({ owner, repo, issue_number: pr, body: `${PAGED}\n🛑 ${msg}` });
-              // The agent:blocked label is set by the "Set state → blocked" step
-              // below (single-value state via set-state), gated on this `paged`.
-              core.setOutput('paged', 'true');
-              core.setOutput('proceed', 'false');
-            };
-            // Paginate: the PAGED latch must see ALL comments, not just the first
-            // page — an iterating PR easily exceeds 30 comments, and missing the
-            // sentinel would re-fire the fix loop after a human was already paged.
-            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr, per_page: 100 });
-            if (comments.some((c) => c.body.includes(PAGED))) { core.setOutput('proceed', 'false'); return; }
-            // A lens that failed CLOSED (no valid verdict) → structural problem, page now.
-            if ('${{ needs.review-panel.outputs.all_valid }}' !== 'true') {
-              return page(`A review lens did not produce a valid verdict. A human should review PR #${pr}.`);
-            }
-            // Unforgeable round bound: count commits where one of OUR panel's
-            // lens checks failed. Match the exact required-check names AND the
-            // producing app (github-actions), so a stray same-prefixed check from
-            // some other installed app can't inflate the counter.
-            const NAMES = new Set('${{ needs.review-panel.outputs.required_checks }}'.split(',').filter(Boolean));
-            const mine = (r) => NAMES.has(r.name) && r.app && r.app.slug === 'github-actions';
-            const commits = await github.paginate(github.rest.pulls.listCommits, { owner, repo, pull_number: pr, per_page: 100 });
-            let failedRounds = 0;
-            for (const c of commits) {
-              const runs = await github.paginate(github.rest.checks.listForRef, { owner, repo, ref: c.sha, per_page: 100 });
-              if (runs.some((r) => mine(r) && r.conclusion === 'failure')) failedRounds++;
-            }
-            if (failedRounds >= max) {
-              return page(`The review panel requested changes ${failedRounds} times (limit ${max}) without converging. A human should take over on PR #${pr}.`);
-            }
-            core.setOutput('proceed', 'true');
-
-      # Loop gave up (round cap, or a lens failed closed) and paged a human →
-      # post the effort summary too. The fix job's normal checkout is gated on
-      # `proceed`, so check out the TRUSTED main copy here to run summarize.
-      - name: Check out gate script (paged summary)
-        if: steps.guard.outputs.paged == 'true'
+      # Everything below runs against UNTRUSTED PR data (commit list,
+      # check-run results, PR comments), so the code deciding what to do with
+      # it must come from the TRUSTED `main` copy, never the PR branch's own
+      # version — also what makes scripts/agent/rounds.mjs importable by
+      # review-round-guard.mjs. Runs unconditionally (not gated on `paged`
+      # like before) since the guard step itself now needs it too.
+      - name: Check out trusted main (for the review-round guard)
         uses: actions/checkout@v4
         with:
           ref: main
+          persist-credentials: false # only reads scripts here; the fix push later uses its own App token
+
+      - name: Review-round guard
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ needs.review-panel.outputs.pr }}
+          ALL_VALID: ${{ needs.review-panel.outputs.all_valid }}
+          REQUIRED_CHECKS: ${{ needs.review-panel.outputs.required_checks }}
+        # Unforgeable round bound: count commits where one of OUR panel's lens
+        # checks failed, EXCLUDING merge commits (see rounds.mjs for the why —
+        # PR #521 demonstrated human branch-sync merges inflating this count).
+        run: node ./scripts/agent/review-round-guard.mjs "$PR" "$MAX_REVIEW_ROUNDS" "$ALL_VALID" "$REQUIRED_CHECKS"
+
       - name: Post agent-effort summary (paged → needs human review)
         if: steps.guard.outputs.paged == 'true'
         continue-on-error: true

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -1,0 +1,105 @@
+// CLI glue for the "Review-round guard" step in agent-review-panel.yml's
+// `fix` job. Runs from a TRUSTED `ref: main` checkout (never the PR branch),
+// so attacker-controlled branch code can never alter this gate's logic.
+//
+// Deliberately a plain `gh`-CLI-driven script (mirrors mark-ready.mjs), NOT
+// `actions/github-script` — there is no precedent anywhere in this repo's
+// workflows for dynamically importing a local ES module from inside a
+// github-script sandbox, and this lets rounds.mjs be imported the normal,
+// already-precedented way (see mark-ready.mjs's `import { allRequiredPassed }
+// from "./checks.mjs"`).
+//
+// Usage (GH_TOKEN must be set):
+//   node ./scripts/agent/review-round-guard.mjs <pr> <max-rounds> <all-valid:true|false> <required-checks-csv>
+// Writes `paged` and `proceed` ("true"/"false") to $GITHUB_OUTPUT.
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { countFailedReviewRounds } from "./rounds.mjs";
+
+const [, , prArg, maxArg, allValidArg, requiredChecksArg] = process.argv;
+const pr = Number(prArg);
+const max = parseInt(maxArg, 10);
+const allValid = allValidArg === "true";
+const requiredCheckNames = (requiredChecksArg ?? "").split(",").filter(Boolean);
+
+if (!Number.isInteger(pr) || pr <= 0 || !Number.isFinite(max)) {
+  console.error(
+    "Usage: node ./scripts/agent/review-round-guard.mjs <pr> <max-rounds> <all-valid> <required-checks-csv>",
+  );
+  process.exit(2);
+}
+
+const PAGED = "<!-- agent-review-paged -->";
+
+function setOutput(name, value) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8" });
+}
+function ghJson(args) {
+  return JSON.parse(gh(args));
+}
+
+// Bare-array endpoints: `--paginate` alone merges all pages into ONE valid
+// JSON array (verified against a real multi-page response). Do NOT add
+// --slurp here — that changes the shape to an array of per-page arrays.
+function listAll(path) {
+  return ghJson(["api", path, "--paginate"]);
+}
+
+function page(msg) {
+  gh(["pr", "comment", String(pr), "--body", `${PAGED}\n🛑 ${msg}`]);
+  try {
+    gh(["pr", "edit", String(pr), "--add-label", "agent:needs-human-review"]);
+  } catch {
+    /* best-effort, matches the original .catch(() => {}) */
+  }
+  setOutput("paged", "true");
+  setOutput("proceed", "false");
+}
+
+// PAGED latch: paginate ALL comments (an iterating PR can exceed one page),
+// so a later page isn't missed and the fix loop doesn't re-fire after a human
+// was already paged.
+const comments = listAll(`repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`);
+if (comments.some((c) => (c.body ?? "").includes(PAGED))) {
+  setOutput("proceed", "false");
+  process.exit(0);
+}
+
+// A lens that failed CLOSED (no valid verdict) → structural problem, page now.
+if (!allValid) {
+  page(`A review lens did not produce a valid verdict. A human should review PR #${pr}.`);
+  process.exit(0);
+}
+
+// Object-wrapped-array endpoint (`{ total_count, check_runs: [] }`): plain
+// `--paginate` concatenates raw per-page JSON objects, which is NOT valid
+// single JSON (verified) — `--slurp` wraps each page as an array element
+// instead; flatten `check_runs` across pages ourselves.
+//
+// Deliberately does NOT catch/swallow errors here (unlike mark-ready.mjs's
+// read helpers, which fail closed by returning false): an uncaught throw
+// fails this step, which fails the `fix` job, which the `stalled` job's
+// safety net (its own page()) already catches and hands to a human. Silently
+// treating an unreadable commit as "no failing checks" would under-count
+// failedRounds and could let the loop run an extra round instead.
+function checkRunsFor(sha) {
+  const pages = ghJson(["api", `repos/{owner}/{repo}/commits/${sha}/check-runs?per_page=100`, "--paginate", "--slurp"]);
+  return pages.flatMap((p) => p.check_runs ?? []);
+}
+
+const commits = listAll(`repos/{owner}/{repo}/pulls/${pr}/commits?per_page=100`);
+for (const c of commits) c.checkRuns = checkRunsFor(c.sha);
+
+const failedRounds = countFailedReviewRounds(commits, requiredCheckNames);
+if (failedRounds >= max) {
+  page(
+    `The review panel requested changes ${failedRounds} times (limit ${max}) without converging. A human should take over on PR #${pr}.`,
+  );
+  process.exit(0);
+}
+
+setOutput("proceed", "true");

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -51,11 +51,11 @@ function listAll(path) {
 
 function page(msg) {
   gh(["pr", "comment", String(pr), "--body", `${PAGED}\n🛑 ${msg}`]);
-  try {
-    gh(["pr", "edit", String(pr), "--add-label", "agent:needs-human-review"]);
-  } catch {
-    /* best-effort, matches the original .catch(() => {}) */
-  }
+  // Labeling is intentionally NOT done here: the single-value state machine
+  // owns it. The "Set state → blocked (paged)" step (gated on this `paged`
+  // output) runs set-state.mjs, which atomically strips every lifecycle label
+  // and sets agent:blocked. Writing agent:needs-human-review here would only
+  // be immediately overwritten and contradicts that clean single-label cutover.
   setOutput("paged", "true");
   setOutput("proceed", "false");
 }

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -1,0 +1,33 @@
+// Fixer-commit filter for the review-round guard (agent-review-panel.yml's
+// `fix` job). A merge commit (2 parents, e.g. a human `git merge main` to
+// resolve conflicts on an iterating PR) is NOT a review-fix attempt and must
+// not count toward MAX_REVIEW_ROUNDS — only genuine single-parent commits
+// pushed in response to a failing lens should. PR #521 demonstrated this: 3
+// single-parent fixer commits + 3 two-parent merge commits, all 6 counted by
+// the old (unfiltered) logic toward the round cap.
+//
+// Deliberately identity-independent (no author/bot-name check): the bot
+// identity behind fixer pushes has already changed once in this pipeline's
+// history, so parent count — not who pushed — is the durable signal.
+
+/** A commit is a "fixer" commit iff it has exactly one parent. */
+export function isFixerCommit(commit) {
+  return Array.isArray(commit?.parents) && commit.parents.length === 1;
+}
+
+/**
+ * Count commits that are BOTH a fixer commit AND carry a failing required
+ * lens check-run from OUR panel (exact name match + producing app, so a
+ * same-named check from some other installed app can't inflate the count).
+ *
+ * `commits`: Array<{ sha, parents, checkRuns: Array<{name, app, conclusion}> }>
+ * `requiredCheckNames`: string[]
+ */
+export function countFailedReviewRounds(commits, requiredCheckNames) {
+  const names = new Set(requiredCheckNames ?? []);
+  const isFailingLensRun = (r) =>
+    names.has(r.name) && r.app?.slug === "github-actions" && r.conclusion === "failure";
+  return (commits ?? []).filter(
+    (c) => isFixerCommit(c) && (c.checkRuns ?? []).some(isFailingLensRun),
+  ).length;
+}

--- a/scripts/agent/rounds.test.mjs
+++ b/scripts/agent/rounds.test.mjs
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isFixerCommit, countFailedReviewRounds } from "./rounds.mjs";
+
+const fixer = (sha, checkRuns = []) => ({ sha, parents: [{ sha: "p1" }], checkRuns });
+const merge = (sha, checkRuns = []) => ({ sha, parents: [{ sha: "p1" }, { sha: "p2" }], checkRuns });
+const failingRun = (name = "agent-review-correctness") => ({ name, app: { slug: "github-actions" }, conclusion: "failure" });
+const passingRun = (name = "agent-review-correctness") => ({ name, app: { slug: "github-actions" }, conclusion: "success" });
+
+test("isFixerCommit: one parent → true; merge (2) or root (0) → false", () => {
+  assert.equal(isFixerCommit({ parents: [{ sha: "a" }] }), true);
+  assert.equal(isFixerCommit({ parents: [{ sha: "a" }, { sha: "b" }] }), false);
+  assert.equal(isFixerCommit({ parents: [] }), false);
+  assert.equal(isFixerCommit({}), false);
+  assert.equal(isFixerCommit(undefined), false);
+});
+
+test("countFailedReviewRounds: PR #521 shape — 3 fixer + 3 merge, same failing check → 3, not 6", () => {
+  const req = ["agent-review-correctness"];
+  const commits = [
+    fixer("f1", [failingRun()]), fixer("f2", [failingRun()]), fixer("f3", [failingRun()]),
+    merge("m1", [failingRun()]), merge("m2", [failingRun()]), merge("m3", [failingRun()]),
+  ];
+  assert.equal(countFailedReviewRounds(commits, req), 3);
+});
+
+test("countFailedReviewRounds: empty commits → 0", () => {
+  assert.equal(countFailedReviewRounds([], ["agent-review-correctness"]), 0);
+});
+
+test("countFailedReviewRounds: fixer commit with only a passing check → not counted", () => {
+  assert.equal(countFailedReviewRounds([fixer("f1", [passingRun()])], ["agent-review-correctness"]), 0);
+});
+
+test("countFailedReviewRounds: check-run name not in requiredCheckNames → not counted", () => {
+  assert.equal(countFailedReviewRounds([fixer("f1", [failingRun("some-other-check")])], ["agent-review-correctness"]), 0);
+});
+
+test("countFailedReviewRounds: failing check-run from a different app.slug → not counted (regression guard)", () => {
+  const commits = [fixer("f1", [{ name: "agent-review-correctness", app: { slug: "some-other-app" }, conclusion: "failure" }])];
+  assert.equal(countFailedReviewRounds(commits, ["agent-review-correctness"]), 0);
+});


### PR DESCRIPTION
## Summary

The "Review-round guard" step in `agent-review-panel.yml`'s `fix` job bounds the autonomous review-fix loop at `MAX_REVIEW_ROUNDS` (5) by counting PR commits with a failing required lens check-run. It didn't filter by commit type, so a **human's merge commit** (`git merge main`, 2 parents) counted identically to a genuine single-parent fixer-agent retry.

This already happened on real PR #521: 3 genuine single-parent `github-actions[bot]` fixer commits + 3 two-parent `hackerwins`/`web-flow` merge commits, all 6 counted toward the cap — the loop hit its round limit and paged a human faster than genuine non-convergence would have, purely because of incidental branch syncs (verified live via `gh api repos/wafflebase/wafflebase/pulls/521/commits`).

## The fix

Filter the commit walk to only count **single-parent** commits (a merge commit always has 2 parents; a normal fixer-pushed commit never does). This is deliberately **identity-independent** — no bot-login check. The bot identity behind fixer pushes has already changed once in this pipeline's history: PR #521's historical commits show `github-actions[bot]`, but the current workflow pushes fixer commits via a GitHub App token (`allowed_bots: "yorkie-agent[bot],yorkie-agent"`, see lines 478-514), so parent count is the more durable signal than a login string that could change again.

## Implementation

- **`scripts/agent/rounds.mjs`** (new) — pure module (no `gh`/octokit calls), following the `severity.mjs`/`checks.mjs` convention. Exports `isFixerCommit()` and `countFailedReviewRounds()`, preserving the existing app-slug-matching semantics (`app.slug === 'github-actions'`) while adding the parent-count filter.
- **`scripts/agent/rounds.test.mjs`** (new) — `node:test` suite, including a fixture built from PR #521's actual commit shape (3 single-parent + 3 two-parent, same failing check) asserting the count is 3, not 6.
- **`scripts/agent/review-round-guard.mjs`** (new) — CLI glue mirroring the existing `mark-ready.mjs` convention (pure-module import + `gh`-CLI-driven glue), replacing the previous inline `actions/github-script` step. There's no precedent anywhere in this repo's workflows for dynamically importing a local ES module from inside a `github-script` sandbox, so this is the safer, more-consistent path. Verified empirically during implementation: `gh api <bare-array-endpoint> --paginate` merges pages into one valid JSON array, but the check-runs endpoint (`{total_count, check_runs: []}`) needs `--paginate --slurp` + a manual `flatMap` — `--paginate` alone on that endpoint produces invalid concatenated JSON.
- **`.github/workflows/agent-review-panel.yml`** — the "Check out gate script (paged summary)" checkout is promoted to run unconditionally, first in the job (with `persist-credentials: false`), since the guard step itself now needs the trusted `main` checkout to import `rounds.mjs`. The now-redundant conditional checkout is removed. Everything downstream of `steps.guard.outputs.*` is untouched.

## Explicitly deferred (not in this PR)

- **`.github/workflows/agent-iterate-ci.yml`'s "Attempts guard"** (~lines 68-110) has the same bug class (counts failed CI workflow runs, no filter on who triggered them) but works on `workflow_run` objects that lack a `.parents` field — would need an extra per-run commit lookup, and isn't empirically demonstrated the way #521 demonstrates the review-panel bug. Follow-up only.
- **Unifying with `scripts/agent/metrics.mjs`'s independent `attempt` counter** (`aggregate()`) — a different data source (ledger vs. commit walk); not touched here.
- A second agent may be working in parallel on this same workflow file's "Record agent effort metrics" step and possibly `metrics.mjs`, for unrelated ledger instrumentation — this PR's changes are scoped to the guard step (lines ~378-426ish before this diff) plus three new files, so conflict risk should be low.

## Test plan

- [x] `cd scripts/agent && npm ci && npm test` — new `rounds.test.mjs` passes alongside the existing suite (28/28 total).
- [x] `corepack pnpm verify:fast` — green.
- [x] `corepack pnpm verify:self` — green (ran via the `pre-push` hook).
- [ ] Cannot be exercised end-to-end without a real iterating PR triggering the `fix` job — relying on the unit test (built from #521's real commit shape) plus a careful read of the YAML diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-round safeguards by using trusted validation logic.
  * Correctly identifies qualifying automated fix rounds while excluding merge commits and unrelated or passing checks.
  * Prevents repeated reviewer notifications when a review has already been escalated.

* **Tests**
  * Added coverage for review-round counting, check validation, merge commits, root commits, and repeated escalation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->