### PR TITLE
Add the UI hunter's prediction protocol: the model proposes, code decides

### DIFF
--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1354,7 +1354,8 @@ prediction protocol are new.**
 Canvas, so the a11y tree covers the React chrome and essentially nothing where the
 content is. `window.__WB_HUNT__` on the DEV-only `/harness/hunt` route answers a CLOSED
 registry of named readers instead — `doc.text`, `doc.runs`, `doc.fontSizes`,
-`sheet.cellValue`, `sheet.cellCenter`, `canUndo` — over `MemStore`/`MemDocStore`, with
+`sheet.cellValue`, `sheet.cellCenter`, `doc.canUndo`, `sheet.canUndo` — over
+`MemStore`/`MemDocStore`, with
 the real `DocsFormattingToolbar` mounted. No backend, no login, no cleanup risk. A
 registry rather than an `evaluate(<model JS>)` hook, so the reachable surface is bounded
 by reviewed code; membership is an own-property test, because a plain object literal

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1341,6 +1341,91 @@ it left alone. `--run` is mandatory so there is no "delete everything that looks
 a fixture" mode to reach by accident, and the run id is in the prefix so concurrent
 runs cannot delete each other's fixtures. Docker lifecycle is NOT reimplemented —
 `scripts/verify-integration-docker.mjs` owns it, and `preflight` reports what is missing.
