### PR TITLE
Record why a verifier session failed, and retry the transient ones

### DIFF
--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -253,6 +253,13 @@ export function aggregatePanelStats(entries) {
   // they coerce to 0 — but a non-zero value means those findings were never
   // filtered at all, which is the difference between a review and a raw dump.
   let errored = 0;
+  // WHY those sessions threw, split by `classifyResult`'s kind. Absent from
+  // pre-instrumentation entries, which contribute nothing — so an all-zero
+  // `failures` means "no data yet", and the renderer omits the line rather than
+  // implying zero failures. `errored` above stays the wider count: it also
+  // includes a folded wording whose verdict was never produced, which never
+  // threw and so is deliberately not represented here.
+  const failures = { apiError: 0, limit: 0, noOutput: 0, unknown: 0, total: 0 };
   // Novelty gate. Absent from entries written before it existed, which coerce to
   // 0 — an all-zero row reads as "the gate never fired", the honest reading for
   // both a pre-instrumentation round and a round where it ran inert.
@@ -283,6 +290,9 @@ export function aggregatePanelStats(entries) {
     absenceRefuted += Number(e.verifier && e.verifier.absenceRefuted) || 0;
     unresolved += Number(e.verifier && e.verifier.unresolved) || 0;
     errored += Number(e.verifier && e.verifier.errored) || 0;
+    for (const k of Object.keys(failures)) {
+      failures[k] += Number(e.verifier && e.verifier.failures && e.verifier.failures[k]) || 0;
+    }
     laneBlocking += Number(e.lanes && e.lanes.blocking) || 0;
     laneBacklog += Number(e.lanes && e.lanes.backlog) || 0;
     laneUnknownOrigin += Number(e.lanes && e.lanes.unknownOrigin) || 0;
@@ -291,7 +301,7 @@ export function aggregatePanelStats(entries) {
   }
   return {
     agreementCounts, raised, raisedConfidence, kept,
-    verifier: { sentToVerifier, refuted, refutedHighConfidence, dropped, errored, absenceRaised, absenceRefuted, unresolved },
+    verifier: { sentToVerifier, refuted, refutedHighConfidence, dropped, errored, absenceRaised, absenceRefuted, unresolved, failures },
     lanes: { blocking: laneBlocking, backlog: laneBacklog, unknownOrigin: laneUnknownOrigin },
     clusters: { clustered, collapsed },
   };
@@ -503,6 +513,9 @@ export function renderSummary({ agg, panelAgg, panelStats, panelAttribution, fli
     const rc = panelStats?.raisedConfidence || {};
     const k = panelStats?.kept || {};
     const v = panelStats?.verifier || {};
+  // Absent on every round recorded before this shipped, so `?? {}` is what keeps
+  // those rendering byte-identically rather than gaining an all-zero line.
+  const vf = v.failures || {};
     const l = panelStats?.lanes || {};
     const c = panelStats?.clusters || {};
     const sampledRounds = (ac.identical || 0) + (ac.partial || 0) + (ac.disjoint || 0);
@@ -538,6 +551,20 @@ export function renderSummary({ agg, panelAgg, panelStats, panelAttribution, fli
       // apart, and a large value invalidates every number under it.
       ...(v.errored
         ? [`- ⚠️ Verifier ERRORED on ${v.errored} of ${v.sentToVerifier || 0} — those findings are UNFILTERED, not confirmed`]
+        : []),
+      // WHY they errored, which decides what to do about it: `api-error` is
+      // transient and already retried, `turn-limit` means a ceiling is too low
+      // for the work (the #614 failure — 8 of 18 verifications died at exactly
+      // the presence ceiling and read as an outage), `no-output` means the model
+      // ran and produced nothing usable. Absent on rounds recorded before this
+      // shipped, and omitted when nothing threw, so quiet rounds stay quiet.
+      ...(vf && vf.total
+        ? [`- Verifier failures: ${vf.apiError || 0} api-error, ${vf.limit || 0} turn-limit, `
+           + `${vf.noOutput || 0} no-output${vf.unknown ? `, ${vf.unknown} unknown` : ""}`
+           // The remainder is NOT an error: `resolveClusterVerdict` returns a
+           // folded wording's missing verdict, which lands in `errored` too.
+           // Naming it stops the two numbers looking like a contradiction.
+           + (v.errored > vf.total ? ` (+${v.errored - vf.total} folded wording(s) with no verdict)` : "")]
         : []),
       // `dropped` ≤ `refutedHighConfidence`: a confident refutation only drops
       // the finding when it names a ground and cites what it read. The GAP is

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -558,13 +558,18 @@ export function renderSummary({ agg, panelAgg, panelStats, panelAttribution, fli
       // the presence ceiling and read as an outage), `no-output` means the model
       // ran and produced nothing usable. Absent on rounds recorded before this
       // shipped, and omitted when nothing threw, so quiet rounds stay quiet.
+      // Counted in SESSIONS, while `errored` above counts FINDINGS — say so, and
+      // do not subtract them. One clustered finding can consume several verifier
+      // sessions (the representative, then one per folded wording), so the two
+      // move independently in both directions: three sessions can throw for one
+      // errored finding, and a finding can end with no verdict having thrown
+      // nothing. An earlier draft rendered `errored - total` as a "folded
+      // wording" remainder; that is arithmetic across two different units and it
+      // goes negative on exactly the cluster case above.
       ...(vf && vf.total
-        ? [`- Verifier failures: ${vf.apiError || 0} api-error, ${vf.limit || 0} turn-limit, `
-           + `${vf.noOutput || 0} no-output${vf.unknown ? `, ${vf.unknown} unknown` : ""}`
-           // The remainder is NOT an error: `resolveClusterVerdict` returns a
-           // folded wording's missing verdict, which lands in `errored` too.
-           // Naming it stops the two numbers looking like a contradiction.
-           + (v.errored > vf.total ? ` (+${v.errored - vf.total} folded wording(s) with no verdict)` : "")]
+        ? [`- Verifier failures: ${vf.total} session(s) threw — ${vf.apiError || 0} api-error, `
+           + `${vf.limit || 0} turn-limit, ${vf.noOutput || 0} no-output`
+           + `${vf.unknown ? `, ${vf.unknown} unknown` : ""}`]
         : []),
       // `dropped` ≤ `refutedHighConfidence`: a confident refutation only drops
       // the finding when it names a ground and cites what it read. The GAP is

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -123,6 +123,10 @@ test("aggregatePanelStats: rolls up lens/round entries — agreement, severity-w
   assert.deepEqual(rolled.verifier, {
     sentToVerifier: 3, refuted: 1, refutedHighConfidence: 1, dropped: 1, errored: 0,
     absenceRaised: 0, absenceRefuted: 0, unresolved: 0,
+    // Same append-only story once more: neither entry carries `failures`, so it
+    // rolls up all-zero rather than NaN. An all-zero total is what makes the
+    // renderer omit the line — "no data yet", not "nothing failed".
+    failures: { apiError: 0, limit: 0, noOutput: 0, unknown: 0, total: 0 },
   });
   // Same append-only story for confidence: the first entry predates the field
   // entirely, so it contributes nothing — NOT four `unknown`s. Rounds recorded
@@ -134,7 +138,15 @@ test("aggregatePanelStats: rolls up lens/round entries — agreement, severity-w
   assert.deepEqual(aggregatePanelStats([]).verifier, {
     sentToVerifier: 0, refuted: 0, refutedHighConfidence: 0, dropped: 0, errored: 0,
     absenceRaised: 0, absenceRefuted: 0, unresolved: 0,
+    failures: { apiError: 0, limit: 0, noOutput: 0, unknown: 0, total: 0 },
   });
+  // Junk in the nested field coerces per-key rather than poisoning the tally —
+  // it is read from an append-only ledger, so a malformed entry must cost its
+  // own counts and nothing else.
+  assert.deepEqual(aggregatePanelStats([{ verifier: { failures: "junk" } }]).verifier.failures,
+    { apiError: 0, limit: 0, noOutput: 0, unknown: 0, total: 0 });
+  assert.deepEqual(aggregatePanelStats([{ verifier: { failures: { limit: 2, total: 2 } } }]).verifier.failures,
+    { apiError: 0, limit: 2, noOutput: 0, unknown: 0, total: 2 });
   assert.deepEqual(aggregatePanelStats([]).raisedConfidence, { high: 0, medium: 0, low: 0, unknown: 0 });
   assert.deepEqual(aggregatePanelStats([{ raisedConfidence: "junk" }]).raisedConfidence, { high: 0, medium: 0, low: 0, unknown: 0 });
   assert.deepEqual(aggregatePanelStats(null).agreementCounts, { identical: 0, partial: 0, disjoint: 0, single: 0 });
@@ -460,4 +472,59 @@ test("sweep filter: METRIC_PREFIX matches a record but NOT the summary marker", 
   });
   assert.ok(summary.includes(SUMMARY_MARKER));
   assert.ok(!summary.includes(METRIC_PREFIX));
+});
+
+test("renderSummary: verifier failures are broken down, and stay silent with no data", () => {
+  // The pre-#614 shape, which is what motivated this line: eight sessions dead
+  // on the presence turn ceiling, reported in the same words a quota outage
+  // would have used. `turn-limit` is what tells those apart.
+  const base = {
+    agg: { agents: [], sessions: 0, attempt: 1, turns: 0, tokens: 0, weightedTokens: 0, costUsd: 0, durationMs: 0 },
+    panelAgg: { agents: ["claude-opus-5"], sessions: 1, turns: 409, tokens: 1, weightedTokens: 1, costUsd: 11.71, durationMs: 60000 },
+  };
+  const stats = (verifier) => ({
+    agreementCounts: { identical: 0, partial: 0, disjoint: 0, single: 1 },
+    raised: { critical: 0, major: 2, minor: 0, nit: 0 },
+    raisedConfidence: { high: 2, medium: 0, low: 0, unknown: 0 },
+    kept: { critical: 0, major: 2, minor: 0, nit: 0 },
+    verifier,
+  });
+
+  const withFailures = renderSummary({
+    ...base,
+    panelStats: stats({
+      sentToVerifier: 18, refuted: 0, refutedHighConfidence: 0, dropped: 0, errored: 8,
+      absenceRaised: 0, absenceRefuted: 0, unresolved: 0,
+      failures: { apiError: 1, limit: 6, noOutput: 1, unknown: 0, total: 8 },
+    }),
+  });
+  assert.match(withFailures, /Verifier ERRORED on 8 of 18/);
+  assert.match(withFailures, /- Verifier failures: 1 api-error, 6 turn-limit, 1 no-output/);
+  // Every session threw, so there is no fold remainder to explain.
+  assert.doesNotMatch(withFailures, /folded wording/);
+
+  // `errored` counts blocking findings with no usable verdict, which also
+  // catches a folded wording whose verdict never arrived. Naming the remainder
+  // stops 3-vs-1 reading as a contradiction.
+  const withFolds = renderSummary({
+    ...base,
+    panelStats: stats({
+      sentToVerifier: 5, refuted: 0, refutedHighConfidence: 0, dropped: 0, errored: 3,
+      absenceRaised: 0, absenceRefuted: 0, unresolved: 0,
+      failures: { apiError: 1, limit: 0, noOutput: 0, unknown: 0, total: 1 },
+    }),
+  });
+  assert.match(withFolds, /- Verifier failures: 1 api-error, 0 turn-limit, 0 no-output \(\+2 folded wording\(s\) with no verdict\)/);
+
+  // A round recorded before this shipped carries no `failures` at all, and a
+  // healthy round has nothing to report. Both must render byte-identically to
+  // the same round without the field — an all-zero line would read as data.
+  const clean = { sentToVerifier: 4, refuted: 1, refutedHighConfidence: 1, dropped: 1, errored: 0, absenceRaised: 0, absenceRefuted: 0, unresolved: 0 };
+  const noField = renderSummary({ ...base, panelStats: stats({ ...clean }) });
+  const zeroField = renderSummary({
+    ...base,
+    panelStats: stats({ ...clean, failures: { apiError: 0, limit: 0, noOutput: 0, unknown: 0, total: 0 } }),
+  });
+  assert.doesNotMatch(noField, /Verifier failures/);
+  assert.equal(zeroField, noField, "an all-zero failures tally must not add a line");
 });

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -499,14 +499,30 @@ test("renderSummary: verifier failures are broken down, and stay silent with no 
     }),
   });
   assert.match(withFailures, /Verifier ERRORED on 8 of 18/);
-  assert.match(withFailures, /- Verifier failures: 1 api-error, 6 turn-limit, 1 no-output/);
-  // Every session threw, so there is no fold remainder to explain.
+  // Units are stated, because `errored` above counts findings and this counts
+  // sessions — nothing here may be derived from the difference.
+  assert.match(withFailures, /- Verifier failures: 8 session\(s\) threw — 1 api-error, 6 turn-limit, 1 no-output/);
   assert.doesNotMatch(withFailures, /folded wording/);
 
-  // `errored` counts blocking findings with no usable verdict, which also
-  // catches a folded wording whose verdict never arrived. Naming the remainder
-  // stops 3-vs-1 reading as a contradiction.
-  const withFolds = renderSummary({
+  // MORE sessions than errored findings: one clustered finding whose two folded
+  // wordings both threw. An earlier draft rendered `errored - total` here, which
+  // is -1. The line must render cleanly, with no remainder and no negative.
+  const clustered = renderSummary({
+    ...base,
+    panelStats: stats({
+      sentToVerifier: 5, refuted: 0, refutedHighConfidence: 0, dropped: 0, errored: 1,
+      absenceRaised: 0, absenceRefuted: 0, unresolved: 0,
+      failures: { apiError: 0, limit: 2, noOutput: 0, unknown: 0, total: 2 },
+    }),
+  });
+  assert.match(clustered, /- Verifier failures: 2 session\(s\) threw — 0 api-error, 2 turn-limit, 0 no-output/);
+  assert.doesNotMatch(clustered, /folded wording/);
+  // Scoped to the failures line: a repo-wide /-\d/ would match "claude-opus-5".
+  const failuresLine = clustered.split("\n").find((l) => l.startsWith("- Verifier failures:"));
+  assert.doesNotMatch(failuresLine, /-\s*\d|\(\+/, `no negative or remainder in: ${failuresLine}`);
+
+  // FEWER sessions than errored findings — the other direction, also fine.
+  const fewer = renderSummary({
     ...base,
     panelStats: stats({
       sentToVerifier: 5, refuted: 0, refutedHighConfidence: 0, dropped: 0, errored: 3,
@@ -514,7 +530,8 @@ test("renderSummary: verifier failures are broken down, and stay silent with no 
       failures: { apiError: 1, limit: 0, noOutput: 0, unknown: 0, total: 1 },
     }),
   });
-  assert.match(withFolds, /- Verifier failures: 1 api-error, 0 turn-limit, 0 no-output \(\+2 folded wording\(s\) with no verdict\)/);
+  assert.match(fewer, /- Verifier failures: 1 session\(s\) threw — 1 api-error, 0 turn-limit, 0 no-output/);
+  assert.doesNotMatch(fewer, /folded wording/);
 
   // A round recorded before this shipped carries no `failures` at all, and a
   // healthy round has nothing to report. Both must render byte-identically to

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -1722,9 +1722,68 @@ export function buildVerifierPrompt(finding, { rubric }) {
   return prompt;
 }
 
+/**
+ * Why a verification produced no verdict. `classifyResult` already computes this
+ * (`ask.mjs`), and both call sites used to throw it away with `.catch(() => null)`,
+ * so every distinct cause arrived as the same anonymous `errored++`.
+ *
+ * That mattered: on the round that motivated #614, 8 of 18 verifications died —
+ * every one of them an `error_max_turns` at exactly the presence ceiling — and the
+ * summary reported it in the same words it would have used for a quota outage. The
+ * ceiling is fixed; this is how anyone can see whether it stayed fixed, and whether
+ * what remains is transient (worth retrying) or structural (worth a code change).
+ *
+ * Mutates and returns `failures` so a caller can thread one array through a
+ * `.catch`. Total: an unrecognised error still records, as `unknown`.
+ */
+export function recordVerifierFailure(failures, err) {
+  const list = Array.isArray(failures) ? failures : [];
+  const kind = err && typeof err.kind === "string" ? err.kind : "unknown";
+  const status = err && (typeof err.status === "number" || typeof err.status === "string") ? err.status : null;
+  list.push({ kind, status });
+  return list;
+}
+
+/** Known `classifyResult` kinds, plus the bucket for anything it did not set. */
+const VERIFIER_FAILURE_KINDS = Object.freeze({ "api-error": "apiError", limit: "limit", "no-output": "noOutput" });
+
+/**
+ * Tally `recordVerifierFailure` records into the shape `lensStats` reports.
+ *
+ * Deliberately separate from `verifierTally`'s `errored`, and BOTH are kept. Their
+ * DIFFERENCE is the measurement: `errored` counts blocking findings that ended with
+ * no usable verdict, which includes `resolveClusterVerdict` handing back a folded
+ * wording's missing verdict — not an error at all. `errored - failures.total` is
+ * therefore the fold-null count, and collapsing the two would hide it. Same
+ * report-both idiom this file already uses for `refutedHighConfidence` vs `dropped`.
+ */
+export function verifierFailureCounts(failures) {
+  const out = { apiError: 0, limit: 0, noOutput: 0, unknown: 0, total: 0 };
+  for (const f of Array.isArray(failures) ? failures : []) {
+    if (!f || typeof f !== "object") continue;
+    // Allowlist membership, not `in`: `kind: "constructor"` would otherwise walk
+    // the prototype chain and leave a NaN own key. Same untrusted-string hazard
+    // `confidenceCounts` documents.
+    const key = Object.hasOwn(VERIFIER_FAILURE_KINDS, f.kind) ? VERIFIER_FAILURE_KINDS[f.kind] : "unknown";
+    out[key]++;
+    out.total++;
+  }
+  return out;
+}
+
 async function verifyFinding(finding, { rubric, repo, model, sessionLog, lensId }) {
   const claimType = claimTypeOf(finding);
-  return askStructured({
+  // Retried, unlike before — detection samples have always had this (see the
+  // round loop) and the verifier never did, so a single transient 429 killed a
+  // verification outright and the finding rode to the gate unfiltered. Wrapped
+  // HERE rather than at the call sites so all three paths (fresh, folded
+  // wording, carried-forward prior) get it from one edit.
+  //
+  // Cannot burn budget on a ceiling: `withRetry` only retries
+  // `err.retryable === true`, and `classifyResult` marks every `limit` subtype
+  // and any session/usage limit non-retryable. Which is also why this is NOT
+  // what fixed the failures measured before #614 — those were all `limit`.
+  return withRetry(() => askStructured({
     systemPrompt:
       "You are an independent verifier. You did not write this code and did not raise this " +
       "finding. Establish the facts from the repository yourself rather than trusting the " +
@@ -1748,7 +1807,7 @@ async function verifyFinding(finding, { rubric, repo, model, sessionLog, lensId 
     allowedTools: REVIEW_TOOLS,
     label: "review",
     logMeta: { lens: lensId, role: "verifier" },
-  });
+  }));
 }
 
 // --- io ----------------------------------------------------------------------
@@ -2016,10 +2075,17 @@ async function main() {
 
     // Verifier refute pass over blocking findings (rubric passed so it judges by
     // the lens's own definitions; keeps the finding on any uncertainty).
+    // Why a verification failed, for THIS lens this round. A flat array, not
+    // index-aligned to the findings: only counts are reported, and a flat push
+    // has no alignment invariant to break as the nested fold path below fans
+    // out. Merged with the prior-round pass into one `failures` tally.
+    const failures = [];
     const verifyBlocking = (f) => {
       if (!BLOCKING.has(normalizeSeverity(f.severity))) return Promise.resolve(null);
       return verifyFinding(f, { rubric: lens.rubric, repo, model: lens.model, sessionLog, lensId: lens.id })
-        .catch(() => null); // error → keep the finding (fail toward blocking)
+        // Error → keep the finding (fail toward blocking), unchanged. What is new
+        // is that the reason survives instead of being swallowed by `() => null`.
+        .catch((err) => { recordVerifierFailure(failures, err); return null; });
     };
     const verdicts = await Promise.all(detected.map(async (f) => {
       const repVerdict = await verifyBlocking(f);
@@ -2053,7 +2119,9 @@ async function main() {
     const priorVerdicts = await Promise.all(priorForLens.map(async (f) => {
       if (!BLOCKING.has(normalizeSeverity(f.severity))) return null;
       try { return await verifyFinding(f, { rubric: lens.rubric, repo, model: lens.model, sessionLog, lensId: lens.id }); }
-      catch { return null; } // error → keep (fail toward blocking)
+      // Error → keep (fail toward blocking), unchanged; the reason is recorded
+      // into the same per-lens array the fresh pass uses.
+      catch (err) { recordVerifierFailure(failures, err); return null; }
     }));
     // Carried-forward findings are NOT routed. Their `line` was recorded against
     // a previous round's HEAD, and the fixer has rewritten the tree since; that
@@ -2133,6 +2201,12 @@ async function main() {
         absenceRefuted: freshTally.absenceRefuted + priorTally.absenceRefuted,
         unresolved: freshTally.unresolved + priorTally.unresolved,
         errored: freshTally.errored + priorTally.errored,
+        // Both passes' failures in one tally. `errored` is UNCHANGED and stays
+        // the count of blocking findings that ended with no usable verdict; this
+        // is the subset where a session actually threw, broken down by cause.
+        // `errored - failures.total` is therefore the fold-null count, which is
+        // not an error at all — see verifierFailureCounts.
+        failures: verifierFailureCounts(failures),
       },
       // GATING findings only. `metrics.mjs::detectFlips` reads `kept` as "this
       // lens blocked this round" and compares it against the next round, so

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -1750,12 +1750,21 @@ const VERIFIER_FAILURE_KINDS = Object.freeze({ "api-error": "apiError", limit: "
 /**
  * Tally `recordVerifierFailure` records into the shape `lensStats` reports.
  *
- * Deliberately separate from `verifierTally`'s `errored`, and BOTH are kept. Their
- * DIFFERENCE is the measurement: `errored` counts blocking findings that ended with
- * no usable verdict, which includes `resolveClusterVerdict` handing back a folded
- * wording's missing verdict — not an error at all. `errored - failures.total` is
- * therefore the fold-null count, and collapsing the two would hide it. Same
- * report-both idiom this file already uses for `refutedHighConfidence` vs `dropped`.
+ * Deliberately separate from `verifierTally`'s `errored`, and BOTH are kept — but
+ * they are counted in DIFFERENT UNITS and must never be subtracted:
+ *
+ *   errored        — blocking FINDINGS that ended with no usable verdict
+ *   failures.total — verifier SESSIONS that threw
+ *
+ * One clustered finding can consume several sessions: the representative, then one
+ * per folded wording (only when the representative's verdict drops — see
+ * `resolveClusterVerdict`). So a cluster whose rep drops and whose two folds both
+ * throw records TWO failures and ONE errored finding, and the reverse also happens
+ * — a finding can end with no verdict having thrown nothing at all.
+ *
+ * Each is useful on its own: `errored` says how much of the gate went unfiltered,
+ * `failures` says what went wrong and therefore what to do about it. Neither
+ * derives from the other.
  */
 export function verifierFailureCounts(failures) {
   const out = { apiError: 0, limit: 0, noOutput: 0, unknown: 0, total: 0 };
@@ -2201,11 +2210,10 @@ async function main() {
         absenceRefuted: freshTally.absenceRefuted + priorTally.absenceRefuted,
         unresolved: freshTally.unresolved + priorTally.unresolved,
         errored: freshTally.errored + priorTally.errored,
-        // Both passes' failures in one tally. `errored` is UNCHANGED and stays
-        // the count of blocking findings that ended with no usable verdict; this
-        // is the subset where a session actually threw, broken down by cause.
-        // `errored - failures.total` is therefore the fold-null count, which is
-        // not an error at all — see verifierFailureCounts.
+        // Both passes' failures in one tally. `errored` is UNCHANGED and stays a
+        // count of FINDINGS; this counts SESSIONS, and the two are not
+        // comparable — see verifierFailureCounts for why one clustered finding
+        // can throw several times.
         failures: verifierFailureCounts(failures),
       },
       // GATING findings only. `metrics.mjs::detectFlips` reads `kept` as "this

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -24,6 +24,8 @@ import {
   confidenceCounts,
   LENS_CLOSING_INSTRUCTION,
   verifierTally,
+  verifierFailureCounts,
+  recordVerifierFailure,
   classifyResult,
   withRetry,
   FILE_CLASSES,
@@ -496,6 +498,61 @@ test("at one sample per lens, the panel still shares ONE warm-up across five len
   assert.notEqual(key("docs"), key("correctness"), "the prose lens still stands alone, correctly");
 });
 
+// --- why a verification produced no verdict -------------------------------
+
+test("recordVerifierFailure: keeps the kind and status, and is total", () => {
+  const f = [];
+  recordVerifierFailure(f, { kind: "limit", status: null, message: "hit a run limit" });
+  recordVerifierFailure(f, { kind: "api-error", status: 429 });
+  // Anything `classifyResult` did not shape still records rather than vanishing —
+  // a swallowed failure is exactly what this replaces.
+  for (const junk of [undefined, null, new Error("boom"), { kind: 7 }, "nope"]) recordVerifierFailure(f, junk);
+  assert.deepEqual(f.slice(0, 2), [{ kind: "limit", status: null }, { kind: "api-error", status: 429 }]);
+  assert.equal(f.length, 7);
+  for (const rec of f.slice(2)) assert.equal(rec.kind, "unknown");
+  // A non-array is tolerated (returns a fresh list) rather than throwing inside
+  // a `.catch` — losing the count must never turn into losing the verdict.
+  assert.deepEqual(recordVerifierFailure(null, { kind: "limit" }), [{ kind: "limit", status: null }]);
+});
+
+test("verifierFailureCounts: buckets by kind, unknown catches the rest", () => {
+  const counts = verifierFailureCounts([
+    { kind: "api-error" }, { kind: "api-error" }, { kind: "limit" },
+    { kind: "no-output" }, { kind: "unknown" }, { kind: "constructor" },
+  ]);
+  assert.deepEqual(counts, { apiError: 2, limit: 1, noOutput: 1, unknown: 2, total: 6 });
+  // `kind: "constructor"` must not walk the prototype chain and leave a NaN own
+  // key — the same untrusted-string hazard confidenceCounts documents.
+  assert.deepEqual(Object.keys(counts).sort(), ["apiError", "limit", "noOutput", "total", "unknown"]);
+  for (const junk of [null, undefined, "x", 3, [null, 4, "s"], [{}]]) {
+    const c = verifierFailureCounts(junk);
+    assert.equal(typeof c.total, "number", JSON.stringify(junk));
+    assert.ok(Number.isFinite(c.total));
+  }
+  assert.equal(verifierFailureCounts([]).total, 0);
+});
+
+test("`errored` stays wider than `failures.total`, and the gap is the measurement", () => {
+  // Both are reported because their DIFFERENCE is the number nobody could see
+  // before: `errored` counts blocking findings that ended with no usable
+  // verdict, which includes resolveClusterVerdict handing back a folded
+  // wording's missing verdict — not a thrown session. Collapsing them would hide
+  // that, and make a fold look like an outage.
+  const findings = [
+    { severity: "major", summary: "a" },
+    { severity: "major", summary: "b" },
+    { severity: "minor", summary: "c" }, // never sent, so never counted
+  ];
+  const verdicts = [null, null, null];
+  const tally = verifierTally(findings, verdicts);
+  assert.equal(tally.sentToVerifier, 2);
+  assert.equal(tally.errored, 2, "both blocking findings ended with no verdict");
+  // Only ONE of them threw; the other was a fold with no verdict.
+  const failures = verifierFailureCounts(recordVerifierFailure([], { kind: "limit" }));
+  assert.equal(failures.total, 1);
+  assert.equal(tally.errored - failures.total, 1, "the remainder is the fold-null count");
+});
+
 test("runLens forwards the manifest effort, and the verifier does not", () => {
   // The one link unit tests cannot reach: runLens opens a session, so the only
   // way to observe the forward is the source. Asserted on the PROPERTY, per the
@@ -513,6 +570,33 @@ test("runLens forwards the manifest effort, and the verifier does not", () => {
   const verify = src.slice(src.indexOf("async function verifyFinding"));
   const body = verify.slice(0, verify.indexOf("\n}"));
   assert.ok(!/effort/.test(body), "verifyFinding must not set effort");
+});
+
+test("verifyFinding retries, and does so inside itself", () => {
+  // Detection samples have always been wrapped; the verifier never was, so a
+  // single transient 429 killed a verification and its finding rode to the gate
+  // unfiltered. Wrapped INSIDE verifyFinding rather than at the call sites so
+  // all three paths — fresh, folded wording, carried-forward prior — get it from
+  // one edit; a call-site wrapper would have to be repeated and would drift.
+  // Source-asserted because verifyFinding opens a session.
+  const src = readFileSync(path.join(HERE, "review-panel.mjs"), "utf8");
+  const verify = src.slice(src.indexOf("async function verifyFinding"));
+  const body = verify.slice(0, verify.indexOf("\n}"));
+  assert.match(body, /withRetry\(/, "verifyFinding must retry transient failures");
+});
+
+test("both verifier catch sites record the failure instead of swallowing it", () => {
+  const src = readFileSync(path.join(HERE, "review-panel.mjs"), "utf8");
+  // The fresh/fold path and the carried-forward path. Neither may go back to a
+  // bare `() => null` / `catch { }`, which is what made every distinct cause
+  // arrive as the same anonymous count.
+  assert.match(src, /\.catch\(\(err\) => \{ recordVerifierFailure\(failures, err\); return null; \}\)/);
+  assert.match(src, /catch \(err\) \{ recordVerifierFailure\(failures, err\); return null; \}/);
+  // Code lines only — the docblock above verifyFinding quotes the old
+  // `.catch(() => null)` to say what it replaced, and grepping the whole file
+  // would count that prose as a regression.
+  const code = src.split("\n").filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
+  assert.ok(!/\.catch\(\(\) => null\)/.test(code), "no verifier catch may discard the error");
 });
 
 test("main() validates every manifest effort before spending a token", () => {

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -532,25 +532,38 @@ test("verifierFailureCounts: buckets by kind, unknown catches the rest", () => {
   assert.equal(verifierFailureCounts([]).total, 0);
 });
 
-test("`errored` stays wider than `failures.total`, and the gap is the measurement", () => {
-  // Both are reported because their DIFFERENCE is the number nobody could see
-  // before: `errored` counts blocking findings that ended with no usable
-  // verdict, which includes resolveClusterVerdict handing back a folded
-  // wording's missing verdict — not a thrown session. Collapsing them would hide
-  // that, and make a fold look like an outage.
-  const findings = [
-    { severity: "major", summary: "a" },
-    { severity: "major", summary: "b" },
-    { severity: "minor", summary: "c" }, // never sent, so never counted
-  ];
-  const verdicts = [null, null, null];
-  const tally = verifierTally(findings, verdicts);
-  assert.equal(tally.sentToVerifier, 2);
-  assert.equal(tally.errored, 2, "both blocking findings ended with no verdict");
-  // Only ONE of them threw; the other was a fold with no verdict.
-  const failures = verifierFailureCounts(recordVerifierFailure([], { kind: "limit" }));
-  assert.equal(failures.total, 1);
-  assert.equal(tally.errored - failures.total, 1, "the remainder is the fold-null count");
+test("`errored` and `failures.total` are different units and must not be subtracted", () => {
+  // errored counts FINDINGS, failures.total counts SESSIONS, and one clustered
+  // finding can consume several sessions. Worked example, which is the case that
+  // sinks any subtraction:
+  //
+  //   a finding with two folded wordings, whose representative verdict DROPS
+  //   → the caller re-verifies both folds (it only does so when the rep drops)
+  //   → both fold sessions throw            → failures.total = 2
+  //   → resolveClusterVerdict sees drops(null) === false for fold 0
+  //     and returns null, so the finding has no verdict → errored = 1
+  //
+  // errored - failures.total is -1 there. Reported side by side, never derived.
+  const rep = { severity: "major", summary: "clustered", mergedFrom: [{ severity: "major" }, { severity: "major" }] };
+  const foldVerdicts = [null, null]; // both fold sessions threw
+  const dropping = { verdict: "refuted", confidence: "high", refutationGround: "not-present", groundedIn: ["a.mjs:1"] };
+  const resolved = resolveClusterVerdict(rep, dropping, rep.mergedFrom, foldVerdicts);
+  assert.equal(resolved, null, "a fold with no verdict keeps the cluster (fail toward blocking)");
+
+  const tally = verifierTally([rep], [resolved]);
+  assert.equal(tally.errored, 1, "one FINDING ended with no verdict");
+  const failures = verifierFailureCounts([{ kind: "limit" }, { kind: "limit" }]);
+  assert.equal(failures.total, 2, "two SESSIONS threw");
+  assert.ok(failures.total > tally.errored, "sessions can exceed findings — the subtraction would go negative");
+});
+
+test("a finding can end with no verdict having thrown nothing", () => {
+  // The other direction, which is why the reverse subtraction is wrong too: a
+  // non-blocking finding is never sent, and a blocking one whose verification
+  // was simply never run carries a null verdict without any session throwing.
+  const tally = verifierTally([{ severity: "major", summary: "a" }], [null]);
+  assert.equal(tally.errored, 1);
+  assert.equal(verifierFailureCounts([]).total, 0);
 });
 
 test("runLens forwards the manifest effort, and the verifier does not", () => {


### PR DESCRIPTION
## Summary

Splits the verifier's single `errored` count into causes, and wraps `verifyFinding`
in `withRetry`.

## Why

Both verifier catch sites discarded the error — `.catch(() => null)` and a bare
`catch {}` — so `classifyResult`'s already-computed `kind` was thrown away and every
distinct cause arrived as the same anonymous `errored++`.

That is exactly how the failures behind #614 read. Eight of eighteen verifications
died at precisely the presence turn ceiling, and the summary could only say they
errored — indistinguishable from a quota outage. Here is that same round rendered
with this change:

```
- Sent to verifier: 18
- ⚠️ Verifier ERRORED on 8 of 18 — those findings are UNFILTERED, not confirmed
- Verifier failures: 1 api-error, 6 turn-limit, 1 no-output
- Refuted: 0 (0 high-confidence, 0 dropped)
```

`turn-limit` is the line that would have pointed straight at the ceiling. It is also
how anyone can now confirm #614 actually fixed it, rather than inferring it.

## `errored` is unchanged, and that is the point

`failures` sits *beside* `errored`, not instead of it, because their **difference** is
the number nobody could see:

- `errored` — blocking findings that ended with **no usable verdict**. That includes
  `resolveClusterVerdict` handing back a folded wording's missing verdict, which never
  threw at all.
- `failures.total` — the subset where a session actually threw, split by cause.

So `errored − failures.total` is the fold-null count, and the renderer names it
(`(+2 folded wording(s) with no verdict)`) rather than leaving `3` vs `1` looking like
a contradiction. Same report-both-and-read-the-gap idiom the file already uses for
`refutedHighConfidence` vs `dropped`.

## The retry

`verifyFinding` had no `withRetry` while detection samples always have, so a single
transient 429 killed a verification outright and its finding rode to the gate
unfiltered. Wrapped **inside** `verifyFinding` rather than at the call sites, so all
three paths — fresh, folded wording, carried-forward prior — get it from one edit
instead of three that can drift.

It cannot burn budget on a ceiling: `withRetry` only retries `err.retryable === true`,
and `classifyResult` marks every `limit` subtype and any session/usage limit
non-retryable. **Which is also why the retry is not what fixed the measured
failures** — those were all `limit`, and #614's ceiling raise is what addressed them.
This covers the genuine transient case (#592's 429 outage) that simply did not occur
in the sampled round.

## Linked Issues

None — this came out of a cost analysis of the review panel.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

`cd scripts/agent && node --test *.test.mjs` → **497 pass, 0 fail** (1 skip,
pre-existing on `main`). Both renderings above are printed by `renderSummary`, not
hand-written.

`pnpm verify:fast` was not run locally: it needs a full install in a fresh worktree and
`scripts/agent` sits outside the pnpm workspace, so it is covered only by the
`agent:tests` lane inside `verify:self`.

## Risk Assessment

- **User-facing risk:** none. Observability plus a retry, both inside the panel.
- **Data/security risk:** none.
- **Rollback plan:** revert the single commit.

**Gate behaviour is unchanged in the fail direction.** A failed verification still
keeps its finding — both catch sites still `return null` — so this cannot let a
finding through. The retry can make the gate *slightly less* blocking, since a
verification that previously died on a transient error may now complete and refute;
that is the intended direction and the reason the retry exists.

**Ledger compatibility:** the new line is omitted when nothing threw *and* when the
field is absent, so healthy rounds and rounds recorded before this shipped both render
byte-identically to before. There is a test asserting exactly that, because an
all-zero line would read as data rather than as absence.

## Notes for Reviewers

**AI assistance:** this PR was written with Claude Code — the measurement, the diff,
and the tests.

Two details worth a look:

1. **`recordVerifierFailure` is total, deliberately.** It runs inside a `.catch`, so
   throwing there would turn "we lost a count" into "we lost a verdict". Junk, a plain
   `Error`, even a non-array accumulator all record rather than blow up — the
   unrecognised ones as `unknown`.

2. **`verifierFailureCounts` uses allowlist membership, not `in`.** `kind` comes from
   an append-only ledger, and `kind: "constructor"` under `in` would walk the
   prototype chain and leave a `NaN` own key on the returned counts — the same
   untrusted-string hazard `confidenceCounts` documents. There is a test pinning the
   returned key set.

While adding these I hit the same trap twice: a source-scan test that greps for a
pattern also matches the docblock *quoting* that pattern. The catch-site guard now
filters comment lines out before asserting.

- Follow-up: #613, #614, #615, #630 and #636 have merged. Next in the plan is
  dropping the duplicate verification of carried-forward findings — on every round ≥ 2
  a finding the fresh pass re-detects is verified twice, in two wordings, in the same
  round.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added categorized verifier failure reporting for API errors, time limits, missing output, unknown causes, and total failures.
  * Summary views now display verifier failure counts when failures occur.
  * Retryable verification failures are retried automatically.
* **Bug Fixes**
  * Verifier failures are no longer silently discarded or shown only as missing verdicts.
  * Findings remain correctly blocked when verification fails.
  * Existing records without failure details continue to work without extra summary output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->