### PR TITLE
Pluralize the Note and PDF document-type filter labels

### DIFF
--- a/packages/frontend/src/app/documents/document-list.tsx
+++ b/packages/frontend/src/app/documents/document-list.tsx
@@ -168,9 +168,9 @@ const TYPE_META: Record<
 > = {
   sheet: { label: "Sheets", Icon: Sheet, color: "text-green-600" },
   doc: { label: "Docs", Icon: FileText, color: "text-blue-500" },
-  note: { label: "Note", Icon: NotebookPen, color: "text-purple-500" },
+  note: { label: "Notes", Icon: NotebookPen, color: "text-purple-500" },
   slides: { label: "Slides", Icon: Presentation, color: "text-orange-500" },
-  pdf: { label: "PDF", Icon: IconFileTypePdf, color: "text-red-500" },
+  pdf: { label: "PDFs", Icon: IconFileTypePdf, color: "text-red-500" },
   image: { label: "Images", Icon: ImageIcon, color: "text-pink-500" },
   board: { label: "Boards", Icon: Frame, color: "text-fuchsia-600" },
 };


### PR DESCRIPTION
## Summary

On the documents list, the document-type filter chips label every type in the
plural — **Sheets, Docs, Slides, Images, Boards** — except **Notes** and
**PDFs**, whose tooltips/aria-labels read the singular "Note" and "PDF". This
pluralizes both so the filter is consistent.

- `note`: `"Note"` → `"Notes"`
- `pdf`: `"PDF"` → `"PDFs"`

`TYPE_META.label` is the single source of truth for the filter chips
(`aria-label="Filter by …"` + tooltip); the type badge in the title cell uses
only the icon/color, so this touches only the filter chips.

## Test plan
- `pnpm verify:fast` green (pre-commit hook); `verify:self` green (pre-push).
- No tests referenced the old singular strings; `label` has no other consumers.
- Filter tooltips now read: Sheets · Docs · Notes · Slides · PDFs · Images · Boards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)