### PR TITLE
Acknowledge @claude fix on the issue when a run starts

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -4,7 +4,9 @@
 # trusted authors), or via manual dispatch for supervised dry-runs. The command
 # is parsed by scripts/agent/command.mjs (the single source of truth for the
 # "@claude <verb>" surface) in a cheap `route` job; only `fix` starts the
-# turn-heavy implement job, and a bare "@claude" gets a help reply. Claude Code
+# turn-heavy implement job, and a bare "@claude" gets a help reply. The implement
+# job posts an immediate "on it" acknowledgment (once its fail-closed gates pass)
+# before the slow work, so the commenter isn't left waiting on the draft PR. Claude Code
 # runs headless in the runner, reads CLAUDE.md/CONTRIBUTING.md (the SessionStart
 # hook also injects the workflow checklist), and follows the existing wafflebase
 # task workflow: plan -> optional design doc -> branch -> implement -> land a
@@ -154,6 +156,29 @@ jobs:
             if (!ok) {
               core.setFailed('main is not protected by a required human review (neither classic protection nor a ruleset requires >=1 approval). Refusing to run.');
             }
+
+      # Acknowledge the kickoff immediately so the commenter knows the run has
+      # started — the draft PR (and its issue comment) can be many minutes away.
+      # Posted AFTER the write-access and branch-protection gates above, so a run
+      # that gets refused never falsely claims to be working. Uses the App token
+      # so the reply comes from Claude, matching the later PR-link comment.
+      # issue_comment only: a workflow_dispatch dry-run has no comment thread.
+      - name: Acknowledge the issue
+        if: github.event_name == 'issue_comment'
+        continue-on-error: true # a failed ack must never block the actual work
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: [
+                "<!-- agent-implement-ack -->",
+                `🤖 On it — I'm working on this issue now. I'll open a draft PR and link it here as soon as the code compiles. [Follow the run](${runUrl}).`,
+              ].join("\n"),
+            });
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Commenting `@claude fix` on an issue kicks off a ~90-minute implement run, but until now the commenter heard **nothing** until the agent posted the draft-PR link at *FINALIZE EARLY* — often many minutes in. This adds an immediate acknowledgment comment so they know the run actually started.

- The ack posts from the `implement` job **as the Claude App** (using the existing App token, matching the later PR-link comment).
- It posts **only after the write-access and branch-protection gates pass**, so a run that gets refused never falsely claims to be working.
- `issue_comment`-only (a `workflow_dispatch` dry-run has no comment thread to reply into) and `continue-on-error: true` so a failed ack can never block the actual work.
- Carries a hidden `<!-- agent-implement-ack -->` marker (consistent with the other agent comments) and links to the workflow run.

Comment body:
> 🤖 On it — I'm working on this issue now. I'll open a draft PR and link it here as soon as the code compiles. [Follow the run](…).

## Test plan

- YAML validated; the new step sits between *Require branch protection on main* and the checkout, so all fail-closed gates run first.
- No new permissions: the job already has `issues: write`.
- Behavior unchanged for `workflow_dispatch` (step is skipped) and for non-`fix` verbs (the `implement` job never runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an immediate acknowledgment comment when an automated task begins.
  * The acknowledgment includes a direct link to the active workflow run for easier progress tracking.

* **Bug Fixes**
  * Improved workflow resilience so acknowledgment issues do not interrupt the main automation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->