### PR TITLE
One review panel per branch, and 200 turns for the fixer

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -21,6 +21,39 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+# ONE panel per PR at a time. Without this, two CI completions close together
+# (a re-run, or a push landing while an earlier round is still in flight) start
+# two full pipelines against the same branch, and it has now broken two PRs in
+# distinguishable ways:
+#
+#   #605 — two panels finished in the SAME SECOND with identical `external_id`
+#          (same reviewed sha, same base, mode full) and CONTRADICTORY verdicts:
+#          correctness 1 major vs 2 major, docs success vs failure. Twelve check
+#          runs for six lenses; whichever wrote last became the truth.
+#   #648 — worse, because the panel dispatches a fixer. Two fixers ran on the
+#          same branch for 21 overlapping minutes on the same nine findings. The
+#          later one converged in 76 turns and pushed; the earlier one crossed
+#          its 80-turn ceiling and its job failed, which made `stalled` page
+#          "the requested changes were not applied" — false, they had just been
+#          applied by the other run. The paged latch then froze the PR, so the
+#          fix that DID land was never reviewed. ~$22 spent, a third of it on a
+#          duplicate that could only lose.
+#
+# CANCEL, not queue: a superseded panel is reviewing a sha that is no longer the
+# head, so its verdict is stale before it is written, and queueing would pay for
+# it in full and then discard it. Cancelling mid-fixer is safe — the fixer only
+# ever appends a commit, and the round the cancellation belongs to is re-run by
+# the push that superseded it.
+#
+# Keyed on the PR's head BRANCH, which is what the `workflow_run` payload
+# carries; the PR number is not resolved until the `gate` job. Two different PRs
+# never share a branch, so this is per-PR in practice. `run_id` is deliberately
+# NOT in the key — that is the mistake that makes a concurrency group match only
+# itself and guard nothing.
+concurrency:
+  group: agent-review-panel-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 permissions: {}
 
 env:
@@ -1251,8 +1284,20 @@ jobs:
             push whose hook output is very large can report non-zero even though the
             ref advanced. If the remote head did not advance, push again before your
             turn ends.
+          # 200, up from 80. On #648 the fixer had nine blocking findings across
+          # 31 files and died at exactly 81 turns — while a concurrent duplicate
+          # doing the same work landed it in 76. That is not a comfortable margin,
+          # it is a coin flip, and the loser costs a full round plus a page.
+          #
+          # Higher than agent-implement's 150 on purpose: the implementer writes
+          # a change it planned itself, while the fixer must first READ code it
+          # did not write at locations the panel chose, then fix every finding in
+          # one pass because the prompt tells it to converge in one round. The
+          # ceiling is a backstop against a runaway loop, not a budget — cost is
+          # bounded by MAX_REVIEW_ROUNDS and the 45-minute job timeout, both of
+          # which bind well before 200 turns of useful work does.
           claude_args: >-
-            --max-turns 80
+            --max-turns 200
             --model claude-opus-5
             --allowedTools "Bash,Read,Edit,Write,Glob,Grep"
 
@@ -1333,8 +1378,20 @@ jobs:
   # a silently-skipped review on a PR that might have been managed.
   stalled:
     needs: [gate, deps, review-panel, promote, fix]
+    # `!cancelled()`, NOT `always()`. This changed with the concurrency guard at
+    # the top of the file: a superseded run is now cancelled mid-flight, and under
+    # `always()` this job still fired — a panel cancelled before it started reports
+    # `skipped`, which is one of the trigger conditions below. That would page a
+    # human and latch the PR to `agent:blocked` at the exact moment a FRESHER round
+    # was starting, and the latch would then stop that round from ever running.
+    #
+    # A spurious page is the worst failure this job has, because the page is
+    # sticky: it is the signal every other part of the pipeline treats as "a human
+    # owns this now". `!cancelled()` still fires on every genuine failure — a
+    # failed dependency is not a cancellation — so nothing this job was built to
+    # catch is lost.
     if: >-
