### PR TITLE
Fork-PR comment fix + running→edited comments for review/summarize/loop

### DIFF
--- a/.github/workflows/agent-loop.yml
+++ b/.github/workflows/agent-loop.yml
@@ -67,7 +67,36 @@ jobs:
               core.setFailed(`@${actor} lacks write access (permission: ${data.permission}); refusing to run.`);
             }
 
+      # Comments are posted/edited with a GitHub App token, NOT GITHUB_TOKEN: on a
+      # fork-PR-triggered run GITHUB_TOKEN is read-only, so the fork-fallback note
+      # would 403. The App token isn't subject to that restriction. Loop runs no
+      # untrusted code (API calls only), so minting it here is safe. Scoped to the
+      # comment API (issues:write); the label + CI re-run stay on GITHUB_TOKEN,
+      # which is writable on the same-repo path where they actually execute.
+      - name: Generate GitHub App token (comments)
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+          permission-issues: write
+
+      # Post the "working on it" comment immediately, then edit it with the result.
+      - name: Post running placeholder
+        id: placeholder
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const { data } = await github.rest.issues.createComment({
+              owner, repo, issue_number: context.payload.issue.number,
+              body: '🤖 Working on `@claude loop`…',
+            });
+            core.setOutput('id', String(data.id));
+
       - name: Enable the loop (label + re-run CI), or fall back on forks
+        id: enable
         uses: actions/github-script@v7
         with:
           script: |
@@ -79,14 +108,15 @@ jobs:
             // auto-fix/promote loop can't run. Point them at the read-only review.
             const isFork = !pr.head.repo || pr.head.repo.full_name !== `${owner}/${repo}`;
             if (isFork) {
-              await github.rest.issues.createComment({ owner, repo, issue_number: pr_number, body:
+              core.setOutput('outcome',
                 "⚠️ `@claude loop` can't run on a fork PR — the auto-fix loop pushes commits to the PR branch, which isn't possible on a fork. " +
-                "Comment **`@claude review`** for the read-only review panel instead (that works on forks)." });
+                "Comment **`@claude review`** for the read-only review panel instead (that works on forks).");
               return;
             }
 
-            // Ensure the label exists, then apply it. agent-review-panel.yml and
-            // agent-iterate-ci.yml gate on it (alongside the agent/ prefix).
+            // Ensure the label exists, then apply it (GITHUB_TOKEN — same-repo path,
+            // so it is writable here). agent-review-panel.yml + agent-iterate-ci.yml
+            // gate on it alongside the agent/ prefix.
             try {
               await github.rest.issues.getLabel({ owner, repo, name: 'agent:managed' });
             } catch (e) {
@@ -110,7 +140,25 @@ jobs:
             } catch (e) {
               core.warning(`Could not re-run CI (${e.message}); the loop will engage on the next CI run.`);
             }
