### PR TITLE
Make the stage-detail capture say which PR it is of

### DIFF
--- a/.github/workflows/agent-review-on-demand.yml
+++ b/.github/workflows/agent-review-on-demand.yml
@@ -349,10 +349,47 @@ jobs:
           --lenses-dir .trusted/scripts/agent/lenses
           --out .agent-review
 
+      # The twin of the gating panel's step — see agent-review-panel.yml for why
+      # the artifact could not say which PR it came from and why the payload is
+      # built in a tested script rather than in YAML. Both producers upload the
+      # same capture, so `channel` is the ONLY field that can tell an advisory
+      # round from a gating one; without it a single head sha reviewed twice
+      # reads as two gating rounds.
+      #
+      # Differs from the twin in exactly four places: `--channel advisory`,
+      # `--workflow agent-review-on-demand.yml`, where the PR and head sha come
+      # from, and no `steps.pr` guard — an `issue_comment` event always carries
+      # `needs.authorize.outputs.pr`, which is the same reason the upload below
+      # has none.
+      - name: Describe the capture (attribution for the artifact below)
+        if: always()
+        continue-on-error: true
+        env:
+          PR: ${{ needs.authorize.outputs.pr }}
+          # The SHA `authorize` pinned and this job checked out — not the floating
+          # PR head, which a push landing mid-run would have moved.
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          BASE_SHA: ${{ steps.diff.outputs.base }}
+        run: |
+          # `.trusted` is this job's `main` checkout — the reviewer's own version.
+          PANEL_SHA=$(git -C .trusted rev-parse HEAD 2>/dev/null || true)
+          node .trusted/scripts/agent/capture-meta.mjs \
+            --out .agent-review/meta.json \
+            --pr "$PR" \
+            --head-sha "$HEAD_SHA" \
+            --base-sha "$BASE_SHA" \
+            --channel advisory \
+            --workflow agent-review-on-demand.yml \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --event "$GITHUB_EVENT_NAME" \
+            --panel-sha "$PANEL_SHA"
+
       # The SAME capture the gating panel uploads (#641), from the same writer, at
-      # the same name, path and retention. Deliberately not a second format: the
-      # panel already wrote these files on every on-demand round and the runner
-      # then deleted them, so this is a route out, not new data.
+      # the same path and retention, and now with the same `meta.json` beside it.
+      # Deliberately not a second format: the panel already wrote these files on
+      # every on-demand round and the runner then deleted them, so this is a route
+      # out, not new data.
       #
       # #641 listed this under "Not built", on the grounds that "advisory
       # `@claude review` invocations are not the population a tuning corpus should
@@ -384,18 +421,27 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
-          name: review-panel-stage-detail
-          path: .agent-review/*/stage-detail.json
+          # PR number in the name — a convenience for humans and for selective
+          # fetching. `meta.json` is the source of truth. See the twin step.
+          name: review-panel-stage-detail-pr-${{ needs.authorize.outputs.pr }}
+          path: |
+            .agent-review/*/stage-detail.json
+            .agent-review/meta.json
           # REQUIRED — see the twin step in agent-review-panel.yml for the
           # mechanism. Without it the glob's search root is the dot-directory
           # `.agent-review`, which @actions/glob skips before reading it, and this
-          # step silently uploads nothing.
+          # step silently uploads nothing. The literal `meta.json` above does not
+          # escape that: its search path is a descendant of the glob's and is
+          # dropped from `getSearchPaths()`.
           include-hidden-files: true
           # Absent whenever capture is disabled, or every lens skipped, or the panel
           # crashed before writing — none of which is an error here. This is also
           # why the flag above cannot be inferred from a green run.
           if-no-files-found: ignore
-          retention-days: 30
+          # 90, the maximum for a public repo. Kept in step with the gating twin:
+          # a collector reading both producers must not find one channel's
+          # captures expiring 60 days before the other's.
+          retention-days: 90
 
       # Post the comment with a GitHub App token, NOT the default GITHUB_TOKEN.
       # This workflow runs on ANY PR incl. forks, and for a run triggered by an

--- a/.github/workflows/agent-review-panel.yml
+++ b/.github/workflows/agent-review-panel.yml
@@ -961,6 +961,73 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
 
+      # WHICH PR THIS CAPTURE IS OF — the one thing the artifact never said.
+      #
+      # This workflow is triggered by `workflow_run`, which makes GitHub execute
+      # the DEFAULT BRANCH's copy, so the run's own metadata reads
+      # `head_branch: main` and `pull_requests: []`. Measured on all three real
+      # captures (#665, #666, #669): every one of them. That is a deliberate
+      # security property — the reviewer must never execute the branch's code —
+      # and it is not going to change, so a consumer cannot recover the PR from
+      # run metadata. This job knows it (`steps.pr.outputs.number`); it just
+      # never wrote it down. `agent-review-on-demand.yml` carries the twin step,
+      # differing only in `--channel` and `--workflow`.
+      #
+      # Written into `.agent-review/meta.json`, at the ROOT of the same directory
+      # the per-lens files live in, so the artifact comes out as `meta.json`
+      # beside `<lens>/stage-detail.json`.
+      #
+      # In the SCRIPT, not in YAML, and this subsystem has paid for that lesson
+      # twice: #641 ("a default in the workflow puts the inverted logic in the one
+      # place no test can reach it") and #664, which existed because a YAML-level
+      # mistake was untestable and stayed silent for five rounds. The step passes
+      # values it already holds; every validation is in `capture-meta.mjs` and
+      # unit-tested.
+      #
+      # `continue-on-error` because a capture problem must never fail a review.
+      # The script still exits 1 and prints an `::error::` ANNOTATION rather than
+      # a log line, because a capture it could not attribute is one a collector
+      # will discard — and a silent pass is exactly how the "No files were found"
+      # bug survived five rounds. It writes NOTHING on doubt: there is no partial
+      # meta.json, so a collector's question is "is the file there?" and never
+      # "can I trust this field?".
+      - name: Describe the capture (attribution for the artifact below)
+        if: always() && steps.pr.outputs.number != ''
+        continue-on-error: true
+        env:
+          PR: ${{ steps.pr.outputs.number }}
+          # The SHA the check runs are attested against and the panel reviewed —
+          # the same value the "Run review panel" step passes as --head-sha.
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # Same merge-base the panel routed novelty against. Empty is legitimate
+          # (the diff step did not run) and the script records `baseSha: null`
+          # rather than refusing — unknown is a fact, a malformed sha is not.
+          BASE_SHA: ${{ steps.diff.outputs.base }}
+        run: |
+          # The reviewer's OWN version: `.trusted` is the `main` checkout this
+          # panel ran from, so its HEAD is the commit that made these decisions.
+          # Reviews from different panel versions are not comparable and nothing
+          # else records which one ran. `|| true` so an unexpectedly missing
+          # `.trusted` reaches the script's named refusal instead of dying here
+          # under `set -e` with no field name in the log.
+          #
+          # NOT a config hash: an audit of the existing config-hash logic found it
+          # omits fields that change behaviour, so two judges that decide
+          # differently hash identically. A commit sha is always available and
+          # always correct, and a config identity can be derived from it later.
+          PANEL_SHA=$(git -C .trusted rev-parse HEAD 2>/dev/null || true)
+          node .trusted/scripts/agent/capture-meta.mjs \
+            --out .agent-review/meta.json \
+            --pr "$PR" \
+            --head-sha "$HEAD_SHA" \
+            --base-sha "$BASE_SHA" \
+            --channel gating \
+            --workflow agent-review-panel.yml \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --event "$GITHUB_EVENT_NAME" \
+            --panel-sha "$PANEL_SHA"
+
       # What each lens actually did this round: per-sample findings before the
       # union, and the verifier's verdict on every blocking finding. Nothing else
       # keeps this. The check runs persist only what GATES (`output.text` is
@@ -997,8 +1064,23 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
-          name: review-panel-stage-detail
-          path: .agent-review/*/stage-detail.json
+          # The PR number in the NAME is a convenience — for a human reading the
+          # artifact list, and for a collector fetching selectively instead of
+          # downloading everything. `meta.json` remains the source of truth;
+          # nothing may parse attribution back out of this string. Safe to rename:
+          # nothing downloads this artifact today (the only other references in
+          # the repo are the two upload steps and this subsystem's task doc).
+          name: review-panel-stage-detail-pr-${{ steps.pr.outputs.number }}
+          # Two entries, and the second one is why the artifact is self-describing.
+          # `getSearchPaths()` drops a search path that is a DESCENDANT of another,
+          # so the literal `meta.json` collapses into the glob's `.agent-review`
+          # root rather than triggering upload-artifact's least-common-ancestor
+          # path — the layout is unchanged for the lens files and `meta.json`
+          # lands at the artifact root. Verified against @actions/glob 0.5.0 with
+          # upload-artifact's own options.
+          path: |
+            .agent-review/*/stage-detail.json
+            .agent-review/meta.json
           # REQUIRED, and not for the files themselves — for the DIRECTORY.
           # upload-artifact resolves a glob with @actions/glob, whose search root
           # is the pattern's non-wildcard prefix: `.agent-review`. With hidden
