### PR TITLE
Attribute CodeRabbit findings to the panel's own findings

### DIFF
--- a/docs/tasks/active/20260803-finding-level-matching-todo.md
+++ b/docs/tasks/active/20260803-finding-level-matching-todo.md
@@ -1,0 +1,174 @@
+# Finding-level matching: tell a restatement from a miss
+
+Script-only, offline harvesting tooling. Changes nothing about what the panel
+decides or what gets reviewed.
+
+## The problem
+
+`harvest.mjs`'s second signature files every CodeRabbit blocking finding as "the
+panel missed this". It cannot do otherwise: the only thing it knows about the panel's
+output is a **count**. `panelVerdictAt` computed `blockingFindings` via
+`tagPriorFindings` and dropped the findings on the floor, so the harvester could say
+the panel raised three blockers and never whether one of them was the comment in
+hand.
+
+So signature 2 over-fires by construction, and the noise lands on a human curator via
+the `verifiedBy` gate. The module's own header names this as the central risk —
+harvester noise is *systematic*, it follows whatever the matcher over-fires on, so it
+moves the panel somewhere specific and wrong rather than nowhere.
+
+## The change
+
+- [x] `scripts/agent/finding-match.mjs` — the anchor layer and the layered matcher,
+      ported from the eval-harness archive branch. `extractAnchor`, `anchorIsEmpty`,
+      `linesOverlap`, `compareAnchors`, `tokenOverlap`, `matchFindings`, `bestMatch`.
+      The two eval-only shape adapters (`labelToFinding`, `artifactToFinding`) were
+      left behind — they describe artifacts that do not exist upstream.
+- [x] **The similarity metric is not re-derived.** `findingSimilarity`,
+      `summaryTokens`, `DEFAULT_SIMILARITY` and `MIN_SHARED_TOKENS` are imported from
+      `rounds.mjs`, which owns them. What this module adds is a *location* signal —
+      a different axis from text — mined from the `summary`/`evidence` prose the
+      finding schema has no field for.
+- [x] `MIN_SHARED_TOKENS` gained an `export` in `rounds.mjs`. One keyword, no
+      behaviour change, no new caller of the old kind: `tokenOverlap` needs the same
+      floor for the same reason and copying `3` into a second file is the drift
+      `CITATION` and `REFUTATION_GROUNDS` both exist to avoid.
+- [x] `panelVerdictAt` returns `blockers` — the blocking findings themselves —
+      alongside the existing three fields, which callers depend on. The **blocking
+      subset only**: a CodeRabbit blocker "already raised" by a nit the panel filed is
+      not a gate hit, and matching against non-blocking findings would suppress a real
+      gate miss on the strength of a passing remark.
+- [x] `attributeToPanel` in `harvest.mjs` — `match` suppresses (counted and logged),
+      `maybe` emits flagged, `no` emits, and the verdict lands in `panelSaw`
+      alongside its score and the panel finding it matched. No new top-level field;
+      `schema` stays `wafflebase/miss@1`.
+- [x] Both sides compared **lens-neutral**, via the `{ ...f, lens: "" }` copy
+      `clusterFindings` already uses. Not a second approach to the same problem.
+      CodeRabbit's lens is a category→lens guess and is often `""`, and a defect the
+      panel raised under a *different* lens is still a defect the panel raised.
+- [x] `codeRabbitDetail` — title plus prose, cut at the first `<details>`, fence or
+      HTML comment. See "Corrected from the plan".
+- [x] 540 agent tests (503 on `main`), all green, no `node_modules` needed.
+
+## Corrected from the plan
+
+**The plan said to feed the matcher CodeRabbit's `summary`. That is six tokens.**
+`summaryTokens("Guard public mutation APIs at the read-only boundary.")` reduces to
+`guard, public, mutation, apis, read, boundary`, and `findingSimilarity` scores
+containment over the *smaller* token set — so two incidentally shared words clear the
+0.3 bar. The title alone is not a summary, it is a headline.
+
+Feeding the **whole body** fails the other way, and in the dangerous direction. Every
+CodeRabbit comment ends with a `🤖 Prompt for AI Agents` block opening with the same
+boilerplate sentence — *"Verify each finding against current code. Fix only
+still-valid issues…"* — contributing `code`, `fix`, `issues`, `changes`, `validate`
+to **every** comparison, plus committable-suggestion blocks that dump literal source.
+Against a ~15-token panel summary that inflates containment on exactly the vocabulary
+every finding in the file already shares, producing false matches where the panel had
+the *most* findings — eating real misses where they are densest.
+
+So the two channels get different text: **title + prose** for the token comparison,
+the **whole body** for the anchor layer, where more text is strictly better and the
+`around lines 395 - 397` range in that same boilerplate block is the most precise
+location signal a review comment carries. Verified against all 10 inline findings on
+#548, #594 and #639: the body is always header → title → prose → blocks, and prose
+never resumes after the first block.
+
+**The ported L2 promoted on location alone.** Its match condition scored
+`max(tokenOverlap, symbolOverlap)` against the threshold, and `symbolOverlap` is 1.0
+whenever both sides name exactly one symbol and it is the same one — so two distinct
+defects that both touch `parseARef`, sharing no summary vocabulary at all, matched at
+1.00. That is the one thing the anchor layer must never do. The gate now keys on
+token overlap; anchors keep their veto and their contribution to the reported score,
+and get no vote on clearing the bar.
+
+**A backticked path was being mined as a bag of symbols.** `IDENT_RE` ran over every
+backtick span including ` `@packages/docs/src/view/text-editor.ts` `, minting
+`packages`, `docs`, `src`, `view` as *symbols* — so any two findings under one
+directory shared symbols on tree vocabulary alone. `PATH_RE` already records the same
+string as a file. CodeRabbit backticks the path on every finding, which makes this
+reachable rather than theoretical.
+
+## Fail directions
+
+| path | on doubt | why |
+|---|---|---|
+| `matchFindings` ambiguity | `maybe` | a false `match` suppresses a candidate, and a suppressed candidate is a miss nobody can recover later; a false `maybe` costs one line of reading |
+| `attributeToPanel` throws | `maybe` | suppressing would silently drop a real miss, emitting unflagged would restore the noise the matcher exists to remove — `maybe` honours "never throw" without choosing either |
+| panel verdict unreadable | `""`, not `no` | `blockers` is `null` for "could not establish" and `[]` for "the panel raised none". The candidate still emits, but the record does not claim the matcher looked and found nothing |
+| anchors name disjoint symbols | demote to `maybe`, never drop | a rephrasing can legitimately name different helpers |
+| every read path | fewer candidates, never throws | unchanged: a GitHub hiccup costs this run's proposals, not the corpus |
+| the one write (`--append`) | **refuses** | unchanged |
+
+`verifiedBy` stays `""` on every harvested record — `toMissRecord` defaults it and no
+harvest path passes it. `dedupeById` still keeps the **first** occurrence, so a
+re-harvest can never blank a human's curation.
+
+## Explicit non-goals
+
+**No second similarity metric.** The one in `rounds.mjs` is calibrated against real
+data; a hand-tuned copy would rot.
+
+**No change to `clusterFindings`,** and this was measured rather than assumed. Over
+153 real captured findings (10 (item, lens) groups, 1,249 pairs), an anchor guard
+blocks **0 of the 39 merges** clustering performs. It is not vacuous — it disagrees
+on 42% of the population generally — but of the 45 pairs that clear the text
+threshold, **none** disagree on anchors. Upstream's clustering is already
+anchor-consistent, so a guard there is pure surface area on a production gate path.
+The opposite direction (merge when anchors agree but text does not) surfaces 53
+candidates of which roughly one is a genuine missed merge; the rest are distinct
+defects sharing domain vocabulary.
+
+**No change to what the panel decides or what gets reviewed.** This is offline
+harvesting tooling. Nothing here runs in the gate path.
+
+**No LLM adjudication.** The designed L3 stays unbuilt until the `maybe` queue is
+shown to be worth paying to shrink. Today that queue is empty (below).
+
+## Verification
+
+- [x] 540 agent tests green (`node --test "scripts/agent/*.test.mjs"`), 503 before.
+- [x] 28 matcher tests, including both trap regressions: a `0` from
+      `findingSimilarity` is not read as "different file" (the gate is checked
+      directly, because 0 also means "same file, under the token floor"), and a
+      `null` `symbolOverlap` means *no evidence*, never disagreement.
+- [x] A third regression for the promotion bug above: shared anchors alone reach
+      `maybe`, never `match`.
+- [x] Harvest-level tests: a restatement is suppressed and logged, an unrelated
+      finding still emits, an ambiguous one emits flagged, an unreadable panel
+      verdict records `""` rather than `no`, and a matcher throw resolves to `maybe`.
+- [x] *EVERY harvested candidate is unverified* still passes.
+
+### On real data: the change is a no-op, and that is the finding
+
+Run against the live API over **every merged agent PR** (33 of the last 200 merged;
+the harvester skips non-agent PRs, which is why #594/#608/#639 contribute nothing):
+
+| | count |
+|---|---:|
+| CodeRabbit blocking candidates, before | 5 |
+| CodeRabbit blocking candidates, after | 5 |
+| suppressed (`match`) | **0** |
+| flagged (`maybe`) | 0 |
+
+Not one record changed. **On all 33 PRs the panel had zero blocking findings at
+`headAtHandoff`** — that is the commit that let the PR through, and `mark-ready.mjs`
+only promotes when the panel approves, so an approving panel has no blockers by
+definition. The comparison set is empty, and every CodeRabbit blocker is unmatched by
+construction. The count-based version gave the same answer; this one reaches it
+honestly and says so in the record.
+
+The union-of-all-rounds comparison set was measured as the alternative and rejected:
+only **2 of 33** PRs have any retrievable panel finding in any round (#605, #521), and
+neither carries a CodeRabbit candidate, so it would also produce 0 suppressions at
+the cost of one API call per commit.
+
+So the value here is **latent**: before this change the harvester could not tell a
+restatement from a miss, and now it can. On the current corpus there is nothing to
+tell apart.
+
+## Not built
+
+Union-of-all-rounds attribution (measured above, no signal yet). L3 LLM adjudication
+of the `maybe` queue. A `harvest --report` roll-up of suppression counts over time,
+which is what would show whether the matcher is earning its place.

--- a/docs/tasks/active/20260803-finding-level-matching-todo.md
+++ b/docs/tasks/active/20260803-finding-level-matching-todo.md
@@ -5,17 +5,21 @@ decides or what gets reviewed.
 
 ## The problem
 
-`harvest.mjs`'s second signature files every CodeRabbit blocking finding as "the
-panel missed this". It cannot do otherwise: the only thing it knows about the panel's
-output is a **count**. `panelVerdictAt` computed `blockingFindings` via
+`harvest.mjs`'s second signature filed every CodeRabbit blocking finding as "the
+panel missed this". It could not do otherwise: the only thing it knew about the
+panel's output was a **count**. `panelVerdictAt` computed `blockingFindings` via
 `tagPriorFindings` and dropped the findings on the floor, so the harvester could say
 the panel raised three blockers and never whether one of them was the comment in
 hand.
 
-So signature 2 over-fires by construction, and the noise lands on a human curator via
-the `verifiedBy` gate. The module's own header names this as the central risk —
+So signature 2 over-fired by construction, and the noise landed on a human curator
+via the `verifiedBy` gate. The module's own header names this as the central risk —
 harvester noise is *systematic*, it follows whatever the matcher over-fires on, so it
 moves the panel somewhere specific and wrong rather than nowhere.
+
+Underneath that sat a second problem, found while measuring the first: **signature 2
+had inherited signature 1's preconditions**, and they cost it every PR where the
+comparison was actually possible. See "Corrected from the plan".
 
 ## The change
 
@@ -30,79 +34,118 @@ moves the panel somewhere specific and wrong rather than nowhere.
       a different axis from text — mined from the `summary`/`evidence` prose the
       finding schema has no field for.
 - [x] `MIN_SHARED_TOKENS` gained an `export` in `rounds.mjs`. One keyword, no
-      behaviour change, no new caller of the old kind: `tokenOverlap` needs the same
-      floor for the same reason and copying `3` into a second file is the drift
-      `CITATION` and `REFUTATION_GROUNDS` both exist to avoid.
+      behaviour change: `tokenOverlap` needs the same floor for the same reason, and
+      copying `3` into a second file is the drift `CITATION` and `REFUTATION_GROUNDS`
+      both exist to avoid.
 - [x] `panelVerdictAt` returns `blockers` — the blocking findings themselves —
       alongside the existing three fields, which callers depend on. The **blocking
       subset only**: a CodeRabbit blocker "already raised" by a nit the panel filed is
-      not a gate hit, and matching against non-blocking findings would suppress a real
-      gate miss on the strength of a passing remark.
-- [x] `attributeToPanel` in `harvest.mjs` — `match` suppresses (counted and logged),
-      `maybe` emits flagged, `no` emits, and the verdict lands in `panelSaw`
-      alongside its score and the panel finding it matched. No new top-level field;
-      `schema` stays `wafflebase/miss@1`.
+      not a gate hit.
+- [x] `attributeToPanel` — `match` suppresses (counted and logged), `maybe` emits
+      flagged, `no` emits, and the verdict lands in `panelSaw` with its score and the
+      panel finding it matched. No new top-level field; `schema` stays
+      `wafflebase/miss@1`.
 - [x] Both sides compared **lens-neutral**, via the `{ ...f, lens: "" }` copy
-      `clusterFindings` already uses. Not a second approach to the same problem.
-      CodeRabbit's lens is a category→lens guess and is often `""`, and a defect the
-      panel raised under a *different* lens is still a defect the panel raised.
+      `clusterFindings` already uses. CodeRabbit's lens is a category→lens guess and
+      is often `""`, and a defect the panel raised under a *different* lens is still a
+      defect the panel raised.
 - [x] `codeRabbitDetail` — title plus prose, cut at the first `<details>`, fence or
-      HTML comment. See "Corrected from the plan".
-- [x] 540 agent tests (503 on `main`), all green, no `node_modules` needed.
+      HTML comment.
+- [x] `parsePanelComment` / `panelFindingsFromComments` — read the on-demand panel's
+      findings out of the comment it posts, as a **fallback** where no lens check runs
+      exist. Author-gated to the App.
+- [x] `harvestPr` restructured so each signature checks only what it needs, and
+      signature 2 requires *evidence the panel reviewed this PR*.
+- [x] `listCandidatePrs` also returns PRs carrying an on-demand panel review, found
+      via the marker the panel itself writes.
+- [x] 551 agent tests (503 on `main`), all green, no `node_modules` needed.
 
 ## Corrected from the plan
 
 **The plan said to feed the matcher CodeRabbit's `summary`. That is six tokens.**
 `summaryTokens("Guard public mutation APIs at the read-only boundary.")` reduces to
-`guard, public, mutation, apis, read, boundary`, and `findingSimilarity` scores
-containment over the *smaller* token set — so two incidentally shared words clear the
-0.3 bar. The title alone is not a summary, it is a headline.
+`guard, public, mutation, apis, read, boundary`, and containment is scored over the
+*smaller* token set — so two incidentally shared words clear the 0.3 bar.
 
 Feeding the **whole body** fails the other way, and in the dangerous direction. Every
 CodeRabbit comment ends with a `🤖 Prompt for AI Agents` block opening with the same
-boilerplate sentence — *"Verify each finding against current code. Fix only
-still-valid issues…"* — contributing `code`, `fix`, `issues`, `changes`, `validate`
-to **every** comparison, plus committable-suggestion blocks that dump literal source.
-Against a ~15-token panel summary that inflates containment on exactly the vocabulary
-every finding in the file already shares, producing false matches where the panel had
-the *most* findings — eating real misses where they are densest.
+boilerplate — *"Verify each finding against current code. Fix only still-valid
+issues…"* — contributing `code`, `fix`, `issues`, `changes`, `validate` to **every**
+comparison, plus committable-suggestion blocks that dump literal source. Against a
+~15-token panel summary that inflates containment on the vocabulary every finding in
+the file already shares, producing false matches where the panel had the *most*
+findings — eating real misses where they are densest.
 
 So the two channels get different text: **title + prose** for the token comparison,
 the **whole body** for the anchor layer, where more text is strictly better and the
 `around lines 395 - 397` range in that same boilerplate block is the most precise
 location signal a review comment carries. Verified against all 10 inline findings on
-#548, #594 and #639: the body is always header → title → prose → blocks, and prose
-never resumes after the first block.
+#548, #594 and #639.
 
 **The ported L2 promoted on location alone.** Its match condition scored
-`max(tokenOverlap, symbolOverlap)` against the threshold, and `symbolOverlap` is 1.0
-whenever both sides name exactly one symbol and it is the same one — so two distinct
-defects that both touch `parseARef`, sharing no summary vocabulary at all, matched at
-1.00. That is the one thing the anchor layer must never do. The gate now keys on
-token overlap; anchors keep their veto and their contribution to the reported score,
-and get no vote on clearing the bar.
+`max(tokenOverlap, symbolOverlap)`, and `symbolOverlap` is 1.0 whenever both sides
+name exactly one symbol and it is the same one — so two distinct defects both
+touching `parseARef`, sharing no summary vocabulary at all, matched at 1.00. That is
+the one thing the anchor layer must never do. The gate now keys on token overlap;
+anchors keep their veto and their score contribution, and get no vote on clearing the
+bar.
 
-**A backticked path was being mined as a bag of symbols.** `IDENT_RE` ran over every
-backtick span including ` `@packages/docs/src/view/text-editor.ts` `, minting
+**A backticked path was mined as a bag of symbols.** `IDENT_RE` ran over every
+backtick span including `` `@packages/docs/src/view/text-editor.ts` ``, minting
 `packages`, `docs`, `src`, `view` as *symbols* — so any two findings under one
-directory shared symbols on tree vocabulary alone. `PATH_RE` already records the same
-string as a file. CodeRabbit backticks the path on every finding, which makes this
+directory shared symbols on tree vocabulary alone. `PATH_RE` already records that
+string as a file. CodeRabbit backticks the path on every finding, so this was
 reachable rather than theoretical.
+
+**Signature 2 was gated on signature 1's preconditions, and that was where all the
+data went.** Measuring the change found it suppressing nothing at all, on any PR in
+the repo's history. Three separate causes, none of them the matcher:
+
+1. **`isAgentPr` gated the whole function.** Signature 1 needs it (a hand-off only
+   exists on a promoted agent PR). Signature 2 does not: *"CodeRabbit flagged
+   something our panel reviewed and did not raise"* is exactly as true on a human PR
+   someone ran `@claude review` on.
+2. **A missing hand-off marker skipped the whole PR.** 18 of 33 agent PRs were opened
+   ready rather than promoted from draft, so they have neither a marker nor a
+   `ready_for_review` event. For signature 1 that is correct — without the moment the
+   panel let go, "after" has no referent. For signature 2 `handoffAt` is not merely
+   unknown but *meaningless*: nothing was handed off.
+3. **`panelVerdictAt` reads check runs, and the on-demand panel writes none.**
+   `agent-review-on-demand.yml` says so four times over — *"purely advisory: it
+   records NO check runs"*, `checks: read` and never `checks: write`. Its findings
+   exist only as markdown in a PR comment. That population — 14 PRs carrying 1-38
+   blocking findings each — was structurally invisible.
+
+Fixing all three is what turned the change from a measured no-op into three real
+suppressions. It also opened a hazard that had to be closed in the same breath:
+widening the population means PRs the panel *never reviewed* would have every
+CodeRabbit blocker filed as a miss. Hence `panelReviewed`.
+
+**`conclusion === ""` vs `blockers: []`.** A commit with zero lens runs returned an
+empty `blockers` array, which read as "the panel raised nothing" and kept the comment
+fallback unreachable. `panelVerdictAt` already distinguishes them — `conclusion` is
+`""` exactly when no lens ran — so the check-run result is only trusted when a run
+existed.
 
 ## Fail directions
 
 | path | on doubt | why |
 |---|---|---|
 | `matchFindings` ambiguity | `maybe` | a false `match` suppresses a candidate, and a suppressed candidate is a miss nobody can recover later; a false `maybe` costs one line of reading |
-| `attributeToPanel` throws | `maybe` | suppressing would silently drop a real miss, emitting unflagged would restore the noise the matcher exists to remove — `maybe` honours "never throw" without choosing either |
-| panel verdict unreadable | `""`, not `no` | `blockers` is `null` for "could not establish" and `[]` for "the panel raised none". The candidate still emits, but the record does not claim the matcher looked and found nothing |
-| anchors name disjoint symbols | demote to `maybe`, never drop | a rephrasing can legitimately name different helpers |
-| every read path | fewer candidates, never throws | unchanged: a GitHub hiccup costs this run's proposals, not the corpus |
+| `attributeToPanel` throws | `maybe` | suppressing would silently drop a real miss, emitting unflagged would restore the noise the matcher exists to remove |
+| panel verdict unreadable | `""`, not `no` | `blockers` is `null` for "could not establish" and `[]` for "the panel raised none". The candidate still emits, but the record does not claim the matcher looked |
+| no evidence the panel reviewed the PR | **no candidates**, logged | "the panel did not raise this" is only a claim about the panel if the panel looked. Withheld ~29 would-be candidates across 19 PRs in the measured window. Withholding writes no row, so a later harvest re-proposes once the evidence exists; a wrong row, once curated, stays |
+| agent authorship | **not** treated as evidence of a review | measured: of 11 agent PRs carrying CodeRabbit blockers, 9 have no `agent-review-*` check run on any commit. They match `isAgentPr` by branch prefix but never went through the panel |
+| commits list unreadable | check-run path lost, comment path unaffected | `headAtHandoff` derives from the commits list, so an outage there withholds; a PR with an on-demand review still harvests. The two sources fail independently |
+| panel comment author is not the App | ignored entirely | these findings can SUPPRESS a candidate, so a forged comment could silence real misses with no trace. #578 already carries a *CodeRabbit* comment containing "Review panel" |
+| multiple on-demand reviews | the **union** of their findings | the record claims "the panel did not raise this"; a finding raised in an earlier review is one the panel raised, and filing it would put a false row in an eval corpus |
+| check runs vs comment | check runs **win** | one is the structured record, the other a rendering of it |
+| on-demand PR search fails | agent PRs only, logged | the agent PRs are already in hand, so the outage costs only the wider population |
+| every other read | fewer candidates, never throws | unchanged |
 | the one write (`--append`) | **refuses** | unchanged |
 
-`verifiedBy` stays `""` on every harvested record — `toMissRecord` defaults it and no
-harvest path passes it. `dedupeById` still keeps the **first** occurrence, so a
-re-harvest can never blank a human's curation.
+`verifiedBy` stays `""` on every harvested record. `dedupeById` still keeps the
+**first** occurrence, so a re-harvest can never blank a human's curation.
 
 ## Explicit non-goals
 
@@ -115,60 +158,84 @@ blocks **0 of the 39 merges** clustering performs. It is not vacuous — it disa
 on 42% of the population generally — but of the 45 pairs that clear the text
 threshold, **none** disagree on anchors. Upstream's clustering is already
 anchor-consistent, so a guard there is pure surface area on a production gate path.
-The opposite direction (merge when anchors agree but text does not) surfaces 53
-candidates of which roughly one is a genuine missed merge; the rest are distinct
-defects sharing domain vocabulary.
 
-**No change to what the panel decides or what gets reviewed.** This is offline
-harvesting tooling. Nothing here runs in the gate path.
+**No change to what the panel decides or what gets reviewed.** Offline tooling only.
+In particular this does **not** make the on-demand review write check runs — it reads
+what that path already publishes. Making it persist findings properly is a separate
+change on the producer side, and it would want check names distinct from
+`agent-review-<lens>` so an advisory review cannot be mistaken for a gating one.
 
 **No LLM adjudication.** The designed L3 stays unbuilt until the `maybe` queue is
-shown to be worth paying to shrink. Today that queue is empty (below).
+shown to be worth paying to shrink. In the measured window that queue is empty.
 
 ## Verification
 
-- [x] 540 agent tests green (`node --test "scripts/agent/*.test.mjs"`), 503 before.
-- [x] 28 matcher tests, including both trap regressions: a `0` from
-      `findingSimilarity` is not read as "different file" (the gate is checked
-      directly, because 0 also means "same file, under the token floor"), and a
-      `null` `symbolOverlap` means *no evidence*, never disagreement.
-- [x] A third regression for the promotion bug above: shared anchors alone reach
-      `maybe`, never `match`.
-- [x] Harvest-level tests: a restatement is suppressed and logged, an unrelated
-      finding still emits, an ambiguous one emits flagged, an unreadable panel
-      verdict records `""` rather than `no`, and a matcher throw resolves to `maybe`.
+- [x] 551 agent tests green (`node --test "scripts/agent/*.test.mjs"`), 503 before.
+- [x] Both trap regressions: a `0` from `findingSimilarity` is not read as "different
+      file" (0 also means "same file, under the token floor"), and a `null`
+      `symbolOverlap` means *no evidence*, never disagreement.
+- [x] A third regression for the promotion bug: shared anchors alone reach `maybe`,
+      never `match`.
+- [x] Harvest-level: a restatement is suppressed and logged, an unrelated finding
+      emits, an ambiguous one emits flagged, an unreadable verdict records `""`
+      rather than `no`, a matcher throw resolves to `maybe`, a forged panel comment
+      is ignored, check runs beat the comment, and a search outage degrades.
 - [x] *EVERY harvested candidate is unverified* still passes.
 
-### On real data: the change is a no-op, and that is the finding
+### On real data
 
-Run against the live API over **every merged agent PR** (33 of the last 200 merged;
-the harvester skips non-agent PRs, which is why #594/#608/#639 contribute nothing):
+Full run over the harvestable population, `--since 2026-07-01` (100 PRs):
 
 | | count |
 |---|---:|
-| CodeRabbit blocking candidates, before | 5 |
-| CodeRabbit blocking candidates, after | 5 |
-| suppressed (`match`) | **0** |
-| flagged (`maybe`) | 0 |
+| CodeRabbit candidates emitted | 2 |
+| **suppressed as restatements of a panel finding** | **3** |
+| human-fix candidates | 21 |
+| would-be candidates withheld — panel never reviewed the PR | ~29 |
 
-Not one record changed. **On all 33 PRs the panel had zero blocking findings at
-`headAtHandoff`** — that is the commit that let the PR through, and `mark-ready.mjs`
-only promotes when the panel approves, so an approving panel has no blockers by
-definition. The comparison set is empty, and every CodeRabbit blocker is unmatched by
-construction. The count-based version gave the same answer; this one reaches it
-honestly and says so in the record.
+**Every emitted CodeRabbit candidate is now backed by an actual panel review**, and
+both carry `matchVerdict: "no"` — compared and unmatched, not "we could not check".
+#548 was compared against readable lens check runs; #559 against a *"Review panel:
+looks good"* comment, i.e. a panel that reviewed and raised nothing, which makes a
+CodeRabbit blocker there a genuine miss candidate.
 
-The union-of-all-rounds comparison set was measured as the alternative and rejected:
-only **2 of 33** PRs have any retrievable panel finding in any round (#605, #521), and
-neither carries a CodeRabbit candidate, so it would also produce 0 suppressions at
-the cost of one API call per commit.
+An earlier iteration of this change emitted 17 with 15 of them carrying
+`matchVerdict: ""` — no comparison possible. Chasing that down is what found the
+authorship assumption: those 15 were on agent PRs the panel had never reviewed at
+all. `""` is now unreachable for a CodeRabbit record by construction, since signature
+2 does not run without a comparison set.
 
-So the value here is **latent**: before this change the harvester could not tell a
-restatement from a miss, and now it can. On the current corpus there is nothing to
-tell apart.
+The three suppressions, each inspected by hand and each a genuine restatement:
+
+- **#582** — CR *"Security lens scopeClasses is missing `design-spec`"* ↔ panel *"The
+  security lens's `scopeClasses` omits `design-spec`, so a `docs/design/**`-only PR
+  is reviewed by design-fit alone"*. Score 1.00.
+- **#582** — CR *"Docs lens `appliesWhen` is missing `docs/…`"* ↔ panel *"…does not
+  cover `docs/**/*.txt`, which the `prose` class does"*. Score 1.00.
+- **#578** — CR *"Retryability is inferred from message text, not status"*, whose body
+  states *"`resets?\b` matches substrings like 'connection reset by peer'"* ↔ panel
+  *"the quota-detection regex's `resets?\b` alternative matches ordinary transient
+  network errors"*. Same regex, same reasoning. Score 0.75.
+
+Both PRs are human-authored and carry no lens check runs, so **all three were
+unreachable before this change** — and all three would have been filed as panel
+misses.
+
+Caveat worth stating: with 3/3 matching there is no negative control in the real
+sample. The `no` and `maybe` paths are evidenced only by tests.
 
 ## Not built
 
-Union-of-all-rounds attribution (measured above, no signal yet). L3 LLM adjudication
-of the `maybe` queue. A `harvest --report` roll-up of suppression counts over time,
-which is what would show whether the matcher is earning its place.
+**Reading lens check runs without a hand-off.** `headAtHandoff` anchors the check-run
+read, so on a PR with no hand-off marker only the comment path reaches signature 2.
+Measured cost today: none — every PR in that population has zero lens runs on *any*
+commit, so an all-commits read (`prCommitsWithCheckRuns` + `allCheckRuns`, the way
+`collectPrior` does it) finds nothing either. Asserted in the tests so it cannot
+change silently.
+
+Persisting on-demand review findings as structured data on the producer side (the
+harvester reads the comment instead). L3 LLM adjudication. A `harvest --report`
+roll-up of suppression counts over time, which is what would show whether the matcher
+keeps earning its place. The 5 existing `misses.jsonl` records keep their original
+three-field `panelSaw`; they are readable and rewriting them would touch rows a human
+may yet curate.

--- a/scripts/agent/finding-match.mjs
+++ b/scripts/agent/finding-match.mjs
@@ -1,0 +1,334 @@
+// Does finding A describe the SAME defect as finding B?
+//
+// `harvest.mjs` needs this and had no way to ask it. Its CodeRabbit signature
+// knew only how MANY blocking findings the panel raised, so it filed every
+// CodeRabbit blocker as "the panel missed this" — including the ones the panel
+// caught and worded differently. That over-fire is systematic rather than
+// random, which is the failure harvest.mjs's own header warns about: noise that
+// follows a matcher moves the panel somewhere specific and wrong.
+//
+// THE SIMILARITY METRIC IS NOT RE-DERIVED HERE. `rounds.mjs` owns it —
+// `summaryTokens`, the overlap-over-Jaccard choice, `MIN_SHARED_TOKENS` and the
+// 0.3 threshold, all calibrated against PR #564's four real rephrasings of one
+// defect. This module imports every one of them. What it ADDS is a location
+// signal, which is a different axis from text: the panel's finding schema has no
+// line or symbol field, but its `summary`/`evidence` prose leaks both, and
+// mining that at scoring time gives sub-file resolution with no run-layer change.
+//
+// WHY LOCATION IS A DEMOTER AND NEVER A PROMOTER. Measured over 1,249 real pairs
+// from 153 captured findings: 55% of ALL pairs share at least one symbol, because
+// in a focused PR nearly every finding names the same identifiers. Anchor
+// agreement therefore means "same topic", not "same defect". L1 and L2 below use
+// anchors to demote a pair to `maybe`; nothing is ever promoted to `match` on
+// location alone. Raising the match rate by relaxing that would re-introduce
+// exactly the over-fire this module exists to remove.
+//
+// The same measurement is why there is no hook into `review-panel.mjs ::
+// clusterFindings`. As a merge guard the anchor layer blocks 0 of the 39 merges
+// clustering performs — of the 45 pairs that clear the text threshold, none
+// disagree on anchors. Upstream's clustering is already anchor-consistent, so a
+// guard there would be pure surface area on a production gate path.
+//
+// LAYERS. `matchFindings` → { verdict, score, method, reason }:
+//   L0  same-run pairs: `findingSimilarity` unchanged, behind its own (lens,
+//       file) gate;
+//   L1  the anchor demotion — same file, both sides named symbols, no symbol in
+//       common ⇒ almost certainly two defects in one file;
+//   L2  cross-source pairs (CodeRabbit / human / a stored label), where the
+//       absolute file gate is wrong because two reviewers can blame different
+//       files for one defect. A soft location score replaces it.
+// A designed L3 (LLM adjudication of the residual `maybe`s) is deliberately
+// unbuilt: it costs money per pair, and nothing has yet shown the `maybe` queue
+// is worth paying to shrink.
+//
+// FAIL DIRECTION: ambiguity resolves to `maybe`, never `match`. A false match
+// SUPPRESSES a candidate, and a suppressed candidate is a miss nobody can
+// recover later; a false `maybe` costs a curator one line of reading.
+
+import { findingSimilarity, summaryTokens, DEFAULT_SIMILARITY, MIN_SHARED_TOKENS } from "./rounds.mjs";
+
+// Code-ish words that appear inside backticks but identify nothing.
+const SYMBOL_STOP = new Set([
+  "true", "false", "null", "undefined", "const", "let", "var", "function", "return",
+  "this", "new", "await", "async", "void", "string", "number", "boolean", "any",
+  "type", "class", "import", "export", "from", "the", "and", "not", "for",
+]);
+
+const CODE_EXT = "ts|tsx|js|jsx|mjs|cjs|json|css|scss|md|mdx|html|yml|yaml";
+const PATH_RE = new RegExp(`\\b[\\w./-]*[\\w-]+\\.(?:${CODE_EXT})\\b`, "g");
+// `line 214`, `lines 626-640`, `lines ~626–640` (en/em dashes tolerated). Also
+// matches CodeRabbit's `around lines 395 - 397`, which is the most precise
+// location signal available anywhere in a review comment.
+const LINES_RE = /\blines?\s*~?\s*(\d+)\s*(?:[-–—]\s*~?\s*(\d+))?/gi;
+// a path/symbol suffixed with a line: `formula.ts:1054`, `foo.ts#L88`
+const SUFFIX_LINE_RE = new RegExp(`(?:${CODE_EXT})[:#]L?(\\d+)\\b`, "gi");
+// a backtick-quoted span (its inside is treated as code)
+const BACKTICK_RE = /`([^`]+)`/g;
+// an identifier that is being CALLED, in prose: `foo(` / `Foo.bar(`
+const CALL_RE = /\b([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(/g;
+// a bare identifier token (used only inside backticked code)
+const IDENT_RE = /[A-Za-z_$][\w$]*/g;
+
+const isSignalIdent = (s) => s.length >= 3 && !SYMBOL_STOP.has(s.toLowerCase()) && !/^\d/.test(s);
+
+/**
+ * Location anchor mined from a finding's `summary` + `evidence`:
+ *   { symbols: string[], lines: [start,end][], files: string[] }
+ * - symbols: identifiers from backticked code spans and prose call-sites
+ *   (dotted chains kept whole AND split, so `Sheet.getUsedBounds` yields the chain
+ *   plus `getUsedBounds`). Deduped case-insensitively, original casing preserved.
+ * - lines: soft ranges; a single `line N` becomes [N,N]. Never compared for exact
+ *   equality downstream — LLM line numbers drift, so the matcher uses a window.
+ * - files: paths named in the prose (BESIDES finding.file), the cross-source
+ *   file-disagreement signal for L2.
+ */
+export function extractAnchor(finding) {
+  const text = `${finding?.summary ?? ""}\n${finding?.evidence ?? ""}`;
+
+  const symbols = new Map(); // lowercased → original (first seen)
+  const addSym = (s) => { if (isSignalIdent(s)) { const k = s.toLowerCase(); if (!symbols.has(k)) symbols.set(k, s); } };
+
+  // symbols from backticked code spans, MINUS any path inside them.
+  //
+  // A backticked path is a LOCATION and `PATH_RE` below already records it in
+  // `files`. Letting IDENT_RE loose on it too mints its segments as symbols —
+  // `packages`, `docs`, `src`, `view` out of
+  // `` `@packages/docs/src/view/text-editor.ts` `` — so any two findings under one
+  // directory would "share symbols" on tree vocabulary alone. That is not a
+  // harmless extra signal: `symbolOverlap` feeds L2's content score, so it can
+  // manufacture a `match`, and a false match suppresses a candidate silently.
+  // CodeRabbit's `🤖 Prompt for AI Agents` block backticks the file path on every
+  // finding, which is what makes this reachable rather than theoretical.
+  for (const m of text.matchAll(BACKTICK_RE)) {
+    for (const id of m[1].replace(PATH_RE, " ").matchAll(IDENT_RE)) addSym(id[0]);
+  }
+  // symbols from prose call-sites: keep the whole dotted chain and each segment
+  for (const m of text.matchAll(CALL_RE)) {
+    addSym(m[1]);
+    if (m[1].includes(".")) for (const seg of m[1].split(".")) addSym(seg);
+  }
+
+  // line hints
+  const lines = [];
+  for (const m of text.matchAll(LINES_RE)) {
+    const a = Number(m[1]); const b = m[2] ? Number(m[2]) : a;
+    if (Number.isFinite(a)) lines.push([Math.min(a, b), Math.max(a, b)]);
+  }
+  for (const m of text.matchAll(SUFFIX_LINE_RE)) {
+    const n = Number(m[1]); if (Number.isFinite(n)) lines.push([n, n]);
+  }
+
+  // file paths named in the prose (excluding the finding's own file)
+  const own = String(finding?.file ?? "");
+  const files = new Set();
+  for (const m of text.matchAll(PATH_RE)) if (m[0] !== own) files.add(m[0]);
+
+  return {
+    symbols: [...symbols.values()],
+    lines: dedupeRanges(lines),
+    files: [...files],
+  };
+}
+
+function dedupeRanges(ranges) {
+  const seen = new Set();
+  const out = [];
+  for (const r of ranges) { const k = `${r[0]}:${r[1]}`; if (!seen.has(k)) { seen.add(k); out.push(r); } }
+  return out;
+}
+
+/** True when the anchor carries no usable location signal → the matcher must fall
+ *  back to L0 (file + token overlap) for this finding. */
+export function anchorIsEmpty(anchor) {
+  return !anchor || (anchor.symbols.length === 0 && anchor.lines.length === 0 && anchor.files.length === 0);
+}
+
+// --- anchor comparison ------------------------------------------------------
+
+const lowerSet = (xs) => new Set((xs ?? []).map((s) => s.toLowerCase()));
+
+export const LINE_WINDOW = 15;
+
+/** Line ranges overlap within a tolerance window. LLM line numbers drift, so this
+ *  is deliberately a window, never equality. */
+export function linesOverlap(a, b, window = LINE_WINDOW) {
+  for (const [s1, e1] of a ?? []) {
+    for (const [s2, e2] of b ?? []) {
+      if (s1 - window <= e2 && s2 - window <= e1) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * How the two anchors relate: { sharedSymbols, symbolOverlap, lineHit }.
+ *
+ * `symbolOverlap` is a containment coefficient over symbols — the same
+ * overlap-over-Jaccard rationale as `findingSimilarity`, since one side routinely
+ * names far more symbols than the other.
+ *
+ * It is `null`, NOT 0, when either side named no symbol at all. That distinction
+ * is load-bearing everywhere it is read: `null` means "no evidence either way"
+ * and 0 means "both sides named symbols and they share none", which is the only
+ * shape that counts as disagreement.
+ */
+export function compareAnchors(a, b) {
+  const A = lowerSet(a?.symbols); const B = lowerSet(b?.symbols);
+  let shared = 0;
+  for (const s of A) if (B.has(s)) shared++;
+  const denom = Math.min(A.size, B.size);
+  return {
+    sharedSymbols: shared,
+    symbolOverlap: denom === 0 ? null : shared / denom,
+    lineHit: linesOverlap(a?.lines, b?.lines),
+  };
+}
+
+// --- the layered matcher ----------------------------------------------------
+
+const trim = (s) => String(s ?? "").trim();
+const res = (verdict, score, method, reason, extra = {}) => ({ verdict, score, method, reason, ...extra });
+
+/** Do the two findings tie to a location at all? Exact same file = 1; a file named
+ *  in the other's evidence, or a basename tie across different depths = 0.6; else
+ *  0. An empty `file` on either side scores 0 — absent, not equal. */
+function locationScore(a, b, anA, anB) {
+  const fa = trim(a.file); const fb = trim(b.file);
+  if (fa && fb && fa === fb) return 1;
+  const namedByB = fa && (anB.files ?? []).some((f) => f === fa || fa.endsWith(`/${f}`) || f.endsWith(`/${fa}`));
+  const namedByA = fb && (anA.files ?? []).some((f) => f === fb || fb.endsWith(`/${f}`) || f.endsWith(`/${fb}`));
+  if (namedByA || namedByB) return 0.6;
+  // basename agreement (packages/x/foo.ts vs foo.ts) — different depth, same file
+  const base = (p) => p.split("/").pop();
+  if (fa && fb && base(fa) === base(fb)) return 0.6;
+  return 0;
+}
+
+/**
+ * Decide whether two findings describe the same defect.
+ *
+ * `opts.crossSource` (default false) selects the gate. Within one panel run both
+ * operands are panel-shaped and the absolute (lens, file) gate is right, so L0/L1
+ * apply. Across sources it is wrong — CodeRabbit has no lens, and two reviewers
+ * can blame different files for one defect — so L2's soft gate applies instead.
+ * `opts.threshold` overrides the token bar.
+ *
+ * Verdicts: `match` (confident), `maybe` (plausible — emit, flagged for a human),
+ * `no`. Conservative by construction: ambiguity yields `maybe`.
+ */
+export function matchFindings(a, b, opts = {}) {
+  if (!a || !b) return res("no", 0, "guard", "missing operand");
+  const crossSource = opts.crossSource === true;
+  const threshold = opts.threshold ?? DEFAULT_SIMILARITY;
+
+  const anA = extractAnchor(a);
+  const anB = extractAnchor(b);
+  const cmp = compareAnchors(anA, anB);
+
+  // ---- same-run path: L0 similarity, then the L1 anchor gate ----------------
+  if (!crossSource) {
+    // The (lens, file) gate is checked HERE rather than inferred from a 0 score:
+    // `findingSimilarity` returns 0 both for "gate failed" and for "same file but
+    // under MIN_SHARED_TOKENS", and those must not be conflated. The first is a
+    // structural no; the second is inconclusive, and its anchors may still agree
+    // decisively. Reading `sim === 0` as "different file" would skip the anchor
+    // check on exactly the pairs that need it.
+    if (trim(a.lens) !== trim(b.lens) || trim(a.file) !== trim(b.file)) {
+      return res("no", 0, "L0-similarity", "different lens or file (same-run gate)", { anchor: cmp });
+    }
+    const sim = findingSimilarity(a, b);
+
+    // L1 — same file and both sides named symbols, but they share NONE: almost
+    // certainly two different defects in one file. Demote rather than drop, since
+    // a rephrasing can legitimately name different helpers.
+    const disjoint = cmp.symbolOverlap === 0 && !cmp.lineHit;
+    if (sim >= threshold) {
+      return disjoint
+        ? res("maybe", sim, "L1-anchor", `token overlap ${sim.toFixed(2)} but anchors share no symbol — likely distinct defects in one file`, { anchor: cmp })
+        : res("match", sim, "L0-similarity", `token overlap ${sim.toFixed(2)} ≥ ${threshold}${cmp.sharedSymbols ? `, ${cmp.sharedSymbols} shared symbol(s)` : ""}`, { anchor: cmp });
+    }
+    // below the token bar but anchors agree strongly → worth a look, not a match
+    if (cmp.lineHit || (cmp.symbolOverlap != null && cmp.symbolOverlap >= 0.5)) {
+      return res("maybe", sim, "L1-anchor", `token overlap ${sim.toFixed(2)} < ${threshold} but anchors agree`, { anchor: cmp });
+    }
+    return res("no", sim, "L0-similarity", `token overlap ${sim.toFixed(2)} < ${threshold}`, { anchor: cmp });
+  }
+
+  // ---- cross-source path: L2 soft location gate ----------------------------
+  const loc = locationScore(a, b, anA, anB);
+  const tokens = tokenOverlap(a.summary, b.summary);
+  // Reported strength of the pair. `symbolOverlap` may raise the SCORE, but it may
+  // not decide the verdict — see the match condition below.
+  const content = Math.max(tokens, cmp.symbolOverlap ?? 0);
+  const anchorsAgree = cmp.lineHit || cmp.sharedSymbols > 0;
+  // Anchors DISAGREE only when both sides named symbols and share none. A null
+  // `symbolOverlap` means one side named nothing — no evidence either way, which
+  // must not be read as disagreement. Same null-vs-zero distinction as the L0 gate.
+  const anchorsDisagree = cmp.symbolOverlap === 0 && !cmp.lineHit;
+
+  // Never match on text alone across sources: no location tie AND no anchor
+  // agreement ⇒ no. This is the floodgate a file-only matcher opens — one
+  // CodeRabbit comment matched 40 panel findings on file co-location alone.
+  if (loc === 0 && !anchorsAgree) {
+    return res("no", 0, "L2-xsource", "no location tie and no shared anchor symbol", { anchor: cmp });
+  }
+  // Combined score: location and content must BOTH contribute.
+  const score = 0.5 * Math.max(loc, anchorsAgree ? 0.6 : 0) + 0.5 * content;
+  // The bar is TOKEN overlap, not `content`. Scoring the gate on
+  // `max(tokens, symbolOverlap)` would let a single shared identifier carry a pair
+  // to `match` with zero textual agreement — `symbolOverlap` is 1.0 whenever both
+  // sides name exactly one symbol and it is the same one. That is promotion on
+  // location alone, which is the one thing the anchor layer must never do: 55% of
+  // real pairs share a symbol, so it would merge distinct defects that happen to
+  // touch the same helper, and in `harvest.mjs` a false match SUPPRESSES a
+  // candidate. Anchors keep their veto (`anchorsDisagree`) and their contribution
+  // to the reported score; they do not get a vote on clearing the bar.
+  if (loc >= 0.6 && tokens >= threshold && !anchorsDisagree) {
+    return res("match", score, "L2-xsource",
+      `location ${loc}, tokens ${tokens.toFixed(2)}${anchorsAgree ? ", shared anchor" : ""}`, { anchor: cmp });
+  }
+  const why = anchorsDisagree ? "anchors name disjoint symbols" : `location ${loc}, content ${content.toFixed(2)}`;
+  return res("maybe", score, "L2-xsource", `partial evidence (${why}) — needs adjudication`, { anchor: cmp });
+}
+
+/**
+ * Token containment between two free-text summaries, with no (lens, file) gate —
+ * the part of `findingSimilarity` that survives a cross-source comparison.
+ *
+ * `MIN_SHARED_TOKENS` is imported rather than dropped, and that matters here more
+ * than it does upstream. The constant encodes `findingSimilarity`'s calibration
+ * note — real same-defect pairs share 7-17 tokens, real different-defect pairs at
+ * most 1 — and it is the guard against a high ratio computed off a tiny numerator.
+ * Cross-source operands are exactly where summaries get short: a CodeRabbit title
+ * is ~6 significant tokens, at which length two incidentally shared words clear a
+ * 0.3 containment bar. Keeping the floor keeps the threshold meaning what it was
+ * calibrated to mean.
+ */
+export function tokenOverlap(s1, s2) {
+  const ta = summaryTokens(s1); const tb = summaryTokens(s2);
+  if (ta.length === 0 || tb.length === 0) return 0;
+  const B = new Set(tb);
+  let shared = 0;
+  for (const t of ta) if (B.has(t)) shared++;
+  if (shared < MIN_SHARED_TOKENS) return 0;
+  return shared / Math.min(ta.length, tb.length);
+}
+
+/**
+ * Best match for `needle` among `candidates`. Returns
+ * `{ index, candidate, result }` for the highest-scoring non-`no` pair, or null
+ * when every candidate is a `no`.
+ *
+ * Ties break toward `match` over `maybe`, then higher score — so a caller can
+ * treat `result.verdict === "maybe"` as "emit this, flagged for a human".
+ */
+export function bestMatch(needle, candidates, opts = {}) {
+  let best = null;
+  (candidates ?? []).forEach((candidate, index) => {
+    const result = matchFindings(needle, candidate, opts);
+    if (result.verdict === "no") return;
+    const rank = (r) => (r.verdict === "match" ? 1 : 0) * 10 + r.score;
+    if (!best || rank(result) > rank(best.result)) best = { index, candidate, result };
+  });
+  return best;
+}

--- a/scripts/agent/finding-match.test.mjs
+++ b/scripts/agent/finding-match.test.mjs
@@ -1,0 +1,268 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractAnchor, anchorIsEmpty, compareAnchors, linesOverlap,
+  matchFindings, tokenOverlap, bestMatch,
+} from "./finding-match.mjs";
+import { findingSimilarity } from "./rounds.mjs";
+
+test("extractAnchor: pulls backticked symbols from real-shaped evidence", () => {
+  // modeled on the pr-521 resolveRange finding
+  const a = extractAnchor({
+    file: "packages/sheets/src/model/core/coordinates.ts",
+    summary: "`resolveRange` throws a raw TypeError on a reference without ':'",
+    evidence: "`resolveRange` does `const [fromStr, toStr] = srng.split(':')`; `parsePartialRef(undefined)` dereferences `.replace`",
+  });
+  const lower = a.symbols.map((s) => s.toLowerCase());
+  assert.ok(lower.includes("resolverange"));
+  assert.ok(lower.includes("parsepartialref"));
+  assert.ok(lower.includes("frompstr") === false); // sanity: made-up token absent
+  assert.ok(!lower.includes("const")); // stopword dropped
+});
+
+test("extractAnchor: keeps dotted chains whole AND split into segments", () => {
+  const a = extractAnchor({ file: "x.ts", summary: "`Sheet.getUsedBounds()` awaits per formula cell", evidence: "" });
+  const lower = a.symbols.map((s) => s.toLowerCase());
+  assert.ok(lower.includes("sheet.getusedbounds")); // whole chain
+  assert.ok(lower.includes("getusedbounds"));        // segment
+});
+
+test("extractAnchor: prose call-sites count as symbols", () => {
+  const a = extractAnchor({ file: "x.ts", summary: "the diff never updates extractFormulaRanges(), which still parses every token", evidence: "" });
+  assert.ok(a.symbols.map((s) => s.toLowerCase()).includes("extractformularanges"));
+});
+
+test("extractAnchor: line hints → soft ranges (single and span)", () => {
+  const a = extractAnchor({ file: "x.ts", summary: "introduces <Tooltip> at lines ~626-640", evidence: "throws at line 214" });
+  assert.deepEqual(a.lines.sort((p, q) => p[0] - q[0]), [[214, 214], [626, 640]]);
+});
+
+test("extractAnchor: reads CodeRabbit's `around lines N - M` form", () => {
+  // The `🤖 Prompt for AI Agents` block every CodeRabbit finding carries states an
+  // exact, GitHub-anchored range. It is the most precise location signal available
+  // in a review comment and appears nowhere else in the body, so the harvester
+  // feeds the whole comment to the anchor layer specifically to reach it.
+  const a = extractAnchor({
+    file: "packages/docs/src/view/text-editor.ts",
+    summary: "Guard public mutation APIs at the read-only boundary.",
+    evidence: "In `@packages/docs/src/view/text-editor.ts` around lines 395 - 397, enforce read-only mode",
+  });
+  assert.deepEqual(a.lines, [[395, 397]]);
+});
+
+test("extractAnchor: path:line suffix contributes a line", () => {
+  const a = extractAnchor({ file: "a.ts", summary: "", evidence: "the input parser (input.ts:242) already treats TRUE/FALSE case-insensitively" });
+  assert.ok(a.lines.some(([s, e]) => s === 242 && e === 242));
+});
+
+test("extractAnchor: names OTHER files but not the finding's own file", () => {
+  const a = extractAnchor({
+    file: "packages/sheets/src/formula/formula.ts",
+    summary: "reconstructed string is fed to extractReferences in calculator.ts",
+    evidence: "docs/design/sheets/formula.md claims whole-column highlighting; formula.ts is unchanged",
+  });
+  assert.ok(a.files.includes("calculator.ts"));
+  assert.ok(a.files.includes("docs/design/sheets/formula.md"));
+  assert.ok(!a.files.includes("packages/sheets/src/formula/formula.ts")); // own file excluded
+});
+
+test("extractAnchor: a backticked PATH is a file, never a bag of symbols", () => {
+  // CodeRabbit backticks the file path on every finding. Running the identifier
+  // scanner over it as well would mint `packages`/`docs`/`src`/`view` as SYMBOLS,
+  // so any two findings under one directory would "share symbols" on tree
+  // vocabulary alone — and `symbolOverlap` is read as location evidence.
+  const a = extractAnchor({
+    file: "",
+    summary: "see `@packages/docs/src/view/text-editor.ts` for the guard",
+    evidence: "",
+  });
+  assert.deepEqual(a.symbols, []);
+  assert.ok(a.files.includes("packages/docs/src/view/text-editor.ts"));
+});
+
+test("extractAnchor: symbols are deduped case-insensitively, original casing kept", () => {
+  const a = extractAnchor({ file: "x.ts", summary: "`toRange` then `toRange`", evidence: "`ToRange`" });
+  const toRange = a.symbols.filter((s) => s.toLowerCase() === "torange");
+  assert.equal(toRange.length, 1);
+  assert.equal(toRange[0], "toRange"); // first-seen casing
+});
+
+test("anchorIsEmpty: true only when no symbol, line, or extra file", () => {
+  assert.equal(anchorIsEmpty(extractAnchor({ file: "x.ts", summary: "a vague prose finding with no code or location", evidence: "" })), true);
+  assert.equal(anchorIsEmpty(extractAnchor({ file: "x.ts", summary: "`foo()` bug", evidence: "" })), false);
+});
+
+// --- anchor comparison ------------------------------------------------------
+
+test("linesOverlap: window-tolerant, never exact equality", () => {
+  assert.equal(linesOverlap([[100, 100]], [[108, 108]]), true);  // within the 15-line window
+  assert.equal(linesOverlap([[100, 100]], [[200, 200]]), false); // far apart
+  assert.equal(linesOverlap([[100, 140]], [[135, 150]]), true);  // ranges genuinely overlap
+  assert.equal(linesOverlap([], [[1, 1]]), false);               // nothing to compare
+});
+
+test("compareAnchors: symbol containment + null when one side names nothing", () => {
+  const a = { symbols: ["resolveRange", "toRange"], lines: [], files: [] };
+  const b = { symbols: ["resolveRange"], lines: [], files: [] };
+  const c = compareAnchors(a, b);
+  assert.equal(c.sharedSymbols, 1);
+  assert.equal(c.symbolOverlap, 1);           // containment over the SMALLER set
+  assert.equal(compareAnchors(a, { symbols: [], lines: [], files: [] }).symbolOverlap, null);
+});
+
+// --- L0 / L1 (same-run) -----------------------------------------------------
+
+const pf = (file, summary, evidence = "", lens = "correctness") => ({ lens, file, summary, evidence });
+
+test("matchFindings L0: two wordings of ONE defect in the same file → match", () => {
+  const a = pf("arguments.ts", "blank-skip in `Arguments.iterate` makes MIN/MAX over an all-blank range return #NUM!");
+  const b = pf("arguments.ts", "`Arguments.iterate` blank skipping causes MIN and MAX over blank ranges to return #NUM! instead of 0");
+  const r = matchFindings(a, b);
+  assert.equal(r.verdict, "match");
+  assert.ok(r.score >= 0.3);
+});
+
+test("matchFindings L0: different file or lens → no (the same-run gate)", () => {
+  const a = pf("a.ts", "`foo()` mishandles blank cells returning #NUM!");
+  assert.equal(matchFindings(a, pf("b.ts", "`foo()` mishandles blank cells returning #NUM!")).verdict, "no");
+  assert.equal(matchFindings(a, pf("a.ts", "`foo()` mishandles blank cells returning #NUM!", "", "security")).verdict, "no");
+});
+
+test("matchFindings L1: same file, high token overlap, but DISJOINT anchors → demoted to maybe", () => {
+  // Two genuinely different defects that share generic vocabulary in one file.
+  const a = pf("plugin.ts", "the relaxation accepts markers and changes paragraph interrupt behaviour for notes", "`isEmptyBulletLine` is the culprit");
+  const b = pf("plugin.ts", "the relaxation accepts markers and changes paragraph interrupt behaviour for notes", "`getRuleFn` is the culprit");
+  const r = matchFindings(a, b);
+  assert.equal(r.verdict, "maybe");
+  assert.equal(r.method, "L1-anchor");
+  assert.match(r.reason, /share no symbol/);
+});
+
+test("matchFindings L1: below the token bar but anchors agree → maybe, not no", () => {
+  const a = pf("x.ts", "guard is missing entirely here", "`toggleCheckboxAt` at lines 3837-3841");
+  const b = pf("x.ts", "formula cells are silently overwritten by the toggle path", "`toggleCheckboxAt` at line 3840");
+  const r = matchFindings(a, b);
+  assert.equal(r.verdict, "maybe");
+  assert.equal(r.method, "L1-anchor");
+});
+
+// --- regressions for the two traps this module is built around --------------
+
+test("regression: a 0 from findingSimilarity is NOT read as 'different file'", () => {
+  // `findingSimilarity` returns 0 for two unrelated reasons: the (lens, file) gate
+  // failed, or the files match and the summaries share fewer than
+  // MIN_SHARED_TOKENS. Inferring the gate from `sim === 0` conflates them and
+  // skips the anchor check on the second — which is exactly the case where the
+  // anchor is the only evidence there is. The gate is therefore checked directly.
+  const a = pf("x.ts", "guard is missing entirely here", "`toggleCheckboxAt` at lines 3837-3841");
+  const b = pf("x.ts", "formula cells are silently overwritten by the toggle path", "`toggleCheckboxAt` at line 3840");
+  assert.equal(findingSimilarity(a, b), 0);           // same lens+file, under the token floor
+  assert.equal(matchFindings(a, b).verdict, "maybe"); // anchors still get a say
+});
+
+test("regression: symbolOverlap null means NO EVIDENCE, never disagreement", () => {
+  // `null` is "one side named no symbol at all". Only 0 — both named symbols and
+  // they share none — is disagreement. Reading null as disagreement would demote
+  // every pair where one reviewer wrote prose without backticks.
+  const withSyms = pf("x.ts", "`Arguments.iterate` skips blanks so MIN and MAX return the wrong aggregate");
+  const noSyms = { file: "x.ts", summary: "iterate skips blanks so MIN and MAX return the wrong aggregate", evidence: "" };
+  assert.equal(compareAnchors(extractAnchor(withSyms), extractAnchor(noSyms)).symbolOverlap, null);
+  const r = matchFindings(withSyms, noSyms, { crossSource: true });
+  assert.equal(r.verdict, "match");
+  assert.doesNotMatch(r.reason, /disjoint/);
+});
+
+test("regression: anchors can DEMOTE but never PROMOTE — a shared symbol is not a match", () => {
+  // Measured over 1,249 real pairs, 55% share at least one symbol: in a focused PR
+  // nearly every finding names the same identifiers. Two distinct defects that
+  // both touch `parseARef`, with no summary vocabulary in common, must not merge.
+  // Keying the gate on `max(tokens, symbolOverlap)` would match them at 1.00,
+  // because symbolOverlap is 1.0 whenever both sides name one symbol and it is
+  // the same one.
+  const a = pf("formula.ts", "`parseARef` is called without a guard on the row index");
+  const b = { file: "formula.ts", summary: "the dependants map enumerates populated cells on each recalculation", evidence: "`parseARef` appears here too" };
+  assert.equal(tokenOverlap(a.summary, b.summary), 0);
+  assert.equal(compareAnchors(extractAnchor(a), extractAnchor(b)).symbolOverlap, 1);
+  assert.equal(matchFindings(a, b, { crossSource: true }).verdict, "maybe");
+});
+
+test("regression: the MIN_SHARED_TOKENS floor survives into tokenOverlap", () => {
+  // Two shared words out of a six-token summary is 0.33 — over DEFAULT_SIMILARITY,
+  // and meaningless. The floor is what makes 0.3 mean what it was calibrated to
+  // mean, and cross-source summaries (a CodeRabbit title is ~6 tokens) are exactly
+  // where summaries get short enough for it to matter.
+  assert.equal(tokenOverlap("guard mutation boundary", "guard mutation elsewhere"), 0);
+  assert.ok(tokenOverlap("guard mutation boundary apis", "guard mutation boundary elsewhere") > 0);
+});
+
+// --- L2 (cross-source) ------------------------------------------------------
+
+test("matchFindings L2: cross-source, DIFFERENT files, same defect → match via evidence-named file", () => {
+  // Our panel blames arguments.ts; the other source blames functions-statistical.ts
+  // but names arguments.ts in its prose. The absolute file gate would score this 0.
+  const panel = pf("packages/sheets/src/formula/arguments.ts",
+    "blank-skip in `Arguments.iterate` makes MIN/MAX over an all-blank range return #NUM!");
+  const other = {
+    file: "packages/sheets/src/formula/functions-statistical.ts",
+    summary: "MIN/MAX over an all-blank range returns #NUM! — blank-skip in `Arguments.iterate`",
+    evidence: "root cause lives in packages/sheets/src/formula/arguments.ts",
+  };
+  assert.equal(matchFindings(panel, other).verdict, "no"); // same-run gate rejects (different file)
+  const r = matchFindings(panel, other, { crossSource: true });
+  assert.equal(r.verdict, "match");
+  assert.equal(r.method, "L2-xsource");
+});
+
+test("matchFindings L2: never matches on text alone — no location tie and no shared symbol → no", () => {
+  const a = pf("a.ts", "the validation guard is missing so invalid input is accepted downstream");
+  const b = { file: "totally/other.ts", summary: "the validation guard is missing so invalid input is accepted downstream", evidence: "" };
+  const r = matchFindings(a, b, { crossSource: true });
+  assert.equal(r.verdict, "no");
+  assert.match(r.reason, /no location tie/);
+});
+
+test("matchFindings L2: same file but only weak content agreement → maybe (adjudication queue)", () => {
+  const a = pf("plugin.ts", "`isEmptyBulletLine` has no 4-space indent ceiling");
+  const b = { file: "plugin.ts", summary: "nitpick about `isEmptyBulletLine` markers", evidence: "at line 214" };
+  const r = matchFindings(a, b, { crossSource: true });
+  assert.ok(r.verdict === "maybe" || r.verdict === "match"); // shares a symbol + file
+  assert.equal(r.method, "L2-xsource");
+});
+
+test("matchFindings L2: an empty file on one side is ABSENT, not equal", () => {
+  // A panel finding can carry no `file` (the infra-record shape). Two empty
+  // strings must not read as "the same file" and hand the pair a location score
+  // of 1 it has not earned.
+  const a = pf("", "the paste path mutates the store while the editor is read-only");
+  const b = { file: "", summary: "the paste path mutates the store while the editor is read-only", evidence: "" };
+  assert.equal(matchFindings(a, b, { crossSource: true }).verdict, "no");
+});
+
+test("matchFindings: basename agreement counts as a partial location tie", () => {
+  const a = pf("packages/sheets/src/formula/arguments.ts", "`Arguments.iterate` blank skip breaks MIN and MAX aggregation");
+  const b = { file: "arguments.ts", summary: "`Arguments.iterate` blank skip breaks MIN and MAX aggregation", evidence: "" };
+  assert.equal(matchFindings(a, b, { crossSource: true }).verdict, "match");
+});
+
+test("matchFindings: missing operand → no, never a throw", () => {
+  assert.equal(matchFindings(null, pf("a.ts", "x")).verdict, "no");
+  assert.equal(matchFindings(pf("a.ts", "x"), undefined).verdict, "no");
+});
+
+test("tokenOverlap: containment over the smaller summary; empty → 0", () => {
+  assert.equal(tokenOverlap("blank skip breaks minmax aggregation", "blank skip breaks minmax aggregation"), 1);
+  assert.equal(tokenOverlap("", "anything here"), 0);
+});
+
+test("bestMatch: picks the strongest candidate and prefers match over maybe", () => {
+  const needle = pf("a.ts", "`resolveRange` throws a raw TypeError on a reference without a colon");
+  const candidates = [
+    pf("a.ts", "completely unrelated rendering glitch in the toolbar widget"),
+    pf("a.ts", "`resolveRange` raises a raw TypeError for a reference lacking a colon"),
+  ];
+  const best = bestMatch(needle, candidates);
+  assert.equal(best.index, 1);
+  assert.equal(best.result.verdict, "match");
+  // nothing plausible at all → null
+  assert.equal(bestMatch(needle, [pf("z.ts", "unrelated")]), null);
+});

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -58,6 +58,7 @@ import { normalizeSeverity, BLOCKING, classify } from "./severity.mjs";
 import { ORIGINS } from "./novelty.mjs";
 import { latestLensRuns, parseReviewState } from "./review-state.mjs";
 import { tagPriorFindings, lensCheckNames } from "./prior-findings.mjs";
+import { bestMatch } from "./finding-match.mjs";
 import { gh, parseArgs, commitCheckRuns, withFullOutput } from "./gh-checks.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -255,7 +256,98 @@ export function classifyCodeRabbitComment(body) {
   const category = headerWords(m[1]);
   // First bolded line after the header is CodeRabbit's one-line title.
   const title = /\*\*(.+?)\*\*/s.exec(str(body))?.[1]?.replace(/\s+/g, " ").trim() ?? "";
-  return { category, severity, lens: CR_CATEGORY_TO_LENS.get(category) ?? "", summary: title };
+  return {
+    category,
+    severity,
+    lens: CR_CATEGORY_TO_LENS.get(category) ?? "",
+    summary: title,
+    detail: codeRabbitDetail(body),
+  };
+}
+
+// Where a CodeRabbit body stops being prose. Verified against every inline
+// finding on #548, #594 and #639: the body is always header → bolded title →
+// prose → structured blocks, and prose never resumes after the first block.
+const CR_PROSE_END = /^[ \t]*(?:<details>|```|<!--)/m;
+
+/**
+ * The part of a CodeRabbit comment worth comparing as TEXT: the title plus the
+ * prose under it, stopping at the first `<details>`, fence or HTML comment.
+ *
+ * Two failure modes sit either side of this, and the boundary is what avoids both.
+ *
+ * The title ALONE is too thin. `summaryTokens` reduces a real one — "Guard public
+ * mutation APIs at the read-only boundary." — to six tokens, and `findingSimilarity`
+ * scores containment over the SMALLER token set, so two incidentally shared words
+ * would clear the 0.3 bar. (`tokenOverlap` keeps `MIN_SHARED_TOKENS` for the same
+ * reason; this is the other half of that defence.)
+ *
+ * The WHOLE body is worse, and worse in the dangerous direction. Every comment ends
+ * with a `🤖 Prompt for AI Agents` block opening with the same boilerplate sentence
+ * — "Verify each finding against current code. Fix only still-valid issues…" —
+ * which alone contributes `code`, `fix`, `issues`, `changes`, `validate` to every
+ * single comparison, plus committable-suggestion blocks that dump literal source.
+ * Against a ~15-token panel summary that inflates containment on the vocabulary
+ * every finding in the file already shares, producing false matches exactly where
+ * the panel had the most findings — i.e. eating real misses where they are densest.
+ *
+ * The full body still reaches the ANCHOR layer (harvestPr passes it as `evidence`),
+ * because `extractAnchor` mines structured items — backticked identifiers, the
+ * `around lines N - M` range — where more text is strictly better.
+ */
+export function codeRabbitDetail(body) {
+  const text = str(body);
+  const cut = text.search(CR_PROSE_END);
+  return (cut === -1 ? text : text.slice(0, cut))
+    .replace(CR_HEADER, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Verdicts `attributeToPanel` can reach. `""` is a fourth state and means the
+ *  question was never asked — see `attributeToPanel`. */
+export const MATCH_VERDICTS = new Set(["match", "maybe", "no"]);
+
+/**
+ * Did the panel already raise this CodeRabbit finding, in different words?
+ *
+ * `blockers` is the panel's blocking findings, or `null` when we could not
+ * establish them (no readable check runs). Those are different questions and get
+ * different answers: `null` yields verdict `""` — "not asked" — which emits the
+ * candidate exactly as this module did before matching existed. An empty ARRAY is
+ * a real answer: the panel raised nothing blocking, so a CodeRabbit blocker is by
+ * definition unmatched.
+ *
+ * Both sides are compared LENS-NEUTRAL. CodeRabbit's lens is a category→lens guess
+ * that is often `""`, and `findingSimilarity` scores any lens mismatch 0 outright.
+ * `clusterFindings` already solved this upstream with a `{ ...f, lens: "" }` copy;
+ * this is the same move, not a second one. The deeper reason is that a defect the
+ * panel raised under a DIFFERENT lens is still a defect the panel raised.
+ *
+ * FAIL DIRECTION — `maybe`, deliberately in the middle. Suppressing on error would
+ * silently drop a real miss, which is the one loss this corpus cannot recover
+ * later; emitting unflagged would restore the noise the matcher exists to remove.
+ * `maybe` honours "never throw" without choosing either.
+ */
+export function attributeToPanel(finding, blockers) {
+  if (!Array.isArray(blockers)) return { verdict: "", score: 0, matchedSummary: "" };
+  try {
+    const neutral = (f) => ({
+      lens: "",
+      file: str(f?.file),
+      summary: str(f?.summary),
+      evidence: str(f?.evidence),
+    });
+    const best = bestMatch(neutral(finding), blockers.map(neutral), { crossSource: true });
+    if (!best) return { verdict: "no", score: 0, matchedSummary: "" };
+    return {
+      verdict: best.result.verdict,
+      score: Math.round(best.result.score * 100) / 100,
+      matchedSummary: str(best.candidate.summary),
+    };
+  } catch (err) {
+    return { verdict: "maybe", score: 0, matchedSummary: "", error: err.message };
+  }
 }
 
 /**
@@ -292,10 +384,18 @@ export function toMissRecord(fields) {
     severity: f.severity == null || f.severity === "" ? "" : normalizeSeverity(f.severity),
     origin: ORIGINS.includes(f.origin) ? f.origin : "unknown",
     summary: str(f.summary),
+    // The match fields live INSIDE `panelSaw` rather than at the top level: they
+    // are three more things we know about what the panel saw, and `schema` is
+    // `wafflebase/miss@1`. They are present on every record, empty on the paths
+    // that never ask the question, because a corpus read in diffs is easier to
+    // scan when every line has the same shape.
     panelSaw: {
       reviewedSha: str(saw.reviewedSha),
       conclusion: str(saw.conclusion),
       blockingFindings: Number.isFinite(Number(saw.blockingFindings)) ? Number(saw.blockingFindings) : 0,
+      matchVerdict: MATCH_VERDICTS.has(saw.matchVerdict) ? saw.matchVerdict : "",
+      matchScore: Number.isFinite(Number(saw.matchScore)) ? Number(saw.matchScore) : 0,
+      matchedSummary: str(saw.matchedSummary),
     },
     verifiedBy: str(f.verifiedBy),
     notes: str(f.notes),
@@ -381,7 +481,14 @@ export function dedupeById(records) {
 
 /**
  * What the panel concluded on a given commit: `{reviewedSha, conclusion,
- * blockingFindings}`.
+ * blockingFindings, blockers}`.
+ *
+ * `blockers` is the blocking findings THEMSELVES, and it is the whole reason
+ * signature 2 can be more than a guess. This function used to compute the count
+ * and drop the findings on the floor, so the CodeRabbit path could say the panel
+ * raised three blockers but never whether one of them was the comment in hand —
+ * every CodeRabbit blocker was filed as a miss by construction. `blockingFindings`
+ * stays a count because callers and the record format depend on it.
  *
  * `reviewedSha` comes from the lens run's `external_id` (incremental review's
  * state pointer) rather than from the commit the run is attached to, because on a
@@ -411,7 +518,16 @@ export function panelVerdictAt(runsByLens) {
       break;
     }
   }
-  return { reviewedSha, conclusion, blockingFindings: classify(findings).blockingCount };
+  const classified = classify(findings);
+  return {
+    reviewedSha,
+    conclusion,
+    blockingFindings: classified.blockingCount,
+    // The BLOCKING subset only. A CodeRabbit blocker "already raised" by a nit the
+    // panel filed is not a gate hit, and matching against non-blocking findings
+    // would suppress a real gate miss on the strength of a passing remark.
+    blockers: classified.findings.filter((f) => BLOCKING.has(f.severity)),
+  };
 }
 
 // --- gh-backed collection ----------------------------------------------------
@@ -457,13 +573,16 @@ function readyForReviewAt(pr, api) {
  */
 export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}) {
   const records = [];
+  // CodeRabbit comments the matcher attributed to a panel finding, so they were
+  // NOT filed. Reported by the CLI: a suppression nobody can see is a deletion.
+  let suppressed = 0;
   let meta;
   try {
     meta = api(["api", `repos/{owner}/{repo}/pulls/${pr}`]);
   } catch (err) {
-    return { records, skipped: `could not read PR #${pr} (${err.message})` };
+    return { records, skipped: `could not read PR #${pr} (${err.message})`, suppressed };
   }
-  if (!isAgentPr(meta)) return { records, skipped: `#${pr} is not an agent PR` };
+  if (!isAgentPr(meta)) return { records, skipped: `#${pr} is not an agent PR`, suppressed };
 
   let comments = [];
   try {
@@ -479,7 +598,7 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
   }
   const handoffAt = handoffTime({ comments, readyForReviewAt: ready });
   if (!handoffAt) {
-    return { records, skipped: `#${pr} has no hand-off marker and no ready_for_review event` };
+    return { records, skipped: `#${pr} has no hand-off marker and no ready_for_review event`, suppressed };
   }
 
   // The verdict that LET THE PR THROUGH: the newest lens runs on or before the
@@ -511,11 +630,20 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
   // looking at and we could not read what it concluded. Collapsing both into ""
   // would make an API hiccup indistinguishable from a PR with no panel at all.
   let panelSaw = { reviewedSha: str(headAtHandoff?.sha), conclusion: "", blockingFindings: 0 };
+  // `null`, not `[]`: "we could not establish the panel's findings" is a different
+  // claim from "the panel raised none", and `attributeToPanel` answers them
+  // differently. Collapsing them would let an API hiccup read as a clean panel.
+  let panelBlockers = null;
   if (headAtHandoff?.sha) {
     try {
       const runs = commitCheckRuns(headAtHandoff.sha, { api });
       const verdict = panelVerdictAt(withFullOutput(latestLensRuns(runs, names), { api, log }));
-      panelSaw = { ...verdict, reviewedSha: verdict.reviewedSha || headAtHandoff.sha };
+      panelSaw = {
+        reviewedSha: verdict.reviewedSha || headAtHandoff.sha,
+        conclusion: verdict.conclusion,
+        blockingFindings: verdict.blockingFindings,
+      };
+      panelBlockers = verdict.blockers;
     } catch (err) {
       log(`#${pr}: could not read the panel's verdict (${err.message}); recording it as unknown.`);
     }
@@ -566,6 +694,29 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
     if (!finding) continue;
     const files = interestingFiles([str(rc.path)]);
     if (files.length === 0) continue;
+
+    // `rc.path` RAW, not the filtered `files` above: `interestingFiles` exists to
+    // decide what may carry a miss, and reusing it here would silently hand the
+    // matcher an empty file — i.e. no location evidence — for a comment we have a
+    // path for. The panel side's `file` may legitimately be empty (the infra-record
+    // shape), which `locationScore` reads as absent rather than as a match.
+    // Prose for the token comparison, the whole body for the anchor layer.
+    const attribution = attributeToPanel(
+      { file: str(rc.path), summary: finding.detail, evidence: str(rc.body) },
+      panelBlockers,
+    );
+    if (attribution.verdict === "match") {
+      // Counted and logged rather than dropped in silence. A matcher that quietly
+      // eats candidates is indistinguishable from a PR nobody reviewed, and this
+      // is the number that says whether the matcher is earning its place.
+      suppressed++;
+      log(
+        `#${pr}: CodeRabbit comment ${rc.id} restates a panel finding ` +
+          `(score ${attribution.score}: "${attribution.matchedSummary}"); not filed as a miss.`,
+      );
+      continue;
+    }
+
     records.push(
       toMissRecord({
         id: candidateId("coderabbit", pr, rc.id),
@@ -582,12 +733,21 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
         lens: finding.lens,
         severity: finding.severity,
         summary: finding.summary,
-        panelSaw,
-        notes: `candidate: CodeRabbit raised a ${finding.severity} ${finding.category} finding`,
+        panelSaw: {
+          ...panelSaw,
+          matchVerdict: attribution.verdict,
+          matchScore: attribution.score,
+          matchedSummary: attribution.matchedSummary,
+        },
+        notes:
+          `candidate: CodeRabbit raised a ${finding.severity} ${finding.category} finding` +
+          (attribution.verdict === "maybe"
+            ? ` — MAYBE already raised by the panel${attribution.error ? ` (matcher failed: ${attribution.error})` : ""}; needs a human decision`
+            : ""),
       }),
     );
   }
-  return { records, skipped: "" };
+  return { records, skipped: "", suppressed };
 }
 
 // --- CLI ---------------------------------------------------------------------
@@ -647,10 +807,18 @@ function cmdHarvest(args) {
   }
 
   const found = [];
+  let suppressed = 0;
   for (const pr of prs) {
-    const { records, skipped } = harvestPr(pr, { api, names });
-    if (skipped) console.error(`harvest: skipped ${skipped}`);
-    found.push(...records);
+    const result = harvestPr(pr, { api, names });
+    if (result.skipped) console.error(`harvest: skipped ${result.skipped}`);
+    found.push(...result.records);
+    suppressed += result.suppressed ?? 0;
+  }
+  if (suppressed > 0) {
+    console.error(
+      `harvest: ${suppressed} CodeRabbit finding(s) attributed to a panel finding and NOT filed. ` +
+        `Each one is named above with the panel finding it matched.`,
+    );
   }
 
   const existingText = existsSync(MISSES_PATH) ? readFileSync(MISSES_PATH, "utf8") : "";

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -304,6 +304,127 @@ export function codeRabbitDetail(body) {
     .trim();
 }
 
+// --- the panel's findings, as posted on a human PR ---------------------------
+//
+// `@claude review` runs the SAME lens panel on a human PR, and records no check
+// runs at all — agent-review-on-demand.yml says so four times over ("purely
+// advisory: it records NO check runs", `checks: read` and never `checks: write`).
+// Its findings exist only as markdown in the comment it posts. `panelVerdictAt`
+// reads check runs exclusively, so that entire population was invisible here: 14
+// PRs carrying 1-38 blocking findings each, against 27 PRs' worth of CodeRabbit
+// blockers, none of it reachable.
+//
+// So this reads the comment. It is a SECOND source for the same fact, not a
+// replacement — `harvestPr` prefers check runs where they exist, because they are
+// structured JSON rather than a rendering of it, and falls back to this.
+
+/** The machine anchor `agent-review-on-demand.yml` writes as the comment's first
+ *  line. The sha is the commit the panel actually reviewed. */
+const PANEL_COMMENT_RE = /^<!--\s*agent-review:([0-9a-f]{40})\s*-->/;
+
+/** The searchable substring of that anchor, used by `listCandidatePrs` to find the
+ *  PRs a panel reviewed on demand. Kept beside the regex it belongs to so the two
+ *  cannot drift; GitHub's comment search cannot express the sha, and does not need
+ *  to — `parsePanelComment` re-checks the full anchor and the author on read. */
+const PANEL_COMMENT_TAG = "agent-review:";
+
+/**
+ * Who may author a panel comment. EXACT logins, and this is a security gate, not
+ * tidiness — the same discipline as `CODERABBIT_LOGINS`, for a sharper reason.
+ *
+ * Findings parsed here can SUPPRESS a CodeRabbit candidate. So anyone able to
+ * forge a panel comment could silence real misses by posting text that matches
+ * them — a deletion with no trace in the corpus. Matching on the marker alone is
+ * not enough: any user can write that HTML comment. It must come from the App.
+ *
+ * Not hypothetical at this parse level: #578 carries a CODERABBIT comment whose
+ * body contains "Review panel", so a content-only match already mis-fires on real
+ * data before anyone tries.
+ */
+const PANEL_LOGINS = new Set(["yorkie-agent[bot]", "app/yorkie-agent"]);
+
+// `renderSummaryMd` emits `### <heading> (<n>)` then one `- ` row per finding.
+// Only the two BLOCKING headings are read; `Minor (non-blocking)`,
+// `Nit (non-blocking)` and the demoted section all terminate a run of rows.
+const PANEL_SECTION_RE = /^###\s+(Critical|Major|Minor|Nit|Demoted)\b/;
+const PANEL_LENS_RE = /review:\s+\*\*/;
+// `- \`file\` — summary`, the shape `section()` writes when a finding has a file.
+// The em-dash is what `section()` emits; en-dash and hyphen are tolerated because
+// this is a rendering being read back, not a wire format.
+const PANEL_FINDING_RE = /^[-*]\s+`([^`]+)`\s*[—–-]\s*(.+)$/;
+
+/**
+ * Blocking findings from one panel comment body, or `null` if it is not one.
+ *
+ * Blocking ONLY, for the same reason `panelVerdictAt` filters: a CodeRabbit
+ * blocker "already raised" by a minor note is not a gate hit, and suppressing it
+ * on that basis would hide a real miss behind a passing remark.
+ *
+ * The trailing `_(verifier could not settle this)_` marker and the `<details>`
+ * block of merged wordings are left in the summary text rather than stripped. They
+ * are words the panel wrote about this finding, `summaryTokens` discards the
+ * punctuation, and a stripper is one more thing to keep in step with the renderer.
+ *
+ * `file` keeps the rendered locator with any `:line` suffix removed, and the whole
+ * locator is repeated into `evidence` so `extractAnchor` still sees the line
+ * numbers — they are the sharpest location signal in the row.
+ */
+export function parsePanelComment(body) {
+  const text = str(body);
+  const m = PANEL_COMMENT_RE.exec(text);
+  if (!m) return null;
+  const findings = [];
+  let severity = null;
+  for (const line of text.split("\n")) {
+    // A new lens's verdict line ends the previous lens's last section.
+    if (PANEL_LENS_RE.test(line)) { severity = null; continue; }
+    const sec = PANEL_SECTION_RE.exec(line);
+    if (sec) {
+      const h = sec[1].toLowerCase();
+      severity = h === "critical" || h === "major" ? h : null;
+      continue;
+    }
+    if (/^###/.test(line)) { severity = null; continue; }
+    if (severity === null) continue;
+    const row = PANEL_FINDING_RE.exec(line);
+    if (!row) continue;
+    const locator = row[1];
+    findings.push({
+      severity,
+      file: locator.replace(/:[\d\s\-–—]+$/, ""),
+      summary: row[2].trim(),
+      evidence: `at ${locator}`,
+    });
+  }
+  return { reviewedSha: m[1], findings };
+}
+
+/**
+ * The panel's blocking findings across every on-demand review on this PR, or
+ * `null` if it was never reviewed that way.
+ *
+ * The UNION of all reviews, not the newest. The record's claim is "the panel did
+ * not raise this", and a finding the panel raised in an earlier review is one the
+ * panel raised — filing it as a miss would put a false row in an eval corpus,
+ * which this module's header calls worse than not tuning at all. That direction
+ * does widen the suppression surface, which is why every suppression is counted
+ * and logged with the finding it matched.
+ */
+export function panelFindingsFromComments(comments) {
+  let seen = false;
+  let reviewedSha = "";
+  const findings = [];
+  for (const c of Array.isArray(comments) ? comments : []) {
+    if (!PANEL_LOGINS.has(str(c?.user?.login))) continue;
+    const parsed = parsePanelComment(c?.body);
+    if (!parsed) continue;
+    seen = true;
+    if (!reviewedSha) reviewedSha = parsed.reviewedSha;
+    findings.push(...parsed.findings);
+  }
+  return seen ? { reviewedSha, findings } : null;
+}
+
 /** Verdicts `attributeToPanel` can reach. `""` is a fourth state and means the
  *  question was never asked — see `attributeToPanel`. */
 export const MATCH_VERDICTS = new Set(["match", "maybe", "no"]);
@@ -566,24 +687,35 @@ function readyForReviewAt(pr, api) {
  * Propose miss records for one PR. NEVER throws: every collection step is
  * individually caught and degrades to fewer candidates.
  *
- * Returns `{records, skipped}` — `skipped` is a human-readable reason when the PR
- * could not be examined at all, so the CLI can say WHY a PR produced nothing.
- * "Zero candidates" and "could not look" must never print the same way; the whole
- * point of the corpus is that an empty result is a claim, not a default.
+ * Returns `{records, skipped, suppressed}` — `skipped` is a human-readable reason
+ * when the PR could not be examined at all, so the CLI can say WHY a PR produced
+ * nothing. "Zero candidates" and "could not look" must never print the same way;
+ * the whole point of the corpus is that an empty result is a claim, not a default.
+ *
+ * THE TWO SIGNATURES HAVE DIFFERENT PRECONDITIONS, and conflating them cost this
+ * module its best data. Signature 1 is defined relative to a hand-off — "a human
+ * changed reviewable code AFTER the panel approved" is meaningless without the
+ * moment it approved — and only an agent PR promoted by `mark-ready.mjs` has one.
+ * Signature 2 needs neither: "CodeRabbit flagged something our panel reviewed and
+ * did not raise" is exactly as true on a human PR reviewed via `@claude review`,
+ * where `handoffAt` is not merely unknown but MEANINGLESS — nothing was handed off.
+ *
+ * Gating both on `isAgentPr` plus a hand-off marker excluded, measurably: 18 of 33
+ * agent PRs (opened ready, so they have neither a marker nor a `ready_for_review`
+ * event), and every human PR — which is where the on-demand panel reviews and the
+ * bulk of CodeRabbit's blocking findings both live. So each signature now checks
+ * only what it actually needs, and `skipped` is set only when nothing could be
+ * examined at all.
  */
 export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}) {
   const records = [];
   // CodeRabbit comments the matcher attributed to a panel finding, so they were
   // NOT filed. Reported by the CLI: a suppression nobody can see is a deletion.
   let suppressed = 0;
-  let meta;
-  try {
-    meta = api(["api", `repos/{owner}/{repo}/pulls/${pr}`]);
-  } catch (err) {
-    return { records, skipped: `could not read PR #${pr} (${err.message})`, suppressed };
-  }
-  if (!isAgentPr(meta)) return { records, skipped: `#${pr} is not an agent PR`, suppressed };
 
