### PR TITLE
Stop hunt probes reaching production, and fix two silent recall losses

### DIFF
--- a/scripts/agent/hunt-probe.mjs
+++ b/scripts/agent/hunt-probe.mjs
@@ -93,6 +93,20 @@ export function renderReproSh(probes, { bin = "wafflebase", extra = [] } = {}) {
 // --- the clean room ---------------------------------------------------------
 
 /**
+ * Where a probe's network traffic goes when no hunt server has been named.
+ *
+ * Loopback port 1: nothing listens there, `connect` fails immediately with
+ * ECONNREFUSED, and no packet leaves the machine. Deliberately not a public
+ * black-hole address — a probe should fail fast and locally, not hang on a
+ * route that silently drops.
+ *
+ * The CLI turns this into its documented error envelope
+ * (`{"error":{"code":"ERROR","message":"fetch failed"}}`), so a backend-free
+ * charter still observes well-formed behaviour rather than a crash.
+ */
+export const NO_SERVER = "http://127.0.0.1:1";
+
+/**
  * Build the probe environment. REPLACES the ambient environment; never extends it.
  *
  * This is the load-bearing line in the module. Spreading `process.env` would let
@@ -120,9 +134,19 @@ export function buildProbeEnv(scratch, cfg = {}) {
     NO_COLOR: "1",
     CI: "1",
   };
-  // Only set when supplied — an undefined value would become the string
-  // "undefined" and the CLI would treat it as a real (broken) setting.
-  if (cfg.server) env.WAFFLEBASE_SERVER = cfg.server;
+  // WAFFLEBASE_SERVER is set UNCONDITIONALLY. Leaving it out does not mean "no
+  // server" — it means the CLI falls back to its own default, and that default is
+  // `https://api.wafflebase.io` (packages/cli/src/config/config.ts:7). A measurement
+  // run found this the expensive way: with no hunt server configured, every probe
+  // in the `contract` and `crash` charters was talking to PRODUCTION, and the
+  // 404 bodies in the journal came back from the live host.
+  //
+  // Nothing was harmed — both charters are non-mutating and unauthenticated, so it
+  // was read-only 404s — but the clean room was isolating credentials while leaving
+  // network egress wide open, and the safety argument rested on `assertSafeArgv`
+  // plus charter non-mutation rather than on isolation. Reaching a real deployment
+  // has to be something an operator opts into by naming a server, never a default.
+  env.WAFFLEBASE_SERVER = cfg.server || NO_SERVER;
   if (cfg.workspace) env.WAFFLEBASE_WORKSPACE = cfg.workspace;
   if (cfg.apiKey) env.WAFFLEBASE_API_KEY = cfg.apiKey;
   return env;
@@ -347,12 +371,24 @@ export function sameObservation(a, b, observedKey) {
  *     ordering are the top source of phantom repros, and they are cheap to
  *     detect this way — before any model is asked to verify anything.
  *
+ * `failingIndex` names WHICH observation carries the defect. It defaults to the
+ * last, which is what this used to assume unconditionally — and that assumption
+ * silently destroyed real findings. The caller keys the CLAIM on
+ * `observations[failingIndex]` (hunt.mjs), so whenever the failing probe was not
+ * last, the claim and the replay were comparing two different probes and the
+ * candidate could NEVER reproduce. Observed live: a candidate citing probes [3,4]
+ * with the defect at 3 compared
+ *   claim  `exit:1|to:0|err:none|kind:text`   (probe 3, the actual defect)
+ *   replay `exit:1|to:0|err:none|kind:json`   (probe 4, merely last)
+ * and was dropped as `not-reproduced`. Pure recall loss, invisible in the funnel:
+ * the drop table just said the replay failed.
+ *
  * Returns `{ status, deterministic, attempts, divergedAt }`.
  * `status` is `"reproduced"` only when every attempt matched the CLAIMED
  * observation. Anything else — divergence between attempts, or agreement on
  * something other than the claim — is not a reproduction.
  */
-export function replay(probes, claimedObserved, { attempts = 3, observedKey, runAttempt } = {}) {
+export function replay(probes, claimedObserved, { attempts = 3, observedKey, runAttempt, failingIndex = null } = {}) {
   if (typeof observedKey !== "function" || typeof runAttempt !== "function") {
     throw new Error("hunt-probe.replay: observedKey and runAttempt are required");
   }
@@ -368,8 +404,13 @@ export function replay(probes, claimedObserved, { attempts = 3, observedKey, run
     // `reproduced` without a single probe having executed. See the header:
     // safety here fails closed, and so must this.
     const ran = Array.isArray(observations) && observations.length > 0;
-    const failing = ran ? observations[observations.length - 1] : undefined;
-    results.push({ attempt: i, key: ran ? observedKey(failing) : null, observation: failing, ran });
+    // Out-of-range is treated as "no observation" rather than clamped to the last.
+    // Clamping would resurrect exactly the bug above — comparing the claim against
+    // a probe it does not describe — and silently, which is the worse failure.
+    const at = Number.isInteger(failingIndex) ? failingIndex : (ran ? observations.length - 1 : -1);
+    const inRange = ran && at >= 0 && at < observations.length;
+    const failing = inRange ? observations[at] : undefined;
+    results.push({ attempt: i, key: inRange ? observedKey(failing) : null, observation: failing, ran: inRange });
   }
   const anyEmpty = results.some((r) => !r.ran);
   const first = results[0]?.key ?? null;

--- a/scripts/agent/hunt-probe.test.mjs
+++ b/scripts/agent/hunt-probe.test.mjs
@@ -14,6 +14,7 @@ import {
   replay,
   sameObservation,
   withScratch,
+  NO_SERVER,
 } from "./hunt-probe.mjs";
 import { observedKey } from "./hunt-fingerprint.mjs";
 
@@ -122,10 +123,31 @@ test("buildProbeEnv: pins the determinism knobs", () => {
   assert.equal(env.LC_ALL, "C");
   assert.equal(env.NO_COLOR, "1");
   assert.equal(env.CI, "1");
-  // Only supplied values are set — an undefined would stringify to "undefined"
-  // and the CLI would treat it as a real (broken) setting.
-  assert.equal("WAFFLEBASE_SERVER" in env, false);
   assert.equal(buildProbeEnv("/tmp/s", { server: "http://localhost:3000" }).WAFFLEBASE_SERVER, "http://localhost:3000");
+});
+
+// The clean room isolates credentials; it must isolate NETWORK EGRESS too.
+//
+// Omitting WAFFLEBASE_SERVER does not mean "no server" — it means the CLI uses its
+// own default, `https://api.wafflebase.io`. A live run spent both backend-free
+// charters probing production before anyone noticed, because nothing here said
+// where the traffic was going.
+test("buildProbeEnv: ALWAYS pins a server, so a probe cannot reach production by default", () => {
+  for (const cfg of [undefined, {}, { server: "" }, { server: null }, { apiKey: "k", workspace: "w" }]) {
+    const env = buildProbeEnv("/tmp/s", cfg);
+    assert.equal(
+      env.WAFFLEBASE_SERVER,
+      NO_SERVER,
+      `cfg ${JSON.stringify(cfg)} must pin the server, not leave the CLI to its default`,
+    );
+  }
+});
+
+test("NO_SERVER is unroutable loopback, not a real host", () => {
+  // A public black-hole address would still leave the machine and could hang; the
+  // point is to fail fast and locally.
+  assert.match(NO_SERVER, /^http:\/\/127\.0\.0\.1:\d+$/);
+  assert.equal(NO_SERVER.includes("wafflebase.io"), false);
 });
 
 // --- argv safety fails CLOSED ----------------------------------------------
@@ -265,6 +287,46 @@ test("runSequence: runs every probe in order", () => {
 const OBS = { a: { exitCode: 1, stderr: "x" }, b: { exitCode: 2, stderr: "y" } };
 
 const attemptsOf = (keys) => (_probes, i) => [OBS[keys[i]]];
+
+// The failing probe is routinely NOT the last one — a candidate cites setup probes
+// plus the one that breaks, then often reads state afterwards. `replay` used to key
+// `observations.at(-1)` unconditionally while the caller keyed the claim on
+// `failingIndex`, so those two compared different probes and the candidate could
+// never reproduce. Seen live: a real envelope defect at probe 3 of [3,4] was dropped
+// as `not-reproduced` because probe 4 answered with a different output kind.
+test("replay: keys the observation at failingIndex, not the last one", () => {
+  // Attempt shape: [defect, something-else]. The claim describes the FIRST.
+  const runAttempt = () => [OBS.a, OBS.b];
+  const r = replay([{ argv: ["boom"] }, { argv: ["after"] }], OBS.a, {
+    attempts: 3,
+    observedKey,
+    runAttempt,
+    failingIndex: 0,
+  });
+  assert.equal(r.status, "reproduced");
+  assert.equal(r.deterministic, true);
+});
+
+test("replay: without failingIndex a mid-sequence defect is missed (the old behaviour)", () => {
+  // Pins the regression rather than just the fix: omitting the index still falls
+  // back to the last observation, so this must NOT report reproduced.
+  const runAttempt = () => [OBS.a, OBS.b];
+  const r = replay([{ argv: ["boom"] }, { argv: ["after"] }], OBS.a, { attempts: 3, observedKey, runAttempt });
+  assert.equal(r.status, "not-reproduced");
+});
+
+test("replay: an out-of-range failingIndex is refused, never clamped", () => {
+  // Clamping to the last observation would silently reintroduce the bug above,
+  // comparing the claim against a probe it does not describe.
+  const r = replay([{ argv: ["x"] }], OBS.a, {
+    attempts: 3,
+    observedKey,
+    runAttempt: () => [OBS.a],
+    failingIndex: 7,
+  });
+  assert.equal(r.status, "not-reproduced");
+  assert.equal(r.deterministic, false);
+});
 
 test("replay: N identical attempts matching the claim → reproduced", () => {
   const r = replay([{ argv: ["x"] }], OBS.a, { attempts: 3, observedKey, runAttempt: attemptsOf(["a", "a", "a"]) });

--- a/scripts/agent/hunt-tool.mjs
+++ b/scripts/agent/hunt-tool.mjs
@@ -78,7 +78,20 @@ const MAX_STREAM_CHARS = 20_000;
  * `now` is injectable so a test can exhaust the clock without waiting.
  */
 export function createProbeBudget({ maxProbes = 40, totalTimeoutMs = 600_000, now = Date.now } = {}) {
-  const started = now();
+  // The clock starts at the FIRST probe, not at construction.
+  //
+  // This budget is created before the session opens, and the explorer also holds
+  // Read/Grep/Glob — so a clock started here bounds thinking and file reading, not
+  // probing. A live run made the consequence unmissable: a `contract` sample was
+  // refused on its very first `run` call with "Session probe time exhausted (939s
+  // of 600s)" having executed ZERO probes, because it had spent fifteen minutes
+  // reading the CLI source first. A `crash` sample lost its last two probes the
+  // same way. Three of that run's seven refusals were this, and the charter that
+  // starved reported nothing at all.
+  //
+  // Reading the source before probing is behaviour the charters actively ask for,
+  // so the budget must not punish it. What needs bounding is the probe loop.
+  let started = null;
   let used = 0;
   const refusals = [];
   return {
@@ -116,6 +129,9 @@ export function createProbeBudget({ maxProbes = 40, totalTimeoutMs = 600_000, no
             "No further commands can run. Report what you have found, or return zero candidates.",
         };
       }
+      // First charge starts the clock, and is always admitted on time: a session
+      // must never be refused its opening probe, which is what happened before.
+      if (started === null) started = now();
       const elapsed = now() - started;
       if (elapsed >= totalTimeoutMs) {
         refusals.push({ kind: "totalTimeoutMs", elapsed });

--- a/scripts/agent/hunt-tool.test.mjs
+++ b/scripts/agent/hunt-tool.test.mjs
@@ -158,6 +158,26 @@ test("maxProbes is enforced, and an exhausted session runs nothing more", async 
   assert.deepEqual(budget.refusals.map((r) => r.kind), ["maxProbes"]);
 });
 
+// The budget is built before the session opens, and the explorer also holds
+// Read/Grep/Glob. A clock started at construction therefore bounds THINKING, not
+// probing. Live consequence: a sample was refused on its first `run` call with
+// "Session probe time exhausted (939s of 600s)" having executed zero probes,
+// because it read the CLI source first — which the charter explicitly asks it to do.
+test("the clock starts at the FIRST probe, not when the budget is built", async () => {
+  let now = 1_000;
+  const budget = createProbeBudget({ maxProbes: 100, totalTimeoutMs: 5_000, now: () => now });
+  // A long stretch of non-probe work: reading source, forming a hypothesis.
+  now += 900_000;
+  const { call } = makeServer({ budget });
+  const first = await call({ argv: ["schema"] });
+  assert.equal(first.isError, false, "the opening probe must never be refused for time it did not spend");
+  assert.deepEqual(budget.refusals, []);
+  // And the bound still applies once probing has actually begun.
+  now += 6_000;
+  assert.equal((await call({ argv: ["schema"] })).isError, true);
+  assert.deepEqual(budget.refusals.map((x) => x.kind), ["totalTimeoutMs"]);
+});
+
 test("totalTimeoutMs is enforced independently of probe count", async () => {
   // An injected clock, so a wall-clock bound is testable without waiting for it.
   let now = 1_000;

--- a/scripts/agent/hunt.mjs
+++ b/scripts/agent/hunt.mjs
@@ -71,6 +71,7 @@ import {
   redactSecrets,
   withScratch,
   DEFAULT_PROBE_TIMEOUT_MS,
+  NO_SERVER,
 } from "./hunt-probe.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -647,9 +648,20 @@ async function cmdPreflight(args) {
   // says exactly what it means instead of leaning on `mutating ⟹ needsBackend`.
   const backendCharters = allCharters.filter((c) => c.needsBackend).map((c) => c.id);
   const mutatingCharters = allCharters.filter((c) => c.mutating).map((c) => c.id);
+  const huntServer = process.env.WAFFLEBASE_HUNT_SERVER ?? "";
+  // Where probes will actually send traffic, stated for EVERY run rather than only
+  // when a backend charter is selected. The old wording said "no server configured"
+  // and stopped there, which reads as "nothing will be contacted" — while the CLI
+  // was quietly falling back to its production default. Say the destination out
+  // loud; it is the one line that would have caught that immediately.
+  notes.push(
+    huntServer
+      ? `probes will reach WAFFLEBASE_HUNT_SERVER (${huntServer}) — a REAL deployment`
+      : `probes are pinned to ${NO_SERVER} (nothing listens there) — no network egress. ` +
+        "Set WAFFLEBASE_HUNT_SERVER to point them at a real backend.",
+  );
   if (backendCharters.length > 0) {
-    const server = process.env.WAFFLEBASE_HUNT_SERVER ?? "";
-    const stack = await checkStack(server);
+    const stack = await checkStack(huntServer);
     (stack.up ? notes : warnings).push(
       stack.up
         ? `backend reachable (${stack.detail}) — ${backendCharters.join(", ")} can run`
@@ -951,6 +963,10 @@ async function cmdRun(args) {
         attempts: 3,
         observedKey,
         runAttempt: () => probeOnce(cand, { bin, charter, cfg: charterContext.cfg }).observations ?? [],
+        // The SAME index the claim was keyed on above. Omitting it made `replay`
+        // fall back to the last observation, so any candidate whose failing probe
+        // sat mid-sequence compared two different probes and never reproduced.
+        failingIndex: cand.failingIndex,
       });
 
       const fp = fingerprint({ charterId: charter.id, argv: cand.probes[cand.failingIndex].argv, oracle: cand.oracle, observed });


### PR DESCRIPTION
## Summary

A CLI-hunter measurement run reported **0 findings for $4.24**. The funnel explained why, and the explanation was three defects in the harness itself. All three are fixed here.

Two product defects from the same run are filed separately as **#654** and **#655**.

## 1. The clean room was not isolating the network 🔴

`buildProbeEnv` set `WAFFLEBASE_SERVER` only when a hunt server was configured. Omitting it does **not** mean "no server" — the CLI falls back to its own default, `https://api.wafflebase.io` (`packages/cli/src/config/config.ts:7`).

So with no hunt server set, every probe in the `contract` and `crash` charters was talking to **production**. The 404 bodies in the run's journal came back from the live host; I confirmed it with a direct request.

Nothing was harmed — both charters are non-mutating and unauthenticated, so it was read-only 404s. But the isolation argument rested on `assertSafeArgv` and charter non-mutation rather than on the clean room, and reaching a real deployment has to be something an operator opts into.

The variable is now **always** set, defaulting to loopback port 1 where nothing listens and no packet leaves the machine. The CLI turns that into its documented envelope, so a backend-free charter still observes well-formed behaviour:

```
$ # probe with no configured server, through the real clean room
{ "error": { "code": "ERROR", "message": "fetch failed" } }
```

Preflight said `no server configured` and stopped, which reads as *nothing will be contacted*. It now names the destination on every run — the one line that would have caught this immediately.

## 2. `replay()` compared the wrong probe

`replay()` keyed `observations.at(-1)` while the caller keyed the claim on `failingIndex`. Any candidate whose failing probe was **not last** compared two different probes and could never reproduce. This run demonstrated it live:

```
claim  key (probe 3, the real defect): exit:1|to:0|err:none|kind:text
replay key (probe 4, merely last):     exit:1|to:0|err:none|kind:json
```

That candidate was dropped as `not-reproduced`. Pure recall loss, and invisible — the drop table just said the replay failed. An out-of-range index is now **refused rather than clamped**, since clamping would silently restore the same bug.

## 3. The probe budget bounded thinking, not probing

The clock started at construction, before the session opened — and the explorer also holds `Read`/`Grep`/`Glob`. A `contract` sample was refused on its very **first** `run` call:

> Session probe time exhausted (939s of 600s)

…having executed **zero** probes, because it spent fifteen minutes reading the CLI source — which the charter explicitly asks it to do. A `crash` sample lost its last two probes the same way; 3 of the run's 7 refusals were this, and the starved charter reported nothing at all.

The clock now starts at the first `charge()`, so the opening probe can never be refused for time it did not spend, and the bound still applies once probing begins.

## Note on #655

That defect (upstream error bodies forwarded verbatim) is only reachable **with** a backend — it was found by way of the egress bug above. Now that probes are pinned, it belongs to the backend tier rather than the backend-free charters.

## Test plan

- `cd scripts/agent && node --test *.test.mjs` — 646 pass
- `pnpm verify:self` — 11/11 lanes
- **All four guards mutation-tested** — each fails with its fix reverted, including the out-of-range clamp
- End-to-end: a probe with no configured server returns `{"error":{"code":"ERROR","message":"fetch failed"}}` from loopback instead of a 404 from the live API
- `hunt.mjs preflight` now prints the probe destination on every run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Probes without a configured destination now avoid unintended connections to production services.
  * Replay checks now validate the specific probe that reported a failure, improving result accuracy.
  * Initial probing is no longer rejected solely because time elapsed before the first probe.
* **Improvements**
  * Preflight information now clearly identifies the destination used for each run and warns when probes are isolated.
  * Probe time limits are applied more consistently after probing begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->