### PR TITLE
Count fix attempts, and restore the budget on rerun

### DIFF
--- a/.github/workflows/agent-rerun.yml
+++ b/.github/workflows/agent-rerun.yml
@@ -161,12 +161,21 @@ jobs:
               core.warning(`Could not re-run CI (${e.message}); the loop will engage on the next CI run.`);
             }
 
+            // The <!-- agent-rerun --> marker is the RESUME POINT, not decoration:
+            // review-round-guard.mjs counts fix attempts only from the newest one, so
+            // un-sticking a PR gives the loop its full MAX_REVIEW_ROUNDS back instead
+            // of resuming a count that was already at the cap. Without it, clearing
+            // the latch buys exactly one panel round and an immediate re-page — which
+            // is what #648 did when it was un-stuck by hand. Kept in the RESULT
+            // comment (rather than a second one) so un-sticking stays one comment, and
+            // hidden rather than prose because the prose will be reworded.
             core.setOutput('outcome',
+              `<!-- agent-rerun -->\n` +
               `🔁 Rerun engaged — cleared ${clearedLatch} paged marker(s) and dropped \`agent:blocked\`. ` +
               (reran
                 ? "Re-running CI now; the review panel will run again and can promote or fix this PR."
                 : "No CI run to re-run — the panel will engage on the next CI run.") +
-              " Still bounded by the pipeline's round/attempt caps, and a human approval is required to merge.");
+              " The fixer's round budget restarts from here; a human approval is still required to merge.");
 
       # Edit the placeholder into the final result. always() so a failure in the
       # clear step still replaces the "working on it" note instead of stranding it.

--- a/.github/workflows/agent-rerun.yml
+++ b/.github/workflows/agent-rerun.yml
@@ -161,21 +161,14 @@ jobs:
               core.warning(`Could not re-run CI (${e.message}); the loop will engage on the next CI run.`);
             }
 
-            // The <!-- agent-rerun --> marker is the RESUME POINT, not decoration:
-            // review-round-guard.mjs counts fix attempts only from the newest one, so
-            // un-sticking a PR gives the loop its full MAX_REVIEW_ROUNDS back instead
-            // of resuming a count that was already at the cap. Without it, clearing
-            // the latch buys exactly one panel round and an immediate re-page — which
-            // is what #648 did when it was un-stuck by hand. Kept in the RESULT
-            // comment (rather than a second one) so un-sticking stays one comment, and
-            // hidden rather than prose because the prose will be reworded.
             core.setOutput('outcome',
-              `<!-- agent-rerun -->\n` +
               `🔁 Rerun engaged — cleared ${clearedLatch} paged marker(s) and dropped \`agent:blocked\`. ` +
               (reran
                 ? "Re-running CI now; the review panel will run again and can promote or fix this PR."
                 : "No CI run to re-run — the panel will engage on the next CI run.") +
-              " The fixer's round budget restarts from here; a human approval is still required to merge.");
+              " The review→fix round budget restarts from here; the CI-fix arm's own" +
+              " attempt bound (counted from prior failed CI runs) is NOT reset, and a human" +
+              " approval is still required to merge.");
 
       # Edit the placeholder into the final result. always() so a failure in the
       # clear step still replaces the "working on it" note instead of stranding it.

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -935,6 +935,36 @@ Components:
   than manufacture a page, since `MAX_REVIEW_ROUNDS` still backstops and a
   spurious page is the costlier error. Tuned via `STALL_REPEATS` /
   `STALL_SIMILARITY`.
+- **`MAX_REVIEW_ROUNDS` counts FIX ATTEMPTS, not panel rounds.** It used to count
+  every single-parent commit carrying a failing lens verdict, which is not the
+  same thing and was wrong on every agent PR measured. The implement workflow
+  pushes its work, self-reviews, fixes what it found, and pushes AGAIN — two
+  commits, each drawing its own panel round, both counted as failed fix rounds
+  before the fix loop had run once. On #648 and #605 alike that consumed exactly
+  2 of the budget, so lowering the cap from 5 to 3 cut the loop from three real
+  attempts to **one**; #648 then reported "requested changes 3 times without
+  converging" after a single fix attempt. The discriminator is already in the
+  data: *a commit committed before the panel first spoke cannot be a response to
+  it*. `isFixerCommit` was renamed `isSingleParentCommit`, because that is all it
+  ever tested and the old name is what made the miscount look correct.
+
+  It **fails toward counting**: a commit whose position cannot be established
+  counts, and with no verdict timestamps anywhere the floor is abandoned entirely.
+  Over-counting pages a round early, which a retry undoes; under-counting means
+  the cap never trips and the loop is unbounded.
+- **`@claude rerun` now restores the fix budget too.** #650 added the command: it
+  deletes the paged comments, drops `agent:blocked` and re-runs CI. What it could
+  not do is give the loop its attempts back — its own summary said the PR was
+  "still bounded by the pipeline's round/attempt caps", which on a PR that reached
+  the cap means one panel round and an immediate re-page. That is exactly what
+  #648 did when it was un-stuck by hand. It now writes a hidden `RERUN_MARKER`
+  into its result comment, and `scripts/agent/review-round-guard.mjs` counts fix
+  attempts only from the newest one.
+
+  The marker is **author-checked** like the paged latch, and for a sharper reason:
+  the latch only ever stops work, while this GRANTS budget, so on a public repo a
+  body test alone would let any account hand the fixer unlimited attempts. Only
+  the workflow's own bot or a human with write access may move the floor.
 - **One panel per branch at a time.** `.github/workflows/agent-review-panel.yml` carries a
   `concurrency` group keyed on the head repository and branch, with
   `cancel-in-progress`. The repository half is a security requirement: the group is

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -957,27 +957,39 @@ Components:
   not do is give the loop its attempts back — its own summary said the PR was
   "still bounded by the pipeline's round/attempt caps", which on a PR that reached
   the cap means one panel round and an immediate re-page. That is exactly what
-  #648 did when it was un-stuck by hand. It now writes a hidden `RERUN_MARKER`
-  into its result comment, and `scripts/agent/review-round-guard.mjs` counts fix
-  attempts only from the newest one.
+  #648 did when it was un-stuck by hand. `scripts/agent/review-round-guard.mjs`
+  now counts fix attempts only from the newest rerun.
 
-  The marker is trusted far more narrowly than the paged latch, because the
-  direction is the opposite one — the latch only ever stops work, while this
-  restarts a safety cap. It must be the comment's **first line**, not merely
-  present: a substring test is re-armable by anyone who quotes it (as happened to
-  the paged latch), and `.github/workflows/agent-summarize.yml`,
-  `.github/workflows/agent-review-on-demand.yml` and
-  `.github/workflows/agent-review-reply.yml` all publish model output verbatim under an allow-listed
-  bot login, so a substring test would make "a model emitted the marker" enough. It
-  is also **bot-only** — no `author_association` path — because `@claude rerun`
-  gates on `getCollaboratorPermissionLevel`, and accepting an association would
-  grant the same budget on a weaker credential than the command itself demands.
+  **The resume point is the maintainer's COMMAND, not the workflow's result
+  comment**, and that is a security property rather than a convenience. The first
+  version keyed on a hidden marker trusted by bot login — but `.github/workflows/agent-rerun.yml`
+  posts with the App token, so the trusted identity is `yorkie-agent[bot]`, the
+  same identity the fixer and implementer post their own free-form comments under.
+  The party bounded by `MAX_REVIEW_ROUNDS` could therefore reset its own bound by
+  opening a comment with the marker line: an LLM reading an untrusted diff, granted
+  unlimited fix attempts, by accident or by injection. A human's command cannot be
+  forged by a bot, because `user.type === "Bot"` is refused and no App can present
+  as a non-Bot — a structural exclusion rather than a string the agent must not
+  guess. Known gap, named rather than hidden: `author_association` is weaker than
+  the `getCollaboratorPermissionLevel` the command itself enforces, so an org
+  member without repo write moves the floor; the workflow still refuses to act for
+  them.
 
   A hand-back also holds the **stall** and **rebuttal-standstill** pages for one
   attempt. Those run before the cap and read pre-rerun history, so without it a
   rerun on an already-stalled PR re-pages on the first post-rerun round — the same
-  failure through a different door. It delays them by exactly one round; it never
-  disables them.
+  failure through a different door. It delays them by one round; it never disables
+  them.
+
+  It does **not** reset the CI-fix arm's separate attempt bound, which
+  `.github/workflows/agent-iterate-ci.yml` counts from prior failed CI runs. The command's summary
+  says so explicitly rather than claiming a blanket restart.
+- **The stall bound counts fix attempts too.** `detectStalledRounds` ran over every
+  round on the PR, including the implementer's two pre-verdict pushes, so three
+  rounds of "evidence" existed immediately and the stall door could cut the loop to
+  one real attempt — the cap fix closed one door and left this one open. Both now
+  share `fixAttemptCommits`, so the two bounds cannot disagree about what a fix
+  attempt is.
 - **One panel per branch at a time.** `.github/workflows/agent-review-panel.yml` carries a
   `concurrency` group keyed on the head repository and branch, with
   `cancel-in-progress`. The repository half is a security requirement: the group is

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -961,10 +961,23 @@ Components:
   into its result comment, and `scripts/agent/review-round-guard.mjs` counts fix
   attempts only from the newest one.
 
-  The marker is **author-checked** like the paged latch, and for a sharper reason:
-  the latch only ever stops work, while this GRANTS budget, so on a public repo a
-  body test alone would let any account hand the fixer unlimited attempts. Only
-  the workflow's own bot or a human with write access may move the floor.
+  The marker is trusted far more narrowly than the paged latch, because the
+  direction is the opposite one — the latch only ever stops work, while this
+  restarts a safety cap. It must be the comment's **first line**, not merely
+  present: a substring test is re-armable by anyone who quotes it (as happened to
+  the paged latch), and `.github/workflows/agent-summarize.yml`,
+  `.github/workflows/agent-review-on-demand.yml` and
+  `.github/workflows/agent-review-reply.yml` all publish model output verbatim under an allow-listed
+  bot login, so a substring test would make "a model emitted the marker" enough. It
+  is also **bot-only** — no `author_association` path — because `@claude rerun`
+  gates on `getCollaboratorPermissionLevel`, and accepting an association would
+  grant the same budget on a weaker credential than the command itself demands.
+
+  A hand-back also holds the **stall** and **rebuttal-standstill** pages for one
+  attempt. Those run before the cap and read pre-rerun history, so without it a
+  rerun on an already-stalled PR re-pages on the first post-rerun round — the same
+  failure through a different door. It delays them by exactly one round; it never
+  disables them.
 - **One panel per branch at a time.** `.github/workflows/agent-review-panel.yml` carries a
   `concurrency` group keyed on the head repository and branch, with
   `cancel-in-progress`. The repository half is a security requirement: the group is

