### PR TITLE
Add per-PR review-panel reliability & effort signals

### DIFF
--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -355,7 +355,10 @@ export function renderSummary({ agg, panelAgg, panelStats, flips, scope }) {
       `- Weighted raised (effort proxy, not recall): ${weightSeverity(r)}`,
       `- Sent to verifier: ${v.sentToVerifier || 0}`,
       `- Refuted: ${v.refuted || 0} (${v.refutedHighConfidence || 0} high-confidence)`,
-      `- Survived to gate: ${k.critical || 0} critical, ${k.major || 0} major`,
+      // All four severities shown (critical/major lead as the blocking ones)
+      // so the raw counts reconcile with the weighted scalar below, which
+      // weights every severity — mirrors the "Findings raised" pair above.
+      `- Survived to gate: ${k.critical || 0} critical, ${k.major || 0} major, ${k.minor || 0} minor, ${k.nit || 0} nit`,
       `- Weighted survived-to-gate: ${weightSeverity(k)}`,
     );
     // Advisory heads-up (NOT a verdict): a lens that blocked then approved across

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -183,6 +183,91 @@ export function aggregatePanelStats(entries) {
   return { agreementCounts, raised, kept, verifier: { sentToVerifier, refuted, refutedHighConfidence } };
 }
 
+/**
+ * Detect blocking→clean flips per lens across an ORDERED list of review records
+ * (one `kind:"review"` record per round). `listAllComments` returns GitHub issue
+ * comments in created_at-ascending order, so the array is already chronological =
+ * round order — do NOT re-sort it. A flip is a lens that was blocking (kept
+ * critical/major > 0) in one valid round and clean (non-blocking) in a LATER
+ * valid round, i.e. it requested changes and then approved. This is the
+ * cross-round analogue of the intra-round sample-agreement signal and is exactly
+ * the failure PR #521 exhibited (blocking finding silently dropped next round).
+ *
+ * Rounds where a lens hit an infra/quota error (`infraError` set or
+ * `samplesOk === 0`, which carry a synthetic blocking finding) are skipped for
+ * that lens — an infra recovery the next round is not a review flip. Only
+ * *valid* consecutive rounds of a lens are compared.
+ *
+ * HONEST LIMITATION: with only per-round severity counts we cannot tell a flip
+ * caused by a genuine fix (good) from one caused by judge inconsistency (bad).
+ * This is therefore an ADVISORY heads-up flag, not a defect count. Tightening it
+ * to "the finding-relevant code did not change" needs per-round diff/line data
+ * the ledger does not carry today. (If GitHub's comment ordering ever stopped
+ * being chronological, flip direction could invert — accepted risk.)
+ *
+ * Shape-safe: records without `lensStats` (pre-instrumentation) or a `kept`
+ * missing a severity key are tolerated and contribute nothing.
+ *
+ * @returns {{ flips: {lens: string, fromRound: number, toRound: number}[], byLens: Record<string, number> }}
+ */
+export function detectFlips(reviewRecords) {
+  const list = Array.isArray(reviewRecords) ? reviewRecords : [];
+  // Per lens id, the ordered subsequence of that lens's VALID round states
+  // (true = blocking, false = clean), tagged with the record index for
+  // human-readable r<from>→r<to> traceability.
+  const byLensStates = new Map();
+  list.forEach((rec, round) => {
+    const lensStats = rec && Array.isArray(rec.lensStats) ? rec.lensStats : [];
+    for (const e of lensStats) {
+      if (!e || typeof e !== "object" || e.id == null) continue;
+      // Skip infra/quota rounds — their synthetic blocking finding and next-round
+      // recovery are not a review flip.
+      if (e.infraError || Number(e.samplesOk) === 0) continue;
+      const kept = e.kept || {};
+      const blocking = (Number(kept.critical) || 0) + (Number(kept.major) || 0) > 0;
+      if (!byLensStates.has(e.id)) byLensStates.set(e.id, []);
+      byLensStates.get(e.id).push({ blocking, round });
+    }
+  });
+  const flips = [];
+  const byLens = {};
+  for (const [lens, seq] of byLensStates) {
+    for (let i = 1; i < seq.length; i++) {
+      // A flip = an adjacent pair of valid rounds going blocking → clean.
+      if (seq[i - 1].blocking && !seq[i].blocking) {
+        flips.push({ lens, fromRound: seq[i - 1].round, toRound: seq[i].round });
+        byLens[lens] = (byLens[lens] || 0) + 1;
+      }
+    }
+  }
+  return { flips, byLens };
+}
+
+/**
+ * Severity weights for collapsing a {critical,major,minor,nit} vector into one
+ * scalar. Mirrors the report's DoorDash-style scheme mapped onto this scale.
+ * A critical finding is worth 8× a nit, so a lens that catches real problems
+ * isn't scored like one that only flags style.
+ */
+export const SEVERITY_WEIGHTS = { critical: 4, major: 2, minor: 1, nit: 0.5 };
+
+/**
+ * Weighted scalar for a severity-count vector. This is an EFFORT/NOISE proxy
+ * (how much reviewer attention the lens generated), NOT recall — recall needs
+ * ground truth, which this per-PR layer deliberately does not have. Always
+ * reported alongside the raw per-severity vector, never as a replacement for it.
+ * Null/shape-safe: a missing object and missing keys count as 0.
+ */
+export function weightSeverity(counts) {
+  const c = counts || {};
+  return (
+    (Number(c.critical) || 0) * SEVERITY_WEIGHTS.critical +
+    (Number(c.major) || 0) * SEVERITY_WEIGHTS.major +
+    (Number(c.minor) || 0) * SEVERITY_WEIGHTS.minor +
+    (Number(c.nit) || 0) * SEVERITY_WEIGHTS.nit
+  );
+}
+
 /** S/M/L from total lines changed in the PR diff. */
 export function scopeSize(additions = 0, deletions = 0) {
   const changed = (Number(additions) || 0) + (Number(deletions) || 0);
@@ -214,7 +299,7 @@ export function formatUsd(n) {
  * responds to what the panel found, and review, the panel's own compute, are
  * easy to conflate by name, so their costs are rendered in separate sections
  * rather than folded into one set of totals). */
-export function renderSummary({ agg, panelAgg, panelStats, scope }) {
+export function renderSummary({ agg, panelAgg, panelStats, flips, scope }) {
   const hasPanel = !!panelAgg && panelAgg.sessions > 0;
   const panelTokens = hasPanel ? panelAgg.tokens : 0;
   const panelWeighted = hasPanel ? panelAgg.weightedTokens : 0;
@@ -259,11 +344,27 @@ export function renderSummary({ agg, panelAgg, panelStats, scope }) {
       `- Rounds: ${panelAgg.sessions}`,
       `- Total-time: ${formatMinutes(panelAgg.durationMs)}`,
       `- Turns: ${panelAgg.turns}`,
-      `- Sample-agreement: ${ac.identical || 0} identical, ${ac.partial || 0} partial, ${ac.disjoint || 0} disjoint (${sampledRounds} lens-round samples)`,
+      // Reliability = whether the judge agrees with ITSELF across the N samples
+      // of a single round (intra-round self-consistency), NOT whether it agrees
+      // with the truth. High agreement here means a stable judge, not a correct
+      // one — see the meta-eval's reliability≠validity finding.
+      `- Reliability (intra-round self-consistency, not correctness): ${ac.identical || 0} identical, ${ac.partial || 0} partial, ${ac.disjoint || 0} disjoint across ${sampledRounds} lens-rounds`,
       `- Findings raised: ${r.critical || 0} critical, ${r.major || 0} major, ${r.minor || 0} minor, ${r.nit || 0} nit`,
+      // Weighted scalar companion to the raw vector above — an effort/noise
+      // proxy, not recall (no ground truth here). Shown alongside, not instead.
+      `- Weighted raised (effort proxy, not recall): ${weightSeverity(r)}`,
       `- Sent to verifier: ${v.sentToVerifier || 0}`,
       `- Refuted: ${v.refuted || 0} (${v.refutedHighConfidence || 0} high-confidence)`,
       `- Survived to gate: ${k.critical || 0} critical, ${k.major || 0} major`,
+      `- Weighted survived-to-gate: ${weightSeverity(k)}`,
+    );
+    // Advisory heads-up (NOT a verdict): a lens that blocked then approved across
+    // rounds — the PR #521 pattern. Can't distinguish a genuine fix from judge
+    // inconsistency here (see detectFlips), so the wording says "review manually".
+    const flipList = flips?.flips || [];
+    lines.push(
+      `- ⚠️ Cross-round flips (blocking→clean; advisory, review manually): ${flipList.length}` +
+        (flipList.length ? ` — ${flipList.map((f) => `${f.lens} r${f.fromRound}→r${f.toRound}`).join(", ")}` : ""),
     );
   }
   return lines.join("\n");
@@ -412,13 +513,16 @@ function cmdSummarize(args) {
   const panelStats = panelRecords.length
     ? aggregatePanelStats(panelRecords.flatMap((r) => (Array.isArray(r.lensStats) ? r.lensStats : [])))
     : null;
+  // `panelRecords` is in ledger (chronological = round) order — detectFlips
+  // relies on that, so pass it as-is without re-sorting.
+  const flips = panelRecords.length ? detectFlips(panelRecords) : null;
   const scope = scopeSize(prInfo.additions, prInfo.deletions);
   try {
     // Post the summary FRESH (not upsert-in-place): a prior summary was pinned at
     // its original creation point (often an early paged hand-off), so editing it
     // leaves the up-to-date summary buried mid-thread. Posting new lands it at the
     // BOTTOM where a human looks; the old one is deleted just below.
-    postComment(pr, renderSummary({ agg, panelAgg, panelStats, scope }));
+    postComment(pr, renderSummary({ agg, panelAgg, panelStats, flips, scope }));
   } catch (e) {
     return bail(`could not post summary for PR #${pr}: ${e.message}`);
   }

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -5,11 +5,14 @@ import {
   sumExecutions,
   aggregate,
   aggregatePanelStats,
+  detectFlips,
   scopeSize,
   formatTokens,
   formatMinutes,
   formatUsd,
   weightedTokensFor,
+  weightSeverity,
+  SEVERITY_WEIGHTS,
   renderSummary,
   serializeRecord,
   parseMetricComment,
@@ -116,6 +119,74 @@ test("aggregatePanelStats: rolls up lens/round entries — agreement, severity-w
   assert.deepEqual(aggregatePanelStats([null, "junk", {}]).raised, { critical: 0, major: 0, minor: 0, nit: 0 });
 });
 
+// One review record (a `kind:"review"` ledger comment) carrying the given lens
+// states. `spec` maps lensId → per-round override; here we build a single round.
+const reviewRound = (lenses) => ({
+  kind: "review",
+  lensStats: lenses.map((l) => ({
+    id: l.id,
+    samplesOk: l.samplesOk ?? 2,
+    ...(l.infraError ? { infraError: l.infraError } : {}),
+    kept: { critical: 0, major: l.blocking ? 1 : 0, minor: 0, nit: 0, ...(l.kept || {}) },
+  })),
+});
+
+test("detectFlips: flags a lens that went blocking→clean across two valid rounds", () => {
+  const records = [
+    reviewRound([{ id: "correctness", blocking: true }]),
+    reviewRound([{ id: "correctness", blocking: false }]),
+  ];
+  const { flips, byLens } = detectFlips(records);
+  assert.deepEqual(flips, [{ lens: "correctness", fromRound: 0, toRound: 1 }]);
+  assert.deepEqual(byLens, { correctness: 1 });
+});
+
+test("detectFlips: stays-blocking or stays-clean is not a flip; clean→blocking is not a flip", () => {
+  const stayBlocking = [reviewRound([{ id: "sec", blocking: true }]), reviewRound([{ id: "sec", blocking: true }])];
+  const stayClean = [reviewRound([{ id: "sec", blocking: false }]), reviewRound([{ id: "sec", blocking: false }])];
+  const escalate = [reviewRound([{ id: "sec", blocking: false }]), reviewRound([{ id: "sec", blocking: true }])];
+  assert.deepEqual(detectFlips(stayBlocking).flips, []);
+  assert.deepEqual(detectFlips(stayClean).flips, []);
+  assert.deepEqual(detectFlips(escalate).flips, []); // only blocking→clean counts
+});
+
+test("detectFlips: an infra/quota round between valid rounds is skipped, not a flip", () => {
+  // blocking → (infra error) → blocking: the infra round is dropped, leaving
+  // blocking→blocking on the valid subsequence, so NO flip.
+  const withInfraError = [
+    reviewRound([{ id: "design", blocking: true }]),
+    reviewRound([{ id: "design", blocking: true, infraError: "429 quota" }]),
+    reviewRound([{ id: "design", blocking: true }]),
+  ];
+  assert.deepEqual(detectFlips(withInfraError).flips, []);
+  // samplesOk:0 is treated the same as infraError (both mark an infra round).
+  const withZeroSamples = [
+    reviewRound([{ id: "design", blocking: true }]),
+    reviewRound([{ id: "design", blocking: true, samplesOk: 0 }]),
+    reviewRound([{ id: "design", blocking: true }]),
+  ];
+  assert.deepEqual(detectFlips(withZeroSamples).flips, []);
+});
+
+test("detectFlips: lenses are independent — one flips, another does not", () => {
+  const records = [
+    reviewRound([{ id: "correctness", blocking: true }, { id: "tests", blocking: true }]),
+    reviewRound([{ id: "correctness", blocking: false }, { id: "tests", blocking: true }]),
+  ];
+  const { flips, byLens } = detectFlips(records);
+  assert.deepEqual(flips, [{ lens: "correctness", fromRound: 0, toRound: 1 }]);
+  assert.deepEqual(byLens, { correctness: 1 });
+});
+
+test("detectFlips: empty / single-round / shape-junk inputs never throw and find nothing", () => {
+  assert.deepEqual(detectFlips([]).flips, []);
+  assert.deepEqual(detectFlips(null).flips, []);
+  assert.deepEqual(detectFlips([reviewRound([{ id: "correctness", blocking: true }])]).flips, []); // one round
+  // pre-instrumentation records (no lensStats) and a lens missing `kept` are tolerated
+  assert.deepEqual(detectFlips([{ kind: "review" }, { kind: "review", lensStats: [{ id: "x" }] }]).flips, []);
+  assert.deepEqual(detectFlips([null, "junk", { lensStats: "nope" }]).flips, []);
+});
+
 test("scopeSize: S/M/L thresholds on total diff lines", () => {
   assert.equal(scopeSize(10, 5), "S");
   assert.equal(scopeSize(50, 0), "S");
@@ -143,6 +214,19 @@ test("weightedTokensFor: cache reads 0.1x, cache writes 1.25x, input/output 1x",
   );
   assert.equal(weightedTokensFor({}), 0);
   assert.equal(weightedTokensFor(undefined), 0);
+});
+
+test("weightSeverity: severity-weighted scalar, shape/null-safe", () => {
+  // critical 4, major 2, minor 1, nit 0.5
+  assert.equal(weightSeverity({ critical: 1, major: 1, minor: 1, nit: 1 }), 7.5);
+  assert.equal(weightSeverity({ critical: 2 }), 8); // missing keys treated as 0
+  assert.equal(weightSeverity({}), 0);
+  assert.equal(weightSeverity(null), 0); // missing object treated as 0
+  assert.equal(weightSeverity(undefined), 0);
+  // non-numeric junk coerces to 0, never NaN
+  assert.equal(weightSeverity({ critical: "x", major: 3 }), 6);
+  // weights are the documented DoorDash-style scheme mapped to this scale
+  assert.deepEqual(SEVERITY_WEIGHTS, { critical: 4, major: 2, minor: 1, nit: 0.5 });
 });
 
 test("renderSummary: matches the requested bullet format", () => {
@@ -176,17 +260,26 @@ test("renderSummary: with review-panel data, renders a separate section + combin
       kept: { critical: 1, major: 3, minor: 0, nit: 0 },
       verifier: { sentToVerifier: 7, refuted: 3, refutedHighConfidence: 2 },
     },
+    flips: { flips: [{ lens: "correctness", fromRound: 0, toRound: 1 }], byLens: { correctness: 1 } },
     scope: "M",
   });
   assert.match(md, /### Code-fix agent/);
   assert.match(md, /### Review panel/);
   assert.match(md, /- Rounds: 2/);
   assert.match(md, /- Total-time: 27m/);
-  assert.match(md, /- Sample-agreement: 6 identical, 1 partial, 1 disjoint \(8 lens-round samples\)/);
+  // reliability wording makes explicit this is self-consistency, not correctness
+  assert.match(md, /- Reliability \(intra-round self-consistency, not correctness\): 6 identical, 1 partial, 1 disjoint across 8 lens-rounds/);
   assert.match(md, /- Findings raised: 2 critical, 5 major, 3 minor, 1 nit/);
+  // weighted companion is additional, not a replacement for the raw vector:
+  // 2*4 + 5*2 + 3*1 + 1*0.5 = 21.5
+  assert.match(md, /- Weighted raised \(effort proxy, not recall\): 21\.5/);
   assert.match(md, /- Sent to verifier: 7/);
   assert.match(md, /- Refuted: 3 \(2 high-confidence\)/);
   assert.match(md, /- Survived to gate: 1 critical, 3 major/);
+  // 1*4 + 3*2 = 10
+  assert.match(md, /- Weighted survived-to-gate: 10/);
+  // advisory cross-round flip line, with the offending lens + round transition
+  assert.match(md, /- ⚠️ Cross-round flips \(blocking→clean; advisory, review manually\): 1 — correctness r0→r1/);
   // per-section cost + weighted/raw tokens carry the split
   assert.match(md, /### Review panel\n\n- Cost: \$0\.80\n- Tokens: ~40K weighted \(~300K raw\)/);
   // combined totals: cost $3.30 + $0.80 = $4.10; weighted 300K + 40K = 340K; raw 1.1M + 300K = 1.4M

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -257,7 +257,7 @@ test("renderSummary: with review-panel data, renders a separate section + combin
     panelStats: {
       agreementCounts: { identical: 6, partial: 1, disjoint: 1, single: 0 },
       raised: { critical: 2, major: 5, minor: 3, nit: 1 },
-      kept: { critical: 1, major: 3, minor: 0, nit: 0 },
+      kept: { critical: 1, major: 3, minor: 2, nit: 2 },
       verifier: { sentToVerifier: 7, refuted: 3, refutedHighConfidence: 2 },
     },
     flips: { flips: [{ lens: "correctness", fromRound: 0, toRound: 1 }], byLens: { correctness: 1 } },
@@ -275,9 +275,10 @@ test("renderSummary: with review-panel data, renders a separate section + combin
   assert.match(md, /- Weighted raised \(effort proxy, not recall\): 21\.5/);
   assert.match(md, /- Sent to verifier: 7/);
   assert.match(md, /- Refuted: 3 \(2 high-confidence\)/);
-  assert.match(md, /- Survived to gate: 1 critical, 3 major/);
-  // 1*4 + 3*2 = 10
-  assert.match(md, /- Weighted survived-to-gate: 10/);
+  // raw line shows all four severities so it reconciles with the weighted scalar
+  assert.match(md, /- Survived to gate: 1 critical, 3 major, 2 minor, 2 nit/);
+  // 1*4 + 3*2 + 2*1 + 2*0.5 = 13
+  assert.match(md, /- Weighted survived-to-gate: 13/);
   // advisory cross-round flip line, with the offending lens + round transition
   assert.match(md, /- ⚠️ Cross-round flips \(blocking→clean; advisory, review manually\): 1 — correctness r0→r1/);
   // per-section cost + weighted/raw tokens carry the split


### PR DESCRIPTION
## Summary

Phase 1 of the review-panel meta-evaluation: three **label-free, per-PR**
signals rendered from data the panel already emits on each PR's metric ledger.
No new storage, no offline harness, no ground truth — pure additions to
`metrics.mjs`'s pure helpers + rendering.

- **Reliability wording (A)** — the sample-agreement line now reads as
  **intra-round self-consistency, not correctness**, so the number is not
  mistaken for a validity signal. It measures whether the judge agrees with
  *itself* across the N samples of a round.
- **Cross-round flip detector (B)** — `detectFlips` flags a lens that went
  **blocking → clean** across rounds (the PR #521 pattern). Infra/quota rounds
  (`infraError` / `samplesOk === 0`) are excluded so an infra recovery isn't
  counted as a flip. Rendered as an **advisory heads-up ("review manually"),
  not a verdict**.
- **Severity-weighted rollup (C)** — `weightSeverity` (`critical 4 / major 2 /
  minor 1 / nit 0.5`) gives the raised/kept vectors a weighted scalar
  companion. This is an **effort/noise proxy, NOT recall** (recall needs ground
  truth). Shown *alongside* the raw per-severity vectors, never replacing them.

All helpers are null/shape-safe against pre-instrumentation records (missing
`lensStats`, missing severity keys) and the summary still renders when a PR has
no panel records.

### Honest caveat (reliability ≠ validity)

This layer measures the panel's **consistency and effort**, not its
**correctness**. The flip flag and the reliability line are heads-up signals;
they cannot prove the judge is right. That is expected — this is the "before"
baseline for a later judge/composition change, which is intentionally sequenced
after this so a before/after comparison is possible.

## Test plan

- `cd scripts/agent && node --test *.test.mjs` — 78 pass, 0 fail.
- New coverage: `detectFlips` (blocking→clean flip; stays-blocking/clean and
  clean→blocking are not flips; infra round skipped; multi-lens independence;
  empty/single-round/junk inputs), `weightSeverity` (known counts, missing
  keys, null/undefined, non-numeric junk), and the panel-summary render test
  extended to assert the reliability wording, both weighted lines, and the
  advisory flip line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliability reporting for review-panel results.
  * Added severity-weighted summaries for findings raised and findings surviving to the gate.
  * Added cross-round flip advisories when review outcomes change from blocking to clean.
* **Bug Fixes**
  * Improved handling of incomplete, invalid, infrastructure, and quota-related review data.
  * Enhanced metric calculations to remain stable with missing or malformed values.
* **Tests**
  * Expanded coverage for reliability, severity weighting, cross-round transitions, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->