### PR TITLE
Report the review panel's real wall-clock as Total-time

### DIFF
--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -957,6 +957,7 @@ jobs:
           path: |
             .agent-review/review-execution.json
             .agent-review/review-lens-stats.json
+            .agent-review/review-timing.json
           if-no-files-found: ignore
           retention-days: 1
 

--- a/scripts/agent/metrics.mjs
+++ b/scripts/agent/metrics.mjs
@@ -137,6 +137,29 @@ export function sumExecutions(messages, kind = "review") {
   };
 }
 
+/**
+ * The panel's TRUE wall-clock duration for one round, from review-panel.mjs's
+ * `review-timing.json` (written next to the execution log). This exists because
+ * the flat sum of `duration_ms` over the execution log is NOT wall-clock: the
+ * panel runs its lenses — and each lens's samples + verifier calls —
+ * CONCURRENTLY, so summing overcounts by the concurrency factor (a ~12-min panel
+ * was reported as 36-63). When the timing file is present and sane, its `wallMs`
+ * is the real elapsed time; absent or malformed → null, and the caller keeps the
+ * summed value (unchanged for pre-instrumentation logs). `timingPath` overrides
+ * the sibling default (for tests / explicit `--timing`).
+ */
+export function readWallMs(executionPath, timingPath) {
+  const p = timingPath
+    || (executionPath ? path.join(path.dirname(executionPath), "review-timing.json") : null);
+  if (!p) return null;
+  try {
+    const ms = Number(JSON.parse(readFileSync(p, "utf8"))?.wallMs);
+    return Number.isFinite(ms) && ms > 0 ? ms : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Per-message usage tally (raw + weighted tokens, turns, cost). */
 function messageUsage(m) {
   const u = (m && m.usage) || {};
@@ -770,6 +793,11 @@ function cmdRecord(args) {
     rec = sumExecutions(messages, kind);
     if (rec.calls === 0) return bail("no result messages in the review execution log");
     delete rec.calls;
+    // Prefer the panel's real wall-clock over the concurrency-inflated sum of
+    // per-call duration_ms (see readWallMs). Falls back to the summed value when
+    // the timing file is absent (older logs / a crash before it was written).
+    const wallMs = readWallMs(args.execution, args.timing);
+    if (wallMs != null) rec.durationMs = wallMs;
     // Per-lens / detection-vs-verifier token split from the SAME messages. Carried
     // on the record so `summarize` can aggregate it across rounds. Empty object on
     // an un-instrumented log — harmless, just yields no attribution table.

--- a/scripts/agent/metrics.test.mjs
+++ b/scripts/agent/metrics.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   parseExecution,
   sumExecutions,
+  readWallMs,
   attributionBreakdown,
   aggregateAttribution,
   aggregate,
@@ -73,6 +74,35 @@ test("sumExecutions: sums EVERY result message (not last-wins like parseExecutio
   assert.equal(empty.calls, 0);
   assert.equal(empty.turns, 0);
   assert.equal(sumExecutions("garbage").calls, 0);
+});
+
+test("readWallMs: reads wallMs from review-timing.json sibling of the execution log", async () => {
+  const { mkdtempSync, writeFileSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const path = (await import("node:path")).default;
+  const dir = mkdtempSync(path.join(tmpdir(), "wallms-"));
+  const exec = path.join(dir, "review-execution.json");
+  writeFileSync(exec, "[]");
+
+  // No timing file yet → null (caller keeps the summed duration).
+  assert.equal(readWallMs(exec), null);
+
+  // Sibling present and sane → its wallMs.
+  writeFileSync(path.join(dir, "review-timing.json"), JSON.stringify({ wallMs: 12 * 60000 }));
+  assert.equal(readWallMs(exec), 12 * 60000);
+
+  // Explicit timingPath overrides the sibling default.
+  const explicit = path.join(dir, "other.json");
+  writeFileSync(explicit, JSON.stringify({ wallMs: 5000 }));
+  assert.equal(readWallMs(exec, explicit), 5000);
+
+  // Non-positive / malformed / missing → null (fail-safe, never throws).
+  writeFileSync(path.join(dir, "review-timing.json"), JSON.stringify({ wallMs: 0 }));
+  assert.equal(readWallMs(exec), null);
+  writeFileSync(path.join(dir, "review-timing.json"), "not json");
+  assert.equal(readWallMs(exec), null);
+  assert.equal(readWallMs(path.join(dir, "nope", "review-execution.json")), null);
+  assert.equal(readWallMs(null), null);
 });
 
 test("aggregate: sums across sessions; attempt counts review-fix rounds + 1", () => {

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -2057,6 +2057,13 @@ export function loadLenses(dir) {
 }
 
 async function main() {
+  // True WALL-CLOCK start. The metrics ledger's "Total-time" must be the elapsed
+  // time of the run, NOT the sum of every SDK call's duration_ms — the lenses, and
+  // each lens's samples + verifier calls, run CONCURRENTLY, so that sum overcounts
+  // by the concurrency factor (a ~12-min panel was reported as 36-63). We stamp the
+  // orchestrator's own elapsed time into review-timing.json and metrics.mjs prefers
+  // it over the summed value.
+  const wallStart = Date.now();
   const args = parseArgs(process.argv);
   const repo = path.resolve(args.repo ?? process.cwd());
   const lensesDir = path.resolve(args["lenses-dir"] ?? path.join(HERE, "lenses"));
@@ -2580,6 +2587,13 @@ async function main() {
   // consumed by metrics.mjs which is itself fail-safe on missing/malformed input).
   writeFileSync(path.join(outDir, "review-execution.json"), JSON.stringify(sessionLog));
   writeFileSync(path.join(outDir, "review-lens-stats.json"), JSON.stringify(lensStats));
+  // True wall-clock elapsed for THIS round — metrics.mjs reads it as the sibling
+  // of review-execution.json and uses it as the round's Total-time (see the
+  // wallStart note at the top of main()).
+  writeFileSync(
+    path.join(outDir, "review-timing.json"),
+    JSON.stringify({ wallMs: Date.now() - wallStart, startedAt: wallStart, endedAt: Date.now() }),
+  );
   process.stdout.write(panel.map((p) => `${p.id}: ${p.conclusion}${p.infraError ? " (infra)" : ""}`).join("\n") + "\n");
   // If EVERY applicable blocking lens failed on an API/quota error, the panel
   // never actually ran — surface it loudly so the workflow pages honestly (and


### PR DESCRIPTION
## Summary

The agent-effort comment's **Total-time** for a review round was wildly overstated — #665 and #666 each ran ~10-15 min but were reported as **36 min and 63 min**.

**Cause:** for a `review` record, `metrics.mjs` sums `duration_ms` across *every* SDK result message in the execution log. But the panel runs its six lenses — and each lens's samples + verifier calls — **concurrently**. Summing concurrent durations overcounts by roughly the concurrency factor, so ~12 min of real elapsed time becomes ~60.

## Fix

- `review-panel.mjs` stamps its own **wall-clock elapsed** (orchestrator start→finish) into a sibling `review-timing.json`.
- `metrics.mjs` (`readWallMs`) reads that sibling and uses it as the round's `durationMs`, **falling back to the old summed value when the file is absent** — so pre-instrumentation logs are unchanged.
- The autonomous panel's artifact upload carries the new file to the separate metrics-record job; the on-demand review path reads it as a same-job sibling (no workflow change needed there).

The summed per-call durations are still a fine measure of *compute*, but Total-time should be the elapsed time a maintainer actually waited — that's what this restores.

Demonstration (8 concurrent sessions summing to 68m, real elapsed 12m):

```
BEFORE (summed concurrent durations): 68m
AFTER  (true wall-clock):             12m
```

## Test plan

- New `readWallMs` unit test: sibling present/absent, explicit-path override, non-positive/malformed/missing all fail-safe to `null`.
- `metrics.test.mjs` green (29 tests); full agent suite green (662 pass, 1 pre-existing skip).
- `review-panel.mjs` / `metrics.mjs` `node --check` clean; workflow YAML validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)