### PR TITLE
Add issue-category classifier to the agent pipeline

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -292,6 +292,18 @@ jobs:
           ISSUE: ${{ github.event.issue.number || github.event.inputs.issue_number }}
         run: node ./scripts/agent/metrics.mjs record --execution "$RUNNER_TEMP/claude-execution-output.json" --kind implement --issue "$ISSUE"
 
+      # Classify the issue by category into a hidden `<!-- agent-class -->`
+      # comment, mirroring the metrics ledger (Dimension A from the issue always;
+      # root-cause bug class from the diff when a PR exists). Fail-safe: exit 0.
+      - name: Classify issue category
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ISSUE: ${{ github.event.issue.number || github.event.inputs.issue_number }}
+        run: node ./scripts/agent/classify.mjs record --issue "$ISSUE"
+
   # A bare "@claude" (no recognized verb) on an issue → point the commenter at
   # the command they probably meant, instead of silently doing nothing. Trusted
   # authors only, matching the implement gate, so it can't be used for drive-by

--- a/scripts/agent/classify.mjs
+++ b/scripts/agent/classify.mjs
@@ -1,0 +1,235 @@
+// Issue-category classification for the autonomous issue→PR pipeline.
+//
+// Applies GitHub labels (type:… always; bugclass:… for verified bug fixes) to
+// the agent's PR — or the issue when no PR was produced — and records the full
+// JSON behind them as a hidden `<!-- agent-class {json} -->` comment, in the
+// same PR ledger metrics.mjs uses for agent run info. Two stages:
+//   A) issue text -> Dimension A (type) + spec/test context     (Haiku, cheap)
+//   B) PR diff    -> Dimension B (bug class) + localization      (Opus + verify)
+// FAIL-SAFE: any error exits 0 so classification can never break the pipeline
+// (the workflow step is also continue-on-error).
+//
+// The gh / PR-resolution / comment-listing helpers are shared from metrics.mjs
+// rather than reinvented; only the upsert-a-single-comment behavior (metrics is
+// append-only) and the label application are classification-specific.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { gh, ghJson, resolvePrByIssue, listAllComments } from "./metrics.mjs";
+
+const CLASS_PREFIX = "<!-- agent-class ";
+const API = "https://api.anthropic.com/v1/messages";
+const MODEL_A = "claude-haiku-4-5";
+const MODEL_B = "claude-opus-4-8";
+
+const TYPE_LABEL = {
+  A1: "type:bug-fix", A2: "type:feature", A3: "type:refactor", A4: "type:performance",
+  A5: "type:security", A6: "type:testing", A7: "type:build-ci", A8: "type:docs",
+};
+const BUG_LABEL = {
+  B1: "bugclass:logic", B2: "bugclass:interface", B3: "bugclass:memory", B4: "bugclass:concurrency",
+  B5: "bugclass:resource", B6: "bugclass:data-input", B7: "bugclass:config",
+};
+const TYPE_COLOR = "1d76db";
+const BUG_COLOR = "d93f0b";
+
+// --- pure helpers (exported for tests; no gh, no network) ------------------
+
+/** One classification record as a self-contained HIDDEN comment. Fields are
+ * machine-generated, but strip the terminator defensively so a rationale can
+ * never break the parser. */
+export function serializeClass(rec) {
+  return `${CLASS_PREFIX}${JSON.stringify(rec).replaceAll("-->", "-- >")} -->`;
+}
+
+/** Recover the record from a comment body; null if it isn't a class comment. */
+export function parseClassComment(body) {
+  const m = /<!-- agent-class ([\s\S]*?) -->/.exec(body || "");
+  if (!m) return null;
+  try {
+    return JSON.parse(m[1]);
+  } catch {
+    return null;
+  }
+}
+
+export function truncate(s, n) {
+  const t = String(s || "");
+  return t.length <= n ? t : `${t.slice(0, n)}\n…[truncated]`;
+}
+
+/** Localization scope (Dimension C1) from the fix diff. */
+export function localizationFromDiff(diff) {
+  const files = new Set();
+  let hunks = 0;
+  for (const line of String(diff || "").split("\n")) {
+    if (line.startsWith("+++ b/")) files.add(line.slice(6));
+    else if (line.startsWith("@@")) hunks++;
+  }
+  if (files.size === 0) return "unknown";
+  if (files.size === 1) return hunks <= 1 ? "single_hunk" : "single_file";
+  const modules = new Set([...files].map((f) => f.split("/").slice(0, 2).join("/")));
+  return modules.size > 1 ? "cross_module" : "multi_file";
+}
+
+const A_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    primary_type: { type: "string", enum: ["A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8"] },
+    secondary_types: { type: "array", items: { type: "string", enum: ["A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8"] } },
+    spec_quality: { type: "string", enum: ["full", "partial", "underspecified"] },
+    test_availability: { type: "string", enum: ["provided", "discoverable", "none"] },
+    confidence: { type: "number" },
+    rationale: { type: "string" },
+  },
+  required: ["primary_type", "secondary_types", "spec_quality", "test_availability", "confidence", "rationale"],
+};
+
+const B_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    bug_class: { type: "string", enum: ["B1", "B2", "B3", "B4", "B5", "B6", "B7"] },
+    secondary_classes: { type: "array", items: { type: "string", enum: ["B1", "B2", "B3", "B4", "B5", "B6", "B7"] } },
+    confidence: { type: "number" },
+    rationale: { type: "string" },
+  },
+  required: ["bug_class", "secondary_classes", "confidence", "rationale"],
+};
+
+const A_SYSTEM =
+  "You classify a software issue by the PRIMARY work it asks for. The GitHub label is a hint only; the issue text is authoritative. Output strict JSON.\n" +
+  "A1 bug_fix · A2 feature · A3 refactor · A4 performance · A5 security · A6 testing · A7 build_ci_config · A8 documentation.\n" +
+  "Pick exactly one primary_type; put any others in secondary_types. spec_quality: full|partial|underspecified. test_availability: provided|discoverable|none. confidence 0-1. rationale <=25 words.";
+
+const B_SYSTEM =
+  "You classify the ROOT CAUSE of a fixed bug from the issue + the diff of the accepted fix. Judge from what the fix CHANGED, not just the symptom. Output strict JSON.\n" +
+  "B1 logic_semantic · B2 interface_api · B3 memory_safety · B4 concurrency · B5 resource_mgmt · B6 data_input · B7 config_environment.\n" +
+  "Adds a lock/atomic -> B4; adds null/bounds/validation guard -> B6 (B3 if memory-unsafe); changes a signature/serialization contract -> B2. One primary bug_class; others in secondary_classes. confidence 0-1. rationale <=25 words.";
+
+const B_SKEPTIC =
+  `${B_SYSTEM}\nA prior pass proposed a class. Argue for the single most likely ALTERNATIVE, then return your own best answer.`;
+
+async function callModel(model, system, user, schema) {
+  const res = await fetch(API, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": process.env.ANTHROPIC_API_KEY,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 400,
+      system,
+      output_config: { format: { type: "json_schema", schema } },
+      messages: [{ role: "user", content: user }],
+    }),
+  });
+  if (!res.ok) throw new Error(`messages API ${res.status}`);
+  const data = await res.json();
+  const text = (data.content || []).find((b) => b.type === "text")?.text;
+  return JSON.parse(text);
+}
+
+// --- gh-backed CLI ---------------------------------------------------------
+
+// Classification must NEVER fail the pipeline: log and exit 0 on any problem.
+function bail(msg) {
+  console.error(`classify: ${msg}`);
+  process.exit(0);
+}
+
+function parseArgs(argv) {
+  const a = {};
+  for (let i = 3; i < argv.length; i++) {
+    if (argv[i].startsWith("--")) {
+      a[argv[i].slice(2)] = argv[i + 1];
+      i++;
+    }
+  }
+  return a;
+}
+
+// Ensure a label exists (idempotent via --force) then leave adding it to the
+// caller. Best-effort: a label failure must not abort the run.
+function ensureLabel(name, color) {
+  try {
+    gh(["label", "create", name, "--color", color, "--force"]);
+  } catch {
+    // label may already exist with different metadata; --force covers it, and
+    // any residual failure is non-fatal (the add below still works if present).
+  }
+}
+
+/** Apply labels to a PR ("pr") or issue ("issue"). `labels` = [[name, color]]. */
+function applyLabels(kind, n, labels) {
+  for (const [name, color] of labels) ensureLabel(name, color);
+  try {
+    gh([kind, "edit", String(n), "--add-label", labels.map(([name]) => name).join(",")]);
+  } catch (e) {
+    console.error(`classify: label add failed on ${kind} #${n}: ${e.message}`);
+  }
+}
+
+/** Upsert the single hidden class comment (metrics.mjs is append-only; the
+ * classification is one fact per PR/issue, so we edit in place instead). */
+function upsertClass(n, body) {
+  const existing = listAllComments(n).find((c) => (c.body || "").includes(CLASS_PREFIX));
+  if (existing) {
+    gh(["api", "-X", "PATCH", `repos/{owner}/{repo}/issues/comments/${existing.id}`, "-f", `body=${body}`]);
+  } else {
+    gh(["api", "-X", "POST", `repos/{owner}/{repo}/issues/${n}/comments`, "-f", `body=${body}`]);
+  }
+}
+
+async function cmdRecord(args) {
+  const issue = args.issue;
+  if (!issue) return bail("need --issue");
+  if (!process.env.ANTHROPIC_API_KEY) return bail("ANTHROPIC_API_KEY unset");
+
+  const iss = ghJson(["issue", "view", issue, "--json", "title,body,labels"]);
+  const labels = (iss.labels || []).map((l) => l.name).join(", ");
+  const userA = `LABELS: [${labels}]\nTITLE: ${iss.title}\nBODY:\n${truncate(iss.body, 6000)}`;
+
+  const a = await callModel(MODEL_A, A_SYSTEM, userA, A_SCHEMA);
+  const rec = { schema: 1, issue: Number(issue), ...a, bug: null, localization_scope: null, verified: null, pr: null };
+
+  const pr = args.pr || resolvePrByIssue(issue);
+  if (a.primary_type === "A1" && pr) {
+    let diff = "";
+    try {
+      diff = gh(["pr", "diff", pr]);
+    } catch {
+      // no diff available — leave bug fields null
+    }
+    if (diff) {
+      const userB = `${userA}\n\nDIFF (truncated):\n${truncate(diff, 8000)}`;
+      const b1 = await callModel(MODEL_B, B_SYSTEM, userB, B_SCHEMA);
+      const b2 = await callModel(MODEL_B, B_SKEPTIC, userB, B_SCHEMA);
+      rec.bug = b1;
+      rec.verified = b1.bug_class === b2.bug_class; // two-pass agreement
+      rec.localization_scope = localizationFromDiff(diff);
+    }
+  }
+  rec.pr = pr ? Number(pr) : null;
+
+  // Label + store on the PR when there is one (same target the metrics ledger
+  // uses); else the issue, so failed/no-PR runs still carry a type: label.
+  const kind = pr ? "pr" : "issue";
+  const n = pr || issue;
+  const labelSet = [[TYPE_LABEL[a.primary_type], TYPE_COLOR]];
+  if (rec.bug) labelSet.push([BUG_LABEL[rec.bug.bug_class], BUG_COLOR]);
+  applyLabels(kind, n, labelSet);
+  upsertClass(n, serializeClass(rec));
+
+  console.error(`classify: labelled ${TYPE_LABEL[a.primary_type]}${rec.bug ? ` + ${BUG_LABEL[rec.bug.bug_class]}` : ""} on ${kind} #${n}`);
+}
+
+// Only run the CLI when executed directly (not when imported for tests).
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const cmd = process.argv[2];
+  if (cmd === "record") cmdRecord(parseArgs(process.argv)).catch((e) => bail(e.message));
+  else bail(`unknown command: ${cmd}`);
+}

