### PR TITLE
Extract the agent SDK wrapper behind a required tool grant

### DIFF
--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -1,0 +1,200 @@
+// Shared Claude Agent SDK wrapper for the agent pipeline — ONE place that opens
+// a model session, so the read-only tool invariant is stated once and can be
+// tested, rather than living as a hardcoded array inside a single caller.
+//
+// Extracted from review-panel.mjs unchanged except for one thing: `allowedTools`
+// is now a REQUIRED, VALIDATED parameter instead of a hardcoded
+// `["Read","Grep","Glob"]`. That matters because a second consumer is arriving
+// (the issue hunter), and the tempting way to share this function is to widen
+// the tool list for everyone. `assertAllowedTools` makes that impossible: the
+// deny-list below is refused no matter who asks, so a caller that needs to
+// execute something must do it in its own trusted code rather than by handing
+// the capability to a model.
+//
+// SDK: @anthropic-ai/claude-agent-sdk (imported lazily so the pure helpers here
+// are unit-testable without the dependency installed). Verified against
+// @anthropic-ai/claude-agent-sdk 0.3.217 (pinned + lockfiled): outputFormat:
+// {type:'json_schema'}, result.structured_output, permissionMode 'dontAsk',
+// settingSources:[], maxTurns all exist; the SDK reads CLAUDE_CODE_OAUTH_TOKEN.
+
+/**
+ * Tools that may NEVER be granted to a subagent spawned through this wrapper,
+ * whatever the caller passes.
+ *
+ * The list is a capability boundary, not a style preference. Every agent that
+ * runs through here reads UNTRUSTED input — a branch diff, an issue body, a
+ * repository checkout — so any of these would turn injected text into an action:
+ * `Bash` executes, the three write tools mutate the checkout, the two network
+ * tools exfiltrate, and `Task` spawns a fresh agent that would not inherit this
+ * check. Read-only inspection (Read/Grep/Glob) is the whole intended surface.
+ *
+ * A consumer that genuinely needs to run something does it in its own trusted
+ * code, from data the model returned — see `hunt-probe.mjs`, which executes
+ * model-proposed argv arrays itself rather than letting the model hold a shell.
+ */
+export const FORBIDDEN_TOOLS = Object.freeze([
+  "Bash",
+  "BashOutput",
+  "KillShell",
+  "Write",
+  "Edit",
+  "NotebookEdit",
+  "WebFetch",
+  "WebSearch",
+  "Task",
+]);
+
+const FORBIDDEN_SET = new Set(FORBIDDEN_TOOLS);
+
+/**
+ * Validate a caller's `allowedTools`, throwing on anything unsafe or malformed.
+ *
+ * Required rather than defaulted ON PURPOSE. A default would let a new caller
+ * inherit read-only access silently and then "just add Bash" at the call site
+ * with no signal that it had crossed a boundary; requiring the argument makes
+ * every grant an explicit, greppable decision. Returns a frozen copy so the
+ * array cannot be mutated after validation.
+ *
+ * Fails closed on every ambiguity: a non-array, an empty array, a non-string
+ * entry, or any entry on the deny-list. An empty array is rejected because the
+ * SDK would treat it as "no tools" and the agent would silently be unable to
+ * read anything — a session that burns quota and returns nothing useful.
+ * (`auth-smoke.mjs` legitimately wants `allowedTools: []` for a pure auth probe,
+ * which is why it calls the SDK directly and does not come through here.)
+ */
+export function assertAllowedTools(allowedTools) {
+  if (!Array.isArray(allowedTools) || allowedTools.length === 0) {
+    throw new Error(
+      "askStructured: `allowedTools` is required and must be a non-empty array " +
+        `(got: ${JSON.stringify(allowedTools)})`,
+    );
+  }
+  for (const t of allowedTools) {
+    if (typeof t !== "string" || t.trim() === "") {
+      throw new Error(`askStructured: \`allowedTools\` entries must be non-empty strings (got: ${JSON.stringify(t)})`);
+    }
+    if (FORBIDDEN_SET.has(t)) {
+      throw new Error(
+        `askStructured: tool "${t}" is never permitted — agents here read untrusted ` +
+          `input, so granting it would turn injected text into an action. ` +
+          `Forbidden: ${FORBIDDEN_TOOLS.join(", ")}.`,
+      );
+    }
+  }
+  return Object.freeze([...allowedTools]);
+}
+
+/**
+ * Classify an SDK `result` message. The SDK reports API/quota failures as
+ * subtype "success" with `is_error: true` (+ `api_error_status`, and a human
+ * `result` string like "You've hit your session limit · resets 3:30pm (UTC)"),
+ * so "subtype === success" alone is NOT proof the model ran. Returns one of:
+ *   { ok:true, output }                                  — real structured verdict
+ *   { ok:false, kind:'api-error', status, detail, retryable } — API/quota failure
+ *   { ok:false, kind:'no-output', detail, retryable:false }   — ran but no verdict
+ * A session/usage-limit resets on a fixed schedule (often hours out), so it is
+ * NOT retryable in-run; any other API error (plain 429/529/overload/network) is.
+ */
+export function classifyResult(message) {
+  const m = message || {};
+  if (m.subtype === "success" && m.structured_output) {
+    return { ok: true, output: m.structured_output };
+  }
+  if (m.is_error || m.api_error_status || m.terminal_reason === "api_error") {
+    const detail = typeof m.result === "string" && m.result ? m.result : "";
+    const isQuota = /session limit|usage limit|quota|rate limit|resets?\b/i.test(detail);
+    return { ok: false, kind: "api-error", status: m.api_error_status ?? null, detail, retryable: !isQuota };
+  }
+  return { ok: false, kind: "no-output", status: null, detail: `subtype=${m.subtype}`, retryable: false };
+}
+
+const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Run `fn`, retrying ONLY on errors flagged `err.retryable === true` (see
+ * classifyResult), with exponential backoff + jitter. A non-retryable error
+ * (quota/session-limit, or a genuine no-output) throws immediately — no wasted
+ * retries on a limit that can't clear in-run. `sleep` is injectable for tests.
+ */
+export async function withRetry(fn, { retries = 2, baseMs = 2000, sleep = defaultSleep, jitter = () => 0 } = {}) {
+  let last;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      last = err;
+      if (!err || err.retryable !== true || attempt === retries) throw err;
+      await sleep(baseMs * 2 ** attempt + jitter());
+    }
+  }
+  throw last;
+}
+
+/**
+ * Open one structured-output SDK session and return the validated object.
+ *
+ * `allowedTools` is required and passes through `assertAllowedTools`. `label`
+ * only shapes the thrown error's wording ("<label> query API error …") so a
+ * caller's logs read naturally; it has no behavioral effect.
+ *
+ * Throws on every non-success path, with `kind`/`status`/`detail`/`retryable`
+ * copied onto the error from `classifyResult` so `withRetry` can decide whether
+ * another attempt could possibly help.
+ */
+export async function askStructured({
+  systemPrompt,
+  prompt,
+  model,
+  repo,
+  schema,
+  sessionLog,
+  maxTurns,
+  allowedTools,
+  label = "agent",
+}) {
+  const tools = assertAllowedTools(allowedTools);
+  const { query } = await import("@anthropic-ai/claude-agent-sdk");
+  for await (const message of query({
+    prompt,
+    options: {
+      systemPrompt,
+      model,
+      cwd: repo,
+      // Only set when the caller asks for a ceiling; omitting it takes the SDK
+      // default. `maxTurns` exists in the pinned SDK (0.3.217), on the same
+      // Options type as allowedTools/outputFormat/permissionMode.
+      ...(Number.isFinite(maxTurns) ? { maxTurns } : {}),
+      allowedTools: tools, // validated read-only set; see FORBIDDEN_TOOLS
+      permissionMode: "dontAsk", // deny anything not allow-listed, no prompts
+      // SECURITY: do NOT load project settings/hooks/agents from cwd — cwd may be
+      // an untrusted branch checkout, and a branch-supplied .claude hook would be
+      // a shell command the SDK could execute. `settingSources: []` disables that
+      // (the review workflow also strips the branch's `.claude/` as
+      // belt-and-suspenders).
+      // settingSources exists in the pinned SDK (0.3.217); [] loads no project config.
+      settingSources: [],
+      outputFormat: { type: "json_schema", schema },
+    },
+  })) {
+    if (message.type === "result") {
+      // Record cost/turns/tokens regardless of success — the call still burned
+      // compute even when it didn't produce usable structured output. This is
+      // the ONLY place an SDK call's result is observable at all; callers
+      // discard everything else, so record before the throw below.
+      if (sessionLog) sessionLog.push(message);
+      const c = classifyResult(message);
+      if (c.ok) return c.output;
+      const err = new Error(
+        c.kind === "api-error"
+          ? `${label} query API error${c.status ? ` (${c.status})` : ""}: ${c.detail || "unknown"}`
+          : `structured output not produced (${c.detail})`,
+      );
+      err.kind = c.kind;
+      err.status = c.status;
+      err.detail = c.detail;
+      err.retryable = c.retryable;
+      throw err;
+    }
+  }
+  throw new Error("query ended without a result message");
+}

