### PR TITLE
Page early when review rounds stop converging

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -411,7 +411,8 @@ Components:
   **`agent-review-<lens>` check run** per lens (the author agent lacks
   `checks:write`). On all-pass it invokes the ready gate; on any failure it feeds
   the combined findings to the author in a bounded fix loop (pages after
-  `MAX_REVIEW_ROUNDS`). The `design-fit` lens additionally reads the originating
+  `MAX_REVIEW_ROUNDS`, or earlier on **non-convergence** — see below). The
+  `design-fit` lens additionally reads the originating
   issue (via `Fixes #N`) for spec-conformance — but ONLY when that issue is
   labelled `agent:candidate` AND authored by a non-Bot account (otherwise the
   author agent, which holds `issues:write`, could hand itself an arbitrary spec);
@@ -487,6 +488,25 @@ Components:
 - **Provenance** — `scripts/hooks/require-ai-disclosure.sh` (PreToolUse Bash,
   gated on `WAFFLEBASE_AGENT_AUTONOMOUS`) enforces an
   `Assisted-by: Claude Code (autonomous)` commit trailer on autonomous runs.
+
+- **Convergence detection (early exit from the fix loop).** `MAX_REVIEW_ROUNDS`
+  is a blunt backstop — PR #521 burned all five rounds re-litigating overlapping
+  findings before anyone was paged. `scripts/agent/rounds.mjs`'s
+  `detectStalledRounds` (wired into
+  `scripts/agent/review-round-guard.mjs`, checked BEFORE the round cap so the
+  more specific reason wins) pages as soon as two consecutive round pairs both
+  (a) fail to reduce the blocking-finding count and (b) exceed a similarity
+  threshold against the previous round's findings.
+  **Overlap alone is deliberately NOT the trigger**: the cross-round re-check
+  above re-merges unresolved priors by design, so a healthy PR shows high
+  overlap every round — only overlap *without* a falling count distinguishes a
+  stall. Similarity is the overlap coefficient over tokenised summaries, gated
+  on lens + file, calibrated at 0.3 against real rephrasings from PR #564
+  (same-defect 0.39-0.71, different-defect ≤0.08). It **fails toward not
+  paging**: malformed, unreadable, or infra/quota rounds break the run rather
+  than manufacture a page, since `MAX_REVIEW_ROUNDS` still backstops and a
+  spurious page is the costlier error. Tuned via `STALL_REPEATS` /
+  `STALL_SIMILARITY`.
 
 Human gate (mechanical, not prompt-based): branch protection on `main` requires a
 human approving review + CI green + dismiss-stale-approvals; the `agent-implement`

