### PR TITLE
Panel priors: only rank COMPLETED check runs

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -266,7 +266,12 @@ jobs:
               const runs = await github.paginate(github.rest.checks.listForRef, { owner, repo, ref: c.sha, per_page: 100 });
               for (const r of runs) {
                 if (!wantNames.has(r.name) || !r.app || r.app.slug !== 'github-actions') continue;
-                const t = new Date(r.started_at || 0).getTime();
+                // Only COMPLETED runs carry final findings in output.text — an
+                // in-progress/queued run has a newer started_at but no findings yet,
+                // and would otherwise shadow the last completed run. Rank by
+                // completed_at (fallback started_at).
+                if (r.status !== 'completed') continue;
+                const t = new Date(r.completed_at || r.started_at || 0).getTime();
                 if (!latest[r.name] || t > latest[r.name].t) latest[r.name] = { id: r.id, t };
               }
             }


### PR DESCRIPTION
## Summary

Fix the autonomous review panel's "Read prior findings" run-selection loop to
only consider **completed** `agent-review-<lens>` check runs, ranked by
`completed_at` (fallback `started_at`).

## Why

The loop picked the newest run per lens by `started_at` with no status filter. If
a panel round is **in progress** on the PR, that incomplete run has a newer
`started_at` but no findings in `output.text` yet — so it could shadow the last
*completed* run and make the cross-round re-check read **empty priors**, letting a
carried-forward blocking finding silently drop.

This is the same defect CodeRabbit flagged in the on-demand review
(`agent-review-on-demand.yml`, fixed in #558); this PR applies the identical fix to
the original loop in `agent-review-panel.yml` for parity.

## What changed

`.github/workflows/agent-review-panel.yml`, "Read prior findings" step:
- Skip any run whose `status !== 'completed'`.
- Rank by `new Date(r.completed_at || r.started_at)`.
- The existing `github-actions`-app and requested-name filters are unchanged.

(The other `latest` loop in the `fix` job's "Gather failing lens findings" already
operates only on `conclusion === 'failure'` runs, which are completed by
definition, so it needs no change.)

## Verification

- YAML parses.
- Pure read-side selection change; no behavior change when there is no concurrent
  in-progress run (the common case).

## Notes for Reviewers

Touches a code-owned agent path, so it needs a maintainer (code-owner) review.
**AI assistance:** authored with Claude Code, reviewed line-by-line.