--- a/scripts/agent/ask.test.mjs
+++ b/scripts/agent/ask.test.mjs
@@ -1,0 +1,103 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { assertAllowedTools, FORBIDDEN_TOOLS, classifyResult, withRetry } from "./ask.mjs";
+import { CITATION } from "./review-panel.mjs";
+
+// The point of ask.mjs is that the read-only tool grant is now a CHECKED
+// invariant rather than a hardcoded array one caller happened to get right.
+// These tests are that check. Note none of them install or touch the SDK —
+// `assertAllowedTools` runs before the lazy `import()`, which is why the
+// validation lives in its own function instead of inline in askStructured.
+
+test("assertAllowedTools: accepts the read-only triple and returns a frozen copy", () => {
+  const tools = assertAllowedTools(["Read", "Grep", "Glob"]);
+  assert.deepEqual([...tools], ["Read", "Grep", "Glob"]);
+  assert.ok(Object.isFrozen(tools), "returned array must be frozen so it cannot be widened after validation");
+  // A frozen copy, not the caller's array — mutating the input afterwards must
+  // not retroactively change what was validated.
+  const input = ["Read"];
+  const validated = assertAllowedTools(input);
+  input.push("Bash");
+  assert.deepEqual([...validated], ["Read"]);
+});
+
+test("assertAllowedTools: every forbidden tool is refused, whoever asks", () => {
+  // Iterate the exported list rather than a hand-written copy: a tool added to
+  // FORBIDDEN_TOOLS without a test would otherwise be silently uncovered.
+  for (const tool of FORBIDDEN_TOOLS) {
+    assert.throws(
+      () => assertAllowedTools(["Read", tool]),
+      new RegExp(`tool "${tool}" is never permitted`),
+      `${tool} must be refused even alongside legitimate read-only tools`,
+    );
+  }
+});
+
+test("assertAllowedTools: Bash is refused even as the sole entry", () => {
+  // The obvious way a future caller widens this: "my agent only needs Bash".
+  assert.throws(() => assertAllowedTools(["Bash"]), /never permitted/);
+});
+
+test("assertAllowedTools: missing / empty / malformed input fails closed", () => {
+  // Required, not defaulted — a default would let a new caller inherit read-only
+  // access silently and then widen it at the call site with no visible signal.
+  assert.throws(() => assertAllowedTools(undefined), /required and must be a non-empty array/);
+  assert.throws(() => assertAllowedTools(null), /required and must be a non-empty array/);
+  assert.throws(() => assertAllowedTools("Read"), /required and must be a non-empty array/);
+  // Empty array is rejected rather than treated as "no tools": the SDK would run
+  // an agent that cannot read anything, burning quota to return nothing useful.
+  assert.throws(() => assertAllowedTools([]), /required and must be a non-empty array/);
+  assert.throws(() => assertAllowedTools(["Read", ""]), /must be non-empty strings/);
+  assert.throws(() => assertAllowedTools(["Read", "   "]), /must be non-empty strings/);
+  assert.throws(() => assertAllowedTools(["Read", 42]), /must be non-empty strings/);
+  assert.throws(() => assertAllowedTools(["Read", null]), /must be non-empty strings/);
+});
+
+test("FORBIDDEN_TOOLS: covers execution, mutation, network and re-spawn, and is frozen", () => {
+  // Named explicitly because each entry closes a distinct escape route; a
+  // reviewer should be able to see the four categories are all covered.
+  for (const t of ["Bash", "Write", "Edit", "NotebookEdit", "WebFetch", "WebSearch", "Task"]) {
+    assert.ok(FORBIDDEN_TOOLS.includes(t), `FORBIDDEN_TOOLS must include ${t}`);
+  }
+  assert.ok(Object.isFrozen(FORBIDDEN_TOOLS));
+});
+
+// --- moved-from-review-panel behavior, asserted at its new home ---------------
+// review-panel.test.mjs already covers these through its re-export and is left
+// untouched by this refactor (that is the evidence behavior did not change).
+// These two assert the same contract against ask.mjs directly, so deleting the
+// re-export later cannot silently drop the coverage.
+
+test("classifyResult: still distinguishes verdict / api-error / no-output at its new home", () => {
+  assert.equal(classifyResult({ subtype: "success", structured_output: { findings: [] } }).ok, true);
+  const quota = classifyResult({ subtype: "success", is_error: true, api_error_status: 429, result: "You've hit your session limit · resets 3:30pm" });
+  assert.equal(quota.kind, "api-error");
+  assert.equal(quota.retryable, false, "a session limit cannot clear in-run, so it must not be retried");
+  assert.equal(classifyResult({ subtype: "success", is_error: true, api_error_status: 529, result: "overloaded_error" }).retryable, true);
+  assert.equal(classifyResult({ subtype: "success" }).kind, "no-output");
+});
+
+test("withRetry: retries only retryable errors", async () => {
+  const noSleep = { baseMs: 0, sleep: async () => {} };
+  let calls = 0;
+  const out = await withRetry(async () => {
+    calls++;
+    if (calls < 3) { const e = new Error("transient"); e.retryable = true; throw e; }
+    return "ok";
+  }, noSleep);
+  assert.equal(out, "ok");
+  assert.equal(calls, 3);
+
+  let once = 0;
+  await assert.rejects(withRetry(async () => { once++; const e = new Error("quota"); e.retryable = false; throw e; }, noSleep));
+  assert.equal(once, 1, "a non-retryable error must not be attempted twice");
+});
+
+test("CITATION: exported from review-panel.mjs so gates share one definition", () => {
+  // Exported by this refactor. The hunt gate consumes it; re-typing the pattern
+  // is the drift failure the panel's own comments argue against.
+  assert.ok(CITATION.test("packages/cli/src/output/formatter.ts:44"));
+  assert.ok(CITATION.test("see scripts/agent/ask.mjs:12 for why"));
+  assert.doesNotMatch("looks fine", CITATION, "a bare assertion is not a citation");
+  assert.doesNotMatch("packages/cli/src/output/formatter.ts", CITATION, "a path with no line number locates nothing");
+});

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -19,16 +19,18 @@
 // Outputs under <out> (default .agent-review):
 //   <out>/<lens>/verdict.json + summary.md   and   <out>/panel.json + panel-summary.md
 //
