### PR TITLE
Turn on incremental review: stamp, resolve, narrow

### DIFF
--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -280,45 +280,25 @@ jobs:
       # findings". Best-effort (continue-on-error) and empty when there's no prior
       # panel history (e.g. a non-agent PR). This review posts NO check runs, so it
       # only READS priors and never contributes new ones.
+      #
+      # The SAME trusted script the gating panel runs, which is the point: this was
+      # the second inline copy of that logic, and two copies of a gate input is how
+      # one of them rots. Both API contracts it depends on are non-obvious and fail
+      # silently as "carried 0 findings" — see gh-checks.mjs.
+      #
+      # This review NEVER narrows its own diff: it records no check runs, so it can
+      # never write a pointer back, and a round that reviewed only a delta with no
+      # pointer to show for it would be invisible to the gating panel. Hence no
+      # review-scope step here and no --review-mode flag below.
       - name: Read prior findings (align with the gating panel)
         continue-on-error: true
-        uses: actions/github-script@v7
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ needs.authorize.outputs.pr }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const owner = context.repo.owner, repo = context.repo.repo;
-            const pr = Number(process.env.PR);
-            const manifest = JSON.parse(fs.readFileSync('.trusted/scripts/agent/lenses/lenses.json', 'utf8'));
-            const wantNames = new Set(manifest.map((l) => `agent-review-${l.id}`));
-            const commits = await github.paginate(github.rest.pulls.listCommits, { owner, repo, pull_number: pr, per_page: 100 });
-            const latest = {}; // check name -> { id, t }
-            for (const c of commits) {
-              const runs = await github.paginate(github.rest.checks.listForRef, { owner, repo, ref: c.sha, per_page: 100 });
-              for (const r of runs) {
-                if (!wantNames.has(r.name) || !r.app || r.app.slug !== 'github-actions') continue;
-                // Only COMPLETED runs carry final findings in output.text — an
-                // in-progress/queued run (e.g. a panel round running right now) has
-                // a newer started_at but no findings yet, and would otherwise shadow
-                // the last completed run. Rank by completed_at (fallback started_at).
-                if (r.status !== 'completed') continue;
-                const t = new Date(r.completed_at || r.started_at || 0).getTime();
-                if (!latest[r.name] || t > latest[r.name].t) latest[r.name] = { id: r.id, t };
-              }
-            }
-            const prior = [];
-            for (const [name, { id }] of Object.entries(latest)) {
-              const lens = name.replace(/^agent-review-/, '');
-              let text = '';
-              try { const { data } = await github.rest.checks.get({ owner, repo, check_run_id: id }); text = (data.output && data.output.text) || ''; } catch {}
-              let findings = [];
-              try { findings = JSON.parse(text); } catch {}
-              if (Array.isArray(findings)) for (const f of findings) if (f && typeof f === 'object') prior.push({ ...f, lens });
-            }
-            fs.writeFileSync('/tmp/prior-findings.json', JSON.stringify(prior));
-            core.info(`prior findings carried into on-demand review: ${prior.length}`);
+        run: >-
+          node .trusted/scripts/agent/prior-findings.mjs "$PR"
+          --lenses .trusted/scripts/agent/lenses/lenses.json
+          --out /tmp/prior-findings.json
 
       - name: Run review panel
         id: panel

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -284,49 +284,119 @@ jobs:
         if: steps.pr.outputs.number != ''
         run: rm -rf "$GITHUB_WORKSPACE/.claude" "$GITHUB_WORKSPACE/.mcp.json"
 
+      # INCREMENTAL REVIEW, part 1 of 2: decide whether this round may review only
+      # the commits added since every lens last produced a verdict. The decision
+      # needs the checks API (each lens's pointer lives in its check run's
+      # external_id) and git (is the pointer still an ancestor, is there a merge in
+      # range, how big is the delta), so it runs in the TRUSTED script rather than
+      # inline here.
+      #
+      # The script resolves every internal failure to `full` itself. `continue-on-error`
+      # covers the class it CANNOT catch — a module-resolution error or a missing
+      # node, which crash before its `main().catch`. Without it such a crash fails
+      # the job, and while that still fails closed (the post step below runs on
+      # `always()` and marks every lens failed), it would turn a bug in a COST
+      # OPTIMISER into a blocked PR. A full review is always correct and merely more
+      # expensive; the empty outputs skip the narrow step below, so the fallback is
+      # exactly today's behaviour with a red step to explain it.
+      - name: Resolve review scope
+        id: scope
+        if: steps.pr.outputs.number != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: >-
+          node .trusted/scripts/agent/review-scope.mjs "$PR"
+          --head "$HEAD_SHA"
+          --lenses .trusted/scripts/agent/lenses/lenses.json
+          --changed-files /tmp/changed.txt
+          --repo "$GITHUB_WORKSPACE"
+
+      # Why this round did what it did, in the run UI. Without it "we never narrow"
+      # and "we narrow and it saves nothing" are indistinguishable from the outside,
+      # and the ten distinct reasons exist precisely to answer that.
+      - name: Report the review scope
+        if: steps.pr.outputs.number != ''
+        continue-on-error: true
+        env:
+          MODE: ${{ steps.scope.outputs.mode }}
+          REASON: ${{ steps.scope.outputs.reason }}
+          ROUNDS: ${{ steps.scope.outputs.rounds }}
+        run: |
+          echo "Review scope: **$MODE** (\`$REASON\`), round $ROUNDS" >> "$GITHUB_STEP_SUMMARY"
+
+      # INCREMENTAL REVIEW, part 2 of 2: replace /tmp/pr.diff with the delta.
+      #
+      # This step is what makes the diff and the `--review-mode` flag inseparable:
+      # BOTH come from here, so they cannot disagree. When it is skipped its outputs
+      # are empty, the panel below receives no flag, and the full diff written by
+      # "Compute diff + changed files" stands — which is why that step is left
+      # byte-identical to the on-demand workflow's copy of it.
+      #
+      # The exclusions and the empty-result fallback mirror the full-diff step for
+      # the same reasons documented there. The extra case is a delta that is empty
+      # even unfiltered: the panel fails closed on an empty diff, so rather than
+      # turn a harmless re-run into an outage we keep the full diff and emit no
+      # flag. `-U15` because a one-line change in an unseen function is
+      # unreviewable at the default -U3, and the delta is small enough to afford it.
+      - name: Narrow the reviewed diff to the delta
+        id: narrow
+        # Also skipped when the scope step crashed: its outputs are then empty, so
+        # this never runs and the full diff stands.
+        if: steps.pr.outputs.number != '' && steps.scope.outputs.mode == 'incremental'
+        # Deliberately NOT continue-on-error, unlike the scope step above, and the
+        # asymmetry is the point: scope only COMPUTES, so tolerating its failure
+        # costs a full review. This step MUTATES the reviewed artifact. If it died
+        # between replacing /tmp/pr.diff and writing `mode`, tolerating that would
+        # hand the panel a narrowed diff with no flag — a lens reviewing a fragment
+        # while believing it is the whole PR, which is the one failure this design
+        # must not have. review-panel.mjs cannot detect it either: it receives a
+        # file and cannot tell a narrowed diff from a full one. So any failure here
+        # fails the job, and the post step (`always()`) marks every lens failed.
+        env:
+          SINCE_SHA: ${{ steps.scope.outputs.since }}
+        run: |
+          set -euo pipefail
+          git diff --no-color -U15 "$SINCE_SHA" HEAD -- . \
+            ':(exclude)packages/sheets/antlr/*.interp' \
+            ':(exclude)packages/sheets/antlr/*.tokens' > /tmp/delta.diff
+          if [ ! -s /tmp/delta.diff ]; then
+            git diff --no-color -U15 "$SINCE_SHA" HEAD > /tmp/delta.diff
+          fi
+          if [ -s /tmp/delta.diff ]; then
+            mv /tmp/delta.diff /tmp/pr.diff
+            echo "mode=incremental" >> "$GITHUB_OUTPUT"
+            echo "narrowed the reviewed diff to $(wc -l < /tmp/pr.diff) lines since $SINCE_SHA" >&2
+          else
+            echo "delta is empty — keeping the full diff and reviewing in full" >&2
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          fi
+
       # Part 2: carry the PREVIOUS round's blocking findings into this run so the
       # panel can re-check they were actually resolved (not just missed). Each
       # lens's findings were persisted in its check run's output.text; take the
       # latest agent-review-<lens> check per lens across the PR's commits (ours
       # only). This runs BEFORE the panel posts its checks, so all existing ones
       # are prior rounds. Never fails the job (best-effort; empty on round 1).
+      #
+      # The logic moved to the TRUSTED script so it could be tested: two GitHub API
+      # contracts here are non-obvious and each silently yields "carried 0 findings"
+      # when got wrong (the list response omits output.text; the object-wrapped
+      # check-runs endpoint needs --slurp). Inline YAML JavaScript can hold neither
+      # a unit test nor a linter, and #558 needed a second copy of it for the
+      # on-demand workflow.
       - name: Read prior findings
         if: steps.pr.outputs.number != ''
         continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const owner = context.repo.owner, repo = context.repo.repo;
-            const pr = Number('${{ steps.pr.outputs.number }}');
-            const manifest = JSON.parse(fs.readFileSync('.trusted/scripts/agent/lenses/lenses.json', 'utf8'));
-            const wantNames = new Set(manifest.map((l) => `agent-review-${l.id}`));
-            const commits = await github.paginate(github.rest.pulls.listCommits, { owner, repo, pull_number: pr, per_page: 100 });
-            const latest = {}; // check name -> { id, t }
-            for (const c of commits) {
-              const runs = await github.paginate(github.rest.checks.listForRef, { owner, repo, ref: c.sha, per_page: 100 });
-              for (const r of runs) {
-                if (!wantNames.has(r.name) || !r.app || r.app.slug !== 'github-actions') continue;
-                // Only COMPLETED runs carry final findings in output.text — an
-                // in-progress/queued run has a newer started_at but no findings yet,
-                // and would otherwise shadow the last completed run. Rank by
-                // completed_at (fallback started_at).
-                if (r.status !== 'completed') continue;
-                const t = new Date(r.completed_at || r.started_at || 0).getTime();
-                if (!latest[r.name] || t > latest[r.name].t) latest[r.name] = { id: r.id, t };
-              }
-            }
-            const prior = [];
-            for (const [name, { id }] of Object.entries(latest)) {
-              const lens = name.replace(/^agent-review-/, '');
-              let text = '';
-              try { const { data } = await github.rest.checks.get({ owner, repo, check_run_id: id }); text = (data.output && data.output.text) || ''; } catch {}
-              let findings = [];
-              try { findings = JSON.parse(text); } catch {}
-              if (Array.isArray(findings)) for (const f of findings) if (f && typeof f === 'object') prior.push({ ...f, lens });
-            }
-            fs.writeFileSync('/tmp/prior-findings.json', JSON.stringify(prior));
-            core.info(`prior findings carried into re-check: ${prior.length}`);
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: >-
+          node .trusted/scripts/agent/prior-findings.mjs "$PR"
+          --lenses .trusted/scripts/agent/lenses/lenses.json
+          --out /tmp/prior-findings.json
 
       # Advisory single-value state: mark the PR "under automated review" while the
       # panel runs. Best-effort; the label is a projection, never a gate. Runs the
@@ -356,6 +426,20 @@ jobs:
           # the Claude token, and repo convention keeps workflow expressions out
           # of shell commands in jobs that hold secrets.
           BASE_SHA: ${{ steps.diff.outputs.base }}
+          # From the NARROW step, not the scope step: whichever step actually wrote
+          # /tmp/pr.diff is the one allowed to say what is in it. When narrowing did
+          # not happen both are EMPTY STRINGS, which review-panel.mjs reads as
+          # absent — so the flags are passed unconditionally rather than assembled
+          # with `${VAR:+...}` inside a folded `run:`, where a quoting slip would
+          # silently drop one of the pair. The script refuses a half-passed pair in
+          # either direction, so a lost value fails the step loudly instead of
+          # reviewing a fragment as if it were the whole PR.
+          REVIEW_MODE: ${{ steps.narrow.outputs.mode }}
+          SINCE_SHA: ${{ steps.narrow.outputs.mode == 'incremental' && steps.scope.outputs.since || '' }}
+          # What this round stamps back as each lens's last-reviewed pointer. The
+          # SHA the check runs below are attested against, so the pointer and the
+          # attestation cannot drift apart.
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: >-
           node .trusted/scripts/agent/review-panel.mjs
           --diff-file /tmp/pr.diff
@@ -363,6 +447,9 @@ jobs:
           --changed-files /tmp/changed.txt
           --prior-findings /tmp/prior-findings.json
           --base-sha "$BASE_SHA"
+          --head-sha "$HEAD_SHA"
+          --review-mode "$REVIEW_MODE"
+          --since-sha "$SINCE_SHA"
           --repo "$GITHUB_WORKSPACE"
           --lenses-dir .trusted/scripts/agent/lenses
           --out .agent-review
@@ -371,10 +458,17 @@ jobs:
         id: panel
         if: always() && steps.pr.outputs.number != ''
         uses: actions/github-script@v7
+        env:
+          # Suffixed onto the check-run title on narrowed rounds ONLY, so a human
+          # reading a verdict knows it saw a delta rather than the whole PR. Empty
+          # in full mode, which keeps those titles byte-identical to before.
+          NARROWED_SINCE: ${{ steps.narrow.outputs.mode == 'incremental' && steps.scope.outputs.since || '' }}
         with:
           script: |
             const fs = require('fs');
             const sha = context.payload.workflow_run.head_sha;
