### PR TITLE
Edit link updates the existing hyperlink in place

### DIFF
--- a/docs/tasks/active/20260728-docs-edit-link-in-place-lessons.md
+++ b/docs/tasks/active/20260728-docs-edit-link-in-place-lessons.md
@@ -1,0 +1,23 @@
+# Lessons — Docs "Edit link" in place (#494)
+
+- **A helper extracted from one call site inherits that site's blind
+  spots.** `removeLink`'s run walk was "correct" only because a
+  zero-width match made `removeLink` a harmless no-op; reused for
+  `insertLink`, the same match silently swallowed the Apply action.
+  When promoting inline logic to a shared helper, re-derive its edge
+  cases against *each* new caller, not just the original one.
+- **`normalizeInlines` keeps the emptied run's style.** A fully-emptied
+  paragraph retains `inlines[0].style` — including `href` — so
+  "empty block" is not the same state as "no formatting". Any feature
+  that keys off inline style at the caret (link popover, pending
+  style, style summaries) must decide explicitly what a zero-width
+  styled residue means for it.
+- **Boundary tie-breaks must be owned by one function.** `removeLink`
+  (last match) and `getLinkAtCursor` (first match) disagreed at the
+  boundary between two adjacent links, so the popover could show link A
+  while Apply/Remove targeted link B. Detection and mutation now share
+  `findLinkRunAt`; the popover's display source is the contract.
+- **The adversarial-review step earns its cost.** The zero-width-run
+  regression passed the full suite (1136 tests) and a green
+  `verify:fast`; it was found only by a review agent explicitly told to
+  refute the change, which reproduced it through the real delete path.

