### PR TITLE
Add a copy-pasteable AI-agent fix prompt to on-demand review

### DIFF
--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -418,6 +418,19 @@ jobs:
           # carries the pulls read too. Read-only — no write to the PR itself.
           permission-pull-requests: read
 
+      # Build the collapsed "Prompt for AI Agents" section from the blocking
+      # (critical/major) findings in each lens's verdict.json. Fail-safe by design
+      # (writes an empty file when nothing blocks or the panel never ran), runs the
+      # TRUSTED main copy, and continue-on-error so it can never fail the review.
+      # The comment step below reads /tmp/ai-prompt.md best-effort.
+      - name: Build the AI-agent prompt section
+        if: always()
+        continue-on-error: true
+        run: >-
+          node .trusted/scripts/agent/ai-prompt.mjs
+          --review-dir .agent-review
+          --out /tmp/ai-prompt.md
+
       # EDIT the "running" placeholder authorize posted (comment_id) into the
       # findings — aggregate panel.json + each lens's summary.md. No check runs;
       # advisory only. Fails closed to a note if the panel crashed. If the
@@ -493,13 +506,24 @@ jobs:
                   + ' · novelty: ' + lanes('backlog') + ' relocated, ' + lanes('unknownOrigin') + ' unplaceable</sub>';
               }
             } catch { /* stats absent (crash before write) — say nothing rather than guess */ }
+            // Collapsed, copy-pasteable "Prompt for AI Agents" fold — the blocking
+            // findings rendered as a fix instruction (built by the trusted
+            // ai-prompt.mjs step above). Empty when nothing blocks or the panel
+            // never ran; best-effort read so a missing file never strands the
+            // comment. It rides ABOVE `note` so the one-line disclaimer stays last,
+            // and is re-appended on truncation because it is the actionable part.
+            let promptSection = '';
+            try {
+              const p = fs.readFileSync('/tmp/ai-prompt.md', 'utf8').trim();
+              if (p) promptSection = `\n\n${p}`;
+            } catch { /* no prompt file (nothing blocked, or panel crashed) */ }
             const note = '\n\n_Advisory only — this on-demand review records no status checks and does not gate merge; a human approval is still required._';
-            let body = `${marker}\n${header}\n\n${bodies.join('\n\n')}${tally}${note}`;
+            let body = `${marker}\n${header}\n\n${bodies.join('\n\n')}${tally}${promptSection}${note}`;
             // GitHub comment hard limit is 65536 chars; trim from the tail if huge.
-            // `tally` is re-appended after the cut, like `note`: a body long
-            // enough to truncate is one with many findings, which is exactly when
-            // "were these actually verified?" matters most.
-            if (body.length > 65000) body = body.slice(0, 64900) + '\n\n… _(truncated)_' + tally + note;
+            // `tally` + `promptSection` are re-appended after the cut, like `note`:
+            // a body long enough to truncate is one with many findings, which is
+            // exactly when "were these verified?" and the fix prompt matter most.
+            if (body.length > 65000) body = body.slice(0, 64900) + '\n\n… _(truncated)_' + tally + promptSection + note;
             await publish(body);
 
       # Record this review's cost/reliability into the PR metric ledger and post

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -394,7 +394,12 @@ Components:
     the same lens panel (below) but ADVISORY — aggregates the findings into ONE PR
     comment, records NO check runs and drives no promote/fix, so it never touches
     the merge gate. Works on any PR incl. forks (read-only). PR author OR
