### PR TITLE
Post an agent-effort summary after an on-demand @claude review

### DIFF
--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -329,7 +329,8 @@ jobs:
       # so issues.createComment 403s ("Resource not accessible by integration").
       # The App installation token is not subject to that fork restriction. Minted
       # AFTER the read-only panel ran (never shares the job with the SDK step) and
-      # scoped to issues:write only. Same pattern as the promote/fix jobs.
+      # scoped to the minimum the post + metrics steps need. Same pattern as the
+      # promote/fix jobs.
       - name: Generate GitHub App token (post-only, issues:write)
         id: app-token
         if: always()
@@ -337,7 +338,11 @@ jobs:
         with:
           app-id: ${{ secrets.AGENT_APP_ID }}
           private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
-          permission-issues: write # PR conversation comments use the issues API
+          permission-issues: write # PR conversation comments (+ metric ledger) use the issues API
+          # metrics.mjs summarize reads PR additions/deletions (`gh pr view`) to
+          # size the scope; a fork-PR GITHUB_TOKEN is read-only, so this token
+          # carries the pulls read too. Read-only — no write to the PR itself.
+          permission-pull-requests: read
 
       # EDIT the "running" placeholder authorize posted (comment_id) into the
       # findings — aggregate panel.json + each lens's summary.md. No check runs;
@@ -400,3 +405,42 @@ jobs:
             // GitHub comment hard limit is 65536 chars; trim from the tail if huge.
             if (body.length > 65000) body = body.slice(0, 64900) + '\n\n… _(truncated)_' + note;
             await publish(body);
