### PR TITLE
Stop a git hook's GIT_DIR from redirecting novelty's git reads

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -190,6 +190,20 @@ Hook scripts live in `scripts/hooks/`.
 | `pnpm verify:entropy` | Dead-code (knip) + doc-staleness entropy gate |
 | `pnpm verify:self` | Runner: `verify:fast` + builds + chunk budgets + entropy; generates `.harness-reports/` JSON |
 
+**Branch-integrity gate.** `verify:self` records `HEAD` before the lanes and
+re-reads it after each one. A lane that moves `HEAD`, or leaves it unreadable,
+fails **even if it exited 0** — a lane can corrupt the repository and still
+report success. The lane report carries `status: "fail"` with a non-zero
+`exitCode` even when the lane's own exit code was 0, so no consumer is handed a
+report that reads as both failed and successful.
+
+The gate detects *net* movement of `HEAD` only. A lane that commits and resets
+back, rewrites another ref, or mutates the index or stash is **not** covered;
+the narrow guarantee is stated deliberately, because overclaiming invites
+trusting a green run. It exists because a test fixture escaping its temp
+directory replaced a working branch's tip three times, and one of those states
+reached a public PR as a diff appearing to delete every file in the repo.
+
 ### Integration Lanes (require database)
 
 | Command | Purpose |
@@ -497,7 +511,17 @@ Components:
   `git grep` against the base tree is a fallback for the second question only
   when move-aware blame cannot answer (shallow clone) — never an override of it.
   All probes run in the trusted script via async `execFile` (array args, no
-  shell, timeout); no capability is granted to a model. The result routes each
+  shell, timeout); no capability is granted to a model. Every git invocation is
+  built by `scripts/agent/git-env.mjs`, because **`cwd` and `-C` do not decide which repository
+  git operates on — the environment does, and it wins.** git exports its location
+  variables into every hook it runs, and `pre-push` runs `verify:self`, which
+  reaches this module; unscoped, a probe under a hook answers about whatever
+  `GIT_DIR` names. `repoScopedEnv` (reads) strips every location and behaviour
+  variable and caps discovery at the repo's parent, so a non-repo path fails
+  loudly instead of answering about an ancestor. `fixtureGitEnv` (writes, tests
+  only) additionally pins `GIT_DIR`/`GIT_WORK_TREE`; pinning `GIT_DIR` alone is
+  insufficient, because an inherited `GIT_INDEX_FILE` still makes `git add`
+  rewrite another repository's index and leaves it corrupt. The result routes each
   blocking finding to a **lane** (`routeFinding`): `blocking` gates as before,
   `backlog` is reported with the base location that proves the code already
   existed but does not gate, is **filtered out of the fixer's checklist**, and is

--- a/docs/tasks/active/20260729-autonomous-issue-hunting-lessons.md
+++ b/docs/tasks/active/20260729-autonomous-issue-hunting-lessons.md
@@ -167,3 +167,36 @@ that "is set" but may not authenticate.
 Dominated by **3.1M cache-read tokens** billed at 0.1× — without prompt caching the
 same run would be roughly an order of magnitude more. `metrics.mjs`'s existing
 `TOKEN_WEIGHTS` (`cacheRead: 0.1`) already models this correctly.
+
+## 13. A test that shells out to git can eat your branch, silently
+
+The tip of this task's branch was replaced three times by `novelty.test.mjs`'s
+4-file fixture tree, discarding ten commits from the branch pointer. One of those
+states reached PR #588, where it rendered as deleting all 3019 files.
+
+`cwd` does not confine git. In a directory that is not itself a repository, git
+walks **up** and finds the surrounding checkout — so a fixture whose `init` did not
+take effect commits into the real repo, on whatever branch is current. Work tree at
+the fixture plus git dir at the real repo yields exactly the observed shape: a
+4-file tree committed onto a live branch. Confinement needs explicit `GIT_DIR` /
+`GIT_WORK_TREE`, which disable discovery outright.
+
+Three things made it expensive rather than trivial:
+
+- **It succeeds.** An escaped fixture does not error; it commits somewhere else.
+  Tests stay green and nothing warns.
+- **`stdio: ["ignore","pipe","ignore"]` discarded stderr**, so git's own account of
+  what it did was thrown away. This became forensics — commit author identity,
+  reflog timestamps, commit-pair counts — instead of a stack trace.
+- **I diagnosed it wrong first.** All three losses coincided with `git push`, so I
+  blamed the `pre-push` → `verify:self` hook and "fixed" it with `--no-verify`. The
+  reflog then showed the commits landing ~5 minutes *before* the push. The
+  correlation was real and the causal direction was invented; `--no-verify` fixed
+  nothing and the hazard stayed live.
+
+Two habits earned: **read `git diff --stat origin/main...HEAD` before every push**
+(one second, and it is the only visible symptom), and **tag before recovering**
+(`archive/hunt-tier1-verified` is why ten commits were recoverable).
+
+And a smaller one, paid for twice: `git reset --hard` to undo a *test* also
+discards uncommitted work. Commit first, then experiment.

