### PR TITLE
Cluster restatements before the verifier, not after

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -487,12 +487,15 @@ Components:
   `verifier.absenceRaised`/`absenceRefuted`/`unresolved`, so a high `unresolved`
   against a low `absenceRefuted` is visible as absence claims riding through
   unchecked rather than being silently discounted.
-  A **clustering** pass (`clusterFindings`) then collapses RESTATEMENTS of one
-  defect. `dedupeFindings` only catches byte-identical summaries, so #578 reported
-  the same defect three times over — two wordings of one missing file, the
-  deny-list bug as both a `critical` and a `major`, the deny-list-shape concern
-  twice — and the verifier could not help, since it judges one finding at a time
-  in isolation and bills for each copy. The similarity metric is **not** re-derived:
+  A **clustering** pass (`clusterFindings`) collapses RESTATEMENTS of one defect
+  **before the verifier runs**, so each distinct defect is verified once rather
+  than once per wording. `dedupeFindings` only catches byte-identical summaries, so
+  #578 reported the same defect three times over — two wordings of one missing
+  file, the deny-list bug as both a `critical` and a `major`, the deny-list-shape
+  concern twice — and the verifier could not help, since it judges one finding at a
+  time in isolation and re-runs a full session (and `git blame`) for each copy:
+  the #578 shape would have paid for four redundant verifier sessions. Collapsing
+  first removes that waste. The similarity metric is **not** re-derived:
   `findingSimilarity` in `scripts/agent/rounds.mjs` already owns it for the
   non-convergence detector, calibrated against real panel output with the overlap
   coefficient chosen over Jaccard for exactly this restatement pattern. It
@@ -505,6 +508,17 @@ Components:
   The only thing removed is count inflation, reported as `clusters.collapsed`. The
   stated limitation: two wordings sharing no vocabulary score 0 and stay separate,
   which leaves the count inflated — the status quo, and the conservative direction.
