### PR TITLE
Tell every lens what the mechanical lanes cover, in one place

### DIFF
--- a/scripts/agent/lenses/blast-radius.md
+++ b/scripts/agent/lenses/blast-radius.md
@@ -37,7 +37,7 @@ If you finish without running `Grep`, you have not done this review.
 - Whether the new guard is the *right* security design, or auth specifics. That
   is the security lens. You only care that something bypasses it.
 - Missing or vacuous tests (test-adequacy), architecture and spec fit
-  (design-fit), style, import-boundary and lint (mechanical).
+  (design-fit), style, import-boundary and lint.
 
 A finding you can state without leaving the diff belongs to another lens.
 

--- a/scripts/agent/lenses/correctness.md
+++ b/scripts/agent/lenses/correctness.md
@@ -11,8 +11,7 @@ Logic and runtime correctness of the change:
 
 ## NOT your lane (defer — other lenses own these; do not report them)
 Security (its own lens), architecture/design fit or duplication, test quality,
-code style. Import-boundary and lint violations are already caught mechanically —
-don't report them.
+code style, import-boundary and lint violations.
 
 ## The diff is where the change is, not where the bug is
 For every new or modified guard, validation, or conditional in this diff, use

--- a/scripts/agent/lenses/design-fit.md
+++ b/scripts/agent/lenses/design-fit.md
@@ -17,7 +17,7 @@ the *right change*, not whether the code is line-by-line correct.
 
 ## NOT your lane (defer — do not report)
 Line-level logic bugs (correctness lens), security specifics (security lens),
-test quality (test-adequacy lens), style, import-boundary/lint (mechanical).
+test quality (test-adequacy lens), style, import-boundary/lint.
 
 ## Coverage first
 **Report EVERY issue you find, including ones you are not sure about.** Do NOT

--- a/scripts/agent/lenses/security.md
+++ b/scripts/agent/lenses/security.md
@@ -12,7 +12,7 @@ vulnerability exists until you convince yourself otherwise.
 
 ## NOT your lane (defer — do not report)
 General logic bugs (correctness lens), design/architecture fit, test quality,
-style. Import-boundary/lint issues are caught mechanically.
+style, import-boundary/lint issues.
 
 ## The diff is where the change is, not where the bug is
 A permission gate is only as strong as its weakest entry point, and the weak one

