### PR TITLE
Extract the agent SDK wrapper behind a required tool grant

### DIFF
--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -100,6 +100,47 @@ export function assertAllowedTools(allowedTools) {
 }
 
 /**
+ * A session/usage limit resets on a fixed schedule, often hours out, so no
+ * in-run retry can clear it. This is the ONE thing that overrides an otherwise
+ * retryable status, so the pattern is deliberately narrow and anchored.
+ *
+ * It replaced `/session limit|usage limit|quota|rate limit|resets?\b/i`, which
+ * over-matched badly in both directions:
+ *   - `resets?\b` matched `ECONNRESET`, `read ECONNRESET` and `connection reset
+ *     by peer` (word boundary at end-of-string), turning ordinary transport
+ *     blips into "give up immediately".
+ *   - `rate limit` made every plain 429 non-retryable, contradicting the very
+ *     docblock above it — a rate limit is the canonical thing you retry.
+ *   - bare `quota` is ambiguous enough to catch unrelated messages.
+ * Dropping those is safe in the cheap direction: if a genuine limit is now
+ * retried, the cost is a few seconds of backoff before the same failure is
+ * reported correctly. Whereas mis-classifying a transient error as permanent
+ * pages a human for nothing, which is the expensive mistake.
+ */
+const SESSION_LIMIT_RE = /\b(?:session|usage)\s+limit\b/i;
+
+/**
+ * Is another attempt at this HTTP status plausibly worth making?
+ *
+ * Keyed on the status the API actually returned rather than on prose, because
+ * the message text is a human string that varies by provider and version while
+ * the status is a contract. Absent status means a transport/network failure
+ * (`fetch failed`, `ECONNRESET`) — those are the most retryable of all.
+ *
+ * 4xx other than 408/429 are deterministic: a 401 from a bad token or a 400 from
+ * a malformed schema will fail identically three times, so retrying only delays
+ * the real error. That is a change in behavior from the previous regex-only rule,
+ * and an intentional one.
+ */
+function isRetryableStatus(status) {
+  if (status == null) return true; // no status → transport/network → transient
+  const s = Number(status);
+  if (!Number.isFinite(s)) return true; // unparseable → treat as transient
+  if (s === 408 || s === 429) return true; // request timeout / rate limited
+  return s >= 500; // 500/502/503/529 overload → transient; other 4xx → not
+}
+
+/**
  * Classify an SDK `result` message. The SDK reports API/quota failures as
  * subtype "success" with `is_error: true` (+ `api_error_status`, and a human
  * `result` string like "You've hit your session limit · resets 3:30pm (UTC)"),
@@ -107,8 +148,11 @@ export function assertAllowedTools(allowedTools) {
  *   { ok:true, output }                                  — real structured verdict
  *   { ok:false, kind:'api-error', status, detail, retryable } — API/quota failure
  *   { ok:false, kind:'no-output', detail, retryable:false }   — ran but no verdict
- * A session/usage-limit resets on a fixed schedule (often hours out), so it is
- * NOT retryable in-run; any other API error (plain 429/529/overload/network) is.
+ *
+ * Retryability = "could another attempt succeed?", decided by `isRetryableStatus`
+ * and overridden to false only for an explicit session/usage limit. A plain 429
+ * IS retryable even when its message mentions rate limiting; a 429 that says
+ * "session limit" is not.
  */
 export function classifyResult(message) {
   const m = message || {};
@@ -117,8 +161,9 @@ export function classifyResult(message) {
   }
   if (m.is_error || m.api_error_status || m.terminal_reason === "api_error") {
     const detail = typeof m.result === "string" && m.result ? m.result : "";
-    const isQuota = /session limit|usage limit|quota|rate limit|resets?\b/i.test(detail);
-    return { ok: false, kind: "api-error", status: m.api_error_status ?? null, detail, retryable: !isQuota };
+    const status = m.api_error_status ?? null;
+    const retryable = !SESSION_LIMIT_RE.test(detail) && isRetryableStatus(status);
+    return { ok: false, kind: "api-error", status, detail, retryable };
   }
   return { ok: false, kind: "no-output", status: null, detail: `subtype=${m.subtype}`, retryable: false };
 }

--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -2,14 +2,19 @@
 // a model session, so the read-only tool invariant is stated once and can be
 // tested, rather than living as a hardcoded array inside a single caller.
 //
-// Extracted from review-panel.mjs unchanged except for one thing: `allowedTools`
-// is now a REQUIRED, VALIDATED parameter instead of a hardcoded
-// `["Read","Grep","Glob"]`. That matters because a second consumer is arriving
-// (the issue hunter), and the tempting way to share this function is to widen
-// the tool list for everyone. `assertAllowedTools` makes that impossible: the
-// deny-list below is refused no matter who asks, so a caller that needs to
-// execute something must do it in its own trusted code rather than by handing
-// the capability to a model.
+// Extracted from review-panel.mjs, which called the SDK inline. Two changes come
+// with the move, both about making the read-only claim real rather than assumed:
+//
+//   1. The tool grant is a REQUIRED, VALIDATED parameter checked against the
+//      `PERMITTED_TOOLS` allow-list below, instead of a hardcoded array. Sharing
+//      a wrapper invites widening it for everyone; an allow-list makes that a
+//      rejected call rather than a one-word edit.
+//   2. The session now sets `tools` as well as `allowedTools`. Only the former
+//      restricts what exists; the latter just pre-approves. See the call site.
+//
+// A consumer that genuinely needs to execute something must do it in its own
+// trusted code, acting on data the model returned — never by holding the
+// capability itself.
 //
 // SDK: @anthropic-ai/claude-agent-sdk (imported lazily so the pure helpers here
 // are unit-testable without the dependency installed). Verified against
@@ -18,47 +23,56 @@
 // settingSources:[], maxTurns all exist; the SDK reads CLAUDE_CODE_OAUTH_TOKEN.
 
 /**
- * Tools that may NEVER be granted to a subagent spawned through this wrapper,
- * whatever the caller passes.
+ * The COMPLETE set of tools any agent spawned through this wrapper may ever be
+ * granted. Callers pass a subset; anything else is refused.
  *
- * The list is a capability boundary, not a style preference. Every agent that
- * runs through here reads UNTRUSTED input — a branch diff, an issue body, a
- * repository checkout — so any of these would turn injected text into an action:
- * `Bash` executes, the three write tools mutate the checkout, the two network
- * tools exfiltrate, and `Task` spawns a fresh agent that would not inherit this
- * check. Read-only inspection (Read/Grep/Glob) is the whole intended surface.
+ * This is an ALLOW-list, and that shape is the whole point. A deny-list of
+ * dangerous names cannot express "read-only" in this SDK, for three independent
+ * reasons — each of which silently grants capability:
  *
- * A consumer that genuinely needs to run something does it in its own trusted
- * code, from data the model returned — see `hunt-probe.mjs`, which executes
- * model-proposed argv arrays itself rather than letting the model hold a shell.
+ *   1. `allowedTools` entries are permission RULES, not bare names. `Bash(git
+ *      diff:*)` is a legal entry, and since `allowedTools` is an auto-approve
+ *      list (see askStructured), it would not merely evade a name-based check —
+ *      it would PRE-APPROVE that shell invocation past `permissionMode:
+ *      'dontAsk'`. Whitespace and `mcp__server__exec` forms slip through the
+ *      same way.
+ *   2. The tool namespace moves. Pinned SDK 0.3.217 ships `Agent` (spawns
+ *      subagents, which inherit the parent's tools), `REPL`, `Workflow`,
+ *      `CronCreate` and `RemoteTrigger` — none of which an author of a
+ *      hand-written deny-list in 2026 would have thought to name. A deny-list
+ *      is wrong by default and only accidentally right.
+ *   3. It is unfalsifiable in review: you cannot tell by reading it whether it
+ *      is complete.
+ *
+ * An allow-list inverts all three: unknown, scoped, aliased and future names are
+ * refused because they are not present, not because someone predicted them.
+ *
+ * Read/Grep/Glob is the entire intended surface. Every agent here reads
+ * UNTRUSTED input — a branch diff, an issue body, a repository checkout — so a
+ * consumer that genuinely needs to run something must do it in its own trusted
+ * code, from data the model returned, rather than holding the capability itself.
  */