-    maintainer, throttled per head SHA.
+    maintainer, throttled per head SHA. The comment ends with a collapsed
+    **"Prompt for AI Agents"** fold (`scripts/agent/ai-prompt.mjs`) — the blocking
+    (critical/major, non-demoted) findings rendered as a fenced, copy-pasteable fix
+    instruction, so a maintainer can hand the whole review to their own coding agent
+    in one click (a fenced code block IS GitHub's native copy button). Empty and
+    omitted when nothing blocks.
   - `@claude loop` (PR) → `.github/workflows/agent-loop.yml`: MAINTAINER-ONLY;
     labels the PR `agent:managed` and re-runs CI to opt it into the full
     review→fix→promote machinery. Same-repo branches only (the fixer can't push to

--- a/scripts/agent/ai-prompt.mjs
+++ b/scripts/agent/ai-prompt.mjs
@@ -1,0 +1,144 @@
+// "Prompt for AI Agents" section for the on-demand review comment.
+//
+// When "@claude review" posts its findings, we also append a COLLAPSED
+// <details> block whose body is a single fenced code block: a ready-to-paste
+// instruction listing every blocking (critical/major) finding, so a maintainer
+// can hand the whole review to their own coding agent in one click. GitHub
+// renders every fenced code block with a native copy-to-clipboard button — that
+// IS the "copy" affordance (a comment cannot run custom JS), so the whole
+// section is deliberately just Markdown: a <details> fold wrapping a ``` fence.
+//
+// Scope: only findings that actually GATE this PR. Critical/major define
+// "blocking" (see severity.mjs); demoted findings (lane === "backlog") are
+// EXCLUDED because the panel already ruled they predate this change and are not
+// this PR's to fix — putting them in a "fix these" prompt would be wrong.
+// Minor/nit are excluded too: this block is the "make the PR mergeable" prompt,
+// not a wishlist.
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { BLOCKING, normalizeSeverity } from "./severity.mjs";
+
+/** A finding gates iff it is blocking (critical/major) and NOT demoted. */
+function isFixable(f) {
+  if (!f || typeof f !== "object") return false;
+  if (f.lane === "backlog") return false; // pre-existing / relocated — not ours to fix
+  return BLOCKING.has(normalizeSeverity(f.severity));
+}
+
+// Collapse whitespace so "same summary, different wrapping" dedupes as one.
+const norm = (s) => String(s ?? "").replace(/\s+/g, " ").trim();
+
+/**
+ * Blocking findings across all lenses, deduped by (file, summary). Sorted
+ * critical-before-major, then by file, so the prompt is stable and the worst
+ * items lead. Order among equal keys is preserved from the input.
+ */
+export function fixableFindings(findings) {
+  const arr = Array.isArray(findings) ? findings.filter(isFixable) : [];
+  const seen = new Set();
+  const unique = [];
+  for (const f of arr) {
+    // "\n" separator: norm() strips newlines, so it can't appear inside either
+    // part — the (file, summary) key is unambiguous.
+    const key = `${norm(f.file)}\n${norm(f.summary)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(f);
+  }
+  const rank = (f) => (normalizeSeverity(f.severity) === "critical" ? 0 : 1);
+  // Stable sort: decorate with the original index so equal keys keep input order.
+  return unique
+    .map((f, i) => ({ f, i }))
+    .sort((a, b) => rank(a.f) - rank(b.f) || norm(a.f.file).localeCompare(norm(b.f.file)) || a.i - b.i)
+    .map((x) => x.f);
+}
+
+// A fence at least one backtick longer than the longest backtick run in the
+// body, so a summary that itself contains ``` cannot close the block early.
+function fenceFor(body) {
+  let longest = 0;
+  for (const m of String(body).matchAll(/`+/g)) longest = Math.max(longest, m[0].length);
+  return "`".repeat(Math.max(3, longest + 1));
+}
+
+/** One prompt line per finding: "N. [severity] `file` — summary". */
+function promptLine(f, n) {
+  const sev = normalizeSeverity(f.severity);
+  const where = f.file ? `\`${norm(f.file)}\` — ` : "";
+  return `${n}. [${sev}] ${where}${norm(f.summary) || "(no summary)"}`;
+}
+
+/**
+ * Render the collapsed "Prompt for AI Agents" section, or "" when there are no
+ * blocking findings (nothing to fix → no section). `findings` is the flattened
+ * findings array from every lens's verdict.json.
+ */
+export function renderAiPromptSection(findings) {
+  const fixable = fixableFindings(findings);
+  if (fixable.length === 0) return "";
+  const intro =
+    "Fix the following blocking issues found by the review panel on this pull request. " +
+    "For each, make the minimal change that resolves it, match the surrounding code style, " +
+    "and do not introduce unrelated changes:";
+  const lines = fixable.map((f, i) => promptLine(f, i + 1)).join("\n");
+  const body = `${intro}\n\n${lines}`;
+  const fence = fenceFor(body);
+  // Blank lines around the fence are REQUIRED for GitHub to render a code block
+  // inside the <details> HTML block (Markdown inside raw HTML needs the break).
+  return (
+    `<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n` +
+    `${fence}\n${body}\n${fence}\n\n` +
+    `</details>`
+  );
+}
+
+/**
+ * Collect the flattened findings from every lens's `<review-dir>/<lens>/verdict.json`.
+ * Fail-safe: a missing dir, a non-lens entry, or a malformed verdict.json is
+ * skipped, never thrown — this feeds an advisory comment and must not break it.
+ */
+export function collectFindings(reviewDir) {
+  let entries = [];
+  try {
+    entries = readdirSync(reviewDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const findings = [];
+  for (const e of entries) {
+    if (!e.isDirectory()) continue; // skip panel.json et al.
+    try {
+      const v = JSON.parse(readFileSync(path.join(reviewDir, e.name, "verdict.json"), "utf8"));
+      if (Array.isArray(v?.findings)) findings.push(...v.findings);
+    } catch {
+      /* no verdict.json in this dir, or malformed — skip */
+    }
+  }
+  return findings;
+}
+
+// --- CLI -------------------------------------------------------------------
+// node ai-prompt.mjs --review-dir .agent-review --out /tmp/ai-prompt.md
+// Writes the rendered section (or "" when nothing blocks) to --out, and echoes
+// it to stdout. Always exits 0: this is an advisory add-on, never a gate.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  const opt = (name, def) => {
+    const i = args.indexOf(name);
+    return i >= 0 && i + 1 < args.length ? args[i + 1] : def;
+  };
+  const reviewDir = opt("--review-dir", ".agent-review");
+  const out = opt("--out", null);
+  let section = "";
+  try {
+    section = renderAiPromptSection(collectFindings(reviewDir));
+  } catch (err) {
+    process.stderr.write(`ai-prompt: ${err?.message ?? err}\n`);
+  }
+  if (out) {
+    try { writeFileSync(out, section); } catch (err) { process.stderr.write(`ai-prompt: ${err?.message ?? err}\n`); }
+  }
+  if (section) process.stdout.write(section + "\n");
+}

--- a/scripts/agent/ai-prompt.test.mjs
+++ b/scripts/agent/ai-prompt.test.mjs
@@ -1,0 +1,133 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { collectFindings, fixableFindings, renderAiPromptSection } from "./ai-prompt.mjs";
+
+const CLI = fileURLToPath(new URL("./ai-prompt.mjs", import.meta.url));
+
+const F = (severity, file, summary, extra = {}) => ({ severity, file, summary, ...extra });
+
+test("fixableFindings keeps only blocking, non-demoted findings", () => {
+  const got = fixableFindings([
+    F("critical", "a.ts", "boom"),
+    F("major", "b.ts", "leak"),
+    F("minor", "c.ts", "style"),
+    F("nit", "d.ts", "typo"),
+  ]);
+  assert.deepEqual(got.map((f) => f.file), ["a.ts", "b.ts"]);
+});
+
+test("demoted (lane=backlog) blocking findings are excluded — not this PR's to fix", () => {
+  const got = fixableFindings([
+    F("critical", "a.ts", "boom"),
+    F("critical", "old.ts", "pre-existing", { lane: "backlog" }),
+  ]);
+  assert.deepEqual(got.map((f) => f.file), ["a.ts"]);
+});
+
+test("unknown severity is treated as major (fail-safe) and kept", () => {
+  const got = fixableFindings([F("weird", "a.ts", "?")]);
+  assert.equal(got.length, 1);
+});
+
+test("dedupes by file + summary across lenses, ignoring whitespace", () => {
+  const got = fixableFindings([
+    F("major", "a.ts", "same  bug"),
+    F("major", "a.ts", "same bug"),
+    F("major", "b.ts", "same bug"),
+  ]);
+  assert.deepEqual(
+    got.map((f) => f.file),
+    ["a.ts", "b.ts"],
+  );
+});
+
+test("critical sorts before major; stable within a severity", () => {
+  const got = fixableFindings([
+    F("major", "z.ts", "m1"),
+    F("critical", "b.ts", "c1"),
+    F("major", "a.ts", "m2"),
+  ]);
+  assert.deepEqual(got.map((f) => f.file), ["b.ts", "a.ts", "z.ts"]);
+});
+
+test("no blocking findings → empty string (no section)", () => {
+  assert.equal(renderAiPromptSection([F("minor", "a.ts", "x")]), "");
+  assert.equal(renderAiPromptSection([]), "");
+  assert.equal(renderAiPromptSection(null), "");
+  assert.equal(renderAiPromptSection(undefined), "");
+});
+
+test("rendered section is a collapsed <details> with a fenced code block", () => {
+  const out = renderAiPromptSection([F("critical", "a.ts", "boom"), F("major", "b.ts", "leak")]);
+  assert.match(out, /^<details>\n<summary>🤖 Prompt for AI Agents<\/summary>/);
+  assert.match(out, /<\/details>$/);
+  // Numbered, severity-tagged lines with the file in backticks.
+  assert.match(out, /1\. \[critical\] `a\.ts` — boom/);
+  assert.match(out, /2\. \[major\] `b\.ts` — leak/);
+  // A blank line after <summary> (Markdown-in-HTML requires it to render).
+  assert.match(out, /<\/summary>\n\n```/);
+});
+
+test("a summary containing a triple-backtick fence cannot break out of the block", () => {
+  const out = renderAiPromptSection([F("critical", "a.ts", "see ``` here")]);
+  // The fence must grow past any backtick run in the body (```→````), so the
+  // summary's ``` can't close the block early.
+  assert.ok(out.includes("````"), "fence should grow to at least 4 backticks");
+  // And the whole thing still closes as one details block.
+  assert.match(out, /<\/details>$/);
+});
+
+test("a finding with no file renders without an empty backtick pair", () => {
+  const out = renderAiPromptSection([F("critical", "", "global issue")]);
+  assert.match(out, /1\. \[critical\] global issue/);
+  assert.doesNotMatch(out, /`` —/);
+});
+
+// Build a fake `.agent-review` tree: one dir per lens with a verdict.json,
+// plus a stray panel.json and a dir with no verdict.json (both must be ignored).
+function fakeReviewDir() {
+  const dir = mkdtempSync(path.join(tmpdir(), "ai-prompt-"));
+  const lens = (id, findings) => {
+    mkdirSync(path.join(dir, id), { recursive: true });
+    writeFileSync(path.join(dir, id, "verdict.json"), JSON.stringify({ findings }));
+  };
+  lens("correctness", [F("critical", "a.ts", "boom"), F("minor", "a.ts", "ZZnitpick")]);
+  lens("security", [F("major", "b.ts", "leak")]);
+  mkdirSync(path.join(dir, "empty-lens"), { recursive: true }); // no verdict.json
+  writeFileSync(path.join(dir, "panel.json"), "[]"); // stray file, not a dir
+  return dir;
+}
+
+test("collectFindings flattens every lens's verdict.json, skips non-lens entries", () => {
+  const dir = fakeReviewDir();
+  const all = collectFindings(dir);
+  assert.equal(all.length, 3); // 2 from correctness + 1 from security
+  // A missing dir is fail-safe, not a throw.
+  assert.deepEqual(collectFindings(path.join(dir, "does-not-exist")), []);
+});
+
+test("CLI writes the section to --out and echoes it (blocking findings present)", () => {
+  const dir = fakeReviewDir();
+  const outFile = path.join(dir, "ai-prompt.md");
+  const stdout = execFileSync("node", [CLI, "--review-dir", dir, "--out", outFile], { encoding: "utf8" });
+  const written = readFileSync(outFile, "utf8");
+  assert.match(written, /🤖 Prompt for AI Agents/);
+  assert.match(written, /\[critical\] `a\.ts` — boom/);
+  assert.match(written, /\[major\] `b\.ts` — leak/);
+  assert.doesNotMatch(written, /ZZnitpick/); // minor excluded
+  assert.equal(stdout.trim(), written.trim());
+});
+
+test("CLI writes an empty file when nothing blocks", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "ai-prompt-empty-"));
+  mkdirSync(path.join(dir, "docs"));
+  writeFileSync(path.join(dir, "docs", "verdict.json"), JSON.stringify({ findings: [F("minor", "a.ts", "x")] }));
+  const outFile = path.join(dir, "ai-prompt.md");
+  execFileSync("node", [CLI, "--review-dir", dir, "--out", outFile], { encoding: "utf8" });
+  assert.equal(readFileSync(outFile, "utf8"), "");
+});


### PR DESCRIPTION
## Summary

The `@claude review` comment now ends with a collapsed **"Prompt for AI Agents"** fold — the blocking (critical/major) findings across every lens, rendered as a fenced, copy-pasteable fix instruction. Clicking it open reveals a code block; a **fenced code block is GitHub's native copy-to-clipboard button**, so a maintainer can hand the entire review to their own coding agent in one click (a PR comment can't run custom JS, so this is the copy affordance).

Example of the appended section:

<details>
<summary>🤖 Prompt for AI Agents</summary>

```
Fix the following blocking issues found by the review panel on this pull request. For each, make the minimal change that resolves it, match the surrounding code style, and do not introduce unrelated changes:

1. [critical] `packages/sheets/src/store.ts` — `setCell` writes before acquiring the batch lock, so a concurrent undo can drop the edit
2. [major] `packages/backend/src/api/v1/cells.controller.ts` — range query is not workspace-scoped
```

</details>

## What's in scope

The fold lists **only findings that gate this PR**:
- Critical/major only (minor/nit excluded — this is the "make it mergeable" prompt, not a wishlist).
- Demoted findings (`lane: "backlog"` — pre-existing/relocated code the panel ruled isn't this PR's to fix) are excluded, so the prompt never tells an agent to "fix" code the PR didn't write.
- Refuted/overturned findings are already absent from `verdict.json`, so they can't leak in.
- Deduped across lenses, sorted critical-first, and **omitted entirely when nothing blocks**.

## Design

- Logic lives in a pure, unit-tested `scripts/agent/ai-prompt.mjs` (module + CLI, mirroring `command.mjs`) — reads each lens's `verdict.json`, filters/dedupes/sorts, renders the fold. Dynamic code-fence length so a summary containing ``` can't break out of the block.
- Wired into `agent-review-on-demand.yml` as a `continue-on-error`, fail-safe step running the **trusted `main` copy**; the comment step reads its output best-effort, so a missing file never strands the comment. It rides above the one-line advisory disclaimer and is re-appended on truncation (it's the actionable part).
- No change to what gates merge: this is advisory text on an already-advisory comment. Records no check runs, drives no fix/promote, needs no new permissions.

## Test plan

- `node --test scripts/agent/ai-prompt.test.mjs` — 12 tests (filtering, demotion exclusion, dedup, sort, fence-escaping, empty→no-section, CLI + `collectFindings` over a fixture tree).
- Full agent suite green (`cd scripts/agent && node --test` → 661 pass).
- Workflow YAML validates; embedded github-script passes `node --check` (async-wrapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)