+  // Comments come FIRST and are load-bearing twice over: they carry the hand-off
+  // marker (signature 1's cutoff) and the on-demand panel's findings (signature
+  // 2's comparison set). One call, both facts.
   let comments = [];
   try {
     comments = listComments(pr, api);
@@ -597,20 +729,18 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
     log(`#${pr}: could not read the timeline (${err.message}).`);
   }
   const handoffAt = handoffTime({ comments, readyForReviewAt: ready });
-  if (!handoffAt) {
-    return { records, skipped: `#${pr} has no hand-off marker and no ready_for_review event`, suppressed };
-  }
 
-  // The verdict that LET THE PR THROUGH: the newest lens runs on or before the
-  // handoff. Runs from later rounds would describe a panel that had already seen
-  // the human's fix.
   let prCommits = [];
   try {
     prCommits = listCommits(pr, api);
   } catch (err) {
     log(`#${pr}: could not list commits (${err.message}); no human-fix candidates from this PR.`);
   }
-  const cutoff = Date.parse(handoffAt);
+  // `handoffAt` may be null now that signature 2 no longer requires one. NaN makes
+  // every `at <= cutoff` false, so `beforeHandoff` empties and `headAtHandoff` goes
+  // undefined — the same "could not establish it" state as an unreadable commit
+  // list. Stated rather than relied upon, because it is load-bearing.
+  const cutoff = handoffAt === null ? NaN : Date.parse(handoffAt);
   const beforeHandoff = prCommits.filter((c) => {
     const at = Date.parse(str(c?.commit?.committer?.date));
     return Number.isFinite(at) && at <= cutoff;
@@ -643,13 +773,50 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
         conclusion: verdict.conclusion,
         blockingFindings: verdict.blockingFindings,
       };
-      panelBlockers = verdict.blockers;
+      // Only a lens run that actually EXISTED is an answer. `conclusion === ""` is
+      // `panelVerdictAt`'s own signal for "no lens runs on this commit", and its
+      // `blockers` is then an empty array meaning "nothing to read" — not "the panel
+      // raised nothing". Treating those alike is what kept the on-demand comment
+      // below unreachable: a commit with zero lens runs looked like a clean panel.
+      if (verdict.conclusion !== "") panelBlockers = verdict.blockers;
     } catch (err) {
       log(`#${pr}: could not read the panel's verdict (${err.message}); recording it as unknown.`);
     }
   }
 