--- a/scripts/agent/review-panel.mjs
+++ b/scripts/agent/review-panel.mjs
@@ -1275,6 +1275,86 @@ export function confidenceCounts(findings) {
 const CONFIDENCE_LEVELS = new Set(FINDING.properties.confidence.enum);
 
 /**
+ * What the mechanical lanes already prove, told to every lens ONCE.
+ *
+ * Four rubrics used to assert this in four different phrasings — "already caught
+ * mechanically", "caught mechanically", "(mechanical)" ×2 — and `test-adequacy`
+ * and `docs` said nothing at all. None of them named a single mechanism, so a
+ * lens could not tell which of its candidate findings CI would catch and spent
+ * turns re-deriving what `verify:self` proves for free.
+ *
+ * EVERY CLAIM HERE WAS READ OFF THE REPO, not assumed, because the failure mode
+ * is silent: tell a lens something is covered when it is not and that whole
+ * finding class stops being reported, with nothing in the output to show for it.
+ * Five drafting errors were caught by auditing rather than by assuming, and they
+ * are why the NOT-ENFORCED half exists at all:
+ *   - `packages/frontend` has NO `tsc` anywhere. No `typecheck` script, no
+ *     checker plugin; `vite build` strips types without checking them. A bare
+ *     "tsc --noEmit runs" would have silenced type findings in the repo's
+ *     largest package (72k lines of src, vs 51k for the next).
+ *   - `backend lint` is not in `verify:fast` at all (only its `lint:arch`), and
+ *     the script carries `--fix` with no `--max-warnings 0`.
+ *   - `packages/core` HAS a vitest suite and nothing runs it. `verify:fast`
+ *     invokes `pnpm core build`, never `pnpm core test`, and the root `test`
+ *     script omits it too — in a package sheets/docs/slides/frontend all import.
+ *   - `verify-entropy`'s doc check uses a non-recursive `readdir` filtered to
+ *     `isFile()`, so it covers the 22 top-level `docs/design/*.md` and none of
+ *     the 81 nested ones. `docs/design/**.md` would have been a lie.
+ *   - `pnpm audit` fails on CRITICAL only (`harness.config.json`
+ *     `failOnCritical`). There are high-severity advisories outstanding today
+ *     that CI prints and ignores.
+ *
+ * MECHANISMS, NEVER CATEGORIES. "a type error `tsc --noEmit` would report in
+ * packages/sheets", never "type problems" — the latter also silences `as any`,
+ * non-null assertions and type-level lies that `tsc` accepts. The scoping to
+ * named packages is load-bearing for the same reason.
+ *
+ * The tense is "runs ... and must pass", not "has already passed": since #651 the
+ * panel runs CONCURRENTLY with CI, so nothing here is proven yet at the moment a
+ * lens reads it. The true claim is that the lens is not the last line of defence,
+ * which holds either way.
+ *
+ * The NOT-enforced half is not a disclaimer — it is the more useful half. It
+ * redirects the turns this note saves toward the gaps nothing else covers, which
+ * is why this change should not read as a pure recall risk.
+ */
+export const MECHANICAL_COVERAGE_NOTE = [
+  "## What the mechanical lanes cover on this branch",
+  "",
+  "These run on this PR and must pass before it can be promoted. A finding whose",
+  "whole content is \"this would fail CI\" costs a review round and tells the author",
+  "nothing they were not about to be told anyway.",
+  "",
+  "ENFORCED — you may rely on these:",
+  "- `tsc --noEmit` in packages/sheets, slides, docs, notes, board and cli. `tsc`",
+  "  also runs inside the core and backend builds.",
+  "- `eslint . --max-warnings 0` in packages/frontend, `eslint scripts`, and the two",
+  "  architecture configs (frontend + backend `lint:arch`) — those are what enforce",
+  "  import boundaries.",
+  "- The suites RUN and must be green: vitest in frontend, sheets, slides, docs,",
+  "  notes, board and cli; jest in backend; node:test in scripts/agent; plus the",
+  "  browser visual + interaction lane and the Postgres/Yorkie integration lane.",
+  "- knip: unused files, unused exports, unused exported types.",
+  "- Frontend bundle budgets: per-chunk KB and total chunk count.",
+  "- Every backticked path inside a TOP-LEVEL docs/design/*.md must resolve on disk.",
+  "- `pnpm audit`: fails the lane on a CRITICAL advisory, and on nothing below it.",
+  "",
+  "NOT ENFORCED BY ANYTHING — a real finding here is worth MORE than one the lanes",
+  "above would have caught, because nothing else in the pipeline will catch it:",
+  "- Type errors in packages/frontend. It has no `tsc` at all — `vite build` strips",
+  "  types without checking them — and it is the largest package in the repo.",
+  "- eslint over packages/backend/src. Only its architecture config runs here.",
+  "- packages/core's own vitest suite. It has one; no lane invokes it. Only `tsc`",
+  "  via its build runs — and sheets, docs, slides and frontend all import it.",
+  "- Broken refs in NESTED design docs. The check does not recurse, so the 81 files",
+  "  under docs/design/<topic>/ are unchecked; only the 22 top-level ones are.",
+  "- `pnpm audit` findings below critical; high/moderate/low are printed and ignored.",
+  "- Formatting. Prettier is write-only in this repo and no lane checks it.",
+  "- Whether a passing test asserts anything. The lanes prove the suite is GREEN,",
+  "  never that it is ADEQUATE — a test that asserts nothing passes just as loudly.",
+].join("\n");
+
+/**
  * The LAST thing a lens reads, appended by `runLens` after the rubric and the
  * diff — so it wins ties against everything above it.
  *
@@ -1556,6 +1636,18 @@ export function buildLensPrompt(lens, { rubric, extraDiff = "", issue = "" }) {
   if (lens.needsIssueSpec && issue) {
     parts.push("", "## The originating issue this PR claims to satisfy (DATA):", "```", issue, "```");
   }
+  // Two SEPARATE pushes, not one combined call. The guard in review-panel.test.mjs
+  // matches `/parts\.push\(\s*""\s*,\s*LENS_CLOSING_INSTRUCTION\s*\)/` to hold the
+  // closing instruction last; folding these into one push would silently break it
+  // while still rendering correctly, which is the worst of both.
+  //
+  // Deliberately in the UNCACHED user prompt rather than the shared system prefix,
+  // even though the text is lens-invariant and `lensCacheKey` would cache it. The
+  // saving is ~1.7k tokens a round — about $0.008 — against this plan's own
+  // finding that cost is TURNS, not tokens; and the prefix sits before the whole
+  // diff, where a note about what not to report carries much less weight than it
+  // does here, one line above the closing instruction.
+  parts.push("", MECHANICAL_COVERAGE_NOTE);
   parts.push("", LENS_CLOSING_INSTRUCTION);
   return parts.join("\n");
 }

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -23,6 +23,7 @@ import {
   severityCounts,
   confidenceCounts,
   LENS_CLOSING_INSTRUCTION,
+  MECHANICAL_COVERAGE_NOTE,
   verifierTally,
   verifierFailureCounts,
   recordVerifierFailure,
@@ -211,12 +212,14 @@ test("incremental review is inert without a scope note: identical rendered prefi
 // The TASK half. Its shape matters for one reason beyond tidiness: the closing
 // instruction has to stay LAST, with nothing after it (see the source guard far
 // below, and the injection-framing test that follows).
-test("the lens user prompt is identity + rubric + closing, and carries no shared diff", () => {
+test("the lens user prompt is identity + rubric + coverage note + closing, and carries no shared diff", () => {
   const p = buildLensPrompt(LENS, { rubric: PROMPT_IN.rubric });
   assert.equal(p, [
     "You are the Correctness reviewer. Stay strictly in your lane; defer other lenses' concerns.",
     "",
     "# rubric",
+    "",
+    MECHANICAL_COVERAGE_NOTE,
     "",
     LENS_CLOSING_INSTRUCTION,
   ].join("\n"));
@@ -1704,6 +1707,114 @@ test("the runLens closing instruction is coverage-first too", () => {
   const src = readFileSync(path.join(HERE, "review-panel.mjs"), "utf8");
   assert.match(src, /parts\.push\(\s*""\s*,\s*LENS_CLOSING_INSTRUCTION\s*\)/,
     "runLens must append LENS_CLOSING_INSTRUCTION, or this guard covers nothing");
+});
+
+// --- what the mechanical lanes cover, told once instead of four ways ---------
+
+test("every lens is told what the mechanical lanes cover", () => {
+  // RENDERED for each manifest lens, not grepped from source: an exported
+  // constant nothing appends is a guard over dead text, and the note is only
+  // worth anything if it reaches the lenses that used to say nothing at all
+  // (test-adequacy, docs) as well as the four that said it four ways.
+  const ids = LENSES.map((l) => l.id);
+  assert.ok(ids.length >= 5, "manifest lost lenses — this guard would cover almost nothing");
+  for (const l of LENSES) {
+    const p = buildLensPrompt(l, { rubric: "# r" });
+    assert.ok(p.includes(MECHANICAL_COVERAGE_NOTE), `${l.id} must be told what CI covers`);
+    // Order is the security invariant: the note must not push the closing
+    // instruction off the end, and untrusted hunks must still precede both.
+    assert.ok(p.endsWith(LENS_CLOSING_INSTRUCTION), `${l.id}: closing instruction must stay LAST`);
+    assert.ok(p.indexOf(MECHANICAL_COVERAGE_NOTE) < p.indexOf(LENS_CLOSING_INSTRUCTION));
+  }
+  // Same anti-clamp rules as the rubrics and the closing instruction. A note that
+  // says "don't report X" is exactly the shape a clamp hides in.
+  assertNoClamp(MECHANICAL_COVERAGE_NOTE, "MECHANICAL_COVERAGE_NOTE");
+});
+
+test("the coverage note claims only mechanisms this repo actually runs", () => {
+  // The failure mode is SILENT: tell a lens something is covered when it is not
+  // and that finding class stops being reported, with nothing in the output to
+  // show for it. Each assertion below pins a fact read off the repo, so a change
+  // to the real lane breaks this test instead of quietly making the note a lie.
+  const N = MECHANICAL_COVERAGE_NOTE;
+
+  // NO FORMATTING CLAIM. Prettier is write-only here — nothing checks it — so
+  // "formatting is covered" would skip a class nothing else covers. It may only
+  // appear in the NOT-enforced half.
+  const enforced = N.slice(N.indexOf("ENFORCED"), N.indexOf("NOT ENFORCED"));
+  assert.ok(!/format|prettier/i.test(enforced), "no lane checks formatting — never claim one does");
+  assert.match(N, /Prettier is write-only/, "the gap must be stated, not merely omitted");
+
+  // packages/frontend has NO tsc: no `typecheck` script, no checker plugin, and
+  // `vite build` strips types. Claiming type coverage without scoping it would
+  // silence type findings in the largest package in the repo.
+  assert.match(N, /packages\/frontend\. It has no `tsc` at all/);
+  const tscLine = N.split("\n").find((l) => l.includes("`tsc --noEmit` in"));
+  assert.ok(!/frontend/.test(tscLine), `the tsc claim must not cover frontend: ${tscLine}`);
+  for (const pkg of ["sheets", "slides", "docs", "notes", "board", "cli"]) {
+    assert.ok(tscLine.includes(pkg), `verify:fast typechecks ${pkg} — the note must say so`);
+  }
+
+  // packages/core has a vitest suite and NOTHING runs it: `verify:fast` invokes
+  // `pnpm core build`, never `pnpm core test`, and the root `test` script omits it
+  // too. Listing core among the suites that run was the draft's second silent
+  // over-claim, in a package sheets/docs/slides/frontend all depend on.
+  const suitesLine = N.split("\n").find((l) => l.includes("The suites RUN"));
+  assert.ok(!/core/.test(suitesLine), `no lane runs core's suite: ${suitesLine}`);
+  assert.match(N, /packages\/core's own vitest suite\. It has one; no lane invokes it/);
+
+  // verify-entropy's doc check uses a NON-recursive readdir filtered to isFile(),
+  // so it sees the 22 top-level docs/design/*.md and none of the 81 nested ones.
+  // A `docs/design/**.md` claim — the draft's third over-claim — would have told
+  // every lens that broken refs in subsystem docs are somebody else's problem.
+  assert.match(N, /TOP-LEVEL docs\/design\/\*\.md/);
+  assert.ok(!/docs\/design\/\*\*/.test(N), "the doc check does not recurse — do not imply it does");
+  assert.match(N, /does not recurse/);
+
+  // `pnpm audit` fails on CRITICAL only (harness.config.json failOnCritical), and
+  // there are high-severity advisories outstanding that CI prints and ignores.
+  assert.match(N, /`pnpm audit`: fails the lane on a CRITICAL advisory/);
+  assert.match(N, /below critical; high\/moderate\/low are printed and ignored/);
+  // The first draft of that bullet read "CRITICAL severity only" and `assertNoClamp`
+  // rejected it on /severity ONLY/i. The guard was blunt but not wrong — a note
+  // saying "don't report X" is exactly where a clamp hides — so the WORDING moved
+  // rather than the rule. Kept as a note to whoever edits this line next.
+
+  // MECHANISMS, NEVER CATEGORIES. "type problems" also covers `as any`, non-null
+  // assertions and type-level lies tsc accepts; "lint issues" covers the backend,
+  // which is not linted here at all. Named tools and named packages only.
+  for (const category of [/\btype problems\b/i, /\btype issues\b/i, /\blint issues are\b/i, /\bstyle problems\b/i]) {
+    assert.ok(!category.test(N), `the note must name a mechanism, not a category: ${category}`);
+  }
+
+  // The tense claim. Since #651 the panel runs CONCURRENTLY with CI, so nothing
+  // here is proven at the moment a lens reads it — only that the lens is not the
+  // last line of defence. "already caught" would be false for the current round.
+  assert.ok(!/already (?:caught|checked|passed|proven)/i.test(N),
+    "the panel runs alongside CI now — the note may not claim these have already passed");
+  assert.match(N, /must pass before it can be promoted/);
+});
+
+test("no rubric asserts mechanical coverage on its own any more", () => {
+  // Four rubrics said this in four different phrasings and none named a
+  // mechanism; two said nothing. One trusted constant replaces all of it, so a
+  // rubric re-adding its own version is a divergence, not a redundancy.
+  for (const l of LENSES) {
+    const md = readFileSync(path.join(HERE, "lenses", `${l.id}.md`), "utf8");
+    assert.ok(!/mechanical/i.test(md), `${l.id}.md must defer to MECHANICAL_COVERAGE_NOTE`);
+  }
+  // The lane deferrals themselves must SURVIVE: dropping "don't report lint" from
+  // a rubric along with its stale justification would re-open the very class this
+  // change is meant to keep closed.
+  for (const [id, pattern] of [
+    ["correctness", /import-boundary and lint violations/i],
+    ["security", /import-boundary\/lint issues/i],
+    ["design-fit", /import-boundary\/lint/i],
+    ["blast-radius", /import-boundary and lint/i],
+  ]) {
+    const md = readFileSync(path.join(HERE, "lenses", `${id}.md`), "utf8");
+    assert.match(md, pattern, `${id}.md must still defer lint to another owner`);
+  }
 });
 
 test("verifierTally: only blocking findings are sent; refuted vs high-confidence vs dropped", () => {


### PR DESCRIPTION
## Summary

Replaces four divergent "already caught mechanically" clauses with one exported
`MECHANICAL_COVERAGE_NOTE` that names the actual mechanisms — and, just as
deliberately, names the gaps.

## Why

Four rubrics asserted this in four different phrasings — *"already caught
mechanically"*, *"caught mechanically"*, *"(mechanical)"* twice — and
`test-adequacy` and `docs` said nothing at all. **None named a single
mechanism**, so a lens could not tell which of its candidate findings CI would
catch and spent turns re-deriving what `verify:self` proves for free.

The four clauses lose their stale justification but **keep their lane
deferrals** — a rubric that stopped saying "don't report lint" would re-open the
class this is meant to keep closed. A test pins both halves.

## Every claim was read off the repo, and that caught five errors

The failure mode here is **silent**: tell a lens something is covered when it is
not, and that finding class stops being reported with nothing in the output to
show for it. So I audited rather than assumed. Five drafting errors fell out, and
they are why the note has a NOT-ENFORCED half at all:

| # | I was about to claim | What's actually true |
|---|---|---|
| 1 | `tsc --noEmit` covers types | **`packages/frontend` has no `tsc` anywhere** — no `typecheck` script, no checker plugin, and `vite build` strips types. That's the largest package in the repo: **72k lines of src** vs 51k for the next |
| 2 | "eslint runs" | `backend lint` is **not in `verify:fast` at all** (only its `lint:arch`), and the script carries `--fix` with no `--max-warnings 0` |
| 3 | vitest runs in core | **`packages/core` has a suite and nothing runs it.** `verify:fast` invokes `core build`, never `core test`; the root `test` script omits it too — in a package sheets/docs/slides/frontend all import |
| 4 | `docs/design/**.md` refs are checked | The check uses a **non-recursive** `readdir` filtered to `isFile()`: 22 top-level files covered, **81 nested ones not** |
| 5 | `pnpm audit` covers vulnerabilities | **CRITICAL only** (`harness.config.json` `failOnCritical`). High-severity advisories are outstanding today; CI prints and ignores them |

Each is now pinned by a test that reads the note, so a change to the real lane
breaks the build instead of quietly turning the note into a lie.

## Mechanisms, never categories

*"a type error `tsc --noEmit` would report in packages/sheets"*, never *"type
problems"* — the latter also silences `as any`, non-null assertions and
type-level lies that `tsc` accepts. The per-package scoping is load-bearing for
the same reason. A test rejects the category phrasings outright.

## Tense

**"must pass before it can be promoted"**, not "already passed". Since #651 the
panel runs *concurrently* with CI, so nothing here is proven at the moment a lens
reads it. The true claim — the lens is not the last line of defence — holds
either way, and a test rejects `already caught`.

## The NOT-ENFORCED half is the more useful half

It isn't a disclaimer. It redirects the turns this saves toward the gaps nothing
else covers, so this should not read as a pure recall risk:

```
NOT ENFORCED BY ANYTHING — a real finding here is worth MORE than one the lanes
above would have caught, because nothing else in the pipeline will catch it:
- Type errors in packages/frontend. It has no `tsc` at all — `vite build` strips
  types without checking them — and it is the largest package in the repo.
- eslint over packages/backend/src. Only its architecture config runs here.
- packages/core's own vitest suite. It has one; no lane invokes it. ...
- Broken refs in NESTED design docs. The check does not recurse ...
- `pnpm audit` findings below critical; high/moderate/low are printed and ignored.
- Formatting. Prettier is write-only in this repo and no lane checks it.
- Whether a passing test asserts anything. The lanes prove the suite is GREEN,
  never that it is ADEQUATE — a test that asserts nothing passes just as loudly.
```

That last bullet is the `test-adequacy` carve-out. A bare "CI runs the tests"
would have gutted that lens; this narrows it in the right direction instead.

## Linked Issues

None — this came out of the review-panel cost work.

## Author checklist

- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] I read every line of this diff and can explain why each change is necessary.
- [x] Changes follow the conventions in the touched packages; any deviations are explained above.
- [x] If AI tools assisted with this PR, I noted where in *Notes for Reviewers* below.

## Verification

- [ ] verify:self — CI comment shows ✅
- [ ] verify:integration — CI comment shows ✅ (or explicit skip reason below)

`cd scripts/agent && node --test *.test.mjs` → **677 pass, 0 fail** (6 skips, all
pre-existing on `main` — confirmed by stashing and re-running). 680 → 683 tests.

## Risk Assessment

- **User-facing risk:** none. Review-prompt content.
- **Data/security risk:** none. The note is a trusted constant in our own source;
  no new untrusted input reaches a prompt. It lands **before**
  `LENS_CLOSING_INSTRUCTION`, which a test asserts is still last, so the
  injection framing is unmoved.
- **Rollback plan:** revert the single commit. The note is one constant and one
  `parts.push`.

**Recall is the real risk in this PR**, and it is the reason for the audit above:
an over-broad claim silences a finding class invisibly. Mitigations are
structural — per-package scoping, mechanism-level wording, `assertNoClamp`
applied to the note as it is to the rubrics, and a test per claim. Watch
`Findings raised` over the next few PRs; a fall while `Rounds` stays flat is the
signal to revert.

## Notes for Reviewers

**AI assistance:** this PR was written with Claude Code — the audit, the note,
and the tests.

Three things worth a look:

1. **Deliberately in the uncached user prompt**, not the cached system prefix,
   even though the text is lens-invariant and `lensCacheKey` would cache it. The
   prefix saves ~1.7k tokens a round (**~$0.008**) against this series' own
   finding that cost is *turns*, not tokens — and it sits before the whole diff,
   where a note about what not to report carries far less weight than it does one
   line above the closing instruction. The comment says so at the call site.

2. **`assertNoClamp` rejected my own first draft.** The bullet read *"CRITICAL
   severity only"* and matched `/severity ONLY/i`. The guard was blunt but not
   wrong — a note that says "don't report X" is exactly where a certainty clamp
   hides — so I moved the **wording**, not the rule, and left a comment on the
   test line saying so.

3. **Findings 3 and 4 above are arguably bugs in the harness**, not just notes:
   `packages/core` ships untested and 81 design docs go unchecked. I have
   deliberately *not* fixed either here — this PR should not quietly change what
   CI enforces while claiming to describe it. Both are worth their own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared guidance to review prompts describing which checks are enforced automatically and which require reviewer attention.
  * Review guidance now consistently directs reviewers toward issues not covered by automated checks.

* **Improvements**
  * Clarified exclusions for style, lint, and import-boundary issues across review lenses.
  * Reduced duplicated or overly certain statements about automated coverage.

* **Tests**
  * Added coverage to verify the guidance appears consistently across all review lenses and accurately reflects CI capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->