### PR TITLE
Collapse restatements of one defect into a single finding

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -523,7 +523,7 @@ jobs:
                   // it every repeat round tells the verifier to "search from
                   // scratch", losing the complementary-search value. Advisory —
                   // never gates (see verifyFinding), so it is safe to carry.
-                  .map((f) => ({ severity: norm(f.severity), file: trim(f.file, 300), claimType: f.claimType === 'absence' ? 'absence' : undefined, searchedFor: Array.isArray(f.searchedFor) ? f.searchedFor.filter((s) => typeof s === 'string' && s.trim()).slice(0, 20).map((s) => trim(s, 300)) : undefined, summary: trim(f.summary, 2000), evidence: trim(f.evidence, 2000) }));
+                  .map((f) => ({ severity: norm(f.severity), file: trim(f.file, 300), claimType: f.claimType === 'absence' ? 'absence' : undefined, searchedFor: Array.isArray(f.searchedFor) ? f.searchedFor.filter((s) => typeof s === 'string' && s.trim()).slice(0, 20).map((s) => trim(s, 300)) : undefined, mergedFrom: Array.isArray(f.mergedFrom) && f.mergedFrom.length ? f.mergedFrom.slice(0, 5).map((m) => ({ severity: norm(m.severity), summary: trim(m.summary, 500) })) : undefined, summary: trim(f.summary, 2000), evidence: trim(f.evidence, 2000) }));
                 // Keep output.text VALID JSON within the 60k limit: NEVER slice the
                 // serialized string (that yields JSON the next round can't parse).
                 // Fields are trimmed above; drop trailing findings until it fits.
@@ -801,7 +801,7 @@ jobs:
               for (const f of findings) {
                 if (!f || typeof f !== 'object') continue;
                 const file = typeof f.file === 'string' && f.file.trim() ? f.file.trim() : '(file not specified)';
-                (byFile[file] ||= []).push({ lens, severity: f.severity, summary: f.summary, evidence: f.evidence });
+                (byFile[file] ||= []).push({ lens, severity: f.severity, summary: f.summary, evidence: f.evidence, mergedFrom: f.mergedFrom });
               }
             }
             // BOUND the checklist. Each lens persists up to 60k chars of findings
@@ -822,8 +822,17 @@ jobs:
               const kept = [];
               for (const i of items) {
                 if (emitted >= MAX_ITEMS) { truncated = true; break; }
+                // Other wordings of the same defect, folded in by the clustering
+                // pass. Included so the fixer reads every description rather than
+                // only the one that won the slot — if the merge was wrong, the
+                // second description is what tells it there are two problems.
+                // Bounded to two, since the point is context, not completeness.
+                const also = Array.isArray(i.mergedFrom) && i.mergedFrom.length
+                  ? i.mergedFrom.slice(0, 2).map((m) => `\n      also reported as: ${clip(m.summary, 300)}`).join('')
+                  : '';
                 const line = `    - (${i.lens}/${i.severity}) ${clip(i.summary, 500)}`
-                  + (i.evidence ? `\n      evidence: ${clip(i.evidence, 400)}` : '');
+                  + (i.evidence ? `\n      evidence: ${clip(i.evidence, 400)}` : '')
+                  + also;
                 if (chars + line.length > MAX_CHARS) { truncated = true; break; }
                 chars += line.length; emitted++; kept.push(line);
               }

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -487,6 +487,24 @@ Components:
   `verifier.absenceRaised`/`absenceRefuted`/`unresolved`, so a high `unresolved`
   against a low `absenceRefuted` is visible as absence claims riding through
   unchecked rather than being silently discounted.
+  A **clustering** pass (`clusterFindings`) then collapses RESTATEMENTS of one
+  defect. `dedupeFindings` only catches byte-identical summaries, so #578 reported
+  the same defect three times over — two wordings of one missing file, the
+  deny-list bug as both a `critical` and a `major`, the deny-list-shape concern
+  twice — and the verifier could not help, since it judges one finding at a time
+  in isolation and bills for each copy. The similarity metric is **not** re-derived:
+  `findingSimilarity` in `scripts/agent/rounds.mjs` already owns it for the
+  non-convergence detector, calibrated against real panel output with the overlap
+  coefficient chosen over Jaccard for exactly this restatement pattern. It
+  separated all four of #578's real duplicate pairs from all four of its real
+  distinct pairs, with the distinct ones scoring 0.000 — so this needs **no model
+  call**. Merging is not deletion, which is what makes that safe: every collapsed
+  wording rides along in `mergedFrom` and is rendered (and reaches the fixer), the
+  survivor takes the cluster's highest severity so a `critical` is never masked by
+  a `major` restatement, it gates if any member gated, and `unsettled` propagates.
+  The only thing removed is count inflation, reported as `clusters.collapsed`. The
+  stated limitation: two wordings sharing no vocabulary score 0 and stay separate,
+  which leaves the count inflated — the status quo, and the conservative direction.
   A **novelty gate** (`scripts/agent/novelty.mjs`) then answers a question the
   verifier structurally cannot: *did this change PUT this line here, carrying
   code that already existed?* The verifier's independence means it never sees the

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -18,6 +18,7 @@ Track task-specific plan/review and lessons files using the active/archive layou
 
 | Task | Todo | Lessons |
 |---|---|---|