-  // Signature 1 — human commits after handoff.
+  // FALLBACK to the on-demand panel's comment, and only a fallback: check runs are
+  // the structured record, this is a rendering of one, so it is read exactly when
+  // there is no structured record to prefer. `panelBlockers === null` is the test
+  // rather than `.length === 0` — an autonomous panel that genuinely raised nothing
+  // has already answered the question, and overwriting that with a comment from a
+  // different review would answer a different one.
+  if (panelBlockers === null) {
+    const fromComment = panelFindingsFromComments(comments);
+    if (fromComment) {
+      panelBlockers = fromComment.findings;
+      // Only fill what is still blank. A sha established from the commit list is
+      // more precise than the comment's, and `conclusion` stays "" because an
+      // advisory review reached no gate conclusion — that is not a missing value.
+      panelSaw = {
+        ...panelSaw,
+        reviewedSha: panelSaw.reviewedSha || fromComment.reviewedSha,
+        blockingFindings: panelSaw.blockingFindings || fromComment.findings.length,
+      };
+      log(
+        `#${pr}: no lens check runs; using the on-demand panel comment ` +
+          `(${fromComment.findings.length} blocking finding(s)) as the comparison set.`,
+      );
+    }
+  }
+
+  // Signature 1 — human commits after handoff. Requires `handoffAt`: without the
+  // moment the panel let go, "after" has no referent and every commit on the PR
+  // would qualify. `isHumanFollowupCommit` returns false on an unusable cutoff, so
+  // this loop is already a no-op then; the guard is here to say so out loud and to
+  // keep the reason next to the code that depends on it.
+  if (handoffAt === null) {
+    log(`#${pr}: no hand-off marker and no ready_for_review event; no human-fix candidates (CodeRabbit signature still runs).`);
+  }
   for (const c of prCommits) {
     if (!isHumanFollowupCommit(c, handoffAt)) continue;
     let files = [];
@@ -666,7 +833,7 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
         label: "miss",
         source: "human-fix",
         pr,
-        handoffAt,
+        handoffAt: str(handoffAt),
         evidence: { commitSha: c.sha, url: str(c.html_url) },
         files,
         summary: str(c.commit?.message).split("\n")[0],
@@ -677,13 +844,36 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
   }
 
   // Signature 2 — CodeRabbit findings the panel did not raise.