@@ -1014,14 +1096,30 @@ jobs:
           # `.harness-reports/` upload already carries this flag for the same
           # reason; #641 shipped without it and produced no artifact on any of the
           # five real panel runs that followed.
+          #
+          # The literal `.agent-review/meta.json` above is NOT immune the way the
+          # execution log's literal paths are, and that is measured rather than
+          # assumed: its search path is a descendant of the glob's, so it is
+          # dropped from `getSearchPaths()` and only the hidden `.agent-review`
+          # root is walked. Without this flag the whole step still uploads zero
+          # files, meta.json included.
           include-hidden-files: true
           # Absent whenever capture is disabled, or a lens was skipped, or the
           # orchestrator crashed before writing — none of which is an error here.
           # It CANNOT stand in for the line above: a silent zero-file upload and a
           # legitimately empty one look identical from here, which is why this was
-          # invisible for five rounds.
+          # invisible for five rounds. Still reachable after the meta step: that
+          # step writes NO meta.json when no lens captured, precisely so an empty
+          # round stays an empty artifact rather than one holding attribution for
+          # nothing.
           if-no-files-found: ignore
-          retention-days: 30
+          # 90, the maximum for a public repo, raised from 30 by the same PR that
+          # added meta.json. The collector that moves these into permanent storage
+          # does not exist yet, so retention is the only thing standing between a
+          # capture and deletion — and this triples the deadline on data already
+          # sitting in Actions. Not the `retention-days: 1` steps above: those are
+          # an intra-run hand-off to promote/fix and 1 day is chosen to match.
+          retention-days: 90
 
   promote:
     # `ci` as well as `review-panel`, and this one is a CORRECTNESS requirement

--- a/docs/tasks/active/20260803-panel-stage-detail-capture-todo.md
+++ b/docs/tasks/active/20260803-panel-stage-detail-capture-todo.md
@@ -759,3 +759,236 @@ is already gone.
 - [ ] **The field itself, in a real artifact.** Blocked on the same thing as the
       section above: no capture has left a runner yet. The first one to arrive should
       show a `lane` on every blocking fresh row and none on a minor.
