### PR TITLE
Make @claude rerun actually re-engage the loop

### DIFF
--- a/.github/workflows/agent-rerun.yml
+++ b/.github/workflows/agent-rerun.yml
@@ -49,8 +49,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      pull-requests: read # resolve the PR (head repo/branch/labels)
-      issues: write # delete the paged comment, drop agent:blocked, post the note
+      # WRITE, not read. Label operations on a PULL REQUEST need
+      # `pull-requests: write`; `issues: write` covers its COMMENTS but not its
+      # labels, so with `read` the paged comments were deleted successfully and
+      # `removeLabel` failed with "Resource not accessible by integration" — while
+      # the summary below still announced it had dropped the label. Observed on #632
+      # and #648: both reported success and stayed `agent:blocked`.
+      pull-requests: write # resolve the PR, and drop agent:blocked
+      issues: write # delete the paged comment, post the note
       actions: write # re-run CI to re-fire the panel
     concurrency:
       group: agent-rerun-${{ github.event.issue.number }}
@@ -140,10 +146,22 @@ jobs:
 
             // Drop the single-value blocked label (best-effort; a fresh round re-derives
             // the correct state). removeLabel 404s if it isn't set — that's fine.
+            //
+            // The OUTCOME IS RECORDED, not assumed. This used to warn on failure and
+            // then announce success regardless, so #632 and #648 both said "dropped
+            // agent:blocked" while staying blocked — a message a human reads and
+            // believes, contradicted by the label right next to it. A summary must
+            // report what happened, not what was attempted.
+            let labelDropped = null; // true | false | null (was not set)
             try {
               await github.rest.issues.removeLabel({ owner, repo, issue_number: pr_number, name: 'agent:blocked' });
+              labelDropped = true;
             } catch (e) {
-              if (e.status !== 404) core.warning(`Could not remove agent:blocked (${e.message}).`);
+              if (e.status === 404) labelDropped = null;
+              else {
+                labelDropped = false;
+                core.warning(`Could not remove agent:blocked (${e.message}).`);
+              }
             }
 
             // Re-run the latest CI run for the head SHA so the panel fires again: on
