### PR TITLE
Remove the docs lens 8-turn cap that paged on prose review

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -459,7 +459,7 @@ Components:
   from that diff, so a verifier reading the same diff inherits its misreadings
   and confirms them — the correlated-error failure of naive review panels. It
   instead re-establishes the facts from the repository itself (Read/Grep/Glob
-  against the branch checkout, capped at 8 turns), is told to distrust the
+  against the branch checkout, capped at 20 turns), is told to distrust the
   finding's quoted evidence, and receives only the cumulative changed-FILE list
   so it can tell new code from pre-existing. Dropping is **grounded, not
   asserted** (`isDroppingVerdict`): the verdict must be an explicit `refuted`, at

--- a/scripts/agent/lenses/lenses.json
+++ b/scripts/agent/lenses/lenses.json
@@ -71,7 +71,6 @@
     "scopeClasses": ["prose"],
     "model": "claude-sonnet-5",
     "samples": 1,
-    "effort": "medium",
-    "maxTurns": 8
+    "effort": "medium"
   }
 ]

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -1512,10 +1512,15 @@ async function runLens(lens, { rubric, diff, extraDiff, issue, repo, sessionLog,
     schema: LENS_SCHEMA,
     sessionLog,
     allowedTools: REVIEW_TOOLS,
-    // Optional per-lens turn ceiling. Omitted = the SDK default, which is what
-    // the repo-walking lenses (blast-radius, correctness) need. A lens whose
-    // rubric only asks it to check the prose in front of it does not, and an
-    // unbounded budget there is spend with nothing to show for it.
+    // Optional per-lens turn ceiling; omitted = the SDK default. Currently NO
+    // lens sets one. The docs lens used to cap at 8 on the theory that prose
+    // review is a shallow lookup, but it kept dying on `error_max_turns` at that
+    // ceiling — failing the blocking lens closed and PAGING a human — exactly as
+    // the verifier's `presence: 8` did before it was raised (see
+    // VERIFIER_MAX_TURNS). Locating the prose, reading enough around it to judge
+    // accuracy, and citing a `file:line` costs more than 8 turns, so docs now runs
+    // at the default like every other lens. Keep the knob for a future lens that
+    // genuinely is bounded, but do not re-cap on a cost hunch: a page is worse.
     maxTurns: lens.maxTurns,
     // Optional per-lens reasoning effort, same manifest-driven shape as
     // `maxTurns` above. Omitted = the SDK default (`high`). This is the panel's


### PR DESCRIPTION
## Why this happened

The docs lens was the **only** lens with a turn ceiling — `maxTurns: 8` in `lenses.json`. On #632 it produced:

> Reviewer did not produce a valid verdict: review query hit a run limit: error_max_turns after 9 turns — Reached maximum number of turns (8)

`error_max_turns` is a **run limit, not an API/quota error** (`ask.mjs`), so it doesn't take the infra path — it falls through to the ordinary "no valid verdict" branch, **fails the blocking lens closed, and pages a human**. That's why #632's panel couldn't promote or fix.

This is the *exact* false economy the codebase already diagnosed and fixed **for the verifier**. The comment above `VERIFIER_MAX_TURNS` records that its `presence: 8` died on `error_max_turns` "every one of them at exactly 9 turns," and raised it to 20 because *"locating the code, reading enough around it to judge the claim, and citing a `file:line` costs more than 8 turns far more often than not."* The docs lens does the same locate → read → cite work on prose and hits the same wall.

## The fix

Remove the cap so **docs runs at the SDK default like the five other detection lenses** — the proven-sufficient budget already in use (the comment notes the repo-walking lenses *need* the default, and they complete fine, including on #632). A bespoke higher number (20, 25) would be invented with no docs-specific turn distribution to justify it — the same "invented number" critique the verifier comment makes. docs is `claude-sonnet-5`, so the extra turns are cheap, and **a page costs far more than the spend the cap was trying to save.**

Also updates the `maxTurns` comment in `review-panel.mjs`, and fixes a stale "capped at 8 turns" in `harness-engineering.md` (the verifier is 20 now).

## Test plan

- Data-only manifest change + comments/doc. `lenses.json` validated; docs now has no `maxTurns` (→ SDK default).
- **502 agent tests pass** (the `ask.test.mjs` `maxTurns: 8` case is a generic plumbing test, not coupled to the docs lens — untouched).
- `node --check` on `review-panel.mjs`; `verify:entropy` doc-staleness **0 issues**.

## Not done here (deliberate)

A detection turn-limit still fails a lens closed and pages — correct as a *safety* default, but for a run-limit specifically (a config problem, not a code problem) a future improvement could retry once with a raised ceiling instead of paging. Out of scope for this one-field fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)