### PR TITLE
Add the UI hunter's browser executor, harness and free oracles

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "verify:frontend:chunks": "node ./scripts/verify-frontend-chunks.mjs",
     "verify:frontend:visual": "pnpm frontend test:visual:browser",
     "verify:frontend:interaction": "pnpm frontend test:interaction",
+    "verify:hunt:oracles": "pnpm frontend test:hunt-oracles",
     "verify:browser:docker": "pnpm frontend test:browser:docker",
     "verify:browser:docker:update": "pnpm frontend test:visual:browser:docker:update",
     "verify:entropy": "node ./scripts/verify-entropy.mjs",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,6 +18,7 @@
     "test:visual:browser": "node ./scripts/verify-visual-browser.mjs",
     "test:visual:browser:update": "UPDATE_VISUAL_BROWSER_BASELINE=true node ./scripts/verify-visual-browser.mjs",
     "test:interaction": "node ./scripts/verify-interaction-browser.mjs",
+    "test:hunt-oracles": "node ./scripts/verify-hunt-oracles.mjs",
     "test:webkit": "node ./scripts/verify-webkit-browser.mjs",
     "test:visual:browser:docker": "bash ../../scripts/run-browser-tests-docker.sh visual",
     "test:visual:browser:docker:update": "bash ../../scripts/run-browser-tests-docker.sh visual:update",

--- a/packages/frontend/scripts/hunt-ui-oracles.mjs
+++ b/packages/frontend/scripts/hunt-ui-oracles.mjs
@@ -65,12 +65,21 @@ export const DOM_INVARIANT_SCAN = /* js */ `(hostTestId) => {
 
   const host = document.querySelector('[data-testid="' + hostTestId + '"]');
   const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-  const bad = /\\b(undefined|NaN|\\[object Object\\])\\b/;
+  // Per-alternative boundaries, NOT one \\b(...)\\b around the group. \\b asserts a
+  // word/non-word transition, and '[' and ']' are both non-word, so the grouped form
+  // required a word character immediately outside the brackets: "[object Object]"
+  // and "value: [object Object]" both MISSED, and only "x[object Object]y" matched.
+  // The bracket literals are self-delimiting and need no boundary of their own.
+  const bad = /\\bundefined\\b|\\bNaN\\b|\\[object Object\\]/;
   let node;
   while ((node = walker.nextNode())) {
     if (host && host.contains(node)) continue;
     const text = (node.nodeValue || '').trim();
     if (text && bad.test(text)) {
+      // One finding per action, deliberately. This is a DETECTOR: the verdict is the
+      // same whether one label or five render "undefined", \`uiObservedKey\` collapses
+      // repeats of a rule to a single entry anyway, and an unbounded walk over a
+      // large DOM would put the whole page into the observation.
       findings.push({ kind: 'dom-invariant', rule: 'placeholder-text', detail: text.slice(0, 120) });
       break;
     }
@@ -79,12 +88,31 @@ export const DOM_INVARIANT_SCAN = /* js */ `(hostTestId) => {
   return findings;
 }`;
 
-/** Run the DOM invariant scan once. A navigation mid-scan is not a defect. */
+/**
+ * Errors that mean "the page moved under us", not "the scan is broken".
+ *
+ * A navigation, a closed context or a detached frame mid-scan is expected — the next
+ * action re-scans. Anything else is the scan itself failing.
+ */
+const TRANSIENT_EVAL_ERROR =
+  /Execution context was destroyed|Target (page, context or browser has been )?closed|frame (was )?detached|Navigation/i;
+
+/**
+ * Run the DOM invariant scan once.
+ *
+ * A blanket `catch { return [] }` here would be the exact failure this whole lane
+ * exists to prevent: a syntax error in `DOM_INVARIANT_SCAN` would make the oracle
+ * return "no findings" forever, and a run with a dead detector is indistinguishable
+ * from a clean run. So only the transient cases are swallowed; a real scan failure
+ * propagates and takes the attempt down loudly.
+ */
 export async function scanDomInvariants(page, hostTestId) {
   try {
     return await page.evaluate(`(${DOM_INVARIANT_SCAN})(${JSON.stringify(hostTestId)})`);
-  } catch {
-    return [];
+  } catch (error) {
+    const message = String(error?.message ?? error);
+    if (TRANSIENT_EVAL_ERROR.test(message)) return [];
+    throw new Error(`hunt-ui-oracles: DOM invariant scan failed — ${message}`);
   }
 }
 

--- a/packages/frontend/scripts/hunt-ui-oracles.mjs
+++ b/packages/frontend/scripts/hunt-ui-oracles.mjs
@@ -1,0 +1,133 @@
+// The FREE oracles — properties that hold for any correct web application, checked
+// after every action at zero model cost.
+//
+// The lineage is Crawljax/ATUSA's "generic invariants": a DOM should have unique
+// element ids, no dangling ARIA references, and no error state on screen. None of
+// these needs a specification, a baseline, or a judgment call, which is exactly why
+// they are the first thing the hunter checks — anything a model does not have to
+// decide is something it cannot be wrong about.
+//
+// Extracted from the runner so `verify-hunt-oracles.mjs` exercises the SAME code the
+// hunter runs. A verification script with its own copy of the oracle would prove
+// only that the copy works.
+
+/**
+ * Is a failed request evidence of a defect, or just the absent backend?
+ *
+ * Tier 1 runs with NO backend by construction, so every API call fails and none of
+ * those failures says anything about the code under test. Scoping by URL shape
+ * rather than by an endpoint list is what keeps this from being a maintenance
+ * treadmill: what matters is whether the app failed to load *its own* assets, which
+ * are the only same-origin paths Vite actually serves.
+ *
+ * `/undefined/` is in the exclusion list because `VITE_BACKEND_API_URL` is unset in
+ * the harness, so `${undefined}/auth/me/doc-styles` resolves to a same-origin URL
+ * beginning with that literal segment.
+ */
+export function isAppAssetRequest(url, baseUrl) {
+  if (typeof url !== "string" || typeof baseUrl !== "string") return false;
+  if (!url.startsWith(baseUrl)) return false;
+  const p = url.slice(baseUrl.length).split("?")[0];
+  if (p.startsWith("/auth/") || p.startsWith("/api/") || p.startsWith("/undefined/")) return false;
+  return true;
+}
+
+/**
+ * DOM invariants, evaluated in-page.
+ *
+ * The placeholder-text scan deliberately EXCLUDES the editor host. A user's document
+ * may legitimately contain the word "undefined"; the application's own chrome may
+ * not. Without that scoping the first thing a typing agent does is trip this, and a
+ * hunter whose first finding is its own harness is worse than no hunter.
+ */
+export const DOM_INVARIANT_SCAN = /* js */ `(hostTestId) => {
+  const findings = [];
+
+  const seen = new Map();
+  for (const el of document.querySelectorAll('[id]')) {
+    const id = el.getAttribute('id');
+    if (!id) continue;
+    seen.set(id, (seen.get(id) ?? 0) + 1);
+  }
+  for (const [id, count] of seen) {
+    if (count > 1) findings.push({ kind: 'dom-invariant', rule: 'duplicate-id', detail: id + ' x' + count });
+  }
+
+  for (const attr of ['aria-labelledby', 'aria-describedby', 'aria-controls']) {
+    for (const el of document.querySelectorAll('[' + attr + ']')) {
+      for (const ref of (el.getAttribute(attr) || '').split(/\\s+/).filter(Boolean)) {
+        if (!document.getElementById(ref)) {
+          findings.push({ kind: 'dom-invariant', rule: 'dangling-' + attr, detail: ref });
+        }
+      }
+    }
+  }
+
+  const host = document.querySelector('[data-testid="' + hostTestId + '"]');
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const bad = /\\b(undefined|NaN|\\[object Object\\])\\b/;
+  let node;
+  while ((node = walker.nextNode())) {
+    if (host && host.contains(node)) continue;
+    const text = (node.nodeValue || '').trim();
+    if (text && bad.test(text)) {
+      findings.push({ kind: 'dom-invariant', rule: 'placeholder-text', detail: text.slice(0, 120) });
+      break;
+    }
+  }
+
+  return findings;
+}`;
+
+/** Run the DOM invariant scan once. A navigation mid-scan is not a defect. */
+export async function scanDomInvariants(page, hostTestId) {
+  try {
+    return await page.evaluate(`(${DOM_INVARIANT_SCAN})(${JSON.stringify(hostTestId)})`);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Subscribe to the page-level oracles.
+ *
+ * These fire asynchronously, so events are buffered and DRAINED after each action.
+ * Attributing an error to the action that caused it is the whole point; a single
+ * end-of-run tally would lose that and leave a 200-action plan saying only
+ * "something threw somewhere".
+ */
+export function attachOracles(page, baseUrl) {
+  const buffer = [];
+  page.on("pageerror", (err) => {
+    buffer.push({
+      kind: "pageerror",
+      name: err?.name ?? "Error",
+      detail: String(err?.message ?? err),
+      stack: typeof err?.stack === "string" ? err.stack.split("\n").slice(0, 6).join("\n") : null,
+    });
+  });
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") return;
+    // A failed request makes the BROWSER log a console error of its own
+    // ("Failed to load resource: net::ERR_FAILED") whose location is the failed URL.
+    // Without this, scoping `network-fail` to app assets achieves nothing: Tier 1 has
+    // no backend, so every API call the app makes would still be reported here — by a
+    // different oracle. The origin rule has to apply to messages ABOUT requests too,
+    // or it only half-applies. Caught by `verify-hunt-oracles.mjs`'s negative control,
+    // which is exactly what that case exists for.
+    const url = msg.location?.()?.url;
+    if (url && !isAppAssetRequest(url, baseUrl)) return;
+    buffer.push({ kind: "console-error", detail: msg.text().slice(0, 500) });
+  });
+  page.on("requestfailed", (req) => {
+    const url = req.url();
+    if (!isAppAssetRequest(url, baseUrl)) return;
+    buffer.push({ kind: "network-fail", detail: `${req.method()} ${url} — ${req.failure()?.errorText ?? "failed"}` });
+  });
+  page.on("response", (res) => {
+    if (res.status() < 500) return;
+    if (!isAppAssetRequest(res.url(), baseUrl)) return;
+    buffer.push({ kind: "network-fail", detail: `${res.status()} ${res.url()}` });
+  });
+  return { drain: () => buffer.splice(0, buffer.length) };
+}

--- a/packages/frontend/scripts/hunt-ui-runner.mjs
+++ b/packages/frontend/scripts/hunt-ui-runner.mjs
@@ -1,0 +1,322 @@
+// The UI hunter's TRUSTED EXECUTOR — runs an action plan in a browser and reports
+// what happened. No model is involved anywhere in this file.
+//
+// WHY IT LIVES HERE AND NOT IN scripts/agent/. `playwright` resolves from
+// `packages/frontend` and NOT from `scripts/agent` — they are separate installs, and
+// `scripts/agent` is outside the pnpm workspace. Duplicating the dependency would
+// also duplicate the version, which `scripts/run-browser-tests-docker.sh` pins
+// against `Dockerfile.playwright`; a drift there means the hunter and CI disagree
+// about what a browser is.
+//
+// Keeping the driver here and spawning it as a SUBPROCESS solves a second problem for
+// free: `hunt-probe.mjs`'s `replay()` is synchronous (`spawnSync`, a sync for-loop),
+// and a browser is not. A subprocess boundary makes the async side look synchronous
+// to the agent, so the well-tested replay/determinism machinery is reused UNCHANGED
+// rather than rewritten to be async.
+//
+// WHY THE ACTION VOCABULARY IS CLOSED. Every action is a tagged object validated
+// below; there is no "evaluate this JavaScript" action and no CSS selector. A caller
+// can only reach the page through Playwright's role locators or through a NAMED
+// reader in the page's own bridge. When PR 3 puts a model behind this, its reachable
+// surface is bounded by code reviewed in this repository rather than by a prompt.
+//
+// ON CLOCK AND RANDOMNESS. Playwright can freeze time (`page.clock`), and the
+// obvious move is to pin it for determinism. This deliberately does NOT, because
+// freezing `Date.now()` changes application BEHAVIOUR: the sheets mobile-edit panel,
+// for one, dismisses itself based on `Date.now() - openedAt < 500`, which is always
+// 0 under a frozen clock. A hunter that manufactures defects with its own
+// instrumentation is worse than no hunter. Time-derived noise is handled where it
+// belongs instead — in `uiObservedKey`, which compares outcome SHAPE and scrubs
+// volatile values, exactly as the CLI hunter does. If replay proves flaky in
+// practice, revisit with evidence rather than pre-emptively.
+
+import path from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createServer } from "vite";
+
+// The oracles live in their own module so `verify-hunt-oracles.mjs` exercises the
+// SAME code this runs. A verification script with its own copy would prove only
+// that the copy works.
+import { attachOracles, scanDomInvariants } from "./hunt-ui-oracles.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(__dirname, "..");
+
+const HOST = "127.0.0.1";
+const BRIDGE_KEY = "__WB_HUNT__";
+const READY_SELECTOR = "[data-testid='hunt-harness-root'][data-hunt-harness-ready='true']";
+const HOST_TESTID = "hunt-harness-host";
+
+/** Per-action ceiling. A hung action must not hang the run. */
+const DEFAULT_ACTION_TIMEOUT_MS = 10_000;
+/** Cap on one serialized read value, so a `dom.snapshot` cannot dominate the output. */
+const MAX_VALUE_CHARS = 20_000;
+
+// --- argument parsing --------------------------------------------------------
+
+function parseArgs(argv) {
+  const out = { plan: null, attempts: 1, out: null, port: 4177, timeoutMs: DEFAULT_ACTION_TIMEOUT_MS };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--plan") out.plan = argv[++i];
+    else if (a === "--attempts") out.attempts = Number(argv[++i]);
+    else if (a === "--out") out.out = argv[++i];
+    else if (a === "--port") out.port = Number(argv[++i]);
+    else if (a === "--timeout-ms") out.timeoutMs = Number(argv[++i]);
+    else throw new Error(`hunt-ui-runner: unknown argument ${JSON.stringify(a)}`);
+  }
+  if (!out.plan) throw new Error("hunt-ui-runner: --plan <file.json> is required");
+  if (!Number.isInteger(out.attempts) || out.attempts < 1) {
+    throw new Error(`hunt-ui-runner: --attempts must be a positive integer, got ${out.attempts}`);
+  }
+  return out;
+}
+
+// --- playwright --------------------------------------------------------------
+
+async function loadPlaywright() {
+  try {
+    const mod = await import("playwright");
+    if (!mod.chromium) throw new Error("Playwright chromium launcher is unavailable.");
+    return mod;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("Cannot find package 'playwright'") || message.includes("Cannot find module 'playwright'")) {
+      console.error("[hunt-ui-runner] Playwright is required. Run `pnpm install`, then");
+      console.error("[hunt-ui-runner] `pnpm --filter @wafflebase/frontend exec playwright install chromium`.");
+      process.exit(1);
+    }
+    throw error;
+  }
+}
+
+// --- reading -----------------------------------------------------------------
+
+/**
+ * Run a named reader.
+ *
+ * `dom.*` readers use Playwright locators and so must run OUT of page; everything
+ * else is the page's own bridge. Routing on the prefix keeps the two namespaces from
+ * having to know about each other.
+ */
+async function readValue(page, name, args) {
+  if (name === "dom.snapshot") {
+    return await page.locator("body").ariaSnapshot();
+  }
+  if (name === "dom.text") {
+    const [role, accName] = args;
+    return await page.getByRole(role, { name: accName }).first().innerText();
+  }
+  if (name === "dom.count") {
+    const [role, accName] = args;
+    const loc = accName === undefined ? page.getByRole(role) : page.getByRole(role, { name: accName });
+    return await loc.count();
+  }
+  return await page.evaluate(
+    ([key, readerName, readerArgs]) => {
+      const bridge = window[key];
+      if (!bridge) throw new Error("hunt bridge is not installed");
+      return bridge.read(readerName, readerArgs);
+    },
+    [BRIDGE_KEY, name, args],
+  );
+}
+
+async function resolveTarget(page, target) {
+  if (target && typeof target.role === "string") {
+    return { kind: "role", locator: page.getByRole(target.role, { name: target.name }).first() };
+  }
+  if (target && typeof target.reader === "string") {
+    const point = await readValue(page, target.reader, target.args ?? []);
+    if (!point || typeof point.x !== "number" || typeof point.y !== "number") {
+      throw new Error(`target reader ${target.reader} did not return {x,y}, got ${JSON.stringify(point)}`);
+    }
+    return { kind: "point", point };
+  }
+  throw new Error(`unresolvable target ${JSON.stringify(target)}`);
+}
+
+// --- the action loop ---------------------------------------------------------
+
+async function waitForReady(page, url) {
+  await page.goto(url, { waitUntil: "networkidle" });
+  // Same animation kill the interaction lane uses. Transitions in flight are the
+  // cheapest source of a screenshot or a hit-test landing on the wrong frame.
+  await page.addStyleTag({
+    content: "*,*::before,*::after{animation:none!important;transition:none!important;}",
+  });
+  await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+  await page.waitForFunction(
+    (key) => {
+      const bridge = window[key];
+      return !!bridge && typeof bridge.ready === "function" && bridge.ready();
+    },
+    BRIDGE_KEY,
+    { timeout: 20_000 },
+  );
+}
+
+function clip(value) {
+  const text = typeof value === "string" ? value : JSON.stringify(value) ?? String(value);
+  if (typeof text !== "string") return text;
+  return text.length > MAX_VALUE_CHARS ? `${text.slice(0, MAX_VALUE_CHARS)}\n…[truncated]` : text;
+}
+
+async function runAction(page, action, baseUrl, timeoutMs) {
+  switch (action.type) {
+    case "goto": {
+      const surface = action.surface === "doc" ? "doc" : "sheet";
+      await waitForReady(page, `${baseUrl}/harness/hunt?surface=${surface}`);
+      return { value: surface };
+    }
+    case "click": {
+      const target = await resolveTarget(page, action.target);
+      const opts = {
+        button: action.button ?? "left",
+        clickCount: action.clickCount ?? 1,
+        timeout: timeoutMs,
+      };
+      if (target.kind === "role") await target.locator.click(opts);
+      else await page.mouse.click(target.point.x, target.point.y, opts);
+      return { value: null };
+    }
+    case "type": {
+      await page.keyboard.type(String(action.text ?? ""), { delay: 0 });
+      return { value: null };
+    }
+    case "key": {
+      await page.keyboard.press(String(action.key));
+      return { value: null };
+    }
+    case "scroll": {
+      if (action.target) {
+        const target = await resolveTarget(page, action.target);
+        if (target.kind === "point") await page.mouse.move(target.point.x, target.point.y);
+        else await target.locator.hover({ timeout: timeoutMs });
+      }
+      await page.mouse.wheel(Number(action.dx ?? 0), Number(action.dy ?? 0));
+      return { value: null };
+    }
+    case "read": {
+      return { value: await readValue(page, action.reader, action.args ?? []) };
+    }
+    case "wait": {
+      const deadline = Date.now() + (Number(action.timeoutMs) || timeoutMs);
+      let last;
+      while (Date.now() < deadline) {
+        last = await readValue(page, action.reader, action.args ?? []);
+        if (action.equals === undefined || JSON.stringify(last) === JSON.stringify(action.equals)) {
+          return { value: last };
+        }
+        await page.waitForTimeout(50);
+      }
+      throw new Error(`wait on ${action.reader} timed out; last value ${JSON.stringify(last)}`);
+    }
+    default:
+      throw new Error(`unknown action type ${JSON.stringify(action.type)}`);
+  }
+}
+
+/**
+ * One attempt: a FRESH browser context, so nothing carries over from the last.
+ *
+ * A fresh context rather than a fresh process is the deliberate trade — it resets
+ * storage, cookies and page state in ~200ms where a process restart costs the ~8s
+ * Vite and Chromium boot. What must not leak between attempts is page state, and a
+ * context boundary is exactly that.
+ */
+async function runAttempt(browser, plan, baseUrl, timeoutMs) {
+  const context = await browser.newContext({
+    viewport: { width: 1600, height: 1200 },
+    deviceScaleFactor: 1,
+    locale: "en-US",
+    timezoneId: "UTC",
+    colorScheme: "light",
+  });
+  try {
+    const page = await context.newPage();
+    // Fulfil backend calls rather than letting them fail. They are handled in the app
+    // (the toolbar catches and toasts), so this is not about preventing a crash — it
+    // is about not teaching a later agent that clicking "save default styles" is a
+    // way to make something red.
+    await page.route("**/auth/**", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ styles: {} }) }),
+    );
+    const oracles = attachOracles(page, baseUrl);
+
+    const observations = [];
+    for (const [index, action] of plan.actions.entries()) {
+      let result = null;
+      let error = null;
+      try {
+        result = await runAction(page, action, baseUrl, timeoutMs);
+      } catch (err) {
+        error = String(err?.message ?? err);
+      }
+      // Give async errors from this action a chance to land before draining. Without
+      // it a rejection scheduled by the click is attributed to the NEXT action.
+      await page.waitForTimeout(30);
+      const domFindings = await scanDomInvariants(page, HOST_TESTID);
+      observations.push({
+        index,
+        action,
+        ok: error === null,
+        error,
+        value: result ? clip(result.value) : null,
+        oracles: [...oracles.drain(), ...domFindings],
+      });
+    }
+    return { observations };
+  } finally {
+    await context.close();
+  }
+}
+
+// --- main --------------------------------------------------------------------
+
+const args = parseArgs(process.argv.slice(2));
+const plan = JSON.parse(readFileSync(args.plan, "utf8"));
+if (!Array.isArray(plan.actions) || plan.actions.length === 0) {
+  throw new Error("hunt-ui-runner: plan must have a non-empty `actions` array");
+}
+
+const playwright = await loadPlaywright();
+const server = await createServer({
+  configFile: path.resolve(frontendRoot, "vite.config.ts"),
+  root: frontendRoot,
+  logLevel: "silent",
+  server: { host: HOST, port: args.port, strictPort: true },
+});
+
+let browser;
+let result;
+try {
+  await server.listen();
+  const baseUrl = `http://${HOST}:${args.port}`;
+  browser = await playwright.chromium.launch({ headless: true });
+
+  const attempts = [];
+  for (let i = 0; i < args.attempts; i++) {
+    attempts.push(await runAttempt(browser, plan, baseUrl, args.timeoutMs));
+  }
+  result = { ok: true, attempts };
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("Executable doesn't exist") || message.includes("download new browsers")) {
+    console.error("[hunt-ui-runner] Chromium is not installed for this Playwright version.");
+    console.error("[hunt-ui-runner] Run `pnpm --filter @wafflebase/frontend exec playwright install chromium`.");
+    process.exit(1);
+  }
+  // A runner-level failure is NOT an observation — reporting it as one would let
+  // infrastructure trouble masquerade as a finding about the app.
+  result = { ok: false, error: message, attempts: [] };
+} finally {
+  if (browser) await browser.close();
+  await server.close();
+}
+
+const json = JSON.stringify(result);
+if (args.out) writeFileSync(args.out, `${json}\n`);
+else process.stdout.write(`${json}\n`);
+process.exit(result.ok ? 0 : 1);