@@ -162,7 +180,12 @@ jobs:
             }
 
             core.setOutput('outcome',
-              `🔁 Rerun engaged — cleared ${clearedLatch} paged marker(s) and dropped \`agent:blocked\`. ` +
+              `🔁 Rerun engaged — cleared ${clearedLatch} paged marker(s). ` +
+              (labelDropped === true
+                ? 'Dropped `agent:blocked`. '
+                : labelDropped === null
+                  ? '`agent:blocked` was not set. '
+                  : '⚠️ Could NOT drop `agent:blocked` — remove it by hand; the loop is otherwise unblocked. ') +
               (reran
                 ? "Re-running CI now; the review panel will run again and can promote or fix this PR."
                 : "No CI run to re-run — the panel will engage on the next CI run.") +

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -326,12 +326,24 @@ jobs:
     permissions:
       contents: read # read-only toward the PR
       checks: write # record per-lens verdicts
-      # issues:write is used ONLY by the trusted "Set state → reviewing" run-step
-      # to set the advisory agent:reviewing label (labels use the issues API). The
-      # SDK step never receives a GitHub token (its env is CLAUDE_CODE_OAUTH_TOKEN
-      # only), so this does not widen what prompt-injected branch code can reach.
+      # issues:write + pull-requests:write are used ONLY by the trusted
+      # "Set state → reviewing" run-step to set the advisory agent:reviewing label.
+      #
+      # pull-requests:WRITE is required, and its absence made this step silently
+      # dead. Labels on a PULL REQUEST need it; `issues: write` covers a PR's
+      # COMMENTS but not its labels — the old comment here claimed "labels use the
+      # issues API", which is the misconception behind the bug. `set-state.mjs` is
+      # fail-safe and exits 0 on any API error, so the step reported success while
+      # `agent:reviewing` never once appeared: #648/#632/#605/#633 all show
+      # implementing → fixing → blocked with no reviewing state between them. The
+      # same missing grant is why `@claude rerun` announced dropping
+      # `agent:blocked` on #632 and #648 and left it in place.
+      #
+      # The SDK step never receives a GitHub token (its env is CLAUDE_CODE_OAUTH_TOKEN
+      # only), so neither grant widens what prompt-injected branch code can reach —
+      # the same argument issues:write already rested on.
       issues: write # design-fit reads the issue spec + set advisory agent:reviewing
-      pull-requests: read
+      pull-requests: write # label writes on a PR need this, not issues:write
     outputs:
       pr: ${{ steps.pr.outputs.number }}
       blocked: ${{ steps.panel.outputs.blocked }}

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -26,12 +26,22 @@ name: Agent Review Panel
 on:
   workflow_run:
     workflows: ["CI"]
-    # `requested` (CI STARTED), not `completed` — this is the whole latency change.
+    # `requested` (CI STARTED) is the latency change: the panel and CI run in
+    # parallel instead of in series. The conclusion this used to gate on has not
+    # been dropped; the `ci` job below waits for it and gates the two PUSHING jobs.
     #
-    # `requested` ONLY, deliberately. Subscribing to both would run the entire
-    # panel twice per CI run, at ~$12 a time. The conclusion this used to gate on
-    # has not been dropped; the `ci` job below waits for it and gates the two
-    # PUSHING jobs on it instead.
+    # `completed` is here ONLY to cover RE-RUNS, and the `gate` job below admits it
+    # only when `run_attempt > 1` — so a fresh CI run still starts exactly one panel
+    # (on `requested`), and subscribing to both does not double the ~$12 round.
+    #
+    # Why it is needed: re-running an existing CI run does NOT emit `requested` —
+    # that fires when a run is CREATED, and a re-run reuses the run id. `@claude
+    # rerun`'s last act is `reRunWorkflow` on the PR's CI run, so from the moment
+    # this trigger became `requested`-only, rerun re-ran CI and re-engaged NOTHING
+    # while still reporting "Re-running CI now; the review panel will run again".
+    # Observed on #632 and #648: CI genuinely re-ran (06:01 → 06:15, success) and no
+    # panel run was created, while `Agent Iterate (CI)` — which listens to
+    # `completed` — fired for both.
     #
     # Still `workflow_run`, which is a SECURITY boundary and not just a trigger:
     # it always executes the workflow definition from the DEFAULT BRANCH. A
@@ -40,7 +50,7 @@ on:
     # author-unforgeable" property rests on. The agent App cannot push
     # `.github/workflows/**`, but an `agent:managed` human PR can. Do not swap
     # this trigger for `push` or `pull_request`.
-    types: [requested]
+    types: [requested, completed]
 
 # ONE panel per PR at a time. Without this, two CI completions close together
 # (a re-run, or a push landing while an earlier round is still in flight) start
@@ -113,9 +123,17 @@ jobs:
   gate:
     # No `conclusion` clause: on a `requested` event there is no conclusion yet.
     # It is read in the `ci` job instead, and still gates every push.
+    #
+    # The action clause is what keeps subscribing to both events from doubling the
+    # cost. A fresh CI run emits `requested` (attempt 1) and later `completed`
+    # (attempt 1) — the first starts the panel, the second is refused here. A RE-RUN
+    # emits only `completed`, with `run_attempt > 1`, which is the one case that
+    # needs admitting and the reason `@claude rerun` re-engages the loop at all.
     if: >-
       vars.AGENT_PIPELINE_ENABLED == 'true' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      (github.event.action == 'requested' ||
+       github.event.workflow_run.run_attempt > 1)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -91,9 +91,30 @@ on:
 #
 # `run_id` is deliberately NOT in the key — that is the mistake that makes a
 # concurrency group match only itself and guard nothing.
+# The trailing segment PARTITIONS the group by whether this run will do any work,
+# and without it subscribing to `completed` disables the review panel outright.
+#
+# `concurrency` is claimed at the workflow level — at RUN CREATION, before any job's
+# `if:` is evaluated. So on a fresh CI run: `requested` starts the panel, CI finishes
+# ~13 minutes later, `completed` creates a second run in the same group, and
+# `cancel-in-progress` KILLS THE PANEL MID-REVIEW. The second run's gate then refuses
+# the event and every job skips, so no verdicts are recorded — and `stalled` is
+# `!cancelled()`, so nothing pages either. The panel takes ~14 min against CI's ~13,
+# so that collision is near-certain rather than occasional. A job-level `if:` cannot
+# protect a group that was already claimed on its behalf.
+#
+# So the runs that will be REFUSED (`completed` on attempt 1 — `requested` already
+# started that round) get their own `noop` group, where cancelling each other costs
+# nothing. Every run that will actually review shares `active`, which keeps the
+# property this guard exists for: #605 had two panels finish in the same second with
+# contradictory verdicts, and #648 had two fixers on one branch for 21 minutes.
+#
+# The partition MUST agree with the gate's admission rule below, and the two are
+# written separately — so checks.test.mjs evaluates both across all four
+# event/attempt combinations and fails if they disagree.
 concurrency:
   group: >-
-    agent-review-panel-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+    agent-review-panel-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}-${{ (github.event.action == 'completed' && github.event.workflow_run.run_attempt == 1) && 'noop' || 'active' }}
   cancel-in-progress: true
 
 permissions: {}

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1521,6 +1521,41 @@ belt-and-braces: the first version spread `js.configs.recommended` and then set
 `eslint scripts` still exited 0. A config that lints nothing reports success, so
 the tests assert on the resolved rule set — `no-undef` is `error`, and every
 upstream recommended rule survives the local override.