-            await github.rest.issues.createComment({ owner, repo, issue_number: pr_number, body:
+            core.setOutput('outcome',
               "🔁 Loop enabled — this PR is now `agent:managed`. On green CI the review panel runs and can promote it; " +
               "on red CI the fixer pushes a follow-up commit. Bounded by the pipeline's round/attempt caps; a human approval is still required to merge." +
-              (reran ? "\n\nRe-running CI now to engage the loop." : "\n\nIt will engage on the next CI run.") });
+              (reran ? "\n\nRe-running CI now to engage the loop." : "\n\nIt will engage on the next CI run."));
+
+      # Edit the placeholder into the final result. always() so a failure in the
+      # enable step still replaces the "working on it" note instead of stranding it.
+      - name: Update the running comment with the result
+        if: always() && steps.placeholder.outputs.id != ''
+        uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ steps.placeholder.outputs.id }}
+          OUTCOME: ${{ steps.enable.outputs.outcome }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const body = process.env.OUTCOME ||
+              '🛑 `@claude loop` failed before it could enable the loop — see the workflow run log.';
+            await github.rest.issues.updateComment({
+              owner, repo, comment_id: Number(process.env.COMMENT_ID), body,
+            });

--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -230,6 +230,22 @@ jobs:
           --lenses-dir .trusted/scripts/agent/lenses
           --out .agent-review
 
+      # Post the comment with a GitHub App token, NOT the default GITHUB_TOKEN.
+      # This workflow runs on ANY PR incl. forks, and for a run triggered by an
+      # issue_comment on a FORK PR, GitHub forces GITHUB_TOKEN to read-only —
+      # so issues.createComment 403s ("Resource not accessible by integration").
+      # The App installation token is not subject to that fork restriction. Minted
+      # AFTER the read-only panel ran (never shares the job with the SDK step) and
+      # scoped to issues:write only. Same pattern as the promote/fix jobs.
+      - name: Generate GitHub App token (post-only, issues:write)
+        id: app-token
+        if: always()
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+          permission-issues: write # PR conversation comments use the issues API
+
       # Aggregate panel.json + each lens's pre-rendered summary.md into ONE comment.
       # No check runs — this is advisory. Fails closed to a note if the panel crashed.
       - name: Post aggregated review comment
@@ -239,7 +255,7 @@ jobs:
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
           PR: ${{ needs.authorize.outputs.pr }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const owner = context.repo.owner, repo = context.repo.repo;

--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -63,6 +63,7 @@ jobs:
       proceed: ${{ steps.gate.outputs.proceed }}
       pr: ${{ steps.gate.outputs.pr }}
       head_sha: ${{ steps.gate.outputs.head_sha }}
+      comment_id: ${{ steps.placeholder.outputs.id }}
     steps:
       - name: Authorize and throttle
         id: gate
@@ -95,6 +96,36 @@ jobs:
             }
             core.setOutput('proceed', 'true');
 
+      # Post the "running" placeholder now (with the throttle marker, so a repeat
+      # @claude review on this SHA is deduped) and hand its id to the review job,
+      # which edits it into the findings when the panel finishes. Posted with an
+      # App token because a fork-PR run's GITHUB_TOKEN is read-only. authorize runs
+      # no untrusted code, so holding the token here is safe.
+      - name: Generate GitHub App token (comment)
+        id: app-token
+        if: steps.gate.outputs.proceed == 'true'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+          permission-issues: write
+
+      - name: Post running placeholder
+        id: placeholder
+        if: steps.gate.outputs.proceed == 'true'
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ steps.gate.outputs.head_sha }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const { data } = await github.rest.issues.createComment({
+              owner, repo, issue_number: context.payload.issue.number,
+              body: `<!-- agent-review:${process.env.HEAD_SHA} -->\n🤖 Review panel is running…`,
+            });
+            core.setOutput('id', String(data.id));
+
   # Install the Agent SDK in an UNPRIVILEGED job (no secrets, no environment) and
   # hand it to the review job as a tarball. Same #501 no-install rule as the
   # autonomous panel: the token-holding review job must never run `npm install`.
@@ -124,7 +155,11 @@ jobs:
 
   review:
     needs: [route, authorize, deps]
-    if: needs.authorize.outputs.proceed == 'true'
+    # always() so that if `deps` fails AFTER authorize posted the placeholder, this
+    # job still runs and the final (always()) step edits the placeholder into a
+    # fail-closed note instead of stranding a "running…" comment. The proceed gate
+    # still keeps it inert for unauthorized/throttled/non-review comments.
+    if: always() && needs.authorize.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     # The CLAUDE_CODE_OAUTH_TOKEN lives in the protected `agent` environment. A
@@ -246,28 +281,36 @@ jobs:
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
           permission-issues: write # PR conversation comments use the issues API
 
-      # Aggregate panel.json + each lens's pre-rendered summary.md into ONE comment.
-      # No check runs — this is advisory. Fails closed to a note if the panel crashed.
-      - name: Post aggregated review comment
+      # EDIT the "running" placeholder authorize posted (comment_id) into the
+      # findings — aggregate panel.json + each lens's summary.md. No check runs;
+      # advisory only. Fails closed to a note if the panel crashed. If the
+      # placeholder id is missing (its post failed), fall back to a fresh comment.
+      - name: Update the running comment with results
         if: always()
         uses: actions/github-script@v7
         env:
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
           PR: ${{ needs.authorize.outputs.pr }}
