### PR TITLE
Record the lane the gate routed on in the stage-detail capture

### DIFF
--- a/docs/tasks/active/20260803-panel-stage-detail-capture-todo.md
+++ b/docs/tasks/active/20260803-panel-stage-detail-capture-todo.md
@@ -610,3 +610,152 @@ no new scope. The on-demand job's permissions are byte-identical before and afte
       advisory one, and would double-count one head sha as two rounds. Recoverable
       from run metadata (`event: issue_comment` versus the panel's `workflow_run`).
       Not a blocker here; it must be settled in the collector.
+
+---
+
+# Follow-up: record the lane the gate routed on
+
+Two lines. The capture records every finding that reached the verifier and what the
+verifier said, and omits the one thing the **gate** decided: which lane the finding
+was routed to. That field cannot be added later, which is the only reason this is
+worth its own change rather than waiting for a consumer to need it.
+
+## The problem
+
+`annotateFindings` attaches `lane` — `blocking`, `discarded` or `backlog` — and it
+returns copies (`{ ...f, lane }`), which is what makes it safe. The capture is handed
+the array that went *in*:
+
+```js
+const kept = keepUnrefuted(
+  annotateFindings(detected, verdicts, await noveltiesFor(detected)),  // labels land here
+);
+…
+writeStageDetail(lensOut, buildStageDetail({ fresh: detected, … }));   // this gets the unlabelled array
+```
+
+The annotated array is never named, so nothing else can reach it.
+
+Two of the three lanes survive that loss; one does not.
+
+| lane | in a capture written today | why |
+|---|---|---|
+| `discarded` | **recoverable** | `dropped` on each row is `isDroppingVerdict` over the recorded verdict — the same predicate, already stored |
+| `blocking` | **recoverable** | it is the residue: neither dropped nor demoted |
+| `backlog` | **gone** | set from `novelty.origin`, which is a `git blame -C -C -C` of the tree *as it stood during the review* |
+
+`backlog` is why this cannot wait. The blame runs against the branch under review;
+once that branch moves the answer is unobtainable, and the artifact expires at 30
+days regardless. So a capture written without the lane is indistinguishable from one
+where nothing was demoted — which is the difference between *"this finding blocked
+the PR"* and *"this finding was waved past."* That is the whole question a gate is
+scored on, and #608 opened this corpus on the grounds that nothing records it.
+
+This is the third follow-up on the same capture, and all three are the same shape: a
+producer gap found by trying to consume the output. Worth naming as the expected
+case rather than a run of bad luck.
+
+## The change
+
+```js
+const annotatedFresh = annotateFindings(detected, verdicts, await noveltiesFor(detected));
+const kept = keepUnrefuted(annotatedFresh);
+…
+fresh: annotatedFresh,   // was: fresh: detected
+```
+
+No new argument, no new field computed anywhere, no additional `git blame` — the
+novelties were already awaited on that line for the gate's own use. `annotateFindings`
+**maps**, so the array is the same length in the same order as `detected`, which is
+what lets it stand in without disturbing the `freshVerdicts` pairing.
+
+`novelty` rides along with the lane, so a later pass can read *why* a finding was
+demoted instead of trusting the label.
+
+### Why `fresh` only
+
+`prior` is deliberately left raw. Prior-round findings are annotated with `null`
+novelties on purpose — probing a stale line offset could permanently demote a
+still-open blocker — so their lane is fully derivable from the verdict already on the
+row. Annotating them would add a field carrying nothing a reader could not compute.
+
+### Why not compute the lane inside `buildStageDetail`
+
+It would be a second router, able to disagree with the first. `routeFinding` is the
+one routing rule and the gate's own; the capture records its output rather than
+re-deriving it. Same reason `dropped` is recomputed through the real
+`isDroppingVerdict` instead of being restated.
+
+### The reader contract, stated because absence is ambiguous
+
+A **missing** lane means *unknown*, never *blocking*. Every capture written before
+this has no lane at all, and a consumer defaulting absence to `blocking` would score
+demoted findings as gating ones — the exact error this change exists to prevent,
+reintroduced at the other end. Non-blocking findings are the one exception:
+`annotateFindings` returns them untouched by design, so for a minor or nit, absence
+is not missing data.
+
+## Fail directions
+
+- **The capture stays best-effort.** Unchanged: `buildStageDetail` is still pure and
+  still runs as an argument to `writeStageDetail`, whose `catch` swallows everything.
+- **Gating is untouched.** `kept` is still what flows to the merge, the cluster and
+  the verdict. The new name is read by the capture only.
+- **A misalignment would be silent, so it is pinned.** Passing `kept` — the filtered
+  array — would also carry lanes and look right, while pairing every row after the
+  first drop with another finding's verdict. There is a test whose whole job is that
+  this is not what happens.
+
+## Explicit non-goal
+
+**No behaviour change.** No lens, no verifier, no lane assignment, no gate decision,
+no check run, no permission. The routing this records already happened on every round;
+the only difference is that it is now written down.
+
+**No collector, still.** Nothing reads `stage-detail.json`. This makes the artifact
+worth reading; it does not read it.
+
+**Nothing recovered retroactively.** Captures from before this — of which there are
+zero, per the section above — would not gain the field, and the blame they would need
+is already gone.
+
+## Verification
+
+- [x] `node --test "scripts/agent/*.test.mjs"` — **666 tests, 0 fail**, against 663 on
+      `upstream/main` (`d02973a14`). Exactly +3. Both numbers are given for each SDK
+      state, because the skip count moves with it and a single figure would not
+      reproduce:
+
+      | Agent SDK | branch | `upstream/main` |
+      |---|---|---|
+      | installed | 666 tests, 665 pass, 1 skipped | 663 / 662 / 1 |
+      | absent (the `agent:tests` lane) | 666 tests, 660 pass, 6 skipped | 663 / 657 / 6 |
+
+      Measured from the committed tree (`git archive`), not the working copy.
+- [x] `eslint scripts` — clean, exit 0, on the lockfile's pinned `eslint@9.24.0`.
+- [x] **The call-site guard fails on both wrong wirings and survives a rename**, which
+      is the property a source-reading test has to earn:
+
+      | tree | result |
+      |---|---|
+      | `fresh: detected` (= today) | **fails** — "passing `detected` loses the lane forever" |
+      | `fresh: kept` (the plausible wrong fix) | **fails** |
+      | the variable renamed, wiring intact | **passes** — the name is read from the source, not hardcoded |
+
+      Read from source only because this call site is unreachable otherwise: it lives
+      inside `main`'s per-lens closure, which is not exported and needs a git repo and
+      live model sessions to enter. What `buildStageDetail` does with an annotated
+      array is tested directly.
+- [x] **The lane carries information no other field does.** In the lane test both
+      findings are `confirmed`, so `dropped` is `false` on both, and the lanes still
+      come out `["backlog", "blocking"]`.
+- [x] **Size, measured.** +198 bytes per blocking fresh finding worst case (a
+      `relocated` origin with both shas and an `alsoAt`), +94 in the ordinary
+      non-demoted case. Against a per-lens capture of 5–30 KB that is under 1%, and it
+      is orthogonal to the diff tiering above.
+- [x] **Purity holds.** The existing "derives only — it never mutates its inputs" test
+      is unchanged and still passes; `annotateFindings` copies, so the findings the
+      panel gates on are the same objects they were.
+- [ ] **The field itself, in a real artifact.** Blocked on the same thing as the
+      section above: no capture has left a runner yet. The first one to arrive should
+      show a `lane` on every blocking fresh row and none on a minor.

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -2354,9 +2354,15 @@ async function main() {
       const foldVerdicts = await Promise.all(folds.map(verifyBlocking));
       return resolveClusterVerdict(f, repVerdict, folds, foldVerdicts);
     }));
