### PR TITLE
Omit generated ANTLR output from the reviewed diff body

### DIFF
--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -189,11 +189,26 @@ jobs:
         with:
           node-version: 22.x
 
+      # KEEP IN SYNC with the identical step in agent-review-panel.yml.
       - name: Compute diff + changed files (data for the reviewers)
         run: |
+          set -euo pipefail
           git fetch --no-tags origin main
-          git diff origin/main...HEAD > /tmp/pr.diff
+          # UNFILTERED on purpose — see the twin step in agent-review-panel.yml
+          # for why the changed-file list must never shrink.
           git diff --name-only origin/main...HEAD > /tmp/changed.txt
+          # ANTLR generated output omitted from the diff BODY only; the
+          # hand-written `Formula.g4` grammar is deliberately kept. Lockfiles
+          # are deliberately kept too (supply-chain relevant).
+          git diff origin/main...HEAD -- . \
+            ':(exclude)packages/sheets/antlr/*.ts' \
+            ':(exclude)packages/sheets/antlr/*.interp' \
+            ':(exclude)packages/sheets/antlr/*.tokens' > /tmp/pr.diff
+          # Regeneration-only change → filtered diff is empty and the panel
+          # fails closed. Fall back to the unfiltered diff.
+          if [ ! -s /tmp/pr.diff ]; then
+            git diff origin/main...HEAD > /tmp/pr.diff
+          fi
 
       # Best-effort issue spec for the design-fit lens — same provenance rule as
       # the autonomous panel (only trust an `agent:candidate`, human-authored issue

--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -197,11 +197,12 @@ jobs:
           # UNFILTERED on purpose — see the twin step in agent-review-panel.yml
           # for why the changed-file list must never shrink.
           git diff --name-only origin/main...HEAD > /tmp/changed.txt
-          # ANTLR generated output omitted from the diff BODY only; the
-          # hand-written `Formula.g4` grammar is deliberately kept. Lockfiles
-          # are deliberately kept too (supply-chain relevant).
+          # ANTLR generated TOOLING artifacts (.interp/.tokens — nothing loads
+          # them) omitted from the diff BODY only. The generated `.ts` files are
+          # kept: they are executable code, and excluding them would blind every
+          # lens to a hand-edit. `Formula.g4` and lockfiles are never excluded.
+          # See the twin step in agent-review-panel.yml for the full rationale.
           git diff origin/main...HEAD -- . \
-            ':(exclude)packages/sheets/antlr/*.ts' \
             ':(exclude)packages/sheets/antlr/*.interp' \
             ':(exclude)packages/sheets/antlr/*.tokens' > /tmp/pr.diff
           # Regeneration-only change → filtered diff is empty and the panel

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -163,12 +163,36 @@ jobs:
         with:
           node-version: 22.x
 
+      # KEEP IN SYNC with the identical step in agent-review-on-demand.yml.
       - name: Compute diff + changed files (data for the reviewers)
         if: steps.pr.outputs.number != ''
         run: |
+          set -euo pipefail
           git fetch --no-tags origin main
-          git diff origin/main...HEAD > /tmp/pr.diff
+          # UNFILTERED on purpose: this list drives lensApplies → required_checks,
+          # and a list that shrinks mid-PR would let a lens that FAILED an earlier
+          # round silently stop being required, promoting an unresolved blocker.
           git diff --name-only origin/main...HEAD > /tmp/changed.txt
+          # Omit ANTLR *generated* output from the diff BODY only. `Formula.g4`
+          # — the hand-written grammar, and the only semantically reviewable
+          # file in that directory — is deliberately NOT excluded. On PR #521
+          # these tables were 35.6 KB of a 75.6 KB diff, re-read by 4 lenses ×
+          # 2 samples × 5 rounds; no reviewer meaningfully audits ANTLR state
+          # tables, and CLAUDE.md forbids hand-editing them (regenerate via
+          # `pnpm sheets build:formula`). Lockfiles are deliberately NOT
+          # excluded: they are supply-chain relevant and measured at 0% of
+          # every agent PR diff to date.
+          git diff origin/main...HEAD -- . \
+            ':(exclude)packages/sheets/antlr/*.ts' \
+            ':(exclude)packages/sheets/antlr/*.interp' \
+            ':(exclude)packages/sheets/antlr/*.tokens' > /tmp/pr.diff
+          # A regeneration-only change filters down to nothing, and the panel
+          # fails closed on an empty diff. Fall back to the unfiltered diff so
+          # that only ever pages for a genuinely empty change, never because
+          # the filter ate the whole thing.
+          if [ ! -s /tmp/pr.diff ]; then
+            git diff origin/main...HEAD > /tmp/pr.diff
+          fi
 
       - name: Fetch originating issue spec (for design-fit)
         if: steps.pr.outputs.number != ''

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -173,17 +173,25 @@ jobs:
           # and a list that shrinks mid-PR would let a lens that FAILED an earlier
           # round silently stop being required, promoting an unresolved blocker.
           git diff --name-only origin/main...HEAD > /tmp/changed.txt
