### PR TITLE
Route the stage-detail capture out of the runner, from both panels

### DIFF
--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -321,6 +321,19 @@ jobs:
           # Via env, never interpolated into the `run:` string — this step holds
           # the Claude token. Same rule as the twin step in agent-review-panel.yml.
           BASE_SHA: ${{ steps.diff.outputs.base }}
+          # Per-lens stage-detail capture, PASSED RAW and for parity with the twin
+          # step in agent-review-panel.yml — not as a way to switch it on. Both
+          # resolve an UNSET repo variable in the script (capture ON, diff content
+          # OFF), which is what this job already got by passing neither.
+          #
+          # Passing them is what stops the two producers from drifting once someone
+          # DOES set one: without these lines `AGENT_STAGE_DETAIL_CAPTURE=false`
+          # would silence the gating capture while this one kept writing, and
+          # `..._DIFF_CONTENT=true` would have one producer emit `lensDiff` and the
+          # other silently omit it — a difference no consumer could see in the
+          # payload.
+          STAGE_DETAIL_CAPTURE: ${{ vars.AGENT_STAGE_DETAIL_CAPTURE }}
+          STAGE_DETAIL_DIFF_CONTENT: ${{ vars.AGENT_STAGE_DETAIL_DIFF_CONTENT }}
         # --prior-findings and --rebuttals are both tolerant of a missing file
         # (existsSync guard in review-panel.mjs → treated as []), so a
         # skipped/failed read step above is safe.
@@ -335,6 +348,54 @@ jobs:
           --repo "$GITHUB_WORKSPACE"
           --lenses-dir .trusted/scripts/agent/lenses
           --out .agent-review
+
+      # The SAME capture the gating panel uploads (#641), from the same writer, at
+      # the same name, path and retention. Deliberately not a second format: the
+      # panel already wrote these files on every on-demand round and the runner
+      # then deleted them, so this is a route out, not new data.
+      #
+      # #641 listed this under "Not built", on the grounds that "advisory
+      # `@claude review` invocations are not the population a tuning corpus should
+      # be scored on". That reasoning holds for scoring the GATE and not for the
+      # measurement this feeds. Severity-weighted precision has `minor`/`nit`
+      # buckets and the independent reviewer we compare against is nit-heavy, so
+      # separating "we missed it" from "we found it and called it minor" needs the
+      # panel's NON-BLOCKING findings — and `samples` is the only channel that
+      # carries them (its sibling `verifications` is blocking-only, and every
+      # permanent channel — check-run output.text, the rendered comment — is
+      # critical/major). Measured over all 17 real on-demand comments: 249 blocking
+      # against 387 non-blocking. Advisory rounds are not scored AS gate decisions;
+      # their per-sample severities are the comparison data.
+      #
+      # Safe from this job, for reasons already established rather than new ones.
+      # upload-artifact needs no write scope, so nothing here widens what this
+      # deliberately read-only job can reach (`checks: read`, never write). The glob
+      # cannot pick up a branch-planted `.agent-review/evil/stage-detail.json`
+      # because "Clear stale verdicts" above does `rm -rf .agent-review` before the
+      # panel runs. The gating `review-panel` job has the identical property — its
+      # SDK cwd is the untrusted branch checkout too — and already uploads two
+      # artifacts.
+      #
+      # No `steps.pr` guard, unlike the gating twin: that one resolves a PR number
+      # from a workflow_run payload that may not have one, while an issue_comment
+      # event always carries `needs.authorize.outputs.pr`.
+      - name: Upload per-lens stage detail
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-panel-stage-detail
+          path: .agent-review/*/stage-detail.json
+          # REQUIRED — see the twin step in agent-review-panel.yml for the
+          # mechanism. Without it the glob's search root is the dot-directory
+          # `.agent-review`, which @actions/glob skips before reading it, and this
+          # step silently uploads nothing.
+          include-hidden-files: true
+          # Absent whenever capture is disabled, or every lens skipped, or the panel
+          # crashed before writing — none of which is an error here. This is also
+          # why the flag above cannot be inferred from a green run.
+          if-no-files-found: ignore
+          retention-days: 30
 
       # Post the comment with a GitHub App token, NOT the default GITHUB_TOKEN.
       # This workflow runs on ANY PR incl. forks, and for a run triggered by an

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -947,8 +947,27 @@ jobs:
         with:
           name: review-panel-stage-detail
           path: .agent-review/*/stage-detail.json