-export const FORBIDDEN_TOOLS = Object.freeze([
-  "Bash",
-  "BashOutput",
-  "KillShell",
-  "Write",
-  "Edit",
-  "NotebookEdit",
-  "WebFetch",
-  "WebSearch",
-  "Task",
-]);
+export const PERMITTED_TOOLS = Object.freeze(["Read", "Grep", "Glob"]);
 
-const FORBIDDEN_SET = new Set(FORBIDDEN_TOOLS);
+const PERMITTED_SET = new Set(PERMITTED_TOOLS);
 
 /**
- * Validate a caller's `allowedTools`, throwing on anything unsafe or malformed.
+ * Validate a caller's tool grant, throwing on anything outside PERMITTED_TOOLS.
  *
  * Required rather than defaulted ON PURPOSE. A default would let a new caller
- * inherit read-only access silently and then "just add Bash" at the call site
- * with no signal that it had crossed a boundary; requiring the argument makes
- * every grant an explicit, greppable decision. Returns a frozen copy so the
- * array cannot be mutated after validation.
+ * inherit read-only access silently and then widen it at the call site with no
+ * signal that it had crossed a boundary; requiring the argument makes every
+ * grant an explicit, greppable decision.
+ *
+ * Matching is exact against the canonical names — deliberately strict. `" Read"`
+ * and `"read"` are refused rather than normalized, because a validator that
+ * repairs its input is guessing at intent, and the one place you do not want
+ * guessing is a capability gate. The caller's fix is to pass the canonical name.
  *
  * Fails closed on every ambiguity: a non-array, an empty array, a non-string
- * entry, or any entry on the deny-list. An empty array is rejected because the
- * SDK would treat it as "no tools" and the agent would silently be unable to
- * read anything — a session that burns quota and returns nothing useful.
+ * entry, or any entry not in the permitted set. An empty array is rejected
+ * because the SDK would treat it as "no tools" and the agent would silently be
+ * unable to read anything — a session that burns quota and returns nothing.
  * (`auth-smoke.mjs` legitimately wants `allowedTools: []` for a pure auth probe,
  * which is why it calls the SDK directly and does not come through here.)
  */
