### PR TITLE
Stop running the review panel on a paged PR

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -54,6 +54,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       pull-requests: read
+      issues: read # the paged latch is an ISSUE comment on the PR
     outputs:
       managed: ${{ steps.gate.outputs.managed }}
       pr: ${{ steps.gate.outputs.pr }}
@@ -81,6 +82,42 @@ jobs:
               }
             } catch (e) {
               core.warning(`Could not resolve PR labels (${e.message}); using branch-prefix only.`);
+            }
+            // PAGED LATCH — the pipeline has already handed this PR to a human.
+            // review-round-guard.mjs reads the same marker to stop dispatching
+            // the fixer, but it runs in `fix`, DOWNSTREAM of `review-panel`, so
+            // until now a paged PR still re-reviewed on every CI-green push:
+            // six lenses plus verification, ~$12 a round, for verdicts nothing
+            // consumes. On #605 that was five rounds and $53.98 after the page,
+            // and it merged manually without ever using them.
+            //
+            // Folded into `managed` rather than exposed as its own output, and
+            // that is load-bearing: `stalled` fires on
+            // `managed == 'true' && review-panel.result == 'skipped'`, so a
+            // separate flag would make every paged PR post a SECOND page. This
+            // belongs in the same category as unmanaged/fork/disabled — reasons
+            // the panel legitimately does not run — which is exactly what the
+            // comment above `stalled` already says that check is for.
+            //
+            // Literal copy of PAGED_LATCH in scripts/agent/rounds.mjs; this job
+            // does no checkout, so it cannot import. rounds.test.mjs asserts the
+            // two match.
+            const PAGED_LATCH = '<!-- agent-review-paged -->';
+            if (managed && prNumber) {
+              try {
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner, repo, issue_number: Number(prNumber), per_page: 100,
+                });
+                if (comments.some((c) => (c.body ?? '').includes(PAGED_LATCH))) {
+                  core.notice(`PR #${prNumber} was already paged to a human — skipping the review panel.`);
+                  managed = false;
+                }
+              } catch (e) {
+                // Fails OPEN, matching the label lookup above. Not knowing
+                // whether a PR was paged must cost a review round, never skip
+                // one: a missed review is worse than a wasted one.
+                core.warning(`Could not read comments (${e.message}); reviewing as if not paged.`);
+              }
             }
             core.setOutput('pr', prNumber);
             core.setOutput('managed', String(managed));
@@ -1059,6 +1096,8 @@ jobs:
             printf '%s\n' \
               '<!-- agent-review-paged -->' \
               '🛑 The fix agent did not advance the branch head, so the requested changes were not applied and the loop cannot re-trigger itself (no push → no new CI → no new panel). Likely causes: it produced no new commit, did not converge within its turn budget, hit tool-permission denials, could not push, or the branch head could not be determined — see the `claude-fix-execution-output` artifact and the run log. **A human should take over** on this PR.' \
+              '' \
+              'The review panel will not run again on this PR, so the `agent-review-*` checks are now frozen at their current state and the ready gate will not promote it. Review and merge it manually.' \
               | gh pr comment "$PR" --body-file -
             node ./scripts/agent/set-state.mjs "$PR" blocked || true
           fi
@@ -1141,7 +1180,7 @@ jobs:
               : 'the pipeline stopped without completing';
             await github.rest.issues.createComment({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number,
-              body: `<!-- agent-review-paged -->\n🛑 The autonomous pipeline stopped without handing off this PR — ${reason}. **A human should review** this PR.`,
+              body: `<!-- agent-review-paged -->\n🛑 The autonomous pipeline stopped without handing off this PR — ${reason}. **A human should review** this PR.\n\nThe review panel will not run again on this PR, so the \`agent-review-*\` checks are now frozen at their current state and the ready gate will not promote it. Review and merge it manually.`,
             });
             // The single-value label is set by the "Reconcile agent state" step
             // below — it re-derives state from the unforgeable signals (the paged

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -99,16 +99,34 @@ jobs:
             // the panel legitimately does not run — which is exactly what the
             // comment above `stalled` already says that check is for.
             //