--- a/scripts/agent/git-env.mjs
+++ b/scripts/agent/git-env.mjs
@@ -1,0 +1,149 @@
+/**
+ * Environments for shelling out to git safely.
+ *
+ * `cwd` and `-C` do NOT decide which repository git operates on — the
+ * environment does, and it wins. That matters because **git exports its
+ * location variables into every hook it runs**, and this repo's `pre-push`
+ * hook runs `pnpm verify:self`, which reaches these scripts. Under a hook,
+ * a command that looks repo-scoped silently operates on whatever `GIT_DIR`
+ * names instead.
+ *
+ * That is not hypothetical. A test fixture inheriting these variables
+ * replaced a working branch's tip three times, and one of those states
+ * reached a public PR as a diff appearing to delete every file in the repo.
+ * Read paths answer about the wrong repository; write paths corrupt it.
+ *
+ * Two environments, because reads and writes need different strictness:
+ *
+ * - `repoScopedEnv(root)` — for READING an existing repository. Strips every
+ *   location variable so `cwd` selects the repo, and caps discovery so it
+ *   cannot ascend past `root`.
+ * - `fixtureGitEnv(dir)` — for WRITING to a throwaway repository. Everything
+ *   above, plus explicit `GIT_DIR`/`GIT_WORK_TREE` so no discovery happens.
+ */
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+/**
+ * Every variable that can redirect which repository, index, or object store
+ * git touches. Removing all of them is the point: a denylist that misses one
+ * is a denylist that fails silently, which is how this class of bug survives.
+ *
+ * The four that redirect WRITES are the dangerous ones. An inherited
+ * `GIT_INDEX_FILE` makes `git add` rewrite another repository's index — and
+ * because the objects it references live elsewhere, it leaves that index
+ * CORRUPT, not merely modified. Pinning `GIT_DIR` alone does not stop it.
+ */
+export const GIT_LOCATION_VARS = Object.freeze([
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_COMMON_DIR",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_CEILING_DIRECTORIES",
+  "GIT_NAMESPACE",
+  "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+  "GIT_INDEX_VERSION",
+]);
+
+/**
+ * Variables that steer git's *behaviour* rather than its location.
+ *
+ * git exports `GIT_CONFIG_PARAMETERS` for every `-c` it was given, so config
+ * set on an outer invocation reaches an inner one. Pathspec-magic variables
+ * silently change what a pathspec matches. Neither redirects the repository,
+ * but both can change an answer this harness then gates on.
+ */
+export const GIT_BEHAVIOUR_VARS = Object.freeze([
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_SYSTEM",
+  "GIT_CONFIG_NOSYSTEM",
+  "GIT_GLOB_PATHSPECS",
+  "GIT_NOGLOB_PATHSPECS",
+  "GIT_LITERAL_PATHSPECS",
+  "GIT_ICASE_PATHSPECS",
+]);
+
+/** `GIT_CONFIG_KEY_0`, `GIT_CONFIG_VALUE_0`, … — numbered, so matched by shape. */
+const NUMBERED_CONFIG = /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/;
+
+/** A copy of `base` with every git-steering variable removed. */
+function stripped(base) {
+  const env = { ...base };
+  for (const key of [...GIT_LOCATION_VARS, ...GIT_BEHAVIOUR_VARS]) delete env[key];
+  for (const key of Object.keys(env)) {
+    if (NUMBERED_CONFIG.test(key)) delete env[key];
+  }
+  return env;
+}
+
+/**
+ * Environment for reading the repository at `root`, with `cwd: root`.
+ *
+ * Deleting `GIT_DIR` rather than pinning it is deliberate: `root` may be a
+ * linked worktree, where `.git` is a FILE holding a `gitdir:` pointer, so a
+ * computed `GIT_DIR: root/.git` would be wrong exactly where it matters most.
+ *
+ * Deletion alone would leave discovery free to ascend, so `root` not being a
+ * repository would silently yield answers about an ancestor — a gate quietly
+ * measuring the wrong tree. `GIT_CEILING_DIRECTORIES` is set to `root`'s
+ * PARENT to cap that: git still finds `root`'s own `.git`, but refuses to
+ * climb past it and fails loudly instead. The parent, not `root` itself —
+ * git only honours ceiling entries that are strict ancestors of the directory
+ * it is searching from, so a ceiling equal to `cwd` is inert.
+ *
+ * Verified against a linked worktree: the `gitdir:` pointer is still followed,
+ * because a ceiling constrains directory discovery, not pointer resolution.
+ */
+export function repoScopedEnv(root, base = process.env) {
+  const env = stripped(base);
+  const abs = path.resolve(root);
+  const parent = path.dirname(abs);
+  // At a filesystem root `dirname` is a fixed point; a ceiling there is inert
+  // and would only be misleading, so leave it unset.
+  if (parent !== abs) env.GIT_CEILING_DIRECTORIES = parent;
+  return env;
+}
+
+/**
+ * Environment for writing to a throwaway repository at `dir`.
+ *
+ * Strictly stronger than `repoScopedEnv`: every steering variable is removed
+ * AND `GIT_DIR`/`GIT_WORK_TREE` are pinned, so git performs no discovery at
+ * all. Pinning is right here (unlike the read path) because `dir` is always a
+ * fresh ordinary repository — never a worktree or a bare repo.
+ */
+export function fixtureGitEnv(dir, base = process.env) {
+  const abs = path.resolve(dir);
+  return {
+    ...repoScopedEnv(abs, base),
+    GIT_DIR: path.join(abs, ".git"),
+    GIT_WORK_TREE: abs,
+  };
+}
+
+/**
+ * The commit `HEAD` names in the repository at `root`, or `null` if that
+ * cannot be determined.
+ *
+ * Scoped like every other read here. A guard that reads `HEAD` with an
+ * inherited environment can watch a different repository than the one being
+ * damaged, which makes it silently inert precisely under a hook — the one
+ * place it is needed.
+ */
+export function readHeadSha(root) {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+      env: repoScopedEnv(root),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}