@@ -73,15 +87,16 @@ export function assertAllowedTools(allowedTools) {
     if (typeof t !== "string" || t.trim() === "") {
       throw new Error(`askStructured: \`allowedTools\` entries must be non-empty strings (got: ${JSON.stringify(t)})`);
     }
-    if (FORBIDDEN_SET.has(t)) {
+    if (!PERMITTED_SET.has(t)) {
       throw new Error(
-        `askStructured: tool "${t}" is never permitted — agents here read untrusted ` +
-          `input, so granting it would turn injected text into an action. ` +
-          `Forbidden: ${FORBIDDEN_TOOLS.join(", ")}.`,
+        `askStructured: tool ${JSON.stringify(t)} is not permitted. Agents here read ` +
+          `untrusted input, so the grant is limited to read-only inspection: ` +
+          `${PERMITTED_TOOLS.join(", ")}. Scoped permission rules (e.g. "Bash(git diff:*)"), ` +
+          `MCP tool names and non-canonical spellings are refused by the same rule.`,
       );
     }
   }
-  return Object.freeze([...allowedTools]);
+  return [...allowedTools];
 }
 
 /**
@@ -152,7 +167,10 @@ export async function askStructured({
   allowedTools,
   label = "agent",
 }) {
-  const tools = assertAllowedTools(allowedTools);
+  // Validate BEFORE the dynamic import: a bad grant must fail without opening a
+  // session (ask.test.mjs asserts this ordering by observing that an invalid
+  // grant throws the validation error even when the SDK cannot be resolved).
+  const sessionTools = assertAllowedTools(allowedTools);
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
   for await (const message of query({
     prompt,
@@ -164,8 +182,23 @@ export async function askStructured({
       // default. `maxTurns` exists in the pinned SDK (0.3.217), on the same
       // Options type as allowedTools/outputFormat/permissionMode.
       ...(Number.isFinite(maxTurns) ? { maxTurns } : {}),
-      allowedTools: tools, // validated read-only set; see FORBIDDEN_TOOLS
-      permissionMode: "dontAsk", // deny anything not allow-listed, no prompts
+      // `tools` and `allowedTools` are DIFFERENT levers and both are needed.
+      // Per the pinned SDK's own docs (sdk.d.ts:1341-1348, :1395-1404):
+      //   tools        = "the base set of available built-in tools" — the actual
+      //                  RESTRICTION. Anything omitted is not in the model's
+      //                  context at all, so it cannot be called or injected into.
+      //   allowedTools = "auto-allowed without prompting" — a PRE-APPROVAL list,
+      //                  not a restriction. On its own it would leave Bash/Write/
+      //                  WebFetch/Agent present and merely unapproved.
+      // Setting only `allowedTools` (as this code did before) left the read-only
+      // claim resting entirely on `permissionMode: 'dontAsk'`. That does deny
+      // un-pre-approved calls, so it was not exploitable by itself — but it made
+      // the guarantee a property of one enum value rather than of the tool set,
+      // and it left every dangerous tool visible to a model reading an untrusted
+      // diff. `tools` closes that: same list, so the two can never disagree.
+      tools: sessionTools,
+      allowedTools: sessionTools, // pre-approve the same read-only set
+      permissionMode: "dontAsk", // deny anything not pre-approved, no prompts
       // SECURITY: do NOT load project settings/hooks/agents from cwd — cwd may be
       // an untrusted branch checkout, and a branch-supplied .claude hook would be
       // a shell command the SDK could execute. `settingSources: []` disables that
@@ -187,7 +220,10 @@ export async function askStructured({
       const err = new Error(
         c.kind === "api-error"
           ? `${label} query API error${c.status ? ` (${c.status})` : ""}: ${c.detail || "unknown"}`
-          : `structured output not produced (${c.detail})`,
+          : // `label` here too: with two consumers sharing the wrapper, an
+            // unattributed "structured output not produced" is exactly the
+            // ambiguity `label` exists to remove.
+            `${label} query: structured output not produced (${c.detail})`,
       );
       err.kind = c.kind;
       err.status = c.status;

--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -1,0 +1,200 @@
+// Shared Claude Agent SDK wrapper for the agent pipeline — ONE place that opens
+// a model session, so the read-only tool invariant is stated once and can be
+// tested, rather than living as a hardcoded array inside a single caller.
+//
+// Extracted from review-panel.mjs unchanged except for one thing: `allowedTools`
+// is now a REQUIRED, VALIDATED parameter instead of a hardcoded
+// `["Read","Grep","Glob"]`. That matters because a second consumer is arriving
+// (the issue hunter), and the tempting way to share this function is to widen
+// the tool list for everyone. `assertAllowedTools` makes that impossible: the
+// deny-list below is refused no matter who asks, so a caller that needs to
+// execute something must do it in its own trusted code rather than by handing
+// the capability to a model.
+//
+// SDK: @anthropic-ai/claude-agent-sdk (imported lazily so the pure helpers here
+// are unit-testable without the dependency installed). Verified against
+// @anthropic-ai/claude-agent-sdk 0.3.217 (pinned + lockfiled): outputFormat:
+// {type:'json_schema'}, result.structured_output, permissionMode 'dontAsk',
+// settingSources:[], maxTurns all exist; the SDK reads CLAUDE_CODE_OAUTH_TOKEN.
+
+/**
+ * Tools that may NEVER be granted to a subagent spawned through this wrapper,
+ * whatever the caller passes.
+ *
+ * The list is a capability boundary, not a style preference. Every agent that
+ * runs through here reads UNTRUSTED input — a branch diff, an issue body, a
+ * repository checkout — so any of these would turn injected text into an action:
+ * `Bash` executes, the three write tools mutate the checkout, the two network
+ * tools exfiltrate, and `Task` spawns a fresh agent that would not inherit this
+ * check. Read-only inspection (Read/Grep/Glob) is the whole intended surface.
+ *
+ * A consumer that genuinely needs to run something does it in its own trusted
+ * code, from data the model returned — see `hunt-probe.mjs`, which executes
+ * model-proposed argv arrays itself rather than letting the model hold a shell.
+ */
+export const FORBIDDEN_TOOLS = Object.freeze([
+  "Bash",
+  "BashOutput",
+  "KillShell",
+  "Write",
+  "Edit",
+  "NotebookEdit",
+  "WebFetch",
+  "WebSearch",
+  "Task",
+]);
+
+const FORBIDDEN_SET = new Set(FORBIDDEN_TOOLS);
+
+/**
+ * Validate a caller's `allowedTools`, throwing on anything unsafe or malformed.
+ *
+ * Required rather than defaulted ON PURPOSE. A default would let a new caller
+ * inherit read-only access silently and then "just add Bash" at the call site
+ * with no signal that it had crossed a boundary; requiring the argument makes
+ * every grant an explicit, greppable decision. Returns a frozen copy so the
+ * array cannot be mutated after validation.
+ *
+ * Fails closed on every ambiguity: a non-array, an empty array, a non-string
+ * entry, or any entry on the deny-list. An empty array is rejected because the
+ * SDK would treat it as "no tools" and the agent would silently be unable to
+ * read anything — a session that burns quota and returns nothing useful.
+ * (`auth-smoke.mjs` legitimately wants `allowedTools: []` for a pure auth probe,
+ * which is why it calls the SDK directly and does not come through here.)
+ */
+export function assertAllowedTools(allowedTools) {
+  if (!Array.isArray(allowedTools) || allowedTools.length === 0) {
+    throw new Error(
+      "askStructured: `allowedTools` is required and must be a non-empty array " +
+        `(got: ${JSON.stringify(allowedTools)})`,
+    );
+  }
+  for (const t of allowedTools) {
+    if (typeof t !== "string" || t.trim() === "") {
+      throw new Error(`askStructured: \`allowedTools\` entries must be non-empty strings (got: ${JSON.stringify(t)})`);
+    }
+    if (FORBIDDEN_SET.has(t)) {
+      throw new Error(
+        `askStructured: tool "${t}" is never permitted — agents here read untrusted ` +
+          `input, so granting it would turn injected text into an action. ` +
+          `Forbidden: ${FORBIDDEN_TOOLS.join(", ")}.`,
+      );
+    }
+  }
+  return Object.freeze([...allowedTools]);
+}
+
+/**
+ * Classify an SDK `result` message. The SDK reports API/quota failures as
+ * subtype "success" with `is_error: true` (+ `api_error_status`, and a human
+ * `result` string like "You've hit your session limit · resets 3:30pm (UTC)"),
+ * so "subtype === success" alone is NOT proof the model ran. Returns one of:
+ *   { ok:true, output }                                  — real structured verdict
+ *   { ok:false, kind:'api-error', status, detail, retryable } — API/quota failure
+ *   { ok:false, kind:'no-output', detail, retryable:false }   — ran but no verdict
+ * A session/usage-limit resets on a fixed schedule (often hours out), so it is
+ * NOT retryable in-run; any other API error (plain 429/529/overload/network) is.
+ */
+export function classifyResult(message) {
+  const m = message || {};
+  if (m.subtype === "success" && m.structured_output) {
+    return { ok: true, output: m.structured_output };
+  }
+  if (m.is_error || m.api_error_status || m.terminal_reason === "api_error") {
+    const detail = typeof m.result === "string" && m.result ? m.result : "";
+    const isQuota = /session limit|usage limit|quota|rate limit|resets?\b/i.test(detail);
+    return { ok: false, kind: "api-error", status: m.api_error_status ?? null, detail, retryable: !isQuota };
+  }
+  return { ok: false, kind: "no-output", status: null, detail: `subtype=${m.subtype}`, retryable: false };
+}
+
+const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Run `fn`, retrying ONLY on errors flagged `err.retryable === true` (see
+ * classifyResult), with exponential backoff + jitter. A non-retryable error
+ * (quota/session-limit, or a genuine no-output) throws immediately — no wasted
+ * retries on a limit that can't clear in-run. `sleep` is injectable for tests.
+ */
+export async function withRetry(fn, { retries = 2, baseMs = 2000, sleep = defaultSleep, jitter = () => 0 } = {}) {
+  let last;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      last = err;
+      if (!err || err.retryable !== true || attempt === retries) throw err;
+      await sleep(baseMs * 2 ** attempt + jitter());
+    }
+  }
+  throw last;
+}
+
+/**
+ * Open one structured-output SDK session and return the validated object.
+ *
+ * `allowedTools` is required and passes through `assertAllowedTools`. `label`
+ * only shapes the thrown error's wording ("<label> query API error …") so a
+ * caller's logs read naturally; it has no behavioral effect.
+ *
+ * Throws on every non-success path, with `kind`/`status`/`detail`/`retryable`
+ * copied onto the error from `classifyResult` so `withRetry` can decide whether
+ * another attempt could possibly help.
+ */
+export async function askStructured({
+  systemPrompt,
+  prompt,
+  model,
+  repo,
+  schema,
+  sessionLog,
+  maxTurns,
+  allowedTools,
+  label = "agent",
+}) {
+  const tools = assertAllowedTools(allowedTools);
+  const { query } = await import("@anthropic-ai/claude-agent-sdk");
+  for await (const message of query({
+    prompt,
+    options: {
+      systemPrompt,
+      model,
+      cwd: repo,
+      // Only set when the caller asks for a ceiling; omitting it takes the SDK
+      // default. `maxTurns` exists in the pinned SDK (0.3.217), on the same
+      // Options type as allowedTools/outputFormat/permissionMode.
+      ...(Number.isFinite(maxTurns) ? { maxTurns } : {}),
+      allowedTools: tools, // validated read-only set; see FORBIDDEN_TOOLS
+      permissionMode: "dontAsk", // deny anything not allow-listed, no prompts
+      // SECURITY: do NOT load project settings/hooks/agents from cwd — cwd may be
+      // an untrusted branch checkout, and a branch-supplied .claude hook would be
+      // a shell command the SDK could execute. `settingSources: []` disables that
+      // (the review workflow also strips the branch's `.claude/` as
+      // belt-and-suspenders).
+      // settingSources exists in the pinned SDK (0.3.217); [] loads no project config.
+      settingSources: [],
+      outputFormat: { type: "json_schema", schema },
+    },
+  })) {
+    if (message.type === "result") {
+      // Record cost/turns/tokens regardless of success — the call still burned
+      // compute even when it didn't produce usable structured output. This is
+      // the ONLY place an SDK call's result is observable at all; callers
+      // discard everything else, so record before the throw below.
+      if (sessionLog) sessionLog.push(message);
+      const c = classifyResult(message);
+      if (c.ok) return c.output;
+      const err = new Error(
+        c.kind === "api-error"
+          ? `${label} query API error${c.status ? ` (${c.status})` : ""}: ${c.detail || "unknown"}`
+          : `structured output not produced (${c.detail})`,
+      );
+      err.kind = c.kind;
+      err.status = c.status;
+      err.detail = c.detail;
+      err.retryable = c.retryable;
+      throw err;
+    }
+  }
+  throw new Error("query ended without a result message");
+}