+            const since = process.env.NARROWED_SINCE || '';
+            const scopeSuffix = since ? ` (delta since ${since.slice(0, 12)})` : '';
             // Single source of truth for the lens set: the TRUSTED manifest. The
             // orchestrator writes panel.json (one entry per lens incl. skipped);
             // any manifest lens missing from panel.json = orchestrator crash → fail closed.
@@ -442,7 +536,20 @@ jobs:
               await github.rest.checks.create({
                 owner: context.repo.owner, repo: context.repo.repo,
                 name: `agent-review-${lens.id}`, head_sha: sha, status: 'completed', conclusion,
-                output: { title: `${lens.id}: ${conclusion}`, summary: summary.slice(0, 60000), text: findingsText },
+                // Incremental review's state channel: what this lens reviewed, so
+                // the NEXT round can narrow to what came after it. Present only
+                // when the orchestrator decided this lens produced a real verdict
+                // (see `panelEntry`) — the write rule is enforced there, in tested
+                // code, rather than re-derived from `conclusion` here where it
+                // could drift. `undefined` omits the field, which is what makes a
+                // crashed or skipped lens force a full round next time.
+                //
+                // Why not output.text: that field is trimmed to fit 60k BY DROPPING
+                // FINDINGS (just below). It is designed to lose data, and a value
+                // deciding whether code gets reviewed must not live in a lossy
+                // channel. external_id is a fixed 255-char slot nothing else writes.
+                external_id: p && p.reviewState ? p.reviewState : undefined,
+                output: { title: `${lens.id}: ${conclusion}${scopeSuffix}`, summary: summary.slice(0, 60000), text: findingsText },
               });
             }
             core.setOutput('blocked', String(blocked));

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -547,7 +547,8 @@ Components:
        over-merge two distinct bugs into one, reintroducing the miss.
     2. **Cross-round re-check.** Each round persists its blocking findings in the
        per-lens check run's `output.text`; the next round reads the latest prior
-       `agent-review-<lens>` findings (`--prior-findings`) and re-verifies each
+       `agent-review-<lens>` findings (`scripts/agent/prior-findings.mjs` →
+       `--prior-findings`, the same script on both panel paths) and re-verifies each
        against the *current repository* with the same biased-to-keep refute pass.
        A prior finding survives unless it is *resolved* on grounded evidence — so
        it can't vanish just because a later fresh pass missed it (only because it
@@ -581,28 +582,44 @@ Components:
     All three lower false-negative odds; none makes the panel safe to
     self-promote — the human review gate stays the backstop.
 
-  - **Incremental review (scope narrowing, `scripts/agent/review-state.mjs`).**
-    ⚠️ **Decision logic only — NOT yet wired, and therefore not yet saving
-    anything.** Nothing stamps `external_id`, nothing calls `resolveReviewMode`,
-    and the panel still reviews the full cumulative diff every round. The workflow
-    half (stamping the pointer, computing the git facts, `-U15` on narrowed rounds,
-    and swapping in `scripts/agent/prior-findings.mjs`) is a separate change; it touches
-    `.github/workflows/**`, which the agent App cannot push, so it needs a human
-    push either way. Read the rest of this entry as the design the scripts
-    implement, not as current behaviour.
+  - **Incremental review (scope narrowing, `scripts/agent/review-state.mjs` +
+    `scripts/agent/review-scope.mjs`).** Live in the autonomous panel; the
+    on-demand path never narrows.
 
-    The reviewed artifact is `git diff origin/main...HEAD`, recomputed every
+    The reviewed artifact was `git diff origin/main...HEAD`, recomputed every
     round, so an 8-round PR reads round-1 code eight times. Both endpoints of
     `...` also move: a human `git merge main` changed the artifact with no
     semantic change to the branch and flipped a lens verdict.
 
-    Each lens's **`external_id`** is to carry what it last reviewed —
+    Each lens's **`external_id`** carries what it last reviewed —
     `{"v":1,"reviewed":…,"base":…,"since":…,"mode":…}`. Every candidate location
     sits behind the same `checks:write` boundary (the author agent cannot forge
     any of them), so the choice was about failure modes: `output.text` is
     disqualified because the panel trims it to fit a 60k limit by *dropping
     findings* — it is designed to lose data, and a field that decides whether code
     gets reviewed must not live in a lossy channel.
+
+    **The write rule is a function, not a convention.** `panelEntry` in
+    `scripts/agent/review-panel.mjs` attaches the pointer only when a lens produced
+    a real verdict (`valid` and not skipped), so a crashed, quota-failed, skipped or
+    inapplicable lens stamps nothing and the next round finds a state gap for it.
+    Coverage is *proven by the presence of a pointer* rather than asserted
+    alongside it, which is why `resolveReviewMode` needs no separate "did this lens
+    actually review?" input. It is a function because the first version was a rule
+    the three call sites were trusted to follow, guarded by a test that scanned the
+    source for which one carried the field — and that test passed when the pointer
+    was also attached elsewhere by a separate assignment.
+
+    **Who decides what, and where.** The panel orchestrator resolves neither the
+    mode nor the diff: `scripts/agent/review-scope.mjs` reads the pointers (checks
+    API) and measures the range (git), `resolveReviewMode` decides purely, and the
+    workflow step that *rewrites the diff* is the same step that emits the
+    `--review-mode` flag — so the two cannot disagree about what the panel is
+    looking at. Their fail directions differ deliberately: the scope step only
+    computes, so it tolerates failure and costs a full review; the narrowing step
+    mutates the reviewed artifact, so any failure there fails the job. A narrowed
+    diff with no flag is the one outcome this design must not produce, and
+    `scripts/agent/review-panel.mjs` cannot detect it — it receives a file, not a range.
 
     `latestLensRuns` filters check runs on `app.slug === "github-actions"`. That
     narrows the writer to a workflow **in this repository**, not to the panel
@@ -628,8 +645,24 @@ Components:
     telling the lens it still owns defects the delta newly exposes in earlier code,
     that the full working tree is its cwd, and that the changed-file list is
     cumulative; a **forced full round** every 3 rounds plus on any of the hazards