+          COMMENT_ID: ${{ needs.authorize.outputs.comment_id }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const owner = context.repo.owner, repo = context.repo.repo;
             const pr = Number(process.env.PR);
+            const commentId = process.env.COMMENT_ID ? Number(process.env.COMMENT_ID) : null;
             const marker = `<!-- agent-review:${process.env.HEAD_SHA} -->`;
+            // Edit the placeholder if we have one; otherwise post a fresh comment.
+            const publish = (body) => commentId
+              ? github.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
+              : github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+
             const manifest = JSON.parse(fs.readFileSync('.trusted/scripts/agent/lenses/lenses.json', 'utf8'));
             let panel = null;
             try { panel = JSON.parse(fs.readFileSync('.agent-review/panel.json', 'utf8')); } catch {}
 
             if (!panel) {
-              await github.rest.issues.createComment({ owner, repo, issue_number: pr, body:
-                `${marker}\n🛑 **On-demand review could not complete** — the panel produced no verdict (failing closed). A human should review this PR.` });
+              await publish(`${marker}\n🛑 **On-demand review could not complete** — the panel produced no verdict (failing closed). A human should review this PR.`);
               return;
             }
             const byId = Object.fromEntries(panel.map((p) => [p.id, p]));
@@ -293,4 +336,4 @@ jobs:
             let body = `${marker}\n${header}\n\n${bodies.join('\n\n')}${note}`;
             // GitHub comment hard limit is 65536 chars; trim from the tail if huge.
             if (body.length > 65000) body = body.slice(0, 64900) + '\n\n… _(truncated)_' + note;
-            await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+            await publish(body);

--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -305,7 +305,11 @@ jobs:
               ? github.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
               : github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
 
-            const manifest = JSON.parse(fs.readFileSync('.trusted/scripts/agent/lenses/lenses.json', 'utf8'));
+            // Read panel.json and take the fail-closed path FIRST, before parsing
+            // the trusted manifest. If an earlier step failed and skipped the
+            // `.trusted` checkout (this job runs under always()), lenses.json is
+            // absent — reading it first would throw and strand the placeholder
+            // instead of editing it to the note below.
             let panel = null;
             try { panel = JSON.parse(fs.readFileSync('.agent-review/panel.json', 'utf8')); } catch {}
 
@@ -313,6 +317,7 @@ jobs:
               await publish(`${marker}\n🛑 **On-demand review could not complete** — the panel produced no verdict (failing closed). A human should review this PR.`);
               return;
             }
+            const manifest = JSON.parse(fs.readFileSync('.trusted/scripts/agent/lenses/lenses.json', 'utf8'));
             const byId = Object.fromEntries(panel.map((p) => [p.id, p]));
             // Overall verdict from the BLOCKING+applicable lenses (same rule as the
             // gating panel), but rendered as advice, not a gate.

--- a/.github/workflows/agent-summarize.yml
+++ b/.github/workflows/agent-summarize.yml
@@ -161,6 +161,20 @@ jobs:
             --model claude-opus-4-8
             --allowedTools "Read,Write"
 
+      # Post with a GitHub App token, NOT the default GITHUB_TOKEN. Summarize runs
+      # on any PR incl. forks, and a run triggered by an issue_comment on a FORK PR
+      # gets a read-only GITHUB_TOKEN, so issues.createComment would 403. The App
+      # installation token isn't subject to that fork restriction. Scoped to
+      # issues:write; Claude never sees it (only this trusted step does).
+      - name: Generate GitHub App token (post-only, issues:write)
+        id: app-token
+        if: steps.gate.outputs.proceed == 'true'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+          permission-issues: write
+
       # Trusted post: prepend the throttle marker (so it's reliable, not
       # agent-authored) and create the comment. Skips quietly if Claude produced
       # nothing.