--- a/docs/tasks/active/20260804-real-fix-rounds-todo.md
+++ b/docs/tasks/active/20260804-real-fix-rounds-todo.md
@@ -1,0 +1,87 @@
+# Count fix attempts, and let a maintainer hand a PR back
+
+Follow-up to the #648 post-mortem (#649 fixed the concurrency race; this fixes the
+round budget, which was an independent defect).
+
+## The problem
+
+`MAX_REVIEW_ROUNDS` is documented as *"Failed **fix** rounds before
+review-round-guard.mjs pages a human."* What it counted was:
+
+> commits that are single-parent **and** carry a failing lens verdict
+
+The predicate was named `isFixerCommit`, which is what made the miscount look
+correct. It is literally `parents.length === 1` — "not a merge commit" — and its
+own docstring says it is *"deliberately identity-independent"*. It cannot tell who
+pushed a commit.
+
+**The implement workflow pushes twice**: its work, then a self-review fix. On #648
+the agent said so at 09:47 — *"Two blocking findings, both fixed in `1d9e19d`."*
+Each commit drew its own panel round, and both counted as failed fix rounds before
+the fix loop had run once.
+
+Measured on both PRs whose data still exists:
+
+| PR | counted as rounds | real fix attempts | pre-consumed |
+|---|---|---|---|
+| #648 | 3 | **1** | 2 |
+| #605 | 5 | 3 | 2 |
+
+So when #615 lowered the cap 5 → 3 — sound reasoning *for panel rounds* — the real
+effect was to cut the fix loop from three attempts to **one**. #648 then paged with
+"requested changes 3 times without converging" after a single attempt, and the one
+attempt it did get had fixed the original nine findings and introduced four new
+ones in the guard it added. An ordinary second round. There wasn't one.
+
+## The change
+
+- [x] **Count only commits committed after the first panel verdict on the PR.** A
+      commit that predates every verdict cannot be a response to one. Needs no
+      identity, and the data already carries it.
+- [x] **`isFixerCommit` → `isSingleParentCommit`**, because that is all it tested.
+- [x] **`@claude rerun` restores the budget.** #650 shipped the command while this
+      was in progress — it clears the latch and re-runs CI, but its own summary said
+      the PR was "still bounded by the pipeline's round/attempt caps". It now writes
+      a hidden `RERUN_MARKER` and the guard counts attempts only from the newest one.
+      I dropped the `@claude retry` command I had built: a second verb for the same
+      job would have been worse than the gap.
+- [x] `MAX_REVIEW_ROUNDS` stays 3 — but now means three *actual* fix attempts.
+
+## Fail directions
+
+**The count fails toward counting.** It feeds a cap: over-counting pages a round
+early, which `@claude rerun` undoes; under-counting means the cap never trips and
+the loop is unbounded, recoverable only if someone notices. So a commit whose
+position cannot be established counts, and with no verdict timestamps anywhere the
+floor is abandoned and every failing commit counts — exactly the old behaviour.
+That is also why the PR #521 fixture still returns 3 unchanged.
+
+**The rerun marker is author-checked**, and for a sharper reason than the paged
+latch: the latch only ever stops work, while this GRANTS budget. On a public repo a
+body test alone would let any account hand the fixer unlimited attempts. Only the
+workflow's own bot, or a human with write access, may move the floor.
+
+## Verification
+
+- [x] `pnpm verify:self` green (11/11).
+- [x] The counter tested against **#648's real shape** — three commits, real
+      timestamps — returning 1 where the old code returned 3.
+- [x] The marker is a contract between a workflow and a module that cannot import
+      it, so a test asserts `agent-rerun.yml` emits `RERUN_MARKER`. A drifted copy
+      does not error — the budget silently never resets, and the PR re-pages after
+      one round exactly as before.
+- [x] A latent crash fixed on the way — `(commits ?? []).filter` threw on a
+      non-array; a thrown guard is a dead fix job, not a conservative one.
+
+## Reworked mid-flight
+
+I had built a separate `@claude retry` command before #650 landed `@claude rerun`
+for the same job. Shipping both would have left two verbs for un-sticking a PR and
+two latch-clearing mechanisms. Dropped mine, including its inline gate copy and the
+cross-implementation drift test that copy needed — `@claude rerun` deletes the paged
+comments outright, so there is no latch left to out-date and no duplication to pin.
+
+## Not in this PR
+
+Whether `MAX_REVIEW_ROUNDS = 3` is still the right number now that it means three
+real attempts. It was chosen when it meant one.

--- a/docs/tasks/active/20260804-real-fix-rounds-todo.md
+++ b/docs/tasks/active/20260804-real-fix-rounds-todo.md
@@ -85,3 +85,66 @@ comments outright, so there is no latch left to out-date and no duplication to p
 
 Whether `MAX_REVIEW_ROUNDS = 3` is still the right number now that it means three
 real attempts. It was chosen when it meant one.
+
+## Review response (panel, #657)
+
+Six fixed, three skipped. The panel was right about the one that mattered.
+
+- [x] **CRITICAL — `retryAt` was undeclared** at the round-cap page, so the guard
+      threw a `ReferenceError` exactly when it should latch the PR. Residue of the
+      dropped `@claude retry` scope: my rename used `str.replace` **without
+      asserting the match**, the pattern didn't match, and the no-op was silent.
+      Every other edit in this series asserts; this one didn't. CI was green because
+      nothing exercises that path.
+- [x] **Only the round cap honoured the rerun floor.** The stall and
+      rebuttal-standstill pages run *before* it and read pre-rerun history, so a
+      rerun on an already-stalled PR re-paged on the first post-rerun round — the
+      same failure this PR exists to end, through a different door. Both now hold
+      for one post-rerun attempt: it delays them by exactly one round, never
+      disables them.
+- [x] **`RERUN_MARKER` matched by substring** — so quoting it re-granted the budget.
+      Now it must be the comment's first line. This is the second time the substring
+      shape has bitten: clearing #648 by hand re-armed the paged latch with the
+      sentence explaining its removal.
+- [x] **The marker was trusted from any `author_association`**, a weaker credential
+      than `@claude rerun` itself enforces (`getCollaboratorPermissionLevel`).
+      Bot-only now. Combined with first-line anchoring this also closes the
+      smuggling channel the security lens found: the allow-listed bots publish LLM
+      output verbatim, so a substring test made "a model emitted the marker" enough.
+- [x] `firstVerdictAt` lacked the `app.slug` guard every other lens-run consumer
+      applies — a foreign app's same-named check could lower the floor and inflate
+      the count.
+- [x] Timestamps compared numerically rather than lexicographically; the string
+      compare was a latent dependency on GitHub emitting Z-normalised,
+      equal-precision ISO.
+- [x] **The marker contract test was vacuous** — satisfied by the explanatory `//`
+      comment in `agent-rerun.yml`, so deleting the emit left it green. Now excludes
+      prose lines and asserts exactly one emitting line.
+- [x] `rounds.mjs`'s header still described the old contract; `gh-checks.mjs` claimed
+      its shape could be "passed straight through" for a round count, but it drops
+      `parents` and `commit.committer.date` — no live bug (the guard fetches commits
+      itself) but the doc invited one.
+
+**Skipped: the first-verdict discriminator is race-dependent.** True and inherent —
+if a verdict lands before the implementer's self-review push, that push counts. It is
+already stated in the PR body and now in the module header. The direction is
+conservative (over-count → page early → undone by a rerun), and nothing in the data
+distinguishes the two.
+
+**Skipped: `rounds.mjs` is drifting into a marker grab-bag.** Fair, but the
+paged-latch precedent is already in this file, and a module holding one marker plus
+one predicate would split the trust list across two places — worse for the property
+that actually matters.
+
+**Skipped: the "relocated code" security finding**, which the panel itself marked as
+pre-existing and not gating.
+
+## The finding behind the finding
+
+`scripts/agent/**` has **no linting at all** — `verify:fast` lints only
+`packages/frontend`. That is why an undefined identifier reached CI green.
+
+Verified rather than assumed: `no-undef` over `scripts/agent/*.mjs` reports the
+`retryAt` bug precisely, and reports **nothing else** across the directory. So the
+class is closable for the price of one config file. Not done here — it is a
+build-config change with its own blast radius, and this PR is about round counting.

--- a/docs/tasks/active/20260804-real-fix-rounds-todo.md
+++ b/docs/tasks/active/20260804-real-fix-rounds-todo.md
@@ -148,3 +148,46 @@ Verified rather than assumed: `no-undef` over `scripts/agent/*.mjs` reports the
 `retryAt` bug precisely, and reports **nothing else** across the directory. So the
 class is closable for the price of one config file. Not done here — it is a
 build-config change with its own blast radius, and this PR is about round counting.
+
+## Second review response (panel + CodeRabbit, #657)
+
+Four fixed, two skipped. The first one is the serious one and it was mine.
+
+- [x] **The bounded party could reset its own bound.** The resume marker was trusted
+      by bot login, and `agent-rerun.yml` posts with the App token — so the trusted
+      identity was `yorkie-agent[bot]`, **the same identity the fixer and implementer
+      post their own free-form comments under** (the self-review comment on every
+      agent PR is one). An LLM reading an untrusted diff could open a comment with
+      the marker line and grant itself unlimited fix attempts.
+
+      Fixed by reading the **maintainer's `@claude rerun` command** instead of the
+      workflow's result marker. A bot cannot forge it: `user.type === "Bot"` is
+      refused and no App can present as a non-Bot — structural, not a string the
+      agent must not guess. `RERUN_MARKER` and the workflow emit are gone, so
+      `agent-rerun.yml` needed no change beyond wording.
+
+      Reuses `parseCommand` rather than a third regex, so the floor cannot move for a
+      rerun the router did not recognise.
+- [x] **The stall door still counted panel rounds** — including the implementer's two
+      pre-verdict pushes — so the loop could still be cut to one real attempt through
+      the other bound. The cap fix closed one door and left this open. Both now share
+      `fixAttemptCommits`, so the two bounds cannot disagree about what a fix attempt
+      is.
+- [x] **The rerun summary overclaimed.** `agent-iterate-ci.yml` keeps its own attempt
+      bound counted from prior failed CI runs, which a rerun does not reset. The
+      summary now says which budget restarts and which does not.
+- [x] Removed 34 lines of dead counter left behind when `fixAttemptCommits` was
+      extracted.
+
+**Skipped: `heldByRerun` grants zero attempts when the first post-rerun round already
+carries a post-rerun failing commit.** True — if a commit lands between the rerun and
+the first panel round, it counts and the hold lifts immediately. The round cap still
+delivers the full `MAX_REVIEW_ROUNDS`, which is the behaviour that was asked for; the
+hold on the stall/standstill pages is secondary, and it fails toward *paging*. Fixing
+it means distinguishing "a fix attempt" from "a commit that happens to postdate the
+rerun", which the data does not support.
+
+**Skipped: `heldByRerun` extends one marker's authority to two other bounds.** The
+premise was a forgeable marker; with the command channel the grant requires a human,
+so there is no marker to forge. The remaining behaviour — a legitimate hand-back
+holding two pages for one round — is the intended design and is documented.