--- a/packages/frontend/scripts/hunt-ui-runner.mjs
+++ b/packages/frontend/scripts/hunt-ui-runner.mjs
@@ -70,6 +70,15 @@ function parseArgs(argv) {
   if (!Number.isInteger(out.attempts) || out.attempts < 1) {
     throw new Error(`hunt-ui-runner: --attempts must be a positive integer, got ${out.attempts}`);
   }
+  // `Number("abc")` is NaN, and an unvalidated NaN reaches Vite's `strictPort` listen
+  // or Playwright's timeout as a confusing failure far from the typo that caused it.
+  // Port 0 is allowed and meaningful: it asks the OS for a free port (see below).
+  if (!Number.isInteger(out.port) || out.port < 0 || out.port > 65535) {
+    throw new Error(`hunt-ui-runner: --port must be an integer in 0..65535, got ${out.port}`);
+  }
+  if (!Number.isFinite(out.timeoutMs) || out.timeoutMs <= 0) {
+    throw new Error(`hunt-ui-runner: --timeout-ms must be a positive number, got ${out.timeoutMs}`);
+  }
   return out;
 }
 
@@ -129,8 +138,11 @@ async function resolveTarget(page, target) {
   }
   if (target && typeof target.reader === "string") {
     const point = await readValue(page, target.reader, target.args ?? []);
-    if (!point || typeof point.x !== "number" || typeof point.y !== "number") {
-      throw new Error(`target reader ${target.reader} did not return {x,y}, got ${JSON.stringify(point)}`);
+    // Number.isFinite, NOT typeof: `typeof NaN === "number"`, so a `typeof` check
+    // waves NaN coordinates straight through to `page.mouse.click(NaN, NaN)` and the
+    // failure surfaces as an opaque Playwright error instead of naming the reader.
+    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+      throw new Error(`target reader ${target.reader} did not return finite {x,y}, got ${JSON.stringify(point)}`);
     }
     return { kind: "point", point };
   }
@@ -282,18 +294,25 @@ if (!Array.isArray(plan.actions) || plan.actions.length === 0) {
 }
 
 const playwright = await loadPlaywright();
