### PR TITLE
Set per-lens reasoning effort on review panel sessions

### DIFF
--- a/scripts/agent/ask.mjs
+++ b/scripts/agent/ask.mjs
@@ -84,6 +84,42 @@ export const PERMITTED_TOOLS = Object.freeze(["Read", "Grep", "Glob"]);
 export const PERMITTED_MCP_TOOLS = Object.freeze(["mcp__wafflebase__run"]);
 
 const PERMITTED_SET = new Set(PERMITTED_TOOLS);
+
+/**
+ * Reasoning-effort levels the SDK accepts (`EffortLevel`, sdk.d.ts:539 in the
+ * pinned 0.3.217). Effort controls how much the model thinks AND how many tool
+ * calls it makes to get there, so on this pipeline it is a COST dial: panel
+ * spend tracks agentic turns almost exactly, and turns are what effort moves.
+ *
+ * Frozen and listed literally rather than derived, for the same reason
+ * `PERMITTED_TOOLS` is: if the SDK ever drops a level, a literal list turns that
+ * into a failing test instead of a session that silently runs at the default.
+ */
+export const EFFORT_LEVELS = Object.freeze(["low", "medium", "high", "xhigh", "max"]);
+
+const EFFORT_SET = new Set(EFFORT_LEVELS);
+
+/**
+ * Validate an effort value, returning it unchanged. `undefined` means "unset" and
+ * passes through — the caller then omits the key entirely and takes the SDK
+ * default, exactly as `maxTurns` does.
+ *
+ * Everything else throws, including `null` and a mis-cased or misspelled level.
+ * That strictness is the point: an unrecognised value would otherwise be dropped
+ * and the session would run at the default `high`, which is a silent COST
+ * regression — no error, no changed output, nothing in the logs. The same class
+ * of failure `assertBoundaryMatchesSdk` exists to prevent, one option over.
+ */
+export function assertEffort(effort) {
+  if (effort === undefined) return undefined;
+  if (typeof effort !== "string" || !EFFORT_SET.has(effort)) {
+    throw new Error(
+      `askStructured: \`effort\` must be one of ${EFFORT_LEVELS.join(", ")} ` +
+        `(got: ${JSON.stringify(effort)}). Omit it to take the SDK default.`,
+    );
+  }
+  return effort;
+}
 const PERMITTED_MCP_SET = new Set(PERMITTED_MCP_TOOLS);
 
 /** Is this grant one of the in-process MCP tools rather than a built-in? */