+  //
+  // REQUIRES evidence that the panel reviewed this PR, and that requirement is what
+  // makes widening the population safe. "The panel did not raise this" is only a
+  // claim about the panel if the panel looked; on a PR it never reviewed, every
+  // CodeRabbit blocker files as a miss and the corpus fills with rows measuring
+  // nothing.
+  //
+  // The evidence is EMPIRICAL — readable lens check runs, or a trusted on-demand
+  // comment — and authorship is deliberately not part of it. `isAgentPr` looks like
+  // a third signal ("the pipeline reviews every agent PR by construction") and it is
+  // wrong: of 11 agent PRs carrying CodeRabbit blockers, 9 have no `agent-review-*`
+  // check run on any commit, only `verify-*` and codecov. They match `isAgentPr` by
+  // branch prefix but never went through the panel — the same 18-of-33 population
+  // that has no hand-off marker because it was opened ready rather than promoted.
+  // Trusting authorship would have filed 15 rows about a reviewer that never looked.
+  //
+  // Withholding is also the RECOVERABLE direction. No row is written, so a later
+  // harvest re-proposes the candidate once the evidence exists; a wrong row, once
+  // curated, is permanent.
+  const panelReviewed = panelBlockers !== null;
   let reviewComments = [];
   try {
     reviewComments = listReviewComments(pr, api);
   } catch (err) {
     log(`#${pr}: could not list review comments (${err.message}).`);
   }