--- a/scripts/agent/git-env.test.mjs
+++ b/scripts/agent/git-env.test.mjs
@@ -1,0 +1,165 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  GIT_LOCATION_VARS,
+  GIT_BEHAVIOUR_VARS,
+  repoScopedEnv,
+  fixtureGitEnv,
+  readHeadSha,
+} from "./git-env.mjs";
+
+/** git with a fixed identity, fully scoped — the helper under test. */
+function git(dir, ...args) {
+  return execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...args], {
+    cwd: dir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: fixtureGitEnv(dir),
+  });
+}
+
+function makeRepo(prefix = "git-env-") {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  git(dir, "init", "-q", "-b", "main");
+  writeFileSync(path.join(dir, "a.mjs"), "export const A = 1;\n");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "base");
+  return dir;
+}
+
+// --- the strip list ----------------------------------------------------------
+
+test("repoScopedEnv removes every location and behaviour variable", () => {
+  // A denylist that misses one entry fails silently, which is how this class of
+  // bug survives — so assert the whole list, derived from the module's own
+  // exports rather than re-typed here.
+  const hostile = {};
+  for (const k of [...GIT_LOCATION_VARS, ...GIT_BEHAVIOUR_VARS]) hostile[k] = "/hostile";
+  const env = repoScopedEnv("/tmp/some/repo", { ...hostile, PATH: "/usr/bin" });
+
+  for (const k of GIT_LOCATION_VARS) {
+    if (k === "GIT_CEILING_DIRECTORIES") continue; // deliberately re-set, below
+    assert.equal(env[k], undefined, `${k} survived`);
+  }
+  for (const k of GIT_BEHAVIOUR_VARS) assert.equal(env[k], undefined, `${k} survived`);
+  assert.equal(env.PATH, "/usr/bin", "unrelated variables must be preserved");
+});
+
+test("repoScopedEnv removes numbered GIT_CONFIG_KEY_n / VALUE_n pairs", () => {
+  // git exports these for every `-c` it was given, so they arrive numbered and
+  // cannot be listed literally.
+  const env = repoScopedEnv("/tmp/r", {
+    GIT_CONFIG_COUNT: "2",
+    GIT_CONFIG_KEY_0: "core.hooksPath",
+    GIT_CONFIG_VALUE_0: "/evil",
+    GIT_CONFIG_KEY_11: "user.name",
+    GIT_CONFIG_VALUE_11: "x",
+    KEEP: "yes",
+  });
+  for (const k of ["GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0", "GIT_CONFIG_KEY_11", "GIT_CONFIG_VALUE_11"]) {
+    assert.equal(env[k], undefined, `${k} survived`);
+  }
+  assert.equal(env.KEEP, "yes");
+});
+
+test("repoScopedEnv caps discovery at the PARENT of root, not root itself", () => {
+  // git only honours ceiling entries that are strict ancestors of the directory
+  // it searches from, so a ceiling equal to cwd is inert. Pinning that here
+  // because the inert form looks correct and silently protects nothing.
+  assert.equal(repoScopedEnv("/a/b/repo").GIT_CEILING_DIRECTORIES, "/a/b");
+  assert.equal(repoScopedEnv("/a/b/repo/").GIT_CEILING_DIRECTORIES, "/a/b");
+});
+
+test("repoScopedEnv omits the ceiling at a filesystem root", () => {
+  // dirname("/") === "/", so a ceiling there would be inert and misleading.
+  assert.equal(repoScopedEnv("/").GIT_CEILING_DIRECTORIES, undefined);
+});
+
+// --- the write path ----------------------------------------------------------
+
+test("fixtureGitEnv pins the git dir AND strips the redirecting variables", () => {
+  // The critical property. Pinning GIT_DIR alone leaves GIT_INDEX_FILE and the
+  // object-store variables inherited, and `git add` through an inherited
+  // GIT_INDEX_FILE rewrites another repository's index — leaving it CORRUPT,
+  // since the objects it records live in this fixture's store.
+  const env = fixtureGitEnv("/tmp/fx", {
+    GIT_INDEX_FILE: "/victim/.git/index",
+    GIT_OBJECT_DIRECTORY: "/victim/.git/objects",
+    GIT_COMMON_DIR: "/victim/.git",
+    GIT_ALTERNATE_OBJECT_DIRECTORIES: "/victim/.git/objects",
+  });
+  assert.equal(env.GIT_DIR, path.join("/tmp/fx", ".git"));
+  assert.equal(env.GIT_WORK_TREE, "/tmp/fx");
+  for (const k of ["GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_COMMON_DIR", "GIT_ALTERNATE_OBJECT_DIRECTORIES"]) {
+    assert.equal(env[k], undefined, `${k} survived into a WRITE environment`);
+  }
+});
+
+// --- readHeadSha: the verify:self guard's only moving part -------------------
+
+test("readHeadSha answers about `root`, not an inherited GIT_DIR", () => {
+  // The guard in verify-self.mjs is top-level script code with no test file of
+  // its own; this covers the one function that decides whether it works. A guard
+  // that reads HEAD with an inherited environment watches the wrong repository
+  // and is silently inert exactly under a hook, where it is needed.
+  const mine = makeRepo("git-env-mine-");
+  const other = makeRepo("git-env-other-");
+  const saved = process.env.GIT_DIR;
+  try {
+    const expected = git(mine, "rev-parse", "HEAD").trim();
+    const foreign = git(other, "rev-parse", "HEAD").trim();
+    process.env.GIT_DIR = path.join(other, ".git");
+    const got = readHeadSha(mine);
+    assert.equal(got, expected);
+    if (foreign !== expected) assert.notEqual(got, foreign);
+  } finally {
+    if (saved === undefined) delete process.env.GIT_DIR;
+    else process.env.GIT_DIR = saved;
+    rmSync(mine, { recursive: true, force: true });
+    rmSync(other, { recursive: true, force: true });
+  }
+});
+
+test("readHeadSha returns null outside a repository rather than an ancestor's sha", () => {
+  // Two properties at once: the guard degrades to "not applicable" outside a
+  // checkout (vendored copy, exported tarball), and the ceiling stops discovery
+  // from ascending into a surrounding repository and answering about IT.
+  const outer = makeRepo("git-env-outer-");
+  const nested = path.join(outer, "plain");
+  mkdirSync(nested, { recursive: true });
+  try {
+    assert.equal(readHeadSha(nested), null);
+  } finally {
+    rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("readHeadSha works in a linked worktree — the reason GIT_DIR is deleted, not pinned", () => {
+  // The stated rationale for deleting rather than pinning: in a linked worktree
+  // `.git` is a FILE holding a `gitdir:` pointer, so a computed
+  // `GIT_DIR: root/.git` would be wrong exactly where it matters most. This is
+  // the fixture that makes that claim testable rather than asserted.
+  const main = makeRepo("git-env-wt-");
+  const linked = path.join(main, "..", path.basename(main) + "-linked");
+  try {
+    git(main, "worktree", "add", "-q", "-b", "side", linked);
+    const viaGit = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: linked,
+      encoding: "utf8",
+      env: repoScopedEnv(linked),
+    }).trim();
+    assert.equal(readHeadSha(linked), viaGit);
+    assert.match(readHeadSha(linked) ?? "", /^[0-9a-f]{40}$/);
+  } finally {
+    try {
+      git(main, "worktree", "remove", "--force", linked);
+    } catch {
+      rmSync(linked, { recursive: true, force: true });
+    }
+    rmSync(main, { recursive: true, force: true });
+  }
+});

--- a/scripts/agent/hunt.mjs
+++ b/scripts/agent/hunt.mjs
@@ -30,6 +30,7 @@
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { repoScopedEnv } from "./git-env.mjs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -364,7 +365,10 @@ function repoSlug(repo) {
 
 function gitSha(repo) {
   try {
-    return execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    return execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+      env: repoScopedEnv(repo),
+    }).trim();
   } catch {
     return "unknown";
   }
