### PR TITLE
Report cost and weighted tokens in the agent-effort summary

### DIFF
--- a/.claude/skills/maintainer-merge/SKILL.md
+++ b/.claude/skills/maintainer-merge/SKILL.md
@@ -121,11 +121,11 @@ The per-session effort is **not** in the git commits. Each agent session
 comment `<!-- agent-metric {json} -->`, and the pipeline renders one aggregated
 summary comment marked `<!-- agent-metrics-summary -->` (heading `## 🤖 Agent
 effort`) via `scripts/agent/metrics.mjs summarize`. **That summary already IS
-the combined effort of every commit** — `renderSummary()` emits Agents,
-Scope-size, Attempt, Sessions, Total-time, Turns, and Tokens (summed across
-sessions). Note it does **not** render a dollar cost: `aggregate()` sums
-`costUsd` internally but `renderSummary()` never prints it, so the summary you
-copy is effort-only. To fold it into the squash body, copy it — don't recompute:
+the combined effort of every commit** — `renderSummary()` emits Total-cost and
+Total-tokens (weighted + raw) up top, then per section (Code-fix agent / Review
+panel) Cost, Tokens, Agents, Scope-size, Attempt, Sessions, Total-time, and
+Turns (all summed across sessions). To fold it into the squash body, copy it —
+don't recompute:
 
 ```bash
 # Pull the rendered summary (aggregate of all sessions) and strip the marker.
@@ -140,9 +140,9 @@ predates the metrics feature, or the pipeline never promoted it — **omit the
 block entirely. Never write plausible-looking numbers.** If you want the raw
 ledger instead of the rendered summary, aggregate the `<!-- agent-metric -->`
 records the same way `aggregate()` in `scripts/agent/metrics.mjs` does (sum
-turns/tokens/durationMs; sessions = count; attempt = review-fix rounds + 1) —
-`costUsd` is summed there too, but keep it out of the message unless the
-renderer starts emitting it.
+turns/tokens/weightedTokens/durationMs/costUsd; sessions = count; attempt =
+review-fix rounds + 1). `costUsd` and `weightedTokens` are now rendered, so the
+copied summary already carries cost and weighted tokens.
 
 ## Pitfalls
 

--- a/docs/tasks/active/20260727-agent-metrics-cost-weighting-todo.md
+++ b/docs/tasks/active/20260727-agent-metrics-cost-weighting-todo.md
@@ -1,0 +1,77 @@
+# Agent-effort summary: cost + weighted tokens
+
+Follow-up to the review-panel-metrics work. Makes the `## 🤖 Agent effort`
+summary comment report resource weight honestly instead of leaning on a raw
+token total that over-counts cheap work.
+
+## Problem
+
+The summary's headline was a raw token sum:
+
+```
+tokens = input_tokens + output_tokens + cache_creation_input_tokens + cache_read_input_tokens
+```
+
+`cache_read_input_tokens` is re-processing of an already-cached prompt prefix.
+It is billed at roughly **1/10** of fresh input, yet the raw sum counts it at
+full weight — so a run dominated by cache reads looks far heavier than it was.
+Raw tokens also can't reflect that the review panel may run pricier/other models
+per token. Token count alone is not a good proxy for how expensive a run was.
+
+## Change
+
+- **Cost is the headline.** `total_cost_usd` is already parsed and summed into
+  `costUsd` on every ledger record (`parseExecution` / `sumExecutions` /
+  `aggregate`) — it was simply never rendered. It's the truest weight measure:
+  the model prices cache reads at ~0.1× and pricier panel models correctly.
+- **Weighted tokens** replace the raw headline token figure. `weightedTokensFor`
+  re-weights the four usage fields toward spend: cache reads **0.1×**, cache
+  writes **1.25×**, input/output **1×**. Raw is still shown in parens for
+  reference. (Output stays 1× — an accurate output multiplier is model-specific,
+  and cost already captures that exactly.)
+- Per-section **Cost** + **Tokens** carry the code-fix vs. review split, so the
+  "review panel is pricier per token" effect is visible.
+
+Rendered shape:
+
+```
+## 🤖 Agent effort
+
+- Total-cost: $4.10 (code-fix $3.30 + review $0.80)
+- Total-tokens: ~340K weighted (~1.4M raw)
+
+### Code-fix agent
+- Cost: $3.30
+- Tokens: ~300K weighted (~1.1M raw)
+- Agents / Scope-size / Attempt / Sessions / Total-time / Turns
+
+### Review panel
+- Cost: $0.80
+- Tokens: ~40K weighted (~300K raw)
+- Agents / Rounds / Total-time / Turns / (existing panel-stat lines)
+```
+
+The weighting rationale lives in the PR description, not the rendered comment
+(kept terse on purpose).
+
+## Tasks
+
+- [x] `weightedTokensFor` + `TOKEN_WEIGHTS` helper (exported, unit-tested).
+- [x] Record `weightedTokens` in `parseExecution` and `sumExecutions`.
+- [x] Sum `weightedTokens` in `aggregate`, falling back to raw `tokens` for
+      pre-rollout records that lack the field (no silent under-count mid-rollout).
+- [x] `formatUsd` (`$X.XX`, `<$0.01` for sub-cent non-zero).
+- [x] `renderSummary`: Total-cost + Total-tokens headline; per-section Cost then
+      Tokens; drop the old raw-only `Total-tokens` line.
+- [x] Update `metrics.test.mjs`.
+- [x] Update `.claude/skills/maintainer-merge/SKILL.md` (it documented that cost
+      is never rendered — no longer true).
+- [ ] `pnpm verify:fast` green; open follow-up PR.
+
+## Notes / non-goals
+
+- No per-model pricing table — deliberately. Weights are a fixed, coarse proxy;
+  `costUsd` is the accurate figure and comes straight from the model.
+- Ledger record schema gains one field (`weightedTokens`); `serializeRecord` /
+  `parseMetricComment` are generic JSON and unchanged. Old records degrade
+  gracefully via the raw-token fallback in `aggregate`.

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -5,17 +5,23 @@
 // promoted to ready-for-review, the promote job renders one aggregated,
 // human-readable SUMMARY comment:
 //
