### PR TITLE
Move the pipeline to Claude Opus 5

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -248,6 +248,14 @@ jobs:
           or any wait-for-later mechanism; they will strand the run before it opens
           the PR. If a command is slow, just let it finish (or skip it per step 5).
 
+          Stay inside the scope of the issue. Deliver the acceptance criteria and
+          nothing beyond them: no unrequested features, refactors, abstractions,
+          or error handling for cases that cannot occur. Make routine judgment
+          calls yourself rather than asking. If you conclude the issue is mistaken
+          or that a better approach exists, say so in a sentence in the PR body and
+          implement what was asked — do not quietly widen, narrow, or substitute
+          the task.
+
           Hard rules: never push to main; never merge; never edit ANTLR generated
           files (regenerate via `pnpm sheets build:formula`); all sheet
           persistence goes through the Store interface. Leave the PR as a DRAFT —
@@ -274,7 +282,7 @@ jobs:
           prompt: ${{ steps.prep.outputs.prompt }}
           claude_args: >-
             --max-turns 150
-            --model claude-opus-4-8
+            --model claude-opus-5
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"
 
       # Capture the full agent transcript (every turn + tool call + any

--- a/.github/workflows/agent-iterate-ci.yml
+++ b/.github/workflows/agent-iterate-ci.yml
@@ -259,7 +259,7 @@ jobs:
             verification thread noting what you fixed. Do not merge.
           claude_args: >-
             --max-turns 80
-            --model claude-opus-4-8
+            --model claude-opus-5
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"
 
       # Diagnostics: keep the fixer's transcript (turns, tool calls, permission

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -805,7 +805,7 @@ jobs:
             merge. Pushing re-runs CI and a fresh review panel.
           claude_args: >-
             --max-turns 80
-            --model claude-opus-4-8
+            --model claude-opus-5
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"
 
       # Diagnostics: keep the fixer's transcript (turns, tool calls, permission

--- a/.github/workflows/agent-review-reply.yml
+++ b/.github/workflows/agent-review-reply.yml
@@ -153,5 +153,5 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           claude_args: >-
             --max-turns 40
-            --model claude-opus-4-8
+            --model claude-opus-5
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"