+### Phase 28: UI Issue Hunting
+
+Phase 26's own residual-risk list names the ceiling this addresses: the CLI reaches
+neither Canvas rendering, CRDT collaboration, nor frontend interaction, which is where
+most open UI bugs live. This is the Playwright hunter that section called "the natural
+next surface", and it reuses Phase 26's precision apparatus wholesale — inverted gate,
+3x replay, adversarial verifier panel, novelty ledger. **Only the probe layer and the
+prediction protocol are new.**
+
+**The sensor is a bridge, not the accessibility tree.** Sheets, docs and slides render to
+Canvas, so the a11y tree covers the React chrome and essentially nothing where the
+content is. `window.__WB_HUNT__` on the DEV-only `/harness/hunt` route answers a CLOSED
+registry of named readers instead — `doc.text`, `doc.runs`, `doc.fontSizes`,
+`sheet.cellValue`, `sheet.cellCenter`, `canUndo` — over `MemStore`/`MemDocStore`, with
+the real `DocsFormattingToolbar` mounted. No backend, no login, no cleanup risk. A
+registry rather than an `evaluate(<model JS>)` hook, so the reachable surface is bounded
+by reviewed code; membership is an own-property test, because a plain object literal
+resolves `readers["toString"]` through the prototype chain and would have invoked it.
+
+**The driver is a subprocess.** `playwright` resolves from `packages/frontend` and NOT
+from `scripts/agent` (separate installs), and duplicating it would duplicate the version
+`scripts/run-browser-tests-docker.sh` pins against `Dockerfile.playwright`. Spawning
+`packages/frontend/scripts/hunt-ui-runner.mjs` also keeps the async browser behind a
+synchronous call, so `scripts/agent/hunt-probe.mjs`'s `replay()` is reused unchanged.
+
+**Free oracles first, run after every action at zero model cost:** `pageerror`,
+`console-error`, `network-fail`, and Crawljax/ATUSA-style DOM invariants (duplicate ids,
+dangling ARIA references, `undefined`/`NaN`/`[object Object]` in the chrome). Two scoping
+rules keep them from reporting the harness: request failures and browser-generated
+console errors about them are ignored for non-app origins, since Tier 1 has no backend by
+construction; and the placeholder-text scan excludes the editor host, because a user's
+document may legitimately contain the word "undefined". `verify:hunt:oracles` proves each
+one fires on an injected fault and stays quiet on the two negative controls — a detector
+that silently stops firing is invisible, because a clean run and a dead detector produce
+the same empty report.
+
+**The prediction protocol is where a mismatch stops being an opinion.** The oracles only
+catch defects that announce themselves; most real UI bugs do not. So the agent commits to
+an expectation — a NAMED READER plus a COMPARISON from a six-operator closed set, never
+prose — submitted WITH the action, with the runner performing the read in the same
+round-trip so the caller cannot look before committing. Trusted code renders the verdict.
+There is deliberately no regex operator: a model-supplied pattern is code this process
+would execute.
+
+Four grounds, each MECHANICALLY checked rather than trusted:
+
+| ground | claim | what the process verifies |
+|---|---|---|
+| A | the app contradicts itself | `value` must be an `@read:`/`@input:` reference to a SUCCESSFUL, STRICTLY EARLIER journal entry, and a `@read:` must name the same reader — a literal is the model asserting its own belief, which is what A exists to exclude |
+| B | `docs/design/**` says otherwise | bounded `source` matching `CITATION`, in the charter's `docsScope`, no `..` |
+| C | the app's own label says otherwise | the quote must appear in that step's page snapshot |
+| D | general convention | never eligible; journalled for a human |
+
+`UNEVALUABLE IS NOT VIOLATED` is load-bearing: a comparison that cannot be carried out is
+never a finding. Collapsing it into `violated` would turn every malformed prediction into
+a report.
+
+**What the protocol does NOT establish** — recorded because two false findings appeared
+within minutes of it first running, both ground A, both traceable, both reproducing:
+`MemStore.undo()` is a no-op, so any undo prediction on the sheet surface is a guaranteed
+false finding (now askable via `canUndo`); and docs undo is per-keystroke, so expecting a
+typing burst to be one undo step is wrong for reasons unrelated to the product. Grounding
+removes a CLASS of bad predictions, not all of them, which is why the verifier panel stays
+load-bearing and its rubric attacks the EXPECTATION before the behaviour.
+
+**Cross-sample agreement is absent by design**, and Phase 26 dropped it too for the same
+measured reason (see that section). Precision therefore rests on journal-reference
+resolution, the 3x deterministic replay, and the panel — so `actual` participates in
+`uiObservedKey`, or replay would be blind to the very value a violation was computed from.
+
+**No visual channel.** There is no screenshot action, and adding one is rejected rather
+than deferred: a "these overlap" claim traces to nothing, so it is ineligible under every
+ground above, and making it eligible would mean adding the "looks wrong" ground this
+design exists to exclude. Spatial questions on slides/board are exactly computable from
+state instead (`boundingBox`, `combinedBoundingBox`, `framesApproxEqual` are already
+exported). Renderer bugs — model right, paint wrong — remain the visual lane's job, which
+already owns 220 baselines with Docker font pinning. Two instruments, two failure classes.
+
+Status: PR 1 (#642) shipped the executor, harness and oracles; PR 2 (#665) the prediction
+protocol. Still to come: the in-process MCP tool that lets a model drive it, the
+orchestrator and personas with a per-surface selector, repro minimization, the backend
+tier, and slides/board. Nothing is filed automatically; the output is a local report, and
+the CLI hunter's filing gate (20 accepted at >=90%) restarts for this surface because it
+generates candidates by a different mechanism.
+
 ### Phase 27: Panel Feedback Corpus
 
 **Principle:** Entropy Management — the panel has been tuned repeatedly with no

--- a/docs/tasks/active/20260729-autonomous-issue-hunting-todo.md
+++ b/docs/tasks/active/20260729-autonomous-issue-hunting-todo.md
@@ -86,10 +86,12 @@ Design doc: [harness-engineering.md](../../design/harness-engineering.md) → Ph
 
 ## Deferred / Non-Goals
 
-- **UI hunting.** The CLI cannot reach Canvas rendering, CRDT collaboration or
-  frontend interaction — where most open bugs live (#494, #343, #333). A
-  Playwright hunter reusing `verify:frontend:interaction` is the natural next
-  surface, not part of this phase.
+- **UI hunting — no longer deferred; moved to Phase 28.** It was out of scope
+  for this phase, and is now in progress: see
+  `docs/design/harness-engineering.md` (Phase 28). PR 1 (#642) landed the
+  browser executor, the `/harness/hunt` route and the free oracles; PR 2 (#665)
+  adds the prediction protocol. Left listed here so the boundary between the two
+  phases stays readable rather than silently rewritten.
 - **HyperFormula as a formula reference.** GPLv3, incompatible with Apache-2.0.
   `@formulajs/formulajs` (MIT) is the candidate if Step 6 needs one.
 - **Semantic/LLM dedup of candidates.** Deterministic overlap matching only; a model

--- a/packages/frontend/scripts/hunt-ui-runner.mjs
+++ b/packages/frontend/scripts/hunt-ui-runner.mjs
@@ -39,6 +39,12 @@ import { createServer } from "vite";
 // SAME code this runs. A verification script with its own copy would prove only
 // that the copy works.
 import { attachOracles, scanDomInvariants } from "./hunt-ui-oracles.mjs";
+// `boundValue` lives with `isUnusableValue` in the protocol module, so the producer of
+// the oversized/unserializable markers and the predicate that recognises them cannot
+// drift. They did drift once: this file promised the protocol treated markers as
+// unevaluable and the protocol had never heard of them. Importing across the boundary
+// is safe and cheap — the module is pure, and its transitive chain is guarded (~9ms).
+import { boundValue } from "../../../scripts/agent/hunt-ui-expect.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const frontendRoot = path.resolve(__dirname, "..");
@@ -50,8 +56,6 @@ const HOST_TESTID = "hunt-harness-host";
 
 /** Per-action ceiling. A hung action must not hang the run. */
 const DEFAULT_ACTION_TIMEOUT_MS = 10_000;
-/** Cap on one serialized read value, so a `dom.snapshot` cannot dominate the output. */
-const MAX_VALUE_CHARS = 20_000;
 
 // --- argument parsing --------------------------------------------------------
 
@@ -109,7 +113,54 @@ async function loadPlaywright() {
  * else is the page's own bridge. Routing on the prefix keeps the two namespaces from
  * having to know about each other.
  */
+/**
+ * Reader namespaces, duplicated here ON PURPOSE.
+ *
+ * `hunt-ui-probe.mjs` validates these too, but it runs in a different PROCESS — this
+ * driver is invocable directly, and a trusted executor whose only namespace check
+ * lives in an out-of-process validator is not actually bounded. Cheap defence in
+ * depth; the authoritative reader list is still the bridge's.
+ */
+const READER_PREFIXES = ["doc.", "sheet.", "dom."];
+
+function assertReaderName(name) {
+  if (typeof name !== "string" || !READER_PREFIXES.some((p) => name.startsWith(p))) {
+    throw new Error(`reader ${JSON.stringify(name)} must start with one of ${READER_PREFIXES.join(", ")}`);
+  }
+}
+
+/**
+ * Read a value once the UI has stopped changing.
+ *
+ * A single fixed sleep was the only settling window, and a prediction read is not a
+ * display concern — a stale value read a few milliseconds early becomes `violated`,
+ * which becomes an eligible candidate. Because the prediction is deliberately bundled
+ * with its action (so the caller cannot look before committing), the caller has no way
+ * to insert a wait of its own, so the settling has to happen here.
+ *
+ * Two consecutive equal reads is the signal, not a longer sleep: it returns as soon as
+ * the value is stable rather than always paying the worst case, and it does not
+ * silently pass a value that is still moving when the deadline expires — the caller
+ * gets the last read either way, but a still-moving value will then diverge across
+ * replay attempts and be dropped as non-deterministic, which is the correct outcome.
+ */
+async function readSettled(page, name, args, deadlineMs) {
+  const deadline = Date.now() + deadlineMs;
+  let previous = await readValue(page, name, args);
+  let serialized = JSON.stringify(previous ?? null);
+  while (Date.now() < deadline) {
+    await page.waitForTimeout(25);
+    const next = await readValue(page, name, args);
+    const nextSerialized = JSON.stringify(next ?? null);
+    if (nextSerialized === serialized) return next;
+    previous = next;
+    serialized = nextSerialized;
+  }
+  return previous;
+}
+
 async function readValue(page, name, args) {
+  assertReaderName(name);
   if (name === "dom.snapshot") {
     return await page.locator("body").ariaSnapshot();
   }
@@ -169,34 +220,6 @@ async function waitForReady(page, url) {
   );
 }
 
-/**
- * Bound a reader value WITHOUT corrupting it.
- *
- * Values leaving here are compared, not just displayed: `hunt-ui-expect.mjs` checks
- * a prediction against `actual`, and `@read:<i>` resolves a baseline out of an
- * earlier observation. So the obvious "truncate to N chars" is unsafe in a way a
- * display-only clip is not — `[11,18,32]` cut short is a different array, and
- * comparing against it produces a confident WRONG answer rather than no answer.
- * Stringifying is equally unsafe: `each-greater-than` against `"[11,18,32]"` is
- * unevaluable, so every numeric prediction would silently stop working.
- *
- * An oversized value therefore becomes a marker object instead of a shortened one.
- * The protocol treats that as unevaluable — no comparison, and no finding — which is
- * the fail-quiet direction. Formatting for a model to read is a separate concern and
- * belongs at the tool boundary, where clipping is harmless.
- */
-function boundValue(value) {
-  if (value === undefined) return null;
-  let json;
-  try {
-    json = JSON.stringify(value);
-  } catch {
-    return { __unserializable: true };
-  }
-  if (json === undefined) return null;
-  if (json.length <= MAX_VALUE_CHARS) return value;
-  return { __oversized: true, chars: json.length };
-}
 
 async function runAction(page, action, baseUrl, timeoutMs) {
   switch (action.type) {
@@ -291,6 +314,10 @@ async function runAttempt(browser, plan, baseUrl, timeoutMs) {
       }
       // Give async errors from this action a chance to land before draining. Without
       // it a rejection scheduled by the click is attributed to the NEXT action.
+      //
+      // This is the ORACLE window only. It is deliberately NOT the prediction window:
+      // a fixed sleep is fine for "did anything throw" and wrong for "what is the value
+      // now", so the prediction read settles on its own below.
       await page.waitForTimeout(30);
 
       // THE PREDICTION READ, performed in the SAME round-trip as the action.
@@ -308,7 +335,7 @@ async function runAttempt(browser, plan, baseUrl, timeoutMs) {
       let actualError = null;
       if (action.expect && typeof action.expect.read === "string") {
         try {
-          actual = await readValue(page, action.expect.read, action.expect.args ?? []);
+          actual = await readSettled(page, action.expect.read, action.expect.args ?? [], timeoutMs);
         } catch (err) {
           // A failed prediction read is not a failed action, and must not be
           // reported as one — the action may well have succeeded. It leaves `actual`

--- a/packages/frontend/scripts/hunt-ui-runner.mjs
+++ b/packages/frontend/scripts/hunt-ui-runner.mjs
@@ -169,10 +169,33 @@ async function waitForReady(page, url) {
   );
 }
 
-function clip(value) {
-  const text = typeof value === "string" ? value : JSON.stringify(value) ?? String(value);
-  if (typeof text !== "string") return text;
-  return text.length > MAX_VALUE_CHARS ? `${text.slice(0, MAX_VALUE_CHARS)}\n…[truncated]` : text;
+/**
+ * Bound a reader value WITHOUT corrupting it.
+ *
+ * Values leaving here are compared, not just displayed: `hunt-ui-expect.mjs` checks
+ * a prediction against `actual`, and `@read:<i>` resolves a baseline out of an
+ * earlier observation. So the obvious "truncate to N chars" is unsafe in a way a
+ * display-only clip is not — `[11,18,32]` cut short is a different array, and
+ * comparing against it produces a confident WRONG answer rather than no answer.
+ * Stringifying is equally unsafe: `each-greater-than` against `"[11,18,32]"` is
+ * unevaluable, so every numeric prediction would silently stop working.
+ *
+ * An oversized value therefore becomes a marker object instead of a shortened one.
+ * The protocol treats that as unevaluable — no comparison, and no finding — which is
+ * the fail-quiet direction. Formatting for a model to read is a separate concern and
+ * belongs at the tool boundary, where clipping is harmless.
+ */
+function boundValue(value) {
+  if (value === undefined) return null;
+  let json;
+  try {
+    json = JSON.stringify(value);
+  } catch {
+    return { __unserializable: true };
+  }
+  if (json === undefined) return null;
+  if (json.length <= MAX_VALUE_CHARS) return value;
+  return { __oversized: true, chars: json.length };
 }
 
 async function runAction(page, action, baseUrl, timeoutMs) {
@@ -269,13 +292,41 @@ async function runAttempt(browser, plan, baseUrl, timeoutMs) {
       // Give async errors from this action a chance to land before draining. Without
       // it a rejection scheduled by the click is attributed to the NEXT action.
       await page.waitForTimeout(30);
+
+      // THE PREDICTION READ, performed in the SAME round-trip as the action.
+      //
+      // Atomicity is the entire point. If the caller had to issue a separate read to
+      // find out what happened, it could act, look at the result, and only then
+      // decide what it had "expected" — which is the difference between a prediction
+      // and a rationalisation. Submitting `expect` with the action and reading here
+      // means the outcome is fixed before the caller sees anything.
+      //
+      // The runner does NOT compare. It reports `actual` and nothing more; the
+      // verdict is `hunt-ui-expect.mjs`'s to render, in pure code the tests can
+      // exercise without a browser.
+      let actual = null;
+      let actualError = null;
+      if (action.expect && typeof action.expect.read === "string") {
+        try {
+          actual = await readValue(page, action.expect.read, action.expect.args ?? []);
+        } catch (err) {
+          // A failed prediction read is not a failed action, and must not be
+          // reported as one — the action may well have succeeded. It leaves `actual`
+          // null, which the protocol treats as unevaluable rather than a violation.
+          actualError = String(err?.message ?? err);
+        }
+      }
+
       const domFindings = await scanDomInvariants(page, HOST_TESTID);
       observations.push({
         index,
         action,
         ok: error === null,
         error,
-        value: result ? clip(result.value) : null,
+        value: result ? boundValue(result.value) : null,
+        // Present only when the action carried a prediction, so an observation
+        // without one is distinguishable from one whose read returned null.
+        ...(action.expect ? { actual: boundValue(actual), actualError } : {}),
         oracles: [...oracles.drain(), ...domFindings],
       });
     }

--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -221,13 +221,21 @@ async function checkUndoCapability(page, baseUrl) {
   // target and is what a user clicks.
   await page.locator(`[data-testid="${HOST_TESTID}"] canvas`).first().click();
   await page.keyboard.type("Q");
-  await page.waitForTimeout(50);
-  const after = await page.evaluate(() => window.__WB_HUNT__.read("doc.canUndo"));
+  // Poll rather than sleep. The undo stack is pushed asynchronously relative to the
+  // keystroke, so a fixed wait is either flaky on a loaded machine or needlessly slow —
+  // and this lane gates CI. Same reasoning as the positive oracle cases above.
+  let after = null;
+  const deadline = Date.now() + FIRE_DEADLINE_MS;
+  for (;;) {
+    after = await page.evaluate(() => window.__WB_HUNT__.read("doc.canUndo"));
+    if (after === true || Date.now() >= deadline) break;
+    await page.waitForTimeout(25);
+  }
   if (after !== true) {
     problems.push(
-      `doc.canUndo should be true after an edit, got ${JSON.stringify(after)} — this is either a broken ` +
-        "bridge reader (harness fault) or a real docs undo regression (product fault); check MemDocStore's " +
-        "undo stack before assuming the harness.",
+      `doc.canUndo was still ${JSON.stringify(after)} after an edit and ${FIRE_DEADLINE_MS}ms of polling — ` +
+        "either the bridge reader is broken (harness fault) or docs undo regressed (product fault); " +
+        "check MemDocStore's undo stack before assuming either.",
     );
   }
 

--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -191,6 +191,42 @@ async function checkCellTargeting(page, baseUrl) {
   return problems;
 }
 
+/**
+ * Undo capability, checked because a prediction that assumes it produces a
+ * confident FALSE finding when it is absent.
+ *
+ * Measured live: `MemStore.undo()` is a no-op ("No-op for memory store (no history
+ * tracking)") while `MemDocStore` keeps real undo/redo stacks. So the same
+ * prediction is sound on the doc surface and unsound on the sheet surface, and the
+ * bridge exposes `canUndo` so a caller can tell which it is looking at.
+ *
+ * This asserts the POSITIVE capability only — that docs really can undo after an
+ * edit. It deliberately does NOT assert that sheets cannot: that is a limitation
+ * worth fixing, not a contract worth freezing, and pinning it would make an
+ * improvement look like a regression. The sheet value is reported, not enforced.
+ */
+async function checkUndoCapability(page, baseUrl) {
+  const problems = [];
+
+  await page.goto(`${baseUrl}/harness/hunt?surface=doc`, { waitUntil: "networkidle" });
+  await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+  const before = await page.evaluate(() => window.__WB_HUNT__.read("doc.canUndo"));
+  if (before !== false) problems.push(`doc.canUndo should be false on a freshly seeded document, got ${JSON.stringify(before)}`);
+  await page.getByRole("textbox").first().click();
+  await page.keyboard.type("Q");
+  await page.waitForTimeout(50);
+  const after = await page.evaluate(() => window.__WB_HUNT__.read("doc.canUndo"));
+  if (after !== true) problems.push(`doc.canUndo should be true after an edit, got ${JSON.stringify(after)}`);
+
+  await page.goto(`${baseUrl}/harness/hunt?surface=sheet`, { waitUntil: "networkidle" });
+  await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
+  const sheetCanUndo = await page.evaluate(() => window.__WB_HUNT__.read("sheet.canUndo"));
+  if (typeof sheetCanUndo !== "boolean") problems.push(`sheet.canUndo must answer with a boolean, got ${JSON.stringify(sheetCanUndo)}`);
+  else console.log(`[verify:hunt-oracles] sheet.canUndo reports ${sheetCanUndo} (MemStore has no history — informational)`);
+
+  return problems;
+}
+
 async function loadPlaywright() {
   try {
     const mod = await import("playwright");
@@ -300,10 +336,16 @@ try {
     colorScheme: "light",
   });
   try {
-    const problems = await checkCellTargeting(await targetingContext.newPage(), baseUrl);
+    const page = await targetingContext.newPage();
+    const problems = await checkCellTargeting(page, baseUrl);
     for (const p of problems) failures.push(`cell targeting: ${p}`);
     if (problems.length === 0) {
       console.log(`[verify:hunt-oracles] cell clicks land correctly: ${TARGETING_CELLS.join(", ")}`);
+    }
+    const undoProblems = await checkUndoCapability(page, baseUrl);
+    for (const p of undoProblems) failures.push(`undo capability: ${p}`);
+    if (undoProblems.length === 0) {
+      console.log("[verify:hunt-oracles] doc.canUndo tracks a real undo stack");
     }
   } finally {
     await targetingContext.close();

--- a/packages/frontend/scripts/verify-hunt-oracles.mjs
+++ b/packages/frontend/scripts/verify-hunt-oracles.mjs
@@ -212,11 +212,24 @@ async function checkUndoCapability(page, baseUrl) {
   await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
   const before = await page.evaluate(() => window.__WB_HUNT__.read("doc.canUndo"));
   if (before !== false) problems.push(`doc.canUndo should be false on a freshly seeded document, got ${JSON.stringify(before)}`);
-  await page.getByRole("textbox").first().click();
+  // NOT getByRole("textbox"): on the doc surface that resolves to the editor's hidden
+  // IME textarea — `position:fixed;top:0;left:0;width:1px;height:1px;opacity:0`
+  // (docs/src/view/text-editor.ts:416-425). Clicking a 1x1 invisible element pinned at
+  // the viewport origin happens to work, but it is a caret-placement path no other
+  // lane in this repo uses, and Playwright's visibility/stability checks on it are a
+  // plausible 30s timeout that would fail the whole lane. The canvas is the real
+  // target and is what a user clicks.
+  await page.locator(`[data-testid="${HOST_TESTID}"] canvas`).first().click();
   await page.keyboard.type("Q");
   await page.waitForTimeout(50);
   const after = await page.evaluate(() => window.__WB_HUNT__.read("doc.canUndo"));
-  if (after !== true) problems.push(`doc.canUndo should be true after an edit, got ${JSON.stringify(after)}`);
+  if (after !== true) {
+    problems.push(
+      `doc.canUndo should be true after an edit, got ${JSON.stringify(after)} — this is either a broken ` +
+        "bridge reader (harness fault) or a real docs undo regression (product fault); check MemDocStore's " +
+        "undo stack before assuming the harness.",
+    );
+  }
 
   await page.goto(`${baseUrl}/harness/hunt?surface=sheet`, { waitUntil: "networkidle" });
   await page.waitForSelector(READY_SELECTOR, { timeout: 20_000 });
@@ -368,4 +381,6 @@ if (failures.length > 0) {
   for (const f of failures) console.error(`  - ${f}`);
   process.exit(1);
 }
-console.log(`[verify:hunt-oracles] all ${CASES.length} oracle checks + cell targeting passed.`);
+console.log(
+  `[verify:hunt-oracles] all ${CASES.length} oracle checks + cell targeting + undo capability passed.`,
+);

--- a/packages/frontend/src/app/harness/hunt/bridge.ts
+++ b/packages/frontend/src/app/harness/hunt/bridge.ts
@@ -285,10 +285,18 @@ export function installHuntBridge(): HuntBridgeController {
     surface: () => state.surface,
     readers: () => Object.keys(readers).sort(),
     read: async (name, args = []) => {
-      const reader = readers[name];
-      if (!reader) {
+      // `Object.hasOwn`, not `readers[name]`. A plain object literal inherits from
+      // Object.prototype, so `readers["toString"]`, `["constructor"]` and
+      // `["valueOf"]` all resolve to inherited FUNCTIONS and were invoked instead of
+      // refused. Harmless in effect here — nothing dangerous is reachable that way —
+      // but a reader registry whose membership test is a prototype-chain lookup is not
+      // the closed set this design claims, and the closed set is the safety property.
+      // `hasOwnProperty.call`, not `Object.hasOwn` — this file compiles under a
+      // pre-ES2022 lib target.
+      if (!Object.prototype.hasOwnProperty.call(readers, name)) {
         refuse(`unknown reader ${JSON.stringify(name)}. Valid readers: ${Object.keys(readers).sort().join(", ")}`);
       }
+      const reader = readers[name];
       // Awaited here so a rejected reader surfaces as a refusal from `read` rather
       // than as an unhandled rejection inside the page — which the crash oracle
       // would then report as a defect in the app under test.

--- a/packages/frontend/src/app/harness/hunt/bridge.ts
+++ b/packages/frontend/src/app/harness/hunt/bridge.ts
@@ -186,6 +186,24 @@ function buildReaders(state: BridgeState): Record<string, (args: unknown[]) => u
 
     "doc.linkCount": () => runsOf(requireDoc(state).editor).filter((r) => typeof r.href === "string").length,
 
+    /**
+     * Can this surface undo right now?
+     *
+     * Exposed because the two in-memory stores DISAGREE, and a caller that assumes
+     * otherwise produces a confident false finding. Measured live:
+     *
+     *   MemDocStore  real snapshot-based undo/redo stacks (docs/src/store/memory.ts)
+     *   MemStore     `undo()` returns {success:false}; `canUndo()` returns false,
+     *                marked "No-op for memory store (no history tracking)"
+     *
+     * So "I edited, then undid, so the value came back" is a sound prediction on the
+     * doc surface and an unsound one on the sheet surface — not because the product
+     * is broken, but because the sheet mount is a test double without history. The
+     * real app uses a Yorkie-backed store that has it. Asking before predicting is
+     * the difference between a finding and noise.
+     */
+    "doc.canUndo": () => requireDoc(state).editor.getStore().canUndo(),
+
     // --- sheets -----------------------------------------------------------
     "sheet.cellValue": async (args) => {
       const sref = asString(args, 0, "sheet.cellValue");
@@ -209,6 +227,9 @@ function buildReaders(state: BridgeState): Record<string, (args: unknown[]) => u
       if (!range) return null;
       return { start: toSref(range[0]), end: toSref(range[1]) };
     },
+
+    /** See `doc.canUndo`. Reports `false` here, because `MemStore` has no history. */
+    "sheet.canUndo": () => requireSheet(state).store.canUndo(),
 
     /**
      * Viewport coordinates of a cell's centre.

--- a/scripts/agent/hunt-ui-expect.mjs
+++ b/scripts/agent/hunt-ui-expect.mjs
@@ -240,7 +240,17 @@ export function resolveExpectationRefs(expect, journal, { atIndex = null } = {})
    * knows which step is predicting. When it is absent the check cannot run, which is
    * why the orchestrator (PR 4) must pass it.
    */
-  const before = (i) => atIndex === null || !Number.isInteger(atIndex) || i < atIndex;
+  const before = (i) => {
+    // Only ABSENT means "cannot check". A present-but-malformed index — "0", 0.5, NaN —
+    // used to satisfy `!Number.isInteger(atIndex)` and wave the ordering check through,
+    // so a caller with an off-by-one bug in its own bookkeeping silently re-enabled the
+    // self-reference generator. Verified: `atIndex: "0"` and `atIndex: 0.5` both made a
+    // `not-equals @read:0` self-reference eligible. A safety check must not fail open on
+    // input it does not understand.
+    if (atIndex === null || atIndex === undefined) return true;
+    if (!Number.isInteger(atIndex)) return false;
+    return i < atIndex;
+  };
 
   const read = READ_REF.exec(raw);
   if (read) {

--- a/scripts/agent/hunt-ui-expect.mjs
+++ b/scripts/agent/hunt-ui-expect.mjs
@@ -1,0 +1,397 @@
+// The PREDICTION PROTOCOL — where a UI mismatch stops being an opinion.
+//
+// WHY THIS EXISTS. The free oracles from PR 1 only catch defects that announce
+// themselves: a crash, a console error, a broken DOM. Most real UI bugs do none of
+// that — the app carries on cheerfully doing the wrong thing. Every UI bug this
+// repo's design doc cites is of that kind: "increase font size" made text smaller,
+// "edit link" inserted one, typing landed in the wrong table. Nothing threw.
+//
+// Catching those means letting the agent say what it expected. And the moment an
+// agent may say "that was wrong", it is both prosecutor and judge — which is the
+// documented way to end up with curl's inbox. This module takes the judge's job
+// back, and it is the whole of the precision argument for the UI hunter now that
+// cross-sample agreement is gone from the pipeline (#662).
+//
+// FOUR RULES, all mechanical:
+//
+//   1. A prediction is a NAMED READER plus a COMPARISON, never prose. If the model
+//      cannot say what it expects as a value some reader returns, it does not get to
+//      expect it. "The document should look right" is unsayable here.
+//
+//   2. The prediction is submitted WITH the action and the model never sees the
+//      result first (enforced in the runner, which performs the read in the same
+//      round-trip). It cannot revise an expectation to fit what happened.
+//
+//   3. Ground A — "the app contradicts itself" — requires the expected value to be
+//      a REFERENCE INTO THE JOURNAL, never a literal. A literal is the model
+//      asserting a fact from its own belief about how spreadsheets ought to behave,
+//      which is exactly what ground A exists to exclude. `@read:4` means "whatever
+//      reader I ran at step 4 returned", so the baseline comes from the app's own
+//      earlier behaviour.
+//
+//   4. UNEVALUABLE IS NOT VIOLATED. A comparison that cannot be carried out —
+//      `each-greater-than` against a string, a reference that does not resolve — is
+//      never a finding. Fail quiet, the same direction as `hunt-gate.mjs`: a model
+//      that writes a nonsense comparison must not get a defect out of it.
+//
+// NO REGEX OPERATOR, deliberately, though the plan listed one. A model-supplied
+// pattern is code this process would execute, with catastrophic-backtracking as the
+// obvious hazard, and `contains` covers what `matches` was for. Adding it later
+// needs a bounded matcher, not `new RegExp`.
+//
+// ============================================================================
+// WHAT THIS DOES NOT CATCH — read before trusting an eligible candidate.
+// ============================================================================
+// The grounding check removes a CLASS of bad predictions: unsourced ones, invented
+// UI quotes, out-of-scope doc citations, references to steps that never happened. It
+// does NOT establish that a well-sourced prediction was a REASONABLE one. Two false
+// findings turned up within minutes of this module first running, both ground A,
+// both traceable to a real earlier read, both reproducing deterministically:
+//
+//   1. CAPABILITY GAP. "I edited a cell, then undid, so the old value is back" —
+//      violated, because `MemStore.undo()` is a no-op ("No-op for memory store (no
+//      history tracking)"). The product is fine; the sheet surface mounts a test
+//      double without history. Mechanically avoidable, and now avoidable: the bridge
+//      exposes `sheet.canUndo`/`doc.canUndo`, and the two disagree. Ask first.
+//
+//   2. GRANULARITY ASSUMPTION. "I typed XYZ, then undid, so the text is back" —
+//      violated, because docs undo is per-keystroke: one undo left "XY". Whether
+//      undo SHOULD coalesce a typing burst is a convention judgement (ground D),
+//      not a self-contradiction. No mechanical check separates that from a real
+//      defect, because the difference is entirely in what a reader ought to expect.
+//
+// Case 2 is why the verifier panel stays load-bearing and why its rubric attacks
+// the EXPECTATION before the behaviour. `refutedAfterReplay` in the funnel is the
+// number that says how often this is happening; if it climbs, the protocol is too
+// permissive, not the verifiers too strict.
+//
+// Pure and dependency-free: `node:` and relative imports only, because the
+// `agent:tests` lane runs with `scripts/agent/node_modules` absent.
+
+import { CITATION } from "./citation.mjs";
+import { citationInScope } from "./hunt-gate.mjs";
+
+/**
+ * The complete comparison vocabulary.
+ *
+ * Small on purpose. Every operator here is total over the values a reader can
+ * return, decidable without executing anything the model wrote, and has an obvious
+ * negation. `changed-from`/`unchanged` from the sketch are absent: once ground A
+ * requires a reference for every operator they add nothing over
+ * `not-equals`/`equals`, and a redundant operator is one more thing to get wrong.
+ */
+export const EXPECT_OPS = Object.freeze([
+  "equals",
+  "not-equals",
+  "contains",
+  "not-contains",
+  "each-greater-than",
+  "each-less-than",
+]);
+
+/**
+ * Where a prediction's authority comes from. See `checkGround` for what each one
+ * has to prove — the letter is a claim, not a credential.
+ */
+export const EXPECT_GROUNDS = Object.freeze(["A", "B", "C", "D"]);
+
+/** `@read:<i>` — the value reader at journal index i returned. */
+const READ_REF = /^@read:(\d+)$/;
+/** `@input:<i>` — the text the agent itself typed at journal index i. */
+const INPUT_REF = /^@input:(\d+)$/;
+
+/** Longest quote `checkGround` will look for in a page snapshot (ground C). */
+const MAX_QUOTE_CHARS = 200;
+
+function isRef(value) {
+  return typeof value === "string" && (READ_REF.test(value) || INPUT_REF.test(value));
+}
+
+// --- shape ------------------------------------------------------------------
+
+/**
+ * Validate a prediction's SHAPE, returning a list of problems (empty = usable).
+ *
+ * Returns rather than throws: a malformed prediction is not an exception, it is a
+ * candidate that will not be eligible, and the caller wants every reason at once so
+ * the run log can say what was wrong instead of only the first thing.
+ */
+export function checkExpectationShape(expect) {
+  const problems = [];
+  if (!expect || typeof expect !== "object") return ["not an object"];
+
+  if (typeof expect.read !== "string" || expect.read === "") problems.push("`read` must be a non-empty reader name");
+  if (expect.args !== undefined && !Array.isArray(expect.args)) problems.push("`args` must be an array when present");
+  if (!EXPECT_OPS.includes(expect.op)) {
+    problems.push(`\`op\` must be one of ${EXPECT_OPS.join(", ")} (got ${JSON.stringify(expect.op)})`);
+  }
+  if (!("value" in expect)) problems.push("`value` is required (a literal, or an @read:/@input: reference)");
+  if (!EXPECT_GROUNDS.includes(expect.ground)) {
+    problems.push(`\`ground\` must be one of ${EXPECT_GROUNDS.join(", ")} (got ${JSON.stringify(expect.ground)})`);
+  }
+  // Prose that a human reads when triaging. Not machine-checked, and deliberately
+  // not load-bearing anywhere — nothing downstream branches on it.
+  if (typeof expect.because !== "string" || expect.because.trim() === "") {
+    problems.push("`because` must say why, in one line");
+  }
+  // B and C are claims ABOUT something external, so they have to name it.
+  if ((expect.ground === "B" || expect.ground === "C") && (typeof expect.source !== "string" || expect.source === "")) {
+    problems.push(`ground ${expect.ground} requires \`source\``);
+  }
+  return problems;
+}
+
+// --- references -------------------------------------------------------------
+
+/**
+ * Resolve a prediction's `value` against the session journal.
+ *
+ * This is the ground-A check, and the reason it can be a check at all rather than a
+ * hope. A model may write `ground: "A"` on anything; it cannot make `@read:4`
+ * resolve to a reading that never happened. Same property as the CLI hunter's
+ * `probeRefs` — evidence is cited, not authored.
+ *
+ * Returns `{ value, trace }` on success and `null` on any failure. Fails QUIET, so
+ * an unresolvable reference costs the candidate rather than raising: dropping is
+ * safe, and a reference nobody can follow is exactly what must not become a report.
+ */
+export function resolveExpectationRefs(expect, journal) {
+  const entries = Array.isArray(journal) ? journal : [];
+  const raw = expect?.value;
+
+  if (!isRef(raw)) {
+    // A literal is legal for grounds B/C/D. `checkGround` is what refuses it for A.
+    return { value: raw, trace: null };
+  }
+
+  const read = READ_REF.exec(raw);
+  if (read) {
+    const i = Number(read[1]);
+    const entry = entries[i];
+    if (!entry || entry.action?.type !== "read") return null;
+    // A read that failed observed nothing, so it cannot be a baseline.
+    if (entry.ok !== true) return null;
+    return {
+      value: entry.value,
+      trace: { kind: "read", index: i, reader: entry.action?.reader ?? null },
+    };
+  }
+
+  const input = INPUT_REF.exec(raw);
+  if (input) {
+    const i = Number(input[1]);
+    const entry = entries[i];
+    if (!entry || entry.action?.type !== "type") return null;
+    if (entry.ok !== true) return null;
+    if (typeof entry.action.text !== "string") return null;
+    return { value: entry.action.text, trace: { kind: "input", index: i, reader: null } };
+  }
+
+  return null;
+}
+
+// --- evaluation -------------------------------------------------------------
+
+/** Deep-ish equality over JSON-shaped reader values. */
+function sameValue(a, b) {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+function numbersOf(value) {
+  const list = Array.isArray(value) ? value : [value];
+  // `undefined` is what a reader returns for an unset style, and it is not a
+  // number — treating it as one would make "every size increased" trivially true.
+  return list.every((n) => typeof n === "number" && Number.isFinite(n)) ? list : null;
+}
+
+/**
+ * Decide whether a prediction held. THE ONLY PLACE A MISMATCH IS DECIDED.
+ *
+ * `verdict` is one of:
+ *   `held`        the prediction was right — no finding
+ *   `violated`    the prediction was wrong — a candidate, if its ground checks out
+ *   `unevaluable` the comparison could not be carried out — NOT a finding
+ *
+ * That third value is the load-bearing one. Collapsing it into `violated` would
+ * turn every malformed comparison into a defect report, which is precisely the
+ * failure mode this whole module exists to prevent. Collapsing it into `held` would
+ * be safe but silent, so it stays distinct and gets counted.
+ *
+ * `expectedValue` is passed separately from `expect.value` because it has already
+ * been through `resolveExpectationRefs` — comparing against the literal string
+ * "@read:4" is a bug this signature makes hard to write.
+ */
+export function evaluateExpectation(expect, actual, expectedValue) {
+  const op = expect?.op;
+  if (!EXPECT_OPS.includes(op)) return { verdict: "unevaluable", detail: `unknown op ${JSON.stringify(op)}` };
+
+  switch (op) {
+    case "equals":
+      return sameValue(actual, expectedValue)
+        ? { verdict: "held", detail: "equal" }
+        : { verdict: "violated", detail: `expected ${JSON.stringify(expectedValue)}, read ${JSON.stringify(actual)}` };
+
+    case "not-equals":
+      return sameValue(actual, expectedValue)
+        ? { verdict: "violated", detail: `expected a change from ${JSON.stringify(expectedValue)}, read the same value` }
+        : { verdict: "held", detail: "differs" };
+
+    case "contains":
+    case "not-contains": {
+      const wants = op === "contains";
+      let has;
+      if (typeof actual === "string") has = actual.includes(String(expectedValue));
+      else if (Array.isArray(actual)) has = actual.some((x) => sameValue(x, expectedValue));
+      else return { verdict: "unevaluable", detail: `${op} needs a string or array, read ${typeof actual}` };
+      if (has === wants) return { verdict: "held", detail: wants ? "present" : "absent" };
+      return {
+        verdict: "violated",
+        detail: `expected ${JSON.stringify(expectedValue)} to be ${wants ? "present" : "absent"}`,
+      };
+    }
+
+    case "each-greater-than":
+    case "each-less-than": {
+      const got = numbersOf(actual);
+      const want = numbersOf(expectedValue);
+      if (!got || !want) {
+        return { verdict: "unevaluable", detail: `${op} needs finite numbers on both sides` };
+      }
+      // Pairwise when the lengths match — that is the "every run got bigger" shape.
+      // A length change means the comparison is not about the same things any more,
+      // which is unevaluable rather than a violation.
+      if (got.length !== want.length) {
+        return { verdict: "unevaluable", detail: `length changed ${want.length} -> ${got.length}` };
+      }
+      const ok = got.every((n, i) => (op === "each-greater-than" ? n > want[i] : n < want[i]));
+      return ok
+        ? { verdict: "held", detail: `every value ${op === "each-greater-than" ? "increased" : "decreased"}` }
+        : {
+            verdict: "violated",
+            detail: `expected every value to ${op === "each-greater-than" ? "increase" : "decrease"}: ${JSON.stringify(want)} -> ${JSON.stringify(got)}`,
+          };
+    }
+
+    default:
+      return { verdict: "unevaluable", detail: `unhandled op ${JSON.stringify(op)}` };
+  }
+}
+
+// --- grounding --------------------------------------------------------------
+
+/**
+ * Is this prediction's claimed authority real?
+ *
+ * The tier letter is what the model asserts; this is what the process verifies. A
+ * violated prediction whose ground does not check out is NOT a candidate — it is
+ * journalled and forgotten.
+ *
+ * Returns `{ eligible, why }`. `why` always says something, including on success,
+ * so the run log can show what a candidate was admitted on rather than only what
+ * killed one.
+ */
+export function checkGround(expect, { journal = [], snapshot = "", charter = {} } = {}) {
+  const ground = expect?.ground;
+
+  if (ground === "D") {
+    // "Ctrl+Z should undo", "Tab should move to the next cell". Often right, and
+    // sourced from nothing but the model's prior about other software — so it is
+    // where the slop lives. Journalled for a human to skim, never reportable.
+    return { eligible: false, why: "ground D (convention) is never eligible — logged for a human, not reported" };
+  }
+
+  if (ground === "A") {
+    // A literal here is the model asserting a fact it believes, which is the exact
+    // thing "self-evident" must not mean. The value has to come from the app's own
+    // earlier behaviour.
+    if (!isRef(expect?.value)) {
+      return {
+        eligible: false,
+        why: "ground A requires `value` to be an @read:/@input: reference, not a literal — a literal is the model's own belief",
+      };
+    }
+    const resolved = resolveExpectationRefs(expect, journal);
+    if (!resolved) {
+      return { eligible: false, why: `ground A reference ${JSON.stringify(expect.value)} does not resolve to a successful journal entry` };
+    }
+    // Comparing one reader's output against another's is a category error that would
+    // "violate" on almost any input — `doc.blockCount` was never going to equal
+    // `sheet.cellValue`. Cross-reader comparisons are still expressible at B/C/D,
+    // where something external backs them.
+    if (resolved.trace?.kind === "read" && resolved.trace.reader !== expect.read) {
+      return {
+        eligible: false,
+        why: `ground A compares reader \`${expect.read}\` against \`${resolved.trace.reader}\` at ${expect.value} — different readers are not a self-contradiction`,
+      };
+    }
+    return { eligible: true, why: `ground A traced to journal ${resolved.trace.kind} #${resolved.trace.index}` };
+  }
+
+  if (ground === "B") {
+    // A documented promise. Reuses the gate's own definition of what counts as a
+    // citation and what counts as in scope, so "evidence" means one thing across
+    // both hunters.
+    const source = expect?.source;
+    if (typeof source !== "string" || !CITATION.test(source)) {
+      return { eligible: false, why: `ground B \`source\` must locate a line (file.ext:123), got ${JSON.stringify(source)}` };
+    }
+    if (!citationInScope(source, charter?.docsScope)) {
+      return { eligible: false, why: `ground B source ${source} is outside this charter's docsScope` };
+    }
+    return { eligible: true, why: `ground B cited ${source}` };
+  }
+
+  if (ground === "C") {
+    // The app's own words. Checkable because the snapshot is what the page actually
+    // said at that step — a quote the model invented is not in it.
+    const quote = expect?.source;
+    if (typeof quote !== "string" || quote.trim() === "") {
+      return { eligible: false, why: "ground C `source` must quote the UI text being relied on" };
+    }
+    if (quote.length > MAX_QUOTE_CHARS) {
+      return { eligible: false, why: `ground C quote is ${quote.length} chars; keep it under ${MAX_QUOTE_CHARS}` };
+    }
+    if (typeof snapshot !== "string" || !snapshot.includes(quote)) {
+      return { eligible: false, why: `ground C quote ${JSON.stringify(quote)} does not appear in the page snapshot at that step` };
+    }
+    return { eligible: true, why: `ground C quoted on-screen text ${JSON.stringify(quote)}` };
+  }
+
+  return { eligible: false, why: `unknown ground ${JSON.stringify(ground)}` };
+}
+
+/**
+ * The whole protocol for one prediction: shape, then reference, then comparison,
+ * then ground.
+ *
+ * Order matters and is the same fail-quiet order the CLI hunter uses. In
+ * particular the GROUND is checked last, after a violation is established, so the
+ * run log can distinguish "predicted wrongly" from "predicted on a basis we do not
+ * accept" — two very different things that a single boolean would merge.
+ */
+export function assessExpectation(expect, actual, { journal = [], snapshot = "", charter = {} } = {}) {
+  const shape = checkExpectationShape(expect);
+  if (shape.length > 0) {
+    return { verdict: "unevaluable", eligible: false, why: `malformed prediction: ${shape.join("; ")}`, detail: null };
+  }
+
+  const resolved = resolveExpectationRefs(expect, journal);
+  if (!resolved) {
+    return {
+      verdict: "unevaluable",
+      eligible: false,
+      why: `reference ${JSON.stringify(expect.value)} does not resolve to a successful journal entry`,
+      detail: null,
+    };
+  }
+
+  const { verdict, detail } = evaluateExpectation(expect, actual, resolved.value);
+  if (verdict !== "violated") {
+    // Nothing to ground. A prediction that held, or one that could not be judged,
+    // is not a candidate no matter how well sourced it was.
+    return { verdict, eligible: false, why: verdict === "held" ? "prediction held" : detail, detail };
+  }
+
+  const ground = checkGround(expect, { journal, snapshot, charter });
+  return { verdict, eligible: ground.eligible, why: ground.why, detail, trace: resolved.trace };
+}

--- a/scripts/agent/hunt-ui-expect.mjs
+++ b/scripts/agent/hunt-ui-expect.mjs
@@ -102,9 +102,72 @@ const INPUT_REF = /^@input:(\d+)$/;
 
 /** Longest quote `checkGround` will look for in a page snapshot (ground C). */
 const MAX_QUOTE_CHARS = 200;
+/**
+ * Ground B's `source` is model-supplied and goes into `CITATION`, whose
+ * `[^\s:]+\.[A-Za-z0-9_]+` prefix backtracks on a long non-matching run. Bounded for
+ * the same reason ground C's quote is.
+ */
+const MAX_SOURCE_CHARS = 300;
 
 function isRef(value) {
   return typeof value === "string" && (READ_REF.test(value) || INPUT_REF.test(value));
+}
+
+/**
+ * Is this value a stand-in the runner emitted because it could not deliver the real
+ * one? `boundValue` substitutes `{__oversized}` / `{__unserializable}` rather than a
+ * truncated value, precisely so nothing compares against a corrupted one.
+ *
+ * NOTHING IMPLEMENTED THIS UNTIL A REVIEW CAUGHT IT. Both this module's header and
+ * the runner's `boundValue` docblock asserted the protocol treated these as
+ * unevaluable; it did not. `equals` compared the marker as an ordinary object, so an
+ * oversized read against a resolved ground-A baseline produced `violated` and an
+ * ELIGIBLE candidate — a false finding manufactured by a value the runner had
+ * already declared it could not measure. Two markers compared to each other were
+ * worse: `equals` said `held`, hiding a real difference.
+ *
+ * A prose invariant that nothing enforces is not an invariant.
+ */
+export function isUnusableValue(value) {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value.__oversized === true || value.__unserializable === true)
+  );
+}
+
+/** Beyond this, a serialized reader value is replaced by a marker. */
+export const MAX_VALUE_CHARS = 20_000;
+
+/**
+ * Bound a reader value WITHOUT corrupting it. The producer half of the marker
+ * contract, deliberately in the SAME module as `isUnusableValue`.
+ *
+ * It began life in the runner, which is how the two halves drifted: the runner's
+ * docblock promised the protocol treated markers as unevaluable, the protocol had never
+ * heard of them, and no single file was wrong on its own. Producer and predicate now
+ * live side by side, so that particular disagreement is not expressible.
+ *
+ * Why a marker rather than a shortened value: what leaves the runner is COMPARED, not
+ * just displayed. `[11,18,32]` cut short is a different array, and comparing against it
+ * yields a confident WRONG answer instead of no answer. Stringifying is equally unsafe —
+ * `each-greater-than` against `"[11,18,32]"` is unevaluable, so every numeric prediction
+ * would quietly stop working. Formatting for a model to read is a separate concern that
+ * belongs at the tool boundary, where clipping is harmless.
+ */
+export function boundValue(value) {
+  if (value === undefined) return null;
+  let json;
+  try {
+    json = JSON.stringify(value);
+  } catch {
+    // A circular structure, or a BigInt. Either way it cannot cross the process
+    // boundary, so it must not masquerade as a value that did.
+    return { __unserializable: true };
+  }
+  if (json === undefined) return null;
+  if (json.length <= MAX_VALUE_CHARS) return value;
+  return { __oversized: true, chars: json.length };
 }
 
 // --- shape ------------------------------------------------------------------
@@ -155,7 +218,7 @@ export function checkExpectationShape(expect) {
  * an unresolvable reference costs the candidate rather than raising: dropping is
  * safe, and a reference nobody can follow is exactly what must not become a report.
  */
-export function resolveExpectationRefs(expect, journal) {
+export function resolveExpectationRefs(expect, journal, { atIndex = null } = {}) {
   const entries = Array.isArray(journal) ? journal : [];
   const raw = expect?.value;
 
@@ -164,13 +227,31 @@ export function resolveExpectationRefs(expect, journal) {
     return { value: raw, trace: null };
   }
 
+  /**
+   * A baseline must come from a step STRICTLY BEFORE the one predicting against it.
+   *
+   * Without this, an action can reference its own journal entry, and the degenerate
+   * case is unconditionally reportable: a `read` action carrying
+   * `not-equals @read:<its own index>` compares the same reading to itself, so it
+   * violates every single time while passing every grounding check — traceable,
+   * same-reader, deterministic on replay. A defect generator with a valid passport.
+   *
+   * `atIndex` is optional because the ordering can only be checked when the caller
+   * knows which step is predicting. When it is absent the check cannot run, which is
+   * why the orchestrator (PR 4) must pass it.
+   */
+  const before = (i) => atIndex === null || !Number.isInteger(atIndex) || i < atIndex;
+
   const read = READ_REF.exec(raw);
   if (read) {
     const i = Number(read[1]);
+    if (!before(i)) return null;
     const entry = entries[i];
     if (!entry || entry.action?.type !== "read") return null;
     // A read that failed observed nothing, so it cannot be a baseline.
     if (entry.ok !== true) return null;
+    // Nor can a value the runner could not deliver.
+    if (isUnusableValue(entry.value)) return null;
     return {
       value: entry.value,
       trace: { kind: "read", index: i, reader: entry.action?.reader ?? null },
@@ -180,6 +261,7 @@ export function resolveExpectationRefs(expect, journal) {
   const input = INPUT_REF.exec(raw);
   if (input) {
     const i = Number(input[1]);
+    if (!before(i)) return null;
     const entry = entries[i];
     if (!entry || entry.action?.type !== "type") return null;
     if (entry.ok !== true) return null;
@@ -192,9 +274,28 @@ export function resolveExpectationRefs(expect, journal) {
 
 // --- evaluation -------------------------------------------------------------
 
-/** Deep-ish equality over JSON-shaped reader values. */
+/**
+ * Deep equality over JSON-shaped reader values, key-order independent.
+ *
+ * Two fixes over the naive `JSON.stringify(a ?? null)`. Object key ORDER is not
+ * semantic — `doc.styleSummary` is assembled by the editor and two runs need not agree
+ * on ordering — so keys are sorted before comparing, or a reordering would read as a
+ * violation. And `undefined` is NOT collapsed into `null`: an unset style and a
+ * present-but-null value are different observations, and `?? null` merged them.
+ */
+function stable(value) {
+  if (value === undefined) return "\u0000undefined";
+  if (value === null) return "null";
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  if (typeof value === "object") {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${stable(value[k])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
 function sameValue(a, b) {
-  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+  return stable(a) === stable(b);
 }
 
 function numbersOf(value) {
@@ -225,6 +326,16 @@ export function evaluateExpectation(expect, actual, expectedValue) {
   const op = expect?.op;
   if (!EXPECT_OPS.includes(op)) return { verdict: "unevaluable", detail: `unknown op ${JSON.stringify(op)}` };
 
+  // BEFORE any operator runs. A marker means the runner could not deliver the value,
+  // so there is nothing to compare on that side — and every operator below is total
+  // over objects, so without this guard each one would happily return a verdict.
+  if (isUnusableValue(actual)) {
+    return { verdict: "unevaluable", detail: `read value is unusable: ${JSON.stringify(actual)}` };
+  }
+  if (isUnusableValue(expectedValue)) {
+    return { verdict: "unevaluable", detail: `baseline value is unusable: ${JSON.stringify(expectedValue)}` };
+  }
+
   switch (op) {
     case "equals":
       return sameValue(actual, expectedValue)
@@ -240,8 +351,15 @@ export function evaluateExpectation(expect, actual, expectedValue) {
     case "not-contains": {
       const wants = op === "contains";
       let has;
-      if (typeof actual === "string") has = actual.includes(String(expectedValue));
-      else if (Array.isArray(actual)) has = actual.some((x) => sameValue(x, expectedValue));
+      if (typeof actual === "string") {
+        // No String(expectedValue). Coercing turned a type error into a comparison —
+        // an object became "[object Object]" and then genuinely "was not present",
+        // reporting `violated` for what is really a malformed prediction.
+        if (typeof expectedValue !== "string") {
+          return { verdict: "unevaluable", detail: `${op} against a string needs a string, got ${typeof expectedValue}` };
+        }
+        has = actual.includes(expectedValue);
+      } else if (Array.isArray(actual)) has = actual.some((x) => sameValue(x, expectedValue));
       else return { verdict: "unevaluable", detail: `${op} needs a string or array, read ${typeof actual}` };
       if (has === wants) return { verdict: "held", detail: wants ? "present" : "absent" };
       return {
@@ -262,6 +380,12 @@ export function evaluateExpectation(expect, actual, expectedValue) {
       // which is unevaluable rather than a violation.
       if (got.length !== want.length) {
         return { verdict: "unevaluable", detail: `length changed ${want.length} -> ${got.length}` };
+      }
+      // `[].every(...)` is true, so an empty comparison would report `held` — a pass
+      // asserting nothing. Saying so is more useful than a vacuous success, and it
+      // catches the case where a selection reader legitimately returned nothing.
+      if (got.length === 0) {
+        return { verdict: "unevaluable", detail: `${op} over an empty list asserts nothing` };
       }
       const ok = got.every((n, i) => (op === "each-greater-than" ? n > want[i] : n < want[i]));
       return ok
@@ -290,7 +414,7 @@ export function evaluateExpectation(expect, actual, expectedValue) {
  * so the run log can show what a candidate was admitted on rather than only what
  * killed one.
  */
-export function checkGround(expect, { journal = [], snapshot = "", charter = {} } = {}) {
+export function checkGround(expect, { journal = [], snapshot = "", charter = {}, atIndex = null } = {}) {
   const ground = expect?.ground;
 
   if (ground === "D") {
@@ -310,7 +434,7 @@ export function checkGround(expect, { journal = [], snapshot = "", charter = {} 
         why: "ground A requires `value` to be an @read:/@input: reference, not a literal — a literal is the model's own belief",
       };
     }
-    const resolved = resolveExpectationRefs(expect, journal);
+    const resolved = resolveExpectationRefs(expect, journal, { atIndex });
     if (!resolved) {
       return { eligible: false, why: `ground A reference ${JSON.stringify(expect.value)} does not resolve to a successful journal entry` };
     }
@@ -332,6 +456,16 @@ export function checkGround(expect, { journal = [], snapshot = "", charter = {} 
     // citation and what counts as in scope, so "evidence" means one thing across
     // both hunters.
     const source = expect?.source;
+    if (typeof source === "string" && source.length > MAX_SOURCE_CHARS) {
+      return { eligible: false, why: `ground B source is ${source.length} chars; keep it under ${MAX_SOURCE_CHARS}` };
+    }
+    // `docs/design/../../etc/x:1` matches a `docs/design/**` glob while pointing
+    // elsewhere. Nothing here reads the path from disk, so this is a misleading-citation
+    // guard rather than a traversal one — but a citation that does not mean what it
+    // says is not evidence.
+    if (typeof source === "string" && source.split("/").includes("..")) {
+      return { eligible: false, why: `ground B source must not contain ".." (got ${JSON.stringify(source)})` };
+    }
     if (typeof source !== "string" || !CITATION.test(source)) {
       return { eligible: false, why: `ground B \`source\` must locate a line (file.ext:123), got ${JSON.stringify(source)}` };
     }
@@ -369,18 +503,38 @@ export function checkGround(expect, { journal = [], snapshot = "", charter = {} 
  * run log can distinguish "predicted wrongly" from "predicted on a basis we do not
  * accept" — two very different things that a single boolean would merge.
  */
-export function assessExpectation(expect, actual, { journal = [], snapshot = "", charter = {} } = {}) {
+export function assessExpectation(
+  expect,
+  actual,
+  { journal = [], snapshot = "", charter = {}, actualError = null, atIndex = null } = {},
+) {
   const shape = checkExpectationShape(expect);
   if (shape.length > 0) {
     return { verdict: "unevaluable", eligible: false, why: `malformed prediction: ${shape.join("; ")}`, detail: null };
   }
 
-  const resolved = resolveExpectationRefs(expect, journal);
+  // A prediction read that THREW measured nothing, so there is nothing to judge.
+  //
+  // The runner emitted `actualError` for exactly this and nothing consumed it, which
+  // left a browser failure looking like a defect: `actual` came back null, `equals`
+  // against a resolved baseline said `violated`, and ground A having traced, the
+  // candidate was eligible. Infrastructure trouble manufacturing a report is the
+  // fail-quiet inversion this module's header forbids.
+  //
+  // Keyed on `actualError` and NOT on `actual === null`, deliberately: null is a
+  // legitimate reading. `sheet.cellValue` of an empty cell is null, and so is
+  // `doc.selection` with nothing selected. Treating null as unevaluable would silently
+  // blind the hunter to every defect about emptiness.
+  if (actualError) {
+    return { verdict: "unevaluable", eligible: false, why: `prediction read failed: ${actualError}`, detail: null };
+  }
+
+  const resolved = resolveExpectationRefs(expect, journal, { atIndex });
   if (!resolved) {
     return {
       verdict: "unevaluable",
       eligible: false,
-      why: `reference ${JSON.stringify(expect.value)} does not resolve to a successful journal entry`,
+      why: `reference ${JSON.stringify(expect.value)} does not resolve to a successful EARLIER journal entry`,
       detail: null,
     };
   }
@@ -392,6 +546,6 @@ export function assessExpectation(expect, actual, { journal = [], snapshot = "",
     return { verdict, eligible: false, why: verdict === "held" ? "prediction held" : detail, detail };
   }
 
-  const ground = checkGround(expect, { journal, snapshot, charter });
+  const ground = checkGround(expect, { journal, snapshot, charter, atIndex });
   return { verdict, eligible: ground.eligible, why: ground.why, detail, trace: resolved.trace };
 }

--- a/scripts/agent/hunt-ui-expect.test.mjs
+++ b/scripts/agent/hunt-ui-expect.test.mjs
@@ -1,0 +1,282 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import {
+  assessExpectation,
+  checkExpectationShape,
+  checkGround,
+  evaluateExpectation,
+  resolveExpectationRefs,
+  EXPECT_GROUNDS,
+  EXPECT_OPS,
+} from "./hunt-ui-expect.mjs";
+
+/** A journal entry as the runner emits one. */
+const readEntry = (reader, value, ok = true) => ({ action: { type: "read", reader }, ok, value });
+const typeEntry = (text, ok = true) => ({ action: { type: "type", text }, ok, value: null });
+
+/** The #343 shape: a mixed-size selection whose sizes must all increase. */
+const JOURNAL = [
+  readEntry("doc.fontSizes", [11, 18, 32]), // 0
+  typeEntry("hello world"), //                 1
+  readEntry("sheet.cellValue", "30"), //       2
+  readEntry("doc.fontSizes", [11, 18, 32], false), // 3 — the read FAILED
+];
+
+const A = (over = {}) => ({
+  read: "doc.fontSizes",
+  op: "each-greater-than",
+  value: "@read:0",
+  ground: "A",
+  because: "increase must increase every size in the selection",
+  ...over,
+});
+
+const CHARTER = { docsScope: ["docs/design/**", "packages/cli/README.md"] };
+
+// --- shape ------------------------------------------------------------------
+
+test("checkExpectationShape accepts a well-formed prediction", () => {
+  assert.deepEqual(checkExpectationShape(A()), []);
+});
+
+test("checkExpectationShape refuses an operator outside the closed set", () => {
+  assert.match(checkExpectationShape(A({ op: "looks-wrong" }))[0], /`op` must be one of/);
+  assert.match(checkExpectationShape(A({ op: undefined }))[0], /`op` must be one of/);
+});
+
+// A model-supplied pattern is code this process would execute, and catastrophic
+// backtracking is the obvious hazard. `contains` covers what it was for.
+test("EXPECT_OPS has no regex operator", () => {
+  for (const banned of ["matches", "regex", "test", "eval"]) {
+    assert.equal(EXPECT_OPS.includes(banned), false, `${banned} must not be an operator`);
+  }
+});
+
+test("checkExpectationShape requires a reader, a value and a reason", () => {
+  assert.match(checkExpectationShape(A({ read: "" }))[0], /non-empty reader name/);
+  const noValue = { ...A() };
+  delete noValue.value;
+  assert.match(checkExpectationShape(noValue).join(" "), /`value` is required/);
+  assert.match(checkExpectationShape(A({ because: "  " })).join(" "), /`because` must say why/);
+});
+
+test("checkExpectationShape requires a source for grounds B and C only", () => {
+  assert.match(checkExpectationShape(A({ ground: "B" })).join(" "), /ground B requires `source`/);
+  assert.match(checkExpectationShape(A({ ground: "C" })).join(" "), /ground C requires `source`/);
+  assert.deepEqual(checkExpectationShape(A({ ground: "D" })), [], "D needs no external source");
+  assert.deepEqual(checkExpectationShape(A({ ground: "A" })), [], "A is sourced from the journal");
+});
+
+test("checkExpectationShape refuses an unknown ground", () => {
+  assert.match(checkExpectationShape(A({ ground: "E" })).join(" "), /`ground` must be one of/);
+  assert.deepEqual(EXPECT_GROUNDS, ["A", "B", "C", "D"]);
+});
+
+// --- references -------------------------------------------------------------
+
+test("resolveExpectationRefs reads a value back out of the journal", () => {
+  const got = resolveExpectationRefs(A(), JOURNAL);
+  assert.deepEqual(got.value, [11, 18, 32]);
+  assert.deepEqual(got.trace, { kind: "read", index: 0, reader: "doc.fontSizes" });
+});
+
+test("resolveExpectationRefs resolves text the agent itself typed", () => {
+  const got = resolveExpectationRefs(A({ op: "contains", value: "@input:1", read: "doc.text" }), JOURNAL);
+  assert.equal(got.value, "hello world");
+  assert.equal(got.trace.kind, "input");
+});
+
+test("resolveExpectationRefs passes a literal through untouched", () => {
+  // Legal for grounds B/C/D; `checkGround` is what refuses it for A.
+  assert.deepEqual(resolveExpectationRefs(A({ value: 42 }), JOURNAL), { value: 42, trace: null });
+});
+
+// The honesty property: a model cannot cite a reading that never happened.
+test("resolveExpectationRefs refuses a reference to a step that does not exist", () => {
+  assert.equal(resolveExpectationRefs(A({ value: "@read:99" }), JOURNAL), null);
+  assert.equal(resolveExpectationRefs(A({ value: "@read:0" }), []), null);
+});
+
+test("resolveExpectationRefs refuses a reference to the wrong KIND of step", () => {
+  // Step 1 is a `type`, not a `read`.
+  assert.equal(resolveExpectationRefs(A({ value: "@read:1" }), JOURNAL), null);
+  // Step 0 is a `read`, not a `type`.
+  assert.equal(resolveExpectationRefs(A({ value: "@input:0" }), JOURNAL), null);
+});
+
+test("resolveExpectationRefs refuses a reference to a step that FAILED", () => {
+  // Step 3 read nothing, so it cannot be a baseline for anything.
+  assert.equal(resolveExpectationRefs(A({ value: "@read:3" }), JOURNAL), null);
+});
+
+// --- evaluation -------------------------------------------------------------
+
+test("evaluateExpectation: each-greater-than on the #343 shape", () => {
+  const e = A();
+  // Every size rose — the prediction held.
+  assert.equal(evaluateExpectation(e, [12, 19, 33], [11, 18, 32]).verdict, "held");
+  // All collapsed to the minimum — the defect that issue describes.
+  const bad = evaluateExpectation(e, [11, 11, 11], [11, 18, 32]);
+  assert.equal(bad.verdict, "violated");
+  assert.match(bad.detail, /\[11,18,32\] -> \[11,11,11\]/);
+  // Unchanged is a violation too: "increase" that did nothing did not increase.
+  assert.equal(evaluateExpectation(e, [11, 18, 32], [11, 18, 32]).verdict, "violated");
+});
+
+test("evaluateExpectation: equals / not-equals over reader-shaped values", () => {
+  const eq = A({ op: "equals", read: "sheet.cellValue" });
+  assert.equal(evaluateExpectation(eq, "5", "5").verdict, "held");
+  assert.equal(evaluateExpectation(eq, "6", "5").verdict, "violated");
+  assert.equal(evaluateExpectation(eq, [1, 2], [1, 2]).verdict, "held", "deep, not reference, equality");
+  const ne = A({ op: "not-equals", read: "sheet.cellValue" });
+  assert.equal(evaluateExpectation(ne, "6", "5").verdict, "held");
+  assert.equal(evaluateExpectation(ne, "5", "5").verdict, "violated");
+});
+
+test("evaluateExpectation: contains / not-contains over strings and arrays", () => {
+  const c = A({ op: "contains", read: "doc.text" });
+  assert.equal(evaluateExpectation(c, "say hello world", "hello").verdict, "held");
+  assert.equal(evaluateExpectation(c, "say goodbye", "hello").verdict, "violated");
+  assert.equal(evaluateExpectation(c, ["a", "b"], "b").verdict, "held");
+  const n = A({ op: "not-contains", read: "doc.text" });
+  assert.equal(evaluateExpectation(n, "clean", "undefined").verdict, "held");
+  assert.equal(evaluateExpectation(n, "saved by undefined", "undefined").verdict, "violated");
+});
+
+// THE load-bearing distinction in this file. A comparison that cannot be carried out
+// must never become a defect: collapsing `unevaluable` into `violated` would turn
+// every malformed prediction into a report, which is the failure this module exists
+// to prevent.
+test("evaluateExpectation: an impossible comparison is UNEVALUABLE, never violated", () => {
+  // Numbers demanded, a string read.
+  assert.equal(evaluateExpectation(A(), "not a number", [11]).verdict, "unevaluable");
+  // Numbers demanded, `undefined` read — an unset style is not a number, and
+  // treating it as one would make "everything increased" trivially true.
+  assert.equal(evaluateExpectation(A(), [12, undefined], [11, 18]).verdict, "unevaluable");
+  // The selection changed size, so the two sides are not about the same things.
+  assert.equal(evaluateExpectation(A(), [12, 19], [11, 18, 32]).verdict, "unevaluable");
+  // `contains` against a number.
+  assert.equal(evaluateExpectation(A({ op: "contains" }), 7, "x").verdict, "unevaluable");
+  // An operator outside the set cannot be evaluated either.
+  assert.equal(evaluateExpectation(A({ op: "nope" }), 1, 1).verdict, "unevaluable");
+});
+
+// --- grounding --------------------------------------------------------------
+
+test("checkGround: ground A traced to the journal is eligible", () => {
+  const got = checkGround(A(), { journal: JOURNAL, charter: CHARTER });
+  assert.equal(got.eligible, true);
+  assert.match(got.why, /traced to journal read #0/);
+});
+
+// The single most important rejection here. `ground: "A"` is a claim the model
+// makes; a literal means the baseline came from its own belief about how the app
+// ought to behave, which is exactly what "the app contradicts itself" must exclude.
+test("checkGround: ground A REFUSES a literal value", () => {
+  const got = checkGround(A({ value: [11, 18, 32] }), { journal: JOURNAL, charter: CHARTER });
+  assert.equal(got.eligible, false);
+  assert.match(got.why, /requires `value` to be an @read:\/@input: reference/);
+});
+
+test("checkGround: ground A refuses a reference that does not resolve", () => {
+  for (const value of ["@read:99", "@read:1", "@read:3"]) {
+    const got = checkGround(A({ value }), { journal: JOURNAL, charter: CHARTER });
+    assert.equal(got.eligible, false, `${value} must not be eligible`);
+    assert.match(got.why, /does not resolve/);
+  }
+});
+
+// A cross-reader comparison "violates" on almost any input — doc.blockCount was
+// never going to equal sheet.cellValue — so it is a category error, not a
+// self-contradiction. Still expressible at B/C/D, where something external backs it.
+test("checkGround: ground A refuses a reference to a DIFFERENT reader", () => {
+  const got = checkGround(A({ read: "doc.blockCount", value: "@read:2" }), { journal: JOURNAL, charter: CHARTER });
+  assert.equal(got.eligible, false);
+  assert.match(got.why, /different readers are not a self-contradiction/);
+});
+
+test("checkGround: ground B needs a citation that locates a line, in docsScope", () => {
+  const ok = checkGround(A({ ground: "B", source: "docs/design/cli.md:707" }), { journal: JOURNAL, charter: CHARTER });
+  assert.equal(ok.eligible, true);
+  // A bare filename locates nothing.
+  assert.equal(checkGround(A({ ground: "B", source: "cli.md" }), { journal: JOURNAL, charter: CHARTER }).eligible, false);
+  // In-shape but outside the charter's documentation scope.
+  const outOfScope = checkGround(A({ ground: "B", source: "packages/cli/src/output/formatter.ts:44" }), {
+    journal: JOURNAL,
+    charter: CHARTER,
+  });
+  assert.equal(outOfScope.eligible, false);
+  assert.match(outOfScope.why, /outside this charter's docsScope/);
+});
+
+test("checkGround: ground C requires the quote to be ON THE PAGE", () => {
+  const snapshot = '- button "Increase font size"\n- spinbutton "Font size": "11"';
+  const ok = checkGround(A({ ground: "C", source: 'button "Increase font size"' }), { journal: JOURNAL, snapshot, charter: CHARTER });
+  assert.equal(ok.eligible, true);
+  // A quote the model invented is not in the snapshot.
+  const invented = checkGround(A({ ground: "C", source: 'button "Make text bigger"' }), { journal: JOURNAL, snapshot, charter: CHARTER });
+  assert.equal(invented.eligible, false);
+  assert.match(invented.why, /does not appear in the page snapshot/);
+  // And an empty snapshot cannot support any quote.
+  assert.equal(checkGround(A({ ground: "C", source: "x" }), { journal: JOURNAL, snapshot: "", charter: CHARTER }).eligible, false);
+});
+
+test("checkGround: ground D is NEVER eligible", () => {
+  // Well-formed, perfectly plausible, and still not reportable — this is where
+  // "Ctrl+Z should undo" lives, and it is sourced from nothing but the model's
+  // prior about other software.
+  const got = checkGround(A({ ground: "D", value: "@read:0" }), { journal: JOURNAL, charter: CHARTER });
+  assert.equal(got.eligible, false);
+  assert.match(got.why, /never eligible/);
+});
+
+// --- the whole protocol -----------------------------------------------------
+
+test("assessExpectation: a grounded violation is a candidate", () => {
+  const got = assessExpectation(A(), [11, 11, 11], { journal: JOURNAL, charter: CHARTER });
+  assert.equal(got.verdict, "violated");
+  assert.equal(got.eligible, true);
+  assert.deepEqual(got.trace, { kind: "read", index: 0, reader: "doc.fontSizes" });
+});
+
+test("assessExpectation: a prediction that HELD is never a candidate", () => {
+  const got = assessExpectation(A(), [12, 19, 33], { journal: JOURNAL, charter: CHARTER });
+  assert.equal(got.verdict, "held");
+  assert.equal(got.eligible, false);
+});
+
+test("assessExpectation: an ungrounded violation is not a candidate", () => {
+  // Really did behave unexpectedly — and the basis is a convention, so it is logged
+  // and forgotten rather than reported.
+  const got = assessExpectation(A({ ground: "D" }), [11, 11, 11], { journal: JOURNAL, charter: CHARTER });
+  assert.equal(got.verdict, "violated", "the mismatch is still recorded");
+  assert.equal(got.eligible, false, "but it cannot become a report");
+});
+
+test("assessExpectation: the ground is checked AFTER the comparison", () => {
+  // So the log can distinguish "predicted wrongly" from "predicted on a basis we do
+  // not accept". A ground-D prediction that HELD reports `held`, not the ground.
+  assert.equal(assessExpectation(A({ ground: "D" }), [12, 19, 33], { journal: JOURNAL, charter: CHARTER }).why, "prediction held");
+});
+
+test("assessExpectation: malformed and unresolvable predictions are unevaluable, not violations", () => {
+  const malformed = assessExpectation(A({ op: "vibes" }), [1], { journal: JOURNAL, charter: CHARTER });
+  assert.equal(malformed.verdict, "unevaluable");
+  assert.equal(malformed.eligible, false);
+  assert.match(malformed.why, /malformed prediction/);
+
+  const dangling = assessExpectation(A({ value: "@read:99" }), [1], { journal: JOURNAL, charter: CHARTER });
+  assert.equal(dangling.verdict, "unevaluable");
+  assert.equal(dangling.eligible, false);
+  assert.match(dangling.why, /does not resolve/);
+});
+
+test("assessExpectation: no ground can make an unevaluable comparison reportable", () => {
+  for (const ground of EXPECT_GROUNDS) {
+    const e = ground === "A" ? A() : A({ ground, source: "docs/design/cli.md:1", value: "@read:0" });
+    const got = assessExpectation(e, "not a number", { journal: JOURNAL, snapshot: "docs/design/cli.md:1", charter: CHARTER });
+    assert.equal(got.verdict, "unevaluable", `ground ${ground}`);
+    assert.equal(got.eligible, false, `ground ${ground} must not be eligible on an unevaluable comparison`);
+  }
+});

--- a/scripts/agent/hunt-ui-expect.test.mjs
+++ b/scripts/agent/hunt-ui-expect.test.mjs
@@ -358,6 +358,24 @@ test("REGRESSION: a reference must point BEFORE the predicting action", () => {
 
   // A forward reference is refused too.
   assert.equal(resolveExpectationRefs({ ...e, value: "@read:5" }, journal, { atIndex: 2 }), null);
+
+  // A PRESENT but malformed index must not wave the check through. It used to: the
+  // guard tested `!Number.isInteger(atIndex)`, which is true for "0" and 0.5, so a
+  // caller with an off-by-one in its own bookkeeping silently re-enabled the
+  // self-reference generator. Only absence means "cannot check".
+  for (const bad of ["0", 0.5, Number.NaN, -1, {}, []]) {
+    assert.equal(
+      resolveExpectationRefs(e, journal, { atIndex: bad }),
+      null,
+      `atIndex ${JSON.stringify(bad) ?? String(bad)} must not resolve`,
+    );
+    const assessed = assessExpectation(e, "hello", { journal, charter: CHARTER, atIndex: bad });
+    assert.equal(assessed.eligible, false, `atIndex ${String(bad)} must not be eligible`);
+  }
+  // Absent still means "the caller cannot say", which stays permissive by design —
+  // the orchestrator is what must pass it.
+  assert.ok(resolveExpectationRefs(e, journal, { atIndex: null }));
+  assert.ok(resolveExpectationRefs(e, journal, {}));
   // And a genuinely earlier one still resolves.
   const later = [...journal, { action: { type: "key", key: "x" }, ok: true, value: null }];
   assert.ok(resolveExpectationRefs(e, later, { atIndex: 1 }));

--- a/scripts/agent/hunt-ui-expect.test.mjs
+++ b/scripts/agent/hunt-ui-expect.test.mjs
@@ -6,6 +6,9 @@ import {
   checkExpectationShape,
   checkGround,
   evaluateExpectation,
+  boundValue,
+  isUnusableValue,
+  MAX_VALUE_CHARS,
   resolveExpectationRefs,
   EXPECT_GROUNDS,
   EXPECT_OPS,
@@ -279,4 +282,186 @@ test("assessExpectation: no ground can make an unevaluable comparison reportable
     assert.equal(got.verdict, "unevaluable", `ground ${ground}`);
     assert.equal(got.eligible, false, `ground ${ground} must not be eligible on an unevaluable comparison`);
   }
+});
+
+// --- review findings, each pinned -------------------------------------------
+
+// The contract the runner's `boundValue` docblock asserted and nothing implemented.
+// An oversized read against a resolved ground-A baseline produced `violated` and an
+// ELIGIBLE candidate: a false finding built from a value the runner had already said
+// it could not measure.
+test("REGRESSION: an oversized/unserializable marker is unevaluable, never a verdict", () => {
+  const marker = { __oversized: true, chars: 25_000 };
+  assert.equal(isUnusableValue(marker), true);
+  assert.equal(isUnusableValue({ __unserializable: true }), true);
+  assert.equal(isUnusableValue([11, 18, 32]), false);
+  assert.equal(isUnusableValue(null), false, "null is a legitimate reader value, not a marker");
+
+  // Either side unusable → no comparison, whatever the operator.
+  for (const op of EXPECT_OPS) {
+    assert.equal(evaluateExpectation(A({ op }), marker, [11, 18, 32]).verdict, "unevaluable", `actual, ${op}`);
+    assert.equal(evaluateExpectation(A({ op }), [11, 18, 32], marker).verdict, "unevaluable", `baseline, ${op}`);
+  }
+  // Two markers previously reported `held` for equals — worse than a false violation,
+  // because it hid a real difference.
+  assert.equal(evaluateExpectation(A({ op: "equals" }), marker, marker).verdict, "unevaluable");
+  assert.equal(evaluateExpectation(A({ op: "not-equals" }), marker, marker).verdict, "unevaluable");
+
+  // And end to end: not eligible, so it cannot become a report.
+  const got = assessExpectation(A(), marker, { journal: JOURNAL, charter: CHARTER });
+  assert.equal(got.verdict, "unevaluable");
+  assert.equal(got.eligible, false);
+});
+
+test("REGRESSION: a marker can never serve as a @read baseline", () => {
+  const journal = [{ action: { type: "read", reader: "doc.fontSizes" }, ok: true, value: { __oversized: true, chars: 9 } }];
+  assert.equal(resolveExpectationRefs(A(), journal), null);
+});
+
+// The runner emits `actualError` when the prediction read throws, and nothing consumed
+// it — so a browser failure surfaced as `actual: null`, compared cleanly to a resolved
+// baseline, and became an eligible candidate. Infrastructure manufacturing a report.
+test("REGRESSION: a failed prediction read is unevaluable, not a violation", () => {
+  const got = assessExpectation(A({ op: "equals", read: "sheet.cellValue" }), null, {
+    journal: JOURNAL,
+    charter: CHARTER,
+    actualError: "hunt bridge is not installed",
+  });
+  assert.equal(got.verdict, "unevaluable");
+  assert.equal(got.eligible, false);
+  assert.match(got.why, /prediction read failed/);
+});
+
+// The discriminator is `actualError`, NOT `actual === null`. Null is a real reading —
+// an empty cell, an absent selection — and treating it as unevaluable would blind the
+// hunter to every defect about emptiness.
+test("a legitimate null reading is still judged", () => {
+  const journal = [{ action: { type: "read", reader: "sheet.cellValue" }, ok: true, value: "10" }];
+  const e = { read: "sheet.cellValue", op: "equals", value: "@read:0", ground: "A", because: "x" };
+  const got = assessExpectation(e, null, { journal, charter: CHARTER });
+  assert.equal(got.verdict, "violated", "cell went from 10 to empty — that is a real observation");
+  assert.equal(got.eligible, true);
+});
+
+// A `read` action carrying `not-equals @read:<its own index>` compares a reading to
+// itself, so it violated every time while passing every grounding check — traceable,
+// same-reader, and deterministic on replay.
+test("REGRESSION: a reference must point BEFORE the predicting action", () => {
+  const e = { read: "doc.text", op: "not-equals", value: "@read:0", ground: "A", because: "x" };
+  const journal = [{ action: { type: "read", reader: "doc.text", expect: e }, ok: true, value: "hello" }];
+
+  // Self-reference: refused once the caller says which step is predicting.
+  assert.equal(resolveExpectationRefs(e, journal, { atIndex: 0 }), null);
+  const selfRef = assessExpectation(e, "hello", { journal, charter: CHARTER, atIndex: 0 });
+  assert.equal(selfRef.eligible, false);
+  assert.match(selfRef.why, /EARLIER/);
+
+  // A forward reference is refused too.
+  assert.equal(resolveExpectationRefs({ ...e, value: "@read:5" }, journal, { atIndex: 2 }), null);
+  // And a genuinely earlier one still resolves.
+  const later = [...journal, { action: { type: "key", key: "x" }, ok: true, value: null }];
+  assert.ok(resolveExpectationRefs(e, later, { atIndex: 1 }));
+});
+
+test("contains does not coerce a non-string expectation", () => {
+  // String({}) is "[object Object]", which then genuinely "was not present" — turning
+  // a malformed prediction into a violation.
+  const e = A({ op: "contains", read: "doc.text" });
+  assert.equal(evaluateExpectation(e, "some text", { a: 1 }).verdict, "unevaluable");
+  assert.equal(evaluateExpectation(e, "some text", 42).verdict, "unevaluable");
+  assert.equal(evaluateExpectation(e, "some text", "text").verdict, "held");
+});
+
+test("each-* over an empty list is unevaluable, not a vacuous pass", () => {
+  // [].every(...) is true, so this used to report `held` while asserting nothing.
+  assert.equal(evaluateExpectation(A(), [], []).verdict, "unevaluable");
+});
+
+test("sameValue is key-order independent and keeps undefined distinct from null", () => {
+  const e = A({ op: "equals", read: "doc.styleSummary" });
+  // Reader-assembled objects need not agree on key order between runs.
+  assert.equal(evaluateExpectation(e, { bold: true, fontSize: 11 }, { fontSize: 11, bold: true }).verdict, "held");
+  // An unset style and a present-null are different observations.
+  assert.equal(evaluateExpectation(e, { fontSize: undefined }, { fontSize: null }).verdict, "violated");
+});
+
+test("ground B bounds its source and rejects traversal", () => {
+  const long = `${"a".repeat(400)}.md:1`;
+  const bounded = checkGround(A({ ground: "B", source: long }), { journal: JOURNAL, charter: CHARTER });
+  assert.equal(bounded.eligible, false);
+  assert.match(bounded.why, /chars; keep it under/);
+
+  const traversal = checkGround(A({ ground: "B", source: "docs/design/../../etc/passwd:1" }), {
+    journal: JOURNAL,
+    charter: CHARTER,
+  });
+  assert.equal(traversal.eligible, false);
+  assert.match(traversal.why, /must not contain/);
+});
+
+test("the ground-C quote ceiling is enforced", () => {
+  const quote = "x".repeat(201);
+  const got = checkGround(A({ ground: "C", source: quote }), { journal: JOURNAL, snapshot: quote, charter: CHARTER });
+  assert.equal(got.eligible, false);
+  assert.match(got.why, /keep it under 200/);
+});
+
+test("an @input-based ground A is eligible", () => {
+  // The other half of ground A: the app should reflect what the agent typed.
+  const e = { read: "doc.text", op: "contains", value: "@input:1", ground: "A", because: "typed text appears" };
+  const got = assessExpectation(e, "before hello world after", { journal: JOURNAL, charter: CHARTER, atIndex: 4 });
+  assert.equal(got.verdict, "held");
+  const violated = assessExpectation(e, "nothing landed", { journal: JOURNAL, charter: CHARTER, atIndex: 4 });
+  assert.equal(violated.verdict, "violated");
+  assert.equal(violated.eligible, true);
+});
+
+test("checkExpectationShape requires args to be an array", () => {
+  assert.match(checkExpectationShape(A({ args: "A1" })).join(" "), /`args` must be an array/);
+  assert.deepEqual(checkExpectationShape(A({ args: ["A1"] })), []);
+});
+
+// --- boundValue: the producer half of the marker contract --------------------
+
+// Untestable while it lived in the Playwright driver (importing that boots Vite), which
+// is how it came to promise a behaviour the protocol did not implement.
+test("boundValue keeps a normal value exactly as-is", () => {
+  for (const v of [[11, 18, 32], "hello", 42, true, null, { a: 1 }]) {
+    assert.deepEqual(boundValue(v), v);
+  }
+});
+
+test("boundValue normalises undefined to null", () => {
+  // JSON.stringify(undefined) is undefined, which would drop the field entirely and
+  // make "the reader returned nothing" indistinguishable from "there was no read".
+  assert.equal(boundValue(undefined), null);
+});
+
+test("boundValue substitutes a marker rather than truncating", () => {
+  const big = "x".repeat(MAX_VALUE_CHARS + 1);
+  const got = boundValue(big);
+  assert.equal(got.__oversized, true);
+  assert.ok(got.chars > MAX_VALUE_CHARS);
+  // The point of the marker: nothing downstream can mistake it for the value.
+  assert.equal(isUnusableValue(got), true);
+  assert.equal(typeof got === "string", false, "a shortened string would compare wrongly");
+});
+
+test("boundValue marks an unserializable value instead of throwing", () => {
+  const circular = {};
+  circular.self = circular;
+  const got = boundValue(circular);
+  assert.deepEqual(got, { __unserializable: true });
+  assert.equal(isUnusableValue(got), true);
+});
+
+test("boundValue's markers round-trip to unevaluable, end to end", () => {
+  // The contract that was asserted in prose and implemented nowhere: what the producer
+  // emits, the evaluator must refuse to judge.
+  const big = boundValue("y".repeat(MAX_VALUE_CHARS + 1));
+  const journal = [{ action: { type: "read", reader: "doc.text" }, ok: true, value: "small" }];
+  const e = { read: "doc.text", op: "equals", value: "@read:0", ground: "A", because: "x" };
+  const got = assessExpectation(e, big, { journal, charter: CHARTER, atIndex: 1 });
+  assert.equal(got.verdict, "unevaluable");
+  assert.equal(got.eligible, false);
 });

--- a/scripts/agent/hunt-ui-probe.mjs
+++ b/scripts/agent/hunt-ui-probe.mjs
@@ -222,7 +222,13 @@ export function uiObservedKey(observation) {
       .sort()
       .join(",") || "none";
   const err = o.ok === true ? "none" : classifyUiError(o.error);
-  return `act:${type}${reader ? `(${reader})` : ""}|ok:${o.ok === true}|err:${err}|oracles:${oracles}|value:${valueKey(o.value)}`;
+  // `actual` participates for the same reason `value` does, and more urgently: it is
+  // the value a prediction verdict RESTS on. Leaving it out made replay — the
+  // determinism gate that exists to kill phantom repros — blind to the one number a
+  // violation was computed from, so a flaky prediction outcome sailed through 3/3
+  // identical attempts. `actualError` is folded in as a class, not a message.
+  const predicted = "actual" in o ? `|actual:${valueKey(o.actual)}|aerr:${o.actualError ? classifyUiError(o.actualError) : "none"}` : "";
+  return `act:${type}${reader ? `(${reader})` : ""}|ok:${o.ok === true}|err:${err}|oracles:${oracles}|value:${valueKey(o.value)}${predicted}`;
 }
 
 /**

--- a/scripts/agent/hunt-ui-probe.mjs
+++ b/scripts/agent/hunt-ui-probe.mjs
@@ -29,6 +29,7 @@ import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { scrubVolatile } from "./hunt-fingerprint.mjs";
+import { checkExpectationShape } from "./hunt-ui-expect.mjs";
 import { withScratch } from "./hunt-probe.mjs";
 
 /** Relative to the repo root — the driver, which is where playwright resolves. */
@@ -100,6 +101,15 @@ export function assertSafeActionPlan(plan) {
     if (!action || typeof action !== "object") bad(`${where} must be an object, got ${JSON.stringify(action)}`);
     if (!UI_ACTION_TYPES.includes(action.type)) {
       bad(`${where} has unknown type ${JSON.stringify(action.type)}; valid: ${UI_ACTION_TYPES.join(", ")}`);
+    }
+    // A prediction is validated HERE, before a browser boots, for the same reason
+    // the action vocabulary is: a shape problem should surface at the plan rather
+    // than eight seconds later inside Playwright. The reader also goes through the
+    // same namespace check as any other, so `expect.read` is not a way around it.
+    if (action.expect !== undefined) {
+      const problems = checkExpectationShape(action.expect);
+      if (problems.length > 0) bad(`${where} prediction is malformed: ${problems.join("; ")}`);
+      assertReader(action.expect.read, `${where} prediction`);
     }
     switch (action.type) {
       case "goto":

--- a/scripts/agent/hunt-ui-probe.test.mjs
+++ b/scripts/agent/hunt-ui-probe.test.mjs
@@ -279,3 +279,55 @@ test("runUiPlan throws when the driver reports its own failure", () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+// --- prediction validation (added in PR 2, untested until a review said so) ---
+
+test("assertSafeActionPlan validates a prediction attached to any action", () => {
+  const withExpect = (expect) => ({ actions: [{ type: "key", key: "z", expect }] });
+  assert.equal(
+    assertSafeActionPlan(
+      withExpect({ read: "doc.text", op: "equals", value: "@read:0", ground: "A", because: "x" }),
+    ),
+    true,
+  );
+  assert.throws(() => assertSafeActionPlan(withExpect({ read: "doc.text", op: "vibes", value: 1, ground: "A", because: "x" })), /prediction is malformed/);
+  assert.throws(() => assertSafeActionPlan(withExpect({ op: "equals", value: 1, ground: "A", because: "x" })), /prediction is malformed/);
+  assert.throws(() => assertSafeActionPlan(withExpect({ read: "doc.text", op: "equals", value: 1, ground: "Z", because: "x" })), /prediction is malformed/);
+  // An action with no prediction stays valid — `expect` is optional.
+  assert.equal(assertSafeActionPlan({ actions: [{ type: "key", key: "z" }] }), true);
+});
+
+// `expect.read` must not be a way around the namespace gate that every other reader
+// goes through.
+test("assertSafeActionPlan refuses a prediction reader outside the namespaces", () => {
+  const escape = { actions: [{ type: "key", key: "z", expect: { read: "eval.window", op: "equals", value: 1, ground: "B", because: "x", source: "docs/a.md:1" } }] };
+  assert.throws(() => assertSafeActionPlan(escape), /prediction reader "eval.window" must start with one of/);
+});
+
+// --- the prediction outcome must reach the replay key ------------------------
+
+// `actual` is the value a verdict RESTS on. Leaving it out of the key made replay —
+// the determinism gate that exists to kill phantom repros — blind to the one number a
+// violation was computed from, so a flaky prediction sailed through 3/3 attempts.
+test("REGRESSION: uiObservedKey distinguishes different prediction outcomes", () => {
+  const withActual = (actual) => obs({ action: { type: "key", key: "Control+z" }, actual });
+  assert.notEqual(uiObservedKey(withActual("10")), uiObservedKey(withActual("999")));
+  assert.equal(uiObservedKey(withActual("10")), uiObservedKey(withActual("10")));
+  // A read that failed is a different outcome from one that returned null.
+  const failed = obs({ action: { type: "key", key: "z" }, actual: null, actualError: "hunt bridge is not installed" });
+  const nulled = obs({ action: { type: "key", key: "z" }, actual: null, actualError: null });
+  assert.notEqual(uiObservedKey(failed), uiObservedKey(nulled));
+});
+
+test("uiObservedKey is unchanged for actions carrying no prediction", () => {
+  // Absence of the field, not a null value — so an action without a prediction keys
+  // exactly as it did before predictions existed.
+  const plain = uiObservedKey(obs({ action: { type: "click" } }));
+  assert.equal(plain.includes("actual:"), false);
+});
+
+test("uiObservedKey scrubs volatile values inside a prediction outcome too", () => {
+  const a = obs({ action: { type: "key", key: "z" }, actual: '{"blockId":"block-1785735868118-3"}' });
+  const b = obs({ action: { type: "key", key: "z" }, actual: '{"blockId":"block-1785735870911-3"}' });
+  assert.equal(uiObservedKey(a), uiObservedKey(b));
+});


### PR DESCRIPTION
## Summary

PR 2 of the UI hunter. **Still no AI in it** — pure logic plus one runner change.

PR 1's free oracles only catch defects that announce themselves: a crash, a console error, a broken DOM. Most real UI bugs do none of that, and every one this repo's design doc cites is of that kind — "increase font size" made text smaller, "edit link" inserted one, typing landed in the wrong cell. Nothing threw.

Catching those means letting the agent say what it expected. The moment it may say *"that was wrong"* it is both prosecutor and judge, which is the documented route to curl's inbox. This takes the judge's job back — and it is now the whole precision argument for the UI hunter, since cross-sample agreement came out of the pipeline in #662.

## The protocol

A prediction is a **named reader plus a comparison**, never prose, submitted **with** the action:

```js
act({
  action: { type: "key", key: "Control+z" },
  expect: {
    read: "sheet.cellValue", args: ["A1"],
    op: "equals", value: "@read:4",
    ground: "A", because: "undo restores the value I read before editing",
  },
})
```

The runner performs the read in the **same round-trip** and reports `actual` without comparing anything. That atomicity is the point: a separate read would let the caller act, look, and only then decide what it had "expected".

Six operators, all total over reader values and decidable without executing anything the model wrote. **No regex operator**, though the plan listed one — a model-supplied pattern is code this process would execute, and `contains` covers what it was for.

**Ground A requires `value` to be a journal reference, never a literal.** A literal is the model asserting a fact from its own belief about how the app ought to behave, which is exactly what "the app contradicts itself" must exclude. `@read:4` resolves to what a reader actually returned. Grounds B and C are checked against the docs scope and the page snapshot; D is never eligible.

**Unevaluable is not violated.** Numbers demanded and a string read, a selection that changed length — never a finding. Collapsing that into `violated` would turn every malformed prediction into a defect report.

## Two things measured while building this, both of which changed the code

**`clip()` was corrupting values.** It returned a JSON string, so `[11,18,32]` became `"[11,18,32]"`. Values leaving the runner are now *compared*, not just displayed, and a truncated array compares **wrongly** rather than not at all — a confident wrong answer. Oversized values become a marker object the protocol treats as unevaluable.

**Two false findings appeared within minutes of the protocol first running** — both ground A, both traceable to a real earlier read, both reproducing deterministically:

1. *"I edited a cell, then undid, so the old value is back"* — violated, because `MemStore.undo()` is a no-op (`"No-op for memory store (no history tracking)"`). The product is fine; the sheet surface mounts a test double without history. **Now mechanically avoidable**: the bridge exposes `sheet.canUndo` / `doc.canUndo`, and they disagree — `false` and `true`, verified in the oracle lane.

2. *"I typed XYZ, then undid, so the text is back"* — violated, because docs undo is **per-keystroke**: one undo left `"XY"`. Whether undo should coalesce a typing burst is a convention judgement, not a self-contradiction, and no mechanical check separates that from a real defect.

Case 2 is why the verifier panel stays load-bearing and why its rubric must attack the expectation *before* the behaviour. Both cases are documented at the top of `hunt-ui-expect.mjs` rather than left for someone to rediscover, because the honest claim is that grounding removes a **class** of bad predictions, not all of them.

## Oracle lane

Gains an undo-capability check asserting the **positive** capability only — docs really can undo after an edit. It deliberately does **not** assert that sheets cannot: that is a limitation worth fixing, not a contract worth freezing, and pinning it would make an improvement look like a regression. The sheet value is reported, not enforced.

## Test plan

- `cd scripts/agent && node --test *.test.mjs` — 686 pass (29 new)
- `pnpm verify:self` — 11/11
- `pnpm verify:hunt:oracles` — 10 oracle checks + cell targeting + undo capability
- **All 11 protocol guards mutation-tested** — each fails with its guard removed
- Live browser run: a grounded violation produced an eligible candidate (`expected "10", read "999"`, traced to journal read #1); a prediction that held produced nothing

## Not yet wired

Nothing calls this. PR 3 gives the model the tool; PR 4 is the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated UI issue hunting with browser-based checks and application-state validation.
  * Added supported predictions for verifying values, relationships, and numeric conditions during UI actions.
  * Added checks for document and sheet undo capability.
* **Bug Fixes**
  * Improved validation for invalid or unsupported predictions and reader names.
  * Improved handling of unstable, oversized, unavailable, or unevaluable values.
* **Documentation**
  * Updated UI issue-hunting documentation and task tracking to reflect the completed capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->