### PR TITLE
Record v0.6.2 post-merge release closeout

### DIFF
--- a/docs/tasks/active/20260731-release-v0.6.2-todo.md
+++ b/docs/tasks/active/20260731-release-v0.6.2-todo.md
@@ -87,22 +87,23 @@ pipeline configured.
       notes 38/38 suites pass).
 - [x] Commit on `release/v0.6.2` (version bump + doc archive + target
       fixes; no executable code).
-- [ ] `/code-review` — skip if the diff is version-bump + doc-archive
-      only (no executable code), same as prior releases.
-- [ ] Push + open PR (Summary + Test plan).
+- [x] `/code-review` — skipped: diff is version-bump + doc-archive +
+      target-version fixes only (no executable code), same as prior releases.
+- [x] Push + open PR (Summary + Test plan) — PR #617, merged as `9d6c574a0`.
 
 ## Post-merge release
 
-- [ ] Sync `main`; confirm `main` at `0.6.2`.
-- [ ] Annotated tag `v0.6.2` ("Release v0.6.2") on the merge commit, pushed.
-- [ ] GitHub Release `v0.6.2` published (marked latest) with categorised
+- [x] Sync `main`; confirmed `main` at `0.6.2` (merge commit `9d6c574a0`).
+- [x] Annotated tag `v0.6.2` ("Release v0.6.2") on the merge commit, pushed.
+- [x] GitHub Release `v0.6.2` published (marked latest) with categorised
       highlights + Contributors.
-- [ ] `npm-publish` + `docker-publish` release-triggered runs succeed.
-- [ ] Confirm `@wafflebase/cli@0.6.2` on npm and
+- [x] `npm-publish` + `docker-publish` release-triggered runs succeed.
+- [x] Confirm `@wafflebase/cli@0.6.2` on npm and
       `yorkieteam/wafflebase:v0.6.2` in the registry.
-- [ ] Devops: check whether the backend image pin needs bumping (deploy
-      topology: backend image is manually pinned in `yorkie-team/devops`
-      → ArgoCD; skew breaks doc-open).
+- [ ] Devops: bump the manually-pinned backend image to `v0.6.2` in the
+      `yorkie-team/devops` repo (ArgoCD) — frontend auto-shipped on `main`
+      (GitHub Pages), so a skew breaks document open. **Maintainer action
+      in the separate repo; not done here.**
 
 ## Tasks staying active (genuine remaining work)
 
@@ -121,4 +122,23 @@ pipeline configured.
 
 ## Review
 
-_(fill in as-shipped after the release PR merges)_
+Shipped as **v0.6.2** on 2026-07-31.
+
+- **PR**: #617 "Release v0.6.2", merged into `main` as merge commit
+  `9d6c574a0`. Diff was `.md` + `.json` only (11 `package.json` version
+  bumps, 3 design-doc `target-version` fixes, 49-task archive, release
+  docs) — no executable code, so `/code-review` was skipped per prior-release
+  precedent. `verify:fast` (local) and `verify:self` (pre-push + CI) green.
+- **Window**: `v0.6.1..v0.6.2`, 92 commits. Two new document types
+  (`image` #499, `board` SP1 #606 + new `@wafflebase/board` package) scoped
+  as a **patch** by maintainer call; the bulk of the window is agent/review
+  pipeline dev-infrastructure.
+- **Tag/Release**: annotated tag `v0.6.2` on `9d6c574a0`; GitHub Release
+  published and marked **latest** (`releases/latest` → `v0.6.2`).
+- **Publish**: release-triggered `Publish to npm` + `Docker Publish`
+  workflows — see the checklist above for confirmed artifact status.
+- **Contributors**: 9 authors across the window (both maintainers
+  @hackerwins and @ggyuchive contributed); credited in the GitHub Release.
+- **Deploy**: frontend auto-shipped on `main` via GitHub Pages. Backend
+  image pin bump in `yorkie-team/devops` remains a maintainer action in
+  that repo.


### PR DESCRIPTION
Post-merge bookkeeping for the shipped [v0.6.2 release](https://github.com/wafflebase/wafflebase/releases/tag/v0.6.2) (#617).

Ticks the post-merge checklist and fills the Review section in the release task todo:
- Tag `v0.6.2` pushed; GitHub Release published + marked **latest**.
- `Publish to npm` + `Docker Publish` succeeded — `@wafflebase/cli@0.6.2` (npm `latest`) and `yorkieteam/wafflebase:v0.6.2` confirmed.
- Backend image pin bump tracked in yorkie-team/devops#332.

Doc-only (`.md`); no executable code.

## Test plan
- Doc-only change; `verify:self` runs on push/CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v0.6.2 release checklist with completed release, publishing, validation, and deployment details.
  * Documented the release classification, timing, tag, contributors, and remaining external deployment task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->