-// SDK: @anthropic-ai/claude-agent-sdk (imported lazily so the pure helpers below
-// are unit-testable without the dependency installed). Verified against
-// @anthropic-ai/claude-agent-sdk 0.3.217 (pinned + lockfiled): outputFormat:
-// {type:'json_schema'}, result.structured_output, permissionMode 'dontAsk',
-// settingSources:[] all exist; the SDK reads CLAUDE_CODE_OAUTH_TOKEN.
+// SDK access goes through ./ask.mjs, which owns the session options and REQUIRES
+// an explicit `allowedTools` (it refuses Bash/write/network/Task outright). This
+// module grants exactly `REVIEW_TOOLS` — read-only — at both call sites. ask.mjs
+// imports the SDK lazily, so the pure helpers below stay unit-testable without
+// the dependency installed. `classifyResult`/`withRetry` live there too and are
+// re-exported from here for existing importers.
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { classify, renderSummaryMd, BLOCKING, normalizeSeverity, KNOWN } from "./severity.mjs";
+import { askStructured, withRetry } from "./ask.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
@@ -179,7 +181,10 @@ export function applyVerifications(findings, verdictsByIndex, opts) {
 }
 
 /** A citation must locate something: `path.ext:line`, anywhere in the string. */
-const CITATION = /[^\s:]+\.[A-Za-z0-9_]+:\d+/;
+// Exported so other gates reuse this exact pattern rather than re-typing it. A
+// hand-copied regex that drifted would silently change what counts as evidence —
+// the same class of failure `REFUTATION_GROUNDS` avoids by deriving from the schema.
+export const CITATION = /[^\s:]+\.[A-Za-z0-9_]+:\d+/;
 
 /**
  * May this verdict DROP a blocking finding? Only on a complete, grounded
@@ -415,101 +420,23 @@ export function verifierTally(findings, verdicts, opts) {
   return { sentToVerifier, refuted, refutedHighConfidence, dropped };
 }
 
-/**
- * Classify an SDK `result` message. The SDK reports API/quota failures as
- * subtype "success" with `is_error: true` (+ `api_error_status`, and a human
- * `result` string like "You've hit your session limit · resets 3:30pm (UTC)"),
- * so "subtype === success" alone is NOT proof the model ran. Returns one of:
- *   { ok:true, output }                                  — real structured verdict
- *   { ok:false, kind:'api-error', status, detail, retryable } — API/quota failure
- *   { ok:false, kind:'no-output', detail, retryable:false }   — ran but no verdict
- * A session/usage-limit resets on a fixed schedule (often hours out), so it is
- * NOT retryable in-run; any other API error (plain 429/529/overload/network) is.
- */
-export function classifyResult(message) {
-  const m = message || {};
-  if (m.subtype === "success" && m.structured_output) {
-    return { ok: true, output: m.structured_output };
-  }
-  if (m.is_error || m.api_error_status || m.terminal_reason === "api_error") {
-    const detail = typeof m.result === "string" && m.result ? m.result : "";
-    const isQuota = /session limit|usage limit|quota|rate limit|resets?\b/i.test(detail);
-    return { ok: false, kind: "api-error", status: m.api_error_status ?? null, detail, retryable: !isQuota };
-  }
-  return { ok: false, kind: "no-output", status: null, detail: `subtype=${m.subtype}`, retryable: false };
-}
-
-const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-/**
- * Run `fn`, retrying ONLY on errors flagged `err.retryable === true` (see
- * classifyResult), with exponential backoff + jitter. A non-retryable error
- * (quota/session-limit, or a genuine no-output) throws immediately — no wasted
- * retries on a limit that can't clear in-run. `sleep` is injectable for tests.
- */
-export async function withRetry(fn, { retries = 2, baseMs = 2000, sleep = defaultSleep, jitter = () => 0 } = {}) {
-  let last;
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      last = err;
-      if (!err || err.retryable !== true || attempt === retries) throw err;
-      await sleep(baseMs * 2 ** attempt + jitter());
-    }
-  }
-  throw last;
-}
-
-// --- SDK wrapper (lazy import) ----------------------------------------------
-
-async function askStructured({ systemPrompt, prompt, model, repo, schema, sessionLog, maxTurns }) {
-  const { query } = await import("@anthropic-ai/claude-agent-sdk");
-  for await (const message of query({
-    prompt,
-    options: {
-      systemPrompt,
-      model,
-      cwd: repo,
-      // Only set when the caller asks for a ceiling — a lens gets the SDK
-      // default. `maxTurns` exists in the pinned SDK (0.3.217), on the same
-      // Options type as allowedTools/outputFormat/permissionMode.
-      ...(Number.isFinite(maxTurns) ? { maxTurns } : {}),
-      allowedTools: ["Read", "Grep", "Glob"], // read-only; NO Bash/Write/network
-      permissionMode: "dontAsk", // deny anything not allow-listed, no prompts
-      // SECURITY: do NOT load project settings/hooks/agents from cwd — cwd is the
-      // untrusted branch checkout, and a branch-supplied .claude hook would be a
-      // shell command the SDK could execute. `settingSources: []` disables that
-      // (the workflow also strips the branch's `.claude/` as belt-and-suspenders).
-      // settingSources exists in the pinned SDK (0.3.217); [] loads no project config.
-      settingSources: [],
-      outputFormat: { type: "json_schema", schema },
-    },
-  })) {
-    if (message.type === "result") {
-      // Record cost/turns/tokens regardless of success — the call still burned
-      // compute even when it didn't produce usable structured output. This is
-      // the ONLY place a review-panel SDK call's result is observable at all;
-      // everything else here discards it, so record before the throw below.
-      if (sessionLog) sessionLog.push(message);
-      const c = classifyResult(message);
-      if (c.ok) return c.output;
-      const err = new Error(
-        c.kind === "api-error"
-          ? `review query API error${c.status ? ` (${c.status})` : ""}: ${c.detail || "unknown"}`
-          : `structured output not produced (${c.detail})`,
-      );
-      err.kind = c.kind;
-      err.status = c.status;
-      err.detail = c.detail;
-      err.retryable = c.retryable;
-      throw err;
-    }
-  }
-  throw new Error("query ended without a result message");
-}
+// `askStructured`, `classifyResult` and `withRetry` moved to ask.mjs, which owns
+// the SDK session and the read-only tool invariant those two exist to serve.
+// Both are re-exported here so this module's public surface is unchanged for
+// existing importers — review-panel.test.mjs covers them and stays untouched by
+// this refactor, which is the evidence that behavior did not change.
+// `withRetry` is imported at the top (main() calls it), so it is re-exported
+// from that binding rather than a second time from ask.mjs.
+export { classifyResult } from "./ask.mjs";
+export { withRetry };
 
 // --- lens + verifier runs ----------------------------------------------------