+| restatement clustering (2026-07-30) | [20260730-restatement-clustering-todo.md](./active/20260730-restatement-clustering-todo.md) | - |
 | absence claims (2026-07-29) | [20260729-absence-claims-todo.md](./active/20260729-absence-claims-todo.md) | - |
 | autonomous issue hunting (2026-07-29) | [20260729-autonomous-issue-hunting-todo.md](./active/20260729-autonomous-issue-hunting-todo.md) | [20260729-autonomous-issue-hunting-lessons.md](./active/20260729-autonomous-issue-hunting-lessons.md) |
 | incremental review (2026-07-29) | [20260729-incremental-review-todo.md](./active/20260729-incremental-review-todo.md) | [20260729-incremental-review-lessons.md](./active/20260729-incremental-review-lessons.md) |
@@ -77,4 +78,4 @@ Track task-specific plan/review and lessons files using the active/archive layou
 - Archived task count: 374
 - Archive index: [archive/README.md](./archive/README.md)
 
-Latest active task: absence claims (2026-07-29)
+Latest active task: restatement clustering (2026-07-30)

--- a/docs/tasks/active/20260730-restatement-clustering-todo.md
+++ b/docs/tasks/active/20260730-restatement-clustering-todo.md
@@ -1,0 +1,101 @@
+# Restatement clustering: collapse wordings of one defect
+
+Stop the panel reporting one defect three times. `dedupeFindings` only catches
+byte-identical summaries; this collapses *restatements*.
+
+## The problem, from #578
+
+The disposition comment's third bucket: **"Three findings were double-reported
+(the `hunt-probe.mjs` nit, the exact-string critical, the deny-list-shape major),
+which inflates the counts."**
+
+Each pair describes one defect in different words, so each gets a different
+`file + lowercased summary` key and both survive. The verifier cannot help: it
+judges one finding at a time in isolation, so it structurally cannot notice it is
+confirming the same bug twice — and it bills for each copy.
+
+## No model call, and why
+
+The plan for this step called for one `askStructured` call per lens to cluster.
+That turned out to be unnecessary: **the metric already exists and is already
+calibrated.**
+
+`findingSimilarity` in `scripts/agent/rounds.mjs` was built for the
+non-convergence detector, gated on same lens + same file, using the overlap
+(containment) coefficient — chosen over Jaccard precisely because "the panel
+restates one defect at different levels of detail, and Jaccard penalises the
+extra specifics in the longer wording". Its threshold was calibrated against real
+panel output (PR #564's design-fit lens emitting four wordings of one defect).
+
+Measured against #578's real data — the three double-reports its disposition
+called out, plus the `CITATION` pair, versus four genuinely distinct findings from
+the same lens and file:
+
+| | score range |
+|---|---|
+| same defect, different wording | 0.308 – 0.933 |
+| distinct defects, same lens+file | 0.000 |
+
+The distinct pairs score exactly 0 because `MIN_SHARED_TOKENS = 3` zeroes them
+out, so the real gate is "share at least 3 meaningful tokens AND overlap ≥ 0.3".
+Clean separation on real data, deterministic, and free.
+
+A second hand-tuned copy of the metric would have been the drift that
+`REFUTATION_GROUNDS` (derived from its schema) and `CITATION` (extracted to a leaf
+module) both exist to avoid. `DEFAULT_SIMILARITY` is imported, not redefined.
+
+## Merging is not deletion
+
+This is what makes clustering safe to do without a model in the loop, and it is
+the same principle the novelty gate landed on after #583's review:
+
+- every collapsed wording rides along in `mergedFrom`, is rendered in the check
+  body, and reaches the fix agent — so a wrong merge is visible and the fixer
+  still reads both descriptions;
+- the survivor takes the cluster's **highest** severity, so #578's `critical`
+  restated as a `major` cannot be masked;
+- the survivor **gates** if any member gated (the rule `dedupeFindings` already
+  has), so merging can never turn a check green;
+- `unsettled` propagates, so doubt recorded on any wording survives;
+- a lane is never invented on a finding that had none.
+
+The only thing removed is the count inflation.
+
+Single-linkage, not compare-to-representative: four wordings collapse to one only
+if a new wording can join on matching ANY member. Membership is decided before a
+representative is chosen, and the representative is picked by a total order
+(gating, severity, has-evidence, longer summary, lexicographic), so the result
+does not depend on input order — asserted both directions in the tests.
+
+## Stated limitation
+
+Two wordings of one defect that share no vocabulary score 0 and stay separate.
+That leaves the count inflated, which is the status quo — the conservative
+direction. A model pass would catch those; it is not worth a paid call per lens
+per round for the residue, and `clusters.collapsed` will show whether it is.
+
+## A bug this surfaced in the merged absence-claims change
+
+Rendering the output rather than trusting the unit tests caught it:
+`normalizeFindings` rebuilt every finding as exactly
+`{severity,file,summary,evidence}`, dropping everything the orchestrator
+annotates after the lens produced it. `renderSummaryMd` renders from
+`classify()`'s output, so **the "verifier could not settle this" marker shipped in
+#587 never appeared in a single check body** — the field was gone before the
+renderer looked for it. `normalizeFindings` now coerces `severity` and preserves
+the rest, with a regression test for the field set and an end-to-end one for the
+rendered body.
+
+## What to watch
+
+`clusters.collapsed` in the metrics comment. A persistently high number means the
+lenses are re-describing the same defects rather than that the PR has that many
+problems — which is a rubric signal, not a clustering one.
+
+## Deliberately not in this PR
+
+The last #578 bucket: **wrong mechanism, true kernel.** A binary
+confirmed/refuted verdict has nowhere to put "the concern is real but the stated
+cause is wrong", so such a finding rides through at full severity (#578's
+"Bash/Write stay available" was overstated but had a true core). Needs a
+`confirmed-corrected` verdict that may only downgrade.

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -191,6 +191,10 @@ export function aggregatePanelStats(entries) {
   // blind (no --base-sha, a shallow clone, findings with no line) rather than
   // that nothing was relocated.
   let laneBlocking = 0, laneBacklog = 0, laneUnknownOrigin = 0;
+  // Restatement collapsed by the clustering pass. `collapsed` is pure count
+  // inflation removed — wordings of a defect already reported under another
+  // finding. Absent from pre-clustering entries, which coerce to 0.
+  let clustered = 0, collapsed = 0;
   for (const e of list) {
     if (!e || typeof e !== "object") continue;
     if (Object.prototype.hasOwnProperty.call(agreementCounts, e.agreement)) agreementCounts[e.agreement]++;
@@ -211,11 +215,14 @@ export function aggregatePanelStats(entries) {
     laneBlocking += Number(e.lanes && e.lanes.blocking) || 0;
     laneBacklog += Number(e.lanes && e.lanes.backlog) || 0;
     laneUnknownOrigin += Number(e.lanes && e.lanes.unknownOrigin) || 0;
+    clustered += Number(e.clusters && e.clusters.clustered) || 0;
+    collapsed += Number(e.clusters && e.clusters.collapsed) || 0;
   }
   return {
     agreementCounts, raised, raisedConfidence, kept,
     verifier: { sentToVerifier, refuted, refutedHighConfidence, dropped, absenceRaised, absenceRefuted, unresolved },
     lanes: { blocking: laneBlocking, backlog: laneBacklog, unknownOrigin: laneUnknownOrigin },
+    clusters: { clustered, collapsed },
   };
 }
 
@@ -382,6 +389,7 @@ export function renderSummary({ agg, panelAgg, panelStats, flips, scope }) {
     const k = panelStats?.kept || {};
     const v = panelStats?.verifier || {};
     const l = panelStats?.lanes || {};
+    const c = panelStats?.clusters || {};
     const sampledRounds = (ac.identical || 0) + (ac.partial || 0) + (ac.disjoint || 0);
     lines.push(
       "",
@@ -428,6 +436,10 @@ export function renderSummary({ agg, panelAgg, panelStats, flips, scope }) {
       // the gate ran blind (no --base-sha, a shallow clone, findings with no
       // line), not that nothing was moved. Only `relocated` demotes.
       `- Novelty gate: ${l.backlog || 0} relocated (demoted), ${l.blocking || 0} gating, ${l.unknownOrigin || 0} unplaceable`,
+      // Restatement, not defects. A persistently high `collapsed` means the
+      // lenses are re-describing the same problems rather than that the PR has
+      // that many — the count inflation #578's disposition called out.
+      `- Restatement collapsed: ${c.collapsed || 0} wording(s) folded into ${c.clustered || 0} finding(s)`,
     );
     // Advisory heads-up (NOT a verdict): a lens that blocked then approved across
     // rounds — the PR #521 pattern. Can't distinguish a genuine fix from judge

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -47,6 +47,13 @@ import { askStructured, withRetry } from "./ask.mjs";
 import { renderScopeNote, serializeReviewState } from "./review-state.mjs";
 import { CITATION } from "./citation.mjs";
 import { findingLocation, noveltyOf, baseResolves, DEMOTING_ORIGINS } from "./novelty.mjs";
+// The similarity metric is NOT re-derived here. `rounds.mjs` already owns it for
+// the non-convergence detector, and it was calibrated against real panel output
+// (PR #564's design-fit lens emitting four wordings of one defect, measured
+// against unrelated real findings) with the overlap coefficient chosen over
+// Jaccard for exactly this restatement pattern. A second, hand-tuned copy would
+// be the drift `REFUTATION_GROUNDS` and `CITATION` both exist to avoid.
+import { findingSimilarity, DEFAULT_SIMILARITY } from "./rounds.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
@@ -433,10 +440,9 @@ export function coerceFindings(raw) {
  * fail-toward-blocking direction the severity rule already has.
  */
 export function dedupeFindings(findings) {
-  const rank = (f) => KNOWN.indexOf(normalizeSeverity(f.severity)); // 0=critical … 3=nit
-  const gates = (f) => f?.lane !== "backlog"; // no lane = gates (see gatingFindings)
   /** Does `a` beat the finding already in the slot? Lane first, then severity. */
-  const beats = (a, b) => (gates(a) !== gates(b) ? gates(a) : rank(a) < rank(b));
+  const beats = (a, b) =>
+    findingGates(a) !== findingGates(b) ? findingGates(a) : severityRank(a) < severityRank(b);
   const byKey = new Map();
   const order = [];
   for (const f of findings) {
@@ -449,6 +455,121 @@ export function dedupeFindings(findings) {
     }
   }
   return order.map((k) => byKey.get(k));
+}
+
+/** 0=critical … 3=nit. Lower is more severe. */
+const severityRank = (f) => KNOWN.indexOf(normalizeSeverity(f && f.severity));
+/** No lane at all = gates. Only an explicit `backlog` does not (see gatingFindings). */
+const findingGates = (f) => !f || f.lane !== "backlog";
+
+/**
+ * Collapse RESTATEMENTS of one defect into a single finding.
+ *
+ * `dedupeFindings` only catches byte-identical summaries, which is why #578
+ * reported the same defect three times over: two wordings of the missing
+ * `hunt-probe.mjs`, the exact-string deny-list bug as both a `critical` and a
+ * `major`, and the deny-list-shape concern twice in design-fit. Each pair
+ * describes one thing in different words, so each gets a different key and both
+ * survive. The verifier cannot help — it judges one finding at a time, in
+ * isolation, so it structurally cannot notice it is confirming the same bug
+ * twice, and it bills for each copy.
+ *
+ * NOTHING IS LOST, which is what makes this safe to do without a model in the
+ * loop. Merging is not deletion:
+ *   - every collapsed wording rides along in `mergedFrom` and is rendered, so a
+ *     wrong merge is visible and the fixer still reads both descriptions;
+ *   - the survivor takes the cluster's HIGHEST severity, so a `critical` is never
+ *     masked by the `major` restatement of it;
+ *   - the survivor GATES if any member gated, so merging can never turn a check
+ *     green (`dedupeFindings` has the same rule, for the same reason);
+ *   - `unsettled` propagates, so doubt recorded on any wording survives.
+ * The only thing this removes is the count inflation.
+ *
+ * Single-linkage, not compare-to-representative: four wordings of one defect
+ * only collapse to one if a new wording can join on matching ANY member, not
+ * just the one that happens to be holding the slot. Membership is decided before
+ * a representative is chosen, so the result does not depend on input order.
+ *
+ * Deliberately NO model call. The metric is already calibrated for this exact
+ * pattern (see the import note), it separated all four of #578's real duplicate
+ * pairs from all four of its real distinct pairs with the distinct ones scoring
+ * 0.000, and it costs nothing. The tradeoff is stated rather than hidden: two
+ * wordings of one defect that share no vocabulary score 0 and stay separate.
+ * That leaves the count inflated, which is the status quo — the conservative
+ * direction, and the one this series keeps choosing.
+ */
+export function clusterFindings(findings, { threshold = DEFAULT_SIMILARITY } = {}) {
+  const list = Array.isArray(findings) ? findings : [];
+  const clusters = [];
+  for (const f of list) {
+    // Junk never joins anything: `findingSimilarity` would score it 0 anyway, and
+    // a malformed entry must keep travelling on its own so coerceFindings' fail
+    // -toward-blocking placeholder is not quietly folded into a real finding.
+    const usable = f && typeof f === "object";
+    // Compare on a lens-neutral copy. `findingSimilarity` scores a lens mismatch
+    // 0 outright, and within one lens's set the fresh findings carry no `lens`
+    // while carried-forward ones do — so the real twin of a prior-round finding
+    // would score 0 for a reason that has nothing to do with the wording.
+    const key = usable ? { ...f, lens: "" } : null;
+    const hit = usable
+      ? clusters.find((c) => c.keys.some((k) => findingSimilarity(k, key) >= threshold))
+      : undefined;
+    if (hit) {
+      hit.members.push(f);
+      hit.keys.push(key);
+    } else {
+      clusters.push({ members: [f], keys: [key] });
+    }
+  }
+  return clusters.map((c) => mergeCluster(c.members));
+}
+
+/**
+ * Pick a cluster's surviving finding and fold the rest into it.
+ *
+ * The representative is the most useful wording, by a TOTAL order so the result
+ * is order-independent: gating first, then severity, then having evidence at all,
+ * then the longer summary, then lexicographic as a final tiebreak. Without that
+ * last rung two equally-good wordings would resolve by input order.
+ */
+function mergeCluster(members) {
+  if (members.length === 1) return members[0];
+  const better = (a, b) =>
+    findingGates(a) !== findingGates(b) ? (findingGates(a) ? -1 : 1)
+    : severityRank(a) !== severityRank(b) ? severityRank(a) - severityRank(b)
+    : !!(a && a.evidence) !== !!(b && b.evidence) ? (a && a.evidence ? -1 : 1)
+    : String(b && b.summary || "").length - String(a && a.summary || "").length
+      || String(a && a.summary || "").localeCompare(String(b && b.summary || ""));
+  const [rep, ...others] = [...members].sort(better);
+  const out = { ...rep };
+  // The cluster's worst severity, so a `critical` is never masked by a `major`
+  // restatement that happened to win on another axis.
+  const worst = members.reduce((acc, m) => (severityRank(m) < severityRank(acc) ? m : acc), rep);
+  out.severity = normalizeSeverity(worst.severity);
+  // If ANY wording gated, the survivor must. Only promote an explicit `backlog`
+  // rep — never invent a lane on a finding that had none (see annotateFindings).
+  if (out.lane === "backlog" && members.some((m) => findingGates(m))) out.lane = "blocking";
+  if (members.some((m) => m && m.unsettled)) out.unsettled = true;
+  out.mergedFrom = others.map((m) => ({
+    severity: normalizeSeverity(m && m.severity),
+    summary: (m && m.summary) ?? "(no summary)",
+    ...(m && m.evidence ? { evidence: m.evidence } : {}),
+  }));
+  return out;
+}
+
+/**
+ * How much restatement this lens produced. `collapsed` counts wordings folded
+ * into another finding — the count inflation that used to reach the PR comment
+ * and the fixer's checklist as separate work items.
+ */
+export function clusterCounts(findings) {
+  let clustered = 0, collapsed = 0;
+  for (const f of Array.isArray(findings) ? findings : []) {
+    const n = f && Array.isArray(f.mergedFrom) ? f.mergedFrom.length : 0;
+    if (n > 0) { clustered++; collapsed += n; }
+  }
+  return { clustered, collapsed };
 }
 
 /**
@@ -1455,9 +1576,14 @@ async function main() {
     const priorKept = keepUnrefuted(
       annotateFindings(priorForLens, priorVerdicts, null, verifyOpts),
     );
-    // Merge fresh + still-open prior findings; dedupe collapses a prior finding
-    // the fresh pass also re-found (and never merges two distinct bugs).
-    const merged = dedupeFindings([...kept, ...priorKept]);
+    // Merge fresh + still-open prior findings. Two passes, narrow then loose:
+    // `dedupeFindings` collapses byte-identical summaries, then `clusterFindings`
+    // collapses RESTATEMENTS of one defect — a prior finding the fresh pass
+    // re-found in different words, or one lens describing the same bug twice at
+    // two severities. Clustering runs AFTER verification on purpose: it merges
+    // only findings that already survived the gate, so it can never decide what
+    // gets verified, and every collapsed wording rides along in `mergedFrom`.
+    const merged = clusterFindings(dedupeFindings([...kept, ...priorKept]));
     // What the LENS CHECK gates on: `merged` minus the demoted blockers. The
     // backlog ones stay in `merged` so the summary still reports them (with the
     // base location that justifies the demotion) — they simply stop failing the
@@ -1499,6 +1625,11 @@ async function main() {
       // gate is inert, and the cause (no --base-sha, a shallow clone, findings
       // with no location) is worth chasing rather than trusting the demotions.
       lanes: laneCounts(merged),
+      // Restatement collapsed this round. `collapsed` is the count inflation that
+      // used to reach the PR comment and the fixer's checklist as separate work
+      // items; a persistently high number means the lenses are re-describing the
+      // same defects rather than that the PR has that many problems.
+      clusters: clusterCounts(merged),
     });
 
     // Advisory lenses report findings but never block.

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -34,6 +34,8 @@ import {
   buildLensPrompt,
   resolveReviewScope,
   claimTypeOf,
+  clusterFindings,
+  clusterCounts,
   VERIFIER_MAX_TURNS,
   buildVerifierPrompt,
   panelEntry,
@@ -721,8 +723,14 @@ test("main() routes both skips to applicable:false and feeds runLens the slice",
   // `keepUnrefuted(annotateFindings(...))`; the region was intact but the regex
   // stopped matching, and this test failed claiming the re-check was "gone".
   // A guard over an implementation detail reports refactors as breakage.
+  //
+  // It happened a second time for the same reason: this pinned
+  // `const merged = dedupeFindings`, and the clustering pass legitimately made it
+  // `const merged = clusterFindings(dedupeFindings(...))`. Anchor on the BINDING,
+  // which is the landmark this test actually cares about, not on which functions
+  // produce it — that is free to change and has now changed twice.
   const priorStart = src.indexOf("const priorForLens = priorFindings.filter");
-  const mergeAt = src.indexOf("const merged = dedupeFindings", priorStart);
+  const mergeAt = src.indexOf("const merged =", priorStart);
   assert.ok(priorStart > 0, "the prior-round re-check is gone");
   assert.ok(mergeAt > priorStart, "the fresh + prior merge no longer follows the re-check");
   assert.ok(!src.slice(priorStart, mergeAt).includes("noNewHunks"),
@@ -1618,4 +1626,144 @@ test("buildVerifierPrompt: an absence claim with no searchedFor says so", () => 
     { rubric: "R", changedContext: ctx },
   );
   assert.match(p, /did not record what it searched/);
+});
+
+// --- clustering restatements -------------------------------------------------
+// dedupeFindings only catches byte-identical summaries. These pin that
+// RESTATEMENTS of one defect collapse, that genuinely distinct findings in the
+// same file do NOT, and that collapsing can never weaken the gate.
+//
+// The pairs are verbatim from #578's check-run output — the same-defect ones are
+// the three double-reports its disposition comment called out, plus the CITATION
+// pair. Real data, not invented strings, because the threshold is calibrated
+// against real panel wording and a synthetic test would not exercise that.
+
+const SAME_DEFECT = [
+  ["The header comment points readers at `hunt-probe.mjs` as the worked example of the trusted-execution pattern, but no such file exists in the repo.",
+   "The header comment points readers at `hunt-probe.mjs` as the worked example of the trusted-execution pattern, but that file does not exist in the repo."],
+  ['The deny-list is an exact string match, but the SDK’s `allowedTools` entries are permission *rules* — "Bash(git *)", " Bash", and mcp__workspace__bash all pass validation and grant shell.',
+   "assertAllowedTools' deny-list only does exact string equality, so the documented SDK permission-rule forms of the same tools (`Bash(git diff:*)`, `WebFetch(domain:x.com)`, `mcp__server__exec`) pass validation and grant the exact capability the module exists to refuse."],
+  ["Deny-list of forbidden tool names is the wrong mechanism for the stated invariant; an allow-list is what the repo already uses and what the claim requires.",
+   "Capability boundary is an exact-name deny-list, so it fails open on tool names it does not enumerate (approach fit)"],
+  ["`CITATION` is newly exported (plus a test) solely for a “hunt gate” that does not exist — unused public surface added outside the stated refactor.",
+   "`CITATION` is exported for a consumer that does not exist in the tree — speculative scope beyond the extraction"],
+];
+
+const DISTINCT_DEFECTS = [
+  ["The quota-detection regex's `resets?\\b` alternative matches ordinary transient network errors (ECONNRESET / connection reset by peer), flipping them to retryable:false so withRetry gives up on the first attempt.",
+   "askStructured has no timeout or abort signal, so a query that stalls without emitting a result message hangs the caller forever; in review-panel every lens sample is inside a Promise.all."],
+  ["classifyResult returns `ok:true` for a result that carries both `structured_output` and `is_error: true`, so a failed session can be written out as a real verdict.",
+   "`label` is applied only to the api-error message, so the no-output error is unattributable now that two consumers share the wrapper."],
+  ["`maxTurns` is silently dropped whenever it is not already a number, so a caller passing a stringified value gets no turn ceiling at all rather than an error.",
+   "`schema` is unvalidated, so a caller that omits it burns a full paid session before failing with a misleading “structured output not produced”."],
+  ["FORBIDDEN_TOOLS misses the execution, respawn and exfiltration tools that actually exist in pinned SDK 0.3.217 — including `Agent`, `REPL`, `Workflow`, `CronCreate`, `RemoteTrigger`.",
+   "The validated array is frozen and then handed directly to the SDK; if the SDK's option normalization mutates `allowedTools`, the frozen array throws a TypeError."],
+];
+
+const asFinding = (summary, over = {}) =>
+  ({ severity: "major", file: "scripts/agent/ask.mjs", summary, ...over });
+
+test("clusterFindings: real #578 restatements of one defect collapse to one", () => {
+  SAME_DEFECT.forEach(([a, b], i) => {
+    const out = clusterFindings([asFinding(a), asFinding(b)]);
+    assert.equal(out.length, 1, `pair ${i + 1} should have merged`);
+    assert.equal(out[0].mergedFrom.length, 1);
+    // The other wording is retained, never dropped.
+    assert.ok([a, b].includes(out[0].summary));
+    assert.ok([a, b].includes(out[0].mergedFrom[0].summary));
+    assert.notEqual(out[0].summary, out[0].mergedFrom[0].summary);
+  });
+});
+
+test("clusterFindings: real #578 DISTINCT findings in the same file never merge", () => {
+  DISTINCT_DEFECTS.forEach(([a, b], i) => {
+    const out = clusterFindings([asFinding(a), asFinding(b)]);
+    assert.equal(out.length, 2, `pair ${i + 1} must NOT have merged`);
+    for (const f of out) assert.equal(f.mergedFrom, undefined);
+  });
+});
+
+test("clusterFindings: a different file never merges, however alike the wording", () => {
+  const [a] = SAME_DEFECT[0];
+  const out = clusterFindings([
+    asFinding(a, { file: "scripts/agent/ask.mjs" }),
+    asFinding(a, { file: "scripts/agent/other.mjs" }),
+  ]);
+  assert.equal(out.length, 2);
+});
+
+test("clusterFindings: the cluster keeps the HIGHEST severity", () => {
+  // #578 reported the exact-string deny-list bug as both a critical and a major.
+  // Merging must not let the major mask the critical.
+  const [a, b] = SAME_DEFECT[1];
+  const out = clusterFindings([asFinding(a, { severity: "major" }), asFinding(b, { severity: "critical" })]);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].severity, "critical");
+  assert.equal(classify(out).conclusion, "failure");
+});
+
+test("clusterFindings: a gating member keeps the whole cluster gating", () => {
+  // Merging must never be able to turn a check green — the same rule
+  // dedupeFindings has, for the same reason.
+  const [a, b] = SAME_DEFECT[0];
+  const out = clusterFindings([
+    asFinding(a, { severity: "critical", lane: "backlog" }),
+    asFinding(b, { severity: "critical", lane: "blocking" }),
+  ]);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].lane, "blocking");
+  assert.equal(classify(gatingFindings(out)).conclusion, "failure");
+});
+
+test("clusterFindings: an all-backlog cluster stays demoted", () => {
+  const [a, b] = SAME_DEFECT[0];
+  const out = clusterFindings([
+    asFinding(a, { lane: "backlog" }),
+    asFinding(b, { lane: "backlog" }),
+  ]);
+  assert.equal(out[0].lane, "backlog");
+});
+
+test("clusterFindings: never invents a lane on a finding that had none", () => {
+  // minor/nit findings carry no lane; giving them one would build the second,
+  // redundant gate axis annotateFindings deliberately avoids.
+  const [a, b] = SAME_DEFECT[0];
+  const out = clusterFindings([asFinding(a, { severity: "nit" }), asFinding(b, { severity: "nit" })]);
+  assert.equal(out.length, 1);
+  assert.equal("lane" in out[0], false);
+});
+
+test("clusterFindings: `unsettled` propagates from any member", () => {
+  const [a, b] = SAME_DEFECT[0];
+  const out = clusterFindings([asFinding(a), asFinding(b, { unsettled: true })]);
+  assert.equal(out[0].unsettled, true);
+});
+
+test("clusterFindings: order-independent, and transitive via single linkage", () => {
+  // Four wordings of one defect must collapse to ONE regardless of the order they
+  // arrive in — which only holds if a wording can join on matching ANY member,
+  // not just whichever one currently holds the slot.
+  const wordings = [SAME_DEFECT[0][0], SAME_DEFECT[0][1], SAME_DEFECT[1][0], SAME_DEFECT[1][1]];
+  const forward = clusterFindings(wordings.map((s) => asFinding(s)));
+  const reverse = clusterFindings([...wordings].reverse().map((s) => asFinding(s)));
+  assert.deepEqual(forward.map((f) => f.summary).sort(), reverse.map((f) => f.summary).sort());
+  // Total finding count is conserved: survivors + everything folded into them.
+  const accounted = (out) => out.length + out.reduce((n, f) => n + (f.mergedFrom?.length ?? 0), 0);
+  assert.equal(accounted(forward), 4);
+  assert.equal(accounted(reverse), 4);
+});
+
+test("clusterFindings: tolerates junk and never folds a malformed entry into a real one", () => {
+  assert.deepEqual(clusterFindings(null), []);
+  assert.deepEqual(clusterFindings([]), []);
+  const out = clusterFindings([null, 42, asFinding("a real distinctive finding about tokens")]);
+  assert.equal(out.length, 3); // each travels alone
+});
+
+test("clusterCounts: reports collapsed wordings, not findings", () => {
+  const [a, b] = SAME_DEFECT[0];
+  const merged = clusterFindings([asFinding(a), asFinding(b), asFinding(SAME_DEFECT[2][0])]);
+  assert.deepEqual(clusterCounts(merged), { clustered: 1, collapsed: 1 });
+  assert.deepEqual(clusterCounts([]), { clustered: 0, collapsed: 0 });
+  assert.deepEqual(clusterCounts(null), { clustered: 0, collapsed: 0 });
 });

--- a/scripts/agent/severity.mjs
+++ b/scripts/agent/severity.mjs
@@ -18,10 +18,23 @@ export function normalizeSeverity(raw) {
   return KNOWN.includes(s) ? s : "major";
 }
 
-/** Normalize a raw findings array into `[{severity,file,summary,evidence}]`. */
+/**
+ * Normalize a raw findings array: `severity` coerced to the known scale, every
+ * other field PRESERVED.
+ *
+ * It used to rebuild each finding as exactly `{severity,file,summary,evidence}`,
+ * which silently dropped everything the orchestrator annotates onto a finding
+ * after the lens produced it. That was a real bug rather than a tidy contract:
+ * `renderSummaryMd` renders from `classify()`'s output, so the
+ * "verifier could not settle this" marker added for unresolved verifications
+ * never appeared in a single check body — the field was gone by the time the
+ * renderer looked for it. Anything that reads a finding downstream of `classify`
+ * needs the whole finding, so the safe shape is additive.
+ */
 export function normalizeFindings(rawFindings) {
   const arr = Array.isArray(rawFindings) ? rawFindings : [];
   return arr.map((f) => ({
+    ...(f && typeof f === "object" ? f : {}),
     severity: normalizeSeverity(f?.severity),
     file: f?.file,
     summary: f?.summary,
@@ -55,7 +68,16 @@ function section(findings, severity, heading) {
       // and could not disprove the claim, which is NOT the same as having
       // confirmed it, and printing them identically would read as endorsement.
       const unsettled = f.unsettled ? " _(verifier could not settle this)_" : "";
-      return `- ${f.file ? `\`${f.file}\` — ` : ""}${f.summary ?? "(no summary)"}${unsettled}`;
+      // Other wordings of this same defect, folded in by the clustering pass.
+      // Printed rather than dropped: merging is a judgement, and a reader — or
+      // the fix agent — must be able to see what was merged and disagree. A
+      // collapse nobody can inspect is a silent deletion with extra steps.
+      const merged = Array.isArray(f.mergedFrom) && f.mergedFrom.length
+        ? `\n  <details><summary>also reported as (${f.mergedFrom.length})</summary>\n\n` +
+          f.mergedFrom.map((m) => `  - (${m.severity}) ${m.summary ?? "(no summary)"}`).join("\n") +
+          "\n  </details>"
+        : "";
+      return `- ${f.file ? `\`${f.file}\` — ` : ""}${f.summary ?? "(no summary)"}${unsettled}${merged}`;
     })
     .join("\n");
   return `\n### ${heading} (${rows.length})\n${body}\n`;

--- a/scripts/agent/severity.test.mjs
+++ b/scripts/agent/severity.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { normalizeSeverity, classify, renderSummaryMd } from "./severity.mjs";
+import { normalizeSeverity, classify, renderSummaryMd, normalizeFindings } from "./severity.mjs";
 
 test("normalizeSeverity: known values pass through, unknown → major (fail-safe)", () => {
   for (const s of ["critical", "major", "minor", "nit"]) assert.equal(normalizeSeverity(s), s);
@@ -85,4 +85,39 @@ test("renderSummaryMd: no demoted findings renders no demoted section at all", (
   assert.doesNotMatch(renderSummaryMd("R", [], "", { demoted: [] }), /Relocated code/);
   // Junk entries are ignored rather than rendered as empty bullets.
   assert.doesNotMatch(renderSummaryMd("R", [], "", { demoted: [null, 42] }), /Relocated code/);
+});
+
+test("normalizeFindings: preserves orchestrator-added fields, not just the four it names", () => {
+  // Regression. This used to rebuild each finding as exactly
+  // {severity,file,summary,evidence}, which silently dropped everything the
+  // orchestrator annotates AFTER the lens produced it. renderSummaryMd renders
+  // from classify()'s output, so the "verifier could not settle this" marker
+  // shipped in the absence-claims change never appeared in a single check body —
+  // the field was gone before the renderer looked for it.
+  const [out] = normalizeFindings([
+    { severity: "weird", file: "a.mjs", summary: "s", evidence: "e",
+      unsettled: true, lane: "blocking", claimType: "absence",
+      novelty: { origin: "introduced" }, mergedFrom: [{ severity: "major", summary: "other wording" }] },
+  ]);
+  assert.equal(out.severity, "major"); // still coerced
+  assert.equal(out.unsettled, true);
+  assert.equal(out.lane, "blocking");
+  assert.equal(out.claimType, "absence");
+  assert.deepEqual(out.novelty, { origin: "introduced" });
+  assert.equal(out.mergedFrom.length, 1);
+  // Junk entries still normalize to a blocking placeholder rather than throwing.
+  assert.equal(normalizeFindings([null, 42])[0].severity, "major");
+});
+
+test("renderSummaryMd: an unsettled finding is marked, and merged wordings are shown", () => {
+  // The end-to-end version of the above: both annotations must survive
+  // classify() and reach the rendered body.
+  const md = renderSummaryMd("R", [
+    { severity: "major", file: "a.mjs", summary: "unsettled one", unsettled: true },
+    { severity: "major", file: "b.mjs", summary: "kept wording",
+      mergedFrom: [{ severity: "major", summary: "folded wording" }] },
+  ], "");
+  assert.match(md, /verifier could not settle this/);
+  assert.match(md, /also reported as \(1\)/);
+  assert.match(md, /folded wording/);
 });


### PR DESCRIPTION
## Summary

Collapse **restatements** of one defect into a single finding. `dedupeFindings`
only catches byte-identical summaries, so the panel reports one bug several times
whenever a lens describes it in different words.

Merging is **not** deletion — every collapsed wording rides along, is rendered,
and reaches the fixer. The only thing removed is the count inflation.

## Why

From #578's disposition comment: *"Three findings were double-reported (the
`hunt-probe.mjs` nit, the exact-string critical, the deny-list-shape major), which
inflates the counts."*

Each pair describes one defect in different words, so each gets a different
`file + lowercased summary` key and both survive. The verifier can't help: it
judges one finding at a time in isolation, so it structurally cannot notice it's
confirming the same bug twice — and it bills for each copy.

## No model call — the metric already exists and is already calibrated

The plan for this step called for one `askStructured` call per lens. That turned
out to be unnecessary.

`findingSimilarity` in `scripts/agent/rounds.mjs` was built for the
non-convergence detector: gated on same lens + same file, using the **overlap**
coefficient — chosen over Jaccard precisely because *"the panel restates one
defect at different levels of detail, and Jaccard penalises the extra specifics in
the longer wording"*. Its threshold was calibrated against real panel output
(#564's design-fit lens emitting four wordings of one defect).

Measured against #578's real data — the three double-reports its disposition
called out, plus the `CITATION` pair, versus four genuinely distinct findings from
the same lens and file:

| | score range |
|---|---|
| same defect, different wording | **0.308 – 0.933** |
| distinct defects, same lens+file | **0.000** |

The distinct pairs score exactly 0 because `MIN_SHARED_TOKENS = 3` zeroes them, so
the real gate is "share ≥3 meaningful tokens **and** overlap ≥ 0.3". Clean
separation on real data, deterministic, free.

`DEFAULT_SIMILARITY` is imported, not redefined — a second hand-tuned copy would
be exactly the drift `REFUTATION_GROUNDS` (derived from its schema) and `CITATION`
(extracted to a leaf module) both exist to avoid.

## Merging is not deletion

This is what makes it safe without a model in the loop, and it's the principle the
novelty gate landed on after this PR series' first review:

- every collapsed wording rides along in `mergedFrom`, is rendered in the check
  body, and reaches the fix agent — so a wrong merge is **visible**, and the fixer
  still reads both descriptions;
- the survivor takes the cluster's **highest** severity, so #578's `critical`
  restated as a `major` cannot be masked;
- the survivor **gates** if any member gated (the rule `dedupeFindings` already
  has), so merging can never turn a check green;
- `unsettled` propagates, and a lane is never invented on a finding that had none.

Single-linkage, not compare-to-representative: four wordings collapse to one only
if a new wording can join on matching **any** member. Membership is decided before
a representative is chosen, and the representative is picked by a total order
(gating → severity → has-evidence → longer summary → lexicographic), so the result
doesn't depend on input order — asserted in both directions.

## Stated limitation

Two wordings of one defect that share no vocabulary score 0 and stay separate.
That leaves the count inflated, which is the status quo — the conservative
direction. `clusters.collapsed` will show whether the residue justifies a paid
pass later.

## Also fixes a bug in the merged #587

Found by **rendering** the output rather than trusting the unit tests.

`normalizeFindings` rebuilt every finding as exactly
`{severity,file,summary,evidence}`, dropping everything the orchestrator annotates
after the lens produced it. `renderSummaryMd` renders from `classify()`'s output,
so **the "verifier could not settle this" marker shipped in #587 never appeared in
a single check body** — the field was gone before the renderer looked for it.

It now coerces `severity` and preserves the rest, with a regression test on the
field set and an end-to-end one on the rendered body.

## Verification

333 agent tests, `verify:self` green locally (11/11). The clustering tests use
**verbatim** #578 summaries rather than invented strings, because the threshold is
calibrated against real panel wording and synthetic text wouldn't exercise that.

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅

## Risk Assessment

- **User-facing risk:** none — review harness only.
- **Data/security risk:** none new. No new tool grants, no new execution, no model
  call added, and no new way for a finding to leave the merge gate.
- **Rollback plan:** drop the `clusterFindings(...)` wrapper in `main()`. Every
  other change is additive (`mergedFrom` rendering, counters), and with no
  clustering there is nothing to render.

## Notes for Reviewers

**AI assistance:** written by Claude Code in an interactive session —
implementation, tests, and this description. I haven't read every line myself yet,
so the author checklist is deliberately unticked.

One pre-existing source-grep test needed loosening for the **second** time and for
the same reason: it pinned `const merged = dedupeFindings`, which legitimately
became `clusterFindings(dedupeFindings(...))`. Its own docblock argues the point —
*"a guard over an implementation detail reports refactors as breakage"* — so it now
anchors on the binding rather than on which functions produce it.

**Last remaining #578 bucket, not in this PR:** wrong mechanism / true kernel. A
binary confirmed/refuted verdict has nowhere to put "the concern is real but the
stated cause is wrong", so such a finding rides through at full severity ("Bash/
Write stay available" was overstated but had a true core). Needs a
`confirmed-corrected` verdict that may only downgrade. See
`docs/tasks/active/20260730-restatement-clustering-todo.md`.

Follows #583 and #587.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Review results now consolidate repeated descriptions of the same defect, reducing inflated finding counts.
  * Consolidated findings retain the highest severity and appropriate gating behavior.
  * Review summaries and fix guidance can show alternate descriptions associated with a consolidated finding.
  * Unresolved status is preserved across merged findings.

* **Metrics**
  * Summaries now report how many repeated descriptions were combined.

* **Documentation**
  * Added guidance on restatement clustering, its safeguards, limitations, and monitoring metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->