+### A re-run does not emit `workflow_run: requested`
+
+`requested` fires when a workflow run is **created**. A re-run reuses the run id, so
+it emits only `completed` — and `@claude rerun`'s last act is `reRunWorkflow` on the
+PR's CI run.
+
+So from the moment the panel's trigger became `requested`-only, `@claude rerun`
+re-ran CI and re-engaged **nothing**, while still reporting *"Re-running CI now; the
+review panel will run again"*. Observed on #632 and #648: CI genuinely re-ran
+(`run_started_at` 06:01, success at 06:15) and no panel run was created, while
+`.github/workflows/agent-iterate-ci.yml` — which listens to `completed` — fired for
+both. The command's mechanism had been silently uncoupled from the trigger it
+depends on.
+
+The panel now subscribes to `[requested, completed]`, and the `gate` job admits
+`completed` **only when `run_attempt > 1`**:
+
+| event | attempt | admitted | why |
+|---|---|---|---|
+| `requested` | 1 | yes | fresh CI — the parallel-start path |
+| `completed` | 1 | **no** | `requested` already started this round |
+| `completed` | 2+ | yes | a re-run, where `requested` never fires |
+
+That keeps one panel per CI run, so subscribing to both does not double the ~$12
+round. Two existing properties make it safe rather than merely intended: the
+`concurrency` group cancels a superseded run, so even if `requested` did fire on a
+re-run the later event would collapse the pair to one; and the `ci` job's
+`decide()` returns `proceed` immediately for an already-completed successful run,
+so the `completed`-triggered path does not sit waiting for a conclusion it already
+has.
+
+**A trigger is part of a command's contract.** `@claude rerun` re-runs CI *in order
+to* fire the panel; narrowing what the panel listens to broke the command without
+touching it, and nothing failed — the rerun reported success both times.
+
 ### Label writes on a PR need `pull-requests: write`
 
 Not `issues: write`. A pull request is an issue for most of the API — its

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1545,12 +1545,31 @@ The panel now subscribes to `[requested, completed]`, and the `gate` job admits
 | `completed` | 2+ | yes | a re-run, where `requested` never fires |
 
 That keeps one panel per CI run, so subscribing to both does not double the ~$12