-  for (const rc of reviewComments) {
+  if (!panelReviewed && reviewComments.length > 0) {
+    log(`#${pr}: ${reviewComments.length} review comment(s) but no evidence the panel ever reviewed this PR; no CodeRabbit candidates.`);
+  }
+  for (const rc of panelReviewed ? reviewComments : []) {
     // EXACT login, not a prefix. `startsWith("coderabbitai")` also accepts
     // `coderabbitai-x`, and anyone can register that name and comment on a public
     // PR — which would let a stranger write rows into the corpus. Curation is the
@@ -723,7 +913,7 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
         label: "miss",
         source: "coderabbit",
         pr,
-        handoffAt,
+        handoffAt: str(handoffAt),
         evidence: {
           commitSha: str(rc.original_commit_id || rc.commit_id),
           commentId: String(rc.id ?? ""),
@@ -747,7 +937,20 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
       }),
     );
   }
-  return { records, skipped: "", suppressed };
+  // `skipped` is reserved for "could not look", never "looked and found nothing".
+  // Nothing was examinable when there was no hand-off (so signature 1 could not
+  // run) AND no CodeRabbit review comment reached the matcher (so signature 2 had
+  // no input). Anything else produced a real, reportable zero.
+  const noSignature1 = handoffAt === null;
+  const noSignature2 = !panelReviewed || reviewComments.length === 0;
+  return {
+    records,
+    skipped:
+      noSignature1 && noSignature2
+        ? `#${pr} has no hand-off marker and no panel review to compare CodeRabbit against — nothing to examine`
+        : "",
+    suppressed,
+  };
 }
 
 // --- CLI ---------------------------------------------------------------------