@@ -171,7 +185,7 @@ jobs:
           PR: ${{ steps.gate.outputs.pr }}
           HEAD_SHA: ${{ steps.gate.outputs.head_sha }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const owner = context.repo.owner, repo = context.repo.repo;

--- a/.github/workflows/agent-summarize.yml
+++ b/.github/workflows/agent-summarize.yml
@@ -1,26 +1,25 @@
 # On-demand PR summary: when someone comments "@claude summarize" on a PR, post a
-# short "what this PR does + is it good to go?" comment. READ-ONLY — it never
-# checks out or executes branch code, never pushes, and never merges; it reads the
-# PR diff/metadata via `gh` and posts one comment.
+# "🤖 Summarizing…" comment immediately, then EDIT it into a short "what this PR
+# does + is it good to go?" summary once Claude finishes. READ-ONLY toward code —
+# it never checks out or executes branch code, never pushes, and never merges; it
+# reads the PR diff/metadata via the API and hands it to Claude as data.
 #
 # Trust: the PR author OR a trusted maintainer may trigger it (a read-only summary
 # is low-risk, so contributors can self-serve on their own PR). Throttled to one
 # summary per head SHA so re-comments don't spam or burn budget.
 #
-# The command verb is parsed by the shared scripts/agent/command.mjs; this
-# workflow runs only for `summarize`.
+# The placeholder + edit are posted with a GitHub App token (a fork-PR-triggered
+# run's GITHUB_TOKEN is read-only, so a plain comment would 403). The `announce`
+# job holds that token and does no untrusted work; the `summarize` job runs Claude
+# read-only and only mints its own token AFTER Claude, so the token never coexists
+# with the model. The command verb is parsed by scripts/agent/command.mjs.
 name: Agent Summarize
 
 on:
   issue_comment:
     types: [created]
 
-# Read-only toward the repo; only needs to post a comment. No contents:write, no
-# App token — this job must never be able to push.
-permissions:
-  contents: read
-  pull-requests: read
-  issues: write # post the summary comment (PR comments use the issues API)
+permissions: {}
 
 jobs:
   route:
@@ -47,20 +46,21 @@ jobs:
           BODY: ${{ github.event.comment.body }}
         run: node scripts/agent/command.mjs "$BODY" pr
 
-  summarize:
+  # Gate + post the "running" placeholder. Runs no untrusted code, so it safely
+  # holds the App token used to post (and later edit) the comment.
+  announce:
     needs: [route]
     if: needs.route.outputs.command == 'summarize'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    # The CLAUDE_CODE_OAUTH_TOKEN lives in the protected `agent` environment (same
-    # as the rest of the pipeline). A maintainer can tune that environment's
-    # protection rules — e.g. no required reviewers — if they want summarize to be
-    # self-service rather than approval-gated.
-    environment: agent
-    # One summary in flight per PR; queue re-requests rather than cancel.
-    concurrency:
-      group: agent-summarize-${{ github.event.issue.number }}
-      cancel-in-progress: false
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+      issues: read
+    outputs:
+      proceed: ${{ steps.gate.outputs.proceed }}
+      pr: ${{ steps.gate.outputs.pr }}
+      head_sha: ${{ steps.gate.outputs.head_sha }}
+      comment_id: ${{ steps.placeholder.outputs.id }}
     steps:
       # Authoritative trust + throttle gate. Authorized = the PR author OR a
       # maintainer with write access. Throttle = skip if this exact head SHA was
@@ -102,16 +102,63 @@ jobs:
             }
             core.setOutput('proceed', 'true');
 