+
+      # Record this review's cost/reliability into the PR metric ledger and post
+      # the aggregated agent-effort summary — the same ledger + renderer the
+      # autonomous panel uses, so a maintainer sees what an on-demand review cost.
+      # Only when the panel actually ran (steps.panel.outcome == 'success'): a
+      # crashed panel already stranded a fail-closed note, and there is nothing to
+      # record. Both steps run the TRUSTED main copy of metrics.mjs (never the
+      # branch's) and use the App token (a fork-PR GITHUB_TOKEN is read-only).
+      # metrics.mjs is fail-safe (exits 0 on any error) and both are
+      # continue-on-error, so metrics can never fail the review.
+      - name: Record on-demand review metrics
+        if: steps.panel.outcome == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ needs.authorize.outputs.pr }}
+        run: |
+          if [ -f .agent-review/review-execution.json ]; then
+            node .trusted/scripts/agent/metrics.mjs record \
+              --execution .agent-review/review-execution.json \
+              --lens-stats .agent-review/review-lens-stats.json \
+              --kind review --pr "$PR"
+          else
+            echo "no review execution log; skipping metrics"
+          fi
+
+      # NOT --final: --final sweeps EVERY hidden agent-metric record on the PR,
+      # which on an agent-managed PR would delete the autonomous pipeline's own
+      # ledger mid-flight. On-demand review only appends its own record and
+      # reposts the summary fresh at the bottom.
+      - name: Post agent-effort summary
+        if: steps.panel.outcome == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ needs.authorize.outputs.pr }}
+        run: node .trusted/scripts/agent/metrics.mjs summarize --pr "$PR"

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -337,6 +337,11 @@ export function formatUsd(n) {
  * rather than folded into one set of totals). */
 export function renderSummary({ agg, panelAgg, panelStats, flips, scope }) {
   const hasPanel = !!panelAgg && panelAgg.sessions > 0;
+  // An on-demand `@claude review` posts a review record but no code-fix session,
+  // so `aggregate([])` yields an all-zero `agg`. Rendering a "Code-fix agent"
+  // section of zeros there reads as broken, so a review-only summary omits it and
+  // collapses the total to the review figure alone.
+  const hasCodeFix = agg.sessions > 0;
   const panelTokens = hasPanel ? panelAgg.tokens : 0;
   const panelWeighted = hasPanel ? panelAgg.weightedTokens : 0;
   const panelCost = hasPanel ? panelAgg.costUsd : 0;
@@ -350,20 +355,26 @@ export function renderSummary({ agg, panelAgg, panelStats, flips, scope }) {
     SUMMARY_MARKER,
     "## 🤖 Agent effort",
     "",
-    `- Total-cost: ${formatUsd(totalCost)} (code-fix ${formatUsd(agg.costUsd)} + review ${formatUsd(panelCost)})`,
+    hasCodeFix
+      ? `- Total-cost: ${formatUsd(totalCost)} (code-fix ${formatUsd(agg.costUsd)} + review ${formatUsd(panelCost)})`
+      : `- Total-cost: ${formatUsd(totalCost)}`,
     `- Total-tokens: ${formatTokens(totalWeighted)} weighted (${formatTokens(totalRaw)} raw)`,
-    "",
-    "### Code-fix agent",
-    "",
-    `- Cost: ${formatUsd(agg.costUsd)}`,
-    `- Tokens: ${formatTokens(agg.weightedTokens)} weighted (${formatTokens(agg.tokens)} raw)`,
-    `- Agents: ${agg.agents.length ? agg.agents.join(", ") : "unknown"}`,
-    `- Scope-size: ${scope}`,
-    `- Attempt: ${agg.attempt}`,
-    `- Sessions: ${agg.sessions}`,
-    `- Total-time: ${formatMinutes(agg.durationMs)}`,
-    `- Turns: ${agg.turns}`,
   ];
+  if (hasCodeFix) {
+    lines.push(
+      "",
+      "### Code-fix agent",
+      "",
+      `- Cost: ${formatUsd(agg.costUsd)}`,
+      `- Tokens: ${formatTokens(agg.weightedTokens)} weighted (${formatTokens(agg.tokens)} raw)`,
+      `- Agents: ${agg.agents.length ? agg.agents.join(", ") : "unknown"}`,
+      `- Scope-size: ${scope}`,
+      `- Attempt: ${agg.attempt}`,
+      `- Sessions: ${agg.sessions}`,
+      `- Total-time: ${formatMinutes(agg.durationMs)}`,
+      `- Turns: ${agg.turns}`,
+    );
+  }
   if (hasPanel) {
     const ac = panelStats?.agreementCounts || {};
     const r = panelStats?.raised || {};

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -317,6 +317,39 @@ test("renderSummary: with review-panel data, renders a separate section + combin
   assert.match(md, /- Total-tokens: ~340K weighted \(~1\.4M raw\)/);
 });
 
+// On-demand `@claude review`: a review record but NO code-fix session, so the
+// code-fix aggregate is all zeros (aggregate([])). The summary must OMIT the
+// Code-fix agent section entirely rather than render it full of $0.00 / 0, and
+// the top total must collapse to the review figure (no misleading code-fix split).
+test("renderSummary: review-only (no code-fix) omits the code-fix section", () => {
+  const md = renderSummary({
+    // The exact shape aggregate([]) returns for zero code-fix records.
+    agg: { agents: [], sessions: 0, attempt: 1, turns: 0, tokens: 0, weightedTokens: 0, durationMs: 0, costUsd: 0 },
+    panelAgg: { agents: ["claude-opus-5", "claude-sonnet-5"], sessions: 1, turns: 15, tokens: 300_000, weightedTokens: 40_000, costUsd: 0.8, durationMs: 27 * 60000 },
+    panelStats: {
+      agreementCounts: { identical: 6, partial: 0, disjoint: 0, single: 0 },
+      raised: { critical: 0, major: 1, minor: 2, nit: 0 },
+      raisedConfidence: { high: 2, medium: 1, low: 0, unknown: 0 },
+      kept: { critical: 0, major: 1, minor: 2, nit: 0 },
+      verifier: { sentToVerifier: 1, refuted: 0, refutedHighConfidence: 0, dropped: 0 },
+    },
+    flips: { flips: [], byLens: {} },
+    scope: "M",
+  });
+  // No code-fix section, and none of its bullets leak in.
+  assert.doesNotMatch(md, /### Code-fix agent/);
+  assert.doesNotMatch(md, /- Scope-size:/);
+  assert.doesNotMatch(md, /- Attempt:/);
+  assert.doesNotMatch(md, /- Sessions:/);
+  // The review panel section still renders in full.
+  assert.match(md, /### Review panel/);
+  assert.match(md, /- Cost: \$0\.80/);
+  // Total collapses to the review figure — NOT the "(code-fix … + review …)" split.
+  assert.match(md, /- Total-cost: \$0\.80\n/);
+  assert.doesNotMatch(md, /code-fix .* \+ review/);
+  assert.match(md, /- Total-tokens: ~40K weighted \(~300K raw\)/);
+});
+
 test("metric comment round-trip: hidden, self-contained, parses back; junk → null", () => {
   const rec = { kind: "review-fix", models: ["claude-opus-4-8"], turns: 3, tokens: 2, durationMs: 1 };
   const body = serializeRecord(rec);


### PR DESCRIPTION
## Summary

`@claude review` (the on-demand review panel) ran the lens panel and posted findings, but — unlike the autonomous panel — it never recorded the review's cost or posted the `🤖 Agent effort` summary. A maintainer saw the findings with no idea what the review cost. This wires up the missing metrics.

The on-demand `review` job already had everything it needed: the panel writes `.agent-review/review-execution.json` + `review-lens-stats.json`. This adds the two steps that consume them.

## Changes

- **`agent-review-on-demand.yml`** — after the findings comment, two new steps:
  - **record** the review into the PR metric ledger (`metrics.mjs record --kind review`)
  - **summarize** (`metrics.mjs summarize --pr N`) → posts the `🤖 Agent effort` comment
  
  Both run the **trusted `.trusted/` copy** of `metrics.mjs` (never the branch's), gate on `steps.panel.outcome == 'success'`, use the **App token** (a fork-PR `GITHUB_TOKEN` is read-only), and are `continue-on-error` on top of `metrics.mjs` already exiting 0 on any error — metrics can never fail a review. Deliberately **not `--final`**: that sweeps every hidden metric record on the PR and would delete the autonomous pipeline's ledger mid-flight on an agent-managed PR.
- **App token** gains `permission-pull-requests: read` — `summarize` calls `gh pr view --json additions,deletions` to size scope.
- **`metrics.mjs renderSummary`** — omits the "Code-fix agent" section when there are no code-fix sessions (`aggregate([])`), so a review-only summary no longer renders a block of $0.00/0 and the total collapses to the review figure. The autonomous path always has a code-fix record, so it's unchanged.

## Test plan

- New `renderSummary: review-only (no code-fix)` test; full agent suite `cd scripts/agent && node --test *.test.mjs` → **344/344 pass**.
- Workflow YAML validated.

Note: this is a pipeline-internal change and ships no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On-demand review results now record execution and lens metrics automatically.
  * Successful reviews now include an aggregated agent-effort summary.

* **Bug Fixes**
  * Review-only summaries no longer display empty code-fix sections or misleading cost breakdowns.
  * Review-only totals and token counts now accurately reflect review activity.

* **Tests**
  * Added coverage validating review-only summary formatting and totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->