### PR TITLE
On-demand review: re-check the gate's prior findings

### DIFF
--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -169,7 +169,8 @@ jobs:
     permissions:
       contents: read # read-only toward the PR
       pull-requests: read
-      issues: write # post the single findings comment (NO checks:write — advisory only)
+      checks: read # READ prior agent-review-<lens> findings (never checks:write — advisory only)
+      issues: write # post the single findings comment
     concurrency:
       group: agent-review-ondemand-${{ needs.authorize.outputs.pr }}
       cancel-in-progress: false
@@ -249,6 +250,50 @@ jobs:
       - name: Strip untrusted agent config from the branch
         run: rm -rf "$GITHUB_WORKSPACE/.claude" "$GITHUB_WORKSPACE/.mcp.json"
 
+      # Carry forward the AUTONOMOUS panel's prior blocking findings (stored as JSON
+      # in each `agent-review-<lens>` check run's output.text) and hand them to the
+      # panel via --prior-findings, so this advisory review RE-CHECKS them the same
+      # way the gate does. Without this, a finding the gate is still holding open
+      # can look "resolved" here just because a fresh pass happened to miss it (the
+      # divergence seen on #548). Same logic as agent-review-panel.yml's "Read prior
+      # findings". Best-effort (continue-on-error) and empty when there's no prior
+      # panel history (e.g. a non-agent PR). This review posts NO check runs, so it
+      # only READS priors and never contributes new ones.
+      - name: Read prior findings (align with the gating panel)
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          PR: ${{ needs.authorize.outputs.pr }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const pr = Number(process.env.PR);
+            const manifest = JSON.parse(fs.readFileSync('.trusted/scripts/agent/lenses/lenses.json', 'utf8'));
+            const wantNames = new Set(manifest.map((l) => `agent-review-${l.id}`));
+            const commits = await github.paginate(github.rest.pulls.listCommits, { owner, repo, pull_number: pr, per_page: 100 });
+            const latest = {}; // check name -> { id, t }
+            for (const c of commits) {
+              const runs = await github.paginate(github.rest.checks.listForRef, { owner, repo, ref: c.sha, per_page: 100 });
+              for (const r of runs) {
+                if (!wantNames.has(r.name) || !r.app || r.app.slug !== 'github-actions') continue;
+                const t = new Date(r.started_at || 0).getTime();
+                if (!latest[r.name] || t > latest[r.name].t) latest[r.name] = { id: r.id, t };
+              }
+            }
+            const prior = [];
+            for (const [name, { id }] of Object.entries(latest)) {
+              const lens = name.replace(/^agent-review-/, '');
+              let text = '';
+              try { const { data } = await github.rest.checks.get({ owner, repo, check_run_id: id }); text = (data.output && data.output.text) || ''; } catch {}
+              let findings = [];
+              try { findings = JSON.parse(text); } catch {}
+              if (Array.isArray(findings)) for (const f of findings) if (f && typeof f === 'object') prior.push({ ...f, lens });
+            }
+            fs.writeFileSync('/tmp/prior-findings.json', JSON.stringify(prior));
+            core.info(`prior findings carried into on-demand review: ${prior.length}`);
+
       - name: Run review panel
         id: panel
         # A crash must not fail the job — the aggregate step below then posts a
@@ -256,11 +301,14 @@ jobs:
         continue-on-error: true
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        # --prior-findings is tolerant of a missing file (existsSync guard in
+        # review-panel.mjs → treated as []), so a skipped/failed read step is safe.
         run: >-
           node .trusted/scripts/agent/review-panel.mjs
           --diff-file /tmp/pr.diff
           --issue-file /tmp/issue.txt
           --changed-files /tmp/changed.txt
+          --prior-findings /tmp/prior-findings.json
           --repo "$GITHUB_WORKSPACE"
           --lenses-dir .trusted/scripts/agent/lenses
           --out .agent-review

--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -278,7 +278,12 @@ jobs:
               const runs = await github.paginate(github.rest.checks.listForRef, { owner, repo, ref: c.sha, per_page: 100 });
               for (const r of runs) {
                 if (!wantNames.has(r.name) || !r.app || r.app.slug !== 'github-actions') continue;
-                const t = new Date(r.started_at || 0).getTime();
+                // Only COMPLETED runs carry final findings in output.text — an
+                // in-progress/queued run (e.g. a panel round running right now) has
+                // a newer started_at but no findings yet, and would otherwise shadow
+                // the last completed run. Rank by completed_at (fallback started_at).
+                if (r.status !== 'completed') continue;
+                const t = new Date(r.completed_at || r.started_at || 0).getTime();
                 if (!latest[r.name] || t > latest[r.name].t) latest[r.name] = { id: r.id, t };
               }
             }


### PR DESCRIPTION
## Summary

Aligns the on-demand `@claude review` with the autonomous gate on **carried-forward
findings**. The review now reads the latest `agent-review-<lens>` check-run findings
for the PR and passes them to `review-panel.mjs` via `--prior-findings`, so it
re-checks prior blocking findings the same way the gate does.

## Why

On **#548** the two panels disagreed on the *same commit*: the autonomous panel's
`agent-review-test-adequacy` check was **failure (2 major)** while the on-demand
`@claude review` comment said **approved**. Cause: the autonomous panel carries the
previous round's blocking findings forward (`--prior-findings`) and keeps any not
confidently resolved (biased fail-toward-blocking), whereas the on-demand review ran
a fresh, stateless pass with no priors — so a finding the gate was still holding open
looked "resolved" in the advisory comment.

## What changed

`agent-review-on-demand.yml`, `review` job:
- New **Read prior findings** step (same logic as `agent-review-panel.yml`): finds
  the latest `agent-review-<lens>` check run across the PR's commits, parses the
  blocking findings JSON from each `output.text`, writes `/tmp/prior-findings.json`.
- Passes `--prior-findings /tmp/prior-findings.json` to `review-panel.mjs`
  (`existsSync`-guarded there, so a skipped/empty read is safe).
- Adds `checks: read` to the job — **read only**; this review still records **no**
  check runs, so it only *reads* priors and never contributes new ones.

Best-effort and empty for non-agent PRs (no prior panel history) → a normal fresh
review. Everything reads with `GITHUB_TOKEN` (reads work on fork PRs).

## Verification

- YAML parses; `review` job perms are `contents/pull-requests/checks: read`,
  `issues: write`.
- **Effective after merge** (issue_comment workflows run the default-branch version).
  End-to-end check: `@claude review` on an agent-managed PR that has an open
  `agent-review-<lens>` failure should now reflect that carried-forward finding
  instead of showing green.

## Risk

- Read-only addition (`checks: read`); no new write surface. The review remains
  advisory (no check runs, no promote/fix).

## Notes for Reviewers

**AI assistance:** authored with Claude Code, reviewed line-by-line. Diagnosed from
the #548 check-run vs comment divergence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On-demand advisory reviews now consider findings from previous review checks.
  * Review results can re-evaluate earlier blocking findings for improved continuity.

* **Improvements**
  * The workflow can now read prior check results while maintaining advisory-only behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->