@@ -375,6 +379,7 @@ function makeChangedSince(repo, globs) {
   return (sha) => {
     try {
       const out = execFileSync("git", ["-C", repo, "log", "--oneline", `${sha}..HEAD`, "--", ...globs], {
+        env: repoScopedEnv(repo),
         encoding: "utf8",
       });
       return out.trim() !== "";

--- a/scripts/agent/novelty.mjs
+++ b/scripts/agent/novelty.mjs
@@ -186,6 +186,7 @@ async function git(args, repo) {
   try {
     const { stdout } = await execFileAsync("git", args, {
       cwd: repo,
+      env: repoScopedEnv(),
       timeout: GIT_TIMEOUT_MS,
       maxBuffer: GIT_MAX_BUFFER,
       encoding: "utf8",
@@ -194,6 +195,40 @@ async function git(args, repo) {
   } catch (e) {
     return { ok: false, status: typeof e?.code === "number" ? e.code : null, stdout: "" };
   }
+}
+
+/**
+ * `process.env` with every git-location variable removed, so `cwd` alone
+ * decides which repository these commands read.
+ *
+ * `cwd` does NOT win against an inherited `GIT_DIR` — the environment does.
+ * That matters because **git exports `GIT_DIR` into every hook it runs**, and
+ * this repo's `pre-push` hook runs `pnpm verify:self`, which reaches this
+ * module. Without this, a novelty lookup performed under any hook silently
+ * blames the WRONG repository: `cwd` says fixture, `GIT_DIR` says the real
+ * checkout, and git obeys `GIT_DIR`. The answers still look well-formed, so a
+ * finding gets demoted or kept on evidence from an unrelated tree.
+ *
+ * Deleting rather than pinning is deliberate: `repo` may be a linked worktree,
+ * where `.git` is a FILE containing a `gitdir:` pointer, so a computed
+ * `GIT_DIR: repo/.git` would be wrong exactly where it matters most. Letting
+ * discovery run from a clean environment handles worktrees, bare repos, and
+ * ordinary checkouts alike.
+ */
+function repoScopedEnv() {
+  const env = { ...process.env };
+  for (const key of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CEILING_DIRECTORIES",
+  ]) {
+    delete env[key];
+  }
+  return env;
 }
 
 /**

--- a/scripts/agent/novelty.mjs
+++ b/scripts/agent/novelty.mjs
@@ -40,6 +40,7 @@
 // finding blocking. Demotion requires BOTH blames to have answered.
 
 import { execFile } from "node:child_process";
+import { repoScopedEnv } from "./git-env.mjs";
 import { promisify } from "node:util";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -186,7 +187,7 @@ async function git(args, repo) {
   try {
     const { stdout } = await execFileAsync("git", args, {
       cwd: repo,
-      env: repoScopedEnv(),
+      env: repoScopedEnv(repo),
       timeout: GIT_TIMEOUT_MS,
       maxBuffer: GIT_MAX_BUFFER,
       encoding: "utf8",
@@ -197,39 +198,6 @@ async function git(args, repo) {
   }
 }
 
-/**
- * `process.env` with every git-location variable removed, so `cwd` alone
- * decides which repository these commands read.
- *
- * `cwd` does NOT win against an inherited `GIT_DIR` — the environment does.
- * That matters because **git exports `GIT_DIR` into every hook it runs**, and
- * this repo's `pre-push` hook runs `pnpm verify:self`, which reaches this
- * module. Without this, a novelty lookup performed under any hook silently
- * blames the WRONG repository: `cwd` says fixture, `GIT_DIR` says the real
- * checkout, and git obeys `GIT_DIR`. The answers still look well-formed, so a
- * finding gets demoted or kept on evidence from an unrelated tree.
- *
- * Deleting rather than pinning is deliberate: `repo` may be a linked worktree,
- * where `.git` is a FILE containing a `gitdir:` pointer, so a computed
- * `GIT_DIR: repo/.git` would be wrong exactly where it matters most. Letting
- * discovery run from a clean environment handles worktrees, bare repos, and
- * ordinary checkouts alike.
- */
-function repoScopedEnv() {
-  const env = { ...process.env };
-  for (const key of [
-    "GIT_DIR",
-    "GIT_WORK_TREE",
-    "GIT_COMMON_DIR",
-    "GIT_INDEX_FILE",
-    "GIT_OBJECT_DIRECTORY",
-    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-    "GIT_CEILING_DIRECTORIES",
-  ]) {
-    delete env[key];
-  }
-  return env;
-}
 
 /**
  * Does `baseSha` name a commit in this repo? Called ONCE by the caller so a

--- a/scripts/agent/novelty.test.mjs
+++ b/scripts/agent/novelty.test.mjs
@@ -1,7 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { fixtureGitEnv } from "./git-env.mjs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -217,19 +220,21 @@ test("noveltyOf: the cache is consulted before any git work", async () => {
 // repo with an actual refactor in it and read the actual answers, so a change
 // that renders the gate inert (or demoting) cannot ship green.
 
+/** The checkout this test file lives in. */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
 /**
- * git with a fixed identity, so the test does not depend on global config.
+ * git with a fixed identity, in an environment that cannot reach any repository
+ * but `dir`.
  *
- * `GIT_DIR`/`GIT_WORK_TREE` are pinned explicitly rather than trusting `cwd`
- * alone. A fixture that escapes its temp directory does not fail — it commits
- * into the SURROUNDING repository, on whatever branch is checked out, replacing
- * the developer's branch tip. `cwd` alone does not prevent that: in a directory
- * that is not itself a repo, git walks UP and finds the real checkout. With
- * these set, git performs no discovery at all. `GIT_CEILING_DIRECTORIES` is
- * belt-and-braces for any subcommand that re-derives the root itself.
+ * `fixtureGitEnv` removes every git-steering variable AND pins
+ * `GIT_DIR`/`GIT_WORK_TREE`. Pinning `GIT_DIR` alone is NOT enough: an inherited
+ * `GIT_INDEX_FILE` still makes `git add` write another repository's index, and
+ * because the objects it records live in this fixture's store, that index is left
+ * CORRUPT rather than merely modified. The escape test below pins that.
  *
- * stderr is captured rather than discarded: when one of these calls does go
- * wrong, git's own message is the only evidence of what it actually did.
+ * stderr is captured rather than discarded: when one of these calls goes wrong,
+ * git's own message is the only evidence of what it actually did.
  */
 function git(dir, ...args) {
   try {
@@ -237,12 +242,7 @@ function git(dir, ...args) {
       cwd: dir,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        GIT_DIR: path.join(dir, ".git"),
-        GIT_WORK_TREE: dir,
-        GIT_CEILING_DIRECTORIES: dir,
-      },
+      env: fixtureGitEnv(dir),
     });
   } catch (e) {
     const why = String(e?.stderr || e?.message || e).trim();
@@ -251,22 +251,35 @@ function git(dir, ...args) {
 }
 
 /**
- * Prove the fixture's git resolves to `dir` and nothing else.
+ * Prove the fixture's git resolves to `dir`'s own repository.
  *
- * The pinning above should make escape impossible, but "should" is what the
- * previous version of this helper also had. This converts a silent commit into
- * the real repository into a loud failure. `realpathSync` on both sides because
- * macOS `tmpdir()` is `/var/...` while git reports the resolved `/private/var/...`,
- * so comparing raw strings would fail every run.
+ * `--absolute-git-dir` is the load-bearing assertion. `--show-toplevel` merely
+ * echoes whatever `GIT_WORK_TREE` was pinned to, so on its own it CANNOT detect a
+ * `GIT_DIR` escape — the exact incident shape — and asserting it alone would be
+ * tautological. The git dir is what decides where commits and refs land.
  */
 function assertIsolated(dir) {
-  const top = git(dir, "rev-parse", "--show-toplevel").trim();
+  const gitDir = git(dir, "rev-parse", "--absolute-git-dir").trim();
   assert.equal(
-    realpathSync(top),
-    realpathSync(dir),
-    `fixture git escaped its temp directory (resolved to ${top}) — it would commit into the real repo`,
+    realpathSync(gitDir),
+    realpathSync(path.join(dir, ".git")),
+    `fixture git dir escaped to ${gitDir} — commits would land in another repository`,
   );
+  const top = git(dir, "rev-parse", "--show-toplevel").trim();
+  assert.equal(realpathSync(top), realpathSync(dir), `fixture work tree escaped to ${top}`);
 }
+
+/** A repo with one commit, used as the thing a leak would damage. */
+function makeVictim() {
+  const dir = mkdtempSync(path.join(tmpdir(), "novelty-victim-"));
+  git(dir, "init", "-q", "-b", "main");
+  writeFileSync(path.join(dir, "victim.mjs"), "export const VICTIM = 1;\n");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "victim base");
+  return dir;
+}
+
+const sha256 = (file) => createHash("sha256").update(readFileSync(file)).digest("hex");
 
 /**
  * A repo whose HEAD commit performs the #578 refactor:
@@ -314,63 +327,85 @@ function makeRepo() {
 }
 
 test("noveltyOf answers about `repo`, not an inherited GIT_DIR", async () => {
-  // THE regression test for the root cause of the branch-clobbering incident.
+  // THE regression test for the root cause. git exports GIT_DIR into every hook
+  // it runs, and this repo's pre-push hook runs `pnpm verify:self`, which reaches
+  // this module. `cwd` does not win against GIT_DIR — the environment does.
   //
-  // git exports GIT_DIR into every hook it runs, and this repo's pre-push hook
-  // runs `pnpm verify:self`, which reaches this module. `cwd` does not win
-  // against GIT_DIR — the environment does. So under any hook, a novelty lookup
-  // would silently blame whatever repository GIT_DIR names instead of `repo`,
-  // and the answers still look well-formed: a finding is demoted or kept on
-  // evidence from an unrelated tree.
-  //
-  // Point GIT_DIR at a DIFFERENT repo and assert the answer is unchanged.
+  // The foreign repo must be DISTINGUISHABLE, or this proves nothing: two copies
+  // of makeRepo() are byte-identical and commit within the same whole second, so
+  // their shas collide and a leaked read returns the same answers. So point
+  // GIT_DIR at an EMPTY repo, where `baseSha` cannot resolve at all: scoped it
+  // answers `relocated`, leaked it can only answer `unknown`.
   const { dir, base } = makeRepo();
-  const foreign = makeRepo();
+  const empty = mkdtempSync(path.join(tmpdir(), "novelty-empty-"));
   const saved = process.env.GIT_DIR;
   try {
-    process.env.GIT_DIR = path.join(foreign.dir, ".git");
+    git(empty, "init", "-q", "-b", "main");
+    process.env.GIT_DIR = path.join(empty, ".git");
     const r = await noveltyOf({ repo: dir, file: "moved.mjs", line: 2, baseSha: base });
-    assert.equal(r.origin, "relocated");
+    assert.equal(r.origin, "relocated", "answered about GIT_DIR's repo, not `repo`");
     assert.match(String(r.alsoAt), /old\.mjs:\d+$/);
   } finally {
     if (saved === undefined) delete process.env.GIT_DIR;
     else process.env.GIT_DIR = saved;
     rmSync(dir, { recursive: true, force: true });
-    rmSync(foreign.dir, { recursive: true, force: true });
+    rmSync(empty, { recursive: true, force: true });
   }
 });
 
-test("fixture git cannot escape into the surrounding repository", () => {
-  // THE regression test for a silent branch-clobbering incident: these fixture
-  // git calls committed into the REAL repository, replacing a developer's branch
-  // tip with the 4-file fixture tree above, and the resulting push read as
-  // deleting all 3019 files. An escaped fixture does not fail — it succeeds
-  // against the wrong repo — so nothing catches it but a check like this one.
+test("fixture git cannot escape, even with a hostile inherited environment", () => {
+  // THE regression test for the write half of the incident, where fixture commits
+  // replaced a branch tip and the resulting push read as deleting every file.
   //
-  // Build the fixture INSIDE the real checkout, the one place discovery would
-  // walk up and find a parent to commit into.
-  const inside = mkdtempSync(path.join(process.cwd(), "novelty-escape-"));
-  try {
-    git(inside, "init", "-q", "-b", "main");
+  // A hostile ambient environment is the whole point: without one, the assertions
+  // below hold whether or not the helper scopes anything, and the test is
+  // decoration. GIT_INDEX_FILE is the sharp one — pinning GIT_DIR does NOT stop
+  // it, and `git add` through it leaves the victim's index corrupt.
+  //
+  // The fixture lives under .harness-reports/ (gitignored) rather than the
+  // working tree proper, so it is still INSIDE a checkout — the condition that
+  // makes discovery dangerous — without an interrupted run leaving a nested .git
+  // that `git add -A` would commit as a gitlink.
+  const scratch = path.join(REPO_ROOT, ".harness-reports");
+  mkdirSync(scratch, { recursive: true });
+  const inside = mkdtempSync(path.join(scratch, "novelty-escape-"));
+  const victim = makeVictim();
+  const victimHead = git(victim, "rev-parse", "HEAD").trim();
+  const victimIndex = sha256(path.join(victim, ".git", "index"));
 
-    // Ordering is load-bearing: prove isolation BEFORE writing a commit, so a
-    // broken pin fails an assertion instead of mutating the real branch.
+  const saved = { ...process.env };
+  try {
+    process.env.GIT_DIR = path.join(victim, ".git");
+    process.env.GIT_WORK_TREE = victim;
+    process.env.GIT_INDEX_FILE = path.join(victim, ".git", "index");
+
+    git(inside, "init", "-q", "-b", "main");
+    // Ordering is load-bearing: prove isolation BEFORE writing, so a broken pin
+    // trips an assertion instead of mutating the victim.
     assertIsolated(inside);
-    assert.equal(
-      realpathSync(git(inside, "rev-parse", "--absolute-git-dir").trim()),
-      realpathSync(path.join(inside, ".git")),
-    );
 
     writeFileSync(path.join(inside, "f.txt"), "contained\n");
     git(inside, "add", "-A");
     git(inside, "commit", "-q", "-m", "fixture-only");
 
-    // A one-commit history with one file proves this is the fixture's repo and
-    // not the real one (thousands of each) — i.e. the commit was contained.
+    // The write landed in the fixture...
     assert.equal(git(inside, "rev-list", "--count", "HEAD").trim(), "1");
     assert.deepEqual(git(inside, "ls-tree", "-r", "--name-only", "HEAD").trim().split("\n"), ["f.txt"]);
   } finally {
-    rmSync(inside, { recursive: true, force: true });
+    for (const k of ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"]) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    // ...and the victim is untouched: same tip, same index, and an index that
+    // still reads (a leaked `git add` leaves one referencing absent objects).
+    try {
+      assert.equal(git(victim, "rev-parse", "HEAD").trim(), victimHead, "victim HEAD moved");
+      assert.equal(sha256(path.join(victim, ".git", "index")), victimIndex, "victim index rewritten");
+      git(victim, "status", "--short");
+    } finally {
+      rmSync(inside, { recursive: true, force: true });
+      rmSync(victim, { recursive: true, force: true });
+    }
   }
 });
 

--- a/scripts/agent/novelty.test.mjs
+++ b/scripts/agent/novelty.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -217,13 +217,55 @@ test("noveltyOf: the cache is consulted before any git work", async () => {
 // repo with an actual refactor in it and read the actual answers, so a change
 // that renders the gate inert (or demoting) cannot ship green.
 
-/** git with a fixed identity, so the test does not depend on global config. */
+/**
+ * git with a fixed identity, so the test does not depend on global config.
+ *
+ * `GIT_DIR`/`GIT_WORK_TREE` are pinned explicitly rather than trusting `cwd`
+ * alone. A fixture that escapes its temp directory does not fail — it commits
+ * into the SURROUNDING repository, on whatever branch is checked out, replacing
+ * the developer's branch tip. `cwd` alone does not prevent that: in a directory
+ * that is not itself a repo, git walks UP and finds the real checkout. With
+ * these set, git performs no discovery at all. `GIT_CEILING_DIRECTORIES` is
+ * belt-and-braces for any subcommand that re-derives the root itself.
+ *
+ * stderr is captured rather than discarded: when one of these calls does go
+ * wrong, git's own message is the only evidence of what it actually did.
+ */
 function git(dir, ...args) {
-  return execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...args], {
-    cwd: dir,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
+  try {
+    return execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...args], {
+      cwd: dir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        GIT_DIR: path.join(dir, ".git"),
+        GIT_WORK_TREE: dir,
+        GIT_CEILING_DIRECTORIES: dir,
+      },
+    });
+  } catch (e) {
+    const why = String(e?.stderr || e?.message || e).trim();
+    throw new Error(`fixture git failed: git ${args.join(" ")} (in ${dir}): ${why}`);
+  }
+}
+
+/**
+ * Prove the fixture's git resolves to `dir` and nothing else.
+ *
+ * The pinning above should make escape impossible, but "should" is what the
+ * previous version of this helper also had. This converts a silent commit into
+ * the real repository into a loud failure. `realpathSync` on both sides because
+ * macOS `tmpdir()` is `/var/...` while git reports the resolved `/private/var/...`,
+ * so comparing raw strings would fail every run.
+ */
+function assertIsolated(dir) {
+  const top = git(dir, "rev-parse", "--show-toplevel").trim();
+  assert.equal(
+    realpathSync(top),
+    realpathSync(dir),
+    `fixture git escaped its temp directory (resolved to ${top}) — it would commit into the real repo`,
+  );
 }
 
 /**
@@ -235,6 +277,7 @@ function git(dir, ...args) {
 function makeRepo() {
   const dir = mkdtempSync(path.join(tmpdir(), "novelty-test-"));
   git(dir, "init", "-q", "-b", "main");
+  assertIsolated(dir);
 
   const movedFn = [
     "export function classifyResult(result) {",
@@ -269,6 +312,40 @@ function makeRepo() {
 
   return { dir, base };
 }
+
+test("fixture git cannot escape into the surrounding repository", () => {
+  // THE regression test for a silent branch-clobbering incident: these fixture
+  // git calls committed into the REAL repository, replacing a developer's branch
+  // tip with the 4-file fixture tree above, and the resulting push read as
+  // deleting all 3019 files. An escaped fixture does not fail — it succeeds
+  // against the wrong repo — so nothing catches it but a check like this one.
+  //
+  // Build the fixture INSIDE the real checkout, the one place discovery would
+  // walk up and find a parent to commit into.
+  const inside = mkdtempSync(path.join(process.cwd(), "novelty-escape-"));
+  try {
+    git(inside, "init", "-q", "-b", "main");
+
+    // Ordering is load-bearing: prove isolation BEFORE writing a commit, so a
+    // broken pin fails an assertion instead of mutating the real branch.
+    assertIsolated(inside);
+    assert.equal(
+      realpathSync(git(inside, "rev-parse", "--absolute-git-dir").trim()),
+      realpathSync(path.join(inside, ".git")),
+    );
+
+    writeFileSync(path.join(inside, "f.txt"), "contained\n");
+    git(inside, "add", "-A");
+    git(inside, "commit", "-q", "-m", "fixture-only");
+
+    // A one-commit history with one file proves this is the fixture's repo and
+    // not the real one (thousands of each) — i.e. the commit was contained.
+    assert.equal(git(inside, "rev-list", "--count", "HEAD").trim(), "1");
+    assert.deepEqual(git(inside, "ls-tree", "-r", "--name-only", "HEAD").trim().split("\n"), ["f.txt"]);
+  } finally {
+    rmSync(inside, { recursive: true, force: true });
+  }
+});
 
 test("noveltyOf [real git]: verbatim-moved code is `relocated` and demotes", async () => {
   const { dir, base } = makeRepo();

--- a/scripts/agent/novelty.test.mjs
+++ b/scripts/agent/novelty.test.mjs
@@ -313,6 +313,33 @@ function makeRepo() {
   return { dir, base };
 }
 
+test("noveltyOf answers about `repo`, not an inherited GIT_DIR", async () => {
+  // THE regression test for the root cause of the branch-clobbering incident.
+  //
+  // git exports GIT_DIR into every hook it runs, and this repo's pre-push hook
+  // runs `pnpm verify:self`, which reaches this module. `cwd` does not win
+  // against GIT_DIR — the environment does. So under any hook, a novelty lookup
+  // would silently blame whatever repository GIT_DIR names instead of `repo`,
+  // and the answers still look well-formed: a finding is demoted or kept on
+  // evidence from an unrelated tree.
+  //
+  // Point GIT_DIR at a DIFFERENT repo and assert the answer is unchanged.
+  const { dir, base } = makeRepo();
+  const foreign = makeRepo();
+  const saved = process.env.GIT_DIR;
+  try {
+    process.env.GIT_DIR = path.join(foreign.dir, ".git");
+    const r = await noveltyOf({ repo: dir, file: "moved.mjs", line: 2, baseSha: base });
+    assert.equal(r.origin, "relocated");
+    assert.match(String(r.alsoAt), /old\.mjs:\d+$/);
+  } finally {
+    if (saved === undefined) delete process.env.GIT_DIR;
+    else process.env.GIT_DIR = saved;
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(foreign.dir, { recursive: true, force: true });
+  }
+});
+
 test("fixture git cannot escape into the surrounding repository", () => {
   // THE regression test for a silent branch-clobbering incident: these fixture
   // git calls committed into the REAL repository, replacing a developer's branch

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -1,4 +1,5 @@
-import { spawn, execFileSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import { readHeadSha } from "./agent/git-env.mjs";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -98,28 +99,27 @@ function writeSummary(results, totalStart) {
 
 /**
  * The commit HEAD points at, or `null` when that cannot be read (a vendored
- * copy or exported tarball, where the guard below simply does not apply).
+ * copy or exported tarball, where the guard below does not apply).
  *
  * Read once before the lanes and again after each one. No lane may move the
- * developer's branch. A test that shells out to git and escapes its fixture
- * directory does not fail — it commits into THIS repository, on whatever branch
- * is checked out, replacing the branch tip. That happened: ten commits left a
- * branch and the resulting push read as deleting all 3019 files. The only
- * symptom was the diff stat, and only if someone looked before pushing.
+ * developer's branch: a test that shells out to git and escapes its fixture
+ * commits into THIS repository instead, on whatever branch is checked out,
+ * replacing the branch tip. That happened — ten commits left a branch and the
+ * resulting push read as deleting every file — and the only symptom was the
+ * diff stat.
  *
- * Checking here catches the whole class rather than one known test, and names
- * the lane responsible — turning a reflog excavation into one line of output.
+ * Scoped via `readHeadSha` rather than trusting `cwd`, because this runner IS
+ * the `pre-push` hook's entry point, and a hook is exactly where git exports
+ * `GIT_DIR`. Reading `HEAD` with an inherited environment would let the guard
+ * watch a different repository than the lanes can damage.
+ *
+ * Detects *net* movement of `HEAD` only. A lane that commits and resets back,
+ * rewrites another ref, or mutates the index or stash is NOT covered; claiming
+ * otherwise would be worse than the narrow guarantee, because it invites
+ * trusting a green run.
  */
 function readHead() {
-  try {
-    return execFileSync("git", ["rev-parse", "HEAD"], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    return null;
-  }
+  return readHeadSha(repoRoot);
 }
 
 // --- main ---
@@ -151,22 +151,38 @@ for (const { name, cmd } of LANES) {
   const { exitCode, output } = await runCommand(cmd, repoRoot);
   const durationMs = Date.now() - start;
 
-  // Fail on a moved branch even when the lane itself passed — a lane that
-  // rewrites history and exits 0 is the exact case this exists to catch.
+  // Checked after the exitCode split so a lane that genuinely failed keeps its
+  // own diagnosis; a moved HEAD is then reported on top of it rather than
+  // instead of it. `headAfter == null` while `headBefore` was readable means
+  // the repository stopped answering during the lane, which is a worse outcome
+  // than movement and must not pass as "unchanged".
   const headAfter = readHead();
-  if (headBefore && headAfter && headAfter !== headBefore) {
+  const headLost = Boolean(headBefore) && headAfter === null;
+  const headMoved = Boolean(headBefore) && Boolean(headAfter) && headAfter !== headBefore;
+
+  if (headMoved || headLost) {
+    const detail = headMoved
+      ? `moved HEAD ${headBefore.slice(0, 9)} -> ${headAfter.slice(0, 9)}`
+      : "left HEAD unreadable";
     const report = {
       lane: name,
       status: "fail",
       durationMs,
-      exitCode,
-      failureSummary: `lane moved HEAD ${headBefore.slice(0, 9)} -> ${headAfter.slice(0, 9)}`,
+      // Deliberately not the lane's own exit code: a lane can corrupt the
+      // repository and still exit 0, and a report saying `fail` alongside
+      // `exitCode: 0` reads as a contradiction to downstream consumers.
+      exitCode: exitCode === 0 ? 1 : exitCode,
+      failureSummary: `lane ${detail}${exitCode === 0 ? "" : ` (lane also exited ${exitCode})`}`,
     };
     results.push(report);
     writeLaneReport(report);
-    console.error(`\n\u2717 ${name} MOVED HEAD: ${headBefore.slice(0, 9)} -> ${headAfter.slice(0, 9)}`);
-    console.error("  This lane committed into the repository. Your branch tip was replaced.");
-    console.error(`  Recover with:  git reset --hard ${headBefore}`);
+    console.error(`\n\u2717 ${name} ${detail}`);
+    console.error("  This lane wrote to the repository. Inspect before doing anything else:");
+    console.error("    git status && git reflog -n 20");
+    if (headMoved) {
+      console.error(`  The prior tip was ${headBefore}. Resetting to it DISCARDS uncommitted work,`);
+      console.error("  so tag the current state first:  git tag rescue/$(date +%s) HEAD");
+    }
     failed = true;
     continue;
   }

--- a/scripts/verify-self.mjs
+++ b/scripts/verify-self.mjs
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -96,12 +96,39 @@ function writeSummary(results, totalStart) {
   return summary;
 }
 
+/**
+ * The commit HEAD points at, or `null` when that cannot be read (a vendored
+ * copy or exported tarball, where the guard below simply does not apply).
+ *
+ * Read once before the lanes and again after each one. No lane may move the
+ * developer's branch. A test that shells out to git and escapes its fixture
+ * directory does not fail — it commits into THIS repository, on whatever branch
+ * is checked out, replacing the branch tip. That happened: ten commits left a
+ * branch and the resulting push read as deleting all 3019 files. The only
+ * symptom was the diff stat, and only if someone looked before pushing.
+ *
+ * Checking here catches the whole class rather than one known test, and names
+ * the lane responsible — turning a reflog excavation into one line of output.
+ */
+function readHead() {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
 // --- main ---
 
 mkdirSync(reportDir, { recursive: true });
 
 const results = [];
 const totalStart = Date.now();
+const headBefore = readHead();
 let failed = false;
 
 for (const { name, cmd } of LANES) {
@@ -123,6 +150,26 @@ for (const { name, cmd } of LANES) {
 
   const { exitCode, output } = await runCommand(cmd, repoRoot);
   const durationMs = Date.now() - start;
+
+  // Fail on a moved branch even when the lane itself passed — a lane that
+  // rewrites history and exits 0 is the exact case this exists to catch.
+  const headAfter = readHead();
+  if (headBefore && headAfter && headAfter !== headBefore) {
+    const report = {
+      lane: name,
+      status: "fail",
+      durationMs,
+      exitCode,
+      failureSummary: `lane moved HEAD ${headBefore.slice(0, 9)} -> ${headAfter.slice(0, 9)}`,
+    };
+    results.push(report);
+    writeLaneReport(report);
+    console.error(`\n\u2717 ${name} MOVED HEAD: ${headBefore.slice(0, 9)} -> ${headAfter.slice(0, 9)}`);
+    console.error("  This lane committed into the repository. Your branch tip was replaced.");
+    console.error(`  Recover with:  git reset --hard ${headBefore}`);
+    failed = true;
+    continue;
+  }
 
   if (exitCode === 0) {
     const report = {


### PR DESCRIPTION
## Summary

While preparing #588 the tip of my working branch was silently replaced **three
times** by `novelty.test.mjs`'s 4-file fixture tree, discarding ten commits from the
branch pointer. One of those states reached #588, where it rendered as **deleting all
3019 files**. Nothing warned: tests passed, and the only symptom was the diff stat.

**Root cause: git exports `GIT_DIR` into every hook it runs, and `cwd` does not win
against it.** This repo's `.githooks/pre-push` runs `pnpm verify:self`, whose
`agent:tests` lane reaches `novelty.mjs` and its fixtures. Under the hook, those git
calls ran with `cwd` at the fixture and `GIT_DIR` at the real checkout — and git obeys
`GIT_DIR`.

That single fact explains every symptom, including the two I could not previously
account for:

| Symptom | Explanation |
|---|---|
| Only ever during `git push` | Hooks are the only context that sets `GIT_DIR` |
| Never reproducible by hand | `GIT_DIR` is unset in an interactive shell |
| 4-file tree on a **real** branch | Work tree = fixture, git dir = real repo |
| Silent | Every command succeeded; it just used the wrong repo |

Reproduced deterministically — with `GIT_DIR` set the way a hook sets it, exactly five
`[real git]` tests fail:

```
$ GIT_DIR=$(git rev-parse --absolute-git-dir) node --test *.test.mjs
✖ noveltyOf [real git]: verbatim-moved code is `relocated` and demotes
✖ noveltyOf [real git]: genuinely new code in the same new file is `introduced`
✖ noveltyOf [real git]: an untouched line is `pre-existing` and does NOT demote
✖ noveltyOf [real git]: a line the change did not add stays pre-existing in a MODIFIED file
✖ noveltyOf [real git]: a line that is only a SUBSTRING of a base line stays gating
ℹ pass 316   ℹ fail 5
```

## This is a production bug, not just a test bug

`novelty.mjs` is the novelty gate the review panel routes findings through. Because its
`git()` passed `cwd` but not the environment, **any invocation under a git hook silently
blames the wrong repository** — and the answers still come back well-formed, so a
finding gets demoted or kept on blame from an unrelated tree. A gate that is quietly
answering about the wrong repo is worse than one that is loudly off, which is the
argument `baseResolves` already makes in its own docstring.

`git()` now strips every git-location variable so `cwd` alone selects the repository.
**Deleting rather than pinning is deliberate:** `repo` may be a linked worktree, where
`.git` is a *file* holding a `gitdir:` pointer, so a computed `GIT_DIR: repo/.git` would
be wrong exactly where it matters most.

## The three changes

1. **`novelty.mjs`** — `git()` strips `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`,
   `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`,
   `GIT_CEILING_DIRECTORIES`. This is the root-cause fix.
2. **`novelty.test.mjs`** — fixtures pin `GIT_DIR`/`GIT_WORK_TREE`/`GIT_CEILING_DIRECTORIES`
   per call, assert the resolved toplevel equals the fixture *before* writing any commit,
   and stop discarding stderr. Two new tests: one points `GIT_DIR` at a *different* repo
   and asserts `noveltyOf`'s answer is unchanged; one builds a fixture inside the real
   checkout and proves commits stay contained.
3. **`verify-self.mjs`** — reads `HEAD` before the lanes and after each one, failing if a
   lane moved it *even when that lane exited 0*. This covers the class rather than this
   one test, and names the offending lane instead of leaving a reflog to excavate.

## Reviewer's guide

- **`repoScopedEnv()` in `novelty.mjs` is the change that matters.** Everything else is
  containment. Please sanity-check the variable list for omissions.
- **`readHead()` returns `null` outside a repo** (vendored copy, exported tarball) and the
  check is then skipped rather than failing. Confirm you agree with that direction — the
  alternative is failing closed, which breaks non-git consumers.
- **The escape test asserts isolation *before* committing.** That ordering is
  load-bearing: a broken pin must trip an assertion rather than mutate the branch.

## Linked Issues

Fixes #

No issue filed — root cause is identified and fixed here. Happy to file one retroactively
for the record if you'd rather it be tracked.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [x] `verify:self` — all 11 lanes green
- [x] `agent:tests` — **322 pass both with and without a hook-style `GIT_DIR`.** Before
      this change it passed only without; that asymmetry was the bug.
- [x] **Pushed with the `pre-push` hook enabled** — the exact path that clobbered the
      branch three times. `HEAD` unchanged, remote tip matches local, diff stat correct.
- [x] **The `verify:self` guard was proven to fire**, not merely to compile: run against a
      stand-in lane that commits and exits 0, it reported
      `✗ fake:clobber MOVED HEAD: d7a43a587 -> 12e0f8485`, printed the recovery command,
      and exited non-zero.
- [ ] verify:integration — n/a; touches only `scripts/`, which no package imports

## Risk Assessment

- **User-facing risk:** none. Nothing ships; no package imports `scripts/`.
- **Behaviour change:** `noveltyOf` now answers about `repo` in environments where it
  previously answered about `GIT_DIR`. That is the fix, but it does mean novelty verdicts
  under a hook or a `GIT_DIR`-setting CI step will change — from wrong to right.
- **Toolchain risk:** `verify-self.mjs` gates every push and CI run, so a bug here blocks
  pushes. Mitigated by exercising the whole file end-to-end (lane run, report write,
  summary, non-zero exit), not just by type-checking it.
- **Rollback plan:** revert. Three files, no config, no state, no migrations.

## Notes for Reviewers

- **AI assistance:** diagnosis and all three changes written with Claude Code (Opus 5).

- **I got the diagnosis wrong twice before getting it right**, and the sequence is worth
  recording. First I blamed the `pre-push` hook and "fixed" it with `--no-verify` — the
  reflog then showed the commits landing minutes *before* the push, so the correlation was
  real and my causal direction was invented; `--no-verify` fixed nothing. Then I concluded
  the fixture code was correct and the cause unknowable, and proposed containment alone.
  Only when the hook failed a lane that passed standalone did the actual mechanism surface.
  The lesson recorded in the lessons file is that "correlates with X" is not "caused by X",
  and that a discrepancy between two runs is more informative than either run alone.

- **`extractFailureSummary` is unreliable and cost me time here.** For the failing lane it
  reported `✔ classifyResult: distinguishes verdict / api-error / no-output` — a *passing*
  line, matched because its `/\b(FAIL|ERROR|error|Error|…)\b/` alternation hits the
  substring `error` in `api-error`. Worth tightening separately; I left it alone to keep
  this diff on one subject.

- **`tasks:archive` has a side effect worth knowing about.** Running it swept 46 completed
  task files from other branches into `docs/tasks/archive/`, including one that looks like
  live work (`20260729-absence-claims-todo.md`). That is correct behaviour per
  `tasks-archive.mjs:94` — a task stays active only while its todo has an unchecked box —
  the backlog had simply accumulated. I reverted it rather than bundle it here, but someone
  should run it deliberately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards to detect unexpected branch changes during verification and stop subsequent checks with clear failure reporting.
  - Improved Git repository isolation for automated checks, preventing commands from affecting unintended repositories.

- **Bug Fixes**
  - Prevented inherited Git settings from redirecting operations to another repository.
  - Improved diagnostics for repository and fixture-related failures.

- **Documentation**
  - Added guidance on branch integrity, secure Git execution, and preventing test fixtures from modifying surrounding repositories.

- **Tests**
  - Added coverage for repository isolation, environment handling, linked worktrees, and branch-integrity failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->