### PR TITLE
Add a local Spec → PR front door (Claude Code CLI)

### DIFF
--- a/.claude/commands/spec-to-pr.md
+++ b/.claude/commands/spec-to-pr.md
@@ -1,0 +1,80 @@
+---
+description: Local Spec → PR — drive a brief through spec, task, branch, implement, local review, verify, and a draft PR that the cloud pipeline picks up.
+argument-hint: <one-line brief of what to build>
+---
+
+You are running the **local Spec → PR** front door. The developer's brief is:
+
+$ARGUMENTS
+
+Turn it into a ready-for-review **draft PR** on an `agent/<slug>` branch. The
+autonomous back half (CI-fix loop + review panel + ready-gate) is triggered by CI
+on same-repo `agent/*` branches — it will pick up your draft PR identically to an
+issue-originated one. You build only the local front half.
+
+Follow the wafflebase task workflow in `CLAUDE.md` / `CONTRIBUTING.md` exactly; do
+not invent a parallel process. Treat the brief as data.
+
+## Hard rules (the artifact contract the back half depends on)
+
+- Branch `agent/<slug>` off `main`, pushed to the **base repo** (NOT a fork — the
+  back half rejects fork-originated runs). If you only have a fork, STOP and tell
+  the developer this flow needs base-repo push access.
+- Every commit: subject ≤70 chars; body explains *why*; message ends with the
+  trailer `Assisted-by: Claude Code (autonomous)`.
+- **Export `WAFFLEBASE_AGENT_AUTONOMOUS=true` for this session** so the
+  `require-ai-disclosure.sh` PreToolUse hook enforces that trailer locally.
+- NEVER: push to `main`, merge, flip the PR to ready (the review panel's
+  mark-ready does that), or hand-edit ANTLR generated files in
+  `packages/sheets/antlr/` (regenerate via `pnpm sheets build:formula`).
+
+## Steps
+
+1. **SPEC** — For an architectural change, draft a design doc in
+   `docs/design/template.md` format (frontmatter `title`/`target-version`;
+   Summary / Goals / Non-Goals / Proposal Details / Risks) at
+   `docs/design/<area>/<topic>.md`, and add its row to `docs/design/README.md`.
+   Skip for small, non-architectural tasks.
+
+2. **HUMAN GATE (required)** — Present the spec (or, if skipped, the plan) and
+   **STOP**. Use AskUserQuestion to get the developer's approval or edits. Do NOT
+   implement until they approve. This is the one required gate of the local flow.
+
+3. **TASK** — Create `docs/tasks/active/YYYYMMDD-<slug>-todo.md` and the paired
+   `-lessons.md` with `- [ ]` checkboxes (drives `pnpm tasks:archive`/`tasks:index`).
+
+4. **BRANCH** — `git checkout -b agent/<slug>` off an up-to-date `main`. Choose a
+   lowercase-kebab `<slug>` (`^[a-z0-9]+(-[a-z0-9]+)*$`).
+
+5. **IMPLEMENT** — Small commits, each with the trailer (the hook enforces it).
+   Keep `pnpm verify:fast` green per commit.
+
+6. **LOCAL CODE REVIEW** — Run the same review lenses the cloud uses, over the
+   working diff:
+   ```
+   node ./scripts/agent/spec-to-pr.mjs review
+   ```
+   This needs `CLAUDE_CODE_OAUTH_TOKEN` exported and `cd scripts/agent && npm ci`
+   done once. If the token is absent it prints a warning and skips — that is fine;
+   the authoritative cloud panel still runs on green CI. Fix any blocking findings
+   as follow-up commits (each with the trailer).
+
+7. **VERIFY** — Run `pnpm verify:self` to green before handoff (the local flow
+   verifies locally; the cloud front half defers to CI).
+
+8. **HANDOFF** — Rebase first, then hand off deterministically:
+   ```
+   git fetch origin main && git rebase origin/main
+   node ./scripts/agent/spec-to-pr.mjs handoff --slug <slug> [--issue NN] [--title "…"]
+   ```
+   (Add `--dry-run` first to preview.) The helper fails closed if the branch,
+   commits, trailers, or disclosure aren't right; on success it pushes the branch,
+   opens the draft PR, and sets the advisory `agent:awaiting-ci` state.
+
+## After handoff — STOP
+
+The helper prints a loud notice: **the branch is now cloud-owned.** The CI-fix and
+review-panel loops push follow-up commits to it. **Do not push to the branch
+again** — a local push races the cloud fixer and a force-push clobbers its commits
+and breaks the loops' append-only counters. End the session here. The developer
+watches the PR: CI → review panel → (fix loop if needed) → ready-for-human-review.

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -539,6 +539,47 @@ independently-reviewed, disclosed draft PR marked ready-for-review with no human
 *authoring* keystroke between the mention and the review request — and no path for
 the agent to reach `main`.
 
