### PR TITLE
Remove cross-sample agreement from the hunt gate

### DIFF
--- a/scripts/agent/hunt-gate.mjs
+++ b/scripts/agent/hunt-gate.mjs
@@ -29,11 +29,18 @@
 //   keepUnrefuted         drops only on a refute     a crashed verifier reports
 //
 // The replacements below (`huntSeverity`, `coerceCandidates`, `dedupeCandidates`,
-// `intersectSamples`, `isFilingVerdict`) are the same five ideas with the failure
-// direction flipped. (The panel's null-verdict behaviour now lives in
+// `isFilingVerdict`) are those ideas with the failure direction flipped. There was a
+// fifth, `intersectSamples`, inverting `unionSamples` by keeping only what >=2
+// samples agreed on. It is gone: once the probe budget stopped starving samples they
+// explored deeply enough to diverge, and it discarded 6 of 6 reproducing findings
+// over citations one line apart. Precision now rests on replay and the panel.
+//
+// (The panel's null-verdict behaviour now lives in
 // `annotateFindings`/`keepUnrefuted`, which drop a finding only on a concrete
-// refutation — so a verdict that never arrived still KEEPS it there.) They are NOT thin wrappers — do not "simplify" them back
-// into their panel counterparts.
+// refutation — so a verdict that never arrived still KEEPS it there.)
+//
+// The survivors are NOT thin wrappers — do not "simplify" them back into their
+// panel counterparts.
 //
 // What IS safely shared, because it is polarity-neutral: `CITATION` from
 // citation.mjs (the repo's own shared home for it), `globToRegExp` from
@@ -280,70 +287,6 @@ export function sameDefect(locsA, locsB) {
   return false;
 }
 
-/**
- * INTERSECT independent explorer samples: keep only candidates that ≥2 samples
- * found. The inverse of `unionSamples`, and the cheapest precision lever here.
- *
- * The panel unions because a bug any sample spots is worth blocking on. Hunting
- * inverts that: a candidate only one sample produced is exactly the profile of a
- * one-off confabulation, and dropping it costs nothing. Fewer than 2 successful
- * samples therefore yields NOTHING — with one sample there is no agreement to
- * measure, and "no agreement" must not read as "agreed".
- *
- * `locationsOf` maps a candidate to its in-scope code-location SET (see
- * `codeLocations`) — NOT a fingerprint. Comparison is by location overlap, not
- * by prose, so two samples describing the same defect in different words still
- * agree.
- */
-export function intersectSamples(sampleCandidateLists, locationsOf, { minAgreement = 2 } = {}) {
-  const lists = (Array.isArray(sampleCandidateLists) ? sampleCandidateLists : []).filter(Array.isArray);
-  const dropped = [];
-  if (lists.length < minAgreement) {
-    // Report every candidate that is being discarded for lack of a second
-    // opinion. Returning a bare [] here is what made the first live run
-    // unexplainable: the funnel said "9 proposed → 0 agreed" with an empty drop
-    // table, which reads identically to "the explorer found nothing".
-    for (const list of lists) {
-      for (const c of list) {
-        dropped.push({ candidate: c, why: `only ${lists.length} sample(s) succeeded; need ${minAgreement} to compare` });
-      }
-    }
-    return { kept: [], dropped };
-  }
-  // `locationsOf` returns the candidate's in-scope code-location SET (see
-  // codeLocations). Matching is greedy clustering by overlap: take an unclaimed
-  // candidate as the anchor, then claim at most one overlapping candidate per
-  // OTHER sample. One-per-sample is what stops a sample that raised three
-  // near-identical candidates from satisfying the threshold by itself.
-  const pools = lists.map((list) => list.map((c) => ({ c, locs: locationsOf(c), taken: false })));
-  const kept = [];
-  for (let i = 0; i < pools.length; i++) {
-    for (const anchor of pools[i]) {
-      if (anchor.taken) continue;
-      anchor.taken = true;
-      if (!anchor.locs || anchor.locs.size === 0) {
-        dropped.push({ candidate: anchor.c, why: "no in-scope code citation that locates a line — cannot be matched across samples" });
-        continue;
-      }
-      let agreeing = 1;
-      for (let j = i + 1; j < pools.length; j++) {
-        const match = pools[j].find((o) => !o.taken && o.locs && sameDefect(anchor.locs, o.locs));
-        if (match) {
-          match.taken = true;
-          agreeing++;
-        }
-      }
-      if (agreeing >= minAgreement) kept.push(anchor.c);
-      else {
-        dropped.push({
-          candidate: anchor.c,
-          why: `only ${agreeing} of ${lists.length} samples cited an overlapping location (need ${minAgreement})`,
-        });
-      }
-    }
-  }
-  return { kept, dropped };
-}
 
 // --- citations --------------------------------------------------------------
 

