### PR TITLE
CODEOWNERS: own agent files by @wafflebase/maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,13 @@
 # approval is required to merge. Later matches win, so more specific paths
 # override the global default.
 #
-# ⚠️ EDIT THE OWNERS BELOW before enabling. Replace @hackerwins with the real
-# maintainer usernames or a team (e.g. @wafflebase/maintainers). Every listed
-# owner must have write access to the repo, or GitHub silently ignores the line.
+# Owners are the @wafflebase/maintainers team, so anyone with write access (i.e.
+# any team member) can satisfy the code-owner review — not a single person.
+# CODEOWNERS has no "anyone with write" wildcard; a team is how you express it,
+# and it auto-tracks membership. PREREQUISITES for these lines to take effect:
+# the team must (1) have write access to this repo and (2) contain every person
+# you consider a write-access reviewer — a write collaborator who is NOT in the
+# team can't satisfy these owners (add them to the team, or list them explicitly).
 #
 # SCOPE: this file intentionally does NOT set a global `* @owner` rule. Doing so
 # would re-route review on EVERY PR in the repo the moment this merges (and, with
@@ -23,9 +27,9 @@
 
 # --- Autonomous agent pipeline + its governance surface (tightly owned) ------
 # Changes to what the agent is allowed to do require an owner's review.
-/.github/workflows/agent-*.yml          @hackerwins
-/.github/ISSUE_TEMPLATE/agent-task.yml  @hackerwins
-/scripts/agent/                         @hackerwins
-/scripts/hooks/                         @hackerwins
-/.claude/                               @hackerwins
-/docs/design/harness-engineering.md     @hackerwins
+/.github/workflows/agent-*.yml          @wafflebase/maintainers
+/.github/ISSUE_TEMPLATE/agent-task.yml  @wafflebase/maintainers
+/scripts/agent/                         @wafflebase/maintainers
+/scripts/hooks/                         @wafflebase/maintainers
+/.claude/                               @wafflebase/maintainers
+/docs/design/harness-engineering.md     @wafflebase/maintainers


### PR DESCRIPTION
## Summary

Change the agent-pipeline CODEOWNERS entries from the single `@hackerwins` to the
**`@wafflebase/maintainers`** team, so anyone with write access (any team member)
can satisfy the code-owner review — not one specific person.

## Why

CODEOWNERS has **no "anyone with write access" wildcard** — every entry must be a
specific user or a team, and each must have write access or GitHub silently ignores
the line. A team is the idiomatic way to express "everyone with write," and it
auto-tracks membership. The file's own comment already suggested
`@wafflebase/maintainers` as the intended replacement.

## What changed

- All six `/.github/workflows/agent-*.yml`, `agent-task.yml`, `/scripts/agent/`,
  `/scripts/hooks/`, `/.claude/`, `harness-engineering.md` owners: `@hackerwins`
  → `@wafflebase/maintainers`.
- Updated the header comment to document how this maps to "anyone with write" and
  the prerequisites below.

## Prerequisites (repo settings — not in this diff)

For these lines to actually take effect:
1. The **`@wafflebase/maintainers` team must have write access** to this repo.
2. It must **contain every person** you consider a write-access reviewer — a write
   collaborator who is *not* in the team can't satisfy these owners (add them to
   the team, or list them explicitly).

If the team's membership isn't exactly your write-access set, tell me and I'll
switch to an explicit username list instead.

## Notes for Reviewers

Scope is unchanged — still only the agent pipeline's own sensitive files, no
repo-wide `* @owner` rule. **AI assistance:** authored with Claude Code.