--- a/.github/workflows/agent-sdk-smoke-test.yml
+++ b/.github/workflows/agent-sdk-smoke-test.yml
@@ -13,7 +13,12 @@
 name: Agent SDK Auth Smoke Test
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Model id to smoke-test (blank = auth-smoke.mjs's default)"
+        required: false
+        default: ""
 
 permissions: {}
 
@@ -39,7 +44,12 @@ jobs:
       # token present). Only the next step gets the token.
       - name: Install the Agent SDK
         run: cd scripts/agent && npm ci --no-audit --no-fund
+      # auth-smoke.mjs already honours SMOKE_MODEL; wiring it to a dispatch input
+      # makes this the pre-flight for a model change too, not just a credential
+      # check — "does this model id resolve on the pinned SDK, with this token".
+      # Blank falls through to the script's own default.
       - name: Live auth check
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          SMOKE_MODEL: ${{ inputs.model }}
         run: node scripts/agent/auth-smoke.mjs

--- a/.github/workflows/agent-summarize.yml
+++ b/.github/workflows/agent-summarize.yml
@@ -204,7 +204,7 @@ jobs:
             Be brief and factual; you are summarizing, not approving or merging.
           claude_args: >-
             --max-turns 15
-            --model claude-opus-4-8
+            --model claude-opus-5
             --allowedTools "Read,Write"
 
       # App token for the edit, minted AFTER Claude so it never coexists with the

--- a/docs/tasks/active/20260728-model-refresh-opus-5-lessons.md
+++ b/docs/tasks/active/20260728-model-refresh-opus-5-lessons.md
@@ -1,0 +1,73 @@
+# Lessons — Model refresh: Claude Opus 4.8 → Opus 5
+
+## A model swap is a string change plus whatever defaults moved underneath it
+
+The dangerous part of this change was not any of the ten model strings. It was
+one silent default: **Opus 4.8 runs no thinking when the `thinking` parameter is
+omitted; Opus 5 runs adaptive thinking.** Since `max_tokens` bounds thinking and
+response text *together*, `classify.mjs`'s hand-written `max_tokens: 400` would
+have been eaten by thinking before the structured record was emitted, and
+`JSON.parse` would have thrown on a truncated response.
+
+That call site was invisible from the plan, which assumed the model lived only in
+`claude_args`. The distinction that mattered: `--max-turns` is a *turn* budget
+managed by `claude-code-action`, so the five workflow call sites are immune;
+`classify.mjs` is the one caller that hits the raw Messages API and sets a token
+ceiling itself. Worth asking on any future model change: *which call sites set
+`max_tokens` by hand?*
+
+## Check the capability before writing a prompt rule about it
+
+The plan called for a subagent cap, because Opus 5 delegates more readily than
+4.8. But `Task` is absent from every `--allowedTools` list, so delegation is
+already impossible — the cap would have been dead text that looked like a
+control.
+
+Generalisable: when the guidance says "instruct the model not to do X", first
+check whether X is even reachable. A mechanical allow-list beats a prompt
+instruction, and a prompt instruction that duplicates one is worse than nothing
+because it implies the allow-list is not doing the work.
+
+## macOS bash 3.2 mis-parses quoted heredocs inside `$( )`, by apostrophe parity
+
+Adding a single sentence containing `the issue's scope` to
+`agent-implement.yml`'s prompt made the whole `run:` block fail `bash -n`
+locally, with a misleading `unexpected EOF while looking for matching ''` pointing
+at a line 20 lines further down.
+
+Minimal repro on `/bin/bash` (3.2.57, what macOS ships):
+
+```bash
+T=$(cat <<'P'
+the issue's field
+the PR's lane
+P
+)
+```
+
+That parses. Add one more apostrophe anywhere in the heredoc body and it does
+**not** — bash 3.2 tracks quote state inside `$( )` even for a *quoted* heredoc,
+where the body should be literal. Bash 5.x (ubuntu-latest, what CI runs) is fine.
+
+Two consequences:
+
+- The change would have shipped and worked in CI. It was caught only because the
+  prompt builder was executed rather than eyeballed — the same habit that caught
+  the unbounded checklist in #569.
+- **The prompt currently contains an even number of apostrophes and is therefore
+  one edit away from breaking local verification again.** Cheapest durable fix is
+  to keep prompt prose apostrophe-free; the alternative is switching the heredoc
+  out of `$( )` into a plain redirect, which is a larger change than this PR
+  should carry.
+
+## Verification that verifies nothing
+
+Everything green here — YAML parses, 101 tests, `verify:self`, prompt renders —
+exercises **zero** model behaviour. It is entirely possible for all of it to pass
+and for `claude-opus-5` to be a bad id, or unavailable to this token, and for the
+first real autonomous run to fail on it.
+
+That gap is why the smoke-test workflow gained a `model` input. `auth-smoke.mjs`
+already honoured `SMOKE_MODEL`; the workflow simply never passed it, so the
+"pre-flight" the plan described was not executable. A documented manual step that
+cannot actually be performed is worse than no step, because it reads as coverage.

--- a/docs/tasks/active/20260728-model-refresh-opus-5-todo.md
+++ b/docs/tasks/active/20260728-model-refresh-opus-5-todo.md
@@ -44,6 +44,20 @@ Opus 5 carries its own documented failure modes, and the records are small enoug
 that the ceiling is only ever headroom. Haiku has no adaptive default and never
 reaches it.
 
+Raising the ceiling makes truncation unlikely, not impossible, so
+`extractStructuredText` now inspects `stop_reason` **before** parsing. A
+truncated or declined response is still HTTP 200 with a partial or empty
+`content` array, so parsing first collapsed every cause into an opaque
+`Unexpected end of JSON input`. It now reports the budget it hit, or the refusal
+category — the other `stop_reason` Opus 5 made reachable, since its safety
+classifiers can decline a request outright.
+
+It deliberately does **not** retry at a larger budget. The classifier already
+exits 0 on any error, so the actionable output is a log line naming the cause; a
+retry would double spend on the expensive Opus pass exactly when the model is
+being verbose, and would break the `b1`/`b2` two-pass agreement check by
+comparing passes produced under different budgets.
+
 ## Corrections to the planned scope
 
 - **Five workflows, not three.** `agent-review-reply` and `agent-summarize` also

--- a/docs/tasks/active/20260728-model-refresh-opus-5-todo.md
+++ b/docs/tasks/active/20260728-model-refresh-opus-5-todo.md
@@ -1,0 +1,103 @@
+# Model refresh: Claude Opus 4.8 → Opus 5
+
+Move every live Opus slot in the agent pipeline to `claude-opus-5`, plus the
+prompt and token-budget changes the model change actually requires.
+
+## Motivation
+
+`claude-opus-5` is the current Opus at **the same price as 4.8** ($5/$25 per
+MTok). For this pipeline the relevant documented improvements are on exactly the
+weak axis: high precision *and* high recall on code review, with accuracy
+retained at lower effort.
+
+This does **not** substitute for the coverage-first rubric work later in the
+series — the severity-filter recall problem (a lens that is told "only report
+high-severity" faithfully declines to report) persists on Opus 5.
+
+## Scope
+
+- [x] Five workflows — `--model claude-opus-5` in `claude_args`:
+      `agent-implement`, `agent-iterate-ci`, `agent-review-panel`,
+      `agent-review-reply`, `agent-summarize`.
+- [x] `scripts/agent/lenses/lenses.json` — all four lenses.
+- [x] `scripts/agent/classify.mjs` — `MODEL_B`, **plus a raised token budget**
+      (see below). `MODEL_A` stays on Haiku 4.5: it is the deliberate cheap
+      first-pass tier, not a stale reference.
+- [x] `agent-implement.yml` — scope-discipline instruction.
+- [x] `agent-sdk-smoke-test.yml` — a `model` dispatch input, so the pre-flight is
+      actually runnable.
+
+## The one real breaking hazard
+
+`classify.mjs` is the only caller that hits the **raw Messages API**, and it is
+the only place `max_tokens` is set by hand.
+
+On Opus 4.8, omitting the `thinking` parameter means no thinking. **On Opus 5 it
+runs adaptive thinking by default**, and `max_tokens` bounds thinking *and*
+response text together. The existing `max_tokens: 400` was sized for a
+no-thinking model; under Opus 5 it would be consumed before the structured record
+was emitted, truncating the response so `JSON.parse` throws.
+
+Raised to 4000 rather than disabling thinking: these are analysis calls
+(`MODEL_B` runs the bug-classification and skeptic passes), disabled thinking on
+Opus 5 carries its own documented failure modes, and the records are small enough
+that the ceiling is only ever headroom. Haiku has no adaptive default and never
+reaches it.
+
+## Corrections to the planned scope
+
+- **Five workflows, not three.** `agent-review-reply` and `agent-summarize` also
+  pin the model. Leaving them would have stranded two stale references for
+  someone to swap blindly later.
+- **The planned "subagent cap" prompt is not applicable.** Opus 5 delegates more
+  readily than 4.8, but `Task` is absent from every `--allowedTools` list, so
+  delegation is already blocked *mechanically* — a stronger control than a prompt
+  instruction, and a cap would have been dead text. (The panel's own per-lens
+  subagents are spawned by `review-panel.mjs` through the SDK, a separate
+  mechanism, deliberately fixed at one per lens.)
+- **`--max-turns` is a turn budget, not a token budget.** The
+  thinking-on-by-default hazard therefore does not touch the five
+  `claude-code-action` call sites at all; it is confined to `classify.mjs`.
+- **Test fixtures left alone.** `metrics.test.mjs` uses `"claude-opus-4-8"` as an
+  arbitrary model-name string in aggregation fixtures. Churning them would add
+  diff noise and assert nothing.
+
+## Deliberately kept, flagged for the reviewer
+
+- **`agent-implement.yml` step 6 (SELF-REVIEW) stays.** Opus 5 guidance says to
+  delete verification scaffolding because the model verifies unasked and explicit
+  instructions cause over-verification. That targets "double-check your answer"
+  phrasing; step 6 is a bounded step that produces a reviewer-facing artifact and
+  demonstrably caught a real blocking finding on PR #548. Removing it is a
+  reasonable follow-up, but it is a behaviour change this PR cannot measure, so
+  it is left for a decision rather than bundled with a model swap.
+- **`classify.mjs` `MODEL_B` is a measurement discontinuity.** The issue
+  classifier (#566) records a two-pass agreement signal
+  (`b1.bug_class === b2.bug_class`). Changing the model changes what that signal
+  measures. Included for consistency — no stale Opus reference should survive —
+  but if that data is being compared over time, pinning `MODEL_B` back to
+  `claude-opus-4-8` is a one-line reversal.
+
+## Pre-flight (do this before arming)
+
+`auth-smoke.mjs` already honoured `SMOKE_MODEL`; the workflow never passed it, so
+the documented pre-flight was not actually executable. Now:
+
+**Actions ▸ "Agent SDK Auth Smoke Test" ▸ Run workflow ▸ model = `claude-opus-5`**
+
+A green run proves the model id resolves on the pinned SDK (0.3.217) with the
+configured token, before any real run spends budget on it.
+
+## Verification
+
+- All six touched workflows re-parse as YAML; the smoke-test input is confirmed
+  to reach the step env.
+- `agent-implement.yml`'s prompt builder executed end-to-end: parses, renders,
+  zero unsubstituted placeholders, scope block present.
+- `classify.mjs` passes `node --check`.
+- `agent:tests` lane: 101 tests green.
+- `pnpm verify:self` green.
+
+Note the limits of that list: **none of it exercises the model.** The pre-flight
+above is the only live check, and the real signal is rounds-to-converge, cost,
+and sample agreement on the next few autonomous PRs.

--- a/scripts/agent/classify.mjs
+++ b/scripts/agent/classify.mjs
@@ -70,6 +70,44 @@ export function truncate(s, n) {
 }
 
 /** Localization scope (Dimension C1) from the fix diff. */
+/**
+ * Pull the structured-output text out of a Messages API response, or throw with
+ * a message naming the actual cause.
+ *
+ * `stop_reason` MUST be inspected BEFORE parsing. A truncated or declined
+ * response still arrives as HTTP 200 with a partial or empty `content` array,
+ * so parsing first collapses every distinct cause into one opaque
+ * `Unexpected end of JSON input`. Both causes became materially more reachable
+ * with Claude Opus 5: adaptive thinking draws on the same `max_tokens` budget
+ * as the answer, and its safety classifiers can decline a request outright.
+ *
+ * Deliberately does NOT retry at a larger budget. `classify.mjs` already exits
+ * 0 on any error (see `bail`) so the pipeline is never harmed — the actionable
+ * output is a log line naming the cause. A retry would double spend on the
+ * expensive Opus pass exactly when the model is being verbose, and would break
+ * the b1/b2 two-pass agreement check by comparing passes produced under
+ * different budgets.
+ */
+export function extractStructuredText(data, model = "model", maxTokens = 0) {
+  const d = data && typeof data === "object" ? data : {};
+  if (d.stop_reason === "max_tokens") {
+    throw new Error(
+      `${model} hit the ${maxTokens}-token budget before finishing the record ` +
+        `(stop_reason=max_tokens) — raise MAX_TOKENS; refusing to parse a truncated response`,
+    );
+  }
+  if (d.stop_reason === "refusal") {
+    throw new Error(
+      `${model} declined the request (stop_reason=refusal, category=${d.stop_details?.category ?? "unknown"})`,
+    );
+  }
+  const text = (Array.isArray(d.content) ? d.content : []).find((b) => b && b.type === "text")?.text;
+  if (typeof text !== "string" || text === "") {
+    throw new Error(`${model} returned no usable text block (stop_reason=${d.stop_reason ?? "unknown"})`);
+  }
+  return text;
+}
+
 export function localizationFromDiff(diff) {
   const files = new Set();
   let hunks = 0;
@@ -139,9 +177,7 @@ async function callModel(model, system, user, schema) {
     }),
   });
   if (!res.ok) throw new Error(`messages API ${res.status}`);
-  const data = await res.json();
-  const text = (data.content || []).find((b) => b.type === "text")?.text;
-  return JSON.parse(text);
+  return JSON.parse(extractStructuredText(await res.json(), model, MAX_TOKENS));
 }
 
 // --- gh-backed CLI ---------------------------------------------------------

