### PR TITLE
Stop feeding infra/quota errors into the next review round

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -612,7 +612,18 @@ jobs:
               // output.text so the NEXT round's "Read prior findings" step can
               // re-check them (Part 2). output.summary stays the human-readable body.
               let findingsText = '[]';
-              try {
+              // A lens that hit an API/quota outage (e.g. a 429 session limit)
+              // never actually reviewed — its only "finding" is the synthesised
+              // "Review could not run …" record written to fail closed. That is
+              // NOT a code finding: carrying it forward makes the NEXT round
+              // re-check "the review could not run" as a blocker, and the verifier
+              // (biased to keep) cannot refute it on grounded evidence. So persist
+              // an empty carry-forward for an infra lens; its check still fails via
+              // `conclusion` above, so nothing promotes. `p.infraError` is the same
+              // signal the honest-paging path uses, so the two cannot disagree.
+              if (p && p.infraError) {
+                findingsText = '[]';
+              } else try {
                 const v = JSON.parse(fs.readFileSync(`.agent-review/${lens.id}/verdict.json`, 'utf8'));
                 const norm = (s) => { const x = String(s ?? '').toLowerCase().trim(); return ['critical', 'major', 'minor', 'nit'].includes(x) ? x : 'major'; };
                 const trim = (s, n) => (typeof s === 'string' && s.length > n ? s.slice(0, n) : s);

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -703,6 +703,20 @@ Components:
        was actually fixed, cited). Unresolved priors merge (deduped) into the
        round's findings.
 
+       **Infra errors are excluded from carry-forward.** A lens that hit an
+       API/quota outage (e.g. a 429 session limit) never reviewed; it writes a
+       synthetic `{ infra: true }` "Review could not run …" record only to fail
+       closed. That record is *not* a code finding — carrying it into the next
+       round would make the panel re-check "the review could not run" as a
+       blocker, and the biased-to-keep verifier cannot refute it on grounded
+       evidence (there is no code claim to disprove), so it would persist across
+       every subsequent round. Two guards prevent it: the panel workflow persists
+       an empty `output.text` for any lens whose `panelEntry` carries `infraError`,
+       and `scripts/agent/prior-findings.mjs` drops any carried record flagged
+       `infra` on read (so the guarantee holds on both panel paths regardless of
+       producer). The lens still fails closed via its check `conclusion`; only the
+       bogus re-check input is suppressed.
+
     3. **Out-of-diff review.** The two measures above both re-read the *same
        artifact*, so neither finds a defect the diff does not contain. A Major
        correctness bug shipped through review on exactly that shape: a new

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -712,14 +712,16 @@ Components:
        evidence (there is no code claim to disprove), so it would persist across
        every subsequent round. Two guards prevent it: the panel workflow persists
        an empty `output.text` for any lens whose `panelEntry` carries `infraError`,
-       and `scripts/agent/prior-findings.mjs` drops any carried record flagged
-       `infra` — or matching the stable "Review could not run — Claude API/quota
-       error" message prefix, which also catches records persisted BEFORE the flag
-       existed — on read (so the guarantee holds on both panel paths regardless of
-       producer, and a PR already contaminated by a pre-fix 429 round self-heals on
-       its next round instead of re-surfacing the error forever). The lens still
-       fails closed via its check `conclusion`; only the bogus re-check input is
-       suppressed.
+       and `scripts/agent/prior-findings.mjs` drops any carried record so flagged on
+       read (so the guarantee holds on both panel paths regardless of producer). The
+       discriminator is the script-set `infra: true` flag — authoritative because,
+       unlike a finding's `summary`, a model cannot forge it. A shape-guarded legacy
+       fallback (the stable "Review could not run …" prefix **and** no `file`, which
+       every genuine finding cites) also catches records persisted before the flag
+       existed, so a PR already contaminated by a pre-fix 429 round self-heals on its
+       next round rather than re-surfacing the error forever — without ever letting
+       model text suppress a real blocker. The lens still fails closed via its check
+       `conclusion`; only the bogus re-check input is suppressed.
 
     3. **Out-of-diff review.** The two measures above both re-read the *same
        artifact*, so neither finds a defect the diff does not contain. A Major

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -713,9 +713,13 @@ Components:
        every subsequent round. Two guards prevent it: the panel workflow persists
        an empty `output.text` for any lens whose `panelEntry` carries `infraError`,
        and `scripts/agent/prior-findings.mjs` drops any carried record flagged
-       `infra` on read (so the guarantee holds on both panel paths regardless of
-       producer). The lens still fails closed via its check `conclusion`; only the
-       bogus re-check input is suppressed.
+       `infra` — or matching the stable "Review could not run — Claude API/quota
+       error" message prefix, which also catches records persisted BEFORE the flag
+       existed — on read (so the guarantee holds on both panel paths regardless of
+       producer, and a PR already contaminated by a pre-fix 429 round self-heals on
+       its next round instead of re-surfacing the error forever). The lens still
+       fails closed via its check `conclusion`; only the bogus re-check input is
+       suppressed.
 
     3. **Out-of-diff review.** The two measures above both re-read the *same
        artifact*, so neither finds a defect the diff does not contain. A Major

--- a/scripts/agent/prior-findings.mjs
+++ b/scripts/agent/prior-findings.mjs
@@ -27,6 +27,18 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { latestLensRuns } from "./review-state.mjs";
 import { gh, prCommitsWithCheckRuns, allCheckRuns, withFullOutput, parseArgs } from "./gh-checks.mjs";
 
+// Stable PREFIX of the synthetic record review-panel.mjs writes when a lens hits
+// an API/quota outage (its `summaryText`: "Review could not run — Claude API/quota
+// error…"). Matched below so records persisted BEFORE the `infra: true` flag
+// existed are still dropped. It is script output, not model text, so a real
+// finding cannot begin with it — keep the two in sync if the message ever changes.
+export const INFRA_SENTINEL = "Review could not run — Claude API/quota error";
+
+/** A carried record that is really an infra/quota outage, not a code finding. */
+function isInfraRecord(f) {
+  return !!f && (f.infra === true || (typeof f.summary === "string" && f.summary.startsWith(INFRA_SENTINEL)));
+}
+
 /**
  * Turn `{ lensCheckName -> check run }` into a flat, lens-tagged findings array.
  *
@@ -62,10 +74,13 @@ export function tagPriorFindings(runsByLens) {
       // Drop the synthesised INFRA record a lens writes when it hits an API/quota
       // outage (e.g. a 429 session limit): the reviewer never ran, so "Review
       // could not run …" is not a finding to re-check, and the verifier (biased to
-      // keep) cannot refute it on grounded evidence. The panel workflow already
-      // persists none for an infra lens; this is the read-side backstop so the
-      // guarantee holds regardless of which producer wrote the check output.
-      if (f && f.infra === true) continue;
+      // keep) cannot refute it on grounded evidence. Matches the `infra` flag AND
+      // the stable message prefix, so a record persisted BEFORE the flag existed
+      // (a PR contaminated by a pre-fix 429 round) is dropped too rather than
+      // re-surfacing every round. The panel workflow already persists none for an
+      // infra lens; this is the read-side backstop so the guarantee holds
+      // regardless of which producer wrote the check output.
+      if (isInfraRecord(f)) continue;
       // `lens` last: a finding cannot spoof its own origin by carrying a `lens`
       // key, since these come from a previous round's model output.
       if (f && typeof f === "object" && !Array.isArray(f)) out.push({ ...f, lens });

--- a/scripts/agent/prior-findings.mjs
+++ b/scripts/agent/prior-findings.mjs
@@ -29,14 +29,34 @@ import { gh, prCommitsWithCheckRuns, allCheckRuns, withFullOutput, parseArgs } f
 
 // Stable PREFIX of the synthetic record review-panel.mjs writes when a lens hits
 // an API/quota outage (its `summaryText`: "Review could not run — Claude API/quota
-// error…"). Matched below so records persisted BEFORE the `infra: true` flag
-// existed are still dropped. It is script output, not model text, so a real
-// finding cannot begin with it — keep the two in sync if the message ever changes.
+// error…"). Used ONLY for the legacy fallback below — see isInfraRecord.
 export const INFRA_SENTINEL = "Review could not run — Claude API/quota error";
 
-/** A carried record that is really an infra/quota outage, not a code finding. */
+/**
+ * A carried record that is really an infra/quota outage, not a code finding.
+ *
+ * `infra: true` is the AUTHORITATIVE signal: the producer (review-panel.mjs) sets
+ * it on the synthesised record, so — unlike `summary`, which is model output — a
+ * model or prompt-injected finding cannot forge it. That flag is the shared
+ * producer/consumer discriminator; prefer it for everything written after it
+ * existed.
+ *
+ * The message-prefix branch is a LEGACY fallback only, for records persisted
+ * BEFORE the flag existed (e.g. a PR contaminated by a pre-fix 429 round, like
+ * #632, whose App-owned check runs cannot be rewritten). Because `summary` is
+ * model-controlled, the prefix alone must NOT mark a record infra — otherwise a
+ * real finding that merely quotes this text could be silently dropped, or an
+ * injected finding could suppress itself from re-check. So the fallback also
+ * requires the synthetic record's shape: no `file`. Every genuine finding cites a
+ * `file`; the synthetic record carries only `{ severity, summary }`. A real
+ * blocker beginning with the legacy text therefore stays a blocker. Remove this
+ * branch once no pre-fix-contaminated PRs remain open.
+ */
 function isInfraRecord(f) {
-  return !!f && (f.infra === true || (typeof f.summary === "string" && f.summary.startsWith(INFRA_SENTINEL)));
+  if (!f || typeof f !== "object") return false;
+  if (f.infra === true) return true;
+  const noFile = f.file === undefined || f.file === null || f.file === "";
+  return noFile && typeof f.summary === "string" && f.summary.startsWith(INFRA_SENTINEL);
 }
 
 /**
@@ -74,12 +94,12 @@ export function tagPriorFindings(runsByLens) {
       // Drop the synthesised INFRA record a lens writes when it hits an API/quota
       // outage (e.g. a 429 session limit): the reviewer never ran, so "Review
       // could not run …" is not a finding to re-check, and the verifier (biased to
-      // keep) cannot refute it on grounded evidence. Matches the `infra` flag AND
-      // the stable message prefix, so a record persisted BEFORE the flag existed
-      // (a PR contaminated by a pre-fix 429 round) is dropped too rather than
-      // re-surfacing every round. The panel workflow already persists none for an
-      // infra lens; this is the read-side backstop so the guarantee holds
-      // regardless of which producer wrote the check output.
+      // keep) cannot refute it on grounded evidence. `isInfraRecord` keys on the
+      // script-set `infra` flag (authoritative), with a shape-guarded legacy
+      // prefix fallback for records persisted before the flag existed — never on
+      // model text alone, so a genuine finding is never suppressed. The panel
+      // workflow already persists none for an infra lens; this is the read-side
+      // backstop so the guarantee holds regardless of which producer wrote it.
       if (isInfraRecord(f)) continue;
       // `lens` last: a finding cannot spoof its own origin by carrying a `lens`
       // key, since these come from a previous round's model output.

--- a/scripts/agent/prior-findings.mjs
+++ b/scripts/agent/prior-findings.mjs
@@ -59,6 +59,13 @@ export function tagPriorFindings(runsByLens) {
     }
     if (!Array.isArray(parsed)) continue;
     for (const f of parsed) {
+      // Drop the synthesised INFRA record a lens writes when it hits an API/quota
+      // outage (e.g. a 429 session limit): the reviewer never ran, so "Review
+      // could not run …" is not a finding to re-check, and the verifier (biased to
+      // keep) cannot refute it on grounded evidence. The panel workflow already
+      // persists none for an infra lens; this is the read-side backstop so the
+      // guarantee holds regardless of which producer wrote the check output.
+      if (f && f.infra === true) continue;
       // `lens` last: a finding cannot spoof its own origin by carrying a `lens`
       // key, since these come from a previous round's model output.
       if (f && typeof f === "object" && !Array.isArray(f)) out.push({ ...f, lens });

--- a/scripts/agent/prior-findings.test.mjs
+++ b/scripts/agent/prior-findings.test.mjs
@@ -40,19 +40,22 @@ test("tagPriorFindings: absent output is NOT 'found nothing'; junk never throws"
   );
 });
 
-test("tagPriorFindings: an infra/quota record (infra:true) is never carried forward", () => {
-  // A lens that hit a 429 session limit writes a synthetic { infra: true } record
-  // so it fails closed. That is not a code finding — carrying it into the next
-  // round would make the panel re-check "the review could not run", and the
-  // verifier (biased to keep) cannot refute it. It must be dropped on read.
+test("tagPriorFindings: an infra/quota record is never carried forward", () => {
+  // A lens that hit a 429 session limit writes a synthetic infra record so it
+  // fails closed. That is not a code finding — carrying it into the next round
+  // would make the panel re-check "the review could not run", and the verifier
+  // (biased to keep) cannot refute it. It must be dropped on read — whether it
+  // carries the { infra: true } flag (records written after the fix) OR only the
+  // stable message prefix (records persisted BEFORE the flag existed — a PR
+  // already contaminated by a pre-fix 429 round, which is how #632 got stuck).
   const runs = new Map([
     ["agent-review-correctness", { output: { text: JSON.stringify([
       { severity: "major", summary: "Review could not run — Claude API/quota error (429): You've hit your session limit", infra: true },
       { severity: "major", summary: "real blocker" },
     ]) } }],
-    // A whole lens whose only record is the infra one → carries nothing.
+    // Legacy record: no `infra` flag, matched by the message prefix alone.
     ["agent-review-security", { output: { text: JSON.stringify([
-      { severity: "major", summary: "Review could not run — Claude API/quota error", infra: true },
+      { severity: "major", summary: "Review could not run — Claude API/quota error (429): You've hit your session limit · resets 3:40am (UTC)" },
     ]) } }],
   ]);
   assert.deepEqual(tagPriorFindings(runs), [

--- a/scripts/agent/prior-findings.test.mjs
+++ b/scripts/agent/prior-findings.test.mjs
@@ -40,6 +40,26 @@ test("tagPriorFindings: absent output is NOT 'found nothing'; junk never throws"
   );
 });
 
+test("tagPriorFindings: an infra/quota record (infra:true) is never carried forward", () => {
+  // A lens that hit a 429 session limit writes a synthetic { infra: true } record
+  // so it fails closed. That is not a code finding — carrying it into the next
+  // round would make the panel re-check "the review could not run", and the
+  // verifier (biased to keep) cannot refute it. It must be dropped on read.
+  const runs = new Map([
+    ["agent-review-correctness", { output: { text: JSON.stringify([
+      { severity: "major", summary: "Review could not run — Claude API/quota error (429): You've hit your session limit", infra: true },
+      { severity: "major", summary: "real blocker" },
+    ]) } }],
+    // A whole lens whose only record is the infra one → carries nothing.
+    ["agent-review-security", { output: { text: JSON.stringify([
+      { severity: "major", summary: "Review could not run — Claude API/quota error", infra: true },
+    ]) } }],
+  ]);
+  assert.deepEqual(tagPriorFindings(runs), [
+    { severity: "major", summary: "real blocker", lens: "correctness" },
+  ]);
+});
+
 test("lensCheckNames: manifest ids → check names; junk → []", () => {
   assert.deepEqual(lensCheckNames([{ id: "correctness" }, { id: "blast-radius" }]),
     ["agent-review-correctness", "agent-review-blast-radius"]);

--- a/scripts/agent/prior-findings.test.mjs
+++ b/scripts/agent/prior-findings.test.mjs
@@ -46,20 +46,38 @@ test("tagPriorFindings: an infra/quota record is never carried forward", () => {
   // would make the panel re-check "the review could not run", and the verifier
   // (biased to keep) cannot refute it. It must be dropped on read — whether it
   // carries the { infra: true } flag (records written after the fix) OR only the
-  // stable message prefix (records persisted BEFORE the flag existed — a PR
-  // already contaminated by a pre-fix 429 round, which is how #632 got stuck).
+  // stable message prefix with the synthetic shape (records persisted BEFORE the
+  // flag existed — a PR contaminated by a pre-fix 429 round, which stuck #632).
   const runs = new Map([
+    // Mixed check: the synthetic infra record AND a real finding — the infra one
+    // is dropped, the real finding is preserved (CodeRabbit: real prior findings
+    // followed by an infrastructure failure must survive).
     ["agent-review-correctness", { output: { text: JSON.stringify([
       { severity: "major", summary: "Review could not run — Claude API/quota error (429): You've hit your session limit", infra: true },
-      { severity: "major", summary: "real blocker" },
+      { severity: "major", file: "src/a.ts", summary: "real blocker" },
     ]) } }],
-    // Legacy record: no `infra` flag, matched by the message prefix alone.
+    // Legacy record: no `infra` flag, matched by prefix + synthetic shape (no file).
     ["agent-review-security", { output: { text: JSON.stringify([
       { severity: "major", summary: "Review could not run — Claude API/quota error (429): You've hit your session limit · resets 3:40am (UTC)" },
     ]) } }],
   ]);
   assert.deepEqual(tagPriorFindings(runs), [
-    { severity: "major", summary: "real blocker", lens: "correctness" },
+    { severity: "major", file: "src/a.ts", summary: "real blocker", lens: "correctness" },
+  ]);
+});
+
+test("tagPriorFindings: a REAL finding is not suppressed by mimicking the infra text", () => {
+  // `summary` is model output. A genuine finding whose summary happens to begin
+  // with the infra sentinel (or one an injected diff crafts to look like it) must
+  // stay a blocker: it cites a `file`, which the script-authored synthetic record
+  // never does, and only `infra: true` (script-set) is authoritative on its own.
+  const runs = new Map([
+    ["agent-review-security", { output: { text: JSON.stringify([
+      { severity: "critical", file: "src/auth.ts", summary: "Review could not run — Claude API/quota error is logged with the raw token" },
+    ]) } }],
+  ]);
+  assert.deepEqual(tagPriorFindings(runs), [
+    { severity: "critical", file: "src/auth.ts", summary: "Review could not run — Claude API/quota error is logged with the raw token", lens: "security" },
   ]);
 });
 

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -1962,7 +1962,16 @@ async function main() {
       // be actively misleading. It lands in `confidenceCounts`' `unknown` bucket,
       // which is literally accurate and keeps the raised/confidence rows
       // reconciling.
-      const failFindings = [{ severity: "major", summary: summaryText }];
+      // `infra: true` marks this as a synthesised INFRASTRUCTURE record (an
+      // API/quota outage, e.g. a 429 session limit), not a code finding. It is
+      // written so the lens fails closed, but it must never be carried into the
+      // next round as a "finding" to re-check — the reviewer never ran, so there
+      // is nothing to re-verify, and the verifier (biased to keep) cannot refute
+      // "the review could not run" on grounded evidence. prior-findings.mjs drops
+      // any finding carrying this flag, and the panel workflow persists none for a
+      // lens with `infraError` set. A genuine no-verdict (model ran, produced
+      // nothing) is NOT infra and stays a normal fail-closed blocker.
+      const failFindings = [{ severity: "major", summary: summaryText, ...(infra ? { infra: true } : {}) }];
       writeVerdict(lensOut, lens, failFindings, infra ? "(review did not run — infrastructure/quota error)" : "(no valid verdict — failing closed)", { valid: false });
       panel.push(panelEntry(lens, {
         blocking, applicable: true, conclusion: "failure", valid: false,


### PR DESCRIPTION
## The bug (why #632 kept re-surfacing the 429)

When a review lens hits an **API/quota outage** — the `429 You've hit your session limit · resets 3:40am (UTC)` you saw on #632 — the reviewer never actually runs. To fail closed, the panel synthesises a `major` finding whose text **is the error message** (`review-panel.mjs`, the `catch` around the lens run).

That synthetic record then leaked into the cross-round **carry-forward**:

1. The per-lens check's `output.text` is the channel the next round reads to re-check prior findings. Its filter only kept `critical`/`major`, non-backlog findings — the synthetic error is `major`, so it **passed** and was persisted.
2. Next round, `prior-findings.mjs` carried it in via `--prior-findings`, so the panel re-checked *"the review could not run"* as if it were a real blocker.
3. The **verifier is biased to keep** — it drops only on a high-confidence *grounded* refutation. "The review could not run" is not a code claim it can disprove against the diff/repo, so it can never refute it. The bogus finding survives every round.

So neither layer "caught" it because neither was ever designed to: the panel treats it as infra at the *top level* (it pages honestly and sets `infraError`), but that knowledge wasn't propagated to the carry-forward channel; and the verifier has no concept of a finding that is actually an infrastructure error rather than a code claim.

## The fix (layered)

- **`review-panel.mjs`** — tag the synthetic record `{ infra: true }`: honest metadata that this is an infrastructure error, not a code finding. (A genuine no-verdict — model ran, produced nothing — is *not* infra and stays a normal fail-closed blocker.)
- **`agent-review-panel.yml`** *(primary fix)* — persist an **empty** carry-forward (`output.text = '[]'`) for any lens whose `panelEntry` carries `infraError`. An infra lens now carries **nothing** into the next round. It still fails closed via its check `conclusion`, so nothing promotes.
- **`prior-findings.mjs`** *(backstop)* — drop any carried record flagged `infra` on read, so the guarantee holds on both panel paths (scheduled + on-demand) regardless of which producer wrote the check output.

## Test plan

- New unit test in `prior-findings.test.mjs`: an `{ infra: true }` record is dropped while a real blocker in the same lens is still carried. **493 agent tests pass** (was 492 + 1 new), 0 fail.
- `node --check` on both changed scripts; `agent-review-panel.yml` YAML validated.
- `verify:entropy` (dead-code + doc-staleness + dep-freshness): **0 issues**.
- Design note added to `harness-engineering.md` (cross-round re-check section).

## Note

This is a workflow + script change, so it only affects panels that start **after** merge — it won't retroactively unstick #632 (that still needs a manual clear + re-fire, and its underlying issue is the shared org credential's 5h limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Infrastructure and quota outages are no longer carried forward as code findings in subsequent review rounds.
  * Genuine review findings continue to be preserved and rechecked as expected.
  * Review failures now more clearly distinguish service availability issues from actionable code issues.

* **Tests**
  * Added coverage to verify correct handling of current and legacy infrastructure failure records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->