-round. Two existing properties make it safe rather than merely intended: the
-`concurrency` group cancels a superseded run, so even if `requested` did fire on a
-re-run the later event would collapse the pair to one; and the `ci` job's
-`decide()` returns `proceed` immediately for an already-completed successful run,
-so the `completed`-triggered path does not sit waiting for a conclusion it already
-has.
+round.
+
+**The concurrency group has to be partitioned to match, and getting this wrong
+disables the panel entirely.** `concurrency` is claimed at the workflow level — at
+RUN CREATION, before any job's `if:` is evaluated. With one undifferentiated group,
+a fresh CI run's `completed` event creates a second run that cancels the panel the
+`requested` event started ~13 minutes earlier, **mid-review**; the second run then
+refuses the event and skips every job. No verdicts recorded, and `stalled` is
+`!cancelled()`, so no page either. The panel takes ~14 min against CI's ~13, so the
+collision is near-certain rather than occasional. A job-level `if:` cannot protect a
+group that was already claimed on its behalf.
+
+So the group carries a suffix: runs that will be refused (`completed` on attempt 1)
+land in a `noop` lane where cancelling each other costs nothing, and every run that
+will actually review shares `active` — which preserves what the guard exists for
+(#605's two same-second contradictory verdicts, #648's two fixers on one branch).
+The partition and the gate's admission rule are written separately and must agree,
+so `scripts/agent/checks.test.mjs` evaluates both across all four event/attempt
+combinations and fails if they diverge, including a check that the partition is not
+degenerate — a group that always answered `active` would pass a same-answer test
+while restoring the bug.
+
+The `ci` job's `decide()` returns `proceed` immediately for an already-completed
+successful run, so the `completed`-triggered path does not sit waiting for a
+conclusion it already has.
 
 **A trigger is part of a command's contract.** `@claude rerun` re-runs CI *in order
 to* fire the panel; narrowing what the panel listens to broke the command without

--- a/docs/design/harness-engineering.md
+++ b/docs/design/harness-engineering.md
@@ -1521,6 +1521,36 @@ belt-and-braces: the first version spread `js.configs.recommended` and then set
 `eslint scripts` still exited 0. A config that lints nothing reports success, so
 the tests assert on the resolved rule set — `no-undef` is `error`, and every
 upstream recommended rule survives the local override.
+### Label writes on a PR need `pull-requests: write`
+
+Not `issues: write`. A pull request is an issue for most of the API — its
+**comments** are reachable with `issues: write` — but its **labels** are not, and
+the mismatch produced two silent failures that looked like success:
+
+- **`@claude rerun` announced dropping `agent:blocked` and did not.** The job held
+  `pull-requests: read`, so `deleteComment` succeeded ("cleared 1 paged marker(s)")
+  and `removeLabel` failed with `Resource not accessible by integration` — while the
+  summary claimed the drop unconditionally. Observed on #632 and #648: both said
+  they had dropped the label, and both stayed blocked.
+- **`agent:reviewing` has never existed.** The `review-panel` job had the same
+  `pull-requests: read`, and `scripts/agent/set-state.mjs` is fail-safe (any API
+  error logs and exits 0), so the "Set state → reviewing" step reported success from
+  the day it was written. #648, #632, #605 and #633 all show
+  implementing → fixing → blocked with no reviewing state in between.
+
+Both are fixed by the grant. Two things generalise:
+
+**Fail-safe writes need their outcome reported.** `scripts/agent/set-state.mjs` exiting 0 on error
+is the right call for a label that gates nothing — it must never fail the pipeline —
+but it means a broken grant is indistinguishable from a working one. The rerun
+summary now reports which of *dropped* / *was not set* / *could not drop* actually
+happened, rather than asserting the happy path.
+
+**Jobs that write labels with the default `GITHUB_TOKEN` are enumerable**, and were
+enumerated: `iterate` inherits the grant workflow-level, `fix` and `stalled` declare
+it, and the two above were the only gaps. `agent-implement`'s label write is not in
+this class — it happens inside the agent's prompt using the App token, whose
+installation permissions the workflow block does not govern.
 
 ## Harness Policy
 

--- a/scripts/agent/checks.test.mjs
+++ b/scripts/agent/checks.test.mjs
@@ -125,7 +125,7 @@ test("ciRunDecision: the three outcomes are exhaustive and disjoint", () => {
   assert.deepEqual([...seen].sort(), ["proceed", "skip", "wait"]);
 });
 
-test("the panel workflow subscribes ONLY to `requested`, and mirrors ciRunDecision", () => {
+test("the panel starts with CI, admits re-runs, and mirrors ciRunDecision", () => {
   const HERE = path.dirname(fileURLToPath(import.meta.url));
   const yml = readFileSync(path.join(HERE, "..", "..", ".github", "workflows", "agent-review-panel.yml"), "utf8");
   // Code lines only. The comments around this change quote both the old
@@ -134,12 +134,24 @@ test("the panel workflow subscribes ONLY to `requested`, and mirrors ciRunDecisi
   // explanation as the thing it warns about. Same trap as #630 and #640.
   const code = yml.split("\n").filter((l) => !/^\s*(#|\/\/)/.test(l)).join("\n");
 
-  // Subscribing to `completed` AS WELL would run the entire panel twice per CI
-  // run — ~$12 each — because both events fire for every run. The conclusion is
-  // not lost by dropping it: the `ci` job waits for it, which is the next two
-  // assertions.
-  assert.match(code, /types: \[requested\]/, "the panel must start when CI starts");
-  assert.ok(!/types: \[[^\]]*completed/.test(code), "subscribing to `completed` too would double every round");
+  // `requested` keeps the panel starting when CI STARTS — the latency property.
+  assert.match(code, /types: \[requested/, "the panel must start when CI starts");
+  // `completed` is subscribed too, and this used to be forbidden here on the
+  // grounds that both events fire for every run and the panel costs ~$12. That
+  // reasoning held for a FRESH run and missed re-runs entirely: `requested` fires
+  // when a run is CREATED, so a re-run emits only `completed` — and `@claude
+  // rerun`'s whole mechanism is `reRunWorkflow` on the PR's CI run. With
+  // `requested` alone it re-ran CI and re-engaged nothing, twice, on #632 and #648,
+  // while reporting that the panel would run again.
+  assert.match(code, /types: \[requested, completed\]/, "re-runs emit only `completed`");
+  // What actually prevents the doubling is the gate, not the subscription: a fresh
+  // run's `completed` carries run_attempt 1 and is refused, so exactly one panel
+  // starts per CI run either way.
+  assert.match(
+    code,
+    /github\.event\.action == 'requested' \|\|\s*\n?\s*github\.event\.workflow_run\.run_attempt > 1/,
+    "the gate must admit `completed` only for re-runs, or every round doubles",
+  );
 
   // The inline copy of the rule. A `github-script` step has no checkout and
   // cannot import checks.mjs, so this logic necessarily exists twice; pinning

--- a/scripts/agent/checks.test.mjs
+++ b/scripts/agent/checks.test.mjs
@@ -153,6 +153,52 @@ test("the panel starts with CI, admits re-runs, and mirrors ciRunDecision", () =
     "the gate must admit `completed` only for re-runs, or every round doubles",
   );
 
+  // THE CONCURRENCY GROUP MUST AGREE WITH THE GATE, and they are written
+  // separately — a suffix expression and a job `if:` — so this evaluates both.
+  //
+  // Why it matters more than tidiness: `concurrency` is claimed at RUN CREATION,
+  // before any `if:` runs. With one undifferentiated group, a fresh CI run's
+  // `completed` event creates a second run that cancels the panel the `requested`
+  // event started ~13 minutes earlier, mid-review — then refuses the event itself
+  // and skips every job. No verdicts, and `stalled` is `!cancelled()` so no page.
+  // The review control would stop working, silently, on every PR.
+  //
+  // So refused runs must land in a DIFFERENT group from working ones, and "refused"
+  // has to mean the same thing in both places.
+  {
+    const gateIf = (yml.match(/^ {2}gate:\n(?:.*\n)*? {4}if: >-\n((?: {6}.*\n)+)/m) || [])[1];
+    assert.ok(gateIf, "could not extract the gate's if: expression");
+    // `.+` not `\S+`: the group is one folded line containing spaces inside `${{ }}`.
+    const group = (yml.match(/group: >-\n\s*(.+)/) || [])[1];
+    assert.ok(group, "could not extract the concurrency group");
+
+    const toJs = (s) =>
+      s.replace(/github\.event\.workflow_run\.run_attempt/g, "ATTEMPT")
+       .replace(/github\.event\.action/g, "ACTION")
+       .replace(/github\.event\.workflow_run\.head_repository\.full_name/g, "'r'")
+       .replace(/github\.repository/g, "'r'")
+       .replace(/github\.event\.workflow_run\.head_branch/g, "'b'")
+       .replace(/vars\.AGENT_PIPELINE_ENABLED/g, "'true'");
+    const admits = new Function("ACTION", "ATTEMPT", `return (${toJs(gateIf)});`);
+    const suffix = (group.match(/\$\{\{ ([^}]*'noop'[^}]*) \}\}\s*$/) || [])[1];
+    assert.ok(suffix, "the group must carry a noop/active partition suffix");
+    const partition = new Function("ACTION", "ATTEMPT", `return (${toJs(suffix)});`);
+
+    for (const [action, attempt] of [["requested", 1], ["requested", 2], ["completed", 1], ["completed", 2]]) {
+      const works = Boolean(admits(action, attempt));
+      const lane = partition(action, attempt);
+      assert.equal(
+        lane,
+        works ? "active" : "noop",
+        `${action}/attempt ${attempt}: gate ${works ? "admits" : "refuses"} but the group says ${lane}`,
+      );
+    }
+    // And prove the partition is not degenerate — a group that always says "active"
+    // would pass a same-answer check while restoring the cancellation bug.
+    assert.equal(partition("requested", 1), "active");
+    assert.equal(partition("completed", 1), "noop");
+  }
+
   // The inline copy of the rule. A `github-script` step has no checkout and
   // cannot import checks.mjs, so this logic necessarily exists twice; pinning
   // the copy is what keeps it ONE rule rather than two that drift.


### PR DESCRIPTION
## Summary

`@claude rerun` on #632 and #648 announced it had dropped `agent:blocked`. Both
stayed blocked. **Labels on a pull request need `pull-requests: write`, not
`issues: write`** — and the summary claimed the drop regardless of whether it worked.

## The evidence

From both run logs:

```
##[warning]Could not remove agent:blocked (Resource not accessible by integration).
```

A PR is an issue for most of the API, and its **comments** are reachable with
`issues: write` — which is why the paged-comment deletion in the very same step
succeeded and reported *"cleared 1 paged marker(s)"*. Its **labels** are not. The job
held `pull-requests: read`.

And the message was built unconditionally, so a human read "dropped `agent:blocked`"
with the label sitting right next to it. Same failure shape as #648's page claiming
the requested changes were not applied when they had been: **a summary asserting the
happy path instead of reporting the outcome.**

It now says which of *dropped* / *was not set* / *could not drop* actually happened.
The three branches were extracted from the YAML and executed, since inline
`github-script` JS holds no test.

## The same grant was missing from `review-panel`, and there it was silently dead

**`agent:reviewing` has never appeared on a PR.** Not once. Same `pull-requests: read`,
and `set-state.mjs` is fail-safe — any API error logs and exits 0, which is correct
for a label that gates nothing — so the "Set state → reviewing" step reported success
from the day it was written.

Confirmed by timeline rather than reasoned: **#648, #632, #605 and #633 all go
implementing → fixing → blocked** with no reviewing state between them.

The comment above that grant said *"labels use the issues API"* — the misconception
itself, now corrected in place.

**Why widening it is safe** is the argument its `issues: write` already rested on: the
SDK step receives no GitHub token (`CLAUDE_CODE_OAUTH_TOKEN` only), so neither grant
widens what prompt-injected branch code can reach. This is the hunk to scrutinise if
you scrutinise one — it's a permission widening on the job that holds the Claude
credential.

## Enumerated, not guessed

Jobs that write labels with the default `GITHUB_TOKEN`:

| job | effective `pull-requests` | |
|---|---|---|
| `agent-iterate-ci::iterate` | `write` | inherited workflow-level |
| `agent-review-panel::fix` | `write` | declared |
| `agent-review-panel::stalled` | `write` | declared |
| `agent-review-panel::review-panel` | ~~`read`~~ → `write` | **fixed** |
| `agent-rerun::rerun` | ~~`read`~~ → `write` | **fixed** |

My first scan also flagged `agent-implement`. **That was wrong** — its label write
happens inside the agent's *prompt* using the App token, whose installation
permissions the workflow block doesn't govern, and #648's timeline shows
`agent:implementing` applied successfully by `yorkie-agent[bot]`. Corrected before
touching it.

## The stale labels

Removed by hand on #632 and #648. Both PRs' paged markers were already gone — the
rerun's comment deletion worked — so the label was the only thing left wrong, and
removing it makes the state honest rather than papering over anything.

## Verification

`pnpm verify:self` green (**11/11**) · both workflows parse · the re-scan above
returns `write` for every label-writing job.

## What I'd push back on as a reviewer

**No test covers this.** The bug is a workflow permission, which nothing in the test
suite can observe — it only manifests against the real API. I verified it by reading
the run logs and the label timelines, but the next regression of this kind will be
found the same way: by someone noticing a label didn't change.

**`set-state.mjs`'s fail-safe exit is load-bearing and now demonstrably hides bugs.**
It should stay fail-safe, but a broken grant looked identical to a working one for
months. Reporting the outcome where a human reads it — as the rerun summary now does —
is the cheap half; a periodic reconcile that flags "the label I set isn't there" is
the thorough half, and isn't here.

## Linked Issues

None — reported directly from #632 and #648.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification checklist

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

## Risk Assessment

- **User-facing risk:** none. No product code.
- **Data/security risk:** two permission widenings, both `pull-requests: read → write`
  on jobs that already hold `issues: write`. `rerun` runs no untrusted code (API calls
  only). `review-panel` runs the SDK, but that step receives no GitHub token, which is
  the same reasoning already documented for its `issues: write`.
- **Rollback:** revert. Label writes go back to failing silently, and the rerun summary
  goes back to claiming a drop it didn't make.

## Notes for Reviewers

- **AI assistance:** investigated and implemented with Claude Code (Opus 5) in an
  interactive session and reviewed by me.
- **The interesting artefact** is that a fail-safe write plus an optimistic summary
  hid a broken permission for months. Neither alone would have — the fail-safe kept
  the pipeline alive, the summary kept anyone from looking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request label management during review and rerun workflows.
  * Status messages now accurately report whether labels were removed successfully, were absent, or could not be removed.
  * Review states can now be applied reliably when appropriate.
  * Prevented duplicate review panels during CI reruns while ensuring eligible reruns are processed.

* **Documentation**
  * Documented required permissions and label-operation behavior for pull request workflows.
  * Clarified how CI events and reruns affect automated review handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->