--- a/scripts/agent/classify.mjs
+++ b/scripts/agent/classify.mjs
@@ -20,7 +20,18 @@ import { gh, ghJson, resolvePrByIssue, listAllComments } from "./metrics.mjs";
 const CLASS_PREFIX = "<!-- agent-class ";
 const API = "https://api.anthropic.com/v1/messages";
 const MODEL_A = "claude-haiku-4-5";
-const MODEL_B = "claude-opus-4-8";
+const MODEL_B = "claude-opus-5";
+
+// `max_tokens` bounds thinking AND response text together, and Claude Opus 5
+// runs adaptive thinking when the `thinking` parameter is omitted (Opus 4.8 did
+// not — omitting it there meant no thinking at all). The previous budget of 400
+// was sized for a no-thinking model and would now be consumed before the
+// structured record was emitted, truncating the response and throwing in
+// `JSON.parse`. Raised rather than disabling thinking: these are analysis calls,
+// disabled thinking on Opus 5 carries its own failure modes, and the records
+// themselves stay small so the extra ceiling is only ever headroom. MODEL_A
+// (Haiku) has no adaptive default and simply never reaches it.
+const MAX_TOKENS = 4000;
 
 const TYPE_LABEL = {
   A1: "type:bug-fix", A2: "type:feature", A3: "type:refactor", A4: "type:performance",
@@ -121,7 +132,7 @@ async function callModel(model, system, user, schema) {
     },
     body: JSON.stringify({
       model,
-      max_tokens: 400,
+      max_tokens: MAX_TOKENS,
       system,
       output_config: { format: { type: "json_schema", schema } },
       messages: [{ role: "user", content: user }],

--- a/scripts/agent/classify.test.mjs
+++ b/scripts/agent/classify.test.mjs
@@ -1,6 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { serializeClass, parseClassComment, truncate, localizationFromDiff } from "./classify.mjs";
+import {
+  serializeClass,
+  parseClassComment,
+  truncate,
+  localizationFromDiff,
+  extractStructuredText,
+} from "./classify.mjs";
 
 test("serializeClass / parseClassComment round-trip", () => {
   const rec = {
@@ -48,4 +54,45 @@ test("localizationFromDiff classifies scope from the diff", () => {
     localizationFromDiff("+++ b/pkg/a/x.ts\n@@ -1 +1 @@\n+++ b/pkg/b/y.ts\n@@ -1 +1 @@"),
     "cross_module", // two files, different modules (pkg/a vs pkg/b)
   );
+});
+
+// A truncated or declined response is HTTP 200 with a partial/empty content
+// array. Parsing it first turns every cause into "Unexpected end of JSON
+// input"; these assert the caller learns WHY instead. Both causes got more
+// reachable on Opus 5 — adaptive thinking spends the same max_tokens budget as
+// the answer, and the safety classifiers can decline outright.
+test("extractStructuredText: happy path returns the text block", () => {
+  const data = { stop_reason: "end_turn", content: [{ type: "text", text: '{"a":1}' }] };
+  assert.equal(extractStructuredText(data, "claude-opus-5", 4000), '{"a":1}');
+  // ignores non-text blocks and picks the text one
+  assert.equal(
+    extractStructuredText({ content: [{ type: "thinking" }, { type: "text", text: "ok" }] }),
+    "ok",
+  );
+});
+
+test("extractStructuredText: max_tokens truncation names the budget, never parses", () => {
+  const truncated = { stop_reason: "max_tokens", content: [{ type: "text", text: '{"a":' }] };
+  assert.throws(
+    () => extractStructuredText(truncated, "claude-opus-5", 4000),
+    /claude-opus-5 hit the 4000-token budget.*stop_reason=max_tokens.*raise MAX_TOKENS/s,
+  );
+});
+
+test("extractStructuredText: a refusal is reported as a refusal, with its category", () => {
+  assert.throws(
+    () => extractStructuredText({ stop_reason: "refusal", stop_details: { category: "cyber" }, content: [] }, "claude-opus-5"),
+    /declined the request \(stop_reason=refusal, category=cyber\)/,
+  );
+  // stop_details is null for most stop reasons, so the category lookup must not throw
+  assert.throws(
+    () => extractStructuredText({ stop_reason: "refusal", stop_details: null, content: [] }),
+    /category=unknown/,
+  );
+});
+
+test("extractStructuredText: missing/garbage payloads still give a reason, never a parse error", () => {
+  for (const bad of [null, undefined, {}, "nope", { content: [] }, { content: "x" }, { content: [{ type: "text" }] }, { content: [{ type: "text", text: "" }] }]) {
+    assert.throws(() => extractStructuredText(bad, "m"), /no usable text block/);
+  }
 });

--- a/scripts/agent/lenses/lenses.json
+++ b/scripts/agent/lenses/lenses.json
@@ -5,7 +5,7 @@
     "gating": "blocking",
     "needsIssueSpec": false,
     "appliesWhen": ["**"],
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "samples": 2
   },
   {
@@ -14,7 +14,7 @@
     "gating": "blocking",
     "needsIssueSpec": false,
     "appliesWhen": ["**"],
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "samples": 2
   },
   {
@@ -23,7 +23,7 @@
     "gating": "blocking",
     "needsIssueSpec": true,
     "appliesWhen": ["packages/**", "scripts/**", "docs/design/**"],
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "samples": 2
   },
   {
@@ -32,7 +32,7 @@
     "gating": "blocking",
     "needsIssueSpec": false,
     "appliesWhen": ["packages/**", "scripts/**"],
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
     "samples": 2
   }
 ]


### PR DESCRIPTION
## Summary

Move every live Opus slot in the pipeline to `claude-opus-5`, plus the token
budget and prompt changes the model change actually requires.

> ⚠️ **Before merging, please run the pre-flight** (see *Verification*). Nothing
> in CI exercises the model.

## Why

`claude-opus-5` is the current Opus at **the same price as 4.8** ($5/$25 per
MTok), and its documented gains are on exactly this pipeline's weak axis: high
precision *and* high recall on code review, with accuracy retained at lower
effort.

This does **not** replace the coverage-first rubric work later in the series. The
severity-filter recall problem — a lens told "only report high-severity"
faithfully declining to report — persists on Opus 5.

## The one real breaking hazard

Ten model strings is the easy part. The risk is a silent default that moved:

**Opus 4.8 runs no thinking when `thinking` is omitted. Opus 5 runs adaptive
thinking** — and `max_tokens` bounds thinking *and* response text together.

`scripts/agent/classify.mjs` is the only caller that hits the raw Messages API
and sets `max_tokens` by hand. Its budget of **400** was sized for a no-thinking
model; under Opus 5 it would be consumed before the structured record was
emitted, truncating the response so `JSON.parse` throws — a hard failure of the
issue classifier on its first real run.

Raised to 4000 rather than disabling thinking: these are analysis calls
(`MODEL_B` runs the bug-classification and skeptic passes), disabled thinking on
Opus 5 carries its own documented failure modes, and the records are small enough
that the ceiling is only ever headroom. Haiku has no adaptive default and never
reaches it.

The five `claude-code-action` call sites are immune — `--max-turns` is a *turn*
budget, not a token budget.

## Two planned changes that turned out not to apply

- **The subagent cap is dead text.** Opus 5 does delegate more readily than 4.8,
  but `Task` is absent from every `--allowedTools` list, so delegation is already
  blocked **mechanically** — a stronger control than a prompt instruction, and
  one a prompt rule would only obscure. (The panel's per-lens subagents come from
  `review-panel.mjs` via the SDK, a separate mechanism, fixed at one per lens.)
- **Five workflows, not three.** `agent-review-reply` and `agent-summarize` also
  pin the model; leaving them would strand two stale references for someone to
  swap blindly later.

## What else changed, and why

| change | reason |
|---|---|
| scope-discipline instruction in `agent-implement.yml` | Opus 5 expands task scope. Both fixers gained scope language in #569; the implement agent had none. |
| `model` dispatch input on `agent-sdk-smoke-test.yml` | `auth-smoke.mjs` already honoured `SMOKE_MODEL`, but the workflow never passed it — so the pre-flight the plan called for was not actually executable. |
| `MODEL_A` left on Haiku 4.5 | The deliberate cheap first-pass tier, not a stale reference. |
| `metrics.test.mjs` fixtures left on `claude-opus-4-8` | An arbitrary model-name string in aggregation fixtures; churning them asserts nothing. |

## Deliberately kept — two calls I'd like a second opinion on

**`agent-implement.yml` step 6 (SELF-REVIEW) stays.** Opus 5 guidance says to
delete verification scaffolding, since the model verifies unasked and explicit
instructions cause over-verification. That targets *"double-check your answer"*
phrasing; step 6 is bounded ("only if turns remain"), produces a reviewer-facing
artifact, and demonstrably caught a real blocking finding on #548. Removing it is
a reasonable follow-up — but it is a behaviour change this PR cannot measure, and
bundling it with a model swap would make both unattributable.

**`classify.mjs` `MODEL_B` is a measurement discontinuity.** The issue classifier
(#566) records a two-pass agreement signal (`b1.bug_class === b2.bug_class`);
changing the model changes what that signal measures. Included for consistency —
no stale Opus reference should survive — but **if you are tracking that data over
time, pinning `MODEL_B` back to `claude-opus-4-8` is a one-line reversal** and I
have no objection to it.

## Linked Issues

None — from the review-panel audit rather than a filed issue.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Locally: `pnpm verify:self` green (11/11); `agent:tests` 101 tests; all six
touched workflows re-parse as YAML; the smoke-test input is confirmed to reach
the step env; `classify.mjs` passes `node --check`; and `agent-implement.yml`'s
prompt builder was **executed** — renders with zero unsubstituted placeholders
and the scope block present.

**None of that exercises the model.** Green CI here means the YAML parses and the
scripts are syntactically sound; it says nothing about whether `claude-opus-5`
resolves on the pinned SDK with the configured token.

**Please run the pre-flight before merging:**

> Actions ▸ **Agent SDK Auth Smoke Test** ▸ Run workflow ▸ model = `claude-opus-5`

A green run proves the id resolves against SDK 0.3.217 with the `agent`
environment's token, before any real run spends budget. Afterwards, the signal to
watch is rounds-to-converge, `Total-cost`, and sample agreement on the next few
autonomous PRs.

## Risk Assessment

- **User-facing risk:** none. No product code.
- **Data/security risk:** none. No permission, gating, or trust-model change.
  Note Opus 5 draws on a **separate rate-limit bucket** from the combined Opus 4.x
  pool, so existing headroom does not carry over.
- **Rollback plan:** revert. Ten string changes plus one token budget; no state,
  no migration. Worth reverting `classify.mjs`'s `MAX_TOKENS` together with its
  model, since the two are coupled.

## Notes for Reviewers

- **AI assistance:** implemented with Claude Code (Opus 5) in an interactive
  session and reviewed by me.
- **Amusing near-miss worth knowing about:** the scope-discipline sentence
  originally read *"Stay inside the issue's scope"*, and that one apostrophe made
  the whole `run:` block fail to parse under macOS `/bin/bash` (3.2). Bash 3.2
  tracks quote state inside `$( )` even for a **quoted** heredoc, where the body
  should be literal — so the prompt breaks on *odd* apostrophe counts. CI (bash
  5.x) is unaffected and it would have shipped fine, but local verification would
  have been broken. Reworded to avoid it. **The prompt now sits at an even count,
  so it is one apostrophe away from breaking again** — worth keeping prompt prose
  apostrophe-free, or moving that heredoc out of `$( )` in a later PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Automated development, review, summarization, and classification workflows now use the Claude Opus 5 model.
  * Automated implementation guidance now keeps changes focused on the requested issue scope.
  * Smoke tests can target a selected model during manual runs.

* **Documentation**
  * Added guidance covering model behavior, token limits, tool access, local execution, and verification practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->