--- a/docs/tasks/active/20260728-docs-edit-link-in-place-todo.md
+++ b/docs/tasks/active/20260728-docs-edit-link-in-place-todo.md
@@ -1,0 +1,144 @@
+# Docs — "Edit link" updates the existing link in place (#494)
+
+## Context
+
+Issue #494: clicking inside an existing hyperlink in Docs and using
+"Edit link" → Apply does not update the link. Instead a brand-new link
+(the URL as text) is inserted at the caret, leaving the original link
+untouched. Dragging to select the link first works — which pins the bug
+to `insertLink`'s collapsed-caret branch.
+
+Root cause: `insertLink` has only two branches — selection present
+(apply `href` to the range) and collapsed caret (insert the URL as new
+linked text). There is no "caret inside an existing link run" case, so
+the popover's Apply falls into the insert-new-text branch
+(`packages/docs/src/view/editor.ts`, and the same shape duplicated in
+`packages/docs/src/view/text-box-editor.ts` which powers Slides text
+boxes and Slides table cells).
+
+The run-boundary logic needed for that third branch already exists —
+`removeLink` finds the full link run at the caret (cursor inline → walk
+`lo`/`hi` across adjacent runs sharing the same `href`) in both editors,
+duplicated inline. Same spirit as #495/PR #520, which put its boundary
+check in one shared place (`isAtLinkTrailingEdge`, a private method on
+the shared `TextEditor` class) — but `insertLink`/`removeLink` live in
+the two editor factories (`initialize` / `initializeTextBox`), which
+share no class, so the shared home here is a standalone module
+(`link-run.ts`), following the `word-boundary.ts` / `url-detect.ts`
+view-helper idiom.
+
+One deliberate semantic choice: at the shared boundary between two
+*adjacent different-href* links (end of A == start of B), `removeLink`'s
+loop used to pick the later run (B), while `getLinkAtCursor` — which
+feeds the popover's URL field — reports A. The extracted helper breaks
+the tie toward the earlier run (first match) so that what the popover
+*shows* is what Apply *updates*; `removeLink` inherits the same
+tie-break, a strict consistency improvement.
+
+## Work
+
+- [x] Extract `findLinkRunAt(block, offset)` into
+  `packages/docs/src/view/link-run.ts` — returns the full
+  `{ start, end, href }` of the link run at the caret (offset within
+  `[start, end]` of an `href` inline, extended across adjacent runs with
+  the same `href`), or `undefined` when the caret isn't in a link.
+- [x] `editor.ts` `insertLink`: third branch — collapsed caret inside a
+  link run → `applyInlineStyle` the new `href` over the whole run
+  instead of inserting the URL as text. Dirty-marking mirrors
+  `removeLink` (cell block → parent table block). Caret stays put.
+- [x] `editor.ts` `removeLink`: refactor onto the shared helper.
+- [x] `text-box-editor.ts` `insertLink` / `removeLink`: same third
+  branch + same refactor (covers Slides text boxes and Slides table
+  cells via the shared factory).
+- [x] Tests:
+  - `test/view/link-run.test.ts` — pure-function coverage: inside /
+    trailing edge / leading edge / split same-href runs / no link /
+    adjacent different-href links (tie-break toward the earlier run).
+  - `test/view/edit-link-in-place.test.ts` — real `initialize()` +
+    jsdom harness (same as `link-trailing-edge.test.ts`): selection-made
+    link then caret click + `insertLink` updates in place (issue repro);
+    trailing-edge caret updates in place; split (bold-prefix) run fully
+    re-hrefed; caret outside any link still inserts URL text; undo
+    restores the old href.
+  - `test/view/text-box-edit-link-in-place.test.ts` — same via
+    `initializeTextBox` (ArrowLeft to place the caret inside the link).
+- [x] `pnpm verify:fast` green (89 docs test files, 1171 passed / 1 skipped; all packages green).
+- [x] Self-review over the branch diff; apply blocking findings.
+- [x] Re-landed on latest upstream `main` (`c810f4f02`) after the base
+  moved 34 commits: the patch applied cleanly; the only overlapping
+  upstream change is #548 (viewer read-only), which no-ops
+  `insertLink`/`removeLink` at the EditorAPI boundary in read-only mode
+  and hides the popover's Edit/Remove buttons — orthogonal to this fix
+  and it gates the new branch automatically.
+
+## Self-review
+
+Dispatched an independent adversarial review agent over the branch diff
+(the `/code-review` skill is not directly invocable in this session).
+Findings:
+
+- **Blocking, fixed**: `findLinkRunAt` matched a zero-width run on an
+  empty-text inline carrying `href` — the residue `normalizeInlines`
+  leaves when a linked paragraph is fully emptied (select-all + delete,
+  or backspacing every character). The in-place branch then called
+  `applyInlineStyle` over a `[0, 0]` range, a silent no-op: Apply did
+  nothing and pushed a junk undo entry, where the pre-fix code inserted
+  the URL. Fixed in the helper — an empty-text inline cannot anchor a
+  run (still crossed by the lo/hi walk inside a wider same-href run),
+  restoring the insert fallback. This also improves the exotic
+  `[empty-href-X, "abc"-href-Y]` state: the caret at 0 now resolves to
+  the real link Y instead of the zero-width X residue. Regression tests
+  added in all three test files.
+- **Non-blocking, not applied** (noted for the record):
+  - `editor.ts`'s `if (!block)` guard after `doc.getBlock` is dead —
+    `Doc.getBlock` throws rather than returning undefined. Pre-existing
+    pattern shared by `removeLink`/`getLinkAtCursor` in the same file;
+    kept for consistency, not a regression (the old branch threw
+    equally inside `doc.insertText`).
+  - The new caret branch doesn't call `setCursorForHistory` (the #523
+    pattern used by the selection branch), so on the Yorkie store an
+    undo of an in-place edit doesn't restore the caret to the link.
+    Matches the pre-existing `removeLink` precedent; the edit itself
+    never moves the caret.
+  - Test gap: no table-cell-block coverage for the
+    `cellInfo → markDirty(tableBlockId)` arm (mirrors `removeLink`,
+    which is equally uncovered).
+- **Verified correct by the review**: snapshot ordering for undo,
+  dirty-marking parity with `removeLink`, `render`/`notifyStyleApplied`
+  parity with sibling branches, caret staying put, no interaction with
+  the #495 trailing-edge pending-style fix, popover flow consistency
+  (`getLinkAtCursor` prefill ↔ Apply target, including the A|B
+  boundary tie-break), and Slides inheriting the fix through the
+  delegating text-box editor with no further change.
+
+### Re-land review (on `c810f4f02`)
+
+A second adversarial review over the re-landed diff against the moved
+base found **no blocking issues**. Grounded verifications: the #548
+read-only no-op allowlist makes the new branch unreachable in viewer
+mode; `findLinkRunAt` matches `getLinkAtCursorPosition`'s empty-inline
+exclusion and tie-break (popover shows == Apply edits); on the Yorkie
+store empty non-image inlines can materialize but every reachable
+residue state is the anchor-excluded case (delete/style paths prune
+emptied inlines), and Yorkie `applyStyle` covers interior empties, so
+the in-place update is whole-run correct on the CRDT path. Non-blocking
+notes:
+
+- **Deliberate behavior change**: caret at a link's trailing edge +
+  Apply now edits that link in place (before: inserted an adjacent
+  second link). Coherent with the popover prefill; call out in the PR
+  body.
+- `getLinkAtCursor` (unchanged) still returns href residue on a
+  fully-emptied paragraph, so residue-state ⌘K prefills the old URL
+  while Apply inserts new linked text — pre-existing prefill quirk,
+  the fallback itself is the tested, intended behavior.
+- Dead `if (!block)`-style guard and missing `setCursorForHistory` in
+  the new branch: same pre-existing patterns as noted above.
+
+## Out of scope
+
+- Editing the link's display *text* from the popover (#494 mentions
+  "URL and/or display text" — the popover currently only has a URL
+  field; text editing is a separate feature).
+- The popover UI itself (`docs-link-popover.tsx`) needs no change: it
+  already calls `editor.insertLink(url)` and the fix makes that DTRT.

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -3100,7 +3100,13 @@ export function initialize(
         if (cursor.position.offset >= pos && cursor.position.offset < inlineEnd) {
           return inline.style.href;
         }
-        if (cursor.position.offset === inlineEnd && inline.style.href) {
+        // Skip an empty-text href residue at the boundary — it must not
+        // shadow an adjacent real link, matching findLinkRunAt's tie-break.
+        if (
+          cursor.position.offset === inlineEnd &&
+          inline.text.length > 0 &&
+          inline.style.href
+        ) {
           return inline.style.href;
         }
         pos = inlineEnd;

--- a/packages/docs/src/view/editor.ts
+++ b/packages/docs/src/view/editor.ts
@@ -22,6 +22,7 @@ import { defaultColorResolver, resolveColorAtPosition } from '../model/color.js'
 import { type PeerCursor, resolvePositionPixel } from './peer-cursor.js';
 import { computeTableMergeContext, type TableMergeContext } from './table-merge-context.js';
 import { createPendingStyle } from './pending-style.js';
+import { findLinkRunAt } from './link-run.js';
 import { SpellSession, type SpellError } from '../spell/session.js';
 import { SpellRouter } from '../spell/router.js';
 import { LocalSpellProvider } from '../spell/local-provider.js';
@@ -3030,9 +3031,30 @@ export function initialize(
         render();
         notifyStyleApplied();
       } else {
-        docStore.snapshot();
         const pos = cursor.position;
 
+        // Caret inside an existing link: update its href in place instead
+        // of inserting the URL as a new link at the caret (#494).
+        const block = doc.getBlock(pos.blockId);
+        const link = block ? findLinkRunAt(block, pos.offset) : undefined;
+        if (block && link) {
+          docStore.snapshot();
+          doc.applyInlineStyle(
+            {
+              anchor: { blockId: block.id, offset: link.start },
+              focus: { blockId: block.id, offset: link.end },
+            },
+            { href: url },
+          );
+          // Cell block: mark the parent table block dirty (mirrors removeLink)
+          const cellInfo = layout.blockParentMap.get(block.id);
+          markDirty(cellInfo ? cellInfo.tableBlockId : block.id);
+          render();
+          notifyStyleApplied();
+          return;
+        }
+
+        docStore.snapshot();
         doc.insertText(pos, url);
         const range = {
           anchor: { blockId: pos.blockId, offset: pos.offset },
@@ -3052,28 +3074,13 @@ export function initialize(
       const block = doc.getBlock(cursor.position.blockId);
       if (!block) return;
 
-      const inlines = block.inlines;
-
-      let cursorInlineIdx = -1;
-      const offsets: number[] = [0];
-      for (let i = 0; i < inlines.length; i++) {
-        const inlineEnd = offsets[i] + inlines[i].text.length;
-        offsets.push(inlineEnd);
-        if (cursor.position.offset >= offsets[i] && cursor.position.offset <= inlineEnd && inlines[i].style.href) {
-          cursorInlineIdx = i;
-        }
-      }
-      if (cursorInlineIdx < 0) return;
-      const href = inlines[cursorInlineIdx].style.href;
-      let lo = cursorInlineIdx;
-      while (lo > 0 && inlines[lo - 1].style.href === href) lo--;
-      let hi = cursorInlineIdx;
-      while (hi < inlines.length - 1 && inlines[hi + 1].style.href === href) hi++;
+      const link = findLinkRunAt(block, cursor.position.offset);
+      if (!link) return;
 
       docStore.snapshot();
       const range = {
-        anchor: { blockId: block.id, offset: offsets[lo] },
-        focus: { blockId: block.id, offset: offsets[hi + 1] },
+        anchor: { blockId: block.id, offset: link.start },
+        focus: { blockId: block.id, offset: link.end },
       };
       doc.applyInlineStyle(range, { href: undefined });
       // Mark the containing block (or table block for cell blocks) as dirty

--- a/packages/docs/src/view/link-run.ts
+++ b/packages/docs/src/view/link-run.ts
@@ -18,7 +18,8 @@ export interface LinkRun {
  * isn't touching one. An offset on either edge of an `href` inline
  * counts as inside it. At the shared boundary between two adjacent
  * *different* links (end of A == start of B) the earlier run wins —
- * the same tie-break as `getLinkAtCursor`, so the link a popover
+ * the same tie-break as `getLinkAtCursor` (both editors skip an
+ * empty-text href residue at the boundary), so the link a popover
  * displays is the link that gets edited or removed.
  *
  * An empty-text inline cannot anchor a run: the `href` residue that

--- a/packages/docs/src/view/link-run.ts
+++ b/packages/docs/src/view/link-run.ts
@@ -1,0 +1,55 @@
+import type { Block } from '../model/types.js';
+
+/**
+ * The full extent of the hyperlink run at `offset` within `block`:
+ * the inline containing the offset, extended left and right across
+ * adjacent inlines sharing the same `href` (a link split into
+ * differently-styled sub-runs, e.g. a bold prefix, is one run).
+ * Offsets are block-local; `end` is exclusive.
+ */
+export interface LinkRun {
+  start: number;
+  end: number;
+  href: string;
+}
+
+/**
+ * Find the link run at a caret offset, or `undefined` when the caret
+ * isn't touching one. An offset on either edge of an `href` inline
+ * counts as inside it. At the shared boundary between two adjacent
+ * *different* links (end of A == start of B) the earlier run wins —
+ * the same tie-break as `getLinkAtCursor`, so the link a popover
+ * displays is the link that gets edited or removed.
+ *
+ * An empty-text inline cannot anchor a run: the `href` residue that
+ * `normalizeInlines` leaves on a fully-emptied paragraph is not an
+ * editable link, and a zero-width range would make `applyInlineStyle`
+ * a silent no-op. (Empty inlines are still crossed by the lo/hi walk
+ * when they sit inside a wider same-href run.)
+ */
+export function findLinkRunAt(block: Block, offset: number): LinkRun | undefined {
+  const inlines = block.inlines;
+  let cursorInlineIdx = -1;
+  const offsets: number[] = [0];
+  for (let i = 0; i < inlines.length; i++) {
+    const inlineEnd = offsets[i] + inlines[i].text.length;
+    offsets.push(inlineEnd);
+    if (
+      cursorInlineIdx < 0 &&
+      offset >= offsets[i] &&
+      offset <= inlineEnd &&
+      inlines[i].text.length > 0 &&
+      inlines[i].style.href
+    ) {
+      cursorInlineIdx = i;
+    }
+  }
+  if (cursorInlineIdx < 0) return undefined;
+  const href = inlines[cursorInlineIdx].style.href;
+  if (!href) return undefined;
+  let lo = cursorInlineIdx;
+  while (lo > 0 && inlines[lo - 1].style.href === href) lo--;
+  let hi = cursorInlineIdx;
+  while (hi < inlines.length - 1 && inlines[hi + 1].style.href === href) hi++;
+  return { start: offsets[lo], end: offsets[hi + 1], href };
+}

--- a/packages/docs/src/view/text-box-editor.ts
+++ b/packages/docs/src/view/text-box-editor.ts
@@ -33,6 +33,7 @@ import { Doc } from '../model/document.js';
 import { MemDocStore } from '../store/memory.js';
 import { CanvasTextMeasurer } from './canvas-measurer.js';
 import { createPendingStyle } from './pending-style.js';
+import { findLinkRunAt } from './link-run.js';
 import {
   computeLayout,
   type ComposingContext,
@@ -1120,8 +1121,28 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
         requestRender();
         notifyStyleApplied();
       } else {
-        docStore.snapshot();
         const pos = cursor.position;
+
+        // Caret inside an existing link: update its href in place instead
+        // of inserting the URL as a new link at the caret (#494).
+        const block = doc.findBlock(pos.blockId);
+        const link = block ? findLinkRunAt(block, pos.offset) : undefined;
+        if (block && link) {
+          docStore.snapshot();
+          doc.applyInlineStyle(
+            {
+              anchor: { blockId: block.id, offset: link.start },
+              focus: { blockId: block.id, offset: link.end },
+            },
+            { href: url },
+          );
+          layoutCache = undefined;
+          requestRender();
+          notifyStyleApplied();
+          return;
+        }
+
+        docStore.snapshot();
         doc.insertText(pos, url);
         const range = {
           anchor: { blockId: pos.blockId, offset: pos.offset },
@@ -1138,26 +1159,12 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
     removeLink(): void {
       const block = doc.findBlock(cursor.position.blockId);
       if (!block) return;
-      const inlines = block.inlines;
-      let cursorInlineIdx = -1;
-      const offsets: number[] = [0];
-      for (let i = 0; i < inlines.length; i++) {
-        const inlineEnd = offsets[i] + inlines[i].text.length;
-        offsets.push(inlineEnd);
-        if (cursor.position.offset >= offsets[i] && cursor.position.offset <= inlineEnd && inlines[i].style.href) {
-          cursorInlineIdx = i;
-        }
-      }
-      if (cursorInlineIdx < 0) return;
-      const href = inlines[cursorInlineIdx].style.href;
-      let lo = cursorInlineIdx;
-      while (lo > 0 && inlines[lo - 1].style.href === href) lo--;
-      let hi = cursorInlineIdx;
-      while (hi < inlines.length - 1 && inlines[hi + 1].style.href === href) hi++;
+      const link = findLinkRunAt(block, cursor.position.offset);
+      if (!link) return;
       docStore.snapshot();
       const range = {
-        anchor: { blockId: block.id, offset: offsets[lo] },
-        focus: { blockId: block.id, offset: offsets[hi + 1] },
+        anchor: { blockId: block.id, offset: link.start },
+        focus: { blockId: block.id, offset: link.end },
       };
       doc.applyInlineStyle(range, { href: undefined });
       layoutCache = undefined;

--- a/packages/docs/src/view/text-box-editor.ts
+++ b/packages/docs/src/view/text-box-editor.ts
@@ -1181,7 +1181,13 @@ export function initializeTextBox(opts: TextBoxEditorOptions): TextBoxEditorAPI 
         if (cursor.position.offset >= pos && cursor.position.offset < inlineEnd) {
           return inline.style.href;
         }
-        if (cursor.position.offset === inlineEnd && inline.style.href) {
+        // Skip an empty-text href residue at the boundary — it must not
+        // shadow an adjacent real link, matching findLinkRunAt's tie-break.
+        if (
+          cursor.position.offset === inlineEnd &&
+          inline.text.length > 0 &&
+          inline.style.href
+        ) {
           return inline.style.href;
         }
         pos = inlineEnd;

--- a/packages/docs/test/view/edit-link-in-place.test.ts
+++ b/packages/docs/test/view/edit-link-in-place.test.ts
@@ -1,0 +1,275 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { initialize, type EditorAPI } from '../../src/view/editor.js';
+import { MemDocStore } from '../../src/store/memory.js';
+import { createEmptyBlock } from '../../src/model/types.js';
+
+/**
+ * Regression coverage for issue #494: with a collapsed caret inside an
+ * existing hyperlink, `insertLink` (the link popover's Apply) must update
+ * that link's href in place — before the fix it fell into the
+ * insert-new-text branch and inserted the URL as a brand-new link at the
+ * caret, leaving the original link untouched.
+ */
+function makeCtxSpy() {
+  return {
+    fillStyle: '#000',
+    strokeStyle: '#000',
+    lineWidth: 1,
+    font: '10px sans-serif',
+    textAlign: 'start' as CanvasTextAlign,
+    textBaseline: 'alphabetic' as CanvasTextBaseline,
+    globalAlpha: 1,
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    clearRect: vi.fn(),
+    setTransform: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    scale: vi.fn(),
+    translate: vi.fn(),
+    rotate: vi.fn(),
+    transform: vi.fn(),
+    clip: vi.fn(),
+    rect: vi.fn(),
+    measureText: (text: string) => ({ width: text.length * 8 }),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    arc: vi.fn(),
+    stroke: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    bezierCurveTo: vi.fn(),
+  };
+}
+
+describe('docs editor — edit link in place (#494)', () => {
+  let container: HTMLElement;
+  let editor: EditorAPI;
+  let origGetContext: HTMLCanvasElement['getContext'];
+  let origRAF: typeof window.requestAnimationFrame;
+
+  beforeEach(() => {
+    if (!(globalThis as { ResizeObserver?: unknown }).ResizeObserver) {
+      class FakeResizeObserver {
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+      (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = FakeResizeObserver;
+    }
+    if (!(globalThis as { OffscreenCanvas?: unknown }).OffscreenCanvas) {
+      class FakeOffscreenCanvas {
+        constructor(public width: number, public height: number) {}
+        getContext(_type: string): unknown {
+          return {
+            font: '10px sans-serif',
+            measureText: (text: string) => ({ width: text.length * 8 }),
+          };
+        }
+      }
+      (globalThis as unknown as { OffscreenCanvas: unknown }).OffscreenCanvas = FakeOffscreenCanvas;
+    }
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    const spy = makeCtxSpy();
+    HTMLCanvasElement.prototype.getContext = function patched(
+      contextId: string,
+    ): unknown {
+      if (contextId === '2d') return spy;
+      return null;
+    } as HTMLCanvasElement['getContext'];
+    origRAF = window.requestAnimationFrame;
+    window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      queueMicrotask(() => cb(performance.now()));
+      return 0;
+    };
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const store = new MemDocStore();
+    store.setDocument({ blocks: [createEmptyBlock()] });
+    editor = initialize(container, store);
+  });
+
+  afterEach(() => {
+    editor.dispose();
+    document.body.removeChild(container);
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+    window.requestAnimationFrame = origRAF;
+  });
+
+  function textarea(): HTMLTextAreaElement {
+    const el = container.querySelector('textarea');
+    if (!el) throw new Error('textarea not mounted');
+    return el;
+  }
+
+  function type(text: string): void {
+    const ta = textarea();
+    ta.value = text;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function firstBlockInlines() {
+    return editor.getDoc().document.blocks[0].inlines;
+  }
+
+  function blockText(): string {
+    return firstBlockInlines().map((i) => i.text).join('');
+  }
+
+  /** Link "example" inside "example text" via a drag selection, then
+   * collapse the caret to `offset` — the issue's repro setup. */
+  function makeLinkedExample(caretOffset: number): string {
+    type('example text');
+    const blockId = editor.getDoc().document.blocks[0].id;
+    editor._setSelectionForTest({
+      anchor: { blockId, offset: 0 },
+      focus: { blockId, offset: 7 },
+    });
+    editor.insertLink('https://example.com');
+    editor._setSelectionForTest(null);
+    editor.restoreLocalCursor({ blockId, offset: caretOffset }, null);
+    return blockId;
+  }
+
+  function pressBackspace(times: number): void {
+    for (let i = 0; i < times; i++) {
+      textarea().dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true }),
+      );
+    }
+  }
+
+  it('caret click inside a link + Apply updates the existing link (issue repro)', () => {
+    makeLinkedExample(3);
+    editor.insertLink('https://example.org');
+
+    expect(blockText()).toBe('example text');
+    const inlines = firstBlockInlines();
+    let pos = 0;
+    for (const inline of inlines) {
+      const end = pos + inline.text.length;
+      if (end <= 7) expect(inline.style.href).toBe('https://example.org');
+      if (pos >= 7) expect(inline.style.href).toBeFalsy();
+      pos = end;
+    }
+    expect(editor.getDoc().document.blocks).toHaveLength(1);
+  });
+
+  it('caret at the trailing edge of the link also updates in place', () => {
+    makeLinkedExample(7);
+    editor.insertLink('https://example.org');
+
+    expect(blockText()).toBe('example text');
+    expect(firstBlockInlines()[0].style.href).toBe('https://example.org');
+  });
+
+  it('updates the whole run when the link is split into styled sub-runs', () => {
+    const blockId = makeLinkedExample(3);
+    // Bold just "exa", splitting the link into two same-href runs.
+    editor._setSelectionForTest({
+      anchor: { blockId, offset: 0 },
+      focus: { blockId, offset: 3 },
+    });
+    editor.applyStyle({ bold: true });
+    editor._setSelectionForTest(null);
+    editor.restoreLocalCursor({ blockId, offset: 5 }, null);
+
+    editor.insertLink('https://example.org');
+
+    expect(blockText()).toBe('example text');
+    let pos = 0;
+    for (const inline of firstBlockInlines()) {
+      const end = pos + inline.text.length;
+      if (end <= 7) expect(inline.style.href).toBe('https://example.org');
+      pos = end;
+    }
+  });
+
+  it('caret outside any link still inserts the URL as new linked text', () => {
+    makeLinkedExample(12); // end of " text", not in the link
+
+    editor.insertLink('https://new.example.com');
+
+    expect(blockText()).toBe('example texthttps://new.example.com');
+    const inlines = firstBlockInlines();
+    const last = inlines[inlines.length - 1];
+    expect(last.style.href).toBe('https://new.example.com');
+    // The original link is untouched.
+    expect(inlines[0].style.href).toBe('https://example.com');
+  });
+
+  it('the caret does not move when a link is updated in place', () => {
+    const blockId = makeLinkedExample(3);
+    editor.insertLink('https://example.org');
+
+    expect(editor._getCursorForTest()).toEqual({ blockId, offset: 3 });
+  });
+
+  it('at the boundary between two links, Apply edits the link the popover shows', () => {
+    type('aaabbb');
+    const blockId = editor.getDoc().document.blocks[0].id;
+    editor._setSelectionForTest({
+      anchor: { blockId, offset: 0 },
+      focus: { blockId, offset: 3 },
+    });
+    editor.insertLink('https://a.example.com');
+    editor._setSelectionForTest({
+      anchor: { blockId, offset: 3 },
+      focus: { blockId, offset: 6 },
+    });
+    editor.insertLink('https://b.example.com');
+    editor._setSelectionForTest(null);
+    editor.restoreLocalCursor({ blockId, offset: 3 }, null);
+
+    // The popover prefills from getLinkAtCursor — link A at this boundary.
+    expect(editor.getLinkAtCursor()).toBe('https://a.example.com');
+    editor.insertLink('https://c.example.com');
+
+    expect(blockText()).toBe('aaabbb');
+    let pos = 0;
+    for (const inline of firstBlockInlines()) {
+      const end = pos + inline.text.length;
+      if (end <= 3) expect(inline.style.href).toBe('https://c.example.com');
+      if (pos >= 3) expect(inline.style.href).toBe('https://b.example.com');
+      pos = end;
+    }
+  });
+
+  it('href residue on a fully-emptied paragraph falls back to inserting the URL', () => {
+    editor.insertLink('https://example.com');
+    pressBackspace('https://example.com'.length);
+
+    // normalizeInlines keeps the emptied run's style — the href residue
+    // state that made in-place apply a silent no-op (zero-width run).
+    const residue = firstBlockInlines();
+    expect(residue.map((i) => i.text).join('')).toBe('');
+    expect(residue[0].style.href).toBe('https://example.com');
+
+    editor.insertLink('https://example.org');
+
+    expect(blockText()).toBe('https://example.org');
+    expect(firstBlockInlines().every((i) => !i.text || i.style.href === 'https://example.org')).toBe(true);
+  });
+
+  it('undo restores the previous href', () => {
+    makeLinkedExample(3);
+    editor.insertLink('https://example.org');
+    expect(firstBlockInlines()[0].style.href).toBe('https://example.org');
+
+    editor.undo();
+
+    expect(blockText()).toBe('example text');
+    expect(firstBlockInlines()[0].style.href).toBe('https://example.com');
+  });
+
+  it('removeLink with the caret inside the link still unlinks the whole run', () => {
+    makeLinkedExample(3);
+    editor.removeLink();
+
+    expect(blockText()).toBe('example text');
+    expect(firstBlockInlines().every((i) => !i.style.href)).toBe(true);
+  });
+});

--- a/packages/docs/test/view/edit-link-in-place.test.ts
+++ b/packages/docs/test/view/edit-link-in-place.test.ts
@@ -254,6 +254,37 @@ describe('docs editor — edit link in place (#494)', () => {
     expect(firstBlockInlines().every((i) => !i.text || i.style.href === 'https://example.org')).toBe(true);
   });
 
+  it('getLinkAtCursor ignores an empty href residue shadowing an adjacent link', () => {
+    // An empty-text href inline directly before a real link is not
+    // reachable through normalizeInlines (it drops empty inlines), so
+    // inject it straight into the store. getLinkAtCursor must skip the
+    // residue and report the real link the caret sits on — matching
+    // findLinkRunAt's tie-break, which is what Apply actually targets.
+    const injected = new MemDocStore();
+    const base = createEmptyBlock();
+    injected.setDocument({
+      blocks: [
+        {
+          ...base,
+          inlines: [
+            { text: '', style: { href: 'https://a.example.com' } },
+            { text: 'abc', style: { href: 'https://b.example.com' } },
+          ],
+        },
+      ],
+    });
+    const box = document.createElement('div');
+    document.body.appendChild(box);
+    const scoped = initialize(box, injected);
+    try {
+      scoped.restoreLocalCursor({ blockId: base.id, offset: 0 }, null);
+      expect(scoped.getLinkAtCursor()).toBe('https://b.example.com');
+    } finally {
+      scoped.dispose();
+      document.body.removeChild(box);
+    }
+  });
+
   it('undo restores the previous href', () => {
     makeLinkedExample(3);
     editor.insertLink('https://example.org');

--- a/packages/docs/test/view/link-run.test.ts
+++ b/packages/docs/test/view/link-run.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { findLinkRunAt } from '../../src/view/link-run.js';
+import { createEmptyBlock } from '../../src/model/types.js';
+import type { Block, Inline } from '../../src/model/types.js';
+
+function makeBlock(inlines: Inline[]): Block {
+  const block = createEmptyBlock();
+  block.inlines = inlines;
+  return block;
+}
+
+const A = 'https://a.example.com';
+const B = 'https://b.example.com';
+
+describe('findLinkRunAt', () => {
+  it('returns undefined when the block has no link', () => {
+    const block = makeBlock([{ text: 'plain text', style: {} }]);
+    expect(findLinkRunAt(block, 0)).toBeUndefined();
+    expect(findLinkRunAt(block, 5)).toBeUndefined();
+    expect(findLinkRunAt(block, 10)).toBeUndefined();
+  });
+
+  it('returns undefined on an empty block', () => {
+    const block = makeBlock([{ text: '', style: {} }]);
+    expect(findLinkRunAt(block, 0)).toBeUndefined();
+  });
+
+  it('finds the run when the offset is inside a link inline', () => {
+    const block = makeBlock([
+      { text: 'before ', style: {} },
+      { text: 'link', style: { href: A } },
+      { text: ' after', style: {} },
+    ]);
+    expect(findLinkRunAt(block, 9)).toEqual({ start: 7, end: 11, href: A });
+  });
+
+  it('treats both edges of the link inline as inside it', () => {
+    const block = makeBlock([
+      { text: 'before ', style: {} },
+      { text: 'link', style: { href: A } },
+      { text: ' after', style: {} },
+    ]);
+    expect(findLinkRunAt(block, 7)).toEqual({ start: 7, end: 11, href: A });
+    expect(findLinkRunAt(block, 11)).toEqual({ start: 7, end: 11, href: A });
+  });
+
+  it('returns undefined when the offset is in surrounding plain text', () => {
+    const block = makeBlock([
+      { text: 'before ', style: {} },
+      { text: 'link', style: { href: A } },
+      { text: ' after', style: {} },
+    ]);
+    expect(findLinkRunAt(block, 3)).toBeUndefined();
+    expect(findLinkRunAt(block, 13)).toBeUndefined();
+  });
+
+  it('extends across adjacent runs sharing the same href', () => {
+    const block = makeBlock([
+      { text: 'ht', style: { href: A, bold: true } },
+      { text: 'tps', style: { href: A } },
+      { text: ' after', style: {} },
+    ]);
+    expect(findLinkRunAt(block, 0)).toEqual({ start: 0, end: 5, href: A });
+    expect(findLinkRunAt(block, 2)).toEqual({ start: 0, end: 5, href: A });
+    expect(findLinkRunAt(block, 5)).toEqual({ start: 0, end: 5, href: A });
+  });
+
+  it('prefers the earlier run at the boundary between two different links', () => {
+    const block = makeBlock([
+      { text: 'aaa', style: { href: A } },
+      { text: 'bbb', style: { href: B } },
+    ]);
+    // Same tie-break as getLinkAtCursor: the popover shows link A here.
+    expect(findLinkRunAt(block, 3)).toEqual({ start: 0, end: 3, href: A });
+    expect(findLinkRunAt(block, 4)).toEqual({ start: 3, end: 6, href: B });
+  });
+
+  it('ignores an href residue on an empty-text inline (emptied paragraph)', () => {
+    // normalizeInlines keeps inlines[0].style when a paragraph is fully
+    // emptied — a zero-width "run" that applyInlineStyle would no-op on.
+    const block = makeBlock([{ text: '', style: { href: A } }]);
+    expect(findLinkRunAt(block, 0)).toBeUndefined();
+  });
+
+  it('an empty href inline does not shadow an adjacent real link', () => {
+    const block = makeBlock([
+      { text: '', style: { href: A } },
+      { text: 'abc', style: { href: B } },
+    ]);
+    expect(findLinkRunAt(block, 0)).toEqual({ start: 0, end: 3, href: B });
+  });
+
+  it('still crosses an empty inline sitting inside a wider same-href run', () => {
+    const block = makeBlock([
+      { text: 'ab', style: { href: A } },
+      { text: '', style: { href: A } },
+      { text: 'cd', style: { href: A } },
+    ]);
+    expect(findLinkRunAt(block, 1)).toEqual({ start: 0, end: 4, href: A });
+  });
+});

--- a/packages/docs/test/view/text-box-edit-link-in-place.test.ts
+++ b/packages/docs/test/view/text-box-edit-link-in-place.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initializeTextBox, type TextBoxEditorAPI } from '../../src/view/text-box-editor.js';
+import type { Block } from '../../src/model/types.js';
+
+/**
+ * Regression coverage for issue #494 in the `initializeTextBox` path —
+ * the factory that powers Slides text boxes and Slides table cells.
+ * With a collapsed caret inside an existing hyperlink, `insertLink`
+ * must update that link's href in place instead of inserting the URL
+ * as a brand-new link at the caret.
+ */
+function installCanvasShim(): void {
+  const ctxHandler: ProxyHandler<object> = {
+    get(_t, prop) {
+      if (prop === 'measureText') {
+        return (text: string) => ({
+          width: typeof text === 'string' ? text.length * 6 : 0,
+          actualBoundingBoxAscent: 8,
+          actualBoundingBoxDescent: 2,
+        });
+      }
+      if (prop === 'canvas') return null;
+      if (prop === 'font') return '12px sans-serif';
+      return () => {};
+    },
+    set() {
+      return true;
+    },
+  };
+  const fakeCtx = new Proxy({}, ctxHandler) as unknown as CanvasRenderingContext2D;
+  (HTMLCanvasElement.prototype as unknown as { getContext: (k: string) => unknown }).getContext =
+    (kind: string) => (kind === '2d' ? fakeCtx : null);
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+}
+
+describe('initializeTextBox — edit link in place (#494)', () => {
+  let container: HTMLElement;
+  let canvas: HTMLCanvasElement;
+  let api: TextBoxEditorAPI;
+  let committed: Block[] | null;
+  let origRAF: typeof window.requestAnimationFrame;
+
+  beforeEach(() => {
+    installCanvasShim();
+    origRAF = window.requestAnimationFrame;
+    window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      queueMicrotask(() => cb(performance.now()));
+      return 0;
+    };
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    canvas = document.createElement('canvas');
+    canvas.width = 400;
+    canvas.height = 200;
+    container.appendChild(canvas);
+    committed = null;
+    api = initializeTextBox({
+      container,
+      canvas,
+      blocks: [],
+      contentWidth: 400,
+      contentHeight: 200,
+      onCommit: (blocks) => {
+        committed = blocks;
+      },
+    });
+    api.focus();
+  });
+
+  afterEach(() => {
+    api.detach();
+    document.body.removeChild(container);
+    window.requestAnimationFrame = origRAF;
+  });
+
+  function textarea(): HTMLTextAreaElement {
+    const el = container.querySelector('textarea');
+    if (!el) throw new Error('textarea not mounted');
+    return el;
+  }
+
+  function pressArrowLeft(times: number): void {
+    for (let i = 0; i < times; i++) {
+      textarea().dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true }),
+      );
+    }
+  }
+
+  /** Flush the final onCommit and return the committed blocks. */
+  function commitBlocks(): Block[] {
+    api.detach();
+    if (!committed) throw new Error('onCommit did not fire');
+    return committed;
+  }
+
+  it('caret at the trailing edge of a link + insertLink updates it in place', () => {
+    api.insertLink('https://example.com');
+    api.insertLink('https://example.org');
+
+    const inlines = commitBlocks()[0].inlines;
+    expect(inlines.map((i) => i.text).join('')).toBe('https://example.com');
+    expect(inlines.every((i) => i.style.href === 'https://example.org')).toBe(true);
+  });
+
+  it('caret inside a link + insertLink updates it in place', () => {
+    api.insertLink('https://example.com');
+    pressArrowLeft(3);
+    api.insertLink('https://example.org');
+
+    const inlines = commitBlocks()[0].inlines;
+    expect(inlines.map((i) => i.text).join('')).toBe('https://example.com');
+    expect(inlines.every((i) => i.style.href === 'https://example.org')).toBe(true);
+  });
+
+  it('href residue on a fully-emptied text box falls back to inserting the URL', () => {
+    api.insertLink('https://example.com');
+    for (let i = 0; i < 'https://example.com'.length; i++) {
+      textarea().dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true }),
+      );
+    }
+    // The emptied run keeps its style, so the residue href is still
+    // reported at the caret — but it is not an editable run.
+    expect(api.getLinkAtCursor()).toBe('https://example.com');
+
+    api.insertLink('https://example.org');
+
+    const inlines = commitBlocks()[0].inlines;
+    expect(inlines.map((i) => i.text).join('')).toBe('https://example.org');
+    expect(inlines.every((i) => !i.text || i.style.href === 'https://example.org')).toBe(true);
+  });
+
+  it('removeLink with the caret inside the link still unlinks the whole run', () => {
+    api.insertLink('https://example.com');
+    pressArrowLeft(3);
+    api.removeLink();
+
+    const inlines = commitBlocks()[0].inlines;
+    expect(inlines.map((i) => i.text).join('')).toBe('https://example.com');
+    expect(inlines.every((i) => !i.style.href)).toBe(true);
+  });
+});

--- a/packages/docs/test/view/text-box-edit-link-in-place.test.ts
+++ b/packages/docs/test/view/text-box-edit-link-in-place.test.ts
@@ -125,9 +125,11 @@ describe('initializeTextBox — edit link in place (#494)', () => {
         new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true, cancelable: true }),
       );
     }
-    // The emptied run keeps its style, so the residue href is still
-    // reported at the caret — but it is not an editable run.
-    expect(api.getLinkAtCursor()).toBe('https://example.com');
+    // The emptied run keeps its style, but the residue href is not an
+    // editable run — getLinkAtCursor skips the empty-text inline, matching
+    // findLinkRunAt, so the popover shows "add link" rather than prefilling
+    // an invisible href.
+    expect(api.getLinkAtCursor()).toBeUndefined();
 
     api.insertLink('https://example.org');
 


### PR DESCRIPTION
## Summary

`insertLink` gains a third branch for a collapsed caret inside an
existing link run: instead of inserting the URL as brand-new linked
text, it updates that run's `href` in place. `removeLink`'s
run-boundary walk is extracted into a shared `findLinkRunAt` helper
(`packages/docs/src/view/link-run.ts`), and the fix is applied to both
editors — Docs body (`editor.ts`) and Slides text boxes / table cells
(`text-box-editor.ts`).

## Why

Clicking inside an existing hyperlink and using "Edit link" → Apply
left the original link untouched and inserted duplicate linked text at
the caret, because `insertLink` only handled a non-empty selection and
a bare collapsed caret — there was no branch for a caret inside a link
run. Sharing `removeLink`'s boundary walk keeps the two code paths from
diverging on what counts as "the link at the caret".

## Linked Issues

Fixes #494

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

CI automatically posts a verification summary comment on this PR with
per-lane results for both `verify:self` and `verify:integration`.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable):

