### PR TITLE
Derive the harvest cutoff from the panel's own check runs

### DIFF
--- a/docs/tasks/active/20260804-harvest-panel-rounds-todo.md
+++ b/docs/tasks/active/20260804-harvest-panel-rounds-todo.md
@@ -1,0 +1,146 @@
+# Harvest: derive the cutoff from the panel's own check runs
+
+The feedback corpus proposer keyed "when did the panel let go of this PR" off a comment
+and, through it, "what had the panel concluded" as well. Both now come from the panel's
+check runs, and the second is resolved per CodeRabbit comment rather than once per PR.
+
+## The problem
+
+`harvestPr` had one cutoff, `handoffTime`, built from the `<!-- agent-handoff -->`
+comment with the `ready_for_review` timeline event as a fallback. Four things were wrong
+with it, and the fourth is the one that cost data.
+
+1. **No marker, no harvest.** `mark-ready.mjs` posts the marker inside a `try/catch`
+   AFTER flipping the PR ready, so a genuinely promoted PR can carry none. Measured: 18
+   of 33 agent PRs have neither a marker nor a `ready_for_review` event, because they
+   were opened ready rather than promoted.
+2. **`ready_for_review` answers a different question.** It fires whether or not the
+   panel ever spoke, so on a manually-readied PR every later human commit became a
+   candidate. It over-fired on the PRs it covered and covered none of the PRs it was
+   reached for.
+3. **A rebase erased it.** The cutoff was a comment timestamp compared against COMMITTER
+   DATES. A force-push after promotion rewrites every one of those, so every commit
+   post-dated the cutoff, `beforeHandoff` emptied, and `headAtHandoff` went undefined.
+4. **Signature 2 read the panel THROUGH signature 1's cutoff.** The comparison set came
+   from whichever commit was head at hand-off. So (a) no hand-off meant no comparison
+   set and every CodeRabbit candidate withheld on a PR whose check runs were readable
+   the whole time, and (b) one set was applied to every finding regardless of which
+   commit it was about — wrong in both directions depending on where the hand-off commit
+   sat relative to the comment.
+
+Signature 2 never needed a hand-off. "CodeRabbit flagged something our panel reviewed and
+did not raise" is exactly as true on a human PR reviewed via `@claude review`, where
+nothing was handed off at all.
+
+## The change
+
+- [x] `panelRounds(commits, runsFor)` — one entry per commit the panel CONCLUDED on,
+      `{sha, index, conclusion, reviewedSha, completedAt, runs}`. Pure, with `runsFor`
+      injected, so the ordering decision is testable without an API.
+- [x] `panelApprovedAt(rounds, markerAt)` replaces `handoffTime`. Check runs first,
+      marker as a fallback, `ready_for_review` **removed outright** rather than demoted —
+      keeping it as a last resort would preserve the over-fire in exactly the cases
+      nothing else can check. The timeline request is gone with it.
+- [x] `commitIndex` + `roundsUpTo(rounds, index)` — the comparison set is now the union
+      of rounds AT OR BEFORE the commit a finding is about, resolved per comment.
+- [x] `commentRounds` — an `@claude review` is a round too, with `conclusion: ""`. It was
+      a whole-PR fallback; as a round it gets the same per-commit treatment the gating
+      arm does, and it can never become signature 1's cutoff.
+- [x] `panelRoundAt` splits the CHEAP half of a verdict (conclusion, reviewedSha,
+      completedAt — all in the check-runs LIST response) from the expensive half. Two
+      phases: one list call per commit to establish the history, and the per-run
+      `withFullOutput` refetch only for rounds a candidate is actually compared against,
+      cached by sha. `panelVerdictAt` now calls it, so the aggregate conclusion rule
+      ("one failing lens means the panel did not let it through") stays in one place.
+- [x] `markerHandoffAt` keeps "FIRST marker, not the last".
+
+## Corrected while building
+
+- **The newest approval is self-defeating, and only real data showed it.** The first
+  implementation took the NEWEST all-success round. Every human fix opens a new round,
+  and that round approves too — so on #548 the cutoff landed on 2026-07-28, four days
+  after the three human fixes of 2026-07-25, and **lost all three, including rows a
+  human has already curated into `misses.jsonl`**. It is the FIRST approval, matching
+  `markerHandoffAt`'s own rule: a later re-approval does not un-say the first one.
+- **An unreadable commit keeps its sha.** Dropping the round entirely lost the property
+  the previous code deliberately had — "we know which commit the panel was looking at
+  and we could not read what it concluded" — which is what tells an API hiccup apart
+  from a PR the panel never touched. It is now an `unreadable: true` round: carries the
+  sha, never counts as evidence, and makes the comparison set refuse rather than resolve
+  to `[]`.
+- **Timestamps are compared as parsed instants.** Lexicographic order works for the `…Z`
+  form GitHub returns and stops working silently for any offset form.
+- **Bug 4's direction was stated backwards in the first draft of its test.** Measured,
+  the old code UNDER-suppressed on that fixture (filing a genuine restatement as a
+  miss); the over-suppression direction is real but needs the hand-off commit to sit
+  later than the comment. Both are now described, and the test says which one it
+  demonstrates.
+
+## Fail directions
+
+| path | on doubt | why |
+|---|---|---|
+| `panelApprovedAt` | **null** | null means "cannot classify" and signature 1 goes silent. Treating it as "approved at time zero" makes every commit on the PR a candidate — the over-fire that removing `ready_for_review` exists to end |
+| an unreadable round | **`null` blockers**, never `[]` | `[]` claims "this round raised nothing blocking" about a round nobody has seen, which files every CodeRabbit finding on the PR as a miss |
+| one unreadable commit | costs its round, not the walk | a PR is not forfeited by one bad request; the rest of its history still resolves |
+| an unplaceable finding or round | **widen** the comparison set | what cannot be placed cannot be excluded. Widening can only over-suppress a finding the panel really did raise; narrowing on a guess writes a false row, and a curated false row is permanent |
+| a round we could not read inside an eligible set | collapse the whole set to `null` | a union missing one round would claim the panel raised nothing where it may have raised exactly this |
+| the `ROUND_WALK_LIMIT` cap | proceed, and **log** | a silently truncated history makes "the panel never approved" indistinguishable from "we stopped looking" |
+
+## Explicit non-goals
+
+- **No schema change.** `wafflebase/miss@1`, same fields, same order. `handoffAt` keeps
+  its name and now means "when the panel approved", which is what every consumer already
+  assumed. Existing ids are unchanged, so `dedupeById`'s first-wins rule still protects
+  every curated `verifiedBy` — verified on #548, which re-harvests to the same four ids.
+- **No change to `attributeToPanel`, `bestMatch` or `clusterFindings`.**
+- **No widening to `minor`/`nit` CodeRabbit findings.** That needs the panel's
+  non-blocking findings to compare against, which is the collector's job.
+- **`--append` untouched**, including both refusal paths. It was not run.
+
+## Verification
+
+- [x] `node --test "scripts/agent/*.test.mjs"` — **676 tests, 675 pass, 0 fail, 1
+      skipped**; 662/661 on `upstream/main` (`35206e585`). 14 new tests.
+- [x] `eslint scripts` — clean, under the repo's pinned `eslint@9.24.0` from
+      `pnpm-lock.yaml`. Worth naming: `eslint@9.39` (what a bare `^9.21.0` install
+      resolves to today) adds `no-useless-assignment` to `recommended` and flags the
+      pre-existing `let files = []` in the signature-1 loop, on `upstream/main` as well
+      as here. That is a version difference, not a defect this PR introduced or should
+      fix.
+- [x] **Each bug pinned by a test named after the failure**, and a before/after harness
+      confirms the old code behaved differently on 4 of 5:
+
+      | case | before | after |
+      |---|---|---|
+      | 1 · no marker anywhere | 0 candidates, `skipped` | human-fix + coderabbit, not skipped |
+      | 2 · manually readied, never approved | 1 human-fix (the over-fire) | 0, `skipped` |
+      | 3 · rebase rewrote every committer date | CodeRabbit withheld | compared against the real verdict |
+      | 4a · finding earlier than the round that raised it | not suppressed | not suppressed *(regression guard, not a fixed bug)* |
+      | 4b · finding on the commit the panel raised it at | filed as a miss | suppressed |
+
+- [x] **Real PRs, read-only, before vs after — #548, #559, #578, #582, #591, #649, and
+      the no-marker population #581, #590, #605, #652. Candidate sets IDENTICAL on all
+      ten.** #548's `handoffAt` moves 22 seconds (the check run at 15:48:06 rather than
+      the marker at 15:48:28) with the same four ids. #591 and #605 change only their
+      `skipped` reporting, correctly: the panel reviewed but never approved, and there
+      is no CodeRabbit input.
+- [x] **API cost, measured.** #548 (9 commits) 13 → 24 calls; #582 (7 commits) 4 → 10.
+      The increase is one check-runs LIST per commit, minus the timeline request that is
+      now gone. Real PRs here run 1–9 commits, so `ROUND_WALK_LIMIT = 100` never binds.
+
+## Not built, and the honest limit of this change
+
+- **No measurable gain on today's data.** This is the part worth stating plainly: the
+  plan predicted more candidates on no-marker agent PRs, and on live data there are
+  none. #581, #590 and #605 have no marker, but the panel never APPROVED them either, so
+  signature 1 has no referent under the new cutoff any more than the old one; and they
+  carry no CodeRabbit blocking findings, so signature 2 has no input. The gains here are
+  demonstrated synthetically, not measured. What the change buys is a mechanism that is
+  correct for the next PR — the rebase case and the per-comment anchoring are latent
+  bugs, not observed losses.
+- **The `minor`/`nit` population.** Waits on the stage-detail collector.
+- **A third signature.** `scripts/agent/eval/github-signals.mjs` on the eval-harness
+  branch derives an `is_real` vote from an author's reply to a bot finding
+  ("Done in `<sha>`" / "not a defect because…"). It needs no cutoff at all — it reads a
+  thread, not a timeline — and is the natural next signature. Out of scope here.

--- a/scripts/agent/harvest.mjs
+++ b/scripts/agent/harvest.mjs
@@ -124,31 +124,85 @@ export function isAgentPr(pr) {
 }
 
 /**
- * When the pipeline handed this PR to humans (ISO string), or null.
+ * When `mark-ready.mjs` posted its hand-off marker (ISO string), or null.
  *
  * FIRST marker comment, not the last: a PR that is un-readied and re-promoted has
  * two, and the human work we are looking for starts at the first one.
  *
- * The `readyForReviewAt` fallback is load-bearing rather than belt-and-braces.
- * `mark-ready.mjs` posts the hand-off comment inside a `try/catch` AFTER the PR is
- * already flipped to ready, explicitly so a failed comment cannot fail a
- * successful promotion — which means a genuinely promoted PR can carry no marker
- * at all. Keying only on the comment would make those PRs invisible to the
- * harvester, and invisible is the one failure a corpus cannot recover from later.
+ * A CORROBORATING signal only — `panelApprovedAt` prefers the panel's own check
+ * runs and reaches for this when it has none. The marker genuinely means "the panel
+ * approved" (that is the only thing that posts it), but it can be absent from a PR
+ * that really was promoted: `mark-ready.mjs` posts it inside a `try/catch` AFTER
+ * flipping the PR ready, so a failed comment cannot fail a successful promotion.
  *
- * Returns null when neither is present. Callers must treat null as "cannot
- * classify this PR" and skip it LOUDLY, never as "handed off at time zero" —
- * that would make every commit on the PR a candidate.
+ * `ready_for_review` USED TO BE the fallback here and has been removed outright, not
+ * demoted. It answers a different question — "when did this PR leave draft" — and
+ * fires whether or not the panel ever spoke, so on a manually-readied PR it made
+ * every subsequent human commit a candidate. It was also unreachable for the 18 of
+ * 33 agent PRs opened ready rather than promoted, i.e. it over-fired on the PRs it
+ * covered and covered none of the PRs it was reached for. The timeline request it
+ * needed is gone with it.
  */
