### PR TITLE
Capture per-lens stage detail as a review-panel artifact

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -549,6 +549,17 @@ jobs:
           # SHA the check runs below are attested against, so the pointer and the
           # attestation cannot drift apart.
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # Per-lens stage-detail capture (uploaded as an artifact below).
+          # DEFAULT ON — an opt-OUT, deliberately the inverse of
+          # AGENT_PIPELINE_ENABLED's `== 'true'` opt-in. Passed RAW, with no
+          # `&& ... || ...` default applied here, because an unset repo variable
+          # interpolates to the EMPTY STRING (the same semantics the BASE_SHA /
+          # SINCE_SHA pair documents above) and the script resolves empty,
+          # whitespace and absent alike to ON. Only an explicit `0`/`false`/`off`
+          # in the repo variable disables it. Deciding the default here instead
+          # would put the inverted logic in a YAML expression that no test can
+          # reach; `stageDetailCaptureEnabled` is tested.
+          STAGE_DETAIL_CAPTURE: ${{ vars.AGENT_STAGE_DETAIL_CAPTURE }}
         run: >-
           node .trusted/scripts/agent/review-panel.mjs
           --diff-file /tmp/pr.diff
@@ -715,6 +726,44 @@ jobs:
             .agent-review/review-lens-stats.json
           if-no-files-found: ignore
           retention-days: 1