-//   - Agents: claude-opus-4-8
-//   - Scope-size: M
-//   - Attempt: 1
-//   - Sessions: 1
-//   - Total-time: 89m
-//   - Turns: 27
-//   - Tokens: ~1.0M
+//   - Total-cost: $1.23 (code-fix $1.10 + review $0.13)
+//   - Total-tokens: ~120K weighted (~1.0M raw)
+//   ...
+//   - Cost: $1.10
+//   - Tokens: ~110K weighted (~950K raw)
 //
 // Data source: `claude-execution-output.json` (the claude-code-action transcript)
-// — its final `result` message carries num_turns / duration_ms / usage / modelUsage.
-// Tokens = input+output+cache (total processed). Scope-size = PR diff lines.
+// — its final `result` message carries num_turns / duration_ms / usage /
+// modelUsage / total_cost_usd.
+//
+// Cost = model-reported `total_cost_usd`, the truest measure of how
+// resource-intensive a run was: it already prices cache reads at ~1/10 of fresh
+// input and the review panel's pricier/other models correctly. Raw tokens =
+// input+output+cache (total processed) — but raw over-counts, since cache-read
+// reprocessing is billed at ~1/10 yet summed at full weight. Weighted tokens
+// re-weight the fields toward spend (see `weightedTokensFor`). Scope-size = PR
+// diff lines.
 //
 // Pure helpers are exported and unit-tested (no gh). The CLI (`record` /
 // `summarize`) talks to GitHub via the `gh` CLI (GH_TOKEN / GITHUB_TOKEN).
@@ -40,6 +46,28 @@ export const SUMMARY_MARKER = "<!-- agent-metrics-summary -->";
 
 // --- pure helpers (exported for tests; no gh) ------------------------------
 