+
+// The ONE tool grant for every reviewer subagent: read-only inspection, no
+// branch-code execution. ask.mjs REQUIRES this argument (and refuses Bash/write/
+// network/Task whatever is passed), so widening review's capabilities has to be a
+// visible edit here rather than a default someone inherits.
+const REVIEW_TOOLS = ["Read", "Grep", "Glob"];
 
 async function runLens(lens, { rubric, diff, issue, repo, sessionLog }) {
   const parts = [
@@ -531,6 +458,8 @@ async function runLens(lens, { rubric, diff, issue, repo, sessionLog }) {
     repo,
     schema: LENS_SCHEMA,
     sessionLog,
+    allowedTools: REVIEW_TOOLS,
+    label: "review",
   });
 }
 
@@ -612,6 +541,8 @@ async function verifyFinding(finding, { rubric, repo, model, sessionLog, changed
     schema: VERIFIER_SCHEMA,
     sessionLog,
     maxTurns: VERIFIER_MAX_TURNS,
+    allowedTools: REVIEW_TOOLS,
+    label: "review",
   });
 }
 


### PR DESCRIPTION
## Summary

Moves `askStructured`, `classifyResult` and `withRetry` out of
`scripts/agent/review-panel.mjs` into a new `scripts/agent/ask.mjs`, and makes
`allowedTools` a **required, validated** parameter instead of a hardcoded array.

