### PR TITLE
Classify review-panel SDK errors; surface quota failures honestly

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -87,6 +87,9 @@ jobs:
       blocked: ${{ steps.panel.outputs.blocked }}
       all_valid: ${{ steps.panel.outputs.all_valid }}
       required_checks: ${{ steps.panel.outputs.required_checks }}
+      # Non-empty when EVERY blocking lens failed on an API/quota error (the panel
+      # never ran) — the fix job pages honestly and skips the fixer.
+      infra: ${{ steps.panel.outputs.infra }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -290,6 +293,7 @@ jobs:
             const byId = Object.fromEntries(panel.map((p) => [p.id, p]));
             let blocked = false, allValid = true;
             const required = [];
+            const infraDetails = []; // lens infraError messages (API/quota — reviewer never ran)
             for (const lens of manifest) {
               const p = byId[lens.id];
               const blocking = String(lens.gating ?? 'blocking') === 'blocking';
@@ -302,6 +306,7 @@ jobs:
                 required.push(`agent-review-${lens.id}`);
                 if (conclusion !== 'success') blocked = true;
                 if (!(p && p.valid)) allValid = false;
+                if (p && p.infraError) infraDetails.push(p.infraError);
               }
               let summary = '_No summary produced (failing closed)._';
               try { summary = fs.readFileSync(`.agent-review/${lens.id}/summary.md`, 'utf8'); } catch {}
@@ -334,6 +339,11 @@ jobs:
             core.setOutput('blocked', String(blocked));
             core.setOutput('all_valid', String(allValid));
             core.setOutput('required_checks', required.join(','));
+            // Panel didn't actually run iff EVERY blocking lens failed on an
+            // API/quota error. Surface the reason so the fix job pages honestly
+            // and skips the fixer (there's nothing to fix). Empty otherwise.
+            const infra = required.length > 0 && infraDetails.length === required.length ? infraDetails[0] : '';
+            core.setOutput('infra', infra);
 
       # Hand the panel's own cost + reliability signals to whichever of
       # promote/fix runs next — THIS job deliberately has no issues:write /
@@ -477,10 +487,12 @@ jobs:
           PR: ${{ needs.review-panel.outputs.pr }}
           ALL_VALID: ${{ needs.review-panel.outputs.all_valid }}
           REQUIRED_CHECKS: ${{ needs.review-panel.outputs.required_checks }}
+          INFRA: ${{ needs.review-panel.outputs.infra }}
         # Unforgeable round bound: count commits where one of OUR panel's lens
         # checks failed, EXCLUDING merge commits (see rounds.mjs for the why —
         # PR #521 demonstrated human branch-sync merges inflating this count).
-        run: node ./scripts/agent/review-round-guard.mjs "$PR" "$MAX_REVIEW_ROUNDS" "$ALL_VALID" "$REQUIRED_CHECKS"
+        # INFRA (API/quota outage) pages honestly and skips the fixer + round count.
+        run: node ./scripts/agent/review-round-guard.mjs "$PR" "$MAX_REVIEW_ROUNDS" "$ALL_VALID" "$REQUIRED_CHECKS" "$INFRA"
 
       # This round's panel cost/reliability data (uploaded by the review-panel
       # job, which lacks write scope to record it itself) — record it

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -414,6 +414,19 @@ Components:
 
     Both lower false-negative odds; neither makes the panel safe to self-promote —
     the human review gate stays the backstop.
+
+    **API/quota error classification.** The Agent SDK reports API failures as a
+    `result` message with `subtype:"success"` but `is_error:true` (+ `api_error_status`,
+    e.g. a 429 "You've hit your session limit"), so "success" alone is not proof the
+    model ran. `classifyResult` distinguishes a real verdict from an *API error* (and
+    a transient API error from a *session/usage-limit*, which resets on a fixed
+    schedule) from a genuine *no-output*. Transient API errors get a bounded
+    `withRetry` (exp backoff); a session-limit fails fast (retry can't clear it). When
+    EVERY blocking lens fails on an API error the panel marks an `infraError`: it still
+    fails closed (never promotes), but the fix job pages with the *real* reason
+    ("Claude API/quota error — re-run after reset"), **skips the fixer** (nothing to
+    fix) and does **not** count it toward `MAX_REVIEW_ROUNDS`. This keeps a credential
+    outage from masquerading as a code review finding (the #547/#548 test failures).
 - **Ready gate** — `scripts/agent/mark-ready.mjs`, invoked by the review-panel
   workflow on all-pass: promotes draft → ready only when the **"CI" workflow run**
   for the head SHA concluded `success` (read via the Actions API, not the

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -244,6 +244,52 @@ export function verifierTally(findings, verdicts) {
   return { sentToVerifier, refuted, refutedHighConfidence };
 }
 
+/**
+ * Classify an SDK `result` message. The SDK reports API/quota failures as
+ * subtype "success" with `is_error: true` (+ `api_error_status`, and a human
+ * `result` string like "You've hit your session limit · resets 3:30pm (UTC)"),
+ * so "subtype === success" alone is NOT proof the model ran. Returns one of:
+ *   { ok:true, output }                                  — real structured verdict
+ *   { ok:false, kind:'api-error', status, detail, retryable } — API/quota failure
+ *   { ok:false, kind:'no-output', detail, retryable:false }   — ran but no verdict
+ * A session/usage-limit resets on a fixed schedule (often hours out), so it is
+ * NOT retryable in-run; any other API error (plain 429/529/overload/network) is.
+ */
+export function classifyResult(message) {
+  const m = message || {};
+  if (m.subtype === "success" && m.structured_output) {
+    return { ok: true, output: m.structured_output };
+  }
+  if (m.is_error || m.api_error_status || m.terminal_reason === "api_error") {
+    const detail = typeof m.result === "string" && m.result ? m.result : "";
+    const isQuota = /session limit|usage limit|quota|rate limit|resets?\b/i.test(detail);
+    return { ok: false, kind: "api-error", status: m.api_error_status ?? null, detail, retryable: !isQuota };
+  }
+  return { ok: false, kind: "no-output", status: null, detail: `subtype=${m.subtype}`, retryable: false };
+}
+
+const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Run `fn`, retrying ONLY on errors flagged `err.retryable === true` (see
+ * classifyResult), with exponential backoff + jitter. A non-retryable error
+ * (quota/session-limit, or a genuine no-output) throws immediately — no wasted
+ * retries on a limit that can't clear in-run. `sleep` is injectable for tests.
+ */
+export async function withRetry(fn, { retries = 2, baseMs = 2000, sleep = defaultSleep, jitter = () => 0 } = {}) {
+  let last;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      last = err;
+      if (!err || err.retryable !== true || attempt === retries) throw err;
+      await sleep(baseMs * 2 ** attempt + jitter());
+    }
+  }
+  throw last;
+}
+
 // --- SDK wrapper (lazy import) ----------------------------------------------
 
 async function askStructured({ systemPrompt, prompt, model, repo, schema, sessionLog }) {
@@ -271,10 +317,18 @@ async function askStructured({ systemPrompt, prompt, model, repo, schema, sessio
       // the ONLY place a review-panel SDK call's result is observable at all;
       // everything else here discards it, so record before the throw below.
       if (sessionLog) sessionLog.push(message);
-      if (message.subtype === "success" && message.structured_output) {
-        return message.structured_output;
-      }
-      throw new Error(`structured output not produced (subtype=${message.subtype})`);
+      const c = classifyResult(message);
+      if (c.ok) return c.output;
+      const err = new Error(
+        c.kind === "api-error"
+          ? `review query API error${c.status ? ` (${c.status})` : ""}: ${c.detail || "unknown"}`
+          : `structured output not produced (${c.detail})`,
+      );
+      err.kind = c.kind;
+      err.status = c.status;
+      err.detail = c.detail;
+      err.retryable = c.retryable;
+      throw err;
     }
   }
   throw new Error("query ended without a result message");
@@ -422,24 +476,45 @@ async function main() {
       // catch below (fail-closed, same as the old single-run crash path).
       const results = await Promise.all(
         Array.from({ length: samples }, async () => {
-          try { return await runLens(lens, { rubric: lens.rubric, diff, issue, repo, sessionLog }); }
-          catch (e) { return { __error: e.message }; }
+          // Retry only genuinely-transient API errors (classifyResult); a
+          // quota/session-limit fails through immediately (can't clear in-run).
+          try { return await withRetry(() => runLens(lens, { rubric: lens.rubric, diff, issue, repo, sessionLog })); }
+          catch (e) { return { __error: e.message, kind: e.kind, status: e.status, detail: e.detail }; }
         }),
       );
       ok = results.filter((r) => r && !r.__error);
-      if (ok.length === 0) throw new Error((results[0] && results[0].__error) || "all lens samples failed");
+      if (ok.length === 0) {
+        // All samples failed. If ANY failed on an API/quota error, this is an
+        // INFRASTRUCTURE failure (the reviewer never ran), NOT a review finding —
+        // tag it so the panel pages honestly instead of inventing "changes requested".
+        const apiErr = results.find((r) => r && r.kind === "api-error");
+        const err = new Error((results[0] && results[0].__error) || "all lens samples failed");
+        if (apiErr) { err.infra = true; err.detail = apiErr.detail; err.status = apiErr.status; }
+        throw err;
+      }
       // unionSamples coerces (never drops) + dedupes (collapses identical
       // file+summary, keeps highest severity, never merges distinct bugs).
       findings = unionSamples(ok);
       summary = ok.map((r) => (typeof r.summary === "string" ? r.summary : "")).filter(Boolean).join("\n\n");
     } catch (err) {
-      const failFindings = [{ severity: "major", summary: `Reviewer did not produce a valid verdict: ${err.message}` }];
-      writeVerdict(lensOut, lens, failFindings, "(no valid verdict — failing closed)", { valid: false });
-      panel.push({ id: lens.id, title: lens.title, blocking, applicable: true, conclusion: "failure", valid: false });
+      // Infra/quota error → the reviewer never ran. Fail closed (never promote),
+      // but say so honestly and tag the entry so the workflow pages with the real
+      // reason (and skips the fixer — there's nothing to fix). A genuine no-verdict
+      // (model ran but produced nothing) stays the ordinary fail-closed blocker.
+      const infra = err.infra ? (err.detail || `API error${err.status ? ` (${err.status})` : ""}`) : null;
+      const summaryText = infra
+        ? `Review could not run — Claude API/quota error${err.status ? ` (${err.status})` : ""}: ${infra}`
+        : `Reviewer did not produce a valid verdict: ${err.message}`;
+      const failFindings = [{ severity: "major", summary: summaryText }];
+      writeVerdict(lensOut, lens, failFindings, infra ? "(review did not run — infrastructure/quota error)" : "(no valid verdict — failing closed)", { valid: false });
+      const entry = { id: lens.id, title: lens.title, blocking, applicable: true, conclusion: "failure", valid: false };
+      if (infra) entry.infraError = infra;
+      panel.push(entry);
       lensStats.push({
         id: lens.id,
         samplesRun: samples,
         samplesOk: 0,
+        ...(infra ? { infraError: infra } : {}),
         agreement: compareSampleAgreement([]),
         raised: severityCounts(failFindings),
         verifier: { sentToVerifier: 0, refuted: 0, refutedHighConfidence: 0 },
@@ -508,7 +583,14 @@ async function main() {
   // consumed by metrics.mjs which is itself fail-safe on missing/malformed input).
   writeFileSync(path.join(outDir, "review-execution.json"), JSON.stringify(sessionLog));
   writeFileSync(path.join(outDir, "review-lens-stats.json"), JSON.stringify(lensStats));
-  process.stdout.write(panel.map((p) => `${p.id}: ${p.conclusion}`).join("\n") + "\n");
+  process.stdout.write(panel.map((p) => `${p.id}: ${p.conclusion}${p.infraError ? " (infra)" : ""}`).join("\n") + "\n");
+  // If EVERY applicable blocking lens failed on an API/quota error, the panel
+  // never actually ran — surface it loudly so the workflow pages honestly (and
+  // skips the fixer) rather than treating it as a real review failure.
+  const blockers = panel.filter((p) => p.blocking && p.applicable);
+  if (blockers.length > 0 && blockers.every((p) => p.infraError)) {
+    process.stderr.write(`PANEL_INFRA_ERROR: ${blockers[0].infraError}\n`);
+  }
 }
 
 function writeVerdict(lensOut, lens, findings, summary, { valid, conclusion, advisory = false } = {}) {

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -11,6 +11,8 @@ import {
   compareSampleAgreement,
   severityCounts,
   verifierTally,
+  classifyResult,
+  withRetry,
 } from "./review-panel.mjs";
 import { classify } from "./severity.mjs";
 
@@ -186,4 +188,57 @@ test("applyVerifications: drops ONLY on high-confidence refuted; keeps on any do
   assert.ok(keptSummaries([{ verdict: "refuted" }, null, null]).includes("c"));
   // non-blocking (minor) is never verified/dropped
   assert.ok(keptSummaries([null, null, { verdict: "refuted", confidence: "high" }]).includes("n"));
+});
+
+test("classifyResult: success with structured output → ok", () => {
+  const c = classifyResult({ type: "result", subtype: "success", structured_output: { findings: [], summary: "ok" } });
+  assert.equal(c.ok, true);
+  assert.deepEqual(c.output, { findings: [], summary: "ok" });
+});
+
+test("classifyResult: the exact #548 session-limit 429 → api-error, NOT retryable", () => {
+  // Captured verbatim from the review-panel execution artifact.
+  const msg = {
+    type: "result", subtype: "success", is_error: true, api_error_status: 429,
+    result: "You've hit your session limit · resets 3:30pm (UTC)",
+    terminal_reason: "api_error", usage: { input_tokens: 0, output_tokens: 0 },
+  };
+  const c = classifyResult(msg);
+  assert.equal(c.ok, false);
+  assert.equal(c.kind, "api-error");
+  assert.equal(c.status, 429);
+  assert.equal(c.retryable, false); // session-limit resets hours out — no in-run retry
+  assert.match(c.detail, /session limit/);
+});
+
+test("classifyResult: transient API errors → api-error, retryable", () => {
+  assert.equal(classifyResult({ subtype: "success", is_error: true, api_error_status: 529, result: "overloaded_error" }).retryable, true);
+  assert.equal(classifyResult({ subtype: "error", is_error: true, api_error_status: 500, result: "internal error" }).retryable, true);
+  assert.equal(classifyResult({ terminal_reason: "api_error", result: "fetch failed" }).retryable, true);
+});
+
+test("classifyResult: success but no structured output → no-output, not retryable", () => {
+  const c = classifyResult({ type: "result", subtype: "success" });
+  assert.equal(c.kind, "no-output");
+  assert.equal(c.retryable, false);
+});
+
+test("withRetry: retries retryable errors, gives up after cap, never retries non-retryable", async () => {
+  const noSleep = { sleep: async () => {}, baseMs: 1 };
+  // succeeds after 2 transient failures
+  let n = 0;
+  const okAfter2 = await withRetry(async () => {
+    if (n++ < 2) { const e = new Error("transient"); e.retryable = true; throw e; }
+    return "done";
+  }, noSleep);
+  assert.equal(okAfter2, "done");
+  assert.equal(n, 3);
+  // gives up after retries+1 attempts on a persistently-retryable error
+  let calls = 0;
+  await assert.rejects(withRetry(async () => { calls++; const e = new Error("x"); e.retryable = true; throw e; }, { ...noSleep, retries: 2 }));
+  assert.equal(calls, 3); // 1 + 2 retries
+  // a non-retryable error throws immediately (no retry)
+  let once = 0;
+  await assert.rejects(withRetry(async () => { once++; const e = new Error("quota"); e.retryable = false; throw e; }, noSleep));
+  assert.equal(once, 1);
 });

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -10,22 +10,25 @@
 // from "./checks.mjs"`).
 //
 // Usage (GH_TOKEN must be set):
-//   node ./scripts/agent/review-round-guard.mjs <pr> <max-rounds> <all-valid:true|false> <required-checks-csv>
+//   node ./scripts/agent/review-round-guard.mjs <pr> <max-rounds> <all-valid:true|false> <required-checks-csv> [infra-detail]
 // Writes `paged` and `proceed` ("true"/"false") to $GITHUB_OUTPUT.
 
 import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import { countFailedReviewRounds } from "./rounds.mjs";
 
-const [, , prArg, maxArg, allValidArg, requiredChecksArg] = process.argv;
+const [, , prArg, maxArg, allValidArg, requiredChecksArg, infraArg] = process.argv;
 const pr = Number(prArg);
 const max = parseInt(maxArg, 10);
 const allValid = allValidArg === "true";
 const requiredCheckNames = (requiredChecksArg ?? "").split(",").filter(Boolean);
+// Non-empty when EVERY blocking lens failed on an API/quota error (the panel
+// never ran) — a distinct, non-code failure worth its own honest hand-off.
+const infra = (infraArg ?? "").trim();
 
 if (!Number.isInteger(pr) || pr <= 0 || !Number.isFinite(max)) {
   console.error(
-    "Usage: node ./scripts/agent/review-round-guard.mjs <pr> <max-rounds> <all-valid> <required-checks-csv>",
+    "Usage: node ./scripts/agent/review-round-guard.mjs <pr> <max-rounds> <all-valid> <required-checks-csv> [infra-detail]",
   );
   process.exit(2);
 }
@@ -66,6 +69,18 @@ function page(msg) {
 const comments = listAll(`repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`);
 if (comments.some((c) => (c.body ?? "").includes(PAGED))) {
   setOutput("proceed", "false");
+  process.exit(0);
+}
+
+// API/quota outage (every blocking lens failed on an API error) → the reviewer
+// never ran. Page with the REAL reason and DO NOT dispatch the fixer or count a
+// round — there's nothing to fix, and a quota outage isn't a failed review
+// round. Checked before the generic all_valid page so the message is honest.
+if (infra) {
+  page(
+    `The review panel could not run — Claude API/quota error: ${infra} ` +
+      `This is an infrastructure/credential issue, not a code problem. Re-run the panel after the limit resets.`,
+  );
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

Live test PRs #547/#548 both blocked with all four lenses reporting
"structured output not produced (subtype=success)." The review-panel execution
artifact revealed the real cause: **every SDK query returned `subtype:"success"`
but `is_error:true`, `api_error_status:429`, `"You've hit your session limit ·
resets 3:30pm (UTC)"`** — the shared `CLAUDE_CODE_OAUTH_TOKEN` hit its session
limit under a burst of concurrent pipeline runs. The panel laundered that
**credential outage** into synthetic "changes requested" findings, so the page
read like a code/review problem when it was a quota outage. (Re-run sequentially
with quota available, #548 promoted cleanly — confirming the pipeline logic was
correct; only the hand-off was misleading.)

This classifies SDK errors and surfaces them honestly:

- **`classifyResult(message)`** — distinguishes a real verdict from an **API
  error** (and a *transient* API error from a **session/usage-limit** that resets
  on a fixed schedule) from a genuine **no-output**. Never trusts
  `subtype:"success"` alone.
- **`withRetry`** — bounded exponential-backoff retry for **only** transient API
  errors; a session-limit (or a genuine no-output) fails fast — no retries that
  can't clear.
- **Infra vs review failure** — when *every* blocking lens fails on an API error,
  the panel tags `infraError`: it still **fails closed** (never promotes), but the
  fix job's guard pages with the *real* reason ("Claude API/quota error — re-run
  after reset"), **skips the fixer** (nothing to fix), and does **not** count it
  toward `MAX_REVIEW_ROUNDS` (a quota outage isn't a failed review round).

## Test plan

- [x] `classifyResult` locked against the **exact captured #548 429 result object**
  → api-error / non-retryable / session-limit detail
- [x] `withRetry` — succeeds-after-N, gives-up-after-cap, never-retries-non-retryable
- [x] `cd scripts/agent && node --test *.test.mjs` — 53/53
- [x] `node --check` (review-panel.mjs, review-round-guard.mjs); workflow YAML parses
- [x] `pnpm verify:entropy` — dead-code 0, doc-staleness 0
- [ ] End-to-end (armed, sequential): force an API error → panel pages with the
  honest infra message and skips the fixer

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of API, quota, and infrastructure outages during automated reviews.
  * Added smarter retry behavior for transient errors, while avoiding retries for session-limit cases.
  * Prevented infra failures from being treated as code issues or counted toward review-round limits; alerts now include the specific failure details.
  * Review output now clearly marks infra-related conclusions, and the guard can page/advance appropriately.

* **Documentation**
  * Clarified how API vs quota failures are classified and how the panel/fix loop responds.

* **Tests**
  * Added unit coverage for failure classification and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->