### PR TITLE
Widen the documents-list selection checkbox hit area to 32x32

### DIFF
--- a/docs/design/workspace-folders.md
+++ b/docs/design/workspace-folders.md
@@ -238,6 +238,14 @@ store needed — unlike the upload queue, selection doesn't outlive the list).
 - **Row click still opens the document** (unchanged). Only the checkbox mutates
   selection. This is the Gmail/Drive-list model and keeps the existing behavior
   intact.
+- Because row click opens the document, a *miss* on the checkbox navigates away
+  and takes the selection with it. The painted 16×16 box therefore carries a
+  transparent `::after` overlay giving it a **32×32 hit area**, the size of the
+  row's more-actions button. The box itself is not resized, so row alignment
+  and the existing handlers are untouched.
+- **Body rows only.** The header has no click handler to fall through to, and
+  there the overlay would cross into the Title column and swallow clicks on
+  `SortableHeader`'s sort button.
 
 ### Frontend — bulk action bar
 

--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -664,7 +664,10 @@ export function DocumentList({
         />
       ),
       cell: ({ row, table }) => (
+        // A miss on the 16x16 box opens the document instead of selecting it,
+        // so `::after` widens the hit area to 32x32 without resizing the box.
         <Checkbox
+          className="relative after:absolute after:top-1/2 after:left-1/2 after:size-8 after:-translate-x-1/2 after:-translate-y-1/2 after:content-['']"
           checked={row.getIsSelected()}
           onCheckedChange={(v) => row.toggleSelected(!!v)}
           onClick={(e) => {


### PR DESCRIPTION
## Summary

Gives the documents-list row-selection checkbox a 32×32 hit area — the same
size as the row's more-actions button — via a transparent `::after` overlay,
instead of resizing the painted 16×16 box.

## Why

The checkbox renders as a bare Radix `<button role="checkbox">` styled
`size-4`, so its clickable region was exactly the box that is painted.

Missing it is not a no-op. The table row carries its own `onClick` that opens
the document and only bails out when the click target is inside
`input, button`, so a click a few pixels off the checkbox fell through to the
row handler, navigated away from the list, and discarded whatever
multi-selection had been built up.

A pseudo-element is hit-tested as part of its originating element, so the
existing `onClick`, shift-click range logic, and `stopPropagation` keep working
untouched, and the painted size and row alignment are unchanged.

Three details worth flagging for review:

- **The overlay is centred and sized (`after:size-8` + half translate) rather
  than given a negative inset.** `inset` resolves against the positioned
  ancestor's *padding* box, which the checkbox's 1px border makes 14px wide, so
  the obvious `after:-inset-2` yields 30×30 rather than 32×32.
- **Body rows only.** The header row has no click handler to fall through to,
  so a near-miss on select-all is already harmless — and there the overlay
  would reach past the column edge (`TableHead` drops the right padding around
  a checkbox) and swallow clicks on the Title sort button, whose `-ml-3` hangs
  it back into exactly that strip. Measured at 7px of the sort button stolen at
  a 500px viewport and 11px at 380px.
- **`table.tsx` is deliberately untouched.** `TableCell` / `TableHead` carry two
  checkbox-only utilities — `[&:has([role=checkbox])]:pr-0` and
  `[&>[role=checkbox]]:translate-y-[2px]` — that in practice apply to this list
  alone, since it is the only place in the app with a checkbox inside a table.
  Neither is made redundant here: they govern column width and the box's
  vertical nudge, whereas this change only adds a transparent overlay. Dropping
  them would widen the select column and shift the checkbox 2px, so it is a
  visual change to decide separately rather than a cleanup implied by this fix.

## Linked Issues

Fixes #620

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

Skip reason (if applicable): n/a — no backend or DB paths touched.

Locally, beyond `verify:fast` / `verify:self`, the geometry was measured in
Chromium against the **production bundle CSS**, driving the exact class string
read out of `document-list.tsx`:

| viewport | `::after` | painted box | row height | gap to title icon |
| --- | --- | --- | --- | --- |
| 1200px | 32×32 | 16×16 | 48.5px | 95.7px |
| 500px | 32×32 | 16×16 | 48.5px | 25.9px |
| 380px | 32×32 | 16×16 | 48.5px | 13.9px |

In the same run the neighbouring row's checkbox and the more-actions button
both stayed clickable, and clicks on the title icon still fell through to the
row (opening the document) at every width.

## Risk Assessment

- User-facing risk: low. CSS-only, scoped to one column of one list. The
  overlay is transparent and does not change what is painted; the widest
  reach (380px) still stops 13.9px short of the title icon.
- Data/security risk: none.
- Rollback plan: revert the commit — the class string is the whole change.

## Notes for Reviewers

- UI changes: nothing visible changes. The only difference is where a click
  registers, which a screenshot cannot show.
- AI assistance: written with Claude Code, including the Chromium measurements
  above and a review pass that caught the header-row collision described in
  *Why*.
- Follow-up work: dropping the `pr-0` described in *Why* would keep the overlay
  inside the select column and let the header select-all get the same 32×32
  target. Happy to open a separate issue for it if reviewers agree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the clickable area for document row selection checkboxes while keeping their existing visual size and behavior.
  * Preserved sortable title-header interactions by excluding the header checkbox from the expanded hit area.

* **Documentation**
  * Updated the bulk-selection specification to document the enlarged checkbox hit areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->