-      always() &&
+      !cancelled() &&
       (needs.gate.result == 'failure' ||
        (needs.gate.outputs.managed == 'true' &&
         (needs.deps.result == 'failure' ||
@@ -1374,9 +1431,35 @@ jobs:
               deps: process.env.DEPS_RESULT, panel: process.env.PANEL_RESULT,
               promote: process.env.PROMOTE_RESULT, fix: process.env.FIX_RESULT,
             };
+            // Did the branch move? `workflow_run.head_sha` is the sha this panel
+            // reviewed; `pr.head.sha` is the branch NOW. A fix job can fail with
+            // the changes already pushed — its own commit landed and a later step
+            // died, or (before the concurrency guard above) a duplicate run pushed
+            // while this one burned its turn ceiling.
+            //
+            // On #648 the flat "the requested changes were not applied" was simply
+            // FALSE: `102e0fa73` was on the branch and CI-green three minutes
+            // before this comment was written. That sentence then sent a human
+            // looking for an unresponsive fixer instead of an unreviewed commit,
+            // and the paged latch meant nothing ever reviewed it. A page is the
+            // one message a human is guaranteed to read, so it is the last place
+            // that should guess.
+            // Three states, not two. "We could not read the head" must not print
+            // as "pushed nothing" — that is the same false certainty in a
+            // different place, and it would be wrong exactly when a human most
+            // needs to know where to look.
+            const reviewedSha = context.payload.workflow_run.head_sha;
+            const headSha = typeof pr.head?.sha === 'string' ? pr.head.sha : '';
+            const advanced = headSha === '' ? null : headSha !== reviewedSha;
+            const fixReason =
+              advanced === null
+                ? "the fixer agent's job failed, and this run could not read the branch head to tell whether anything was pushed — check the branch before assuming the changes are missing"
+                : advanced
+                  ? `the fixer agent's job failed, but the branch DID advance to \`${headSha.slice(0, 9)}\` — changes were applied and have NOT been reviewed (a common cause is the fixer exhausting its turn budget after pushing)`
+                  : 'the fixer agent failed and pushed nothing, so the requested changes were not applied';
             // First matching cause wins (fix/promote are downstream of the panel).
             const reason =
-              r.fix === 'failure' ? 'the fixer agent failed, so the requested changes were not applied'
+              r.fix === 'failure' ? fixReason
               : r.promote === 'failure' ? 'the ready-gate (promotion) step errored'
               : r.panel === 'failure' ? 'the review-panel job failed to complete'
               : (r.panel === 'skipped' || r.deps === 'failure') ? 'the review panel could not start (dependency setup failed)'

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -45,13 +45,24 @@ on:
 # ever appends a commit, and the round the cancellation belongs to is re-run by
 # the push that superseded it.
 #
-# Keyed on the PR's head BRANCH, which is what the `workflow_run` payload
-# carries; the PR number is not resolved until the `gate` job. Two different PRs
-# never share a branch, so this is per-PR in practice. `run_id` is deliberately
-# NOT in the key — that is the mistake that makes a concurrency group match only
-# itself and guard nothing.
+# Keyed on the head REPOSITORY and branch, both of which the `workflow_run`
+# payload carries; the PR number is not resolved until the `gate` job.
+#
+# The repository half is a security requirement, not tidiness. This repo is
+# PUBLIC, and `concurrency` is evaluated at the workflow level — BEFORE `gate`
+# applies its `head_repository.full_name == github.repository` fork check. Keyed
+# on the branch alone, anyone could fork, open a PR from a branch named to match
+# an in-flight agent branch, and have their CI completion CANCEL the legitimate
+# panel: denial of review from an unprivileged position, and the run that did the
+# cancelling would then be skipped by the gate, leaving no trace of a review that
+# should have happened. The same reasoning the paged latch in `gate` already
+# applies to its marker.
+#
+# `run_id` is deliberately NOT in the key — that is the mistake that makes a
+# concurrency group match only itself and guard nothing.
 concurrency:
-  group: agent-review-panel-${{ github.event.workflow_run.head_branch }}
+  group: >-
+    agent-review-panel-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 permissions: {}
@@ -1376,6 +1387,63 @@ jobs:
   # unmanaged/fork/disabled PR — only when a managed PR's pipeline actually broke.
   # A hard `gate` failure (managed unknown) also pages: better a spurious page than
   # a silently-skipped review on a PR that might have been managed.
+  # Close lens checks left spinning by a panel that did not finish.
+  #
+  # SPLIT OUT OF `stalled`, and the split is the point. This cleanup was written
+  # for the "panel KILLED mid-run (timeout/cancel)" case and used to ride on
+  # `stalled`'s `always()`. Moving `stalled` to `!cancelled()` — necessary, or a
+  # superseded run pages and latches the PR — would have taken this with it, at
+  # exactly the moment the concurrency guard above made cancellation the COMMON
+  # outcome rather than a rare one. Every superseded round would then leave six
+  # `agent-review-*` checks spinning forever.
+  #
+  # A separate job rather than a second condition on `stalled`, because the two
+  # need OPPOSITE cancellation behaviour: paging must not happen on a cancelled
+  # run, and cleanup must. Bundling them is what created the regression.
+  #
+  # It never pages, never labels, and holds `checks: write` alone — so running it
+  # on a cancelled run cannot produce the sticky state `stalled` was moved away
+  # from producing.
+  close-stuck-checks:
+    needs: [gate, review-panel]
+    # Skips a clean run (nothing is left open) and a never-started panel (nothing
+    # was ever opened). Everything else — cancelled, killed, timed out — is the
+    # case this exists for.
+    if: >-
+      always() &&
+      needs.review-panel.result != 'success' &&
+      needs.review-panel.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      checks: write
+    steps:
+      # Best-effort; only touches UNFINISHED agent-review-* checks on this SHA.
+      # A newer run that has already opened its own checks on the same sha (a CI
+      # re-run keeps the sha) may briefly see them closed here, then updates the
+      # same check-run ids with its real verdicts — the transient failure is
+      # overwritten rather than left behind.
+      - name: Close stuck in-progress lens checks
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const { data } = await github.rest.checks.listForRef({
+              owner: context.repo.owner, repo: context.repo.repo, ref: sha, per_page: 100,
+            });
+            for (const c of data.check_runs) {
+              if (!/^agent-review-/.test(c.name) || c.status === 'completed') continue;
+              await github.rest.checks.update({
+                owner: context.repo.owner, repo: context.repo.repo, check_run_id: c.id,
+                status: 'completed', conclusion: 'failure',
+                output: {
+                  title: `${c.name.replace(/^agent-review-/, '')}: panel stopped`,
+                  summary: 'The review panel stopped before this lens produced a verdict.',
+                },
+              });
+            }
+
   stalled:
     needs: [gate, deps, review-panel, promote, fix]
     # `!cancelled()`, NOT `always()`. This changed with the concurrency guard at
@@ -1448,6 +1516,13 @@ jobs:
             // as "pushed nothing" — that is the same false certainty in a
             // different place, and it would be wrong exactly when a human most
             // needs to know where to look.
+            //
+            // AND NO ATTRIBUTION. All this run can observe is that the head is no
+            // longer the sha it reviewed; it cannot see WHO moved it. A human push,
+            // or a concurrent run's fixer (the #648 shape), both look identical
+            // from here — so "the fixer pushed" and "the changes were applied"
+            // would be the same unproven claim the old sentence made, only
+            // pointing the other way. State the shas and let the human look.
             const reviewedSha = context.payload.workflow_run.head_sha;
             const headSha = typeof pr.head?.sha === 'string' ? pr.head.sha : '';
             const advanced = headSha === '' ? null : headSha !== reviewedSha;
@@ -1455,8 +1530,8 @@ jobs:
               advanced === null
                 ? "the fixer agent's job failed, and this run could not read the branch head to tell whether anything was pushed — check the branch before assuming the changes are missing"
                 : advanced
-                  ? `the fixer agent's job failed, but the branch DID advance to \`${headSha.slice(0, 9)}\` — changes were applied and have NOT been reviewed (a common cause is the fixer exhausting its turn budget after pushing)`
-                  : 'the fixer agent failed and pushed nothing, so the requested changes were not applied';
+                  ? `the fixer agent's job failed. The branch head is now \`${headSha.slice(0, 9)}\`, not the \`${reviewedSha.slice(0, 9)}\` this panel reviewed — a commit landed and has NOT been reviewed. Check whether it is the requested fix before assuming the changes are missing`
+                  : 'the fixer agent failed and the branch head is unchanged, so the requested changes were not applied';
             // First matching cause wins (fix/promote are downstream of the panel).
             const reason =
               r.fix === 'failure' ? fixReason
@@ -1471,34 +1546,6 @@ jobs:
             // The single-value label is set by the "Reconcile agent state" step
             // below — it re-derives state from the unforgeable signals (the paged
             // comment just posted → agent:blocked) and self-heals any drift.
-
-      # If the panel job was KILLED mid-run (timeout/cancel), the "Mark lens
-      # checks in progress" step's checks are still spinning — the always()
-      # finaliser in review-panel doesn't run on a job kill, only on a step
-      # failure. Close any that are still open so the PR shows a resolved state
-      # matching the paged comment above, not a spinner that never completes.
-      # Best-effort; only touches unfinished agent-review-* checks on this SHA.
-      - name: Close stuck in-progress lens checks
-        if: steps.page.outputs.pr != ''
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const sha = context.payload.workflow_run.head_sha;
-            const { data } = await github.rest.checks.listForRef({
-              owner: context.repo.owner, repo: context.repo.repo, ref: sha, per_page: 100,
-            });
-            for (const c of data.check_runs) {
-              if (!/^agent-review-/.test(c.name) || c.status === 'completed') continue;
-              await github.rest.checks.update({
-                owner: context.repo.owner, repo: context.repo.repo, check_run_id: c.id,
-                status: 'completed', conclusion: 'failure',
-                output: {
-                  title: `${c.name.replace(/^agent-review-/, '')}: panel stopped`,
-                  summary: 'The review panel stopped before this lens produced a verdict. A human was paged.',
-                },
-              });
-            }
 
       # The panel died before producing verdicts, but earlier sessions
       # (kickoff / ci-fix) recorded effort — post the summary so the hand-off

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -930,7 +930,10 @@ Components:
   spurious page is the costlier error. Tuned via `STALL_REPEATS` /
   `STALL_SIMILARITY`.
 - **One panel per branch at a time.** `.github/workflows/agent-review-panel.yml` carries a
-  `concurrency` group keyed on the PR's head branch with `cancel-in-progress`.
+  `concurrency` group keyed on the head repository and branch, with
+  `cancel-in-progress`. The repository half is a security requirement: the group is
+  evaluated before `gate` applies its fork check, so a branch-only key would let a
+  fork PR named to match an in-flight agent branch cancel the real panel.
   Two CI completions close together (a re-run, or a push landing mid-round) used
   to start two full pipelines against the same branch, and it broke two PRs in
   distinguishable ways. **#605**: two panels finished in the *same second* with
@@ -944,13 +947,17 @@ Components:
   superseded panel is reviewing a sha that is no longer the head, so its verdict is
   stale before it is written.
 
-  Two consequences worth stating because each is a trap. The `stalled` job moved
-  from `always()` to `!cancelled()`: under `always()` a cancelled run still paged,
+  Three consequences worth stating because each is a trap. **`stalled` moved from
+  `always()` to `!cancelled()`**: under `always()` a cancelled run still paged,
   because a panel cancelled before it started reports `skipped`, which is one of
-  its trigger conditions — so the guard would have latched a PR to
-  `agent:blocked` at the moment a fresher round was starting, and the latch would
-  then stop that round. And the group key must not include `run_id`, or it matches
-  only itself and guards nothing.
+  its trigger conditions — so the guard would have latched a PR to `agent:blocked`
+  at the moment a fresher round was starting, and the latch would then stop that
+  round. **The stuck-check cleanup had to move out of `stalled`** into its own
+  `close-stuck-checks` job: it exists for the killed/cancelled case and rode on the
+  same `always()`, so leaving it there would have stranded six `agent-review-*`
+  checks in progress on every superseded round — the two need opposite cancellation
+  behaviour, which is why bundling them regressed. **The group key must not include
+  `run_id`**, or it matches only itself and guards nothing.
 - **The fixer's turn ceiling is 200**, above `agent-implement`'s 150. The fixer
   must first READ code it did not write, at locations the panel chose, then fix
   every finding in one pass because the prompt tells it to converge in one round.
@@ -959,8 +966,11 @@ Components:
   against a runaway loop, not a budget: `MAX_REVIEW_ROUNDS` and the 45-minute job
   timeout both bind well before 200 turns of useful work does.
 - **A page must not guess.** The `stalled` page distinguishes three states when the
-  fixer job fails — the branch advanced (changes applied, unreviewed), it did not
-  (nothing pushed), or the head could not be read (say so). The flat
+  fixer job fails — the head moved (an unreviewed commit landed), it did not
+  (nothing pushed), or the head could not be read (say so). It deliberately does not
+  say WHO moved it: a human push and a concurrent run's fixer are indistinguishable
+  from there, so "the fixer pushed the fix" would be the same unproven claim in the
+  other direction. The flat
   "the requested changes were not applied" was simply false on #648, and because a
   page is the one message a human is guaranteed to read, it sent the investigation
   after an unresponsive fixer instead of an unreviewed commit.

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -909,9 +909,11 @@ Components:
   exhausted: `detectStalledRounds` needs `minRepeats + 1` = 3 rounds of evidence
   before it can report a stall, so no earlier non-convergence page is possible,
   and rounds 4-5 were a PR paying a full panel round each (~$12) on the way to a
-  page that was already inevitable. Note this bounds the **fixer**, not panel
-  spend: the guard runs in the `fix` job, so a paged PR still re-reviews on every
-  CI-green push. `scripts/agent/rounds.mjs`'s
+  page that was already inevitable. Note this bounds the **fixer** directly; panel
+  spend after a page is bounded separately, by the paged latch in the `gate` job
+  (the round guard runs in `fix`, downstream of `review-panel`, so on its own it
+  left a paged PR re-reviewing on every CI-green push — five rounds and $53.98 on
+  #605). `scripts/agent/rounds.mjs`'s
   `detectStalledRounds` (wired into
   `scripts/agent/review-round-guard.mjs`, checked BEFORE the round cap so the
   more specific reason wins) pages as soon as two consecutive round pairs both
@@ -927,6 +929,41 @@ Components:
   than manufacture a page, since `MAX_REVIEW_ROUNDS` still backstops and a
   spurious page is the costlier error. Tuned via `STALL_REPEATS` /
   `STALL_SIMILARITY`.
+- **One panel per branch at a time.** `.github/workflows/agent-review-panel.yml` carries a
+  `concurrency` group keyed on the PR's head branch with `cancel-in-progress`.
+  Two CI completions close together (a re-run, or a push landing mid-round) used
+  to start two full pipelines against the same branch, and it broke two PRs in
+  distinguishable ways. **#605**: two panels finished in the *same second* with
+  identical `external_id` and contradictory verdicts — correctness 1 major vs 2
+  major, docs success vs failure — twelve check runs for six lenses, last writer
+  wins. **#648**, worse because the panel dispatches a fixer: two fixers ran on
+  one branch for 21 overlapping minutes on the same nine findings; the later
+  converged in 76 turns and pushed, the earlier crossed its 80-turn ceiling and
+  failed, and `stalled` then paged *"the requested changes were not applied"* when
+  they had just been applied by the other run. Cancel rather than queue — a
+  superseded panel is reviewing a sha that is no longer the head, so its verdict is
+  stale before it is written.
+
+  Two consequences worth stating because each is a trap. The `stalled` job moved
+  from `always()` to `!cancelled()`: under `always()` a cancelled run still paged,
+  because a panel cancelled before it started reports `skipped`, which is one of
+  its trigger conditions — so the guard would have latched a PR to
+  `agent:blocked` at the moment a fresher round was starting, and the latch would
+  then stop that round. And the group key must not include `run_id`, or it matches
+  only itself and guards nothing.
+- **The fixer's turn ceiling is 200**, above `agent-implement`'s 150. The fixer
+  must first READ code it did not write, at locations the panel chose, then fix
+  every finding in one pass because the prompt tells it to converge in one round.
+  At 80 it died at exactly 81 turns on #648 while a concurrent duplicate landed
+  the same work in 76 — not a margin, a coin flip. The ceiling is a backstop
+  against a runaway loop, not a budget: `MAX_REVIEW_ROUNDS` and the 45-minute job
+  timeout both bind well before 200 turns of useful work does.
+- **A page must not guess.** The `stalled` page distinguishes three states when the
+  fixer job fails — the branch advanced (changes applied, unreviewed), it did not
+  (nothing pushed), or the head could not be read (say so). The flat
+  "the requested changes were not applied" was simply false on #648, and because a
+  page is the one message a human is guaranteed to read, it sent the investigation
+  after an unresponsive fixer instead of an unreviewed commit.
 
 Human gate (mechanical, not prompt-based): branch protection on `main` requires a
 human approving review + CI green + dismiss-stale-approvals; the `agent-implement`

--- a/docs/tasks/active/20260804-panel-concurrency-todo.md
+++ b/docs/tasks/active/20260804-panel-concurrency-todo.md
@@ -30,7 +30,8 @@ contradictory verdicts — correctness 1 major vs 2 major, docs success vs failu
 
 ## The change
 
-- [x] `concurrency: agent-review-panel-<head_branch>` with `cancel-in-progress`.
+- [x] `concurrency: agent-review-panel-<head_repo>-<head_branch>` with
+      `cancel-in-progress`.
       Cancel rather than queue: a superseded panel is reviewing a sha that is no
       longer the head, so its verdict is stale before it is written.
 - [x] Fixer `--max-turns` **80 → 200**, above `agent-implement`'s 150. The fixer
@@ -38,9 +39,11 @@ contradictory verdicts — correctness 1 major vs 2 major, docs success vs failu
       finding in one pass. The ceiling is a runaway backstop, not a budget —
       `MAX_REVIEW_ROUNDS` and the 45-minute job timeout bind first.
 - [x] The `stalled` page now distinguishes **three** states on a fixer failure:
-      branch advanced (applied, unreviewed), did not advance (nothing pushed), or
-      head unreadable (say so).
-- [x] `stalled` moved from `always()` to `!cancelled()` — see below.
+      the head moved (an unreviewed commit landed — without claiming who pushed it),
+      it did not move (nothing pushed), or it could not be read (say so).
+- [x] `stalled` moved from `always()` to `!cancelled()` — see below, plus a new
+      cancellation-safe `close-stuck-checks` job so that move does not strand
+      lens checks.
 - [x] Corrected a now-stale line in `harness-engineering.md` claiming a paged PR
       still re-reviews on every CI-green push; the gate's paged latch ended that.
 
@@ -57,18 +60,19 @@ every other part of the pipeline treats it as "a human owns this now".
 `!cancelled()` still fires on every genuine failure; a failed dependency is not a
 cancellation.
 
-Also checked: the remaining `always()` uses in this workflow are step-level, and
-the one that writes state (`Post per-lens check runs`) is self-healing — a
-superseded run's lens checks are overwritten by the newer run, since check runs are
-resolved latest-per-name.
+The stuck-check cleanup that rode on the same `always()` had to move with it —
+see the review response below. The remaining `always()` uses in this workflow are
+step-level, and the one that writes state (`Post per-lens check runs`) is
+self-healing: a superseded run's lens checks are overwritten by the newer run, since
+check runs resolve latest-per-name.
 
 ## Verification
 
 - [x] `pnpm verify:self` green (11/11); workflow parses.
 - [x] **The three-state reason logic extracted from the YAML and executed** — inline
       `github-script` JS can hold neither a test nor a linter, so it was run against
-      #648's real shape (moved → "applied and NOT reviewed"), a genuine no-push, and
-      an unreadable head.
+      #648's real shape, a genuine no-push, and an unreadable head — asserting the
+      output carries no unproven attribution.
 - [x] Group key contains no `run_id` — that is the mistake that makes a concurrency
       group match only itself and guard nothing.
 
@@ -81,3 +85,40 @@ is a trust question rather than a bug fix.
 
 #648 itself still needs unblocking by hand so one round can review `102e0fa73`.
 Nothing here does that.
+
+## Review response (CodeRabbit, #649)
+
+Three fixed, one skipped.
+
+- [x] **Fork branch-name collision could cancel a legitimate panel.** `concurrency`
+      is evaluated at the workflow level, *before* `gate` applies its
+      `head_repository.full_name == github.repository` fork check. Keyed on the
+      branch alone, anyone could fork this **public** repo, open a PR from a branch
+      named to match an in-flight agent branch, and have their CI completion cancel
+      the real panel — denial of review from an unprivileged position, with the
+      cancelling run then skipped by the gate so nothing records the review that
+      should have happened. The group now includes the head repository.
+- [x] **`!cancelled()` stranded the stuck-check cleanup.** That cleanup exists for
+      the "panel KILLED mid-run (timeout/**cancel**)" case and rode on `stalled`'s
+      `always()`. Moving `stalled` off `always()` removed it at exactly the moment
+      the concurrency guard made cancellation the *common* outcome — every
+      superseded round would have left six `agent-review-*` checks spinning forever.
+      Split into a `close-stuck-checks` job that runs on cancellation, never pages,
+      never labels, and holds `checks: write` alone. The two genuinely need opposite
+      cancellation behaviour, which is why bundling them created the regression.
+- [x] **My own fix still attributed the push.** "the branch DID advance … changes
+      were applied" claims the *fixer* pushed the *requested fix*, and this run can
+      observe neither. A human push and a concurrent run's fixer look identical from
+      here. It now states both shas and says a commit landed unreviewed, without
+      saying who or what — otherwise it is the same unproven claim as the sentence it
+      replaced, pointing the other way.
+
+**Skipped: wrapping the `pulls.list` lookup in try/catch and reusing `gate`'s PR
+number.** The `advanced` computation cannot throw (`typeof pr.head?.sha === 'string'`),
+so the new code path is already covered. A `pulls.list` throw failing the whole step
+is pre-existing behaviour with pre-existing consequences, and `gate` emits only the PR
+number — not the head sha this needs — so reusing it would still cost a second call.
+
+**Skipped: `#648` at line start rendering as a heading.** CommonMark requires
+whitespace after the `#` run, so `#648` is not an ATX heading; GitHub follows
+CommonMark and auto-links it as an issue reference, which is the intent.

--- a/docs/tasks/active/20260804-panel-concurrency-todo.md
+++ b/docs/tasks/active/20260804-panel-concurrency-todo.md
@@ -1,0 +1,83 @@
+# One panel per branch, and a fixer with room to finish
+
+Two failures found while investigating why **#648** came out `agent:blocked`.
+
+## What happened on #648
+
+The label and the page both said the fixer couldn't satisfy the panel. Neither was
+what happened.
+
+`agent-review-panel.yml` had **no `concurrency` guard**, so two CI completions
+close together started two full pipelines against `agent/586-cli-system-exit-code`:
+
+| run | panel | fix | turns | outcome |
+|---|---|---|---|---|
+| A `30803409664` | 09:55→10:05 | 10:05→**10:35:52** | **81** | ❌ `Reached maximum number of turns (80)` |
+| B `30803718950` | 10:00→10:11 | 10:11→10:32:48 | 76 | ✅ pushed `102e0fa73` |
+
+**21 overlapping minutes, two fixer agents, the same nine findings.** B converged
+and pushed; A crossed its ceiling and its job failed. Run A's `stalled` job then
+paged with *"the fixer agent failed, so the requested changes were not applied"* —
+**false**: `102e0fa73` was on the branch and CI-green three minutes earlier.
+
+The paged latch (correctly) froze the PR, so the commit that *did* land was never
+reviewed. `$22.30` spent, roughly a third of it on a duplicate that could only
+lose.
+
+The same absent guard had already produced a different symptom on **#605**: two
+panels completing in the *same second* with identical `external_id` and
+contradictory verdicts — correctness 1 major vs 2 major, docs success vs failure.
+
+## The change
+
+- [x] `concurrency: agent-review-panel-<head_branch>` with `cancel-in-progress`.
+      Cancel rather than queue: a superseded panel is reviewing a sha that is no
+      longer the head, so its verdict is stale before it is written.
+- [x] Fixer `--max-turns` **80 → 200**, above `agent-implement`'s 150. The fixer
+      reads code it did not write at locations the panel chose, then fixes every
+      finding in one pass. The ceiling is a runaway backstop, not a budget —
+      `MAX_REVIEW_ROUNDS` and the 45-minute job timeout bind first.
+- [x] The `stalled` page now distinguishes **three** states on a fixer failure:
+      branch advanced (applied, unreviewed), did not advance (nothing pushed), or
+      head unreadable (say so).
+- [x] `stalled` moved from `always()` to `!cancelled()` — see below.
+- [x] Corrected a now-stale line in `harness-engineering.md` claiming a paged PR
+      still re-reviews on every CI-green push; the gate's paged latch ended that.
+
+## The trap my own change introduced
+
+`stalled` ran under `always()`. With `cancel-in-progress` now cancelling
+superseded runs, a panel cancelled **before it started** reports `skipped` — which
+is one of `stalled`'s trigger conditions. It would have paged and latched the PR to
+`agent:blocked` at the exact moment a fresher round was starting, and the latch
+would then have stopped that round from running.
+
+A spurious page is this job's worst failure mode, because the page is *sticky* —
+every other part of the pipeline treats it as "a human owns this now".
+`!cancelled()` still fires on every genuine failure; a failed dependency is not a
+cancellation.
+
+Also checked: the remaining `always()` uses in this workflow are step-level, and
+the one that writes state (`Post per-lens check runs`) is self-healing — a
+superseded run's lens checks are overwritten by the newer run, since check runs are
+resolved latest-per-name.
+
+## Verification
+
+- [x] `pnpm verify:self` green (11/11); workflow parses.
+- [x] **The three-state reason logic extracted from the YAML and executed** — inline
+      `github-script` JS can hold neither a test nor a linter, so it was run against
+      #648's real shape (moved → "applied and NOT reviewed"), a genuine no-push, and
+      an unreadable head.
+- [x] Group key contains no `run_id` — that is the mistake that makes a concurrency
+      group match only itself and guard nothing.
+
+## Deliberately NOT in this PR
+
+The third finding from the investigation: **don't latch on a page whose premise the
+branch contradicts.** If the head advanced and CI is green after a page, that is
+worth one more panel round. It needs a decision about who may clear a latch, which
+is a trust question rather than a bug fix.
+
+#648 itself still needs unblocking by hand so one round can review `102e0fa73`.
+Nothing here does that.


### PR DESCRIPTION
## Summary

Two fixes from investigating why **#648** came out `agent:blocked`. Neither the
label nor the page described what actually happened.

## What broke on #648

`agent-review-panel.yml` had **no `concurrency` guard**, so two CI completions
close together started two full pipelines against `agent/586-cli-system-exit-code`:

| run | panel | fix | turns | outcome |
|---|---|---|---|---|
| A `30803409664` | 09:55→10:05 | 10:05→**10:35:52** | **81** | ❌ `Reached maximum number of turns (80)` |
| B `30803718950` | 10:00→10:11 | 10:11→10:32:48 | 76 | ✅ pushed `102e0fa73` |

**Two fixer agents, 21 overlapping minutes, the same nine findings.** B converged
and pushed. A crossed its ceiling and its job failed, which fired `stalled`:

> 🛑 … the fixer agent failed, **so the requested changes were not applied**.

That sentence was false. `102e0fa73` was on the branch and CI-green three minutes
earlier. The paged latch then correctly froze the PR — so the commit that *did*
land was never reviewed. **$22.30 spent, roughly a third of it on a duplicate that
could only lose.**

The same absent guard had already broken **#605** with a different symptom: two
panels completing in the *same second* with identical `external_id` and
contradictory verdicts — correctness 1 major vs 2 major, docs success vs failure,
twelve check runs for six lenses, last writer wins.

## The changes

**1. `concurrency` on the panel, `cancel-in-progress: true`.**

Cancel rather than queue: a superseded panel is reviewing a sha that is no longer
the head, so its verdict is stale before it is written, and queueing pays for it in
full and then discards it. Keyed on the head **branch** — the PR number isn't
resolved until the `gate` job. No `run_id` in the key; that's the mistake that makes
a group match only itself and guard nothing.

**2. Fixer `--max-turns` 80 → 200.**

Above `agent-implement`'s 150 on purpose. The implementer writes a change it planned
itself; the fixer must first **read** code it did not write, at locations the panel
chose, then fix every finding in one pass because the prompt tells it to converge in
one round. At 80 it died at exactly 81 while the duplicate landed the same work in
76 — a coin flip, not a margin. The ceiling is a runaway backstop, not a budget:
`MAX_REVIEW_ROUNDS` and the 45-minute job timeout both bind well before 200 turns of
useful work does.

**3. The page no longer guesses.** On a fixer failure it distinguishes three states:
the branch advanced (applied, unreviewed, naming the sha), it did not (nothing
pushed), or the head couldn't be read (says so).

## The trap this change introduced

Caught before pushing, and it's the part most worth reviewing.

`stalled` ran under **`always()`**. With `cancel-in-progress` now cancelling
superseded runs, a panel cancelled *before it starts* reports `skipped` — which is
one of `stalled`'s own trigger conditions. It would have paged and latched the PR to
`agent:blocked` **at the exact moment a fresher round was starting**, and the latch
would then have stopped that round from running.

Now `!cancelled()`, which still fires on every genuine failure — a failed dependency
is not a cancellation. A spurious page is this job's worst outcome because the page
is **sticky**: every other part of the pipeline reads it as "a human owns this now".

I also checked the remaining `always()` uses in the file. All step-level, and the one
that writes state (`Post per-lens check runs`) is self-healing — a superseded run's
lens checks get overwritten, since check runs resolve latest-per-name.

## Verification

`pnpm verify:self` green (**11/11**) · workflow parses.

- **The three-state reason logic was extracted from the YAML and executed** — inline
  `github-script` JS can hold neither a test nor a linter, so it was run against
  #648's real shape (head moved → "applied and NOT reviewed"), a genuine no-push, and
  an unreadable head. The unknown case says it's unknown rather than falling back to
  "pushed nothing", which would be the same false certainty in a new place.

## What I'd push back on as a reviewer

**200 is a judgement, not a measurement.** The only data points are 76 (converged)
and 81 (died); nothing says where the real ceiling should be. It's deliberately far
above both so the ceiling stops being the binding constraint — the round cap and job
timeout are the intended bounds — but if fixer runs start costing noticeably more per
round, this is the number to revisit.

**`cancel-in-progress` can kill a fixer mid-work.** That's intended (its base is
stale), and safe because the fixer only ever appends a commit. But a cancelled fixer
that had already pushed leaves a commit whose round never completed — the push
re-triggers CI and a fresh panel, so it converges, just not for free.

## Also in here

One stale line in `harness-engineering.md` claiming a paged PR still re-reviews on
every CI-green push. The gate's paged latch ended that, and the sentence sat directly
above what I was editing.

## Deliberately NOT in this PR

The third finding from the investigation: **don't latch on a page whose premise the
branch contradicts.** If the head advanced and CI is green after a page, that's worth
one more panel round. It needs a decision about who may clear a latch — a trust
question, not a bug fix.

**#648 itself still needs unblocking by hand** so one round can review `102e0fa73`.
Nothing here does that.

## Linked Issues

None — from the #648 post-mortem.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification checklist

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

## Risk Assessment

- **User-facing risk:** none. No product code.
- **Data/security risk:** no permission or trust-model change. The concurrency guard
  only reduces what runs; the turn ceiling and the page wording change no scope.
- **Rollback:** revert. Both changes are single-value; removing the `concurrency`
  block restores the previous (racy) behaviour exactly.

## Notes for Reviewers

- **AI assistance:** investigated and implemented with Claude Code (Opus 5) in an
  interactive session and reviewed by me.
- **This is the second time the missing guard caused a real failure** (#605, #648).
  The failures looked unrelated — contradictory verdicts vs a mislabelled PR — which
  is why it survived the first one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping automated review runs for the same branch by cancelling superseded runs.
  * Improved stalled and failure notifications to ignore cancelled runs and accurately reflect branch status.
  * Reduced stale outcomes and duplicate work during automated review and fix processes.

* **Improvements**
  * Increased the automated fixer’s maximum work limit, enabling it to handle more complex changes.

* **Documentation**
  * Documented concurrency issues, completed safeguards, verification results, and remaining manual follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->