### PR TITLE
Verify absence claims by hunting a counterexample

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -424,7 +424,12 @@ jobs:
                   // absence claim as an absence claim. Without it a carried
                   // finding defaults to `presence` and gets the wrong procedure
                   // (and the smaller turn budget) on every round after the first.
-                  .map((f) => ({ severity: norm(f.severity), file: trim(f.file, 300), claimType: f.claimType === 'absence' ? 'absence' : undefined, summary: trim(f.summary, 2000), evidence: trim(f.evidence, 2000) }));
+                  // `searchedFor` rides along for the same reason: the original
+                  // lens recorded what it already searched, and without carrying
+                  // it every repeat round tells the verifier to "search from
+                  // scratch", losing the complementary-search value. Advisory —
+                  // never gates (see verifyFinding), so it is safe to carry.
+                  .map((f) => ({ severity: norm(f.severity), file: trim(f.file, 300), claimType: f.claimType === 'absence' ? 'absence' : undefined, searchedFor: Array.isArray(f.searchedFor) ? f.searchedFor.filter((s) => typeof s === 'string' && s.trim()).slice(0, 20).map((s) => trim(s, 300)) : undefined, summary: trim(f.summary, 2000), evidence: trim(f.evidence, 2000) }));
                 // Keep output.text VALID JSON within the 60k limit: NEVER slice the
                 // serialized string (that yields JSON the next round can't parse).
                 // Fields are trimmed above; drop trailing findings until it fits.

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -420,7 +420,11 @@ jobs:
                 let blockers = (Array.isArray(v.findings) ? v.findings : [])
                   .filter((f) => norm(f.severity) === 'critical' || norm(f.severity) === 'major')
                   .filter((f) => f.lane !== 'backlog')
-                  .map((f) => ({ severity: norm(f.severity), file: trim(f.file, 300), summary: trim(f.summary, 2000), evidence: trim(f.evidence, 2000) }));
+                  // `claimType` rides along so the next round verifies an
+                  // absence claim as an absence claim. Without it a carried
+                  // finding defaults to `presence` and gets the wrong procedure
+                  // (and the smaller turn budget) on every round after the first.
+                  .map((f) => ({ severity: norm(f.severity), file: trim(f.file, 300), claimType: f.claimType === 'absence' ? 'absence' : undefined, summary: trim(f.summary, 2000), evidence: trim(f.evidence, 2000) }));
                 // Keep output.text VALID JSON within the 60k limit: NEVER slice the
                 // serialized string (that yields JSON the next round can't parse).
                 // Fields are trimmed above; drop trailing findings until it fits.

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -449,6 +449,30 @@ Components:
   metrics comment reports
   `refutedHighConfidence` and `dropped` separately; the gap between them is the
   count of confident refutations the gate declined to act on.
