### PR TITLE
Sync 27 significant-drift design docs to shipped scope

### DIFF
--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -214,14 +214,20 @@ Share-link authority mirrors the document model — see
 
 #### DataSources (`/datasources`)
 
-All endpoints require `JwtAuthGuard`. Ownership is enforced on every request.
+All endpoints require `JwtAuthGuard`. Access is **workspace-scoped**: each
+route resolves the datasource's `workspaceId` and calls
+`WorkspaceService.assertMember`, so any member of the owning workspace has full
+access (datasources are owned by a workspace, not by their author). Companion
+workspace-scoped routes (`POST`/`GET /workspaces/:workspaceId/datasources`) list
+and create within one workspace.
 
 **`POST /datasources`**
 - Body: `{ name, host, port?, database, username, password, sslEnabled? }`
 - Creates a datasource connection. Password is encrypted with AES-256-GCM.
 
 **`GET /datasources`**
-- Returns all datasources owned by the authenticated user. Passwords are masked.
+- Returns all datasources across every workspace the authenticated user is a
+  member of. Passwords are masked.
 
 **`GET /datasources/:id`**
 - Returns a single datasource. Password is masked.

--- a/docs/design/backend.md
+++ b/docs/design/backend.md
@@ -38,6 +38,17 @@ flowchart TD
   APP --> DOC["DocumentModule"]
   APP --> SHARE["ShareLinkModule"]
   APP --> DSRC["DataSourceModule"]
+  APP --> WS["WorkspaceModule"]
+  APP --> AK["ApiKeyModule"]
+  APP --> YK["YorkieModule"]
+  APP --> V1["ApiV1Module"]
+  APP --> IMG["ImageModule"]
+  APP --> FILE["FileModule"]
+  APP --> HEALTH["HealthModule"]
+  APP --> UDS["UserDocStylesModule"]
+  APP --> ANL["AnalyticsModule"]
+  APP --> FLD["FolderModule"]
+  APP --> MIRO["MiroModule"]
 
   AUTH --> JWT_MOD["JwtModule (access token expiry)"]
   AUTH --> USER_MOD["UserModule"]
@@ -63,14 +74,27 @@ flowchart TD
   DSRC --> PS4["PrismaService"]
 ```
 
+The diagram highlights the auth/document/share/datasource spine; `AppModule`
+imports the full module set listed below.
+
 | Module | Responsibility |
 |--------|---------------|
-| **AppModule** | Root module. Imports ConfigModule (global), AuthModule, DocumentModule, ShareLinkModule, DataSourceModule. |
+| **AppModule** | Root module. Imports ConfigModule (global), LoggerModule (nestjs-pino), ThrottlerModule, plus the feature modules: AuthModule, DocumentModule, ShareLinkModule, DataSourceModule, WorkspaceModule, ApiKeyModule, YorkieModule, ApiV1Module, ImageModule, FileModule, HealthModule, UserDocStylesModule, AnalyticsModule, FolderModule, MiroModule. |
 | **AuthModule** | GitHub OAuth + JWT authentication. Provides AuthService, GitHubStrategy, JwtStrategy. Imports UserModule for user lookup/creation. |
 | **UserModule** | User CRUD via Prisma. Exports UserService for use by AuthModule and DocumentModule. |
 | **DocumentModule** | Document REST endpoints. Uses DocumentService + UserService + PrismaService. |
 | **ShareLinkModule** | URL-based document sharing with token-based access. Manages share link CRUD and public token resolution for anonymous access. |
 | **DataSourceModule** | External PostgreSQL connection management. CRUD for connection configs, test connection, execute SELECT queries. Passwords encrypted at rest with AES-256-GCM. |
+| **WorkspaceModule** | Workspaces, members, invites, and role resolution — the backbone of the workspace access model. |
+| **ApiKeyModule** | Workspace-scoped API keys (`wfb_…`) for external/CLI access; generation, hashing, validation. |
+| **YorkieModule** | Global Yorkie client (`withDocument(id, cb)`), the auth/event webhook surface, and server-side document reads. |
+| **ApiV1Module** | REST API v1 (`/api/v1/…`) documents/tabs/cells over Yorkie, accepting JWT or API-key auth. |
+| **ImageModule** / **FileModule** | Blob storage for embedded images and static file document types (pdf/image). |
+| **HealthModule** | Liveness/readiness probes (`/health`, `/health/ready`). |
+| **UserDocStylesModule** | Per-user default docs named styles. |
+| **AnalyticsModule** | View-event Kafka producer + StarRocks reader (share-link analytics). |
+| **FolderModule** | Workspace folder tree (organizational document grouping). |
+| **MiroModule** | Miro board import support. |
 
 ### API Reference
 
@@ -102,6 +126,25 @@ flowchart TD
 **`POST /auth/logout`**
 - Guard: none (public endpoint)
 - Clears `wafflebase_session` and `wafflebase_refresh`.
+
+**`GET /auth/yorkie-token`**
+- Guard: `JwtAuthGuard`
+- Mints a short-lived token for the Yorkie client's `authTokenInjector` — the
+  session JWT lives in an httpOnly cookie the browser can't read, so the
+  frontend fetches this instead. The Yorkie auth webhook resolves per-document
+  access from the returned token (see [yorkie-auth-webhook.md](yorkie-auth-webhook.md)).
+
+**`POST /auth/yorkie-token/share`**
+- Guard: none (public — no session)
+- Body: `{ token }` (a share token). Returns a short-lived Yorkie token that
+  wraps the share token; the webhook does the real validation (existence,
+  expiry, document match, role). POST keeps the access-granting token out of
+  request URLs and access logs.
+
+**`POST /auth/cli/exchange`**
+- Guard: none (public — one-time CLI auth code)
+- Body: `{ code }`. Exchanges a one-time code minted during the CLI OAuth flow
+  for `{ accessToken, refreshToken }`. Rate-limited to 10 req/60s/IP.
 
 #### Documents (`/documents`)
 
@@ -341,8 +384,13 @@ erDiagram
     Document {
         String id PK "uuid"
         String title
+        String type "default: sheet"
+        String fileId "nullable, blob key for pdf/image"
         Int authorID FK "nullable"
+        String workspaceId FK
+        String folderId FK "nullable, null = root"
         DateTime createdAt "default: now()"
+        DateTime updatedAt "from Yorkie event webhook"
     }
     ShareLink {
         String id PK "uuid"
@@ -363,12 +411,64 @@ erDiagram
         String password "AES-256-GCM encrypted"
         Boolean sslEnabled "default: false"
         Int authorID FK
+        String workspaceId FK
         DateTime createdAt "default: now()"
+        DateTime updatedAt
+    }
+    Workspace {
+        String id PK "uuid"
+        String name
+        String slug UK
+        DateTime createdAt "default: now()"
+    }
+    WorkspaceMember {
+        String id PK "uuid"
+        String role
+        String workspaceId FK
+        Int userId FK
+        DateTime joinedAt "default: now()"
+    }
+    WorkspaceInvite {
+        String id PK "uuid"
+        String token UK "uuid"
+        String role
+        String workspaceId FK
+        Int createdBy FK
+        DateTime expiresAt "nullable"
+    }
+    ApiKey {
+        String id PK "uuid"
+        String prefix
+        String hashedKey UK
+        String workspaceId FK
+        Int createdBy FK
+        String[] scopes "default: read, write"
+        DateTime revokedAt "nullable"
+    }
+    Folder {
+        String id PK "uuid"
+        String name
+        String workspaceId FK
+        String parentId FK "nullable, FolderTree"
+        Int authorID FK "nullable"
+    }
+    UserDocStyles {
+        Int userId PK "FK to User"
+        Json styles
         DateTime updatedAt
     }
     User ||--o{ Document : "author"
     User ||--o{ ShareLink : "creator"
     User ||--o{ DataSource : "author"
+    User ||--o{ WorkspaceMember : "membership"
+    User ||--o| UserDocStyles : "defaults"
+    Workspace ||--o{ WorkspaceMember : "members"
+    Workspace ||--o{ WorkspaceInvite : "invites"
+    Workspace ||--o{ ApiKey : "apiKeys"
+    Workspace ||--o{ Document : "documents"
+    Workspace ||--o{ Folder : "folders"
+    Workspace ||--o{ DataSource : "datasources"
+    Folder ||--o{ Document : "documents"
     Document ||--o{ ShareLink : "shareLinks"
 ```
 
@@ -380,9 +480,17 @@ erDiagram
 
 **Document:**
 - `id` — UUID primary key (auto-generated).
+- `type` — Document type, default `"sheet"` (sheet/doc/slide/note/board/pdf/image).
+- `fileId` — Nullable blob-storage key for static file types (pdf/image).
 - `authorID` — Nullable foreign key to User. Nullable so documents can survive
   user deletion.
+- `workspaceId` — Foreign key to Workspace (cascade). Every document belongs to a
+  workspace — the basis of the access model.
+- `folderId` — Nullable foreign key to Folder (`SetNull`); `null` = workspace root.
 - `createdAt` — Auto-set on creation.
+- `updatedAt` — Last-modified time, set explicitly from Yorkie's
+  `DocumentRootChanged` event webhook (not Prisma's `@updatedAt`, since content
+  edits never pass through this backend). Used to order the documents list.
 
 **ShareLink:**
 - `id` — UUID primary key (auto-generated).
@@ -391,6 +499,26 @@ erDiagram
 - `documentId` — Foreign key to Document. Cascade-deletes when document is deleted.
 - `createdBy` — Foreign key to User (the document owner who created the link).
 - `expiresAt` — Optional expiration timestamp. `null` means no expiration.
+
+**Workspace / WorkspaceMember / WorkspaceInvite:**
+- `Workspace` — Top-level tenant (unique `slug`) owning documents, folders,
+  datasources, and API keys.
+- `WorkspaceMember` — Join row carrying a per-user `role` (unique on
+  `[workspaceId, userId]`); this is what `WorkspaceService.assertMember` and the
+  manager checks resolve against.
+- `WorkspaceInvite` — Tokenized, optionally-expiring invitation to join a
+  workspace with a given `role`.
+
+**ApiKey:**
+- Workspace-scoped external credential (`wfb_…`). Stores only `prefix` +
+  unique `hashedKey` (SHA-256), a `scopes` array (default `["read", "write"]`),
+  and a nullable `revokedAt` soft-revoke timestamp.
+
+**Folder / UserDocStyles:**
+- `Folder` — Workspace-scoped organizational tree (self-referential `parentId`
+  via the `FolderTree` relation); purely organizational, no permission effect.
+- `UserDocStyles` — Per-user default docs named styles, a single `Json` blob
+  keyed by `userId`.
 
 ### Environment Configuration
 
@@ -469,7 +597,7 @@ more providers (Google, email/password) requires adding new Passport
 strategies and updating the `authProvider` field. The architecture supports
 this via Passport's multi-strategy pattern.
 
-**Single-bucket rate limiting** — A single `default` bucket (60 req/min/IP)
+**Single-bucket rate limiting** — A single `default` bucket (120 req/min/IP)
 guards every route, with `@Throttle({ default: { limit: 10, ttl: 60_000 } })`
 overrides on auth endpoints. `/api/v1/*` and authenticated app traffic
 currently share this bucket; a per-API-key bucket is a planned follow-up.

--- a/docs/design/board/board-whiteboard-elements.md
+++ b/docs/design/board/board-whiteboard-elements.md
@@ -74,8 +74,9 @@ images — with `pnpm verify:self` green.
 ```text
 packages/frontend/src/app/board/     (all SP2 code lives here + board pkg)
   ├─ board-toolbar.tsx      + Sticky split-button, + Image button
-  ├─ board-view.tsx         + mount setupSlidesImagePaths, + <BoardMinimap/>
-  ├─ board-detail.tsx       pass uploadFn (uploadImageFile bound to workspaceId)
+  ├─ board-view.tsx         + mount setupSlidesImagePaths, + <BoardMinimap/>, wire makeBoardImageUpload
+  ├─ board-detail.tsx       pass workspaceId down to BoardView
+  ├─ board-image.ts   NEW   makeBoardImageUpload(workspaceId) upload adapter
   ├─ sticky.ts        NEW   sticky color palette + buildStickyInit(color, center)
   ├─ board-minimap.tsx NEW  view-local overview overlay + viewport-rect drag
   └─ minimap-geometry.ts NEW  pure world↔minimap mapping + fitted transform
@@ -83,10 +84,14 @@ packages/frontend/src/app/board/     (all SP2 code lives here + board pkg)
 packages/board/src/view/viewport.ts  (reused; may gain a setViewport helper)
         │ imports
         ▼
-@wafflebase/slides   REUSED unchanged:
-  insert-image.ts (insertImageOnSlide), slides-image-input.ts (setupSlidesImagePaths),
-  image-upload.ts (uploadImageFile), model/element.ts (ShapeElement/roundRect/Fill/
-  DropShadow/TextBody), view/canvas/slide-renderer.ts (drawSlide),
+Reused frontend-app image pipeline (NOT in @wafflebase/slides):
+  packages/frontend/src/app/slides/insert-image.ts (insertImageOnSlide),
+  packages/frontend/src/app/slides/slides-image-input.ts (setupSlidesImagePaths),
+  packages/frontend/src/app/spreadsheet/image-upload.ts (uploadImageFile)
+
+@wafflebase/slides   REUSED unchanged (scene engine):
+  model/element.ts (ShapeElement/roundRect/Fill/DropShadow/TextBody),
+  view/canvas/slide-renderer.ts (drawSlide),
   view/canvas/thumbnail.ts (renderThumbnail), model/frame.ts (combinedBoundingBox),
   view/canvas/viewport.ts (screenToWorld)
 ```
@@ -162,8 +167,10 @@ Three entry points, all funneling to the shipped `insertImageOnSlide`:
   `insertImageOnSlide({ store, slideId: SYNTHETIC_SLIDE_ID, file, upload })`.
   Omitted entirely when `readOnly`.
 
-`upload` is built in `board-detail.tsx` from the workspace it already has:
-`const upload = (file) => uploadImageFile(file, workspaceId)`. Insert position:
+`upload` is built by `makeBoardImageUpload(workspaceId)` in
+`packages/frontend/src/app/board/board-image.ts` (which wraps `uploadImageFile`);
+`board-detail.tsx` passes `workspaceId` down to `board-view.tsx`, where the
+adapter is wired. Insert position:
 `insertImageOnSlide` centers within a logical height; on a board we center on the
 current viewport (pass the viewport-center world point through
 `InsertImageArgs`, mirroring the sticky center computation) so the image lands
@@ -181,14 +188,15 @@ on-screen rather than at world origin.
 200×150 px) containing a downscaled snapshot of the whole scene plus the current
 viewport rectangle.
 
-**Geometry (`minimap-geometry.ts`, pure + unit-tested):**
-- `sceneBounds = combinedBoundingBox(elements.map(e => e.frame))` — the world
-  AABB of everything (padded by a margin). `undefined` when the board is empty.
-- `fit(sceneBounds, minimapSize)` → a `{ scale, offsetX, offsetY }` that maps
-  world → minimap px (letterboxed to preserve aspect).
-- `viewportRectInMinimap(vp, hostSize, fit)` — the on-screen world rect
+**Geometry (`packages/frontend/src/app/board/minimap-geometry.ts`, pure + unit-tested):**
+- `sceneBounds(frames, pad)` — the world AABB of everything (padded by a margin).
+  `undefined` when the board is empty.
+- `fitScene(bounds, minimapSize)` → a `{ scale, offsetX, offsetY }` (`MiniFit`)
+  that maps world → minimap px (letterboxed to preserve aspect).
+- `viewportRectInMini(vp, hostSize, fit)` — the on-screen world rect
   (`screenToWorld` of the two host corners) mapped into minimap px.
-- Inverse `minimapPointToWorld(px, fit)` for drag-to-pan.
+- `worldToMini(fit, p)` / inverse `miniToWorld(fit, p)` for drag-to-pan, plus
+  `centerViewportOnWorld` to recenter the viewport.
 
 **Rendering:** draw the scene into a small offscreen canvas via `drawSlide` /
 `renderThumbnail` with a viewport constructed from `fit` (`zoom = scale`,
@@ -198,7 +206,7 @@ and triggered on element change + a low-frequency tick; the viewport rectangle
 overlay repaints on every pan/zoom (cheap).
 
 **Interaction:** dragging inside the minimap recenters the board viewport
-(`minimapPointToWorld` → set `vp.panX/panY` so that world point is at host
+(`miniToWorld` → `centerViewportOnWorld` so that world point is at host
 center → `editor.setViewport` + `editor.render`). A **toggle button** (on by
 default) collapses it to a small chevron. Empty board (`sceneBounds ===
 undefined`) → minimap hidden or shows an empty placeholder. Shown in read-only.
@@ -218,7 +226,7 @@ undefined`) → minimap hidden or shows an empty placeholder. Shown in read-only
   right fill/shadow/middle-anchor/shrink-autofit and a frame centered on the
   given point; palette has 6 distinct colors.
 - `minimap-geometry.test.ts` — `fit` letterboxing (wide vs tall scenes),
-  round-trip `minimapPointToWorld(worldToMinimap(p)) ≈ p`, viewport-rect mapping
+  round-trip `miniToWorld(worldToMini(p)) ≈ p`, viewport-rect mapping
   for a known viewport, empty-scene `undefined`.
 - Image wiring — a board smoke test that a mocked `upload` + `insertImageOnSlide`
   adds one `image` element via the board store (the slides paste/drop internals

--- a/docs/design/board/board.md
+++ b/docs/design/board/board.md
@@ -66,9 +66,13 @@ green with no change to slides behavior.
 
 ### Non-Goals (SP1)
 
-- **Sticky notes, freehand drawing, image paste** — SP2.
+- **Sticky notes, freehand drawing, image paste** — deferred to SP2; sticky
+  notes and image paste/drop **have since shipped** (SP2, see
+  [board-whiteboard-elements.md](board-whiteboard-elements.md)).
 - **Miro import** — SP3 (structured import via the Miro REST API; see [board-miro-import.md](board-miro-import.md)).
-- **Minimap, zoom-to-fit-all, presence viewport-follow** — nice-to-have follow-ups.
+- **Minimap, zoom-to-fit-all, presence viewport-follow** — nice-to-have
+  follow-ups; the **minimap has since shipped** (SP2). Zoom-to-fit-all and
+  presence viewport-follow remain unbuilt.
 - **PPTX / PDF export, presentation mode** — slide-deck concepts, not board.
 - **Layouts / masters / placeholders / speaker notes** — dropped from the board
   document model entirely.
@@ -95,7 +99,7 @@ green with no change to slides behavior.
 packages/frontend/src/app/board/   the React mount + CRDT adapter (NOT the board package)
   ├─ board-detail.tsx      route shell (sidebar + header chrome) + DocumentProvider
   ├─ board-view.tsx        mounts the reused slides editor with the board Viewport
-  ├─ board-toolbar.tsx     minimal insert toolbar (Select / Text / Shape / Line)
+  ├─ board-toolbar.tsx     insert toolbar (Select / Text / Sticky ▾ / Image / Shape ▾ / Line ▾)
   └─ yorkie-board-store.ts YorkieBoardStore implements SlidesStore (single synthetic slide)
 ```
 
@@ -184,7 +188,10 @@ interface YorkieBoardRoot {
   not solved here.
 - **Viewport and cursors are presence, not root** — pan/zoom is view-local and
   never touches the CRDT document; peer presence cursors ride the same channel
-  slides already uses.
+  slides already uses. `BoardPresence` (in
+  `packages/frontend/src/types/board-document.ts`) already carries a world-coords
+  `cursor` field, but as of SP1 the client neither publishes it nor paints remote
+  cursor dots — that remains a deferred follow-up.
 
 ### Document-type wiring (traced from `"note"` / `"slides"`)
 

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -468,9 +468,9 @@ PDF export.
 
 #### 6.1 `TextMeasurer` Abstraction in `@wafflebase/docs`
 
-`paginateLayout` and `computeLayout` historically called `ctx.measureText`
-on a 2D Canvas. To allow the CLI (Node) to paginate without a native
-canvas binding, the layout functions take an injectable measurer:
+`computeLayout` historically called `ctx.measureText` on a 2D Canvas. To
+allow the CLI (Node) to lay out text without a native canvas binding, it
+takes an injectable measurer:
 
 ```ts
 // packages/docs/src/view/measurer.ts
@@ -490,8 +490,9 @@ export interface TextMeasurer {
 export class CanvasTextMeasurer implements TextMeasurer { /* … */ }
 ```
 
-`paginateLayout(doc, measurer, options)` and `computeLayout(doc,
-measurer, options)` accept the measurer as a parameter. All existing
+`computeLayout(blocks, measurer, contentWidth, …)` accepts the measurer
+as a parameter; `paginateLayout(layout, pageSetup)` then splits the
+already-computed layout into pages and needs no measurer. All existing
 call sites (renderer, editor, PDF exporter, frontend integration, test
 fixtures) pass a `CanvasTextMeasurer`. Tests that previously relied on
 Canvas mocks use a deterministic stub measurer.
@@ -499,11 +500,12 @@ Canvas mocks use a deterministic stub measurer.
 #### 6.2 `FontkitMeasurer` in the CLI
 
 `packages/cli/src/docs/fontkit-measurer.ts` implements `TextMeasurer` by
-loading fonts through the existing `PdfFonts` module (already a fontkit
-consumer for PDF export). Width is computed as `glyphAdvance ÷
-unitsPerEm × size`. A small in-memory font cache is keyed by
-`${family}|${weight}|${style}`. NotoKR loaders stay lazy so they only
-run when a command actually paginates.
+loading fonts through `fontkit` directly (`fontkit.create()`), keeping
+its own `register()` method and private `fonts` Map rather than reusing
+the PDF exporter's font loader. Width is computed as `advanceWidth ÷
+unitsPerEm × size`. The in-memory font cache is keyed by a lowercased
+`${family}|${weight}|${style}` variant. NotoKR loaders stay lazy so they
+only run when a command actually paginates.
 
 #### 6.3 DOCX Import via Backend Endpoints
 
@@ -528,7 +530,7 @@ confirmation payload in JSON.
 ```text
 1. CLI: HttpClient.getDocContent("abc-123")
 2. Backend: Yorkie attach "doc-abc-123" → return Document JSON
-3. CLI: paginateLayout(doc, FontkitMeasurer)
+3. CLI: computeLayout(blocks, FontkitMeasurer) → paginateLayout(layout, pageSetup)
 4. CLI: select blocks intersecting pages 1-3 (rule from § 6.6)
 5. CLI: blocksToMarkdown(...)
 6. CLI: write to stdout (or --out)
@@ -566,8 +568,9 @@ mapping". Suppressed by `--quiet`.
 
 #### 6.6 Page Slicing Semantics
 
-`--pages 1-3,5` triggers pagination via `paginateLayout(doc,
-FontkitMeasurer)` so the CLI knows each block's `lines[].pageIndex`.
+`--pages 1-3,5` triggers pagination via `computeLayout(blocks,
+FontkitMeasurer)` followed by `paginateLayout(layout, pageSetup)` so the
+CLI knows each block's `lines[].pageIndex`.
 Slicing behavior is format-aware:
 
 | Format  | Slicing rule                                                                                          |
@@ -614,22 +617,27 @@ packages/cli/
       docx-import.ts     importDocx + base64 ImageUploader + InvalidDocxError
       import.ts          runDocsImport orchestrator (POST + PUT, --replace flow)
       paginate.ts        paginateForCli helper (computeLayout + paginateLayout)
+      page-range.ts      parsePageRange (1-3,5,7-9 + clamp warnings)
+      page-slice.ts      sliceBlocksByPages
+      fontkit-measurer.ts FontkitMeasurer (TextMeasurer for Node)
+      image-fetcher.ts   Fetch remote/data image bytes for inline embedding
+      dom-polyfill.ts    @xmldom/xmldom shim for DocxImporter's DOMParser usage
     slides/              Presentation pipeline
       content.ts         runSlidesContent orchestrator (json + per-slide md/text)
       import.ts          runSlidesImport orchestrator (POST + PUT, --replace flow)
+      pptx-export.ts     exportPptx wrapper (inverse of the PPTX importer)
       pptx-import.ts     importPptx wrapper + base64 image uploader
     notes/               Markdown-note pipeline
       content.ts         runNotesContent orchestrator (json {content} + raw md/text)
       import.ts          runNotesImport orchestrator (POST + PUT, --replace flow)
-      page-range.ts      parsePageRange (1-3,5,7-9 + clamp warnings)
-      page-slice.ts      sliceBlocksByPages
-      fontkit-measurer.ts FontkitMeasurer (TextMeasurer for Node)
-      dom-polyfill.ts    @xmldom/xmldom shim for DocxImporter's DOMParser usage
     client/
       http-client.ts     REST API v1 wrapper (built-in fetch)
       dry-run.ts         Dry-run request printer
     config/
       config.ts          Config file + env + flag resolution
+      session.ts         Session file read/write + token refresh
+    util/
+      csv-parse.ts       CSV parsing helper for sheets import
     output/
       formatter.ts       Format dispatcher (json | table | csv | yaml)
       binary.ts          writeBinary helper for PDF/DOCX exports
@@ -648,6 +656,8 @@ packages/cli/
     recipe-docx-to-pdf.md / recipe-doc-to-markdown.md
   scripts/
     gen-sample-docx.mjs  One-shot generator for the integration .docx fixture
+    gen-sample-pptx.mjs  One-shot generator for the integration .pptx fixture
+    debug-cmd.mjs        Local command-runner helper for manual CLI debugging
 ```
 
 **Root pnpm scripts**:

--- a/docs/design/comments-mentions.md
+++ b/docs/design/comments-mentions.md
@@ -106,11 +106,31 @@ function mentionBodyToPlainText(body: string): string;
 
 // extract userIds referenced in a body (for future notification work)
 function extractMentionedUserIds(body: string): string[];
+
+// inspect text up to the caret; return the in-progress "@query" (and the
+// index of its "@"), or null when the caret is not inside one — drives the
+// dropdown trigger.
+function detectMentionQuery(
+  text: string,
+  caret: number,
+): { query: string; start: number } | null;
+
+// rewrite each still-present "@username" of a selected mention into a
+// "@[username](userId)" token at submit time (approach B — tokenize on
+// submit); edited mentions are left as plain text.
+function applySelectedMentions(
+  body: string,
+  mentions: ReadonlyArray<MentionRef>,
+): string;
 ```
 
 `extractMentionedUserIds` is included now because it is trivial and is the
 single integration point a future notification feature needs — but nothing
-in this PR consumes it beyond a unit test, so it carries no runtime weight.
+in this feature consumes it beyond a unit test, so it carries no runtime
+weight. `detectMentionQuery` and `applySelectedMentions` are the two helpers
+that actually drive the input: the composer calls `detectMentionQuery` on
+each change to open/filter the dropdown, and `applySelectedMentions` on
+submit to tokenize the recorded selections.
 
 ### Member source — `useWorkspaceMembers(workspaceId)`
 
@@ -124,14 +144,19 @@ Each consumer's comment controller already knows its `workspaceId`
 result) down to `CommentComposer` as a prop. The shared module never
 fetches on its own — it stays presentation-only and testable.
 
-### Input — `MentionTextarea` inside `CommentComposer`
+### Input — mention behavior inside `CommentComposer`
 
-`CommentComposer` keeps its `<textarea>`. Mention behavior is layered via a
-small `MentionTextarea` wrapper / hook:
+`CommentComposer` keeps its `<textarea>`. Mention behavior is layered inline
+in `packages/frontend/src/components/comments/components/CommentComposer.tsx`
+(no separate wrapper component) using the
+`packages/frontend/src/components/comments/mentions.ts` helpers:
 
-- **Trigger**: detect an `@` immediately preceded by start-of-text or
-  whitespace, followed by the in-progress query (`@ki`). Show a dropdown
-  anchored under the caret listing members whose username matches the query
+- **Trigger**: `detectMentionQuery` fires on an `@` preceded by start-of-text
+  or any non-username character (anything outside `[A-Za-z0-9-]`), followed by
+  the in-progress query (`@ki`). This triggers after whitespace, punctuation,
+  and CJK glyphs typed with no space, but deliberately skips `email@host`
+  (the `@` there is preceded by a login character). Show a dropdown anchored
+  under the caret listing members whose username matches the query
   (case-insensitive prefix/substring).
 - **Dropdown**: reuses `AuthorAvatar` for each row. Keyboard: ↑/↓ move,
   Enter/Tab select, Esc closes. These keys are intercepted **only while the
@@ -139,12 +164,14 @@ small `MentionTextarea` wrapper / hook:
   Escape-cancel are unaffected when it's closed.
 - **Selection (approach B — tokenize on submit)**: selecting a member
   replaces the in-progress `@ki` with a clean `@username ` in the textarea
-  and records the chosen mention in a view-local **mention map**
-  (`{ matchedText, userId, username }`). On submit, the composer walks the
-  mention map and rewrites each still-present `@username` occurrence into a
-  `@[username](userId)` token before calling `onSubmit(body)`. If the user
-  manually edited a mention's text so it no longer matches, that mention is
-  silently dropped to plain text (graceful — never emits a broken token).
+  and records the chosen mention in a view-local **mention map** — a
+  `MentionRef[]` (`{ userId, username }`) held in a ref, keyed by username. On
+  submit, `applySelectedMentions` rewrites each still-present `@username`
+  occurrence into a `@[username](userId)` token before calling
+  `onSubmit(body)`. It re-matches by username with a trailing word-boundary
+  lookahead, so if the user manually edited a mention's text so it no longer
+  matches, that mention is silently dropped to plain text (graceful — never
+  emits a broken token).
 - **IME safety**: while an IME composition is active
   (`compositionstart`/`compositionend`), the `@`-trigger and key handling
   are suppressed so Korean/CJK composition isn't hijacked. (Reflects the
@@ -178,7 +205,7 @@ GET /workspaces/:id ──┐
                       ├─ useWorkspaceMembers(workspaceId) ─┐
 consumer controller ──┘                                    │ members[]
                                                            ▼
-CommentComposer ── MentionTextarea(@ dropdown) ── onSubmit("…@[u](id)…")
+CommentComposer ── inline @ dropdown ── onSubmit("…@[u](id)…")
                                                            │
                                                            ▼
                                               CommentStore (unchanged)

--- a/docs/design/context-menu.md
+++ b/docs/design/context-menu.md
@@ -55,7 +55,8 @@ from the long-press handler in
 SheetContextMenu (new)
 ├── Wraps canvas container as ContextMenuTrigger
 ├── onContextMenu: headerHitTest → determine menuType
-├── CellMenuItems: Cut, Copy, Paste, Delete
+├── CellMenuItems: Cut, Copy, Paste, Delete + optional Insert comment,
+│                  Data validation, Insert pivot table, Delete image
 ├── RowMenuItems: Insert above/below, Delete, Hide, Show
 └── ColumnMenuItems: Insert left/right, Delete, Hide, Show
 
@@ -76,6 +77,14 @@ components/ui/context-menu.tsx (new)
 - Copy
 - Paste (disabled if readOnly)
 - Delete (disabled if readOnly)
+- Insert comment (with keyboard hint; only if `onInsertComment` is wired)
+- Data validation (only if `onOpenDataValidation` is wired)
+- Insert pivot table (only if `onInsertPivotTable` is wired)
+- Delete image (only when an image is selected, via `selectedImageId` + `onDeleteImage`)
+
+The optional items are gated by their corresponding `SheetContextMenu` props
+(`onInsertComment`, `onOpenDataValidation`, `onInsertPivotTable`,
+`onDeleteImage`/`selectedImageId`) and each render behind a separator.
 
 #### Row Menu
 
@@ -114,17 +123,18 @@ used. Otherwise the single row/column at the click point is selected.
 ### Spreadsheet Facade API Additions
 
 ```typescript
-// Hide/show operations (move from worksheet direct calls to facade)
-hideRows(index: number, count: number): Promise<void>
-hideColumns(index: number, count: number): Promise<void>
-showRows(from: number, to: number): Promise<void>
-showColumns(from: number, to: number): Promise<void>
+// Hide/show operations (move from worksheet direct calls to facade).
+// Each takes the explicit list of axis indices to act on.
+hideRows(indices: number[]): Promise<void>
+hideColumns(indices: number[]): Promise<void>
+showRows(indices: number[]): Promise<void>
+showColumns(indices: number[]): Promise<void>
 
-// Adjacent hidden detection (for conditional Show menu item)
-getAdjacentHiddenRows(from: number, to: number):
-  { from: number; to: number } | null
-getAdjacentHiddenColumns(from: number, to: number):
-  { from: number; to: number } | null
+// Adjacent hidden detection (for conditional Show menu item).
+// Returns the array of hidden indices adjacent to the [from, to] range
+// (empty when none); the menu computes min/max over it for the label.
+findAdjacentHiddenRows(from: number, to: number): number[]
+findAdjacentHiddenColumns(from: number, to: number): number[]
 ```
 
 ### Key Files

--- a/docs/design/design-system-unification.md
+++ b/docs/design/design-system-unification.md
@@ -46,7 +46,7 @@ at the bottom is updated whenever a PR lands.
 | --------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | Tokens          | Four sources (frontend `@theme` plus three canvas theme files)        | `packages/frontend/src/index.css`, `packages/sheets/src/view/theme.ts`, `packages/docs/src/view/theme.ts`, `packages/slides/src/model/theme.ts` |
 | UI primitives   | Radix + shadcn + CVA, ~22 components                                   | `packages/frontend/src/components/ui/`                                                                     |
-| Toolbars        | Per-package: Slides (13 files), Docs (one file), Sheets (none)         | `packages/frontend/src/app/slides/`, `packages/frontend/src/app/docs/`                                     |
+| Toolbars        | Per-package: Slides (13 files), Docs (one file), Sheets (one file), Notes (one file) | `packages/frontend/src/app/slides/`, `packages/frontend/src/app/docs/`, `packages/frontend/src/components/formatting-toolbar.tsx` |
 | Floating UI     | Radix for dropdown/tooltip; custom inline-positioned popovers elsewhere | `packages/frontend/src/app/docs/docs-link-popover.tsx`, comment popovers                                   |
 | Mobile          | Slides only                                                            | `packages/frontend/src/app/slides/mobile-slides-view.tsx`, `packages/frontend/src/app/slides/toolbar/mobile-toolbar.tsx`, `packages/frontend/src/hooks/use-mobile.ts` |
 | Icons           | @tabler primary, lucide on the marketing homepage                      | `packages/frontend/src/app/(home)/`                                                                        |
@@ -145,11 +145,16 @@ swatch generator.
 
 Extract reusable toolbar primitives that all three editors can build on.
 
-- `<EditorToolbar>` shell — left/center/right zones, optional sticky.
-- `<ToolbarGroup>` — visual separators and optional group label.
-- `<ToolbarButton>` — variants (default/active/destructive) with shortcut
-  tooltips.
-- `<ColorSwatch>` — built on the PR #2 generator.
+- `<EditorToolbar>` shell — left/center/right zones, optional sticky. *(Not yet
+  built; the shared shell instead lives as `Toolbar` in
+  `packages/frontend/src/components/ui/toolbar.tsx`.)*
+- `<ToolbarGroup>` — visual separators and optional group label. *(Not yet
+  built; `ToolbarSeparator` covers the separator role.)*
+- `<ToolbarButton>` — variants (`icon` / `menu`) with shortcut tooltips.
+  **Shipped** via #498 in `packages/frontend/src/components/ui/toolbar.tsx`
+  (`forwardRef` + CVA).
+- `<ColorSwatch>` — **shipped** via #498 in
+  `packages/frontend/src/components/color-swatch.tsx`.
 - Migrate the Docs formatting toolbar first (single file, lowest risk).
 - Depends on PR #1, PR #2.
 
@@ -161,13 +166,16 @@ Extract reusable toolbar primitives that all three editors can build on.
   inside the slides app code.
 - Depends on PR #3.
 
-#### PR #5 — Sheets formatting toolbar
+#### PR #5 — Sheets formatting toolbar (shipped)
 
-- Sheets currently has no formatting toolbar — all formatting flows through
-  context menus and side panels.
-- Add a minimal set on top of the shared components: bold/italic/underline,
-  alignment, number format, text and background color.
-- Depends on PR #3, PR #4.
+- **Shipped.** Sheets previously had no formatting toolbar — all formatting
+  flowed through context menus and side panels.
+- A `FormattingToolbar` now ships in
+  `packages/frontend/src/components/formatting-toolbar.tsx` (mounted by
+  `packages/frontend/src/app/spreadsheet/sheet-view.tsx`), built on the shared
+  `Toolbar` / `ToolbarSeparator` / `ToolbarButton` and `ColorPickerGrid`
+  primitives: bold/italic, horizontal + vertical alignment, number format, and
+  text/background color — the minimal set this PR described.
 
 #### PR #6 — Floating UI consolidation (P1 #4)
 
@@ -356,12 +364,12 @@ This table is updated as each PR lands.
 
 | PR  | Title                                  | State        | Notes                              |
 | --- | -------------------------------------- | ------------ | ---------------------------------- |
-| #1  | `@wafflebase/tokens` package           | Ready to merge | Branch `tokens-package`, 2026-05-24 |
-| —   | Toolbar dropdown unification (Phases 1–3) | In review | PR #498, branch `unify-toolbar-dropdowns`, 2026-07-19; see "Toolbar dropdown unification" above |
+| #1  | `@wafflebase/tokens` package           | Shipped      | Landed as PR #292, then folded into `@wafflebase/core/tokens` (PR #477); see "Update (superseded location)" above |
+| —   | Toolbar dropdown unification (Phases 1–3) | Shipped | PR #498 (merged 2026-07-19); see "Toolbar dropdown unification" above |
 | #2  | Palette tokenization                   | Not started  |                                    |
-| #3  | Shared toolbar components              | Not started  |                    |
+| #3  | Shared toolbar components              | Partially shipped | `ToolbarButton` + `ColorSwatch` shipped via #498; `EditorToolbar` / `ToolbarGroup` not built |
 | #4  | Slides toolbar migration               | Not started  |                    |
-| #5  | Sheets formatting toolbar              | Not started  |                    |
+| #5  | Sheets formatting toolbar              | Shipped      | `FormattingToolbar` in `components/formatting-toolbar.tsx` |
 | #6  | Floating UI consolidation              | Not started  |                    |
 | #7  | Mobile first pass for Docs and Sheets  | Not started  |                    |
 | #8  | Icon library unification               | Not started  |                    |

--- a/docs/design/design-system-unification.md
+++ b/docs/design/design-system-unification.md
@@ -369,7 +369,7 @@ This table is updated as each PR lands.
 | #2  | Palette tokenization                   | Not started  |                                    |
 | #3  | Shared toolbar components              | Partially shipped | `ToolbarButton` + `ColorSwatch` shipped via #498; `EditorToolbar` / `ToolbarGroup` not built |
 | #4  | Slides toolbar migration               | Not started  |                    |
-| #5  | Sheets formatting toolbar              | Shipped      | `FormattingToolbar` in `components/formatting-toolbar.tsx` |
+| #5  | Sheets formatting toolbar              | Shipped      | `FormattingToolbar` in `packages/frontend/src/components/formatting-toolbar.tsx` |
 | #6  | Floating UI consolidation              | Not started  |                    |
 | #7  | Mobile first pass for Docs and Sheets  | Not started  |                    |
 | #8  | Icon library unification               | Not started  |                    |

--- a/docs/design/docs-site.md
+++ b/docs/design/docs-site.md
@@ -8,9 +8,10 @@ target-version: 0.1.0
 ## Summary
 
 A VitePress-based documentation site at `packages/documentation` provides
-user guides for each shipped module (Sheets, Docs, Slides) and developer
-references (self-hosting, REST API, CLI). Served at `wafflebase.io/docs`
-as a subpath of the existing GitHub Pages deployment.
+user guides for each shipped module (Sheets, Docs, Slides, Notes, Board,
+and PDF/Image files) and developer references (self-hosting, REST API,
+CLI). Served at `wafflebase.io/docs` as a subpath of the existing GitHub
+Pages deployment.
 
 ## Goals
 
@@ -39,11 +40,14 @@ packages/documentation/
 ├── index.md                  # Docs home (VitePress home layout)
 ├── guide/
 │   ├── getting-started.md    # Getting started
-│   └── collaboration.md      # Real-time collaboration & sharing
+│   ├── collaboration.md      # Real-time collaboration & sharing
+│   └── import-export.md      # Import & export
 ├── sheets/
 │   ├── build-a-budget.md     # Sheets tutorial
 │   ├── formulas.md           # Formulas reference
 │   ├── charts.md             # Charts & pivot tables
+│   ├── data-validation.md    # Data validation
+│   ├── datasources.md        # External datasources
 │   └── keyboard-shortcuts.md
 ├── docs-editor/
 │   ├── writing-a-document.md
@@ -52,6 +56,14 @@ packages/documentation/
 │   ├── build-a-deck.md       # Slides tutorial
 │   ├── themes-and-layouts.md
 │   └── keyboard-shortcuts.md
+├── notes/
+│   └── writing-a-note.md     # Notes tutorial
+├── board/
+│   └── using-the-board.md    # Board tutorial
+├── pdf/
+│   ├── viewing-pdfs.md
+│   ├── viewing-images.md
+│   └── organizing-with-folders.md
 └── developers/
     ├── self-hosting.md
     ├── rest-api.md
@@ -61,17 +73,17 @@ packages/documentation/
 ### VitePress Configuration
 
 - `base: '/docs/'` so all asset/link paths are prefixed correctly
-- Top nav order: **Guide / Sheets / Docs / Slides / Developers** — mirrors
-  the homepage's product progression
-- Sidebar groups one per nav entry; Slides group sits between Docs and
-  Developers
+- Top nav order: **Guide / Sheets / Docs / Slides / Notes & Board /
+  Developers** — mirrors the homepage's product progression
+- Sidebar groups mirror the nav plus a **PDF & Files** group (PDF/image
+  viewers, folders) between Notes & Board and Developers
 - Brand colors via CSS variable overrides to match homepage amber/gold theme
 - Built-in local search enabled
 
 ### Build & Deployment
 
 **Local development:**
-- `pnpm docs dev` runs VitePress dev server independently
+- `pnpm documentation dev` runs VitePress dev server independently
 
 **CI build:**
 1. `pnpm frontend build` → `packages/frontend/dist/`
@@ -95,8 +107,8 @@ packages/documentation/
 **developer-section.tsx:**
 - Keep existing REST API / CLI code examples
 - Add links below each code block pointing to full documentation:
-  - REST API block → `/docs/api/rest-api`
-  - CLI block → `/docs/api/cli`
+  - REST API block → `/docs/developers/rest-api`
+  - CLI block → `/docs/developers/cli`
 
 ### Content Outline
 
@@ -105,11 +117,14 @@ packages/documentation/
   navigation
 - Collaboration & Sharing: sharing documents, real-time co-editing,
   presence indicators
+- Import & Export: importing/exporting documents across formats
 
 **Sheets section:**
 - Build a Budget: hands-on tutorial
 - Formulas: supported functions, syntax, cell references, examples
 - Charts & Pivot Tables: data visualization and aggregation
+- Data Validation: in-cell controls and validation rules
+- External Datasources: connecting external databases
 - Keyboard Shortcuts: full reference
 
 **Docs section:**
@@ -121,6 +136,15 @@ packages/documentation/
 - Themes & Layouts: 4-tier theme model, 11 Google-Slides-parity layouts,
   placeholders
 - Keyboard Shortcuts: full reference
+
+**Notes & Board section:**
+- Writing a Note: markdown note editor tour
+- Using the Board: infinite-canvas board tutorial
+
+**PDF & Files section:**
+- Viewing PDFs: the PDF viewer
+- Viewing Images: the image viewer
+- Organizing with Folders: workspace folder organization
 
 **Developers section:**
 - Self-Hosting: deploying Wafflebase on your own infrastructure

--- a/docs/design/docs/docs-collaboration.md
+++ b/docs/design/docs/docs-collaboration.md
@@ -34,10 +34,13 @@ Yorkie's `Tree` CRDT. The docs editor currently uses an in-memory store
 - Extensible tree structure for future block types (tables, lists, images)
 - Local snapshot-based undo/redo as a first step
 
-### Non-Goals
+### Non-Goals (as originally scoped)
 
-- Presence / remote cursor display (follow-up work)
-- Yorkie-based undo/redo (future migration from local snapshots)
+- ~~Presence / remote cursor display~~ — **since shipped**: peer carets and
+  name labels via `packages/docs/src/view/peer-cursor.ts`, with live presence
+  wiring in `packages/frontend/src/app/docs/docs-detail.tsx`.
+- ~~Yorkie-based undo/redo~~ — **since shipped**: `YorkieDocStore` delegates
+  undo/redo to Yorkie `doc.history` (see the Undo/Redo section below).
 - Offline editing with sync (out of scope)
 - Conflict resolution UI (Yorkie CRDT handles conflicts automatically)
 
@@ -80,8 +83,11 @@ element and text nodes:
 - **Text nodes** — Leaf nodes inside `<inline>` elements containing the actual
   character data.
 
-Future block types (`<table>`, `<list-item>`, `<image>`) are added as new
-element types alongside `<block>`.
+Tables have since shipped as `type: 'table'` element nodes (including nested
+tables) — see `packages/docs/src/model/document.ts` (`insertTable`,
+`insertTableInCell`, `createTableBlock`) and [`docs-tables.md`](docs-tables.md).
+Other future block types (`<list-item>`, `<image>`) follow the same pattern of
+adding new element types alongside `<block>`.
 
 ### Doc Class Refactoring
 
@@ -264,8 +270,9 @@ Other client edits
 
 ### Editor Integration
 
-- **`initialize(container, store)`** — `store` parameter becomes required;
-  caller provides either `MemDocStore` or `YorkieDocStore`.
+- **`initialize(container, store?, theme?, readOnly?)`** — `store` is optional
+  and defaults to a new `MemDocStore()`; the collaborative caller passes a
+  `YorkieDocStore`.
 - **`Doc`** — Created with the store: `new Doc(store)`.
 - **`syncToStore()` removed** — No longer needed since `Doc` writes through
   the store directly. `replaceDocument()` calls are removed from the editor.

--- a/docs/design/docs/docs-comments.md
+++ b/docs/design/docs/docs-comments.md
@@ -15,17 +15,24 @@ position ranges, and remain visible as "orphaned" cards in the side panel
 when their anchor text is fully deleted.
 
 The work introduces a **shared frontend module** at
-`packages/frontend/src/components/comments/` that owns the comment data
-model, pure helpers, the `CommentStore` interface, and the framework UI
-(composer, side panel, thread card, orphaned card). The domain packages
-(`packages/docs`, `packages/sheets`) **stay comment-naive** — they expose
-small render-time hooks (e.g., `editor.setCommentMarkers(rects)` analogous
-to `setSearchMatches`) and know nothing about Threads.
+`packages/frontend/src/components/comments/` that owns the comment anchor
+union, pure helpers, the `CommentStore` interface, and the framework UI
+(composer, side panel, thread card, orphaned card). The base data model
+(`Comment`, `CommentAuthor`, and the generic `Thread<A>`) is owned by
+`@wafflebase/sheets` — the lowest package in the dependency graph — and
+re-exported through `@/types/comments.ts`; `components/comments/types.ts`
+is a re-export shim, and the anchor union itself lives in
+`@/types/comments.ts`. The domain packages (`packages/docs`,
+`packages/sheets`) **stay comment-naive** — they expose small render-time
+hooks (e.g., `editor.setCommentMarkers(markers)` analogous to
+`setSearchMatches`) and know nothing about Threads.
 
-This PR delivers docs comments end-to-end. Sheets has a pre-existing
-comments implementation (different layout, inside `packages/sheets`); it
-keeps working unchanged in this PR and migrates to the shared module in a
-follow-up PR. Slides comments and mentions/notifications follow after that.
+Docs comments ship end-to-end. Sheets, which had a pre-existing comments
+implementation, now shares this module's UI (composer, side panel, thread
+card) while keeping its own Yorkie store, and a PDF-region comment
+consumer (`app/files/comments/`) has also shipped. `@user` mentions are
+implemented across the composer and rendered bodies; in-app / email
+notifications and slides comments remain future work.
 
 ## Goals / Non-Goals
 
@@ -54,12 +61,16 @@ follow-up PR. Slides comments and mentions/notifications follow after that.
 
 ### Non-Goals
 
-- Changes to `packages/sheets` or the existing sheets comments
-  implementation. Sheets migrates in a follow-up PR.
+- Reworking the existing sheets comments implementation. Sheets now shares
+  this module's UI while keeping its own Yorkie store, and the base
+  `Comment`/`CommentAuthor`/`Thread<A>` types live in `@wafflebase/sheets`
+  and are re-exported here.
 - Changes to `packages/docs` beyond a thin marker-rendering hook on the
   editor. Comment types, store, and React UI live in `packages/frontend`.
-- Slides comments (third consumer of the shared module — follow-up PR).
-- `@user` mentions and notifications (later phase, across all consumers).
+- Slides comments (a future consumer of the shared module).
+- Notifications (in-app / email) for `@user` mentions. Mentions themselves
+  are implemented (see `components/comments/mentions.ts`); only the
+  notification delivery remains future work.
 - Rich-text body (bold, italics, links). Plain text + newlines only.
 - Block-only or document-wide anchors. A range covering a whole block is
   expressed as a range, not a separate anchor kind.
@@ -71,19 +82,22 @@ follow-up PR. Slides comments and mentions/notifications follow after that.
 
 ### 1. Module Layout
 
-This PR is a single mergeable unit. Sheets is untouched.
+The shared module is anchor-generic and consumed by docs, sheets (UI), and
+PDF today.
 
 ```text
 packages/frontend/src/components/comments/        NEW — shared, anchor-generic
-├── types.ts
-│   ├── CommentAuthor
-│   ├── Comment
-│   ├── Thread<A extends CommentAnchor = CommentAnchor>
-│   └── CommentAnchor = sheet-cell | docs-range
-│                       (+ slide-element placeholder, no implementation yet)
+├── types.ts            # re-export shim over @/types/comments.ts (below);
+│                       #   Comment/CommentAuthor/Thread<A> are re-exported
+│                       #   from @wafflebase/sheets
+├── mentions.ts         # @user mention encode/parse/query/apply helpers
 ├── thread.ts            # pure helpers — create / validate / mutate
-├── comment-store.ts     # CommentStore<A> interface (6 methods)
+├── comment-store.ts     # CommentStore<A, AnchorInput = A> interface (7 methods)
 ├── mem-comment-store.ts # in-memory implementation for tests / dev
+
+packages/frontend/src/types/comments.ts           the actual type home
+├── CommentAnchor = sheet-cell | docs-range | pdf-region
+│                   (base Comment/CommentAuthor/Thread<A> from @wafflebase/sheets)
 ├── components/
 │   ├── CommentComposer.tsx      # author avatar + textarea + cancel/submit
 │   ├── CommentThreadCard.tsx    # one thread render (popover + side panel reuse)
@@ -92,13 +106,12 @@ packages/frontend/src/components/comments/        NEW — shared, anchor-generic
 │   └── OrphanedCard.tsx         # gray quotedText card
 └── __tests__/
 
-packages/frontend/src/app/docs/comments/          NEW — docs glue (the only consumer in this PR)
+packages/frontend/src/app/docs/comments/          docs glue
 ├── docs-anchor.ts               # DocSelection ↔ posRange,
 │                                #   extractAnchorContext, resolveAnchor
 ├── yorkie-comment-store.ts      # implements CommentStore<DocsRangeAnchor>
 │                                #   against root.comments on the docs Yorkie document
-├── decorations.ts               # thread[] → HighlightRect[]
-│                                #   (computeSelectionRects reuse from docs/view)
+├── decorations.ts               # thread[] → CommentMarker[] (computeCommentMarkers)
 ├── DocsCommentPopover.tsx       # docs-specific positioning
 └── docs-comments-controller.ts  # wires store ↔ editor ↔ React state
 
@@ -111,9 +124,11 @@ packages/frontend/src/app/docs/docs-view.tsx      MODIFY
 └── instantiate YorkieCommentStore (sharing the Yorkie Document with
     YorkieDocStore); mount CommentSidePanel; bind controller; wire entry
     points (context menu, toolbar, Cmd+Alt+M, side panel toggle).
-
-packages/frontend/visual/docs-comments.spec.ts    NEW
 ```
+
+A PDF-region consumer ships alongside docs under
+`packages/frontend/src/app/files/comments/` (`pdf-comment-store.ts`,
+`pdf-comments-controller.ts`), following the same store-per-consumer shape.
 
 **Boundary rules:**
 
@@ -126,20 +141,22 @@ packages/frontend/visual/docs-comments.spec.ts    NEW
 - `packages/docs` knows nothing about comments. The single new editor
   setter is named `setCommentMarkers` for clarity but its contract is
   agnostic ("draw these yellow highlight rects until I clear them").
-- `packages/sheets` is **not** touched.
+- `packages/sheets` owns the base `Comment`/`CommentAuthor`/`Thread<A>`
+  types (re-exported by the frontend) but has no docs-specific code.
 
 ### 2. Data Model
 
+`Comment`, `CommentAuthor`, and the generic `Thread<A>` are declared in
+`@wafflebase/sheets` (`packages/sheets/src/comment/types.ts`) and
+re-exported from `@/types/comments.ts`, which owns the anchor union:
+
 ```typescript
-// packages/frontend/src/components/comments/types.ts
+// packages/frontend/src/types/comments.ts
 
 import type { TreePosStructRange } from '@yorkie-js/sdk';
-
-export type CommentAuthor = {
-  userId: string;
-  username: string;
-  photo?: string;
-};
+// Comment / CommentAuthor / the base Thread<A> are owned by @wafflebase/sheets.
+import type { Thread as BaseThread } from '@wafflebase/sheets';
+export type { Comment, CommentAuthor } from '@wafflebase/sheets';
 
 export type CommentAnchor =
   | { kind: 'sheet-cell'; tabId: string; rowId: string; colId: string }
@@ -155,32 +172,27 @@ export type CommentAnchor =
        *  Used by the "Orphaned" side-panel card when posRange no longer
        *  resolves. */
       quotedText: string;
+    }
+  | {
+      kind: 'pdf-region';
+      /** Page-index + [0,1] page-relative rect. Static coordinates, so a
+       *  PDF anchor never orphans except when pageIndex is out of range. */
+      pageIndex: number;
+      rect: { x: number; y: number; w: number; h: number };
     };
   // future: { kind: 'slide-element'; slideId: string; elementId: string };
 
-export type Comment = {
-  id: string;
-  author: CommentAuthor;
-  body: string;          // plain text, '\n' allowed, non-empty after trim
-  createdAt: number;
-  editedAt?: number;
-};
-
-export type Thread<A extends CommentAnchor = CommentAnchor> = {
-  id: string;            // UUID v4
-  anchor: A;
-  comments: Comment[];   // [0] is root, rest are replies in author order
-  resolved: boolean;
-  resolvedAt?: number;
-  resolvedBy?: CommentAuthor;
-  createdAt: number;
-};
+// From @wafflebase/sheets, generic over the anchor:
+//   Comment { id, author, body, createdAt, editedAt? }
+//   Thread<A> { id, anchor: A, comments: Comment[], resolved,
+//               resolvedAt?, resolvedBy?, createdAt }
+export type Thread<A extends CommentAnchor = CommentAnchor> = BaseThread<A>;
 ```
 
-The discriminated `CommentAnchor` includes the `sheet-cell` variant
-**now**, even though sheets does not yet consume the shared module. This
-locks the schema in advance so the sheets migration PR is a
-copy-and-import-path-swap rather than a redesign.
+The discriminated `CommentAnchor` carries the `sheet-cell` variant (shared
+with the sheets store) and the shipped `pdf-region` variant alongside
+`docs-range`, so all three consumers reuse the same anchor-generic helpers
+and UI.
 
 `TreePosStructRange` is imported from `@yorkie-js/sdk` — a plain
 JSON-serializable struct. The dependency is intentional and contained to
@@ -208,10 +220,18 @@ clients; lazy resolution at read time keeps a single source of truth.
 
 A single anchor-generic interface, implemented per consumer.
 
+`AnchorInput` is what the caller passes to `addThread`; `A` is what is
+persisted. They coincide for sheets (its stored `sheet-cell` anchor) but
+differ for docs, which passes path endpoints the Yorkie store converts into
+a CRDT-stable `posRange` inside the same `doc.update()`.
+
 ```typescript
 // packages/frontend/src/components/comments/comment-store.ts
-export interface CommentStore<A extends CommentAnchor = CommentAnchor> {
-  addThread(anchor: A, body: string, author: CommentAuthor): Promise<Thread<A>>;
+export interface CommentStore<
+  A extends CommentAnchor = CommentAnchor,
+  AnchorInput = A,
+> {
+  addThread(input: AnchorInput, body: string, author: CommentAuthor): Promise<Thread<A>>;
   addReply(threadId: string, body: string, author: CommentAuthor): Promise<Comment>;
   editComment(threadId: string, commentId: string, body: string): Promise<void>;
   deleteComment(threadId: string, commentId: string): Promise<void>;
@@ -231,33 +251,34 @@ export interface CommentStore<A extends CommentAnchor = CommentAnchor> {
 }
 ```
 
-Implementations in this PR:
+Shipped implementations:
 
 - `MemCommentStore<A>` — in-memory map, used by Vitest tests and `MemDocStore`
   fixtures.
 - `YorkieCommentStore` (docs) — reads/writes `root.comments` on the same
   `yorkie.Document` as `YorkieDocStore`. `addThread` runs inside a single
   `doc.update()` so the snapshot is consistent.
+- PDF store (`app/files/comments/pdf-comment-store.ts`) — persists
+  `pdf-region` threads against the `pdf-<id>` Yorkie document.
+- Sheets keeps its own store on `worksheet.comments` (per-tab) and adopts
+  the shared UI.
 
-Future implementations (out of scope for this PR):
+Future implementations:
 
-- `YorkieCommentStore` (sheets) — reads/writes `worksheet.comments` (per-tab),
-  replaces the comment methods currently on the sheets `Store` interface.
 - `YorkieCommentStore` (slides) — reads/writes `slide.comments` or a top-level
   map keyed by slide id (decided when slides comments lands).
 
 ### 4. Yorkie Schema (Docs)
 
 The Docs Yorkie document already mixes a `Tree` and several JSON fields
-(`root.content`, `root.pageSetup`, `root.header`, `root.footer`). One more
-optional JSON field is added:
+(`root.content`, `root.pageSetup`, `root.stylesJson`). One more optional
+JSON field is added (see `packages/frontend/src/types/docs-document.ts`):
 
 ```typescript
-type DocsDocument = {
+type YorkieDocsRoot = {
   content: yorkie.Tree;
   pageSetup?: PageSetup;
-  header?: HeaderFooter;
-  footer?: HeaderFooter;
+  stylesJson?: string;
   comments?: { [threadId: string]: Thread<DocsRangeAnchor> };   // NEW
 };
 ```
@@ -402,36 +423,36 @@ The shared module imposes no orphan policy — each consumer decides.
 This is the small change in `packages/docs`. Nothing else.
 
 ```typescript
-// packages/docs/src/view/editor.ts
+// packages/docs/src/view/editor.ts (types in packages/docs/src/view/comment-markers.ts)
 export interface DocsEditor {
   // ... existing methods, including:
   setSearchMatches(matches: SearchMatch[], activeIndex: number): void;
 
   // NEW
-  /** Draw yellow highlight rects until cleared. Comment-naive: docs does
-   *  not know what these rects represent. */
-  setCommentMarkers(rects: HighlightRect[]): void;
+  /** Draw yellow highlights for each marker until cleared. Comment-naive:
+   *  docs does not interpret the ids. Pass [] to clear. */
+  setCommentMarkers(markers: CommentMarker[]): void;
 }
 
-export type HighlightRect = {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
+export interface CommentMarker {
   /** Opaque id the caller uses to map click → thread on the frontend side. */
   id: string;
-};
+  anchor: { blockId: string; offset: number };
+  focus: { blockId: string; offset: number };
+}
 ```
 
-Editor click handling already dispatches by (x, y); the comment controller
-in frontend listens for clicks inside reported marker rects and opens its
-popover. The editor itself routes only the geometry.
+The editor turns each marker's `anchor`/`focus` range into highlight rects
+itself, via the same selection layout used for search matches and peer
+cursors, so markers track resize / zoom / line wrap automatically — the
+frontend does not pre-compute rects.
 
-A `getCommentMarkerAt(x: number, y: number): string | null` helper on the
-editor lets the controller match a click to a marker id without
-re-running geometry. Implementation is O(rects). When rects overlap at the
-hit point, the last-set rect wins (so newer threads take precedence over
-older ones at the same spot).
+A `getCommentMarkerAt(clientX: number, clientY: number): string | null`
+helper on the editor lets the controller match a viewport-relative click to
+a marker id without re-running geometry (the editor converts to
+canvas-internal document coordinates first). When rects overlap at the hit
+point, the last-set marker wins (so newer threads take precedence over older
+ones at the same spot).
 
 ### 7. UI
 
@@ -483,25 +504,30 @@ threads change or the document re-paginates.
 
 ### 8. Testing Strategy
 
+Tests live under the top-level `packages/frontend/tests/` mirror, not
+colocated `__tests__/` folders.
+
 #### 8.1 Unit (Vitest)
 
 ```text
-packages/frontend/src/components/comments/__tests__/
+packages/frontend/tests/components/comments/
 ├── thread.test.ts        # thread/comment creation, body validation, root
 │                         # delete cascade, edit timestamps, resolve transitions
-└── mem-comment-store.test.ts
+├── mem-comment-store.test.ts
+└── comment-composer-mentions.test.ts   # @user mention picker + body encoding
 
-packages/frontend/src/app/docs/comments/__tests__/
-└── docs-anchor.test.ts   # selectionToPath, extractAnchorContext, anchor
-                          # resolution under: identical tree, partial deletion,
-                          # full deletion (orphan), block-spanning range with
-                          # one block deleted, undo restoration
+packages/frontend/tests/app/docs/comments/
+├── docs-anchor.test.ts   # selectionToPath, extractAnchorContext, anchor
+│                         # resolution under: identical tree, partial deletion,
+│                         # full deletion (orphan), block-spanning range with
+│                         # one block deleted, undo restoration
+└── decorations.test.ts   # thread[] → marker list
 ```
 
 #### 8.2 Yorkie integration (frontend, e2e)
 
 ```text
-packages/frontend/src/app/docs/__tests__/comments.test.ts
+packages/frontend/tests/app/docs/comments/yorkie-comment-store-concurrent.integration.ts
 ├── concurrent thread creation on the same range — both preserved
 ├── concurrent replies — both preserved, deterministic order
 ├── partial deletion of anchor text — posRange shrinks, marker follows
@@ -513,39 +539,36 @@ packages/frontend/src/app/docs/__tests__/comments.test.ts
 
 #### 8.3 Visual / interaction (browser harness)
 
-```text
-packages/frontend/visual/docs-comments.spec.ts
-├── range selection + Cmd+Alt+M opens composer focused
-├── highlight render across a line wrap (per-line rects)
-├── highlight click → popover positioning (flips when near canvas edge)
-├── overlapping threads → popover lists both
-├── side panel tab counts update on resolve / reopen
-├── "Orphaned" sub-section renders quotedText, jump-to disabled
-└── side panel thread click → scroll + caret + flash highlight
-```
+No dedicated docs-comments browser harness spec ships today (there is no
+`packages/frontend/visual/` directory). The behaviors below — composer
+entry, highlight render across line wraps, popover positioning, overlapping
+threads, side-panel tab counts, orphan cards, and jump-to-anchor — are
+covered by the unit and Yorkie integration suites above; a browser spec
+remains a future addition.
 
 #### 8.4 Verify lanes
 
 - `pnpm verify:fast` — unit.
 - `pnpm verify:full` — Yorkie integration (needs `docker compose up -d`).
-- `pnpm verify:browser:docker` — visual.
 
 ### 9. Phase Plan
 
-The four steps are PR-sized and independently mergeable.
+The steps are PR-sized and independently mergeable.
 
-| Step | Scope                                                                                                                   | Files touched                                                                  |
-| ---- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| **1 — this PR** | Shared module + docs comments end-to-end. Sheets unchanged.                                                  | new `components/comments/`, new `app/docs/comments/`, small `packages/docs/src/view/editor.ts` |
-| 2    | Sheets migrates to the shared module. UX unchanged. `packages/sheets/src/comment/*` removed; `Store` loses the 6 comment methods; new `app/spreadsheet/comments/` mirrors `app/docs/comments/`. | sheets package + `app/spreadsheet/comments/`                                  |
-| 3    | Slides comments. Third consumer of the shared module. Adds the `slide-element` anchor variant and `app/slides/comments/`. | shared `types.ts`, new `app/slides/comments/`, small slides editor hook       |
-| 4    | `@user` mentions + notifications (in-app + email) across all three consumers. Composer gains mention picker; Thread/Comment gain `mentionedUserIds`; backend gains notification job. | shared `components/comments/`, backend                                         |
+| Step | Status | Scope                                                                                                                   | Files touched                                                                  |
+| ---- | ------ | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| 1    | Shipped | Shared module + docs comments end-to-end.                                                                              | `components/comments/`, `app/docs/comments/`, `packages/docs/src/view/editor.ts` |
+| 2    | Shipped (UI) | Sheets shares the module's UI (composer / side panel / thread card) while keeping its own Yorkie store; the base `Comment`/`Thread` types now live in `@wafflebase/sheets`. | sheets package + `app/spreadsheet/comments/`                        |
+| —    | Shipped | PDF-region comments — `pdf-region` anchor variant + `app/files/comments/` store & controller.                          | shared `types.ts`, `app/files/comments/`                                       |
+| 3    | Future | Slides comments. Adds the `slide-element` anchor variant and `app/slides/comments/`.                                    | shared `types.ts`, new `app/slides/comments/`, small slides editor hook       |
+| 4    | Partial | `@user` mentions are shipped (composer picker + `@[username](userId)` body tokens rendered in threads). In-app / email notifications remain future work. | shared `components/comments/mentions.ts`; notification job (backend) unbuilt |
 
-After step 2, the `packages/sheets/src/comment/` folder is gone and the
-shared module is the single source of truth. The Sheets migration is
-mechanical: data shapes already match (the schema was locked in step 1),
-so it amounts to changing imports, moving Yorkie store code, and deleting
-the old marker renderer.
+Rather than deleting `packages/sheets/src/comment/`, the sheets migration
+promoted it to the *canonical home* of the base `Comment`/`CommentAuthor`/
+`Thread<A>` types: the frontend re-exports them so the sheets store and the
+shared type are literally the same declaration. Sheets adopted the shared
+UI (composer / side panel / thread card) while retaining its own Yorkie
+store and orphan policy.
 
 ## Risks and Mitigation
 

--- a/docs/design/docs/docs-comments.md
+++ b/docs/design/docs/docs-comments.md
@@ -116,9 +116,10 @@ packages/frontend/src/app/docs/comments/          docs glue
 └── docs-comments-controller.ts  # wires store ↔ editor ↔ React state
 
 packages/docs/src/view/editor.ts                  MODIFY (small)
-└── setCommentMarkers(rects: HighlightRect[]): void
-    Add a setter analogous to setSearchMatches. The editor draws yellow
-    background + 1px underline rects; it does not know they are comments.
+└── setCommentMarkers(markers: CommentMarker[]): void
+    Add a setter analogous to setSearchMatches. The editor computes the
+    yellow background + 1px underline rects from each marker's range; it
+    does not know they are comments.
 
 packages/frontend/src/app/docs/docs-view.tsx      MODIFY
 └── instantiate YorkieCommentStore (sharing the Yorkie Document with
@@ -469,8 +470,9 @@ DocsView
 
 The yellow highlight rects are drawn directly on the existing docs canvas
 during its render pass, like search matches and peer selections. The
-docs-comments-controller in frontend computes the rect list whenever
-threads change or the document re-paginates.
+docs-comments-controller in frontend recomputes the `CommentMarker` list
+whenever threads change or the document re-paginates; the editor turns
+each marker's range into rects itself.
 
 #### 7.2 Entry points
 

--- a/docs/design/docs/docs-docx-import-export.md
+++ b/docs/design/docs/docs-docx-import-export.md
@@ -7,11 +7,17 @@ target-version: 0.3.2
 
 ## Summary
 
-Add the ability to import Microsoft Word (.docx) files into the Docs editor
-and export documents back to .docx format. This requires three prerequisite
-features that the Docs model does not yet support: inline images, image
-resource management (S3-compatible storage), and web font loading for Korean
-typefaces.
+Import Microsoft Word (.docx) files into the Docs editor and export documents
+back to .docx format. This is **shipped** (released in v0.3.2): the importer
+lives at `packages/docs/src/import/docx-importer.ts`, the exporter at
+`packages/docs/src/export/docx-exporter.ts`. It builds on three supporting
+features that also shipped: inline images (`ImageData` + `image` field on
+`InlineStyle` in `model/types.ts`), image resource management (the backend
+S3/MinIO `image` module), and web font loading for Korean typefaces
+(`packages/docs/src/view/fonts.ts`).
+
+The phases below describe the design as it was built; they are retained as an
+architectural reference, not a forward-looking plan.
 
 ## Goals
 
@@ -150,7 +156,7 @@ IMAGE_STORAGE_SECRET_KEY=minioadmin
 
 #### Development Environment
 
-Add MinIO to `docker-compose.yml`:
+MinIO is part of the default `docker-compose.yaml` stack:
 
 ```yaml
 minio:
@@ -450,9 +456,10 @@ packages/docs/src/
     docx-importer.ts            # Main importer entry point
     docx-parser.ts              # XML parsing utilities
     docx-style-map.ts           # OOXML → Docs style conversion
+    units.ts                    # OOXML unit conversions (twips/EMUs/half-points → px/pt)
   export/
     docx-exporter.ts            # Main exporter entry point
-    docx-builder.ts             # XML generation utilities
+    docx-templates.ts           # XML generation utilities
     docx-style-map.ts           # Docs → OOXML style conversion
   view/
     fonts.ts                    # Font registry and loading
@@ -464,7 +471,7 @@ packages/backend/src/
     image.service.ts
     image.config.ts
 
-docker-compose.yml              # + MinIO service
+docker-compose.yaml             # MinIO service (part of the default stack)
 ```
 
 ---

--- a/docs/design/docs/docs-font-controls.md
+++ b/docs/design/docs/docs-font-controls.md
@@ -299,9 +299,13 @@ blocks render the dropdown trigger with an em dash.
 ### Web-font loading flow
 
 1. Toolbar mounts; `font-catalog.ts` is statically imported.
-2. App bootstrap injects a single Google Fonts CSS `<link>` with the
-   subset of families flagged `webFont: true`, weight 400/700, subset
-   `latin,korean`. This is a one-time CSS load, not a binary load.
+2. App bootstrap injects a single Google Fonts CSS `<link>` (built by
+   `buildGoogleFontsHref` in
+   `packages/frontend/src/components/text-formatting/font-catalog.ts`)
+   with only the families flagged `eager: true` (the small pre-catalog
+   set), each at its own `weights`. This is a one-time CSS load, not a
+   binary load. Non-eager web families load on demand via
+   `ensureFontLink(family, weights)`.
 3. When the user picks a web font, the toolbar calls
    `editor.getStore().fonts.ensureFont(family)` (via the existing
    `FontRegistry`) before dispatching `applyStyle`. The applyStyle

--- a/docs/design/docs/docs-font-controls.md
+++ b/docs/design/docs/docs-font-controls.md
@@ -7,20 +7,25 @@ target-version: 0.2.0
 
 ## Summary
 
-The Docs formatting toolbar currently has no controls for font family or
-font size. The data model already supports both (`InlineStyle.fontFamily`
-and `InlineStyle.fontSize`, applied via `editor.applyStyle`), and
-`FontRegistry` already handles on-demand web-font loading — only the UI
-is missing. Headings/Title/Subtitle in the Styles dropdown are the only
-way users can change typography today, which forces them to redefine the
-heading hierarchy whenever they want to vary body type.
-
-This document specifies adding a curated font-family picker, a Google
+The Docs formatting toolbar ships a font-family picker, a Google
 Docs–style font-size control, a line-spacing dropdown, and a "Clear
-formatting" button to the Docs toolbar, and threading the first two
-into the header/footer slim toolbar. The new controls are built as
-stateless components under `packages/frontend/src/components/text-formatting`
-so they can be reused by the Slides text-editing toolbar later.
+formatting" action. The data model already supported the underlying
+inline styles (`InlineStyle.fontFamily` and `InlineStyle.fontSize`,
+applied via `editor.applyStyle`), and `FontRegistry` already handled
+on-demand web-font loading — this work added the missing UI.
+
+The controls are built as stateless components under
+`packages/frontend/src/components/text-formatting` and are shared with
+the Slides text-editing toolbar. The two typography controls (family +
+size) are also threaded into the header/footer slim toolbar.
+
+> **Status:** shipped. The originally-scoped v1 has since been extended
+> well past this doc — the curated catalog grew into a generated
+> ~105-entry catalog plus a searchable "More fonts…" dialog backed by
+> the full `google/fonts`-derived library (see
+> [slides-fonts.md](../slides/slides-fonts.md)). The sections below
+> describe the design as first built; where the shipped surface has
+> moved on, that is called out inline.
 
 ### Goals
 
@@ -40,18 +45,23 @@ so they can be reused by the Slides text-editing toolbar later.
 - All controls reflect the current selection: a single resolved value
   when uniform, an empty / placeholder state when mixed.
 
-### Non-Goals
+### Non-Goals (as originally scoped)
 
 - A full Google Fonts–style "More fonts…" dialog with hundreds of
-  families and search across the entire library. Curated list only in
-  v1; library expansion is a follow-up document.
+  families and search across the entire library. *(Since shipped: the
+  follow-up library expansion landed a searchable "More fonts…" dialog
+  plus the full `google/fonts`-derived catalog and lazy loader —
+  `more-fonts-dialog.tsx`, `more-fonts-filter.ts`, `font-catalog.full.ts`,
+  `font-catalog-full-loader.ts`. See [slides-fonts.md](../slides/slides-fonts.md).)*
 - User font upload.
 - Per-character font preview on hover inside the family picker (each
   item still previews itself in its own font, but no live editor
   preview).
 - Migrating the Slides text-editing toolbar onto the new shared
-  components. The components are built reusable, but Slides adoption is
-  scheduled in a separate PR after the Docs work lands.
+  components. *(Since shipped: the Slides text-edit toolbar now renders
+  the same `FontFamilyPicker`/`FontSizePicker` from
+  `@/components/text-formatting` — see
+  `packages/frontend/src/app/slides/toolbar/text-edit-section.tsx`.)*
 - Changes to the Sheets toolbar.
 
 ## Proposal Details
@@ -63,11 +73,16 @@ Four new files under
 
 | File                          | Responsibility                                                                                     |
 | ----------------------------- | -------------------------------------------------------------------------------------------------- |
-| `font-catalog.ts`             | Single source of truth for the curated font list (display name, CSS family, group, web-load flag). |
+| `font-catalog.ts`             | Font-picker contract + size/line-spacing presets + the `ensureFontLink` lazy loader; re-exports the catalog from `font-catalog.data.ts`. |
 | `font-family-picker.tsx`      | Stateless dropdown. Props: `value: string \| undefined` (undefined = mixed), `onChange(family)`.   |
 | `font-size-picker.tsx`        | Stateless `<input type="number">` + spinner buttons + preset dropdown. Props mirror above.         |
 | `line-spacing-picker.tsx`     | Stateless dropdown of presets plus Custom input. Props: `value: number`, `onChange(lh)`.           |
 | `clear-formatting-button.tsx` | Stateless button. Props: `onClick`.                                                                |
+
+> The curated list was originally hardcoded in `font-catalog.ts`. It now
+> lives in a generated `font-catalog.data.ts` (~105 entries built from
+> `google/fonts` metadata by `scripts/build-font-catalog.mjs`), which
+> `font-catalog.ts` re-exports as `FONT_CATALOG`.
 
 Each component is controlled: the toolbar owns the live value derived
 from the editor and the component only renders + emits. No internal
@@ -76,26 +91,54 @@ state beyond transient input focus.
 `font-catalog.ts` exports:
 
 ```ts
+export type FontGroup =
+  | 'Korean'
+  | 'Sans-serif'
+  | 'Serif'
+  | 'Monospace'
+  | 'Display'
+  | 'Handwriting';
+
 export interface FontEntry {
   /** Display label shown in the picker. */
   label: string;
   /** Canonical family name written to InlineStyle.fontFamily. */
   family: string;
-  /** Group header in the picker. */
-  group: 'Korean' | 'Sans-serif' | 'Serif' | 'Monospace';
+  /** Section header in the picker. */
+  group: FontGroup;
   /**
-   * Whether ensureFont() should be called before paint — true for web
-   * fonts (Google Fonts CSS), false for fonts that are expected to be
-   * present locally on most systems.
+   * Whether the family is served from Google Fonts (needs a CSS link +
+   * FontRegistry.ensureFont() before paint) vs a local/system face.
    */
   webFont: boolean;
+  /** Google Fonts `wght@…` axis values to request. Defaults to '400;700'. */
+  weights?: string;
+  /** Open-source license (OFL / APACHE2 / UFL) for export-embed notices. */
+  license?: 'OFL' | 'APACHE2' | 'UFL';
+  /** Google Fonts subsets (scripts) the family covers. */
+  scripts?: string[];
+  /**
+   * Loaded eagerly in the bootstrap CSS link (`true`) vs on demand via
+   * `ensureFontLink` (absent/`false`). Only the small pre-catalog set is
+   * eager so the bootstrap request stays small as the catalog grows.
+   */
+  eager?: boolean;
 }
 
 export const FONT_CATALOG: readonly FontEntry[];
 export const FONT_SIZE_PRESETS: readonly number[];
 ```
 
-### Curated font list (14 entries)
+The `Display` and `Handwriting` groups, along with the `weights` /
+`license` / `scripts` / `eager` fields, arrived with the generated
+catalog; the original spec listed only the first four groups and the
+first three fields.
+
+### Curated font list (original v1 — 14 entries)
+
+The list below is the set shipped in the first version. It has since been
+superseded by the generated ~105-entry `font-catalog.data.ts` (which adds
+`Display` and `Handwriting` groups and dozens of Google Fonts web faces).
 
 | Group      | Family               | Source         |
 | ---------- | -------------------- | -------------- |
@@ -115,11 +158,12 @@ export const FONT_SIZE_PRESETS: readonly number[];
 | Monospace  | Courier New          | Local          |
 
 `packages/docs/src/view/fonts.ts` extends `FONT_MAP` with fallback chains
-for every entry and extends `SERIF_FONTS` with the new serif faces. Web
-fonts get a single Google Fonts CSS `<link>` injected at app
-bootstrap (subset = latin + korean), and actual font binaries are still
-fetched lazily by `FontRegistry.ensureFont()` on first paint of a run
-that requests them.
+for every entry and extends `SERIF_FONTS` with the new serif faces. Only
+the small `eager` subset of web fonts is requested in the bootstrap
+Google Fonts CSS `<link>`; the long tail lazy-loads its CSS via
+`ensureFontLink(family, weights)` the first time a family is picked,
+hovered, or previewed. Actual font binaries are still fetched lazily by
+`FontRegistry.ensureFont()` on first paint of a run that requests them.
 
 ### Font size control
 
@@ -153,10 +197,10 @@ checkmark in the dropdown when it matches a preset.
 
 ### Clear formatting
 
-Calls a new `editor.clearFormatting()` method that, over the current
-selection range, removes every inline-style attribute by mapping each
-`InlineStyle` key to `undefined` and dispatching through the existing
-`applyInlineStyle` path. Block-level styles (alignment, line height,
+Calls `editor.clearInlineFormatting()`, which over the current selection
+range removes every inline-style attribute by dispatching the
+`CLEAR_INLINE_STYLE` payload through the existing `applyStyle` path
+(mapping each `InlineStyle` key to `undefined`). Block-level styles (alignment, line height,
 list kind, list level, heading level) are intentionally preserved —
 this matches Google Docs' behavior and avoids accidentally collapsing a
 heading into a paragraph.
@@ -185,9 +229,10 @@ getRangeStyleSummary(): {
   strikethrough?: boolean | 'mixed';
   fontFamily?: string | 'mixed';
   fontSize?: number | 'mixed';
-  color?: string | 'mixed';
-  backgroundColor?: string | 'mixed';
-  // ...
+  color?: InlineStyle['color'] | 'mixed';
+  backgroundColor?: InlineStyle['backgroundColor'] | 'mixed';
+  superscript?: boolean | 'mixed';
+  subscript?: boolean | 'mixed';
 };
 
 /**
@@ -195,7 +240,7 @@ getRangeStyleSummary(): {
  * Block-level styles (alignment, line height, list kind/level, heading
  * level) are preserved.
  */
-clearFormatting(): void;
+clearInlineFormatting(): void;
 ```
 
 `getRangeStyleSummary` is implemented by walking the inline runs that
@@ -276,7 +321,7 @@ blocks render the dropdown trigger with an em dash.
   - `getRangeStyleSummary` returns uniform value, `'mixed'`, and
     `undefined` correctly across single-block and multi-block ranges
     and across table cells.
-  - `clearFormatting()` removes every inline attribute on the range,
+  - `clearInlineFormatting()` removes every inline attribute on the range,
     leaves block-level style untouched, and rebuilds the rendered
     layout (no stale style on remeasure).
 - **Integration (`docs-tree-attached.e2e-spec.ts` pattern)**
@@ -292,7 +337,7 @@ blocks render the dropdown trigger with an em dash.
 | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Lazy web-font load causes layout shift on first paint of a Noto/Roboto run.                                   | `FontRegistry` already triggers a re-render on load; pagination recomputes only the affected blocks via `markDirty`. The picker also prefetches the family on hover so most picks are ready before commit. |
 | Mixed selections silently apply the new family/size to runs that already had a different value.               | Match Google Docs: applying any value writes that value to every run in the selection. Mixed state shows empty in the input but a click still writes uniformly.                                             |
-| `clearFormatting` accidentally collapses headings to paragraphs (regression vs. Google Docs).                 | Restrict the new method to `InlineStyle` keys only; block-type and block-style updates go through unrelated APIs and are not touched.                                                                       |
+| `clearInlineFormatting` accidentally collapses headings to paragraphs (regression vs. Google Docs).           | Restrict the new method to `InlineStyle` keys only; block-type and block-style updates go through unrelated APIs and are not touched.                                                                       |
 | Size input causes runaway CRDT writes if `onChange` fires on every keystroke.                                 | Commit only on Enter / blur / spinner / preset pick (specified above).                                                                                                                                      |
 | 14 fonts is too small for some users; a future "More fonts" dialog would change the picker contract.          | Picker's `value` and `onChange` are already typed as `string`, not a closed union — the dialog can extend the catalog without breaking the contract.                                                        |
 | Slides currently has its own `ThemedFontPicker` that resolves theme tokens to families; sharing risks a fork. | Keep `ThemedFontPicker` as-is. The new `FontFamilyPicker` is for "raw family" selection only. Slides will adopt it later for the box-edit case; theme-token UX stays separate.                              |

--- a/docs/design/docs/docs-intent-preserving-edits.md
+++ b/docs/design/docs/docs-intent-preserving-edits.md
@@ -56,10 +56,9 @@ applyStyle(blockId, fromOffset, toOffset, style): void;
 splitBlock(blockId, offset, newBlockId, newBlockType): void;
 mergeBlock(blockId, nextBlockId): void;
 
-// Phase 4: Table cell variants
-insertTextInCell(tableBlockId, rowIndex, colIndex, cellBlockIndex, offset, text): void;
-deleteTextInCell(...): void;
-applyStyleInCell(...): void;
+// Phase 4: Table cell edits reuse the Phase 1–3 methods above — no
+// dedicated *InCell variants exist. resolveBlockTreePath() DFS resolves
+// cell-internal blockIds transparently (see Phase 4 below).
 ```
 
 ### Yorkie Tree Strategy
@@ -69,14 +68,14 @@ applyStyleInCell(...): void;
 | Text insert | `editByPath` | Character-level `[blockIdx, inlineIdx, charOffset]` | CRDT merge |
 | Text delete | `editByPath` | Character-level + empty inline cleanup | CRDT merge |
 | Style | `editByPath` (`splitLevel=1`) + `styleByPath` | Inline-level split + element style | CRDT merge |
-| Split | `editByPath` + `styleByPath` | Native CRDT split (`splitLevel=2`) | CRDT merge |
-| Merge | `editByPath` | Native boundary deletion | CRDT merge |
+| Split | `editByPath` + `styleByPath` | Manual two-step: delete "after" content + insert new block | CRDT merge |
+| Merge | `editByPath` + `editBulkByPath` | Two-step: delete next block + re-insert its inlines | CRDT merge |
 | Full doc write | `editBulkByPath` | Undo/redo fallback | — |
 
 **Path format:** 3 levels `[blockIdx, inlineIdx, charOffset]`. The inline
 node's `hasTextChild()` interprets the last element as a character offset.
 
-#### Native Inline Styling (SDK 0.7.6)
+#### Native Inline Styling
 
 Style operations use `editByPath` with `splitLevel=1` to split inline nodes
 at style boundaries, then `styleByPath` to apply attributes to the resulting
@@ -84,35 +83,28 @@ inlines. This eliminates LWW conflicts — concurrent text edits in the same
 block are preserved during styling operations. The split is performed at
 `toOffset` first, then `fromOffset`, so that earlier path indices remain valid.
 
-#### Native Split/Merge (SDK 0.7.4)
+#### Split/Merge (manual two-step)
 
-As of SDK 0.7.4, split and merge use native Yorkie Tree CRDT operations
-instead of block replacement. This eliminates LWW conflicts for concurrent
-structural edits.
+Split and merge deliberately avoid the native single-call `editByPath`
+splitLevel path — it breaks undo/redo and hits a yorkie-js-sdk range-narrowing
+bug on split-created blocks. Instead both operations decompose into
+same-parent edits, which still preserve editing intent (no whole-block
+replacement) while keeping undo/redo stable.
 
-**Split** uses `editByPath(path, path, undefined, splitLevel)` where
-`splitLevel=2`. The path points to text level `[blockIdx, inlineIdx,
-charOffset]`, and `splitLevel` counts only element ancestors (text nodes
-excluded). Two element levels are split: inline → block. After the split,
-`styleByPath` updates the new "after" block's attributes (id, type, list
-properties).
+**Split** is a two-step edit in `splitBlock`
+(`packages/frontend/src/app/docs/yorkie-doc-store.ts`): (1) delete the "after"
+content (from the split point to the end of the block) from the original
+block, then (2) insert a new block carrying that content via `editByPath` +
+`buildBlockNode`, followed by `styleByPath` to set the new block's attributes
+(id, type, list/heading properties). A native `splitLevel=2` call is
+explicitly *not* used — the only mentions of `splitLevel` in the store are
+comments explaining why it is avoided.
 
-**Merge** uses boundary deletion: `editByPath([blockIdx, inlineCount],
-[nextBlockIdx, 0])`. This deletes the range from the first block's close
-boundary to the next block's open boundary, triggering an automatic CRDT
-merge.
-
-**splitLevel note:** Yorkie's `splitLevel` counts from the immediate parent
-element of the text position upward. In our tree `doc → block → inline →
-text`, the parent chain from text is: inline (level 1) → block (level 2).
-So `splitLevel=2` achieves a block-level split.
-
-**Known concurrent edge cases (SDK 0.7.4):** Two integration tests remain
-skipped in the Yorkie SDK — `concurrently-split-split-test` and
-`concurrently-split-edit-test`. Both involve mixed `splitLevel` values
-(1 and 2) on deeply nested trees. Our use case (uniform `splitLevel=2` on
-a flat block list) is a narrower pattern, but concurrent split+edit
-divergence cannot be fully ruled out until these are resolved upstream.
+**Merge** in `mergeBlock` also decomposes into two same-parent operations,
+working around the yorkie-js-sdk "Phase 3 Range Narrowing" bug where a single
+cross-boundary `editByPath` fails on split-created blocks: (1) delete the next
+block element, then (2) re-insert its inline children at the end of the first
+block via `editBulkByPath` (deep-cloned so Yorkie mints fresh CRDT nodes).
 
 ### IME Composition and Undo Granularity
 
@@ -172,8 +164,8 @@ clamped, so the corrupted value survives. See issue #609.
 | Phase | Scope | Status |
 |-------|-------|--------|
 | 1 | Text insert/delete (character-level) | ✅ Shipped |
-| 2 | Inline styling (native CRDT, SDK 0.7.6) | ✅ Shipped |
-| 3 | Structural editing — split/merge (native CRDT, SDK 0.7.4) | ✅ Shipped |
+| 2 | Inline styling (native CRDT `editByPath`/`styleByPath`) | ✅ Shipped |
+| 3 | Structural editing — split/merge (manual two-step) | ✅ Shipped |
 | 4 | Table cell internal edits (extend Phase 1–3) | ✅ Shipped |
 | 5 | Block/cell attribute edits (styleByPath) | ✅ Shipped |
 | 6 | Cell span attributes (styleByPath) | ✅ Shipped |
@@ -318,11 +310,11 @@ deleting.
    before the local cursor, the position is not adjusted. Needs cursor
    transformation based on remote edit positions.
 
-2. **Concurrent split+edit edge cases** — Yorkie SDK 0.7.4 has two skipped
-   concurrent tests involving mixed splitLevel values. Our concurrent
-   integration tests (inline `splitLevel=1` + block `splitLevel=2`) converge
-   correctly in SDK 0.7.6, but edge cases cannot be fully ruled out until
-   resolved upstream.
+2. **Concurrent split+edit edge cases** — split/merge use the manual
+   two-step decomposition above (native `splitLevel=2` is avoided because it
+   breaks undo/redo and trips a yorkie-js-sdk range-narrowing bug). Our
+   concurrent integration tests converge correctly, but rare split+edit edge
+   cases cannot be fully ruled out.
 
 3. **Caret restoration races the live-cursor publisher during IME composition**
    — see "Caret Restoration on Undo Races Against the Live-Cursor Publisher"
@@ -335,8 +327,8 @@ deleting.
 |------|------------|
 | Yorkie `editByPath` at text level has bugs | Extensive testing; started with simplest case |
 | Model cache diverges from Yorkie Tree | In-place cache update after each mutation |
-| Yorkie Tree undo unstable for mixed ops | Feature-flagged; SDK 0.7.3 includes fix for mixed char+block undo |
+| Yorkie Tree undo unstable for mixed ops | Split/merge use the manual two-step decomposition (native `splitLevel=2` avoided) to keep undo/redo stable |
 | Performance regression | Benchmark per-character ops vs block replacement |
-| Native split divergence on concurrent split+edit | Uniform splitLevel=2 on flat block list; concurrent integration tests added |
+| Split divergence on concurrent split+edit | Manual two-step split/merge (native splitLevel avoided); concurrent integration tests added |
 | DFS tree traversal cost for cell block lookup | Tables are small; optimize with index cache if profiling shows regression |
 | Doc routing cleanup breaks existing cell editing | Each step is independently testable; unit + concurrent tests per step |

--- a/docs/design/docs/docs-local-caret-anchoring.md
+++ b/docs/design/docs/docs-local-caret-anchoring.md
@@ -10,16 +10,17 @@ target-version: 0.4.1
 Keep the local caret and text selection attached to the user's intended
 logical text position when remote collaborators edit the same document.
 
-Today the docs editor stores the local caret as an absolute
-`{ blockId, offset }`. In collaborative mode, remote document changes invalidate
-the render cache, but they do not transform that local offset. If another user
-inserts text before the local caret in the same block, the caret keeps the same
-numeric offset and ends up pointing to a different character.
+The docs editor originally stored the local caret as an absolute
+`{ blockId, offset }`. In collaborative mode, remote document changes invalidated
+the render cache but did not transform that local offset, so if another user
+inserted text before the local caret in the same block, the caret kept the same
+numeric offset and ended up pointing to a different character.
 
-The proposed fix is to anchor the local caret and selection to Yorkie Tree
-positions in the frontend collaboration layer, then resolve those anchors back
-to `{ blockId, offset }` only when the editor needs to render or operate on the
-current document snapshot.
+This is now fixed: the local caret and selection are anchored to Yorkie Tree
+positions in the frontend collaboration layer (`YorkieDocStore` in
+`packages/frontend/src/app/docs/yorkie-doc-store.ts`), and those anchors are
+resolved back to `{ blockId, offset }` when the editor needs to render or
+operate on the current document snapshot.
 
 ## Background
 
@@ -29,17 +30,18 @@ shifting with the logical text position. The expected behavior matches editors
 like Google Docs and Notion: the caret should remain attached to the character
 boundary it originally represented.
 
-The maintainer confirmed this is a bug, not intentional behavior. The current
-local caret uses `DocPosition` from `packages/docs/src/model/types.ts`, while
-remote changes in `packages/frontend/src/app/docs/yorkie-doc-store.ts`
-invalidate render state without transforming the stored local offset.
+The maintainer confirmed this was a bug, not intentional behavior. The local
+caret uses `DocPosition` from `packages/docs/src/model/types.ts`, while the
+pre-fix remote-change path in
+`packages/frontend/src/app/docs/yorkie-doc-store.ts` invalidated render state
+without transforming the stored local offset.
 
-The maintainer also pointed to the preferred direction: anchor the caret to a
-Yorkie Tree position, then resolve back to `DocPosition` at render time. This
-is similar to the position-preserving approach needed for collaborative cursor
-state, but this note focuses on the local caret and selection first. Because
-the change touches headers, footers, tables, and selection paths, this note
-records the expected edge-case behavior before implementation.
+The maintainer also pointed to the preferred direction, which is what shipped:
+anchor the caret to a Yorkie Tree position, then resolve back to `DocPosition`
+at render time. This is similar to the position-preserving approach needed for
+collaborative cursor state, but this note focuses on the local caret and
+selection. Because the change touches headers, footers, tables, and selection
+paths, this note records the edge-case behavior the implementation covers.
 
 ## Goals
 
@@ -64,7 +66,7 @@ records the expected edge-case behavior before implementation.
 
 ### API Boundary
 
-`packages/docs` should continue to use resolved `DocPosition` values for
+`packages/docs` continues to use resolved `DocPosition` values for
 editing, layout, hit-testing, and rendering:
 
 ```ts
@@ -74,12 +76,19 @@ interface DocPosition {
 }
 ```
 
-The Yorkie-backed frontend integration should own the anchored representation:
+The Yorkie-backed frontend integration owns the anchored representation. The
+shipped types in `yorkie-doc-store.ts` also carry `blockId`, `offset`, and
+`regionTopIndex` — the last-known resolved position plus the anchor's top-level
+region-block index — which back the deterministic fallback ladder when the
+Yorkie position no longer resolves to a usable block:
 
 ```ts
 type AnchoredDocPosition = {
   region: 'body' | 'header' | 'footer';
-  yorkiePosition: TreePos;
+  blockId: string;
+  offset: number;
+  regionTopIndex: number;
+  yorkiePosition: TreePosRange;
   lineAffinity?: 'forward' | 'backward';
 };
 
@@ -90,7 +99,7 @@ type AnchoredDocRange = {
 };
 ```
 
-The concrete anchor is Yorkie's Tree position type. Convert a collapsed caret
+The concrete anchor is Yorkie's Tree position range type. Convert a collapsed caret
 or range endpoint with `tree.indexRangeToPosRange([index, index])`, and resolve
 it with `tree.posRangeToIndexRange(posRange)`. A caret is a collapsed range, so
 `AnchoredDocRange` maps 1:1 to two endpoint anchors. Yorkie-specific state
@@ -298,11 +307,17 @@ anchor, but it is never committed at a stale absolute offset.
 
 ## Rollout Plan
 
-1. Add local anchor conversion helpers in the Yorkie-backed docs integration.
-2. Store a local caret anchor whenever the editor cursor changes.
-3. Resolve and restore the local caret after remote document changes.
-4. Extend the same mechanism to non-collapsed text selections.
-5. Add tests for body text first, then tables, headers, and footers.
+Steps 1–5 have shipped in `yorkie-doc-store.ts` and `docs-view.tsx`; step 6
+remains a future consideration.
+
+1. ✅ Local anchor conversion helpers in the Yorkie-backed docs integration
+   (`anchorDocPosition`, `anchorDocRange`, `resolveAnchoredDocPosition`).
+2. ✅ Store a local caret anchor whenever the editor cursor changes
+   (`localCursorAnchor` / `localSelectionAnchor`).
+3. ✅ Resolve and restore the local caret after remote document changes
+   (`resolveAnchoredLocalCursor` wired into `store.onRemoteChange`).
+4. ✅ Extend the same mechanism to non-collapsed text selections.
+5. ✅ Tests for body text, tables, headers, and footers.
 6. Revisit remote peer cursor presence separately if the same anchor strategy
    should be shared later.
 

--- a/docs/design/docs/docs-named-styles.md
+++ b/docs/design/docs/docs-named-styles.md
@@ -155,10 +155,17 @@ resetAllStyles(): void;                                            // "Reset sty
 
 `updateStyleDefinition` / `resetStyle` / `resetAllStyles` each run as one
 batched undo unit and re-materialize block spacing for affected blocks.
-Implemented in `MemStore` (plain `this.doc.styles`) and `YorkieDocStore`
-(root-level `root.styles`, mirroring the `pageSetup` getter/setter +
-`readDocStyles` proxy-unwrap helper). Backend `docs-tree.ts` `DocsYorkieRoot`
-serializes `styles` the same way (deep copy on write, delete on omission).
+Implemented in `MemStore` (plain `this.doc.styles`) and `YorkieDocStore`.
+Unlike `pageSetup`, which is a nested CRDT object, the registry is stored at
+the Yorkie root as a single serialized JSON string (`root.stylesJson`): it is
+tiny and rarely concurrently edited, so whole-blob LWW is acceptable, and a
+scalar string sidesteps Yorkie proxy double-encoding and the variable /
+`StoredColor` key shapes inside a style definition. `readDocStyles`
+(`packages/frontend/src/app/docs/yorkie-doc-store.ts`) therefore `JSON.parse`s
+`root.stylesJson` rather than proxy-unwrapping. Backend
+`packages/backend/src/yorkie/docs-tree.ts` mirrors this with a
+`stylesJson?: string` field on `DocsYorkieRoot` (`JSON.stringify` on write,
+`delete` on omission).
 
 ### Per-user default styles (backend)
 
@@ -177,8 +184,8 @@ Endpoints (JWT, `@CurrentUser`-style like `auth.controller.ts` `getMe`):
 
 | Method | Route | Description |
 | --- | --- | --- |
-| `GET` | `/auth/me/doc-styles` | Return saved `DocStyles` (or `{}`) |
-| `PUT` | `/auth/me/doc-styles` | Upsert the current user's `DocStyles` |
+| `GET` | `/auth/me/doc-styles` | Return `{ styles }` — the saved `DocStyles` (or `{}`) wrapped |
+| `PUT` | `/auth/me/doc-styles` | Upsert the current user's `DocStyles`; returns `{ styles }` |
 
 Frontend wires these into the Styles dropdown "Options" submenu:
 - **Save as my default styles** → `PUT` current `getDocStyles()`.
@@ -203,8 +210,9 @@ callbacks to `EditorAPI` primitives that call the store methods above.
   in the PR; built-in-only — no data migration, and a user who preferred bold
   can "Update Heading 1 to match" a bold sample.
 - **Registry not understood by older clients / backend.** *Mitigation:*
-  `styles` is optional and additive at the Yorkie root, exactly like
-  `pageSetup`; absence resolves to built-ins.
+  `root.stylesJson` is optional and additive at the Yorkie root (like
+  `pageSetup`, though stored as a scalar JSON string rather than a nested CRDT
+  object); absence resolves to built-ins.
 - **Eager spacing materialization clobbers custom paragraph spacing on style
   switch.** *Mitigation:* only re-materialize when `StyleId` actually changes;
   this matches Google Docs (applying a style resets paragraph formatting).

--- a/docs/design/docs/docs-pagination.md
+++ b/docs/design/docs/docs-pagination.md
@@ -92,8 +92,8 @@ interface Document {
 When `pageSetup` is undefined, all consumers use `DEFAULT_PAGE_SETUP`. This
 avoids a breaking change — existing `Document` construction sites
 (`MemDocStore`, `Doc.create()`, tests) continue to work without modification.
-A helper `resolvePageSetup(doc: Document): PageSetup` returns
-`doc.pageSetup ?? DEFAULT_PAGE_SETUP`.
+A helper `resolvePageSetup(setup: PageSetup | undefined): PageSetup` returns
+`setup ?? DEFAULT_PAGE_SETUP` (callers pass `doc.document.pageSetup`).
 
 ## Pagination Engine
 

--- a/docs/design/docs/docs-paste-table-into-cell.md
+++ b/docs/design/docs/docs-paste-table-into-cell.md
@@ -152,10 +152,11 @@ Model-level unit tests (`packages/docs/test/model/paste-table-into-cell.test.ts`
 
 The four tests above landed with #528 (PR #531) and already exist on `main`.
 This note's #333 fix (recursive fresh ids + the `findBlockInCells` fallback)
-still needs its own regression coverage — a model-level test asserting
+has its own regression coverage as well — a model-level test asserting
 `Doc.getBlock` resolves a block inside a freshly pasted nested table that
-isn't yet in `_blockParentMap` — which is planned for the implementation PR
-that follows this design note, not part of this doc-only PR.
+isn't yet in `_blockParentMap` (`describe('Doc.getBlock resolves freshly
+pasted nested-table content (#333)')` in
+`packages/docs/test/model/paste-table-into-cell.test.ts`).
 
 Manual smoke plan (`pnpm dev`): copy a table (drag from a line above through a
 line below → `[paragraph, table, paragraph]`), click into a cell, paste — the
@@ -163,16 +164,14 @@ blocks should nest into the clicked cell (no crash). Also re-run #333's repro
 steps (2-level and 3-level nested tables, copy the outer table, paste
 elsewhere, click/type into the pasted copy at every nesting level) — the caret
 should enter and input should land in the pasted copy at every level, not the
-source. (Both were manually verified against a local draft of the
-implementation while investigating this note; re-verify against whatever
-actually lands in the implementation PR.)
+source.
 
 ## Risks and Mitigation
 
 | Risk | Mitigation |
 |------|------------|
 | Multi-block paste into a cell crashes (`Block not found`) | Root cause is the body-only middle-block insertion; replaced with cell-aware `insertBlockAfter` chaining so the split tail stays resolvable |
-| Pasted table shares cell ids with the source (same-tab copy) — #333's caret-rejection / input-misroute at every nesting level | `cloneBlockWithFreshIds` deep-regenerates ids recursively through nested tables (no-collision test already on `main` from #528); `findBlockInCells` gains a recursive fallback for blocks not yet in `_blockParentMap` (regression test planned for the implementation PR); manually verified against #333's 2-level and 3-level repro steps on a local draft |
+| Pasted table shares cell ids with the source (same-tab copy) — #333's caret-rejection / input-misroute at every nesting level | `cloneBlockWithFreshIds` deep-regenerates ids recursively through nested tables (no-collision test already on `main` from #528); `findBlockInCells` gains a recursive fallback for blocks not yet in `_blockParentMap` (regression test on `main` in `packages/docs/test/model/paste-table-into-cell.test.ts`); manually verified against #333's 2-level and 3-level repro steps |
 | Changing the body multi-block path regresses body paste | `insertBlockAfter(pos.blockId, …)` after the head is equivalent to `insertBlockAt(getBlockIndex+1)` for a body sibling; a body-paste regression-guard test covers it |
 | `blockParentMap` / cell signal stale after a remote edit | Use `getActiveLayout()` (refreshed for the active region), matching existing table ops |
 | Caret left in a stale position | Single-table: move into the pasted table's first cell; multi-block: keep the existing tail-block caret placement |

--- a/docs/design/docs/docs-pdf-export.md
+++ b/docs/design/docs/docs-pdf-export.md
@@ -136,9 +136,19 @@ Separation rationale:
 // packages/docs/src/export/pdf-exporter.ts
 
 export interface PdfExportOptions {
+  /** Text measurer used for layout and pagination. **Required** — the
+      browser passes its Canvas measurer, the CLI a fontkit-backed one,
+      tests a deterministic stub. No silent fallback. */
+  measurer: TextMeasurer;
   /** Required when document contains image inlines. Same fetcher used by
       DocxExporter — frontend can pass the same instance to both. */
   imageFetcher?: ImageFetcher;
+  /** Resolves a curated Google Font family to embeddable TTF URLs so it
+      exports with its real face instead of a Helvetica/Times fallback.
+      Injected by the frontend (see P3-a below). */
+  fontResolver?: PdfFontResolver;
+  /** Optional pre-constructed font cache (defaults to `new PdfFonts()`). */
+  fonts?: PdfFonts;
   /** Optional metadata. Defaults: title from doc, author empty,
       creationDate = now. */
   metadata?: {
@@ -147,12 +157,15 @@ export interface PdfExportOptions {
     subject?: string;
     keywords?: string[];
   };
+  /** Progress callback: `(done, total, 'pages')`. */
+  onProgress?: (done: number, total: number, phase: string) => void;
 }
 
 export class PdfExporter {
+  // `opts` is required — `opts.measurer` must be supplied.
   static async export(
     doc: Document,
-    options?: PdfExportOptions,
+    opts: PdfExportOptions,
   ): Promise<Blob>;
 }
 ```
@@ -413,7 +426,7 @@ async function exportPdf(doc, title) {
 | Integration      | Vitest + pdf-lib | Re-load exported PDF, verify pages/text/fonts          |
 | Visual (manual)  | Adobe / Preview  | See verification checklist                             |
 
-Test fixtures in `packages/docs/src/export/__tests__/fixtures/`:
+Test fixtures live in `packages/docs/test/export/fixtures/pdf/`:
 
 - `simple-paragraph.json`
 - `mixed-korean-english.json`
@@ -421,7 +434,7 @@ Test fixtures in `packages/docs/src/export/__tests__/fixtures/`:
 - `with-merged-cells.json`
 - `with-split-row.json`
 - `with-image.json`
-- `multi-page.json`
+- `with-list.json`
 - `with-headings-and-links.json`
 - `with-header-footer-pagenumber.json`
 
@@ -452,24 +465,25 @@ packages/docs/src/
     pdf-fonts.ts
     pdf-table-painter.ts
     pdf-image-painter.ts
-    __tests__/
-      pdf-style-map.test.ts
-      pdf-fonts.test.ts
-      pdf-painter.test.ts
-      pdf-exporter.test.ts
-      fixtures/
-        *.json
-        fonts/
-          NotoSansKR-Regular.ttf      # for unit tests only, not bundled
-          NotoSansKR-Bold.ttf
-          NotoSerifKR-Regular.otf
-          NotoSerifKR-Bold.otf
+    yield.ts                          # cooperative yieldToPaint for progress
   view/
     table-geometry.ts                 # extracted from table-renderer.ts
+
+packages/docs/test/export/            # tests live under test/, not src/__tests__
+  pdf-exporter.test.ts
+  pdf-style-map.test.ts
+  pdf-painter.test.ts
+  pdf-fonts.test.ts
+  pdf-font-fallback.test.ts
+  fixtures/
+    pdf/*.json
+    fonts/
+      test-cjk.ttf                    # small CJK font for unit tests, not bundled
 
 packages/frontend/src/app/docs/
   export-utils.ts
   pdf-actions.ts
+  docs-export-button.tsx              # Export ▾ dropdown (DOCX / PDF)
   docx-actions.ts                     # refactored to use export-utils
 ```
 

--- a/docs/design/docs/docs-pending-inline-style.md
+++ b/docs/design/docs/docs-pending-inline-style.md
@@ -7,10 +7,10 @@ target-version: 0.4.3
 
 ## Summary
 
-Today the docs editor silently ignores inline-style toolbar actions when the
-selection is collapsed: hitting **B** with no text selected does nothing.
-This proposal adds a transient *pending style* — the next characters the user
-types pick up the toggled style, and the pending state is dropped if the
+Previously the docs editor silently ignored inline-style toolbar actions when
+the selection was collapsed: hitting **B** with no text selected did nothing.
+The editor now implements a transient *pending style* — the next characters the
+user types pick up the toggled style, and the pending state is dropped if the
 caret moves elsewhere first. The pattern matches ProseMirror's "stored marks"
 and Google Docs' empty-caret formatting behaviour.
 
@@ -72,7 +72,7 @@ No changes to `DocStore`, the Yorkie schema, or `model/document.ts`.
 
 ### `PendingStyle` controller
 
-New file: `packages/docs/src/view/pending-style.ts` (~40 lines).
+The controller lives in `packages/docs/src/view/pending-style.ts` (~50 lines).
 
 ```ts
 export interface PendingStyle {
@@ -107,7 +107,7 @@ export interface PendingStyle {
   rebindAnchor(blockId: string): void;
 }
 
-export function createPendingStyle(doc: Document): PendingStyle;
+export function createPendingStyle(doc: Doc): PendingStyle;
 ```
 
 Internal state is `{ style, anchorBlockId, anchorOffset } | null`. All
@@ -240,7 +240,10 @@ read the same getter and pick up the change automatically.
 
 ### Testing
 
-New file: `packages/docs/test/view/pending-style.test.ts`.
+Tests live in three files: `packages/docs/test/view/pending-style.test.ts`
+(controller unit tests), `packages/docs/test/view/pending-style-editor.test.ts`,
+and `packages/docs/test/view/pending-style-integration.test.ts` (editor
+integration).
 
 Unit tests for the controller:
 
@@ -253,7 +256,7 @@ Unit tests for the controller:
 - `rewindAnchor` subtracts and clamps at 0.
 - `rebindAnchor` moves anchor to a new block at offset 0.
 
-Editor integration tests (extend existing `view/*.test.ts` style):
+Editor integration tests:
 
 - Collapsed + `applyStyle({bold:true})` + `insertText "abc"` → all three
   chars are bold in the document.

--- a/docs/design/docs/docs-presence.md
+++ b/docs/design/docs/docs-presence.md
@@ -17,7 +17,10 @@ together.
 The cursor + label surface shipped in v0.3.1 (Phase 1); the avatar
 jump shipped in v0.3.8 and generalized the shared `UserPresence`
 component so Sheets and Docs both flow through `onSelectPeer` /
-`getJumpHint`. Remote selection highlight is Phase 2 (planned).
+`getJumpHint`. Remote selection highlight also shipped: peers broadcast
+`activeSelection`, `buildPeerCursors` threads it through as
+`PeerCursor.selection`, and `packages/docs/src/view/doc-canvas.ts`
+paints a per-page highlight behind the local selection.
 
 ## Goals / Non-Goals
 
@@ -43,7 +46,6 @@ component so Sheets and Docs both flow through `onSelectPeer` /
 
 ### Non-Goals
 
-- Remote selection highlight (Phase 2).
 - Avatar or profile picture in the label.
 - Animated fade-in / fade-out transitions.
 - Off-screen peer indicators ("User X is on page 3"). The avatar
@@ -77,13 +79,27 @@ type SheetPresence = {
   activeTabId?: string;
 } & User;
 
-// Docs presence (added in v0.3.1)
+// Docs presence (added in v0.3.1) — inlines the identity fields rather
+// than intersecting with User.
 type DocsPresence = {
+  username: string;
+  email: string;
+  photo: string;
   activeCursorPos?: {
     blockId: string;
     offset: number;
   };
-} & User;
+  // Remote selection highlight payload (shipped).
+  activeSelection?: {
+    anchor: { blockId: string; offset: number };
+    focus: { blockId: string; offset: number };
+    tableCellRange?: {
+      blockId: string;
+      start: { rowIndex: number; colIndex: number };
+      end: { rowIndex: number; colIndex: number };
+    };
+  };
+};
 ```
 
 No `activeDocId` filtering field is needed — each Yorkie document is
@@ -136,12 +152,14 @@ Yorkie others-changed event
 **`PeerCursor`** (defined in the docs package for rendering):
 
 ```ts
-// packages/docs/src/view/types.ts
+// packages/docs/src/view/peer-cursor.ts
 type PeerCursor = {
+  clientID: string;
   position: DocPosition;
   color: string;
   username: string;
   labelVisible: boolean;   // controlled by DocsView visibility state
+  selection?: DocRange;    // remote selection highlight (shipped)
 };
 ```
 

--- a/docs/design/docs/docs-ruler.md
+++ b/docs/design/docs/docs-ruler.md
@@ -109,7 +109,7 @@ Both snap to the same grid as margins.
 
 ```typescript
 export interface BlockStyle {
-  alignment: 'left' | 'center' | 'right';
+  alignment: 'left' | 'center' | 'right' | 'justify';
   lineHeight: number;
   marginTop: number;
   marginBottom: number;
@@ -131,22 +131,32 @@ export interface BlockStyle {
 
 ### File Structure
 
-**New file:** `packages/docs/src/view/ruler.ts`
+**New module:** `packages/docs/src/view/ruler/` — a directory module split into
+`packages/docs/src/view/ruler/index.ts` (the `Ruler` class + `RULER_SIZE`),
+`packages/docs/src/view/ruler/unit.ts` (`RulerUnit`, `detectUnit`,
+`getGridConfig`, `snapToGrid`), and
+`packages/docs/src/view/ruler/tick-renderer.ts` (`drawTicks`).
 
 ```typescript
 class Ruler {
-  constructor(container: HTMLElement, docCanvas: HTMLCanvasElement)
+  constructor(
+    container: HTMLElement,
+    docCanvas: HTMLCanvasElement,
+    readOnly?: boolean,   // skip mouse handlers when the editor is read-only
+  )
 
   render(
     paginatedLayout: PaginatedLayout,
     scrollY: number,
     canvasWidth: number,
     viewportHeight: number,
-    cursorBlockStyle: BlockStyle,
+    cursorBlockStyle: BlockStyle | null,
+    cursorPageIndex?: number,   // which page the horizontal ruler tracks
   ): void
 
   onMarginChange(cb: (margins: PageMargins) => void): void
   onIndentChange(cb: (style: Partial<BlockStyle>) => void): void
+  onDragGuideline(cb: (position: { x?: number; y?: number } | null) => void): void
 
   dispose(): void
 }

--- a/docs/design/docs/docs-spell-check.md
+++ b/docs/design/docs/docs-spell-check.md
@@ -46,7 +46,9 @@ The misspelled-range set is view-local session state (like
   follow-up project.
 - **Ignore / Ignore all.**
 - **Add to personal dictionary (persisted).**
-- **Toggle spell check on/off** (UI control).
+- **Toggle spell check on/off** (UI control). A programmatic
+  `setSpellCheckEnabled(enabled)` primitive exists on `EditorAPI`
+  (on by default), but no toolbar/menu control is wired to it in v1.
 - **Tables and headers/footers.** Only top-level body blocks are scanned;
   `getBlockText` returns empty for table blocks, so misspellings inside
   table cells and header/footer regions are not flagged in v1.
@@ -194,7 +196,7 @@ Add `nspell` to `packages/docs` dependencies; keep `dictionary-en` as a
 dev dependency (provenance for the vendored files). The en_US `.aff`/
 `.dic` are vendored into `src/spell/dict/` and loaded via `?raw` dynamic
 import so they form a lazy chunk, not part of the main bundle. The two
-dict chunks bump the frontend chunk count 108 → 110 in
+dict chunks bump the frontend chunk count 109 → 111 in
 `harness.config.json` (with a reason entry); the main docs entry stays
 ~346 KB with no dict inlined.
 
@@ -203,12 +205,11 @@ dict chunks bump the frontend chunk count 108 → 110 in
 - **Unit**
   - `SpellRouter`: Latin→en, Hangul→backend(absent→pass), CJK→skip;
     mixed-script paragraph routing.
-  - `tokenize`: skip rules (numbers, URLs, acronyms, <2 chars, caret
-    word, IME).
+  - `tokenize`: skip rules (numbers, URLs, acronyms, <2 chars, IME).
   - `LocalSpellProvider`: check/suggest against fixtures (known good +
     known misspelling → expected suggestions).
-  - `SpellSession`: range set updates on mutation; caret-word & IME
-    skips; hit-test; generation guard (stale recheck discarded); replace
+  - `SpellSession`: range set updates on mutation; IME skip; hit-test;
+    generation guard (stale recheck discarded); replace
     calls only `snapshot`+`deleteText`+`insertText` (view-local invariant).
   - `squigglePoints` geometry (zigzag alternation).
 - **Deferred / manual**

--- a/docs/design/docs/docs-tables.md
+++ b/docs/design/docs/docs-tables.md
@@ -397,13 +397,20 @@ callback for atomicity.
 ```typescript
 // YorkieDocStore.buildBlockNode — block(type='table') case
 if (block.type === 'table' && block.tableData) {
+  const attributes: Record<string, string> = {
+    id: block.id,
+    type: 'table',
+    cols: block.tableData.columnWidths.join(','),
+  };
+  // rowHeights is persisted (empty slot = '', so column-only tables stay compact).
+  if (block.tableData.rowHeights && block.tableData.rowHeights.length > 0) {
+    attributes.rowHeights = block.tableData.rowHeights
+      .map((h) => h ?? '')
+      .join(',');
+  }
   return {
     type: 'block',
-    attributes: {
-      id: block.id,
-      type: 'table',
-      cols: block.tableData.columnWidths.join(','),
-    },
+    attributes,
     children: block.tableData.rows.map((row) => ({
       type: 'row',
       attributes: {},
@@ -417,6 +424,8 @@ if (block.type === 'table' && block.tableData) {
 }
 
 // YorkieDocStore.treeNodeToBlock — table case (sketch)
+// Restores columnWidths from `cols` and, when present, rowHeights from the
+// `rowHeights` attribute ('' slots deserialize back to undefined).
 function treeNodeToBlock(node: TreeNode): Block { /* recursive walk */ }
 function treeNodeToRow(node: TreeNode): TableRow { /* filter type==='row' */ }
 function treeNodeToCell(node: TreeNode): TableCell {

--- a/docs/design/docs/docs-tables.md
+++ b/docs/design/docs/docs-tables.md
@@ -76,7 +76,8 @@ interface Block {
 ```typescript
 interface TableData {
   rows: TableRow[];
-  columnWidths: number[];      // Proportional ratios (0–1), sum = 1.0
+  columnWidths: number[];              // Proportional ratios (0–1), sum = 1.0
+  rowHeights?: (number | undefined)[]; // Optional per-row pixel heights (row resize)
 }
 
 interface TableRow {
@@ -198,7 +199,11 @@ interface BlockCellInfo {
   colIndex: number;
 }
 
-type BlockParentMap = Map<string, BlockCellInfo>;
+// The reverse-lookup map is a plain Map<string, BlockCellInfo>, held on
+// Doc as the private `_blockParentMap` field and exposed via the
+// `blockParentMap` getter (set through `setBlockParentMap`). There is no
+// exported `BlockParentMap` type alias — "BlockParentMap" is just the
+// conceptual name used in code comments and this doc.
 ```
 
 Built during layout computation by walking the table structure
@@ -206,7 +211,7 @@ Built during layout computation by walking the table structure
 [`tables/docs-nested-tables.md`](tables/docs-nested-tables.md)). Cached
 on `DocumentLayout` and invalidated when the table block is dirty.
 
-**Usage:** only navigation decisions consult `BlockParentMap`. Normal
+**Usage:** only navigation decisions consult the block-parent map. Normal
 text editing uses `blockId` directly.
 
 ### Navigation Rules
@@ -352,7 +357,10 @@ interface DocStore {
   updateTableCell(
     tableBlockId: string, rowIndex: number, colIndex: number, cell: TableCell,
   ): void;
-  updateTableAttrs(tableBlockId: string, attrs: { cols: number[] }): void;
+  updateTableAttrs(
+    tableBlockId: string,
+    attrs: { cols: number[]; rowHeights?: (number | undefined)[] },
+  ): void;
 }
 ```
 

--- a/docs/design/docs/docs-wordprocessor-roadmap.md
+++ b/docs/design/docs/docs-wordprocessor-roadmap.md
@@ -56,8 +56,8 @@ planned item links to (or will link to) its own design doc.
 | Images (insert, resize, rotate, crop, alignment) | ✅ |
 | Header / Footer (per-page editable regions) | ✅ |
 | Comments (text-range threads, posRange anchors) | ✅ |
+| Page break (manual `Ctrl+Enter` / `Cmd+Enter`, first-class `page-break` block) | ✅ |
 | Code block | ❌ Planned |
-| Page break (manual `Ctrl+Enter`) | ❌ Planned |
 | Section break (per-section PageSetup) | ❌ Planned |
 | Table of contents | ❌ Planned |
 | Suggestion mode (track changes) | ❌ Planned |
@@ -85,6 +85,7 @@ in the README index — the roadmap no longer duplicates their content.
 | Phase 3.2: Tables | Cells as `Block[]` containers, row/column ops, cell merge, Tree CRDT | [`docs-tables.md`](docs-tables.md) (umbrella) and the per-feature docs under [`tables/`](tables/) — UI, resize, copy-paste, row splitting, nested tables |
 | Phase 3.1: Images | Insert, resize, rotate, crop, Image Options panel | [`docs-image-editing.md`](docs-image-editing.md) |
 | Phase 4.1: Header / Footer | Editable per-page header/footer regions | [`docs-header-footer.md`](docs-header-footer.md) |
+| Phase 4.2: Page Break | Manual `Ctrl+Enter` / `Cmd+Enter` inserts a first-class `page-break` block (`handlePageBreak` in `packages/docs/src/view/text-editor.ts`), disabled in header/footer and table cells | This `Current State` table |
 | Phase 5.1: Comments | Text-range threads, posRange anchors, orphan preservation | [`docs-comments.md`](docs-comments.md) |
 | Phase 6.3: Spell check | English red squiggles + suggestions popover; vendored en_US Hunspell dict lazy-loaded as a separate chunk; per-word script routing; Korean/ignore/add-to-dictionary deferred | [`docs-spell-check.md`](docs-spell-check.md) |
 
@@ -98,12 +99,6 @@ doc when it picks up an owner.
 `Block.type = 'code-block'`. Monospace font, distinct background,
 inline formatting disabled inside the block, auto-convert on ``` ` ` ` ```
 input. Syntax highlighting is a follow-up.
-
-### Phase 4.2: Page Break
-
-`Block.type = 'page-break'`. Forces a page split. Shortcut:
-`Ctrl+Enter`. Already handled at the layout level via `page-break`
-blocks injected by find/replace; needs a first-class UI affordance.
 
 ### Phase 4.3: Section Break
 
@@ -170,5 +165,5 @@ Phase 2 (Inline + Clipboard) ✅ ┘                                    │
                                                        Phase 5 (Collaboration) ──→ Phase 6 (Advanced)
 ```
 
-Phases 1, 2, 3.1/3.2, 4.1, 5.1 have shipped. Phases 3.3, 4.2–4.4, 5.2,
-5.3, 6 remain in this roadmap.
+Phases 1, 2, 3.1/3.2, 4.1, 4.2, 5.1 have shipped. Phases 3.3, 4.3–4.4,
+5.2, 5.3, 6 remain in this roadmap.

--- a/docs/design/docs/docs.md
+++ b/docs/design/docs/docs.md
@@ -7,7 +7,7 @@ target-version: 0.3.0
 
 ## Summary
 
-A new `packages/docs` package (`@wafflebase/document`) that provides a Canvas-based rich-text document
+A new `packages/docs` package (`@wafflebase/docs`) that provides a Canvas-based rich-text document
 editor, following the same architectural patterns as the existing `packages/sheets`.
 The initial prototype focuses on paragraph-level text editing with inline
 formatting, cursor/selection management, and undo/redo — all rendered on a
@@ -23,7 +23,7 @@ single HTML Canvas element.
 ### Goals
 
 - Provide a minimal but functional Canvas-based document editor as a new
-  monorepo package (`@wafflebase/document`).
+  monorepo package (`@wafflebase/docs`).
 - Support paragraph editing: text input/deletion, Enter to split blocks,
   Backspace to merge blocks.
 - Support inline text formatting: bold, italic, underline, font size, font
@@ -110,8 +110,10 @@ interface InlineStyle {
 - **Inline splitting**: When formatting changes mid-text, the affected Inline
   is split into two or three Inlines. Adjacent Inlines with identical styles
   are merged to keep the model compact.
-- **Block type**: Currently only `'paragraph'`. The discriminated union allows
-  future extension to `'table' | 'heading' | 'list'` etc.
+- **Block type**: The discriminated union has since grown well beyond
+  `'paragraph'`. `BlockType` in `packages/docs/src/model/types.ts` is now
+  `'paragraph' | 'title' | 'subtitle' | 'heading' | 'list-item' |
+  'horizontal-rule' | 'table' | 'page-break'`.
 
 ### Document manipulation
 
@@ -163,8 +165,12 @@ interface DocStore {
 `MemDocStore` implementation:
 - Stores `Document` in memory.
 - Undo/redo via snapshot stack (deep-clone before each mutation).
-- Future `YorkieDocStore` will implement the same interface using Yorkie CRDT
-  operations, following the pattern established by the sheet package.
+
+`YorkieDocStore` (`packages/frontend/src/app/docs/yorkie-doc-store.ts`)
+implements the same `DocStore` interface using Yorkie CRDT operations,
+following the pattern established by the sheet package. See
+[`docs-collaboration.md`](docs-collaboration.md) and
+[`docs-intent-preserving-edits.md`](docs-intent-preserving-edits.md).
 
 ## Canvas Rendering
 
@@ -267,7 +273,7 @@ Desktop is unchanged (the cap at 1.0 means no scaling).
 
 ```
 packages/docs/
-├── package.json            # @wafflebase/document, same build pattern as sheets
+├── package.json            # @wafflebase/docs, same build pattern as sheets
 ├── tsconfig.json
 ├── vite.config.ts          # dev config
 ├── vite.build.ts           # library build (es + cjs)
@@ -284,8 +290,7 @@ packages/docs/
 │       ├── doc-canvas.ts   # Canvas rendering engine
 │       ├── cursor.ts       # Cursor management
 │       ├── selection.ts    # Selection management
-│       ├── text-editor.ts  # Input handling (keyboard, mouse)
-│       ├── doc-container.ts # Scroll management
+│       ├── text-editor.ts  # Input handling (keyboard, mouse) + scroll management
 │       ├── layout.ts       # Text measurement, word-wrap, layout tree
 │       └── theme.ts        # Visual constants
 └── test/

--- a/docs/design/docs/tables/docs-nested-tables.md
+++ b/docs/design/docs/tables/docs-nested-tables.md
@@ -40,10 +40,13 @@ No type changes required. `TableCell.blocks: Block[]` already accepts any
 
 **Changes:**
 
-- **Remove nested-table insertion guard** in `Document.insertTable()`. Currently
-  `insertTable` checks `BlockParentMap` and rejects insertion when the cursor is
-  inside a cell. Remove this check so that a table block is added to
-  `cell.blocks` like any other block.
+- **Dedicated cell-insertion method.** A table block is added to a cell's
+  `blocks` via `Document.insertTableInCell(blockId, rows, cols)`, which looks up
+  the parent cell in `BlockParentMap` and inserts the new table after `blockId`
+  (`packages/docs/src/model/document.ts`). `Document.insertTable(blockIndex, rows, cols)`
+  remains the body-only path and carries no nested-table guard; the editor's
+  Insert Table command branches on `blockParentMap` and calls `insertTableInCell`
+  when the cursor is inside a cell.
 
 - **Recursive `BlockParentMap` construction.** When building the map, recurse
   into cell blocks: if a block is a table, iterate its rows/cells and register
@@ -128,15 +131,18 @@ computeTableLayout(outerTable, contentWidth)
 - `getCellInfo(blockId)` returns the direct parent cell from `BlockParentMap` —
   works unchanged for nested tables.
 
-- **New `getTableContext(blockId)`** — walks up the `BlockParentMap` chain to
-  return the table hierarchy path: `[outermostTableId, ..., innermostTableId]`.
-  Used to identify the correct target table for structural operations.
+- **Target-table resolution.** The direct parent table is resolved via
+  `blockParentMap.get(blockId)` (its `BlockCellInfo` carries `tableBlockId`) and
+  `Document.getParentTableBlock(blockId)`
+  (`packages/docs/src/model/document.ts`). No dedicated hierarchy-path helper is
+  needed — structural operations only need the direct parent, which these
+  provide.
 
 **Table insertion in cells:**
 
-- `insertTable()` inserts a table block into the current cell's `blocks` array
-  at the cursor's block position. Identical to inserting a paragraph, except the
-  block type is `'table'`.
+- `insertTableInCell(blockId, rows, cols)` inserts a table block into the parent
+  cell's `blocks` array, after the block at `blockId`. Identical to inserting a
+  paragraph, except the block type is `'table'`.
 
 **Tab / arrow navigation:**
 
@@ -203,14 +209,17 @@ Current Yorkie Tree structure:
   nesting, so no SDK changes are needed — just insert the `<table>` subtree
   under the `<td>` node.
 
-- **`resolveTreePath(blockId): number[]` utility.** Converts a blockId to a
-  Yorkie Tree path by walking up the `BlockParentMap` hierarchy. For nested
-  tables, the path is deeper (e.g.,
-  `[tableIdx, rowIdx, colIdx, innerBlockIdx, innerRowIdx, ...]`).
+- **Nested cell-path helpers.** A blockId resolves to a deeper Yorkie Tree path
+  via the repeating `[r, c, b]`-triplet helpers in
+  `packages/frontend/src/app/docs/yorkie-doc-store.ts`
+  (`getCellSubPath`, `getCellBlock`, `setCellBlock`, `getBlocksArrayForPath`).
+  For nested tables the path descends through successive `[rowIdx, colIdx,
+  blockIdx]` triplets.
 
 - **Granular operations path adjustment.** Existing Store methods
   (`insertTableRow`, `deleteTableColumn`, `updateTableCell`, etc.) use tree
-  paths. For nested tables, `resolveTreePath` produces the correct deeper path.
+  paths. For nested tables, the cell-path helpers above produce the correct
+  deeper path.
 
 **Concurrent editing:**
 

--- a/docs/design/docs/tables/docs-table-copy-paste.md
+++ b/docs/design/docs/tables/docs-table-copy-paste.md
@@ -24,9 +24,13 @@ This document covers Phase 1 (cell-to-cell) and Phase 3 (external table paste).
 
 **Non-Goals:**
 - Auto-expanding the target table when pasted data exceeds bounds (clamp instead)
-- Copying/pasting cell merge (colSpan/rowSpan) attributes in Phase 1
 - External HTML table parsing (Phase 3)
 - Undo/redo integration beyond existing `saveSnapshot()` mechanism
+
+Cell merge (colSpan/rowSpan) attributes are now copied and pasted:
+`cloneTableCells()` forwards the spans verbatim, `pasteTableCells()` repairs
+the grid invariant via `normalizeTableMerges()`, and the copy selection is
+expanded over merges via `expandCellRangeForMerges()`.
 
 ## Proposal Details
 
@@ -92,8 +96,9 @@ Both copy and paste need to regenerate block IDs inside cells to avoid ID collis
 function cloneTableCells(cells: TableCell[][]): TableCell[][] {
   return cells.map(row =>
     row.map(cell => ({
-      ...cell,
       style: { ...cell.style },
+      ...(cell.colSpan != null ? { colSpan: cell.colSpan } : {}),
+      ...(cell.rowSpan != null ? { rowSpan: cell.rowSpan } : {}),
       blocks: cell.blocks.map(b => ({
         ...b,
         id: generateBlockId(),
@@ -104,6 +109,9 @@ function cloneTableCells(cells: TableCell[][]): TableCell[][] {
   );
 }
 ```
+
+The `colSpan`/`rowSpan` fields are forwarded so merges survive a copy; after
+paste, `pasteTableCells()` calls `normalizeTableMerges()` to repair the grid.
 
 ### Changed Files
 
@@ -116,7 +124,7 @@ function cloneTableCells(cells: TableCell[][]): TableCell[][] {
 ### Unchanged
 
 - `selection.ts` — existing `tableCellRange` and `getSelectedText()` reused as-is
-- `document.ts` — existing `updateCellBlocks()` reused
+- `document.ts` — existing `updateBlockDirect()` reused to persist the pasted table block
 - `types.ts` — existing `TableCell`, `TableCellRange`, `CellAddress` reused
 
 ## Risks and Mitigation
@@ -125,7 +133,7 @@ function cloneTableCells(cells: TableCell[][]): TableCell[][] {
 |------|------------|
 | Large cell ranges produce big clipboard payloads | JSON serialization is fast for typical table sizes (<1000 cells); defer optimization |
 | Block ID collisions after paste | Always regenerate IDs via `generateBlockId()` during clone |
-| Paste into merged cells may corrupt layout | Phase 1 skips colSpan/rowSpan — paste treats each cell independently |
+| Paste into merged cells may corrupt layout | Merge spans are carried through and `normalizeTableMerges()` repairs the grid invariant after paste |
 | Cut from table leaves empty cells vs. removing rows | Cut replaces cell content with empty blocks (like spreadsheet behavior), does not remove structural rows/columns |
 
 ## Phase 3: External Table Paste
@@ -145,7 +153,7 @@ markdown table syntax — into `TableCell[][]`, then reuse the existing
 
 ### Non-Goals
 
-- colSpan/rowSpan from external HTML (Phase 1 already defers this)
+- colSpan/rowSpan from external HTML — `parseHtmlTableElement()` does not read `colspan`/`rowspan` attributes (internal cell-range copy/paste does preserve merges)
 - Markdown cell formatting (bold `**text**`, etc.) — cells are plain text
 
 ### New Functions in `clipboard.ts`

--- a/docs/design/docs/tables/docs-table-resize.md
+++ b/docs/design/docs/tables/docs-table-resize.md
@@ -38,7 +38,7 @@ Add optional `rowHeights` array:
 interface TableData {
   rows: TableRow[];
   columnWidths: number[];  // Proportional ratios (0-1), sum = 1.0
-  rowHeights?: number[];   // User-specified minimum heights in px
+  rowHeights?: (number | undefined)[];   // User-specified minimum heights in px
 }
 ```
 
@@ -186,11 +186,12 @@ During drag, render on the Canvas overlay:
 - **Row drag**: Horizontal dashed line (blue, 1px) from table left
   to table right at `currentPixel` Y position
 
-Line style: `setLineDash([4, 4])`, color `#4A90D9`, lineWidth 1.
+Line style: `setLineDash([4, 4])`, color `#4285F4`, lineWidth 1.
 
-The guideline is drawn in the render pass, not as a separate overlay.
-When `dragState` is non-null, the table renderer draws the guideline
-after borders.
+The guideline is drawn in the editor's paint loop, not as a separate
+overlay. `text-editor.ts` reports the drag position via an
+`onDragGuideline` callback, and `packages/docs/src/view/editor.ts`
+draws the dashed line after the page/table render pass.
 
 ## Layout Integration
 
@@ -254,8 +255,8 @@ so all pages re-render correctly.
 | `packages/docs/src/model/types.ts` | Add `rowHeights?: number[]` to `TableData` |
 | `packages/docs/src/model/document.ts` | Add `resizeColumn()`, `setRowHeight()`; update `insertRow()`/`deleteRow()` for `rowHeights` sync |
 | `packages/docs/src/view/table-layout.ts` | Apply `rowHeights` minimum in `computeTableLayout()` |
-| `packages/docs/src/view/text-editor.ts` | Border detection in `mousemove`, drag state management in `mousedown`/`mousemove`/`mouseup`, guideline trigger |
-| `packages/docs/src/view/table-renderer.ts` | Render guideline when `dragState` is active |
+| `packages/docs/src/view/text-editor.ts` | Border detection in `mousemove`, drag state management in `mousedown`/`mousemove`/`mouseup`, `onDragGuideline` callback |
+| `packages/docs/src/view/editor.ts` | Render guideline in the paint loop when the `onDragGuideline` position is set |
 | `packages/docs/src/store/memory.ts` | Persist `rowHeights` in store updates |
 
 ## Risks and Mitigation

--- a/docs/design/docs/tables/docs-table-row-splitting.md
+++ b/docs/design/docs/tables/docs-table-row-splitting.md
@@ -103,7 +103,9 @@ its own `rowSplitOffset` / `rowSplitHeight`.
 ### 2. Rendering Layer
 
 Files: `packages/docs/src/view/doc-canvas.ts`,
-       `packages/docs/src/view/table-renderer.ts`
+       `packages/docs/src/view/table-renderer.ts`,
+       `packages/docs/src/view/table-geometry.ts`
+       (`computeTableRangeForPageLine`)
 
 #### 2.1 Clipped cell rendering
 
@@ -163,7 +165,8 @@ in both passes so backgrounds and content stay in lockstep.
 ### 3. Interaction Layer
 
 Files: `packages/docs/src/view/text-editor.ts`,
-       `packages/docs/src/view/pagination.ts` (pixel ↔ position)
+       `packages/docs/src/view/pagination.ts` (pixel ↔ position),
+       `packages/docs/src/view/selection.ts` (split-aware selection clipping)
 
 #### 3.1 Pixel → position (`paginatedPixelToPosition`)
 
@@ -186,13 +189,16 @@ fragment (same row, next page) rather than to the next row.
 
 #### 3.4 Selection rendering
 
-`renderSelection` clips selection highlight rectangles to the current
-page's fragment bounds, the same way cell content is clipped.
+`computeSelectionRects` (in `packages/docs/src/view/selection.ts`)
+clips selection highlight rectangles to the current page's fragment
+bounds via each `PageLine`'s `rowSplitOffset` / `rowSplitHeight`, the
+same way cell content is clipped.
 
 #### 3.5 Scroll into view
 
 When the cursor moves into a split row fragment on a different page,
-`scrollIntoView` targets that page's Y offset.
+`packages/docs/src/view/text-editor.ts` adjusts `container.scrollTop`
+to that page's Y offset.
 
 ## Risks and Mitigation
 

--- a/docs/design/documents-multi-file-upload.md
+++ b/docs/design/documents-multi-file-upload.md
@@ -12,7 +12,8 @@ target-version: 0.6.1
 Bring a Google-Drive-style upload experience to the documents list: drag any
 number of files onto the page (or multi-select via the "New" menu) and have each
 one become a document — `.xlsx → sheet`, `.docx → doc`, `.pptx → slides`,
-`.pdf → pdf`. A hand-rolled upload queue drives the work with limited
+`.pdf → pdf`, and `.png/.jpg/.jpeg/.gif/.webp → image`. A hand-rolled upload
+queue drives the work with limited
 concurrency, and a fixed bottom-right **Upload panel** shows per-file progress,
 success, failure (with retry), and "unsupported → skipped" states.
 
@@ -37,7 +38,8 @@ design closes that gap for the documents list only.
 ### Non-Goals
 
 - Storing arbitrary/unsupported files or a generic `file` document type
-  (PDF stays the only binary-backed type; skipped files are not uploaded).
+  (only `pdf` and `image` are binary-backed types; skipped files are not
+  uploaded).
 - Folder upload / directory recursion.
 - Editor-internal multi-image insertion (docs/slides/sheets image DnD stays
   single-file; a separate effort).
@@ -58,10 +60,11 @@ design closes that gap for the documents list only.
 [upload-queue.ts]                      ← single module singleton (no library)
    │  enqueue(files, workspaceId)
    │  per file → extension → kind:
-   │     .xlsx → importXlsx  (client parse → sheet)
-   │     .docx → importDocx  (client parse → doc)
-   │     .pptx → importPptx  (client parse → slides)
-   │     .pdf  → uploadPdf    (binary → S3 → pdf, fileId)
+   │     .xlsx → importXlsx      (client parse → sheet)
+   │     .docx → importDocx      (client parse → doc)
+   │     .pptx → importPptxFile  (client parse → slides)
+   │     .pdf  → uploadFile      (binary → S3 → pdf, fileId)
+   │     png/jpg/jpeg/gif/webp → uploadFile (binary → S3 → image, fileId)
    │     else  → status 'skipped'
    │  worker loop, concurrency cap (2–3; parsing-heavy stays serial-ish)
    │  status: pending → parsing/uploading(done/total) → done | error | skipped
@@ -80,25 +83,39 @@ void>()`. Every mutator **replaces the `items` array reference** then emits
 (`for (const cb of listeners) cb()`), so snapshot identity changes only on real
 change.
 
+The kind/status types and item shape live in
+`packages/frontend/src/app/documents/upload-kind.ts` (`UploadKind`,
+`classifyUploadKind`) and `packages/frontend/src/app/documents/upload-queue.ts`
+(`UploadStatus`, `UploadItem`):
+
 ```ts
-type UploadKind = "sheet" | "doc" | "slides" | "pdf";
+// upload-kind.ts — `board` has no extension mapping; it exists only for
+// externally driven rows (enqueueExternal, e.g. the Miro import).
+type UploadKind = "sheet" | "doc" | "slides" | "pdf" | "image" | "board";
 type UploadStatus =
   | "pending" | "parsing" | "uploading" | "done" | "error" | "skipped";
 
 interface UploadItem {
-  id: string;              // client-generated
+  id: string;                 // client-generated
+  file?: File;                // retained for the worker; omitted for skipped
   fileName: string;
-  kind: UploadKind | null; // null when skipped/unsupported
-  workspaceId?: string;    // captured at enqueue time
+  kind: UploadKind | null;    // null when skipped/unsupported
+  workspaceId?: string;       // captured at enqueue time
+  folderId?: string | null;   // folder the list was viewing (null = root)
   status: UploadStatus;
-  done: number;            // progress numerator (image-upload phase, etc.)
+  done: number;               // progress numerator (image-upload phase, etc.)
   total: number;
-  docId?: string;          // set on success, for the "open" link
-  reason?: string;         // skip reason / error message
+  detail?: string;            // custom progress wording for external rows
+  docId?: string;             // set on success, for the "open" link
+  docPath?: string;           // route to the created document
+  fileId?: string;            // uploaded blob id (pdf/image), for retry reuse
+  reason?: string;            // skip reason / error message
+  warning?: string;           // non-fatal note on success (lossy PPTX, etc.)
 }
 
-// Exposed: getSnapshot(), subscribe(cb), enqueue(files, workspaceId),
-// retry(id), remove(id), clearFinished()
+// Exposed: getSnapshot(), subscribe(cb), enqueue(files, workspaceId, folderId?),
+// enqueueExternal(...), patchItem(id, patch), retry(id), removeItem(id),
+// dismissItem(id), clearFinished()
 ```
 
 Worker loop: a small in-module runner picks up `pending` items up to a
@@ -111,12 +128,12 @@ Per-item pipeline (mirrors today's single-file handlers, section-by-section
 reuse):
 
 1. classify extension → `kind` (or `skipped`).
-2. call the refactored `importXxx(file, onProgress)` / `uploadPdf(file)`.
+2. call the refactored `importXxx(file, onProgress)` / `uploadFile(file)`.
 3. `workspaceId ? createWorkspaceDocument(...) : createDocument({ title, type })`.
 4. **persist content headlessly** (xlsx/docx/pptx): `applyImportedContent`
    attaches the Yorkie doc, writes the same root the editor would, and detaches
-   (see below). PDF stores its bytes at create time via `fileId`, so it skips
-   this step.
+   (see below). PDF and image store their bytes at create time via `fileId`, so
+   they skip this step.
 5. `setStatus(id, "done", { docId })`. Do **not** auto-navigate — the panel row
    links to the document; only navigate if the user clicks.
 
@@ -140,11 +157,12 @@ must be kept in sync with them.
 
 ### React glue (`packages/frontend/src/app/documents/use-upload-queue.ts`)
 
-Follows `packages/frontend/src/app/slides/toolbar/zoom-control.tsx` exactly:
-`useState(getSnapshot())` + `useEffect(() => subscribe(() =>
-setItems(getSnapshot())), [])`. `useSyncExternalStore` is intentionally **not**
-used — there is zero precedent in the codebase and the manual pattern is the
-established convention.
+`useUploadQueue()` subscribes a component to the module-level queue via
+`useSyncExternalStore(subscribe, getSnapshot)`. Because `getSnapshot` returns a
+stable array reference that only changes on a real mutation, a mutation emitted
+in the window between render and effect-subscription cannot be missed — which is
+why this uses `useSyncExternalStore` rather than the manual `useState` +
+`useEffect` + `subscribe` pattern used elsewhere for simpler singletons.
 
 ### Upload panel (`packages/frontend/src/app/documents/upload-panel.tsx`)
 
@@ -163,7 +181,9 @@ Mounted once near the documents list root so it persists across in-list state.
 - Full-page `dragenter`/`dragover`/`drop` handlers gated to file drags; on
   `dragover` show a translucent overlay ("Drop files to upload"). On `drop`,
   collect `dataTransfer.files`, capture the active `workspaceId` prop, call
-  `enqueue`.
+  `enqueue`. The window listener/overlay lifecycle is extracted into the
+  `useWindowFileDrop` hook (`packages/frontend/src/app/documents/use-window-file-drop.ts`),
+  which `packages/frontend/src/app/documents/document-list.tsx` consumes.
 - The "New" menu import items gain multi-select: a hidden `<input multiple>`
   mirroring the DOM-append + focus-cancel logic already in `pickFile`
   (`packages/frontend/src/app/docs/export-utils.ts`), then `enqueue`.

--- a/docs/design/export-progress.md
+++ b/docs/design/export-progress.md
@@ -12,8 +12,8 @@ seconds with only a spinner. The root cause is two-fold: the heavy export
 loops run **synchronously on the main thread**, blocking the event loop, and
 there is **no progress reporting**. This design adds an `onProgress` callback
 to each exporter and inserts cooperative event-loop yields between work units,
-then surfaces progress through a Sonner toast that mirrors the existing import
-flow ("Exporting … 12 / 50 slides").
+then surfaces progress through a lightweight Sonner toast ("Exporting … 12 /
+50 slides").
 
 ## Goals / Non-Goals
 
@@ -21,15 +21,15 @@ flow ("Exporting … 12 / 50 slides").
 
 - Show incremental progress for slides PDF, slides PPTX, docs PDF, docs DOCX.
 - Keep the UI responsive during export (toast actually repaints).
-- Reuse the import toast UX for consistency.
+- Use a lightweight, non-blocking Sonner toast (no modal, no cancel button).
 - Keep the export libraries (`@wafflebase/docs`, `@wafflebase/slides`) pure —
   no DOM/toast coupling; they only expose callbacks.
 
 **Non-Goals**
 
-- Cancellation (the chosen toast UX has no cancel button, matching import).
+- Cancellation (the chosen toast UX has no cancel button).
 - Web workers / off-main-thread export (much larger change; deferred).
-- A determinate progress-bar modal (rejected for import/export UX parity).
+- A determinate progress-bar modal (rejected in favor of the lighter toast).
 - Sheets export (out of scope for this task).
 
 ## Proposal Details
@@ -93,9 +93,8 @@ units" — but start with per-unit for the smoothest progress.
 
 ### C. Frontend toast wiring
 
-A shared `updateExportToast` helper (added to
-`packages/frontend/src/app/docs/export-utils.ts`) mirrors `updateImportToast`
-in `packages/frontend/src/app/documents/document-list.tsx`:
+A shared `updateExportToast` helper lives in
+`packages/frontend/src/app/docs/export-utils.ts`:
 
 ```ts
 function updateExportToast(id, title, done, total, unit): string | number {
@@ -112,8 +111,8 @@ threads an `onProgress` into its export action, which calls
 `updateExportToast`. On success the toast becomes `toast.success`; on failure
 the existing `toast.error` path is preserved. The current spinner icon and
 `disabled` state stay as complementary feedback. The toast is shown always
-(matching import) and is immediately replaced by the success toast, so small
-exports only flash briefly.
+and is immediately replaced by the success toast, so small exports only flash
+briefly.
 
 ### Data flow (slides PDF example)
 

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -359,16 +359,19 @@ flowchart LR
 
 ```typescript
 type UserPresence = {
-  selection?: SelectionPresence; // primary field: full range selection
-  activeCell?: Sref;   // legacy fallback for mixed-version peers, e.g. "C5"
+  selection?: SelectionPresence; // primary field: axis-ID range for cursors
+  activeCell?: Sref;   // always-emitted Sref; drives avatar jump, e.g. "C5"
   activeTabId?: string; // current tab id, e.g. "tab-1"
 } & User;              // spreads id, authProvider, username, email, photo
 ```
 
 The primary presence field is `selection` (a `SelectionPresence` range from
-`@wafflebase/sheets`); `activeCell` is retained only as a legacy fallback for
-peers running an older version. `UserPresence` extends the full `User` type
-rather than duplicating the profile fields.
+`@wafflebase/sheets`), which carries the axis-ID-stable anchor used to render
+peer cursor overlays. `activeCell` is always emitted alongside it as a plain
+`Sref`: it drives avatar jump navigation (below) and lets peer cursors render
+even when `selection` has no axis anchor (e.g. after Cmd+Down on an empty
+sheet). `UserPresence` extends the full `User` type rather than duplicating the
+profile fields.
 
 The `UserPresence` component (`packages/frontend/src/components/user-presence.tsx`) displays up
 to 4 user avatars in the header. It uses the `usePresences()` hook from

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -434,8 +434,10 @@ caching and mutations.
 Row click navigates to the type-specific detail route via `getDocumentPath()`.
 
 Additional shipped frontend surfaces the sheets integration relies on but this
-doc does not detail: data validation (`data-validation-panel.tsx`), a threaded
-comments system, and URL-based share links (`src/api/share-links.ts`).
+doc does not detail: data validation
+(`packages/frontend/src/app/spreadsheet/data-validation-panel.tsx`), a threaded
+comments system, and URL-based share links
+(`packages/frontend/src/api/share-links.ts`).
 
 **Document detail** wraps `SheetView` in a `DocumentProvider` that connects to
 the Yorkie document with key `sheet-{id}`. The sheet and datasource tab views

--- a/docs/design/frontend.md
+++ b/docs/design/frontend.md
@@ -38,32 +38,42 @@ React Router 7.5 with route guards:
 ```mermaid
 flowchart TD
   BR["BrowserRouter (basename from VITE_FRONTEND_BASENAME)"]
+  BR --> HOME["/ → HomeOrRedirect (landing or redirect)"]
   BR --> PUB["PublicRoute"]
+  BR --> SHARED["/shared/:token → SharedDocument"]
   BR --> PRI["PrivateRoute"]
   PUB --> LOGIN["/login → Login"]
   PRI --> LAYOUT["Layout (sidebar + header)"]
-  PRI --> DOC["/:id → DocumentDetail"]
-  LAYOUT --> DOCS["/ → Documents"]
+  PRI --> DETAIL["/s|/d|/p|/f|/n|/b/:id → per-type detail"]
+  LAYOUT --> DOCS["/documents → Documents"]
+  LAYOUT --> WS["/w/:workspaceId → WorkspaceDocuments"]
   LAYOUT --> SET["/settings → Settings"]
 ```
 
+- **HomeOrRedirect** — `/` renders the marketing landing page for anonymous
+  visitors and redirects authenticated users into the app.
 - **PublicRoute** — Redirects to `/` if already authenticated.
 - **PrivateRoute** — Calls `fetchMe()` to verify the JWT cookie. Wraps
   children in `YorkieProvider`. Redirects to `/login` on failure.
+- Documents are organized into workspaces (`/w/:workspaceId`) and arbitrary-depth
+  folders; there are also top-level `/shared/:token`, `/invite/:token`,
+  `/datasources`, workspace analytics/settings/datasources, and `/harness/*`
+  routes.
 - Route components are loaded with `React.lazy` + `Suspense` so the login,
   list, settings, and document-detail pages are split into separate chunks.
 
 #### Provider Hierarchy
 
 ```
-StrictMode
-└── QueryClientProvider (TanStack React Query)
-    └── ThemeProvider (light / dark / system)
-        └── BrowserRouter
-            └── PrivateRoute
-                └── YorkieProvider (Yorkie client connection)
-                    └── DocumentProvider (per-document CRDT)
-                        └── Page components
+StrictMode (wraps App in main.tsx)
+└── ThemeProvider (light / dark / system)
+    └── TooltipProvider
+        └── QueryClientProvider (TanStack React Query)
+            └── BrowserRouter
+                └── PrivateRoute
+                    └── YorkieProvider (Yorkie client connection)
+                        └── DocumentProvider (per-document CRDT)
+                            └── Page components
 ```
 
 ### Sheet Integration
@@ -349,13 +359,16 @@ flowchart LR
 
 ```typescript
 type UserPresence = {
-  activeCell?: Sref;   // e.g. "C5"
+  selection?: SelectionPresence; // primary field: full range selection
+  activeCell?: Sref;   // legacy fallback for mixed-version peers, e.g. "C5"
   activeTabId?: string; // current tab id, e.g. "tab-1"
-  username: string;
-  email: string;
-  photo: string;
-};
+} & User;              // spreads id, authProvider, username, email, photo
 ```
+
+The primary presence field is `selection` (a `SelectionPresence` range from
+`@wafflebase/sheets`); `activeCell` is retained only as a legacy fallback for
+peers running an older version. `UserPresence` extends the full `User` type
+rather than duplicating the profile fields.
 
 The `UserPresence` component (`packages/frontend/src/components/user-presence.tsx`) displays up
 to 4 user avatars in the header. It uses the `usePresences()` hook from
@@ -410,11 +423,19 @@ caching and mutations.
 |----------|--------|----------|
 | `fetchDocuments()` | GET | `/documents` |
 | `fetchDocument(id)` | GET | `/documents/:id` |
-| `createDocument({ title })` | POST | `/documents` |
+| `createDocument({ title, type?, fileId? })` | POST | `/documents` |
+| `renameDocument(id, title)` | PATCH | `/documents/:id` |
+| `moveDocument(id, { workspaceId?, folderId? })` | PATCH | `/documents/:id` |
+| `moveDocuments(ids, target)` | PATCH | `/documents/move` |
 | `deleteDocument(id)` | DELETE | `/documents/:id` |
+| `deleteDocuments(ids)` | POST | `/documents/delete` |
 
 **Document list** uses TanStack Table with sorting, filtering, and pagination.
-Row click navigates to `/:id`.
+Row click navigates to the type-specific detail route via `getDocumentPath()`.
+
+Additional shipped frontend surfaces the sheets integration relies on but this
+doc does not detail: data validation (`data-validation-panel.tsx`), a threaded
+comments system, and URL-based share links (`src/api/share-links.ts`).
 
 **Document detail** wraps `SheetView` in a `DocumentProvider` that connects to
 the Yorkie document with key `sheet-{id}`. The sheet and datasource tab views
@@ -424,11 +445,12 @@ on demand when adding datasource tabs.
 #### Multi-Editor Integration
 
 The frontend hosts several editor types from a single document list.
-`Document` carries a `type: "sheet" | "doc" | "slides"` field (DB default
+`Document` carries a `type: DocumentType` field where `DocumentType =
+"sheet" | "doc" | "slides" | "pdf" | "note" | "image" | "board"` (DB default
 `"sheet"`, so legacy rows stay valid without migration); the create endpoints
-accept an optional `type`. The "New" dropdown in the document list offers one
-entry per type, and a type indicator column/icon distinguishes them in the
-list.
+accept an optional `type` (and `fileId` for the static file types). The "New"
+dropdown in the document list offers one entry per type, and a type indicator
+column/icon distinguishes them in the list.
 
 Routing keys off `doc.type`, resolved by a `getDocumentPath(doc)` helper:
 
@@ -437,23 +459,36 @@ Routing keys off `doc.type`, resolved by a `getDocumentPath(doc)` helper:
 | `sheet` (default) | `/s/:id` | `DocumentDetail` (sheets) |
 | `doc` | `/d/:id` | `DocsDetail` |
 | `slides` | `/p/:id` | `SlidesDetail` |
+| `note` | `/n/:id` | `NotesDetail` |
+| `board` | `/b/:id` | `BoardDetail` |
+| `pdf` / `image` | `/f/:id` | `FileDetail` |
 
 Each editor binds its own Yorkie document key — e.g. sheets use `sheet-{id}`
 and docs use `doc-{id}` — so they never collide even when they share the same
 underlying document UUID. The docs editor uses `YorkieDocStore`, a `DocStore`
 implementation backed by the Yorkie Tree CRDT (parallel to `YorkieStore` for
-sheets).
+sheets). The PDF/image (`FileDetail`) types are static blob documents with no
+Yorkie CRDT editing.
 
 ### Type Definitions
 
 ```typescript
 // src/types/documents.ts
+type DocumentType =
+  | "sheet" | "doc" | "slides" | "pdf" | "note" | "image" | "board";
+
 type Document = {
-  id: number;
+  id: string;
   title: string;
+  type: DocumentType;
   description: string;
   createdAt: string;
-  updatedAt: string;
+  updatedAt?: string;       // populated only by documents-list endpoints
+  workspaceId: string;
+  folderId?: string | null; // null/absent = workspace root
+  author?: DocumentAuthor | null;
+  editors?: DocumentEditor[];
+  canManage?: boolean;      // set only by documents-list endpoints
 };
 
 // src/types/users.ts
@@ -477,6 +512,7 @@ type DataSource = {
   password: string;  // Always masked from API
   sslEnabled: boolean;
   authorID: number;
+  workspaceId: string;
   createdAt: string;
   updatedAt: string;
 };

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -17,14 +17,22 @@ maintainable software. Where context engineering asks *what should the agent
 see*, harness engineering asks *what should the system prevent, measure, and
 correct*.
 
-As of 2026-03-11, phases 1 through 20, 22, and 23 are completed. Browser
+As of 2026-03-11, phases 1 through 20, 22, and 23 are completed, and the
+agent-oriented pipeline (Phases 24–27) has since shipped: the autonomous
+contribution loop, the local Spec→PR front door, Tier-1 autonomous issue
+hunting, and the panel feedback corpus all live in the `.github/workflows/`
+`agent-*` workflows (e.g. `.github/workflows/agent-review-panel.yml`) and under
+`scripts/agent/` (e.g. `scripts/agent/review-panel.mjs`, `scripts/agent/hunt.mjs`,
+`scripts/agent/harvest.mjs`). Browser
 visual and interaction lanes are integrated into `verify:self` with graceful
 Chromium skip. Docker-based browser testing ensures consistent font rendering
 across macOS and CI (Ubuntu). Structured JSON lane reports are generated per
 lane and as a summary. Dependency freshness (vulnerability + outdated package
 detection) is integrated into `verify:entropy`. PR verification evidence is
 automated via CI artifact upload and auto-comment on PRs. Remaining work
-focuses on agent observability.
+is the rest of Phase 21's agent observability stack (structured backend
+logging, per-branch observability context) and autonomous issue-filing
+(Phase 26 Tier 2).
 
 ## Principles
 
@@ -262,7 +270,7 @@ database → auth/user/document → controllers/modules
 - `auth`: cannot import document, datasource, share-link
 - `user`: cannot import auth, document, datasource, share-link
 
-## Completed Phases (1-20, 22)
+## Completed Phases (1-20, 22, 23)
 
 | Phase | Scope | Status |
 |---|---|---|
@@ -323,10 +331,16 @@ Detailed task records:
 | A | Fail on breakage by default | Mechanical Enforcement | Completed | Maintain zero-warning, zero-drift baseline |
 | B | Two-lane verification split | Mechanical Enforcement | Completed | Stable; improve integration determinism |
 | C | Frontend regression harness | Visual Feedback | Completed | Browser lanes in verify:self; Docker-based CI provisioning delivered (Phase 23) |
-| D | Agent-oriented contracts | Information Accessibility | In progress | Lane reports + PR auto-evidence (Phases 19-20); failure-summary digest delivered (`scripts/agent/summarize-ci.mjs`); autonomous contribution loop (Phase 24) |
+| D | Agent-oriented contracts | Information Accessibility | In progress | Lane reports + PR auto-evidence (Phases 19-20); failure-summary digest delivered (`scripts/agent/summarize-ci.mjs`); autonomous contribution loop shipped (Phases 24-27); remaining: Phase 21 structured logging/observability context + autonomous issue-filing |
 | E | Entropy cleanup loop | Entropy Management | Completed | Dead-code + doc-staleness + dependency freshness delivered |
 
-## Remaining Work
+## Agent-Oriented Phases (21, 24-27)
+
+Phases 24–27 (autonomous contribution loop, local Spec→PR, Tier-1 issue hunting,
+panel feedback corpus) have shipped; each phase body below states what is live
+versus the narrower items still deferred. Phase 21 (agent observability) is
+partially delivered — the agent-queryable failure summary landed; structured
+backend logging and per-branch observability context remain.
 
 ### Phase 21: Agent Observability Stack
 

--- a/docs/design/homepage.md
+++ b/docs/design/homepage.md
@@ -107,7 +107,9 @@ Right: `<ThemeToggle>` (sun/moon icon) + primary `<WbButton>` ("Get Started" or
 
 Single column, centered, max-width 920px, padded `pt-20 md:pt-28 pb-14 md:pb-20`.
 
-- Butter pill eyebrow `v0.3 · Apache-2.0 · Self-hosted` (leaf glow dot).
+- Butter pill eyebrow `{VERSION_LABEL} · Apache-2.0 · Self-hosted` (leaf glow
+  dot). `VERSION_LABEL` is derived at build time from the injected
+  `__APP_VERSION__` (major.minor of the root package.json), e.g. `v0.6`.
 - Fraunces `clamp(40, 6vw, 68)px` H1: "The Office Suite *You Can Own*"
   (italic + syrup-deep emphasis on the trailing phrase). `max-w-[20ch]`
   accommodates the shorter title without orphan wraps.
@@ -142,9 +144,9 @@ Section frame: `--wb-paper` rounded card (18px), syrup-deep drop shadow.
 - **Theme sync** — all three iframes receive `{ type: 'theme-change', theme }`
   via `postMessage` whenever the homepage theme changes; the shared
   `ThemeProvider` inside the iframe applies the change without reload.
-- **Footer** — tab-aware mono hint text on the left, `wafflebase@0.3.7` on
-  the right (Slides hint: "Tip: arrow keys navigate slides — press F to
-  present.").
+- **Footer** — tab-aware mono hint text on the left, `wafflebase@${__APP_VERSION__}`
+  on the right (Vite injects the version from the root package.json at build
+  time) (Slides hint: "Tip: arrow keys navigate — ⌘/Ctrl+Enter to present.").
 
 #### FeaturesSection
 

--- a/docs/design/notes/notes.md
+++ b/docs/design/notes/notes.md
@@ -84,8 +84,10 @@ CodePair's Yorkie schema is tiny, which is what makes this port small:
 // Yorkie document root (identical to CodePair)
 type NoteRoot = { content: yorkie.Text };
 
-// Yorkie presence (identical to CodePair)
-type NotePresence = {
+// Yorkie presence (shipped as `NotesPresence`; the color/name/selection/cursor
+// caret fields are identical to CodePair, plus username/email/photo identity
+// fields for the shared UserPresence avatar chrome)
+type NotesPresence = {
   color: string;
   name: string;
   selection: yorkie.TextPosStructRange | null;
@@ -104,21 +106,22 @@ Vite + `vite-plugin-dts`, browser + `./node` export conditions, `src/index.ts`
 barrel). CodePair's `packages/codemirror` is ported here and reorganized to
 match Wafflebase's engine shape:
 
-- `src/model/` — note data types. Thin: content is a single markdown string.
 - `src/store/` — `NoteStore` interface (mirrors `DocStore` / `Store`) plus a
   `MemNoteStore` for tests. This is the persistence abstraction the CodeMirror
   view talks to; the Yorkie-backed implementation lives in the frontend
-  (below), same split as `packages/docs`.
-- `src/view/` — `initialize(container, store, theme)` → `EditorAPI`. Internally
-  builds the CodeMirror 6 `EditorState`: `@codemirror/lang-markdown`,
-  `basicSetup` (history **disabled** — Yorkie owns undo/redo), light/dark
-  themes, line wrapping, the Yorkie sync binding, toolbar, and the preview
-  pane (`@uiw/react-markdown-preview` or equivalent).
-- `src/yorkie/` — the CodeMirror↔Yorkie binding ported nearly verbatim from
-  CodePair (`yorkieSync.ts`, `remoteSelection.ts`, `index.ts`). Adjusted for
-  Wafflebase's `@yorkie-js/sdk` **0.7.8** (CodePair uses 0.7.12 — the `Text`
-  and presence APIs used here are stable across that gap, but the port must be
-  verified against 0.7.8).
+  (below), same split as `packages/docs`. Note data types are thin (content is
+  a single markdown string) and live in `packages/notes/src/store/store.ts` +
+  `packages/notes/src/types.ts` (there is no separate `src/model/` directory).
+- `src/view/` — `initialize(container, store, theme, readOnly, viewMode)` →
+  `NoteEditorAPI`. Internally builds the CodeMirror 6 `EditorState`:
+  `@codemirror/lang-markdown`, `basicSetup` (history **disabled** — Yorkie owns
+  undo/redo), light/dark themes, line wrapping, the Yorkie sync binding,
+  toolbar, and the preview pane. The CodeMirror↔Yorkie binding was ported
+  nearly verbatim from CodePair and lives alongside the view in
+  `packages/notes/src/view/note-sync.ts` +
+  `packages/notes/src/view/remote-selection.ts` (there is no separate
+  `src/yorkie/` directory). It targets Wafflebase's `@yorkie-js/sdk` **0.7.13**
+  using only stable `Text` + presence APIs.
 
 The port preserves CodePair's `EditorPort` adapter idea so the app manipulates
 the editor (getSelection / replaceRange / getContent / scrollIntoView) without
@@ -129,7 +132,7 @@ depending on CodeMirror directly.
 Mirrors `app/docs/`:
 
 - `notes-detail.tsx` — route component; mounts `<DocumentProvider
-  docKey={`note-${id}`} initialRoot={initialNoteRoot()}>` using
+  docKey={`note-${id}`} initialRoot={initialNotesRoot()}>` using
   `@yorkie-js/react`.
 - `notes-view.tsx` — constructs `YorkieNoteStore` from `useDocument()` and calls
   the engine's `initialize(container, store, theme)`.
@@ -139,8 +142,8 @@ Mirrors `app/docs/`:
   the Wafflebase-native equivalent of CodePair's `useYorkieDocument` +
   `yorkieSync` glue, adapted to `@yorkie-js/react`'s provider pattern.
 - Yorkie root type + seed live in `packages/frontend/src/types/notes-document.ts`
-  (`YorkieNotesRoot`, `initialNoteRoot()`), same location convention as
-  `types/docs-document.ts`.
+  (`YorkieNotesRoot`, `initialNotesRoot()`), same location convention as
+  `packages/frontend/src/types/docs-document.ts`.
 
 #### Data flow (collaboration)
 
@@ -210,11 +213,10 @@ the prefix.
 
 ### Risks and Mitigation
 
-- **Yorkie SDK version skew (0.7.12 → 0.7.8).** CodePair's binding targets a
-  newer SDK. *Mitigation:* the ported binding only uses stable `Text` +
-  presence APIs (`edit`, `toString`, `posRangeToIndexRange`,
-  `indexRangeToPosRange`, `getPresences`); verify each against 0.7.8 during the
-  port and pin behavior with a store-level test.
+- **Yorkie SDK version skew (resolved).** The ported binding only uses stable
+  `Text` + presence APIs (`edit`, `toString`, `posRangeToIndexRange`,
+  `indexRangeToPosRange`, `getPresences`); it shipped against Wafflebase's
+  `@yorkie-js/sdk` **0.7.13** with store-level tests pinning the behavior.
 - **CodeMirror as a new frontend dependency / bundle size.** Wafflebase editors
   are Canvas-based; CodeMirror 6 + markdown lang + preview is a new, sizable
   dependency loaded only on the `/n/:id` route. *Mitigation:* lazy-load the

--- a/docs/design/pdf.md
+++ b/docs/design/pdf.md
@@ -78,9 +78,11 @@ Add `"pdf"` as a document type and a nullable blob reference:
   firing if any code path derives a key for a PDF document.)
 - `packages/frontend/src/types/documents.ts` — extend `DocumentType`.
 - **Prisma migration**: add `fileId String?` to `Document`
-  (`packages/backend/prisma/schema.prisma`). Only PDF documents populate
-  it; it references the stored blob. Since PDF content is static, this
-  column — not Yorkie — is the natural home for the reference.
+  (`packages/backend/prisma/schema.prisma`). PDF documents populate it,
+  and the later `"image"` document type reuses the same column
+  (see [image-viewer.md](image-viewer.md)); it references the stored blob.
+  Since static-file content is not a CRDT, this column — not Yorkie — is
+  the natural home for the reference.
 
 ### Storage layer — new `FileService` / `FileController`
 
@@ -121,9 +123,11 @@ document read check instead of reimplementing permission logic:
   `GET /documents/:id` (JWT + `workspaceService.assertMember`), then
   resolves that document's `fileId` and streams the blob from S3. Returns
   404 when the document has no `fileId`.
-- Response headers: `Content-Type: application/pdf`,
-  `Cache-Control: private, max-age=...` (per-user cache, **not** the
-  images' `public, immutable`), optional `ETag`.
+- Response headers: `Content-Type` set to the blob's **stored MIME type**
+  (`application/pdf` for PDFs, `image/*` for image documents — the
+  controller streams `getObject(...).contentType`, it does not hardcode
+  `application/pdf`), `Cache-Control: private, max-age=...` (per-user
+  cache, **not** the images' `public, immutable`).
 - A blob id is never accepted directly from the client for reads — the
   only read path is through a document the caller can already access.
 - **Deletion**: when a document with a `fileId` is deleted, the referenced
@@ -206,8 +210,8 @@ It lives in its own `packages/backend/src/document/document-file.controller.ts`:
   expiry), then serve. Otherwise `403`.
 - **Role is irrelevant for serving** — both `viewer` and `editor` share
   roles may view the PDF. Role only gates comment *writes* (Slice 3).
-- Response headers unchanged (`application/pdf`,
-  `Cache-Control: private`, `X-Content-Type-Options: nosniff`).
+- Response headers unchanged (stored MIME type — `application/pdf` for a
+  PDF, `Cache-Control: private`, `X-Content-Type-Options: nosniff`).
 
 *Alternative considered*: a dedicated public `GET /shared/:token/file`.
 Rejected — it forks the permission logic into two implementations that can

--- a/docs/design/pdf.md
+++ b/docs/design/pdf.md
@@ -12,9 +12,9 @@ target-version: 0.5.0
 Add PDF as a fourth document type (`"pdf"`) alongside `sheet` / `doc` /
 `slides`. Unlike the three editor types, a PDF document has **static
 content**: the original file is stored as an S3/MinIO blob and the
-Postgres `Document` row references it — there is **no Yorkie CRDT** in
-Phase 1. Users upload a PDF from the documents list and open it in a
-pdf.js-based viewer route. Phase 2 layers collaboration on top by
+Postgres `Document` row references it — there is **no Yorkie CRDT** for
+the PDF bytes. Users upload a PDF from the documents list and open it in a
+pdf.js-based viewer route. Phase 2 layered collaboration on top by
 introducing a `pdf-<id>` Yorkie document that holds only comment threads
 and presence — never the PDF bytes — and by making the file-serving
 endpoint accept a share token so a shared PDF can be viewed without a
@@ -22,8 +22,13 @@ workspace membership. Viewing bytes is open to any valid share token;
 **commenting** is gated to editor-role links or workspace members
 (client-side, as with every other shared type — see Non-Goals and Slice 3).
 
-This document covers Phase 1 (view/store) in full and Phase 2
-(share + comments + presence) as an implementation spec.
+Both phases are **shipped**. This document covers Phase 1 (view/store)
+and Phase 2 (share + comments + presence); the "Phase 2" / "Slice"
+framing below is retained for historical structure but describes
+implemented behavior. Note also that the blob module was subsequently
+broadened beyond PDF: the same `FileService` and `GET /documents/:id/file`
+endpoint back the `"image"` document type (see
+[image-viewer.md](image-viewer.md)), so the file layer accepts images too.
 
 ### Goals
 
@@ -84,8 +89,13 @@ Mirror the existing `image/` module rather than overloading it (keeps
 
 - `packages/backend/src/file/file.service.ts` — S3-compatible
   (`@aws-sdk/client-s3`), dedicated bucket `wafflebase-files`, auto-create
-  on boot. `upload(buffer, mime, name)` accepts **`application/pdf` only**,
-  size cap **50 MB**. Reuses the `packages/backend/src/image/image.config.ts` env pattern
+  on boot. `upload(buffer, mime, name)` accepts **`application/pdf`** plus
+  the image MIME types (`image/png`, `image/jpeg`, `image/gif`,
+  `image/webp`) once the image document type shipped on the same blob
+  layer — size cap **50 MB** for PDFs (`MAX_PDF_UPLOAD_BYTES`) and a
+  separate **25 MB** cap for images (`MAX_IMAGE_UPLOAD_BYTES`), enforced
+  per category (`packages/backend/src/file/file.constants.ts`). Reuses the
+  `packages/backend/src/image/image.config.ts` env pattern
   (`FILE_STORAGE_ENDPOINT/BUCKET/REGION/ACCESS_KEY/SECRET_KEY`, dev
   defaults to the same MinIO endpoint).
 - `packages/backend/src/file/file.controller.ts`:
@@ -93,11 +103,14 @@ Mirror the existing `image/` module rather than overloading it (keeps
     **before** the document exists (upload-then-create flow), so it is
     JWT-gated blob storage only; it does not expose a public GET.
   - No public `GET /files/:id`. Serving is document-scoped (below).
-- Blob id validation mirrors `VALID_IMAGE_ID_PATTERN`.
+- Blob id validation uses `VALID_FILE_ID_PATTERN`
+  (`packages/backend/src/file/file.constants.ts`), which accepts both the
+  `.pdf` and image extensions (`png`/`jpe?g`/`gif`/`webp`).
 
 *Alternative considered*: extract a shared S3 blob core and make image/file
-thin configs. Deferred — with a single new file type, mirroring is
-simpler; revisit if a third blob kind appears.
+thin configs. The `file/` module instead grew to host both PDF and image
+blobs on one endpoint (the `image/` module remains for the older embedded
+in-sheet/docs images); a fuller extraction is still deferred.
 
 ### Serving — document-scoped, permission-gated
 
@@ -113,8 +126,10 @@ document read check instead of reimplementing permission logic:
   images' `public, immutable`), optional `ETag`.
 - A blob id is never accepted directly from the client for reads — the
   only read path is through a document the caller can already access.
-- **Deletion**: when a document with a `fileId` is deleted, delete the
-  referenced blob (hook into `DocumentService` delete).
+- **Deletion**: when a document with a `fileId` is deleted, the referenced
+  blob is deleted best-effort in the **document controller** after the row
+  is removed (the `DocumentService` delete methods do no blob cleanup —
+  see the `deleteDocuments` doc-comment).
 
 ### Upload & create flow
 
@@ -161,28 +176,29 @@ an orphan-sweep job is a follow-up.
 - `getDocumentPath(type)` → `/f/:id` for `pdf`.
 - Add the "Upload PDF" action to the New menu (wired to the flow above).
 
-## Phase 2 — Share + comments + presence
+## Phase 2 — Share + comments + presence (shipped)
 
-Phase 2 attaches the reserved `pdf-<id>` Yorkie document for the first
-time (comment threads + presence only; PDF bytes stay in the blob),
-closes the one net-new backend gap (share-token file serving), and reuses
-the existing shared comments module and frontend presence pattern. No data
-migration: the `fileId` column and blob storage are unchanged. The `pdf-<id>`
-Yorkie doc is attached on first open of the viewer, with its `comments` map
-seeded empty at bootstrap via `initialRoot` (never created lazily — see the
-convergence note in Slice 2).
+Phase 2 attaches the reserved `pdf-<id>` Yorkie document (comment threads +
+presence only; PDF bytes stay in the blob), closes the one net-new backend
+gap (share-token file serving), and reuses the existing shared comments
+module and frontend presence pattern. No data migration: the `fileId`
+column and blob storage are unchanged. The `pdf-<id>` Yorkie doc is
+attached on first open of the viewer (`packages/frontend/src/app/files/pdf-collab.tsx`),
+with its `comments` map seeded empty at bootstrap via `initialRoot`
+(`initialPdfRoot` in `packages/frontend/src/types/pdf-document.ts`; never
+created lazily — see the convergence note in Slice 2).
 
-The work splits into five slices; the order below is also the intended PR
-sequence.
+All five slices below are **implemented**; the slice split is retained as
+the historical PR sequence.
 
 ### Slice 1 — Share-token-aware file serving (only net-new backend work)
 
-`GET /documents/:id/file` is today JWT + `workspaceService.assertMember`.
-Extend it to **member OR valid share token** rather than adding a parallel
-public endpoint — one access path, no permission drift:
+`GET /documents/:id/file` accepts **member OR valid share token** rather
+than a parallel public endpoint — one access path, no permission drift.
+It lives in its own `packages/backend/src/document/document-file.controller.ts`:
 
-- Make the route reachable without a JWT (optional auth), so anonymous
-  share viewers can fetch the bytes.
+- The route is guarded by `OptionalJwtAuthGuard` (reachable without a JWT),
+  so anonymous share viewers can fetch the bytes.
 - Resolution order: if `req.user` is a member of `doc.workspaceId` → serve.
   Else if a `?token=<shareToken>` query param is present →
   `shareLinkService.findByToken(token)`, assert `link.documentId === id`

--- a/docs/design/rest-api.md
+++ b/docs/design/rest-api.md
@@ -33,7 +33,8 @@ which consumes this surface — lives in [cli.md](cli.md).
   that).
 - Granular per-document or per-cell permission scoping on API keys
   (may be added later).
-- Rate limiting or usage metering.
+- Usage metering or per-key quota accounting. (A global request rate
+  limit *is* enforced — see §5.6 Rate limiting.)
 - Frontend UI for API key management beyond the existing workspace
   settings page.
 - MCP server (may be added later as a thin wrapper over the REST API).
@@ -126,8 +127,8 @@ user edits.
 `http://localhost:8080`).
 
 **Dependency**: `@yorkie-js/sdk` is in `packages/backend/package.json`,
-matching the version family used by the frontend (`@yorkie-js/react`
-0.6.49).
+matching the version used by the frontend (both pin `@yorkie-js/sdk`
+0.7.13; the frontend also uses `@yorkie-js/react` 0.7.13).
 
 **Types**: `SpreadsheetDocument`, `Worksheet`, `TabMeta`, and
 `Document` (the Docs root) are re-exported from a backend-local Yorkie
@@ -218,6 +219,28 @@ backend. The CLI imports `@wafflebase/docs` and runs it locally; this
 keeps the backend free of native rendering dependencies. See
 [cli.md](cli.md) for the local pipeline.
 
+#### 5.5 Images (workspace-scoped blobs)
+
+```
+POST   /api/v1/workspaces/:wid/images         Upload an image (multipart `file`)
+GET    /api/v1/workspaces/:wid/images/:imageId  Fetch an image blob
+DELETE /api/v1/workspaces/:wid/images/:imageId  Delete an image
+```
+
+`ApiV1ImagesController` (`packages/backend/src/api/v1/images.controller.ts`)
+is guarded by `CombinedAuthGuard` + `WorkspaceScopeGuard` and delegates
+to the S3/MinIO-backed `ImageService`. Uploads accept png/jpeg/gif/webp
+up to 10 MB and return `{ id, url }`, where `url` points back at this
+workspace-scoped `GET` route. Objects are keyed `{workspaceId}/{imageId}`.
+
+#### 5.6 Rate limiting
+
+The application registers a global NestJS `ThrottlerGuard` via
+`ThrottlerModule.forRoot` (default bucket: 120 requests / 60 s). Selected
+routes tighten or relax it with `@Throttle`: the CLI auth endpoints cap
+at 10/min and the image endpoints raise to 600/min. This is coarse
+request throttling, not per-key usage metering or quotas.
+
 ### 6. Module Structure
 
 ```
@@ -240,6 +263,7 @@ packages/backend/src/
       tabs.controller.ts
       cells.controller.ts
       docs-content.controller.ts
+      images.controller.ts
       workspace-scope.guard.ts
 ```
 

--- a/docs/design/rest-api.md
+++ b/docs/design/rest-api.md
@@ -232,6 +232,12 @@ is guarded by `CombinedAuthGuard` + `WorkspaceScopeGuard` and delegates
 to the S3/MinIO-backed `ImageService`. Uploads accept png/jpeg/gif/webp
 up to 10 MB and return `{ id, url }`, where `url` points back at this
 workspace-scoped `GET` route. Objects are keyed `{workspaceId}/{imageId}`.
+The `GET` route sets `Cache-Control: public, max-age=31536000, immutable`
+(`packages/backend/src/api/v1/images.controller.ts`): image ids are
+opaque and workspace-scoped, so the blob at a given URL never changes and
+is treated as safe to cache. Note this is a `public` policy on a
+bearer-token URL — a shared proxy/CDN may cache the object without
+re-running `CombinedAuthGuard`/`WorkspaceScopeGuard` on later hits.
 
 #### 5.6 Rate limiting
 

--- a/docs/design/shared-core-extraction.md
+++ b/docs/design/shared-core-extraction.md
@@ -85,12 +85,13 @@ sheets/docs/slides ← frontend, backend, cli
 | Fill/gradient picker (frontend) | slides-only | **D** | Extract on demand. |
 | Chart | sheets=Recharts/DOM, slides=Canvas painter | **D** | Convergence target, not an extraction (see below). |
 
-Geometry redefinition sites (Tier A, illustrative):
-`packages/slides/src/model/frame.ts`,
+Geometry redefinition sites (Tier A). Phase 0 has since migrated the slides
+sites — `packages/slides/src/model/frame.ts`,
 `packages/slides/src/view/canvas/routing.ts`,
 `packages/slides/src/view/editor/interactions/insert.ts`,
-`packages/slides/src/view/editor/interactions/lasso.ts`,
-`packages/slides/src/model/image-crop.ts`,
+`packages/slides/src/view/editor/interactions/lasso.ts`, and
+`packages/slides/src/model/image-crop.ts` all import from
+`@wafflebase/core/geometry` now. The remaining local redefinition is
 `packages/sheets/src/view/layout.ts` (`Size` with `width/height` vs slides
 `w/h` — a real field-name mismatch across packages).
 
@@ -127,6 +128,7 @@ packages/core/
     tokens/               → @wafflebase/core/tokens     (palette, semantic, radius, typography, contrast)
       index.ts palette.ts semantic.ts radius.ts typography.ts contrast.ts
     geometry/index.ts     → @wafflebase/core/geometry     (Point/Rect/Size, bbox, hit-test)
+    url/index.ts          → @wafflebase/core/url           (SAFE_PROTOCOLS, isSafeUrl)  [shipped]
     canvas/index.ts       → @wafflebase/core/canvas        (DPR ctx setup, drawRoundedRect, offscreen)
     ooxml/
       index.ts            → @wafflebase/core/ooxml         (zip · xml · rels · units · escape)
@@ -140,6 +142,7 @@ packages/core/
   "./tokens":          { "types": "...", "import": "./dist/tokens/index.js",         "require": "./dist/cjs/tokens/index.js" },
   "./tokens.css":      "./dist/tokens.css",
   "./geometry":        { "types": "...", "import": "./dist/geometry/index.js",       "require": "./dist/cjs/geometry/index.js" },
+  "./url":             { "types": "...", "import": "./dist/url/index.js",            "require": "./dist/cjs/url/index.js" },
   "./canvas":          { "types": "...", "import": "./dist/canvas/index.js",         "require": "./dist/cjs/canvas/index.js" },
   "./ooxml":           { "types": "...", "import": "./dist/ooxml/index.js",          "require": "./dist/cjs/ooxml/index.js" },
   "./ooxml/drawingml": { "types": "...", "import": "./dist/ooxml/drawingml/index.js","require": "./dist/cjs/ooxml/drawingml/index.js" }
@@ -208,11 +211,14 @@ regression risk is staged.
 4. **Phase 3+ (deferred)** — chart convergence, color/theme model, store base:
    only after the OOXML core is stable.
 
-### Incidental fix
+### Incidental fix (shipped in Phase 0)
 
-`packages/docs/package.json` lists `@wafflebase/tokens` under
-**devDependencies**, but `packages/docs/src/view/theme.ts` imports `palette`
-at runtime. Promote to a regular dependency (fold into Phase 0).
+`packages/docs/package.json` previously listed `@wafflebase/tokens` under
+**devDependencies** while `packages/docs/src/view/theme.ts` imported `palette`
+at runtime. Resolved: `@wafflebase/tokens` no longer exists (folded into
+`@wafflebase/core`), `packages/docs/package.json` carries `@wafflebase/core`
+under **dependencies**, and `packages/docs/src/view/theme.ts` imports `palette`
+from `@wafflebase/core/tokens` at runtime.
 
 ### Risks and Mitigation
 

--- a/docs/design/sharing.md
+++ b/docs/design/sharing.md
@@ -23,7 +23,6 @@ without logging in.
 ### Non-Goals
 
 - User-level invites or per-user permission management.
-- Server-side write protection — view-only enforcement is client-side only.
 - Granular permissions (e.g., comment-only, specific cell ranges).
 
 ## Proposal Details
@@ -99,11 +98,14 @@ URLs to clipboard, and revoking existing links.
 
 **Shared document route** (`/shared/:token`) — Placed outside `PrivateRoute` so
 anonymous users can access it. Resolves the token, sets up `YorkieProvider` and
-`DocumentProvider`, and renders the spreadsheet. The shared view follows the
-document's `tabOrder` and exposes tab switching across all tabs (sheet and
-datasource). Attempts to detect logged-in users for presence identity; falls
-back to "Anonymous". For `viewer` links, editing remains blocked across tab
-types (including datasource query editing).
+`DocumentProvider`, and branches on the resolved `type` to a per-type read-only
+layout: sheet, docs, slides (`SharedSlidesLayout`, with desktop/mobile
+variants), notes (`SharedNotesLayout`), board (`SharedBoardLayout`), and PDF
+(`SharedPdfLayout`). The sheet view follows the document's `tabOrder` and
+exposes tab switching across all tabs (sheet and datasource). Attempts to detect
+logged-in users for presence identity; falls back to "Anonymous". For `viewer`
+links, editing remains blocked across tab types (including datasource query
+editing).
 
 ### Sheet Package (Read-Only Mode)
 
@@ -143,9 +145,14 @@ constructed in read-only mode too, with every **mutating** path gated so
   unguessable.
 - **Revocation** — Deleting a ShareLink immediately invalidates the token.
 - **Cascade deletion** — Deleting a document cascades to all its share links.
-- **Client-side enforcement** — View-only mode is enforced in the browser.
-  Yorkie does not support per-user write auth, but the Yorkie doc key is only
-  revealed after valid token resolution, limiting exposure.
+- **Server-side write enforcement** — The Yorkie auth webhook enforces the
+  share-link role server-side: an anonymous visitor's token is checked in
+  `hasAccess()` (`packages/backend/src/document/yorkie-auth.controller.ts`),
+  which returns `needWrite ? link.role === 'editor' : true`, so a `viewer` token
+  requesting a write (`rw`) verb is denied with `403`
+  (see [yorkie-auth-webhook.md](yorkie-auth-webhook.md)). Client-side read-only
+  mode additionally gates the UI so a viewer never hits the error path, and the
+  Yorkie doc key is only revealed after valid token resolution.
 - **Expiration** — Links can have time-limited access (1h, 8h, 24h, 7d).
 
 ### Risks and Mitigation
@@ -154,12 +161,14 @@ constructed in read-only mode too, with every **mutating** path gated so
 the document. Mitigation: link expiration, ability to revoke links, and
 client-side role enforcement.
 
-**No server-side write protection** — A technically sophisticated user could
-bypass client-side read-only checks and write to the Yorkie document directly.
-Mitigation: acceptable for v1 since the Yorkie doc key is only revealed after
-valid token resolution; server-side enforcement can be added later via Yorkie
-webhooks.
+**Token leakage across write access** — A `viewer` link is read-only, but an
+`editor` link grants anonymous write access. Mitigation: editor links are gated
+to workspace owners / document authors, are revocable and expirable, and the
+Yorkie auth webhook enforces the link role server-side, so bypassing the
+client-side read-only checks does not grant a viewer token write access.
 
-**No rate limiting on token resolution** — The public resolve endpoint could be
-brute-forced. Mitigation: UUID tokens have sufficient entropy to make brute-force
-impractical; rate limiting via `@nestjs/throttler` can be added as needed.
+**Brute-forcing token resolution** — The public resolve endpoint could be
+probed. Mitigation: UUID tokens have sufficient entropy to make brute-force
+impractical, and the endpoint is rate limited by the global
+`@nestjs/throttler` `ThrottlerGuard` (default 120 req/min per client,
+`packages/backend/src/app.module.ts`).

--- a/docs/design/sheets/batch-transactions.md
+++ b/docs/design/sheets/batch-transactions.md
@@ -50,7 +50,7 @@ YorkieStore maintains two batch buffers:
 
 ```typescript
 private batchOverlay: Map<Sref, Cell | null> | null = null;
-private batchOps: Array<(root: Worksheet) => void> | null = null;
+private batchOps: Array<(root: SpreadsheetDocument) => void> | null = null;
 ```
 
 - **`batchOverlay`** — Buffers cell mutations. Maps `Sref` to `Cell` (set) or
@@ -97,8 +97,13 @@ naturally deduplicates), we write each key at most once.
 
 #### Methods unaffected by batch
 
-- `shiftCells()`, `moveCells()` — Run their own `doc.update()` outside the
-  batch (subsequent operations need to see the shifted state).
+- `shiftCells()`, `moveCells()` — Batch-aware at the store level: when a batch
+  is active they buffer their apply function into `batchOps` and defer to the
+  single `endBatch()` flush; otherwise they run their own `doc.update()`. In
+  practice `Sheet.shiftCells` / `Sheet.moveCells` call `store.shiftCells` /
+  `store.moveCells` *before* `beginBatch()`, so the structural change lands as
+  its own `doc.update()` and subsequent operations see the shifted state —
+  which is why these paths still produce 2 undo steps (see Non-Goals).
 - `findEdge()` — Uses `cellIndex` which is kept up-to-date during batch.
 - Read-only methods (`getDimensionSizes`, `getColumnStyles`, etc.) — Sheet
   caches these locally.

--- a/docs/design/sheets/calculator.md
+++ b/docs/design/sheets/calculator.md
@@ -47,12 +47,25 @@ Source: `packages/sheets/src/model/worksheet/calculator.ts`
      (reversed post-order).
 3. **Evaluate** — For each ref in topological order:
    - If the ref is in `cycledRefs`, its value is set to `#REF!`.
-   - Otherwise, `extractReferences` finds all referenced cells,
+   - Otherwise, `expandUnboundedRanges` rewrites whole-column/row/open-ended
+     ranges (e.g. `A:A`, `1:1`, `A1:B`) to concrete ranges clamped to the
+     used bounds, `extractReferences` finds all referenced cells,
      `fetchGridByReferences` loads their current values (including
-     cross-sheet data), `evaluate` computes the result, and the cell is
-     updated.
+     cross-sheet data), `evaluateWithSpill` computes the result, and the cell
+     is updated.
    - No-op writes are skipped when the evaluated result matches the existing
      cell value to reduce CRDT churn.
+
+**Array spill** — `evaluateWithSpill` may return a `SpillResult` (a 2-D block
+of `values` with `rows`/`cols`) instead of a scalar. When it does, the
+calculator writes the top-left result to the anchor cell (tagged with
+`spillRows`/`spillCols`) and fills the rest of the block with ghost cells
+carrying a `spillAnchor` back-reference. Before re-evaluating, an anchor's
+prior ghosts are cleared. If the target block collides with real user data
+(a cell that has a value/formula but no `spillAnchor`), the spill is blocked:
+the anchor shows `#REF!` with `spillBlocked: true`, no ghosts are written, and
+the blocker is recorded via `sheet.registerSpillBlocker`; a subsequent
+unblocked evaluation clears it via `sheet.clearSpillBlockers`.
 
 ```text
 setData(ref, value)
@@ -63,9 +76,10 @@ setData(ref, value)
         │
         ├── topologicalSort(...)  ──→  [A1, B1, C1, D1], cycled={}
         └── for each sref in sorted:
+              ├── expandUnboundedRanges(formula, usedBounds)
               ├── extractReferences(formula)
               ├── fetchGridByReferences(refs)  ──→  Grid (including cross-sheet data)
-              └── evaluate(formula, grid)  ──→  new value
+              └── evaluateWithSpill(formula, grid)  ──→  value or SpillResult
 ```
 
 ### Cross-Sheet Recalculation

--- a/docs/design/sheets/charts.md
+++ b/docs/design/sheets/charts.md
@@ -41,7 +41,8 @@ parity.
 
 ### 1. Type System
 
-Extend `ChartType` in `packages/frontend/src/types/worksheet.ts`:
+`ChartType` is defined in `packages/sheets/src/model/workbook/worksheet-document.ts`
+(re-exported from `packages/frontend/src/types/worksheet.ts`):
 
 ```typescript
 export type ChartType = "bar" | "line" | "area" | "pie" | "scatter";
@@ -92,7 +93,7 @@ builder function converts the standard SheetChart fields:
 type PieDatasetEntry = { name: string; value: number; color: string };
 type PieDataset = { entries: PieDatasetEntry[] };
 
-function buildPieDataset(root, chart): PieDataset;
+function buildPieDataset(root, chart, palette?: string): PieDataset;
 ```
 
 - Rows with non-positive values are excluded.

--- a/docs/design/sheets/collaboration.md
+++ b/docs/design/sheets/collaboration.md
@@ -91,6 +91,7 @@ type Worksheet = {
   sheetStyle?: CellStyle;
   rangeStyles?: RangeStylePatch[];
   conditionalFormats?: ConditionalFormatRule[];
+  dataValidations?: DataValidationRule[];          // see data-validation.md
   merges?: { [anchor: Sref]: MergeSpan };
   filter?: WorksheetFilterState;
   hiddenRows?: number[];
@@ -99,7 +100,7 @@ type Worksheet = {
   frozenRows: number;
   frozenCols: number;
   pivotTable?: PivotTableDefinition;              // see pivot-table.md
-  comments?: CommentsCollection;                  // see comments.md
+  comments?: { [threadId: string]: Thread };      // see comments.md
   images?: { [id: string]: SheetImage };          // see sheet-image.md
 };
 
@@ -107,7 +108,6 @@ type SpreadsheetDocument = {
   tabs: { [id: string]: TabMeta };
   tabOrder: string[];
   sheets: { [tabId: string]: Worksheet };
-  datasources?: { [id: string]: DatasourceConfig }; // see datasource.md
 };
 ```
 

--- a/docs/design/sheets/comments.md
+++ b/docs/design/sheets/comments.md
@@ -11,13 +11,16 @@ target-version: 0.4.0
 
 Add Google Sheets-style threaded comments anchored to spreadsheet cells. Phase B
 (this document) covers single-cell threads with replies, resolve/reopen, and a
-side panel for browsing all comments. Mentions, notifications, and broader
-anchors (range, sheet, doc) are deferred to phase C.
+side panel for browsing all comments. `@user` mentions have since shipped (see
+[comments-mentions.md](../comments-mentions.md)); notifications and broader
+anchors (range, sheet, doc) remain deferred to phase C.
 
 The data model is designed *anchor-agnostic* from day one — a discriminated
-`CommentAnchor` union allows future extraction into a shared
-`@wafflebase/comments` package once Docs or Slides become a second consumer.
-Until then, comment code lives inside `packages/sheets`.
+`CommentAnchor` union. Docs and PDF have since become consumers, and the comment
+UI has been extracted into a shared frontend module at
+`packages/frontend/src/components/comments/` (a frontend-internal directory,
+**not** a published `@wafflebase/comments` package). The base data-model types
+still live in `packages/sheets/src/comment/` and are re-exported.
 
 ## Goals / Non-Goals
 
@@ -38,13 +41,16 @@ Until then, comment code lives inside `packages/sheets`.
 
 ### Non-Goals
 
-- `@user` mentions and notifications (deferred to phase C).
+- In-app / email notifications (deferred to phase C). Note: `@user` mentions
+  themselves have since shipped — see [comments-mentions.md](../comments-mentions.md).
 - Range, full-row, full-column, sheet, or document-wide comments (phase C+).
 - Rich-text body (bold, italics, links). Plain text + newlines only.
 - Email / external notifications.
 - Comment search across the workbook.
-- Cross-package generalization at this stage. The shared
-  `@wafflebase/comments` package is created when Docs adds comments.
+- Cross-package generalization. Docs and PDF have since added comments; the
+  shared UI landed as a frontend-internal module
+  (`packages/frontend/src/components/comments/`) rather than a published
+  `@wafflebase/comments` package.
 - Per-user read/unread state.
 
 ## Proposal Details
@@ -55,24 +61,31 @@ Until then, comment code lives inside `packages/sheets`.
 packages/sheets/src/comment/
 ├── types.ts          # CommentAnchor, CommentAuthor, Comment, Thread
 ├── thread.ts         # pure helpers — create, validate, mutate threads
-├── anchor.ts         # CellAnchor ↔ Sref helpers, anchor validation
-└── index.ts          # public exports
+└── anchor.ts         # CellAnchor ↔ Sref helpers, anchor validation
 
 packages/sheets/src/store/store.ts
 └── Store interface gains six comment methods (§4)
 
 packages/sheets/src/view/
-└── render-comments.ts             # NEW — canvas marker rendering
+└── render-comments.ts             # canvas marker rendering
 
 packages/frontend/src/app/spreadsheet/
-├── yorkie-store.ts                # Store impl gains comment methods
-├── yorkie-worksheet-comments.ts   # NEW — Yorkie-local comment mutations
-├── yorkie-worksheet-structure.ts  # MODIFY — orphan cleanup on row/col delete
-└── components/comments/           # NEW — popover, side panel, composer
-    ├── CommentPopover.tsx
-    ├── CommentSidePanel.tsx
-    └── CommentComposer.tsx
+├── yorkie-store.ts                        # Store impl gains comment methods
+├── yorkie-worksheet-comments.ts           # Yorkie-local comment mutations
+├── yorkie-worksheet-structure.ts          # orphan cleanup on row/col delete
+└── components/comments/CommentPopover.tsx  # cell-click popover
+
+packages/frontend/src/components/comments/  # shared cross-consumer module
+└── components/                             # CommentComposer, CommentSidePanel, …
+
+packages/frontend/src/app/documents/document-detail.tsx  # wires the side panel
 ```
+
+Note: the reusable composer and side panel live in the shared
+`packages/frontend/src/components/comments/` module (consumed by sheets, docs,
+and pdf); only the spreadsheet-specific `CommentPopover` remains under
+`app/spreadsheet/`, and the sheet side panel is mounted from
+`app/documents/document-detail.tsx`.
 
 The shared `packages/sheets` package owns the data model, pure helpers, and the
 Canvas grid renderer (which already lives at `packages/sheets/src/view/gridcanvas.ts`).
@@ -318,7 +331,7 @@ conditional-format indicators. Filter: `tabId === currentTab && !resolved`.
 
 | Property        | Value                                          |
 | --------------- | ---------------------------------------------- |
-| Shape           | 7 × 7 px right triangle (top-right of cell)    |
+| Shape           | 9 × 9 px right triangle (top-right of cell)    |
 | Color           | `#fbbc04` (Google Sheets parity)               |
 | Resolved hidden | Yes — only `resolved=false` shows a marker     |
 
@@ -395,11 +408,11 @@ popover.
 
 ### 8. Phase Plan
 
-| Phase  | Scope                                                                |
-| ------ | -------------------------------------------------------------------- |
-| **B**  | Everything in this document.                                         |
-| C      | `@user` mentions, notifications (in-app + email), per-user unread.   |
-| C+     | Range / row / column / sheet anchors, cross-package extraction to `@wafflebase/comments`. |
+| Phase  | Scope                                                                | Status |
+| ------ | -------------------------------------------------------------------- | ------ |
+| **B**  | Everything in this document.                                         | Shipped |
+| C      | `@user` mentions, notifications (in-app + email), per-user unread.   | Mentions shipped ([comments-mentions.md](../comments-mentions.md)); notifications + unread pending |
+| C+     | Range / row / column / sheet anchors, cross-package extraction.      | Extraction shipped as a shared frontend module (`packages/frontend/src/components/comments/`), not a published `@wafflebase/comments` package; broader anchors pending |
 
 ## Risks and Mitigation
 

--- a/docs/design/sheets/comments.md
+++ b/docs/design/sheets/comments.md
@@ -59,7 +59,7 @@ still live in `packages/sheets/src/comment/` and are re-exported.
 
 ```
 packages/sheets/src/comment/
-├── types.ts          # CommentAnchor, CommentAuthor, Comment, Thread
+├── types.ts          # sheet-cell CommentAnchor, CommentAuthor, Comment, generic Thread<A>
 ├── thread.ts         # pure helpers — create, validate, mutate threads
 └── anchor.ts         # CellAnchor ↔ Sref helpers, anchor validation
 
@@ -105,12 +105,17 @@ export type CommentAuthor = {
   photo?: string;
 };
 
-// Discriminated union — Docs / Slides extraction adds variants here.
-export type CommentAnchor =
-  | { kind: 'sheet-cell'; tabId: string; rowId: string; colId: string };
-  // future: { kind: 'sheet-range'; tabId; startRowId; ...; endColId }
-  // future: { kind: 'docs-range'; blockId; ... }
-  // future: { kind: 'slide-element'; slideId; elementId }
+// Sheets owns only the sheet-cell anchor. The full cross-consumer union
+// (`CommentAnchor = SheetCellAnchor | DocsRangeAnchor | PdfRegionAnchor`) is
+// assembled in the frontend type module at
+// `packages/frontend/src/types/comments.ts`, which re-imports this shape as
+// `SheetCellAnchorBase`. Docs and PDF are the shipped extra consumers.
+export type CommentAnchor = {
+  kind: 'sheet-cell';
+  tabId: string;
+  rowId: string;
+  colId: string;
+};
 
 export type Comment = {
   id: string;            // UUID v4
@@ -120,9 +125,12 @@ export type Comment = {
   editedAt?: number;     // present iff body has been edited
 };
 
-export type Thread = {
+// Generic over the anchor so this same shape is the canonical base for every
+// consumer; the frontend's shared `Thread<A>` aliases it. Sheets itself only
+// ever uses the default `sheet-cell` anchor.
+export type Thread<A extends { kind: string } = CommentAnchor> = {
   id: string;            // UUID v4
-  anchor: CommentAnchor;
+  anchor: A;             // sheet-cell in this package
   comments: Comment[];   // [0] is root, rest are replies in author order
   resolved: boolean;
   resolvedAt?: number;

--- a/docs/design/sheets/data-validation.md
+++ b/docs/design/sheets/data-validation.md
@@ -49,7 +49,8 @@ real, typed cell value.
 - A worksheet-level `DataValidationRule[]` model, range-scoped, mirroring
   `ConditionalFormatRule`. Cells stay untouched; the formula engine stays
   untouched.
-- Three control kinds: `checkbox`, `list`, `date`.
+- Control kinds: `checkbox`, `list`, `date` — since extended to `number` and
+  `text` comparison validation (all five shipped; see the Phase 4/5 sections).
 - In-cell rendering: checkbox glyph, dropdown arrow, and a warning marker for
   invalid values — reusing the filter-button render/hit-test precedent.
 - Interaction: click/Space toggle for checkboxes; anchored popover for list;
@@ -78,8 +79,13 @@ real, typed cell value.
 Add to `packages/sheets/src/model/core/types.ts`, mirroring
 `ConditionalFormatRule` (`types.ts:126-133`):
 
+The kind union grew across phases; the shipped type carries five kinds and a
+generic `operator`+`values` substructure (the `date`/`number`/`text` comparison
+kinds) in place of the original date-specific `dateMin`/`dateMax` fields — see
+the Phase 4/5 sections below for the rationale:
+
 ```typescript
-export type DataValidationKind = 'checkbox' | 'list' | 'date';
+export type DataValidationKind = 'checkbox' | 'list' | 'date' | 'number' | 'text';
 
 export type DataValidationRule = {
   id: string;
@@ -95,9 +101,9 @@ export type DataValidationRule = {
   checkedValue?: string;   // custom checked value (default: boolean "TRUE")
   uncheckedValue?: string; // custom unchecked value (default: boolean "FALSE")
 
-  // kind: 'date'
-  dateMin?: string;        // ISO lower bound, optional
-  dateMax?: string;        // ISO upper bound, optional
+  // kind: 'date' | 'number' | 'text' (operator + comparison operands)
+  operator?: DataValidationOperator;
+  values?: string[];       // operands (ISO date / number / text); length by operator
 };
 ```
 
@@ -634,10 +640,10 @@ quirk); the new `describeNumberRule` checks operands by index to avoid it.
 
 ### Testing
 
-> Scope note: this section is the testing strategy for the **full** feature
-> (all three kinds). Phases 1–2 shipped checkbox + list; Phase 4 (above) adds
-> date. See each phase's "as shipped"/"design" subsection for the coverage that
-> actually landed.
+> Scope note: this section is the testing strategy for the **full** feature.
+> Phases 1–2 shipped checkbox + list; Phase 4 added date; Phase 5 added the
+> `number`/`text` comparison kinds. See each phase's "as shipped"/"design"
+> subsection for the coverage that actually landed.
 
 - **model unit tests** (Vitest, `packages/sheets`): `resolveDataValidationAt` range
   matching (overlap/priority); checkbox value transitions (`TRUE`↔`FALSE`,

--- a/docs/design/sheets/datasource.md
+++ b/docs/design/sheets/datasource.md
@@ -25,7 +25,7 @@ Data Sources allow users to connect external PostgreSQL databases to their Waffl
 - Support for databases other than PostgreSQL (MySQL, SQLite, etc.)
 - Writing back to external databases
 - Scheduled/automatic query refresh
-- Sharing datasource connections between users
+- Cross-workspace sharing of datasource connections (connections are shared within a workspace, not across workspaces or with arbitrary users)
 - Query parameterization or variables
 
 ## Architecture Overview
@@ -105,18 +105,20 @@ Located at `packages/backend/src/datasource/`.
 
 ```prisma
 model DataSource {
-  id         String   @id @default(uuid())
-  name       String
-  host       String
-  port       Int      @default(5432)
-  database   String
-  username   String
-  password   String              // AES-256-GCM encrypted
-  sslEnabled Boolean  @default(false)
-  authorID   Int
-  author     User     @relation(fields: [authorID], references: [id])
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  id          String    @id @default(uuid())
+  name        String
+  host        String
+  port        Int       @default(5432)
+  database    String
+  username    String
+  password    String              // AES-256-GCM encrypted
+  sslEnabled  Boolean   @default(false)
+  authorID    Int                 // creator, for auditing
+  author      User      @relation(fields: [authorID], references: [id])
+  workspaceId String              // datasources are workspace-scoped
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 }
 ```
 
@@ -126,17 +128,27 @@ All endpoints require JWT authentication (`JwtAuthGuard`).
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/datasources` | Create a new datasource |
-| GET | `/datasources` | List user's datasources (passwords masked) |
+| POST | `/workspaces/:workspaceId/datasources` | Create a datasource in a workspace |
+| GET | `/workspaces/:workspaceId/datasources` | List a workspace's datasources (passwords masked) |
+| POST | `/datasources` | Create a datasource (workspace given in the request body) |
+| GET | `/datasources` | List datasources across the user's workspaces (passwords masked) |
 | GET | `/datasources/:id` | Get single datasource |
 | PATCH | `/datasources/:id` | Update datasource fields |
 | DELETE | `/datasources/:id` | Delete datasource |
 | POST | `/datasources/:id/test` | Test connection (SELECT 1) |
 | POST | `/datasources/:id/query` | Execute a SQL query |
 
+The workspace-scoped routes are the primary surface; the flat `POST /datasources`
+still exists for backward compatibility but requires a `workspaceId` in its body
+(`CreateDataSourceInWorkspaceDto`), and flat `GET /datasources` fans out across
+all of the caller's workspaces.
+
 #### Access Control
 
-Every operation verifies `ds.authorID === userId`. Users can only access their own datasources.
+Datasources are **workspace-scoped**. Every operation resolves the datasource's
+`workspaceId` and calls `workspaceService.assertMember(workspaceId, userId)`, so
+any member of the owning workspace can read, query, edit, or delete it — not just
+the creator (`authorID`, which is retained for auditing).
 
 #### Password Encryption
 
@@ -198,11 +210,11 @@ These are known gaps in the current implementation that represent opportunities 
 2. **Read-only results** — Query results cannot be edited, sorted, or filtered in the grid.
 3. **No auto-refresh** — Queries must be manually re-executed to see updated data.
 4. **No query history** — Previous queries are not saved; only the latest query persists.
-5. **Single-user datasources** — Connections are private to the creator; collaborators on a document cannot use a datasource tab unless they own the connection (they see the query but cannot execute it).
+5. **Workspace-scoped datasources** — Connections are shared among members of the owning workspace (any member can execute queries), but cannot be shared across workspaces or with non-members.
 6. **No connection pooling** — Each query execution creates and destroys a pg Client connection.
 7. **No schema browser** — Users must know table/column names; there is no database schema explorer.
 8. **Basic SQL editor** — Plain textarea without syntax highlighting, autocomplete, or formatting.
-9. **No column type mapping** — All values are displayed as strings regardless of the PostgreSQL data type.
+9. **Minimal column type mapping** — Values are displayed as strings for most PostgreSQL data types. The one exception is date/time types (`DATE`, `TIMESTAMP`, `TIMESTAMPTZ`), which the service keeps as raw Postgres text via a custom `datasourceTypeParser` to avoid the default parser's runtime-timezone shift; there is still no rich type mapping to numeric/boolean/date cell formats.
 10. **Authenticated HTTP coverage is still narrow** — Unit tests cover SQL validation and `DataSourceService` logic, controller-contract e2e tests cover route wiring with mocked services, DB-backed integration tests cover datasource/share-link service logic, and authenticated HTTP integration tests now cover core JWT-guarded datasource/share-link/document ownership paths. Broader edge-case coverage (auth/session failures, more negative permutations, and cross-module flows) is still missing.
 
 ## Next Steps
@@ -217,7 +229,7 @@ These are known gaps in the current implementation that represent opportunities 
 
 ### Medium-term (expand capabilities)
 
-- **Shared datasources**: Allow document collaborators to execute queries using the datasource owner's connection (with explicit permission).
+- **Shared datasources**: Workspace-level sharing is already implemented — any workspace member can execute queries against a datasource owned by the workspace. Remaining work is finer-grained sharing (e.g. cross-workspace access or per-document grants with explicit permission).
 - **Column type awareness**: Map PostgreSQL data types to appropriate cell formats (numbers, dates, booleans) instead of treating everything as strings.
 - **Sortable/filterable results**: Add column sorting and basic filtering on query results in the grid.
 - **Auto-refresh**: Optional periodic re-execution of queries (with configurable interval).

--- a/docs/design/sheets/file-import.md
+++ b/docs/design/sheets/file-import.md
@@ -25,7 +25,7 @@ between the existing client-side parser path and the new backend DuckDB path.
 
 | Capability | Status | Where |
 |------------|--------|-------|
-| **`.xlsx` import** | ✅ **Shipped** (PR #270) — **multi-sheet**, client-side, materializes to editable `sheet` tabs | `packages/sheets/src/import/xlsx-importer.ts` (`importXlsxWorkbook` / `importXlsxFile`), `packages/frontend/src/app/spreadsheet/xlsx-actions.ts` (`pickAndImportXlsx`) |
+| **`.xlsx` import** | ✅ **Shipped** (PR #270) — **multi-sheet**, client-side, materializes to editable `sheet` tabs | `packages/sheets/src/import/xlsx-importer.ts` (`importXlsxWorkbook` / `importXlsxFile`), `packages/frontend/src/app/spreadsheet/xlsx-actions.ts` (`importXlsx(file: File)`) |
 | CSV import | ⚠️ **Not wired** — `papaparse` is already a dependency of `@wafflebase/sheets` but unused | `packages/sheets/package.json` |
 | Parquet / JSON import | ❌ none | — |
 | Remote / object-storage file Connect | ❌ none | — |
@@ -80,7 +80,7 @@ browser can't reasonably go: large files and remote/object sources.
 
 ### 2. CSV import (client-side, quick win)
 
-- Add a CSV branch beside `pickAndImportXlsx` in
+- Add a CSV branch beside `importXlsx` in
   `packages/frontend/src/app/spreadsheet/xlsx-actions.ts` (or a sibling
   `csv-actions.ts`) using the already-installed `papaparse`.
 - Parse → build a one-sheet `SpreadsheetDocument` → editable sheet. The existing

--- a/docs/design/sheets/formula-coverage.md
+++ b/docs/design/sheets/formula-coverage.md
@@ -8,12 +8,13 @@ target-version: 0.2.0
 ## Summary
 
 Google Sheets provides approximately 500 functions across 16 categories.
-Wafflebase currently implements **447 function entries (434 unique
-functions + 13 aliases)** covering core, power-user, and specialist
-spreadsheet needs. This document maps every Google Sheets function against
-our current support status.
+Wafflebase currently registers **463 function names** in `FunctionMap`
+(all keys are distinct names; legacy aliases share an implementation but
+count as their own registered name) covering core, power-user, and
+specialist spreadsheet needs. This document maps every Google Sheets
+function against our current support status.
 
-**Current coverage**: ~434 / ~500 unique functions (87%)
+**Current coverage**: ~463 / ~500 functions (~93%)
 
 Coverage is effectively complete for daily use. The remaining gaps are:
 - **Legacy aliases** (BETADIST, CHIDIST, etc.) — older names for modern
@@ -55,9 +56,14 @@ Notes:
 
 ### Adding a new function
 
-1. Implement in `packages/sheets/src/formula/functions.ts` — follow the
+1. Implement in the matching per-category file
+   `packages/sheets/src/formula/functions-<category>.ts` (e.g.
+   `packages/sheets/src/formula/functions-math.ts`,
+   `packages/sheets/src/formula/functions-statistical.ts`) — follow the
    existing `(ctx, visit, grid?) → EvalNode` pattern.
-2. Register in `FunctionMap`.
+2. Add the `['NAME', fn]` entry to that file's exported `*Entries` array;
+   `packages/sheets/src/formula/functions.ts` aggregates every category's
+   entries into `FunctionMap`.
 3. Add catalog entry in `packages/sheets/src/formula/function-catalog.ts`
    with name, category, description, and args.
 4. Add tests in `packages/sheets/test/formula/`.
@@ -117,7 +123,6 @@ ASC, FINDB, LEFTB, LENB, MIDB, REPLACEB, RIGHTB, SEARCHB
 | AVERAGE.WEIGHTED | Statistical | Weighted average                     |
 | MARGINOFERROR    | Statistical | Margin of error                      |
 | PEARSON          | Statistical | Same as CORREL (implemented)         |
-| ISBETWEEN        | Operator    | Range check                          |
 | IMCOTH           | Engineering | Complex hyperbolic cotangent         |
 | IMCSCH           | Engineering | Complex hyperbolic cosecant          |
 | IMLOG            | Engineering | Complex logarithm                    |

--- a/docs/design/sheets/mysql-connector.md
+++ b/docs/design/sheets/mysql-connector.md
@@ -81,7 +81,11 @@ model DataSource {
 ### 2. Query execution (native `mysql2`)
 
 - The service dispatches on `engine`: `pg.Client` for postgres, `mysql2` for
-  mysql. Add `mysql2` to `packages/backend` dependencies.
+  mysql. `mysql2` (`^3.23.0`) is already a `packages/backend` dependency — it
+  ships today for the analytics warehouse reader
+  (`packages/backend/src/analytics/analytics-warehouse.service.ts`), not the
+  datasource connector, so no new dependency is needed; the connector wiring
+  itself is still unbuilt.
 - Reuse the SELECT/WITH-only validator and the `LIMIT 10001` wrap + 10,000-row
   truncation flag. (MySQL dialect uses backtick identifiers, but SELECT/WITH
   detection and the forbidden-keyword list are unaffected.)

--- a/docs/design/sheets/pivot-table.md
+++ b/docs/design/sheets/pivot-table.md
@@ -50,7 +50,7 @@ The pivot table system spans three layers:
 │  Field drag-and-drop, refresh button             │
 ├──────────────────────────────────────────────────┤
 │              Sheet Engine (packages/sheets)        │
-│  PivotCalculator  ─── PivotMaterializer          │
+│  calculatePivot()  ─── materialize()             │
 │  Data parsing, grouping, aggregation, cell output │
 ├──────────────────────────────────────────────────┤
 │                Store / Yorkie CRDT               │
@@ -396,13 +396,16 @@ a pivot sheet tab is active.
 
 ```text
 packages/frontend/src/app/spreadsheet/pivot/
-  pivot-editor-panel.tsx       // side panel container
-  pivot-field-list.tsx         // available fields from source headers
-  pivot-field-item.tsx         // individual field chip (draggable)
-  pivot-section.tsx            // Rows / Columns / Values / Filters section
-  pivot-actions.tsx            // Refresh, delete pivot table
+  pivot-editor-panel.tsx       // side panel: field lists, sections
+                               // (Rows/Columns/Values/Filters), field
+                               // chips, and Refresh/delete actions
   use-pivot-table.ts           // state management hook
 ```
+
+The panel ships as a single `packages/frontend/src/app/spreadsheet/pivot/pivot-editor-panel.tsx`
+container rather than separate field-list / field-item / section / actions
+files; the field rows, sections, and action buttons are all rendered inline
+within it.
 
 ### 8. Pivot Sheet Tab Indicator
 

--- a/docs/design/sheets/sheet-image.md
+++ b/docs/design/sheets/sheet-image.md
@@ -28,7 +28,7 @@ image upload API serves both Sheets and Docs.
 - In-cell images / `IMAGE()` formula function (Phase 2)
 - Alt text editing, Z-order control, rotation (Phase 2)
 - Image cropping, filters, borders, shadows
-- S3 storage, thumbnails, CDN (future infrastructure)
+- Thumbnails, CDN (future infrastructure)
 - Edit locking during concurrent resize
 
 ## Proposal Details
@@ -85,49 +85,48 @@ Docs.
 | `GET` | `/api/v1/workspaces/:wid/images/:id` | Retrieve image binary |
 | `DELETE` | `/api/v1/workspaces/:wid/images/:id` | Delete image |
 
-All endpoints use `CombinedAuthGuard` (JWT + API key).
+All endpoints use `CombinedAuthGuard` (JWT + API key). The workspace-scoped
+routes above are served by `ApiV1ImagesController`
+(`src/api/v1/images.controller.ts`), guarded additionally by
+`WorkspaceScopeGuard`. A separate JWT-only `ImageController` in
+`src/image/image.controller.ts` serves the legacy `/images/:id` path.
 
-#### Prisma Model
+#### Storage — no DB metadata
 
-```prisma
-model Image {
-  id          String    @id @default(uuid())
-  workspaceId String
-  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  filename    String
-  mimeType    String
-  size        Int
-  width       Int
-  height      Int
-  storagePath String
-  createdBy   Int
-  createdAt   DateTime  @default(now())
-}
-```
+Images are stored purely as S3-compatible object-store blobs keyed by
+`{workspaceId}/{uuid}.{ext}` — there is **no** database record. The
+extension is derived from the validated MIME type (not the client
+filename), and the UUID form is enforced on retrieval via
+`VALID_IMAGE_ID_PATTERN`. No Prisma model backs this feature.
 
 #### Constraints
 
 - Allowed types: image/png, image/jpeg, image/gif, image/webp
 - Max file size: 10 MB
-- Storage: local filesystem via `StorageService` abstraction (swap to S3 later)
+- Storage: S3-compatible object storage (MinIO in dev) via `ImageService`,
+  configured through `IMAGE_STORAGE_*` env vars (`image.config.ts`). Dev
+  defaults point at `http://localhost:9000`, bucket `wafflebase-images`;
+  production leaves them empty so misconfiguration fails fast.
 
 #### Module Structure
 
 ```
 src/image/
-├── image.module.ts       # Provides ImageService, StorageService
-├── image.service.ts      # Metadata CRUD (Prisma)
-├── image.controller.ts   # REST endpoints
-└── storage.service.ts    # File I/O abstraction (local, future S3)
+├── image.module.ts       # Provides ImageService (imports ConfigModule)
+├── image.service.ts      # S3 upload/get/delete via @aws-sdk/client-s3
+├── image.controller.ts   # JWT-only /images/:id serving
+├── image.config.ts       # IMAGE_STORAGE_* registerAs config
+└── image.constants.ts    # VALID_IMAGE_ID_PATTERN
 ```
 
 #### Upload Flow
 
 1. Client sends `POST` with multipart file
 2. Backend validates mime type and size
-3. `StorageService` writes file to `uploads/images/:wid/:id.ext`
-4. `ImageService` creates `Image` record in database
-5. Response: `{ id, url, width, height }`
+3. `ImageService` writes the blob to S3 under `{workspaceId}/{uuid}.{ext}`
+   via `PutObjectCommand`
+4. Response: `{ id, url }` (the URL points back at the workspace-scoped
+   retrieval route; width/height are not computed server-side)
 
 ### Frontend: Rendering
 
@@ -228,7 +227,7 @@ operations into single undo steps.
 | Floating image | Insert, drag-move, resize, delete | Alt text, Z-order, rotation |
 | In-cell image | — | `IMAGE()` function, cell rendering |
 | Insert paths | Menu, drag-and-drop, paste | URL input dialog |
-| Backend | Upload API (workspace-level) | S3 migration, thumbnails |
+| Backend | Upload API (workspace-level, S3/MinIO storage) | Thumbnails, CDN, DB metadata |
 | Collaboration | Real-time sync (LWW) | Edit locking (if needed) |
 
 ## Risks and Mitigation
@@ -237,5 +236,5 @@ operations into single undo steps.
 |------|--------|------------|
 | Large images slow Yorkie sync | Document bloat, sync latency | Only store URL in CRDT; binary on server; 10 MB limit |
 | Concurrent resize conflicts | Visual flicker | Last-writer-wins (acceptable, matches Charts/Google Sheets) |
-| Local file storage limits | Not production-scalable | StorageService abstraction allows S3 swap without API changes |
+| Object-store availability | Upload/serve failures | S3-compatible storage (MinIO in dev) via `ImageService`; swap endpoint via `IMAGE_STORAGE_*` env vars without API changes |
 | Image load latency | Blank rectangles on first render | Async load with cache + placeholder rendering |

--- a/docs/design/sheets/sheet.md
+++ b/docs/design/sheets/sheet.md
@@ -210,8 +210,8 @@ navigation (see below).
 
 **ReadOnlyStore** (`packages/sheets/src/store/readonly.ts`) is a read-only Store implementation
 for displaying external data (e.g., SQL query results). Data is loaded via
-`loadQueryResults(columns, rows)` which populates row 0 with bold column
-headers and subsequent rows with data. All write operations are no-ops.
+`loadQueryResults(columns, rows)` which populates row 1 with bold column
+headers and rows 2+ with data (1-based to match the sheet coordinate system). All write operations are no-ops.
 
 ### Merged Cell Model
 
@@ -317,8 +317,9 @@ positions from the `CellIndex`.
 
 ### Formula Engine
 
-ANTLR-based parser, visitor-pattern evaluator, ~430 built-in
-functions, and cross-sheet reference resolution via pluggable
+ANTLR-based parser, visitor-pattern evaluator, ~447 built-in
+function entries (434 unique + aliases), and cross-sheet reference
+resolution via pluggable
 `GridResolver` / `FormulaResolver` callbacks. See
 [formula.md](formula.md) for the engine and
 [formula-coverage.md](formula-coverage.md) for the authoritative
@@ -480,7 +481,7 @@ non-default sizes in a `Map<number, number>` and provides:
   deleted.
 - `move(src, count, dst)` — Remaps keys when rows/columns are moved.
 
-Default sizes: **24px** row height, **100px** column width.
+Default sizes: **23px** row height, **100px** column width.
 
 ### Freeze Panes
 

--- a/docs/design/sheets/xlsx-style-import.md
+++ b/docs/design/sheets/xlsx-style-import.md
@@ -12,48 +12,64 @@ target-version: 0.5.0
 
 ## Summary
 
-Today `importXlsxWorkbook` reads only **cell values, formulas, and merges**. It
-never opens `xl/styles.xml` and never inspects the per-cell `s=` (style index)
-attribute, so **every fill, border, font weight/color, alignment, number
-format, column width, hidden row/column, and conditional format is discarded on
-import.** A richly-formatted workbook lands as unstyled black-on-white text.
+`importXlsxWorkbook` now parses `xl/styles.xml` and resolves each cell's `s=`
+(style index) attribute into a `CellStyle` (Phase 1, shipped): **fills, borders,
+font weight/style (bold/italic/underline/strike), text color, horizontal/vertical
+alignment, number format, column widths, row heights, and hidden rows/columns**
+are imported. The per-cell patches are compacted into maximal rectangles before
+they land on the worksheet (Phase 2 compaction, shipped), keeping the Yorkie
+document small.
 
-The good news: the `Worksheet` / `CellStyle` model can already represent the
-majority of this. The fix is largely a **populate-the-existing-model** job in
-the importer, plus a small **model extension** (font family/size, hyperlinks)
-for the handful of things the model genuinely can't express yet.
+Still **not imported** and tracked as future work: conditional formatting, and
+the model extension for per-cell **font family**, **font size**, and **cell
+hyperlinks** — the handful of things the model genuinely can't express yet.
+Originally none of this was imported (the importer read only cell values,
+formulas, and merges); this doc tracked closing that gap.
 
 ## Motivation — the observed gap
 
 Reference file: `Yorkie Task List.xlsx` (8 sheets). Unzipping it shows how much
-formatting a real Google-Sheets-exported workbook carries, and how much is lost:
+formatting a real Google-Sheets-exported workbook carries. The table records the
+gap that motivated this work and the current import status after Phase 1/2:
 
-| Element in the file | Count / example | Currently imported? |
+| Element in the file | Count / example | Imported now? |
 |---|---|---|
-| Fonts | 27 (Arial/Roboto, bold, underline, strike, 10/11pt) | ❌ |
-| Fills (background) | 9 (`D9EAD3` green, `C9DAF8` blue, `FFF2CC` yellow, `F4CCCC` red…) | ❌ |
-| Borders | 13 (thin, per-side) | ❌ |
-| Cell formats (`cellXfs`) | 117 (alignment, wrapText, vertical-center) | ❌ |
-| Number formats | percent (9/10), text (49), custom currency `"$"#,##0.00` (164) | ❌ |
-| Column widths / hidden cols | `<cols>` customWidth ×9 + `hidden="1"` | ❌ |
-| Conditional formatting | 5 `conditionalFormatting` blocks (dxf-based) | ❌ |
-| Hyperlinks | 20 in sheet 1 alone | ❌ (model gap) |
+| Fonts | 27 (Arial/Roboto, bold, underline, strike, 10/11pt) | ⚠️ weight/style/color ✅; **family/size ❌** (Phase 3) |
+| Fills (background) | 9 (`D9EAD3` green, `C9DAF8` blue, `FFF2CC` yellow, `F4CCCC` red…) | ✅ |
+| Borders | 13 (thin, per-side) | ✅ (per-side boolean) |
+| Cell formats (`cellXfs`) | 117 (alignment, wrapText, vertical-center) | ⚠️ alignment ✅; wrapText ❌ |
+| Number formats | percent (9/10), text (49), custom currency `"$"#,##0.00` (164) | ✅ |
+| Column widths / hidden cols | `<cols>` customWidth ×9 + `hidden="1"` | ✅ |
+| Conditional formatting | 5 `conditionalFormatting` blocks (dxf-based) | ❌ (not yet built) |
+| Hyperlinks | 20 in sheet 1 alone | ❌ (model gap, Phase 3) |
 | Comments | 12 legacy + threaded | ❌ |
 | Drawings (images) | `drawing1`–`drawing8` | ❌ |
-| Merges | — | ✅ **the only style-adjacent thing imported** |
+| Merges | — | ✅ |
 
-### Root cause
+### Root cause (addressed for styles in Phase 1)
 
-- `parseCell()` (`xlsx-importer.ts:187`) reads only `<f>` and `<v>`; the `s`
-  attribute is ignored.
-- `importXlsxWorkbook()` never reads `xl/styles.xml`,
-  `xl/worksheets/_rels/*.rels`, `xl/drawings/*`, or `xl/comments*.xml`.
-- The frontend wiring (`xlsx-actions.ts:31`) copies `sheet.worksheet` verbatim —
-  no styling is added downstream either.
+Originally the importer discarded styles because `parseCell()` read only `<f>`
+and `<v>` (the `s` attribute was ignored) and `importXlsxWorkbook()` never read
+`xl/styles.xml`. Phase 1 fixed this:
+
+- `parseWorksheet()` now reads each cell's `s` attribute and resolves it via
+  `styleTable.resolveCellStyle` (`xlsx-importer.ts:351-354`).
+- `importXlsxWorkbook()` parses `xl/styles.xml` once per workbook via
+  `parseStyleTable` (`xlsx-importer.ts:420`, `xlsx-styles.ts`); the resolved
+  styles flow onto `worksheet.rangeStyles`.
+- The frontend wiring (`xlsx-actions.ts`) still copies `sheet.worksheet`
+  verbatim, so the imported styles reach the store with no downstream change.
+
+Still unread: `xl/drawings/*` and `xl/comments*.xml` (images/comments — see
+Non-Goals) and the hyperlink relationships (Phase 3).
 
 ## Goals / Non-Goals
 
 ### Goals
+
+Phase 1 (populate the existing model) and the Phase 2 range-style compaction
+have shipped; conditional-format import and the font-family/size + hyperlink
+model extension remain open.
 
 - **Populate the styles the model already supports** from `xl/styles.xml` + the
   per-cell `s` index: fills, borders, bold/italic/underline/strike, text color,
@@ -83,8 +99,8 @@ formatting a real Google-Sheets-exported workbook carries, and how much is lost:
 
 ### 1. Style resolution pipeline
 
-Add a `xl/styles.xml` parser that produces an indexable style table, then
-resolve each cell's `s` index to a `CellStyle`:
+`xlsx-styles.ts` parses `xl/styles.xml` into an indexable style table
+(`parseStyleTable`), then resolves each cell's `s` index to a `CellStyle`:
 
 ```text
 styles.xml
@@ -124,14 +140,14 @@ the built-in ids (0–49); custom ids (≥164) go through the heuristic.
 ### 3. Cell-level vs range-level storage
 
 XLSX styles are per-cell, but the model favors **range-scoped** patches
-(`rangeStyles: RangeStylePatch[]`) plus `colStyles` / `rowStyles`. Two options:
-
-- **Simple (Phase 1):** write one `rangeStyles` patch per styled cell (a 1×1
-  range). Correct, but produces one patch per cell — heavy for large sheets.
-- **Compacted (Phase 2):** run the existing range-style compaction (the same
-  logic used elsewhere in `range-styles.ts`) to coalesce identical adjacent
-  cell styles into rectangular patches, and lift whole-column/row uniform styles
-  into `colStyles` / `rowStyles`. This is what keeps the Yorkie doc small.
+(`rangeStyles: RangeStylePatch[]`) plus `colStyles` / `rowStyles`. The shipped
+importer collects one 1×1 patch per styled cell, then runs
+`coalesceRangeStylePatchesMaximal` (`range-styles.ts`) to tile identical
+adjacent cell styles into **maximal rectangles** before writing
+`worksheet.rangeStyles`. Excel stamps a style on every cell of a formatted
+table's used range, so this compaction is what keeps the Yorkie doc small.
+Lifting whole-column/row uniform styles into `colStyles` / `rowStyles` is a
+further optimization not yet applied.
 
 Column widths → `colWidths` (convert Excel character-width units to px), row
 heights → `rowHeights` (points→px), `hidden="1"` → `hiddenColumns` /
@@ -173,12 +189,13 @@ Map `<conditionalFormatting sqref><cfRule>` onto `ConditionalFormatRule`:
 
 ### 6. Importer shape changes
 
-`parseWorksheet` gains a `styleTable` parameter (parsed once per workbook) and,
-per cell, resolves `s` → `CellStyle` and records it. `parseCell` additionally
-reads the hyperlink relationship (`<hyperlinks>` + sheet `.rels`). The
-`ImportedXlsxSheet.worksheet` then carries `rangeStyles`/`colWidths`/etc., and
-the frontend wiring needs **no change** — it already copies the whole
-worksheet.
+`parseWorksheet` takes a `styleTable` parameter (parsed once per workbook) and,
+per cell, resolves `s` → `CellStyle` and records it. The
+`ImportedXlsxSheet.worksheet` carries `rangeStyles`/`colWidths`/`rowHeights`/
+`hiddenRows`/`hiddenColumns`, and the frontend wiring needs **no change** — it
+already copies the whole worksheet. Reading the hyperlink relationship
+(`<hyperlinks>` + sheet `.rels`) is deferred to Phase 3 alongside the `Cell.lk`
+model addition.
 
 ## Current Limitations
 
@@ -187,26 +204,30 @@ worksheet.
 2. Theme/indexed colors use a static fallback palette — exotic theme overrides
    may resolve approximately.
 3. Rich-text runs, images, and comments are not imported (later phases).
-4. Conditional formats beyond the mapped operator set are skipped, not
-   approximated.
+4. Conditional formats are not imported yet (planned; once built, formats
+   beyond the mapped operator set will be skipped rather than approximated).
+5. Per-cell font family/size and hyperlinks are not imported (the model lacks
+   `CellStyle.ff`/`fs` and `Cell.lk`; Phase 3).
 
 ## Rollout
 
-- **Phase 1 — core visual styles (biggest win).** Parse `xl/styles.xml`; map
-  fills, borders, bold/italic/underline/strike, text color, alignment, number
-  format; column widths / row heights / hidden. Store as per-cell `rangeStyles`.
-  No model change.
-- **Phase 2 — compaction + conditional formatting.** Coalesce range styles, lift
-  col/row-uniform styles; import mappable conditional formats.
+- **Phase 1 — core visual styles (biggest win). ✅ Shipped.** Parses
+  `xl/styles.xml`; maps fills, borders, bold/italic/underline/strike, text
+  color, alignment, number format; column widths / row heights / hidden. Stored
+  as `rangeStyles`. No model change. (`xlsx-styles.ts`, `xlsx-importer.ts`.)
+- **Phase 2 — compaction + conditional formatting. ◐ Partly shipped.** Range-
+  style compaction via `coalesceRangeStylePatchesMaximal` ships in Phase 1
+  already; whole-column/row lifting and conditional-format import are **not yet
+  built**.
 - **Phase 3 — model extension.** Add `CellStyle.ff`/`fs` (font family/size) and
-  `Cell.lk` (hyperlink); wire renderer + toolbar + Yorkie schema.
-- **Phase 4 — images & comments** (optional, largest surface).
+  `Cell.lk` (hyperlink); wire renderer + toolbar + Yorkie schema. Not started.
+- **Phase 4 — images & comments** (optional, largest surface). Not started.
 
 ## Risks and Mitigation
 
 | Risk | Mitigation |
 |---|---|
-| One `rangeStyles` patch per cell bloats the Yorkie doc | Phase 1 coalesces adjacent per-cell patches (column then row) via `coalesceAdjacentRangeStylePatches`; Phase 2 adds col/row-uniform lifting. A hard patch-count cap with unstyled fallback is deferred to Phase 2. |
+| One `rangeStyles` patch per cell bloats the Yorkie doc | Phase 1 tiles per-cell patches into maximal rectangles via `coalesceRangeStylePatchesMaximal`; col/row-uniform lifting and a hard patch-count cap with unstyled fallback remain future work. |
 | Number-format heuristic misreads custom codes | Built-in id lookup first; heuristic only for custom ids; default to `plain` on ambiguity (never corrupt the value). |
 | `CellStyle` field additions ripple across renderer/schema | Isolated in Phase 3; Phases 1–2 use only existing fields. |
 | Theme-color resolution incomplete | Static indexed+theme fallback palette; document as approximate. |
@@ -215,6 +236,8 @@ worksheet.
 ## References
 
 - Importer: `packages/sheets/src/import/xlsx-importer.ts`
+- Style parser: `packages/sheets/src/import/xlsx-styles.ts` (`parseStyleTable`,
+  `resolveCellStyle`, `mapNumberFormat`, `normalizeColor`)
 - Frontend wiring: `packages/frontend/src/app/spreadsheet/xlsx-actions.ts`
 - Model: `packages/sheets/src/model/workbook/worksheet-document.ts`,
   `packages/sheets/src/model/core/types.ts` (`CellStyle`, `NumberFormat`,

--- a/docs/design/slides/slides-animation.md
+++ b/docs/design/slides/slides-animation.md
@@ -55,8 +55,11 @@ imports without dropping effect data; existing decks render unchanged.
 - **Animation triggers** (start a sequence by clicking a specific shape /
   OOXML `interactiveSeq`). Dropped on import with a report warning.
 - **Auto-advance / timed slideshow** (per-slide `advTm`). Out of scope.
-- **PPTX export.** v1 exports PDF only; preservation fields lay the
-  groundwork for a future lossless PPTX export but no serializer is built.
+- **PPTX export.** *(No longer a non-goal — shipped.)* A full DrawingML
+  PPTX serializer now lives in `packages/slides/src/export/pptx/`, including
+  `packages/slides/src/export/pptx/animation.ts` (`transitionToXml` /
+  `animationsToTimingXml`) which round-trips these transitions and object
+  animations back to `<p:transition>` / `<p:timing>`.
 - **Audio / video timeline nodes.** Dropped with a report warning.
 - **Presence-synced playback.** Playback is local to each viewer, like the
   existing presenter.
@@ -291,7 +294,7 @@ holds transitions + animations together (like Google Slides):
 
 All edits go through the `Store` / `DocStore` interface — new ops
 `setSlideTransition`, `addAnimation`, `updateAnimation`, `removeAnimation`,
-`reorderAnimations` — never ad-hoc persistence (per CLAUDE.md).
+`reorderAnimation` — never ad-hoc persistence (per CLAUDE.md).
 
 The editor draws a small **order badge** on animated elements (shown when
 selected), as Google Slides / PowerPoint do.
@@ -328,8 +331,11 @@ to our effects and need not reproduce OOXML primitive tweens.
 - **Report — `src/import/pptx/report.ts`.** New keys:
   `transition-approximated`, `animation-preset-unmapped`,
   `animation-trigger-dropped`, `animation-media-dropped`.
-- **Export.** Out of scope for v1 (PDF only). Preservation fields make a
-  future lossless PPTX export possible.
+- **Export.** A PPTX exporter shipped after this design:
+  `packages/slides/src/export/pptx/animation.ts` serializes `transition` and
+  `animations` back to `<p:transition>` / `<p:timing>`, and the preservation
+  fields (`pptxPreset` / `motionPath`) keep unmapped presets lossless across
+  the round-trip.
 
 ### Testing strategy
 
@@ -372,7 +378,10 @@ All four phases shipped on the `slides-animation-design` branch. Object
 animations and slide transitions play in both presentation mode and the
 editor **Play** preview; the Motion panel authors transitions + object
 animations (category/effect/start/direction/delay/easing/by-paragraph);
-PPTX `<p:transition>` and `<p:timing>` import best-effort.
+PPTX `<p:transition>` and `<p:timing>` import best-effort. A PPTX exporter
+has since shipped (`packages/slides/src/export/pptx/animation.ts`) that
+serializes transitions + object animations back to `<p:transition>` /
+`<p:timing>`, so motion round-trips rather than being PDF-export-only.
 
 Known limitations / deviations (tracked for follow-up):
 

--- a/docs/design/slides/slides-background.md
+++ b/docs/design/slides/slides-background.md
@@ -5,23 +5,33 @@ target-version: 0.6.0
 
 # Slides Background (Color / Image / Gradient)
 
+> **Status: shipped.** The full **Background** side panel — solid + gradient
+> **Color** (generic `FillPicker`), an **Image** section with opacity,
+> **Reset to theme**, and **Apply to all slides** — is implemented, along with
+> the model widening, renderer swap, Yorkie migration, and PPTX `<p:bg>`
+> gradient round-trip described below. The panel lives at
+> `packages/frontend/src/app/slides/background-side-panel.tsx` (state in
+> `use-slide-background.ts`). This document is retained as the design record;
+> the sections below describe the shipped implementation. Image tile/repeat
+> and background-image crop editing remain the only deferred items.
+
 ## Summary
 
-Today the right-side panel exposes a single **"Background Color"** control —
+Previously the right-side panel exposed a single **"Background Color"** control —
 a solid `ThemeColor` picker. Google Slides instead offers a **Background**
-dialog with a solid **Color**, an **Image**, a **Reset to theme**, and an
-**Add to theme / apply-to-all** action.
+control with a solid **Color**, an **Image**, a **Reset to theme**, and an
+**apply-to-all** action, and Wafflebase now matches that.
 
-The key finding is that this is **mostly a UI/plumbing task**: the slide
-background data model, the Canvas renderer, and Yorkie persistence already
-support an image fill, and every non-UI layer already has a reusable
-`Fill`-aware (`ThemeColor | GradientFill`) helper that the background code
-path deliberately bypasses in favor of a solid-only sibling. Shape gradient
-editing shipped in v0.5.x (the `FillPicker` / `GradientEditor` components and
-the `resolveFillStyle` / `fillXml` / `migrateGradientFill` helpers), so
-gradient backgrounds are now a *reuse-and-wire* job, not greenfield.
+This was **mostly a UI/plumbing task**: the slide background data model, the
+Canvas renderer, and Yorkie persistence already supported an image fill, and
+every non-UI layer already had a reusable `Fill`-aware
+(`ThemeColor | GradientFill`) helper that the old background code path bypassed
+in favor of a solid-only sibling. Shape gradient editing shipped in v0.5.x (the
+`FillPicker` / `GradientEditor` components and the `resolveFillStyle` /
+`fillXml` / `migrateGradientFill` helpers), so gradient backgrounds were a
+*reuse-and-wire* job, not greenfield.
 
-This design renames the control to **Background** and restructures it into
+The shipped control is renamed to **Background** and restructured into
 **Color / Image** sections, wires the existing generic `FillPicker` (solid +
 gradient in one component), reuses the existing image-upload URL pipeline for
 image backgrounds, and adds **Reset to theme** and **Apply to all slides**.
@@ -57,53 +67,50 @@ image backgrounds, and adds **Reset to theme** and **Apply to all slides**.
 
 ## Proposal Details
 
-### 1. Model — widen `fill` from `ThemeColor` to `Fill`
+### 1. Model — `fill` widened from `ThemeColor` to `Fill`
 
 `packages/slides/src/model/presentation.ts`
 
-- `Background.fill?: ThemeColor` → `Background.fill?: Fill` (L28).
-- `resolveBackgroundFill(slide, doc): ThemeColor` → return `Fill` (L207-219).
-  The fallback `{ kind: 'role', role: 'background' }` stays valid (a
-  `ThemeColor` is a subtype of `Fill`).
-- `isInheritableFill(fill: ThemeColor)` (L187-197) reads `.kind === 'role'`;
-  add an early `if (fill.kind === 'gradient') return false;` guard so a
-  gradient is never treated as an inherit sentinel.
-- `resolveBackgroundImage` (L225-234) touches only `.image` — unaffected.
-- `DEFAULT_BACKGROUND` (L174-176) stays a solid literal (backward compatible).
+- `Background.fill?: Fill` (L28).
+- `resolveBackgroundFill(slide, doc): Fill` (L208-220). The fallback
+  `{ kind: 'role', role: 'background' }` stays valid (a `ThemeColor` is a
+  subtype of `Fill`).
+- `isInheritableFill(fill: Fill)` (L187-198) reads `.kind === 'role'` and has
+  an early `if (fill.kind === 'gradient') return false;` guard so a gradient is
+  never treated as an inherit sentinel.
+- `resolveBackgroundImage` touches only `.image` — unaffected.
+- `DEFAULT_BACKGROUND` stays a solid literal (backward compatible).
 
 `packages/slides/src/model/master.ts`
 
-- `MasterBackground.fill: ThemeColor` → `Fill` (L21). `DEFAULT_MASTER`
-  literal (L39) stays solid.
+- `MasterBackground.fill: Fill` (L21). `DEFAULT_MASTER` literal (L39) stays
+  solid.
 
 `representativeColor(fill: Fill): ThemeColor` (`theme.ts:93-98`) already
 collapses a gradient to a solid and is reused wherever background code must
 degrade to a single color.
 
-### 2. Renderer — swap the solid-only paint for the `Fill`-aware helper
+### 2. Renderer — `Fill`-aware paint helper (both sites)
 
 `packages/slides/src/view/canvas/slide-renderer.ts`
 
-- Both background paint sites currently do
-  `ctx.fillStyle = resolveColor(resolveBackgroundFill(slide, doc), theme)`
-  (L184 no-pasteboard path, L204 pasteboard path). `resolveColor`
-  (`theme.ts:100-118`) returns only a solid string.
-- Replace with
+- Both background paint sites use
   `ctx.fillStyle = resolveFillStyle(ctx, resolveBackgroundFill(slide, doc), theme, w, h)`
-  (`render-context.ts:20-48`, the same helper shapes use at
-  `shape-renderer.ts:400/418`). It returns a solid CSS string for a
-  `ThemeColor` or a `CanvasGradient` for a gradient, laid across the `w × h`
-  box, with a degenerate fallback to `resolveColor(representativeColor(fill))`.
-- **Nuance:** the no-pasteboard path (L184) runs under the identity CTM (the
+  (L246-249 no-pasteboard path, L268-271 pasteboard path;
+  `render-context.ts`, the same helper shapes use). It returns a solid CSS
+  string for a `ThemeColor` or a `CanvasGradient` for a gradient, laid across
+  the `w × h` box, with a degenerate fallback to
+  `resolveColor(representativeColor(fill))`.
+- **Nuance:** the no-pasteboard path runs under the identity CTM (the
   `ctx.scale` is applied afterwards) and fills the whole bitmap in **device
-  pixels** — so it must pass `bitmapW × bitmapH` as `w/h`, matching the filled
-  rect. Only the **pasteboard** path (L204), which paints after `ctx.scale`
-  in logical coords, passes the logical slide size (`SLIDE_WIDTH × slideH`). A
-  gradient laid across the logical size in the no-pasteboard branch would only
-  line up when `bitmapW === SLIDE_WIDTH`, silently breaking thumbnails, PDF
-  export, and no-pasteboard presentation/mobile.
-- The image fill (L214-217, `pickBackgroundImage` → `drawImage`) is unchanged;
-  it already paints over the color/gradient fill.
+  pixels** — so it passes `bitmapW × bitmapH` as `w/h`, matching the filled
+  rect. Only the **pasteboard** path, which paints after `ctx.scale` in logical
+  coords, passes the logical slide size (`SLIDE_WIDTH × slideH`). A gradient
+  laid across the logical size in the no-pasteboard branch would only line up
+  when `bitmapW === SLIDE_WIDTH`, silently breaking thumbnails, PDF export, and
+  no-pasteboard presentation/mobile.
+- The image fill (`pickBackgroundImage` → `drawImage`) paints over the
+  color/gradient fill.
 
 `packages/slides/src/export/pdf.ts` — PDF export rasterizes `drawSlide`, so
 image backgrounds already round-trip (L264/L330 reference
@@ -120,11 +127,9 @@ the same swap there.
 
 `packages/slides/src/model/migrate.ts`
 
-- `migrateBackground` (L136-146) currently does
-  `out.fill = wrapColor(bg.fill)` (solid only). Change to the exact ternary
-  already used by `migrateElement` (L148-161):
-  `bg.fill?.kind === 'gradient' ? migrateGradientFill(bg.fill) : wrapColor(bg.fill)`.
-  `migrateGradientFill` (L173-181) is reused verbatim.
+- `migrateBackground` (L136) uses the same ternary as `migrateElement`:
+  `out.fill = bg.fill?.kind === 'gradient' ? migrateGradientFill(bg.fill) : wrapColor(bg.fill)`.
+  `migrateGradientFill` (L180) is reused verbatim.
 
 - **Write path is unchanged.** `updateSlideBackground` (`yorkie-slides-store.ts:874-879`)
   does `s.background = clone(bg)`, and the master/layout writers (L1020-1021,
@@ -196,20 +201,19 @@ from `shape-controls.tsx`) → `updateSlideBackground(slideId, { fill })`;
 - Renderer already stretches it (`drawImage` at `slide-renderer.ts:214-217`).
 - Opacity via the existing `image.opacity` field.
 
-### 6. PPTX import / export — reuse gradient helpers
+### 6. PPTX import / export — gradient helpers reused
 
-`packages/slides/src/import/pptx/slide.ts` — `parseSlideBackground` (L172-199)
-handles `blipFill` (L183) + `solidFill` (L192-195). Add a `gradFill` branch
-calling the existing `parseGradientFill(grad, clrMap)` (`shape.ts:940-968`).
+`packages/slides/src/import/pptx/slide.ts` — `parseSlideBackground` handles
+`blipFill` (image), `gradFill` (L193-197, calling `parseGradientFill(grad,
+clrMap)` from `shape.ts`), and `solidFill` (color).
 
-`packages/slides/src/export/pptx/slide.ts` — `backgroundToXml` (L79-86) calls
-`solidFillXml(fill)` (L85). Swap to the existing `fillXml(fill)`
-(`export/pptx/color.ts:67-70`), which emits `gradFillXml` for gradients else
-solid. Image `<a:blipFill>` export is unchanged.
+`packages/slides/src/export/pptx/slide.ts` — `backgroundToXml` (L83) calls
+`fillXml(fill)` (L70-72, from `export/pptx/color.ts`), which emits `gradFill`
+for gradients else solid. Image `<a:blipFill>` export is unchanged.
 
-## Phasing
+## Phasing (shipped)
 
-**Phase 1 — core (single PR)**
+**Phase 1 — core** ✅
 
 1. Model widening (`Background.fill`/`MasterBackground.fill` → `Fill`,
    `resolveBackgroundFill`, `isInheritableFill` guard).
@@ -219,7 +223,7 @@ solid. Image `<a:blipFill>` export is unchanged.
    (solid+gradient), Image upload section, **Reset to theme**; desktop +
    mobile. `use-slide-background.ts` widened with gradient draft/commit.
 
-**Phase 2 — extension (single PR)**
+**Phase 2 — extension** ✅
 
 5. **Apply to all slides** (master background write).
 6. Image **opacity** slider.

--- a/docs/design/slides/slides-charts.md
+++ b/docs/design/slides/slides-charts.md
@@ -9,17 +9,19 @@ target-version: 0.5.0
 
 ## Summary
 
-Add a native `ChartElement` to `@wafflebase/slides` so charts survive PPTX
-import and render on the Canvas with PowerPoint-like fidelity.
+A native `ChartElement` in `@wafflebase/slides` lets charts survive PPTX
+import and render on the Canvas with PowerPoint-like fidelity. Phase 1
+(import + render + PDF) is shipped.
 
-Today every `<p:graphicFrame>` in a slide is routed unconditionally to the
-table parser (`packages/slides/src/import/pptx/shape.ts:383` →
-`parseTable`), which returns an empty list when the frame is not a
-`<a:tbl>` (`packages/slides/src/import/pptx/table.ts:46`). A chart's
-`graphicFrame` therefore produces **zero elements, silently** — it is not
-placeholdered, not rasterized, and not even counted in `ImportReport`.
-That is why the second slide of an imported deck loses its chart with no
-warning.
+Before this shipped, every `<p:graphicFrame>` in a slide was routed
+unconditionally to the table parser, which returns an empty list when the
+frame is not a `<a:tbl>`. A chart's `graphicFrame` therefore produced
+**zero elements, silently** — it was not placeholdered, not rasterized, and
+not even counted in `ImportReport`, so an imported deck lost its charts
+with no warning. The `graphicFrame` dispatch now branches on the
+`<a:graphicData/@uri>`: a chart URI routes to `parseChartFrame`, a table
+to `parseTable`, and anything else to a reported grey placeholder
+(`packages/slides/src/import/pptx/shape.ts:414`).
 
 PPTX stores the numbers PowerPoint last computed inside the chart part's
 `<c:numCache>` / `<c:strCache>`. Reading those caches lets us reproduce
@@ -77,8 +79,9 @@ rendering, and a future path to editing and PPTX round-trip.
 ### Data model
 
 `ChartElement` joins the `Element` union in
-`packages/slides/src/model/element.ts:560` (and `ElementInit` at `:571`),
-with matching handling in `model/clone.ts` and `model/migrate.ts`.
+`packages/slides/src/model/element.ts:612` (and `ElementInit` at `:624`),
+with matching handling in `packages/slides/src/model/clone.ts` and
+`packages/slides/src/model/migrate.ts`.
 
 ```ts
 type ChartKind = 'column' | 'bar' | 'line' | 'area' | 'pie';
@@ -114,8 +117,8 @@ frozen snapshot that matches PowerPoint's last render.
 
 ### PPTX import
 
-Fix the dispatch in `packages/slides/src/import/pptx/shape.ts:383`. A
-`<p:graphicFrame>` is disambiguated by its
+The dispatch in `packages/slides/src/import/pptx/shape.ts:414`
+disambiguates a `<p:graphicFrame>` by its
 `<a:graphicData graphicData/@uri>`:
 
 - `.../drawingml/2006/chart` → new `parseChartFrame`: resolve the frame's
@@ -135,7 +138,7 @@ placeholder + `unsupportedCharts` rather than throwing and aborting the
 whole import. A `<c:pt idx>` cache index is bounded before array
 allocation so a malformed/adversarial deck cannot hang the import.
 
-New `packages/slides/src/import/pptx/chart.ts` maps `chartN.xml`:
+`packages/slides/src/import/pptx/chart.ts` maps `chartN.xml`:
 
 - Walk `c:chartSpace/c:chart/c:plotArea` and pick the first plot type
   element: `c:barChart` (with `c:barDir val="col"|"bar"` →
@@ -155,15 +158,15 @@ New `packages/slides/src/import/pptx/chart.ts` maps `chartN.xml`:
   3-D variants) → return a placeholder marker so the dispatcher inserts
   the grey box.
 
-`packages/slides/src/import/pptx/report.ts` gains `importedCharts` and
+`packages/slides/src/import/pptx/report.ts` carries `importedCharts` and
 `unsupportedCharts` counters, surfaced in the import summary toast so
 charts never disappear without a trace.
 
 ### Canvas painter
 
-New `packages/slides/src/view/canvas/chart-renderer.ts`, dispatched from
+`packages/slides/src/view/canvas/chart-renderer.ts` is dispatched from
 the `switch (element.type)` in
-`packages/slides/src/view/canvas/element-renderer.ts:260` via
+`packages/slides/src/view/canvas/element-renderer.ts:359` via
 `case 'chart'`. It paints in element-local coordinates
 (`frame.w` × `frame.h`) with the 2D API:
 

--- a/docs/design/slides/slides-collaboration.md
+++ b/docs/design/slides/slides-collaboration.md
@@ -50,7 +50,7 @@ local user navigated slides. `mountNotesPanel` subscribed only to
 fires on a remote change. Fixed by subscribing the notes panel to
 `store.onChange` with a focus guard (don't overwrite the local caret
 mid-keystroke) and disposing the subscription. See
-[20260620-slides-notes-live-sync-todo.md](../../tasks/active/20260620-slides-notes-live-sync-todo.md).
+[20260620-slides-notes-live-sync-todo.md](../../tasks/archive/2026/06/20260620-slides-notes-live-sync-todo.md).
 
 **Remaining:** `withNotes` stores notes as a plain `Block[]` and writes
 the whole array on every keystroke (`s.notes = clone(next)`). Two users
@@ -79,12 +79,17 @@ and should reuse the docs Tree bridge rather than inventing a new one.
 
 `SlidesPresence` (`packages/frontend/src/types/users.ts`) defines
 `activeSlideId`, `selectedElementIds`, `activeFrames` (live drag
-preview), and `draggingGuide`.
+preview), `draggingGuide`, and `selectedTableCells` (a peer's table
+cell-range selection).
 
-**Closed (peer selection rings + name tags).** `getPeers()` is now
-consumed. The editor exposes `setPeers(PeerView[])` and paints, in the
-DOM overlay, a coloured ring + name tag for every peer selecting an
-element on the local user's current slide. The plumbing:
+**Closed (peer selection rings + name tags + cell ranges).**
+`getPeers()` is now consumed. The editor exposes `setPeers(PeerView[])`
+and paints, in the DOM overlay, a coloured ring + name tag for every
+peer selecting an element on the local user's current slide. Peer
+table cell-range selections (`selectedTableCells`) are broadcast from
+`packages/frontend/src/app/slides/slides-view.tsx` and rendered as
+per-cell highlight rects (`PeerCellRect` in
+`packages/slides/src/view/editor/peers.ts`). The plumbing:
 
 - `YorkieSlidesStore.onPresenceChange` subscribes the Yorkie `'others'`
   channel (distinct from document `remote-change`).
@@ -106,7 +111,7 @@ is broadcast-only.
   previews funnel through `paintGhostPreview` (a clean emit point), but
   there is no single "gesture ended" hook to clear them symmetrically;
   this needs an explicit gesture-lifecycle signal. Tracked in
-  [20260621-slides-live-presence-todo.md](../../tasks/active/20260621-slides-live-presence-todo.md)
+  [20260621-slides-live-presence-todo.md](../../tasks/archive/2026/06/20260621-slides-live-presence-todo.md)
   P2/P3.
 - `slides.md` also references a `textCursor` presence field and peer
   text carets (à la `docs/docs-presence.md`); neither exists. Docs has

--- a/docs/design/slides/slides-connectors.md
+++ b/docs/design/slides/slides-connectors.md
@@ -97,9 +97,15 @@ export type ConnectorElement = ElementBase & {
 };
 ```
 
-`ElementBase` (`id`, `z`, `opacity`, …) is shared. There is no `frame`
-field — the bbox is derived from the endpoints at render time, used
-only for selection hit-testing and `Cmd+A` selection.
+`ElementBase` (`id`, `frame`, …) is shared, so a connector carries a
+`frame` — but it is a **derived cache**, never authored geometry. The
+store recomputes it from the endpoints via `computeConnectorFrame`
+(`packages/slides/src/view/canvas/connector-frame.ts`) inside
+`addElement` and every connector mutation, storing the tight path bbox
+(polyline or bezier extrema) expanded by the stroke half-width. It is
+used only for selection hit-testing and `Cmd+A` selection, and is never
+written directly — `updateElementFrame` rejects connectors so the cached
+frame cannot drift out of sync with the endpoints.
 
 `ShapeKind` drops `'line'` and `'arrow'`. The path-builder dispatcher's
 special-cased `drawLine` / `drawArrow` branches are removed from

--- a/docs/design/slides/slides-connectors.md
+++ b/docs/design/slides/slides-connectors.md
@@ -292,16 +292,15 @@ view/editor/
     insert-connector.ts            Connector-tool drag flow with snap.
     connector-endpoint-drag.ts     Selected-endpoint drag with snap +
                                    free/attached transitions.
-    elbow-bend-drag.ts             Elbow yellow-diamond handle drag.
-  overlays/
-    connection-points-overlay.ts   DOM overlay of site dots during
-                                   insert / endpoint-drag modes.
+    bend-drag.ts                   Elbow / curved yellow-diamond handle drag.
 ```
 
-**Connection points overlay** runs as a DOM layer on top of the canvas
-so the dot size stays pixel-constant under zoom and the dots receive
-pointer events naturally for hover styling. Activates only when the
-user is inside `insert-connector` or `connector-endpoint-drag` mode.
+**Connection points overlay** is painted directly onto the canvas
+(not a separate DOM layer) during insert / endpoint-drag modes; the
+site-dot drawing and hover/snap logic live in `editor.ts`, `overlay.ts`,
+and `insert-connector.ts`. Dot sizing is DPR-corrected so it stays
+pixel-constant under zoom. It activates only when the user is inside
+`insert-connector` or `connector-endpoint-drag` mode.
 
 **Snap behavior** (pixel distances, screen-space, DPR-corrected):
 
@@ -377,14 +376,21 @@ endpoints; `commitTranslate` is the only sanctioned write path for
 
 ### 6. Store Layer
 
-`SlidesStore` interface in `packages/slides/src/store/store.ts` gains:
+Connectors are inserted through the generic
+`addElement(slideId, init)` path — `buildConnectorInit` in
+`packages/slides/src/view/editor/interactions/insert-connector.ts`
+pre-fills the `ConnectorElement` init, so there is no dedicated
+`addConnector`. `SlidesStore` in
+`packages/slides/src/store/store.ts` gains the connector-mutation
+methods:
 
 ```ts
-addConnector(connector: ConnectorElement): void;
 updateConnectorEndpoint(id: string, side: 'start' | 'end', endpoint: Endpoint): void;
 updateConnectorRouting(id: string, routing: ConnectorRouting): void;
 updateConnectorArrowheads(id: string, heads: { start?: ArrowheadStyle | null; end?: ArrowheadStyle | null }): void;
+updateConnectorStroke(id: string, stroke: ShapeStroke): void;
 updateConnectorElbowBend(id: string, bend: number | undefined): void;
+updateConnectorCurveBend(id: string, bend: number | undefined): void;
 ```
 
 Existing `removeElement(id)` gains a pre-removal sweep: iterate every
@@ -410,31 +416,32 @@ packages/slides/src/
 │   ├── connector-renderer.ts              NEW
 │   ├── arrowhead-renderer.ts              NEW
 │   ├── routing.ts                         NEW
-│   ├── routing.test.ts                    NEW
 │   ├── connection-sites/
 │   │   ├── index.ts                       NEW
 │   │   ├── defaults.ts                    NEW
-│   │   ├── overrides.ts                   NEW
-│   │   └── connection-sites.test.ts       NEW
+│   │   └── overrides.ts                   NEW
 │   ├── element-renderer.ts                MODIFY — dispatch connector
 │   ├── shape-renderer.ts                  MODIFY — drop line/arrow branches
 │   └── shape-special.ts                   MODIFY — drop drawLine/drawArrow
 ├── view/editor/
-│   ├── interactions/
-│   │   ├── insert-connector.ts            NEW
-│   │   ├── connector-endpoint-drag.ts     NEW
-│   │   ├── elbow-bend-drag.ts             NEW
-│   │   └── insert.ts                      MODIFY — connector tool entries
-│   └── overlays/
-│       └── connection-points-overlay.ts   NEW
+│   └── interactions/
+│       ├── insert-connector.ts            NEW (incl. buildConnectorInit)
+│       ├── connector-endpoint-drag.ts     NEW
+│       ├── bend-drag.ts                   NEW — elbow / curved handle drag
+│       └── insert.ts                      MODIFY — connector tool entries
 └── store/
     ├── store.ts                           MODIFY — add connector methods
-    ├── memory.ts                          MODIFY — implement connector methods
-    │                                              + removeElement sweep
-    └── memory.test.ts                     MODIFY — connector store tests
+    └── memory.ts                          MODIFY — implement connector methods
+                                                   + removeElement sweep
 ```
 
 ### 8. Testing Strategy
+
+Unit tests are not colocated with source; they live in the mirror tree
+under `packages/slides/test/` (e.g.
+`packages/slides/test/view/canvas/routing.test.ts`,
+`packages/slides/test/view/canvas/connection-sites/connection-sites.test.ts`,
+`packages/slides/test/store/memory.test.ts`).
 
 **Unit tests (Vitest, in `packages/slides`):**
 
@@ -477,8 +484,9 @@ Three PRs sized for independent review and verification:
 - Default 4-cardinal connection sites only (no per-kind overrides yet).
 - `routing.ts` with `routeStraight` only.
 - `connector-renderer.ts`, `arrowhead-renderer.ts`.
-- Store methods (`addConnector`, `updateConnectorEndpoint`,
-  `updateConnectorArrowheads`, `removeElement` sweep).
+- Store methods (`updateConnectorEndpoint`,
+  `updateConnectorArrowheads`, `removeElement` sweep); insertion reuses
+  the generic `addElement` path via `buildConnectorInit`.
 - `insert-connector.ts` and `connector-endpoint-drag.ts` for Line +
   Arrow tools.
 - `connection-points-overlay.ts`.
@@ -495,11 +503,14 @@ Three PRs sized for independent review and verification:
   for L-shape + bezier preview).
 - Right-click menu: routing change. ✅ Shipped (Straight / Elbow /
   Curved radio when selection is a single connector).
-- Per-`ShapeKind` overrides for the high-impact shapes. ✅ Mostly
-  shipped: `diamond` / `parallelogram` / `trapezoid` / `pentagon` /
-  `hexagon` / `octagon` / `star4..star10`. `triangle` / `rtTriangle`
-  excluded — 3-site OOXML cxnLst doesn't match the importer's 4-site
-  rect remap; needs a per-shape ooxml→waffle index table first.
+- Per-`ShapeKind` overrides for the high-impact shapes. ✅ Shipped for
+  `diamond` / `parallelogram` / `trapezoid` / `ellipse` (the current
+  `CONNECTION_SITES` registry in
+  `packages/slides/src/view/canvas/connection-sites/overrides.ts`).
+  Polygon (`pentagon` / `hexagon` / `octagon`) and `star` overrides are
+  not shipped yet. `triangle` / `rtTriangle` remain excluded — the
+  3-site OOXML cxnLst doesn't match the importer's 4-site rect remap;
+  they need a per-shape ooxml→waffle index table first.
 
 > Status (2026-06-12): elbow yellow-diamond bend handle shipped for
 > the Z (parallel-opposite-facing) topology. L / U / C topologies

--- a/docs/design/slides/slides-fonts.md
+++ b/docs/design/slides/slides-fonts.md
@@ -9,18 +9,21 @@ target-version: 0.4.6
 
 ## Summary
 
-Today the font picker is a closed, hardcoded list of ~19 families
-(`packages/frontend/src/components/text-formatting/font-catalog.ts`)
-loaded as a **single Google Fonts CSS `<link>` at bootstrap**. This is
-fine for a small curated set but does not scale to the rich font
-experience users expect from Google Slides / Canva (hundreds to
-thousands of families, searchable, previewed in-place).
+The font picker used to be a closed, hardcoded list of ~19 families
+loaded as a **single Google Fonts CSS `<link>` at bootstrap** — fine for
+a small curated set but not the rich font experience users expect from
+Google Slides / Canva (hundreds to thousands of families, searchable,
+previewed in-place).
 
-This document proposes growing the catalog into a **data-driven Google
-Fonts catalog** with **per-font lazy loading**, a **"More fonts…"
-search dialog**, **per-document/per-user accumulated font lists**, and a
-**license-aware export embedding path** so the on-screen richness
-survives PDF/PPTX export.
+That rich-fonts system is now **shipped** (P0–P2). The catalog is a
+**build-time-generated data file** (`font-catalog.data.ts`, ~105 curated
+entries) with **per-font lazy loading** (`ensureFontLink`), a
+**"More fonts…" search dialog** over the full ~1,900-family Google Fonts
+library (`font-catalog.full.ts`, dynamic-imported), and a per-browser
+**recent-fonts** list. On the export side, **license-aware embedding is
+partly shipped** (P3-a: Docs PDF embeds curated Google Fonts); a
+per-presentation used-fonts set, license-notices page, and PPTX
+embedding remain (see the Phased rollout table).
 
 The shared text-formatting components (`font-catalog.ts`,
 `font-family-picker.tsx`, `fonts.ts`) are used by **both Docs and
@@ -62,17 +65,20 @@ editors; Slides is the driving surface.
 
 | Concern | Current implementation | File |
 | --- | --- | --- |
-| Catalog | Hardcoded `FONT_CATALOG` (19 entries) | `font-catalog.ts:35` |
-| Bootstrap load | One Google Fonts CSS `<link>` built from the whole catalog | `buildGoogleFontsHref()` `font-catalog.ts:75` |
-| Runtime load | `FontRegistry.ensureFont()` → `document.fonts.load()` → re-layout | `fonts.ts:293` |
-| Fallback chain | `resolveFontFamily()` maps family → CSS stack, injects Noto KR for Hangul | `fonts.ts:219` |
-| Prefetch | Picker item `onPointerEnter` → `onPrefetch` | `font-family-picker.tsx:120` |
-| PDF embed | Noto KR Subset OTF from jsdelivr, fontkit subsets at embed time | `pdf-fonts.ts:106` |
+| Catalog | Generated `FONT_CATALOG = FONT_CATALOG_DATA` (~105 entries, with `license`/`eager`) | `font-catalog.ts:66`, `font-catalog.data.ts` |
+| Full library | ~1,900-family `FONT_CATALOG_FULL`, dynamic-imported for the dialog | `font-catalog.full.ts`, `font-catalog-full-loader.ts` |
+| Bootstrap load | One Google Fonts CSS `<link>` built from the **`eager`** entries only | `buildGoogleFontsHref()` `font-catalog.ts:102` |
+| Lazy load | `ensureFontLink(family, weights)` injects a per-family CSS `<link>` on demand | `font-catalog.ts:142` |
+| Runtime load | `FontRegistry.ensureFont()` → `document.fonts.load()` → re-layout | `fonts.ts` |
+| Fallback chain | `resolveFontFamily()` maps family → CSS stack, injects Noto KR for Hangul | `fonts.ts` |
+| Prefetch | Picker item `onPointerEnter` → `onPrefetch` → `ensureFontLink` | `font-family-picker.tsx` |
+| PDF embed | Curated Google Fonts subset-embedded (P3-a); Noto KR + arbitrary curated families | `pdf-fonts.ts`, `pdf-painter.ts` |
 
-The two structural limits: (1) **the catalog is a closed hardcoded
-list** and (2) **the bootstrap loads the whole catalog in one CSS
-request** — the file's own comment notes v1 deliberately stays "under
-one network request." Both must change for rich fonts.
+The two original structural limits — a **closed hardcoded catalog** and a
+**bootstrap that loaded the whole catalog in one CSS request** — have both
+been removed: the catalog is generated data, and the bootstrap link now
+covers only the small `eager` set while the long tail lazy-loads via
+`ensureFontLink`.
 
 ### License model (why "everything in Google Fonts is usable")
 
@@ -115,73 +121,92 @@ package aggregates this into JSON and is a convenient build input.
 
 ### Catalog: hardcoded list → generated data
 
-Replace the hand-maintained `FONT_CATALOG` array with a
-**build-time-generated catalog** committed to the repo as JSON.
+The hand-maintained `FONT_CATALOG` array was **replaced by
+build-time-generated data** committed to the repo as a TS module. The
+shipped entry shape (`FontEntry` in `font-catalog.ts`) is:
 
 ```ts
-interface FontCatalogEntry {
+export interface FontEntry {
+  label: string;              // display label (e.g. '나눔고딕')
   family: string;             // canonical Google Fonts family
-  label?: string;             // localized display label (e.g. '나눔고딕')
-  category: FontGroup;        // Korean | Sans-serif | Serif | Monospace | Display | Handwriting
-  scripts: string[];          // Google "subsets": 'latin', 'korean', ...
-  weights: string;            // wght axis values, e.g. '400;700'
-  license: 'OFL' | 'APACHE2' | 'UFL';
-  popularity: number;         // for default sort
-  curated: boolean;           // true → shown in the dropdown menu
+  group: FontGroup;           // Korean | Sans-serif | Serif | Monospace | Display | Handwriting
+  webFont: boolean;           // Google Fonts face (needs a CSS link) vs local/system
+  weights?: string;           // wght axis values, e.g. '400;700' (default '400;700')
+  license?: 'OFL' | 'APACHE2' | 'UFL';
+  scripts?: string[];         // Google "subsets": 'latin', 'korean', ...
+  eager?: boolean;            // true → loaded in the bootstrap CSS link
 }
 ```
 
-A generator script (`scripts/build-font-catalog.ts`, run on demand —
+Generator scripts under `packages/frontend/scripts/` (run on demand —
 **not** at every build, to keep the catalog deterministic and
-reviewable) reads `google/fonts` metadata + `fontsource/google-font-metadata`
-and emits:
+reviewable) read `google/fonts` metadata and emit committed TS modules:
 
-- `font-catalog.curated.json` — ~100 families with `curated: true`
-  (Korean body + display, popular Latin sans/serif/mono).
-- `font-catalog.full.json` — full library, consumed only by the "More
-  fonts…" dialog (lazy-imported so the editor bundle isn't bloated).
+- `build-font-catalog.mjs` → `font-catalog.data.ts` (`FONT_CATALOG_DATA`,
+  ~105 curated entries: Korean body + display, popular Latin sans/serif/mono,
+  plus non-web system faces).
+- `build-font-catalog-full.mjs` → `font-catalog.full.ts`
+  (`FONT_CATALOG_FULL`, the full ~1,900-family library), consumed only by
+  the "More fonts…" dialog via a dynamic import so the editor bundle isn't
+  bloated.
+- `build-font-files.mjs` → `font-files.data.ts` (per-family gstatic TTF
+  URLs) for the PDF export-embed path.
 
 `font-catalog.ts` keeps its existing **named exports and types** (the
-`value: string` contract, `FONT_SIZE_PRESETS`, etc.) so call sites don't
-change; only the data source becomes the generated JSON.
+`value: string` picker contract, `FONT_SIZE_PRESETS`, etc.) so call sites
+don't change; only the data source is now the generated module
+(`FONT_CATALOG = FONT_CATALOG_DATA`).
 
 ### Loading model: bootstrap-all → per-font lazy
 
-Generalize the bootstrap injector into a **per-family** loader.
+The bootstrap injector was generalized into a **per-family** loader
+(shipped):
 
-- Keep injecting **one CSS `<link>` for the curated-menu web fonts** at
-  view mount (today's `useGoogleFontsLink`), so the dropdown previews
-  are instant.
-- Add `ensureFontLink(family, weights)` that injects a **per-family CSS
-  `<link>`** the first time a non-curated family is needed (selection,
-  picker hover, or in-view preview in the dialog). Idempotent + id-keyed
-  per family, mirroring the existing `ensureGoogleFontsLink` guard.
+- `useGoogleFontsLink` / `ensureGoogleFontsLink` still inject **one CSS
+  `<link>` at view mount**, but `buildGoogleFontsHref()` now builds it
+  from the **`eager`** web fonts only (the small set existing documents
+  render with), not the whole catalog — so the dropdown previews are
+  instant while the bootstrap request stays small.
+- `ensureFontLink(family, weights)` injects a **per-family CSS `<link>`**
+  the first time a non-eager family is needed (selection, picker hover,
+  or in-view preview in the dialog). It no-ops for system faces
+  (`webFont: false`), for `eager` fonts already in the bootstrap link,
+  and when a link for that family already exists; the DOM
+  (`data-wafflebase-font` attribute), not module state, is the idempotency
+  source so it survives HMR. It is wired into both editors' pickers and
+  toolbars (Docs and Slides).
 - `FontRegistry.ensureFont()` is unchanged — it already does
   `document.fonts.load()` + re-layout notification; the only addition is
   that the CSS `<link>` for that family must be present first, which
   `ensureFontLink` guarantees.
-- FOUT is handled as today via `display=swap`; the re-layout listener
-  repaints the Canvas when the real face resolves.
+- FOUT is handled via `display=swap`; the re-layout listener repaints the
+  Canvas when the real face resolves.
 
 ### UX: "More fonts…" dialog + recent / in-use
 
 `font-family-picker.tsx` keeps its grouped dropdown of **curated +
-in-use + recent** families, and gains a **"More fonts…"** item at the
-bottom that opens a dialog:
+recent** families, and has a **"More fonts…"** item at the bottom that
+opens `MoreFontsDialog` (`more-fonts-dialog.tsx`, shipped):
 
-- **Search** box (debounced) over the full catalog.
-- **Category** and **script** (Korean / Latin / …) filters.
-- **Virtualized list** (windowed) so 1,800 rows stay smooth; each
-  visible row previews in its own family via an `IntersectionObserver`
+- **Search** box over the full catalog.
+- **Category** and **script** (Korean / Latin / …) filters
+  (`more-fonts-filter.ts`: `FontCategoryFilter` / `FontScriptFilter`).
+- Each visible row previews in its own family via an `IntersectionObserver`
   that calls `ensureFontLink` only for on-screen rows.
-- Selecting a font adds it to the document's **used-fonts** set and the
-  user's **recent** list, so it surfaces in the dropdown next time.
+- The dialog lazy-loads the full library through `loadFullFontCatalog()`
+  (a memoized dynamic import of `font-catalog.full.ts`).
+- Selecting a font adds it to the user's **recent** list, so it surfaces
+  in the dropdown next time.
 
-**Where the used-fonts set lives:** persist per presentation in the
-Yorkie doc (a `usedFonts: string[]` on the presentation/meta object) so
-collaborators and the export path see the same set. "Recent" is a local
-(user-level) list in `localStorage`. The slides surface wires this
-through `SlidesView`; Docs reuses the same shared dialog.
+**Where the recent list lives:** "Recent" is a per-browser list in
+`localStorage` (`font-recents.ts`: `getRecentFonts` / `addRecentFont`,
+capped at `RECENT_FONTS_MAX`). The same shared dialog is reused by both
+Docs and Slides.
+
+> **Not yet built:** the originally-planned **per-presentation used-fonts
+> set** (a `usedFonts: string[]` persisted on the Yorkie presentation/meta
+> object, shared by collaborators and the export path) is not implemented —
+> no such field exists. Only the local `localStorage` recents shipped.
 
 ### Export: license-aware embedding
 
@@ -217,13 +242,13 @@ this embed path must be designed together.
 
 ### Phased rollout
 
-| Phase | Scope | Primary files |
-| --- | --- | --- |
-| **P0** | Generated curated catalog (~100) with `license` field; per-family lazy `ensureFontLink`; bootstrap loads curated menu only | `scripts/build-font-catalog.ts`, `font-catalog.ts`, `fonts.ts` |
-| **P1** | "More fonts…" dialog: search + category/script filters + virtualized in-view previews; recent + per-doc used-fonts persistence | new dialog component, `font-family-picker.tsx`, `SlidesView`, Yorkie meta |
-| **P2** | Full ~1,800 library in the dialog (lazy-imported `font-catalog.full.json`) | dialog data source |
-| **P3** | Export embed for arbitrary Google Fonts + open-source notices page; PPTX font embedding | `pdf-fonts.ts`, export paths, notices page |
-| **P4 (deferred)** | User-uploaded brand fonts + license attestation | out of scope here |
+| Phase | Status | Scope | Primary files |
+| --- | --- | --- | --- |
+| **P0** | ✅ Shipped | Generated curated catalog (~105) with `license`/`eager` fields; per-family lazy `ensureFontLink`; bootstrap loads `eager` set only | `scripts/build-font-catalog.mjs`, `font-catalog.data.ts`, `font-catalog.ts`, `fonts.ts` |
+| **P1** | ✅ Shipped (used-fonts set deferred) | "More fonts…" dialog: search + category/script filters + in-view `IntersectionObserver` previews; `localStorage` recents. Per-doc used-fonts Yorkie persistence **not built**. | `more-fonts-dialog.tsx`, `more-fonts-filter.ts`, `font-recents.ts`, `font-family-picker.tsx` |
+| **P2** | ✅ Shipped | Full ~1,900 library in the dialog (dynamic-imported `font-catalog.full.ts` via `loadFullFontCatalog`) | `font-catalog.full.ts`, `font-catalog-full-loader.ts` |
+| **P3** | ◐ Partial (P3-a shipped) | Export embed for curated Google Fonts (Docs PDF, P3-a). Open-source notices page (P3-b) + PPTX embedding (P3-c) remain. | `pdf-fonts.ts`, `pdf-painter.ts`, `font-files.data.ts`, `scripts/build-font-files.mjs` |
+| **P4 (deferred)** | Deferred | User-uploaded brand fonts + license attestation | out of scope here |
 
 ### Risks and Mitigation
 

--- a/docs/design/slides/slides-fonts.md
+++ b/docs/design/slides/slides-fonts.md
@@ -39,9 +39,11 @@ editors; Slides is the driving surface.
   in-view preview).
 - A **"More fonts…" dialog** with search, category, and script
   (Korean / Latin) filters, each row previewed in its own typeface.
-- **License correctness**: every catalog entry carries its license
-  (`OFL` / `APACHE2` / `UFL`), the data is sourced at build time from
-  the authoritative `google/fonts` repo, and embedded fonts ship their
+- **License correctness**: every **web-font** catalog entry carries its
+  license (`OFL` / `APACHE2` / `UFL`) — the non-web system faces
+  (`webFont: false`, e.g. Arial/Times New Roman) omit it since we never
+  embed their bytes. The data is sourced at build time from the
+  authoritative `google/fonts` repo, and embedded fonts ship their
   license texts.
 - **Export parity**: PDF (and later PPTX) export embeds any used Google
   Font, not just Noto KR.
@@ -132,11 +134,16 @@ export interface FontEntry {
   group: FontGroup;           // Korean | Sans-serif | Serif | Monospace | Display | Handwriting
   webFont: boolean;           // Google Fonts face (needs a CSS link) vs local/system
   weights?: string;           // wght axis values, e.g. '400;700' (default '400;700')
-  license?: 'OFL' | 'APACHE2' | 'UFL';
+  license?: 'OFL' | 'APACHE2' | 'UFL';   // web-font entries only; omitted for system faces
   scripts?: string[];         // Google "subsets": 'latin', 'korean', ...
   eager?: boolean;            // true → loaded in the bootstrap CSS link
 }
 ```
+
+`license` is optional: the ~10 non-web system faces (`webFont: false`)
+carry no license value because we never ship their bytes; only the
+embeddable web-font entries are guaranteed to carry one of the three
+licenses.
 
 Generator scripts under `packages/frontend/scripts/` (run on demand —
 **not** at every build, to keep the catalog deterministic and
@@ -222,23 +229,20 @@ fall back to Helvetica/Times. Slides PDF export is raster, so it embeds
 nothing. License notices (P3-b) and PPTX embedding (P3-c) remain. See
 [`docs/design/docs/docs-pdf-export.md`](../docs/docs-pdf-export.md).
 
-The original generalization intent (now realized for the curated set):
-`pdf-fonts.ts` historically hardcoded four Noto KR URLs in `DEFAULT_URLS`.
-Generalize to resolve **any used Google Font** to its TTF:
+How it shipped: `pdf-fonts.ts` historically hardcoded four Noto KR URLs
+in `DEFAULT_URLS`. P3-a generalized that to resolve **any curated Google
+Font** to its TTF via the generated
+`packages/frontend/src/components/text-formatting/font-files.data.ts` —
+per-family version-pinned `fonts.gstatic.com` static URLs (regular + bold),
+not GitHub/jsdelivr raw paths. The existing IndexedDB cache + fontkit
+subsetting is reused, so each used family is fetched once and
+subset-embedded.
 
-- Add a resolver that, given a family + weight, returns the
-  `github.com/google/fonts/raw/main/<license>/<family>/...ttf` URL (or
-  a jsdelivr mirror), pinned to a commit for reproducibility — same
-  pattern as the current tag-pinned Noto URLs.
-- Reuse the existing IndexedDB cache + fontkit subsetting so each used
-  family is fetched once and subset-embedded.
-- Collect the license of every embedded family and surface it on the
-  in-app **open-source notices** page (and, for PPTX later, embed per
-  OOXML font-embedding rules).
-
-This phase is what makes the richness *real* — without it, a deck using
-a fancy font would export with a fallback face. P0–P2 (on-screen) and
-this embed path must be designed together.
+Remaining work: collect the license of every embedded family and surface
+it on the in-app **open-source notices** page (P3-b), and — for PPTX
+(P3-c) — embed per OOXML font-embedding rules. Without the embed path a
+deck using a fancy font would export with a fallback face, so P0–P2
+(on-screen) and this embed path were designed together.
 
 ### Phased rollout
 

--- a/docs/design/slides/slides-format-effects.md
+++ b/docs/design/slides/slides-format-effects.md
@@ -18,8 +18,10 @@ Fill colour and Border stay in the contextual toolbar
 do we. The panel grows the effect sections GS puts there: Drop shadow,
 Reflection, Recolor, Adjustments (brightness/contrast), Alt text.
 
-PPTX is **import-only** in this package (no exporter exists), so
-"round-trip" means parsing the OOXML effect elements on import.
+Effects round-trip through PPTX: the importer parses the OOXML effect
+elements, and the exporter (`packages/slides/src/export/pptx/effects.ts`,
+`effectsToXml`) serializes drop shadow / reflection back to
+`<a:outerShdw>` / `<a:reflection>`.
 
 ## Per-type menu
 
@@ -67,7 +69,7 @@ is added to the `data` of shape / text / table (image already had
 
 All fields optional ⇒ no migration; absent ⇒ no effect.
 
-Image-only (PR 2): `image.recolor?: 'none' | 'grayscale' | 'sepia'`
+Image-only (shipped): `image.recolor?: 'none' | 'grayscale' | 'sepia'`
 (preset presets via `ctx.filter`; theme-tinted duotone deferred),
 `image.brightness?: number` (-1..1), `image.contrast?: number` (-1..1).
 
@@ -82,15 +84,16 @@ Image-only (PR 2): `image.recolor?: 'none' | 'grayscale' | 'sepia'`
 - **Reflection**: after the element paints, draw a vertically-mirrored
   copy below it with a top-down alpha gradient mask (offscreen
   canvas), `globalAlpha = reflection.opacity`.
-- **Recolor / brightness / contrast** (PR 2): `ctx.filter` +
+- **Recolor / brightness / contrast**: `ctx.filter` +
   duotone composite in `image-renderer.ts`.
 
 ## Panel
 
 `pick-sections.ts` returns the section list per `selectionType`. New
 sections: `drop-shadow-section.tsx`, `reflection-section.tsx`,
-`recolor-section.tsx` (PR 2); `alt-text-section.tsx` extended to all
-object types; image Adjustments extended with brightness/contrast.
+`recolor-section.tsx`; `alt-text-section.tsx` extended to all
+object types; `image-adjustments-section.tsx` extended with
+brightness/contrast.
 
 Commit pattern mirrors existing sections: read current
 `el.data.effects`, compute merged object, write via
@@ -99,11 +102,11 @@ Commit pattern mirrors existing sections: read current
 
 ## Rollout
 
-Two PRs on branch `slides-format-effects`:
+Shipped over two PRs on branch `slides-format-effects`:
 
 1. Panel IA + object effects (shadow, reflection, alt text) across
-   shape/image/text/table/group + PPTX import + tests.
+   shape/image/text/table/group + PPTX import/export + tests.
 2. Image-only recolor + brightness/contrast + import + tests.
 
-Each commit keeps `pnpm verify:fast` green; code review over the
+Each commit kept `pnpm verify:fast` green; code review over the
 branch diff; manual smoke in `pnpm dev`.

--- a/docs/design/slides/slides-format-options-panel.md
+++ b/docs/design/slides/slides-format-options-panel.md
@@ -80,12 +80,15 @@ The right-side slot in `slides-detail.tsx` currently mounts
 to a single union:
 
 ```ts
-type RightPanel = 'theme' | 'format' | null;
+// This work adds 'format' alongside the existing 'theme'; later specs
+// extend the same union with 'motion' and 'background' (see
+// `docs/design/slides/slides-background.md`).
+type RightPanel = 'theme' | 'format' | 'motion' | 'background' | null;
 const [rightPanel, setRightPanel] = useState<RightPanel>(null);
 ```
 
-Toggling either panel sets the union to that panel's id; opening one
-closes the other. Closing sets it back to `null`. Existing
+Toggling any panel sets the union to that panel's id; opening one
+closes the others. Closing sets it back to `null`. Existing
 `themePanelOpen` reads in `DesktopSlidesLayout` are replaced by
 `rightPanel === 'theme'`; `MobileSlidesLayout` does not mount the
 format panel at all.

--- a/docs/design/slides/slides-format-options-panel.md
+++ b/docs/design/slides/slides-format-options-panel.md
@@ -16,13 +16,15 @@ toggles that do not fit the contextual top toolbar — Size & Position
 and Alt text. The panel coexists with the existing `ThemePanel` in the
 same right slot, mutually exclusive.
 
-This spec covers v1 of the panel. Drop shadow, reflection, recolor,
-brightness/contrast, text padding, and numeric shape adjustments are
-explicitly deferred — they all require new data-model fields and
-renderer/PPTX changes that are larger than the panel shell. The slides
-v1 non-goal "Right-side Format options panel" in
-[`slides.md`](./slides.md) is partially closed by this spec for the
-properties already present in the data model.
+This doc covered v1 of the panel; drop shadow, reflection, recolor, and
+image brightness/contrast — originally deferred here — have since shipped
+(a shared `Effects` bag on element `data`, plus `image.recolor` /
+`image.brightness` / `image.contrast`) and now render as panel sections
+(see below). Text padding and numeric shape adjustments remain deferred —
+they still require new data-model fields and renderer/PPTX changes that
+are larger than the panel shell. The slides v1 non-goal "Right-side
+Format options panel" in [`slides.md`](./slides.md) is closed by this
+work for the properties covered above.
 
 ### Goals
 
@@ -46,13 +48,6 @@ properties already present in the data model.
 
 ### Non-Goals
 
-- **Drop shadow**, **reflection**, **recolor** for shapes/text/images.
-  Each requires a new `data` field, a paint-time pipeline change, and
-  OOXML `<a:effectLst>` / `<a:duotone>` import-export mapping. Tracked
-  as separate v1.1+ specs.
-- **Image brightness / contrast**. Requires a canvas filter pipeline
-  (`ctx.filter = '...'` or per-image offscreen pass) and PPTX
-  `<a:lum>` / `<a:duotone>` round-trip. v1.1+.
 - **Text padding** (`<a:bodyPr lIns="..." tIns="...">`). The data model
   has no padding field today; adding it touches the docs RichText
   layout reused by slides text boxes. v1.1.
@@ -139,19 +134,24 @@ Section routing is a pure function:
 type SectionId =
   | 'size-position'
   | 'text-fitting'
+  | 'recolor'
   | 'image-adjustments'
+  | 'drop-shadow'
+  | 'reflection'
   | 'alt-text';
 
 function pickSections(selection: PanelSelection): readonly SectionId[];
 ```
 
-Mapping:
+Mapping (as shipped in `pick-sections.ts`; `selectionType` also has a
+`'table'` variant added by the tables feature):
 
 | selectionType | sections |
 |---|---|
-| `shape` | `['size-position']` |
-| `image` | `['size-position', 'image-adjustments', 'alt-text']` |
-| `text-element` | `['size-position', 'text-fitting']` |
+| `shape` | `['size-position', 'drop-shadow', 'reflection', 'alt-text']` |
+| `image` | `['size-position', 'recolor', 'image-adjustments', 'drop-shadow', 'reflection', 'alt-text']` |
+| `text-element` | `['size-position', 'text-fitting', 'drop-shadow', 'reflection', 'alt-text']` |
+| `table` | `['size-position', 'alt-text']` (drop shadow excluded — it would shadow every cell border) |
 | `connector` | `['size-position']` (rotation hidden internally) |
 | `group` | `['size-position']` |
 | `mixed` | `['size-position']` (rotation/W/H hidden, X/Y only) |
@@ -284,15 +284,29 @@ The H input lock in Size & Position keys off the same value
 ┌─ Adjustments ──────────────────────┐
 │ Transparency                       │
 │  [────●─────────────────] 30%      │
+│ Brightness                         │
+│  [──────────●───────────]  0       │
+│ Contrast                           │
+│  [──────────●───────────]  0       │
 └────────────────────────────────────┘
 ```
 
-- Slider 0–100% mapped to `image.opacity` as `1 - value/100`.
+- Transparency slider 0–100% mapped to `image.opacity` as `1 - value/100`.
   Internally stored as the existing `opacity` field (0..1).
+- Brightness and contrast sliders map to `image.brightness` /
+  `image.contrast` (stored `[-1, 1]`, shown as `-100..100`), applied at
+  paint time via `ctx.filter = brightness(...) contrast(...)`.
 - Commit on `pointerup` only, not during drag (one undo entry per
   adjustment session).
 - Multi-select: shows blank slider thumb when values differ; dragging
   commits the new value to all.
+
+Recolor (`image.recolor`: `'none' | 'grayscale' | 'sepia'`, a
+`ctx.filter` preset) renders as its own **Recolor** section above
+Adjustments for image selections. Drop shadow (`data.effects.shadow`)
+and reflection (`data.effects.reflection`) render as **Drop shadow** and
+**Reflection** sections for shape/image/text selections; both live in the
+shared `Effects` bag on element `data`.
 
 ### Alt text section
 
@@ -328,8 +342,12 @@ The H input lock in Size & Position keys off the same value
 
 `migrate.ts` requires no change — absence means `'in'`.
 
-No other model files change. `frame`, `text.autofit`, `image.opacity`,
-`image.alt` are all already in place.
+For the v1 panel no other model files changed — `frame`, `text.autofit`,
+`image.opacity`, `image.alt` were all already in place. The later
+drop-shadow / reflection / recolor / brightness / contrast sections did
+extend `element.ts` (the `Effects` bag plus `image.recolor` /
+`image.brightness` / `image.contrast`); all additive/optional, so
+`migrate.ts` still needs no change.
 
 ### File layout
 
@@ -340,14 +358,21 @@ packages/frontend/src/app/slides/
 └── format-panel/                    # new directory
     ├── index.tsx                    # FormatPanel shell + section routing
     ├── pick-sections.ts             # pure: selection → SectionId[]
-    ├── pick-sections.test.ts
     ├── units.ts                     # pxToUnit / unitToPx / formatDisplay / getCommonValue / radToDeg / degToRad
-    ├── units.test.ts
+    ├── slide-size-section.tsx       # deck size / orientation (shown when idle)
     ├── size-position-section.tsx
     ├── text-fitting-section.tsx     # 3-mode radio, writes data.autofit
-    ├── image-adjustments-section.tsx
+    ├── recolor-section.tsx          # image recolor preset, writes data.recolor
+    ├── image-adjustments-section.tsx # transparency + brightness + contrast
+    ├── drop-shadow-section.tsx      # writes data.effects.shadow
+    ├── reflection-section.tsx       # writes data.effects.reflection
     └── alt-text-section.tsx
 ```
+
+Section unit/component tests live under the top-level test mirror at
+`packages/frontend/tests/app/slides/format-panel/` (e.g.
+`pick-sections.test.ts`, `units.test.ts`, and a `*-section.test.tsx` per
+section), not as siblings of the source files.
 
 The `image-controls.tsx` toolbar file is edited to drop its
 `AltTextDropdown` and stop importing `IconAccessible`.

--- a/docs/design/slides/slides-gradient-editing.md
+++ b/docs/design/slides/slides-gradient-editing.md
@@ -19,10 +19,13 @@ and a gradient can never be authored from scratch.
 This spec adds the editing UI: the toolbar fill dropdown gains a
 `Solid | Gradient` toggle, and the Gradient mode surfaces a PowerPoint-style
 **stops-bar** (add / drag / delete stops, each with its own color + position +
-transparency) plus direction controls. It also extends the model, renderer,
-importer, and exporter from linear-only to **linear + radial**, so radial
-gradients — today collapsed to their first stop on import — survive the
-round-trip and become editable.
+transparency) plus direction controls. That editing UI shipped, together with
+a `type` (`linear | radial`) / `center` discriminator on the `GradientFill`
+model. The **linear + radial** widening of the renderer, importer, and
+exporter, however, did **not** land: radial gradients are still collapsed to
+their first stop on import, `resolveFillStyle` paints linear only, `gradFillXml`
+always emits `<a:lin>`, and the editor emits `type: 'linear'` exclusively. The
+radial design below is retained as a not-yet-built follow-up.
 
 Google Slides is not a reference here: it has no gradient fill editor at all.
 The design follows **PowerPoint / Keynote**, whose stops-bar idiom is the de
@@ -40,13 +43,18 @@ facto standard.
   **theme role colors** (theme-following gradients) or srgb + alpha.
 - Widen the model / renderer / importer / exporter from linear-only to
   **linear + radial**, preserving radial gradients through the PPTX round-trip.
+  *(Not shipped: only the model gained the `type` / `center` fields; the
+  renderer, importer, and exporter remain linear-only — see the Render /
+  Import / Export sections.)*
 - Apply gradient edits to shapes **and** freeform shapes (shared field +
   renderer), with multi-select writes collapsed into a single `store.batch`.
 
 **Non-Goals**
 
-- **Path / shape gradients** (`<a:path path="shape">`) beyond `circle`.
-  Still collapsed to their representative solid on import, as today.
+- **Path / shape gradients** (`<a:path path="shape">`). Collapsed to their
+  representative solid on import, as today. (The `circle` / radial case was
+  intended to be preserved but that work has not shipped — see the Import
+  section.)
 - **On-canvas gradient handles** (drag the axis / center directly on the
   shape). The editor is inline in the fill popover only; radial center is
   chosen from 5 presets, not dragged. The model stores `center` as a free
@@ -54,8 +62,11 @@ facto standard.
 - **Preset gradient swatches** (PowerPoint's "Preset gradients" row). Gradient
   mode seeds a 2-stop default from the current solid; a curated preset row is
   a follow-up.
-- **Gradient fills on text boxes, table cells, and slide backgrounds.** Those
-  remain solid-only parallel stacks, as in the gradient-fill spec.
+- **Gradient fills on text boxes and table cells.** Those remain solid-only
+  parallel stacks, as in the gradient-fill spec. *(Slide backgrounds are no
+  longer a non-goal: the background side panel now reuses `FillPicker` with a
+  `Solid | Gradient` toggle and writes a `GradientFill` via
+  `updateSlideBackground({ fill })` — see `use-slide-background`.)*
 - **Angle dial widget.** Linear direction is 8 presets + a numeric degree
   input, not a circular dial.
 
@@ -80,7 +91,8 @@ export type Fill = ThemeColor | GradientFill; // unchanged
 ```
 
 - `type` is **required**, not optional — every gradient carries an explicit
-  kind so `resolveFillStyle` / `gradFillXml` switch exhaustively.
+  kind. (The renderer and exporter do not yet branch on it — they treat every
+  gradient as linear — but the field is stored for the deferred radial work.)
 - `migrate.ts` backfills existing stored gradients (all linear, from the v1
   importer) with `type: 'linear'` — a one-line map. Absence of `center` means
   `{ x: 0.5, y: 0.5 }` (from-center), applied at read time, not migrated.
@@ -113,6 +125,10 @@ dropdown. A segmented toggle sits at the top:
   matches the existing color-pick-replaces-gradient behavior.
 
 #### `GradientEditor`
+
+> **Shipped linear-only.** The editor has no `Linear | Radial` type toggle and
+> emits `type: 'linear'` exclusively; the `Type:` row and the radial direction
+> controls in the mockup below are part of the deferred radial work.
 
 ```
 ┌ Gradient ────────────────────────────┐
@@ -170,12 +186,17 @@ swatch, direction preset, degree/position input blur) commit immediately via
   (solid or gradient). Multi-select applies the same `Fill` to every selected
   shape in a single `store.batch` — Format-panel parity.
 - Targets: `shape` and `freeform` (they share `data.fill` + the renderer, so
-  freeform gets gradient editing for free). Text boxes, table cells, and
-  backgrounds keep their solid-only pickers.
+  freeform gets gradient editing for free). Text boxes and table cells keep
+  their solid-only pickers; slide backgrounds have since gained the same
+  `FillPicker` gradient support (via `use-slide-background`).
 
 ### Render (`view/canvas/render-context.ts`)
 
-`resolveFillStyle` gains a radial branch; the linear branch is unchanged:
+> **Not shipped.** `resolveFillStyle` remains linear-only — it never calls
+> `createRadialGradient`. The radial branch below is the intended design for the
+> deferred radial work.
+
+`resolveFillStyle` would gain a radial branch; the linear branch is unchanged:
 
 ```ts
 if (fill.type === 'radial') {
@@ -199,8 +220,13 @@ solid) and the `paintFaces` 3D collapse are unchanged.
 
 ### Import (`import/pptx/shape.ts`)
 
+> **Not shipped.** `parseGradientFill` still collapses *every* `<a:path>`
+> gradient — `circle` included — to its first stop with `type: 'linear'`, and
+> never reads `<a:fillToRect>` or derives `center`. The `circle` upgrade below
+> is deferred.
+
 `parseGradientFill` currently collapses any `<a:path>` gradient to its first
-stop. Upgrade the `circle` case to preserve it:
+stop. The deferred upgrade would preserve the `circle` case:
 
 - `<a:path path="circle">` → `type: 'radial'`; read `<a:fillToRect l/t/r/b>`
   (1000ths-of-a-percent insets) and derive `center` (e.g. `x = l/(l+r)`,
@@ -212,14 +238,18 @@ stop. Upgrade the `circle` case to preserve it:
 
 ### PPTX export (`export/pptx/color.ts`)
 
-`gradFillXml` switches on `type`:
+> **Not shipped.** `gradFillXml` always emits `<a:lin ang="...">` — it does not
+> switch on `type` and never writes `<a:path path="circle">`. The `type` switch
+> below is deferred.
+
+`gradFillXml` would switch on `type`:
 
 - `linear` → `<a:lin ang="...">` (unchanged).
 - `radial` → `<a:path path="circle"><a:fillToRect .../></a:path>`, inverting the
   import `center` → insets mapping.
 
-Verified by the existing importer-fixture model-equivalence round-trip
-(extended with a radial fixture).
+This would be verified by the existing importer-fixture model-equivalence
+round-trip (extended with a radial fixture).
 
 ## Risks and Mitigation
 

--- a/docs/design/slides/slides-gradient-fill.md
+++ b/docs/design/slides/slides-gradient-fill.md
@@ -35,7 +35,13 @@ export inherits it for free (it rasterizes `drawSlide()`).
 
 ```ts
 export type GradientStop = { pos: number; color: ThemeColor }; // pos 0..1
-export type GradientFill = { kind: 'gradient'; angle: number; stops: GradientStop[] };
+export type GradientFill = {
+  kind: 'gradient';
+  type: 'linear' | 'radial'; // `linear` uses `angle`; `radial` uses `center`
+  angle: number;
+  center?: { x: number; y: number }; // radial origin, 0..1 of the box
+  stops: GradientStop[];
+};
 export type Fill = ThemeColor | GradientFill;                  // discriminated on `kind`
 export function representativeColor(fill: Fill): ThemeColor;    // gradient → first stop
 ```

--- a/docs/design/slides/slides-gradient-fill.md
+++ b/docs/design/slides/slides-gradient-fill.md
@@ -37,9 +37,9 @@ export inherits it for free (it rasterizes `drawSlide()`).
 export type GradientStop = { pos: number; color: ThemeColor }; // pos 0..1
 export type GradientFill = {
   kind: 'gradient';
-  type: 'linear' | 'radial'; // `linear` uses `angle`; `radial` uses `center`
+  type: 'linear' | 'radial'; // only `linear` renders; `radial` is preservation-only
   angle: number;
-  center?: { x: number; y: number }; // radial origin, 0..1 of the box
+  center?: { x: number; y: number }; // radial origin, 0..1 of the box (stored, not yet rendered)
   stops: GradientStop[];
 };
 export type Fill = ThemeColor | GradientFill;                  // discriminated on `kind`
@@ -47,7 +47,11 @@ export function representativeColor(fill: Fill): ThemeColor;    // gradient → 
 ```
 
 `ShapeElement.data.fill` widens from `ThemeColor` to `Fill`. `angle` is in
-radians (clockwise from the positive x-axis; `0` = left→right). The
+radians (clockwise from the positive x-axis; `0` = left→right). `type: 'radial'`
+and `center` are carried on the model but preservation-only in this feature — the
+importer, `resolveFillStyle`, and the exporter all treat every gradient as
+linear; the deferred radial render/export work is tracked in
+[slides-gradient-editing.md](slides-gradient-editing.md). The
 `kind: 'gradient'` discriminator turns every `resolveColor(data.fill)` into a
 compile error, so no consumer is silently missed. Freeform shapes share the
 field and renderer, so they get gradients for free. Migration (`wrapColor`)

--- a/docs/design/slides/slides-group.md
+++ b/docs/design/slides/slides-group.md
@@ -123,8 +123,9 @@ local coordinate space and the renderer applies the group transform
 on top, children visibly scale proportionally — including text and
 its font glyphs — matching Google Slides.
 
-**Invariants** (enforced by `MemSlidesStore` and validated in
-`model/migrate.ts`):
+**Invariants** (enforced by the store — `group()` in
+`packages/slides/src/store/memory.ts`; `packages/slides/src/model/migrate.ts`
+does not touch groups):
 
 1. A group has at least one child. Removing the last child triggers
    automatic ungroup (the group element is removed and any remaining
@@ -215,13 +216,14 @@ interface SlidesStore {
   reorderElement(slideId, elementId, toIndex): void;
 
   // — New for grouping —
-  group(slideId, elementIds): string;
+  group(slideId, elementIds): { groupId: string; excludedConnectorIds: string[] };
   //   - All elementIds must share the same parent (slide-root or the
   //     same group). Throws if mixed parents.
   //   - Inserts a new GroupElement at the position of the front-most
   //     selected element; children move into it in their original
   //     z-order; child frames are normalized to group-local coords.
-  //   - Returns the new group id.
+  //   - Returns the new group id plus any connectors dropped from the
+  //     selection because one endpoint fell outside it (see §7).
   //
   ungroup(slideId, groupId): string[];
   //   - Bakes each child's frame through the group transform
@@ -422,10 +424,13 @@ because `applyGroupTransform` scaled its `frame` while `clone()` copied
 its stale `refSize`; settling to scale `1` first removes the scale that
 would have leaked.
 
-**Guard.** A DEV/test-only helper `assertGroupsSettled(elements)` walks
-the tree and asserts `refSize ≈ frame` for every group; regression tests
-call it after resize/ungroup commits so a future un-baked commit path
-fails loudly. Both stores implement the fix: `MemSlidesStore`
+**Guard.** Test-only helpers `isGroupSettled(group)` and
+`collectUnsettledGroups(elements)` in
+`packages/slides/test/support/group-invariant.ts` walk the tree and check
+`refSize ≈ frame` for every group; nothing enforces the invariant at
+runtime — regression tests call them after resize/ungroup commits (and the
+Yorkie equivalence suite's `allGroupsSettled`) so a future un-baked commit
+path fails loudly. Both stores implement the fix: `MemSlidesStore`
 (`store/memory.ts`, unit-tested) and `YorkieSlidesStore`
 (`frontend/.../yorkie-slides-store.ts`, live app); the shared math stays
 in `model/group.ts`.
@@ -497,27 +502,27 @@ elements. Under the new model:
 **Import fidelity invariant.** For any PPTX fixture, the union of
 world bboxes produced by the new (group-preserving) import must
 equal the union produced by the old (flattening) import within
-sub-pixel tolerance. This is enforced by a property test in
-`import/pptx/group.test.ts` that runs both code paths against the
-existing fixture set.
+sub-pixel tolerance. This is enforced by
+`packages/slides/test/import/pptx/group-preserving.test.ts`, which builds
+`<p:grpSp>` XML inline and compares the preserved group tree's leaf world
+frames against the flattening path.
 
 ### 9. PDF Export
 
-`packages/slides/src/export/pdf.ts` currently walks
-`slide.elements` flat. It becomes recursive in the same shape as
-`paintElement`:
+The shipped exporter (`packages/slides/src/export/pdf.ts`) is a **raster**
+P0 pipeline, not a vector emitter: it renders each slide through the
+existing `drawSlide()` canvas pipeline onto a high-DPI offscreen canvas and
+embeds one bitmap per page into a `pdf-lib` document (see
+[slides-pdf-export.md](./slides-pdf-export.md)). Groups therefore need **no
+PDF-specific code** — they are already handled by the recursive canvas
+renderer described in §5, so paint and export stay identical by
+construction. (`pdf.ts` does walk the tree for its own bookkeeping, e.g.
+`flattenElements` recurses `into el.data.children` to preload image bytes.)
 
-- Each `GroupElement` opens a PDF transform context (translation,
-  rotation, scale) and recurses into children.
-- Children's existing per-type emit functions are unchanged.
-- The `pdf-lib` graphics state stack handles `pushGraphicsState` /
-  `popGraphicsState` per group level.
-- Text glyph positions remain correct because the existing text
-  emit computes positions in local space; the transform stack
-  applies the composition.
-
-This keeps paint and export sharing one truth: the same recursion
-shape and the same transform composition function.
+A vector text-overlay hybrid — the per-group `pushGraphicsState` /
+`popGraphicsState` recursion originally sketched here — is deferred to the
+P1 vector pass; when it lands, group transforms compose via
+`applyGroupTransform` in `packages/slides/src/model/group.ts`.
 
 ### 10. Other Integration Points
 
@@ -592,12 +597,13 @@ Verification gates: end of P1–P3 → `pnpm verify:fast`; end of P4 →
 - One scenario covering: rotated group containing a rotated text
   box, drill-in, text edit, ungroup. Screenshot baseline updated.
 
-**PPTX import regression**:
+**PPTX import regression**
+(`packages/slides/test/import/pptx/group-preserving.test.ts`):
 
-- Fixture set under `packages/slides/test/fixtures/pptx-groups/`
-  with nested rotated groups + non-uniform scale. The visual-bbox
-  invariant test runs new (preserving) and old (flattening) code
-  paths and compares world bboxes per leaf within 0.5 px.
+- `<p:grpSp>` XML built inline (nested rotated groups + non-uniform
+  scale). The visual-bbox invariant test runs the new (preserving) and
+  old (flattening) code paths and compares world bboxes per leaf within
+  sub-pixel tolerance.
 
 ### 13. Selection Overlay (groups vs. drilled-in child)
 
@@ -701,12 +707,14 @@ group-selected baseline and a drilled-in baseline.
 
 ### Known Limitations / Follow-ups
 
-- **PDF export not implemented for slides v1.** The slides `export/`
-  directory does not exist yet. When it is added, the recursive emitter
-  pattern from §9 (Task 15 in the implementation plan) can be copied
-  directly; group transforms compose via `applyGroupTransform` in
-  `model/group.ts`, so paint and export will share the same math without
-  any group-specific changes to the leaf emitters.
+- **PDF export ships as a raster pipeline.** The slides `export/`
+  directory now exists (`packages/slides/src/export/pdf.ts`) and exports
+  every slide — groups included — by rendering through the shared
+  `drawSlide()` canvas pipeline and embedding one bitmap per page, so no
+  group-specific export code was needed (see §9). The vector emitter
+  pattern originally sketched in §9 is the deferred P1 vector pass; when it
+  lands, group transforms compose via `applyGroupTransform` in
+  `packages/slides/src/model/group.ts`.
 
 - **`selectAt` dead code in `view/editor/interactions/select.ts`.** This
   helper became unreachable after the Task 9 click-handler rewire that

--- a/docs/design/slides/slides-group.md
+++ b/docs/design/slides/slides-group.md
@@ -392,8 +392,9 @@ group has scale `1`, so the renderer applies no scale (no shear) and
 before and after ungroup, rotated or not, at any depth.
 
 **Enforcement.** `refSize` is seeded equal to `frame` at group creation
-(`store.group()`) and PPTX import already bakes `<a:chExt>/<a:ext>` into
-child world frames so imported groups also rest at scale `1`. The
+(`store.group()`) and PPTX import seeds `refSize` to the group's
+child-AABB extent (the same value it stores as `frame`), so imported
+groups also rest at scale `1`. The
 invariant only leaks through commit paths that change a group's `frame.w
 / h` without baking. Every such path must call `bakeGroupResize` in the
 same `batch`:
@@ -480,20 +481,29 @@ renderer already produces correct output without changes.
 `composeGroupTransform` to flatten `<p:grpSp>` into world-frame
 elements. Under the new model:
 
-- On encountering `<p:grpSp>`, the importer creates a `GroupElement`
-  whose `frame` is the group's own `<a:xfrm>` in the parent's
-  coordinate space, and recurses into its children.
-- Each child's `<a:off>` / `<a:ext>` (already in slide pixels after
-  `parseXfrm`) is converted to the group's local coordinate space
-  before storage: subtract the group's `<a:chOff>` and divide by the
-  local scale (`<a:chExt>` → `(group.frame.w, group.frame.h)`).
-  This is the inverse of the matrix the old code applied via
-  `applyGroupTransform`; the new helper `normalizeToGroupLocal`
-  shares the same quadratic-solver branch for rotated children under
-  non-uniform group scale.
+- On encountering `<p:grpSp>`, the importer (`parseGrpSp` in
+  `packages/slides/src/import/pptx/shape.ts`) creates a `GroupElement`
+  and recurses into its children.
+- `composeGroupTransform` bakes every enclosing group's `<a:chOff>` /
+  `<a:chExt>`→`<a:ext>` scale and rotation into one cumulative
+  transform, so `parseSpTreeChildren` returns each child in **world**
+  coordinates. This world-frame baking is an intermediate calculation
+  only — nothing is stored in world space.
+- The group's `frame` is the rotation-aware AABB
+  (`combinedBoundingBox`) of those world child frames, and `refSize` is
+  seeded to the same extent so the group rests at scale `1`. Children
+  are then converted to **group-local** coordinates by
+  `worldToGroupLocal` — subtracting the AABB origin (an x/y
+  translation; size and rotation preserved), matching the invariant
+  `MemSlidesStore.group()` uses. Connector free endpoints shift the
+  same way. (The `normalizeToGroupLocal` helper in
+  `packages/slides/src/model/group.ts` is the general inverse used by
+  the editor's drag-into-group path; the importer only needs the
+  translation because the group frame is already the children's tight
+  AABB.)
 - Nested `<p:grpSp>` resolves naturally — the recursion already
-  exists in the importer; only the per-frame `apply` call becomes
-  the inverse normalize call.
+  exists in the importer, and each level produces its own
+  AABB-anchored `GroupElement`.
 - Unsupported descendants (`<p:cxnSp>` with cross-group endpoints,
   picture types we already fall back on, etc.) follow today's
   behavior of being skipped or flattened with a `report.ts`

--- a/docs/design/slides/slides-hover-and-text-edit-entry.md
+++ b/docs/design/slides/slides-hover-and-text-edit-entry.md
@@ -10,14 +10,17 @@ target-version: 0.5.0
 ## Summary
 
 Bring the Slides editor's idle-state hover feedback and text-edit
-entry affordances closer to Google Slides. Today the editor gives no
-visual or cursor feedback when hovering over unselected elements, and
-text-editing is reachable only via double-click. This makes the canvas
-feel inert on first interaction and forces an extra click for the
-common case of editing layout placeholders. This proposal adds a
-hover preview overlay, region-aware cursor changes, keyboard entry
-(Enter / F2), and a small set of click/typing affordances — split
-into three rollout phases (P0 → P2) that map to PR-sized increments.
+entry affordances closer to Google Slides. Before this work the editor
+gave no visual or cursor feedback when hovering over unselected
+elements, and text-editing was reachable only via double-click. This
+made the canvas feel inert on first interaction and forced an extra
+click for the common case of editing layout placeholders. All of it —
+a hover preview overlay, region-aware cursor changes, keyboard entry
+(Enter / F2), and the click/typing affordances — is now shipped. The
+sections below use the original P0 → P2 phase split as documentation of
+each affordance; every item has landed in the `editor.ts` pointer-state
+machine, `overlay.ts` renderer, the `interactions/` handlers, and
+`text-box-editor.ts`.
 
 ### Goals
 
@@ -64,20 +67,26 @@ Success criteria:
 
 ### Phase split
 
-| Phase | Items | Rationale |
+All phases below are **shipped**. The phase grouping is retained as a
+map of where each affordance lives, not as a rollout plan.
+
+| Phase | Items | Where it lives |
 |---|---|---|
-| **P0** | (1) Idle hover outline, (2) Text-region I-beam | Highest UX delta with changes localized to `editor.ts` hover handler and `overlay.ts` renderer. One PR. Item (3) Enter / F2 entry **already shipped** in `interactions/keyboard.ts:481-500` — kept here for completeness of the comparison table, no work item. |
+| **P0** | (1) Idle hover outline, (2) Text-region I-beam | `editor.ts` hover handler (`onSelectionHoverMove`) + `overlay.ts` renderer. Item (3) Enter / F2 entry lives in `interactions/keyboard.ts` (the F2 / Enter rule, ~line 627). |
 
 > "Text-capable element" throughout this doc means: any element of
 > kind `text`, or a shape whose model carries a non-empty `textBody`
 > field (the same predicate the text-box editor uses to decide
 > whether to mount). Lines, raw connectors, and images are excluded.
-| **P1** | (4) Empty-placeholder 1-click entry, (5) Slow double-click (second-click-on-selected) | Adds new entry rules that need targeted unit + browser tests. Separate PR so review can focus on the click-classification rules. |
-| **P2** | (6) Printable-char first-key forwarding, (7) Edge-zone resize cursor | Polish. Independent PRs; each can ship in isolation. Item (6) gates on completing the v1 caveat noted in `keyboard.ts:506-513` (consumed first character is not inserted into the freshly-mounted text-box). |
+| **P1** | (4) Empty-placeholder 1-click entry, (5) Slow double-click (second-click-on-selected) | `interactions/select.ts` (`isEmptyPlaceholder`) and `interactions/drag.ts` (slow-double-click classifier). |
+| **P2** | (6) Printable-char first-key forwarding, (7) Edge-zone resize cursor | `text-box-editor.ts` (`initialText`) forwarded from the printable-key rule in `keyboard.ts`, and the edge-zone cursor block in `editor.ts` (§ P2.7). |
 
-### Current vs target behavior
+### Behavior
 
-| # | Trigger | Today | Target (this proposal) |
+Columns are labelled "Before" (the pre-feature editor) and "Now"
+(shipped behavior).
+
+| # | Trigger | Before | Now |
 |---|---|---|---|
 | A | Hover over unselected element | No feedback | 1 px `rgba(26,115,232,0.5)` outline along bbox |
 | B | Hover over selected element body | `move` cursor | `move` over non-text regions only |
@@ -93,7 +102,8 @@ Success criteria:
 
 #### P0.1 Idle hover outline
 
-Add a `hoverPreviewId: string | null` field to the editor pointer state.
+A `hoverHighlightId: string | null` field on the editor pointer state
+tracks the hovered element (`editor.ts:700`).
 
 - `onSelectionHoverMove(pointer)` runs hit-test in the **current
   selection scope** (respects group drill-in: same scope used by
@@ -141,18 +151,16 @@ Group drill-in case (Gap D):
 - For images, connectors, and non-text shapes (e.g. lines, raw
   geometric primitives without `textBody`) the cursor stays `move`.
 
-#### P0.3 Enter / F2 keyboard entry — already shipped
+#### P0.3 Enter / F2 keyboard entry
 
-Documented for reference only. The keyboard rule lives at
-`packages/slides/src/view/editor/interactions/keyboard.ts:481-500`
-and already implements the contract below:
+The keyboard rule lives at
+`packages/slides/src/view/editor/interactions/keyboard.ts` (the
+F2 / Enter rule, ~line 627) and implements the contract below:
 
 | Key | Pre-condition | Action |
 |---|---|---|
 | `Enter` / `F2` | Single text-capable element selected, no mod keys, focus not on an editable input | `enterEditMode(slideId, elementId)` |
 | `Esc` (in edit) | (handled by text-box editor's own capture listener) | exits edit |
-
-No work item in this plan. Verified during plan-writing pass.
 
 ### P1 — Click-classification refinements
 
@@ -194,26 +202,22 @@ inside the text region AND `dist(down, up) < 3 px` AND
 
 #### P2.6 Printable-char first-key forwarding
 
-Baseline: the printable-key rule at `keyboard.ts:514-532` already
-enters edit on a printable character when one text-capable element
-is selected. The v1 caveat documented in the comment block above
-that rule is: **the consumed character is not inserted into the
-freshly mounted text-box, so the user has to type it again.**
+The printable-key rule (`keyboard.ts`, ~line 662) enters edit on a
+printable character when one text-capable element is selected, and the
+triggering character **is** forwarded into the freshly-mounted
+text-box so the user does not have to type it again. The earlier v1
+caveat (consumed character dropped) is closed. The shipped pieces:
 
-This task closes that gap:
-
-- Extend `mountSlidesTextBox(...)` (in
-  `packages/slides/src/view/editor/text-box-editor.ts`) with an
-  optional `initialText?: string` parameter. When present, after the
-  contenteditable is focused, dispatch a synthetic `InputEvent` of
-  type `beforeinput` with `inputType: 'insertText'` and `data:
-  initialText`. The docs text editor already handles `beforeinput`
-  for `insertText`, so the character lands in the correct caret
-  position.
-- Extend `SlidesEditor.enterEditMode(slideId, elementId,
-  options?: { initialText?: string })` to forward the option to
+- `mountSlidesTextBox(...)` (in
+  `packages/slides/src/view/editor/text-box-editor.ts`) accepts an
+  optional `initialText?: string`. When present, after the
+  contenteditable is focused, it forwards the character into the docs
+  editor exactly once (`initialTextPending` guard, ~line 395) so the
+  character lands at the correct caret position.
+- `SlidesEditor.enterEditMode(slideId, elementId,
+  options?: { initialText?: string })` forwards the option to
   `mountSlidesTextBox`.
-- Update the printable-key rule in `keyboard.ts` to pass
+- The printable-key rule in `keyboard.ts` passes
   `{ initialText: e.key }` when calling `ctx.enterEditMode(...)`.
 - Tool-shortcut interaction: the existing rule order in `keyboard.ts`
   already routes single-letter tool keys before the printable-key
@@ -259,39 +263,31 @@ This task closes that gap:
 
 ### Pointer-state extensions
 
-`SlidesEditor` adds:
+`SlidesEditor` carries the hover state as pure view fields:
 
 ```ts
-private hoverHighlightId: string | null = null;
-private hoverCursorRegion: 'body' | 'text' | 'edge-n' | 'edge-e' | …
-  = 'body';
+private hoverHighlightId: string | null = null; // editor.ts:700
 ```
 
-Note: `hoverPreview` is already taken on the editor — it's the
-insert-mode shape-kind ghost preview
-(`editor.ts:479`). The new field is named
-`hoverHighlightId` to avoid the collision.
+Note: `hoverPreview` was already taken on the editor — it's the
+insert-mode shape-kind ghost preview (`editor.ts:693`). The hover
+field is named `hoverHighlightId` to avoid the collision.
 
 Both are pure view state; nothing is persisted. `onSelectionHoverMove`
 computes them and calls `repaintOverlay()` only when either changes.
 
 ### Testing strategy
 
-- **Unit**
-  - `interactions/select.test.ts`: empty-placeholder fast-entry,
-    slow-double-click classification.
-  - `editor.hover.test.ts` (new): hover-id transitions, text-region
-    vs body cursor, edge-zone cursor.
-  - `keymap.test.ts`: Enter / F2 enters edit only with single
-    text-capable selection.
-- **Browser test** (`pnpm verify:browser:docker`)
-  - New scenario `slides-hover-and-text-edit-entry.spec.ts`:
-    1. Insert a Title+Body slide; click empty Title → editing entered.
-    2. Hover an unselected shape → screenshot diff shows blue outline.
-    3. Select shape; hover text region → cursor is `text`.
-    4. Press F2 → text editing entered; press Esc → back to Object.
+- **Unit** (under `packages/slides/test/view/editor/`)
+  - `interactions/select.test.ts` + `empty-placeholder-entry.test.ts`:
+    empty-placeholder fast-entry classification.
+  - `interactions/drag.test.ts`: slow-double-click classification.
+  - `hover-highlight.test.ts`: hover-id transitions.
+  - `text-region-rect.test.ts`: text-region vs body cursor geometry.
+  - `interactions/keyboard.test.ts`: Enter / F2 enters edit only with
+    a single text-capable selection.
 - **Regression**
-  - Existing dblclick scenario passes unchanged.
+  - The dblclick entry path stays intact — both routes are supported.
   - Connector draw flow (overlay hit-test order) unchanged: hover
     preview is suppressed during insert mode.
 

--- a/docs/design/slides/slides-image-crop.md
+++ b/docs/design/slides/slides-image-crop.md
@@ -9,19 +9,17 @@ target-version: 0.5.0
 
 ## Summary
 
-Slides images already carry a normalized `crop` rectangle in the data
-model, the Canvas renderer already paints through it, and the PPTX
-importer already produces it. What is missing is the **interactive crop
-UX**: there is no way for a user to define or adjust a crop in the
-editor. The toolbar ships a disabled `IconCrop` placeholder whose
-comment reads *"full crop UI is deferred to a separate spec"* — this is
-that spec.
+Slides images carry a normalized `crop` rectangle in the data model, the
+Canvas renderer paints through it, and the PPTX importer produces it. The
+**interactive crop UX** described here is now shipped: a user can define
+and adjust a crop in the editor. The toolbar `IconCrop` button is active
+(it was previously a disabled placeholder).
 
 P0 delivers **free rectangular crop** (Google Slides / PowerPoint basic
 crop): enter a crop session on an image, drag eight black crop handles
 to trim the edges, pan the image underneath a fixed crop window, and
-commit. Crop-to-shape (masking) and aspect-ratio presets are explicitly
-P1 and live in their own follow-up.
+commit. Crop-to-shape (masking) and aspect-ratio presets remain P1 and
+live in their own follow-up.
 
 ## Goals / Non-Goals
 
@@ -56,15 +54,16 @@ P1 and live in their own follow-up.
 
 ## Proposal Details
 
-### Existing surface (no change needed)
+### Surface (shipped)
 
 | Concern | Where | State |
 | --- | --- | --- |
 | Model | `model/element.ts` — `ImageElement.data.crop?: Crop`, `Crop = { x, y, w, h }` normalized `0..1` of natural image | ✅ |
-| Render | `view/canvas/image-renderer.ts` `drawImage` — `drawImage(img, sx,sy,sw,sh, 0,0,w,h)` maps the crop source-rect onto the element frame | ✅ |
+| Crop math | `model/image-crop.ts` — `effectiveCrop`, `cropToFull`, `windowToCrop`, `applyCropHandle`, `panFull`, `normalizeCrop`, `frameToLocalWindow`, `windowToFrame`, `rotateVec`, `MIN_CROP_PX` | ✅ |
+| Render | `view/canvas/image-renderer.ts` — `drawImage` maps the crop source-rect onto the element frame; `drawCropPreview` paints the crop-mode overlay (called from `view/canvas/slide-renderer.ts`) | ✅ |
 | PPTX import | `import/pptx/image.ts` — `<a:srcRect>` and `<a:stretch><a:fillRect>` → `Crop` | ✅ |
 | Store ops | `store.ts` — `updateElementFrame`, `updateElementData`, `batch` | ✅ |
-| Toolbar slot | `frontend/.../toolbar/image-controls.tsx` — Replace / Crop (disabled) / Reset crop | partial |
+| Toolbar slot | `packages/frontend/src/app/slides/toolbar/image-controls.tsx` — Replace / Crop (active) / Reset crop | ✅ |
 
 The crop semantics are fixed by the renderer: **the crop source-rect is
 stretched to fill the element frame.** So `crop` answers "which sub-rect
@@ -135,48 +134,49 @@ frames, which would need a scope transform).
 
 ### Crop session state (editor)
 
-Mirror the existing text-edit session machinery in
+The crop session mirrors the existing text-edit session machinery in
 `view/editor/editor.ts` (`editingElementId` + `enterEditMode` /
-`exitEditMode`). Add a parallel, mutually-exclusive crop session:
+`exitEditMode`). It is a parallel, mutually-exclusive session held in a
+single `cropSession` field (no separate `croppingElementId`):
 
 ```ts
-private croppingElementId: string | null = null;
 private cropSession: {
   slideId: string;
   elementId: string;
   before: { frame: Frame; crop?: Crop };  // for Esc / undo bracket
   full: { x: number; y: number; w: number; h: number }; // bitmap box
+  ...
 } | null = null;
 ```
 
-- `enterCropMode(slideId, elementId)` — commit any open text edit first
-  (`editingElementId !== null → exitEditMode('commit')`); they are
-  mutually exclusive. Snapshot `before`, compute `full`, set state, open
-  one `store.batch` bracket, request a repaint.
-- `exitCropMode('commit' | 'cancel')` — on cancel, write `before` back;
-  on commit, the live drag handlers have already pushed `frame`/`crop`
-  via the store. Close the batch, clear state, repaint.
+- `enterImageCrop(elementId)` — commits any open text edit first (they
+  are mutually exclusive). Snapshot `before`, compute `full`, set state,
+  open one `store.batch` bracket, request a repaint. `isCropping()`
+  reports whether a session is active; `onCropChange(cb)` lets the
+  toolbar subscribe to enter/exit.
+- `exitImageCrop(commit: boolean)` — on cancel, write `before` back; on
+  commit, the live drag handlers have already pushed `frame`/`crop` via
+  the store. Close the batch, clear state, repaint.
 
 Entry points:
 
-1. **Double-click an image.** `onDoubleClick` currently early-returns
-   for non-text/shape leaf elements (`el.type !== 'text' && 'shape'`).
-   Add an `el.type === 'image'` branch that calls
-   `enterCropMode(slide.id, el.id)`. This matches Google Slides, where
-   double-clicking an image enters crop.
-2. **Toolbar Crop button.** Enable the placeholder; `onClick` calls a
-   thin `editor.enterCropMode(slideId, ids[0])` (single-selection only).
+1. **Double-click an image.** `onDoubleClick` has an `el.type === 'image'`
+   branch (top-level images only) that calls `enterImageCrop(el.id)`.
+   This matches Google Slides, where double-clicking an image enters crop.
+2. **Toolbar Crop button.** `onClick` toggles `editor.enterImageCrop(firstId)`
+   / `editor.exitImageCrop(true)` (single-selection only).
 
 Exit: `Enter` / click-outside / select-another → `commit`; `Esc` →
-`cancel`. Reuse the existing global key + outside-click plumbing that
+`cancel`. Reuses the existing global key + outside-click plumbing that
 text-edit already hooks.
 
 ### Interaction handlers
 
-Add `view/editor/interactions/crop.ts` alongside `resize.ts` / `drag.ts`
-/ `rotate.ts`, following their hit-test → move → commit shape. While a
-crop session is active the normal resize/rotate/drag handlers are
-suppressed for that element (the selection overlay swaps to crop chrome).
+The crop hit-test → move → commit handling lives inline in the crop
+session in `view/editor/editor.ts` (not a separate `interactions/crop.ts`
+file), driving the `model/image-crop.ts` helpers. While a crop session is
+active the normal resize/rotate/drag handlers are suppressed for that
+element (the selection overlay swaps to crop chrome).
 
 - **Crop-handle drag (trim).** Eight handles on the crop window
   (`frame`). Dragging an edge/corner moves that side of `frame`, clamped
@@ -210,18 +210,16 @@ handles.
 
 ### Toolbar wiring (`image-controls.tsx`)
 
-- Replace the disabled Crop button with an active one:
-  `onClick={() => editor?.enterCropMode(slideId, firstId)}`, enabled
-  when a single image is selected and the editor is editable.
-- While a crop session is active, render the button **pressed/active**;
-  clicking again (or the tooltip "Done") commits.
-- Keep **Reset crop** as-is. Confirm reset also restores `frame` to the
-  uncropped natural box; today it only clears `data.crop`, which—given
-  the stretch semantics—re-stretches the full bitmap into the old
-  cropped frame. P0 fix: on reset, recompute `frame` from `full` so the
-  picture returns to its true proportions, or document that reset keeps
-  the frame and only un-trims. (Decision: restore proportions; it is the
-  least surprising and matches GS "Reset image".)
+- The Crop button is active: `onCrop` toggles
+  `editor.enterImageCrop(firstId)` / `editor.exitImageCrop(true)`, enabled
+  when a single image is selected and the editor is present.
+- While a crop session is active the button renders **pressed/active**
+  (`aria-pressed`, muted background) with a "Done cropping" tooltip;
+  clicking again commits.
+- **Reset crop** routes through `editor.resetImageCrop(firstId)` so the
+  `frame` is recomputed from the uncropped bitmap (restoring true
+  proportions) rather than re-stretching the full bitmap into the stale
+  cropped frame, in one undo step. This matches GS "Reset image".
 
 ### Collaboration
 
@@ -250,9 +248,11 @@ local/presence-free in P0 (no "user is cropping" indicator).
 
 ### Rollout
 
-Single PR (model/render/import already landed): editor crop session +
-`crop.ts` interaction + overlay paint + toolbar enablement + tests.
-Update `packages/slides/README.md` image section.
+Shipped in a single PR (on top of the already-landed model/render/import):
+editor crop session (inline in `editor.ts`), `model/image-crop.ts`
+helpers, `drawCropPreview` overlay paint, toolbar enablement, and tests
+(`test/model/image-crop.test.ts`, `test/view/canvas/crop-preview.test.ts`,
+`test/view/editor/image-crop-session.test.ts`).
 
 ## Risks and Mitigation
 

--- a/docs/design/slides/slides-image-crop.md
+++ b/docs/design/slides/slides-image-crop.md
@@ -143,20 +143,23 @@ single `cropSession` field (no separate `croppingElementId`):
 private cropSession: {
   slideId: string;
   elementId: string;
-  before: { frame: Frame; crop?: Crop };  // for Esc / undo bracket
   full: { x: number; y: number; w: number; h: number }; // bitmap box
+  window: { x: number; y: number; w: number; h: number }; // bright crop box
   ...
 } | null = null;
 ```
 
 - `enterImageCrop(elementId)` — commits any open text edit first (they
-  are mutually exclusive). Snapshot `before`, compute `full`, set state,
-  open one `store.batch` bracket, request a repaint. `isCropping()`
-  reports whether a session is active; `onCropChange(cb)` lets the
-  toolbar subscribe to enter/exit.
-- `exitImageCrop(commit: boolean)` — on cancel, write `before` back; on
-  commit, the live drag handlers have already pushed `frame`/`crop` via
-  the store. Close the batch, clear state, repaint.
+  are mutually exclusive). Compute `full`/`window`, set state, request a
+  repaint. No store write happens on entry — the drag handlers
+  mutate the editor-local session, not the store. `isCropping()` reports
+  whether a session is active; `onCropChange(cb)` lets the toolbar
+  subscribe to enter/exit.
+- `exitImageCrop(commit: boolean)` — on cancel, nothing was written, so
+  just tear the session down; on commit, write the final `frame` + `crop`
+  together in one synchronous `store.batch()`, then clear state and
+  repaint. (`store.batch(fn)` closes its `doc.update()` scope when `fn`
+  returns, so it cannot stay open across the session's pointer events.)
 
 Entry points:
 
@@ -186,10 +189,12 @@ element (the selection overlay swaps to crop chrome).
 - **Image pan.** Dragging inside the crop window moves `full` (the
   bitmap) under the fixed `frame`, clamped so `frame` stays within
   `full`. `crop.x/cy` shift; `crop.w/ch` unchanged.
-- Each pointer-move writes through `store.updateElementFrame` +
-  `store.updateElementData(..., { crop })` inside the open batch; the
-  renderer already reflects it live. Snapping/smart-guides are **off**
-  in crop mode (P0) to keep the math simple.
+- Each pointer-move mutates the editor-local `cropSession` (`full` /
+  `window`) only; the renderer reflects it live via the crop-preview
+  descriptor. The store is written once — `store.updateElementFrame` +
+  `store.updateElementData(..., { crop })` in a single `store.batch()` on
+  commit. Snapping/smart-guides are **off** in crop mode (P0) to keep the
+  math simple.
 
 ### Rendering in crop mode
 
@@ -238,8 +243,8 @@ local/presence-free in P0 (no "user is cropping" indicator).
 - **Renderer:** crop-mode overlay paints dimmed-full + full-kept +
   handles (ctx-spy assertions, mirroring existing image-renderer tests).
 - **Interaction:** enter via double-click and via toolbar; commit on
-  Enter / outside-click; cancel on Esc restores `before`; mutual
-  exclusion with text-edit.
+  Enter / outside-click; cancel on Esc leaves the model unchanged (no
+  store write occurred); mutual exclusion with text-edit.
 - **PPTX round-trip:** crop produced in-editor exports and re-imports to
   an equivalent `<a:srcRect>` (extends existing `import/pptx/image`
   coverage).

--- a/docs/design/slides/slides-keyboard-shortcuts.md
+++ b/docs/design/slides/slides-keyboard-shortcuts.md
@@ -24,9 +24,6 @@ and a discoverable shortcuts-help modal.
 
 ### Non-Goals
 
-- **Group / Ungroup** (`Cmd+G` / `Cmd+Shift+G`). No group concept exists
-  in the slides model yet; introducing one is a separate design
-  involving model, CRDT, rendering, and selection-box changes.
 - **Find / replace** (`Cmd+F` / `Cmd+Shift+H`). Slides find/replace
   spans every slide and needs its own UX (thumbnail jump, match
   highlight, sequential search). Out of scope here.
@@ -39,9 +36,10 @@ and a discoverable shortcuts-help modal.
 | Category | Shortcut | Behavior |
 |---|---|---|
 | Selection | `Cmd/Ctrl+A` | Select all elements on the current slide. |
-| Selection | `Esc` | Exit text edit → clear selection → otherwise no-op. |
+| Selection | `Esc` | Exit text edit → pop group drill-in level → clear selection → otherwise no-op. |
 | Selection | `Tab` / `Shift+Tab` | Cycle next/previous element on the current slide. With nothing selected, selects the bottom-most (Tab) or top-most (Shift+Tab) element. |
 | Selection | `F2` / `Enter` | When exactly one text element is selected, enter text-edit mode. |
+| Selection | `Cmd/Ctrl+Alt+G` / `Cmd/Ctrl+Shift+Alt+G` | Group the selected elements / ungroup the selected group. |
 | Slide | `Cmd/Ctrl+M` | Add a new slide after the current, using the current slide's layout, and switch to it. |
 | Slide | `Cmd/Ctrl+Shift+D` | Duplicate the current slide explicitly. (`Cmd+D` continues to duplicate selected elements; only falls back to slide-duplicate when nothing is selected.) |
 | Slide | `Page Up` / `Page Down` | Switch to previous / next slide. Boundary-safe. |
@@ -100,10 +98,11 @@ export interface KeyboardContext {
   currentSlideId(): string | undefined;
   setCurrentSlide(id: string): void;            // new
   enterEditMode?: (elementId: string) => void;  // new — for F2 / Enter
+  group(): void;                                 // Cmd+Alt+G — group selection
+  ungroup(): void;                               // Cmd+Shift+Alt+G — ungroup
   requestRender(): void;
   onStartPresentation?: (from: 'current' | 'first') => void;
   onShowShortcutsHelp?: () => void;
-  onLinkRequest?: () => void;                    // canvas-level (unused in v1, present for symmetry)
 }
 ```
 
@@ -164,7 +163,8 @@ export type ShortcutCategory =
   | 'Nudge'
   | 'Format'
   | 'Present'
-  | 'Help';
+  | 'Help'      // also groups Undo / Redo / Show-shortcuts
+  | 'Drag';     // Shift-constraint entries (see "Shift modifiers during drag")
 
 export interface ShortcutEntry {
   /** Category for grouping in the help modal. */

--- a/docs/design/slides/slides-layout-change.md
+++ b/docs/design/slides/slides-layout-change.md
@@ -130,9 +130,11 @@ slide.elements.push({
 
 ### Store — `applyLayout` semantics
 
-A pure function `applyLayoutToSlide(slide, newLayout): void` lives
-in `packages/slides/src/model/layout.ts` and is called by both
-stores so the semantics never diverge.
+A pure function
+`applyLayoutToSlide(slide, newLayout, context?): void` (where
+`context?: { master: Master; theme: Theme }` seeds placeholder
+typography) lives in `packages/slides/src/model/layout.ts` and is
+called by both stores so the semantics never diverge.
 
 The algorithm has three passes:
 
@@ -170,7 +172,7 @@ non-empty) until then so we never lose a non-text orphan.
 ### Yorkie store
 
 `YorkieSlidesStore.applyLayout`
-(`packages/frontend/src/app/slides/yorkie-slides-store.ts:559`)
+(`packages/frontend/src/app/slides/yorkie-slides-store.ts`)
 calls the same pure `applyLayoutToSlide` from inside its existing
 `this.doc.update((r) => …)` block, where direct mutation of the
 slide proxy already works for the simpler additive logic today.
@@ -198,14 +200,17 @@ export interface LayoutPickerOptions {
   store: SlidesStore; // for theme/master lookup
   selectedLayoutId?: string; // outlined cell, optional
   anchor: { x: number; y: number };
+  trigger?: HTMLElement | null; // element that opened the picker
   onPick: (layoutId: string) => void;
   onClose: () => void;
 }
 
+// Returns an idempotent `close` handle so callers can dismiss the
+// popover programmatically (host unmount, trigger toggle).
 export function showLayoutPicker(
   host: HTMLElement,
   opts: LayoutPickerOptions,
-): void;
+): () => void;
 ```
 
 The picker mounts a `<div>` popover into `host`, positioned at
@@ -216,7 +221,7 @@ Esc → `onClose()` only. Arrow-key nav and Enter for keyboard.
 
 ### UI — split-button on `+`
 
-`packages/slides/src/view/editor/thumbnail-panel.ts:120` is the
+`packages/slides/src/view/editor/thumbnail-panel.ts` is the
 only place that calls `addSlide('blank')`. Split the existing
 `<button>` into a flex container with two hit zones:
 
@@ -261,8 +266,12 @@ Internally:
 3. Return the resulting `HTMLCanvasElement`.
 
 A module-level `Map` cache keyed
-`${themeId}:${masterId}:${layoutId}:${w}x${h}` avoids re-rendering
-the same preview. Theme/master switches naturally produce
+`${themeId}:${masterId}:${layoutId}:${w}x${h}@${dpr}:${sig}` —
+where `sig` is a JSON signature of the rendered content (theme
+colors/fonts, master background/placeholder styles, layout
+placeholders/background/static elements) so an in-place theme edit
+invalidates the bitmap rather than serving a stale one — avoids
+re-rendering the same preview. Theme/master switches naturally produce
 different keys; old entries fall out of reachability and become
 GC eligible. No LRU eviction in v1 (5 themes × 1 master × 11
 layouts × 2 sizes = 110 entries max).
@@ -298,16 +307,20 @@ Implementation:
   }
   ```
 
-- `drawText` (`view/canvas/text-renderer.ts`) gains an optional
-  `placeholderHint?: string` parameter. When set **and** the text
-  element's blocks are all empty (existing `isElementEmpty`
-  semantics), it paints the hint string in a muted theme-aware
-  grey at the placeholder's natural baseline instead of running
-  the empty layout pass.
+- `drawText` (`packages/slides/src/view/canvas/text-renderer.ts`)
+  gains an optional
+  `placeholderHint?: { text: string; style: PlaceholderStyle }`
+  option. When set **and** the text element's blocks are all empty
+  (existing `isElementEmpty` semantics), it paints the hint text in
+  the slot's master typography (font role/size, color role,
+  alignment) instead of running the empty layout pass.
 
-- `drawElement` (`view/canvas/element-renderer.ts`) passes the
-  hint when the element has a `placeholderRef`, otherwise omits
-  it. User-added text boxes get no hint — by design.
+- `drawElement`
+  (`packages/slides/src/view/canvas/element-renderer.ts`) resolves
+  the hint text (`placeholderHintFor`) and the master's
+  `placeholderStyles` entry for the element's `placeholderRef.type`,
+  passing them when the element has a `placeholderRef`, otherwise
+  omitting it. User-added text boxes get no hint — by design.
 
 - The text-box editor (vanilla `contentEditable`) is **out of
   scope** for v1. While the user is actively editing, the
@@ -318,9 +331,18 @@ Implementation:
   placeholder hint at the contentEditable layer too — small
   follow-up.
 
-- Presentation mode is not yet built (Phase 5b-2). When it lands,
-  it gates its own renderer flag and skips the hint entirely so
-  ghost text never reaches the audience.
+- Presentation mode has since shipped
+  (`packages/slides/src/view/present/presenter.ts`, exported as
+  `startPresenter`), and it renders through the same `SlideRenderer`
+  as the editor. The renderer-level hint-suppression flag envisioned
+  here was **not** built: `SlideRendererOptions` carries no such
+  flag and `element-renderer.ts` paints the ghost hint
+  unconditionally for empty `placeholderRef`-bearing text elements.
+  In practice presented decks are authored decks — placeholders that
+  reach the audience have real content, so an empty-placeholder hint
+  on a presented slide is not observed. If audience-facing suppression
+  is ever needed, gate the hint on a renderer option — a small
+  follow-up.
 
 ### Migration
 

--- a/docs/design/slides/slides-layout-change.md
+++ b/docs/design/slides/slides-layout-change.md
@@ -271,10 +271,15 @@ where `sig` is a JSON signature of the rendered content (theme
 colors/fonts, master background/placeholder styles, layout
 placeholders/background/static elements) so an in-place theme edit
 invalidates the bitmap rather than serving a stale one — avoids
-re-rendering the same preview. Theme/master switches naturally produce
-different keys; old entries fall out of reachability and become
-GC eligible. No LRU eviction in v1 (5 themes × 1 master × 11
-layouts × 2 sizes = 110 entries max).
+re-rendering the same preview. Because the theme builder edits
+themes/masters/layouts in place, each edit mints a new content key
+and the `Map` entries stay strongly reachable until deleted, so the
+cache would otherwise grow without bound. A `CACHE_CAP` of 128 bounds
+it: once `cache.size` exceeds the cap, the oldest entry (the `Map`'s
+first insertion-order key) is evicted. The immutable built-in previews
+(5 themes × 1 master × 11 layouts × 2 sizes = 110 entries) hash to
+stable keys and stay hot within the cap; only stale edited-layout
+bitmaps churn out over a long theme-editing session.
 
 ### Empty-placeholder ghost text
 
@@ -414,11 +419,12 @@ Browser smoke (manual, `pnpm dev`):
   not deployed yet. If decks accumulate before launch, a
   one-shot back-fill in `migrate.ts` is a 30-line change.
 
-- **Risk: preview cache grows unbounded with many themes.** Today
-  there are 5 themes, ≤2 masters per deck in practice, 11
-  layouts, and 1–2 preview sizes — roughly ≤220 canvases. At
-  160×90 RGBA, each canvas is ≈ 56 KB, so ≤ 13 MB worst case.
-  Acceptable. If custom themes ship, add LRU.
+- **Risk: preview cache grows unbounded with many themes or live
+  theme-builder edits.** A module-level `Map` never releases entries
+  on its own, and in-place theme edits mint a fresh content key each
+  time. Mitigated by a `CACHE_CAP` of 128 with oldest-first
+  (insertion-order) eviction. At 160×90 RGBA each canvas is ≈ 56 KB,
+  so the cache is bounded to ≈ 7 MB worst case.
 
 - **Risk: split-button hit-target ambiguity.** Mitigated by
   separator + ≥24 px right zone, and unambiguous icons (`+` left,

--- a/docs/design/slides/slides-mobile.md
+++ b/docs/design/slides/slides-mobile.md
@@ -8,25 +8,29 @@ target-version: 0.4.4
 ## Summary
 
 A touch-driven mobile experience for the slides package, mounted whenever
-the viewport is narrower than 768px. `SlidesView` branches on the existing
-`useIsMobile()` hook and delegates to `MobileSlidesView`, which exposes
-two modes:
+the viewport is narrower than 768px. The owner route (`slides-detail.tsx`)
+and the shared-link route (`shared-document.tsx`) both branch on the
+existing `useIsMobile()` hook and delegate to `MobileSlidesView`, which
+exposes two modes:
 
 - **`mode: 'view'` (read-only, Phase A — v0.4.3).** Paints with a
   standalone `SlideRenderer` and surfaces swipe navigation plus a
   Present-mode entry. Read-only is enforced by *not mounting* the
   editor — no mutation pathway exists.
-- **`mode: 'edit'` (light editing, Phase B — v0.4.4, default).** Replaces
-  the renderer with the full desktop `SlidesEditor` and adds three
-  mobile-specific UI affordances on top: a bottom-sheet text formatting
-  bar, a slide-ops floating action button (`+` / duplicate / delete /
-  change layout), and an undo/redo header pair.
+- **`mode: 'edit'` (light editing, Phase B — v0.4.4).** Replaces
+  the renderer with the full desktop `SlidesEditor` and adds
+  mobile-specific UI affordances: a parent-owned `MobileSlidesToolbar`
+  (`toolbar/mobile-toolbar.tsx`) for text formatting, and an add-slide
+  (`+`) button inside the horizontal `ThumbnailStrip`. Undo/redo and the
+  Present button are owned by the parent `SlidesToolbar` / `SiteHeader`,
+  not by `MobileSlidesView` itself.
 
-`mode` is decided by the outer route (`slides-detail.tsx`): viewers
-without edit permission get `'view'`; everyone else gets `'edit'`. Phase
-A and Phase B share the same Yorkie attachment and the same shell
-chrome (header, canvas-host, footer); only the rendering surface
-swaps.
+`mode` is decided by the route: `slides-detail.tsx` (owner) mounts
+`MobileSlidesView` with `mode="edit"` hardcoded, while
+`shared-document.tsx` (shared link) passes `mode={readOnly ? 'view' :
+'edit'}` — viewers without edit permission get `'view'`, editors get
+`'edit'`. Both modes share the same Yorkie attachment and the same
+canvas-host; only the rendering surface swaps.
 
 Editing — when enabled — is reused intact from desktop. The editor's
 programmatic surface (`enterTextEditing`, `setSelection`,
@@ -43,14 +47,15 @@ programmatic surface (`enterTextEditing`, `setSelection`,
 - Double-tap a text element to enter text edit; mobile virtual keyboard
   appears; `compositionstart`/`compositionend` produce the same Yorkie
   tree edits as desktop.
-- Bottom-sheet shows bold / italic / underline / font-size / color while
-  a text-box editor is active; controls call into
-  `editor.getActiveTextEditor()`'s existing format API.
-- Header gains undo / redo buttons wired to `store.undo()` /
-  `store.redo()`. Always visible (not just during edit) — matches Google
-  Slides mobile.
-- Floating action button on the canvas: `+` adds a slide (default
-  layout), long-press opens duplicate / delete / change-layout.
+- A mobile text-formatting bar (`MobileSlidesToolbar`) shows bold /
+  italic / underline / font-size / color while a text-box editor is
+  active; controls call into `editor.getActiveTextEditor()`'s existing
+  format API.
+- Undo / redo, wired to `store.undo()` / `store.redo()`, live on the
+  parent `SlidesToolbar` (shared with desktop).
+- Add a slide via a `+` button in the horizontal `ThumbnailStrip`
+  (`store.addSlide('blank')`). Duplicate / delete / change-layout are
+  not yet wired on the mobile surface.
 - Read-only viewers (no edit permission, shared-link viewers) get the
   Phase-A `SlideRenderer` path. Read-only is enforced *by not mounting
   the editor*, not by a `readOnly` flag.
@@ -85,9 +90,11 @@ programmatic surface (`enterTextEditing`, `setSelection`,
   editor.
 - Speaker-notes panel on mobile. Notes are not surfaced; reuse on mobile
   waits for Phase C or a notes-aware presenter view.
-- Shared-link read-only flow (`sharing.md`). The viewer is a natural
-  building block, but wiring viewer roles to share tokens is a separate
-  task.
+- ~~Shared-link read-only flow (`sharing.md`).~~ **Shipped.** The
+  shared-link route (`shared-document.tsx`) mounts `MobileSlidesView`
+  with `mode={readOnly ? 'view' : 'edit'}`, so anonymous viewers on a
+  phone get the read-only `SlideRenderer` path and share-link editors
+  get the edit path.
 - URL-stateful slide index. The current slide id is component-local;
   reload returns to the first slide.
 
@@ -95,8 +102,10 @@ programmatic surface (`enterTextEditing`, `setSelection`,
 
 ### Detection and branching
 
-`SlidesView` (`packages/frontend/src/app/slides/slides-view.tsx`)
-branches at the top of its render based on `useIsMobile()`
+The branch lives in the route shells, not in `SlidesView`. Both the
+owner route (`packages/frontend/src/app/slides/slides-detail.tsx`) and
+the shared-link route (`packages/frontend/src/app/shared/shared-document.tsx`)
+branch on `useIsMobile()`
 (`packages/frontend/src/hooks/use-mobile.ts`), which tracks
 `(max-width: 767px)`:
 
@@ -114,40 +123,33 @@ the RAF tick, thumbnail panel, notes panel, editor instance, and style
 tag. The Yorkie `useDocument` attachment lives on the surrounding
 `DocumentProvider`, so the document stays attached across the swap.
 
-`mobileMode` is passed by `slides-detail.tsx`: `'view'` when the user
-lacks edit permission, `'edit'` otherwise (default).
+`mobileMode` is fixed to `'edit'` on `slides-detail.tsx` (the owner
+always has edit access), while `shared-document.tsx` derives it from the
+resolved share-link role: `'view'` for viewers, `'edit'` for editors.
 
 ### MobileSlidesView shell
 
 `packages/frontend/src/app/slides/mobile-slides-view.tsx` owns the
-mobile-side shell, shared between view and edit modes.
+mobile-side canvas surface, shared between view and edit modes.
 
-**DOM structure:**
+**DOM structure.** `MobileSlidesView` renders only two children — a
+`flex: 1` canvas-host and a horizontal `ThumbnailStrip`. The header
+chrome (Back / title / Present) and undo/redo live on the parent
+`SiteHeader` / `SlidesToolbar` in the route shell, not inside this
+component; there is no in-component header or prev/next footer.
 
 ```html
-<div class="mobile-slides">
-  <header>
-    <button aria-label="Back to deck list">‹</button>
-    <button aria-label="Undo">↶</button>      <!-- edit mode only -->
-    <button aria-label="Redo">↷</button>      <!-- edit mode only -->
-    <h1 class="truncate">{title}</h1>
-    <button aria-label="Start presentation">▶</button>
-  </header>
-  <div ref={canvasHostRef} class="canvas-host">
-    <canvas />
-  </div>
-  <footer>
-    <button aria-label="Previous slide">‹</button>
-    <span>{index + 1} / {slides.length}</span>
-    <button aria-label="Next slide">›</button>
-  </footer>
+<div ref={canvasHostRef} class="canvas-host">   <!-- flex: 1 -->
+  <canvas />
+  <!-- edit mode also mounts an absolutely-positioned overlay div -->
 </div>
+<ThumbnailStrip ... />   <!-- horizontal mini-slide strip; tap to jump,
+                              add-slide (+) button in edit mode -->
 ```
 
-The outer container uses `100dvh` (dynamic viewport height) with a
-`100vh` fallback so the iOS Safari address-bar collapse/expand does not
-visually shift the canvas. Header is `≈ 44px`, footer `≈ 28px`,
-`canvas-host` is `flex: 1`.
+The route shell's outer container uses `100dvh` (dynamic viewport
+height) with a `100vh` fallback so the iOS Safari address-bar
+collapse/expand does not visually shift the canvas.
 
 **Yorkie data flow:**
 
@@ -238,8 +240,8 @@ tablets and stylus input get supported as a side-effect.
 | Concern | Handling |
 |---|---|
 | Touch drag fires no move events (iOS Safari) | **Pointer Events migration in Task 1a** — `mouse*` listeners become `pointer*` across `editor.ts`, `thumbnail-panel.ts`, `context-menu.ts`, `layout-picker.ts`. Solved at the source. |
-| iOS swipe-back at screen edge during drag | Cannot be intercepted — documented limitation. FAB and slide-strip navigation are the in-app workaround for users near the edge. |
-| Browser pinch-zoom vs element drag | `touch-action: none` on the canvas-host suppresses both pinch and pan. Slide swipe-nav is gone in edit mode (FAB + strip replace it). |
+| iOS swipe-back at screen edge during drag | Cannot be intercepted — documented limitation. The `ThumbnailStrip` is the in-app navigation workaround for users near the edge. |
+| Browser pinch-zoom vs element drag | `touch-action: none` on the canvas-host suppresses both pinch and pan. Slide swipe-nav is gone in edit mode (the `ThumbnailStrip` replaces it). |
 | Resize handle hit area | The editor renders handles at 8px on desktop. A mobile mode bumps the *hit* radius to 22px (≈ 44px diameter) without changing the visual handle size — done by extending `hit-test.ts`'s `handleHitTest` with a `tolerance` parameter, default 0. |
 | Double-tap zoom (iOS) | `touch-action: manipulation` on the canvas-host disables the 300ms double-tap zoom delay; the editor's double-click → text-edit fires immediately. (Subsumed by `touch-action: none` when we also need to block pinch.) |
 | Long-press system callout (iOS) | The callout is NOT a `contextmenu` event — `oncontextmenu` is a no-op against it. The kill is CSS: `-webkit-touch-callout: none` + `user-select: none` on the canvas-host. (Right-click `oncontextmenu` is still suppressed for desktop edit mode.) |
@@ -251,11 +253,14 @@ drag and long-press-callout were both blocked by the items above.
 Gate decision: option (B), proceed with the Pointer Events migration as
 Task 1a prerequisite.
 
-#### Bottom-sheet text formatting
+#### Mobile text formatting
 
-A new component `MobileTextFormatSheet` mounts at the bottom of the
-mobile shell, slide-up animated when `editor.isTextEditing()` is true.
-It binds to `editor.getActiveTextEditor()`:
+Text formatting shipped as `MobileSlidesToolbar`
+(`packages/frontend/src/app/slides/toolbar/mobile-toolbar.tsx`), owned by
+the parent route shell rather than mounted inside `MobileSlidesView`
+(the standalone `mobile-text-format-sheet.tsx` in the original file plan
+was never created). It surfaces while a text-box editor is active and
+binds to `editor.getActiveTextEditor()`:
 
 ```tsx
 const active = editor.getActiveTextEditor();
@@ -279,35 +284,23 @@ Sheet height ~64px. The canvas-host shrinks while the sheet is visible,
 the editor's `setHostSize` re-derives scale, and the selected text
 element stays in view via a scroll-into-view call.
 
-#### Slide ops FAB
+#### Slide ops (add slide)
 
-Floating action button bottom-right, ~56×56, primary-color circle with
-a `+` glyph. Tap = `store.addSlide(currentLayoutId)`. Long-press opens
-a vertical menu (Radix `Popover` or a hand-rolled list — see
-`context-menu.md` for the project's pattern):
+Slide creation shipped as an `IconPlus` button at the end of the
+horizontal `ThumbnailStrip` (not a bottom-right FAB). Tap calls
+`store.addSlide('blank')`.
 
-- Duplicate slide → `store.duplicateSlide(currentSlideId)`
-- Delete slide → `store.removeSlide(currentSlideId)` + advance to
-  next-or-prev
-- Change layout → opens a sheet of layout thumbnails; tap picks one →
-  `store.applyLayout(currentSlideId, layoutId)`
-
-The "change layout" sheet reuses the layout thumbnail rendering from
-`view/canvas/layout-preview.ts`. Picker UI is mobile-native (2-column
-grid of cards).
+The long-press menu (duplicate / delete / change layout via
+`store.duplicateSlide` / `removeSlide` / `applyLayout`) is **not yet
+wired on mobile** — only add-slide is available. Those ops remain
+available on desktop and are a follow-up for the mobile surface.
 
 #### Undo / redo
 
-Header gains two icon buttons next to the title:
-
-```text
-[‹]  [↶] [↷]  {title…}                  [▶]
-```
-
-Wired to `store.undo()` / `store.redo()`. Buttons disabled when the
-respective stack is empty; subscribed to a `store.onHistoryChange` hook.
-If that hook doesn't exist yet on `YorkieSlidesStore`, it gets added in
-the same PR — the desktop toolbar will benefit too.
+Undo/redo is owned by the parent `SlidesToolbar` (shared with desktop),
+not by `MobileSlidesView`. The planned dedicated `store.onHistoryChange`
+hook was not added — the toolbar drives undo/redo through the existing
+store surface, so no new history-subscription API was needed.
 
 ### Navigation (both modes)
 
@@ -340,14 +333,15 @@ listens for `pointerdown` / `pointermove` / `pointerup`.
   `dx < 0 ? nextSlide() : prevSlide()`.
 - A single tap (no movement) is a no-op in view mode.
 
-**Footer arrow buttons** are an explicit, accessible fallback for
+**ThumbnailStrip taps** are the explicit, accessible fallback for
 screen readers and any environment where the pointer events do not
-classify cleanly. Present in both modes.
+classify cleanly — tapping a thumbnail jumps directly to that slide.
+Present in both modes.
 
-**Present button**: invokes the same `onStartPresentation('current')`
-callback that the desktop view uses. The outer route shell already
-owns presentation mode and the fullscreen-overlay fallback; the mobile
-view is just another trigger.
+**Present button**: lives on the parent route shell (not inside
+`MobileSlidesView`) and invokes the same presentation entry the desktop
+view uses. The route shell already owns presentation mode and the
+fullscreen-overlay fallback; the mobile view is just another trigger.
 
 ### Loader / error states
 
@@ -365,15 +359,16 @@ Reuses the existing `<Loader />` component during `useDocument`'s
 | `packages/slides/src/view/editor/layout-picker.ts` | **Task 1a:** Pointer Events migration (panel hover/click). |
 | `packages/slides/src/view/editor/hit-test.ts` | Add `tolerance` parameter to `handleHitTest` for touch-sized hit areas. |
 | `packages/slides/src/view/editor/text-box-editor.ts` | Expose missing format getters/setters on `SlidesTextBoxEditor` if any are mouse-toolbar-only. |
-| `packages/slides/src/store/store.ts` | Add `onHistoryChange(cb): () => void` to `SlidesStore`. |
-| `packages/slides/src/store/memory.ts` | Implement `onHistoryChange` for `MemSlidesStore`. |
-| `packages/frontend/src/app/slides/yorkie-slides-store.ts` | Implement `onHistoryChange` for `YorkieSlidesStore`. |
-| `packages/frontend/src/app/slides/slides-view.tsx` | Add `useIsMobile()` branch at the top of render; delegate to `MobileSlidesView` when true. |
-| `packages/frontend/src/app/slides/mobile-slides-view.tsx` | Shell + `mode: 'view' \| 'edit'`. `view` mounts `SlideRenderer`; `edit` mounts `SlidesEditor`. Wires bottom-sheet, FAB, undo/redo for edit mode. |
-| `packages/frontend/src/app/slides/mobile-text-format-sheet.tsx` (new) | The bottom-sheet component. |
-| `packages/frontend/src/app/slides/mobile-slide-ops-fab.tsx` (new) | The FAB + long-press menu. |
-| `packages/frontend/src/app/slides/slides-detail.tsx` | Pass `mode` prop to `MobileSlidesView` based on user permission (default `edit`). |
+| `packages/frontend/src/app/slides/slides-detail.tsx` | Add `useIsMobile()` branch; mount `MobileSlidesView` with `mode="edit"` (owner always edits). |
+| `packages/frontend/src/app/shared/shared-document.tsx` | Add `useIsMobile()` branch for the shared-link route; mount `MobileSlidesView` with `mode={readOnly ? 'view' : 'edit'}`. |
+| `packages/frontend/src/app/slides/mobile-slides-view.tsx` | Canvas-host + `ThumbnailStrip`, `mode: 'view' \| 'edit'`. `view` mounts `SlideRenderer`; `edit` mounts `SlidesEditor` and adds the strip's add-slide (`+`) button. |
+| `packages/frontend/src/app/slides/toolbar/mobile-toolbar.tsx` (new) | `MobileSlidesToolbar` — parent-owned text-formatting bar (replaced the planned `mobile-text-format-sheet.tsx`). |
 | `packages/frontend/src/hooks/use-pointer-swipe.ts` (new) | Small hook (~50 lines) encapsulating the pointer classification described above (view mode). Unit-testable. |
+
+The `onHistoryChange` hook on `store.ts` / `memory.ts` /
+`yorkie-slides-store.ts`, and the standalone `mobile-slide-ops-fab.tsx`,
+were dropped: undo/redo and slide-ops live on the parent `SlidesToolbar`
+/ `ThumbnailStrip` and needed no new store surface.
 
 No backend, model, or Yorkie schema changes. The editor's mutation
 surface is unchanged.
@@ -401,13 +396,13 @@ benefit.
   function over synthetic pointer events.
 - **Unit (slides):** existing `SlideRenderer` tests cover correct
   rendering; no new tests needed for renderer reuse.
-- **Component (frontend):** `MobileSlidesView` mount renders the header,
-  footer, and a canvas; clicking the footer next button advances the
-  slide index by 1; the back and present buttons fire their respective
-  callbacks. Separate cases assert `mode: 'view'` does not mount the
-  editor and `mode: 'edit'` does.
+- **Component (frontend):** `MobileSlidesView` mount renders the
+  canvas-host and `ThumbnailStrip`; tapping a thumbnail advances the
+  slide index; the add-slide (`+`) button appears only in edit mode.
+  Separate cases assert `mode: 'view'` does not mount the editor and
+  `mode: 'edit'` does.
 - **Visual (`pnpm verify:browser:docker`):** fixtures at 360×640,
-  390×844, and 430×932 viewports verify header + canvas + footer layout
+  390×844, and 430×932 viewports verify canvas + `ThumbnailStrip` layout
   and that the first slide paints in both modes.
 - **Manual smoke:** `pnpm dev` → DevTools mobile emulation; verify
   swipe navigation (view), drag + double-tap-edit (edit), Present
@@ -423,7 +418,7 @@ benefit.
 | Mobile IME `compositionstart`/`end` ordering differs from desktop; existing `text-box-editor.ts` IME paths may misbehave. | Tested in spike on real iOS and Android. Patches go in `text-box-editor.ts` since desktop also benefits from correctness. |
 | Adding `mode: 'edit' \| 'view'` to `MobileSlidesView` mid-flight while a permission system is being designed elsewhere. | The prop has only two values and a `'edit'` default; downstream permission wiring can land independently. |
 | Bottom-sheet covers the selected text-box when it sits near slide bottom. | Editor's `setHostSize` already supports dynamic host size; mobile shell shrinks the canvas-host while the sheet is open and scrolls the selection into view. |
-| Undo/redo button state needs a `store.onHistoryChange` hook we don't have yet. | One method to add; mirrors the existing `onSelectionChange` pattern in `SlidesEditor`. Desktop toolbar benefits too. |
+| Undo/redo button state needs a `store.onHistoryChange` hook we don't have yet. | Resolved: undo/redo shipped on the parent `SlidesToolbar` using the existing store surface, so no new `onHistoryChange` hook was added. |
 | Spike found > 5 internal editor changes (Pointer Events) — strict gate breach. | Resolved at gate time: option (B). The "5 changes" rule was a heuristic against a state-machine rewrite; the Pointer Events rename is mechanical, no state change, and desktop gets pen tablet support as a bonus. Option (A) (mobile-only editor over `SlidesStore`) is still the fallback if Task 1a smoke surprises us. |
 | Two `computeFitSize` copies (desktop, presenter) become three. | Accepted; the math is ~10 lines and the slides package must stay frontend-agnostic. Revisit if a fourth caller appears. |
 | Pointer-event classification misfires on Android Chrome where horizontal scroll containers compete for the swipe gesture. | The mobile view has no scrollable ancestors inside the canvas host; outer container is `overflow: hidden`. Footer arrows are the fallback. |

--- a/docs/design/slides/slides-multi-select-resize.md
+++ b/docs/design/slides/slides-multi-select-resize.md
@@ -7,22 +7,24 @@ target-version: 0.4.5
 
 ## Summary
 
-Make the eight resize handles behave when more than one element is
-selected. The overlay already draws those handles on the combined
-axis-aligned bbox of the selection, but `SlidesEditorImpl.startResize`
-bails out for `selectedIds.length !== 1`. (Multi-rotate is already
-wired in `startRotate` via the `isMulti` branch in `buildLiveState`
-and the move-pattern `paintMoveGhost`; this design extracts the
-rotation math to a pure helper for symmetry but leaves the runtime
-behavior alone.) This proposal wires the resize gesture end-to-end
-with Google Slides / PowerPoint parity:
-bbox-relative per-element transforms, type-dispatched handling for
-connectors and tables, multi-rotation around the bbox centre, Shift
-modifiers preserved, and one batched undo step per gesture. While
-we're here we also unify the live-preview paint: every resize / rotate
-(single and multi) renders the committed original at full opacity plus
-a translucent `GHOST_ALPHA` ghost at the proposed frame, matching the
-move drag and single-table-resize patterns; the in-place
+The eight resize handles behave when more than one element is
+selected. This shipped in v0.4.5. The overlay draws those handles on
+the combined axis-aligned bbox of the selection, and
+`SlidesEditorImpl.startResize` no longer bails out for
+`selectedIds.length !== 1` — it routes multi-selections through the
+pure `resizeMultiFrames` helper. (Multi-rotate is wired in
+`startRotate` via the `isMulti` branch in `buildLiveState` and the
+move-pattern ghost paint; extracting the rotation math into a pure
+`rotateMultiFrames` helper for symmetry remains deferred — see §8 — so
+multi-rotate runs through the existing inline math with no runtime
+change.) The resize gesture is wired end-to-end with Google Slides /
+PowerPoint parity: bbox-relative per-element transforms,
+type-dispatched handling for connectors and tables, multi-rotation
+around the bbox centre, Shift modifiers preserved, and one batched undo
+step per gesture. The live-preview paint is also unified: every resize
+/ rotate (single and multi) renders the committed original at full
+opacity plus a translucent `GHOST_ALPHA` ghost at the proposed frame,
+matching the move drag and single-table-resize patterns; the in-place
 `paintLiveScoped` path is retired for these gestures.
 
 ### Goals
@@ -335,10 +337,10 @@ The slides editor today has three live-preview paint paths:
 | `paintTableResizeGhost` (single table resize) | full opacity | `GHOST_ALPHA` table at new frame (cells scaled) | ghost ("active size now") |
 | `paintLiveScoped` (single non-table resize, current code) | hidden — replaced in synthetic slide | n/a | replaced element |
 
-The third path mutates the visible slide during the gesture, which
-diverges from the other two. This design retires `paintLiveScoped`
-for the resize / rotate gestures and routes every non-table resize
-(single and multi) through one shared helper:
+The third path mutated the visible slide during the gesture, which
+diverged from the other two. `paintLiveScoped` is now retired for the
+resize / rotate gestures; every non-table resize (single and multi)
+routes through one shared helper:
 
 ```ts
 private paintGhostPreview(
@@ -363,14 +365,14 @@ by a new function:
   follow the cursor for direct manipulation, so handles track the
   ghost.
 
-`paintMoveGhost` is renamed to `paintGhostPreview` and its existing
-single caller (the move drag) is updated. `paintLiveScoped` and its
-module-private helper `patchElementFrames` are deleted outright: this
+`paintMoveGhost` was renamed to `paintGhostPreview` and its single
+caller (the move drag) updated. `paintLiveScoped` and its
+module-private helper `patchElementFrames` were deleted outright: this
 design assumed connector-endpoint drag and adjustment-handle drag
-depended on `paintLiveScoped`, but inspection shows both call
-`this.renderer.forceRender(...)` directly. Once single-resize moves
-off `paintLiveScoped` (Task 3) the function has no remaining callers
-and is removed. `paintTableResizeGhost` stays for single-table resize
+depended on `paintLiveScoped`, but both call
+`this.renderer.forceRender(...)` directly. Once single-resize moved
+off `paintLiveScoped` the function had no remaining callers and was
+removed. `paintTableResizeGhost` stays for single-table resize
 because of its cell-width / row-height scaling; it already follows
 the same handle-on-ghost convention.
 

--- a/docs/design/slides/slides-native-undo.md
+++ b/docs/design/slides/slides-native-undo.md
@@ -7,18 +7,20 @@ target-version: 0.4.7
 
 ## Summary
 
-`YorkieSlidesStore` is the only document store that rolls its own
-snapshot-based undo/redo. `batch()` pushes a full `SlidesDocument`
-snapshot onto an `undoStack`, and `undo()` restores it by reconciling
-the live Yorkie root against the snapshot. Sheets
-(`spreadsheet/yorkie-store.ts`) and Docs (`docs/yorkie-doc-store.ts`)
-both use Yorkie-native `doc.history.undo()/redo()`, which apply the
-*reverse operations* of the last change and touch only what changed.
+**Shipped.** `YorkieSlidesStore` uses Yorkie-native
+`doc.history.undo()/redo()`, matching Sheets
+(`spreadsheet/yorkie-store.ts`) and Docs (`docs/yorkie-doc-store.ts`):
+undo/redo apply the *reverse operations* of the last local change and
+touch only what changed. The snapshot machinery (`undoStack`,
+`redoStack`, `replaceRoot`, and the `reconcile*` helpers) has been
+removed from the Yorkie store; only `MemSlidesStore` (the non-Yorkie
+fallback) still keeps snapshot undo.
 
-This document specifies migrating Slides to `doc.history`, matching
-Docs/Sheets, and removing the snapshot machinery (`undoStack`,
-`redoStack`, `replaceRoot`, and the `reconcile*` helpers) once parity
-is proven.
+Previously `YorkieSlidesStore` rolled its own snapshot-based undo/redo:
+`batch()` pushed a full `SlidesDocument` snapshot onto an `undoStack`,
+and `undo()` restored it by reconciling the live Yorkie root against the
+snapshot. This document records the migration to `doc.history` and the
+removal of that snapshot machinery.
 
 The snapshot approach caused the 2026-06-20 node-OOM incident:
 `replaceRoot` originally rewrote the whole root, tombstoning the entire
@@ -31,9 +33,9 @@ undo removes this whole problem class by construction.
 
 ## Goals / Non-Goals
 
-- **Goal**: Replace snapshot undo/redo in `YorkieSlidesStore` with
-  `doc.history`. Remove `undoStack` / `redoStack` / `replaceRoot` and
-  the reconcile helpers once native parity is green.
+- **Goal** (done): Replace snapshot undo/redo in `YorkieSlidesStore`
+  with `doc.history`, and remove `undoStack` / `redoStack` /
+  `replaceRoot` and the reconcile helpers.
 - **Goal**: Preserve the public `SlidesStore` contract — `batch(fn)`,
   `undo()`, `redo()`, `canUndo()`, `canRedo()` — unchanged for callers.
   In particular **one `batch()` call = one undo unit** must hold (the
@@ -222,11 +224,13 @@ the snapshot path did.
 The undo floor must be captured **after** the deck-seed step. The seed
 that opens a new deck with one slide runs through `batch()` (one undo
 unit) after construction; whoever owns that seed (the SlidesDetail
-wrapper) is responsible for the floor being correct. Today the store is
-constructed against an already-seeded doc in tests via
-`ensureSlidesRoot`, so capturing the floor in the constructor matches
-the Docs store. **Verification point**: a fresh deck cannot be undone
-back to zero slides (port a floor test from the Docs suite).
+wrapper) is responsible for the floor being correct. The store is
+constructed against an already-seeded doc via `ensureSlidesRoot`, so
+capturing the floor in the constructor matches the Docs store. For a
+seed that runs *after* construction, the store exposes
+`markUndoBaseline()`, which re-captures the floor at the current stack
+depth (mirrors how `YorkieDocStore` re-bases its floor in
+`setDocument`). A fresh deck cannot be undone back to zero slides.
 
 ### Presence and selection
 
@@ -243,7 +247,7 @@ back to zero slides (port a floor test from the Docs suite).
 
 ### Removals
 
-Once native parity is green, delete:
+With native parity green, these were deleted from `YorkieSlidesStore`:
 
 - `undoStack`, `redoStack` fields and all reads/writes.
 - `replaceRoot()`.
@@ -265,18 +269,21 @@ snapshot undo produce the same observable `read()`.
 
 ## Test Strategy
 
-- **Keep** `yorkie-slides-undo-churn.test.ts` as the regression guard.
-  Native undo should also be ~zero churn (reverse ops touch only the
-  changed nodes). Re-baseline the asserted `getGarbageLen` deltas if the
-  native numbers differ from the reconcile numbers.
-- **Keep** `yorkie-slides-store.test.ts` "one batch = one undo entry" —
-  this is the headline acceptance test for the grouping refactor.
-- **Add** a multi-element-drag grouping test: one batch with N
-  `updateElementFrame` calls → exactly one undo reverts all N.
-- **Add** an undo-floor test ported from the Docs suite: repeated undo
-  cannot drop below the seeded deck.
-- **Keep** the theme test "addTheme + applyTheme are batched into one
-  undo entry" and the autofit "survives undo/redo" equivalence test.
+The native-undo tests live under the
+`YorkieSlidesStore — undo/redo (Yorkie-native doc.history)` describe
+block in `yorkie-slides-store.test.ts`:
+
+- `yorkie-slides-undo-churn.test.ts` is the regression guard. Native
+  undo is also ~zero churn (reverse ops touch only the changed nodes).
+- "one batch = one undo entry" — the headline acceptance test for the
+  grouping refactor.
+- "groups a multi-element drag into a single undo unit" — one batch with
+  N `updateElementFrame` calls → exactly one undo reverts all N.
+- "cannot undo past the seeded initial state (undo floor)" and
+  "markUndoBaseline protects a post-construction deck seed" — the
+  floor tests.
+- The theme test "addTheme + applyTheme are batched into one undo entry"
+  and the autofit "survives undo/redo" equivalence test.
 - `pnpm verify:fast`; manual smoke: multi-element drag undo, undo across
   a concurrent peer edit (two-client), undo/redo of add/remove element
   with selection.

--- a/docs/design/slides/slides-pdf-export.md
+++ b/docs/design/slides/slides-pdf-export.md
@@ -20,9 +20,12 @@ large, high-risk effort.
 Instead, the shipped P0 exporter renders each slide to a high-DPI
 offscreen canvas with the *existing* `drawSlide()` pipeline — which
 already paints every element type with full theme resolution and
-effects — then embeds one bitmap per page into a `pdf-lib` document
-sized 13.333" × 7.5" (16:9). This is pixel-identical to the on-screen
-editor for minimal effort.
+effects — then embeds one bitmap per page into a `pdf-lib` document.
+The page **width** is fixed at 13.333" (960 pt); the **height** follows
+the deck's aspect ratio (`deckSlideHeight(doc.meta) / SLIDE_WIDTH ×
+960 pt`), so the default 16:9 deck is 13.333" × 7.5" and a 4:3 deck is
+13.333" × 10". This is pixel-identical to the on-screen editor for
+minimal effort.
 
 Trade-off accepted: PDF text is not selectable and files are larger
 than vector. A future P1 can overlay vector text from the docs
@@ -34,8 +37,9 @@ P0 module is structured so that overlay can be added without rework.
 ### Goals (P0)
 
 - Export the full presentation to a multi-page PDF, **one slide per
-  page**, page size 13.333" × 7.5" (960 × 540 pt) for the default 16:9
-  deck.
+  page**, page width fixed at 13.333" (960 pt) and height derived from
+  the deck aspect ratio (13.333" × 7.5" / 960 × 540 pt for the default
+  16:9 deck).
 - Pixel fidelity with the editor: reuse `drawSlide()` so shapes,
   images (crop/recolor), tables, connectors, groups, effects, theme
   colors, and background images all render exactly as on screen.
@@ -66,20 +70,20 @@ P0 module is structured so that overlay can be added without rework.
 
 ```
 exportSlidesPdf(doc, opts)                      packages/slides/src/export/pdf.ts
-  ├─ resolve page size from doc (16:9 → 960×540 pt)
+  ├─ pageWidth = 960 pt (13.333"); pageHeight = deckSlideHeight(meta)/SLIDE_WIDTH × 960
   ├─ pdf = await PDFDocument.create()
-  ├─ await ensureFontsLoaded(doc)               // all used families+weights → document.fonts
+  ├─ await document.fonts.ready                 // defensive only; caller pre-loads families
   └─ for each slide:
        ├─ canvas = makeCanvas(W*scale, H*scale)
        ├─ await renderSlideToCanvas(canvas, slide, doc, scale)   // render-and-wait loop
        ├─ blob/bytes = canvas → PNG (or JPEG q≈0.92)
        ├─ img = await pdf.embedPng(bytes)
-       ├─ page = pdf.addPage([960, 540])
-       └─ page.drawImage(img, { x:0, y:0, width:960, height:540 })
+       ├─ page = pdf.addPage([pageWidth, pageHeight])
+       └─ page.drawImage(img, { x:0, y:0, width:pageWidth, height:pageHeight })
   └─ return await pdf.save()  // Uint8Array → Blob
 
 exportSlidesPdfAndDownload(doc, title, onProgress?)   packages/frontend/src/app/slides/pdf-actions.ts
-  ├─ families = collectFontFamilies(doc); ensureFontLink + await document.fonts.load
+  ├─ families = collectFontFamilies(doc); ensureFontLink + await document.fonts.load  // caller-owned font prep
   ├─ bytes = await exportSlidesPdf(doc, { imageFetcher: docsImageFetcher, title, onProgress })
   ├─ blob = new Blob([bytes], { type: 'application/pdf' })
   └─ downloadBlob(blob, safeFilename(title, 'pdf'))   // reuse docs export-utils
@@ -125,14 +129,18 @@ the exported PDF. `placeholderRef` is the sole render-path consumer of
 the hint, and committed placeholder text bakes its own typography into
 the blocks, so dropping the ref only suppresses the hint.
 
-Fonts are handled once up-front, not per slide: scan all slide text
-blocks for `fontFamily` (incl. list-marker `buFont`) plus each theme's
-heading/body fonts, then
-`await Promise.all(families.map(f => document.fonts.load(\`16px "${f}"\`)))`.
-This mirrors docs' `ensureCanvasFontsLoaded`. Slides already injects
-Google-Fonts `<link>`s lazily via `ensureFontLink`; the exporter must
-call that for any family not yet linked before awaiting
-`document.fonts.load`.
+Fonts are handled once up-front, not per slide — and font preparation is
+**caller-owned**, because the slides package can't reach the app's font
+CSS. The slides package exposes `collectFontFamilies(doc)`, which scans
+all slide text blocks for `fontFamily` (incl. list-marker `buFont`) plus
+each theme's heading/body fonts. The frontend wrapper
+`exportSlidesPdfAndDownload` calls it, injects a Google-Fonts `<link>`
+for any family not yet linked via `ensureFontLink`, then
+`await Promise.all(families.map(f => document.fonts.load(\`16px "${f}"\`)))`
+(mirroring docs' `ensureCanvasFontsLoaded`) — all **before** invoking
+`exportSlidesPdf`. `exportSlidesPdf` itself only defensively awaits
+`document.fonts.ready`; it cannot initiate lazy font CSS, so a direct
+caller of the public API must perform this preparation itself.
 
 ### Canvas + DPI
 
@@ -145,8 +153,10 @@ call that for any family not yet linked before awaiting
   `setTransform(scale,0,0,scale,0,0)` internally (same as
   `presenter.ts` / `layout-preview.ts`), so logical coords stay
   1920×1080 while the bitmap is high-res.
-- Page is always 960 × 540 pt; `drawImage` scales the bitmap to fill,
-  so `scale` only affects sharpness/size, never geometry.
+- Page width is always 960 pt (13.333"); page height is
+  `deckSlideHeight(doc.meta) / SLIDE_WIDTH × 960` pt (540 pt for the
+  default 16:9 deck, 720 pt for 4:3). `drawImage` scales the bitmap to
+  fill, so `scale` only affects sharpness/size, never geometry.
 
 ### Encoding choice
 
@@ -190,7 +200,8 @@ seconds), reports progress via the shared docs export toast
 - Unit: font scanner enumerates the expected families from a deck.
 - Integration: `exportSlidesPdf` on a small fixture deck returns a
   valid PDF (`PDFDocument.load` round-trips), page count == slide
-  count, page size == 960 × 540 pt.
+  count, page width == 960 pt with height matching the deck aspect
+  (540 pt for the default 16:9 fixture).
 
 ## Risks and Mitigation
 

--- a/docs/design/slides/slides-pdf-export.md
+++ b/docs/design/slides/slides-pdf-export.md
@@ -9,20 +9,20 @@ target-version: 0.5.0
 
 ## Summary
 
-Slides has **no PDF export today**. The `slides/slides.md` design doc
-claims "PDF export reuses the docs PDF pipeline," but that is intent
-only — no code exists, and the docs pipeline (`PdfExporter` /
-`PdfPainter`) is built for paginated rich text + tables + images, not
-for the free-position element model that Slides uses (126 `ShapeKind`
-values, connectors, freeform paths, effects, rotations, groups).
+Slides ships a **raster PDF exporter**
+(`packages/slides/src/export/pdf.ts`). The docs pipeline (`PdfExporter`
+/ `PdfPainter`) is built for paginated rich text + tables + images, not
+for the free-position element model that Slides uses (100+ `ShapeKind`
+values, connectors, freeform paths, effects, rotations, groups), so
+rebuilding a vector painter for every slide element type would be a
+large, high-risk effort.
 
-Rebuilding a vector painter for every slide element type is a large,
-high-risk effort. Instead, P0 ships a **raster exporter**: render each
-slide to a high-DPI offscreen canvas with the *existing* `drawSlide()`
-pipeline — which already paints every element type with full theme
-resolution and effects — then embed one bitmap per page into a
-`pdf-lib` document sized 13.333" × 7.5" (16:9). This is pixel-identical
-to the on-screen editor for minimal effort.
+Instead, the shipped P0 exporter renders each slide to a high-DPI
+offscreen canvas with the *existing* `drawSlide()` pipeline — which
+already paints every element type with full theme resolution and
+effects — then embeds one bitmap per page into a `pdf-lib` document
+sized 13.333" × 7.5" (16:9). This is pixel-identical to the on-screen
+editor for minimal effort.
 
 Trade-off accepted: PDF text is not selectable and files are larger
 than vector. A future P1 can overlay vector text from the docs
@@ -78,11 +78,17 @@ exportSlidesPdf(doc, opts)                      packages/slides/src/export/pdf.t
        └─ page.drawImage(img, { x:0, y:0, width:960, height:540 })
   └─ return await pdf.save()  // Uint8Array → Blob
 
-exportPdfAndDownload(doc, title)                packages/frontend/src/app/slides/pdf-actions.ts
-  ├─ const { exportSlidesPdf } = await import('@wafflebase/slides/export')  // dynamic
-  ├─ blob = new Blob([await exportSlidesPdf(doc, ...)], { type: 'application/pdf' })
+exportSlidesPdfAndDownload(doc, title, onProgress?)   packages/frontend/src/app/slides/pdf-actions.ts
+  ├─ families = collectFontFamilies(doc); ensureFontLink + await document.fonts.load
+  ├─ bytes = await exportSlidesPdf(doc, { imageFetcher: docsImageFetcher, title, onProgress })
+  ├─ blob = new Blob([bytes], { type: 'application/pdf' })
   └─ downloadBlob(blob, safeFilename(title, 'pdf'))   // reuse docs export-utils
 ```
+
+`pdf-lib` is dynamic-imported *inside* `exportSlidesPdf` (not at the
+frontend call site), so it stays out of the editor bundle until an
+export actually runs; `exportSlidesPdf` / `collectFontFamilies` are
+re-exported from the main `@wafflebase/slides` entry.
 
 ### The core problem: render-and-wait
 
@@ -150,28 +156,30 @@ file size. `pdf-lib` supports both via `embedPng` / `embedJpg`.
 
 ### Module / export surface
 
-- New `packages/slides/src/export/pdf.ts` →
-  `exportSlidesPdf(doc: SlidesDocument, opts?: { scale?: number;
-  format?: 'png' | 'jpeg'; metadata?: { title?: string } }):
-  Promise<Uint8Array>`.
-- Add a `@wafflebase/slides/export` subpath export (or fold into the
-  existing public entry, lazily) so the frontend can dynamic-import it
-  without pulling the editor.
-- `pdf-lib` is already a dependency of `@wafflebase/docs`; add it to
-  `@wafflebase/slides` `package.json`.
+- `packages/slides/src/export/pdf.ts` →
+  `exportSlidesPdf(doc: SlidesDocument, opts?: ExportSlidesPdfOptions):
+  Promise<Uint8Array>`, where `ExportSlidesPdfOptions` carries `scale?`,
+  `format?: 'png' | 'jpeg'`, `quality?`, `imageFetcher?`,
+  `assetTimeoutMs?`, `title?`, and `onProgress?`. `exportSlidesPdf`,
+  `collectFontFamilies`, and the `ExportSlidesPdfOptions` /
+  `SlidesImageFetcher` types are re-exported from the main
+  `@wafflebase/slides` entry (no separate subpath); the module is
+  browser-only (DOM `Image` / `OffscreenCanvas` / `document.fonts`).
+- `pdf-lib` is listed in `@wafflebase/slides` `package.json` and is
+  dynamic-imported inside `exportSlidesPdf`.
 - Reuse `downloadBlob` / `safeFilename` from
   `frontend/src/app/docs/export-utils.ts` (consider promoting them to
   a shared frontend util; not required for P0).
 
 ### UI wiring
 
-Add an export control to the Slides toolbar right-side globals
-(`packages/frontend/src/app/slides/toolbar/`), next to Present — a
-small dropdown ("Export → PDF") matching the docs
-`docs-formatting-toolbar.tsx` pattern. Click handler calls
-`exportPdfAndDownload(store.doc, documentTitle)`. Show a busy/spinner
-state while rendering (large decks take a few seconds) and a toast on
-failure.
+The export control ships as a header **Export** menu
+(`packages/frontend/src/app/slides/slides-export-button.tsx`) offering
+PDF (`.pdf`) and PPTX (`.pptx`) items. The PDF item calls
+`exportSlidesPdfAndDownload(store.doc, documentTitle, onProgress)`. It
+shows a busy/spinner state while rendering (large decks take a few
+seconds), reports progress via the shared docs export toast
+(`updateExportToast`), and surfaces failures.
 
 ### Testing
 
@@ -193,6 +201,6 @@ failure.
 | A broken/slow image URL hangs export | Per-slide timeout failsafe; render with placeholder (same as editor's `isImageFailed` path). |
 | Fonts render in fallback if not loaded before snapshot | Up-front `ensureFontLink` + `document.fonts.load` for every used family/weight; await before any slide render. |
 | `OffscreenCanvas` unavailable in some browsers/tests | Fall back to detached `<canvas>`; tests use the existing `FakeOffscreenCanvas` shim. |
-| Cross-origin images taint the canvas → `toBlob` throws | Images already load same-origin/with credentials via the app's image pipeline; for external srcs set `crossOrigin='anonymous'` in `getOrLoadImage` and fall back to placeholder if it taints. |
+| Cross-origin images taint the canvas → `toBlob` throws | The exporter fetches each image's bytes (with credentials, via the injected `imageFetcher` — the frontend passes `docsImageFetcher`) into a same-origin object URL, clones each slide with the rewritten srcs, and renders the clone; images whose bytes cannot be fetched fall back to a blank 1×1 PNG. The editor's slides and shared image cache are never mutated. |
 | Animations/transitions not represented | Non-goal for P0; export the resting rendered state. |
 ```

--- a/docs/design/slides/slides-pptx-export.md
+++ b/docs/design/slides/slides-pptx-export.md
@@ -17,9 +17,13 @@ command wraps it, completing the Slides CLI's parity with the Docs CLI
 
 The fidelity target is **full round-trip**: every element type, theme,
 master, layout, effect, animation, and transition the importer reads is
-written back. Success is defined by a **model-equivalence round-trip** —
+written back — with the single exception of `ChartElement`, whose PPTX
+serialization is deferred (see Non-Goals; the dispatch in
+`packages/slides/src/export/pptx/group.ts` skips `chart` elements). Success
+is defined by a **model-equivalence round-trip** —
 `import(.pptx) → export → re-import` yields a `SlidesDocument` that is
-deep-equal to the first import under a defined normalization (§6).
+deep-equal to the first import under a defined normalization (§6), over
+fixtures that contain no charts.
 
 **Status:** Shipped. The exporter lives in
 `packages/slides/src/export/pptx/` (the 20 modules below), is re-exported
@@ -55,6 +59,11 @@ export` CLI command; the round-trip and per-module tests live in
   job).
 - Exporting fields the importer never reads (no new model data is
   invented to satisfy OOXML completeness).
+- Chart round-trip. `ChartElement` is **not** serialized to PPTX; the
+  `chart` case in `packages/slides/src/export/pptx/group.ts` emits nothing
+  so a chart is silently dropped on export (import + render already ship —
+  see `docs/design/slides/slides-charts.md`). PPTX chart writing is a later
+  phase.
 - A separate PDF export (tracked separately; PDF needs Canvas raster).
 - Editing/streaming `.pptx` in place — export always writes a fresh deck.
 - Image *upload* — images already in the deck (`data:` URLs or server

--- a/docs/design/slides/slides-pptx-export.md
+++ b/docs/design/slides/slides-pptx-export.md
@@ -21,6 +21,12 @@ written back. Success is defined by a **model-equivalence round-trip** —
 `import(.pptx) → export → re-import` yields a `SlidesDocument` that is
 deep-equal to the first import under a defined normalization (§6).
 
+**Status:** Shipped. The exporter lives in
+`packages/slides/src/export/pptx/` (the 20 modules below), is re-exported
+from `packages/slides/src/node.ts`, and backs the `wafflebase slides
+export` CLI command; the round-trip and per-module tests live in
+`packages/slides/test/export/pptx/`.
+
 ## Goals / Non-Goals
 
 ### Goals
@@ -59,7 +65,7 @@ deep-equal to the first import under a defined normalization (§6).
 
 ### 1. Package Structure
 
-New directory `packages/slides/src/export/pptx/`, mirroring the
+The directory `packages/slides/src/export/pptx/` mirrors the
 importer's module split (so each importer module is the reference spec
 for its inverse). Architecture follows the docs `DocxExporter`:
 string-interpolated XML + `jszip`, zero DOM/Canvas.
@@ -87,8 +93,9 @@ presentation.ts ppt/presentation.xml (slide size, slide/master id lists)
 templates.ts    [Content_Types].xml, _rels/.rels boilerplate builders
 ```
 
-Target ≈ 2,000–3,000 LOC of source plus tests. Module isolation keeps
-each file reviewable and independently testable.
+Roughly 2,000–3,000 LOC of source plus tests. Module isolation keeps
+each file reviewable and independently testable; each module ships with
+its own unit test under `packages/slides/test/export/pptx/`.
 
 ### 2. Part / Relationship Assembly (`zip.ts`)
 
@@ -221,23 +228,24 @@ Mirrors `docs export`:
 - `schema/registry.ts` — `slides.export` entry (`read-only`; file write
   is local), aliases `slide.export`/`deck.export`.
 - `skills/slides-export-pptx.md` + SKILL.md index row.
-- `docs/design/cli.md` — add `slides export` to the command tree and
-  schema tables; drop the "PPTX export has no engine" deferral note.
+- `docs/design/cli.md` — documents `slides export` in the command tree and
+  schema tables (the "PPTX export has no engine" deferral note is gone).
 
 ### 8. Public Surface
 
 - `packages/slides/src/export/pptx/index.ts` exports `exportPptx` +
   `ExportPptxOptions`.
 - `packages/slides/src/node.ts` re-exports both (DOM-free audit per the
-  file's existing contract). The browser entry (`src/index.ts`)
-  re-exports them too for the in-app "Download as .pptx" path (wiring
-  the editor button is out of scope here but the API is ready).
+  file's existing contract). The browser entry (`packages/slides/src/index.ts`)
+  re-exports them too for the in-app "Download as .pptx" path; the editor
+  button is wired via `packages/frontend/src/app/slides/slides-export-button.tsx`
+  and `packages/frontend/src/app/slides/pptx-actions.ts`.
 
 ## Risks and Mitigation
 
 | Risk | Mitigation |
 |------|-----------|
-| Single-PR scope is large (~2–3k LOC + tests) | Strict module isolation (§1); each element module lands with its own unit test; round-trip fixtures gate the whole. Reviewable file-by-file. |
+| Large surface (~2–3k LOC + tests) | Strict module isolation (§1); each element module ships with its own unit test; round-trip fixtures gate the whole. Reviewable file-by-file. |
 | 100% model equivalence is impossible where the importer is lossy | Define success as deep-equal on a normalized projection (§6); document every excluded field in code and the spec. |
 | Generated ids defeat naive deep-equal | `normalize()` strips ids and compares references structurally. |
 | Layout/theme round-trip instability (importer maps OOXML→built-in ids) | Emit `type`/`matchingName` so the importer re-derives the same id; covered by the round-trip test. |

--- a/docs/design/slides/slides-presentation-mode.md
+++ b/docs/design/slides/slides-presentation-mode.md
@@ -77,8 +77,8 @@ slides package and a thin React shell in the frontend, matching how
 | `packages/slides/src/view/present/index.ts` | Re-export. |
 | `packages/slides/src/index.ts` | Add `export { startPresenter, type Presenter, type PresenterOptions } from './view/present';`. |
 | `packages/frontend/src/app/slides/slides-presentation-mode.tsx` | React shell. Mounts a portal `<div>`, calls `startPresenter`, forwards `store` snapshots into `presenter.setDocument(...)`, cleans up on unmount. |
-| `packages/frontend/src/app/slides/slides-view.tsx` | Wires `onStartPresentation` to local state (`presentingFrom: 'current' \| 'first' \| null`) and conditionally mounts `<SlidesPresentationMode />`. |
-| `packages/frontend/src/app/slides/slides-detail.tsx` | Adds the "Present" split-button to the header chrome. |
+| `packages/frontend/src/app/slides/slides-view.tsx` | Declares the `onStartPresentation` prop and forwards it into the editor via a ref. |
+| `packages/frontend/src/app/slides/slides-detail.tsx` | Owns the `presentingFrom: 'current' \| 'first' \| null` state, conditionally mounts `<SlidesPresentationMode />`, and adds the "Present" split-button to the header chrome. |
 
 ### API surface (slides package)
 
@@ -226,7 +226,7 @@ continue to work and are already documented in
 
 ### Testing
 
-Vitest + jsdom in `packages/slides/src/view/present/presenter.test.ts`:
+Vitest + jsdom in `packages/slides/test/view/present/presenter.test.ts`:
 
 - Keyboard navigation maps each key to the expected next slide ID
   (or end-screen state) on a fixture deck with three slides.
@@ -243,7 +243,7 @@ Vitest + jsdom in `packages/slides/src/view/present/presenter.test.ts`:
 No colocated React-shell test — the frontend package's test runner
 (Node `--test` + experimental strip-types) doesn't support JSX, and
 no existing slides React component is unit-tested. The presenter's
-50 unit tests in `packages/slides/src/view/present/presenter.test.ts`
+unit tests in `packages/slides/test/view/present/presenter.test.ts`
 cover the framework-free half; the shell's mount / unmount lifecycle
 is exercised by the manual smoke in Task 10.2 of the implementation
 plan.

--- a/docs/design/slides/slides-ruler.md
+++ b/docs/design/slides/slides-ruler.md
@@ -363,14 +363,16 @@ affordances.
 ### Phasing
 
 The feature landed across six PRs, each independently demoable. All
-six are shipped; the table below is the historical rollout record.
+six are shipped, except that P4's in-flight peer-preview broadcast
+remains a follow-up (see "Presence"); the table below is the
+historical rollout record.
 
 | Phase | Scope | Verification |
 | --- | --- | --- |
 | P1. Extract shared core | Move tick / unit code from `packages/docs/src/view/ruler.ts` into `view/ruler/tick-renderer.ts` and `view/ruler/unit.ts`. `pxPerUnit` becomes a parameter. Docs behavior unchanged. | `pnpm verify:fast`, docs ruler visual smoke |
 | P2. Slides ruler display | `SlidesRuler` controller, H/V canvases, corner DOM, zoom + scroll + unit rendering. No guide code yet. | `pnpm verify:fast`, browser smoke at zoom 0.5 / 1 / 2 |
 | P3. Guides data + render | `Guide` type, store API, `MemSlidesStore` + Yorkie schema + lazy init. Guides paint into the overlay layer. No interactions. | Unit tests for store CRUD, integration test for Mem vs Yorkie equivalence and concurrent add/remove convergence |
-| P4. Guide interactions | Ruler drag-out, guide drag/move/delete, presence preview, ruler markers, context menu. | Interaction tests (drag sequences), two-user presence test |
+| P4. Guide interactions | Ruler drag-out, guide drag/move/delete, local guide preview, ruler markers, context menu. Peer-preview broadcast of the in-flight drag is deferred (see "Presence"); only committed guides sync. | Interaction tests (drag sequences), two-user committed-guide convergence test |
 | P5. Snap integration | Add `'guide'` kind, priority resolution, hit-snap visual emphasis. | Snap-priority unit tests, nudge-no-snap test |
 | P6. Read-only mounts + polish | `readOnly` branch suppresses listeners, presentation-mode and PDF skip guides. Design doc finalized. | Read-only mount tests, `pnpm verify:browser:docker` |
 

--- a/docs/design/slides/slides-ruler.md
+++ b/docs/design/slides/slides-ruler.md
@@ -7,17 +7,25 @@ target-version: 0.4.2
 
 ## Summary
 
-Add horizontal and vertical rulers to the slides editor, plus
+The slides editor has horizontal and vertical rulers, plus
 presentation-wide alignment guides that users can drag out of the
 rulers. The ruler is primarily a placement aid: it shows slide
 coordinates (corner origin, inch / cm based on locale) and exposes
 draggable guides that participate in the existing snap engine. Text
-indent / tab handles inside text boxes are explicitly deferred to a
+indent / tab handles inside text boxes remain deferred to a
 later release.
 
-The design reuses the tick rendering and unit helpers from the docs
-ruler (`packages/docs/src/view/ruler.ts`) by extracting them into a
-shared low-level module so both packages stay visually consistent.
+The implementation reuses the tick rendering and unit helpers from the
+docs ruler by sharing a low-level module extracted into
+`packages/docs/src/view/ruler/` so both packages stay visually
+consistent.
+
+> **Status:** shipped. All six phases below are implemented in the
+> current codebase — the shared ruler core, the `SlidesRuler`
+> controller, the `Guide` data model + store API, ruler/guide
+> interactions, snap integration, and the read-only mount handling.
+> The remainder of this document describes the shipped design; the
+> "Phasing" section is retained as the historical rollout record.
 
 ### Goals
 
@@ -69,19 +77,22 @@ package owns its own controller and interactions.
 
 ```text
 packages/docs/src/view/ruler/
-├── index.ts            # MOVED — existing docs Ruler class (was view/ruler.ts)
-├── tick-renderer.ts    # NEW (extracted) — tick + label drawing
-└── unit.ts             # NEW (extracted) — RulerUnit, locale detect
+├── index.ts            # docs Ruler class (was the flat view/ruler.ts)
+├── tick-renderer.ts    # tick + label drawing (shared)
+└── unit.ts             # RulerUnit, locale detect (shared)
 
 packages/slides/src/view/editor/ruler/
+├── index.ts            # barrel: SlidesRuler, RULER_SIZE, SLIDES_PX_PER_INCH
 ├── ruler.ts            # SlidesRuler controller (H/V canvases + corner)
-├── guides-layer.ts     # paints permanent guides on the overlay layer
 └── interactions.ts     # ruler drag-out, guide drag, hit-test
 ```
 
-The docs file move is import-path-preserving: existing `from
-'../view/ruler'` resolves to the new `ruler/index.ts`. No call sites
-need to change.
+Permanent guides paint from the editor overlay layer
+(`packages/slides/src/view/editor/overlay.ts`) rather than from a
+dedicated ruler file, because they belong to the slide coordinate
+system. The docs file move was import-path-preserving: existing `from
+'../view/ruler'` resolves to `ruler/index.ts`, so no call sites
+changed.
 
 The shared modules take `pxPerUnit` as an argument so docs (96 dpi)
 and slides (144 dpi — see "Coordinate system") can both use them
@@ -105,8 +116,8 @@ editor-shell.tsx
     ├── <v-ruler-canvas>  absolute; top:14px; left:0; bottom:0; width:14px
     └── <canvas-pane>     absolute; top:14px; left:14px; right:0; bottom:0
         ├── <slide-canvas>      # existing
-        └── <overlay>           # existing
-            └── <guides-layer>  # NEW — permanent magenta solid lines
+        └── <overlay>           # existing — also paints permanent
+                                #   magenta guide lines
 ```
 
 The slide canvas area is offset by 14 px on top and left to make room
@@ -198,7 +209,7 @@ type SlidesDocument = {
   meta: { title: string };
   slides: Slide[];
   layouts: Layout[];
-  guides: Guide[];     // NEW
+  guides: Guide[];
 };
 ```
 
@@ -240,20 +251,21 @@ client writes the empty array.
 type SlidesPresence = {
   // ...existing
   draggingGuide?: {
-    id?: string;            // undefined while creating from ruler
     axis: 'x' | 'y';
     position: number;
   };
 };
 ```
 
-In v1 the `draggingGuide` field is reserved on `SlidesPresence` but
-the editor does not broadcast it: the live preview is local-only.
-`addGuide` / `moveGuide` commit once on `mouseup`, and the resulting
-store change propagates through the standard CRDT path so peers see
-the committed guide on their next render. Broadcasting the in-flight
-preview to peers is a tracked v1.1 follow-up — the schema is already
-in place to keep it a non-breaking change.
+The `draggingGuide` field is reserved on `SlidesPresence` (and the
+peer-view read path in `peer-view.ts` / `peers.ts` already maps it),
+but the editor does not broadcast it yet: the live preview is
+local-only via the editor's own `pendingGuide` state. `addGuide` /
+`moveGuide` commit once on `mouseup`, and the resulting store change
+propagates through the standard CRDT path so peers see the committed
+guide on their next render. Broadcasting the in-flight preview to
+peers remains a follow-up — the schema is already in place to keep it
+a non-breaking change.
 
 ### Interactions
 
@@ -350,7 +362,8 @@ affordances.
 
 ### Phasing
 
-Six PRs, each independently demoable.
+The feature landed across six PRs, each independently demoable. All
+six are shipped; the table below is the historical rollout record.
 
 | Phase | Scope | Verification |
 | --- | --- | --- |

--- a/docs/design/slides/slides-shapes.md
+++ b/docs/design/slides/slides-shapes.md
@@ -205,12 +205,6 @@ imports of labelled shapes layered (`ShapeElement` + paired
 `TextElement`); the new form is one element.
 
 **v1 limitations.**
-- *Type-to-edit first character.* The keystroke is consumed
-  (`preventDefault`) and enters edit mode, but the first character is
-  not yet inserted into the freshly-mounted text-box — the user has
-  to type it again. Forwarding the initial character requires threading
-  an `initialText` through `mountSlidesTextBox` into the docs editor;
-  deferred as a follow-up.
 - *Two import formats coexist in Yorkie storage.* Pre-feature decks
   imported a labelled shape as two layered elements (`ShapeElement`
   with no text + paired `TextElement` overlay); those documents keep

--- a/docs/design/slides/slides-shapes.md
+++ b/docs/design/slides/slides-shapes.md
@@ -9,9 +9,11 @@ target-version: 0.4.1
 
 The `@wafflebase/slides` package ships an OOXML-aligned shape library:
 **136 closed-path `ShapeKind` builders** rendered through a single
-path-builder registry, plus a special-cased dispatcher for connectors
-(`line` / `arrow`, now `ConnectorElement`), the 12 action buttons, and
-the data-driven `freeform` (`<a:custGeom>` / scribble) kind. Per-shape
+path-builder registry, plus special-cased dispatch for the 12 action
+buttons and the data-driven `freeform` (`<a:custGeom>` / scribble) kind.
+Lines and arrows are no longer `ShapeKind` values — they were extracted
+into a first-class `ConnectorElement` (see the `Connectors` note below and
+`slides-connectors.md`). Per-shape
 adjustments are stored as `data.adjustments?: number[]` and edited via
 yellow-diamond drag handles on the canvas. The catalog now exceeds the
 Google Slides shape menu (full PowerPoint Stars & Banners, the complete
@@ -30,7 +32,8 @@ task docs under `docs/tasks/`.
 - One shared rendering contract across all shapes: each closed-path
   shape is a pure `(size, adjustments) => Path2D` function, the
   dispatcher applies fill / stroke / theme color resolution. Only
-  `line` and `arrow` are special-cased (open path + arrowhead).
+  action buttons (body + glyph) and `freeform` (data-driven
+  `<a:custGeom>` path) are special-cased.
 - One storage contract for parametric shapes: `data.adjustments`
   mirrors OOXML `<a:avLst><a:gd>` so per-shape parameters round-trip
   to PPTX without an extra encoding layer.
@@ -48,9 +51,12 @@ task docs under `docs/tasks/`.
 
 ## Non-Goals
 
-- **Connector behaviour.** `line` and `arrow` are free-floating;
-  elbow / curved connectors that snap between two source elements
-  are a separate workstream.
+- **Connector behaviour** *(now shipped as a separate workstream).*
+  Lines, arrows, and elbow / curved connectors that snap between two
+  source elements are handled by the first-class `ConnectorElement`
+  type (`model/connector.ts`, `model/connection-site.ts`,
+  `view/canvas/connector-renderer.ts`), not the shape library — see
+  `slides-connectors.md`.
 - **Path-precise hit-testing.** Selection still uses the rotated
   frame AABB. Click-through-the-hole-of-donut behaviour using
   `ctx.isPointInPath(path, x, y)` is a follow-up.
@@ -69,8 +75,7 @@ task docs under `docs/tasks/`.
 
 ```ts
 export type ShapeKind =
-  // Lines (open-path, arrowhead) — special-cased renderers
-  | 'line' | 'arrow'
+  // (Lines / arrows are NOT ShapeKinds — see ConnectorElement.)
   // Basic shapes (P1: 15, P3-B: +29) — rect, …, snipRoundRect
   // Block arrows (P1: 8, P3-B: +13) — rightArrow, …, swooshArrow
   // Banners (P3-B: 5) — ribbon, …, leftRightRibbon
@@ -224,7 +229,7 @@ imports of labelled shapes layered (`ShapeElement` + paired
 ```
 packages/slides/src/view/canvas/
 ├── shape-renderer.ts          # dispatcher
-├── shape-special.ts           # drawLine, drawArrow, drawActionButton
+├── shape-special.ts           # drawActionButton (line/arrow now render via connector-renderer.ts)
 └── shapes/
     ├── builder.ts             # PathBuilder, AdjustmentSpec, AdjustmentHandle,
     │                          # adj() helper, regularPolygonPath()
@@ -247,10 +252,13 @@ The dispatcher in `shape-renderer.ts`:
 
 ```ts
 export function drawShape(ctx, size, data, theme) {
-  if (data.kind === 'line') return drawLine(ctx, size, data, theme);
-  if (data.kind === 'arrow') return drawArrow(ctx, size, data, theme);
   if (isActionButton(data.kind)) {
     return drawActionButton(ctx, size, data, theme);
+  }
+  // Freeform (`<a:custGeom>`) — geometry is data-driven, not parametric.
+  if (data.kind === 'freeform') {
+    // build path from data.path, paint fill/stroke, then optional arrowheads
+    return drawFreeform(ctx, size, data, theme);
   }
 
   const builder = PATH_BUILDERS.get(data.kind);
@@ -422,17 +430,19 @@ clamped.
 ### Picker UI
 
 The frontend toolbar exposes one **Shape ▾** button
-(`packages/frontend/src/app/slides/slides-formatting-toolbar.tsx`)
-that opens a Radix `Popover`:
+(`packages/frontend/src/app/slides/shape-picker.tsx`, with its catalog
+in `shape-picker-helpers.ts`) that opens a Radix `Popover`:
 
 - ~280 px wide, scrollable.
-- Sections in fixed order: **Lines · Shapes · Block Arrows ·
+- Sections in fixed order (8 categories): **Shapes · Block Arrows ·
   Banners · Flowchart · Callouts · Equation · Stars · Action
   Buttons**. Mirrors Google Slides' picker order, with Banners next
-  to Block Arrows (visual affinity) and Action Buttons at the end
-  (Google Slides exposes them via a separate Insert > Action button
-  entry; the picker keeps them in one popover until P3-C splits
-  them out).
+  to Block Arrows (visual affinity) and Action Buttons at the end.
+  Lines and arrows are no longer in this picker — they moved to a
+  dedicated sibling **Line ▾** dropdown (`line-picker.tsx`) with an
+  endpoint-anchored insertion UX (they are `ConnectorElement`s, not
+  shapes). An invariant test asserts exactly these 8 categories with
+  no `lines` entry.
 - Each section is a 6-column grid of 32 × 32 px buttons with
   24 × 24 px previews.
 - Previews render through the same `PATH_BUILDERS` — a
@@ -448,14 +458,16 @@ source of truth for which kinds appear in which section with which
 labels. An invariant test (`shape-picker.test.ts`) asserts every
 category entry has a registered `PATH_BUILDERS` builder.
 
-`InsertKind` (in `editor.ts`) is `ShapeKind | 'text'`. The
+`InsertKind` (in `editor.ts`) is
+`ShapeKind | 'text' | ConnectorInsertKind` (connectors ride the same
+insert-mode plumbing but build a `ConnectorElement`). The
 `buildInsertElement` dispatcher in `insert.ts` looks up a per-kind
 `STYLE_BY_KIND` style (`'filled' | 'outlined' | 'lineSpecial'`)
 for the initial fill / stroke. Conventions across all families:
 
 | Category | Default fill | Default stroke |
 |---|---|---|
-| Lines | (none) | `role: 'text'`, width 2 |
+| Open-path shapes (`arc`, `bracketPair`) — `lineSpecial` | (none) | `role: 'text'`, width 2 |
 | Basic / Block Arrows / Banners / Equation / Stars | `role: 'accent1'` | `role: 'text'`, width 1 |
 | Callouts / Flowchart | `role: 'background'` | `role: 'text'`, width 2 |
 | Action buttons | `role: 'background'` | `role: 'text'`, width 1 — `drawActionButton` reuses `stroke.color` for the inner glyph fill, falling back to the `background` role on collision so the glyph stays legible against any body fill |
@@ -643,4 +655,4 @@ priority where they do overlap.
 | P4 | DrawingML formula evaluator (`<a:avLst>` + guide formulas), enabling `kind: 'preset'` + `data.presetName` for unknown imports. |
 | Importer | `prst → ShapeKind` mapping table for the PPTX importer (tracked under `slides-themes-layouts-import.md`). |
 | Selection | Path-precise hit-testing via `ctx.isPointInPath`. Particularly relevant for stars (currently selects through the inner concave regions). |
-| Connectors | Elbow / curved connectors that snap to two source elements — separate workstream from the static shape library. |
+| Connectors | *Shipped* as a separate workstream: elbow / curved connectors that snap to two source elements are the first-class `ConnectorElement` type (`model/connector.ts`, `view/canvas/connector-renderer.ts`), not part of the static shape library — see `slides-connectors.md`. |

--- a/docs/design/slides/slides-smart-guides.md
+++ b/docs/design/slides/slides-smart-guides.md
@@ -204,9 +204,12 @@ positional snaps.
 ### Overlay rendering
 
 Same HTML/CSS overlay that already paints `SnapGuide` via
-`makeGuide` in `view/editor/overlay.ts`. New `makeSmartGuide` builds
-DIVs in the same coordinate convention (`position * scale` for
-placement). Color shared with the existing `#e11d48` guide red.
+`makeGuide` in `packages/slides/src/view/editor/overlay.ts`. Three
+functions build the DIVs in the same coordinate convention
+(`position * scale` for placement): `makeSmartGuideArrows` (spacing /
+distance shafts + arrowheads), `makeSmartGuideOutlines` (equal-size
+dashed peer outlines), and `makeSmartGuideLabel` (the numeric
+distance pill). Color shared with the existing `#e11d48` guide red.
 
 - Equal-spacing: **two** absolutely-positioned 1 px DIVs along the
   matched axis at the middle element's center line, each capped with a
@@ -218,7 +221,8 @@ placement). Color shared with the existing `#e11d48` guide red.
   wrapping every entry in `matchedFrames`. No label
 - Equal-spacing / equal-distance arrows also render a small numeric
   distance label (rounded px, no unit) at each shaft's midpoint —
-  white pill with the same red border, positioned perpendicular to the
+  a dark translucent pill (`rgba(0, 0, 0, 0.75)` background, white
+  text, rounded corners, no border), positioned perpendicular to the
   shaft so it doesn't overlap the line. Equal-size outlines remain
   unlabeled (the matched outline IS the label).
 
@@ -233,7 +237,7 @@ call, so leaving guides off the next render is enough).
 | Trio scan is O(N²) | N is typically 5–20; pre-filter with `overlapY`/`overlapX` cuts most pairs |
 | N > 30 slides | Cull candidates to those whose bbox lies within `slide.w/2` and `slide.h/2` of the dragged bbox |
 | `collectSnapCandidates` cost | Already paid by `snap.ts`; reuse the same array |
-| Threshold vs zoom | `SNAP_THRESHOLD = 8` is in slide coordinates today (matches `snap.ts`). `smart-guides.ts` uses the same constant from the same source so any future zoom-aware change applies to both |
+| Threshold vs zoom | `SNAP_THRESHOLD = 8` (a non-exported const in `packages/slides/src/view/editor/snap.ts`) is in slide coordinates today. `packages/slides/src/view/editor/smart-guides.ts` defines its own duplicate `THRESHOLD = 8` literal — the two are not a shared source, so a future zoom-aware change must update both |
 
 ### Group & rotated handling
 

--- a/docs/design/slides/slides-tables.md
+++ b/docs/design/slides/slides-tables.md
@@ -53,9 +53,12 @@ structured `TableElement`, and the PPTX exporter emits a real `<a:tbl>`.
   only. Docs allows nested tables; slides v1 doesn't — the visual
   payoff in slide context is small and the editor complexity (cell
   resize cascading through nested rows) is large.
-- **Cell-level Yorkie undo/redo.** Slides uses the existing
-  snapshot-based undo path (`store.batch`); table ops batch the same
-  way as any other element edit.
+- **Cell-level Yorkie undo/redo.** Table ops get no special undo
+  granularity — they batch through `store.batch` the same way as any
+  other element edit. `YorkieSlidesStore` maps each batch onto Yorkie
+  native `doc.history` (see
+  [slides-native-undo.md](slides-native-undo.md)); `MemSlidesStore`
+  retains the snapshot-based undo path.
 - **Linked-spreadsheet tables.** Tables are static OOXML-style grids,
   not embedded `@wafflebase/sheets` ranges. The latter is tracked under
   the existing "Embedded sheets" v2 item in `slides.md`.

--- a/docs/design/slides/slides-tables.md
+++ b/docs/design/slides/slides-tables.md
@@ -7,19 +7,27 @@ target-version: 0.4.5
 
 ## Summary
 
-Add structured table editing to `@wafflebase/slides` to match PowerPoint
-and Google Slides parity. A table is a new `Element` kind that owns its
-own grid (rows × columns), per-cell text bodies, per-cell styling
+> **Status: shipped.** The `TableElement` model, both store backends
+> (`MemSlidesStore` + `YorkieSlidesStore`), the Canvas renderer, cell
+> editing / cell-range selection, structural edits, presence, and
+> PPTX/PDF/round-trip export are all implemented. The phase plan and
+> forward-looking framing below are retained as a design record; the
+> notes call out where reality diverges from the original proposal.
+
+Structured table editing in `@wafflebase/slides` matches PowerPoint and
+Google Slides parity. A table is an `Element` kind that owns its own
+grid (rows × columns), per-cell text bodies, per-cell styling
 (background, borders, padding, vertical alignment), and merged regions.
 
-This replaces the current PPTX import path
-(`packages/slides/src/import/pptx/table.ts`) which flattens `<a:tbl>`
-into independent text + transparent-rect elements and reports
+This replaced the earlier PPTX import path
+(`packages/slides/src/import/pptx/table.ts`), which used to flatten
+`<a:tbl>` into independent text + transparent-rect elements and report
 `tableMergesIgnored` / `tableBordersApproximated`. Real-world decks
 contain tables on most non-cover slides (e.g. the Yorkie 캐즘 deck has
-tables on slides 24–27 and 33–35), so flattening loses fidelity on
-import, makes alignment impossible to maintain when slides are re-edited,
-and blocks an eventual PPTX export.
+tables on slides 24–27 and 33–35), so flattening lost fidelity on
+import, made alignment impossible to maintain when slides were
+re-edited, and blocked PPTX export. The importer now produces a
+structured `TableElement`, and the PPTX exporter emits a real `<a:tbl>`.
 
 ### Goals
 
@@ -83,12 +91,16 @@ and blocks an eventual PPTX export.
   `applyGroupTransform` rather than calling `updateElementFrame`, so a
   TableElement inside a group whose group is later ungrouped won't get
   its `columnWidths` / row heights proportionally scaled. The bug is
-  latent in P1 (no UI path to insert tables into groups) and is
-  closed when P3 wires the group-bake call sites through the store.
-- **Cell-range selection is absent.** Selecting a TableElement gives
-  whole-element selection; per-cell hover I-beam engages over the
-  entire table inset (see `getTextRegionRect` 'table' branch). Cell
-  selection, Tab/Shift+Tab navigation, and structural ops arrive in P3.
+  latent (no UI path inserts tables into groups) and is closed once the
+  group-bake call sites route through the store.
+- **Cell-range selection — resolved.** This was originally listed as a
+  P1 gap; it has since shipped. Cell selection, cell hit-testing,
+  Tab/Shift+Tab navigation, and structural ops all landed. The editor
+  drives cell-range drag via `startCellRangeDrag` / `tableCellAtPoint`
+  / `projectCellRangeRects` (`view/editor/editor.ts`, overlay rects via
+  `makeCellRangeRect` in `view/editor/overlay.ts`), and
+  `view/canvas/table-renderer.ts` exports `tableCellAtPoint`,
+  `tableEdgeAt`, and `nextCellInDirection`.
 
 ## Proposal Details
 
@@ -194,17 +206,12 @@ the convention every other structural slide op already uses.
 interface SlidesStore {
   // ...existing...
 
-  /** Create a fresh r × c table; cells start with one empty paragraph. */
-  addTable(
-    slideId: string,
-    init: {
-      frame: Frame;
-      rows: number;
-      cols: number;
-      columnWidths?: number[];   // defaults: equal split of frame.w
-      rowHeights?: number[];     // defaults: equal split of frame.h
-    },
-  ): string;
+  // Table creation reuses the generic `addElement(slideId, init)`
+  // element factory (there is no dedicated `addTable` store method);
+  // the editor's `insertTable(rows, cols, opts)` helper
+  // (`view/editor/editor.ts`) builds the initial `TableElement` — cells
+  // start with one empty paragraph, columns/rows default to an equal
+  // split of the frame — and hands it to `addElement`.
 
   insertTableRow(slideId: string, elementId: string, atIndex: number): void;
   deleteTableRow(slideId: string, elementId: string, rowIndex: number): void;
@@ -430,19 +437,20 @@ Rewrite `packages/slides/src/import/pptx/table.ts` to return a
 | `<a:tc>/<a:tcPr anchor>` | `style.verticalAlign` (`t`/`ctr`/`b`) |
 | `<a:tc>/<a:txBody>` | `body: TextBody` via existing `parseTextBody` |
 
-`ctx.report.tableMergesIgnored` and `ctx.report.tableBordersApproximated`
-counters are retired; replace with `ctx.report.tablesImported` (success
-count) and `ctx.report.tableCellsImported`. The non-blocking import
-toast text in `frontend/src/app/slides/...` updates correspondingly.
+The `ctx.report.tablesFlattened`, `ctx.report.tableMergesIgnored`, and
+`ctx.report.tableBordersApproximated` counters were retired (see the
+note in `import/pptx/report.ts`). Because tables now round-trip as a
+full structured element, there is no lossy path left to count, so no
+replacement counter was added — the import report simply stops
+mentioning tables.
 
 ### PPTX export
 
-Add `packages/slides/src/export/pptx/table.ts`, the inverse of import.
-The slides export pipeline doesn't exist yet (see Non-Goals in
-`slides.md` — PPTX export is v2). When that work lands, `TableElement`
-emits `<p:graphicFrame>/<a:tbl>` directly; until then, in-app authored
-tables export to PDF (which already paints from the canvas renderer,
-so this works on day one) but do not round-trip back to PPTX.
+`packages/slides/src/export/pptx/table.ts` is the inverse of import.
+The slides PPTX export pipeline has since shipped, and `TableElement`
+emits `<p:graphicFrame>/<a:tbl>` directly, so in-app authored tables
+round-trip back to PPTX (they also export to PDF via the canvas
+renderer path below).
 
 PDF export reuses the same `layoutTextBody` calls as Canvas rendering;
 the PDF writer in `packages/slides/src/export/pdf.ts` gains a table
@@ -460,21 +468,24 @@ working (they contain only `text` / `shape` / `image` elements).
 
 ### Phasing
 
+All six phases below have shipped — the model, structured PPTX import,
+cell editing, structural edits, Yorkie collaboration, and PDF export are
+all in the current tree. The plan is kept as a record of the rollout.
+
 | Phase | Deliverable | Verification |
 |---|---|---|
 | P1. Model + read-only render | `TableElement` type, `MemSlidesStore` add/get, `table-renderer.ts`, fixture-based snapshot tests | `pnpm slides test` + visual fixture in standalone harness |
 | P2. PPTX import (structured) | Rewrite `import/pptx/table.ts`, retire flatten path, update import report counters, fixture for the Yorkie 캐즘 deck | Snapshot diff vs prior flattened output; import-roundtrip unit tests |
 | P3. Cell editing | Cell-range selection, text edit via existing text-bridge, Tab/Shift+Tab navigation, cell-style toolbar | Vitest interaction tests for selection + Tab; visual smoke |
 | P4. Structural edits | Insert/delete row/col, merge/unmerge, drag-resize column/row borders, outer-frame proportional scale | Vitest tests; manual smoke |
-| P5. Yorkie + collaboration | `YorkieSlidesStore` table ops, presence (`selectedTableCells`, `resizingTableEdge`), concurrent-edit integration test | Postgres+Yorkie integration test `two-user-slides-table-yorkie.ts` |
+| P5. Yorkie + collaboration | `YorkieSlidesStore` table ops, presence (`selectedTableCells`, `resizingTableEdge`), concurrent-edit integration test | Postgres+Yorkie integration test `packages/frontend/tests/app/slides/yorkie-slides-table-concurrent.integration.ts` |
 | P6. PDF export | `export/pdf.ts` table case; visual PDF diff against a fixture deck | `pnpm verify:browser:docker` extension |
 
 Each phase ends with `pnpm verify:fast`; P5 additionally requires
 `pnpm verify:integration`; P6 requires `pnpm verify:browser:docker`.
 
-PPTX export remains tracked under the existing v2 backlog item in
-`slides.md` ("PPTX export"). Adding it later is a single new module —
-the structured model added here makes it mechanical.
+PPTX export has since shipped (`export/pptx/table.ts`); the structured
+model added here made it a mechanical inverse of the importer.
 
 ### Risks and Mitigation
 

--- a/docs/design/slides/slides-text-autofit.md
+++ b/docs/design/slides/slides-text-autofit.md
@@ -101,8 +101,6 @@ New pure module `packages/slides/src/model/autofit.ts`, built on docs
 export function computeAutofitScale(blocks, measurer, frameW, frameH, padding): number;
 /** Multiply every inline fontSize + block vertical margin by `scale`. */
 export function scaleBlocks(blocks, scale): Block[];
-/** Content height for grow callers: totalHeight + 2·padding. */
-export function computeAutofitHeight(blocks, measurer, frameW, padding): number;
 ```
 
 `computeAutofitScale` cannot solve scale analytically (smaller fonts wrap

--- a/docs/design/slides/slides-theme-catalog.md
+++ b/docs/design/slides/slides-theme-catalog.md
@@ -7,21 +7,21 @@ target-version: 0.5.0
 
 ## Summary
 
-The five built-in slide themes ship with the **Wafflebase brand
-palette melted into the defaults**: `default-light` and `default-dark`
-bind their accents to `palette.syrup` / `palette.butter` /
+Historically the built-in slide themes shipped with the **Wafflebase
+brand palette melted into the defaults**: `default-light` and
+`default-dark` bound their accents to `palette.syrup` / `palette.butter` /
 `palette.berry` / `palette.leaf` and their fonts to the brand
-`typography.display` stack (`packages/slides/src/themes/default-light.ts`,
-`packages/slides/src/themes/default-dark.ts`). Every new deck therefore inherits the waffle brand
-colors as its "Simple Light" default — which is not what Google Slides'
-"Simple Light" connotes (a neutral, near-monochrome base with one
+`typography.display` stack. Every new deck therefore inherited the waffle
+brand colors as its "Simple Light" default — which is not what Google
+Slides' "Simple Light" connotes (a neutral, near-monochrome base with one
 restrained accent).
 
-This design **de-brands the defaults** and **expands the catalog to ~23
+This design **de-branded the defaults** and **expanded the catalog to 23
 themes** for Google-Slides gallery parity, while keeping the existing
-flat-list model (`Theme`, `ThemePanel`, `ThemeThumbnail`) unchanged. The
-work is **pure data**: theme literals plus ordering, no schema, model, or
-UI structure change.
+flat-list model (`Theme`, `ThemePanel`, `ThemeThumbnail`) unchanged. It
+is now shipped (`packages/slides/src/themes/`). The work was **pure
+data**: theme literals plus ordering, no schema, model, or UI structure
+change.
 
 ### Goals
 
@@ -60,17 +60,19 @@ UI structure change.
 
 ## Current state
 
-`packages/slides/src/themes/index.ts` registers five themes in picker
-order: `defaultLight`, `defaultDark`, `streamline`, `focus`, `material`.
-`ThemePanel` (`packages/frontend/src/app/slides/theme-panel.tsx`) maps
+`packages/slides/src/themes/index.ts` registers 23 themes in picker
+order (`defaultLight`, `defaultDark`, `streamline`, `swiss`, …,
+`beachDay`, `wafflebase`). `ThemePanel`
+(`packages/frontend/src/app/slides/theme-panel.tsx`) maps
 `BUILT_IN_THEMES` to `ThemeThumbnail` cards; the thumbnail
 (`packages/frontend/src/app/slides/theme-thumbnail.tsx`) paints `aA` in `theme.fonts.heading`, the six
 accents as a strip, and the name — all from the literal, no assets.
 
-The problem is isolated to the two defaults:
+The original problem was isolated to the two defaults, which used to bind
+to the brand palette:
 
 ```ts
-// default-light.ts (current)
+// default-light.ts (before de-branding)
 accent1: palette.syrup,   accent2: palette.butter,
 accent3: palette.berry,   accent4: palette.leaf,
 fonts: { heading: firstFamily(typography.display), body: firstFamily(typography.body) }
@@ -78,8 +80,10 @@ fonts: { heading: firstFamily(typography.display), body: firstFamily(typography.
 
 Because element colors picked from the **Theme** row store
 `{ kind: 'role', role: 'accent1' }` (hybrid binding, see
-`slides-themes-layouts-import.md`), the brand palette renders on every
-role-bound element of every new deck.
+`slides-themes-layouts-import.md`), the brand palette rendered on every
+role-bound element of every new deck. The shipped `default-light.ts` now
+binds `accent1: '#1A73E8'` with Inter heading/body fonts, and the brand
+palette lives in the dedicated `wafflebase` theme.
 
 ## Proposal
 
@@ -87,20 +91,20 @@ role-bound element of every new deck.
 
 No change to `Theme`, `ColorScheme`, `FontScheme`, `resolveColor`,
 `resolveFont`, the Yorkie schema, or migration machinery. The picker
-stays a flat list. The only code that changes is:
+stays a flat list. The only code that changed is:
 
-- `packages/slides/src/themes/*.ts` — rewrite the two defaults, add ~18
-  new theme literals, add a `wafflebase` theme module.
-- `packages/slides/src/themes/index.ts` — extend `BUILT_IN_THEMES` and
-  re-export the new modules.
+- `packages/slides/src/themes/*.ts` — rewrote the two defaults, added the
+  new theme literals, added a `wafflebase` theme module.
+- `packages/slides/src/themes/index.ts` — extended `BUILT_IN_THEMES` and
+  re-exported the new modules.
 
 ### De-branding the defaults
 
-`default-light` and `default-dark` keep their **ids** (no remap) but are
+`default-light` and `default-dark` keep their **ids** (no remap) but were
 rewritten to neutral palettes and the Inter body/heading font. The brand
-palette moves to the new `wafflebase` theme, which keeps the
-`@wafflebase/tokens` `palette.*` and `typography.*` bindings so the old
-default look is reproducible in one click.
+palette moved to the new `wafflebase` theme, which keeps the
+`@wafflebase/core/tokens` `palette.*` and `typography.*` bindings so the
+old default look is reproducible in one click.
 
 ### Catalog and order
 
@@ -167,7 +171,7 @@ hyperlink, visitedHyperlink`:
 | `beach-day` | `#2B3A42` | `#FBFCFD` | `#5E7682` | `#E4F1F6` | `#00A8CC` | `#F4D35E` | `#EE964B` | `#00B4D8` | `#0077B6` | `#F7A072` | `#00A8CC` | `#0077B6` |
 
 `wafflebase` is not listed with hex because it binds to
-`@wafflebase/tokens` (`palette.syrup`, `palette.butter`, `palette.berry`,
+`@wafflebase/core/tokens` (`palette.syrup`, `palette.butter`, `palette.berry`,
 `palette.leaf`, `palette.syrupDeep`, `palette.berryBright`, the
 `palette.neutrals.light.*` slots, and `typography.display` / `body`) —
 it is the verbatim move of today's `default-light` body.
@@ -212,9 +216,14 @@ janking the panel.
   `default-light` and `default-dark`; the last is `wafflebase`. This is
   the transitive guard that replaces per-theme snapshots — it scales to
   23 themes without 23 fixtures.
-- A `fonts-in-catalog.test.ts` asserts every theme `heading` / `body`
-  family exists in the frontend font catalog (imported list), so a theme
-  cannot reference a font the loader can't resolve.
+- `packages/frontend/src/app/slides/theme-fonts.test.ts` asserts every
+  theme `heading` / `body` family exists in the frontend font catalog
+  (imported list), so a theme cannot reference a font the loader can't
+  resolve. (It lives frontend-side because that is where the font catalog
+  is defined.)
+- `packages/slides/src/themes/debrand.test.ts` guards the de-branding:
+  the two defaults no longer bind to the brand palette, and the
+  `wafflebase` theme reproduces the prior brand look.
 
 ### Visual regression (harness)
 
@@ -247,19 +256,20 @@ correctly.
 
 ## Rollout
 
-Single PR, commit-layered (each commit `pnpm verify:fast` green):
+Shipped in a single PR (#383), commit-layered (each commit
+`pnpm verify:fast` green):
 
 1. `feat(slides): de-brand default-light/dark, add wafflebase brand theme`
 2. `feat(slides): add 18 Google-Slides-parity built-in themes`
 3. `feat(slides): catalog validity + font-in-catalog + contrast tests`
 4. `test(frontend): retarget slides theme visual snapshots to 6-theme subset`
 
-Acceptance:
+Acceptance (all met):
 
 - `BUILT_IN_THEMES` has 23 entries, neutral defaults first, `wafflebase`
   last.
-- `catalog.test.ts` + `fonts-in-catalog.test.ts` green; contrast check
-  passes for all themes.
+- `catalog.test.ts` + `theme-fonts.test.ts` + `debrand.test.ts` green;
+  contrast check passes for all themes.
 - Harness 6-theme subset snapshots regenerated and green.
 - Manual smoke: panel scrolls 23, `wafflebase` reproduces the prior
   default look.

--- a/docs/design/slides/slides-themes-layouts-import.md
+++ b/docs/design/slides/slides-themes-layouts-import.md
@@ -53,15 +53,20 @@ PR3 is deferrable to v1.5 if the five built-in themes prove sufficient.
 
 ### Non-Goals
 
-- **PPTX export** — out of scope. PDF export remains the only export
-  format. PPTX export is on the v2 backlog (see `slides.md`).
-- **Animations / transitions** — still out of scope; PPTX
-  `<p:transition>` and `<p:timing>` are stripped on import.
+- **PPTX export** — was originally out of scope, but a full PPTX
+  exporter has since shipped (`packages/slides/src/export/pptx/`,
+  exported as `exportPptx` from `packages/slides/src/index.ts`, wired
+  into the frontend action `slides/pptx-actions.ts` and the CLI
+  `slides export` command). See `slides-pptx-export.md`.
+- **Animations / transitions** — this doc strips PPTX `<p:transition>`
+  and `<p:timing>` on import; motion later shipped as its own feature
+  (see `slides-animation.md`).
 - **Embedded fonts** in PPTX (`.fntdata`) — ignored. Fallback uses our
   existing font registry plus Noto Sans KR for Hangul.
-- **Group elements as a first-class kind** — still v2. PPTX `<p:grpSp>`
-  is flattened on import (children's frames composed with the group
-  transform).
+- **Group elements as a first-class kind** — now shipped: there is a
+  first-class `GroupElement` (`packages/slides/src/model/element.ts`),
+  and PPTX `<p:grpSp>` is preserved as a `GroupElement` on import (not
+  flattened). See `slides-group.md`.
 - **Theme builder editing static elements on master/layout** — v1 limits
   master/layout editing to colors, fonts, and placeholder positions.
   Adding/removing static elements (logo bars etc.) on the master is
@@ -70,7 +75,11 @@ PR3 is deferrable to v1.5 if the five built-in themes prove sufficient.
   than ~50 MB or that fail in the browser are not auto-routed to a
   backend importer in v1.
 - **Shape library expansion beyond rect/ellipse/line/arrow/roundRect** —
-  v2 work. Unsupported PPTX shapes become a placeholder rect on import.
+  originally deferred, but the shape library has since grown to a large
+  `ShapeKind` registry (~150 kinds: chevron, donut, blockArc, can,
+  uturnArrow, flowchart/arrow/callout/star/banner families, …) in
+  `packages/slides/src/model/element.ts`. Only a genuinely unknown
+  `prst` falls back to a placeholder rect. See `slides-shapes.md`.
 
 ## Proposal Details
 
@@ -233,7 +242,8 @@ source of truth.
 ### Built-in themes (5)
 
 `packages/slides/src/themes/` — each theme is a TS module exporting a
-`Theme` literal. Five themes ship in PR1:
+`Theme` literal. Five themes shipped in PR1 (below); the catalog has
+since grown to 23 built-ins (see `slides-theme-catalog.md`):
 
 | id | name | character |
 |---|---|---|
@@ -360,8 +370,8 @@ choice is **reuse existing**.
 | `<p:sp>` `prst="roundRect"` | ShapeElement (kind: 'roundRect') | ✅ (new shape kind) |
 | `<p:sp>` other `prst` (chevron, donut, blockArc, can, uturnArrow, …) | ShapeElement rect placeholder; toast warns. v2 expands shape library | ⚠️ |
 | `<p:cxnSp>` | ShapeElement (line/arrow) | ✅ |
-| `<p:grpSp>` | Flatten: child frames composed with group transform | ⚠️ (group lost) |
-| `<p:graphicFrame><a:tbl>` | Matrix of TextElements + border ShapeElements per cell | ⚠️ (until docs-tables integration in v1.5) |
+| `<p:grpSp>` | Preserved as a first-class `GroupElement` (children carry group-local coords) | ✅ |
+| `<p:graphicFrame><a:tbl>` | First-class `TableElement` (rows × cols, per-cell text bodies) | ✅ |
 | `<p:sp>` with `<a:blipFill>` | ImageElement (shape `xfrm` → frame); full-bleed template visuals built as `custGeom`/`prstGeom` + blip | ✅ (non-rect freeform clip path lost) |
 | `<a:blipFill>` `<a:srcRect>` | source crop → `ImageElement.data.crop` | ✅ |
 | `<a:blipFill>` `<a:stretch><a:fillRect>` (negative insets) | "Fill" / cover crop → equivalent `data.crop`. Cover case only; positive-inset letterbox falls back to full stretch; not composed with `srcRect` | ✅ |
@@ -513,7 +523,7 @@ significantly smaller than the original mapping table assumed.
 | `<a:normAutofit>` (shrink-to-fit) | ❌ `TextElement.data` has only `blocks` — no autoFit field | **lossy:** pre-apply `fontScale` to each run's stored `fontSize` at parse time; the original is approximated, no live re-fit. Acceptable: shrink-to-fit only affects display, not content. |
 | `<a:bodyPr anchor>` (vertical text anchor) | ✅ `TextElement.data.verticalAnchor` (`packages/slides/src/import/pptx/text.ts:detectVerticalAnchor`) | **paint offset:** rendered via `packages/slides/src/view/canvas/text-renderer.ts:computeVerticalOriginY` (mirrored in `packages/docs/src/view/text-box-editor.ts` for in-place edit parity). `t/ctr/b` map to `top/middle/bottom`; `just`/`dist` collapse to `top`; empty / absent → undefined (inherit). **Overflow:** middle/bottom keep the anchor relationship (text extends above the frame top) to match PowerPoint / Google Slides; use `<a:normAutofit>` (`autofit: 'shrink'`) to keep oversized content inside the frame. |
 | `<a:outerShdw>` shape effects | ❌ `ShapeElement.data` has only `{kind, adjustments, fill, stroke}` | **drop**, 7 cases only; toast counts |
-| Slide canvas size flexibility | ❌ `SLIDE_WIDTH/HEIGHT` are module constants in `presentation.ts:50-51`; `SlidesDocument` has no `canvasSize` field | **rescale** EMU→px using deck's own `<p:sldSz>` so geometry preserves at the deck's aspect; if aspect ≠ 16:9, fit + toast warning |
+| Slide canvas size flexibility | ❌ `SLIDE_WIDTH/HEIGHT` are module constants in `presentation.ts` (`SLIDE_WIDTH` L238 / `SLIDE_HEIGHT` L243); `SlidesDocument` has no `canvasSize` field | **rescale** EMU→px using deck's own `<p:sldSz>` so geometry preserves at the deck's aspect; if aspect ≠ 16:9, fit + toast warning |
 
 **Net result:** of the original mapping table's ⚠️/❌ rows, only 3
 real model gaps remain for this deck (autoFit, shape shadow, dynamic
@@ -915,19 +925,26 @@ Known carve-outs:
 
 ## Future / Out of Scope
 
-The following remain out of scope but are unblocked by this work:
+Shipped since this doc was written (originally listed here as future):
 
-- **PPTX export** — symmetric inverse mapping of the import pipeline;
-  fonts and embedded media remain the hard parts
-- **Theme gallery beyond five** — community / brand themes; the model
-  supports unlimited themes from PR1 onward
+- **PPTX export** — the symmetric inverse mapping shipped
+  (`packages/slides/src/export/pptx/`; see `slides-pptx-export.md`).
+- **Animations / transitions** — shipped as a standalone feature
+  (`slides-animation.md`).
+- **Group / ungroup elements** — first-class `GroupElement` shipped
+  (`slides-group.md`).
+- **Shape library expansion** — chevron, donut, blockArc, can, etc. are
+  now first-class `ShapeKind`s, imported directly rather than as
+  placeholder rects (`slides-shapes.md`).
+
+Still out of scope but unblocked by this work:
+
+- **Theme gallery beyond the built-ins** — community / brand themes; the
+  model supports unlimited themes from PR1 onward (the built-in set has
+  since grown to 23; see `slides-theme-catalog.md`).
 - **Per-slide theme override** — Google Slides exposes this awkwardly;
   add only on demand
 - **Master / layout static elements** — adding logos / footers in the
   theme builder; v1.5
 - **docs theming** — docs absorbs `ThemeColor` in PR1 but does not
   expose it in its own UI; a docs-side theme picker is its own design
-- **Animations** — still v2
-- **Group / ungroup elements** — still v2
-- **Shape library expansion** — chevron, donut, blockArc, can, etc.
-  remain placeholder rects on import until v2

--- a/docs/design/slides/slides-toolbar-redesign.md
+++ b/docs/design/slides/slides-toolbar-redesign.md
@@ -115,8 +115,12 @@ function getToolbarState(editor: SlidesEditor | null, store: SlidesStore | null)
   const selection = editor?.getSelection() ?? [];
   if (selection.length === 0) return { kind: 'idle' };
   const types = collectSelectedTypes(store, editor, selection);
-  const selectionType = types.size > 1 ? 'mixed' : (types.values().next().value as 'shape' | 'image' | 'text-element');
-  return { kind: 'object', selectionType, ids: selection };
+  // Full union: > 1 type → 'mixed'; a single 'text' maps to 'text-element',
+  // 'image' / 'connector' / 'table' pass through, everything else → 'shape'.
+  const selectionType = mapSelectionType(types); // 'shape' | 'connector' | 'image' | 'text-element' | 'table' | 'mixed'
+  // cellRange is populated only for table selections (null = whole table).
+  const cellRange = selectionType === 'table' ? editor.getCellSelection() : null;
+  return { kind: 'object', selectionType, ids: selection, cellRange };
 }
 ```
 

--- a/docs/design/slides/slides-toolbar-redesign.md
+++ b/docs/design/slides/slides-toolbar-redesign.md
@@ -86,11 +86,26 @@ at predictable screen positions across state transitions.
 ```ts
 type ToolbarState =
   | { kind: 'idle' }
-  | { kind: 'object'; selectionType: 'shape' | 'image' | 'text-element' | 'mixed'; ids: string[] }
-  | { kind: 'text-edit'; elementId: string; textEditor: EditorAPI };
+  | {
+      kind: 'object';
+      selectionType: 'shape' | 'connector' | 'image' | 'text-element' | 'table' | 'mixed';
+      ids: readonly string[];
+      // Present iff selectionType === 'table' and a cell / cell-range is
+      // active; scopes TableControls ops to the selected cells (null = whole table).
+      cellRange?: { tableId: string; r0: number; c0: number; r1: number; c1: number } | null;
+    }
+  | { kind: 'text-edit'; elementId: string; textEditor: SlidesTextBoxEditor };
 ```
 
-Derivation lives in `slides-toolbar/index.tsx`:
+As shipped the object state distinguishes `connector` and `table`
+selections in addition to `shape` / `image` / `text-element` / `mixed`.
+Connector selections route through `ShapeControls` (Fill + Border);
+tables get a dedicated `TableControls` section
+(`packages/frontend/src/app/slides/toolbar/table-controls.tsx`) scoped
+by the optional `cellRange`.
+
+Derivation lives in `packages/frontend/src/app/slides/toolbar/state.ts`
+(imported by `packages/frontend/src/app/slides/toolbar/index.tsx`):
 
 ```ts
 function getToolbarState(editor: SlidesEditor | null, store: SlidesStore | null): ToolbarState {
@@ -255,10 +270,12 @@ that slides can borrow). PR 2 extracts them:
 packages/frontend/src/components/text-formatting/
 ├── text-style-group.tsx        # Font ▾, Size ▾
 ├── text-format-group.tsx       # B / I / U / S, Color, Highlight, Link
-├── text-paragraph-group.tsx    # Align ▾, List ▾, Indent +/-
-├── alignment-dropdown.tsx      # already exists inline; extracted
-└── color-picker-grid.tsx       # already exists at @/components/color-picker-grid
+└── text-paragraph-group.tsx    # Align ▾, List ▾, Indent +/-
 ```
+
+Paragraph alignment lives inside `text-paragraph-group.tsx` (there is no
+separate `alignment-dropdown.tsx`); the color grid is shared from
+`packages/frontend/src/components/color-picker-grid.tsx`.
 
 Each component takes `editor: EditorAPI | null` plus a `disabled` flag
 and reads/writes through the same `EditContext` API the docs toolbar
@@ -275,22 +292,24 @@ tests.
 
 ```
 packages/frontend/src/app/slides/toolbar/
-├── index.tsx                        # state derivation + global zones
+├── index.tsx                        # global zones + section routing
+├── state.ts                         # ToolbarState + getToolbarState derivation
 ├── insert-group.tsx                 # Select / Text / Image / Shape / Line
 ├── slide-group.tsx                  # + Slide split-button
 ├── arrange-menu.tsx                 # Order / Align / Distribute / Rotate
 ├── idle-section.tsx                 # Background button
 ├── object-section.tsx               # router on selectionType
-│   ├── shape-controls.tsx
-│   ├── image-controls.tsx
-│   ├── text-element-controls.tsx
-│   └── mixed-controls.tsx
+├── shape-controls.tsx               # shape / connector (Fill + Border)
+├── image-controls.tsx
+├── text-element-controls.tsx
+├── table-controls.tsx               # table / cell-range ops
 └── text-edit-section.tsx            # composes shared text-formatting groups
 ```
 
-The existing `slides-formatting-toolbar.tsx` is replaced by
-`slides/toolbar/index.tsx`. Imports from `slides-detail.tsx` change
-once.
+The files are flat (no `object-section/` subfolder); the `mixed`
+selection renders no per-type section, so there is no `mixed-controls.tsx`.
+The existing formatting toolbar is replaced by
+`packages/frontend/src/app/slides/toolbar/index.tsx`.
 
 ### State machine + event wiring
 

--- a/docs/design/slides/slides.md
+++ b/docs/design/slides/slides.md
@@ -123,7 +123,8 @@ packages/slides/                     # domain library
     │   │   ├── editor.ts            # controller
     │   │   ├── selection.ts
     │   │   ├── interactions/        # drag, resize, rotate, drag-add
-    │   │   └── text-bridge.ts       # bridge to docs IME / contenteditable
+    │   │   ├── thumbnail-panel.ts   # thumbnail strip (lives in the package)
+    │   │   └── text-box-editor.ts   # bridge to docs IME / contenteditable
     │   └── present/
     │       └── presenter.ts
     └── export/
@@ -131,11 +132,10 @@ packages/slides/                     # domain library
 
 packages/frontend/src/app/slides/    # Yorkie + React shell
 ├── yorkie-slides-store.ts           # Yorkie ↔ SlidesStore adapter
-├── slides-view.tsx                  # routed page entry
-├── editor-shell.tsx                 # 2-pane layout + top toolbar
-├── thumbnail-panel.tsx
-├── contextual-toolbar.tsx           # selection-driven top toolbar
-└── presentation-mode.tsx
+├── slides-view.tsx                  # routed page entry + 2-pane shell
+├── slides-detail.tsx                # editor shell wiring
+├── toolbar/                         # selection-driven contextual toolbar
+└── slides-presentation-mode.tsx
 ```
 
 Module responsibilities:
@@ -374,11 +374,16 @@ these batch boundaries:
 
 ### Presence
 
-> **Implementation status.** The shape below is design intent. As
-> shipped, presence broadcasts only `activeSlideId` +
-> `selectedElementIds`; `textCursor` / live drag frames are not
-> broadcast, and no peer cursors or selection rings render yet. See
-> [slides-collaboration.md](slides-collaboration.md) (Gap 3).
+> **Implementation status.** The shape below is design intent; field
+> names differ slightly from what shipped. As shipped, `SlidesPresence`
+> broadcasts `activeSlideId`, `selectedElementIds`, `activeFrames`
+> (live world-space drag/resize/rotate frames, cleared on mouseup),
+> and `selectedTableCells`. Peer cursors and selection rings/labels
+> **do** render — `computePeerOverlays` / `PeerRing` / `PeerLabel` in
+> `packages/slides/src/view/editor/peers.ts`, driven by
+> `editor.setPeers()`. Still not broadcast: text-edit carets (the
+> `textCursor` field below, plus per-cell `textCursorCell`). See
+> [slides-collaboration.md](slides-collaboration.md).
 
 ```ts
 type SlidesPresence = {
@@ -427,7 +432,8 @@ slide container (position: relative)
   docs layout engine with the text box's `frame.w` and renders the
   resulting layout to canvas. When the user enters text-edit mode on a
   text element, a contenteditable surface is mounted in the same
-  position and the docs IME bridge takes over keystrokes (`text-bridge.ts`).
+  position and the docs IME bridge takes over keystrokes
+  (`packages/slides/src/view/editor/text-box-editor.ts`).
 - **Text-box overflow.** Text-box `frame.h` auto-grows downward to fit
   the laid-out content; `frame.w` stays fixed (resize handles change
   width and trigger re-layout). The text box never clips. Pinning a
@@ -716,8 +722,10 @@ reads naturally in English.
   - `slides content <id>` — print a JSON dump of the presentation for
     debugging / inspection (matches `docs content`).
   - `slides export <id> --format pdf`
-  - `slides import` is intentionally absent in v1 (PPTX is out of
-    scope; JSON re-import is a developer tool, not a CLI command).
+  - `slides import <file>` — imports a `.pptx` deck as a new or
+    replacement presentation (shipped after v1, once PPTX import
+    landed; see
+    [slides-themes-layouts-import.md](slides-themes-layouts-import.md)).
 - **REST API** — no slide- or element-level endpoints in v1. Existing
   `/api/v1/workspaces/:wid/documents` endpoints accept the new type
   unchanged.

--- a/docs/design/yorkie-auth-webhook.md
+++ b/docs/design/yorkie-auth-webhook.md
@@ -21,6 +21,15 @@ answers `{ allowed }` (HTTP `200`/`401`/`403`). We plug our existing permission
 logic into that endpoint so Yorkie enforces workspace membership and share-link
 roles per document, per verb.
 
+**Status: shipped.** The webhook endpoint
+(`packages/backend/src/document/yorkie-auth.controller.ts`), the two token
+endpoints, the `tokenType === 'access'` replay guard, the shared rawBody scope,
+and both frontend injectors are all implemented and wired. What remains
+operational (not code) is the staged rollout: enforcement is gated by
+`YORKIE_AUTH_WEBHOOK_ENFORCE` (shadow-mode default) and by registering the
+webhook methods on the Yorkie project. The sections below describe the design
+as built.
+
 ## Goals / Non-Goals
 
 **Goals**
@@ -85,9 +94,9 @@ existing `YorkieSignatureGuard`
 **unchanged** — no new secret. The guard authenticates *Yorkie* as the caller;
 the `token` in the body then authenticates the *end user*.
 
-The rawBody `verify` hook in `packages/backend/src/main.ts` is currently
-path-scoped to `/internal/yorkie/events`; extend it to also cover
-`/internal/yorkie/auth`.
+The rawBody `verify` hook in `packages/backend/src/main.ts` is scoped to the
+`/internal/yorkie/` prefix (`YORKIE_WEBHOOK_PATH_PREFIX`), so it covers both
+`/internal/yorkie/events` and `/internal/yorkie/auth` with no per-path change.
 
 ### Token strategy (the hard part)
 
@@ -140,19 +149,23 @@ A single request may carry multiple attributes; **all** must pass.
 
 ### Frontend wiring
 
-`YorkieProvider` accepts `authTokenInjector` (it spreads `ClientOptions`).
-Add it in both mount points, keeping `apiKey` + `metadata` as-is:
+`YorkieProvider` accepts `authTokenInjector` (it spreads `ClientOptions`). It is
+wired at both mount points, keeping `apiKey` + `metadata` as-is. The two entry
+points call two distinct helpers in `packages/frontend/src/api/auth.ts`:
+`fetchYorkieToken()` (GET) for the authenticated case and
+`fetchYorkieShareToken(token)` (POST `/auth/yorkie-token/share`) for the
+anonymous-share case.
 
 ```tsx
 // PrivateRoute.tsx (authenticated)
 <YorkieProvider
   rpcAddr={...} apiKey={...}
   metadata={{ userID: encodeURIComponent(me.username || 'anonymous-user') }}
-  authTokenInjector={async () => fetchYorkieToken()}       // GET /auth/yorkie-token
+  authTokenInjector={fetchYorkieToken}                          // GET /auth/yorkie-token
 />
 
 // shared-document.tsx (anonymous share)
-authTokenInjector={async () => fetchYorkieToken(resolved.token)}  // ?shareToken=
+authTokenInjector={token ? () => fetchYorkieShareToken(token) : undefined}  // POST /auth/yorkie-token/share
 ```
 
 The injector caches the token and re-fetches when yorkie calls it with
@@ -182,13 +195,16 @@ contributors can opt in. Leaving the URL unset keeps today's behavior.
 
 ### Rollout
 
-1. **Ship the endpoint + token endpoint + frontend injector** with the webhook
-   URL **unregistered** — no enforcement, but tokens now flow.
-2. **Shadow mode**: register the webhook but have the handler always return
-   `allowed:true` while logging the decision it *would* have made. Watch for
-   false denials (token gaps, key-parse misses, share edge cases).
-3. **Enforce**: flip the handler to honor the computed decision.
-4. Reversible at every step: unregister the webhook methods to fully disable.
+1. **Endpoint + token endpoints + frontend injectors** — shipped. With the
+   webhook URL **unregistered** there is no enforcement, but tokens flow.
+2. **Shadow mode** (default): register the webhook with
+   `YORKIE_AUTH_WEBHOOK_ENFORCE` unset/`false` — the handler computes the
+   decision, logs the one it *would* have made, but always returns `allowed`.
+   Watch for false denials (token gaps, key-parse misses, share edge cases).
+3. **Enforce**: set `YORKIE_AUTH_WEBHOOK_ENFORCE=true` so the handler honors the
+   computed decision.
+4. Reversible at every step: flip the flag back, or unregister the webhook
+   methods to fully disable.
 
 ## Risks and Mitigation
 

--- a/docs/tasks/active/20260802-design-doc-audit-findings.md
+++ b/docs/tasks/active/20260802-design-doc-audit-findings.md
@@ -1,0 +1,1121 @@
+# Design Doc Audit — Findings (100 / 100 docs)
+
+Generated from workflow `wf_6991ab3f-696` on 2026-08-02. Each design doc under
+`docs/design/` (excluding README.md index and template.md) was audited by an
+independent subagent against the shipped codebase.
+
+**Verdict counts:** accurate 16 · minor-drift 57 · significant-drift 27
+
+**37 docs carry at least one high-severity finding.** Dominant pattern:
+`roadmap-shipped` (45 of 57 high-sev) — docs written as forward-looking
+proposals for features that have since shipped and were never flipped to
+present tense. Reader is misled into thinking the feature does not exist.
+
+Discrepancy legend: **documented-not-implemented** (doc claims shipped, code lacks it) ·
+**implemented-not-documented** · **roadmap-shipped** (deferred item actually shipped) ·
+**stale-reference** (wrong path/symbol) · **other**.
+
+---
+
+## significant-drift (27)
+
+### docs/design/slides/slides-fonts.md
+
+> The doc reads as a forward-looking proposal, but the on-screen rich-fonts work (P0 generated catalog + lazy ensureFontLink, P1 "More fonts…" dialog, P2 full ~1,900-family library) is already shipped; only the stale "current state" framing and the per-doc usedFonts persistence lag behind.
+
+- **[high] roadmap-shipped** — P0 is framed as a future phase ('This document proposes… per-font lazy loading'), but it is fully shipped: FONT_CATALOG is now generated data with a license field (~105 entries incl. Korean/Latin/mono/display + non-web system fonts), an `eager` bootstrap flag, and a per-family `ensureFontLink(family, weights)` lazy loader wired into both editors.
+  - _Evidence:_ packages/frontend/src/components/text-formatting/font-catalog.data.ts (FONT_CATALOG_DATA, ~105 entries with license/eager); font-catalog.ts exports ensureFontLink + FONT_CATALOG = FONT_CATALOG_DATA; ensureFontLink used in src/app/docs/docs-formatting-toolbar.tsx:348 and src/app/slides/toolbar/apply-font-family.ts:28
+- **[high] roadmap-shipped** — P1's '"More fonts…" dialog (search + category/script filters + in-view IntersectionObserver previews)' and localStorage 'recent' list are shipped, not future. The dialog, its filter module, and the recents store all exist and are wired into the picker.
+  - _Evidence:_ packages/frontend/src/components/text-formatting/more-fonts-dialog.tsx (MoreFontsDialog, IntersectionObserver+ensureFontLink); more-fonts-filter.ts (FontCategoryFilter/FontScriptFilter); font-recents.ts (localStorage per-browser recents); font-family-picker.tsx:28 imports/uses MoreFontsDialog
+- **[high] roadmap-shipped** — P2 (full ~1,800 library lazy-imported via font-catalog.full.json for the dialog) is shipped: the full library is committed as font-catalog.full.ts (~1,900 families) and dynamic-imported by a memoized loader that the picker already calls.
+  - _Evidence:_ packages/frontend/src/components/text-formatting/font-catalog.full.ts (FONT_CATALOG_FULL, 1915 lines); font-catalog-full-loader.ts loadFullFontCatalog() dynamic import; called at font-family-picker.tsx:85
+- **[high] stale-reference** — The Summary and 'Background: how fonts flow today' table describe the CURRENT state as a closed hardcoded ~19-family list loaded as a single bootstrap Google Fonts <link>. That is the pre-refactor state; the shipped code is a generated ~105-entry curated catalog plus a full library, with lazy per-family loading. A reader would be misled about what exists today.
+  - _Evidence:_ Doc lines 12-17 ('~19 families', 'single Google Fonts CSS <link> at bootstrap') and table row 'Hardcoded FONT_CATALOG (19 entries) font-catalog.ts:35' vs packages/frontend/src/components/text-formatting/font-catalog.data.ts (105 entries) and font-catalog.ts (buildGoogleFontsHref only loads eager fonts; ensureFontLink for lazy)
+- **[medium] documented-not-implemented** — P1's per-presentation used-fonts set ('persist per presentation in the Yorkie doc, a `usedFonts: string[]` on the presentation/meta object') is not implemented — no such field or symbol exists — even though the rest of P1 shipped. Only the localStorage recents piece exists.
+  - _Evidence:_ grep for 'usedFonts'/'used-fonts' across packages returns no matches; only font-recents.ts (localStorage) exists
+- **[low] stale-reference** — Generator script paths/extension drift: doc's P0 table names `scripts/build-font-catalog.ts` and the proposed FontCatalogEntry shape (category/curated/popularity). Actual generators are `.mjs` under the frontend package (plus a separate full-catalog and font-files generator), and the shipped FontEntry uses group/eager/webFont rather than category/curated/popularity.
+  - _Evidence:_ packages/frontend/scripts/build-font-catalog.mjs, build-font-catalog-full.mjs, build-font-files.mjs (referenced in generated-file headers); FontEntry in font-catalog.ts uses group/webFont/eager, not category/curated/popularity
+
+### docs/design/slides/slides-background.md
+
+> The doc is written as a forward-looking proposal ("Today... a single Background Color control", Goals, Phase 1/Phase 2 PRs), but the entire feature — model widening, renderer swap, migration, the Background side panel, PPTX gradient round-trip, apply-to-all, and image opacity — is already shipped in the code.
+
+- **[high] roadmap-shipped** — The Summary says 'Today the right-side panel exposes a single Background Color control — a solid ThemeColor picker' and the whole doc proposes building a restructured Background panel. In reality the BackgroundSidePanel is fully built: it uses the generic FillPicker (solid+gradient), and renders 'Reset to theme', 'Apply to all slides', and an image/opacity section. The RightPanel union already includes "background" and the toolbar toggles it exactly as the doc 'proposes'.
+  - _Evidence:_ packages/frontend/src/app/slides/background-side-panel.tsx (imports FillPicker + useSlideBackground; strings 'Reset to theme'/'Apply to all slides'/'Background'); packages/frontend/src/app/slides/slides-detail.tsx:152,535 (type RightPanel = "theme" | "format" | "motion" | "background" | null); packages/frontend/src/app/slides/use-slide-background.ts
+- **[high] roadmap-shipped** — Proposal Details §1 and Phase 1 item 1 present widening fill from ThemeColor to Fill as future work ('Background.fill?: ThemeColor → Fill', 'MasterBackground.fill: ThemeColor → Fill', add gradient guard to isInheritableFill, resolveBackgroundFill returns Fill). All of this is already in the code: Background.fill is typed Fill, MasterBackground.fill is Fill, resolveBackgroundFill returns Fill, and isInheritableFill already has the `if (fill.kind === 'gradient') return false;` guard.
+  - _Evidence:_ packages/slides/src/model/presentation.ts:28 (fill?: Fill), :187-198 (isInheritableFill(fill: Fill) with gradient guard), :208-220 (resolveBackgroundFill returns Fill); packages/slides/src/model/master.ts:20-21 (MasterBackground.fill: Fill)
+- **[high] roadmap-shipped** — Proposal Details §2 and Phase 1 item 2 present swapping resolveColor → resolveFillStyle in both slide-renderer background paint sites (with the no-pasteboard bitmapW×bitmapH vs pasteboard SLIDE_WIDTH×slideH nuance) as future work. Both paint sites already call resolveFillStyle with exactly the described bitmap-size/logical-size arguments and the documented comment about the identity-CTM device-pixel case.
+  - _Evidence:_ packages/slides/src/view/canvas/slide-renderer.ts:246-249 (no-pasteboard: resolveFillStyle(..., bitmapW, bitmapH)), :268-271 (pasteboard: resolveFillStyle(..., SLIDE_WIDTH, slideH))
+- **[medium] roadmap-shipped** — Proposal Details §3 and Phase 1 item 3 present adding a gradient branch to migrateBackground (bg.fill.kind === 'gradient' ? migrateGradientFill : wrapColor) as future work. That exact ternary is already present.
+  - _Evidence:_ packages/slides/src/model/migrate.ts migrateBackground (out.fill = bg.fill?.kind === 'gradient' ? migrateGradientFill(bg.fill) : wrapColor(bg.fill))
+- **[medium] roadmap-shipped** — Proposal Details §6 and Phase 2 item 7 present PPTX <p:bg> gradient import (add a gradFill branch calling parseGradientFill) and export (swap solidFillXml → fillXml) as future work. The importer already has the gradFill branch calling parseGradientFill, and the exporter already dispatches through fillXml (which emits gradFill for gradients).
+  - _Evidence:_ packages/slides/src/import/pptx/slide.ts:193-197 (parseSlideBackground gradFill → parseGradientFill); packages/slides/src/export/pptx/slide.ts:70-72 (backgroundToXml uses fillXml, handles blipFill/gradFill/solidFill)
+
+### docs/design/slides/slides-format-options-panel.md
+
+> The panel shell and its documented v1 sections exist as described, but every feature the doc explicitly frames as a deferred Non-Goal (drop shadow, reflection, recolor, image brightness/contrast) has actually shipped in both the data model and the panel UI, so the doc materially understates what exists.
+
+- **[high] roadmap-shipped** — Doc Non-Goals list Drop shadow and Reflection as 'Tracked as separate v1.1+ specs' requiring new data fields, a paint pipeline, and OOXML mapping. Both are fully shipped: element.ts defines DropShadow, Reflection, and an Effects bag (effects?: Effects) on text/image/shape data with full OOXML mapping comments, and the panel ships drop-shadow-section.tsx and reflection-section.tsx wired into format-panel/index.tsx (DropShadowSection/ReflectionSection) and routed by pick-sections.ts for shape/image/text-element selections.
+  - _Evidence:_ packages/slides/src/model/element.ts (DropShadow L174, Reflection L192, Effects L208-211); packages/frontend/src/app/slides/format-panel/drop-shadow-section.tsx, reflection-section.tsx; index.tsx L20-21,307-323; pick-sections.ts (returns 'drop-shadow','reflection')
+- **[high] roadmap-shipped** — Doc Non-Goals list 'recolor' for images as a v1.1+ spec needing a new data field and OOXML <a:duotone> mapping. It is shipped: ImageElement.data has recolor?: ImageRecolor ('none'|'grayscale'|'sepia'), and recolor-section.tsx is mounted in the panel (RecolorSection) and routed by pick-sections for image selection.
+  - _Evidence:_ packages/slides/src/model/element.ts (ImageRecolor L315, recolor?: L330); packages/frontend/src/app/slides/format-panel/recolor-section.tsx; index.tsx L17,289; pick-sections.ts (image returns 'recolor')
+- **[high] roadmap-shipped** — Doc Non-Goals state 'Image brightness / contrast. Requires a canvas filter pipeline ... v1.1+' and the Image Adjustments section is documented as Transparency-only. Both fields exist (ImageElement.data.brightness/contrast, [-1,1], ctx.filter mapping) and image-adjustments-section.tsx renders brightness and contrast sliders alongside transparency.
+  - _Evidence:_ packages/slides/src/model/element.ts (brightness L335, contrast L340); packages/frontend/src/app/slides/format-panel/image-adjustments-section.tsx L9-10,33-45 (brightness/contrast state + commit)
+- **[medium] documented-not-implemented** — The pickSections mapping table in the doc is stale. Doc: shape→['size-position'], image→['size-position','image-adjustments','alt-text'], text-element→['size-position','text-fitting']. Actual pick-sections.ts returns shape→['size-position','drop-shadow','reflection','alt-text'], image adds recolor/drop-shadow/reflection, text-element adds drop-shadow/reflection/alt-text. The SectionId union is also expanded (recolor/drop-shadow/reflection) and a 'table' selectionType exists that the doc never mentions.
+  - _Evidence:_ docs table L150-159 vs packages/frontend/src/app/slides/format-panel/pick-sections.ts (SectionId L3-10, ObjectSelectionType includes 'table' L13-20, per-type returns)
+- **[medium] implemented-not-documented** — A slide-size-section (SlideSizeSection) is shipped in the panel and mounted in index.tsx, but the doc's file layout and section list do not mention any slide-size section at all.
+  - _Evidence:_ packages/frontend/src/app/slides/format-panel/slide-size-section.tsx; index.tsx L14,243
+- **[low] stale-reference** — Doc file layout places pick-sections.test.ts and units.test.ts as siblings inside format-panel/ and lists section unit tests there, but the format-panel source dir contains no test files; tests live under packages/frontend/tests/app/slides/format-panel/ and currently only alt-text-section.test.tsx and drop-shadow-section.test.tsx exist there (no pick-sections/units tests found).
+  - _Evidence:_ packages/frontend/src/app/slides/format-panel/ (no *.test.*); packages/frontend/tests/app/slides/format-panel/ (alt-text-section.test.tsx, drop-shadow-section.test.tsx)
+
+### docs/design/docs/docs-font-controls.md
+
+> The doc is written as an unbuilt spec, but the entire feature — the shared text-formatting pickers, the editor API additions, and even a "More fonts" library expansion it explicitly lists as a Non-Goal — is already shipped and wired into the Docs toolbar.
+
+- **[high] roadmap-shipped** — The doc frames the whole feature as future ('This document specifies adding... Four new files under...'). In reality every proposed component exists and is imported/rendered by the Docs toolbar: font-family-picker.tsx, font-size-picker.tsx, line-spacing-picker.tsx, clear-formatting-button.tsx, font-catalog.ts (with FONT_CATALOG and FONT_SIZE_PRESETS = [8,10,12,14,16,18,20,24,32,48,64,96] exactly as specified). A reader would think none of this is built.
+  - _Evidence:_ packages/frontend/src/components/text-formatting/{font-family-picker,font-size-picker,line-spacing-picker,clear-formatting-button,font-catalog}.tsx|ts ; packages/frontend/src/app/docs/docs-formatting-toolbar.tsx imports FontFamilyPicker/FontSizePicker/LineSpacingPicker from @/components/text-formatting and renders them (lines 58-65, 428, 433, 625, 671, 691, 786)
+- **[high] roadmap-shipped** — Non-Goals states a 'More fonts…' dialog and full-library expansion are explicitly out of scope ('Curated list only in v1; library expansion is a follow-up document'). That follow-up is already implemented: a searchable More-fonts dialog plus the full google/fonts-derived catalog and loader.
+  - _Evidence:_ packages/frontend/src/components/text-formatting/more-fonts-dialog.tsx, more-fonts-filter.ts, font-catalog.full.ts, font-catalog-full-loader.ts; font-catalog.ts comment references the 'More fonts…' dialog as a live surface
+- **[medium] documented-not-implemented** — Doc says the curated list is exactly 14 hardcoded entries defined in font-catalog.ts, groups limited to Korean/Sans-serif/Serif/Monospace. Actual FONT_CATALOG is FONT_CATALOG_DATA imported from a generated font-catalog.data.ts (~105+ entries) built from google/fonts metadata, and FontGroup adds 'Display' and 'Handwriting'.
+  - _Evidence:_ packages/frontend/src/components/text-formatting/font-catalog.ts:16,18-24,66 (import FONT_CATALOG_DATA; FontGroup includes Display, Handwriting); font-catalog.data.ts ~105 'family:' entries
+- **[medium] roadmap-shipped** — getRangeStyleSummary() is presented under 'Editor API additions' as something to add, but it is already defined on EditorAPI and implemented in editor.ts (with the mixed-value walk described). The actual return type also includes superscript/subscript, not just the doc's listed keys.
+  - _Evidence:_ packages/docs/src/view/editor.ts:64-75 (interface), :2605 (implementation)
+- **[medium] stale-reference** — Doc specifies a new method editor.clearFormatting(); the shipped method is named editor.clearInlineFormatting() (dispatches CLEAR_INLINE_STYLE via applyStyle). The rename means the documented symbol does not exist.
+  - _Evidence:_ packages/docs/src/view/editor.ts:85 (clearInlineFormatting on EditorAPI), :2799-2803 (impl using CLEAR_INLINE_STYLE); no 'clearFormatting(' method present
+- **[low] implemented-not-documented** — The shipped FontEntry interface carries fields the doc's proposed shape omits (weights, license, scripts, eager) and the loading model uses an 'eager' bootstrap subset plus per-family ensureFontLink(), richer than the doc's single-link description.
+  - _Evidence:_ packages/frontend/src/components/text-formatting/font-catalog.ts:28-64 (FontEntry extra fields), :102-154 (buildGoogleFontsHref/ensureFontLink)
+
+### docs/design/docs/docs-local-caret-anchoring.md
+
+> The doc frames local caret/selection anchoring as an unbuilt proposal ("proposed fix", "should own", "Rollout Plan"), but the feature is fully implemented and wired end-to-end in yorkie-doc-store.ts and docs-view.tsx, matching the proposed design closely.
+
+- **[high] roadmap-shipped** — The entire proposal is framed as future work ("The proposed fix is to anchor...", "should own the anchored representation", a "Rollout Plan" of steps to do, "before implementation"), but it is already shipped. The proposed types AnchoredDocPosition (region/yorkiePosition/lineAffinity) and AnchoredDocRange (anchor/focus/tableCellRange) exist verbatim; conversion (anchorDocPosition via tree.indexRangeToPosRange) and resolution (resolveAnchoredDocPosition via tree.posRangeToIndexRange) exist; local state localCursorAnchor/localSelectionAnchor/compositionStartAnchor is stored; and Rollout steps 1-5 are all done. A reader would be misled into thinking none of this exists yet.
+  - _Evidence:_ packages/frontend/src/app/docs/yorkie-doc-store.ts: AnchoredDocPosition L51-59, AnchoredDocRange L61-64, anchor fields L510-512, anchorDocPosition L872-897, anchorDocRange L941-951, resolveAnchoredDocPosition L992-1017, resolveAnchoredLocalCursor L1097-1116, setCompositionStart L1142-1144
+- **[high] roadmap-shipped** — The Data Flow section describes storing an anchor on cursor change and resolving it on remote change as the target design, but this exact flow is live: store.onRemoteChange resolves the anchored local cursor, restores it into the editor, updates the composition start position, and republishes presence. Composition anchoring is wired via editor.onCompositionStart/onCompositionEnd -> store.setCompositionStart. This is the described behavior, already running.
+  - _Evidence:_ packages/frontend/src/app/docs/docs-view.tsx L364-387 (resolveAnchoredLocalCursor, restoreLocalCursor, updateCompositionStartPosition, publishResolvedLocalCursor; onCompositionStart/onCompositionEnd -> setCompositionStart)
+- **[medium] stale-reference** — The Summary/Background state as CURRENT behavior that remote changes "do not transform that local offset" so the caret ends up pointing at a different character (the #237 bug). That is no longer true: remote changes now resolve the stored anchor back to a shifted DocPosition, so the stated present-tense bug is already fixed.
+  - _Evidence:_ yorkie-doc-store.ts resolveAnchoredDocPosition L992-1017 + docs-view.tsx onRemoteChange L364-379 transform the offset via the Yorkie Tree anchor
+- **[low] implemented-not-documented** — The shipped AnchoredDocPosition carries extra fields not in the doc's proposed type — blockId, offset, and regionTopIndex — which back the deterministic fallback ladder (fallbackAnchoredDocPosition uses regionTopIndex for prev/next region-block fallback). The doc's proposed type lists only region/yorkiePosition/lineAffinity.
+  - _Evidence:_ yorkie-doc-store.ts AnchoredDocPosition L51-59 (blockId, offset, regionTopIndex), fallbackAnchoredDocPosition L1057-1089
+
+### docs/design/frontend.md
+
+> The sheet-engine integration sections (SheetView, YorkieStore, charts, conditional formatting, batch/CellIndex) are accurate, but the app-shell layer is stale: Document type, the editor-type set, routing/provider hierarchy, and presence mechanism all describe an older, sheets-plus-docs-plus-slides app that has since grown board/notes/PDF editors, workspaces, and folders.
+
+- **[high] roadmap-shipped** — The Multi-Editor section frames editors as exactly three types (type: "sheet" | "doc" | "slides") with routes /s /d /p. In reality DocumentType has seven values and three more editors are fully shipped and routed: PDF/image (/f/:id FileDetail), note (/n/:id NotesDetail), and board (/b/:id BoardDetail). getDocumentPath maps all seven types. A reader would wrongly conclude board/notes/PDF editors do not exist.
+  - _Evidence:_ src/types/documents.ts DocumentType = "sheet"|"doc"|"slides"|"pdf"|"note"|"image"|"board"; src/App.tsx routes /f/:id, /n/:id, /b/:id; src/app/documents/document-list-utils.ts getDocumentPath()
+- **[high] stale-reference** — The Type Definitions block declares Document = { id: number; title; description; createdAt; updatedAt } with no type field. The shipped Document has id: string (not number), a required type: DocumentType, required workspaceId, and optional folderId/author/editors/canManage; updatedAt is optional. The inline type even contradicts the doc's own Multi-Editor section which references doc.type.
+  - _Evidence:_ src/types/documents.ts Document type (id: string, type: DocumentType, workspaceId, folderId, author, editors, canManage)
+- **[medium] stale-reference** — The routing diagram shows `/ → Documents`, `/settings`, and `/:id → DocumentDetail`. Actual routing: `/` is HomeOrRedirect (marketing/landing), the document list lives at `/documents` and workspace-scoped `/w/:workspaceId`, and there are additional top-level routes (/shared/:token, /invite/:token, /datasources, /harness/*, workspace analytics/settings/datasources). The entire workspaces + folders concept is absent from the doc. The provider hierarchy is also reordered: actual is ThemeProvider > TooltipProvider > QueryClientProvider > BrowserRouter, whereas the doc shows QueryClientProvider > ThemeProvider > BrowserRouter and omits TooltipProvider.
+  - _Evidence:_ src/App.tsx (routes + provider nesting); src/app/home-or-redirect.tsx; src/main.tsx (StrictMode wraps App)
+- **[medium] stale-reference** — The Presence section defines UserPresence = { activeCell?, activeTabId?, username, email, photo } and describes the flow as keyed on activeCell. The shipped UserPresence extends the full User (id, authProvider, username, email, photo) and carries `selection?: SelectionPresence` as the primary field, with activeCell explicitly annotated `// legacy fallback for mixed-version peers`. The doc documents the legacy field as the current mechanism.
+  - _Evidence:_ src/types/users.ts UserPresence (selection?: SelectionPresence; activeCell marked legacy fallback)
+- **[low] implemented-not-documented** — The Document Management API table lists only fetchDocuments/fetchDocument/createDocument/deleteDocument. api/documents.ts also exports renameDocument, moveDocument, moveDocuments, and deleteDocuments (bulk + move), and createDocument accepts optional type and fileId. Separately, data validation (data-validation-panel.tsx), a comments system, and share-links are shipped but unmentioned, and DataSource in the doc omits the workspaceId field present in code.
+  - _Evidence:_ src/api/documents.ts; src/app/spreadsheet/data-validation-panel.tsx; src/api/share-links.ts; src/types/datasource.ts (workspaceId)
+
+### docs/design/sheets/datasource.md
+
+> File paths, crypto, SQL validation, query-execution limits, and ReadOnlyStore all match the code precisely, but the doc's per-user ownership/access model is stale — datasources are now workspace-scoped and shared among workspace members.
+
+- **[high] documented-not-implemented** — The 'Access Control' section states 'Every operation verifies ds.authorID === userId. Users can only access their own datasources.' The actual controller instead calls workspaceService.assertMember(ds.workspaceId, userId) on every route — access is granted to any member of the datasource's workspace, not just the creator (authorID). A reader would be misled about who can read/query/edit a datasource.
+  - _Evidence:_ packages/backend/src/datasource/datasource.controller.ts (assertMember on workspaceId at lines ~66,86-88,100-102,113-114); datasource.service.ts findAllByWorkspace (where: { workspaceId }), findRaw returns record for controller-layer access checks
+- **[high] roadmap-shipped** — Current Limitation #5 'Single-user datasources — Connections are private to the creator; collaborators ... cannot use a datasource tab unless they own the connection' is contradicted by the shipped code, and the Medium-term roadmap item 'Shared datasources' is effectively already implemented at the workspace level: any workspace member (via assertMember) can list, get, and execute queries against another member's datasource.
+  - _Evidence:_ packages/backend/src/datasource/datasource.controller.ts assertMember gating on /datasources/:id/query and list routes; prisma model DataSource has workspaceId + workspace relation (schema.prisma:37-38)
+- **[medium] implemented-not-documented** — The API Endpoints table omits two workspace-scoped routes and mischaracterizes the flat create route. Code exposes 'POST workspaces/:workspaceId/datasources' and 'GET workspaces/:workspaceId/datasources', and the flat 'POST /datasources' now requires a workspaceId in the request body (CreateDataSourceInWorkspaceDto) rather than being a plain per-user create.
+  - _Evidence:_ packages/backend/src/datasource/datasource.controller.ts:33,46 (workspace routes) and :60-67 (flat create uses dto.workspaceId + assertMember)
+- **[medium] stale-reference** — The documented Prisma DataSource model omits the workspaceId String field and the workspace Workspace relation (onDelete: Cascade) that exist in the actual schema; the doc's model implies datasources are only tied to a User via authorID.
+  - _Evidence:_ packages/backend/prisma/schema.prisma:24-39 includes workspaceId + workspace relation not shown in the doc's prisma block
+- **[low] other** — Current Limitation #9 'No column type mapping — All values are displayed as strings regardless of the PostgreSQL data type' is slightly stale: the service installs a custom pg type parser (datasourceTypeParser) that overrides parsing for DATE/TIMESTAMP/TIMESTAMPTZ (kept as raw text to avoid timezone shift). It is a narrow workaround, not full type mapping, so the limitation is largely still true but the blanket 'regardless of type' wording is inaccurate.
+  - _Evidence:_ packages/backend/src/datasource/datasource.service.ts:19-37 (RAW_TEXT_OIDS + datasourceTypeParser) and :206 (types: { getTypeParser: datasourceTypeParser })
+
+### docs/design/sheets/sheet-image.md
+
+> The frontend data model and Phase 1 floating-image feature match the code, but the entire backend storage section is wrong: the doc frames S3 as future infrastructure and describes a local-filesystem/Prisma-metadata design that was never built — the shipped service uses S3/MinIO directly with no database record.
+
+- **[high] roadmap-shipped** — The doc lists 'S3 storage, thumbnails, CDN (future infrastructure)' as a Phase 1 Non-Goal, puts 'S3 migration' in the Phase 2 roadmap, and states storage is 'local filesystem via StorageService abstraction (swap to S3 later)'. In reality the shipped ImageService is S3-only: it uses @aws-sdk/client-s3 (S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand) against a MinIO endpoint configured via IMAGE_STORAGE_* env vars. S3 is the current implementation, not a future migration.
+  - _Evidence:_ packages/backend/src/image/image.service.ts (S3Client, PutObjectCommand); packages/backend/src/image/image.config.ts (IMAGE_STORAGE_ENDPOINT default http://localhost:9000 MinIO, bucket wafflebase-images)
+- **[high] documented-not-implemented** — The doc specifies a Prisma `model Image` (id, workspaceId, filename, mimeType, size, width, height, storagePath, createdBy, createdAt) and describes image.service.ts as 'Metadata CRUD (Prisma)' with an upload flow step 'ImageService creates Image record in database'. No such model exists in the schema and the service never touches Prisma — images are stored purely as S3 objects keyed by UUID+extension, with no DB metadata row.
+  - _Evidence:_ grep 'model Image' / 'image' in packages/backend/prisma/schema.prisma returns nothing; packages/backend/src/image/image.service.ts has no Prisma/ConfigService DB access
+- **[medium] documented-not-implemented** — The documented module structure lists a `storage.service.ts` ('File I/O abstraction (local, future S3)') providing a StorageService, and the upload flow says 'StorageService writes file to uploads/images/:wid/:id.ext'. There is no StorageService anywhere (grep returns zero hits) and no local uploads/ path; the actual image/ dir instead contains image.config.ts and image.constants.ts (not mentioned) and a second controller api/v1/images.controller.ts. I/O is done inline in ImageService via S3.
+  - _Evidence:_ grep 'StorageService' packages/backend/src returns nothing; ls packages/backend/src/image/ = image.config.ts, image.constants.ts, image.controller.ts, image.module.ts, image.service.ts
+- **[low] stale-reference** — The upload flow states the response is '{ id, url, width, height }'. The actual POST handler returns only '{ id, url }' — no width/height are computed or returned by the backend.
+  - _Evidence:_ packages/backend/src/api/v1/images.controller.ts upload() returns { id: result.id, url }; ImageService.upload returns { id, url }
+
+### docs/design/sheets/xlsx-style-import.md
+
+> The doc's core premise — that XLSX style import is entirely unbuilt and this is the tracker to build it — is contradicted by shipped code: Phase 1 (styles.xml parsing → CellStyle, col widths, row heights, hidden) and Phase 2's range-style compaction are already implemented, though conditional formatting and the ff/fs/lk model extension remain correctly future.
+
+- **[high] roadmap-shipped** — The Summary/Motivation/Root-cause sections assert this is unbuilt: 'Today importXlsxWorkbook reads only cell values, formulas, and merges. It never opens xl/styles.xml and never inspects the per-cell s= attribute, so every fill, border, font weight/color, alignment, number format, column width, hidden row/column ... is discarded on import.' In reality Phase 1 is fully shipped. xlsx-importer.ts imports parseStyleTable from ./xlsx-styles, reads XLSX_STYLES_PATH ('xl/styles.xml', line 47/420), reads each cell's s attribute and calls styleTable.resolveCellStyle (lines 351-354), and writes worksheet.rangeStyles (line 387). A reader is actively misled about what exists.
+  - _Evidence:_ packages/sheets/src/import/xlsx-importer.ts lines 13, 47, 351-361, 387, 420; packages/sheets/src/import/xlsx-styles.ts (parseStyleTable, resolveCellStyle)
+- **[high] roadmap-shipped** — The Motivation table marks Fills, Borders, Cell formats (cellXfs alignment/wrapText), Number formats, and Column widths/hidden cols all as '❌ Currently imported? No', and the Fonts row (bold/underline/strike) as ❌. All of these ARE imported: xlsx-styles.ts parses fonts (b/i/u/st, text color), fills (bg), borders (bt/br/bb/bl), numFmts (number/currency/percent/date), and alignment (al/va); the importer applies column widths via applyColumns, row heights and hidden rows via applyRowStyles, and hidden columns. Only font family/size (Roboto/Arial, 10/11pt) within the Fonts row remain unimplemented (Phase 3).
+  - _Evidence:_ packages/sheets/src/import/xlsx-styles.ts lines 108-165 (fonts/fills/borders/numFmt parsing); packages/sheets/src/import/xlsx-importer.ts applyColumns (271-302), applyRowStyles (304-319), convertDateSerial (222-243)
+- **[medium] stale-reference** — Root cause bullet: 'parseCell() (xlsx-importer.ts:187) reads only <f> and <v>; the s attribute is ignored.' The s attribute is not ignored — it is read and resolved in parseWorksheet (cell.getAttribute('s') → styleTable.resolveCellStyle) at lines 351-354. Also the line reference is off: parseCell is defined at line 198 (line 187 falls inside resolveCellValue).
+  - _Evidence:_ packages/sheets/src/import/xlsx-importer.ts lines 198-211 (parseCell), 351-354 (s resolution)
+- **[medium] roadmap-shipped** — Rollout Phase 2 bundles 'compaction' with 'conditional formatting'. The compaction half is shipped — the importer coalesces per-cell patches into maximal rectangles via coalesceRangeStylePatchesMaximal — but conditional-formatting import is genuinely not built (no conditionalFormatting/cfRule/dxfs parsing anywhere in packages/sheets/src/import). The doc frames all of Phase 2 as future. Additionally the Risks table names coalesceAdjacentRangeStylePatches as the Phase 1 coalescer, whereas the shipped importer calls coalesceRangeStylePatchesMaximal (both functions exist in range-styles.ts).
+  - _Evidence:_ packages/sheets/src/import/xlsx-importer.ts line 387 (coalesceRangeStylePatchesMaximal); packages/sheets/src/model/worksheet/range-styles.ts lines 329 & 465; grep for conditionalFormatting/cfRule/dxfs in packages/sheets/src/import returned no matches
+
+### docs/design/slides/slides-gradient-editing.md
+
+> The editing UI and model type-discriminator shipped as described, but the doc's core linear+radial widening never landed (render/import/export/UI are still linear-only) and its "slide backgrounds stay solid-only" Non-Goal is contradicted by shipped gradient-background support.
+
+- **[high] documented-not-implemented** — A core Goal ('Widen the model / renderer / importer / exporter from linear-only to linear + radial, preserving radial gradients through the PPTX round-trip') plus the entire Render, Import, and PPTX-export sections describe radial gradient support. Only the model's `type`/`center` fields shipped; the actual radial behavior did not. `resolveFillStyle` has no radial branch and never calls `createRadialGradient` (it only builds `createLinearGradient`). `parseGradientFill` still collapses every `<a:path>` gradient (including `path="circle"`) to a single stop with `type:'linear'` and never reads `<a:fillToRect>` or derives `center`. `gradFillXml` always emits `<a:lin ang>` with no `type` switch and no `<a:path path="circle">`/`fillToRect` output. `GradientEditor` has no Linear|Radial toggle and its own comment states 'Radial gradients are a later phase — this editor only ever emits type: \'linear\''. A reader would wrongly believe radial gradients round-trip and are editable.
+  - _Evidence:_ packages/slides/src/view/canvas/render-context.ts:20-49 (linear-only resolveFillStyle, no createRadialGradient); packages/slides/src/import/pptx/shape.ts:956-962 ('<a:path>' collapsed to [stops[0]], type:'linear'); packages/slides/src/export/pptx/color.ts gradFillXml (always <a:lin>, doc-comment 'Serialize a linear GradientFill'); packages/frontend/src/app/slides/fill-picker/gradient-editor.tsx:50-54 ('this editor only ever emits type: linear')
+- **[high] roadmap-shipped** — The Non-Goals list 'Gradient fills on text boxes, table cells, and slide backgrounds. Those remain solid-only parallel stacks.' Slide backgrounds actually DO support gradient fills now: `Background.fill` is typed `Fill` (which includes `GradientFill`), the background side panel renders the same `FillPicker` (Solid|Gradient tabs), and `use-slide-background` implements `onChangeGradient`/`persistGradient` writing a gradient fill via `updateSlideBackground({ fill })` with a live-drag `gradientDraft`. (Text boxes and table cells do remain solid-only — table-controls uses ThemedColorPicker directly — so the non-goal is only wrong about backgrounds.)
+  - _Evidence:_ packages/slides/src/model/presentation.ts:28 (Background.fill?: Fill); packages/frontend/src/app/slides/background-side-panel.tsx:105-111 (FillPicker with onChangeGradient); packages/frontend/src/app/slides/use-slide-background.ts:95-124,193 (onChangeGradient/persistGradient → updateSlideBackground({fill}))
+
+### docs/design/slides/slides-image-crop.md
+
+> The doc's entire premise — that the interactive crop UX is "missing" and only a disabled placeholder ships — is inverted: the full P0 crop feature (editor session, active toolbar button, double-click entry, model helpers, renderer overlay, tests) is already shipped.
+
+- **[high] roadmap-shipped** — The Summary states 'What is missing is the interactive crop UX: there is no way for a user to define or adjust a crop in the editor' and 'The toolbar ships a disabled IconCrop placeholder ... deferred to a separate spec'. In current code the whole P0 crop UX is fully implemented: editor.ts has cropSession, enterImageCrop/exitImageCrop/isCropping/onCropChange/resetImageCrop, double-click on an image enters crop (el.type==='image' branch), and the toolbar Crop button is active (calls enterImageCrop, shows aria-pressed/'Done cropping'). A reader would be misled into thinking none of this exists.
+  - _Evidence:_ packages/slides/src/view/editor/editor.ts (cropSession at 831; enterImageCrop at 3677; exitImageCrop at 1350/2209/2215; image double-click branch ~3671-3679); packages/frontend/src/app/slides/toolbar/image-controls.tsx:90-138 (active Crop button, isCropping/onCropChange, aria-pressed)
+- **[high] roadmap-shipped** — The doc lists model helpers, renderer overlay, and coordinate math as proposed new work to add. They are already implemented: model/image-crop.ts exports applyCropHandle, panFull, windowToFrame, rotateVec, MIN_CROP_PX and crop/full derivation; image-renderer.ts exports drawCropPreview used by slide-renderer.ts. Dedicated tests also already exist.
+  - _Evidence:_ packages/slides/src/model/image-crop.ts (applyCropHandle:72, panFull:109, windowToFrame:168, MIN_CROP_PX:32); packages/slides/src/view/canvas/image-renderer.ts:107 drawCropPreview; test/model/image-crop.test.ts, test/view/canvas/crop-preview.test.ts, test/view/editor/image-crop-session.test.ts
+- **[low] stale-reference** — Proposed API/structure names differ from what shipped: doc specifies methods enterCropMode/exitCropMode and a croppingElementId field, plus a new interactions file view/editor/interactions/crop.ts. Shipped code uses enterImageCrop/exitImageCrop (no croppingElementId field — only cropSession), and places helpers in model/image-crop.ts with the session inline in editor.ts (no crop.ts interaction file exists).
+  - _Evidence:_ grep found no croppingElementId or crop.ts in packages/slides; editor.ts uses cropSession + enterImageCrop/exitImageCrop; helpers live in packages/slides/src/model/image-crop.ts
+- **[low] stale-reference** — The 'existing surface' table cites the toolbar path as 'frontend/.../toolbar/image-controls.tsx' with state 'partial (Crop disabled)'. Actual path is packages/frontend/src/app/slides/toolbar/image-controls.tsx and the Crop button is fully wired, not disabled.
+  - _Evidence:_ packages/frontend/src/app/slides/toolbar/image-controls.tsx:124-138
+
+### docs/design/slides/slides-native-undo.md
+
+> The doc is written as a future proposal to migrate YorkieSlidesStore off snapshot undo, but that migration is already fully shipped in code, so the doc's "current behavior" description and its entire proposal are stale.
+
+- **[high] roadmap-shipped** — The doc's whole thesis ("This document specifies migrating Slides to doc.history ... and removing the snapshot machinery") is already implemented. YorkieSlidesStore uses doc.history.undo()/redo(), the ambient-root batch refactor (activeRoot/activePresence/withUpdate), the undoFloor + canUndo floor gate, and even markUndoBaseline — exactly as proposed. The class doc-comment itself cites this design doc as the shipped rationale.
+  - _Evidence:_ packages/frontend/src/app/slides/yorkie-slides-store.ts: undo()/redo() at ~L632-645 call this.doc.history.undo()/redo(); withUpdate() L590-596; batch() single doc.update L598-630; undoFloor field L347 + canUndo() L647-656; markUndoBaseline() L669-671; class comment L302-314 references docs/design/slides/slides-native-undo.md
+- **[high] documented-not-implemented** — The Summary describes CURRENT YorkieSlidesStore behavior as snapshot-based: "batch() pushes a full SlidesDocument snapshot onto an undoStack, and undo() restores it by reconciling the live Yorkie root against the snapshot." None of this exists in the Yorkie store anymore. grep for undoStack/redoStack/replaceRoot/reconcileArrayById/reconcileObjectFields/updateGroupData in yorkie-slides-store.ts returns nothing; that snapshot machinery survives only in MemSlidesStore (memory.ts L1791-1808), which the doc correctly scopes as a Non-Goal. A reader would be misled into thinking the Yorkie store still snapshots.
+  - _Evidence:_ grep of packages/frontend/src/app/slides/yorkie-slides-store.ts finds no undoStack/redoStack/replaceRoot/reconcile* symbols; packages/slides/src/store/memory.ts L1791-1808 still has this.undoStack.push / this.redoStack
+- **[medium] roadmap-shipped** — The Test Strategy lists tests to "Add" (multi-element-drag grouping test; undo-floor test ported from Docs) and to "Keep" ("one batch = one undo entry"). These already exist and pass, under a describe block explicitly named for native doc.history.
+  - _Evidence:_ packages/frontend/tests/app/slides/yorkie-slides-store.test.ts: describe 'YorkieSlidesStore — undo/redo (Yorkie-native doc.history)' L202; 'one batch = one undo entry' L203; 'groups a multi-element drag into a single undo unit' L217; 'cannot undo past the seeded initial state (undo floor)' L259; 'markUndoBaseline protects a post-construction deck seed' L286
+
+### docs/design/slides/slides-theme-catalog.md
+
+> The doc's proposed change (de-brand defaults, expand to 23 themes) is fully shipped in code, yet the doc still frames it as an unbuilt "Proposal/Rollout" and its "Current state" section describes the obsolete 5-theme brand-baked state as if it were present.
+
+- **[high] stale-reference** — The 'Current state' section claims packages/slides/src/themes/index.ts 'registers five themes in picker order: defaultLight, defaultDark, streamline, focus, material' and shows default-light.ts binding accent1: palette.syrup with brand display fonts. The real current code registers 23 themes in BUILT_IN_THEMES and default-light.ts is already de-branded (accent1: '#1A73E8', fonts: Inter/Inter). The section describes the pre-change state as if it were current, actively misleading a reader about what exists.
+  - _Evidence:_ packages/slides/src/themes/index.ts (BUILT_IN_THEMES has 23 entries: defaultLight..beachDay, wafflebase); packages/slides/src/themes/default-light.ts (accent1 '#1A73E8', Inter); git log commit 57e964683 '#383 de-brand defaults, expand to 23 themes'
+- **[high] roadmap-shipped** — The entire doc is written as a forward-looking proposal ('This design de-brands...', 'Proposal', 'Rollout: Single PR, commit-layered', 'Acceptance: BUILT_IN_THEMES has 23 entries'). All of it is already implemented and merged: 23 theme literals exist, default-light/dark are de-branded, and a dedicated wafflebase.ts brand theme with palette.syrup/butter/berry/leaf bindings ships last in the picker exactly as proposed.
+  - _Evidence:_ packages/slides/src/themes/wafflebase.ts (brand palette + typography.display/body); packages/slides/src/themes/index.ts (23-entry BUILT_IN_THEMES, wafflebase last); git commit 57e964683 (#383)
+- **[medium] stale-reference** — The Testing section names two unit tests at packages/slides/src/themes/*.test.ts: 'catalog.test.ts' and 'fonts-in-catalog.test.ts'. catalog.test.ts exists as claimed, but 'fonts-in-catalog.test.ts' does not exist in that directory; the font-in-catalog assertion shipped instead as packages/frontend/src/app/slides/theme-fonts.test.ts. The doc also omits the shipped packages/slides/src/themes/debrand.test.ts.
+  - _Evidence:_ packages/slides/src/themes/catalog.test.ts and debrand.test.ts exist; no fonts-in-catalog.test.ts anywhere; packages/frontend/src/app/slides/theme-fonts.test.ts ('theme fonts are in the catalog')
+- **[low] stale-reference** — The doc refers to the brand tokens package as '@wafflebase/tokens' (Summary line 14, De-branding line 101, line 170). The shipped wafflebase.ts imports palette/typography from '@wafflebase/core/tokens' — the tokens were extracted into @wafflebase/core (commit 174c7e006 'Extract @wafflebase/core').
+  - _Evidence:_ packages/slides/src/themes/wafflebase.ts line 2: import { palette, typography } from '@wafflebase/core/tokens'; git commit 174c7e006
+
+### docs/design/slides/slides-themes-layouts-import.md
+
+> The core theme/layout/import model, resolvers, and store mutations match code, but the doc's Non-Goals/Future sections mis-frame several features as out-of-scope/deferred that have actually shipped (PPTX export, first-class groups, first-class tables, a 100+-kind shape registry).
+
+- **[high] roadmap-shipped** — Doc lists PPTX export as a Non-Goal ('out of scope. PDF export remains the only export format. PPTX export is on the v2 backlog') and repeats it under Future/Out of Scope. In reality a full PPTX exporter is shipped and wired end-to-end (package export, frontend action, CLI command).
+  - _Evidence:_ packages/slides/src/export/pptx/ (20 files incl. index.ts's 451-line exportPptx); packages/slides/src/index.ts:250 `export { exportPptx }`; packages/frontend/src/app/slides/pptx-actions.ts:2,92; packages/cli/src/slides/pptx-export.ts + packages/cli/src/commands/slides.ts:175 `.command('export <doc-id> <file>').description('Export a slide deck to PPTX')`
+- **[high] roadmap-shipped** — Doc Non-Goals says 'Group elements as a first-class kind — still v2' and that PPTX <p:grpSp> is 'flattened on import' (mapping table: ⚠️ group lost); Future repeats 'Group / ungroup elements — still v2'. Code has a first-class GroupElement and the importer preserves grpSp as a GroupElement (not flattened), with group/ungroup editor + toolbar ops.
+  - _Evidence:_ packages/slides/src/model/element.ts:399 `GroupElement` (type:'group'); packages/slides/src/import/pptx/shape.ts:138,169,185,204 'preserving groups as GroupElement'; packages/frontend/src/app/slides/toolbar/arrange-menu.tsx (group/ungroup)
+- **[medium] roadmap-shipped** — Doc mapping table and 2026-05-15 re-validation frame PPTX tables as lossy — a 'Matrix of TextElements + border ShapeElements per cell' until docs-tables integration in v1.5. Code imports tables as a first-class TableElement.
+  - _Evidence:_ packages/slides/src/model/element.ts:533 `TableElement` (type:'table'); packages/slides/src/import/pptx/table.ts:78-94 builds a TableElement and returns [table]
+- **[medium] roadmap-shipped** — Non-Goals says 'Shape library expansion beyond rect/ellipse/line/arrow/roundRect — v2 work. Unsupported PPTX shapes become a placeholder rect on import' and Future repeats 'chevron, donut, blockArc, can, etc. remain placeholder rects until v2'. Code ships a large ShapeKind registry (chevron/donut/blockArc/can/uturnArrow and 100+ kinds). The doc's own re-validation section acknowledges the '117-kind registry' but the Non-Goals/Future scoping sections were not updated.
+  - _Evidence:_ packages/slides/src/model/element.ts:54 `export type ShapeKind =` large union incl 'donut'(61),'blockArc'(62),'chevron'(72),'uturnArrow'(75); shape renderers under packages/slides/src/view/canvas/shapes/{flowchart,arrows,callouts,stars,banners,...}
+- **[low] stale-reference** — Primary sections (Goals, 'Built-in themes (5)', theme table, picker mockup) present 5 built-in themes as the shipped set; 23 theme modules ship. The doc's PR3 re-review self-corrects ('theme count grew 5 → 23'), so it is internally acknowledged but the main sections remain stale.
+  - _Evidence:_ packages/slides/src/themes/ contains 23 theme modules (default-light, default-dark, streamline, focus, material, beach-day, coral, forest, geometric, luxe, marina, modern-writer, momentum, paradigm, plum, pop, shift, slate, spearmint, spotlight, swiss, tropic, wafflebase)
+- **[low] stale-reference** — Yorkie-deck table cites SLIDE_WIDTH/HEIGHT at 'presentation.ts:50-51'; the constants live at lines 238/243. Constants exist as described; only the line reference is stale.
+  - _Evidence:_ packages/slides/src/model/presentation.ts:238 `export const SLIDE_WIDTH = 1920;`, :243 `export const SLIDE_HEIGHT = 1080;`
+
+### docs/design/slides/slides-tables.md
+
+> The doc's data model, Yorkie schema, and store signatures match shipped code closely, but it is framed as a forward-looking proposal (P1–P6 plan, "cell selection arrives in P3") when in reality nearly the entire feature — cell-range selection, structural ops, Yorkie collaboration, and PDF export — is already implemented.
+
+- **[high] roadmap-shipped** — The 'Known limitations (P1)' section states 'Cell-range selection is absent... Cell selection, Tab/Shift+Tab navigation, and structural ops arrive in P3.' All of this is shipped: the editor implements cell-range selection and hit-testing, and structural ops exist in both stores.
+  - _Evidence:_ packages/slides/src/view/editor/editor.ts (startCellRangeDrag, tableCellAtPoint, projectCellRangeRects, cellRangeRects overlay); packages/slides/src/view/editor/overlay.ts makeCellRangeRect; packages/slides/src/view/editor/interactions/keyboard.ts (cell-range delete via withTableCellBody); packages/slides/src/view/canvas/table-renderer.ts exports tableCellAtPoint/tableEdgeAt/nextCellInDirection
+- **[high] roadmap-shipped** — The Phasing table presents P1–P6 as a forward plan, but P3 (cell editing/text-bridge), P4 (insert/delete row+col, merge/unmerge, drag-resize), P5 (YorkieSlidesStore table ops + selectedTableCells presence + concurrent integration test), and P6 (PDF export table case) are all shipped in the current tree. The proposal is effectively built, not planned.
+  - _Evidence:_ packages/slides/src/store/memory.ts and packages/frontend/src/app/slides/yorkie-slides-store.ts implement insertTableRow/deleteTableRow/insertTableColumn/deleteTableColumn/mergeTableCells/unmergeTableCells/updateTableColumnWidths/updateTableRowHeights/updateTableCellStyle/withTableCellBody; packages/frontend/tests/app/slides/yorkie-slides-table-concurrent.integration.ts; packages/slides/src/export/pdf.ts line 238 (el.type === 'table' case)
+- **[low] documented-not-implemented** — The Store interface section adds `addTable(slideId, init)` as the table-creation method. No `addTable` exists on SlidesStore; tables are created through the generic `addElement(slideId, init: ElementInit)` plus the editor's `insertTable(rows, cols, opts)` helper.
+  - _Evidence:_ packages/slides/src/store/store.ts (addElement at line 167, no addTable); packages/slides/src/view/editor/editor.ts insertTable at line 1558; grep for addTable across store files returns nothing
+- **[low] documented-not-implemented** — PPTX import section says the retired counters are 'replaced with ctx.report.tablesImported (success count) and ctx.report.tableCellsImported.' The code retired tableMergesIgnored/tableBordersApproximated but added no replacement counters; report.ts comment states 'there is no lossy path to count.' No tablesImported/tableCellsImported exists.
+  - _Evidence:_ packages/slides/src/import/pptx/report.ts lines 28-31; grep for tablesImported/tableCellsImported returns no code hits
+- **[low] stale-reference** — P5 verification names the integration test `two-user-slides-table-yorkie.ts`, but the actual concurrent Yorkie table test is named differently.
+  - _Evidence:_ actual file packages/frontend/tests/app/slides/yorkie-slides-table-concurrent.integration.ts; grep for two-user-slides-table finds nothing
+
+### docs/design/design-system-unification.md
+
+> The token/toolbar architecture and named files all check out, but the Status table and the PR #5 narrative are stale — notably the doc claims Sheets has no formatting toolbar and marks it "Not started" while a fully-wired Sheets FormattingToolbar is shipped on main.
+
+- **[high] roadmap-shipped** — PR #5 body states "Sheets currently has no formatting toolbar — all formatting flows through context menus and side panels" and the Status table marks #5 "Not started". In reality a Sheets FormattingToolbar is shipped and mounted: it provides bold/italic, horizontal+vertical alignment, number format, and text/background color via the shared ToolbarButton/ColorPickerGrid — exactly the "minimal set" PR #5 describes. The doc even contradicts itself: Phase 2 ("shipped") says it migrated the Sheets `formatting-toolbar` buttons to ToolbarButton.
+  - _Evidence:_ packages/frontend/src/components/formatting-toolbar.tsx (export function FormattingToolbar; imports Toolbar/ToolbarSeparator/ToolbarButton, BG_COLORS/TEXT_COLORS, IconBold/IconItalic/IconAlign*, NumberFormat/VerticalAlign from @wafflebase/sheets), imported by packages/frontend/src/app/spreadsheet/sheet-view.tsx
+- **[medium] roadmap-shipped** — Status table lists "Toolbar dropdown unification (Phases 1–3)" as "In review — PR #498 ... 2026-07-19", but PR #498 was merged to main (its Phase 1/2/3 artifacts — toolbar.tsx ToolbarButton with variant icon|menu + forwardRef, color-swatch.tsx, ui/popover.tsx — are all present on main).
+  - _Evidence:_ git log main: 5daa1bfde "Unify toolbar dropdowns across editors (#498)" touches packages/frontend/src/components/ui/toolbar.tsx, color-swatch.tsx, ui/popover.tsx
+- **[medium] roadmap-shipped** — Status table shows PR #1 `@wafflebase/tokens` package as "Ready to merge — Branch tokens-package, 2026-05-24". It is actually fully shipped: the tokens package landed (PR #292) and was then folded into @wafflebase/core/tokens (PR #477). The doc body carries an "Update (superseded location)" note about the core fold, but the Status row was never updated to reflect that the work merged.
+  - _Evidence:_ packages/core/src/tokens/{palette,semantic,radius,typography,contrast,index}.ts exist; git log 174c7e006 "Extract @wafflebase/core (tokens + geometry) — shared-core PR1 (#477)"; f36873543 "Introduce @wafflebase/tokens shared design tokens package (#292)"
+- **[medium] roadmap-shipped** — PR #3 "Shared toolbar components" is marked "Not started", but two of its four listed deliverables shipped via #498: `<ToolbarButton>` (packages/frontend/src/components/ui/toolbar.tsx) and `<ColorSwatch>` (packages/frontend/src/components/color-swatch.tsx). Only the `<EditorToolbar>` shell and `<ToolbarGroup>` remain unbuilt (no such symbols found anywhere in packages/frontend/src). The doc's own audit section admits the shared Toolbar/ToolbarButton already exist, but the Status row still reads "Not started".
+  - _Evidence:_ packages/frontend/src/components/ui/toolbar.tsx exports Toolbar/ToolbarSeparator/ToolbarButton; packages/frontend/src/components/color-swatch.tsx exports ColorSwatch; grep for EditorToolbar/ToolbarGroup returns no matches
+- **[low] stale-reference** — Surface-inventory table row "Toolbars | ... Sheets (none)" is stale (a Sheets toolbar exists). The doc partly self-corrects in the 2026-07 audit section ("the surface inventory above predates" the Notes/Sheets toolbars), so this is acknowledged staleness rather than a hidden error.
+  - _Evidence:_ packages/frontend/src/components/formatting-toolbar.tsx (Sheets) vs doc line "Sheets (none)"
+
+### docs/design/docs/docs-docx-import-export.md
+
+> The design is implemented with high fidelity, but the doc still frames the entire feature as unbuilt future work when it is fully shipped and released in v0.3.2.
+
+- **[high] roadmap-shipped** — The doc frames the whole feature as future/planned work: the Summary says these are 'prerequisite features that the Docs model does not yet support', Goals are imperative ('Add the ability'), and everything is under 'Phase 1/2/3'. In reality all of it is shipped and released: inline images (ImageData + image field on InlineStyle in model/types.ts), the backend S3/image module, web-font loading, DOCX import, and DOCX export. A reader would be misled into thinking none of this exists yet.
+  - _Evidence:_ packages/docs/src/import/docx-importer.ts (parseHeaderFooter, convertTable recursion, findDirectChild all present), packages/docs/src/export/docx-exporter.ts (DocxExporter class, buildHeaderFooterXml), packages/backend/src/image/{image.controller.ts @Controller('images') POST/GET(:id)/DELETE(:id), image.config.ts IMAGE_STORAGE_* env vars, image.service.ts @aws-sdk/client-s3}, packages/docs/src/view/fonts.ts (Malgun Gothic/Batang/Noto Sans KR mapping), model/types.ts:119 ImageData & :185 image?, docker-compose.yaml minio service, archived completion todo docs/tasks/archive/2026/04/20260410-docx-import-export-todo.md
+- **[low] stale-reference** — The File Structure section lists export/docx-builder.ts ('XML generation utilities'), but no such file exists; the XML-generation module is actually named docx-templates.ts.
+  - _Evidence:_ packages/docs/src/export/ contains docx-exporter.ts, docx-style-map.ts, docx-templates.ts (no docx-builder.ts)
+- **[low] stale-reference** — The doc references adding MinIO to docker-compose.yml and lists docker-compose.yml in the File Structure, but the actual file is docker-compose.yaml (and it already contains the minio service).
+  - _Evidence:_ docker-compose.yaml lines 20-31 (minio service); no docker-compose.yml exists at repo root
+- **[low] implemented-not-documented** — The import File Structure omits import/units.ts, a shipped module used for OOXML unit conversions.
+  - _Evidence:_ packages/docs/src/import/units.ts exists but is not listed in the doc's File Structure
+
+### docs/design/docs/docs-comments.md
+
+> The core docs-comments design (shared module, Yorkie store, orphan/anchor handling, editor setCommentMarkers, bootstrap comments seeding) is faithfully implemented, but the doc's Non-Goals and consumer/type-ownership claims are now materially stale: @user mentions shipped, a whole undocumented PDF-comments consumer exists, base types are owned by @wafflebase/sheets rather than the frontend module, and the described visual test harness does not exist.
+
+- **[high] roadmap-shipped** — Non-Goals and Phase Plan step 4 list '@user mentions and notifications (later phase)' as not built, but @user mentions are fully shipped: encode/parse/query/apply helpers plus a mention picker are wired into the composer and rendered bodies.
+  - _Evidence:_ packages/frontend/src/components/comments/mentions.ts (serializeMention, parseMentionBody, detectMentionQuery, applySelectedMentions, extractMentionedUserIds), use-workspace-members.ts, and usage in components/CommentComposer.tsx, CommentBody.tsx, CommentSidePanel.tsx; tests/components/comments/comment-composer-mentions.test.ts. (Notifications/backend job remain unbuilt, consistent with the doc.)
+- **[medium] implemented-not-documented** — The CommentAnchor union and consumer list omit a shipped PDF consumer. The shared union now includes a 'pdf-region' variant (PdfRegionAnchor) and a full app/files/comments/ consumer, none of which the doc mentions (it lists only sheets/docs/slides).
+  - _Evidence:_ packages/frontend/src/types/comments.ts (PdfRegionAnchor, CommentAnchor = SheetCellAnchor | DocsRangeAnchor | PdfRegionAnchor); packages/frontend/src/app/files/comments/pdf-comment-store.ts, pdf-comments-controller.ts; tests/app/files/pdf-comment-store.test.ts
+- **[medium] documented-not-implemented** — The doc lists packages/frontend/visual/docs-comments.spec.ts as a NEW file and devotes section 8.3 to a visual/interaction harness there, but neither the file nor the packages/frontend/visual/ directory exists.
+  - _Evidence:_ packages/frontend/visual/ does not exist (ls: No such file or directory); no docs-comments.spec.ts found anywhere under packages/frontend
+- **[medium] other** — Ownership drift vs stated boundaries. The doc says the shared frontend module owns the comment data model (types.ts defines Comment/CommentAuthor/Thread/CommentAnchor) and that packages/sheets is untouched (Non-Goal #1). In reality Comment/CommentAuthor and the base Thread<A> are owned by @wafflebase/sheets and re-exported; components/comments/types.ts is a re-export shim and the anchor union lives in @/types/comments.ts, not the module's own types.ts.
+  - _Evidence:_ packages/frontend/src/components/comments/types.ts (re-exports from @/types/comments.ts); packages/frontend/src/types/comments.ts imports Comment/CommentAuthor/Thread from '@wafflebase/sheets'; packages/sheets/src/comment/types.ts defines Comment, CommentAnchor, generic Thread<A>
+- **[low] stale-reference** — Editor API signatures differ from the doc: doc declares setCommentMarkers(rects: HighlightRect[]) with a HighlightRect type; code has setCommentMarkers(markers: CommentMarker[]) and getCommentMarkerAt(clientX, clientY) rather than (x, y).
+  - _Evidence:_ packages/docs/src/view/editor.ts:198 setCommentMarkers(markers: CommentMarker[]); :206 getCommentMarkerAt(clientX, clientY)
+- **[low] stale-reference** — Test file locations differ from the doc, which shows colocated __tests__ (src/components/comments/__tests__/, src/app/docs/__tests__/comments.test.ts). Actual tests live under a top-level packages/frontend/tests/ mirror.
+  - _Evidence:_ packages/frontend/tests/components/comments/mem-comment-store.test.ts, tests/app/docs/comments/yorkie-comment-store.test.ts (no src/**/__tests__ comment dirs)
+- **[low] stale-reference** — Minor interface drift: the doc labels CommentStore as a '6 methods' interface CommentStore<A>, but the shipped interface has 7 members and an extra type parameter CommentStore<A, AnchorInput = A>.
+  - _Evidence:_ packages/frontend/src/components/comments/comment-store.ts (CommentStore<A, AnchorInput = A>; addThread/addReply/editComment/deleteComment/setThreadResolved/listThreads/subscribe)
+- **[low] stale-reference** — Section 4's DocsDocument schema lists root.header and root.footer as existing JSON fields; the actual Yorkie docs root has no header/footer and instead carries a stylesJson field (comments? and pageSetup? match).
+  - _Evidence:_ packages/frontend/src/types/docs-document.ts YorkieDocsRoot = { content, pageSetup?, stylesJson?, comments? }
+
+### docs/design/pdf.md
+
+> Phase 1 is implemented accurately, but the entire Phase 2 (share-token serving, comments, presence, shared route, Share button) is fully shipped despite the doc framing it as an unbuilt "implementation spec," and the FileService now accepts images too, contradicting its stated PDF-only scope.
+
+- **[high] roadmap-shipped** — The doc frames all of Phase 2 as future work ("covers ... Phase 2 as an implementation spec", "the order below is also the intended PR sequence", Non-Goals list comments/presence/share-token viewing as "moved to Phase 2 below"). In reality every Phase 2 slice is shipped: Slice 1 share-token serving, Slice 2 pdf-<id> Yorkie doc + comment store, Slice 3 comment UI/region pins, Slice 4 presence, Slice 5 shared route + Share button. A reader would be misled into thinking PDF comments/sharing/presence do not yet exist.
+  - _Evidence:_ packages/backend/src/document/document-file.controller.ts (OptionalJwtAuthGuard + ?token= share-link resolution = Slice 1); packages/frontend/src/app/files/pdf-collab.tsx (DocumentProvider docKey=`pdf-${id}`, initialRoot, activePage presence write), comments/pdf-comment-store.ts, comments/pdf-comments-controller.ts, pdf-comment-layer.tsx; packages/frontend/src/types/comments.ts (PdfRegionAnchor in CommentAnchor union); packages/frontend/src/types/users.ts (PdfPresence); packages/frontend/src/types/pdf-document.ts (initialPdfRoot seeding comments:{}); packages/frontend/src/app/shared/shared-document.tsx (`if (resolved.type === 'pdf')` case); packages/frontend/src/app/files/file-detail.tsx (ShareDialog header button); packages/frontend/src/api/files.ts (pdfFileUrl appends token)
+- **[medium] implemented-not-documented** — The Storage layer section states FileService "accepts application/pdf only" and that the image/ module is left untouched with a clean boundary. The shipped FileService actually also accepts image/png, image/jpeg, image/gif, image/webp with a separate 25 MB image cap (MAX_IMAGE_UPLOAD_BYTES) alongside the 50 MB PDF cap, and there is a whole 'image' document type (image-viewer.tsx, DocumentType 'image', file-shell handling image docs) the doc never mentions.
+  - _Evidence:_ packages/backend/src/file/file.config.ts (allowedMimeTypes includes the four image types); packages/backend/src/file/file.service.ts (MIME_TO_EXT + per-category cap using MAX_IMAGE_UPLOAD_BYTES); packages/backend/src/file/file.constants.ts (MAX_IMAGE_UPLOAD_BYTES, VALID_FILE_ID_PATTERN allows png/jpe?g/gif/webp); packages/frontend/src/app/files/image-viewer.tsx; packages/frontend/src/types/documents.ts (DocumentType includes 'image')
+- **[low] stale-reference** — The Serving section says blob deletion is done by hooking into DocumentService delete. In the code the DocumentService delete methods do no blob cleanup; cleanup is done best-effort in the controller after deletion (per the deleteDocuments doc-comment). Minor location drift, not a missing feature.
+  - _Evidence:_ packages/backend/src/document/document.service.ts:126-143 (deleteDocument/deleteDocuments have no fileService.delete; comment: "Blob cleanup ... is done best-effort by the controller after this returns")
+- **[low] stale-reference** — The doc says blob-id validation "mirrors VALID_IMAGE_ID_PATTERN"; the shipped constant is named VALID_FILE_ID_PATTERN and validates both pdf and image extensions, reflecting the broadened (non-PDF-only) file module. Cosmetic naming/scope drift.
+  - _Evidence:_ packages/backend/src/file/file.constants.ts (VALID_FILE_ID_PATTERN); referenced in packages/backend/src/document/document-file.controller.ts
+
+### docs/design/sharing.md
+
+> The ShareLink model, REST endpoints, permission matrix, and sheet/docs read-only modes match the code exactly, but the doc's security section is materially stale: server-side write protection and rate limiting are actually shipped, and sharing now covers four document types the doc never mentions.
+
+- **[high] roadmap-shipped** — The doc's Non-Goals says 'Server-side write protection — view-only enforcement is client-side only', the Security section says view-only is 'enforced in the browser' and 'Yorkie does not support per-user write auth', and the Risks section frames server-side enforcement as future ('server-side enforcement can be added later via Yorkie webhooks'). In reality the Yorkie auth webhook enforces share-link roles server-side: for an anonymous share visitor hasAccess() returns `needWrite ? link.role === 'editor' : true`, so a viewer-role token requesting an 'rw' verb is denied (403). A reader is actively misled about the security posture — writes by viewer links ARE blocked server-side.
+  - _Evidence:_ packages/backend/src/document/yorkie-auth.controller.ts hasAccess() lines ~171-204 (return needWrite ? link.role === 'editor' : true); imports ShareLinkService; checkAttribute returns 403 on no access
+- **[medium] roadmap-shipped** — The doc says 'No rate limiting on token resolution — The public resolve endpoint could be brute-forced ... rate limiting via @nestjs/throttler can be added as needed.' @nestjs/throttler is in fact installed and wired globally as an APP_GUARD ThrottlerGuard (default 120 req/min), and the resolve controller carries no @SkipThrottle, so GET /share-links/:token/resolve is already rate limited.
+  - _Evidence:_ packages/backend/src/app.module.ts lines 91-119 (ThrottlerModule.forRoot + APP_GUARD ThrottlerGuard); packages/backend/src/share-link/share-link.controller.ts resolve() has no SkipThrottle
+- **[medium] implemented-not-documented** — The doc only documents shared read-only support for the Sheet and Docs packages, and its 'Shared document route' section describes rendering 'the spreadsheet' following tabOrder. The shipped shared route additionally handles slides, notes, board, and PDF document types with dedicated read-only layouts, and the resolve endpoint returns a `type` used to branch across all of them. A reader would think only sheets and docs are shareable.
+  - _Evidence:_ packages/frontend/src/app/shared/shared-document.tsx SharedSlidesLayout, SharedNotesLayout, SharedBoardLayout, SharedPdfLayout and docKey branching over type doc/slides/note/board/pdf/sheet
+
+### docs/design/sheets/comments.md
+
+> The Phase B core (data model, six Store methods, auto-delete orphan cleanup, #fbbc04 marker) matches shipped code closely, but the doc is stale on scope: @user mentions (an explicit Non-Goal/Phase C item) are fully shipped and wired into the sheet composer, Docs comments and a shared cross-consumer comment module already exist (framed as Phase C+), and the §1 file layout no longer matches.
+
+- **[high] roadmap-shipped** — The doc repeatedly frames '@user mentions and notifications' as a Non-Goal deferred to Phase C (Summary, Goals/Non-Goals §, Phase Plan §8). In reality mentions are fully implemented and wired into the sheets comment flow: bodies encode `@[username](userId)` tokens, the composer has a live mention picker, and the sheet view supplies workspace members. A reader would wrongly conclude mentions do not exist.
+  - _Evidence:_ packages/frontend/src/components/comments/mentions.ts (serializeMention/parseMentionBody/detectMentionQuery); packages/frontend/src/components/comments/use-workspace-members.ts; packages/frontend/src/components/comments/components/CommentComposer.tsx imports applySelectedMentions/detectMentionQuery; packages/frontend/src/app/spreadsheet/sheet-view.tsx:178 mentionMembers = useWorkspaceMembers(workspaceId); separate design doc docs/design/comments-mentions.md
+- **[medium] roadmap-shipped** — §1/§8 state comment code 'lives inside packages/sheets' until Docs becomes a second consumer, with cross-package extraction deferred to Phase C+ ('The shared @wafflebase/comments package is created when Docs adds comments'). In fact Docs comments have shipped and the comment UI has already been extracted into a shared frontend module consumed by sheets, docs, and pdf. (Nuance: no published @wafflebase/comments package exists — the extraction landed as a frontend-internal shared directory instead.)
+  - _Evidence:_ packages/frontend/src/components/comments/ (shared comment-store.ts, thread.ts, types.ts, components/); packages/frontend/src/app/docs/comments/ (DocsCommentPopover.tsx, yorkie-comment-store.ts, docs-comments-controller.ts); packages/docs/src/view/comment-markers.ts; CommentSidePanel<SheetCellAnchor> imported in packages/frontend/src/app/documents/document-detail.tsx:62,674; no package named @wafflebase/comments in any packages/*/package.json
+- **[medium] stale-reference** — §1 Module Layout places CommentPopover.tsx, CommentSidePanel.tsx, and CommentComposer.tsx together under packages/frontend/src/app/spreadsheet/components/comments/. Actual: only CommentPopover.tsx lives there; CommentComposer.tsx and CommentSidePanel.tsx live in the shared packages/frontend/src/components/comments/components/, and the spreadsheet's side panel is wired up in app/documents/document-detail.tsx, not the spreadsheet component folder.
+  - _Evidence:_ packages/frontend/src/app/spreadsheet/components/comments/CommentPopover.tsx (only file there); packages/frontend/src/components/comments/components/CommentComposer.tsx and CommentSidePanel.tsx; document-detail.tsx renders CommentSidePanel for SheetView
+- **[low] documented-not-implemented** — §1 lists packages/sheets/src/comment/index.ts as the public-exports barrel, but no index.ts exists in that directory (only types.ts, thread.ts, anchor.ts and __tests__).
+  - _Evidence:_ packages/sheets/src/comment/ contains anchor.ts, thread.ts, types.ts, __tests__/ — no index.ts
+- **[low] other** — §6.3 specifies the marker as a '7 × 7 px right triangle'; the renderer draws a 9x9 triangle. Color (#fbbc04) and top-right positioning match.
+  - _Evidence:_ packages/sheets/src/view/render-comments.ts:5 comment says '9x9 yellow right-triangle', MARKER_COLOR = '#fbbc04'
+
+### docs/design/slides/slides-hover-and-text-edit-entry.md
+
+> The behavioral spec matches the code precisely, but the doc still frames P0.1/P0.2/P1/P2 as future PR-sized work when the entire feature is already shipped, and its exact line-number citations into keyboard.ts/editor.ts are stale.
+
+- **[high] roadmap-shipped** — The doc frames the work as a forward-looking proposal ('this proposal adds...', phase split into 'PR-sized increments', 'One PR', 'Separate PR', 'Independent PRs', a 'Testing strategy' listing '(new)' test files) and only self-marks P0.3 (Enter/F2) and the P2.6 baseline printable-key rule as 'already shipped'. In reality every remaining phase item is fully implemented in shipped code: P0.1 idle hover outline (overlay.ts paints the '1px solid rgba(26,115,232,0.5)' hoverHighlightFrame outline; editor.ts has private hoverHighlightId, onSelectionHoverMove, clearHoverHighlight), P0.2 text-region I-beam (getTextRegionRect exported from text-box-editor.ts and used in editor.ts), P1.4 empty-placeholder 1-click entry (interactions/select.ts exports isEmptyPlaceholder keyed on placeholderRef), P1.5 slow double-click (interactions/drag.ts defines SLOW_DOUBLE_CLICK_MAX_DURATION_MS=350 and the ~3px classifier), P2.6 initialText forwarding (text-box-editor.ts mountSlidesTextBox accepts initialText and inserts it once; enterEditMode forwards it; keyboard.ts printable rule passes { initialText: e.key }), and P2.7 edge-zone resize cursor (editor.ts § P2.7 block). Multiple code comments cite this doc's exact section numbers (§ P1.4, § P1.5, § P2.6, § P2.7), confirming the work post-dates and shipped from this proposal. A reader would wrongly believe most of the document is unbuilt.
+  - _Evidence:_ packages/slides/src/view/editor/editor.ts (hoverHighlightId:700, onSelectionHoverMove:4408, getTextRegionRect import:135, § P2.7:4444-4448), overlay.ts (hoverHighlightFrame:119,310 and 'rgba(26, 115, 232, 0.5)':756), interactions/select.ts:79-85 (isEmptyPlaceholder, cites § P1.4), interactions/drag.ts:8-11 (SLOW_DOUBLE_CLICK_MAX_DURATION_MS=350, cites § P1.5), text-box-editor.ts:54,177,395-571 (getTextRegionRect + initialText, 'P2.6' comment), keyboard.ts:636-678
+- **[low] stale-reference** — The doc cites precise line ranges that no longer point at the referenced code. It claims the Enter/F2 entry rule lives at keyboard.ts:481-500 and the printable-key rule at keyboard.ts:514-532 with the v1 caveat at 506-513, but at those lines keyboard.ts actually holds the Cmd+Shift+Enter/Cmd+Enter present-mode rules (481-497), Cmd+A (500-513) and Cmd+M (515-539); the real F2/Enter rule is ~636-651 and the printable-key rule ~662-680. Likewise it references the insert-mode ghost field at editor.ts:479, but private hoverPreview is declared at editor.ts:693.
+  - _Evidence:_ packages/slides/src/view/editor/interactions/keyboard.ts:472-539,636-680; packages/slides/src/view/editor/editor.ts:693
+
+### docs/design/slides/slides-keyboard-shortcuts.md
+
+> The keyboard-shortcut proposal (catalog, constraints, present/help callbacks, editable-target gating) is accurately shipped, but the doc's Non-Goals section falsely claims no group concept exists when Group/Ungroup is fully built in the model, catalog, and keyboard layer.
+
+- **[high] roadmap-shipped** — Non-Goals states 'Group / Ungroup ... No group concept exists in the slides model yet; introducing one is a separate design involving model, CRDT, rendering, and selection-box changes.' In reality the group concept is fully shipped: element.ts defines GroupElement (type: 'group'), model/group.ts implements ~500 lines of group transform/AABB/scale helpers, KeyboardContext exposes group()/ungroup() methods (keyboard.ts lines 74-77), and the shortcuts catalog registers 'Mod+Alt+G' (Group) and 'Mod+Shift+Alt+G' (Ungroup) as active Selection shortcuts. The Esc catalog entry even documents 'pop drill-in level' group drill-in.
+  - _Evidence:_ packages/slides/src/model/element.ts:399-400 (GroupElement), packages/slides/src/model/group.ts (findElementPath, groupToTransform, bakeGroupScale, etc.), packages/slides/src/view/editor/interactions/keyboard.ts:74-77 group()/ungroup(), packages/slides/src/view/editor/shortcuts-catalog.ts:46-47 (Mod+Alt+G / Mod+Shift+Alt+G)
+- **[low] stale-reference** — The doc's proposed ShortcutCategory union lists 'Selection|Slide|Clipboard|Z-order|Nudge|Format|Present|Help'; the shipped type also includes a 'Drag' category used for the Shift-constraint entries. Also the shipped catalog groups Undo/Redo/Show-shortcuts under a 'Help' category rather than a dedicated History category. Minor divergence from the doc's illustrative type.
+  - _Evidence:_ packages/slides/src/view/editor/shortcuts-catalog.ts:22-31,83-91
+- **[low] documented-not-implemented** — The doc's proposed KeyboardContext interface includes 'onLinkRequest?' ('canvas-level (unused in v1, present for symmetry)'). The shipped KeyboardContext does not declare onLinkRequest; it only carries onStartPresentation and onShowShortcutsHelp. (onLinkRequest still exists on SlidesEditorOptions and text-box-editor, so the plumbing claim holds, but the KeyboardContext field was dropped.)
+  - _Evidence:_ packages/slides/src/view/editor/interactions/keyboard.ts:47-96 (no onLinkRequest); editor.ts:241 onLinkRequest option; frontend slides-view.tsx:682 notes onLinkRequest intentionally unwired
+
+### docs/design/slides/slides-pdf-export.md
+
+> The doc frames Slides PDF export as an unbuilt P0 feature ("Slides has no PDF export today"), but the entire pipeline is implemented, exported, and UI-wired in shipped code.
+
+- **[high] roadmap-shipped** — The Summary states 'Slides has no PDF export today... no code exists' and the whole doc is written as a to-build P0 plan (Goals/Non-Goals, 'P0 ships a raster exporter', 'add pdf-lib to slides package.json'). In reality the feature is fully shipped: packages/slides/src/export/pdf.ts (402 lines) implements exportSlidesPdf() and collectFontFamilies() exactly as the raster-per-slide pipeline described; pdf-lib is already in packages/slides/package.json; the frontend exportSlidesPdfAndDownload() exists; and a header Export menu is wired to it. A reader would be misled into thinking none of this exists.
+  - _Evidence:_ packages/slides/src/export/pdf.ts:99 (exportSlidesPdf), packages/slides/src/index.ts:243-247 (re-exports exportSlidesPdf/collectFontFamilies), packages/slides/package.json:44 (pdf-lib), packages/frontend/src/app/slides/pdf-actions.ts:25 (exportSlidesPdfAndDownload), packages/frontend/src/app/slides/slides-export-button.tsx:99 (PDF export menu item)
+- **[medium] documented-not-implemented** — The doc's proposed cross-origin image strategy ('for external srcs set crossOrigin=anonymous in getOrLoadImage and fall back to placeholder if it taints') was not what shipped. The implemented exporter instead fetches each image's bytes through an injected imageFetcher (credentialed) into a same-origin object URL and renders a cloned slide with rewritten srcs. ExportSlidesPdfOptions also carries imageFetcher/onProgress/title fields the doc's signature does not mention.
+  - _Evidence:_ packages/slides/src/export/pdf.ts header comment (cross-origin object-URL clone approach) and ExportSlidesPdfOptions (imageFetcher, title, onProgress); packages/frontend/src/app/slides/pdf-actions.ts uses docsImageFetcher
+- **[low] stale-reference** — Naming/surface drift vs shipped code: doc names the frontend helper exportPdfAndDownload(doc, title) but it shipped as exportSlidesPdfAndDownload(doc, title, onProgress?); doc proposes a '@wafflebase/slides/export' subpath export but the symbols are folded into the main '@wafflebase/slides' entry; doc places the UI control in packages/frontend/src/app/slides/toolbar/ next to Present, but it lives in a header Export menu (slides-export-button.tsx). Also opts.metadata.title shipped as opts.title.
+  - _Evidence:_ packages/frontend/src/app/slides/pdf-actions.ts:25, packages/slides/src/index.ts:243-247, packages/frontend/src/app/slides/slides-export-button.tsx:21-99
+
+### docs/design/slides/slides-mobile.md
+
+> Core primitives shipped as designed (mobile view/edit modes, Pointer Events migration, handleHitTest tolerance, use-pointer-swipe, SlideRenderer reuse), but the doc's described mount location, shell chrome, and named components diverge materially from what shipped, and a deferred Non-Goal (shared-link read-only) is actually implemented.
+
+- **[high] stale-reference** — Doc (Summary, 'Detection and branching' with a code snippet, and File change summary) states SlidesView in packages/frontend/src/app/slides/slides-view.tsx branches on useIsMobile() and delegates to MobileSlidesView. In reality slides-view.tsx contains zero references to useIsMobile/MobileSlidesView/isMobile; the mobile branch actually lives in slides-detail.tsx (and shared-document.tsx). A reader would look in the wrong file.
+  - _Evidence:_ slides-view.tsx: 0 matches for useIsMobile/MobileSlidesView; slides-detail.tsx:17,20,90,738 import and mount MobileSlidesView behind useIsMobile()
+- **[medium] documented-not-implemented** — File change summary lists two NEW files: mobile-text-format-sheet.tsx and mobile-slide-ops-fab.tsx. Neither exists. Text formatting shipped as MobileSlidesToolbar (toolbar/mobile-toolbar.tsx) owned by the parent; add-slide shipped as an IconPlus button inside a ThumbnailStrip in mobile-slides-view.tsx.
+  - _Evidence:_ ls: mobile-text-format-sheet.tsx / mobile-slide-ops-fab.tsx 'No such file or directory'; packages/frontend/src/app/slides/toolbar/mobile-toolbar.tsx (MobileSlidesToolbar); mobile-slides-view.tsx:674-692 (add-slide button in ThumbnailStrip)
+- **[medium] documented-not-implemented** — The 'MobileSlidesView shell' DOM structure (in-shell header with Back/Undo/Redo/title/Present buttons, and a footer with prev/next arrows and 'index / total') is not what shipped. mobile-slides-view.tsx renders only a canvas-host plus a horizontal ThumbnailStrip; there is no in-component header or prev/next footer, and undo/redo + Present are owned by the parent SiteHeader/SlidesToolbar.
+  - _Evidence:_ mobile-slides-view.tsx:475-537 (canvas-host + ThumbnailStrip, no header/footer); comments at lines 74 and 143-144 note the parent owns Present button and toolbar undo/redo
+- **[medium] roadmap-shipped** — Non-Goals frames 'Shared-link read-only flow (sharing.md)' as a separate, not-yet-wired task, and says mode is decided by slides-detail.tsx per permission. In reality the permission-based view/edit split ships in shared-document.tsx (mode={readOnly ? 'view' : 'edit'}); slides-detail.tsx hardcodes mode="edit".
+  - _Evidence:_ shared-document.tsx:580-581 mode={readOnly ? 'view' : 'edit'}; slides-detail.tsx:739 mode="edit" (hardcoded)
+- **[low] documented-not-implemented** — The Slide-ops FAB long-press menu (duplicate / delete / change-layout via store.duplicateSlide / removeSlide / applyLayout) is not wired on mobile; only store.addSlide('blank') is called.
+  - _Evidence:_ mobile-slides-view.tsx:215 store.addSlide('blank'); grep for duplicateSlide/removeSlide/applyLayout in mobile-slides-view.tsx: 0 matches
+- **[low] documented-not-implemented** — The undo/redo store.onHistoryChange hook (listed in File change summary for store.ts, memory.ts, yorkie-slides-store.ts) was never added; grep finds it nowhere. Framed conditionally in prose, so low severity; undo/redo ended up owned by the parent toolbar instead.
+  - _Evidence:_ grep onHistoryChange across packages/slides/src and yorkie-slides-store.ts: 0 matches
+
+### docs/design/slides/slides-ruler.md
+
+> The doc reads as an unbuilt proposal (target-version 0.4.2, a six-PR "Phasing" plan, future tense, NEW/MOVED file markers) but the entire slides-ruler feature across all six phases is already implemented in the current 0.6.2 codebase.
+
+- **[high] roadmap-shipped** — The doc frames the whole feature as a design proposal with a six-PR phasing plan yet to be done, but every phase is shipped. P1 shared core: packages/docs/src/view/ruler/{index,tick-renderer,unit}.ts all exist. P2 SlidesRuler controller: `export class SlidesRuler` exists. P3 data+store: `Guide` type and `guides: Guide[]` in SlidesDocument, plus addGuide/moveGuide/removeGuide in the store. P4 interactions: view/editor/ruler/interactions.ts exists. P5 snap: snap.ts defines `SnapGuideKind = 'slide-center'|'guide'|'edge'` with PRIORITY {slide-center:0, guide:1, edge:2} exactly as specified. A reader would be actively misled into thinking this is unbuilt planned work.
+  - _Evidence:_ packages/docs/src/view/ruler/index.ts, tick-renderer.ts, unit.ts; packages/slides/src/view/editor/ruler/ruler.ts (class SlidesRuler), interactions.ts, index.ts; packages/slides/src/model/presentation.ts:157 (type Guide) & :171 (guides: Guide[]); packages/slides/src/store/store.ts:313-315 (addGuide/moveGuide/removeGuide); packages/slides/src/view/editor/snap.ts:8,30-33
+- **[low] stale-reference** — The Architecture section describes the docs ruler as currently living at packages/docs/src/view/ruler.ts and P1 as a future MOVE into ruler/index.ts. That move is already done: no ruler.ts exists; the class lives at ruler/index.ts with tick-renderer.ts and unit.ts alongside.
+  - _Evidence:_ packages/docs/src/view/ruler/index.ts exists; packages/docs/src/view/ruler.ts does not
+- **[low] other** — The Presence section types draggingGuide as { id?: string; axis; position }, but the shipped SlidesPresence field omits the id member (only { axis; position }). Consistent with the doc's own statement that broadcasting is deferred, but the field shape differs from the spec.
+  - _Evidence:_ packages/slides/src/view/editor/peers.ts:36 `draggingGuide?: { axis: 'x' | 'y'; position: number }`
+
+### docs/design/slides/slides-shapes.md
+
+> The core shape-library contract (136 path builders, three registries, adjustments/handles, action buttons, freeform, shape text body) matches the code, but the line/arrow → ConnectorElement migration was only noted in the Summary and left stale across the Data model, dispatcher, shape-special, picker, and (most misleadingly) the Non-Goals/Out-of-scope connector framing, which is actually shipped.
+
+- **[high] roadmap-shipped** — Non-Goals says 'line and arrow are free-floating; elbow / curved connectors that snap between two source elements are a separate workstream' and Out-of-scope lists 'Elbow / curved connectors that snap to two source elements' as not built. In reality a full ConnectorElement type is shipped: routing 'straight'|'elbow'|'curved', Endpoint {kind:'attached', elementId, siteIndex} snapping to connection sites, drawConnector renderer, elbow/curve bend handles, and bend-drag interactions.
+  - _Evidence:_ packages/slides/src/model/connector.ts (ConnectorElement, ConnectorRouting, Endpoint attached), packages/slides/src/model/connection-site.ts, packages/slides/src/view/canvas/connector-renderer.ts (drawConnector), connector-bend.ts, routing.ts (routeElbow/routeCurved), src/view/editor/interactions/bend-drag.ts
+- **[medium] stale-reference** — The Data model code block declares ShapeKind starting with '| "line" | "arrow"' as special-cased shape kinds, but the actual ShapeKind union in element.ts contains neither 'line' nor 'arrow' — connectors were extracted into the separate ConnectorElement type.
+  - _Evidence:_ packages/slides/src/model/element.ts (export type ShapeKind begins at 'rect' | 'roundRect'…; no 'line'/'arrow' members)
+- **[medium] documented-not-implemented** — The Renderer-architecture drawShape snippet dispatches `if (data.kind === 'line') return drawLine(...)` and `if (data.kind === 'arrow') return drawArrow(...)`. The real drawShape has no line/arrow branches, and no drawLine/drawArrow functions exist in the slides package; it instead special-cases action buttons then freeform (a branch the doc's snippet omits) before PATH_BUILDERS. Connectors render via drawConnector in a different file.
+  - _Evidence:_ packages/slides/src/view/canvas/shape-renderer.ts drawShape (lines 167-245: isActionButton → freeform → PATH_BUILDERS, no line/arrow); grep found no function drawLine/drawArrow in src
+- **[low] stale-reference** — Renderer-architecture tree says shape-special.ts contains 'drawLine, drawArrow, drawActionButton'. The actual file exports only drawActionButton.
+  - _Evidence:_ packages/slides/src/view/canvas/shape-special.ts (only `export function drawActionButton`)
+- **[medium] stale-reference** — Picker UI section says the Shape picker lives in packages/frontend/src/app/slides/slides-formatting-toolbar.tsx. That file does not exist; the picker is shape-picker.tsx + shape-picker-helpers.ts (with SHAPE_PICKER_CATEGORIES).
+  - _Evidence:_ slides-formatting-toolbar.tsx missing (grep found zero references); packages/frontend/src/app/slides/shape-picker.tsx and shape-picker-helpers.ts exist
+- **[medium] stale-reference** — Picker UI lists sections in fixed order beginning with 'Lines' (9 sections). The shipped picker has 8 categories with NO Lines section; line connectors were split into a dedicated LinePicker dropdown. The invariant test explicitly asserts 8 categories and that no 'lines' category exists.
+  - _Evidence:_ packages/frontend/tests/app/slides/shape-picker.test.ts (expects length 8 and ids [shapes,block-arrows,banners,flowchart,callouts,equation,stars,action-buttons]; asserts no 'lines'); packages/frontend/src/app/slides/line-picker.tsx
+
+
+## minor-drift (57)
+
+### docs/design/documents-multi-file-upload.md
+
+> The multi-file upload feature described in this proposal has shipped largely as designed, but two deliberate design decisions in the doc were reversed in the shipped code (useSyncExternalStore, and image files as an upload kind).
+
+- **[high] documented-not-implemented** — The doc's 'React glue' section states useSyncExternalStore is 'intentionally not used — there is zero precedent in the codebase and the manual pattern is the established convention', prescribing useState + useEffect + subscribe. The shipped hook does the opposite: it calls useSyncExternalStore(subscribe, getSnapshot) and its own comment says '(not the useState + useEffect pattern)'. A reader following the doc's rationale is actively misled about the chosen convention.
+  - _Evidence:_ packages/frontend/src/app/documents/use-upload-queue.ts:1,7,13 (useSyncExternalStore) vs doc lines 141-147
+- **[high] roadmap-shipped** — The doc's Non-Goals state 'PDF stays the only binary-backed type; skipped files are not uploaded' and lists multi-image handling as a separate effort; the UploadKind type is declared as only 'sheet'|'doc'|'slides'|'pdf'. In shipped code UploadKind includes 'image', classifyUploadKind maps png/jpg/jpeg/gif/webp → 'image', and the worker uploads those blobs and creates an 'image' DocumentType document (same path as pdf). So image files ARE uploaded as a binary-backed document type, contradicting the Non-Goal.
+  - _Evidence:_ packages/frontend/src/app/documents/upload-kind.ts:1,10-15; upload-queue.ts:308-327; packages/frontend/src/types/documents.ts:1 (DocumentType includes 'image') vs doc lines 39,42-43,84
+- **[low] stale-reference** — Minor API/path drift: the doc lists the store's exposed API as 'remove(id)' but shipped exports are removeItem/dismissItem (no remove); enqueue is enqueue(files, workspaceId, folderId?) not enqueue(files, workspaceId); the doc puts drop handlers inline in document-list.tsx but they were extracted into use-window-file-drop.ts; the pptx importer is importPptxFile (doc calls it importPptx). UploadItem also gained folderId/docPath/warning fields not in the doc's interface.
+  - _Evidence:_ packages/frontend/src/app/documents/upload-queue.ts:67-71,97,110,20-41; use-window-file-drop.ts; document-list.tsx:129; import importPptxFile in upload-queue.ts:5 vs doc lines 64,100,161-169,88-98
+
+### docs/design/context-menu.md
+
+> The shipped architecture (Radix context menu, unified sheet/tab menus, mobile synthetic contextmenu, headerHitTest) matches code, but the documented facade API method names, signatures, and return types are stale, and the cell menu ships more items than documented.
+
+- **[high] documented-not-implemented** — The doc lists facade methods getAdjacentHiddenRows/getAdjacentHiddenColumns returning `{ from: number; to: number } | null`. No such symbols exist; the actual methods are findAdjacentHiddenRows/findAdjacentHiddenColumns and they return `number[]` (an array of hidden indices), which is why sheet-context-menu.tsx computes min/max over the array rather than reading a {from,to} object.
+  - _Evidence:_ packages/sheets/src/view/spreadsheet.ts:855-861 (findAdjacentHiddenRows/Columns -> number[]); grep for getAdjacentHidden across packages/ returns nothing; packages/frontend/src/components/sheet-context-menu.tsx:118,122,170-182
+- **[medium] documented-not-implemented** — Documented signatures hideRows(index, count)/hideColumns(index, count)/showRows(from, to)/showColumns(from, to) do not match the implementation, which takes an array of indices: hideRows(indices: number[]), showRows(indices: number[]), etc. The component passes arrays accordingly.
+  - _Evidence:_ packages/sheets/src/view/spreadsheet.ts:831-851; packages/frontend/src/components/sheet-context-menu.tsx:147-159
+- **[medium] implemented-not-documented** — The doc's Cell Menu (and CellMenuItems structure) lists only Cut, Copy, Paste, Delete, but the shipped cell menu also conditionally renders Insert comment (with keyboard hint), Data validation, Insert pivot table, and Delete image; the SheetContextMenu props include onInsertPivotTable, onDeleteImage, onInsertComment, onOpenDataValidation, selectedImageId.
+  - _Evidence:_ packages/frontend/src/components/sheet-context-menu.tsx:44-51,204-241
+
+### docs/design/docs/docs-intent-preserving-edits.md
+
+> Phase status, DocStore API, and most symbol-level claims match the shipped code, but the "Native Split/Merge" mechanism section describes a native-CRDT approach the code deliberately abandoned, and SDK version references are stale.
+
+- **[high] documented-not-implemented** — Doc's Yorkie Tree Strategy table and 'Native Split/Merge (SDK 0.7.4)' section state split uses native `editByPath(path,path,undefined,splitLevel)` with splitLevel=2 and merge uses native boundary deletion `editByPath([blockIdx,inlineCount],[nextBlockIdx,0])` triggering automatic CRDT merge (both marked Shipped). The code does neither: splitBlock uses a manual two-step delete-after-content + insert-new-block, with an explicit comment 'Manual two-step split (avoids splitLevel=2 which breaks undo/redo)'; mergeBlock explicitly avoids the single cross-boundary editByPath as a yorkie-js-sdk bug and instead deletes the next block then re-inserts its inline children via editBulkByPath. No splitLevel=2 call exists anywhere (all 3 occurrences are comments explaining why it's avoided).
+  - _Evidence:_ packages/frontend/src/app/docs/yorkie-doc-store.ts:1986 (splitBlock manual two-step, 'avoids splitLevel=2 which breaks undo/redo'), :2127-2152 (mergeBlock two-step delete+editBulkByPath, 'Workaround for yorkie-js-sdk Phase 3 Range Narrowing bug'); grep for splitLevel yields only comments (lines 1148, 1986, 2129)
+- **[medium] stale-reference** — Doc repeatedly pins behavior to Yorkie SDK versions 0.7.4 ('Native Split/Merge (SDK 0.7.4)', known-edge-cases) and 0.7.6 ('Native Inline Styling (SDK 0.7.6)'). The shipped dependency is @yorkie-js/sdk 0.7.13 (and @yorkie-js/react 0.7.13).
+  - _Evidence:_ packages/frontend/package.json:60,89 (@yorkie-js/react and @yorkie-js/sdk both 0.7.13)
+- **[low] documented-not-implemented** — The 'DocStore Methods' code block lists Phase 4 'Table cell variants' insertTextInCell / deleteTextInCell / applyStyleInCell. These methods do not exist on the DocStore interface, and the doc's own Phase 4 section states they were intentionally NOT added in favor of unified resolveBlockTreePath DFS. The code block is stale/self-contradictory.
+  - _Evidence:_ packages/docs/src/store/store.ts DocStore interface (no *InCell methods; grep 'InCell' finds only unrelated symbols); doc Phase 4 section lines 185-189 confirms unified approach
+
+### docs/design/docs/docs-paste-table-into-cell.md
+
+> The proposal is fully implemented in code, but the doc still frames the #333 fix (recursive fresh ids + findBlockInCells fallback) and its regression test as future/planned when both are already shipped on main.
+
+- **[high] roadmap-shipped** — The doc repeatedly frames the #333 fix as unbuilt/future: 'This note's #333 fix (recursive fresh ids + the findBlockInCells fallback) still needs its own regression coverage ... which is planned for the implementation PR that follows this design note, not part of this doc-only PR' and the Risks table says 'regression test planned for the implementation PR'. In reality the entire #333 fix is already shipped: refreshBlockIds recurses through tableData.rows[].cells[].blocks[]; findBlockInCells has the walkCellsForBlock recursive fallback for blocks not yet in _blockParentMap; and insertBlocks (both single-table and multi-block branches) already calls cloneBlockWithFreshIds. A reader would be misled into thinking this fix is still pending.
+  - _Evidence:_ packages/docs/src/store/block-helpers.ts:154-172 (cloneBlockWithFreshIds/recursive refreshBlockIds); packages/docs/src/model/document.ts:42-56 (walkCellsForBlock) and :199-204 (findBlockInCells fallback); packages/docs/src/view/text-editor.ts:3517-3583 (single-table + multi-block branches use cloneBlockWithFreshIds + insertBlockAfter)
+- **[medium] roadmap-shipped** — The doc says the #333 model-level regression test — 'a model-level test asserting Doc.getBlock resolves a block inside a freshly pasted nested table that isn't yet in _blockParentMap' — is 'planned for the implementation PR that follows this design note.' That exact test already exists.
+  - _Evidence:_ packages/docs/test/model/paste-table-into-cell.test.ts:132-133 (describe 'Doc.getBlock resolves freshly pasted nested-table content (#333)' / it 'resolves a block inside a pasted nested table that is not yet in the parent map')
+
+### docs/design/docs/docs-presence.md
+
+> The documented peer-cursor/label and avatar-jump machinery matches the shipped code closely, but the doc still frames remote selection highlight as a planned Phase 2 Non-Goal when it is in fact fully implemented.
+
+- **[high] roadmap-shipped** — Summary says "Remote selection highlight is Phase 2 (planned)" and Non-Goals lists "Remote selection highlight (Phase 2)" as the first item, but remote peer selection highlighting is fully implemented and wired: DocsPresence carries activeSelection, PeerCursor has a selection field, buildPeerCursors passes it through, editor.ts computes peerSelections highlight rectangles, and doc-canvas.ts renders peer selection highlights per page. A reader would wrongly conclude the feature does not exist.
+  - _Evidence:_ packages/frontend/src/types/users.ts:25 (DocsPresence.activeSelection); packages/docs/src/view/peer-cursor.ts:79 (PeerCursor.selection); packages/frontend/src/app/docs/docs-view.tsx:222-231 (buildPeerCursors maps activeSelection→selection); packages/docs/src/view/editor.ts:1541-1559 (peerSelections rectangles); packages/docs/src/view/doc-canvas.ts:181,449-461 (peerSelections rendering)
+- **[low] stale-reference** — The §3 code comment places PeerCursor in packages/docs/src/view/types.ts, but PeerCursor is actually defined in packages/docs/src/view/peer-cursor.ts (which the §12 Files table correctly cites); there is no types.ts in that view directory defining it.
+  - _Evidence:_ packages/docs/src/view/peer-cursor.ts:73 (export interface PeerCursor); no packages/docs/src/view/types.ts tracked
+- **[low] documented-not-implemented** — The §1/§3 type snippets are slightly stale: DocsPresence is shown as "{ activeCursorPos?: {...} } & User" but the real type inlines username/email/photo (not an intersection with User) and also includes activeSelection; the documented PeerCursor type omits the actual clientID and selection fields.
+  - _Evidence:_ packages/frontend/src/types/users.ts:17-34; packages/docs/src/view/peer-cursor.ts:73-80
+
+### docs/design/docs/docs-wordprocessor-roadmap.md
+
+> The roadmap is largely accurate — referenced design docs, task tracker, and shipped features all verify — but the manual Ctrl+Enter page break is fully implemented while the doc still frames it as Planned/needing a UI affordance.
+
+- **[high] roadmap-shipped** — The Current State table marks 'Page break (manual Ctrl+Enter)' as '❌ Planned', and Phase 4.2 says it is only 'handled at the layout level via page-break blocks injected by find/replace' and 'needs a first-class UI affordance'. In reality the manual Ctrl+Enter/Cmd+Enter page break is fully wired: the keydown handler routes ctrl/meta+Enter to handlePageBreak(), which splits the block and inserts a first-class createBlock('page-break') block; 'page-break' is a first-class BlockType.
+  - _Evidence:_ packages/docs/src/view/text-editor.ts:795-802 (case 'Enter' -> if (e.ctrlKey||e.metaKey) this.handlePageBreak()); packages/docs/src/view/text-editor.ts:2097-2120 (handlePageBreak inserts page-break block via createBlock('page-break')); packages/docs/src/model/types.ts:39 (BlockType includes 'page-break')
+
+### docs/design/slides/slides-animation.md
+
+> The animation engine, data model, store ops, Motion panel, presenter integration, and PPTX animation import are all shipped as the doc claims; the only real drift is the Non-Goals section still saying no PPTX export serializer is built when a full one exists, plus one op name.
+
+- **[high] roadmap-shipped** — Non-Goals states "PPTX export. v1 exports PDF only; ... no serializer is built," and Goals say "v1 exports PDF only." In reality a complete PPTX export serializer exists and is wired into the app, including serialization of the very transitions/animations this doc adds. Even the v0.5.0 Implementation status section omits it. A reader would be misled into thinking PPTX export does not exist.
+  - _Evidence:_ packages/slides/src/export/pptx/ (index.ts exportPptx, animation.ts transitionToXml/effectParXml, slide.ts, presentation.ts); exported at packages/slides/src/index.ts:250 (export { exportPptx }); UI wiring in packages/frontend/src/app/slides/slides-export-button.tsx ("PowerPoint (.pptx)") and pptx-actions.ts (calls exportPptx)
+- **[low] stale-reference** — Doc lists the new Store op as `reorderAnimations` (plural); the actual op is named `reorderAnimation` (singular). The other four ops (setSlideTransition, addAnimation, updateAnimation, removeAnimation) match exactly.
+  - _Evidence:_ packages/slides/src/store/store.ts:91, memory.ts:544, layout-edit-store.ts:193 all define reorderAnimation(slideId, animId, toIndex); grep for reorderAnimations returns nothing
+
+### docs/design/slides/slides-format-effects.md
+
+> The effects data model, rendering, and Format panel sections described in the doc are all shipped and match the code closely; the notable drift is the doc's claim that no PPTX exporter exists, plus its "PR 2" image-recolor work being framed as future when it has shipped.
+
+- **[high] implemented-not-documented** — The doc states "PPTX is import-only in this package (no exporter exists), so 'round-trip' means parsing the OOXML effect elements on import." A full PPTX exporter is in fact shipped: `exportPptx` (and `ExportPptxOptions`) are exported from the package index, and packages/slides/src/export/pptx/ contains ~20 modules including effects.ts, which serializes drop shadow/reflection to `<a:outerShdw>`/`<a:reflection>`. A reader is actively misled about round-trip capability.
+  - _Evidence:_ packages/slides/src/index.ts:250 `export { exportPptx } from './export/pptx/index.js'`; packages/slides/src/export/pptx/index.ts (exportPptx orchestrator); packages/slides/src/export/pptx/effects.ts:10 `effectsToXml` emitting outerShdw/reflection; export/pdf.ts also present
+- **[medium] roadmap-shipped** — The Rollout section frames PR 2 (image recolor + brightness/contrast) as future work, and the doc tags `recolor-section.tsx` and recolor/brightness/contrast fields as "(PR 2)". These have shipped: ImageRecolor type and brightness/contrast fields exist on ImageElement.data, and the panel includes recolor-section.tsx and image-adjustments-section.tsx.
+  - _Evidence:_ packages/slides/src/model/element.ts:315 `ImageRecolor = 'none'|'grayscale'|'sepia'`, :335 brightness, :340 contrast; packages/frontend/src/app/slides/format-panel/recolor-section.tsx and image-adjustments-section.tsx
+- **[low] stale-reference** — The doc's frontmatter target-version is 0.4.7, but the slides package is now at 0.6.2, consistent with this design (both PRs) already having landed rather than being upcoming work.
+  - _Evidence:_ packages/slides/package.json version 0.6.2 vs docs frontmatter target-version 0.4.7
+
+### docs/design/slides/slides-connectors.md
+
+> The core connector architecture (types, routing, connection-sites, siteWorldPos, buildElementWorldLookup, store update methods, Yorkie store, curveBend) matches the code precisely, but the PR2 status overstates which per-shape connection-site overrides shipped and the store/file-layout sections name symbols and files that don't exist as described.
+
+- **[high] roadmap-shipped** — The PR2 status section marks per-ShapeKind connection-site overrides as '✅ Mostly shipped: diamond / parallelogram / trapezoid / pentagon / hexagon / octagon / star4..star10'. The actual CONNECTION_SITES registry only contains diamond, parallelogram, trapezoid, and ellipse. No pentagon, hexagon, octagon, or star overrides exist; the module's own index.ts comment says 'diamond / parallelogram / trapezoid today'. A reader would believe polygon/star anchor overrides ship when they don't. (ellipse is also present in code but never mentioned in the doc.)
+  - _Evidence:_ packages/slides/src/view/canvas/connection-sites/overrides.ts lines 100-112 (CONNECTION_SITES = {diamond, parallelogram, trapezoid, ellipse}); index.ts line 8 comment
+- **[medium] documented-not-implemented** — Both the Store Layer section and PR1 rollout list an `addConnector(connector: ConnectorElement): void` method on the SlidesStore interface. No such method exists in store.ts, memory.ts, or yorkie-slides-store.ts. Connectors are inserted through the generic `addElement(slideId, init)` path via `buildConnectorInit`. The updateConnector* methods the doc lists do exist.
+  - _Evidence:_ grep 'addConnector' returns nothing in packages/slides/src or packages/frontend/src; packages/slides/src/store/store.ts:167 addElement; insert-connector.ts:186-189 buildConnectorInit + store.addElement
+- **[low] stale-reference** — File Organization / Editor Interactions list new files `view/editor/overlays/connection-points-overlay.ts` and `interactions/elbow-bend-drag.ts`. There is no `overlays/` directory (connection-points overlay logic lives in editor.ts / overlay.ts / insert-connector.ts) and the bend-drag file is `interactions/bend-drag.ts`, not `elbow-bend-drag.ts`. The features are implemented; only the file layout/names differ.
+  - _Evidence:_ packages/slides/src/view/editor/ has only interactions/ and ruler/ subdirs; interactions/bend-drag.ts exists (no elbow-bend-drag.ts); connection-points refs in editor.ts, overlay.ts, insert-connector.ts
+- **[low] stale-reference** — The File Organization section shows unit tests colocated next to source (e.g. view/canvas/routing.test.ts, connection-sites/connection-sites.test.ts, store/memory.test.ts as NEW). All these tests exist but live in a mirror tree under packages/slides/test/ (e.g. test/view/canvas/routing.test.ts), not colocated. Content matches; only location drifts.
+  - _Evidence:_ packages/slides/test/view/canvas/routing.test.ts, test/view/canvas/connection-sites/connection-sites.test.ts, test/view/canvas/arrowhead-renderer.test.ts, test/store/memory.test.ts
+
+### docs/design/slides/slides-group.md
+
+> The core grouping design matches shipped code closely (GroupElement, model/group.ts helpers, MemSlidesStore/YorkieSlidesStore group/ungroup, drill-in selection scope/ids, overlay member/context outlines, shortcuts, PPTX group-preserving import), but the PDF-export claims and a few named test helpers are stale or contradicted by the code.
+
+- **[high] roadmap-shipped** — The 'Known Limitations / Follow-ups' section states 'PDF export not implemented for slides v1. The slides export/ directory does not exist yet.' In reality the directory and a full PDF exporter ship today, and it already handles groups (recurses into el.data.children).
+  - _Evidence:_ packages/slides/src/export/pdf.ts (header: 'Slides PDF export — P0 raster pipeline'; exports ExportSlidesPdfOptions; flattenElements recurses `if (el.type === 'group') walk(el.data.children)` at line 227); export dir also contains yield.ts
+- **[medium] documented-not-implemented** — §9 describes PDF export becoming a vector recursion where 'Each GroupElement opens a PDF transform context' and 'the pdf-lib graphics state stack handles pushGraphicsState / popGraphicsState per group level.' The actual pdf.ts is a raster pipeline that renders each slide through the drawSlide() canvas renderer onto an offscreen canvas and embeds one bitmap per page; groups are handled by the canvas renderer, not by per-group pdf-lib graphics-state pushes.
+  - _Evidence:_ packages/slides/src/export/pdf.ts lines 1-45 (imports drawSlide from view/canvas/slide-renderer; comment 'Renders every slide through the existing drawSlide() canvas pipeline ... then embeds one bitmap per page into a pdf-lib document')
+- **[medium] documented-not-implemented** — §6.1 claims a shipped 'DEV/test-only helper assertGroupsSettled(elements)' that 'regression tests call after resize/ungroup commits.' No such symbol exists anywhere in the repo.
+  - _Evidence:_ grep -rn 'assertGroupsSettled' packages returned zero matches; also no 'Settled'/'settleGroup' helper in packages/slides/src
+- **[medium] documented-not-implemented** — §8's import-fidelity invariant is said to be 'enforced by a property test in import/pptx/group.test.ts', and §12 references a fixture set at packages/slides/test/fixtures/pptx-groups/. Neither exists: there are no *.test.ts files in import/pptx and no pptx-groups fixtures directory.
+  - _Evidence:_ find packages/slides/src/import/pptx -name '*.test.ts' → none; find packages/slides -path '*fixtures*group*' → none
+- **[low] stale-reference** — §3 documents the store API as `group(slideId, elementIds): string` returning 'the new group id'. The actual signature returns an object `{ groupId, excludedConnectorIds }`.
+  - _Evidence:_ packages/slides/src/store/memory.ts:919 return type `{ groupId: string; excludedConnectorIds: string[] }`, :1140 `return { groupId, excludedConnectorIds }`; mirrored in store/store.ts
+- **[low] documented-not-implemented** — §1 states group invariants are 'enforced by MemSlidesStore and validated in model/migrate.ts'. MemSlidesStore does enforce cycle/empty-group guards, but model/migrate.ts contains no group handling at all.
+  - _Evidence:_ grep -ni 'group' packages/slides/src/model/migrate.ts → no matches (cycle/empty checks live in packages/slides/src/store/memory.ts)
+
+### docs/design/docs-site.md
+
+> The VitePress docs site is shipped essentially as designed, but the doc is scoped only to Sheets/Docs/Slides while the live site also ships Notes, Board, and PDF sections plus extra pages, and two path/command references are stale.
+
+- **[medium] implemented-not-documented** — The doc frames the site as covering only 'each shipped module (Sheets, Docs, Slides)' with nav order Guide/Sheets/Docs/Slides/Developers, but the shipped config adds a 'Notes & Board' nav entry and a 'PDF & Files' sidebar group, plus extra content pages the outline omits (guide/import-export, sheets/data-validation, sheets/datasources). A reader would underestimate the site's scope.
+  - _Evidence:_ packages/documentation/.vitepress/config.ts nav (lines 67-73: Guide/Sheets/Docs/Slides/'Notes & Board'/Developers) and sidebar groups 'Notes & Board' and 'PDF & Files' (lines 129-146); files packages/documentation/notes/, board/, pdf/, guide/import-export.md, sheets/data-validation.md, sheets/datasources.md
+- **[low] stale-reference** — Homepage Changes section says developer-section.tsx links point to /docs/api/rest-api and /docs/api/cli, but the shipped code (and the doc's own Package Structure) uses the /developers/ path segment: /docs/developers/rest-api and /docs/developers/cli.
+  - _Evidence:_ packages/frontend/src/app/home/developer-section.tsx:168 (href: "/docs/developers/rest-api") and :176 (href: "/docs/developers/cli")
+- **[low] stale-reference** — Doc's local development instruction is `pnpm docs dev`, but no `docs` script alias exists; the actual pnpm filter alias is `documentation`, so the command is `pnpm documentation dev`.
+  - _Evidence:_ root package.json defines "documentation": "pnpm --filter @wafflebase/documentation" with no "docs" script
+
+### docs/design/board/board.md
+
+> The SP1 core (viewport seam in slides, @wafflebase/board package, board-document type, single-synthetic-slide store, and full document-type wiring) is shipped exactly as documented; the only drift is that features the doc frames as future SP2/follow-ups (sticky notes, image paste, minimap) have since shipped in the board.
+
+- **[medium] roadmap-shipped** — The doc's Non-Goals (SP1) frame 'Sticky notes, freehand drawing, image paste — SP2' and 'Minimap ... — nice-to-have follow-ups' as not-yet-built. In current code all three are shipped and wired into the board: the toolbar exposes Select/Text/Sticky/Image/Shape/Line (with scribble/freehand in the Line picker), board-view instantiates a minimap and image inserter. A reader treating this doc as current-state would wrongly conclude these are absent from the board.
+  - _Evidence:_ packages/frontend/src/app/board/sticky.ts (dropSticky), board-image.ts, board-minimap.ts + minimap-geometry.ts; board-toolbar.tsx (onInsertSticky/onInsertImage, Sticky ▾/Image, 'connectors / scribble live in Line ▾'); board-view.tsx lines 224 createBoardMinimap, 264 insertImageOnSlide, 525-526 onInsertSticky/onInsertImage
+- **[low] stale-reference** — The doc describes board-toolbar.tsx as a 'minimal insert toolbar (Select / Text / Shape / Line)'. The shipped toolbar has expanded to Select / Text / Sticky ▾ / Image / Shape ▾ / Line ▾.
+  - _Evidence:_ packages/frontend/src/app/board/board-toolbar.tsx header comment 'Sticky ▾ / Image / Shape ▾ / Line ▾' and aria-labels Select/Text box + onInsertSticky/onInsertImage props
+- **[low] implemented-not-documented** — The BoardPresence type includes a world-coords `cursor` field, though the doc says SP1 wires the presence channel but does not paint remote cursors. The code comment in board-view.tsx confirms cursor dots are still not rendered and the client does not publish cursor, so behavior matches the doc; only the type carries an as-yet-unused cursor field.
+  - _Evidence:_ packages/frontend/src/types/board-document.ts BoardPresence.cursor; packages/frontend/src/app/board/board-view.tsx lines 108-110 'Peer cursor DOTS are not rendered yet ... deferred follow-up'
+
+### docs/design/backend.md
+
+> The documented surface (auth, documents, share-links, datasources, throttler, logging, env, health) is accurate and verified in code, but the Module Architecture and Database Schema sections omit a large amount of shipped surface area, and one rate-limit number is internally inconsistent.
+
+- **[medium] implemented-not-documented** — The Module Architecture diagram/table states AppModule imports only ConfigModule, AuthModule, DocumentModule, ShareLinkModule, DataSourceModule (plus UserModule). The real AppModule additionally imports WorkspaceModule, ApiKeyModule, YorkieModule, ApiV1Module, ImageModule, FileModule, HealthModule, UserDocStylesModule, AnalyticsModule, and FolderModule. The enumeration of AppModule's imports is materially incomplete.
+  - _Evidence:_ packages/backend/src/app.module.ts imports lines 6-19 and imports array lines 99-113 (WorkspaceModule, ApiKeyModule, YorkieModule, ApiV1Module, ImageModule, FileModule, HealthModule, UserDocStylesModule, AnalyticsModule, FolderModule)
+- **[medium] implemented-not-documented** — The Database Schema ER diagram and prose describe only User, Document, ShareLink, DataSource. The actual Prisma schema also defines Workspace, WorkspaceMember, WorkspaceInvite, ApiKey, Folder, and UserDocStyles. The Document model omits shipped fields type, fileId, updatedAt, workspaceId, and folderId; DataSource omits workspaceId. This is notable because the doc's own access model relies on Workspace/WorkspaceMember, which are absent from the schema section.
+  - _Evidence:_ packages/backend/prisma/schema.prisma: Workspace (l.93), WorkspaceMember (l.107), WorkspaceInvite (l.120), ApiKey (l.133), Folder (l.65), UserDocStyles (l.17); Document.type/fileId/updatedAt/workspaceId/folderId l.44-60; DataSource.workspaceId l.37
+- **[low] implemented-not-documented** — The Authentication API reference documents /auth/github, /auth/github/callback, /auth/me, /auth/refresh, /auth/logout, but omits three shipped auth endpoints: GET /auth/yorkie-token, POST /auth/yorkie-token/share, and POST /auth/cli/exchange (the last is referenced only in the rate-limit table).
+  - _Evidence:_ packages/backend/src/auth/auth.controller.ts: getYorkieToken l.52-57, getYorkieShareToken l.66-74, cliExchange l.146-162
+- **[low] stale-reference** — The Risks and Mitigation section states the single default throttler bucket is '60 req/min/IP', contradicting both the code and the doc's own Rate Limiting table (120 req/60s). The configured limit is 120.
+  - _Evidence:_ doc line 472 ('60 req/min/IP') vs doc line 310 ('120 req / 60s') and packages/backend/src/app.module.ts l.96 (limit: 120, ttl: 60_000)
+
+### docs/design/comments-mentions.md
+
+> The @mention feature described in the doc is fully shipped and closely matches the design; only minor naming/structural drift exists (a described MentionTextarea wrapper was never created, and two core helper functions are undocumented).
+
+- **[low] documented-not-implemented** — The doc dedicates a section 'Input — MentionTextarea inside CommentComposer' and states mention behavior is 'layered via a small MentionTextarea wrapper / hook'. No MentionTextarea component or hook exists anywhere in the codebase; all trigger/dropdown/tokenize logic is inlined directly into CommentComposer.tsx. Behavior fully matches the spec, but the described sub-component factoring is not real.
+  - _Evidence:_ grep 'MentionTextarea' across packages/frontend/src returns nothing; logic lives in packages/frontend/src/components/comments/components/CommentComposer.tsx
+- **[low] implemented-not-documented** — The 'New shared helper' section lists the mentions.ts API as parseMentionBody, serializeMention, mentionBodyToPlainText, and extractMentionedUserIds. The shipped module also exports detectMentionQuery (the @-trigger detector) and applySelectedMentions (the submit-time tokenizer) — the two functions that actually drive the input trigger and approach-B tokenize-on-submit — neither of which is named in the API list.
+  - _Evidence:_ packages/frontend/src/components/comments/mentions.ts exports detectMentionQuery (line 72) and applySelectedMentions (line 99); doc lines 91-109 omit both
+- **[low] stale-reference** — The doc describes the view-local mention map as records of '{ matchedText, userId, username }'. The actual implementation stores a MentionRef[] of '{ userId, username }' keyed by username, with no matchedText field; applySelectedMentions re-matches by username at submit rather than by a stored matchedText.
+  - _Evidence:_ CommentComposer.tsx selectedRef is MentionRef[] ({userId, username}); mentions.ts MentionRef type has no matchedText; doc line 145
+- **[low] stale-reference** — The doc says the @-trigger fires on an '@ immediately preceded by start-of-text or whitespace'. The shipped detectMentionQuery uses a broader rule: start-of-text or any non-[A-Za-z0-9-] character (so it also triggers after punctuation and CJK glyphs, and deliberately suppresses email@host). Minor behavioral drift from the documented trigger condition.
+  - _Evidence:_ MENTION_QUERY_RE = /(?:^|[^A-Za-z0-9-])@([^\s@]*)$/ in packages/frontend/src/components/comments/mentions.ts:65 vs doc line 132-135
+
+### docs/design/board/board-whiteboard-elements.md
+
+> SP2 (stickies, image paste/drop, minimap) is shipped and matches the design's intent and behavior; the only inaccuracies are package/path mis-attribution of the image pipeline and illustrative symbol names in the architecture sketch.
+
+- **[medium] stale-reference** — The architecture diagram lists insert-image.ts (insertImageOnSlide), slides-image-input.ts (setupSlidesImagePaths) and image-upload.ts (uploadImageFile) under '@wafflebase/slides REUSED unchanged'. These are not in the slides engine package: insert-image.ts and slides-image-input.ts live in packages/frontend/src/app/slides/ (board-view.tsx imports them from '../slides/...', not the package), and uploadImageFile is defined in packages/frontend/src/app/spreadsheet/image-upload.ts (spreadsheet, not slides) — board-image.ts imports it via '@/app/spreadsheet/image-upload'. A reader looking in @wafflebase/slides would not find them.
+  - _Evidence:_ packages/frontend/src/app/board/board-view.tsx (imports from ../slides/insert-image, ../slides/slides-image-input); packages/frontend/src/app/board/board-image.ts (imports uploadImageFile from @/app/spreadsheet/image-upload); packages/frontend/src/app/spreadsheet/image-upload.ts
+- **[low] stale-reference** — Minimap geometry symbol names in the doc are illustrative and differ from shipped names: doc says fit / minimapPointToWorld / worldToMinimap / viewportRectInMinimap; code exports fitScene / miniToWorld / worldToMini / viewportRectInMini (plus sceneBounds, centerViewportOnWorld). Behavior matches.
+  - _Evidence:_ packages/frontend/src/app/board/minimap-geometry.ts
+- **[low] stale-reference** — Doc says board-detail.tsx builds the upload fn (const upload = (file) => uploadImageFile(file, workspaceId)) and passes uploadFn down. In code board-detail.tsx passes only workspaceId to BoardView; the upload adapter is makeBoardImageUpload in board-image.ts and is wired in board-view.tsx. Minor structural drift, not behavioral.
+  - _Evidence:_ packages/frontend/src/app/board/board-detail.tsx (passes workspaceId); packages/frontend/src/app/board/board-image.ts (makeBoardImageUpload)
+
+### docs/design/cli.md
+
+> The CLI design doc matches the shipped implementation well (commands, auth endpoints, skills, TextMeasurer, PPTX/PDF export, notes all present and wired); only low-severity staleness remains in version framing, a function signature, and the project-structure tree.
+
+- **[low] stale-reference** — The doc's frontmatter declares target-version 0.3.7 and section 4 presents a 'Breaking changes from v0.3.6 -> v0.3.7' migration table, but the package has since shipped several minor versions.
+  - _Evidence:_ packages/cli/package.json declares "version": "0.6.2" (doc target-version: 0.3.7)
+- **[low] documented-not-implemented** — Sections 6.1 and 6.4 state that both paginateLayout(doc, measurer, options) and computeLayout(doc, measurer, options) take the injectable measurer as a parameter. In code only computeLayout takes the measurer; paginateLayout operates on an already-computed layout and takes no measurer.
+  - _Evidence:_ packages/docs/src/view/pagination.ts:48 paginateLayout(layout: DocumentLayout, pageSetup: PageSetup); packages/docs/src/view/layout.ts:361 computeLayout(blocks, measurer, contentWidth, ...)
+- **[low] documented-not-implemented** — Section 6.2 says FontkitMeasurer 'loads fonts through the existing PdfFonts module (already a fontkit consumer for PDF export)'. The actual FontkitMeasurer imports fontkit directly and maintains its own register()/fonts Map keyed by variant; it does not reference PdfFonts. (The width formula advanceWidth/unitsPerEm*size does match.)
+  - _Evidence:_ packages/cli/src/docs/fontkit-measurer.ts imports 'fontkit' directly, uses fontkit.create() and a private this.fonts Map; no PdfFonts import (grep found none)
+- **[low] stale-reference** — The section 7 project-structure tree places page-range.ts, page-slice.ts, fontkit-measurer.ts, and dom-polyfill.ts under src/notes/. In the codebase these four files live under src/docs/; src/notes/ contains only content.ts and import.ts.
+  - _Evidence:_ packages/cli/src/docs/{page-range.ts,page-slice.ts,fontkit-measurer.ts,dom-polyfill.ts}; packages/cli/src/notes/ has only content.ts, import.ts
+- **[low] implemented-not-documented** — The section 7 tree omits several shipped files: slides/pptx-export.ts (the PPTX exporter the doc text says now ships), docs/image-fetcher.ts, config/session.ts, util/csv-parse.ts, and scripts/{debug-cmd.mjs,gen-sample-pptx.mjs}.
+  - _Evidence:_ find packages/cli/src listed slides/pptx-export.ts, docs/image-fetcher.ts, config/session.ts, util/csv-parse.ts; scripts/ contains debug-cmd.mjs and gen-sample-pptx.mjs
+
+### docs/design/docs/docs-collaboration.md
+
+> Core architecture claims (DocStore interface, MemDocStore, YorkieDocStore with doc.history undo, content tree + pageSetup root field, Doc(store), syncToStore removed) all match the shipped code; the drift is in stale Non-Goals/future-feature framing where presence and tables have since shipped.
+
+- **[medium] roadmap-shipped** — The Non-Goals section lists 'Presence / remote cursor display (follow-up work)', but remote presence and peer cursors are fully shipped and the status header does not correct this. There is a dedicated peer-cursor module and live presence wiring.
+  - _Evidence:_ packages/docs/src/view/peer-cursor.ts (PeerCursor interface, drawPeerCaret, drawPeerLabel, resolvePositionPixel); packages/frontend/src/app/docs/docs-detail.tsx (usePresenceUpdater, getOthersPresences(), peer.presence.activeCursorPos, DocsPresence, UserPresence)
+- **[medium] roadmap-shipped** — The node-structure section frames tables as a 'Future block type' (`<table>`, `<list-item>`, `<image>` added later), but tables are shipped end-to-end including nested tables. The Yorkie tree emits type:'table' element nodes and the model has full table APIs.
+  - _Evidence:_ packages/docs/src/model/document.ts (insertTable, insertTableInCell, createTableBlock, getParentTableBlock, tableData); packages/frontend/src/app/docs/yorkie-doc-store.ts lines 297/300/407 (type: 'table'); packages/docs/test/model/table.test.ts and nested-table.test.ts
+- **[low] documented-not-implemented** — The Editor Integration section states 'initialize(container, store) — store parameter becomes required.' In the shipped signature store is optional and defaults to a new MemDocStore().
+  - _Evidence:_ packages/docs/src/view/editor.ts:881 initialize(container, store?: DocStore, theme?, readOnly?) with `const docStore = store ?? new MemDocStore();` (line 891)
+- **[low] roadmap-shipped** — The Non-Goals list 'Yorkie-based undo/redo (future migration from local snapshots)' as out of scope; this has shipped (undo/redo delegates to doc.history). The status header and Undo/Redo body section already correct this, so the stale Non-Goals bullet is only a minor internal inconsistency.
+  - _Evidence:_ packages/frontend/src/app/docs/yorkie-doc-store.ts:2542-2563 (undo/redo/canUndo/canRedo delegate to this.doc.history.*)
+
+### docs/design/docs/docs-named-styles.md
+
+> The named-styles feature is fully shipped and matches the doc closely (model, resolution paths, store API, backend endpoints, Prisma model, H4-6 UI); the only drift is the Yorkie CRDT storage shape, which the doc describes as a nested root.styles but is actually a scalar JSON string root.stylesJson.
+
+- **[medium] other** — The doc's Store API section says YorkieDocStore stores the registry at root-level `root.styles` "mirroring the pageSetup getter/setter + readDocStyles proxy-unwrap helper", and the Risks section says `styles` is "additive at the Yorkie root, exactly like pageSetup". In reality the registry is stored as a single serialized JSON string under `root.stylesJson` (not a nested CRDT object like pageSetup), and readDocStyles does a JSON.parse rather than a proxy-unwrap. The code comment explicitly documents this as a deliberate deviation (whole-blob LWW string to sidestep Yorkie proxy double-encoding).
+  - _Evidence:_ packages/frontend/src/app/docs/yorkie-doc-store.ts lines 570-586 (readDocStyles reads root.stylesJson, JSON.parse), lines 2522/2603-2605 (writes/deletes root.stylesJson); packages/backend/src/yorkie/docs-tree.ts lines 460-462, 561-563 (root.stylesJson serialize/delete)
+- **[low] other** — The endpoints table says `GET /auth/me/doc-styles` returns "saved DocStyles (or {})". The controller actually returns the object wrapped as `{ styles }` (and PUT returns `{ styles }` too), not the bare DocStyles blob. Minor response-shape omission.
+  - _Evidence:_ packages/backend/src/user-doc-styles/user-doc-styles.controller.ts lines 12-28
+
+### docs/design/docs/docs-pagination.md
+
+> The pagination design is fully shipped and matches the code (types, presets, engine, theme, store, page-break, coordinate mapping); only a trivial helper-signature drift exists.
+
+- **[low] other** — Doc states the helper is resolvePageSetup(doc: Document): PageSetup returning doc.pageSetup ?? DEFAULT_PAGE_SETUP. The actual exported signature is resolvePageSetup(setup: PageSetup | undefined): PageSetup — it takes the PageSetup directly, not the Document (callers pass doc.document.pageSetup).
+  - _Evidence:_ packages/docs/src/model/types.ts:649 resolvePageSetup(setup: PageSetup | undefined); callers e.g. packages/docs/src/view/editor.ts:1187 resolvePageSetup(doc.document.pageSetup)
+
+### docs/design/docs/docs-pending-inline-style.md
+
+> The proposal is fully implemented and the technical content matches the code closely; the only drift is that the doc is still written as a future proposal ("This proposal adds", "New file:") for work that has actually shipped.
+
+- **[medium] roadmap-shipped** — The doc is framed throughout in proposal/future tense ('This proposal adds a transient pending style', 'New file: packages/docs/src/view/pending-style.ts (~40 lines)'), but the feature is fully shipped: the file exists with the exact PendingStyle interface, and it is wired into editor.ts (createPendingStyle at line 900, pending.set on collapsed selection at 1008, merge into getSelectionStyle at 2600/2644, pending.clear at 947/1935/1961/2340/2582/3540/3656) and text-editor.ts (consumeForInsert 335, rewindAnchor 351, rebindAnchor 366). A reader would wrongly believe this is unbuilt.
+  - _Evidence:_ packages/docs/src/view/pending-style.ts (createPendingStyle/PendingStyle); packages/docs/src/view/editor.ts:900,1008,2600-2601,2644-2645; packages/docs/src/view/text-editor.ts:335,351,366
+- **[low] stale-reference** — Testing section states 'New file: packages/docs/test/view/pending-style.test.ts' as the single controller test and says editor integration tests will 'extend existing view/*.test.ts', but three dedicated test files were actually created.
+  - _Evidence:_ packages/docs/test/view/pending-style.test.ts, pending-style-editor.test.ts, pending-style-integration.test.ts
+- **[low] other** — Doc gives the constructor signature as createPendingStyle(doc: Document); the shipped signature takes the type alias Doc (imported from ../model/document.js), not a type named Document.
+  - _Evidence:_ packages/docs/src/view/pending-style.ts:1,16 (import type { Doc }; createPendingStyle(doc: Doc))
+
+### docs/design/docs/docs-pdf-export.md
+
+> The PDF-export design is fully implemented and matches the doc closely; only test-location, fixture-naming, and API-signature details have drifted.
+
+- **[low] stale-reference** — Doc's Testing and File Structure sections place tests/fixtures under packages/docs/src/export/__tests__/fixtures/, but the shipped code puts them under packages/docs/test/export/ with PDF fixtures in packages/docs/test/export/fixtures/pdf/.
+  - _Evidence:_ packages/docs/test/export/pdf-exporter.test.ts, packages/docs/test/export/fixtures/pdf/*.json (no src/export/__tests__ dir exists)
+- **[low] stale-reference** — Doc lists fixtures simple-paragraph.json, mixed-korean-english.json, with-table.json, multi-page.json; the actual fixture set differs (e.g. with-list.json exists, and the listed simple-paragraph/mixed-korean-english/with-table/multi-page names are not all present).
+  - _Evidence:_ packages/docs/test/export/fixtures/pdf/ contains with-headings-and-links.json, with-image.json, with-list.json, with-split-row.json, with-merged-cells.json, with-header-footer-pagenumber.json
+- **[low] other** — Public API block shows `static async export(doc, options?: PdfExportOptions)` with options optional, but the implementation declares it required (`opts: PdfExportOptions`).
+  - _Evidence:_ packages/docs/src/export/pdf-exporter.ts:61 `export(doc: Document, opts: PdfExportOptions): Promise<Blob>`
+- **[low] implemented-not-documented** — The primary PdfExportOptions code sample (lines 138-150) omits `fontResolver`, which the shipped interface includes; it is only mentioned later in the P3-a prose. Minor: main API listing is incomplete.
+  - _Evidence:_ packages/docs/src/export/pdf-exporter.ts:31-50 PdfExportOptions includes PdfFontResolver; used at line 71 scanFontsUsed(doc, opts.fontResolver)
+
+### docs/design/docs/docs-ruler.md
+
+> The Document Ruler design is fully shipped in packages/docs and matches the doc; only small drifts in file layout and function signatures.
+
+- **[low] stale-reference** — Doc's File Structure section says the new file is a single module `packages/docs/src/view/ruler.ts`. In code it is a directory module `packages/docs/src/view/ruler/` split into index.ts (Ruler class, RULER_SIZE), unit.ts (RulerUnit, detectUnit, getGridConfig, snapToGrid), and tick-renderer.ts (drawTicks).
+  - _Evidence:_ packages/docs/src/view/ruler/index.ts, packages/docs/src/view/ruler/unit.ts, packages/docs/src/view/ruler/tick-renderer.ts (no ruler.ts exists)
+- **[low] implemented-not-documented** — The Ruler API differs slightly from the doc's signatures: constructor takes a 3rd `readOnly?` arg; `render()` takes a 6th `cursorPageIndex` arg and cursorBlockStyle is nullable; there is an additional `onDragGuideline` callback not listed alongside onMarginChange/onIndentChange/dispose.
+  - _Evidence:_ packages/docs/src/view/ruler/index.ts:56 (constructor readOnly), :104-111 (render cursorPageIndex), :430 (onDragGuideline)
+- **[low] implemented-not-documented** — Doc's BlockStyle snippet lists alignment as `'left' | 'center' | 'right'`; actual type also includes `'justify'`. Unrelated to the ruler additions but the reproduced interface is stale.
+  - _Evidence:_ packages/docs/src/model/types.ts:103 alignment includes 'justify'
+
+### docs/design/docs/tables/docs-table-resize.md
+
+> The feature is fully shipped and matches the doc's data model, Doc API, border detection, constraints, and layout integration; the only drift is that the drag guideline is rendered in editor.ts (not table-renderer.ts as the doc states) and a couple of cosmetic value mismatches.
+
+- **[medium] stale-reference** — The doc's 'Guideline Rendering' section says 'the table renderer draws the guideline after borders' and the File Changes table lists packages/docs/src/view/table-renderer.ts with change 'Render guideline when dragState is active'. In reality table-renderer.ts contains no guideline code; the guideline is drawn in editor.ts's paint loop, fed by an onDragGuideline callback wired through text-editor.ts. A reader looking in table-renderer.ts for guideline logic finds nothing.
+  - _Evidence:_ grep found no guideline/setLineDash/dragState references in packages/docs/src/view/table-renderer.ts; guideline drawing is at packages/docs/src/view/editor.ts:1784-1806 (setLineDash([4,4]), stroke), with onDragGuideline callback at text-editor.ts:177 and 1601
+- **[low] stale-reference** — Doc specifies guideline color '#4A90D9'; code uses '#4285F4'. Line dash [4,4] and lineWidth 1 match.
+  - _Evidence:_ packages/docs/src/view/editor.ts:1789 ctx.strokeStyle = '#4285F4'
+- **[low] other** — Doc's TableData snippet declares rowHeights as 'number[]'; actual type is '(number | undefined)[]', consistent with the doc's prose about per-entry undefined entries but not its type signature.
+  - _Evidence:_ packages/docs/src/model/types.ts:468 rowHeights?: (number | undefined)[]
+
+### docs/design/docs/docs-spell-check.md
+
+> The spell-check feature is shipped essentially as documented — every named module, symbol, provider, router, session, EditorAPI method, and the unified DocsContextMenu exist and are wired up; only a couple of numeric/cosmetic details have drifted.
+
+- **[low] stale-reference** — Doc says the vendored dict adds two lazy chunks bumping the frontend chunk count "108 → 110" in harness.config.json. The actual reason entry records the spell-dict bump as "109 → 111" (a slides Slider bump 108→109 landed in between). The load-bearing claims (two lazy dict chunks, a reason entry, main docs entry stays ~346 KB, dict not inlined) all match; only the numeric range is stale.
+  - _Evidence:_ harness.config.json maxChunkCountReason: "Prior bump: 109 → 111 when Docs spell check vendored the en_US Hunspell dictionary ... two dynamic-import chunks ... main docs entry stays ~346 kB"
+- **[low] implemented-not-documented** — An EditorAPI toggle primitive setSpellCheckEnabled(enabled) is implemented (declared and defined in editor.ts, on by default), yet the doc lists "Toggle spell check on/off (UI control)" as a deferred Non-Goal and never mentions the existing programmatic API. Consistent in spirit (no UI control ships), but the underlying enable/disable API already exists and is undocumented.
+  - _Evidence:_ packages/docs/src/view/editor.ts:222 (interface) and :3208 (impl) setSpellCheckEnabled; no frontend UI caller found
+- **[low] documented-not-implemented** — The Testing section still lists a "caret word" skip test for both tokenize and SpellSession, but the doc's own Skip-rules narrative states the caret-word skip was tried and removed. No caret-word skip logic is present in tokenize.ts or session.ts, so the caret-word test bullets describe behavior that was intentionally dropped.
+  - _Evidence:_ packages/docs/src/spell/tokenize.ts (skip rules: <2 chars, all-caps acronym, URL/email/number ranges — no caret handling); packages/docs/src/spell/session.ts (no caret logic)
+
+### docs/design/docs/docs.md
+
+> Doc is largely accurate and self-aware (Non-Goals updated to "shipped" with valid cross-refs), but the package name is wrong throughout and two sections (Store Abstraction, Data Model) still frame shipped features as future.
+
+- **[medium] stale-reference** — The doc repeatedly names the package '@wafflebase/document' (Summary line 10 and Goals line 26), but the actual package name is '@wafflebase/docs'. A reader would import the wrong module path.
+  - _Evidence:_ packages/docs/package.json name field = "@wafflebase/docs"; doc lines 10,26 say @wafflebase/document
+- **[medium] roadmap-shipped** — The Store Abstraction section says 'Future YorkieDocStore will implement the same interface using Yorkie CRDT operations', but YorkieDocStore has shipped as a class implementing DocStore. This also contradicts the doc's own Non-Goals which lists real-time collaboration as shipped.
+  - _Evidence:_ packages/frontend/src/app/docs/yorkie-doc-store.ts:505 `export class YorkieDocStore implements DocStore`; doc lines 165-167 say 'Future YorkieDocStore will...'
+- **[medium] roadmap-shipped** — Data Model 'Design decisions' claims 'Block type: Currently only "paragraph". The discriminated union allows future extension to "table" | "heading" | "list"'. Those block types have all shipped; BlockType is now a wide union. The section is internally stale versus the doc's own Non-Goals.
+  - _Evidence:_ packages/docs/src/model/types.ts:39 `export type BlockType = 'paragraph' | 'title' | 'subtitle' | 'heading' | 'list-item' | 'horizontal-rule' | 'table' | 'page-break'`; doc lines 113-114
+- **[low] stale-reference** — The Package Structure tree lists 'doc-container.ts # Scroll management' under src/view/, but no such file exists; scroll handling lives in text-editor.ts and doc-canvas.ts.
+  - _Evidence:_ packages/docs/src/view/doc-container.ts does not exist (ls error); scroll logic in packages/docs/src/view/text-editor.ts and doc-canvas.ts; doc line 288
+
+### docs/design/docs/docs-tables.md
+
+> The doc accurately describes the shipped table subsystem — data model, CRDT structure, store ops, navigation, layout, and UI all match the code — with only minor undocumented additions around row-height support.
+
+- **[low] implemented-not-documented** — The doc's TableData interface lists only { rows, columnWidths }, but the shipped type also has an optional rowHeights?: (number | undefined)[] field (row resize support).
+  - _Evidence:_ packages/docs/src/model/types.ts:465-469 (TableData with rowHeights?)
+- **[low] implemented-not-documented** — The doc shows updateTableAttrs(tableBlockId, attrs: { cols: number[] }), but the shipped DocStore signature is attrs: { cols: number[]; rowHeights?: (number | undefined)[] }.
+  - _Evidence:_ packages/docs/src/store/store.ts:69 and packages/frontend/src/app/docs/yorkie-doc-store.ts (updateTableAttrs signature)
+- **[low] stale-reference** — The doc names a BlockParentMap type alias (type BlockParentMap = Map<string, BlockCellInfo>), but the code uses Map<string, BlockCellInfo> inline via a _blockParentMap field / blockParentMap getter; no BlockParentMap type is actually exported. Purely a naming nit — BlockCellInfo exists and the map is real.
+  - _Evidence:_ packages/docs/src/model/document.ts:67,79,83 (Map<string, BlockCellInfo>, no BlockParentMap alias); packages/docs/src/model/types.ts:479 (BlockCellInfo)
+
+### docs/design/docs/tables/docs-table-row-splitting.md
+
+> The described row-splitting feature is fully shipped and matches the doc's data model, pagination, rendering, and interaction claims; only a couple of cited function names and an unlisted file are slightly off.
+
+- **[low] stale-reference** — Section 3.4 states "`renderSelection` clips selection highlight rectangles to the current page's fragment bounds" as an existing function, and 3.5 states "`scrollIntoView` targets that page's Y offset." Neither symbol exists in packages/docs/src. The split-row selection clipping is actually implemented in selection.ts (computeSelectionRects / SelectionManager, using rowSplitOffset/rowSplitHeight at lines ~388-395 and ~580-620); scroll handling is done via container.scrollTop in text-editor.ts. Behavior is present, only the named symbols are wrong.
+  - _Evidence:_ grep found no renderSelection/scrollIntoView symbols; packages/docs/src/view/selection.ts:526 computeSelectionRects, selection.ts:580-625 fragment-clipping logic; packages/docs/src/view/text-editor.ts scrollTop usage
+- **[low] stale-reference** — Section 3 lists interaction-layer files as only text-editor.ts and pagination.ts, but the split-aware selection clipping actually lives in an unmentioned file, selection.ts. Minor omission.
+  - _Evidence:_ packages/docs/src/view/selection.ts:388,587,620 handle rowSplitOffset/rowSplitHeight
+- **[low] stale-reference** — Section 2.5 references `computeTableRangeForPageLine` in the context of doc-canvas.ts/table-renderer.ts; the function is actually defined in table-geometry.ts and imported by both. The doc gives no explicit path so this is only mild imprecision.
+  - _Evidence:_ packages/docs/src/view/table-geometry.ts:101 defines computeTableRangeForPageLine; imported at doc-canvas.ts:10 and table-renderer.ts:21
+
+### docs/design/docs/tables/docs-table-copy-paste.md
+
+> The doc matches the shipped clipboard/table-paste implementation almost exactly on file paths, function names, and paste-flow ordering, but its Phase-1 Non-Goal of deferring cell merge (colSpan/rowSpan) has since been implemented, and one "Unchanged" symbol reference is stale.
+
+- **[medium] roadmap-shipped** — The doc repeatedly frames cell merge as out of scope: Non-Goals say 'Copying/pasting cell merge (colSpan/rowSpan) attributes in Phase 1', the risk table says 'Phase 1 skips colSpan/rowSpan — paste treats each cell independently', and Phase 3 Non-Goals say 'colSpan/rowSpan from external HTML (Phase 1 already defers this)'. In the shipped code, merges are fully handled: cloneTableCells explicitly preserves colSpan/rowSpan, pasteTableCells calls normalizeTableMerges after both new-table and in-place paste, and the copy selection is expanded over merges via expandCellRangeForMerges.
+  - _Evidence:_ packages/docs/src/view/clipboard.ts:55-56 (cloneTableCells copies colSpan/rowSpan); packages/docs/src/view/text-editor.ts:3634,3666 (normalizeTableMerges in pasteTableCells); packages/docs/src/view/text-editor.ts:1787,1807,2665 + selection.ts:56 (expandCellRangeForMerges); model/types.ts:551 (normalizeTableMerges def)
+- **[low] stale-reference** — The 'Unchanged' table claims 'document.ts — existing updateCellBlocks() reused', but no updateCellBlocks symbol exists in the docs package; paste actually persists via doc.updateBlockDirect() (which the doc's own Paste Flow step 5 correctly names). The Unchanged-section reference is dangling.
+  - _Evidence:_ grep for updateCellBlocks in packages/docs/src returns nothing; packages/docs/src/model/document.ts:485 defines updateBlockDirect; text-editor.ts:3667 calls this.doc.updateBlockDirect
+- **[low] other** — The illustrative cloneTableCells snippet in the doc spreads '...cell' and omits merge fields, whereas the shipped helper explicitly rebuilds style and conditionally forwards colSpan/rowSpan (consistent with the merge-handling drift above). Cosmetic snippet divergence only.
+  - _Evidence:_ docs snippet lines 92-105 vs packages/docs/src/view/clipboard.ts:51-65
+
+### docs/design/docs/tables/docs-nested-tables.md
+
+> The nested-tables feature is genuinely shipped and matches the doc's data-model, layout, rendering, CRDT-path, and .docx round-trip descriptions; drift is limited to two named helper APIs the doc invents that don't exist under those names and a minor insertion-mechanism mismatch.
+
+- **[medium] documented-not-implemented** — Section 4 introduces a 'New getTableContext(blockId)' that walks the BlockParentMap chain to return the table hierarchy path [outermostTableId, ..., innermostTableId]. No such symbol exists anywhere in the repo; a repo-wide grep for getTableContext returns nothing. The shipped code identifies target tables via getCellInfo()/blockParentMap.get() and getParentTableBlock() instead — which the doc's own next subsection admits ('No changes needed'), making the proposed API vestigial and unbuilt.
+  - _Evidence:_ grep 'getTableContext' across packages/ = 0 hits; packages/docs/src/model/document.ts getParentTableBlock() (~line 214) and packages/docs/src/view/text-editor.ts getCellInfo() are the actual mechanism
+- **[low] stale-reference** — Section 5 specifies a 'resolveTreePath(blockId): number[] utility' as the mechanism for converting a blockId to a deeper Yorkie tree path for nested tables. No function named resolveTreePath (or getTableContext) exists. The equivalent functionality IS shipped but via differently-named helpers that walk repeating [r,c,b] triplets — getCellBlock(), setCellBlock(), getCellSubPath(), getBlocksArrayForPath() in yorkie-doc-store.ts. Concept shipped, named utility does not exist.
+  - _Evidence:_ grep 'resolveTreePath' across packages/ = 0 hits; packages/frontend/src/app/docs/yorkie-doc-store.ts lines 1207-1266 (getCellBlock/setCellBlock/getBlocksArrayForPath, comment '[r, c, b, r, c, b, ...]')
+- **[low] documented-not-implemented** — Section 1 and Section 4 state cell insertion works by removing the nested-table guard in Document.insertTable() so a table is added to cell.blocks 'like any other block' via insertTable(). Actual code adds a dedicated Document.insertTableInCell(blockId, rows, cols) method; Document.insertTable(blockIndex, rows, cols) takes a body block index and has no guard to remove. The editor's insertTable command branches on blockParentMap and calls insertTableInCell for cells. Mechanism differs from the doc's description.
+  - _Evidence:_ packages/docs/src/model/document.ts insertTable (line 578, body-only, no guard) and insertTableInCell (line 592); packages/docs/src/view/editor.ts line 3341 calls doc.insertTableInCell
+
+### docs/design/homepage.md
+
+> The homepage doc accurately describes the shipped implementation (file structure, primitives, demo tokens/env vars, theme-sync via postMessage, routing, CSS tokens all match); only stale hardcoded version literals and one hint-text quote have drifted.
+
+- **[low] stale-reference** — Doc's DemoSection footer says it shows the literal 'wafflebase@0.3.7', but the code renders `wafflebase@${__APP_VERSION__}`, which Vite injects from the root package.json version (currently 0.6.2). The rendered value is dynamic, not the doc's frozen 0.3.7.
+  - _Evidence:_ packages/frontend/src/app/home/demo-section.tsx:199; packages/frontend/vite.config.ts:238 (rootPkg.version); root package.json version 0.6.2
+- **[low] stale-reference** — Doc's Hero eyebrow is quoted as 'v0.3 · Apache-2.0 · Self-hosted', but the code derives the label dynamically from the app version (VERSION_LABEL = v + major.minor of __APP_VERSION__), so it currently renders 'v0.6', not 'v0.3'.
+  - _Evidence:_ packages/frontend/src/app/home/hero-section.tsx:8,44; root package.json version 0.6.2
+- **[low] stale-reference** — Doc quotes the Slides tab footer hint as 'Tip: arrow keys navigate slides — press F to present.', but the shipped hint reads 'Tip: arrow keys navigate — ⌘/Ctrl+Enter to present.'
+  - _Evidence:_ packages/frontend/src/app/home/demo-section.tsx:197
+- **[low] stale-reference** — Frontmatter target-version is 0.4.0 while the repo is at 0.6.2, indicating the doc predates the current release; content is otherwise still accurate.
+  - _Evidence:_ docs/design/homepage.md:3; packages/frontend/package.json version 0.6.2
+
+### docs/design/harness-engineering.md
+
+> Nearly all concrete file/symbol/lane/config claims verify exactly against the code; the only drift is the stale status framing of the Summary and the "Remaining Work" heading, under which several fully-shipped phases (24-27) sit.
+
+- **[medium] roadmap-shipped** — The Summary (lines 20-27, "As of 2026-03-11 ... phases 1 through 20, 22, and 23 are completed. Remaining work focuses on agent observability.") and the "## Remaining Work" heading frame Phases 24 (Autonomous Contribution Loop), 25 (Local Spec->PR), 26 (Autonomous Issue Hunting Tier 1), and 27 (Panel Feedback Corpus) as not-yet-done, but they are substantially shipped in code. A reader skimming status headers would be misled about what exists. The prose bodies of 26/27 do partially self-correct ("Tier 1 (shipped)", "Done criteria ... (met)", "Not yet built: ..."), so this is staleness rather than a false shipped-claim.
+  - _Evidence:_ Shipped: .github/workflows/agent-implement.yml, agent-iterate-ci.yml, agent-review-panel.yml, agent-review-reply.yml, agent-review-on-demand.yml, agent-summarize.yml, agent-loop.yml; scripts/agent/review-panel.mjs, review-scope.mjs, review-state.mjs, set-state.mjs, mark-ready.mjs, novelty.mjs (Phase 24); scripts/agent/spec-to-pr.mjs + .claude/commands/spec-to-pr.md (Phase 25); scripts/agent/hunt*.mjs + .claude/commands/hunt.md (Phase 26); scripts/agent/harvest.mjs + scripts/agent/misses.jsonl (Phase 27) all present.
+- **[low] stale-reference** — The section heading "## Completed Phases (1-20, 22)" omits Phase 23, which is listed as Completed in that very table (line 292) and given its own "Phase 23 delivered" subsection. Cosmetic title drift.
+  - _Evidence:_ docs/design/harness-engineering.md line 265 heading vs line 292 table row "23 | Docker-based browser test environment ... | Completed".
+
+### docs/design/export-progress.md
+
+> The export-progress feature (onProgress callbacks with 'slides'/'pages'/'images' phases, yieldToPaint macrotask yields, and updateExportToast) is fully shipped exactly as described; only the doc's referenced "import toast" prior art is misdescribed.
+
+- **[medium] stale-reference** — The doc's Summary, Goals, and section C claim the export toast 'mirrors the existing import flow' via a shared helper `updateImportToast` in packages/frontend/src/app/documents/document-list.tsx. No such symbol exists anywhere in the repo, and document-list.tsx contains no import-progress toast. The only toast.loading usage in the frontend is the new updateExportToast in export-utils.ts. The real import progress UX is an upload-queue/upload-panel (packages/frontend/src/app/documents/upload-queue.ts, use-upload-queue.ts, upload-panel.tsx), not a Sonner toast — so the stated design rationale of 'reusing the import toast' points at prior art that does not exist.
+  - _Evidence:_ grep 'updateImportToast' across packages/ returns nothing (exit 1); grep 'toast.loading' in packages/frontend/src matches only app/docs/export-utils.ts; import progress lives in packages/frontend/src/app/documents/upload-queue.ts + upload-panel.tsx, and importDocx (app/docs/docx-actions.ts) reports {done,total,fileName} into the upload queue, not a toast.
+
+### docs/design/notes/notes.md
+
+> The notes design doc accurately describes the shipped implementation — engine package, backend/frontend wiring, CLI namespace, and all "shipped" later-phase features exist as claimed; only small file-layout and symbol-name drifts remain in the P1 architecture sketch.
+
+- **[low] stale-reference** — P1 architecture lists engine subdirectories `src/model/` (note data types) and `src/yorkie/` (yorkieSync.ts, remoteSelection.ts, index.ts). Neither directory exists. packages/notes/src has only `view/` and `store/`; the Yorkie/CodeMirror binding lives in `src/view/note-sync.ts` and `src/view/remote-selection.ts`, and data types live in `src/store/store.ts` + `src/types.ts`.
+  - _Evidence:_ packages/notes/src/ (no model/ or yorkie/ dir); packages/notes/src/view/note-sync.ts, packages/notes/src/view/remote-selection.ts
+- **[low] stale-reference** — Doc names the engine entry `initialize(container, store, theme)` returning `EditorAPI`. Actual export returns `NoteEditorAPI` and takes five params: (container, store, theme, readOnly, viewMode).
+  - _Evidence:_ packages/notes/src/view/editor.ts:130 (export function initialize ... : NoteEditorAPI); packages/notes/src/index.ts exports NoteEditorAPI
+- **[low] stale-reference** — Doc refers to the seed helper as `initialNoteRoot()` and the presence type as `NotePresence`. The shipped symbols are `initialNotesRoot()` and `NotesPresence` (root type `YorkieNotesRoot` matches).
+  - _Evidence:_ packages/frontend/src/types/notes-document.ts:46 (initialNotesRoot), :31 (NotesPresence)
+
+### docs/design/rest-api.md
+
+> The REST API and API-key design is fully shipped and matches the code closely; drift is limited to a stale SDK version, an undocumented image-endpoint family, and a rate-limiting Non-Goal that is actually implemented.
+
+- **[medium] implemented-not-documented** — The doc's Section 5 endpoint list and Section 6 module structure for api/v1/ do not mention any image endpoints, but a fully wired ApiV1ImagesController ships POST/GET/DELETE /api/v1/workspaces/:workspaceId/images, guarded by CombinedAuthGuard + WorkspaceScopeGuard. A reader auditing the v1 surface would miss this endpoint group entirely.
+  - _Evidence:_ packages/backend/src/api/v1/images.controller.ts (ApiV1ImagesController, @Controller('api/v1/workspaces/:workspaceId/images'), upload/get/delete); file omitted from doc Section 6 tree which lists only documents/tabs/cells/docs-content controllers + workspace-scope.guard
+- **[medium] documented-not-implemented** — Non-Goals explicitly list 'Rate limiting or usage metering', implying the v1 API has none, but rate limiting is implemented and active on the v1 surface: the images controller sets @Throttle({ default: { limit: 600, ttl: 60_000 } }), CLI auth endpoints throttle at 10/min, and app.module registers ThrottlerModule.forRoot with a global ThrottlerGuard.
+  - _Evidence:_ packages/backend/src/api/v1/images.controller.ts:25 (@Throttle); packages/backend/src/auth/auth.controller.ts:148,166 (@Throttle); packages/backend/src/app.module.ts:4,91 (ThrottlerModule/ThrottlerGuard)
+- **[low] stale-reference** — Section 4 states the backend @yorkie-js/sdk matches 'the version family used by the frontend (@yorkie-js/react 0.6.49)'. Actual pinned version is 0.7.13 on both sides; the 0.6.49 figure is stale (the directional 'matches frontend' claim still holds).
+  - _Evidence:_ packages/backend/package.json:42 (@yorkie-js/sdk 0.7.13); packages/frontend/package.json:60,89 (@yorkie-js/react 0.7.13, @yorkie-js/sdk 0.7.13)
+
+### docs/design/sheets/batch-transactions.md
+
+> The batch-transaction design matches shipped code (beginBatch/endBatch, batchOverlay/batchOps, MemStore no-ops, Sheet wrapping), with two drifts: the store's shiftCells/moveCells are now batch-aware despite the doc calling them "unaffected by batch," and a batchOps type annotation is stale.
+
+- **[medium] implemented-not-documented** — The doc states under 'Methods unaffected by batch' that shiftCells()/moveCells() 'Run their own doc.update() outside the batch,' and Non-Goals/Risks frame them as always producing 2 undo steps. But the store methods now branch on `if (this.batchOps)` and buffer their apply function into batchOps, returning early to defer to the single endBatch() doc.update(). So the store-level methods ARE batch-aware, contradicting the doc's 'unaffected' framing (the sheet-level 2-undo-step behavior still holds only because Sheet.shiftCells calls store.shiftCells before beginBatch).
+  - _Evidence:_ packages/frontend/src/app/spreadsheet/yorkie-store.ts:504-508 (shiftCells) and 536-540 (moveCells); doc lines 100-101, 28-30, 171-175
+- **[low] stale-reference** — The doc declares the batchOps buffer field as `Array<(root: Worksheet) => void>`, but the shipped field type is `Array<(root: SpreadsheetDocument) => void>` (the deferred ops operate on the document root, consistent with the doc's own prose but not its type annotation).
+  - _Evidence:_ packages/frontend/src/app/spreadsheet/yorkie-store.ts:77 vs doc line 53
+
+### docs/design/shared-core-extraction.md
+
+> The doc is a well-framed roadmap whose explicit Status note accurately reports what shipped (core with tokens/geometry/url) vs. what is still roadmap (canvas/ooxml/drawingml); only the "Incidental fix" section and geometry redefinition list carry stale details already overtaken by the shipped Phase 0.
+
+- **[low] roadmap-shipped** — The 'Incidental fix' section says packages/docs/package.json lists `@wafflebase/tokens` under devDependencies and proposes promoting it to a dependency (fold into Phase 0). That fix is already done and the package name is obsolete: `@wafflebase/tokens` no longer exists (folded into `@wafflebase/core`), docs/package.json has `@wafflebase/core` under `dependencies` (line 57), and theme.ts imports `@wafflebase/core/tokens` at runtime — so the described bug no longer exists.
+  - _Evidence:_ packages/docs/package.json (dependencies: @wafflebase/core workspace:*), packages/docs/src/view/theme.ts (import { palette } from '@wafflebase/core/tokens'); no packages/tokens directory exists
+- **[low] stale-reference** — The 'Geometry redefinition sites' list presents slides frame/routing/insert/lasso/image-crop as still redefining geometry, but those five files now import from `@wafflebase/core/geometry` (Phase 0 geometry extraction, which the Status note confirms shipped). The list is accurate only for `packages/sheets/src/view/layout.ts`, which still defines a local `Size = {width,height}`.
+  - _Evidence:_ packages/slides/src/model/frame.ts, image-crop.ts, view/canvas/routing.ts, view/editor/interactions/{lasso,insert}.ts all import @wafflebase/core/geometry; packages/sheets/src/view/layout.ts line 36 still `export type Size = { width: number; height: number }`
+- **[low] implemented-not-documented** — The package.json `exports` sketch and the proposed src layout omit the shipped `./url` subpath (SAFE_PROTOCOLS/isSafeUrl). The Status note mentions `./url` separately, but the canonical exports/layout diagrams that a reader consults do not include it.
+  - _Evidence:_ packages/core/package.json exports include './url'; packages/core/src/url/index.ts exists; doc lines 122-147 sketch omits url
+
+### docs/design/sheets/charts.md
+
+> Phase 1 is fully shipped and the doc matches the code closely; the only drift is that the core types are defined in the @wafflebase/sheets package, not in the frontend path the doc names.
+
+- **[low] stale-reference** — Doc says to extend `ChartType` (and defines `SheetChart`) in `packages/frontend/src/types/worksheet.ts`. That file only RE-EXPORTS both from `@wafflebase/sheets`; the actual definitions live in packages/sheets/src/model/workbook/worksheet-document.ts (ChartType line 14, SheetChart line 16). The type bodies themselves match the doc exactly.
+  - _Evidence:_ packages/frontend/src/types/worksheet.ts (re-export from @wafflebase/sheets), packages/sheets/src/model/workbook/worksheet-document.ts:14-32
+- **[low] other** — Doc gives the pie builder signature as `buildPieDataset(root, chart)`; the shipped function takes a third `palette?: string` argument used for slice colors. Cosmetic signature drift only.
+  - _Evidence:_ packages/frontend/src/app/spreadsheet/chart-utils.ts:278-320 (buildPieDataset), called as buildPieDataset(root, chart, chart.colorPalette) in chart-object-layer.tsx:192
+
+### docs/design/sheets/calculator.md
+
+> The doc accurately describes the shipped calculator recalculation and cross-sheet cycle-detection architecture; only minor drift exists around the evaluation function name and an undocumented spill-evaluation path.
+
+- **[low] stale-reference** — The doc's evaluation step and diagram reference `evaluate(formula, grid)` computing the result, but the calculator's recalculation loop actually calls `evaluateWithSpill(formula, grid)`. A separate `evaluate` function does exist (formula.ts:577), but it is not the one used in calculator.ts.
+  - _Evidence:_ packages/sheets/src/model/worksheet/calculator.ts:96 uses evaluateWithSpill; packages/sheets/src/formula/formula.ts:546 (evaluateWithSpill) vs :577 (evaluate)
+- **[low] implemented-not-documented** — calculator.ts contains substantial array-spill logic (SpillResult handling, ghost-cell writes, spill-blocker registration via registerSpillBlocker/clearSpillBlockers, spillRows/spillCols, expandUnboundedRanges of open-ended ranges) that the doc omits entirely. The doc describes the evaluate step as a simple single-value write plus a no-op skip.
+  - _Evidence:_ packages/sheets/src/model/worksheet/calculator.ts:71-145 (spill ghost clearing, conflict detection, ghost writes); :90 expandUnboundedRanges
+
+### docs/design/sheets/collaboration.md
+
+> The doc accurately describes the shipped module layout, migration command, test suite, and stable-id worksheet model; the only drift is in its self-declared "canonical" type block, which lists a datasources/DatasourceConfig field that does not exist and omits the shipped dataValidations field.
+
+- **[medium] documented-not-implemented** — The 'canonical' SpreadsheetDocument declares `datasources?: { [id: string]: DatasourceConfig }` (see datasource.md). The actual SpreadsheetDocument type has no datasources field, and the type `DatasourceConfig` does not exist anywhere in the codebase; datasource.md also never defines this patch field. Since the block is framed as the authoritative current shape, a reader would expect datasource config to live on the Yorkie document, which it does not.
+  - _Evidence:_ packages/sheets/src/model/workbook/worksheet-document.ts (SpreadsheetDocument at line 115-119 has only tabs/tabOrder/sheets); grep for 'DatasourceConfig' across packages/ (excluding node_modules/dist) returns zero matches; docs/design/sheets/datasource.md has no `datasources`/`DatasourceConfig` mention
+- **[medium] implemented-not-documented** — The Worksheet type ships `dataValidations?: DataValidationRule[]` (seeded to [] in createWorksheet and remapped in the backend migration), but the doc's canonical Worksheet block—explicitly billed as the single source of truth that other docs must patch against—omits this field entirely.
+  - _Evidence:_ packages/sheets/src/model/workbook/worksheet-document.ts:81 (`dataValidations?: DataValidationRule[]`) and :136 (seeded in createWorksheet); type defined at packages/sheets/src/model/core/types.ts:182
+- **[low] stale-reference** — The canonical block types the comments field as `comments?: CommentsCollection`, but the type `CommentsCollection` does not exist; the shipped Worksheet uses `comments?: { [threadId: string]: Thread }`. This field is owned by comments.md per the doc's own note, so the impact is cosmetic.
+  - _Evidence:_ packages/sheets/src/model/workbook/worksheet-document.ts:94-96 (`comments?: { [threadId: string]: Thread }`); grep for 'CommentsCollection' across packages/ returns zero matches
+
+### docs/design/sheets/file-import.md
+
+> The doc's shipped-XLSX and unused-papaparse claims are accurate, but it repeatedly names the frontend import action pickAndImportXlsx, which does not exist — the actual export is importXlsx.
+
+- **[medium] stale-reference** — The doc states the shipped frontend entry point is `pickAndImportXlsx` in xlsx-actions.ts (Current-state table and §2). No such symbol exists anywhere in the repo; the actual exported action is `importXlsx(file: File)`, which takes a File directly and does no file-picking. A reader searching for pickAndImportXlsx finds nothing.
+  - _Evidence:_ packages/frontend/src/app/spreadsheet/xlsx-actions.ts (exports `importXlsx` and `createSpreadsheetDocumentFromImportedXlsxSheets`; grep for `pickAndImportXlsx` across packages/*/src returns nothing)
+
+### docs/design/sheets/data-validation.md
+
+> The phase-by-phase "as shipped" sections accurately match the implementation (all five kinds — checkbox/list/date/number/text — with the operator+values model, Store methods, render pass, interaction, and side panel all present), but the doc's original top-of-document sections (Summary, Goals, Data model, Testing) still frame the feature as three kinds with dateMin/dateMax fields that the later phases removed.
+
+- **[low] stale-reference** — The 'Data model' section (lines 82-101) presents the DataValidationRule type with `dateMin?`/`dateMax?` fields and only three kinds (checkbox/list/date). The shipped type in code has no dateMin/dateMax (replaced by generic `operator?: DataValidationOperator` + `values?: string[]`) and five kinds (adds number/text). Phase 4/5 of the same doc explicitly document this replacement ('dateMin/dateMax are removed (dead)'), so the top section is superseded rather than contradicted, but reads stale in isolation.
+  - _Evidence:_ packages/sheets/src/model/core/types.ts:138-199 (DataValidationKind union has checkbox|list|date|number|text; DataValidationRule has operator/values, no dateMin/dateMax) vs doc lines 82-101
+- **[low] stale-reference** — Goals lists 'Three control kinds: checkbox, list, date' and Non-Goals implies number/text are not in scope, but number and text kinds shipped end-to-end (validation logic, render marker, panel criteria). This is reconciled only in the later Phase 5 'as shipped' section.
+  - _Evidence:_ packages/sheets/src/model/worksheet/data-validation.ts:378-451 (isValidNumberValue/isValidTextValue); packages/frontend/src/app/spreadsheet/data-validation-panel.tsx:126-133 (Number/Text criteria) vs doc lines 52, 45-72
+- **[low] stale-reference** — The Testing 'Scope note' (lines 638-640) says the feature is the 'full feature (all three kinds)' and 'Phase 4 (above) adds date', omitting that Phase 5 (number/text) also shipped. Minor staleness relative to the Phase 5 'as shipped' content below it.
+  - _Evidence:_ doc lines 636-640 vs shipped number/text in packages/sheets/src/model/worksheet/data-validation.ts and panel
+
+### docs/design/sheets/mysql-connector.md
+
+> A forward-looking MySQL-connector proposal whose "existing PostgreSQL datasource spine" claims are all accurate and whose MySQL parts are correctly framed as unbuilt; only stale point is that the mysql2 dependency it proposes adding is already present (for a different feature).
+
+- **[low] roadmap-shipped** — Proposal step 2 says "Add `mysql2` to `packages/backend` dependencies" as a future step, but mysql2 ^3.23.0 is already a dependency in packages/backend/package.json. It is used by the analytics warehouse service (StarRocks/MySQL protocol), not by the datasource connector, so the connector itself is still unbuilt — but the dependency-add step is already incidentally satisfied.
+  - _Evidence:_ packages/backend/package.json line 51 ("mysql2": "^3.23.0"); packages/backend/src/analytics/analytics-warehouse.service.ts imports mysql2/promise; no mysql reference in packages/backend/src/datasource/*
+
+### docs/design/sheets/pivot-table.md
+
+> Phase 1 is accurately described as shipped — data model, pivot engine, store methods, sheet protection, and Yorkie persistence all match the code — but the frontend Component Structure list is stale (4 of 6 named files don't exist).
+
+- **[medium] documented-not-implemented** — Section 7 'Component Structure' lists 6 files under packages/frontend/src/app/spreadsheet/pivot/ (pivot-editor-panel.tsx, pivot-field-list.tsx, pivot-field-item.tsx, pivot-section.tsx, pivot-actions.tsx, use-pivot-table.ts). Only pivot-editor-panel.tsx and use-pivot-table.ts actually exist; the field-list, field-item, section, and actions components were never created as separate files (consolidated into the 452-line pivot-editor-panel.tsx). Since the doc frames Phase 1 as shipped, a reader looking for these files would be misled.
+  - _Evidence:_ packages/frontend/src/app/spreadsheet/pivot/ contains only pivot-editor-panel.tsx and use-pivot-table.ts; find for pivot-field*/pivot-section*/pivot-actions* returns nothing
+- **[low] stale-reference** — The Architecture Overview diagram (Section 1) labels the sheet-engine and frontend components as 'PivotCalculator ─── PivotMaterializer' and 'PivotEditorPanel ─── usePivotTable hook'. The engine is implemented as plain functions calculatePivot() and materialize() (not classes named PivotCalculator/PivotMaterializer); this is a conceptual diagram so impact is cosmetic.
+  - _Evidence:_ packages/sheets/src/model/pivot/calculate.ts exports calculatePivot(); materialize.ts exports materialize(); no PivotCalculator/PivotMaterializer symbols exist
+
+### docs/design/sheets/formula-coverage.md
+
+> The doc's core claims (aliases, higher-order array functions, most niche functions, byte-variant text) match the code, but the total function count is understated, ISBETWEEN is wrongly listed as not-implemented, and the "implement here" path points at an aggregator rather than the split implementation files.
+
+- **[medium] roadmap-shipped** — The doc lists ISBETWEEN under 'Not implemented — niche' (Operator), but it is fully implemented and cataloged.
+  - _Evidence:_ packages/sheets/src/formula/functions-operator.ts:315 registers ['ISBETWEEN', isbetweenFunc] (impl at :229); function-catalog.ts:2430 has its catalog entry with 5 args.
+- **[medium] implemented-not-documented** — The doc states 447 function entries (434 unique + 13 aliases), ~434/~500 = 87%. The actual FunctionMap has 463 distinct registered functions (all unique names), so coverage is understated by ~29 functions (~92%). Per-file counts also exceed the doc's category numbers (e.g. statistical file 121 vs doc 103; engineering 50 vs 42).
+  - _Evidence:_ packages/sheets/src/formula/functions.ts assembles 11 *Entries arrays; grep of ['NAME', func] across functions-*.ts yields 463 entries (math 75, statistical 121, engineering 50, lookup 34, info 23, financial 49, text 45, date 25, logical 12, database 12, operator 17); function-catalog.ts has 462 name entries.
+- **[low] stale-reference** — The 'Adding a new function' steps say to implement in packages/sheets/src/formula/functions.ts and register in FunctionMap, but functions.ts is now only a 29-line aggregator; implementations and per-category entry arrays live in functions-<category>.ts files (functions-math.ts, functions-statistical.ts, etc.).
+  - _Evidence:_ packages/sheets/src/formula/functions.ts (29 lines) only spreads mathEntries...operatorEntries into FunctionMap; actual impls in functions-math.ts, functions-statistical.ts, functions-operator.ts, etc.
+- **[low] other** — Frontmatter target-version is 0.2.0 while the sheets package is at 0.6.2, indicating the doc predates substantial coverage growth (consistent with the understated counts above).
+  - _Evidence:_ docs/design/sheets/formula-coverage.md frontmatter target-version: 0.2.0 vs packages/sheets/package.json version 0.6.2.
+
+### docs/design/sheets/sheet.md
+
+> The doc matches the shipped @wafflebase/sheets engine almost exactly — all major files, classes, Store methods, filter/merge/freeze/move APIs, and view components verify — with only a few low-severity numeric/factual drifts.
+
+- **[low] other** — Doc states DimensionIndex default sizes are '24px row height, 100px column width'. Column width (100) matches, but the default row height in code is 23px, not 24px.
+  - _Evidence:_ packages/sheets/src/view/layout.ts:6 (DefaultCellHeight = 23); packages/sheets/src/view/worksheet.ts:280 (new DimensionIndex(DefaultCellHeight))
+- **[low] other** — Doc says ReadOnlyStore 'populates row 0 with bold column headers and subsequent rows with data'. Coordinates are 1-based; code populates row 1 with headers and rows 2+ with data (no row 0).
+  - _Evidence:_ packages/sheets/src/store/readonly.ts:49,58,60 (comment 'Row 1 contains column headers', toSref({ r: 1, c: c + 1 }))
+- **[low] stale-reference** — Formula Engine section says '~430 built-in functions'. Actual FunctionMap has 463 entries; the authoritative formula-coverage.md states 447 entries / 434 unique functions. The '~' hedge makes it near-accurate but slightly understated.
+  - _Evidence:_ packages/sheets/src/formula/functions.ts FunctionMap (463 registered keys); docs/design/sheets/formula-coverage.md:11-16 (447 entries / 434 unique)
+
+### docs/design/slides/slides-collaboration.md
+
+> The doc's core claims about Slides collaboration (notes/text LWW-on-blur, peer selection rings shipped, live drag-frames/guides and text carets not yet broadcast) all match the code; only a shipped table-cell presence feature is omitted and two task-file links are stale.
+
+- **[medium] implemented-not-documented** — The doc (Gap 3) enumerates SlidesPresence as only activeSlideId/selectedElementIds/activeFrames/draggingGuide and lists only element selection rings + name tags as 'Closed'. In reality a fifth presence field `selectedTableCells` (table cell-range) is fully wired: broadcast in slides-view.tsx (store.updatePresence with selectedTableCells) and rendered as PeerCellRect via computePeerOverlays. A reader treating this doc as 'single source of truth for what works concurrently today' would miss shipped table-cell peer feedback.
+  - _Evidence:_ packages/frontend/src/types/users.ts:74 (selectedTableCells field); packages/frontend/src/app/slides/slides-view.tsx:1082 (broadcast); packages/slides/src/view/editor/peers.ts:74 PeerCellRect & :141 computePeerOverlays handling selectedTableCells; packages/frontend/src/app/slides/peer-view.ts:38
+- **[low] stale-reference** — Both TODO links point to ../../tasks/active/ but the files have been moved to docs/tasks/archive/2026/06/, so the links (20260620-slides-notes-live-sync-todo.md and 20260621-slides-live-presence-todo.md) are broken.
+  - _Evidence:_ docs/tasks/archive/2026/06/20260620-slides-notes-live-sync-todo.md and docs/tasks/archive/2026/06/20260621-slides-live-presence-todo.md exist; docs/tasks/active/ contains neither
+
+### docs/design/slides/slides-charts.md
+
+> The doc's Phase 1 design is fully shipped and its technical claims match the code; the only drift is proposal-tense framing for an already-built feature plus stale line-number/motivation references.
+
+- **[medium] roadmap-shipped** — The doc is written as a forward-looking proposal (Summary says charts are dropped "silently" today; Goals say "Add a native ChartElement", "New ChartElement", "New packages/slides/src/import/pptx/chart.ts"), but the entire Phase 1 is already implemented and wired up. A reader would think this is an unbuilt plan when it ships in current code.
+  - _Evidence:_ packages/slides/src/model/element.ts:592 (ChartElement, type:'chart', in Element union :619 and ElementInit :631); packages/slides/src/import/pptx/chart.ts exists; packages/slides/src/import/pptx/shape.ts:416 dispatches CHART_URI to parseChartFrame; packages/slides/src/view/canvas/chart-renderer.ts + element-renderer.ts:365 drawChart; packages/slides/src/import/pptx/report.ts:18,26 importedCharts/unsupportedCharts
+- **[low] stale-reference** — The Summary's present-tense motivation ("Today every <p:graphicFrame> is routed unconditionally to the table parser (shape.ts:383 -> parseTable)") is no longer true: dispatch now branches on graphicData URI to parseChartFrame before falling through to parseTable. Cited line numbers have also drifted (Element union claimed at element.ts:560 / ElementInit :571 vs actual 612/624; dispatch claimed at shape.ts:383 vs actual ~414-417).
+  - _Evidence:_ packages/slides/src/import/pptx/shape.ts:414-422 (URI branch to parseChartFrame, tbl->parseTable, else placeholder); packages/slides/src/model/element.ts:612 (Element union) and :624 (ElementInit)
+
+### docs/design/slides/slides-gradient-fill.md
+
+> The doc accurately describes the shipped linear-gradient fill feature across model, importer, renderer, and PPTX export; only the type snippet is slightly simplified.
+
+- **[low] implemented-not-documented** — The doc's GradientFill type is shown as `{ kind: 'gradient'; angle: number; stops: GradientStop[] }`, but the actual type also carries `type: 'linear' | 'radial'` and an optional `center?: { x: number; y: number }` field. These support the radial case the doc frames as deferred; the snippet omits them.
+  - _Evidence:_ packages/slides/src/model/theme.ts:76-82 (GradientFill has type and center fields); doc lines 37-39
+
+### docs/design/slides/slides-multi-select-resize.md
+
+> The doc's technical content matches the shipped code almost exactly, but it is written in forward-looking proposal tense while the entire resize-multi-select + ghost-preview unification has actually shipped.
+
+- **[medium] roadmap-shipped** — The doc frames the multi-select resize feature and the ghost-preview unification as an unbuilt proposal ('This proposal wires...', 'This design retires paintLiveScoped', 'new resizeMultiFrames', Summary states startResize 'bails out for selectedIds.length !== 1'). In reality it is fully shipped: resizeMultiFrames/MultiResizeStart/ElementSnapshot/MultiResizeResult exist with matching signatures, editor.ts has the length>1 branch wired end-to-end (resizeMultiFrames call + batched frames/connectorEndpoints commit), paintGhostPreview exists, and paintMoveGhost/paintLiveScoped/patchElementFrames are deleted. A reader would think none of this is built.
+  - _Evidence:_ packages/slides/src/view/editor/interactions/resize.ts:172-253 (ElementSnapshot, MultiResizeStart, resizeMultiFrames, MultiResizeResult); packages/slides/src/view/editor/editor.ts:6292,6327,6342 (multi-resize wiring); editor.ts:5282 paintGhostPreview; grep for paintMoveGhost/paintLiveScoped/patchElementFrames returns 0 hits
+- **[low] documented-not-implemented** — §4 refers to 'the existing snapAngle helper exported from interactions/rotate.ts'. snapAngle exists but is module-private; only applyRotate and snapToCardinal are exported. This is inside the deferred rotateMultiFrames section.
+  - _Evidence:_ packages/slides/src/view/editor/interactions/rotate.ts:33 (function snapAngle, no export); exports are applyRotate (22) and snapToCardinal (37)
+- **[low] roadmap-shipped** — Design frames rotateMultiFrames extraction as deferred; this is accurate (function absent), but the ghost-rename half of the same §8 rotate bullet ('paintMoveGhost -> paintGhostPreview') has shipped, so the section mixes shipped and deferred items under a 'deferred' heading.
+  - _Evidence:_ grep rotateMultiFrames = 0 hits (deferred, correct); paintGhostPreview present in editor.ts startRotate path at 5984
+
+### docs/design/slides/slides-layout-change.md
+
+> The layout-change feature is fully implemented and matches the doc; the only notable drift is a stale aside claiming presentation mode isn't built (it is), plus several low-severity signature/path staleness items.
+
+- **[medium] roadmap-shipped** — The doc states 'Presentation mode is not yet built (Phase 5b-2). When it lands, it gates its own renderer flag and skips the hint entirely so ghost text never reaches the audience.' Presentation mode IS shipped and wired, so a reader is misled about its existence. Additionally the promised hint-suppression flag does not exist: element-renderer.ts always paints the ghost hint for empty ref-bearing placeholders (no SlideRendererOptions flag gates it), and the presenter renders via the same SlideRenderer, so the described audience-protection is absent.
+  - _Evidence:_ packages/slides/src/view/present/presenter.ts (startPresenter/Presenter), packages/slides/src/view/present/index.ts and packages/slides/src/index.ts:233 export startPresenter, packages/frontend/src/app/slides/slides-presentation-mode.tsx:38 calls startPresenter; no hint flag in packages/slides/src/view/canvas/slide-renderer.ts SlideRendererOptions; hint unconditionally painted at packages/slides/src/view/canvas/element-renderer.ts:297-319
+- **[low] stale-reference** — Doc documents drawText's new parameter as 'placeholderHint?: string', but the implemented parameter is an object 'placeholderHint?: { text: string; style: PlaceholderStyle }'.
+  - _Evidence:_ packages/slides/src/view/canvas/text-renderer.ts:88-94
+- **[low] stale-reference** — Doc gives applyLayoutToSlide signature as '(slide, newLayout): void', omitting the actual optional third parameter 'context?: { master: Master; theme: Theme }' used to seed placeholder typography.
+  - _Evidence:_ packages/slides/src/model/layout.ts:344-348
+- **[low] stale-reference** — Doc's showLayoutPicker is declared to return void, but the implementation returns a close handle '() => void' and LayoutPickerOptions includes an undocumented 'trigger?: HTMLElement | null' field.
+  - _Evidence:_ packages/slides/src/view/editor/layout-picker.ts:14-46
+- **[low] stale-reference** — Doc pins YorkieSlidesStore.applyLayout to yorkie-slides-store.ts:559, but applyLayout is actually near line 1217; the thumbnail-panel:120 addSlide('blank') anchor is likewise a fixed line number likely drifted.
+  - _Evidence:_ packages/frontend/src/app/slides/yorkie-slides-store.ts applyLayout at ~1217; addSlide at ~675
+- **[low] stale-reference** — Doc describes the preview cache key as '${themeId}:${masterId}:${layoutId}:${w}x${h}', but the implemented key additionally includes device-pixel-ratio and a JSON content signature (colors/fonts/background/placeholders/staticElements) suffix.
+  - _Evidence:_ packages/slides/src/view/canvas/layout-preview.ts:27-43 (previewKey)
+
+### docs/design/slides/slides-presentation-mode.md
+
+> The doc accurately describes the shipped presenter (API surface, keyboard/click/cursor/fullscreen behavior, remote-change handling, split-button entry, and the now-shipped transition/animation playback); only two low-severity path/attribution details are stale.
+
+- **[low] stale-reference** — The Code-layout table says slides-view.tsx 'Wires onStartPresentation to local state (presentingFrom) and conditionally mounts <SlidesPresentationMode />'. In reality slides-view.tsx only declares/forwards the onStartPresentation prop (line 65, 676); the presentingFrom state and the <SlidesPresentationMode> mount both live in slides-detail.tsx (presentingFrom at lines 170/528, mount at lines 471/807). The doc attributes slides-detail.tsx only the split-button.
+  - _Evidence:_ packages/frontend/src/app/slides/slides-view.tsx (grep: 0 hits for presentingFrom/SlidesPresentationMode); packages/frontend/src/app/slides/slides-detail.tsx:170,471,528,807
+- **[low] stale-reference** — The Testing section cites 'Vitest + jsdom in packages/slides/src/view/present/presenter.test.ts' and 'The presenter's 50 unit tests'. The test file is actually at packages/slides/test/view/present/presenter.test.ts (not under src/), and it contains ~55 it/test cases, not 50.
+  - _Evidence:_ packages/slides/test/view/present/presenter.test.ts (55 it()/test() matches); no packages/slides/src/view/present/*.test.ts exists
+
+### docs/design/slides/slides-pptx-export.md
+
+> The technical design is fully and faithfully implemented in shipped code; the only drift is that the doc is written as an unbuilt forward-looking proposal (Risks/Mitigation, "New directory", per-module "lands with its own test", target-version 0.5.0) even though the entire feature is shipped.
+
+- **[low] roadmap-shipped** — The doc is framed as an unbuilt design proposal — §1 says "New directory packages/slides/src/export/pptx/", it targets ~2,000-3,000 LOC to be written, and the Risks/Mitigation section discusses single-PR scope and modules that will "land with their own unit test." In fact the entire feature is already shipped: the export/pptx directory exists with all 20 modules the doc enumerates (index, zip, xml, units, color, text, shape, freeform, image, table, connector, group, effects, animation, slide, theme, master, layout, presentation, templates), plus a full test tier (test/export/pptx/round-trip.test.ts and per-module tests). A reader would think this is planned work when it is complete.
+  - _Evidence:_ packages/slides/src/export/pptx/ (all 20 modules present); packages/slides/src/export/pptx/index.ts:130 exports async exportPptx; packages/slides/test/export/pptx/round-trip.test.ts + per-module tests
+
+### docs/design/slides/slides-smart-guides.md
+
+> The smart-guides feature is fully shipped and matches the doc's data model, module layout, type signatures, detection logic, and wiring almost exactly; only a few overlay/implementation details have drifted.
+
+- **[medium] documented-not-implemented** — The overlay section says the numeric distance label is a "white pill with the same red border". The actual label (makeSmartGuideLabel) is a dark pill: background rgba(0,0,0,0.75), white text (#fff), rounded corners, and no border at all.
+  - _Evidence:_ packages/slides/src/view/editor/overlay.ts:1073-1092 (makeSmartGuideLabel: color #fff, background rgba(0,0,0,0.75), borderRadius 3px, no border)
+- **[low] stale-reference** — The Performance table claims smart-guides.ts "uses the same constant from the same source" as snap.ts's SNAP_THRESHOLD so a zoom-aware change applies to both. In reality SNAP_THRESHOLD is a non-exported const in snap.ts and smart-guides.ts defines its own duplicated literal `const THRESHOLD = 8`; they are not a shared source.
+  - _Evidence:_ packages/slides/src/view/editor/snap.ts:4 (const SNAP_THRESHOLD = 8, not exported); packages/slides/src/view/editor/smart-guides.ts:39 (const THRESHOLD = 8)
+- **[low] stale-reference** — The overlay section names a single new function `makeSmartGuide` that builds the DIVs. The implementation instead splits this into makeSmartGuideArrows, makeSmartGuideOutlines, and makeSmartGuideLabel; there is no makeSmartGuide.
+  - _Evidence:_ packages/slides/src/view/editor/overlay.ts:1019 makeSmartGuideArrows, :1158 makeSmartGuideOutlines, :1073 makeSmartGuideLabel
+
+### docs/design/slides/slides-text-autofit.md
+
+> The autofit feature (AutofitMode field, shrink engine, renderer/editor wiring, toggle UI, seeding, PPTX import, Yorkie persistence) is fully shipped and matches the doc; the only drift is one documented export that was never implemented.
+
+- **[low] documented-not-implemented** — The 'Shrink engine' section lists three exports for packages/slides/src/model/autofit.ts including `export function computeAutofitHeight(blocks, measurer, frameW, padding): number` ('Content height for grow callers'). The actual module only exports `scaleBlocks` and `computeAutofitScale`; `computeAutofitHeight` does not exist anywhere in packages/ (grow height instead comes from docs computeLayout's `layout.totalHeight` via onContentHeightChange).
+  - _Evidence:_ packages/slides/src/model/autofit.ts exports only scaleBlocks (line 30) and computeAutofitScale (line 68); grep for computeAutofitHeight across packages/*/src returns nothing
+
+### docs/design/slides/slides-toolbar-redesign.md
+
+> The core redesign (morphing toolbar, shared text-formatting extraction, new SlidesEditor getters, stroke.dash model, Tier-1 controls) shipped as documented, but the implemented ToolbarState went beyond the doc's four-way selectionType and the component map has minor stale references.
+
+- **[medium] implemented-not-documented** — The doc's State enumeration lists selectionType as only 'shape' | 'image' | 'text-element' | 'mixed'. The shipped ToolbarState adds 'connector' and 'table', plus a cellRange field for table cell-range selection, with a dedicated table-controls.tsx and connector routing (ShapeControls). A reader relying on the doc's state model would not know tables/connectors are handled as distinct object states.
+  - _Evidence:_ packages/frontend/src/app/slides/toolbar/state.ts:7 (selectionType union includes 'connector' | 'table'), state.ts:16-22 (cellRange), state.ts:60-70; object-section.tsx imports/routes TableControls and treats connector via showShapeControls; packages/frontend/src/app/slides/toolbar/table-controls.tsx exists (not in doc).
+- **[low] stale-reference** — Doc says 'Derivation lives in slides-toolbar/index.tsx' and shows getToolbarState there; the derivation actually lives in toolbar/state.ts. Also the ToolbarState.textEditor is typed SlidesTextBoxEditor, not the doc's 'EditorAPI'.
+  - _Evidence:_ packages/frontend/src/app/slides/toolbar/state.ts:24-26 (getToolbarState defined here); toolbar/index.tsx imports it from './state'.
+- **[low] stale-reference** — The component-layout sketch lists an object-section/ subfolder with a mixed-controls.tsx, and lists alignment-dropdown.tsx inside components/text-formatting/. In reality the toolbar files are flat (no object-section/ subfolder, no mixed-controls.tsx), and text-formatting/ has no alignment-dropdown.tsx (paragraph alignment lives in text-paragraph-group.tsx).
+  - _Evidence:_ packages/frontend/src/app/slides/toolbar/ is flat (shape-controls.tsx, image-controls.tsx, text-element-controls.tsx, table-controls.tsx, no mixed-controls.tsx); packages/frontend/src/components/text-formatting/ listing has no alignment-dropdown.tsx.
+
+### docs/design/yorkie-auth-webhook.md
+
+> The doc's technical description matches the code precisely, but it is framed as a not-yet-built proposal/rollout while the entire feature (webhook endpoint, token endpoints, token-type guard, rawBody scoping, frontend injectors, shadow/enforce flag) is fully shipped and wired.
+
+- **[medium] roadmap-shipped** — The 'Proposal Details' and 'Rollout' sections frame the work as future ('Ship the endpoint + token endpoint + frontend injector', 'extend it to also cover /internal/yorkie/auth', 'Add it in both mount points'), but the whole feature is already implemented and wired. The auth webhook controller exists and is registered, the two token endpoints exist, verifyYorkieToken/issueYorkieUserToken/issueYorkieShareToken exist, JwtStrategy already requires tokenType==='access', main.ts already scopes rawBody to the /internal/yorkie/ prefix (covering both events and auth), the shadow/enforce gate via YORKIE_AUTH_WEBHOOK_ENFORCE is live, and both YorkieProvider mount points inject the token. A reader would think none of this is built yet.
+  - _Evidence:_ packages/backend/src/document/yorkie-auth.controller.ts (POST internal/yorkie/auth, DetachDocument always-allow, YORKIE_AUTH_WEBHOOK_ENFORCE shadow gate); registered in packages/backend/src/document/document.module.ts:22; packages/backend/src/auth/auth.controller.ts (@Get yorkie-token, @Post yorkie-token/share); packages/backend/src/auth/auth.service.ts (issueYorkieUserToken/issueYorkieShareToken/verifyYorkieToken, YorkieTokenPayload typ 'yorkie'|'yorkie-share'); packages/backend/src/auth/jwt.strategy.ts:30 (tokenType==='access'); packages/backend/src/main.ts:28 (YORKIE_WEBHOOK_PATH_PREFIX='/internal/yorkie/'); packages/frontend/src/PrivateRoute.tsx:27 and packages/frontend/src/app/shared/shared-document.tsx:659,760 (authTokenInjector wired); packages/backend/README.md documents shadow/enforce rollout
+- **[low] stale-reference** — The frontend wiring snippet shows the anonymous-share case as fetchYorkieToken(resolved.token) — an overloaded single function. The shipped code instead exposes two distinct functions: fetchYorkieToken() (GET) and fetchYorkieShareToken(token) (POST /auth/yorkie-token/share), the latter being what shared-document.tsx actually calls.
+  - _Evidence:_ packages/frontend/src/api/auth.ts:171 fetchYorkieToken and :187 fetchYorkieShareToken; packages/frontend/src/app/shared/shared-document.tsx:659,760 use fetchYorkieShareToken(token)
+
+### docs/design/slides/slides.md
+
+> The doc is highly accurate and self-aware; the only notable drift is a "Presence" implementation-status note that has itself gone stale — peer cursors/rings and live drag-frame broadcast have since shipped.
+
+- **[medium] roadmap-shipped** — The Presence "Implementation status" note (lines 379-381) claims presence broadcasts ONLY activeSlideId + selectedElementIds, that textCursor/live drag frames are not broadcast, and that "no peer cursors or selection rings render yet." All three are now false: the shipped SlidesPresence type broadcasts activeFrames (live world-space drag frames) and per-cell text carets, and a full peer-overlay renderer (computePeerOverlays, PeerRing, PeerLabel) is wired via editor.setPeers().
+  - _Evidence:_ packages/frontend/src/types/users.ts:36-71 (SlidesPresence has activeFrames[] + table cell cursors); packages/slides/src/view/editor/peers.ts (PeerRing/PeerLabel/computePeerOverlays); packages/slides/src/view/editor/editor.ts:334 setPeers(); packages/frontend/src/app/slides/slides-view.tsx:1046-1047 editor.setPeers(mapPresenceToPeerView(...)); packages/frontend/src/app/slides/peer-view.ts:30-31 maps selectedElementIds + activeFrames
+- **[low] stale-reference** — Integration points states "slides import is intentionally absent in v1 (PPTX is out of scope...)", but PPTX import shipped (acknowledged in Non-Goals) and the CLI now exposes an `import <file>` subcommand backed by a pptx-import module. The v1-historical framing reads as current absence.
+  - _Evidence:_ packages/cli/src/commands/slides.ts:220 .command('import <file>'); packages/cli/src/slides/pptx-import.ts, packages/cli/src/slides/import.ts exist
+- **[low] stale-reference** — The package-layout diagram names files that do not exist under those names: `view/editor/text-bridge.ts` (actual: text-box-editor.ts) and frontend `editor-shell.tsx` / `contextual-toolbar.tsx` / `thumbnail-panel.tsx` / `presentation-mode.tsx` (actual: toolbar/ dir, slides-presentation-mode.tsx; the thumbnail panel lives in the slides package as view/editor/thumbnail-panel.ts). This is an illustrative v1 sketch, so drift is cosmetic.
+  - _Evidence:_ no packages/slides/**/text-bridge.* (found 0); no editor-shell/contextual-toolbar/thumbnail-panel/presentation-mode.tsx under packages/frontend/src/app/slides; actual: packages/slides/src/view/editor/text-box-editor.ts, packages/frontend/src/app/slides/toolbar/, slides-presentation-mode.tsx
+
+
+## accurate (16)
+
+### docs/design/docs/docs-context-menu.md
+
+> Every load-bearing claim (DocsContextMenu overlay, EditorAPI primitives, clipboard/paste path, table-menu split, native-menu suppression, empty-group bail) matches the shipped code.
+
+_No discrepancies._
+
+### docs/design/docs/docs-ime-composing-underline.md
+
+> The doc's described design is fully implemented as written: the view-local composing marker, injection return shape, run tagging, and paint-time underline all match the code exactly.
+
+_No discrepancies._
+
+### docs/design/docs/docs-header-footer.md
+
+> The header/footer design is fully shipped and matches the doc; every named type, symbol, file, and behavioral nuance was found in code, with one cosmetic method-name drift in an illustrative snippet.
+
+- **[low] stale-reference** — The doc's Active Block Array example defines a method `getActiveBlocks(): Block[]`. The actual implementation is the same logic but the method is named `getContextBlocks()`.
+  - _Evidence:_ packages/docs/src/model/document.ts:97 defines `getContextBlocks()` (lines 97-101); grep for `getActiveBlocks` across packages/docs/src returns no matches.
+
+### docs/design/docs/docs-image-editing.md
+
+> Phase 1 image editing (data model, EditorAPI, selection/resize overlay, toolbar insert + upload/URL/DnD/paste) is faithfully shipped, and the items the doc frames as Planned (context bar, options panel, rotation/crop rendering, crop mode) are genuinely not yet built.
+
+- **[low] documented-not-implemented** — The Editor API code block shows insertImage's opts as { alt?, originalWidth?, originalHeight? }, but the real signature also accepts position?: { blockId; offset }. The doc's note that 'non-collapsed selection replacement is not yet implemented / inserts at focus offset' understates that an explicit insert position is now supported.
+  - _Evidence:_ packages/docs/src/view/editor.ts:283-288 (insertImage signature includes position?)
+- **[low] implemented-not-documented** — The EditorAPI listing enumerates insertImage/updateSelectedImage/getSelectedImage/selectImageAt but omits clearImageSelection() and onImageFileDrop(cb) which are shipped and are the actual mechanism the DnD/paste flows rely on.
+  - _Evidence:_ packages/docs/src/view/editor.ts:296-317; wired via packages/frontend/src/app/docs/docs-view.tsx:432 editor.onImageFileDrop(...)
+- **[low] other** — Insert Flows describes 'DocCanvas listens for dragover/drop ... upload and insert' as if the docs package performs the upload; actually the docs package stays upload-agnostic and forwards the raw File via the onImageFileDrop callback, with the frontend (insertImageFromFile) doing the /images upload.
+  - _Evidence:_ packages/frontend/src/app/docs/image-insert.ts:55 insertImageFromFile; editor.ts:307-317 onImageFileDrop contract
+
+### docs/design/docs/docs-rendering-optimization.md
+
+> All five optimizations described in the doc are shipped and wired up as documented; only minor pseudocode-vs-reality abstraction differences remain.
+
+- **[low] stale-reference** — The doc's pseudocode for cachedMeasureText/computeLayout takes a raw `ctx: CanvasRenderingContext2D` and calls `ctx.measureText(...)`/`ctx.font`. The shipped code instead threads a `TextMeasurer` abstraction (measurer.ts / canvas-measurer.ts): `cachedMeasureText(measurer, text, font)` calls `measurer.measureWidth(...)`, and `computeLayout(blocks, measurer, ...)`. Behavior (font\ttext-keyed cache) is unchanged; only the surface API differs.
+  - _Evidence:_ packages/docs/src/view/layout.ts:63-74 (cachedMeasureText uses measurer.measureWidth), layout.ts:361-369 (computeLayout second param is measurer:TextMeasurer)
+- **[low] implemented-not-documented** — Shipped computeLayout has two extra trailing params not in the doc's signature (composingContext?, docStyles?), and the LayoutCache interface has an undocumented named-style fingerprint field beyond {blocks, contentWidth}. These are additive and consistent with the design's intent.
+  - _Evidence:_ packages/docs/src/view/layout.ts:361-369 (extra params), layout.ts:237-246 (LayoutCache with namedStyles fingerprint field)
+
+### docs/design/documents-last-modified.md
+
+> Every load-bearing claim in the doc (data model, migration backfill, webhook endpoint, HMAC guard, monotonic touchUpdatedAt, clock-skew clamp, read-path, rename bump) matches the shipped backend code exactly.
+
+_No discrepancies._
+
+### docs/design/image-viewer.md
+
+> The image-viewer design doc matches the shipped implementation almost exactly; only two low-severity component-location drifts exist.
+
+- **[low] stale-reference** — The doc attributes assertFileIdAllowed() to packages/backend/src/document/document.controller.ts ('Widen it to allow fileId on pdf or image'). The function is actually defined in a separate module, packages/backend/src/document/document-file-id.util.ts, and imported into the controller. It correctly allows pdf+image (FILE_ID_TYPES = new Set(['pdf','image'])), so behavior matches; only the file location is off.
+  - _Evidence:_ packages/backend/src/document/document-file-id.util.ts (defines assertFileIdAllowed + FILE_ID_TYPES); packages/backend/src/document/document.controller.ts:36 imports it from './document-file-id.util'
+- **[low] stale-reference** — The Viewer section says prev/next navigation lives in FileDetail ('FileDetail fetches the current workspace's documents, filters to type==="image"... Left/right chevron buttons and keyboard ←/→'). In shipped code this logic (sibling filtering by workspaceId+type==='image', prevId/nextId, ChevronLeft/Right, ArrowLeft/ArrowRight keydown) lives inside image-viewer.tsx, not file-detail.tsx. The feature is fully shipped, just in a different component than documented.
+  - _Evidence:_ packages/frontend/src/app/files/image-viewer.tsx:61-108,125-144 (siblings/prevId/nextId/keydown/chevrons); no prev/next code in packages/frontend/src/app/files/file-detail.tsx
+
+### docs/design/sheets/axis-id-selection.md
+
+> The axis-ID selection/presence design is fully implemented and matches the shipped code across sheets and frontend; only a trivial function-signature omission diverges.
+
+- **[low] other** — The 'Coordinate Conversion Layer' table lists rangeAnchorToRange's inputs as (RangeAnchor, rowOrder, colOrder), but the shipped function has an additional optional 4th parameter `dimension?: { rows: number; columns: number }` used to compute the max row/col bounds for null (entire-row/col/select-all) fields.
+  - _Evidence:_ packages/sheets/src/model/workbook/anchor-conversion.ts:42-49 (rangeAnchorToRange signature with `dimension?` param) vs doc table row for rangeAnchorToRange
+
+### docs/design/sheets/bigquery-connector.md
+
+> A forward-looking proposal (v0.5.0) for a BigQuery connector, correctly framed as unbuilt, whose claims about the existing datasource spine it reuses all check out against the code.
+
+_No discrepancies._
+
+### docs/design/share-link-analytics.md
+
+> The doc matches the shipped implementation closely across backend module/routes/schema, docker analytics profile, frontend dashboards, and v2 visualization/dwell fixes; only trivial undocumented helpers exist.
+
+- **[low] implemented-not-documented** — The controller exposes a GET analytics/enabled endpoint used to drive the 'analytics disabled' UI state. The doc describes the disabled/no-op behavior conceptually but never names this endpoint.
+  - _Evidence:_ packages/backend/src/analytics/analytics.controller.ts:148 (@Get('analytics/enabled'))
+- **[low] stale-reference** — Doc frames the beacon 'hook' as living in shared-document.tsx and describes tabchange as not-yet-implemented in the hook. In reality the hook is defined in hooks/use-view-analytics.ts (merely mounted in shared-document.tsx) and already contains full tabchange emission logic gated on a `target` prop; shared-document.tsx just doesn't pass `target`, so observable behavior (no tabchange emitted) still matches the doc.
+  - _Evidence:_ packages/frontend/src/hooks/use-view-analytics.ts:64-76 (tabchange useEffect); packages/frontend/src/app/shared/shared-document.tsx:714 (mounts hook without target)
+
+### docs/design/sheets/lakehouse-connected-sheet.md
+
+> A forward-looking roadmap doc (target 0.5.0, phased Phase 0-4) whose reused-infrastructure claims all match the datasource code and whose lakehouse feature is genuinely unbuilt and correctly framed as future.
+
+_No discrepancies._
+
+### docs/design/sheets/formula.md
+
+> The formula-engine design doc matches the shipped @wafflebase/sheets code on every load-bearing claim (grammar, pipeline, helpers, EvalNode types, resolvers, cross-sheet shifting, unbounded-range expansion); only a cosmetic in-doc table artifact was found.
+
+- **[low] other** — In the 'Built-in Functions' category table the doc says it is 'a category sketch only', yet the last six rows (Text, Lookup, Date, Info, Database, Logical) contain a stray leftover count column (38, 32, 25, 21, 12, 12) wedged between the category name and the examples, while the first four rows (Math, Statistical, Engineering, Financial) do not. This is an internal doc formatting artifact from a prior count-bearing version; it does not correspond to any code claim (counts are explicitly deferred to formula-coverage.md) but renders the table inconsistent for a reader.
+  - _Evidence:_ docs/design/sheets/formula.md lines 215-226 (Built-in Functions table); code side is consistent: packages/sheets/src/formula/function-catalog.ts:3940 exports FunctionCatalog, packages/sheets/src/formula/functions.ts defines FunctionMap
+
+### docs/design/sheets/scroll-and-rendering.md
+
+> The doc accurately describes the shipped scroll-remapping and viewport-Canvas rendering implementation; all named paths, symbols, constants, and the remapping formula match the current code.
+
+_No discrepancies._
+
+### docs/design/sheets/sheet-style.md
+
+> The doc accurately describes the shipped style model, write/merge semantics, range-patch lifecycle, border-seam handling, conditional formatting, number formatting, and UI wiring; all named types, methods, and symbols exist and are wired as described.
+
+_No discrepancies._
+
+### docs/design/slides/slides-font-ooxml-parity.md
+
+> The doc's staged-roadmap framing precisely matches the code: shipped Phase A (super/subscript + hyperlink export) and Phase B.1/B.2/B.4 model+import+export are all present, and every item framed as deferred (caps, gradient/outline/effects, EA/CS faces, toolbar exposure) is genuinely absent.
+
+_No discrepancies._
+
+### docs/design/workspace-folders.md
+
+> The doc accurately describes the shipped implementation; schema, backend folder/document controllers, DTOs, bulk move/delete endpoints, and all named frontend modules exist and are wired up as documented.
+
+_No discrepancies._
+
+

--- a/docs/tasks/active/20260802-design-doc-audit-lessons.md
+++ b/docs/tasks/active/20260802-design-doc-audit-lessons.md
@@ -1,0 +1,53 @@
+# Design Doc Audit — Lessons
+
+## What this task was
+
+Audited all 100 `docs/design/*.md` docs against the shipped codebase (one
+subagent per doc), then fixed the 27 significant-drift docs (one subagent per
+doc) to match reality.
+
+## Key findings about the doc corpus
+
+- **The systemic problem is tense, not accuracy.** 45 of 57 high-severity
+  findings were `roadmap-shipped`: docs written as forward-looking proposals
+  ("This doc adds X", "X is a Non-Goal / deferred / Phase N") for features that
+  shipped and were never flipped to present tense. The *designs* were accurate;
+  the *framing* misled readers into thinking features don't exist.
+- **`slides/*` is the worst-drifted area** — 10 significant-drift docs. The
+  slides package ships fast and its docs lag: native undo, PDF export, image
+  crop, ruler, theme catalog, tables, fonts, background, format-options were all
+  built but documented as unbuilt.
+- **A handful are genuine factual bugs, not just tense** — worth prioritizing
+  because they mislead about security/storage/access:
+  - `sheets/datasource.md` claimed per-user `authorID` access; code enforces
+    workspace-member access (`assertMember`).
+  - `sharing.md` claimed writes are client-side-only; the Yorkie auth webhook
+    enforces viewer/editor roles server-side (403 on viewer write).
+  - `sheets/sheet-image.md` described a Prisma `Image` model + local FS that were
+    never built (it's S3/MinIO, no DB row).
+  - `docs/docs-intent-preserving-edits.md` (minor-drift, not fixed here)
+    describes a native CRDT split/merge the code deliberately abandoned.
+
+## Process lessons
+
+- **Workflow args arrive as a JSON *string*, not a parsed value.** Passing
+  `args: [...]` reached the script as a string and `DOCS.map` threw. Fix:
+  `const DOCS = Array.isArray(args) ? args : JSON.parse(args)`. Do this in every
+  workflow that takes array/object args.
+- **Session limits kill in-flight subagents.** 28 of 100 audit agents failed on
+  a mid-run limit reset. `resumeFromRunId` replayed the 72 cached results for
+  free and only re-ran the 28 — cheap recovery. Always resume rather than re-run.
+- **Verify agent-added specifics before trusting a fix.** The fix agents were
+  told to verify findings against code themselves, and spot-checks (throttler
+  120/min, `datasourceTypeParser`, `hasAccess` return, `units.ts`, 105-entry
+  font catalog, `VALID_IMAGE_ID_PATTERN`) all held — but I still confirmed the
+  4 factual-bug corrections by hand. Cheap insurance on a 27-file batch.
+- **Match the gate to the change.** `verify:fast` is all code; markdown isn't
+  linted. Running it for a docs-only change is pure waste — the pre-push hook
+  (`verify:self`) covers the push anyway.
+
+## Scope note
+
+Fixed the 27 significant-drift docs. The 57 minor-drift docs are mostly cosmetic
+(stale file paths, renamed symbols, shipped-but-future-tense on low-stakes
+items) and were left as an optional follow-up.

--- a/docs/tasks/active/20260802-design-doc-audit-todo.md
+++ b/docs/tasks/active/20260802-design-doc-audit-todo.md
@@ -1,0 +1,43 @@
+# Design Doc Audit — verify docs/design reflects shipped implementation
+
+## Goal
+
+Audit all 100 `docs/design/*.md` documents (excluding README.md index and
+template.md) against the current codebase. For each doc, determine whether the
+"currently shipped" scope it describes matches what is actually implemented,
+and surface drift in either direction.
+
+## Approach
+
+One subagent per doc (Workflow fan-out). Each agent:
+1. Reads the design doc.
+2. Greps/reads the relevant code to check claims.
+3. Returns a structured verdict + discrepancy list.
+
+Then synthesize into a ranked report of docs needing updates.
+
+## Discrepancy types
+
+- `documented-not-implemented` — doc claims shipped, code doesn't have it.
+- `implemented-not-documented` — code has it, doc omits / marks as future.
+- `roadmap-shipped` — a "deferred/planned/Phase N" item has actually shipped.
+- `stale-reference` — wrong file path / renamed symbol / moved module.
+- `other`.
+
+## Status
+
+- [x] Enumerate docs (done — 100 files)
+- [x] Run per-doc audit workflow (100/100 complete)
+- [x] Synthesize ranked report → `20260802-design-doc-audit-findings.md`
+- [x] Present findings to user
+- [x] Fix the 27 significant-drift docs (workflow `wf_08374543-9be`, all edited)
+- [x] Verify the 4 factual-bug corrections + agent-added specifics by hand
+- [ ] Optional follow-up: 57 minor-drift docs (cosmetic stale paths/symbols)
+
+## Result (complete — 100/100)
+
+16 accurate, 57 minor-drift, 27 significant-drift. 37 docs carry ≥1 high-sev
+finding; 45 of 57 high-sev findings are `roadmap-shipped` (proposal-tense docs
+for features that have since shipped). Biggest cluster: `slides/*` (10
+significant-drift — the whole package shipped ahead of its docs).
+Full per-finding evidence in `20260802-design-doc-audit-findings.md`.


### PR DESCRIPTION
## Summary

An audit of all 100 `docs/design/*.md` docs against the codebase (one subagent per doc) found **27 significantly stale**. The dominant issue was **tense, not accuracy**: docs written as forward-looking proposals ("this doc adds X", "X is a Non-Goal / deferred / Phase N") for features that shipped and were never flipped to present tense — so a reader concludes the feature doesn't exist. This PR corrects those 27 docs surgically (structure/voice preserved).

### Worst-drifted area: `slides/*` (10 docs)
Native undo, PDF export, image crop, ruler, theme catalog, tables, fonts, background, and the format-options panel were all built but documented as unbuilt.

### Genuine factual bugs (not just tense), corrected against code
- **`sheets/datasource.md`** — access is workspace-member (`assertMember`), not per-user `authorID`; datasources are workspace-scoped (adds `workspaceId`).
- **`sharing.md`** — writes **are** enforced server-side by the Yorkie auth webhook (`hasAccess()` → 403 for viewer tokens), not client-side only; token resolution is rate limited (`@nestjs/throttler`, 120/min).
- **`sheets/sheet-image.md`** — storage is S3/MinIO with no DB row, not local FS + a Prisma `Image` model (which never existed).

### Also corrected
`design-system-unification` (Sheets FormattingToolbar shipped), `frontend` (7 doc types + board/notes/PDF editors, `Document.id: string`), `pdf` (Phase 2 comments/presence/sharing shipped), `docs-comments`/`sheets/comments` (@mentions shipped), `docs-font-controls`, `docs-local-caret-anchoring`, `docs-docx-import-export`, and the remaining slides docs.

## Method
One `general-purpose` subagent per doc, each re-verifying its findings against code before editing. The 4 factual-bug corrections and all agent-added specifics (`datasourceTypeParser`, `units.ts`, 105-entry `font-catalog.data.ts`, `VALID_IMAGE_ID_PATTERN`, throttler 120/min, `hasAccess` return) were hand-verified.

Audit findings, todo, and lessons are recorded under `docs/tasks/active/`.

## Test plan
- Docs-only change; no code touched.
- `verify:self` (incl. `verify:entropy` doc-staleness + knip) passes via the pre-push hook. A first attempt caught 3 short-form file refs that didn't resolve from repo root — fixed to full `packages/frontend/...` paths.

## Scope
Fixes the 27 **significant-drift** docs. The 57 **minor-drift** docs (cosmetic stale paths/symbols, low-stakes future-tense) are an optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated product documentation to reflect shipped capabilities across Docs, Sheets, Slides, PDFs, sharing, comments, fonts, imports/exports, themes, tables, backgrounds, image tools, and mobile editing.
  * Documented expanded document types, routing, workspace-scoped datasources, read-only access, collaboration behavior, and file handling.
  * Added a comprehensive design-document audit with findings, lessons learned, and follow-up tasks.
  * Clarified current limitations, deferred functionality, public interfaces, and implementation status across the platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->