`assertAllowedTools` refuses `Bash`, `BashOutput`, `KillShell`, `Write`, `Edit`,
`NotebookEdit`, `WebFetch`, `WebSearch` and `Task` whatever the caller passes,
and returns a frozen copy. `review-panel.mjs` now grants exactly
`REVIEW_TOOLS = ["Read","Grep","Glob"]` at both call sites.

Also exports `CITATION` from `review-panel.mjs`.

## Why

A second consumer of this SDK plumbing is arriving — an autonomous
issue-hunting pipeline (planned as harness Phase 26). The tempting way to share
`askStructured` is to widen its hardcoded `allowedTools` for every caller, which
would quietly grant the review lenses capabilities they must never have: they
read an untrusted diff, so `Bash` would turn injected text into execution.

Making the grant a required parameter with a deny-list inverts that: widening a
grant becomes impossible rather than merely discouraged, and a consumer that
genuinely needs to execute something has to do it in its own trusted code from
data the model returned. The read-only invariant was previously a hardcoded
array with no test; it is now stated in one place and covered by eight.

`CITATION` is exported for the same reason `REFUTATION_GROUNDS` is derived from
its schema rather than hand-written: a copied regex that drifted would silently
change what counts as evidence in a gate.

This is deliberately a standalone refactor PR ahead of the new subsystem — a
pure change to a CODEOWNERS-protected, safety-critical file reviews far better
alone than bundled with a new feature.