--- a/docs/tasks/active/20260727-detect-stalled-review-rounds-lessons.md
+++ b/docs/tasks/active/20260727-detect-stalled-review-rounds-lessons.md
@@ -1,0 +1,76 @@
+# Lessons — Detect stalled review rounds
+
+## The obvious signal was the wrong signal
+
+The intuitive design is "page when consecutive rounds raise the same findings."
+That fires on healthy PRs, because `review-panel.mjs` **deliberately** re-merges
+every unresolved prior finding into the current round — the cross-round re-check
+that exists to stop a real bug vanishing when a later pass misses it. High
+overlap is therefore the designed steady state, not an anomaly.
+
+The discriminating signal is overlap **plus a blocking count that did not fall**.
+Worth noting because the same trap will recur: any future metric over rounds has
+to account for carry-forward inflating round-to-round similarity by
+construction.
+
+## Two thresholds I guessed wrong, caught by measuring
+
+Both defaults in the plan were invented, and both were wrong. Writing tests
+against *real* data rather than synthetic fixtures is what exposed them.
+
+**Jaccard at 0.6.** PR #564's design-fit lens emitted four verbatim rephrasings
+of one defect. They score 0.19–0.52 pairwise under Jaccard — so the shipped
+threshold would have matched **none of them**, and the feature would have been
+dead code that always reported "progressing." Measuring three metrics against
+those four real strings plus four real unrelated findings gave:
+
+| metric | same defect | different defect |
+|---|---|---|
+| jaccard | 0.19 – 0.52 | 0.00 – 0.04 |
+| dice | 0.32 – 0.68 | 0.00 – 0.09 |
+| overlap | 0.39 – 0.71 | 0.00 – 0.08 |
+
+Overlap (containment) both separates widest and is semantically right: the panel
+restates one defect at different levels of detail, and Jaccard punishes the
+longer wording for carrying more specifics. Threshold 0.3.
+
+**Greedy one-to-one matching.** Intended to stop two identical findings both
+claiming one prior and inflating the ratio. But #564's real shape was *2 priors
+becoming 4 rephrasings*, which one-to-one scores 0.5 — under-reporting exactly
+when the loop is most visibly stuck. Many-to-one is the honest answer to "how
+much of this round is recycled", and the count test already covers the inflation
+risk.
+
+Generalisable: when a heuristic has a tunable constant, calibrate it against
+production artifacts before shipping. Both errors were invisible to code review
+and obvious after one measurement.
+
+## Absent is not empty
+
+`groupReviewRounds` treats a lens whose check run has **no** `output.text` as
+`partial`, not as "found nothing". A clean lens legitimately persists `"[]"`, so
+conflating absent with empty would let an unreadable round look like a clean one
+— and a clean round breaks a stall run, which is a fail-*open* toward burning
+more rounds. The same distinction bit the panel before, in the 60k trim loop
+that must never slice serialized JSON.
+
+## Verify a CLI by running it, not by reading it
+
+`review-round-guard.mjs` shells out to `gh`, so it has no unit tests and the
+pure helpers cannot cover the wiring. A ~20-line `gh` stub on `PATH` plus
+`STUB_DATA`/`GITHUB_OUTPUT` env made the whole script exercisable end-to-end,
+and caught things inspection would not have: that the back-fill actually fires,
+and — more importantly — that when the back-fill *fails* the rounds degrade to
+partial and the guard correctly does **not** page.
+
+Cheap enough that the same stub pattern is worth reusing for `mark-ready.mjs`
+and `metrics.mjs`, which are equally untested at the CLI layer.
+
+## Check what merged before starting
+
+Main moved twice more while the plan sat (PR #566, PR #568). #568 added
+`detectFlips`, close enough in name to be worth checking for duplication —
+it reads severity *counts* from the ledger to spot blocking → clean, whereas
+this reads finding *text* from check runs to spot non-convergence. Complementary,
+no overlap. But the check took a minute and the earlier #565 collision cost half
+a PR's work, so it stays a standing step.

--- a/docs/tasks/active/20260727-detect-stalled-review-rounds-todo.md
+++ b/docs/tasks/active/20260727-detect-stalled-review-rounds-todo.md
@@ -1,0 +1,101 @@
+# Detect stalled review rounds
+
+Page a human as soon as the review-fix loop is demonstrably re-litigating the
+same findings, instead of waiting for the blunt `MAX_REVIEW_ROUNDS` cap.
+
+Script-only; no workflow edit required.
+
+## Motivation
+
+`MAX_REVIEW_ROUNDS = 5` is the only exit from the fix loop today. On PR #521 the
+loop burned all five rounds on overlapping findings before anyone was paged —
+five panel rounds plus five fixer sessions of budget spent re-covering the same
+ground. Detecting the shape earlier pages at round 3 and saves the difference.
+
+This also matters more after the recall work later in this series: a
+coverage-first rubric and a stricter verifier both raise the number of findings
+that survive to the gate, so rounds get more expensive before they get cheaper.
+
+## The trap this design exists to avoid
+
+**Round-to-round overlap is not evidence of a stall.** `review-panel.mjs`
+deliberately re-merges every unresolved prior finding into the current round
+(the cross-round re-check that guards against false negatives), so a *healthy*
+PR that fixed 2 of 5 findings still shows 3 identical findings next round.
+Keying on overlap alone would page on essentially every PR.
+
+What separates #521 from a healthy PR is that **the blocking count did not go
+down**. So a round pair stalls only when it is both highly overlapping *and* not
+shrinking, and two consecutive such pairs are required before paging.
+
+## Scope
+
+- [x] `scripts/agent/rounds.mjs` — new pure exports: `summaryTokens`,
+      `findingSimilarity`, `repeatRatio`, `groupReviewRounds`,
+      `detectStalledRounds`, `DEFAULT_SIMILARITY`.
+- [x] `scripts/agent/review-round-guard.mjs` — run the check before the
+      round-cap branch; page naming the repeated findings. Tuning via
+      `STALL_REPEATS` / `STALL_SIMILARITY` env, so no workflow edit is needed.
+- [x] `scripts/agent/rounds.test.mjs` — 15 new cases.
+
+## Design decisions
+
+- **Similarity is calibrated on real findings, not guessed.** The first draft
+  used Jaccard at a 0.6 threshold. Measured against PR #564's four *verbatim*
+  design-fit rephrasings of one defect (vs. four unrelated real findings from
+  #564/#548):
+
+  | metric | same defect | different defect |
+  |---|---|---|
+  | jaccard | 0.19 – 0.52 | 0.00 – 0.04 |
+  | dice | 0.32 – 0.68 | 0.00 – 0.09 |
+  | **overlap** | **0.39 – 0.71** | **0.00 – 0.08** |
+
+  Jaccard at 0.6 would have matched **none** of the four real rephrasings.
+  Shipping the overlap (containment) coefficient at **0.3** — widest margin, and
+  the right semantics, since the panel restates one defect at different levels
+  of detail and Jaccard penalises the extra specifics in the longer wording.
+  Backed by an absolute `shared >= 3` token floor (true pairs share 7–17 tokens,
+  false pairs at most 1).
+- **Matching is many-to-one, not greedy one-to-one.** A one-to-one pairing was
+  tried first; it scored #564's "2 priors became 4 rephrasings" at 0.5 and
+  missed, under-reporting precisely when the loop is most obviously spinning.
+  The question is "how much of this round is recycled", and four wordings of two
+  priors is all of it. The inflation risk one-to-one guarded against is covered
+  by the count test instead.
+- **Similarity is gated on lens + file.** A different lens or file scores 0
+  outright, so three distinct bugs in one file — fixed one per round — never
+  read as one finding repeated three times.
+- **Fails toward NOT paging.** Malformed rounds, an unreadable check payload, an
+  infra/quota round, or too little history all return `stalled: false`. This is
+  the one place in this pipeline where safe means *keep going*:
+  `MAX_REVIEW_ROUNDS` is still the backstop, and a spurious page — summoning a
+  human off a converging loop — is the more expensive error.
+- **Fuzzy matching stays out of `dedupeFindings`.** That function *drops*
+  findings, and over-merging two distinct bugs there is exactly the fail-open its
+  own comment warns about. This path only ever reports.
+- **No new API calls in the happy path.** The guard already paginates every PR
+  commit and its check runs. `output.text` can be omitted from the list
+  response, so it is back-filled — but only for the newest `STALL_REPEATS + 1`
+  commits carrying lens runs, and only where the field is missing.
+- **Env-tuned, not positional.** The guard already takes five positional args,
+  and env config means this ships without a workflow edit (the agent App cannot
+  push `.github/workflows/**`).
+
+## Relationship to `detectFlips` (#568)
+
+Complementary, not overlapping. `detectFlips` reads severity **counts** from the
+metrics ledger to spot a lens going blocking → clean (a false-negative signal,
+reported only). This reads finding **text** from check runs to spot rounds that
+never converge, and it **acts** by paging. No shared machinery.
+
+## Verification
+
+- `agent:tests` lane: 93 tests green (15 new).
+- Similarity calibrated and asserted against the verbatim #564 strings, so a
+  regression in tokenisation or threshold fails the suite.
+- End-to-end against the real script with a stubbed `gh`: a 3-round repeat pages
+  with `paged=true proceed=false`; a shrinking 2→1→0 sequence sets
+  `proceed=true`; a list response missing `output.text` is back-filled and still
+  detected; and when the back-fill *also* fails the rounds go partial and it
+  correctly does **not** page.

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -15,7 +15,12 @@
 
 import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
-import { countFailedReviewRounds } from "./rounds.mjs";
+import {
+  countFailedReviewRounds,
+  groupReviewRounds,
+  detectStalledRounds,
+  DEFAULT_SIMILARITY,
+} from "./rounds.mjs";
 
 const [, , prArg, maxArg, allValidArg, requiredChecksArg, infraArg] = process.argv;
 const pr = Number(prArg);
@@ -25,6 +30,13 @@ const requiredCheckNames = (requiredChecksArg ?? "").split(",").filter(Boolean);
 // Non-empty when EVERY blocking lens failed on an API/quota error (the panel
 // never ran) — a distinct, non-code failure worth its own honest hand-off.
 const infra = (infraArg ?? "").trim();
+
+// Convergence tuning, read from the env rather than added as a 6th and 7th
+// positional: this script already takes five, and keeping it env-driven means
+// the feature ships without a workflow edit (the agent App cannot push
+// .github/workflows/**).
+const stallRepeats = Number(process.env.STALL_REPEATS) || 2;
+const stallSimilarity = Number(process.env.STALL_SIMILARITY) || DEFAULT_SIMILARITY;
 
 if (!Number.isInteger(pr) || pr <= 0 || !Number.isFinite(max)) {
   console.error(
@@ -108,6 +120,50 @@ function checkRunsFor(sha) {
 
 const commits = listAll(`repos/{owner}/{repo}/pulls/${pr}/commits?per_page=100`);
 for (const c of commits) c.checkRuns = checkRunsFor(c.sha);
+
+// CONVERGENCE, checked before the round cap. A loop that keeps re-raising the
+// same findings without reducing them has already failed; saying *that* is more
+// actionable than "we hit 5 rounds", and it pages ~2 rounds sooner. Same
+// ordering rationale as the INFRA branch above: the more specific reason wins.
+//
+// The list response for commits/{sha}/check-runs can omit or truncate
+// output.text (the panel workflow's own "Read prior findings" step does a
+// separate checks.get for exactly this reason), so back-fill it — but only for
+// the newest rounds convergence actually inspects, and only where it is
+// missing. Bounded to about (rounds x lenses) extra calls, usually zero.
+const lensNames = new Set(requiredCheckNames);
+const isLensRun = (r) => lensNames.has(r.name) && r.app?.slug === "github-actions";
+for (const c of commits.filter((x) => (x.checkRuns ?? []).some(isLensRun)).slice(-(stallRepeats + 1))) {
+  for (const r of c.checkRuns) {
+    if (!isLensRun(r) || (typeof r.output?.text === "string" && r.output.text !== "")) continue;
+    // A failure here leaves output.text absent, which groupReviewRounds treats
+    // as a PARTIAL round — that breaks the stall run rather than inventing one.
+    try {
+      r.output = ghJson(["api", `repos/{owner}/{repo}/check-runs/${r.id}`]).output ?? r.output;
+    } catch {
+      /* fail toward not paging */
+    }
+  }
+}
+
+const stall = detectStalledRounds(groupReviewRounds(commits, requiredCheckNames), {
+  minRepeats: stallRepeats,
+  similarity: stallSimilarity,
+});
+console.error(`convergence: ${stall.reason} (stalls=${stall.stalls}, rounds=${stall.rounds})`);
+if (stall.stalled) {
+  const named = stall.repeated
+    .slice(0, 5)
+    .map((f) => `\`${f.file || "?"}\` — ${String(f.summary ?? "").slice(0, 160)}`)
+    .join("; ");
+  page(
+    `The review panel is re-raising the same findings without resolving them ` +
+      `(${stall.stalls + 1} consecutive rounds with no reduction in blocking findings). ` +
+      `Repeated: ${named}. Another fix round would spend budget on the same ground — ` +
+      `a human should take over on PR #${pr}.`,
+  );
+  process.exit(0);
+}
 
 const failedRounds = countFailedReviewRounds(commits, requiredCheckNames);
 if (failedRounds >= max) {

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -31,3 +31,259 @@ export function countFailedReviewRounds(commits, requiredCheckNames) {
     (c) => isFixerCommit(c) && (c.checkRuns ?? []).some(isFailingLensRun),
   ).length;
 }
+
+// --- convergence detection ---------------------------------------------------
+//
+// MAX_REVIEW_ROUNDS is a blunt backstop: on PR #521 the loop burned all five
+// rounds re-litigating overlapping findings before anyone was paged. This
+// detects that shape earlier — but the obvious implementation is wrong, so the
+// reasoning matters:
+//
+//   Overlap between rounds is NOT evidence of a stall. The prior-findings
+//   carry-forward in review-panel.mjs deliberately re-merges every unresolved
+//   prior finding into the current round, so a HEALTHY PR that fixed 2 of 5
+//   findings still shows 3 identical findings next round. Keying on overlap
+//   alone would page on essentially every PR.
+//
+// What separates #521 from a healthy PR is that the blocking count did not go
+// DOWN. So a pair of rounds "stalls" only when it is both highly overlapping
+// AND not shrinking, and we require two consecutive such pairs before paging.
+//
+// Fuzzy matching lives here and ONLY here. It must never be pushed into
+// dedupeFindings (review-panel.mjs), which DROPS findings — over-merging two
+// distinct bugs there is exactly the fail-open its own comment warns about.
+// This path only ever reports.
+
+// Common English + review-boilerplate words carry no signal for "is this the
+// same finding", and leaving them in inflates every Jaccard score toward 1.
+const STOPWORDS = new Set([
+  "the", "and", "not", "but", "for", "with", "without", "this", "that", "these", "those",
+  "are", "was", "were", "been", "being", "has", "have", "had", "its", "it's", "from",
+  "into", "than", "then", "there", "here", "when", "which", "what", "who", "whom",
+  "can", "could", "should", "would", "may", "might", "will", "shall", "does", "did",
+  "done", "only", "also", "any", "all", "each", "every", "some", "more", "most",
+  "actually", "still", "just", "even", "because", "since", "while", "however",
+]);
+
+/**
+ * Significant tokens of an LLM-written summary: camelCase / snake_case / dotted
+ * and slashed identifiers are split apart, punctuation dropped, stopwords
+ * removed, then sorted + deduped. The point is stability across rephrasings —
+ * the panel routinely emits several different wordings of one defect (PR #564's
+ * design-fit lens produced four), and an exact-text key would treat those as
+ * four distinct findings.
+ *
+ * Tokens shorter than 3 chars are dropped as noise (`ts`, `g4`, bare digits).
+ */
+export function summaryTokens(summary) {
+  return [
+    ...new Set(
+      String(summary ?? "")
+        .replace(/([a-z0-9])([A-Z])/g, "$1 $2") // camelCase → camel Case
+        .toLowerCase()
+        .split(/[^a-z0-9]+/) // paths, dots, underscores, punctuation all separate
+        .filter((t) => t.length > 2 && !STOPWORDS.has(t)),
+    ),
+  ].sort();
+}
+
+const trimmed = (s) => String(s ?? "").trim();
+
+// A couple of incidentally-shared words is never a match, however short the
+// shorter summary is. Calibrated below: real same-defect pairs share 7-17
+// tokens; real different-defect pairs share at most 1.
+const MIN_SHARED_TOKENS = 3;
+
+/** Default similarity threshold — see the calibration note on `findingSimilarity`. */
+export const DEFAULT_SIMILARITY = 0.3;
+
+/**
+ * How alike are two findings, in [0, 1]? GATED first: a different lens or a
+ * different file scores 0 outright. That gate is what stops "three distinct
+ * bugs in one file, fixed one per round" from reading as the same finding three
+ * times — similarity is only ever asked within a single (lens, file) pair.
+ *
+ * The metric is the OVERLAP (containment) coefficient — shared tokens over the
+ * smaller token set — not Jaccard. The panel restates one defect at different
+ * levels of detail, and Jaccard penalises the extra specifics in the longer
+ * wording, which is precisely the wrong behaviour here.
+ *
+ * Calibrated against real data rather than guessed: PR #564's design-fit lens
+ * emitted four wordings of ONE defect, measured against four unrelated real
+ * findings from #564/#548.
+ *
+ *   metric    same-defect        different-defect
+ *   jaccard   0.19 - 0.52        0.00 - 0.04
+ *   dice      0.32 - 0.68        0.00 - 0.09
+ *   overlap   0.39 - 0.71        0.00 - 0.08   <- widest margin
+ *
+ * Hence `DEFAULT_SIMILARITY = 0.3`: 1.3x under the lowest true positive and
+ * 3.75x over the highest true negative. (An initial guess of 0.6 with Jaccard
+ * would have matched none of the four real rephrasings.)
+ *
+ * When either token set degenerates to empty (a punctuation-only or
+ * all-stopword summary, or coerceFindings' `(malformed finding …)`
+ * placeholder), fall back to exact case-insensitive text equality so a
+ * placeholder still matches itself across rounds rather than scoring 0.
+ */
+export function findingSimilarity(a, b) {
+  if (!a || !b) return 0;
+  if (trimmed(a.lens) !== trimmed(b.lens)) return 0;
+  if (trimmed(a.file) !== trimmed(b.file)) return 0;
+  const ta = summaryTokens(a.summary);
+  const tb = summaryTokens(b.summary);
+  if (ta.length === 0 || tb.length === 0) {
+    return trimmed(a.summary).toLowerCase() === trimmed(b.summary).toLowerCase() ? 1 : 0;
+  }
+  const B = new Set(tb);
+  let shared = 0;
+  for (const t of ta) if (B.has(t)) shared++;
+  if (shared < MIN_SHARED_TOKENS) return 0;
+  return shared / Math.min(ta.length, tb.length);
+}
+
+/**
+ * Fraction of `curr` findings that match ANY finding in `prev` at or above
+ * `threshold`. Empty `curr` → 0, so a clean round never counts as a repeat.
+ *
+ * Matching is deliberately many-to-one: several current findings may all match
+ * the same prior. A greedy one-to-one pairing was tried first and is wrong for
+ * this question — the panel routinely emits multiple wordings of one defect
+ * (PR #564's design-fit lens turned 2 priors into 4 rephrasings), and
+ * consuming each prior once scored that 0.5, under-reporting the very case
+ * where the loop is most obviously spinning. The question here is "how much of
+ * this round is recycled prior material", and when four findings are four
+ * wordings of two priors the honest answer is "all of it".
+ *
+ * The inflation risk that one-to-one guarded against is instead handled by the
+ * caller's count test: a round that genuinely found NEW distinct problems has a
+ * rising count of *unmatched* findings, and `detectStalledRounds` only treats a
+ * pair as stalling when the count also fails to fall.
+ */
+export function repeatRatio(prev, curr, threshold = DEFAULT_SIMILARITY) {
+  const p = Array.isArray(prev) ? prev : [];
+  const c = Array.isArray(curr) ? curr : [];
+  if (c.length === 0) return 0;
+  const matched = c.filter((f) => p.some((q) => findingSimilarity(q, f) >= threshold)).length;
+  return matched / c.length;
+}
+
+// The two synthetic summaries review-panel.mjs writes when a lens never
+// produced a real verdict. Their blocking finding is an infrastructure signal,
+// not a review finding, and two consecutive quota outages must not read as a
+// stall — the guard already pages separately on the INFRA path.
+const INFRA_SUMMARY = /^\s*(Review could not run|Reviewer did not produce a valid verdict)/i;
+
+/**
+ * Group the commits + check runs the round guard ALREADY fetched into review
+ * rounds, oldest first. One round per commit carrying any of our lens checks;
+ * `findings` is the union of each lens's LATEST run's persisted blocking
+ * findings, tagged with its lens id.
+ *
+ * `partial: true` marks a round we could not fully read — a lens with no
+ * machine-readable payload, unparseable JSON, or an infra/quota round. A
+ * partial round breaks the stall run rather than contributing to it, so an
+ * unreadable round can never manufacture a page.
+ *
+ * `commits`: Array<{ sha, checkRuns: Array<{name, app, output, started_at, completed_at}> }>
+ */
+export function groupReviewRounds(commits, lensCheckNames) {
+  const names = new Set(lensCheckNames ?? []);
+  const rounds = [];
+  for (const c of Array.isArray(commits) ? commits : []) {
+    const runs = (c?.checkRuns ?? []).filter(
+      (r) => r && names.has(r.name) && r.app?.slug === "github-actions",
+    );
+    if (runs.length === 0) continue; // no panel verdict here → not a round
+    // Latest run per lens: a re-run supersedes the earlier attempt.
+    const latest = new Map();
+    for (const r of runs) {
+      const t = new Date(r.completed_at || r.started_at || 0).getTime();
+      const cur = latest.get(r.name);
+      if (!cur || t >= cur.t) latest.set(r.name, { run: r, t });
+    }
+    const findings = [];
+    let partial = false;
+    for (const [name, { run }] of latest) {
+      const lens = name.replace(/^agent-review-/, "");
+      const text = run.output?.text;
+      // A CLEAN lens legitimately persists "[]", so an ABSENT payload is not
+      // "found nothing" — it means we cannot see what this lens found.
+      if (typeof text !== "string" || text === "") {
+        partial = true;
+        continue;
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        partial = true;
+        continue;
+      }
+      if (!Array.isArray(parsed)) {
+        partial = true;
+        continue;
+      }
+      for (const f of parsed) {
+        if (!f || typeof f !== "object" || INFRA_SUMMARY.test(String(f.summary ?? ""))) {
+          partial = true;
+          continue;
+        }
+        findings.push({ lens, severity: f.severity, file: f.file, summary: f.summary });
+      }
+    }
+    rounds.push({ sha: c.sha, findings, partial });
+  }
+  return rounds;
+}
+
+/**
+ * Is the fix loop re-litigating the same findings instead of converging?
+ *
+ * Walks CONSECUTIVE round pairs backwards from the newest. A pair stalls iff
+ * the blocking count did NOT go down AND `repeatRatio` is at or above
+ * `similarity` (default 0.3, calibrated on real findings). `minRepeats` consecutive stalling pairs (default 2, so three
+ * rounds of evidence) is the trigger — earliest page at round 3, versus the
+ * round-5 cap, while tolerating one noisy round.
+ *
+ * FAILS TOWARD NOT PAGING. Malformed input, a partial round, or too little
+ * history all return `stalled: false`. This is the one place in this pipeline
+ * where the safe default is "keep going": MAX_REVIEW_ROUNDS is still the
+ * backstop, and a spurious page — summoning a human when the loop was in fact
+ * converging — is the more expensive error.
+ */
+export function detectStalledRounds(rounds, { minRepeats = 2, similarity = DEFAULT_SIMILARITY } = {}) {
+  const list = (Array.isArray(rounds) ? rounds : []).filter((r) => r && typeof r === "object");
+  const base = { stalled: false, stalls: 0, rounds: list.length, repeated: [] };
+  if (list.length < minRepeats + 1) return { ...base, reason: "too-few-rounds" };
+
+  const count = (r) => (Array.isArray(r.findings) ? r.findings.length : 0);
+  let stalls = 0;
+  const repeated = new Map();
+
+  for (let i = list.length - 1; i >= 1 && stalls < minRepeats; i--) {
+    const curr = list[i];
+    const prev = list[i - 1];
+    if (curr.partial || prev.partial) break; // unreadable → end the trailing run
+    if (count(curr) < count(prev)) break; // findings went down → real progress
+    if (repeatRatio(prev.findings, curr.findings, similarity) < similarity) break;
+    stalls++;
+    for (const f of curr.findings) {
+      if (!prev.findings.some((p) => findingSimilarity(p, f) >= similarity)) continue;
+      repeated.set(`${f.lens}::${trimmed(f.file)}::${trimmed(f.summary).toLowerCase()}`, {
+        lens: f.lens,
+        file: f.file,
+        summary: f.summary,
+      });
+    }
+  }
+
+  const stalled = stalls >= minRepeats;
+  return {
+    ...base,
+    stalled,
+    stalls,
+    repeated: stalled ? [...repeated.values()] : [],
+    reason: stalled ? "repeat-without-reduction" : stalls > 0 ? "partial-stall" : "progressing",
+  };
+}

--- a/scripts/agent/rounds.test.mjs
+++ b/scripts/agent/rounds.test.mjs
@@ -1,6 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { isFixerCommit, countFailedReviewRounds } from "./rounds.mjs";
+import {
+  isFixerCommit,
+  countFailedReviewRounds,
+  summaryTokens,
+  findingSimilarity,
+  repeatRatio,
+  groupReviewRounds,
+  detectStalledRounds,
+} from "./rounds.mjs";
 
 const fixer = (sha, checkRuns = []) => ({ sha, parents: [{ sha: "p1" }], checkRuns });
 const merge = (sha, checkRuns = []) => ({ sha, parents: [{ sha: "p1" }, { sha: "p2" }], checkRuns });
@@ -39,4 +47,191 @@ test("countFailedReviewRounds: check-run name not in requiredCheckNames → not 
 test("countFailedReviewRounds: failing check-run from a different app.slug → not counted (regression guard)", () => {
   const commits = [fixer("f1", [{ name: "agent-review-correctness", app: { slug: "some-other-app" }, conclusion: "failure" }])];
   assert.equal(countFailedReviewRounds(commits, ["agent-review-correctness"]), 0);
+});
+
+// --- convergence detection ---------------------------------------------------
+
+// The four summaries below are VERBATIM from PR #564's design-fit lens, round 2:
+// one defect, four wordings, same file. An exact-text key (what dedupeFindings
+// uses) saw four distinct findings; that is why this path needs fuzzy matching.
+const D564 = [
+  "Deliverables 2 and 3 are not actually implemented: the changes to agent-review-panel.yml, agent-iterate-ci.yml, and agent-implement.yml live only as text inside a committed .patch file under docs/tasks/active/, and are never applied to the real workflow files.",
+  "Deliverables 2 & 3 are not actually applied — the workflow changes live only in an unapplied .patch file, so the pipeline gets none of the fixer-checklist or exploration-focus behavior the issue requires.",
+  "Deliverables 2 and 3 are not actually implemented: the workflow prompt changes live only as inert text inside docs/tasks/active/20260727-scope-lenses-tighten-fixer-workflow-prompts.patch, and were never applied to the real .github/workflows/*.yml files.",
+  "Deliverables 2 & 3 are not actually implemented — the fixer/implement prompt changes exist only as an inert .patch file committed under docs/, not applied to the workflow YAMLs. The issue requires edits to agent-review-panel.yml, agent-iterate-ci.yml, and agent-implement.yml; those files are unchanged",
+];
+const PATCH_FILE = "docs/tasks/active/20260727-scope-lenses-tighten-fixer-workflow-prompts.patch";
+const f = (lens, file, summary) => ({ lens, file, summary, severity: "major" });
+const round = (findings, partial = false, sha = "s") => ({ sha, findings, partial });
+
+test("summaryTokens: splits identifiers, drops stopwords/short tokens, sorted + deduped", () => {
+  // camelCase splits (readOnly → read+only, EditorAPI → editor+api); "on" is
+  // too short and "only" is a stopword, so both drop out.
+  assert.deepEqual(summaryTokens("readOnly guard on EditorAPI.paste()"), [
+    "api", "editor", "guard", "paste", "read",
+  ]);
+  // snake_case, paths and dots all split; "the"/"is" dropped; "ts" too short
+  assert.deepEqual(
+    summaryTokens("the cache_read_input_tokens in a/b/file.ts is wrong"),
+    ["cache", "file", "input", "read", "tokens", "wrong"].sort(),
+  );
+  assert.deepEqual(summaryTokens(""), []);
+  assert.deepEqual(summaryTokens(null), []);
+  assert.deepEqual(summaryTokens("!!! ... ???"), []); // punctuation only
+  assert.deepEqual(summaryTokens("Bug X"), summaryTokens("bug x")); // case-insensitive
+});
+
+test("findingSimilarity: the real #564 rephrasings all match; lens/file gate to 0", () => {
+  // Every pair of the four REAL wordings must clear the calibrated 0.3 threshold.
+  for (let i = 0; i < D564.length; i++) {
+    for (let j = i + 1; j < D564.length; j++) {
+      const s = findingSimilarity(f("design-fit", PATCH_FILE, D564[i]), f("design-fit", PATCH_FILE, D564[j]));
+      assert.ok(s >= 0.3, `#564 wordings ${i}/${j} scored ${s.toFixed(2)}, expected >= 0.3`);
+    }
+  }
+  // Same text, DIFFERENT lens or DIFFERENT file → 0. This gate is what stops
+  // three distinct bugs in one file (fixed one per round) reading as a repeat.
+  assert.equal(findingSimilarity(f("design-fit", "a.ts", D564[0]), f("security", "a.ts", D564[0])), 0);
+  assert.equal(findingSimilarity(f("design-fit", "a.ts", D564[0]), f("design-fit", "b.ts", D564[0])), 0);
+  // Unrelated findings in the same file stay well below threshold.
+  assert.ok(findingSimilarity(f("c", "a.ts", "off-by-one in the row loop"), f("c", "a.ts", D564[0])) < 0.3);
+  // Degenerate tokens (coerceFindings placeholder) fall back to exact equality.
+  const ph = "(malformed finding — treated as blocking)";
+  assert.equal(findingSimilarity(f("c", "a.ts", ph), f("c", "a.ts", ph)), 1);
+  assert.equal(findingSimilarity(f("c", "a.ts", "!!!"), f("c", "a.ts", "???")), 0);
+  assert.equal(findingSimilarity(null, f("c", "a.ts", "x")), 0);
+});
+
+test("repeatRatio: many-to-one — N wordings of one prior are all repeats", () => {
+  const a = f("c", "a.ts", "MIN over an all-blank range returns #NUM!");
+  const b = f("c", "b.ts", "unrelated null deref in the header path");
+  assert.equal(repeatRatio([a], [a]), 1);
+  // The duplication case the panel actually produces: one prior, two wordings
+  // of it this round. All of this round is recycled, so 1.0 — a one-to-one
+  // pairing would score 0.5 and miss exactly when the loop is most stuck.
+  assert.equal(repeatRatio([a], [a, a]), 1);
+  const rephrased = f("c", PATCH_FILE, D564[1]);
+  assert.equal(repeatRatio([f("c", PATCH_FILE, D564[0])], [rephrased, rephrased]), 1);
+  // A genuinely new finding alongside a repeat still drags the ratio down.
+  assert.equal(repeatRatio([a], [a, b]), 0.5);
+  assert.equal(repeatRatio([a], [b]), 0);
+  assert.equal(repeatRatio([], [a]), 0);
+  assert.equal(repeatRatio([a], []), 0); // clean round is never a repeat
+  assert.equal(repeatRatio(null, null), 0);
+});
+
+test("detectStalledRounds: the #521 shape — flat count, same findings → stalled", () => {
+  const fs = [f("design-fit", PATCH_FILE, D564[0]), f("security", "lenses.json", "security scoped away from root files")];
+  const r = detectStalledRounds([round(fs), round(fs), round(fs)]);
+  assert.equal(r.stalled, true);
+  assert.equal(r.stalls, 2);
+  assert.equal(r.reason, "repeat-without-reduction");
+  assert.ok(r.repeated.length > 0, "must name the findings it is paging about");
+});
+
+// THE most important negative. Carry-forward re-merges unresolved priors every
+// round BY DESIGN, so a healthy PR shows near-total overlap. Keying on overlap
+// alone would page on essentially every PR; only the count test saves us.
+test("detectStalledRounds: shrinking 3→2→1 at overlap 1.0 is PROGRESS, not a stall", () => {
+  const [x, y, z] = [f("c", "a.ts", D564[0]), f("c", "b.ts", D564[1]), f("c", "c.ts", D564[2])];
+  const r = detectStalledRounds([round([x, y, z]), round([x, y]), round([x])]);
+  assert.equal(r.stalled, false);
+  assert.equal(r.reason, "progressing");
+});
+
+test("detectStalledRounds: rising count with high overlap → stalled (getting worse counts too)", () => {
+  const x = f("design-fit", PATCH_FILE, D564[0]);
+  const r = detectStalledRounds([
+    round([x]),
+    round([x, f("design-fit", PATCH_FILE, D564[1])]),
+    round([x, f("design-fit", PATCH_FILE, D564[2]), f("design-fit", PATCH_FILE, D564[3])]),
+  ]);
+  assert.equal(r.stalled, true);
+});
+
+test("detectStalledRounds: flat count but DISJOINT findings → not a stall", () => {
+  const mk = (n) => [f("c", `${n}.ts`, `a completely distinct defect number ${n} in the parser`)];
+  const r = detectStalledRounds([round(mk(1)), round(mk(2)), round(mk(3))]);
+  assert.equal(r.stalled, false);
+  assert.equal(r.reason, "progressing");
+});
+
+test("detectStalledRounds: a partial round breaks the trailing run (unreadable never pages)", () => {
+  const fs = [f("design-fit", PATCH_FILE, D564[0])];
+  assert.equal(detectStalledRounds([round(fs), round(fs, true), round(fs)]).stalled, false);
+  // partial as the newest round also breaks it
+  assert.equal(detectStalledRounds([round(fs), round(fs), round(fs, true)]).stalled, false);
+});
+
+test("detectStalledRounds: needs minRepeats+1 rounds; one stalling pair is not enough", () => {
+  const fs = [f("design-fit", PATCH_FILE, D564[0])];
+  assert.equal(detectStalledRounds([round(fs), round(fs)]).reason, "too-few-rounds");
+  assert.equal(detectStalledRounds([round(fs)]).stalled, false);
+  // 3 rounds where only the newest pair repeats → 1 stall, below the threshold
+  const other = [f("c", "z.ts", "an entirely different problem in another module")];
+  const r = detectStalledRounds([round(other), round(fs), round(fs)]);
+  assert.equal(r.stalls, 1);
+  assert.equal(r.stalled, false);
+  assert.equal(r.reason, "partial-stall");
+});
+
+test("detectStalledRounds: junk input → false, never throws", () => {
+  for (const junk of [null, undefined, [], "nope", [null, 3, "x"], [{}, {}, {}]]) {
+    assert.doesNotThrow(() => detectStalledRounds(junk));
+    assert.equal(detectStalledRounds(junk).stalled, false);
+  }
+  // findings not an array on every round → counts as 0, ratio 0 → no stall
+  assert.equal(detectStalledRounds([{ findings: "x" }, { findings: "x" }, { findings: "x" }]).stalled, false);
+});
+
+test("detectStalledRounds: two clean rounds never stall (empty curr → ratio 0)", () => {
+  assert.equal(detectStalledRounds([round([]), round([]), round([])]).stalled, false);
+});
+
+// --- groupReviewRounds -------------------------------------------------------
+
+const NAMES = ["agent-review-correctness", "agent-review-design-fit"];
+const run = (name, findings, over = {}) => ({
+  name, app: { slug: "github-actions" }, conclusion: "failure",
+  completed_at: "2026-07-27T06:00:00Z",
+  output: { summary: "s", text: JSON.stringify(findings) }, ...over,
+});
+const commit = (sha, checkRuns) => ({ sha, parents: [{ sha: "p" }], checkRuns });
+
+test("groupReviewRounds: commit order preserved; non-panel commits are not rounds", () => {
+  const one = [{ severity: "major", file: "a.ts", summary: "x" }];
+  const rounds = groupReviewRounds(
+    [commit("c1", [run("agent-review-correctness", one)]), commit("c2", []), commit("c3", [run("agent-review-correctness", one)])],
+    NAMES,
+  );
+  assert.deepEqual(rounds.map((r) => r.sha), ["c1", "c3"]);
+  assert.equal(rounds[0].findings[0].lens, "correctness"); // prefix stripped
+});
+
+test("groupReviewRounds: unreadable payloads mark the round partial, not clean", () => {
+  const bad = (over) => groupReviewRounds([commit("c1", [{ name: "agent-review-correctness", app: { slug: "github-actions" }, ...over }])], NAMES)[0];
+  assert.equal(bad({ output: { text: "not json" } }).partial, true);
+  assert.equal(bad({ output: { text: '{"not":"an array"}' } }).partial, true);
+  assert.equal(bad({ output: {} }).partial, true); // ABSENT text ≠ "found nothing"
+  assert.equal(bad({ output: { text: "[]" } }).partial, false); // "[]" IS a clean verdict
+  assert.deepEqual(bad({ output: { text: "[]" } }).findings, []);
+});
+
+test("groupReviewRounds: infra/quota findings mark the round partial (not a repeat)", () => {
+  const infra = [{ severity: "major", summary: "Review could not run — Claude API/quota error (429): limit" }];
+  const r = groupReviewRounds([commit("c1", [run("agent-review-correctness", infra)])], NAMES)[0];
+  assert.equal(r.partial, true);
+  assert.equal(r.findings.length, 0);
+  const noVerdict = [{ severity: "major", summary: "Reviewer did not produce a valid verdict: boom" }];
+  assert.equal(groupReviewRounds([commit("c1", [run("agent-review-correctness", noVerdict)])], NAMES)[0].partial, true);
+});
+
+test("groupReviewRounds: other-app check ignored; newest run per lens wins", () => {
+  const one = [{ severity: "major", file: "a.ts", summary: "x" }];
+  const foreign = { name: "agent-review-correctness", app: { slug: "some-other-app" }, output: { text: JSON.stringify(one) } };
+  assert.deepEqual(groupReviewRounds([commit("c1", [foreign])], NAMES), []);
+  // two runs of one lens on one commit → the later completed_at wins
+  const older = run("agent-review-correctness", [{ severity: "major", file: "a.ts", summary: "OLD" }], { completed_at: "2026-07-27T05:00:00Z" });
+  const newer = run("agent-review-correctness", [{ severity: "major", file: "a.ts", summary: "NEW" }], { completed_at: "2026-07-27T07:00:00Z" });
+  assert.deepEqual(groupReviewRounds([commit("c1", [older, newer])], NAMES)[0].findings.map((x) => x.summary), ["NEW"]);
 });


### PR DESCRIPTION
## Summary

Page a human as soon as the review-fix loop is demonstrably re-litigating the
same findings, rather than waiting for the blunt `MAX_REVIEW_ROUNDS` cap.
Script-only — no workflow edit needed.

## Why

`MAX_REVIEW_ROUNDS = 5` is the only exit from the fix loop today. On PR #521 it
burned all five rounds on overlapping findings before anyone was paged — five
panel rounds plus five fixer sessions spent re-covering the same ground. This
pages at round 3 and names the findings being recycled.

It also matters more as this series continues: coverage-first rubrics and a
stricter verifier both raise the number of findings surviving to the gate, so
rounds get more expensive before they get cheaper.

### The trap this design exists to avoid

**Round-to-round overlap is not evidence of a stall.** `review-panel.mjs`
*deliberately* re-merges every unresolved prior finding into the current round —
the cross-round re-check that guards against false negatives. So a **healthy** PR
that fixed 2 of 5 findings still shows 3 identical findings next round. Keying on
overlap alone would page on essentially every PR.

What separates #521 is that **the blocking count did not fall**. A pair of rounds
stalls only when it is both highly overlapping *and* not shrinking, and two
consecutive such pairs are required before paging.

The single most important test in this PR is the negative one: `3 → 2 → 1
findings at overlap 1.0` must read as **progress**.

### Both tunables were guessed in the plan, and both were wrong

Measured against PR #564's four **verbatim** design-fit rephrasings of one
defect, versus four unrelated real findings from #564/#548:

| metric | same defect | different defect |
|---|---|---|
| jaccard | 0.19 – 0.52 | 0.00 – 0.04 |
| dice | 0.32 – 0.68 | 0.00 – 0.09 |
| **overlap** | **0.39 – 0.71** | **0.00 – 0.08** |

The planned Jaccard-at-0.6 would have matched **none** of the four real
rephrasings — the feature would have shipped as dead code that always reported
"progressing."

Ships the **overlap (containment) coefficient at 0.3**: widest margin, and the
right semantics — the panel restates one defect at different levels of detail,
and Jaccard penalises the longer wording for carrying more specifics. Backed by
an absolute 3-shared-token floor (true pairs share 7–17 tokens, false pairs at
most 1).

Matching is **many-to-one** for the same reason. Greedy one-to-one was tried
first and scored #564's real shape — 2 priors becoming 4 rephrasings — at 0.5,
under-reporting precisely when the loop is most obviously spinning.

## Safety properties

- **Fails toward NOT paging.** Malformed rounds, an unreadable check payload, an
  infra/quota round, or too little history all return `stalled: false`. This is
  the one place in this pipeline where safe means *keep going*:
  `MAX_REVIEW_ROUNDS` still backstops, and summoning a human off a converging
  loop is the costlier error.
- **Similarity is gated on lens + file.** Three distinct bugs in one file, fixed
  one per round, never read as one finding repeated three times.
- **Fuzzy matching stays out of `dedupeFindings`.** That function *drops*
  findings; over-merging two distinct bugs there is exactly the fail-open its own
  comment warns about. This path only ever reports.
- **Absent ≠ empty.** A lens with no `output.text` marks the round `partial`, not
  clean — a clean lens legitimately persists `"[]"`, and conflating the two would
  let an unreadable round break a stall run (a fail-*open*).
- **No new API calls in the happy path.** The guard already paginates every PR
  commit and its check runs. `output.text` can be omitted from the list response,
  so it is back-filled — but only for the newest `STALL_REPEATS + 1` commits
  carrying lens runs, and only where the field is missing.
- **Env-tuned, not positional.** The guard already takes five positional args,
  and env config means this ships without a workflow edit.

## Relationship to `detectFlips` (#568)

Complementary, checked before building. `detectFlips` reads severity **counts**
from the metrics ledger to spot a lens going blocking → clean (a false-negative
signal, reported only). This reads finding **text** from check runs to spot
non-convergence, and it **acts** by paging. No shared machinery, no duplication.

## Linked Issues

None — from the review-panel audit rather than a filed issue.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Locally: `pnpm verify:self` green; `agent:tests` lane **93 tests** (15 new).

The similarity threshold is asserted against the verbatim #564 strings, so a
regression in tokenisation or calibration fails the suite rather than silently
disabling detection.

`review-round-guard.mjs` is a `gh`-shelling CLI with no unit-test surface, so it
was exercised **end to end** against the real script with a stubbed `gh`:

| scenario | result |
|---|---|
| 3 rounds, same defect reworded | pages, `paged=true proceed=false` |
| shrinking 2 → 1 → 0 | `progressing`, `proceed=true` |
| list response omits `output.text` | back-filled, still detected |
| back-fill *also* fails | rounds go `partial`, correctly does **not** page |

## Risk Assessment

- **User-facing risk:** none. No product code.
- **Data/security risk:** none. Read-only over data the guard already fetches; no
  new permissions, no change to what the pipeline gates on. It can only cause a
  page (the existing, well-trodden hand-off), never a promotion.
- **Rollback plan:** revert, or set `STALL_REPEATS` to a large number to disable
  it without a code change.

## Notes for Reviewers

- **AI assistance:** implemented with Claude Code (Opus 5) in an interactive
  session and reviewed by me. The calibration table above is measured output, not
  an estimate.
- **Worth a close look:** the many-to-one matching decision. It is deliberately
  the *less* conservative choice on that axis; the count test is what carries the
  false-positive protection. If you disagree, the alternative is one-to-one plus
  a lower threshold, which I rejected because it under-reports the duplication
  case the panel actually exhibits.
- **Fork PR caveat:** no review panel / auto-fix / promote, and CI needs a
  maintainer to approve the run.