-    above; and wider diff context (`-U15`) on narrowed rounds, which the wiring
-    supplies. The honest saving is therefore **~2x, not ~8x**.
+    above; and wider diff context (`-U15`) on narrowed rounds. The honest saving is
+    therefore **~2x, not ~8x**.
+
+    **A pointer means the lens LOOKED, not merely that it reported.** Per-lens diff
+    slicing (#582) lets a lens produce a valid verdict having run zero detection
+    samples: `lensReviewPlan` returns an empty slice when the PR contains files it
+    reads but none changed in this round's delta, and the round then rests on the
+    prior-finding re-check alone. Such a lens does **not** stamp — `panelEntry`
+    requires `ranDetection`, derived from the samples that actually returned.
+
+    Letting it stamp would make `scopeClasses`/`classifyFile` **retroactive**:
+    widening a lens's scope later would apply only to commits after the pointer,
+    where today it self-heals because every round re-reads the whole diff. Not
+    stamping costs one forced-full round; stamping costs a permanent, invisible
+    hole. If those forced rounds prove expensive, the cheaper form is a digest of
+    the lens's scope config inside the state, so changing the config invalidates
+    the pointer — the mechanism `REVIEW_STATE_VERSION` already provides for shape
+    changes.
 
     `--changed-files` stays **cumulative** in every mode. Fed the delta instead,
     `lensApplies` could mark a narrow-glob lens inapplicable in round N, the

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -19,10 +19,13 @@ Track task-specific plan/review and lessons files using the active/archive layou
 | Task | Todo | Lessons |
 |---|---|---|
 | absence claims (2026-07-29) | [20260729-absence-claims-todo.md](./active/20260729-absence-claims-todo.md) | - |
+| autonomous issue hunting (2026-07-29) | [20260729-autonomous-issue-hunting-todo.md](./active/20260729-autonomous-issue-hunting-todo.md) | [20260729-autonomous-issue-hunting-lessons.md](./active/20260729-autonomous-issue-hunting-lessons.md) |
 | incremental review (2026-07-29) | [20260729-incremental-review-todo.md](./active/20260729-incremental-review-todo.md) | [20260729-incremental-review-lessons.md](./active/20260729-incremental-review-lessons.md) |
+| incremental review wiring (2026-07-29) | [20260729-incremental-review-wiring-todo.md](./active/20260729-incremental-review-wiring-todo.md) | [20260729-incremental-review-wiring-lessons.md](./active/20260729-incremental-review-wiring-lessons.md) |
 | review novelty gate (2026-07-29) | [20260729-review-novelty-gate-todo.md](./active/20260729-review-novelty-gate-todo.md) | - |
 | blast radius lens (2026-07-28) | [20260728-blast-radius-lens-todo.md](./active/20260728-blast-radius-lens-todo.md) | [20260728-blast-radius-lens-lessons.md](./active/20260728-blast-radius-lens-lessons.md) |
 | coverage first rubrics (2026-07-28) | [20260728-coverage-first-rubrics-todo.md](./active/20260728-coverage-first-rubrics-todo.md) | [20260728-coverage-first-rubrics-lessons.md](./active/20260728-coverage-first-rubrics-lessons.md) |
+| docs edit link in place (2026-07-28) | [20260728-docs-edit-link-in-place-todo.md](./active/20260728-docs-edit-link-in-place-todo.md) | [20260728-docs-edit-link-in-place-lessons.md](./active/20260728-docs-edit-link-in-place-lessons.md) |
 | independent verifier (2026-07-28) | [20260728-independent-verifier-todo.md](./active/20260728-independent-verifier-todo.md) | [20260728-independent-verifier-lessons.md](./active/20260728-independent-verifier-lessons.md) |
 | model refresh opus 5 (2026-07-28) | [20260728-model-refresh-opus-5-todo.md](./active/20260728-model-refresh-opus-5-todo.md) | [20260728-model-refresh-opus-5-lessons.md](./active/20260728-model-refresh-opus-5-lessons.md) |
 | agent metrics cost weighting (2026-07-27) | [20260727-agent-metrics-cost-weighting-todo.md](./active/20260727-agent-metrics-cost-weighting-todo.md) | - |

--- a/docs/tasks/active/20260729-incremental-review-wiring-lessons.md
+++ b/docs/tasks/active/20260729-incremental-review-wiring-lessons.md
@@ -1,0 +1,88 @@
+# Lessons: incremental review (wiring)
+
+## A guard that watches syntax is not a guard
+
+The write rule — only a lens that produced a verdict may stamp a last-reviewed
+pointer — started as a convention across three `panel.push` sites, with the pointer
+spread into one of them and a test that scanned `review-panel.mjs` for which push
+carried the field.
+
+I mutation-tested it. Removing the pointer failed the test, so it looked real. Then
+I tried the mutation in the *dangerous* direction — attaching the pointer to the
+fail-closed entry as well — and **the test passed**, because the mutation used
+`entry.reviewState = ...` instead of a property inside the object literal the regex
+matched. The guard was watching the syntax I happened to write.
+
+The fix was not a better regex. It was `panelEntry`, a function that decides, so
+every call site can pass `reviewState` unconditionally and the rule still holds.
+Now the rule is executable: the test feeds it a crashed lens and asserts no pointer
+comes back, and both remaining mutations (dropping the `valid` check, bypassing the
+function) fail.
+
+**Mutation-test in the direction of the failure you fear, not the direction that is
+easy to write.** Deleting a guard is the easy mutation and it proves almost
+nothing; the mutation worth running is the one an author would plausibly make while
+adding a feature. And when a rule is enforced by convention at N call sites, the
+answer is usually one function, not N assertions.
+
+## When inputs are circular, make the two phases explicit
+
+`resolveReviewMode` takes git facts as arguments — that purity is what makes its
+decision table testable. But the facts have to describe `since..head`, and `since`
+comes out of the pointers, so a caller cannot gather its inputs in one pass. My
+first version of the caller would have had to re-derive the agreed sha itself,
+duplicating logic the pure module already had.
+
+Exporting `agreedReviewedSha` and having `resolveReviewMode` call it internally
+fixed both halves: the caller learns the range from the same code that will later
+decide on it, so the two cannot disagree.
+
+**A documented caller contract that the caller cannot mechanically satisfy is a
+latent bug.** If the contract says "measure X over range R", export whatever
+computes R. And the test for it should capture what the dependency actually
+received — here, the git argv — because the pure function is *handed* the facts and
+by construction cannot notice they describe the wrong range.
+
+## Put the flag and the artifact in the same step
+
+The narrowed diff and the `--review-mode` flag that tells the lens it is narrowed
+are written by one workflow step. That is not tidiness. `review-panel.mjs` receives
+a *file*: it cannot tell a narrowed diff from a full one, so nothing downstream can
+catch a disagreement between them. The only defence is to make disagreement
+structurally impossible, and two values from one step is how.
+
+The corollary is a fail-direction split I got wrong first time. I put
+`continue-on-error: true` on both the scope step and the narrowing step, reasoning
+"a cost optimiser must never block a PR." True for the step that only *computes* —
+but the narrowing step *mutates* the reviewed artifact, and tolerating a failure
+between `mv` and the output write would ship exactly the fragment-reviewed-as-whole
+outcome the design exists to prevent.
+
+**Ask what a step leaves behind when it dies half-done.** A step that computes can
+fail soft; a step that mutates the thing a gate reads cannot.
+
+## `continue-on-error` is not the same as "the script handles its own errors"
+
+I wrote a comment arguing the scope step needed no `continue-on-error` because the
+script resolves every failure to `full` internally. That was wrong in a way worth
+remembering: `main().catch(...)` cannot catch an **import-time** failure. A bad
+module path or a missing node crashes before any of that logic runs.
+
+So the reasoning has to be about the *step*, not the script: what does the runner do
+if this process exits non-zero for a reason the process never saw? Here that meant
+`continue-on-error: true` after all, on the step whose failure is affordable.
+
+## Test the shell-out against the real thing at least once
+
+`gitFacts` is fully covered by a stubbed runner, and every branch passes. That
+proves the *logic*, and nothing about the *argv*. A misspelled flag or a wrong range
+syntax makes every fact `null`, which resolves to `full` — a silent, permanent
+no-op that looks exactly like a feature working conservatively.
+
+Running it against real history took one command and confirmed all four shapes
+(`--is-ancestor` both ways, a nonexistent sha, `--numstat` summing). Same for
+`review-scope.mjs` end-to-end against the real API: it proved the `--slurp`
+pagination parses, which is the contract this series has now broken twice.
+
+**For anything that shells out or calls an API, stubs test the branches and one real
+run tests the call.** Both, not either.

--- a/docs/tasks/active/20260729-incremental-review-wiring-todo.md
+++ b/docs/tasks/active/20260729-incremental-review-wiring-todo.md
@@ -1,0 +1,121 @@
+# Incremental review: the wiring (turn it on)
+
+#581 landed the decision logic inert. This connects it: the panel now stamps what
+each lens reviewed, resolves the next round's scope from those pointers, and
+reviews only the delta when every condition holds.
+
+## What this PR does
+
+- [x] `scripts/agent/review-scope.mjs` — the caller `review-state.mjs` was written
+      for. Reads each lens's pointer (checks API), measures the range (git), calls
+      `resolveReviewMode`, emits `mode` / `since` / `reason` / `rounds` as step
+      outputs. `decideScope` and `gitFacts` take their API and git runners as
+      arguments, so the composition is tested rather than only its parts.
+- [x] `scripts/agent/gh-checks.mjs` — the two check-run API contracts, stated once
+      and shared by `review-scope.mjs` and `prior-findings.mjs` (see below).
+- [x] `review-state.mjs` — `agreedReviewedSha` exported so the two-phase caller
+      contract is usable, not just documented. `resolveReviewMode` uses it
+      internally, so the two cannot disagree about which pointer is in play.
+- [x] `review-panel.mjs` — `--head-sha`; `panelEntry` owns the write rule.
+- [x] `agent-review-panel.yml` — scope step, narrowing step, the new flags, and
+      `external_id` on each check run.
+- [x] Both workflows — the inline prior-findings `github-script` replaced by
+      `prior-findings.mjs`. On-demand already had `checks: read` (from #558).
+
+## The two-phase contract, and why it exists
+
+The inputs are circular: `resolveReviewMode` needs git facts about `since..head`,
+and `since` is only knowable after reading the pointers. So `decideScope` asks
+`agreedReviewedSha` first and measures git **only over the range it is about to
+narrow to**.
+
+This is the hazard `resolveReviewMode` cannot detect — it is *handed* the facts, so
+facts measured over a different range would validate one range and narrow another.
+The test asserts it by capturing the argv git receives, not by trusting the shape.
+
+## Where the fail directions differ, on purpose
+
+| step | on failure | why |
+|---|---|---|
+| `Resolve review scope` | tolerated → full review | It only computes. Every internal failure already resolves to `full`; `continue-on-error` covers the class the script cannot catch (module resolution, missing node). A bug in a cost optimiser must not block a PR. |
+| `Narrow the reviewed diff` | **fails the job** | It MUTATES the reviewed artifact. Tolerating a failure between replacing `/tmp/pr.diff` and writing `mode` would hand the panel a narrowed diff with no flag — a lens reviewing a fragment while believing it is the whole PR. `review-panel.mjs` cannot detect that: it receives a file, not a range. |
+| `Read prior findings` | tolerated → carry none | Prior findings can only re-raise a blocker, never clear one. |
+
+The flag and the diff come from the **same step**, which is what makes them
+inseparable. When narrowing does not happen its outputs are empty, the panel gets
+no flag, and the full diff written earlier stands — so the existing diff step is
+left byte-identical to the on-demand workflow's copy of it.
+
+## The write rule is a function
+
+`panelEntry` attaches the pointer only when `valid === true` and the conclusion is
+not `skipped`. Every call site passes `reviewState` unconditionally and the rule
+still holds.
+
+It became a function because the first version was a rule the three `panel.push`
+sites were trusted to follow, guarded by a test that scanned the source for which
+one carried the field. **That test passed** when the pointer was also attached to
+the fail-closed entry by a separate `entry.reviewState = ...` — see the lessons
+file.
+
+## Deduplication, not a third copy
+
+`prior-findings.mjs` and `review-scope.mjs` both need "every check run on this PR's
+commits". That logic carries two contracts this repo has now got wrong twice: the
+list response omits `output.text`, and the object-wrapped check-runs endpoint needs
+`--slurp`. Each failure is silent and reads as "carried 0 findings". They live in
+`gh-checks.mjs` once. `parseArgs` moved there too rather than becoming a fifth copy.
+
+`review-round-guard.mjs` is deliberately **not** refactored onto it: it feeds the
+paging path, and pulling a gate file into this change trades a real risk for a
+cosmetic one.
+
+## Verification
+
+- `agent:tests`: **225 tests** green (was 224 on `main`); `review-scope.test.mjs`
+  is new, `prior-findings.test.mjs` re-pointed at the shared `parseArgs`.
+- `pnpm verify:self` green. Both workflows parse.
+- **`gitFacts` verified against real git**, not only stubs — a wrong flag would
+  yield `null`, resolve to `full`, and be a silent permanent no-op that stubs
+  cannot catch. On `origin/main~4..origin/main`: `isAncestor: true`,
+  `hasMergeInRange: false`, `deltaLines: 4521`; reversed → `isAncestor: false`;
+  a nonexistent sha → all `null`; same sha → `0`.
+- **`review-scope.mjs` run end-to-end against the real API** (PR #581): enumerated
+  its commits, fetched check runs with `--slurp` without a parse error, found no
+  pointers, emitted `mode=full reason=no-prior-state`.
+- **The narrowing path proven with real git** and a stubbed API (we cannot write
+  `external_id` without `checks:write`): default cap → `delta-too-large` on a real
+  1670-line range, raised cap → `incremental` with the correct `since`,
+  `fullEvery: 1` → `periodic-rebaseline`.
+
+What none of this covers: `external_id` actually round-tripping through the checks
+API. Nothing local can write one. **Round 1 after merge will still be `full`
+(`no-prior-state`); round 2 is the first that can narrow** — that is the signal to
+watch, along with the `Review scope:` line in the run summary.
+
+## The #582 interaction, closed rather than noted
+
+Per-lens diff slicing landed while this was in flight, which turned a hypothetical
+into a live one. `lensReviewPlan` can return an empty slice — the PR contains files
+the lens reads, but none changed in this round's delta — so the lens runs **zero
+detection samples** and still produces a valid verdict.
+
+Stamped naively, that pointer would say "this lens has looked at everything up to
+here" when it looked at nothing. The consequence is not the round itself (there was
+nothing in its lane to see) but that `scopeClasses`/`classifyFile` become
+**retroactive**: widening a lens's scope later would apply only to commits after
+the pointer, where today it self-heals because every round re-reads the whole diff.
+
+`panelEntry` therefore requires `ranDetection`, derived from `ok.length > 0` — the
+samples that actually returned — rather than from a flag that could drift. Cost:
+one forced-full round after any round where a lens had an empty slice. That is the
+right trade; the alternative is a permanent, invisible hole.
+
+## Follow-ups, deliberately not here
+
+- `fullEvery = 3` and `maxDeltaLines = 400` still have no data behind them. They
+  are parameters; tune once there are real round counts.
+- A scope digest inside the state would let an empty-slice lens stamp safely, since
+  changing the config would then invalidate the pointer. Only worth it if the
+  forced-full rounds above prove expensive.
+- Surfacing `reason` in the metrics comment as well as the step summary.

--- a/scripts/agent/gh-checks.mjs
+++ b/scripts/agent/gh-checks.mjs
@@ -1,0 +1,123 @@
+// Read a PR's check runs from the GitHub API, correctly.
+//
+// WHY THIS IS A MODULE AND NOT THREE COPIES. Two contracts of the check-runs API
+// are non-obvious, and this repo has now got each of them wrong at least once:
+//
+//   1. `commits/{sha}/check-runs` returns an OBJECT (`{ total_count, check_runs }`),
+//      so plain `gh api --paginate` concatenates raw per-page objects into text
+//      that is NOT valid JSON. `--slurp` wraps each page as an array element
+//      instead, and the caller flattens `check_runs` itself.
+//   2. That list response OMITS or TRUNCATES `output.text`. Reading findings from
+//      it yields nothing for a lens that had many — a truncated payload does not
+//      even fail loudly, it just fails `JSON.parse` and gets skipped.
+//
+// Both were verified the hard way in review-round-guard.mjs, then re-broken in the
+// first draft of prior-findings.mjs. Stating them once is the point of this file:
+// a hand-written third copy is how one of them rots.
+//
+// FAIL DIRECTION. Every read here degrades to less data, never to a throw, and
+// every `catch` is per-commit or per-run so one bad response cannot zero the rest.
+// Both consumers can survive missing data (carry fewer prior findings; fall back
+// to a full review) and neither can survive an outage of the whole panel.
+
+import { execFileSync } from "node:child_process";
+
+/** One `gh api` call, parsed. Injected as `api` in tests. */
+export function gh(args) {
+  return JSON.parse(execFileSync("gh", args, { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }));
+}
+
+/**
+ * `--flag value` pairs plus positionals in `_`, shared by the two CLIs in this
+ * pair rather than copied into each.
+ *
+ * Two properties worth keeping in one place: the accumulator has a NULL prototype,
+ * so `--__proto__ x` writes an ordinary key instead of setting the object's
+ * prototype; and positionals are collected wherever they appear, so argument order
+ * is not load-bearing (reading the PR number from `argv[2]` made a flag-first
+ * invocation fail with a usage error).
+ */
+export function parseArgs(argv) {
+  const a = Object.create(null);
+  const positional = [];
+  for (let i = 2; i < (Array.isArray(argv) ? argv.length : 0); i++) {
+    const v = argv[i];
+    if (typeof v !== "string") continue;
+    if (v.startsWith("--")) { a[v.slice(2)] = argv[i + 1]; i++; } else positional.push(v);
+  }
+  a._ = positional;
+  return a;
+}
+
+/**
+ * Every commit on the PR with its check runs attached: `[{ sha, checkRuns }]`.
+ *
+ * All commits, not just the head: the last completed run for a lens may sit on an
+ * earlier commit if that lens produced no verdict in the most recent round. The
+ * shape matches what `rounds.mjs::groupReviewRounds` consumes, so a caller that
+ * needs a round count can pass this straight through.
+ *
+ * `pulls/{pr}/commits` is a bare-array endpoint, where plain `--paginate` is
+ * correct (same call shape as review-round-guard.mjs's `listAll`). Only the
+ * check-runs endpoint needs `--slurp`.
+ */
+export function prCommitsWithCheckRuns(pr, opts) {
+  const { api = gh, log = console.error } = opts && typeof opts === "object" ? opts : {};
+  let commits;
+  try {
+    commits = api(["api", "--paginate", `repos/{owner}/{repo}/pulls/${pr}/commits?per_page=100`]);
+  } catch (err) {
+    log(`could not list commits for #${pr} (${err.message}); treating the PR as having none.`);
+    return [];
+  }
+  const out = [];
+  for (const c of Array.isArray(commits) ? commits : []) {
+    if (!c?.sha) continue;
+    // PER COMMIT: one unreadable commit costs that commit's runs, not the PR's.
+    try {
+      const pages = api([
+        "api",
+        `repos/{owner}/{repo}/commits/${c.sha}/check-runs?per_page=100`,
+        "--paginate",
+        "--slurp",
+      ]);
+      out.push({ sha: c.sha, checkRuns: (Array.isArray(pages) ? pages : []).flatMap((p) => p?.check_runs ?? []) });
+    } catch (err) {
+      log(`could not read check runs for ${c.sha} (${err.message}); skipping that commit.`);
+      // Still record the commit: `groupReviewRounds` treats a commit with no lens
+      // runs as "not a round", which is the same conclusion it would reach for a
+      // commit that genuinely has none. Dropping it entirely would be identical
+      // here, but keeping it means the caller's commit count stays truthful.
+      out.push({ sha: c.sha, checkRuns: [] });
+    }
+  }
+  return out;
+}
+
+/** Flatten `prCommitsWithCheckRuns` output to a single run list. */
+export function allCheckRuns(commits) {
+  return (Array.isArray(commits) ? commits : []).flatMap((c) => c?.checkRuns ?? []);
+}
+
+/**
+ * Re-fetch each selected run by id so `output.text` is the FULL payload.
+ *
+ * See contract 2 in the header. Bounded at one call per entry (five lenses today).
+ * Per-entry `try`, falling back to the list copy rather than dropping the entry: if
+ * that copy happens to be complete it parses, and if it is truncated the outcome is
+ * the same skip the caller would have reached anyway.
+ */
+export function withFullOutput(byName, opts) {
+  const { api = gh, log = console.error } = opts && typeof opts === "object" ? opts : {};
+  const out = new Map();
+  for (const [name, run] of byName instanceof Map ? byName : Object.entries(byName ?? {})) {
+    out.set(name, run);
+    if (!run?.id) continue;
+    try {
+      out.set(name, api(["api", `repos/{owner}/{repo}/check-runs/${run.id}`]));
+    } catch (err) {
+      log(`could not fetch ${name} in full (${err.message}); using the list copy.`);
+    }
+  }
+  return out;
+}

--- a/scripts/agent/prior-findings.mjs
+++ b/scripts/agent/prior-findings.mjs
@@ -23,9 +23,9 @@
 //
 // Requires the `gh` CLI authenticated via GH_TOKEN / GITHUB_TOKEN.
 
-import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { latestLensRuns } from "./review-state.mjs";
+import { gh, prCommitsWithCheckRuns, allCheckRuns, withFullOutput, parseArgs } from "./gh-checks.mjs";
 
 /**
  * Turn `{ lensCheckName -> check run }` into a flat, lens-tagged findings array.
@@ -76,100 +76,25 @@ export function lensCheckNames(manifest) {
 
 // --- CLI --------------------------------------------------------------------
 
-// Prototype-free accumulator: `--__proto__ x` would otherwise set this object's
-// prototype instead of a key. Also accepts flags before the positional, so
-// argument order is not load-bearing.
-export function parseArgs(argv) {
-  const a = Object.create(null);
-  const positional = [];
-  for (let i = 2; i < (Array.isArray(argv) ? argv.length : 0); i++) {
-    const v = argv[i];
-    if (typeof v !== "string") continue;
-    if (v.startsWith("--")) { a[v.slice(2)] = argv[i + 1]; i++; } else positional.push(v);
-  }
-  a._ = positional;
-  return a;
-}
-
-/** One `gh api` call, parsed. Replaced by a stub in tests — see `collectPrior`. */
-function gh(args) {
-  return JSON.parse(execFileSync("gh", args, { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }));
-}
-
 /**
  * Read every prior round's findings for a PR.
  *
  * `api` is injected — the reason this module exists is that inline YAML JavaScript
  * cannot be tested, and a version whose only API path was reachable exclusively
- * through a real `gh` binary would have kept exactly that problem. The four
- * failure paths below are each covered in prior-findings.test.mjs.
+ * through a real `gh` binary would have kept exactly that problem.
+ *
+ * The two API contracts this depends on (`--slurp` on the object-wrapped
+ * check-runs endpoint; the per-run re-fetch because the list response omits
+ * `output.text`) live in gh-checks.mjs, stated once and shared with
+ * review-scope.mjs. The first draft of this module got both wrong.
  *
  * NEVER throws: worst case it returns []. See `tagPriorFindings` for why the fail
  * direction here is the opposite of the rest of the pipeline.
  */
 export function collectPrior({ pr, names, api = gh, log = console.error }) {
-  // Object-wrapped-array endpoint (`{ total_count, check_runs: [] }`). Plain
-  // `--paginate` concatenates the raw per-page objects, which is NOT valid single
-  // JSON — verified and documented in review-round-guard.mjs, which hit this
-  // first. `--slurp` wraps each page as an array element instead; flatten
-  // `check_runs` across pages ourselves. Without `--slurp`, any commit past one
-  // page of check runs throws.
-  const checkRunsFor = (sha) => {
-    const pages = api(["api", `repos/{owner}/{repo}/commits/${sha}/check-runs?per_page=100`, "--paginate", "--slurp"]);
-    return (Array.isArray(pages) ? pages : []).flatMap((p) => p?.check_runs ?? []);
-  };
-
-  // Re-fetch each SELECTED run so `output.text` is the FULL payload. The list
-  // response omits or truncates it — the inline github-script this replaces does a
-  // per-run `checks.get` for exactly that reason, and review-round-guard.mjs
-  // documents the same contract and back-fills too. Reading the list copy instead
-  // would be worse than useless: a truncated payload fails `JSON.parse`, so a lens
-  // with many findings silently carries ZERO — the #521 false negative this whole
-  // path exists to prevent.
-  //
-  // Bounded at one call per lens (five today). Per-lens `try`, falling back to the
-  // list copy rather than dropping the lens: if that copy is complete it parses,
-  // and if it is truncated the outcome is the same skip.
-  const withFullOutput = (byLens) => {
-    const out = new Map();
-    for (const [name, run] of byLens) {
-      out.set(name, run);
-      if (!run?.id) continue;
-      try {
-        out.set(name, api(["api", `repos/{owner}/{repo}/check-runs/${run.id}`]));
-      } catch (err) {
-        log(`could not fetch ${name} in full (${err.message}); using the list copy.`);
-      }
-    }
-    return out;
-  };
-
-  // Every commit on the PR, not just the head: the last completed run for a lens
-  // may sit on an earlier commit if that lens produced no verdict in the most
-  // recent round. Bare-array endpoint, so plain `--paginate` is correct here (same
-  // call shape as review-round-guard.mjs's `listAll`).
-  let commits;
   try {
-    commits = api(["api", "--paginate", `repos/{owner}/{repo}/pulls/${pr}/commits?per_page=100`]);
-  } catch (err) {
-    // Nothing left to enumerate. Fewer findings, not an outage.
-    log(`Could not list commits for #${pr} (${err.message}); carrying no prior findings.`);
-    return [];
-  }
-  const runs = [];
-  for (const c of Array.isArray(commits) ? commits : []) {
-    if (!c?.sha) continue;
-    // PER COMMIT, so one unreadable commit costs that commit's runs and not the
-    // whole PR's carry-forward. An older run then speaks for the lens, which is
-    // still additive; a panel-wide zero would not be.
-    try {
-      runs.push(...checkRunsFor(c.sha));
-    } catch (err) {
-      log(`could not read check runs for ${c.sha} (${err.message}); skipping that commit.`);
-    }
-  }
-  try {
-    return tagPriorFindings(withFullOutput(latestLensRuns(runs, names)));
+    const runs = allCheckRuns(prCommitsWithCheckRuns(pr, { api, log }));
+    return tagPriorFindings(withFullOutput(latestLensRuns(runs, names), { api, log }));
   } catch (err) {
     log(`Could not assemble prior findings (${err.message}); carrying none.`);
     return [];

--- a/scripts/agent/prior-findings.test.mjs
+++ b/scripts/agent/prior-findings.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { tagPriorFindings, lensCheckNames, parseArgs, collectPrior } from "./prior-findings.mjs";
+import { tagPriorFindings, lensCheckNames, collectPrior } from "./prior-findings.mjs";
+import { parseArgs } from "./gh-checks.mjs";
 
 const NAMES = ["agent-review-correctness", "agent-review-security"];
 

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -18,10 +18,17 @@
 //        [--repo <dir>] [--lenses-dir <dir>] [--out <dir>]
 //        [--prior-findings <f>]
 //        [--review-mode full|incremental] [--since-sha <sha>] [--base-sha <sha>]
-// `--review-mode` defaults to `full`, so a caller passing none of the last three
-// behaves exactly as before. The MODE IS NOT DECIDED HERE — this script has no
-// git or API access by design; the caller resolves it via `resolveReviewMode`
-// in review-state.mjs and passes the answer in.
+//        [--head-sha <sha>]
+// `--review-mode` defaults to `full`, so a caller passing none of these behaves
+// exactly as before. The MODE IS NOT DECIDED HERE — this script has no GitHub API
+// access by design, and the mode depends on each lens's last-reviewed pointer in
+// the checks API. `review-scope.mjs` resolves it (via `resolveReviewMode` in
+// review-state.mjs) and passes the answer in. `--head-sha` is what this run
+// stamps back as that pointer; omitted, nothing is stamped.
+//
+// It does now reach git INDIRECTLY: novelty.mjs runs `git blame`/`git grep` in
+// this process to date each finding against `--base-sha`. So "no git access" is no
+// longer the reason the mode lives elsewhere — the API is.
 // Outputs under <out> (default .agent-review):
 //   <out>/<lens>/verdict.json + summary.md   and   <out>/panel.json + panel-summary.md
 //
@@ -37,7 +44,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { classify, renderSummaryMd, BLOCKING, normalizeSeverity, KNOWN } from "./severity.mjs";
 import { askStructured, withRetry } from "./ask.mjs";
-import { renderScopeNote } from "./review-state.mjs";
+import { renderScopeNote, serializeReviewState } from "./review-state.mjs";
 import { CITATION } from "./citation.mjs";
 import { findingLocation, noveltyOf, baseResolves, DEMOTING_ORIGINS } from "./novelty.mjs";
 
@@ -669,6 +676,24 @@ export function resolveReviewScope(args, changedFiles) {
     baseSha: a["base-sha"],
     changedFiles,
   });
+  // The pointer the workflow stamps on every lens check run that produces a REAL
+  // verdict, so the next round can narrow to what this round reviewed. Serialized
+  // here rather than in the workflow's `github-script` step for two reasons: that
+  // step cannot import an ES module, and `serializeReviewState` refuses to emit
+  // junk — a guarantee worth having on the value that decides whether code gets
+  // reviewed at all.
+  //
+  // Computed ONCE (it is identical for every lens) and up front, so a malformed
+  // `--head-sha` fails before the panel spends a single token rather than after.
+  // Absent `--head-sha` means "do not stamp", which is exactly today's behaviour.
+  const stateExternalId = a["head-sha"]
+    ? serializeReviewState({
+        reviewed: a["head-sha"],
+        base: a["base-sha"],
+        since: reviewMode === "incremental" ? a["since-sha"] : "",
+        mode: reviewMode,
+      })
+    : "";
   if (reviewMode === "incremental" && scopeNote === "") {
     throw new Error(
       "--review-mode incremental requires a valid 40-hex --since-sha; refusing to " +
@@ -682,7 +707,54 @@ export function resolveReviewScope(args, changedFiles) {
         "Refusing to guess (failing closed).",
     );
   }
-  return { reviewMode, scopeNote };
+  return { reviewMode, scopeNote, stateExternalId };
+}
+
+/**
+ * One panel.json entry, and the ONE place the review-state write rule lives.
+ *
+ * A lens may hand back a pointer only if it actually produced a verdict:
+ * `valid === true` and a conclusion the workflow does not map to `neutral`. A
+ * crashed, quota-failed, skipped or inapplicable lens stamps nothing, so the next
+ * round finds a state gap for it and reviews the full diff. Coverage is proven by
+ * the presence of a pointer rather than asserted next to it.
+ *
+ * This is a FUNCTION rather than a rule the call sites are trusted to follow,
+ * because the first version of it was exactly that — three `panel.push` sites, the
+ * pointer spread into one of them, and a test that scanned the source for which
+ * push carried it. That test passed when the pointer was ALSO attached to the
+ * fail-closed path by a separate assignment: it was watching the syntax it
+ * expected, not the property. Every caller may now pass `reviewState`
+ * unconditionally and the rule still holds.
+ */
+export function panelEntry(lens, { blocking, applicable, conclusion, valid, reviewState, infraError, ranDetection }) {
+  const stamps =
+    valid === true &&
+    conclusion !== "skipped" &&
+    // `ranDetection` must be explicitly true. A lens can now produce a valid
+    // verdict having run ZERO detection samples: `lensReviewPlan` returns
+    // `{ skip: null, diff: "" }` when the PR contains files it reads but none
+    // changed in THIS round's delta, and the round then rests entirely on the
+    // prior-finding re-check. Such a lens must NOT advance its pointer, because
+    // the pointer's whole meaning is "this lens has looked at everything up to
+    // here". Letting it advance would make `scopeClasses`/`classifyFile`
+    // retroactive: widening a lens's scope later would apply only to commits
+    // after the pointer, where today it self-heals because every round re-reads
+    // the full diff. Not stamping costs one forced-full round; stamping costs a
+    // permanent, invisible hole.
+    ranDetection === true &&
+    typeof reviewState === "string" &&
+    reviewState !== "";
+  return {
+    id: lens.id,
+    title: lens.title,
+    blocking,
+    applicable,
+    conclusion,
+    valid,
+    ...(infraError ? { infraError } : {}),
+    ...(stamps ? { reviewState } : {}),
+  };
 }
 
 /**
@@ -1189,7 +1261,7 @@ async function main() {
   const changedFiles = args["changed-files"] && existsSync(args["changed-files"])
     ? readFileSync(args["changed-files"], "utf8").split("\n").map((s) => s.trim()).filter(Boolean)
     : [];
-  const { reviewMode, scopeNote } = resolveReviewScope(args, changedFiles);
+  const { reviewMode, scopeNote, stateExternalId } = resolveReviewScope(args, changedFiles);
   if (reviewMode === "incremental") console.log(`review scope: incremental since ${args["since-sha"]}`);
   // ONE source of truth for the changed-file trust decision, shared by the
   // verifier prompt (which grounds it may offer) and the gate (which grounds it
@@ -1266,7 +1338,9 @@ async function main() {
     const plan = lensReviewPlan(lens, changedFiles, fileBlocks);
     if (plan.skip) {
       writeVerdict(lensOut, lens, [], plan.skip, { valid: true, conclusion: "skipped" });
-      panel.push({ id: lens.id, title: lens.title, blocking, applicable: false, conclusion: "skipped", valid: true });
+      panel.push(panelEntry(lens, {
+        blocking, applicable: false, conclusion: "skipped", valid: true, reviewState: stateExternalId,
+      }));
       return;
     }
     const lensDiff = plan.diff;
@@ -1331,9 +1405,10 @@ async function main() {
       // reconciling.
       const failFindings = [{ severity: "major", summary: summaryText }];
       writeVerdict(lensOut, lens, failFindings, infra ? "(review did not run — infrastructure/quota error)" : "(no valid verdict — failing closed)", { valid: false });
-      const entry = { id: lens.id, title: lens.title, blocking, applicable: true, conclusion: "failure", valid: false };
-      if (infra) entry.infraError = infra;
-      panel.push(entry);
+      panel.push(panelEntry(lens, {
+        blocking, applicable: true, conclusion: "failure", valid: false,
+        infraError: infra, reviewState: stateExternalId,
+      }));
       lensStats.push({
         id: lens.id,
         samplesRun: samples,
@@ -1433,7 +1508,19 @@ async function main() {
       advisory: !blocking,
       gating,
     });
-    panel.push({ id: lens.id, title: lens.title, blocking, applicable: true, conclusion, valid: true });
+    // Every site passes `reviewState` unconditionally; `panelEntry` decides whether
+    // it survives. This is the only site where it can, and only when this lens
+    // actually ran a detection pass.
+    //
+    // `ok.length > 0` rather than `!noNewHunks`, though the two coincide: this is
+    // the count of samples that actually returned a verdict, so it is derived from
+    // the work done rather than from a flag that could drift away from it. (An
+    // all-samples-failed round never reaches here — it throws to the fail-closed
+    // catch above, which stamps nothing either.)
+    panel.push(panelEntry(lens, {
+      blocking, applicable: true, conclusion, valid: true,
+      reviewState: stateExternalId, ranDetection: ok.length > 0,
+    }));
   }));
 
   mkdirSync(outDir, { recursive: true });

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -36,6 +36,7 @@ import {
   claimTypeOf,
   VERIFIER_MAX_TURNS,
   buildVerifierPrompt,
+  panelEntry,
 } from "./review-panel.mjs";
 import { classify, normalizeSeverity } from "./severity.mjs";
 
@@ -219,18 +220,118 @@ test("resolveReviewScope: refuses a half-wired incremental invocation, both dire
   assert.match(ok.scopeNote, new RegExp(SHA.slice(0, 12)));
 });
 
-// The scope note reaches the model only if main() threads it through runLens.
-// Neither is executable without opening an SDK session, so this stays a source
-// assertion — narrowed to the plumbing, with the prompt SHAPE now covered by the
-// rendered tests above.
-test("main() threads the resolved scope note into runLens", () => {
+// The pointer this run stamps back, so the NEXT round knows what was reviewed.
+// Serialized here rather than in the workflow's github-script step because that
+// step cannot import an ES module and `serializeReviewState` refuses to emit junk.
+test("resolveReviewScope: stamps a pointer only when --head-sha is given", () => {
+  const HEAD = "a".repeat(40), BASE = "b".repeat(40), SINCE = "c".repeat(40);
+  // No --head-sha = today's behaviour: nothing is stamped, so no round can narrow.
+  assert.equal(resolveReviewScope({}, []).stateExternalId, "");
+  assert.equal(resolveReviewScope({ "base-sha": BASE }, []).stateExternalId, "");
+
+  const full = resolveReviewScope({ "head-sha": HEAD, "base-sha": BASE }, []);
+  assert.deepEqual(JSON.parse(full.stateExternalId),
+    { v: 1, reviewed: HEAD, base: BASE, since: "", mode: "full" });
+
+  const inc = resolveReviewScope(
+    { "head-sha": HEAD, "base-sha": BASE, "since-sha": SINCE, "review-mode": "incremental" }, []);
+  assert.deepEqual(JSON.parse(inc.stateExternalId),
+    { v: 1, reviewed: HEAD, base: BASE, since: SINCE, mode: "incremental" });
+
+  // A malformed --head-sha must fail BEFORE the panel spends a token, not after —
+  // and it must not silently stamp nothing, which would disable narrowing forever
+  // with no signal.
+  assert.throws(() => resolveReviewScope({ "head-sha": "nope" }, []), /'reviewed' must be a 40-hex sha/);
+  assert.throws(() => resolveReviewScope({ "head-sha": HEAD, "base-sha": "nope" }, []), /'base'/);
+});
+
+// The scope note reaches the model only if main() threads it through runLens, and
+// neither is executable without opening an SDK session. So this stays a source
+// assertion — but on the PROPERTIES, not on a literal destructuring: the first
+// version pinned `const { reviewMode, scopeNote } = ...` and broke the moment a
+// third field was added, which is a test failing for its own formatting rather
+// than for the behaviour it guards.
+test("main() threads the resolved scope through runLens", () => {
   const src = readFileSync(path.join(HERE, "review-panel.mjs"), "utf8");
-  assert.match(src, /const \{ reviewMode, scopeNote \} = resolveReviewScope\(args, changedFiles\)/,
-    "main() must resolve the scope through the tested helper");
+  const call = /const \{([^}]*)\} = resolveReviewScope\(args, changedFiles\)/.exec(src);
+  assert.ok(call, "main() must resolve the scope through the tested helper");
+  for (const field of ["reviewMode", "scopeNote", "stateExternalId"]) {
+    assert.ok(call[1].includes(field), `main() must take ${field} from resolveReviewScope`);
+  }
   assert.match(src, /runLens\(lens, \{[^}]*scopeNote[^}]*\}\)/,
     "runLens must receive scopeNote, or incremental mode reviews a fragment silently");
   assert.match(src, /prompt: buildLensPrompt\(lens, \{[^}]*scopeNote[^}]*\}\)/,
     "runLens must pass scopeNote on to the prompt builder");
+  // Every panel entry must be built by panelEntry, which is what makes the
+  // write-rule test below binding. An entry assembled inline could carry a pointer
+  // the rule would have stripped.
+  assert.equal((src.match(/panel\.push\(/g) ?? []).length, (src.match(/panel\.push\(panelEntry\(/g) ?? []).length,
+    "every panel.push must go through panelEntry, or the write rule is bypassable");
+  // PLUMBING, not the rule — the rule is executed in the panelEntry test below.
+  // `ranDetection` must be derived from samples that actually returned, never
+  // hardcoded: a literal `true` here would stamp a pointer for a lens that ran no
+  // detection pass, and no test can execute main() to catch that.
+  assert.match(src, /ranDetection: ok\.length > 0/,
+    "ranDetection must be derived from the samples that ran, not asserted");
+});
+
+// THE WRITE RULE, executed. A lens that did not produce a verdict must not hand
+// back a last-reviewed pointer: the next round would narrow past commits nothing
+// actually looked at, and `resolveReviewMode` cannot detect that because a pointer
+// being present IS its evidence of coverage.
+//
+// This replaced a source scan that asserted which `panel.push` carried the field.
+// That scan passed while the pointer was also attached to the fail-closed entry by
+// a separate `entry.reviewState = ...` — it watched the syntax it expected instead
+// of the property, the same defect as the mis-aimed clamp guard on #574.
+test("panelEntry: only a real verdict carries a review-state pointer", () => {
+  const lens = { id: "correctness", title: "Correctness" };
+  const PTR = '{"v":1,"reviewed":"a"}';
+  const entry = (over) => panelEntry(lens, { blocking: true, reviewState: PTR, ranDetection: true, ...over });
+
+  // The one case that stamps.
+  assert.equal(entry({ applicable: true, conclusion: "success", valid: true }).reviewState, PTR);
+  // A FAILING verdict still stamps: the lens did review the code, and its findings
+  // are preserved by carry-forward. Not stamping here would force a full round
+  // after every round that found something — i.e. never narrow on a real PR.
+  assert.equal(entry({ applicable: true, conclusion: "failure", valid: true }).reviewState, PTR);
+
+  for (const [why, over] of [
+    ["a crashed or quota-failed lens", { applicable: true, conclusion: "failure", valid: false }],
+    ["an invalid success", { applicable: true, conclusion: "success", valid: false }],
+    ["an inapplicable lens", { applicable: false, conclusion: "skipped", valid: true }],
+    ["a lens skipped for any reason", { applicable: true, conclusion: "skipped", valid: true }],
+    // THE #582 INTERACTION. `lensReviewPlan` can return `{ skip: null, diff: "" }`:
+    // the PR contains files this lens reads, but none changed in this round's
+    // delta, so it runs ZERO detection samples and the round rests on the prior
+    // re-check alone. That is a valid verdict — and it must not advance the
+    // pointer, whose meaning is "this lens has looked at everything up to here".
+    // Advancing it would make scopeClasses/classifyFile retroactive: widening a
+    // lens's scope later would apply only to commits after the pointer, where
+    // today it self-heals because every round re-reads the whole diff.
+    ["a lens that ran no detection pass (empty slice)", { applicable: true, conclusion: "success", valid: true, ranDetection: false }],
+    ["ranDetection left unset", { applicable: true, conclusion: "success", valid: true, ranDetection: undefined }],
+    ["ranDetection merely truthy", { applicable: true, conclusion: "success", valid: true, ranDetection: 1 }],
+  ]) {
+    assert.ok(!("reviewState" in entry(over)), `${why} must not stamp a pointer`);
+  }
+  // No pointer to stamp (no --head-sha) is today's behaviour, on every path.
+  for (const bad of [undefined, null, "", 7, {}]) {
+    assert.ok(!("reviewState" in panelEntry(lens, {
+      blocking: true, applicable: true, conclusion: "success", valid: true, ranDetection: true, reviewState: bad,
+    })), `reviewState=${JSON.stringify(bad)} must not be stamped`);
+  }
+  // infraError still rides along only when present — the field the fix job pages on.
+  assert.equal(entry({ applicable: true, conclusion: "failure", valid: false, infraError: "429" }).infraError, "429");
+  assert.ok(!("infraError" in entry({ applicable: true, conclusion: "success", valid: true })));
+
+  // RESIDUAL, stated rather than guarded: the only remaining way to stamp from a
+  // non-verdict path is to also claim `valid: true` for a lens that crashed. That
+  // is not a loophole in this rule — `valid` is the same field the workflow feeds
+  // to `all_valid`, which makes review-round-guard.mjs page ("a review lens did
+  // not produce a valid verdict"). Tying the pointer to the validity claim is the
+  // point: you cannot stamp without asserting a verdict, and asserting a verdict
+  // that did not happen breaks something louder than narrowing.
 });
 
 // Injection framing must cover the WORKING TREE, not just the diff. Every lens

--- a/scripts/agent/review-scope.mjs
+++ b/scripts/agent/review-scope.mjs
@@ -1,0 +1,252 @@
+// Decide whether THIS review round may look at only the delta, and hand the
+// answer to the workflow as step outputs.
+//
+// This is the caller `review-state.mjs` was written for. It owns the two things
+// that module deliberately cannot do: read each lens's last-reviewed pointer from
+// the checks API, and measure the commit range with git. `resolveReviewMode` then
+// makes the decision, purely, from those facts.
+//
+// Usage:
+//   node review-scope.mjs <pr> --head <sha> --lenses <lenses.json>
+//                              --changed-files <f> [--repo <dir>]
+//                              [--full-every N] [--max-delta-lines N]
+//
+// Outputs (appended to $GITHUB_OUTPUT when set, always logged):
+//   mode=full|incremental   since=<sha40 or empty>   reason=<why>   rounds=<n>
+//
+// FAIL DIRECTION — the whole file. This ALWAYS exits 0 with a usable mode, and
+// EVERY failure path resolves to `mode=full`. Unlike the rest of the pipeline,
+// failing closed here would be wrong: a full review is always correct, merely more
+// expensive, so there is no reason for a cost optimiser to be able to take the
+// panel down. A bad argument, an unreachable API, a shallow clone and an outright
+// crash all produce the same safe answer, distinguished only by `reason`.
+//
+// TWO-PHASE, because the inputs are circular: the git facts must be measured over
+// `since..head`, and `since` is only knowable after reading the pointers. So we ask
+// `agreedReviewedSha` first, and only measure git when there is a range to measure.
+//
+// Requires the `gh` CLI authenticated via GH_TOKEN / GITHUB_TOKEN, and a checkout
+// with enough history for `merge-base --is-ancestor` (the panel job uses
+// `fetch-depth: 0`).
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { appendFileSync, readFileSync } from "node:fs";
+import { agreedReviewedSha, resolveReviewMode, latestLensRuns } from "./review-state.mjs";
+import { gh, prCommitsWithCheckRuns, allCheckRuns, parseArgs } from "./gh-checks.mjs";
+import { lensApplies } from "./review-panel.mjs";
+import { groupReviewRounds } from "./rounds.mjs";
+
+const execFileAsync = promisify(execFile);
+const SHA = /^[0-9a-fA-F]{40}$/;
+// Same ceiling as novelty.mjs's git probes. These four commands are cheap; a
+// repository state that makes one hang is one we should stop waiting for and
+// review in full.
+const GIT_TIMEOUT_MS = 10_000;
+
+/**
+ * One git command. `status` is carried out separately from `ok` because git uses
+ * the exit code as an ANSWER for some commands (`--is-ancestor` 1 = "no") and as
+ * an ERROR for the rest. Collapsing them would record a broken lookup as a
+ * confident answer — the same distinction novelty.mjs draws, for the same reason.
+ *
+ * Deliberately a local copy rather than an import from novelty.mjs: that module is
+ * a gate (it decides whether a finding blocks), and widening its exports for an
+ * unrelated consumer couples the two. The shared `gh` calls in gh-checks.mjs are
+ * deduplicated because getting those wrong is SILENT; getting this wrong yields
+ * `null`, which resolves to `full`.
+ */
+async function git(args, repo) {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd: repo,
+      timeout: GIT_TIMEOUT_MS,
+      maxBuffer: 32 * 1024 * 1024,
+      encoding: "utf8",
+    });
+    return { ok: true, status: 0, stdout };
+  } catch (e) {
+    return { ok: false, status: typeof e?.code === "number" ? e.code : null, stdout: "" };
+  }
+}
+
+/**
+ * The three git facts `resolveReviewMode` needs about `since..head`.
+ *
+ * Any fact this cannot establish comes back `null`, which `resolveReviewMode`
+ * reads as `git-facts-unavailable` and resolves to `full`. `run` is injected so
+ * every branch below is testable without building repositories.
+ *
+ * `deltaLines` is `null` — not 0 — when a numstat row is non-numeric (a binary
+ * file). Counting binary changes as zero lines would UNDER-count the delta, and
+ * since the delta size is an upper bound that permits narrowing, under-counting is
+ * the fail-open direction.
+ */
+export async function gitFacts({ since, head, repo, run = git }) {
+  const unknown = { isAncestor: null, hasMergeInRange: null, deltaLines: null };
+  if (typeof since !== "string" || !SHA.test(since)) return unknown;
+  if (typeof head !== "string" || !SHA.test(head)) return unknown;
+
+  // Does the pointer still name a commit here? A pointer that does not resolve is
+  // a rewritten or garbage-collected history, and every fact below would be
+  // meaningless.
+  if (!(await run(["cat-file", "-e", `${since}^{commit}`], repo)).ok) return unknown;
+
+  const anc = await run(["merge-base", "--is-ancestor", since, head], repo);
+  // 0 = yes, 1 = git's ANSWER ("no", i.e. force-push/rebase/amend), anything else
+  // = the lookup broke and must not read as a confident "no".
+  const isAncestor = anc.status === 0 ? true : anc.status === 1 ? false : null;
+  if (isAncestor === null) return unknown;
+
+  const merges = await run(["rev-list", "--merges", `${since}..${head}`], repo);
+  if (!merges.ok) return unknown;
+  const hasMergeInRange = merges.stdout.trim() !== "";
+
+  const stat = await run(["diff", "--numstat", since, head], repo);
+  if (!stat.ok) return unknown;
+  let deltaLines = 0;
+  for (const line of stat.stdout.split("\n")) {
+    if (line.trim() === "") continue;
+    const [added, deleted] = line.split("\t");
+    const a = Number(added), d = Number(deleted);
+    if (!Number.isFinite(a) || !Number.isFinite(d)) return { isAncestor, hasMergeInRange, deltaLines: null };
+    deltaLines += a + d;
+  }
+  return { isAncestor, hasMergeInRange, deltaLines };
+}
+
+/**
+ * Lens ids that will actually review this round, from the manifest and the
+ * CUMULATIVE changed-file list.
+ *
+ * Only these are required to have a pointer. Including a lens that is not running
+ * would demand state it never wrote, so every round would report `lens-state-gap`
+ * and nothing would ever narrow. Applicability is monotonic in the cumulative list,
+ * and a lens that becomes applicable later has no pointer — which forces `full`,
+ * so it reads a whole diff before it can ever narrow.
+ *
+ * Advisory (non-blocking) lenses are included: gating is not the question here.
+ * They read the same reviewed artifact, so narrowing hides code from them too.
+ */
+export function reviewingLensIds(manifest, changedFiles) {
+  return (Array.isArray(manifest) ? manifest : [])
+    .filter((l) => l && typeof l.id === "string" && l.id !== "")
+    .filter((l) => lensApplies(l, Array.isArray(changedFiles) ? changedFiles : []))
+    .map((l) => l.id);
+}
+
+/**
+ * The whole decision, with the API and git injected. Exported so the TWO-PHASE
+ * composition is executed by tests, not just its parts: the hazard this shape
+ * exists to avoid is measuring git over one range and narrowing to another, and
+ * `resolveReviewMode` cannot detect that — it is handed the facts.
+ *
+ * Never throws; every failure is a `full` decision with a naming `reason`.
+ */
+export async function decideScope(opts) {
+  const {
+    pr, head, manifest, changedFiles, repo,
+    fullEvery = 3, maxDeltaLines = 400,
+    api = gh, run = git, log = console.error,
+  } = opts && typeof opts === "object" ? opts : {};
+  const full = (reason, rounds = 0) => ({ mode: "full", sinceSha: "", reason, rounds });
+
+  if (!/^\d+$/.test(String(pr ?? "")) || typeof head !== "string" || !SHA.test(head)) {
+    log(`review-scope: need a PR number and a 40-hex head (got pr=${JSON.stringify(pr)}, head=${JSON.stringify(head)}).`);
+    return full("invalid-input");
+  }
+  const lensIds = reviewingLensIds(manifest, changedFiles);
+  const lensCheckNames = lensIds.map((id) => `agent-review-${id}`);
+
+  const commits = prCommitsWithCheckRuns(pr, { api, log });
+  // The round count drives the periodic full rebaseline. `groupReviewRounds` needs
+  // no `output.text` to COUNT rounds (a commit with any lens run is a round,
+  // `partial` or not), so no per-run back-fill is paid for here.
+  const rounds = groupReviewRounds(commits, lensCheckNames).length;
+  // The pointer lives in `external_id`; `resolveReviewMode` parses and validates it.
+  const states = new Map(
+    [...latestLensRuns(allCheckRuns(commits), lensCheckNames)].map(([name, r]) => [name, r?.external_id]),
+  );
+
+  // Phase 1: is there a range at all? Measuring git before knowing `since` would
+  // measure the wrong range — see the caller contract on `resolveReviewMode`.
+  const agreed = agreedReviewedSha(lensIds, states);
+  if (!agreed.sha) {
+    log(`review-scope: no usable prior pointer (${agreed.reason}).`);
+    return full(agreed.reason, rounds);
+  }
+
+  // Phase 2: measure exactly `agreed.sha..head`, then decide.
+  const facts = await gitFacts({ since: agreed.sha, head, repo, run });
+  const decision = resolveReviewMode({
+    lensIds, states, headSha: head, roundIndex: rounds, fullEvery, maxDeltaLines, ...facts,
+  });
+  log(
+    `review-scope: ${decision.mode} (${decision.reason}) — round ${rounds}, ${lensIds.length} lens(es), ` +
+      `delta ${facts.deltaLines ?? "?"} lines since ${agreed.sha.slice(0, 12)}`,
+  );
+  return { ...decision, rounds };
+}
+
+function readLines(file) {
+  try {
+    return readFileSync(file, "utf8").split("\n").map((s) => s.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function setOutput(name, value) {
+  const line = `${name}=${value}`;
+  console.error(`  ${line}`);
+  if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `${line}\n`);
+}
+
+function emit({ mode, sinceSha, reason, rounds }) {
+  // `since` is only ever non-empty for `incremental`, and the workflow keys the
+  // narrowed `git diff` off `mode`. Emitting both keeps the pair inseparable:
+  // review-panel.mjs REFUSES `--since-sha` without `--review-mode incremental`
+  // and vice versa, so a half-passed pair fails the panel loudly rather than
+  // reviewing a fragment as if it were the whole PR.
+  setOutput("mode", mode);
+  setOutput("since", mode === "incremental" ? sinceSha : "");
+  setOutput("reason", reason);
+  setOutput("rounds", String(rounds ?? 0));
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const num = (v, dflt) => {
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0 ? n : dflt;
+  };
+  let manifest = null;
+  try {
+    manifest = JSON.parse(readFileSync(args.lenses, "utf8"));
+  } catch (err) {
+    // Left null, so `reviewingLensIds` yields no lenses and the decision is
+    // `invalid-input` → full. Logged, because "we never narrowed" and "we narrowed
+    // and it saved nothing" look identical from the outside otherwise.
+    console.error(`review-scope: could not read --lenses '${args.lenses}' (${err.message}).`);
+  }
+  emit(
+    await decideScope({
+      pr: args._[0],
+      head: typeof args.head === "string" ? args.head.trim() : "",
+      manifest,
+      changedFiles: readLines(args["changed-files"]),
+      repo: args.repo || process.cwd(),
+      fullEvery: num(args["full-every"], 3),
+      maxDeltaLines: num(args["max-delta-lines"], 400),
+    }),
+  );
+}
+
+// A crash must not take the panel down: report `full` and exit 0. There is no
+// failure of this script that a full review does not correctly absorb.
+if (process.argv[1] && process.argv[1].endsWith("review-scope.mjs")) {
+  main().catch((err) => {
+    console.error(`review-scope: crashed (${err.message}) — reviewing in full.`);
+    emit({ mode: "full", sinceSha: "", reason: "scope-error", rounds: 0 });
+  });
+}

--- a/scripts/agent/review-scope.test.mjs
+++ b/scripts/agent/review-scope.test.mjs
@@ -1,0 +1,254 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { gitFacts, reviewingLensIds, decideScope } from "./review-scope.mjs";
+import { serializeReviewState } from "./review-state.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+const quiet = () => {};
+
+// --- gitFacts ---------------------------------------------------------------
+
+// A stubbed runner keyed by the first two argv words, so each branch is exercised
+// without building repositories. `ok`/`status` are kept distinct because git uses
+// the exit code as an ANSWER for `--is-ancestor` and as an ERROR elsewhere.
+const runner = (over = {}) => async (args) => {
+  const key = args.slice(0, 2).join(" ");
+  if (key in over) return over[key];
+  if (key === "cat-file -e") return { ok: true, status: 0, stdout: "" };
+  if (key === "merge-base --is-ancestor") return { ok: true, status: 0, stdout: "" };
+  if (key === "rev-list --merges") return { ok: true, status: 0, stdout: "" };
+  if (key === "diff --numstat") return { ok: true, status: 0, stdout: "10\t5\tsrc/a.ts\n1\t0\tsrc/b.ts\n" };
+  throw new Error(`unstubbed git ${key}`);
+};
+
+test("gitFacts: the happy path sums added+deleted across the numstat", async () => {
+  assert.deepEqual(await gitFacts({ since: A, head: B, run: runner() }),
+    { isAncestor: true, hasMergeInRange: false, deltaLines: 16 });
+});
+
+test("gitFacts: exit 1 from --is-ancestor is an ANSWER; any other failure is not", async () => {
+  // 1 = "no", i.e. force-push / rebase / amend. This must be reported as a
+  // confident false so resolveReviewMode can say force-push-or-rewrite.
+  const forced = await gitFacts({ since: A, head: B, run: runner({ "merge-base --is-ancestor": { ok: false, status: 1, stdout: "" } }) });
+  assert.equal(forced.isAncestor, false);
+  // Any other status, or none (spawn failure / timeout), is a BROKEN LOOKUP.
+  // Recording it as a confident "no" would name the wrong reason; null → unavailable.
+  for (const status of [128, 2, null]) {
+    const got = await gitFacts({ since: A, head: B, run: runner({ "merge-base --is-ancestor": { ok: false, status, stdout: "" } }) });
+    assert.equal(got.isAncestor, null, `status ${status} must not be a confident answer`);
+  }
+});
+
+test("gitFacts: an unresolvable pointer makes every fact unknown", async () => {
+  // A pointer that no longer names a commit (rewritten or gc'd history) makes
+  // every measurement below it meaningless, so none is attempted.
+  const got = await gitFacts({ since: A, head: B, run: runner({ "cat-file -e": { ok: false, status: 1, stdout: "" } }) });
+  assert.deepEqual(got, { isAncestor: null, hasMergeInRange: null, deltaLines: null });
+  // Junk shas never reach git at all.
+  for (const bad of [undefined, null, "", "abc", 7, A.slice(0, 39)]) {
+    assert.deepEqual(await gitFacts({ since: bad, head: B, run: runner() }),
+      { isAncestor: null, hasMergeInRange: null, deltaLines: null }, `since=${JSON.stringify(bad)}`);
+    assert.deepEqual(await gitFacts({ since: A, head: bad, run: runner() }),
+      { isAncestor: null, hasMergeInRange: null, deltaLines: null }, `head=${JSON.stringify(bad)}`);
+  }
+});
+
+test("gitFacts: a merge in range is reported; a failed rev-list is not 'no merges'", async () => {
+  const merged = await gitFacts({ since: A, head: B, run: runner({ "rev-list --merges": { ok: true, status: 0, stdout: `${B}\n` } }) });
+  assert.equal(merged.hasMergeInRange, true);
+  const broken = await gitFacts({ since: A, head: B, run: runner({ "rev-list --merges": { ok: false, status: 128, stdout: "" } }) });
+  assert.equal(broken.hasMergeInRange, null, "a broken lookup must not read as 'no merges'");
+});
+
+test("gitFacts: a binary row makes deltaLines unknown, never zero", async () => {
+  // numstat prints `-\t-` for binary files. Counting that as 0 lines UNDER-counts
+  // the delta, and the delta size is an upper bound that PERMITS narrowing — so
+  // under-counting is the fail-open direction. null → full.
+  const got = await gitFacts({ since: A, head: B, run: runner({ "diff --numstat": { ok: true, status: 0, stdout: "-\t-\timg.png\n" } }) });
+  assert.equal(got.deltaLines, null);
+  // An empty numstat is a real zero, not a failure.
+  const empty = await gitFacts({ since: A, head: B, run: runner({ "diff --numstat": { ok: true, status: 0, stdout: "\n" } }) });
+  assert.equal(empty.deltaLines, 0);
+  const failed = await gitFacts({ since: A, head: B, run: runner({ "diff --numstat": { ok: false, status: 128, stdout: "" } }) });
+  assert.equal(failed.deltaLines, null);
+});
+
+// --- reviewingLensIds -------------------------------------------------------
+
+test("reviewingLensIds: only lenses that will actually review, from the REAL manifest", () => {
+  const manifest = JSON.parse(readFileSync(path.join(HERE, "lenses", "lenses.json"), "utf8"));
+  // Requiring a pointer from a lens that is not running would report
+  // `lens-state-gap` every round, so nothing would ever narrow and nothing would
+  // say why. So this must track `appliesWhen` exactly — asserted here on the two
+  // concrete directions rather than by re-deriving it, which would be tautological.
+  const code = reviewingLensIds(manifest, ["packages/sheets/src/index.ts"]);
+  const docs = reviewingLensIds(manifest, ["docs/tasks/active/x-todo.md"]);
+
+  // Wildcard lenses run on everything, so both sets are non-empty.
+  for (const set of [code, docs]) {
+    for (const id of ["correctness", "security"]) {
+      assert.ok(set.includes(id), `${id} is wildcard-scoped and must always be reviewing`);
+    }
+  }
+  // Each set EXCLUDES the other's scoped lenses — the property that makes the
+  // pointer requirement match reality.
+  for (const id of ["test-adequacy", "blast-radius"]) {
+    assert.ok(code.includes(id), `${id} must review a code change`);
+    assert.ok(!docs.includes(id), `${id} must not be required to have reviewed a docs-only change`);
+  }
+  assert.ok(docs.includes("docs"), "the docs lens must review a markdown change");
+  assert.ok(!code.includes("docs"), "the docs lens must not be required for a .ts-only change");
+  // Both are strict subsets, so neither direction silently degenerates to "all".
+  for (const [name, set] of [["code", code], ["docs", docs]]) {
+    assert.ok(set.length < manifest.length, `${name} should be a strict subset, got ${set.join(",")}`);
+  }
+  // Junk in, empty out — never a throw.
+  for (const bad of [null, undefined, "x", 7, {}]) assert.deepEqual(reviewingLensIds(bad, ["a.ts"]), []);
+  assert.deepEqual(reviewingLensIds([{ id: "" }, {}, null], ["a.ts"]), []);
+});
+
+// --- decideScope: the two-phase composition ---------------------------------
+
+const MANIFEST = [
+  { id: "correctness", gating: "blocking", appliesWhen: ["**"] },
+  { id: "security", gating: "blocking", appliesWhen: ["**"] },
+];
+const LENS_NAMES = ["agent-review-correctness", "agent-review-security"];
+const CODE = ["packages/sheets/src/a.ts"];
+
+const lensRun = (name, id, externalId) => ({
+  name, id, status: "completed", app: { slug: "github-actions" },
+  completed_at: "2026-07-20T10:00:00Z",
+  external_id: externalId,
+});
+
+// A PR whose last round stamped `reviewed: A` for both lenses.
+const stampedAt = (sha) =>
+  LENS_NAMES.map((n, i) => lensRun(n, 10 + i, serializeReviewState({ reviewed: sha, mode: "full" })));
+
+// Find the PATH argument rather than assuming a position: `prCommitsWithCheckRuns`
+// puts `--paginate` before the path for the commits call and after it for
+// check-runs. An earlier version of this stub indexed argv[1] for both, which made
+// every call throw, every commit list come back empty, and four tests fail —
+// including one that then "passed" for the wrong reason.
+const apiFor = (runsBySha) => (args) => {
+  const p = args.find((a) => typeof a === "string" && a.startsWith("repos/"));
+  assert.ok(p, `no path in gh args: ${args.join(" ")}`);
+  if (p.includes("/commits?")) return Object.keys(runsBySha).map((sha) => ({ sha }));
+  const sha = p.split("/commits/")[1].split("/")[0];
+  return [{ check_runs: runsBySha[sha] ?? [] }];
+};
+
+test("decideScope: narrows when every lens agrees and git is clean", async () => {
+  const got = await decideScope({
+    pr: "581", head: B, manifest: MANIFEST, changedFiles: CODE,
+    api: apiFor({ [A]: stampedAt(A) }), run: runner(), log: quiet,
+  });
+  assert.equal(got.mode, "incremental");
+  assert.equal(got.sinceSha, A);
+  assert.equal(got.reason, "ok");
+  assert.equal(got.rounds, 1);
+});
+
+// THE hazard this shape exists to prevent. `resolveReviewMode` is handed its git
+// facts and cannot tell which range they describe, so the caller must measure the
+// range it is about to narrow to. Assert it by capturing the argv git receives.
+test("decideScope: git facts are measured over the AGREED range, not any other", async () => {
+  const seen = [];
+  const spy = async (args) => {
+    seen.push(args.join(" "));
+    return runner()(args);
+  };
+  const got = await decideScope({
+    pr: "581", head: B, manifest: MANIFEST, changedFiles: CODE,
+    api: apiFor({ [A]: stampedAt(A) }), run: spy, log: quiet,
+  });
+  assert.equal(got.sinceSha, A);
+  assert.ok(seen.includes(`merge-base --is-ancestor ${A} ${B}`), `measured the wrong range: ${seen.join(" | ")}`);
+  assert.ok(seen.includes(`rev-list --merges ${A}..${B}`));
+  assert.ok(seen.includes(`diff --numstat ${A} ${B}`));
+  assert.ok(seen.includes(`cat-file -e ${A}^{commit}`));
+});
+
+test("decideScope: git is not touched at all when there is no range to measure", async () => {
+  // Phase 1 short-circuits. Measuring first would either measure a guessed range
+  // or waste four git calls on every first round.
+  const spy = async () => { throw new Error("git must not run without an agreed pointer"); };
+  const got = await decideScope({
+    pr: "581", head: B, manifest: MANIFEST, changedFiles: CODE,
+    api: apiFor({ [A]: [lensRun(LENS_NAMES[0], 10, undefined), lensRun(LENS_NAMES[1], 11, undefined)] }),
+    run: spy, log: quiet,
+  });
+  assert.equal(got.mode, "full");
+  assert.equal(got.reason, "no-prior-state");
+});
+
+test("decideScope: every failure resolves to full, and names itself", async () => {
+  const base = { pr: "581", head: B, manifest: MANIFEST, changedFiles: CODE, run: runner(), log: quiet };
+  const cases = [
+    // one lens stamped, one not: a coverage hole, not a narrowing opportunity
+    ["lens-state-gap", { api: apiFor({ [A]: [stampedAt(A)[0], lensRun(LENS_NAMES[1], 11, undefined)] }) }],
+    // lenses disagree about what they last reviewed
+    ["lens-state-divergence", {
+      api: apiFor({ [A]: [stampedAt(A)[0], lensRun(LENS_NAMES[1], 11, serializeReviewState({ reviewed: "c".repeat(40), mode: "full" }))] }),
+    }],
+    // a re-run on the already-reviewed sha
+    ["no-new-commits", { head: A, api: apiFor({ [A]: stampedAt(A) }) }],
+    // a pointer that no longer resolves
+    ["git-facts-unavailable", {
+      api: apiFor({ [A]: stampedAt(A) }),
+      run: runner({ "cat-file -e": { ok: false, status: 1, stdout: "" } }),
+    }],
+    ["force-push-or-rewrite", {
+      api: apiFor({ [A]: stampedAt(A) }),
+      run: runner({ "merge-base --is-ancestor": { ok: false, status: 1, stdout: "" } }),
+    }],
+    ["merge-in-range", {
+      api: apiFor({ [A]: stampedAt(A) }),
+      run: runner({ "rev-list --merges": { ok: true, status: 0, stdout: `${B}\n` } }),
+    }],
+    ["delta-too-large", {
+      api: apiFor({ [A]: stampedAt(A) }),
+      run: runner({ "diff --numstat": { ok: true, status: 0, stdout: "401\t0\tbig.ts\n" } }),
+    }],
+    // garbage from the API, and an unreadable manifest (main() passes null)
+    ["no-prior-state", { api: () => { throw new Error("gh: 403"); } }],
+    ["invalid-input", { manifest: null, api: apiFor({ [A]: stampedAt(A) }) }],
+    ["invalid-input", { pr: "not-a-number", api: apiFor({ [A]: stampedAt(A) }) }],
+    ["invalid-input", { head: "nope", api: apiFor({ [A]: stampedAt(A) }) }],
+  ];
+  for (const [reason, over] of cases) {
+    const got = await decideScope({ ...base, ...over });
+    assert.equal(got.mode, "full", `${reason}: must be full`);
+    assert.equal(got.reason, reason, `wrong reason for ${JSON.stringify(Object.keys(over))}`);
+    assert.equal(got.sinceSha, "", "full mode must not hand back a since-sha");
+  }
+  // Junk options object: still an answer, still full.
+  for (const bad of [undefined, null, 7, "x", []]) {
+    const got = await decideScope(bad);
+    assert.equal(got.mode, "full");
+    assert.equal(got.reason, "invalid-input");
+  }
+});
+
+test("decideScope: the periodic rebaseline fires on the round count from the API", async () => {
+  // Three commits each carrying lens runs = three rounds; fullEvery 3 forces full.
+  const shas = [A, B, "c".repeat(40)];
+  const api = apiFor(Object.fromEntries(shas.map((s) => [s, stampedAt(A)])));
+  const got = await decideScope({
+    pr: "581", head: B, manifest: MANIFEST, changedFiles: CODE, api, run: runner(), log: quiet,
+  });
+  assert.equal(got.rounds, 3);
+  assert.equal(got.reason, "periodic-rebaseline");
+  // Same PR with the cap raised narrows, which is what proves the round count —
+  // not the pointer state — is what forced it above.
+  const raised = await decideScope({
+    pr: "581", head: B, manifest: MANIFEST, changedFiles: CODE, api, run: runner(), log: quiet, fullEvery: 4,
+  });
+  assert.equal(raised.mode, "incremental");
+});

--- a/scripts/agent/review-state.mjs
+++ b/scripts/agent/review-state.mjs
@@ -173,6 +173,77 @@ export function latestLensRuns(runs, lensCheckNames) {
  * Checks run correctness-first, then policy, so the reported reason names a real
  * hazard when one exists rather than an arbitrary cap that happened to also fire.
  */
+/**
+ * The one sha every lens agrees it last reviewed, or `{ sha: "", reason }`.
+ *
+ * Exported to make the two-phase caller contract usable rather than merely
+ * documented. `resolveReviewMode` needs git facts measured over `since..head`,
+ * but `since` is only knowable AFTER reading the states — so a caller cannot
+ * gather its inputs in one pass. It calls this first to learn the range (or that
+ * there is no range and the answer is already `full`), measures git over exactly
+ * that range, then calls `resolveReviewMode`.
+ *
+ * `resolveReviewMode` uses this internally too, so the two cannot disagree about
+ * which pointer is under consideration.
+ *
+ * Never throws. Reasons are the state-only subset: `invalid-input`,
+ * `no-prior-state`, `lens-state-gap`, `lens-state-divergence`, or `ok`.
+ */
+export function agreedReviewedSha(lensIds, states) {
+  const none = (reason) => ({ sha: "", reason });
+  const ids = (Array.isArray(lensIds) ? lensIds : []).filter((id) => typeof id === "string" && id !== "");
+  if (ids.length === 0) return none("invalid-input");
+
+  // Keyed by lens id (`correctness`) OR by check name (`agent-review-correctness`),
+  // because `latestLensRuns` returns the latter and `lensIds` are the former.
+  // Accepting both removes a silent trap: the natural composition of the two would
+  // otherwise find no state for any lens, report `no-prior-state` forever, and
+  // never narrow anything with nothing to indicate a mistake.
+  //
+  // `Object.hasOwn` rather than a bare index: a lens id of `constructor` would
+  // otherwise pick up `Object.prototype.constructor` as if it were state.
+  const pick = (k) => {
+    if (states instanceof Map) return states.get(k);
+    return states && typeof states === "object" && Object.hasOwn(states, k) ? states[k] : undefined;
+  };
+  const get = (id) => {
+    const v = pick(id) ?? pick(`agent-review-${id}`);
+    // Either a raw external_id string or an already-parsed record — both go
+    // through the same validation, so pre-parsing cannot skip it.
+    return typeof v === "string" ? parseReviewState(v) : normalizeState(v);
+  };
+
+  // EVERY lens must have usable, agreeing state. A lens with no state has a
+  // coverage hole: it never saw the commits between its last verdict and now, and
+  // an incremental round would never show them to it. One lens short is enough to
+  // force a full round for all of them — the reviewed artifact is global, so
+  // partial narrowing is not on offer.
+  //
+  // This is also what covers "a check run exists but no review happened", which is
+  // NOT a separate input and does not need to be. The pointer is stamped only when
+  // a lens produced a real verdict, so a crashed, quota-failed, skipped or
+  // otherwise `neutral` run carries no `external_id` at all; `latestLensRuns` hands
+  // back that newest run, it parses as no state, and this forces `full`. Same for a
+  // lens that was inapplicable in earlier rounds and becomes applicable now: no
+  // state, so no narrowing until it has reviewed a full diff once. Coverage is
+  // proven by the presence of a pointer, not asserted alongside it.
+  const found = ids.map(get);
+  if (found.every((s) => !s)) return none("no-prior-state");
+  // `!s` is the whole test: anything `get` returns non-null came through
+  // `normalizeState`, so `reviewed` is already a validated 40-hex sha. A second
+  // check here would be unreachable, and an unreachable condition in a gate reads
+  // as protection that is not doing anything.
+  if (found.some((s) => !s)) return none("lens-state-gap");
+
+  const reviewedSet = new Set(found.map((s) => s.reviewed));
+  // Lenses normally stamp the same head SHA in one panel run. They diverge only
+  // when a lens missed a round (infra error), which is the same coverage hole as
+  // a gap — and picking the newest would skip commits the laggard never saw,
+  // while picking the oldest re-reviews for everyone anyway. So: full.
+  if (reviewedSet.size !== 1) return none("lens-state-divergence");
+  return { sha: [...reviewedSet][0], reason: "ok" };
+}
+
 export function resolveReviewMode(opts) {
   // Destructure from a coerced object, NOT via a `= {}` parameter default: that
   // default only fires for `undefined`, so `resolveReviewMode(null)` threw — which
@@ -192,61 +263,16 @@ export function resolveReviewMode(opts) {
   const full = (reason) => ({ mode: "full", sinceSha: "", reason });
 
   // --- input sanity: a caller passing junk gets `full`, never a throw ---------
-  const ids = (Array.isArray(lensIds) ? lensIds : []).filter((id) => typeof id === "string" && id !== "");
   const head = sha(headSha);
   const okEvery = Number.isInteger(fullEvery) && fullEvery > 0;
   const okRound = Number.isInteger(roundIndex) && roundIndex >= 0;
   const okMax = Number.isFinite(maxDeltaLines) && maxDeltaLines >= 0;
-  if (ids.length === 0 || !head || !okEvery || !okRound || !okMax) return full("invalid-input");
+  if (!head || !okEvery || !okRound || !okMax) return full("invalid-input");
 
   // --- per-lens state: EVERY lens must have usable, agreeing state ------------
-  // A lens with no state has a coverage hole: it never saw the commits between
-  // its last verdict and now, and an incremental round would never show them to
-  // it. One lens short is enough to force a full round for all of them — the
-  // reviewed artifact is global, so partial narrowing is not on offer.
-  //
-  // This is also what covers "a check run exists but no review happened", which is
-  // NOT a separate input here and does not need to be. The pointer is stamped only
-  // when a lens produced a real verdict, so a crashed, quota-failed, skipped or
-  // otherwise `neutral` run carries no `external_id` at all; `latestLensRuns`
-  // hands back that newest run, it parses as no state, and this check forces
-  // `full`. Same for a lens that was inapplicable in earlier rounds and becomes
-  // applicable now: no state, so no narrowing until it has reviewed a full diff
-  // once. Coverage is proven by the presence of a pointer, not asserted alongside
-  // it.
-  // Keyed by lens id (`correctness`) OR by check name (`agent-review-correctness`),
-  // because `latestLensRuns` returns the latter and `lensIds` are the former.
-  // Accepting both removes a silent trap: the natural composition of the two would
-  // otherwise find no state for any lens, report `no-prior-state` forever, and
-  // never narrow anything with nothing to indicate a mistake.
-  //
-  // `Object.hasOwn` rather than a bare index: a lens id of `constructor` would
-  // otherwise pick up `Object.prototype.constructor` as if it were state.
-  const pick = (k) => {
-    if (states instanceof Map) return states.get(k);
-    return states && typeof states === "object" && Object.hasOwn(states, k) ? states[k] : undefined;
-  };
-  const get = (id) => {
-    const v = pick(id) ?? pick(`agent-review-${id}`);
-    // Either a raw external_id string or an already-parsed record — both go
-    // through the same validation, so pre-parsing cannot skip it.
-    return typeof v === "string" ? parseReviewState(v) : normalizeState(v);
-  };
-  const found = ids.map(get);
-  if (found.every((s) => !s)) return full("no-prior-state");
-  // `!s` is the whole test: anything `get` returns non-null came through
-  // `normalizeState`, so `reviewed` is already a validated 40-hex sha. A second
-  // check here would be unreachable, and an unreachable condition in a gate reads
-  // as protection that is not doing anything.
-  if (found.some((s) => !s)) return full("lens-state-gap");
-
-  const reviewedSet = new Set(found.map((s) => s.reviewed));
-  // Lenses normally stamp the same head SHA in one panel run. They diverge only
-  // when a lens missed a round (infra error), which is the same coverage hole as
-  // a gap — and picking the newest would skip commits the laggard never saw,
-  // while picking the oldest re-reviews for everyone anyway. So: full.
-  if (reviewedSet.size !== 1) return full("lens-state-divergence");
-  const since = [...reviewedSet][0];
+  const agreed = agreedReviewedSha(lensIds, states);
+  if (!agreed.sha) return full(agreed.reason);
+  const since = agreed.sha;
 
   // Re-run on an already-reviewed SHA. The delta is empty, and review-panel.mjs
   // refuses an empty diff (fails closed), so narrowing here would turn a


### PR DESCRIPTION
## Summary

**Turns incremental review on.** #581 landed the decision logic inert; this
connects it. The panel now records what each lens reviewed, resolves the next
round's scope from those records, and reviews only the delta when every condition
holds.

> **Replaces #589**, whose branch was polluted by another session's smoke-test
> commits. Same work, cherry-picked clean onto current `main` (post-#582/#587/#588)
> as a single commit.
>
> ⚠️ **This PR cannot self-test.** It is authored from a fork, and
> `agent-review-panel.yml` gates on `head_repository.full_name == github.repository` —
> so the workflow half of this change gets no panel run here. See *What is still
> unverified* before merging.

## Read this first if you read nothing else

**Round 1 after merge is still `full`** (`reason=no-prior-state` — nothing has
stamped a pointer yet). **Round 2 is the first that can narrow.** The signal to
watch is the `Review scope:` line in the run summary.

## What each piece does

| file | role |
|---|---|
| `review-scope.mjs` (new) | The caller `review-state.mjs` was written for. Reads each lens's pointer (checks API), measures the range (git), calls `resolveReviewMode`, emits `mode`/`since`/`reason`/`rounds`. |
| `gh-checks.mjs` (new) | The two check-run API contracts, stated once. |
| `review-state.mjs` | `agreedReviewedSha` exported — see *the two phases*. |
| `review-panel.mjs` | `--head-sha`; `panelEntry` owns the write rule. |
| `agent-review-panel.yml` | Scope step, narrowing step, the flags, `external_id`. |
| both workflows | Inline prior-findings `github-script` → `prior-findings.mjs`. |

## The two phases, because the inputs are circular

`resolveReviewMode` needs git facts about `since..head`. But `since` is only
knowable *after* reading the pointers — so a caller cannot gather its inputs in one
pass.

`agreedReviewedSha` is now exported, and `resolveReviewMode` calls it internally, so
the two cannot disagree about which pointer is in play. This matters because facts
measured over a *different* range would validate one range and narrow another, and
**`resolveReviewMode` cannot detect that** — it is handed the facts. The test
asserts it by capturing the argv git actually receives, not by trusting the shape.

A documented caller contract the caller cannot mechanically satisfy is a latent bug.

## The flag and the diff come from the same step

Whichever workflow step rewrites `/tmp/pr.diff` is the step that emits
`--review-mode`. They cannot disagree about what the panel is looking at.
`review-panel.mjs` cannot check this itself — it receives a *file*, not a range.

When narrowing does not happen those outputs are empty, the panel gets no flag, and
the existing full diff stands. That is why the diff step is left **byte-identical**
to the on-demand workflow's copy of it.

**Fail directions differ deliberately:**

| step | on failure | why |
|---|---|---|
| Resolve review scope | tolerated → full review | Only *computes*. `continue-on-error` covers the class the script's own `catch` cannot — `main().catch` never sees an import-time crash. A bug in a cost optimiser must not block a PR. |
| Narrow the diff | **fails the job** | *Mutates* the reviewed artifact. Tolerating a death between the `mv` and the output write would hand a lens a fragment to review as if it were the whole PR — the one outcome this design must not produce. |
| Read prior findings | tolerated → carry none | Priors can only re-raise a blocker, never clear one. |

## The write rule is a function, not a convention

`panelEntry` attaches the pointer only when a lens produced a real verdict. A
crashed, quota-failed or skipped lens stamps nothing, so the next round finds a
state gap and reviews in full. **Coverage is proven by the presence of a pointer**
rather than asserted beside it — which is why `resolveReviewMode` needs no separate
"did this lens actually review?" input.

It is a function because the first version was a rule three `panel.push` sites were
trusted to follow, guarded by a test that scanned the source for which one carried
the field. **That test passed** when the pointer was also attached to the
fail-closed entry by a separate `entry.reviewState = ...`. It was watching the
syntax I happened to write. Both remaining mutations now fail.

## Three implementations → one

The last review noted that #581 took the prior-findings read from two copies to
three. This closes that: `gh-checks.mjs` holds the two contracts, both workflows'
inline copies are gone, and `parseArgs` moved there rather than becoming a fifth
copy. `review-round-guard.mjs` is deliberately **not** refactored onto it — it feeds
the paging path, and pulling a gate file in here trades a real risk for a cosmetic
one.

On-demand already had `checks: read` (#558), and it never narrows: it records no
check runs, so it could never write a pointer back.

## A pointer means the lens LOOKED, not merely that it reported

#582 (per-lens diff slicing) merged while this was in flight, turning a hazard I
had only documented into a live one.

`lensReviewPlan` can return an **empty slice** — the PR contains files a lens reads,
but none changed in this round's delta — so the lens runs **zero detection samples**
and still produces a valid verdict. Stamping that pointer would claim the lens
looked at everything up to here when it looked at nothing.

The round itself is fine (there was nothing in its lane to see). The damage is that
`scopeClasses`/`classifyFile` become **retroactive**: widening a lens's scope later
would apply only to commits *after* the pointer, where today it self-heals because
every round re-reads the whole diff.

So `panelEntry` requires `ranDetection`, derived from `ok.length > 0` — the samples
that actually returned — rather than from a flag that could drift from them.
**Cost:** one forced-full round after any round where a lens had an empty slice.
A scope digest inside the state would avoid that cost and is the follow-up if those
rounds prove expensive; a permanent invisible hole is not worth trading for them now.

## Verification

`pnpm verify:self` green (11/11) · **333 tests** (331 on `main`) · both workflows
parse.

**Stubs prove the branches; one real run proves the call.** A misspelled git flag
yields `null`, resolves to `full`, and is a silent permanent no-op that no stub can
catch — so all three were run for real:

- **`gitFacts` against real history.** `origin/main~4..origin/main` →
  `isAncestor: true, hasMergeInRange: false, deltaLines: 4521`; reversed →
  `isAncestor: false`; nonexistent sha → all `null`; same sha → `0`.
- **`review-scope.mjs` end-to-end against the real API** (#581): enumerated its
  commits, fetched check runs with `--slurp` **without a parse error** — the
  contract this series has broken twice — and emitted
  `mode=full reason=no-prior-state`.
- **The narrowing path with real git**, stubbed API (nothing local can write
  `external_id`): default cap → `delta-too-large` on a real 1670-line range; raised
  cap → `incremental` with the correct `since`; `fullEvery: 1` →
  `periodic-rebaseline`.

## What is still unverified

- **`external_id` round-tripping through the checks API.** Nothing local can write
  one, and this PR gets no panel run (fork). The first real exercise is the next
  agent PR after merge.
- **Blast radius if it misbehaves:** the narrowing step either produces a delta
  *and* the flag, or fails the job. So the realistic failure is "rounds keep
  reviewing in full" — the safe direction — rather than an under-reviewed PR.
- If you would rather this ran the panel on itself first, it needs to be pushed to
  a base-repo branch instead of the fork; say so and I will redo it that way.

## Linked Issues

None — from the review-panel audit.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification checklist

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

## Risk Assessment

- **User-facing risk:** none. No product code.
- **Data/security risk:** no permission or trust-model change. `external_id` sits
  behind the same `checks:write` boundary as the verdicts. `latestLensRuns` filters
  `app.slug === "github-actions"`, which narrows the writer to a workflow **in this
  repo** — the slug identifies the App, not the workflow. Only the panel declares
  `checks: write`, and no author-controlled workflow can gain it because a branch
  cannot edit `.github/workflows/**`. That push restriction is the boundary; the
  filter narrows to it rather than replacing it.
- **Rollback:** revert. Two new files plus workflow steps; reverting restores
  full-diff review immediately, and stale pointers are then simply never read.

## Notes for Reviewers

- **AI assistance:** implemented with Claude Code (Opus 5) in an interactive
  session and reviewed by me.
- **Where I'd push hardest:** `fullEvery = 3` and `maxDeltaLines = 400` still have
  no data behind them. `fullEvery` sets how long a delta-exposed defect can hide
  *and* is the biggest lever on the saving. Both are parameters, tunable once there
  are real round counts.
- **`fullEvery`/`maxDeltaLines` aside, the #582 interaction is now handled, not
  noted** — see *A pointer means the lens looked* above. The remaining judgement
  call there is whether the forced-full rounds it costs are worth avoiding with a
  scope digest later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated review panels now support incremental rounds, focusing on changes since the last completed review when conditions are suitable.
  * Review results retain accurate progress between rounds, helping prevent previously reviewed areas from being overlooked.
  * Prior blocking findings can be carried into subsequent review rounds.

* **Bug Fixes**
  * Improved resilience when review data or service responses are incomplete or unavailable.

* **Documentation**
  * Updated guidance and task records to explain incremental review behavior, safeguards, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->