--- a/scripts/agent/hunt-gate.test.mjs
+++ b/scripts/agent/hunt-gate.test.mjs
@@ -6,7 +6,6 @@ import {
   huntSeverity,
   coerceCandidates,
   dedupeCandidates,
-  intersectSamples,
   codeLocations,
   citationPath,
   citationInScope,
@@ -263,63 +262,6 @@ test("dedupeCandidates: keeps the first, never escalates severity", () => {
   assert.equal(out[0].severity, "nit", "the first wins; severity is never merged upward");
   // An unusable fingerprint drops the candidate rather than grouping it.
   assert.deepEqual(dedupeCandidates([{ fp: "" }, { fp: null }], fp), []);
-});
-
-test("intersectSamples: requires OVERLAPPING evidence, the inverse of unionSamples", () => {
-  // The matcher now receives each candidate's in-scope code-location SET.
-  const locs = (c) => new Set(c.locs);
-  const s1 = [{ locs: ["a.ts:1"], title: "x" }, { locs: ["b.ts:2"], title: "y" }];
-  const s2 = [{ locs: ["a.ts:1"], title: "x-again" }, { locs: ["c.ts:3"], title: "z" }];
-  const out = intersectSamples([s1, s2], locs);
-  assert.deepEqual(out.kept.map((c) => c.title), ["x"], "only the overlapping candidate survives");
-
-  // One sample is NOT agreement — unionSamples would return everything here.
-  assert.deepEqual(intersectSamples([s1], locs).kept, []);
-  assert.deepEqual(intersectSamples([], locs).kept, []);
-  assert.deepEqual(intersectSamples(null, locs).kept, []);
-});
-
-test("REGRESSION: agreement is OVERLAP, not equality — the two-live-run fix", () => {
-  const locs = (c) => new Set(c.locs);
-  // Real shape from run 2: same defect, overlapping but NOT identical evidence,
-  // listed in different order. Hashing any identity of these missed the match.
-  const a = { title: "exit 2 never produced", locs: ["packages/cli/src/output/formatter.ts:46", "packages/cli/src/output/formatter.ts:39", "packages/cli/src/commands/docs.ts:84"] };
-  const b = { title: "documented exit code 2 never set", locs: ["packages/cli/src/output/formatter.ts:39", "packages/cli/src/output/formatter.ts:46"] };
-  assert.equal(intersectSamples([[a], [b]], locs).kept.length, 1, "overlapping evidence = same defect");
-
-  // ...but a shared FILE is deliberately NOT enough. formatter.ts really does hold
-  // two distinct defects; keying on file alone would hide one of them.
-  const envelope = { title: "envelope omits `command`", locs: ["packages/cli/src/output/formatter.ts:43"] };
-  assert.equal(intersectSamples([[a], [envelope]], locs).kept.length, 0, "same file, different lines = different defects");
-});
-
-test("intersectSamples: explains every drop instead of discarding silently", () => {
-  // Run 1 reported "9 proposed -> 0 agreed" with an EMPTY drop table, which reads
-  // identically to "the explorer found nothing". A funnel that cannot explain its
-  // own biggest gap is useless for calibration.
-  const locs = (c) => new Set(c.locs);
-  const out = intersectSamples([[{ locs: ["a.ts:1"], title: "solo" }], [{ locs: ["z.ts:9"], title: "other" }]], locs);
-  assert.deepEqual(out.kept, []);
-  assert.equal(out.dropped.length, 2, "both unmatched candidates accounted for");
-  for (const d of out.dropped) {
-    assert.match(d.why, /only 1 of 2 samples cited an overlapping location/);
-    assert.ok(d.candidate, "the candidate is carried so the report can name it");
-  }
-
-  const thin = intersectSamples([[{ locs: ["a.ts:1"], title: "a" }]], locs);
-  assert.equal(thin.dropped.length, 1);
-  assert.match(thin.dropped[0].why, /only 1 sample\(s\) succeeded/);
-
-  const unlocatable = intersectSamples([[{ locs: [], title: "vague" }], [{ locs: [], title: "vague2" }]], locs);
-  assert.equal(unlocatable.kept.length, 0);
-  assert.match(unlocatable.dropped[0].why, /no in-scope code citation/);
-});
-
-test("intersectSamples: one sample cannot satisfy the threshold by itself", () => {
-  // Three near-identical candidates from ONE sample must not look like agreement.
-  const locs = (c) => new Set(c.locs);
-  const dupes = [{ locs: ["a.ts:1"], title: "p" }, { locs: ["a.ts:1"], title: "q" }, { locs: ["a.ts:1"], title: "r" }];
-  assert.equal(intersectSamples([dupes, [{ locs: ["z.ts:1"] }]], locs).kept.length, 0);
 });
 
 test("codeLocations: in-scope located citations only", () => {

--- a/scripts/agent/hunt.mjs
+++ b/scripts/agent/hunt.mjs
@@ -7,12 +7,11 @@
 // The pipeline, and which side of the trust boundary each stage sits on:
 //
 //   explore   MODEL   proposes candidates + probe plans (argv, never shell)
-//   intersect script  keeps only what >=2 independent samples agreed on
 //   coerce    script  drops structurally unusable candidates
 //   novelty   script  skips what a previous run already resolved
 //   probe     script  executes the argv in a clean room
 //   replay    script  re-runs 3x in fresh scratches; must agree AND match
-//   verify    MODEL   N verifiers per candidate, each naming a ground
+//   verify    MODEL   N verifiers per candidate, each naming a ground (capped)
 //   gate      script  isFilingVerdict — the ONLY place "report it" is decided
 //   report    script  renders, redacting secrets first
 //
@@ -40,7 +39,6 @@ import {
   dropReason,
   coerceCandidates,
   dedupeCandidates,
-  intersectSamples,
   codeLocations,
 } from "./hunt-gate.mjs";
 import {
@@ -75,6 +73,16 @@ import {
 } from "./hunt-probe.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * How many reproduced candidates one charter may send to the verifier panel.
+ *
+ * This is the cost bound that replaced cross-sample agreement. Agreement used to
+ * gate verification implicitly — on the run that retired it, zero of six reproduced
+ * candidates were admitted, so verification was free. Without a bound the same run
+ * would have opened twelve verifier sessions.
+ */
+const DEFAULT_MAX_VERIFIED = 4;
 
 // The read grant. `ask.mjs` validates this against its own allow-list and refuses
 // anything else, so the hunter still cannot hold a shell.
@@ -121,7 +129,9 @@ export function validateCharter(c) {
     problems.push("missing reportableSeverities[]");
   }
   if (Number(c.verifiers) < 2) problems.push("verifiers must be >= 2");
-  if (Number(c.samples) < 2) problems.push("samples must be >= 2 (intersection needs two to agree)");
+  // Still >= 2, but for COVERAGE rather than agreement: two independent sessions
+  // explore different parts of the surface. Nothing intersects them any more.
+  if (Number(c.samples) < 2) problems.push("samples must be >= 2 (independent sessions cover more surface)");
   return problems;
 }
 
@@ -473,21 +483,22 @@ export function renderReport({ runId, headSha, charters, reported, dropped, stat
       );
     }
   }
-  // The agreement measurement, SHOWN rather than merely counted. Each of these
-  // reproduced deterministically in a clean room and was dropped only because a
-  // single sample proposed it. Reading a few is how you decide whether
-  // cross-sample agreement buys precision or costs real defects — a funnel count
-  // cannot answer that. A persistently empty section means agreement is filtering
-  // nothing that replay would not have filtered for free.
-  const solo = dropped.filter((d) => d.agreement === "solo" && d.reproduced);
+  // Candidates the verification CAP truncated, SHOWN rather than merely counted.
+  //
+  // This section is the successor to "Reproduced but not corroborated", which
+  // existed to make cross-sample agreement's cost readable and did exactly that
+  // before agreement was removed. The same argument applies to the cap: a bound on
+  // how much gets verified is only honest if what it dropped can be read, or a
+  // truncated run is indistinguishable from a thorough one.
+  const solo = dropped.filter((d) => d.capped && d.reproduced);
   if (solo.length > 0) {
     lines.push(
-      `## Reproduced but not corroborated (${solo.length})`,
+      `## Reproduced but not verified — cap reached (${solo.length})`,
       "",
-      "Each REPRODUCED deterministically and was dropped only for lacking a second",
-      "sample. Judge them by hand: if most are real, cross-sample agreement is too",
-      "strict. They are deliberately absent from the ledger, so they stay eligible",
-      "for a later run.",
+      "Each REPRODUCED deterministically and was dropped only because this charter's",
+      "verification cap was already spent. Judge them by hand, and raise",
+      "`charter.maxVerified` if the tail is consistently worth the tokens. They are",
+      "deliberately absent from the ledger, so they stay eligible for a later run.",
       "",
     );
     for (const d of solo) {
@@ -744,12 +755,19 @@ async function cmdRun(args) {
   // that ran two commands and reported nothing is a very different failure from
   // one that ran forty, and before this the funnel could not tell them apart.
   //
-  // The rest of the funnel order matches the pipeline order below. `soloReproduced`
-  // is not a stage — it is the MEASUREMENT: candidates only one sample proposed
-  // that a trusted replay nevertheless reproduced deterministically. If it stays
-  // high across runs, cross-sample agreement is discarding genuine defects and the
-  // threshold needs revisiting; if it stays at zero, agreement is doing replay's
-  // job for free and belongs where it is.
+  // The rest of the funnel order matches the pipeline order below.
+  //
+  // `corroborated` and `soloReproduced` are gone with cross-sample agreement. They
+  // measured how much agreement kept and how much it cost, and that measurement did
+  // its job: it read 0 while samples were starving on an unenforced probe budget,
+  // then 6-of-6 once they could probe properly, which is what retired the stage.
+  //
+  // Two measurements replace them, and `refutedAfterReplay` is now THE precision
+  // signal. It counts candidates that reproduced deterministically and were still
+  // refused by the verifier panel — the work agreement used to share. Rising across
+  // runs means the explorer is proposing more plausible-but-wrong defects, not that
+  // the verifiers got stricter. `cappedUnverified` is the recall cost of the cost
+  // bound, kept visible so a truncated run cannot read as a thorough one.
   const stats = {
     probesRun: 0,
     probeRefusals: 0,
@@ -757,8 +775,8 @@ async function cmdRun(args) {
     unique: 0,
     novel: 0,
     reproduced: 0,
-    corroborated: 0,
-    soloReproduced: 0,
+    refutedAfterReplay: 0,
+    cappedUnverified: 0,
     reported: 0,
   };
   const ledgerAdds = [];
@@ -822,8 +840,9 @@ async function cmdRun(args) {
     // They are independent by construction — that independence is the whole point
     // of intersecting them — so running them serially doubles wall-clock for no
     // benefit. Each is individually caught: a failed sample contributes nothing
-    // rather than aborting the charter, and `intersectSamples` then returns []
-    // because fewer than 2 succeeded, which is the correct fail-quiet outcome.
+    // rather than aborting the charter, and the surviving samples still contribute
+    // their candidates — no longer fatal to the charter now that nothing intersects
+    // them, which is what made ONE transient API error cost a whole charter before.
     // `--samples N` overrides the charter default for every charter this run;
     // absent, each charter uses its own. Floored at 2 either way — intersection
     // needs two samples to have any agreement to measure.
@@ -898,25 +917,38 @@ async function cmdRun(args) {
       ) + "\n",
     );
 
-    // Agreement is COMPUTED here but APPLIED after replay.
+    // CROSS-SAMPLE AGREEMENT IS GONE. `intersectSamples` is not called.
     //
-    // Replay costs no tokens — trusted code re-running recorded argv in a clean
-    // room — so filtering on agreement first threw away, for free, the only
-    // evidence of whether a single-sample candidate was real at all. The funnel
-    // could not answer "is 2-of-3 too strict?" because the candidates that would
-    // answer it were discarded before anything ran them.
+    // It was the cheapest precision lever here for as long as its own measurement
+    // said so: `soloReproduced` sat at 0, meaning agreement discarded nothing real.
+    // Then the probe-budget fix (#656) let samples spend their full budget instead
+    // of starving on read-only exploration, and the next run measured
+    // `soloReproduced: 6` out of 6 — agreement threw away EVERY reproducing finding.
     //
-    // The REPORTED set is unchanged by this reorder: agreement still gates
-    // verification, just later. What changes is that every agreement drop now
-    // carries whether the defect reproduced, and that costs only probe wall-clock.
-    const { kept: agreedRaw, dropped: notAgreed } = intersectSamples(samples, locsOf);
-    const agreedKeys = new Set(agreedRaw.map((c) => keyOf(c)).filter((k) => k !== ""));
-    const soloWhy = new Map();
-    for (const d of notAgreed) {
-      const k = keyOf(d.candidate);
-      if (k !== "") soloWhy.set(k, d.why);
-    }
-
+    // The cause is that agreement's identity was line-level citation overlap inside
+    // `codeScope`. Deeper exploration makes samples diverge, and two samples that
+    // found the SAME defect cited it a line or two apart:
+    //
+    //   envelope defect   sample A `formatter.ts:43`      sample B `formatter.ts:44`
+    //   --dry-run defect  sample A `docs.ts:75,116`       sample B `docs.ts:70,113`
+    //
+    // Both pairs also shared a DOC citation (`cli.md:707`, `README.md:109`), but
+    // `codeLocations` filters to `codeScope`, which excludes docs paths — so the one
+    // thing they agreed on could not count. Three real defects came out of that run
+    // (#659, #660, #661), all hand-verified, none reported.
+    //
+    // Widening the identity to file level was the alternative. It was rejected
+    // because `formatter.ts` demonstrably holds several distinct defects, so file
+    // level would collapse them and hide all but the first — the same reasoning that
+    // chose line level originally. Rather than trade one silent loss for another,
+    // precision now rests on the filters that measure the defect itself: journal-ref
+    // resolution, a deterministic 3x replay, and an adversarial verifier panel.
+    //
+    // What replaces agreement as the COST bound is `maxVerifiedPerCharter` below.
+    // Agreement was quietly gating how many candidates reached the two-verifier
+    // stage, and removing it without a cap would let one noisy charter spend
+    // unboundedly.
+    //
     // Probe the UNION of everything any sample proposed, deduped by defect.
     //
     // Surface unlocatable candidates FIRST. `dedupeCandidates` silently skips any
@@ -933,6 +965,11 @@ async function cmdRun(args) {
     }
     const unique = dedupeCandidates(flatProposals, keyOf);
     stats.unique += unique.length;
+
+    // Per-charter, not per-run: one charter must not be able to consume another's
+    // verification budget just by running first.
+    const maxVerified = Number.isInteger(charter.maxVerified) ? charter.maxVerified : DEFAULT_MAX_VERIFIED;
+    let verifiedThisCharter = 0;
 
     const changedSince = makeChangedSince(repo, charter.codeScope);
     for (const cand of unique) {
@@ -985,37 +1022,38 @@ async function cmdRun(args) {
       const reproduced = rep.status === "reproduced" && rep.deterministic;
       if (reproduced) stats.reproduced++;
 
-      // ── Agreement, applied here instead of before replay ──
-      // A defect only one sample proposed is still dropped; the difference is we
-      // now know whether it was real. Deliberately NOT written to the ledger: a
-      // candidate no verifier ever judged must stay eligible next run, the same
-      // trap the unjudged-verdict case avoids below. Recording it as "seen" would
-      // permanently hide a defect this run declined to even assess.
-      if (!agreedKeys.has(dk)) {
-        const base = soloWhy.get(dk) ?? "proposed by only one sample";
-        dropped.push({
-          title: cand.title,
-          why: `${base} — replay: ${rep.status}${rep.deterministic ? "" : " (nondeterministic)"}`,
-          agreement: "solo",
-          reproduced,
-          // Carried so the report can SHOW a reproduced-but-solo candidate rather
-          // than only counting it: a count cannot tell you whether agreement is
-          // discarding real defects, but reading four of them can. `secrets` rides
-          // along because this puts probe-derived text through the report's egress
-          // boundary, which previously only saw REPORTED candidates.
-          claimed: reproduced ? { ...cand } : undefined,
-          secrets: reproduced ? [context.cfg.apiKey].filter(Boolean) : undefined,
-        });
-        if (reproduced) stats.soloReproduced++;
-        continue;
-      }
-
       if (!reproduced) {
-        dropped.push({ title: cand.title, why: `replay: ${rep.status}`, agreement: "corroborated", reproduced: false });
+        dropped.push({ title: cand.title, why: `replay: ${rep.status}`, reproduced: false });
         ledgerAdds.push({ fp: dk, keyVersion: LEDGER_KEY_VERSION, probeFp: fp, charterId: charter.id, verdict: "dropped", dropReason: rep.status, runId, sha: headSha });
         continue;
       }
-      stats.corroborated++;
+
+      // The cost bound that replaces agreement.
+      //
+      // Agreement was silently gating how many candidates reached the two-verifier
+      // stage — on the run that motivated this change it admitted zero of six, so
+      // verification cost nothing. Without a cap, the same run would have opened
+      // twelve verifier sessions. Reproduced candidates are processed in dedupe
+      // order, so this bites the tail rather than a chosen subset.
+      //
+      // NOT written to the ledger, for the same reason an unjudged verdict is not:
+      // a candidate no verifier ever assessed has to stay eligible next run, or the
+      // cap would permanently hide whatever it truncated.
+      if (verifiedThisCharter >= maxVerified) {
+        dropped.push({
+          title: cand.title,
+          why: `verification cap reached (${maxVerified} per charter) — NOT recorded, will be retried next run`,
+          capped: true,
+          reproduced: true,
+          // Carried so the report can SHOW what the cap dropped rather than only
+          // counting it. A silent truncation reads as "we checked everything".
+          claimed: { ...cand },
+          secrets: [context.cfg.apiKey].filter(Boolean),
+        });
+        stats.cappedUnverified++;
+        continue;
+      }
+      verifiedThisCharter++;
 
       // Verify with N independent verifiers, then let the trusted gate decide.
       // Verifiers run CONCURRENTLY. They must be INDEPENDENT to be worth having —
@@ -1054,6 +1092,13 @@ async function cmdRun(args) {
       } else {
         const why = dropReason(record, verdicts, charter);
         dropped.push({ title: cand.title, why: unjudged ? `${why} — NOT recorded, will be retried next run` : why });
+        // THE precision signal, now that agreement is gone. This candidate
+        // reproduced deterministically in a clean room and the panel still said no,
+        // which is exactly the judgement agreement used to help make. An `unjudged`
+        // drop is excluded: a verifier that errored produced no opinion, and
+        // counting infrastructure failure as a refutation would make the signal
+        // read worse the flakier the API got.
+        if (!unjudged) stats.refutedAfterReplay++;
         if (!unjudged) {
           ledgerAdds.push({ fp: dk, keyVersion: LEDGER_KEY_VERSION, probeFp: fp, charterId: charter.id, verdict: "dropped", dropReason: why, runId, sha: headSha });
         }
@@ -1088,8 +1133,9 @@ async function cmdRun(args) {
   writeFileSync(ledgerFile, serializeSeenLedger([...seen, ...ledgerAdds]));
   process.stdout.write(
     `hunt: ${stats.proposed} proposed → ${stats.unique} unique → ${stats.novel} novel → ` +
-      `${stats.reproduced} reproduced → ${stats.corroborated} corroborated → ${stats.reported} reported\n` +
-      `      ${stats.soloReproduced} reproduced but proposed by only ONE sample (agreement cost)\n` +
+      `${stats.reproduced} reproduced → ${stats.reported} reported\n` +
+      `      ${stats.refutedAfterReplay} reproduced but refuted by the panel, ` +
+      `${stats.cappedUnverified} reproduced but never verified (cap)\n` +
       `hunt: report written to ${path.join(outDir, "report.md")}\n`,
   );
 }

--- a/scripts/agent/hunt.test.mjs
+++ b/scripts/agent/hunt.test.mjs
@@ -221,22 +221,22 @@ test("renderReport: a pipe in a title cannot break the drop table", () => {
 
 // --- the agreement measurement -----------------------------------------------
 
-test("renderReport: shows reproduced-but-solo candidates, not just a count", () => {
-  // The whole point of applying agreement AFTER replay. A count cannot tell you
-  // whether 2-of-3 agreement is discarding real defects; four readable candidates
-  // can. If this section ever silently stops rendering, the measurement is gone
-  // and the funnel looks like agreement costs nothing.
+test("renderReport: shows cap-truncated candidates, not just a count", () => {
+  // A bound on how much gets verified is only honest if what it dropped can be
+  // READ. If this section ever silently stops rendering, a truncated run becomes
+  // indistinguishable from a thorough one. (Successor to the agreement-cost
+  // section this replaced when cross-sample agreement was removed.)
   const md = renderReport({
     runId: "r1",
     headSha: "abc1234",
     charters: ["contract"],
     reported: [],
-    stats: { proposed: 9, unique: 7, novel: 7, reproduced: 5, corroborated: 2, soloReproduced: 3, reported: 0 },
+    stats: { proposed: 9, unique: 7, novel: 7, reproduced: 5, refutedAfterReplay: 2, cappedUnverified: 3, reported: 0 },
     dropped: [
       {
         title: "--format yaml prints undefined",
-        why: "proposed by only one sample — replay: reproduced",
-        agreement: "solo",
+        why: "verification cap reached (4 per charter) — NOT recorded, will be retried next run",
+        capped: true,
         reproduced: true,
         claimed: {
           oracle: "contract",
@@ -247,23 +247,24 @@ test("renderReport: shows reproduced-but-solo candidates, not just a count", () 
           docCitation: "docs/design/cli.md:714",
         },
       },
-      { title: "flaky one", why: "proposed by only one sample — replay: diverged (nondeterministic)", agreement: "solo", reproduced: false },
-      { title: "corroborated but broken", why: "replay: not-reproduced", agreement: "corroborated", reproduced: false },
+      { title: "flaky one", why: "replay: diverged (nondeterministic)", capped: true, reproduced: false },
+      { title: "panel said no", why: "verifier 0 refuted the candidate", reproduced: false },
     ],
   });
 
-  assert.match(md, /## Reproduced but not corroborated \(1\)/, "must show the count of judgeable candidates");
+  assert.match(md, /## Reproduced but not verified — cap reached \(1\)/, "must show the count of judgeable candidates");
   assert.match(md, /--format yaml prints undefined/);
   assert.match(md, /valid YAML on stdout/, "expected/observed are what makes it judgeable by hand");
   assert.match(md, /packages\/cli\/src\/output\/formatter\.ts:37/);
   assert.match(md, /docs\/design\/cli\.md:714/);
   // A solo candidate that did NOT reproduce is not judgeable and must not appear
   // in this section — it would dilute exactly the signal being measured.
-  assert.equal(/### flaky one/.test(md), false, "non-reproduced solo must not be promoted");
-  assert.equal(/### corroborated but broken/.test(md), false, "corroborated drops belong in the plain table");
+  assert.equal(/### flaky one/.test(md), false, "a capped candidate that did not reproduce is not judgeable");
+  assert.equal(/### panel said no/.test(md), false, "panel refutations belong in the plain table, not here");
   // ...but everything still appears in the full drop table.
   assert.match(md, /## Dropped \(3\)/);
-  assert.match(md, /\| soloReproduced \| 3 \|/, "the funnel must carry the measurement too");
+  assert.match(md, /\| cappedUnverified \| 3 \|/, "the funnel must carry the measurement too");
+  assert.match(md, /\| refutedAfterReplay \| 2 \|/, "and the precision signal that replaced agreement");
 });
 
 test("renderReport: redacts secrets carried by DROPPED candidates", () => {
@@ -277,12 +278,12 @@ test("renderReport: redacts secrets carried by DROPPED candidates", () => {
     headSha: "abc1234",
     charters: ["contract"],
     reported: [],
-    stats: { proposed: 1, soloReproduced: 1 },
+    stats: { proposed: 1, cappedUnverified: 1 },
     dropped: [
       {
         title: "leaky",
-        why: "proposed by only one sample — replay: reproduced",
-        agreement: "solo",
+        why: "verification cap reached (4 per charter)",
+        capped: true,
         reproduced: true,
         secrets: ["s3cr3t-workspace-key"],
         claimed: { oracle: "contract", severity: "major", expected: "ok", observed: "sent s3cr3t-workspace-key upstream", citations: [] },


### PR DESCRIPTION
## Summary

Cross-sample agreement kept only candidates that ≥2 independent explorer samples found, matched by overlapping `file:line` citations inside `codeScope`. It was the cheapest precision lever here for exactly as long as its own measurement said so — and that measurement has now said the opposite.

## What changed the answer

`soloReproduced` existed to answer *"is 2-of-3 too strict?"*. It read **0** for several runs — agreement discarded nothing real. But those runs were measuring a **starved** harness: the probe budget's clock started before the session opened, so samples burned their allowance on read-only exploration and probed shallowly. #656 fixed that.

The next run probed **137 times instead of 27**, and measured `soloReproduced: 6` **out of 6**. Agreement threw away every reproducing finding.

```
BEFORE #656   2 proposed →  1 unique → 1 novel → 0 reproduced → 0 reported   $4.24
AFTER  #656  11 proposed →  6 unique → 6 novel → 6 reproduced → 0 reported   $9.07
                                                  ^^^^^^^^^^^^ all 6 lost to agreement
```

## Why it failed

Deeper exploration makes samples diverge, and two samples that found the **same** defect cited it a line or two apart:

| defect | sample A | sample B |
|---|---|---|
| envelope shape | `formatter.ts:43` | `formatter.ts:44` |
| `--dry-run` ignored | `docs.ts:75,116` | `docs.ts:70,113` |

Both pairs *also* shared a doc citation (`cli.md:707`, `README.md:109`) — but `codeLocations` filters to `codeScope`, which excludes docs paths, so the one thing they agreed on could not count.

Three real defects came out of that run, hand-verified and filed as **#659**, **#660**, **#661**. None was reported.

## Why not just widen the identity to file level

That is precisely what the deleted `REGRESSION: agreement is OVERLAP, not equality` test argued against, and its reasoning still holds: `formatter.ts` genuinely holds two distinct defects — the exit-code bug at `:39/:46` and the envelope bug at `:43` — so file-level matching would collapse them and hide one.

The trade is real in **both** directions. Rather than swap one silent loss for another, precision now rests on the filters that measure the defect itself rather than the wording of its citation: journal-ref resolution, a deterministic 3× replay, and an adversarial verifier panel that defaults to `refuted`.

This also matches the UI hunter's design, which never had agreement for the same predicted reason.

## `maxVerified` replaces it as the cost bound

Agreement was quietly gating how many candidates reached the two-verifier stage — it admitted **zero of six** on that run, so verification was free. Removing it without a cap would have opened twelve verifier sessions.

Default 4, per charter (not per run, so one charter cannot eat another's budget). **What the cap drops is shown in the report, not just counted** — same reason the agreement-cost section existed: a truncated run must not read as a thorough one.

## Funnel keys

`corroborated` and `soloReproduced` are gone with the stage. Two replace them:

- **`refutedAfterReplay`** is now *the* precision signal — reproduced deterministically and still refused by the panel, which is the judgement agreement used to share. Excludes `unjudged` drops, or the signal would read worse the flakier the API got.
- **`cappedUnverified`** is the recall cost of the cap.

## Incidental fix

One transient API error used to cost a **whole charter**: a failed sample left fewer than 2 for intersection, so the charter reported nothing regardless of what the survivors found. That happened on the run before last, and it is why I originally mis-attributed that run's emptiness.

## Not covered by a test

The cap counter is inline in `cmdRun`, which is not unit-testable without extracting it. It is observable through `cappedUnverified` and the report section, both of which **are** tested.

`intersectSamples` and its four tests are **deleted** rather than left unused — dead code with passing tests is worse than no code, because the tests imply something is exercised. The reasoning is preserved in the commit message and in git history.

## Test plan

- `cd scripts/agent && node --test *.test.mjs` — 646 pass
- `pnpm verify:self` — 11/11 lanes
- Report rendering covered for both new funnel keys and the cap section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Candidate review now includes reproduced results held back by verification limits, along with their supporting evidence.
  * Reports clearly distinguish verified results, verifier refutations, and candidates awaiting review.
  * Processing can continue when an individual sample fails, provided other samples succeed.
  * Validation messages and pipeline output now better reflect the updated review process.

* **Bug Fixes**
  * Improved reporting of excluded candidates and verification outcomes.
  * Preserved relevant evidence while applying verification limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->