## Linked Issues

Fixes #

No issue filed — this is a prerequisite refactor for the issue-hunting pipeline.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): n/a — awaiting CI. Locally `pnpm verify:self`
passed all 11 lanes; this change touches only `scripts/agent/*.mjs`, which no
package imports.

Behavior-preservation evidence beyond the lanes:

- **Export surface diff vs `origin/main` is exactly `+CITATION`** — the one
  intentional addition (compared by importing both revisions and diffing
  `Object.keys`).
- **`review-panel.test.mjs` is untouched** and all 27 tests still pass. It
  imports `classifyResult`/`withRetry` from `review-panel.mjs`, which is why
  they are re-exported there; leaving that file unmodified is the evidence.
- **Lazy SDK import preserved** — all 121 agent tests pass with the
  `@anthropic-ai/claude-agent-sdk` specifier hard-blocked by a resolver hook,
  confirming neither module resolves it at import time.
- **The SDK does not mutate `allowedTools`** (it destructures and zod-validates
  it), so returning a frozen array is safe.

## Risk Assessment

- **User-facing risk:** none. No package imports `scripts/agent/`; nothing ships.
- **Data/security risk:** net reduction. The read-only tool grant for reviewer
  subagents was an untested hardcoded array; it is now validated on every call
  with a deny-list that cannot be overridden by a caller. No change to
  `permissionMode: "dontAsk"` or `settingSources: []`.
