### PR TITLE
Add @claude rerun to un-stick a paged agent PR in one step

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -368,6 +368,6 @@ jobs:
               body: [
                 "👋 Did you mean **`@claude fix`**? Commenting `@claude fix` on this issue starts an autonomous run that opens a draft PR.",
                 "",
-                "On a **pull request** you can also use `@claude review`, `@claude summarize`, or `@claude loop`.",
+                "On a **pull request** you can also use `@claude review`, `@claude summarize`, `@claude loop`, or `@claude rerun` (un-stick a paged agent PR).",
               ].join("\n"),
             });

--- a/.github/workflows/agent-rerun.yml
+++ b/.github/workflows/agent-rerun.yml
@@ -1,0 +1,187 @@
+# "@claude rerun": clear a paged/blocked agent PR and re-engage the review→fix
+# loop in one step. When the autonomous pipeline pages a human it drops a
+# `<!-- agent-review-paged -->` (or `<!-- agent-paged -->`) comment and an
+# `agent:blocked` label, and — crucially — review-round-guard.mjs LATCHES on that
+# comment, so the loop will not resume on its own even after CI re-runs. Un-sticking
+# it by hand means: delete the paged comment, remove the label, and re-run CI so the
+# panel fires again. This verb does exactly that.
+#
+# Like "@claude loop" (and unlike the read-only "@claude review"), this re-engages
+# machinery that pushes bot commits and can promote, so it is TRUSTED-AUTHOR ONLY
+# and only acts on an agent-managed same-repo PR (an `agent/` branch OR one labelled
+# `agent:managed`). A fork / unmanaged PR gets a note and nothing else.
+name: Agent Rerun
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  route:
+    if: >-
+      vars.AGENT_PIPELINE_ENABLED == 'true' &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      command: ${{ steps.route.outputs.command }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/agent/command.mjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Route command
+        id: route
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: node scripts/agent/command.mjs "$BODY" pr
+
+  rerun:
+    needs: [route]
+    if: needs.route.outputs.command == 'rerun'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read # resolve the PR (head repo/branch/labels)
+      issues: write # delete the paged comment, drop agent:blocked, post the note
+      actions: write # re-run CI to re-fire the panel
+    concurrency:
+      group: agent-rerun-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      # Authoritative trust gate — rerun re-engages a loop that pushes commits and
+      # promotes, so it is maintainers only (org membership ≠ repo write; check the
+      # real permission on THIS repo).
+      - name: Verify commenter has write access
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const actor = context.payload.comment.user.login;
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner, repo: context.repo.repo, username: actor,
+            });
+            if (!['admin', 'maintain', 'write'].includes(data.permission)) {
+              core.setFailed(`@${actor} lacks write access (permission: ${data.permission}); refusing to run.`);
+            }
+
+      # Human-facing comments go through a GitHub App token, NOT GITHUB_TOKEN: on a
+      # fork-PR-triggered run GITHUB_TOKEN is read-only, so the "not managed" note
+      # would 403. rerun runs no untrusted code (API calls only), so minting it here
+      # is safe. The block-clearing + CI re-run below stay on GITHUB_TOKEN, which is
+      # writable on the same-repo managed path where they actually execute.
+      - name: Generate GitHub App token (comments)
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.AGENT_APP_ID }}
+          private-key: ${{ secrets.AGENT_APP_PRIVATE_KEY }}
+          permission-issues: write
+
+      - name: Post running placeholder
+        id: placeholder
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const { data } = await github.rest.issues.createComment({
+              owner, repo, issue_number: context.payload.issue.number,
+              body: '🤖 Working on `@claude rerun`…',
+            });
+            core.setOutput('id', String(data.id));
+
+      - name: Clear the block and re-run CI
+        id: rerun
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const pr_number = context.payload.issue.number;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: pr_number });
+
+            // rerun re-engages the auto-fix/promote loop, which pushes to the PR head
+            // branch and only runs on agent-managed same-repo PRs. A fork can't be
+            // pushed to (so it never gets the loop, never gets paged); an unmanaged
+            // PR has no loop to resume. Refuse both with a note rather than re-running
+            // CI on a PR the pipeline doesn't own.
+            const isFork = !pr.head.repo || pr.head.repo.full_name !== `${owner}/${repo}`;
+            const managed = !isFork &&
+              (pr.head.ref.startsWith('agent/') ||
+               (pr.labels || []).some((l) => (l.name || l) === 'agent:managed'));
+            if (!managed) {
+              core.setOutput('outcome', isFork
+                ? "⚠️ `@claude rerun` only works on same-repo agent-managed PRs — a fork PR is never driven by the auto-fix loop, so there is nothing to re-run. Use **`@claude review`** for a read-only review."
+                : "⚠️ This PR isn't agent-managed (no `agent/` branch and no `agent:managed` label), so there's no paged loop to resume. Comment **`@claude loop`** to opt it into the loop.");
+              return;
+            }
+
+            // Clear the PAGED LATCH: review-round-guard.mjs stops the loop as long as
+            // an <!-- agent-review-paged --> comment exists (and set-state derives
+            // `blocked` from it OR the CI-side <!-- agent-paged -->). Delete both so
+            // the next round can proceed. Best-effort per comment.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pr_number, per_page: 100,
+            });
+            let clearedLatch = 0;
+            for (const c of comments) {
+              const body = c.body || '';
+              if (body.includes('<!-- agent-review-paged -->') || body.includes('<!-- agent-paged -->')) {
+                try { await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id }); clearedLatch++; }
+                catch (e) { core.warning(`Could not delete paged comment ${c.id} (${e.message}).`); }
+              }
+            }
+
+            // Drop the single-value blocked label (best-effort; a fresh round re-derives
+            // the correct state). removeLabel 404s if it isn't set — that's fine.
+            try {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: pr_number, name: 'agent:blocked' });
+            } catch (e) {
+              if (e.status !== 404) core.warning(`Could not remove agent:blocked (${e.message}).`);
+            }
+
+            // Re-run the latest CI run for the head SHA so the panel fires again: on
+            // green CI → review panel (promote/fix), on red CI → the CI-fix arm. Same
+            // mechanism agent-loop.yml uses to engage the loop. Best-effort — if there
+            // is nothing to re-run, the cleared latch still lets the next CI run through.
+            let reran = false;
+            try {
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: 'ci.yml', head_sha: pr.head.sha, per_page: 1,
+              });
+              const run = runs.data.workflow_runs[0];
+              if (run) { await github.rest.actions.reRunWorkflow({ owner, repo, run_id: run.id }); reran = true; }
+            } catch (e) {
+              core.warning(`Could not re-run CI (${e.message}); the loop will engage on the next CI run.`);
+            }
+
+            core.setOutput('outcome',
+              `🔁 Rerun engaged — cleared ${clearedLatch} paged marker(s) and dropped \`agent:blocked\`. ` +
+              (reran
+                ? "Re-running CI now; the review panel will run again and can promote or fix this PR."
+                : "No CI run to re-run — the panel will engage on the next CI run.") +
+              " Still bounded by the pipeline's round/attempt caps, and a human approval is required to merge.");
+
+      # Edit the placeholder into the final result. always() so a failure in the
+      # clear step still replaces the "working on it" note instead of stranding it.
+      - name: Update the running comment with the result
+        if: always() && steps.placeholder.outputs.id != ''
+        uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ steps.placeholder.outputs.id }}
+          OUTCOME: ${{ steps.rerun.outputs.outcome }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const body = process.env.OUTCOME ||
+              '🛑 `@claude rerun` failed before it could clear the block — see the workflow run log.';
+            await github.rest.issues.updateComment({
+              owner, repo, comment_id: Number(process.env.COMMENT_ID), body,
+            });

--- a/scripts/agent/command.mjs
+++ b/scripts/agent/command.mjs
@@ -7,7 +7,7 @@
 // (one run of whitespace), so "@claude please review" is NOT `review` (it does
 // not contain the contiguous "@claude review") — it falls through to `reply`.
 //
-// Recognized verbs: fix | summarize (alias summarise) | review | loop.
+// Recognized verbs: fix | summarize (alias summarise) | review | loop | rerun.
 // If a comment contains more than one verb, the FIRST occurrence wins
 // (leftmost match — deterministic and documented).
 //
@@ -30,6 +30,7 @@ const VERB_TO_COMMAND = {
   summarise: "summarize", // en-GB spelling normalizes to the same command
   review: "review",
   loop: "loop",
+  rerun: "rerun", // clear a paged/blocked agent PR and re-engage the review→fix loop
 };
 
 // "@claude" + one run of whitespace + a recognized verb, as a whole word.
@@ -47,7 +48,7 @@ const MENTION_RE = /@claude(?![\w-])/i;
  * @param {string} body - the raw comment body.
  * @param {{surface?: 'issue'|'pr'}} [opts] - where the comment was posted; only
  *   affects the no-verb fallback (`reply` on a PR vs `help` on an issue).
- * @returns {{command: 'fix'|'summarize'|'review'|'loop'|'reply'|'help'|'none', rest: string}}
+ * @returns {{command: 'fix'|'summarize'|'review'|'loop'|'rerun'|'reply'|'help'|'none', rest: string}}
  *   `rest` is the text following the matched command (trimmed), for passing any
  *   extra instructions through to the agent; "" when there is no verb match.
  */

--- a/scripts/agent/command.test.mjs
+++ b/scripts/agent/command.test.mjs
@@ -16,6 +16,7 @@ test("recognizes each verb regardless of trailing words", () => {
   assert.equal(cmd("@claude summarize this PR", "pr"), "summarize");
   assert.equal(cmd("@claude review this PR", "pr"), "review");
   assert.equal(cmd("@claude loop", "pr"), "loop");
+  assert.equal(cmd("@claude rerun this PR", "pr"), "rerun");
   // bare verb, no trailing phrase
   assert.equal(cmd("@claude fix", "issue"), "fix");
 });
@@ -43,7 +44,7 @@ test("first recognized verb wins when several appear", () => {
 test("no collision: the new verbs never fall through to reply", () => {
   // Regression guard for the agent-review-reply.yml double-fire bug: a review /
   // summarize / loop comment on a PR must NOT parse as the generic `reply`.
-  for (const body of ["@claude review this PR", "@claude summarize this PR", "@claude loop"]) {
+  for (const body of ["@claude review this PR", "@claude summarize this PR", "@claude loop", "@claude rerun"]) {
     assert.notEqual(cmd(body, "pr"), "reply");
   }
 });


### PR DESCRIPTION
## Why

When the autonomous pipeline pages a human, un-sticking the PR is a fiddly three-step manual dance: **delete the paged latch comment** (`review-round-guard.mjs` latches on `<!-- agent-review-paged -->`, so the loop won't resume while it exists), **remove the `agent:blocked` label**, and **re-run CI** so the panel fires again. This adds a command that does all three.

Comment **`@claude rerun`** on a paged agent PR → it clears the block and re-engages the review→fix loop.

## What it does

- **`command.mjs`** — new `rerun` verb (+ tests). Recognized on a PR; inert on an issue (no workflow handles `rerun` there); never collides with the generic `reply` path (regression-guarded like the other verbs).
- **`agent-rerun.yml`** — new workflow, modeled on `agent-loop.yml`:
  - **Trusted-author only** (it re-engages machinery that pushes bot commits and can promote — same bar as `@claude loop`, authoritative `getCollaboratorPermissionLevel` check, no PR-author relaxation).
  - **Agent-managed same-repo PRs only** (`agent/` branch or `agent:managed` label). A fork (never driven by the loop) or unmanaged PR gets a note pointing at `@claude review` / `@claude loop` and does nothing else — it won't re-run CI on a PR the pipeline doesn't own.
  - Deletes the `agent-review-paged` **and** `agent-paged` latch comment(s), drops `agent:blocked`, then **re-runs the latest CI run** for the head SHA — the exact re-engage mechanism `agent-loop.yml` already uses (green CI → panel promote/fix; red CI → CI-fix arm). Every step is best-effort so a partial failure still makes progress.
  - Human-facing comments use the **App token** (a fork-triggered run's `GITHUB_TOKEN` is read-only); the clearing + CI re-run stay on `GITHUB_TOKEN`, writable on the same-repo managed path where they execute.
- **`agent-implement.yml`** help reply now lists `@claude rerun`.

## Security invariants preserved

- `AGENT_PIPELINE_ENABLED` gate; trusted-author-only; no PR-author relaxation (unlike read-only `review`/`summarize`).
- Re-engages **existing** bounded machinery only — it does not bypass `MAX_REVIEW_ROUNDS` / `MAX_ATTEMPTS`, and **a human approving review is still the non-bypassable merge gate**. It just clears the latch and kicks CI; it never promotes or merges itself.
- Runs no untrusted code (API calls only).

## Test plan

- **12 command tests pass**, including `@claude rerun` recognition and the no-`reply`-collision guard. Verified parsing locally: `@claude rerun this PR` / `please @claude rerun 🔁` → `rerun`.
- Both workflow YAMLs validate; the embedded github-script passes `node --check`.
- `verify:entropy` (dead-code + doc-staleness) **0 issues**.

Once merged, un-sticking a paged PR (like the repeated #632 dance in this session) becomes a single comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)