+  Findings carry a **`claimType`**, because the two shapes are verified in
+  opposite directions. A `presence` claim ("this code is wrong") is refuted by
+  looking it up where the finding says it is. An `absence` claim ("no test covers
+  this", "no validation on this input") is refuted by FINDING ONE
+  COUNTEREXAMPLE — a search whose failure is indistinguishable from the thing
+  genuinely not existing. Running the presence procedure on an absence claim is
+  why a false *"no CI workflow runs these tests"* survived #578: the
+  counterexample was real and three hops away (`.github/workflows/ci.yml` →
+  `pnpm verify:self` → `scripts/verify-self.mjs` → the `agent:tests` lane) and the
+  verifier ran out of turns,
+  so bias-to-keep confirmed it. Absence claims now get a counterexample-hunting
+  prompt, the `searchedFor` list the lens recorded (so it searches where the lens
+  did *not*), a `counterexample` refutation ground, and a larger turn ceiling
+  (`VERIFIER_MAX_TURNS`, 20 vs 8). A third verdict, **`unresolved`**, exists so
+  "I searched and could not disprove this" stops being reported as "confirmed" —
+  it does **not** demote: `isDroppingVerdict` still requires an explicit
+  `refuted`, so an unsettled finding gates exactly as a confirmed one does. That
+  is deliberate. Absence claims are the entire output of test-adequacy and much
+  of security and design-fit, so routing unsettleable ones off the gate would
+  repeat the mistake the novelty gate had to correct. The finding is marked
+  *"verifier could not settle this"* in the summary and counted in
+  `verifier.absenceRaised`/`absenceRefuted`/`unresolved`, so a high `unresolved`
+  against a low `absenceRefuted` is visible as absence claims riding through
+  unchecked rather than being silently discounted.
   A **novelty gate** (`scripts/agent/novelty.mjs`) then answers a question the
   verifier structurally cannot: *did this change PUT this line here, carrying
   code that already existed?* The verifier's independence means it never sees the

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| absence claims (2026-07-29) | [20260729-absence-claims-todo.md](./active/20260729-absence-claims-todo.md) | - |
 | incremental review (2026-07-29) | [20260729-incremental-review-todo.md](./active/20260729-incremental-review-todo.md) | [20260729-incremental-review-lessons.md](./active/20260729-incremental-review-lessons.md) |
 | review novelty gate (2026-07-29) | [20260729-review-novelty-gate-todo.md](./active/20260729-review-novelty-gate-todo.md) | - |
 | blast radius lens (2026-07-28) | [20260728-blast-radius-lens-todo.md](./active/20260728-blast-radius-lens-todo.md) | [20260728-blast-radius-lens-lessons.md](./active/20260728-blast-radius-lens-lessons.md) |
@@ -73,4 +74,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 374
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: incremental review (2026-07-29)
+Latest active task: absence claims (2026-07-29)

--- a/docs/tasks/active/20260729-absence-claims-todo.md
+++ b/docs/tasks/active/20260729-absence-claims-todo.md
@@ -1,0 +1,99 @@
+# Absence claims: verify "there is no X" by hunting a counterexample
+
+Split findings into `presence` and `absence` claims and verify them in opposite
+directions, because refuting the second means FINDING something rather than
+failing to find it.
+
+## The problem, from #578
+
+The disposition comment's second bucket was findings that simply "don't hold".
+The clearest was **"No CI workflow runs `scripts/agent/*.test.mjs`"** — false.
+`ci.yml:41` runs `pnpm verify:self`, whose first lane is `agent:tests`
+(`verify-self.mjs:16`). Those tests gate every PR.
+
+The verifier confirmed it anyway, and the reason is structural rather than a
+prompt weakness. To refute *"there is no X"* it must **find an X**: chase
+`ci.yml` → `pnpm verify:self` → `verify-self.mjs` → the `agent:tests` lane, then
+read each to confirm. That is three hops plus reads against a ceiling of 8 turns.
+It ran out, could not reach a grounded refutation, and the bias-to-keep rule did
+the rest.
+
+The asymmetry is the whole problem:
+
+|  | refuted by | cost |
+|---|---|---|
+| presence — "this code is wrong" | showing the code is not as described | a lookup at a named location |
+| absence — "there is no X" | finding one instance of X | a search across the repository |
+
+**Failing to find X is indistinguishable from X not existing.** So the same
+bias-to-keep rule that protects real findings rubber-stamps false absence claims.
+
+## What this PR does
+
+- [x] `FINDING` gains `claimType` (`presence`/`absence`, **required** so a lens
+      must decide rather than default by omission) and `searchedFor` — what the
+      lens actually searched before concluding something is missing.
+- [x] Guidance goes in `LENS_CLOSING_INSTRUCTION`, the shared prompt slot, not
+      copied into five rubric files. A test asserts no rubric carries its own copy.
+- [x] `verifyFinding` branches its prompt on `claimType`. An absence claim is
+      told the job is to find ONE counterexample, that the thing may live under
+      another name or be reached indirectly ("two or three hops from where you
+      started"), and exactly what the lens already searched — so it looks where
+      the lens did **not** rather than repeating a search that came up empty.
+- [x] New `counterexample` refutation ground. The existing grounds all describe
+      ways a PRESENT thing fails to be a defect, which is the wrong shape.
+- [x] `VERIFIER_MAX_TURNS` becomes `{presence: 8, absence: 20}`. Absence claims
+      are the minority, so the extra ceiling is bounded in practice.
+- [x] New `unresolved` verdict, plus `absenceRaised`/`absenceRefuted`/
+      `unresolved` counters through `verifierTally` → `lensStats` →
+      `metrics.mjs`, and an *"(verifier could not settle this)"* marker in the
+      rendered summary.
+- [x] `claimType` persisted into check `output.text`, so round N+1 verifies a
+      carried-forward absence claim as an absence claim rather than defaulting it
+      to `presence` and giving it the smaller budget.
+- [x] `buildVerifierPrompt` extracted and exported so both branches are checked
+      by RENDERING, following the precedent `buildLensPrompt` set. 223 tests green.
+
+## `unresolved` does NOT demote — and that is the point
+
+The original plan had `unresolved` route to a non-gating lane. That was rejected
+after PR #583's review, which caught the novelty gate demoting an entire
+legitimate class of findings.
+
+The same trap is here, and it is bigger. Absence claims are not a noise category:
+*"no test covers this"* is **test-adequacy's entire output contract**, *"no
+validation on this input"* is much of security, and *"no design doc records this
+module"* was a **correct** #578 finding. Routing unsettleable absence claims off
+the merge gate would silently disable large parts of three lenses.
+
+So `unresolved` keeps the finding blocking, exactly as `confirmed` does.
+`isDroppingVerdict` is untouched and still requires an explicit `refuted`. The
+value is honesty and measurement: "I searched and could not disprove this" and "I
+checked and it is real" used to be the same word, and collapsing them hid how
+often the verifier was guessing.
+
+**The mechanism that actually fixes #578's case is refutation, not demotion.**
+The counterexample there is real and findable; with 20 turns, a hunt-shaped
+prompt and the lens's `searchedFor` to search around, it should come back
+`refuted` on the `counterexample` ground — dropped by the existing rule, with
+cited evidence, no new demotion path required.
+
+## What to watch
+
+`absenceRaised` vs `absenceRefuted` vs `unresolved` in the metrics comment.
+
+- High `unresolved`, low `absenceRefuted` → absence claims are riding through
+  unchecked. Either the turn ceiling is still too low or the lenses are raising
+  claims they have not searched for; `searchedFor` being empty distinguishes them.
+- High `absenceRefuted` → the mechanism is working and #578's class is being
+  caught at the point it should be.
+
+## Deliberately not in this PR
+
+- **Wrong mechanism, true kernel.** A binary confirmed/refuted verdict has
+  nowhere to put "the concern is real but the stated cause is wrong", so such a
+  finding rides through at full severity (#578's "Bash/Write stay available").
+  Needs a `confirmed-corrected` verdict that may only downgrade.
+- **Duplicates.** `dedupeFindings` keys on `file + lowercased summary` and the
+  verifier runs per-finding in isolation, so the same bug in different words
+  survives twice. Needs a clustering pass over the whole surviving set.

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -179,6 +179,10 @@ export function aggregatePanelStats(entries) {
   // drop count WAS `refutedHighConfidence`, so a mixed-history PR shows the
   // grounded drops it can actually account for rather than an inflated total.
   let sentToVerifier = 0, refuted = 0, refutedHighConfidence = 0, dropped = 0;
+  // Absence claims ("there is no X"), which are refuted by finding ONE
+  // counterexample rather than by failing to find the code. Absent from entries
+  // written before the split existed, which coerce to 0.
+  let absenceRaised = 0, absenceRefuted = 0, unresolved = 0;
   // Novelty gate. Absent from entries written before it existed, which coerce to
   // 0 — an all-zero row reads as "the gate never fired", the honest reading for
   // both a pre-instrumentation round and a round where it ran inert.
@@ -201,13 +205,16 @@ export function aggregatePanelStats(entries) {
     refuted += Number(e.verifier && e.verifier.refuted) || 0;
     refutedHighConfidence += Number(e.verifier && e.verifier.refutedHighConfidence) || 0;
     dropped += Number(e.verifier && e.verifier.dropped) || 0;
+    absenceRaised += Number(e.verifier && e.verifier.absenceRaised) || 0;
+    absenceRefuted += Number(e.verifier && e.verifier.absenceRefuted) || 0;
+    unresolved += Number(e.verifier && e.verifier.unresolved) || 0;
     laneBlocking += Number(e.lanes && e.lanes.blocking) || 0;
     laneBacklog += Number(e.lanes && e.lanes.backlog) || 0;
     laneUnknownOrigin += Number(e.lanes && e.lanes.unknownOrigin) || 0;
   }
   return {
     agreementCounts, raised, raisedConfidence, kept,
-    verifier: { sentToVerifier, refuted, refutedHighConfidence, dropped },
+    verifier: { sentToVerifier, refuted, refutedHighConfidence, dropped, absenceRaised, absenceRefuted, unresolved },
     lanes: { blocking: laneBlocking, backlog: laneBacklog, unknownOrigin: laneUnknownOrigin },
   };
 }
@@ -395,6 +402,11 @@ export function renderSummary({ agg, panelAgg, panelStats, flips, scope }) {
       // the finding when it names a ground and cites what it read. The GAP is
       // the signal — it counts refutations the gate declined to act on.
       `- Refuted: ${v.refuted || 0} (${v.refutedHighConfidence || 0} high-confidence, ${v.dropped || 0} dropped)`,
+      // Absence claims are refuted by finding ONE counterexample, so a low
+      // refute rate here is not reassurance — it is the shape of a claim nobody
+      // could settle riding through as though it had been checked. `unresolved`
+      // is that case counted honestly; it still blocks.
+      `- Absence claims: ${v.absenceRaised || 0} raised, ${v.absenceRefuted || 0} refuted by counterexample, ${v.unresolved || 0} unresolved (still blocking)`,
       // All four severities shown (critical/major lead as the blocking ones)
       // so the raw counts reconcile with the weighted scalar below, which
       // weights every severity — mirrors the "Findings raised" pair above.

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -116,7 +116,12 @@ test("aggregatePanelStats: rolls up lens/round entries — agreement, severity-w
   assert.deepEqual(rolled.kept, { critical: 1, major: 1, minor: 2, nit: 1 });
   // a ledger entry written before `dropped` existed contributes 0, not NaN — the
   // ledger is append-only, so a mid-PR upgrade always produces this mixed shape.
-  assert.deepEqual(rolled.verifier, { sentToVerifier: 3, refuted: 1, refutedHighConfidence: 1, dropped: 1 });
+  // The absence/unresolved fields tell the same append-only story: entries
+  // written before the claim-type split contribute 0, not NaN.
+  assert.deepEqual(rolled.verifier, {
+    sentToVerifier: 3, refuted: 1, refutedHighConfidence: 1, dropped: 1,
+    absenceRaised: 0, absenceRefuted: 0, unresolved: 0,
+  });
   // Same append-only story for confidence: the first entry predates the field
   // entirely, so it contributes nothing — NOT four `unknown`s. Rounds recorded
   // before the split are absent data, not findings a lens declined to rate, and
@@ -124,7 +129,10 @@ test("aggregatePanelStats: rolls up lens/round entries — agreement, severity-w
   // unreadable on exactly the PRs that straddle the change.
   assert.deepEqual(rolled.raisedConfidence, { high: 1, medium: 1, low: 1, unknown: 0 });
   // tolerant of junk/empty input — never throws, never blocks recording
-  assert.deepEqual(aggregatePanelStats([]).verifier, { sentToVerifier: 0, refuted: 0, refutedHighConfidence: 0, dropped: 0 });
+  assert.deepEqual(aggregatePanelStats([]).verifier, {
+    sentToVerifier: 0, refuted: 0, refutedHighConfidence: 0, dropped: 0,
+    absenceRaised: 0, absenceRefuted: 0, unresolved: 0,
+  });
   assert.deepEqual(aggregatePanelStats([]).raisedConfidence, { high: 0, medium: 0, low: 0, unknown: 0 });
   assert.deepEqual(aggregatePanelStats([{ raisedConfidence: "junk" }]).raisedConfidence, { high: 0, medium: 0, low: 0, unknown: 0 });
   assert.deepEqual(aggregatePanelStats(null).agreementCounts, { identical: 0, partial: 0, disjoint: 0, single: 0 });

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -69,8 +69,23 @@ const FINDING = {
     line: { type: "integer" },
     summary: { type: "string" },
     evidence: { type: "string" },
+    // Is the defect something PRESENT that should not be, or something ABSENT
+    // that should be there? The two are verified in opposite directions, and
+    // conflating them is why a false "no CI workflow runs these tests" survived
+    // #578: refuting a presence claim means failing to find the code, but
+    // refuting an ABSENCE claim means FINDING the thing — a search whose failure
+    // is indistinguishable from the thing not existing. The verifier is told
+    // which job it has; without this it always did the first one.
+    // Required, so a lens must actually decide rather than defaulting by
+    // omission — the same reason `confidence` is required.
+    claimType: { type: "string", enum: ["presence", "absence"] },
+    // For an absence claim ONLY: what you actually searched before concluding
+    // the thing is missing. Handed to the verifier so it searches DIFFERENTLY
+    // rather than repeating a search that already came up empty. Advisory —
+    // it never affects gating (see the note in verifyFinding).
+    searchedFor: { type: "array", items: { type: "string" } },
   },
-  required: ["severity", "confidence", "summary"],
+  required: ["severity", "confidence", "summary", "claimType"],
 };
 const LENS_SCHEMA = {
   type: "object",
@@ -89,12 +104,23 @@ const LENS_SCHEMA = {
 const VERIFIER_SCHEMA = {
   type: "object",
   properties: {
-    verdict: { type: "string", enum: ["confirmed", "refuted"] },
+    // `unresolved` exists so "I could not settle this" stops being reported as
+    // "confirmed". It does NOT drop the finding — `isDroppingVerdict` still
+    // requires an explicit `refuted`, so an unresolved verification keeps the
+    // finding on the gate exactly as a confirmation would. The value is
+    // measurement: an absence claim nobody can settle is a different animal from
+    // one a verifier actively confirmed, and collapsing them hides how often the
+    // verifier is guessing.
+    verdict: { type: "string", enum: ["confirmed", "refuted", "unresolved"] },
     confidence: { type: "string", enum: ["high", "low"] },
     reason: { type: "string" },
     refutationGround: {
       type: "string",
-      enum: ["not-present", "already-guarded", "out-of-scope", "pre-existing", "none"],
+      // `counterexample` is the ground for refuting an ABSENCE claim: the
+      // finding says "there is no X", and the verifier found an X. The other
+      // grounds all describe ways a PRESENT thing fails to be a defect, which is
+      // the wrong shape for that job.
+      enum: ["not-present", "already-guarded", "out-of-scope", "pre-existing", "counterexample", "none"],
     },
     groundedIn: { type: "array", items: { type: "string" } },
   },
@@ -249,9 +275,17 @@ export function routeFinding(finding, { verdict = null, novelty = null } = {}, o
 export function annotateFindings(findings, verdictsByIndex, noveltiesByIndex, opts) {
   return findings.map((f, i) => {
     if (!BLOCKING.has(normalizeSeverity(f.severity))) return f; // only blockers reach the gate
+    const verdict = verdictsByIndex?.[i] ?? null;
     const novelty = noveltiesByIndex?.[i] ?? null;
-    const lane = routeFinding(f, { verdict: verdictsByIndex?.[i] ?? null, novelty }, opts);
-    return novelty ? { ...f, lane, novelty } : { ...f, lane };
+    const lane = routeFinding(f, { verdict, novelty }, opts);
+    const out = { ...f, lane };
+    if (novelty) out.novelty = novelty;
+    // Carried through to reporting ONLY. `unresolved` does not change the lane —
+    // an unsettled finding gates exactly like a confirmed one — but a reader
+    // deciding whether to trust it should be told the verifier could not settle
+    // it rather than reading silence as endorsement.
+    if (verdict?.verdict === "unresolved") out.unsettled = true;
+    return out;
   });
 }
 
@@ -602,6 +636,17 @@ export const LENS_CLOSING_INSTRUCTION = [
   "change RELOCATED rather than wrote. A finding on code the change did not add",
   "is never set aside for that reason, so cite the true location; omitting it is",
   "safe and only costs precision.",
+  "Set `claimType`. `presence` = something is THERE that should not be (a wrong",
+  "condition, a missing-guard crash, an injectable path). `absence` = something",
+  "is NOT there that should be (no test covers this, no validation on this input,",
+  "no design doc records this module). Most findings are `presence`; say so",
+  "rather than guessing.",
+  "If you raise an `absence` finding, fill `searchedFor` with the searches you",
+  "actually ran before concluding the thing is missing — the greps, globs and",
+  "files you opened. Proving something absent needs an exhaustive search, so the",
+  "verifier has to look where you did NOT; telling it what you already tried is",
+  "what makes its search complementary instead of a repeat. This never changes",
+  "whether your finding blocks — it only makes a wrong one easier to disprove.",
 ].join("\n");
 
 /**
@@ -621,19 +666,30 @@ export const LENS_CLOSING_INSTRUCTION = [
  */
 export function verifierTally(findings, verdicts, opts) {
   let sentToVerifier = 0, refuted = 0, refutedHighConfidence = 0, dropped = 0;
+  // Absence claims, and how often one could not be settled either way. Both
+  // outcomes KEEP the finding, so neither number changes the gate — they exist
+  // because "the verifier confirmed this" and "the verifier could not disprove
+  // it" are very different statements that used to be the same word. A high
+  // `unresolved` against a low `absenceRefuted` is the signal that absence
+  // claims are riding through unchecked, which is the #578 failure.
+  let absenceRaised = 0, absenceRefuted = 0, unresolved = 0;
   (Array.isArray(findings) ? findings : []).forEach((f, i) => {
     if (!BLOCKING.has(normalizeSeverity(f.severity))) return;
     sentToVerifier++;
+    const isAbsence = claimTypeOf(f) === "absence";
+    if (isAbsence) absenceRaised++;
     const v = verdicts[i];
     if (v && v.verdict === "refuted") {
       refuted++;
       if (v.confidence === "high") refutedHighConfidence++;
+      if (isAbsence) absenceRefuted++;
     }
-    // Same `opts` as applyVerifications, so `dropped` counts what was actually
-    // dropped rather than what would have been under a different trust rule.
+    if (v && v.verdict === "unresolved") unresolved++;
+    // Same `opts` as the router, so `dropped` counts what was actually dropped
+    // rather than what would have been under a different trust rule.
     if (isDroppingVerdict(v, opts)) dropped++;
   });
-  return { sentToVerifier, refuted, refutedHighConfidence, dropped };
+  return { sentToVerifier, refuted, refutedHighConfidence, dropped, absenceRaised, absenceRefuted, unresolved };
 }
 
 // `askStructured`, `classifyResult` and `withRetry` moved to ask.mjs, which owns
@@ -697,13 +753,34 @@ async function runLens(lens, { rubric, diff, issue, repo, sessionLog, scopeNote 
   });
 }
 
-// Turn ceiling for one verification. The verifier now establishes facts from the
+// Turn ceiling for one verification. The verifier establishes facts from the
 // repository instead of being handed a diff, so it needs tool calls — but it is
 // judging ONE finding, and an unbounded budget multiplies across every blocking
 // finding in every round.
-const VERIFIER_MAX_TURNS = 8;
+//
+// ABSENCE claims get more. Refuting "there is no X" means FINDING an X, which is
+// a search across the repository, while refuting a presence claim is a lookup at
+// a location the finding already names. On #578 the false "no CI workflow runs
+// these tests" survived precisely here: the counterexample is real and
+// reachable — ci.yml -> `pnpm verify:self` -> verify-self.mjs -> the agent:tests
+// lane — but that is three hops plus the reads to confirm each, and the verifier
+// ran out of turns, so bias-to-keep confirmed a false claim. Absence claims are
+// the minority, so the extra ceiling is bounded in practice.
+export const VERIFIER_MAX_TURNS = { presence: 8, absence: 20 };
 
-async function verifyFinding(finding, { rubric, repo, model, sessionLog, changedContext }) {
+/** `presence` unless the finding explicitly says otherwise. */
+export function claimTypeOf(finding) {
+  return finding?.claimType === "absence" ? "absence" : "presence";
+}
+
+/**
+ * Assemble one verifier prompt. Exported and pure for the same reason
+ * `buildLensPrompt` is: the claim-type branch is a behaviour claim about the
+ * PROMPT, and a regex over this file cannot observe it. Rendering both branches
+ * is the only way to check that an absence claim is actually told to hunt for a
+ * counterexample rather than to look the code up. Nothing else imports it.
+ */
+export function buildVerifierPrompt(finding, { rubric, changedContext }) {
   // INDEPENDENCE — the point of this function. The verifier is deliberately NOT
   // given the diff. The lens that raised this finding reasoned from the diff, so
   // a verifier reading that same diff inherits its blind spots: a misread line
@@ -717,16 +794,48 @@ async function verifyFinding(finding, { rubric, repo, model, sessionLog, changed
   // could disagree; then the prompt would offer a ground the gate silently
   // refuses, or worse, the reverse.
   const { authoritative, listed, total } = changedContext ?? changedFileContext([]);
+  const claimType = claimTypeOf(finding);
+  const searched = Array.isArray(finding.searchedFor)
+    ? finding.searchedFor.filter((s) => typeof s === "string" && s.trim()).slice(0, 20)
+    : [];
   const prompt = [
     "Another reviewer raised the finding below. Decide whether it is genuinely a",
     "blocking defect in THIS repository, which is your working directory.",
     "",
+    // The two claim shapes are verified in OPPOSITE directions, and running the
+    // presence procedure on an absence claim is what let a false one through on
+    // #578. Say which job this is, first, before any of the how-to.
+    claimType === "absence"
+      ? [
+          "THIS IS AN ABSENCE CLAIM: the reviewer says something is MISSING.",
+          "You refute it by FINDING ONE COUNTEREXAMPLE — a single instance of the",
+          "thing it says does not exist is enough, and that is the whole job.",
+          "",
+          "Search hard and search WIDE before concluding it is really missing.",
+          "The thing may exist under another name, in another directory, or be",
+          "reached indirectly: a script invoked by another script, a config that",
+          "includes a file, a helper called by the thing you expected to find it",
+          "in. Follow those chains — the counterexample is often two or three hops",
+          "from where you started, not in the obvious place.",
+          searched.length
+            ? `The reviewer already searched the following and came up empty, so look\nELSEWHERE rather than repeating these:\n${searched.map((s) => `  - ${s}`).join("\n")}`
+            : "The reviewer did not record what it searched, so assume nothing was\nchecked thoroughly and search from scratch.",
+        ].join("\n")
+      : [
+          "THIS IS A PRESENCE CLAIM: the reviewer says something IS there and is",
+          "wrong. You refute it by showing the code is not as described, or is",
+          "unreachable, or is out of scope for this lens.",
+        ].join("\n"),
+    "",
     "How to work:",
     "- Locate the code yourself with Grep/Glob/Read. Do NOT take the finding's",
     "  quoted evidence at face value — checking it IS the job.",
-    "- Code not present as described        -> refutationGround `not-present`",
-    "- A guard/check/caller elsewhere already makes it unreachable",
-    "                                       -> `already-guarded` (cite the guard)",
+    ...(claimType === "absence"
+      ? ["- Found even ONE instance of the thing said to be missing",
+         "                                       -> `counterexample` (cite it)"]
+      : ["- Code not present as described        -> refutationGround `not-present`",
+         "- A guard/check/caller elsewhere already makes it unreachable",
+         "                                       -> `already-guarded` (cite the guard)"]),
     "- Real, but not blocking under this lens's rubric -> `out-of-scope`",
     authoritative
       ? "- Lives in a file this change did not touch -> `pre-existing`. The changed-file\n  list below is authoritative for what this PR modified."
@@ -735,8 +844,12 @@ async function verifyFinding(finding, { rubric, repo, model, sessionLog, changed
     "Refuting DROPS the finding from the merge gate, so the bar is high:",
     '- Return {verdict:"refuted", confidence:"high"} ONLY with a named',
     "  `refutationGround` AND `groundedIn` file:line locations you actually read.",
-    '- Unsure for ANY reason -> {verdict:"confirmed"}, refutationGround "none".',
-    "  Uncertainty keeps the finding. That is the correct outcome, not a failure.",
+    // The honest third answer. Without it, "I searched and found nothing" and "I
+    // checked and it is real" both come back as `confirmed`, which is why an
+    // unsettleable claim was indistinguishable from a verified one.
+    claimType === "absence"
+      ? '- Searched thoroughly and still found no counterexample, but cannot be sure\n  you looked everywhere -> {verdict:"unresolved"}, refutationGround "none".\n  This KEEPS the finding on the gate, exactly like `confirmed` — it only\n  records that you could not settle it. Prefer it over a confirmation you\n  do not actually have.'
+      : '- Unsure for ANY reason -> {verdict:"confirmed"}, refutationGround "none".\n  Uncertainty keeps the finding. That is the correct outcome, not a failure.',
     "",
     "Judge 'blocking' strictly by this lens's rubric:",
     "",
@@ -763,18 +876,32 @@ async function verifyFinding(finding, { rubric, repo, model, sessionLog, changed
   ]
     .filter((l) => l !== null) // `""` entries are deliberate blank lines — keep them
     .join("\n");
+  return prompt;
+}
+
+async function verifyFinding(finding, { rubric, repo, model, sessionLog, changedContext }) {
+  const claimType = claimTypeOf(finding);
   return askStructured({
     systemPrompt:
       "You are an independent verifier. You did not write this code and did not raise this " +
       "finding. Establish the facts from the repository yourself rather than trusting the " +
       "reviewer's account of them. Refuting removes a finding from the merge gate, so refute " +
-      "only with a named ground and cited locations; when in doubt, confirm.",
-    prompt,
+      "only with a named ground and cited locations. " +
+      (claimType === "absence"
+        // "Confirm when in doubt" is wrong for an absence claim: doubt there
+        // means "I did not find it", which is exactly what the claim asserts, so
+        // confirming on doubt rubber-stamps it. `unresolved` keeps the finding
+        // just the same but says what actually happened.
+        ? "This is an absence claim: one counterexample refutes it. If you cannot find one " +
+          "but cannot be confident you looked everywhere, answer `unresolved` rather than " +
+          "`confirmed` — both keep the finding, only one is honest."
+        : "When in doubt, confirm."),
+    prompt: buildVerifierPrompt(finding, { rubric, changedContext }),
     model,
     repo,
     schema: VERIFIER_SCHEMA,
     sessionLog,
-    maxTurns: VERIFIER_MAX_TURNS,
+    maxTurns: VERIFIER_MAX_TURNS[claimType],
     allowedTools: REVIEW_TOOLS,
     label: "review",
   });
@@ -1010,6 +1137,9 @@ async function main() {
         refuted: freshTally.refuted + priorTally.refuted,
         refutedHighConfidence: freshTally.refutedHighConfidence + priorTally.refutedHighConfidence,
         dropped: freshTally.dropped + priorTally.dropped,
+        absenceRaised: freshTally.absenceRaised + priorTally.absenceRaised,
+        absenceRefuted: freshTally.absenceRefuted + priorTally.absenceRefuted,
+        unresolved: freshTally.unresolved + priorTally.unresolved,
       },
       // GATING findings only. `metrics.mjs::detectFlips` reads `kept` as "this
       // lens blocked this round" and compares it against the next round, so

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -135,6 +135,20 @@ const VERIFIER_SCHEMA = {
 // silently reject a legal ground (or accept a removed one).
 const REFUTATION_GROUNDS = new Set(VERIFIER_SCHEMA.properties.refutationGround.enum);
 
+// Which refutation grounds may DROP a finding of each claim type. The prompt
+// only *advises* this shape (buildVerifierPrompt offers `counterexample` to
+// absence claims and `not-present`/`already-guarded` to presence claims;
+// `out-of-scope` and `pre-existing` are offered to both) — `isDroppingVerdict`
+// enforces it when the claim type is known, so a model that emits the wrong
+// shape (e.g. `not-present` for an absence claim, or `counterexample` for a
+// presence claim) can no longer drop the finding. Catching that
+// instruction-following failure is precisely why the independent verifier
+// exists. `none` is never a dropping ground and is intentionally absent.
+const DROP_GROUNDS_BY_CLAIM = {
+  absence: new Set(["counterexample", "out-of-scope", "pre-existing"]),
+  presence: new Set(["not-present", "already-guarded", "out-of-scope", "pre-existing"]),
+};
+
 // --- pure helpers (exported for tests; no SDK dependency) -------------------
 
 /** Minimal glob→RegExp: `**` = any, `*` = non-slash run, `?` = one non-slash. */
@@ -247,7 +261,7 @@ const COUNTED_LANES = new Set(["blocking", "backlog"]);
  * here can lose a finding that the current gate would have kept.
  */
 export function routeFinding(finding, { verdict = null, novelty = null } = {}, opts) {
-  if (isDroppingVerdict(verdict, opts)) return "discarded";
+  if (isDroppingVerdict(verdict, { ...opts, claimType: claimTypeOf(finding) })) return "discarded";
   // ONLY `relocated` — a line this change added, carrying code that already
   // existed. Notably NOT `pre-existing`: a finding about code the change did not
   // touch is what the blast-radius lens is FOR (its rubric orders it to cite the
@@ -344,7 +358,7 @@ export function keepUnrefuted(annotated) {
  * confidence, a null (the verifier errored), an unknown ground, or a
  * `groundedIn` that cites no location.
  */
-export function isDroppingVerdict(v, { allowPreExisting = false } = {}) {
+export function isDroppingVerdict(v, { allowPreExisting = false, claimType = null } = {}) {
   return (
     !!v &&
     v.verdict === "refuted" &&
@@ -353,6 +367,12 @@ export function isDroppingVerdict(v, { allowPreExisting = false } = {}) {
     REFUTATION_GROUNDS.has(v.refutationGround) &&
     v.refutationGround !== "none" &&
     (v.refutationGround !== "pre-existing" || allowPreExisting) &&
+    // The ground must fit the claim's shape when the claim type is known. Omitted
+    // (null) preserves the prior any-ground behaviour for callers without the
+    // finding; the gate paths (routeFinding, verifierTally) always pass it. An
+    // unrecognized claimType matches no set and therefore KEEPS the finding — the
+    // conservative direction for a drop decision.
+    (claimType == null || DROP_GROUNDS_BY_CLAIM[claimType]?.has(v.refutationGround) === true) &&
     Array.isArray(v.groundedIn) &&
     v.groundedIn.some((s) => typeof s === "string" && CITATION.test(s))
   );
@@ -682,12 +702,17 @@ export function verifierTally(findings, verdicts, opts) {
     if (v && v.verdict === "refuted") {
       refuted++;
       if (v.confidence === "high") refutedHighConfidence++;
-      if (isAbsence) absenceRefuted++;
+      // ONLY counterexample-grounded refutations — the metric reports "refuted
+      // by counterexample" (metrics.mjs) and the design doc reads a low
+      // absenceRefuted as "absence claims riding through unchecked". An absence
+      // claim demoted via `out-of-scope`/`pre-existing` (both also offered for
+      // absence claims) would otherwise inflate it and mask that #578 signal.
+      if (isAbsence && v.refutationGround === "counterexample") absenceRefuted++;
     }
     if (v && v.verdict === "unresolved") unresolved++;
-    // Same `opts` as the router, so `dropped` counts what was actually dropped
-    // rather than what would have been under a different trust rule.
-    if (isDroppingVerdict(v, opts)) dropped++;
+    // Same `opts` (and claim type) as the router, so `dropped` counts what was
+    // actually dropped rather than what would have been under a different rule.
+    if (isDroppingVerdict(v, { ...opts, claimType: claimTypeOf(f) })) dropped++;
   });
   return { sentToVerifier, refuted, refutedHighConfidence, dropped, absenceRaised, absenceRefuted, unresolved };
 }

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -1014,6 +1014,36 @@ test("`counterexample` is a droppable ground for a refuted absence claim", () =>
   );
 });
 
+test("a refutation ground must match the claim's shape to drop", () => {
+  const cited = (ground) => ({
+    verdict: "refuted", confidence: "high", reason: "r",
+    refutationGround: ground, groundedIn: ["a.mjs:1"],
+  });
+  // Wrong shape: `not-present`/`already-guarded` describe a PRESENT thing that
+  // fails to be a defect — nonsense for an absence claim, so they must NOT drop.
+  assert.equal(isDroppingVerdict(cited("not-present"), { claimType: "absence" }), false);
+  assert.equal(isDroppingVerdict(cited("already-guarded"), { claimType: "absence" }), false);
+  // …and `counterexample` (the absence-refutation ground) must not drop a
+  // presence claim either.
+  assert.equal(isDroppingVerdict(cited("counterexample"), { claimType: "presence" }), false);
+  // Right shape still drops.
+  assert.equal(isDroppingVerdict(cited("counterexample"), { claimType: "absence" }), true);
+  assert.equal(isDroppingVerdict(cited("not-present"), { claimType: "presence" }), true);
+  // Universal grounds drop under either claim type.
+  assert.equal(isDroppingVerdict(cited("out-of-scope"), { claimType: "absence" }), true);
+  // Omitted claimType preserves the prior any-ground behaviour.
+  assert.equal(isDroppingVerdict(cited("counterexample")), true);
+  // routeFinding enforces it at the gate: a mismatched ground KEEPS the finding.
+  assert.equal(
+    routeFinding({ severity: "major", claimType: "absence" }, { verdict: cited("not-present") }),
+    "blocking",
+  );
+  assert.equal(
+    routeFinding({ severity: "major", claimType: "absence" }, { verdict: cited("counterexample") }),
+    "discarded",
+  );
+});
+
 test("annotateFindings marks an unsettled finding without changing its lane", () => {
   const out = annotateFindings(
     [{ severity: "critical", summary: "no test covers X", claimType: "absence" }],
@@ -1045,6 +1075,25 @@ test("verifierTally counts absence claims and unresolved outcomes separately", (
   assert.equal(t.absenceRefuted, 1);
   assert.equal(t.unresolved, 1);
   assert.equal(t.dropped, 1);
+});
+
+test("absenceRefuted counts ONLY counterexample-grounded refutations", () => {
+  // metrics.mjs prints this as "refuted by counterexample" and the design doc
+  // reads a low value as "absence claims riding through unchecked". An absence
+  // claim demoted via out-of-scope/pre-existing (both valid absence grounds)
+  // must NOT inflate it, or it masks exactly that #578 signal.
+  const findings = [
+    { severity: "major", claimType: "absence", summary: "no X" },
+    { severity: "major", claimType: "absence", summary: "no Y" },
+  ];
+  const verdicts = [
+    { verdict: "refuted", confidence: "high", refutationGround: "out-of-scope", groundedIn: ["a.mjs:1"] },
+    { verdict: "refuted", confidence: "high", refutationGround: "counterexample", groundedIn: ["b.mjs:2"] },
+  ];
+  const t = verifierTally(findings, verdicts, {});
+  assert.equal(t.refuted, 2); // both are refutations
+  assert.equal(t.absenceRefuted, 1); // …but only the counterexample one counts here
+  assert.equal(t.dropped, 2); // out-of-scope still drops the finding
 });
 
 test("the lens prompt explains both claim shapes, in ONE place", () => {

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -27,6 +27,9 @@ import {
   withRetry,
   buildLensPrompt,
   resolveReviewScope,
+  claimTypeOf,
+  VERIFIER_MAX_TURNS,
+  buildVerifierPrompt,
 } from "./review-panel.mjs";
 import { classify, normalizeSeverity } from "./severity.mjs";
 
@@ -533,23 +536,27 @@ test("verifierTally: only blocking findings are sent; refuted vs high-confidence
   const verdicts = [{ verdict: "refuted", confidence: "high" }, { verdict: "refuted", confidence: "low" }, null];
   // the high-confidence refute is UNGROUNDED, so it is counted but not dropped —
   // this gap is the whole point of reporting both numbers.
-  assert.deepEqual(verifierTally(findings, verdicts), { sentToVerifier: 2, refuted: 2, refutedHighConfidence: 1, dropped: 0 });
+  assert.deepEqual(verifierTally(findings, verdicts), { sentToVerifier: 2, refuted: 2, refutedHighConfidence: 1, dropped: 0, absenceRaised: 0, absenceRefuted: 0, unresolved: 0 });
   // the same shape WITH a ground and a citation does drop
   assert.deepEqual(
     verifierTally(findings, [GROUNDED_REFUTE, { verdict: "refuted", confidence: "low" }, null]),
-    { sentToVerifier: 2, refuted: 2, refutedHighConfidence: 1, dropped: 1 },
+    { sentToVerifier: 2, refuted: 2, refutedHighConfidence: 1, dropped: 1, absenceRaised: 0, absenceRefuted: 0, unresolved: 0 },
   );
   // confirmed / null verdicts: sent but not refuted
   assert.deepEqual(
     verifierTally(findings, [{ verdict: "confirmed", confidence: "high" }, null, null]),
-    { sentToVerifier: 2, refuted: 0, refutedHighConfidence: 0, dropped: 0 },
+    { sentToVerifier: 2, refuted: 0, refutedHighConfidence: 0, dropped: 0, absenceRaised: 0, absenceRefuted: 0, unresolved: 0 },
   );
-  assert.deepEqual(verifierTally([], []), { sentToVerifier: 0, refuted: 0, refutedHighConfidence: 0, dropped: 0 });
+  assert.deepEqual(verifierTally([], []), {
+    sentToVerifier: 0, refuted: 0, refutedHighConfidence: 0, dropped: 0,
+    absenceRaised: 0, absenceRefuted: 0, unresolved: 0,
+  });
   // a dropping verdict on a NON-blocking finding is not counted: it was never
   // sent, and applyVerifications would not have acted on it either.
   assert.deepEqual(
     verifierTally([{ severity: "minor", summary: "n" }], [GROUNDED_REFUTE]),
-    { sentToVerifier: 0, refuted: 0, refutedHighConfidence: 0, dropped: 0 },
+    { sentToVerifier: 0, refuted: 0, refutedHighConfidence: 0, dropped: 0,
+      absenceRaised: 0, absenceRefuted: 0, unresolved: 0 },
   );
 });
 
@@ -953,4 +960,151 @@ test("laneCounts: counts lanes and how often origin could not be established", (
 test("laneCounts: tolerates junk without throwing", () => {
   assert.deepEqual(laneCounts(null), { blocking: 0, backlog: 0, unknownOrigin: 0 });
   assert.deepEqual(laneCounts([null, 42, {}, { lane: "bogus" }]), { blocking: 0, backlog: 0, unknownOrigin: 0 });
+});
+
+// --- absence claims ----------------------------------------------------------
+// Refuting "there is no X" means FINDING an X, so failing to find one is
+// indistinguishable from the thing not existing. These pin that the two claim
+// shapes are verified differently — and that neither one gains a way to fall
+// off the merge gate.
+
+test("claimTypeOf: absence only when the finding says so", () => {
+  assert.equal(claimTypeOf({ claimType: "absence" }), "absence");
+  // Everything else is `presence`, so an omitted or junk value keeps today's
+  // procedure rather than silently switching the verifier's job.
+  for (const f of [{ claimType: "presence" }, { claimType: "ABSENCE" }, { claimType: 1 }, {}, null, undefined]) {
+    assert.equal(claimTypeOf(f), "presence", JSON.stringify(f));
+  }
+});
+
+test("absence claims get a larger turn budget than presence claims", () => {
+  // #578's false "no CI workflow runs these tests" had a real counterexample
+  // three hops away (ci.yml → verify:self → verify-self.mjs → agent:tests) and
+  // confirmed because the verifier ran out of turns, not because it was right.
+  assert.ok(VERIFIER_MAX_TURNS.absence > VERIFIER_MAX_TURNS.presence);
+  assert.equal(VERIFIER_MAX_TURNS.presence, 8);
+});
+
+test("`unresolved` does NOT drop a finding", () => {
+  // The whole point: it records that the verifier could not settle the claim,
+  // and settles nothing itself. Only an explicit `refuted` may drop.
+  const unresolved = {
+    verdict: "unresolved",
+    confidence: "high",
+    reason: "searched widely, found nothing",
+    refutationGround: "none",
+    groundedIn: ["scripts/agent/ask.mjs:105"],
+  };
+  assert.equal(isDroppingVerdict(unresolved), false);
+  // …even if it names a ground and cites locations, which would drop a `refuted`.
+  assert.equal(isDroppingVerdict({ ...unresolved, refutationGround: "counterexample" }), false);
+  assert.equal(routeFinding({ severity: "major" }, { verdict: unresolved }), "blocking");
+});
+
+test("`counterexample` is a droppable ground for a refuted absence claim", () => {
+  assert.equal(
+    isDroppingVerdict({
+      verdict: "refuted",
+      confidence: "high",
+      reason: "ci.yml runs it",
+      refutationGround: "counterexample",
+      groundedIn: [".github/workflows/ci.yml:41"],
+    }),
+    true,
+  );
+});
+
+test("annotateFindings marks an unsettled finding without changing its lane", () => {
+  const out = annotateFindings(
+    [{ severity: "critical", summary: "no test covers X", claimType: "absence" }],
+    [{ verdict: "unresolved", confidence: "low", reason: "", refutationGround: "none", groundedIn: [] }],
+    null,
+    {},
+  );
+  assert.equal(out[0].lane, "blocking"); // still gates
+  assert.equal(out[0].unsettled, true); // but says so
+  assert.equal(classify(gatingFindings(out)).conclusion, "failure");
+});
+
+test("verifierTally counts absence claims and unresolved outcomes separately", () => {
+  const findings = [
+    { severity: "critical", claimType: "absence", summary: "no test" },
+    { severity: "major", claimType: "absence", summary: "no doc" },
+    { severity: "major", claimType: "presence", summary: "bad regex" },
+    { severity: "minor", claimType: "absence", summary: "not sent to verifier" },
+  ];
+  const verdicts = [
+    { verdict: "refuted", confidence: "high", refutationGround: "counterexample", groundedIn: ["a.mjs:1"] },
+    { verdict: "unresolved", confidence: "low", refutationGround: "none", groundedIn: [] },
+    { verdict: "confirmed", confidence: "high", refutationGround: "none", groundedIn: [] },
+    null,
+  ];
+  const t = verifierTally(findings, verdicts, {});
+  assert.equal(t.sentToVerifier, 3); // the minor is never verified
+  assert.equal(t.absenceRaised, 2); // …so its absence claim is not counted either
+  assert.equal(t.absenceRefuted, 1);
+  assert.equal(t.unresolved, 1);
+  assert.equal(t.dropped, 1);
+});
+
+test("the lens prompt explains both claim shapes, in ONE place", () => {
+  // Guidance belongs in the shared closing instruction, not copied into five
+  // rubric files — the drift the LENS_CLOSING_INSTRUCTION docblock exists to
+  // prevent, and a mistake this change already made once.
+  assert.match(LENS_CLOSING_INSTRUCTION, /`presence` = something is THERE/);
+  assert.match(LENS_CLOSING_INSTRUCTION, /`absence` = something/);
+  assert.match(LENS_CLOSING_INSTRUCTION, /searchedFor/);
+  for (const id of ["correctness", "security", "design-fit", "test-adequacy", "blast-radius"]) {
+    const md = readFileSync(path.join(HERE, "lenses", `${id}.md`), "utf8");
+    assert.doesNotMatch(md, /claimType/, `${id}.md must not carry its own copy`);
+  }
+});
+
+test("buildVerifierPrompt: an absence claim is told to hunt a counterexample", () => {
+  // Rendered, not grepped from source — the claim is about the PROMPT, and a
+  // regex over review-panel.mjs cannot observe what the verifier actually reads.
+  const ctx = { authoritative: true, listed: ["a.mjs"], total: 1 };
+  const p = buildVerifierPrompt(
+    { severity: "major", file: "x.mjs", summary: "no CI runs these tests", claimType: "absence",
+      searchedFor: ["grep -r agent-tests .github/workflows"] },
+    { rubric: "RUBRIC", changedContext: ctx },
+  );
+  assert.match(p, /ABSENCE CLAIM/);
+  assert.match(p, /FINDING ONE COUNTEREXAMPLE/);
+  assert.match(p, /`counterexample`/);
+  assert.match(p, /two or three hops/); // the #578 failure was a 3-hop chain
+  assert.match(p, /grep -r agent-tests \.github\/workflows/); // told what was tried
+  assert.match(p, /unresolved/); // the honest third answer is offered
+  // The presence-only grounds are NOT offered — they are the wrong shape here.
+  assert.doesNotMatch(p, /not-present/);
+  assert.doesNotMatch(p, /already-guarded/);
+});
+
+test("buildVerifierPrompt: a presence claim keeps the original procedure", () => {
+  const ctx = { authoritative: true, listed: ["a.mjs"], total: 1 };
+  const p = buildVerifierPrompt(
+    { severity: "major", file: "x.mjs", summary: "regex is wrong", claimType: "presence" },
+    { rubric: "RUBRIC", changedContext: ctx },
+  );
+  assert.match(p, /PRESENCE CLAIM/);
+  assert.match(p, /not-present/);
+  assert.match(p, /already-guarded/);
+  assert.match(p, /Unsure for ANY reason -> \{verdict:"confirmed"\}/);
+  assert.doesNotMatch(p, /COUNTEREXAMPLE/);
+});
+
+test("buildVerifierPrompt: a finding with no claimType gets the presence procedure", () => {
+  // Prior-round findings and any schema drift must keep today's behaviour.
+  const ctx = { authoritative: false, listed: [], total: 0 };
+  const p = buildVerifierPrompt({ severity: "major", summary: "x" }, { rubric: "R", changedContext: ctx });
+  assert.match(p, /PRESENCE CLAIM/);
+});
+
+test("buildVerifierPrompt: an absence claim with no searchedFor says so", () => {
+  const ctx = { authoritative: true, listed: [], total: 0 };
+  const p = buildVerifierPrompt(
+    { severity: "major", summary: "no test", claimType: "absence" },
+    { rubric: "R", changedContext: ctx },
+  );
+  assert.match(p, /did not record what it searched/);
 });

--- a/scripts/agent/severity.mjs
+++ b/scripts/agent/severity.mjs
@@ -49,7 +49,14 @@ function section(findings, severity, heading) {
   const rows = findings.filter((f) => f.severity === severity);
   if (rows.length === 0) return "";
   const body = rows
-    .map((f) => `- ${f.file ? `\`${f.file}\` — ` : ""}${f.summary ?? "(no summary)"}`)
+    .map((f) => {
+      // An `unsettled` finding blocks exactly like any other — the marker is for
+      // the human deciding how much to trust it. It means the verifier searched
+      // and could not disprove the claim, which is NOT the same as having
+      // confirmed it, and printing them identically would read as endorsement.
+      const unsettled = f.unsettled ? " _(verifier could not settle this)_" : "";
+      return `- ${f.file ? `\`${f.file}\` — ` : ""}${f.summary ?? "(no summary)"}${unsettled}`;
+    })
     .join("\n");
   return `\n### ${heading} (${rows.length})\n${body}\n`;
 }


### PR DESCRIPTION
## Summary

Split findings into **presence** and **absence** claims and verify them in
opposite directions. Refuting *"this code is wrong"* is a lookup at a location
the finding already names. Refuting *"there is no X"* means **finding an X** — a
search across the repository whose failure is indistinguishable from the thing
genuinely not existing.

The panel ran the first procedure on both, so the bias-to-keep rule that protects
real findings was rubber-stamping false absence claims.

`isDroppingVerdict` is **unchanged**. No new demotion path — see below.

## Why

From #578's disposition, the clearest "doesn't hold" finding was **"No CI
workflow runs `scripts/agent/*.test.mjs`"**. It's false: `ci.yml:41` runs
`pnpm verify:self`, whose first lane is `agent:tests` (`verify-self.mjs:16`).

The verifier confirmed it anyway, and the reason is structural rather than a weak
prompt. To refute it, the verifier must **find** the CI lane: chase `ci.yml` →
`verify:self` → `verify-self.mjs` → `agent:tests`, reading each to confirm. Three
hops against a ceiling of 8 turns. It ran out, couldn't reach a grounded
refutation, and bias-to-keep did the rest.

|  | refuted by | cost |
|---|---|---|
| presence | showing the code isn't as described | a lookup at a named location |
| absence | finding one instance of the thing | a search across the repo |

## How

- `claimType` (`presence`/`absence`, **required** so a lens decides rather than
  defaults by omission) and `searchedFor` — what the lens actually searched
  before concluding something is missing.
- An absence claim gets a **counterexample-hunting prompt**: one instance is
  enough, the thing may live under another name or be reached indirectly ("two or
  three hops from where you started"), and here is exactly what the lens already
  tried — so it searches where the lens did **not**, rather than repeating a
  search that came up empty.
- A **`counterexample`** refutation ground. The existing grounds all describe
  ways a *present* thing fails to be a defect, which is the wrong shape.
- `VERIFIER_MAX_TURNS` becomes `{presence: 8, absence: 20}`. Absence claims are
  the minority, so the extra ceiling is bounded in practice.

## `unresolved` does NOT demote — and that's the point

The plan for this PR had `unresolved` route to a non-gating lane. I dropped that
after #583's review caught the novelty gate demoting an entire legitimate class
of findings, because **the same trap is here and it's bigger.**

Absence claims are not a noise category. *"No test covers this"* is
test-adequacy's entire output contract. *"No validation on this input"* is much
of security. *"No design doc records this module"* was a **correct** #578
finding. Routing unsettleable absence claims off the merge gate would silently
disable large parts of three lenses.

So `unresolved` keeps the finding blocking exactly as `confirmed` does. Its value
is honesty and measurement: *"I searched and couldn't disprove this"* and *"I
checked and it's real"* used to be the same word, which hid how often the
verifier was guessing. The finding is marked *"(verifier could not settle this)"*
in the summary and counted separately.

**The mechanism that actually fixes #578's case is refutation, not demotion.**
That counterexample is real and findable; with 20 turns, a hunt-shaped prompt and
`searchedFor` to search around, it should come back `refuted` on the
`counterexample` ground — dropped by the rule that already exists, with cited
evidence.

## What to watch

`absenceRaised` / `absenceRefuted` / `unresolved` in the metrics comment.

- High `unresolved`, low `absenceRefuted` → absence claims are riding through
  unchecked. Either the ceiling is still too low or lenses are raising claims
  they haven't searched for; an empty `searchedFor` distinguishes the two.
- High `absenceRefuted` → #578's class is being caught where it should be.

## Verification

Both prompt branches are checked by **rendering**, following the precedent
`buildLensPrompt` set — the claim is about the prompt, and a regex over
`review-panel.mjs` cannot observe what the verifier actually reads. Tests assert
an absence prompt offers `counterexample` and `unresolved` and does *not* offer
the presence-only grounds, and that a finding with no `claimType` gets today's
procedure unchanged.

223 agent tests, `verify:self` green locally (11/11).

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅

## Risk Assessment

- **User-facing risk:** none — review harness only.
- **Data/security risk:** none new. No new tool grants, no new execution, and no
  new way for a finding to leave the merge gate. `searchedFor` is model-supplied
  but advisory: it only shapes where the verifier looks, never whether a finding
  blocks.
- **Rollback plan:** a finding with no `claimType` takes the presence path, which
  is byte-identical to today's prompt and turn budget. Reverting the schema field
  alone restores current behaviour.

## Notes for Reviewers

**AI assistance:** written by Claude Code in an interactive session —
implementation, tests, and this description. I haven't read every line myself
yet, so the author checklist is deliberately unticked.

**Deliberately not in this PR** (each its own diff): the wrong-mechanism/true-kernel
case, where a binary verdict has nowhere to put "the concern is real but the
stated cause is wrong" (#578's "Bash/Write stay available" rode through at full
severity); and duplicates, where `dedupeFindings` keys on `file + lowercased
summary` and the verifier runs per-finding in isolation, so the same bug in
different words survives twice. See
`docs/tasks/active/20260729-absence-claims-todo.md`.

Follows #583.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Review findings now distinguish between claims that code is present and claims that code is absent.
  * Absence claims receive deeper verification, including counterexample searches, and may be marked unresolved when verification is inconclusive.
  * Unresolved absence findings remain relevant to review gating and are visibly labeled in severity reports.
  * Review summaries now report absence claims raised, refuted, and unresolved.
* **Documentation**
  * Updated review-panel design documentation and task tracking to describe absence-claim verification and related metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->