### PR TITLE
Count probes that ran, and require resolvable paths in finding prose

### DIFF
--- a/scripts/agent/charters/contract.md
+++ b/scripts/agent/charters/contract.md
@@ -56,6 +56,13 @@ cannot be cited, and a candidate whose citations do not resolve is dropped.
 exit code and the output. `expected` is what the documentation says should have
 happened. A vague pair cannot be contradicted and therefore cannot be verified.
 
+Write every file reference as a **repo-root-relative path**, in prose as well as in
+`citations` — `packages/cli/src/commands/schema.ts:33`, never `schema.ts:33`. The
+gate only validates the `citations` array, so a bare filename in `expected` or
+`observed` passes review and then lands in a filed issue as something a reader
+cannot open. The first live run produced exactly that: correct paths in
+`citations`, `schema.ts:33` and `status.ts:8` in the prose beside them.
+
 ## In your lane
 
 - Documented exit codes vs what the code actually sets.

--- a/scripts/agent/charters/crash.md
+++ b/scripts/agent/charters/crash.md
@@ -43,6 +43,13 @@ Cite the runs that demonstrate the crash: `probeRefs` is the 0-based indices of
 your own runs this session, and `failingRef` is the one that crashed. You cannot
 cite a run you did not perform.
 
+Write every file reference as a **repo-root-relative path**, in prose as well as in
+`citations` — `packages/cli/src/commands/schema.ts:33`, never `schema.ts:33`. The
+gate only validates the `citations` array, so a bare filename in `expected` or
+`observed` passes review and then lands in a filed issue as something a reader
+cannot open. The first live run produced exactly that: correct paths in
+`citations`, `schema.ts:33` and `status.ts:8` in the prose beside them.
+
 Fruitful things to try, all backend-free:
 
 - Missing required arguments; too many arguments.

--- a/scripts/agent/charters/round-trip.md
+++ b/scripts/agent/charters/round-trip.md
@@ -64,6 +64,13 @@ two sides disagreeing. You cannot cite a run you did not perform.
 `observed` is what you SAW — quote both sides. A vague pair cannot be contradicted
 and therefore cannot be verified.
 
+Write every file reference as a **repo-root-relative path**, in prose as well as in
+`citations` — `packages/cli/src/commands/schema.ts:33`, never `schema.ts:33`. The
+gate only validates the `citations` array, so a bare filename in `expected` or
+`observed` passes review and then lands in a filed issue as something a reader
+cannot open. The first live run produced exactly that: correct paths in
+`citations`, `schema.ts:33` and `status.ts:8` in the prose beside them.
+
 ## In your lane
 
 - Data that changes value across an import/export cycle.

--- a/scripts/agent/charters/state.md
+++ b/scripts/agent/charters/state.md
@@ -62,6 +62,13 @@ wrong state. You cannot cite a run you did not perform.
 actually returned — quote it. A vague pair cannot be contradicted and therefore
 cannot be verified.
 
+Write every file reference as a **repo-root-relative path**, in prose as well as in
+`citations` — `packages/cli/src/commands/schema.ts:33`, never `schema.ts:33`. The
+gate only validates the `citations` array, so a bare filename in `expected` or
+`observed` passes review and then lands in a filed issue as something a reader
+cannot open. The first live run produced exactly that: correct paths in
+`citations`, `schema.ts:33` and `status.ts:8` in the prose beside them.
+
 ## In your lane
 
 - A mutation that reports success without changing anything.