+          # REQUIRED, and not for the files themselves — for the DIRECTORY.
+          # upload-artifact resolves a glob with @actions/glob, whose search root
+          # is the pattern's non-wildcard prefix: `.agent-review`. With hidden
+          # files excluded (the v4 default) the globber skips any traversed item
+          # whose basename starts with a dot — including that root — so it never
+          # reads the directory and the whole subtree is invisible. It reports
+          # "No files were found", which if-no-files-found: ignore then swallows.
+          #
+          # The execution-log step above needs no such line only because it names
+          # its files literally: each search root is then the FILE, and no hidden
+          # component is ever inspected. Two steps reading the same directory,
+          # with opposite outcomes, is the shape of this bug. `ci.yml`'s
+          # `.harness-reports/` upload already carries this flag for the same
+          # reason; #641 shipped without it and produced no artifact on any of the
+          # five real panel runs that followed.
+          include-hidden-files: true
           # Absent whenever capture is disabled, or a lens was skipped, or the
           # orchestrator crashed before writing — none of which is an error here.
+          # It CANNOT stand in for the line above: a silent zero-file upload and a
+          # legitimately empty one look identical from here, which is why this was
+          # invisible for five rounds.
           if-no-files-found: ignore
           retention-days: 30
 

--- a/docs/tasks/active/20260803-panel-stage-detail-capture-todo.md
+++ b/docs/tasks/active/20260803-panel-stage-detail-capture-todo.md
@@ -392,3 +392,221 @@ raised. Growth is sub-linear rather than absent — 5.7× more payload across 49
 more diff. That is still the result worth having: the 2 MB worst case becomes
 29.5 KB, which turns the collector job's storage question into a much smaller one
 without pretending it has disappeared.
