### PR TITLE
Give the issue hunter the CLI: run commands, cite the transcript

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1089,6 +1089,34 @@ Not yet built: `round-trip` and `state` charters (need the backend tier and a
 autonomous filing behind `HUNT_FILING_ENABLED` with a mechanical accept-rate kill
 switch, and the formula differential oracle.
 
+**The explorer EXECUTES.** The first cut could not: its grant was Read/Grep/Glob and
+its prompt said *"you never run commands yourself"*, so it read the source,
+predicted a contradiction, and a trusted runner tested the prediction afterwards.
+That removed the only reason to target a CLI — a CLI's unique value is being an
+executable interface — and made surprise impossible, which is the product.
+
+The propose/execute split survives where it earns its keep. It is correct for
+**reporting** (exact replay, no shell injection) and wrong for **exploration**
+(blindness is the problem). So exploration now runs through one in-process MCP tool
+(`scripts/agent/hunt-tool.mjs`): `argv` arrays only, no shell, `assertSafeArgv` plus
+the CLI's own `schema` safety annotations, an environment `buildProbeEnv`
+**replaces**, and an enforced probe budget. Verifiers keep the read-only grant —
+handing them execution would let a verifier confirm a finding with evidence of its
+own making.
+
+Evidence is **cited, not authored**. Every tool call is journalled, and a candidate
+names `probeRefs`/`failingRef` — indices into that journal. A model therefore cannot
+describe a reproduction it never performed, which a model-authored `probes` array
+allowed; `resolveProbeRefs` converts the indices back into the shape the gate,
+replay and report already speak, and drops any candidate whose references do not
+resolve. The repro is a transcript rather than a claim.
+
+Two grounds exist only because the explorer can now act: `self-inconsistent` (two
+paths disagree about the same data) and `schema-annotation-false` (a command
+violates its own declared safety level). Both are checkable from a transcript, which
+is what stops them collapsing into *"this surprised me"* — the ground deliberately
+absent, because it is the slop generator that ended curl's bug bounty.
+
 ### Phase 27: Panel Feedback Corpus
 
 **Principle:** Entropy Management — the panel has been tuned repeatedly with no

--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -454,14 +454,10 @@ export async function askStructured({
   // wires `mcpServers`, so the whole session shape stays observable in one place.
   const options = buildSessionOptions({ systemPrompt, model, repo, schema, maxTurns, allowedTools, mcpServers });
 
-  // MCP tool calls are otherwise "effectively unbounded by default"
-  // (sdk.d.ts:477). Each call already carries its own probe timeout, so this is
-  // the backstop for a call that never returns at all. A process-level env side
-  // effect, so it stays OUT of the pure `buildSessionOptions`; `options.mcpServers`
-  // is present only when the grant actually wired a server.
-  if (options.mcpServers && !process.env.MCP_TOOL_TIMEOUT) {
-    process.env.MCP_TOOL_TIMEOUT = String(60_000);
-  }
+  // NOTE: `MCP_TOOL_TIMEOUT` is deliberately NOT set here. It has to be in place
+  // before the SDK is imported, and by this line it already has been — the server
+  // passed in `mcpServers` was built by `createProbeServer` (hunt-tool.mjs), which
+  // imports the SDK itself. That is where the backstop is set.
 
   const sdk = await import("@anthropic-ai/claude-agent-sdk");
   // The one place the real SDK is in hand, so the one place the cache-boundary

--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -57,7 +57,39 @@
  */
 export const PERMITTED_TOOLS = Object.freeze(["Read", "Grep", "Glob"]);
 
+/**
+ * In-process MCP tools this repo implements itself, permitted by EXACT name.
+ *
+ * Reason (2) above names `mcp__server__exec` as a deny-list bypass, so admitting
+ * an MCP name at all needs justifying rather than assuming. The distinction is
+ * ownership, not naming:
+ *
+ *   * A conventional MCP grant trusts a server the SDK connects to — another
+ *     process, whose capabilities this file cannot see or bound.
+ *   * These are `createSdkMcpServer` tools defined in THIS repo, running in THIS
+ *     process, whose handler is `scripts/agent/hunt-tool.mjs` and whose entire
+ *     reachable surface is `node <cli-bin> <argv…>` behind `assertSafeArgv`,
+ *     a replaced environment, and a probe budget.
+ *
+ * So the capability is bounded by code in this repository, reviewed alongside it,
+ * rather than by a name. The list stays SEPARATE from `PERMITTED_TOOLS` for two
+ * reasons: the two are wired to different SDK levers (built-in `tools` versus
+ * `mcpServers`), and keeping them apart preserves the meaning of the existing
+ * tests that assert no MCP name reaches a review-panel session.
+ *
+ * Matching is exact, so `mcp__wafflebase__exec`, `mcp__other__run` and every
+ * future MCP name remain refused because they are absent — the same inversion
+ * that makes the allow-list above work.
+ */
+export const PERMITTED_MCP_TOOLS = Object.freeze(["mcp__wafflebase__run"]);
+
 const PERMITTED_SET = new Set(PERMITTED_TOOLS);
+const PERMITTED_MCP_SET = new Set(PERMITTED_MCP_TOOLS);
+
+/** Is this grant one of the in-process MCP tools rather than a built-in? */
+export function isMcpTool(name) {
+  return PERMITTED_MCP_SET.has(name);
+}
 
 /**
  * Validate a caller's tool grant, throwing on anything outside PERMITTED_TOOLS.
@@ -90,12 +122,14 @@ export function assertAllowedTools(allowedTools) {
     if (typeof t !== "string" || t.trim() === "") {
       throw new Error(`askStructured: \`allowedTools\` entries must be non-empty strings (got: ${JSON.stringify(t)})`);
     }
-    if (!PERMITTED_SET.has(t)) {
+    if (!PERMITTED_SET.has(t) && !PERMITTED_MCP_SET.has(t)) {
       throw new Error(
         `askStructured: tool ${JSON.stringify(t)} is not permitted. Agents here read ` +
-          `untrusted input, so the grant is limited to read-only inspection: ` +
-          `${PERMITTED_TOOLS.join(", ")}. Scoped permission rules (e.g. "Bash(git diff:*)"), ` +
-          `MCP tool names and non-canonical spellings are refused by the same rule.`,
+          `untrusted input, so the grant is limited to read-only inspection ` +
+          `(${PERMITTED_TOOLS.join(", ")}) plus this repo's own in-process MCP tools ` +
+          `(${PERMITTED_MCP_TOOLS.join(", ")}). Scoped permission rules (e.g. ` +
+          `"Bash(git diff:*)"), other MCP tool names and non-canonical spellings are ` +
+          `refused by the same rule.`,
       );
     }
   }
@@ -300,8 +334,41 @@ export async function withRetry(fn, { retries = 2, baseMs = 2000, sleep = defaul
  * `allowedTools` is validated here, which is also what keeps the grant check
  * ahead of the lazy SDK import at the one call site below.
  */
-export function buildSessionOptions({ systemPrompt, model, repo, schema, maxTurns, allowedTools }) {
+export function buildSessionOptions({ systemPrompt, model, repo, schema, maxTurns, allowedTools, mcpServers }) {
   const sessionTools = assertAllowedTools(allowedTools);
+
+  // `tools` restricts BUILT-IN tools only ("the base set of available built-in
+  // tools", sdk.d.ts:1395). MCP tools do not come from there — they come from
+  // `mcpServers` — so passing an `mcp__…` name in `tools` would at best be
+  // ignored and at worst drop the built-in restriction. Split, deliberately.
+  const builtinTools = sessionTools.filter((t) => !isMcpTool(t));
+  const mcpTools = sessionTools.filter((t) => isMcpTool(t));
+
+  // A grant and its server must arrive together. Either half alone is a silent
+  // bug: a granted tool with no server is invisible to the model (a session that
+  // burns quota and cannot probe), and a server with no grant leaves the tool
+  // present but never pre-approved, so every call is denied by `dontAsk` with no
+  // explanation the model can act on. Fail loudly at the call site instead.
+  const hasServers = Boolean(mcpServers) && Object.keys(mcpServers).length > 0;
+  if (mcpTools.length > 0 && !hasServers) {
+    throw new Error(
+      `buildSessionOptions: granted ${mcpTools.join(", ")} but passed no \`mcpServers\`; ` +
+        "the tool would not exist in the session.",
+    );
+  }
+  if (hasServers && mcpTools.length === 0) {
+    throw new Error(
+      "buildSessionOptions: passed `mcpServers` but granted no MCP tool; every call would " +
+        "be denied by `permissionMode: 'dontAsk'`.",
+    );
+  }
+  if (builtinTools.length === 0) {
+    throw new Error(
+      "buildSessionOptions: the grant must include at least one built-in read tool " +
+        `(${PERMITTED_TOOLS.join(", ")}); an agent that can act but not read cannot cite evidence.`,
+    );
+  }
+
   return {
     // Forwarded VERBATIM, and the SDK accepts `string | string[]`. The array form
     // is load-bearing for COST, not just style: review-panel.mjs puts the shared
@@ -331,8 +398,15 @@ export function buildSessionOptions({ systemPrompt, model, repo, schema, maxTurn
     // the guarantee a property of one enum value rather than of the tool set,
     // and it left every dangerous tool visible to a model reading an untrusted
     // diff. `tools` closes that: same list, so the two can never disagree.
-    tools: sessionTools,
-    allowedTools: sessionTools, // pre-approve the same read-only set
+    tools: builtinTools,
+    // Pre-approve the built-ins AND any in-process MCP tool. This is the one
+    // place the two lists legitimately differ: the MCP tool must be approved
+    // here to be callable, but must NOT appear in `tools`, which is built-ins
+    // only. Anything absent from both stays denied by `dontAsk`.
+    allowedTools: sessionTools,
+    // Only attach the server(s) when one was actually wired — `askStructured`
+    // keys its MCP timeout backstop off the presence of this field.
+    ...(hasServers ? { mcpServers } : {}),
     permissionMode: "dontAsk", // deny anything not pre-approved, no prompts
     // SECURITY: do NOT load project settings/hooks/agents from cwd — cwd may be
     // an untrusted branch checkout, and a branch-supplied .claude hook would be
@@ -365,6 +439,7 @@ export async function askStructured({
   sessionLog,
   maxTurns,
   allowedTools,
+  mcpServers,
   label = "agent",
   // Optional attribution ({ lens, role }) stamped onto this call's logged result
   // message, so a consumer summing `sessionLog` can split cost by lens and by
@@ -375,8 +450,19 @@ export async function askStructured({
   // Built BEFORE the dynamic import, because it validates the tool grant: a bad
   // grant must fail without opening a session (ask.test.mjs asserts this ordering
   // by observing that an invalid grant throws the validation error even when the
-  // SDK cannot be resolved).
-  const options = buildSessionOptions({ systemPrompt, model, repo, schema, maxTurns, allowedTools });
+  // SDK cannot be resolved). It also splits any MCP grant from the built-ins and
+  // wires `mcpServers`, so the whole session shape stays observable in one place.
+  const options = buildSessionOptions({ systemPrompt, model, repo, schema, maxTurns, allowedTools, mcpServers });
+
+  // MCP tool calls are otherwise "effectively unbounded by default"
+  // (sdk.d.ts:477). Each call already carries its own probe timeout, so this is
+  // the backstop for a call that never returns at all. A process-level env side
+  // effect, so it stays OUT of the pure `buildSessionOptions`; `options.mcpServers`
+  // is present only when the grant actually wired a server.
+  if (options.mcpServers && !process.env.MCP_TOOL_TIMEOUT) {
+    process.env.MCP_TOOL_TIMEOUT = String(60_000);
+  }
+
   const sdk = await import("@anthropic-ai/claude-agent-sdk");
   // The one place the real SDK is in hand, so the one place the cache-boundary
   // mirror can be checked against it. Cheap, and it converts a silent 10x cost

--- a/scripts/agent/ask.test.mjs
+++ b/scripts/agent/ask.test.mjs
@@ -412,17 +412,31 @@ test("no module under scripts/agent statically imports a third-party package", (
   // (`./`, `../`) or a builtin (`node:`). Third-party dependencies are reachable
   // only through `await import(...)` inside the function that needs them.
   const dir = path.dirname(fileURLToPath(import.meta.url));
-  const files = readdirSync(dir).filter((f) => f.endsWith(".mjs"));
+  // Recursive: a guard against a future mistake has to cover where a future module
+  // might be put, and `node --test *.test.mjs` globbing flatly is exactly the trap
+  // that makes a nested module easy to add and easy to miss.
+  const walk = (d) =>
+    readdirSync(d, { withFileTypes: true }).flatMap((e) => {
+      if (e.name === "node_modules" || e.name.startsWith(".")) return [];
+      const full = path.join(d, e.name);
+      return e.isDirectory() ? walk(full) : e.name.endsWith(".mjs") ? [full] : [];
+    });
+  const files = walk(dir);
   assert.ok(files.length > 10, "expected to find the agent modules");
 
-  const STATIC_FROM = /^\s*(?:import|export)\b[^;]*?\sfrom\s+["']([^"']+)["']/gm;
+  // Two forms, because both load the package: `import x from "pkg"` and the bare
+  // side-effect `import "pkg"`. Matching only the first would leave the simpler
+  // one — the one someone reaches for to register a polyfill — undetected.
+  const WITH_FROM = /^\s*(?:import|export)\b[^;]*?\sfrom\s+["']([^"']+)["']/gm;
+  const SIDE_EFFECT = /^\s*import\s+["']([^"']+)["']/gm;
+  const isLocal = (spec) => spec.startsWith("./") || spec.startsWith("../") || spec.startsWith("node:");
   const offenders = [];
   for (const file of files) {
-    const src = readFileSync(path.join(dir, file), "utf8");
-    for (const m of src.matchAll(STATIC_FROM)) {
-      const spec = m[1];
-      if (spec.startsWith("./") || spec.startsWith("../") || spec.startsWith("node:")) continue;
-      offenders.push(`${file} → ${spec}`);
+    const src = readFileSync(file, "utf8");
+    for (const re of [WITH_FROM, SIDE_EFFECT]) {
+      for (const m of src.matchAll(re)) {
+        if (!isLocal(m[1])) offenders.push(`${path.relative(dir, file)} → ${m[1]}`);
+      }
     }
   }
   assert.deepEqual(

--- a/scripts/agent/ask.test.mjs
+++ b/scripts/agent/ask.test.mjs
@@ -1,5 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import {
   askStructured,
   assertAllowedTools,
@@ -388,4 +391,44 @@ test("classifyResult: the fix is strictly tightening — clean successes still p
   const clean = classifyResult({ type: "result", subtype: "success", structured_output: { findings: [] }, is_error: false, terminal_reason: "completed", num_turns: 14 });
   assert.equal(clean.ok, true);
   assert.deepEqual(clean.output, { findings: [] });
+});
+
+// --- the invariant that CI depends on ----------------------------------------
+
+test("no module under scripts/agent statically imports a third-party package", () => {
+  // `verify-self.mjs`'s `agent:tests` lane runs with `scripts/agent/node_modules`
+  // ABSENT — CI never installs it, which is what keeps the lane fast and makes the
+  // pure helpers here testable without the SDK. A single static third-party import
+  // breaks every test in its file AND every file importing it, with
+  // ERR_MODULE_NOT_FOUND rather than an assertion.
+  //
+  // That invariant was documented in prose at the top of ask.mjs and nothing
+  // enforced it, so hunt-tool.mjs was written with `import … from
+  // "@anthropic-ai/claude-agent-sdk"` and `import { z } from "zod"`, and CI failed
+  // with 377/379 while every local run was green. Prose invariants get broken;
+  // tested ones do not. Hence this.
+  //
+  // The rule: a top-level `import`/`export … from` specifier must be relative
+  // (`./`, `../`) or a builtin (`node:`). Third-party dependencies are reachable
+  // only through `await import(...)` inside the function that needs them.
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const files = readdirSync(dir).filter((f) => f.endsWith(".mjs"));
+  assert.ok(files.length > 10, "expected to find the agent modules");
+
+  const STATIC_FROM = /^\s*(?:import|export)\b[^;]*?\sfrom\s+["']([^"']+)["']/gm;
+  const offenders = [];
+  for (const file of files) {
+    const src = readFileSync(path.join(dir, file), "utf8");
+    for (const m of src.matchAll(STATIC_FROM)) {
+      const spec = m[1];
+      if (spec.startsWith("./") || spec.startsWith("../") || spec.startsWith("node:")) continue;
+      offenders.push(`${file} → ${spec}`);
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    "static third-party import(s) found; use `await import(...)` inside the function instead:\n  " +
+      offenders.join("\n  "),
+  );
 });

--- a/scripts/agent/charters/charters.json
+++ b/scripts/agent/charters/charters.json
@@ -37,7 +37,7 @@
       "totalTimeoutMs": 600000
     },
     "verifierMaxTurns": 20,
-    "explorerMaxTurns": 40
+    "explorerMaxTurns": 55
   },
   {
     "id": "crash",
@@ -75,6 +75,6 @@
       "totalTimeoutMs": 600000
     },
     "verifierMaxTurns": 20,
-    "explorerMaxTurns": 40
+    "explorerMaxTurns": 55
   }
 ]

--- a/scripts/agent/charters/charters.json
+++ b/scripts/agent/charters/charters.json
@@ -11,7 +11,11 @@
     "needsBackend": false,
     "mutating": false,
     "codeScope": [
-      "packages/cli/src/**"
+      "packages/cli/src/**",
+      "packages/docs/src/**",
+      "packages/sheets/src/**",
+      "packages/slides/src/**",
+      "packages/backend/src/**"
     ],
     "docsScope": [
       "packages/cli/README.md",
@@ -32,7 +36,8 @@
       "perProbeTimeoutMs": 20000,
       "totalTimeoutMs": 600000
     },
-    "verifierMaxTurns": 20
+    "verifierMaxTurns": 20,
+    "explorerMaxTurns": 40
   },
   {
     "id": "crash",
@@ -46,7 +51,11 @@
     "needsBackend": false,
     "mutating": false,
     "codeScope": [
-      "packages/cli/src/**"
+      "packages/cli/src/**",
+      "packages/docs/src/**",
+      "packages/sheets/src/**",
+      "packages/slides/src/**",
+      "packages/backend/src/**"
     ],
     "docsScope": [
       "packages/cli/README.md",
@@ -65,6 +74,7 @@
       "perProbeTimeoutMs": 20000,
       "totalTimeoutMs": 600000
     },
-    "verifierMaxTurns": 20
+    "verifierMaxTurns": 20,
+    "explorerMaxTurns": 40
   }
 ]

--- a/scripts/agent/charters/contract.md
+++ b/scripts/agent/charters/contract.md
@@ -3,8 +3,9 @@ places where the CLI's OBSERVED behavior contradicts a WRITTEN promise.
 
 ## The oracle — this is what makes a candidate reportable
 
-You do not judge whether behavior is *good*. You show that it contradicts
-something the project has written down. Every candidate must name BOTH sides:
+You do not judge whether behaviour is *good*. You show that what the CLI ACTUALLY
+DID contradicts something the project has written down. Every candidate must name
+BOTH sides:
 
 1. **The documented promise** — a `file.ext:line` inside this charter's docs
    scope (`packages/cli/README.md`, `docs/design/cli.md`,
@@ -20,20 +21,40 @@ code that under-delivers — but say which you believe is wrong and why.
 
 ## How you work
 
-You are read-only. You have Read, Grep and Glob. You do **not** run commands.
+You **run the CLI**. You have a `run` tool that executes it in an isolated scratch
+workspace and returns the real exit code, stdout and stderr.
 
-Instead you emit a **probe plan**: ordered `argv` arrays that a trusted runner
-executes on your behalf, plus your prediction of what each will produce.
+Work empirically, in a loop:
 
-- `argv` is the arguments AFTER the binary name. `["docs", "--format", "json"]`,
-  never `["wafflebase", "docs"]`, and never a shell string.
-- The probe at `failingIndex` must be the one that demonstrates the
-  contradiction. Earlier probes exist only to set it up.
-- Commit to a specific `expected` and `observed`. Your prediction being wrong is
-  informative and costs you nothing — hedging costs you the candidate, because a
-  vague prediction cannot be contradicted and therefore cannot be verified.
-- Prefer probes that need no backend: `--help`, `schema`, `--dry-run`, unknown
-  flags, unknown subcommands, malformed arguments, and local-file import/export.
+1. **Look around first.** `--help` at every level, then `schema`, to learn what
+   actually exists rather than what you assume exists.
+2. **Run something and READ the output.** Do not predict and move on.
+3. **Let what you saw choose the next command.** A surprising exit code, an error
+   that is not JSON, a flag that changed nothing — each is a thread to pull.
+4. **Confirm before you report.** Run it again, and run the neighbouring command
+   too, so you know whether the behaviour is specific or general.
+
+Then check what you observed against what is written down, and cite both.
+
+- `argv` is the arguments AFTER the binary name: `["docs", "--format", "json"]`,
+  never `["wafflebase", "docs"]`. It is an array, never a shell string — quoting,
+  `;`, pipes and `$(…)` have no meaning and will be passed through literally.
+- State persists between runs in your scratch workspace, so you can write a
+  fixture with `files` and then import it.
+- Credential, login and context-switching commands are refused. So are commands
+  the CLI declares `write` or `destructive`. A refusal is a limit, not a puzzle —
+  read it and pick a different command.
+- Your run budget is finite. Spend it on threads worth pulling, not on
+  enumerating every flag.
+
+**Report only what you have actually observed.** Cite the runs that demonstrate
+it: `probeRefs` is the 0-based indices of your own runs this session, in order,
+and `failingRef` is the one that shows the defect. A reproduction you did not run
+cannot be cited, and a candidate whose citations do not resolve is dropped.
+
+`expected` and `observed` must be specific. `observed` is what you SAW — quote the
+exit code and the output. `expected` is what the documentation says should have
+happened. A vague pair cannot be contradicted and therefore cannot be verified.
 
 ## In your lane
 

--- a/scripts/agent/charters/crash.md
+++ b/scripts/agent/charters/crash.md
@@ -23,13 +23,27 @@ that should have been `parseAsync`. "It crashed somewhere" is not actionable.
 
 ## How you work
 
-You are read-only. You have Read, Grep and Glob. You do **not** run commands.
+You **run the CLI**. You have a `run` tool that executes it in an isolated scratch
+workspace and returns the real exit code, stdout and stderr.
 
-You emit a **probe plan**: ordered `argv` arrays a trusted runner executes for
-you, plus your prediction. `argv` is the arguments AFTER the binary name, never a
-shell string.
+For this charter the transcript IS the evidence, so run things and read what comes
+back. A stack trace, a hang, or an error that bypasses the JSON envelope is visible
+in the output and nowhere else — no amount of reading the source proves the CLI
+actually printed it.
 
-Fruitful places to point probes, all backend-free:
+- `argv` is the arguments AFTER the binary name, and it is an array, never a shell
+  string: `;`, pipes and `$(…)` are passed through as literal characters.
+- Use `files` to plant a malformed fixture, and `stdin` to feed input. State
+  persists across runs in your scratch workspace.
+- Credential, login and context-switching commands are refused, as are commands the
+  CLI declares `write` or `destructive`. Read the refusal and move on.
+- Your run budget is finite.
+
+Cite the runs that demonstrate the crash: `probeRefs` is the 0-based indices of
+your own runs this session, and `failingRef` is the one that crashed. You cannot
+cite a run you did not perform.
+
+Fruitful things to try, all backend-free:
 
 - Missing required arguments; too many arguments.
 - Unknown commands and unknown flags; a flag given without its value.

--- a/scripts/agent/hunt-gate.mjs
+++ b/scripts/agent/hunt-gate.mjs
@@ -50,36 +50,22 @@ import { KNOWN } from "./severity.mjs";
 // schema instead of hand-copied (the same drift guard review-panel.mjs applies to
 // REFUTATION_GROUNDS).
 
-/**
- * One probe: an argv array the trusted runner will execute, never a shell string.
- *
- * This is the anti-slop mechanism and the single most important shape in the
- * pipeline. The hunter does NOT get Bash — it proposes argv and predicts the
- * outcome, and `hunt-probe.mjs` runs it. Three consequences:
- *   - No shell string is ever built from model output, so there is nothing to
- *     inject into.
- *   - The clean room is enforceable, because trusted code owns env/cwd/timeouts.
- *   - Replay is FREE and exact: re-running the same argv IS the replay, so the
- *     "repro doesn't match what the agent actually did" failure class cannot
- *     occur. `repro.sh` is rendered from the argv for humans, never authored.
- */
-const PROBE = {
-  type: "object",
-  properties: {
-    argv: { type: "array", items: { type: "string" } },
-    note: { type: "string" },
-    stdin: { type: "string" },
-    files: {
-      type: "array",
-      items: {
-        type: "object",
-        properties: { path: { type: "string" }, contentBase64: { type: "string" } },
-        required: ["path", "contentBase64"],
-      },
-    },
-  },
-  required: ["argv"],
-};
+// A probe is an argv ARRAY the trusted runner executes, never a shell string —
+// the anti-slop mechanism and the most important shape in the pipeline. Three
+// consequences, all still in force:
+//   - No shell string is ever built from model output, so there is nothing to
+//     inject into.
+//   - The clean room is enforceable, because trusted code owns env/cwd/timeouts.
+//   - Replay is exact: re-running the same argv IS the replay, so the "repro
+//     doesn't match what the agent actually did" failure class cannot occur.
+//     `repro.sh` is rendered from the argv for humans, never authored.
+//
+// The probe SCHEMA used to live here, because the hunter authored probes and
+// predicted their outcome. It now runs them itself through one bounded in-process
+// tool (`hunt-tool.mjs`) and cites journal indices instead, so the shape is owned
+// by that tool's zod input and this duplicate was deleted rather than left to
+// drift. The propose/execute split survives where it earns its keep — reporting —
+// and exploration is no longer blind, which is the only way surprise is possible.
 
 const CANDIDATE = {
   type: "object",
@@ -88,15 +74,22 @@ const CANDIDATE = {
     severity: { type: "string", enum: ["critical", "major", "minor", "nit"] },
     title: { type: "string" },
     // `expected` and `observed` are what make a candidate falsifiable: the
-    // hunter must commit to a prediction the runner can contradict.
+    // hunter must commit to a claim the runner can contradict.
     expected: { type: "string" },
     observed: { type: "string" },
-    probes: { type: "array", items: PROBE },
-    failingIndex: { type: "integer" },
+    // Evidence is CITED, not authored. These are indices into the session's probe
+    // journal — the commands this process actually ran, in order. The hunter can
+    // therefore only point at reproductions that genuinely happened; it cannot
+    // describe a command it never issued, which is what a model-authored `probes`
+    // array allowed. `resolveProbeRefs` (hunt-tool.mjs) converts them back into
+    // the `probes`/`failingIndex` shape the gate, replay and report already use,
+    // so nothing downstream had to change.
+    probeRefs: { type: "array", items: { type: "integer" } },
+    failingRef: { type: "integer" },
     citations: { type: "array", items: { type: "string" } },
     docCitation: { type: "string" },
   },
-  required: ["oracle", "severity", "title", "expected", "observed", "probes", "failingIndex", "citations"],
+  required: ["oracle", "severity", "title", "expected", "observed", "probeRefs", "failingRef", "citations"],
 };
 
 export const EXPLORER_SCHEMA = {
@@ -132,6 +125,13 @@ export const HUNT_VERIFIER_SCHEMA = {
         "relation-violated", // round-trip: a metamorphic identity broke
         "state-inconsistent", // state: a lifecycle op left the wrong state
         "value-diverges", // formula-diff: value differs from the reference
+        // Two grounds that only become available once the explorer can EXECUTE.
+        // Both are checkable from a transcript, which is what keeps them from
+        // degenerating into "this surprised me" — the one ground deliberately
+        // absent from this list, because it is the slop generator that ended
+        // curl's bug bounty.
+        "self-inconsistent", // two paths disagree about the same data
+        "schema-annotation-false", // `schema` declares a safety level the command violates
         "none",
       ],
     },

--- a/scripts/agent/hunt-gate.test.mjs
+++ b/scripts/agent/hunt-gate.test.mjs
@@ -343,18 +343,24 @@ test("HUNT_GROUNDS is derived from the schema, not hand-copied", () => {
   assert.ok(HUNT_GROUNDS.has("none"), "'none' is a legal value the gate then refuses to act on");
 });
 
-test("EXPLORER_SCHEMA: probes are argv arrays, and the falsifiable fields are required", () => {
+test("EXPLORER_SCHEMA: evidence is CITED as journal indices, never authored", () => {
   const cand = EXPLORER_SCHEMA.properties.candidates.items;
-  for (const f of ["oracle", "severity", "title", "expected", "observed", "probes", "failingIndex", "citations"]) {
+  for (const f of ["oracle", "severity", "title", "expected", "observed", "probeRefs", "failingRef", "citations"]) {
     assert.ok(cand.required.includes(f), `${f} must be required`);
   }
-  const probe = cand.properties.probes.items;
-  assert.deepEqual(probe.properties.argv, { type: "array", items: { type: "string" } });
-  assert.deepEqual(probe.required, ["argv"]);
-  // There must be NO way to express a shell command in the schema — the whole
-  // anti-injection design rests on the model only ever emitting argv.
+  // Indices into the session journal, so the only reproductions a candidate can
+  // cite are runs this process actually performed and recorded.
+  assert.deepEqual(cand.properties.probeRefs, { type: "array", items: { type: "integer" } });
+  assert.deepEqual(cand.properties.failingRef, { type: "integer" });
+
+  // The model must have NO way to hand back a command at all — not a shell string,
+  // and no longer even an argv array. Commands reach the CLI only through the
+  // bounded `run` tool, so a candidate cannot describe a reproduction that never
+  // happened. This is strictly stronger than the argv-array rule it replaces.
+  assert.equal(cand.properties.probes, undefined, "candidates must not author probes");
+  assert.equal(cand.properties.argv, undefined);
   const json = JSON.stringify(EXPLORER_SCHEMA);
-  for (const forbidden of ["command", "shell", "script", "bash"]) {
+  for (const forbidden of ["command", "shell", "script", "bash", "argv"]) {
     assert.doesNotMatch(json, new RegExp(`"${forbidden}"`, "i"), `schema must not offer a "${forbidden}" field`);
   }
 });

--- a/scripts/agent/hunt-tool.mjs
+++ b/scripts/agent/hunt-tool.mjs
@@ -39,8 +39,17 @@
 // charter is non-mutating") lets it adapt and keep exploring, which is the
 // difference between a bounded agent and a stuck one.
 
-import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
-import { z } from "zod";
+// The SDK and zod are imported LAZILY, inside `createProbeServer` only.
+//
+// This is not style. `scripts/verify-self.mjs`'s `agent:tests` lane runs with
+// `scripts/agent/node_modules` ABSENT — CI never installs it — so a static import
+// here makes every test in this file, and every file importing it, fail with
+// ERR_MODULE_NOT_FOUND. `ask.mjs` states the same invariant and it still caught me
+// out in a new file: CI failed with
+//   Cannot find package '@anthropic-ai/claude-agent-sdk' imported from … hunt-tool.mjs
+//
+// So everything testable lives in `createProbeTool`, which has no third-party
+// imports at all, and `createProbeServer` is a thin async wrapper that needs them.
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -240,7 +249,16 @@ function renderObservation(obs, secrets) {
  * exercise refusal, budgeting, journalling and redaction without spawning a CLI
  * or touching a network.
  */
-export function createProbeServer({
+/**
+ * The tool's behaviour, with NO third-party dependency.
+ *
+ * Returns the handler `createProbeServer` will register. Split out so the tests can
+ * exercise budgeting, refusal, journalling and redaction without the SDK installed
+ * — which is the environment CI actually runs.
+ *
+ * `runner` is injectable for the same reason `runProbe`'s is: no CLI, no network.
+ */
+export function createProbeTool({
   charter,
   bin,
   cfg = {},
@@ -252,6 +270,69 @@ export function createProbeServer({
 } = {}) {
   const secrets = [cfg.apiKey].filter(Boolean);
   const timeoutMs = charter?.probeBudget?.perProbeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+
+  return async function runTool({ argv, note, stdin, files } = {}) {
+    // 1. BUDGET FIRST. Checked before validation so an exhausted session cannot be
+    //    kept alive by a stream of malformed calls.
+    const charged = budget.charge();
+    if (!charged.ok) return say(charged.why, { isError: true });
+
+    // 2. SAFETY. Independent of the CLI's own schema for the hard denials, and
+    //    additionally consulting that schema, whose wrongness is itself one of the
+    //    things this hunter looks for.
+    try {
+      assertSafeArgv(argv, {
+        mutating: charter?.mutating === true,
+        safetyOf: isReadOnlyByConstruction(argv) ? () => "read-only" : safetyOf,
+      });
+    } catch (err) {
+      return say(
+        `Refused: ${err.message}\n\n` +
+          "This is a hard limit, not a suggestion. Choose a different command; do not " +
+          "retry this one.",
+        { isError: true },
+      );
+    }
+
+    // 3. RUN in the replaced environment, inside the session scratch.
+    let obs;
+    try {
+      obs = runProbe(
+        { argv, stdin, files },
+        { bin, env: buildProbeEnv(scratch, cfg), cwd: scratch, timeoutMs, runner },
+      );
+    } catch (err) {
+      // A fixture path escaping the scratch lands here. Still a readable refusal,
+      // not a thrown tool call.
+      return say(`Refused: ${err.message}`, { isError: true });
+    }
+
+    // 4. JOURNAL. This, not any model-authored field, is what the trusted runner
+    //    replays and what the report's repro is rendered from.
+    journal.push({
+      argv: [...argv],
+      note: typeof note === "string" ? note : undefined,
+      stdin: typeof stdin === "string" ? stdin : undefined,
+      files: Array.isArray(files) ? files : undefined,
+      observed: obs,
+    });
+
+    // 5. REDACT on the way out.
+    return say(renderObservation(obs, secrets));
+  };
+}
+
+/**
+ * The in-process MCP server exposing the single `run` tool.
+ *
+ * ASYNC and lazy on purpose: this is the only function here that touches the SDK or
+ * zod, so it is the only one that cannot run in the `agent:tests` lane. Everything
+ * worth testing is in `createProbeTool`, which this merely wraps in a tool schema.
+ */
+export async function createProbeServer(opts = {}) {
+  const { createSdkMcpServer, tool } = await import("@anthropic-ai/claude-agent-sdk");
+  const { z } = await import("zod");
+  const runTool = createProbeTool(opts);
 
   return createSdkMcpServer({
     name: "wafflebase",
@@ -287,55 +368,7 @@ export function createProbeServer({
             .optional()
             .describe("Fixture files to create before running, e.g. a document to import."),
         },
-        async ({ argv, note, stdin, files }) => {
-          // 1. BUDGET FIRST. Checked before validation so an exhausted session
-          //    cannot be kept alive by a stream of malformed calls.
-          const charged = budget.charge();
-          if (!charged.ok) return say(charged.why, { isError: true });
-
-          // 2. SAFETY. Independent of the CLI's own schema for the hard denials,
-          //    and additionally consulting that schema, whose wrongness is itself
-          //    one of the things this hunter looks for.
-          try {
-            assertSafeArgv(argv, {
-              mutating: charter?.mutating === true,
-              safetyOf: isReadOnlyByConstruction(argv) ? () => "read-only" : safetyOf,
-            });
-          } catch (err) {
-            return say(
-              `Refused: ${err.message}\n\n` +
-                "This is a hard limit, not a suggestion. Choose a different command; " +
-                "do not retry this one.",
-              { isError: true },
-            );
-          }
-
-          // 3. RUN in the replaced environment, inside the session scratch.
-          let obs;
-          try {
-            obs = runProbe(
-              { argv, stdin, files },
-              { bin, env: buildProbeEnv(scratch, cfg), cwd: scratch, timeoutMs, runner },
-            );
-          } catch (err) {
-            // A fixture path escaping the scratch lands here. Still a readable
-            // refusal, not a thrown tool call.
-            return say(`Refused: ${err.message}`, { isError: true });
-          }
-
-          // 4. JOURNAL. This, not any model-authored field, is what the trusted
-          //    runner replays and what the report's repro is rendered from.
-          journal.push({
-            argv: [...argv],
-            note: typeof note === "string" ? note : undefined,
-            stdin: typeof stdin === "string" ? stdin : undefined,
-            files: Array.isArray(files) ? files : undefined,
-            observed: obs,
-          });
-
-          // 5. REDACT on the way out.
-          return say(renderObservation(obs, secrets));
-        },
+        (args) => runTool(args),
       ),
     ],
   });

--- a/scripts/agent/hunt-tool.mjs
+++ b/scripts/agent/hunt-tool.mjs
@@ -115,7 +115,11 @@ export function createProbeBudget({ maxProbes = 40, totalTimeoutMs = 600_000, no
         };
       }
       used++;
-      return { ok: true };
+      // How much session time is left AFTER admitting this probe. The caller clamps
+      // the per-probe timeout to it: without that, a probe admitted with 100ms of
+      // budget remaining still runs for its full 20s, so `totalTimeoutMs` bounds
+      // when a probe may START but not when the session ends.
+      return { ok: true, remainingMs: Math.max(0, totalTimeoutMs - elapsed) };
     },
   };
 }
@@ -226,29 +230,25 @@ function clip(s) {
  * the two would hide it.
  */
 function renderObservation(obs, secrets) {
+  // Redact BEFORE clipping. Clipping first can cut a token in half, leaving a head
+  // that no longer matches any secret pattern — so the truncation itself would
+  // defeat the redaction it precedes.
+  const safe = (text) => clip(redactSecrets(String(text ?? ""), { extra: secrets }));
   const parts = [
     `exit code: ${obs.exitCode === null ? "null (killed)" : obs.exitCode}`,
     obs.signal ? `signal: ${obs.signal}` : null,
     obs.timedOut ? "TIMED OUT" : null,
     obs.spawnError ? `spawn error: ${obs.spawnError}` : null,
     `--- stdout (${obs.stdout.length} chars) ---`,
-    clip(obs.stdout),
+    safe(obs.stdout),
     `--- stderr (${obs.stderr.length} chars) ---`,
-    clip(obs.stderr),
+    safe(obs.stderr),
   ].filter((p) => p !== null);
-  // Redacted HERE, at the boundary where text first becomes visible to a model
-  // whose output reaches a public report. `runProbe` output can carry an
-  // `Authorization: Bearer …` header or the configured API key verbatim.
+  // Redacted again over the whole thing, which also covers the metadata lines (a
+  // spawn error can echo an argument). The streams are already clean by here.
   return redactSecrets(parts.join("\n"), { extra: secrets });
 }
 
-/**
- * The in-process MCP server exposing the single `run` tool.
- *
- * `runner` is injectable for the same reason `runProbe`'s is: the tests must
- * exercise refusal, budgeting, journalling and redaction without spawning a CLI
- * or touching a network.
- */
 /**
  * The tool's behaviour, with NO third-party dependency.
  *
@@ -281,9 +281,25 @@ export function createProbeTool({
     //    additionally consulting that schema, whose wrongness is itself one of the
     //    things this hunter looks for.
     try {
+      // The help exemption may only RESCUE an unresolvable annotation; it must
+      // never override a resolved one. `docs delete d1 --help` would otherwise be
+      // waved through as read-only despite `docs.delete` being declared
+      // destructive, because the flag matched anywhere in argv. Ask the real
+      // `safetyOf` first and defer to it whenever it has an answer.
       assertSafeArgv(argv, {
         mutating: charter?.mutating === true,
-        safetyOf: isReadOnlyByConstruction(argv) ? () => "read-only" : safetyOf,
+        // When no annotation table is available at all, pass `null` through
+        // unchanged so `assertSafeArgv` skips the annotation check entirely and
+        // falls back to the hard-deny list — wrapping it here would instead make
+        // EVERY command unresolvable, and therefore refused.
+        safetyOf:
+          typeof safetyOf === "function"
+            ? (words) => {
+                const declared = safetyOf(words);
+                if (declared != null) return declared;
+                return isReadOnlyByConstruction(argv) ? "read-only" : null;
+              }
+            : null,
       });
     } catch (err) {
       return say(
@@ -299,7 +315,14 @@ export function createProbeTool({
     try {
       obs = runProbe(
         { argv, stdin, files },
-        { bin, env: buildProbeEnv(scratch, cfg), cwd: scratch, timeoutMs, runner },
+        {
+          bin,
+          env: buildProbeEnv(scratch, cfg),
+          cwd: scratch,
+          // Never let one probe outlive the session budget it was admitted under.
+          timeoutMs: Math.max(1, Math.min(timeoutMs, charged.remainingMs ?? timeoutMs)),
+          runner,
+        },
       );
     } catch (err) {
       // A fixture path escaping the scratch lands here. Still a readable refusal,
@@ -330,6 +353,14 @@ export function createProbeTool({
  * worth testing is in `createProbeTool`, which this merely wraps in a tool schema.
  */
 export async function createProbeServer(opts = {}) {
+  // Set BEFORE the SDK is imported. MCP tool calls are otherwise "effectively
+  // unbounded by default" (sdk.d.ts:477), and the per-server `timeoutMs` override
+  // at sdk.d.ts:1011 exists only on the http/sse/stdio/proxy server types — NOT on
+  // in-process SDK servers — so this variable is the only lever available here.
+  // Setting it at the earliest point on the MCP path costs nothing and removes any
+  // question about whether a cached SDK import already read it.
+  if (!process.env.MCP_TOOL_TIMEOUT) process.env.MCP_TOOL_TIMEOUT = String(60_000);
+
   const { createSdkMcpServer, tool } = await import("@anthropic-ai/claude-agent-sdk");
   const { z } = await import("zod");
   const runTool = createProbeTool(opts);

--- a/scripts/agent/hunt-tool.mjs
+++ b/scripts/agent/hunt-tool.mjs
@@ -1,0 +1,342 @@
+// The explorer's ONE capability: run the wafflebase CLI and see what happened.
+//
+// WHY THIS EXISTS. The first cut of this hunter could not run anything. Its tools
+// were `Read`/`Grep`/`Glob` and its system prompt said "you never run commands
+// yourself", so it read the source, PREDICTED a contradiction, and a trusted
+// runner tested the prediction afterwards. That inverted the point of targeting a
+// CLI at all: a CLI's only unique value is that it is an executable interface, and
+// a reader that cannot execute may as well have been pointed at any package in the
+// repo. It could never be surprised, and surprise is the entire product.
+//
+// WHAT IS AND IS NOT BEING RELAXED. The propose/execute split is NOT the mistake
+// and is NOT abandoned. It is correct for REPORTING — it is what makes replay
+// exact and shell injection structurally impossible. The mistake was applying it
+// to EXPLORATION, where blindness is the problem. So:
+//
+//   exploration  the model calls this tool, sees real output, forms a hypothesis,
+//                calls again. Every call is JOURNALED as an argv array.
+//   reporting    the trusted runner replays the JOURNAL 3x after the session.
+//
+// Because the journal records what actually ran rather than what the model claims
+// it ran, the repro is now strictly MORE trustworthy than before, not less.
+//
+// WHY THIS IS NOT A SHELL. `Bash` would grant arbitrary execution. This grants one
+// tool that can only reach `node <cli-bin> <argv...>`:
+//
+//   * `argv` is a string ARRAY. No shell is ever involved (`spawnSync`, no
+//     `shell:true`), so quoting, `;`, `$(…)` and globs have no meaning.
+//   * `assertSafeArgv` hard-denies credential and session commands independently
+//     of the CLI's own schema, and — now that the model drives execution — also
+//     consults that schema's `destructive`/`write` annotations via `safetyOf`.
+//   * `buildProbeEnv` REPLACES the environment. The developer's real session,
+//     config and workspace are unreachable, so the clean room is not a promise
+//     about behaviour, it is a property of the process.
+//   * A budget bounds probe count and wall-clock, because an uncapped tool loop is
+//     how a $6 run becomes a $200 one.
+//
+// WHY REFUSALS ARE RETURNED, NOT THROWN. A thrown error aborts the tool call and
+// teaches the model nothing. A refusal it can READ ("that command is denied; the
+// charter is non-mutating") lets it adapt and keep exploring, which is the
+// difference between a bounded agent and a stuck one.
+
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  assertSafeArgv,
+  buildProbeEnv,
+  redactSecrets,
+  runProbe,
+  DEFAULT_PROBE_TIMEOUT_MS,
+} from "./hunt-probe.mjs";
+
+export const PROBE_TOOL_NAME = "mcp__wafflebase__run";
+
+/** Truncation cap for one stream in a tool result. Bounded, but a stack fits. */
+const MAX_STREAM_CHARS = 20_000;
+
+/**
+ * Bounds on one exploration session.
+ *
+ * `charters.json` has declared `maxProbes` and `totalTimeoutMs` since the
+ * beginning and NOTHING ever enforced them — only `perProbeTimeoutMs` was read
+ * (`hunt.mjs`). That was survivable while the model could not act. The moment it
+ * drives a loop, an unenforced budget is the only thing between a normal run and
+ * an unbounded one, so it is enforced here, at the single choke point.
+ *
+ * `now` is injectable so a test can exhaust the clock without waiting.
+ */
+export function createProbeBudget({ maxProbes = 40, totalTimeoutMs = 600_000, now = Date.now } = {}) {
+  const started = now();
+  let used = 0;
+  const refusals = [];
+  return {
+    get used() {
+      return used;
+    },
+    get refusals() {
+      return [...refusals];
+    },
+    /**
+     * Reserve one probe. Returns `{ok:false, why}` instead of throwing, and does
+     * NOT consume the reservation when it refuses — a refused call must not push
+     * the budget further toward exhaustion.
+     */
+    charge() {
+      if (used >= maxProbes) {
+        refusals.push({ kind: "maxProbes", used });
+        return {
+          ok: false,
+          why:
+            `Probe budget exhausted: ${maxProbes} probes already run in this session. ` +
+            "No further commands can run. Report what you have found, or return zero candidates.",
+        };
+      }
+      const elapsed = now() - started;
+      if (elapsed >= totalTimeoutMs) {
+        refusals.push({ kind: "totalTimeoutMs", elapsed });
+        return {
+          ok: false,
+          why:
+            `Session probe time exhausted (${Math.round(elapsed / 1000)}s of ` +
+            `${Math.round(totalTimeoutMs / 1000)}s). No further commands can run. ` +
+            "Report what you have found, or return zero candidates.",
+        };
+      }
+      used++;
+      return { ok: true };
+    },
+  };
+}
+
+/**
+ * A scratch directory for one exploration session, plus its disposal.
+ *
+ * Deliberately per SESSION, not per probe. The model has to be able to write a
+ * fixture and then import it, or read back a file a previous command exported —
+ * a fresh directory per call would make every multi-step behaviour untestable.
+ * Isolation does not come from throwing the directory away: it comes from
+ * `buildProbeEnv` replacing the environment, so nothing here can address the
+ * developer's real workspace no matter how much state accumulates.
+ *
+ * (`withScratch` in hunt-probe.mjs is the per-call equivalent and stays in use
+ * for replay, where a fresh room per attempt is exactly what is wanted.)
+ */
+export function openSessionScratch({ prefix = "wb-explore-" } = {}) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
+  return { dir, dispose: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+/**
+ * Turn a candidate's journal REFERENCES into the `probes`/`failingIndex` shape
+ * the rest of the pipeline already speaks.
+ *
+ * The candidate cites indices into the session journal rather than authoring argv
+ * itself. That is the honesty property of this whole redesign: a model cannot
+ * report a reproduction it never actually ran, because the only commands it can
+ * cite are ones this process executed and recorded. Previously `probes` was
+ * model-authored prose that a later runner hopefully re-executed; now it is a
+ * transcript.
+ *
+ * Fails QUIET, like every other gate here: any bad reference returns `null` and
+ * the caller drops the candidate. An out-of-range index is not repaired and not
+ * partially honoured — a candidate whose evidence cannot be located is exactly
+ * the thing that must not become a report.
+ *
+ * Duplicate references are preserved rather than collapsed: running the same
+ * command twice is legitimate evidence (idempotency, or a second call behaving
+ * differently from the first), and deduplicating would erase that.
+ */
+export function resolveProbeRefs(candidate, journal) {
+  const refs = candidate?.probeRefs;
+  if (!Array.isArray(refs) || refs.length === 0) return null;
+  if (!refs.every((i) => Number.isInteger(i) && i >= 0 && i < journal.length)) return null;
+
+  const failing = candidate?.failingRef;
+  if (!Number.isInteger(failing)) return null;
+  const failingIndex = refs.indexOf(failing);
+  if (failingIndex === -1) return null; // the failing probe must be among the cited ones
+
+  const probes = refs.map((i) => {
+    const e = journal[i];
+    return {
+      argv: [...e.argv],
+      ...(e.note === undefined ? {} : { note: e.note }),
+      ...(e.stdin === undefined ? {} : { stdin: e.stdin }),
+      ...(e.files === undefined ? {} : { files: e.files }),
+    };
+  });
+  return { probes, failingIndex };
+}
+
+/**
+ * Is this invocation read-only no matter what the registry says?
+ *
+ * `assertSafeArgv` fails CLOSED when `safetyOf` cannot resolve a command, which is
+ * the right default — an unknown command must not be assumed safe. But two of the
+ * explorer's most important commands are unresolvable by construction:
+ *
+ *   * `docs --help` reduces to the single word `docs`, and the registry only names
+ *     leaves (`docs.list`, `docs.export`, …). Commander prints help and exits
+ *     WITHOUT running any command, so a help request cannot mutate anything.
+ *   * `schema` does not appear in its own output, and all it does is print the
+ *     registry.
+ *
+ * Without this exemption the annotation lookup would refuse `--help` — the primary
+ * way an explorer discovers the surface at all — and the whole session would be
+ * spent on refusals. The hard-denial list is checked BEFORE `safetyOf` inside
+ * `assertSafeArgv`, so `api-keys revoke --help` stays denied regardless.
+ */
+const HELP_FLAGS = new Set(["--help", "-h", "--version", "-V"]);
+const META_READ_ONLY = new Set(["schema"]);
+export function isReadOnlyByConstruction(argv) {
+  const list = Array.isArray(argv) ? argv : [];
+  if (list.some((a) => HELP_FLAGS.has(a))) return true;
+  const words = list.filter((a) => typeof a === "string" && !a.startsWith("-"));
+  return words.length > 0 && META_READ_ONLY.has(words[0]);
+}
+
+/** A tool result the model reads as prose. `isError` marks a refusal. */
+function say(text, { isError = false } = {}) {
+  return { content: [{ type: "text", text }], isError };
+}
+
+function clip(s) {
+  const t = String(s ?? "");
+  return t.length > MAX_STREAM_CHARS ? `${t.slice(0, MAX_STREAM_CHARS)}\n…[truncated]` : t;
+}
+
+/**
+ * Render an observation for the model.
+ *
+ * Both streams are labelled and reported separately even when empty, because
+ * WHICH stream carried the output is itself a contract the charter hunts — a
+ * message on stdout that the docs promise on stderr is a finding, and collapsing
+ * the two would hide it.
+ */
+function renderObservation(obs, secrets) {
+  const parts = [
+    `exit code: ${obs.exitCode === null ? "null (killed)" : obs.exitCode}`,
+    obs.signal ? `signal: ${obs.signal}` : null,
+    obs.timedOut ? "TIMED OUT" : null,
+    obs.spawnError ? `spawn error: ${obs.spawnError}` : null,
+    `--- stdout (${obs.stdout.length} chars) ---`,
+    clip(obs.stdout),
+    `--- stderr (${obs.stderr.length} chars) ---`,
+    clip(obs.stderr),
+  ].filter((p) => p !== null);
+  // Redacted HERE, at the boundary where text first becomes visible to a model
+  // whose output reaches a public report. `runProbe` output can carry an
+  // `Authorization: Bearer …` header or the configured API key verbatim.
+  return redactSecrets(parts.join("\n"), { extra: secrets });
+}
+
+/**
+ * The in-process MCP server exposing the single `run` tool.
+ *
+ * `runner` is injectable for the same reason `runProbe`'s is: the tests must
+ * exercise refusal, budgeting, journalling and redaction without spawning a CLI
+ * or touching a network.
+ */
+export function createProbeServer({
+  charter,
+  bin,
+  cfg = {},
+  scratch,
+  budget,
+  journal,
+  safetyOf = null,
+  runner = null,
+} = {}) {
+  const secrets = [cfg.apiKey].filter(Boolean);
+  const timeoutMs = charter?.probeBudget?.perProbeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+
+  return createSdkMcpServer({
+    name: "wafflebase",
+    version: "1.0.0",
+    instructions:
+      "Run the wafflebase CLI in an isolated scratch workspace. Arguments are passed " +
+      "directly to the binary as an array — there is no shell, so quoting and " +
+      "substitution have no effect. Credential, login and context-switching commands " +
+      "are refused. State persists across calls within this session.",
+    tools: [
+      tool(
+        "run",
+        "Run the wafflebase CLI with the given arguments and return its exit code, " +
+          "stdout and stderr. `argv` excludes the binary name: pass " +
+          '["docs","--help"], not ["wafflebase","docs","--help"].',
+        {
+          argv: z
+            .array(z.string())
+            .min(1)
+            .describe('CLI arguments after the binary name, e.g. ["docs","import","--dry-run","f.docx"]'),
+          note: z
+            .string()
+            .optional()
+            .describe("Why you are running this — recorded alongside the command for the report."),
+          stdin: z.string().optional().describe("Text to write to the command's stdin."),
+          files: z
+            .array(
+              z.object({
+                path: z.string().describe("Path relative to the scratch workspace."),
+                contentBase64: z.string().describe("File contents, base64-encoded."),
+              }),
+            )
+            .optional()
+            .describe("Fixture files to create before running, e.g. a document to import."),
+        },
+        async ({ argv, note, stdin, files }) => {
+          // 1. BUDGET FIRST. Checked before validation so an exhausted session
+          //    cannot be kept alive by a stream of malformed calls.
+          const charged = budget.charge();
+          if (!charged.ok) return say(charged.why, { isError: true });
+
+          // 2. SAFETY. Independent of the CLI's own schema for the hard denials,
+          //    and additionally consulting that schema, whose wrongness is itself
+          //    one of the things this hunter looks for.
+          try {
+            assertSafeArgv(argv, {
+              mutating: charter?.mutating === true,
+              safetyOf: isReadOnlyByConstruction(argv) ? () => "read-only" : safetyOf,
+            });
+          } catch (err) {
+            return say(
+              `Refused: ${err.message}\n\n` +
+                "This is a hard limit, not a suggestion. Choose a different command; " +
+                "do not retry this one.",
+              { isError: true },
+            );
+          }
+
+          // 3. RUN in the replaced environment, inside the session scratch.
+          let obs;
+          try {
+            obs = runProbe(
+              { argv, stdin, files },
+              { bin, env: buildProbeEnv(scratch, cfg), cwd: scratch, timeoutMs, runner },
+            );
+          } catch (err) {
+            // A fixture path escaping the scratch lands here. Still a readable
+            // refusal, not a thrown tool call.
+            return say(`Refused: ${err.message}`, { isError: true });
+          }
+
+          // 4. JOURNAL. This, not any model-authored field, is what the trusted
+          //    runner replays and what the report's repro is rendered from.
+          journal.push({
+            argv: [...argv],
+            note: typeof note === "string" ? note : undefined,
+            stdin: typeof stdin === "string" ? stdin : undefined,
+            files: Array.isArray(files) ? files : undefined,
+            observed: obs,
+          });
+
+          // 5. REDACT on the way out.
+          return say(renderObservation(obs, secrets));
+        },
+      ),
+    ],
+  });
+}

--- a/scripts/agent/hunt-tool.test.mjs
+++ b/scripts/agent/hunt-tool.test.mjs
@@ -1,0 +1,314 @@
+// The explorer can now RUN things, so this file is the boundary that decides what
+// "can run" means. Every test here exists because removing the guard it covers
+// would let a model reach something it must not, or report something that never
+// happened. Each one was checked to FAIL with its guard removed — a safety test
+// that passes either way is worse than none, because it certifies nothing while
+// looking like it does.
+//
+// No CLI and no network: `runner` is injected, exactly as hunt-probe.test.mjs does.
+// The exception is the two tests about file handling, which pass `real: true` —
+// `runProbe` returns before materializing fixtures when a runner is present, so
+// injecting one there would skip the very guard under test.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  createProbeBudget,
+  createProbeServer,
+  openSessionScratch,
+  resolveProbeRefs,
+  PROBE_TOOL_NAME,
+} from "./hunt-tool.mjs";
+
+/** Reach the tool's handler the way the SDK will call it. */
+function handlerOf(server) {
+  const t = server.instance._registeredTools.run;
+  assert.ok(typeof t?.handler === "function", "the `run` tool must be registered");
+  return (args) => t.handler(args, {});
+}
+
+// `real: true` uses the genuine runProbe path instead of an injected runner.
+// runProbe returns EARLY when a runner is present, before materializing fixtures,
+// so any test about file handling has to take the real path. `bin` need not exist:
+// runProbe records a spawn failure rather than throwing.
+function makeServer({ charter = { mutating: false }, cfg = {}, budget, journal = [], safetyOf = null, runner, real = false } = {}) {
+  const scratch = openSessionScratch();
+  const server = createProbeServer({
+    charter,
+    bin: "/nonexistent/bin.js",
+    cfg,
+    scratch: scratch.dir,
+    budget: budget ?? createProbeBudget({ maxProbes: 10 }),
+    journal,
+    safetyOf,
+    runner: real
+      ? null
+      : (runner ??
+        ((argv) => ({ argv, exitCode: 0, signal: null, stdout: "ok", stderr: "", timedOut: false, spawnError: null }))),
+  });
+  return { call: handlerOf(server), journal, scratch };
+}
+
+const textOf = (r) => r.content.map((c) => c.text).join("\n");
+
+// --- the tool is not a shell -------------------------------------------------
+
+test("the granted tool name is the exact one ask.mjs permits", () => {
+  // If these drift, the session grants a tool that does not exist (model can read
+  // but never probe) or runs a server whose tool is never approved. Both fail
+  // silently at runtime, so pin the string.
+  assert.equal(PROBE_TOOL_NAME, "mcp__wafflebase__run");
+});
+
+test("argv reaches the runner as DATA — metacharacters are never interpreted", async () => {
+  const seen = [];
+  const { call } = makeServer({
+    runner: (argv) => {
+      seen.push(argv);
+      return { argv, exitCode: 0, signal: null, stdout: "", stderr: "", timedOut: false, spawnError: null };
+    },
+  });
+  const nasty = ["docs", "list", "; rm -rf /", "$(id)", "`whoami`", "a\nb", "'quoted'", "*"];
+  await call({ argv: nasty });
+  assert.deepEqual(seen[0], nasty, "every element must survive verbatim, unsplit and unexpanded");
+});
+
+// --- refusals are readable, not thrown ---------------------------------------
+
+test("a hard-denied command is refused as READABLE text, and never runs", async () => {
+  // A thrown error aborts the tool call and teaches the model nothing; it would
+  // retry or stall. A refusal it can read lets it adapt, which is the difference
+  // between a bounded agent and a stuck one.
+  let ran = 0;
+  const journal = [];
+  const { call } = makeServer({
+    journal,
+    runner: (argv) => {
+      ran++;
+      return { argv, exitCode: 0, signal: null, stdout: "", stderr: "", timedOut: false, spawnError: null };
+    },
+  });
+
+  for (const argv of [
+    ["api-keys", "revoke", "k1"],
+    ["login"],
+    ["logout"],
+    ["ctx", "switch", "other"],
+  ]) {
+    const r = await call({ argv });
+    assert.equal(r.isError, true, `${argv.join(" ")} must be refused`);
+    assert.match(textOf(r), /Refused/, "the refusal must be legible to the model");
+  }
+  assert.equal(ran, 0, "a refused command must never reach the runner");
+  assert.equal(journal.length, 0, "a refused command must not be journalled as evidence");
+});
+
+test("a hard denial survives a flag value shifting the command words", async () => {
+  // The position-anchored version of this check let `--format json api-keys revoke`
+  // through, because a flag VALUE shifted the words. Contiguous-anywhere matching
+  // is what fixed it; this pins it at the tool boundary too.
+  const { call } = makeServer();
+  const r = await call({ argv: ["--format", "json", "api-keys", "revoke", "k1"] });
+  assert.equal(r.isError, true);
+});
+
+test("the schema's own safety annotations are consulted, not just the hard list", async () => {
+  // `safetyOf` had been accepted by assertSafeArgv and passed by nobody, so the 39
+  // read-only/write/destructive annotations gated nothing. Now that the model
+  // executes directly they are a live second line of defence.
+  // Receives the WORDS ARRAY, exactly as assertSafeArgv passes it — and that array
+  // still holds operands, so `docs delete d1` arrives as ["docs","delete","d1"].
+  // Mirror buildSafetyOf's longest-prefix resolution; a stub matching only the
+  // exact join would silently pass everything and prove nothing.
+  const table = new Map([["docs.delete", "destructive"], ["docs.list", "read-only"]]);
+  const safetyOf = (words) => {
+    for (let n = words.length; n >= 1; n--) {
+      const k = words.slice(0, n).join(".");
+      if (table.has(k)) return table.get(k);
+    }
+    return null;
+  };
+  const { call } = makeServer({ charter: { mutating: false }, safetyOf });
+  assert.equal((await call({ argv: ["docs", "delete", "d1"] })).isError, true, "destructive under a non-mutating charter");
+  assert.equal((await call({ argv: ["docs", "list"] })).isError, false, "read-only must still be allowed");
+});
+
+// --- the budget actually bounds the loop --------------------------------------
+
+test("maxProbes is enforced, and an exhausted session runs nothing more", async () => {
+  // charters.json declared maxProbes from the start and NOTHING enforced it. That
+  // was survivable while the model could not act; with a tool loop it is the only
+  // thing between a normal run and an unbounded one.
+  let ran = 0;
+  const budget = createProbeBudget({ maxProbes: 3 });
+  const { call } = makeServer({
+    budget,
+    runner: (argv) => {
+      ran++;
+      return { argv, exitCode: 0, signal: null, stdout: "", stderr: "", timedOut: false, spawnError: null };
+    },
+  });
+  for (let i = 0; i < 3; i++) assert.equal((await call({ argv: ["schema"] })).isError, false);
+  const over = await call({ argv: ["schema"] });
+  assert.equal(over.isError, true);
+  assert.match(textOf(over), /exhausted/i);
+  assert.equal(ran, 3, "the over-budget call must not reach the runner");
+  // And a refused call must not push the budget further, or an exhausted session
+  // could not even report the refusal consistently.
+  assert.equal(budget.used, 3);
+  assert.deepEqual(budget.refusals.map((r) => r.kind), ["maxProbes"]);
+});
+
+test("totalTimeoutMs is enforced independently of probe count", async () => {
+  // An injected clock, so a wall-clock bound is testable without waiting for it.
+  let now = 1_000;
+  const budget = createProbeBudget({ maxProbes: 100, totalTimeoutMs: 5_000, now: () => now });
+  const { call } = makeServer({ budget });
+  assert.equal((await call({ argv: ["schema"] })).isError, false);
+  now += 6_000;
+  const r = await call({ argv: ["schema"] });
+  assert.equal(r.isError, true);
+  assert.match(textOf(r), /time exhausted/i);
+  assert.deepEqual(budget.refusals.map((x) => x.kind), ["totalTimeoutMs"]);
+});
+
+// --- the clean room and the egress boundary -----------------------------------
+
+test("the ambient environment never reaches the CLI", async () => {
+  // `buildProbeEnv` REPLACES rather than extends. If it ever spread process.env,
+  // the clean room would be a claim rather than a property, and a probe could act
+  // on the developer's real documents.
+  const saved = process.env.WAFFLEBASE_API_KEY;
+  process.env.WAFFLEBASE_API_KEY = "leaked-ambient-key";
+  try {
+    let captured = null;
+    const { call } = makeServer({
+      runner: (argv, opts) => {
+        captured = opts.env;
+        return { argv, exitCode: 0, signal: null, stdout: "", stderr: "", timedOut: false, spawnError: null };
+      },
+    });
+    await call({ argv: ["status"] });
+    assert.equal(captured.WAFFLEBASE_API_KEY, undefined, "the ambient key must not survive");
+    assert.ok(captured.HOME && captured.HOME !== process.env.HOME, "HOME must point into the scratch");
+  } finally {
+    if (saved === undefined) delete process.env.WAFFLEBASE_API_KEY;
+    else process.env.WAFFLEBASE_API_KEY = saved;
+  }
+});
+
+test("secrets echoed by the CLI are redacted before the model ever sees them", async () => {
+  // A NEW egress boundary. Previously probe output was only redacted on the way
+  // into a report; now it flows into a model's context first, and that model's
+  // output reaches a public issue. Both stream shapes are covered.
+  const { call } = makeServer({
+    cfg: { apiKey: "wfb_LIVEKEYVALUE" },
+    runner: (argv) => ({
+      argv,
+      exitCode: 1,
+      signal: null,
+      stdout: "configured key: wfb_LIVEKEYVALUE",
+      stderr: "GET /x\nAuthorization: Bearer eyJhbGci.payload.sig",
+      timedOut: false,
+      spawnError: null,
+    }),
+  });
+  const t = textOf(await call({ argv: ["status"] }));
+  assert.equal(t.includes("wfb_LIVEKEYVALUE"), false, "the run's own key leaked to the model");
+  assert.equal(t.includes("eyJhbGci.payload.sig"), false, "a bearer token leaked to the model");
+});
+
+test("a fixture path escaping the scratch is refused", async () => {
+  // No injected runner: `runProbe` materializes fixtures only on the real path, so
+  // injecting one here would skip the very guard under test. `bin` never has to
+  // exist because the escape throws before any spawn.
+  const { call, scratch } = makeServer({ real: true });
+  try {
+    const r = await call({
+      argv: ["docs", "import", "x"],
+      files: [{ path: "../../escaped.txt", contentBase64: "aGk=" }],
+    });
+    assert.equal(r.isError, true);
+    assert.match(textOf(r), /escapes the scratch/);
+    assert.equal(existsSync(path.join(scratch.dir, "..", "..", "escaped.txt")), false);
+  } finally {
+    scratch.dispose();
+  }
+});
+
+test("state persists across calls within a session, so multi-step behaviour is reachable", async () => {
+  // Deliberately per-session scratch: writing a fixture then importing it is the
+  // whole point. Isolation comes from the replaced environment, not from throwing
+  // the directory away between calls.
+  // Again no injected runner, so fixtures are actually written. The spawn itself
+  // fails (bin does not exist) and `runProbe` records that rather than throwing,
+  // which is all this test needs.
+  const { call, scratch } = makeServer({ real: true });
+  try {
+    await call({ argv: ["docs", "import", "a.txt"], files: [{ path: "a.txt", contentBase64: "aGVsbG8=" }] });
+    assert.equal(readFileSync(path.join(scratch.dir, "a.txt"), "utf8"), "hello");
+    await call({ argv: ["docs", "list"] });
+    assert.equal(readFileSync(path.join(scratch.dir, "a.txt"), "utf8"), "hello", "state must survive the next call");
+  } finally {
+    scratch.dispose();
+  }
+});
+
+test("openSessionScratch disposes its directory", () => {
+  const s = openSessionScratch();
+  assert.ok(existsSync(s.dir));
+  s.dispose();
+  assert.equal(existsSync(s.dir), false);
+});
+
+// --- the journal is the evidence ---------------------------------------------
+
+test("every run is journalled with what actually ran", async () => {
+  const journal = [];
+  const { call } = makeServer({ journal });
+  await call({ argv: ["docs", "--help"], note: "map the surface" });
+  await call({ argv: ["schema"], stdin: "x" });
+  assert.equal(journal.length, 2);
+  assert.deepEqual(journal[0].argv, ["docs", "--help"]);
+  assert.equal(journal[0].note, "map the surface");
+  assert.equal(journal[1].stdin, "x");
+  assert.equal(journal[0].observed.exitCode, 0, "the observation rides with the command");
+});
+
+test("resolveProbeRefs rebuilds the pipeline's probe shape from cited indices", () => {
+  const journal = [
+    { argv: ["a"], observed: {} },
+    { argv: ["b"], note: "n", observed: {} },
+    { argv: ["c"], observed: {} },
+  ];
+  const got = resolveProbeRefs({ probeRefs: [0, 2], failingRef: 2 }, journal);
+  assert.deepEqual(got.probes, [{ argv: ["a"] }, { argv: ["c"] }]);
+  assert.equal(got.failingIndex, 1, "failingIndex is the position WITHIN the cited list");
+  // Order is preserved as cited, and a repeated run is kept rather than collapsed:
+  // running the same command twice is legitimate evidence (idempotency, or a second
+  // call behaving differently), and deduplicating would erase it.
+  const dup = resolveProbeRefs({ probeRefs: [1, 1], failingRef: 1 }, journal);
+  assert.deepEqual(dup.probes, [{ argv: ["b"], note: "n" }, { argv: ["b"], note: "n" }]);
+});
+
+test("resolveProbeRefs DROPS a candidate citing runs that never happened", () => {
+  // The honesty property. A model describing a reproduction it never performed is
+  // exactly what citing the journal exists to make impossible, and the fail-quiet
+  // response is to drop it — not to repair the reference or honour it partially.
+  const journal = [{ argv: ["a"], observed: {} }, { argv: ["b"], observed: {} }];
+  for (const bad of [
+    { probeRefs: [0, 5], failingRef: 0 }, // out of range
+    { probeRefs: [-1], failingRef: -1 }, // negative
+    { probeRefs: [], failingRef: 0 }, // no evidence at all
+    { probeRefs: [0], failingRef: 1 }, // failing probe not among those cited
+    { probeRefs: [0.5], failingRef: 0 }, // non-integer
+    { probeRefs: "0,1", failingRef: 0 }, // not an array
+    { probeRefs: [0] }, // no failingRef
+    {}, // nothing
+  ]) {
+    assert.equal(resolveProbeRefs(bad, journal), null, `must drop: ${JSON.stringify(bad)}`);
+  }
+  assert.equal(resolveProbeRefs({ probeRefs: [0], failingRef: 0 }, []), null, "empty journal cites nothing");
+});

--- a/scripts/agent/hunt-tool.test.mjs
+++ b/scripts/agent/hunt-tool.test.mjs
@@ -348,3 +348,94 @@ test("createProbeServer registers the `run` tool (skipped without the SDK)", asy
     scratch.dispose();
   }
 });
+
+// --- review follow-ups ---------------------------------------------------------
+
+test("a probe is clamped to the session time remaining, not its own timeout", async () => {
+  // `totalTimeoutMs` bounded when a probe may START and nothing bounded how long it
+  // then ran, so a probe admitted with 100ms of budget left still got its full
+  // per-probe timeout — the session could overrun by nearly 20s.
+  let now = 0;
+  // Session budget must EXCEED the per-probe cap, or the session is always the
+  // binding constraint and the test proves nothing about the cap.
+  const budget = createProbeBudget({ maxProbes: 10, totalTimeoutMs: 600_000, now: () => now });
+  const seen = [];
+  const call = createProbeTool({
+    charter: { mutating: false, probeBudget: { perProbeTimeoutMs: 20_000 } },
+    bin: "/x",
+    scratch: "/tmp",
+    budget,
+    journal: [],
+    runner: (argv, opts) => {
+      seen.push(opts.timeoutMs);
+      return { argv, exitCode: 0, signal: null, stdout: "", stderr: "", timedOut: false, spawnError: null };
+    },
+  });
+
+  await call({ argv: ["schema"] });
+  assert.equal(seen[0], 20_000, "with the whole session left, the per-probe cap applies");
+
+  now = 599_900; // 100ms of session budget remains
+  await call({ argv: ["schema"] });
+  assert.equal(seen[1], 100, "near the deadline the probe must be clamped to what is left");
+  assert.ok(seen[1] < 20_000);
+});
+
+test("the help exemption cannot override a resolved destructive annotation", async () => {
+  // `--help` matched anywhere in argv used to force "read-only", so
+  // `docs delete d1 --help` was waved through despite the schema declaring
+  // docs.delete destructive. The exemption may only RESCUE an unresolvable lookup.
+  const table = new Map([["docs.delete", "destructive"], ["docs.list", "read-only"]]);
+  const safetyOf = (words) => {
+    for (let n = words.length; n >= 1; n--) {
+      const k = words.slice(0, n).join(".");
+      if (table.has(k)) return table.get(k);
+    }
+    return null;
+  };
+  const { call } = makeServer({ charter: { mutating: false }, safetyOf });
+
+  assert.equal((await call({ argv: ["docs", "delete", "d1", "--help"] })).isError, true, "help must not launder a destructive command");
+  assert.equal((await call({ argv: ["docs", "delete", "d1", "-h"] })).isError, true, "short form too");
+  // …while the cases the exemption exists for still work: `docs` alone and `schema`
+  // are absent from the registry, so the lookup is unresolvable and would otherwise
+  // fail closed on the explorer's primary discovery tools.
+  assert.equal((await call({ argv: ["docs", "--help"] })).isError, false, "`docs --help` must stay allowed");
+  assert.equal((await call({ argv: ["schema"] })).isError, false, "`schema` must stay allowed");
+  assert.equal((await call({ argv: ["docs", "list"] })).isError, false, "resolved read-only still allowed");
+});
+
+test("a shapeless secret straddling the truncation boundary is still redacted", () => {
+  // Clipping ran BEFORE redaction, so a token cut in half left a head that no
+  // longer matched. The shape patterns (`wfb_…`, JWT, Bearer) catch a fragment
+  // anyway, so the exploitable case is a secret whose ONLY protection is the exact
+  // `extra` match in redactSecrets — `split(v).join(...)`, which a truncated value
+  // cannot satisfy. Hence a deliberately shapeless value here; a `wfb_`-prefixed
+  // one would pass whether or not the fix is present, and prove nothing.
+  const secret = "Zq7Z".repeat(10); // 40 chars, no recognisable shape
+  const { call } = makeServer({
+    cfg: { apiKey: secret },
+    runner: (argv) => ({
+      argv,
+      exitCode: 0,
+      signal: null,
+      // Straddles the 20k clip boundary: 10 chars before it, the rest after.
+      stdout: "x".repeat(20_000 - 10) + secret + "tail",
+      stderr: "",
+      timedOut: false,
+      spawnError: null,
+    }),
+  });
+  return call({ argv: ["status"] }).then((r) => {
+    const t = textOf(r);
+    assert.equal(t.includes(secret), false, "the whole secret leaked");
+    // Only the first 10 characters survive the 20k clip, so THAT is the fragment
+    // to assert on — checking a longer slice is vacuous, since it could not have
+    // been present either way.
+    assert.equal(
+      t.includes(secret.slice(0, 10)),
+      false,
+      "a secret FRAGMENT survived: the clip cut it before redaction could match it",
+    );
+  });
+});

--- a/scripts/agent/hunt-tool.test.mjs
+++ b/scripts/agent/hunt-tool.test.mjs
@@ -5,7 +5,11 @@
 // that passes either way is worse than none, because it certifies nothing while
 // looking like it does.
 //
-// No CLI and no network: `runner` is injected, exactly as hunt-probe.test.mjs does.
+// No CLI, no network, and NO SDK: these exercise `createProbeTool`, the handler
+// factory, which has no third-party imports. That is deliberate — the `agent:tests`
+// lane runs with `scripts/agent/node_modules` absent, so a test that reached through
+// the real MCP server object would fail in CI with ERR_MODULE_NOT_FOUND. The server
+// wrapper is covered by one self-skipping smoke test at the bottom.
 // The exception is the two tests about file handling, which pass `real: true` —
 // `runProbe` returns before materializing fixtures when a runner is present, so
 // injecting one there would skip the very guard under test.
@@ -16,18 +20,11 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import {
   createProbeBudget,
-  createProbeServer,
+  createProbeTool,
   openSessionScratch,
   resolveProbeRefs,
   PROBE_TOOL_NAME,
 } from "./hunt-tool.mjs";
-
-/** Reach the tool's handler the way the SDK will call it. */
-function handlerOf(server) {
-  const t = server.instance._registeredTools.run;
-  assert.ok(typeof t?.handler === "function", "the `run` tool must be registered");
-  return (args) => t.handler(args, {});
-}
 
 // `real: true` uses the genuine runProbe path instead of an injected runner.
 // runProbe returns EARLY when a runner is present, before materializing fixtures,
@@ -35,7 +32,7 @@ function handlerOf(server) {
 // runProbe records a spawn failure rather than throwing.
 function makeServer({ charter = { mutating: false }, cfg = {}, budget, journal = [], safetyOf = null, runner, real = false } = {}) {
   const scratch = openSessionScratch();
-  const server = createProbeServer({
+  const call = createProbeTool({
     charter,
     bin: "/nonexistent/bin.js",
     cfg,
@@ -48,7 +45,7 @@ function makeServer({ charter = { mutating: false }, cfg = {}, budget, journal =
       : (runner ??
         ((argv) => ({ argv, exitCode: 0, signal: null, stdout: "ok", stderr: "", timedOut: false, spawnError: null }))),
   });
-  return { call: handlerOf(server), journal, scratch };
+  return { call, journal, scratch };
 }
 
 const textOf = (r) => r.content.map((c) => c.text).join("\n");
@@ -311,4 +308,43 @@ test("resolveProbeRefs DROPS a candidate citing runs that never happened", () =>
     assert.equal(resolveProbeRefs(bad, journal), null, `must drop: ${JSON.stringify(bad)}`);
   }
   assert.equal(resolveProbeRefs({ probeRefs: [0], failingRef: 0 }, []), null, "empty journal cites nothing");
+});
+
+
+// --- the SDK wrapper -----------------------------------------------------------
+
+test("createProbeServer registers the `run` tool (skipped without the SDK)", async (t) => {
+  // The one thing `createProbeTool` cannot cover: that the tool is actually wired
+  // into an MCP server under the exact name ask.mjs pre-approves. It needs the SDK,
+  // which the agent:tests lane deliberately runs without — so it SKIPS there rather
+  // than failing, and still runs locally where the dependency exists.
+  let mod;
+  try {
+    mod = await import("@anthropic-ai/claude-agent-sdk");
+  } catch {
+    t.skip("Agent SDK not installed (expected in the agent:tests lane)");
+    return;
+  }
+  assert.ok(mod, "sdk import should have produced a namespace");
+
+  const { createProbeServer } = await import("./hunt-tool.mjs");
+  const scratch = openSessionScratch();
+  try {
+    const server = await createProbeServer({
+      charter: { mutating: false },
+      bin: "/nonexistent/bin.js",
+      scratch: scratch.dir,
+      budget: createProbeBudget({ maxProbes: 1 }),
+      journal: [],
+      runner: (argv) => ({ argv, exitCode: 0, signal: null, stdout: "", stderr: "", timedOut: false, spawnError: null }),
+    });
+    assert.equal(server.name, "wafflebase");
+    const registered = Object.keys(server.instance._registeredTools ?? {});
+    assert.deepEqual(registered, ["run"]);
+    // The registered name must compose to exactly what ask.mjs permits, or the
+    // session grants a tool that does not exist.
+    assert.equal(`mcp__${server.name}__${registered[0]}`, PROBE_TOOL_NAME);
+  } finally {
+    scratch.dispose();
+  }
 });

--- a/scripts/agent/hunt.mjs
+++ b/scripts/agent/hunt.mjs
@@ -54,6 +54,13 @@ import {
 } from "./hunt-fingerprint.mjs";
 import { renderDeferrals, loadScopedDocs, renderIssues, fetchIssues } from "./hunt-corpus.mjs";
 import {
+  createProbeBudget,
+  createProbeServer,
+  openSessionScratch,
+  resolveProbeRefs,
+  PROBE_TOOL_NAME,
+} from "./hunt-tool.mjs";
+import {
   buildProbeEnv,
   resolveCliBin,
   assertSafeArgv,
@@ -67,10 +74,19 @@ import {
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
-// The read-only grant. ask.mjs validates this against its own allow-list and
-// refuses anything else, so the hunter cannot hold a shell — probes run in
-// hunt-probe.mjs instead, from argv the model returned as data.
+// The read grant. `ask.mjs` validates this against its own allow-list and refuses
+// anything else, so the hunter still cannot hold a shell.
 const HUNT_TOOLS = ["Read", "Grep", "Glob"];
+
+// The EXPLORER's grant: the same reads, plus the one in-process tool that runs the
+// CLI in a replaced environment behind `assertSafeArgv` and a probe budget
+// (`hunt-tool.mjs`). This is what makes exploration empirical rather than
+// predictive — the hunter observes real behaviour instead of guessing at it from
+// the source, which is the only way it can be surprised by something nobody wrote
+// down. Verifiers deliberately keep the read-only grant: their job is to check a
+// claim against the code, and handing them execution would let a verifier
+// "confirm" a finding by producing new evidence of its own.
+const EXPLORER_TOOLS = [...HUNT_TOOLS, PROBE_TOOL_NAME];
 
 // --- charters ---------------------------------------------------------------
 
@@ -109,8 +125,72 @@ export function validateCharter(c) {
 
 // --- exploration ------------------------------------------------------------
 
-async function explore(charter, { repo, context, sessionLog }) {
+/**
+ * Build a `safetyOf` lookup from the CLI's own `schema` output.
+ *
+ * `assertSafeArgv` has always accepted this and nothing ever passed it, so the 39
+ * `read-only`/`write`/`destructive` annotations gated nothing. That was tolerable
+ * while the model only proposed argv for later execution; now that it executes
+ * directly, the annotations become a live second line of defence behind the hard
+ * denials.
+ *
+ * Note the annotations are hand-maintained and their WRONGNESS is itself one of
+ * the things this hunter looks for (`docs export` is marked `read-only` while
+ * writing a file). So this is defence in depth, never the primary gate: returning
+ * `null` on any failure degrades to the hard-denial list rather than opening up.
+ */
+function buildSafetyOf(bin, cfg) {
+  try {
+    const out = withScratch((dir) =>
+      runProbe(
+        { argv: ["schema", "--format", "json"] },
+        { bin, env: buildProbeEnv(dir, cfg), cwd: dir, timeoutMs: 10_000 },
+      ),
+    );
+    if (out.exitCode !== 0) return null;
+    const parsed = JSON.parse(out.stdout);
+    const list = Array.isArray(parsed) ? parsed : (parsed.commands ?? []);
+    const table = new Map();
+    for (const c of Array.isArray(list) ? list : Object.values(list)) {
+      const name = c?.name ?? c?.command;
+      if (typeof name === "string" && typeof c?.safety === "string") table.set(name, c.safety);
+    }
+    if (table.size === 0) return null;
+    // `assertSafeArgv` calls this with the WORDS ARRAY (flags stripped), not a
+    // dotted name — and that array still contains flag VALUES, so
+    // `docs list --format json` arrives as ["docs","list","json"]. Match the
+    // LONGEST prefix that names a real command, or the annotation would never
+    // resolve and every command would fail closed.
+    return (words) => {
+      const w = Array.isArray(words) ? words : [String(words)];
+      for (let n = w.length; n >= 1; n--) {
+        const key = w.slice(0, n).join(".");
+        if (table.has(key)) return table.get(key);
+      }
+      return null;
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One exploration session: the model drives the CLI and reports what it found.
+ *
+ * The session owns a scratch directory and a probe budget for its whole lifetime.
+ * Scratch is per SESSION, not per probe, so a multi-step behaviour is reachable —
+ * write a fixture, import it, export it back. Isolation does not come from
+ * discarding the directory but from `buildProbeEnv` replacing the environment, so
+ * accumulated state can never address the developer's real workspace.
+ *
+ * `probes` are NOT taken from the model. It cites journal indices, and trusted
+ * code resolves them, so a reported reproduction is necessarily one this process
+ * actually ran.
+ */
+async function explore(charter, { repo, context, sessionLog, bin, safetyOf }) {
   const { askStructured, withRetry } = await import("./ask.mjs");
+  const budgetCfg = charter.probeBudget ?? {};
+
   const prompt = [
     charter.rubric,
     "",
@@ -124,26 +204,68 @@ async function explore(charter, { repo, context, sessionLog }) {
     context.issues || "(none supplied)",
     "```",
     "",
+    `You have at most ${budgetCfg.maxProbes ?? 40} CLI runs this session.`,
+    "Spend them: run commands, read the real output, and let what you see decide",
+    "what to try next. A hypothesis you have not executed is not a finding.",
+    "",
     `Return at most ${charter.maxCandidates ?? 8} candidates. Returning zero is a`,
-    "valid and often correct result. Every candidate needs a probe plan whose",
-    "`failingIndex` probe demonstrates the defect, and citations that locate a line.",
+    "valid and often correct result. Every candidate must cite `probeRefs`: the",
+    "0-based indices of the runs that demonstrate it, in order, with `failingRef`",
+    "naming the one that shows the defect. Indices refer to your own runs this",
+    "session, counted from 0. Also cite `citations` that locate a line in the code.",
   ].join("\n");
-  // Retry genuinely-transient API errors, exactly as review-panel.mjs does for its
-  // lens samples. classifyResult marks a quota/session-limit non-retryable so it
-  // fails through immediately rather than burning attempts on a limit that cannot
-  // clear in-run.
-  return withRetry(() => askStructured({
-    systemPrompt:
-      `You are the ${charter.title} hunter. Stay strictly in your lane. You propose probes ` +
-      `as argv arrays for a trusted runner to execute; you never run commands yourself.`,
-    prompt,
-    model: charter.model,
-    repo,
-    schema: EXPLORER_SCHEMA,
-    sessionLog,
-    allowedTools: HUNT_TOOLS,
-    label: "hunt",
-  }));
+
+  // Each ATTEMPT gets its OWN journal, budget and scratch.
+  //
+  // `withRetry` re-invokes this closure on a transient API error, and sharing that
+  // state across attempts would be a correctness bug rather than mere waste: the
+  // model in a second attempt counts its runs from 0, so `probeRefs: [0]` would
+  // resolve to the ABANDONED attempt's first command and the candidate would ship
+  // a reproduction of something else. The honesty property depends on the journal
+  // describing exactly one session, so it is rebuilt per attempt.
+  let live = null;
+  try {
+    const out = await withRetry(() => {
+      live?.scratch.dispose(); // close the previous attempt's room first
+      const journal = [];
+      const budget = createProbeBudget({
+        maxProbes: budgetCfg.maxProbes ?? 40,
+        totalTimeoutMs: budgetCfg.totalTimeoutMs ?? 600_000,
+      });
+      const scratch = openSessionScratch();
+      live = { journal, budget, scratch };
+      return askStructured({
+        systemPrompt:
+          `You are the ${charter.title} hunter. Stay strictly in your lane. Use the ` +
+          `wafflebase run tool to execute CLI commands and observe what actually ` +
+          `happens; report only what you have demonstrated.`,
+        prompt,
+        model: charter.model,
+        repo,
+        schema: EXPLORER_SCHEMA,
+        sessionLog,
+        maxTurns: Number.isFinite(charter.explorerMaxTurns) ? charter.explorerMaxTurns : 40,
+        allowedTools: EXPLORER_TOOLS,
+        mcpServers: {
+          wafflebase: createProbeServer({
+            charter,
+            bin,
+            cfg: context.cfg,
+            scratch: scratch.dir,
+            budget,
+            journal,
+            safetyOf,
+          }),
+        },
+        label: "hunt",
+      });
+    });
+    return { out, journal: live.journal, probeCount: live.budget.used, refusals: live.budget.refusals };
+  } finally {
+    // Always disposed, including when every attempt threw — a scratch dir per
+    // sample would otherwise accumulate across a multi-charter run.
+    live?.scratch.dispose();
+  }
 }
 
 // --- verification -----------------------------------------------------------
@@ -504,16 +626,37 @@ async function cmdRun(args) {
   }
 
   const context = loadContext(repo, args, charters);
+  // Built once per run: one CLI invocation, shared by every session. Degrades to
+  // `null` (hard denials only) rather than failing the run — the annotations are
+  // defence in depth, and their wrongness is itself something this hunter reports.
+  const safetyOf = buildSafetyOf(bin, context.cfg);
+  if (!safetyOf) {
+    console.error("hunt: could not read `schema --format json`; falling back to hard denials only");
+  }
   const sessionLog = [];
   const reported = [];
   const dropped = [];
-  // Funnel order matches the pipeline order below. `soloReproduced` is not a
-  // stage — it is the MEASUREMENT: candidates only one sample proposed that a
-  // trusted replay nevertheless reproduced deterministically. If it stays high
-  // across runs, cross-sample agreement is discarding genuine defects and the
+  // `probesRun` and `probeRefusals` make the empirical loop visible: a session
+  // that ran two commands and reported nothing is a very different failure from
+  // one that ran forty, and before this the funnel could not tell them apart.
+  //
+  // The rest of the funnel order matches the pipeline order below. `soloReproduced`
+  // is not a stage — it is the MEASUREMENT: candidates only one sample proposed
+  // that a trusted replay nevertheless reproduced deterministically. If it stays
+  // high across runs, cross-sample agreement is discarding genuine defects and the
   // threshold needs revisiting; if it stays at zero, agreement is doing replay's
   // job for free and belongs where it is.
-  const stats = { proposed: 0, unique: 0, novel: 0, reproduced: 0, corroborated: 0, soloReproduced: 0, reported: 0 };
+  const stats = {
+    probesRun: 0,
+    probeRefusals: 0,
+    proposed: 0,
+    unique: 0,
+    novel: 0,
+    reproduced: 0,
+    corroborated: 0,
+    soloReproduced: 0,
+    reported: 0,
+  };
   const ledgerAdds = [];
 
   // Charters run SERIALLY, unlike samples and verifiers below. This is a budget
@@ -549,7 +692,7 @@ async function cmdRun(args) {
     const sampleResults = await Promise.all(
       Array.from({ length: sampleCount }, async (_unused, i) => {
         try {
-          return await explore(charter, { repo, context, sessionLog });
+          return await explore(charter, { repo, context, sessionLog, bin, safetyOf });
         } catch (err) {
           console.error(`hunt: ${charter.id} sample ${i} failed: ${err.message}`);
           return null;
@@ -557,10 +700,35 @@ async function cmdRun(args) {
       }),
     );
     const samples = [];
-    for (const out of sampleResults) {
-      if (!out) continue;
-      const { kept, dropped: bad } = coerceCandidates(out.candidates);
-      stats.proposed += Array.isArray(out.candidates) ? out.candidates.length : 0;
+    for (const sample of sampleResults) {
+      if (!sample) continue;
+      const { out, journal, probeCount, refusals } = sample;
+      stats.probesRun += probeCount;
+      stats.probeRefusals += refusals.length;
+
+      // Resolve each candidate's journal REFERENCES into the `probes` shape the
+      // rest of the pipeline speaks, BEFORE coercion — `coerceCandidates` requires
+      // a non-empty `probes` and would otherwise reject every candidate.
+      //
+      // A candidate citing a run that does not exist is DROPPED, not repaired. It
+      // is the signature of a model describing a reproduction it never performed,
+      // which is precisely what citing the journal exists to make impossible.
+      const raw = Array.isArray(out.candidates) ? out.candidates : [];
+      stats.proposed += raw.length;
+      const resolved = [];
+      for (const c of raw) {
+        const refs = resolveProbeRefs(c, journal);
+        if (!refs) {
+          dropped.push({
+            title: c?.title,
+            why: `cited runs that did not happen (probeRefs ${JSON.stringify(c?.probeRefs)}, failingRef ${JSON.stringify(c?.failingRef)}, journal has ${journal.length})`,
+          });
+          continue;
+        }
+        resolved.push({ ...c, ...refs });
+      }
+
+      const { kept, dropped: bad } = coerceCandidates(resolved);
       for (const b of bad) dropped.push({ title: b.candidate?.title, why: `malformed: ${b.why}` });
       samples.push(kept);
     }
@@ -573,7 +741,17 @@ async function cmdRun(args) {
     mkdirSync(charterDir, { recursive: true });
     writeFileSync(
       path.join(charterDir, "explore-raw.json"),
-      redactSecrets(JSON.stringify(sampleResults, null, 2), { extra: [context.cfg.apiKey].filter(Boolean) }) + "\n",
+      redactSecrets(
+        JSON.stringify(
+          // The journal rides along: for a run that reports nothing, WHAT THE MODEL
+          // RAN is the only thing that explains why, and it is not recoverable from
+          // the candidates it chose not to return.
+          sampleResults.map((r) => (r ? { summary: r.out?.summary, candidates: r.out?.candidates, journal: r.journal, probeCount: r.probeCount, refusals: r.refusals } : null)),
+          null,
+          2,
+        ),
+        { extra: [context.cfg.apiKey].filter(Boolean) },
+      ) + "\n",
     );
 
     // Agreement is COMPUTED here but APPLIED after replay.

--- a/scripts/agent/hunt.mjs
+++ b/scripts/agent/hunt.mjs
@@ -225,7 +225,7 @@ async function explore(charter, { repo, context, sessionLog, bin, safetyOf }) {
   // describing exactly one session, so it is rebuilt per attempt.
   let live = null;
   try {
-    const out = await withRetry(() => {
+    const out = await withRetry(async () => {
       live?.scratch.dispose(); // close the previous attempt's room first
       const journal = [];
       const budget = createProbeBudget({
@@ -247,7 +247,7 @@ async function explore(charter, { repo, context, sessionLog, bin, safetyOf }) {
         maxTurns: Number.isFinite(charter.explorerMaxTurns) ? charter.explorerMaxTurns : 40,
         allowedTools: EXPLORER_TOOLS,
         mcpServers: {
-          wafflebase: createProbeServer({
+          wafflebase: await createProbeServer({
             charter,
             bin,
             cfg: context.cfg,

--- a/scripts/agent/hunt.test.mjs
+++ b/scripts/agent/hunt.test.mjs
@@ -76,10 +76,21 @@ test("charter scopes actually match the files they are meant to cover", () => {
     true,
     "the real ground-truth citation pair must pass the shipped scopes",
   );
+  // The engine packages ARE in scope on purpose: the CLI is a thin client, so a
+  // defect it surfaces often lives in docs/sheets/slides/backend rather than in
+  // `packages/cli`. Scoping citations to the CLI would have forced the hunter to
+  // blame the driver for a bug in the engine.
   assert.equal(
     isFilingVerdict(cand(["packages/sheets/src/formula/formula.ts:1", "docs/design/cli.md:691"], "docs/design/cli.md:691"), ok, contract),
+    true,
+    "an engine-package citation is in scope — the CLI drives these packages",
+  );
+  // But scope is still a scope: the frontend is unreachable from a CLI, so a
+  // citation there cannot be evidence for anything this hunter observed.
+  assert.equal(
+    isFilingVerdict(cand(["packages/frontend/src/App.tsx:1", "docs/design/cli.md:691"], "docs/design/cli.md:691"), ok, contract),
     false,
-    "a citation outside packages/cli/src must not satisfy codeScope",
+    "a citation outside every scoped package must not satisfy codeScope",
   );
 });
 
@@ -101,20 +112,29 @@ test("every charter has a rubric that states the inversion and forbids minor/nit
   }
 });
 
-test("every charter rubric states the argv contract and forbids a shell string", () => {
-  // The anti-injection design rests on the model only ever emitting argv, and the
-  // rubric is where it learns that. Asserting the ABSENCE of the word "shell"
-  // cannot work — the rubrics legitimately contain "never a shell string" — so
-  // assert the prohibition is PRESENT instead. Also pin that the rubric tells the
-  // model it does not run commands, since a rubric implying otherwise would have
-  // it emit commands the runner then refuses, wasting every probe.
+test("every charter rubric states the argv contract and the empirical loop", () => {
+  // The anti-injection design rests on commands only ever being argv ARRAYS, and
+  // the rubric is where the model learns that. Asserting the ABSENCE of the word
+  // "shell" cannot work — the rubrics legitimately say "never a shell string" — so
+  // assert the prohibition is PRESENT instead.
+  //
+  // The second half of this test INVERTED with the executing explorer. It used to
+  // require the rubric say the model does not run commands; a rubric that still
+  // said so would now be a lie that wastes the whole session, because the model
+  // would sit predicting instead of probing. So it must say the opposite, and must
+  // also warn about refusals and the finite budget — a model surprised by either
+  // burns runs rediscovering them.
   for (const c of CHARTERS) {
     assert.match(c.rubric, /argv/i, `${c.id} must describe the argv contract`);
-    // `\s+` throughout: these rubrics are hard-wrapped markdown, so any phrase
-    // can straddle a newline. A literal-space regex silently depends on where the
+    // `\s+` throughout: these rubrics are hard-wrapped markdown, so any phrase can
+    // straddle a newline. A literal-space regex silently depends on where the
     // author happened to wrap.
     assert.match(c.rubric, /never a\s+shell\s+string/i, `${c.id} must forbid a shell string outright`);
-    assert.match(c.rubric, /do \*\*not\*\*\s+run\s+commands/i, `${c.id} must say the model does not execute`);
+    assert.match(c.rubric, /You \*\*run\s+the\s+CLI\*\*/i, `${c.id} must tell the model it executes`);
+    assert.match(c.rubric, /probeRefs/, `${c.id} must explain citing runs by index`);
+    assert.match(c.rubric, /refus/i, `${c.id} must warn that some commands are refused`);
+    assert.match(c.rubric, /budget/i, `${c.id} must warn the run budget is finite`);
+    assert.doesNotMatch(c.rubric, /do \*\*not\*\*\s+run\s+commands/i, `${c.id} must not claim it cannot execute`);
   }
 });
 

--- a/scripts/agent/package-lock.json
+++ b/scripts/agent/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@wafflebase/agent-scripts",
       "version": "0.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.217"
+        "@anthropic-ai/claude-agent-sdk": "0.3.217",
+        "zod": "4.4.3"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -1466,7 +1467,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/agent/package.json
+++ b/scripts/agent/package.json
@@ -8,6 +8,7 @@
     "test": "node --test *.test.mjs"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.217"
+    "@anthropic-ai/claude-agent-sdk": "0.3.217",
+    "zod": "4.4.3"
   }
 }


### PR DESCRIPTION
## Summary

The issue hunter added in #588 **could not run anything.** Its grant was `Read`/`Grep`/`Glob` and its system prompt said *"you never run commands yourself"* — so it read the source, **predicted** a contradiction, and a trusted runner tested the prediction afterwards.

That removed the only reason to point it at a CLI. A CLI's unique value is being an *executable* interface; a reader that cannot execute could have been aimed at any package in the repo, and it could never be **surprised** — which is the entire product. As a static reader, scoping it to `packages/cli/src/**` was arbitrary too.

Exploration is now empirical. It runs through **one** in-process MCP tool (`scripts/agent/hunt-tool.mjs`) whose entire reachable surface is `node <cli-bin> <argv…>`.

## What is and is not being relaxed

The propose/execute split is **not** the mistake and is **not** abandoned:

| | verdict |
|---|---|
| For **reporting** | Correct — exact replay, shell injection structurally impossible. **Kept.** |
| For **exploration** | Wrong — blindness is the problem. **Replaced.** |

This is **not** `Bash`. The tool can only reach the CLI binary:

- `argv` is a string **array**; `spawnSync` with no `shell`, so `;`, `$(…)`, pipes and globs are inert. Pinned by a test passing `["docs","list","; rm -rf /","$(id)","`whoami`","a\nb","'quoted'","*"]` and asserting every element survives verbatim.
- `assertSafeArgv` hard-denies credential/login/context commands, **and now consults the CLI's own `schema` safety annotations** — `safetyOf` had been accepted by `assertSafeArgv` and passed by nobody, so 39 `read-only`/`write`/`destructive` annotations gated nothing.
- `buildProbeEnv` **replaces** the environment, so the developer's real session, config and workspace are unreachable — a property of the process, not a promise.
- Refusals are **returned as readable text, not thrown**. A thrown error aborts the call and teaches the model nothing; a refusal it can read lets it adapt instead of stalling.

## Evidence is cited, not authored

Every tool call is journalled. A candidate names `probeRefs`/`failingRef` — **indices into that journal** — so a model **cannot describe a reproduction it never performed**. `resolveProbeRefs` converts them back into the `probes`/`failingIndex` shape the gate, replay and report already speak (so nothing downstream changed) and **drops** any candidate whose references don't resolve.

The repro is now a transcript rather than a claim. That is strictly *more* trustworthy than before, not less.

## Three latent gaps closed

1. **`probeBudget.maxProbes` and `totalTimeoutMs` were declared in `charters.json` from the start and nothing ever enforced them** — only `perProbeTimeoutMs` was read.
2. **Exploration had no `maxTurns` at all**; only verifiers were capped.
3. **`safetyOf` was never passed** (above).

All three were harmless while the model couldn't act. With a tool loop they are the difference between a bounded run and an unbounded one.

## Reviewer's guide — two subtleties I'd want checked

**Help requests and `schema` are exempt from the annotation lookup.** `docs --help` reduces to the single word `docs`; the registry only names leaves (`docs.list`, `docs.export`, …); and an unresolvable lookup **fails closed**. Without the exemption the gate would refuse `--help`, the explorer's primary discovery tool, and the session would be spent on refusals. Commander prints help and exits without running any command, so a help request cannot mutate — but this is the judgement call most worth a second opinion. Hard denials are checked *before* `safetyOf`, so `api-keys revoke --help` stays denied.

**Each retry attempt gets a fresh journal, budget and scratch.** I had this wrong first: `withRetry` re-invokes the session, and a model in a second attempt counts its runs from 0 — so a shared journal would resolve `probeRefs: [0]` to the **abandoned** attempt's first command and ship a reproduction of something else.

Also worth a look: scratch is per **session**, not per call, so the model can write a fixture and then import it. Isolation comes from the replaced environment, not from discarding state.

## Linked Issues

Fixes #

No issue — follow-up to #588, redirecting a working pipeline.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [x] `verify:self` — 11/11 lanes green; pushed **with the `pre-push` hook enabled**
- [x] `agent:tests` — **372 pass** (357 before, +15 for `hunt-tool.mjs`)
- [x] **Every safety test mutation-tested.** Removing the budget check fails 2 tests, the safety check 3, redaction 1, the journal push 1. Two of my tests on #592 passed with their own fix reverted, so a test that certifies nothing while looking like it does is the specific failure mode guarded against here.
- [x] `zod` pinned explicitly and the lockfile regenerated — it resolved only as an SDK transitive dep, and this package installs with `npm ci`
- [ ] **No live run yet.** The pipeline is exercised only by unit tests; the first real run is the acceptance test.

## Risk Assessment

- **This is the largest capability increase in the harness so far**: a model-driven loop that executes a real binary. Mitigations above; the residual risk is that `assertSafeArgv`'s hard-deny list is incomplete, which is why the schema annotations are now wired as a second layer. **Please try to break it.**
- **Egress:** probe output now flows into a model's context *before* reaching a report, and that model's output can reach a public issue. Redaction happens at the tool boundary, covered by a test asserting both the run's own API key and a `Bearer` token are stripped.
- **Cost:** tool loops add turns. Expect **~$8–12/run** against the static $6.17. `maxProbes: 40`, `explorerMaxTurns: 40`, `totalTimeoutMs: 600s`.
- **User-facing risk:** none. Nothing ships; no package imports `scripts/agent/`.
- **Rollback:** revert. Self-contained to `scripts/agent/` plus one design-doc section.

## Notes for Reviewers

- **AI assistance:** design and implementation with Claude Code (Opus 5).

- **This PR exists because a reviewer pushed back on my design, and they were right.** I had built a static doc-vs-code comparator and described it as a CLI explorer. The critique — *if it only reads code, why the CLI, and why not the whole repo?* — was correct in both directions, and the plan was rewritten rather than defended.

- **`codeScope` widens to the engine packages.** The CLI is a thin client, so a defect it surfaces often lives in `packages/docs`, `packages/sheets`, `packages/slides` or `packages/backend`. Scoping citations to `packages/cli` forced the hunter to blame the driver for a bug in the engine. `packages/frontend` stays out — unreachable from a CLI — and a test pins that.

- **Two new grounds, and one deliberately absent.** `self-inconsistent` and `schema-annotation-false` are both checkable from a transcript. *"This surprised me"* is **not** a ground, and never will be — it is the slop generator that ended curl's bug bounty.

- **Follow-up:** backend-bound commands (create/import/export/delete, i.e. actually exercising docs/sheets/slides) need Phase C and the `WAFFLEBASE_HUNT_WORKSPACE` safety rail, which must refuse to run against the developer's real workspace. This PR reaches `--help`, `schema`, argument validation and `--dry-run` paths.

- **#599 conflicts trivially with this** (both touch `hunt.mjs`); whichever lands second, I'll rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safe, in-process CLI exploration with isolated workspaces, command validation, execution budgets, output redaction, and persistent session state.
  * Added evidence journaling so findings reference reproducible probe results.
  * Added support for approved tool integrations in agent sessions.
  * Expanded contract and crash analysis across documentation, spreadsheets, presentations, backend, and CLI sources.
  * Added verification grounds for inconsistent observations and inaccurate safety declarations.

* **Bug Fixes**
  * Invalid or unsupported probe references are now rejected.
  * Restricted commands receive readable refusals without interrupting exploration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->