- **Rollback plan:** revert the commit. The change is self-contained to three
  files in `scripts/agent/` and has no migrations, config, or state.

## Notes for Reviewers

- **AI assistance:** this PR was written with Claude Code (Opus 5) in an
  interactive session — design, implementation, tests and this description.
  Every line was reviewed by me before commit. This is *not* an autonomous
  pipeline run: `WAFFLEBASE_AGENT_AUTONOMOUS` was unset, so the branch is
  deliberately **not** named `agent/*` and the PR is not agent-managed (see
  below).

- **Branch naming is deliberate.** `agent-review-panel.yml`'s gate sets
  `managed = true` unconditionally for any branch starting with `agent/`. Using
  that prefix for a human-authored PR would hand branch ownership to the cloud
  fix loop mid-review, which is the single-writer hazard
  `docs/design/harness-engineering.md` warns about for the local front door.
  Hence `harness/`. If you want the panel's opinion on this diff, `@claude review`
  gives an advisory pass, or `@claude loop` opts in fully.

- **Two small judgement calls worth a look:**
  1. An empty `allowedTools: []` is *rejected*, not treated as "no tools" — the
     SDK would run an agent that cannot read anything. `auth-smoke.mjs`
     legitimately wants `[]` for a pure auth probe, which is why it calls the SDK
     directly and does not come through this wrapper; noted in `ask.mjs`.
  2. `askStructured` takes a `label` (default `"agent"`) purely so the thrown
     error keeps reading `review query API error …` for the panel. It has no
     behavioral effect; it exists to keep existing log output identical.

- **Follow-up work:** the issue-hunting pipeline itself (harness Phase 26),
  which is what needs this seam. It will import `askStructured` with the same
  read-only grant and execute model-proposed `argv` arrays in its own trusted
  code rather than holding a shell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured AI-assisted review workflows with validated outputs, retry handling, and clear error reporting.
  - Restricted review agents to read-only inspection capabilities for safer analysis.
  - Added shared citation validation for file-and-line references.

- **Bug Fixes**
  - Improved handling of quota, session-limit, and missing-result failures.
  - Prevented invalid or unsafe tool configurations from being accepted.

- **Tests**
  - Added coverage for tool restrictions, retry behavior, result classification, and citation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->