--- a/scripts/agent/ask.test.mjs
+++ b/scripts/agent/ask.test.mjs
@@ -1,0 +1,103 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { assertAllowedTools, FORBIDDEN_TOOLS, classifyResult, withRetry } from "./ask.mjs";
+import { CITATION } from "./review-panel.mjs";
+
+// The point of ask.mjs is that the read-only tool grant is now a CHECKED
+// invariant rather than a hardcoded array one caller happened to get right.
+// These tests are that check. Note none of them install or touch the SDK —
+// `assertAllowedTools` runs before the lazy `import()`, which is why the
+// validation lives in its own function instead of inline in askStructured.
+
+test("assertAllowedTools: accepts the read-only triple and returns a frozen copy", () => {
+  const tools = assertAllowedTools(["Read", "Grep", "Glob"]);
+  assert.deepEqual([...tools], ["Read", "Grep", "Glob"]);
+  assert.ok(Object.isFrozen(tools), "returned array must be frozen so it cannot be widened after validation");
+  // A frozen copy, not the caller's array — mutating the input afterwards must
+  // not retroactively change what was validated.
+  const input = ["Read"];
+  const validated = assertAllowedTools(input);
+  input.push("Bash");
+  assert.deepEqual([...validated], ["Read"]);
+});
+
+test("assertAllowedTools: every forbidden tool is refused, whoever asks", () => {
+  // Iterate the exported list rather than a hand-written copy: a tool added to
+  // FORBIDDEN_TOOLS without a test would otherwise be silently uncovered.
+  for (const tool of FORBIDDEN_TOOLS) {
+    assert.throws(
+      () => assertAllowedTools(["Read", tool]),
+      new RegExp(`tool "${tool}" is never permitted`),
+      `${tool} must be refused even alongside legitimate read-only tools`,
+    );
+  }
+});
+
+test("assertAllowedTools: Bash is refused even as the sole entry", () => {
+  // The obvious way a future caller widens this: "my agent only needs Bash".
+  assert.throws(() => assertAllowedTools(["Bash"]), /never permitted/);
+});
+
+test("assertAllowedTools: missing / empty / malformed input fails closed", () => {
+  // Required, not defaulted — a default would let a new caller inherit read-only
+  // access silently and then widen it at the call site with no visible signal.
+  assert.throws(() => assertAllowedTools(undefined), /required and must be a non-empty array/);
+  assert.throws(() => assertAllowedTools(null), /required and must be a non-empty array/);
+  assert.throws(() => assertAllowedTools("Read"), /required and must be a non-empty array/);
+  // Empty array is rejected rather than treated as "no tools": the SDK would run
+  // an agent that cannot read anything, burning quota to return nothing useful.
+  assert.throws(() => assertAllowedTools([]), /required and must be a non-empty array/);
+  assert.throws(() => assertAllowedTools(["Read", ""]), /must be non-empty strings/);
+  assert.throws(() => assertAllowedTools(["Read", "   "]), /must be non-empty strings/);
+  assert.throws(() => assertAllowedTools(["Read", 42]), /must be non-empty strings/);
+  assert.throws(() => assertAllowedTools(["Read", null]), /must be non-empty strings/);
+});
+
+test("FORBIDDEN_TOOLS: covers execution, mutation, network and re-spawn, and is frozen", () => {
+  // Named explicitly because each entry closes a distinct escape route; a
+  // reviewer should be able to see the four categories are all covered.
+  for (const t of ["Bash", "Write", "Edit", "NotebookEdit", "WebFetch", "WebSearch", "Task"]) {
+    assert.ok(FORBIDDEN_TOOLS.includes(t), `FORBIDDEN_TOOLS must include ${t}`);
+  }
+  assert.ok(Object.isFrozen(FORBIDDEN_TOOLS));
+});
+
+// --- moved-from-review-panel behavior, asserted at its new home ---------------
+// review-panel.test.mjs already covers these through its re-export and is left
+// untouched by this refactor (that is the evidence behavior did not change).
+// These two assert the same contract against ask.mjs directly, so deleting the
+// re-export later cannot silently drop the coverage.
+
+test("classifyResult: still distinguishes verdict / api-error / no-output at its new home", () => {
+  assert.equal(classifyResult({ subtype: "success", structured_output: { findings: [] } }).ok, true);
+  const quota = classifyResult({ subtype: "success", is_error: true, api_error_status: 429, result: "You've hit your session limit · resets 3:30pm" });
+  assert.equal(quota.kind, "api-error");
+  assert.equal(quota.retryable, false, "a session limit cannot clear in-run, so it must not be retried");
+  assert.equal(classifyResult({ subtype: "success", is_error: true, api_error_status: 529, result: "overloaded_error" }).retryable, true);
+  assert.equal(classifyResult({ subtype: "success" }).kind, "no-output");
+});
+
+test("withRetry: retries only retryable errors", async () => {
+  const noSleep = { baseMs: 0, sleep: async () => {} };
+  let calls = 0;
+  const out = await withRetry(async () => {
+    calls++;
+    if (calls < 3) { const e = new Error("transient"); e.retryable = true; throw e; }
+    return "ok";
+  }, noSleep);
+  assert.equal(out, "ok");
+  assert.equal(calls, 3);
+
+  let once = 0;
+  await assert.rejects(withRetry(async () => { once++; const e = new Error("quota"); e.retryable = false; throw e; }, noSleep));
+  assert.equal(once, 1, "a non-retryable error must not be attempted twice");
+});
+
+test("CITATION: exported from review-panel.mjs so gates share one definition", () => {
+  // Exported by this refactor. The hunt gate consumes it; re-typing the pattern
+  // is the drift failure the panel's own comments argue against.
+  assert.ok(CITATION.test("packages/cli/src/output/formatter.ts:44"));
+  assert.ok(CITATION.test("see scripts/agent/ask.mjs:12 for why"));
+  assert.doesNotMatch("looks fine", CITATION, "a bare assertion is not a citation");
+  assert.doesNotMatch("packages/cli/src/output/formatter.ts", CITATION, "a path with no line number locates nothing");
+});

--- a/scripts/agent/ask.test.mjs
+++ b/scripts/agent/ask.test.mjs
@@ -1,51 +1,88 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { assertAllowedTools, FORBIDDEN_TOOLS, classifyResult, withRetry } from "./ask.mjs";
-import { CITATION } from "./review-panel.mjs";
+import { askStructured, assertAllowedTools, PERMITTED_TOOLS, classifyResult, withRetry } from "./ask.mjs";
+import { REVIEW_TOOLS } from "./review-panel.mjs";
 
-// The point of ask.mjs is that the read-only tool grant is now a CHECKED
-// invariant rather than a hardcoded array one caller happened to get right.
-// These tests are that check. Note none of them install or touch the SDK —
-// `assertAllowedTools` runs before the lazy `import()`, which is why the
-// validation lives in its own function instead of inline in askStructured.
+// ask.mjs exists to make the read-only tool grant a CHECKED invariant instead of
+// a hardcoded array. These tests are that check, so they are deliberately mostly
+// NEGATIVE: the interesting property is what the gate refuses.
+//
+// None of them install or touch the SDK. `assertAllowedTools` runs before the
+// lazy `import()`, which is what lets the askStructured tests below assert the
+// validation happens at all without a token or a network call.
 
