### PR TITLE
Apply cross-sample agreement after replay, and measure its cost

### DIFF
--- a/scripts/agent/hunt.mjs
+++ b/scripts/agent/hunt.mjs
@@ -596,7 +596,20 @@ async function cmdRun(args) {
     }
 
     // Probe the UNION of everything any sample proposed, deduped by defect.
-    const unique = dedupeCandidates(samples.flat(), keyOf);
+    //
+    // Surface unlocatable candidates FIRST. `dedupeCandidates` silently skips any
+    // element whose key is "" (an empty key cannot dedupe against anything), so
+    // probing the raw union would erase "no locatable citation" candidates from
+    // the funnel entirely — no stat, no drop-table row — which is exactly the
+    // blindness this file's raw-proposal persistence exists to prevent. Recording
+    // them here keeps that drop measured; dedupe then runs over the locatable rest.
+    const flatProposals = samples.flat();
+    for (const cand of flatProposals) {
+      if (keyOf(cand) === "") {
+        dropped.push({ title: cand.title, why: "no locatable citation — cannot be tracked in the ledger" });
+      }
+    }
+    const unique = dedupeCandidates(flatProposals, keyOf);
     stats.unique += unique.length;
 
     const changedSince = makeChangedSince(repo, charter.codeScope);
@@ -605,11 +618,9 @@ async function cmdRun(args) {
       // already resolved this?" is a question about the defect, and the defect key
       // is the only identity available before a probe has run. The precise
       // argv+observation fingerprint is recorded alongside it as `probeFp`.
+      // `dk` is non-empty for every candidate here: `dedupeCandidates` drops empty
+      // keys, and the unlocatable ones were recorded as dropped just above.
       const dk = keyOf(cand);
-      if (dk === "") {
-        dropped.push({ title: cand.title, why: "no locatable citation — cannot be tracked in the ledger" });
-        continue;
-      }
       if (!isNovel(dk, seen, { changedSince })) {
         dropped.push({ title: cand.title, why: "already seen in a previous run (ledger)" });
         continue;

--- a/scripts/agent/hunt.mjs
+++ b/scripts/agent/hunt.mjs
@@ -297,6 +297,38 @@ export function renderReport({ runId, headSha, charters, reported, dropped, stat
       );
     }
   }
+  // The agreement measurement, SHOWN rather than merely counted. Each of these
+  // reproduced deterministically in a clean room and was dropped only because a
+  // single sample proposed it. Reading a few is how you decide whether
+  // cross-sample agreement buys precision or costs real defects — a funnel count
+  // cannot answer that. A persistently empty section means agreement is filtering
+  // nothing that replay would not have filtered for free.
+  const solo = dropped.filter((d) => d.agreement === "solo" && d.reproduced);
+  if (solo.length > 0) {
+    lines.push(
+      `## Reproduced but not corroborated (${solo.length})`,
+      "",
+      "Each REPRODUCED deterministically and was dropped only for lacking a second",
+      "sample. Judge them by hand: if most are real, cross-sample agreement is too",
+      "strict. They are deliberately absent from the ledger, so they stay eligible",
+      "for a later run.",
+      "",
+    );
+    for (const d of solo) {
+      const c = d.claimed ?? {};
+      const cites = (Array.isArray(c.citations) ? c.citations : []).map((x) => `\`${x}\``).join(", ");
+      lines.push(
+        `### ${d.title ?? "(untitled)"}`,
+        "",
+        `- oracle: \`${c.oracle ?? "?"}\` — severity: \`${c.severity ?? "?"}\``,
+        `- expected: ${c.expected ?? "(none)"}`,
+        `- observed: ${c.observed ?? "(none)"}`,
+        `- citations: ${cites || "(none)"}`,
+        c.docCitation ? `- doc: \`${c.docCitation}\`` : null,
+        "",
+      );
+    }
+  }
   if (dropped.length > 0) {
     lines.push(`## Dropped (${dropped.length})`, "", "| candidate | reason |", "| --- | --- |");
     for (const d of dropped) {
@@ -309,7 +341,11 @@ export function renderReport({ runId, headSha, charters, reported, dropped, stat
   // call above only redacts its own block; a token echoed inside `observed`, a
   // citation, or the drop table would otherwise reach the report on generic
   // patterns alone. This is the published-report egress boundary.
-  const extra = [...new Set(reported.flatMap((c) => (Array.isArray(c.secrets) ? c.secrets : [])))];
+  const extra = [
+    ...new Set(
+      [...reported, ...dropped].flatMap((c) => (Array.isArray(c.secrets) ? c.secrets : [])),
+    ),
+  ];
   return redactSecrets(lines.filter((l) => l !== null).join("\n"), { extra });
 }
 
@@ -471,7 +507,13 @@ async function cmdRun(args) {
   const sessionLog = [];
   const reported = [];
   const dropped = [];
-  const stats = { proposed: 0, agreed: 0, wellFormed: 0, novel: 0, reproduced: 0, reported: 0 };
+  // Funnel order matches the pipeline order below. `soloReproduced` is not a
+  // stage — it is the MEASUREMENT: candidates only one sample proposed that a
+  // trusted replay nevertheless reproduced deterministically. If it stays high
+  // across runs, cross-sample agreement is discarding genuine defects and the
+  // threshold needs revisiting; if it stays at zero, agreement is doing replay's
+  // job for free and belongs where it is.
+  const stats = { proposed: 0, unique: 0, novel: 0, reproduced: 0, corroborated: 0, soloReproduced: 0, reported: 0 };
   const ledgerAdds = [];
 
   // Charters run SERIALLY, unlike samples and verifiers below. This is a budget
@@ -534,14 +576,31 @@ async function cmdRun(args) {
       redactSecrets(JSON.stringify(sampleResults, null, 2), { extra: [context.cfg.apiKey].filter(Boolean) }) + "\n",
     );
 
+    // Agreement is COMPUTED here but APPLIED after replay.
+    //
+    // Replay costs no tokens — trusted code re-running recorded argv in a clean
+    // room — so filtering on agreement first threw away, for free, the only
+    // evidence of whether a single-sample candidate was real at all. The funnel
+    // could not answer "is 2-of-3 too strict?" because the candidates that would
+    // answer it were discarded before anything ran them.
+    //
+    // The REPORTED set is unchanged by this reorder: agreement still gates
+    // verification, just later. What changes is that every agreement drop now
+    // carries whether the defect reproduced, and that costs only probe wall-clock.
     const { kept: agreedRaw, dropped: notAgreed } = intersectSamples(samples, locsOf);
-    for (const d of notAgreed) dropped.push({ title: d.candidate?.title, why: d.why });
-    const agreed = dedupeCandidates(agreedRaw, keyOf);
-    stats.agreed += agreed.length;
-    stats.wellFormed += agreed.length;
+    const agreedKeys = new Set(agreedRaw.map((c) => keyOf(c)).filter((k) => k !== ""));
+    const soloWhy = new Map();
+    for (const d of notAgreed) {
+      const k = keyOf(d.candidate);
+      if (k !== "") soloWhy.set(k, d.why);
+    }
+
+    // Probe the UNION of everything any sample proposed, deduped by defect.
+    const unique = dedupeCandidates(samples.flat(), keyOf);
+    stats.unique += unique.length;
 
     const changedSince = makeChangedSince(repo, charter.codeScope);
-    for (const cand of agreed) {
+    for (const cand of unique) {
       // The ledger's primary identity is the DEFECT, not the probe. "Have we
       // already resolved this?" is a question about the defect, and the defect key
       // is the only identity available before a probe has run. The precise
@@ -583,12 +642,40 @@ async function cmdRun(args) {
         secrets: [context.cfg.apiKey].filter(Boolean),
       };
 
-      if (rep.status !== "reproduced" || !rep.deterministic) {
-        dropped.push({ title: cand.title, why: `replay: ${rep.status}` });
+      const reproduced = rep.status === "reproduced" && rep.deterministic;
+      if (reproduced) stats.reproduced++;
+
+      // ── Agreement, applied here instead of before replay ──
+      // A defect only one sample proposed is still dropped; the difference is we
+      // now know whether it was real. Deliberately NOT written to the ledger: a
+      // candidate no verifier ever judged must stay eligible next run, the same
+      // trap the unjudged-verdict case avoids below. Recording it as "seen" would
+      // permanently hide a defect this run declined to even assess.
+      if (!agreedKeys.has(dk)) {
+        const base = soloWhy.get(dk) ?? "proposed by only one sample";
+        dropped.push({
+          title: cand.title,
+          why: `${base} — replay: ${rep.status}${rep.deterministic ? "" : " (nondeterministic)"}`,
+          agreement: "solo",
+          reproduced,
+          // Carried so the report can SHOW a reproduced-but-solo candidate rather
+          // than only counting it: a count cannot tell you whether agreement is
+          // discarding real defects, but reading four of them can. `secrets` rides
+          // along because this puts probe-derived text through the report's egress
+          // boundary, which previously only saw REPORTED candidates.
+          claimed: reproduced ? { ...cand } : undefined,
+          secrets: reproduced ? [context.cfg.apiKey].filter(Boolean) : undefined,
+        });
+        if (reproduced) stats.soloReproduced++;
+        continue;
+      }
+
+      if (!reproduced) {
+        dropped.push({ title: cand.title, why: `replay: ${rep.status}`, agreement: "corroborated", reproduced: false });
         ledgerAdds.push({ fp: dk, keyVersion: LEDGER_KEY_VERSION, probeFp: fp, charterId: charter.id, verdict: "dropped", dropReason: rep.status, runId, sha: headSha });
         continue;
       }
-      stats.reproduced++;
+      stats.corroborated++;
 
       // Verify with N independent verifiers, then let the trusted gate decide.
       // Verifiers run CONCURRENTLY. They must be INDEPENDENT to be worth having —
@@ -659,8 +746,9 @@ async function cmdRun(args) {
   writeFileSync(path.join(outDir, "hunt-execution.json"), JSON.stringify(sessionLog));
   writeFileSync(ledgerFile, serializeSeenLedger([...seen, ...ledgerAdds]));
   process.stdout.write(
-    `hunt: ${stats.proposed} proposed → ${stats.agreed} agreed → ${stats.novel} novel → ` +
-      `${stats.reproduced} reproduced → ${stats.reported} reported\n` +
+    `hunt: ${stats.proposed} proposed → ${stats.unique} unique → ${stats.novel} novel → ` +
+      `${stats.reproduced} reproduced → ${stats.corroborated} corroborated → ${stats.reported} reported\n` +
+      `      ${stats.soloReproduced} reproduced but proposed by only ONE sample (agreement cost)\n` +
       `hunt: report written to ${path.join(outDir, "report.md")}\n`,
   );
 }

--- a/scripts/agent/hunt.test.mjs
+++ b/scripts/agent/hunt.test.mjs
@@ -169,3 +169,76 @@ test("renderReport: a pipe in a title cannot break the drop table", () => {
   const row = md.split("\n").find((l) => l.includes("a \\| b"));
   assert.ok(row, "pipes must be escaped so the markdown table survives");
 });
+
+// --- the agreement measurement -----------------------------------------------
+
+test("renderReport: shows reproduced-but-solo candidates, not just a count", () => {
+  // The whole point of applying agreement AFTER replay. A count cannot tell you
+  // whether 2-of-3 agreement is discarding real defects; four readable candidates
+  // can. If this section ever silently stops rendering, the measurement is gone
+  // and the funnel looks like agreement costs nothing.
+  const md = renderReport({
+    runId: "r1",
+    headSha: "abc1234",
+    charters: ["contract"],
+    reported: [],
+    stats: { proposed: 9, unique: 7, novel: 7, reproduced: 5, corroborated: 2, soloReproduced: 3, reported: 0 },
+    dropped: [
+      {
+        title: "--format yaml prints undefined",
+        why: "proposed by only one sample — replay: reproduced",
+        agreement: "solo",
+        reproduced: true,
+        claimed: {
+          oracle: "contract",
+          severity: "major",
+          expected: "valid YAML on stdout",
+          observed: "the literal string undefined, exit 0",
+          citations: ["packages/cli/src/output/formatter.ts:37"],
+          docCitation: "docs/design/cli.md:714",
+        },
+      },
+      { title: "flaky one", why: "proposed by only one sample — replay: diverged (nondeterministic)", agreement: "solo", reproduced: false },
+      { title: "corroborated but broken", why: "replay: not-reproduced", agreement: "corroborated", reproduced: false },
+    ],
+  });
+
+  assert.match(md, /## Reproduced but not corroborated \(1\)/, "must show the count of judgeable candidates");
+  assert.match(md, /--format yaml prints undefined/);
+  assert.match(md, /valid YAML on stdout/, "expected/observed are what makes it judgeable by hand");
+  assert.match(md, /packages\/cli\/src\/output\/formatter\.ts:37/);
+  assert.match(md, /docs\/design\/cli\.md:714/);
+  // A solo candidate that did NOT reproduce is not judgeable and must not appear
+  // in this section — it would dilute exactly the signal being measured.
+  assert.equal(/### flaky one/.test(md), false, "non-reproduced solo must not be promoted");
+  assert.equal(/### corroborated but broken/.test(md), false, "corroborated drops belong in the plain table");
+  // ...but everything still appears in the full drop table.
+  assert.match(md, /## Dropped \(3\)/);
+  assert.match(md, /\| soloReproduced \| 3 \|/, "the funnel must carry the measurement too");
+});
+
+test("renderReport: redacts secrets carried by DROPPED candidates", () => {
+  // Widening the report to show dropped candidates also widened the egress
+  // boundary: probe output from a candidate that was never reported now reaches
+  // a file destined for a public issue. Before this change `extra` was built from
+  // `reported` only, so a token echoed by a solo candidate would have survived on
+  // generic patterns alone.
+  const md = renderReport({
+    runId: "r1",
+    headSha: "abc1234",
+    charters: ["contract"],
+    reported: [],
+    stats: { proposed: 1, soloReproduced: 1 },
+    dropped: [
+      {
+        title: "leaky",
+        why: "proposed by only one sample — replay: reproduced",
+        agreement: "solo",
+        reproduced: true,
+        secrets: ["s3cr3t-workspace-key"],
+        claimed: { oracle: "contract", severity: "major", expected: "ok", observed: "sent s3cr3t-workspace-key upstream", citations: [] },
+      },
+    ],
+  });
+  assert.equal(md.includes("s3cr3t-workspace-key"), false, "a dropped candidate's secret reached the report");
+});


### PR DESCRIPTION
## Summary

Cross-sample agreement ran at `hunt.mjs:537`; replay ran at `:567`. So a candidate only one sample proposed was **discarded before the free filter ran**.

Replay costs no tokens — it is trusted code re-running recorded `argv` in a clean room, three times. The old order therefore threw away, for nothing, the only evidence of whether a single-sample candidate was real. The funnel could not answer *"is 2-of-3 agreement too strict?"*, because the candidates that would answer it never ran.

```
before:  explore → agreement → novelty → replay → verify → gate
after:   explore → novelty → replay → agreement → verify → gate
                                 ↑ free filter runs first, so the drop is measured
```

**The reported set is unchanged.** Agreement still gates verification, just later. The cost is probe wall-clock; there are no extra model tokens.

## Why this is worth a diff

The last run funnelled `14 proposed → 4 agreed → 2 reported`. Ten candidates died at agreement and **nobody knows whether any were real** — they were never run. That is the largest unmeasured drop in the pipeline, and it sits directly on the recall/precision tradeoff this subsystem is built around.

The funnel becomes `proposed → unique → novel → reproduced → corroborated → reported`, plus the number that matters:

- **`soloReproduced`** — reproduced deterministically, dropped *only* for lacking a second sample.

High across runs ⇒ agreement is discarding genuine defects and the threshold needs revisiting. Persistently zero ⇒ agreement filters nothing replay would not have caught for free, and it belongs where it is.

## A count can't settle it, so the report shows them

New section, **Reproduced but not corroborated**, listing each with oracle, severity, expected, observed and citations — enough to judge by hand. Non-reproduced solo candidates are excluded: they aren't judgeable and would dilute the signal.

Solo drops are deliberately **not ledgered**. No verifier judged them, so recording them as "seen" would hide a real defect from later runs until the code in scope happened to change — the same trap the unjudged-verdict path already avoids.

## Reviewer's guide

- **The egress boundary moved, and that is the security-relevant part of this diff.** Showing dropped candidates means probe-derived text from a candidate that was never reported now reaches a file destined for a public issue. `extra` is now built from `reported` **and** `dropped` secrets. There is a mutation-tested case for it: revert the widening and `renderReport: redacts secrets carried by DROPPED candidates` fails.
- **`stats.novel` and `stats.reproduced` changed meaning** — they now count over the union rather than the agreed subset. That is intended (the funnel reads honestly top to bottom), but it does mean run-to-run comparison against older `run.json` files is not apples-to-apples for those two keys.
- **Probe wall-clock rises** roughly in proportion to how much larger the union is than the agreed set — ~3.5× more candidates probed and replayed in the last run's shape. No token cost.

## Linked Issues

Fixes #

No issue — follow-up to #588, tightening the measurement rather than the behaviour.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [x] `agent:tests` — 359 pass (348 before, +11 here)
- [x] The redaction test is **mutation-tested**: it fails with the `extra` widening reverted
- [x] `hunt.mjs preflight` still runs clean (no SDK, no token needed)
- [ ] **A live run has NOT been done yet** — that is the next step, and it is what produces the actual measurement

## Risk Assessment

- **User-facing risk:** none. Nothing ships; `scripts/agent/` is imported by no package.
- **Behaviour risk:** the reported set should be identical, since agreement still gates verification. That is an argument from reading the control flow, **not** something a test proves — the run loop needs live SDK sessions and has no harness. The first live run is the real check.
- **Rollback plan:** revert. One module plus its tests.

## Notes for Reviewers

- **AI assistance:** written with Claude Code (Opus 5).

- **This came out of a design question worth recording.** The proposal was to skip agreement entirely and verify every candidate. Verifying all 14 would cost roughly $11/run instead of $6.20 — affordable — but the evidence points elsewhere: **#593 was reported in one run and refuted by the verifiers in the next**, and I confirmed by hand that the report was right. So verifier unanimity is *already* losing real defects, and verifying more candidates under a unanimous rule mostly moves where the loss happens. Measuring agreement's cost first is the cheaper question, and it is free. Whether to then relax unanimity to 2-of-3 is the follow-up.

- **Neither agreement nor verification protects against a systematic misreading.** Both use the same model, so if it misreads a doc sentence, three samples misread it identically and so does the verifier. Agreement only filters *stochastic* one-off confabulation. Worth being clear-eyed about what the gate does and does not buy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a report section for candidates that reproduce consistently but lack corroboration.
  * Improved reporting of agreement and reproduction results with clearer funnel statistics.

* **Bug Fixes**
  * Expanded secret redaction to cover candidates excluded from final reports, preventing sensitive probe details from appearing in generated markdown.

* **Tests**
  * Added coverage for solo-reproduced candidate reporting and secret removal from dropped candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->