--- a/scripts/agent/classify.test.mjs
+++ b/scripts/agent/classify.test.mjs
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { serializeClass, parseClassComment, truncate, localizationFromDiff } from "./classify.mjs";
+
+test("serializeClass / parseClassComment round-trip", () => {
+  const rec = {
+    schema: 1, issue: 42, primary_type: "A1", secondary_types: [],
+    spec_quality: "full", test_availability: "provided", confidence: 0.9,
+    rationale: "off-by-one in loop bound", bug: { bug_class: "B1", secondary_classes: [], confidence: 0.8, rationale: "wrong condition" },
+    localization_scope: "single_file", verified: true, pr: 566,
+  };
+  const body = serializeClass(rec);
+  assert.ok(body.startsWith("<!-- agent-class "));
+  assert.ok(body.endsWith(" -->"));
+  assert.deepEqual(parseClassComment(body), rec);
+});
+
+test("serializeClass neutralizes an embedded terminator so the parser can't be broken", () => {
+  const body = serializeClass({ rationale: "a --> b" });
+  // exactly one closing terminator (the real one), regex still recovers the record
+  assert.equal(body.match(/-->/g).length, 1);
+  assert.equal(parseClassComment(body).rationale, "a -- > b");
+});
+
+test("parseClassComment returns null for non-class / malformed bodies", () => {
+  assert.equal(parseClassComment("<!-- agent-metric {\"turns\":3} -->"), null); // different marker
+  assert.equal(parseClassComment("just a normal PR comment"), null);
+  assert.equal(parseClassComment(""), null);
+  assert.equal(parseClassComment("<!-- agent-class not json -->"), null); // matches marker, bad JSON
+});
+
+test("truncate leaves short input untouched and marks long input", () => {
+  assert.equal(truncate("abc", 10), "abc");
+  const out = truncate("abcdef", 3);
+  assert.ok(out.startsWith("abc"));
+  assert.ok(out.includes("[truncated]"));
+});
+
+test("localizationFromDiff classifies scope from the diff", () => {
+  assert.equal(localizationFromDiff(""), "unknown");
+  assert.equal(localizationFromDiff("+++ b/pkg/a/x.ts\n@@ -1 +1 @@"), "single_hunk");
+  assert.equal(localizationFromDiff("+++ b/pkg/a/x.ts\n@@ -1 +1 @@\n@@ -9 +9 @@"), "single_file");
+  assert.equal(
+    localizationFromDiff("+++ b/pkg/a/x.ts\n@@ -1 +1 @@\n+++ b/pkg/a/y.ts\n@@ -1 +1 @@"),
+    "multi_file", // two files, same first-two-segment module (pkg/a)
+  );
+  assert.equal(
+    localizationFromDiff("+++ b/pkg/a/x.ts\n@@ -1 +1 @@\n+++ b/pkg/b/y.ts\n@@ -1 +1 @@"),
+    "cross_module", // two files, different modules (pkg/a vs pkg/b)
+  );
+});

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -289,14 +289,14 @@ export function parseMetricComment(body) {
 
 // --- gh-backed CLI ---------------------------------------------------------
 
-function gh(args) {
+export function gh(args) {
   return execFileSync("gh", args, { encoding: "utf8" });
 }
-function ghJson(args) {
+export function ghJson(args) {
   return JSON.parse(gh(args));
 }
 
-function resolvePrByIssue(issue) {
+export function resolvePrByIssue(issue) {
   // The kickoff creates a branch `agent/<issue>-<slug>`; find the open PR for it.
   // --limit well above the default 30 so a busy repo's PR list isn't truncated
   // before ours is seen.
@@ -309,7 +309,7 @@ function resolvePrByIssue(issue) {
 // ALL comment pages, not just the first 100 — a chatty PR exceeds one page, and
 // missing pages would drop metric records or the summary marker. `--slurp` wraps
 // the paginated responses in a JSON array of pages, which we flatten.
-function listAllComments(pr) {
+export function listAllComments(pr) {
   const pages = ghJson(["api", "--paginate", "--slurp", `repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`]);
   return Array.isArray(pages) ? pages.flat() : [];
 }


### PR DESCRIPTION
## Summary

Adds issue-category tracking to the autonomous issue→PR pipeline so agent performance can be sliced by the *kind* of issue worked on (bug fix vs. feature vs. refactor …, and for bug fixes the root-cause class).

On each `agent-implement` run, `scripts/agent/classify.mjs`:

- Classifies the issue by **primary type** (bug-fix / feature / refactor / performance / security / testing / build-ci / docs) from the issue text, and — for bug fixes that produced a PR — the **root-cause bug class** from the diff (with a cheap two-pass verification) plus localization scope.
- Applies the results as **namespaced GitHub labels** — `type:…` always, `bugclass:…` for verified bug fixes — to the PR, or to the issue when no PR was produced, creating any missing label idempotently. This is the queryable/browsable surface.
- Records the **full JSON** (confidence, rationale, localization, verify flag) behind those labels as a hidden `<!-- agent-class {json} -->` comment — the same PR ledger `metrics.mjs` already uses for agent run info.

Wired in as one `if: always()` step in `agent-implement.yml`, right after the metrics step, so it runs even on failed runs (labels the issue when no PR exists) and keeps "attempted, no PR" rows for the resolve-rate denominator. Fail-safe: `exit 0` on any error, `continue-on-error` on the step.

Read back by listing PRs/issues by label, or by scraping the `agent-class` comments and joining to `agent-metric` by PR number.

## Notes

- `classify.mjs` **shares** `metrics.mjs`'s `gh` / PR-resolution / comment-listing helpers (now exported) rather than duplicating them; the upsert + label logic is classification-specific (the metrics ledger is append-only). Its CLI is guarded so the pure helpers are importable.
- Model tiering: Haiku for the coarse type, Opus for the bug class + verification pass.

## Test plan

- `scripts/agent/classify.test.mjs` covers the pure logic (serialize/parse round-trip, `-->` terminator neutralization, truncation, localization-scope branches): `node --test scripts/agent/*.test.mjs` → green.
- `agent-implement.yml` change is purely additive (one step); no existing step is modified. `metrics.mjs` change is only `export` on four existing helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