@@ -334,8 +370,11 @@ export async function withRetry(fn, { retries = 2, baseMs = 2000, sleep = defaul
  * `allowedTools` is validated here, which is also what keeps the grant check
  * ahead of the lazy SDK import at the one call site below.
  */
-export function buildSessionOptions({ systemPrompt, model, repo, schema, maxTurns, allowedTools, mcpServers }) {
+export function buildSessionOptions({ systemPrompt, model, repo, schema, maxTurns, allowedTools, mcpServers, effort }) {
   const sessionTools = assertAllowedTools(allowedTools);
+  // Validated here, not at the spread below, so a bad value fails before the
+  // session is opened — same ordering as the tool grant.
+  const sessionEffort = assertEffort(effort);
 
   // `tools` restricts BUILT-IN tools only ("the base set of available built-in
   // tools", sdk.d.ts:1395). MCP tools do not come from there — they come from
@@ -384,6 +423,12 @@ export function buildSessionOptions({ systemPrompt, model, repo, schema, maxTurn
     // default. `maxTurns` exists in the pinned SDK (0.3.217), on the same
     // Options type as allowedTools/outputFormat/permissionMode.
     ...(Number.isFinite(maxTurns) ? { maxTurns } : {}),
+    // Same shape as `maxTurns`: present only when the caller asked for one, so
+    // an unset effort takes the SDK default (`high`) rather than being pinned
+    // here. `effort` is a session option, NOT prompt text — it never reaches
+    // `systemPrompt`, so it cannot fragment the cross-lens cache prefix that
+    // review-panel.mjs's warm-up depends on.
+    ...(sessionEffort === undefined ? {} : { effort: sessionEffort }),
     // `tools` and `allowedTools` are DIFFERENT levers and both are needed.
     // Per the pinned SDK's own docs (sdk.d.ts:1341-1348, :1395-1404):
     //   tools        = "the base set of available built-in tools" — the actual
@@ -440,6 +485,7 @@ export async function askStructured({
   maxTurns,
   allowedTools,
   mcpServers,
+  effort,
   label = "agent",
   // Optional attribution ({ lens, role }) stamped onto this call's logged result
   // message, so a consumer summing `sessionLog` can split cost by lens and by
@@ -452,7 +498,7 @@ export async function askStructured({
   // by observing that an invalid grant throws the validation error even when the
   // SDK cannot be resolved). It also splits any MCP grant from the built-ins and
   // wires `mcpServers`, so the whole session shape stays observable in one place.
-  const options = buildSessionOptions({ systemPrompt, model, repo, schema, maxTurns, allowedTools, mcpServers });
+  const options = buildSessionOptions({ systemPrompt, model, repo, schema, maxTurns, allowedTools, mcpServers, effort });
 
   // NOTE: `MCP_TOOL_TIMEOUT` is deliberately NOT set here. It has to be in place
   // before the SDK is imported, and by this line it already has been — the server

--- a/scripts/agent/ask.test.mjs
+++ b/scripts/agent/ask.test.mjs
@@ -7,7 +7,9 @@ import {
   askStructured,
   assertAllowedTools,
   assertBoundaryMatchesSdk,
+  assertEffort,
   buildSessionOptions,
+  EFFORT_LEVELS,
   PERMITTED_TOOLS,
   SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
   classifyResult,
@@ -153,8 +155,44 @@ test("buildSessionOptions: pins the read-only session shape", () => {
   // Omitted rather than passed as undefined, so the SDK default applies.
   assert.ok(!("maxTurns" in o), "an unset ceiling must not appear at all");
   assert.equal(buildSessionOptions({ schema: {}, maxTurns: 8, allowedTools: ["Read"] }).maxTurns, 8);
+  // Same rule for effort: absent means "take the SDK default", not "high".
+  assert.ok(!("effort" in o), "an unset effort must not appear at all");
+  assert.equal(
+    buildSessionOptions({ schema: {}, effort: "medium", allowedTools: ["Read"] }).effort,
+    "medium",
+  );
   // The gate still runs here — this is the one place it is reached.
   assert.throws(() => buildSessionOptions({ schema: {}, allowedTools: ["Bash"] }), /is not permitted/);
+});
+
+test("EFFORT_LEVELS pins the SDK's levels as a literal", () => {
+  // Deliberately NOT derived from the SDK: this repo's agent test lane runs with
+  // the SDK absent. If a level is ever removed upstream, a literal list turns
+  // that into a failing assertion rather than a session that silently falls back
+  // to the default — the same silent-cost-regression shape assertBoundaryMatchesSdk
+  // exists to catch. Matches `EffortLevel` at sdk.d.ts:539 in the pinned 0.3.217.
+  assert.deepEqual([...EFFORT_LEVELS], ["low", "medium", "high", "xhigh", "max"]);
+});
+
+test("assertEffort: unset passes through, anything unrecognised throws", () => {
+  assert.equal(assertEffort(undefined), undefined);
+  for (const level of EFFORT_LEVELS) assert.equal(assertEffort(level), level);
+  // Strict on purpose. A dropped-and-defaulted value is a COST regression with
+  // no error, no changed output and nothing in the logs, so every ambiguity
+  // fails loudly instead: casing, whitespace, near-misses and wrong types.
+  for (const bad of ["MEDIUM", " medium", "med", "hgih", "", null, 0, 3, true, [], {}]) {
+    assert.throws(() => assertEffort(bad), /effort/, JSON.stringify(bad));
+  }
+});
+
+test("buildSessionOptions: an invalid effort throws before a session is opened", () => {
+  // Ordering matters — the same reason the tool grant is validated first. This
+  // runs with the SDK unresolvable, so reaching the throw proves nothing had to
+  // be imported to get there.
+  assert.throws(
+    () => buildSessionOptions({ schema: {}, effort: "hgih", allowedTools: ["Read"] }),
+    /effort/,
+  );
 });
 
 test("buildSessionOptions: an array systemPrompt reaches the SDK VERBATIM", () => {

--- a/scripts/agent/lenses/lenses.json
+++ b/scripts/agent/lenses/lenses.json
@@ -7,7 +7,8 @@
     "appliesWhen": ["**"],
     "scopeClasses": ["code", "code-adjacent", "policy"],
     "model": "claude-opus-5",
-    "samples": 1
+    "samples": 1,
+    "effort": "medium"
   },
   {
     "id": "security",
@@ -27,7 +28,8 @@
     "appliesWhen": ["packages/**", "scripts/**", "docs/design/**"],
     "scopeClasses": ["code", "code-adjacent", "policy", "design-spec"],
     "model": "claude-opus-5",
-    "samples": 1
+    "samples": 1,
+    "effort": "medium"
   },
   {
     "id": "test-adequacy",
@@ -37,7 +39,8 @@
     "appliesWhen": ["packages/**", "scripts/**"],
     "scopeClasses": ["code", "code-adjacent", "policy"],
     "model": "claude-opus-5",
-    "samples": 1
+    "samples": 1,
+    "effort": "medium"
   },
   {
     "id": "blast-radius",
@@ -47,7 +50,8 @@
     "appliesWhen": ["packages/**", "scripts/**"],
     "scopeClasses": ["code", "code-adjacent", "policy"],
     "model": "claude-opus-5",
-    "samples": 1
+    "samples": 1,
+    "effort": "medium"
   },
   {
     "id": "docs",
@@ -67,6 +71,7 @@
     "scopeClasses": ["prose"],
     "model": "claude-sonnet-5",
     "samples": 1,
+    "effort": "medium",
     "maxTurns": 8
   }
 ]

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -43,7 +43,7 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { classify, renderSummaryMd, BLOCKING, normalizeSeverity, KNOWN } from "./severity.mjs";
-import { askStructured, withRetry, SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "./ask.mjs";
+import { askStructured, withRetry, SYSTEM_PROMPT_DYNAMIC_BOUNDARY, assertEffort } from "./ask.mjs";
 import { renderScopeNote, serializeReviewState } from "./review-state.mjs";
 import { CITATION } from "./citation.mjs";
 import { findingLocation, noveltyOf, baseResolves, DEMOTING_ORIGINS } from "./novelty.mjs";
@@ -1517,6 +1517,13 @@ async function runLens(lens, { rubric, diff, extraDiff, issue, repo, sessionLog,
     // rubric only asks it to check the prose in front of it does not, and an
     // unbounded budget there is spend with nothing to show for it.
     maxTurns: lens.maxTurns,
+    // Optional per-lens reasoning effort, same manifest-driven shape as
+    // `maxTurns` above. Omitted = the SDK default (`high`). This is the panel's
+    // main cost dial: spend tracks agentic turns, and effort is what moves them.
+    // Deliberately NOT set on the verifier (see verifyFinding) — a weaker
+    // verifier refutes less, so more findings survive to the fixer and the round
+    // gets more expensive, not less.
+    effort: lens.effort,
     label: "review",
     logMeta: { lens: lens.id, role: "detection" },
   });
@@ -1826,6 +1833,19 @@ async function main() {
   const fileBlocks = sliceDiffByFile(diff);
 
   const allLenses = loadLenses(lensesDir);
+  // Validate every manifest `effort` BEFORE the first token is spent. Without
+  // this a typo (`"hgih"`) would not surface until that lens opened its session,
+  // partway through a round that has already paid for the lenses ahead of it —
+  // and `assertEffort` throwing there lands in the per-lens catch, which reports
+  // it as a blocking "reviewer did not produce a valid verdict" finding rather
+  // than as the manifest error it is. Failing here is loud, free and honest.
+  for (const lens of allLenses) {
+    try {
+      assertEffort(lens.effort);
+    } catch (err) {
+      throw new Error(`lenses.json: lens "${lens.id}" has an invalid \`effort\` — ${err.message}`);
+    }
+  }
   // panel[] is the AUTHORITATIVE lens list the workflow + mark-ready consume —
   // one entry per manifest lens (applicable or skipped), so the three-way drift
   // between lenses.json / the workflow / mark-ready is removed.

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -49,7 +49,7 @@ import {
   buildVerifierPrompt,
   panelEntry,
 } from "./review-panel.mjs";
-import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY } from "./ask.mjs";
+import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY, EFFORT_LEVELS } from "./ask.mjs";
 import { classify, normalizeSeverity } from "./severity.mjs";
 
 // The lens scoping under test is the REAL manifest, not a copy of it. An
@@ -490,6 +490,39 @@ test("at one sample per lens, the panel still shares ONE warm-up across five len
   assert.equal(key("design-fit"), key("correctness"), "the issue spec must not split design-fit off");
   assert.equal(key("security"), key("correctness"), "extra classes must not split security off");
   assert.notEqual(key("docs"), key("correctness"), "the prose lens still stands alone, correctly");
+});
+
+test("runLens forwards the manifest effort, and the verifier does not", () => {
+  // The one link unit tests cannot reach: runLens opens a session, so the only
+  // way to observe the forward is the source. Asserted on the PROPERTY, per the
+  // convention above — a literal destructuring pin breaks the moment a field is
+  // added beside it. If this forward were dropped, every lens would quietly run
+  // at the SDK default and the manifest would be decorative.
+  const src = readFileSync(path.join(HERE, "review-panel.mjs"), "utf8");
+  assert.match(src, /effort: lens\.effort/, "runLens must pass the manifest effort through");
+
+  // And verifyFinding must NOT. Lowering verifier effort looks like the safe
+  // place to save, and it is backwards: a weaker verifier refutes LESS (it must
+  // still reach refuted + high + a named ground + a real file:line to drop
+  // anything), so more findings survive to the fixer and the round gets more
+  // expensive. Pinned so "set effort everywhere" has to argue with a test.
+  const verify = src.slice(src.indexOf("async function verifyFinding"));
+  const body = verify.slice(0, verify.indexOf("\n}"));
+  assert.ok(!/effort/.test(body), "verifyFinding must not set effort");
+});
+
+test("main() validates every manifest effort before spending a token", () => {
+  // A typo must fail as a manifest error, loudly and for free. Inside the
+  // per-lens loop it would instead land in the fail-closed catch and be reported
+  // as a blocking "reviewer did not produce a valid verdict" finding — after the
+  // lenses ahead of it had already been paid for.
+  const src = readFileSync(path.join(HERE, "review-panel.mjs"), "utf8");
+  const main = src.slice(src.indexOf("async function main()"));
+  const load = main.indexOf("loadLenses(lensesDir)");
+  const firstSession = main.indexOf("sampleWithWarmup");
+  assert.ok(load > 0 && firstSession > load, "expected loadLenses before the first session");
+  assert.match(main.slice(load, firstSession), /assertEffort\(lens\.effort\)/,
+    "the manifest effort check must run between loadLenses and the first session");
 });
 
 test("main() decides cacheability from the session count before opening any session", () => {
@@ -1405,6 +1438,44 @@ test("lens rubrics are coverage-first, with no certainty clamp", () => {
     assert.match(md, /Report EVERY issue you find/, `${id}.md must instruct coverage-first`);
     assert.match(md, /[Nn]ever downgrade\s+severity/, `${id}.md must separate severity from doubt`);
     assert.match(md, /confidence/i, `${id}.md must tell the lens what confidence is for`);
+  }
+});
+
+test("every manifest effort is a level the SDK accepts", () => {
+  // Same manifest-walk construction as the clamp guard above: a new lens is
+  // covered by existing, not by remembering to extend a literal list. A typo
+  // here would otherwise be dropped by the SDK and the lens would silently run
+  // at the default `high` — a cost regression with nothing to see in the logs.
+  for (const lens of LENSES) {
+    if (lens.effort === undefined) continue; // unset is legal: take the SDK default
+    assert.ok(
+      EFFORT_LEVELS.includes(lens.effort),
+      `lens ${lens.id} has effort "${lens.effort}", not one of ${EFFORT_LEVELS.join(", ")}`,
+    );
+  }
+});
+
+test("security keeps the SDK default effort", () => {
+  // Every other lens has a backstop for a missed finding: the verifier re-checks
+  // blocking findings, test-adequacy is re-derivable from a failing suite, docs
+  // is prose. At samples: 1 a security miss has none, so it is the one lens where
+  // buying turns back is not worth the recall edge. Pinned so a later sweep that
+  // sets effort "on all lenses" has to argue with a test.
+  const security = LENSES.find((l) => l.id === "security");
+  assert.ok(security, "manifest lost the security lens");
+  assert.equal(security.effort, undefined);
+});
+
+test("effort cannot reach the shared cache prefix", () => {
+  // The panel's cross-lens warm-up keys on the prefix BYTES, so anything
+  // lens-specific in there collapses every shared group and silently turns
+  // caching off panel-wide. `effort` is a session option and must never become
+  // prompt text. #611 already made this structural by dropping the lens argument
+  // from lensCacheKey; this pins the property one level up, where a future
+  // "include effort in the prompt so the model knows" edit would land.
+  const base = buildLensSystemPrompt(PROMPT_IN);
+  for (const effort of EFFORT_LEVELS) {
+    assert.deepEqual(buildLensSystemPrompt({ ...PROMPT_IN, effort }), base, `effort ${effort} changed the prefix`);
   }
 });
 


### PR DESCRIPTION
## Summary

Adds an optional per-lens `effort` to the manifest and threads it onto the review
session. Set to `medium` on five lenses; `security` and the verifier keep the SDK
default.

## Why

`buildSessionOptions` never set `effort`, so **every review session has been running
at the SDK default `high`**. Effort governs how much the model thinks *and* how many
tool calls it makes getting there — and panel spend tracks agentic turns almost
exactly. The measured baseline is **$11.71 over 409 turns, ~$0.032 a turn**, so turns
are the bill and effort is the untouched dial that moves them.

Both Anthropic's `/code-review` docs and the Opus 5 guidance say the same thing for
this workload specifically: at `low`/`medium` the review reports the findings it is
most confident in, so it cuts cost *and* the minor/nit churn that drives extra rounds.

## What each session now gets

| lens | model | effort |
|---|---|---|
| correctness | opus-5 | `medium` |
| **security** | opus-5 | **(absent → SDK default)** |
| design-fit | opus-5 | `medium` |
| test-adequacy | opus-5 | `medium` |
| blast-radius | opus-5 | `medium` |
| docs | sonnet-5 | `medium` |
| **verifier** | per-lens | **(absent → SDK default)** |

**Why security is excluded.** Every other lens has a backstop for a missed finding —
the verifier re-checks blocking findings, a test-adequacy gap is re-derivable from a
failing suite, docs is prose. At `samples: 1` a security miss has none. It is the one
lens where buying turns back isn't worth the recall edge, and it costs ~1/6 of the
saving to leave it alone.

**Why the verifier is excluded.** Lowering effort there looks like the obvious safe
place to save and is backwards: a weaker verifier refutes *less* — it must still reach
`refuted` + `high` confidence + a named `refutationGround` + a real `file:line` in
`groundedIn` to drop anything — so more findings survive to the fixer and the round
gets *more* expensive. A test pins this so a later "set effort everywhere" sweep has
to argue with it.

## Design notes

**Threaded exactly like `maxTurns`.** Optional manifest field → `loadLenses` →
`runLens` → `askStructured` → conditional spread. An unset lens keeps taking the SDK
default rather than being pinned to `high` here, so the field stays inert until set.

**It cannot fragment the cache.** `effort` is a session option and never becomes
prompt text, so it can't split the cross-lens warm-up prefix. #611 made that
structural by dropping the lens argument from `lensCacheKey`; this pins the property
one level up at `buildLensSystemPrompt`, which is where a future "tell the model its
effort level" edit would land.

**`assertEffort` is strict** — `null`, `"MEDIUM"`, `" medium"`, `"hgih"` and wrong
types all throw rather than being dropped. A dropped value leaves the session at
`high` with no error, no changed output and nothing in the logs: the same
silent-cost-regression shape `assertBoundaryMatchesSdk` exists to catch.

**Validated before a token is spent.** `main()` checks the whole manifest between
`loadLenses` and the first session. Inside the per-lens loop instead, a typo would
land in the fail-closed catch and be reported as a blocking *"reviewer did not produce
a valid verdict"* finding — after the lenses ahead of it had already been paid for.

## Linked Issues

None — this came out of a cost analysis of the review panel.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

`cd scripts/agent && node --test *.test.mjs` → **491 pass, 0 fail** (1 skip,
pre-existing on `main`). SDK checked: pinned `0.3.217`, `effort?: EffortLevel` at
`sdk.d.ts:1637`, levels at `:539` — matching the literal `EFFORT_LEVELS`.

The table above is not hand-written — it's printed by driving the real manifest
through the same `buildSessionOptions` call `runLens` makes.

`pnpm verify:fast` was not run locally: it needs a full install in a fresh worktree
and `scripts/agent` sits outside the pnpm workspace, so it is covered only by the
`agent:tests` lane inside `verify:self`.

## Risk Assessment

- **User-facing risk:** none. Affects only the autonomous review panel.
- **Data/security risk:** none.
- **Rollback plan:** delete the `"effort"` line from any lens in `lenses.json` — one
  field, per lens, same idiom as `samples`. The plumbing is inert without it.

**This is the largest recall risk in the cost series, and the mitigation is the
granularity.** Shallower detection can miss findings. If the ledger shows
`Findings raised` falling while `Rounds` stays flat, revert the affected lens with a
one-line edit rather than the whole change.

## Notes for Reviewers

**AI assistance:** this PR was written with Claude Code — the cost analysis, the diff,
and the tests.

Two things worth a second look:

1. **`medium` is a starting point, not a tuned value.** There is no per-lens effort
   data to fit — nothing has ever run at anything but `high`. `medium` is one step
   down, on five lenses, with the riskiest excluded; the next move should come from
   the ledger, not from another guess.

2. **This PR cannot dogfood itself.** It goes out from a fork, and the panel's `gate`
   job requires `head_repository == github.repository`, so the review panel will not
   run on it — the one change in the series where watching it review itself would have
   been the most direct signal. If you want that, it needs to be re-opened from a
   base-repo branch.

- Follow-up: #613, #614, #615 and #630 have merged. Still open in the plan: verifier
  failure-kind instrumentation, dropping the duplicate verification of carried-forward
  findings, and the CI-coverage note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable AI review effort levels: low, medium, high, xhigh, and max.
  * Review configurations can now select an effort level, while unspecified settings retain the default behavior.
  * Invalid effort values are reported before a review begins.

* **Bug Fixes**
  * Improved validation and error handling for review configuration settings.

* **Tests**
  * Added coverage for supported, omitted, and invalid effort values across review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->