--- a/scripts/agent/gh-checks.mjs
+++ b/scripts/agent/gh-checks.mjs
@@ -92,8 +92,13 @@ export function commitCheckRuns(sha, opts) {
  *
  * All commits, not just the head: the last completed run for a lens may sit on an
  * earlier commit if that lens produced no verdict in the most recent round. The
- * shape matches what `rounds.mjs::groupReviewRounds` consumes, so a caller that
- * needs a round count can pass this straight through.
+ * shape matches what `rounds.mjs::groupReviewRounds` consumes — and ONLY that.
+ *
+ * It is NOT enough for `countFailedReviewRounds`, which also reads `parents` and
+ * `commit.committer.date`; both are dropped here. Its caller fetches
+ * `pulls/{pr}/commits` itself for exactly that reason. A round count built on this
+ * shape would not error — it would silently see no merges and no timestamps, and
+ * count every failing commit.
  *
  * `pulls/{pr}/commits` is a bare-array endpoint, where plain `--paginate` is
  * correct (same call shape as review-round-guard.mjs's `listAll`). Only the

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -51,7 +51,7 @@
 import { readFileSync, appendFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { isFixerCommit } from "./rounds.mjs";
+import { isSingleParentCommit } from "./rounds.mjs";
 import { classifyFile } from "./review-panel.mjs";
 import { HANDOFF_MARKER, hasDisclosureTrailer } from "./disclosure.mjs";
 import { normalizeSeverity, BLOCKING, classify } from "./severity.mjs";
@@ -156,7 +156,7 @@ export function handoffTime({ comments = [], readyForReviewAt = null } = {}) {
  *
  * Four conditions, each excluding a different non-miss:
  *   - lands after `handoffAt` — before it, the panel had not spoken yet;
- *   - single-parent (`isFixerCommit`) — a `git merge main` to resolve conflicts
+ *   - single-parent (`isSingleParentCommit`) — a `git merge main` to resolve conflicts
  *     is not a fix, and it drags in every unrelated file on main;
  *   - no autonomous-disclosure trailer — the review-fix loop's own commits land
  *     after handoff too on a re-opened round, and they are the panel WORKING;
@@ -176,7 +176,7 @@ export function isHumanFollowupCommit(commit, handoffAt) {
   if (!Number.isFinite(cutoff)) return false; // no handoff → cannot classify
   const at = Date.parse(str(c.commit?.committer?.date) || str(c.commit?.author?.date));
   if (!Number.isFinite(at) || at <= cutoff) return false;
-  if (!isFixerCommit(c)) return false;
+  if (!isSingleParentCommit(c)) return false;
   if (hasDisclosureTrailer(c.commit?.message)) return false;
   if (c.author?.type === "Bot") return false;
   return true;

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -22,6 +22,7 @@ import {
   DEFAULT_SIMILARITY,
   PAGED_LATCH,
   isPagedLatchComment,
+  rerunPointFrom,
 } from "./rounds.mjs";
 import { exhaustedFindings, MAX_REBUTTAL_ROUNDS } from "./rebuttal.mjs";
 
@@ -102,6 +103,14 @@ if (comments.some(isPagedLatchComment)) {
   setOutput("proceed", "false");
   process.exit(0);
 }
+// `@claude rerun` (#650) deletes the paged comments, so the latch above is
+// already clear by the time we get here. What it cannot do on its own is give the
+// budget back — its summary says the PR is "still bounded by the pipeline's
+// round/attempt caps", which on a PR that reached the cap means one panel round
+// and an immediate re-page. That is exactly what #648 did when it was un-stuck by
+// hand. The marker rerun leaves behind moves the round floor forward.
+const rerunAt = rerunPointFrom(comments);
+if (rerunAt) console.error(`rerun: counting fix rounds from ${rerunAt}`);
 
 // API/quota outage (every blocking lens failed on an API error) → the reviewer
 // never ran. Page with the REAL reason and DO NOT dispatch the fixer or count a
@@ -209,10 +218,11 @@ if (stall.stalled) {
   process.exit(0);
 }
 
-const failedRounds = countFailedReviewRounds(commits, requiredCheckNames);
+const failedRounds = countFailedReviewRounds(commits, requiredCheckNames, { since: rerunAt });
 if (failedRounds >= max) {
   page(
-    `The review panel requested changes ${failedRounds} times (limit ${max}) without converging. A human should take over on PR #${pr}.`,
+    `The fixer has tried ${failedRounds} time(s) (limit ${max}) without converging` +
+      `${retryAt ? " since the last retry" : ""}. A human should take over on PR #${pr}.`,
   );
   process.exit(0);
 }

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -17,6 +17,7 @@ import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import {
   countFailedReviewRounds,
+  fixAttemptCommits,
   groupReviewRounds,
   detectStalledRounds,
   DEFAULT_SIMILARITY,
@@ -176,6 +177,17 @@ for (const c of commits.filter((x) => (x.checkRuns ?? []).some(isLensRun)).slice
 
 const rounds = groupReviewRounds(commits, requiredCheckNames);
 
+// The stall detector gets FIX-ATTEMPT rounds only, for the same reason the round
+// cap counts them: `groupReviewRounds` over every commit includes the two the
+// implement workflow pushes before the panel has ever spoken, so with three rounds
+// of "evidence" available immediately the stall door could cut the loop to one real
+// attempt — the very failure the round-cap fix closed, arriving through the other
+// bound. `fixAttemptCommits` is the same predicate, exposed so both agree.
+const stallRounds = groupReviewRounds(
+  fixAttemptCommits(commits, requiredCheckNames, { since: rerunAt }),
+  requiredCheckNames,
+);
+
 // ARGUED TO A STANDSTILL, checked before convergence for the same reason the
 // infra branch is checked before `allValid`: the more specific reason wins, and
 // "the author disputed this twice and an independent adjudicator upheld it both
@@ -217,7 +229,7 @@ if (exhausted.length > 0) {
   process.exit(0);
 }
 
-const stall = detectStalledRounds(rounds, {
+const stall = detectStalledRounds(stallRounds, {
   minRepeats: stallRepeats,
   similarity: stallSimilarity,
 });

--- a/scripts/agent/review-round-guard.mjs
+++ b/scripts/agent/review-round-guard.mjs
@@ -187,8 +187,26 @@ const rounds = groupReviewRounds(commits, requiredCheckNames);
 // extra count costs only an unnecessary human look; but a bound the disputing
 // party can move is not a bound, and it would be the one number in this file that
 // the party it constrains gets to choose.
+// Computed BEFORE the three page paths below, because all three are bounds on the
+// loop and a hand-back has to reset all three. Only the round cap honoured the
+// rerun floor at first, which left the earlier two pages looking at pre-rerun
+// history — so `@claude rerun` on a PR that had already stalled or exhausted its
+// rebuttals re-paged on the very first post-rerun round. That is the exact "one
+// panel round and an immediate re-page" this change exists to end, arriving through
+// a different door.
+const failedRounds = countFailedReviewRounds(commits, requiredCheckNames, { since: rerunAt });
+// A hand-back buys the loop at least one attempt before the softer bounds may fire
+// again. The round cap needs no such rule — its count already starts at the rerun.
+// The other two cannot be filtered as cleanly: the stall detector reads rounds
+// whose findings carry no timestamp, and the rebuttal count is an integer riding
+// forward on the finding with no provenance at all. "At least one post-rerun
+// attempt" is the honest common denominator, and it fails toward paging: it delays
+// these two by exactly one round, never disables them.
+const heldByRerun = rerunAt !== null && failedRounds === 0;
+if (heldByRerun) console.error("rerun: holding the stall/standstill pages for one attempt");
+
 const latestRound = rounds.length ? rounds[rounds.length - 1] : null;
-const exhausted = exhaustedFindings(latestRound?.findings);
+const exhausted = heldByRerun ? [] : exhaustedFindings(latestRound?.findings);
 if (exhausted.length > 0) {
   page(
     `A finding has been disputed ${MAX_REBUTTAL_ROUNDS} times and upheld every time by an ` +
@@ -204,7 +222,7 @@ const stall = detectStalledRounds(rounds, {
   similarity: stallSimilarity,
 });
 console.error(`convergence: ${stall.reason} (stalls=${stall.stalls}, rounds=${stall.rounds})`);
-if (stall.stalled) {
+if (stall.stalled && !heldByRerun) {
   const named = stall.repeated
     .slice(0, 5)
     .map((f) => `\`${f.file || "?"}\` — ${String(f.summary ?? "").slice(0, 160)}`)
@@ -218,11 +236,10 @@ if (stall.stalled) {
   process.exit(0);
 }
 
-const failedRounds = countFailedReviewRounds(commits, requiredCheckNames, { since: rerunAt });
 if (failedRounds >= max) {
   page(
     `The fixer has tried ${failedRounds} time(s) (limit ${max}) without converging` +
-      `${retryAt ? " since the last retry" : ""}. A human should take over on PR #${pr}.`,
+      `${rerunAt ? " since the last rerun" : ""}. A human should take over on PR #${pr}.`,
   );
   process.exit(0);
 }

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -21,6 +21,8 @@
 // is the conservative one (it over-counts, which pages early and is undone by
 // `@claude rerun`).
 
+import { parseCommand } from "./command.mjs";
+
 /**
  * The marker that latches a PR as "handed to a human". Written by
  * review-round-guard.mjs's `page()` and by the `stalled` job, and read back by
@@ -75,66 +77,51 @@ export function isPagedLatchComment(comment) {
 }
 
 /**
- * Hidden marker `agent-rerun.yml` writes when a maintainer un-sticks a PR.
+ * ISO timestamp of the newest `@claude rerun` from a HUMAN MAINTAINER, or null.
  *
- * `@claude rerun` (#650) already clears the paged latch and re-runs CI — it
- * DELETES the paged comments outright, so nothing here needs to out-date them.
- * What it could not do is give the loop its budget back: its own summary says
- * the PR is "still bounded by the pipeline's round/attempt caps", which on a PR
- * that reached the cap means one panel round and an immediate re-page. This
- * marker is the resume point that fixes that.
+ * This reads the maintainer's own COMMAND, not the marker the rerun workflow
+ * writes back — and that distinction is the whole security property.
  *
- * A hidden marker rather than the visible prose, because the prose is a message
- * to a human and will be reworded; and on the RESULT comment rather than a new
- * one, so un-sticking stays a single comment in the thread.
- */
-export const RERUN_MARKER = "<!-- agent-rerun -->";
-
-/**
- * ISO timestamp of the newest rerun, or null.
+ * The first version keyed on a hidden marker in the workflow's result comment,
+ * trusted by bot login. But `agent-rerun.yml` posts with the App token, so the
+ * trusted identity is `yorkie-agent[bot]` — the SAME identity the fixer and
+ * implementer post their own free-form comments under (the self-review comment on
+ * every agent PR is one). That made the party bounded by `MAX_REVIEW_ROUNDS` able
+ * to reset its own bound by opening a comment with the marker line: an LLM reading
+ * an untrusted diff, granted unlimited fix attempts, by accident or by injection.
  *
- * Author-checked for the same reason the paged latch is: this repo is PUBLIC, and
- * the marker GRANTS the loop a fresh budget. A body test alone would let any
- * account post it and hand the fixer unlimited attempts. Only the workflow's own
- * bot, or a human with write access, may move the floor.
+ * A human's command cannot be forged by a bot, because `user.type === "Bot"` is
+ * refused outright and no App can present as a non-Bot. That is a STRUCTURAL
+ * exclusion rather than a string it must not guess, which is why it replaced the
+ * marker rather than being added alongside it.
+ *
+ * `parseCommand` is reused rather than re-matched: `agent-rerun.yml`'s router uses
+ * it to decide the command actually ran, so a second regex here could recognise a
+ * rerun the router did not (or miss one it did) and move the floor for a hand-back
+ * that never happened.
+ *
+ * `author_association` is weaker than the `getCollaboratorPermissionLevel` gate the
+ * command itself enforces — an org MEMBER without repo write passes here. Named as
+ * a known gap rather than hidden: the consequence is extra fix attempts on a PR a
+ * member asked about, which is a different order of problem from the agent
+ * un-bounding itself, and closing it needs an API call this pure function cannot
+ * make. The workflow still refuses to DO anything for such a user.
  */
 export function rerunPointFrom(comments) {
   const stamps = (Array.isArray(comments) ? comments : [])
-    .filter(isRerunComment)
+    .filter(isRerunCommand)
     .map((c) => Date.parse(String(c.created_at ?? "")))
     .filter((n) => Number.isFinite(n));
   return stamps.length ? new Date(Math.max(...stamps)).toISOString() : null;
 }
 
-/**
- * Does this comment grant the loop a fresh budget?
- *
- * TWO restrictions, both narrower than the paged latch's, because the direction is
- * the opposite one: the latch only ever stops work, while this RESTARTS a safety
- * cap.
- *
- * FIRST LINE, not a substring. A substring test is re-armable by anyone who merely
- * quotes the marker — this repo already proved it, when clearing #648 by hand
- * re-armed the paged latch with the sentence explaining its removal. Worse here:
- * `agent-summarize.yml`, `agent-review-on-demand.yml` and `agent-review-reply.yml`
- * all publish LLM output verbatim under an allow-listed bot login, so a substring
- * test makes "a model emitted the marker" enough to reset the cap. The real writer
- * puts it on line one; nothing else does.
- *
- * BOT ONLY — no `author_association` path. `agent-rerun.yml` is the sole writer and
- * posts as an allow-listed App, while a human's route is the `@claude rerun`
- * command, which gates on `getCollaboratorPermissionLevel` (actual write access).
- * Accepting `author_association` here would grant the budget on a strictly weaker
- * credential than the command enforces — `MEMBER` is org membership, not repo
- * write — so the hand-written path is refused rather than left as the soft
- * underbelly of the stronger one.
- */
-export function isRerunComment(comment) {
+/** Is this a maintainer's `@claude rerun`? Bots are refused — see rerunPointFrom. */
+export function isRerunCommand(comment) {
   const c = comment && typeof comment === "object" ? comment : {};
-  const firstLine = String(c.body ?? "").split("\n").map((l) => l.trim()).find((l) => l !== "") ?? "";
-  if (firstLine !== RERUN_MARKER) return false;
   const user = c.user && typeof c.user === "object" ? c.user : {};
-  return user.type === "Bot" && PAGE_AUTHOR_LOGINS.includes(user.login);
+  if (user.type === "Bot") return false;
+  if (!TRUSTED_ASSOCIATIONS.has(String(c.author_association ?? ""))) return false;
+  return parseCommand(String(c.body ?? ""), { surface: "pr" }).command === "rerun";
 }
 
 /** A commit has exactly one parent — i.e. it is not a merge commit.
@@ -184,40 +171,38 @@ function firstVerdictAt(commits, names) {
  * data. `since` moves the floor forward again after a maintainer's `@claude rerun`, so a
  * hand-back grants a fresh budget rather than resuming one already spent.
  */
-export function countFailedReviewRounds(commits, requiredCheckNames, { since = null } = {}) {
+export function fixAttemptCommits(commits, requiredCheckNames, { since = null } = {}) {
   const names = new Set(requiredCheckNames ?? []);
   const isFailingLensRun = (r) =>
     names.has(r.name) && r.app?.slug === "github-actions" && r.conclusion === "failure";
-  // Epoch milliseconds, not ISO strings. Lexicographic comparison is only correct
-  // for Z-normalised, equal-precision timestamps; GitHub happens to emit those
-  // today, which makes a string compare a latent dependency on an API detail
-  // rather than a property of the code.
   const first = firstVerdictAt(commits, names);
   const s = Date.parse(String(since ?? ""));
   const sinceMs = Number.isFinite(s) ? s : null;
   const floor = first === null ? null : sinceMs !== null && sinceMs > first ? sinceMs : first;
-  // `Array.isArray`, not `?? []`: a non-array truthy value (a string from a
-  // mis-wired caller) passes the nullish guard and then throws on `.filter`,
-  // which fails the guard STEP rather than the round count — and a thrown guard
-  // is a dead fix job, not a conservative one.
+  // FAILS TOWARD INCLUDING, so both consumers stay conservative: the count pages a
+  // round early (undone by a rerun) and the stall detector keeps the evidence it
+  // would otherwise discard. Under-including would silently unbound both.
   return (Array.isArray(commits) ? commits : []).filter((c) => {
     if (!isSingleParentCommit(c)) return false;
     if (!(c.checkRuns ?? []).some(isFailingLensRun)) return false;
-    // FAILS TOWARD COUNTING, and the direction matters more here than the
-    // precision does. This number feeds a CAP: over-counting pages a round early,
-    // which a maintainer can undo with `@claude rerun`, while under-counting means
-    // the cap never trips and the loop is unbounded — recoverable only if someone
-    // happens to notice. So a commit whose position cannot be established counts,
-    // and if no verdict timestamp exists anywhere the whole floor is abandoned and
-    // every failing commit counts, exactly as before this refinement.
     if (floor === null) return true;
     // Committer date, not author date: a rebased commit keeps an author date that
     // can predate a verdict it plainly followed.
     const at = Date.parse(String(c?.commit?.committer?.date ?? ""));
     if (!Number.isFinite(at)) return true;
     return at > floor;
-  }).length;
+  });
 }
+
+/**
+ * How many times has the FIX LOOP tried and failed? See `fixAttemptCommits` for
+ * what counts and why; this is its length, kept as its own export because the
+ * number is what `MAX_REVIEW_ROUNDS` compares against.
+ */
+export function countFailedReviewRounds(commits, requiredCheckNames, opts = {}) {
+  return fixAttemptCommits(commits, requiredCheckNames, opts).length;
+}
+
 
 // --- convergence detection ---------------------------------------------------
 //

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -63,26 +63,118 @@ export function isPagedLatchComment(comment) {
   return TRUSTED_ASSOCIATIONS.has(String(c.author_association ?? ""));
 }
 
-/** A commit is a "fixer" commit iff it has exactly one parent. */
-export function isFixerCommit(commit) {
+/**
+ * Hidden marker `agent-rerun.yml` writes when a maintainer un-sticks a PR.
+ *
+ * `@claude rerun` (#650) already clears the paged latch and re-runs CI — it
+ * DELETES the paged comments outright, so nothing here needs to out-date them.
+ * What it could not do is give the loop its budget back: its own summary says
+ * the PR is "still bounded by the pipeline's round/attempt caps", which on a PR
+ * that reached the cap means one panel round and an immediate re-page. This
+ * marker is the resume point that fixes that.
+ *
+ * A hidden marker rather than the visible prose, because the prose is a message
+ * to a human and will be reworded; and on the RESULT comment rather than a new
+ * one, so un-sticking stays a single comment in the thread.
+ */
+export const RERUN_MARKER = "<!-- agent-rerun -->";
+
+/**
+ * ISO timestamp of the newest rerun, or null.
+ *
+ * Author-checked for the same reason the paged latch is: this repo is PUBLIC, and
+ * the marker GRANTS the loop a fresh budget. A body test alone would let any
+ * account post it and hand the fixer unlimited attempts. Only the workflow's own
+ * bot, or a human with write access, may move the floor.
+ */
+export function rerunPointFrom(comments) {
+  const stamps = (Array.isArray(comments) ? comments : [])
+    .filter((c) => {
+      const o = c && typeof c === "object" ? c : {};
+      if (!String(o.body ?? "").includes(RERUN_MARKER)) return false;
+      const user = o.user && typeof o.user === "object" ? o.user : {};
+      if (user.type === "Bot" && PAGE_AUTHOR_LOGINS.includes(user.login)) return true;
+      return TRUSTED_ASSOCIATIONS.has(String(o.author_association ?? ""));
+    })
+    .map((c) => String(c.created_at ?? ""))
+    .filter((s) => s !== "" && Number.isFinite(Date.parse(s)))
+    .sort();
+  return stamps.length ? stamps[stamps.length - 1] : null;
+}
+
+/** A commit has exactly one parent — i.e. it is not a merge commit.
+ *
+ * NOT "was pushed by the fixer", which is what the old name (`isFixerCommit`)
+ * claimed and what every caller read it as. It cannot know that: the check is
+ * deliberately identity-independent, because the bot identity behind fixer
+ * pushes has already changed once in this pipeline's history. See
+ * `countFailedReviewRounds` for what actually separates a fix attempt from the
+ * implementer's own commits. */
+export function isSingleParentCommit(commit) {
   return Array.isArray(commit?.parents) && commit.parents.length === 1;
 }
 
+/** Earliest completed panel verdict anywhere on the PR, or null. */
+function firstVerdictAt(commits, names) {
+  const stamps = [];
+  for (const c of Array.isArray(commits) ? commits : []) {
+    for (const r of c?.checkRuns ?? []) {
+      if (!names.has(r?.name)) continue;
+      const t = String(r?.completed_at ?? "");
+      if (t !== "" && Number.isFinite(Date.parse(t))) stamps.push(t);
+    }
+  }
+  stamps.sort();
+  return stamps.length ? stamps[0] : null;
+}
+
 /**
- * Count commits that are BOTH a fixer commit AND carry a failing required
- * lens check-run from OUR panel (exact name match + producing app, so a
- * same-named check from some other installed app can't inflate the count).
+ * How many times has the FIX LOOP tried and failed?
  *
- * `commits`: Array<{ sha, parents, checkRuns: Array<{name, app, conclusion}> }>
- * `requiredCheckNames`: string[]
+ * This used to count every single-parent commit carrying a failing lens verdict,
+ * which is not the same thing and was wrong on every agent PR measured. The
+ * implement workflow pushes its work, self-reviews, fixes what it found, and
+ * pushes AGAIN — two commits, each triggering CI, each drawing its own panel
+ * round. Both were counted as failed fix rounds before the fix loop had run once.
+ * On #648 and #605 alike that silently consumed exactly 2 of the budget, so when
+ * #615 lowered `MAX_REVIEW_ROUNDS` from 5 to 3 believing it was trimming a
+ * wasteful tail, the real effect was to cut the loop from three attempts to ONE.
+ * #648 then reported "requested changes 3 times without converging" after a
+ * single fix attempt.
+ *
+ * A commit committed BEFORE the panel first spoke cannot be a response to it.
+ * That is the whole discriminator, it needs no identity, and it is already in the
+ * data. `since` moves the floor forward again after a maintainer's `@claude rerun`, so a
+ * hand-back grants a fresh budget rather than resuming one already spent.
  */
-export function countFailedReviewRounds(commits, requiredCheckNames) {
+export function countFailedReviewRounds(commits, requiredCheckNames, { since = null } = {}) {
   const names = new Set(requiredCheckNames ?? []);
   const isFailingLensRun = (r) =>
     names.has(r.name) && r.app?.slug === "github-actions" && r.conclusion === "failure";
-  return (commits ?? []).filter(
-    (c) => isFixerCommit(c) && (c.checkRuns ?? []).some(isFailingLensRun),
-  ).length;
+  const first = firstVerdictAt(commits, names);
+  const s = typeof since === "string" && Number.isFinite(Date.parse(since)) ? since : null;
+  const floor = first === null ? null : s && s > first ? s : first;
+  // `Array.isArray`, not `?? []`: a non-array truthy value (a string from a
+  // mis-wired caller) passes the nullish guard and then throws on `.filter`,
+  // which fails the guard STEP rather than the round count — and a thrown guard
+  // is a dead fix job, not a conservative one.
+  return (Array.isArray(commits) ? commits : []).filter((c) => {
+    if (!isSingleParentCommit(c)) return false;
+    if (!(c.checkRuns ?? []).some(isFailingLensRun)) return false;
+    // FAILS TOWARD COUNTING, and the direction matters more here than the
+    // precision does. This number feeds a CAP: over-counting pages a round early,
+    // which a maintainer can undo with `@claude rerun`, while under-counting means
+    // the cap never trips and the loop is unbounded — recoverable only if someone
+    // happens to notice. So a commit whose position cannot be established counts,
+    // and if no verdict timestamp exists anywhere the whole floor is abandoned and
+    // every failing commit counts, exactly as before this refinement.
+    if (floor === null) return true;
+    // Committer date, not author date: a rebased commit keeps an author date that
+    // can predate a verdict it plainly followed.
+    const at = String(c?.commit?.committer?.date ?? "");
+    if (at === "" || !Number.isFinite(Date.parse(at))) return true;
+    return at > floor;
+  }).length;
 }
 
 // --- convergence detection ---------------------------------------------------

--- a/scripts/agent/rounds.mjs
+++ b/scripts/agent/rounds.mjs
@@ -1,14 +1,25 @@
-// Fixer-commit filter for the review-round guard (agent-review-panel.yml's
-// `fix` job). A merge commit (2 parents, e.g. a human `git merge main` to
-// resolve conflicts on an iterating PR) is NOT a review-fix attempt and must
-// not count toward MAX_REVIEW_ROUNDS — only genuine single-parent commits
-// pushed in response to a failing lens should. PR #521 demonstrated this: 3
-// single-parent fixer commits + 3 two-parent merge commits, all 6 counted by
-// the old (unfiltered) logic toward the round cap.
+// Round arithmetic for the review-round guard (agent-review-panel.yml's `fix`
+// job), plus the comment markers that start and stop the loop.
 //
-// Deliberately identity-independent (no author/bot-name check): the bot
-// identity behind fixer pushes has already changed once in this pipeline's
-// history, so parent count — not who pushed — is the durable signal.
+// WHAT COUNTS AS A FIX ATTEMPT takes two filters, and for a long time it had only
+// the first. A merge commit (2 parents, e.g. a human `git merge main` on an
+// iterating PR) is not a fix attempt: PR #521 had 3 single-parent fixer commits
+// and 3 merges, and all 6 counted. But parent count alone is not enough either —
+// the implement workflow pushes its work, self-reviews, and pushes AGAIN, so two
+// commits draw two panel rounds before the fix loop has run once. Both were
+// counted, which on #648 and #605 consumed exactly 2 of the budget and left
+// `MAX_REVIEW_ROUNDS: 3` meaning ONE real attempt.
+//
+// The second filter is time: a commit committed BEFORE the panel first spoke
+// cannot be a response to it. Deliberately identity-independent, like the first —
+// the bot identity behind fixer pushes has already changed once in this
+// pipeline's history, so neither "who pushed" nor a name is a durable signal.
+//
+// It is a heuristic about ORDERING, not provenance, and the edge is worth naming:
+// if a panel verdict lands before the implementer's self-review push, that push
+// counts as an attempt. Nothing in the data distinguishes them, and the direction
+// is the conservative one (it over-counts, which pages early and is undone by
+// `@claude rerun`).
 
 /**
  * The marker that latches a PR as "handed to a human". Written by
@@ -89,17 +100,41 @@ export const RERUN_MARKER = "<!-- agent-rerun -->";
  */
 export function rerunPointFrom(comments) {
   const stamps = (Array.isArray(comments) ? comments : [])
-    .filter((c) => {
-      const o = c && typeof c === "object" ? c : {};
-      if (!String(o.body ?? "").includes(RERUN_MARKER)) return false;
-      const user = o.user && typeof o.user === "object" ? o.user : {};
-      if (user.type === "Bot" && PAGE_AUTHOR_LOGINS.includes(user.login)) return true;
-      return TRUSTED_ASSOCIATIONS.has(String(o.author_association ?? ""));
-    })
-    .map((c) => String(c.created_at ?? ""))
-    .filter((s) => s !== "" && Number.isFinite(Date.parse(s)))
-    .sort();
-  return stamps.length ? stamps[stamps.length - 1] : null;
+    .filter(isRerunComment)
+    .map((c) => Date.parse(String(c.created_at ?? "")))
+    .filter((n) => Number.isFinite(n));
+  return stamps.length ? new Date(Math.max(...stamps)).toISOString() : null;
+}
+
+/**
+ * Does this comment grant the loop a fresh budget?
+ *
+ * TWO restrictions, both narrower than the paged latch's, because the direction is
+ * the opposite one: the latch only ever stops work, while this RESTARTS a safety
+ * cap.
+ *
+ * FIRST LINE, not a substring. A substring test is re-armable by anyone who merely
+ * quotes the marker — this repo already proved it, when clearing #648 by hand
+ * re-armed the paged latch with the sentence explaining its removal. Worse here:
+ * `agent-summarize.yml`, `agent-review-on-demand.yml` and `agent-review-reply.yml`
+ * all publish LLM output verbatim under an allow-listed bot login, so a substring
+ * test makes "a model emitted the marker" enough to reset the cap. The real writer
+ * puts it on line one; nothing else does.
+ *
+ * BOT ONLY — no `author_association` path. `agent-rerun.yml` is the sole writer and
+ * posts as an allow-listed App, while a human's route is the `@claude rerun`
+ * command, which gates on `getCollaboratorPermissionLevel` (actual write access).
+ * Accepting `author_association` here would grant the budget on a strictly weaker
+ * credential than the command enforces — `MEMBER` is org membership, not repo
+ * write — so the hand-written path is refused rather than left as the soft
+ * underbelly of the stronger one.
+ */
+export function isRerunComment(comment) {
+  const c = comment && typeof comment === "object" ? comment : {};
+  const firstLine = String(c.body ?? "").split("\n").map((l) => l.trim()).find((l) => l !== "") ?? "";
+  if (firstLine !== RERUN_MARKER) return false;
+  const user = c.user && typeof c.user === "object" ? c.user : {};
+  return user.type === "Bot" && PAGE_AUTHOR_LOGINS.includes(user.login);
 }
 
 /** A commit has exactly one parent — i.e. it is not a merge commit.
@@ -119,13 +154,15 @@ function firstVerdictAt(commits, names) {
   const stamps = [];
   for (const c of Array.isArray(commits) ? commits : []) {
     for (const r of c?.checkRuns ?? []) {
-      if (!names.has(r?.name)) continue;
-      const t = String(r?.completed_at ?? "");
-      if (t !== "" && Number.isFinite(Date.parse(t))) stamps.push(t);
+      // Same app guard every other lens-run consumer applies. Without it a
+      // same-named check from another installed App lowers the floor, which
+      // widens the count — the wrong direction for a value that gates a cap.
+      if (!names.has(r?.name) || r?.app?.slug !== "github-actions") continue;
+      const t = Date.parse(String(r?.completed_at ?? ""));
+      if (Number.isFinite(t)) stamps.push(t);
     }
   }
-  stamps.sort();
-  return stamps.length ? stamps[0] : null;
+  return stamps.length ? Math.min(...stamps) : null;
 }
 
 /**
@@ -151,9 +188,14 @@ export function countFailedReviewRounds(commits, requiredCheckNames, { since = n
   const names = new Set(requiredCheckNames ?? []);
   const isFailingLensRun = (r) =>
     names.has(r.name) && r.app?.slug === "github-actions" && r.conclusion === "failure";
+  // Epoch milliseconds, not ISO strings. Lexicographic comparison is only correct
+  // for Z-normalised, equal-precision timestamps; GitHub happens to emit those
+  // today, which makes a string compare a latent dependency on an API detail
+  // rather than a property of the code.
   const first = firstVerdictAt(commits, names);
-  const s = typeof since === "string" && Number.isFinite(Date.parse(since)) ? since : null;
-  const floor = first === null ? null : s && s > first ? s : first;
+  const s = Date.parse(String(since ?? ""));
+  const sinceMs = Number.isFinite(s) ? s : null;
+  const floor = first === null ? null : sinceMs !== null && sinceMs > first ? sinceMs : first;
   // `Array.isArray`, not `?? []`: a non-array truthy value (a string from a
   // mis-wired caller) passes the nullish guard and then throws on `.filter`,
   // which fails the guard STEP rather than the round count — and a thrown guard
@@ -171,8 +213,8 @@ export function countFailedReviewRounds(commits, requiredCheckNames, { since = n
     if (floor === null) return true;
     // Committer date, not author date: a rebased commit keeps an author date that
     // can predate a verdict it plainly followed.
-    const at = String(c?.commit?.committer?.date ?? "");
-    if (at === "" || !Number.isFinite(Date.parse(at))) return true;
+    const at = Date.parse(String(c?.commit?.committer?.date ?? ""));
+    if (!Number.isFinite(at)) return true;
     return at > floor;
   }).length;
 }

--- a/scripts/agent/rounds.test.mjs
+++ b/scripts/agent/rounds.test.mjs
@@ -15,8 +15,8 @@ import {
   PAGE_AUTHOR_LOGINS,
   isPagedLatchComment,
   rerunPointFrom,
-  isRerunComment,
-  RERUN_MARKER,
+  isRerunCommand,
+  fixAttemptCommits,
 } from "./rounds.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -359,99 +359,65 @@ test("groupReviewRounds: other-app check ignored; newest run per lens wins", () 
   assert.deepEqual(groupReviewRounds([commit("c1", [older, newer])], NAMES)[0].findings.map((x) => x.summary), ["NEW"]);
 });
 
-// --- the rerun resume point -------------------------------------------------
+// --- the rerun resume point --------------------------------------------------
 
 const human = (body, over = {}) => ({
-  body, created_at: "2026-08-04T10:00:00Z",
+  body, created_at: "2026-08-04T09:30:00Z",
   user: { login: "harrykim8672", type: "User" }, author_association: "MEMBER", ...over,
 });
-const rerunResult = (over = {}) => ({
-  body: `${RERUN_MARKER}\n🔁 Rerun engaged — cleared 1 paged marker(s)`,
-  created_at: "2026-08-04T09:30:00Z",
-  user: { login: "github-actions[bot]", type: "Bot" }, author_association: "CONTRIBUTOR", ...over,
-});
 
-test("rerunPointFrom: the newest rerun wins; no rerun is null", () => {
+test("rerunPointFrom: a maintainer's @claude rerun moves the floor", () => {
   assert.equal(rerunPointFrom([]), null);
   assert.equal(rerunPointFrom([human("just a comment")]), null);
-  assert.equal(rerunPointFrom([rerunResult()]), "2026-08-04T09:30:00.000Z");
+  assert.equal(rerunPointFrom([human("@claude rerun")]), "2026-08-04T09:30:00.000Z");
   assert.equal(
-    rerunPointFrom([rerunResult(), rerunResult({ created_at: "2026-08-04T14:00:00Z" })]),
+    rerunPointFrom([human("@claude rerun"), human("@claude rerun", { created_at: "2026-08-04T14:00:00Z" })]),
     "2026-08-04T14:00:00.000Z",
   );
-  assert.equal(rerunPointFrom([rerunResult({ created_at: "nonsense" })]), null);
+  assert.equal(rerunPointFrom([human("@claude rerun", { created_at: "nonsense" })]), null);
   for (const bad of [null, undefined, "x", 7]) assert.equal(rerunPointFrom(bad), null);
 });
 
-test("rerunPointFrom: a stranger cannot grant the loop a fresh budget", () => {
-  // Public repo, and this marker RESETS the fix-attempt cap.
-  assert.equal(rerunPointFrom([rerunResult({ user: { login: "drive-by", type: "User" }, author_association: "NONE" })]), null);
-  assert.equal(rerunPointFrom([rerunResult({ user: { login: "coderabbitai[bot]", type: "Bot" }, author_association: "CONTRIBUTOR" })]), null);
-  assert.equal(rerunPointFrom([rerunResult()]), "2026-08-04T09:30:00.000Z");
-});
-
-test("agent-rerun.yml EMITS the marker — prose mentioning it does not count", () => {
-  // The marker is a contract between a workflow and a module that cannot import
-  // it. A drifted copy does not error — the budget silently never resets and the
-  // PR re-pages after one round, exactly as before this existed.
+test("isRerunCommand: A BOT CAN NEVER RESET ITS OWN BOUND", () => {
+  // The reason this reads the maintainer's COMMAND and not the workflow's result
+  // marker. agent-rerun.yml posts with the App token, so the trusted identity would
+  // be yorkie-agent[bot] — the same identity the fixer and implementer post their
+  // own free-form comments under (the self-review comment on every agent PR). A
+  // marker keyed on bot login let the party bounded by MAX_REVIEW_ROUNDS grant
+  // itself unlimited attempts, by accident or by injection from the diff it reads.
   //
-  // The first version of this test was `includes(RERUN_MARKER)`, which the file's
-  // own EXPLANATORY COMMENT satisfied: deleting the emit left the test green. Same
-  // shape as the latch-write test below it, so prose lines are excluded and the
-  // remaining line must actually be emitting into a body.
-  const rerunWorkflow = readFileSync(
-    path.join(HERE, "..", "..", ".github", "workflows", "agent-rerun.yml"),
-    "utf8",
-  );
-  const emits = rerunWorkflow
-    .split("\n")
-    .filter((l) => l.includes(RERUN_MARKER) && !/^\s*(#|\/\/)/.test(l));
-  assert.equal(emits.length, 1, "expected exactly one line that EMITS the rerun marker");
-  assert.match(emits[0], /`/, "the emitting line should be a template literal in the comment body");
+  // Structural, not a secret: no App can present as a non-Bot.
+  for (const login of ["yorkie-agent[bot]", "github-actions[bot]", "coderabbitai[bot]"]) {
+    for (const assoc of ["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]) {
+      assert.equal(
+        isRerunCommand(human("@claude rerun", { user: { login, type: "Bot" }, author_association: assoc })),
+        false,
+        `${login}/${assoc}`,
+      );
+    }
+  }
+  assert.equal(rerunPointFrom([human("@claude rerun", { user: { login: "yorkie-agent[bot]", type: "Bot" } })]), null);
 });
 
-test("isRerunComment: the marker must be the FIRST LINE, not merely present", () => {
-  // A substring test is re-armable by anyone who quotes the marker — this repo
-  // proved it when clearing #648 by hand re-armed the paged latch with the very
-  // sentence explaining its removal.
-  assert.equal(isRerunComment(rerunResult()), true);
-  assert.equal(
-    isRerunComment(rerunResult({ body: `a maintainer wrote ${RERUN_MARKER} in prose` })),
-    false,
-  );
-  assert.equal(
-    isRerunComment(rerunResult({ body: `## Summary\n\n${RERUN_MARKER}\nreset` })),
-    false,
-  );
-});
-
-test("isRerunComment: LLM output under a trusted bot login cannot reset the cap", () => {
-  // agent-summarize.yml, agent-review-on-demand.yml and agent-review-reply.yml all
-  // publish model output verbatim under an allow-listed bot login. With a
-  // substring test, "a model emitted the marker" would have been enough.
-  const smuggled = rerunResult({
-    body: `## 🤖 Agent effort\n\nThe fixer noted: ${RERUN_MARKER} — see the guard.`,
-  });
-  assert.equal(isRerunComment(smuggled), false);
-  assert.equal(rerunPointFrom([smuggled]), null);
-});
-
-test("isRerunComment: BOT ONLY — author_association is not a strong enough credential", () => {
-  // `@claude rerun` gates on getCollaboratorPermissionLevel (real write access).
-  // Accepting author_association here would grant the same budget on a weaker
-  // credential — MEMBER is org membership, not repo write.
+test("isRerunCommand: a stranger cannot reset it either; junk never throws", () => {
+  for (const assoc of ["NONE", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR"]) {
+    assert.equal(isRerunCommand(human("@claude rerun", { author_association: assoc })), false, assoc);
+  }
   for (const assoc of ["OWNER", "MEMBER", "COLLABORATOR"]) {
-    assert.equal(
-      isRerunComment(rerunResult({ user: { login: "a-maintainer", type: "User" }, author_association: assoc })),
-      false,
-      assoc,
-    );
+    assert.equal(isRerunCommand(human("@claude rerun", { author_association: assoc })), true, assoc);
   }
-  assert.equal(isRerunComment(rerunResult({ user: { login: "coderabbitai[bot]", type: "Bot" } })), false);
-  for (const login of PAGE_AUTHOR_LOGINS) {
-    assert.equal(isRerunComment(rerunResult({ user: { login, type: "Bot" } })), true, login);
-  }
-  for (const bad of [null, undefined, "x", 7, {}]) assert.equal(isRerunComment(bad), false);
+  for (const bad of [null, undefined, "x", 7, {}]) assert.equal(isRerunCommand(bad), false);
+});
+
+test("isRerunCommand: it is parseCommand's verb, so the router cannot disagree", () => {
+  // A second regex here could recognise a rerun agent-rerun.yml's router did not,
+  // moving the floor for a hand-back that never happened.
+  assert.equal(isRerunCommand(human("@claude rerun")), true);
+  assert.equal(isRerunCommand(human("@claude rerun this please")), true);
+  assert.equal(isRerunCommand(human("@claude loop")), false);
+  assert.equal(isRerunCommand(human("@claude review")), false);
+  // A different account is not a command for us.
+  assert.equal(isRerunCommand(human("@claude-bot rerun")), false);
 });
 
 // --- the round count, against #648's real shape ------------------------------
@@ -544,4 +510,19 @@ test("firstVerdictAt: a foreign app's same-named check cannot lower the floor", 
   // Without the app guard the floor would drop to 09:00 and 1d9e19dee (09:43) would
   // count as an attempt; with it, the floor stays at the real first verdict.
   assert.equal(countFailedReviewRounds(spoofed, ROUND_NAMES), 1);
+});
+
+test("fixAttemptCommits: the STALL door sees fix rounds only, like the cap", () => {
+  // The stall bound ran over groupReviewRounds(ALL commits), which includes the two
+  // the implement workflow pushes before the panel has spoken — so three rounds of
+  // "evidence" existed immediately and the stall door could cut the loop to one real
+  // attempt, the same failure the cap fix closed arriving through the other bound.
+  const kept = fixAttemptCommits(PR648, ROUND_NAMES);
+  assert.deepEqual(kept.map((c) => c.sha), ["102e0fa73"]);
+  // Same predicate the cap uses — if these ever disagree, one bound is counting
+  // something the other is not.
+  assert.equal(kept.length, countFailedReviewRounds(PR648, ROUND_NAMES));
+  // A rerun floor narrows both together.
+  assert.deepEqual(fixAttemptCommits(PR648, ROUND_NAMES, { since: "2026-08-03T18:00:00Z" }), []);
+  for (const bad of [null, undefined, "x", 7]) assert.deepEqual(fixAttemptCommits(bad, ROUND_NAMES), []);
 });

--- a/scripts/agent/rounds.test.mjs
+++ b/scripts/agent/rounds.test.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  isFixerCommit,
+  isSingleParentCommit,
   countFailedReviewRounds,
   summaryTokens,
   findingSimilarity,
@@ -14,6 +14,8 @@ import {
   PAGED_LATCH,
   PAGE_AUTHOR_LOGINS,
   isPagedLatchComment,
+  rerunPointFrom,
+  RERUN_MARKER,
 } from "./rounds.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -135,12 +137,12 @@ const merge = (sha, checkRuns = []) => ({ sha, parents: [{ sha: "p1" }, { sha: "
 const failingRun = (name = "agent-review-correctness") => ({ name, app: { slug: "github-actions" }, conclusion: "failure" });
 const passingRun = (name = "agent-review-correctness") => ({ name, app: { slug: "github-actions" }, conclusion: "success" });
 
-test("isFixerCommit: one parent → true; merge (2) or root (0) → false", () => {
-  assert.equal(isFixerCommit({ parents: [{ sha: "a" }] }), true);
-  assert.equal(isFixerCommit({ parents: [{ sha: "a" }, { sha: "b" }] }), false);
-  assert.equal(isFixerCommit({ parents: [] }), false);
-  assert.equal(isFixerCommit({}), false);
-  assert.equal(isFixerCommit(undefined), false);
+test("isSingleParentCommit: one parent → true; merge (2) or root (0) → false", () => {
+  assert.equal(isSingleParentCommit({ parents: [{ sha: "a" }] }), true);
+  assert.equal(isSingleParentCommit({ parents: [{ sha: "a" }, { sha: "b" }] }), false);
+  assert.equal(isSingleParentCommit({ parents: [] }), false);
+  assert.equal(isSingleParentCommit({}), false);
+  assert.equal(isSingleParentCommit(undefined), false);
 });
 
 test("countFailedReviewRounds: PR #521 shape — 3 fixer + 3 merge, same failing check → 3, not 6", () => {
@@ -354,4 +356,126 @@ test("groupReviewRounds: other-app check ignored; newest run per lens wins", () 
   const older = run("agent-review-correctness", [{ severity: "major", file: "a.ts", summary: "OLD" }], { completed_at: "2026-07-27T05:00:00Z" });
   const newer = run("agent-review-correctness", [{ severity: "major", file: "a.ts", summary: "NEW" }], { completed_at: "2026-07-27T07:00:00Z" });
   assert.deepEqual(groupReviewRounds([commit("c1", [older, newer])], NAMES)[0].findings.map((x) => x.summary), ["NEW"]);
+});
+
+// --- the rerun resume point -------------------------------------------------
+
+const human = (body, over = {}) => ({
+  body, created_at: "2026-08-04T10:00:00Z",
+  user: { login: "harrykim8672", type: "User" }, author_association: "MEMBER", ...over,
+});
+const rerunResult = (over = {}) => ({
+  body: `${RERUN_MARKER}\n🔁 Rerun engaged — cleared 1 paged marker(s)`,
+  created_at: "2026-08-04T09:30:00Z",
+  user: { login: "github-actions[bot]", type: "Bot" }, author_association: "CONTRIBUTOR", ...over,
+});
+
+test("rerunPointFrom: the newest rerun wins; no rerun is null", () => {
+  assert.equal(rerunPointFrom([]), null);
+  assert.equal(rerunPointFrom([human("just a comment")]), null);
+  assert.equal(rerunPointFrom([rerunResult()]), "2026-08-04T09:30:00Z");
+  assert.equal(
+    rerunPointFrom([rerunResult(), rerunResult({ created_at: "2026-08-04T14:00:00Z" })]),
+    "2026-08-04T14:00:00Z",
+  );
+  assert.equal(rerunPointFrom([rerunResult({ created_at: "nonsense" })]), null);
+  for (const bad of [null, undefined, "x", 7]) assert.equal(rerunPointFrom(bad), null);
+});
+
+test("rerunPointFrom: a stranger cannot grant the loop a fresh budget", () => {
+  // Public repo, and this marker RESETS the fix-attempt cap — a body test alone
+  // would let any account hand the fixer unlimited attempts.
+  assert.equal(rerunPointFrom([rerunResult({ user: { login: "drive-by", type: "User" }, author_association: "NONE" })]), null);
+  assert.equal(rerunPointFrom([rerunResult({ user: { login: "coderabbitai[bot]", type: "Bot" }, author_association: "CONTRIBUTOR" })]), null);
+  // The workflow's own bot, and a maintainer by hand, both may.
+  assert.equal(rerunPointFrom([rerunResult()]), "2026-08-04T09:30:00Z");
+  assert.equal(
+    rerunPointFrom([rerunResult({ user: { login: "a-maintainer", type: "User" }, author_association: "OWNER" })]),
+    "2026-08-04T09:30:00Z",
+  );
+});
+
+test("agent-rerun.yml writes the marker the guard reads", () => {
+  // The marker is a contract between a workflow and a module that cannot import
+  // it. A drifted copy does not error — the budget silently never resets, and the
+  // PR re-pages after one round exactly as it did before this existed.
+  const rerunWorkflow = readFileSync(
+    path.join(HERE, "..", "..", ".github", "workflows", "agent-rerun.yml"),
+    "utf8",
+  );
+  assert.ok(
+    rerunWorkflow.includes(RERUN_MARKER),
+    "agent-rerun.yml must emit RERUN_MARKER into its result comment",
+  );
+});
+
+// --- the round count, against #648's real shape ------------------------------
+
+const ROUND_NAMES = ["agent-review-correctness", "agent-review-security"];
+const lensRun = (conclusion, completed_at) => ({
+  name: "agent-review-correctness", app: { slug: "github-actions" }, conclusion, completed_at,
+});
+const commitAt = (sha, date, runs) => ({
+  sha, parents: [{ sha: "p" }], commit: { committer: { date } }, checkRuns: runs,
+});
+
+// The exact shape of PR #648: the implement agent pushes its work, self-reviews,
+// fixes what it found and pushes AGAIN — two commits before the panel has ever
+// spoken — then the fix loop pushes once. The old count returned 3 and tripped a
+// cap of 3 after a SINGLE fix attempt.
+const PR648 = [
+  commitAt("cde0fad48", "2026-08-03T09:31:22Z", [lensRun("failure", "2026-08-03T10:05:15Z")]),
+  commitAt("1d9e19dee", "2026-08-03T09:43:53Z", [lensRun("failure", "2026-08-03T10:11:28Z")]),
+  commitAt("102e0fa73", "2026-08-03T10:32:17Z", [lensRun("failure", "2026-08-03T17:42:33Z")]),
+];
+
+test("countFailedReviewRounds: commits predating the FIRST verdict are not fix attempts", () => {
+  // A commit committed before the panel first spoke cannot be a response to it.
+  assert.equal(countFailedReviewRounds(PR648, ROUND_NAMES), 1);
+});
+
+test("countFailedReviewRounds: a retry moves the floor, granting a fresh budget", () => {
+  // #648 after a maintainer hands it back: the pre-retry attempt no longer counts,
+  // so the loop gets its full MAX_REVIEW_ROUNDS again instead of re-paging on the
+  // first round.
+  assert.equal(countFailedReviewRounds(PR648, ROUND_NAMES, { since: "2026-08-03T18:00:00Z" }), 0);
+  // A post-retry failure does count.
+  const after = [...PR648, commitAt("aaaaaaaaa", "2026-08-03T18:30:00Z", [lensRun("failure", "2026-08-03T18:45:00Z")])];
+  assert.equal(countFailedReviewRounds(after, ROUND_NAMES, { since: "2026-08-03T18:00:00Z" }), 1);
+  // A retry OLDER than the first verdict must not widen the count back out.
+  assert.equal(countFailedReviewRounds(PR648, ROUND_NAMES, { since: "2026-08-03T08:00:00Z" }), 1);
+});
+
+test("countFailedReviewRounds: FAILS TOWARD COUNTING when the floor is unknowable", () => {
+  // This number feeds a CAP. Over-counting pages a round early, which `@claude
+  // retry` undoes; under-counting means the cap never trips and the loop is
+  // unbounded, recoverable only if someone notices. So missing timestamps must
+  // not silently disable the bound.
+  //
+  // No verdict timestamps anywhere → no floor → every failing commit counts,
+  // exactly as before this refinement. (This is the PR #521 fixture's shape.)
+  const noStamps = PR648.map((c) => ({
+    ...c,
+    checkRuns: c.checkRuns.map((r) => ({ ...r, completed_at: undefined })),
+  }));
+  assert.equal(countFailedReviewRounds(noStamps, ROUND_NAMES), 3);
+  // A floor exists, but ONE commit has no committer date → it cannot be proven to
+  // predate the floor, so it counts.
+  const undated = [PR648[0], { ...PR648[1], commit: {} }, PR648[2]];
+  assert.equal(countFailedReviewRounds(undated, ROUND_NAMES), 2);
+  // Genuinely nothing to count.
+  const noRuns = PR648.map((c) => ({ ...c, checkRuns: [] }));
+  assert.equal(countFailedReviewRounds(noRuns, ROUND_NAMES), 0);
+  for (const bad of [null, undefined, "x", 7]) assert.equal(countFailedReviewRounds(bad, ROUND_NAMES), 0);
+  assert.equal(countFailedReviewRounds(PR648, []), 0);
+});
+
+test("countFailedReviewRounds: merges and passing rounds still do not count", () => {
+  const merge = { ...PR648[2], parents: [{ sha: "a" }, { sha: "b" }] };
+  assert.equal(countFailedReviewRounds([PR648[0], PR648[1], merge], ROUND_NAMES), 0);
+  const passed = { ...PR648[2], checkRuns: [lensRun("success", "2026-08-03T17:42:33Z")] };
+  assert.equal(countFailedReviewRounds([PR648[0], PR648[1], passed], ROUND_NAMES), 0);
+  // A same-named check from another app cannot inflate the count.
+  const foreign = { ...PR648[2], checkRuns: [{ ...lensRun("failure", "2026-08-03T17:42:33Z"), app: { slug: "other" } }] };
+  assert.equal(countFailedReviewRounds([PR648[0], PR648[1], foreign], ROUND_NAMES), 0);
 });

--- a/scripts/agent/rounds.test.mjs
+++ b/scripts/agent/rounds.test.mjs
@@ -15,6 +15,7 @@ import {
   PAGE_AUTHOR_LOGINS,
   isPagedLatchComment,
   rerunPointFrom,
+  isRerunComment,
   RERUN_MARKER,
 } from "./rounds.mjs";
 
@@ -373,40 +374,84 @@ const rerunResult = (over = {}) => ({
 test("rerunPointFrom: the newest rerun wins; no rerun is null", () => {
   assert.equal(rerunPointFrom([]), null);
   assert.equal(rerunPointFrom([human("just a comment")]), null);
-  assert.equal(rerunPointFrom([rerunResult()]), "2026-08-04T09:30:00Z");
+  assert.equal(rerunPointFrom([rerunResult()]), "2026-08-04T09:30:00.000Z");
   assert.equal(
     rerunPointFrom([rerunResult(), rerunResult({ created_at: "2026-08-04T14:00:00Z" })]),
-    "2026-08-04T14:00:00Z",
+    "2026-08-04T14:00:00.000Z",
   );
   assert.equal(rerunPointFrom([rerunResult({ created_at: "nonsense" })]), null);
   for (const bad of [null, undefined, "x", 7]) assert.equal(rerunPointFrom(bad), null);
 });
 
 test("rerunPointFrom: a stranger cannot grant the loop a fresh budget", () => {
-  // Public repo, and this marker RESETS the fix-attempt cap — a body test alone
-  // would let any account hand the fixer unlimited attempts.
+  // Public repo, and this marker RESETS the fix-attempt cap.
   assert.equal(rerunPointFrom([rerunResult({ user: { login: "drive-by", type: "User" }, author_association: "NONE" })]), null);
   assert.equal(rerunPointFrom([rerunResult({ user: { login: "coderabbitai[bot]", type: "Bot" }, author_association: "CONTRIBUTOR" })]), null);
-  // The workflow's own bot, and a maintainer by hand, both may.
-  assert.equal(rerunPointFrom([rerunResult()]), "2026-08-04T09:30:00Z");
-  assert.equal(
-    rerunPointFrom([rerunResult({ user: { login: "a-maintainer", type: "User" }, author_association: "OWNER" })]),
-    "2026-08-04T09:30:00Z",
-  );
+  assert.equal(rerunPointFrom([rerunResult()]), "2026-08-04T09:30:00.000Z");
 });
 
-test("agent-rerun.yml writes the marker the guard reads", () => {
+test("agent-rerun.yml EMITS the marker — prose mentioning it does not count", () => {
   // The marker is a contract between a workflow and a module that cannot import
-  // it. A drifted copy does not error — the budget silently never resets, and the
-  // PR re-pages after one round exactly as it did before this existed.
+  // it. A drifted copy does not error — the budget silently never resets and the
+  // PR re-pages after one round, exactly as before this existed.
+  //
+  // The first version of this test was `includes(RERUN_MARKER)`, which the file's
+  // own EXPLANATORY COMMENT satisfied: deleting the emit left the test green. Same
+  // shape as the latch-write test below it, so prose lines are excluded and the
+  // remaining line must actually be emitting into a body.
   const rerunWorkflow = readFileSync(
     path.join(HERE, "..", "..", ".github", "workflows", "agent-rerun.yml"),
     "utf8",
   );
-  assert.ok(
-    rerunWorkflow.includes(RERUN_MARKER),
-    "agent-rerun.yml must emit RERUN_MARKER into its result comment",
+  const emits = rerunWorkflow
+    .split("\n")
+    .filter((l) => l.includes(RERUN_MARKER) && !/^\s*(#|\/\/)/.test(l));
+  assert.equal(emits.length, 1, "expected exactly one line that EMITS the rerun marker");
+  assert.match(emits[0], /`/, "the emitting line should be a template literal in the comment body");
+});
+
+test("isRerunComment: the marker must be the FIRST LINE, not merely present", () => {
+  // A substring test is re-armable by anyone who quotes the marker — this repo
+  // proved it when clearing #648 by hand re-armed the paged latch with the very
+  // sentence explaining its removal.
+  assert.equal(isRerunComment(rerunResult()), true);
+  assert.equal(
+    isRerunComment(rerunResult({ body: `a maintainer wrote ${RERUN_MARKER} in prose` })),
+    false,
   );
+  assert.equal(
+    isRerunComment(rerunResult({ body: `## Summary\n\n${RERUN_MARKER}\nreset` })),
+    false,
+  );
+});
+
+test("isRerunComment: LLM output under a trusted bot login cannot reset the cap", () => {
+  // agent-summarize.yml, agent-review-on-demand.yml and agent-review-reply.yml all
+  // publish model output verbatim under an allow-listed bot login. With a
+  // substring test, "a model emitted the marker" would have been enough.
+  const smuggled = rerunResult({
+    body: `## 🤖 Agent effort\n\nThe fixer noted: ${RERUN_MARKER} — see the guard.`,
+  });
+  assert.equal(isRerunComment(smuggled), false);
+  assert.equal(rerunPointFrom([smuggled]), null);
+});
+
+test("isRerunComment: BOT ONLY — author_association is not a strong enough credential", () => {
+  // `@claude rerun` gates on getCollaboratorPermissionLevel (real write access).
+  // Accepting author_association here would grant the same budget on a weaker
+  // credential — MEMBER is org membership, not repo write.
+  for (const assoc of ["OWNER", "MEMBER", "COLLABORATOR"]) {
+    assert.equal(
+      isRerunComment(rerunResult({ user: { login: "a-maintainer", type: "User" }, author_association: assoc })),
+      false,
+      assoc,
+    );
+  }
+  assert.equal(isRerunComment(rerunResult({ user: { login: "coderabbitai[bot]", type: "Bot" } })), false);
+  for (const login of PAGE_AUTHOR_LOGINS) {
+    assert.equal(isRerunComment(rerunResult({ user: { login, type: "Bot" } })), true, login);
+  }
+  for (const bad of [null, undefined, "x", 7, {}]) assert.equal(isRerunComment(bad), false);
 });
 
 // --- the round count, against #648's real shape ------------------------------
@@ -478,4 +523,25 @@ test("countFailedReviewRounds: merges and passing rounds still do not count", ()
   // A same-named check from another app cannot inflate the count.
   const foreign = { ...PR648[2], checkRuns: [{ ...lensRun("failure", "2026-08-03T17:42:33Z"), app: { slug: "other" } }] };
   assert.equal(countFailedReviewRounds([PR648[0], PR648[1], foreign], ROUND_NAMES), 0);
+});
+
+test("countFailedReviewRounds: a malformed `since` is ignored, not treated as zero", () => {
+  // A `since` of NaN must fall back to the first-verdict floor rather than
+  // silently becoming epoch 0 (which would count every commit) or Infinity.
+  for (const bad of ["nonsense", "", null, undefined, 7, {}]) {
+    assert.equal(countFailedReviewRounds(PR648, ROUND_NAMES, { since: bad }), 1, JSON.stringify(bad));
+  }
+});
+
+test("firstVerdictAt: a foreign app's same-named check cannot lower the floor", () => {
+  // Reached through countFailedReviewRounds. A lower floor widens the count, which
+  // is the wrong direction for a value that gates a cap.
+  const spoofed = [
+    { ...PR648[0], checkRuns: [{ name: "agent-review-correctness", app: { slug: "impostor" }, conclusion: "failure", completed_at: "2026-08-03T09:00:00Z" }] },
+    PR648[1],
+    PR648[2],
+  ];
+  // Without the app guard the floor would drop to 09:00 and 1d9e19dee (09:43) would
+  // count as an attempt; with it, the floor stays at the real first verdict.
+  assert.equal(countFailedReviewRounds(spoofed, ROUND_NAMES), 1);
 });


### PR DESCRIPTION
## Summary

`MAX_REVIEW_ROUNDS = 3` meant **one** actual fix attempt, not three. This makes it
mean three, and makes `@claude rerun` restore the budget so a hand-back is worth
something.

## The problem

The cap is documented as *"Failed **fix** rounds before review-round-guard.mjs pages
a human."* What it counted was:

> commits that are single-parent **and** carry a failing lens verdict

The predicate was named `isFixerCommit`, which is what made the miscount look
correct. It's literally `parents.length === 1` — "not a merge commit" — and its own
docstring says it's *"deliberately identity-independent"*. It cannot tell who pushed
a commit.

**The implement workflow pushes twice**: its work, then a self-review fix. On #648
the agent said so at 09:47 — *"Two blocking findings, both fixed in `1d9e19d`."*
Each commit drew its own panel round, and both counted as failed fix rounds before
the fix loop had run once.

Measured on both PRs whose data still exists:

| PR | counted as rounds | real fix attempts | pre-consumed |
|---|---|---|---|
| #648 | 3 | **1** | 2 |
| #605 | 5 | 3 | 2 |

So when #615 lowered the cap 5 → 3 — sound reasoning *for panel rounds* — the real
effect was to cut the fix loop from three attempts to **one**. #648 then paged
*"requested changes 3 times without converging"* after a single attempt. That
attempt had fixed the original nine findings and introduced four new ones in the
SSRF guard it added, which is an ordinary second round. There was no second round.

## The fix

**A commit committed before the panel first spoke cannot be a response to it.** The
discriminator is already in the data, needs no identity, and gives `failedRounds = 1`
on #648 where the old code gave 3.

`isFixerCommit` → `isSingleParentCommit`, because that is all it ever tested.

## `@claude rerun` now restores the budget

#650 landed this command while the above was in progress. It clears the paged latch,
drops `agent:blocked` and re-runs CI — but its own summary said the PR was *"still
bounded by the pipeline's round/attempt caps"*, which on a PR at the cap means one
panel round and an immediate re-page. **That is exactly what #648 did when I
un-stuck it by hand.**

It now writes a hidden `RERUN_MARKER` into its result comment, and the round guard
counts fix attempts only from the newest one.

**Author-checked**, for a sharper reason than the paged latch: the latch only ever
stops work, while this *grants* budget. On a public repo a body test alone would let
any account hand the fixer unlimited attempts. Only the workflow's own bot, or a
human with write access, may move the floor.

## Reworked mid-flight

I had built a separate `@claude retry` for the same job before #650 landed. **I
dropped it** — two verbs for un-sticking a PR would be worse than the gap. That also
removed an inline copy in the gate and the cross-implementation drift test that copy
required: `@claude rerun` deletes the paged comments outright, so there's no latch
left to out-date and no duplication to pin. `agent-review-panel.yml` is byte-identical
to `main` in this PR.

## Fail direction

**The count fails toward counting.** Over-counting pages a round early, which a rerun
undoes; under-counting means the cap never trips and the loop is unbounded,
recoverable only if someone notices. So a commit whose position cannot be established
counts, and with no verdict timestamps anywhere the floor is abandoned and every
failing commit counts — exactly the old behaviour. That is also why the PR #521
fixture still returns 3 unchanged.

## Verification

`pnpm verify:self` green (**11/11**) · **651 agent tests**.

- The counter tested against **#648's real shape** — three commits, real timestamps.
- A test asserts `agent-rerun.yml` emits `RERUN_MARKER`: it's a contract between a
  workflow and a module that cannot import it, and a drifted copy wouldn't error —
  the budget would silently never reset and the PR would re-page after one round,
  exactly as before.
- A latent crash fixed on the way: `(commits ?? []).filter` threw on a non-array, and
  a thrown guard is a dead fix job rather than a conservative one.

## What I'd push back on as a reviewer

**Is 3 still the right number?** It was chosen when it meant one real attempt. Three
genuine fix rounds at ~$12 of panel each is a materially bigger spend than what #615
measured, and nobody has data on how often a third attempt converges.

**The floor is a heuristic about time, not provenance.** A human who pushes to an
agent PR after the first verdict has their commit counted as a fix attempt. That's
arguably right — it did draw a round — but it isn't what the name says.

## Linked Issues

None — from the #648 post-mortem. Companion to #649 (concurrency race), which was the
other, independent half.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification checklist

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

## Risk Assessment

- **User-facing risk:** none. No product code.
- **Data/security risk:** one new trust surface — the rerun marker resets a safety
  cap, so it is author-checked to the same standard as the paged latch. The count
  itself only ever moves in the conservative direction when data is missing.
- **Rollback:** revert. The cap returns to counting panel rounds.

## Notes for Reviewers

- **AI assistance:** investigated and implemented with Claude Code (Opus 5) in an
  interactive session and reviewed by me.
- **The rename is the interesting part of the diff.** `isFixerCommit` reading as
  "the fixer pushed this" is why a counter that never counted fix attempts survived
  review for as long as it did.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Review-round limits now reflect actual fixer attempts, excluding unrelated changes and merge activity.
  - `@claude rerun` restarts review-round tracking from the rerun point.
  - Rerun requests require trusted maintainer authentication, reducing spoofing risk.
  - Stall and rebuttal-limit alerts are delayed for one attempt after a rerun.
  - CI-fix attempt limits remain cumulative across previous failed runs.
  - Human approval requirements remain unchanged.

- **Documentation**
  - Added guidance and verification details for review-round counting, reruns, fallback behavior, and validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->