+      # App token for the comment: a fork-PR-triggered run's GITHUB_TOKEN is
+      # read-only, so a plain createComment would 403. announce runs no untrusted
+      # code, so holding the token here is safe. Scoped to issues:write.
+      - name: Generate GitHub App token (comment)
+        id: app-token
+        if: steps.gate.outputs.proceed == 'true'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+          permission-issues: write
+
+      # Post the placeholder now (with the throttle marker) and hand its id to the
+      # summarize job, which edits it into the summary once Claude finishes.
+      - name: Post running placeholder
+        id: placeholder
+        if: steps.gate.outputs.proceed == 'true'
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ steps.gate.outputs.head_sha }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const { data } = await github.rest.issues.createComment({
+              owner, repo, issue_number: context.payload.issue.number,
+              body: `<!-- agent-summarize:${process.env.HEAD_SHA} -->\n🤖 Summarizing this PR…`,
+            });
+            core.setOutput('id', String(data.id));
+
+  summarize:
+    needs: [route, announce]
+    if: needs.announce.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # The CLAUDE_CODE_OAUTH_TOKEN lives in the protected `agent` environment (same
+    # as the rest of the pipeline). A maintainer can tune that environment's
+    # protection rules — e.g. no required reviewers — if they want summarize to be
+    # self-service rather than approval-gated.
+    environment: agent
+    permissions:
+      contents: read # fetch the PR diff via the API
+      pull-requests: read
+    # One summary in flight per PR; queue re-requests rather than cancel.
+    concurrency:
+      group: agent-summarize-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
       # Fetch the PR metadata + diff with the trusted GITHUB_TOKEN and write them
       # to files. Claude then reads these as DATA — it never runs `gh` itself, so
       # it needs no repo credential and no shell. (This job has no checkout, so a
       # `gh` call by Claude would also have no repo context — another reason to
       # fetch here via the API.)
       - name: Prepare PR data (trusted read)
-        if: steps.gate.outputs.proceed == 'true'
         uses: actions/github-script@v7
         env:
-          PR: ${{ steps.gate.outputs.pr }}
+          PR: ${{ needs.announce.outputs.pr }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -135,7 +182,6 @@ jobs:
             fs.writeFileSync('/tmp/pr.diff', diff);
 
       - name: Summarize (read-only; no repo credentials)
-        if: steps.gate.outputs.proceed == 'true'
         # Pinned to the v1 release commit (immutable) for supply-chain safety.
         # NO github_token and NO Bash — Claude can only Read the pre-fetched PR
         # data and Write its summary to a file. Holding no write-capable credential
@@ -161,37 +207,40 @@ jobs:
             --model claude-opus-4-8
             --allowedTools "Read,Write"
 
-      # Post with a GitHub App token, NOT the default GITHUB_TOKEN. Summarize runs
-      # on any PR incl. forks, and a run triggered by an issue_comment on a FORK PR
-      # gets a read-only GITHUB_TOKEN, so issues.createComment would 403. The App
-      # installation token isn't subject to that fork restriction. Scoped to
-      # issues:write; Claude never sees it (only this trusted step does).
+      # App token for the edit, minted AFTER Claude so it never coexists with the
+      # model. A fork-PR run's GITHUB_TOKEN is read-only, so updateComment needs it.
       - name: Generate GitHub App token (post-only, issues:write)
         id: app-token
-        if: steps.gate.outputs.proceed == 'true'
+        if: always()
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.AGENT_APP_ID }}
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
           permission-issues: write
 
-      # Trusted post: prepend the throttle marker (so it's reliable, not
-      # agent-authored) and create the comment. Skips quietly if Claude produced
-      # nothing.
-      - name: Post the summary comment (trusted)
-        if: steps.gate.outputs.proceed == 'true'
+      # EDIT the placeholder announce posted into the summary. always() so a Claude
+      # failure still replaces the "Summarizing…" note instead of stranding it. If
+      # the placeholder id is missing, fall back to a fresh comment.
+      - name: Update the running comment with the summary
+        if: always()
         uses: actions/github-script@v7
         env:
-          PR: ${{ steps.gate.outputs.pr }}
-          HEAD_SHA: ${{ steps.gate.outputs.head_sha }}
+          PR: ${{ needs.announce.outputs.pr }}
+          HEAD_SHA: ${{ needs.announce.outputs.head_sha }}
+          COMMENT_ID: ${{ needs.announce.outputs.comment_id }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const fs = require('fs');
             const owner = context.repo.owner, repo = context.repo.repo;
-            const issue_number = Number(process.env.PR);
             const marker = `<!-- agent-summarize:${process.env.HEAD_SHA} -->`;
+            const commentId = process.env.COMMENT_ID ? Number(process.env.COMMENT_ID) : null;
+            const publish = (body) => commentId
+              ? github.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
+              : github.rest.issues.createComment({ owner, repo, issue_number: Number(process.env.PR), body });
             let summary = '';
             try { summary = fs.readFileSync('/tmp/summary.md', 'utf8').trim(); } catch {}
-            if (!summary) { core.warning('No summary was produced; posting nothing.'); return; }
-            await github.rest.issues.createComment({ owner, repo, issue_number, body: `${marker}\n${summary}` });
+            const body = summary
+              ? `${marker}\n${summary}`
+              : `${marker}\n🛑 No summary was produced — see the workflow run log.`;
+            await publish(body);


### PR DESCRIPTION
## Summary

Two related changes to the on-demand `@claude` verbs (`review` / `summarize` /
`loop`):

1. **Fork-PR fix.** These verbs post their result as a PR comment. On a **fork PR**
   the run is triggered by `issue_comment`, and GitHub forces the automatic
   `GITHUB_TOKEN` to **read-only** — so `issues.createComment` returns
   `403 Resource not accessible by integration`. Posting now uses a **GitHub App
   installation token** (the one the promote/fix jobs already use), which isn't
   subject to the fork restriction.
2. **"Running → result" UX.** Each verb now posts a `🤖 working…` placeholder
   comment immediately, then **edits that same comment** into the review / summary /
   loop-result when done.

## Why

Observed on **#550** (a fork PR): [the `@claude review` run](https://github.com/wafflebase/wafflebase/actions/runs/30165338383)
ran the panel fine and failed only on the final comment —
`POST /repos/wafflebase/wafflebase/issues/550/comments → 403`. Every *read* in the
job worked; only the *write* failed, because the fork-triggered `GITHUB_TOKEN` is
read-only regardless of the `permissions:` block.

## What changed

- **`agent-review-on-demand.yml`**: `authorize` posts the placeholder (with the
  throttle marker) via an App token and outputs its id; the `review` job edits it
  into the findings using a second App token minted *after* the read-only panel.
  The review job is `always() && proceed` so a `deps` failure edits the placeholder
  to a fail-closed note instead of stranding it.
- **`agent-summarize.yml`**: split into an `announce` job (gate + placeholder,
  holds the App token, runs no untrusted code) and the `summarize` job (fetch data
  → read-only Claude → mint App token **after** Claude → edit). The token never
  coexists with the model.
- **`agent-loop.yml`**: posts/edits its comment with the App token (so the
  fork-fallback note works on a fork PR); label + CI re-run stay on `GITHUB_TOKEN`
  (same-repo path). Posts a placeholder → does the work → edits with the outcome.
- All edits fall back to a fresh comment if the placeholder id is missing, and run
  under `always()` so a failure still replaces the placeholder.

## Author checklist

- [x] I read every line of this diff.
- [ ] Tests — none (workflow-only). Needs a live re-run of each verb (incl. on a
      fork PR) after merge.
- [x] AI assistance noted below.

## Verification

- All workflows parse as valid YAML; the App-token action pin matches the existing
  promote/fix usage.
- **Effective only after merge to `main`** — `issue_comment` workflows always run
  the default-branch version, so re-running `@claude review` on #550 will keep
  using the old (broken) workflow until this lands.

## Risk Assessment

- App token (scoped `issues: write`) is introduced for comment writes. In `review`
  and `summarize` it is never present in the same job as the untrusted-influenced
  model/SDK step (placeholder posts from a no-untrusted-code job; the result-edit
  token is minted after the model runs). `loop` runs no untrusted code at all.
- Fork-PR review still reviews untrusted code read-only (Read/Grep/Glob, trusted
  `main` orchestrator, pinned SHA) — unchanged.

## Notes for Reviewers

**AI assistance:** authored with Claude Code, reviewed line-by-line. Diagnosed from
the failed run logs of #550's `@claude review`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Workflow status comments are now posted immediately and updated in place with final results.
  * Review, summarization, and loop workflows reliably replace progress messages even when processing fails.
  * Fork pull requests receive clearer outcome messages, including whether CI was rerun.
  * Workflow permissions are more tightly scoped to required actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->