### PR TITLE
Require the disclosure trailer to be terminal

### DIFF
--- a/scripts/agent/disclosure.mjs
+++ b/scripts/agent/disclosure.mjs
@@ -18,7 +18,11 @@ export function disclosesAiAuthorship(body) {
   return /autonomous/i.test(b) && /(claude|ai[- ]assist|ai tools)/i.test(b);
 }
 
-/** True iff a single commit message carries the autonomous disclosure trailer. */
+/** True iff a single commit message ENDS with the autonomous disclosure trailer.
+ * The contract is that the trailer is terminal (a git trailer, last line); an
+ * `includes()` check would also pass a message with the trailer buried mid-body
+ * followed by arbitrary content, so require it at the end (ignoring trailing
+ * whitespace). */
 export function hasDisclosureTrailer(message) {
-  return String(message ?? "").includes(DISCLOSURE_TRAILER);
+  return String(message ?? "").trimEnd().endsWith(DISCLOSURE_TRAILER);
 }

--- a/scripts/agent/spec-to-pr.test.mjs
+++ b/scripts/agent/spec-to-pr.test.mjs
@@ -67,6 +67,11 @@ test("hasDisclosureTrailer / commitsMissingTrailer", () => {
   const bad = "Add a thing\n\nBody with no trailer.";
   assert.ok(hasDisclosureTrailer(good));
   assert.ok(!hasDisclosureTrailer(bad));
+  // Terminal-only: a trailer followed by more content does NOT count (an
+  // includes() check would wrongly pass this).
+  assert.ok(!hasDisclosureTrailer(`Add a thing\n\n${DISCLOSURE_TRAILER}\n\nSneaky trailing line.`));
+  // Trailing whitespace after the trailer is tolerated (still terminal).
+  assert.ok(hasDisclosureTrailer(`${good}\n  \n`));
   assert.deepEqual(commitsMissingTrailer([good, good]), []);
   assert.deepEqual(commitsMissingTrailer([good, bad]), [bad]);
   assert.deepEqual(commitsMissingTrailer([]), []);


### PR DESCRIPTION
## Summary

Require the disclosure trailer to be terminal

## Why

See the linked design doc / task file for the rationale and acceptance criteria.

## Linked Issues

Fixes #

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

`pnpm verify:self` was run locally to green before handoff; CI re-runs the full lanes.

## Risk Assessment

- User-facing risk:
- Data/security risk:
- Rollback plan:

## Notes for Reviewers

- Authored autonomously by Claude Code (AI tools assisted) via the local spec-to-PR flow. No human has verified these changes yet — please review every line before approving.
- Follow-up work (if any):