## Risk Assessment

- User-facing risk: Low. Only the "Edit link" → Apply path changes;
  selection-based insert and remove-link behavior are untouched. Two
  known edge cases fall back to the previous insert behavior: the
  `href` residue `normalizeInlines` leaves on a fully-emptied
  paragraph, and the boundary between two adjacent different links
  (the earlier run wins, matching what `getLinkAtCursor` shows in the
  popover — the link displayed is the link edited).
- Data/security risk: None. View-layer editing only; no schema, store,
  or URL-handling changes.
- Rollback plan: Revert the PR; no migration or data cleanup needed.

## Notes for Reviewers

- UI changes (screenshots/gifs if applicable): No visual change —
  behavior fix only (existing link's URL now updates in place).
- Follow-up work (if any): The two fallback edge cases above could be
  handled explicitly later if they turn out to matter in practice.
- Implemented with Claude Code assistance (commit co-authored).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Edit link” now updates an existing hyperlink in place when the caret is inside a link run (including at edges), rather than inserting new URL text.
  * Link editing/removal are consistent across the Docs editor and Slides text boxes.
  * Improved accuracy when resolving link boundaries and adjacent linked text.

* **Bug Fixes**
  * Fixed caret targeting and link “href residue” edge cases so adjacent links are not shadowed.
  * Preserved caret position and undo behavior during in-place link changes.

* **Tests**
  * Added/expanded regression and unit coverage for in-place edit, remove, boundary, and empty-text scenarios.

* **Documentation**
  * Added updated Docs task notes for the “edit link” in-place behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->