### PR TITLE
Attribute review-panel tokens per lens and detection/verifier

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -597,7 +597,15 @@ Components:
   `lensStats.lanes` reports `blocking`/`backlog`/`unknownOrigin` and
   `scripts/agent/metrics.mjs` renders it; read `unknownOrigin` first, since a zero `backlog`
   beside a high `unknownOrigin` means the gate ran blind rather than that nothing
-  was relocated. The
+  was relocated.
+  **Token attribution.** Every SDK call is stamped with `{ lens, role }`
+  (`role` ∈ `detection` | `verifier`) as `scripts/agent/ask.mjs` pushes its result
+  to the shared execution log, so `scripts/agent/metrics.mjs`'s
+  `attributionBreakdown` can split the panel's spend per lens and by
+  detection-vs-verifier instead of one anonymous total — the effort summary renders
+  it as a cost · weighted-tokens table. This is what makes "which
+  lens, and is it the verifier?" answerable from the ledger rather than by guessing;
+  it is measurement only and gates nothing. The
   **trusted orchestrator** (run from a `main` checkout, via the shared
   `scripts/agent/severity.mjs` rule) computes each lens's conclusion — the
   subagents only classify — and the job records one unforgeable

--- a/docs/tasks/active/20260730-token-attribution-lessons.md
+++ b/docs/tasks/active/20260730-token-attribution-lessons.md
@@ -1,0 +1,19 @@
+# Lessons: token attribution
+
+- [x] **The per-call data already existed — only the label was missing.** Each SDK
+      session is its own `result` message in `sessionLog` (own `session_id`, usage,
+      cost). The blocker to a per-lens breakdown was purely that `ask.mjs` pushed the
+      message un-tagged. A one-field `{ lens, role }` stamp turned a flat total into a
+      full breakdown without changing what's logged or any workflow.
+
+- [x] **Tag at the shared choke point, attribute at the caller.** `ask.mjs` is the one
+      place every lens sample and every verifier call funnels through, so the stamp
+      lives there; the *meaning* (`detection` vs `verifier`, which lens) is only known
+      at the `review-panel.mjs` call sites, so `logMeta` is passed in rather than
+      inferred. Both verifier paths (representative/fold and prior-round re-check) had
+      to be tagged, or verifier cost would have looked artificially low.
+
+- [x] **Ship it dark-safe.** Un-attributed messages fall into an `other` bucket and a
+      round with no attribution renders no table, so the change is invisible on old
+      PRs and lights up only as instrumented rounds accumulate — no migration, no
+      flag day.

--- a/docs/tasks/active/20260730-token-attribution-todo.md
+++ b/docs/tasks/active/20260730-token-attribution-todo.md
@@ -1,0 +1,39 @@
+# Per-lens / detection-vs-verifier token attribution
+
+The review panel is expensive enough that two runs can exhaust a session limit,
+but the logs could not say *where* the tokens went: `review-execution.json` was a
+flat, un-tagged list of SDK result messages, and the effort summary collapsed it
+to one aggregate. So "which lens?" and "is it the verifier?" were unanswerable
+from the ledger.
+
+## The change
+
+- [x] `ask.mjs`: `askStructured` takes an optional `logMeta` and stamps it onto the
+      logged result message (shallow copy — the SDK message is not mutated), so
+      every call carries `{ lens, role }`.
+- [x] `review-panel.mjs`: `runLens` tags `role: "detection"`; `verifyFinding` takes
+      a `lensId` and tags `role: "verifier"` — both verifier call sites (fresh/rep +
+      fold re-verify, and the prior-round re-check) pass `lensId`.
+- [x] `metrics.mjs`: `attributionBreakdown(messages)` → `{ lens: { detection|verifier|other:
+      {cost,weighted,tokens,turns,calls} } }`; `aggregateAttribution` sums it across
+      rounds; `cmdRecord` attaches it to the review record; `cmdSummarize` aggregates
+      and `renderSummary` renders a per-lens cost · weighted-tokens table plus a
+      detection-vs-verifier headline.
+- [x] Tests for `attributionBreakdown`, `aggregateAttribution`, and the rendered table.
+- [x] Design-doc note in `harness-engineering.md`.
+
+## Safe by construction
+
+- **No workflow change.** The attribution rides inside `review-execution.json`, which
+  `metrics.mjs record --kind review` already reads on both the autonomous and
+  on-demand paths.
+- **Backward compatible.** A message without attribution → `unattributed`/`other`;
+  a round with none → no table at all (pre-instrumentation PRs render as before).
+- **Measurement only** — gates nothing, and `metrics.mjs` stays fail-safe (exits 0).
+
+## Follow-up once the data lands
+
+The point of this is to *measure*, not yet to cut. Once a few real rounds carry
+attribution, the likely levers (from the structural analysis) are: `samples` 2→1 on
+the cheaper lenses, a lower absence-verifier `maxTurns` (20 is high), or a
+per-round cap on verifier calls. Decide those from the table, not from a guess.