+
+---
+
+# Follow-up: route the capture out — from both panels
+
+Two changes that are one change. The capture has never left a runner: the upload
+step could not see the files it was pointed at. Fixing that also settles where the
+second producer's copy goes, because the fix is the reason a naive copy of the step
+would have failed the same way.
+
+1. **The glob never matched.** `.agent-review` is a dot-directory, and
+   `upload-artifact` excludes hidden paths by default. Five real panel runs, zero
+   artifacts.
+2. **`agent-review-on-demand.yml` now uploads the same capture.** #641 left this
+   under "Not built"; the reason it gives holds for scoring the gate and not for the
+   measurement this feeds. See "Why the second producer" below.
+
+They ship together because the invariant test written for (1) is what proves (2)
+correct — it scans every workflow's upload steps, so the new step is covered with no
+additional test, and would have failed without the flag.
+
+## The problem
+
+The section above closes with a prediction: *"the first managed PR after this
+merges will produce the artifact."* It did not, and neither did the four after it.
+Every panel run since #641 merged that provably reached the lenses —
+`30799533061`, `30803409664`, `30803718950`, `30836949850`, `30837818619` — logged
+
+```
+No files were found with the provided path: .agent-review/*/stage-detail.json.
+```
+
+Five rounds of capture, zero rows collected.
+
+Nothing in the script is at fault, and the same job proves it. In run
+`30837818619` all six lenses reported `success`, so each one passed the
+unconditional `writeStageDetail` call — it sits after the skip and fail-closed
+returns and before the verdict write, so a lens that produced a verdict went
+through it. `STAGE_DETAIL_CAPTURE` echoes **empty**, which
+`stageDetailCaptureEnabled` resolves to ON exactly as the fail-direction table
+above intends. No `stage-detail capture failed (continuing)` line, so nothing
+threw. And the per-lens directories demonstrably held real content: each check
+run's `output.summary` is 836–2,838 characters read straight out of
+`.agent-review/<lens>/summary.md`, written by `writeVerdict` into the *same*
+`lensOut` from the *same* `mkdirSync`.
+
+The fault is in the glob. `upload-artifact` resolves patterns through
+`@actions/glob` with `excludeHiddenFiles: !include-hidden-files`, and
+`include-hidden-files` defaults to **false**. The globber's search root is the
+pattern's non-wildcard prefix — for `.agent-review/*/stage-detail.json` that is the
+**directory** `.agent-review` — and its traversal skips any item whose basename
+starts with a dot:
+
+```js
+// @actions/glob/lib/internal-globber.js
+if (options.excludeHiddenFiles && path.basename(item.path).match(/^\./)) {
+  continue;
+}
+```
+
+The root is the first item on the stack. It is skipped before `readdir`, so the
+entire subtree is never enumerated. Not "the files were filtered out" — the
+directory was never opened.
+
+What made this read as a write bug for so long is the sibling step. **The
+execution-log upload, in the same job, from the same hidden directory, works.**
+It names its two files literally, so each search root is the *file*, whose basename
+is not hidden, and no hidden component is ever inspected. One step succeeding and
+one step silent, three lines apart in the same YAML, is the whole reason the
+evidence pointed at `writeStageDetail`.
+
+`ci.yml`'s `.harness-reports/` upload already carries `include-hidden-files: true`
+for precisely this reason. #641 did not carry it across.
+
+## The change
+
+- [x] `include-hidden-files: true` on the `Upload per-lens stage detail` step, with
+      the mechanism written down at the point of use — the flag reads as being
+      about *files* and is in fact about the *directory*, which is why copying the
+      step elsewhere without it will fail the same way.
+- [x] Amend the `if-no-files-found: ignore` comment to say what it cannot do. It is
+      still correct (capture off, or every lens skipped, are both normal), but it
+      is also what turned this into five silent rounds, and the next reader deserves
+      both halves.
+- [x] One test, in `review-panel.test.mjs` beside the `writeStageDetail` tests:
+      parse every `upload-artifact` step out of the real workflows and require
+      `include-hidden-files: true` on any path that makes the globber **walk** (a
+      wildcard, or a trailing `/`) through a dot-prefixed segment. Comment lines are
+      stripped first, the same trap #630/#640/#651 each hit; a literal file path is
+      correctly exempt, because that is genuinely immune.
+- [x] The same step in `agent-review-on-demand.yml`'s `review` job, after the panel
+      runs and before the comment is posted — so the capture survives even when the
+      comment step fails. Same name, path, retention and flag.
+- [x] `STAGE_DETAIL_CAPTURE` / `STAGE_DETAIL_DIFF_CONTENT` on the on-demand panel
+      step, passed RAW. A **no-op today** — both repo variables are unset, which is
+      the same ON/OFF pair this job already resolved by passing neither. What it buys
+      is that the two producers cannot drift the moment someone sets one.
+- [x] The test asserts the **pair**, not one step: two producers, one name, one
+      path, both flagged. `filter`, not `find` — with two identically-named steps a
+      `find` would assert about whichever file the directory listing yielded first
+      and leave the other free to regress.
+
+## Why the second producer
+
+#641 filed on-demand parity under "Not built": *"advisory `@claude review`
+invocations are not the population a tuning corpus should be scored on."* That is
+right about scoring **the gate** and does not apply to the measurement this feeds.
+
+Severity-weighted precision has `minor` and `nit` buckets and the independent
+reviewer we compare against is nit-heavy, so separating *"we missed it"* from *"we
+found it and called it minor"* requires the panel's **non-blocking** findings.
+`samples` is the only channel that carries them — its own sibling `verifications` is
+blocking-only, and every permanent channel (check-run `output.text`, the rendered
+comment) is critical/major. Measured over all 17 real on-demand comments: **249
+blocking against 387 non-blocking** (25 critical / 224 major / 315 minor / 72 nit).
+
+So advisory rounds are still not scored as gate decisions. Their per-sample
+severities are the comparison data, which is a different use and the one that was
+otherwise uncomputable.
+
+Uploading from that job needs no new permission and grants none: `upload-artifact`
+requires no scope, and the job keeps `checks: read` with no `checks: write`. The glob
+cannot pick up a branch-planted `.agent-review/evil/stage-detail.json` because
+"Clear stale verdicts" does `rm -rf .agent-review` before the panel runs. The gating
+`review-panel` job has the identical property — its SDK cwd is the untrusted branch
+checkout too — and already uploads two artifacts.
+
+## Corrected from the plan
+
+- **"Ruled out: hidden-file exclusion, because the sibling upload succeeded from
+  the same hidden directory."** Wrong, and wrong in the most useful way — the
+  sibling's immunity *is* the mechanism, not evidence against it. A glob and a
+  literal path resolve through different code in `getSearchPaths`, so "same
+  directory, same job, one worked" says nothing about the other.
+- **"A throwaway diagnostic PR is the next step."** Not needed. `@actions/glob` is
+  40 lines of readable traversal and the option is a published input; a local
+  repro against the real package answered it in one run, and no CI round was spent.
+- **"Perhaps no panel ran after #641 merged."** They ran. Most `agent-review-panel`
+  workflow runs carry **no artifacts at all**, because the `gate` job exits before
+  `review-panel` starts — so a run list is not a panel list. The five above are the
+  ones holding `review-panel-execution`, which is proof the job reached the
+  uploads.
+
+## Fail directions
+
+| path | on doubt | why |
+|---|---|---|
+| the upload glob | **upload**, including dot-prefixed paths | the population is written by this pipeline into a directory this pipeline chose. There is no untrusted content to exclude here: the branch's own `.agent-review` is `rm -rf`-ed before the panel runs, and `include-hidden-files` still only admits paths the pattern already matched |
+| `if-no-files-found` | stays `ignore` | unchanged and still right — an empty capture is normal. The lesson is not to make it warn, it is that a *tolerant* step needs its precondition pinned by a test rather than watched by a human |
+| the new test | **fails loudly** | it is the only thing standing between a future hidden-path upload and another five silent rounds. It asserts the parser found ≥8 of the repo's 11 upload steps and that at least one hidden glob exists, so it can never pass by finding nothing |
+| the on-demand upload step | `if: always()`, `continue-on-error` | it must not be able to fail an advisory review. It sits before the comment step so a capture survives a failed comment, and after the panel so there is something to capture |
+| the on-demand `STAGE_DETAIL_*` pair | passed **raw**, resolved in the script | the same reason #641 gives for the gating twin: a `&& 'x' \|\| 'y'` default in YAML puts the inverted logic where no test can reach it. `stageDetailCaptureEnabled` is tested; a workflow expression is not |
+
+## Explicit non-goal
+
+**No script change, and no change to what is captured.** `writeStageDetail`,
+`buildStageDetail`, the gate and the payload are all untouched and were never
+wrong. Both producers already wrote these files; only the route out is new. The five
+lost rounds are not recoverable and are not worth trying to recover: they are five
+rows of a corpus that will have thousands.
+
+**No collector, still.** Nothing reads `stage-detail.json` after this. Two producers
+instead of one is the point of doing them together — the collector gains a second
+source with no new case to handle.
+
+**No advisory round is made gating.** No check run, no conclusion, no required check,
+no new scope. The on-demand job's permissions are byte-identical before and after.
+
+## Verification
+
+- [x] **The mechanism, reproduced locally.** `@actions/glob@0.5.0` against a
+      `.agent-review/{correctness,docs}/stage-detail.json` fixture, with
+      `upload-artifact`'s own glob options:
+
+      | pattern | excludeHiddenFiles | files found |
+      |---|---|---|
+      | `.agent-review/*/stage-detail.json` | `true` (today) | **0** |
+      | `.agent-review/*/stage-detail.json` | `false` (fixed) | 2 |
+      | the two literal execution-log paths | `true` | 2 |
+      | the two literal execution-log paths | `false` | 2 |
+
+      The debug output names the cause outright: the glob's search path is the
+      directory `.agent-review`, the literal paths' search paths are the files.
+      This is the production log, both steps, exactly.
+- [x] **Artifact layout after the fix.** One search path, so `search.ts` returns
+      `rootDirectory: searchPaths[0]` — the artifact holds
+      `<lens>/stage-detail.json`, which is the layout the collector was planned
+      against. Unchanged by this fix; confirmed, not assumed.
+- [x] `node --test "scripts/agent/*.test.mjs"` — **658 tests, 657 pass, 0 fail, 1
+      skipped**; 657/656 on `upstream/main` (`dfc7ec674`).
+- [x] **The test fails on all three regressions**, each naming the right file:
+
+      | tree | assertion that fires |
+      |---|---|
+      | the gating step without the flag (= #641 as shipped) | `agent-review-panel.yml "Upload per-lens stage detail" globs the hidden path … without include-hidden-files: true` |
+      | the on-demand step without the flag (= a naive copy) | same message, `agent-review-on-demand.yml` |
+      | the on-demand step deleted | `both the gating and the on-demand panel must upload the stage-detail capture` |
+
+      The middle row is why these ship together: the test written for the bug is what
+      makes the parity step correct, with nothing added.
+- [x] The invariant holds across every existing upload step: `ci.yml`'s
+      `.harness-reports/` already sets the flag; `docker-publish.yml`'s
+      `${{ runner.temp }}/digests/*` has no hidden segment; every
+      `claude-execution-output.json` and `.tgz` upload is a literal path.
+- [x] **Both workflows parse**, and the on-demand `review` job's permissions are
+      unchanged: `{contents: read, pull-requests: read, checks: read, issues: write}`
+      — no `checks: write`, no addition.
+- [ ] **The artifact itself, from either producer.** Still unverified end-to-end and
+      cannot be from here: the gating side needs one managed PR to run the panel, the
+      on-demand side one `@claude review`. The number to check against the size table
+      is the largest per-lens file, which is the check #641 asked for and never got.
+- [ ] **Two producers, one artifact name — a collector requirement, recorded now.**
+      `stage-detail.json` carries no field naming the workflow that wrote it, so a
+      collector resolving "artifacts named `review-panel-stage-detail` for PR X"
+      gets both producers with nothing in the payload to tell a gating round from an
+      advisory one, and would double-count one head sha as two rounds. Recoverable
+      from run metadata (`event: issue_comment` versus the panel's `workflow_run`).
+      Not a blocker here; it must be settled in the collector.

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { readFileSync, readdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -2603,6 +2603,125 @@ test("writeStageDetail: disabled writes nothing at all", () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+/**
+ * Parse every `actions/upload-artifact` step out of the real workflows.
+ *
+ * Comment lines are dropped first. These workflows carry more prose than YAML and
+ * the comments quote `path:` and the flag being asserted here by name, so a
+ * whole-file grep would answer out of the explanation instead of the config —
+ * the same trap #630, #640 and #651 each had to work around.
+ */
+function uploadArtifactSteps() {
+  const dir = path.join(HERE, "..", "..", ".github", "workflows");
+  const steps = [];
+  for (const file of readdirSync(dir).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))) {
+    const lines = readFileSync(path.join(dir, file), "utf8")
+      .split("\n")
+      .filter((l) => !/^\s*#/.test(l));
+    for (let i = 0; i < lines.length; i++) {
+      const at = lines[i].indexOf("uses: actions/upload-artifact");
+      if (at < 0) continue;
+      // The step body: every following line indented deeper than this key, or at
+      // the same depth (its sibling keys, e.g. `with:`). A shallower line is the
+      // next step or the next job.
+      const body = [];
+      for (let j = i + 1; j < lines.length; j++) {
+        if (!lines[j].trim()) { body.push(lines[j]); continue; }
+        const indent = lines[j].search(/\S/);
+        if (indent < at || /^\s*- /.test(lines[j].slice(0, at + 2))) break;
+        body.push(lines[j]);
+      }
+      // `name:` may precede `uses:`, so look backwards for the step's label too.
+      let name = "";
+      for (let j = i - 1; j >= 0 && !name; j--) {
+        if (!lines[j].trim()) continue;
+        const m = /^\s*-?\s*name:\s*(.+?)\s*$/.exec(lines[j]);
+        if (m) name = m[1];
+        else if (lines[j].search(/\S/) < at) break;
+      }
+      // `path:` is a scalar on one line, or a block scalar whose entries follow.
+      const paths = [];
+      for (let j = 0; j < body.length; j++) {
+        const m = /^(\s*)path:\s*(.*)$/.exec(body[j]);
+        if (!m) continue;
+        const [, indent, inline] = m;
+        if (inline && !/^[|>]/.test(inline)) { paths.push(inline.replace(/^["']|["']$/g, "")); continue; }
+        for (let k = j + 1; k < body.length; k++) {
+          if (!body[k].trim()) continue;
+          if (body[k].search(/\S/) <= indent.length) break;
+          paths.push(body[k].trim().replace(/^["']|["']$/g, ""));
+        }
+      }
+      steps.push({
+        file, name, paths,
+        includeHidden: body.some((l) => /^\s*include-hidden-files:\s*true\s*$/.test(l)),
+      });
+    }
+  }
+  return steps;
+}
+
+test("every upload-artifact step that GLOBS a hidden path opts hidden files back in", () => {
+  // #641 shipped `path: .agent-review/*/stage-detail.json` without
+  // `include-hidden-files: true` and uploaded nothing on five consecutive real
+  // panel runs. The files were written; the glob never saw them.
+  //
+  // upload-artifact resolves globs with @actions/glob, whose search root is the
+  // pattern's non-wildcard prefix — here the DIRECTORY `.agent-review`. With
+  // hidden files excluded (the v4 default) the globber skips any traversed item
+  // whose basename starts with a dot, the root included, so it never reads the
+  // directory at all. `if-no-files-found: ignore` then swallows the report.
+  //
+  // A literal file path is immune, which is the trap: the sibling
+  // `review-panel-execution` step names its two files outright, so each search
+  // root is the FILE and no hidden component is ever inspected. Two steps reading
+  // the same hidden directory in the same job, one working and one silent, is
+  // what made this look like a write bug rather than an upload bug.
+  const risky = (p) => {
+    // Only a glob or a directory makes the globber WALK; a named file is handed
+    // straight to stat.
+    if (!/[*?[]/.test(p) && !p.endsWith("/")) return false;
+    return p.split("/").some((seg) => seg.startsWith(".") && seg !== "." && seg !== "..");
+  };
+
+  const steps = uploadArtifactSteps();
+  // Guard the parser itself: an upload step that silently stopped being found
+  // would make every assertion below vacuous.
+  assert.ok(steps.length >= 8, `expected to find the upload steps, found ${steps.length}`);
+  assert.ok(steps.every((s) => s.paths.length > 0), `every upload step must declare a path: ${JSON.stringify(steps.filter((s) => !s.paths.length))}`);
+
+  for (const step of steps) {
+    for (const p of step.paths) {
+      if (!risky(p)) continue;
+      assert.ok(
+        step.includeHidden,
+        `${step.file} "${step.name}" globs the hidden path ${p} without include-hidden-files: true — it will upload nothing, silently`,
+      );
+    }
+  }
+
+  // Named, so a rename or a path rewrite still fails loudly here rather than going
+  // quiet in production for another five rounds. `filter`, not `find`: BOTH panels
+  // upload this capture and a `find` would assert about whichever workflow the
+  // directory listing happened to yield first, leaving the other free to regress.
+  // Asserting the pair is also what pins the PARITY — one name, one path, one
+  // retention, from two producers — which is the property a collector depends on.
+  const stage = steps.filter((s) => s.name === "Upload per-lens stage detail");
+  assert.deepEqual(
+    stage.map((s) => s.file).sort(),
+    ["agent-review-on-demand.yml", "agent-review-panel.yml"],
+    "both the gating and the on-demand panel must upload the stage-detail capture",
+  );
+  for (const s of stage) {
+    assert.deepEqual(s.paths, [".agent-review/*/stage-detail.json"], `${s.file}: the capture path must match the other producer`);
+    assert.ok(s.includeHidden, `${s.file}: the stage-detail upload must set include-hidden-files: true`);
+  }
+
+  // The invariant has to hold for a REASON, not by coincidence: at least one
+  // upload in the repo must be a hidden glob, or the loop above proves nothing.
+  assert.ok(steps.some((s) => s.paths.some(risky)), "no hidden-path upload found — this test would be vacuous");
 });
 
 test("writeStageDetail: a failed write NEVER propagates", () => {


### PR DESCRIPTION
## The bug

#641 added the per-lens stage-detail capture and predicted *"the first managed PR after this merges will produce the artifact."* It did not, and neither did the four after it. Every panel run since that merge which provably reached the lenses — `30799533061`, `30803409664`, `30803718950`, `30836949850`, `30837818619` — logged:

```
No files were found with the provided path: .agent-review/*/stage-detail.json
```

**The capture has never left a runner.**

Nothing in the script was wrong, and the same job proves it. In run `30837818619` all six lenses reported `success`, so each passed the unconditional `writeStageDetail` call (it sits after the skip and fail-closed returns, before the verdict write). `STAGE_DETAIL_CAPTURE` echoes empty, which `stageDetailCaptureEnabled` resolves to ON exactly as intended. No `stage-detail capture failed` line, so nothing threw. And the per-lens directories held real content: each check run's `output.summary` is 836–2,838 characters read straight out of `.agent-review/<lens>/summary.md`, written by `writeVerdict` into the **same** `lensOut` from the **same** `mkdirSync`.

The fault is the glob. `upload-artifact` resolves patterns through `@actions/glob` with `excludeHiddenFiles: !include-hidden-files`, and the input defaults to `false`. The globber's search root is the pattern's non-wildcard prefix — for `.agent-review/*/stage-detail.json` that is the **directory** `.agent-review` — and it skips any traversed item whose basename starts with a dot:

```js
// @actions/glob/lib/internal-globber.js
if (options.excludeHiddenFiles && path.basename(item.path).match(/^\./)) continue;
```

The root is the first item on the stack, so it is skipped **before `readdir`** and the whole subtree is never enumerated. Not "the files were filtered out" — the directory was never opened. `if-no-files-found: ignore` then swallows the report, which is why five rounds passed silently.

What made this read as a *write* bug is the sibling step: the execution-log upload, in the same job, from the same hidden directory, **works** — because it names its two files literally, so each search root is the FILE, whose basename is not hidden, and no hidden component is ever inspected. A glob and a literal path resolve through different branches of `getSearchPaths`, so "same directory, same job, one worked" says nothing about the other.

`ci.yml`'s `.harness-reports/` upload already carries `include-hidden-files: true` for exactly this reason; #641 did not carry it across.

Reproduced against `@actions/glob@0.5.0` with `upload-artifact`'s own glob options:

| pattern | `excludeHiddenFiles` | files found |
|---|---|---|
| `.agent-review/*/stage-detail.json` | `true` (today) | **0** |
| `.agent-review/*/stage-detail.json` | `false` (fixed) | 2 |
| the two literal execution-log paths | `true` | 2 |
| the two literal execution-log paths | `false` | 2 |

That is the production log, both steps, exactly.

## The second producer

`agent-review-on-demand.yml` now uploads the same capture — same name, path, retention and flag.

#641 filed this under "Not built", on the grounds that *"advisory `@claude review` invocations are not the population a tuning corpus should be scored on."* That is right about scoring **the gate** and does not apply to the measurement this feeds. Severity-weighted precision has `minor` and `nit` buckets and the independent reviewer we compare against is nit-heavy, so separating *"we missed it"* from *"we found it and called it minor"* needs the panel's **non-blocking** findings. `samples` is the only channel carrying them — its own sibling `verifications` is blocking-only, and every permanent channel (check-run `output.text`, the rendered comment) is critical/major. Measured over all 17 real on-demand comments: **249 blocking against 387 non-blocking**.

Advisory rounds are still not scored *as gate decisions*. Their per-sample severities are the comparison data.

`STAGE_DETAIL_CAPTURE` / `STAGE_DETAIL_DIFF_CONTENT` are now passed on the on-demand panel step too. A **no-op today** — both repo variables are unset, which is the same ON/OFF pair this job already resolved by passing neither — but without them `AGENT_STAGE_DETAIL_CAPTURE=false` would silence the gating capture while this one kept writing, and `DIFF_CONTENT=true` would have one producer emit `lensDiff` and the other silently omit it. Passed raw and resolved in the script, for #641's reason: a YAML default puts the inverted logic where no test can reach it.

## Why one PR

The test written for the bug is what makes the parity step correct. It parses every `upload-artifact` step out of the real workflows and requires `include-hidden-files: true` on any path that makes the globber **walk** (a wildcard, or a trailing `/`) through a dot-prefixed segment. It fails on all three regressions:

| tree | assertion that fires |
|---|---|
| gating step without the flag (= #641 as shipped) | `agent-review-panel.yml "Upload per-lens stage detail" globs the hidden path … without include-hidden-files: true` |
| on-demand step without the flag (= a naive copy) | same message, `agent-review-on-demand.yml` |
| on-demand step deleted | `both the gating and the on-demand panel must upload the stage-detail capture` |

So the parity half needed no test of its own. Comment lines are stripped before parsing — these workflows quote both the flag and the path in prose, the same trap #630/#640/#651 each hit. A literal file path is exempt, because it genuinely is immune. The named assertion uses `filter`, not `find`: with two identically-named steps a `find` would assert about whichever file the directory listing yielded first and leave the other free to regress.

## Scope

**No script change, and no change to what is captured.** `writeStageDetail`, `buildStageDetail`, the gate and the payload are untouched and were never wrong. Both producers already wrote these files; only the route out is new.

**No new permission, and none granted.** `upload-artifact` uses `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`, so it needs no scope — the `deps` jobs upload today holding only `contents: read`. The on-demand `review` job's permissions are byte-identical before and after: `{contents: read, pull-requests: read, checks: read, issues: write}`. No `checks: write`, no check run, no conclusion, no required check. **Nothing here makes an advisory review gating.**

The glob cannot pick up a branch-planted `.agent-review/evil/stage-detail.json` because "Clear stale verdicts" does `rm -rf .agent-review` before the panel runs. The gating `review-panel` job has the identical untrusted-cwd property and already uploads two artifacts.

**Producer only, still.** Nothing reads `stage-detail.json` after this — which is the reason to do both halves together rather than in sequence: the collector gains a second source with no new case to handle.

## Verification

- `node --test "scripts/agent/*.test.mjs"` — **658 tests, 657 pass, 0 fail, 1 skipped**; 657/656 on `main` (`dfc7ec674`).
- Both workflows parse; the on-demand `review` job's permissions are unchanged.
- The invariant holds across every existing upload step: `ci.yml`'s `.harness-reports/` already sets the flag; `docker-publish.yml`'s `${{ runner.temp }}/digests/*` has no hidden segment; every `claude-execution-output.json` and `.tgz` upload is a literal path.
- Artifact layout after the fix is unchanged and confirmed rather than assumed: one search path, so `search.ts` returns `rootDirectory: searchPaths[0]` and the artifact holds `<lens>/stage-detail.json` — the layout the collector was planned against.

## Still open, deliberately

- **The artifact itself is unverified end to end** and cannot be from here: the gating side needs one managed PR to run the panel, the on-demand side one `@claude review`. The number to check against #641's size table is the largest per-lens file — the check #641 asked for and never got.
- **Two producers under one artifact name is a collector requirement.** `stage-detail.json` carries no field naming the workflow that wrote it, so a collector resolving "artifacts named `review-panel-stage-detail` for PR X" gets both producers with nothing in the payload to tell a gating round from an advisory one, and would double-count one head sha as two rounds. Recoverable from run metadata (`event: issue_comment` versus the panel's `workflow_run`). Must be settled in the collector, not here.

Both are recorded as unchecked boxes in the task doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed review-stage capture and artifact uploads.
  * Added optional capture settings for on-demand reviews.
  * Artifacts now retain generated stage-detail files for 30 days, including files in hidden directories.

* **Bug Fixes**
  * Fixed missing stage-detail files caused by hidden-file upload exclusions.

* **Tests**
  * Added workflow validation and regression coverage for hidden-path artifact uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->