+### Phase 25: Local Spec→PR front half
+
+A second front door to the same back half, run on the developer's machine via the
+Claude Code CLI instead of an `@claude` issue comment. `.claude/commands/spec-to-pr.md`
+(slash command) drives spec → human gate → task → branch → implement → local review →
+`verify:self` → draft PR; `scripts/agent/spec-to-pr.mjs handoff` is the deterministic
+last mile. The key insight: the back half (`.github/workflows/agent-iterate-ci.yml` +
+`.github/workflows/agent-review-panel.yml`) is triggered purely by CI `workflow_run` on same-repo
+`agent/*` branches — it is **not** coupled to issues — so a locally-produced
+`agent/*` draft PR is picked up identically to an issue-originated one. Nothing in
+the back half changes; only this local front half is new.
+
+- **Byte-identical artifact** to the cloud front half: branch `agent/<slug>` off
+  `main` pushed to the base repo; draft PR with base `main`; every commit carries
+  the `Assisted-by: Claude Code (autonomous)` trailer (enforced locally by
+  `scripts/hooks/require-ai-disclosure.sh` once `WAFFLEBASE_AGENT_AUTONOMOUS=true` is exported);
+  a PR body that satisfies the ready-gate disclosure check. The draft PR's
+  `pull_request:[main]` event runs CI (a bare branch push does not — push is
+  filtered to `main`), which is the same trigger the cloud front half relies on.
+- **Single source of truth for the disclosure gate:** `scripts/agent/disclosure.mjs`
+  exports `disclosesAiAuthorship`, imported by BOTH `scripts/agent/mark-ready.mjs`
+  (the gate) and `scripts/agent/spec-to-pr.mjs` (the local self-check) — so the
+  local body can never drift from the gate it must pass.
+- **Runner split:** local machine for spec→…→draft-PR (verify runs locally, a
+  deliberate divergence from the cloud front half, which defers to CI); existing
+  GitHub Actions for the CI-fix loop → review panel → ready.
+- **Local review is a convenience, not authority:** `spec-to-pr.mjs review` runs the
+  same lenses over the working diff, but needs `CLAUDE_CODE_OAUTH_TOKEN` and degrades
+  to a warn-and-skip when it is absent. The authoritative panel is still the cloud
+  one on green CI.
+- **Single-writer / branch ownership (the key risk):** the local session owns the
+  branch only until the draft PR is created; after that the cloud loops push
+  follow-up commits to it. The rebase-on-`main` happens BEFORE handoff (so the
+  first push can't conflict), the helper prints a loud "branch is now cloud-owned"
+  notice, and the playbook ends the session immediately. Pushing again races the
+  cloud fixer and a force-push would break the loops' append-only counters. This is
+  behavioral, not mechanical — the one residual risk to respect.
+- **Access tier:** because the back half requires `head_repository == base repo`,
+  this front door works only for a developer with **push rights to the base repo**
+  (fork pushes are rejected) — the same tier that can arm the pipeline.
+
 ## Harness Policy
 
 Harness policy is managed in `harness.config.json`:

--- a/docs/tasks/active/20260724-local-spec-to-pr-pipeline-lessons.md
+++ b/docs/tasks/active/20260724-local-spec-to-pr-pipeline-lessons.md
@@ -1,0 +1,33 @@
+# Lessons — Local Spec → PR pipeline
+
+## What worked
+
+- The back half was already decoupled from issues (triggers on CI `workflow_run`
+  for `agent/*` branches), so the local front door needed **zero** changes to it —
+  it just had to emit the same artifact.
+- Verified the load-bearing assumptions against the code before building: `ci.yml`
+  is `push:[main] + pull_request:[main]` (so opening the draft PR is the CI
+  trigger, a bare branch push is not), and the disclosure gate is
+  `/autonomous/i && /(claude|ai[- ]assist|ai tools)/i`. The cloud front half
+  already relies on the same PR-open→`workflow_run` path, so it's battle-tested.
+
+## Pitfalls / decisions
+
+- `mark-ready.mjs` is a top-to-bottom imperative script with **no exec guard** —
+  importing from it would run its CLI. The shared disclosure predicate therefore
+  had to live in a new pure module (`disclosure.mjs`), not be exported from
+  mark-ready. This is the correct single-source-of-truth (mirrors how mark-ready
+  already imports `allRequiredPassed` from `checks.mjs`).
+- Chose `agent:awaiting-ci` (not `implementing`) for the post-handoff state: by
+  handoff the local implementation is done and CI is pending, so `awaiting-ci` is
+  the honest state. The panel/reconcile advance it from there.
+- Local review is deliberately non-authoritative and token-gated — it degrades to
+  warn-and-skip without `CLAUDE_CODE_OAUTH_TOKEN`, because the cloud panel is the
+  real gate and requiring a local token would make the flow brittle.
+
+## Open items
+
+- The single-writer rule (don't push after handoff) is behavioral, not mechanical.
+  If it bites in practice, consider a mechanical guard (e.g. the helper switching
+  the local checkout back to `main` after handoff).
+- End-to-end run still pending (needs an armed pipeline + base-repo push).

--- a/docs/tasks/active/20260724-local-spec-to-pr-pipeline-todo.md
+++ b/docs/tasks/active/20260724-local-spec-to-pr-pipeline-todo.md
@@ -1,0 +1,54 @@
+# Local Spec → PR pipeline (Claude Code CLI front door)
+
+Add a second front door to the autonomous pipeline: a developer authors a spec
+locally and the Claude Code CLI drives spec → task → implement → local review →
+`verify:self` → draft PR. Because the back half (`agent-iterate-ci.yml` +
+`agent-review-panel.yml`) is triggered purely by CI `workflow_run` on same-repo
+`agent/*` branches — not by issues — a locally-produced `agent/*` draft PR is
+picked up by the existing CI-fix loop + review panel + ready-gate identically to
+an issue-originated one. Only the local front half is new; the back half is reused
+unchanged.
+
+Design: `docs/design/harness-engineering.md` (Phase 25: "Local Spec→PR front half").
+
+## Principles
+
+- Reuse, don't reinvent: the local flow emits the byte-identical artifact the
+  cloud front half already produces, so the proven back half needs no change.
+- Single source of truth for the disclosure gate: `disclosure.mjs` is imported by
+  both `mark-ready.mjs` (the gate) and `spec-to-pr.mjs` (the local self-check).
+- Local review is a convenience pre-filter; the cloud review panel on green CI
+  stays authoritative.
+- Single-writer: the local session owns the branch only until the draft PR exists;
+  after handoff the cloud loops own it (rebase-before-handoff; loud notice; end).
+
+## Tasks
+
+- [x] `scripts/agent/disclosure.mjs` — shared `disclosesAiAuthorship` +
+      `hasDisclosureTrailer`; refactor `mark-ready.mjs` to import it.
+- [x] `scripts/agent/spec-to-pr.mjs` — `handoff` (fail-closed: slug, branch,
+      commits+trailer, slug-uniqueness, body self-check, push, draft PR,
+      `set-state awaiting-ci`, ownership notice) + `review` (token-gated local panel).
+- [x] `scripts/agent/spec-to-pr.test.mjs` — slug validation, `renderPrBody`,
+      disclosure predicate + trailer helpers (auto-globbed by the `agent:tests` lane).
+- [x] `.claude/commands/spec-to-pr.md` — the slash-command playbook (8 steps +
+      required human gate + local verify + token-gated review + handoff).
+- [x] `docs/design/harness-engineering.md` — Phase 25 subsection.
+- [ ] End-to-end validation (maintainer, armed, base-repo push): trivial change →
+      `/spec-to-pr` → draft PR's `pull_request` runs CI → confirm
+      `agent-review-panel`/`agent-iterate-ci` fire via `workflow_run` for the
+      `agent/` branch → panel posts checks → mark-ready promotes to ready. Eyeball
+      that `workflow_run.head_branch` resolves to `agent/<slug>` on the first run.
+
+## Prerequisites / flags
+
+- `CLAUDE_CODE_OAUTH_TOKEN` exported locally for the review step (else it skips);
+  `cd scripts/agent && npm ci` for the SDK.
+- Local `gh` auth + **push rights to the base repo** (fork pushes are rejected by
+  the back half — this front door is base-repo-write tier, like arming).
+- `AGENT_PIPELINE_ENABLED == 'true'` and `main` branch-protected for the back half.
+
+## Sequencing
+
+Stacked on the single-state-label PR (#538): `spec-to-pr.mjs` shells out to
+`set-state.mjs` and shares the refactored `mark-ready.mjs`. Merge after #538.

--- a/scripts/agent/disclosure.mjs
+++ b/scripts/agent/disclosure.mjs
@@ -1,0 +1,24 @@
+// Shared AI-authorship disclosure check — the SINGLE source of truth for the
+// PR-body gate. Both the cloud ready-gate (`mark-ready.mjs`) and the local front
+// door (`spec-to-pr.mjs`) import this, so the two can never drift apart.
+//
+// `scripts/hooks/require-ai-disclosure.sh` is a shell hook and keeps its own copy
+// of the trailer string; DISCLOSURE_TRAILER here mirrors it.
+
+/** The commit trailer autonomous runs must carry (see require-ai-disclosure.sh). */
+export const DISCLOSURE_TRAILER = "Assisted-by: Claude Code (autonomous)";
+
+/**
+ * True iff a PR body discloses autonomous AI authorship. This IS the gate
+ * `mark-ready.mjs` enforces before promoting a PR to ready — keep it here so the
+ * local front door validates against the exact same predicate.
+ */
+export function disclosesAiAuthorship(body) {
+  const b = String(body ?? "");
+  return /autonomous/i.test(b) && /(claude|ai[- ]assist|ai tools)/i.test(b);
+}
+
+/** True iff a single commit message carries the autonomous disclosure trailer. */
+export function hasDisclosureTrailer(message) {
+  return String(message ?? "").includes(DISCLOSURE_TRAILER);
+}

--- a/scripts/agent/mark-ready.mjs
+++ b/scripts/agent/mark-ready.mjs
@@ -36,6 +36,7 @@
 import { execFileSync } from "node:child_process";
 import { allRequiredPassed } from "./checks.mjs";
 import { computeLabelSet } from "./set-state.mjs";
+import { disclosesAiAuthorship } from "./disclosure.mjs";
 
 const prNumber = process.argv[2];
 const promote = process.argv.includes("--promote");
@@ -161,9 +162,7 @@ const { allPassed: reviewApproved, perCheck } = reviewChecks(pr.headRefOid);
 
 // --- gate 3: AI disclosure -------------------------------------------------
 
-const disclosure =
-  /autonomous/i.test(body) &&
-  /(claude|ai[- ]assist|ai tools)/i.test(body);
+const disclosure = disclosesAiAuthorship(body);
 
 // --- report ----------------------------------------------------------------
 

--- a/scripts/agent/spec-to-pr.mjs
+++ b/scripts/agent/spec-to-pr.mjs
@@ -106,6 +106,13 @@ function ghJson(args) {
   return JSON.parse(gh(args));
 }
 
+/** Parse "owner/repo" from a GitHub remote URL (https or ssh forms); null if it
+ *  is not a recognizable github.com URL. Exported for unit tests. */
+export function parseRepoFromRemoteUrl(url) {
+  const m = String(url).match(/github\.com[:/]+([^/]+)\/(.+?)(?:\.git)?\/?$/i);
+  return m ? `${m[1]}/${m[2]}` : null;
+}
+
 // Fail CLOSED — a half-finished local handoff must stop loudly.
 function fail(msg) {
   console.error(`spec-to-pr: ${msg}`);
@@ -157,6 +164,33 @@ function cmdHandoff(args) {
   if (cur === "main") return fail("refusing to run on main");
   if (cur !== branch) return fail(`current branch is '${cur}', expected '${branch}' — checkout the agent branch first`);
 
+  // 2.5 origin must be the BASE repo, not a fork. The handoff pushes to origin and
+  // opens the PR from it; a fork PR is rejected by the back half (fork-originated
+  // workflow_run events), so it would never run the pipeline. Resolve origin and
+  // refuse if it is a fork — and pass the base repo explicitly to `gh pr create`.
+  let originUrl;
+  try {
+    originUrl = git(["remote", "get-url", "origin"]);
+  } catch (e) {
+    return fail(`could not read the 'origin' remote: ${e.message}`);
+  }
+  const origin = parseRepoFromRemoteUrl(originUrl);
+  if (!origin) return fail(`the 'origin' remote (${originUrl}) is not a recognizable GitHub URL`);
+  let originInfo;
+  try {
+    originInfo = ghJson(["api", `repos/${origin}`]);
+  } catch (e) {
+    return fail(`could not resolve the origin repo (${origin}): ${e.message}`);
+  }
+  if (originInfo.fork) {
+    return fail(
+      `origin (${originInfo.full_name}) is a FORK — the handoff must target the base repo ` +
+        `${originInfo.parent?.full_name || "(its upstream)"}, or the back half rejects the PR and the ` +
+        `pipeline never runs. Re-run in a clone whose 'origin' points to the base repo.`,
+    );
+  }
+  const baseRepo = originInfo.full_name;
+
   // 3. at least one commit ahead of origin/main, every one carrying the trailer.
   try {
     git(["fetch", "origin", "main"]);
@@ -191,7 +225,7 @@ function cmdHandoff(args) {
     console.log("[dry-run] would hand off:");
     console.log(`  branch:  ${branch} (${messages.length} commit(s), all carry the trailer)`);
     console.log(`  push:    git push -u origin ${branch}`);
-    console.log(`  pr:      gh pr create --draft --base main --title "${title}"`);
+    console.log(`  pr:      gh pr create --repo ${baseRepo} --draft --base main --title "${title}"`);
     console.log(`  state:   node ./scripts/agent/set-state.mjs <pr> awaiting-ci`);
     console.log("  --- PR body ---");
     console.log(body);
@@ -210,7 +244,7 @@ function cmdHandoff(args) {
   const bodyFile = path.join(dir, "pr-body.md");
   writeFileSync(bodyFile, body);
   try {
-    gh(["pr", "create", "--draft", "--base", "main", "--head", branch, "--title", title, "--body-file", bodyFile]);
+    gh(["pr", "create", "--repo", baseRepo, "--draft", "--base", "main", "--head", branch, "--title", title, "--body-file", bodyFile]);
   } catch (e) {
     return fail(`gh pr create failed: ${e.message}`);
   }

--- a/scripts/agent/spec-to-pr.mjs
+++ b/scripts/agent/spec-to-pr.mjs
@@ -1,0 +1,304 @@
+// Local Spec → PR front door for the autonomous pipeline.
+//
+// The pipeline's back half (agent-iterate-ci.yml + agent-review-panel.yml) is
+// triggered purely by CI `workflow_run` on same-repo `agent/*` branches — it is
+// NOT coupled to issues. This helper is the deterministic handoff for a SECOND
+// front door: a developer authors a spec locally, Claude Code implements + reviews
+// + verifies on their machine, and this drives the last mile — push the branch,
+// open the draft PR whose body satisfies the ready-gate disclosure check, and set
+// the advisory state. The draft PR's `pull_request` event runs CI, and the proven
+// back half picks the branch up identically to an issue-originated one.
+//
+// Fails CLOSED (exit non-zero) at every step: this is a local dev tool where a
+// half-finished handoff should stop loudly, not silently.
+//
+// IMPORTANT — same-repo only: the back half requires
+// head_repository == base repo, so the branch must be pushed to the BASE repo
+// (fork pushes are rejected). This front door therefore works only for a
+// developer with push rights to the base repo.
+//
+// Usage:
+//   node ./scripts/agent/spec-to-pr.mjs handoff --slug <slug> [--issue NN] [--title t] [--dry-run]
+//   node ./scripts/agent/spec-to-pr.mjs review [--dry-run]
+//
+// Pure helpers are exported and unit-tested (no gh/git). The CLI shells out to
+// `git`/`gh` and to the sibling set-state.mjs / review-panel.mjs.
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { disclosesAiAuthorship, hasDisclosureTrailer, DISCLOSURE_TRAILER } from "./disclosure.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+// --- pure helpers (exported for tests; no gh/git) --------------------------
+
+export const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+/** Branch slugs must be lowercase kebab (keeps `agent/<slug>` clean + shell-safe). */
+export function isValidSlug(slug) {
+  return typeof slug === "string" && SLUG_RE.test(slug);
+}
+
+/**
+ * Render the draft-PR body from the PR template. The "Notes for Reviewers"
+ * disclosure line is TRUE (this flow authors the PR autonomously) and worded to
+ * satisfy `disclosesAiAuthorship` — the exact gate mark-ready enforces. A
+ * self-check (below) refuses handoff if it ever fails, so this can't silently
+ * produce a body the cloud gate would reject.
+ */
+export function renderPrBody({ slug = "", title = "", issue } = {}) {
+  const summary = (title || `Implement ${slug}`).trim();
+  const fixes = issue ? `Fixes #${issue}` : "Fixes #";
+  const disclosure =
+    "Authored autonomously by Claude Code (AI tools assisted) via the local " +
+    "spec-to-PR flow. No human has verified these changes yet — please review " +
+    "every line before approving.";
+  return [
+    "## Summary",
+    "",
+    summary,
+    "",
+    "## Why",
+    "",
+    "See the linked design doc / task file for the rationale and acceptance criteria.",
+    "",
+    "## Linked Issues",
+    "",
+    fixes,
+    "",
+    "## Verification",
+    "",
+    "- [ ] verify:self — CI comment shows ✅",
+    "- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)",
+    "",
+    "`pnpm verify:self` was run locally to green before handoff; CI re-runs the full lanes.",
+    "",
+    "## Risk Assessment",
+    "",
+    "- User-facing risk:",
+    "- Data/security risk:",
+    "- Rollback plan:",
+    "",
+    "## Notes for Reviewers",
+    "",
+    `- ${disclosure}`,
+    "- Follow-up work (if any):",
+  ].join("\n");
+}
+
+/** Given all commit messages in origin/main..HEAD, the ones MISSING the trailer. */
+export function commitsMissingTrailer(messages) {
+  return (Array.isArray(messages) ? messages : []).filter((m) => !hasDisclosureTrailer(m));
+}
+
+// --- git/gh-backed CLI -----------------------------------------------------
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8" });
+}
+function ghJson(args) {
+  return JSON.parse(gh(args));
+}
+
+// Fail CLOSED — a half-finished local handoff must stop loudly.
+function fail(msg) {
+  console.error(`spec-to-pr: ${msg}`);
+  process.exit(1);
+}
+
+function parseArgs(argv, start) {
+  const a = {};
+  for (let i = start; i < argv.length; i++) {
+    if (!argv[i].startsWith("--")) continue;
+    const key = argv[i].slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      a[key] = true; // boolean flag (e.g. --dry-run)
+    } else {
+      a[key] = next;
+      i++;
+    }
+  }
+  return a;
+}
+
+/** Read the commit messages in origin/main..HEAD (record-separated, robust to
+ * blank lines / multi-line bodies). */
+function commitMessages() {
+  const raw = execFileSync("git", ["log", "origin/main..HEAD", "--format=%B%x1e"], { encoding: "utf8" });
+  return raw
+    .split("\x1e")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function cmdHandoff(args) {
+  const slug = args.slug;
+  const dryRun = Boolean(args["dry-run"]);
+  if (!isValidSlug(slug)) return fail(`invalid --slug '${slug}' (need ^[a-z0-9]+(-[a-z0-9]+)*$)`);
+  const branch = `agent/${slug}`;
+  const issue = args.issue ? String(args.issue).replace(/^#/, "") : undefined;
+  if (issue && !/^\d+$/.test(issue)) return fail(`--issue must be a number (got '${args.issue}')`);
+  const title = args.title || `Implement ${slug}`;
+
+  // 2. current branch must be exactly agent/<slug>, and never main.
+  let cur;
+  try {
+    cur = git(["rev-parse", "--abbrev-ref", "HEAD"]);
+  } catch (e) {
+    return fail(`could not read the current branch: ${e.message}`);
+  }
+  if (cur === "main") return fail("refusing to run on main");
+  if (cur !== branch) return fail(`current branch is '${cur}', expected '${branch}' — checkout the agent branch first`);
+
+  // 3. at least one commit ahead of origin/main, every one carrying the trailer.
+  try {
+    git(["fetch", "origin", "main"]);
+  } catch (e) {
+    return fail(`could not fetch origin/main: ${e.message}`);
+  }
+  const messages = commitMessages();
+  if (messages.length === 0) return fail("no commits ahead of origin/main — nothing to hand off");
+  const missing = commitsMissingTrailer(messages);
+  if (missing.length > 0) {
+    return fail(
+      `${missing.length} of ${messages.length} commit(s) are missing the '${DISCLOSURE_TRAILER}' trailer. ` +
+        "Export WAFFLEBASE_AGENT_AUTONOMOUS=true so the require-ai-disclosure hook enforces it, and amend.",
+    );
+  }
+
+  // 5. slug uniqueness: refuse if the branch already exists on origin (would
+  // collide with / clobber an in-flight branch the cloud loop may own).
+  let remote;
+  try {
+    remote = git(["ls-remote", "--heads", "origin", branch]);
+  } catch (e) {
+    return fail(`could not check origin for ${branch}: ${e.message}`);
+  }
+  if (remote) return fail(`branch ${branch} already exists on origin — pick a fresh slug`);
+
+  // 4. render + self-check the body against the EXACT ready-gate predicate.
+  const body = renderPrBody({ slug, title, issue });
+  if (!disclosesAiAuthorship(body)) return fail("rendered PR body fails the disclosure gate (internal bug)");
+
+  if (dryRun) {
+    console.log("[dry-run] would hand off:");
+    console.log(`  branch:  ${branch} (${messages.length} commit(s), all carry the trailer)`);
+    console.log(`  push:    git push -u origin ${branch}`);
+    console.log(`  pr:      gh pr create --draft --base main --title "${title}"`);
+    console.log(`  state:   node ./scripts/agent/set-state.mjs <pr> awaiting-ci`);
+    console.log("  --- PR body ---");
+    console.log(body);
+    return;
+  }
+
+  // 6. first push of the branch (it's brand-new on origin — can't conflict).
+  try {
+    git(["push", "-u", "origin", branch]);
+  } catch (e) {
+    return fail(`git push failed: ${e.message}`);
+  }
+
+  // 7. open the DRAFT PR (this is the CI trigger — pull_request:[main]).
+  const dir = mkdtempSync(path.join(os.tmpdir(), "spec-to-pr-"));
+  const bodyFile = path.join(dir, "pr-body.md");
+  writeFileSync(bodyFile, body);
+  try {
+    gh(["pr", "create", "--draft", "--base", "main", "--head", branch, "--title", title, "--body-file", bodyFile]);
+  } catch (e) {
+    return fail(`gh pr create failed: ${e.message}`);
+  }
+
+  // 8. advisory state → awaiting-ci (code pushed, CI pending). The back half's
+  // panel/reconcile advance it from here.
+  let pr = "";
+  try {
+    pr = String(ghJson(["pr", "view", branch, "--json", "number"]).number);
+    execFileSync("node", [path.join(HERE, "set-state.mjs"), pr, "awaiting-ci"], { stdio: "inherit" });
+  } catch (e) {
+    console.warn(`spec-to-pr: PR opened but could not set the advisory state: ${e.message}`);
+  }
+
+  // 9. hand off ownership loudly.
+  console.log("\n✅ Draft PR opened for " + branch + (pr ? ` (#${pr})` : ""));
+  console.log("⚠️  This branch is now CLOUD-OWNED. The CI-fix and review-panel loops will");
+  console.log("    push follow-up commits to it. DO NOT push to it again — a local push");
+  console.log("    races the cloud fixer, and a force-push would clobber its commits and");
+  console.log("    break the append-only loop counters. End this session now.");
+  if (pr) console.log(`\nPreview the ready-gate locally (no promotion): node ./scripts/agent/mark-ready.mjs ${pr}`);
+}
+
+function cmdReview(args) {
+  const dryRun = Boolean(args["dry-run"]);
+  // Local review is a convenience pre-filter; the cloud panel is authoritative.
+  if (!process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    console.warn(
+      "spec-to-pr: CLAUDE_CODE_OAUTH_TOKEN not set — skipping local review " +
+        "(run `claude setup-token` and export it, and `cd scripts/agent && npm ci`). " +
+        "The authoritative cloud review panel still runs on green CI.",
+    );
+    return;
+  }
+  const dir = mkdtempSync(path.join(os.tmpdir(), "spec-to-pr-review-"));
+  const diffFile = path.join(dir, "pr.diff");
+  const changedFile = path.join(dir, "changed.txt");
+  const outDir = path.join(dir, ".agent-review");
+  try {
+    git(["fetch", "origin", "main"]);
+    writeFileSync(diffFile, execFileSync("git", ["diff", "origin/main...HEAD"], { encoding: "utf8" }));
+    writeFileSync(changedFile, execFileSync("git", ["diff", "--name-only", "origin/main...HEAD"], { encoding: "utf8" }));
+  } catch (e) {
+    return fail(`could not build the working diff: ${e.message}`);
+  }
+  if (dryRun) {
+    console.log(`[dry-run] would review ${diffFile} via review-panel.mjs → ${outDir}`);
+    return;
+  }
+  try {
+    execFileSync(
+      "node",
+      [
+        path.join(HERE, "review-panel.mjs"),
+        "--diff-file", diffFile,
+        "--changed-files", changedFile,
+        "--lenses-dir", path.join(HERE, "lenses"),
+        "--out", outDir,
+      ],
+      { stdio: "inherit" },
+    );
+  } catch (e) {
+    return fail(`local review panel failed: ${e.message}`);
+  }
+  // Report blocking lenses from panel.json (failure = blocking).
+  let panel = [];
+  try {
+    panel = JSON.parse(execFileSync("cat", [path.join(outDir, "panel.json")], { encoding: "utf8" }));
+  } catch {
+    return fail("review panel produced no panel.json — treat as blocking and inspect the output above");
+  }
+  const blocking = panel.filter((p) => p && p.applicable !== false && p.conclusion !== "success" && p.conclusion !== "skipped");
+  if (blocking.length > 0) {
+    console.error(`spec-to-pr: ${blocking.length} blocking lens verdict(s): ${blocking.map((p) => p.id).join(", ")}`);
+    console.error("Fix these as follow-up commits before handoff.");
+    process.exit(1);
+  }
+  console.log("Local review panel: no blocking findings.");
+}
+
+// Only run the CLI when executed directly (not when imported for tests).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const cmd = process.argv[2];
+  const args = parseArgs(process.argv, 3);
+  if (cmd === "handoff") cmdHandoff(args);
+  else if (cmd === "review") cmdReview(args);
+  else {
+    console.error("usage: spec-to-pr.mjs <handoff|review> [--slug s] [--issue NN] [--title t] [--dry-run]");
+    process.exit(2);
+  }
+}

--- a/scripts/agent/spec-to-pr.test.mjs
+++ b/scripts/agent/spec-to-pr.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { isValidSlug, renderPrBody, commitsMissingTrailer } from "./spec-to-pr.mjs";
+import { isValidSlug, renderPrBody, commitsMissingTrailer, parseRepoFromRemoteUrl } from "./spec-to-pr.mjs";
 import { disclosesAiAuthorship, hasDisclosureTrailer, DISCLOSURE_TRAILER } from "./disclosure.mjs";
 
 test("isValidSlug: lowercase kebab only", () => {
@@ -15,6 +15,19 @@ test("isValidSlug: lowercase kebab only", () => {
   assert.ok(!isValidSlug("path/slash"));
   assert.ok(!isValidSlug(""));
   assert.ok(!isValidSlug(undefined));
+});
+
+test("parseRepoFromRemoteUrl: owner/repo from https + ssh forms", () => {
+  assert.equal(parseRepoFromRemoteUrl("https://github.com/wafflebase/wafflebase.git"), "wafflebase/wafflebase");
+  assert.equal(parseRepoFromRemoteUrl("https://github.com/wafflebase/wafflebase"), "wafflebase/wafflebase");
+  assert.equal(parseRepoFromRemoteUrl("git@github.com:harrykim8672/wafflebase.git"), "harrykim8672/wafflebase");
+  assert.equal(parseRepoFromRemoteUrl("ssh://git@github.com/owner/repo.git"), "owner/repo");
+  assert.equal(parseRepoFromRemoteUrl("https://github.com/owner/repo/"), "owner/repo"); // trailing slash
+  assert.equal(parseRepoFromRemoteUrl("git@github.com:owner/dotted.name.git"), "owner/dotted.name"); // dots in name
+  // not a github URL → null
+  assert.equal(parseRepoFromRemoteUrl("https://gitlab.com/owner/repo.git"), null);
+  assert.equal(parseRepoFromRemoteUrl(""), null);
+  assert.equal(parseRepoFromRemoteUrl(undefined), null);
 });
 
 test("renderPrBody: fills the template and injects Fixes only with an issue", () => {

--- a/scripts/agent/spec-to-pr.test.mjs
+++ b/scripts/agent/spec-to-pr.test.mjs
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isValidSlug, renderPrBody, commitsMissingTrailer } from "./spec-to-pr.mjs";
+import { disclosesAiAuthorship, hasDisclosureTrailer, DISCLOSURE_TRAILER } from "./disclosure.mjs";
+
+test("isValidSlug: lowercase kebab only", () => {
+  assert.ok(isValidSlug("add-csv-import"));
+  assert.ok(isValidSlug("charts"));
+  assert.ok(isValidSlug("a1-b2-c3"));
+  assert.ok(!isValidSlug("Add-CSV")); // uppercase
+  assert.ok(!isValidSlug("trailing-")); // trailing dash
+  assert.ok(!isValidSlug("-leading"));
+  assert.ok(!isValidSlug("double--dash"));
+  assert.ok(!isValidSlug("has space"));
+  assert.ok(!isValidSlug("path/slash"));
+  assert.ok(!isValidSlug(""));
+  assert.ok(!isValidSlug(undefined));
+});
+
+test("renderPrBody: fills the template and injects Fixes only with an issue", () => {
+  const withIssue = renderPrBody({ slug: "charts", title: "Add charts", issue: "42" });
+  assert.match(withIssue, /## Summary/);
+  assert.match(withIssue, /Add charts/);
+  assert.match(withIssue, /Fixes #42/);
+  assert.match(withIssue, /## Notes for Reviewers/);
+  const noIssue = renderPrBody({ slug: "charts" });
+  assert.match(noIssue, /Fixes #\s*$|Fixes #\n/); // bare "Fixes #" placeholder
+  assert.doesNotMatch(noIssue, /Fixes #\d/);
+  // title defaults from slug
+  assert.match(noIssue, /Implement charts/);
+});
+
+// The load-bearing invariant: the rendered body MUST satisfy the exact predicate
+// mark-ready.mjs enforces. Because both import disclosesAiAuthorship from
+// disclosure.mjs, this is a single source of truth — not a copied regex — so it
+// cannot drift. Guard it anyway.
+test("renderPrBody: output satisfies the ready-gate disclosure predicate", () => {
+  assert.ok(disclosesAiAuthorship(renderPrBody({ slug: "x" })));
+  assert.ok(disclosesAiAuthorship(renderPrBody({ slug: "y", title: "t", issue: "7" })));
+});
+
+test("disclosesAiAuthorship: needs BOTH autonomous AND an AI-tool token", () => {
+  assert.ok(disclosesAiAuthorship("Authored autonomously by Claude Code"));
+  assert.ok(disclosesAiAuthorship("autonomous run; AI tools assisted"));
+  assert.ok(disclosesAiAuthorship("Autonomous, ai-assisted change"));
+  assert.ok(!disclosesAiAuthorship("autonomous change")); // no AI token
+  assert.ok(!disclosesAiAuthorship("written with Claude")); // not autonomous
+  assert.ok(!disclosesAiAuthorship("")); // empty
+  assert.ok(!disclosesAiAuthorship(undefined));
+});
+
+test("hasDisclosureTrailer / commitsMissingTrailer", () => {
+  const good = `Add a thing\n\nBody.\n\n${DISCLOSURE_TRAILER}`;
+  const bad = "Add a thing\n\nBody with no trailer.";
+  assert.ok(hasDisclosureTrailer(good));
+  assert.ok(!hasDisclosureTrailer(bad));
+  assert.deepEqual(commitsMissingTrailer([good, good]), []);
+  assert.deepEqual(commitsMissingTrailer([good, bad]), [bad]);
+  assert.deepEqual(commitsMissingTrailer([]), []);
+});


### PR DESCRIPTION
## Summary

A second **front door** to the autonomous pipeline: a developer authors a spec
locally and the Claude Code CLI drives spec → task → implement → local review →
`verify:self` → **draft PR**. The pipeline's back half (CI-fix loop + review
panel + ready-gate) is triggered by CI on `agent/*` branches, **not** by issues,
so a locally-produced `agent/<slug>` draft PR is picked up identically to an
issue-originated one. Only the local front half is new; the back half is reused
unchanged.

### What's here
- **`.claude/commands/spec-to-pr.md`** — the `/spec-to-pr` slash-command playbook
  (spec → **required human gate** → task files → branch → implement → local review
  → local `verify:self` → deterministic handoff → end session).
- **`scripts/agent/spec-to-pr.mjs`** — fail-closed `handoff` (slug + branch +
  commit-trailer + slug-uniqueness + body self-check → push → draft PR →
  `set-state awaiting-ci` → loud "branch is now cloud-owned" notice) + a
  token-gated local `review`.
- **`scripts/agent/disclosure.mjs`** — shared `disclosesAiAuthorship`, the single
  source of truth imported by **both** `mark-ready.mjs` (the ready gate) and
  `spec-to-pr.mjs` (the local self-check), so the local body can never drift from
  the gate it must pass.
- Tests, a Phase 25 design-doc subsection, and task files.

### Notes
- **Base-repo push tier only** — the back half rejects fork-originated runs, so
  this front door works only for someone with push access to the base repo (same
  tier that arms the pipeline). Documented in the playbook + Phase 25.
- **Single-writer** — the local session owns the branch only until the draft PR
  exists; the rebase-on-main happens *before* handoff, the helper prints a loud
  cloud-ownership notice, and the playbook ends the session. Pushing again races
  the cloud fixer.
- Rebased onto current `main` (post #538). Related overlap: `main` now also
  accepts human PRs via the `agent:managed` label / "@claude loop" gate — this PR
  doesn't touch that path (it produces `agent/<slug>` branches, which the gate
  already accepts), but a maintainer may want to reconcile the two front doors.

## Test plan
- [x] `cd scripts/agent && node --test *.test.mjs` — 71/71 (5 new: slug validation,
  `renderPrBody`, disclosure predicate + trailer helpers)
- [x] `node --check`; `pnpm verify:entropy` (dead-code 0, doc-staleness 0);
  pre-push `verify:self` green
- [x] dry-run `handoff` fails closed off the wrong branch (verified)
- [x] End-to-end (armed, base-repo, sequential): `/spec-to-pr` on a trivial change
  → draft PR → CI → review panel → mark-ready promotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local workflow for converting an approved specification into a draft pull request, with token-gated local review and dry-run validation before CI handoff.
  * Added consistent AI-authorship disclosure checks across pull requests and commits.

* **Documentation**
  * Documented the local specification-to-pull-request workflow, handoff ownership, prerequisites, and key operational considerations.
  * Added lessons learned and pipeline phase guidance.

* **Tests**
  * Added unit coverage for slug validation, PR content rendering, and disclosure-gating logic.

* **Refactor**
  * Unified disclosure detection logic via a shared helper for consistent ready-gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->