--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -366,6 +366,11 @@ export async function askStructured({
   maxTurns,
   allowedTools,
   label = "agent",
+  // Optional attribution ({ lens, role }) stamped onto this call's logged result
+  // message, so a consumer summing `sessionLog` can split cost by lens and by
+  // detection-vs-verifier instead of seeing one anonymous total. No behavioral
+  // effect; omitted for callers that don't attribute.
+  logMeta,
 }) {
   // Built BEFORE the dynamic import, because it validates the tool grant: a bad
   // grant must fail without opening a session (ask.test.mjs asserts this ordering
@@ -384,7 +389,10 @@ export async function askStructured({
       // compute even when it didn't produce usable structured output. This is
       // the ONLY place an SDK call's result is observable at all; callers
       // discard everything else, so record before the throw below.
-      if (sessionLog) sessionLog.push(message);
+      // Tag the recorded entry with its attribution when given (a shallow copy so
+      // the SDK's message is not mutated). metrics.mjs reads `.attribution`; every
+      // other field is preserved, so the log stays claude-execution-output shaped.
+      if (sessionLog) sessionLog.push(logMeta ? { ...message, attribution: logMeta } : message);
       const c = classifyResult(message);
       if (c.ok) return c.output;
       const err = new Error(

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -128,6 +128,72 @@ export function sumExecutions(messages, kind = "review") {
   };
 }
 
+/** Per-message usage tally (raw + weighted tokens, turns, cost). */
+function messageUsage(m) {
+  const u = (m && m.usage) || {};
+  return {
+    tokens:
+      (u.input_tokens || 0) +
+      (u.output_tokens || 0) +
+      (u.cache_creation_input_tokens || 0) +
+      (u.cache_read_input_tokens || 0),
+    weightedTokens: weightedTokensFor(u),
+    turns: (m && m.num_turns) || 0,
+    costUsd: (m && m.total_cost_usd) || 0,
+  };
+}
+
+const emptyBucket = () => ({ costUsd: 0, weightedTokens: 0, tokens: 0, turns: 0, calls: 0 });
+function addBucket(acc, u) {
+  acc.costUsd += u.costUsd; acc.weightedTokens += u.weightedTokens;
+  acc.tokens += u.tokens; acc.turns += u.turns; acc.calls += 1;
+}
+
+/**
+ * Break a review execution log down by ATTRIBUTION — `{ lens: { role: bucket } }`,
+ * role ∈ `detection` | `verifier` (anything else → `other`). Each SDK result
+ * message carries `attribution: { lens, role }` (stamped by ask.mjs when the
+ * panel tags the call); a message without it lands under lens `"unattributed"`,
+ * role `"other"`, so a pre-instrumentation round is visible as one bucket rather
+ * than silently dropped. This is the per-lens / detection-vs-verifier split the
+ * flat `sumExecutions` total cannot give. Shape-safe: junk contributes nothing.
+ */
+export function attributionBreakdown(messages) {
+  const out = {};
+  for (const m of Array.isArray(messages) ? messages : []) {
+    if (!m || m.type !== "result") continue;
+    const a = (m.attribution && typeof m.attribution === "object") ? m.attribution : {};
+    const lens = typeof a.lens === "string" && a.lens ? a.lens : "unattributed";
+    const role = a.role === "detection" || a.role === "verifier" ? a.role : "other";
+    out[lens] = out[lens] || {};
+    out[lens][role] = out[lens][role] || emptyBucket();
+    addBucket(out[lens][role], messageUsage(m));
+  }
+  return out;
+}
+
+/** Merge N `attributionBreakdown` objects (one per round) into one. */
+export function aggregateAttribution(breakdowns) {
+  const out = {};
+  for (const bd of Array.isArray(breakdowns) ? breakdowns : []) {
+    if (!bd || typeof bd !== "object") continue;
+    for (const [lens, roles] of Object.entries(bd)) {
+      if (!roles || typeof roles !== "object") continue;
+      out[lens] = out[lens] || {};
+      for (const [role, b] of Object.entries(roles)) {
+        out[lens][role] = out[lens][role] || emptyBucket();
+        const t = out[lens][role];
+        t.costUsd += Number(b?.costUsd) || 0;
+        t.weightedTokens += Number(b?.weightedTokens) || 0;
+        t.tokens += Number(b?.tokens) || 0;
+        t.turns += Number(b?.turns) || 0;
+        t.calls += Number(b?.calls) || 0;
+      }
+    }
+  }
+  return out;
+}
+
 /** Aggregate an array of session records into pipeline-wide totals. */
 export function aggregate(records) {
   const list = Array.isArray(records) ? records : [];
@@ -347,7 +413,51 @@ export function formatUsd(n) {
  * responds to what the panel found, and review, the panel's own compute, are
  * easy to conflate by name, so their costs are rendered in separate sections
  * rather than folded into one set of totals). */
-export function renderSummary({ agg, panelAgg, panelStats, flips, scope }) {
+/** Per-lens / detection-vs-verifier token table for the review panel, or [] when
+ * the log carries no attribution (pre-instrumentation rounds, or a code-only PR).
+ * Cost leads with weighted tokens alongside — the same measure the sections above
+ * use. This is the split that answers "which lens / is it the verifier?". */
+function renderAttribution(attr) {
+  const byLens = attr && typeof attr === "object" ? attr : {};
+  const cell = (b) => (b && b.calls > 0 ? `${formatUsd(b.costUsd)} · ${formatTokens(b.weightedTokens)}` : "—");
+  const det = emptyBucket(), ver = emptyBucket(), other = emptyBucket();
+  const add = (acc, b) => {
+    if (!b) return;
+    acc.costUsd += b.costUsd; acc.weightedTokens += b.weightedTokens;
+    acc.tokens += b.tokens; acc.turns += b.turns; acc.calls += b.calls;
+  };
+  const rows = [];
+  for (const lens of Object.keys(byLens).sort()) {
+    const roles = byLens[lens] || {};
+    add(det, roles.detection); add(ver, roles.verifier); add(other, roles.other);
+    // A lens with only an `other` bucket is an un-instrumented round; fold it into
+    // the note below rather than showing an empty detection/verifier row.
+    if ((roles.detection?.calls || 0) + (roles.verifier?.calls || 0) > 0) {
+      rows.push(`| ${lens} | ${cell(roles.detection)} | ${cell(roles.verifier)} |`);
+    }
+  }
+  if (!rows.length) return []; // nothing attributed → skip the table entirely
+  const out = [
+    "",
+    "#### Token attribution — cost · weighted tokens, all rounds",
+    "",
+    "| Lens | Detection | Verifier |",
+    "| --- | --- | --- |",
+    ...rows,
+    `| **Total** | ${cell(det)} | ${cell(ver)} |`,
+    "",
+    `- Detection vs verifier: ${formatUsd(det.costUsd)} vs ${formatUsd(ver.costUsd)} ` +
+      `(${formatTokens(det.weightedTokens)} / ${formatTokens(ver.weightedTokens)} weighted).`,
+  ];
+  if (other.calls > 0) {
+    out.push(
+      `- ${formatUsd(other.costUsd)} · ${formatTokens(other.weightedTokens)} weighted from rounds recorded before attribution existed.`,
+    );
+  }
+  return out;
+}
+
+export function renderSummary({ agg, panelAgg, panelStats, panelAttribution, flips, scope }) {
   const hasPanel = !!panelAgg && panelAgg.sessions > 0;
   // An on-demand `@claude review` posts a review record but no code-fix session,
   // so `aggregate([])` yields an all-zero `agg`. Rendering a "Code-fix agent"
@@ -461,6 +571,9 @@ export function renderSummary({ agg, panelAgg, panelStats, flips, scope }) {
       `- ⚠️ Cross-round flips (blocking→clean; advisory, review manually): ${flipList.length}` +
         (flipList.length ? ` — ${flipList.map((f) => `${f.lens} r${f.fromRound}→r${f.toRound}`).join(", ")}` : ""),
     );
+    // Per-lens / detection-vs-verifier token split (empty until rounds carry
+    // attribution, so pre-instrumentation PRs render exactly as before).
+    lines.push(...renderAttribution(panelAttribution));
   }
   return lines.join("\n");
 }
@@ -563,6 +676,10 @@ function cmdRecord(args) {
     rec = sumExecutions(messages, kind);
     if (rec.calls === 0) return bail("no result messages in the review execution log");
     delete rec.calls;
+    // Per-lens / detection-vs-verifier token split from the SAME messages. Carried
+    // on the record so `summarize` can aggregate it across rounds. Empty object on
+    // an un-instrumented log — harmless, just yields no attribution table.
+    rec.attribution = attributionBreakdown(messages);
     // Sample-agreement/verifier-outcome data is optional and best-effort: a
     // missing/malformed file must never block recording the cost that WAS
     // captured, so log and move on rather than bail.
@@ -608,6 +725,10 @@ function cmdSummarize(args) {
   const panelStats = panelRecords.length
     ? aggregatePanelStats(panelRecords.flatMap((r) => (Array.isArray(r.lensStats) ? r.lensStats : [])))
     : null;
+  // Per-lens / detection-vs-verifier token split, summed across every round.
+  const panelAttribution = panelRecords.length
+    ? aggregateAttribution(panelRecords.map((r) => r.attribution).filter(Boolean))
+    : null;
   // `panelRecords` is in ledger (chronological = round) order — detectFlips
   // relies on that, so pass it as-is without re-sorting.
   const flips = panelRecords.length ? detectFlips(panelRecords) : null;
@@ -617,7 +738,7 @@ function cmdSummarize(args) {
     // its original creation point (often an early paged hand-off), so editing it
     // leaves the up-to-date summary buried mid-thread. Posting new lands it at the
     // BOTTOM where a human looks; the old one is deleted just below.
-    postComment(pr, renderSummary({ agg, panelAgg, panelStats, flips, scope }));
+    postComment(pr, renderSummary({ agg, panelAgg, panelStats, panelAttribution, flips, scope }));
   } catch (e) {
     return bail(`could not post summary for PR #${pr}: ${e.message}`);
   }

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import {
   parseExecution,
   sumExecutions,
+  attributionBreakdown,
+  aggregateAttribution,
   aggregate,
   aggregatePanelStats,
   detectFlips,
@@ -348,6 +350,88 @@ test("renderSummary: review-only (no code-fix) omits the code-fix section", () =
   assert.match(md, /- Total-cost: \$0\.80\n/);
   assert.doesNotMatch(md, /code-fix .* \+ review/);
   assert.match(md, /- Total-tokens: ~40K weighted \(~300K raw\)/);
+});
+
+// A result message tagged the way ask.mjs tags it. No cache fields, so weighted
+// tokens == raw tokens (input+output weight 1x), keeping the arithmetic obvious.
+const attrMsg = (lens, role, { inp = 0, out = 0, cost = 0, turns = 0 } = {}) => ({
+  type: "result",
+  num_turns: turns,
+  total_cost_usd: cost,
+  usage: { input_tokens: inp, output_tokens: out },
+  ...(lens || role ? { attribution: { lens, role } } : {}),
+});
+const cents = (n) => Number((n).toFixed(2));
+
+test("attributionBreakdown: buckets by lens and detection/verifier role", () => {
+  const bd = attributionBreakdown([
+    attrMsg("correctness", "detection", { inp: 100, out: 20, cost: 0.3, turns: 5 }),
+    attrMsg("correctness", "detection", { inp: 100, out: 20, cost: 0.3, turns: 5 }), // 2 samples
+    attrMsg("correctness", "verifier", { inp: 400, out: 10, cost: 0.5, turns: 8 }),
+    attrMsg("security", "detection", { inp: 80, out: 10, cost: 0.2, turns: 4 }),
+    attrMsg(null, null, { inp: 5, cost: 0.01 }),   // no attribution → unattributed/other
+    { type: "user" },                                // non-result → ignored
+    null,                                            // junk → ignored
+  ]);
+  assert.equal(bd.correctness.detection.calls, 2);
+  assert.equal(cents(bd.correctness.detection.costUsd), 0.6);
+  assert.equal(bd.correctness.detection.tokens, 240);   // (100+20) × 2
+  assert.equal(bd.correctness.detection.weightedTokens, 240);
+  assert.equal(bd.correctness.detection.turns, 10);
+  assert.equal(bd.correctness.verifier.calls, 1);
+  assert.equal(bd.correctness.verifier.tokens, 410);
+  assert.equal(bd.security.detection.calls, 1);
+  // An un-attributed message is preserved, not dropped.
+  assert.equal(bd.unattributed.other.calls, 1);
+  assert.equal(bd.unattributed.other.tokens, 5);
+  // Shape-safe on junk.
+  assert.deepEqual(attributionBreakdown(null), {});
+});
+
+test("aggregateAttribution: sums per-round breakdowns", () => {
+  const r1 = attributionBreakdown([attrMsg("correctness", "detection", { inp: 100, cost: 0.3 })]);
+  const r2 = attributionBreakdown([
+    attrMsg("correctness", "detection", { inp: 50, cost: 0.2 }),
+    attrMsg("correctness", "verifier", { inp: 200, cost: 0.4 }),
+  ]);
+  const agg = aggregateAttribution([r1, r2]);
+  assert.equal(agg.correctness.detection.calls, 2);
+  assert.equal(cents(agg.correctness.detection.costUsd), 0.5);
+  assert.equal(agg.correctness.detection.tokens, 150);
+  assert.equal(agg.correctness.verifier.calls, 1);
+  assert.deepEqual(aggregateAttribution(null), {});
+});
+
+test("renderSummary: renders the per-lens detection/verifier token table", () => {
+  const bucket = (cost, weighted) => ({ costUsd: cost, weightedTokens: weighted, tokens: weighted, turns: 1, calls: 1 });
+  const md = renderSummary({
+    agg: { agents: [], sessions: 0, attempt: 1, turns: 0, tokens: 0, weightedTokens: 0, durationMs: 0, costUsd: 0 },
+    panelAgg: { agents: ["claude-opus-5"], sessions: 1, turns: 8, tokens: 1000, weightedTokens: 1000, costUsd: 1.0, durationMs: 60000 },
+    panelStats: {},
+    panelAttribution: {
+      correctness: { detection: bucket(0.3, 120), verifier: bucket(0.5, 400) },
+      security: { detection: bucket(0.2, 90) }, // no verifier finding → "—"
+    },
+    flips: { flips: [] },
+    scope: "M",
+  });
+  assert.match(md, /#### Token attribution/);
+  assert.match(md, /\| correctness \| \$0\.30 · ~120 \| \$0\.50 · ~400 \|/);
+  assert.match(md, /\| security \| \$0\.20 · ~90 \| — \|/);         // no verifier cell
+  assert.match(md, /\| \*\*Total\*\* \| \$0\.50 · ~210 \| \$0\.50 · ~400 \|/);
+  assert.match(md, /Detection vs verifier: \$0\.50 vs \$0\.50/);
+});
+
+test("renderSummary: no attribution table when the log carries none", () => {
+  const md = renderSummary({
+    agg: { agents: ["x"], sessions: 1, attempt: 1, turns: 1, tokens: 1, weightedTokens: 1, durationMs: 1, costUsd: 0.1 },
+    panelAgg: { agents: ["claude-opus-5"], sessions: 1, turns: 8, tokens: 1000, weightedTokens: 1000, costUsd: 1.0, durationMs: 60000 },
+    panelStats: {},
+    panelAttribution: null, // pre-instrumentation round
+    flips: { flips: [] },
+    scope: "M",
+  });
+  assert.doesNotMatch(md, /Token attribution/);
 });
 
 test("metric comment round-trip: hidden, self-contained, parses back; junk → null", () => {

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -1377,6 +1377,7 @@ async function runLens(lens, { rubric, diff, issue, repo, sessionLog, scopeNote,
     // unbounded budget there is spend with nothing to show for it.
     maxTurns: lens.maxTurns,
     label: "review",
+    logMeta: { lens: lens.id, role: "detection" },
   });
 }
 
@@ -1551,7 +1552,7 @@ export function buildVerifierPrompt(finding, { rubric }) {
   return prompt;
 }
 
-async function verifyFinding(finding, { rubric, repo, model, sessionLog }) {
+async function verifyFinding(finding, { rubric, repo, model, sessionLog, lensId }) {
   const claimType = claimTypeOf(finding);
   return askStructured({
     systemPrompt:
@@ -1576,6 +1577,7 @@ async function verifyFinding(finding, { rubric, repo, model, sessionLog }) {
     maxTurns: VERIFIER_MAX_TURNS[claimType],
     allowedTools: REVIEW_TOOLS,
     label: "review",
+    logMeta: { lens: lensId, role: "verifier" },
   });
 }
 
@@ -1815,7 +1817,7 @@ async function main() {
     // the lens's own definitions; keeps the finding on any uncertainty).
     const verifyBlocking = (f) => {
       if (!BLOCKING.has(normalizeSeverity(f.severity))) return Promise.resolve(null);
-      return verifyFinding(f, { rubric: lens.rubric, repo, model: lens.model, sessionLog })
+      return verifyFinding(f, { rubric: lens.rubric, repo, model: lens.model, sessionLog, lensId: lens.id })
         .catch(() => null); // error → keep the finding (fail toward blocking)
     };
     const verdicts = await Promise.all(detected.map(async (f) => {
@@ -1849,7 +1851,7 @@ async function main() {
     const priorForLens = priorFindings.filter((p) => p.lens === lens.id);
     const priorVerdicts = await Promise.all(priorForLens.map(async (f) => {
       if (!BLOCKING.has(normalizeSeverity(f.severity))) return null;
-      try { return await verifyFinding(f, { rubric: lens.rubric, repo, model: lens.model, sessionLog }); }
+      try { return await verifyFinding(f, { rubric: lens.rubric, repo, model: lens.model, sessionLog, lensId: lens.id }); }
       catch { return null; } // error → keep (fail toward blocking)
     }));
     // Carried-forward findings are NOT routed. Their `line` was recorded against


### PR DESCRIPTION
## Summary

The review panel is expensive enough that two runs can exhaust a session limit, but the logs couldn't say **where** the tokens went: `review-execution.json` was a flat, un-tagged list of SDK result messages (`ask.mjs` did a bare `sessionLog.push(message)`), and the effort summary collapsed it to one aggregate. So "which lens?" and "is it the verifier?" were unanswerable from the ledger.

This adds a per-lens / detection-vs-verifier token breakdown, surfaced in the effort summary you already get.

## How

- **`ask.mjs`** — `askStructured` takes an optional `logMeta` and stamps it onto the logged result message (**shallow copy** — the SDK message is not mutated; every field is preserved so the log stays `claude-execution-output`-shaped).
- **`review-panel.mjs`** — `runLens` tags `role: "detection"`; `verifyFinding` takes a `lensId` and tags `role: "verifier"`. Both verifier call sites (representative + fold re-verify, and the prior-round re-check) pass `lensId`, so verifier cost isn't undercounted.
- **`metrics.mjs`** — `attributionBreakdown(messages)` → `{ lens: { detection|verifier|other: {cost,weighted,tokens,turns,calls} } }`; `aggregateAttribution` sums it across rounds; `cmdRecord` attaches it to the review record; `renderSummary` renders a per-lens **cost · weighted-tokens** table plus a detection-vs-verifier headline.

Example (rendered in the `🤖 Agent effort` → Review panel section):

```
#### Token attribution — cost · weighted tokens, all rounds
| Lens | Detection | Verifier |
| --- | --- | --- |
| correctness | $0.30 · ~120K | $0.50 · ~400K |
| security | $0.20 · ~90K | — |
| **Total** | $0.50 · ~210K | $0.50 · ~400K |

- Detection vs verifier: $0.50 vs $0.50 (~210K / ~400K weighted).
```

## Safe by construction

- **No workflow change** — the attribution rides inside `review-execution.json`, which `metrics.mjs record --kind review` already reads on both the autonomous and on-demand paths.
- **Backward compatible** — a message with no attribution → `other` bucket; a round with none → no table at all, so pre-instrumentation PRs render exactly as before.
- **Measurement only** — gates nothing; `metrics.mjs` stays fail-safe (exits 0 on any error).

## Test plan

- New tests: `attributionBreakdown`, `aggregateAttribution`, the rendered table, and the no-attribution (no-table) case.
- Full agent suite: `cd scripts/agent && node --test *.test.mjs` → **386/386 pass**.

Follow-up (task file): once real rounds carry attribution, decide cost levers (samples 2→1 on cheap lenses, lower absence-verifier `maxTurns`, cap verifier calls) from the table rather than a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token attribution to review summaries, broken down by lens and detection versus verifier activity.
  * Added cost, weighted-token, turn, and call metrics for attributed review activity.
  * Preserved compatibility with earlier records by handling unattributed activity separately.

* **Documentation**
  * Documented token attribution behavior, measurement scope, and backward-compatible handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->