### PR TITLE
Raise the verifier's presence turn ceiling from 8 to 20

### DIFF
--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -1577,15 +1577,32 @@ export function createWarmupGate() {
 // judging ONE finding, and an unbounded budget multiplies across every blocking
 // finding in every round.
 //
-// ABSENCE claims get more. Refuting "there is no X" means FINDING an X, which is
-// a search across the repository, while refuting a presence claim is a lookup at
-// a location the finding already names. On #578 the false "no CI workflow runs
-// these tests" survived precisely here: the counterexample is real and
-// reachable — ci.yml -> `pnpm verify:self` -> verify-self.mjs -> the agent:tests
-// lane — but that is three hops plus the reads to confirm each, and the verifier
-// ran out of turns, so bias-to-keep confirmed a false claim. Absence claims are
-// the minority, so the extra ceiling is bounded in practice.
-export const VERIFIER_MAX_TURNS = { presence: 8, absence: 20 };
+// ABSENCE claims were given more on the theory that refuting "there is no X"
+// means FINDING an X — a search across the repository — while refuting a presence
+// claim is a lookup at a location the finding already names. The absence half of
+// that is well evidenced: on #578 the false "no CI workflow runs these tests"
+// survived precisely here, because its counterexample is real and reachable
+// (ci.yml -> `pnpm verify:self` -> verify-self.mjs -> the agent:tests lane) but
+// three hops away, and the verifier ran out of turns, so bias-to-keep confirmed a
+// false claim.
+//
+// The PRESENCE half was wrong, and `presence: 8` came from it. Measured over one
+// round (`review-execution.json`, run 30610776868): 8 of 18 verifications died on
+// `error_max_turns`, every one of them at exactly 9 turns — this ceiling. They
+// burned $1.93 and returned no verdict, so their findings reached the gate
+// unfiltered while the summary reported an "outage". A lookup is evidently not
+// what this job is: locating the code, reading enough around it to judge the
+// claim, and citing a `file:line` costs more than 8 turns far more often than not.
+//
+// So presence is raised to the value already proven sufficient for the HARDER job.
+// It is not tuned to a measured presence distribution, because there isn't one:
+// nothing has been allowed past 9 turns, so every successful verification observed
+// (10 through 22 turns) was necessarily an absence claim. 20 is the defensible
+// choice precisely because any smaller number would be invented.
+//
+// The two keys stay separate at equal values. They encode different jobs and will
+// diverge again once presence claims have a distribution of their own to read.
+export const VERIFIER_MAX_TURNS = { presence: 20, absence: 20 };
 
 /** `presence` unless the finding explicitly says otherwise. */
 export function claimTypeOf(finding) {

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -1880,12 +1880,33 @@ test("claimTypeOf: absence only when the finding says so", () => {
   }
 });
 
-test("absence claims get a larger turn budget than presence claims", () => {
+test("no claim type verifies on a budget that measurement showed is too small", () => {
   // #578's false "no CI workflow runs these tests" had a real counterexample
   // three hops away (ci.yml → verify:self → verify-self.mjs → agent:tests) and
   // confirmed because the verifier ran out of turns, not because it was right.
-  assert.ok(VERIFIER_MAX_TURNS.absence > VERIFIER_MAX_TURNS.presence);
-  assert.equal(VERIFIER_MAX_TURNS.presence, 8);
+  // That is why ABSENCE got 20.
+  //
+  // PRESENCE was 8, on the theory that it is only a lookup. Measured over one
+  // round (review-execution.json, run 30610776868): 8 of 18 verifications died on
+  // error_max_turns, all at exactly 9 turns — this ceiling — burning $1.93 for no
+  // verdict. `absence > presence` is therefore no longer asserted: the asymmetry
+  // it encoded was the reasoning that produced the wrong number.
+  assert.ok(VERIFIER_MAX_TURNS.absence >= VERIFIER_MAX_TURNS.presence);
+  // Literal pins, so lowering either one has to break a test and be argued for.
+  assert.equal(VERIFIER_MAX_TURNS.presence, 20);
+  assert.equal(VERIFIER_MAX_TURNS.absence, 20);
+});
+
+test("every claim type maps to a real turn budget", () => {
+  // claimTypeOf returns one of these two and nothing else, so a missing key would
+  // pass `maxTurns: undefined` to the SDK — an unbounded verification, which is
+  // the failure this constant exists to prevent.
+  for (const claimType of ["presence", "absence"]) {
+    const budget = VERIFIER_MAX_TURNS[claimType];
+    assert.equal(typeof budget, "number", claimType);
+    assert.ok(Number.isInteger(budget) && budget > 0, `${claimType} budget must be a positive integer`);
+  }
+  assert.deepEqual(Object.keys(VERIFIER_MAX_TURNS).sort(), ["absence", "presence"]);
 });
 
 test("`unresolved` does NOT drop a finding", () => {


### PR DESCRIPTION
## Summary

`VERIFIER_MAX_TURNS.presence` goes from `8` to `20`, matching `absence`.

## Why

Measured over one panel round (`review-execution.json`, artifact
`review-panel-execution` from run `30610776868`):

| | calls | turns | cost |
|---|---|---|---|
| detection | 6 | 185 | $7.01 |
| verifier — **`error_max_turns`** | **8** | 72 | **$1.93** |
| verifier — success | 10 | 152 | $2.78 |
| **round total** | 24 | **409** | **$11.71** |

**Every one of the 8 failures died at exactly 9 turns** — this ceiling. They burned
$1.93 of an $11.71 round and returned no verdict, so their findings reached the merge
gate unfiltered. The panel reported it honestly (`⚠️ Verifier ERRORED on N of M …
those findings are UNFILTERED rather than confirmed`), but it reads as an API/quota
outage, which is how it has been read.

The number came from a theory stated in the docblock: refuting an absence claim means
finding a counterexample somewhere in the repo, whereas refuting a presence claim is
*"a lookup at a location the finding already names"*. The absence half is well
evidenced — it is why #578's false *"no CI workflow runs these tests"* survived, with
a real counterexample three hops away. The presence half is not. Locating the code,
reading enough around it to judge the claim, and producing a `file:line` citation
costs more than 8 turns far more often than not, and per the `FINDING` schema
presence is the majority claim type — so the verifier has been failing on the common
case, not the edge case.

### Why 20, and not a tuned number

There is no presence distribution to fit. Nothing has ever been allowed past 9 turns,
so **every successful verification observed — 10, 12, 13, 15, 16, 19, 20, 21, 22
turns — was necessarily an absence claim.** Picking 12 or 16 would be inventing a
number; 20 is the value already proven sufficient in production for the strictly
harder job. If a repo-wide hunt fits in 20, a located lookup does.

The two keys stay separate at equal values. They encode different jobs and should
diverge again once presence claims have a distribution of their own to read.

## Linked Issues

None — this came out of a cost analysis of the review panel.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Locally: `cd scripts/agent && node --test *.test.mjs` → **456 pass, 0 fail**. (The 1
skipped test is pre-existing on `main` — confirmed by re-running with this branch's
changes stashed.)

`pnpm verify:fast` was not run locally: it needs a full install in a fresh worktree
and cannot observe either changed file, since `scripts/agent` sits outside the pnpm
workspace and is covered only by the `agent:tests` lane inside `verify:self`.

## Risk Assessment

- **User-facing risk:** none. Changes only the autonomous review panel's internals.
- **Data/security risk:** none.
- **Rollback plan:** revert the single commit; it is one constant and its tests.

**This may raise cost per round while lowering cost per PR, and that is the intended
trade.** Each previously-truncated verification now runs to completion instead of
dying at 9. Worst case at 18 verifications is roughly +$2/round — against $1.93
currently spent on nothing, plus whatever a false finding costs in fixer turns and
extra review rounds downstream. **Read this change on rounds-per-PR, not on
cost-per-round.**

**Recall direction:** this *increases* filtering, so findings that previously survived
on a failed verification can now be refuted away. That is the verifier's designed job,
and `isDroppingVerdict` still requires `refuted` + `high` confidence + a named
`refutationGround` + a real `file:line` in `groundedIn` before anything is dropped.

## Notes for Reviewers

**AI assistance:** this PR was written with Claude Code — the measurement that found
the ceiling, the diff, and the tests.

The existing test did exactly what a literal pin is for — it forced this to be
deliberate:

```js
assert.ok(VERIFIER_MAX_TURNS.absence > VERIFIER_MAX_TURNS.presence);
assert.equal(VERIFIER_MAX_TURNS.presence, 8);
```

Both assertions had to change, and the strict `>` is now `>=`. That is the part worth
arguing about, so to be explicit: **the asymmetry is not disproven — only the
magnitude is.** It remains plausible that absence needs more than presence. What the
data disproves is the *reason* the asymmetry was set where it was, and since that
reasoning is what produced `8`, keeping a strict inequality would mean preserving the
shape of an argument the measurement refuted while having no evidence for any
particular gap. Both literals are still pinned, so lowering either has to break a test
and be argued for.

A second test asserts every `claimTypeOf` output maps to a positive-integer budget:
`claimTypeOf` returns exactly `"presence"` or `"absence"`, and a missing key would
pass `maxTurns: undefined` to the SDK — an unbounded verification, which is the
failure this constant exists to prevent.

- Follow-up work: PR 1 of this series is #613. Next is a round-budget cap
  (`MAX_REVIEW_ROUNDS` 5→3) and splitting the verifier's `errored` counter into
  `api-error` / `turn-limit` / `no-output`, so the effect of *this* change is legible
  in the metrics ledger rather than inferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the verification limit for presence claims to 20 turns, matching the existing limit for absence claims.
  * Improved validation to ensure verification budgets are positive integers and contain only supported claim types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->