-export function handoffTime({ comments = [], readyForReviewAt = null } = {}) {
+export function markerHandoffAt(comments = []) {
   const marked = (Array.isArray(comments) ? comments : [])
     .filter((c) => str(c?.body).includes(HANDOFF_MARKER))
     .map((c) => str(c?.created_at))
     .filter((t) => t !== "" && Number.isFinite(Date.parse(t)))
     .sort();
-  if (marked.length > 0) return marked[0];
-  const ready = str(readyForReviewAt);
-  return ready !== "" && Number.isFinite(Date.parse(ready)) ? ready : null;
+  return marked.length > 0 ? marked[0] : null;
+}
+
+/**
+ * When the panel APPROVED this PR (ISO string), or null.
+ *
+ * The panel's own check runs are the primary source, and the reason is that they
+ * are the only signal which is present whenever the panel ran, carries a server
+ * timestamp, and means what we need it to mean:
+ *
+ * |                                  | marker comment | ready_for_review | check runs |
+ * |----------------------------------|----------------|------------------|------------|
+ * | present whenever the panel ran   | no (try/catch) | no               | YES        |
+ * | survives a rebase / force-push   | yes            | yes              | YES        |
+ * | means "the panel approved"       | yes            | NO               | YES        |
+ *
+ * That third row is why `ready_for_review` is gone, and the first is why the marker
+ * cannot be primary. The second row is the one that matters most in practice:
+ * `completed_at` is stamped by GitHub on the check run, so a rebase that rewrites
+ * every committer date on the PR cannot move it. The previous implementation keyed
+ * the cutoff off a comment and then compared it against committer dates, so a
+ * force-push after promotion pushed every commit past the cutoff, emptied the
+ * before-handoff set, and left signature 2 with no comparison set at all.
+ *
+ * The FIRST all-success round, not the newest, and this is the one place where the
+ * obvious choice is actively self-defeating. Every human fix pushed after an approval
+ * opens a new round, and that round then approves too — so keying on the newest
+ * approval moves the cutoff PAST the very commits the signature exists to catch.
+ * Measured on #548: the newest-approval cutoff lands on 2026-07-28, four days after
+ * the three human fixes of 2026-07-25, and loses all three — including the rows a
+ * human has already curated into `misses.jsonl`.
+ *
+ * So this matches `markerHandoffAt`'s "FIRST marker, not the last" for the same
+ * reason: the human work being looked for starts the first time the panel said the PR
+ * was fine. A later re-approval does not un-say it.
+ *
+ * Rounds with `conclusion: "failure"` or `""` are not approvals, which is also what
+ * keeps ADVISORY rounds out — an `@claude review` round carries `conclusion: ""`
+ * because it reached no gate conclusion (see `panelRounds`).
+ *
+ * Returns null when the panel never approved. Callers must treat null as "cannot
+ * classify", never as "approved at time zero" — that would make every commit on the
+ * PR a candidate, which is precisely the over-fire this replaces.
+ */
+export function panelApprovedAt(rounds, markerAt = null) {
+  // Ordered by PARSED TIME, for the reason `panelRoundAt` gives.
+  const approvals = (Array.isArray(rounds) ? rounds : [])
+    .filter((r) => str(r?.conclusion) === "success")
+    .map((r) => str(r?.completedAt))
+    .filter((t) => t !== "" && Number.isFinite(Date.parse(t)))
+    .sort((a, b) => Date.parse(a) - Date.parse(b));
+  if (approvals.length > 0) return approvals[0];
+  const marker = str(markerAt);
+  return marker !== "" && Number.isFinite(Date.parse(marker)) ? marker : null;
 }
 
 /**
@@ -425,6 +479,45 @@ export function panelFindingsFromComments(comments) {
   return seen ? { reviewedSha, findings } : null;
 }
 
+/**
+ * Each on-demand review as a ROUND, in the same shape `panelRounds` produces.
+ *
+ * The point of expressing an advisory review this way is that everything downstream
+ * — ordering, `roundsUpTo`, `panelApprovedAt`, `panelSaw` — then works on one kind of
+ * thing. The previous code treated this channel as a whole-PR fallback, so an
+ * on-demand PR got a single comparison set for every CodeRabbit finding on it no
+ * matter which commit each was about; as a round it gets the same per-commit
+ * treatment the gating arm does, for free.
+ *
+ * `conclusion` is `""`, and that is not a missing value — an advisory review reaches
+ * no gate conclusion. It is also what keeps these rounds out of `panelApprovedAt`,
+ * which selects on `"success"`: an `@claude review` is not an approval and must never
+ * become signature 1's cutoff.
+ *
+ * `blockers` is carried already-parsed, so these rounds cost no second request. The
+ * `index` is where the reviewed commit sits on the PR, or -1 when that commit is no
+ * longer on the branch (see `roundsUpTo` for what -1 buys).
+ */
+export function commentRounds(comments, commits) {
+  const out = [];
+  for (const c of Array.isArray(comments) ? comments : []) {
+    if (!PANEL_LOGINS.has(str(c?.user?.login))) continue;
+    const parsed = parsePanelComment(c?.body);
+    if (!parsed) continue;
+    const sha = str(parsed.reviewedSha);
+    out.push({
+      sha,
+      index: commitIndex(commits, sha),
+      conclusion: "",
+      reviewedSha: sha,
+      completedAt: str(c?.created_at),
+      blockers: parsed.findings,
+      advisory: true,
+    });
+  }
+  return out;
+}
+
 /** Verdicts `attributeToPanel` can reach. `""` is a fourth state and means the
  *  question was never asked — see `attributeToPanel`. */
 export const MATCH_VERDICTS = new Set(["match", "maybe", "no"]);
@@ -621,9 +714,27 @@ export function dedupeById(records) {
  * per-lens because the question a miss record asks is "did the panel let this
  * through", and one failing lens means it did not.
  */
-export function panelVerdictAt(runsByLens) {
-  const runs = runsByLens instanceof Map ? runsByLens : new Map(Object.entries(runsByLens ?? {}));
-  const findings = tagPriorFindings(runs);
+const asRunMap = (runsByLens) =>
+  runsByLens instanceof Map ? runsByLens : new Map(Object.entries(runsByLens ?? {}));
+
+/**
+ * The CHEAP half of a verdict: `{reviewedSha, conclusion, completedAt}`.
+ *
+ * Split out because it is answerable from the check-runs LIST response, which omits
+ * `output.text` — so establishing WHICH commits the panel reviewed costs one call per
+ * commit, and the per-run refetch that carries the findings is spent only on the
+ * rounds a candidate is actually compared against. See `harvestPr`.
+ *
+ * Not merely an optimisation. `conclusion`'s aggregate rule is load-bearing ("one
+ * failing lens means the panel did not let it through") and this keeps it in ONE
+ * place rather than growing a second copy for the cheap path to use.
+ *
+ * `completedAt` is the LATEST `completed_at` across the lens runs, because the round
+ * is not over until its last lens is. It falls back to `started_at` on the same
+ * per-run basis `latestLensRuns` orders by, and to `""` when neither parses.
+ */
+export function panelRoundAt(runsByLens) {
+  const runs = asRunMap(runsByLens);
   const conclusions = [...runs.values()].map((r) => str(r?.conclusion));
   const conclusion =
     conclusions.length === 0 ? "" : conclusions.includes("failure") ? "failure" : "success";
@@ -639,7 +750,51 @@ export function panelVerdictAt(runsByLens) {
       break;
     }
   }
-  const classified = classify(findings);
+  // Compared as PARSED TIMES, not as strings. Lexicographic order happens to work for
+  // the `…Z` form GitHub returns and silently stops working for any offset form, which
+  // is the kind of latent bug a timestamp comparison should not have.
+  let completedAt = "";
+  let latest = -Infinity;
+  for (const r of runs.values()) {
+    const t = str(r?.completed_at) || str(r?.started_at);
+    const at = Date.parse(t);
+    if (t !== "" && Number.isFinite(at) && at > latest) {
+      latest = at;
+      completedAt = t;
+    }
+  }
+  return { reviewedSha, conclusion, completedAt };
+}
+
+/**
+ * What the panel concluded on a given commit: `{reviewedSha, conclusion,
+ * blockingFindings, blockers}`.
+ *
+ * `blockers` is the blocking findings THEMSELVES, and it is the whole reason
+ * signature 2 can be more than a guess. This function used to compute the count
+ * and drop the findings on the floor, so the CodeRabbit path could say the panel
+ * raised three blockers but never whether one of them was the comment in hand —
+ * every CodeRabbit blocker was filed as a miss by construction. `blockingFindings`
+ * stays a count because callers and the record format depend on it.
+ *
+ * `reviewedSha` comes from the lens run's `external_id` (incremental review's
+ * state pointer) rather than from the commit the run is attached to, because on a
+ * narrowed round those differ — the run hangs off the head commit while the
+ * verdict covers only the delta. The commit sha is the fallback.
+ *
+ * `conclusion` is the AGGREGATE: `failure` if any lens failed, `success` only if
+ * at least one ran and none failed, `""` if none ran. Aggregate rather than
+ * per-lens because the question a miss record asks is "did the panel let this
+ * through", and one failing lens means it did not.
+ *
+ * The return shape deliberately does NOT carry `panelRoundAt`'s `completedAt`:
+ * three callers `deepEqual` this object, and a field they do not use would make them
+ * assert about the timestamp of a fixture.
+ */
+export function panelVerdictAt(runsByLens) {
+  const runs = asRunMap(runsByLens);
+  const { reviewedSha, conclusion } = panelRoundAt(runs);
+  const classified = classify(tagPriorFindings(runs));
   return {
     reviewedSha,
     conclusion,
@@ -649,6 +804,94 @@ export function panelVerdictAt(runsByLens) {
     // would suppress a real gate miss on the strength of a passing remark.
     blockers: classified.findings.filter((f) => BLOCKING.has(f.severity)),
   };
+}
+
+/**
+ * Position of a sha in the PR's commit list, or -1.
+ *
+ * The list is chronological, so the index is an ordering usable for "at or before".
+ * -1 means the sha is not on the PR at all, which is a real and reachable state: a
+ * force-push rewrites history and leaves a CodeRabbit comment's
+ * `original_commit_id` pointing at a commit no longer reachable from the branch.
+ */
+export function commitIndex(commits, sha) {
+  const want = str(sha);
+  if (want === "") return -1;
+  return (Array.isArray(commits) ? commits : []).findIndex((c) => str(c?.sha) === want);
+}
+
+/**
+ * Every ROUND of review on this PR: one entry per commit the panel concluded on,
+ * chronological, each `{sha, index, conclusion, reviewedSha, completedAt, runs}`.
+ *
+ * `runs` is the `latestLensRuns` map for that commit, kept so the caller can spend
+ * the expensive per-run refetch later without listing the commit's checks again.
+ *
+ * PURE, with `runsFor(sha)` injected: the whole ordering decision is testable
+ * without an API, which is the same reason `prior-findings.mjs` injects its `api`.
+ *
+ * A commit whose checks cannot be READ yields an `unreadable: true` round rather
+ * than nothing, and the distinction is load-bearing in two directions at once. It
+ * must not count as evidence the panel reviewed anything — so it carries
+ * `conclusion: ""`, which keeps it out of `panelApprovedAt` and makes `blockersOf`
+ * refuse it — but the SHA is a fact we hold regardless, and dropping the round would
+ * throw it away. "We know which commit the panel was looking at and we could not
+ * read what it concluded" is a more honest record than an empty one, and it is what
+ * tells an API hiccup apart from a PR the panel never touched.
+ *
+ * A commit with no lens runs AT ALL is not a round; that is a real, readable answer
+ * ("the panel did not review this commit"), not a failure. Either way the walk
+ * continues, so one bad commit never costs the rest of the PR.
+ */
+export function panelRounds(commits, runsFor, { log = () => {} } = {}) {
+  const rounds = [];
+  const list = Array.isArray(commits) ? commits : [];
+  for (let index = 0; index < list.length; index++) {
+    const sha = str(list[index]?.sha);
+    if (sha === "") continue;
+    let runs;
+    try {
+      runs = asRunMap(typeof runsFor === "function" ? runsFor(sha) : null);
+    } catch (err) {
+      log(`could not read the panel's verdict at ${sha} (${err.message}); recording it as unknown.`);
+      rounds.push({ sha, index, conclusion: "", reviewedSha: "", completedAt: "", unreadable: true });
+      continue;
+    }
+    if (runs.size === 0) continue;
+    const { reviewedSha, conclusion, completedAt } = panelRoundAt(runs);
+    if (conclusion === "") continue; // no lens actually completed here
+    rounds.push({ sha, index, conclusion, reviewedSha, completedAt, runs });
+  }
+  return rounds;
+}
+
+/**
+ * The rounds a finding on `index` may be compared against: every round AT OR BEFORE
+ * it, newest last. `index < 0` (a sha not on the PR) yields ALL rounds.
+ *
+ * "At or before" is the correction this exists for. The comparison set used to be a
+ * single set computed from the hand-off commit and then applied to every CodeRabbit
+ * finding regardless of which commit it was about — so on a multi-round PR a finding
+ * could be checked against a verdict the panel reached AFTER it, and suppressed as
+ * "already raised" by a finding that did not exist yet.
+ *
+ * ONE rule covers both unplaceable directions: **what cannot be placed cannot be
+ * excluded.** An `index < 0` finding sees every round; a round with `index < 0` (an
+ * advisory review of a commit no longer on the branch) is eligible for every finding.
+ * Both widen the set, and widening can only ever over-suppress a finding the panel
+ * really did raise somewhere on this PR — whereas narrowing on a guess files a miss
+ * against a reviewer that did raise it. The same middle-of-the-road direction
+ * `attributeToPanel` takes with `maybe`, and it is logged either way.
+ *
+ * The UNION rather than the newest single round, which is deliberate and unchanged
+ * from the behaviour `panelFindingsFromComments` documented: the record's claim is
+ * "the panel did not raise this", and a finding raised in an earlier round is one the
+ * panel raised. Narrowing to one round would file those as misses.
+ */
+export function roundsUpTo(rounds, index) {
+  const all = Array.isArray(rounds) ? rounds : [];
+  if (index < 0) return [...all];
+  return all.filter((r) => Number(r?.index) < 0 || Number(r?.index) <= index);
 }
 
 // --- gh-backed collection ----------------------------------------------------
@@ -676,12 +919,17 @@ function commitFiles(sha, api) {
   return Array.isArray(out?.files) ? out.files : [];
 }
 
-/** The `ready_for_review` timeline event's timestamp, or "". */
-function readyForReviewAt(pr, api) {
-  const events = api(["api", "--paginate", `repos/{owner}/{repo}/issues/${pr}/timeline?per_page=100`]);
-  const hit = (Array.isArray(events) ? events : []).find((e) => e?.event === "ready_for_review");
-  return str(hit?.created_at);
-}
+/**
+ * How many of a PR's commits to read check runs for.
+ *
+ * One LIST call each, so this is the only place this module's cost grows with PR
+ * size. Set well above the real distribution rather than tuned to it: the widest PR
+ * this corpus has looked at carries 9 commits, and `pulls/{n}/commits` itself stops
+ * at 250. A PR past this cap loses its OLDEST rounds, so a CodeRabbit finding down
+ * there is compared against a wider set than it should be (see `roundsUpTo`) — which
+ * is why exceeding it is logged rather than absorbed.
+ */
+const ROUND_WALK_LIMIT = 100;
 
 /**
  * Propose miss records for one PR. NEVER throws: every collection step is
@@ -693,19 +941,27 @@ function readyForReviewAt(pr, api) {
  * the whole point of the corpus is that an empty result is a claim, not a default.
  *
  * THE TWO SIGNATURES HAVE DIFFERENT PRECONDITIONS, and conflating them cost this
- * module its best data. Signature 1 is defined relative to a hand-off — "a human
- * changed reviewable code AFTER the panel approved" is meaningless without the
- * moment it approved — and only an agent PR promoted by `mark-ready.mjs` has one.
- * Signature 2 needs neither: "CodeRabbit flagged something our panel reviewed and
+ * module its best data twice over.
+ *
+ * Signature 1 is defined relative to an approval — "a human changed reviewable code
+ * AFTER the panel approved" is meaningless without the moment it approved. Signature
+ * 2 needs no approval at all: "CodeRabbit flagged something our panel reviewed and
  * did not raise" is exactly as true on a human PR reviewed via `@claude review`,
- * where `handoffAt` is not merely unknown but MEANINGLESS — nothing was handed off.
+ * where nothing was ever handed off.
  *
  * Gating both on `isAgentPr` plus a hand-off marker excluded, measurably: 18 of 33
  * agent PRs (opened ready, so they have neither a marker nor a `ready_for_review`
  * event), and every human PR — which is where the on-demand panel reviews and the
- * bulk of CodeRabbit's blocking findings both live. So each signature now checks
- * only what it actually needs, and `skipped` is set only when nothing could be
- * examined at all.
+ * bulk of CodeRabbit's blocking findings both live.
+ *
+ * The second conflation survived that fix and is what this rewrite removes:
+ * signature 2 still reached the panel's findings THROUGH signature 1's cutoff. The
+ * comparison set was read from whichever commit was head at hand-off, so a PR with
+ * no hand-off produced no comparison set and withheld every CodeRabbit candidate —
+ * even with perfectly readable check runs on every commit. `panelRounds` now
+ * establishes the review history directly from the check runs, `roundsUpTo` resolves
+ * a comparison set PER COMMENT, and the cutoff is one more thing derived from that
+ * history rather than the thing it all depends on.
  */
 export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}) {
   const records = [];
@@ -714,111 +970,159 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
   let suppressed = 0;
 
   // Comments come FIRST and are load-bearing twice over: they carry the hand-off
-  // marker (signature 1's cutoff) and the on-demand panel's findings (signature
-  // 2's comparison set). One call, both facts.
+  // marker (signature 1's corroborating cutoff) and every on-demand review, which
+  // `commentRounds` turns into rounds. One call, both facts.
   let comments = [];
   try {
     comments = listComments(pr, api);
   } catch (err) {
-    log(`#${pr}: could not list comments (${err.message}); trying the timeline only.`);
+    log(`#${pr}: could not list comments (${err.message}); no marker and no advisory rounds from this PR.`);
   }
-  let ready = "";
-  try {
-    ready = readyForReviewAt(pr, api);
-  } catch (err) {
-    log(`#${pr}: could not read the timeline (${err.message}).`);
-  }
-  const handoffAt = handoffTime({ comments, readyForReviewAt: ready });
 
   let prCommits = [];
   try {
     prCommits = listCommits(pr, api);
   } catch (err) {
-    log(`#${pr}: could not list commits (${err.message}); no human-fix candidates from this PR.`);
+    log(`#${pr}: could not list commits (${err.message}); no rounds and no human-fix candidates from this PR.`);
   }
-  // `handoffAt` may be null now that signature 2 no longer requires one. NaN makes
-  // every `at <= cutoff` false, so `beforeHandoff` empties and `headAtHandoff` goes
-  // undefined — the same "could not establish it" state as an unreadable commit
-  // list. Stated rather than relied upon, because it is load-bearing.
-  const cutoff = handoffAt === null ? NaN : Date.parse(handoffAt);
-  const beforeHandoff = prCommits.filter((c) => {
-    const at = Date.parse(str(c?.commit?.committer?.date));
-    return Number.isFinite(at) && at <= cutoff;
-  });
-  // NO fallback to the PR's last commit. If every commit post-dates the handoff
-  // (a force-push or rebase after promotion rewrites committer dates), the last
-  // commit is one the panel saw only AFTER the human's fix — recording its verdict
-  // would describe a panel that had already been shown the answer. An empty
-  // `panelSaw` says "we could not establish what the panel saw", which is true; a
-  // post-handoff sha would be a wrong measurement that reads as a right one.
-  const headAtHandoff = beforeHandoff[beforeHandoff.length - 1];
+  if (prCommits.length > ROUND_WALK_LIMIT) {
+    log(
+      `#${pr}: ${prCommits.length} commits exceeds the ${ROUND_WALK_LIMIT}-commit round walk; ` +
+        `the oldest were NOT read, so a CodeRabbit finding on one is compared against a wider set than it should be.`,
+    );
+  }
+  const walked = prCommits.slice(0, ROUND_WALK_LIMIT);
 
-  // The sha is known for certain the moment we have the commit list, so it is
-  // recorded OUTSIDE the check-run fetch. Only `conclusion` and
-  // `blockingFindings` depend on the API call, and leaving those empty while the
-  // sha is present says exactly what happened: we know which commit the panel was
-  // looking at and we could not read what it concluded. Collapsing both into ""
-  // would make an API hiccup indistinguishable from a PR with no panel at all.
-  let panelSaw = { reviewedSha: str(headAtHandoff?.sha), conclusion: "", blockingFindings: 0 };
-  // `null`, not `[]`: "we could not establish the panel's findings" is a different
-  // claim from "the panel raised none", and `attributeToPanel` answers them
-  // differently. Collapsing them would let an API hiccup read as a clean panel.
-  let panelBlockers = null;
-  if (headAtHandoff?.sha) {
+  // PHASE 1 — which commits did the panel conclude on, and when. One check-runs
+  // LIST call per commit; the list response omits `output.text`, so this establishes
+  // the review history WITHOUT paying for the findings. Advisory reviews join as
+  // rounds of their own, already carrying their findings.
+  const rounds = [
+    ...panelRounds(walked, (sha) => latestLensRuns(commitCheckRuns(sha, { api }), names), {
+      log: (m) => log(`#${pr}: ${m}`),
+    }),
+    ...commentRounds(comments, walked),
+  ].sort((a, b) => a.index - b.index || (Date.parse(str(a.completedAt)) || 0) - (Date.parse(str(b.completedAt)) || 0));
+
+  // The cutoff, from the panel's own check runs — not from a comment, and no longer
+  // from `ready_for_review` at all. See `panelApprovedAt` for why that ordering is
+  // the whole point of this function.
+  const approvedAt = panelApprovedAt(rounds, markerHandoffAt(comments));
+  if (approvedAt === null && rounds.length > 0) {
+    log(`#${pr}: the panel reviewed this PR but never approved it; no human-fix candidates (the CodeRabbit signature still runs).`);
+  }
+
+  // PHASE 2 — the findings, fetched per round and ONLY for rounds a candidate is
+  // actually compared against. `withFullOutput` is one request per lens run, so this
+  // is the expensive half; caching by sha keeps a PR with many CodeRabbit comments
+  // from re-fetching the same round once per comment.
+  const blockersBySha = new Map();
+  const blockersOf = (round) => {
+    // An advisory round parsed its findings out of the comment already.
+    if (Array.isArray(round?.blockers)) return round.blockers;
+    // A round whose checks could not be listed has no findings to read and MUST NOT
+    // resolve to `[]`. Falling through would hand `withFullOutput` an absent `runs`,
+    // get an empty map back, and report "this round raised nothing blocking" about a
+    // round nobody has seen — filing every CodeRabbit finding on the PR as a miss.
+    if (round?.unreadable) return null;
+    const key = str(round?.sha);
+    if (blockersBySha.has(key)) return blockersBySha.get(key);
+    let out = null;
     try {
-      const runs = commitCheckRuns(headAtHandoff.sha, { api });
-      const verdict = panelVerdictAt(withFullOutput(latestLensRuns(runs, names), { api, log }));
-      panelSaw = {
-        reviewedSha: verdict.reviewedSha || headAtHandoff.sha,
-        conclusion: verdict.conclusion,
-        blockingFindings: verdict.blockingFindings,
-      };
-      // Only a lens run that actually EXISTED is an answer. `conclusion === ""` is
-      // `panelVerdictAt`'s own signal for "no lens runs on this commit", and its
-      // `blockers` is then an empty array meaning "nothing to read" — not "the panel
-      // raised nothing". Treating those alike is what kept the on-demand comment
-      // below unreachable: a commit with zero lens runs looked like a clean panel.
-      if (verdict.conclusion !== "") panelBlockers = verdict.blockers;
+      out = panelVerdictAt(withFullOutput(round.runs, { api, log })).blockers;
     } catch (err) {
-      log(`#${pr}: could not read the panel's verdict (${err.message}); recording it as unknown.`);
+      log(`#${pr}: could not read the panel's findings at ${key} (${err.message}); recording it as unknown.`);
     }
-  }
+    blockersBySha.set(key, out);
+    return out;
+  };
 
-  // FALLBACK to the on-demand panel's comment, and only a fallback: check runs are
-  // the structured record, this is a rendering of one, so it is read exactly when
-  // there is no structured record to prefer. `panelBlockers === null` is the test
-  // rather than `.length === 0` — an autonomous panel that genuinely raised nothing
-  // has already answered the question, and overwriting that with a comment from a
-  // different review would answer a different one.
-  if (panelBlockers === null) {
-    const fromComment = panelFindingsFromComments(comments);
-    if (fromComment) {
-      panelBlockers = fromComment.findings;
-      // Only fill what is still blank. A sha established from the commit list is
-      // more precise than the comment's, and `conclusion` stays "" because an
-      // advisory review reached no gate conclusion — that is not a missing value.
-      panelSaw = {
-        ...panelSaw,
-        reviewedSha: panelSaw.reviewedSha || fromComment.reviewedSha,
-        blockingFindings: panelSaw.blockingFindings || fromComment.findings.length,
-      };
-      log(
-        `#${pr}: no lens check runs; using the on-demand panel comment ` +
-          `(${fromComment.findings.length} blocking finding(s)) as the comparison set.`,
-      );
+  /**
+   * The panel's blocking findings a candidate at `index` may be compared against, or
+   * `null` when that cannot be established.
+   *
+   * `null` vs `[]` is the same distinction it has always been, now decided per
+   * candidate: `[]` is a real answer ("the panel reviewed this and raised nothing
+   * blocking"), `null` is the absence of one. A single unreadable round in the
+   * eligible set collapses the whole set to `null` — a union missing one round would
+   * claim the panel raised nothing where it may have raised exactly this.
+   *
+   * GATING AND ADVISORY ROUNDS ARE UNIONED, not ranked, and that is a change from the
+   * fallback ordering this replaces. The record's claim is "the panel did not raise
+   * this", and `@claude review` runs the SAME lens panel — so a finding it raised is a
+   * finding the panel raised, whether or not a gating round also covered that commit.
+   * Ranking check runs above the comment made sense when there was one set per PR and
+   * the question was which rendering of ONE round to trust; across rounds it would
+   * discard real findings and file them as misses.
+   *
+   * It does widen the suppression surface, which is the direction
+   * `panelFindingsFromComments` already chose and for the same reason: a finding the
+   * panel raised in an earlier round is one the panel raised. The mitigation is
+   * unchanged — every suppression is counted and logged with the finding it matched.
+   */
+  const comparisonSetAt = (index) => {
+    const eligible = roundsUpTo(rounds, index);
+    if (eligible.length === 0) return null;
+    const out = [];
+    for (const r of eligible) {
+      const b = blockersOf(r);
+      if (b === null) return null;
+      out.push(...b);
     }
-  }
+    return out;
+  };
 
-  // Signature 1 — human commits after handoff. Requires `handoffAt`: without the
-  // moment the panel let go, "after" has no referent and every commit on the PR
-  // would qualify. `isHumanFollowupCommit` returns false on an unusable cutoff, so
-  // this loop is already a no-op then; the guard is here to say so out loud and to
-  // keep the reason next to the code that depends on it.
-  if (handoffAt === null) {
-    log(`#${pr}: no hand-off marker and no ready_for_review event; no human-fix candidates (CodeRabbit signature still runs).`);
+  /**
+   * What the panel had concluded as of `index`, for the record's `panelSaw`.
+   *
+   * The GATING round wins here, and only here. This is where "check runs are the
+   * structured record and the comment is a rendering of one" is actually observable
+   * in the output: a gating round carries a real `conclusion` and an `external_id`
+   * state pointer, an advisory one carries `""` and the comment's sha. Letting an
+   * advisory round supply these would report `conclusion: ""` for a PR the panel
+   * demonstrably passed, which is a wrong measurement rather than a missing one.
+   *
+   * The COMPARISON SET above does not work this way, on purpose — see
+   * `comparisonSetAt`. Which round is the better witness to "what did the panel
+   * conclude" and which findings count as "the panel raised this" are two different
+   * questions, and the old single-set code could only answer them the same way.
+   */
+  const panelSawAt = (index, blockers) => {
+    const eligible = roundsUpTo(rounds, index);
+    const newest = eligible.filter((r) => !r?.advisory).at(-1) ?? eligible.at(-1);
+    return {
+      // The round's own state pointer when it has one, else the commit it hung off.
+      reviewedSha: str(newest?.reviewedSha) || str(newest?.sha),
+      conclusion: str(newest?.conclusion),
+      blockingFindings: Array.isArray(blockers) ? blockers.length : 0,
+    };
+  };
+
+  // Signature 1's anchor is the round that FIRST approved — the same round
+  // `panelApprovedAt` takes its timestamp from, so the record's `handoffAt` and its
+  // `panelSaw` describe one event rather than two. Not the newest round: a push after
+  // approval opens rounds that say nothing about the approval the human reacted to,
+  // and one of them re-approving is what would drag the cutoff past their fix.
+  const approvingRound = rounds
+    .filter((r) => str(r?.conclusion) === "success")
+    .sort((a, b) => (Date.parse(str(a.completedAt)) || 0) - (Date.parse(str(b.completedAt)) || 0))[0];
+
+  // Signature 1 — human commits after the panel approved. Requires `approvedAt`:
+  // without the moment the panel let go, "after" has no referent and every commit on
+  // the PR would qualify. `isHumanFollowupCommit` returns false on an unusable
+  // cutoff, so this loop is already a no-op then; the guard is here to say so out
+  // loud and to keep the reason next to the code that depends on it.
+  //
+  // The cutoff is a check-run `completed_at`, which is why a rebase no longer breaks
+  // this: it rewrites the committer dates on the left of the comparison but cannot
+  // touch the timestamp on the right.
+  const sig1PanelSaw = panelSawAt(approvingRound ? approvingRound.index : -1,
+    approvingRound ? blockersOf(approvingRound) : null);
+  if (approvedAt === null && rounds.length === 0) {
+    log(`#${pr}: no panel round and no hand-off marker; no human-fix candidates (the CodeRabbit signature still runs).`);
   }
   for (const c of prCommits) {
-    if (!isHumanFollowupCommit(c, handoffAt)) continue;
+    if (!isHumanFollowupCommit(c, approvedAt)) continue;
     let files = [];
     try {
       files = interestingFiles(commitFiles(c.sha, api));
@@ -833,11 +1137,11 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
         label: "miss",
         source: "human-fix",
         pr,
-        handoffAt: str(handoffAt),
+        handoffAt: str(approvedAt),
         evidence: { commitSha: c.sha, url: str(c.html_url) },
         files,
         summary: str(c.commit?.message).split("\n")[0],
-        panelSaw,
+        panelSaw: sig1PanelSaw,
         notes: "candidate: a human changed reviewable code after the panel approved",
       }),
     );
@@ -863,17 +1167,28 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
   // Withholding is also the RECOVERABLE direction. No row is written, so a later
   // harvest re-proposes the candidate once the evidence exists; a wrong row, once
   // curated, is permanent.
-  const panelReviewed = panelBlockers !== null;
+  //
+  // The evidence is now resolved PER COMMENT rather than once per PR, and that is the
+  // correction this change exists for. The comparison set used to come from whichever
+  // commit was head at hand-off, and was then applied to every CodeRabbit finding on
+  // the PR — so on a multi-round PR a finding could be checked against a verdict the
+  // panel reached AFTER it and suppressed as "already raised" by a finding that did
+  // not exist yet. It also meant no hand-off (18 of 33 agent PRs) left the set at
+  // `null` and withheld every candidate on a PR whose check runs were sitting right
+  // there, readable. Signature 2 never needed a hand-off; now it does not consult one.
   let reviewComments = [];
   try {
     reviewComments = listReviewComments(pr, api);
   } catch (err) {
     log(`#${pr}: could not list review comments (${err.message}).`);
   }
-  if (!panelReviewed && reviewComments.length > 0) {
+  // An unreadable round is not evidence of anything — it is the absence of evidence
+  // with a sha attached — so this counts only rounds we could actually read.
+  if (rounds.filter((r) => !r?.unreadable).length === 0 && reviewComments.length > 0) {
     log(`#${pr}: ${reviewComments.length} review comment(s) but no evidence the panel ever reviewed this PR; no CodeRabbit candidates.`);
   }
-  for (const rc of panelReviewed ? reviewComments : []) {
+  let panelReviewed = false;
+  for (const rc of rounds.length === 0 ? [] : reviewComments) {
     // EXACT login, not a prefix. `startsWith("coderabbitai")` also accepts
     // `coderabbitai-x`, and anyone can register that name and comment on a public
     // PR — which would let a stranger write rows into the corpus. Curation is the
@@ -884,6 +1199,26 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
     if (!finding) continue;
     const files = interestingFiles([str(rc.path)]);
     if (files.length === 0) continue;
+
+    // WHICH COMMIT this finding is about, so it is compared against what the panel
+    // had concluded by then and not against a later round. `original_commit_id` is
+    // the commit the comment was first written on; `commit_id` is where GitHub
+    // currently places it, and is the fallback.
+    const at = commitIndex(walked, str(rc.original_commit_id || rc.commit_id));
+    if (at < 0) {
+      log(
+        `#${pr}: CodeRabbit comment ${rc.id} sits on a commit that is no longer on the PR; ` +
+          `comparing it against every round (see roundsUpTo — what cannot be placed cannot be excluded).`,
+      );
+    }
+    const panelBlockers = comparisonSetAt(at);
+    if (panelBlockers === null) {
+      // No round at or before this comment, or one of them was unreadable. Either
+      // way there is no basis for "the panel did not raise this".
+      log(`#${pr}: no readable panel round at or before CodeRabbit comment ${rc.id}; withheld.`);
+      continue;
+    }
+    panelReviewed = true;
 
     // `rc.path` RAW, not the filtered `files` above: `interestingFiles` exists to
     // decide what may carry a miss, and reusing it here would silently hand the
@@ -913,7 +1248,7 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
         label: "miss",
         source: "coderabbit",
         pr,
-        handoffAt: str(handoffAt),
+        handoffAt: str(approvedAt),
         evidence: {
           commitSha: str(rc.original_commit_id || rc.commit_id),
           commentId: String(rc.id ?? ""),
@@ -924,7 +1259,7 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
         severity: finding.severity,
         summary: finding.summary,
         panelSaw: {
-          ...panelSaw,
+          ...panelSawAt(at, panelBlockers),
           matchVerdict: attribution.verdict,
           matchScore: attribution.score,
           matchedSummary: attribution.matchedSummary,
@@ -938,16 +1273,16 @@ export function harvestPr(pr, { api = gh, log = console.error, names = [] } = {}
     );
   }
   // `skipped` is reserved for "could not look", never "looked and found nothing".
-  // Nothing was examinable when there was no hand-off (so signature 1 could not
-  // run) AND no CodeRabbit review comment reached the matcher (so signature 2 had
-  // no input). Anything else produced a real, reportable zero.
-  const noSignature1 = handoffAt === null;
-  const noSignature2 = !panelReviewed || reviewComments.length === 0;
+  // Nothing was examinable when the panel never approved (so signature 1 could not
+  // run) AND no CodeRabbit comment reached the matcher with a round behind it (so
+  // signature 2 had no input). Anything else produced a real, reportable zero.
+  const noSignature1 = approvedAt === null;
+  const noSignature2 = !panelReviewed;
   return {
     records,
     skipped:
       noSignature1 && noSignature2
-        ? `#${pr} has no hand-off marker and no panel review to compare CodeRabbit against — nothing to examine`
+        ? `#${pr} has no panel approval and no panel round to compare CodeRabbit against — nothing to examine`
         : "",
     suppressed,
   };

--- a/scripts/agent/harvest.test.mjs
+++ b/scripts/agent/harvest.test.mjs
@@ -7,7 +7,13 @@ import {
   SOURCES,
   MISSES_PATH,
   isAgentPr,
-  handoffTime,
+  markerHandoffAt,
+  panelApprovedAt,
+  commitIndex,
+  panelRounds,
+  roundsUpTo,
+  commentRounds,
+  panelRoundAt,
   isHumanFollowupCommit,
   interestingFiles,
   fileClassesOf,
@@ -50,9 +56,13 @@ test("isAgentPr: a human PR on a non-agent branch is not one; junk never throws"
   for (const bad of [null, undefined, "x", 7, []]) assert.equal(isAgentPr(bad), false);
 });
 
-// --- handoffTime -------------------------------------------------------------
+// --- markerHandoffAt / panelApprovedAt ---------------------------------------
 
-test("handoffTime: the FIRST marker comment wins", () => {
+const round = (over = {}) => ({
+  sha: "a".repeat(40), index: 0, conclusion: "success", reviewedSha: "", completedAt: "2026-07-24T15:40:00Z", ...over,
+});
+
+test("markerHandoffAt: the FIRST marker comment wins", () => {
   const comments = [
     { body: `${HANDOFF_MARKER}\n## re-promoted`, created_at: "2026-07-26T00:00:00Z" },
     { body: "unrelated chatter", created_at: "2026-07-24T00:00:00Z" },
@@ -60,32 +70,173 @@ test("handoffTime: the FIRST marker comment wins", () => {
   ];
   // A PR that is un-readied and re-promoted has two markers. The human work this
   // corpus is looking for starts at the first one.
-  assert.equal(handoffTime({ comments }), "2026-07-24T15:48:28Z");
+  assert.equal(markerHandoffAt(comments), "2026-07-24T15:48:28Z");
 });
 
-test("handoffTime: falls back to ready_for_review when the marker comment is missing", () => {
-  // NOT belt-and-braces. mark-ready.mjs posts the hand-off comment inside a
-  // try/catch AFTER flipping the PR to ready, so a genuinely promoted PR can carry
-  // no marker at all — and a PR the harvester cannot see is a miss nothing can
-  // recover later. On #548 the two timestamps were 3 seconds apart.
+test("markerHandoffAt: null with no usable marker; junk never throws", () => {
+  assert.equal(markerHandoffAt([]), null);
+  assert.equal(markerHandoffAt(), null);
+  assert.equal(markerHandoffAt([{ body: HANDOFF_MARKER, created_at: "not a date" }]), null);
+  assert.equal(markerHandoffAt([{ body: HANDOFF_MARKER }]), null);
+  for (const bad of [null, "x", 7]) assert.equal(markerHandoffAt(bad), null);
+});
+
+test("panelApprovedAt: the panel's own check run beats the marker comment", () => {
+  // The check run is the primary source because it is the only signal present
+  // WHENEVER the panel ran. The marker is posted in a try/catch after the PR is
+  // already flipped ready, so a genuinely promoted PR can carry none.
   assert.equal(
-    handoffTime({ comments: [{ body: "no marker here", created_at: "2026-07-24T00:00:00Z" }], readyForReviewAt: "2026-07-24T15:48:25Z" }),
-    "2026-07-24T15:48:25Z",
-  );
-  // marker present → it wins over the event
-  assert.equal(
-    handoffTime({ comments: [{ body: HANDOFF_MARKER, created_at: "2026-07-24T15:48:28Z" }], readyForReviewAt: "2026-07-24T15:48:25Z" }),
-    "2026-07-24T15:48:28Z",
+    panelApprovedAt([round({ completedAt: "2026-07-24T15:40:00Z" })], "2026-07-24T15:48:28Z"),
+    "2026-07-24T15:40:00Z",
   );
 });
 
-test("handoffTime: null when there is no handoff at all, and on unusable timestamps", () => {
-  assert.equal(handoffTime({}), null);
-  assert.equal(handoffTime(), null);
-  assert.equal(handoffTime({ comments: [{ body: HANDOFF_MARKER, created_at: "not a date" }] }), null);
-  assert.equal(handoffTime({ comments: [{ body: HANDOFF_MARKER }] }), null);
-  assert.equal(handoffTime({ readyForReviewAt: "nonsense" }), null);
-  for (const bad of [null, "x", 7]) assert.equal(handoffTime({ comments: bad }), null);
+test("panelApprovedAt: the FIRST approval, because the newest one is self-defeating", () => {
+  // The trap this exists to avoid. Every human fix pushed after an approval opens a
+  // new round, and that round approves too — so a newest-approval cutoff moves PAST
+  // the very commits the signature is looking for.
+  //
+  // Measured on #548: newest-approval lands on 2026-07-28, four days after the three
+  // human fixes of 2026-07-25, and loses all three — including rows already curated
+  // into misses.jsonl. Same rule as markerHandoffAt's "FIRST marker, not the last":
+  // a later re-approval does not un-say the first one.
+  const rounds = [
+    round({ index: 0, completedAt: "2026-07-24T15:40:00Z" }),
+    round({ index: 1, completedAt: "2026-07-28T01:00:56Z" }),
+  ];
+  assert.equal(panelApprovedAt(rounds), "2026-07-24T15:40:00Z");
+  // Order in the array must not matter — it is the timestamps that decide.
+  assert.equal(panelApprovedAt([...rounds].reverse()), "2026-07-24T15:40:00Z");
+});
+
+test("panelApprovedAt: only success is an approval — failure, unread and ADVISORY are not", () => {
+  assert.equal(panelApprovedAt([round({ conclusion: "failure" })]), null);
+  assert.equal(panelApprovedAt([round({ conclusion: "" })]), null);
+  // An `@claude review` round carries conclusion "" precisely so it can never
+  // become signature 1's cutoff: it is advice, not a gate decision.
+  assert.equal(panelApprovedAt(commentRounds([], [])), null);
+  // …and a failing round does not suppress an earlier real approval.
+  assert.equal(
+    panelApprovedAt([round({ index: 0, completedAt: "2026-07-24T15:40:00Z" }), round({ index: 1, conclusion: "failure", completedAt: "2026-07-26T09:00:00Z" })]),
+    "2026-07-24T15:40:00Z",
+  );
+});
+
+test("panelApprovedAt: falls back to the marker, and to null; junk never throws", () => {
+  assert.equal(panelApprovedAt([], "2026-07-24T15:48:28Z"), "2026-07-24T15:48:28Z");
+  assert.equal(panelApprovedAt([]), null);
+  assert.equal(panelApprovedAt([], "nonsense"), null);
+  assert.equal(panelApprovedAt([round({ completedAt: "not a date" })], null), null);
+  for (const bad of [null, "x", 7]) assert.equal(panelApprovedAt(bad), null);
+});
+
+// --- panelRoundAt / panelRounds / commitIndex / roundsUpTo -------------------
+
+const lensRun = (over = {}) => ({
+  name: "agent-review-correctness", app: { slug: "github-actions" }, status: "completed",
+  conclusion: "success", completed_at: "2026-07-24T15:40:00Z", ...over,
+});
+
+test("panelRoundAt: completedAt is the LATEST lens, because the round is not over until its last one", () => {
+  const runs = new Map([
+    ["agent-review-correctness", lensRun({ completed_at: "2026-07-24T15:38:00Z" })],
+    ["agent-review-test-adequacy", lensRun({ completed_at: "2026-07-24T15:41:00Z" })],
+  ]);
+  assert.equal(panelRoundAt(runs).completedAt, "2026-07-24T15:41:00Z");
+  // started_at is the per-run fallback latestLensRuns itself orders by
+  assert.equal(panelRoundAt(new Map([["x", { conclusion: "success", started_at: "2026-07-24T15:00:00Z" }]])).completedAt, "2026-07-24T15:00:00Z");
+  // unusable timestamps degrade to "", never to NaN or a throw
+  assert.equal(panelRoundAt(new Map([["x", { conclusion: "success", completed_at: "nope" }]])).completedAt, "");
+  assert.equal(panelRoundAt(null).completedAt, "");
+  // Ordered by PARSED TIME, not lexicographically. These two strings sort the wrong
+  // way as text and the right way as instants, so a string comparison fails here.
+  const offsets = new Map([
+    ["a", { conclusion: "success", completed_at: "2026-07-24T09:00:00-06:00" }], // 15:00Z
+    ["b", { conclusion: "success", completed_at: "2026-07-24T14:00:00Z" }],
+  ]);
+  assert.equal(panelRoundAt(offsets).completedAt, "2026-07-24T09:00:00-06:00");
+  assert.equal(
+    panelApprovedAt([round({ completedAt: "2026-07-24T14:00:00Z" }), round({ completedAt: "2026-07-24T09:00:00-06:00" })]),
+    "2026-07-24T14:00:00Z", // the earlier INSTANT, though it sorts later as text
+  );
+});
+
+test("panelRoundAt: shares the aggregate conclusion rule rather than copying it", () => {
+  // One failing lens means the panel did not let it through — the same rule
+  // panelVerdictAt reports, from the same function, so the cheap path used to
+  // establish rounds can never disagree with the expensive one used to read them.
+  const runs = new Map([["a", lensRun()], ["b", lensRun({ conclusion: "failure" })]]);
+  assert.equal(panelRoundAt(runs).conclusion, "failure");
+  assert.equal(panelVerdictAt(runs).conclusion, "failure");
+  assert.equal(panelRoundAt(new Map()).conclusion, "");
+  assert.equal(panelVerdictAt(new Map()).conclusion, "");
+});
+
+test("commitIndex: position on the PR, and -1 for a commit that is not on it", () => {
+  const commits = [{ sha: "a".repeat(40) }, { sha: "b".repeat(40) }];
+  assert.equal(commitIndex(commits, "b".repeat(40)), 1);
+  // A force-push leaves a CodeRabbit comment's original_commit_id pointing at a
+  // commit no longer reachable from the branch. That is a real state, not junk.
+  assert.equal(commitIndex(commits, "c".repeat(40)), -1);
+  assert.equal(commitIndex(commits, ""), -1);
+  for (const bad of [null, "x", 7]) assert.equal(commitIndex(bad, "a".repeat(40)), -1);
+});
+
+test("panelRounds: only commits the panel CONCLUDED on become rounds", () => {
+  const commits = [{ sha: "a".repeat(40) }, { sha: "b".repeat(40) }, { sha: "c".repeat(40) }];
+  const rounds = panelRounds(commits, (sha) => {
+    if (sha === "a".repeat(40)) return new Map([["agent-review-correctness", lensRun()]]);
+    if (sha === "b".repeat(40)) return new Map(); // no lens runs at all → not a round
+    return new Map([["agent-review-correctness", lensRun({ conclusion: "failure", completed_at: "2026-07-25T10:00:00Z" })]]);
+  });
+  assert.deepEqual(rounds.map((r) => [r.index, r.conclusion]), [[0, "success"], [2, "failure"]]);
+});
+
+test("panelRounds: an unreadable commit keeps its SHA but is never evidence", () => {
+  // Two directions at once. The round must not count as "the panel reviewed this" —
+  // so conclusion "" keeps it out of panelApprovedAt and `unreadable` makes the
+  // comparison set refuse it — but the sha is a fact we hold either way, and it is
+  // what tells an API hiccup apart from a PR the panel never touched.
+  const commits = [{ sha: "a".repeat(40) }, { sha: "b".repeat(40) }];
+  const logged = [];
+  const rounds = panelRounds(commits, (sha) => {
+    if (sha === "a".repeat(40)) throw new Error("502");
+    return new Map([["agent-review-correctness", lensRun()]]);
+  }, { log: (m) => logged.push(m) });
+  assert.deepEqual(rounds.map((r) => [r.index, r.conclusion, r.unreadable ?? false]), [[0, "", true], [1, "success", false]]);
+  assert.equal(rounds[0].sha, "a".repeat(40));
+  assert.ok(logged.some((m) => /could not read the panel's verdict at a{40} \(502\)/.test(m)));
+  // It is not an approval, and the readable round beside it still is.
+  assert.equal(panelApprovedAt([rounds[0]]), null);
+  assert.equal(panelApprovedAt(rounds), "2026-07-24T15:40:00Z");
+});
+
+test("roundsUpTo: what cannot be PLACED cannot be EXCLUDED", () => {
+  const rounds = [round({ index: 0 }), round({ index: 2 }), round({ index: -1, sha: "z".repeat(40) })];
+  // A finding on commit 1 sees round 0 — and the unplaceable round, which cannot be
+  // ruled out on evidence — but NOT round 2, which the panel reached afterwards.
+  assert.deepEqual(roundsUpTo(rounds, 1).map((r) => r.index), [0, -1]);
+  // An unplaceable finding sees everything.
+  assert.deepEqual(roundsUpTo(rounds, -1).map((r) => r.index), [0, 2, -1]);
+  // Both directions widen: narrowing on a guess would file a miss against a
+  // reviewer that did raise it, which is the unrecoverable error.
+  assert.deepEqual(roundsUpTo(rounds, 5).map((r) => r.index), [0, 2, -1]);
+  for (const bad of [null, "x", 7]) assert.deepEqual(roundsUpTo(bad, 0), []);
+});
+
+test("commentRounds: an advisory review is a round, with conclusion \"\"", () => {
+  const sha = "a".repeat(40);
+  const body = `<!-- agent-review:${sha} -->\ncorrectness review: **changes requested**\n\n### Major (1)\n\n- \`pkg/x.ts:10\` — a real defect\n`;
+  const rounds = commentRounds([{ user: { login: "yorkie-agent[bot]" }, body, created_at: "2026-07-24T16:00:00Z" }], [{ sha }]);
+  assert.equal(rounds.length, 1);
+  assert.equal(rounds[0].index, 0);
+  assert.equal(rounds[0].conclusion, ""); // advisory: reached no gate conclusion
+  assert.equal(rounds[0].advisory, true);
+  assert.equal(rounds[0].blockers.length, 1); // findings already parsed — no second request
+  // Author-gated before anything is parsed: these findings can suppress a candidate.
+  assert.deepEqual(commentRounds([{ user: { login: "harrykim8672" }, body }], [{ sha }]), []);
+  // Reviewed a commit no longer on the PR → unplaceable, which roundsUpTo handles.
+  assert.equal(commentRounds([{ user: { login: "yorkie-agent[bot]" }, body }], [{ sha: "b".repeat(40) }])[0].index, -1);
 });
 
 // --- isHumanFollowupCommit ---------------------------------------------------
@@ -418,8 +569,11 @@ test("harvestPr: proposes both signatures, and only from reviewable code", () =>
   assert.deepEqual(fix.files, ["packages/docs/src/view/text-editor.ts"]);
   assert.deepEqual(fix.fileClasses, ["code"]);
   assert.equal(fix.summary, "Guard EditorAPI.paste()"); // first line only
-  assert.equal(fix.handoffAt, HANDOFF);
-  // the verdict that LET THE PR THROUGH — the runs on the head commit at handoff
+  // The CHECK RUN's completed_at, not the marker comment's created_at (15:48:28Z).
+  // The panel's own run is the primary source now; the marker is a fallback for a
+  // PR that has no readable round at all.
+  assert.equal(fix.handoffAt, "2026-07-24T15:40:00Z");
+  // the verdict that LET THE PR THROUGH — the round that approved
   assert.deepEqual(fix.panelSaw, { ...EMPTY_PANEL_SAW, reviewedSha: SHA_BASE, conclusion: "success" });
 
   const cr = records.find((r) => r.source === "coderabbit");
@@ -713,8 +867,12 @@ test("harvestPr: with no check runs, the on-demand comment becomes the compariso
   const { records, suppressed } = harvestPr(548, { api, log: (m) => logged.push(m), names: NAMES });
   assert.equal(suppressed, 1);
   assert.equal(records.filter((r) => r.source === "coderabbit").length, 0);
-  assert.ok(logged.some((m) => /using the on-demand panel comment/.test(m)));
   assert.ok(logged.some((m) => /restates a panel finding/.test(m)));
+  // No "using the on-demand comment as a fallback" line any more, and its absence is
+  // the point: an advisory review is now a ROUND like any other rather than a
+  // whole-PR substitute reached only when check runs are missing. There is nothing to
+  // announce, because nothing was substituted.
+  assert.ok(!logged.some((m) => /using the on-demand panel comment/.test(m)));
 });
 
 test("harvestPr: real check runs WIN over the comment", () => {
@@ -781,12 +939,19 @@ test("harvestPr: every commit after the handoff leaves panelSaw EMPTY, not wrong
 });
 
 test("harvestPr: 'could not look' never reads the same as 'nothing found'", () => {
-  // Nothing examinable: no hand-off (signature 1 cannot run) AND no review
-  // comments (signature 2 has no input). Only this shape sets `skipped`.
+  // Nothing examinable: NO PANEL ROUND (so there is no approval for signature 1 and
+  // nothing for signature 2 to compare against) and no review comments. Only this
+  // shape sets `skipped`.
+  //
+  // Dropping the check runs is now part of the fixture, and that is the change: with
+  // them present this PR IS examinable — a successful round is an approval, and the
+  // human commit after it is a candidate — even with no marker comment anywhere. That
+  // is the 18-of-33 agent PRs the old marker-only cutoff could not see.
   const nothing = harvestPr(548, {
     api: fakeApi({
       "repos/{owner}/{repo}/issues/548/comments?per_page=100": [],
       "repos/{owner}/{repo}/pulls/548/comments?per_page=100": [],
+      [`repos/{owner}/{repo}/commits/${SHA_BASE}/check-runs?per_page=100`]: [{ check_runs: [] }],
     }),
     log: () => {},
     names: NAMES,
@@ -794,41 +959,61 @@ test("harvestPr: 'could not look' never reads the same as 'nothing found'", () =
   assert.deepEqual(nothing.records, []);
   assert.match(nothing.skipped, /nothing to examine/);
 
-  // No hand-off, but an on-demand panel review: signature 1 is silently
-  // inapplicable, signature 2 runs against the comment, and the record carries
-  // handoffAt "" rather than a guess. This is the shape the relaxation exists for.
-  const noHandoff = harvestPr(548, {
+  // The same PR WITH its check runs: no marker, no ready_for_review, still harvested.
+  const noMarker = harvestPr(548, {
+    api: fakeApi({
+      "repos/{owner}/{repo}/issues/548/comments?per_page=100": [],
+      "repos/{owner}/{repo}/pulls/548/comments?per_page=100": [],
+    }),
+    log: () => {},
+    names: NAMES,
+  });
+  assert.equal(noMarker.skipped, "");
+  assert.equal(noMarker.records.filter((r) => r.source === "human-fix").length, 1);
+  assert.equal(noMarker.records[0].handoffAt, "2026-07-24T15:40:00Z");
+
+  // An ADVISORY review and nothing else: signature 1 is silently inapplicable —
+  // `@claude review` is not an approval — signature 2 runs against the comment round,
+  // and the record carries handoffAt "" rather than a guess. This is the shape the
+  // relaxation exists for, and it is now expressed by the absence of a SUCCESS round
+  // rather than the absence of a marker comment.
+  const advisoryOnly = harvestPr(548, {
     api: fakeApi({
       "repos/{owner}/{repo}/issues/548/comments?per_page=100": [
         { user: { login: "yorkie-agent[bot]" }, body: PANEL_BODY },
       ],
+      [`repos/{owner}/{repo}/commits/${SHA_BASE}/check-runs?per_page=100`]: [{ check_runs: [] }],
       ...crComment(CR_MAJOR_CORRECTNESS),
     }),
     log: () => {},
     names: NAMES,
   });
-  assert.equal(noHandoff.skipped, "");
-  assert.equal(noHandoff.records.filter((r) => r.source === "human-fix").length, 0);
-  assert.equal(noHandoff.records.filter((r) => r.source === "coderabbit").length, 1);
-  assert.equal(noHandoff.records[0].handoffAt, "");
-  assert.equal(noHandoff.records[0].panelSaw.matchVerdict, "no");
+  assert.equal(advisoryOnly.skipped, "");
+  assert.equal(advisoryOnly.records.filter((r) => r.source === "human-fix").length, 0);
+  assert.equal(advisoryOnly.records.filter((r) => r.source === "coderabbit").length, 1);
+  assert.equal(advisoryOnly.records[0].handoffAt, "");
+  assert.equal(advisoryOnly.records[0].panelSaw.matchVerdict, "no");
 
-  // KNOWN LIMITATION, asserted so it cannot change silently: without a hand-off
-  // there is no `headAtHandoff`, so lens CHECK RUNS are never read — only the
-  // comment path reaches signature 2 here. It costs nothing measurable today (the
-  // no-hand-off population has no lens runs on any commit either) and is recorded
-  // in the task doc's "Not built".
-  const noHandoffNoComment = harvestPr(548, {
+  // THE LIMITATION THIS CHANGE REMOVES, now asserted in the opposite direction.
+  // It used to read: "without a hand-off there is no `headAtHandoff`, so lens CHECK
+  // RUNS are never read — only the comment path reaches signature 2 here." That was
+  // signature 2 depending on signature 1's cutoff, and it withheld every CodeRabbit
+  // candidate on a PR whose check runs were readable the whole time.
+  const noMarkerNoComment = harvestPr(548, {
     api: fakeApi({ "repos/{owner}/{repo}/issues/548/comments?per_page=100": [] }),
     log: () => {},
     names: NAMES,
   });
-  assert.equal(noHandoffNoComment.records.filter((r) => r.source === "coderabbit").length, 0);
+  assert.equal(noMarkerNoComment.records.filter((r) => r.source === "coderabbit").length, 1);
+  // …and it is compared against the CHECK RUNS, not a comment there is none of.
+  const fromRuns = noMarkerNoComment.records.find((r) => r.source === "coderabbit");
+  assert.equal(fromRuns.panelSaw.conclusion, "success");
+  assert.equal(fromRuns.panelSaw.reviewedSha, SHA_BASE);
 
-  // An unreadable COMMITS list costs the check-run path — `headAtHandoff` is derived
-  // from it — so the panel cannot be established and signature 2 withholds too.
-  // Documented rather than worked around: it is the recoverable direction, and a
-  // re-harvest re-proposes the candidate.
+  // An unreadable COMMITS list costs the check-run path — rounds are walked over it —
+  // so the panel cannot be established and signature 2 withholds too. Documented
+  // rather than worked around: it is the recoverable direction, and a re-harvest
+  // re-proposes the candidate.
   const noCommits = harvestPr(548, {
     api: fakeApi({ "repos/{owner}/{repo}/pulls/548/commits?per_page=100": new Error("502") }),
     log: () => {},
@@ -851,6 +1036,118 @@ test("harvestPr: 'could not look' never reads the same as 'nothing found'", () =
     names: NAMES,
   });
   assert.equal(noCommitsWithPanel.records.filter((r) => r.source === "coderabbit").length, 1);
+});
+
+// --- the four cutoff bugs, one test each ------------------------------------
+//
+// Each of these FAILS on the marker-based cutoff this replaces. They are the reason
+// the change exists, so they are named after the failure rather than the mechanism.
+
+test("cutoff bug 1: no marker anywhere still harvests, from the check runs", () => {
+  // Measured population: 18 of 33 agent PRs were opened ready rather than promoted,
+  // so they carry neither a hand-off marker nor a `ready_for_review` event. The old
+  // cutoff had nothing to key on, which silenced signature 1 AND — because signature
+  // 2 read the panel through signature 1's commit — every CodeRabbit candidate too.
+  const api = fakeApi({
+    "repos/{owner}/{repo}/issues/548/comments?per_page=100": [],
+    "repos/{owner}/{repo}/issues/548/timeline?per_page=100": [],
+    ...crComment(CR_MAJOR_CORRECTNESS),
+  });
+  const { records, skipped } = harvestPr(548, { api, log: () => {}, names: NAMES });
+  assert.equal(skipped, "");
+  assert.deepEqual(records.map((r) => r.source).sort(), ["coderabbit", "human-fix"]);
+  assert.equal(records.find((r) => r.source === "human-fix").handoffAt, "2026-07-24T15:40:00Z");
+});
+
+test("cutoff bug 2: a manually-readied PR the panel never approved harvests NOTHING", () => {
+  // `ready_for_review` fires whether or not the panel ever spoke, so keying the
+  // cutoff off it made every later human commit a candidate on a PR no reviewer had
+  // passed. The signal is gone; the absence of a SUCCESS round is now what decides.
+  const api = fakeApi({
+    "repos/{owner}/{repo}/issues/548/comments?per_page=100": [],
+    // The event that used to be the fallback cutoff, now ignored entirely.
+    "repos/{owner}/{repo}/issues/548/timeline?per_page=100": [
+      { event: "ready_for_review", created_at: "2026-07-24T15:48:25Z" },
+    ],
+    [`repos/{owner}/{repo}/commits/${SHA_BASE}/check-runs?per_page=100`]: [{ check_runs: [] }],
+    "repos/{owner}/{repo}/pulls/548/comments?per_page=100": [],
+  });
+  const { records, skipped } = harvestPr(548, { api, log: () => {}, names: NAMES });
+  assert.deepEqual(records, []);
+  assert.match(skipped, /no panel approval/);
+});
+
+test("cutoff bug 3: a rebase after approval no longer erases the comparison set", () => {
+  // The sharpest one. A force-push rewrites every committer date on the PR, so with a
+  // comment-based cutoff EVERY commit post-dated it, `beforeHandoff` emptied, and the
+  // check runs were never read — leaving signature 2 with no comparison set on a PR
+  // whose verdict was sitting right there. `completed_at` is stamped by GitHub on the
+  // check run and a rebase cannot move it.
+  const rebased = [
+    { sha: SHA_BASE, parents: [{ sha: "0" }], author: { type: "Bot" }, commit: { message: "agent work", committer: { date: "2026-07-30T00:00:00Z" } } },
+    { sha: SHA_FIX, parents: [{ sha: SHA_BASE }], author: { login: "harrykim8672", type: "User" }, html_url: "https://x/commit", commit: { message: "Guard EditorAPI.paste()", committer: { date: "2026-07-30T00:01:00Z" } } },
+  ];
+  const api = fakeApi({
+    "repos/{owner}/{repo}/pulls/548/commits?per_page=100": rebased,
+    ...crComment(CR_MAJOR_CORRECTNESS),
+  });
+  const { records } = harvestPr(548, { api, log: () => {}, names: NAMES });
+  // The CodeRabbit candidate is compared against the real verdict, not withheld.
+  const cr = records.find((r) => r.source === "coderabbit");
+  assert.ok(cr, "the CodeRabbit candidate must survive a rebase");
+  assert.equal(cr.panelSaw.conclusion, "success");
+  assert.equal(cr.panelSaw.reviewedSha, SHA_BASE);
+});
+
+test("cutoff bug 4: a finding is compared against what the panel knew BY THEN", () => {
+  // The comparison set used to be ONE set per PR, read from whichever commit was head
+  // at hand-off, and applied to every CodeRabbit finding regardless of which commit it
+  // was about. That is wrong in both directions, and which one you get depends only on
+  // where the hand-off commit happens to sit:
+  //
+  //   - hand-off commit EARLIER than the finding → the set misses rounds the panel had
+  //     already reached, so a genuine restatement is filed as a miss. Measured: that is
+  //     what this fixture produced before the change (`suppressed: 0` on 4b).
+  //   - hand-off commit LATER than the finding → the set includes rounds that did not
+  //     exist yet, so a real miss is suppressed by a finding from the future.
+  //
+  // The first costs a false row, the second costs a real one. Anchoring per comment
+  // removes both, and the two halves below pin the boundary from either side: the panel
+  // raises the defect only at SHA_FIX, so the same comment must be a miss on SHA_BASE
+  // and a restatement on SHA_FIX.
+  //
+  // 4a is a REGRESSION GUARD rather than a fixed bug — the old code also left it
+  // unsuppressed, for the wrong reason. It is here because the new per-comment logic is
+  // the thing that could newly over-suppress it.
+  const laterRound = {
+    [`repos/{owner}/{repo}/commits/${SHA_BASE}/check-runs?per_page=100`]: [{ check_runs: [
+      { id: 1, name: "agent-review-correctness", app: { slug: "github-actions" }, status: "completed", conclusion: "success", completed_at: "2026-07-24T15:40:00Z", output: { text: "[]" } },
+    ] }],
+    [`repos/{owner}/{repo}/commits/${SHA_FIX}/check-runs?per_page=100`]: [{ check_runs: [
+      { id: 2, name: "agent-review-correctness", app: { slug: "github-actions" }, status: "completed", conclusion: "failure", completed_at: "2026-07-26T09:00:00Z" },
+    ] }],
+    "repos/{owner}/{repo}/check-runs/1": { id: 1, name: "agent-review-correctness", conclusion: "success", output: { text: "[]" } },
+    "repos/{owner}/{repo}/check-runs/2": { id: 2, name: "agent-review-correctness", conclusion: "failure", output: { text: JSON.stringify([{ severity: "major", file: "packages/docs/src/view/text-editor.ts", summary: "Guard public mutation APIs at the read-only boundary: EditorAPI.paste() reaches TextEditor.pasteContent() unguarded and mutates a viewer-mode document.", evidence: "" }]) } },
+  };
+  const onEarly = harvestPr(548, {
+    api: fakeApi({ ...laterRound, ...crComment(CR_MAJOR_CORRECTNESS) }),
+    log: () => {}, names: NAMES,
+  });
+  assert.equal(onEarly.suppressed, 0, "a later round cannot suppress an earlier finding");
+  assert.equal(onEarly.records.filter((r) => r.source === "coderabbit").length, 1);
+
+  // The identical comment, moved onto the commit the panel raised it at.
+  const onLate = harvestPr(548, {
+    api: fakeApi({
+      ...laterRound,
+      "repos/{owner}/{repo}/pulls/548/comments?per_page=100": [
+        { id: 999, user: { login: "coderabbitai[bot]" }, path: "packages/docs/src/view/text-editor.ts", original_commit_id: SHA_FIX, html_url: "https://x/d", body: CR_MAJOR_CORRECTNESS },
+      ],
+    }),
+    log: () => {}, names: NAMES,
+  });
+  assert.equal(onLate.suppressed, 1, "at or after the round that raised it, it IS a restatement");
+  assert.equal(onLate.records.filter((r) => r.source === "coderabbit").length, 0);
 });
 
 test("harvestPr: one failed sub-request costs its own candidates, not the PR's", () => {


### PR DESCRIPTION
## The problem

`harvest.mjs` keyed *"when did the panel let go of this PR"* off the `<!-- agent-handoff -->` comment, with the `ready_for_review` timeline event as a fallback — and then read *"what had the panel concluded"* **through** that cutoff. Four problems, and the fourth is the one that cost data.

| # | Problem | Consequence |
|---|---|---|
| 1 | **No marker, no harvest.** `mark-ready.mjs` posts the marker inside a `try/catch` *after* flipping the PR ready, so a genuinely promoted PR can carry none. | Measured: **18 of 33 agent PRs** have neither a marker nor a `ready_for_review` event, having been opened ready rather than promoted. |
| 2 | **`ready_for_review` answers a different question.** It fires whether or not the panel ever spoke. | On a manually-readied PR, every later human commit became a candidate. It over-fired on the PRs it covered and covered none of the PRs it was reached for. |
| 3 | **A rebase erased it.** The cutoff was a comment timestamp compared against **committer dates**. | A force-push after promotion pushed every commit past the cutoff, emptied `beforeHandoff`, and left `headAtHandoff` undefined. |
| 4 | **Signature 2 read the panel through signature 1's cutoff.** The comparison set came from whichever commit was head at hand-off. | No hand-off ⟹ no comparison set ⟹ **every CodeRabbit candidate withheld on a PR whose check runs were readable the whole time.** And one set was applied to every finding regardless of which commit it was about. |

Signature 2 never needed a hand-off. *"CodeRabbit flagged something our panel reviewed and did not raise"* is exactly as true on a human PR reviewed via `@claude review`, where nothing was handed off at all.

## The change

The panel's own check runs are the only signal that is present whenever the panel ran, carries a server timestamp, and means "the panel approved":

|  | marker comment | `ready_for_review` | check runs |
|---|---|---|---|
| present whenever the panel ran | no (`try/catch`) | no | **yes** |
| survives a rebase / force-push | yes | yes | **yes** |
| means "the panel approved" | yes | **no** | **yes** |

`completed_at` is stamped by GitHub, so the rebase that rewrites every committer date on the PR cannot move it.

- **`panelRounds(commits, runsFor)`** — one round per commit the panel *concluded* on. Pure, with `runsFor` injected, so the ordering decision is testable without an API.
- **`panelApprovedAt(rounds, markerAt)`** replaces `handoffTime`. **`ready_for_review` is removed outright, not demoted** — keeping it as a last resort would preserve the over-fire in exactly the cases nothing else can check. Its timeline request is gone with it. The marker stays as a fallback for a PR with no readable round, because it *does* mean the panel approved; it is only unreliably present.
- **`commitIndex` + `roundsUpTo`** — the comparison set is the union of rounds **at or before** the commit a finding is about, resolved **per CodeRabbit comment**.
- **`commentRounds`** — an `@claude review` is a round too, with `conclusion: ""`. Not a missing value: it reached no gate conclusion, which is also what keeps it out of `panelApprovedAt`. It used to be a whole-PR fallback reached only when check runs were absent; as a round it gets the same per-commit treatment the gating arm does.
- **`panelRoundAt`** splits the *cheap* half of a verdict (conclusion, reviewedSha, completedAt — all in the check-runs LIST response) from the expensive half. Two phases: one list call per commit to establish the history, and the per-run `withFullOutput` refetch only for rounds a candidate is actually compared against, cached by sha. `panelVerdictAt` now calls it, so the aggregate conclusion rule ("one failing lens means the panel did not let it through") stays in one place rather than growing a second copy.

### One deliberate semantic change

Gating and advisory rounds are now **unioned** rather than ranked. The record's claim is "the panel did not raise this", and both arms run the same lens panel — so a finding either raised is a finding the panel raised. Ranking check runs above the comment made sense when there was one set per PR and the question was which *rendering of one round* to trust; across rounds it discards real findings and files them as misses. `panelSaw` still prefers the gating round, which is where "check runs are the structured record" is actually observable in the output.

## Corrected while building — real data caught it

The first implementation took the **newest** all-success round. Every human fix opens a new round, and that round approves too — so on **#548 the cutoff landed on 2026-07-28, four days after the three human fixes of 2026-07-25, and lost all three, including rows a human has already curated into `misses.jsonl`.** It is the **first** approval, matching `markerHandoffAt`'s own "FIRST marker, not the last": a later re-approval does not un-say the first one.

Also corrected: an unreadable commit now yields an `unreadable: true` round rather than nothing, which keeps the property the previous code deliberately had — *"we know which commit the panel was looking at and we could not read what it concluded"* — and makes the comparison set refuse rather than resolve to `[]`, which would file every CodeRabbit finding on the PR as a miss against a verdict nobody has seen. Timestamps are compared as parsed instants, not sorted as strings.

## Fail directions

| path | on doubt | why |
|---|---|---|
| `panelApprovedAt` | **null** | null means "cannot classify" and signature 1 goes silent. "Approved at time zero" makes every commit a candidate — the over-fire removing `ready_for_review` exists to end |
| an unreadable round | **`null` blockers**, never `[]` | `[]` claims "this round raised nothing blocking" about a round nobody has seen |
| one unreadable commit | costs its round, not the walk | a PR is not forfeited by one bad request |
| an unplaceable finding or round | **widen** the comparison set | what cannot be placed cannot be excluded. Widening can only over-suppress a finding the panel really did raise; narrowing on a guess writes a false row, and a curated false row is permanent |
| the `ROUND_WALK_LIMIT` cap | proceed, and **log** | a silently truncated history makes "never approved" indistinguishable from "we stopped looking" |

## Scope

**No schema change.** `wafflebase/miss@1`, same fields, same order. `handoffAt` keeps its name and now means "when the panel approved", which is what every consumer already assumed. **Ids are unchanged, so `dedupeById`'s first-wins rule still protects every curated `verifiedBy`** — verified on #548, which re-harvests to the same four ids.

No change to `attributeToPanel`, `bestMatch` or `clusterFindings`. No widening to `minor`/`nit` CodeRabbit findings (that needs the panel's non-blocking findings, i.e. the stage-detail collector). `--append` untouched, including both refusal paths, and not run.

## Verification

- `node --test "scripts/agent/*.test.mjs"` — **676 tests, 675 pass, 0 fail, 1 skipped**; 662/661 on `main` (`35206e585`). 14 new tests.
- `eslint scripts` — clean, under the lockfile's pinned `eslint@9.24.0`.
- **Each bug pinned by a test named after the failure**, with a before/after harness confirming the old code behaved differently on 4 of 5:

| case | before | after |
|---|---|---|
| 1 · no marker anywhere | 0 candidates, `skipped` | human-fix + coderabbit, not skipped |
| 2 · manually readied, never approved | 1 human-fix *(the over-fire)* | 0, `skipped` |
| 3 · rebase rewrote every committer date | CodeRabbit withheld | compared against the real verdict |
| 4a · finding earlier than the round that raised it | not suppressed | not suppressed *(regression guard, not a fixed bug)* |
| 4b · finding on the commit the panel raised it at | filed as a miss | suppressed |

- **Real PRs, read-only, before vs after — #548, #559, #578, #582, #591, #649, and the no-marker population #581, #590, #605, #652. Candidate sets identical on all ten.** #548's `handoffAt` moves 22 seconds (the check run at 15:48:06 rather than the marker at 15:48:28) with the same four ids. #591 and #605 change only their `skipped` reporting, correctly: the panel reviewed but never approved, and there is no CodeRabbit input.
- **API cost, measured.** #548 (9 commits) 13 → 24 calls; #582 (7 commits) 4 → 10. One check-runs LIST per commit, minus the timeline request that is now gone. Real PRs here run 1–9 commits, so `ROUND_WALK_LIMIT = 100` never binds.

## The honest limit of this change

Stated plainly because the plan predicted otherwise: **there is no measurable gain on today's data.** #581, #590 and #605 have no marker, but the panel never *approved* them either — so signature 1 has no referent under the new cutoff any more than the old one — and they carry no CodeRabbit blocking findings, so signature 2 has no input. The gains here are demonstrated **synthetically**, not measured.

What this buys is a mechanism that is correct for the next PR. The rebase case and the per-comment anchoring are latent bugs rather than observed losses, and #548 shows the change is behaviour-preserving where the corpus already has rows.

**Not built:** a third signature. `scripts/agent/eval/github-signals.mjs` derives an `is_real` vote from an author's reply to a bot finding ("Done in `<sha>`" / "not a defect because…"). It needs no cutoff at all — it reads a thread, not a timeline — and is the natural next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review findings now use panel check-run history to determine approval and comparison cutoffs.
  * Supports advisory and unreadable review rounds, commit-specific comparisons, and fallback handoff evidence.
  * Code review findings are evaluated independently from handoff status.

* **Bug Fixes**
  * Improved attribution across rebases, on-demand reviews, and multiple review rounds.
  * Corrected cutoff handling and skip reporting when review evidence is incomplete.

* **Documentation**
  * Added guidance covering panel-round derivation, fallback behavior, limitations, and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->