+/**
+ * Per-token weights relative to fresh input, so a token total tracks spend
+ * rather than raw throughput. `cache_read_input_tokens` (re-processing an
+ * already-cached prefix) is billed at ~1/10 of fresh input but is otherwise
+ * summed at full weight, which inflates the raw total; cache creation carries a
+ * ~1.25x write premium. Output stays at 1x here — weighting it accurately needs
+ * per-model pricing, which the model-reported `total_cost_usd` (kept as
+ * `costUsd`) already applies exactly, so cost is the authoritative measure.
+ */
+export const TOKEN_WEIGHTS = { input: 1, output: 1, cacheCreation: 1.25, cacheRead: 0.1 };
+
+/** Weighted (spend-representative) token count from a usage object. */
+export function weightedTokensFor(usage) {
+  const u = usage || {};
+  return Math.round(
+    (u.input_tokens || 0) * TOKEN_WEIGHTS.input +
+      (u.output_tokens || 0) * TOKEN_WEIGHTS.output +
+      (u.cache_creation_input_tokens || 0) * TOKEN_WEIGHTS.cacheCreation +
+      (u.cache_read_input_tokens || 0) * TOKEN_WEIGHTS.cacheRead,
+  );
+}
+
 /** Extract one session record from a parsed claude-execution-output.json array. */
 export function parseExecution(messages, kind = "implement") {
   const arr = Array.isArray(messages) ? messages : [];
@@ -56,6 +84,7 @@ export function parseExecution(messages, kind = "implement") {
     models: Object.keys(result.modelUsage || {}),
     turns: result.num_turns || 0,
     tokens,
+    weightedTokens: weightedTokensFor(u),
     durationMs: result.duration_ms || 0,
     costUsd: result.total_cost_usd || 0,
     sessionId: result.session_id || "",
@@ -72,7 +101,7 @@ export function sumExecutions(messages, kind = "review") {
   const arr = Array.isArray(messages) ? messages : [];
   const results = arr.filter((m) => m && m.type === "result");
   const models = new Set();
-  let turns = 0, tokens = 0, durationMs = 0, costUsd = 0;
+  let turns = 0, tokens = 0, weightedTokens = 0, durationMs = 0, costUsd = 0;
   for (const r of results) {
     const u = r.usage || {};
     tokens +=
@@ -80,6 +109,7 @@ export function sumExecutions(messages, kind = "review") {
       (u.output_tokens || 0) +
       (u.cache_creation_input_tokens || 0) +
       (u.cache_read_input_tokens || 0);
+    weightedTokens += weightedTokensFor(u);
     turns += r.num_turns || 0;
     durationMs += r.duration_ms || 0;
     costUsd += r.total_cost_usd || 0;
@@ -90,6 +120,7 @@ export function sumExecutions(messages, kind = "review") {
     models: [...models].sort(),
     turns,
     tokens,
+    weightedTokens,
     durationMs,
     costUsd,
     sessionId: results.length ? results[results.length - 1].session_id || "" : "",
@@ -111,6 +142,13 @@ export function aggregate(records) {
     attempt: reviewFixes + 1,
     turns: sum("turns"),
     tokens: sum("tokens"),
+    // Records written before weighted tokens existed have no `weightedTokens`;
+    // fall back to raw `tokens` for those so an in-flight PR's total isn't
+    // silently under-counted mid-rollout.
+    weightedTokens: list.reduce(
+      (s, r) => s + (Number(r.weightedTokens) || Number(r.tokens) || 0),
+      0,
+    ),
     durationMs: sum("durationMs"),
     costUsd: sum("costUsd"),
   };
@@ -164,6 +202,12 @@ export function formatMinutes(ms) {
   return `${Math.max(1, Math.round((Number(ms) || 0) / 60000))}m`;
 }
 
+export function formatUsd(n) {
+  const v = Number(n) || 0;
+  if (v > 0 && v < 0.01) return "<$0.01";
+  return `$${v.toFixed(2)}`;
+}
+
 /** Render the human-readable summary comment body. `panelAgg`/`panelStats`
  * are omitted when the PR has no review-panel ledger records yet (kept
  * separate from the code-fix agent's numbers — review-fix, the agent that
@@ -172,22 +216,32 @@ export function formatMinutes(ms) {
  * rather than folded into one set of totals). */
 export function renderSummary({ agg, panelAgg, panelStats, scope }) {
   const hasPanel = !!panelAgg && panelAgg.sessions > 0;
-  const totalTokens = agg.tokens + (hasPanel ? panelAgg.tokens : 0);
+  const panelTokens = hasPanel ? panelAgg.tokens : 0;
+  const panelWeighted = hasPanel ? panelAgg.weightedTokens : 0;
+  const panelCost = hasPanel ? panelAgg.costUsd : 0;
+  const totalWeighted = agg.weightedTokens + panelWeighted;
+  const totalRaw = agg.tokens + panelTokens;
+  const totalCost = agg.costUsd + panelCost;
+  // Cost leads (it prices cache reads and pricier panel models correctly);
+  // tokens are shown weighted with the raw total in parens. Per-section cost
+  // and tokens carry the code-fix vs review split.
   const lines = [
     SUMMARY_MARKER,
     "## 🤖 Agent effort",
     "",
-    `- Total-tokens: ${formatTokens(totalTokens)} (code-fix ${formatTokens(agg.tokens)} + review ${formatTokens(hasPanel ? panelAgg.tokens : 0)})`,
+    `- Total-cost: ${formatUsd(totalCost)} (code-fix ${formatUsd(agg.costUsd)} + review ${formatUsd(panelCost)})`,
+    `- Total-tokens: ${formatTokens(totalWeighted)} weighted (${formatTokens(totalRaw)} raw)`,
     "",
     "### Code-fix agent",
     "",
+    `- Cost: ${formatUsd(agg.costUsd)}`,
+    `- Tokens: ${formatTokens(agg.weightedTokens)} weighted (${formatTokens(agg.tokens)} raw)`,
     `- Agents: ${agg.agents.length ? agg.agents.join(", ") : "unknown"}`,
     `- Scope-size: ${scope}`,
     `- Attempt: ${agg.attempt}`,
     `- Sessions: ${agg.sessions}`,
     `- Total-time: ${formatMinutes(agg.durationMs)}`,
     `- Turns: ${agg.turns}`,
-    `- Tokens: ${formatTokens(agg.tokens)}`,
   ];
   if (hasPanel) {
     const ac = panelStats?.agreementCounts || {};
@@ -199,11 +253,12 @@ export function renderSummary({ agg, panelAgg, panelStats, scope }) {
       "",
       "### Review panel",
       "",
+      `- Cost: ${formatUsd(panelAgg.costUsd)}`,
+      `- Tokens: ${formatTokens(panelAgg.weightedTokens)} weighted (${formatTokens(panelAgg.tokens)} raw)`,
       `- Agents: ${panelAgg.agents.length ? panelAgg.agents.join(", ") : "unknown"}`,
       `- Rounds: ${panelAgg.sessions}`,
       `- Total-time: ${formatMinutes(panelAgg.durationMs)}`,
       `- Turns: ${panelAgg.turns}`,
-      `- Tokens: ${formatTokens(panelAgg.tokens)}`,
       `- Sample-agreement: ${ac.identical || 0} identical, ${ac.partial || 0} partial, ${ac.disjoint || 0} disjoint (${sampledRounds} lens-round samples)`,
       `- Findings raised: ${r.critical || 0} critical, ${r.major || 0} major, ${r.minor || 0} minor, ${r.nit || 0} nit`,
       `- Sent to verifier: ${v.sentToVerifier || 0}`,

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -8,6 +8,8 @@ import {
   scopeSize,
   formatTokens,
   formatMinutes,
+  formatUsd,
+  weightedTokensFor,
   renderSummary,
   serializeRecord,
   parseMetricComment,
@@ -36,7 +38,9 @@ test("parseExecution: pulls turns/tokens(incl cache)/time/model from the last re
   assert.equal(rec.kind, "implement");
   assert.deepEqual(rec.models, ["claude-opus-4-8"]);
   assert.equal(rec.turns, 27);
-  assert.equal(rec.tokens, 100 + 34633 + 136293 + 800000); // total incl. cache
+  assert.equal(rec.tokens, 100 + 34633 + 136293 + 800000); // raw total incl. cache
+  // weighted: cache reads at 0.1x, cache writes at 1.25x, input/output at 1x
+  assert.equal(rec.weightedTokens, Math.round(100 + 34633 + 136293 * 1.25 + 800000 * 0.1));
   assert.equal(rec.durationMs, 89 * 60000);
   // no result message → null (caller treats as nothing to record)
   assert.equal(parseExecution([{ type: "assistant" }]), null);
@@ -51,6 +55,7 @@ test("sumExecutions: sums EVERY result message (not last-wins like parseExecutio
   assert.deepEqual(rec.models, ["claude-opus-4-8", "claude-sonnet-5"]); // unique, sorted, across all calls
   assert.equal(rec.turns, 8); // 3 + 5, not just the last (5)
   assert.equal(rec.tokens, 30); // 10 + 20
+  assert.equal(rec.weightedTokens, 30); // input-only usage → unweighted (summed, not last-wins)
   assert.equal(rec.durationMs, 3000);
   assert.equal(rec.costUsd, 3.75); // 1.5 + 2.25, not just the last
   assert.equal(rec.sessionId, "s2"); // last call's session id
@@ -64,9 +69,9 @@ test("sumExecutions: sums EVERY result message (not last-wins like parseExecutio
 
 test("aggregate: sums across sessions; attempt counts review-fix rounds + 1", () => {
   const recs = [
-    { kind: "implement", models: ["claude-opus-4-8"], turns: 10, tokens: 500000, durationMs: 600000 },
-    { kind: "ci-fix", models: ["claude-opus-4-8"], turns: 5, tokens: 200000, durationMs: 120000 },
-    { kind: "review-fix", models: ["claude-sonnet-5"], turns: 8, tokens: 300000, durationMs: 300000 },
+    { kind: "implement", models: ["claude-opus-4-8"], turns: 10, tokens: 500000, weightedTokens: 150000, costUsd: 2, durationMs: 600000 },
+    { kind: "ci-fix", models: ["claude-opus-4-8"], turns: 5, tokens: 200000, weightedTokens: 60000, costUsd: 0.5, durationMs: 120000 },
+    { kind: "review-fix", models: ["claude-sonnet-5"], turns: 8, tokens: 300000, weightedTokens: 90000, costUsd: 1, durationMs: 300000 },
   ];
   const agg = aggregate(recs);
   assert.deepEqual(agg.agents, ["claude-opus-4-8", "claude-sonnet-5"]); // unique, sorted
@@ -74,7 +79,12 @@ test("aggregate: sums across sessions; attempt counts review-fix rounds + 1", ()
   assert.equal(agg.attempt, 2); // one review-fix → attempt 2
   assert.equal(agg.turns, 23);
   assert.equal(agg.tokens, 1000000);
+  assert.equal(agg.weightedTokens, 300000);
+  assert.equal(agg.costUsd, 3.5);
   assert.equal(agg.durationMs, 1020000);
+  // pre-rollout records lack weightedTokens → fall back to raw tokens (not 0)
+  assert.equal(aggregate([{ tokens: 500000 }]).weightedTokens, 500000);
+  assert.equal(aggregate([{ tokens: 500000, weightedTokens: 120000 }]).weightedTokens, 120000);
   // no review-fix → attempt 1
   assert.equal(aggregate([{ kind: "implement" }]).attempt, 1);
   assert.equal(aggregate([]).sessions, 0);
@@ -114,38 +124,52 @@ test("scopeSize: S/M/L thresholds on total diff lines", () => {
   assert.equal(scopeSize(400, 200), "L");
 });
 
-test("formatTokens / formatMinutes: human-friendly", () => {
+test("formatTokens / formatMinutes / formatUsd: human-friendly", () => {
   assert.equal(formatTokens(1_000_000), "~1.0M");
   assert.equal(formatTokens(6_200_000), "~6.2M");
   assert.equal(formatTokens(34_733), "~35K");
   assert.equal(formatTokens(0), "~0");
   assert.equal(formatMinutes(89 * 60000), "89m");
   assert.equal(formatMinutes(5000), "1m"); // floor at 1m
+  assert.equal(formatUsd(4.1), "$4.10");
+  assert.equal(formatUsd(0), "$0.00");
+  assert.equal(formatUsd(0.004), "<$0.01"); // sub-cent, non-zero
+});
+
+test("weightedTokensFor: cache reads 0.1x, cache writes 1.25x, input/output 1x", () => {
+  assert.equal(
+    weightedTokensFor({ input_tokens: 100, output_tokens: 200, cache_creation_input_tokens: 1000, cache_read_input_tokens: 5000 }),
+    Math.round(100 + 200 + 1000 * 1.25 + 5000 * 0.1), // 100 + 200 + 1250 + 500 = 2050
+  );
+  assert.equal(weightedTokensFor({}), 0);
+  assert.equal(weightedTokensFor(undefined), 0);
 });
 
 test("renderSummary: matches the requested bullet format", () => {
   const md = renderSummary({
-    agg: { agents: ["claude-opus-4-8"], sessions: 1, attempt: 1, turns: 27, tokens: 1_000_000, durationMs: 89 * 60000 },
+    agg: { agents: ["claude-opus-4-8"], sessions: 1, attempt: 1, turns: 27, tokens: 1_000_000, weightedTokens: 300_000, costUsd: 3.3, durationMs: 89 * 60000 },
     scope: "M",
   });
   assert.match(md, /### Code-fix agent/);
+  assert.match(md, /- Cost: \$3\.30/);
+  assert.match(md, /- Tokens: ~300K weighted \(~1\.0M raw\)/);
   assert.match(md, /- Agents: claude-opus-4-8/);
   assert.match(md, /- Scope-size: M/);
   assert.match(md, /- Attempt: 1/);
   assert.match(md, /- Sessions: 1/);
   assert.match(md, /- Total-time: 89m/);
   assert.match(md, /- Turns: 27/);
-  assert.match(md, /- Tokens: ~1\.0M/);
   // no review-panel records on this PR → no "Review panel" section at all,
-  // and the top total-tokens line reflects code-fix only
+  // and the top totals collapse the review side to zero
   assert.doesNotMatch(md, /### Review panel/);
-  assert.match(md, /- Total-tokens: ~1\.0M \(code-fix ~1\.0M \+ review ~0\)/);
+  assert.match(md, /- Total-cost: \$3\.30 \(code-fix \$3\.30 \+ review \$0\.00\)/);
+  assert.match(md, /- Total-tokens: ~300K weighted \(~1\.0M raw\)/);
 });
 
 test("renderSummary: with review-panel data, renders a separate section + combined total", () => {
   const md = renderSummary({
-    agg: { agents: ["claude-opus-4-8"], sessions: 3, attempt: 2, turns: 31, tokens: 1_100_000, durationMs: 94 * 60000 },
-    panelAgg: { agents: ["claude-opus-4-8"], sessions: 2, turns: 15, tokens: 300_000, durationMs: 27 * 60000 },
+    agg: { agents: ["claude-opus-4-8"], sessions: 3, attempt: 2, turns: 31, tokens: 1_100_000, weightedTokens: 300_000, costUsd: 3.3, durationMs: 94 * 60000 },
+    panelAgg: { agents: ["claude-opus-4-8", "claude-sonnet-5"], sessions: 2, turns: 15, tokens: 300_000, weightedTokens: 40_000, costUsd: 0.8, durationMs: 27 * 60000 },
     panelStats: {
       agreementCounts: { identical: 6, partial: 1, disjoint: 1, single: 0 },
       raised: { critical: 2, major: 5, minor: 3, nit: 1 },
@@ -163,8 +187,11 @@ test("renderSummary: with review-panel data, renders a separate section + combin
   assert.match(md, /- Sent to verifier: 7/);
   assert.match(md, /- Refuted: 3 \(2 high-confidence\)/);
   assert.match(md, /- Survived to gate: 1 critical, 3 major/);
-  // combined total = code-fix (1.1M) + review (300K) = 1.4M
-  assert.match(md, /- Total-tokens: ~1\.4M \(code-fix ~1\.1M \+ review ~300K\)/);
+  // per-section cost + weighted/raw tokens carry the split
+  assert.match(md, /### Review panel\n\n- Cost: \$0\.80\n- Tokens: ~40K weighted \(~300K raw\)/);
+  // combined totals: cost $3.30 + $0.80 = $4.10; weighted 300K + 40K = 340K; raw 1.1M + 300K = 1.4M
+  assert.match(md, /- Total-cost: \$4\.10 \(code-fix \$3\.30 \+ review \$0\.80\)/);
+  assert.match(md, /- Total-tokens: ~340K weighted \(~1\.4M raw\)/);
 });
 
 test("metric comment round-trip: hidden, self-contained, parses back; junk → null", () => {


### PR DESCRIPTION
## Summary

Follow-up to the review-panel metrics work. The `## 🤖 Agent effort` summary
led with a raw token total, which misrepresents how resource-intensive a run
was:

- `cache_read_input_tokens` (re-processing an already-cached prefix) is billed
  at ~1/10 of fresh input, but was summed at **full** weight.
- A raw token count can't reflect the review panel running pricier / other
  models per token.

### Changes

- **Cost is the headline.** `total_cost_usd` was already recorded on every
  ledger record (`parseExecution` / `sumExecutions` / `aggregate`) but never
  rendered. It's the truest weight — the model prices cache reads at ~0.1× and
  each model correctly. Now shown as `Total-cost` plus a per-section `Cost`.
- **Weighted tokens** replace the raw headline figure. `weightedTokensFor`
  re-weights the usage fields toward spend: cache reads **0.1×**, cache writes
  **1.25×**, input/output **1×**. Raw is kept in parens. Output stays 1× — an
  accurate output multiplier is model-specific, and cost already captures that.
- Per-section **Cost** + **Tokens** carry the code-fix vs. review split.
- `aggregate` falls back to raw `tokens` for pre-rollout records missing
  `weightedTokens`, so in-flight PRs aren't under-counted mid-rollout.

Rendered:

```
## 🤖 Agent effort

- Total-cost: $4.10 (code-fix $3.30 + review $0.80)
- Total-tokens: ~340K weighted (~1.4M raw)

### Code-fix agent
- Cost: $3.30
- Tokens: ~300K weighted (~1.1M raw)
- Agents / Scope-size / Attempt / Sessions / Total-time / Turns

### Review panel
- Cost: $0.80
- Tokens: ~40K weighted (~300K raw)
- Agents / Rounds / Total-time / Turns / (panel-stat lines)
```

Also updates `maintainer-merge/SKILL.md` (it documented that cost is never
rendered — no longer true).

> Follow-up to #540 (review-panel metrics), which is merged — its
> `renderSummary` code-fix/review split is on `main`, so this is the 4-file
> delta on top of it.

## Test plan

- `cd scripts/agent && node --test *.test.mjs` → 29/29 pass.
- New/updated coverage: `weightedTokensFor` weights, `formatUsd`
  (incl. `<$0.01`), the raw-token fallback in `aggregate`, and the new
  `renderSummary` layout (headline + per-section, with and without a panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent effort summaries now display total cost in USD.
  - Token usage is shown as weighted tokens alongside raw token totals.
  - Code-fix and review sections now include cost and token breakdowns.
  - Combined summaries include totals across all reported work.

- **Documentation**
  - Updated maintainer guidance and task documentation to describe the revised cost and token summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->