+  Running clustering *before* the verifier (it began *after* it, in #591) has one
+  tradeoff, stated rather than hidden: the merge now decides what the verifier
+  sees, so a wrong merge means a folded wording is judged only through its
+  representative. Two things bound it — the threshold is conservative (the #578
+  distinct pairs scored 0.000, so they stay separate) and `mergeCluster` elects the
+  strongest wording as representative (gating, then highest severity, then
+  evidence-bearing), so the verifier judges the form most likely to gate and every
+  folded wording is still rendered, making a bad merge visible rather than silent.
+  A finding can now be clustered twice (fresh pass pre-verify, then again when a
+  fresh survivor restates a carried-forward prior finding), so `mergeCluster`
+  flattens the wordings each pass folded rather than overwriting them.
   A **novelty gate** (`scripts/agent/novelty.mjs`) then answers a question the
   verifier structurally cannot: *did this change PUT this line here, carrying
   code that already existed?* The verifier's independence means it never sees the

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -508,14 +508,19 @@ Components:
   The only thing removed is count inflation, reported as `clusters.collapsed`. The
   stated limitation: two wordings sharing no vocabulary score 0 and stay separate,
   which leaves the count inflated — the status quo, and the conservative direction.
-  Running clustering *before* the verifier (it began *after* it, in #591) has one
-  tradeoff, stated rather than hidden: the merge now decides what the verifier
-  sees, so a wrong merge means a folded wording is judged only through its
-  representative. Two things bound it — the threshold is conservative (the #578
-  distinct pairs scored 0.000, so they stay separate) and `mergeCluster` elects the
-  strongest wording as representative (gating, then highest severity, then
-  evidence-bearing), so the verifier judges the form most likely to gate and every
-  folded wording is still rendered, making a bad merge visible rather than silent.
+  Running clustering *before* the verifier (it began *after* it, in #591) means
+  the merge now decides what the verifier sees, so a wrong merge could let a
+  representative's refutation drop a genuinely distinct wording that merged in and
+  was never checked on its own. `resolveClusterVerdict` closes that: a
+  representative refutation is honoured only when every folded BLOCKING wording is
+  ALSO confidently refuted — otherwise the cluster is kept, carrying the surviving
+  verdict. That re-verification runs only on the rare dropping verdict of a
+  multi-member cluster, so the common confirmed path still pays for exactly one
+  verifier session per cluster. Two further bounds: the threshold is conservative
+  (the #578 distinct pairs scored 0.000, so they stay separate) and `mergeCluster`
+  elects the strongest wording as representative (gating, then highest severity,
+  then evidence-bearing), so the verifier judges the form most likely to gate and
+  every folded wording is still rendered.
   A finding can now be clustered twice (fresh pass pre-verify, then again when a
   fresh survivor restates a carried-forward prior finding), so `mergeCluster`
   flattens the wordings each pass folded rather than overwriting them.

--- a/docs/tasks/active/20260730-verify-after-clustering-lessons.md
+++ b/docs/tasks/active/20260730-verify-after-clustering-lessons.md
@@ -1,0 +1,23 @@
+# Lessons: verify after clustering
+
+- [x] **Reordering the two clustering passes needed `mergeCluster` to flatten,
+      not overwrite.** Once fresh findings are clustered before verification, the
+      surviving representative already carries `mergedFrom`; the later fresh-vs-prior
+      merge would re-run `mergeCluster` and clobber it with only the new fold.
+      Making `mergeCluster` accumulate each member's own `mergedFrom` makes the
+      operation composable and idempotent-safe — a property worth having regardless
+      of call order.
+
+- [x] **Stats index-alignment is a correctness trap.** `verdicts` are produced
+      over `detected` (post-cluster), so every consumer indexed against them
+      (`annotateFindings`, `verifierTally`) had to switch from `findings` to
+      `detected`. `raised` deliberately stayed on raw `findings` — it is the honest
+      "how many wordings the lens produced" count, with `clusters.collapsed`
+      reporting the inflation separately.
+
+- [x] **This reversed a deliberate #591 decision, so the tradeoff is documented in
+      code and design doc.** #591 put clustering after verification on purpose
+      ("it can never decide what gets verified"). Moving it before is a real
+      change to that safety property; the mitigations (conservative threshold,
+      strongest-wording representative, every wording rendered) are stated where a
+      future reader will look, not assumed.

--- a/docs/tasks/active/20260730-verify-after-clustering-todo.md
+++ b/docs/tasks/active/20260730-verify-after-clustering-todo.md
@@ -40,12 +40,18 @@ similarity threshold (the #578 distinct pairs score 0.000, staying separate), an
 evidence-bearing) as representative, with every folded wording still rendered so a
 bad merge is visible rather than silent.
 
+## Guarding the drop decision (added after CodeRabbit review of #601)
+
+- [x] Re-verify a refuted cluster's folded members individually before dropping
+      them (`resolveClusterVerdict`), so a wrong merge cannot drop a
+      genuinely-distinct finding on a shared refutation. A representative refutation
+      is honoured only when every folded BLOCKING wording is also confidently
+      refuted; otherwise the cluster is kept, carrying the surviving verdict. The
+      re-verification runs only on the rare dropping verdict of a multi-member
+      cluster, so the confirmed common path stays one session per cluster.
+
 ## Not done here (candidate follow-up)
 
-- Re-verify a refuted cluster's folded members individually before dropping them,
-  so a wrong merge cannot drop a genuinely-distinct finding on a shared
-  refutation. Preserves safety in the only dangerous direction (dropping) while
-  keeping the savings in the common confirmed case.
 - The prior-round re-check still verifies each `priorForLens` entry; those were
   already collapsed when persisted last round, so the waste there is minimal —
   left as-is to keep this change focused.

--- a/docs/tasks/active/20260730-verify-after-clustering-todo.md
+++ b/docs/tasks/active/20260730-verify-after-clustering-todo.md
@@ -1,0 +1,51 @@
+# Verify after clustering: stop paying the verifier per wording
+
+Follow-up to [restatement clustering](20260730-restatement-clustering-todo.md)
+(#591). That PR added `clusterFindings` to collapse restatements of one defect,
+but ran it *after* the verifier — so the verifier still ran once per wording
+before the collapse, which is the token waste #578 first surfaced.
+
+## The problem
+
+Per-lens flow in `review-panel.mjs` was: sample → union → **verify each fresh
+finding** → prior re-check → `merged = clusterFindings(dedupeFindings(...))`.
+
+With four restatement pairs (the #578 shape), the verifier opened four redundant
+sessions (and four redundant `git blame` calls via `noveltiesFor`) for defects
+that clustering then collapsed to one.
+
+## The change
+
+- [x] Cluster the fresh findings **before** the verifier pass:
+      `const detected = clusterFindings(findings)`; verify / annotate / tally over
+      `detected`, not the raw `findings`.
+- [x] Keep the merge-step `clusterFindings(dedupeFindings([...kept, ...priorKept]))`
+      — it now only collapses **cross-pass** restatements (a prior finding the
+      fresh pass re-found in different words).
+- [x] A finding can now be clustered twice, so `mergeCluster` **flattens**
+      `mergedFrom` (each folded member contributes itself + its own prior
+      `mergedFrom`, and the rep's is kept) instead of overwriting — no wording is
+      lost across the two passes.
+- [x] `raised`/`raisedConfidence` stats stay on raw `findings` (honest raised
+      count); `sentToVerifier` now counts distinct defects (`detected`).
+- [x] Tests: re-cluster-keeps-every-wording regression; full agent suite green.
+- [x] Design doc (`harness-engineering.md`) updated: ordering + the tradeoff.
+
+## The tradeoff (stated, not hidden)
+
+Clustering now decides what the verifier sees, so a wrong merge means a folded
+wording is judged only through its representative. Bounded by: the conservative
+similarity threshold (the #578 distinct pairs score 0.000, staying separate), and
+`mergeCluster` electing the strongest wording (gating → highest severity →
+evidence-bearing) as representative, with every folded wording still rendered so a
+bad merge is visible rather than silent.
+
+## Not done here (candidate follow-up)
+
+- Re-verify a refuted cluster's folded members individually before dropping them,
+  so a wrong merge cannot drop a genuinely-distinct finding on a shared
+  refutation. Preserves safety in the only dangerous direction (dropping) while
+  keeping the savings in the common confirmed case.
+- The prior-round re-check still verifies each `priorForLens` entry; those were
+  already collapsed when persisted last round, so the waste there is minimal —
+  left as-is to keep this change focused.

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -733,6 +733,38 @@ export function isDroppingVerdict(v, { allowPreExisting = false, claimType = nul
 }
 
 /**
+ * The effective verdict for a CLUSTERED finding, guarding its drop decision.
+ *
+ * Clustering runs before verification so each defect is verified once, not once
+ * per wording — but a merge is conservative, not infallible. If the representative
+ * is confidently refuted, its verdict would drop the WHOLE cluster, including any
+ * genuinely distinct wording that merged in and was never verified on its own.
+ * So a representative refutation is honoured only when every folded BLOCKING
+ * wording is ALSO confidently refuted (`isDroppingVerdict`). If any survives, the
+ * cluster is KEPT and that surviving verdict is returned, so an `unresolved` fold
+ * still marks the finding unsettled downstream.
+ *
+ * Non-blocking folds never reached the gate, so they cannot keep a cluster alive.
+ * A fold whose verdict is null — unverified, or the verifier errored — counts as
+ * surviving: the fail-toward-keep direction the rest of this path takes. When the
+ * representative is not a dropping verdict, or has no folds, its own verdict
+ * stands unchanged (the common path, where no fold was re-verified at all).
+ *
+ * `foldFindings[i]`/`foldVerdicts[i]` are index-aligned; `opts` is the same
+ * `{ allowPreExisting }` threaded to `isDroppingVerdict` everywhere else.
+ */
+export function resolveClusterVerdict(rep, repVerdict, foldFindings, foldVerdicts, opts) {
+  const drops = (v, f) => isDroppingVerdict(v, { ...opts, claimType: claimTypeOf(f) });
+  if (!drops(repVerdict, rep)) return repVerdict; // rep kept → nothing to guard
+  const folds = Array.isArray(foldFindings) ? foldFindings : [];
+  for (let i = 0; i < folds.length; i++) {
+    if (!BLOCKING.has(normalizeSeverity(folds[i] && folds[i].severity))) continue; // never gated
+    if (!drops(foldVerdicts?.[i], folds[i])) return foldVerdicts?.[i] ?? null; // a fold survives → keep
+  }
+  return repVerdict; // every blocking fold also refuted (or none gated) → drop stands
+}
+
+/**
  * The changed-file list is re-sent with EVERY verification (one per blocking
  * finding, per lens, per round), so an unbounded list on a sweeping PR
  * multiplies across the whole panel. Cap what is listed.
@@ -1747,21 +1779,39 @@ async function main() {
     // wording rides along in `mergedFrom`.
     //
     // TRADEOFF vs #591's original "cluster after verify" order: clustering now
-    // decides what the verifier sees, so a wrong merge means a folded wording is
-    // judged only through its representative's verdict. Two things bound that: the
-    // similarity threshold is conservative (the #578 distinct pairs scored 0.000,
-    // so they stay separate), and mergeCluster picks the STRONGEST wording as the
-    // representative (gating, then highest severity, then evidence-bearing), so
-    // the verifier judges the form most likely to survive — and every folded
-    // wording is still rendered, so a bad merge is visible rather than silent.
+    // decides what the verifier sees. The bound below (`resolveClusterVerdict`)
+    // keeps that from dropping a distinct finding: a representative refutation is
+    // honoured only if every folded wording is ALSO refuted. Merges are already
+    // conservative (the #578 distinct pairs scored 0.000, staying separate) and
+    // the STRONGEST wording is elected representative (gating, then highest
+    // severity, then evidence-bearing), so the verifier judges the form most
+    // likely to gate and every folded wording is still rendered.
     const detected = clusterFindings(findings);
 
     // Verifier refute pass over blocking findings (rubric passed so it judges by
     // the lens's own definitions; keeps the finding on any uncertainty).
+    const verifyBlocking = (f) => {
+      if (!BLOCKING.has(normalizeSeverity(f.severity))) return Promise.resolve(null);
+      return verifyFinding(f, { rubric: lens.rubric, repo, model: lens.model, sessionLog, changedContext })
+        .catch(() => null); // error → keep the finding (fail toward blocking)
+    };
     const verdicts = await Promise.all(detected.map(async (f) => {
-      if (!BLOCKING.has(normalizeSeverity(f.severity))) return null;
-      try { return await verifyFinding(f, { rubric: lens.rubric, repo, model: lens.model, sessionLog, changedContext }); }
-      catch { return null; } // error → keep the finding (fail toward blocking)
+      const repVerdict = await verifyBlocking(f);
+      // Reconstruct the folded wordings as findings. Clustering only merges within
+      // one file, so the representative's `file` is theirs too, and `mergedFrom`
+      // carries the severity/summary/evidence verifyFinding reads.
+      const folds = (Array.isArray(f.mergedFrom) ? f.mergedFrom : []).map((m) => ({
+        severity: m.severity, summary: m.summary, evidence: m.evidence, file: f.file,
+      }));
+      // Only pay for the extra verifier calls when the representative would
+      // actually drop the cluster (refutations are the minority, so the common
+      // confirmed path stays one session per cluster). Then keep the cluster
+      // unless every folded blocking wording is also confidently refuted.
+      if (!folds.length || !isDroppingVerdict(repVerdict, { ...verifyOpts, claimType: claimTypeOf(f) })) {
+        return repVerdict;
+      }
+      const foldVerdicts = await Promise.all(folds.map(verifyBlocking));
+      return resolveClusterVerdict(f, repVerdict, folds, foldVerdicts, verifyOpts);
     }));
     const kept = keepUnrefuted(
       annotateFindings(detected, verdicts, await noveltiesFor(detected), verifyOpts),

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -550,11 +550,22 @@ function mergeCluster(members) {
   // rep — never invent a lane on a finding that had none (see annotateFindings).
   if (out.lane === "backlog" && members.some((m) => findingGates(m))) out.lane = "blocking";
   if (members.some((m) => m && m.unsettled)) out.unsettled = true;
-  out.mergedFrom = others.map((m) => ({
+  // Flatten, don't overwrite. A finding can be clustered twice now — once within
+  // the fresh pass before verification, then again when a fresh survivor and a
+  // carried-forward prior finding turn out to restate one defect. Each folded
+  // member contributes ITSELF plus anything it had already folded, and the
+  // representative's own prior `mergedFrom` is kept, so no wording is lost across
+  // the two passes. (For the common single-pass case `others` carry no nested
+  // `mergedFrom` and `rep` has none, so this is exactly the old one-level list.)
+  const fold = (m) => ({
     severity: normalizeSeverity(m && m.severity),
     summary: (m && m.summary) ?? "(no summary)",
     ...(m && m.evidence ? { evidence: m.evidence } : {}),
-  }));
+  });
+  out.mergedFrom = [
+    ...others.flatMap((m) => [fold(m), ...(Array.isArray(m && m.mergedFrom) ? m.mergedFrom : [])]),
+    ...(Array.isArray(rep.mergedFrom) ? rep.mergedFrom : []),
+  ];
   return out;
 }
 
@@ -1727,15 +1738,33 @@ async function main() {
       return;
     }
 
+    // Collapse RESTATEMENTS of one defect BEFORE verifying, so the verifier runs
+    // once per distinct defect rather than once per wording — the #578 waste,
+    // where four restatement pairs meant four redundant verifier sessions (and,
+    // via noveltiesFor below, four redundant `git blame` calls). See
+    // clusterFindings for why merging loses nothing: the survivor takes the
+    // cluster's worst severity and gates if any member did, and every folded
+    // wording rides along in `mergedFrom`.
+    //
+    // TRADEOFF vs #591's original "cluster after verify" order: clustering now
+    // decides what the verifier sees, so a wrong merge means a folded wording is
+    // judged only through its representative's verdict. Two things bound that: the
+    // similarity threshold is conservative (the #578 distinct pairs scored 0.000,
+    // so they stay separate), and mergeCluster picks the STRONGEST wording as the
+    // representative (gating, then highest severity, then evidence-bearing), so
+    // the verifier judges the form most likely to survive — and every folded
+    // wording is still rendered, so a bad merge is visible rather than silent.
+    const detected = clusterFindings(findings);
+
     // Verifier refute pass over blocking findings (rubric passed so it judges by
     // the lens's own definitions; keeps the finding on any uncertainty).
-    const verdicts = await Promise.all(findings.map(async (f) => {
+    const verdicts = await Promise.all(detected.map(async (f) => {
       if (!BLOCKING.has(normalizeSeverity(f.severity))) return null;
       try { return await verifyFinding(f, { rubric: lens.rubric, repo, model: lens.model, sessionLog, changedContext }); }
       catch { return null; } // error → keep the finding (fail toward blocking)
     }));
     const kept = keepUnrefuted(
-      annotateFindings(findings, verdicts, await noveltiesFor(findings), verifyOpts),
+      annotateFindings(detected, verdicts, await noveltiesFor(detected), verifyOpts),
     );
 
     // Part 2: re-check this lens's blocking findings from the PREVIOUS round
@@ -1761,11 +1790,12 @@ async function main() {
     );
     // Merge fresh + still-open prior findings. Two passes, narrow then loose:
     // `dedupeFindings` collapses byte-identical summaries, then `clusterFindings`
-    // collapses RESTATEMENTS of one defect — a prior finding the fresh pass
-    // re-found in different words, or one lens describing the same bug twice at
-    // two severities. Clustering runs AFTER verification on purpose: it merges
-    // only findings that already survived the gate, so it can never decide what
-    // gets verified, and every collapsed wording rides along in `mergedFrom`.
+    // collapses RESTATEMENTS ACROSS the two passes — a prior finding the fresh
+    // pass re-found in different words. (Within the fresh pass, restatements were
+    // already collapsed before verification, above; this catches only the
+    // fresh-vs-prior kind.) A finding can therefore be clustered twice now, so
+    // mergeCluster flattens the wordings each side already folded — this second
+    // pass loses none of the ones the first recorded in `mergedFrom`.
     const merged = clusterFindings(dedupeFindings([...kept, ...priorKept]));
     // What the LENS CHECK gates on: `merged` minus the demoted blockers. The
     // backlog ones stay in `merged` so the summary still reports them (with the
@@ -1776,7 +1806,10 @@ async function main() {
     // Reliability signals for this round: did the samples agree (fresh pass
     // only — prior-round re-checks aren't a sampling question), and what did
     // the verifier do across BOTH the fresh and prior-round re-check passes.
-    const freshTally = verifierTally(findings, verdicts, verifyOpts);
+    // `detected`, not `findings`: `verdicts` are index-aligned to what was
+    // actually sent to the verifier (post-cluster), so `sentToVerifier` counts
+    // distinct defects rather than wordings.
+    const freshTally = verifierTally(detected, verdicts, verifyOpts);
     const priorTally = verifierTally(priorForLens, priorVerdicts, verifyOpts);
     lensStats.push({
       id: lens.id,

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -2023,3 +2023,26 @@ test("clusterCounts: reports collapsed wordings, not findings", () => {
   assert.deepEqual(clusterCounts([]), { clustered: 0, collapsed: 0 });
   assert.deepEqual(clusterCounts(null), { clustered: 0, collapsed: 0 });
 });
+
+test("clusterFindings: re-clustering a merged finding keeps every folded wording", () => {
+  // Findings are now clustered TWICE: once in the fresh pass before verification,
+  // then again when a fresh survivor restates a carried-forward prior finding. The
+  // second pass must FLATTEN what the first folded, not overwrite it — otherwise a
+  // wording collapsed in round one silently vanishes when the finding merges again.
+  const [a, b] = SAME_DEFECT[0];
+  const first = clusterFindings([asFinding(a), asFinding(b)]);
+  assert.equal(first.length, 1);
+  assert.equal(first[0].mergedFrom.length, 1); // `b` folded into `a` (or vice-versa)
+
+  // Re-cluster the survivor — which already carries `mergedFrom` — against another
+  // wording of the same defect. Pre-fix this returned mergedFrom.length 1, dropping
+  // the wording folded in `first`.
+  const second = clusterFindings([first[0], asFinding(a)]);
+  assert.equal(second.length, 1);
+  assert.equal(second[0].mergedFrom.length, 2, "the earlier fold was overwritten, not flattened");
+  // Both original wordings survive somewhere on the finding — nothing is lost.
+  const kept = new Set([second[0].summary, ...second[0].mergedFrom.map((m) => m.summary)]);
+  assert.ok(kept.has(a) && kept.has(b), "a re-cluster dropped one of the folded wordings");
+  // And the collapsed count reflects the flattened total, not just this pass.
+  assert.deepEqual(clusterCounts(second), { clustered: 1, collapsed: 2 });
+});

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -41,6 +41,7 @@ import {
   claimTypeOf,
   clusterFindings,
   clusterCounts,
+  resolveClusterVerdict,
   VERIFIER_MAX_TURNS,
   buildVerifierPrompt,
   panelEntry,
@@ -2022,6 +2023,32 @@ test("clusterCounts: reports collapsed wordings, not findings", () => {
   assert.deepEqual(clusterCounts(merged), { clustered: 1, collapsed: 1 });
   assert.deepEqual(clusterCounts([]), { clustered: 0, collapsed: 0 });
   assert.deepEqual(clusterCounts(null), { clustered: 0, collapsed: 0 });
+});
+
+test("resolveClusterVerdict: a representative refutation cannot drop a surviving fold", () => {
+  // Clustering runs before verification, so a rep refutation would drop the whole
+  // cluster. resolveClusterVerdict re-checks the folds first: the cluster is
+  // dropped ONLY when the rep AND every folded blocking wording are refuted.
+  const opts = { allowPreExisting: false };
+  const rep = { severity: "major", file: "scripts/agent/ask.mjs", summary: "rep" };
+  const fold = { severity: "major", file: "scripts/agent/ask.mjs", summary: "fold" };
+  // A valid dropping verdict for a presence claim (see isDroppingVerdict).
+  const drop = { verdict: "refuted", confidence: "high", refutationGround: "not-present", groundedIn: ["scripts/agent/ask.mjs:12"] };
+  const keep = { verdict: "confirmed", confidence: "high", refutationGround: "none", groundedIn: [] };
+
+  // Rep not refuted → its own verdict stands, folds irrelevant (common path).
+  assert.equal(resolveClusterVerdict(rep, keep, [fold], [drop], opts), keep);
+  // No folds → the rep's drop stands.
+  assert.equal(resolveClusterVerdict(rep, drop, [], [], opts), drop);
+  // Rep refuted, the only blocking fold also refuted → drop stands.
+  assert.equal(resolveClusterVerdict(rep, drop, [fold], [drop], opts), drop);
+  // Rep refuted but a blocking fold SURVIVES → cluster kept, surviving verdict returned.
+  assert.equal(resolveClusterVerdict(rep, drop, [fold], [keep], opts), keep);
+  // A surviving fold whose verdict is null (unverified / errored) still keeps the cluster.
+  assert.equal(resolveClusterVerdict(rep, drop, [fold], [null], opts), null);
+  // A NON-blocking fold can never keep a cluster alive, even un-refuted.
+  const nitFold = { severity: "nit", file: "scripts/agent/ask.mjs", summary: "style" };
+  assert.equal(resolveClusterVerdict(rep, drop, [nitFold], [null], opts), drop);
 });
 
 test("clusterFindings: re-clustering a merged finding keeps every folded wording", () => {


### PR DESCRIPTION
## Summary

Follow-up to #591. That PR added `clusterFindings` to collapse restatements of one defect into a single finding, but ran it **after** the verifier — so the verifier still opened a full session (and a `git blame` via `noveltiesFor`) for **every wording** before the collapse. On the #578 shape (four restatement pairs), that was four redundant verifier sessions for defects that clustering then merged to one.

This moves the fresh-pass clustering **before** the verify pass, so the verifier runs once per distinct defect.

## Changes

- **`review-panel.mjs`** — `const detected = clusterFindings(findings)` before the verify pass; verify / `annotateFindings` / `verifierTally` now run over `detected`, not the raw `findings`.
- The merge-step `clusterFindings(dedupeFindings([...kept, ...priorKept]))` **stays** — it now only collapses **cross-pass** restatements (a prior finding the fresh pass re-found in different words).
- **`mergeCluster` flattens `mergedFrom`** instead of overwriting it. A finding can be clustered twice now (fresh pre-verify, then fresh-vs-prior), and without flattening the second pass would drop the wordings the first folded. Each folded member contributes itself + its own prior `mergedFrom`, and the representative's is kept — nothing is lost.
- `raised`/`raisedConfidence` stats stay on raw `findings` (honest raised count); `sentToVerifier` now counts distinct defects.
- Design doc + paired task/lessons files.

## The tradeoff (stated, not hidden)

#591 deliberately clustered **after** verification so it "can never decide what gets verified." This reverses that: the merge now decides what the verifier sees, so a wrong merge means a folded wording is judged only through its representative. Two things bound it:
- the similarity threshold is conservative — the #578 *distinct* pairs score **0.000**, so they stay separate;
- `mergeCluster` elects the **strongest** wording as representative (gating → highest severity → evidence-bearing), so the verifier judges the form most likely to gate, and **every folded wording is still rendered** — a bad merge is visible, not silent.

A candidate follow-up (noted in the task file): re-verify a *refuted* cluster's folded members individually before dropping them, preserving safety in the only dangerous direction while keeping the savings in the common confirmed case.

## Test plan

- New `clusterFindings: re-clustering a merged finding keeps every folded wording` regression test (asserts flattening; pre-fix it dropped a wording).
- Full agent suite: `cd scripts/agent && node --test *.test.mjs` → **358/358 pass**.

Pipeline-internal; ships no product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Verification now runs on clustered findings, reducing redundant verification sessions for duplicate defects.
  * Clustered findings retain complete wording provenance across repeated clustering passes.
  * Reporting metrics now distinguish raw findings from distinct defects sent for verification.

* **Tests**
  * Added regression coverage to ensure re-clustering preserves all merged wording details and accurate cluster counts.

* **Documentation**
  * Documented the updated verification workflow, behavior, metrics, tradeoffs, and safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->