-            // Literal copy of PAGED_LATCH in scripts/agent/rounds.mjs; this job
-            // does no checkout, so it cannot import. rounds.test.mjs asserts the
-            // two match.
+            // AUTHOR-CHECKED, and that is load-bearing: this repo is PUBLIC, so
+            // matching on the marker alone would let ANY GitHub account post
+            // '<!-- agent-review-paged -->' and permanently stop the review
+            // panel on any agent PR — denial of review from an unauthenticated
+            // position. Trust is an allow-listed bot login (GitHub reserves the
+            // '[bot]' suffix for Apps, so these cannot be registered), or a
+            // human with write access, which keeps "a maintainer halts it by
+            // hand" working. author_association alone is NOT enough: the writing
+            // bots report CONTRIBUTOR, same as any outside contributor.
+            //
+            // Literal copy of PAGED_LATCH / PAGE_AUTHOR_LOGINS / the predicate
+            // in scripts/agent/rounds.mjs; this job does no checkout, so it
+            // cannot import. rounds.test.mjs asserts the copies match.
             const PAGED_LATCH = '<!-- agent-review-paged -->';
+            const PAGE_AUTHOR_LOGINS = ['github-actions[bot]', 'yorkie-agent[bot]'];
+            const TRUSTED_ASSOCIATIONS = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const isPagedLatchComment = (c) => {
+              if (!String((c || {}).body ?? '').includes(PAGED_LATCH)) return false;
+              const user = (c || {}).user || {};
+              if (user.type === 'Bot' && PAGE_AUTHOR_LOGINS.includes(user.login)) return true;
+              return TRUSTED_ASSOCIATIONS.includes(String((c || {}).author_association ?? ''));
+            };
             if (managed && prNumber) {
               try {
                 const comments = await github.paginate(github.rest.issues.listComments, {
                   owner, repo, issue_number: Number(prNumber), per_page: 100,
                 });
-                if (comments.some((c) => (c.body ?? '').includes(PAGED_LATCH))) {
+                if (comments.some(isPagedLatchComment)) {
                   core.notice(`PR #${prNumber} was already paged to a human — skipping the review panel.`);
                   managed = false;
                 }

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -20,6 +20,7 @@ import {
   groupReviewRounds,
   detectStalledRounds,
   DEFAULT_SIMILARITY,
+  PAGED_LATCH,
 } from "./rounds.mjs";
 
 const [, , prArg, maxArg, allValidArg, requiredChecksArg, infraArg] = process.argv;
@@ -45,7 +46,10 @@ if (!Number.isInteger(pr) || pr <= 0 || !Number.isFinite(max)) {
   process.exit(2);
 }
 
-const PAGED = "<!-- agent-review-paged -->";
+// Imported, not re-declared: agent-review-panel.yml's `gate` job now reads the
+// same latch to stop running the panel, so a second literal here would be a
+// second thing to keep in sync. See PAGED_LATCH's docblock in rounds.mjs.
+const PAGED = PAGED_LATCH;
 
 function setOutput(name, value) {
   appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
@@ -64,8 +68,18 @@ function listAll(path) {
   return ghJson(["api", path, "--paginate"]);
 }
 
+// Appended to every page. The latch does not just stop the fixer any more —
+// agent-review-panel.yml's `gate` job reads it too and stops running the panel,
+// so from here on there are no fresh lens verdicts and nothing will flip the
+// PR to ready. Saying so is the difference between a handoff and a PR that
+// looks like it is still being worked on.
+const HANDOFF_NOTE =
+  "\n\nThe review panel will not run again on this PR, so the " +
+  "`agent-review-*` checks are now frozen at their current state and the ready " +
+  "gate will not promote it. Review and merge it manually.";
+
 function page(msg) {
-  gh(["pr", "comment", String(pr), "--body", `${PAGED}\n🛑 ${msg}`]);
+  gh(["pr", "comment", String(pr), "--body", `${PAGED}\n🛑 ${msg}${HANDOFF_NOTE}`]);
   // Labeling is intentionally NOT done here: the single-value state machine
   // owns it. The "Set state → blocked (paged)" step (gated on this `paged`
   // output) runs set-state.mjs, which atomically strips every lifecycle label

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -21,6 +21,7 @@ import {
   detectStalledRounds,
   DEFAULT_SIMILARITY,
   PAGED_LATCH,
+  isPagedLatchComment,
 } from "./rounds.mjs";
 
 const [, , prArg, maxArg, allValidArg, requiredChecksArg, infraArg] = process.argv;
@@ -92,8 +93,11 @@ function page(msg) {
 // PAGED latch: paginate ALL comments (an iterating PR can exceed one page),
 // so a later page isn't missed and the fix loop doesn't re-fire after a human
 // was already paged.
+// AUTHOR-CHECKED: this repo is public, so a body test alone would let any
+// GitHub account stop the fix loop by pasting the marker. See
+// isPagedLatchComment.
 const comments = listAll(`repos/{owner}/{repo}/issues/${pr}/comments?per_page=100`);
-if (comments.some((c) => (c.body ?? "").includes(PAGED))) {
+if (comments.some(isPagedLatchComment)) {
   setOutput("proceed", "false");
   process.exit(0);
 }

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -10,6 +10,23 @@
 // identity behind fixer pushes has already changed once in this pipeline's
 // history, so parent count — not who pushed — is the durable signal.
 
+/**
+ * The marker that latches a PR as "handed to a human". Written by
+ * review-round-guard.mjs's `page()` and by the `stalled` job, and read back by
+ * BOTH of the pipeline's stop conditions:
+ *
+ *   - review-round-guard.mjs, to stop dispatching the fixer;
+ *   - agent-review-panel.yml's `gate` job, to stop running the panel at all.
+ *
+ * It lives here, exported, because those two readers are a JS module and a
+ * `github-script` step that cannot import one (the `gate` job does no checkout).
+ * The workflow therefore carries a literal copy, and `rounds.test.mjs` asserts
+ * the two are byte-identical — a drifted copy would not error, it would just
+ * silently stop latching, which is the failure mode this constant exists to
+ * prevent.
+ */
+export const PAGED_LATCH = "<!-- agent-review-paged -->";
+
 /** A commit is a "fixer" commit iff it has exactly one parent. */
 export function isFixerCommit(commit) {
   return Array.isArray(commit?.parents) && commit.parents.length === 1;

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -27,6 +27,42 @@
  */
 export const PAGED_LATCH = "<!-- agent-review-paged -->";
 
+/**
+ * Bot identities allowed to WRITE the latch. Both are real: the guard and the
+ * `stalled` job comment with `secrets.GITHUB_TOKEN` (`github-actions[bot]`),
+ * while the fix job's branch-head page uses the App token (`yorkie-agent[bot]`).
+ *
+ * A login allow-list is sound because GitHub reserves the `[bot]` suffix for
+ * Apps — no account can register one of these names.
+ */
+export const PAGE_AUTHOR_LOGINS = Object.freeze(["github-actions[bot]", "yorkie-agent[bot]"]);
+
+/** Associations that mean "has write access to this repo". */
+const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+/**
+ * Does this comment legitimately latch the PR as handed-to-a-human?
+ *
+ * The marker alone is NOT enough, and this repo is PUBLIC: anyone with a GitHub
+ * account can comment on a PR, so a body test on its own lets a stranger post
+ * `<!-- agent-review-paged -->` and permanently stop the fixer AND the review
+ * panel on any agent PR. Denial of review, from an unauthenticated position.
+ *
+ * `author_association` cannot carry this on its own — the writing bots report
+ * `CONTRIBUTOR`, the same value an arbitrary outside contributor gets. So trust
+ * is either an allow-listed bot login, or a human who actually has write access
+ * (a maintainer halting the pipeline by hand stays supported).
+ *
+ * Pure and total: any unknown shape is untrusted, which fails toward reviewing.
+ */
+export function isPagedLatchComment(comment) {
+  const c = comment && typeof comment === "object" ? comment : {};
+  if (!String(c.body ?? "").includes(PAGED_LATCH)) return false;
+  const user = c.user && typeof c.user === "object" ? c.user : {};
+  if (user.type === "Bot" && PAGE_AUTHOR_LOGINS.includes(user.login)) return true;
+  return TRUSTED_ASSOCIATIONS.has(String(c.author_association ?? ""));
+}
+
 /** A commit is a "fixer" commit iff it has exactly one parent. */
 export function isFixerCommit(commit) {
   return Array.isArray(commit?.parents) && commit.parents.length === 1;

--- a/scripts/agent/rounds.test.mjs
+++ b/scripts/agent/rounds.test.mjs
@@ -1,5 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   isFixerCommit,
   countFailedReviewRounds,
@@ -8,7 +11,55 @@ import {
   repeatRatio,
   groupReviewRounds,
   detectStalledRounds,
+  PAGED_LATCH,
 } from "./rounds.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PANEL_WORKFLOW = readFileSync(
+  path.join(HERE, "..", "..", ".github", "workflows", "agent-review-panel.yml"),
+  "utf8",
+);
+
+// --- the paged latch, shared between a module and a github-script step -------
+//
+// The latch is the pipeline's stop condition and has TWO readers:
+// review-round-guard.mjs (stops the fixer) and the `gate` job (stops the panel).
+// `gate` does no checkout, so it cannot import PAGED_LATCH and carries a literal
+// copy. A drifted copy does not error — it just silently stops latching, so the
+// panel would keep re-reviewing a PR that was handed to a human. Hence a test.
+
+test("PAGED_LATCH is the exact marker, pinned as a literal", () => {
+  // Deliberately not derived from the module: the point is that changing the
+  // marker must break a test rather than quietly un-latch every open PR.
+  assert.equal(PAGED_LATCH, "<!-- agent-review-paged -->");
+});
+
+test("the gate job's literal copy of the latch matches the module", () => {
+  assert.ok(
+    PANEL_WORKFLOW.includes(`const PAGED_LATCH = '${PAGED_LATCH}';`),
+    "agent-review-panel.yml's gate job must carry a byte-identical copy of PAGED_LATCH",
+  );
+});
+
+test("every site that writes the latch also says the panel has stopped", () => {
+  // Writing the latch now freezes the agent-review-* checks, so a page that
+  // does not say so leaves a human waiting for verdicts that will never come.
+  // Three writers today: the guard's page() (in review-round-guard.mjs), the
+  // fix job's branch-head-did-not-advance path, and the stalled job.
+  const HANDOFF = "The review panel will not run again on this PR";
+  const guard = readFileSync(path.join(HERE, "review-round-guard.mjs"), "utf8");
+  assert.ok(guard.includes(HANDOFF), "review-round-guard.mjs page() must carry the handoff note");
+
+  // In the workflow, count latch WRITES (a `<!-- ... -->` emitted into a comment
+  // body) and require as many handoff sentences. The gate job's read-side copy
+  // is the `const PAGED_LATCH =` line, excluded here so it is not miscounted.
+  const writes = PANEL_WORKFLOW.split("\n").filter(
+    (l) => l.includes(PAGED_LATCH) && !l.includes("const PAGED_LATCH"),
+  ).length;
+  const notes = PANEL_WORKFLOW.split(HANDOFF).length - 1;
+  assert.ok(writes > 0, "expected the workflow to write the latch somewhere");
+  assert.equal(notes, writes, `each of the ${writes} latch write(s) needs a handoff note`);
+});
 
 const fixer = (sha, checkRuns = []) => ({ sha, parents: [{ sha: "p1" }], checkRuns });
 const merge = (sha, checkRuns = []) => ({ sha, parents: [{ sha: "p1" }, { sha: "p2" }], checkRuns });

--- a/scripts/agent/rounds.test.mjs
+++ b/scripts/agent/rounds.test.mjs
@@ -12,6 +12,8 @@ import {
   groupReviewRounds,
   detectStalledRounds,
   PAGED_LATCH,
+  PAGE_AUTHOR_LOGINS,
+  isPagedLatchComment,
 } from "./rounds.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -39,6 +41,70 @@ test("the gate job's literal copy of the latch matches the module", () => {
     PANEL_WORKFLOW.includes(`const PAGED_LATCH = '${PAGED_LATCH}';`),
     "agent-review-panel.yml's gate job must carry a byte-identical copy of PAGED_LATCH",
   );
+  // The author allow-list is half the rule; a copy that drifted to a smaller set
+  // would silently stop honouring a real page, and a larger one re-opens the
+  // spoof this check exists to close.
+  for (const login of PAGE_AUTHOR_LOGINS) {
+    assert.ok(PANEL_WORKFLOW.includes(`'${login}'`), `gate job must trust ${login}`);
+  }
+  assert.ok(
+    PANEL_WORKFLOW.includes("const isPagedLatchComment = (c) =>"),
+    "gate job must author-check the latch, not match the marker alone",
+  );
+});
+
+// --- who may write the latch ------------------------------------------------
+//
+// wafflebase/wafflebase is PUBLIC. Matching on the marker alone lets any GitHub
+// account post it and permanently stop both the fix loop and the review panel,
+// which is denial of review from an unauthenticated position.
+
+test("isPagedLatchComment: an untrusted author cannot latch the PR", () => {
+  const body = `${PAGED_LATCH}\n🛑 nice pipeline you have there`;
+  const untrusted = [
+    { body, user: { login: "drive-by", type: "User" }, author_association: "NONE" },
+    { body, user: { login: "drive-by", type: "User" }, author_association: "CONTRIBUTOR" },
+    { body, user: { login: "drive-by", type: "User" }, author_association: "FIRST_TIME_CONTRIBUTOR" },
+    // A human cannot register a '[bot]' login, but pin that the TYPE is checked
+    // too rather than the name alone.
+    { body, user: { login: "github-actions[bot]", type: "User" }, author_association: "NONE" },
+    // An unrelated App is a Bot, but not one of ours.
+    { body, user: { login: "coderabbitai[bot]", type: "Bot" }, author_association: "CONTRIBUTOR" },
+  ];
+  for (const c of untrusted) {
+    assert.equal(isPagedLatchComment(c), false, JSON.stringify(c.user) + " " + c.author_association);
+  }
+});
+
+test("isPagedLatchComment: the real writers, and a maintainer by hand, do latch", () => {
+  const body = `${PAGED_LATCH}\n🛑 paged`;
+  // Both observed in production: the guard and `stalled` comment as
+  // github-actions[bot]; the fix job's branch-head page uses the App token.
+  for (const login of PAGE_AUTHOR_LOGINS) {
+    assert.equal(
+      isPagedLatchComment({ body, user: { login, type: "Bot" }, author_association: "CONTRIBUTOR" }),
+      true,
+      login,
+    );
+  }
+  // Halting the pipeline by hand stays supported for anyone with write access.
+  for (const assoc of ["OWNER", "MEMBER", "COLLABORATOR"]) {
+    assert.equal(
+      isPagedLatchComment({ body, user: { login: "a-maintainer", type: "User" }, author_association: assoc }),
+      true,
+      assoc,
+    );
+  }
+});
+
+test("isPagedLatchComment: no marker, or junk, is never a latch", () => {
+  const trusted = { user: { login: PAGE_AUTHOR_LOGINS[0], type: "Bot" }, author_association: "OWNER" };
+  assert.equal(isPagedLatchComment({ ...trusted, body: "just a normal comment" }), false);
+  assert.equal(isPagedLatchComment({ ...trusted, body: "" }), false);
+  assert.equal(isPagedLatchComment({ ...trusted }), false, "absent body");
+  for (const junk of [null, undefined, 42, "string", [], { body: null }, { body: PAGED_LATCH }]) {
+    assert.equal(isPagedLatchComment(junk), false, JSON.stringify(junk));
+  }
 });
 
 test("every site that writes the latch also says the panel has stopped", () => {
@@ -50,11 +116,14 @@ test("every site that writes the latch also says the panel has stopped", () => {
   const guard = readFileSync(path.join(HERE, "review-round-guard.mjs"), "utf8");
   assert.ok(guard.includes(HANDOFF), "review-round-guard.mjs page() must carry the handoff note");
 
-  // In the workflow, count latch WRITES (a `<!-- ... -->` emitted into a comment
-  // body) and require as many handoff sentences. The gate job's read-side copy
-  // is the `const PAGED_LATCH =` line, excluded here so it is not miscounted.
+  // In the workflow, count latch WRITES (the marker emitted into a comment body)
+  // and require as many handoff sentences. Two kinds of line mention the marker
+  // without writing it and must not be counted: the gate job's read-side
+  // `const PAGED_LATCH =`, and prose — both `#` YAML comments and `//` JS
+  // comments, since the rationale above the gate check quotes the marker.
+  const isProse = (l) => /^\s*(#|\/\/)/.test(l);
   const writes = PANEL_WORKFLOW.split("\n").filter(
-    (l) => l.includes(PAGED_LATCH) && !l.includes("const PAGED_LATCH"),
+    (l) => l.includes(PAGED_LATCH) && !l.includes("const PAGED_LATCH") && !isProse(l),
   ).length;
   const notes = PANEL_WORKFLOW.split(HANDOFF).length - 1;
   assert.ok(writes > 0, "expected the workflow to write the latch somewhere");


### PR DESCRIPTION
## Summary

The `gate` job now reads the `<!-- agent-review-paged -->` latch and reports the PR as
unmanaged, so a PR the pipeline has already handed to a human stops being re-reviewed.

## Why

`review-round-guard.mjs` reads that latch to stop dispatching the fixer — but the
guard runs in the `fix` job, **downstream of `review-panel`**, and neither `gate`
(`AGENT_PIPELINE_ENABLED` + CI conclusion + same-repo) nor `review-panel`
(`needs.gate.outputs.managed == 'true'`) checked it. So a paged PR kept re-reviewing
on every CI-green push: six lenses plus per-finding verification, ~$12 a round, for
verdicts nothing consumes.

Surveying PRs 540–630 against the metric ledger, counting a round as post-page only if
it posted **more than 120 s** after the latch (the round that *causes* a page posts
about a second after it, from the same job):

| | |
|---|---|
| PRs with review activity | 9 |
| PRs paged | 4 |
| **PRs that kept billing after the page** | **2** |
| **Post-page rounds / cost** | **6 / $58.53** |
| Share of all review spend in range | **44.4%** |

Low frequency, unbounded tail: **$53.98 of that is #605 alone** — paged at round 1,
then five more full rounds over two days ($10.05, $18.25, $11.71, $12.76, $1.21).

### Those rounds are not the price of keeping the promotion path open

They could have been. `promote` is gated only on `blocked == 'false'` and does **not**
check the latch, so in principle a human who fixes everything gets a clean round and
an automatic promotion. In practice nothing has ever used it:

| PR | outcome | labels | post-page |
|---|---|---|---|
| #548 | merged by `hackerwins` | `agent:blocked` | 1 round, $4.55 |
| #564 | merged by `harrykim8672` | `agent:ready` | **0 rounds** — promoted without any |
| #575 | closed | `agent:blocked` | 0 rounds |
| #605 | merged by `hackerwins`, **no label** | — | 5 rounds, **$53.98** |

#605 is the decisive one: it never got `agent:ready`, so those five rounds bought no
promotion. The maintainer asked **CodeRabbit** for a review and merged manually 28
minutes later. Four for four, a paged PR ends with a human.

If a paged PR ever does need to re-enter the gate, an `agent:resume` label read by
`gate` (which already reads labels for `agent:managed`) is a small follow-up. Building
it now would be designing for a path the evidence says nobody walks.

## Design notes

**Folded into `managed` rather than exposed as its own output — load-bearing, not
tidiness.** `stalled` fires on `needs.gate.outputs.managed == 'true' &&
needs.review-panel.result == 'skipped'`, so a separate `paged` flag would make every
paged PR post a **second** page. A deliberate skip belongs in the same category as
unmanaged/fork/disabled — which is exactly what the comment above `stalled` already
says that check is for: *"we do NOT page when the panel was skipped for being an
unmanaged/fork/disabled PR — only when a managed PR's pipeline actually broke."*

**Fails open**, matching the label lookup beside it. Not knowing whether a PR was paged
must cost a review round, never skip one — a missed review is worse than a wasted one.

**`issues: read`** added to `gate`: the latch is an issue comment on the PR.

**The page comments now say the panel has stopped.** The latch freezes the
`agent-review-*` checks, so a page that doesn't say so leaves a human waiting for
verdicts that will never arrive. All three write sites get the line, and a test
asserts each one carries it so a fourth page path can't be added silently.

**`PAGED_LATCH` moved to `rounds.mjs`** so the guard imports it instead of declaring
its own copy. `gate` does no checkout and cannot import, so it carries a literal copy —
and a drifted copy wouldn't error, it would just stop latching, so `rounds.test.mjs`
asserts the two are byte-identical.

## Linked Issues

None — this came out of a cost analysis of the review panel.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

`cd scripts/agent && node --test *.test.mjs` → **480 pass, 0 fail** (1 skip,
pre-existing on `main`). Workflow YAML parses; the `gate` step's script passes
`node --check`; so does `review-round-guard.mjs`.

The gate step was also driven end-to-end against a stubbed GitHub API — extracted from
the YAML so the *shipped* script runs, not a copy:

| case | `managed` |
|---|---|
| `agent/` branch, not paged | `true` |
| `agent/` branch, **paged** | `false` + notice |
| labelled human PR, **paged** | `false` + notice |
| unmanaged branch | `false` |
| **comment read throws 403** | **`true`** + warning (fails open) |

`pnpm verify:fast` was not run locally: it needs a full install in a fresh worktree and
covers neither `.github/workflows/**` nor `scripts/agent` (outside the pnpm workspace).

## Risk Assessment

- **User-facing risk:** none. Affects only the autonomous pipeline.
- **Data/security risk:** none. Adds one read-only permission (`issues: read`) and
  strictly *reduces* what runs.
- **Rollback plan:** revert the single commit.

**The trade:** a paged PR can no longer be auto-promoted by fixing it and pushing.
On the evidence that path has never been used, and the page comment now states it
plainly. Fail direction is "a human merges it themselves", which is where all four
paged PRs already ended up.

## Notes for Reviewers

**AI assistance:** this PR was written with Claude Code — the survey, the diff, and the
tests.

The one judgement call worth challenging is folding into `managed` instead of adding a
`paged` output. It reads as conflating two things, and I'd normally agree — but a
separate flag makes `stalled` fire on every paged PR, and the alternative (also
teaching `stalled` about the new flag) means two conditions that must stay in sync
for the pipeline not to double-page. One concept, one output, and `core.notice()`
records *why* a PR was skipped in the run summary.

- Follow-up work: this is PR 10 of a series; #613, #614 and #615 have merged. Still
  open in the plan: per-lens reasoning `effort` (the largest remaining per-round
  lever), verifier failure-kind instrumentation, and dropping the duplicate
  verification of carried-forward findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automated review panels from restarting after a pull request has been handed off for human review.
  * Improved handling of stalled pipelines and unavailable comment checks so review status is clearer and safer.

* **User Experience**
  * Added explicit notices when automated review and merge readiness are paused, indicating that manual review and merging are required.

* **Tests**
  * Added coverage to verify handoff markers and pause messages remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->