+
+---
+
+# Follow-up: make the capture say which PR it is of
+
+The artifact has been leaving the runner since #664 and **nothing inside it says
+what it is a capture of.** One new file, `meta.json`, at the root of the same
+artifact; retention 30 → 90 in both producers.
+
+## The problem
+
+The section above closes on an unchecked box that predicted this:
+
+> **Two producers, one artifact name — a collector requirement, recorded now.**
+> `stage-detail.json` carries no field naming the workflow that wrote it … a
+> collector … would double-count one head sha as two rounds. Recoverable from run
+> metadata (`event: issue_comment` versus the panel's `workflow_run`).
+
+**The recovery it offers does not exist.** Both workflows are triggered by events
+— `workflow_run` and `issue_comment` — that make GitHub execute the DEFAULT
+BRANCH's copy of the workflow. From GitHub's point of view the run belongs to
+`main`, not to the branch under review. Measured on all three real captures to
+date (#665, #666, #669), every one of them reports:
+
+```
+head_branch = "main"        pull_requests = []
+```
+
+So the run metadata names neither the PR nor the branch, and the two producers
+upload under the **same artifact name** with nothing in the payload to separate
+them. A consumer has three unanswerable questions — which PR, which channel,
+which reviewer version — and the third is the one nobody was going to notice:
+reviews from different panel versions are not comparable, and no channel records
+which version ran.
+
+This is not a gap in GitHub. It is a deliberate security property — the reviewer
+must never execute code from the branch it is reviewing — and it is not going to
+change. The producing job holds every answer; it simply never wrote them down.
+
+Attribution also cannot be guessed later. A capture filed against the wrong PR is
+worse than a missing one: absence is visible, and a wrong row corrupts the corpus
+in a way no downstream check would catch. So the fix belongs in the producer, and
+it only fixes captures written **after** it lands — the same one-way property the
+lane field had, which is the whole reason this is small and goes first.
+
+## The change
+
+- [x] `scripts/agent/capture-meta.mjs`. `buildCaptureMeta({...})` is **pure** —
+      no clock, no filesystem, no environment; `capturedAt` and `lenses` are
+      injected. `capturedLenses(outDir)` is the one side effect. A thin CLI joins
+      them and writes the file.
+- [x] **In a script, not in YAML**, and this subsystem is the argument: #641
+      recorded that "a YAML default puts the inverted logic where no test can
+      reach it", and #664 existed because a YAML-level mistake was untestable and
+      stayed silent for five rounds. The workflow contributes only values it
+      already holds.
+- [x] The payload: `schema`, `pr`, `headSha`, `baseSha`, `channel`, `workflow`,
+      `runId`, `runAttempt`, `event`, `panelSha`, `lenses`, `capturedAt`. Two
+      fields carry most of the value. **`channel`** is the only thing that can
+      tell a gating round from an advisory one; without it a single commit
+      reviewed twice reads as two gating rounds. **`panelSha`** is the reviewer's
+      own version, from `git -C .trusted rev-parse HEAD`.
+- [x] **No `config_hash`, deliberately.** A separate audit of the existing
+      config-hash logic found it omits fields that change behaviour, so two judges
+      that decide differently hash identically. A wrong fingerprint is worse than
+      none — it merges two populations silently. A raw commit sha is always
+      available and always correct, and a config identity can be derived from it
+      later. There is a test whose only job is that nobody adds it back as an
+      obvious improvement.
+- [x] A `Describe the capture` step in **both** workflows, after the panel and
+      before the upload, `continue-on-error: true`.
+- [x] The artifact name gains the PR number:
+      `review-panel-stage-detail-pr-<n>`. A convenience for a human reading the
+      artifact list and for a collector fetching selectively; `meta.json` remains
+      the source of truth and nothing may parse attribution back out of the name.
+      Safe: **nothing downloads this artifact** — the only other references in the
+      repo are the two upload steps and this document.
+- [x] `retention-days: 30` → **90**, the maximum for a public repo, in both. The
+      `retention-days: 1` steps are untouched: those are an intra-run hand-off to
+      promote/fix and 1 day is chosen to match that lifetime.
+- [x] 14 new tests in `capture-meta.test.mjs`, and the existing
+      `uploadArtifactSteps()` invariant test **extended** rather than duplicated —
+      it now also pins retention, the artifact name, the meta step's existence,
+      its position before the upload, and that each producer names its own
+      channel and its own workflow file.
+
+## Corrected while building
+
+- **The upload glob does not match `meta.json`, and the literal path is NOT
+  immune to the hidden-files trap the way the execution log is.** The plan said
+  "write `.agent-review/meta.json`" and stopped there. `path:
+  .agent-review/*/stage-detail.json` matches nothing at the root of that
+  directory, so the file would have been written on every round and uploaded on
+  none — this subsystem's signature failure, for a third time. The fix is a
+  second `path:` entry, and the interesting half is what that entry does **not**
+  buy. #664 established that a literal file path escapes the hidden-file
+  exclusion because its search root is the FILE. That reasoning does not carry
+  here: `getSearchPaths()` **drops a search path that is a descendant of
+  another**, so `.agent-review/meta.json` collapses into the glob's
+  `.agent-review` root and is skipped with it. Measured against `@actions/glob`
+  0.5.0 with upload-artifact's own options — with `include-hidden-files: false`
+  the two-path step uploads **zero** files, `meta.json` included. The same
+  collapse is what keeps the layout right: one search path means no
+  least-common-ancestor calculation, so the artifact is `meta.json` beside
+  `<lens>/stage-detail.json` exactly as before.
+- **Writing `meta.json` unconditionally would have broken the empty case.** The
+  obvious implementation writes attribution every round. But "every lens skipped"
+  is normal — it is what `if-no-files-found: ignore` exists for — and an
+  unconditional write turns that legitimately empty round into an artifact
+  containing attribution and nothing else, which a collector must treat as
+  "present but nothing valid inside", i.e. loud. So the CLI writes nothing when no
+  lens captured, and `buildCaptureMeta` refuses an empty `lenses` list. The two
+  halves make one invariant: **`meta.json` present ⟺ a real capture.**
+- **The schema string in the plan and in the design note disagreed**
+  (`wafflebase/stage-capture@1` vs `…/stage-capture-meta@1`). Settled as
+  `wafflebase/stage-capture-meta@1` — it names the file, not the subsystem, and
+  `stage-detail.json` may want its own version line later.
+- **The plan's line numbers for the gating file were one low** (upload step at
+  `:995`, retention at `:1024`, not `:994`/`:1023`). The on-demand ones were
+  exact. Nothing about the conclusions changed.
+- **A mutation test can pass by editing a comment.** The first run of the
+  mutation harness reported "advisory producer copy-pasted `--workflow`" as
+  survived. The test was fine; the harness had rewritten the string where it
+  appears in the step's own **comment block**, which the parser strips before
+  asserting. These workflows carry more prose than YAML — the same trap #630,
+  #640 and #651 hit — and it now catches the people testing the test too.
+
+## Fail directions
+
+| path | on doubt | why |
+|---|---|---|
+| `buildCaptureMeta` (the payload) | **throws**, naming the field and the value | the single write path, so it refuses on any doubt. A `meta.json` reading `"pr": null` that uploaded anyway is precisely the shape this subsystem keeps producing: collected-looking and unusable. Because the builder is all-or-nothing there is no partial file, so "is this attributable?" is answered by the file's existence and never by inspecting a field |
+| the meta step (a refusal) | **no meta.json, exit 1, `::error::`** — and the upload still runs | two separate decisions, deliberately. The upload is unconditional because the lens files remain the only copy for 90 days and a human can still read the run log to see which PR it was; withholding them destroys recoverable data. What is *not* allowed is a bad `meta.json`, and none is written. An `::error::` is an ANNOTATION on the run summary rather than a log line, which is the distinction that let "No files were found" hide for five rounds. Enforcement proper is the collector's: it exits non-zero on a capture with no `meta.json` |
+| the meta step (any failure) | `continue-on-error: true` | a capture problem must never fail a code review. The script's own exit 1 carries the signal instead, and the invariant test pins the flag so nobody removes it "to make failures visible" |
+| no lens captured | **write nothing**, exit **0**, say so on stdout | capture off, or every lens skipped, is normal. The line is printed anyway: "the artifact was legitimately empty" is a claim a reader should be able to check, and it is indistinguishable from a broken capture if nobody prints it |
+| `capturedLenses`, any other read error | **exit 1, `::error::`**, no file | it rethrows, and the CLI catches it: an uncaught readdir error prints a stack trace with no annotation, so the run summary stays clean while the artifact goes out unattributable |
+| a count that does not fit a JS number | **refuse** | the digit regex admits a 20-digit run id that `Number` rounds to a different one, and a 30-digit one that becomes `1e+30`. Well-formed and wrong is the single outcome this file exists to prevent |
+| `capturedLenses`, missing directory | `[]` | same normal case. Any **other** readdir error propagates: an unreadable capture directory is a real fault and must not be laundered into "nothing was captured" |
+| `capturedLenses`, one unreadable lens dir | that lens is not listed; its siblings are | per-lens isolation, the same rule the collector's design takes. One bad directory must not discard four healthy captures |
+| `baseSha` absent | `null` — present, and not `""` | an absent KEY is indistinguishable from a file written before the field existed, and `""` is a value a consumer might take literally. The diff base is genuinely unknown when the diff step never ran; a *malformed* one is a refusal |
+| `panelSha` unobtainable | `git … \|\| true` yields `""`, the script refuses by name | dying inside the shell under `set -e` would put "exit 128" in the log with no field name. Reaching the script's own refusal names the fix |
+
+## Explicit non-goals
+
+**No collector.** Nothing reads `stage-detail.json` or `meta.json` after this.
+This makes the artifact attributable; moving it into permanent storage is the next
+PR, and it is separate for a permissions reason rather than a tidiness one.
+
+**No new permission, in either workflow, and none wanted.** The `review-panel`
+job keeps `{contents: read, checks: write, issues: write, pull-requests: write}`
+and the on-demand `review` job keeps `{contents: read, pull-requests: read,
+checks: read, issues: write}` — verified byte-identical before and after. No
+`id-token`, no `contents: write`. `upload-artifact` needs no scope and neither
+does writing a file.
+
+**No change to what is captured.** `writeStageDetail`, `buildStageDetail`, the
+gates and the payload are untouched. `meta.json` is a sibling file, not a field.
+
+**No advisory round is made gating**, and no lens, verifier, lane or gate
+decision changes.
+
+**No backfill.** The three existing captures (#665, #666, #669) have no
+`meta.json` by definition and will not gain one; they expire 2026-09-03 and are to
+be collected by hand, marked as such. A collector correctly refusing them is that
+validation path passing its first real test, not a regression.
+
+**No `config_hash`** — see *The change*.
+
+## Verification
+
+- [x] `node --test "scripts/agent/*.test.mjs"` — **708 tests, 0 fail**, against
+      693 on `upstream/main` (`e5de00ae9`). Exactly +15, all in the new
+      `capture-meta.test.mjs`; the workflow invariant was extended in place and
+      adds none. Both numbers given for each SDK state, because the skip count
+      moves with it:
+
+      | Agent SDK | branch | `upstream/main` |
+      |---|---|---|
+      | installed | 708 tests, 708 pass, 0 skipped | 693 / 693 / 0 |
+      | absent (the `agent:tests` lane) | 708 tests, 707 pass, 1 skipped | 693 / 692 / 1 |
+
+      Both columns measured with a root workspace install present. Without one,
+      five `lint-config.test.mjs` cases skip as well and the figure reads 6 —
+      which is the number a run in a bare checkout produces, and the reason a
+      skip count is only meaningful with its environment stated.
+- [x] `eslint scripts` — clean, exit 0, on the lockfile's pinned `eslint@9.24.0`.
+- [x] **Every new assertion mutation-tested — 23 mutations, 23 caught**, each
+      naming the right file. The workflow ones: retention back to 30 (both
+      producers, each named); the meta step deleted (both, each named); the meta
+      step moved to run *after* the upload; `meta.json` dropped from the upload
+      path; the artifact name reverted to the un-numbered one; the advisory
+      producer copy-pasted with `--channel gating`; the same with
+      `--workflow agent-review-panel.yml`; `continue-on-error` removed; the
+      payload built by `echo` in YAML instead of the script. The builder's:
+      `pr` validation relaxed to accept anything (the `"pr": null` failure this
+      change exists to prevent) — caught by both the field test *and* the CLI's
+      end-to-end refusal test; `baseSha` omitted rather than `null`; `headSha`
+      relaxed to any hex; `capturedAt` accepting a UTC offset; an empty lens list
+      accepted; a `config_hash` added back; the caller's array sorted in place;
+      `capturedLenses` listing directories with no capture; and the CLI writing a
+      `meta.json` after the payload was refused.
+- [x] **The artifact layout, from the real workflow config.** Both `path:` values
+      parsed straight out of the committed YAML and run through `@actions/glob`
+      0.5.0 with upload-artifact's own options, over a `.agent-review` holding
+      five captured lenses, one lens directory with no capture, and the sibling
+      timing/verdict files:
+
+      ```
+      meta.json
+      blast-radius/stage-detail.json   correctness/stage-detail.json
+      design-fit/stage-detail.json     security/stage-detail.json
+      test-adequacy/stage-detail.json
+      ```
+
+      `meta.json` at the artifact root, the lens layout unchanged, the
+      un-captured lens absent from both the artifact and `meta.lenses`.
+- [x] **Both workflows parse** (`yaml.safe_load`), and every job's `permissions`
+      block in both files is identical before and after — compared parsed and as
+      raw bytes, all 13 jobs.
+- [x] Verified from the **committed tree** (`git archive <branch> | tar -x`), not
+      the working copy.
+- [ ] **A real artifact from either producer.** Unverified end-to-end and cannot
+      be from here: the gating side needs one managed PR, the on-demand side one
+      `@claude review`. The first capture to arrive should hold a `meta.json` whose
+      `pr` matches the PR it was posted on and whose `panelSha` is the `main`
+      commit this merged into. That is also the only check that can confirm
+      `steps.pr.outputs.number` and `needs.authorize.outputs.pr` arrive non-empty
+      in production.
+- [ ] **90-day retention on a real upload.** The value is asserted in the YAML;
+      whether GitHub honours it depends on the repository's
+      `actions.artifact_retention_days` maximum, which a workflow cannot read.
+      If the repo setting is lower, GitHub silently clamps — check the first
+      artifact's expiry rather than assuming.

--- a/scripts/agent/capture-meta.mjs
+++ b/scripts/agent/capture-meta.mjs
@@ -1,0 +1,297 @@
+// Make the stage-detail capture SELF-DESCRIBING: one `meta.json` per artifact,
+// naming the PR, the commit, the channel and the panel version that produced it.
+//
+// THE PROBLEM. #641/#664 route a per-lens capture out of both review panels as
+// the artifact `review-panel-stage-detail`, and **nothing inside it says which
+// pull request it came from.** That is not an oversight in the payload, it is a
+// property of how these workflows are triggered: `workflow_run` and
+// `issue_comment` both make GitHub execute the DEFAULT BRANCH's copy of the
+// workflow, so the run's own metadata reads `head_branch: main` and
+// `pull_requests: []`. Measured on all three real captures to date (#665, #666,
+// #669) — every one of them. A consumer therefore cannot attribute a capture
+// from run metadata, and both producers upload under the SAME artifact name, so
+// it cannot tell a gating round from an advisory one either and would record one
+// head sha as two reviews. The #664 task doc filed exactly this as the open item
+// a collector must settle. It is settled here instead, in the producer, because
+// the producing job is the only place that still knows the answer.
+//
+// WHY A MODULE AND NOT YAML. This subsystem has now paid for that lesson twice.
+// #641: "a `&& 'x' || 'y'` default in the workflow would put the inverted logic
+// in the one place no test can reach it." #664 existed *because* a YAML-level
+// mistake — one missing `include-hidden-files: true` — was untestable and stayed
+// silent for five consecutive rounds. So the payload is built by a pure function
+// with unit tests, and the workflow contributes only values it already holds.
+//
+// WHY `panelSha` AND NOT A `config_hash`. Two reviews are comparable only if the
+// reviewer was the same, and a config hash is the obvious way to say so — but a
+// separate audit of the existing config-hash logic found it omits fields that
+// change behaviour, so two judges that decide differently hash identically. A
+// raw commit sha of the trusted `main` checkout that RAN the panel is always
+// available, always correct, and a config identity can be derived from it later.
+// A wrong fingerprint is worse than none: it merges two populations silently.
+//
+// FAIL DIRECTION — refuse, never approximate. `buildCaptureMeta` throws on any
+// field it cannot validate rather than emitting the field as `null`. A
+// `meta.json` reading `"pr": null` that still uploaded would be the exact shape
+// of failure this pipeline keeps re-learning: a capture that looks collected and
+// is not attributable. Because the builder is all-or-nothing, a `meta.json` on
+// disk is ALWAYS complete, and "is this capture attributable?" is a question a
+// consumer answers by the file's existence rather than by inspecting it.
+
+import { readdirSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "./gh-checks.mjs";
+
+// Bumped only on a BREAKING change to the field set. A consumer that does not
+// recognise the major must skip the capture loudly rather than guess at it —
+// mis-parsing writes plausible garbage into the corpus, which no later check
+// would notice.
+export const CAPTURE_META_SCHEMA = "wafflebase/stage-capture-meta@1";
+
+// The file name is part of the contract: it sits at the ROOT of the artifact,
+// beside the per-lens directories, so a consumer reads one well-known entry.
+export const CAPTURE_META_FILE = "meta.json";
+
+const SHA40 = /^[0-9a-f]{40}$/;
+// A positive integer with no leading zeros, sign, whitespace or decimal point.
+// Deliberately stricter than Number(): `pr` and `runId` become S3 KEY SEGMENTS
+// downstream, and a value that survives coercion but not this regex ("1e3",
+// " 12", "../..") is how a path escapes its prefix.
+const POSITIVE_INT = /^[1-9][0-9]*$/;
+// Lens directory names, which also become file names inside the artifact.
+const LENS_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+// A workflow FILE name, not a display name — `agent-review-panel.yml`. The
+// display name ("Agent Review Panel") is editable prose; the file name is what a
+// consumer can join against `.github/workflows/`.
+const WORKFLOW_FILE = /^[A-Za-z0-9._-]+\.ya?ml$/;
+// GitHub event names are lowercase with underscores: `workflow_run`,
+// `issue_comment`, `workflow_dispatch`.
+const EVENT_NAME = /^[a-z][a-z_]*$/;
+// UTC only, with the `Z`. An offset-bearing timestamp compares wrong
+// lexicographically, and this codebase has already been bitten by that once.
+const ISO_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+
+export const CAPTURE_CHANNELS = ["gating", "advisory"];
+
+/** Every refusal carries the field name and the offending value, so the log line names the fix. */
+function refuse(field, value, expected) {
+  const shown = typeof value === "string" ? JSON.stringify(value.slice(0, 80)) : JSON.stringify(value);
+  throw new Error(`capture meta: ${field} must be ${expected}, got ${shown}`);
+}
+
+function requireMatch(field, value, re, expected) {
+  if (typeof value !== "string" || !re.test(value)) refuse(field, value, expected);
+  return value;
+}
+
+/** A count that arrives as a string from the environment, kept as a NUMBER in the payload. */
+function requireCount(field, value) {
+  const s = typeof value === "number" && Number.isSafeInteger(value) ? String(value) : value;
+  requireMatch(field, s, POSITIVE_INT, "a positive integer");
+  const n = Number(s);
+  // The regex admits ANY run of digits, and `Number` then quietly rounds one
+  // that will not fit: a 20-digit run id becomes …567000 and a 30-digit one
+  // becomes 1e+30. Either would be emitted as a JSON number that a consumer
+  // renders into a key segment naming a DIFFERENT run — a wrong attribution
+  // that looks well-formed, which is the one outcome this module exists to
+  // make impossible. Refuse instead; GitHub's real ids are far inside this range.
+  if (!Number.isSafeInteger(n)) refuse(field, s, "a positive integer below 2^53");
+  return n;
+}
+
+/**
+ * The producer facts that identify one capture. PURE — no clock, no filesystem,
+ * no environment; `capturedAt` and `lenses` are injected by the caller so the
+ * whole payload is a function of its arguments and a test needs neither.
+ *
+ * Throws on ANY field it cannot validate. See the header: a partial meta.json is
+ * worse than none, because absence is visible and a null field is not.
+ */
+export function buildCaptureMeta({
+  pr,
+  headSha,
+  baseSha,
+  channel,
+  workflow,
+  runId,
+  runAttempt,
+  event,
+  panelSha,
+  lenses,
+  capturedAt,
+}) {
+  if (!CAPTURE_CHANNELS.includes(channel)) refuse("channel", channel, `one of ${CAPTURE_CHANNELS.join(" | ")}`);
+
+  // Non-empty on purpose, and it is the load-bearing half of a two-part rule:
+  // the CLI below does not write a meta.json when no lens captured anything.
+  // Together they make `meta.json` present ⟺ a real capture, which keeps the
+  // "every lens skipped" case — normal, and the reason the upload step carries
+  // `if-no-files-found: ignore` — producing NO artifact rather than an artifact
+  // holding attribution for nothing. A collector would have to treat the latter
+  // as "present but nothing valid inside", which its own spec makes loud.
+  if (!Array.isArray(lenses) || lenses.length === 0) refuse("lenses", lenses, "a non-empty array of lens slugs");
+  for (const lens of lenses) requireMatch("lenses[]", lens, LENS_SLUG, "a lowercase kebab-case slug");
+  // Copy before sorting: the caller's array must come back untouched, and the
+  // panel's own purity discipline (#641) is not worth breaking for a sort.
+  const sortedLenses = [...new Set(lenses)].sort();
+
+  const at = capturedAt instanceof Date ? capturedAt.toISOString() : capturedAt;
+  requireMatch("capturedAt", at, ISO_UTC, "an ISO 8601 UTC timestamp ending in Z");
+
+  // `null`, not omitted, and not "". The diff base is legitimately unknown when
+  // the diff step never ran, and a consumer must be able to tell "we did not
+  // record it" from "we recorded the empty string" without a second rule. An
+  // absent KEY would additionally be indistinguishable from a pre-schema file.
+  const base = baseSha === undefined || baseSha === null || baseSha === "" ? null : requireMatch("baseSha", baseSha, SHA40, "40 lowercase hex characters or null");
+
+  // Insertion order IS the on-disk field order — schema first so a reader can
+  // dispatch on it before parsing anything else.
+  return {
+    schema: CAPTURE_META_SCHEMA,
+    pr: requireCount("pr", pr),
+    headSha: requireMatch("headSha", headSha, SHA40, "40 lowercase hex characters"),
+    baseSha: base,
+    channel,
+    workflow: requireMatch("workflow", workflow, WORKFLOW_FILE, "a workflow file name ending in .yml"),
+    runId: requireCount("runId", runId),
+    runAttempt: requireCount("runAttempt", runAttempt),
+    event: requireMatch("event", event, EVENT_NAME, "a GitHub event name"),
+    panelSha: requireMatch("panelSha", panelSha, SHA40, "40 lowercase hex characters"),
+    lenses: sortedLenses,
+    capturedAt: at,
+  };
+}
+
+/**
+ * Which lenses actually left a capture in `outDir` — the injected side effect.
+ *
+ * Read off the DIRECTORY rather than from the panel's lens manifest, because the
+ * question this answers is "what is about to be uploaded", not "what was
+ * planned". A lens that skipped, crashed or was not applicable writes no
+ * `stage-detail.json`, and listing it here would tell a collector to expect a
+ * file that never existed.
+ *
+ * A missing `outDir` is NOT an error: capture disabled, or every lens skipped,
+ * is the same normal case `if-no-files-found: ignore` exists for. Any other
+ * readdir failure propagates — an unreadable capture directory is a real fault
+ * and must not be laundered into "nothing was captured".
+ */
+export function capturedLenses(outDir) {
+  let entries;
+  try {
+    entries = readdirSync(outDir, { withFileTypes: true });
+  } catch (e) {
+    if (e && e.code === "ENOENT") return [];
+    throw e;
+  }
+  return entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => {
+      try {
+        // `isFile()`, not merely "an entry with that name": upload-artifact
+        // drops directories from its search results, so a `stage-detail.json`
+        // that is not a file would be listed here and uploaded nowhere — the
+        // one way this function could claim more than the artifact carries.
+        return readdirSync(path.join(outDir, name), { withFileTypes: true })
+          .some((f) => f.name === "stage-detail.json" && f.isFile());
+      } catch {
+        // One unreadable lens directory must not hide its four healthy
+        // siblings; it simply is not listed.
+        return false;
+      }
+    })
+    .sort();
+}
+
+/**
+ * Usage:
+ *   node capture-meta.mjs --out .agent-review/meta.json
+ *     --pr <n> --head-sha <sha> [--base-sha <sha>] --channel gating|advisory
+ *     --workflow <file.yml> --run-id <n> --run-attempt <n> --event <name>
+ *     --panel-sha <sha>
+ *
+ * The directory scanned for lens captures is `dirname(--out)`, not a second
+ * flag. The meta file describes the capture it SITS IN, and coupling the two
+ * removes the way they could be pointed at different directories — which is
+ * also what makes the artifact layout come out as `meta.json` beside
+ * `<lens>/stage-detail.json`.
+ *
+ * Exit codes:
+ *   0  meta.json written, or nothing to describe (no lens capture — normal)
+ *   1  refused: a field could not be validated, or the write failed
+ *
+ * Exit 1 is deliberately paired with `continue-on-error: true` at the call site:
+ * a capture problem must never fail a code review, but it must not pass for
+ * healthy either. The `::error::` below is a run-level ANNOTATION rather than a
+ * log line, so it is visible on the run summary without opening the job — the
+ * distinction that let "No files were found" hide for five rounds. Enforcement
+ * proper belongs to the collector, which exits non-zero on a capture that has
+ * no meta.json.
+ */
+function main(argv, now = new Date()) {
+  const a = parseArgs(argv);
+  const out = a.out;
+  if (!out) {
+    console.error("::error::capture meta: --out is required");
+    return 1;
+  }
+
+  // `capturedLenses` rethrows anything that is not a missing directory, on
+  // purpose — an unreadable capture directory is a real fault. It still has to
+  // arrive as this step's own named annotation: an uncaught throw prints a
+  // readdir stack trace with no `::error::`, so the run summary stays clean
+  // while the artifact goes out unattributable. Same reason the workflow runs
+  // `git … || true` rather than letting `set -e` kill the step.
+  let lenses;
+  try {
+    lenses = capturedLenses(path.dirname(out));
+  } catch (e) {
+    console.error(`::error::capture meta: could not read the capture directory ${path.dirname(out)}: ${e.message} — this capture will have no meta.json and a collector will discard it as unattributable`);
+    return 1;
+  }
+  if (lenses.length === 0) {
+    // Not an error, and said out loud anyway: this is indistinguishable from a
+    // broken capture if nobody prints it, and "the artifact was legitimately
+    // empty" is a claim a reader should be able to check.
+    console.log(`capture meta: no per-lens capture under ${path.dirname(out)}; not writing ${path.basename(out)}`);
+    return 0;
+  }
+
+  let meta;
+  try {
+    meta = buildCaptureMeta({
+      pr: a.pr,
+      headSha: a["head-sha"],
+      baseSha: a["base-sha"],
+      channel: a.channel,
+      workflow: a.workflow,
+      runId: a["run-id"],
+      runAttempt: a["run-attempt"],
+      event: a.event,
+      panelSha: a["panel-sha"],
+      lenses,
+      capturedAt: now,
+    });
+  } catch (e) {
+    console.error(`::error::${e.message} — this capture will have no meta.json and a collector will discard it as unattributable`);
+    return 1;
+  }
+
+  try {
+    mkdirSync(path.dirname(out), { recursive: true });
+    writeFileSync(out, `${JSON.stringify(meta, null, 2)}\n`);
+  } catch (e) {
+    console.error(`::error::capture meta: could not write ${out}: ${e.message}`);
+    return 1;
+  }
+  console.log(`capture meta: ${out} — pr ${meta.pr}, ${meta.channel}, ${meta.headSha.slice(0, 8)}, panel ${meta.panelSha.slice(0, 8)}, ${meta.lenses.length} lens(es): ${meta.lenses.join(", ")}`);
+  return 0;
+}
+
+// Only when executed directly — same guard as review-panel.mjs, so importing
+// this module for tests never writes a file.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(main(process.argv));
+}

--- a/scripts/agent/capture-meta.test.mjs
+++ b/scripts/agent/capture-meta.test.mjs
@@ -1,0 +1,318 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildCaptureMeta, capturedLenses, CAPTURE_META_SCHEMA } from "./capture-meta.mjs";
+
+const CLI = fileURLToPath(new URL("./capture-meta.mjs", import.meta.url));
+
+const HEAD = "c18b6abbd7df4247c865fe12fc0f0d3530c294d6";
+const BASE = "268fb507b1e4a9b0c3d2e5f60718293a4b5c6d7e";
+const PANEL = "5ee400b4210b10ffe66765f66de7df51a6e7dbf0";
+
+/** A complete, valid gating capture. Every test below varies exactly one field of it. */
+const GATING = {
+  pr: 669,
+  headSha: HEAD,
+  baseSha: BASE,
+  channel: "gating",
+  workflow: "agent-review-panel.yml",
+  runId: 30889625585,
+  runAttempt: 1,
+  event: "workflow_run",
+  panelSha: PANEL,
+  lenses: ["correctness", "security"],
+  capturedAt: "2026-08-04T07:53:22Z",
+};
+
+const tmp = () => mkdtempSync(path.join(tmpdir(), "capture-meta-"));
+
+/** A `.agent-review`-shaped directory: one subdirectory per lens that captured. */
+function captureDir(lenses, { extraFiles = {} } = {}) {
+  const dir = path.join(tmp(), ".agent-review");
+  mkdirSync(dir, { recursive: true });
+  for (const lens of lenses) {
+    mkdirSync(path.join(dir, lens), { recursive: true });
+    writeFileSync(path.join(dir, lens, "stage-detail.json"), '{"samples":[]}\n');
+    // The panel writes these beside it; they must not be mistaken for a capture.
+    writeFileSync(path.join(dir, lens, "verdict.json"), '{"ok":true}\n');
+    writeFileSync(path.join(dir, lens, "summary.md"), "# summary\n");
+  }
+  for (const [name, body] of Object.entries(extraFiles)) writeFileSync(path.join(dir, name), body);
+  return dir;
+}
+
+test("buildCaptureMeta: the exact payload a collector will read, field for field", () => {
+  // deepEqual, not a field-by-field spot check: the whole point of this file is
+  // that a consumer can be written against a fixed shape, so an ADDED field is a
+  // schema change and has to be a deliberate one.
+  assert.deepEqual(buildCaptureMeta(GATING), {
+    schema: "wafflebase/stage-capture-meta@1",
+    pr: 669,
+    headSha: HEAD,
+    baseSha: BASE,
+    channel: "gating",
+    workflow: "agent-review-panel.yml",
+    runId: 30889625585,
+    runAttempt: 1,
+    event: "workflow_run",
+    panelSha: PANEL,
+    lenses: ["correctness", "security"],
+    capturedAt: "2026-08-04T07:53:22Z",
+  });
+  assert.equal(CAPTURE_META_SCHEMA, "wafflebase/stage-capture-meta@1");
+});
+
+test("buildCaptureMeta: NO config_hash, and no field a consumer must guess at", () => {
+  // Deliberately excluded — see the module header. An audit of the existing
+  // config-hash logic found it omits fields that change behaviour, so two judges
+  // that decide differently hash identically; `panelSha` is the honest identity.
+  // Pinned as a key-set assertion because the failure mode is someone ADDING it
+  // back as an obvious improvement.
+  const keys = Object.keys(buildCaptureMeta(GATING));
+  assert.ok(!keys.includes("config_hash"), `config_hash is deliberately absent, found: ${keys.join(", ")}`);
+  assert.ok(!keys.includes("configHash"), `configHash is deliberately absent, found: ${keys.join(", ")}`);
+  // `schema` first, so a reader can dispatch on the version before parsing.
+  assert.equal(keys[0], "schema");
+});
+
+test("buildCaptureMeta: channel is the ONLY thing separating a gating round from an advisory one", () => {
+  // Both producers upload the same capture, from the same writer, for the same
+  // commit. Without this field one head sha reviewed twice reads as two gating
+  // rounds — and nothing else in the payload differs.
+  const advisory = buildCaptureMeta({
+    ...GATING,
+    channel: "advisory",
+    workflow: "agent-review-on-demand.yml",
+    event: "issue_comment",
+  });
+  assert.equal(advisory.channel, "advisory");
+  assert.equal(advisory.workflow, "agent-review-on-demand.yml");
+  assert.equal(advisory.event, "issue_comment");
+  // Same PR, same commit, same panel version — the two payloads are otherwise
+  // identical, which is exactly why `channel` has to carry the distinction.
+  const gating = buildCaptureMeta(GATING);
+  for (const k of ["pr", "headSha", "baseSha", "panelSha", "runId", "capturedAt"]) {
+    assert.deepEqual(advisory[k], gating[k], `${k} must not differ between channels`);
+  }
+});
+
+test("buildCaptureMeta: an absent diff base is null — present, and not the empty string", () => {
+  // `null`, not omitted: an absent KEY is indistinguishable from a file written
+  // before the field existed. `""` would be a value a consumer might take
+  // literally. The diff base is genuinely unknown when the diff step never ran.
+  for (const absent of [undefined, null, ""]) {
+    const meta = buildCaptureMeta({ ...GATING, baseSha: absent });
+    assert.ok("baseSha" in meta, `baseSha must be PRESENT for input ${JSON.stringify(absent)}`);
+    assert.equal(meta.baseSha, null);
+  }
+  // A base sha that is present but malformed is a refusal, not a null: the
+  // difference between "we did not record it" and "we recorded nonsense".
+  assert.throws(() => buildCaptureMeta({ ...GATING, baseSha: "268fb50" }), /baseSha must be 40 lowercase hex/);
+});
+
+test("buildCaptureMeta: every field refuses rather than degrading, and the message names it", () => {
+  // The failure this whole module exists to prevent is a meta.json that reads
+  // `"pr": null` and uploads anyway. There is no partial payload: the builder
+  // either returns a complete object or throws.
+  const cases = [
+    ["pr", 0], ["pr", -1], ["pr", "12a"], ["pr", "1e3"], ["pr", " 12"], ["pr", "01"],
+    ["pr", "../../etc"], ["pr", 1.5], ["pr", null], ["pr", undefined],
+    ["headSha", "C18B6ABBD7DF4247C865FE12FC0F0D3530C294D6"], // upper case is not the sha git prints
+    ["headSha", HEAD.slice(0, 39)], ["headSha", `${HEAD}0`], ["headSha", ""], ["headSha", null],
+    ["channel", "GATING"], ["channel", "gate"], ["channel", ""], ["channel", undefined],
+    ["workflow", "agent-review-panel"], ["workflow", "Agent Review Panel"], ["workflow", "../x.yml"], ["workflow", ""],
+    ["runId", "0"], ["runId", "abc"], ["runId", ""],
+    // Digits all the way down, and `Number` rounds them off: 12345678901234567890
+    // parses to …567000 and a 30-digit run to 1e+30. Either would be a JSON
+    // number naming a DIFFERENT run, well-formed and wrong.
+    ["runId", "12345678901234567890"], ["runId", "9".repeat(30)],
+    ["pr", "12345678901234567890"],
+    ["runAttempt", "0"], ["runAttempt", "-1"], ["runAttempt", undefined],
+    ["event", "workflow-run"], ["event", "Workflow_Run"], ["event", ""],
+    ["panelSha", "main"], ["panelSha", ""],
+    ["capturedAt", "2026-08-04T07:53:22+09:00"], // an offset compares wrong lexicographically
+    ["capturedAt", "2026-08-04 07:53:22Z"], ["capturedAt", "2026-08-04"], ["capturedAt", 1754294002000],
+  ];
+  for (const [field, value] of cases) {
+    assert.throws(
+      () => buildCaptureMeta({ ...GATING, [field]: value }),
+      (e) => e.message.includes(`capture meta: ${field}`),
+      `${field}=${JSON.stringify(value)} must be refused with a message naming ${field}`,
+    );
+  }
+});
+
+test("buildCaptureMeta: lenses must be a non-empty list of slugs, sorted and deduped", () => {
+  // Non-empty is half of the rule that makes `meta.json` present ⟺ a real
+  // capture; the CLI supplies the other half by not writing one when no lens
+  // captured. Slugs because these become file names in the artifact and path
+  // segments in whatever stores it.
+  for (const bad of [[], undefined, null, "correctness", [""], ["Correctness"], ["../evil"], ["a b"], [null]]) {
+    assert.throws(() => buildCaptureMeta({ ...GATING, lenses: bad }), /capture meta: lenses/, `lenses=${JSON.stringify(bad)} must be refused`);
+  }
+  const meta = buildCaptureMeta({ ...GATING, lenses: ["security", "correctness", "security", "test-adequacy"] });
+  assert.deepEqual(meta.lenses, ["correctness", "security", "test-adequacy"]);
+});
+
+test("buildCaptureMeta: derives only — it never mutates its inputs", () => {
+  // Same property #641 pinned on `buildStageDetail`, for the same reason: this
+  // runs beside a review, and instrumentation that edits its caller's arrays is
+  // how instrumentation changes a verdict.
+  const input = { ...GATING, lenses: ["security", "correctness"] };
+  const before = JSON.stringify(input);
+  buildCaptureMeta(input);
+  assert.equal(JSON.stringify(input), before);
+});
+
+test("buildCaptureMeta: accepts a Date and env-shaped strings, emits numbers and a Z timestamp", () => {
+  // Everything the workflow passes arrives as a STRING. The payload must still
+  // hold `pr`/`runId`/`runAttempt` as JSON numbers, or a consumer comparing
+  // against run metadata compares 669 with "669".
+  const meta = buildCaptureMeta({
+    ...GATING,
+    pr: "669",
+    runId: "30889625585",
+    runAttempt: "2",
+    capturedAt: new Date(Date.UTC(2026, 7, 4, 7, 53, 22)),
+  });
+  assert.equal(meta.pr, 669);
+  assert.equal(meta.runId, 30889625585);
+  assert.equal(meta.runAttempt, 2);
+  assert.equal(meta.capturedAt, "2026-08-04T07:53:22.000Z");
+  assert.equal(typeof meta.pr, "number");
+  // Round-trips: the file on disk is exactly the object this returned.
+  assert.deepEqual(JSON.parse(JSON.stringify(meta)), meta);
+});
+
+test("capturedLenses: reads what will be UPLOADED, not what was planned", () => {
+  const dir = captureDir(["security", "correctness"], { extraFiles: { "review-timing.json": "{}\n" } });
+  // A lens directory with no stage-detail.json — skipped, crashed, or not
+  // applicable. Listing it would tell a collector to expect a file that never
+  // existed.
+  mkdirSync(path.join(dir, "design-fit"), { recursive: true });
+  writeFileSync(path.join(dir, "design-fit", "verdict.json"), '{"ok":true}\n');
+  // A `stage-detail.json` that is not a FILE. upload-artifact drops directories
+  // from its search results, so listing this lens would claim a capture the
+  // artifact does not carry — the one direction in which this function could
+  // over-report.
+  mkdirSync(path.join(dir, "blast-radius", "stage-detail.json"), { recursive: true });
+  assert.deepEqual(capturedLenses(dir), ["correctness", "security"]);
+});
+
+test("capturedLenses: a missing capture directory is empty, not an error", () => {
+  // Capture disabled, or every lens skipped — the same normal case the upload
+  // step's `if-no-files-found: ignore` exists for.
+  assert.deepEqual(capturedLenses(path.join(tmp(), "never-created")), []);
+});
+
+test("CLI: writes meta.json beside the lens directories, and says what it wrote", () => {
+  const dir = captureDir(["correctness", "security"]);
+  const out = path.join(dir, "meta.json");
+  const stdout = execFileSync("node", [CLI,
+    "--out", out,
+    "--pr", "669", "--head-sha", HEAD, "--base-sha", BASE,
+    "--channel", "gating", "--workflow", "agent-review-panel.yml",
+    "--run-id", "30889625585", "--run-attempt", "1",
+    "--event", "workflow_run", "--panel-sha", PANEL,
+  ], { encoding: "utf8" });
+
+  const meta = JSON.parse(readFileSync(out, "utf8"));
+  assert.equal(meta.schema, CAPTURE_META_SCHEMA);
+  assert.equal(meta.pr, 669);
+  assert.equal(meta.channel, "gating");
+  assert.deepEqual(meta.lenses, ["correctness", "security"]);
+  // Discovered from disk, never passed in — the one field the caller cannot get wrong.
+  assert.ok(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/.test(meta.capturedAt), meta.capturedAt);
+  // A silent success is the failure mode this subsystem keeps hitting.
+  assert.match(stdout, /pr 669, gating/);
+});
+
+test("CLI: no lens capture → no meta.json, exit 0, and it SAYS so", () => {
+  // The artifact is then empty and never uploaded, which is normal. Writing
+  // attribution for a capture that does not exist would make an empty round look
+  // like "artifact present but nothing valid inside" — loud, and wrong.
+  const dir = path.join(tmp(), ".agent-review");
+  mkdirSync(dir, { recursive: true });
+  const out = path.join(dir, "meta.json");
+  const stdout = execFileSync("node", [CLI, "--out", out, "--pr", "669", "--head-sha", HEAD,
+    "--channel", "gating", "--workflow", "agent-review-panel.yml", "--run-id", "1",
+    "--run-attempt", "1", "--event", "workflow_run", "--panel-sha", PANEL], { encoding: "utf8" });
+  assert.equal(existsSync(out), false, "no capture must mean no meta.json");
+  assert.match(stdout, /no per-lens capture/);
+});
+
+test("CLI: an unattributable capture writes NOTHING and exits 1 with an annotation", () => {
+  // The whole failure this PR exists to prevent, exercised end to end: an unknown
+  // PR number must not become `"pr": null` on disk. `continue-on-error: true` at
+  // the call site keeps this off the review's critical path; `::error::` makes it
+  // an annotation on the run summary rather than a log line nobody opens.
+  const dir = captureDir(["correctness"]);
+  const out = path.join(dir, "meta.json");
+  let status = 0, stderr = "";
+  try {
+    execFileSync("node", [CLI, "--out", out, "--pr", "", "--head-sha", HEAD,
+      "--channel", "gating", "--workflow", "agent-review-panel.yml", "--run-id", "1",
+      "--run-attempt", "1", "--event", "workflow_run", "--panel-sha", PANEL],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (e) {
+    status = e.status;
+    stderr = String(e.stderr);
+  }
+  assert.equal(status, 1, "a refused capture must exit non-zero");
+  assert.equal(existsSync(out), false, "a refused capture must leave NO meta.json behind");
+  assert.match(stderr, /^::error::capture meta: pr must be a positive integer/m);
+  assert.match(stderr, /unattributable/);
+});
+
+test("CLI: an unreadable capture directory is an ANNOTATION, never a stack trace", () => {
+  // `capturedLenses` rethrows anything that is not a missing directory, so the
+  // CLI has to catch it: an uncaught readdir error exits non-zero with a stack
+  // trace and NO `::error::`, which leaves the run summary clean while the
+  // artifact goes out unattributable. A real failure shape — `--out` under a
+  // path that is a regular file — not a mock.
+  const dir = tmp();
+  const notADir = path.join(dir, "occupied");
+  writeFileSync(notADir, "i am a file\n");
+  let status = 0, stderr = "";
+  try {
+    execFileSync("node", [CLI, "--out", path.join(notADir, "meta.json"), "--pr", "669", "--head-sha", HEAD,
+      "--channel", "gating", "--workflow", "agent-review-panel.yml", "--run-id", "1",
+      "--run-attempt", "1", "--event", "workflow_run", "--panel-sha", PANEL],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (e) {
+    status = e.status;
+    stderr = String(e.stderr);
+  }
+  assert.equal(status, 1);
+  assert.match(stderr, /^::error::capture meta: could not read the capture directory/m);
+  assert.doesNotMatch(stderr, /at capturedLenses|node:fs/, "a stack trace is not an annotation");
+});
+
+test("CLI: a write it cannot perform is refused loudly, not swallowed", () => {
+  // Distinct from the validation path: the payload was fine and the file still
+  // did not land. A collector must be able to tell "no capture" from "capture we
+  // failed to describe", and only the exit code carries that here.
+  //
+  // A real failure shape rather than a mock or a chmod — `meta.json` already
+  // exists as a DIRECTORY, so mkdirSync succeeds and writeFileSync raises EISDIR.
+  // chmod would be a no-op for a test process running as root.
+  const dir = captureDir(["correctness"]);
+  const out = path.join(dir, "meta.json");
+  mkdirSync(out);
+  let status = 0, stderr = "";
+  try {
+    execFileSync("node", [CLI, "--out", out, "--pr", "669", "--head-sha", HEAD,
+      "--channel", "gating", "--workflow", "agent-review-panel.yml", "--run-id", "1",
+      "--run-attempt", "1", "--event", "workflow_run", "--panel-sha", PANEL],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (e) {
+    status = e.status;
+    stderr = String(e.stderr);
+  }
+  assert.equal(status, 1);
+  assert.match(stderr, /^::error::capture meta: could not write/m);
+});

--- a/scripts/agent/review-panel.test.mjs
+++ b/scripts/agent/review-panel.test.mjs
@@ -2605,21 +2605,36 @@ test("writeStageDetail: disabled writes nothing at all", () => {
   }
 });
 
+const WORKFLOW_DIR = path.join(HERE, "..", "..", ".github", "workflows");
+
+/**
+ * A workflow file with its comment lines dropped.
+ *
+ * These workflows carry more prose than YAML and the comments quote `path:`,
+ * `retention-days:` and the flags being asserted here by name, so a whole-file
+ * grep would answer out of the explanation instead of the config — the same trap
+ * #630, #640 and #651 each had to work around.
+ *
+ * SHARED by both parsers below, and that is load-bearing rather than tidy: the
+ * step-ordering assertion compares line indexes across the two, so they must be
+ * indexing the same array. Two copies of this filter could drift and the
+ * comparison would quietly become meaningless.
+ */
+function strippedWorkflowLines(file) {
+  return readFileSync(path.join(WORKFLOW_DIR, file), "utf8")
+    .split("\n")
+    .filter((l) => !/^\s*#/.test(l));
+}
+
+const workflowFiles = () => readdirSync(WORKFLOW_DIR).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+
 /**
  * Parse every `actions/upload-artifact` step out of the real workflows.
- *
- * Comment lines are dropped first. These workflows carry more prose than YAML and
- * the comments quote `path:` and the flag being asserted here by name, so a
- * whole-file grep would answer out of the explanation instead of the config —
- * the same trap #630, #640 and #651 each had to work around.
  */
 function uploadArtifactSteps() {
-  const dir = path.join(HERE, "..", "..", ".github", "workflows");
   const steps = [];
-  for (const file of readdirSync(dir).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))) {
-    const lines = readFileSync(path.join(dir, file), "utf8")
-      .split("\n")
-      .filter((l) => !/^\s*#/.test(l));
+  for (const file of workflowFiles()) {
+    const lines = strippedWorkflowLines(file);
     for (let i = 0; i < lines.length; i++) {
       const at = lines[i].indexOf("uses: actions/upload-artifact");
       if (at < 0) continue;
@@ -2654,9 +2669,62 @@ function uploadArtifactSteps() {
           paths.push(body[k].trim().replace(/^["']|["']$/g, ""));
         }
       }
+      // The ARTIFACT name (a `with:` input) as distinct from the step label read
+      // above. Both are spelled `name:`; only the one inside the step body is the
+      // artifact's, which is why it is picked out here and not by the backward
+      // scan.
+      let artifactName = null;
+      for (const l of body) {
+        const m = /^\s*name:\s*(.+?)\s*$/.exec(l);
+        if (m) { artifactName = m[1].replace(/^["']|["']$/g, ""); break; }
+      }
+      const retention = body.map((l) => /^\s*retention-days:\s*(\d+)\s*$/.exec(l)).find(Boolean);
       steps.push({
-        file, name, paths,
+        file, name, paths, artifactName,
+        line: i,
+        retention: retention ? Number(retention[1]) : null,
         includeHidden: body.some((l) => /^\s*include-hidden-files:\s*true\s*$/.test(l)),
+      });
+    }
+  }
+  return steps;
+}
+
+/**
+ * Parse the `capture-meta.mjs` step out of each workflow that has one.
+ *
+ * Read from the workflow source because that is the only place the wiring
+ * exists: the values are step-level `env:` and literal flags, so no unit test of
+ * `buildCaptureMeta` can reach them. The four facts asserted below — which
+ * channel, which workflow name, where the file lands, and that a failure cannot
+ * fail the review — are each a one-token edit away from being silently wrong,
+ * and three of them are what a copy of this step into the other workflow gets
+ * wrong first.
+ */
+function captureMetaSteps() {
+  const steps = [];
+  for (const file of workflowFiles()) {
+    const lines = strippedWorkflowLines(file);
+    for (let i = 0; i < lines.length; i++) {
+      const m = /^(\s*)- name:\s*(Describe the capture.*?)\s*$/.exec(lines[i]);
+      if (!m) continue;
+      const keyIndent = m[1].length + 2;
+      const body = [];
+      for (let j = i + 1; j < lines.length; j++) {
+        if (!lines[j].trim()) { body.push(lines[j]); continue; }
+        if (lines[j].search(/\S/) < keyIndent) break;
+        body.push(lines[j]);
+      }
+      const text = body.join("\n");
+      const flag = (name) => {
+        const f = new RegExp(`--${name}\\s+(\\S+)`).exec(text);
+        return f ? f[1].replace(/^["']|["']$/g, "") : null;
+      };
+      steps.push({
+        file, line: i, name: m[2], text,
+        runsBuilder: /node \.trusted\/scripts\/agent\/capture-meta\.mjs/.test(text),
+        continueOnError: /^\s*continue-on-error:\s*true\s*$/m.test(text),
+        out: flag("out"), channel: flag("channel"), workflow: flag("workflow"),
       });
     }
   }
@@ -2714,10 +2782,55 @@ test("every upload-artifact step that GLOBS a hidden path opts hidden files back
     ["agent-review-on-demand.yml", "agent-review-panel.yml"],
     "both the gating and the on-demand panel must upload the stage-detail capture",
   );
+  const meta = captureMetaSteps();
   for (const s of stage) {
-    assert.deepEqual(s.paths, [".agent-review/*/stage-detail.json"], `${s.file}: the capture path must match the other producer`);
+    assert.deepEqual(
+      s.paths,
+      [".agent-review/*/stage-detail.json", ".agent-review/meta.json"],
+      `${s.file}: the capture path must match the other producer, and must carry meta.json — the glob does NOT match a file at the root of .agent-review`,
+    );
     assert.ok(s.includeHidden, `${s.file}: the stage-detail upload must set include-hidden-files: true`);
+
+    // 90 days, the maximum for a public repo, in BOTH producers. Nothing reads
+    // these artifacts yet, so retention is the only thing between a capture and
+    // deletion, and a collector must not find one channel expiring before the
+    // other. Deliberately does NOT touch the `retention-days: 1` steps, which are
+    // an intra-run hand-off.
+    assert.equal(s.retention, 90, `${s.file}: the stage-detail capture must be retained for 90 days (the public-repo maximum), got ${s.retention}`);
+
+    // The PR number in the artifact name, always as an expression — a literal
+    // would mean every run overwrote the same name.
+    assert.match(
+      s.artifactName ?? "",
+      /^review-panel-stage-detail-pr-\$\{\{ [^}]+ \}\}$/,
+      `${s.file}: the artifact name must carry the PR number, got ${JSON.stringify(s.artifactName)}`,
+    );
+
+    // Attribution must be WRITTEN before it is uploaded. A meta step that ran
+    // after the upload would produce a file nobody ever sees, and the artifact
+    // would still be unattributable — while every other assertion here passed.
+    const m = meta.find((x) => x.file === s.file);
+    assert.ok(m, `${s.file}: no "Describe the capture" step — the uploaded artifact would carry no meta.json and a collector would discard it`);
+    assert.ok(m.line < s.line, `${s.file}: the capture must be described BEFORE it is uploaded (meta step at line ${m.line}, upload at ${s.line})`);
+    assert.ok(m.runsBuilder, `${s.file}: the meta step must run the trusted capture-meta.mjs, not build the payload in YAML`);
+    assert.equal(m.out, ".agent-review/meta.json", `${s.file}: meta.json must land where the upload above looks for it`);
+    assert.ok(s.paths.includes(m.out), `${s.file}: the upload does not carry ${m.out}`);
+    // A capture problem must never fail a code review. The script's own exit 1
+    // is the signal; this is what keeps it off the critical path.
+    assert.ok(m.continueOnError, `${s.file}: the meta step must be continue-on-error — a capture must never fail a review`);
+    // Each producer names ITSELF. This is the assertion a copy-paste between the
+    // two workflows fails, which is how #664's naive copy would have gone wrong.
+    assert.equal(m.workflow, s.file, `${s.file}: --workflow must name this workflow, got ${JSON.stringify(m.workflow)}`);
   }
+
+  // `channel` is the only field that can separate a gating round from an
+  // advisory one — the two producers are otherwise byte-identical in what they
+  // capture, so a single head sha reviewed twice would read as two gating rounds.
+  assert.deepEqual(
+    meta.map((m) => [m.file, m.channel]).sort(),
+    [["agent-review-on-demand.yml", "advisory"], ["agent-review-panel.yml", "gating"]],
+    "each producer must declare its own channel, and the two must differ",
+  );
 
   // The invariant has to hold for a REASON, not by coincidence: at least one
   // upload in the repo must be a hidden glob, or the loop above proves nothing.


### PR DESCRIPTION
### Nothing in the stage-detail artifact says which PR it is of

#664 routed the per-lens capture out of both panels and closed on an unchecked box: two producers, one artifact name, and a payload naming neither the PR nor the workflow — so a collector "must tell a gating round from an advisory one out of run metadata."

**That recovery does not exist.** Both producers are triggered by events (`workflow_run`, `issue_comment`) that make GitHub run the *default branch's* copy of the workflow. Measured on all three real captures (#665, #666, #669), every one reports:

```
head_branch = "main"        pull_requests = []
```

This is a deliberate security property — the reviewer must never execute the branch's code — not a bug, and it is not going to change. And a capture filed against the wrong PR is worse than a missing one: absence is visible, a wrong row corrupts the corpus silently. The producing job holds every answer and never wrote it down.

### The change

`scripts/agent/capture-meta.mjs` writes `.agent-review/meta.json` beside the per-lens files — `pr`, `headSha`, `baseSha`, `channel`, `workflow`, `runId`, `runAttempt`, `event`, `panelSha`, `lenses`, `capturedAt`. `buildCaptureMeta` is pure; `capturedLenses(outDir)` is the one side effect. In a script rather than YAML for the reason this subsystem has paid for twice (#641, #664).

`channel` is the only field that can tell a gating round from an advisory one. `panelSha` is the reviewer's own version — **not** a `config_hash`: an audit found the existing hash omits fields that change behaviour, so two judges that decide differently hash identically, and a wrong fingerprint is worse than none because it merges two populations silently.

The builder **throws** rather than emitting a field as `null`, so there is no partial file and a consumer answers "is this attributable?" by the file's existence. On a refusal the step writes nothing, prints an `::error::` annotation and exits 1 under `continue-on-error` — a capture can never fail a review. The upload still runs: the lens files are the only copy for 90 days and are still hand-recoverable from the run log. Symmetrically, no `meta.json` is written when no lens captured, so a legitimately empty round stays an empty artifact rather than one holding attribution for nothing.

The upload needed a **second `path:` entry**: the glob matches nothing at the root of `.agent-review`, and the literal `meta.json` is *not* immune to the hidden-file trap the way the execution log is — `getSearchPaths()` drops it as a descendant of the glob's root. Measured against `@actions/glob` 0.5.0 with upload-artifact's own options, `include-hidden-files: false` makes the two-path step upload zero files, `meta.json` included.

Artifact name gains the PR number; **retention 30 → 90**, the public-repo maximum, in both producers — nothing reads these yet, so retention is all that stands between a capture and deletion. The `retention-days: 1` steps are untouched.

### Verification

- **707 agent tests, 0 fail; 693 on `main` (`e5de00ae9`)** — exactly +14. SDK installed: 707 / 707 pass / 0 skipped, against 693 / 693 / 0. SDK absent: 707 / 706 / 1, against 693 / 692 / 1. Measured from the committed tree.
- `eslint scripts` clean, exit 0 on the lockfile's pinned `eslint@9.24.0`.
- **20 mutations, 20 caught**, each naming the right file: retention reverted to 30 (both producers), the meta step deleted (both) or moved to run *after* the upload, `meta.json` dropped from the path, the artifact name un-numbered, the advisory producer copy-pasted with the gating channel or workflow name, `continue-on-error` removed, the payload built in YAML — plus `pr` validation relaxed (the `"pr": null` failure this exists to prevent), `baseSha` omitted rather than `null`, `capturedAt` accepting a UTC offset, an empty lens list accepted, a `config_hash` added back, and the CLI writing a file after refusing one.
- Artifact layout confirmed against the real `path:` values parsed out of the committed YAML: `meta.json` at the artifact root, `<lens>/stage-detail.json` unchanged, a lens directory with no capture absent from both the artifact and `meta.lenses`.
- **No new permission.** Every job's `permissions` block in both workflows is identical before and after, compared parsed and as raw bytes across all 13 jobs.

Producer only — nothing reads the capture after this; the collector is a separate PR, and separate for a permissions reason. The three existing captures have no `meta.json` by definition and expire 2026-09-03.

Two things this cannot verify from here, recorded as open boxes in the task doc: a real artifact from either producer (needs one managed PR or one `@claude review`), and whether 90 days is honoured — GitHub silently clamps to the repository's `actions.artifact_retention_days` maximum, which a workflow cannot read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attribution metadata to stage-detail review artifacts, including pull request, commit, workflow, run, channel, panel, and lens details.
  * Artifacts now use pull request-specific names and include hidden metadata files when captures are available.
  * Extended artifact retention from 30 to 90 days.

* **Bug Fixes**
  * Improved handling of missing, empty, or invalid capture data without disrupting reviews.

* **Tests**
  * Expanded coverage for metadata validation, artifact uploads, naming, retention, permissions, and workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->