-test("assertAllowedTools: accepts the read-only triple and returns a frozen copy", () => {
-  const tools = assertAllowedTools(["Read", "Grep", "Glob"]);
-  assert.deepEqual([...tools], ["Read", "Grep", "Glob"]);
-  assert.ok(Object.isFrozen(tools), "returned array must be frozen so it cannot be widened after validation");
-  // A frozen copy, not the caller's array — mutating the input afterwards must
-  // not retroactively change what was validated.
+// --- the allow-list itself ---------------------------------------------------
+
+test("PERMITTED_TOOLS: pinned to exactly the read-only triple", () => {
+  // A LITERAL pin, not derived from the module. The point is that widening the
+  // grant must break a test — if this asserted against PERMITTED_TOOLS itself it
+  // would pass no matter what anyone added to it.
+  assert.deepEqual([...PERMITTED_TOOLS], ["Read", "Grep", "Glob"]);
+  assert.ok(Object.isFrozen(PERMITTED_TOOLS));
+});
+
+test("assertAllowedTools: accepts the full permitted set and any subset", () => {
+  assert.deepEqual(assertAllowedTools(["Read", "Grep", "Glob"]), ["Read", "Grep", "Glob"]);
+  assert.deepEqual(assertAllowedTools(["Read"]), ["Read"]);
+  // A copy, not the caller's array — mutating the input afterwards must not
+  // retroactively change what was validated and handed to the session.
   const input = ["Read"];
   const validated = assertAllowedTools(input);
   input.push("Bash");
-  assert.deepEqual([...validated], ["Read"]);
+  assert.deepEqual(validated, ["Read"]);
 });
 
-test("assertAllowedTools: every forbidden tool is refused, whoever asks", () => {
-  // Iterate the exported list rather than a hand-written copy: a tool added to
-  // FORBIDDEN_TOOLS without a test would otherwise be silently uncovered.
-  for (const tool of FORBIDDEN_TOOLS) {
-    assert.throws(
-      () => assertAllowedTools(["Read", tool]),
-      new RegExp(`tool "${tool}" is never permitted`),
-      `${tool} must be refused even alongside legitimate read-only tools`,
-    );
+test("assertAllowedTools: refuses execution / write / network / spawn tools", () => {
+  // Literal names, deliberately NOT looped over a list the module exports.
+  for (const tool of ["Bash", "Write", "Edit", "MultiEdit", "NotebookEdit", "WebFetch", "WebSearch"]) {
+    assert.throws(() => assertAllowedTools(["Read", tool]), /is not permitted/, `${tool} must be refused`);
   }
 });
 
-test("assertAllowedTools: Bash is refused even as the sole entry", () => {
-  // The obvious way a future caller widens this: "my agent only needs Bash".
-  assert.throws(() => assertAllowedTools(["Bash"]), /never permitted/);
+test("assertAllowedTools: refuses tools an author of a deny-list would have missed", () => {
+  // The regression this allow-list exists for. Every name here is a REAL tool in
+  // pinned SDK 0.3.217 (sdk-tools.d.ts) that a hand-written deny-list of
+  // "dangerous" names did not contain. `Agent` is the worst of them: it spawns
+  // subagents that inherit the parent's tools, i.e. the exact respawn escape the
+  // module claims to prevent. An allow-list refuses all of them for free.
+  for (const tool of ["Agent", "REPL", "Workflow", "CronCreate", "RemoteTrigger", "Artifact", "Mcp", "SendFeedback"]) {
+    assert.throws(() => assertAllowedTools(["Read", tool]), /is not permitted/, `${tool} must be refused`);
+  }
+});
+
+test("assertAllowedTools: refuses scoped permission-rule syntax", () => {
+  // THE critical bypass. `allowedTools` entries are permission RULES, so these
+  // are legal SDK input — and because the list is an auto-APPROVE list, a
+  // name-based deny-list would not merely fail to catch them, it would
+  // pre-approve the shell invocation past permissionMode:'dontAsk'.
+  for (const rule of ["Bash(git diff:*)", "Bash(*)", "Bash(git log:*)", "WebFetch(domain:example.com)", "Read(/etc/**)"]) {
+    assert.throws(() => assertAllowedTools([rule]), /is not permitted/, `${rule} must be refused`);
+  }
+});
+
+test("assertAllowedTools: refuses MCP tool names", () => {
+  for (const t of ["mcp__server__exec", "mcp__workspace__bash", "mcp__*"]) {
+    assert.throws(() => assertAllowedTools([t]), /is not permitted/, `${t} must be refused`);
+  }
+});
+
+test("assertAllowedTools: refuses non-canonical spellings rather than repairing them", () => {
+  // Strictness is the design: a validator that normalizes its input is guessing
+  // at intent, and a capability gate is the last place to guess. " Bash" is the
+  // specific case a trim-then-compare-untrimmed bug would have let through.
+  for (const t of [" Bash", "Bash ", "bash", "READ", " Read", "Read\t"]) {
+    assert.throws(() => assertAllowedTools([t]), /is not permitted/, `${JSON.stringify(t)} must be refused`);
+  }
 });
 
 test("assertAllowedTools: missing / empty / malformed input fails closed", () => {
   // Required, not defaulted — a default would let a new caller inherit read-only
-  // access silently and then widen it at the call site with no visible signal.
+  // access silently and then widen it with no visible signal.
   assert.throws(() => assertAllowedTools(undefined), /required and must be a non-empty array/);
   assert.throws(() => assertAllowedTools(null), /required and must be a non-empty array/);
   assert.throws(() => assertAllowedTools("Read"), /required and must be a non-empty array/);
-  // Empty array is rejected rather than treated as "no tools": the SDK would run
-  // an agent that cannot read anything, burning quota to return nothing useful.
+  // Empty is rejected rather than read as "no tools": the SDK would run an agent
+  // that cannot read anything, burning a paid session to return nothing.
   assert.throws(() => assertAllowedTools([]), /required and must be a non-empty array/);
   assert.throws(() => assertAllowedTools(["Read", ""]), /must be non-empty strings/);
   assert.throws(() => assertAllowedTools(["Read", "   "]), /must be non-empty strings/);
@@ -53,32 +90,80 @@ test("assertAllowedTools: missing / empty / malformed input fails closed", () =>
   assert.throws(() => assertAllowedTools(["Read", null]), /must be non-empty strings/);
 });
 
-test("FORBIDDEN_TOOLS: covers execution, mutation, network and re-spawn, and is frozen", () => {
-  // Named explicitly because each entry closes a distinct escape route; a
-  // reviewer should be able to see the four categories are all covered.
-  for (const t of ["Bash", "Write", "Edit", "NotebookEdit", "WebFetch", "WebSearch", "Task"]) {
-    assert.ok(FORBIDDEN_TOOLS.includes(t), `FORBIDDEN_TOOLS must include ${t}`);
-  }
-  assert.ok(Object.isFrozen(FORBIDDEN_TOOLS));
+// --- askStructured actually enforces it --------------------------------------
+// Without these, deleting the assertAllowedTools call from askStructured — the
+// one line that makes any of the above load-bearing — leaves the suite green.
+
+test("askStructured: validates the grant BEFORE opening a session", async () => {
+  // The SDK is never reached: these reject with the VALIDATION error, and the
+  // assertion on the message is what proves the ordering. If the import ran
+  // first, an unresolvable/unauthenticated SDK would produce a different error.
+  await assert.rejects(
+    () => askStructured({ prompt: "x", schema: {}, allowedTools: ["Bash"] }),
+    /is not permitted/,
+    "a forbidden grant must fail before any session is opened",
+  );
+  await assert.rejects(
+    () => askStructured({ prompt: "x", schema: {}, allowedTools: ["Bash(git diff:*)"] }),
+    /is not permitted/,
+    "a scoped rule must fail before any session is opened",
+  );
+  await assert.rejects(
+    () => askStructured({ prompt: "x", schema: {} }),
+    /required and must be a non-empty array/,
+    "an omitted grant must fail before any session is opened",
+  );
+});
+
+// There is deliberately NO "valid grant reaches the SDK" test here. Asserting
+// that would mean letting askStructured past the validation gate, which opens a
+// real model session — slow, and on any runner that has credentials it would
+// burn a paid session from a unit suite. The complement is covered without a
+// session by the direct `assertAllowedTools(REVIEW_TOOLS)` assertion below: a
+// valid grant returns rather than throws, so the rejections above are the gate
+// firing and not a blanket failure.
+
+test("REVIEW_TOOLS: the panel's actual grant is inside the permitted set", () => {
+  // Pins what review-panel.mjs really passes at both call sites. Exported for
+  // exactly this: previously nothing could observe the panel's grant at all.
+  assert.deepEqual(REVIEW_TOOLS, ["Read", "Grep", "Glob"]);
+  assert.deepEqual(assertAllowedTools(REVIEW_TOOLS), REVIEW_TOOLS, "the panel's own grant must pass its own gate");
 });
 
 // --- moved-from-review-panel behavior, asserted at its new home ---------------
-// review-panel.test.mjs already covers these through its re-export and is left
-// untouched by this refactor (that is the evidence behavior did not change).
-// These two assert the same contract against ask.mjs directly, so deleting the
-// re-export later cannot silently drop the coverage.
+// review-panel.test.mjs still covers these through the re-export and is untouched
+// by this refactor (that is the evidence behavior did not change). These assert
+// the same contract against ask.mjs directly, so deleting the re-export later
+// cannot silently drop the coverage. Kept at parity with the originals, not
+// weaker: retry-cap, terminal_reason and the returned value are all covered.
 
-test("classifyResult: still distinguishes verdict / api-error / no-output at its new home", () => {
-  assert.equal(classifyResult({ subtype: "success", structured_output: { findings: [] } }).ok, true);
-  const quota = classifyResult({ subtype: "success", is_error: true, api_error_status: 429, result: "You've hit your session limit · resets 3:30pm" });
+test("classifyResult: distinguishes verdict / api-error / no-output at its new home", () => {
+  const ok = classifyResult({ subtype: "success", structured_output: { findings: [], summary: "s" } });
+  assert.equal(ok.ok, true);
+  assert.deepEqual(ok.output, { findings: [], summary: "s" });
+
+  const quota = classifyResult({
+    subtype: "success",
+    is_error: true,
+    api_error_status: 429,
+    result: "You've hit your session limit · resets 3:30pm (UTC)",
+  });
   assert.equal(quota.kind, "api-error");
+  assert.equal(quota.status, 429);
   assert.equal(quota.retryable, false, "a session limit cannot clear in-run, so it must not be retried");
+
   assert.equal(classifyResult({ subtype: "success", is_error: true, api_error_status: 529, result: "overloaded_error" }).retryable, true);
-  assert.equal(classifyResult({ subtype: "success" }).kind, "no-output");
+  assert.equal(classifyResult({ subtype: "error", is_error: true, api_error_status: 500, result: "internal error" }).retryable, true);
+  assert.equal(classifyResult({ terminal_reason: "api_error", result: "fetch failed" }).retryable, true);
+
+  const none = classifyResult({ subtype: "success" });
+  assert.equal(none.kind, "no-output");
+  assert.equal(none.retryable, false);
 });
 
-test("withRetry: retries only retryable errors", async () => {
+test("withRetry: retries retryable errors, honors the cap, never retries non-retryable", async () => {
   const noSleep = { baseMs: 0, sleep: async () => {} };
+
   let calls = 0;
   const out = await withRetry(async () => {
     calls++;
@@ -88,16 +173,22 @@ test("withRetry: retries only retryable errors", async () => {
   assert.equal(out, "ok");
   assert.equal(calls, 3);
 
+  let capped = 0;
+  await assert.rejects(withRetry(async () => { capped++; const e = new Error("x"); e.retryable = true; throw e; }, { ...noSleep, retries: 2 }));
+  assert.equal(capped, 3, "retries:2 means 3 total attempts, then give up");
+
   let once = 0;
   await assert.rejects(withRetry(async () => { once++; const e = new Error("quota"); e.retryable = false; throw e; }, noSleep));
   assert.equal(once, 1, "a non-retryable error must not be attempted twice");
 });
 
-test("CITATION: exported from review-panel.mjs so gates share one definition", () => {
-  // Exported by this refactor. The hunt gate consumes it; re-typing the pattern
-  // is the drift failure the panel's own comments argue against.
-  assert.ok(CITATION.test("packages/cli/src/output/formatter.ts:44"));
-  assert.ok(CITATION.test("see scripts/agent/ask.mjs:12 for why"));
-  assert.doesNotMatch("looks fine", CITATION, "a bare assertion is not a citation");
-  assert.doesNotMatch("packages/cli/src/output/formatter.ts", CITATION, "a path with no line number locates nothing");
+test("withRetry: backoff grows exponentially from baseMs", async () => {
+  // The delay argument was previously unobserved — both suites stubbed sleep with
+  // a zero-arg no-op, so a backoff of 0 would have passed.
+  const delays = [];
+  await assert.rejects(
+    withRetry(async () => { const e = new Error("x"); e.retryable = true; throw e; },
+      { retries: 3, baseMs: 100, sleep: async (ms) => { delays.push(ms); }, jitter: () => 0 }),
+  );
+  assert.deepEqual(delays, [100, 200, 400]);
 });

--- a/scripts/agent/ask.test.mjs
+++ b/scripts/agent/ask.test.mjs
@@ -161,6 +161,48 @@ test("classifyResult: distinguishes verdict / api-error / no-output at its new h
   assert.equal(none.retryable, false);
 });
 
+test("classifyResult: transport errors are retryable — the ECONNRESET regression", () => {
+  // The old quota pattern ended in `resets?\b`, which matches "ECONNRESET" at the
+  // end-of-string word boundary. Every one of these was classified NOT retryable,
+  // so withRetry gave up on the first attempt and the panel reported a false
+  // infrastructure failure for an ordinary network blip.
+  for (const detail of ["ECONNRESET", "read ECONNRESET", "connection reset by peer", "socket hang up", "fetch failed"]) {
+    const c = classifyResult({ is_error: true, result: detail });
+    assert.equal(c.retryable, true, `${detail} must be retryable`);
+  }
+});
+
+test("classifyResult: a plain 429 stays retryable even when it mentions rate limiting", () => {
+  // `rate limit` used to be in the non-retryable pattern, directly contradicting
+  // the docblock. A rate limit is the canonical retry-with-backoff case.
+  for (const detail of ["rate limit exceeded, please retry", "Too Many Requests", "rate_limit_error"]) {
+    assert.equal(classifyResult({ is_error: true, api_error_status: 429, result: detail }).retryable, true, detail);
+  }
+});
+
+test("classifyResult: a session/usage limit overrides an otherwise-retryable 429", () => {
+  // The one case that must stay non-retryable: it resets on a fixed schedule, so
+  // no amount of in-run backoff clears it. Status alone cannot decide this —
+  // both a plain rate limit and a session limit arrive as 429 — which is why the
+  // narrow text override survives.
+  for (const detail of ["You've hit your session limit · resets 3:30pm (UTC)", "usage limit reached for this month"]) {
+    assert.equal(classifyResult({ is_error: true, api_error_status: 429, result: detail }).retryable, false, detail);
+  }
+});
+
+test("classifyResult: deterministic 4xx is not retried; 5xx is", () => {
+  // Keyed on status, not prose. A bad token fails identically three times, so
+  // retrying only delays the real error.
+  for (const status of [400, 401, 403, 404, 422]) {
+    assert.equal(classifyResult({ is_error: true, api_error_status: status, result: "nope" }).retryable, false, `${status}`);
+  }
+  for (const status of [408, 429, 500, 502, 503, 529]) {
+    assert.equal(classifyResult({ is_error: true, api_error_status: status, result: "nope" }).retryable, true, `${status}`);
+  }
+  // A stringified status must not silently become non-retryable.
+  assert.equal(classifyResult({ is_error: true, api_error_status: "529", result: "overloaded" }).retryable, true);
+});
+
 test("withRetry: retries retryable errors, honors the cap, never retries non-retryable", async () => {
   const noSleep = { baseMs: 0, sleep: async () => {} };
 

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -20,11 +20,11 @@
 //   <out>/<lens>/verdict.json + summary.md   and   <out>/panel.json + panel-summary.md
 //
 // SDK access goes through ./ask.mjs, which owns the session options and REQUIRES
-// an explicit `allowedTools` (it refuses Bash/write/network/Task outright). This
-// module grants exactly `REVIEW_TOOLS` — read-only — at both call sites. ask.mjs
-// imports the SDK lazily, so the pure helpers below stay unit-testable without
-// the dependency installed. `classifyResult`/`withRetry` live there too and are
-// re-exported from here for existing importers.
+// an explicit tool grant, validated against its read-only allow-list. This module
+// grants exactly `REVIEW_TOOLS` at both call sites. ask.mjs imports the SDK
+// lazily, so the pure helpers below stay unit-testable without the dependency
+// installed. `classifyResult`/`withRetry` live there too and are re-exported from
+// here for existing importers.
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import path from "node:path";
@@ -181,10 +181,7 @@ export function applyVerifications(findings, verdictsByIndex, opts) {
 }
 
 /** A citation must locate something: `path.ext:line`, anywhere in the string. */
-// Exported so other gates reuse this exact pattern rather than re-typing it. A
-// hand-copied regex that drifted would silently change what counts as evidence —
-// the same class of failure `REFUTATION_GROUNDS` avoids by deriving from the schema.
-export const CITATION = /[^\s:]+\.[A-Za-z0-9_]+:\d+/;
+const CITATION = /[^\s:]+\.[A-Za-z0-9_]+:\d+/;
 
 /**
  * May this verdict DROP a blocking finding? Only on a complete, grounded
@@ -454,10 +451,11 @@ export { withRetry };
 // --- lens + verifier runs ----------------------------------------------------
 
 // The ONE tool grant for every reviewer subagent: read-only inspection, no
-// branch-code execution. ask.mjs REQUIRES this argument (and refuses Bash/write/
-// network/Task whatever is passed), so widening review's capabilities has to be a
-// visible edit here rather than a default someone inherits.
-const REVIEW_TOOLS = ["Read", "Grep", "Glob"];
+// branch-code execution. ask.mjs REQUIRES this argument and validates it against
+// its `PERMITTED_TOOLS` allow-list, so widening review's capabilities has to be a
+// visible edit HERE and is refused there anyway. Exported so a test can assert
+// what the panel actually grants; nothing else imports it.
+export const REVIEW_TOOLS = ["Read", "Grep", "Glob"];
 
 async function runLens(lens, { rubric, diff, issue, repo, sessionLog }) {
   const parts = [

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -19,16 +19,18 @@
 // Outputs under <out> (default .agent-review):
 //   <out>/<lens>/verdict.json + summary.md   and   <out>/panel.json + panel-summary.md
 //
-// SDK: @anthropic-ai/claude-agent-sdk (imported lazily so the pure helpers below
-// are unit-testable without the dependency installed). Verified against
-// @anthropic-ai/claude-agent-sdk 0.3.217 (pinned + lockfiled): outputFormat:
-// {type:'json_schema'}, result.structured_output, permissionMode 'dontAsk',
-// settingSources:[] all exist; the SDK reads CLAUDE_CODE_OAUTH_TOKEN.
+// SDK access goes through ./ask.mjs, which owns the session options and REQUIRES
+// an explicit `allowedTools` (it refuses Bash/write/network/Task outright). This
+// module grants exactly `REVIEW_TOOLS` — read-only — at both call sites. ask.mjs
+// imports the SDK lazily, so the pure helpers below stay unit-testable without
+// the dependency installed. `classifyResult`/`withRetry` live there too and are
+// re-exported from here for existing importers.
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { classify, renderSummaryMd, BLOCKING, normalizeSeverity, KNOWN } from "./severity.mjs";
+import { askStructured, withRetry } from "./ask.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
@@ -179,7 +181,10 @@ export function applyVerifications(findings, verdictsByIndex, opts) {
 }
 
 /** A citation must locate something: `path.ext:line`, anywhere in the string. */
-const CITATION = /[^\s:]+\.[A-Za-z0-9_]+:\d+/;
+// Exported so other gates reuse this exact pattern rather than re-typing it. A
+// hand-copied regex that drifted would silently change what counts as evidence —
+// the same class of failure `REFUTATION_GROUNDS` avoids by deriving from the schema.
+export const CITATION = /[^\s:]+\.[A-Za-z0-9_]+:\d+/;
 
 /**
  * May this verdict DROP a blocking finding? Only on a complete, grounded
@@ -436,101 +441,23 @@ export function verifierTally(findings, verdicts, opts) {
   return { sentToVerifier, refuted, refutedHighConfidence, dropped };
 }
 
-/**
- * Classify an SDK `result` message. The SDK reports API/quota failures as
- * subtype "success" with `is_error: true` (+ `api_error_status`, and a human
- * `result` string like "You've hit your session limit · resets 3:30pm (UTC)"),
- * so "subtype === success" alone is NOT proof the model ran. Returns one of:
- *   { ok:true, output }                                  — real structured verdict
- *   { ok:false, kind:'api-error', status, detail, retryable } — API/quota failure
- *   { ok:false, kind:'no-output', detail, retryable:false }   — ran but no verdict
- * A session/usage-limit resets on a fixed schedule (often hours out), so it is
- * NOT retryable in-run; any other API error (plain 429/529/overload/network) is.
- */
-export function classifyResult(message) {
-  const m = message || {};
-  if (m.subtype === "success" && m.structured_output) {
-    return { ok: true, output: m.structured_output };
-  }
-  if (m.is_error || m.api_error_status || m.terminal_reason === "api_error") {
-    const detail = typeof m.result === "string" && m.result ? m.result : "";
-    const isQuota = /session limit|usage limit|quota|rate limit|resets?\b/i.test(detail);
-    return { ok: false, kind: "api-error", status: m.api_error_status ?? null, detail, retryable: !isQuota };
-  }
-  return { ok: false, kind: "no-output", status: null, detail: `subtype=${m.subtype}`, retryable: false };
-}
-
-const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-/**
- * Run `fn`, retrying ONLY on errors flagged `err.retryable === true` (see
- * classifyResult), with exponential backoff + jitter. A non-retryable error
- * (quota/session-limit, or a genuine no-output) throws immediately — no wasted
- * retries on a limit that can't clear in-run. `sleep` is injectable for tests.
- */
-export async function withRetry(fn, { retries = 2, baseMs = 2000, sleep = defaultSleep, jitter = () => 0 } = {}) {
-  let last;
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      last = err;
-      if (!err || err.retryable !== true || attempt === retries) throw err;
-      await sleep(baseMs * 2 ** attempt + jitter());
-    }
-  }
-  throw last;
-}
-
-// --- SDK wrapper (lazy import) ----------------------------------------------
-
-async function askStructured({ systemPrompt, prompt, model, repo, schema, sessionLog, maxTurns }) {
-  const { query } = await import("@anthropic-ai/claude-agent-sdk");
-  for await (const message of query({
-    prompt,
-    options: {
-      systemPrompt,
-      model,
-      cwd: repo,
-      // Only set when the caller asks for a ceiling — a lens gets the SDK
-      // default. `maxTurns` exists in the pinned SDK (0.3.217), on the same
-      // Options type as allowedTools/outputFormat/permissionMode.
-      ...(Number.isFinite(maxTurns) ? { maxTurns } : {}),
-      allowedTools: ["Read", "Grep", "Glob"], // read-only; NO Bash/Write/network
-      permissionMode: "dontAsk", // deny anything not allow-listed, no prompts
-      // SECURITY: do NOT load project settings/hooks/agents from cwd — cwd is the
-      // untrusted branch checkout, and a branch-supplied .claude hook would be a
-      // shell command the SDK could execute. `settingSources: []` disables that
-      // (the workflow also strips the branch's `.claude/` as belt-and-suspenders).
-      // settingSources exists in the pinned SDK (0.3.217); [] loads no project config.
-      settingSources: [],
-      outputFormat: { type: "json_schema", schema },
-    },
-  })) {
-    if (message.type === "result") {
-      // Record cost/turns/tokens regardless of success — the call still burned
-      // compute even when it didn't produce usable structured output. This is
-      // the ONLY place a review-panel SDK call's result is observable at all;
-      // everything else here discards it, so record before the throw below.
-      if (sessionLog) sessionLog.push(message);
-      const c = classifyResult(message);
-      if (c.ok) return c.output;
-      const err = new Error(
-        c.kind === "api-error"
-          ? `review query API error${c.status ? ` (${c.status})` : ""}: ${c.detail || "unknown"}`
-          : `structured output not produced (${c.detail})`,
-      );
-      err.kind = c.kind;
-      err.status = c.status;
-      err.detail = c.detail;
-      err.retryable = c.retryable;
-      throw err;
-    }
-  }
-  throw new Error("query ended without a result message");
-}
+// `askStructured`, `classifyResult` and `withRetry` moved to ask.mjs, which owns
+// the SDK session and the read-only tool invariant those two exist to serve.
+// Both are re-exported here so this module's public surface is unchanged for
+// existing importers — review-panel.test.mjs covers them and stays untouched by
+// this refactor, which is the evidence that behavior did not change.
+// `withRetry` is imported at the top (main() calls it), so it is re-exported
+// from that binding rather than a second time from ask.mjs.
+export { classifyResult } from "./ask.mjs";
+export { withRetry };
 
 // --- lens + verifier runs ----------------------------------------------------
+
+// The ONE tool grant for every reviewer subagent: read-only inspection, no
+// branch-code execution. ask.mjs REQUIRES this argument (and refuses Bash/write/
+// network/Task whatever is passed), so widening review's capabilities has to be a
+// visible edit here rather than a default someone inherits.
+const REVIEW_TOOLS = ["Read", "Grep", "Glob"];
 
 async function runLens(lens, { rubric, diff, issue, repo, sessionLog }) {
   const parts = [
@@ -552,6 +479,8 @@ async function runLens(lens, { rubric, diff, issue, repo, sessionLog }) {
     repo,
     schema: LENS_SCHEMA,
     sessionLog,
+    allowedTools: REVIEW_TOOLS,
+    label: "review",
   });
 }
 
@@ -633,6 +562,8 @@ async function verifyFinding(finding, { rubric, repo, model, sessionLog, changed
     schema: VERIFIER_SCHEMA,
     sessionLog,
     maxTurns: VERIFIER_MAX_TURNS,
+    allowedTools: REVIEW_TOOLS,
+    label: "review",
   });
 }
 


### PR DESCRIPTION
## Summary

Moves `askStructured`, `classifyResult` and `withRetry` out of
`scripts/agent/review-panel.mjs` into a new `scripts/agent/ask.mjs`, and makes
`allowedTools` a **required, validated** parameter instead of a hardcoded array.

`assertAllowedTools` refuses `Bash`, `BashOutput`, `KillShell`, `Write`, `Edit`,
`NotebookEdit`, `WebFetch`, `WebSearch` and `Task` whatever the caller passes,
and returns a frozen copy. `review-panel.mjs` now grants exactly
`REVIEW_TOOLS = ["Read","Grep","Glob"]` at both call sites.

Also exports `CITATION` from `review-panel.mjs`.

## Why

A second consumer of this SDK plumbing is arriving — an autonomous
issue-hunting pipeline (planned as harness Phase 26). The tempting way to share
`askStructured` is to widen its hardcoded `allowedTools` for every caller, which
would quietly grant the review lenses capabilities they must never have: they
read an untrusted diff, so `Bash` would turn injected text into execution.

Making the grant a required parameter with a deny-list inverts that: widening a
grant becomes impossible rather than merely discouraged, and a consumer that
genuinely needs to execute something has to do it in its own trusted code from
data the model returned. The read-only invariant was previously a hardcoded
array with no test; it is now stated in one place and covered by eight.

`CITATION` is exported for the same reason `REFUTATION_GROUNDS` is derived from
its schema rather than hand-written: a copied regex that drifted would silently
change what counts as evidence in a gate.

This is deliberately a standalone refactor PR ahead of the new subsystem — a
pure change to a CODEOWNERS-protected, safety-critical file reviews far better
alone than bundled with a new feature.

## Linked Issues

Fixes #

No issue filed — this is a prerequisite refactor for the issue-hunting pipeline.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [x] verify:self — CI comment shows ✅
- [x] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): n/a — awaiting CI. Locally `pnpm verify:self`
passed all 11 lanes; this change touches only `scripts/agent/*.mjs`, which no
package imports.

Behavior-preservation evidence beyond the lanes:

- **Export surface diff vs `origin/main` is exactly `+CITATION`** — the one
  intentional addition (compared by importing both revisions and diffing
  `Object.keys`).
- **`review-panel.test.mjs` is untouched** and all 27 tests still pass. It
  imports `classifyResult`/`withRetry` from `review-panel.mjs`, which is why
  they are re-exported there; leaving that file unmodified is the evidence.
- **Lazy SDK import preserved** — all 121 agent tests pass with the
  `@anthropic-ai/claude-agent-sdk` specifier hard-blocked by a resolver hook,
  confirming neither module resolves it at import time.
- **The SDK does not mutate `allowedTools`** (it destructures and zod-validates
  it), so returning a frozen array is safe.

## Risk Assessment

- **User-facing risk:** none. No package imports `scripts/agent/`; nothing ships.
- **Data/security risk:** net reduction. The read-only tool grant for reviewer
  subagents was an untested hardcoded array; it is now validated on every call
  with a deny-list that cannot be overridden by a caller. No change to
  `permissionMode: "dontAsk"` or `settingSources: []`.
- **Rollback plan:** revert the commit. The change is self-contained to three
  files in `scripts/agent/` and has no migrations, config, or state.

## Notes for Reviewers

- **AI assistance:** this PR was written with Claude Code (Opus 5) in an
  interactive session — design, implementation, tests and this description.
  Every line was reviewed by me before commit. This is *not* an autonomous
  pipeline run: `WAFFLEBASE_AGENT_AUTONOMOUS` was unset, so the branch is
  deliberately **not** named `agent/*` and the PR is not agent-managed (see
  below).

- **Branch naming is deliberate.** `agent-review-panel.yml`'s gate sets
  `managed = true` unconditionally for any branch starting with `agent/`. Using
  that prefix for a human-authored PR would hand branch ownership to the cloud
  fix loop mid-review, which is the single-writer hazard
  `docs/design/harness-engineering.md` warns about for the local front door.
  Hence `harness/`.

- **This is a fork PR**, so the agent pipeline's back half cannot run on it
  regardless of prefix — the review-panel gate requires
  `head_repository.full_name == github.repository`. `@claude review` still works
  (it is read-only and explicitly supports forks) if you want the lens panel's
  advisory opinion; `@claude loop` does not, as it needs a same-repo branch the
  fixer can push to.

- **Two small judgement calls worth a look:**
  1. An empty `allowedTools: []` is *rejected*, not treated as "no tools" — the
     SDK would run an agent that cannot read anything. `auth-smoke.mjs`
     legitimately wants `[]` for a pure auth probe, which is why it calls the SDK
     directly and does not come through this wrapper; noted in `ask.mjs`.
  2. `askStructured` takes a `label` (default `"agent"`) purely so the thrown
     error keeps reading `review query API error …` for the panel. It has no
     behavioral effect; it exists to keep existing log output identical.

- **Follow-up work:** the issue-hunting pipeline itself (harness Phase 26),
  which is what needs this seam. It will import `askStructured` with the same
  read-only grant and execute model-proposed `argv` arrays in its own trusted
  code rather than holding a shell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a standardized structured agent request flow with enforced read-only tool permissions.
  - Introduced strict validation for allowed tool lists and improved result normalization (success vs no-output vs API/quota failures).
  - Implemented targeted retries with exponential backoff for eligible failures.
  - Centralized reviewer orchestration to reuse the same permissioning and retry/classification logic.

- **Tests**
  - Added unit tests covering tool allowlisting, request validation, result classification scenarios, and retry timing/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->