### PR TITLE
Verify a re-found prior finding once, not twice

### DIFF
--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -253,6 +253,11 @@ export function aggregatePanelStats(entries) {
   // they coerce to 0 — but a non-zero value means those findings were never
   // filtered at all, which is the difference between a review and a raw dump.
   let errored = 0;
+  // Prior-round findings this round's fresh pass re-found, so one verdict settled
+  // both and only one session ran. Absent from entries written before the reuse
+  // existed, which coerce to 0 — the honest reading, since those rounds really
+  // did verify every carried-forward finding a second time.
+  let reusedPriorVerdicts = 0;
   // WHY those sessions threw, split by `classifyResult`'s kind. Absent from
   // pre-instrumentation entries, which contribute nothing — so an all-zero
   // `failures` means "no data yet", and the renderer omits the line rather than
@@ -290,6 +295,7 @@ export function aggregatePanelStats(entries) {
     absenceRefuted += Number(e.verifier && e.verifier.absenceRefuted) || 0;
     unresolved += Number(e.verifier && e.verifier.unresolved) || 0;
     errored += Number(e.verifier && e.verifier.errored) || 0;
+    reusedPriorVerdicts += Number(e.verifier && e.verifier.reusedPriorVerdicts) || 0;
     for (const k of Object.keys(failures)) {
       failures[k] += Number(e.verifier && e.verifier.failures && e.verifier.failures[k]) || 0;
     }
@@ -301,7 +307,7 @@ export function aggregatePanelStats(entries) {
   }
   return {
     agreementCounts, raised, raisedConfidence, kept,
-    verifier: { sentToVerifier, refuted, refutedHighConfidence, dropped, errored, absenceRaised, absenceRefuted, unresolved, failures },
+    verifier: { sentToVerifier, refuted, refutedHighConfidence, dropped, errored, absenceRaised, absenceRefuted, unresolved, reusedPriorVerdicts, failures },
     lanes: { blocking: laneBlocking, backlog: laneBacklog, unknownOrigin: laneUnknownOrigin },
     clusters: { clustered, collapsed },
   };
@@ -545,6 +551,16 @@ export function renderSummary({ agg, panelAgg, panelStats, panelAttribution, fli
       // proxy, not recall (no ground truth here). Shown alongside, not instead.
       `- Weighted raised (effort proxy, not recall): ${weightSeverity(r)}`,
       `- Sent to verifier: ${v.sentToVerifier || 0}`,
+      // Why that number is lower on a round ≥ 2 than the finding count suggests.
+      // Each of these would have been one more verifier session under the old
+      // unconditional re-check, so this is literally the sessions not run — and
+      // without it a falling `Sent to verifier` is ambiguous between "the reuse
+      // is working" and "the lenses raised less", which call for opposite
+      // actions. Omitted at zero: round 1 has no prior findings at all, and
+      // rounds recorded before the reuse existed coerce to 0 and stay quiet.
+      ...(v.reusedPriorVerdicts
+        ? [`- Prior findings re-found this round: ${v.reusedPriorVerdicts} (verified once, not twice)`]
+        : []),
       // Read this BEFORE the refute counts. A verifier session that threw keeps
       // its finding, so an outage looks identical in the output to a verifier
       // that confirmed everything — this line is the only thing that tells them

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -109,7 +109,7 @@ test("aggregatePanelStats: rolls up lens/round entries — agreement, severity-w
       raised: { critical: 0, major: 2, minor: 0, nit: 1 },
       raisedConfidence: { high: 1, medium: 1, low: 1, unknown: 0 },
       kept: { critical: 0, major: 1, minor: 0, nit: 1 },
-      verifier: { sentToVerifier: 2, refuted: 1, refutedHighConfidence: 1, dropped: 1 },
+      verifier: { sentToVerifier: 2, refuted: 1, refutedHighConfidence: 1, dropped: 1, reusedPriorVerdicts: 2 },
     },
   ];
   const rolled = aggregatePanelStats(entries);
@@ -123,6 +123,10 @@ test("aggregatePanelStats: rolls up lens/round entries — agreement, severity-w
   assert.deepEqual(rolled.verifier, {
     sentToVerifier: 3, refuted: 1, refutedHighConfidence: 1, dropped: 1, errored: 0,
     absenceRaised: 0, absenceRefuted: 0, unresolved: 0,
+    // Only the second entry carries it: 2 + a missing field, not 2 + NaN. Rounds
+    // that predate the reuse really did re-verify every carried-forward finding,
+    // so 0 is the honest contribution rather than merely the safe one.
+    reusedPriorVerdicts: 2,
     // Same append-only story once more: neither entry carries `failures`, so it
     // rolls up all-zero rather than NaN. An all-zero total is what makes the
     // renderer omit the line — "no data yet", not "nothing failed".
@@ -137,7 +141,7 @@ test("aggregatePanelStats: rolls up lens/round entries — agreement, severity-w
   // tolerant of junk/empty input — never throws, never blocks recording
   assert.deepEqual(aggregatePanelStats([]).verifier, {
     sentToVerifier: 0, refuted: 0, refutedHighConfidence: 0, dropped: 0, errored: 0,
-    absenceRaised: 0, absenceRefuted: 0, unresolved: 0,
+    absenceRaised: 0, absenceRefuted: 0, unresolved: 0, reusedPriorVerdicts: 0,
     failures: { apiError: 0, limit: 0, noOutput: 0, unknown: 0, total: 0 },
   });
   // Junk in the nested field coerces per-key rather than poisoning the tally —
@@ -544,4 +548,32 @@ test("renderSummary: verifier failures are broken down, and stay silent with no 
   });
   assert.doesNotMatch(noField, /Verifier failures/);
   assert.equal(zeroField, noField, "an all-zero failures tally must not add a line");
+});
+
+test("renderSummary: reused prior verdicts are reported, and silent when there are none", () => {
+  const base = {
+    agg: { agents: [], sessions: 0, attempt: 1, turns: 0, tokens: 0, weightedTokens: 0, costUsd: 0, durationMs: 0 },
+    panelAgg: { agents: ["claude-opus-5"], sessions: 1, turns: 409, tokens: 1, weightedTokens: 1, costUsd: 11.71, durationMs: 60000 },
+  };
+  const stats = (verifier) => ({
+    agreementCounts: { identical: 0, partial: 0, disjoint: 0, single: 1 },
+    raised: { critical: 0, major: 2, minor: 0, nit: 0 },
+    raisedConfidence: { high: 2, medium: 0, low: 0, unknown: 0 },
+    kept: { critical: 0, major: 2, minor: 0, nit: 0 },
+    verifier,
+  });
+  const clean = { sentToVerifier: 10, refuted: 1, refutedHighConfidence: 1, dropped: 1, errored: 0, absenceRaised: 0, absenceRefuted: 0, unresolved: 0 };
+
+  // Without this line a falling `Sent to verifier` is ambiguous between "the
+  // reuse is working" and "the lenses raised less" — opposite conclusions.
+  const reused = renderSummary({ ...base, panelStats: stats({ ...clean, reusedPriorVerdicts: 4 }) });
+  assert.match(reused, /- Prior findings re-found this round: 4 \(verified once, not twice\)/);
+
+  // Round 1 has no prior findings at all, and a round recorded before the reuse
+  // existed carries no field. Both must stay byte-identical to today's output —
+  // a `: 0` line every first round would be noise, not data.
+  const noField = renderSummary({ ...base, panelStats: stats({ ...clean }) });
+  const zeroField = renderSummary({ ...base, panelStats: stats({ ...clean, reusedPriorVerdicts: 0 }) });
+  assert.doesNotMatch(noField, /re-found this round/);
+  assert.equal(zeroField, noField, "zero reuse must not add a line");
 });

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -549,7 +549,7 @@ export function dedupeFindings(findings) {
   const byKey = new Map();
   const order = [];
   for (const f of findings) {
-    const key = `${f.file ?? ""}::${String(f.summary ?? "").toLowerCase().trim()}`;
+    const key = findingKey(f);
     if (!byKey.has(key)) {
       byKey.set(key, f);
       order.push(key);
@@ -559,6 +559,15 @@ export function dedupeFindings(findings) {
   }
   return order.map((k) => byKey.get(k));
 }
+
+/**
+ * `dedupeFindings`' collision key: file plus case- and whitespace-insensitive
+ * summary. Extracted so `sameFinding` can be built ON it rather than beside it —
+ * a second copy of this expression could drift looser than the merge it is
+ * supposed to agree with, and that drift is what would let a verification be
+ * skipped for a finding the merge then keeps separately.
+ */
+const findingKey = (f) => `${f.file ?? ""}::${String(f.summary ?? "").toLowerCase().trim()}`;
 
 /** 0=critical … 3=nit. Lower is more severe. */
 const severityRank = (f) => KNOWN.indexOf(normalizeSeverity(f && f.severity));
@@ -866,6 +875,105 @@ export function resolveClusterVerdict(rep, repVerdict, foldFindings, foldVerdict
     if (!drops(foldVerdicts?.[i], folds[i])) return foldVerdicts?.[i] ?? null; // a fold survives → keep
   }
   return repVerdict; // every blocking fold also refuted (or none gated) → drop stands
+}
+
+/**
+ * Are these two findings the SAME CLAIM, such that one verdict settles both?
+ *
+ * Deliberately `dedupeFindings`' own key (`findingKey`) and nothing looser. That
+ * is the whole safety argument: two findings sharing this key are ALREADY
+ * collapsed into one downstream — `main()` runs `dedupeFindings([...kept,
+ * ...priorKept])` — so at most one of them was ever going to survive the round.
+ * Verifying both was paying twice for one surviving finding, by construction.
+ *
+ * NOT `findingSimilarity` / `clusterFindings`. Fuzzy matching is safe when the
+ * consequence is a merge (nothing is lost — every folded wording still rides in
+ * `mergedFrom` and is rendered), and unsafe when the consequence is that a
+ * verification does not happen: a near-miss there means a verdict about one
+ * defect silently settles a different one, with nothing rendered to make the
+ * mistake visible.
+ *
+ * CLAIM TYPE is the one field added on top of the key, because it is not a
+ * matter of wording. It selects the verifier's whole procedure (hunt for a
+ * counterexample vs. look the code up), its turn budget, and which
+ * `refutationGround`s `isDroppingVerdict` will act on. A presence verdict must
+ * never settle an absence claim, however identically the two are worded.
+ *
+ * `severity`, `evidence` and `searchedFor` are deliberately NOT in the rule.
+ * They change the prompt's framing, not the claim being judged, and requiring
+ * them would make this match essentially never fire: the carry-forward round
+ * trip normalises severity and truncates evidence at 2000 chars
+ * (`agent-review-panel.yml`), so a prior copy differs from its fresh twin in
+ * those fields as a matter of routine. A rule that never fires is not a safe
+ * rule, it is a dead one that looks safe.
+ *
+ * An empty summary matches nothing, itself included. `coerceFindings` rewrites a
+ * malformed summary to a shared placeholder, and two placeholders in one file
+ * are not one claim — that is exactly the case where the text carries no
+ * information to match ON.
+ */
+export function sameFinding(a, b) {
+  if (!a || typeof a !== "object" || !b || typeof b !== "object") return false;
+  if (!String(a.summary ?? "").trim()) return false;
+  if (claimTypeOf(a) !== claimTypeOf(b)) return false;
+  return findingKey(a) === findingKey(b);
+}
+
+/**
+ * Which carried-forward findings still need a verifier session of their own.
+ *
+ * On every round ≥ 2 the panel verified each prior-round blocking finding
+ * unconditionally, having just verified this round's FRESH detections
+ * separately. A still-open defect the fresh pass re-found was therefore verified
+ * TWICE in the same round, in two wordings — the same duplicate spend
+ * `clusterFindings` was introduced to remove, one axis over. On #605 round 3
+ * that was up to 13 redundant sessions.
+ *
+ * Returns, index-aligned to `prior`:
+ *   reuseIdx[i] — index into `detected` whose verdict finding i inherits, or -1
+ *   sentIdx     — the indices with no match, i.e. the ones this round verifies
+ *
+ * Reuse requires BOTH sides to be blocking. The prior side because a
+ * non-blocking prior is never verified anyway, so calling it a reuse would
+ * report a saving that did not happen. The `detected` side because that is the
+ * trap: a blocking prior matching a MINOR fresh twin would inherit that twin's
+ * `null` — never verified, since `verifyBlocking` skips non-blockers — and
+ * `dedupeFindings` keeps the higher severity, so the blocking finding would
+ * reach the gate unverified where today it is checked. Requiring both closes it.
+ *
+ * WHAT THIS CHANGES, stated rather than left to be discovered. Today the two
+ * copies get two INDEPENDENT verdicts and the OR of them decides: whichever copy
+ * survives `keepUnrefuted` wins the `dedupeFindings` slot, so the finding lives
+ * if EITHER session kept it. After this, one verdict decides both. On the same
+ * text that only differs when two sessions disagree — which is model noise, not
+ * a second opinion worth paying for — but it moves the outcome in both
+ * directions: a fresh refutation now also drops the prior copy that would have
+ * survived, and a fresh confirmation now keeps a prior copy that would have been
+ * dropped (and which, carrying no novelty lane, outranks a `backlog` fresh twin
+ * at dedup). This is the same call #591/#601 already made when clustering moved
+ * ahead of verification — one defect, one verdict — applied to the fresh-vs-prior
+ * axis. It needs no `resolveClusterVerdict`-style bound because the match here is
+ * exact rather than fuzzy: there is no distinct wording that could have merged in.
+ *
+ * A matched fresh verdict of `null` IS reused rather than re-verified. It is
+ * tempting to treat the prior copy as a second attempt, but that would be a
+ * retry policy expressed as an accident of a finding appearing in two lists —
+ * available to duplicates and to nothing else. The retry policy lives in
+ * `withRetry` inside `verifyFinding`, where it applies to every verification;
+ * `classifyResult` marks the non-retryable kinds non-retryable on purpose. The
+ * fail direction is unchanged either way: no verdict keeps the finding.
+ *
+ * First match wins, and `detected` has a deterministic order, so the plan does
+ * not depend on iteration accidents.
+ */
+export function planPriorVerifications(detected, prior) {
+  const fresh = Array.isArray(detected) ? detected : [];
+  const list = Array.isArray(prior) ? prior : [];
+  const blocking = (f) => BLOCKING.has(normalizeSeverity(f && f.severity));
+  const reuseIdx = list.map((p) =>
+    blocking(p) ? fresh.findIndex((f) => blocking(f) && sameFinding(p, f)) : -1);
+  const sentIdx = reuseIdx.map((j, i) => (j < 0 ? i : -1)).filter((i) => i >= 0);
+  return { reuseIdx, sentIdx };
 }
 
 /**
@@ -2124,8 +2232,15 @@ async function main() {
     // and a still-present one is confirmed (kept). Because applyVerifications
     // drops only on high-confidence `refuted`, a prior finding survives unless
     // it's confidently resolved — even if this round's fresh pass missed it.
+    //
+    // A prior finding the fresh pass ALREADY re-found this round is not verified
+    // a second time — it inherits its fresh twin's verdict. `sameFinding` is
+    // `dedupeFindings`' own key plus claim type, so a reused pair is one the
+    // merge below was always going to collapse into a single finding anyway.
     const priorForLens = priorFindings.filter((p) => p.lens === lens.id);
-    const priorVerdicts = await Promise.all(priorForLens.map(async (f) => {
+    const { reuseIdx, sentIdx } = planPriorVerifications(detected, priorForLens);
+    const priorVerdicts = await Promise.all(priorForLens.map(async (f, i) => {
+      if (reuseIdx[i] >= 0) return verdicts[reuseIdx[i]] ?? null;
       if (!BLOCKING.has(normalizeSeverity(f.severity))) return null;
       try { return await verifyFinding(f, { rubric: lens.rubric, repo, model: lens.model, sessionLog, lensId: lens.id }); }
       // Error → keep (fail toward blocking), unchanged; the reason is recorded
@@ -2182,6 +2297,10 @@ async function main() {
       freshVerdicts: verdicts,
       prior: priorForLens,
       priorVerdicts,
+      // Which prior verdicts no session produced. Without it the capture shows a
+      // verdict on every prior row and a later pass counting "prior-round
+      // verifications" would over-count by exactly what this change saves.
+      priorReuseIdx: reuseIdx,
     }));
 
     // Reliability signals for this round: did the samples agree (fresh pass
@@ -2191,7 +2310,17 @@ async function main() {
     // actually sent to the verifier (post-cluster), so `sentToVerifier` counts
     // distinct defects rather than wordings.
     const freshTally = verifierTally(detected, verdicts);
-    const priorTally = verifierTally(priorForLens, priorVerdicts);
+    // The SENT SUBSET, not every prior finding. `priorVerdicts` now carries
+    // inherited verdicts for the re-found ones, and tallying those would count
+    // one session twice — `sentToVerifier` would report no saving on the round
+    // this change exists to make cheaper, and a reused `null` would land a
+    // second `errored` on a finding the fresh pass already counted. Both arrays
+    // are indexed through the SAME `sentIdx`, so they cannot drift apart the way
+    // two separately-filtered copies would.
+    const priorTally = verifierTally(
+      sentIdx.map((i) => priorForLens[i]),
+      sentIdx.map((i) => priorVerdicts[i]),
+    );
     lensStats.push({
       id: lens.id,
       // 0/0 when detection was skipped for want of new hunks — reporting the
@@ -2210,6 +2339,11 @@ async function main() {
         absenceRefuted: freshTally.absenceRefuted + priorTally.absenceRefuted,
         unresolved: freshTally.unresolved + priorTally.unresolved,
         errored: freshTally.errored + priorTally.errored,
+        // Carried-forward findings this round's fresh pass re-found, so one
+        // verdict settled both. Counted because the saving is otherwise
+        // invisible: `sentToVerifier` falls, but so does it when a round simply
+        // raises fewer findings, and the two readings call for opposite actions.
+        reusedPriorVerdicts: reuseIdx.filter((j) => j >= 0).length,
         // Both passes' failures in one tally. `errored` is UNCHANGED and stays a
         // count of FINDINGS; this counts SESSIONS, and the two are not
         // comparable — see verifierFailureCounts for why one clustered finding
@@ -2319,23 +2453,32 @@ export function stageDetailCaptureEnabled(env = process.env) {
  *   verdict and whether it dropped. `dropped` is recomputed through the real
  *   `isDroppingVerdict` rather than restated, so it cannot drift from the gate.
  *   `verdict: null` means the verifier errored and the finding was kept.
+ * - `priorReuseIdx` — `planPriorVerifications`' plan, which marks the prior rows
+ *   whose verdict was INHERITED from a fresh twin rather than produced by a
+ *   session of their own (`reused: true`). Without it the capture is indistinguishable
+ *   from one where every prior finding was verified, and counting rows in it
+ *   would overstate what the round actually spent.
  * - `fresh` must be the POST-cluster findings (`detected`), not the union:
  *   restatement clustering moved ahead of verification in #591/#601, so `verdicts`
  *   is index-aligned to what was clustered. Passing the union here would pair
  *   findings with other findings' verdicts.
  */
-export function buildStageDetail({ lensDiff, scopeNote, samples, fresh, freshVerdicts, prior, priorVerdicts }) {
-  const rows = (population, findings, verdicts) =>
+export function buildStageDetail({ lensDiff, scopeNote, samples, fresh, freshVerdicts, prior, priorVerdicts, priorReuseIdx }) {
+  const rows = (population, findings, verdicts, reuseIdx) =>
     (Array.isArray(findings) ? findings : []).map((f, i) => {
       const verdict = (Array.isArray(verdicts) ? verdicts : [])[i] ?? null;
-      return { population, finding: f, verdict, dropped: isDroppingVerdict(verdict, { claimType: claimTypeOf(f) }) };
+      const row = { population, finding: f, verdict, dropped: isDroppingVerdict(verdict, { claimType: claimTypeOf(f) }) };
+      // Present ONLY on a reused row, so every capture written before this — and
+      // every row that really was verified — keeps its exact previous shape.
+      if ((Array.isArray(reuseIdx) ? reuseIdx : [])[i] >= 0) row.reused = true;
+      return row;
     });
   // Only blocking findings are ever sent to the verifier, so the same filter that
   // gates `verifyBlocking` gates what is recorded — a minor finding has no verdict
   // to report and a `verdict: null` row for it would read as a verifier error.
   const verifications = [
     ...rows("fresh", fresh, freshVerdicts),
-    ...rows("prior-round", prior, priorVerdicts),
+    ...rows("prior-round", prior, priorVerdicts, priorReuseIdx),
   ].filter((v) => BLOCKING.has(normalizeSeverity(v.finding?.severity)));
   return {
     // The ROUTED slice this lens reviewed (its file-class subset, #582) — NOT the

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -48,6 +48,8 @@ import {
   clusterFindings,
   clusterCounts,
   resolveClusterVerdict,
+  sameFinding,
+  planPriorVerifications,
   VERIFIER_MAX_TURNS,
   buildVerifierPrompt,
   panelEntry,
@@ -610,6 +612,111 @@ test("both verifier catch sites record the failure instead of swallowing it", ()
   // would count that prose as a regression.
   const code = src.split("\n").filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
   assert.ok(!/\.catch\(\(\) => null\)/.test(code), "no verifier catch may discard the error");
+});
+
+// --- one verdict per claim, not one per list the claim appears in ----------
+
+test("sameFinding: dedupeFindings' key, and never looser than it", () => {
+  const f = (over) => ({ severity: "major", file: "a.ts", summary: "Missing null check", ...over });
+  // Case and surrounding whitespace are not the claim, exactly as in the key.
+  assert.ok(sameFinding(f(), f({ summary: "  MISSING NULL CHECK " })));
+  // Neither are the fields the carry-forward round trip rewrites anyway: it
+  // normalises severity and truncates evidence at 2000 chars, so requiring them
+  // would make this never fire on the one path it exists for.
+  assert.ok(sameFinding(f(), f({ severity: "critical", evidence: "line 12", searchedFor: ["x"] })));
+  assert.ok(!sameFinding(f(), f({ file: "b.ts" })), "a different file is a different claim");
+  assert.ok(!sameFinding(f(), f({ summary: "Missing bounds check" })));
+
+  // NEVER LOOSER THAN THE MERGE. Two findings this calls the same are two
+  // `dedupeFindings` was always going to collapse into one, which is the entire
+  // safety argument for skipping the second verification. The converse is not
+  // asserted: this is deliberately STRICTER in the two cases below.
+  const pairs = [
+    [f(), f()], [f(), f({ summary: " MISSING NULL CHECK" })], [f(), f({ file: "b.ts" })],
+    [f(), f({ summary: "other" })], [f(), f({ severity: "nit" })],
+  ];
+  for (const [a, b] of pairs) {
+    if (sameFinding(a, b)) assert.equal(dedupeFindings([a, b]).length, 1, `merge disagrees: ${b.file} ${b.summary}`);
+  }
+});
+
+test("sameFinding: claim type and empty summaries, where it is stricter than the key", () => {
+  const f = (over) => ({ severity: "major", file: "a.ts", summary: "No test covers parseX", ...over });
+  // Same words, opposite job. An absence claim is refuted by finding ONE
+  // counterexample and gets its own turn budget and its own dropping grounds, so
+  // a presence verdict cannot settle it however identically it is worded — and
+  // `dedupeFindings` WOULD collapse this pair, which is why it is checked here.
+  assert.ok(!sameFinding(f({ claimType: "absence" }), f()));
+  assert.ok(sameFinding(f({ claimType: "absence" }), f({ claimType: "absence" })));
+  assert.equal(dedupeFindings([f({ claimType: "absence" }), f()]).length, 1,
+    "the merge does collapse these — the claim-type guard is this rule's own");
+
+  // No summary, no claim to match on. `coerceFindings` rewrites a malformed
+  // summary to one shared placeholder, and two placeholders are not one defect.
+  assert.ok(!sameFinding(f({ summary: "" }), f({ summary: "" })));
+  // Both orders: the guard reads only the first argument, so symmetry rests on
+  // the keys differing in the other direction. It is the kind of thing that
+  // breaks silently, and an asymmetric "same" is a plan that depends on which
+  // list a finding happened to be in.
+  assert.ok(!sameFinding(f({ summary: "   " }), f()));
+  assert.ok(!sameFinding(f(), f({ summary: "   " })));
+  for (const junk of [null, undefined, "nope", 7, []]) {
+    assert.ok(!sameFinding(junk, f()), `junk must match nothing: ${JSON.stringify(junk)}`);
+    assert.ok(!sameFinding(f(), junk), `junk must match nothing: ${JSON.stringify(junk)}`);
+  }
+});
+
+test("planPriorVerifications: a re-found prior inherits its fresh twin's verdict", () => {
+  const detected = [
+    { severity: "major", file: "a.ts", summary: "Missing null check" },
+    { severity: "minor", file: "b.ts", summary: "Naming nit" },
+  ];
+  const prior = [
+    { severity: "major", file: "a.ts", summary: "  missing null check " }, // re-found → reuse
+    { severity: "major", file: "c.ts", summary: "Missing null check" },    // other file → verify
+    // The TRAP: the fresh twin is MINOR, so `verifyBlocking` never sent it and
+    // its verdict is null. Inheriting that would put a blocking finding on the
+    // gate unverified — `dedupeFindings` keeps the higher severity — where today
+    // it is checked. Reuse must require BOTH sides to be blocking.
+    { severity: "major", file: "b.ts", summary: "Naming nit" },
+    { severity: "nit", file: "a.ts", summary: "Missing null check" },      // never verified anyway
+  ];
+  const plan = planPriorVerifications(detected, prior);
+  assert.deepEqual(plan.reuseIdx, [0, -1, -1, -1]);
+  assert.deepEqual(plan.sentIdx, [1, 2, 3]);
+  // The two outputs are one decision expressed twice; nothing may fall between.
+  assert.equal(plan.reuseIdx.length, prior.length);
+  assert.deepEqual(plan.sentIdx, plan.reuseIdx.map((j, i) => (j < 0 ? i : -1)).filter((i) => i >= 0));
+});
+
+test("planPriorVerifications: claim type splits, and junk plans nothing", () => {
+  const absence = { severity: "major", file: "a.ts", summary: "No test covers parseX", claimType: "absence" };
+  const presence = { severity: "major", file: "a.ts", summary: "No test covers parseX" };
+  assert.deepEqual(planPriorVerifications([presence], [absence]).reuseIdx, [-1],
+    "a presence verdict must not settle an absence claim");
+  assert.deepEqual(planPriorVerifications([absence], [absence]).reuseIdx, [0]);
+
+  // Runs inside the per-lens path with a prior-findings file the panel does not
+  // control (`parsePriorFindings` only guarantees "objects"), so it must plan
+  // rather than throw. Everything unmatched simply gets verified, as today.
+  assert.deepEqual(planPriorVerifications(null, null), { reuseIdx: [], sentIdx: [] });
+  assert.deepEqual(planPriorVerifications([null, "x"], [null, {}, presence]).reuseIdx, [-1, -1, -1]);
+});
+
+test("the prior tally counts the SENT subset, not every prior finding", () => {
+  // The one link a unit test cannot reach: main() opens sessions. Two things must
+  // hold together or the change reports a saving it did not make — the verify
+  // loop must inherit on a match, and the tally must then exclude those. Tallying
+  // `priorForLens` would count one session twice in `sentToVerifier` and land a
+  // second `errored` on a finding the fresh pass already counted.
+  const src = readFileSync(path.join(HERE, "review-panel.mjs"), "utf8");
+  // Code lines only: the docblocks below quote both shapes to explain them, and a
+  // whole-file grep would read that prose as the code it warns about.
+  const code = src.split("\n").filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l)).join("\n");
+  assert.match(code, /if \(reuseIdx\[i\] >= 0\) return verdicts\[reuseIdx\[i\]\] \?\? null;/,
+    "the verify loop must inherit the fresh verdict on a match");
+  assert.match(code, /verifierTally\(\s*sentIdx\.map/, "the prior tally must read the sent subset");
+  assert.ok(!/verifierTally\(priorForLens/.test(code), "the prior tally must not read every prior finding");
 });
 
 test("main() validates every manifest effort before spending a token", () => {
@@ -2569,6 +2676,28 @@ test("buildStageDetail: verifications cover only what reached the verifier", () 
   const errored = buildStageDetail({ fresh: [major], freshVerdicts: [] });
   assert.equal(errored.verifications[0].verdict, null);
   assert.equal(errored.verifications[0].dropped, false);
+});
+
+test("buildStageDetail: an inherited prior verdict is marked as one", () => {
+  // The capture is the durable, replayable record of what the round did. A prior
+  // row whose verdict came from its fresh twin looks, unmarked, exactly like a
+  // row a session produced — so counting "prior-round verifications" in it would
+  // overstate the spend by precisely what the reuse saves.
+  const major = { severity: "major", file: "a.ts", summary: "blocking" };
+  const other = { severity: "major", file: "b.ts", summary: "also blocking" };
+  const keep = { verdict: "confirmed", confidence: "high", refutationGround: "none", groundedIn: [] };
+  const detail = buildStageDetail({
+    fresh: [major], freshVerdicts: [keep],
+    prior: [major, other], priorVerdicts: [keep, keep], priorReuseIdx: [0, -1],
+  });
+  const prior = detail.verifications.filter((v) => v.population === "prior-round");
+  assert.equal(prior[0].reused, true, "the re-found one inherited its verdict");
+  // Absent, not false: every row written before this shipped, and every row that
+  // really was verified, keeps its exact previous shape.
+  assert.ok(!("reused" in prior[1]), "a genuinely verified prior row is unmarked");
+  assert.ok(!("reused" in detail.verifications.find((v) => v.population === "fresh")));
+  const noPlan = buildStageDetail({ prior: [major], priorVerdicts: [keep] });
+  assert.ok(!("reused" in noPlan.verifications[0]), "an omitted plan marks nothing");
 });
 
 test("buildStageDetail: derives only — it never mutates its inputs", () => {


### PR DESCRIPTION
## Summary

Stops the panel verifying the same defect twice in one round, once as a fresh
detection and once as a carried-forward prior finding.

## Why

`main()` verifies this round's `detected` findings, then verifies each of the
lens's prior-round blocking findings **separately and unconditionally**, and only
afterwards merges the two:

```js
const merged = clusterFindings(dedupeFindings([...kept, ...priorKept]));
```

So on every round ≥ 2 a still-open defect the fresh pass re-found is verified
**twice, in two wordings, in the same round** — the same duplicate spend
`clusterFindings` was introduced to remove, one axis over. On #605 round 3 that
was up to 13 redundant verifier sessions.

The two copies were never both going to survive. `dedupeFindings` collapses them
on the line above, so a pair sharing its key had at most one survivor all along.
Verifying both was paying twice for one finding, by construction.

## The matching rule

`sameFinding` is built **on** `dedupeFindings`' key — extracted as `findingKey`
so a second copy of the expression cannot drift looser than the merge the safety
argument rests on — plus one field:

- **claim type.** Not a matter of wording: it selects the verifier's whole
  procedure (hunt for a counterexample vs. look the code up), its turn budget,
  and which `refutationGround`s `isDroppingVerdict` will act on. A presence
  verdict must not settle an absence claim however identically the two read.
  `dedupeFindings` *would* collapse that pair, so this guard is the rule's own.

**Not `clusterFindings`' fuzzy similarity.** Fuzzy matching is safe when the
consequence is a merge — every folded wording still rides in `mergedFrom` and is
rendered, so a bad merge is visible — and unsafe when the consequence is that a
verification does not happen, where a near-miss silently applies one defect's
verdict to another with nothing rendered to make the mistake visible.

`severity`, `evidence` and `searchedFor` are deliberately **out**. They change
the prompt's framing, not the claim. Requiring them would make the rule
essentially never fire, because the carry-forward round trip normalises severity
and truncates evidence at 2000 chars — a rule that never fires is not a safe
rule, it is a dead one that looks safe. Checked rather than assumed, by running
the workflow's own persistence mapper over realistic findings:

```
REUSED | plain presence    | merge collapses: true
REUSED | absence claim     | merge collapses: true
REUSED | clustered finding | merge collapses: true
verify | 2001-char summary | merge collapses: false
```

The last row is the only non-firing case, and it stays in lockstep with the
merge: a truncated summary is a different key, so those two findings do not
collapse today either and both are verified exactly as before.

## The trap: reuse requires BOTH sides to be blocking

A blocking prior matching a **minor** fresh twin would inherit that twin's
`null` — never verified, since `verifyBlocking` skips non-blockers — and
`dedupeFindings` keeps the higher severity, so a blocking finding would reach the
gate **unverified** where today it is checked. Requiring both sides closes it,
and there is a test named for exactly this case.

## What this changes at the gate

Stated up front rather than left to be found. Today the two copies get two
independent verdicts and the **OR** of them decides — whichever copy survives
`keepUnrefuted` wins the dedup slot, so the finding lives if *either* session
kept it. Now one verdict decides both, and it moves in both directions:

| fresh | prior | today | now |
|---|---|---|---|
| keep | keep | survives | survives |
| keep | drop | survives (fresh) | survives — and the prior copy, carrying no novelty lane, outranks a `backlog` fresh twin at dedup |
| **drop** | **keep** | **survives (prior)** | **dropped** |
| drop | drop | dropped | dropped |

On identical text that only differs when two sessions disagree, which is model
noise rather than a second opinion worth paying for. It is also the call
**#591/#601 already made** when clustering moved ahead of verification — one
defect, one verdict — applied to the fresh-vs-prior axis. It needs no
`resolveClusterVerdict`-style bound because this match is exact rather than
fuzzy: there is no distinct wording that could have merged in unverified.

## Two accounting details

**The tally reads the sent subset.** `priorVerdicts` now carries inherited
verdicts, and tallying those would count one session twice in `sentToVerifier` —
reporting no saving on the round this exists to make cheaper — and land a second
`errored` on a finding the fresh pass already counted, re-introducing exactly the
findings-vs-sessions conflation #640 removed. Both arrays index through the same
`sentIdx`, so they cannot drift the way two separately-filtered copies would.

**`reusedPriorVerdicts` is reported**, because the saving is otherwise invisible:

```
- Sent to verifier: 12
- Prior findings re-found this round: 4 (verified once, not twice)
```

`sentToVerifier` falls when the reuse works — and it also falls when the lenses
simply raise less, and those two readings call for opposite actions. Each reuse
is exactly one `verifyFinding` call not made, so the number is literally the
sessions saved. The stage-detail capture marks inherited rows (`reused: true`)
for the same reason: unmarked, a later pass counting prior-round verifications in
it would overstate the round's spend by precisely what this change saves.

Both are omitted at zero, so round 1 and every round recorded before this shipped
render byte-identically. There are tests asserting that.

## Linked Issues

None — this came out of a cost analysis of the review panel.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained in *Why* above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

`cd scripts/agent && node --test *.test.mjs` → **517 pass, 0 fail** (1 skip,
pre-existing on `main`); 498 before this PR. The `agent:tests` lane of
`pnpm verify:self` passes locally. The other lanes need a full install in a fresh
worktree and cannot observe these files anyway — `scripts/agent` sits outside the
pnpm workspace — so the push used `--no-verify` and CI runs the full lane.

The round-trip table above is printed by running the workflow's persistence
mapper against the real exported functions, not hand-written.

## Risk Assessment

- **User-facing risk:** none. Panel-internal.
- **Data/security risk:** none. No new input reaches a prompt; this only decides
  which prompts are *not* sent.
- **Rollback plan:** revert the single commit.

**Recall.** The row-3 case above is a genuine change and the reason this is not
filed as pure cost work: a finding that today survives because one of two
sessions kept it can now be dropped. The bar for that drop is unchanged and high
(`refuted` + `high` + a named ground + a real `file:line` the verifier read), and
the alternative is paying for a second opinion on byte-identical text whose
disagreements are noise. Watch `Refuted`/`dropped` against `Findings raised` over
the next few round-2+ PRs.

**Skipping a verification cannot un-gate anything on its own** — a finding with
no verdict is kept, and `annotateFindings`/`gatingFindings` are untouched.

## Notes for Reviewers

**AI assistance:** this PR was written with Claude Code — the analysis, the diff,
and the tests.

Three things worth a look:

1. **`findingKey` is an extraction, not a new rule.** `dedupeFindings` is
   byte-for-byte equivalent afterwards; the point is that `sameFinding` is now
   built on the same expression rather than a copy of it, so "never looser than
   the merge" is structural. There is a test that asserts the implication
   directly over a table of pairs.

2. **The plan does not see verdicts, deliberately.** A matched fresh verdict of
   `null` is inherited rather than re-verified. Treating the prior copy as a
   second attempt would be a retry policy expressed as an accident of a finding
   appearing in two lists — available to duplicates and nothing else. The retry
   policy lives in `withRetry` inside `verifyFinding` (#640), where it applies to
   every verification, and `classifyResult` marks the non-retryable kinds
   non-retryable on purpose.

3. **`sameFinding` is symmetric**, including on empty summaries, where it is
   deliberately stricter than the key: `coerceFindings` rewrites a malformed
   summary to one shared placeholder, and two placeholders in a file are not one
   claim. Both argument orders are pinned, since an asymmetric "same" would make
   the plan depend on which list a finding happened to be in.

- Follow-up: #613, #614, #615, #630, #636 and #640 have merged. Next in the plan
  is telling every lens what CI already checks, in one place, so lenses stop
  spending turns re-deriving what `verify:self` already proves.