-          # Omit ANTLR *generated* output from the diff BODY only. `Formula.g4`
-          # — the hand-written grammar, and the only semantically reviewable
-          # file in that directory — is deliberately NOT excluded. On PR #521
-          # these tables were 35.6 KB of a 75.6 KB diff, re-read by 4 lenses ×
-          # 2 samples × 5 rounds; no reviewer meaningfully audits ANTLR state
-          # tables, and CLAUDE.md forbids hand-editing them (regenerate via
-          # `pnpm sheets build:formula`). Lockfiles are deliberately NOT
-          # excluded: they are supply-chain relevant and measured at 0% of
-          # every agent PR diff to date.
+          # Omit ANTLR generated *tooling* artifacts from the diff BODY only.
+          # `.interp` / `.tokens` are IDE/tooling files with no reference
+          # anywhere in src, package.json, or the build — nothing loads them at
+          # runtime, so no lens can act on their contents. On PR #521 they were
+          # 17.2 KB of a 75.6 KB diff, re-read by 4 lenses x 2 samples x 5 rounds.
+          #
+          # The generated `.ts` files are deliberately KEPT, even though they are
+          # the larger half: they are executable code shipped in the sheets
+          # package, and excluding them would leave EVERY lens (security included)
+          # with no view of a hand-edit that `Formula.g4` does not justify. The
+          # security lens raised exactly this on the PR that introduced this step,
+          # and it was right — the only compensating control is an edit-time hook
+          # that an out-of-band editor bypasses. Re-excluding them requires a
+          # regen-and-diff CI lane first (see the follow-up issue).
+          #
+          # `Formula.g4` (the hand-written grammar) is never excluded. Lockfiles
+          # are never excluded either: supply-chain relevant, and measured at 0%
+          # of every agent PR diff to date.
           git diff origin/main...HEAD -- . \
-            ':(exclude)packages/sheets/antlr/*.ts' \
             ':(exclude)packages/sheets/antlr/*.interp' \
             ':(exclude)packages/sheets/antlr/*.tokens' > /tmp/pr.diff
           # A regeneration-only change filters down to nothing, and the panel

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -396,13 +396,16 @@ Components:
   spawns a FRESH read-only subagent per **lens** — `correctness`, `security`,
   `design-fit`, `test-adequacy` (declared data-drivenly in
   `scripts/agent/lenses/lenses.json` + one rubric `.md` each). The reviewed
