### PR TITLE
Drop the security review lens to one sample too

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -634,16 +634,19 @@ Components:
        highest severity; distinct bugs never merge), and the verifier refute pass
        is the precision counterweight. No LLM/semantic merge — that could
        over-merge two distinct bugs into one, reintroducing the miss.
-       The code-quality lenses (`correctness`, `design-fit`, `test-adequacy`,
-       `blast-radius`) run at `samples: 1`. A second opus detection sample was the
-       panel's single largest cost — detection dominated one L-size PR's ~$14
-       panel (#605, surfaced by the per-lens token attribution above) — while a
-       missed code defect is already backstopped by the verifier, the tests, and
-       CI. `security` deliberately keeps `samples: 2`: a planted instruction or a
-       pasted secret it non-deterministically misses has no other backstop, and it
-       is one of the cheaper lenses, so the recall insurance is worth the marginal
-       cost. The knob is per-lens, so this split is a one-field change to revisit
-       once the attribution table shows the effect.
+       Every blocking lens runs at `samples: 1`. A second opus detection sample
+       was the panel's single largest cost — detection dominated one L-size PR's
+       ~$14 panel (#605, surfaced by the per-lens token attribution above) — so the
+       second sample was dropped across the board to keep a panel runnable within
+       one session limit. The recall the union bought is given up: a defect a
+       single sample non-deterministically misses is no longer recovered by a
+       second one. For the code-quality lenses the verifier, the tests, and CI
+       still backstop a miss; for `security` there is **no** such backstop — a
+       planted instruction or a pasted secret missed on the one sample is missed —
+       so this is the sharpest edge of the trade, accepted for cost. `samples` is a
+       per-lens field, so raising `security` (or any lens) back to 2 is a one-field
+       change the moment the attribution table or a missed finding says it is worth
+       the spend.
     2. **Cross-round re-check.** Each round persists its blocking findings in the
        per-lens check run's `output.text`; the next round reads the latest prior
        `agent-review-<lens>` findings (`scripts/agent/prior-findings.mjs` →

--- a/docs/tasks/active/20260731-reduce-lens-samples-lessons.md
+++ b/docs/tasks/active/20260731-reduce-lens-samples-lessons.md
@@ -11,7 +11,9 @@
       `samples: 1` is honored (`Math.max(1, floor)`), so this was a data-only change —
       no code, no test churn (388/388 still green).
 
-- [x] **Recall vs cost is a per-lens call, not a global one.** Uniformly dropping to
-      1 would have weakened the injection/secret gate, which has no verifier/test/CI
-      backstop. Keeping `security` at 2 while cutting the code lenses preserves the
-      one place non-determinism is unrecoverable, for little cost.
+- [x] **Recall vs cost is a per-lens call.** The code lenses have a
+      verifier/test/CI backstop for a missed finding; `security` does not, so its
+      second sample was the one worth keeping on cost/safety grounds. It was
+      ultimately dropped too, on request — a deliberate, documented acceptance of
+      that risk, not an oversight — and the per-lens knob makes it reversible the
+      moment a missed injection/secret says otherwise.

--- a/docs/tasks/active/20260731-reduce-lens-samples-todo.md
+++ b/docs/tasks/active/20260731-reduce-lens-samples-todo.md
@@ -1,4 +1,4 @@
-# Reduce review-lens detection samples 2 → 1 (keep security at 2)
+# Reduce review-lens detection samples 2 → 1 (all lenses)
 
 The review panel is expensive enough that two runs exhaust a session limit. On
 #605 (L-size PR) the panel cost **~$14 / 428 turns / 73 min for one round**, its
@@ -11,20 +11,23 @@ verifier**: $11.60 detection vs $2.74 verifier, dominated by `correctness` $3.81
 ## The change
 
 - [x] `scripts/agent/lenses/lenses.json`: `correctness`, `design-fit`,
-      `test-adequacy`, `blast-radius` → `samples: 1`. `security` stays `samples: 2`;
-      `docs` was already 1.
-- [x] Design-doc note (`harness-engineering.md`, sampling section) explaining the
-      split and its rationale.
+      `test-adequacy`, `blast-radius` → `samples: 1` (**#607, merged**).
+- [x] `security` → `samples: 1` as well (this follow-up), on request.
+      `docs` was already 1, so every blocking lens is now single-sample.
+- [x] Design-doc note (`harness-engineering.md`, sampling section) updated to
+      reflect all-lenses single-sample and the accepted `security` tradeoff.
 
-## Why this split
+## Why
 
 `samples: 2` + union exists to raise recall against single-sample non-determinism
 (the #521 false negative). Reducing to 1 trades some recall for ~halved detection
-cost. The trade is acceptable for the code-quality lenses because a missed defect
-there is already backstopped by the **verifier**, the **tests**, and **CI**.
-`security` is the exception — a planted instruction or a pasted secret it misses
-has *no* other backstop — and it is one of the cheaper lenses, so keeping its
-second sample costs little.
+cost. The trade is safest for the code-quality lenses because a missed defect there
+is already backstopped by the **verifier**, the **tests**, and **CI**.
+
+`security` was initially kept at 2 for exactly one reason — a planted instruction
+or a pasted secret it misses has *no* backstop — but was **also dropped to 1** on
+request, accepting that sharper edge for the cost. The knob is per-lens, so raising
+it back is a one-field change if injection/secret misses appear.
 
 Secondary benefit: fewer raw findings per round → less load on the verifier,
 which is what was hitting 429s.
@@ -34,5 +37,5 @@ which is what was hitting 429s.
 - The docs lens `error_max_turns` page (the proximate #605 trigger) is a separate
   fix — either raise `docs.maxTurns` or stop a detection turn-limit from failing
   the whole lens closed as a blocking no-verdict.
-- Whether to also drop `correctness`/`security` further is left for the attribution
-  table to inform; the knob is per-lens.
+- Whether any lens should go back to 2 is left for the attribution table (or a
+  missed finding) to inform; the knob is per-lens.

--- a/scripts/agent/lenses/lenses.json
+++ b/scripts/agent/lenses/lenses.json
@@ -17,7 +17,7 @@
     "appliesWhen": ["**"],
     "scopeClasses": ["code", "code-adjacent", "policy", "design-spec", "prose"],
     "model": "claude-opus-5",
-    "samples": 2
+    "samples": 1
   },
   {
     "id": "design-fit",


### PR DESCRIPTION
## Summary

Follow-up to **#607** (merged), which cut the code-quality lenses to `samples: 1` but **kept `security` at 2**. This drops `security` to 1 as well, on request — so every blocking review lens is now single-sample.

## Change

One field in `scripts/agent/lenses/lenses.json` (`security`: `2 → 1`) plus the design-doc note and task files updated to match. Final state:

| Lens | samples |
|---|---|
| correctness, security, design-fit, test-adequacy, blast-radius | **1** |
| docs | 1 (already) |

## The tradeoff (accepted, and reversible)

`security` was the one lens #607 deliberately left at 2, because `samples: 2` + union is the only recall guard against single-sample non-determinism there — a planted instruction or pasted secret it misses on one sample has **no** verifier/test/CI backstop the way a code defect does. Dropping to 1 accepts that edge for the cost of a panel that fits within one session limit.

`samples` is a per-lens field, so raising `security` back to 2 is a one-line change the moment the token-attribution table or a missed finding says it's worth the spend.

## Test plan

- Data-only manifest change; `sampleCountFor` honors `samples: 1` and is unit-tested against synthetic lenses, so no code/test churn.
- Full agent suite: `cd scripts/agent && node --test *.test.mjs` → **388/388 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated review-lens guidance to use one sample for all lenses.
  * Documented the associated cost and detection-recall tradeoffs.
  * Recorded the accepted, reversible reduction for security reviews and criteria for future increases.

* **Configuration**
  * Reduced security review sampling from two samples to one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->