+// `--port 0` asks the OS for a free port, and that is what `runUiPlan` passes.
+// Samples run concurrently from PR 4 onward, and a fixed port under `strictPort`
+// makes the second runner fail to boot. A pinned port stays the default for manual
+// runs, where a stable URL is worth more than concurrency.
+const ephemeralPort = args.port === 0;
 const server = await createServer({
   configFile: path.resolve(frontendRoot, "vite.config.ts"),
   root: frontendRoot,
   logLevel: "silent",
-  server: { host: HOST, port: args.port, strictPort: true },
+  server: { host: HOST, port: args.port, strictPort: !ephemeralPort },
 });
 
 let browser;
 let result;
 try {
   await server.listen();
-  const baseUrl = `http://${HOST}:${args.port}`;
+  const listening = server.httpServer?.address();
+  const actualPort = listening && typeof listening === "object" ? listening.port : args.port;
+  const baseUrl = `http://${HOST}:${actualPort}`;
   browser = await playwright.chromium.launch({ headless: true });
 
   const attempts = [];

--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -1,0 +1,231 @@
+// Prove the UI hunter's free oracles actually fire — and, just as importantly, that
+// they DO NOT fire on the things they are scoped to ignore.
+//
+// WHY THIS EXISTS AS ITS OWN LANE. The oracles are the only part of the hunter that
+// can report a defect without any model involvement, so an oracle that silently
+// never fires makes the whole pipeline look clean while seeing nothing. That failure
+// is invisible from the outside: a run with no findings and a run with a broken
+// detector produce the same empty report.
+//
+// It also validates the baseline measurement taken before this was built: both
+// existing browser lanes were reported clean of page errors, and "clean" only means
+// something if the instrument is known to work.
+//
+// Faults are injected from the DRIVER, never from application code. There is no
+// `?fault=` query parameter and no test-only branch in the harness route — the page
+// under test is the page that ships, and Playwright supplies the damage.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer } from "vite";
+
+import { attachOracles, scanDomInvariants } from "./hunt-ui-oracles.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(__dirname, "..");
+
+const HOST = "127.0.0.1";
+const PORT = Number(process.env.HUNT_ORACLES_PORT || 4178);
+const READY_SELECTOR = "[data-testid='hunt-harness-root'][data-hunt-harness-ready='true']";
+const HOST_TESTID = "hunt-harness-host";
+
+/**
+ * Each case injects one fault and names the oracle that must notice.
+ *
+ * `expect: null` is a NEGATIVE control — the case creates something that superficially
+ * resembles a fault and asserts the oracle stays quiet. Those matter as much as the
+ * positives: a false positive costs a maintainer's attention, and the two scoping
+ * rules below (backend requests, editor-host text) are the two places this hunter is
+ * most likely to report its own environment as a bug.
+ */
+const CASES = [
+  {
+    name: "clean page fires nothing",
+    expect: null,
+    inject: async () => {},
+  },
+  {
+    name: "pageerror on an uncaught exception",
+    expect: { kind: "pageerror" },
+    inject: async (page) => {
+      await page.evaluate(() => {
+        setTimeout(() => {
+          throw new Error("injected uncaught error");
+        }, 0);
+      });
+    },
+  },
+  {
+    name: "console-error on console.error",
+    expect: { kind: "console-error" },
+    inject: async (page) => {
+      await page.evaluate(() => console.error("injected console error"));
+    },
+  },
+  {
+    name: "network-fail on a failed app asset",
+    expect: { kind: "network-fail" },
+    inject: async (page) => {
+      await page.route("**/injected-asset.js", (route) => route.abort("failed"));
+      await page.evaluate(() => fetch("/injected-asset.js").catch(() => {}));
+    },
+  },
+  {
+    // The scoping rule that keeps Tier 1 usable: there is no backend by
+    // construction, so a failed API call is the environment, not a defect.
+    name: "network-fail STAYS QUIET for an absent backend",
+    expect: null,
+    inject: async (page) => {
+      await page.unrouteAll({ behavior: "ignoreErrors" });
+      await page.route("**/auth/**", (route) => route.abort("failed"));
+      await page.evaluate(() => fetch("/auth/me/doc-styles").catch(() => {}));
+    },
+  },
+  {
+    name: "dom-invariant on a duplicate element id",
+    expect: { kind: "dom-invariant", rule: "duplicate-id" },
+    inject: async (page) => {
+      await page.evaluate(() => {
+        for (const _ of [0, 1]) {
+          const el = document.createElement("div");
+          el.id = "injected-duplicate";
+          document.body.appendChild(el);
+        }
+      });
+    },
+  },
+  {
+    name: "dom-invariant on a dangling aria reference",
+    expect: { kind: "dom-invariant", rule: "dangling-aria-labelledby" },
+    inject: async (page) => {
+      await page.evaluate(() => {
+        const el = document.createElement("div");
+        el.setAttribute("aria-labelledby", "injected-missing-label");
+        document.body.appendChild(el);
+      });
+    },
+  },
+  {
+    name: "dom-invariant on placeholder text in the chrome",
+    expect: { kind: "dom-invariant", rule: "placeholder-text" },
+    inject: async (page) => {
+      await page.evaluate(() => {
+        const el = document.createElement("div");
+        el.textContent = "Saved by undefined";
+        document.body.appendChild(el);
+      });
+    },
+  },
+  {
+    // The other scoping rule: a user's DOCUMENT may legitimately contain the word
+    // "undefined". Only the application's own chrome may not. Without this the first
+    // thing a typing agent does is trip the oracle on its own input.
+    name: "placeholder-text STAYS QUIET inside the editor host",
+    expect: null,
+    inject: async (page) => {
+      await page.evaluate((hostTestId) => {
+        const host = document.querySelector(`[data-testid="${hostTestId}"]`);
+        const el = document.createElement("div");
+        el.textContent = "the user typed undefined here";
+        host?.appendChild(el);
+      }, HOST_TESTID);
+    },
+  },
+];
+
+async function loadPlaywright() {
+  try {
+    const mod = await import("playwright");
+    if (!mod.chromium) throw new Error("Playwright chromium launcher is unavailable.");
+    return mod;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("Cannot find package 'playwright'") || message.includes("Cannot find module 'playwright'")) {
+      console.error("[verify:hunt-oracles] Playwright is required. Run `pnpm install`, then");
+      console.error("[verify:hunt-oracles] `pnpm --filter @wafflebase/frontend exec playwright install chromium`.");
+      process.exit(1);
+    }
+    throw error;
+  }
+}
+
+function matches(fired, expected) {
+  return fired.some((f) => f.kind === expected.kind && (expected.rule === undefined || f.rule === expected.rule));
+}
+
+const playwright = await loadPlaywright();
+const server = await createServer({
+  configFile: path.resolve(frontendRoot, "vite.config.ts"),
+  root: frontendRoot,
+  logLevel: "silent",
+  server: { host: HOST, port: PORT, strictPort: true },
+});
+
+let browser;
+const failures = [];
+try {
+  await server.listen();
+  const baseUrl = `http://${HOST}:${PORT}`;
+  browser = await playwright.chromium.launch({ headless: true });
+
+  for (const testCase of CASES) {
+    // A fresh context per case, so one case's injected damage cannot leak into the
+    // next and make a later oracle look like it fired on its own.
+    const context = await browser.newContext({
+      viewport: { width: 1600, height: 1200 },
+      locale: "en-US",
+      timezoneId: "UTC",
+      colorScheme: "light",
+    });
+    try {
+      const page = await context.newPage();
+      await page.route("**/auth/**", (route) =>
+        route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ styles: {} }) }),
+      );
+      const oracles = attachOracles(page, baseUrl);
+      await page.goto(`${baseUrl}/harness/hunt?surface=doc`, { waitUntil: "networkidle" });
+      await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+      // Drain anything from page load itself. A case asserts about ITS fault, and a
+      // load-time event would otherwise be credited to the injection.
+      oracles.drain();
+
+      await testCase.inject(page);
+      await page.waitForTimeout(120);
+      const fired = [...oracles.drain(), ...(await scanDomInvariants(page, HOST_TESTID))];
+
+      if (testCase.expect === null) {
+        if (fired.length > 0) {
+          failures.push(`${testCase.name}: expected silence, got ${JSON.stringify(fired)}`);
+        } else {
+          console.log(`[verify:hunt-oracles] quiet as required: ${testCase.name}`);
+        }
+      } else if (!matches(fired, testCase.expect)) {
+        failures.push(
+          `${testCase.name}: expected ${JSON.stringify(testCase.expect)}, got ${JSON.stringify(fired) || "nothing"}`,
+        );
+      } else {
+        console.log(`[verify:hunt-oracles] fired as required: ${testCase.name}`);
+      }
+    } finally {
+      await context.close();
+    }
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("Executable doesn't exist") || message.includes("download new browsers")) {
+    console.error("[verify:hunt-oracles] Chromium is not installed for this Playwright version.");
+    console.error("[verify:hunt-oracles] Run `pnpm --filter @wafflebase/frontend exec playwright install chromium`.");
+    process.exit(1);
+  }
+  throw error;
+} finally {
+  if (browser) await browser.close();
+  await server.close();
+}
+
+if (failures.length > 0) {
+  console.error(`\n[verify:hunt-oracles] ${failures.length} oracle check(s) FAILED:`);
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+console.log(`[verify:hunt-oracles] all ${CASES.length} oracle checks passed.`);

--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -29,6 +29,11 @@ const PORT = Number(process.env.HUNT_ORACLES_PORT || 4178);
 const READY_SELECTOR = "[data-testid='hunt-harness-root'][data-hunt-harness-ready='true']";
 const HOST_TESTID = "hunt-harness-host";
 
+/** How long silence must hold before a negative control counts as quiet. */
+const QUIET_WINDOW_MS = 250;
+/** How long a positive control may take to fire before it counts as a miss. */
+const FIRE_DEADLINE_MS = 5_000;
+
 /**
  * Each case injects one fault and names the oracle that must notice.
  *
@@ -117,6 +122,23 @@ const CASES = [
     },
   },
   {
+    // Separate from the "undefined" case above, and not redundant with it: the
+    // original regex wrapped one \b(...)\b around the whole alternation, which
+    // matched "undefined" and "NaN" fine but required a word character immediately
+    // outside the brackets of "[object Object]" — so the most common React
+    // stringification bug of all was the one alternative that never fired. A test
+    // that only injects "undefined" passes either way and proves nothing about it.
+    name: "dom-invariant on a bare [object Object]",
+    expect: { kind: "dom-invariant", rule: "placeholder-text" },
+    inject: async (page) => {
+      await page.evaluate(() => {
+        const el = document.createElement("div");
+        el.textContent = "[object Object]";
+        document.body.appendChild(el);
+      });
+    },
+  },
+  {
     // The other scoping rule: a user's DOCUMENT may legitimately contain the word
     // "undefined". Only the application's own chrome may not. Without this the first
     // thing a typing agent does is trip the oracle on its own input.
@@ -125,13 +147,49 @@ const CASES = [
     inject: async (page) => {
       await page.evaluate((hostTestId) => {
         const host = document.querySelector(`[data-testid="${hostTestId}"]`);
+        // Throw rather than `host?.appendChild`. If the host selector ever drifts,
+        // the optional-chaining form injects NOTHING, the oracle stays quiet, and
+        // this negative control PASSES for entirely the wrong reason — a vacuous
+        // test that asserts the scan ignores text it was never shown.
+        if (!host) throw new Error(`negative control cannot run: no [data-testid="${hostTestId}"]`);
         const el = document.createElement("div");
         el.textContent = "the user typed undefined here";
-        host?.appendChild(el);
+        host.appendChild(el);
       }, HOST_TESTID);
     },
   },
 ];
+
+/**
+ * Cell-click targeting, checked alongside the oracles because it fails the same way:
+ * silently, and only in the direction of wrong findings.
+ *
+ * `sheet.cellCenter` is the ONLY way to click something that exists purely as pixels
+ * on a canvas. When it is wrong, every probe still succeeds — the click lands, the
+ * page reacts, nothing errors — it just acts on the wrong cell, and a hunter reading
+ * the result concludes the app mis-handles selection. Measured live: an origin error
+ * of 43px made "click C3" select C1.
+ */
+const TARGETING_CELLS = ["A1", "A2", "A3", "B2", "C3", "D5"];
+
+async function checkCellTargeting(page, baseUrl) {
+  const problems = [];
+  await page.goto(`${baseUrl}/harness/hunt?surface=sheet`, { waitUntil: "networkidle" });
+  await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+  for (const ref of TARGETING_CELLS) {
+    const point = await page.evaluate((r) => window.__WB_HUNT__.read("sheet.cellCenter", [r]), ref);
+    if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) {
+      problems.push(`sheet.cellCenter(${ref}) returned ${JSON.stringify(point)}`);
+      continue;
+    }
+    await page.mouse.click(point.x, point.y);
+    const active = await page.evaluate(() => window.__WB_HUNT__.read("sheet.activeCell"));
+    if (active !== ref) {
+      problems.push(`clicking sheet.cellCenter(${ref}) at (${point.x},${point.y}) selected ${active}`);
+    }
+  }
+  return problems;
+}
 
 async function loadPlaywright() {
   try {
@@ -190,8 +248,30 @@ try {
       oracles.drain();
 
       await testCase.inject(page);
-      await page.waitForTimeout(120);
-      const fired = [...oracles.drain(), ...(await scanDomInvariants(page, HOST_TESTID))];
+
+      // Positive and negative cases need opposite waiting strategies, and a single
+      // fixed sleep gets one of them wrong. Proving something DID happen can stop as
+      // soon as it happens, so poll — a fixed delay there is either flaky (too short
+      // on a loaded machine) or slow. Proving something did NOT happen has no early
+      // exit: the full window must elapse before silence means anything.
+      let fired = [];
+      if (testCase.expect === null) {
+        await page.waitForTimeout(QUIET_WINDOW_MS);
+        fired = [...oracles.drain(), ...(await scanDomInvariants(page, HOST_TESTID))];
+      } else {
+        const deadline = Date.now() + FIRE_DEADLINE_MS;
+        // Page-event drains ACCUMULATE (each drain empties the buffer, so an event
+        // seen on an earlier poll would be lost); the DOM scan is a fresh snapshot of
+        // current state each time and must replace, not append, or a finding would be
+        // duplicated once per poll in the failure message.
+        const drained = [];
+        for (;;) {
+          drained.push(...oracles.drain());
+          fired = [...drained, ...(await scanDomInvariants(page, HOST_TESTID))];
+          if (matches(fired, testCase.expect) || Date.now() >= deadline) break;
+          await page.waitForTimeout(25);
+        }
+      }
 
       if (testCase.expect === null) {
         if (fired.length > 0) {
@@ -209,6 +289,24 @@ try {
     } finally {
       await context.close();
     }
+  }
+
+  // Targeting, in its own context so no injected fault from the cases above can
+  // perturb the grid it measures.
+  const targetingContext = await browser.newContext({
+    viewport: { width: 1600, height: 1200 },
+    locale: "en-US",
+    timezoneId: "UTC",
+    colorScheme: "light",
+  });
+  try {
+    const problems = await checkCellTargeting(await targetingContext.newPage(), baseUrl);
+    for (const p of problems) failures.push(`cell targeting: ${p}`);
+    if (problems.length === 0) {
+      console.log(`[verify:hunt-oracles] cell clicks land correctly: ${TARGETING_CELLS.join(", ")}`);
+    }
+  } finally {
+    await targetingContext.close();
   }
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
@@ -228,4 +326,4 @@ if (failures.length > 0) {
   for (const f of failures) console.error(`  - ${f}`);
   process.exit(1);
 }
-console.log(`[verify:hunt-oracles] all ${CASES.length} oracle checks passed.`);
+console.log(`[verify:hunt-oracles] all ${CASES.length} oracle checks + cell targeting passed.`);

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -22,6 +22,26 @@ const InteractionHarnessPage = lazy(
   () => import("@/app/harness/interaction/page"),
 );
 const DocsHarnessPage = lazy(() => import("@/app/harness/docs/page"));
+/**
+ * DEV-only, unlike the three harness routes above, and the reason is measurable.
+ *
+ * This one mounts the real `DocsFormattingToolbar`, which makes it a SECOND
+ * separately-split importer of modules previously reached only through `docs-view`.
+ * Vite responds with the usual second-importer hoist, and a production build gained
+ * SEVEN chunks (147 -> 154): the route itself plus `docs-view`, `docx-actions`,
+ * `use-mobile`, `button`, `IconHash` and `IconPalette` lifted out of the docs route
+ * chunk. That changes the download shape of a real user-facing route to serve a page
+ * no user can reach.
+ *
+ * `import.meta.env.DEV` is statically replaced at build time, so the import edge
+ * disappears from the production graph entirely and the count returns to 147. The
+ * browser lanes are unaffected: they all run against `vite` dev servers created in
+ *-process (`verify-interaction-browser.mjs`, `verify-hunt-oracles.mjs`,
+ * `hunt-ui-runner.mjs`), where DEV is true.
+ */
+const HuntHarnessPage = import.meta.env.DEV
+  ? lazy(() => import("@/app/harness/hunt/page"))
+  : null;
 const DocsDetail = lazy(() => import("@/app/docs/docs-detail"));
 const SlidesDetail = lazy(() => import("@/app/slides/slides-detail"));
 const FileDetail = lazy(() => import("@/app/files/file-detail"));
@@ -66,6 +86,9 @@ function App() {
                   element={<InteractionHarnessPage />}
                 />
                 <Route path="/harness/docs" element={<DocsHarnessPage />} />
+                {HuntHarnessPage && (
+                  <Route path="/harness/hunt" element={<HuntHarnessPage />} />
+                )}
                 <Route path="/shared/:token" element={<SharedDocument />} />
                 <Route path="/" element={<HomeOrRedirect />} />
                 <Route element={<PrivateRoute />}>

--- a/packages/frontend/src/app/harness/hunt/bridge.ts
+++ b/packages/frontend/src/app/harness/hunt/bridge.ts
@@ -19,7 +19,7 @@
 // pipeline downstream assumes the action list is the complete causal history. If you
 // need to change something, that is an action, not a reader.
 
-import type { Block, EditorAPI, Inline, InlineStyle } from "@wafflebase/docs";
+import type { Block, EditorAPI, InlineStyle } from "@wafflebase/docs";
 import { parseRef, toSref, type MemStore, type Spreadsheet } from "@wafflebase/sheets";
 
 export const HUNT_BRIDGE_KEY = "__WB_HUNT__";
@@ -115,7 +115,7 @@ function runsOf(editor: EditorAPI): RunSnapshot[] {
   const blocks: Block[] = editor.getDoc().getContextBlocks();
   const out: RunSnapshot[] = [];
   blocks.forEach((block, blockIndex) => {
-    for (const inline of block.inlines as Inline[]) {
+    for (const inline of block.inlines) {
       const style: InlineStyle = inline.style ?? {};
       out.push({
         blockIndex,
@@ -221,11 +221,31 @@ function buildReaders(state: BridgeState): Record<string, (args: unknown[]) => u
       const sref = asString(args, 0, "sheet.cellCenter");
       const { spreadsheet, host } = requireSheet(state);
       const rect = spreadsheet.getCellRect(parseRef(sref));
-      const hostRect = host.getBoundingClientRect();
-      return {
-        x: Math.round(hostRect.left + rect.left + rect.width / 2),
-        y: Math.round(hostRect.top + rect.top + rect.height / 2),
-      };
+      // Origin is the GRID CANVAS, not the mount container. `getCellRect` is
+      // canvas-relative, and the engine paints a band of its own chrome above the
+      // canvas — measured at 43px here (container top 41, canvas top 84). Adding the
+      // container's origin instead puts every point that many pixels high, which
+      // silently lands clicks one or two rows off: asking for C3 selected C1.
+      //
+      // `getCellCenterClientPoint` in the interaction harness has the same formula
+      // and the same error; it goes unnoticed there because that lane only ever
+      // `mouse.move`s to the point for a wheel event, and a scroll does not care
+      // which row it starts on. Nothing in this repo has clicked a cell by
+      // coordinate before, so this is the first use that could expose it.
+      const canvas = host.querySelector("canvas");
+      if (!canvas) {
+        refuse(`sheet.cellCenter(${sref}) has no grid canvas to measure against — is the sheet mounted?`);
+      }
+      const origin = canvas.getBoundingClientRect();
+      const x = Math.round(origin.left + rect.left + rect.width / 2);
+      const y = Math.round(origin.top + rect.top + rect.height / 2);
+      // Refuse here rather than hand back NaN. A caller clicking at NaN gets an
+      // opaque Playwright error pointing at the mouse, not at the cell reference or
+      // the unmeasurable host that actually caused it.
+      if (!Number.isFinite(x) || !Number.isFinite(y)) {
+        refuse(`sheet.cellCenter(${sref}) resolved to a non-finite point (${x}, ${y}) — is the grid laid out?`);
+      }
+      return { x, y };
     },
   };
 }

--- a/packages/frontend/src/app/harness/hunt/bridge.ts
+++ b/packages/frontend/src/app/harness/hunt/bridge.ts
@@ -1,0 +1,282 @@
+// The UI hunter's SENSOR — a closed set of named questions the page will answer
+// about itself.
+//
+// WHY THIS EXISTS. Sheets, docs and slides render to Canvas. A browser-automation
+// tool that reads the DOM sees one opaque <canvas> rectangle where all the content
+// is: the accessibility tree covers the React chrome (toolbar, menus, dialogs) and
+// essentially nothing else. So the standard web-agent approach — snapshot the a11y
+// tree, reason about it — is blind to the actual product here. This bridge is what
+// replaces it, and it is the primary sensor rather than a convenience.
+//
+// WHY IT IS A CLOSED REGISTRY AND NOT `page.evaluate(<model-authored JS>)`. The
+// caller names a reader; it cannot supply code. An unknown name is refused with the
+// list of valid ones. That keeps the eventual model-driven caller (PR 3) bounded by
+// code reviewed in this repository rather than by a prompt, which is the same
+// property `assertSafeArgv` gives the CLI hunter.
+//
+// INVARIANT: every reader is a PURE READ. A reader that focused a cell or committed
+// an edit would make observation indistinguishable from interaction, and the whole
+// pipeline downstream assumes the action list is the complete causal history. If you
+// need to change something, that is an action, not a reader.
+
+import type { Block, EditorAPI, Inline, InlineStyle } from "@wafflebase/docs";
+import { parseRef, toSref, type MemStore, type Spreadsheet } from "@wafflebase/sheets";
+
+export const HUNT_BRIDGE_KEY = "__WB_HUNT__";
+
+export type HuntSurface = "sheet" | "doc";
+
+export type SheetHandle = {
+  spreadsheet: Spreadsheet;
+  store: MemStore;
+  host: HTMLElement;
+};
+
+export type DocHandle = {
+  editor: EditorAPI;
+  host: HTMLElement;
+};
+
+/** A flattened text run — one `Inline`, with the style fields worth asserting on. */
+export type RunSnapshot = {
+  blockIndex: number;
+  text: string;
+  fontSize?: number;
+  fontFamily?: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  href?: string;
+};
+
+type BridgeState = {
+  ready: boolean;
+  surface: HuntSurface;
+  sheet: SheetHandle | null;
+  doc: DocHandle | null;
+};
+
+export type HuntBridge = {
+  ready(): boolean;
+  surface(): HuntSurface;
+  readers(): string[];
+  read(name: string, args?: unknown[]): Promise<unknown>;
+};
+
+export type HuntBridgeController = {
+  bridge: HuntBridge;
+  setReady(ready: boolean): void;
+  setSurface(surface: HuntSurface): void;
+  setSheet(handle: SheetHandle | null): void;
+  setDoc(handle: DocHandle | null): void;
+  dispose(): void;
+};
+
+/**
+ * Thrown when a reader cannot run. Carried across `page.evaluate` as a plain
+ * message, which the driver turns into a readable refusal rather than a crash —
+ * "you asked for something that does not exist" must not look like "the app broke".
+ */
+function refuse(message: string): never {
+  throw new Error(`[hunt-bridge] ${message}`);
+}
+
+function requireSheet(state: BridgeState): SheetHandle {
+  if (!state.sheet) {
+    refuse(`sheet reader used while surface is "${state.surface}" — goto the sheet surface first`);
+  }
+  return state.sheet;
+}
+
+function requireDoc(state: BridgeState): DocHandle {
+  if (!state.doc) {
+    refuse(`doc reader used while surface is "${state.surface}" — goto the doc surface first`);
+  }
+  return state.doc;
+}
+
+function asString(args: unknown[], i: number, reader: string): string {
+  const v = args[i];
+  if (typeof v !== "string" || v === "") {
+    refuse(`${reader} needs a non-empty string argument at position ${i}, got ${JSON.stringify(v)}`);
+  }
+  return v;
+}
+
+/**
+ * Flatten the body blocks into runs.
+ *
+ * `getContextBlocks()` is the editor's own notion of "the blocks currently being
+ * edited" (body, or header/footer when that context is active), so a reader built on
+ * it observes what the user is actually looking at rather than a fixed region.
+ */
+function runsOf(editor: EditorAPI): RunSnapshot[] {
+  const blocks: Block[] = editor.getDoc().getContextBlocks();
+  const out: RunSnapshot[] = [];
+  blocks.forEach((block, blockIndex) => {
+    for (const inline of block.inlines as Inline[]) {
+      const style: InlineStyle = inline.style ?? {};
+      out.push({
+        blockIndex,
+        text: inline.text,
+        fontSize: style.fontSize,
+        fontFamily: style.fontFamily,
+        bold: style.bold,
+        italic: style.italic,
+        underline: style.underline,
+        strikethrough: style.strikethrough,
+        href: style.href,
+      });
+    }
+  });
+  return out;
+}
+
+/**
+ * The reader registry.
+ *
+ * Names are namespaced by surface so the driver can route without guessing, and so
+ * `dom.*` readers (which need Playwright locators, not page state) can live in the
+ * driver without colliding. Adding a reader here is the intended way to widen what
+ * the hunter can observe — adding an escape hatch is not.
+ */
+function buildReaders(state: BridgeState): Record<string, (args: unknown[]) => unknown> {
+  return {
+    // --- docs -------------------------------------------------------------
+    "doc.text": () =>
+      requireDoc(state)
+        .editor.getDoc()
+        .getContextBlocks()
+        .map((b) => b.inlines.map((i) => i.text).join(""))
+        .join("\n"),
+
+    "doc.blockCount": () => requireDoc(state).editor.getDoc().getContextBlocks().length,
+
+    /** Every run with its style — the general reader most doc expectations build on. */
+    "doc.runs": () => runsOf(requireDoc(state).editor),
+
+    /**
+     * Font size per run, in document order.
+     *
+     * Derived from `doc.runs` rather than stored separately so the two can never
+     * disagree. This is the reader issue #343 turns on: "increase font size on a
+     * mixed-size selection" must raise every entry, and the bug is that it collapses
+     * them all to the minimum.
+     */
+    "doc.fontSizes": () => runsOf(requireDoc(state).editor).map((r) => r.fontSize),
+
+    "doc.blockTypes": () =>
+      requireDoc(state)
+        .editor.getDoc()
+        .getContextBlocks()
+        .map((b) => b.type),
+
+    /** What the toolbar itself reads — `number | 'mixed' | undefined` per property. */
+    "doc.styleSummary": () => requireDoc(state).editor.getRangeStyleSummary(),
+
+    "doc.selection": () => {
+      const sel = requireDoc(state).editor.getActiveSelection();
+      if (!sel) return null;
+      return {
+        anchor: { blockId: sel.anchor.blockId, offset: sel.anchor.offset },
+        focus: { blockId: sel.focus.blockId, offset: sel.focus.offset },
+      };
+    },
+
+    "doc.linkCount": () => runsOf(requireDoc(state).editor).filter((r) => typeof r.href === "string").length,
+
+    // --- sheets -----------------------------------------------------------
+    "sheet.cellValue": async (args) => {
+      const sref = asString(args, 0, "sheet.cellValue");
+      const cell = await requireSheet(state).store.get(parseRef(sref));
+      return cell?.v ?? null;
+    },
+
+    "sheet.cellFormula": async (args) => {
+      const sref = asString(args, 0, "sheet.cellFormula");
+      const cell = await requireSheet(state).store.get(parseRef(sref));
+      return cell?.f ?? null;
+    },
+
+    "sheet.activeCell": () => {
+      const active = requireSheet(state).spreadsheet.getActiveCell();
+      return active ? toSref(active) : null;
+    },
+
+    "sheet.selectionRange": () => {
+      const range = requireSheet(state).spreadsheet.getSelectionRangeOrActiveCell();
+      if (!range) return null;
+      return { start: toSref(range[0]), end: toSref(range[1]) };
+    },
+
+    /**
+     * Viewport coordinates of a cell's centre.
+     *
+     * This is how a caller clicks something that only exists as pixels on a canvas:
+     * the grid has no DOM node per cell, so only the engine can say where `B2` is.
+     * Mirrors `getCellCenterClientPoint` in the interaction harness.
+     */
+    "sheet.cellCenter": (args) => {
+      const sref = asString(args, 0, "sheet.cellCenter");
+      const { spreadsheet, host } = requireSheet(state);
+      const rect = spreadsheet.getCellRect(parseRef(sref));
+      const hostRect = host.getBoundingClientRect();
+      return {
+        x: Math.round(hostRect.left + rect.left + rect.width / 2),
+        y: Math.round(hostRect.top + rect.top + rect.height / 2),
+      };
+    },
+  };
+}
+
+/**
+ * Install the bridge on `window` and return the handles the page uses to keep it
+ * current. The page owns mounting; this owns answering questions about what is
+ * mounted.
+ */
+export function installHuntBridge(): HuntBridgeController {
+  const state: BridgeState = { ready: false, surface: "sheet", sheet: null, doc: null };
+  const readers = buildReaders(state);
+
+  const bridge: HuntBridge = {
+    ready: () => state.ready,
+    surface: () => state.surface,
+    readers: () => Object.keys(readers).sort(),
+    read: async (name, args = []) => {
+      const reader = readers[name];
+      if (!reader) {
+        refuse(`unknown reader ${JSON.stringify(name)}. Valid readers: ${Object.keys(readers).sort().join(", ")}`);
+      }
+      // Awaited here so a rejected reader surfaces as a refusal from `read` rather
+      // than as an unhandled rejection inside the page — which the crash oracle
+      // would then report as a defect in the app under test.
+      return await reader(Array.isArray(args) ? args : []);
+    },
+  };
+
+  const owner = window as unknown as Record<string, unknown>;
+  owner[HUNT_BRIDGE_KEY] = bridge;
+
+  return {
+    bridge,
+    setReady: (ready) => {
+      state.ready = ready;
+    },
+    setSurface: (surface) => {
+      state.surface = surface;
+    },
+    setSheet: (handle) => {
+      state.sheet = handle;
+    },
+    setDoc: (handle) => {
+      state.doc = handle;
+    },
+    dispose: () => {
+      state.ready = false;
+      state.sheet = null;
+      state.doc = null;
+      if (owner[HUNT_BRIDGE_KEY] === bridge) delete owner[HUNT_BRIDGE_KEY];
+    },
+  };
+}

--- a/packages/frontend/src/app/harness/hunt/page.tsx
+++ b/packages/frontend/src/app/harness/hunt/page.tsx
@@ -1,0 +1,204 @@
+// The UI hunter's target surface — real engines, real toolbar, fake storage.
+//
+// WHY A SEPARATE ROUTE FROM /harness/visual AND /harness/interaction. Those two are
+// built for what they measure: `visual` mounts scenes READ-ONLY for screenshot
+// diffing, and `interaction` mounts a bare `Spreadsheet` with no chrome. Neither can
+// exercise a toolbar, and a toolbar is where a large share of the product's real
+// defects live — every UI bug the design doc cites (#343, #494, #333) is reached
+// through one.
+//
+// So this route mounts the REAL engines over IN-MEMORY stores and hangs the REAL
+// `DocsFormattingToolbar` off the editor. `MemStore`/`MemDocStore` mean there is no
+// backend, no login, no docker, and nothing a probe does can touch real data —
+// safety is a property of what is mounted rather than a rule the driver must respect.
+//
+// SURFACE SELECTION IS A QUERY PARAM, not bridge state. `?surface=doc` remounts from
+// a fixed seed, mirroring `/harness/visual?section=…`. Navigation is therefore the
+// reset primitive: every run starts from a byte-identical document, which is what
+// makes a 3x replay comparable at all.
+
+import {
+  DEFAULT_BLOCK_STYLE,
+  DEFAULT_PAGE_SETUP,
+  MemDocStore,
+  generateBlockId,
+  initialize as initializeDocs,
+  type Block,
+  type Document as DocsDocument,
+  type EditorAPI,
+} from "@wafflebase/docs";
+import {
+  MemStore,
+  initialize as initializeSheet,
+  type Grid,
+  type Spreadsheet,
+} from "@wafflebase/sheets";
+import { useEffect, useRef, useState } from "react";
+
+import { DocsFormattingToolbar } from "@/app/docs/docs-formatting-toolbar";
+
+import { installHuntBridge, type HuntSurface } from "./bridge";
+
+type HarnessStatus = "loading" | "ready" | "error";
+
+function useSurfaceFromSearchParams(): HuntSurface {
+  try {
+    const surface = new URLSearchParams(window.location.search).get("surface");
+    return surface === "doc" ? "doc" : "sheet";
+  } catch {
+    return "sheet";
+  }
+}
+
+/**
+ * The doc seed.
+ *
+ * Block 0 deliberately carries THREE different font sizes on one line. That is the
+ * exact shape issue #343 needs — "increasing font size on a mixed-size selection
+ * resets to the minimum" is unobservable on uniformly-sized text — and it is the
+ * same shape `harness/visual/docs-scenarios.tsx` uses for its baseline. Duplicated
+ * rather than imported: coupling two harnesses means a change made for a screenshot
+ * silently changes what the hunter explores.
+ */
+function seedDocument(): DocsDocument {
+  const mixed: Block = {
+    id: generateBlockId(),
+    type: "paragraph",
+    inlines: [
+      { text: "Small ", style: { fontSize: 11 } },
+      { text: "Medium ", style: { fontSize: 18 } },
+      { text: "LARGE", style: { fontSize: 32, bold: true } },
+    ],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  };
+  const plain: Block = {
+    id: generateBlockId(),
+    type: "paragraph",
+    inlines: [{ text: "The quick brown fox jumps over the lazy dog.", style: {} }],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  };
+  const styled: Block = {
+    id: generateBlockId(),
+    type: "paragraph",
+    inlines: [
+      { text: "Bold start ", style: { bold: true } },
+      { text: "then italic ", style: { italic: true } },
+      { text: "then plain.", style: {} },
+    ],
+    style: { ...DEFAULT_BLOCK_STYLE },
+  };
+  return { blocks: [mixed, plain, styled], pageSetup: DEFAULT_PAGE_SETUP };
+}
+
+/** The sheet seed — values, a formula to recalculate, and rows to scroll through. */
+function seedGrid(): Grid {
+  const grid: Grid = new Map([
+    ["A1", { v: "10" }],
+    ["A2", { v: "20" }],
+    ["A3", { v: "30" }],
+    ["B1", { v: "Label" }],
+    ["C1", { f: "=A1+A2", v: "30" }],
+  ]);
+  for (let row = 2; row <= 60; row++) {
+    grid.set(`D${row}`, { v: `Row ${row}` });
+  }
+  return grid;
+}
+
+export default function HuntHarnessPage() {
+  const surface = useSurfaceFromSearchParams();
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState<HarnessStatus>("loading");
+  // The toolbar is a React child of this page, so the editor has to reach it through
+  // state rather than a ref — a ref assignment would not re-render and the toolbar
+  // would stay permanently disabled.
+  const [editor, setEditor] = useState<EditorAPI | null>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return undefined;
+
+    // One effect owns install + mount + teardown. Split across two effects this is
+    // correct but fiddly to reason about under StrictMode's mount/unmount/remount;
+    // keeping it in one makes the ordering obvious and the cleanup total.
+    const controller = installHuntBridge();
+    controller.setSurface(surface);
+
+    let disposed = false;
+    let spreadsheet: Spreadsheet | undefined;
+    let docEditor: EditorAPI | undefined;
+
+    async function mount() {
+      setStatus("loading");
+      host!.innerHTML = "";
+      try {
+        if (surface === "doc") {
+          const store = new MemDocStore();
+          store.setDocument(seedDocument());
+          docEditor = initializeDocs(host!, store, "light", /* readOnly */ false);
+          if (disposed) return;
+          controller.setDoc({ editor: docEditor, host: host! });
+          setEditor(docEditor);
+        } else {
+          const store = new MemStore(seedGrid());
+          await store.setDimensionSize("column", 1, 110);
+          await store.setDimensionSize("column", 2, 160);
+          await store.setDimensionSize("column", 3, 180);
+          await store.setDimensionSize("column", 4, 260);
+          spreadsheet = await initializeSheet(host!, { theme: "light", store });
+          if (disposed) return;
+          await spreadsheet.focusCell({ r: 1, c: 1 });
+          controller.setSheet({ spreadsheet, store, host: host! });
+        }
+        if (disposed) return;
+        // Ready is set LAST, after the surface is mounted and registered. The driver
+        // gates on it, so flipping it earlier would let a probe act on a half-built
+        // page and record the resulting mess as a defect.
+        controller.setReady(true);
+        setStatus("ready");
+      } catch (error) {
+        console.error("[hunt-harness] failed to initialize", error);
+        if (!disposed) setStatus("error");
+      }
+    }
+
+    void mount();
+
+    return () => {
+      disposed = true;
+      setEditor(null);
+      controller.dispose();
+      docEditor?.dispose();
+      spreadsheet?.cleanup();
+      host.innerHTML = "";
+    };
+  }, [surface]);
+
+  return (
+    <main
+      className="flex h-screen flex-col overflow-clip bg-muted/20"
+      data-testid="hunt-harness-root"
+      data-hunt-harness-ready={status === "ready" ? "true" : "false"}
+      data-hunt-harness-status={status}
+      data-hunt-harness-surface={surface}
+    >
+      <header className="border-b bg-card px-4 py-2">
+        <span className="text-xs text-muted-foreground">
+          Wafflebase Hunt Harness — surface:{" "}
+          <span data-testid="hunt-harness-surface">{surface}</span>, status:{" "}
+          <span data-testid="hunt-harness-status">{status}</span>
+        </span>
+      </header>
+
+      {surface === "doc" && (
+        <div className="border-b bg-background" data-testid="hunt-harness-toolbar">
+          <DocsFormattingToolbar editor={editor} />
+        </div>
+      )}
+
+      <section className="min-h-0 flex-1 overflow-hidden bg-white">
+        <div className="h-full w-full" data-testid="hunt-harness-host" ref={hostRef} />
+      </section>
+    </main>
+  );
+}

--- a/packages/frontend/src/app/harness/hunt/page.tsx
+++ b/packages/frontend/src/app/harness/hunt/page.tsx
@@ -128,16 +128,49 @@ export default function HuntHarnessPage() {
     let spreadsheet: Spreadsheet | undefined;
     let docEditor: EditorAPI | undefined;
 
+    /**
+     * This mount's OWN container, not the shared host.
+     *
+     * Two facts collide here, and the isolation is what keeps them apart.
+     *
+     * First, the sheet branch awaits before it can assign `spreadsheet`, so an
+     * unmount landing mid-await leaves the teardown's `spreadsheet?.cleanup()` with
+     * nothing to clean; the promise then resolves into a live engine — RAF loop and
+     * listeners — that nothing ever disposes. StrictMode's mount/unmount/remount
+     * makes that the normal dev path.
+     *
+     * Second, and this is what makes the obvious fix wrong: disposing that abandoned
+     * engine tears down whatever DOM it was given, and by then the NEXT mount has
+     * already painted into the same host. Cleaning up the stale engine therefore
+     * deletes the live canvas. Measured, not theorised — the first attempt at this
+     * fix left the sheet surface with no canvas at all, which the bridge readers
+     * cannot see because they read the engine rather than the DOM.
+     *
+     * Giving every mount its own child means a stale cleanup operates on a node that
+     * was already detached, and the live mount is untouched.
+     */
+    const container = document.createElement("div");
+    container.style.width = "100%";
+    container.style.height = "100%";
+
+    const disposeMounted = () => {
+      docEditor?.dispose();
+      docEditor = undefined;
+      spreadsheet?.cleanup();
+      spreadsheet = undefined;
+      container.remove();
+    };
+
     async function mount() {
       setStatus("loading");
-      host!.innerHTML = "";
+      host!.replaceChildren(container);
       try {
         if (surface === "doc") {
           const store = new MemDocStore();
           store.setDocument(seedDocument());
-          docEditor = initializeDocs(host!, store, "light", /* readOnly */ false);
-          if (disposed) return;
-          controller.setDoc({ editor: docEditor, host: host! });
+          docEditor = initializeDocs(container, store, "light", /* readOnly */ false);
+          if (disposed) return disposeMounted();
+          controller.setDoc({ editor: docEditor, host: container });
           setEditor(docEditor);
         } else {
           const store = new MemStore(seedGrid());
@@ -145,12 +178,12 @@ export default function HuntHarnessPage() {
           await store.setDimensionSize("column", 2, 160);
           await store.setDimensionSize("column", 3, 180);
           await store.setDimensionSize("column", 4, 260);
-          spreadsheet = await initializeSheet(host!, { theme: "light", store });
-          if (disposed) return;
+          spreadsheet = await initializeSheet(container, { theme: "light", store });
+          if (disposed) return disposeMounted();
           await spreadsheet.focusCell({ r: 1, c: 1 });
-          controller.setSheet({ spreadsheet, store, host: host! });
+          controller.setSheet({ spreadsheet, store, host: container });
         }
-        if (disposed) return;
+        if (disposed) return disposeMounted();
         // Ready is set LAST, after the surface is mounted and registered. The driver
         // gates on it, so flipping it earlier would let a probe act on a half-built
         // page and record the resulting mess as a defect.
@@ -168,9 +201,9 @@ export default function HuntHarnessPage() {
       disposed = true;
       setEditor(null);
       controller.dispose();
-      docEditor?.dispose();
-      spreadsheet?.cleanup();
-      host.innerHTML = "";
+      // Removes only THIS mount's container; a later mount's container is a sibling
+      // this closure never sees, so teardown cannot reach across into it.
+      disposeMounted();
     };
   }, [surface]);
 

--- a/scripts/agent/hunt-ui-probe.mjs
+++ b/scripts/agent/hunt-ui-probe.mjs
@@ -53,6 +53,10 @@ export const UI_READER_PREFIXES = Object.freeze(["doc.", "sheet.", "dom."]);
 const DEFAULT_ATTEMPTS = 1;
 /** Beyond this a value is keyed by hash — a `dom.snapshot` must not become the key. */
 const MAX_INLINE_VALUE_CHARS = 200;
+/** Mouse buttons Playwright accepts. */
+const CLICK_BUTTONS = Object.freeze(["left", "right", "middle"]);
+/** Enough for a triple-click; anything more is a typo or a hang. */
+const MAX_CLICK_COUNT = 3;
 
 // --- plan validation ---------------------------------------------------------
 
@@ -105,6 +109,19 @@ export function assertSafeActionPlan(plan) {
         break;
       case "click":
         assertTarget(action.target, where);
+        // `button` and `clickCount` are forwarded straight to Playwright, so an
+        // unvalidated value fails inside the browser driver rather than at plan
+        // validation — and `clickCount: 1e6` would not fail at all, it would hang.
+        // The vocabulary is closed everywhere else; these two were the gap.
+        if (action.button !== undefined && !CLICK_BUTTONS.includes(action.button)) {
+          bad(`${where} button must be one of ${CLICK_BUTTONS.join(", ")}, got ${JSON.stringify(action.button)}`);
+        }
+        if (
+          action.clickCount !== undefined &&
+          (!Number.isInteger(action.clickCount) || action.clickCount < 1 || action.clickCount > MAX_CLICK_COUNT)
+        ) {
+          bad(`${where} clickCount must be an integer in 1..${MAX_CLICK_COUNT}, got ${JSON.stringify(action.clickCount)}`);
+        }
         break;
       case "type":
         if (typeof action.text !== "string") bad(`${where} needs a string \`text\``);
@@ -201,11 +218,15 @@ export function uiObservedKey(observation) {
 /**
  * One key for a whole attempt.
  *
- * Position-independent comparison is deliberate: `replay()` keys only the LAST
- * observation, which for a CLI probe is the failing one but for a UI plan usually is
- * not — the failing action is commonly mid-sequence with reads after it. Folding
- * every observation in means a divergence anywhere in the plan is a divergence,
- * which is the property replay actually needs.
+ * `replay()` keys only the LAST observation, which for a CLI probe is the failing one
+ * but for a UI plan usually is not — the failing action is commonly mid-sequence with
+ * reads after it. Folding every observation in means a divergence ANYWHERE in the
+ * plan is a divergence, which is the property replay actually needs.
+ *
+ * Order is significant: the per-observation keys are joined in sequence, so the same
+ * outcomes in a different order hash differently. That is intended — two attempts of
+ * one plan execute the same actions in the same order, and if they did not, that is
+ * itself a divergence worth catching.
  */
 export function uiPlanKey(observations) {
   const parts = (Array.isArray(observations) ? observations : []).map(uiObservedKey);
@@ -236,11 +257,14 @@ export function oraclesFired(observations) {
  * observations. Infrastructure trouble must not be able to present itself as "the
  * app did nothing", which is a shape a caller could mistake for a finding.
  */
-export function runUiPlan(plan, { repoRoot, attempts = DEFAULT_ATTEMPTS, timeoutMs = 180_000, runner = null } = {}) {
+export function runUiPlan(
+  plan,
+  { repoRoot, attempts = DEFAULT_ATTEMPTS, timeoutMs = 180_000, port = 0, runner = null } = {},
+) {
   assertSafeActionPlan(plan);
   if (!Number.isInteger(attempts) || attempts < 1) bad(`attempts must be a positive integer, got ${attempts}`);
 
-  if (typeof runner === "function") return runner(plan, { repoRoot, attempts });
+  if (typeof runner === "function") return runner(plan, { repoRoot, attempts, port });
 
   const runnerPath = path.join(repoRoot, UI_RUNNER_REL);
   return withScratch((dir) => {
@@ -250,7 +274,10 @@ export function runUiPlan(plan, { repoRoot, attempts = DEFAULT_ATTEMPTS, timeout
 
     const res = spawnSync(
       process.execPath,
-      [runnerPath, "--plan", planFile, "--out", outFile, "--attempts", String(attempts)],
+      // Port 0 by default: the OS picks a free one. The runner's own default is a
+      // fixed port for reproducible manual runs, but two concurrent samples on a
+      // fixed port make the second fail to boot, and PR 4 runs samples concurrently.
+      [runnerPath, "--plan", planFile, "--out", outFile, "--attempts", String(attempts), "--port", String(port)],
       {
         cwd: path.join(repoRoot, "packages", "frontend"),
         timeout: timeoutMs,

--- a/scripts/agent/hunt-ui-probe.mjs
+++ b/scripts/agent/hunt-ui-probe.mjs
@@ -1,0 +1,273 @@
+// The agent-side half of the UI probe — validates an action plan, runs it, and
+// reduces what came back to a comparable SHAPE.
+//
+// WHY A SUBPROCESS AND NOT AN IMPORT. `playwright` does not resolve from this
+// directory. `scripts/agent` is a standalone npm package outside the pnpm workspace
+// with its own `node_modules`; playwright is a dependency of
+// `packages/frontend`. Verified, not assumed:
+//
+//   from packages/frontend :  import('playwright') -> ok, chromium present
+//   from scripts/agent     :  import('playwright') -> ERR_MODULE_NOT_FOUND
+//
+// Adding it here would duplicate a version that `run-browser-tests-docker.sh` pins
+// against `Dockerfile.playwright`, so the hunter and CI could silently disagree
+// about what a browser is. The driver therefore lives in `packages/frontend/scripts`
+// and this module spawns it.
+//
+// That boundary also keeps the async browser behind a SYNCHRONOUS call, which is
+// what lets `hunt-probe.mjs`'s `replay()` — a sync for-loop over `spawnSync` — be
+// reused unchanged instead of rewritten.
+//
+// NO THIRD-PARTY STATIC IMPORTS. `verify-self.mjs`'s `agent:tests` lane runs with
+// `scripts/agent/node_modules` ABSENT, so a static import of anything that is not
+// `node:` or relative makes every test in this file fail to load. `ask.test.mjs`
+// enforces this with a recursive walk; it is stated here too because prose
+// invariants get broken (that is exactly how #600 broke CI).
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { scrubVolatile } from "./hunt-fingerprint.mjs";
+import { withScratch } from "./hunt-probe.mjs";
+
+/** Relative to the repo root — the driver, which is where playwright resolves. */
+export const UI_RUNNER_REL = path.join("packages", "frontend", "scripts", "hunt-ui-runner.mjs");
+
+/**
+ * The complete action vocabulary. Closed on purpose: there is no "evaluate this
+ * JavaScript" action and no CSS selector, so a caller's reachable surface is bounded
+ * by code in this repository rather than by whatever it can phrase.
+ */
+export const UI_ACTION_TYPES = Object.freeze(["goto", "click", "type", "key", "scroll", "read", "wait"]);
+
+/**
+ * Reader namespaces. This is not a duplicate of the reader list — it is the ROUTING
+ * contract the driver implements (`dom.*` needs Playwright locators, everything else
+ * is the page's own bridge). The authoritative list of reader NAMES lives in the
+ * bridge, which refuses an unknown one at runtime with the valid set; checking the
+ * prefix here just fails a typo before paying for a browser boot.
+ */
+export const UI_READER_PREFIXES = Object.freeze(["doc.", "sheet.", "dom."]);
+
+const DEFAULT_ATTEMPTS = 1;
+/** Beyond this a value is keyed by hash — a `dom.snapshot` must not become the key. */
+const MAX_INLINE_VALUE_CHARS = 200;
+
+// --- plan validation ---------------------------------------------------------
+
+function bad(message) {
+  throw new Error(`hunt-ui-probe: ${message}`);
+}
+
+function assertReader(name, where) {
+  if (typeof name !== "string" || name === "") bad(`${where} needs a reader name, got ${JSON.stringify(name)}`);
+  if (!UI_READER_PREFIXES.some((p) => name.startsWith(p))) {
+    bad(`${where} reader ${JSON.stringify(name)} must start with one of ${UI_READER_PREFIXES.join(", ")}`);
+  }
+}
+
+function assertTarget(target, where) {
+  if (!target || typeof target !== "object") bad(`${where} needs a target object, got ${JSON.stringify(target)}`);
+  const hasRole = typeof target.role === "string" && target.role !== "";
+  const hasReader = typeof target.reader === "string" && target.reader !== "";
+  if (hasRole === hasReader) {
+    bad(`${where} target must have exactly one of \`role\` or \`reader\`, got ${JSON.stringify(target)}`);
+  }
+  if (hasReader) assertReader(target.reader, `${where} target`);
+  if (target.args !== undefined && !Array.isArray(target.args)) bad(`${where} target \`args\` must be an array`);
+}
+
+/**
+ * Validate an action plan, throwing on the first problem.
+ *
+ * Fails CLOSED, the same direction as `assertSafeArgv`: an action whose shape cannot
+ * be established is refused rather than passed through and interpreted loosely by
+ * the driver. Over-refusing costs one rejected plan; under-refusing means a caller
+ * reached something the vocabulary was supposed to bound.
+ */
+export function assertSafeActionPlan(plan) {
+  if (!plan || typeof plan !== "object") bad(`plan must be an object, got ${JSON.stringify(plan)}`);
+  const actions = plan.actions;
+  if (!Array.isArray(actions) || actions.length === 0) bad("plan.actions must be a non-empty array");
+
+  actions.forEach((action, i) => {
+    const where = `action ${i}`;
+    if (!action || typeof action !== "object") bad(`${where} must be an object, got ${JSON.stringify(action)}`);
+    if (!UI_ACTION_TYPES.includes(action.type)) {
+      bad(`${where} has unknown type ${JSON.stringify(action.type)}; valid: ${UI_ACTION_TYPES.join(", ")}`);
+    }
+    switch (action.type) {
+      case "goto":
+        if (action.surface !== "sheet" && action.surface !== "doc") {
+          bad(`${where} surface must be "sheet" or "doc", got ${JSON.stringify(action.surface)}`);
+        }
+        break;
+      case "click":
+        assertTarget(action.target, where);
+        break;
+      case "type":
+        if (typeof action.text !== "string") bad(`${where} needs a string \`text\``);
+        break;
+      case "key":
+        if (typeof action.key !== "string" || action.key === "") bad(`${where} needs a non-empty \`key\``);
+        break;
+      case "scroll":
+        if (action.target !== undefined) assertTarget(action.target, where);
+        if (!Number.isFinite(action.dx ?? 0) || !Number.isFinite(action.dy ?? 0)) {
+          bad(`${where} dx/dy must be finite numbers`);
+        }
+        break;
+      case "read":
+      case "wait":
+        assertReader(action.reader, where);
+        if (action.args !== undefined && !Array.isArray(action.args)) bad(`${where} \`args\` must be an array`);
+        break;
+      default:
+        bad(`${where} unhandled type ${JSON.stringify(action.type)}`);
+    }
+  });
+  return true;
+}
+
+// --- outcome shape -----------------------------------------------------------
+
+/**
+ * Remove the parts of an observation that legitimately differ between two runs of
+ * the same behaviour.
+ *
+ * Layered on `scrubVolatile` rather than replacing it, so the two hunters cannot
+ * drift on what "volatile" means. One UI-specific rule is added because
+ * `generateBlockId()` is `block-${Date.now()}-${counter}` — measured live, the same
+ * selection read twice gave `block-1785735868118-3` and `block-1785735870911-3`.
+ * Only the timestamp moves, so only the timestamp is scrubbed: keeping the ordinal
+ * preserves the distinction between block 3 and block 5, which is real signal.
+ */
+export function scrubUiVolatile(text) {
+  const once = scrubVolatile([String(text ?? "")])[0];
+  return once.replace(/\bblock-\d{10,}-(\d+)\b/g, "block-<T>-$1");
+}
+
+/**
+ * Collapse a Playwright/driver error to a stable class.
+ *
+ * A raw message embeds timeouts in ms and locator text, so keying on it would make
+ * every replay look divergent — the same reason `observedKey` compares outcome shape
+ * rather than message text.
+ */
+export function classifyUiError(message) {
+  const m = String(message ?? "");
+  if (m === "") return "none";
+  if (/Timeout .*exceeded|timed out/i.test(m)) return "timeout";
+  if (/unknown reader/i.test(m)) return "unknown-reader";
+  if (/unresolvable target|did not return \{x,y\}/i.test(m)) return "unresolvable-target";
+  if (/hunt bridge is not installed/i.test(m)) return "no-bridge";
+  if (/goto the (sheet|doc) surface first/i.test(m)) return "wrong-surface";
+  if (/unknown action type/i.test(m)) return "unknown-action";
+  return `other:${scrubUiVolatile(m).split("\n")[0].slice(0, 80)}`;
+}
+
+function valueKey(value) {
+  if (value === null || value === undefined) return "null";
+  const scrubbed = scrubUiVolatile(typeof value === "string" ? value : JSON.stringify(value));
+  if (scrubbed.length <= MAX_INLINE_VALUE_CHARS) return scrubbed;
+  return `sha256:${createHash("sha256").update(scrubbed).digest("hex").slice(0, 16)}`;
+}
+
+/**
+ * The SHAPE of what one action did — never its message text.
+ *
+ * The UI analogue of `observedKey` in hunt-fingerprint.mjs, and it carries one thing
+ * that one does not: the read VALUE. For a CLI probe the outcome is the exit code;
+ * for a UI read the value IS the outcome — `[11,18,32]` versus `[11,11,11]` is the
+ * entire difference between working and broken. Values are scrubbed, and hashed past
+ * a threshold so a page snapshot cannot become the key.
+ *
+ * Oracles are reduced to `kind:rule` and de-duplicated: WHICH invariant broke is
+ * stable, how many times it broke in one action is not.
+ */
+export function uiObservedKey(observation) {
+  const o = observation && typeof observation === "object" ? observation : {};
+  const type = o.action && typeof o.action === "object" ? String(o.action.type ?? "?") : "?";
+  const reader = o.action && typeof o.action === "object" && o.action.reader ? String(o.action.reader) : "";
+  const oracles =
+    [...new Set((Array.isArray(o.oracles) ? o.oracles : []).map((x) => (x?.rule ? `${x.kind}:${x.rule}` : String(x?.kind ?? "?"))))]
+      .sort()
+      .join(",") || "none";
+  const err = o.ok === true ? "none" : classifyUiError(o.error);
+  return `act:${type}${reader ? `(${reader})` : ""}|ok:${o.ok === true}|err:${err}|oracles:${oracles}|value:${valueKey(o.value)}`;
+}
+
+/**
+ * One key for a whole attempt.
+ *
+ * Position-independent comparison is deliberate: `replay()` keys only the LAST
+ * observation, which for a CLI probe is the failing one but for a UI plan usually is
+ * not — the failing action is commonly mid-sequence with reads after it. Folding
+ * every observation in means a divergence anywhere in the plan is a divergence,
+ * which is the property replay actually needs.
+ */
+export function uiPlanKey(observations) {
+  const parts = (Array.isArray(observations) ? observations : []).map(uiObservedKey);
+  return `n:${parts.length}|${createHash("sha256").update(parts.join(" ")).digest("hex").slice(0, 32)}`;
+}
+
+/** Did any free oracle fire anywhere in this attempt? */
+export function oraclesFired(observations) {
+  const out = [];
+  for (const o of Array.isArray(observations) ? observations : []) {
+    for (const oracle of Array.isArray(o?.oracles) ? o.oracles : []) {
+      out.push({ index: o.index, ...oracle });
+    }
+  }
+  return out;
+}
+
+// --- running -----------------------------------------------------------------
+
+/**
+ * Run an action plan in a browser, N times, returning one observation array per
+ * attempt.
+ *
+ * `runner` is injectable for the same reason `runProbe`'s is: the tests exercise
+ * validation, keying and error handling with no browser and no network.
+ *
+ * A runner-level failure (`ok: false`) THROWS rather than returning empty
+ * observations. Infrastructure trouble must not be able to present itself as "the
+ * app did nothing", which is a shape a caller could mistake for a finding.
+ */
+export function runUiPlan(plan, { repoRoot, attempts = DEFAULT_ATTEMPTS, timeoutMs = 180_000, runner = null } = {}) {
+  assertSafeActionPlan(plan);
+  if (!Number.isInteger(attempts) || attempts < 1) bad(`attempts must be a positive integer, got ${attempts}`);
+
+  if (typeof runner === "function") return runner(plan, { repoRoot, attempts });
+
+  const runnerPath = path.join(repoRoot, UI_RUNNER_REL);
+  return withScratch((dir) => {
+    const planFile = path.join(dir, "plan.json");
+    const outFile = path.join(dir, "out.json");
+    writeFileSync(planFile, JSON.stringify(plan));
+
+    const res = spawnSync(
+      process.execPath,
+      [runnerPath, "--plan", planFile, "--out", outFile, "--attempts", String(attempts)],
+      {
+        cwd: path.join(repoRoot, "packages", "frontend"),
+        timeout: timeoutMs,
+        killSignal: "SIGKILL",
+        encoding: "utf8",
+        maxBuffer: 8 << 20,
+      },
+    );
+
+    let parsed;
+    try {
+      parsed = JSON.parse(readFileSync(outFile, "utf8"));
+    } catch {
+      const detail = (res.stderr || res.stdout || "").trim().split("\n").slice(-5).join("\n");
+      bad(`runner produced no readable result (exit ${res.status}${res.signal ? `, ${res.signal}` : ""})\n${detail}`);
+    }
+    if (!parsed.ok) bad(`runner failed: ${parsed.error}`);
+    return parsed.attempts.map((a) => a.observations);
+  }, { prefix: "wb-hunt-ui-" });
+}

--- a/scripts/agent/hunt-ui-probe.test.mjs
+++ b/scripts/agent/hunt-ui-probe.test.mjs
@@ -1,0 +1,234 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import {
+  assertSafeActionPlan,
+  classifyUiError,
+  oraclesFired,
+  runUiPlan,
+  scrubUiVolatile,
+  uiObservedKey,
+  uiPlanKey,
+  UI_ACTION_TYPES,
+  UI_READER_PREFIXES,
+} from "./hunt-ui-probe.mjs";
+
+const okPlan = { actions: [{ type: "goto", surface: "doc" }] };
+
+/** An observation as the driver emits one. */
+function obs(over = {}) {
+  return { index: 0, action: { type: "read", reader: "doc.fontSizes" }, ok: true, error: null, value: null, oracles: [], ...over };
+}
+
+// --- plan validation: the closed vocabulary ---------------------------------
+
+test("assertSafeActionPlan accepts a well-formed plan", () => {
+  assert.equal(assertSafeActionPlan(okPlan), true);
+});
+
+test("assertSafeActionPlan refuses an unknown action type", () => {
+  assert.throws(
+    () => assertSafeActionPlan({ actions: [{ type: "evaluate", script: "window.x=1" }] }),
+    /unknown type "evaluate"/,
+  );
+});
+
+test("assertSafeActionPlan refuses an empty or missing action list", () => {
+  assert.throws(() => assertSafeActionPlan({ actions: [] }), /non-empty array/);
+  assert.throws(() => assertSafeActionPlan({}), /non-empty array/);
+  assert.throws(() => assertSafeActionPlan(null), /must be an object/);
+});
+
+// The reader prefix check is what stops a caller reaching outside the registry —
+// there is no `eval.` namespace, so a typo AND an escape attempt both land here.
+test("assertSafeActionPlan refuses a reader outside the known namespaces", () => {
+  assert.throws(() => assertSafeActionPlan({ actions: [{ type: "read", reader: "eval.window" }] }), /must start with one of/);
+  assert.throws(() => assertSafeActionPlan({ actions: [{ type: "read", reader: "" }] }), /needs a reader name/);
+  assert.throws(() => assertSafeActionPlan({ actions: [{ type: "read" }] }), /needs a reader name/);
+});
+
+test("assertSafeActionPlan accepts every declared reader namespace", () => {
+  for (const prefix of UI_READER_PREFIXES) {
+    assert.equal(assertSafeActionPlan({ actions: [{ type: "read", reader: `${prefix}whatever` }] }), true);
+  }
+});
+
+// A target with both forms is ambiguous, and one with neither is unresolvable.
+// Either would be silently interpreted by the driver rather than refused.
+test("assertSafeActionPlan refuses an ambiguous or empty click target", () => {
+  assert.throws(
+    () => assertSafeActionPlan({ actions: [{ type: "click", target: { role: "button", reader: "sheet.cellCenter" } }] }),
+    /exactly one of/,
+  );
+  assert.throws(() => assertSafeActionPlan({ actions: [{ type: "click", target: {} }] }), /exactly one of/);
+  assert.throws(() => assertSafeActionPlan({ actions: [{ type: "click" }] }), /needs a target object/);
+});
+
+test("assertSafeActionPlan refuses a click target whose reader escapes the namespaces", () => {
+  assert.throws(
+    () => assertSafeActionPlan({ actions: [{ type: "click", target: { reader: "eval.point" } }] }),
+    /must start with one of/,
+  );
+});
+
+test("assertSafeActionPlan refuses a goto to an unknown surface", () => {
+  assert.throws(() => assertSafeActionPlan({ actions: [{ type: "goto", surface: "slides" }] }), /must be "sheet" or "doc"/);
+});
+
+test("assertSafeActionPlan refuses malformed type/key/scroll payloads", () => {
+  assert.throws(() => assertSafeActionPlan({ actions: [{ type: "type", text: 42 }] }), /string `text`/);
+  assert.throws(() => assertSafeActionPlan({ actions: [{ type: "key", key: "" }] }), /non-empty `key`/);
+  assert.throws(() => assertSafeActionPlan({ actions: [{ type: "scroll", dy: "far" }] }), /finite numbers/);
+});
+
+test("UI_ACTION_TYPES has no execution escape hatch", () => {
+  for (const banned of ["evaluate", "eval", "script", "exec", "goto-url"]) {
+    assert.equal(UI_ACTION_TYPES.includes(banned), false, `${banned} must not be an action type`);
+  }
+});
+
+// --- outcome shape ----------------------------------------------------------
+
+test("uiObservedKey ignores volatile block ids", () => {
+  // Both strings are REAL output, captured from two attempts of the same plan:
+  // generateBlockId() is `block-${Date.now()}-${counter}`. Without scrubbing, every
+  // candidate that reads a selection would replay as non-deterministic and be dropped.
+  const a = obs({ action: { type: "read", reader: "doc.selection" }, value: '{"anchor":{"blockId":"block-1785735868118-3","offset":0}}' });
+  const b = obs({ action: { type: "read", reader: "doc.selection" }, value: '{"anchor":{"blockId":"block-1785735870911-3","offset":0}}' });
+  assert.equal(uiObservedKey(a), uiObservedKey(b));
+});
+
+test("uiObservedKey keeps the block ORDINAL, which is real signal", () => {
+  const a = obs({ value: '{"blockId":"block-1785735868118-3"}' });
+  const b = obs({ value: '{"blockId":"block-1785735868118-5"}' });
+  assert.notEqual(uiObservedKey(a), uiObservedKey(b));
+});
+
+// The single most important assertion in this file. For a CLI probe the outcome is
+// the exit code; for a UI read the VALUE is the outcome. If the value did not
+// participate in the key, [11,18,32] and [11,11,11] would be the same observation
+// and the hunter would be structurally unable to see a formatting defect at all.
+test("uiObservedKey distinguishes different read values", () => {
+  const before = obs({ value: "[11,18,32]" });
+  const after = obs({ value: "[11,11,11]" });
+  assert.notEqual(uiObservedKey(before), uiObservedKey(after));
+});
+
+test("uiObservedKey hashes an oversized value instead of inlining it", () => {
+  const key = uiObservedKey(obs({ value: "x".repeat(5000) }));
+  assert.match(key, /value:sha256:[0-9a-f]{16}$/);
+  assert.ok(key.length < 300, `key should stay bounded, got ${key.length} chars`);
+});
+
+test("uiObservedKey distinguishes which oracle fired, not how often", () => {
+  const once = obs({ oracles: [{ kind: "dom-invariant", rule: "duplicate-id", detail: "a" }] });
+  const twice = obs({ oracles: [
+    { kind: "dom-invariant", rule: "duplicate-id", detail: "a" },
+    { kind: "dom-invariant", rule: "duplicate-id", detail: "b" },
+  ] });
+  const other = obs({ oracles: [{ kind: "dom-invariant", rule: "placeholder-text", detail: "undefined" }] });
+  assert.equal(uiObservedKey(once), uiObservedKey(twice), "same rule twice is the same outcome");
+  assert.notEqual(uiObservedKey(once), uiObservedKey(other), "a different rule is a different outcome");
+});
+
+test("uiObservedKey separates a clean action from one that fired an oracle", () => {
+  assert.notEqual(uiObservedKey(obs()), uiObservedKey(obs({ oracles: [{ kind: "pageerror" }] })));
+});
+
+test("classifyUiError collapses timeouts that differ only in duration", () => {
+  assert.equal(classifyUiError("Timeout 10000ms exceeded."), "timeout");
+  assert.equal(classifyUiError("Timeout 30000ms exceeded."), "timeout");
+  assert.equal(
+    uiObservedKey(obs({ ok: false, error: "Timeout 10000ms exceeded." })),
+    uiObservedKey(obs({ ok: false, error: "Timeout 30000ms exceeded." })),
+  );
+});
+
+test("classifyUiError keeps distinct failure classes distinct", () => {
+  const classes = [
+    classifyUiError('[hunt-bridge] unknown reader "doc.nope". Valid readers: a, b'),
+    classifyUiError("[hunt-bridge] doc reader used while surface is \"sheet\" — goto the doc surface first"),
+    classifyUiError("unresolvable target {}"),
+    classifyUiError("Timeout 5000ms exceeded."),
+  ];
+  assert.deepEqual(classes, ["unknown-reader", "wrong-surface", "unresolvable-target", "timeout"]);
+});
+
+test("classifyUiError scrubs volatile paths out of an unclassified message", () => {
+  const key = classifyUiError("boom at /var/folders/xy/T/wb-hunt-ui-abc123/plan.json:4");
+  assert.ok(!key.includes("wb-hunt-ui-abc123"), `temp path leaked into the error class: ${key}`);
+});
+
+test("scrubUiVolatile still applies the shared scrubber", () => {
+  // Layered on scrubVolatile rather than replacing it, so the CLI and UI hunters
+  // cannot drift on what "volatile" means.
+  assert.equal(scrubUiVolatile("id 550e8400-e29b-41d4-a716-446655440000"), "id <UUID>");
+});
+
+// --- plan-level key ---------------------------------------------------------
+
+test("uiPlanKey notices a divergence that is not the last observation", () => {
+  // replay() keys only the LAST observation. For a UI plan the failing action is
+  // usually mid-sequence with reads after it, so a last-only key would call two
+  // materially different runs identical.
+  const good = [obs({ index: 0, value: "[11,18,32]" }), obs({ index: 1, value: "done" })];
+  const bad = [obs({ index: 0, value: "[11,11,11]" }), obs({ index: 1, value: "done" })];
+  assert.notEqual(uiPlanKey(good), uiPlanKey(bad));
+  assert.equal(uiObservedKey(good.at(-1)), uiObservedKey(bad.at(-1)), "last observation alone cannot tell them apart");
+});
+
+test("uiPlanKey is stable for identical attempts and counts length", () => {
+  const run = [obs({ index: 0 }), obs({ index: 1 })];
+  assert.equal(uiPlanKey(run), uiPlanKey([obs({ index: 0 }), obs({ index: 1 })]));
+  assert.match(uiPlanKey(run), /^n:2\|/);
+  assert.notEqual(uiPlanKey(run), uiPlanKey([obs({ index: 0 })]));
+});
+
+test("oraclesFired flattens every oracle with the action that caused it", () => {
+  const fired = oraclesFired([
+    obs({ index: 0 }),
+    obs({ index: 1, oracles: [{ kind: "pageerror", detail: "boom" }] }),
+    obs({ index: 2, oracles: [{ kind: "console-error", detail: "bad" }] }),
+  ]);
+  assert.deepEqual(fired.map((f) => [f.index, f.kind]), [[1, "pageerror"], [2, "console-error"]]);
+});
+
+// --- running ----------------------------------------------------------------
+
+test("runUiPlan validates BEFORE spawning anything", () => {
+  let called = false;
+  assert.throws(
+    () => runUiPlan({ actions: [{ type: "evaluate" }] }, { repoRoot: "/nope", runner: () => { called = true; } }),
+    /unknown type/,
+  );
+  assert.equal(called, false, "an invalid plan must not reach the runner");
+});
+
+test("runUiPlan passes the plan and attempt count to an injected runner", () => {
+  const seen = [];
+  const result = runUiPlan(okPlan, {
+    repoRoot: "/repo",
+    attempts: 3,
+    runner: (plan, opts) => {
+      seen.push({ plan, opts });
+      return [[obs()], [obs()], [obs()]];
+    },
+  });
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].opts.attempts, 3);
+  assert.deepEqual(seen[0].plan, okPlan);
+  assert.equal(result.length, 3);
+});
+
+test("runUiPlan refuses a non-positive attempt count", () => {
+  assert.throws(() => runUiPlan(okPlan, { repoRoot: "/r", attempts: 0, runner: () => [] }), /positive integer/);
+});
+
+// A runner that died must NOT look like "the app did nothing". An empty observation
+// array is a shape a caller could read as a finding; an exception cannot be.
+test("runUiPlan throws when the driver cannot produce a result", () => {
+  assert.throws(
+    () => runUiPlan(okPlan, { repoRoot: "/definitely/not/a/repo", timeoutMs: 5000 }),
+    /runner produced no readable result|runner failed/,
+  );
+});

--- a/scripts/agent/hunt-ui-probe.test.mjs
+++ b/scripts/agent/hunt-ui-probe.test.mjs
@@ -1,4 +1,7 @@
 import { strict as assert } from "node:assert";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -69,6 +72,24 @@ test("assertSafeActionPlan refuses a click target whose reader escapes the names
     () => assertSafeActionPlan({ actions: [{ type: "click", target: { reader: "eval.point" } }] }),
     /must start with one of/,
   );
+});
+
+// `button` and `clickCount` reach Playwright verbatim. An unvalidated button fails
+// inside the driver instead of at validation, and a huge clickCount does not fail at
+// all — it hangs.
+test("assertSafeActionPlan refuses an unsupported mouse button", () => {
+  const withButton = (button) => ({ actions: [{ type: "click", target: { role: "button", name: "x" }, button }] });
+  assert.equal(assertSafeActionPlan(withButton("right")), true);
+  assert.throws(() => assertSafeActionPlan(withButton("scroll")), /button must be one of/);
+  assert.throws(() => assertSafeActionPlan(withButton(1)), /button must be one of/);
+});
+
+test("assertSafeActionPlan bounds clickCount", () => {
+  const withCount = (clickCount) => ({ actions: [{ type: "click", target: { role: "button", name: "x" }, clickCount }] });
+  assert.equal(assertSafeActionPlan(withCount(2)), true);
+  assert.throws(() => assertSafeActionPlan(withCount(1_000_000)), /clickCount must be an integer in 1\.\.3/);
+  assert.throws(() => assertSafeActionPlan(withCount(0)), /clickCount must be an integer in 1\.\.3/);
+  assert.throws(() => assertSafeActionPlan(withCount(1.5)), /clickCount must be an integer in 1\.\.3/);
 });
 
 test("assertSafeActionPlan refuses a goto to an unknown surface", () => {
@@ -231,4 +252,30 @@ test("runUiPlan throws when the driver cannot produce a result", () => {
     () => runUiPlan(okPlan, { repoRoot: "/definitely/not/a/repo", timeoutMs: 5000 }),
     /runner produced no readable result|runner failed/,
   );
+});
+
+// The other failure path: the driver ran, wrote a well-formed result, and reported
+// `ok: false`. Distinct from the unreadable-output case above and separately
+// reachable, so it gets its own stub rather than being assumed equivalent.
+test("runUiPlan throws when the driver reports its own failure", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "wb-hunt-ui-stub-"));
+  try {
+    const scriptDir = path.join(root, "packages", "frontend", "scripts");
+    mkdirSync(scriptDir, { recursive: true });
+    // A stand-in for the real runner: parses --out and reports a driver-level
+    // failure, exactly as the runner does when Vite or Chromium cannot start.
+    writeFileSync(
+      path.join(scriptDir, "hunt-ui-runner.mjs"),
+      [
+        'import { writeFileSync } from "node:fs";',
+        'const argv = process.argv.slice(2);',
+        'const out = argv[argv.indexOf("--out") + 1];',
+        'writeFileSync(out, JSON.stringify({ ok: false, error: "stub driver failure", attempts: [] }));',
+        "process.exit(1);",
+      ].join("\n"),
+    );
+    assert.throws(() => runUiPlan(okPlan, { repoRoot: root, timeoutMs: 20_000 }), /runner failed: stub driver failure/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/scripts/verify-browser-lanes.mjs
+++ b/scripts/verify-browser-lanes.mjs
@@ -65,6 +65,14 @@ try {
     cwd: repoRoot,
     stdio: "inherit",
   });
+  // The UI hunter's free oracles. Runs here rather than in `verify:self` because it
+  // needs Chromium, and because an oracle that silently stops firing is invisible
+  // from the outside — a run with no findings and a run with a dead detector produce
+  // the same empty report, so the detector needs its own lane.
+  execSync("pnpm verify:hunt:oracles", {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
 } catch (error) {
   process.exit(error.status ?? 1);
 }


### PR DESCRIPTION
## Summary

First piece of the UI issue hunter (Phase 28). **No model is involved anywhere in this PR** — it is the hands and the senses. You hand it a JSON list of clicks and keystrokes; it performs them on the real app and reports what broke.

`docs/design/harness-engineering.md:1130-1133` already names this as the next surface: the CLI hunter cannot reach Canvas rendering, CRDT collaboration or frontend interaction, which is where most currently-open UI bugs live.

### `__WB_HUNT__` — the sensor

Sheets, docs and slides render to **Canvas**, so the accessibility tree covers the React chrome and essentially nothing else. The standard web-agent approach (snapshot the a11y tree, reason about it) is blind to the actual product. The bridge replaces it with a closed registry of named readers the page answers about itself — including the cell-centre lookup that is the only way to click something existing purely as pixels.

A registry rather than an evaluate-arbitrary-JS hook, so the model-driven caller in a later PR stays bounded by reviewed code.

### `/harness/hunt` — the target

Mounts the real engines over `MemStore`/`MemDocStore` and hangs the real `DocsFormattingToolbar` off the editor. Toolbars are where a large share of real defects live, and neither existing harness route can reach one (`visual` mounts scenes read-only, `interaction` mounts a bare grid). Nothing here can touch real data because there is no backend to touch.

### Three decisions worth reviewing

**The driver lives under `packages/frontend`, not `scripts/agent`.** Verified both ways rather than assumed: `import('playwright')` resolves from the former and throws `ERR_MODULE_NOT_FOUND` from the latter. Duplicating the dep would also duplicate a version that `run-browser-tests-docker.sh` pins against `Dockerfile.playwright`. Spawning it as a subprocess additionally keeps the async browser behind a synchronous call, so `hunt-probe.mjs`'s `replay()` is **reused unchanged** instead of rewritten.

**The clock is deliberately NOT frozen.** Pinning `Date.now()` is the obvious determinism move and it changes application behaviour — the sheets mobile-edit panel dismisses on `Date.now() - openedAt < 500`, always `0` under a frozen clock. A hunter that manufactures defects with its own instrumentation is worse than no hunter. Measured instead: three attempts of the same plan are byte-identical. Volatile values are handled in `uiObservedKey`, layered on the shared `scrubVolatile`; one UI-specific rule was needed because `generateBlockId()` is `block-${Date.now()}-n`, so the same read gave `block-1785735868118-3` and `block-1785735870911-3`. Only the timestamp is scrubbed — the ordinal is real signal.

**The route is DEV-only, unlike the three harness routes beside it.** Mounting the real toolbar makes it a second separately-split importer, and a production build gained **seven** chunks (147 → 154, with main at exactly the limit): the route plus `docs-view`, `docx-actions`, `use-mobile`, `button`, `IconHash`, `IconPalette` hoisted out of the docs route chunk. That changes the download shape of a user-facing route to serve a page no user can reach. Gated behind `import.meta.env.DEV`, the production bundle is **unchanged at 147** — no budget bump needed. The lanes are unaffected: they all run against in-process `vite` dev servers.

### The oracles get their own lane

An oracle that silently stops firing is invisible — a run with no findings and a run with a dead detector produce the same empty report. `verify-hunt-oracles.mjs` runs 9 checks: 6 positive (each oracle fires on an injected fault) and 3 negative. Faults are injected from the driver, so no test-only branch ships in the harness route.

The negative controls earned their keep immediately. `network-fail` correctly ignored the absent backend — but the browser logs its *own* `Failed to load resource: net::ERR_FAILED` console error, so `console-error` reported it anyway. In Tier 1, where there is no backend by construction, every API call the app makes would have been a finding. The origin rule now applies to messages *about* requests too.

### Incidental finding

Issue #343 ("increasing font size on a mixed-size selection resets to the minimum") appears to be **already fixed** and left open. `font-size-picker.tsx:80-92` carries a guard whose comment describes the bug exactly, landed in #358 (a *slides* PR). Confirmed empirically through this harness: the sizes stay `[11,18,32]`. Not touched here — flagging it for whoever wants to close the issue.

## Test plan

- `cd scripts/agent && node --test *.test.mjs` — 519 pass (27 new)
- `pnpm verify:self` — 11/11 lanes
- `pnpm verify:hunt:oracles` — 9/9 (also wired into `verify-browser-lanes.mjs`, so it runs in `verify:browser:docker`)
- **All ten safety guards mutation-tested** — each fails when its guard is removed. Two survived initially; both were faults in my mutation harness, not vacuous tests.
- Determinism: 3 attempts of the same plan produce byte-identical observations.
- End-to-end: a scripted plan drives both surfaces, reads engine state through the bridge, and clicks a real toolbar button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development-only UI hunt harness for document and spreadsheet surfaces.
  * Added browser-based UI action execution, observation, and error detection.
  * Added read-only inspection of document formatting, selections, links, spreadsheet cells, and viewport data.

* **Tests**
  * Added automated checks for UI actions, browser errors, accessibility issues, failed assets, and invalid DOM states.
  * Integrated oracle verification into browser validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->