-  artifact is the branch diff against `main`, minus generated ANTLR output
-  (`packages/sheets/antlr/*.ts|.interp|.tokens`) — the hand-written
-  `packages/sheets/antlr/Formula.g4` grammar is deliberately kept (mirroring
-  `scripts/hooks/guard-generated-files.sh`, which already blocks edits to the
-  generated siblings), and the changed-FILE list is left
-  unfiltered because it drives `lensApplies` → the required-check set, so a list
-  that shrank mid-PR could un-require a lens that failed an earlier round. Each subagent has
+  artifact is the branch diff against `main`, minus ANTLR generated *tooling*
+  artifacts (`packages/sheets/antlr/*.interp|.tokens` — nothing loads them at
+  runtime, so no lens can act on them). The generated `.ts` files stay IN the
+  diff even though they are the larger half: they are executable code, and
+  excluding them would leave every lens blind to a hand-edit that
+  `packages/sheets/antlr/Formula.g4` does not justify, whose only compensating
+  control (`scripts/hooks/guard-generated-files.sh`) is bypassable out-of-band.
+  Re-excluding them requires a regen-and-diff lane first. The changed-FILE list
+  is left unfiltered because it drives `lensApplies` → the required-check set, so
+  a list that shrank mid-PR could un-require a lens that failed an earlier round. Each subagent has
   read-only tools only (Read/Grep/Glob; no branch-code execution), runs with
   `settingSources: []` (so the untrusted branch's `.claude` hooks/settings are
   never loaded — the workflow also strips `.claude/` and installs the SDK in a

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -395,7 +395,14 @@ Components:
   ONE orchestrator process (`scripts/agent/review-panel.mjs`, Claude Agent SDK)
   spawns a FRESH read-only subagent per **lens** — `correctness`, `security`,
   `design-fit`, `test-adequacy` (declared data-drivenly in
-  `scripts/agent/lenses/lenses.json` + one rubric `.md` each). Each subagent has
+  `scripts/agent/lenses/lenses.json` + one rubric `.md` each). The reviewed
+  artifact is the branch diff against `main`, minus generated ANTLR output
+  (`packages/sheets/antlr/*.ts|.interp|.tokens`) — the hand-written
+  `packages/sheets/antlr/Formula.g4` grammar is deliberately kept (mirroring
+  `scripts/hooks/guard-generated-files.sh`, which already blocks edits to the
+  generated siblings), and the changed-FILE list is left
+  unfiltered because it drives `lensApplies` → the required-check set, so a list
+  that shrank mid-PR could un-require a lens that failed an earlier round. Each subagent has
   read-only tools only (Read/Grep/Glob; no branch-code execution), runs with
   `settingSources: []` (so the untrusted branch's `.claude` hooks/settings are
   never loaded — the workflow also strips `.claude/` and installs the SDK in a

--- a/docs/tasks/active/20260727-omit-generated-antlr-from-review-lessons.md
+++ b/docs/tasks/active/20260727-omit-generated-antlr-from-review-lessons.md
@@ -1,0 +1,82 @@
+# Lessons — Omit generated ANTLR output from the reviewed diff
+
+## Half of this PR was superseded while it was being written
+
+The PR was scoped as "measurement foundation + cheap cost win": split
+`cache_read_input_tokens` out of the metrics ledger so a token total means
+something, *plus* the diff exclusion. The metrics half was written, tested, and
+green — and then PR #565 ("Report cost and weighted tokens in the agent-effort
+summary") turned out to have merged about an hour earlier, doing the same job
+better:
+
+- It renders `total_cost_usd`, which was **already recorded** on every ledger
+  record and simply never displayed. Cost is strictly better than any
+  hand-rolled weighting: the model prices cache reads at ~0.1× *and* prices each
+  model correctly, which a token ratio cannot.
+- It adds `weightedTokensFor` (cache read 0.1×, cache write 1.25×) as the
+  headline token figure.
+
+The `cachedTokens` + `formatCacheShare` work was reverted. It would have added a
+competing field to the same schema-free ledger for a diagnostic percentage that
+cost already expresses. Two things to carry forward: **re-check `origin/main`
+immediately before starting each PR in a multi-PR plan** — this plan was written
+against a `main` that moved twice within the day (#562, #565) — and when a
+metric you want is derivable from a field already being recorded, render the
+field before inventing a new one.
+
+Silver lining: PR 7 (incremental review) now has a *better* yardstick than
+planned. Its cost claim should be judged against #565's `Total-cost`, not
+against raw or cache-adjusted tokens.
+
+## The exclusion looked worthless until it was measured
+
+The instinct was to exclude lockfiles — the classic diff-bloat candidate.
+Measuring inverted that: lockfiles are 0% of *every* agent PR diff to date, and
+the only PR with real generated bloat was #521, at 48%. #521 is also the single
+PR that exhausted `MAX_REVIEW_ROUNDS` without converging. So the honest framing
+is not "diffs are big" but "the one historically-failing category is half
+generated output" — a much better reason to ship, and one that only appeared
+after measuring instead of assuming.
+
+Excluding lockfiles would have been actively wrong: it trades a real
+supply-chain signal for a measured saving of zero.
+
+## Two corrections that came from checking rather than pattern-matching
+
+- **`Formula.g4` must be kept.** A first pass matched on the directory name and
+  would have excluded the hand-written grammar along with its generated output.
+  The grammar is 1.1 KB of the 36.7 KB and is the only place a semantic bug in
+  that directory is visible.
+- **The repo had already drawn this exact line.**
+  `scripts/hooks/guard-generated-files.sh` blocks `PreToolUse(Edit|Write)` under
+  `packages/sheets/antlr/` with an explicit `.g4` carve-out. The pathspec here
+  mirrors it. Worth checking for an existing mechanically-enforced boundary
+  before designing a new one — the justification writes itself, and consistency
+  is free.
+
+## The planned prefix-caching optimization rested on a wrong premise
+
+Also scoped in and dropped: "put the diff first and the rubric last so the 8
+lens calls in a round share a cache prefix."
+
+Caching keys on an exact prefix rendered `tools → system → messages`, and
+`runLens` gives every lens a *different* `systemPrompt`
+(`You are the ${lens.title} reviewer…`) — so the calls already diverge at the
+system block and reordering the user message changes nothing. Making it work
+needs the system prompt unified across lenses **and** a serialized warm-up,
+because a cache entry is only readable once the first response starts streaming
+and both fan-outs (`Promise.all` over lenses, `Promise.all` over samples) fire
+concurrently. The most tractable version is narrower: the two samples of one
+lens are byte-identical requests firing in parallel, so serializing just those
+would let the second read the first's cache, at the cost of doubling per-lens
+latency. Left for a PR that can measure it against #565's cost line.
+
+## There is no drift check on the generated output
+
+Nothing in `package.json`, `scripts/verify-*.mjs`, or `harness.config.json`
+regenerates the parser and compares it against the committed files. Excluding
+those files from review therefore removes no guard that existed — the "review"
+of those 35.6 KB was theater either way. But it does leave a real (pre-existing)
+gap: a hand-edit to `FormulaLexer.ts` that does not match `Formula.g4` is caught
+by nothing except the edit-time hook, which an out-of-band editor bypasses. A
+regen-and-diff lane would close it cheaply.

--- a/docs/tasks/active/20260727-omit-generated-antlr-from-review-lessons.md
+++ b/docs/tasks/active/20260727-omit-generated-antlr-from-review-lessons.md
@@ -71,6 +71,33 @@ lens are byte-identical requests firing in parallel, so serializing just those
 would let the second read the first's cache, at the cost of doubling per-lens
 latency. Left for a PR that can measure it against #565's cost line.
 
+## Documenting a risk is not mitigating it
+
+The first revision excluded the generated `.ts` files, and this very file said:
+
+> a hand-edit to `FormulaLexer.ts` that does not match `Formula.g4` would be
+> caught by nothing
+
+The security lens then raised exactly that as a blocking `major`. Writing the
+risk down had made it feel handled; it wasn't. The lens was right, the finding
+was accepted, and the `.ts` exclusion was reverted — the executable half of the
+generated output stays reviewable.
+
+Two things worth keeping from how that went:
+
+- **The lens earned its keep on a PR about the lens system.** It was correct,
+  in-lane, correctly severity-rated (`major`, not `critical`, because
+  exploitability depends on merge automation not visible in the diff), and it
+  explicitly credited the parts of the change that were security-positive
+  (`set -euo pipefail`, the fail-closed empty-diff fallback, keeping lockfiles
+  and `changed.txt` unfiltered). That is what a useful review looks like.
+- **The right response to a valid finding is to close the gap, not to restore the
+  thing that was wasteful.** Reverting the whole exclusion would have put 35 KB
+  of unreviewable state tables back in front of four lenses for a control that
+  detects nothing in practice. Narrowing to the non-executable artifacts kept 22%
+  of the saving with no security tradeoff, and the full saving stays available
+  behind a mechanical check.
+
 ## There is no drift check on the generated output
 
 Nothing in `package.json`, `scripts/verify-*.mjs`, or `harness.config.json`

--- a/docs/tasks/active/20260727-omit-generated-antlr-from-review-todo.md
+++ b/docs/tasks/active/20260727-omit-generated-antlr-from-review-todo.md
@@ -35,12 +35,50 @@ Reviewing them was never meaningful:
 
 ## Scope
 
-- [x] `agent-review-panel.yml`: exclude `packages/sheets/antlr/*.ts|.interp|.tokens`
+- [x] `agent-review-panel.yml`: exclude `packages/sheets/antlr/*.interp|.tokens`
       from the diff **body**; keep `changed.txt` unfiltered; add an
       empty-filter fallback; add `set -euo pipefail`.
 - [x] `agent-review-on-demand.yml`: the identical step, marked KEEP IN SYNC.
 - [x] `docs/design/harness-engineering.md`: document the reviewed-artifact scope
       in the review-panel section.
+
+## Narrowed after review: the generated `.ts` files stay in the diff
+
+The first revision also excluded `packages/sheets/antlr/*.ts`. **The security
+lens raised a `major` on that, and it was right:**
+
+> Excluding `packages/sheets/antlr/*.ts` from the reviewed diff body creates a
+> security review blindspot: arbitrary TypeScript added/modified in that path is
+> executed as part of the sheets package but is never shown to any review lens,
+> and the only compensating control is bypassable.
+
+That is the same gap this task's own lessons file had already written down — so
+it was a documented risk, not a surprise, and documenting a risk is not
+mitigating it. The `.ts` exclusion is reverted.
+
+What remains excluded is `.interp` / `.tokens`, which is unambiguously safe:
+`grep` across `packages/sheets/src`, `packages/sheets/package.json`, and
+`scripts/` finds **zero** references, so nothing loads them at runtime or build
+time and no lens could act on their contents.
+
+Cost of the narrowing, measured on #521:
+
+| exclusion | reviewed body | saving |
+|---|---|---|
+| none | 75,566 B | — |
+| `.ts` + `.interp` + `.tokens` (first revision) | 39,923 B | 47% |
+| `.interp` + `.tokens` (shipped) | 58,398 B | **22%** |
+
+Half the benefit, and worth it. A 22% cut on formula-engine PRs is still real,
+and it is now bought with no security tradeoff at all.
+
+The `.ts` exclusion can return once a **regen-and-diff CI lane** exists — CI
+runs `pnpm sheets build:formula` and fails if the committed output differs from
+what `Formula.g4` produces. That is a strictly stronger control than review (no
+reviewer meaningfully audits 18 KB of ANTLR tables), but it needs a JRE in CI
+(`antlr4ts-cli` wraps the Java tool; not installable locally here) and its
+determinism must be verified before anything depends on it. Filed as a follow-up
+rather than guessed at inside this PR.
 
 ## Design decisions
 

--- a/docs/tasks/active/20260727-omit-generated-antlr-from-review-todo.md
+++ b/docs/tasks/active/20260727-omit-generated-antlr-from-review-todo.md
@@ -1,0 +1,87 @@
+# Omit generated ANTLR output from the reviewed diff
+
+Stop paying four lenses × two samples × N rounds to "review" ANTLR parser
+tables that nobody is allowed to hand-edit.
+
+First of eight PRs from the review-panel recall & cost audit.
+
+## Motivation
+
+The review panel reviews `git diff origin/main...HEAD` verbatim, which includes
+the generated ANTLR parser output under `packages/sheets/antlr/`.
+
+Measuring the generated/lock share of every agent PR diff to date:
+
+| PR | generated share |
+|---|---|
+| #513, #544, #546, #547, #548, #549, #559 | 0% |
+| **#521** | **48%** (35.6 KB of 75.6 KB) |
+
+The exclusion is worthless on routine PRs and material on exactly one category —
+formula-engine work, which regenerates the parser. #521 is also the only PR to
+date that exhausted `MAX_REVIEW_ROUNDS` without converging, so those 35.6 KB
+were re-read by 4 lenses × 2 samples × 5 rounds.
+
+Reviewing them was never meaningful:
+
+- `CLAUDE.md` states regeneration is the only valid edit path, and the repo
+  already enforces that mechanically — `scripts/hooks/guard-generated-files.sh`
+  is a `PreToolUse(Edit|Write)` hook that **blocks** edits under
+  `packages/sheets/antlr/` while explicitly allowing `Formula.g4`. This change
+  simply makes the reviewer consistent with a boundary the harness already
+  enforces at edit time.
+- The files carry `@ts-nocheck` and are ANTLR serialization tables; no reviewer
+  meaningfully audits them.
+
+## Scope
+
+- [x] `agent-review-panel.yml`: exclude `packages/sheets/antlr/*.ts|.interp|.tokens`
+      from the diff **body**; keep `changed.txt` unfiltered; add an
+      empty-filter fallback; add `set -euo pipefail`.
+- [x] `agent-review-on-demand.yml`: the identical step, marked KEEP IN SYNC.
+- [x] `docs/design/harness-engineering.md`: document the reviewed-artifact scope
+      in the review-panel section.
+
+## Design decisions
+
+- **`Formula.g4` is deliberately kept.** It is the hand-written grammar and the
+  only semantically reviewable file in the directory — 1.1 KB of the 36.7 KB on
+  #521, and where a bad grammar change is actually visible. The pathspec mirrors
+  `guard-generated-files.sh`'s own `.g4`-allowed carve-out.
+- **`changed.txt` is deliberately NOT filtered.** It drives `lensApplies` →
+  `required_checks`. A changed-file list that shrank mid-PR could mark a
+  narrow-glob lens non-applicable in a later round, drop it from the required
+  set, and promote a PR whose lens FAILED an earlier round. Only the diff body
+  is filtered. (Unreachable with today's all-`**` manifest; PR #564 introduces
+  narrow globs, so the invariant is about to start mattering.)
+- **Lockfiles are deliberately NOT excluded**, despite being the obvious
+  candidate. They are supply-chain relevant — a swapped dependency is a real
+  attack the security lens should see — and measurement showed they are 0% of
+  every agent PR diff to date. Excluding them would trade a real signal for no
+  measured saving.
+- **Empty-filter fallback.** A regeneration-only change filters down to nothing,
+  and `review-panel.mjs` fails closed on an empty diff. The step falls back to
+  the unfiltered diff so an empty review only ever pages for a genuinely empty
+  change, never because the filter ate everything.
+- **`set -euo pipefail` added.** Previously a failed `git fetch` could leave a
+  stale `origin/main` and silently produce the wrong diff; only the final
+  command's status was observed.
+
+## Deliberately out of scope
+
+- **Metrics/cost instrumentation** — this PR originally carried a `cachedTokens`
+  split, superseded mid-flight by PR #565. See the lessons file.
+- **Prompt reordering for prefix caching** — scoped in, then dropped on a wrong
+  premise. See the lessons file.
+- **A regen-drift check.** Nothing currently regenerates the parser and compares
+  it to the committed files, so a hand-edit that does not match `Formula.g4` is
+  caught by nothing. Pre-existing gap, not introduced here, but worth a lane.
+
+## Verification
+
+- `pnpm verify:self` — all 11 lanes green (incl. lane 1 `agent:tests`, 73 tests,
+  and `verify:entropy`'s doc-staleness check over the edited design doc).
+- Simulated against PR #521's squashed change: 75,524 B → 39,885 B (47% of the
+  reviewed body removed), `Formula.g4` still present in the filtered diff, all
+  three `antlr` entries still in `changed.txt`, zero generated `.ts` leaked.
+- Both workflow files re-parsed as YAML; both `run:` blocks checked with `bash -n`.


### PR DESCRIPTION
## Summary

Exclude generated ANTLR output (`packages/sheets/antlr/*.ts|.interp|.tokens`)
from the **body** of the diff the review panel reviews, in both
`agent-review-panel.yml` and `agent-review-on-demand.yml`. The hand-written
`Formula.g4` grammar is kept, and `changed.txt` is left unfiltered.

First of eight PRs from a review-panel recall & cost audit.

## Why

The panel reads `git diff origin/main...HEAD` verbatim, so it also reviews the
generated ANTLR parser. Measuring the generated share of every agent PR diff to
date:

| PR | generated share |
|---|---|
| #513, #544, #546, #547, #548, #549, #559 | 0% |
| **#521** | **48%** (35.6 KB of 75.6 KB) |

So the saving is nil on routine PRs and material on exactly one category —
formula-engine work, which regenerates the parser. #521 is also the only PR to
date that exhausted `MAX_REVIEW_ROUNDS` without converging, which means those
35.6 KB were re-read by 4 lenses × 2 samples × 5 rounds.

Reviewing those bytes was never meaningful, and the repo already says so
mechanically: `scripts/hooks/guard-generated-files.sh` is a
`PreToolUse(Edit|Write)` hook that **blocks** edits under
`packages/sheets/antlr/` with an explicit `Formula.g4` carve-out, and `CLAUDE.md`
makes regeneration the only valid edit path. This change just makes the
*reviewer* consistent with a boundary the harness already enforces at *edit*
time — the pathspec mirrors that same carve-out.

Simulated against #521's squashed change: **75,524 B → 39,885 B** (47% of the
reviewed body removed), `Formula.g4` still present, all three `antlr` entries
still in `changed.txt`, zero generated `.ts` leaked.

### Three deliberate non-changes

- **`changed.txt` stays unfiltered.** It drives `lensApplies` →
  `required_checks`. A file list that shrank mid-PR could mark a narrow-glob
  lens non-applicable in a later round, drop it from the required set, and
  promote a PR whose lens **failed** an earlier round. Unreachable with today's
  all-`**` manifest — but #564 is about to introduce narrow globs, so the
  invariant starts mattering imminently.
- **Lockfiles stay in the diff.** The obvious candidate, but they are
  supply-chain relevant (a swapped dependency is a real attack the security lens
  should see) and measure at 0% of every agent PR diff. Excluding them would
  trade a real signal for no measured saving.
- **Empty-filter fallback.** A regeneration-only change would filter down to
  nothing, and `review-panel.mjs` fails closed on an empty diff. The step falls
  back to the unfiltered diff, so an empty review only ever pages for a
  genuinely empty change — never because the filter ate everything.

Also adds `set -euo pipefail` to both steps: previously a failed `git fetch`
could leave a stale `origin/main` and silently produce the wrong diff, since
only the final command's status was observed.

## Linked Issues

None — this came out of an audit rather than a filed issue.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Locally: `pnpm verify:self` green 11/11 (117.5s), including lane 1 `agent:tests`
(73 tests) and `verify:entropy`'s doc-staleness check over the edited design
doc. Both workflow files re-parsed as YAML and both `run:` blocks checked with
`bash -n`.

Skip reason (if applicable): n/a — CI runs both lanes.

## Risk Assessment

- **User-facing risk:** none. No product code changes; this only affects what
  the review panel is shown.
- **Data/security risk:** low, and deliberately bounded. The security lens loses
  sight of hand-edits to generated ANTLR files — but those are already blocked
  at edit time by `guard-generated-files.sh`, and no reviewer was meaningfully
  auditing 17 KB of serialization tables. Lockfiles, the genuinely
  security-relevant case, are explicitly **not** excluded. Note a pre-existing
  gap this makes visible but does not create: nothing regenerates the parser and
  diffs it against the committed files, so a hand-edit that doesn't match
  `Formula.g4` is caught by nothing but the edit-time hook. A regen-and-diff
  lane would close it cheaply — filed as follow-up below.
- **Rollback plan:** revert the commit. The change is two `run:` blocks and a
  doc paragraph; no state, no migration.

## Notes for Reviewers

- **AI assistance:** authored with Claude Code (Opus 5) in an interactive
  session — the measurement, the design decisions, and this description were
  produced in that session and reviewed by me. Not an autonomous pipeline run,
  so no `Assisted-by:` trailer; the commit carries the repo's usual
  `Co-Authored-By:` trailer instead.
- **Fork PR caveat:** this is opened from a fork, so
  `agent-review-panel.yml`/`agent-iterate-ci.yml` skip it (both gate on
  `head_repository.full_name == github.repository`). It gets **no review panel,
  no auto-fix, no promote** — please review directly. `@claude review` does run
  on forks (advisory, no check runs) if a second opinion is useful.
- **The two `Compute diff` steps are intentionally duplicated** and marked
  `KEEP IN SYNC`. Consolidating them into a shared trusted script is planned for
  a later PR in this series, which restructures that step anyway.
- **Follow-up work:**
  - A regen-and-diff lane for `packages/sheets/antlr/` (see Data/security risk).
  - Seven further PRs from the same audit: convergence detection, model refresh,
    an independent (repo-grounded) verifier, coverage-first lens rubrics, a
    blast-radius lens, incremental review, and a labelled-miss corpus.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Review panels now omit generated ANTLR parser artifacts from diff content, reducing noise while retaining relevant grammar changes.
  - Changed-file lists remain complete so all applicable review checks continue to run.
  - Added a fallback to display the full diff when filtering would produce no content.
  - Improved safeguards for reliable diff generation.

- **Documentation**
  - Updated review-process documentation with filtering rules, exceptions, verification expectations, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->