--- a/scripts/agent/hunt-tool.mjs
+++ b/scripts/agent/hunt-tool.mjs
@@ -89,6 +89,19 @@ export function createProbeBudget({ maxProbes = 40, totalTimeoutMs = 600_000, no
       return [...refusals];
     },
     /**
+     * Record a refusal the BUDGET did not make.
+     *
+     * A probe blocked by `assertSafeArgv` is charged (the charge happens first, so
+     * a stream of malformed calls cannot keep an exhausted session alive) but never
+     * runs. Without this, that probe is invisible: it does not appear in the journal
+     * and it is not a budget refusal, so a session that spent half its budget on
+     * denied commands reads exactly like one that probed freely. The first live run
+     * showed 26 charged against 23 journalled with no explanation anywhere.
+     */
+    noteRefusal(kind, detail) {
+      refusals.push({ kind, detail });
+    },
+    /**
      * Reserve one probe. Returns `{ok:false, why}` instead of throwing, and does
      * NOT consume the reservation when it refuses — a refused call must not push
      * the budget further toward exhaustion.
@@ -302,6 +315,7 @@ export function createProbeTool({
             : null,
       });
     } catch (err) {
+      budget.noteRefusal?.("unsafe-argv", err.message);
       return say(
         `Refused: ${err.message}\n\n` +
           "This is a hard limit, not a suggestion. Choose a different command; do not " +
@@ -327,6 +341,7 @@ export function createProbeTool({
     } catch (err) {
       // A fixture path escaping the scratch lands here. Still a readable refusal,
       // not a thrown tool call.
+      budget.noteRefusal?.("unsafe-fixture", err.message);
       return say(`Refused: ${err.message}`, { isError: true });
     }
 

--- a/scripts/agent/hunt-tool.test.mjs
+++ b/scripts/agent/hunt-tool.test.mjs
@@ -439,3 +439,40 @@ test("a shapeless secret straddling the truncation boundary is still redacted", 
     );
   });
 });
+
+test("a safety refusal is recorded, so charged-but-never-run is visible", async () => {
+  // The first live run charged 26 probes and journalled 23, and nothing explained
+  // the gap: a probe blocked by assertSafeArgv is charged (the charge precedes
+  // validation on purpose, so malformed calls cannot keep an exhausted session
+  // alive) but never runs and never appears as a budget refusal. A session that
+  // spent half its budget on denied commands read exactly like one that probed
+  // freely.
+  const budget = createProbeBudget({ maxProbes: 10 });
+  const journal = [];
+  let ran = 0;
+  const call = createProbeTool({
+    charter: { mutating: false },
+    bin: "/x",
+    scratch: "/tmp",
+    budget,
+    journal,
+    runner: (argv) => {
+      ran++;
+      return { argv, exitCode: 0, signal: null, stdout: "", stderr: "", timedOut: false, spawnError: null };
+    },
+  });
+
+  await call({ argv: ["schema"] });
+  await call({ argv: ["api-keys", "revoke", "k1"] }); // hard-denied
+  await call({ argv: ["login"] }); // hard-denied
+  await call({ argv: ["schema"] });
+
+  assert.equal(ran, 2, "only the two safe commands reach the runner");
+  assert.equal(journal.length, 2, "the journal records what RAN");
+  assert.equal(budget.used, 4, "all four were charged — the charge precedes validation");
+  assert.deepEqual(
+    budget.refusals.map((r) => r.kind),
+    ["unsafe-argv", "unsafe-argv"],
+    "and both refusals are recorded, so charged minus journalled is explained",
+  );
+});

--- a/scripts/agent/hunt.mjs
+++ b/scripts/agent/hunt.mjs
@@ -831,7 +831,11 @@ async function cmdRun(args) {
     for (const sample of sampleResults) {
       if (!sample) continue;
       const { out, journal, probeCount, refusals } = sample;
-      stats.probesRun += probeCount;
+      // What RAN, not what was charged. A probe refused on safety is charged (the
+      // charge precedes validation on purpose) but never executes, so counting
+      // charges here overstated activity by exactly the refusals — 26 vs 23 on the
+      // first live run, with the gap explained nowhere.
+      stats.probesRun += journal.length;
       stats.probeRefusals += refusals.length;
 
       // Resolve each candidate's journal REFERENCES into the `probes` shape the


### PR DESCRIPTION
## Summary

Two observability defects that the **first live run of the executing explorer** exposed. Neither changes what the hunter finds; both change whether you can tell what it did.

## `probesRun` counted probes charged, not probes run

The run reported 26 probes in one sample and 30 in the other. The journals held 23 and 28.

A probe blocked by `assertSafeArgv` is *charged* — the charge deliberately precedes validation, so a stream of malformed calls cannot keep an exhausted session alive — but it never executes, and it was not recorded as a budget refusal either. So it vanished: absent from the journal, absent from `probeRefusals`. A session that burned half its budget on denied commands read exactly like one that probed freely.

- `probesRun` now counts journal entries — what actually ran.
- The tool records its own refusals through a new `budget.noteRefusal`, so **charged minus journalled is always accounted for**.

## Findings cited files the reader cannot open

The run produced `schema.ts:33` and `status.ts:8` in finding prose. Neither resolves.

**My first diagnosis was wrong** and the correction is the interesting part. I assumed the report renderer was truncating paths. The raw journal shows the `citations` arrays were clean, full, repo-root-relative paths throughout — the gate validates those against `codeScope`, so they cannot be bare. The bare refs were in the model's **prose** (`expected` / `observed`), which nothing validates.

So this is a rubric fix, not a code fix. All four charters now require repo-root-relative paths in prose as well as in `citations`, with the reason stated: a bare filename passes every gate and then lands in a filed issue as something a reader cannot click.

## Reviewer's guide

- **`budget.noteRefusal` is the load-bearing change.** The charge-before-validate ordering is deliberate and unchanged; this only makes its consequence visible.
- **Nothing about which findings pass the gate changes.** These are counters and prose guidance.

## Linked Issues

Fixes #

No issue — follow-up from the first live run of #600/#602.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [x] `agent:tests` — 485 pass
- [x] The refusal accounting is **mutation-tested**: dropping the `noteRefusal` call fails its test
- [x] Evidence is from a real run, not a hypothetical: `8 proposed → 5 unique → 5 novel → 2 reproduced → 2 corroborated → 2 reported`, $4.93, both findings hand-verified and filed as #634 and #635

## Risk Assessment

- **User-facing risk:** none. Nothing ships; no package imports `scripts/agent/`.
- **Behaviour risk:** none to the gate. `probesRun` will read *lower* than before for the same run — that is the fix, not a regression.
- **Rollback:** revert. Two modules, four rubric files.

## Notes for Reviewers

- **AI assistance:** written with Claude Code (Opus 5).

- **The live run worked, and is worth recording.** The explorer genuinely iterates — it ran `--help`, then `schema`, drilled into individual commands, then tried `status` and `status --format json`, noticed byte-identical output, and reported it. Three candidates were dropped for citing journal indices that did not exist, which is the honesty check doing precisely what it was built for on its first outing.

- **`soloReproduced` was 0**, so on this run cross-sample agreement cost nothing — it dropped only what replay would have dropped anyway. One data point, but it is the measurement #599 exists to produce.

- **Unrelated, and it has now cost me time twice:** `extractFailureSummary` in `scripts/verify-self.mjs` reported a `WARN` line as a failing lane's summary. Its `/\b(FAIL|ERROR|error|…)\b/` alternation matches warnings and the substring `error` inside unrelated words. Worth tightening separately; I left it out to keep this diff on one subject.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - File references in generated prose and citations now consistently use repository-relative paths, making reported issues easier to locate.
  - Activity statistics now count only probes that actually execute, excluding safety-refused attempts.
  - Safety-refused probe attempts are now recorded for clearer session tracking while remaining excluded from execution and activity results.

- **Tests**
  - Added coverage to verify safety refusals are tracked accurately without being executed or journaled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->