+
+      # What each lens actually did this round: per-sample findings before the
+      # union, and the verifier's verdict on every blocking finding. Nothing else
+      # keeps this. The check runs persist only what GATES (`output.text` is
+      # critical/major, drops the `backlog` lane, and drops trailing findings to
+      # fit 60k — review-state.mjs calls that channel "DESIGNED to lose data"),
+      # and `review-lens-stats.json` above keeps counts, not the findings counted.
+      # So panel tuning decisions cannot currently be scored after the fact, which
+      # is the gap #608's feedback corpus exists to close — this records its input.
+      #
+      # A SEPARATE step from the execution log above, on purpose. Those two files
+      # are an intra-run hand-off to promote/fix and their 1-day retention is
+      # chosen to match that lifetime; this one has to outlive the run to be worth
+      # capturing. Extending that step would silently change the hand-off's
+      # semantics, and upload-artifact@v4 rejects a duplicate name within a run,
+      # so the name differs too.
+      #
+      # An artifact rather than a comment or a commit for the same reason the
+      # execution log is one: this job's SDK cwd is the untrusted branch checkout,
+      # so it is not granted the write scopes that would let it push this data
+      # anywhere itself. Anything that collects these belongs in its own job.
+      #
+      # Size tracks diff size and nothing else — `lensDiff` is 76-97% of each
+      # file. Measured over real PRs: ~25 KB per run for a 10 KB diff, ~105 KB for
+      # 17 KB, and ~2 MB for a 470 KB diff (the largest in the last 40 commits).
+      # upload-artifact deflates, and diffs compress ~3x, so the worst case above
+      # stores as ~0.6 MB.
+      - name: Upload per-lens stage detail
+        if: always() && steps.pr.outputs.number != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-panel-stage-detail
+          path: .agent-review/*/stage-detail.json
+          # Absent whenever capture is disabled, or a lens was skipped, or the
+          # orchestrator crashed before writing — none of which is an error here.
+          if-no-files-found: ignore
+          retention-days: 30
 
   promote:
     needs: review-panel

--- a/docs/tasks/active/20260803-panel-stage-detail-capture-todo.md
+++ b/docs/tasks/active/20260803-panel-stage-detail-capture-todo.md
@@ -1,0 +1,197 @@
+# Panel stage detail: record what the panel actually did
+
+Producer only. One JSON file per lens per round, uploaded as an artifact, read by
+nothing yet.
+
+## The problem
+
+#608 opened the feedback corpus on the grounds that **"nothing records outcomes, so
+every tuning decision was argued from intuition"**. That is still true one stage
+earlier, and worse: the panel's own decisions are not merely unscored, they are
+**unrecoverable**. By the time a round ends, the only surviving evidence of what six
+lenses detected and how the verifier ruled has been squeezed through two channels
+that were built for other jobs.
+
+`output.text` on each `agent-review-<lens>` check run is one of them, and it is
+disqualified by construction:
+
+- It keeps `critical`/`major` only, and drops `lane === 'backlog'` — so every minor
+  finding, every nit, and the entire demoted lane the novelty gate (#583) exists to
+  produce are absent.
+- It drops **trailing findings** until the array fits 60k.
+- `review-state.mjs` already refuses to trust it for the same reason, in as many
+  words: *"the panel workflow trims it to fit a 60k limit by dropping findings, i.e.
+  it is DESIGNED to lose data."*
+
+`output.summary` is the other, and it is prose whose shape has drifted with
+#573–#610 — a renderer, not a record.
+
+Neither has ever carried the two things a scoring pass most needs, at any severity:
+**which sample raised what** (`unionSamples` collapses the samples; `lensStats`
+keeps `agreement` as a score, not the findings it scored) and **how the verifier
+ruled on each finding** (`lensStats.verifier` keeps tallies; every verdict, ground
+and citation is discarded).
+
+So `misses.jsonl` can record that the panel was wrong about a PR, but nothing can
+say *which stage* was wrong, or on which sample, or on what ground. This records
+that, at zero model cost and with no new permissions.
+
+## The change
+
+- [x] `stageDetailCaptureEnabled(env)` in `review-panel.mjs` — the gate, and the
+      only reason this needs tests at all (see *Fail directions*). **Default ON.**
+- [x] `buildStageDetail({ lensDiff, scopeNote, samples, fresh, freshVerdicts,
+      prior, priorVerdicts })` — pure, so "capture changes no verdict" is a property
+      a test can assert rather than a claim a reader has to take on trust.
+- [x] `writeStageDetail(lensOut, detail, env)` — dependency-free `writeFileSync`
+      into the lens out dir the lens already owns, beside `verdict.json`. Returns
+      whether it landed; swallows everything.
+- [x] Called once per lens, after `gatingFindings(merged)` and before
+      `writeVerdict` — verification is complete, so every verdict exists, and
+      nothing has been written yet, so it reads exactly the values the check run is
+      built from.
+- [x] `samples` records the raw per-sample findings **before** `unionSamples` and
+      before `clusterFindings`. That is the per-sample detection signal, and it is
+      the one thing no other channel can be back-filled to produce.
+- [x] `verifications` records every finding that reached the verifier, tagged
+      `population: "fresh" | "prior-round"`, with its verdict and whether it
+      dropped. `dropped` is recomputed through the real `isDroppingVerdict` rather
+      than restated, so the capture cannot drift from the gate. `verdict: null`
+      means the verifier errored and the finding was kept.
+- [x] `lensDiff` is the **routed** slice (#582), not the PR diff — what makes a
+      capture replayable, and 76–97% of the file's bytes.
+- [x] `AGENT_STAGE_DETAIL_CAPTURE` repo variable → `STAGE_DETAIL_CAPTURE` in the
+      "Run review panel" step's `env:`. Passed **raw**, with no YAML-side default.
+- [x] A second `upload-artifact` step, `review-panel-stage-detail`,
+      `.agent-review/*/stage-detail.json`, `if-no-files-found: ignore`,
+      `retention-days: 30`, mirroring the existing step's
+      `always() && steps.pr.outputs.number != ''` and `continue-on-error: true`.
+- [x] 9 new tests. 501 agent tests, 500 pass / 0 fail / 1 pre-existing skip.
+
+No new job permissions, and none wanted — see *Explicit non-goal*.
+
+## Corrected from the plan
+
+The writer was to be ported from the eval-harness branch, where it has run since
+July. **Three of its four lines would now be wrong**, because #591/#601 moved
+restatement clustering to *before* verification after that code was written.
+
+- **`verdicts` is index-aligned to `detected`, not to `findings`.** The original
+  mapped the fresh population over `findings` — the post-union, pre-cluster set —
+  which was correct when the verifier ran on it. It no longer does: `clusterFindings`
+  runs first and `verdicts` is built over its output. Copying the line forward would
+  have paired findings with **other findings' verdicts** whenever a round clustered
+  anything, and the pairing is the entire content of the file. This is the failure
+  that would not have shown up in a test, only in a corpus that quietly disagreed
+  with reality.
+- **`isDroppingVerdict` takes `{ claimType }` now, not `verifyOpts`.** That
+  parameter no longer exists; `verifyOpts` is gone from this scope entirely. Passing
+  a stale options bag would have scored absence claims against presence grounds —
+  silently, since the function's contract is to KEEP on anything it does not
+  recognize.
+- **`VERIFIER_MAX_TURNS` needed no export.** The original commit exported it for the
+  harness. Upstream exports it already, and it is now `{ presence, absence }` rather
+  than a scalar. Nothing to do, which is worth saying: the port's diff is smaller
+  than the branch it came from, not larger.
+
+The original also wrote inline in `main()` and had **no gate at all**. Splitting it
+into a pure builder and a swallowing writer is what makes both properties below
+testable.
+
+## Fail directions, opposite on purpose
+
+| path | on doubt | why |
+|---|---|---|
+| `writeStageDetail` (the write) | **no capture**, logged, returns `false` | it runs inside `Promise.all(allLenses.map(...))`, where a throw aborts every other lens. Losing one round's diagnostic costs a row in a dataset; failing the round blocks a PR on an instrumentation bug. There is no symmetry, so there is no case where a write error propagates |
+| `stageDetailCaptureEnabled` (the gate) | **ON** | a repo variable that was never set arrives as the empty string, so the ordinary `if (env.X)` flag shape resolves "nobody configured it" to OFF. A diagnostic that is quietly absent is worse than one that is loudly broken: the corpus would look thin rather than unwired, and nothing would page |
+| an unrecognized gate value (`"banana"`) | **ON** | same direction. Only `0`/`false`/`off` are off-words; anything else keeps the default |
+| `buildStageDetail` (the payload) | a stable shape, never a throw | `lensDiff`/`scopeNote` degrade to `""` and a sample with no `findings` array to `[]`, so a consumer reading `detail.lensDiff.length` never has to guard the field's absence. A `null` row would have to be special-cased by every reader, forever |
+| the upload step | `continue-on-error`, `if-no-files-found: ignore` | absent files are the *normal* case when capture is off or every lens skipped. Warning on that would train the pipeline's watchers to ignore a real warning |
+
+The gate is the inverse of `AGENT_PIPELINE_ENABLED`'s `== 'true'` opt-in, and it is
+resolved **in the script**, not in a YAML expression. A `&& 'x' || 'y'` default in
+the workflow would put the inverted logic in the one place no test can reach it.
+
+## Explicit non-goal
+
+**This must not change a single verdict.** It is instrumentation placed inside the
+decision path, which is the one thing that can go wrong here that would matter, so
+the design is arranged to make it checkable rather than argued: `buildStageDetail`
+is pure and asserted not to mutate its inputs, `writeStageDetail` touches only the
+filesystem, and the call site consumes `lensDiff`, `ok`, `detected`, `verdicts`,
+`priorForLens` and `priorVerdicts` without writing to any of them. Capture ON and
+capture OFF differ by one file on disk.
+
+**No consumer, and no collector job.** Nothing reads `stage-detail.json`. Moving
+these artifacts into a store is a separate PR, and it is separate for a permissions
+reason, not a tidiness one: this job's SDK working directory is the untrusted branch
+checkout, so it is not granted the write scopes that would let it push data
+anywhere. An artifact is the hand-off precisely because of that boundary, exactly as
+it already is for `review-panel-execution`. **Nothing in this PR adds a permission**,
+and a later collector must be its own job rather than a scope widened here.
+
+**`stage-detail.json` must never enter a lens or verifier prompt** — the same
+prohibition `misses.jsonl` carries, and for a stronger reason: `lensDiff` is a
+verbatim copy of contributor-authored diff text. If it ever reaches a model it goes
+in fenced as DATA, like the diff it contains.
+
+## Verification
+
+- [x] `node --test "scripts/agent/*.test.mjs"` — 501 tests, 500 pass, 0 fail, 1
+      skipped (pre-existing). No `node_modules` needed for this lane.
+- [x] The gate, in both directions: absent / `""` / `"   "` / `undefined` / `"1"` /
+      `"true"` / `"on"` / `"yes"` / `"banana"` → **ON**; `"0"` / `"false"` / `"off"`
+      / `"FALSE"` / `"Off"` / `" false "` → **OFF**. The empty-string case is the
+      one that would silently unwire this and it is asserted with a message.
+- [x] A failed write returns `false` and does not throw, on two real failure shapes
+      and no mocks: a `lensOut` nested under a regular file (ENOTDIR from
+      `mkdirSync`), and payloads `JSON.stringify` refuses (a circular reference, a
+      `BigInt`).
+- [x] OFF writes **nothing** — the lens out dir is not even created, so an opted-out
+      run is byte-identical to today.
+- [x] `buildStageDetail` does not mutate: findings and verdicts are
+      `JSON.stringify`-compared before and after.
+- [x] Non-blocking findings are excluded from `verifications`; a blocking finding
+      with a missing verdict is recorded as `verdict: null, dropped: false`.
+
+### Size, measured
+
+Built with the real `lensReviewPlan`/`sliceDiffByFile` routing over four actual
+upstream commits, with two findings per sample and three verifier verdicts per lens:
+
+| PR diff | lenses applicable | per run, raw | largest lens |
+|---|---|---|---|
+| 9.6 KB (#638) | 2 | 25 KB | 12.7 KB |
+| 17.4 KB (#636) | 5 | 105 KB | 21.0 KB |
+| 204.6 KB | 6 | 1.0 MB | 214.7 KB |
+| 470.7 KB | 6 | 2.0 MB | 486.4 KB |
+
+`lensDiff` is 76–97% of every file, so this tracks diff size and nothing else.
+**The planned "30–80 KB per lens" holds only for small PRs** — a 470 KB diff costs
+~2 MB per run, 25× the planned ceiling. It is still not a problem:
+`upload-artifact@v4` deflates, and these diffs compress 3.1–3.6×, so the worst
+case above stores as ~0.6 MB and a typical round as under 10 KB. At a few PRs a day
+and 30-day retention that is single-digit MB standing.
+
+Routing narrows less than its name suggests on this repository — most lenses read
+source files, so `lensDiff` came out within 0–30% of the full diff on all four
+samples. Worth knowing before anyone counts on #582 for size rather than for focus.
+
+## Not built
+
+- **A collector.** Downloading these into a store, keyed by run and commit, is the
+  next PR. It needs write scopes this job must not have.
+- **Anything that reads the file.** No schema module, no validator, no projection.
+  The producer is deliberately shaped as JSON with a stable field set so that a
+  consumer can be written against it later without a migration; that is the whole
+  extent of the forward commitment.
+- **`agent-review-on-demand.yml`.** It runs the same panel, so capture is ON there
+  and the files are written — but it uploads no artifact (it does not upload the
+  execution log either) and its rounds record no check runs and drive no
+  promote/fix loop. Advisory `@claude review` invocations are not the population a
+  tuning corpus should be scored on. Wiring it up is a one-step addition if that
+  changes.
+- **A real end-to-end panel run.** The sizes above are computed from real diffs
+  through the real routing code, not read off a completed workflow. The first
+  managed PR after this merges will produce the artifact; the number to check
+  against the table is the largest per-lens file.

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -2074,6 +2074,34 @@ async function main() {
     // check and stop reaching the fixer.
     const gating = gatingFindings(merged);
 
+    // Record WHAT THIS LENS DID, as data, before any of it is flattened for
+    // humans. Placed here on purpose: verification is complete (so every verdict
+    // exists) and nothing has been written yet, so this reads the same values the
+    // check run is about to be built from.
+    //
+    // The counters below say HOW MANY findings each stage moved. Nothing says which
+    // sample raised what, or how the verifier ruled on each one — and the channels
+    // that survive the job cannot be back-filled into it. `output.text` on the
+    // check run is blocking-only (it drops the whole `backlog` lane) and truncates
+    // trailing findings at the 60k cap; `review-state.mjs` states outright that it
+    // is designed to lose data. `output.summary` is prose whose shape has drifted
+    // every few PRs. So the panel's own decisions are, today, unscoreable after the
+    // fact — which is the same gap #608's corpus was opened to close, one stage
+    // earlier and at zero model cost.
+    //
+    // Read-only and best-effort. `buildStageDetail` derives; `writeStageDetail`
+    // swallows. Neither can change `merged`, `gating` or the conclusion.
+    writeStageDetail(lensOut, buildStageDetail({
+      lensDiff,
+      scopeNote,
+      samples: ok,
+      // `detected`, not `findings`: post-cluster, index-aligned with `verdicts`.
+      fresh: detected,
+      freshVerdicts: verdicts,
+      prior: priorForLens,
+      priorVerdicts,
+    }));
+
     // Reliability signals for this round: did the samples agree (fresh pass
     // only — prior-round re-checks aren't a sampling question), and what did
     // the verifier do across BOTH the fresh and prior-round re-check passes.
@@ -2166,6 +2194,93 @@ async function main() {
   const blockers = panel.filter((p) => p.blocking && p.applicable);
   if (blockers.length > 0 && blockers.every((p) => p.infraError)) {
     process.stderr.write(`PANEL_INFRA_ERROR: ${blockers[0].infraError}\n`);
+  }
+}
+
+/**
+ * Is per-lens stage-detail capture on? **Default ON** — this reads as an opt-OUT,
+ * which is the inverse of `AGENT_PIPELINE_ENABLED`'s `== 'true'` opt-in, and the
+ * inversion is the whole reason this is a function with tests instead of a
+ * truthiness check at the call site.
+ *
+ * A GitHub repo variable that has never been set arrives as the **empty string**,
+ * not as absent — the same semantics the panel workflow already documents for
+ * `REVIEW_MODE`/`SINCE_SHA` ("When narrowing did not happen both are EMPTY
+ * STRINGS, which review-panel.mjs reads as absent"). So `if (env.X)` would resolve
+ * unset to OFF and the capture would silently never run, on every repository that
+ * had not explicitly opted in — a diagnostic that is quietly absent is worse than
+ * one that is loudly broken. Unset, empty and whitespace therefore all mean ON;
+ * only an explicit off-word turns it off.
+ */
+export function stageDetailCaptureEnabled(env = process.env) {
+  const raw = String(env.STAGE_DETAIL_CAPTURE ?? "").trim().toLowerCase();
+  return !(raw === "0" || raw === "false" || raw === "off");
+}
+
+/**
+ * What this lens actually did this round, as data — the input a later scoring pass
+ * needs and that no existing channel carries.
+ *
+ * Pure and read-only over its arguments on purpose: this function is the reason a
+ * reviewer can be sure capture changes no verdict. It derives, copies and returns;
+ * it cannot reach the findings the panel goes on to gate on.
+ *
+ * - `samples` — the raw per-sample findings, BEFORE `unionSamples` and before
+ *   `clusterFindings`. Per-sample detection is otherwise unrecoverable:
+ *   `lensStats.agreement` keeps a score, not the findings it scored.
+ * - `verifications` — one record per finding that reached the verifier, with the
+ *   verdict and whether it dropped. `dropped` is recomputed through the real
+ *   `isDroppingVerdict` rather than restated, so it cannot drift from the gate.
+ *   `verdict: null` means the verifier errored and the finding was kept.
+ * - `fresh` must be the POST-cluster findings (`detected`), not the union:
+ *   restatement clustering moved ahead of verification in #591/#601, so `verdicts`
+ *   is index-aligned to what was clustered. Passing the union here would pair
+ *   findings with other findings' verdicts.
+ */
+export function buildStageDetail({ lensDiff, scopeNote, samples, fresh, freshVerdicts, prior, priorVerdicts }) {
+  const rows = (population, findings, verdicts) =>
+    (Array.isArray(findings) ? findings : []).map((f, i) => {
+      const verdict = (Array.isArray(verdicts) ? verdicts : [])[i] ?? null;
+      return { population, finding: f, verdict, dropped: isDroppingVerdict(verdict, { claimType: claimTypeOf(f) }) };
+    });
+  // Only blocking findings are ever sent to the verifier, so the same filter that
+  // gates `verifyBlocking` gates what is recorded — a minor finding has no verdict
+  // to report and a `verdict: null` row for it would read as a verifier error.
+  const verifications = [
+    ...rows("fresh", fresh, freshVerdicts),
+    ...rows("prior-round", prior, priorVerdicts),
+  ].filter((v) => BLOCKING.has(normalizeSeverity(v.finding?.severity)));
+  return {
+    // The ROUTED slice this lens reviewed (its file-class subset, #582) — NOT the
+    // whole PR diff. It is what makes a capture replayable: a later pass can feed a
+    // lens exactly what it saw. Also the bulk of the file, by a wide margin.
+    lensDiff: typeof lensDiff === "string" ? lensDiff : "",
+    // The incremental-scope prompt addendum; "" in full mode. Recorded because it
+    // is part of the prompt, so a round is not reproducible without it.
+    scopeNote: typeof scopeNote === "string" ? scopeNote : "",
+    samples: (Array.isArray(samples) ? samples : []).map((r) => (Array.isArray(r?.findings) ? r.findings : [])),
+    verifications,
+  };
+}
+
+/**
+ * Write one lens's stage detail, or don't. Returns whether it landed.
+ *
+ * **This must never fail a review.** The capture is a diagnostic; the round is the
+ * product. Every failure mode — a full disk, a read-only mount, a value
+ * `JSON.stringify` refuses — degrades to "this run has no capture" and is logged,
+ * never to a thrown error inside `Promise.all(allLenses.map(...))`, which would
+ * take out the whole panel and turn an instrumentation bug into a review outage.
+ */
+export function writeStageDetail(lensOut, detail, env = process.env) {
+  if (!stageDetailCaptureEnabled(env)) return false;
+  try {
+    mkdirSync(lensOut, { recursive: true });
+    writeFileSync(path.join(lensOut, "stage-detail.json"), JSON.stringify(detail) + "\n");
+    return true;
+  } catch (err) {
+    console.log(`stage-detail capture failed (continuing): ${err.message}`);
+    return false;
   }
 }
 

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -48,6 +49,9 @@ import {
   VERIFIER_MAX_TURNS,
   buildVerifierPrompt,
   panelEntry,
+  stageDetailCaptureEnabled,
+  buildStageDetail,
+  writeStageDetail,
 } from "./review-panel.mjs";
 import { SYSTEM_PROMPT_DYNAMIC_BOUNDARY, EFFORT_LEVELS } from "./ask.mjs";
 import { classify, normalizeSeverity } from "./severity.mjs";
@@ -2340,4 +2344,151 @@ test("clusterFindings: re-clustering a merged finding keeps every folded wording
   assert.ok(kept.has(a) && kept.has(b), "a re-cluster dropped one of the folded wordings");
   // And the collapsed count reflects the flattened total, not just this pass.
   assert.deepEqual(clusterCounts(second), { clustered: 1, collapsed: 2 });
+});
+
+// ---------------------------------------------------------------------------
+// Stage-detail capture. Instrumentation, so every test here is really a claim
+// that it CANNOT affect a review: the gate defaults on rather than silently off,
+// the payload only derives, and a failed write is swallowed.
+// ---------------------------------------------------------------------------
+
+test("stageDetailCaptureEnabled: unset, empty and whitespace all mean ON", () => {
+  // The trap this function exists for. A GitHub repo variable that was never set
+  // reaches the runner as the EMPTY STRING, not as absent — so the ordinary
+  // `if (env.X)` feature-flag shape would resolve "nobody configured it" to OFF
+  // and the capture would never run anywhere, silently. Default ON means an
+  // unconfigured repo captures; only an explicit off-word stops it.
+  assert.equal(stageDetailCaptureEnabled({}), true, "absent must be ON");
+  assert.equal(stageDetailCaptureEnabled({ STAGE_DETAIL_CAPTURE: "" }), true, "empty string must be ON");
+  assert.equal(stageDetailCaptureEnabled({ STAGE_DETAIL_CAPTURE: "   " }), true, "whitespace must be ON");
+  assert.equal(stageDetailCaptureEnabled({ STAGE_DETAIL_CAPTURE: undefined }), true, "undefined must be ON");
+  // Anything affirmative, and anything unrecognized, also stays ON — an
+  // unparseable value must not disable a diagnostic that defaults to enabled.
+  for (const v of ["1", "true", "on", "yes", "TRUE", "banana"]) {
+    assert.equal(stageDetailCaptureEnabled({ STAGE_DETAIL_CAPTURE: v }), true, `${v} must be ON`);
+  }
+});
+
+test("stageDetailCaptureEnabled: only an explicit off-word turns it OFF", () => {
+  for (const v of ["0", "false", "off", "FALSE", "Off", " false "]) {
+    assert.equal(stageDetailCaptureEnabled({ STAGE_DETAIL_CAPTURE: v }), false, `${v} must be OFF`);
+  }
+});
+
+test("writeStageDetail: writes into the lens out dir when enabled", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "stage-detail-"));
+  try {
+    const lensOut = path.join(dir, "correctness");
+    assert.equal(writeStageDetail(lensOut, { samples: [], verifications: [] }, {}), true);
+    const written = JSON.parse(readFileSync(path.join(lensOut, "stage-detail.json"), "utf8"));
+    assert.deepEqual(written, { samples: [], verifications: [] });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeStageDetail: disabled writes nothing at all", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "stage-detail-"));
+  try {
+    const lensOut = path.join(dir, "correctness");
+    assert.equal(writeStageDetail(lensOut, { samples: [] }, { STAGE_DETAIL_CAPTURE: "false" }), false);
+    // Not merely an empty file — the lens out dir is not even created, so an
+    // OFF run is byte-identical to today's behaviour.
+    assert.throws(() => readFileSync(path.join(lensOut, "stage-detail.json"), "utf8"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeStageDetail: a failed write NEVER propagates", () => {
+  // The one property that matters operationally. This runs inside
+  // `Promise.all(allLenses.map(...))`, so a throw here would abort the whole
+  // panel — an instrumentation bug becoming a review outage. Two real failure
+  // shapes, no mocking: an unusable path, and a value JSON.stringify refuses.
+  const dir = mkdtempSync(path.join(os.tmpdir(), "stage-detail-"));
+  try {
+    // `lensOut` under a regular FILE → mkdirSync fails ENOTDIR.
+    const notADir = path.join(dir, "occupied");
+    writeFileSync(notADir, "i am a file\n");
+    assert.equal(writeStageDetail(path.join(notADir, "correctness"), { samples: [] }, {}), false);
+
+    // A circular structure → JSON.stringify throws TypeError.
+    const circular = { samples: [] };
+    circular.self = circular;
+    assert.equal(writeStageDetail(path.join(dir, "security"), circular, {}), false);
+
+    // A BigInt → JSON.stringify throws too, on a different code path.
+    assert.equal(writeStageDetail(path.join(dir, "design-fit"), { n: 1n }, {}), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildStageDetail: records per-sample findings before the union collapses them", () => {
+  // `unionSamples` dedupes across samples and `lensStats.agreement` keeps only a
+  // score, so which sample raised what is unrecoverable afterwards. That is the
+  // per-sample detection signal this capture exists to preserve.
+  const a = { severity: "major", file: "a.ts", summary: "same defect" };
+  const b = { severity: "nit", file: "b.ts", summary: "only sample 2" };
+  const detail = buildStageDetail({
+    lensDiff: "diff --git a/a.ts b/a.ts\n",
+    scopeNote: "",
+    samples: [{ findings: [a] }, { findings: [a, b] }],
+    fresh: [], freshVerdicts: [], prior: [], priorVerdicts: [],
+  });
+  assert.deepEqual(detail.samples, [[a], [a, b]]);
+  assert.equal(detail.lensDiff, "diff --git a/a.ts b/a.ts\n");
+  assert.equal(detail.scopeNote, "");
+  // A sample with no `findings` array contributes an empty list, never a crash
+  // and never a `null` row a consumer would have to special-case.
+  assert.deepEqual(
+    buildStageDetail({ samples: [{}, { findings: null }, null] }).samples,
+    [[], [], []],
+  );
+});
+
+test("buildStageDetail: verifications cover only what reached the verifier", () => {
+  // `verifyBlocking` sends critical/major only, so recording a minor finding here
+  // would show a `verdict: null` row that reads as a verifier error when in fact
+  // the verifier was never asked.
+  const major = { severity: "major", file: "a.ts", summary: "blocking" };
+  const nit = { severity: "nit", file: "a.ts", summary: "not blocking" };
+  const drop = { verdict: "refuted", confidence: "high", refutationGround: "not-present", groundedIn: ["a.ts:12"] };
+  const keep = { verdict: "confirmed", confidence: "high", refutationGround: "none", groundedIn: [] };
+  const detail = buildStageDetail({
+    samples: [],
+    fresh: [major, nit], freshVerdicts: [drop, null],
+    prior: [major], priorVerdicts: [keep],
+  });
+  assert.equal(detail.verifications.length, 2, "the nit must not be recorded");
+  assert.deepEqual(detail.verifications.map((v) => v.population), ["fresh", "prior-round"]);
+  // `dropped` is recomputed through the real gate rather than restated, so the
+  // capture cannot disagree with what the panel actually did.
+  assert.equal(detail.verifications[0].dropped, true);
+  assert.equal(detail.verifications[1].dropped, false);
+  // A blocking finding the verifier ERRORED on is recorded with a null verdict —
+  // that is the "kept because we could not check it" case, and it has to be
+  // distinguishable from a confirmation.
+  const errored = buildStageDetail({ fresh: [major], freshVerdicts: [] });
+  assert.equal(errored.verifications[0].verdict, null);
+  assert.equal(errored.verifications[0].dropped, false);
+});
+
+test("buildStageDetail: derives only — it never mutates its inputs", () => {
+  // The claim the review cares about most: capture cannot change a verdict. The
+  // payload builder is pure, so the findings the panel goes on to gate on are
+  // untouched by having been recorded.
+  const findings = [{ severity: "major", file: "a.ts", summary: "s" }];
+  const verdicts = [{ verdict: "confirmed", confidence: "low" }];
+  const before = JSON.stringify({ findings, verdicts });
+  buildStageDetail({ lensDiff: "d", scopeNote: "n", samples: [{ findings }], fresh: findings, freshVerdicts: verdicts, prior: [], priorVerdicts: [] });
+  assert.equal(JSON.stringify({ findings, verdicts }), before);
+});
+
+test("buildStageDetail: a missing lensDiff or scopeNote degrades to an empty string", () => {
+  // JSON with a stable shape matters more than a faithful `undefined`: a consumer
+  // reading `detail.lensDiff.length` must not have to guard the field's absence.
+  const detail = buildStageDetail({});
+  assert.deepEqual(detail, { lensDiff: "", scopeNote: "", samples: [], verifications: [] });
+  assert.equal(typeof JSON.parse(JSON.stringify(detail)).lensDiff, "string");
 });


### PR DESCRIPTION
## Summary

Each review lens now writes `stage-detail.json` into its out dir — what it
detected per sample, and how the verifier ruled on each blocking finding — and a
new upload step publishes those at 30-day retention.

```json
{ "lensDiff": "…", "scopeNote": "", "samples": [[…], […]], "verifications": [{ "population": "fresh", "finding": {…}, "verdict": {…}, "dropped": false }] }
```

**Producer only.** Nothing reads the file. No new job permissions. Zero model
cost — the panel already computed all of this and then discarded it.

## Why

#608 opened the feedback corpus because *"nothing records outcomes, so every
tuning decision was argued from intuition."* That is still true one stage
earlier, and worse: the panel's own decisions are not merely unscored, they are
**unrecoverable** once the job ends.

The two channels that survive a round were built for other jobs:

- **`output.text`** keeps `critical`/`major` only, drops the whole `backlog` lane
  the novelty gate (#583) exists to produce, and drops **trailing findings** until
  the array fits 60k. `review-state.mjs` already refuses to trust it for exactly
  this reason, in as many words: *"the panel workflow trims it to fit a 60k limit
  by dropping findings, i.e. it is **DESIGNED to lose data**."*
- **`output.summary`** is prose whose shape has drifted across #573–#610 — a
  renderer, not a record.

Neither has ever carried the two things a scoring pass most needs, at any
severity:

- **which sample raised what** — `unionSamples` collapses the samples, and
  `lensStats.agreement` keeps a *score*, not the findings it scored;
- **how the verifier ruled on each finding** — `lensStats.verifier` keeps
  tallies; every verdict, refutation ground and citation is discarded.

So `misses.jsonl` can record that the panel was wrong about a PR, but nothing can
say *which stage* was wrong, on which sample, or on what ground. This is the
missing input to the corpus #608 already justified, not a new direction.

### What it records, and why each field

- **`samples`** — raw per-sample findings, *before* `unionSamples` and *before*
  `clusterFindings`. This is the only irreplaceable part: per-sample detection
  cannot be reconstructed from anything that survives today.
- **`verifications`** — every finding that reached the verifier, tagged
  `population: "fresh" | "prior-round"`, with its verdict and whether it dropped.
  `dropped` is **recomputed through the real `isDroppingVerdict`** rather than
  restated, so the capture cannot drift from the gate. `verdict: null` means the
  verifier errored and the finding was kept.
- **`lensDiff`** — the *routed* slice this lens actually reviewed (#582), not the
  whole PR diff. It is what makes a capture replayable.
- **`scopeNote`** — the incremental-scope prompt addendum (`""` in full mode).
  Part of the prompt, so a round is not reproducible without it.

### Two fail directions, both deliberate

**The write can only degrade to "no capture."** It runs inside
`Promise.all(allLenses.map(...))`, where a throw would abort every *other* lens —
turning an instrumentation bug into a review outage. So `writeStageDetail`
wraps everything, logs, and returns `false`. Losing one round's diagnostic costs
a row in a dataset; failing the round blocks a PR. There is no symmetry.

**An unset gate resolves to ON.** A GitHub repo variable that was never set
arrives as the **empty string**, so the ordinary `if (env.X)` flag shape would
resolve *"nobody configured it"* to OFF and the capture would silently never run.
A diagnostic that is quietly absent is worse than one that is loudly broken — the
corpus would look thin rather than unwired, and nothing would page. Unset, empty
and whitespace all mean ON; only an explicit `0`/`false`/`off` disables it.

`AGENT_STAGE_DETAIL_CAPTURE` is passed **raw** into the step's `env:`, with no
`&& … || …` default in YAML: that would put the inverted logic in the one place no
test can reach it. `stageDetailCaptureEnabled` is tested in both directions. This
is the inverse of `AGENT_PIPELINE_ENABLED`'s `== 'true'` opt-in, which is why it
is a named function rather than a truthiness check at the call site.

### Size 

Built with the real `lensReviewPlan`/`sliceDiffByFile` routing over four actual
`main` commits, two findings per sample and three verdicts per lens:

| PR diff | lenses applicable | per run, raw | largest lens |
|---|---|---|---|
| 9.6 KB (#638) | 2 | 25 KB | 12.7 KB |
| 17.4 KB (#636) | 5 | 105 KB | 21.0 KB |
| 204.6 KB | 6 | 1.0 MB | 214.7 KB |
| 470.7 KB | 6 | 2.0 MB | 486.4 KB |

`lensDiff` is 76–97% of every file, so this tracks diff size and nothing else.
`upload-artifact@v4` deflates and these diffs compress 3.1–3.6×, so the worst case
above stores as ~0.6 MB and a typical round under 10 KB. At a few PRs a day and
30-day retention that is single-digit MB standing.

Two honest notes from measuring it: the estimate this was planned against
(30–80 KB per lens) **holds only for small PRs** — a 470 KB diff costs ~25× that.
And routing narrowed the slice by only 0–30% on all four samples, since most
lenses read source files; #582 buys focus, not size.

### Explicit non-goals

- **No verdict may change.** This is instrumentation placed inside the decision
  path, so the design makes that checkable rather than argued: `buildStageDetail`
  is pure and asserted not to mutate its inputs, `writeStageDetail` touches only
  the filesystem, and the call site reads `lensDiff`, `ok`, `detected`,
  `verdicts`, `priorForLens`, `priorVerdicts` and writes to none of them. Capture
  ON and OFF differ by exactly one file on disk.
- **No consumer and no collector.** Deliberately a separate PR — see permissions
  above.
- **`stage-detail.json` must never enter a lens or verifier prompt** — the same
  prohibition `misses.jsonl` carries, for a stronger reason: `lensDiff` is a
  verbatim copy of contributor-authored diff text. If it ever reaches a model it
  goes in fenced as DATA, like the diff it contains.

## Linked Issues

No issue — this completes the motivation stated in #608. Related: #582 (routing,
which defines `lensDiff`), #583 (the `backlog` lane `output.text` drops),
#591/#601 (the clustering order that dictated where the writer goes).

Fixes #

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
      (No open or merged PR touches stage capture. Three open PRs do touch
      `review-panel.mjs` — see *Follow-up work*.)
- [x] I read every line of this diff and can explain why each change is necessary.
      *Author to tick after review — every line is explained in* Why *above and in
      `docs/tasks/active/20260803-panel-stage-detail-capture-todo.md`.*
- [x] Changes follow the conventions in the touched packages; any deviations are
      explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers*
      below.

## Risk Assessment

- **User-facing risk:** none. No behaviour a PR author sees changes — same check
  runs, same conclusions, same comment bodies. The only observable difference is
  an extra artifact on the workflow run.
- **Data/security risk:** the artifact contains verbatim diff text (already
  visible on the PR) and model-authored finding prose, at 30-day retention on a
  public repo's workflow runs. No secrets pass through the panel's out dir. **No
  new permissions**, and no new network egress or tool access. The one forward
  constraint is recorded in the task doc: this file must never be fed back into a
  model prompt except fenced as DATA.
- **Rollback plan:** set the repo variable `AGENT_STAGE_DETAIL_CAPTURE=false`.
  No revert, no deploy, effective on the next round — capture stops and the
  upload step no-ops via `if-no-files-found: ignore`. That is most of why the gate
  exists. Reverting the commit is also safe: nothing depends on the file.

## Notes for Reviewers

- **Where to look first:** the call site in `review-panel.mjs` (immediately after
  `gatingFindings(merged)`). The claim worth checking is that `fresh: detected`
  and `freshVerdicts: verdicts` are index-aligned — that is the one mistake here
  that tests would not catch, and it is why the writer was re-placed rather than
  copied.
- **Follow-up work:**
  - The collector job that pulls these artifacts into a store, keyed by run and
    commit. Separate PR, separate permissions.
  - `agent-review-on-demand.yml` is deliberately untouched. It runs the same
    panel, so capture is ON there and the files are written, but it uploads no
    artifact (it does not upload the execution log either) and its rounds record
    no check runs and drive no promote/fix loop. Advisory `@claude review`
    invocations are not the population a tuning corpus should be scored on. One
    step to add if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review results now include detailed per-lens stage information, including routed changes, sample findings, and verifier outcomes.
  - Stage-detail artifacts are retained for 30 days and remain available even when execution logs expire.
  - Capture is enabled by default and can be explicitly disabled through configuration.

- **Bug Fixes**
  - Missing detail files no longer cause artifact uploads to fail.
  - Capture or write failures do not affect review verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->