@@ -762,6 +965,9 @@ function loadLensNames() {
 }
 
 const PR_LIST_LIMIT = 200;
+
+/** GitHub's search API maximum. Asking for more is a 422, not a clamp. */
+const SEARCH_PAGE_LIMIT = 100;
 
 /**
  * Merged agent PRs to examine. `--since` is passed straight to GitHub's search
@@ -784,7 +990,44 @@ export function listCandidatePrs({ since, api, log = console.error }) {
         `window were NOT examined. Narrow --since and run again.`,
     );
   }
-  return all.filter(isAgentPr).map((p) => p.number);
+  const numbers = new Set(all.filter(isAgentPr).map((p) => p.number));
+
+  // Plus every PR the panel reviewed on demand. `isAgentPr` is the wrong question
+  // for signature 2 — "did our panel review this" is the right one, and a human PR
+  // someone ran `@claude review` on is as much a panel subject as an agent PR. That
+  // population is unreachable through `pr list` (authorship and branch name say
+  // nothing about it), so it is found by the marker the panel itself writes.
+  //
+  // ONE search call, and its failure is survivable by design: the agent PRs above
+  // are already in hand, so a search outage costs this run the on-demand PRs and
+  // nothing else. Same fail direction as every other read here.
+  try {
+    // `gh` expands `{owner}/{repo}` in an endpoint PATH, not inside a `-f` value, so
+    // the slug is resolved explicitly. Routed through the injected `api` (rather
+    // than hunt.mjs's direct `execFileSync`) so this stays testable.
+    const slug = str(api(["repo", "view", "--json", "nameWithOwner"])?.nameWithOwner);
+    if (slug === "") throw new Error("could not resolve owner/repo");
+    const found = api([
+      "api", "-X", "GET", "search/issues",
+      "-f", `q=repo:${slug} is:pr "${PANEL_COMMENT_TAG}" in:comments${since ? ` merged:>=${since}` : ""}`,
+      // The search API caps `per_page` at 100 regardless of what is asked, and a
+      // larger value is a 422 rather than a clamp.
+      "-f", `per_page=${SEARCH_PAGE_LIMIT}`,
+    ]);
+    const items = Array.isArray(found?.items) ? found.items : [];
+    if (Number(found?.total_count) > items.length) {
+      log(
+        `harvest: ${found.total_count} on-demand-reviewed PR(s) matched but only ${items.length} ` +
+          `were returned, so some were NOT examined. Narrow --since and run again.`,
+      );
+    }
+    let added = 0;
+    for (const it of items) if (Number.isFinite(it?.number) && !numbers.has(it.number)) { numbers.add(it.number); added++; }
+    if (added > 0) log(`harvest: ${added} additional PR(s) carry an on-demand panel review.`);
+  } catch (err) {
+    log(`harvest: could not search for on-demand-reviewed PRs (${err.message}); agent PRs only.`);
+  }
+  return [...numbers];
 }
 
 function cmdHarvest(args) {

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -14,6 +14,8 @@ import {
   classifyCodeRabbitComment,
   codeRabbitDetail,
   attributeToPanel,
+  parsePanelComment,
+  panelFindingsFromComments,
   toMissRecord,
   candidateId,
   parseJsonl,
@@ -541,18 +543,36 @@ test("harvestPr: an ambiguous CodeRabbit finding emits FLAGGED for the curator",
   assert.match(cr.notes, /MAYBE already raised by the panel/);
 });
 
-test("harvestPr: an unreadable panel verdict is NOT ASKED, not answered `no`", () => {
-  // `blockers` is null rather than [] when the check runs could not be read. The
-  // candidate still emits — exactly as before matching existed — but the record
-  // does not claim the matcher looked and found nothing.
+test("harvestPr: an unreadable panel verdict WITHHOLDS, because it is recoverable", () => {
+  // `blockers` stays null when the check runs could not be read, so there is no
+  // evidence the panel reviewed this PR and no basis for the claim "the panel did
+  // not raise this". Withholding writes no row, so a later harvest re-proposes the
+  // candidate once the evidence exists — whereas a wrong row, once curated, stays.
   const api = fakeApi({
     [`repos/{owner}/{repo}/commits/${SHA_BASE}/check-runs?per_page=100`]: new Error("502"),
     ...crComment(CR_MAJOR_CORRECTNESS),
   });
+  const logged = [];
+  const { records } = harvestPr(548, { api, log: (m) => logged.push(m), names: NAMES });
+  assert.equal(records.filter((r) => r.source === "coderabbit").length, 0);
+  assert.ok(logged.some((m) => /could not read the panel's verdict/.test(m)));
+  assert.ok(logged.some((m) => /no evidence the panel ever reviewed/.test(m)));
+});
+
+test("harvestPr: agent authorship is NOT evidence that the panel reviewed the PR", () => {
+  // Measured: of 11 agent PRs carrying CodeRabbit blockers, 9 have no
+  // `agent-review-*` check run on any commit — they match `isAgentPr` by branch
+  // prefix but never went through the panel. Trusting authorship would have filed
+  // 15 rows about a reviewer that never looked.
+  const api = fakeApi({
+    "repos/{owner}/{repo}/pulls/548": { user: { login: "yorkie-agent[bot]" }, head: { ref: "agent/482-x" } },
+    [`repos/{owner}/{repo}/commits/${SHA_BASE}/check-runs?per_page=100`]: [
+      { check_runs: [{ id: 7, name: "verify-self (22.x)", app: { slug: "github-actions" }, status: "completed", conclusion: "success" }] },
+    ],
+    ...crComment(CR_MAJOR_CORRECTNESS),
+  });
   const { records } = harvestPr(548, { api, log: () => {}, names: NAMES });
-  const cr = records.find((r) => r.source === "coderabbit");
-  assert.equal(cr.panelSaw.matchVerdict, "");
-  assert.equal(cr.panelSaw.conclusion, "");
+  assert.equal(records.filter((r) => r.source === "coderabbit").length, 0);
 });
 
 test("attributeToPanel: a matcher failure resolves to `maybe` — never a throw, never a suppression", () => {
@@ -578,6 +598,142 @@ test("attributeToPanel: compares LENS-NEUTRAL, so a lens mismatch cannot fake a 
   const cr = { lens: "", file: "a.ts", summary: "Blank skip in Arguments.iterate makes MIN and MAX return the wrong aggregate", evidence: "" };
   const panel = [{ lens: "test-adequacy", severity: "major", file: "a.ts", summary: "Blank skip in Arguments.iterate makes MIN and MAX return the wrong aggregate", evidence: "" }];
   assert.equal(attributeToPanel(cr, panel).verdict, "match");
+});
+
+// --- the on-demand panel's findings, read from its comment --------------------
+
+const PANEL_SHA = "7".repeat(40);
+const PANEL_BODY = [
+  `<!-- agent-review:${PANEL_SHA} -->`,
+  "### 🔴 Review panel: changes suggested",
+  "",
+  "❌ Correctness review: **changes requested** — 2 blocking (critical/major) finding(s) (1 critical, 1 major, 1 minor, 0 nit).",
+  "",
+  "Some prose the lens wrote.",
+  "### Critical (1)",
+  "- `scripts/agent/lenses/lenses.json:69` — `maxTurns: 3` with `samples: 1` makes turn exhaustion a hard blocking failure",
+  "",
+  "### Major (1)",
+  "- `scripts/agent/review-panel.mjs:817-822` — The empty-slice early return skips the prior-round re-check _(verifier could not settle this)_",
+  "",
+  "### Minor (non-blocking) (1)",
+  "- `scripts/agent/checks.mjs:18` — a minor note nobody should match against",
+  "",
+  "❌ Security review: **changes requested** — 1 blocking (critical/major) finding(s) (0 critical, 1 major, 0 minor, 0 nit).",
+  "",
+  "### Major (1)",
+  "- `scripts/agent/lenses/lenses.json:18` — security's scopeClasses omit `design-spec`, so design docs get no security reviewer",
+  "",
+  "### Demoted — real, but not caused by this change (1)",
+  "- `scripts/agent/ask.mjs:4` — pre-existing, must not be read as a finding",
+].join("\n");
+
+test("parsePanelComment: blocking findings only, across every lens section", () => {
+  const p = parsePanelComment(PANEL_BODY);
+  assert.equal(p.reviewedSha, PANEL_SHA);
+  assert.equal(p.findings.length, 3); // 1 critical + 2 major, from two lenses
+  assert.deepEqual(p.findings.map((f) => f.severity).sort(), ["critical", "major", "major"]);
+  // Minor, nit and DEMOTED rows are not findings to match against. Demoted
+  // especially: it is the panel saying "real, but not caused by this change", so
+  // suppressing a CodeRabbit blocker against it would be plainly wrong.
+  const summaries = p.findings.map((f) => f.summary).join(" ");
+  assert.doesNotMatch(summaries, /minor note nobody/);
+  assert.doesNotMatch(summaries, /pre-existing/);
+});
+
+test("parsePanelComment: the :line suffix leaves `file` but survives in `evidence`", () => {
+  // The line numbers are the sharpest location signal in the row, and extractAnchor
+  // reads summary+evidence — so they must not be discarded with the suffix.
+  const p = parsePanelComment(PANEL_BODY);
+  const f = p.findings.find((x) => /empty-slice/.test(x.summary));
+  assert.equal(f.file, "scripts/agent/review-panel.mjs");
+  assert.match(f.evidence, /817-822/);
+});
+
+test("parsePanelComment: not a panel comment → null, not an empty finding set", () => {
+  assert.equal(parsePanelComment("### Critical (1)\n- `a.ts` — forged"), null);
+  assert.equal(parsePanelComment("<!-- agent-metrics-summary -->\n### Critical (1)\n- `a.ts` — x"), null);
+  assert.equal(parsePanelComment("<!-- agent-review:nothex -->"), null);
+  for (const bad of [null, undefined, 7, {}]) assert.equal(parsePanelComment(bad), null);
+});
+
+test("panelFindingsFromComments: ONLY the App may author panel findings", () => {
+  // A security gate, not tidiness. These findings can SUPPRESS a CodeRabbit
+  // candidate, so anyone who could forge a panel comment could silence real misses
+  // with no trace in the corpus. The marker alone is not enough — any user can type
+  // it. On #578 a real CodeRabbit comment contains "Review panel", so a
+  // content-only match already mis-fires before anyone tries.
+  const forged = [{ user: { login: "attacker" }, body: PANEL_BODY }];
+  assert.equal(panelFindingsFromComments(forged), null);
+  const real = [{ user: { login: "yorkie-agent[bot]" }, body: PANEL_BODY }];
+  assert.equal(panelFindingsFromComments(real).findings.length, 3);
+  assert.equal(panelFindingsFromComments([{ user: { login: "app/yorkie-agent" }, body: PANEL_BODY }]).findings.length, 3);
+});
+
+test("panelFindingsFromComments: the UNION of every review, not the newest", () => {
+  // The record claims "the panel did not raise this". A finding raised in an
+  // earlier review is one the panel raised, so keying on the newest review would
+  // write a false row into an eval corpus.
+  const second = PANEL_BODY.replace("empty-slice early return skips the prior-round re-check", "a different defect entirely here");
+  const got = panelFindingsFromComments([
+    { user: { login: "yorkie-agent[bot]" }, body: PANEL_BODY },
+    { user: { login: "yorkie-agent[bot]" }, body: second },
+  ]);
+  assert.equal(got.findings.length, 6);
+  assert.equal(got.reviewedSha, PANEL_SHA); // first established sha wins
+});
+
+test("panelFindingsFromComments: never reviewed on demand → null", () => {
+  assert.equal(panelFindingsFromComments([{ user: { login: "yorkie-agent[bot]" }, body: "## 🤝 Ready for human review" }]), null);
+  for (const bad of [null, undefined, "x", 7]) assert.equal(panelFindingsFromComments(bad), null);
+});
+
+test("harvestPr: with no check runs, the on-demand comment becomes the comparison set", () => {
+  // The population this unlocks: a human PR reviewed via `@claude review`, where the
+  // panel records no check runs at all, so the count-based harvester filed every
+  // CodeRabbit blocker as a miss.
+  const crBody = [
+    "_🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_",
+    "",
+    "**Security lens scopeClasses is missing `design-spec`.**",
+    "",
+    "security's scopeClasses omit `design-spec`, so design docs get no security reviewer at all.",
+  ].join("\n");
+  const api = fakeApi({
+    "repos/{owner}/{repo}/issues/548/comments?per_page=100": [
+      { body: HANDOFF_MARKER, created_at: HANDOFF },
+      { user: { login: "yorkie-agent[bot]" }, body: PANEL_BODY },
+    ],
+    [`repos/{owner}/{repo}/commits/${SHA_BASE}/check-runs?per_page=100`]: [{ check_runs: [] }],
+    "repos/{owner}/{repo}/pulls/548/comments?per_page=100": [
+      { id: 42, user: { login: "coderabbitai[bot]" }, path: "scripts/agent/lenses/lenses.json", body: crBody },
+    ],
+  });
+  const logged = [];
+  const { records, suppressed } = harvestPr(548, { api, log: (m) => logged.push(m), names: NAMES });
+  assert.equal(suppressed, 1);
+  assert.equal(records.filter((r) => r.source === "coderabbit").length, 0);
+  assert.ok(logged.some((m) => /using the on-demand panel comment/.test(m)));
+  assert.ok(logged.some((m) => /restates a panel finding/.test(m)));
+});
+
+test("harvestPr: real check runs WIN over the comment", () => {
+  // Check runs are the structured record; the comment is a rendering of one. An
+  // autonomous panel that genuinely raised nothing has already answered the
+  // question, and a comment from a different review would answer a different one.
+  const api = fakeApi({
+    "repos/{owner}/{repo}/issues/548/comments?per_page=100": [
+      { body: HANDOFF_MARKER, created_at: HANDOFF },
+      { user: { login: "yorkie-agent[bot]" }, body: PANEL_BODY },
+    ],
+    ...crComment(CR_MAJOR_CORRECTNESS),
+  });
+  const logged = [];
+  const { records, suppressed } = harvestPr(548, { api, log: (m) => logged.push(m), names: NAMES });
+  // fakeApi's default check run is a clean `[]` — a real, empty answer.
+  assert.equal(suppressed, 0);
+  assert.equal(records.find((r) => r.source === "coderabbit").panelSaw.matchVerdict, "no");
+  assert.ok(!logged.some((m) => /using the on-demand panel comment/.test(m)));
 });
 
 test("harvestPr: ignores CodeRabbit replies and non-CodeRabbit authors", () => {
@@ -625,28 +781,76 @@ test("harvestPr: every commit after the handoff leaves panelSaw EMPTY, not wrong
 });
 
 test("harvestPr: 'could not look' never reads the same as 'nothing found'", () => {
-  const notAgent = harvestPr(548, {
-    api: fakeApi({ "repos/{owner}/{repo}/pulls/548": { user: { login: "harrykim8672" }, head: { ref: "feat/x" } } }),
+  // Nothing examinable: no hand-off (signature 1 cannot run) AND no review
+  // comments (signature 2 has no input). Only this shape sets `skipped`.
+  const nothing = harvestPr(548, {
+    api: fakeApi({
+      "repos/{owner}/{repo}/issues/548/comments?per_page=100": [],
+      "repos/{owner}/{repo}/pulls/548/comments?per_page=100": [],
+    }),
     log: () => {},
     names: NAMES,
   });
-  assert.deepEqual(notAgent.records, []);
-  assert.match(notAgent.skipped, /not an agent PR/);
+  assert.deepEqual(nothing.records, []);
+  assert.match(nothing.skipped, /nothing to examine/);
 
+  // No hand-off, but an on-demand panel review: signature 1 is silently
+  // inapplicable, signature 2 runs against the comment, and the record carries
+  // handoffAt "" rather than a guess. This is the shape the relaxation exists for.
   const noHandoff = harvestPr(548, {
+    api: fakeApi({
+      "repos/{owner}/{repo}/issues/548/comments?per_page=100": [
+        { user: { login: "yorkie-agent[bot]" }, body: PANEL_BODY },
+      ],
+      ...crComment(CR_MAJOR_CORRECTNESS),
+    }),
+    log: () => {},
+    names: NAMES,
+  });
+  assert.equal(noHandoff.skipped, "");
+  assert.equal(noHandoff.records.filter((r) => r.source === "human-fix").length, 0);
+  assert.equal(noHandoff.records.filter((r) => r.source === "coderabbit").length, 1);
+  assert.equal(noHandoff.records[0].handoffAt, "");
+  assert.equal(noHandoff.records[0].panelSaw.matchVerdict, "no");
+
+  // KNOWN LIMITATION, asserted so it cannot change silently: without a hand-off
+  // there is no `headAtHandoff`, so lens CHECK RUNS are never read — only the
+  // comment path reaches signature 2 here. It costs nothing measurable today (the
+  // no-hand-off population has no lens runs on any commit either) and is recorded
+  // in the task doc's "Not built".
+  const noHandoffNoComment = harvestPr(548, {
     api: fakeApi({ "repos/{owner}/{repo}/issues/548/comments?per_page=100": [] }),
     log: () => {},
     names: NAMES,
   });
-  assert.deepEqual(noHandoff.records, []);
-  assert.match(noHandoff.skipped, /no hand-off marker/);
+  assert.equal(noHandoffNoComment.records.filter((r) => r.source === "coderabbit").length, 0);
 
-  const unreadable = harvestPr(548, {
-    api: fakeApi({ "repos/{owner}/{repo}/pulls/548": new Error("502") }),
+  // An unreadable COMMITS list costs the check-run path — `headAtHandoff` is derived
+  // from it — so the panel cannot be established and signature 2 withholds too.
+  // Documented rather than worked around: it is the recoverable direction, and a
+  // re-harvest re-proposes the candidate.
+  const noCommits = harvestPr(548, {
+    api: fakeApi({ "repos/{owner}/{repo}/pulls/548/commits?per_page=100": new Error("502") }),
     log: () => {},
     names: NAMES,
   });
-  assert.match(unreadable.skipped, /could not read PR #548/);
+  assert.equal(noCommits.records.length, 0);
+
+  // But the COMMENT path needs no commits at all, so the same outage on a PR with an
+  // on-demand review still yields its CodeRabbit candidate. The two sources fail
+  // independently, which is the point of having two.
+  const noCommitsWithPanel = harvestPr(548, {
+    api: fakeApi({
+      "repos/{owner}/{repo}/pulls/548/commits?per_page=100": new Error("502"),
+      "repos/{owner}/{repo}/issues/548/comments?per_page=100": [
+        { body: HANDOFF_MARKER, created_at: HANDOFF },
+        { user: { login: "yorkie-agent[bot]" }, body: PANEL_BODY },
+      ],
+    }),
+    log: () => {},
+    names: NAMES,
+  });
+  assert.equal(noCommitsWithPanel.records.filter((r) => r.source === "coderabbit").length, 1);
 });
 
 test("harvestPr: one failed sub-request costs its own candidates, not the PR's", () => {
@@ -676,35 +880,75 @@ test("listCandidatePrs: a capped list is REPORTED, never passed off as complete"
   // "We found no misses in that window" is exactly the conclusion this corpus must
   // never reach by accident, and a silently truncated PR list produces it.
   const full = Array.from({ length: 200 }, (_, i) => ({ number: i + 1, headRefName: "agent/x", author: { login: "x" } }));
+  // The on-demand search is routed to a clean empty result so this test speaks only
+  // about the PR-list cap.
+  const apiFor = (list) => (argv) =>
+    argv.includes("nameWithOwner")
+      ? { nameWithOwner: "wafflebase/wafflebase" }
+      : argv.includes("search/issues")
+        ? { total_count: 0, items: [] }
+        : list;
   const logged = [];
-  assert.equal(listCandidatePrs({ api: () => full, log: (m) => logged.push(m) }).length, 200);
+  assert.equal(listCandidatePrs({ api: apiFor(full), log: (m) => logged.push(m) }).length, 200);
   assert.equal(logged.length, 1);
   assert.match(logged[0], /cap.*NOT examined/s);
 
   // Under the cap, nothing is said.
   const quiet = [];
-  listCandidatePrs({ api: () => full.slice(0, 199), log: (m) => quiet.push(m) });
+  listCandidatePrs({ api: apiFor(full.slice(0, 199)), log: (m) => quiet.push(m) });
   assert.deepEqual(quiet, []);
 });
 
-test("listCandidatePrs: --since goes to GitHub's search, and non-agent PRs drop out", () => {
-  let seen = null;
+test("listCandidatePrs: agent PRs from the list, on-demand-reviewed PRs from search", () => {
+  let listArgv = null, searchArgv = null;
   const api = (argv) => {
-    seen = argv;
+    if (argv.includes("nameWithOwner")) return { nameWithOwner: "wafflebase/wafflebase" };
+    if (argv.includes("search/issues")) { searchArgv = argv; return { total_count: 1, items: [{ number: 9 }] }; }
+    listArgv = argv;
     return [
       { number: 1, headRefName: "agent/1-x", author: { login: "harrykim8672" } },
       { number: 2, headRefName: "feat/y", author: { login: "harrykim8672" } },
       { number: 3, headRefName: "feat/z", author: { login: "app/yorkie-agent" } },
     ];
   };
-  assert.deepEqual(listCandidatePrs({ since: "2026-07-01", api, log: () => {} }), [1, 3]);
-  assert.ok(seen.includes("--search") && seen.includes("merged:>=2026-07-01"));
+  // 1 and 3 are agent PRs; 2 is not, but 9 was reviewed on demand — which is the
+  // right question for signature 2 and one authorship cannot answer.
+  assert.deepEqual(listCandidatePrs({ since: "2026-07-01", api, log: () => {} }), [1, 3, 9]);
+  assert.ok(listArgv.includes("--search") && listArgv.includes("merged:>=2026-07-01"));
+  assert.ok(searchArgv.some((a) => String(a).includes("agent-review:")));
+  assert.ok(searchArgv.some((a) => String(a).includes("merged:>=2026-07-01")));
+
   // No --since → no search term at all, rather than an empty one.
   listCandidatePrs({ api, log: () => {} });
-  assert.ok(!seen.includes("--search"));
+  assert.ok(!listArgv.includes("--search"));
+
   for (const junk of [null, "x", 7, {}]) {
     assert.deepEqual(listCandidatePrs({ api: () => junk, log: () => {} }), []);
   }
+});
+
+test("listCandidatePrs: a search outage costs the on-demand PRs, never the agent ones", () => {
+  // Same fail direction as every other read: degrade to fewer candidates.
+  const api = (argv) => {
+    if (argv.includes("nameWithOwner")) return { nameWithOwner: "wafflebase/wafflebase" };
+    if (argv.includes("search/issues")) throw new Error("422 rate limited");
+    return [{ number: 1, headRefName: "agent/1-x", author: { login: "harrykim8672" } }];
+  };
+  const logged = [];
+  assert.deepEqual(listCandidatePrs({ api, log: (m) => logged.push(m) }), [1]);
+  assert.ok(logged.some((m) => /could not search for on-demand-reviewed PRs/.test(m)));
+});
+
+test("listCandidatePrs: a capped search is REPORTED, not silently truncated", () => {
+  const api = (argv) =>
+    argv.includes("nameWithOwner")
+      ? { nameWithOwner: "wafflebase/wafflebase" }
+      : argv.includes("search/issues")
+        ? { total_count: 500, items: [{ number: 9 }] }
+        : [];
+  const logged = [];
+  listCandidatePrs({ api, log: (m) => logged.push(m) });
+  assert.ok(logged.some((m) => /500 on-demand-reviewed PR\(s\) matched but only 1/.test(m)));
 });
 
 // --- the corpus file itself --------------------------------------------------

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -12,6 +12,8 @@ import {
   interestingFiles,
   fileClassesOf,
   classifyCodeRabbitComment,
+  codeRabbitDetail,
+  attributeToPanel,
   toMissRecord,
   candidateId,
   parseJsonl,
@@ -200,6 +202,8 @@ test("classifyCodeRabbitComment: reads the header this repo actually emits", () 
     severity: "major",
     lens: "correctness",
     summary: "Guard public mutation APIs at the read-only boundary.",
+    detail:
+      "**Guard public mutation APIs at the read-only boundary.** This flag only protects event handlers.",
   });
   assert.equal(classifyCodeRabbitComment(CR_MAJOR_SECURITY).lens, "security");
 });
@@ -237,11 +241,19 @@ const FIELD_ORDER = [
   "lens", "severity", "origin", "summary", "panelSaw", "verifiedBy", "notes",
 ];
 
+/** `panelSaw` with nothing established and no attribution attempted. */
+const EMPTY_PANEL_SAW = {
+  reviewedSha: "", conclusion: "", blockingFindings: 0,
+  matchVerdict: "", matchScore: 0, matchedSummary: "",
+};
+
 test("toMissRecord: field order is stable, because the corpus is read in diffs", () => {
   assert.deepEqual(Object.keys(toMissRecord({})), FIELD_ORDER);
   assert.deepEqual(Object.keys(toMissRecord({ id: "x", pr: 1, files: ["a.ts"] })), FIELD_ORDER);
   assert.deepEqual(Object.keys(toMissRecord({}).evidence), ["commitSha", "commentId", "url"]);
-  assert.deepEqual(Object.keys(toMissRecord({}).panelSaw), ["reviewedSha", "conclusion", "blockingFindings"]);
+  assert.deepEqual(Object.keys(toMissRecord({}).panelSaw), [
+    "reviewedSha", "conclusion", "blockingFindings", "matchVerdict", "matchScore", "matchedSummary",
+  ]);
 });
 
 test("toMissRecord: junk coerces to safe defaults rather than throwing", () => {
@@ -252,7 +264,7 @@ test("toMissRecord: junk coerces to safe defaults rather than throwing", () => {
   assert.equal(r.origin, "unknown");
   assert.equal(r.pr, 0);
   assert.deepEqual(r.files, []);
-  assert.deepEqual(r.panelSaw, { reviewedSha: "", conclusion: "", blockingFindings: 0 });
+  assert.deepEqual(r.panelSaw, EMPTY_PANEL_SAW);
   for (const bad of [null, undefined, "x", 7]) assert.equal(toMissRecord(bad).schema, SCHEMA);
 });
 
@@ -322,7 +334,12 @@ test("panelVerdictAt: one failing lens means the panel did NOT let it through", 
     ["agent-review-correctness", { conclusion: "success", output: { text: "[]" } }],
     ["agent-review-test-adequacy", { conclusion: "failure", output: { text: '[{"severity":"major","summary":"vacuous test"}]' } }],
   ]);
-  assert.deepEqual(panelVerdictAt(runs), { reviewedSha: "", conclusion: "failure", blockingFindings: 1 });
+  assert.deepEqual(panelVerdictAt(runs), {
+    reviewedSha: "", conclusion: "failure", blockingFindings: 1,
+    // `normalizeFindings` keeps every field it was handed and names the four it
+    // knows, so an absent file/evidence surfaces as undefined rather than "".
+    blockers: [{ severity: "major", summary: "vacuous test", file: undefined, evidence: undefined, lens: "test-adequacy" }],
+  });
 });
 
 test("panelVerdictAt: reviewedSha comes from external_id, not the commit it hangs off", () => {
@@ -347,7 +364,9 @@ test("panelVerdictAt: reviewedSha comes from external_id, not the commit it hang
 });
 
 test("panelVerdictAt: no lens runs is '', which is not the same as success", () => {
-  assert.deepEqual(panelVerdictAt(new Map()), { reviewedSha: "", conclusion: "", blockingFindings: 0 });
+  assert.deepEqual(panelVerdictAt(new Map()), {
+    reviewedSha: "", conclusion: "", blockingFindings: 0, blockers: [],
+  });
   for (const bad of [null, undefined, {}]) assert.equal(panelVerdictAt(bad).conclusion, "");
 });
 
@@ -399,7 +418,7 @@ test("harvestPr: proposes both signatures, and only from reviewable code", () =>
   assert.equal(fix.summary, "Guard EditorAPI.paste()"); // first line only
   assert.equal(fix.handoffAt, HANDOFF);
   // the verdict that LET THE PR THROUGH — the runs on the head commit at handoff
-  assert.deepEqual(fix.panelSaw, { reviewedSha: SHA_BASE, conclusion: "success", blockingFindings: 0 });
+  assert.deepEqual(fix.panelSaw, { ...EMPTY_PANEL_SAW, reviewedSha: SHA_BASE, conclusion: "success" });
 
   const cr = records.find((r) => r.source === "coderabbit");
   assert.equal(cr.lens, "correctness");
@@ -414,6 +433,151 @@ test("harvestPr: EVERY harvested candidate is unverified", () => {
   const { records } = harvestPr(548, { api: fakeApi(), log: () => {}, names: NAMES });
   assert.ok(records.length > 0);
   for (const r of records) assert.equal(r.verifiedBy, "");
+});
+
+// --- finding-level attribution (signature 2) ---------------------------------
+
+test("codeRabbitDetail: title + prose, stopping at the first structured block", () => {
+  // Verified against the real bodies on #548/#594/#639: header → bolded title →
+  // prose → blocks, and prose never resumes afterwards.
+  const body = [
+    "_🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_",
+    "",
+    "**Guard the read-only boundary.**",
+    "",
+    "`EditorAPI.paste()` mutates the store regardless of the flag.",
+    "",
+    "<details>",
+    "<summary>🤖 Prompt for AI Agents</summary>",
+    "",
+    "```",
+    "Verify each finding against current code. Fix only still-valid issues.",
+    "```",
+    "</details>",
+    "",
+    "<!-- This is an auto-generated comment by CodeRabbit -->",
+  ].join("\n");
+  const detail = codeRabbitDetail(body);
+  assert.match(detail, /Guard the read-only boundary/);
+  assert.match(detail, /EditorAPI\.paste/);
+  // The boilerplate every comment repeats must NOT reach the token comparison —
+  // it would contribute `code`, `fix`, `issues`, `validate` to every pair.
+  assert.doesNotMatch(detail, /Verify each finding/);
+  assert.doesNotMatch(detail, /Functional Correctness/); // the header line is dropped
+});
+
+/** A panel check-run whose findings are `findings`. */
+const panelRun = (findings) => ({
+  [`repos/{owner}/{repo}/commits/${SHA_BASE}/check-runs?per_page=100`]: [
+    { check_runs: [{ id: 1, name: "agent-review-correctness", app: { slug: "github-actions" }, status: "completed", conclusion: "failure", completed_at: "2026-07-24T15:40:00Z", output: { text: JSON.stringify(findings) } }] },
+  ],
+  [`repos/{owner}/{repo}/check-runs/1`]: { id: 1, name: "agent-review-correctness", conclusion: "failure", output: { text: JSON.stringify(findings) } },
+});
+
+/** One CodeRabbit review comment on #548. */
+const crComment = (body, path = "packages/docs/src/view/text-editor.ts") => ({
+  [`repos/{owner}/{repo}/pulls/548/comments?per_page=100`]: [
+    { id: 999, user: { login: "coderabbitai[bot]" }, path, original_commit_id: SHA_BASE, html_url: "https://x/d", body },
+  ],
+});
+
+test("harvestPr: a CodeRabbit finding the panel already raised is SUPPRESSED, and said so", () => {
+  // The whole point of the matcher. Before it, this comment was filed as a miss
+  // because the only thing known about the panel was a count.
+  const logged = [];
+  const api = fakeApi({
+    ...panelRun([{ severity: "major", file: "packages/docs/src/view/text-editor.ts", summary: "Public mutation APIs are not guarded at the read-only boundary, so EditorAPI.paste() still mutates the store" }]),
+    ...crComment(CR_MAJOR_CORRECTNESS),
+  });
+  const { records, suppressed } = harvestPr(548, { api, log: (m) => logged.push(m), names: NAMES });
+  assert.equal(suppressed, 1);
+  assert.equal(records.filter((r) => r.source === "coderabbit").length, 0);
+  // Visible, not silent: the log names the panel finding it was attributed to.
+  assert.ok(logged.some((m) => /restates a panel finding/.test(m) && /Public mutation APIs/.test(m)));
+});
+
+test("harvestPr: a CodeRabbit finding the panel did NOT raise still emits, unflagged", () => {
+  // The panel's only blocker is in a different file and shares no vocabulary:
+  // no location tie and no shared anchor, which is the one shape L2 calls `no`.
+  const api = fakeApi({
+    ...panelRun([{ severity: "major", file: "packages/sheets/src/formula/calculator.ts", summary: "Pagination recomputes every page on each keystroke, which stalls long documents" }]),
+    ...crComment(CR_MAJOR_CORRECTNESS),
+  });
+  const { records, suppressed } = harvestPr(548, { api, log: () => {}, names: NAMES });
+  assert.equal(suppressed, 0);
+  const cr = records.find((r) => r.source === "coderabbit");
+  assert.equal(cr.panelSaw.matchVerdict, "no");
+  assert.equal(cr.panelSaw.matchedSummary, "");
+  assert.doesNotMatch(cr.notes, /MAYBE/);
+});
+
+test("harvestPr: same file, unrelated defect → emitted as `maybe`, never suppressed", () => {
+  // A known and deliberate property: co-location in one file is partial evidence,
+  // so it reaches `maybe` rather than `no`. Both verdicts EMIT — the difference is
+  // only whether a curator is asked to look — so the cost of the conservative call
+  // is one line of reading, and the cost of the other direction is a lost miss.
+  const api = fakeApi({
+    ...panelRun([{ severity: "major", file: "packages/docs/src/view/text-editor.ts", summary: "Pagination recomputes every page on each keystroke, which stalls long documents" }]),
+    ...crComment(CR_MAJOR_CORRECTNESS),
+  });
+  const { records, suppressed } = harvestPr(548, { api, log: () => {}, names: NAMES });
+  assert.equal(suppressed, 0);
+  const cr = records.find((r) => r.source === "coderabbit");
+  assert.equal(cr.panelSaw.matchVerdict, "maybe");
+});
+
+test("harvestPr: an ambiguous CodeRabbit finding emits FLAGGED for the curator", () => {
+  // Same file and a shared symbol, but the summaries share almost no vocabulary.
+  // Location is necessary and never sufficient, so this is a `maybe` — emitted,
+  // because suppressing it could lose a real miss.
+  const api = fakeApi({
+    ...panelRun([{ severity: "major", file: "packages/docs/src/view/text-editor.ts", summary: "Pagination recomputes every page on each keystroke", evidence: "`pasteContent` is on that path" }]),
+    ...crComment("_🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_\n\n**Unrelated wording entirely.**\n\nSomething about `pasteContent` here."),
+  });
+  const { records, suppressed } = harvestPr(548, { api, log: () => {}, names: NAMES });
+  assert.equal(suppressed, 0);
+  const cr = records.find((r) => r.source === "coderabbit");
+  assert.equal(cr.panelSaw.matchVerdict, "maybe");
+  assert.match(cr.notes, /MAYBE already raised by the panel/);
+});
+
+test("harvestPr: an unreadable panel verdict is NOT ASKED, not answered `no`", () => {
+  // `blockers` is null rather than [] when the check runs could not be read. The
+  // candidate still emits — exactly as before matching existed — but the record
+  // does not claim the matcher looked and found nothing.
+  const api = fakeApi({
+    [`repos/{owner}/{repo}/commits/${SHA_BASE}/check-runs?per_page=100`]: new Error("502"),
+    ...crComment(CR_MAJOR_CORRECTNESS),
+  });
+  const { records } = harvestPr(548, { api, log: () => {}, names: NAMES });
+  const cr = records.find((r) => r.source === "coderabbit");
+  assert.equal(cr.panelSaw.matchVerdict, "");
+  assert.equal(cr.panelSaw.conclusion, "");
+});
+
+test("attributeToPanel: a matcher failure resolves to `maybe` — never a throw, never a suppression", () => {
+  // The fail direction, and it is deliberately in the middle. Suppressing on
+  // error would silently drop a real miss; emitting unflagged would restore the
+  // noise the matcher exists to remove.
+  const exploding = [{ get summary() { throw new Error("boom"); } }];
+  const r = attributeToPanel({ file: "a.ts", summary: "anything", evidence: "" }, exploding);
+  assert.equal(r.verdict, "maybe");
+  assert.equal(r.error, "boom");
+});
+
+test("attributeToPanel: null blockers is 'not asked'; an empty array is a real answer", () => {
+  const finding = { file: "a.ts", summary: "the guard is missing on the paste path", evidence: "" };
+  assert.equal(attributeToPanel(finding, null).verdict, "");
+  assert.equal(attributeToPanel(finding, []).verdict, "no");
+});
+
+test("attributeToPanel: compares LENS-NEUTRAL, so a lens mismatch cannot fake a miss", () => {
+  // CodeRabbit's lens is a category guess and is often "". `findingSimilarity`
+  // scores any lens mismatch 0 outright, so comparing on the raw lens would file
+  // every CodeRabbit blocker the panel raised under a different lens as a miss.
+  const cr = { lens: "", file: "a.ts", summary: "Blank skip in Arguments.iterate makes MIN and MAX return the wrong aggregate", evidence: "" };
+  const panel = [{ lens: "test-adequacy", severity: "major", file: "a.ts", summary: "Blank skip in Arguments.iterate makes MIN and MAX return the wrong aggregate", evidence: "" }];
+  assert.equal(attributeToPanel(cr, panel).verdict, "match");
 });
 
 test("harvestPr: ignores CodeRabbit replies and non-CodeRabbit authors", () => {
@@ -457,7 +621,7 @@ test("harvestPr: every commit after the handoff leaves panelSaw EMPTY, not wrong
   });
   const fix = records.find((r) => r.source === "human-fix");
   assert.ok(fix, "the candidate is still proposed");
-  assert.deepEqual(fix.panelSaw, { reviewedSha: "", conclusion: "", blockingFindings: 0 });
+  assert.deepEqual(fix.panelSaw, EMPTY_PANEL_SAW);
 });
 
 test("harvestPr: 'could not look' never reads the same as 'nothing found'", () => {

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -145,7 +145,7 @@ const trimmed = (s) => String(s ?? "").trim();
 // A couple of incidentally-shared words is never a match, however short the
 // shorter summary is. Calibrated below: real same-defect pairs share 7-17
 // tokens; real different-defect pairs share at most 1.
-const MIN_SHARED_TOKENS = 3;
+export const MIN_SHARED_TOKENS = 3;
 
 /** Default similarity threshold — see the calibration note on `findingSimilarity`. */
 export const DEFAULT_SIMILARITY = 0.3;


### PR DESCRIPTION
## Summary

`harvest.mjs`'s CodeRabbit signature filed **every** blocking finding as a candidate
panel miss, including the ones the panel caught and merely worded differently. It
could not do otherwise: the only thing it knew about the panel's output was a
**count**. `panelVerdictAt` computed `blockingFindings` and dropped the findings on
the floor, so the harvester could say the panel raised three blockers and never
whether one of them was the comment in hand.

That is the failure the module's own header calls out — harvester noise is
*systematic*, it follows whatever the matcher over-fires on, so it moves the panel
somewhere specific and wrong rather than nowhere.

Two commits, separable:

1. **`finding-match.mjs` + the wiring.** A location signal — symbols, line ranges and
   paths mined from the `summary`/`evidence` prose the finding schema has no field for
   — layered on top of the existing text similarity. `match` suppresses (counted and
   logged), `maybe` emits flagged, `no` emits.
2. **Harvest the PRs the panel actually reviewed.** Signature 2 had inherited
   signature 1's preconditions, and that is where all the data was going.

### The similarity metric is not re-derived

`findingSimilarity`, `summaryTokens`, `DEFAULT_SIMILARITY` and `MIN_SHARED_TOKENS` are
all imported from `rounds.mjs`, which owns them. The only change there is one `export`
keyword on `MIN_SHARED_TOKENS` — `tokenOverlap` needs the same floor for the same
reason, and copying `3` into a second file is the drift `CITATION` and
`REFUTATION_GROUNDS` both exist to avoid.

Anchors only ever **demote** a pair to `maybe`. Measured over 1,249 real pairs from
153 captured findings, **55% of all pairs share at least one symbol** — in a focused
PR nearly every finding names the same identifiers — so location agreement means
"same topic", not "same defect".

### `clusterFindings` is untouched, and here is the evidence for why

This was measured rather than assumed, and the result is a free piece of validation
for your calibration. Replicating `clusterFindings` exactly (single-linkage,
lens-neutral key, `findingSimilarity >= 0.3`) over 153 real captured findings — 10
`(item, lens)` groups, 1,249 candidate pairs — then re-running it with an anchor
condition added:

An anchor guard blocks **0 of the 39 merges** clustering performs.

It is not vacuous. The guard has real discriminating power across the population:

| anchor outcome | all 1,249 pairs |
|---|---:|
| line-range hit | 92 (7.4%) |
| shares ≥1 symbol | 692 (55.4%) |
| **disagrees — would block a merge** | **525 (42.0%)** |

But of the 45 pairs that clear the text threshold, **none** disagree on anchors:

```
{ lineHit: 4, nullOverlap: 0, sharedSymbols: 41, disagree: 0 }
```

**Your clustering is already anchor-consistent.** The `(lens, file)` gate plus the 0.3
overlap threshold never merges anything an independent location signal would object
to. A filter that discriminates on 42% of the population and 0% of the operating
region is pure surface area — on a production gate path — so there is no hook into
`clusterFindings` here, in either direction.

## What changed in `harvest.mjs`

Measuring the matcher found it suppressing nothing on any PR in the repo's history.
Four causes, none of them the matcher:

1. **`isAgentPr` gated the whole function.** Signature 1 needs it — a hand-off only
   exists on a promoted agent PR. Signature 2 does not: *"CodeRabbit flagged something
   our panel reviewed and did not raise"* is exactly as true on a human PR someone ran
   `@claude review` on.
2. **A missing hand-off marker skipped the whole PR.** 18 of 33 agent PRs were opened
   ready rather than promoted from draft, so they carry neither a marker nor a
   `ready_for_review` event. For signature 1 that is correct. For signature 2
   `handoffAt` is not merely unknown but *meaningless* — nothing was handed off.
3. **`panelVerdictAt` reads check runs, and the on-demand review writes none.**
   `agent-review-on-demand.yml` states this four times over (*"purely advisory: it
   records NO check runs"*, `checks: read` and never `checks: write`). Its findings
   exist only as markdown in the comment it posts, so that whole population was
   invisible. `parsePanelComment` now reads it, as a **fallback** — check runs win
   where they exist, because one is the structured record and the other a rendering.
4. **Agent authorship is not evidence that the panel reviewed anything.** Of 11 agent
   PRs carrying CodeRabbit blockers, **9 have no `agent-review-*` check run on any
   commit** — only `verify-*` and codecov. They match `isAgentPr` by branch prefix but
   never went through the panel.

Widening the population opens one hazard, closed here: on a PR the panel never
reviewed, every CodeRabbit blocker would file as a miss. Signature 2 now requires
**empirical** evidence of a review — readable lens runs or a trusted panel comment.

The panel-comment parser is author-gated to the App. That is a security gate, not
tidiness: findings parsed from a comment can **suppress** a candidate, so anyone able
to forge one could silence real misses with no row left behind. The marker alone is
insufficient — any user can type an HTML comment.

## Before / after on real data

Full run over the harvestable population, `--since 2026-07-01` (100 PRs):

| | count |
|---|---:|
| CodeRabbit candidates emitted | 2 |
| **suppressed as restatements of a panel finding** | **3** |
| human-fix candidates | 21 |
| withheld — no evidence the panel reviewed the PR | ~29 |

The three suppressions, each inspected by hand and each a genuine restatement:

- **#582** — CR *"Security lens scopeClasses is missing `design-spec`"* ↔ panel *"The
  security lens's `scopeClasses` omits `design-spec`, so a `docs/design/**`-only PR is
  reviewed by design-fit alone"*. Score 1.00.
- **#582** — CR *"Docs lens `appliesWhen` is missing `docs/…`"* ↔ panel *"…does not
  cover `docs/**/*.txt`, which the `prose` class does"*. Score 1.00.
- **#578** — CR *"Retryability is inferred from message text, not status"*, whose body
  states *"`resets?\b` matches substrings like 'connection reset by peer'"* ↔ panel
  *"the quota-detection regex's `resets?\b` alternative matches ordinary transient
  network errors"*. Same regex, same reasoning. Score 0.75.

Both PRs are human-authored and carry no lens check runs, so **all three were
unreachable before this change** — and all three would have been filed as panel
misses. Both emitted candidates are backed by a real panel review (#548 via check
runs, #559 via a *"Review panel: looks good"* comment), and both carry
`matchVerdict: "no"` — compared and unmatched, not "we could not check".

Nothing was written to `misses.jsonl`: every measurement called `harvestPr()` directly
and `--append` was never passed. The corpus still holds its original 5 records.

## Two bugs found in the ported layer

**It promoted on location alone.** The cross-source match condition scored
`max(tokenOverlap, symbolOverlap)` against the threshold, and `symbolOverlap` is 1.0
whenever both sides name exactly one symbol and it is the same one — so two distinct
defects both touching `parseARef`, sharing no summary vocabulary at all, matched at
1.00. The gate now keys on token overlap; anchors keep their veto and their
contribution to the reported score, and get no vote on clearing the bar.

**A backticked path was mined as a bag of symbols.** `IDENT_RE` ran over every
backtick span including `` `@packages/docs/src/view/text-editor.ts` ``, minting
`packages`, `docs`, `src`, `view` as *symbols*, so any two findings under one
directory shared symbols on tree vocabulary alone. `PATH_RE` already records that
string as a file. CodeRabbit backticks the path on every finding, so this was
reachable rather than theoretical.

## Known limitations

- **No negative control in the real sample.** 3 of 3 matched, so the `no` and `maybe`
  paths are evidenced only by tests.
- **L2's cross-source weights are inherited uncalibrated.** `DEFAULT_SIMILARITY` was
  calibrated for same-run pairs; reusing it as the cross-source bar is a reasoned
  guess. `MIN_SHARED_TOKENS` and the title+prose input (below) are what keep it
  honest, not a fresh calibration.
- **The panel-comment parser requires the exact `<!-- agent-review:<40-hex> -->`
  anchor.** An older or differently-formatted panel comment is invisible to it.
- **Without a hand-off, lens check runs are never read** — `headAtHandoff` anchors
  that read, so only the comment path reaches signature 2 there. Measured cost today:
  none; that population has zero lens runs on any commit, so an all-commits read finds
  nothing either. Asserted in a test so it cannot change silently.
- **A commits-list outage withholds CodeRabbit candidates too**, since `headAtHandoff`
  derives from it. The comment path is unaffected, so the two sources fail
  independently.
- **No LLM adjudication.** The designed L3 stays unbuilt until the `maybe` queue is
  shown to be worth paying to shrink; in the measured window it is empty.

## A note on CodeRabbit's comment format

The token comparison gets **title + prose**; the anchor layer gets the **whole body**.
Both halves matter. A title alone reduces to six significant tokens
(`guard, public, mutation, apis, read, boundary`), and containment is scored over the
smaller set, so two incidentally shared words clear the bar. The whole body fails the
other way and in the dangerous direction: every comment ends with a `🤖 Prompt for AI
Agents` block opening with the same boilerplate sentence, contributing `code`, `fix`,
`issues`, `changes`, `validate` to *every* comparison, plus suggestion blocks that
dump literal source — inflating containment on exactly the vocabulary every finding in
the file already shares. Verified against all 10 inline findings on #548, #594 and
#639. The full body still reaches the anchor layer, where the `around lines N - M`
range in that same block is the most precise location signal a review comment carries.

## Test plan

- `node --test "scripts/agent/*.test.mjs"` — **559 pass, 0 fail** (48 new). This lane
  needs no `node_modules`.
- Both regressions the ported code was built around: a `0` from `findingSimilarity` is
  not read as "different file" (it also means "same file, under the token floor"), and
  a `null` `symbolOverlap` means *no evidence*, never disagreement.
- A third regression for the promotion bug: shared anchors alone reach `maybe`, never
  `match`.
- Harvest-level: a restatement is suppressed and logged, an unrelated finding emits, an
  ambiguous one emits flagged, an unreadable verdict withholds, a matcher throw
  resolves to `maybe`, a forged panel comment is ignored, check runs beat the comment,
  authorship is not evidence of a review, and a search outage degrades to agent PRs.
- *EVERY harvested candidate is unverified* still passes — `verifiedBy` stays `""` and
  no harvest path can set it.
- End-to-end against the live API on #582, #578, #548, #559, #628, #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