-    const kept = keepUnrefuted(
-      annotateFindings(detected, verdicts, await noveltiesFor(detected)),
-    );
+    // Named, rather than passed straight into `keepUnrefuted`, because the
+    // stage-detail capture below needs the ANNOTATED findings and cannot rebuild
+    // them: `annotateFindings` returns copies, so the `lane` it assigns exists
+    // only here. Index-aligned with `verdicts` exactly as `detected` is —
+    // `annotateFindings` maps, so it neither reorders nor filters — which is what
+    // lets the capture take this in place of `detected` without touching the
+    // verdict pairing.
+    const annotatedFresh = annotateFindings(detected, verdicts, await noveltiesFor(detected));
+    const kept = keepUnrefuted(annotatedFresh);
 
     // Part 2: re-check this lens's blocking findings from the PREVIOUS round
     // against the CURRENT diff, biased-to-keep. verifyFinding asks "is this
@@ -2445,9 +2451,22 @@ async function main() {
       lensDiff,
       scopeNote,
       samples: ok,
-      // `detected`, not `findings`: post-cluster, index-aligned with `verdicts`.
-      fresh: detected,
+      // `annotatedFresh`, not `findings`: post-cluster, index-aligned with
+      // `verdicts`, and carrying the `lane`/`novelty` the gate actually routed on.
+      //
+      // The lane is the one thing here that CANNOT be recovered later. `discarded`
+      // could be — `dropped` below is the same predicate — but `backlog` comes from
+      // `noveltyOf`, which is a `git blame` against the tree as it stood during the
+      // review. Once the branch moves there is nothing left to blame, so a capture
+      // written without it can never be told apart from one where nothing was
+      // demoted. That is the difference between "this finding gated" and "this
+      // finding was waved past", which is the whole question a gate is scored on.
+      fresh: annotatedFresh,
       freshVerdicts: verdicts,
+      // Deliberately NOT annotated. Prior-round findings are routed with `null`
+      // novelties on purpose (see the call site), so their lane is derivable from
+      // the verdict already recorded on each row — annotating here would add a
+      // field that says nothing the reader could not compute.
       prior: priorForLens,
       priorVerdicts,
       // Which prior verdicts no session produced. Without it the capture shows a
@@ -2682,10 +2701,21 @@ function lensDiffMetadata(routedDiff) {
  *   session of their own (`reused: true`). Without it the capture is indistinguishable
  *   from one where every prior finding was verified, and counting rows in it
  *   would overstate what the round actually spent.
- * - `fresh` must be the POST-cluster findings (`detected`), not the union:
- *   restatement clustering moved ahead of verification in #591/#601, so `verdicts`
- *   is index-aligned to what was clustered. Passing the union here would pair
- *   findings with other findings' verdicts.
+ * - `fresh` must be the POST-cluster findings, not the union: restatement clustering
+ *   moved ahead of verification in #591/#601, so `verdicts` is index-aligned to what
+ *   was clustered. Passing the union here would pair findings with other findings'
+ *   verdicts. Pass the ANNOTATED array (`annotatedFresh`), which is the same list in
+ *   the same order — `annotateFindings` maps — and additionally carries `lane` and
+ *   `novelty`.
+ * - `lane`/`novelty` on a fresh row are the gate's own routing decision, and the only
+ *   part of a capture that is unrecoverable in principle rather than merely absent.
+ *   `lane: "discarded"` is recomputable from `dropped`; `lane: "backlog"` is not — it
+ *   comes from a `git blame` of the tree under review, so it expires with the branch.
+ *   A reader must therefore treat a MISSING lane as "unknown", never as "blocking":
+ *   every capture written before this existed has no lane at all, and reading absence
+ *   as blocking would silently score demoted findings as gating ones.
+ *   Non-blocking findings never carry a lane by design (`annotateFindings` returns
+ *   them untouched) — for those, absence is not missing data.
  */
 export function buildStageDetail({ lensDiff, scopeNote, samples, fresh, freshVerdicts, prior, priorVerdicts, priorReuseIdx, env = process.env }) {
   const rows = (population, findings, verdicts, reuseIdx) =>

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -2832,6 +2832,90 @@ test("buildStageDetail: derives only — it never mutates its inputs", () => {
   assert.equal(JSON.stringify({ findings, verdicts }), before);
 });
 
+test("buildStageDetail: a fresh row carries the lane the gate routed on", () => {
+  // The lane is the gate's decision, and `backlog` is the one field in a capture
+  // that is unrecoverable rather than merely absent: it comes from `noveltyOf`,
+  // a blame of the tree as it stood during the review. `discarded` survives
+  // without this (it is `dropped` under another name), so a capture missing lanes
+  // cannot be told apart from one where nothing was demoted — which is exactly
+  // the difference between a finding that gated and one waved past.
+  const relocated = { severity: "major", file: "a.ts", summary: "moved, not added" };
+  const added = { severity: "major", file: "b.ts", summary: "genuinely new" };
+  const keep = { verdict: "confirmed", confidence: "high", refutationGround: "none", groundedIn: [] };
+  const novelties = [
+    { origin: "relocated", addedBy: "a".repeat(40), contentSha: null, alsoAt: "old.ts:4" },
+    { origin: "added", addedBy: "b".repeat(40), contentSha: null, alsoAt: null },
+  ];
+  const annotated = annotateFindings([relocated, added], [keep, keep], novelties);
+  const detail = buildStageDetail({
+    fresh: annotated, freshVerdicts: [keep, keep], prior: [], priorVerdicts: [],
+  });
+  const lanes = detail.verifications.map((v) => v.finding.lane);
+  assert.deepEqual(lanes, ["backlog", "blocking"]);
+  // Both were CONFIRMED, so `dropped` is false on both — the proof that the lane
+  // carries information no other recorded field does.
+  assert.deepEqual(detail.verifications.map((v) => v.dropped), [false, false]);
+  // The novelty itself rides along, so a later pass can see WHY it was demoted
+  // rather than having to trust the label.
+  assert.equal(detail.verifications[0].finding.novelty.origin, "relocated");
+  // A non-blocking finding has no lane, by design — `annotateFindings` returns it
+  // untouched. Absence there is not missing data, and a reader must not read it
+  // as `blocking`.
+  const nit = { severity: "nit", file: "c.ts", summary: "style" };
+  assert.ok(!("lane" in annotateFindings([nit], [null], [null])[0]));
+});
+
+test("buildStageDetail: the annotated array preserves verdict alignment; the kept array would not", () => {
+  // `annotateFindings` MAPS — same length, same order — which is what makes it a
+  // drop-in for `detected` at the capture call site. The obvious wrong fix is to
+  // pass `kept`, the post-`keepUnrefuted` array: it is annotated too, so lanes
+  // would appear and the capture would look correct while every row after the
+  // first drop is paired with another finding's verdict.
+  const a = { severity: "major", file: "a.ts", summary: "refuted one" };
+  const b = { severity: "major", file: "b.ts", summary: "confirmed one" };
+  const drop = { verdict: "refuted", confidence: "high", refutationGround: "not-present", groundedIn: ["a.ts:1"] };
+  const keep = { verdict: "confirmed", confidence: "high", refutationGround: "none", groundedIn: [] };
+  const verdicts = [drop, keep];
+  const annotated = annotateFindings([a, b], verdicts, [null, null]);
+  assert.equal(annotated.length, 2, "annotation must not filter");
+  const rows = buildStageDetail({ fresh: annotated, freshVerdicts: verdicts }).verifications;
+  assert.deepEqual(rows.map((v) => [v.finding.summary, v.dropped]),
+    [["refuted one", true], ["confirmed one", false]]);
+  // The misalignment the above rules out, stated as the thing it would produce:
+  // `kept` has dropped row 0, so its row 0 is `b` — which would then be paired
+  // with `drop` and recorded as a refuted finding the panel actually gated on.
+  const kept = keepUnrefuted(annotated);
+  assert.deepEqual(kept.map((f) => f.summary), ["confirmed one"]);
+  assert.equal(buildStageDetail({ fresh: kept, freshVerdicts: verdicts }).verifications[0].dropped, true,
+    "documents the bug passing `kept` would cause, so the call-site guard below has a reason");
+});
+
+test("the capture is wired to the ANNOTATED fresh findings, not the raw ones", () => {
+  // Read from the source, and only because the behaviour is genuinely out of
+  // reach: this call site lives inside `main`'s per-lens closure, which is not
+  // exported and needs a git repo plus live model sessions to enter. The tests
+  // above pin what `buildStageDetail` does with an annotated array; nothing but
+  // this can pin that the panel HANDS it one.
+  //
+  // Structural rather than a literal match, per the inertness note at the top of
+  // this file: the variable name is read out of the source instead of hardcoded,
+  // so renaming it keeps this green and reverting to the unannotated array does
+  // not.
+  const src = readFileSync(path.join(HERE, "review-panel.mjs"), "utf8");
+  const assigned = src.match(/const\s+(\w+)\s*=\s*annotateFindings\(\s*detected\s*,/);
+  assert.ok(assigned, "the fresh annotation must be assigned to a name the capture can reach");
+  const [, name] = assigned;
+  const call = src.match(/buildStageDetail\(\{[\s\S]*?\n\s*\}\)/);
+  assert.ok(call, "buildStageDetail call site not found");
+  const fresh = call[0].match(/^\s*fresh:\s*(\w+),/m);
+  assert.ok(fresh, "the call site must pass `fresh` as a plain identifier");
+  assert.equal(fresh[1], name,
+    `fresh: must be the annotated array (${name}); passing \`detected\` loses the lane forever`);
+  // And it must not be the filtered one — that is the misalignment the test above
+  // demonstrates, and it is the mistake a reader "simplifying" this would make.
+  assert.notEqual(fresh[1], "kept");
+});
+
 test("buildStageDetail: the default payload is valid JSON of the expected shape, with no diff body", () => {
   // The whole default shape in one assertion, so a field added or dropped here
   // has to be a decision rather than an accident. `lensDiff` is ABSENT — see the


### PR DESCRIPTION
The stage-detail capture records every finding that reached the verifier and what the verifier said. It omits what the **gate** decided: the lane.

`annotateFindings` returns copies — `{ ...f, lane }`, which is what makes it safe — and the capture is handed the array that went in, so the annotated one is never named and nothing can reach it.

**Two of the three lanes survive that; one doesn't.** `discarded` is recoverable (`dropped` on each row is `isDroppingVerdict` over the recorded verdict) and `blocking` is the residue. `backlog` is not: it comes from `novelty.origin`, i.e. a `git blame` of the tree *as it stood during the review*. Once the branch moves, that answer is unobtainable — and the artifact expires at 30 days anyway.

So a capture without the lane can't be told apart from one where nothing was demoted: the difference between *"this finding blocked the PR"* and *"this finding was waved past."* That's the question a gate is scored on, and #608 opened this corpus on the grounds that nothing records it. It's also why this is worth doing now rather than when a consumer asks — every other missing field could be backfilled later.

## The change

```js
const annotatedFresh = annotateFindings(detected, verdicts, await noveltiesFor(detected));
const kept = keepUnrefuted(annotatedFresh);
…
fresh: annotatedFresh,   // was: fresh: detected
```

**No behaviour change.** `kept` is still what flows to the merge, the cluster and the verdict — no lens, verifier, lane assignment, gate decision, check run or permission moves; the new name is read by the capture only.

No new argument, no field computed anywhere, no extra `git blame` — the novelties were already awaited on that line for the gate's own use. `annotateFindings` **maps**, so the array is the same length in the same order as `detected`, which is what lets it stand in without disturbing the `freshVerdicts` pairing.

`prior` stays raw on purpose: prior-round findings are routed with `null` novelties deliberately, so their lane is derivable from the verdict already on the row. And the lane isn't recomputed inside `buildStageDetail` — that would be a second router able to disagree with the gate's own.

One reader contract, documented where a consumer will look: **a missing lane means unknown, never blocking.** Every capture written before this has none, and defaulting absence to `blocking` would score demoted findings as gating ones — this bug reintroduced at the other end. Non-blocking findings are the exception; they never carry a lane by design.

## Tests

Three. Two behavioural — a fresh row carries the lane (both findings `confirmed`, so `dropped` is `false` on both while the lanes still come out `backlog`/`blocking`, which is the proof the lane carries information no other recorded field does), and the annotated array preserves verdict alignment where `kept` would not. Passing `kept` is the plausible wrong fix: it's annotated too, so lanes appear and the capture *looks* right while every row after the first drop is paired with another finding's verdict.

The third reads the source, and only because the call site is genuinely unreachable — inside `main`'s per-lens closure, unexported, needing a git repo and live model sessions. It's structural rather than a literal match (per the inertness note in that file, the variable name is read out of the source): it fails on `fresh: detected`, fails on `fresh: kept`, and stays green when the variable is renamed with the wiring intact.

## Verification

- **666 agent tests, 0 fail**, against 663 on `main` — exactly +3. With the Agent SDK installed that's 665 pass / 1 skipped vs 662 / 1; without it (the `agent:tests` lane) 660 / 6 vs 657 / 6. Measured from the committed tree.
- `eslint scripts` clean, on the lockfile's pinned `eslint@9.24.0`.
- **+198 bytes** per blocking fresh finding worst case (a `relocated` origin with both shas and an `alsoAt`), +94 ordinarily — under 1% of a 5–30 KB per-lens capture.
- Still unverified in a real artifact, because **none has left a runner yet** — the same open box #664's section records. The first capture to arrive should show a `lane` on every blocking fresh row and none on a minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
